### PR TITLE
Fix #3114: keep jump-to-question button on intermediate assistant messages

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -6487,8 +6487,14 @@ function renderMessages(options){
     const tsTitle=tsVal?(_fmtSv?_fmtSv(new Date(tsVal*1000),{}):new Date(tsVal*1000).toLocaleString()):'';
     const tsTime=_formatMessageFooterTimestamp(tsVal);
     const timeHtml = tsTime ? `<span class="msg-time" title="${esc(tsTitle)}">${tsTime}</span>` : '';
-    const questionJumpBtn = (!isUser&&!m._live&&isTurnFinalAssistant)
-      ? _questionJumpButtonHtml(questionRawIdxByAssistantRawIdx.get(rawIdx))
+    // #3114: show jump-to-question on every assistant message that has a
+    // resolvable question target, not just the turn-final one. Multi-step
+    // turns (tool_call -> assistant -> tool_call -> assistant) otherwise
+    // strip the button from every intermediate assistant bubble and the
+    // user loses the navigation affordance.
+    const _qJumpTarget=(!isUser&&!m._live)?questionRawIdxByAssistantRawIdx.get(rawIdx):undefined;
+    const questionJumpBtn = (_qJumpTarget!==undefined&&_qJumpTarget!==null)
+      ? _questionJumpButtonHtml(_qJumpTarget)
       : '';
     const footHtml = `<div class="msg-foot">${timeHtml}<span class="msg-actions">${editBtn}${ttsBtn}${forkBtn}${copyBtn}${retryBtn}</span>${questionJumpBtn}</div>`;
 


### PR DESCRIPTION
## Thinking Path

Issue #3114 reports the jump-to-question affordance disappearing on intermediate assistant bubbles in multi-step turns (assistant → tool_call → assistant → tool_call → final assistant). Looked at the gate at `static/ui.js:6490`: `(!isUser && !m._live && isTurnFinalAssistant) ? _questionJumpButtonHtml(...) : ''`. `isTurnFinalAssistant` is the wrong predicate — turn-finality was used as a proxy for "has a navigable question target", but in multi-step turns it under-covers because every assistant bubble *except* the final one fails the test, even when `questionRawIdxByAssistantRawIdx.get(rawIdx)` would resolve a perfectly valid target.

## What Changed

- `static/ui.js`: replace the `isTurnFinalAssistant` gate with a direct check on the actual precondition — does `questionRawIdxByAssistantRawIdx` have a target for this message's `rawIdx`. The button now appears on every assistant message that *can* navigate to its originating user question.

## Why It Matters

Closes #3114. The button was the documented way to jump back to the originating question; losing it on intermediate steps broke navigation through tool-heavy turns.

## Verification

- Lint clean (`patch` tool ran ESLint-equivalent — no diagnostics).
- Read the renderer call sites: `_questionJumpButtonHtml` already handles `rawIdx | undefined` defensively. Gate change is a strict superset of the prior condition (turn-final assistants still satisfy the new gate because they also have valid targets).

## Risks / Follow-ups

Minimal. If a future change ever populates `questionRawIdxByAssistantRawIdx` with stale entries for non-final assistants, the button would appear in unexpected places — but the same code already trusted that map for the turn-final case, so the trust boundary hasn't moved.

## Model Used

claude-opus-4.7 via GitHub Copilot.

Closes #3114.