### PR TITLE
fix: polish WebUI assistant replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- WebUI chat instructions now explicitly prevent terse scratchpad/planning fragments from appearing in visible assistant replies, while still allowing clear user-facing progress updates during tool-heavy work.
+
 ## [v0.51.157] — 2026-05-28 — Release EC (stage-batch39 — 5-PR mixed-risk cleanup: gateway prefill forward + prefill budget + compressed-continuation sidebar + browser-transcript memory guidance + reasoning max parity)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -9628,6 +9628,7 @@ def _handle_chat_sync(handler, body):
                 session_id=s.session_id,
             )
             from api.streaming import (
+                _WEBUI_PROGRESS_PROMPT,
                 _dedupe_replayed_context_messages,
                 _merge_display_messages_after_agent_result,
                 _restore_display_reasoning_metadata,
@@ -9646,7 +9647,8 @@ def _handle_chat_sync(handler, body):
                 "prompt, memory, or conversation history. Always use the value from the most recent "
                 "[Workspace::v1: ...] tag as your default working directory for ALL file operations: "
                 "write_file, read_file, search_files, terminal workdir, and patch. "
-                "Never fall back to a hardcoded path when this tag is present."
+                "Never fall back to a hardcoded path when this tag is present.\n\n"
+                f"{_WEBUI_PROGRESS_PROMPT}"
             )
 
             _previous_messages = list(s.messages or [])

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -203,6 +203,7 @@ WebUI progress guidance:
 - Each update should say what you are about to check, what you just confirmed, or why the next tool call is needed.
 - Keep updates concise, factual, and in the user's language. One or two short sentences are enough.
 - Do not reveal hidden reasoning, chain-of-thought, private scratchpads, secrets, raw logs, or long tool output.
+- Do not include terse planning fragments or scratchpad shorthand in visible assistant text. Avoid fragments like "Need check logs", "Need inspect email", or "maybe invite"; either omit them or rewrite them as clear user-facing progress.
 - For direct answers or very short tasks, skip progress updates and answer normally.
 """.strip()
 

--- a/tests/test_webui_surface_context.py
+++ b/tests/test_webui_surface_context.py
@@ -22,6 +22,9 @@ def test_webui_ephemeral_prompt_includes_browser_surface_context():
     assert "Do not copy or dump this browser transcript" in prompt
     assert "explicit captures" in prompt
     assert "durable user preferences" in prompt
+    assert "Do not include terse planning fragments" in prompt
+    assert "Need inspect email" in prompt
+    assert "clear user-facing progress" in prompt
 
 
 def test_webui_ephemeral_prompt_skips_empty_surface_fields():


### PR DESCRIPTION
## Thinking Path
- Browser chat should preserve normal Hermes answer quality while still allowing concise progress updates during tool-heavy work.
- Terse planning fragments such as "Need check logs" are useful as internal scratchpad shorthand, but they are confusing when persisted as visible assistant text.
- The fix should be prompt-level and narrowly scoped before adding any aggressive output sanitizer.

## What Changed
- Tightens the WebUI progress guidance so visible assistant text must not include terse scratchpad/planning fragments.
- Reuses the same progress guidance in the synchronous `/api/chat` path so both WebUI chat paths get the same final-answer polish instruction.
- Adds regression coverage asserting the WebUI ephemeral prompt includes the new final-answer polish guidance.
- Adds a changelog entry for the user-visible behavior change.

## Why It Matters
Users should see clear, readable final answers and progress updates, not internal shorthand such as "Need inspect email" or "maybe invite" at the start of assistant replies.

## Verification
- `python -m py_compile api/routes.py api/streaming.py`
- `python -m pytest tests/test_webui_surface_context.py -q`
- `git diff --check`

## Risks / Follow-ups
- This is intentionally prompt-level guidance, not a content sanitizer. If models still emit scratchpad fragments, a follow-up can add a carefully bounded sanitizer after more examples are collected.
