### PR TITLE
Fix #3103: stop emitting Connection: close on long-lived SSE streams (session-list reconnect loop)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -7449,7 +7449,14 @@ def _handle_gateway_sse_stream(handler, parsed):
     handler.send_header('Content-Type', 'text/event-stream; charset=utf-8')
     handler.send_header('Cache-Control', 'no-cache')
     handler.send_header('X-Accel-Buffering', 'no')
-    handler.send_header('Connection', 'close')
+    # #3103: do NOT emit `Connection: close` on long-lived SSE streams.
+    # The python BaseHTTPServer worker only handles one request per
+    # connection anyway, but browsers (Chrome/Firefox) treat the close
+    # header as a hard signal that the EventSource lifecycle has ended
+    # and trigger an instant reconnect, producing a tight loop of
+    # connect/sessions_changed snapshot/disconnect that thrashes the
+    # session list every ~1s. Letting the server close the socket
+    # naturally after the stream ends is sufficient.
     handler.end_headers()
 
     q = watcher.subscribe()
@@ -7482,7 +7489,8 @@ def _handle_session_events_stream(handler):
     handler.send_header('Content-Type', 'text/event-stream; charset=utf-8')
     handler.send_header('Cache-Control', 'no-cache')
     handler.send_header('X-Accel-Buffering', 'no')
-    handler.send_header('Connection', 'close')
+    # #3103: see _handle_gateway_sse_stream — `Connection: close` causes
+    # EventSource reconnect storms in browsers on long-lived SSE.
     handler.end_headers()
 
     q = subscribe_session_events()


### PR DESCRIPTION
## Thinking Path

Issue #3103 reports a tight EventSource reconnect loop on the session-list SSE stream introduced in 598fd4ff. Tracked it to `api/routes.py:7452` and `:7485` — both SSE handlers (`_handle_gateway_sse_stream`, `_handle_session_events_stream`) emit `Connection: close`. On long-lived SSE, browsers (Chrome/Firefox/Safari) interpret that as "this is a one-shot response; the EventSource lifecycle ends with this body". When the server-side worker rotates or the response ends for any reason, the browser's auto-reconnect fires immediately, producing connect → snapshot → reconnect every ~1s.

## What Changed

- `api/routes.py`: remove `Connection: close` from both SSE response headers; add explanatory comments. Let `BaseHTTPServer` close the socket naturally — that's the lifecycle EventSource expects on long-lived streams.

## Why It Matters

Closes #3103. The loop pegged the python worker, thrashed the session-list UI on every reconnect (full snapshot redraw), and prevented the in-app session list from ever settling.

## Verification

- `python3 -c "import ast; ast.parse(open('api/routes.py').read())"` → OK.
- The remaining headers (`Cache-Control: no-cache`, `X-Accel-Buffering: no`, `Content-Type: text/event-stream`) are the standard SSE set — nothing else changed.
- Manual: after this change EventSource stays connected; reconnects only happen on actual disconnect.

## Risks / Follow-ups

Minimal. `Connection: close` was the regression; the prior working behavior also did not set it. The python `BaseHTTPRequestHandler` is single-request-per-connection anyway, so the header was both wrong (semantically signaling end-of-EventSource) and redundant (the worker already closes the socket).

## Model Used

claude-opus-4.7 via GitHub Copilot.

Closes #3103.