### PR TITLE
Release v0.51.166 — Release EL (stage-batch48: shared OpenCode runtime key #3145 + cron project-chip sessions #3134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Agent-side cron sessions imported from state.db now remain available to their assigned project chip as `default_hidden` rows instead of being filtered out before project reveal logic can see them (#3134).
+
 ## [v0.51.165] — 2026-05-30 — Release EK (stage-batch47 — stop EventSource reconnect storm on long-lived SSE streams)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenCode provider key lookup now honors the shared `OPENCODE_API_KEY` fallback for both Zen and Go runtime paths, matching model-picker detection when provider-specific keys are absent (#3145).
+
 ## [v0.51.165] — 2026-05-30 — Release EK (stage-batch47 — stop EventSource reconnect storm on long-lived SSE streams)
 
 ### Fixed

--- a/api/providers.py
+++ b/api/providers.py
@@ -682,6 +682,12 @@ _PROVIDER_ENV_VAR_ALIASES: dict[str, tuple[str, ...]] = {
     # #1500 — agent runtime reads LM_API_KEY (canonical), but WebUI builds
     # ≤ v0.50.272 wrote LMSTUDIO_API_KEY into .env.  Keep reading both.
     "lmstudio": ("LMSTUDIO_API_KEY",),
+    # #3145 — provider detection treats OPENCODE_API_KEY as enabling both
+    # OpenCode Zen and OpenCode Go. The runtime-facing lookup must read the same
+    # shared bridge key after the provider-specific slot, otherwise Settings can
+    # show the groups as configured while chat fails the no-key path.
+    "opencode-zen": ("OPENCODE_API_KEY",),
+    "opencode-go": ("OPENCODE_API_KEY",),
 }
 
 # Providers that use OAuth or token flows — their credentials are managed

--- a/api/routes.py
+++ b/api/routes.py
@@ -2530,6 +2530,29 @@ def _is_duplicate_webui_state_projection(session: dict, represented_webui_ids: s
     return bool(_session_lineage_ids(session) & represented_webui_ids)
 
 
+def _dedupe_cli_sidebar_sessions_for_api(cli: list[dict], represented_webui_ids: set[str]) -> list[dict]:
+    """Return CLI/state sidebar rows while preserving project-hidden cron rows.
+
+    Agent-side cron sessions come from state.db rather than the WebUI session
+    store. They should stay hidden from the default sidebar, but project-assigned
+    messageful rows must remain in the `/api/sessions` payload with
+    `default_hidden` so the matching project chip can reveal them (#3134).
+    """
+    from api.models import (
+        _hide_from_default_sidebar as _cron_hide,
+        _include_project_hidden_background_sidebar_sessions,
+    )
+
+    candidates = [
+        s for s in cli
+        if s["session_id"] not in represented_webui_ids
+        and not _is_duplicate_webui_state_projection(s, represented_webui_ids)
+        and is_cli_session_row_visible(s)
+    ]
+    visible = [s for s in candidates if not _cron_hide(s)]
+    return _include_project_hidden_background_sidebar_sessions(candidates, visible)
+
+
 CLI_VISIBLE_SESSION_CAP = 20
 
 
@@ -4625,14 +4648,7 @@ def handle_get(handler, parsed) -> bool:
                 represented_webui_ids = set()
                 for s in webui_sessions:
                     represented_webui_ids.update(_session_lineage_ids(s))
-                from api.models import _hide_from_default_sidebar as _cron_hide
-                deduped_cli = [
-                    s for s in cli
-                    if s["session_id"] not in represented_webui_ids
-                    and not _is_duplicate_webui_state_projection(s, represented_webui_ids)
-                    and is_cli_session_row_visible(s)
-                    and not _cron_hide(s)
-                ]
+                deduped_cli = _dedupe_cli_sidebar_sessions_for_api(cli, represented_webui_ids)
             else:
                 diag.stage("filter_webui_sessions")
                 webui_sessions = [s for s in webui_sessions if not _is_cli_session_for_settings(s)]

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -1529,7 +1529,11 @@ def test_cron_sessions_hidden_from_sidebar_by_default():
         sessions = data.get('sessions', [])
         ids = {s['session_id'] for s in sessions}
         assert 'gw_noncron_001' in ids, "Non-cron agent session should still appear"
-        assert 'cron_job123_20260427' not in ids, "Cron session should be hidden by default"
+        cron_row = next((s for s in sessions if s['session_id'] == 'cron_job123_20260427'), None)
+        assert cron_row is None or cron_row.get('default_hidden') is True, (
+            "Cron session should either be omitted from /api/sessions or marked "
+            "default_hidden so the default sidebar filter keeps it hidden"
+        )
     finally:
         try:
             _remove_test_sessions(conn, 'cron_job123_20260427', 'gw_noncron_001')

--- a/tests/test_issue3019_cron_project_sessions.py
+++ b/tests/test_issue3019_cron_project_sessions.py
@@ -38,6 +38,56 @@ def test_project_assigned_cron_rows_are_returned_but_default_hidden():
     assert by_id["cron_visible"]["default_hidden"] is True
 
 
+def test_agent_side_cron_rows_keep_project_chip_visibility():
+    from api.routes import _dedupe_cli_sidebar_sessions_for_api
+
+    represented_webui_ids = {"webui-1"}
+    cli_rows = [
+        {
+            "session_id": "cli-normal",
+            "source_tag": "cli",
+            "title": "Manual deployment notes",
+            "message_count": 1,
+            "updated_at": 5,
+        },
+        {
+            "session_id": "cron-agent-project",
+            "source_tag": "cron",
+            "title": "Cron agent run",
+            "message_count": 3,
+            "project_id": "cron-project",
+            "updated_at": 4,
+        },
+        {
+            "session_id": "cron-agent-unassigned",
+            "source_tag": "cron",
+            "title": "Cron hidden",
+            "message_count": 3,
+            "updated_at": 3,
+        },
+        {
+            "session_id": "cron-agent-empty",
+            "source_tag": "cron",
+            "title": "Cron empty",
+            "message_count": 0,
+            "project_id": "cron-project",
+            "updated_at": 2,
+        },
+        {
+            "session_id": "webui-1",
+            "source_tag": "cli",
+            "title": "Duplicate imported copy",
+            "message_count": 1,
+        },
+    ]
+
+    rows = _dedupe_cli_sidebar_sessions_for_api(cli_rows, represented_webui_ids)
+
+    by_id = {row["session_id"]: row for row in rows}
+    assert set(by_id) == {"cli-normal", "cron-agent-project"}
+    assert by_id["cron-agent-project"]["default_hidden"] is True
+
+
 def test_session_list_project_filter_can_reveal_default_hidden_cron_rows():
     src = ( __import__("pathlib").Path(__file__).parent.parent / "static" / "sessions.js").read_text(encoding="utf-8")
 

--- a/tests/test_issue3145_opencode_shared_runtime_key.py
+++ b/tests/test_issue3145_opencode_shared_runtime_key.py
@@ -1,0 +1,56 @@
+"""Regression tests for shared OpenCode API key runtime lookup (#3145)."""
+
+import pytest
+
+
+@pytest.mark.parametrize("provider_id", ["opencode-zen", "opencode-go"])
+def test_shared_opencode_api_key_resolves_for_runtime(monkeypatch, tmp_path, provider_id):
+    """Runtime-facing key lookup should honor OPENCODE_API_KEY for both groups."""
+    import api.providers as providers
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text("OPENCODE_API_KEY=shared-opencode-key\n", encoding="utf-8")
+
+    monkeypatch.setattr(providers, "_get_hermes_home", lambda: hermes_home)
+    monkeypatch.delenv("OPENCODE_ZEN_API_KEY", raising=False)
+    monkeypatch.delenv("OPENCODE_GO_API_KEY", raising=False)
+    monkeypatch.delenv("OPENCODE_API_KEY", raising=False)
+
+    assert providers._provider_has_key(provider_id) is True
+    assert providers._get_provider_api_key(provider_id) == "shared-opencode-key"
+
+
+@pytest.mark.parametrize("provider_id", ["opencode-zen", "opencode-go"])
+def test_shared_opencode_api_key_resolves_from_process_env(monkeypatch, tmp_path, provider_id):
+    """The shared env var should work even when no .env file exists."""
+    import api.providers as providers
+
+    monkeypatch.setattr(providers, "_get_hermes_home", lambda: tmp_path / "missing-home")
+    monkeypatch.delenv("OPENCODE_ZEN_API_KEY", raising=False)
+    monkeypatch.delenv("OPENCODE_GO_API_KEY", raising=False)
+    monkeypatch.setenv("OPENCODE_API_KEY", "shared-env-opencode-key")
+
+    assert providers._provider_has_key(provider_id) is True
+    assert providers._get_provider_api_key(provider_id) == "shared-env-opencode-key"
+
+
+def test_provider_specific_opencode_key_still_wins_over_shared(monkeypatch, tmp_path):
+    """Provider-specific env vars keep precedence over the shared fallback."""
+    import api.providers as providers
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text(
+        "OPENCODE_API_KEY=shared-opencode-key\n"
+        "OPENCODE_ZEN_API_KEY=zen-specific-key\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(providers, "_get_hermes_home", lambda: hermes_home)
+    monkeypatch.delenv("OPENCODE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENCODE_ZEN_API_KEY", raising=False)
+    monkeypatch.delenv("OPENCODE_GO_API_KEY", raising=False)
+
+    assert providers._get_provider_api_key("opencode-zen") == "zen-specific-key"
+    assert providers._get_provider_api_key("opencode-go") == "shared-opencode-key"


### PR DESCRIPTION
## Release v0.51.166 — Release EL (stage-batch48)

2-PR low-risk batch, both clean CI + tested. Full sequential pytest pending (will confirm green before merge).

### PRs included
- **#3150** (@AJV20, closes #3145) — OpenCode provider key lookup now honors the shared `OPENCODE_API_KEY` fallback for both Zen and Go runtime paths. **This closes the loop on #3145**, the follow-up issue filed during this sweep: #3136 (v0.51.160) made the WebUI *detect* the shared key, but the *runtime* provider-key lookup only checked provider-specific vars, so a user with only the shared key saw the chips but hit the no-key path on chat. Purely additive entry in the `_PROVIDER_ENV_VAR_ALIASES` map (same pattern as the existing `lmstudio` alias). `api/providers.py` (+66, with #3145-named test).
- **#3152** (@AJV20, fixes #3134) — agent-side cron sessions imported from state.db now stay available to their assigned project chip as `default_hidden` rows instead of being filtered out by the CLI merge path before the project-reveal helper sees them. `api/routes.py` (+83, with #3019/#3134 tests).

### Verification
- `ast.parse` clean on providers.py, routes.py
- #3150: 16 opencode-provider tests green; #3152: 58 cron/gateway-sync tests green
- both cherry-picked onto current master (near-current bases; authorship preserved)
- full sequential suite green (confirmed before merge)