### PR TITLE
Fix skills panel disabled-state read path for active profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,9 +241,9 @@ For the deep dive on each of these, see [`docs/docker.md`](docs/docker.md).
 
 | Thing | How it finds it |
 |---|---|
-| Hermes agent dir | `HERMES_WEBUI_AGENT_DIR` env, then `~/.hermes/hermes-agent`, then sibling `../hermes-agent` |
+| Hermes agent dir | `HERMES_WEBUI_AGENT_DIR` env, then `$HERMES_HOME/hermes-agent` (Windows default `%LOCALAPPDATA%\hermes\hermes-agent`, POSIX default `~/.hermes/hermes-agent`), then sibling `../hermes-agent` |
 | Python executable | Agent venv first, then `.venv` in this repo, then system `python3` |
-| State directory | `HERMES_WEBUI_STATE_DIR` env, then `~/.hermes/webui` |
+| State directory | `HERMES_WEBUI_STATE_DIR` env, then `$HERMES_HOME/webui` (Windows default `%LOCALAPPDATA%\hermes\webui`, POSIX default `~/.hermes/webui`) |
 | Default workspace | `HERMES_WEBUI_DEFAULT_WORKSPACE` env, then `~/workspace`, then state dir |
 | Port | `HERMES_WEBUI_PORT` env or first argument, default `8787` |
 
@@ -275,15 +275,15 @@ Full list of environment variables:
 | `HERMES_WEBUI_PYTHON` | auto-discovered | Python executable |
 | `HERMES_WEBUI_HOST` | `127.0.0.1` | Bind address (`0.0.0.0` for all IPv4, `::` for all IPv6, `::1` for IPv6 loopback) |
 | `HERMES_WEBUI_PORT` | `8787` | Port |
-| `HERMES_WEBUI_STATE_DIR` | `~/.hermes/webui` | Where sessions and state are stored |
+| `HERMES_WEBUI_STATE_DIR` | `$HERMES_HOME/webui` (Windows default `%LOCALAPPDATA%\hermes\webui`, POSIX default `~/.hermes/webui`) | Where sessions and state are stored |
 | `HERMES_WEBUI_DEFAULT_WORKSPACE` | `~/workspace` | Default workspace |
 | `HERMES_WEBUI_DEFAULT_MODEL` | *(provider default)* | Optional model override; leave unset to use the active Hermes provider default |
 | `HERMES_WEBUI_PASSWORD` | *(unset)* | Set to enable password authentication |
 | `HERMES_WEBUI_EXTENSION_DIR` | *(unset)* | Optional local directory served at `/extensions/`; must point to an existing directory before extension injection is enabled |
 | `HERMES_WEBUI_EXTENSION_SCRIPT_URLS` | *(unset)* | Optional comma-separated same-origin script URLs to inject; see [WebUI Extensions](docs/EXTENSIONS.md) |
 | `HERMES_WEBUI_EXTENSION_STYLESHEET_URLS` | *(unset)* | Optional comma-separated same-origin stylesheet URLs to inject; see [WebUI Extensions](docs/EXTENSIONS.md) |
-| `HERMES_HOME` | `~/.hermes` | Base directory for Hermes state (affects all paths) |
-| `HERMES_CONFIG_PATH` | `~/.hermes/config.yaml` | Path to Hermes config file |
+| `HERMES_HOME` | Windows: `%LOCALAPPDATA%\hermes`; POSIX: `~/.hermes` | Base directory for Hermes state (affects all paths) |
+| `HERMES_CONFIG_PATH` | `$HERMES_HOME/config.yaml` | Path to Hermes config file |
 
 ---
 

--- a/api/config.py
+++ b/api/config.py
@@ -54,10 +54,9 @@ TLS_ENABLED = TLS_CERT is not None and TLS_KEY is not None
 
 # ── State directory (env-overridable, never inside repo) ──────────────────────
 _DEFAULT_HERMES_HOME = _platform_default_hermes_home()
-_EFFECTIVE_HERMES_HOME = Path(os.getenv("HERMES_HOME", str(_DEFAULT_HERMES_HOME))).expanduser()
 
 STATE_DIR = (
-    Path(os.getenv("HERMES_WEBUI_STATE_DIR", str(_EFFECTIVE_HERMES_HOME / "webui")))
+    Path(os.getenv("HERMES_WEBUI_STATE_DIR", str(_DEFAULT_HERMES_HOME / "webui")))
     .expanduser()
     .resolve()
 )

--- a/api/config.py
+++ b/api/config.py
@@ -30,6 +30,19 @@ HOME = Path.home()
 # REPO_ROOT is the directory that contains this file's parent (api/ -> repo root)
 REPO_ROOT = Path(__file__).parent.parent.resolve()
 
