### PR TITLE
feat: add runner-local HTTP client boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `runner-local` can now use an explicit `HERMES_WEBUI_RUNNER_BASE_URL` HTTP client instead of always returning the bounded not-configured path. The default remains legacy-direct, `runner-local` without a URL still returns a safe 501, and the WebUI process only creates a client boundary rather than owning runner streams, cancellation flags, approval/clarify queues, cached agents, or active-run registries. Adds a minimal in-memory runner backend skeleton for contract tests and future supervised backend work.
+
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -188,6 +188,26 @@ messaging surfaces. Attachments, cancellation, approvals, and clarify prompts
 still follow WebUI's current compatibility path and may not match every messaging
 surface until the runtime-adapter migration is complete.
 
+### Optional runner-local backend client
+
+`HERMES_WEBUI_RUNTIME_ADAPTER=runner-local` remains default-off and experimental.
+With no runner URL configured it intentionally returns a bounded `501` instead of
+silently falling back to the legacy in-process runtime. Operators testing the
+runtime-adapter migration can now point the runner-local seam at an explicitly
+supervised HTTP backend:
+
+```bash
+HERMES_WEBUI_RUNTIME_ADAPTER=runner-local \
+HERMES_WEBUI_RUNNER_BASE_URL=http://127.0.0.1:8788 \
+./ctl.sh restart
+```
+
+The WebUI process only creates an HTTP client for this boundary; it does not own
+runner streams, cancellation flags, approval/clarify queues, cached agents, or
+active-run registries. Successful `/api/chat/start` responses remain limited to
+the existing browser-compatible field whitelist while runner-internal `run_id`,
+`status`, and `active_controls` stay behind the adapter.
+
 The bootstrap will:
 
 1. Detect Hermes Agent and, if missing, attempt the official installer (`curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash`).

