### PR TITLE
Fix for #2914: stop agent from seeing deleted messages after Edit/Undo (from state.db)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -637,18 +637,6 @@ class Session:
     def path(self):
         return SESSION_DIR / f'{self.session_id}.json'
 
-    def _maybe_clear_truncation_watermark(self) -> None:
-        watermark = _message_timestamp_as_float({"timestamp": self.truncation_watermark})
-        if watermark is None:
-            return
-        max_message_timestamp = None
-        for msg in self.messages or []:
-            timestamp = _message_timestamp_as_float(msg)
-            if timestamp is not None:
-                max_message_timestamp = timestamp if max_message_timestamp is None else max(max_message_timestamp, timestamp)
-        if max_message_timestamp is not None and max_message_timestamp > watermark:
-            self.truncation_watermark = None
-
     def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
@@ -671,7 +659,6 @@ class Session:
             )
         if touch_updated_at:
             self.updated_at = time.time()
-        self._maybe_clear_truncation_watermark()
         # Write metadata fields first so load_metadata_only() can read them
         # without parsing the full messages array (which may be 400KB+).
         # Fields are listed in the order they should appear in the JSON file.
@@ -4012,6 +3999,20 @@ def merge_session_messages_append_only(
             and timestamp is not None
             and timestamp > watermark_timestamp
             and key not in seen_message_keys
+        ):
+            continue
+        # When a truncation watermark is active, state.db may contain original
+        # messages that were replaced by Edit (old content with old timestamp).
+        # The timestamp-based filter above catches messages AFTER the watermark,
+        # but messages BEFORE it (like the original pre-edit content) slip through.
+        # If a state.db message's content is not present in the sidecar and its
+        # timestamp is before the watermark, it's a replaced/stale row — skip it.
+        if (
+            watermark_timestamp is not None
+            and timestamp is not None
+            and timestamp < watermark_timestamp
+            and key not in seen_message_keys
+            and _session_message_content_key(msg) not in seen_content_keys
         ):
             continue
         if max_sidecar_timestamp is not None and timestamp is not None and timestamp <= max_sidecar_timestamp:

--- a/api/routes.py
+++ b/api/routes.py
@@ -6057,13 +6057,28 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, "Session not found", 404)
         keep = int(body["keep_count"])
         with _get_session_agent_lock(body["session_id"]):
+            old_msg_count = len(s.messages or [])
+            old_ctx_count = len(getattr(s, 'context_messages', None) or [])
             s.messages = s.messages[:keep]
+            # Truncate context_messages in sync with messages so the agent's
+            # model-facing context doesn't retain rows the user removed via
+            # Edit / Regenerate.  Without this, context_messages still contains
+            # the full pre-truncation history and the agent sees "deleted"
+            # turns on the next turn (#2914).
+            if isinstance(getattr(s, 'context_messages', None), list):
+                s.context_messages = s.context_messages[:keep]
             try:
                 from api.session_ops import _truncation_watermark_for
                 s.truncation_watermark = _truncation_watermark_for(s.messages)
             except Exception:
                 s.truncation_watermark = 0.0
             s.save()
+            logger.info(
+                "truncate %s: messages %d→%d, context_messages %d→%d, watermark=%.2f",
+                body["session_id"], old_msg_count, len(s.messages or []),
+                old_ctx_count, len(getattr(s, 'context_messages', None) or []),
+                s.truncation_watermark or 0,
+            )
         return j(
             handler, {"ok": True, "session": s.compact() | {"messages": s.messages}}
         )

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -45,6 +45,7 @@ from api.turn_journal import append_turn_journal_event_for_stream
 from api.usage import prompt_cache_hit_percent
 from api.models import (
     _is_empty_partial_activity_message,
+    _message_timestamp_as_float,
     get_state_db_session_messages,
     reconciled_state_db_messages_for_session,
 )
@@ -2628,6 +2629,35 @@ def _restore_display_reasoning_metadata(previous_messages, updated_messages):
         updated_messages.insert(safe_pos, copy.deepcopy(prev_msg))
         inserted_reasoning_only += 1
     return updated_messages
+
+
+def _clamp_context_to_watermark(session, messages: list) -> list:
+    """Filter context_messages to the truncation watermark boundary (#2914).
+
+    When a user edits, regenerates, or undoes messages, the agent's result
+    may contain the full state.db history including turns the user deliberately
+    removed.  This helper drops messages whose timestamp exceeds the active
+    watermark so the next turn doesn't feed the agent "deleted" rows again.
+    """
+    _tw = getattr(session, 'truncation_watermark', None)
+    if _tw is None:
+        return messages
+    _tw_ts = _message_timestamp_as_float({'timestamp': _tw})
+    if _tw_ts is None:
+        return messages
+    _clamped = [
+        m for m in messages
+        # Keep m_ts <= watermark (messages AT the watermark boundary are kept).
+        # Matches the merge filter in models.py merge_session_messages_append_only,
+        # which drops state.db rows with timestamp > watermark_timestamp (strict).
+        if (m_ts := _message_timestamp_as_float(m)) is None or m_ts <= _tw_ts
+    ]
+    if len(_clamped) != len(messages):
+        logger.info(
+            "clamping context_messages: %d → %d (watermark=%.2f, session=%s)",
+            len(messages), len(_clamped), _tw_ts, session.session_id,
+        )
+    return _clamped
 
 
 def _session_context_messages(session):
@@ -5336,6 +5366,7 @@ def _run_agent_streaming(
                     _previous_context_messages,
                     _next_context_messages,
                 )
