### PR TITLE
fix: preserve clarify fallback ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Clarify prompt SSE fallback polling now preserves its owner session id, matching approval polling behavior so terminal events from another session cannot stop the active clarify fallback poller.
+
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 
 ### Added

--- a/static/messages.js
+++ b/static/messages.js
@@ -3147,7 +3147,8 @@ function startClarifyPolling(sid) {
   });
 
   _clarifyEventSource.onerror = function() {
-    stopClarifyPolling();
+    if (_clarifyEventSource) { try { _clarifyEventSource.close(); } catch(_){} _clarifyEventSource = null; }
+    if (_clarifyHealthTimer) { clearInterval(_clarifyHealthTimer); _clarifyHealthTimer = null; }
     _startClarifyFallbackPoll(sid);
   };
 
@@ -3177,6 +3178,7 @@ function startClarifyPolling(sid) {
 }
 
 function _startClarifyFallbackPoll(sid) {
+  _clarifyPollingSessionId = sid || null;
   _clarifyFallbackTimer = setInterval(async () => {
     if (!S.session || S.session.session_id !== sid) {
       stopClarifyPolling(); _hideClarifyCardIfOwner(sid, true, 'session'); return;

--- a/tests/test_session_runtime_ownership_invariants.py
+++ b/tests/test_session_runtime_ownership_invariants.py
@@ -117,6 +117,21 @@ class TestSessionOwnedRuntimeInvariants:
             "the active pane currently owns."
         )
 
+    def test_clarify_sse_fallback_preserves_owner_session_id(self):
+        messages = read("static/messages.js")
+        start_clarify = _function_body(messages, "startClarifyPolling")
+        fallback = _function_body(messages, "_startClarifyFallbackPoll")
+
+        assert "_clarifyPollingSessionId = sid || null" in fallback, (
+            "Any clarify fallback poller should retain its owner session id."
+        )
+        onerror_idx = start_clarify.index("_clarifyEventSource.onerror")
+        onerror_body = start_clarify[onerror_idx:start_clarify.index("};", onerror_idx)]
+        assert "stopClarifyPolling();" not in onerror_body, (
+            "SSE fallback must not clear _clarifyPollingSessionId before starting the fallback poller."
+        )
+        assert "_startClarifyFallbackPoll(sid)" in onerror_body
+
     def test_live_stream_transport_and_inflight_state_remain_session_keyed(self):
         messages = read("static/messages.js")
         close_live = _function_body(messages, "closeLiveStream")


### PR DESCRIPTION
## Thinking Path

Approval polling keeps its owner session when SSE falls back to polling. Clarify polling had an asymmetric path: its SSE `onerror` called the full stop helper before starting fallback polling, briefly clearing `_clarifyPollingSessionId` and allowing later terminal cleanup from another session to stop the active fallback poller.

## What Changed

- Clarify SSE `onerror` now closes only the SSE/health resources before starting fallback polling.
- `_startClarifyFallbackPoll(sid)` explicitly records the fallback owner session id.
- Adds source-level regression coverage for the fallback ownership invariant.
- Adds a changelog entry.

## Verification

- `node --check static/messages.js`
- `python3.11 -m pytest tests/test_session_runtime_ownership_invariants.py tests/test_1694_prompt_ownership.py -q -o addopts=` (`12 passed`)
- `git diff --check origin/master...HEAD`
