### PR TITLE
Bugfix for #3120

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1515,6 +1515,18 @@ async function _loadOlderMessages() {
     _messageRenderWindowSize=_currentMessageRenderWindowSize()+Math.max(addedRenderable, MESSAGE_RENDER_WINDOW_DEFAULT);
     _messagesTruncated = !!responseSession._messages_truncated;
     _oldestIdx = responseSession._messages_offset || 0;
+    // Sync S.toolCalls with the expanded message set so renderMessages() uses
+    // fresh indices. For sessions where messages carry per-message tool_use data
+    // the server sends tool_calls=[]; clearing S.toolCalls here lets the
+    // renderMessages fallback rebuild them with correct rawIdx values from the
+    // updated S.messages. For older sessions with absolute-index session-level
+    // tool_calls the server sends the window-filtered list; adopt it directly.
+    const _loadedTc = (responseSession.tool_calls || []).filter(Boolean);
+    if (_loadedTc.length > 0) {
+      S.toolCalls = _loadedTc.map(tc => ({...tc, done: true}));
+    } else {
+      S.toolCalls = [];
+    }
     renderMessages({ preserveScroll: true });
     if (container) {
       // Prepending older messages must not teleport the reader. Preserve the
@@ -1586,6 +1598,16 @@ async function _ensureAllMessagesLoaded() {
     _oldestIdx = 0;
     if (S.session && S.session.session_id === sid) {
       S.session.message_count = Number(data.session.message_count || msgs.length);
+    }
+    // Loading all messages gives us absolute rawIdx=0..N, so server-side
+    // tool_calls (absolute indices, no windowing filter) are valid. Adopt
+    // them directly, or reset to [] for per-message-metadata sessions so
+    // the renderMessages fallback rebuilds with correct rawIdx values.
+    const _allTc = (data.session.tool_calls || []).filter(Boolean);
+    if (_allTc.length > 0) {
+      S.toolCalls = _allTc.map(tc => ({...tc, done: true}));
+    } else {
+      S.toolCalls = [];
     }
   } finally {
     _loadingOlder = false;


### PR DESCRIPTION
Disclaimer: Bugfix by Claude. Verified by me. Someone who knows the code better will have to verify that the fix makes sense.

**Description from Claude:**
For any session where messages have Anthropic-format `tool_use` blocks in the content (i.e., all modern Claude Code sessions), the server intentionally omits the session-level `tool_calls` to avoid redundancy. The client then uses a fallback in renderMessages that derives tool call cards from the messages directly, using `rawIdx` (index in the current `S.messages` array) as the `assistant_msg_idx`.

The problem: when you scroll up and `_loadOlderMessages` fires, it replaces `S.messages` with an expanded set containing more (older) messages. The `rawIdx` values from the initial fallback now point to completely different messages — the newly loaded older ones. Since `S.toolCalls` is non-empty, the fallback doesn't re-run on the next renderMessages call. Tool cards silently migrate to the wrong (older) messages and "disappear" from the recent turns where you expect them.

**The fix (two places in sessions.js):**
  1. `_loadOlderMessages` (the scroll path): after updating `S.messages`, sync `S.toolCalls` from the server response. If the response has session-level tool calls (old-format sessions), adopt them directly. If it returns `[]` (per-message-metadata sessions), clear `S.toolCalls` so the fallback rebuilds with fresh rawIdx values.
  2. `_ensureAllMessagesLoaded` (the Jump to Start path): same fix — when all messages are loaded, `rawIdx = absolute_index`, so the server's absolute-index tool calls are now correct.