### PR TITLE
stage-batch39: v0.51.157 / Release EC — 5-PR mixed-risk cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Gateway-backed WebUI chat now forwards configured prefill/session-recall context and a compact WebUI session-context block into delegated Gateway turns, so browser sessions retain note recall, connected-platform awareness, and delivery hints instead of sending only the latest user message. If the dynamic prefill script fails, WebUI falls back to the configured static router prefill when available.
+
 ## [v0.51.154] — 2026-05-28 — Release DZ (stage-batch36 — 9-PR medium-risk cleanup: cron project chip + KaTeX streaming + recovery + .env keys + discoverability repair + media MEDIA tokens + gateway 401 + notes prefill + cron filter)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- The reasoning-effort selector now offers a `max` level, matching the agent's `hermes_constants.VALID_REASONING_EFFORTS`. This restores parity with the underlying set (the WebUI mirror previously stopped at `xhigh`) so providers such as Anthropic that support the `max` thinking level are selectable from the composer dropdown and the `/reasoning` command.
+
 ## [v0.51.155] — 2026-05-28 — Release EA (stage-batch37 — 3-PR very low-risk cleanup: passive timeout toasts + sidecar order + subsecond timestamps)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+## [v0.51.157] — 2026-05-28 — Release EC (stage-batch39 — 5-PR mixed-risk cleanup: gateway prefill forward + prefill budget + compressed-continuation sidebar + browser-transcript memory guidance + reasoning max parity)
+
 ### Added
 
 - The reasoning-effort selector now offers a `max` level, matching the agent's `hermes_constants.VALID_REASONING_EFFORTS`. This restores parity with the underlying set (the WebUI mirror previously stopped at `xhigh`) so providers such as Anthropic that support the `max` thinking level are selectable from the composer dropdown and the `/reasoning` command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Gateway-backed WebUI chat now forwards configured prefill/session-recall context and a compact WebUI session-context block into delegated Gateway turns, so browser sessions retain note recall, connected-platform awareness, and delivery hints instead of sending only the latest user message. If the dynamic prefill script fails, WebUI falls back to the configured static router prefill when available.
 - Oversized WebUI startup prefill payloads now respect a configurable context budget (`webui_prefill_context_max_chars` / `HERMES_WEBUI_PREFILL_CONTEXT_MAX_CHARS`, default 12,000 chars). When a dynamic prefill script exceeds the budget and a compact static prefill file is configured, WebUI falls back to the compact file; otherwise it injects a small retrieval instruction instead of dumping the full note/body payload into every new chat.
+- Sidebar now keeps the newest active continuation visible when it has more recent activity than an older fuller pre-compression snapshot in the same lineage. Adds lineage-aware dedupe for WebUI-origin state-db projections, restores normal context-only turns into the visible transcript after compression while preserving order, and recognizes `[Session Arc Summary]` as a compression marker so it isn't backfilled into the chat transcript.
 
 ## [v0.51.156] — 2026-05-28 — Release EB (stage-batch38 — 2-PR Tier B cleanup: WebUI request/runtime hardening + chat-start provider fallback)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Oversized WebUI startup prefill payloads now respect a configurable context budget (`webui_prefill_context_max_chars` / `HERMES_WEBUI_PREFILL_CONTEXT_MAX_CHARS`, default 12,000 chars). When a dynamic prefill script exceeds the budget and a compact static prefill file is configured, WebUI falls back to the compact file; otherwise it injects a small retrieval instruction instead of dumping the full note/body payload into every new chat.
+
 ## [v0.51.155] — 2026-05-28 — Release EA (stage-batch37 — 3-PR very low-risk cleanup: passive timeout toasts + sidecar order + subsecond timestamps)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- WebUI's browser-session surface prompt now explicitly tells agents not to dump browser transcripts into external notes or durable memory by default; it limits saving to explicit captures and clearly reusable durable signals such as preferences, decisions, blockers, and runbook-worthy workflows.
+
 ## [v0.51.154] — 2026-05-28 — Release DZ (stage-batch36 — 9-PR medium-risk cleanup: cron project chip + KaTeX streaming + recovery + .env keys + discoverability repair + media MEDIA tokens + gateway 401 + notes prefill + cron filter)
 
 ### Added

--- a/api/compression_anchor.py
+++ b/api/compression_anchor.py
@@ -68,6 +68,7 @@ def is_context_compression_marker(message):
         text.startswith("[context compaction")
         or text.startswith("context compaction")
         or text.startswith("[your active task list was preserved across context compression]")
+        or text.startswith("[session arc summary")
     )
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -2073,7 +2073,7 @@ def get_effective_default_model(config_data: dict | None = None) -> str:
 # Mirrors hermes_constants.parse_reasoning_effort so WebUI can validate without
 # importing from the agent tree (which may not be installed).  Any drift here
 # will show up in the shared test suite since both sides accept the same set.
-VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
 
 def parse_reasoning_effort(effort):

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -223,6 +223,22 @@ def _run_gateway_chat_streaming(
         from api.config import get_config  # imported lazily to avoid config-cycle churn
 
         cfg = get_config()
+        try:
+            from api.streaming import (
+                _load_webui_prefill_context,
+                _prefill_messages_with_webui_context,
+                _public_prefill_context_status,
+            )
+
+            prefill_context = _load_webui_prefill_context(cfg)
+            prefill_messages = _prefill_messages_with_webui_context(prefill_context, cfg)
+            put_gateway_event("context_status", {
+                "session_id": session_id,
+                "prefill": _public_prefill_context_status(prefill_context),
+            })
+        except Exception:
+            logger.debug("Failed to load WebUI gateway prefill context", exc_info=True)
+            prefill_messages = []
         base_url = _gateway_base_url(cfg)
         api_key = _gateway_api_key()
         url = f"{base_url}/v1/chat/completions"
@@ -248,7 +264,7 @@ def _run_gateway_chat_streaming(
         body = {
             "model": model or "default",
             "stream": True,
-            "messages": [{"role": "user", "content": message_content}],
+            "messages": [*prefill_messages, {"role": "user", "content": message_content}],
         }
         if model_provider:
             body["provider"] = model_provider

--- a/api/models.py
+++ b/api/models.py
@@ -2493,6 +2493,14 @@ def _prefer_fuller_snapshots_for_sidebar(sessions: list[dict]) -> list[dict]:
         if _sidebar_message_count(best_snapshot) <= best_visible_count:
             continue
 
+        newest_visible_ts = max(_session_sort_timestamp(session) for session in visible)
+        snapshot_ts = _session_sort_timestamp(best_snapshot)
+        # Keep the active continuation visible when it has newer activity than
+        # the archived snapshot. A fuller snapshot can still be older than a
+        # continuation that contains the latest turns after compression.
+        if newest_visible_ts > snapshot_ts:
+            continue
+
         snapshot_ids_to_show.add(str(best_snapshot.get('session_id')))
         continuation_ids_to_hide.update(
             str(session.get('session_id'))

--- a/api/routes.py
+++ b/api/routes.py
@@ -2434,6 +2434,43 @@ def _normalize_sidebar_source_flags(session: dict) -> dict:
     return normalized
 
 
+def _session_source_is_webui(session: dict) -> bool:
+    """Return True for state.db/sidebar rows that describe WebUI-origin sessions."""
+    if not isinstance(session, dict):
+        return False
+    for key in ("source_tag", "raw_source", "session_source", "source"):
+        if str(session.get(key) or "").strip().lower() == "webui":
+            return True
+    return False
+
+
+def _session_lineage_ids(session: dict) -> set[str]:
+    """Return known ids that identify one logical sidebar lineage."""
+    if not isinstance(session, dict):
+        return set()
+    ids: set[str] = set()
+    for key in ("session_id", "_lineage_root_id", "_lineage_tip_id"):
+        value = session.get(key)
+        if value:
+            ids.add(str(value))
+    return ids
+
+
+def _is_duplicate_webui_state_projection(session: dict, represented_webui_ids: set[str]) -> bool:
+    """Return True when a state.db row is only a duplicate WebUI-origin projection.
+
+    The "Show non-WebUI sessions" toggle should add external/agent-owned
+    conversations, not make WebUI compression continuations appear only when the
+    external-session bridge is enabled. WebUI-origin state.db rows are still
+    useful metadata sidecars, but if any id in their compression lineage is
+    already represented by WebUI session JSON, they should not be injected as an
+    additive external row.
+    """
+    if not _session_source_is_webui(session):
+        return False
+    return bool(_session_lineage_ids(session) & represented_webui_ids)
+
+
 CLI_VISIBLE_SESSION_CAP = 20
 
 
@@ -4495,9 +4532,17 @@ def handle_get(handler, parsed) -> bool:
                 # Apply the same CLI visibility semantics to imported local copies so
                 # low-value imported artifacts do not leak into the sidebar.
                 webui_sessions = [s for s in webui_sessions if is_cli_session_row_visible(s)]
-                webui_ids = {s["session_id"] for s in webui_sessions}
+                represented_webui_ids = set()
+                for s in webui_sessions:
+                    represented_webui_ids.update(_session_lineage_ids(s))
                 from api.models import _hide_from_default_sidebar as _cron_hide
-                deduped_cli = [s for s in cli if s["session_id"] not in webui_ids and is_cli_session_row_visible(s) and not _cron_hide(s)]
+                deduped_cli = [
+                    s for s in cli
+                    if s["session_id"] not in represented_webui_ids
+                    and not _is_duplicate_webui_state_projection(s, represented_webui_ids)
+                    and is_cli_session_row_visible(s)
+                    and not _cron_hide(s)
+                ]
             else:
                 diag.stage("filter_webui_sessions")
                 webui_sessions = [s for s in webui_sessions if not _is_cli_session_for_settings(s)]

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -292,6 +292,74 @@ def _resolve_prefill_path(raw: str) -> Path:
 
 
 _PREFILL_SCRIPT_OUTPUT_LIMIT = 262_144
+_PREFILL_CONTEXT_DEFAULT_MAX_CHARS = 12_000
+
+
+def _prefill_context_max_chars(config_data: dict) -> int:
+    raw = os.getenv("HERMES_WEBUI_PREFILL_CONTEXT_MAX_CHARS", "") or str(
+        config_data.get("webui_prefill_context_max_chars") or ""
+    )
+    try:
+        value = int(raw or _PREFILL_CONTEXT_DEFAULT_MAX_CHARS)
+    except Exception:
+        value = _PREFILL_CONTEXT_DEFAULT_MAX_CHARS
+    return max(0, min(value, _PREFILL_SCRIPT_OUTPUT_LIMIT))
+
+
+def _prefill_context_char_count(messages: list[dict]) -> int:
+    return sum(len(str(message.get("content") or "")) for message in messages if isinstance(message, dict))
+
+
+def _budget_compacted_prefill_context(context: dict, *, max_chars: int, char_count: int) -> dict:
+    label = str(context.get("label") or "prefill context")
+    message = (
+        "A configured WebUI startup prefill source was available, but it exceeded "
+        f"the WebUI prefill context budget ({char_count} chars > {max_chars} chars), "
+        "so the note/body payload was omitted from this new chat. If the user's "
+        "request depends on prior decisions, durable notes, runbooks, current "
+        "context, or open issues, use the available retrieval/search/note tools "
+        "to fetch only the relevant details before answering."
+    )
+    return {
+        "status": "loaded",
+        "source": "budget_compacted",
+        "label": label,
+        "messages": [{"role": "user", "content": message}],
+        "message_count": 1,
+        "compacted": True,
+        "original_source": context.get("source", ""),
+        "original_message_count": int(context.get("message_count") or 0),
+        "original_char_count": char_count,
+        "max_chars": max_chars,
+    }
+
+
+def _apply_prefill_context_budget(context: dict, config_data: dict) -> dict:
+    if context.get("status") != "loaded":
+        return context
+    max_chars = _prefill_context_max_chars(config_data)
+    if max_chars <= 0:
+        return context
+    messages = context.get("messages") or []
+    char_count = _prefill_context_char_count(messages if isinstance(messages, list) else [])
+    if char_count <= max_chars:
+        return context
+
+    file_raw = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "") or str(config_data.get("prefill_messages_file") or "")
+    if context.get("source") == "script" and file_raw:
+        fallback = _load_prefill_messages_file(file_raw, source="file_budget_fallback")
+        fallback_messages = fallback.get("messages") if isinstance(fallback, dict) else []
+        fallback_chars = _prefill_context_char_count(fallback_messages if isinstance(fallback_messages, list) else [])
+        if fallback.get("status") == "loaded" and fallback_chars <= max_chars:
+            fallback["compacted"] = True
+            fallback["original_source"] = context.get("source", "")
+            fallback["original_label"] = context.get("label", "")
+            fallback["original_message_count"] = int(context.get("message_count") or 0)
+            fallback["original_char_count"] = char_count
+            fallback["max_chars"] = max_chars
+            return fallback
+
+    return _budget_compacted_prefill_context(context, max_chars=max_chars, char_count=char_count)
 
 
 def _prefill_not_configured() -> dict:
@@ -397,10 +465,10 @@ def _load_webui_prefill_context(
     cfg = config_data if isinstance(config_data, dict) else get_config()
     script_context = _load_prefill_messages_script(cfg)
     if script_context.get("status") != "not_configured":
-        return script_context
+        return _apply_prefill_context_budget(script_context, cfg)
     file_raw = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "") or str(cfg.get("prefill_messages_file") or "")
     if file_raw:
-        return _load_prefill_messages_file(file_raw)
+        return _apply_prefill_context_budget(_load_prefill_messages_file(file_raw), cfg)
     return _prefill_not_configured()
 
 
@@ -412,6 +480,11 @@ def _public_prefill_context_status(prefill_context: dict) -> dict:
         "label": prefill_context.get("label", ""),
         "message_count": int(prefill_context.get("message_count") or 0),
         **({"error": prefill_context.get("error", "")} if prefill_context.get("error") else {}),
+        **({"compacted": True} if prefill_context.get("compacted") else {}),
+        **({"original_source": prefill_context.get("original_source", "")} if prefill_context.get("original_source") else {}),
+        **({"original_message_count": int(prefill_context.get("original_message_count") or 0)} if prefill_context.get("original_message_count") else {}),
+        **({"original_char_count": int(prefill_context.get("original_char_count") or 0)} if prefill_context.get("original_char_count") else {}),
+        **({"max_chars": int(prefill_context.get("max_chars") or 0)} if prefill_context.get("max_chars") else {}),
     }
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -396,12 +396,17 @@ def _load_webui_prefill_context(
     """
     cfg = config_data if isinstance(config_data, dict) else get_config()
     script_context = _load_prefill_messages_script(cfg)
-    if script_context.get("status") != "not_configured":
-        return script_context
     file_raw = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "") or str(cfg.get("prefill_messages_file") or "")
-    if file_raw:
-        return _load_prefill_messages_file(file_raw)
-    return _prefill_not_configured()
+    if script_context.get("status") == "not_configured":
+        if file_raw:
+            return _load_prefill_messages_file(file_raw)
+        return _prefill_not_configured()
+    if script_context.get("status") == "error" and file_raw:
+        file_context = _load_prefill_messages_file(file_raw, source="file_fallback")
+        if file_context.get("status") == "loaded":
+            file_context["script_error"] = script_context.get("error", "")
+            return file_context
+    return script_context
 
 
 def _public_prefill_context_status(prefill_context: dict) -> dict:
@@ -413,6 +418,94 @@ def _public_prefill_context_status(prefill_context: dict) -> dict:
         "message_count": int(prefill_context.get("message_count") or 0),
         **({"error": prefill_context.get("error", "")} if prefill_context.get("error") else {}),
     }
+
+
+def _webui_session_context_message(config_data: Optional[dict] = None) -> dict:
+    """Return a compact browser-session context message for WebUI agents.
+
+    Messaging gateway sessions get a small "Current Session Context" block that
+    tells the agent where the turn came from, which platforms are connected, and
+    how scheduled-task delivery should be interpreted. Browser-originated WebUI
+    turns do not have a Gateway ``SessionSource``, but they still benefit from a
+    safe equivalent so the model understands that this is a WebUI session, not a
+    literal Telegram thread, while retaining access to configured messaging
+    delivery targets.
+    """
+    cfg = config_data if isinstance(config_data, dict) else get_config()
+    lines = [
+        "## Current Session Context",
+        "",
+        "**Source:** WebUI (browser session)",
+        "**Session type:** Browser-originated Hermes WebUI chat. This is a separate WebUI transcript, not the same live Telegram/Discord/other messaging thread.",
+    ]
+
+    try:
+        from api.profiles import get_active_profile_name
+
+        profile_name = get_active_profile_name() or "default"
+    except Exception:
+        profile_name = "default"
+    lines.append(f"**Active Hermes profile:** {profile_name}")
+
+    connected = ["local (files on this machine)"]
+    try:
+        from hermes_constants import get_hermes_home, display_hermes_home
+
+        state_path = get_hermes_home() / "gateway_state.json"
+        if state_path.exists():
+            raw_state = json.loads(state_path.read_text(encoding="utf-8"))
+            platforms = raw_state.get("platforms") if isinstance(raw_state, dict) else {}
+            if isinstance(platforms, dict):
+                for name in sorted(platforms):
+                    pdata = platforms.get(name) or {}
+                    if isinstance(pdata, dict) and pdata.get("state") == "connected" and name != "local":
+                        connected.append(f"{name}: Connected ✓")
+    except Exception:
+        display_hermes_home = None  # type: ignore[assignment]
+    lines.append(f"**Connected Platforms:** {', '.join(connected)}")
+
+    home_channels = {}
+    try:
+        platforms_cfg = cfg.get("platforms", {}) if isinstance(cfg, dict) else {}
+        if isinstance(platforms_cfg, dict):
+            for name, pdata in platforms_cfg.items():
+                if not isinstance(pdata, dict):
+                    continue
+                if pdata.get("enabled") is False:
+                    continue
+                home = pdata.get("home_channel")
+                if isinstance(home, dict):
+                    home_channels[str(name)] = str(home.get("name") or name)
+    except Exception:
+        home_channels = {}
+
+    if home_channels:
+        lines.append("")
+        lines.append("**Home Channels (default destinations):**")
+        for platform, label in sorted(home_channels.items()):
+            lines.append(f"  - {platform}: {label}")
+
+    lines.append("")
+    lines.append("**Delivery options for scheduled tasks:**")
+    lines.append("- `\"origin\"` → Back to this WebUI/browser session when the WebUI runtime supports origin delivery; otherwise prefer an explicit platform target.")
+    try:
+        home_display = display_hermes_home() if display_hermes_home else "~/.hermes"  # type: ignore[name-defined]
+    except Exception:
+        home_display = "~/.hermes"
+    lines.append(f"- `\"local\"` → Save to local files only ({home_display}/cron/output/)")
+    for platform, label in sorted(home_channels.items()):
+        lines.append(f"- `\"{platform}\"` → Home channel ({label})")
+    lines.append("")
+    lines.append("*For explicit targeting, use `\"platform:chat_id\"` format if the user provides a specific chat ID. Do not invent private IDs.*")
+
+    return {"role": "user", "content": "\n".join(lines)}
+
+
+def _prefill_messages_with_webui_context(prefill_context: dict, config_data: Optional[dict] = None) -> list[dict]:
+    """Combine recall prefill with WebUI's gateway-like session context."""
+    messages = list(prefill_context.get("messages") or [])
+    messages.append(_webui_session_context_message(config_data))
+    return messages
 
 
 def _has_new_assistant_reply(all_messages: list, prev_count: int) -> bool:
@@ -4319,7 +4412,7 @@ def _run_agent_streaming(
             from api.config import get_config as _get_config
             _cfg = _get_config()
             _prefill_context = _load_webui_prefill_context(_cfg)
-            _prefill_messages = _prefill_context.get('messages') or []
+            _prefill_messages = _prefill_messages_with_webui_context(_prefill_context, _cfg)
             put('context_status', {
                 'session_id': session_id,
                 'prefill': _public_prefill_context_status(_prefill_context),

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -222,6 +222,7 @@ def _webui_surface_context_prompt(surface_context: Optional[dict]) -> str:
         "WebUI session context:",
         "- This browser session is not the same live transcript as Telegram, Discord, Slack, or other messaging surfaces.",
         "- Use durable memory, saved sessions, and available tools for cross-surface recall instead of assuming those transcripts are in this browser chat.",
+        "- Do not copy or dump this browser transcript into external notes or durable memory by default. Save only explicit captures, durable user preferences, decisions, blockers, runbook-worthy workflows, or other clearly reusable signals.",
     ]
     fields = (
         ("source", "Source"),

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2890,6 +2890,60 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
     if not result_messages:
         return previous_display
 
+    # ── Backfill normal turns from previous_context that are missing from
+    # previous_display.  After context compression recovery, previous_context
+    # can contain user/assistant turns that were never rendered in the visible
+    # transcript (they were behind a compression marker). On the next
+    # append-only merge those turns sit inside the shared prefix and get
+    # stripped, leaving them permanently invisible.  Reinsert them now.
+    #
+    # Use display as the backbone to preserve visible order. Walk display in
+    # order and for each display message search for its identity in context
+    # at/after a cursor. Any context messages between the cursor and that
+    # match are context-only gaps that get spliced in before the display msg.
+    if previous_display and previous_context:
+        _display_id_set = {_message_identity(m) for m in previous_display}
+        _context_id_set = {_message_identity(m) for m in previous_context}
+        _has_context_only_turns = bool(_context_id_set - _display_id_set)
+        if _has_context_only_turns:
+            context_keys = [_message_identity(m) for m in previous_context]
+            _backfilled = []
+            _emitted = set()
+            _cursor = 0
+            for _dmsg in previous_display:
+                _dkey = _message_identity(_dmsg)
+                if _dkey is not None:
+                    _j = _cursor
+                    while _j < len(context_keys) and context_keys[_j] != _dkey:
+                        _j += 1
+                    if _j < len(context_keys):
+                        for _k in range(_cursor, _j):
+                            _ckey = context_keys[_k]
+                            _cmsg = previous_context[_k]
+                            if _ckey is not None and _ckey not in _emitted and not _is_context_compression_marker(_cmsg):
+                                _backfilled.append(copy.deepcopy(_cmsg))
+                                _emitted.add(_ckey)
+                        _cursor = _j + 1
+                if _dkey not in _emitted:
+                    _backfilled.append(_dmsg)
+                    if _dkey is not None:
+                        _emitted.add(_dkey)
+            while _cursor < len(context_keys):
+                _ckey = context_keys[_cursor]
+                _cmsg = previous_context[_cursor]
+                _cursor += 1
+                if _ckey is not None and _ckey not in _emitted and not _is_context_compression_marker(_cmsg):
+                    _backfilled.append(copy.deepcopy(_cmsg))
+                    _emitted.add(_ckey)
+            if len(_backfilled) > len(previous_display):
+                logger.debug(
+                    "Backfilled %d context-only turns into previous_display (was %d, now %d)",
+                    len(_backfilled) - len(previous_display),
+                    len(previous_display),
+                    len(_backfilled),
+                )
+                previous_display = _backfilled
+
     if _messages_have_prefix(result_messages, previous_context):
         candidates = result_messages[len(previous_context):]
         candidates = _strip_replayed_prefix(previous_display, candidates)

--- a/static/commands.js
+++ b/static/commands.js
@@ -29,7 +29,7 @@ const COMMANDS=[
   {name:'background',desc:t('cmd_background'),fn:cmdBackground,arg:'prompt',  noEcho:true},
   {name:'status',    desc:t('cmd_status'),   fn:cmdStatus},
   {name:'voice',     desc:t('cmd_voice'),    fn:cmdVoice,     noEcho:true},
-  {name:'reasoning', desc:t('cmd_reasoning'), fn:cmdReasoning, arg:'show|hide|none|minimal|low|medium|high|xhigh', subArgs:['show','hide','none','minimal','low','medium','high','xhigh'], noEcho:true},
+  {name:'reasoning', desc:t('cmd_reasoning'), fn:cmdReasoning, arg:'show|hide|none|minimal|low|medium|high|xhigh|max', subArgs:['show','hide','none','minimal','low','medium','high','xhigh','max'], noEcho:true},
   {name:'yolo', desc:t('cmd_yolo'), fn:cmdYolo, noEcho:true},
   {name:'branch', desc:t('cmd_branch'), fn:cmdBranch, arg:'[name]', noEcho:true},
 ];
@@ -1131,13 +1131,13 @@ function cmdReasoning(args){
   const arg=(args||'').trim().toLowerCase();
   const BRAIN='\uD83E\uDDE0';
   // Matches hermes_constants.VALID_REASONING_EFFORTS + 'none' (CLI parity).
-  const EFFORTS=['none','minimal','low','medium','high','xhigh'];
+  const EFFORTS=['none','minimal','low','medium','high','xhigh','max'];
   // Shared status renderer used by the no-args branch and as a fallback.
   function _fmtStatus(st){
     const vis=(st && st.show_reasoning===false)?'off':'on';
     const eff=(st && st.reasoning_effort)||'default';
     return BRAIN+' Reasoning effort: '+eff+' \u00B7 display: '+vis
-      +'  |  /reasoning show|hide|none|minimal|low|medium|high|xhigh';
+      +'  |  /reasoning show|hide|none|minimal|low|medium|high|xhigh|max';
   }
   if(!arg){
     // Status — read from the same config.yaml keys the CLI uses.

--- a/static/index.html
+++ b/static/index.html
@@ -715,6 +715,7 @@
             <div class="reasoning-option" data-effort="medium">Medium</div>
             <div class="reasoning-option" data-effort="high">High</div>
             <div class="reasoning-option" data-effort="xhigh">Extra High</div>
+            <div class="reasoning-option" data-effort="max">Max</div>
           </div>
           <div class="composer-toolsets-dropdown" id="composerToolsetsDropdown">
             <div class="toolsets-dropdown-desc" id="toolsetsDropdownDesc"></div>

--- a/tests/test_context_message_dedup.py
+++ b/tests/test_context_message_dedup.py
@@ -173,3 +173,171 @@ def test_merge_display_messages_preserves_current_user_turn():
     # Current user message should use msg_text
     user_msgs = [m for m in merged if m.get("role") == "user"]
     assert any(m.get("content") == "next question" for m in user_msgs)
+
+
+def test_merge_display_backfill_preserves_visible_head_ordering():
+    """Display head must stay before hidden context-only middle turns.
+
+    A compacted session can have a visible transcript head that is absent from
+    model context, plus a later visible tail that is present in model context.
+    When model-only middle turns are restored, the merged order must be:
+
+        old visible head
+        hidden context-only middle turn(s)
+        current visible tail
+        new current turn
+    """
+    from api.streaming import _merge_display_messages_after_agent_result
+
+    previous_display = [
+        {"role": "user", "content": "visible head user turn"},
+        {"role": "assistant", "content": "visible head assistant turn"},
+        {"role": "user", "content": "visible tail user turn"},
+    ]
+    previous_context = [
+        {"role": "user", "content": "context-only middle user turn"},
+        {"role": "assistant", "content": "context-only middle assistant turn"},
+        {"role": "user", "content": "visible tail user turn"},
+    ]
+    result_messages = previous_context + [
+        {"role": "user", "content": "new follow-up user turn"},
+        {"role": "assistant", "content": "new follow-up assistant turn"},
+    ]
+    msg_text = "new follow-up user turn"
+
+    merged = _merge_display_messages_after_agent_result(
+        previous_display, previous_context, result_messages, msg_text
+    )
+
+    user_texts = [
+        m.get("content", "")
+        for m in merged
+        if isinstance(m, dict) and m.get("role") == "user"
+    ]
+
+    head_idx = next(i for i, t in enumerate(user_texts) if "visible head" in t)
+    middle_idx = next(i for i, t in enumerate(user_texts) if "context-only middle" in t)
+    tail_idx = next(i for i, t in enumerate(user_texts) if "visible tail" in t)
+    followup_idx = next(i for i, t in enumerate(user_texts) if "new follow-up" in t)
+
+    assert head_idx < middle_idx, f"Visible head must precede restored context middle; got indices {head_idx} vs {middle_idx}"
+    assert middle_idx < tail_idx, f"Restored context middle must precede visible tail; got indices {middle_idx} vs {tail_idx}"
+    assert tail_idx < followup_idx, f"Visible tail must precede new turn; got indices {tail_idx} vs {followup_idx}"
+
+
+def test_merge_display_backfills_context_only_turns_missing_from_display():
+    """Normal user/assistant turns present in previous_context but absent from
+    previous_display must be restored into the visible transcript.
+
+    This reproduces the generic bug where context compression recovery expands
+    previous_context with normal turns that never appear in previous_display.
+    A subsequent append-only merge skips over the shared context prefix, so
+    without backfill those turns remain permanently invisible in the WebUI.
+    """
+    from api.streaming import _merge_display_messages_after_agent_result
+
+    previous_display = [
+        {"role": "user", "content": "visible head user turn"},
+        {"role": "assistant", "content": "visible head assistant turn"},
+    ]
+    previous_context = [
+        {"role": "user", "content": "visible head user turn"},
+        {"role": "assistant", "content": "visible head assistant turn"},
+        {"role": "user", "content": "context-only middle user turn"},
+        {"role": "assistant", "content": "context-only middle assistant turn"},
+    ]
+    result_messages = previous_context + [
+        {"role": "user", "content": "new follow-up user turn"},
+        {"role": "assistant", "content": "new follow-up assistant turn"},
+    ]
+    msg_text = "new follow-up user turn"
+
+    merged = _merge_display_messages_after_agent_result(
+        previous_display, previous_context, result_messages, msg_text
+    )
+
+    merged_texts = [
+        (m.get("role"), _message_text_safe(m))
+        for m in merged
+        if isinstance(m, dict) and m.get("role") in ("user", "assistant")
+    ]
+
+    assert any(
+        "context-only middle user turn" in text
+        for role, text in merged_texts
+        if role == "user"
+    ), f"Missing context-only user turn from visible transcript; got: {merged_texts}"
+
+    assert any(
+        "context-only middle assistant turn" in text
+        for role, text in merged_texts
+        if role == "assistant"
+    ), f"Missing context-only assistant turn from visible transcript; got: {merged_texts}"
+
+    assert any(
+        "new follow-up user turn" in text
+        for role, text in merged_texts
+        if role == "user"
+    ), "New current turn should also be present"
+
+    head_idx = next(i for i, (r, t) in enumerate(merged_texts) if "visible head" in t)
+    middle_idx = next(i for i, (r, t) in enumerate(merged_texts) if "context-only middle" in t)
+    assert head_idx < middle_idx, f"Display head must come before backfilled context turn; got indices {head_idx} vs {middle_idx}"
+
+
+def test_merge_display_backfill_does_not_reintroduce_compression_markers():
+    """Context compression markers in previous_context that were intentionally
+    removed from previous_display must NOT be restored by the backfill logic."""
+    from api.streaming import _merge_display_messages_after_agent_result
+
+    previous_display = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+    ]
+    previous_context = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+        {"role": "assistant", "content": "[context compaction] prior messages summarized"},
+        {"role": "user", "content": "context-only middle user turn"},
+        {"role": "assistant", "content": "context-only middle assistant turn"},
+    ]
+    result_messages = previous_context + [
+        {"role": "user", "content": "next question"},
+        {"role": "assistant", "content": "next answer"},
+    ]
+    msg_text = "next question"
+
+    merged = _merge_display_messages_after_agent_result(
+        previous_display, previous_context, result_messages, msg_text
+    )
+
+    merged_texts = [
+        _message_text_safe(m)
+        for m in merged
+        if isinstance(m, dict) and m.get("role") == "assistant"
+    ]
+
+    assert not any(
+        "[context compaction]" in t for t in merged_texts
+    ), f"Compression marker should not be in visible display; got: {merged_texts}"
+
+    assert any(
+        "context-only middle user turn" in _message_text_safe(m)
+        for m in merged
+        if isinstance(m, dict) and m.get("role") == "user"
+    ), "Normal user turn from context should be backfilled"
+
+
+def _message_text_safe(msg):
+    """Extract plain text from a message content field (list or string)."""
+    if not isinstance(msg, dict):
+        return ""
+    content = msg.get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            part.get("text", "") for part in content
+            if isinstance(part, dict) and isinstance(part.get("text"), str)
+        )
+    return str(content or "")

--- a/tests/test_reasoning_show_hide.py
+++ b/tests/test_reasoning_show_hide.py
@@ -297,7 +297,7 @@ class TestReasoningConfigHelpers:
         # Snapshot-style assertion: if hermes_constants adds a level, this
         # test will fail fast so we know to update WebUI too.
         assert VALID_REASONING_EFFORTS == (
-            'minimal', 'low', 'medium', 'high', 'xhigh'
+            'minimal', 'low', 'medium', 'high', 'xhigh', 'max'
         )
 
     def test_set_reasoning_effort_persists_to_config_yaml(self, tmp_path, monkeypatch):

--- a/tests/test_session_import_cli_fallback_model.py
+++ b/tests/test_session_import_cli_fallback_model.py
@@ -14,10 +14,32 @@ proceeds with a sensible default rather than crashing.
 
 from __future__ import annotations
 
+import io
+import json
 from pathlib import Path
+from urllib.parse import urlparse
 
 REPO = Path(__file__).resolve().parents[1]
 ROUTES_PY = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.status = None
+        self.headers = {}
+        self.wfile = io.BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def json_body(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
 
 
 def _extract_handler(name: str) -> str:
@@ -272,6 +294,99 @@ def test_merge_cli_sidebar_metadata_keeps_larger_sidecar_message_count():
     )
 
     assert merged["message_count"] == 535
+
+
+def test_webui_state_projection_dedupes_by_lineage_root():
+    """WebUI-origin state.db projections should not be additive non-WebUI rows."""
+    import api.routes as routes
+
+    represented = {"root_sid"}
+    state_projection = {
+        "session_id": "tip_sid",
+        "source_tag": "webui",
+        "raw_source": "webui",
+        "session_source": "webui",
+        "_lineage_root_id": "root_sid",
+        "_lineage_tip_id": "tip_sid",
+    }
+
+    assert routes._is_duplicate_webui_state_projection(state_projection, represented) is True
+
+
+def test_external_state_projection_not_deduped_by_webui_source_guard():
+    """The WebUI-source guard must not hide real external conversations."""
+    import api.routes as routes
+
+    represented = {"root_sid"}
+    external_projection = {
+        "session_id": "tip_sid",
+        "source_tag": "telegram",
+        "raw_source": "telegram",
+        "session_source": "messaging",
+        "_lineage_root_id": "root_sid",
+        "_lineage_tip_id": "tip_sid",
+    }
+
+    assert routes._is_duplicate_webui_state_projection(external_projection, represented) is False
+
+
+def test_sessions_endpoint_suppresses_duplicate_webui_state_projection(monkeypatch):
+    """The /api/sessions merge should not add WebUI state.db lineage duplicates."""
+    import api.profiles as profiles
+    import api.routes as routes
+
+    monkeypatch.setattr(routes, "_reconcile_stale_stream_state_for_session_rows", lambda _sessions: False)
+    monkeypatch.setattr(routes, "load_settings", lambda: {"show_cli_sessions": True})
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+
+    webui_row = {
+        "session_id": "visible_tip",
+        "title": "Long Conversation",
+        "profile": "default",
+        "updated_at": 20,
+        "last_message_at": 20,
+        "source_tag": "webui",
+        "raw_source": "webui",
+        "session_source": "webui",
+        "_lineage_root_id": "root_sid",
+        "_lineage_tip_id": "visible_tip",
+    }
+    duplicate_webui_projection = {
+        "session_id": "state_projection_tip",
+        "title": "Long Conversation",
+        "profile": "default",
+        "updated_at": 30,
+        "last_message_at": 30,
+        "source_tag": "webui",
+        "raw_source": "webui",
+        "session_source": "webui",
+        "_lineage_root_id": "root_sid",
+        "_lineage_tip_id": "state_projection_tip",
+    }
+    external_projection = {
+        "session_id": "telegram_tip",
+        "title": "External Thread",
+        "profile": "default",
+        "updated_at": 10,
+        "last_message_at": 10,
+        "source_tag": "telegram",
+        "raw_source": "telegram",
+        "session_source": "messaging",
+        "_lineage_root_id": "root_sid",
+        "_lineage_tip_id": "telegram_tip",
+    }
+
+    monkeypatch.setattr(routes, "all_sessions", lambda diag=None: [webui_row])
+    monkeypatch.setattr(routes, "get_cli_sessions", lambda: [duplicate_webui_projection, external_projection])
+
+    handler = _FakeHandler()
+    routes.handle_get(handler, urlparse("http://example.com/api/sessions"))
+
+    assert handler.status == 200
+    session_ids = [row["session_id"] for row in handler.json_body()["sessions"]]
+    assert "visible_tip" in session_ids
+    assert "state_projection_tip" not in session_ids
+    assert "telegram_tip" in session_ids
 
 
 def test_messaging_session_loader_prefers_longer_sidecar_transcript():

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -423,8 +423,8 @@ def test_pre_compression_snapshot_hidden_from_active_sidebar_but_file_remains(mo
         parent_session_id="old_sid",
         updated_at=200.0,
     )
-    snapshot.save()
-    continuation.save()
+    snapshot.save(touch_updated_at=False)
+    continuation.save(touch_updated_at=False)
     monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
 
     rows = models.all_sessions()
@@ -452,16 +452,18 @@ def test_fuller_pre_compression_snapshot_replaces_shorter_visible_segment(monkey
         ],
         pre_compression_snapshot=True,
         updated_at=300.0,
+        last_message_at=300.0,
     )
     continuation = Session(
         session_id="short_child",
         title="Long Conversation",
         messages=[{"role": "user", "content": "first"}],
         parent_session_id="full_parent",
-        updated_at=400.0,
+        updated_at=250.0,
+        last_message_at=250.0,
     )
-    snapshot.save()
-    continuation.save()
+    snapshot.save(touch_updated_at=False)
+    continuation.save(touch_updated_at=False)
     monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
 
     rows = models.all_sessions()
@@ -469,6 +471,48 @@ def test_fuller_pre_compression_snapshot_replaces_shorter_visible_segment(monkey
     assert [row["session_id"] for row in rows] == ["full_parent"]
     assert rows[0]["message_count"] == 4
     assert rows[0]["pre_compression_snapshot"] is True
+
+
+def test_newer_continuation_beats_older_fuller_snapshot(monkeypatch):
+    """Do not hide a newer continuation behind an older fuller snapshot.
+
+    Compression snapshots can have a higher message count while still being
+    older than the continuation that contains the latest user-visible turns.
+    The sidebar should keep the newer continuation visible in that case.
+    """
+    snapshot = Session(
+        session_id="older_full_parent",
+        title="Long Conversation",
+        messages=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+            {"role": "user", "content": "third"},
+            {"role": "assistant", "content": "fourth"},
+        ],
+        pre_compression_snapshot=True,
+        updated_at=300.0,
+        last_message_at=300.0,
+    )
+    continuation = Session(
+        session_id="newer_short_child",
+        title="Long Conversation",
+        messages=[
+            {"role": "user", "content": "latest task"},
+            {"role": "assistant", "content": "latest result"},
+        ],
+        parent_session_id="older_full_parent",
+        updated_at=450.0,
+        last_message_at=450.0,
+    )
+    snapshot.save(touch_updated_at=False)
+    continuation.save(touch_updated_at=False)
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    rows = models.all_sessions()
+
+    assert [row["session_id"] for row in rows] == ["newer_short_child"]
+    assert rows[0]["pre_compression_snapshot"] is False
+    assert rows[0]["message_count"] == 2
 
 
 def test_session_save_does_not_persist_metadata_message_count_hint():

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -8,6 +8,7 @@ import urllib.error
 
 import api.gateway_chat as gateway_chat
 import api.models as models
+import api.streaming as streaming
 from api.config import STREAMS, create_stream_channel
 from api.models import new_session
 from api.gateway_chat import (
@@ -201,6 +202,8 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
 
     monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
     monkeypatch.setenv("HERMES_WEBUI_GATEWAY_API_KEY", "secret-token")
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {"status": "loaded", "source": "test", "label": "test", "message_count": 1, "messages": [{"role": "user", "content": "prefill"}]})
+    monkeypatch.setattr(streaming, "_prefill_messages_with_webui_context", lambda ctx, cfg: list(ctx["messages"]) + [{"role": "user", "content": "webui session context"}])
     monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", fake_urlopen)
 
     s = new_session()
@@ -231,6 +234,12 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     assert captured["headers"]["X-hermes-session-id"] == s.session_id
     assert captured["headers"]["X-hermes-session-key"] == f"webui:{s.session_id}"
     assert '"stream": true' in captured["body"]
+    payload = json.loads(captured["body"])
+    assert [m["content"] for m in payload["messages"]] == [
+        "prefill",
+        "webui session context",
+        "Say hello",
+    ]
 
 
 def test_gateway_chat_worker_forwards_image_attachments_as_multimodal_parts(tmp_path, monkeypatch):
@@ -263,6 +272,8 @@ def test_gateway_chat_worker_forwards_image_attachments_as_multimodal_parts(tmp_
         return FakeResponse()
 
     monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {"status": "not_configured", "source": "none", "label": "", "message_count": 0, "messages": []})
+    monkeypatch.setattr(streaming, "_prefill_messages_with_webui_context", lambda ctx, cfg: [{"role": "user", "content": "webui session context"}])
     monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", fake_urlopen)
 
     s = new_session()
@@ -280,7 +291,8 @@ def test_gateway_chat_worker_forwards_image_attachments_as_multimodal_parts(tmp_
         [{"path": str(image_path), "mime": "image/png", "is_image": True}],
     )
 
-    content = captured["body"]["messages"][0]["content"]
+    content = captured["body"]["messages"][-1]["content"]
+    assert captured["body"]["messages"][0] == {"role": "user", "content": "webui session context"}
     assert content[0] == {"type": "text", "text": "What is in this image?"}
     assert content[1]["type"] == "image_url"
     assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")

--- a/tests/test_webui_prefill_context.py
+++ b/tests/test_webui_prefill_context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import sys
+import types
 from pathlib import Path
 
 
@@ -209,10 +210,11 @@ def test_webui_session_context_adds_gateway_like_metadata(monkeypatch, tmp_path)
         def __truediv__(self, name):
             return gateway_state if name == "gateway_state.json" else tmp_path / name
 
-    import hermes_constants
-
-    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: FakeHome())
-    monkeypatch.setattr(hermes_constants, "display_hermes_home", lambda: "/tmp/hermes-test-home")
+    fake_constants = types.SimpleNamespace(
+        get_hermes_home=lambda: FakeHome(),
+        display_hermes_home=lambda: "/tmp/hermes-test-home",
+    )
+    monkeypatch.setitem(sys.modules, "hermes_constants", fake_constants)
 
     messages = _prefill_messages_with_webui_context(
         {"messages": [{"role": "user", "content": "recall"}]},

--- a/tests/test_webui_prefill_context.py
+++ b/tests/test_webui_prefill_context.py
@@ -114,6 +114,25 @@ def test_webui_prefill_script_takes_precedence_over_static_file(tmp_path):
     assert result["messages"] == [{"role": "user", "content": "dynamic"}]
 
 
+def test_webui_prefill_script_error_falls_back_to_static_router_file(tmp_path):
+    from api.streaming import _load_webui_prefill_context
+
+    prefill = tmp_path / "prefill.json"
+    prefill.write_text(json.dumps([{"role": "system", "content": "Joplin router fallback"}]), encoding="utf-8")
+    script = tmp_path / "broken_recall.py"
+    script.write_text("import sys; print('api_key=redaction-test-placeholder', file=sys.stderr); raise SystemExit(2)\n", encoding="utf-8")
+
+    result = _load_webui_prefill_context({
+        "prefill_messages_file": str(prefill),
+        "webui_prefill_messages_script": [sys.executable, str(script)],
+    })
+
+    assert result["status"] == "loaded"
+    assert result["source"] == "file_fallback"
+    assert result["messages"] == [{"role": "system", "content": "Joplin router fallback"}]
+    assert "redaction-test-placeholder" not in result.get("script_error", "")
+
+
 def test_webui_prefill_script_timeout_returns_redacted_error(tmp_path):
     from api.streaming import _load_webui_prefill_context
 
@@ -167,6 +186,55 @@ def test_public_prefill_status_strips_message_bodies():
         "message_count": 1,
     }
     assert "messages" not in public
+
+
+def test_webui_session_context_adds_gateway_like_metadata(monkeypatch, tmp_path):
+    from api.streaming import _prefill_messages_with_webui_context
+
+    gateway_state = tmp_path / "gateway_state.json"
+    gateway_state.write_text(
+        json.dumps(
+            {
+                "platforms": {
+                    "telegram": {"state": "connected"},
+                    "discord": {"state": "paused"},
+                    "api_server": {"state": "connected"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class FakeHome:
+        def __truediv__(self, name):
+            return gateway_state if name == "gateway_state.json" else tmp_path / name
+
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: FakeHome())
+    monkeypatch.setattr(hermes_constants, "display_hermes_home", lambda: "/tmp/hermes-test-home")
+
+    messages = _prefill_messages_with_webui_context(
+        {"messages": [{"role": "user", "content": "recall"}]},
+        {
+            "platforms": {
+                "telegram": {
+                    "enabled": True,
+                    "home_channel": {"name": "Home DM", "chat_id": "should-not-leak"},
+                }
+            }
+        },
+    )
+
+    assert messages[0] == {"role": "user", "content": "recall"}
+    context = messages[-1]
+    assert context["role"] == "user"
+    assert "## Current Session Context" in context["content"]
+    assert "**Source:** WebUI (browser session)" in context["content"]
+    assert "telegram: Connected" in context["content"]
+    assert "discord: Connected" not in context["content"]
+    assert "Home DM" in context["content"]
+    assert "should-not-leak" not in context["content"]
 
 
 def test_prefill_status_redactor_handles_secret_shaped_text():

--- a/tests/test_webui_prefill_context.py
+++ b/tests/test_webui_prefill_context.py
@@ -147,6 +147,80 @@ def test_webui_prefill_script_rejects_oversized_stdout(tmp_path):
     assert "output exceeded" in result["error"]
 
 
+def test_webui_prefill_script_over_budget_uses_static_file_fallback(tmp_path):
+    from api.streaming import _load_webui_prefill_context, _public_prefill_context_status
+
+    prefill = tmp_path / "router.json"
+    prefill.write_text(json.dumps([{"role": "user", "content": "Compact router context"}]), encoding="utf-8")
+    script = tmp_path / "large_recall.py"
+    script.write_text("print('x' * 80)\n", encoding="utf-8")
+
+    result = _load_webui_prefill_context(
+        {
+            "webui_prefill_messages_script": [sys.executable, str(script)],
+            "prefill_messages_file": str(prefill),
+            "webui_prefill_context_max_chars": 40,
+        }
+    )
+
+    assert result["status"] == "loaded"
+    assert result["source"] == "file_budget_fallback"
+    assert result["messages"] == [{"role": "user", "content": "Compact router context"}]
+    assert result["compacted"] is True
+    assert result["original_source"] == "script"
+    assert result["original_char_count"] == 80
+    public = _public_prefill_context_status(result)
+    assert public["compacted"] is True
+    assert public["original_char_count"] == 80
+    assert "messages" not in public
+
+
+def test_webui_prefill_file_over_budget_compacts_without_leaking_body(tmp_path):
+    from api.streaming import _load_webui_prefill_context, _public_prefill_context_status
+
+    prefill = tmp_path / "huge.json"
+    prefill.write_text(json.dumps([{"role": "user", "content": "secret project note " * 20}]), encoding="utf-8")
+
+    result = _load_webui_prefill_context(
+        {
+            "prefill_messages_file": str(prefill),
+            "webui_prefill_context_max_chars": 50,
+        }
+    )
+
+    assert result["status"] == "loaded"
+    assert result["source"] == "budget_compacted"
+    assert result["message_count"] == 1
+    assert result["compacted"] is True
+    assert result["original_source"] == "file"
+    assert result["original_char_count"] > 50
+    compact_message = result["messages"][0]["content"]
+    assert "exceeded the WebUI prefill context budget" in compact_message
+    assert "secret project note" not in compact_message
+    public = _public_prefill_context_status(result)
+    assert public["source"] == "budget_compacted"
+    assert public["compacted"] is True
+    assert "messages" not in public
+
+
+def test_webui_prefill_context_budget_can_be_disabled(tmp_path):
+    from api.streaming import _load_webui_prefill_context
+
+    prefill = tmp_path / "huge.json"
+    prefill.write_text(json.dumps([{"role": "user", "content": "x" * 80}]), encoding="utf-8")
+
+    result = _load_webui_prefill_context(
+        {
+            "prefill_messages_file": str(prefill),
+            "webui_prefill_context_max_chars": 0,
+        }
+    )
+
+    assert result["source"] == "file"
+    assert result["messages"] == [{"role": "user", "content": "x" * 80}]
+    assert "compacted" not in result
+
+
 def test_public_prefill_status_strips_message_bodies():
     from api.streaming import _public_prefill_context_status
 

--- a/tests/test_webui_surface_context.py
+++ b/tests/test_webui_surface_context.py
@@ -19,6 +19,9 @@ def test_webui_ephemeral_prompt_includes_browser_surface_context():
     assert "Profile: default" in prompt
     assert "Workspace: /tmp/example-workspace" in prompt
     assert "not the same live transcript as Telegram" in prompt
+    assert "Do not copy or dump this browser transcript" in prompt
+    assert "explicit captures" in prompt
+    assert "durable user preferences" in prompt
 
 
 def test_webui_ephemeral_prompt_skips_empty_surface_fields():


### PR DESCRIPTION
# stage-batch39 — v0.51.157 — Release EC

**5-PR mixed-risk cleanup.** All contributor PRs, all CI-green on origin, all going through Opus advisor before merge.

## Included

- **#3092 (AJV20)** `Limit WebUI durable memory guidance to explicit reusable signals` — one-line addition to the browser-session surface prompt instructing agents not to dump browser transcripts into external notes / durable memory by default.
- **#3093 (theseussss)** `fix(reasoning): add max effort level to match hermes_constants` — adds `'max'` to `VALID_REASONING_EFFORTS`, the `<div data-effort="max">` chip, the `/reasoning` command's effort list, and updates the snapshot assertion.
- **#3090 (AJV20)** `fix: carry WebUI context through gateway chat` — gateway-backed turns now call `_load_webui_prefill_context()` + `_prefill_messages_with_webui_context()` and prepend results to the Gateway-bound messages array. Emits a `context_status` SSE event so the browser knows which prefill source was used. Adds a static-router-prefill fallback when the dynamic prefill script returns `status="error"`.
- **#3094 (AJV20)** `fix: budget oversized WebUI prefill context` — new `webui_prefill_context_max_chars` / `HERMES_WEBUI_PREFILL_CONTEXT_MAX_CHARS` config (default 12,000 chars, capped at 262,144). Oversized prefill payloads fall back to the static prefill file when available; otherwise inject a compact retrieval-hint message instead of the full payload.
- **#3091 (starship-s)** `fix(sidebar): keep compressed continuations visible` — sidebar `_prefer_fuller_snapshots_for_sidebar` now keeps the newer continuation when it has more recent activity than its fuller pre-compression snapshot. Adds lineage-aware dedupe for WebUI-origin state-db projections (preserves external/messaging row visibility). Visible-transcript writeback after compression restores normal context-only turns into `messages` in order, using the visible transcript as the ordering backbone. Recognizes `[Session Arc Summary]` as a compression marker so it's not backfilled into the chat transcript. CHANGELOG entry added during stage merge (PR did not include one).

## Verification

- Cross-PR conflict resolution: `_load_webui_prefill_context` (api/streaming.py) was edited by both #3090 (script→file fallback structure) and #3094 (budget application). Resolved by applying #3094's `_apply_prefill_context_budget` to each of #3090's return paths so both intents land.
- ast.parse: api/streaming.py, api/compression_anchor.py, api/models.py, api/routes.py, api/gateway_chat.py, api/config.py — OK
- node -c: static/messages.js, static/commands.js — OK
- Conflict markers: none
- CJK escapes: none new (one commit subject has Chinese characters — harmless commit metadata)
- Full pytest suite: running (target: zero failures sequential, no:xdist)
- Opus advisor: running concurrently

## Held back this batch

(Same hold list as previous batches in this sweep — #3030, #3050, #3052, #3062, #3065, #3067, #3068, #3073, #3075, #3080 for UX/architectural review; #3026, #3083 for `changes-requested` follow-up.)