### PR TITLE
Release v0.51.165 — Release EK (stage-batch47: stop EventSource reconnect storm #3103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.165] — 2026-05-30 — Release EK (stage-batch47 — stop EventSource reconnect storm on long-lived SSE streams)
+
+### Fixed
+
+- The session-events and gateway SSE streams no longer emit `Connection: close`, which browsers interpreted as a signal that the EventSource lifecycle had ended — triggering an instant reconnect loop that thrashed the session list roughly once per second and forced repeated re-renders / scroll-to-bottom (#3103, regression from the HTTP/1.1 keep-alive change in 598fd4ff). Finite responses that lack a `Content-Length` (e.g. the on-the-fly workspace ZIP download) keep `Connection: close` for unambiguous HTTP/1.1 message framing.
+
 ## [v0.51.164] — 2026-05-30 — Release EJ (stage-batch46 — passive performance hardening: refresh coalescing + draft-save dedup + activity placeholders + bounded restart-safety wait)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -7559,7 +7559,14 @@ def _handle_gateway_sse_stream(handler, parsed):
     handler.send_header('Content-Type', 'text/event-stream; charset=utf-8')
     handler.send_header('Cache-Control', 'no-cache')
     handler.send_header('X-Accel-Buffering', 'no')
-    handler.send_header('Connection', 'close')
+    # #3103: do NOT emit `Connection: close` on long-lived SSE streams.
+    # The python BaseHTTPServer worker only handles one request per
+    # connection anyway, but browsers (Chrome/Firefox) treat the close
+    # header as a hard signal that the EventSource lifecycle has ended
+    # and trigger an instant reconnect, producing a tight loop of
+    # connect/sessions_changed snapshot/disconnect that thrashes the
+    # session list every ~1s. Letting the server close the socket
+    # naturally after the stream ends is sufficient.
     handler.end_headers()
 
     q = watcher.subscribe()
@@ -7592,7 +7599,8 @@ def _handle_session_events_stream(handler):
     handler.send_header('Content-Type', 'text/event-stream; charset=utf-8')
     handler.send_header('Cache-Control', 'no-cache')
     handler.send_header('X-Accel-Buffering', 'no')
-    handler.send_header('Connection', 'close')
+    # #3103: see _handle_gateway_sse_stream — `Connection: close` causes
+    # EventSource reconnect storms in browsers on long-lived SSE.
     handler.end_headers()
 
     q = subscribe_session_events()

--- a/tests/test_issue3103_sse_no_connection_close.py
+++ b/tests/test_issue3103_sse_no_connection_close.py
@@ -1,0 +1,60 @@
+"""Regression test for #3103 / PR #3128.
+
+Commit 598fd4ff added `Connection: close` to the two long-lived SSE handlers
+(`_handle_gateway_sse_stream`, `_handle_session_events_stream`). Browsers treat
+`Connection: close` on an SSE response as a signal that the EventSource lifecycle
+has ended and auto-reconnect, producing a reconnect storm that thrashes the
+session list (#3103). These handlers must NOT emit `Connection: close`.
+
+Finite responses (the on-the-fly ZIP download, terminal SSE, etc.) still need the
+header for unambiguous HTTP/1.1 message boundaries — this test only pins the two
+long-lived session/gateway event streams.
+"""
+
+import re
+from pathlib import Path
+
+ROUTES = (Path(__file__).resolve().parents[1] / "api" / "routes.py").read_text(encoding="utf-8")
+
+
+def _handler_body(name: str) -> str:
+    """Return the source of a handler function from its `def` to the next top-level `def`."""
+    start = ROUTES.index(f"def {name}(")
+    # find the next top-level "def " after the function start
+    nxt = ROUTES.find("\ndef ", start + 1)
+    return ROUTES[start: nxt if nxt != -1 else len(ROUTES)]
+
+
+def _emits_connection_close(body: str) -> bool:
+    """True if the handler actually CALLS send_header to emit Connection: close
+    (ignores mentions in comments)."""
+    return bool(
+        re.search(r"send_header\(\s*['\"]Connection['\"]\s*,\s*['\"]close['\"]", body)
+    )
+
+
+def test_session_events_stream_does_not_emit_connection_close():
+    body = _handler_body("_handle_session_events_stream")
+    assert "text/event-stream" in body, "sanity: this is the SSE handler"
+    assert not _emits_connection_close(body), (
+        "_handle_session_events_stream must not emit `Connection: close` — it triggers "
+        "browser EventSource reconnect storms on this long-lived stream (#3103)"
+    )
+
+
+def test_gateway_sse_stream_does_not_emit_connection_close():
+    body = _handler_body("_handle_gateway_sse_stream")
+    assert "text/event-stream" in body, "sanity: this is the SSE handler"
+    assert not _emits_connection_close(body), (
+        "_handle_gateway_sse_stream must not emit `Connection: close` — it triggers "
+        "browser EventSource reconnect storms on this long-lived stream (#3103)"
+    )
+
+
+def test_connection_close_still_present_for_finite_zip_download():
+    """The on-the-fly ZIP download (no Content-Length) still needs Connection: close
+    for unambiguous HTTP/1.1 framing (#2836). Guard against an over-broad removal."""
+    assert ROUTES.count('"Connection", "close"') + ROUTES.count("'Connection', 'close'") >= 1, (
+        "at least the finite-response handlers (ZIP download, etc.) must keep "
+        "`Connection: close` for HTTP/1.1 message-boundary correctness (#2836)"
+    )


### PR DESCRIPTION
## Release v0.51.165 — Release EK (stage-batch47)

Single-PR release. Full sequential pytest: 6881 passed, 0 failures.

### PR included
- **#3128** (@Sanjays2402, fixes #3103) — stop emitting `Connection: close` on the two long-lived SSE handlers (`_handle_session_events_stream`, `_handle_gateway_sse_stream`). Browsers treat `Connection: close` on an SSE response as "the EventSource lifecycle ended" and auto-reconnect, producing a ~1/sec reconnect storm that thrashes the session list (regression from the HTTP/1.1 keep-alive change in `598fd4ff`). `api/routes.py`.

### Maintainer-approved despite inconclusive automated repro
The reconnect storm could NOT be reproduced in a headless CDP/EventSource harness — both master and the fix branch showed 1 open / 0 reconnects over 15s (a synthetic EventSource on a blank page doesn't replicate the full-app connection lifecycle that triggers the storm). Approved by maintainer (Nathan) on the basis of: exact match to #3103's documented root cause, low risk (removes one response header), confirmed healthy stream (connects once, no errors, no regression), and zero downside (relaxing connection reuse on an infinite stream can't make things worse). The #2836 `Connection: close` rationale applies to *finite* responses (the on-the-fly ZIP download) and is preserved there — this only touches the two infinite SSE streams.

### Added during review
- `tests/test_issue3103_sse_no_connection_close.py` (3 tests): pins that the two long-lived SSE handlers don't emit `Connection: close`, AND that finite responses still keep it (guards against an over-broad future removal). #3128 shipped without a test.

### Verification
- `ast.parse` clean on routes.py; 534 SSE/streaming/update tests green; full suite 6881 passed, 0 failures.
- Confirmed the change only touches the 2 long-lived stream handlers; the other ~3 SSE endpoints + ZIP download keep `Connection: close`. (Noted the inconsistency to Nathan; he chose to ship the targeted #3103 fix as-is.)
- Cherry-picked onto current master (stale base; authorship preserved).