### PR TITLE
fix: explain unavailable browser tools in WebUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- WebUI now injects safe tool-availability diagnostics into browser chat context, so agents can explain when browser tools are enabled but filtered out by backend requirements instead of claiming WebUI/API sessions permanently lack browser access.
+
 ## [v0.51.157] — 2026-05-28 — Release EC (stage-batch39 — 5-PR mixed-risk cleanup: gateway prefill forward + prefill budget + compressed-continuation sidebar + browser-transcript memory guidance + reasoning max parity)
 
 ### Added

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -40,6 +40,7 @@ from api.config import (
 from api.helpers import redact_session_data, _redact_text
 from api.compression_anchor import is_context_compression_marker, visible_messages_for_anchor
 from api.metering import meter
+from api.tool_availability import build_tool_availability_context, tool_availability_prompt_lines
 from api.run_journal import RunJournalWriter
 from api.turn_journal import append_turn_journal_event_for_stream
 from api.usage import prompt_cache_hit_percent
@@ -235,6 +236,11 @@ def _webui_surface_context_prompt(surface_context: Optional[dict]) -> str:
         value = str(raw).strip() if raw is not None else ""
         if value:
             lines.append(f"- {label}: {value}")
+    tool_availability = surface_context.get("tool_availability")
+    availability_lines = tool_availability_prompt_lines(tool_availability)
+    if availability_lines:
+        lines.append("Tool availability diagnostics:")
+        lines.extend(availability_lines)
     return "\n".join(lines)
 
 
@@ -4951,6 +4957,11 @@ def _run_agent_streaming(
             # (agent's own mechanism). This preserves any selected personality
             # while making long tool runs emit real user-visible interim text
             # through interim_assistant_callback instead of frontend guesses.
+            _tool_availability = build_tool_availability_context(
+                enabled_toolsets=_toolsets,
+                agent_tools=getattr(agent, 'tools', None),
+                cfg=_cfg,
+            )
             agent.ephemeral_system_prompt = _webui_ephemeral_system_prompt(
                 _personality_prompt,
                 surface_context={
@@ -4958,6 +4969,7 @@ def _run_agent_streaming(
                     'session_id': session_id,
                     'profile': getattr(s, 'profile', None),
                     'workspace': s.workspace,
+                    'tool_availability': _tool_availability,
                 },
             )
             _pending_started_at = getattr(s, 'pending_started_at', None)

--- a/api/tool_availability.py
+++ b/api/tool_availability.py
@@ -1,0 +1,137 @@
+"""Safe agent tool availability diagnostics for WebUI runtime prompts.
+
+The Hermes Agent tool list is the result of two separate filters:
+
+1. platform/session toolsets (for example, whether ``browser`` is enabled), and
+2. per-tool requirement checks (for example, whether the selected browser
+   backend has a CLI, browser binary, or cloud credentials).
+
+WebUI should not let the model infer permanent platform limitations from a tool
+that is enabled but currently filtered out.  This module builds a tiny,
+non-secret diagnostic block that can be included in ephemeral session context.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+_BROWSER_TOOL_PREFIX = "browser_"
+_BROWSER_CLOUD_ENV_HINTS = {
+    "browser-use": ("BROWSER_USE_API_KEY",),
+    "browser_use": ("BROWSER_USE_API_KEY",),
+    "browserbase": ("BROWSERBASE_API_KEY", "BROWSERBASE_PROJECT_ID"),
+    "firecrawl": ("FIRECRAWL_API_KEY",),
+}
+
+
+def _tool_name(tool: Any) -> str:
+    if isinstance(tool, dict):
+        function = tool.get("function")
+        if isinstance(function, dict):
+            return str(function.get("name") or "")
+        return str(tool.get("name") or "")
+    return str(getattr(tool, "name", "") or "")
+
+
+def _tool_names(tools: Iterable[Any] | None) -> set[str]:
+    return {name for tool in (tools or []) if (name := _tool_name(tool))}
+
+
+def _browser_provider_from_config(cfg: dict[str, Any] | None) -> str:
+    browser_cfg = (cfg or {}).get("browser") or {}
+    provider = browser_cfg.get("cloud_provider")
+    if provider is None or str(provider).strip() == "":
+        return "local"
+    return str(provider).strip()
+
+
+def _browser_hint(provider: str, available: bool) -> str:
+    if available:
+        return "Browser tools are available in this WebUI session."
+    normalized = provider.lower()
+    env_names = _BROWSER_CLOUD_ENV_HINTS.get(normalized)
+    if env_names:
+        return (
+            "Browser toolset is enabled, but the selected browser backend is not ready. "
+            f"Configure {', '.join(env_names)} or switch browser.cloud_provider to local."
+        )
+    if normalized == "local":
+        return (
+            "Browser toolset is enabled, but local browser requirements are not ready. "
+            "Install/configure agent-browser and a supported browser engine."
+        )
+    return (
+        "Browser toolset is enabled, but browser tools were filtered out by Hermes Agent "
+        "requirement checks for the selected backend."
+    )
+
+
+def build_tool_availability_context(
+    *,
+    enabled_toolsets: Iterable[str] | None,
+    agent_tools: Iterable[Any] | None,
+    cfg: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a small safe summary of tool availability for WebUI context.
+
+    The payload intentionally contains no paths, command lines, tokens, or raw
+    config.  It reports only the distinction a user-facing answer needs: whether
+    a capability's toolset was requested and whether actual schemas survived
+    Hermes Agent's requirement checks.
+    """
+    toolsets = {str(name).strip() for name in (enabled_toolsets or []) if str(name).strip()}
+    names = _tool_names(agent_tools)
+
+    browser_toolset_enabled = "browser" in toolsets
+    browser_tools = sorted(name for name in names if name.startswith(_BROWSER_TOOL_PREFIX))
+    browser_available = bool(browser_tools)
+    provider = _browser_provider_from_config(cfg)
+
+    if not browser_toolset_enabled and not browser_available:
+        return {
+            "browser": {
+                "toolset_enabled": False,
+                "available": False,
+                "reason": "browser_toolset_not_enabled",
+                "hint": "Browser tools are not enabled for this WebUI session.",
+            }
+        }
+
+    reason = "available" if browser_available else "browser_requirements_unmet"
+    return {
+        "browser": {
+            "toolset_enabled": browser_toolset_enabled,
+            "available": browser_available,
+            "reason": reason,
+            "provider": provider,
+            "tools": browser_tools[:12],
+            "hint": _browser_hint(provider, browser_available),
+        }
+    }
+
+
+def tool_availability_prompt_lines(tool_availability: dict[str, Any] | None) -> list[str]:
+    """Render a compact prompt-safe diagnostic list for the agent."""
+    if not isinstance(tool_availability, dict):
+        return []
+    browser = tool_availability.get("browser")
+    if not isinstance(browser, dict):
+        return []
+
+    enabled = bool(browser.get("toolset_enabled"))
+    available = bool(browser.get("available"))
+    lines = [
+        "- Browser toolset enabled: " + ("yes" if enabled else "no"),
+        "- Browser tools available: " + ("yes" if available else "no"),
+    ]
+    provider = str(browser.get("provider") or "").strip()
+    if provider:
+        lines.append(f"- Browser backend: {provider}")
+    hint = str(browser.get("hint") or "").strip()
+    if hint:
+        lines.append(f"- Browser availability note: {hint}")
+    if enabled and not available:
+        lines.append(
+            "- If asked about browser access, explain this as enabled-but-unavailable "
+            "runtime configuration, not as a permanent WebUI/API limitation."
+        )
+    return lines

--- a/tests/test_tool_availability_context.py
+++ b/tests/test_tool_availability_context.py
@@ -1,0 +1,56 @@
+from api.streaming import _webui_surface_context_prompt
+from api.tool_availability import build_tool_availability_context, tool_availability_prompt_lines
+
+
+def test_browser_toolset_enabled_but_filtered_reports_runtime_config_issue():
+    payload = build_tool_availability_context(
+        enabled_toolsets=["browser", "terminal"],
+        agent_tools=[{"function": {"name": "terminal"}}],
+        cfg={"browser": {"cloud_provider": "browser-use"}},
+    )
+
+    browser = payload["browser"]
+    assert browser["toolset_enabled"] is True
+    assert browser["available"] is False
+    assert browser["reason"] == "browser_requirements_unmet"
+    assert browser["provider"] == "browser-use"
+    assert "BROWSER_USE_API_KEY" in browser["hint"]
+    assert "permanent WebUI/API limitation" in "\n".join(tool_availability_prompt_lines(payload))
+
+
+def test_browser_tools_available_reports_available_tools():
+    payload = build_tool_availability_context(
+        enabled_toolsets=["browser"],
+        agent_tools=[
+            {"function": {"name": "browser_navigate"}},
+            {"function": {"name": "browser_snapshot"}},
+        ],
+        cfg={"browser": {"cloud_provider": "local"}},
+    )
+
+    browser = payload["browser"]
+    assert browser["available"] is True
+    assert browser["reason"] == "available"
+    assert browser["tools"] == ["browser_navigate", "browser_snapshot"]
+
+
+def test_webui_surface_context_includes_tool_availability_note():
+    prompt = _webui_surface_context_prompt(
+        {
+            "source": "webui",
+            "session_id": "session-123",
+            "workspace": "/workspace",
+            "tool_availability": build_tool_availability_context(
+                enabled_toolsets=["browser"],
+                agent_tools=[],
+                cfg={"browser": {"cloud_provider": "browser-use"}},
+            ),
+        }
+    )
+
+    assert "Source: webui" in prompt
+    assert "Session ID: session-123" in prompt
+    assert "Tool availability diagnostics:" in prompt
+    assert "Browser toolset enabled: yes" in prompt
+    assert "Browser tools available: no" in prompt
+    assert "enabled-but-unavailable runtime configuration" in prompt


### PR DESCRIPTION
## Summary
- Adds a safe WebUI runtime diagnostic for enabled-but-filtered browser tools
- Includes the diagnostic in the ephemeral WebUI session context so agents can explain backend/config readiness instead of saying browser access is categorically unavailable
- Covers the browser-use credentials-missing case and available-browser-tools case with focused tests

## Test Plan
- `python3.11 -m py_compile api/tool_availability.py api/streaming.py`
- `python3.11 -m pytest tests/test_tool_availability_context.py -q`
- `git diff --check`
