### PR TITLE
Release stage-batch59 → v0.51.177 (Docker smoke-test layer caching, #3197 docker half)

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -66,10 +66,31 @@ jobs:
             echo "::endgroup::"
           done
 
+  # Build the Docker image once and cache layers via GHA cache.
+  # The smoke matrix jobs then pull from this cache instead of rebuilding
+  # from scratch, saving ~1-3 minutes per variant.
+  build-image:
+    name: Build Docker image (cache layers)
+    runs-on: ubuntu-latest
+    needs: compose-config
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build and cache Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ghcr.io/nesquena/hermes-webui:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   smoke:
     name: Smoke ${{ matrix.variant }}
     runs-on: ubuntu-latest
-    needs: compose-config
+    needs: [compose-config, build-image]
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -80,6 +101,19 @@ jobs:
           - three-container
     steps:
       - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      # Restore the cached Docker image from the build-image job.
+      # Read-only: the build-image job already populated the GHA cache, so the
+      # smoke variants only need cache-from (no redundant cache-to re-export).
+      - name: Restore Docker image from cache
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ghcr.io/nesquena/hermes-webui:latest
+          cache-from: type=gha
 
       - name: Resolve compose file + project name
         id: vars
@@ -118,15 +152,6 @@ jobs:
           for n in $(docker network ls --format '{{.Name}}' | grep "^hermes-smoke-" || true); do
             docker network rm "$n" || true
           done
-
-      - name: Build local Dockerfile
-        # We always build the local Dockerfile so the PR's changes are tested,
-        # even on the multi-container variants whose compose files reference
-        # ghcr.io/nesquena/hermes-webui:latest. Without this retag, multi-container
-        # smoke runs would test the previous release, not the PR.
-        run: |
-          set -euo pipefail
-          docker build -t ghcr.io/nesquena/hermes-webui:latest .
 
       - name: Prepare ephemeral host paths
         id: paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.177] — 2026-05-30 — Release EW (stage-batch59 — Docker smoke-test layer caching)
+
+### Changed
+
+- CI: the Docker smoke-test workflow now builds the image once and caches its layers via the GitHub Actions cache (`type=gha`), then each compose variant restores from that cache instead of rebuilding from scratch — saving ~1-3 minutes per variant. The image is still built from the PR's local Dockerfile (`load: true`), so PR changes are tested, not the released image. (Partial adoption of #3197 — the Docker half; the test-sharding half is deferred pending test-suite shard-safety work.)
+
 ## [v0.51.176] — 2026-05-30 — Release EV (stage-batch58 — sidebar attention indicators)
 
 ### Added


### PR DESCRIPTION
## Release stage-batch59 → v0.51.177 (Release EW)

Partial adoption of @hayriodabas's #3197 — **the Docker-cache half only**.

### What's included
- `docker-smoke.yml`: build the image once in a new `build-image` job, cache layers via GitHub Actions cache (`type=gha`), each compose variant restores from that cache instead of rebuilding. ~1-3 min saved per variant.
- Maintainer tweak: the variant restore step uses `cache-from` only (dropped the redundant `cache-to` re-export — only `build-image` writes the cache).

### What's deferred (and why)
The **test-sharding half of #3197 is NOT included.** I tested it empirically: the partition is clean (6903 tests, no loss/overlap) and the ~66% speedup is real, BUT our test suite has order-dependent tests (`test_onboarding_status_defaults_incomplete`, `test_title_aux_routing`, `test_ctl_script`) that pass in the full sequential run but fail when sharded — they rely on shared module-level/server state. Shipping sharding onto an order-dependent suite would make CI flaky. That half is deferred pending dedicated test-suite shard-safety work (tracked separately).

### Verification
- YAML validity confirmed.
- Cache topology correct: 1 writer (`build-image` cache-to), 2 readers (cache-from).
- Image still built from the PR's local Dockerfile (`load: true`) — PR changes are tested, not the released `ghcr.io` image (preserves the existing anti-trap).
- Security: `type=gha` is GitHub's first-party per-repo-scoped cache — no external registry, no credential/supply-chain surface.
- **This PR's own docker-smoke CI run validates the cache flow end-to-end before merge.**

Co-authored-by: hayriodabas preserved.