--- a/api/routes.py
+++ b/api/routes.py
@@ -9015,15 +9015,17 @@ def _start_chat_stream_for_session(
 
 
 def _runtime_runner_client_factory():
-    """Return the runner-local client when a supervised backend exists.
+    """Return the configured runner-local HTTP client.
 
-    Slice 4d wires the `/api/chat/start` selection point without silently falling
-    back to the legacy in-process runtime when `runner-local` is explicitly
-    requested. The supervised runner backend itself is intentionally not created
-    in this helper yet; a later slice can replace this factory with the concrete
-    client while keeping the route contract stable.
+    The runner remains default-off: selecting ``runner-local`` without an
+    explicit ``HERMES_WEBUI_RUNNER_BASE_URL`` still returns the existing bounded
+    501 path (``runner-local chat backend is not configured``).  When configured,
+    WebUI only creates a client for the external runner boundary; it does not
+    allocate runner-owned stream/cancel/approval state in this process.
     """
-    raise NotImplementedError("runner-local chat backend is not configured")
+    from api.runner_client import build_runner_client_from_env
+
+    return build_runner_client_from_env()
 
 
 def _chat_start_response_from_run_start(result):

--- a/api/runner_backend.py
+++ b/api/runner_backend.py
@@ -1,0 +1,216 @@
+"""Minimal in-memory runner backend skeleton for the runner-local seam.
+
+The class here models the runner-side contract without wiring the default WebUI
+request process to a new execution owner. It is deliberately process-local to the
+runner backend object only; callers that need restart survival should run it in a
+supervised backend and later replace the storage with durable runner-owned state.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import itertools
+import threading
+import time
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+
+def _request_payload(value: Any) -> dict[str, Any]:
+    if hasattr(value, "__dataclass_fields__") and not isinstance(value, type):
+        return asdict(value)
+    if isinstance(value, dict):
+        return dict(value)
+    return {}
+
+
+class InMemoryRunnerBackend:
+    """Tiny runner-side backend implementing the HTTP client contract methods."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._counter = itertools.count(1)
+        self._runs: dict[str, dict[str, Any]] = {}
+        self._events: dict[str, list[dict[str, Any]]] = {}
+        self._session_runs: dict[str, str] = {}
+
+    def start_run(self, request: Any) -> dict[str, Any]:
+        payload = _request_payload(request)
+        session_id = str(payload.get("session_id") or "")
+        run_id = f"runner-local-{next(self._counter)}"
+        now = time.time()
+        event = {
+            "event_id": f"{run_id}:1",
+            "seq": 1,
+            "run_id": run_id,
+            "session_id": session_id,
+            "type": "run.started",
+            "created_at": now,
+            "terminal": False,
+            "payload": {
+                "status": "running",
+                "workspace": payload.get("workspace"),
+                "profile": payload.get("profile"),
+                "model": payload.get("model"),
+                "provider": payload.get("provider"),
+            },
+        }
+        status = {
+            "run_id": run_id,
+            "session_id": session_id,
+            "stream_id": run_id,
+            "status": "running",
+            "started_at": now,
+            "last_event_id": event["event_id"],
+            "terminal_state": None,
+            "active_controls": ["cancel"],
+            "pending_approval_id": None,
+            "pending_clarify_id": None,
+        }
+        with self._lock:
+            self._runs[run_id] = status
+            self._events[run_id] = [event]
+            if session_id:
+                self._session_runs[session_id] = run_id
+        return dict(status)
+
+    def observe_run(self, run_id: str, *, cursor: str | None = None) -> dict[str, Any]:
+        after_seq = _cursor_to_seq(cursor)
+        with self._lock:
+            events = [dict(event) for event in self._events.get(run_id, []) if int(event.get("seq") or 0) > after_seq]
+            status = self._runs.get(run_id, {})
+        cursor_value = str(events[-1]["seq"]) if events else (cursor or "")
+        return {
+            "run_id": run_id,
+            "events": events,
+            "cursor": cursor_value,
+            "last_event_id": events[-1]["event_id"] if events else status.get("last_event_id"),
+        }
+
+    def get_run(self, run_id: str) -> dict[str, Any]:
+        with self._lock:
+            return dict(self._runs.get(run_id, {"run_id": run_id, "status": "unknown", "active_controls": []}))
+
+    def latest_run_for_session(self, session_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            run_id = self._session_runs.get(session_id)
+            if not run_id:
+                return None
+            return dict(self._runs.get(run_id, {}))
+
+    def cancel_run(self, run_id: str) -> dict[str, Any]:
+        now = time.time()
+        with self._lock:
+            status = self._runs.get(run_id)
+            if not status or status.get("terminal_state"):
+                return {"ok": False, "status": "not-active", "message": "Run is not active."}
+            next_seq = len(self._events.get(run_id, [])) + 1
+            event = {
+                "event_id": f"{run_id}:{next_seq}",
+                "seq": next_seq,
+                "run_id": run_id,
+                "session_id": status.get("session_id"),
+                "type": "cancelled",
+                "created_at": now,
+                "terminal": True,
+                "payload": {"ok": True},
+            }
+            self._events.setdefault(run_id, []).append(event)
+            status.update(
+                {
+                    "status": "cancelled",
+                    "terminal_state": "cancelled",
+                    "last_event_id": event["event_id"],
+                    "active_controls": [],
+                }
+            )
+        return {"ok": True, "status": "cancelled", "event_id": event["event_id"]}
+
+    def respond_approval(self, run_id: str, approval_id: str, choice: str) -> dict[str, Any]:
+        return {"ok": False, "status": "unsupported", "message": "Approval is not supported by this runner backend."}
+
+    def respond_clarify(self, run_id: str, clarify_id: str, response: str) -> dict[str, Any]:
+        return {"ok": False, "status": "unsupported", "message": "Clarify is not supported by this runner backend."}
+
+    def queue_message(self, run_id: str, message: str, *, mode: str = "queue") -> dict[str, Any]:
+        return {"ok": False, "status": "unsupported", "message": "Queue is not supported by this runner backend."}
+
+    def update_goal(self, session_id: str, action: str, text: str = "") -> dict[str, Any]:
+        return {"ok": False, "status": "unsupported", "message": "Goal is not supported by this runner backend."}
+
+
+def make_runner_handler(backend: InMemoryRunnerBackend | None = None) -> type[BaseHTTPRequestHandler]:
+    """Return a small HTTP handler exposing the runner client endpoint shape."""
+    runner = backend or InMemoryRunnerBackend()
+
+    class RunnerBackendHandler(BaseHTTPRequestHandler):
+        def log_message(self, format, *args):  # pragma: no cover - embedder owns logging
+            return
+
+        def _read_json(self) -> dict[str, Any]:
+            length = int(self.headers.get("Content-Length") or "0")
+            if length <= 0:
+                return {}
+            try:
+                parsed = json.loads(self.rfile.read(length).decode("utf-8"))
+            except json.JSONDecodeError:
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+
+        def _send_json(self, payload: dict[str, Any], status: int = 200) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self) -> None:
+            body = self._read_json()
+            parsed = urlparse(self.path)
+            parts = [part for part in parsed.path.split("/") if part]
+            if parts == ["v1", "runs"]:
+                return self._send_json(runner.start_run(body))
+            if len(parts) == 4 and parts[:2] == ["v1", "runs"] and parts[3] == "cancel":
+                return self._send_json(runner.cancel_run(parts[2]))
+            if len(parts) == 5 and parts[:2] == ["v1", "runs"] and parts[3] == "approval":
+                return self._send_json(runner.respond_approval(parts[2], parts[4], str(body.get("choice") or "")))
+            if len(parts) == 5 and parts[:2] == ["v1", "runs"] and parts[3] == "clarify":
+                return self._send_json(runner.respond_clarify(parts[2], parts[4], str(body.get("response") or "")))
+            if len(parts) == 4 and parts[:2] == ["v1", "runs"] and parts[3] == "queue":
+                return self._send_json(runner.queue_message(parts[2], str(body.get("message") or ""), mode=str(body.get("mode") or "queue")))
+            if len(parts) == 4 and parts[:2] == ["v1", "sessions"] and parts[3] == "goal":
+                return self._send_json(runner.update_goal(parts[2], str(body.get("action") or "status"), str(body.get("text") or "")))
+            return self._send_json({"error": "not found"}, status=404)
+
+        def do_GET(self) -> None:
+            parsed = urlparse(self.path)
+            parts = [part for part in parsed.path.split("/") if part]
+            if len(parts) == 4 and parts[:2] == ["v1", "runs"] and parts[3] == "events":
+                cursor = (parse_qs(parsed.query).get("cursor") or [None])[0]
+                return self._send_json(runner.observe_run(parts[2], cursor=cursor))
+            if len(parts) == 3 and parts[:2] == ["v1", "runs"]:
+                return self._send_json(runner.get_run(parts[2]))
+            if len(parts) == 4 and parts[:2] == ["v1", "sessions"] and parts[3] == "latest-run":
+                return self._send_json(runner.latest_run_for_session(parts[2]) or {"status": "unknown"})
+            return self._send_json({"error": "not found"}, status=404)
+
+    return RunnerBackendHandler
+
+
+def make_runner_server(host: str = "127.0.0.1", port: int = 0, *, backend: InMemoryRunnerBackend | None = None) -> ThreadingHTTPServer:
+    """Create, but do not start, an embeddable runner HTTP server."""
+    return ThreadingHTTPServer((host, port), make_runner_handler(backend))
+
+
+def _cursor_to_seq(cursor: str | None) -> int:
+    if cursor in (None, ""):
+        return 0
+    try:
+        text = str(cursor)
+        if ":" in text:
+            text = text.rsplit(":", 1)[-1]
+        return max(0, int(text))
+    except (TypeError, ValueError):
+        return 0

--- a/api/runner_client.py
+++ b/api/runner_client.py
@@ -1,0 +1,149 @@
+"""HTTP client for the default-off WebUI runner-local adapter backend.
+
+This module is intentionally small: it translates RuntimeAdapter dataclasses into
+HTTP/JSON calls to a separately supervised runner backend. It does not create or
+own agent instances, stream maps, cancellation flags, approval queues, clarify
+queues, goal state, or process-local active-run registries in the main WebUI
+process.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict
+import json
+import os
+from typing import Any
+from urllib import error, parse, request
+
+_RUNNER_BASE_URL_ENV = "HERMES_WEBUI_RUNNER_BASE_URL"
+_RUNNER_TIMEOUT_ENV = "HERMES_WEBUI_RUNNER_TIMEOUT"
+_NOT_CONFIGURED = "runner-local chat backend is not configured"
+
+
+def runner_base_url(environ: dict[str, str] | None = None) -> str | None:
+    """Return the explicitly configured runner base URL, if any."""
+    source = os.environ if environ is None else environ
+    raw = str(source.get(_RUNNER_BASE_URL_ENV, "") or "").strip()
+    if not raw:
+        return None
+    return raw.rstrip("/")
+
+
+def runner_client_configured(environ: dict[str, str] | None = None) -> bool:
+    return runner_base_url(environ) is not None
+
+
+def _runner_timeout(environ: dict[str, str] | None = None) -> float:
+    source = os.environ if environ is None else environ
+    raw = str(source.get(_RUNNER_TIMEOUT_ENV, "") or "").strip()
+    if not raw:
+        return 10.0
+    try:
+        return max(0.5, float(raw))
+    except ValueError:
+        return 10.0
+
+
+def build_runner_client_from_env(environ: dict[str, str] | None = None) -> "HttpRunnerClient":
+    """Build the configured runner client or keep runner-local bounded/off."""
+    base_url = runner_base_url(environ)
+    if not base_url:
+        raise NotImplementedError(_NOT_CONFIGURED)
+    return HttpRunnerClient(base_url=base_url, timeout=_runner_timeout(environ))
+
+
+def _to_jsonable(value: Any) -> Any:
+    if hasattr(value, "__dataclass_fields__") and not isinstance(value, type):
+        return asdict(value)
+    if isinstance(value, dict):
+        return dict(value)
+    return value
+
+
+class HttpRunnerClient:
+    """RuntimeAdapter-compatible HTTP/JSON client for a runner backend."""
+
+    def __init__(self, *, base_url: str, timeout: float = 10.0):
+        self.base_url = str(base_url or "").strip().rstrip("/")
+        if not self.base_url:
+            raise ValueError("base_url is required")
+        self.timeout = timeout
+
+    def _url(self, path: str, query: dict[str, str] | None = None) -> str:
+        url = f"{self.base_url}{path}"
+        if query:
+            encoded = parse.urlencode({k: v for k, v in query.items() if v not in (None, "")})
+            if encoded:
+                url = f"{url}?{encoded}"
+        return url
+
+    def _json_request(self, method: str, path: str, payload: Any | None = None, query: dict[str, str] | None = None) -> dict[str, Any]:
+        body = None
+        headers = {"Accept": "application/json"}
+        if payload is not None:
+            body = json.dumps(_to_jsonable(payload)).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        req = request.Request(self._url(path, query=query), data=body, headers=headers, method=method)
+        try:
+            with request.urlopen(req, timeout=self.timeout) as resp:
+                raw = resp.read()
+        except error.HTTPError as exc:
+            try:
+                detail = json.loads(exc.read().decode("utf-8") or "{}")
+            except Exception:
+                detail = {}
+            safe = detail.get("error") or detail.get("message") or f"runner backend returned HTTP {exc.code}"
+            raise RuntimeError(str(safe)) from exc
+        except error.URLError as exc:
+            raise RuntimeError(f"runner backend unavailable: {exc.reason}") from exc
+        if not raw:
+            return {}
+        try:
+            parsed = json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("runner backend returned invalid JSON") from exc
+        if not isinstance(parsed, dict):
+            raise RuntimeError("runner backend returned a non-object JSON payload")
+        return parsed
+
+    def start_run(self, request_payload: Any) -> dict[str, Any]:
+        return self._json_request("POST", "/v1/runs", request_payload)
+
+    def observe_run(self, run_id: str, *, cursor: str | None = None) -> dict[str, Any]:
+        return self._json_request("GET", f"/v1/runs/{parse.quote(str(run_id), safe='')}/events", query={"cursor": cursor or ""})
+
+    def get_run(self, run_id: str) -> dict[str, Any]:
+        return self._json_request("GET", f"/v1/runs/{parse.quote(str(run_id), safe='')}")
+
+    def cancel_run(self, run_id: str) -> dict[str, Any]:
+        return self._json_request("POST", f"/v1/runs/{parse.quote(str(run_id), safe='')}/cancel", {})
+
+    def respond_approval(self, run_id: str, approval_id: str, choice: str) -> dict[str, Any]:
+        return self._json_request(
+            "POST",
+            f"/v1/runs/{parse.quote(str(run_id), safe='')}/approval/{parse.quote(str(approval_id), safe='')}",
+            {"choice": choice},
+        )
+
+    def respond_clarify(self, run_id: str, clarify_id: str, response_text: str) -> dict[str, Any]:
+        return self._json_request(
+            "POST",
+            f"/v1/runs/{parse.quote(str(run_id), safe='')}/clarify/{parse.quote(str(clarify_id), safe='')}",
+            {"response": response_text},
+        )
+
+    def queue_message(self, run_id: str, message: str, *, mode: str = "queue") -> dict[str, Any]:
+        return self._json_request(
+            "POST",
+            f"/v1/runs/{parse.quote(str(run_id), safe='')}/queue",
+            {"message": message, "mode": mode},
+        )
+
+    def update_goal(self, session_id: str, action: str, text: str = "") -> dict[str, Any]:
+        return self._json_request(
+            "POST",
+            f"/v1/sessions/{parse.quote(str(session_id), safe='')}/goal",
+            {"action": action, "text": text},
+        )
+
+    def latest_run_for_session(self, session_id: str) -> dict[str, Any]:
+        return self._json_request("GET", f"/v1/sessions/{parse.quote(str(session_id), safe='')}/latest-run")

--- a/docs/rfcs/hermes-run-adapter-contract.md
+++ b/docs/rfcs/hermes-run-adapter-contract.md
@@ -956,6 +956,12 @@ Non-goals for Slice 4e:
 
 #### Slice 4f: Supervised local runner client backend gate
 
+Status as of 2026-05-28: implementation in progress. The code now defines an
+explicit `HERMES_WEBUI_RUNNER_BASE_URL` HTTP client boundary and a minimal
+in-memory runner backend skeleton for contract tests while keeping the default
+legacy-direct path unchanged. `runner-local` without a configured runner URL
+still returns the bounded not-configured response.
+
 After the route-selection harness ships, the next reviewable step is not to make
 `runner-local` the default. It is to define the first concrete supervised/local
 runner client backend that can replace the bounded 501 path under the existing

--- a/tests/test_runner_client.py
+++ b/tests/test_runner_client.py
@@ -1,0 +1,233 @@
+import importlib
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+
+class RecordingRunnerHandler(BaseHTTPRequestHandler):
+    calls = []
+
+    def log_message(self, format, *args):  # pragma: no cover - keep test output quiet
+        return
+
+    def _read_json(self):
+        length = int(self.headers.get("Content-Length") or "0")
+        if length <= 0:
+            return {}
+        return json.loads(self.rfile.read(length).decode("utf-8"))
+
+    def _send_json(self, payload, status=200):
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_POST(self):
+        body = self._read_json()
+        RecordingRunnerHandler.calls.append(("POST", self.path, body))
+        if self.path == "/v1/runs":
+            self._send_json({
+                "run_id": "run-http-1",
+                "session_id": body["session_id"],
+                "stream_id": "run-http-1",
+                "status": "running",
+                "active_controls": ["cancel"],
+                "received_workspace": body.get("workspace"),
+                "received_profile": body.get("profile"),
+            })
+        elif self.path == "/v1/runs/run-http-1/cancel":
+            self._send_json({"ok": True, "status": "accepted", "event_id": "run-http-1:3"})
+        elif self.path == "/v1/runs/run-http-1/approval/approval-1":
+            self._send_json({"ok": True, "status": body.get("choice")})
+        elif self.path == "/v1/runs/run-http-1/clarify/clarify-1":
+            self._send_json({"ok": True, "status": "answered"})
+        elif self.path == "/v1/runs/run-http-1/queue":
+            self._send_json({"ok": False, "status": "unsupported", "message": "Queue unavailable."})
+        elif self.path == "/v1/sessions/session-1/goal":
+            self._send_json({"ok": False, "status": "unsupported", "message": "Goal unavailable."})
+        else:
+            self._send_json({"error": "not found"}, status=404)
+
+    def do_GET(self):
+        RecordingRunnerHandler.calls.append(("GET", self.path, {}))
+        parsed = urlparse(self.path)
+        if parsed.path == "/v1/runs/run-http-1/events":
+            cursor = (parse_qs(parsed.query).get("cursor") or [None])[0]
+            self._send_json({
+                "run_id": "run-http-1",
+                "cursor": "2",
+                "last_event_id": "run-http-1:2",
+                "events": [
+                    {"event_id": "run-http-1:2", "seq": 2, "type": "done", "payload": {"ok": True}},
+                ],
+                "seen_cursor": cursor,
+            })
+        elif parsed.path == "/v1/runs/run-http-1":
+            self._send_json({
+                "run_id": "run-http-1",
+                "session_id": "session-1",
+                "status": "completed",
+                "terminal_state": "completed",
+                "last_event_id": "run-http-1:2",
+                "active_controls": [],
+            })
+        else:
+            self._send_json({"error": "not found"}, status=404)
+
+
+def run_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), RecordingRunnerHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, f"http://127.0.0.1:{server.server_port}"
+
+
+def test_runner_client_factory_is_default_off_and_uses_explicit_base_url(monkeypatch):
+    runner_client = importlib.import_module("api.runner_client")
+
+    assert runner_client.runner_base_url({}) is None
+    assert runner_client.runner_client_configured({}) is False
+
+    try:
+        runner_client.build_runner_client_from_env({})
+    except NotImplementedError as exc:
+        assert "runner-local chat backend is not configured" in str(exc)
+    else:
+        raise AssertionError("runner client factory must stay default-off")
+
+    client = runner_client.build_runner_client_from_env({"HERMES_WEBUI_RUNNER_BASE_URL": " http://runner.local/ "})
+    assert isinstance(client, runner_client.HttpRunnerClient)
+    assert client.base_url == "http://runner.local"
+
+
+def test_http_runner_client_matches_runtime_adapter_contract():
+    runtime = importlib.import_module("api.runtime_adapter")
+    runner_client = importlib.import_module("api.runner_client")
+    server, base_url = run_server()
+    RecordingRunnerHandler.calls.clear()
+    try:
+        client = runner_client.HttpRunnerClient(base_url=base_url, timeout=2)
+        request = runtime.StartRunRequest(
+            session_id="session-1",
+            message="hello runner",
+            attachments=[{"name": "photo.png", "path": "/uploads/photo.png", "mime": "image/png"}],
+            workspace="/workspace/project",
+            profile="research",
+            provider="openai-codex",
+            model="gpt-5.5",
+            toolsets=["terminal", "file"],
+            source="webui",
+            metadata={"route": "/api/chat/start"},
+        )
+
+        started = client.start_run(request)
+        replay = client.observe_run("run-http-1", cursor="1")
+        status = client.get_run("run-http-1")
+        cancel = client.cancel_run("run-http-1")
+        approval = client.respond_approval("run-http-1", "approval-1", "once")
+        clarify = client.respond_clarify("run-http-1", "clarify-1", "answer")
+        queued = client.queue_message("run-http-1", "next", mode="queue")
+        goal = client.update_goal("session-1", "status", "")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert started["run_id"] == "run-http-1"
+    assert started["session_id"] == "session-1"
+    assert started["received_workspace"] == "/workspace/project"
+    assert started["received_profile"] == "research"
+    assert replay["last_event_id"] == "run-http-1:2"
+    assert replay["seen_cursor"] == "1"
+    assert status["terminal_state"] == "completed"
+    assert cancel["event_id"] == "run-http-1:3"
+    assert approval["status"] == "once"
+    assert clarify["status"] == "answered"
+    assert queued["status"] == "unsupported"
+    assert goal["status"] == "unsupported"
+
+    start_call = RecordingRunnerHandler.calls[0]
+    assert start_call[0:2] == ("POST", "/v1/runs")
+    assert start_call[2]["session_id"] == "session-1"
+    assert start_call[2]["workspace"] == "/workspace/project"
+    assert start_call[2]["profile"] == "research"
+    assert start_call[2]["provider"] == "openai-codex"
+    assert start_call[2]["model"] == "gpt-5.5"
+    assert start_call[2]["toolsets"] == ["terminal", "file"]
+    assert start_call[2]["source"] == "webui"
+    assert start_call[2]["metadata"] == {"route": "/api/chat/start"}
+
+
+def test_runtime_runner_factory_uses_http_client_only_when_base_url_configured(monkeypatch):
+    routes = importlib.import_module("api.routes")
+    runner_client = importlib.import_module("api.runner_client")
+
+    monkeypatch.delenv("HERMES_WEBUI_RUNNER_BASE_URL", raising=False)
+    try:
+        routes._runtime_runner_client_factory()
+    except NotImplementedError as exc:
+        assert "runner-local chat backend is not configured" in str(exc)
+    else:
+        raise AssertionError("runner-local must still return bounded 501 when no runner URL is configured")
+
+    monkeypatch.setenv("HERMES_WEBUI_RUNNER_BASE_URL", "http://127.0.0.1:65535")
+    client = routes._runtime_runner_client_factory()
+    assert isinstance(client, runner_client.HttpRunnerClient)
+
+
+def test_in_memory_runner_backend_provides_minimal_supervised_contract():
+    runner_backend = importlib.import_module("api.runner_backend")
+    runtime = importlib.import_module("api.runtime_adapter")
+
+    backend = runner_backend.InMemoryRunnerBackend()
+    request = runtime.StartRunRequest(
+        session_id="session-1",
+        message="hello",
+        workspace="/workspace/project",
+        profile="default",
+    )
+
+    started = backend.start_run(request)
+    status = backend.get_run(started["run_id"])
+    replay = backend.observe_run(started["run_id"], cursor="0")
+    cancel = backend.cancel_run(started["run_id"])
+    second_status = backend.get_run(started["run_id"])
+
+    assert started["session_id"] == "session-1"
+    assert started["stream_id"] == started["run_id"]
+    assert started["active_controls"] == ["cancel"]
+    assert status["status"] == "running"
+    assert [event["type"] for event in replay["events"]] == ["run.started"]
+    assert cancel["status"] == "cancelled"
+    assert second_status["terminal_state"] == "cancelled"
+
+
+def test_runner_backend_http_handler_matches_runner_client_endpoints():
+    runner_backend = importlib.import_module("api.runner_backend")
+    runner_client = importlib.import_module("api.runner_client")
+    runtime = importlib.import_module("api.runtime_adapter")
+
+    server = runner_backend.make_runner_server()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{server.server_port}"
+    try:
+        client = runner_client.HttpRunnerClient(base_url=base_url, timeout=2)
+        started = client.start_run(runtime.StartRunRequest(session_id="session-1", message="hello"))
+        status = client.get_run(started["run_id"])
+        latest = client.latest_run_for_session("session-1")
+        replay = client.observe_run(started["run_id"], cursor="0")
+        cancel = client.cancel_run(started["run_id"])
+        second_replay = client.observe_run(started["run_id"], cursor="1")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert started["run_id"].startswith("runner-local-")
+    assert status["status"] == "running"
+    assert latest["run_id"] == started["run_id"]
+    assert [event["type"] for event in replay["events"]] == ["run.started"]
+    assert cancel["status"] == "cancelled"
+    assert [event["type"] for event in second_replay["events"]] == ["cancelled"]


