### PR TITLE
fix(reasoning): expose effort levels for bare/dot-separated model names on custom providers

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2131,6 +2131,32 @@ def _heuristic_reasoning_efforts(model_id: str, provider_id: str) -> list[str]:
     )
     if any(model.startswith(prefix) for prefix in prefixes):
         return list(VALID_REASONING_EFFORTS)
+    # Custom API aggregators (e.g. New API, One API) use non-standard model naming:
+    # bare names like "deepseek-v4-flash" or dot-separated "moonshotai.kimi-k2.5"
+    # rather than the OpenRouter-style "vendor/model" that the prefix list targets.
+    # Strip a dot-vendor prefix (e.g. "moonshotai.kimi-k2.5" → "kimi-k2.5") and
+    # check both the original bare name and the stripped suffix.
+    bare_after_dot = bare.split(".", 1)[-1] if "." in bare else bare
+    thinking_bare_prefixes = (
+        "deepseek-v4",
+        "deepseek-r1",
+        "deepseek-r2",
+        "kimi-k2",
+        "kimi-thinking",
+        "qwen3",
+        "claude-3",
+        "claude-4",
+        "o1-",
+        "o3-",
+        "o4-",
+    )
+    if any(
+        bare.startswith(p) or bare_after_dot.startswith(p)
+        for p in thinking_bare_prefixes
+    ):
+        return list(VALID_REASONING_EFFORTS)
+    if "thinking" in bare or "reasoning" in bare:
+        return list(VALID_REASONING_EFFORTS)
     return []
 
 

--- a/tests/test_custom_provider_bare_model_reasoning.py
+++ b/tests/test_custom_provider_bare_model_reasoning.py
@@ -1,0 +1,109 @@
+"""Regression tests: custom providers with non-slash model names expose reasoning efforts.
+
+Custom API aggregators (e.g. New API, One API) route requests using their own
+naming conventions — bare names like ``deepseek-v4-flash`` or dot-separated
+names like ``moonshotai.kimi-k2.5`` — rather than the OpenRouter-style
+``vendor/model`` slash format that the heuristic prefix list was written for.
+
+Before this fix, ``resolve_model_reasoning_efforts`` always returned ``[]`` for
+these combinations, hiding the reasoning effort selector in the UI even though
+the underlying models fully support thinking/reasoning.
+"""
+
+import api.config as cfg
+
+
+# ── bare model names (no slash or dot prefix) ────────────────────────────────
+
+def test_deepseek_v4_flash_bare_name_custom_provider():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "deepseek-v4-flash",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}, (
+        "deepseek-v4-flash via custom provider should expose reasoning efforts"
+    )
+
+
+def test_deepseek_r1_bare_name_custom_provider():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "deepseek-r1",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}
+
+
+# ── dot-separated model names (vendor.model) ─────────────────────────────────
+
+def test_kimi_dot_separated_custom_provider():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "moonshotai.kimi-k2.5",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}, (
+        "moonshotai.kimi-k2.5 via custom provider should expose reasoning efforts"
+    )
+
+
+def test_qwen3_dot_separated_custom_provider():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "qwen.qwen3-vl-235b-a22b-instruct",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}
+
+
+# ── "thinking" keyword in model name ─────────────────────────────────────────
+
+def test_thinking_keyword_in_model_name_custom_provider():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "vendor.some-model-thinking-preview",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}, (
+        "model name containing 'thinking' should always expose reasoning efforts"
+    )
+
+
+def test_reasoning_keyword_in_model_name_custom_provider():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "vendor.model-reasoning-v1",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}
+
+
+# ── non-reasoning models must stay hidden ─────────────────────────────────────
+
+def test_plain_llm_bare_name_custom_provider_no_reasoning():
+    assert cfg.resolve_model_reasoning_efforts(
+        "llama-3.1-8b-instruct",
+        provider_id="custom:newapi",
+    ) == [], (
+        "generic llama model via custom provider should NOT expose reasoning efforts"
+    )
+
+
+def test_plain_llm_dot_separated_custom_provider_no_reasoning():
+    assert cfg.resolve_model_reasoning_efforts(
+        "meta.llama-3.1-70b",
+        provider_id="custom:newapi",
+    ) == []
+
+
+# ── slash-prefixed names must still work (no regression) ─────────────────────
+
+def test_deepseek_slash_prefix_still_works():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "deepseek/deepseek-v4-flash",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}
+
+
+def test_openrouter_slash_prefix_unaffected():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "anthropic/claude-sonnet-4.5",
+        provider_id="openrouter",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}


### PR DESCRIPTION
## Problem

Custom API aggregators such as **New API** and **One API** route requests using their own model naming conventions:

- Bare names: `deepseek-v4-flash`, `deepseek-r1`
- Dot-separated: `moonshotai.kimi-k2.5`, `qwen.qwen3-vl-235b-a22b-instruct`

`_heuristic_reasoning_efforts` only recognises the OpenRouter-style `vendor/model` slash format (e.g. `deepseek/`, `anthropic/`). None of these custom names matched, so the function returned `[]` — hiding the reasoning effort selector in the WebUI even though the underlying models fully support thinking/reasoning.

The models.dev path (`_models_dev_reasoning_efforts`) also returns `None` for `custom:*` providers since they have no entry in the models.dev database, so the bug persists even after the `74fe79dd` metadata refactor.

## Fix

Add a secondary fallback block at the end of `_heuristic_reasoning_efforts` that:

1. Strips an optional dot-vendor prefix (`moonshotai.kimi-k2.5` → `kimi-k2.5`)
2. Matches the bare model name against known thinking-capable prefixes: `deepseek-v4`, `deepseek-r1`, `deepseek-r2`, `kimi-k2`, `kimi-thinking`, `qwen3`, `claude-3`, `claude-4`, `o1-`, `o3-`, `o4-`
3. Falls back to a keyword match for model names containing `thinking` or `reasoning`

All existing provider-specific fast paths (copilot, lmstudio, models.dev metadata, slash-prefix heuristic) are unchanged. The new block runs only as a final fallback when everything else returns no result.

## Tests

New file: `tests/test_custom_provider_bare_model_reasoning.py` (10 cases)

- `deepseek-v4-flash` + `custom:newapi` → full effort list ✓
- `deepseek-r1` + `custom:newapi` → full effort list ✓
- `moonshotai.kimi-k2.5` + `custom:newapi` → full effort list ✓
- `qwen.qwen3-vl-235b-a22b-instruct` + `custom:newapi` → full effort list ✓
- model name containing `thinking` → full effort list ✓
- model name containing `reasoning` → full effort list ✓
- `llama-3.1-8b-instruct` + `custom:newapi` → `[]` (no false positives) ✓
- `meta.llama-3.1-70b` + `custom:newapi` → `[]` ✓
- `deepseek/deepseek-v4-flash` slash form still works (no regression) ✓
- `anthropic/claude-sonnet-4.5` via openrouter unaffected ✓

All 26 reasoning-related tests pass.