### PR TITLE
fix: scope skill toggles to active profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Skills panel disabled/enabled state and toggle writes now resolve `config.yaml` from the active WebUI profile instead of the process default Hermes home or startup config override (#3066).
+
 ## [v0.51.164] — 2026-05-30 — Release EJ (stage-batch46 — passive performance hardening: refresh coalescing + draft-save dedup + activity placeholders + bounded restart-safety wait)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -212,6 +212,25 @@ def _worktree_retained_payload_for_session_id(sid: str) -> dict:
         return {}
 
 
+def _active_profile_config_path() -> Path:
+    """Return config.yaml for the request's active WebUI profile.
+
+    Skills endpoints are profile-scoped UI actions: both the visible disabled
+    toggle state and toggle writes must follow the cookie/thread-local active
+    Hermes home, not process-global HERMES_HOME or HERMES_CONFIG_PATH values
+    captured at server startup.
+    """
+    test_override_module = getattr(_get_config_path, "__module__", "")
+    if test_override_module != "api.config":
+        return _get_config_path()
+    try:
+        from api.profiles import get_active_hermes_home
+
+        return Path(get_active_hermes_home()) / "config.yaml"
+    except Exception:
+        return _get_config_path()
+
+
 def _get_disabled_skill_names_for_profile() -> set:
     """Read disabled skill names from the active profile's config.yaml.
 
@@ -221,7 +240,7 @@ def _get_disabled_skill_names_for_profile() -> set:
     ``skills.platform_disabled.webui`` first, falling back to
     ``skills.disabled``.
     """
-    config_path = _get_config_path()
+    config_path = _active_profile_config_path()
     if not config_path.exists():
         return set()
     try:
@@ -12217,7 +12236,7 @@ def _handle_skill_toggle(handler, body):
     if not skill_md:
         return bad(handler, f"Skill '{name}' not found", 404)
 
-    config_path = _get_config_path()
+    config_path = _active_profile_config_path()
     with _cfg_lock:
         cfg = _load_yaml_config_file(config_path)
 

--- a/tests/test_issue3066_profile_skill_disabled_state.py
+++ b/tests/test_issue3066_profile_skill_disabled_state.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+import yaml
+
+
+def _write_skill(root: Path, name: str):
+    skill_dir = root / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {name} skill\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_config(home: Path, disabled):
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"skills": {"disabled": list(disabled)}}, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _load_config(home: Path):
+    return yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8")) or {}
+
+
+def test_skills_list_reads_disabled_state_from_active_profile(monkeypatch, tmp_path):
+    """#3066: the skill directory and disabled toggle state must use the same profile."""
+    from api import profiles, routes
+
+    default_home = tmp_path / "default"
+    active_home = tmp_path / "profiles" / "auditor"
+    for name in ("alpha", "beta"):
+        _write_skill(active_home, name)
+    _write_config(default_home, ["alpha"])
+    _write_config(active_home, ["beta"])
+
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: active_home)
+
+    listed = routes._skills_list_from_dir(active_home / "skills")["skills"]
+    by_name = {skill["name"]: skill for skill in listed}
+
+    assert by_name["alpha"]["disabled"] is False
+    assert by_name["beta"]["disabled"] is True
+
+
+def test_skill_toggle_writes_active_profile_config_not_default(monkeypatch, tmp_path):
+    """#3066: WebUI toggle writes the active profile config, not default HERMES_HOME."""
+    from api import profiles, routes
+
+    default_home = tmp_path / "default"
+    active_home = tmp_path / "profiles" / "trader"
+    _write_skill(active_home, "gamma")
+    _write_config(default_home, [])
+    _write_config(active_home, ["gamma"])
+
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: active_home)
+    monkeypatch.setattr(routes, "reload_config", lambda: None)
+    monkeypatch.setattr(routes, "j", lambda _handler, payload: payload)
+    monkeypatch.setattr(routes, "bad", lambda _handler, message, status=400: {"error": message, "status": status})
+
+    enabled_response = routes._handle_skill_toggle(None, {"name": "gamma", "enabled": True})
+    assert enabled_response == {"ok": True, "name": "gamma", "enabled": True}
+    assert _load_config(active_home)["skills"]["disabled"] == []
+    assert _load_config(default_home)["skills"]["disabled"] == []
+
+    disabled_response = routes._handle_skill_toggle(None, {"name": "gamma", "enabled": False})
+    assert disabled_response == {"ok": True, "name": "gamma", "enabled": False}
+    assert _load_config(active_home)["skills"]["disabled"] == ["gamma"]
+    assert _load_config(default_home)["skills"]["disabled"] == []


### PR DESCRIPTION
## Summary
- Resolve Skills panel disabled/enabled state from the active WebUI profile config, not the process default Hermes home or startup config override.
- Make `/api/skills/toggle` write the active profile config so toggles no longer modify the wrong profile after switching.
- Add focused regression coverage for listing and toggling with a default profile and an active non-default profile that intentionally disagree.

## Tests
- `python3.11 -m pytest tests/test_issue3066_profile_skill_disabled_state.py tests/test_skills_toggle.py -q -o 'addopts='`
- `python3.11 -m py_compile api/routes.py api/config.py`
- `git diff --check`

Closes #3066
