### PR TITLE
fix: submit composer on numpad enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The chat composer now treats the numeric keypad Enter key as a submit shortcut even when the send-key preference is set to Ctrl/Cmd+Enter, while preserving regular Enter-as-newline behavior in that mode.
+
 ## [v0.51.157] — 2026-05-28 — Release EC (stage-batch39 — 5-PR mixed-risk cleanup: gateway prefill forward + prefill budget + compressed-continuation sidebar + browser-transcript memory guidance + reasoning max parity)
 
 ### Added

--- a/static/boot.js
+++ b/static/boot.js
@@ -1115,6 +1115,9 @@ function _isVirtualKeyboardLikelyOpen(){
   if(!vv||!window.innerHeight)return true;
   return window.innerHeight-vv.height>120;
 }
+function _isNumpadEnter(e){
+  return e.key==='Enter'&&(e.code==='NumpadEnter'||e.location===KeyboardEvent.DOM_KEY_LOCATION_NUMPAD);
+}
 $('msg').addEventListener('keydown',e=>{
   // Autocomplete navigation when dropdown is open
   const dd=$('cmdDropdown');
@@ -1139,9 +1142,10 @@ $('msg').addEventListener('keydown',e=>{
   // Users can override in Settings by explicitly choosing 'enter' mode.
   if(e.key==='Enter'){
     if(_isImeEnter(e)){return;}
+    const isNumpadEnter=_isNumpadEnter(e);
     const _mobileDefault=matchMedia('(pointer:coarse)').matches&&window._sendKey==='enter'&&_isVirtualKeyboardLikelyOpen();
     if(window._sendKey==='ctrl+enter'||_mobileDefault){
-      if(e.ctrlKey||e.metaKey){e.preventDefault();send();}
+      if(isNumpadEnter||e.ctrlKey||e.metaKey){e.preventDefault();send();}
     } else {
       if(!e.shiftKey){e.preventDefault();send();}
     }

--- a/tests/test_numpad_enter_submit.py
+++ b/tests/test_numpad_enter_submit.py
@@ -1,0 +1,26 @@
+"""Keyboard contract for treating Numpad Enter as a submit shortcut."""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+
+
+def test_boot_defines_numpad_enter_helper():
+    assert "function _isNumpadEnter(e)" in BOOT_JS
+    assert "e.code==='NumpadEnter'" in BOOT_JS
+    assert "e.location===KeyboardEvent.DOM_KEY_LOCATION_NUMPAD" in BOOT_JS
+
+
+def test_ctrl_enter_mode_allows_numpad_enter_to_submit():
+    ctrl_branch = BOOT_JS.split("if(window._sendKey==='ctrl+enter'||_mobileDefault){", 1)[1]
+    ctrl_branch = ctrl_branch.split("} else {", 1)[0]
+    assert "isNumpadEnter" in ctrl_branch
+    assert "if(isNumpadEnter||e.ctrlKey||e.metaKey){e.preventDefault();send();}" in ctrl_branch
+
+
+def test_ime_guard_runs_before_numpad_enter_detection():
+    enter_branch = BOOT_JS.split("if(e.key==='Enter'){")[-1]
+    ime_idx = enter_branch.index("if(_isImeEnter(e)){return;}")
+    numpad_idx = enter_branch.index("const isNumpadEnter=_isNumpadEnter(e);")
+    assert ime_idx < numpad_idx


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI already lets users choose whether regular Enter submits or inserts a newline.
- Full-size keyboards have a separate numeric keypad Enter that many users expect to submit forms.
- The current composer logic only checks `e.key === 'Enter'`, so Ctrl/Cmd+Enter mode treats both regular Enter and Numpad Enter as newline unless Ctrl/Cmd is held.
- This PR adds a narrow Numpad Enter detection path so keypad Enter submits while preserving the existing regular Enter/Ctrl+Enter preference behavior and IME guard.

## What Changed
- Added `_isNumpadEnter(e)` in `static/boot.js`, using `e.code === 'NumpadEnter'` with a numpad-location fallback.
- In Ctrl/Cmd+Enter mode, Numpad Enter now submits without requiring Ctrl/Cmd.
- Regular Enter still follows the configured send-key preference.
- Added static regression coverage for the helper, Ctrl/Cmd+Enter branch behavior, and IME guard ordering.
- Added an Unreleased changelog entry.

## Why It Matters
Users who prefer regular Enter for newlines can still submit quickly from a numeric keypad without changing the global send-key setting or breaking IME composition flows.

## Verification
- `python -m pytest tests/test_numpad_enter_submit.py tests/test_mobile_layout.py tests/test_ime_composition.py tests/test_issue1443_ime_helper_promotion.py tests/test_1003_preferences_autosave.py -q` → 80 passed, 1 warning
- `node --check static/boot.js`
- `git diff --check`
- Scanned added diff lines for non-ASCII text; none found.

## Risks / Follow-ups
- This relies on browsers reporting `KeyboardEvent.code` as `NumpadEnter` or `KeyboardEvent.location` as `DOM_KEY_LOCATION_NUMPAD`. If an unusual remote desktop/browser collapses keypad Enter into regular Enter with no numpad metadata, it will keep the existing regular Enter behavior.
- No visual UI changes; screenshot evidence is not applicable.

## Contract Routing
Task type: small composer keyboard interaction fix.
Touched areas: `static/boot.js`, composer keyboard contract tests, changelog.
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/UIUX-GUIDE.md`
- `DESIGN.md`
Scope boundaries: no layout, theme, streaming, runtime-state, or persistence contract changes.
Evidence needed before claiming done: targeted keyboard/static tests plus JS syntax and diff hygiene.

## Model Used
OpenAI Codex GPT-5.5 via Hermes Agent WebUI, with repository inspection and local shell/test tooling.
