### PR TITLE
fix: dedupe sidebar completion session ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid duplicate sidebar rows when a compressed session completes after both the preserved snapshot id and continuation id are already present in the session list.
+
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 
 ### Added

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -361,7 +361,9 @@ function _markSessionCompletedInList(session, previousSid = null) {
   if (!session || !Array.isArray(_allSessions)) return;
   const finalSid = session.session_id || previousSid;
   if (!finalSid) return;
-  const idx = _allSessions.findIndex(s => s && (s.session_id === finalSid || s.session_id === previousSid));
+  const finalIdx = _allSessions.findIndex(s => s && s.session_id === finalSid);
+  const previousIdx = previousSid ? _allSessions.findIndex(s => s && s.session_id === previousSid) : -1;
+  const idx = finalIdx >= 0 ? finalIdx : previousIdx;
   if (idx < 0) return;
   const {messages: _messages, tool_calls: _toolCalls, ...sessionMeta} = session;
   const messageCount = Number(
@@ -384,6 +386,11 @@ function _markSessionCompletedInList(session, previousSid = null) {
   _sessionStreamingById.set(finalSid, false);
   _forgetObservedStreamingSession(finalSid);
   if (previousSid && previousSid !== finalSid) {
+    for (let i = _allSessions.length - 1; i >= 0; i--) {
+      if (i !== idx && _allSessions[i] && _allSessions[i].session_id === previousSid) {
+        _allSessions.splice(i, 1);
+      }
+    }
     _sessionStreamingById.delete(previousSid);
     _forgetObservedStreamingSession(previousSid);
     _sessionListSnapshotById.delete(previousSid);

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -100,7 +100,9 @@ def test_sidebar_cache_completion_handles_compression_session_rotation():
 
     assert "function _markSessionCompletedInList(session, previousSid = null)" in helper_block
     assert "const finalSid = session.session_id || previousSid;" in helper_block
-    assert "s.session_id === finalSid || s.session_id === previousSid" in helper_block
+    assert "const finalIdx = _allSessions.findIndex(s => s && s.session_id === finalSid);" in helper_block
+    assert "const previousIdx = previousSid ? _allSessions.findIndex(s => s && s.session_id === previousSid) : -1;" in helper_block
+    assert "const idx = finalIdx >= 0 ? finalIdx : previousIdx;" in helper_block
     assert "const {messages: _messages, tool_calls: _toolCalls, ...sessionMeta} = session;" in helper_block
     assert "...sessionMeta" in helper_block
     assert "session_id: finalSid" in helper_block

--- a/tests/test_sidebar_completion_dedupe.py
+++ b/tests/test_sidebar_completion_dedupe.py
@@ -1,0 +1,51 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _extract_js_function(src: str, name: str) -> str:
+    start = src.index(f"function {name}(")
+    brace = src.index("{", start)
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : idx + 1]
+    raise AssertionError(f"could not extract {name}")
+
+
+def test_mark_session_completed_in_list_dedupes_old_and_new_sid_rows():
+    sessions_src = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+    fn_src = _extract_js_function(sessions_src, "_markSessionCompletedInList")
+    script = f"""
+let _allSessions = [
+  {{ session_id: 'old', title: 'Before', message_count: 10, pre_compression_snapshot: true }},
+  {{ session_id: 'new', title: 'After', message_count: 2, parent_session_id: 'old' }},
+];
+let _sessionStreamingById = new Map([['old', true], ['new', true]]);
+let _sessionListSnapshotById = new Map([['old', {{message_count: 10}}]]);
+function _forgetObservedStreamingSession(_sid) {{}}
+function renderSessionListFromCache() {{}}
+{fn_src}
+_markSessionCompletedInList({{
+  session_id: 'new',
+  title: 'After done',
+  message_count: 3,
+  parent_session_id: 'old',
+}}, 'old');
+console.log(JSON.stringify({{rows: _allSessions, oldStreaming: _sessionStreamingById.has('old')}}));
+"""
+    result = subprocess.run(["node", "-e", script], check=True, text=True, capture_output=True)
+    payload = json.loads(result.stdout)
+
+    assert [row["session_id"] for row in payload["rows"]] == ["new"]
+    assert payload["rows"][0]["title"] == "After done"
+    assert payload["rows"][0]["message_count"] == 3
+    assert payload["oldStreaming"] is False


### PR DESCRIPTION
## Summary
- prefer the final/continuation session row when marking a compressed stream complete
- remove stale previous-id rows after completion so the sidebar cannot show both preserved snapshot id and continuation id for the same run
- add a focused Node-backed regression test for the duplicate old/new row case
- update the adjacent source-invariant test to assert final-id priority instead of the previous old-or-new match expression

## Why
During compression completion the session list can temporarily contain both the preserved snapshot id and the continuation id. The previous completion helper matched either id and could update the old row into the new id while leaving the already-present new row intact, producing duplicate sidebar rows for the same conversation.

## Contract Routing
- State layer mutated: frontend sidebar session-list cache only.
- Persistent session data and backend lineage are unchanged.
- Preserves canonical visible-tip behavior by keeping the final session id row and dropping the stale previous-id row from the local list.

## Validation
- `pytest tests/test_sidebar_completion_dedupe.py tests/test_session_lineage_collapse.py tests/test_issue856_background_completion_unread.py::test_sidebar_cache_completion_handles_compression_session_rotation -q` → 24 passed
- `node --check static/sessions.js`
- `git diff --check`
- Independent blocker review: passed; no blockers.
- GitHub Actions `test (3.11)`, `test (3.12)`, and `test (3.13)` passed on head `9458df6f4d8d958bb579a96428a1461ffc800a71`.
