### PR TITLE
fix: restore attached media previews after reload

### DIFF
--- a/static/i18n.js
+++ b/static/i18n.js
@@ -47,6 +47,8 @@ const LOCALES = {
     selected_text_reply: 'Reply with selection',
     selected_text_reply_title: 'Append selected chat text as quoted context',
     selected_text_reply_appended: 'Selected text added to composer',
+    attached_file: 'Attached file',
+    attached_files: 'Attached files',
 
     diff_loading: 'Loading diff',
     diff_error: 'Could not load patch file',
@@ -1362,6 +1364,8 @@ const LOCALES = {
     selected_text_reply: 'Rispondi con selezione',
     selected_text_reply_title: 'Aggiungi il testo della chat selezionato come contesto citato',
     selected_text_reply_appended: 'Testo selezionato aggiunto al compositore',
+    attached_file: 'File allegato',
+    attached_files: 'File allegati',
 
     diff_loading: 'Caricamento diff',
     diff_error: 'Impossibile caricare il file patch',
@@ -2669,6 +2673,8 @@ const LOCALES = {
     selected_text_reply: '選択範囲で返信',
     selected_text_reply_title: '選択したチャットテキストを引用コンテキストとして追加',
     selected_text_reply_appended: '選択したテキストを入力欄に追加しました',
+    attached_file: '添付ファイル',
+    attached_files: '添付ファイル',
 
     diff_loading: '差分を読み込み中',
     diff_error: 'パッチファイルを読み込めませんでした',
@@ -3978,6 +3984,8 @@ const LOCALES = {
     selected_text_reply: 'Ответить с выделенным',
     selected_text_reply_title: 'Добавить выделенный текст чата как цитируемый контекст',
     selected_text_reply_appended: 'Выделенный текст добавлен в поле ввода',
+    attached_file: 'Прикрепленный файл',
+    attached_files: 'Прикрепленные файлы',
 
     diff_loading: 'Загрузка diff',
     diff_error: 'Не удалось загрузить файл патча',
@@ -5218,6 +5226,8 @@ const LOCALES = {
     selected_text_reply: 'Responder con selección',
     selected_text_reply_title: 'Añadir el texto del chat seleccionado como contexto citado',
     selected_text_reply_appended: 'Texto seleccionado añadido al compositor',
+    attached_file: 'Archivo adjunto',
+    attached_files: 'Archivos adjuntos',
 
     diff_loading: 'Cargando diff',
     diff_error: 'No se pudo cargar el archivo de parche',
@@ -6461,6 +6471,8 @@ const LOCALES = {
     selected_text_reply: 'Mit Auswahl antworten',
     selected_text_reply_title: 'Ausgewählten Chattext als Zitatkontext anhängen',
     selected_text_reply_appended: 'Auswahl zum Composer hinzugefügt',
+    attached_file: 'Angehängte Datei',
+    attached_files: 'Angehängte Dateien',
 
     diff_loading: 'Lade Diff',
     diff_error: 'Patch-Datei konnte nicht geladen werden',
@@ -7708,6 +7720,8 @@ const LOCALES = {
     selected_text_reply: '用所选内容回复',
     selected_text_reply_title: '将所选聊天文本作为引用上下文追加',
     selected_text_reply_appended: '已将所选文本添加到输入框',
+    attached_file: '附加文件',
+    attached_files: '附加文件',
 
     diff_loading: '加载 diff',
     diff_error: '无法加载 patch 文件',
@@ -10263,6 +10277,8 @@ const LOCALES = {
     selected_text_reply: 'Responder com seleção',
     selected_text_reply_title: 'Anexar o texto selecionado do chat como contexto citado',
     selected_text_reply_appended: 'Texto selecionado adicionado ao compositor',
+    attached_file: 'Arquivo anexado',
+    attached_files: 'Arquivos anexados',
     you: 'Você',
     thinking: 'Pensando',
     expand_all: 'Expandir tudo',
@@ -11389,6 +11405,8 @@ const LOCALES = {
     selected_text_reply: '선택 항목으로 답장',
     selected_text_reply_title: '선택한 채팅 텍스트를 인용 컨텍스트로 추가',
     selected_text_reply_appended: '선택한 텍스트가 입력창에 추가되었습니다',
+    attached_file: '첨부 파일',
+    attached_files: '첨부 파일',
 
     diff_loading: 'diff 불러오는 중',
     diff_error: '패치 파일을 로드할 수 없습니다',
@@ -12694,6 +12712,8 @@ const LOCALES = {
     selected_text_reply: 'Répondre avec la sélection',
     selected_text_reply_title: 'Ajouter le texte sélectionné du chat comme contexte cité',
     selected_text_reply_appended: 'Texte sélectionné ajouté au compositeur',
+    attached_file: 'Fichier joint',
+    attached_files: 'Fichiers joints',
     diff_loading: 'Chargement des différences',
     diff_error: 'Impossible de charger le fichier de correctif',
     diff_too_large: 'Fichier de correctif trop volumineux pour être affiché en ligne',
@@ -13936,6 +13956,8 @@ const LOCALES = {
     selected_text_reply: 'Seçimle yanıtla',
     selected_text_reply_title: 'Seçilen sohbet metnini alıntılanan bağlam olarak ekle',
     selected_text_reply_appended: 'Seçilen metin besteciye eklendi',
+    attached_file: 'Ekli dosya',
+    attached_files: 'Ekli dosyalar',
 
     diff_loading: 'Fark yükleniyor',
     diff_error: 'Yama dosyası yüklenemedi',

--- a/static/messages.js
+++ b/static/messages.js
@@ -286,6 +286,12 @@ function applySessionTitleUpdate(sid, titleText, options={}){
   return true;
 }
 
+function _attachedFilesMarkerText(paths){
+  const clean=(paths||[]).map(p=>String(p||'').trim()).filter(Boolean);
+  if(!clean.length) return '';
+  return `[Attached files:\n${clean.join('\n')}\n]`;
+}
+
 async function send(){
   // Reject concurrent invocations early — before any await yields control.
   // If a send is already in-flight (e.g. queue drain), re-queue the message
@@ -456,9 +462,10 @@ async function send(){
 
   const uploadedNames=uploaded.map(u=>u.name||u);
   const uploadedPaths=uploaded.map(u=>u&&u.path?u.path:(u&&u.name?u.name:(u&&u.filename?u.filename:u)));
+  const attachedFilesMarker=_attachedFilesMarkerText(uploadedPaths);
   let msgText=text;
-  if(uploaded.length&&!msgText)msgText=`I've uploaded ${uploaded.length} file(s): ${uploadedPaths.join(', ')}`;
-  else if(uploaded.length)msgText=`${text}\n\n[Attached files: ${uploadedPaths.join(', ')}]`;
+  if(uploaded.length&&!msgText)msgText=`I've uploaded ${uploaded.length} file(s).\n\n${attachedFilesMarker}`;
+  else if(uploaded.length)msgText=`${text}\n\n${attachedFilesMarker}`;
   if(!msgText){setComposerStatus('Nothing to send');return;}
 
   $('msg').value='';autoResize();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1375,7 +1375,10 @@ function _messageComparableText(m){
 }
 
 function _stripAttachedFilesMarker(text){
-  return String(text||'').replace(/\n\n\[Attached files: [^\]]+\]$/,'').trim();
+  const value=String(text||'');
+  const withoutNewMarker=value.replace(/(?:\n{1,2}|^)\[Attached files:\s*\n[\s\S]*?\n\]\s*$/,'').trim();
+  if(withoutNewMarker!==value.trim()) return withoutNewMarker;
+  return value.replace(/(?:\n{1,2}|^)\[Attached files:\s*[^\n\]]*?\]\s*$/,'').trim();
 }
 
 function _sameTranscriptMessage(a,b){

--- a/static/style.css
+++ b/static/style.css
@@ -1545,6 +1545,13 @@
   .msg-body .katex{font-size:1.1em;}
   .msg-body .katex-display{margin:8px 0;}
   .msg-files{display:flex;flex-wrap:wrap;gap:6px;padding-left:30px;margin-bottom:10px;}
+  .msg-files--attached{padding-left:0;margin:8px 0 0;}
+  .msg-attached-files{margin:6px 0 10px 30px;border:1px solid var(--border);border-radius:8px;background:var(--surface);overflow:hidden;}
+  .msg-attached-files summary{display:flex;align-items:center;gap:6px;cursor:pointer;padding:7px 10px;font-size:12px;font-weight:600;color:var(--muted);user-select:none;}
+  .msg-attached-files[open] summary{border-bottom:1px solid var(--border);color:var(--text);}
+  .msg-attached-files .msg-files{padding:8px 10px;}
+  .msg-attached-lazy:not([src]){background:var(--hover-bg);}
+  .msg-file-badge--missing{background:rgba(233,69,96,.12);border-color:rgba(233,69,96,.35);color:var(--error,#e94560);}
   .msg-file-badge{display:flex;align-items:center;gap:5px;background:var(--accent-bg);border:1px solid var(--accent-bg-strong);border-radius:6px;padding:4px 9px;font-size:12px;color:var(--accent-text);}
   /* MEDIA: inline image rendering (feat #450) */
   .msg-media-img{display:inline-block;width:120px;height:90px;border-radius:6px;margin:3px 4px 3px 0;cursor:zoom-in;object-fit:cover;border:1px solid var(--border);vertical-align:bottom;transition:opacity .15s;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -728,6 +728,80 @@ function _renderAttachmentHtml(fname, url){
   }
   return `<div class="msg-file-badge">${li('paperclip',12)} ${esc(fname)}</div>`;
 }
+function _attachedFilesMarkerInfo(content){
+  const text=String(content||'');
+  // New format: closing bracket lives on its own line, so paths may contain
+  // commas and `]` safely. Keep a legacy single-line fallback for old sessions.
+  let match=text.match(/(?:^|\n+)\[Attached files:\s*\n([\s\S]*?)\n\]\s*$/);
+  let files=[];
+  if(match){
+    files=String(match[1]||'').replace(/\r/g,'').split(/\n+/).map(p=>p.trim()).filter(Boolean);
+  }else{
+    const legacyMatch=text.match(/(?:^|\n+)\[Attached files:\s*([^\n\]]*?)\]\s*$/);
+    if(!legacyMatch) return {content:text, files:[]};
+    match=legacyMatch;
+    const rawLegacy=String(match[1]||'').replace(/\r/g,'').trim();
+    files=rawLegacy.includes(',')
+      ? rawLegacy.split(/\s*,\s*/).map(p=>p.trim()).filter(Boolean)
+      : rawLegacy.split(/\n+/).map(p=>p.trim()).filter(Boolean);
+  }
+  return {content:text.slice(0,match.index).trimEnd(), files};
+}
+function _attachedFileMediaUrl(path, inline=false){
+  const ref=String(path||'').trim();
+  if(/^https?:\/\//i.test(ref)) return ref;
+  let url='api/media?path='+encodeURIComponent(ref);
+  if(inline) url+='&inline=1';
+  return url;
+}
+function _renderLazyAttachedFileHtml(path){
+  const ref=String(path||'').trim();
+  if(!ref) return '';
+  const fname=ref.split(/[\\/]/).pop()||ref;
+  const kind=_mediaKindForName(fname);
+  if(kind==='image'){
+    const src=_attachedFileMediaUrl(ref);
+    return `<img class="msg-media-img msg-attached-lazy" data-attached-src="${esc(src)}" alt="${esc(fname)}" loading="lazy">`;
+  }
+  if(kind==='audio'||kind==='video'){
+    const src=_attachedFileMediaUrl(ref,true);
+    const safeName=esc(fname);
+    const safeSrc=esc(src);
+    const tag=kind==='video'
+      ? `<video class="msg-media-player msg-media-video msg-attached-lazy" data-attached-src="${safeSrc}" controls preload="metadata" playsinline title="${safeName}"></video>`
+      : `<audio class="msg-media-player msg-media-audio msg-attached-lazy" data-attached-src="${safeSrc}" controls preload="metadata" title="${safeName}"></audio>`;
+    return `<div class="msg-media-editor msg-media-editor--${kind}" data-media-kind="${kind}">${tag}<div class="msg-media-meta"><span class="msg-media-name">${safeName}</span></div>${_mediaSpeedControlsHtml(kind,safeName)}</div>`;
+  }
+  const url=_attachedFileMediaUrl(ref,false)+'&download=1';
+  return `<a class="msg-media-link" href="${esc(url)}" download="${esc(fname)}">${li('paperclip',12)} ${esc(fname)}</a>`;
+}
+function _renderAttachedFilesMarkerHtml(files){
+  const clean=(files||[]).map(f=>String(f||'').trim()).filter(Boolean);
+  if(!clean.length) return '';
+  const label=clean.length===1?t('attached_file'):t('attached_files');
+  return `<details class="msg-attached-files"><summary>${li('paperclip',12)} ${esc(label)} (${clean.length})</summary><div class="msg-files msg-files--attached">${clean.map(_renderLazyAttachedFileHtml).join('')}</div></details>`;
+}
+function _activateLazyAttachedFiles(root){
+  const scope=root&&root.querySelectorAll?root:document;
+  scope.querySelectorAll('.msg-attached-files[open] [data-attached-src]').forEach(el=>{
+    const src=el.getAttribute('data-attached-src');
+    if(!src||el.getAttribute('src')) return;
+    el.setAttribute('src',src);
+  });
+}
+document.addEventListener('toggle', e=>{
+  const details=e.target&&e.target.closest?e.target.closest('.msg-attached-files'):null;
+  if(details&&details.open) _activateLazyAttachedFiles(details);
+}, true);
+document.addEventListener('error', e=>{
+  const el=e.target;
+  if(!el||!el.matches||!el.matches('.msg-attached-files [data-attached-src]')) return;
+  const label=el.getAttribute('alt')||el.getAttribute('title')||'attachment';
+  const missing=document.createElement('div');
+  missing.className='msg-file-badge msg-file-badge--missing';
+  missing.textContent='⚠ '+label+' unavailable';
+  el.replaceWith(missing);
+}, true);
 document.addEventListener('click', e => {
   const btn=e.target&&e.target.closest?e.target.closest('.media-speed-btn'):null;
   if(!btn) return;
@@ -6531,14 +6605,18 @@ function renderMessages(options){
       content='**Error:** No response received after context compression. Please retry.';
     }
     const displayContent=isUser?_stripWorkspaceDisplayPrefix(content):content;
+    const attachedMarker=isUser?_attachedFilesMarkerInfo(displayContent):{content:displayContent,files:[]};
+    const bodyContent=isUser?attachedMarker.content:displayContent;
     if(thinkingText&&!isUser){
-      thinkingText=_stripVisibleAssistantEchoFromThinking(thinkingText, displayContent);
+      thinkingText=_stripVisibleAssistantEchoFromThinking(thinkingText, bodyContent);
     }
     const isLastAssistant=!isUser&&vi===renderVisWithIdx.length-1;
     const nextRendered=renderVisWithIdx[vi+1];
     const isTurnFinalAssistant=!isUser&&(!nextRendered||!nextRendered.m||nextRendered.m.role!=='assistant');
     let filesHtml='';
-    if(m.attachments&&m.attachments.length){
+    const hasAttachedMarkerFiles=isUser&&attachedMarker.files&&attachedMarker.files.length;
+    const renderStructuredAttachments=!hasAttachedMarkerFiles&&(m.attachments&&m.attachments.length);
+    if(renderStructuredAttachments){
       // Static regression tests intentionally look for msg-media-img/msg-file-badge near this branch.
       const _attachSid=(S.session&&S.session.session_id)||'';
       filesHtml=`<div class="msg-files">${m.attachments.map(f=>{
@@ -6549,7 +6627,10 @@ function renderMessages(options){
         return _renderAttachmentHtml(fname,fileUrl);
       }).join('')}</div>`;
     }
-    let bodyHtml = _getCachedRender(displayContent, isUser);
+    if(isUser&&attachedMarker.files&&attachedMarker.files.length){
+      filesHtml+=_renderAttachedFilesMarkerHtml(attachedMarker.files);
+    }
+    let bodyHtml = _getCachedRender(bodyContent, isUser);
     if(!isUser&&m.provider_details){
       const summary=m.provider_details_label||'Provider details';
       bodyHtml += `<details class="provider-error-details"><summary>${esc(String(summary))}</summary><pre><code>${esc(String(m.provider_details))}</code></pre></details>`;
@@ -6601,7 +6682,7 @@ function renderMessages(options){
       row.id=_userMessageDomId(rawIdx);
       row.dataset.msgIdx=rawIdx;
       row.dataset.role='user';
-      row.dataset.rawText=String(displayContent).trim();
+      row.dataset.rawText=String(bodyContent).trim();
       row.innerHTML=`${filesHtml}<div class="msg-body">${bodyHtml}</div>${footHtml}`;
       inner.appendChild(row);
       userRows.set(rawIdx, row);

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -26,6 +26,9 @@ from tests._pytest_port import BASE, TEST_STATE_DIR
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+I18N_JS = (REPO_ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
 WORKSPACE_JS = (REPO_ROOT / "static" / "workspace.js").read_text(encoding="utf-8")
 
 
@@ -100,6 +103,67 @@ class TestMediaRenderMdStash(unittest.TestCase):
         # PR #1135: CSS class toggle replaced by proper lightbox overlay
         self.assertIn("_openImgLightbox", UI_JS,
                       "Clicking the image must open lightbox overlay (_openImgLightbox)")
+
+
+class TestReloadedAttachedFilesMarker(unittest.TestCase):
+    """Persisted transcript markers should render as guarded lazy media again."""
+
+    def test_attached_files_marker_parser_exists(self):
+        self.assertIn("_attachedFilesMarkerInfo", UI_JS)
+        self.assertIn("Attached files:", UI_JS)
+        self.assertIn("msg-attached-files", UI_JS)
+
+    def test_attached_files_marker_renders_lazy_guard(self):
+        self.assertIn("<details class=\"msg-attached-files\"", UI_JS)
+        self.assertIn("data-attached-src", UI_JS)
+        self.assertIn("_activateLazyAttachedFiles", UI_JS)
+        self.assertIn("api/media?path=", UI_JS)
+
+    def test_render_messages_strips_marker_from_user_body(self):
+        render_start = UI_JS.index("function renderMessages(options)")
+        marker_start = UI_JS.index("const attachedMarker=", render_start)
+        render_body = UI_JS[marker_start:marker_start + 2500]
+        self.assertIn("_attachedFilesMarkerInfo(displayContent)", render_body)
+        self.assertIn("attachedMarker.content", render_body)
+        self.assertIn("_renderAttachedFilesMarkerHtml", render_body)
+
+    def test_dedupe_strip_handles_multiline_marker(self):
+        self.assertIn("[\\s\\S]*?", SESSIONS_JS)
+        self.assertIn("Attached files:", SESSIONS_JS)
+
+    def test_marker_preview_suppresses_duplicate_structured_preview(self):
+        render_start = UI_JS.index("function renderMessages(options)")
+        marker_start = UI_JS.index("const attachedMarker=", render_start)
+        render_body = UI_JS[marker_start:marker_start + 2500]
+        self.assertIn("const hasAttachedMarkerFiles=", render_body)
+        self.assertIn("const renderStructuredAttachments=", render_body)
+        self.assertIn("!hasAttachedMarkerFiles&&(m.attachments&&m.attachments.length)", render_body)
+
+    def test_new_marker_serialization_is_newline_based(self):
+        self.assertIn("function _attachedFilesMarkerText", MESSAGES_JS)
+        marker_start = MESSAGES_JS.index("function _attachedFilesMarkerText")
+        marker_body = MESSAGES_JS[marker_start:marker_start + 800]
+        self.assertIn("clean.join('\\n')", marker_body)
+        self.assertNotIn("paths.join(', ')", marker_body)
+        self.assertIn("_attachedFilesMarkerText(uploadedPaths)", MESSAGES_JS)
+
+    def test_upload_only_messages_keep_machine_readable_marker(self):
+        send_start = MESSAGES_JS.index("const attachedFilesMarker=_attachedFilesMarkerText(uploadedPaths)")
+        send_body = MESSAGES_JS[send_start:send_start + 500]
+        self.assertIn("if(uploaded.length&&!msgText)", send_body)
+        self.assertIn("${attachedFilesMarker}", send_body)
+
+    def test_parser_supports_newline_marker_with_brackets_in_path(self):
+        parser_start = UI_JS.index("function _attachedFilesMarkerInfo")
+        parser_body = UI_JS[parser_start:parser_start + 1600]
+        self.assertIn("\\n\\]", parser_body)
+        self.assertIn("legacyMatch", parser_body)
+
+    def test_attached_files_summary_uses_i18n_keys(self):
+        self.assertIn("t('attached_file')", UI_JS)
+        self.assertIn("t('attached_files')", UI_JS)
+        self.assertIn("attached_file:", I18N_JS)
+        self.assertIn("attached_files:", I18N_JS)
 
 
 # ── Static analysis: CSS ──────────────────────────────────────────────────────

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -250,7 +250,7 @@ class TestToolCallGroupingStatic:
     def test_settled_thinking_suppresses_visible_assistant_echoes(self):
         render_fn = _function_body(UI_JS, "renderMessages")
         helper = _function_body(UI_JS, "_stripVisibleAssistantEchoFromThinking")
-        assert "_stripVisibleAssistantEchoFromThinking(thinkingText, displayContent)" in render_fn, (
+        assert "_stripVisibleAssistantEchoFromThinking(thinkingText, bodyContent)" in render_fn, (
             "Settled Thinking cards should not repeat text already rendered as visible assistant content."
         )
         assert "s.length>=20" in helper, (

--- a/tests/test_workspace_display_prefix.py
+++ b/tests/test_workspace_display_prefix.py
@@ -43,8 +43,8 @@ def test_user_render_uses_stripped_display_content_without_preempting_context_ca
     assert user_idx != -1, "user render branch not found"
     assert display_idx < context_idx < user_idx
     # The render call may be a direct _renderUserFencedBlocks call or go
-    # through the cached wrapper _getCachedRender.  Both paths accept the
-    # already-stripped displayContent, so the invariant holds either way.
-    assert ("_renderUserFencedBlocks(displayContent)" in render_prefix or
-            "_getCachedRender(displayContent, isUser)" in render_prefix)
-    assert "row.dataset.rawText=String(displayContent).trim();" in render_prefix
+    # through the cached wrapper _getCachedRender. Both paths render bodyContent,
+    # which is displayContent after any persisted attachment marker is split out.
+    assert ("_renderUserFencedBlocks(bodyContent)" in render_prefix or
+            "_getCachedRender(bodyContent, isUser)" in render_prefix)
+    assert "row.dataset.rawText=String(bodyContent).trim();" in render_prefix


### PR DESCRIPTION
## Summary
- Render persisted `[Attached files: ...]` transcript markers back into guarded media previews after session reload/import.
- Use lazy loading behind a `<details>` disclosure so large attachments do not overload the chat on render.
- Preserve legacy marker parsing, add newline-based marker serialization for paths containing commas or `]`, and suppress duplicate previews when live structured attachments are also present.
- Add locale labels across all locale bundles and a release-note entry.

## Validation
- `python3 -m pytest tests/test_media_inline.py -q` → 51 passed
- `python3 -m pytest tests/test_chinese_locale.py tests/test_japanese_locale.py tests/test_korean_locale.py tests/test_russian_locale.py tests/test_spanish_locale.py tests/test_turkish_locale.py tests/test_ui_tool_call_cleanup.py::TestToolCallGroupingStatic::test_settled_thinking_suppresses_visible_assistant_echoes tests/test_workspace_display_prefix.py::test_user_render_uses_stripped_display_content_without_preempting_context_cards -q` → 35 passed
- `env TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 python3 -m pytest tests/ -q` → 6637 passed, 54 skipped, 3 xpassed, 8 subtests passed
- `node --check static/ui.js`
- `node --check static/messages.js`
- `node --check static/sessions.js`
- `node --check static/i18n.js`
- `git diff --check`
- Added-line sensitive marker scan → 0 hits
- Independent blocker-only review → PASS

## Contract Routing
- UI/UX: follows the existing progressive-disclosure pattern for metadata/media so reload-restored attachments stay available without flooding the transcript.
- State/session rendering: changes frontend rendering and marker serialization; `/api/media` serving behavior is unchanged.

## Notes
- Complements #3064: that PR handles session media image sources; this PR handles persisted attachment markers after reload/import.
- A non-sanitized local full-suite run had one locale-format-only failure in `test_issue1144_session_time_sync.py` (`10:00 AM` expected vs German locale output). The CI-like `LC_ALL=C.UTF-8` run passed.
