### PR TITLE
fix: preserve tilde workspace suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Workspace path autocomplete now preserves `~/` suggestions while browsing under the user's home directory (#3173).
+
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 
 ### Added

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -468,10 +468,28 @@ def list_workspace_suggestions(prefix: str = "", limit: int = 12) -> list[str]:
 
     normalized = str(target)
     normalized_lower = normalized.lower()
+    preserve_tilde = raw.startswith("~")
+    home_root: Path | None = None
+    if preserve_tilde:
+        try:
+            home_root = Path.home().expanduser().resolve()
+        except Exception:
+            home_root = None
     suggestions: list[str] = []
 
+    def format_suggestion(path: Path) -> str:
+        if preserve_tilde and home_root is not None:
+            try:
+                rel = path.resolve().relative_to(home_root)
+                if str(rel) == ".":
+                    return "~"
+                return "~/" + rel.as_posix()
+            except (OSError, ValueError):
+                pass
+        return str(path)
+
     def add(path: Path) -> None:
-        value = str(path)
+        value = format_suggestion(path)
         if value not in suggestions:
             suggestions.append(value)
 

--- a/tests/test_sprint5.py
+++ b/tests/test_sprint5.py
@@ -108,6 +108,50 @@ def test_workspace_suggest_hidden_dirs_only_when_requested(cleanup_test_sessions
     assert status2 == 200
     assert str(hidden) in data2["suggestions"]
 
+
+def test_workspace_suggest_preserves_tilde_prefix(monkeypatch, tmp_path):
+    from api import workspace
+
+    home = tmp_path / "home"
+    child = home / "Projects"
+    child.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(workspace, "_trusted_workspace_roots", lambda: [home.resolve()])
+
+    suggestions = workspace.list_workspace_suggestions("~/")
+
+    assert "~/Projects" in suggestions
+    assert str(child.resolve()) not in suggestions
+
+
+def test_workspace_suggest_preserves_tilde_prefix_for_partial_child(monkeypatch, tmp_path):
+    from api import workspace
+
+    home = tmp_path / "home"
+    child = home / "Projects"
+    child.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(workspace, "_trusted_workspace_roots", lambda: [home.resolve()])
+
+    suggestions = workspace.list_workspace_suggestions("~/Pro")
+
+    assert suggestions == ["~/Projects"]
+
+
+def test_workspace_suggest_keeps_absolute_prefix_absolute(monkeypatch, tmp_path):
+    from api import workspace
+
+    home = tmp_path / "home"
+    child = home / "Projects"
+    child.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(workspace, "_trusted_workspace_roots", lambda: [home.resolve()])
+
+    suggestions = workspace.list_workspace_suggestions(str(home) + "/Pro")
+
+    assert suggestions == [str(child.resolve())]
+
+
 def test_workspace_remove(cleanup_test_sessions):
     _, ws = make_session_tracked(cleanup_test_sessions)
     child = make_workspace_child(ws, f"workspace-remove-{uuid.uuid4().hex[:6]}")


### PR DESCRIPTION
## Thinking Path
Issue #3173 asks for workspace directory completion that behaves like the standard UI when typing `~/`. The existing suggestions endpoint already expands `~/` safely, but it returns absolute `/home/...` values, so choosing a suggestion loses the user's tilde-based path context.

## What Changed
- Keeps workspace suggestion scanning limited to trusted roots.
- Preserves `~/...` formatting for suggestions under the current home directory when the user typed a `~` prefix.
- Leaves absolute-prefix suggestions absolute.
- Adds regression coverage for `~/`, `~/partial`, and absolute home prefixes.
- Adds an Unreleased changelog entry.

## Why It Matters
Typing `~/` in the workspace path field now completes home-relative directories without replacing the input with a long absolute path. Validation still expands the path server-side when the workspace is saved.

## Verification
- `python3 -m py_compile api/workspace.py`
- `python3 -m pytest tests/test_sprint5.py::test_workspace_suggest_preserves_tilde_prefix tests/test_sprint5.py::test_workspace_suggest_preserves_tilde_prefix_for_partial_child tests/test_sprint5.py::test_workspace_suggest_keeps_absolute_prefix_absolute tests/test_sprint5.py::test_workspace_suggest_returns_trusted_directories tests/test_sprint5.py::test_workspace_suggest_hides_untrusted_system_prefix tests/test_sprint5.py::test_workspace_suggest_hidden_dirs_only_when_requested -q` → 6 passed
- `git diff --check`
- Added-line private/risky marker scan → 0 hits
- Independent blocker-only review: passed, no security or logic blockers

## Risks / Follow-ups
- This only changes suggestion display values for `~`-prefixed input. Saved workspace paths still resolve through the existing validation path.
- Open PRs also touch `static/panels.js` and workspace-adjacent areas, but this slice only changes backend suggestion formatting plus tests.

Closes #3173

## Model Used
OpenAI Codex GPT-5.5 via Hermes WebUI, with terminal/file tools and an independent reviewer subagent.
