### PR TITLE
Fix #3076: don't force mobile send-on-Enter when a real keyboard is co-present

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -1115,6 +1115,18 @@ function _isVirtualKeyboardLikelyOpen(){
   if(!vv||!window.innerHeight)return true;
   return window.innerHeight-vv.height>120;
 }
+// #3076: a touch-primary device (`pointer:coarse`) can still have a
+// physical keyboard attached (Android tablet + Bluetooth keyboard,
+// detachable Surface in tablet mode, iPad + Magic Keyboard). When that
+// happens we should NOT force the mobile newline-on-Enter override
+// because Shift+Enter / Ctrl+Enter come from real keys and the user
+// expects desktop semantics. `matchMedia('(any-pointer:fine)')` is true
+// whenever ANY available pointing device is fine-grained — which is the
+// strongest signal browsers expose for "there is a real keyboard /
+// trackpad in the picture too". Skip the mobile default in that case.
+function _hasFinePointerCoexisting(){
+  try{ return matchMedia('(any-pointer:fine)').matches; }catch(_){ return false; }
+}
 $('msg').addEventListener('keydown',e=>{
   // Autocomplete navigation when dropdown is open
   const dd=$('cmdDropdown');
@@ -1139,7 +1151,10 @@ $('msg').addEventListener('keydown',e=>{
   // Users can override in Settings by explicitly choosing 'enter' mode.
   if(e.key==='Enter'){
     if(_isImeEnter(e)){return;}
-    const _mobileDefault=matchMedia('(pointer:coarse)').matches&&window._sendKey==='enter'&&_isVirtualKeyboardLikelyOpen();
+    const _mobileDefault=matchMedia('(pointer:coarse)').matches
+      &&!_hasFinePointerCoexisting()
+      &&window._sendKey==='enter'
+      &&_isVirtualKeyboardLikelyOpen();
     if(window._sendKey==='ctrl+enter'||_mobileDefault){
       if(e.ctrlKey||e.metaKey){e.preventDefault();send();}
     } else {


### PR DESCRIPTION
## Thinking Path

Issue #3076 reports that Shift+Enter and Ctrl+Enter don't work on an Android tablet with an external keyboard. Traced to `static/boot.js:1142`:

```js
const _mobileDefault = matchMedia('(pointer:coarse)').matches
                    && window._sendKey === 'enter'
                    && _isVirtualKeyboardLikelyOpen();
```

The problem: a touch-primary device (`pointer:coarse`) can *also* have a physical keyboard attached (Android tablet + Bluetooth keyboard, detachable Surface, iPad + Magic Keyboard). When that's the case, the visual-viewport heuristic in `_isVirtualKeyboardLikelyOpen()` often returns true (toolbar inset, on-screen IME hint chip, etc.) even though the user is typing on hardware keys, and `_mobileDefault` flips Enter to newline. Combined with the `ctrlKey || metaKey` gate, the user cannot submit at all.

## What Changed

- `static/boot.js`:
  - Add `_hasFinePointerCoexisting()` helper — `matchMedia('(any-pointer:fine)')`. This is the strongest browser signal for "there is a real keyboard/trackpad/stylus in the picture alongside touch".
  - Short-circuit the `_mobileDefault` path when any fine pointer is co-present. Pure-touch phones/tablets are unaffected.

## Why It Matters

Closes #3076. Hardware-keyboard users on touch devices regain desktop submission semantics. Pure-touch users keep newline-on-Enter.

## Verification

- Lint clean.
- `(any-pointer:fine)` is supported across all evergreen browsers (Chrome, Firefox, Safari, Edge — Level 4 Media Queries, shipped since ~2017).
- Wrapped in a `try/catch` so unknown-query environments fall back to the prior behavior.

## Risks / Follow-ups

A touch-only device that ships with a "fine" pointer (some smart-TV setups expose a remote as fine pointer) would lose the mobile default. The risk is small — those devices typically aren't running hermes-webui interactively — and the failure mode there (desktop Enter semantics on a TV) is recoverable via the explicit Settings choice that already exists.

## Model Used

claude-opus-4.7 via GitHub Copilot.

Closes #3076.