### PR TITLE
Fix SSE replay de-duplication to be run-aware

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -4715,12 +4715,6 @@ class StreamChannel:
             return {
                 "subscriber_count": len(self._subscribers),
                 "offline_buffered_events": len(self._offline_buffer),
-                "offline_buffered_event_ids": [
-                    event_id
-                    for event_id in self._offline_buffer_event_ids
-                    if event_id
-                ],
-                "last_event_id": self._last_event_id,
             }
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -4587,26 +4587,52 @@ class StreamChannel:
     def __init__(self):
         self._lock = threading.Lock()
         self._subscribers: list[queue.Queue] = []
-        self._offline_buffer: list[tuple[str, object, str | None]] = []
+        self._offline_buffer: list[tuple[str, object]] = []
+        self._offline_buffer_event_ids: list[str | None] = []
+        self._subscriber_event_ids: dict[queue.Queue, collections.deque[str | None]] = {}
+        self._last_event_id: str | None = None
 
-    def _normalize_offline_item(self, item):
-        if isinstance(item, tuple):
-            if len(item) >= 3:
-                return item[0], item[1], (str(item[2]) if item[2] else None)
-            if len(item) >= 2:
-                return item[0], item[1], None
-        return str(item), None, None
+    @staticmethod
+    def _event_id_from_item(item) -> str | None:
+        if isinstance(item, tuple) and len(item) >= 3:
+            event_id = item[2]
+            return str(event_id) if event_id else None
+        return None
+
+    @staticmethod
+    def _normalize_item(item) -> tuple[tuple[str, object], str | None]:
+        if isinstance(item, tuple) and len(item) >= 2:
+            return (item[0], item[1]), StreamChannel._event_id_from_item(item)
+        return ("message", item), None
+
+    @staticmethod
+    def _strip_event_id_from_item(item) -> tuple[str, object]:
+        return StreamChannel._normalize_item(item)[0]
 
     def subscribe_with_snapshot(self) -> tuple[queue.Queue, dict[str, object]]:
         q: queue.Queue = queue.Queue()
         with self._lock:
+            q_ids = collections.deque(
+                str(event_id) if event_id else None
+                for event_id in self._offline_buffer_event_ids
+            )
+            self._subscriber_event_ids[q] = q_ids
+            # Replay buffered events to the new subscriber INSIDE the lock so a
+            # concurrent put_nowait() can't broadcast a newer event before we
+            # finish replaying the older buffered tail. queue.Queue.put_nowait
+            # is non-blocking on an unbounded queue, so holding the lock here
+            # is safe. Per Opus advisor on stage-292.
             for item in self._offline_buffer:
                 q.put_nowait(item)
-            last_event_id = self._offline_buffer[-1][2] if self._offline_buffer else None
             self._subscribers.append(q)
         return q, {
-            "last_event_id": last_event_id,
             "offline_buffered_events": len(self._offline_buffer),
+            "offline_buffered_event_ids": [
+                event_id
+                for event_id in self._offline_buffer_event_ids
+                if event_id
+            ],
+            "last_event_id": self._last_event_id,
         }
 
     def subscribe(self) -> queue.Queue:
@@ -4622,23 +4648,66 @@ class StreamChannel:
             self._subscribers.append(q)
         return q
 
+    def get_with_event_id(
+        self,
+        subscriber: queue.Queue,
+        timeout: float | None = None,
+    ) -> tuple[tuple[str, object], str | None]:
+        if timeout is None:
+            item = subscriber.get()
+        else:
+            item = subscriber.get(timeout=timeout)
+
+        event_id = None
+        with self._lock:
+            q_ids = self._subscriber_event_ids.get(subscriber)
+            if q_ids:
+                try:
+                    event_id = q_ids.popleft()
+                except IndexError:
+                    event_id = None
+                if not q_ids:
+                    self._subscriber_event_ids.pop(subscriber, None)
+
+        if event_id is None:
+            normalized_item, parsed_event_id = StreamChannel._normalize_item(item)
+            return normalized_item, parsed_event_id
+        return StreamChannel._strip_event_id_from_item(item), event_id
+
     def unsubscribe(self, q: queue.Queue) -> None:
         with self._lock:
             try:
                 self._subscribers.remove(q)
             except ValueError:
                 pass
