### PR TITLE
fix(sessions+compression+tool-card): stale unread dot, timer leak, tool card duplication (#3020, #2973)

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1673,7 +1673,15 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         tc={name:d.name||'tool', preview:d.preview||'', args:d.args||{}, snippet:'', done:true};
         inflight.toolCalls.push(tc);
       }
-      tc.preview=d.preview||tc.preview||'';
+      // Route result to .snippet (detail) instead of overwriting .preview
+      // (header).  During streaming .preview already holds the last progress
+      // text — replacing it with the same content caused header/detail
+      // duplication.  Fallback: if no progress events were sent, use the
+      // result as preview so the header is not blank.
+      if(d.preview){
+        tc.snippet=tc.snippet||d.preview;
+        if(!tc.preview) tc.preview=d.preview;
+      }
       tc.args=d.args||tc.args||{};
       tc.done=true;
       tc.is_error=!!d.is_error;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -142,6 +142,9 @@ function _setSessionViewedCount(sid, messageCount = 0) {
   const next = Number.isFinite(messageCount) ? Number(messageCount) : 0;
   counts[sid] = next;
   _saveSessionViewedCounts();
+  // If the viewed count is now current, any prior completion-unread marker is
+  // stale — clear it so _hasUnreadForSession doesn't short-circuit (#3020).
+  _clearSessionCompletionUnread(sid);
 }
 
 function _getSessionCompletionUnread() {
@@ -407,8 +410,13 @@ function _markPollingCompletionUnreadTransitions(sessions) {
       )
     );
     const completedPersistedObservedStream = Boolean(observedStreaming && !isStreaming);
-    if ((completedObservedStream || completedPersistedObservedStream || completedWithNewMessages) && !_isSessionActivelyViewedForList(sid)) {
-      _markSessionCompletionUnread(sid, s.message_count);
+    if (completedObservedStream || completedPersistedObservedStream || completedWithNewMessages) {
+      if (!_isSessionActivelyViewedForList(sid)) {
+        _markSessionCompletionUnread(sid, s.message_count);
+      } else {
+        // Sync viewed count so we don't flag stale unread on tab switch (#3020)
+        _setSessionViewedCount(sid, messageCount);
+      }
     }
     _sessionStreamingById.set(sid, isStreaming);
     if (isStreaming) {

--- a/static/ui.js
+++ b/static/ui.js
@@ -6947,7 +6947,7 @@ function buildToolCard(tc){
   const row=document.createElement('div');
   row.className='tool-card-row';
   const icon=toolIcon(tc.name);
-  const hasDetail=tc.snippet||(tc.args&&Object.keys(tc.args).length>0);
+  const hasDetail=(tc.snippet&&tc.snippet!==tc.preview)||(tc.args&&Object.keys(tc.args).length>0);
   let displaySnippet='';
   if(tc.snippet){
     const s=tc.snippet;

--- a/static/ui.js
+++ b/static/ui.js
@@ -5675,6 +5675,19 @@ function appendLiveCompressionCard(state){
     node.setAttribute('data-compression-started-at',String(started));
     node.setAttribute('data-compression-message',String(state.message||'Auto-compressing context...'));
     _startCompressionElapsedTimer();
+  } else {
+    // Completion or error: clear the elapsed-timer attributes so the
+    // interval reader (_compressionLiveCardState) doesn't keep treating
+    // the replaced card as a running compression (#2973).
+    node.removeAttribute('data-compression-started-at');
+    node.removeAttribute('data-compression-message');
+    // Only clear the global timer when the *active* session has no running
+    // compression.  An SSE completion for a background session must not
+    // kill the timer that's driving the current session's display.
+    const _activeCompState = _compressionStateForCurrentSession();
+    if (!_activeCompState || !_activeCompState.automatic || _activeCompState.phase !== 'running') {
+      _clearCompressionElapsedTimer();
+    }
   }
   const existing=inner.querySelector('[data-live-compression-card="1"]');
   if(existing) existing.replaceWith(node);


### PR DESCRIPTION
## Summary

Three bugfixes, rebased onto current master (post-#3069):

- **#3020**: Sync viewed-count in the polling path for actively-viewed sessions so navigating away doesn't show a stale unread dot. Defensive clear of completion-unread marker in `_setSessionViewedCount`.

- **#2973**: Clear elapsed-timer attributes and interval when a live compression card transitions from running to done, preventing the orphan timer from overwriting the completed card state. Guarded by active-session check to avoid killing a timer driving another session's display.

- **Tool card duplication**: Fix tool card header/detail showing identical content after tool completion. Route result to `tc.snippet` only, preserving `tc.preview` as the last streaming progress text.

## What's NOT in this PR

- #3019 changes (dropped — handled by #3069)
- `ensure_cron_project` system flag (may be a follow-up)
- CLI tool-result snippet 200→4000 bump (separate PR)
- `test_pr_3019_3020_2973.py` (tests need updating for new scope)

## Test plan

- [ ] Manual: view session with new messages → navigate away → no stale dot
- [ ] Manual: trigger auto-compression → timer clears on completion
- [ ] Manual: run terminal tool → card header shows progress, detail shows result (no duplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)