### PR TITLE
Release stage-batch61 → v0.51.179 (custom-provider reasoning efforts #3202 + clearer sidebar tooltips #3203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Fixed
 
 - Reasoning effort selector now appears for thinking-capable models served through custom API aggregators (New API, One API, etc.) that use non-standard model naming — bare names like `deepseek-v4-flash` or dot-separated `moonshotai.kimi-k2.5` rather than the OpenRouter-style `vendor/model` slash format. The heuristic now also strips a dot-vendor prefix and recognizes a `thinking`/`reasoning` token anywhere in the model name; plain non-reasoning models stay hidden as before (#3202).
-- Sidebar session row tooltips now explain the fork, prior-turn, child-session, and running/unread status badges, and hovering a truncated chat title shows the full title instead of the old "Double-click to rename" hint (#3203). The localized pending-approval/clarify attention tooltip retains precedence over the generic running/unread state tooltip on the status dot.
+- Sidebar session row tooltips now explain the fork, prior-turn, child-session, and running/unread status badges, and hovering a truncated chat title shows the full title instead of the old "Double-click to rename" hint (#3203). The localized pending-approval/clarify attention tooltip retains precedence over the generic running/unread state tooltip on the status dot, and the fork tooltip keeps its localized "Forked from" base.
 
 ## [v0.51.178] — 2026-05-30 — Release EX (stage-batch60 — parallel sharded CI test runs)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Fixed
 
 - Reasoning effort selector now appears for thinking-capable models served through custom API aggregators (New API, One API, etc.) that use non-standard model naming — bare names like `deepseek-v4-flash` or dot-separated `moonshotai.kimi-k2.5` rather than the OpenRouter-style `vendor/model` slash format. The heuristic now also strips a dot-vendor prefix and recognizes a `thinking`/`reasoning` token anywhere in the model name; plain non-reasoning models stay hidden as before (#3202).
-- Sidebar session row tooltips now explain the fork, prior-turn, child-session, and running/unread status badges, and hovering a truncated chat title shows the full title instead of the old "Double-click to rename" hint (#3203).
+- Sidebar session row tooltips now explain the fork, prior-turn, child-session, and running/unread status badges, and hovering a truncated chat title shows the full title instead of the old "Double-click to rename" hint (#3203). The localized pending-approval/clarify attention tooltip retains precedence over the generic running/unread state tooltip on the status dot.
 
 ## [v0.51.178] — 2026-05-30 — Release EX (stage-batch60 — parallel sharded CI test runs)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Sidebar session row tooltips now explain fork, prior-turn, child-session, and status badges, and hovering the truncated chat title now shows the full title instead of the old rename hint.
+
 ## [v0.51.173] — 2026-05-30 — Release ES (stage-batch55 — Windows path/journal safety + pin-quota snapshot fix + tool-card paging anchor + sidebar dedupe + quieter tool cards)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -2131,6 +2131,32 @@ def _heuristic_reasoning_efforts(model_id: str, provider_id: str) -> list[str]:
     )
     if any(model.startswith(prefix) for prefix in prefixes):
         return list(VALID_REASONING_EFFORTS)
+    # Custom API aggregators (e.g. New API, One API) use non-standard model naming:
+    # bare names like "deepseek-v4-flash" or dot-separated "moonshotai.kimi-k2.5"
+    # rather than the OpenRouter-style "vendor/model" that the prefix list targets.
+    # Strip a dot-vendor prefix (e.g. "moonshotai.kimi-k2.5" → "kimi-k2.5") and
+    # check both the original bare name and the stripped suffix.
+    bare_after_dot = bare.split(".", 1)[-1] if "." in bare else bare
+    thinking_bare_prefixes = (
+        "deepseek-v4",
+        "deepseek-r1",
+        "deepseek-r2",
+        "kimi-k2",
+        "kimi-thinking",
+        "qwen3",
+        "claude-3",
+        "claude-4",
+        "o1-",
+        "o3-",
+        "o4-",
+    )
+    if any(
+        bare.startswith(p) or bare_after_dot.startswith(p)
+        for p in thinking_bare_prefixes
+    ):
+        return list(VALID_REASONING_EFFORTS)
+    if "thinking" in bare or "reasoning" in bare:
+        return list(VALID_REASONING_EFFORTS)
     return []
 
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3348,7 +3348,11 @@ function _sessionFullTitleTooltip(rawTitle, cleanTitle){
 
 function _sessionForkTooltip(parentLabel){
   const parent=String(parentLabel||'').trim()||'unknown parent';
-  return `Forked conversation — parent: ${parent}`;
+  // Preserve the localized "Forked from" base (the catalog key exists in all
+  // locales) rather than hardcoding English — the only regression risk in the
+  // tooltip rework was dropping t('forked_from') here.
+  const prefix=(typeof t==='function'?t('forked_from'):'Forked from');
+  return `${prefix}: ${parent}`;
 }
 
 function _sessionLineageBadgeTooltip(label, canExpand){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4345,9 +4345,15 @@ function renderSessionListFromCache(){
     const state=document.createElement('span');
     const attentionDotClass=attention?(attention.kind==='approval'?' is-attention-approval':(attention.kind==='clarify'?' is-attention-clarify':' is-attention-generic')):'';
     state.className='session-attention-indicator session-state-indicator'+(isStreaming?' is-streaming':(hasUnread?' is-unread':''))+attentionDotClass;
-    if(attention&&attention.title) state.title=attention.title;
     state.setAttribute('aria-hidden','true');
-    state.title=_sessionStateTooltip({isStreaming,hasUnread});
+    // Tooltip precedence: a localized attention title (pending approval/clarify,
+    // from the attention-indicator feature) is more specific and actionable than
+    // the generic running/unread state tooltip, so it wins. Fall back to the state
+    // tooltip only when there is no attention title AND the state tooltip is
+    // non-empty — never blank an otherwise-meaningful tooltip.
+    const _stateTip=_sessionStateTooltip({isStreaming,hasUnread});
+    if(attention&&attention.title) state.title=attention.title;
+    else if(_stateTip) state.title=_stateTip;
     el.appendChild(state);
     // Single trigger button that opens a shared dropdown menu
     let actions=null;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3145,6 +3145,36 @@ function _sessionTitleForForkParent(parentSid){
   return title;
 }
 
+function _sessionFullTitleTooltip(rawTitle, cleanTitle){
+  const fallback=String(cleanTitle||'Untitled').trim()||'Untitled';
+  const full=String(rawTitle||fallback).trim()||fallback;
+  if(full.startsWith('[SYSTEM:')) return fallback;
+  return full;
+}
+
+function _sessionForkTooltip(parentLabel){
+  const parent=String(parentLabel||'').trim()||'unknown parent';
+  return `Forked conversation — parent: ${parent}`;
+}
+
+function _sessionLineageBadgeTooltip(label, canExpand){
+  const base=String(label||'Prior turns').trim()||'Prior turns';
+  return canExpand
+    ? `${base} — earlier context turns are collapsed here. Click to show or hide them.`
+    : `${base} — earlier context turns are collapsed here.`;
+}
+
+function _sessionChildBadgeTooltip(label){
+  const base=String(label||'Child sessions').trim()||'Child sessions';
+  return `${base} — child conversations spawned from this session. Click to show or hide them.`;
+}
+
+function _sessionStateTooltip({isStreaming=false,hasUnread=false}={}){
+  if(isStreaming) return 'Conversation is running';
+  if(hasUnread) return 'Unread completion';
+  return '';
+}
+
 function _attachChildSessionsToSidebarRows(collapsedRows, rawSessions){
   const rows=(collapsedRows||[]).filter(s=>!_isChildSession(s)).map(s=>({...s}));
   const visibleBySid=new Map();
@@ -3843,7 +3873,7 @@ function renderSessionListFromCache(){
       branchInd.className='session-branch-indicator';
       branchInd.innerHTML=li('git-branch',12);
       const parentLabel=_sessionTitleForForkParent(s.parent_session_id)||_truncatedSessionId(s.parent_session_id);
-      branchInd.title=(typeof t==='function'?t('forked_from'):'Forked from')+' '+parentLabel;
+      branchInd.title=_sessionForkTooltip(parentLabel);
       titleRow.appendChild(branchInd);
     }
     const title=document.createElement('span');
@@ -3852,7 +3882,7 @@ function renderSessionListFromCache(){
     const titleMatched=Boolean(searchQueryRaw&&displayTitle.toLowerCase().includes(searchQueryRaw.toLowerCase()));
     if(titleMatched) _appendHighlightedText(title,displayTitle,searchQueryRaw,'session-search-hit');
     else title.textContent=displayTitle;
-    title.title=readOnly?'Read-only imported session':'Double-click to rename';
+    title.title=_sessionFullTitleTooltip(rawTitle,cleanTitle);
     const tsMs=_sessionTimestampMs(s);
     const ts=document.createElement('span');
     const hasAttentionState=isStreaming||hasUnread;
@@ -3888,7 +3918,7 @@ function renderSessionListFromCache(){
       segmentCountEl.className='session-lineage-count'+(canExpandLineageSegments?' expandable':'');
       const segmentLabel=t('session_meta_segments', segmentCount);
       segmentCountEl.textContent=segmentLabel;
-      segmentCountEl.title=segmentLabel;
+      segmentCountEl.title=_sessionLineageBadgeTooltip(segmentLabel,canExpandLineageSegments);
       if(canExpandLineageSegments){
         segmentCountEl.setAttribute('role','button');
         segmentCountEl.setAttribute('tabindex','0');
@@ -3917,7 +3947,7 @@ function renderSessionListFromCache(){
       childCountEl.className='session-child-count';
       const childLabel=t('session_meta_children', childCount);
       childCountEl.textContent=childLabel;
-      childCountEl.title=childLabel;
+      childCountEl.title=_sessionChildBadgeTooltip(childLabel);
       ['pointerdown','pointerup','click'].forEach(ev=>childCountEl.addEventListener(ev,e=>e.stopPropagation()));
       childCountEl.onclick=(e)=>{
         e.stopPropagation();
@@ -4104,6 +4134,7 @@ function renderSessionListFromCache(){
     const state=document.createElement('span');
     state.className='session-attention-indicator session-state-indicator'+(isStreaming?' is-streaming':(hasUnread?' is-unread':''));
     state.setAttribute('aria-hidden','true');
+    state.title=_sessionStateTooltip({isStreaming,hasUnread});
     el.appendChild(state);
     // Single trigger button that opens a shared dropdown menu
     let actions=null;

--- a/tests/test_custom_provider_bare_model_reasoning.py
+++ b/tests/test_custom_provider_bare_model_reasoning.py
@@ -1,0 +1,109 @@
+"""Regression tests: custom providers with non-slash model names expose reasoning efforts.
+
+Custom API aggregators (e.g. New API, One API) route requests using their own
+naming conventions — bare names like ``deepseek-v4-flash`` or dot-separated
+names like ``moonshotai.kimi-k2.5`` — rather than the OpenRouter-style
+``vendor/model`` slash format that the heuristic prefix list was written for.
+
+Before this fix, ``resolve_model_reasoning_efforts`` always returned ``[]`` for
+these combinations, hiding the reasoning effort selector in the UI even though
+the underlying models fully support thinking/reasoning.
+"""
+
+import api.config as cfg
+
+
+# ── bare model names (no slash or dot prefix) ────────────────────────────────
+
+def test_deepseek_v4_flash_bare_name_custom_provider():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "deepseek-v4-flash",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}, (
+        "deepseek-v4-flash via custom provider should expose reasoning efforts"
+    )
+
+
+def test_deepseek_r1_bare_name_custom_provider():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "deepseek-r1",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}
+
+
+# ── dot-separated model names (vendor.model) ─────────────────────────────────
+
+def test_kimi_dot_separated_custom_provider():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "moonshotai.kimi-k2.5",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}, (
+        "moonshotai.kimi-k2.5 via custom provider should expose reasoning efforts"
+    )
+
+
+def test_qwen3_dot_separated_custom_provider():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "qwen.qwen3-vl-235b-a22b-instruct",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}
+
+
+# ── "thinking" keyword in model name ─────────────────────────────────────────
+
+def test_thinking_keyword_in_model_name_custom_provider():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "vendor.some-model-thinking-preview",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}, (
+        "model name containing 'thinking' should always expose reasoning efforts"
+    )
+
+
+def test_reasoning_keyword_in_model_name_custom_provider():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "vendor.model-reasoning-v1",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}
+
+
+# ── non-reasoning models must stay hidden ─────────────────────────────────────
+
+def test_plain_llm_bare_name_custom_provider_no_reasoning():
+    assert cfg.resolve_model_reasoning_efforts(
+        "llama-3.1-8b-instruct",
+        provider_id="custom:newapi",
+    ) == [], (
+        "generic llama model via custom provider should NOT expose reasoning efforts"
+    )
+
+
+def test_plain_llm_dot_separated_custom_provider_no_reasoning():
+    assert cfg.resolve_model_reasoning_efforts(
+        "meta.llama-3.1-70b",
+        provider_id="custom:newapi",
+    ) == []
+
+
+# ── slash-prefixed names must still work (no regression) ─────────────────────
+
+def test_deepseek_slash_prefix_still_works():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "deepseek/deepseek-v4-flash",
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}
+
+
+def test_openrouter_slash_prefix_unaffected():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "anthropic/claude-sonnet-4.5",
+        provider_id="openrouter",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}

--- a/tests/test_sidebar_tooltips.py
+++ b/tests/test_sidebar_tooltips.py
@@ -1,0 +1,34 @@
+"""Sidebar tooltip contract tests."""
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+SESSIONS_JS_PATH = REPO_ROOT / "static" / "sessions.js"
+
+
+def _sessions_js() -> str:
+    return SESSIONS_JS_PATH.read_text(encoding="utf-8")
+
+
+def test_session_title_hover_shows_full_title_not_rename_hint():
+    """The truncated sidebar title needs a real full-title tooltip.
+
+    The old "Double-click to rename" title hid the only native hover affordance
+    that can reveal a long chat title when badges/tags squeeze the row.
+    """
+    js = _sessions_js()
+    assert "Double-click to rename" not in js
+    assert "title.title=_sessionFullTitleTooltip(rawTitle,cleanTitle);" in js
+
+
+def test_sidebar_status_badges_have_explanatory_tooltips():
+    """Compact badges/icons must explain what they mean, not repeat the chip text."""
+    js = _sessions_js()
+    assert "function _sessionFullTitleTooltip" in js
+    assert "function _sessionForkTooltip" in js
+    assert "function _sessionLineageBadgeTooltip" in js
+    assert "function _sessionChildBadgeTooltip" in js
+    assert "function _sessionStateTooltip" in js
+    assert "branchInd.title=_sessionForkTooltip(parentLabel);" in js
+    assert "segmentCountEl.title=_sessionLineageBadgeTooltip(segmentLabel,canExpandLineageSegments);" in js
+    assert "childCountEl.title=_sessionChildBadgeTooltip(childLabel);" in js
+    assert "state.title=_sessionStateTooltip({isStreaming,hasUnread});" in js

--- a/tests/test_sidebar_tooltips.py
+++ b/tests/test_sidebar_tooltips.py
@@ -54,3 +54,16 @@ def test_state_tooltip_does_not_clobber_attention_title():
     assert "else if(_stateTip) state.title=_stateTip;" in js
     # The old unconditional-clobber line must be gone.
     assert "state.title=_sessionStateTooltip({isStreaming,hasUnread});" not in js
+
+
+def test_fork_tooltip_preserves_localized_base():
+    """The fork tooltip must keep using the localized ``forked_from`` catalog
+    key rather than hardcoding an English string — dropping ``t('forked_from')``
+    was the one genuine i18n regression in the tooltip rework.
+    """
+    js = _sessions_js()
+    assert "function _sessionForkTooltip" in js
+    # Helper resolves the localized key with the usual typeof-t guard.
+    assert "t('forked_from')" in js
+    # The hardcoded English sentence from the first cut must be gone.
+    assert "Forked conversation — parent:" not in js

--- a/tests/test_sidebar_tooltips.py
+++ b/tests/test_sidebar_tooltips.py
@@ -31,4 +31,26 @@ def test_sidebar_status_badges_have_explanatory_tooltips():
     assert "branchInd.title=_sessionForkTooltip(parentLabel);" in js
     assert "segmentCountEl.title=_sessionLineageBadgeTooltip(segmentLabel,canExpandLineageSegments);" in js
     assert "childCountEl.title=_sessionChildBadgeTooltip(childLabel);" in js
-    assert "state.title=_sessionStateTooltip({isStreaming,hasUnread});" in js
+    assert "_sessionStateTooltip({isStreaming,hasUnread})" in js
+
+
+def test_state_tooltip_does_not_clobber_attention_title():
+    """The generic running/unread state tooltip must NOT overwrite a more
+    specific, localized attention tooltip (pending approval/clarify).
+
+    Regression: the first cut of this feature set ``state.title`` to the
+    state tooltip *unconditionally*, two lines after assigning the localized
+    ``attention.title`` — which both clobbered the attention tooltip and, for a
+    needs-attention session that was not currently streaming, blanked it to ''
+    (``_sessionStateTooltip`` returns '' when neither streaming nor unread).
+    The attention title must take precedence, and the state tooltip must only
+    apply when it is non-empty.
+    """
+    js = _sessions_js()
+    # The attention title still wins.
+    assert "if(attention&&attention.title) state.title=attention.title;" in js
+    # The state tooltip is applied via an else-if guarded on non-empty, never
+    # as an unconditional assignment that could blank the attention title.
+    assert "else if(_stateTip) state.title=_stateTip;" in js
+    # The old unconditional-clobber line must be gone.
+    assert "state.title=_sessionStateTooltip({isStreaming,hasUnread});" not in js


### PR DESCRIPTION
Release stage-batch61 → v0.51.179 (Release EY)

Two low-risk contributor PRs, batched.

## #3202 — reasoning effort for custom-provider bare/dot model names (@Carry00)
Extends `_heuristic_reasoning_efforts` so thinking-capable models served via custom API aggregators (New API, One API) that use non-slash naming (bare `deepseek-v4-flash`, dot-separated `moonshotai.kimi-k2.5`) expose the reasoning-effort selector. Strips a dot-vendor prefix and recognizes a `thinking`/`reasoning` token; plain non-reasoning models stay hidden. 109-line regression test exercises the public entry with positives, negatives, and slash-prefix preservation. Opus advisor: SHIP (no MUST/SHOULD-FIX); slash-prefix path runs first and is regression-tested.

## #3203 — clearer sidebar session tooltips (@ai-ag2026)
Adds explanatory tooltips for fork / prior-turn / child-session / status badges and shows the full chat title on hover instead of the old "Double-click to rename" hint.

**Two regressions caught (Opus advisor + agent) and fixed in stamp commits:**
- **MUST-FIX (attention tooltip clobber):** the original hunk set `state.title` unconditionally two lines after assigning the localized `attention.title`, blanking the "Waiting for permission decision / your answer" hover for any approval/clarify-pending session not currently streaming. Fixed: attention title takes precedence; state tooltip applies only when non-empty. Regression test added.
- **SHOULD-FIX (i18n):** the fork tooltip dropped `t('forked_from')` for a hardcoded English string. Restored the localized base. Regression test added.

Deferred to follow-up: new lineage/child explanatory suffixes (additive English, need locale keys) + read-only title hint (still surfaced by the existing meta chip).

## Verification
- Full sequential suite: **6974 passed, 7 skipped, 3 xpassed, 0 failed** (`pytest -p no:xdist`).
- Pre-Opus gate: `node -c` + ESLint runtime gate (CLEAN) + `ast.parse` + no merge markers + `[Unreleased]` resolves clean.
- Opus advisor independent review: PR #3202 SHIP; PR #3203 SHIP after the clobber fix (which is included).

🤖 Co-authored per-PR attribution preserved in commit trailers.