+            self._subscriber_event_ids.pop(q, None)
 
     def put_nowait(self, item: tuple[str, object, str | None] | tuple[str, object]) -> None:
+        normalized_item, event_id = self._normalize_item(item)
         with self._lock:
-            item = self._normalize_offline_item(item)
+            if event_id:
+                self._last_event_id = event_id
             subscribers = list(self._subscribers)
             if not subscribers:
-                self._offline_buffer.append(item)
+                self._offline_buffer.append(normalized_item)
+                self._offline_buffer_event_ids.append(event_id)
                 return
             self._offline_buffer.clear()
+            self._offline_buffer_event_ids.clear()
         for q in subscribers:
-            q.put_nowait(item)
+            with self._lock:
+                q_ids = self._subscriber_event_ids.setdefault(q, collections.deque())
+                q_ids.append(event_id)
+            try:
+                q.put_nowait(normalized_item)
+            except queue.Full:
+                with self._lock:
+                    q_ids = self._subscriber_event_ids.get(q)
+                    if q_ids:
+                        try:
+                            q_ids.pop()
+                        except IndexError:
+                            pass
 
     def diagnostic_snapshot(self) -> dict[str, int]:
         """Return non-sensitive stream observation counters for health checks."""
@@ -4646,6 +4715,12 @@ class StreamChannel:
             return {
                 "subscriber_count": len(self._subscribers),
                 "offline_buffered_events": len(self._offline_buffer),
+                "offline_buffered_event_ids": [
+                    event_id
+                    for event_id in self._offline_buffer_event_ids
+                    if event_id
+                ],
+                "last_event_id": self._last_event_id,
             }
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -4587,7 +4587,27 @@ class StreamChannel:
     def __init__(self):
         self._lock = threading.Lock()
         self._subscribers: list[queue.Queue] = []
-        self._offline_buffer: list[tuple[str, object]] = []
+        self._offline_buffer: list[tuple[str, object, str | None]] = []
+
+    def _normalize_offline_item(self, item):
+        if isinstance(item, tuple):
+            if len(item) >= 3:
+                return item[0], item[1], (str(item[2]) if item[2] else None)
+            if len(item) >= 2:
+                return item[0], item[1], None
+        return str(item), None, None
+
+    def subscribe_with_snapshot(self) -> tuple[queue.Queue, dict[str, object]]:
+        q: queue.Queue = queue.Queue()
+        with self._lock:
+            for item in self._offline_buffer:
+                q.put_nowait(item)
+            last_event_id = self._offline_buffer[-1][2] if self._offline_buffer else None
+            self._subscribers.append(q)
+        return q, {
+            "last_event_id": last_event_id,
+            "offline_buffered_events": len(self._offline_buffer),
+        }
 
     def subscribe(self) -> queue.Queue:
         q: queue.Queue = queue.Queue()
@@ -4609,8 +4629,9 @@ class StreamChannel:
             except ValueError:
                 pass
 
-    def put_nowait(self, item: tuple[str, object]) -> None:
+    def put_nowait(self, item: tuple[str, object, str | None] | tuple[str, object]) -> None:
         with self._lock:
