### PR TITLE
Release stage-batch55 → v0.51.173 (Windows safety + pin-quota snapshot + tool-card paging anchor + sidebar dedupe + quieter tool cards)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Restored the legacy compact tool-call card chrome by removing the persistent "Tool output" badge and returning the left rail to the muted border treatment. This keeps tool activity visually quieter while preserving the existing collapsible tool details.
+
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Windows native runs now skip the POSIX-only turn-journal directory fsync instead of raising `AttributeError` for missing `os.O_DIRECTORY` on every submitted turn (#3170).
+- `/api/media` now treats Windows cross-drive `commonpath()` comparisons as non-matches instead of 500ing when media paths and allowed roots live on different drives (#3171).
+
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid duplicate sidebar rows when a compressed session completes after both the preserved snapshot id and continuation id are already present in the session list.
+
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Hidden pre-compression snapshots no longer keep stale pin state or count toward the visible pinned-session quota (#3181).
+
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 
 ## [Unreleased]
 
+## [v0.51.173] — 2026-05-30 — Release ES (stage-batch55 — Windows path/journal safety + pin-quota snapshot fix + tool-card paging anchor + sidebar dedupe + quieter tool cards)
+
+### Fixed
+
+- Windows native runs now skip the POSIX-only turn-journal directory fsync instead of raising `AttributeError` for missing `os.O_DIRECTORY` on every submitted turn (#3170).
+- `/api/media` now treats Windows cross-drive `commonpath()` comparisons as non-matches instead of 500ing when media paths and allowed roots live on different drives (#3171).
+- Hidden pre-compression snapshots no longer keep stale pin state or count toward the visible pinned-session quota (#3181).
+- Tool-call cards stay anchored when scrolling back through paginated history; legacy session-level tool-call indices are rebased to the returned message window and the browser refreshes tool-call anchors whenever a larger history window is loaded (#3120).
+- Avoid duplicate sidebar rows when a compressed session completes after both the preserved snapshot id and continuation id are already present in the session list.
+
+### Changed
+
+- Restored the legacy compact tool-call card chrome by removing the persistent "Tool output" badge and returning the left rail to the muted border treatment. This keeps tool activity visually quieter while preserving the existing collapsible tool details.
+
 ## [v0.51.172] — 2026-05-30 — Release ER (stage-batch54 — model-label fallback + dev cache-bust hash + tilde workspace completion + cron project-chip sessions)
 
 ### Fixed
@@ -11,20 +25,6 @@
 - Dev-build cache-busting now includes a short hash of the tracked dirty diff, so local asset URLs change on each edit instead of staying at a constant `-dirty` suffix (#3159).
 - Workspace path autocomplete now preserves `~/` suggestions while browsing under the user's home directory (#3173).
 - CLI-sourced cron sessions that were squeezed past the default sidebar window now stay addressable under their project chip via a dedicated cron-only lookup pass (#3172).
-
-- Windows native runs now skip the POSIX-only turn-journal directory fsync instead of raising `AttributeError` for missing `os.O_DIRECTORY` on every submitted turn (#3170).
-- `/api/media` now treats Windows cross-drive `commonpath()` comparisons as non-matches instead of 500ing when media paths and allowed roots live on different drives (#3171).
-
-- Hidden pre-compression snapshots no longer keep stale pin state or count toward the visible pinned-session quota (#3181).
-
-- Tool-call cards stay anchored when scrolling back through paginated history; legacy session-level tool-call indices are rebased to the returned message window and the browser refreshes tool-call anchors whenever a larger history window is loaded (#3120).
-
-- Avoid duplicate sidebar rows when a compressed session completes after both the preserved snapshot id and continuation id are already present in the session list.
-
-### Changed
-
-- Restored the legacy compact tool-call card chrome by removing the persistent "Tool output" badge and returning the left rail to the muted border treatment. This keeps tool activity visually quieter while preserving the existing collapsible tool details.
-
 
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Tool-call cards stay anchored when scrolling back through paginated history; legacy session-level tool-call indices are rebased to the returned message window and the browser refreshes tool-call anchors whenever a larger history window is loaded (#3120).
+
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -99,6 +99,25 @@ def _session_field(session, field, default=None):
     return getattr(session, field, default)
 
 
+def _session_counts_toward_pin_quota(session) -> bool:
+    """Return True when a pinned session should consume visible pin quota."""
+    if not _session_field(session, "pinned", False):
+        return False
+    if _session_field(session, "archived", False):
+        return False
+    if isinstance(session, dict):
+        row = session
+    elif hasattr(session, "compact"):
+        row = session.compact()
+    else:
+        row = {
+            "pre_compression_snapshot": _session_field(session, "pre_compression_snapshot", False),
+            "source_tag": _session_field(session, "source_tag", None),
+            "default_hidden": _session_field(session, "default_hidden", False),
+        }
+    return not _hide_from_default_sidebar(row)
+
+
 # ── Profile-scoped session/project filtering (#1611, #1614) ────────────────
 #
 # Sessions and projects are stored in the WebUI sidecar without per-row
@@ -2730,6 +2749,7 @@ from api.models import (
     merge_session_messages_append_only,
     _session_message_merge_key,
     _is_empty_partial_activity_message,
+    _hide_from_default_sidebar,
     prune_session_from_index,
     ensure_cron_project,
     is_cron_session,
@@ -6509,7 +6529,7 @@ def handle_post(handler, parsed) -> bool:
             # so must run outside our own LOCK acquire below).
             persisted_pinned_ids = {
                 _session_field(existing, "session_id", None) for existing in all_sessions()
-                if _session_field(existing, "pinned", False) and not _session_field(existing, "archived", False)
+                if _session_counts_toward_pin_quota(existing)
             }
             with LOCK:
                 # Final authoritative count: merge persisted-pinned with the
@@ -6519,7 +6539,7 @@ def handle_post(handler, parsed) -> bool:
                 pinned_ids = set(persisted_pinned_ids)
                 pinned_ids.update(
                     sid for sid, existing in SESSIONS.items()
-                    if getattr(existing, "pinned", False) and not getattr(existing, "archived", False)
+                    if _session_counts_toward_pin_quota(existing)
                 )
                 pinned_ids.discard(body["session_id"])
                 pinned_sessions_limit = int(load_settings().get("pinned_sessions_limit", 3) or 3)

--- a/api/routes.py
+++ b/api/routes.py
@@ -2257,7 +2257,13 @@ def _messages_include_tool_metadata(messages) -> bool:
 
 
 def _tool_calls_for_message_window(tool_calls, start_idx: int, message_count: int) -> list:
-    """Keep session-level tool calls that point into a returned message window."""
+    """Keep session-level tool calls that point into a returned message window.
+
+    ``assistant_msg_idx`` is stored in the full transcript coordinate space, but
+    the frontend renders the returned ``messages`` array from index 0. Rebase the
+    index into the returned window so legacy session-level tool cards still
+    anchor to their visible assistant turn after paginated loads.
+    """
     if not isinstance(tool_calls, list) or message_count <= 0:
         return []
     end_idx = start_idx + message_count
@@ -2269,7 +2275,9 @@ def _tool_calls_for_message_window(tool_calls, start_idx: int, message_count: in
         if isinstance(assistant_idx, bool) or not isinstance(assistant_idx, int):
             continue
         if start_idx <= assistant_idx < end_idx:
-            filtered.append(tool_call)
+            rebased = dict(tool_call)
+            rebased["assistant_msg_idx"] = assistant_idx - start_idx
+            filtered.append(rebased)
     return filtered
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -7887,6 +7887,14 @@ def _session_media_token_allows_image_path(sid: str, target: Path, image_mimes: 
     return False
 
 
+def _path_is_within_root(child: Path, root: Path) -> bool:
+    """Return True when ``child`` is inside ``root`` without crashing on Windows drives."""
+    try:
+        return os.path.commonpath([str(child), str(root)]) == str(root)
+    except ValueError:
+        return False
+
+
 def _handle_media(handler, parsed):
     """Serve a local file by absolute path for inline display in the chat.
 
@@ -7963,7 +7971,7 @@ def _handle_media(handler, parsed):
         "image/x-icon", "image/bmp",
     }
     within_allowed = any(
-        _os.path.commonpath([str(target), str(root)]) == str(root)
+        _path_is_within_root(target, root)
         for root in allowed_roots
         if root.exists()
     )

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2286,8 +2286,10 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
             # pre-existing parent_session_id lineage.
             saved_sid = s.session_id
             saved_snapshot = bool(getattr(s, 'pre_compression_snapshot', False))
+            saved_pinned = bool(getattr(s, 'pinned', False))
             s.session_id = old_sid
             s.pre_compression_snapshot = True
+            s.pinned = False
             # Stage-359 / PR #2295: clear runtime stream-state fields on the
             # archived snapshot so the sidebar does not reopen the parent as
             # a permanently-running session while the child already holds the
@@ -2314,6 +2316,7 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
             finally:
                 s.session_id = saved_sid
                 s.pre_compression_snapshot = saved_snapshot
+                s.pinned = saved_pinned
                 s.active_stream_id = saved_active_stream_id
                 s.pending_user_message = saved_pending_user_message
                 s.pending_attachments = saved_pending_attachments
@@ -2326,6 +2329,7 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
         snapshot = Session.load(old_sid)
         if snapshot:
             snapshot.pre_compression_snapshot = True
+            snapshot.pinned = False
             # Stage-359 Opus SHOULD-FIX: clear runtime fields on the loaded
             # snapshot too. If the disk snapshot was last persisted while the
             # parent was live, it could carry a stale active_stream_id /

--- a/api/turn_journal.py
+++ b/api/turn_journal.py
@@ -94,14 +94,16 @@ def append_turn_journal_event(
             fh.write(line)
             fh.flush()
             os.fsync(fh.fileno())
-    try:
-        dir_fd = os.open(path.parent, os.O_DIRECTORY)
+    o_directory = getattr(os, "O_DIRECTORY", None)
+    if o_directory is not None:
         try:
-            os.fsync(dir_fd)
-        finally:
-            os.close(dir_fd)
-    except OSError:
-        pass
+            dir_fd = os.open(path.parent, o_directory)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass
     return payload
 
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1310,7 +1310,7 @@ let _messagesTruncated = false;
 // Older messages are loaded on-demand via _loadOlderMessages().
 const _INITIAL_MSG_LIMIT = 30;
 
-function _syncToolCallsForLoadedMessages(messages, sessionToolCalls, windowOffset=0){
+function _syncToolCallsForLoadedMessages(messages, sessionToolCalls){
   const msgs=Array.isArray(messages)?messages:[];
   const hasMessageToolMetadata=msgs.some(m=>{
     if(!m) return false;
@@ -1319,15 +1319,7 @@ function _syncToolCallsForLoadedMessages(messages, sessionToolCalls, windowOffse
     return hasTc||hasTu;
   });
   if(!hasMessageToolMetadata&&Array.isArray(sessionToolCalls)&&sessionToolCalls.length){
-    const offset=Number.isFinite(Number(windowOffset))?Number(windowOffset):0;
-    S.toolCalls=sessionToolCalls.map(tc=>{
-      const copy={...tc,done:true};
-      const idx=copy.assistant_msg_idx;
-      if(Number.isInteger(idx)&&idx>=offset&&idx<offset+msgs.length){
-        copy.assistant_msg_idx=idx-offset;
-      }
-      return copy;
-    });
+    S.toolCalls=sessionToolCalls.map(tc=>({...tc,done:true}));
   }else{
     S.toolCalls=[];
   }
@@ -1350,7 +1342,7 @@ async function _ensureMessagesLoaded(sid) {
   // toast on every mobile message (SSE/visibility events trigger this reload path
   // more aggressively on mobile).
   let msgs = (data.session.messages || []).filter(m => m && m.role);
-  _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls, data.session._messages_offset||0);
+  _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls);
   clearLiveToolCards();
   // #3018: preserve client-side ephemeral turn fields (_turnUsage, _turnDuration,
   // _turnTps, _gatewayRouting, _statusCard) across the loadSession replace.
@@ -1513,7 +1505,7 @@ async function _loadOlderMessages() {
     const container = $('messages');
     const prevScrollH = container ? container.scrollHeight : 0;
     S.messages = nextMessages;
-    _syncToolCallsForLoadedMessages(nextMessages, responseSession.tool_calls, responseSession._messages_offset||0);
+    _syncToolCallsForLoadedMessages(nextMessages, responseSession.tool_calls);
     // renderMessages() windows long transcripts from the end. If we do not
     // expand that window before rendering, the newly prepended page stays
     // hidden and the "hidden" counter rises while the viewport appears stuck.
@@ -1598,7 +1590,7 @@ async function _ensureAllMessagesLoaded() {
     S.messages = msgs;
     _messagesTruncated = false;
     _oldestIdx = 0;
-    _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls, data.session._messages_offset||0);
+    _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls);
     if (S.session && S.session.session_id === sid) {
       S.session.message_count = Number(data.session.message_count || msgs.length);
     }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -361,7 +361,9 @@ function _markSessionCompletedInList(session, previousSid = null) {
   if (!session || !Array.isArray(_allSessions)) return;
   const finalSid = session.session_id || previousSid;
   if (!finalSid) return;
-  const idx = _allSessions.findIndex(s => s && (s.session_id === finalSid || s.session_id === previousSid));
+  const finalIdx = _allSessions.findIndex(s => s && s.session_id === finalSid);
+  const previousIdx = previousSid ? _allSessions.findIndex(s => s && s.session_id === previousSid) : -1;
+  const idx = finalIdx >= 0 ? finalIdx : previousIdx;
   if (idx < 0) return;
   const {messages: _messages, tool_calls: _toolCalls, ...sessionMeta} = session;
   const messageCount = Number(
@@ -384,6 +386,11 @@ function _markSessionCompletedInList(session, previousSid = null) {
   _sessionStreamingById.set(finalSid, false);
   _forgetObservedStreamingSession(finalSid);
   if (previousSid && previousSid !== finalSid) {
+    for (let i = _allSessions.length - 1; i >= 0; i--) {
+      if (i !== idx && _allSessions[i] && _allSessions[i].session_id === previousSid) {
+        _allSessions.splice(i, 1);
+      }
+    }
     _sessionStreamingById.delete(previousSid);
     _forgetObservedStreamingSession(previousSid);
     _sessionListSnapshotById.delete(previousSid);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1310,6 +1310,29 @@ let _messagesTruncated = false;
 // Older messages are loaded on-demand via _loadOlderMessages().
 const _INITIAL_MSG_LIMIT = 30;
 
+function _syncToolCallsForLoadedMessages(messages, sessionToolCalls, windowOffset=0){
+  const msgs=Array.isArray(messages)?messages:[];
+  const hasMessageToolMetadata=msgs.some(m=>{
+    if(!m) return false;
+    const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
+    const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
+    return hasTc||hasTu;
+  });
+  if(!hasMessageToolMetadata&&Array.isArray(sessionToolCalls)&&sessionToolCalls.length){
+    const offset=Number.isFinite(Number(windowOffset))?Number(windowOffset):0;
+    S.toolCalls=sessionToolCalls.map(tc=>{
+      const copy={...tc,done:true};
+      const idx=copy.assistant_msg_idx;
+      if(Number.isInteger(idx)&&idx>=offset&&idx<offset+msgs.length){
+        copy.assistant_msg_idx=idx-offset;
+      }
+      return copy;
+    });
+  }else{
+    S.toolCalls=[];
+  }
+}
+
 async function _ensureMessagesLoaded(sid) {
   // Already have messages? (e.g. from INFLIGHT restore path, already set)
   if (S.messages && S.messages.length > 0 && S.messages[0] && S.messages[0].role) {
@@ -1327,17 +1350,7 @@ async function _ensureMessagesLoaded(sid) {
   // toast on every mobile message (SSE/visibility events trigger this reload path
   // more aggressively on mobile).
   let msgs = (data.session.messages || []).filter(m => m && m.role);
-  // Check for tool-call metadata on messages (for tool-call card rendering)
-  const hasMessageToolMetadata = msgs.some(m => {
-    const hasTc = Array.isArray(m.tool_calls) && m.tool_calls.length > 0;
-    const hasTu = Array.isArray(m.content) && m.content.some(p => p && p.type === 'tool_use');
-    return hasTc || hasTu;
-  });
-  if (!hasMessageToolMetadata && data.session.tool_calls && data.session.tool_calls.length) {
-    S.toolCalls = data.session.tool_calls.map(tc => ({...tc, done: true}));
-  } else {
-    S.toolCalls = [];
-  }
+  _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls, data.session._messages_offset||0);
   clearLiveToolCards();
   // #3018: preserve client-side ephemeral turn fields (_turnUsage, _turnDuration,
   // _turnTps, _gatewayRouting, _statusCard) across the loadSession replace.
@@ -1500,6 +1513,7 @@ async function _loadOlderMessages() {
     const container = $('messages');
     const prevScrollH = container ? container.scrollHeight : 0;
     S.messages = nextMessages;
+    _syncToolCallsForLoadedMessages(nextMessages, responseSession.tool_calls, responseSession._messages_offset||0);
     // renderMessages() windows long transcripts from the end. If we do not
     // expand that window before rendering, the newly prepended page stays
     // hidden and the "hidden" counter rises while the viewport appears stuck.
@@ -1584,6 +1598,7 @@ async function _ensureAllMessagesLoaded() {
     S.messages = msgs;
     _messagesTruncated = false;
     _oldestIdx = 0;
+    _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls, data.session._messages_offset||0);
     if (S.session && S.session.session_id === sid) {
       S.session.message_count = Number(data.session.message_count || msgs.length);
     }

--- a/static/style.css
+++ b/static/style.css
@@ -2624,12 +2624,12 @@ body.resizing .sidebar{transition:none!important;}
     display:none;
   }
 }
-.tool-card{background:var(--surface-subtle);border:1px solid var(--border-muted);border-left:3px solid var(--accent-bg-strong);border-radius:var(--radius-card);margin:2px 0;overflow:hidden;transition:border-color .15s,background-color .15s;}
+.tool-card{background:var(--surface-subtle);border:1px solid var(--border-muted);border-left:2px solid var(--border-muted);border-radius:var(--radius-card);margin:2px 0;overflow:hidden;transition:border-color .15s,background-color .15s;}
 .tool-card:hover{border-color:var(--border2);background:var(--surface-subtle-hover);}
 .tool-card-running{border-color:var(--accent-bg-strong);background:var(--accent-bg);}
 .tool-card-header{display:flex;align-items:center;gap:var(--space-2);padding:var(--space-1) var(--space-3);cursor:pointer;user-select:none;}
 .tool-card-icon{font-size:13px;flex-shrink:0;opacity:.65;}
-.tool-card-badge{flex-shrink:0;font-size:10px;line-height:1.2;text-transform:uppercase;letter-spacing:.045em;font-weight:700;color:var(--accent-text);background:var(--accent-bg);border:1px solid var(--accent-bg-strong);border-radius:999px;padding:1px 6px;}
+
 .tool-card-name{font-size:var(--font-size-xs);font-weight:600;color:var(--muted);font-family:'SF Mono',ui-monospace,monospace;flex-shrink:0;}
 .tool-card-preview{font-size:var(--font-size-xs);color:var(--muted);opacity:.62;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .tool-card-toggle{font-size:10px;color:var(--muted);opacity:.45;flex-shrink:0;display:inline-flex;align-items:center;justify-content:center;transform-origin:center;transition:transform .18s ease;will-change:transform;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -6987,7 +6987,6 @@ function buildToolCard(tc){
       <div class="tool-card-header" onclick="this.closest('.tool-card').classList.toggle('open')">
         ${runIndicator}
         <span class="tool-card-icon">${icon}</span>
-        <span class="tool-card-badge">Tool output</span>
         <span class="tool-card-name">${esc(displayName)}</span>
         <span class="tool-card-preview">${esc(previewText)}</span>
         ${hasDetail?`<span class="tool-card-toggle">${li('chevron-right',12)}</span>`:''}

--- a/tests/test_compression_snapshot_runtime_clear.py
+++ b/tests/test_compression_snapshot_runtime_clear.py
@@ -9,6 +9,7 @@ class FakeSession:
         self.session_id = "new_session"
         self.parent_session_id = "original_parent"
         self.pre_compression_snapshot = False
+        self.pinned = True
         self.active_stream_id = "live-stream"
         self.pending_user_message = "current prompt"
         self.pending_attachments = [{"name": "file.txt"}]
@@ -21,6 +22,7 @@ class FakeSession:
             "session_id": self.session_id,
             "parent_session_id": self.parent_session_id,
             "pre_compression_snapshot": self.pre_compression_snapshot,
+            "pinned": self.pinned,
             "active_stream_id": self.active_stream_id,
             "pending_user_message": self.pending_user_message,
             "pending_attachments": list(self.pending_attachments),
@@ -43,6 +45,7 @@ def test_preserve_pre_compression_snapshot_clears_runtime_fields_while_restoring
         "session_id": "old_session",
         "parent_session_id": "original_parent",
         "pre_compression_snapshot": True,
+        "pinned": False,
         "active_stream_id": None,
         "pending_user_message": None,
         "pending_attachments": [],
@@ -52,6 +55,7 @@ def test_preserve_pre_compression_snapshot_clears_runtime_fields_while_restoring
     }
     assert session.session_id == "new_session"
     assert session.pre_compression_snapshot is False
+    assert session.pinned is True
     assert session.active_stream_id == "live-stream"
     assert session.pending_user_message == "current prompt"
     assert session.pending_attachments == [{"name": "file.txt"}]
@@ -59,6 +63,7 @@ def test_preserve_pre_compression_snapshot_clears_runtime_fields_while_restoring
 
     saved = json.loads((tmp_path / "old_session.json").read_text(encoding="utf-8"))
     assert saved["pre_compression_snapshot"] is True
+    assert saved["pinned"] is False
     assert saved["active_stream_id"] is None
     assert saved["pending_user_message"] is None
     assert saved["pending_attachments"] == []
@@ -77,6 +82,7 @@ def test_preserve_pre_compression_snapshot_load_and_mark_branch_clears_runtime_f
             {"role": "user", "content": "newer prompt already on disk"},
         ],
         "pre_compression_snapshot": True,
+        "pinned": True,
         "active_stream_id": "stale-stream",
         "pending_user_message": "stale prompt",
         "pending_attachments": [{"name": "stale.txt"}],
@@ -91,6 +97,7 @@ def test_preserve_pre_compression_snapshot_load_and_mark_branch_clears_runtime_f
     saved = json.loads((tmp_path / "old_session.json").read_text(encoding="utf-8"))
     assert saved["messages"] == old_payload["messages"]
     assert saved["pre_compression_snapshot"] is True
+    assert saved["pinned"] is False
     assert saved["active_stream_id"] is None
     assert saved["pending_user_message"] is None
     assert saved["pending_attachments"] == []

--- a/tests/test_issue2508_session_pin_cap.py
+++ b/tests/test_issue2508_session_pin_cap.py
@@ -2,6 +2,7 @@
 
 import json
 import pathlib
+from types import SimpleNamespace
 import urllib.error
 import urllib.request
 
@@ -65,6 +66,35 @@ def test_session_pin_endpoint_caps_pinned_sessions_at_three():
     finally:
         for sid in created:
             post("/api/session/delete", {"session_id": sid})
+
+
+def test_hidden_pre_compression_snapshot_does_not_count_toward_pin_quota():
+    from api.routes import _session_counts_toward_pin_quota
+
+    assert _session_counts_toward_pin_quota({
+        "session_id": "hidden-snapshot",
+        "pinned": True,
+        "archived": False,
+        "pre_compression_snapshot": True,
+    }) is False
+    assert _session_counts_toward_pin_quota({
+        "session_id": "visible-session",
+        "pinned": True,
+        "archived": False,
+        "pre_compression_snapshot": False,
+    }) is True
+
+
+def test_hidden_in_memory_snapshot_does_not_count_toward_pin_quota():
+    from api.routes import _session_counts_toward_pin_quota
+
+    snapshot = SimpleNamespace(
+        session_id="hidden-memory-snapshot",
+        pinned=True,
+        archived=False,
+        pre_compression_snapshot=True,
+    )
+    assert _session_counts_toward_pin_quota(snapshot) is False
 
 
 def test_session_pin_cap_has_backend_and_frontend_guards():

--- a/tests/test_issue2508_session_pin_cap.py
+++ b/tests/test_issue2508_session_pin_cap.py
@@ -2,11 +2,12 @@
 
 import json
 import pathlib
+import time
 from types import SimpleNamespace
 import urllib.error
 import urllib.request
 
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE, TEST_STATE_DIR
 
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
@@ -42,6 +43,41 @@ def make_session(created):
     return sid
 
 
+
+def inject_hidden_pinned_snapshot(sid="hidden-pinned-snapshot"):
+    """Add a persisted legacy hidden snapshot without touching server memory."""
+    sessions_dir = TEST_STATE_DIR / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    row = {
+        "session_id": sid,
+        "title": "Hidden pinned snapshot",
+        "workspace": str(TEST_STATE_DIR / "test-workspace"),
+        "model": "test/pin-cap",
+        "created_at": now,
+        "updated_at": now,
+        "last_message_at": now,
+        "message_count": 1,
+        "messages": [{"role": "user", "content": "legacy hidden snapshot"}],
+        "tool_calls": [],
+        "pinned": True,
+        "archived": False,
+        "pre_compression_snapshot": True,
+        "_show_pre_compression_snapshot": False,
+    }
+    (sessions_dir / f"{sid}.json").write_text(json.dumps(row), encoding="utf-8")
+    index_path = sessions_dir / "_index.json"
+    try:
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        index = []
+    compact = {k: v for k, v in row.items() if k not in {"messages", "tool_calls"}}
+    index = [item for item in index if item.get("session_id") != sid]
+    index.append(compact)
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+    return sid
+
+
 def test_session_pin_endpoint_caps_pinned_sessions_at_three():
     created = []
     try:
@@ -66,6 +102,35 @@ def test_session_pin_endpoint_caps_pinned_sessions_at_three():
     finally:
         for sid in created:
             post("/api/session/delete", {"session_id": sid})
+
+
+def test_session_pin_endpoint_ignores_hidden_snapshot_when_enforcing_cap():
+    created = []
+    hidden_sid = "hidden-pinned-snapshot-quota-route"
+    try:
+        hidden = inject_hidden_pinned_snapshot(hidden_sid)
+        pinned = [make_session(created) for _ in range(2)]
+        for sid in pinned:
+            d, status = post("/api/session/pin", {"session_id": sid, "pinned": True})
+            assert status == 200
+            assert d["session"]["pinned"] is True
+
+        third_visible = make_session(created)
+        d, status = post("/api/session/pin", {"session_id": third_visible, "pinned": True})
+        assert status == 200, d
+        assert d["session"]["pinned"] is True
+        assert hidden not in {third_visible, *pinned}
+    finally:
+        for sid in created:
+            post("/api/session/delete", {"session_id": sid})
+        (TEST_STATE_DIR / "sessions" / f"{hidden_sid}.json").unlink(missing_ok=True)
+        index_path = TEST_STATE_DIR / "sessions" / "_index.json"
+        try:
+            index = json.loads(index_path.read_text(encoding="utf-8"))
+            index = [item for item in index if item.get("session_id") != hidden_sid]
+            index_path.write_text(json.dumps(index), encoding="utf-8")
+        except (FileNotFoundError, json.JSONDecodeError):
+            pass
 
 
 def test_hidden_pre_compression_snapshot_does_not_count_toward_pin_quota():

--- a/tests/test_issue2821_session_pin_state_sync.py
+++ b/tests/test_issue2821_session_pin_state_sync.py
@@ -41,9 +41,10 @@ def test_session_field_helper_reads_dicts_and_objects():
 
 
 def test_pin_limit_snapshot_counts_index_dict_entries():
+    assert "def _session_counts_toward_pin_quota(session)" in ROUTES_PY
     assert "_session_field(existing, \"session_id\", None)" in ROUTES_PY
-    assert "_session_field(existing, \"pinned\", False)" in ROUTES_PY
-    assert "_session_field(existing, \"archived\", False)" in ROUTES_PY
+    assert "_session_counts_toward_pin_quota(existing)" in ROUTES_PY
+    assert "_hide_from_default_sidebar(row)" in ROUTES_PY
     start = ROUTES_PY.find("persisted_pinned_ids = {")
     assert start != -1, "persisted pin snapshot not found"
     end = ROUTES_PY.find("with LOCK:", start)

--- a/tests/test_issue2867_tool_output_visual_distinction.py
+++ b/tests/test_issue2867_tool_output_visual_distinction.py
@@ -5,29 +5,23 @@ UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
 
 
-def test_tool_cards_render_persistent_tool_output_badge():
-    """Tool output must remain distinguishable without relying on hover state."""
+def test_tool_cards_use_legacy_compact_header_without_tool_output_badge():
+    """Tool cards keep the legacy compact header: icon, tool name, preview."""
     build_start = UI_JS.index('function buildToolCard(tc){')
     build_end = UI_JS.index('function _syncToolCallGroupSummary', build_start)
     build_tool_card = UI_JS[build_start:build_end]
 
-    assert '<span class="tool-card-badge">Tool output</span>' in build_tool_card
+    assert 'tool-card-badge' not in build_tool_card
+    assert 'Tool output' not in build_tool_card
     assert '<span class="tool-card-name">${esc(displayName)}</span>' in build_tool_card
-    assert build_tool_card.index('class="tool-card-badge"') < build_tool_card.index('class="tool-card-name"')
 
 
-def test_tool_card_badge_style_is_not_hover_only():
-    badge_rule_start = STYLE_CSS.index('.tool-card-badge{')
-    badge_rule_end = STYLE_CSS.index('}', badge_rule_start)
-    badge_rule = STYLE_CSS[badge_rule_start:badge_rule_end]
-
+def test_tool_card_badge_style_is_absent():
+    assert '.tool-card-badge{' not in STYLE_CSS
     assert '.tool-card:hover .tool-card-badge' not in STYLE_CSS
-    assert 'text-transform:uppercase' in badge_rule
-    assert 'background:var(--accent-bg)' in badge_rule
-    assert 'border:1px solid var(--accent-bg-strong)' in badge_rule
-    assert 'color:var(--accent-text)' in badge_rule
 
 
-def test_tool_cards_have_persistent_accent_rail():
+def test_tool_cards_use_legacy_muted_rail():
     assert '.tool-card{background:var(--surface-subtle);' in STYLE_CSS
-    assert 'border-left:3px solid var(--accent-bg-strong)' in STYLE_CSS
+    assert 'border-left:2px solid var(--border-muted)' in STYLE_CSS
+    assert 'border-left:3px solid var(--accent-bg-strong)' not in STYLE_CSS

--- a/tests/test_issue401.py
+++ b/tests/test_issue401.py
@@ -28,10 +28,10 @@ def test_loadsession_preserves_tool_rows():
 
 def test_loadsession_uses_session_toolcalls_only_as_fallback():
     """Session summaries are the fallback, not the primary reload source."""
-    assert ("if(!hasMessageToolMetadata&&data.session.tool_calls&&data.session.tool_calls.length)" in SESSIONS_JS or
-            "if (!hasMessageToolMetadata && data.session.tool_calls && data.session.tool_calls.length)" in SESSIONS_JS)
-    assert ("S.toolCalls=(data.session.tool_calls||[]).map(tc=>({...tc,done:true}));" in SESSIONS_JS or
-            "S.toolCalls = data.session.tool_calls.map(tc => ({...tc, done: true}));" in SESSIONS_JS)
+    assert "function _syncToolCallsForLoadedMessages(messages, sessionToolCalls, windowOffset=0)" in SESSIONS_JS
+    assert "if(!hasMessageToolMetadata&&Array.isArray(sessionToolCalls)&&sessionToolCalls.length)" in SESSIONS_JS
+    assert "const offset=Number.isFinite(Number(windowOffset))?Number(windowOffset):0;" in SESSIONS_JS
+    assert "copy.assistant_msg_idx=idx-offset;" in SESSIONS_JS
     assert "S.toolCalls=[];" in SESSIONS_JS
 
 

--- a/tests/test_issue401.py
+++ b/tests/test_issue401.py
@@ -28,10 +28,10 @@ def test_loadsession_preserves_tool_rows():
 
 def test_loadsession_uses_session_toolcalls_only_as_fallback():
     """Session summaries are the fallback, not the primary reload source."""
-    assert "function _syncToolCallsForLoadedMessages(messages, sessionToolCalls, windowOffset=0)" in SESSIONS_JS
+    assert "function _syncToolCallsForLoadedMessages(messages, sessionToolCalls)" in SESSIONS_JS
     assert "if(!hasMessageToolMetadata&&Array.isArray(sessionToolCalls)&&sessionToolCalls.length)" in SESSIONS_JS
-    assert "const offset=Number.isFinite(Number(windowOffset))?Number(windowOffset):0;" in SESSIONS_JS
-    assert "copy.assistant_msg_idx=idx-offset;" in SESSIONS_JS
+    assert "windowOffset" not in SESSIONS_JS
+    assert "copy.assistant_msg_idx=idx-offset;" not in SESSIONS_JS
     assert "S.toolCalls=[];" in SESSIONS_JS
 
 
@@ -114,3 +114,27 @@ def test_reload_uses_session_summary_when_messages_have_no_tool_metadata():
     assert result["has_metadata"] is False
     assert result["fallback_len"] == 1
     assert result["done_flag"] is True
+
+
+def test_rebased_legacy_toolcalls_stay_distinct_in_paged_window():
+    """Backend-rebased legacy tool calls must not be rebased a second time."""
+    result = _run_js("""
+        const messages = [
+            { role: 'assistant', content: 'first legacy page row' },
+            { role: 'assistant', content: 'second legacy page row' }
+        ];
+        const sessionToolCalls = [
+            { name: 'first_tool', assistant_msg_idx: 0, snippet: 'first' },
+            { name: 'second_tool', assistant_msg_idx: 1, snippet: 'second' }
+        ];
+        const loaded = loadSessionShape(messages, sessionToolCalls);
+        const renderedRawIdxs = messages.map((_, idx) => idx);
+        process.stdout.write(JSON.stringify({
+            indices: loaded.toolCalls.map(tc => tc.assistant_msg_idx),
+            distinct_indices: new Set(loaded.toolCalls.map(tc => tc.assistant_msg_idx)).size,
+            anchors_visible: loaded.toolCalls.every(tc => renderedRawIdxs.includes(tc.assistant_msg_idx))
+        }));
+    """)
+    assert result["indices"] == [0, 1]
+    assert result["distinct_indices"] == 2
+    assert result["anchors_visible"] is True

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -100,7 +100,9 @@ def test_sidebar_cache_completion_handles_compression_session_rotation():
 
     assert "function _markSessionCompletedInList(session, previousSid = null)" in helper_block
     assert "const finalSid = session.session_id || previousSid;" in helper_block
-    assert "s.session_id === finalSid || s.session_id === previousSid" in helper_block
+    assert "const finalIdx = _allSessions.findIndex(s => s && s.session_id === finalSid);" in helper_block
+    assert "const previousIdx = previousSid ? _allSessions.findIndex(s => s && s.session_id === previousSid) : -1;" in helper_block
+    assert "const idx = finalIdx >= 0 ? finalIdx : previousIdx;" in helper_block
     assert "const {messages: _messages, tool_calls: _toolCalls, ...sessionMeta} = session;" in helper_block
     assert "...sessionMeta" in helper_block
     assert "session_id: finalSid" in helper_block

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -255,6 +255,32 @@ class TestMediaEndpointUnit(unittest.TestCase):
         self.assertIn(".split(_os.pathsep)", block)
         self.assertNotIn('.split(":")', block)
 
+    def test_path_is_within_root_treats_commonpath_valueerror_as_not_within(self):
+        """Windows cross-drive commonpath() errors must not crash /api/media."""
+        from api import routes
+
+        with mock.patch.object(
+            routes.os.path,
+            "commonpath",
+            side_effect=ValueError("Paths don't have the same drive"),
+        ):
+            self.assertFalse(
+                routes._path_is_within_root(
+                    pathlib.Path("D:/outputs/card.png"),
+                    pathlib.Path("C:/Users/agent/.hermes"),
+                )
+            )
+
+    def test_path_is_within_root_accepts_child_path(self):
+        from api import routes
+
+        with tempfile.TemporaryDirectory() as tmpd:
+            root = pathlib.Path(tmpd).resolve()
+            child = root / "media" / "card.png"
+            child.parent.mkdir()
+            child.write_bytes(b"png")
+            self.assertTrue(routes._path_is_within_root(child.resolve(), root))
+
     def test_media_endpoints_advertise_byte_range_support(self):
         routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
         self.assertIn("Accept-Ranges", routes_src)

--- a/tests/test_session_tail_payload.py
+++ b/tests/test_session_tail_payload.py
@@ -117,11 +117,12 @@ def test_msg_before_window_keeps_only_that_page_session_tool_calls():
     session = _FakeSession([
         {"role": "user", "content": "first"},
         {"role": "assistant", "content": "second legacy message"},
-        {"role": "user", "content": "third"},
+        {"role": "assistant", "content": "third legacy message"},
         {"role": "assistant", "content": "fourth legacy message"},
     ])
     session.tool_calls = [
         {"name": "first-page-tool", "snippet": "kept", "assistant_msg_idx": 1},
+        {"name": "second-page-tool", "snippet": "also kept", "assistant_msg_idx": 2},
         {"name": "tail-tool", "snippet": "not in page", "assistant_msg_idx": 3},
         {"name": "unindexed-tool", "snippet": "cannot place"},
     ]
@@ -133,7 +134,9 @@ def test_msg_before_window_keeps_only_that_page_session_tool_calls():
 
     assert payload["messages"] == session.messages[1:3]
     assert payload["tool_calls"] == [
-        {"name": "first-page-tool", "snippet": "kept", "assistant_msg_idx": 0}
+        {"name": "first-page-tool", "snippet": "kept", "assistant_msg_idx": 0},
+        {"name": "second-page-tool", "snippet": "also kept", "assistant_msg_idx": 1},
     ]
     assert session.tool_calls[0]["assistant_msg_idx"] == 1
+    assert session.tool_calls[1]["assistant_msg_idx"] == 2
     assert payload["_messages_offset"] == 1

--- a/tests/test_session_tail_payload.py
+++ b/tests/test_session_tail_payload.py
@@ -92,7 +92,10 @@ def test_tail_window_keeps_only_visible_session_tool_calls_for_legacy_messages_w
     payload = _invoke(session)
 
     assert payload["messages"] == [session.messages[-1]]
-    assert payload["tool_calls"] == [session.tool_calls[-1]]
+    assert payload["tool_calls"] == [
+        {"name": "visible-tool", "snippet": "visible snippet", "assistant_msg_idx": 0}
+    ]
+    assert session.tool_calls[-1]["assistant_msg_idx"] == 1
 
 
 def test_full_load_keeps_all_session_tool_calls_for_legacy_messages_without_metadata():
@@ -129,5 +132,8 @@ def test_msg_before_window_keeps_only_that_page_session_tool_calls():
     )
 
     assert payload["messages"] == session.messages[1:3]
-    assert payload["tool_calls"] == [session.tool_calls[0]]
+    assert payload["tool_calls"] == [
+        {"name": "first-page-tool", "snippet": "kept", "assistant_msg_idx": 0}
+    ]
+    assert session.tool_calls[0]["assistant_msg_idx"] == 1
     assert payload["_messages_offset"] == 1

--- a/tests/test_sidebar_completion_dedupe.py
+++ b/tests/test_sidebar_completion_dedupe.py
@@ -1,0 +1,51 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _extract_js_function(src: str, name: str) -> str:
+    start = src.index(f"function {name}(")
+    brace = src.index("{", start)
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : idx + 1]
+    raise AssertionError(f"could not extract {name}")
+
+
+def test_mark_session_completed_in_list_dedupes_old_and_new_sid_rows():
+    sessions_src = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+    fn_src = _extract_js_function(sessions_src, "_markSessionCompletedInList")
+    script = f"""
+let _allSessions = [
+  {{ session_id: 'old', title: 'Before', message_count: 10, pre_compression_snapshot: true }},
+  {{ session_id: 'new', title: 'After', message_count: 2, parent_session_id: 'old' }},
+];
+let _sessionStreamingById = new Map([['old', true], ['new', true]]);
+let _sessionListSnapshotById = new Map([['old', {{message_count: 10}}]]);
+function _forgetObservedStreamingSession(_sid) {{}}
+function renderSessionListFromCache() {{}}
+{fn_src}
+_markSessionCompletedInList({{
+  session_id: 'new',
+  title: 'After done',
+  message_count: 3,
+  parent_session_id: 'old',
+}}, 'old');
+console.log(JSON.stringify({{rows: _allSessions, oldStreaming: _sessionStreamingById.has('old')}}));
+"""
+    result = subprocess.run(["node", "-e", script], check=True, text=True, capture_output=True)
+    payload = json.loads(result.stdout)
+
+    assert [row["session_id"] for row in payload["rows"]] == ["new"]
+    assert payload["rows"][0]["title"] == "After done"
+    assert payload["rows"][0]["message_count"] == 3
+    assert payload["oldStreaming"] is False

--- a/tests/test_tool_call_history_paging.py
+++ b/tests/test_tool_call_history_paging.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def test_sessions_js_resyncs_tool_calls_after_history_window_replacement():
+    """History paging replaces S.messages with a larger window.
+
+    Legacy sessions keep tool card data in session.tool_calls, so that side data
+    must be refreshed alongside the message window. Otherwise renderMessages()
+    can keep stale anchors and show unloaded/thinking placeholders while the
+    user scrolls through history.
+    """
+    assert "function _syncToolCallsForLoadedMessages(messages, sessionToolCalls, windowOffset=0)" in SESSIONS_JS
+    assert "_syncToolCallsForLoadedMessages(msgs, data.session.tool_calls, data.session._messages_offset||0);" in SESSIONS_JS
+    assert "S.messages = nextMessages;\n    _syncToolCallsForLoadedMessages(nextMessages, responseSession.tool_calls, responseSession._messages_offset||0);" in SESSIONS_JS
+    assert "S.messages = msgs;\n    _messagesTruncated = false;\n    _oldestIdx = 0;\n    _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls, data.session._messages_offset||0);" in SESSIONS_JS
+
+
+def test_sessions_js_clears_session_tool_calls_when_messages_have_own_metadata():
+    assert "const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;" in SESSIONS_JS
+    assert "const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');" in SESSIONS_JS
+    assert "const offset=Number.isFinite(Number(windowOffset))?Number(windowOffset):0;" in SESSIONS_JS
+    assert "const copy={...tc,done:true};" in SESSIONS_JS
+    assert "S.toolCalls=[];" in SESSIONS_JS

--- a/tests/test_tool_call_history_paging.py
+++ b/tests/test_tool_call_history_paging.py
@@ -13,15 +13,16 @@ def test_sessions_js_resyncs_tool_calls_after_history_window_replacement():
     can keep stale anchors and show unloaded/thinking placeholders while the
     user scrolls through history.
     """
-    assert "function _syncToolCallsForLoadedMessages(messages, sessionToolCalls, windowOffset=0)" in SESSIONS_JS
-    assert "_syncToolCallsForLoadedMessages(msgs, data.session.tool_calls, data.session._messages_offset||0);" in SESSIONS_JS
-    assert "S.messages = nextMessages;\n    _syncToolCallsForLoadedMessages(nextMessages, responseSession.tool_calls, responseSession._messages_offset||0);" in SESSIONS_JS
-    assert "S.messages = msgs;\n    _messagesTruncated = false;\n    _oldestIdx = 0;\n    _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls, data.session._messages_offset||0);" in SESSIONS_JS
+    assert "function _syncToolCallsForLoadedMessages(messages, sessionToolCalls)" in SESSIONS_JS
+    assert "_syncToolCallsForLoadedMessages(msgs, data.session.tool_calls);" in SESSIONS_JS
+    assert "S.messages = nextMessages;\n    _syncToolCallsForLoadedMessages(nextMessages, responseSession.tool_calls);" in SESSIONS_JS
+    assert "S.messages = msgs;\n    _messagesTruncated = false;\n    _oldestIdx = 0;\n    _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls);" in SESSIONS_JS
 
 
 def test_sessions_js_clears_session_tool_calls_when_messages_have_own_metadata():
     assert "const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;" in SESSIONS_JS
     assert "const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');" in SESSIONS_JS
-    assert "const offset=Number.isFinite(Number(windowOffset))?Number(windowOffset):0;" in SESSIONS_JS
-    assert "const copy={...tc,done:true};" in SESSIONS_JS
+    assert "windowOffset" not in SESSIONS_JS
+    assert "copy.assistant_msg_idx=idx-offset;" not in SESSIONS_JS
+    assert "S.toolCalls=sessionToolCalls.map(tc=>({...tc,done:true}));" in SESSIONS_JS
     assert "S.toolCalls=[];" in SESSIONS_JS

--- a/tests/test_turn_journal_lifecycle.py
+++ b/tests/test_turn_journal_lifecycle.py
@@ -1,3 +1,5 @@
+import os
+
 from api.turn_journal import (
     append_turn_journal_event,
     append_turn_journal_event_for_stream,
@@ -36,3 +38,16 @@ def test_append_turn_journal_event_for_stream_falls_back_to_new_turn_for_missing
     assert event["stream_id"] == "stream-missing"
     assert event["turn_id"]
     assert event["event"] == "interrupted"
+
+
+def test_append_turn_journal_event_skips_directory_fsync_without_o_directory(tmp_path, monkeypatch):
+    monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
+
+    event = append_turn_journal_event(
+        "sid-windows",
+        {"event": "submitted", "content": "hello"},
+        session_dir=tmp_path,
+    )
+
+    assert event["event"] == "submitted"
+    assert (tmp_path / "_turn_journal" / "sid-windows.jsonl").is_file()


### PR DESCRIPTION
## Release stage-batch55 → v0.51.173 (Release ES)

Batch of 5 PRs from @ai-ag2026 (trusted contributor). 4 stale-base fixes rebased onto fresh master + 1 maintainer-approved UX revert.

| PR | Summary |
|----|---------|
| #3180 | Windows path/journal safety — guard `os.O_DIRECTORY` (getattr) + wrap cross-drive `commonpath()` in try/except (#3170, #3171) |
| #3184 | Hidden pre-compression snapshots no longer hold stale pin state or consume the visible pinned-session quota (#3181) |
| #3187 | Tool-call cards stay anchored when paging back through history; session-level indices rebased to the returned window (#3120) |
| #3192 | Dedupe sidebar rows when a compressed session completes with both snapshot + continuation ids present |
| #3178 | **Maintainer-approved UX revert:** remove the persistent "Tool output" badge added in v0.51.171 (#2867) and restore the quieter legacy tool-card chrome (muted rail). Nathan confirmed he prefers the calmer treatment. |

### Verification
- **Pre-Opus gate:** `node -c`, ESLint runtime gate, `ast.parse`, merge markers, CHANGELOG placeholder — all clean.
- **Full pytest suite (sequential, `-p no:xdist`):** 6930 passed, 11 skipped, 0 failed.
- **Opus advisor review:** SHIP all five, no must-fixes, no nits. The #3184 `_preserve_pre_compression_snapshot` pinned-flag save/restore (scrutinized hardest, sensitive path) confirmed balanced + exception-safe. #3187 index-rebasing boundary algebra verified correct + test-pinned. #3192 splice loop confirmed reverse-iterating splice-safe.

Supersedes #3186 (partial JS-only fix for the same #3120 bug).

Co-authored-by trailers preserved.
