### PR TITLE
fix: use getModelLabel() in _formatSessionModelWithGateway fallback

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -120,7 +120,7 @@ function _formatSessionModelWithGateway(s){
   if(!s||!s.model)return'';
   const routing=(typeof _latestGatewayRoutingForSession==='function')?_latestGatewayRoutingForSession(s):(s.gateway_routing||null);
   if(typeof _formatGatewayModelLabel==='function'){
-    return _formatGatewayModelLabel(s.model,s.model,routing)||s.model;
+    return _formatGatewayModelLabel(s.model,s.model,routing)||getModelLabel(s.model);
   }
   return s.model;
 }


### PR DESCRIPTION
## Problem

`_formatSessionModelWithGateway` in `sessions.js:123` falls back to raw `s.model` when `gateway_routing` is absent:

```js
return _formatGatewayModelLabel(s.model,s.model,routing)||s.model;
```

When `s.model` contains a `@provider:` prefix, the session list displays the raw provider-qualified ID instead of the clean model name.

`getModelLabel()` already handles stripping `@provider:` prefixes (`ui.js:2855`) but is never called in this fallback path.

## Fix

```diff
- return _formatGatewayModelLabel(s.model,s.model,routing)||s.model;
+ return _formatGatewayModelLabel(s.model,s.model,routing)||getModelLabel(s.model);
```

## Notes

- When routing data exists, `_formatGatewayModelLabel` already calls `getModelLabel()` internally — no double-processing
- When routing is absent, `getModelLabel()` strips the `@provider:` prefix and returns the clean model name