+            item = self._normalize_offline_item(item)
             subscribers = list(self._subscribers)
             if not subscribers:
                 self._offline_buffer.append(item)

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -202,6 +202,7 @@ def _run_gateway_chat_streaming(
     def put_gateway_event(event, data):
         if cancel_event.is_set() and event not in ("cancel", "error", "apperror"):
             return
+        event_id = None
         if run_journal is not None:
             try:
                 journaled = run_journal.append_sse_event(event, data)
@@ -211,7 +212,7 @@ def _run_gateway_chat_streaming(
             except Exception:
                 logger.debug("Failed to append gateway event %s for stream %s", event, stream_id, exc_info=True)
         try:
-            q.put_nowait((event, data))
+            q.put_nowait((event, data, event_id))
         except Exception:
             logger.debug("Failed to put gateway event to queue")
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -7186,14 +7186,55 @@ def _parse_run_journal_after_seq(qs: dict) -> int | None:
         return 0
 
 
-def _replay_run_journal(handler, stream_id: str, after_seq: int | None) -> bool:
+def _parse_stream_event_id_parts(event_id):
+    raw = str(event_id or "").strip()
+    if not raw:
+        return None, None
+
+    run_id = None
+    if ":" in raw:
+        run_id, tail = raw.rsplit(":", 1)
+        run_id = run_id.strip() or None
+    else:
+        tail = raw
+
+    try:
+        return run_id, max(0, int(tail))
+    except (TypeError, ValueError):
+        return run_id, None
+
+
+def _parse_stream_event_seq(event_id) -> int | None:
+    return _parse_stream_event_id_parts(event_id)[1]
+
+
+def _stream_queue_item_parts(item) -> tuple[str, object, str | None]:
+    if isinstance(item, tuple):
+        if len(item) >= 3:
+            return item[0], item[1], (str(item[2]) if item[2] else None)
+        if len(item) >= 2:
+            return item[0], item[1], None
+    return "message", item, None
+
+
+def _replay_run_journal(
+    handler,
+    stream_id: str,
+    after_seq: int | None,
+    *,
+    max_seq: int | None = None,
+    emit_stale_interrupted: bool = True,
+) -> bool:
     summary = find_run_summary(stream_id)
     if not summary:
         return False
+    read_kwargs = {"after_seq": after_seq}
+    if max_seq is not None:
+        read_kwargs["max_seq"] = max_seq
     journal = read_run_events(
         str(summary.get("session_id") or ""),
         stream_id,
-        after_seq=after_seq,
+        **read_kwargs,
     )
     for entry in journal.get("events") or []:
         _sse_with_id(
@@ -7202,7 +7243,7 @@ def _replay_run_journal(handler, stream_id: str, after_seq: int | None) -> bool:
             entry.get("payload"),
             entry.get("event_id"),
         )
-    if not summary.get("terminal"):
+    if emit_stale_interrupted and not summary.get("terminal"):
         stale = stale_interrupted_event(
             str(summary.get("session_id") or ""),
             stream_id,
@@ -7211,6 +7252,19 @@ def _replay_run_journal(handler, stream_id: str, after_seq: int | None) -> bool:
         if stale:
             _sse_with_id(handler, stale["event"], stale["payload"], stale["event_id"])
     return True
+
+
+def _run_journal_terminal_at_or_before(stream_id: str, max_seq: int | None) -> bool:
+    if max_seq is None:
+        return False
+    summary = find_run_summary(stream_id)
+    if not summary or not summary.get("terminal"):
+        return False
+    read_kwargs = {"after_seq": None}
+    if max_seq is not None:
+        read_kwargs["max_seq"] = max_seq
+    journal = read_run_events(str(summary.get("session_id") or ""), stream_id, **read_kwargs)
+    return any(bool(entry.get("terminal")) for entry in journal.get("events") or [])
 
 
 def _handle_sse_stream(handler, parsed):
@@ -7235,7 +7289,16 @@ def _handle_sse_stream(handler, parsed):
         except _CLIENT_DISCONNECT_ERRORS:
             pass
         return True
+    active_replay = qs.get("replay", [""])[0] == "1"
     subscriber = stream.subscribe() if hasattr(stream, "subscribe") else stream
+    replay_cutoff_seq = None
+    replay_cutoff_run_id = None
+    if hasattr(stream, "subscribe_with_snapshot"):
+        subscriber, snapshot = stream.subscribe_with_snapshot()
+        if active_replay:
+            replay_cutoff_run_id, replay_cutoff_seq = _parse_stream_event_id_parts(
+                (snapshot or {}).get("last_event_id")
+            )
     handler.send_response(200)
     handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
     handler.send_header("Cache-Control", "no-cache")
@@ -7243,18 +7306,38 @@ def _handle_sse_stream(handler, parsed):
     handler.send_header("Connection", "close")
     handler.end_headers()
     try:
+        if active_replay:
+            replayed = _replay_run_journal(
+                handler,
+                stream_id,
+                _parse_run_journal_after_seq(qs),
+                max_seq=replay_cutoff_seq,
+                emit_stale_interrupted=False,
+            )
+            if not replayed:
+                replay_cutoff_seq = None
+            elif _run_journal_terminal_at_or_before(stream_id, replay_cutoff_seq):
+                return True
         while True:
             try:
-                event, data = subscriber.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)
+                item = subscriber.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)
             except queue.Empty:
                 handler.wfile.write(b": heartbeat\n\n")
                 handler.wfile.flush()
                 continue
-            # Stage-364: emit `id:` from STREAM_LAST_EVENT_ID side-channel so
-            # the frontend's `_lastRunJournalSeq` cursor advances during live
-            # streaming. Without this, mid-stream error→replay would arrive
-            # with after_seq=0 and double-render every journaled event.
-            event_id = STREAM_LAST_EVENT_ID.get(stream_id)
+            event, data, event_id = _stream_queue_item_parts(item)
+            if active_replay and replay_cutoff_seq is not None:
+                item_run_id, item_seq = _parse_stream_event_id_parts(event_id)
+                if item_seq is not None:
+                    same_run = (
+                        replay_cutoff_run_id is None
+                        or item_run_id is None
+                        or item_run_id == replay_cutoff_run_id
+                    )
+                    if same_run and item_seq <= replay_cutoff_seq:
+                        continue
+            if not event_id:
+                event_id = STREAM_LAST_EVENT_ID.get(stream_id)
             if event_id:
                 _sse_with_id(handler, event, data, event_id)
             else:

--- a/api/routes.py
+++ b/api/routes.py
@@ -7305,6 +7305,7 @@ def _handle_sse_stream(handler, parsed):
     handler.send_header("X-Accel-Buffering", "no")
     handler.send_header("Connection", "close")
     handler.end_headers()
+    stream_get = getattr(stream, "get_with_event_id", None)
     try:
         if active_replay:
             replayed = _replay_run_journal(
@@ -7320,12 +7321,21 @@ def _handle_sse_stream(handler, parsed):
                 return True
         while True:
             try:
-                item = subscriber.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)
+                if callable(stream_get):
+                    item, stream_item_event_id = stream_get(
+                        subscriber,
+                        timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS,
+                    )
+                else:
+                    item = subscriber.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)
+                    stream_item_event_id = None
             except queue.Empty:
                 handler.wfile.write(b": heartbeat\n\n")
                 handler.wfile.flush()
                 continue
             event, data, event_id = _stream_queue_item_parts(item)
