### PR TITLE
Release v0.51.162 — Release EH (stage-batch44: conversation-filter clear button + title-lang regression coverage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Conversation filtering now shows a clear button inside the search field whenever text is present, letting users clear the filter with one click.
+
 ## [v0.51.161] — 2026-05-29 — Release EG (stage-batch43 — 3-PR live-display fixes: jump-to-question on intermediate assistant messages + per-turn usage badge persistence + stale unread/compression-timer/tool-card dedup)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+## [v0.51.162] — 2026-05-30 — Release EH (stage-batch44 — conversation-filter clear button + code-only title-language regression coverage)
+
 ### Added
 
 - Conversation filtering now shows a clear button inside the search field whenever text is present, letting users clear the filter with one click.

--- a/static/boot.js
+++ b/static/boot.js
@@ -1224,7 +1224,10 @@ document.addEventListener('keydown',async e=>{
     closeWsDropdown();
     // Clear session search
     const ss=$('sessionSearch');
-    if(ss&&ss.value){ss.value='';filterSessions();}
+    if(ss&&ss.value){
+      if(typeof clearSessionSearch==='function') clearSessionSearch(false);
+      else { ss.value=''; filterSessions(); }
+    }
     // Cancel any active message edit
     const editArea=document.querySelector('.msg-edit-area');
     if(editArea){
@@ -1754,6 +1757,7 @@ function applyBotName(){
   // separately below by a `pageshow` listener — the async IIFE here does NOT
   // re-run when the browser restores the page from bfcache.
   const _srch = document.getElementById('sessionSearch'); if (_srch) _srch.value = '';
+  if (typeof syncSessionSearchClear === 'function') syncSessionSearchClear();
   // Initialize reasoning chip on boot (fixes #1103 — chip hidden until session load)
   if(typeof fetchReasoningChip==='function') fetchReasoningChip();
   if(typeof refreshProviderQuotaIndicator==='function') refreshProviderQuotaIndicator();
@@ -1858,6 +1862,7 @@ window.addEventListener('pageshow', async (event) => {
   if (!event.persisted) return;  // fresh loads are handled by the IIFE above
   const _srch = document.getElementById('sessionSearch');
   if (_srch) _srch.value = '';
+  if (typeof syncSessionSearchClear === 'function') syncSessionSearchClear();
   // Close any dropdowns/popovers that were open when the user navigated away.
   // bfcache freezes DOM state, so a dropdown left open remains open on restore.
   if (typeof closeModelDropdown === 'function') try { closeModelDropdown(); } catch (_) {}

--- a/static/index.html
+++ b/static/index.html
@@ -195,7 +195,7 @@
           </button>
         </div>
       </div>
-      <div class="session-search sidebar-search"><svg class="sidebar-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg><input id="sessionSearch" placeholder="Filter conversations..." data-i18n-placeholder="filter_conversations" oninput="filterSessions()" autocomplete="off"></div>
+      <div class="session-search sidebar-search"><div class="session-search-field"><svg class="sidebar-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg><input id="sessionSearch" placeholder="Filter conversations..." data-i18n-placeholder="filter_conversations" oninput="filterSessions()" autocomplete="off"><button type="button" id="sessionSearchClear" class="session-search-clear has-tooltip has-tooltip--bottom-right" aria-label="Clear conversation filter" data-tooltip="Clear conversation filter" onclick="clearSessionSearch()" hidden><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button></div></div>
       <div class="session-list" id="sessionList"></div>
     </div>
     <!-- Tasks (cron) panel -->

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2666,9 +2666,29 @@ function _sessionSearchContentPreview(session, query){
   return preview||'';
 }
 
+function syncSessionSearchClear(){
+  const input=$('sessionSearch');
+  const clear=$('sessionSearchClear');
+  if(!input||!clear) return;
+  clear.hidden=!Boolean(input.value);
+}
+
+function clearSessionSearch(focusInput=true){
+  const input=$('sessionSearch');
+  if(!input) return;
+  if(input.value){
+    input.value='';
+    filterSessions();
+  }else{
+    syncSessionSearchClear();
+  }
+  if(focusInput) input.focus();
+}
+
 function filterSessions(){
   // Immediate client-side title filter (no flicker)
   // Debounced content search via API for message text
+  syncSessionSearchClear();
   const q = ($('sessionSearch').value || '').trim();
   if(q!==_lastSessionSearchQuery){
     _lastSessionSearchQuery=q;

--- a/static/style.css
+++ b/static/style.css
@@ -701,13 +701,14 @@
   .new-chat-btn{width:100%;padding:9px 12px;border-radius:9px;background:var(--accent-bg);border:1px solid var(--accent-bg-strong);color:var(--accent-text);font-size:13px;cursor:pointer;display:flex;align-items:center;gap:8px;transition:all .15s;margin-bottom:8px;font-weight:500;}
   .new-chat-btn:hover{background:var(--accent-bg-strong);border-color:var(--accent);}
   .session-list{flex:1;overflow-y:auto;padding:0 8px 8px;min-height:0;overscroll-behavior-y:contain;touch-action:pan-y;overflow-anchor:none;}
-  .sidebar-search{padding:8px 12px;flex-shrink:0;}
+  .sidebar-search{position:relative;padding:8px 12px;flex-shrink:0;}
   .session-search-field{position:relative;display:flex;align-items:center;width:100%;}
   .sidebar-search input{width:100%;background:var(--bg);border:1px solid var(--border);border-radius:8px;color:var(--text);padding:7px 10px 7px 32px;font-size:13px;outline:none;transition:border-color .15s,box-shadow .15s,background .15s;box-sizing:border-box;}
   .session-search input{padding-right:34px;}
   .sidebar-search input:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-bg);}
   .sidebar-search input::placeholder{color:var(--muted);opacity:.7;}
-  .sidebar-search-icon{position:absolute;left:10px;top:50%;transform:translateY(-50%);width:14px;height:14px;color:var(--muted);opacity:.7;pointer-events:none;}
+  .sidebar-search-icon{position:absolute;left:22px;top:50%;transform:translateY(-50%);width:14px;height:14px;color:var(--muted);opacity:.7;pointer-events:none;}
+  .session-search .sidebar-search-icon{left:10px;}
   .session-search .session-search-clear{position:absolute;right:6px;top:50%;transform:translateY(-50%);z-index:1;width:24px;height:24px;border:0;border-radius:6px;background:transparent;color:var(--muted);display:flex;align-items:center;justify-content:center;padding:0;cursor:pointer;opacity:.78;}
   .session-search-clear[hidden]{display:none;}
   .session-search-clear svg{width:14px;height:14px;}

--- a/static/style.css
+++ b/static/style.css
@@ -701,11 +701,18 @@
   .new-chat-btn{width:100%;padding:9px 12px;border-radius:9px;background:var(--accent-bg);border:1px solid var(--accent-bg-strong);color:var(--accent-text);font-size:13px;cursor:pointer;display:flex;align-items:center;gap:8px;transition:all .15s;margin-bottom:8px;font-weight:500;}
   .new-chat-btn:hover{background:var(--accent-bg-strong);border-color:var(--accent);}
   .session-list{flex:1;overflow-y:auto;padding:0 8px 8px;min-height:0;overscroll-behavior-y:contain;touch-action:pan-y;overflow-anchor:none;}
-  .sidebar-search{position:relative;padding:8px 12px;flex-shrink:0;}
+  .sidebar-search{padding:8px 12px;flex-shrink:0;}
+  .session-search-field{position:relative;display:flex;align-items:center;width:100%;}
   .sidebar-search input{width:100%;background:var(--bg);border:1px solid var(--border);border-radius:8px;color:var(--text);padding:7px 10px 7px 32px;font-size:13px;outline:none;transition:border-color .15s,box-shadow .15s,background .15s;box-sizing:border-box;}
+  .session-search input{padding-right:34px;}
   .sidebar-search input:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-bg);}
   .sidebar-search input::placeholder{color:var(--muted);opacity:.7;}
-  .sidebar-search-icon{position:absolute;left:22px;top:50%;transform:translateY(-50%);width:14px;height:14px;color:var(--muted);opacity:.7;pointer-events:none;}
+  .sidebar-search-icon{position:absolute;left:10px;top:50%;transform:translateY(-50%);width:14px;height:14px;color:var(--muted);opacity:.7;pointer-events:none;}
+  .session-search .session-search-clear{position:absolute;right:6px;top:50%;transform:translateY(-50%);z-index:1;width:24px;height:24px;border:0;border-radius:6px;background:transparent;color:var(--muted);display:flex;align-items:center;justify-content:center;padding:0;cursor:pointer;opacity:.78;}
+  .session-search-clear[hidden]{display:none;}
+  .session-search-clear svg{width:14px;height:14px;}
+  .session-search-clear:hover,.session-search-clear:focus-visible{background:var(--hover);color:var(--text);opacity:1;}
+  .session-search-clear:focus-visible{outline:2px solid var(--accent);outline-offset:1px;}
   /* Inline session title edit */
   .session-title-input{flex:1;background:var(--surface);border:1px solid var(--accent);border-radius:6px;color:var(--text);padding:3px 8px;font-size:13px;outline:none;min-width:0;box-shadow:0 0 0 2px var(--accent-bg-strong);font-family:inherit;}
   /* padding-right was 86px to reserve space for the absolute-positioned

--- a/tests/test_sidebar_search_highlights.py
+++ b/tests/test_sidebar_search_highlights.py
@@ -102,9 +102,11 @@ def test_session_search_has_accessible_clear_button():
 
 def test_session_search_clear_button_styles_do_not_shift_input_width():
     css = STYLE_CSS.read_text(encoding="utf-8")
+    assert ".sidebar-search{position:relative;padding:8px 12px;flex-shrink:0;}" in css
     assert ".session-search-field{position:relative;display:flex;align-items:center;width:100%;}" in css
     assert ".session-search input{padding-right:34px;}" in css
-    assert ".sidebar-search-icon{position:absolute;left:10px;top:50%;transform:translateY(-50%);" in css
+    assert ".sidebar-search-icon{position:absolute;left:22px;top:50%;transform:translateY(-50%);" in css
+    assert ".session-search .sidebar-search-icon{left:10px;}" in css
     assert ".session-search .session-search-clear{position:absolute;" in css
     assert "right:6px;top:50%;transform:translateY(-50%)" in css
     assert "z-index:1" in css

--- a/tests/test_sidebar_search_highlights.py
+++ b/tests/test_sidebar_search_highlights.py
@@ -7,6 +7,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 SESSIONS_JS = ROOT / "static" / "sessions.js"
 STYLE_CSS = ROOT / "static" / "style.css"
+INDEX_HTML = ROOT / "static" / "index.html"
 
 
 def _run_js_ranges(cases):
@@ -85,3 +86,63 @@ def test_sidebar_search_rendering_uses_safe_dom_helpers():
     assert "if(($('sessionSearch').value||'').trim()) _hideSearchPreviewsAfterSelect=true;" in src
     assert ".session-search-preview" in css
     assert "-webkit-line-clamp:2" in css
+
+
+def test_session_search_has_accessible_clear_button():
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    assert '<div class="session-search sidebar-search"><div class="session-search-field">' in html
+    clear = re.search(r'<button[^>]*id="sessionSearchClear"[^>]*>', html)
+    assert clear, "#sessionSearchClear button not found beside #sessionSearch"
+    tag = clear.group(0)
+    assert 'type="button"' in tag
+    assert 'hidden' in tag
+    assert 'onclick="clearSessionSearch()"' in tag
+    assert 'aria-label="Clear conversation filter"' in tag
+
+
+def test_session_search_clear_button_styles_do_not_shift_input_width():
+    css = STYLE_CSS.read_text(encoding="utf-8")
+    assert ".session-search-field{position:relative;display:flex;align-items:center;width:100%;}" in css
+    assert ".session-search input{padding-right:34px;}" in css
+    assert ".sidebar-search-icon{position:absolute;left:10px;top:50%;transform:translateY(-50%);" in css
+    assert ".session-search .session-search-clear{position:absolute;" in css
+    assert "right:6px;top:50%;transform:translateY(-50%)" in css
+    assert "z-index:1" in css
+    assert ".session-search-clear[hidden]{display:none;}" in css
+    assert ".session-search-clear:focus-visible" in css
+
+
+def test_session_search_clear_sync_and_click_behaviour():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    start = src.index("function syncSessionSearchClear")
+    end = src.index("function filterSessions", start)
+    helper = src[start:end]
+    script = helper + r"""
+const input = { value: 'Psalm', focused: false, focus(){ this.focused = true; } };
+const clear = { hidden: true };
+let filtered = 0;
+function $(id){ return id === 'sessionSearch' ? input : clear; }
+function filterSessions(){ filtered += 1; syncSessionSearchClear(); }
+syncSessionSearchClear();
+const visibleAfterText = clear.hidden === false;
+clearSessionSearch();
+const clearedOnClick = input.value === '' && clear.hidden === true && filtered === 1 && input.focused === true;
+input.value = 'again';
+input.focused = false;
+clearSessionSearch(false);
+const preserveFocus = input.value === '' && clear.hidden === true && filtered === 2 && input.focused === false;
+console.log(JSON.stringify({visibleAfterText, clearedOnClick, preserveFocus}));
+"""
+    completed = subprocess.run(
+        ["node", "-e", script],
+        check=True,
+        text=True,
+        capture_output=True,
+        cwd=ROOT,
+    )
+    result = json.loads(completed.stdout)
+    assert result == {
+        "visibleAfterText": True,
+        "clearedOnClick": True,
+        "preserveFocus": True,
+    }

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -305,6 +305,16 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
         self.assertNotEqual(title, 'Session Bilder')
         self.assertIn('Warum', title)
 
+    def test_code_only_first_message_does_not_trigger_german_language_guard(self):
+        """Code-only starts should fall through to the neutral/default title path."""
+        from api.streaming import _detect_title_language, _title_language_mismatch, _title_prompt_language_rule
+
+        code_only = "print('hello')\nfor i in range(3):\n    print(i)"
+
+        self.assertEqual(_detect_title_language(code_only), '')
+        self.assertEqual(_title_prompt_language_rule(code_only), 'Match the language of the user question.\n')
+        self.assertFalse(_title_language_mismatch(code_only, 'Python Hello Loop'))
+
     def test_configured_api_key_is_not_sent_to_caller_supplied_route(self):
         """Regression: title task keys must not leak to explicit fallback routes.
 


### PR DESCRIPTION
## Release v0.51.162 — Release EH (stage-batch44)

Small 2-PR batch. Full sequential pytest: 6827 passed, 0 failures.

### PRs included
- **#3026** (@george-andraws) — adds a clear (X) button inside the sidebar conversation-filter search field, visible only when text is present. **Screenshot-gated and approved by maintainer** (desktop 1440 + mobile 320px both verified: search icon left, text, X right, aligned, no overlap/clipping, X stays inside the field). The earlier cross-input CSS regression (kanban + skills search icon alignment) was fixed by the author by scoping the rule to `.session-search-field`; re-verified clean. PR's own test passes (10/10).
- **#2984** (@ai-ag2026) — test-only: adds regression coverage that a code-only first message doesn't trip the title-language guard (the implementation already shipped upstream; this PR now carries only the safety-net test). Verified the imported functions exist on master and the test passes.

### Verification
- `node -c` clean on boot.js, sessions.js
- no merge markers; CHANGELOG consolidated (clear-button entry under Added; #2984 is test-only, no user-facing entry)
- full sequential suite: 6827 passed, 11 skipped, 0 failures (177s)
- both PRs cherry-picked off stale bases onto fresh master (authorship preserved); #3026's CHANGELOG had a misplaced entry from its stale base which was relocated to the current `[Unreleased]`