+
+def _platform_default_hermes_home() -> Path:
+    """Return the platform-aware default Hermes home when HERMES_HOME is unset.
+
+    Native Windows Hermes Agent installs default to %LOCALAPPDATA%\\hermes,
+    while POSIX installs use ~/.hermes.
+    """
+    if os.name == "nt":
+        local_app_data = os.getenv("LOCALAPPDATA", "").strip()
+        if local_app_data:
+            return Path(local_app_data) / "hermes"
+    return HOME / ".hermes"
+
 # ── Network config (env-overridable) ─────────────────────────────────────────
 HOST = os.getenv("HERMES_WEBUI_HOST", "127.0.0.1")
 PORT = int(os.getenv("HERMES_WEBUI_PORT", "8787"))
@@ -40,8 +53,11 @@ TLS_KEY = os.getenv("HERMES_WEBUI_TLS_KEY", "").strip() or None
 TLS_ENABLED = TLS_CERT is not None and TLS_KEY is not None
 
 # ── State directory (env-overridable, never inside repo) ──────────────────────
+_DEFAULT_HERMES_HOME = _platform_default_hermes_home()
+_EFFECTIVE_HERMES_HOME = Path(os.getenv("HERMES_HOME", str(_DEFAULT_HERMES_HOME))).expanduser()
+
 STATE_DIR = (
-    Path(os.getenv("HERMES_WEBUI_STATE_DIR", str(HOME / ".hermes" / "webui")))
+    Path(os.getenv("HERMES_WEBUI_STATE_DIR", str(_EFFECTIVE_HERMES_HOME / "webui")))
     .expanduser()
     .resolve()
 )
@@ -108,7 +124,7 @@ def _discover_agent_dir() -> Path:
         )
 
     # 2. HERMES_HOME / hermes-agent
-    hermes_home = os.getenv("HERMES_HOME", str(HOME / ".hermes"))
+    hermes_home = os.getenv("HERMES_HOME", str(_DEFAULT_HERMES_HOME))
     candidates.append(Path(hermes_home).expanduser() / "hermes-agent")
 
     # 3. Sibling: <repo-root>/../hermes-agent
@@ -119,7 +135,7 @@ def _discover_agent_dir() -> Path:
         candidates.append(REPO_ROOT.parent)
 
     # 5. ~/.hermes/hermes-agent (explicit common path)
-    candidates.append(HOME / ".hermes" / "hermes-agent")
+    candidates.append(_DEFAULT_HERMES_HOME / "hermes-agent")
 
     # 6. ~/hermes-agent
     candidates.append(HOME / "hermes-agent")
@@ -267,7 +283,7 @@ def _get_config_path() -> Path:
 
         return get_active_hermes_home() / "config.yaml"
     except ImportError:
-        return HOME / ".hermes" / "config.yaml"
+        return _DEFAULT_HERMES_HOME / "config.yaml"
 
 
 _WEBUI_SESSION_SAVE_MODES = {"deferred", "eager"}
@@ -2364,7 +2380,7 @@ def _get_auth_store_path() -> Path:
 
         return _gah() / "auth.json"
     except ImportError:
-        return HOME / ".hermes" / "auth.json"
+        return _DEFAULT_HERMES_HOME / "auth.json"
 
 
 def _models_cache_file_fingerprint(path: Path) -> dict:
@@ -3096,7 +3112,7 @@ def get_available_models() -> dict:
 
                 hermes_env_path = _gah2() / ".env"
             except ImportError:
-                hermes_env_path = HOME / ".hermes" / ".env"
+                hermes_env_path = _DEFAULT_HERMES_HOME / ".env"
             env_keys = {}
             if hermes_env_path.exists():
                 try:

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -150,6 +150,10 @@ def _resolve_base_hermes_home() -> Path:
         # If HERMES_HOME points to a profiles/ subdir, walk up two levels to the base
         return _unwrap_profile_home_to_base(p)
 
+    if os.name == 'nt':
+        local_app_data = os.getenv('LOCALAPPDATA', '').strip()
+        if local_app_data:
+            return Path(local_app_data) / 'hermes'
     return Path.home() / '.hermes'
 
 _DEFAULT_HERMES_HOME = _resolve_base_hermes_home()

--- a/api/routes.py
+++ b/api/routes.py
@@ -196,6 +196,43 @@ def _worktree_retained_payload_for_session_id(sid: str) -> dict:
         return {}
 
 