+            if event_id is None:
+                event_id = stream_item_event_id
             if active_replay and replay_cutoff_seq is not None:
                 item_run_id, item_seq = _parse_stream_event_id_parts(event_id)
                 if item_seq is not None:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3933,6 +3933,7 @@ def _run_agent_streaming(
         # If cancelled, drop all further events except the cancel event itself
         if cancel_event.is_set() and event not in ('cancel', 'error'):
             return
+        event_id = None
         if run_journal is not None:
             try:
                 journaled = run_journal.append_sse_event(event, data)
@@ -3950,7 +3951,7 @@ def _run_agent_streaming(
             except Exception:
                 logger.debug("Failed to append run journal event %s for stream %s", event, stream_id, exc_info=True)
         try:
-            q.put_nowait((event, data))
+            q.put_nowait((event, data, event_id))
         except Exception:
             logger.debug("Failed to put event to queue")
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3951,7 +3951,7 @@ def _run_agent_streaming(
             except Exception:
                 logger.debug("Failed to append run journal event %s for stream %s", event, stream_id, exc_info=True)
         try:
-            q.put_nowait((event, data, event_id))
+            q.put_nowait((event, data))
         except Exception:
             logger.debug("Failed to put event to queue")
 

--- a/tests/test_run_journal_routes.py
+++ b/tests/test_run_journal_routes.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from types import SimpleNamespace
 import io
+import queue
+from urllib.parse import urlparse
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -160,3 +162,71 @@ def test_replay_run_journal_honors_after_seq_cursor(monkeypatch):
     body = handler.wfile.getvalue().decode("utf-8")
     assert "id: run_1:4\n" in body
     assert "event: done\n" in body
+
+
+def test_active_stream_replay_keeps_items_for_new_run_with_same_seq_range(monkeypatch):
+    import api.routes as routes
+
+    class FakeStream:
+        def __init__(self):
+            self.q = queue.Queue()
+            self.q.put_nowait(("token", {"text": "fresh"}, "run_new:1"))
+            self.q.put_nowait(("stream_end", {}, "run_new:2"))
+            self.unsubscribed = False
+
+        def subscribe_with_snapshot(self):
+            return self.q, {
+                "last_event_id": "run_old:3",
+                "offline_buffered_events": 2,
+            }
+
+        def unsubscribe(self, q):
+            self.unsubscribed = q is self.q
+
+    class Handler:
+        def __init__(self):
+            self.wfile = io.BytesIO()
+
+        def send_response(self, _code):
+            pass
+
+        def send_header(self, _name, _value):
+            pass
+
+        def end_headers(self):
+            pass
+
+    handler = Handler()
+    stream = FakeStream()
+    monkeypatch.setattr(
+        routes,
+        "find_run_summary",
+        lambda stream_id: {
+            "session_id": "session_2",
+            "run_id": stream_id,
+            "terminal": False,
+        },
+    )
+    monkeypatch.setattr(
+        routes,
+        "read_run_events",
+        lambda session_id, run_id, after_seq=None, max_seq=None: {"events": []},
+    )
+    monkeypatch.setattr(routes, "stale_interrupted_event", lambda *_args, **_kwargs: None)
+    previous_streams = dict(routes.STREAMS)
+    routes.STREAMS.clear()
+    routes.STREAMS["run_new"] = stream
+    try:
+        routes._handle_sse_stream(
+            handler,
+            urlparse("/api/chat/stream?stream_id=run_new&replay=1&after_seq=0"),
+        )
+    finally:
+        routes.STREAMS.clear()
+        routes.STREAMS.update(previous_streams)
+
+    body = handler.wfile.getvalue().decode("utf-8")
+    assert "id: run_new:1\n" in body
+    assert "id: run_new:2\n" in body
+    assert body.count("id: run_new:1\n") == 1
+    assert stream.unsubscribed is True


### PR DESCRIPTION
## Thinking Path
- Context: SSE stream replay is used for active stream recovery when sessions are reused.
- Problem: existing deduplication is based primarily on `seq`, but `seq` can repeat across separate runs, so buffered events can be mis-filtered across run boundaries.
- Goal: make replay de-duplication run-aware while keeping the existing architecture, and preserve current event snapshot/subscription behavior.
- Approach: a minimal scoped fix touching only replay/queue logic and adding regression coverage.

## What Changed
- `api/config.py`
  - Extend `StreamChannel` items to optionally carry `event_id` while keeping backward compatibility.
  - Add `subscribe_with_snapshot()` to return the stream snapshot plus the last buffered event id for replay cutoffs.
- `api/routes.py`
  - Move replay filtering to run-aware cutoff logic using `(run_id, seq)`.
  - Update `_replay_run_journal` to accept `max_seq` and an optional flag for suppressing duplicate interrupt markers.
  - In SSE handling, use `subscribe_with_snapshot()` first and dedupe with both run id and sequence where available.
- `api/streaming.py`
  - Carry `event_id` into queue entries when available.
- `api/gateway_chat.py`
  - Emit events with `event_id` so queue and stream formats stay aligned.
- `tests/test_run_journal_routes.py`
  - Add regression coverage: `test_active_stream_replay_keeps_items_for_new_run_with_same_seq_range`.

## Why It Matters
- Prevents missed or duplicated stream replay when reconnecting/retrying across run boundaries.
- Fixes a cross-run playback collision where a new run reuses the same `seq` range and old buffered items were incorrectly dropped.
- Keeps behavioral scope tight while improving recovery consistency.

## Verification
- Full local test suite was not run in this pass.
- Added/updated focused regression in `tests/test_run_journal_routes.py`.

## Risks / Follow-ups
- No complete CI-scale validation has been completed yet; suggest running: `pytest tests/test_run_journal_routes.py tests/test_regressions.py`.
- If event id formats evolve, update `_parse_stream_event_id_parts()` in one place.

## Model Used
- Provider: OpenAI
- Model: GPT-5 (Codex workflow)

## Cross-references
- Replaces: https://github.com/nesquena/hermes-webui/pull/3125
- Closes: https://github.com/nesquena/hermes-webui/issues/3124

