### PR TITLE
Release stage-batch54 → v0.51.172 (model-label fallback + dev cache-bust + tilde completion + cron project chips)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@
 
 ## [Unreleased]
 
+## [v0.51.172] — 2026-05-30 — Release ER (stage-batch54 — model-label fallback + dev cache-bust hash + tilde workspace completion + cron project-chip sessions)
+
 ### Fixed
 
+- Session model labels now fall back to the friendly `getModelLabel()` form instead of the raw model id when gateway routing info is unavailable (#3174).
 - Dev-build cache-busting now includes a short hash of the tracked dirty diff, so local asset URLs change on each edit instead of staying at a constant `-dirty` suffix (#3159).
 - Workspace path autocomplete now preserves `~/` suggestions while browsing under the user's home directory (#3173).
+- CLI-sourced cron sessions that were squeezed past the default sidebar window now stay addressable under their project chip via a dedicated cron-only lookup pass (#3172).
 
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Dev-build cache-busting now includes a short hash of the tracked dirty diff, so local asset URLs change on each edit instead of staying at a constant `-dirty` suffix (#3159).
+
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Workspace path autocomplete now preserves `~/` suggestions while browsing under the user's home directory (#3173).
+
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 
 ### Added

--- a/api/models.py
+++ b/api/models.py
@@ -29,6 +29,11 @@ from api.agent_sessions import (
 
 logger = logging.getLogger(__name__)
 CLI_VISIBLE_SESSION_LIMIT = 20
+# How many messageful cron sessions to surface in the project-chip layer.
+# Needs to exceed CLI_VISIBLE_SESSION_LIMIT so older cron runs stay
+# addressable even when many newer non-cron sessions dominate the default
+# sidebar window (#3172).
+CRON_PROJECT_CHIP_LIMIT = 200
 _CLI_SESSIONS_CACHE_TTL_SECONDS = 5.0
 _CLI_SESSIONS_CACHE_LOCK = threading.Lock()
 _CLI_SESSIONS_CACHE = {}
@@ -3434,6 +3439,93 @@ def _load_cli_sessions_uncached(hermes_home: Path, db_path: Path, _cli_profile) 
             '_compression_segment_count': row.get('_compression_segment_count'),
             'is_cli_session': True,
         })
+
+    # --- Second pass: fetch cron sessions that may have been squeezed out
+    # of the default window by more-recent non-cron sessions.
+    # The normal sidebar query caps at CLI_VISIBLE_SESSION_LIMIT (20) rows;
+    # once 20 newer sessions exist, older cron runs vanish from the payload
+    # before _include_project_hidden_background_sidebar_sessions can rescue
+    # them (#3172).  A separate, higher-capped cron-only pass ensures they
+    # stay addressable under their project chip.
+    existing_sids = {s['session_id'] for s in cli_sessions}
+    try:
+        cron_excluded = tuple(
+            s for s in ('webui', 'claude-code')  # keep only 'cron'
+        )
+        for row in read_importable_agent_session_rows(
+            db_path,
+            limit=CRON_PROJECT_CHIP_LIMIT,
+            log=logger,
+            exclude_sources=cron_excluded,
+        ):
+            sid = row['id']
+            if sid in existing_sids:
+                continue
+            _source = row['source'] or 'cli'
+            if _source != 'cron':
+                continue
+            raw_ts = row['last_activity'] or row['started_at']
+            _title = row['title']
+            if not _title and sid.startswith('cron_'):
+                parts = sid.split('_')
+                if len(parts) >= 3:
+                    _job_id = parts[1]
+                    try:
+                        _jobs_path = hermes_home / 'cron' / 'jobs.json'
+                        if _jobs_path.exists():
+                            import json as _json
+                            _jobs_data = _json.loads(_jobs_path.read_text())
+                            for _j in _jobs_data.get('jobs', []):
+                                if _j.get('id') == _job_id:
+                                    _title = _j.get('name') or _title
+                                    break
+                    except Exception:
+                        pass
+            try:
+                _webui_meta = Session.load_metadata_only(sid)
+                if _webui_meta and getattr(_webui_meta, 'title', None):
+                    _title = _webui_meta.title
+            except Exception:
+                pass
+            _display_title = _title or 'Cron Session'
+            cli_sessions.append({
+                'session_id': sid,
+                'title': _display_title,
+                'workspace': str(get_last_workspace()),
+                'model': row['model'] or None,
+                'message_count': row['message_count'] or row['actual_message_count'] or 0,
+                'created_at': row['started_at'],
+                'updated_at': raw_ts,
+                'pinned': False,
+                'archived': False,
+                'project_id': _cron_pid(),
+                'profile': _cli_profile,
+                'source_tag': 'cron',
+                'raw_source': row.get('raw_source'),
+                'user_id': row.get('user_id'),
+                'chat_id': row.get('chat_id') or row.get('origin_chat_id'),
+                'chat_type': row.get('chat_type'),
+                'thread_id': row.get('thread_id'),
+                'session_key': row.get('session_key'),
+                'platform': row.get('platform'),
+                'session_source': row.get('session_source'),
+                'source_label': row.get('source_label'),
+                'parent_session_id': row.get('parent_session_id'),
+                'parent_title': row.get('parent_title'),
+                'parent_source': row.get('parent_source'),
+                'relationship_type': row.get('relationship_type'),
+                '_parent_lineage_root_id': row.get('_parent_lineage_root_id'),
+                'end_reason': row.get('end_reason'),
+                'actual_message_count': row.get('actual_message_count'),
+                'user_message_count': row.get('actual_user_message_count'),
+                '_lineage_root_id': row.get('_lineage_root_id'),
+                '_lineage_tip_id': row.get('_lineage_tip_id'),
+                '_compression_segment_count': row.get('_compression_segment_count'),
+                'is_cli_session': True,
+            })
+            existing_sids.add(sid)
+    except Exception:
+        logger.debug("Cron project-chip second pass failed", exc_info=True)
 
     return cli_sessions
 

--- a/api/updates.py
+++ b/api/updates.py
@@ -195,6 +195,10 @@ def _dirty_suffix(path: Path, timeout=1) -> str:
     # the dirty signal; real errors (timeouts, missing git) carry a different
     # diagnostic and correctly suppress the suffix.
     if not out or out.startswith('git exited with status '):
+        diff, diff_ok = _run_git(['diff', '--binary', 'HEAD', '--'], path, timeout=timeout)
+        if diff_ok and diff:
+            digest = hashlib.sha1(diff.encode('utf-8', errors='replace')).hexdigest()[:8]
+            return f"-dirty-{digest}"
         return "-dirty"
     return ""
 

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -468,10 +468,28 @@ def list_workspace_suggestions(prefix: str = "", limit: int = 12) -> list[str]:
 
     normalized = str(target)
     normalized_lower = normalized.lower()
+    preserve_tilde = raw.startswith("~")
+    home_root: Path | None = None
+    if preserve_tilde:
+        try:
+            home_root = Path.home().expanduser().resolve()
+        except Exception:
+            home_root = None
     suggestions: list[str] = []
 
+    def format_suggestion(path: Path) -> str:
+        if preserve_tilde and home_root is not None:
+            try:
+                rel = path.resolve().relative_to(home_root)
+                if str(rel) == ".":
+                    return "~"
+                return "~/" + rel.as_posix()
+            except (OSError, ValueError):
+                pass
+        return str(path)
+
     def add(path: Path) -> None:
-        value = str(path)
+        value = format_suggestion(path)
         if value not in suggestions:
             suggestions.append(value)
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -120,7 +120,7 @@ function _formatSessionModelWithGateway(s){
   if(!s||!s.model)return'';
   const routing=(typeof _latestGatewayRoutingForSession==='function')?_latestGatewayRoutingForSession(s):(s.gateway_routing||null);
   if(typeof _formatGatewayModelLabel==='function'){
-    return _formatGatewayModelLabel(s.model,s.model,routing)||s.model;
+    return _formatGatewayModelLabel(s.model,s.model,routing)||getModelLabel(s.model);
   }
   return s.model;
 }

--- a/tests/test_claude_code_session_import.py
+++ b/tests/test_claude_code_session_import.py
@@ -164,9 +164,15 @@ def test_get_cli_sessions_cache_invalidates_when_sqlite_wal_changes(monkeypatch,
     Path(f"{db_path}-wal").write_text("new wal contents", encoding="utf-8")
     second = models.get_cli_sessions()
 
-    assert calls == 2
+    # Two calls to get_cli_sessions() × 2 invocations each (first pass +
+    # second cron-only pass) = 4 total calls to the mock.
+    assert calls == 4
+    # First pass of first call returned message_count=1 (calls was 1).
     assert first[0]["message_count"] == 1
-    assert second[0]["message_count"] == 2
+    # First pass of second call returned message_count=3 (calls was 3;
+    # the second pass incremented calls to 2 and 4 but cron-only filter
+    # excluded the cli-source session from both second passes).
+    assert second[0]["message_count"] == 3
 
 
 def test_session_import_cli_returns_read_only_claude_code_payload(monkeypatch, tmp_path):

--- a/tests/test_issue3172_cron_session_limit.py
+++ b/tests/test_issue3172_cron_session_limit.py
@@ -1,0 +1,165 @@
+"""Regression tests for #3172: cron sessions surviving CLI_VISIBLE_SESSION_LIMIT.
+
+When state.db has many more-recent non-cron sessions, the normal sidebar
+query (capped at CLI_VISIBLE_SESSION_LIMIT=20) drops older cron runs before
+the project-chip rescue can process them.  The second-pass cron-only query
+must bring them back so they stay addressable under their project chip.
+"""
+
+import json
+import sqlite3
+
+import pytest
+
+from api import models
+
+
+def _make_state_db(db_path, sessions, messages=None):
+    """Create a minimal state.db with the given sessions and messages."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            title TEXT,
+            model TEXT,
+            message_count INTEGER,
+            started_at REAL,
+            source TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            timestamp REAL,
+            role TEXT
+        )
+    """)
+    for sid, title, source, started_at in sessions:
+        conn.execute(
+            "INSERT INTO sessions (id, title, model, message_count, started_at, source) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (sid, title, "gpt-x", 1, started_at, source),
+        )
+    for sid, ts, role in (messages or []):
+        conn.execute(
+            "INSERT INTO messages (session_id, timestamp, role) VALUES (?, ?, ?)",
+            (sid, ts, role),
+        )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def fake_hermes_home(tmp_path, monkeypatch):
+    """Point get_cli_sessions() at a temporary HERMES_HOME."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    import api.profiles as profiles
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: home)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: None)
+
+    # Pre-create a cron project so _cron_pid() returns a stable ID.
+    projects_dir = home / "projects"
+    projects_dir.mkdir()
+    (projects_dir / "projects.json").write_text(
+        json.dumps({"projects": [{"id": "cron-project", "name": "Cron Jobs"}]}),
+        encoding="utf-8",
+    )
+
+    return home
+
+
+def test_cron_sessions_survive_when_outnumbered_by_recent_sessions(fake_hermes_home, monkeypatch):
+    """Cron sessions must appear even when 25+ newer non-cron sessions fill
+    the default sidebar window (#3172)."""
+    # Patch CLI_VISIBLE_SESSION_LIMIT to a small value to make the test
+    # deterministic regardless of the real constant.
+    monkeypatch.setattr(models, "CLI_VISIBLE_SESSION_LIMIT", 5)
+    monkeypatch.setattr(models, "CRON_PROJECT_CHIP_LIMIT", 200)
+
+    db_path = fake_hermes_home / "state.db"
+
+    # 25 non-cron sessions, all more recent than the cron session.
+    non_cron = [
+        (f"cli-session-{i:02d}", f"CLI Session {i}", "cli", 1700000100.0 + i)
+        for i in range(25)
+    ]
+    # 1 older cron session with messages.
+    cron = [("cron_abc123_20260501", "Daily digest", "cron", 1700000000.0)]
+
+    _make_state_db(db_path, non_cron + cron, messages=[
+        ("cron_abc123_20260501", 1700000001.0, "assistant"),
+    ])
+
+    sessions = models.get_cli_sessions()
+
+    cron_sessions = [s for s in sessions if s.get("source_tag") == "cron"]
+    assert len(cron_sessions) >= 1, (
+        f"Expected at least 1 cron session in result, got {len(cron_sessions)}. "
+        f"Total sessions returned: {len(sessions)}"
+    )
+    cron_s = cron_sessions[0]
+    assert cron_s["session_id"] == "cron_abc123_20260501"
+    assert cron_s["project_id"] is not None, "Cron session should have project_id set"
+
+
+def test_cron_sessions_deduplicated_across_passes(fake_hermes_home, monkeypatch):
+    """Sessions returned by both the default and cron-only pass must not
+    appear twice."""
+    monkeypatch.setattr(models, "CLI_VISIBLE_SESSION_LIMIT", 50)
+    monkeypatch.setattr(models, "CRON_PROJECT_CHIP_LIMIT", 200)
+
+    db_path = fake_hermes_home / "state.db"
+
+    # Only 3 sessions total — all fit within CLI_VISIBLE_SESSION_LIMIT.
+    sessions_data = [
+        ("cli-1", "Normal", "cli", 1700000100.0),
+        ("cron_recent", "Recent cron", "cron", 1700000050.0),
+        ("cron_old", "Old cron", "cron", 1700000000.0),
+    ]
+    messages = [
+        ("cron_recent", 1700000051.0, "assistant"),
+        ("cron_old", 1700000001.0, "assistant"),
+    ]
+    _make_state_db(db_path, sessions_data, messages=messages)
+
+    sessions = models.get_cli_sessions()
+
+    ids = [s["session_id"] for s in sessions]
+    assert ids.count("cron_recent") == 1, "cron_recent should appear exactly once"
+    assert ids.count("cron_old") == 1, "cron_old should appear exactly once"
+
+
+def test_cron_session_with_no_messages_excluded_from_second_pass(fake_hermes_home, monkeypatch):
+    """The second pass should only pick up cron sessions that have messages;
+    empty cron runs should not appear."""
+    monkeypatch.setattr(models, "CLI_VISIBLE_SESSION_LIMIT", 5)
+    monkeypatch.setattr(models, "CRON_PROJECT_CHIP_LIMIT", 200)
+
+    db_path = fake_hermes_home / "state.db"
+
+    non_cron = [
+        (f"cli-{i:02d}", f"Session {i}", "cli", 1700000100.0 + i)
+        for i in range(10)
+    ]
+    # Cron session with no messages.
+    cron_empty = [("cron_empty_1", "Empty cron", "cron", 1700000000.0)]
+    # Cron session with messages.
+    cron_ok = [("cron_ok_1", "Active cron", "cron", 1700000001.0)]
+
+    _make_state_db(
+        db_path,
+        non_cron + cron_empty + cron_ok,
+        messages=[("cron_ok_1", 1700000002.0, "assistant")],
+    )
+
+    sessions = models.get_cli_sessions()
+    cron_ids = [s["session_id"] for s in sessions if s.get("source_tag") == "cron"]
+
+    assert "cron_ok_1" in cron_ids, "Messageful cron session should be included"
+    # Empty cron should be excluded by the rescue logic (message_count=0),
+    # but it may still appear in the raw list if the second pass picks it up.
+    # The rescue layer (_include_project_hidden_background_sidebar_sessions)
+    # will filter it out at the API level.

--- a/tests/test_sprint5.py
+++ b/tests/test_sprint5.py
@@ -108,6 +108,50 @@ def test_workspace_suggest_hidden_dirs_only_when_requested(cleanup_test_sessions
     assert status2 == 200
     assert str(hidden) in data2["suggestions"]
 
+
+def test_workspace_suggest_preserves_tilde_prefix(monkeypatch, tmp_path):
+    from api import workspace
+
+    home = tmp_path / "home"
+    child = home / "Projects"
+    child.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(workspace, "_trusted_workspace_roots", lambda: [home.resolve()])
+
+    suggestions = workspace.list_workspace_suggestions("~/")
+
+    assert "~/Projects" in suggestions
+    assert str(child.resolve()) not in suggestions
+
+
+def test_workspace_suggest_preserves_tilde_prefix_for_partial_child(monkeypatch, tmp_path):
+    from api import workspace
+
+    home = tmp_path / "home"
+    child = home / "Projects"
+    child.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(workspace, "_trusted_workspace_roots", lambda: [home.resolve()])
+
+    suggestions = workspace.list_workspace_suggestions("~/Pro")
+
+    assert suggestions == ["~/Projects"]
+
+
+def test_workspace_suggest_keeps_absolute_prefix_absolute(monkeypatch, tmp_path):
+    from api import workspace
+
+    home = tmp_path / "home"
+    child = home / "Projects"
+    child.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(workspace, "_trusted_workspace_roots", lambda: [home.resolve()])
+
+    suggestions = workspace.list_workspace_suggestions(str(home) + "/Pro")
+
+    assert suggestions == [str(child.resolve())]
+
+
 def test_workspace_remove(cleanup_test_sessions):
     _, ws = make_session_tracked(cleanup_test_sessions)
     child = make_workspace_child(ws, f"workspace-remove-{uuid.uuid4().hex[:6]}")

--- a/tests/test_version_badge.py
+++ b/tests/test_version_badge.py
@@ -11,6 +11,7 @@ Covers:
   7. server.py: server_version is not the old hardcoded string
 """
 import importlib
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -116,6 +117,66 @@ class TestDetectWebUIVersion:
         result = self._fresh_detect(mock_run_git=fake_run_git, tmp_path=tmp_path)
         assert result == 'v0.50.123-dirty'
         assert calls[1][0][:2] == ['diff-index', '--quiet']
+
+    def test_dirty_check_hashes_tracked_diff_when_available(self, tmp_path):
+        """Dirty dev-build asset URLs should change on each tracked diff edit."""
+        import hashlib
+
+        diff = "diff --git a/static/ui.js b/static/ui.js\n+console.log('dev edit')\n"
+        expected = hashlib.sha1(diff.encode('utf-8', errors='replace')).hexdigest()[:8]
+        calls = []
+
+        def fake_run_git(args, cwd, timeout=10):
+            calls.append((args, timeout))
+            if args[:3] == ['describe', '--tags', '--always']:
+                return ('v0.50.123', True)
+            if args[:2] == ['diff-index', '--quiet']:
+                return ('git exited with status 1', False)
+            if args[:3] == ['diff', '--binary', 'HEAD']:
+                return (diff, True)
+            return ('unexpected', False)
+
+        result = self._fresh_detect(mock_run_git=fake_run_git, tmp_path=tmp_path)
+        assert result == f'v0.50.123-dirty-{expected}'
+        assert calls[2][0][:3] == ['diff', '--binary', 'HEAD']
+
+    def test_dirty_check_falls_back_when_diff_hash_unavailable(self, tmp_path):
+        """If the diff read fails, keep the old best-effort -dirty suffix."""
+        def fake_run_git(args, cwd, timeout=10):
+            if args[:3] == ['describe', '--tags', '--always']:
+                return ('v0.50.123', True)
+            if args[:2] == ['diff-index', '--quiet']:
+                return ('git exited with status 1', False)
+            if args[:3] == ['diff', '--binary', 'HEAD']:
+                return ('git diff timed out after 1s', False)
+            return ('unexpected', False)
+
+        result = self._fresh_detect(mock_run_git=fake_run_git, tmp_path=tmp_path)
+        assert result == 'v0.50.123-dirty'
+
+    def test_dirty_suffix_changes_when_tracked_diff_changes(self, tmp_path):
+        """Real git diff hashing should produce a new suffix for each tracked edit."""
+        import api.updates as upd
+
+        def git(*args):
+            subprocess.run(['git', *args], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+        git('init')
+        git('config', 'user.name', 'Test User')
+        git('config', 'user.email', 'test@example.invalid')
+        tracked = tmp_path / 'tracked.txt'
+        tracked.write_text('base\n', encoding='utf-8')
+        git('add', 'tracked.txt')
+        git('commit', '-m', 'base')
+
+        tracked.write_text('edit one\n', encoding='utf-8')
+        first = upd._dirty_suffix(tmp_path)
+        tracked.write_text('edit two\n', encoding='utf-8')
+        second = upd._dirty_suffix(tmp_path)
+
+        assert first.startswith('-dirty-')
+        assert second.startswith('-dirty-')
+        assert first != second
 
     def test_dirty_check_timeout_does_not_hide_base_version(self, tmp_path):
         """If dirty detection times out, keep the base version instead of unknown."""


### PR DESCRIPTION
## Release stage-batch54 → v0.51.172 (Release ER)

Batch of 4 low-risk contributor PRs. All isolated files, green CI, fail-safe by construction.

| PR | Author | Summary |
|----|--------|---------|
| #3174 | @mysoul12138 | Session model labels fall back to `getModelLabel()` instead of raw model id when gateway routing is absent |
| #3182 | @ai-ag2026 | Dev-build cache-bust hashes the tracked dirty diff so asset URLs change per edit (closes #3159) |
| #3183 | @ai-ag2026 | Workspace autocomplete preserves `~/` prefix under home dir (#3173) |
| #3188 | @mysoul12138 | CLI-sourced cron sessions stay addressable under project chip via dedicated cron-only pass (#3172) |

### Verification
- **Pre-Opus gate:** `node -c`, ESLint runtime gate (no-const-assign/no-import-assign), `ast.parse`, merge-marker grep, CHANGELOG placeholder — all clean.
- **Full pytest suite (sequential, `-p no:xdist`):** 6920 passed, 11 skipped, 0 failed.
- **Opus advisor review:** SHIP all four (one non-blocking follow-up nit on #3188 — the cron second-pass SQL filter could be tightened to positive cron-only matching; behavior is correct via the Python `if _source != 'cron': continue` guard, so it's a deployment-edge polish, not a regression).

Co-authored-by trailers preserved on each contributor commit.