+                _next_context_messages = _clamp_context_to_watermark(s, _next_context_messages)
                 s.context_messages = _deduplicate_context_messages(_next_context_messages)
                 s.messages = _merge_display_messages_after_agent_result(
                     _previous_messages,
@@ -5483,6 +5514,7 @@ def _run_agent_streaming(
                                     _previous_context_messages,
                                     _next_context_messages,
                                 )
+                                _next_context_messages = _clamp_context_to_watermark(s, _next_context_messages)
                                 s.context_messages = _deduplicate_context_messages(_next_context_messages)
                                 s.messages = _merge_display_messages_after_agent_result(
                                     _previous_messages,
@@ -6523,6 +6555,7 @@ def _run_agent_streaming(
                                     _previous_context_messages,
                                     _next_context_messages,
                                 )
+                                _next_context_messages = _clamp_context_to_watermark(s, _next_context_messages)
                                 s.context_messages = _deduplicate_context_messages(_next_context_messages)
                                 s.messages = _merge_display_messages_after_agent_result(
                                     _previous_messages,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2630,15 +2630,6 @@ def _restore_display_reasoning_metadata(previous_messages, updated_messages):
     return updated_messages
 
 
-def _clamp_context_to_watermark(session, messages: list) -> list:
-    """Return messages unchanged — the merge-side watermark filter in
-    merge_session_messages_append_only already handles #2914 for the
-    state.db replay path.  Clamping here was a permanent ceiling that
-    dropped legitimate new turns after Edit/Retry/Undo.
-    """
-    return messages
-
-
 def _session_context_messages(session):
     """Return model-facing history without assuming it matches the UI transcript."""
     context_messages = getattr(session, 'context_messages', None)
@@ -5345,7 +5336,6 @@ def _run_agent_streaming(
                     _previous_context_messages,
                     _next_context_messages,
                 )
-                _next_context_messages = _clamp_context_to_watermark(s, _next_context_messages)
                 s.context_messages = _deduplicate_context_messages(_next_context_messages)
                 s.messages = _merge_display_messages_after_agent_result(
                     _previous_messages,
@@ -5493,7 +5483,6 @@ def _run_agent_streaming(
                                     _previous_context_messages,
                                     _next_context_messages,
                                 )
-                                _next_context_messages = _clamp_context_to_watermark(s, _next_context_messages)
                                 s.context_messages = _deduplicate_context_messages(_next_context_messages)
                                 s.messages = _merge_display_messages_after_agent_result(
                                     _previous_messages,
@@ -6534,7 +6523,6 @@ def _run_agent_streaming(
                                     _previous_context_messages,
                                     _next_context_messages,
                                 )
-                                _next_context_messages = _clamp_context_to_watermark(s, _next_context_messages)
                                 s.context_messages = _deduplicate_context_messages(_next_context_messages)
                                 s.messages = _merge_display_messages_after_agent_result(
                                     _previous_messages,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -45,7 +45,6 @@ from api.turn_journal import append_turn_journal_event_for_stream
 from api.usage import prompt_cache_hit_percent
 from api.models import (
     _is_empty_partial_activity_message,
-    _message_timestamp_as_float,
     get_state_db_session_messages,
     reconciled_state_db_messages_for_session,
 )
@@ -2632,32 +2631,12 @@ def _restore_display_reasoning_metadata(previous_messages, updated_messages):
 
 
 def _clamp_context_to_watermark(session, messages: list) -> list:
-    """Filter context_messages to the truncation watermark boundary (#2914).
-
-    When a user edits, regenerates, or undoes messages, the agent's result
-    may contain the full state.db history including turns the user deliberately
-    removed.  This helper drops messages whose timestamp exceeds the active
-    watermark so the next turn doesn't feed the agent "deleted" rows again.
+    """Return messages unchanged — the merge-side watermark filter in
+    merge_session_messages_append_only already handles #2914 for the
+    state.db replay path.  Clamping here was a permanent ceiling that
+    dropped legitimate new turns after Edit/Retry/Undo.
     """
-    _tw = getattr(session, 'truncation_watermark', None)
-    if _tw is None:
-        return messages
-    _tw_ts = _message_timestamp_as_float({'timestamp': _tw})
-    if _tw_ts is None:
-        return messages
-    _clamped = [
-        m for m in messages
-        # Keep m_ts <= watermark (messages AT the watermark boundary are kept).
-        # Matches the merge filter in models.py merge_session_messages_append_only,
-        # which drops state.db rows with timestamp > watermark_timestamp (strict).
-        if (m_ts := _message_timestamp_as_float(m)) is None or m_ts <= _tw_ts
-    ]
-    if len(_clamped) != len(messages):
-        logger.info(
-            "clamping context_messages: %d → %d (watermark=%.2f, session=%s)",
-            len(messages), len(_clamped), _tw_ts, session.session_id,
-        )
-    return _clamped
+    return messages
 
 
 def _session_context_messages(session):

--- a/tests/test_issue2914_truncation_watermark.py
+++ b/tests/test_issue2914_truncation_watermark.py
@@ -299,11 +299,17 @@ def test_edit_then_new_turn_then_undo_leaks_original_via_state_db(monkeypatch, t
     assert "light speed" not in contents
 
 
-# ── _clamp_context_to_watermark unit tests ────────────────────────────────
+# ── _clamp_context_to_watermark is no-op (merge-side filter handles #2914) ──
 
 
-def test_clamp_context_to_watermark_filters_beyond_watermark():
-    """_clamp_context_to_watermark must drop messages with timestamp > watermark."""
+def test_clamp_context_to_watermark_is_no_op():
+    """_clamp_context_to_watermark must pass all messages through unchanged.
+
+    The merge-side watermark filter in merge_session_messages_append_only
+    already handles #2914 for the state.db replay path.  Clamping in the
+    streaming finalize path was a permanent ceiling that dropped legitimate
+    new turns after Edit/Retry/Undo.
+    """
     from api.streaming import _clamp_context_to_watermark
 
     class FakeSession:
@@ -313,14 +319,12 @@ def test_clamp_context_to_watermark_filters_beyond_watermark():
     messages = [
         _msg("user", "first", 1.0, "u1"),
         _msg("assistant", "reply", 2.0, "a1"),
-        _msg("user", "deleted", 3.0, "u2"),
-        _msg("assistant", "deleted reply", 4.0, "a2"),
+        _msg("user", "new turn", 3.0, "u2"),
+        _msg("assistant", "new reply", 4.0, "a2"),
     ]
 
     result = _clamp_context_to_watermark(FakeSession(), messages)
-    contents = [m["content"] for m in result]
-    assert contents == ["first", "reply"]
-    assert "deleted" not in contents
+    assert result is messages  # same object — no filtering
 
 
 def test_clamp_context_to_watermark_no_watermark_passes_all():
@@ -337,11 +341,11 @@ def test_clamp_context_to_watermark_no_watermark_passes_all():
     ]
 
     result = _clamp_context_to_watermark(FakeSession(), messages)
-    assert result is messages  # same object — no copy when nothing to filter
+    assert result is messages
 
 
-def test_clamp_context_to_watermark_zero_watermark_blocks_all():
-    """When truncation_watermark is 0.0, all messages with timestamp > 0 are dropped."""
+def test_clamp_context_to_watermark_zero_watermark_passes_all():
+    """Even with truncation_watermark = 0.0, _clamp_context_to_watermark passes all through."""
     from api.streaming import _clamp_context_to_watermark
 
     class FakeSession:
@@ -354,27 +358,7 @@ def test_clamp_context_to_watermark_zero_watermark_blocks_all():
     ]
 
     result = _clamp_context_to_watermark(FakeSession(), messages)
-    assert result == []
-
-
-def test_clamp_context_to_watermark_keeps_messages_without_timestamp():
-    """Messages without a timestamp field are kept (m_ts is None → passes filter)."""
-    from api.streaming import _clamp_context_to_watermark
-
-    class FakeSession:
-        session_id = "clamp-nots"
-        truncation_watermark = 2.0
-
-    messages = [
-        {"role": "user", "content": "no-timestamp"},  # no timestamp at all
-        _msg("assistant", "reply", 2.0, "a1"),
-        _msg("user", "deleted", 3.0, "u2"),
-    ]
-
-    result = _clamp_context_to_watermark(FakeSession(), messages)
-    contents = [m["content"] for m in result]
-    assert contents == ["no-timestamp", "reply"]
-    assert "deleted" not in contents
+    assert result is messages
 
 
 def test_clamp_context_to_watermark_empty_messages():
@@ -425,3 +409,184 @@ def test_save_does_not_auto_clear_truncation_watermark(monkeypatch, tmp_path):
     # Watermark must NOT be cleared even though max message ts (3.0) > watermark (2.0)
     assert loaded.truncation_watermark == 2.0, \
         f"Watermark was cleared on save! Got {loaded.truncation_watermark}"
+
+
+# ── Streaming finalize regression: watermark must not become permanent ceiling ──
+
+
+def test_edit_then_two_turns_agent_sees_all_turns():
+    """Regression: after Edit sets watermark, subsequent turns must NOT be
+    clamped out of context_messages by the streaming finalize path (#2914).
+
+    Scenario (reproduces the brick-class regression caught by pre-release gate):
+    1. Edit → watermark = 101.0
+    2. Turn 1: user asks "square" (ts=200), agent replies "360°" (ts=201)
+    3. Turn 2: user asks "list all" (ts=300), agent replies "square, list" (ts=301)
+    4. Agent on Turn 2 must see Turn 1 in context — otherwise agent 'forgets'
+       everything after the Edit point permanently.
+
+    Root cause: _clamp_context_to_watermark() drops ALL messages with
+    timestamp > watermark, including legitimate new turns. Combined with
+    _maybe_clear_truncation_watermark() being removed from save(), the
+    watermark becomes a permanent ceiling.
+    """
+    from api.streaming import _clamp_context_to_watermark
+
+    class FakeSession:
+        session_id = "post-edit-streaming"
+        # Watermark set by Edit at ts=101
+        truncation_watermark = 101.0
+
+    # After Turn 1, agent returns full context including new turn:
+    # [pre-edit messages at ts=100/101, new turn at ts=200/201]
+    _next_context_after_turn1 = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+        _msg("user", "what is circle", 200.0, "ctx-u2"),
+        _msg("assistant", "360 degrees", 201.0, "ctx-a2"),
+    ]
+
+    # _clamp_context_to_watermark is called on every streaming finalize.
+    # After Turn 1, context_messages should still contain the new turn.
+    result = _clamp_context_to_watermark(FakeSession(), _next_context_after_turn1)
+    contents = [m["content"] for m in result]
+
+    # NEW TURN must be preserved — this is the regression:
+    # _clamp_context_to_watermark drops ts=200/201 because 200 > 101 (watermark)
+    assert "what is circle" in contents, \
+        f"Turn 1 was clamped out of context! Contents: {contents}"
+    assert "360 degrees" in contents, \
+        f"Turn 1 reply was clamped out of context! Contents: {contents}"
+
+
+def test_edit_then_two_turns_second_turn_sees_first():
+    """End-to-end streaming simulation: Edit → Turn 1 → Turn 2.
+
+    After Turn 1 is finalized, context_messages is saved.
+    On Turn 2, the agent's result includes Turn 1 + Turn 2.
+    _clamp_context_to_watermark must NOT drop Turn 1 from Turn 2's context.
+    """
+    from api.streaming import _clamp_context_to_watermark
+
+    class FakeSession:
+        session_id = "two-turns-post-edit"
+        truncation_watermark = 101.0
+
+    # Turn 2: agent returns context with Turn 1 + Turn 2
+    _next_context_after_turn2 = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+        _msg("user", "what is circle", 200.0, "ctx-u2"),   # Turn 1
+        _msg("assistant", "360 degrees", 201.0, "ctx-a2"),  # Turn 1 reply
+        _msg("user", "list all shapes", 300.0, "ctx-u3"),   # Turn 2
+        _msg("assistant", "square, circle", 301.0, "ctx-a3"), # Turn 2 reply
+    ]
+
+    result = _clamp_context_to_watermark(FakeSession(), _next_context_after_turn2)
+    contents = [m["content"] for m in result]
+
+    # Both Turn 1 and Turn 2 must be preserved
+    assert "what is circle" in contents, \
+        f"Turn 1 was clamped out! Contents: {contents}"
+    assert "360 degrees" in contents, \
+        f"Turn 1 reply was clamped out! Contents: {contents}"
+    assert "list all shapes" in contents, \
+        f"Turn 2 was clamped out! Contents: {contents}"
+    assert "square, circle" in contents, \
+        f"Turn 2 reply was clamped out! Contents: {contents}"
+
+
+def test_streaming_finalize_preserves_new_turns_after_edit(monkeypatch, tmp_path):
+    """Integration: simulate the full streaming finalize pipeline for two
+    consecutive turns after Edit, verifying that context_messages retains
+    all new turns (not just the pre-Edit history).
+
+    This exercises the actual finalize chain:
+      _restore_reasoning_metadata → _dedupe_replayed_context_messages
+      → _clamp_context_to_watermark → _deduplicate_context_messages
+
+    Scenario:
+    1. Edit sets watermark = 101.0, context_messages = [pre-edit messages]
+    2. Turn 1: agent returns [pre-edit + Turn 1] → finalize → save context_messages
+    3. Turn 2: agent returns [pre-edit + Turn 1 + Turn 2] → finalize → save
+    4. Assert context_messages after Turn 2 contains Turn 1 + Turn 2
+    """
+    import api.models as models
+    from api.models import Session
+    from api.streaming import (
+        _restore_reasoning_metadata,
+        _dedupe_replayed_context_messages,
+        _clamp_context_to_watermark,
+        _deduplicate_context_messages,
+    )
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    # Pre-Edit context (after Edit, watermark = 101.0)
+    pre_edit = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+    ]
+
+    session = Session(
+        session_id="finalize_two_turns",
+        messages=list(pre_edit),
+        context_messages=list(pre_edit),
+        truncation_watermark=101.0,
+    )
+    session.save()
+    models.SESSIONS["finalize_two_turns"] = session
+
+    # ── Turn 1: agent returns [pre-edit + Turn 1] ──
+    _previous_context = list(session.context_messages)
+    _result_messages_turn1 = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+        _msg("user", "what is circle", 200.0, "ctx-u2"),
+        _msg("assistant", "360 degrees", 201.0, "ctx-a2"),
+    ]
+
+    # Run the finalize chain
+    _next = _restore_reasoning_metadata(_previous_context, _result_messages_turn1)
+    _next = _dedupe_replayed_context_messages(_previous_context, _next)
+    _next = _clamp_context_to_watermark(session, _next)
+    session.context_messages = _deduplicate_context_messages(_next)
+
+    # Turn 1: context must contain the new turn
+    turn1_contents = [m["content"] for m in session.context_messages]
+    assert "what is circle" in turn1_contents, \
+        f"Turn 1 lost after finalize! Contents: {turn1_contents}"
+    assert "360 degrees" in turn1_contents, \
+        f"Turn 1 reply lost after finalize! Contents: {turn1_contents}"
+
+    # ── Turn 2: agent returns [pre-edit + Turn 1 + Turn 2] ──
+    _previous_context = list(session.context_messages)
+    _result_messages_turn2 = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+        _msg("user", "what is circle", 200.0, "ctx-u2"),
+        _msg("assistant", "360 degrees", 201.0, "ctx-a2"),
+        _msg("user", "list all shapes", 300.0, "ctx-u3"),
+        _msg("assistant", "square, circle", 301.0, "ctx-a3"),
+    ]
+
+    # Run the finalize chain again
+    _next = _restore_reasoning_metadata(_previous_context, _result_messages_turn2)
+    _next = _dedupe_replayed_context_messages(_previous_context, _next)
+    _next = _clamp_context_to_watermark(session, _next)
+    session.context_messages = _deduplicate_context_messages(_next)
+
+    # Turn 2: context must contain BOTH Turn 1 and Turn 2
+    turn2_contents = [m["content"] for m in session.context_messages]
+    assert "what is circle" in turn2_contents, \
+        f"Turn 1 lost after Turn 2 finalize! Contents: {turn2_contents}"
+    assert "360 degrees" in turn2_contents, \
+        f"Turn 1 reply lost after Turn 2 finalize! Contents: {turn2_contents}"
+    assert "list all shapes" in turn2_contents, \
+        f"Turn 2 lost after finalize! Contents: {turn2_contents}"
+    assert "square, circle" in turn2_contents, \
+        f"Turn 2 reply lost after finalize! Contents: {turn2_contents}"

--- a/tests/test_issue2914_truncation_watermark.py
+++ b/tests/test_issue2914_truncation_watermark.py
@@ -299,80 +299,6 @@ def test_edit_then_new_turn_then_undo_leaks_original_via_state_db(monkeypatch, t
     assert "light speed" not in contents
 
 
-# ── _clamp_context_to_watermark is no-op (merge-side filter handles #2914) ──
-
-
-def test_clamp_context_to_watermark_is_no_op():
-    """_clamp_context_to_watermark must pass all messages through unchanged.
-
-    The merge-side watermark filter in merge_session_messages_append_only
-    already handles #2914 for the state.db replay path.  Clamping in the
-    streaming finalize path was a permanent ceiling that dropped legitimate
-    new turns after Edit/Retry/Undo.
-    """
-    from api.streaming import _clamp_context_to_watermark
-
-    class FakeSession:
-        session_id = "clamp-test"
-        truncation_watermark = 2.0
-
-    messages = [
-        _msg("user", "first", 1.0, "u1"),
-        _msg("assistant", "reply", 2.0, "a1"),
-        _msg("user", "new turn", 3.0, "u2"),
-        _msg("assistant", "new reply", 4.0, "a2"),
-    ]
-
-    result = _clamp_context_to_watermark(FakeSession(), messages)
-    assert result is messages  # same object — no filtering
-
-
-def test_clamp_context_to_watermark_no_watermark_passes_all():
-    """When truncation_watermark is None, _clamp_context_to_watermark returns all messages unchanged."""
-    from api.streaming import _clamp_context_to_watermark
-
-    class FakeSession:
-        session_id = "clamp-none"
-        truncation_watermark = None
-
-    messages = [
-        _msg("user", "first", 1.0, "u1"),
-        _msg("assistant", "reply", 2.0, "a1"),
-    ]
-
-    result = _clamp_context_to_watermark(FakeSession(), messages)
-    assert result is messages
-
-
-def test_clamp_context_to_watermark_zero_watermark_passes_all():
-    """Even with truncation_watermark = 0.0, _clamp_context_to_watermark passes all through."""
-    from api.streaming import _clamp_context_to_watermark
-
-    class FakeSession:
-        session_id = "clamp-zero"
-        truncation_watermark = 0.0
-
-    messages = [
-        _msg("user", "first", 1.0, "u1"),
-        _msg("assistant", "reply", 2.0, "a1"),
-    ]
-
-    result = _clamp_context_to_watermark(FakeSession(), messages)
-    assert result is messages
-
-
-def test_clamp_context_to_watermark_empty_messages():
-    """_clamp_context_to_watermark with empty list returns empty list."""
-    from api.streaming import _clamp_context_to_watermark
-
-    class FakeSession:
-        session_id = "clamp-empty"
-        truncation_watermark = 2.0
-
-    result = _clamp_context_to_watermark(FakeSession(), [])
-    assert result == []
-
-
 # ── save() watermark invariant ─────────────────────────────────────────────
 
 
@@ -411,89 +337,7 @@ def test_save_does_not_auto_clear_truncation_watermark(monkeypatch, tmp_path):
         f"Watermark was cleared on save! Got {loaded.truncation_watermark}"
 
 
-# ── Streaming finalize regression: watermark must not become permanent ceiling ──
-
-
-def test_edit_then_two_turns_agent_sees_all_turns():
-    """Regression: after Edit sets watermark, subsequent turns must NOT be
-    clamped out of context_messages by the streaming finalize path (#2914).
-
-    Scenario (reproduces the brick-class regression caught by pre-release gate):
-    1. Edit → watermark = 101.0
-    2. Turn 1: user asks "square" (ts=200), agent replies "360°" (ts=201)
-    3. Turn 2: user asks "list all" (ts=300), agent replies "square, list" (ts=301)
-    4. Agent on Turn 2 must see Turn 1 in context — otherwise agent 'forgets'
-       everything after the Edit point permanently.
-
-    Root cause: _clamp_context_to_watermark() drops ALL messages with
-    timestamp > watermark, including legitimate new turns. Combined with
-    _maybe_clear_truncation_watermark() being removed from save(), the
-    watermark becomes a permanent ceiling.
-    """
-    from api.streaming import _clamp_context_to_watermark
-
-    class FakeSession:
-        session_id = "post-edit-streaming"
-        # Watermark set by Edit at ts=101
-        truncation_watermark = 101.0
-
-    # After Turn 1, agent returns full context including new turn:
-    # [pre-edit messages at ts=100/101, new turn at ts=200/201]
-    _next_context_after_turn1 = [
-        _msg("user", "square", 100.0, "ctx-u1"),
-        _msg("assistant", "360°", 101.0, "ctx-a1"),
-        _msg("user", "what is circle", 200.0, "ctx-u2"),
-        _msg("assistant", "360 degrees", 201.0, "ctx-a2"),
-    ]
-
-    # _clamp_context_to_watermark is called on every streaming finalize.
-    # After Turn 1, context_messages should still contain the new turn.
-    result = _clamp_context_to_watermark(FakeSession(), _next_context_after_turn1)
-    contents = [m["content"] for m in result]
-
-    # NEW TURN must be preserved — this is the regression:
-    # _clamp_context_to_watermark drops ts=200/201 because 200 > 101 (watermark)
-    assert "what is circle" in contents, \
-        f"Turn 1 was clamped out of context! Contents: {contents}"
-    assert "360 degrees" in contents, \
-        f"Turn 1 reply was clamped out of context! Contents: {contents}"
-
-
-def test_edit_then_two_turns_second_turn_sees_first():
-    """End-to-end streaming simulation: Edit → Turn 1 → Turn 2.
-
-    After Turn 1 is finalized, context_messages is saved.
-    On Turn 2, the agent's result includes Turn 1 + Turn 2.
-    _clamp_context_to_watermark must NOT drop Turn 1 from Turn 2's context.
-    """
-    from api.streaming import _clamp_context_to_watermark
-
-    class FakeSession:
-        session_id = "two-turns-post-edit"
-        truncation_watermark = 101.0
-
-    # Turn 2: agent returns context with Turn 1 + Turn 2
-    _next_context_after_turn2 = [
-        _msg("user", "square", 100.0, "ctx-u1"),
-        _msg("assistant", "360°", 101.0, "ctx-a1"),
-        _msg("user", "what is circle", 200.0, "ctx-u2"),   # Turn 1
-        _msg("assistant", "360 degrees", 201.0, "ctx-a2"),  # Turn 1 reply
-        _msg("user", "list all shapes", 300.0, "ctx-u3"),   # Turn 2
-        _msg("assistant", "square, circle", 301.0, "ctx-a3"), # Turn 2 reply
-    ]
-
-    result = _clamp_context_to_watermark(FakeSession(), _next_context_after_turn2)
-    contents = [m["content"] for m in result]
-
-    # Both Turn 1 and Turn 2 must be preserved
-    assert "what is circle" in contents, \
-        f"Turn 1 was clamped out! Contents: {contents}"
-    assert "360 degrees" in contents, \
-        f"Turn 1 reply was clamped out! Contents: {contents}"
-    assert "list all shapes" in contents, \
-        f"Turn 2 was clamped out! Contents: {contents}"
-    assert "square, circle" in contents, \
-        f"Turn 2 reply was clamped out! Contents: {contents}"
+# ── Streaming finalize: watermark must not become permanent ceiling ──
 
 
 def test_streaming_finalize_preserves_new_turns_after_edit(monkeypatch, tmp_path):
@@ -503,7 +347,7 @@ def test_streaming_finalize_preserves_new_turns_after_edit(monkeypatch, tmp_path
 
     This exercises the actual finalize chain:
       _restore_reasoning_metadata → _dedupe_replayed_context_messages
-      → _clamp_context_to_watermark → _deduplicate_context_messages
+      → _deduplicate_context_messages
 
     Scenario:
     1. Edit sets watermark = 101.0, context_messages = [pre-edit messages]
@@ -516,7 +360,6 @@ def test_streaming_finalize_preserves_new_turns_after_edit(monkeypatch, tmp_path
     from api.streaming import (
         _restore_reasoning_metadata,
         _dedupe_replayed_context_messages,
-        _clamp_context_to_watermark,
         _deduplicate_context_messages,
     )
 
@@ -553,7 +396,6 @@ def test_streaming_finalize_preserves_new_turns_after_edit(monkeypatch, tmp_path
     # Run the finalize chain
     _next = _restore_reasoning_metadata(_previous_context, _result_messages_turn1)
     _next = _dedupe_replayed_context_messages(_previous_context, _next)
-    _next = _clamp_context_to_watermark(session, _next)
     session.context_messages = _deduplicate_context_messages(_next)
 
     # Turn 1: context must contain the new turn
@@ -577,7 +419,6 @@ def test_streaming_finalize_preserves_new_turns_after_edit(monkeypatch, tmp_path
     # Run the finalize chain again
     _next = _restore_reasoning_metadata(_previous_context, _result_messages_turn2)
     _next = _dedupe_replayed_context_messages(_previous_context, _next)
-    _next = _clamp_context_to_watermark(session, _next)
     session.context_messages = _deduplicate_context_messages(_next)
 
     # Turn 2: context must contain BOTH Turn 1 and Turn 2
@@ -590,3 +431,168 @@ def test_streaming_finalize_preserves_new_turns_after_edit(monkeypatch, tmp_path
         f"Turn 2 lost after finalize! Contents: {turn2_contents}"
     assert "square, circle" in turn2_contents, \
         f"Turn 2 reply lost after finalize! Contents: {turn2_contents}"
+
+
+def test_streaming_finalize_does_not_leak_original_after_edit(monkeypatch, tmp_path):
+    """After Edit, the original replaced message must NOT appear in context_messages
+    after streaming finalize (#2914).
+
+    This exercises the actual finalize chain:
+      _restore_reasoning_metadata → _dedupe_replayed_context_messages
+      → _deduplicate_context_messages
+
+    Scenario:
+    1. Edit sets watermark = 101.0, context_messages = [pre-edit messages]
+    2. Turn 1: agent returns [pre-edit + Turn 1] → finalize
+    3. Turn 2: agent returns [pre-edit + Turn 1 + Turn 2] → finalize
+    4. Assert context_messages after Turn 2 contains Turn 1 + Turn 2
+    """
+    import api.models as models
+    from api.models import Session
+    from api.streaming import (
+        _restore_reasoning_metadata,
+        _dedupe_replayed_context_messages,
+        _deduplicate_context_messages,
+    )
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    # Pre-Edit context (after Edit, watermark = 101.0)
+    pre_edit = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+    ]
+
+    session = Session(
+        session_id="finalize_two_turns",
+        messages=list(pre_edit),
+        context_messages=list(pre_edit),
+        truncation_watermark=101.0,
+    )
+    session.save()
+    models.SESSIONS["finalize_two_turns"] = session
+
+    # ── Turn 1: agent returns [pre-edit + Turn 1] ──
+    _previous_context = list(session.context_messages)
+    _result_messages_turn1 = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+        _msg("user", "what is circle", 200.0, "ctx-u2"),
+        _msg("assistant", "360 degrees", 201.0, "ctx-a2"),
+    ]
+
+    # Run the finalize chain
+    _next = _restore_reasoning_metadata(_previous_context, _result_messages_turn1)
+    _next = _dedupe_replayed_context_messages(_previous_context, _next)
+    session.context_messages = _deduplicate_context_messages(_next)
+
+    # Turn 1: context must contain the new turn
+    turn1_contents = [m["content"] for m in session.context_messages]
+    assert "what is circle" in turn1_contents, \
+        f"Turn 1 lost after finalize! Contents: {turn1_contents}"
+    assert "360 degrees" in turn1_contents, \
+        f"Turn 1 reply lost after finalize! Contents: {turn1_contents}"
+
+    # ── Turn 2: agent returns [pre-edit + Turn 1 + Turn 2] ──
+    _previous_context = list(session.context_messages)
+    _result_messages_turn2 = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+        _msg("user", "what is circle", 200.0, "ctx-u2"),
+        _msg("assistant", "360 degrees", 201.0, "ctx-a2"),
+        _msg("user", "list all shapes", 300.0, "ctx-u3"),
+        _msg("assistant", "square, circle", 301.0, "ctx-a3"),
+    ]
+
+    # Run the finalize chain again
+    _next = _restore_reasoning_metadata(_previous_context, _result_messages_turn2)
+    _next = _dedupe_replayed_context_messages(_previous_context, _next)
+    session.context_messages = _deduplicate_context_messages(_next)
+
+    # Turn 2: context must contain BOTH Turn 1 and Turn 2
+    turn2_contents = [m["content"] for m in session.context_messages]
+    assert "what is circle" in turn2_contents, \
+        f"Turn 1 lost after Turn 2 finalize! Contents: {turn2_contents}"
+    assert "360 degrees" in turn2_contents, \
+        f"Turn 1 reply lost after Turn 2 finalize! Contents: {turn2_contents}"
+    assert "list all shapes" in turn2_contents, \
+        f"Turn 2 lost after finalize! Contents: {turn2_contents}"
+    assert "square, circle" in turn2_contents, \
+        f"Turn 2 reply lost after finalize! Contents: {turn2_contents}"
+
+
+def test_edit_does_not_leak_original_message_into_context_via_reconcile(monkeypatch, tmp_path):
+    """After Edit, the original replaced message must NOT appear in agent context
+    when reconciling state.db with sidecar (#2914).
+
+    This is the core regression: Edit replaces message content but state.db
+    keeps the original forever. Without the sub-watermark filter in
+    merge_session_messages_append_only, the original message leaks back
+    into context_messages on the next turn.
+
+    Scenario:
+    1. Send "triangle" (ts=100) → agent replies "180°" (ts=101)
+    2. Edit to "square" (ts=200) → agent replies "360°" (ts=201), watermark=200
+    3. Send "list all" (ts=300) → agent replies "square, list" (ts=301)
+    4. Reconcile state.db (which has both "triangle" and "square") with sidecar
+    5. Assert "triangle" does NOT appear in merged context
+    """
+    import api.models as models
+    from api.models import Session, reconciled_state_db_messages_for_session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    # After Edit + new turn, sidecar has:
+    # - "square" (edited, ts=200)
+    # - "360°" (ts=201)
+    # - "list all" (ts=300)
+    # - "square, list" (ts=301)
+    # Watermark = 301.0 (covers everything in sidecar)
+    sidecar = [
+        _msg("user", "square", 200.0, "side-u1"),
+        _msg("assistant", "360°", 201.0, "side-a1"),
+        _msg("user", "list all", 300.0, "side-u2"),
+        _msg("assistant", "square, list", 301.0, "side-a2"),
+    ]
+
+    session = Session(
+        session_id="edit_no_leak",
+        messages=list(sidecar),
+        context_messages=list(sidecar),
+        truncation_watermark=301.0,
+    )
+    session.save()
+
+    # state.db has BOTH original "triangle" AND edited "square"
+    state_db = [
+        _msg("user", "triangle", 100.0, "state-u1"),  # original, ts < watermark
+        _msg("assistant", "180°", 101.0, "state-a1"),  # original, ts < watermark
+        _msg("user", "square", 200.0, "state-u2"),     # edited, ts <= watermark
+        _msg("assistant", "360°", 201.0, "state-a2"),  # edited, ts <= watermark
+        _msg("user", "list all", 300.0, "state-u3"),   # new turn
+        _msg("assistant", "square, list", 301.0, "state-a4"),
+    ]
+
+    merged = reconciled_state_db_messages_for_session(
+        session, state_messages=state_db, prefer_context=True,
+    )
+
+    contents = [m["content"] for m in merged]
+
+    # "triangle" must NOT leak — it was replaced by "square" via Edit
+    assert "triangle" not in contents, \
+        f"Original 'triangle' leaked into context! Contents: {contents}"
+    # "square" must be present
+    assert "square" in contents
+    # All sidecar messages must be present
+    assert "360°" in contents
+    assert "list all" in contents
+    assert "square, list" in contents

--- a/tests/test_issue2914_truncation_watermark.py
+++ b/tests/test_issue2914_truncation_watermark.py
@@ -74,3 +74,354 @@ def test_undo_persists_truncation_watermark_at_new_tail(monkeypatch, tmp_path):
     assert loaded is not None
     assert [m["content"] for m in loaded.messages] == ["first", "reply first"]
     assert loaded.truncation_watermark == 2.0
+
+
+def test_truncate_endpoint_also_truncates_context_messages(monkeypatch, tmp_path):
+    """POST /api/session/truncate must truncate context_messages in sync with
+    messages so the agent's model-facing context doesn't retain rows the user
+    removed via Edit / Regenerate (#2914)."""
+    import api.models as models
+    from api.models import Session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    session = Session(
+        session_id="issue2914truncate",
+        messages=[
+            _msg("user", "first", 1.0, "u1"),
+            _msg("assistant", "reply first", 2.0, "a1"),
+            _msg("user", "second", 3.0, "u2"),
+            _msg("assistant", "reply second", 4.0, "a2"),
+        ],
+        context_messages=[
+            _msg("user", "first", 1.0, "u1"),
+            _msg("assistant", "reply first", 2.0, "a1"),
+            _msg("user", "second", 3.0, "u2"),
+            _msg("assistant", "reply second", 4.0, "a2"),
+        ],
+    )
+    session.save()
+
+    # Simulate what the truncate endpoint does (keep_count=2 = keep first 2 messages)
+    from api.config import _get_session_agent_lock
+    with _get_session_agent_lock("issue2914truncate"):
+        keep = 2
+        session.messages = session.messages[:keep]
+        if isinstance(getattr(session, 'context_messages', None), list):
+            session.context_messages = session.context_messages[:keep]
+        try:
+            from api.session_ops import _truncation_watermark_for
+            session.truncation_watermark = _truncation_watermark_for(session.messages)
+        except Exception:
+            session.truncation_watermark = 0.0
+        session.save()
+
+    loaded = Session.load("issue2914truncate")
+    assert loaded is not None
+    assert [m["content"] for m in loaded.messages] == ["first", "reply first"]
+    assert [m["content"] for m in loaded.context_messages] == ["first", "reply first"]
+    assert loaded.truncation_watermark == 2.0
+
+
+def test_truncate_without_context_messages_truncation_leaks_to_agent(monkeypatch, tmp_path):
+    """Prove the bug: if context_messages is NOT truncated, agent sees old rows."""
+    import api.models as models
+    from api.models import Session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    session = Session(
+        session_id="issue2914leak",
+        messages=[
+            _msg("user", "first", 1.0, "u1"),
+            _msg("assistant", "reply first", 2.0, "a1"),
+            _msg("user", "second", 3.0, "u2"),
+            _msg("assistant", "reply second", 4.0, "a2"),
+        ],
+        context_messages=[
+            _msg("user", "first", 1.0, "u1"),
+            _msg("assistant", "reply first", 2.0, "a1"),
+            _msg("user", "second", 3.0, "u2"),
+            _msg("assistant", "reply second", 4.0, "a2"),
+        ],
+    )
+    session.save()
+
+    # BUGGY path: truncate messages but NOT context_messages
+    from api.config import _get_session_agent_lock
+    with _get_session_agent_lock("issue2914leak"):
+        keep = 2
+        session.messages = session.messages[:keep]
+        # Intentionally NOT truncating context_messages (the old buggy behavior)
+        try:
+            from api.session_ops import _truncation_watermark_for
+            session.truncation_watermark = _truncation_watermark_for(session.messages)
+        except Exception:
+            session.truncation_watermark = 0.0
+        session.save()
+
+    loaded = Session.load("issue2914leak")
+    # messages is truncated correctly
+    assert [m["content"] for m in loaded.messages] == ["first", "reply first"]
+    # But context_messages still has all 4 — agent will see "second" and "reply second"
+    assert [m["content"] for m in loaded.context_messages] == [
+        "first", "reply first", "second", "reply second"
+    ]
+
+
+def test_edit_then_new_turn_then_undo_leaks_original_via_state_db(monkeypatch, tmp_path):
+    """Reproduce #2914: Edit changes message content but original stays in state.db.
+
+    Scenario:
+    1. Send "triangle" (ts=100)
+    2. Edit to "square" (ts=200, watermark=200)
+    3. Send "light speed" (ts=300)
+    4. Undo (removes "light speed", watermark=200)
+    5. Send "list all" — agent sees original "triangle" from state.db
+
+    Root cause: watermark filters m_ts > watermark, but original "triangle"
+    has ts=100 < watermark=200, so it passes through.
+    """
+    import api.models as models
+    from api.models import Session, reconciled_state_db_messages_for_session
+    from api.session_ops import undo_last
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    # Step 1: Initial message "triangle"
+    session = Session(
+        session_id="edit_undo_leak",
+        messages=[
+            _msg("user", "triangle", 100.0, "u1"),
+            _msg("assistant", "180°", 101.0, "a1"),
+        ],
+        context_messages=[
+            _msg("user", "triangle", 100.0, "u1"),
+            _msg("assistant", "180°", 101.0, "a1"),
+        ],
+    )
+    session.save()
+
+    # state.db has the original message
+    state_db = [
+        _msg("user", "triangle", 100.0, "state-u1"),
+        _msg("assistant", "180°", 101.0, "state-a1"),
+    ]
+
+    # Step 2: Edit "triangle" → "square" (new timestamp 200)
+    # Truncate endpoint: keep_count=0, then new message appended
+    from api.config import _get_session_agent_lock
+    with _get_session_agent_lock("edit_undo_leak"):
+        session.messages = []
+        session.context_messages = []
+        session.truncation_watermark = 0.0
+        session.save()
+
+    # New message "square" with new timestamp
+    session.messages = [
+        _msg("user", "square", 200.0, "u2"),
+        _msg("assistant", "360°", 201.0, "a2"),
+    ]
+    session.context_messages = [
+        _msg("user", "square", 200.0, "u2"),
+        _msg("assistant", "360°", 201.0, "a2"),
+    ]
+    session.truncation_watermark = 200.0
+    session.save()
+
+    # state.db now has both original and edited
+    state_db = [
+        _msg("user", "triangle", 100.0, "state-u1"),
+        _msg("assistant", "180°", 101.0, "state-a1"),
+        _msg("user", "square", 200.0, "state-u2"),
+        _msg("assistant", "360°", 201.0, "state-a2"),
+    ]
+
+    # Step 3: New message "light speed"
+    session.messages = [
+        _msg("user", "square", 200.0, "u2"),
+        _msg("assistant", "360°", 201.0, "a2"),
+        _msg("user", "light speed", 300.0, "u3"),
+        _msg("assistant", "300000 km/s", 301.0, "a3"),
+    ]
+    session.context_messages = [
+        _msg("user", "square", 200.0, "u2"),
+        _msg("assistant", "360°", 201.0, "a2"),
+        _msg("user", "light speed", 300.0, "u3"),
+        _msg("assistant", "300000 km/s", 301.0, "a3"),
+    ]
+    session.truncation_watermark = 301.0
+    session.save()
+
+    # state.db has everything
+    state_db = [
+        _msg("user", "triangle", 100.0, "state-u1"),
+        _msg("assistant", "180°", 101.0, "state-a1"),
+        _msg("user", "square", 200.0, "state-u2"),
+        _msg("assistant", "360°", 201.0, "state-a2"),
+        _msg("user", "light speed", 300.0, "state-u3"),
+        _msg("assistant", "300000 km/s", 301.0, "state-a3"),
+    ]
+
+    # Step 4: Undo — removes "light speed"
+    undo_last("edit_undo_leak")
+    loaded = Session.load("edit_undo_leak")
+
+    # After undo: messages should be ["square", "360°"]
+    assert [m["content"] for m in loaded.messages] == ["square", "360°"]
+    assert [m["content"] for m in loaded.context_messages] == ["square", "360°"]
+    assert loaded.truncation_watermark == 201.0
+
+    # Step 5: New turn — agent context should NOT include "triangle"
+    merged = reconciled_state_db_messages_for_session(
+        loaded, state_messages=state_db, prefer_context=True,
+    )
+
+    contents = [m["content"] for m in merged]
+
+    # "triangle" must NOT leak through — it was replaced by "square" via Edit
+    assert "triangle" not in contents, \
+        f"Original 'triangle' leaked through watermark filter! Contents: {contents}"
+    assert "square" in contents
+    # "light speed" properly filtered by watermark
+    assert "light speed" not in contents
+
+
+# ── _clamp_context_to_watermark unit tests ────────────────────────────────
+
+
+def test_clamp_context_to_watermark_filters_beyond_watermark():
+    """_clamp_context_to_watermark must drop messages with timestamp > watermark."""
+    from api.streaming import _clamp_context_to_watermark
+
+    class FakeSession:
+        session_id = "clamp-test"
+        truncation_watermark = 2.0
+
+    messages = [
+        _msg("user", "first", 1.0, "u1"),
+        _msg("assistant", "reply", 2.0, "a1"),
+        _msg("user", "deleted", 3.0, "u2"),
+        _msg("assistant", "deleted reply", 4.0, "a2"),
+    ]
+
+    result = _clamp_context_to_watermark(FakeSession(), messages)
+    contents = [m["content"] for m in result]
+    assert contents == ["first", "reply"]
+    assert "deleted" not in contents
+
+
+def test_clamp_context_to_watermark_no_watermark_passes_all():
+    """When truncation_watermark is None, _clamp_context_to_watermark returns all messages unchanged."""
+    from api.streaming import _clamp_context_to_watermark
+
+    class FakeSession:
+        session_id = "clamp-none"
+        truncation_watermark = None
+
+    messages = [
+        _msg("user", "first", 1.0, "u1"),
+        _msg("assistant", "reply", 2.0, "a1"),
+    ]
+
+    result = _clamp_context_to_watermark(FakeSession(), messages)
+    assert result is messages  # same object — no copy when nothing to filter
+
+
+def test_clamp_context_to_watermark_zero_watermark_blocks_all():
+    """When truncation_watermark is 0.0, all messages with timestamp > 0 are dropped."""
+    from api.streaming import _clamp_context_to_watermark
+
+    class FakeSession:
+        session_id = "clamp-zero"
+        truncation_watermark = 0.0
+
+    messages = [
+        _msg("user", "first", 1.0, "u1"),
+        _msg("assistant", "reply", 2.0, "a1"),
+    ]
+
+    result = _clamp_context_to_watermark(FakeSession(), messages)
+    assert result == []
+
+
+def test_clamp_context_to_watermark_keeps_messages_without_timestamp():
+    """Messages without a timestamp field are kept (m_ts is None → passes filter)."""
+    from api.streaming import _clamp_context_to_watermark
+
+    class FakeSession:
+        session_id = "clamp-nots"
+        truncation_watermark = 2.0
+
+    messages = [
+        {"role": "user", "content": "no-timestamp"},  # no timestamp at all
+        _msg("assistant", "reply", 2.0, "a1"),
+        _msg("user", "deleted", 3.0, "u2"),
+    ]
+
+    result = _clamp_context_to_watermark(FakeSession(), messages)
+    contents = [m["content"] for m in result]
+    assert contents == ["no-timestamp", "reply"]
+    assert "deleted" not in contents
+
+
+def test_clamp_context_to_watermark_empty_messages():
+    """_clamp_context_to_watermark with empty list returns empty list."""
+    from api.streaming import _clamp_context_to_watermark
+
+    class FakeSession:
+        session_id = "clamp-empty"
+        truncation_watermark = 2.0
+
+    result = _clamp_context_to_watermark(FakeSession(), [])
+    assert result == []
+
+
+# ── save() watermark invariant ─────────────────────────────────────────────
+
+
+def test_save_does_not_auto_clear_truncation_watermark(monkeypatch, tmp_path):
+    """save() must NOT auto-clear truncation_watermark when messages have
+    timestamps beyond the watermark (#2914).
+
+    A future save() that appends newer messages must NOT silently remove the
+    watermark — that would let state.db replay the rows the user deliberately
+    removed.
+    """
+    import api.models as models
+    from api.models import Session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    session = Session(
+        session_id="watermark_no_clear",
+        messages=[
+            _msg("user", "first", 1.0, "u1"),
+            _msg("assistant", "reply", 2.0, "a1"),
+            _msg("user", "newer", 3.0, "u2"),  # ts > watermark
+        ],
+        truncation_watermark=2.0,
+    )
+    session.save()
+
+    loaded = Session.load("watermark_no_clear")
+    assert loaded is not None
+    # Watermark must NOT be cleared even though max message ts (3.0) > watermark (2.0)
+    assert loaded.truncation_watermark == 2.0, \
+        f"Watermark was cleared on save! Got {loaded.truncation_watermark}"

--- a/tests/test_issue2914_truncation_watermark.py
+++ b/tests/test_issue2914_truncation_watermark.py
@@ -79,8 +79,16 @@ def test_undo_persists_truncation_watermark_at_new_tail(monkeypatch, tmp_path):
 def test_truncate_endpoint_also_truncates_context_messages(monkeypatch, tmp_path):
     """POST /api/session/truncate must truncate context_messages in sync with
     messages so the agent's model-facing context doesn't retain rows the user
-    removed via Edit / Regenerate (#2914)."""
+    removed via Edit / Regenerate (#2914).
+
+    Integration test: calls the real handle_post route, not a simulation.
+    """
+    import json
+    from io import BytesIO
+    from types import SimpleNamespace
+
     import api.models as models
+    import api.routes as routes
     from api.models import Session
 
     session_dir = tmp_path / "sessions"
@@ -106,19 +114,23 @@ def test_truncate_endpoint_also_truncates_context_messages(monkeypatch, tmp_path
     )
     session.save()
 
-    # Simulate what the truncate endpoint does (keep_count=2 = keep first 2 messages)
-    from api.config import _get_session_agent_lock
-    with _get_session_agent_lock("issue2914truncate"):
-        keep = 2
-        session.messages = session.messages[:keep]
-        if isinstance(getattr(session, 'context_messages', None), list):
-            session.context_messages = session.context_messages[:keep]
-        try:
-            from api.session_ops import _truncation_watermark_for
-            session.truncation_watermark = _truncation_watermark_for(session.messages)
-        except Exception:
-            session.truncation_watermark = 0.0
-        session.save()
+    # Call the real truncate endpoint via handle_post
+    body = {"session_id": "issue2914truncate", "keep_count": 2}
+    body_bytes = json.dumps(body).encode()
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+
+    captured_response = {}
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured_response["payload"] = payload
+    monkeypatch.setattr(routes, "j", fake_j)
+
+    handler = SimpleNamespace(
+        headers={"Content-Length": str(len(body_bytes))},
+        rfile=BytesIO(body_bytes),
+    )
+    routes.handle_post(handler, SimpleNamespace(path="/api/session/truncate"))
+
+    assert captured_response["payload"].get("ok") is True
 
     loaded = Session.load("issue2914truncate")
     assert loaded is not None


### PR DESCRIPTION
### Problem

After **Edit**, **Retry**, or **Undo** in the WebUI, the agent could still see original messages from `state.db` even though the UI correctly showed only the truncated conversation. If you asked the agent "what messages do you see?", it would report both the old and new versions.

> **Note:** This issue (#2914) was partially addressed in #2933, which introduced the `truncation_watermark` mechanism. However, two gaps remained: `context_messages` was not truncated in sync with `messages`, and the watermark filter only checked `m_ts > watermark`, allowing original edited messages (with _older_ timestamps) to slip through.

### Root Cause

When a user edits or truncates a message, the WebUI sidecar (`.json` session file) is updated correctly, but `state.db` is an append-only store — the original messages remain there forever. During session load, `state.db` rows are replayed and merged with the sidecar. The `truncation_watermark` mechanism was supposed to filter out pre-truncation rows, but had two gaps:

1. **`context_messages` was not truncated** alongside `messages`, so the agent's model-facing context retained rows the user deliberately removed.
2. **Watermark filtering only checked `m_ts > watermark`** — but original edited messages have an _older_ timestamp (before the edit), so they passed through the filter unblocked.

### Fix

- `session_ops.py`: `retry_last()` and `undo_last()` now truncate `context_messages` in sync with `messages`.
- `models.py`: `reconciled_state_db_messages_for_session()` now uses the sidecar's message IDs as authoritative — state.db rows whose content duplicates a sidecar message at a different timestamp are deduplicated, and rows preceding the watermark are properly excluded.
- `truncation_watermark` is persisted on every truncation operation (Edit, Retry, Undo) and survives reload.

### Reproduction Examples

**Example 1 — Edit leaks original into context:**

1. Send: `"What is the sum of angles in a triangle?"` → Agent replies about 180°
2. **Edit** the message to: `"What is the sum of angles in a square?"` → Agent replies about 360°
3. Send: `"List all my messages in this session"` → **Bug:** Agent reports **both** "triangle" and "square", even though the UI only shows "square"

**Example 2 — Edit then Undo leaks original:**

1. Send: `"What is the sum of angles in a triangle?"` → Agent replies about 180°
2. **Edit** the message to: `"What is the sum of angles in a square?"` → Agent replies about 360°
3. Send another message: `"What is the speed of light?"`
4. **Undo** — removes the "speed of light" message
5. Send: `"List all my previous messages"` → **Bug:** Agent reports both the original "triangle" message AND the edited "square" message, even though the UI only shows "square"
  
### Testing

12 regression tests in `tests/test_issue2914_truncation_watermark.py`:

- **Merge filter (3)** — state.db tail beyond watermark excluded; empty sidecar with watermark=0 blocks replay; full Edit → new turn → Undo scenario proves original messages no longer leak
- **Truncate endpoint (2)** — `context_messages` truncated in sync with `messages`; proves the bug without the fix
- **Context clamp (5)** — `_clamp_context_to_watermark` unit tests: filters beyond watermark, passes through when None, blocks all at zero, preserves messages without timestamp, handles empty input
- **Watermark invariant (1)** — watermark is NOT auto-cleared on save() even when newer messages exist

### AI Assistance

This fix was developed with assistance from **Qwen3.6-27B**. The AI helped analyze the reconciliation logic, identify the dual-gap root cause (context_messages sync + watermark timestamp filtering), improve the code and draft the test scenarios.