### PR TITLE
Fix #3018: preserve per-turn ephemeral fields (_turnUsage, _turnDuration, _gatewayRouting) across session refreshes

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -2244,7 +2244,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}`);
           if(data&&data.session&&S.session&&S.session.session_id===activeSid){
             S.session=data.session;
-            S.messages=(data.session.messages||[]).filter(m=>m&&m.role);
+            const _nextMsgs3018=(data.session.messages||[]).filter(m=>m&&m.role);
+            S.messages=_carryForwardEphemeralTurnFields(S.messages||[], _nextMsgs3018);
             clearLiveToolCards();if(!assistantText)removeThinking();
             _markSessionViewed(activeSid, data.session.message_count ?? S.messages.length);
             renderMessages({preserveScroll:true});
@@ -2266,6 +2267,48 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     for(const _runJournalEventName of ['token','interim_assistant','reasoning','tool','tool_complete','approval','clarify','title','title_status','context_status','goal','goal_continue','done','stream_end','pending_steer_leftover','compressing','compressed','metering','apperror','warning','error','cancel']){
       source.addEventListener(_runJournalEventName,_rememberRunJournalCursor);
     }
+  }
+
+  // #3018: per-turn ephemeral fields are computed client-side in _finishDone
+  // and attached to message objects (S.messages). When a server refresh
+  // (loadSession, _restoreSettledSession, external active-session poll,
+  // SSE error recovery) replaces S.messages with fresh server data, those
+  // fields are dropped and the usage badge / duration / gateway routing
+  // pill flashes-then-disappears. Carry them forward by matching messages
+  // on (role, timestamp, content prefix) — the same identity the renderer
+  // already uses for stable keys.
+  function _messageIdentityKey(m){
+    if(!m||!m.role) return '';
+    const ts=m._ts||m.timestamp||'';
+    let body='';
+    if(typeof m.content==='string') body=m.content;
+    else if(Array.isArray(m.content)){
+      try{ body=m.content.map(p=>(p&&typeof p==='object')?(p.text||p.input_text||'')||'':String(p||'')).join('').slice(0,160); }catch(_){ body=''; }
+    }
+    return `${m.role}|${ts}|${body.slice(0,160)}`;
+  }
+  const _EPHEMERAL_TURN_FIELDS=['_turnUsage','_turnDuration','_turnTps','_gatewayRouting','_statusCard'];
+  function _carryForwardEphemeralTurnFields(prevMessages, nextMessages){
+    if(!Array.isArray(prevMessages)||!Array.isArray(nextMessages)) return nextMessages;
+    if(!prevMessages.length||!nextMessages.length) return nextMessages;
+    const prevIdx=new Map();
+    for(const pm of prevMessages){
+      const k=_messageIdentityKey(pm); if(!k) continue;
+      // If duplicate keys, prefer the latest occurrence (it carries the
+      // most-recently-attached ephemeral state).
+      prevIdx.set(k,pm);
+    }
+    for(const nm of nextMessages){
+      const k=_messageIdentityKey(nm); if(!k) continue;
+      const pm=prevIdx.get(k); if(!pm) continue;
+      for(const f of _EPHEMERAL_TURN_FIELDS){
+        if(pm[f]!=null && nm[f]==null) nm[f]=pm[f];
+      }
+    }
+    return nextMessages;
+  }
+  if(typeof window!=='undefined'){
+    window._carryForwardEphemeralTurnFields=_carryForwardEphemeralTurnFields;
   }
 
   async function _restoreSettledSession(source){
@@ -2296,7 +2339,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(isActiveSession){
         S.activeStreamId=null;
         clearLiveToolCards();if(!assistantText)removeThinking();
-        S.session=session;S.messages=(session.messages||[]).filter(m=>m&&m.role);
+        S.session=session;
+        const _nextMsgs3018=(session.messages||[]).filter(m=>m&&m.role);
+        S.messages=_carryForwardEphemeralTurnFields(S.messages||[], _nextMsgs3018);
         if(S.session&&S.session.session_id){
           try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
           if(typeof _setActiveSessionUrl==='function') _setActiveSessionUrl(S.session.session_id);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1319,6 +1319,11 @@ async function _ensureMessagesLoaded(sid) {
     S.toolCalls = [];
   }
   clearLiveToolCards();
+  // #3018: preserve client-side ephemeral turn fields (_turnUsage, _turnDuration,
+  // _turnTps, _gatewayRouting, _statusCard) across the loadSession replace.
+  if(typeof window._carryForwardEphemeralTurnFields==='function'){
+    msgs=window._carryForwardEphemeralTurnFields(S.messages||[], msgs);
+  }
   S.messages = msgs;
   if(S.session&&S.session.session_id===sid){
     S.session.message_count=Number(data.session.message_count || msgs.length);


### PR DESCRIPTION
## Thinking Path

Issue #3018 reports the per-turn token usage badge flashing for ~1s after `done` then disappearing. The bug report nails the diagnosis: `_turnUsage` (and `_turnDuration`, `_turnTps`, `_gatewayRouting`) are client-side-only fields attached to the last assistant message in `_finishDone()` (`messages.js:1881`). Three code paths replace `S.messages` wholesale with fresh API data that lacks these fields:

1. `_restoreSettledSession()` after a late `stream_end` or SSE error (`messages.js:2299`).
2. The late-restore branch after `done` (`messages.js:2247`).
3. `loadSession()` for active-session external refresh / focus-change (`sessions.js:1322`).

When any fire after `done`, the renderer at `ui.js:6823` (`const hasTurnUsage = !!msg._turnUsage`) sees `undefined` and skips the badge entirely.

The bug report offered three options. Picked **Option A** (preserve on client) because:

- **Option B** (synthesize from `S.lastUsage`) is lossy — `lastUsage` is a session-level aggregate, not a per-turn breakdown. Multi-turn sessions would show the same usage on every turn.
- **Option C** (set `_streamFinalized` earlier) would suppress *legitimate* late-arriving server data on transient errors.

## What Changed

- `static/messages.js`: added `_carryForwardEphemeralTurnFields(prev, next)` (exposed on `window` for cross-file use) that:
  - Builds an identity index from previous messages using `(role, timestamp, content prefix)` — the same identity shape the renderer uses for stable keys.
  - Walks the new message array; for any match, copies forward `_turnUsage`, `_turnDuration`, `_turnTps`, `_gatewayRouting`, `_statusCard` *only when the new message has them null* (so an authoritative server value, if/when the API ever surfaces per-turn usage, wins).
- `static/messages.js`: wired into both replace sites in `_restoreSettledSession` and the late-restore branch.
- `static/sessions.js`: wired into `loadSession`'s `S.messages = msgs` site (guarded with `typeof window._carryForwardEphemeralTurnFields === 'function'` for load-order safety).

## Why It Matters

Closes #3018. The token usage badge — and duration / gateway routing pill — now persist on the last assistant message across all the documented refresh paths.

## Verification

- `node --check` on both modified files → OK.
- Lint clean (`patch` tool ran ESLint-equivalent on every edit).
- Conservative merge semantics (null-only copy-forward) mean this fix is forward-compatible if/when per-turn usage gets API support.

## Risks / Follow-ups

The identity key uses content prefix; in the extreme edge case of two assistant messages with identical timestamps and identical first 160 chars (effectively never in practice), the later one would inherit the earlier one's ephemeral fields. The renderer already tolerates this — those fields are pure display state. If it becomes a concern, swap to a message-id-based key once the server exposes per-message stable ids on all paths.

## Model Used

claude-opus-4.7 via GitHub Copilot.

Closes #3018.