### PR TITLE
fix: harden external notes guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- WebUI's durable-notes guardrail now also applies to sync chat and explicitly asks agents to leave external notes and durable memory unchanged unless a turn contains an explicit capture or reusable durable signal; durable note writes should be summarized back to the user.
+
 ## [v0.51.157] — 2026-05-28 — Release EC (stage-batch39 — 5-PR mixed-risk cleanup: gateway prefill forward + prefill budget + compressed-continuation sidebar + browser-transcript memory guidance + reasoning max parity)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -9646,7 +9646,13 @@ def _handle_chat_sync(handler, body):
                 "prompt, memory, or conversation history. Always use the value from the most recent "
                 "[Workspace::v1: ...] tag as your default working directory for ALL file operations: "
                 "write_file, read_file, search_files, terminal workdir, and patch. "
-                "Never fall back to a hardcoded path when this tag is present."
+                "Never fall back to a hardcoded path when this tag is present.\n\n"
+                "WebUI external-notes/durable-memory policy: Do not copy or dump this browser transcript "
+                "into external notes or durable memory by default. Write or update durable "
+                "notes only for explicit captures, durable preferences, decisions, blockers/open "
+                "issues, runbook-worthy workflows, or other clearly reusable signals; otherwise "
+                "leave external notes and durable memory unchanged. When you do write or update a durable note, briefly tell "
+                "the user what note or section changed so the write is reviewable."
             )
 
             _previous_messages = list(s.messages or [])

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -222,7 +222,9 @@ def _webui_surface_context_prompt(surface_context: Optional[dict]) -> str:
         "WebUI session context:",
         "- This browser session is not the same live transcript as Telegram, Discord, Slack, or other messaging surfaces.",
         "- Use durable memory, saved sessions, and available tools for cross-surface recall instead of assuming those transcripts are in this browser chat.",
-        "- Do not copy or dump this browser transcript into external notes or durable memory by default. Save only explicit captures, durable user preferences, decisions, blockers, runbook-worthy workflows, or other clearly reusable signals.",
+        "- Do not copy or dump this browser transcript into external notes or durable memory by default.",
+        "- Write to external notes or durable memory only for explicit captures, durable user preferences, decisions, blockers/open issues, runbook-worthy workflows, or other clearly reusable signals; otherwise leave notes unchanged.",
+        "- When you do write or update a durable note, briefly tell the user what note/section changed so the write is reviewable.",
     ]
     fields = (
         ("source", "Source"),

--- a/tests/test_webui_surface_context.py
+++ b/tests/test_webui_surface_context.py
@@ -20,6 +20,9 @@ def test_webui_ephemeral_prompt_includes_browser_surface_context():
     assert "Workspace: /tmp/example-workspace" in prompt
     assert "not the same live transcript as Telegram" in prompt
     assert "Do not copy or dump this browser transcript" in prompt
+    assert "Write to external notes or durable memory only" in prompt
+    assert "otherwise leave notes unchanged" in prompt
+    assert "what note/section changed" in prompt
     assert "explicit captures" in prompt
     assert "durable user preferences" in prompt
 


### PR DESCRIPTION
## Thinking Path
- Keep this PR focused on browser-session durable-write guardrails only.
- Leave notes-provider authentication transport unchanged so the external-notes policy can be reviewed independently.

## What Changed
- Strengthen WebUI durable-notes guidance so external notes and durable memory are only updated for explicit captures or reusable durable signals.
- Apply the same external-notes/durable-memory policy to sync chat startup context.
- Add regression coverage for the selective durable-notes guidance.
- Add a release-note entry for the guardrail behavior change.

## Why It Matters
- Keeps browser sessions from dumping full transcripts into any external notes backend or durable memory by default.
- Makes durable note writes more reviewable by asking the agent to summarize what note or section changed.
- Keeps provider-specific notes transport behavior out of this PR.

## Verification
- `python -m py_compile api/routes.py api/streaming.py`
- `python -m pytest tests/test_webui_surface_context.py -q`
- `git diff --check`

## Contract Routing
Task type: small provider-neutral guardrail hardening
Touched areas:
- WebUI surface/sync chat context prompts
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/README.md`
Scope boundaries:
- No new note-writing automation or UI permission surface is added.
- No notes-provider authentication transport is changed.
- No runtime adapter, session schema, or data-at-rest contract is changed.
Evidence needed before claiming done:
- Focused Python compile and regression tests pass.

## Risks / Follow-ups
- A future UI receipt or explicit “ask before saving” setting could provide stronger user-facing controls, but that is intentionally out of scope here.
- Any provider-specific notes API compatibility fix should be handled in a separate focused PR.
