### PR TITLE
feat: per-tab profile isolation via sessionStorage + URL hash param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Model picker now exposes the `kimi-coding-cn` / `KIMI_CN_API_KEY` provider as "Kimi / Moonshot (China)" instead of requiring the global `KIMI_API_KEY` route, so China-region Kimi keys can select `kimi-k2.6` without being sent to the wrong endpoint.
+
 ## [v0.51.145] — 2026-05-26 — Release DQ (stage-batch27 — sidebar running-state preservation)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -712,6 +712,7 @@ _PROVIDER_DISPLAY = {
     "cursor-acp": "Cursor ACP",
     "zai": "Z.AI / GLM",
     "kimi-coding": "Kimi / Moonshot",
+    "kimi-coding-cn": "Kimi / Moonshot (China)",
     "deepseek": "DeepSeek",
     "minimax": "MiniMax",
     "minimax-cn": "MiniMax (China)",
@@ -1107,6 +1108,14 @@ _PROVIDER_MODELS = {
         {"id": "moonshot-v1-128k", "label": "Moonshot v1 128k"},
         {"id": "kimi-latest", "label": "Kimi Latest"},
         {"id": "kimi-k2.5", "label": "Kimi K2.5"},
+    ],
+    "kimi-coding-cn": [
+        {"id": "kimi-k2.6", "label": "Kimi K2.6"},
+        {"id": "kimi-k2.5", "label": "Kimi K2.5"},
+        {"id": "moonshot-v1-8k", "label": "Moonshot v1 8k"},
+        {"id": "moonshot-v1-32k", "label": "Moonshot v1 32k"},
+        {"id": "moonshot-v1-128k", "label": "Moonshot v1 128k"},
+        {"id": "moonshot-v1-auto", "label": "Moonshot v1 Auto"},
     ],
     "minimax": [
         {"id": "MiniMax-M2.7", "label": "MiniMax M2.7"},
@@ -3395,6 +3404,7 @@ def get_available_models() -> dict:
                 "GEMINI_API_KEY",
                 "GLM_API_KEY",
                 "KIMI_API_KEY",
+                "KIMI_CN_API_KEY",
                 "DEEPSEEK_API_KEY",
                 "XIAOMI_API_KEY",
                 "OPENCODE_ZEN_API_KEY",
@@ -3428,6 +3438,8 @@ def get_available_models() -> dict:
                 detected_providers.add("zai")
             if all_env.get("KIMI_API_KEY"):
                 detected_providers.add("kimi-coding")
+            if all_env.get("KIMI_CN_API_KEY"):
+                detected_providers.add("kimi-coding-cn")
             if all_env.get("MINIMAX_API_KEY"):
                 detected_providers.add("minimax")
             if all_env.get("MINIMAX_CN_API_KEY"):

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -383,7 +383,23 @@ def get_profile_cookie_name() -> str:
 
 
 def get_profile_cookie(handler) -> str | None:
-    """Extract the active-profile cookie value from the request, or None."""
+    """Extract the active-profile value from the request, or None.
+
+    Checks query parameter ``?profile=`` first (per-tab isolation via
+    sessionStorage), then falls back to the ``hermes_profile`` cookie
+    (shared across tabs).  This lets different browser tabs operate under
+    different profiles even though cookies are same-origin-scoped.
+    """
+    # ── Query param override (per-tab profile isolation) ──────────────
+    from urllib.parse import urlparse, parse_qs
+    parsed = urlparse(handler.path)
+    qp_profile = parse_qs(parsed.query).get('profile', [None])[0]
+    if qp_profile:
+        from api.profiles import _PROFILE_ID_RE
+        if qp_profile == 'default' or _PROFILE_ID_RE.fullmatch(qp_profile):
+            return qp_profile
+
+    # ── Cookie fallback (shared across same-origin tabs) ──────────────
     cookie_header = handler.headers.get('Cookie', '')
     if not cookie_header:
         return None

--- a/api/providers.py
+++ b/api/providers.py
@@ -642,6 +642,7 @@ _PROVIDER_ENV_VAR: dict[str, str] = {
     "gemini": "GEMINI_API_KEY",
     "zai": "GLM_API_KEY",
     "kimi-coding": "KIMI_API_KEY",
+    "kimi-coding-cn": "KIMI_CN_API_KEY",
     "deepseek": "DEEPSEEK_API_KEY",
     "minimax": "MINIMAX_API_KEY",
     "minimax-cn": "MINIMAX_CN_API_KEY",

--- a/api/routes.py
+++ b/api/routes.py
@@ -5922,20 +5922,19 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, "name is required")
         try:
             from api.profiles import switch_profile, _validate_profile_name
-            from api.helpers import build_profile_cookie
             if name != 'default':
                 _validate_profile_name(name)
             # process_wide=False: don't mutate the process-global _active_profile.
-            # Per-client profile is managed via cookie + thread-local (#798).
+            # Per-client profile is managed via sessionStorage + query param +
+            # thread-local.  Do NOT set a cookie here — cookies with path='/' are
+            # shared across all tabs and cause cross-tab profile contamination.
             result = switch_profile(name, process_wide=False)
             # Invalidate the models cache so the very next /api/models request
             # rebuilds from the new profile's config.yaml rather than returning
             # the old profile's cached model list (#1200 — profile-switch model bug).
             from api.config import invalidate_models_cache
             invalidate_models_cache()
-            return j(handler, result, extra_headers={
-                'Set-Cookie': build_profile_cookie(name),
-            })
+            return j(handler, result)
         except (ValueError, FileNotFoundError) as e:
             return bad(handler, _sanitize_error(e), 404)
         except RuntimeError as e:

--- a/static/boot.js
+++ b/static/boot.js
@@ -1657,8 +1657,23 @@ function applyBotName(){
     const _checkUrl='api/updates/check'+(_testUpdates?'?simulate=1':'');
     api(_checkUrl).then(d=>{if(!_testUpdates)sessionStorage.setItem('hermes-update-checked','1');if((d.webui&&d.webui.behind>0)||(d.agent&&d.agent.behind>0))_showUpdateBanner(d);}).catch(()=>{});
   }
-  // Fetch active profile
-  try{const p=await api('/api/profile/active');S.activeProfile=p.name||'default';}catch(e){S.activeProfile='default';}
+  // Fetch active profile — URL param or sessionStorage takes priority
+  // for per-tab profile isolation (cookie is same-origin-scoped and
+  // cannot differentiate tabs without these sources).
+  const _searchParams=new URLSearchParams(location.search);
+  const _hashQuery=location.hash.replace(/^#[^?]*\??/,'');
+  if(_hashQuery)new URLSearchParams(_hashQuery).forEach(function(v,k){_searchParams.set(k,v);});
+  const _urlProfile=_searchParams.get('profile');
+  const _ssProfile=sessionStorage.getItem('hermes-profile');
+  const _profileHint=_urlProfile||_ssProfile;
+  try{
+    const p=await api('/api/profile/active'+(_profileHint?'?profile='+encodeURIComponent(_profileHint):''));
+    S.activeProfile=p.name||'default';
+  }catch(e){S.activeProfile=_profileHint||'default';}
+  // Persist to sessionStorage so the api() helper can attach ?profile=
+  // to requests, and so a page refresh (which strips the URL param)
+  // keeps this tab on the same profile.
+  try{sessionStorage.setItem('hermes-profile',S.activeProfile);}catch(_){}
   applyBotName();
   // Update profile chip label immediately
   const profileLabel=$('profileChipLabel');

--- a/static/panels.js
+++ b/static/panels.js
@@ -5242,6 +5242,17 @@ async function switchToProfile(name) {
     const data = await api('/api/profile/switch', { method: 'POST', body: JSON.stringify({ name }) });
     if (_switchGen !== _profileSwitchGeneration) return;
     S.activeProfile = data.active || name;
+    // Per-tab profile isolation: persist in sessionStorage so api() can
+    // attach ?profile= to every request (cookies are same-origin-scoped
+    // and cannot provide per-tab isolation).
+    try { sessionStorage.setItem('hermes-profile', S.activeProfile); } catch (_) {}
+    // Per-tab profile isolation: update URL hash so page refresh and
+    // shared bookmarks keep this tab on its chosen profile.
+    try {
+      const _h=location.hash||'#/chat';
+      const _base=_h.replace(/[?#].*$/,'');
+      location.replace(_base+'?profile='+encodeURIComponent(S.activeProfile));
+    } catch(_) {}
 
     // Update composer placeholder and title bar while the core profile-switch
     // state is still close to the profile API response.
@@ -5282,11 +5293,12 @@ async function switchToProfile(name) {
         : {model:modelToUse,model_provider:providerId};
       S._pendingProfileModel = modelToUse;
       S._pendingProfileModelProvider = modelState.model_provider||providerId||null;
-      // Only patch the in-memory session model if we're NOT about to replace the session
-      if (S.session && !sessionInProgress) {
-        S.session.model = modelToUse;
-        S.session.model_provider = modelState.model_provider||providerId||null;
-      }
+      // Per-tab profile isolation: do NOT mutate S.session.{model,model_provider}
+      // in-place.  Sessions in state.db are shared across tabs (same cookie
+      // domain).  If one tab switches profile and patches the session's provider
+      // (e.g. default→kimi-coding), the other tab's next chat picks up the
+      // wrong provider and routes its model to the wrong API endpoint.
+      // _pendingProfile* fields are consumed by newSession() only.  (#tab-isolation)
     }
 
     // ── Apply workspace ────────────────────────────────────────────────────

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -2,6 +2,16 @@ async function api(path,opts={}){
   // Strip leading slash so URL resolves relative to location.href (supports subpath mounts)
   const rel = path.startsWith('/') ? path.slice(1) : path;
   const url=new URL(rel,document.baseURI||location.href);
+  // Per-tab profile isolation: inject sessionStorage profile as query param
+  // so different tabs can operate under different profiles (the hermes_profile
+  // cookie is same-origin-scoped, so it cannot provide per-tab isolation).
+  const _tpProfile = sessionStorage.getItem('hermes-profile');
+  // Only inject sessionStorage profile if the caller didn't already
+  // specify one — preserves explicit ?profile= overrides (e.g. boot.js
+  // uses ?profile=default when navigating from a non-default tab).
+  if (_tpProfile && !url.searchParams.has('profile')) {
+    url.searchParams.set('profile', _tpProfile);
+  }
   const timeoutMs=Object.prototype.hasOwnProperty.call(opts,'timeoutMs')?opts.timeoutMs:30000;
   // Retry up to 2 times on network errors (e.g. stale keep-alive after long idle).
   // Server errors (4xx/5xx) and client-side timeouts are NOT retried.

--- a/tests/test_kimi_cn_provider.py
+++ b/tests/test_kimi_cn_provider.py
@@ -1,0 +1,79 @@
+"""Regression tests for Kimi China provider visibility in the model picker."""
+
+import builtins
+
+import api.config as config
+from api.providers import _PROVIDER_ENV_VAR
+
+
+def _force_env_fallback(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in ("hermes_cli.models", "hermes_cli.auth"):
+            raise ImportError(name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def _run_available_models_with_cfg(monkeypatch, tmp_path, cfg):
+    old_cfg = dict(config.cfg)
+    old_mtime = config._cfg_mtime
+    monkeypatch.setattr(config, "_models_cache_path", tmp_path / "models_cache.json")
+    monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "missing-config.yaml")
+    config.cfg.clear()
+    config.cfg.update(cfg)
+    config._cfg_mtime = 0.0
+    try:
+        config.invalidate_models_cache()
+        return config.get_available_models()
+    finally:
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+        config._cfg_mtime = old_mtime
+        config.invalidate_models_cache()
+
+
+def test_kimi_coding_cn_has_static_catalog():
+    assert config._PROVIDER_DISPLAY.get("kimi-coding-cn") == "Kimi / Moonshot (China)"
+    ids = [m["id"] for m in config._PROVIDER_MODELS.get("kimi-coding-cn", [])]
+    assert "kimi-k2.6" in ids
+
+
+def test_kimi_cn_api_key_detects_china_provider_only(monkeypatch, tmp_path):
+    _force_env_fallback(monkeypatch)
+    monkeypatch.delenv("KIMI_API_KEY", raising=False)
+    monkeypatch.setenv("KIMI_CN_API_KEY", "test-cn-key")
+
+    result = _run_available_models_with_cfg(monkeypatch, tmp_path, {"model": {}})
+    groups = {g["provider_id"]: g for g in result["groups"]}
+
+    assert "kimi-coding-cn" in groups, f"kimi-coding-cn group missing: {groups.keys()}"
+    assert groups["kimi-coding-cn"]["provider"] == "Kimi / Moonshot (China)"
+    assert "kimi-k2.6" in {m["id"] for m in groups["kimi-coding-cn"]["models"]}
+    assert "kimi-coding" not in groups
+
+
+def test_kimi_coding_cn_active_provider_gets_picker_group(monkeypatch, tmp_path):
+    _force_env_fallback(monkeypatch)
+    monkeypatch.delenv("KIMI_API_KEY", raising=False)
+    monkeypatch.delenv("KIMI_CN_API_KEY", raising=False)
+
+    result = _run_available_models_with_cfg(
+        monkeypatch,
+        tmp_path,
+        {
+            "model": {"provider": "kimi-coding-cn", "default": "kimi-k2.6"},
+            "providers": {},
+        },
+    )
+    groups = {g["provider_id"]: g for g in result["groups"]}
+
+    assert result["active_provider"] == "kimi-coding-cn"
+    assert result["default_model"] == "kimi-k2.6"
+    assert "kimi-coding-cn" in groups
+
+
+def test_kimi_coding_cn_key_can_be_managed_from_provider_settings():
+    assert _PROVIDER_ENV_VAR.get("kimi-coding-cn") == "KIMI_CN_API_KEY"


### PR DESCRIPTION
Profile switching previously relied solely on the hermes_profile cookie (path='/'), which is same-origin-scoped and shared across all browser tabs. Switching profile in one tab contaminated every other tab.

Changes:
- api/helpers.py: get_profile_cookie() respects ?profile= query param before falling back to the cookie, enabling per-request isolation
- static/boot.js: parses ?profile= from URL hash, persists to sessionStorage, with priority: URL > sessionStorage > cookie
- static/panels.js: switchToProfile() writes sessionStorage + updates URL hash; stops mutating S.session.{model,model_provider} to prevent cross-tab session corruption (default tab getting routed to wrong API)
- static/workspace.js: api() injects ?profile= from sessionStorage on every request, including 'default' profile

Also adds kimi-coding-cn provider support (KIMI_CN_API_KEY) so China- region Kimi keys can use the api.moonshot.cn endpoint instead of being routed to the global api.moonshot.ai.

Closes: per-tab profile sharing / cross-contamination issue