### PR DESCRIPTION
## Thinking Path

The runner-local adapter already had a safe route-selection seam, but the selected runner path still stopped at a bounded not-configured response. The next safe slice is to add an explicit HTTP client boundary and a tiny runner-side skeleton without making runner-local default, removing legacy execution, or moving runner-owned state into the main WebUI process.

## What Changed

- Adds `api/runner_client.py`, a stdlib HTTP/JSON client behind `HERMES_WEBUI_RUNNER_BASE_URL`.
- Wires `_runtime_runner_client_factory()` to return that client only when the URL is configured; otherwise the existing bounded `501` behavior remains.
- Adds `api/runner_backend.py`, a minimal in-memory runner backend plus embeddable HTTP handler matching the client endpoints for contract tests and future supervised backend work.
- Documents the optional runner-local client in the README, updates the Slice 4f RFC status note, and adds a changelog entry.
- Adds regression coverage for default-off selection, HTTP endpoint shape, explicit payload forwarding, route factory behavior, and bounded unsupported controls.

## Why It Matters

This replaces the previous runner-local dead-end with a concrete but still default-off boundary. WebUI can now be pointed at a supervised runner backend for Slice 4f testing without silently falling back to legacy execution and without adding new main-process stream/cancel/approval registries.

## Verification

- `python3.11 -m pytest tests/test_runner_client.py tests/test_runtime_adapter_seam.py -q`
- `python3.11 -m py_compile api/runner_client.py api/runner_backend.py api/routes.py api/runtime_adapter.py`
- `git diff --cached --check`

## Risks / Follow-ups

- The in-memory backend is only a skeleton/contract fixture; durable runner-owned storage and real agent execution remain follow-up work.
- `runner-local` is still experimental and default-off.
- Successful browser chat-start responses keep the legacy-compatible field whitelist; exposing runner-internal fields would need a separate contract update.

## Contract Routing

Task type: runtime adapter / runner-local backend slice.

Touched areas:
- Runner client boundary
- Runner backend skeleton
- `/api/chat/start` runner-local factory
- Runtime adapter RFC docs

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/hermes-run-adapter-contract.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`

Scope boundaries:
- No default-on runner mode.
- No removal of legacy-direct or legacy-journal paths.
- No new main-process runner-owned active-run maps or callback queues.
- No public `/api/chat/start` response-shape expansion.

Evidence needed before claiming done:
- Focused runner client/backend tests pass.
- Existing runtime-adapter seam tests pass.
- Python syntax checks pass.
