### PR TITLE
fix(ui): match tool result snippet limit to backend (200 -> 4000 chars)

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -6111,7 +6111,7 @@ function _cliLooksLikePatchDiff(text){
 function _cliToolResultSnippet(raw){
   const fullText=_cliToolResultText(raw);
   if(_cliLooksLikePatchDiff(fullText)) return _clipCliToolSnippet(fullText);
-  return String(fullText||'').slice(0,200);
+  return String(fullText||'').slice(0,4000);
 }
 
 function _prefixedCliDiffLines(prefix, value){

--- a/tests/test_tool_snippet_limit_parity.py
+++ b/tests/test_tool_snippet_limit_parity.py
@@ -1,0 +1,11 @@
+"""Regression test: JS tool-result snippet limit matches the Python backend limit."""
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def test_tool_snippet_limit_parity():
+    py = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")
+    js = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+    assert "_TOOL_RESULT_SNIPPET_MAX = 4000" in py
+    assert ".slice(0,4000)" in js


### PR DESCRIPTION
## Summary

`_cliToolResultSnippet` truncated to 200 chars while the backend's `_tool_result_snippet` uses 4000. This caused tool card details to be more aggressively truncated after session reload than during live streaming.

## Impact

- Tool cards now show the same amount of detail after reload as during live streaming
- 4000 chars is a 20x bump from 200 — may affect rendering on very long shell commands

## Test plan

- [ ] Run a terminal tool with long output → reload session → detail shows same content as during streaming
- [ ] Verify long tool outputs don't break card layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)