### PR TITLE
fix(sessions): full transcript load on INFLIGHT restore

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -11,6 +11,7 @@
 async function cancelStream(){
   const streamId = S.activeStreamId;
   if(!streamId) return;
+  const sid = S.session ? S.session.session_id : null;
   try{
     await fetch(new URL(`api/chat/cancel?stream_id=${encodeURIComponent(streamId)}`,document.baseURI||location.href).href,{credentials:'include'});
   }catch(e){/* cancel request failed - cleanup below still runs */}
@@ -19,6 +20,12 @@ async function cancelStream(){
   // closed it won't arrive — so we handle cleanup here as the guaranteed path.
   S.activeStreamId=null;
   setBusy(false);
+  // Clear INFLIGHT so stale live messages don't get merged on next session load
+  // (prevents message splicing errors after stop — #3043).
+  if(sid && typeof INFLIGHT!=='undefined' && INFLIGHT[sid]){
+    delete INFLIGHT[sid];
+    if(typeof clearInflightState==='function') clearInflightState(sid);
+  }
   if(typeof setComposerStatus==='function') setComposerStatus('');
   else setStatus('');
 }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -699,7 +699,7 @@ async function loadSession(sid){
     S.messages=[];
     S.toolCalls=[];
     try {
-      await _ensureMessagesLoaded(sid);
+      await _ensureMessagesLoaded(sid, {fullTranscript: true});
     } catch(e) {
       S.messages=inflightMessages;
     }
@@ -1292,13 +1292,17 @@ let _messagesTruncated = false;
 // Older messages are loaded on-demand via _loadOlderMessages().
 const _INITIAL_MSG_LIMIT = 30;
 
-async function _ensureMessagesLoaded(sid) {
+async function _ensureMessagesLoaded(sid, opts) {
   // Already have messages? (e.g. from INFLIGHT restore path, already set)
   if (S.messages && S.messages.length > 0 && S.messages[0] && S.messages[0].role) {
     return;
   }
   // Fetch session messages with a tail window for fast initial load.
-  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${_INITIAL_MSG_LIMIT}`);
+  // When fullTranscript is requested (INFLIGHT merge path), skip msg_limit
+  // so the server returns the complete message array — this eliminates
+  // truncation ambiguity that causes message splicing errors (#3043).
+  const limit = (opts && opts.fullTranscript) ? '' : `&msg_limit=${_INITIAL_MSG_LIMIT}`;
+  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0${limit}`);
   // Guard: api() may have redirected (401) and returned undefined.
   if (!data || !data.session) return;
   _messagesTruncated = !!data.session._messages_truncated;
@@ -1359,12 +1363,36 @@ function _mergeInflightTailMessages(baseMessages, inflightMessages){
     if(inflight[i]&&inflight[i]._live){liveIdx=i;break;}
   }
   if(liveIdx<0) return base;
+  // If the base already has more messages than the inflight snapshot AND the
+  // session is no longer actively streaming, the server transcript is
+  // authoritative and the inflight tail is stale (#3043). Only skip merge when
+  // we are confident the stream has settled — during active streaming the
+  // server's msg_limit truncation can make base.length == inflight.length even
+  // though the live tail is still valid.
+  if(base.length>0 && inflight.length>0 && base.length>=inflight.length && !S.activeStreamId) return base;
   let start=liveIdx;
   if(liveIdx>0&&inflight[liveIdx-1]&&inflight[liveIdx-1].role==='user') start=liveIdx-1;
   const tail=inflight.slice(start).filter(m=>m&&m.role);
   const merged=[...base];
   for(const msg of tail){
-    const duplicate=merged.slice(-Math.max(5,tail.length+2)).some(existing=>_sameTranscriptMessage(existing,msg));
+    // Widen the dedup window to cover the entire tail + a generous margin.
+    // Also treat partial-content matches as duplicates: a streaming _live
+    // message may have less text than the settled server version.
+    const window=Math.max(10,tail.length+5);
+    const candidates=merged.slice(-window);
+    const msgText=_messageComparableText(msg);
+    const duplicate=candidates.some(existing=>{
+      if(_sameTranscriptMessage(existing,msg)) return true;
+      // Partial match: if the existing message starts with or contains the
+      // inflight text (or vice versa), treat as duplicate. Only apply to
+      // messages longer than 30 chars to avoid false positives on short
+      // responses like "Yes", "OK", "Done" (#3043).
+      if(msg.role==='assistant'&&existing.role==='assistant'&&msgText&&msgText.length>30){
+        const existingText=_messageComparableText(existing);
+        if(existingText&&existingText.length>30&&(existingText.startsWith(msgText)||msgText.startsWith(existingText))) return true;
+      }
+      return false;
+    });
     if(!duplicate) merged.push(msg);
   }
   return merged;

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -311,12 +311,18 @@ async function loadDir(path){
       }
       if(expanded.size>0)renderFileTree();
     }
-    if(typeof clearPreview==='function'){
+    // Only clear preview when switching to a different session's workspace.
+    // Same-session refreshes (e.g. background resume, external update poll)
+    // should preserve the user's open file preview and unsaved edits (#3042).
+    if(typeof clearPreview==='function' && sessionId!==_lastPreviewSessionId){
       if(typeof _previewDirty!=='undefined'&&_previewDirty){
-        showConfirmDialog({title:t('unsaved_confirm'),message:'',confirmLabel:'Discard',danger:true,focusCancel:true}).then(ok=>{if(ok)clearPreview({keepPanelOpen:true});});
+        showConfirmDialog({title:t('unsaved_confirm'),message:'',confirmLabel:'Discard',danger:true,focusCancel:true}).then(ok=>{if(ok){clearPreview({keepPanelOpen:true});_lastPreviewSessionId=sessionId;}});
       }else{
         clearPreview({keepPanelOpen:true});
+        _lastPreviewSessionId=sessionId;
       }
+    }else if(!_lastPreviewSessionId){
+      _lastPreviewSessionId=sessionId;
     }
     // Fetch git info for workspace root (non-blocking)
     if(!path||path==='.') _refreshGitBadge();
@@ -404,6 +410,7 @@ function largeMarkdownPlainTextStatus(content){
 let _previewCurrentPath = '';  // relative path of currently previewed file
 let _previewCurrentMode = '';  // 'code' | 'md' | 'image' | 'html' | 'pdf' | 'audio' | 'video'
 let _previewDirty = false;     // true when edits are unsaved
+let _lastPreviewSessionId = '';  // tracks which session owns the current preview
 
 function showPreview(mode){
   // mode: 'code' | 'image' | 'md' | 'html' | 'pdf' | 'audio' | 'video'

--- a/tests/test_issue3042_3043_fixes.py
+++ b/tests/test_issue3042_3043_fixes.py
@@ -1,0 +1,240 @@
+"""
+Unit tests for #3042 (Discard popup on background resume) and #3043 (message splicing).
+
+These tests re-implement the patched JavaScript logic in Python to verify
+correctness without needing a JS runtime. The logic is simple enough that
+a faithful Python port is unambiguous.
+"""
+import pytest
+
+
+# ─── Python port of _mergeInflightTailMessages (patched version) ───
+
+def _message_comparable_text(m):
+    if not m:
+        return ''
+    return str(m.get('content') or '').strip()
+
+
+def _same_transcript_message(a, b):
+    if not (a and b):
+        return False
+    if str(a.get('role', '')) != str(b.get('role', '')):
+        return False
+    a_text = _message_comparable_text(a)
+    b_text = _message_comparable_text(b)
+    return a_text == b_text
+
+
+def merge_inflight_tail_messages(base_messages, inflight_messages, active_stream_id=None):
+    """Python port of the patched _mergeInflightTailMessages."""
+    base = base_messages if isinstance(base_messages, list) else []
+    inflight = inflight_messages if isinstance(inflight_messages, list) else []
+
+    live_idx = -1
+    for i in range(len(inflight) - 1, -1, -1):
+        if inflight[i] and inflight[i].get('_live'):
+            live_idx = i
+            break
+
+    if live_idx < 0:
+        return base
+
+    # Staleness guard: only skip when NOT streaming
+    if (len(base) > 0 and len(inflight) > 0
+            and len(base) >= len(inflight) and not active_stream_id):
+        return base
+
+    start = live_idx
+    if live_idx > 0 and inflight[live_idx - 1] and inflight[live_idx - 1].get('role') == 'user':
+        start = live_idx - 1
+
+    tail = [m for m in inflight[start:] if m and m.get('role')]
+    merged = list(base)
+
+    for msg in tail:
+        window_size = max(10, len(tail) + 5)
+        candidates = merged[-window_size:]
+        msg_text = _message_comparable_text(msg)
+        duplicate = False
+
+        for existing in candidates:
+            if _same_transcript_message(existing, msg):
+                duplicate = True
+                break
+            # Partial prefix match — only for long assistant messages
+            if (msg.get('role') == 'assistant' and existing.get('role') == 'assistant'
+                    and msg_text and len(msg_text) > 30):
+                existing_text = _message_comparable_text(existing)
+                if (existing_text and len(existing_text) > 30
+                        and (existing_text.startswith(msg_text) or msg_text.startswith(existing_text))):
+                    duplicate = True
+                    break
+
+        if not duplicate:
+            merged.append(msg)
+
+    return merged
+
+
+# ─── Tests for #3043: merge logic ───
+
+class TestMergeInflightStaleDetection:
+    """Verify stale inflight is discarded when session is idle."""
+
+    def test_stale_inflight_discarded_when_not_streaming(self):
+        base = [{'role': 'user', 'content': f'msg{i}'} for i in range(10)]
+        inflight = [{'role': 'user', 'content': f'msg{i}'} for i in range(8)]
+        inflight.append({'role': 'user', 'content': 'question'})
+        inflight.append({'role': 'assistant', 'content': 'partial', '_live': True})
+        # base=10, inflight=10, not streaming → stale, return base
+        result = merge_inflight_tail_messages(base, inflight, active_stream_id=None)
+        assert len(result) == 10
+        assert not any(m.get('content') == 'partial' for m in result)
+
+    def test_valid_merge_when_streaming(self):
+        base = [{'role': 'user', 'content': f'msg{i}'} for i in range(10)]
+        inflight = [{'role': 'user', 'content': f'msg{i}'} for i in range(8)]
+        inflight.append({'role': 'user', 'content': 'new question'})
+        inflight.append({'role': 'assistant', 'content': 'streaming...', '_live': True})
+        # base=10, inflight=10, but streaming → merge proceeds
+        result = merge_inflight_tail_messages(base, inflight, active_stream_id='stream-123')
+        assert any(m.get('content') == 'streaming...' for m in result)
+
+    def test_no_live_message_returns_base(self):
+        base = [{'role': 'user', 'content': 'hi'}, {'role': 'assistant', 'content': 'hello'}]
+        inflight = [{'role': 'user', 'content': 'hi'}, {'role': 'assistant', 'content': 'hello'}]
+        result = merge_inflight_tail_messages(base, inflight)
+        assert result == base
+
+
+class TestMergeInflightDedup:
+    """Verify dedup catches exact and partial duplicates."""
+
+    def test_exact_duplicate_not_appended(self):
+        base = [
+            {'role': 'user', 'content': 'hello'},
+            {'role': 'assistant', 'content': 'world'},
+        ]
+        inflight = [
+            {'role': 'user', 'content': 'hello'},
+            {'role': 'assistant', 'content': 'world', '_live': True},
+        ]
+        result = merge_inflight_tail_messages(base, inflight, active_stream_id='x')
+        assert len(result) == 2
+
+    def test_partial_prefix_long_message_deduped(self):
+        long_text = "This is a very long response that keeps going and going with lots of detail about the topic"
+        partial = long_text[:50]  # > 30 chars
+        base = [
+            {'role': 'user', 'content': 'question'},
+            {'role': 'assistant', 'content': long_text},
+        ]
+        inflight = [
+            {'role': 'user', 'content': 'question'},
+            {'role': 'assistant', 'content': partial, '_live': True},
+        ]
+        result = merge_inflight_tail_messages(base, inflight, active_stream_id='x')
+        # partial is prefix of long_text → duplicate
+        assert len(result) == 2
+        assert result[1]['content'] == long_text
+
+    def test_short_message_not_false_positive(self):
+        """Short messages must NOT be caught by prefix matching."""
+        base = [
+            {'role': 'user', 'content': 'agree?'},
+            {'role': 'assistant', 'content': 'Yes, but actually I think we should reconsider'},
+        ]
+        inflight = [
+            {'role': 'user', 'content': 'agree?'},
+            {'role': 'assistant', 'content': 'Yes', '_live': True},
+        ]
+        result = merge_inflight_tail_messages(base, inflight, active_stream_id='x')
+        # "Yes" is < 30 chars → prefix match skipped → treated as new message
+        assert len(result) == 3
+        assert result[2]['content'] == 'Yes'
+
+    def test_new_message_appended(self):
+        """Genuinely new messages should be appended."""
+        base = [
+            {'role': 'user', 'content': 'first question'},
+            {'role': 'assistant', 'content': 'first answer'},
+        ]
+        inflight = [
+            {'role': 'user', 'content': 'first question'},
+            {'role': 'assistant', 'content': 'first answer'},
+            {'role': 'user', 'content': 'second question'},
+            {'role': 'assistant', 'content': 'second answer in progress', '_live': True},
+        ]
+        result = merge_inflight_tail_messages(base, inflight, active_stream_id='x')
+        assert len(result) == 4
+        assert result[2]['content'] == 'second question'
+        assert result[3]['content'] == 'second answer in progress'
+
+
+# ─── Tests for #3042: workspace preview session tracking ───
+
+class TestWorkspacePreviewSessionTracking:
+    """Verify _lastPreviewSessionId logic."""
+
+    def test_same_session_skips_clear(self):
+        """Same session ID → condition is False → no clear, no popup."""
+        session_id = "session-abc-123"
+        last_preview_session_id = "session-abc-123"
+        should_clear = (session_id != last_preview_session_id)
+        assert should_clear is False
+
+    def test_different_session_triggers_clear(self):
+        """Different session ID → condition is True → clear preview."""
+        session_id = "session-def-456"
+        last_preview_session_id = "session-abc-123"
+        should_clear = (session_id != last_preview_session_id)
+        assert should_clear is True
+
+    def test_first_load_with_empty_tracker(self):
+        """First call: _lastPreviewSessionId is '' → different from any real session ID."""
+        session_id = "session-abc-123"
+        last_preview_session_id = ""
+        should_clear = (session_id != last_preview_session_id)
+        # True, but that's fine — first load has nothing to clear
+        assert should_clear is True
+
+
+# ─── Tests for #3043: cancelStream INFLIGHT cleanup ───
+
+class TestCancelStreamInflightCleanup:
+    """Verify cancelStream logic clears INFLIGHT."""
+
+    def test_cancel_clears_inflight(self):
+        """Simulating cancelStream: INFLIGHT[sid] should be deleted."""
+        INFLIGHT = {'sess-1': {'messages': [{'role': 'user', 'content': 'hi'}]}}
+        sid = 'sess-1'
+        active_stream_id = 'stream-1'
+
+        # Simulate cancelStream logic
+        if active_stream_id:
+            if sid and sid in INFLIGHT:
+                del INFLIGHT[sid]
+
+        assert 'sess-1' not in INFLIGHT
+        assert INFLIGHT == {}
+
+    def test_cancel_noop_when_no_inflight(self):
+        """If INFLIGHT doesn't have the session, no error."""
+        INFLIGHT = {}
+        sid = 'sess-1'
+        if sid and sid in INFLIGHT:
+            del INFLIGHT[sid]
+        assert INFLIGHT == {}
+
+    def test_cancel_preserves_other_sessions(self):
+        """Cancelling one session should not affect others."""
+        INFLIGHT = {
+            'sess-1': {'messages': [{'role': 'user', 'content': 'hi'}]},
+            'sess-2': {'messages': [{'role': 'user', 'content': 'other'}]},
+        }
+        sid = 'sess-1'
+        if sid and sid in INFLIGHT:
+            del INFLIGHT[sid]
+        assert 'sess-1' not in INFLIGHT
+        assert 'sess-2' in INFLIGHT

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -633,7 +633,7 @@ def test_loadSession_inflight_merges_tail_with_persisted_transcript(cleanup_test
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
     inflight_block = src[inflight_idx:inflight_idx+1200]
 
-    assert "await _ensureMessagesLoaded(sid);" in inflight_block, (
+    assert "await _ensureMessagesLoaded(sid" in inflight_block, (
         "returning to an active stream should load the persisted transcript before adding the live tail"
     )
     assert "_mergeInflightTailMessages(S.messages,inflightMessages)" in inflight_block, (


### PR DESCRIPTION
## Summary

Fixes message splicing errors after stop/refresh/background-resume (#3043) and false discard popups on background resume (#3042).

## Changes

- `_ensureMessagesLoaded(sid, opts)`: new `fullTranscript` option skips `msg_limit=30` truncation
- INFLIGHT restore path passes `{fullTranscript: true}` so the server returns the complete message array — merge logic degrades to "append live message only"
- `cancelStream()` clears `INFLIGHT[sid]` to prevent stale cache from being merged on next load
- `loadDir()` tracks `_lastPreviewSessionId` to avoid clearing preview on same-session refresh
- Hardened `_mergeInflightTailMessages`: base>=inflight guard with activeStreamId check, wider dedup window, 30-char prefix matching threshold

## Testing

- 13 new targeted unit tests (all pass)
- Full test suite: 1778 passed, 1 skipped, 1 unrelated DNS failure
- Syntax validation: all modified files pass `node -c`