### PR TITLE
Fix #3107: throttle active-session external-refresh fallback poll from 5s to 30s

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2309,7 +2309,13 @@ let _gatewaySSEWarningShown = false;
 const _gatewayFallbackPollMs = 30000;
 const _streamingPollMs = 5000;
 const _sessionTimeRefreshMs = 60000;
-const _activeSessionExternalRefreshMs = 5000;
+// #3107: the active-session "is it externally updated?" poll used to fire
+// every 5 s. On long sessions this caused visible scroll jitter and a
+// noticeable network/CPU floor because the SSE session-events stream
+// already pushes invalidations in real time; this poll exists only as a
+// fallback for the case where SSE is broken/unavailable. Bump to 30 s
+// to keep the safety net without turning it into a primary refresh path.
+const _activeSessionExternalRefreshMs = 30000;
 let _streamingPollTimer = null;
 let _sessionTimeRefreshTimer = null;
 let _activeSessionExternalRefreshTimer = null;


### PR DESCRIPTION
## Thinking Path

Issue #3107 reports visible scroll churn on long sessions traced to the active-session fallback poll at `_activeSessionExternalRefreshMs = 5000` in `static/sessions.js:2312` (introduced in 467ef33a). This poll is a *fallback* for environments where the SSE session-events stream is unavailable; SSE already pushes invalidations in real time. At 5s with full message-list rebuilds and scroll-position restoration, it acts as a primary refresh path and burns CPU/network while the user is just reading.

## What Changed

- `static/sessions.js`: bump `_activeSessionExternalRefreshMs` from 5000 → 30000 (matching the existing `_gatewayFallbackPollMs = 30000` precedent for "this is a safety net, not a primary path"). Added a comment that documents the rationale and the SSE-primary expectation.

## Why It Matters

Closes #3107. Restores the no-build-step UX intent: SSE drives real-time updates, polling is the fallback. 30s is large enough to be invisible to the user but still recovers within a reasonable window when SSE is broken.

## Verification

- Lint clean.
- Other timer constants (`_gatewayFallbackPollMs = 30000`, `_sessionTimeRefreshMs = 60000`) confirm 30s+ is the right magnitude for fallback polling in this file.

## Risks / Follow-ups

If SSE breaks silently in an environment, the user could see up to 30s of stale active-session metadata. That's already the cost the gateway-fallback path pays at the same cadence, and the SSE-broken state is itself surfaced via `_gatewaySSEWarningShown`.

A follow-up could short-circuit the poll entirely when SSE is healthy, but that's a bigger refactor than this critical-bug-fix milestone asks for.

## Model Used

claude-opus-4.7 via GitHub Copilot.

Closes #3107.