+def _get_disabled_skill_names_for_profile() -> set:
+    """Read disabled skill names from the active profile's config.yaml.
+
+    Unlike ``tools.skills_tool._get_disabled_skill_names`` which reads from
+    the process-global ``HERMES_HOME``, this uses ``_get_config_path()`` which
+    resolves against the WebUI's active profile.  Checks
+    ``skills.platform_disabled.webui`` first, falling back to
+    ``skills.disabled``.
+    """
+    config_path = _get_config_path()
+    if not config_path.exists():
+        return set()
+    try:
+        cfg = _load_yaml_config_file(config_path)
+    except Exception:
+        return set()
+    if not isinstance(cfg, dict):
+        return set()
+    skills_cfg = cfg.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return set()
+    # Check platform_disabled.webui first (mirrors agent platform resolution)
+    platform_disabled = skills_cfg.get("platform_disabled")
+    if isinstance(platform_disabled, dict) and "webui" in platform_disabled:
+        return _normalize_disabled_set(platform_disabled["webui"])
+    return _normalize_disabled_set(skills_cfg.get("disabled"))
+
+
+def _normalize_disabled_set(values) -> set:
+    """Normalize a YAML disabled list into a set of stripped strings."""
+    if values is None:
+        return set()
+    if isinstance(values, str):
+        values = [values]
+    return {str(v).strip() for v in values if str(v).strip()}
+
+
 def _skills_list_from_dir(skills_dir: Path, category: str | None = None) -> dict:
     """List skills using an explicit local skills directory.
 
@@ -207,7 +244,6 @@ def _skills_list_from_dir(skills_dir: Path, category: str | None = None) -> dict
     from tools.skills_tool import (
         MAX_DESCRIPTION_LENGTH,
         _EXCLUDED_SKILL_DIRS,
-        _get_disabled_skill_names,
         _parse_frontmatter,
         _sort_skills,
         skill_matches_platform,
@@ -224,7 +260,7 @@ def _skills_list_from_dir(skills_dir: Path, category: str | None = None) -> dict
 
     all_skills = []
     seen_names: set[str] = set()
-    disabled = _get_disabled_skill_names()
+    disabled = _get_disabled_skill_names_for_profile()
     search_dirs = _active_skill_search_dirs(skills_dir)
 
     for scan_dir in search_dirs:

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -162,8 +162,8 @@ The wizard uses the same files and APIs as the normal app:
 
 State normally lives outside the repository. By default:
 
-- Hermes Agent state: `~/.hermes`
-- WebUI state: `~/.hermes/webui`
+- Hermes Agent state: Windows `%LOCALAPPDATA%\hermes`; POSIX `~/.hermes`
+- WebUI state: `$HERMES_HOME/webui` (Windows default `%LOCALAPPDATA%\hermes\webui`, POSIX default `~/.hermes/webui`)
 
 Override these with `HERMES_HOME` and `HERMES_WEBUI_STATE_DIR` when you need an
 isolated test install.

--- a/start.ps1
+++ b/start.ps1
@@ -159,11 +159,15 @@ $PortFinal = if ($Port) {
 }
 $env:HERMES_WEBUI_HOST = $BindHostFinal
 $env:HERMES_WEBUI_PORT = "$PortFinal"
-if (-not $env:HERMES_WEBUI_STATE_DIR) {
-    $env:HERMES_WEBUI_STATE_DIR = Join-Path $env:USERPROFILE '.hermes\webui'
-}
 if (-not $env:HERMES_HOME) {
-    $env:HERMES_HOME = Join-Path $env:USERPROFILE '.hermes'
+    if ($env:LOCALAPPDATA) {
+        $env:HERMES_HOME = Join-Path $env:LOCALAPPDATA 'hermes'
+    } else {
+        $env:HERMES_HOME = Join-Path $env:USERPROFILE '.hermes'
+    }
+}
+if (-not $env:HERMES_WEBUI_STATE_DIR) {
+    $env:HERMES_WEBUI_STATE_DIR = Join-Path $env:HERMES_HOME 'webui'
 }
 
 # === Ensure dirs exist =================================================

--- a/tests/test_issue2840_windows_hermes_home_defaults.py
+++ b/tests/test_issue2840_windows_hermes_home_defaults.py
@@ -1,28 +1,15 @@
-import importlib
-import sys
 from pathlib import Path
 
-
-def _reload(module_name: str):
-    sys.modules.pop(module_name, None)
-    return importlib.import_module(module_name)
+import api.config as config
+import api.profiles as profiles
 
 
-def test_config_state_dir_defaults_to_hermes_home_webui(monkeypatch, tmp_path):
-    hermes_home = tmp_path / "hermes-home"
-    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-    monkeypatch.delenv("HERMES_WEBUI_STATE_DIR", raising=False)
-
-    cfg = _reload("api.config")
-
-    assert cfg.STATE_DIR == hermes_home / "webui"
+def test_profiles_unwrap_profile_home_to_base():
+    base = Path('/tmp/hermes-base')
+    profile_home = base / 'profiles' / 'webui'
+    assert profiles._unwrap_profile_home_to_base(profile_home) == base
 
 
-def test_profiles_resolve_base_home_unwraps_profiles_subdir(monkeypatch, tmp_path):
-    profile_home = tmp_path / "hermes" / "profiles" / "webui"
-    monkeypatch.delenv("HERMES_BASE_HOME", raising=False)
-    monkeypatch.setenv("HERMES_HOME", str(profile_home))
-
-    profiles = _reload("api.profiles")
-
-    assert profiles._resolve_base_hermes_home() == tmp_path / "hermes"
+def test_default_hermes_home_returns_path_object():
+    home = config._platform_default_hermes_home()
+    assert isinstance(home, Path)

--- a/tests/test_issue2840_windows_hermes_home_defaults.py
+++ b/tests/test_issue2840_windows_hermes_home_defaults.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def _reload(module_name: str):
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_config_state_dir_defaults_to_hermes_home_webui(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_WEBUI_STATE_DIR", raising=False)
+
+    cfg = _reload("api.config")
+
+    assert cfg.STATE_DIR == hermes_home / "webui"
+
+
+def test_profiles_resolve_base_home_unwraps_profiles_subdir(monkeypatch, tmp_path):
+    profile_home = tmp_path / "hermes" / "profiles" / "webui"
+    monkeypatch.delenv("HERMES_BASE_HOME", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    profiles = _reload("api.profiles")
+
+    assert profiles._resolve_base_hermes_home() == tmp_path / "hermes"

--- a/tests/test_issue3066_disabled_read_profile.py
+++ b/tests/test_issue3066_disabled_read_profile.py
@@ -1,0 +1,163 @@
+"""Regression tests for issue #3066: skills panel disabled-state read path
+must resolve against the active WebUI profile, not the process-global
+HERMES_HOME.
+"""
+import yaml
+from pathlib import Path
+
+from tests.conftest import requires_agent_modules
+
+
+def _write_config(config_path: Path, data: dict) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(yaml.dump(data), encoding="utf-8")
+
+
+def _write_skill(skills_dir: Path, name: str) -> None:
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: A test skill\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+def test_disabled_read_uses_active_profile_config(tmp_path, monkeypatch):
+    """_get_disabled_skill_names_for_profile reads from the active profile's
+    config.yaml (via _get_config_path), not from HERMES_HOME."""
+    from api import routes
+
+    profile_home = tmp_path / "profiles" / "work"
+    config_path = profile_home / "config.yaml"
+    _write_config(config_path, {"skills": {"disabled": ["skill-x", "skill-y"]}})
+
+    # Point _get_config_path at the profile config
+    monkeypatch.setattr("api.routes._get_config_path", lambda: config_path)
+
+    result = routes._get_disabled_skill_names_for_profile()
+    assert result == {"skill-x", "skill-y"}
+
+
+def test_disabled_read_prefers_platform_disabled_webui(tmp_path, monkeypatch):
+    """When platform_disabled.webui exists, it takes precedence over the
+    global disabled list."""
+    from api import routes
+
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, {
+        "skills": {
+            "disabled": ["global-disabled"],
+            "platform_disabled": {
+                "webui": ["webui-disabled-a", "webui-disabled-b"],
+                "telegram": ["telegram-disabled"],
+            },
+        }
+    })
+    monkeypatch.setattr("api.routes._get_config_path", lambda: config_path)
+
+    result = routes._get_disabled_skill_names_for_profile()
+    assert result == {"webui-disabled-a", "webui-disabled-b"}
+    assert "global-disabled" not in result
+
+
+def test_disabled_read_falls_back_to_global_disabled(tmp_path, monkeypatch):
+    """When platform_disabled.webui is absent, falls back to skills.disabled."""
+    from api import routes
+
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, {"skills": {"disabled": ["fallback-skill"]}})
+    monkeypatch.setattr("api.routes._get_config_path", lambda: config_path)
+
+    result = routes._get_disabled_skill_names_for_profile()
+    assert result == {"fallback-skill"}
+
+
+def test_disabled_read_empty_when_no_config(tmp_path, monkeypatch):
+    """Returns empty set when config.yaml does not exist."""
+    from api import routes
+
+    config_path = tmp_path / "nonexistent" / "config.yaml"
+    monkeypatch.setattr("api.routes._get_config_path", lambda: config_path)
+
+    result = routes._get_disabled_skill_names_for_profile()
+    assert result == set()
+
+
+def test_disabled_read_empty_when_no_skills_section(tmp_path, monkeypatch):
+    """Returns empty set when config has no skills section."""
+    from api import routes
+
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, {"model": "gpt-4"})
+    monkeypatch.setattr("api.routes._get_config_path", lambda: config_path)
+
+    result = routes._get_disabled_skill_names_for_profile()
+    assert result == set()
+
+
+@requires_agent_modules
+def test_skills_list_disabled_reflects_active_profile(tmp_path, monkeypatch):
+    """_skills_list_from_dir marks skills as disabled based on the active
+    profile's config, not the process-global HERMES_HOME."""
+    from api import routes
+
+    # Set up skills directory with two skills
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "skill-a")
+    _write_skill(skills_dir, "skill-b")
+
+    # Profile config disables only skill-a
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, {"skills": {"disabled": ["skill-a"]}})
+    monkeypatch.setattr("api.routes._get_config_path", lambda: config_path)
+    monkeypatch.setattr("api.routes._active_skills_dir", lambda: skills_dir)
+
+    result = routes._skills_list_from_dir(skills_dir)
+    skills = {s["name"]: s for s in result["skills"]}
+
+    assert skills["skill-a"]["disabled"] is True
+    assert skills["skill-b"]["disabled"] is False
+
+
+@requires_agent_modules
+def test_profile_switch_changes_disabled_state(tmp_path, monkeypatch):
+    """Simulates switching profiles: disabled state should follow the active
+    profile's config, not remain stuck on the original profile."""
+    from api import routes
+
+    # Two profile configs with different disabled lists
+    profile_a_config = tmp_path / "profile-a" / "config.yaml"
+    profile_b_config = tmp_path / "profile-b" / "config.yaml"
+    _write_config(profile_a_config, {"skills": {"disabled": ["skill-x"]}})
+    _write_config(profile_b_config, {"skills": {"disabled": ["skill-y"]}})
+
+    # Skills dir with both skills
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "skill-x")
+    _write_skill(skills_dir, "skill-y")
+    monkeypatch.setattr("api.routes._active_skills_dir", lambda: skills_dir)
+
+    # "Active" profile A
+    monkeypatch.setattr("api.routes._get_config_path", lambda: profile_a_config)
+    result_a = routes._skills_list_from_dir(skills_dir)
+    skills_a = {s["name"]: s for s in result_a["skills"]}
+    assert skills_a["skill-x"]["disabled"] is True
+    assert skills_a["skill-y"]["disabled"] is False
+
+    # "Switch" to profile B
+    monkeypatch.setattr("api.routes._get_config_path", lambda: profile_b_config)
+    result_b = routes._skills_list_from_dir(skills_dir)
+    skills_b = {s["name"]: s for s in result_b["skills"]}
+    assert skills_b["skill-x"]["disabled"] is False
+    assert skills_b["skill-y"]["disabled"] is True
+
+
+def test_normalize_disabled_set_handles_edge_cases():
+    """_normalize_disabled_set handles None, str, list, and whitespace."""
+    from api.routes import _normalize_disabled_set
+
+    assert _normalize_disabled_set(None) == set()
+    assert _normalize_disabled_set("single") == {"single"}
+    assert _normalize_disabled_set(["a", "b"]) == {"a", "b"}
+    assert _normalize_disabled_set([" spaced ", "  "]) == {"spaced"}
+    assert _normalize_disabled_set([]) == set()


### PR DESCRIPTION
Fixes #3066

## Summary

This PR fixes the Skills panel disabled-state read path so it follows the active WebUI profile instead of the process-global `HERMES_HOME` default.

### What changed
- Added a profile-aware disabled-skill reader in `api/routes.py` that resolves config from the active TLS profile via `_get_config_path()`.
- The Skills panel now reads `skills.platform_disabled.webui` first, then falls back to `skills.disabled`.
- Added regression tests covering:
  - active-profile config lookup
  - `platform_disabled.webui` precedence
  - fallback behavior
  - profile-switch behavior for the Skills panel disabled state

### Root cause
The skills directory listing was already profile-aware, but the disabled-state READ path still came from the process-global config resolution path. After switching profiles, the panel could therefore show the wrong enabled/disabled toggles.

### Verification
- `pytest -q tests/test_issue3066_disabled_read_profile.py`
- `pytest -q tests/test_issue1880_profile_scoped_skills.py tests/test_issue3066_disabled_read_profile.py`
