### PR TITLE
fix(#3195): prevent stale session data overwrite during streaming completion

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1807,6 +1807,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('done',e=>{
       if(_streamFinalized) return;
+      // Set _streamFinalized IMMEDIATELY — before any fade delay. Without this,
+      // a stream_end event arriving during the fade window sees
+      // _streamFinalized=false, calls _restoreSettledSession(), and overwrites
+      // S.messages with stale server data (issue #3195).
+      _streamFinalized=true;
       _terminalStateReached=true;
       if(_persistTimer){clearTimeout(_persistTimer);_persistTimer=null;}
       const _doneData=JSON.parse(e.data);

--- a/static/ui.js
+++ b/static/ui.js
@@ -6270,6 +6270,7 @@ function renderMessages(options){
       if(typeof loadTodos==='function'&&document.getElementById('panelTodos')&&document.getElementById('panelTodos').classList.contains('active')){loadTodos();}
       return;
     }
+  } else {
   }
 
   const compressionState=_compressionStateForCurrentSession();


### PR DESCRIPTION
## Problem

When a streaming session completes while the user has switched to a different session tab, intermediate assistant text messages are lost upon switching back. Tool-call blocks are preserved, but the assistant text between them disappears.

## Root Cause

The SSE `done` and `stream_end` events arrive in sequence. The `done` handler defers its finalization (`_finishDone`) behind `_drainStreamFadeBeforeDone()` for fade animation. During the fade window:

1. `done` sets `_terminalStateReached = true` but `_streamFinalized` remains `false` (it's set inside the deferred `_finishDone`)
2. `stream_end` arrives, sees `_streamFinalized === false`, and calls `_restoreSettledSession()`
3. `_restoreSettledSession()` fetches the session from the server, which may have stale/partial data
4. It overwrites `S.messages` with the stale server data
5. A subsequent `refreshActiveSessionIfExternallyUpdated` force-reload cements the stale data

## Fix

Set `_streamFinalized = true` immediately at the top of the `done` handler, before the fade delay. This ensures the `stream_end` handler's guard check (`if(_streamFinalized) return`) prevents `_restoreSettledSession()` from overwriting `S.messages` with stale data.

## Testing

Reproduced the bug by:
1. Starting a multi-round tool chain in session A
2. Switching to session B while streaming
3. Waiting for the stream to complete
4. Switching back to session A

Before fix: assistant text messages were lost (server returned ~30 messages instead of ~254).
After fix: all messages are preserved correctly.
