### PR TITLE
feat: add global profile switcher in app titlebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Profile switcher is now available globally in the app titlebar, not just in the chat composer. Clicking the profile button in the header opens the profile dropdown from any panel (Chat, Tasks, Kanban, Settings, Skills, etc.). The label tracks the active profile on boot and after every switch.
+
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 
 ### Added

--- a/static/boot.js
+++ b/static/boot.js
@@ -1687,6 +1687,8 @@ function applyBotName(){
   // Update profile chip label immediately
   const profileLabel=$('profileChipLabel');
   if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
+  const titleLabel=$('titlebarProfileLabel');
+  if(titleLabel) titleLabel.textContent=S.activeProfile||'default';
   // Fetch available models without blocking session restore. The static HTML
   // options are enough for first paint; the dynamic provider list can settle
   // after the saved session is visible.

--- a/static/index.html
+++ b/static/index.html
@@ -118,9 +118,16 @@
 </head>
 <body>
 <header class="app-titlebar" role="banner">
-  <button class="app-titlebar-hamburger has-tooltip has-tooltip--bottom" id="btnHamburger" onclick="toggleMobileSidebar()" type="button" data-tooltip="Menu" aria-label="Menu">
+  <div class="app-titlebar-left">
+    <button class="app-titlebar-profile" id="titlebarProfileBtn" type="button" onclick="toggleProfileDropdown(event)" aria-label="Switch profile">
+      <span class="app-titlebar-profile-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>
+      <span class="app-titlebar-profile-label" id="titlebarProfileLabel">default</span>
+      <span class="app-titlebar-profile-chevron" aria-hidden="true"><svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span>
+    </button>
+    <button class="app-titlebar-hamburger has-tooltip has-tooltip--bottom" id="btnHamburger" onclick="toggleMobileSidebar()" type="button" data-tooltip="Menu" aria-label="Menu">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
   </button>
+  </div>
   <div class="app-titlebar-inner">
     <span class="app-titlebar-icon" aria-hidden="true">
       <svg viewBox="0 0 64 64" width="16" height="16" aria-hidden="true">
@@ -706,7 +713,6 @@
               <button class="ctx-compress-btn composer-mobile-context-compress" id="composerMobileCtxCompressBtn" type="button" style="display:none"></button>
             </div>
           </div>
-          <div class="profile-dropdown" id="profileDropdown"></div>
           <div class="ws-dropdown ws-dropdown-footer" id="composerWsDropdown"></div>
           <div class="composer-reasoning-dropdown" id="composerReasoningDropdown">
             <div class="reasoning-option" data-effort="none">None</div>
@@ -1494,5 +1500,6 @@
     </div>
   </div>
 </div>
+<div class="profile-dropdown" id="profileDropdown"></div>
 </body>
 </html>

--- a/static/panels.js
+++ b/static/panels.js
@@ -4345,15 +4345,26 @@ function _positionComposerWsDropdown(){
 
 function _positionProfileDropdown(){
   const dd=$('profileDropdown');
-  const chip=$('profileChip');
-  const footer=document.querySelector('.composer-footer');
-  if(!dd||!chip||!footer)return;
-  const chipRect=chip.getBoundingClientRect();
-  const footerRect=footer.getBoundingClientRect();
-  let left=chipRect.left-footerRect.left;
-  const maxLeft=Math.max(0, footer.clientWidth-dd.offsetWidth);
-  left=Math.max(0, Math.min(left, maxLeft));
-  dd.style.left=`${left}px`;
+  const trigger=_profileDropdownTrigger||$('profileChip');
+  if(!dd||!trigger)return;
+  const rect=trigger.getBoundingClientRect();
+  const gap=4;
+  const ddW=dd.offsetWidth||260;
+  // Decide direction: below for titlebar, above for composer
+  const openBelow=trigger===document.getElementById('titlebarProfileBtn');
+  // Horizontal: center on trigger, clamp to viewport
+  let left=rect.left+(rect.width/2)-(ddW/2);
+  left=Math.max(8, Math.min(left, window.innerWidth-ddW-8));
+  dd.style.left=left+'px';
+  // Vertical
+  if(openBelow){
+    dd.style.top=(rect.bottom+gap)+'px';
+    dd.classList.add('open-below');
+  }else{
+    dd.style.top=''; dd.style.bottom=''; // clear fixed top/bottom
+    dd.style.bottom=(window.innerHeight-rect.top+gap)+'px';
+    dd.classList.remove('open-below');
+  }
 }
 
 function renderWorkspaceDropdownInto(dd, workspaces, currentWs){
@@ -4952,6 +4963,7 @@ async function switchToWorkspace(path,name){
 // ── Profile panel + dropdown ──
 let _profilesCache = null;
 let _profileSwitchGeneration = 0;
+let _profileDropdownTrigger = null;  // tracks which element triggered the dropdown
 
 async function _profileSwitchPanelLoad(){
   if (_currentPanel === 'skills') await loadSkills();
@@ -5203,20 +5215,28 @@ function renderProfileDropdown(data) {
   mgmt.innerHTML = `${li('settings',12)} ${esc(t('manage_profiles'))}`;
   mgmt.onclick = () => { closeProfileDropdown(); mobileSwitchPanel('profiles'); };
   dd.appendChild(mgmt);
+  // Sync titlebar label to the resolved active profile
+  const tbl = $('titlebarProfileLabel');
+  if (tbl) tbl.textContent = active;
 }
 
-function toggleProfileDropdown() {
+function toggleProfileDropdown(e) {
   const dd = $('profileDropdown');
   if (!dd) return;
   if (dd.classList.contains('open')) { closeProfileDropdown(); return; }
   closeWsDropdown(); // close workspace dropdown if open
   if(typeof closeModelDropdown==='function') closeModelDropdown();
+  // Track which element triggered the dropdown for positioning
+  _profileDropdownTrigger = (e && e.currentTarget) || $('profileChip');
   api('/api/profiles').then(data => {
     renderProfileDropdown(data);
     dd.classList.add('open');
     _positionProfileDropdown();
+    // Mark the triggering button as active
     const chip=$('profileChip');
-    if(chip) chip.classList.add('active');
+    if(chip && _profileDropdownTrigger===chip) chip.classList.add('active');
+    const tbtn=$('titlebarProfileBtn');
+    if(tbtn && _profileDropdownTrigger===tbtn) tbtn.classList.add('active');
   }).catch(e => { showToast(t('profiles_load_failed')); });
 }
 
@@ -5225,9 +5245,11 @@ function closeProfileDropdown() {
   if (dd) dd.classList.remove('open');
   const chip=$('profileChip');
   if(chip) chip.classList.remove('active');
+  const tbtn=$('titlebarProfileBtn');
+  if(tbtn) tbtn.classList.remove('active');
 }
 document.addEventListener('click', e => {
-  if (!e.target.closest('#profileChipWrap') && !e.target.closest('#profileDropdown')) closeProfileDropdown();
+  if (!e.target.closest('#profileChipWrap') && !e.target.closest('#titlebarProfileBtn') && !e.target.closest('#profileDropdown')) closeProfileDropdown();
 });
 window.addEventListener('resize',()=>{
   const dd=$('profileDropdown');
@@ -5244,11 +5266,15 @@ async function switchToProfile(name) {
   // feedback while the async switch is in progress.
   const _chip = $('profileChip');
   const _chipLabel = $('profileChipLabel');
+  const _titlebarBtn = $('titlebarProfileBtn');
+  const _titlebarLabel = $('titlebarProfileLabel');
   const _prevProfileName = S.activeProfile || 'default';
   const _switchGen = ++_profileSwitchGeneration;
   if (_chip) { _chip.classList.add('switching'); _chip.disabled = true; }
+  if (_titlebarBtn) { _titlebarBtn.classList.add('switching'); _titlebarBtn.disabled = true; }
   // Optimistic name update — shows the target name right away
   if (_chipLabel) _chipLabel.textContent = name;
+  if (_titlebarLabel) _titlebarLabel.textContent = name;
 
   // Determine whether the current session has any messages.
   // A session with messages is "in progress" and belongs to the current profile —
@@ -5368,10 +5394,12 @@ async function switchToProfile(name) {
   } catch (e) {
     // Revert the optimistic name update on error
     if (_switchGen === _profileSwitchGeneration && _chipLabel) _chipLabel.textContent = _prevProfileName;
+    if (_switchGen === _profileSwitchGeneration && _titlebarLabel) _titlebarLabel.textContent = _prevProfileName;
     if (_switchGen === _profileSwitchGeneration) showToast(t('switch_failed') + e.message);
   } finally {
     // Always remove loading indicator regardless of success or failure
     if (_switchGen === _profileSwitchGeneration && _chip) { _chip.classList.remove('switching'); _chip.disabled = false; }
+    if (_switchGen === _profileSwitchGeneration && _titlebarBtn) { _titlebarBtn.classList.remove('switching'); _titlebarBtn.disabled = false; }
   }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -749,8 +749,17 @@
   html{background:var(--sidebar);}
   body{background:var(--bg);color:var(--text);height:100vh;height:100dvh;overflow:hidden;display:flex;flex-direction:column;}
   .layout{display:flex;width:100%;flex:1 1 auto;min-height:0;}
-  .app-titlebar{display:flex;align-items:center;justify-content:center;height:38px;flex-shrink:0;background:var(--sidebar);border-bottom:1px solid var(--border);padding:0 12px;padding-top:var(--app-titlebar-safe-top);padding-left:max(12px,env(safe-area-inset-left,0));padding-right:max(12px,env(safe-area-inset-right,0));box-sizing:content-box;font-size:12px;color:var(--muted);user-select:none;-webkit-app-region:drag;position:relative;z-index:20;}
-  .app-titlebar-inner{display:flex;align-items:center;gap:8px;min-width:0;max-width:100%;justify-content:center;}
+  .app-titlebar{display:grid;grid-template-columns:1fr auto 1fr;align-items:center;height:38px;flex-shrink:0;background:var(--sidebar);border-bottom:1px solid var(--border);padding:0 12px;padding-top:var(--app-titlebar-safe-top);padding-left:max(12px,env(safe-area-inset-left,0));padding-right:max(12px,env(safe-area-inset-right,0));box-sizing:content-box;font-size:12px;color:var(--muted);user-select:none;-webkit-app-region:drag;z-index:20;}
+  .app-titlebar-left{display:flex;align-items:center;gap:4px;}
+  .app-titlebar-inner{display:flex;align-items:center;gap:8px;min-width:0;justify-content:center;}
+  /* Profile switcher — in left column of titlebar grid */
+  .app-titlebar-profile{display:inline-flex;align-items:center;gap:4px;height:28px;flex-shrink:0;background:none;border:1px solid var(--border2);color:var(--muted);border-radius:6px;cursor:pointer;padding:0 8px;-webkit-tap-highlight-color:transparent;transition:background-color .15s,color .15s,border-color .15s;font-size:11px;font-weight:500;white-space:nowrap;-webkit-app-region:no-drag;}
+  .app-titlebar-profile:hover{background:var(--hover-bg);color:var(--text);border-color:var(--border);}
+  .app-titlebar-profile.active{background:var(--accent-bg);color:var(--accent-text);border-color:var(--accent-bg-strong);}
+  .app-titlebar-profile.switching{opacity:.6;pointer-events:none;}
+  .app-titlebar-profile-icon{display:inline-flex;align-items:center;flex-shrink:0;}
+  .app-titlebar-profile-label{max-width:80px;overflow:hidden;text-overflow:ellipsis;}
+  .app-titlebar-profile-chevron{display:inline-flex;align-items:center;flex-shrink:0;opacity:.5;}
   .system-health-panel.insights-card{display:flex;flex-direction:column;gap:12px;color:var(--muted);}
   .system-health-panel.unavailable{display:none;}
   .system-health-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;}
@@ -2088,7 +2097,7 @@
     .sidebar.mobile-open{left:0;}
     .sidebar .resize-handle{display:none;}
     /* Hamburger button (in app titlebar on mobile) */
-    .app-titlebar{justify-content:space-between;}
+    .app-titlebar{grid-template-columns:auto 1fr auto;justify-content:unset;}
     .app-titlebar-hamburger,.app-titlebar-spacer{display:flex;}
     .app-titlebar-inner{flex:1 1 auto;}
     .system-health-panel.insights-card{gap:10px;padding:12px;}
@@ -2310,8 +2319,9 @@
 .ws-action-btn:hover{background:rgba(255,255,255,.1);color:var(--text);}
 /* ── Profile dropdown + management panel ── */
 .profile-chip{user-select:none;color:var(--accent-text)!important;}
-.profile-dropdown{display:none;position:absolute;bottom:calc(100% + 4px);left:0;min-width:260px;max-width:min(260px,calc(100vw - 32px));background:var(--surface);border:1px solid var(--border2);border-radius:10px;box-shadow:0 -4px 24px rgba(0,0,0,.4);z-index:200;overflow:hidden;max-height:380px;overflow-y:auto;}
+.profile-dropdown{display:none;position:fixed;min-width:260px;max-width:min(260px,calc(100vw - 32px));background:var(--surface);border:1px solid var(--border2);border-radius:10px;box-shadow:0 -4px 24px rgba(0,0,0,.4);z-index:200;overflow:hidden;max-height:380px;overflow-y:auto;}
 .profile-dropdown.open{display:block;}
+.profile-dropdown.open-below{box-shadow:0 4px 24px rgba(0,0,0,.4);}
 .profile-opt{padding:10px 14px;cursor:pointer;transition:background .12s;}
 .profile-opt:hover{background:rgba(255,255,255,.07);}
 .profile-opt.active{background:var(--accent-bg);}

--- a/static/ui.js
+++ b/static/ui.js
@@ -5218,6 +5218,8 @@ function syncTopbar(){
     // Update profile chip even when no session is active (e.g. right after profile switch)
     const _profileLabel=$('profileChipLabel');
     if(_profileLabel) _profileLabel.textContent=S.activeProfile||'default';
+    const _titleLabel=$('titlebarProfileLabel');
+    if(_titleLabel) _titleLabel.textContent=S.activeProfile||'default';
     return;
   }
   const sessionTitle=S.session.title||t('untitled');
@@ -5329,6 +5331,8 @@ function syncTopbar(){
   // Update profile chip label
   const profileLabel=$('profileChipLabel');
   if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
+  const titleLabel=$('titlebarProfileLabel');
+  if(titleLabel) titleLabel.textContent=S.activeProfile||'default';
 }
 
 function msgContent(m){


### PR DESCRIPTION

### Thinking Path

- Hermes WebUI supports multiple named profiles, each with its own system prompt, model, and session history
- The profile switcher chip lived inside the chat composer footer — a node that only exists when the Chat panel is active
- Users on Tasks, Kanban, Settings, or Skills had no way to switch profiles without navigating back to Chat
- Root cause: `#profileDropdown` was a child of the composer footer block, and its positioning logic assumed `.composer-footer` was always in the layout
- This PR lifts the dropdown to `<body>` scope, adds a permanent profile button to the app titlebar, and makes the positioning direction-aware
- Profile switching is now available from every panel, with a single shared dropdown and no DOM duplication

---

### Problem

The profile dropdown was anchored inside `.composer-footer` in `index.html`. This meant it did not exist in the DOM on Kanban, Tasks, Settings, or Skills — calling `toggleProfileDropdown()` from outside Chat silently failed. Label sync code had no titlebar target.

---

### Solution

A permanent `#titlebarProfileBtn` is added to `<header>` inside a `.app-titlebar-left` wrapper, always rendered. The titlebar is switched from `display:flex; justify-content:center` to a CSS Grid with `grid-template-columns:1fr auto 1fr`, pinning the profile button to the far left above the rail tabs while keeping the Hermes title centered. `#profileDropdown` is moved to `<body>` level with `position:fixed`, so it can position against either trigger: downward from the titlebar, upward from the composer chip.

---

### Files Changed

| File | What changed |
|---|---|
| `static/index.html` | `.app-titlebar-left` wrapper (profile + hamburger); profile button (icon + label + chevron, no tooltip); dropdown moved from `#mainChat` to `<body>` |
| `static/style.css` | Grid layout (`flex` → `1fr auto 1fr`); `.app-titlebar-left` wrapper; profile styles lifted from `@supports` block to global scope; dropdown `position:absolute` → `position:fixed`; `.open-below` shadow; mobile grid override |
| `static/panels.js` | Trigger-aware `_positionProfileDropdown()`; `_profileDropdownTrigger` module var; dual-chip support in toggle/close/switch/render |
| `static/ui.js` | `syncTopbar()` both code paths update `#titlebarProfileLabel` |
| `static/boot.js` | `applyBotName()` updates `#titlebarProfileLabel` on boot |
| `CHANGELOG.md` | Entry under `[Unreleased]` |


---


### Screenshots and Responsiveness

Laptop Screen
<img width="1636" height="882" alt="profile switcher" src="https://github.com/user-attachments/assets/cd425eca-f057-4239-b058-50095f9ed8e0" />

Iphone SE
<img width="747" height="791" alt="Iphone SE" src="https://github.com/user-attachments/assets/005f6180-23a9-4b20-8af2-3cb7302857a9" />


Surface Duo
<img width="747" height="791" alt="durfaceduo" src="https://github.com/user-attachments/assets/3a6886ab-0d02-4961-936b-0953a13ccf4a" />


Ipad Mini
<img width="747" height="791" alt="ipadmini" src="https://github.com/user-attachments/assets/30f4ef42-7e3b-4295-9d56-391baaf1ccdb" />



---

### How It Works

**CSS Grid layout** — the titlebar switched from `display:flex; justify-content:center` to `display:grid; grid-template-columns:1fr auto 1fr`. The left column holds the profile + hamburger group, the center holds the Hermes title, and the right column holds the reload button. The `1fr auto 1fr` pattern keeps the title perfectly centered regardless of the profile label length. The profile styles were also lifted out of a `@supports (padding-top: env(safe-area-inset-top))` block that unintentionally hid them outside PWA mode.

**Two entry points, one dropdown** — both titlebar button and composer chip share `#profileDropdown`. `toggleProfileDropdown(event)` passes `event.currentTarget`; `_profileDropdownTrigger` tracks which opened it.

**Direction-aware** — opens **below** titlebar (`top = rect.bottom + gap`), **above** composer (`bottom = innerHeight - rect.top + gap`), centered on trigger with viewport clamping.

**Full sync** — every label update path writes to both chips: `applyBotName`, `syncTopbar` (both branches), `switchToProfile` (optimistic + error revert), `renderProfileDropdown`.

**No duplication** — single `#profileDropdown` at body level, `position:fixed`.

---

### Test Plan

- [ ] Titlebar button visible on Chat, Tasks, Kanban, Settings, Skills
- [ ] Dropdown opens below titlebar, above composer — correct direction
- [ ] Switch from any panel — both labels update
- [ ] Error revert — both labels restore previous name
- [ ] Switching class on titlebar button during transition
- [ ] Narrow viewport clamping, resize repositioning

---

### Verification

`python3 bootstrap.py` → navigate to any non-Chat panel → click titlebar profile button → switch profile → verify both labels and session state.

### Related

- Closes #2645 — quick access profile switcher from any panel
- Addresses #749 — align Web UI profile management with Hermes runtime model (profile switcher now globally available)
- Supersedes #2672 — sidebar quick profile switcher (same goal, different approach; maintainer's closing comment identified the non-chat-panel gap this PR fills)