### PR TITLE
fix(models): preserve provider-qualified model selections in the picker

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -1068,6 +1068,13 @@ function _findModelInDropdown(modelId, sel, preferredProviderId){
   if(opts.includes(modelId)) return modelId;
   const exact=opts.find(o=>norm(o)===target);
   if(exact) return exact;
+  // If the request is provider-qualified (either explicit @provider:model or
+  // a slash-qualified vendor/model id), do NOT fuzzy-match a sibling model
+  // once exact/provider-aware lookup failed. Returning null lets the caller
+  // preserve the raw typed value instead of snapping to the closest catalog
+  // entry. This keeps uncatalogued models routable instead of silently turning
+  // them into a nearby curated sibling.
+  if(rawModel.startsWith('@')||rawModel.includes('/')) return null;
   // 3. Prefix/substring: require the candidate to start with the FULL normalized target
   // (not a truncated base). This avoids false matches like gpt.5.5 → gpt.5.4.mini (#1188).
   // Only fall back to the shorter base form if target itself is very short (a bare root

--- a/tests/test_issue1188_fuzzy_match.py
+++ b/tests/test_issue1188_fuzzy_match.py
@@ -45,10 +45,22 @@ function extractFunc(name) {
   }
   return ui.slice(start, i);
 }
+function _getOptionProviderId(opt) {
+  if (!opt) return '';
+  if (opt.dataset && opt.dataset.provider) return opt.dataset.provider;
+  const group = opt.parentElement;
+  if (group && group.tagName === 'OPTGROUP' && group.dataset && group.dataset.provider) {
+    return group.dataset.provider;
+  }
+  const value = String(opt.value || '');
+  if (value.startsWith('@') && value.includes(':')) return value.slice(1, value.lastIndexOf(':'));
+  return '';
+}
+
 eval(extractFunc('_findModelInDropdown'));
 const args = JSON.parse(process.argv[3]);
 const sel = { options: args.options.map(v => ({value: v})) };
-const got = _findModelInDropdown(args.modelId, sel);
+const got = _findModelInDropdown(args.modelId, sel, args.preferredProvider || undefined);
 process.stdout.write(JSON.stringify(got));
 """
 
@@ -60,11 +72,11 @@ def driver_path(tmp_path_factory):
     return str(p)
 
 
-def _find(driver_path, model_id: str, options: list[str]):
+def _find(driver_path, model_id: str, options: list[str], preferred: str | None = None):
     import json
     result = subprocess.run(
         [NODE, driver_path, str(UI_JS_PATH),
-         json.dumps({"modelId": model_id, "options": options})],
+         json.dumps({"modelId": model_id, "options": options, "preferredProvider": preferred})],
         capture_output=True, text=True, timeout=10,
     )
     if result.returncode != 0:
@@ -112,6 +124,33 @@ class TestPreservedFuzzyMatches:
             ["@nous:openai/gpt-5.5", "@nous:openai/gpt-5.4-mini"],
         )
         assert got == "@nous:openai/gpt-5.5"
+
+    def test_explicit_provider_hint_does_not_snap_to_sibling_model(self, driver_path):
+        """Provider-qualified requests must not fuzzy-match a sibling catalog entry.
+
+        This is the generalized regression behind #3113: any slash-qualified or
+        @provider-qualified model that is missing from the curated catalog should
+        preserve its exact value instead of snapping to a nearby curated sibling.
+        """
+        got = _find(
+            driver_path,
+            "vendor/special-model",
+            ["@openrouter:vendor/special-model-pro"],
+            preferred="openrouter",
+        )
+        assert got is None, (
+            "provider-qualified uncatalogued models must not fuzzy-match sibling models "
+            "(#3113)"
+        )
+
+    def test_provider_qualified_exact_match_still_resolves(self, driver_path):
+        got = _find(
+            driver_path,
+            "vendor/special-model",
+            ["@openrouter:vendor/special-model"],
+            preferred="openrouter",
+        )
+        assert got == "@openrouter:vendor/special-model"
 
     def test_bare_root_gpt_matches_versioned_option(self, driver_path):
         """Short root targets still fall back to the looser prefix match."""


### PR DESCRIPTION
## Bug Description
Provider-qualified model selections that were not already in the curated picker list were being silently snapped to a nearby curated sibling. That made uncatalogued routable models appear to work in the picker while actually resolving to the wrong model.

Fixes #3113

## Root Cause
 allowed fuzzy prefix/substring fallback even when the request was provider-qualified, so a missing model like  could resolve to .

## Fix
- Treat provider-qualified requests ( and ) as exact-only after the exact/provider-aware lookup.
- If there is no exact match, return  so the caller can preserve the raw typed selection instead of snapping to a curated sibling.

## How to Verify
1. Open the WebUI model picker or use the Custom Model Id input.
2. Enter a provider-qualified model that is missing from the curated catalog.
3. Confirm the picker preserves the typed selection instead of snapping to a similar curated model.
4. Run the updated regression tests for provider-qualified picker behavior.

## Test Plan
- [x] Added regression test for provider-qualified uncatalogued selections
- [x] Existing tests still pass
- [x] Manual verification of the fix

## Risk Assessment
Low — the change only narrows fuzzy fallback behavior for provider-qualified inputs, leaving bare search strings unaffected.