### PR TITLE
fix: add Joplin search auth compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Joplin notes search now keeps the `Authorization` header and adds a query-token compatibility shim only for Web Clipper `/search` calls, covering clipper builds that return HTTP 403 for header-only search auth while keeping other Joplin API URLs token-free.
+
 ## [v0.51.157] — 2026-05-28 — Release EC (stage-batch39 — 5-PR mixed-risk cleanup: gateway prefill forward + prefill budget + compressed-continuation sidebar + browser-transcript memory guidance + reasoning max parity)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -12969,6 +12969,11 @@ def _joplin_api_get(path: str, params: dict | None = None) -> dict:
         raise ValueError("Joplin token is not configured")
     safe_path = "/" + str(path or "").lstrip("/")
     query = dict(params or {})
+    # Joplin Web Clipper builds can reject header-only auth on /search even when
+    # they accept it elsewhere. Keep the Authorization header for defense in
+    # depth and add the query token only for /search compatibility.
+    if safe_path == "/search":
+        query["token"] = token
     url = f"{base_url}{safe_path}?{urlencode(query)}"
     request = Request(url, headers={"Authorization": f"token {token}"})
     try:

--- a/tests/test_webui_notes_sources.py
+++ b/tests/test_webui_notes_sources.py
@@ -138,7 +138,7 @@ def test_joplin_get_note_validates_id_and_truncates_body(monkeypatch):
     assert "Preview truncated" in note["body"]
 
 
-def test_joplin_api_get_uses_authorization_header(monkeypatch):
+def test_joplin_api_get_sends_header_and_query_token_for_clip_search_compat(monkeypatch):
     from api import routes
 
     captured = {}
@@ -162,10 +162,40 @@ def test_joplin_api_get_uses_authorization_header(monkeypatch):
     monkeypatch.setattr(routes, "_joplin_connection_from_config", lambda: ("http://127.0.0.1:41184", "secret-token"))
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
-    data = routes._joplin_api_get("/notes", {"query": "hello world"})
+    data = routes._joplin_api_get("/search", {"query": "hello world"})
 
     assert data == {"ok": True}
     assert captured["timeout"] == 8
+    assert "token=secret-token" in captured["url"]
+    assert "query=hello+world" in captured["url"]
+    assert captured["authorization"] == "token secret-token"
+
+
+def test_joplin_api_get_keeps_non_search_token_out_of_url(monkeypatch):
+    from api import routes
+
+    captured = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self, _limit):
+            return b'{"ok": true}'
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["authorization"] = request.get_header("Authorization")
+        return FakeResponse()
+
+    monkeypatch.setattr(routes, "_joplin_connection_from_config", lambda: ("http://127.0.0.1:41184", "secret-token"))
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    routes._joplin_api_get("/notes", {"query": "hello world"})
+
     assert "token=" not in captured["url"]
     assert "query=hello+world" in captured["url"]
     assert captured["authorization"] == "token secret-token"


### PR DESCRIPTION
## Thinking Path
- Keep this PR focused only on the Joplin Web Clipper search authentication compatibility issue.
- Preserve the existing Authorization-header behavior from the prior defense-in-depth fix, and add the query token only where local Web Clipper search rejects header-only auth.

## What Changed
- `_joplin_api_get` keeps sending `Authorization: token ...` for all Joplin API requests.
- `/search` requests also include the token as a query parameter as a compatibility shim for Web Clipper builds that return HTTP 403 for header-only search auth.
- Non-search Joplin API URLs remain token-free.
- Tests now cover both the `/search` compatibility path and the non-search token-free URL behavior.
- Added a focused changelog entry.

## Why It Matters
- Restores WebUI Joplin notes search on Web Clipper builds where `/search` rejects header-only auth.
- Avoids fully reverting the prior URL-token leak mitigation: only `/search` gets the query-token shim, while all requests still keep the Authorization header.
- Keeps this provider-specific bug separate from the external-notes guardrail PR.

## Local Compatibility Evidence
- Local Web Clipper `/ping`: 200, `JoplinClipperServer`.
- Local Web Clipper `/version`: 404 unavailable.
- Local `/search` with header-only auth: HTTP 403.
- Local `/search` with query-token auth: HTTP 200.
- Local `/search` with both header and query-token auth: HTTP 200.

## Verification
- `python -m pytest tests/test_webui_notes_sources.py::test_joplin_api_get_sends_header_and_query_token_for_clip_search_compat tests/test_webui_notes_sources.py::test_joplin_api_get_keeps_non_search_token_out_of_url -q`
- `python -m py_compile api/routes.py`
- `python -m pytest tests/test_webui_notes_sources.py -q`
- `git diff --check`

## Contract Routing
Task type: small provider-specific bug fix
Touched areas:
- Joplin Web Clipper helper
- Joplin notes source regression tests
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
Scope boundaries:
- No external-notes durable-write policy changes are included.
- No UI permission surface or note-writing automation is added.
- Non-search Joplin API URLs remain token-free.
Evidence needed before claiming done:
- Focused Joplin notes-source tests pass.
