### PR TITLE
Release stage-batch62 → v0.51.180 (session/agent cache ownership hardening — #3191 + #3166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Guard session and agent caches against compression/continuation id drift so a stale cached object cannot make `/api/session?session_id=<tip>` return an older transcript segment.
+
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 
 ### Added

--- a/api/models.py
+++ b/api/models.py
@@ -2200,6 +2200,22 @@ def get_session(sid, metadata_only=False):
         if cached is not None:
             SESSIONS.move_to_end(sid)  # LRU: mark as recently used
     if cached is not None:
+        # Defensive cache ownership check: compression/continuation and recovery
+        # paths can temporarily juggle Session objects across lineage ids.  A
+        # stale object stored under the wrong key makes GET /api/session return
+        # a different transcript than the requested sid, which looks exactly
+        # like a disappeared session.  Evict instead of trusting the LRU.
+        if str(getattr(cached, 'session_id', '') or '') != str(sid):
+            logger.warning(
+                "evicting mismatched cached session: requested %s but cached object is %s",
+                sid,
+                getattr(cached, 'session_id', None),
+            )
+            with LOCK:
+                if SESSIONS.get(sid) is cached:
+                    SESSIONS.pop(sid, None)
+            cached = None
+    if cached is not None:
         if not metadata_only and _inactive_cache_tail_needs_disk_check(cached):
             try:
                 disk_session = Session.load(sid)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3609,6 +3609,69 @@ def _agent_cache_api_key_sig(resolved_api_key, credential_pool) -> str:
     return _hashlib.sha256((resolved_api_key or '').encode()).hexdigest()[:16]
 
 
+def _lifecycle_commit_session_memory(session_id: str, *, agent=None, wait: bool = False) -> bool:
+    from api.session_lifecycle import commit_session_memory
+
+    return commit_session_memory(session_id, agent=agent, wait=wait)
+
+
+def _lifecycle_has_uncommitted_work(session_id: str) -> bool:
+    from api.session_lifecycle import has_uncommitted_work
+
+    return has_uncommitted_work(session_id)
+
+
+def _lifecycle_unregister_agent(session_id: str) -> None:
+    from api.session_lifecycle import unregister_agent
+
+    unregister_agent(session_id)
+
+
+def _close_evicted_agent_at_session_boundary(session_id: str, agent) -> bool:
+    """Commit and tear down an evicted cached agent at a WebUI session boundary.
+
+    WebUI keeps AIAgent instances in an LRU cache so memory providers can carry
+    state across turns. When an agent is evicted, commit pending memory first;
+    if the lifecycle entry is clean afterwards, unregister and call
+    shutdown_memory_provider(messages) so provider-owned clients such as
+    Hindsight's aiohttp session are closed instead of being garbage-collected
+    later. Passing the cached transcript mirrors gateway cleanup semantics for
+    providers that use on_session_end(messages) during shutdown.
+    """
+    if agent is None:
+        return True
+
+    should_close_evicted_agent = True
+    try:
+        _lifecycle_commit_session_memory(session_id, agent=agent, wait=True)
+        if not _lifecycle_has_uncommitted_work(session_id):
+            _lifecycle_unregister_agent(session_id)
+        else:
+            should_close_evicted_agent = False
+    except Exception:
+        should_close_evicted_agent = False
+        logger.debug("Lifecycle commit on eviction failed for %s", session_id, exc_info=True)
+
+    if not should_close_evicted_agent:
+        return False
+
+    try:
+        shutdown_memory_provider = getattr(agent, 'shutdown_memory_provider', None)
+        if callable(shutdown_memory_provider):
+            session_messages = vars(agent).get('_session_messages', [])
+            shutdown_memory_provider(session_messages)
+    except Exception:
+        logger.debug("Failed to shut down evicted agent memory provider for session %s", session_id, exc_info=True)
+
+    try:
+        session_db = getattr(agent, '_session_db', None)
+        if session_db is not None:
+            session_db.close()
+    except Exception:
+        logger.debug("Failed to close evicted agent session DB for session %s", session_id, exc_info=True)
+    return True
+
+
 def _refresh_cached_agent_runtime(agent, agent_kwargs: dict) -> bool:
     """Refresh volatile runtime credentials on a reused cached AIAgent.
 
@@ -4880,24 +4943,7 @@ def _run_agent_streaming(
                     for _evicted_sid, _evicted_entry in _evicted_items:
                         try:
                             _evicted_agent = _evicted_entry[0] if isinstance(_evicted_entry, tuple) else None
-                            _should_close_evicted_agent = True
-                            if _evicted_agent is not None:
-                                try:
-                                    from api.session_lifecycle import (
-                                        commit_session_memory as _lifecycle_commit,
-                                        has_uncommitted_work as _lifecycle_has_uncommitted_work,
-                                        unregister_agent as _lifecycle_unregister_agent,
-                                    )
-                                    _lifecycle_commit(_evicted_sid, agent=_evicted_agent, wait=True)
-                                    if not _lifecycle_has_uncommitted_work(_evicted_sid):
-                                        _lifecycle_unregister_agent(_evicted_sid)
-                                    else:
-                                        _should_close_evicted_agent = False
-                                except Exception:
-                                    _should_close_evicted_agent = False
-                                    logger.debug("Lifecycle commit on eviction failed for %s", _evicted_sid, exc_info=True)
-                            if _should_close_evicted_agent and _evicted_agent is not None and getattr(_evicted_agent, '_session_db', None) is not None:
-                                _evicted_agent._session_db.close()
+                            _close_evicted_agent_at_session_boundary(_evicted_sid, _evicted_agent)
                         except Exception:
                             logger.debug("Failed to close evicted agent for session %s", _evicted_sid, exc_info=True)
                         logger.debug('[webui] Evicted LRU agent from cache: %s', _evicted_sid)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -28,7 +28,7 @@ from api.config import (
     STREAM_REASONING_TEXT, STREAM_LIVE_TOOL_CALLS,
     STREAM_GOAL_RELATED, PENDING_GOAL_CONTINUATION,
     STREAM_LAST_EVENT_ID,
-    LOCK, SESSIONS, SESSION_DIR,
+    LOCK, SESSIONS, SESSIONS_MAX, SESSION_DIR,
     _get_session_agent_lock, _set_thread_env, _clear_thread_env,
     register_active_run, update_active_run, unregister_active_run,
     SESSION_AGENT_LOCKS, SESSION_AGENT_LOCKS_LOCK,
@@ -2163,7 +2163,9 @@ def _run_background_title_update(session_id: str, user_text: str, assistant_text
         if next_title:
             with _get_session_agent_lock(session_id):
                 with LOCK:
-                    s = SESSIONS.get(session_id, s)
+                    cached_session = SESSIONS.get(session_id)
+                    if cached_session is not None and getattr(cached_session, 'session_id', None) == session_id:
+                        s = cached_session
                     effective_title = str(s.title or '').strip()
                     invalid_existing_now = _looks_invalid_generated_title(s.title)
                     still_auto = (
@@ -2238,7 +2240,9 @@ def _run_background_title_refresh(session_id: str, user_text: str, assistant_tex
             return
         with _get_session_agent_lock(session_id):
             with LOCK:
-                s = SESSIONS.get(session_id, s)
+                cached_session = SESSIONS.get(session_id)
+                if cached_session is not None and getattr(cached_session, 'session_id', None) == session_id:
+                    s = cached_session
                 # Re-check: user may have renamed while we were generating
                 if str(s.title or '').strip() != current_title:
                     _put_title_status(put_event, session_id, 'skipped', 'manual_title', str(s.title or '').strip())
@@ -3685,6 +3689,33 @@ def _refresh_cached_agent_runtime(agent, agent_kwargs: dict) -> bool:
         return False
 
 
+def _cached_agent_session_identity(agent) -> str | None:
+    """Best-effort session id carried by a cached AIAgent.
+
+    The cache key is only safe when it agrees with the object's own session
+    identity. Some old/fake agents may not expose an identity; keep those
+    backwards-compatible and treat them as unverifiable rather than mismatched.
+    """
+    if agent is None:
+        return None
+    for attr in ('session_id', '_session_id'):
+        value = getattr(agent, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    session_db = getattr(agent, '_session_db', None)
+    if session_db is not None:
+        for attr in ('session_id', '_session_id'):
+            value = getattr(session_db, attr, None)
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
+def _cached_agent_matches_session(agent, session_id: str) -> bool:
+    identity = _cached_agent_session_identity(agent)
+    return identity is None or identity == str(session_id)
+
+
 def _refresh_cached_agent_primary_runtime_snapshot(agent) -> None:
     """Keep AIAgent's primary-runtime snapshot aligned with refreshed creds.
 
@@ -4792,9 +4823,19 @@ def _run_agent_streaming(
                 with SESSION_AGENT_CACHE_LOCK:
                     _cached = SESSION_AGENT_CACHE.get(session_id)
                     if _cached and _cached[1] == _agent_sig:
-                        agent = _cached[0]
-                        SESSION_AGENT_CACHE.move_to_end(session_id)  # LRU: mark as recently used
-                        logger.debug('[webui] Reusing cached agent for session %s', session_id)
+                        _cached_agent = _cached[0]
+                        if _cached_agent_matches_session(_cached_agent, session_id):
+                            agent = _cached_agent
+                            SESSION_AGENT_CACHE.move_to_end(session_id)  # LRU: mark as recently used
+                            logger.debug('[webui] Reusing cached agent for session %s', session_id)
+                        else:
+                            SESSION_AGENT_CACHE.pop(session_id, None)
+                            logger.warning(
+                                '[webui] Evicted cached agent with mismatched session identity: cache_key=%s agent_session_id=%s',
+                                session_id,
+                                _cached_agent_session_identity(_cached_agent),
+                            )
+                    if agent is not None:
                         # Reopened/cache-hit sessions must register the agent
                         # so later lifecycle commits can find it.
                         try:
@@ -5448,8 +5489,22 @@ def _run_agent_streaming(
                     # parent, losing access to the recoverable history in old_sid.json.
                     s.parent_session_id = old_sid
                     with LOCK:
-                        if old_sid in SESSIONS:
-                            SESSIONS[new_sid] = SESSIONS.pop(old_sid)
+                        cached_old_session = SESSIONS.pop(old_sid, None)
+                        if cached_old_session is not None and cached_old_session is not s:
+                            cached_old_sid = str(getattr(cached_old_session, 'session_id', '') or '')
+                            if cached_old_sid == str(old_sid):
+                                SESSIONS[old_sid] = cached_old_session
+                            else:
+                                logger.warning(
+                                    "compression cache migration skipped stale object: old_sid=%s new_sid=%s cached_session_id=%s",
+                                    old_sid,
+                                    new_sid,
+                                    cached_old_sid or None,
+                                )
+                        SESSIONS[new_sid] = s
+                        SESSIONS.move_to_end(new_sid)
+                        while len(SESSIONS) > SESSIONS_MAX:
+                            SESSIONS.popitem(last=False)
                     # Migrate the per-session lock: alias new_sid to the held
                     # _agent_lock reference directly (not via old_sid lookup),
                     # then remove the old_sid entry to prevent a leak.
@@ -5462,7 +5517,16 @@ def _run_agent_streaming(
                     with SESSION_AGENT_CACHE_LOCK:
                         _cached_entry = SESSION_AGENT_CACHE.pop(old_sid, None)
                         if _cached_entry:
-                            SESSION_AGENT_CACHE[new_sid] = _cached_entry
+                            _cached_agent = _cached_entry[0]
+                            if _cached_agent_matches_session(_cached_agent, new_sid):
+                                SESSION_AGENT_CACHE[new_sid] = _cached_entry
+                            else:
+                                logger.warning(
+                                    '[webui] Skipped cached agent migration with mismatched session identity: old_sid=%s new_sid=%s agent_session_id=%s',
+                                    old_sid,
+                                    new_sid,
+                                    _cached_agent_session_identity(_cached_agent),
+                                )
                     _compressed = True
                 # Also detect compression via the result dict or compressor state
                 if not _compressed:
@@ -6338,6 +6402,16 @@ def _handle_chat_steer(handler, body: dict) -> bool:
 
     with _cfg.SESSION_AGENT_CACHE_LOCK:
         cached = _cfg.SESSION_AGENT_CACHE.get(sid)
+        if cached:
+            agent = cached[0]
+            if not _cached_agent_matches_session(agent, sid):
+                _cfg.SESSION_AGENT_CACHE.pop(sid, None)
+                logger.warning(
+                    '[webui] Evicted cached agent before steer due to mismatched session identity: cache_key=%s agent_session_id=%s',
+                    sid,
+                    _cached_agent_session_identity(agent),
+                )
+                cached = None
     if not cached:
         # No active agent for this session — caller falls back to interrupt
         return j(handler, {"accepted": False, "fallback": "no_cached_agent",

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -465,14 +465,17 @@ class TestIssue765FollowupHardening:
         )
         fn_idx = src.find("def _run_background_title_update(")
         assert fn_idx != -1, "_run_background_title_update not found"
-        fn_block = src[fn_idx:fn_idx + 3200]
+        fn_block = src[fn_idx:fn_idx + 4200]
         assert "with LOCK:" in fn_block, (
             "_run_background_title_update must acquire LOCK before rebinding "
             "to canonical cached session instance"
         )
-        assert "s = SESSIONS.get(session_id, s)" in fn_block, (
-            "_run_background_title_update must rebind to canonical cached "
-            "session instance under LOCK"
+        assert "cached_session = SESSIONS.get(session_id)" in fn_block, (
+            "_run_background_title_update must read the cached session under LOCK"
+        )
+        assert "getattr(cached_session, 'session_id', None) == session_id" in fn_block, (
+            "_run_background_title_update must only rebind to a canonical cached "
+            "session instance whose id matches the requested session"
         )
 
     def test_cancel_stream_uses_agent_lock(self):

--- a/tests/test_memory_session_lifecycle_generation.py
+++ b/tests/test_memory_session_lifecycle_generation.py
@@ -329,8 +329,12 @@ def test_lru_eviction_commits_outside_cache_lock():
     assert "commit_session_memory" not in locked_section
     assert "_lifecycle_commit" not in locked_section
     assert "SESSION_AGENT_CACHE.popitem" in locked_section
-    assert "_lifecycle_commit" in outside_section
-    assert "wait=True" in outside_section
+    assert "_close_evicted_agent_at_session_boundary" in outside_section
+    helper_start = src.index("def _close_evicted_agent_at_session_boundary")
+    helper_end = src.index("\ndef _refresh_cached_agent_runtime", helper_start)
+    helper_section = src[helper_start:helper_end]
+    assert "_lifecycle_commit_session_memory" in helper_section
+    assert "wait=True" in helper_section
     assert "outside the cache lock" in outside_section
 
 

--- a/tests/test_session_cache_ownership.py
+++ b/tests/test_session_cache_ownership.py
@@ -1,0 +1,122 @@
+import json
+from io import BytesIO
+from types import SimpleNamespace
+
+import api.config as config
+import api.models as models
+from api.models import Session, get_session
+
+
+def test_get_session_evicts_cached_object_with_wrong_session_id(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(config, "SESSION_INDEX_FILE", session_dir / "_index.json", raising=False)
+    models.SESSIONS.clear()
+
+    requested = Session(
+        session_id="requested-tip",
+        title="Requested Tip",
+        messages=[{"role": "user", "content": "correct transcript"}],
+    )
+    requested.save()
+    wrong = Session(
+        session_id="older-segment",
+        title="Older Segment",
+        messages=[{"role": "user", "content": "wrong transcript"}],
+    )
+
+    models.SESSIONS["requested-tip"] = wrong
+
+    loaded = get_session("requested-tip")
+
+    assert loaded.session_id == "requested-tip"
+    assert loaded.title == "Requested Tip"
+    assert loaded.messages == [{"role": "user", "content": "correct transcript"}]
+    assert models.SESSIONS["requested-tip"] is loaded
+
+    models.SESSIONS.clear()
+
+
+def test_get_session_metadata_only_evicts_cached_object_with_wrong_session_id(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(config, "SESSION_INDEX_FILE", session_dir / "_index.json", raising=False)
+    models.SESSIONS.clear()
+
+    requested = Session(
+        session_id="requested-tip",
+        title="Requested Tip",
+        messages=[{"role": "user", "content": "correct transcript"}],
+    )
+    requested.save()
+    models.SESSIONS["requested-tip"] = Session(session_id="older-segment", title="Older Segment")
+
+    loaded = get_session("requested-tip", metadata_only=True)
+
+    assert loaded.session_id == "requested-tip"
+    assert loaded.title == "Requested Tip"
+    assert models.SESSIONS.get("requested-tip") is None
+
+    models.SESSIONS.clear()
+
+
+def test_compression_cache_migration_never_moves_unverified_cached_object_to_new_sid():
+    streaming_src = open("api/streaming.py", encoding="utf-8").read()
+
+    assert "SESSIONS[new_sid] = SESSIONS.pop(old_sid)" not in streaming_src
+    assert "cached_old_session is not s" in streaming_src
+    assert "SESSIONS[new_sid] = s" in streaming_src
+
+
+def test_cached_agent_session_identity_matches_requested_sid():
+    from api.streaming import _cached_agent_matches_session, _cached_agent_session_identity
+
+    matching = SimpleNamespace(session_id="requested")
+    mismatched = SimpleNamespace(session_id="other")
+    legacy = SimpleNamespace()
+    db_owned = SimpleNamespace(_session_db=SimpleNamespace(session_id="requested"))
+
+    assert _cached_agent_session_identity(matching) == "requested"
+    assert _cached_agent_matches_session(matching, "requested") is True
+    assert _cached_agent_matches_session(mismatched, "requested") is False
+    assert _cached_agent_matches_session(db_owned, "requested") is True
+    assert _cached_agent_matches_session(legacy, "requested") is True
+
+
+def test_handle_chat_steer_evicts_mismatched_cached_agent():
+    from api.streaming import _handle_chat_steer
+
+    class Handler:
+        headers = {}
+
+        def __init__(self):
+            self.status = None
+            self.response_headers = []
+            self.wfile = BytesIO()
+
+        def send_response(self, status):
+            self.status = status
+
+        def send_header(self, key, value):
+            self.response_headers.append((key, value))
+
+        def end_headers(self):
+            pass
+
+    wrong_agent = SimpleNamespace(session_id="other-session", steer=lambda _text: True)
+    config.SESSION_AGENT_CACHE.clear()
+    config.SESSION_AGENT_CACHE["requested"] = (wrong_agent, "sig")
+    handler = Handler()
+
+    _handle_chat_steer(handler, {"session_id": "requested", "text": "please steer"})
+
+    payload = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert handler.status == 200
+    assert payload == {"accepted": False, "fallback": "no_cached_agent", "stream_id": None}
+    assert "requested" not in config.SESSION_AGENT_CACHE
+
+    config.SESSION_AGENT_CACHE.clear()

--- a/tests/test_streaming_agent_cache_lifecycle.py
+++ b/tests/test_streaming_agent_cache_lifecycle.py
@@ -1,0 +1,73 @@
+from unittest.mock import MagicMock
+
+
+def test_evicted_agent_lifecycle_commits_unregisters_and_shutdowns(monkeypatch):
+    import api.streaming as streaming
+
+    events = []
+
+    def fake_commit(session_id, *, agent=None, wait=False):
+        events.append(("commit", session_id, agent, wait))
+        return True
+
+    def fake_has_uncommitted_work(session_id):
+        events.append(("has_uncommitted", session_id))
+        return False
+
+    def fake_unregister(session_id):
+        events.append(("unregister", session_id))
+
+    monkeypatch.setattr(streaming, "_lifecycle_commit_session_memory", fake_commit)
+    monkeypatch.setattr(streaming, "_lifecycle_has_uncommitted_work", fake_has_uncommitted_work)
+    monkeypatch.setattr(streaming, "_lifecycle_unregister_agent", fake_unregister)
+
+    session_db = MagicMock()
+    agent = MagicMock()
+    agent._session_db = session_db
+    agent._session_messages = [{"role": "user", "content": "hello"}]
+
+    streaming._close_evicted_agent_at_session_boundary("old-session", agent)
+
+    assert ("commit", "old-session", agent, True) in events
+    assert ("has_uncommitted", "old-session") in events
+    assert ("unregister", "old-session") in events
+    agent.shutdown_memory_provider.assert_called_once_with(agent._session_messages)
+    session_db.close.assert_called_once()
+
+
+def test_evicted_agent_lifecycle_shutdown_uses_empty_messages_when_missing(monkeypatch):
+    import api.streaming as streaming
+
+    monkeypatch.setattr(streaming, "_lifecycle_commit_session_memory", lambda *a, **kw: True)
+    monkeypatch.setattr(streaming, "_lifecycle_has_uncommitted_work", lambda session_id: False)
+    monkeypatch.setattr(streaming, "_lifecycle_unregister_agent", MagicMock())
+
+    agent = MagicMock()
+    agent._session_db = MagicMock()
+
+    streaming._close_evicted_agent_at_session_boundary("old-session", agent)
+
+    agent.shutdown_memory_provider.assert_called_once_with([])
+    agent._session_db.close.assert_called_once()
+
+
+def test_evicted_agent_lifecycle_keeps_provider_alive_when_commit_still_dirty(monkeypatch):
+    import api.streaming as streaming
+
+    def fake_commit(session_id, *, agent=None, wait=False):
+        return True
+
+    def fake_has_uncommitted_work(session_id):
+        return True
+
+    monkeypatch.setattr(streaming, "_lifecycle_commit_session_memory", fake_commit)
+    monkeypatch.setattr(streaming, "_lifecycle_has_uncommitted_work", fake_has_uncommitted_work)
+    monkeypatch.setattr(streaming, "_lifecycle_unregister_agent", MagicMock())
+
+    agent = MagicMock()
+    agent._session_db = MagicMock()
+
+    streaming._close_evicted_agent_at_session_boundary("dirty-session", agent)
+
+    agent.shutdown_memory_provider.assert_not_called()
+    agent._session_db.close.assert_not_called()

--- a/tests/test_v050259_sessiondb_fd_leak.py
+++ b/tests/test_v050259_sessiondb_fd_leak.py
@@ -85,9 +85,17 @@ def test_lru_eviction_closes_evicted_agent_session_db():
         "is the original bug shape."
     )
 
-    # Positive pattern: must close on the evicted agent.
-    assert "_evicted_agent._session_db.close()" in block, (
-        "LRU eviction must close the evicted agent\'s _session_db. "
+    # Positive pattern: eviction must call the lifecycle helper, and the helper
+    # must close the evicted agent's SessionDB after provider teardown.
+    assert "_close_evicted_agent_at_session_boundary(_evicted_sid, _evicted_agent)" in block, (
+        "LRU eviction must route the evicted agent through the session-boundary "
+        "close helper."
+    )
+    helper_start = src.index("def _close_evicted_agent_at_session_boundary")
+    helper_end = src.index("\ndef _refresh_cached_agent_runtime", helper_start)
+    helper_block = src[helper_start:helper_end]
+    assert "session_db.close()" in helper_block, (
+        "LRU eviction helper must close the evicted agent's _session_db. "
         "(Opus pre-release follow-up to PR #1421.)"
     )
 


### PR DESCRIPTION
Release stage-batch62 → v0.51.180 (Release EZ)

Two contributor PRs from @ai-ag2026, both hardening the LOCK-protected session/agent cache. Batched together because they touch adjacent-but-non-overlapping regions of `api/streaming.py` (`#3191` guards the cache-HIT path, `#3166` refactors the cache-EVICT path) — verified no hunk overlap, clean auto-merge except a CHANGELOG-only conflict.

## #3191 — guard session cache ownership across compression
- `GET /api/session` (`api/models.py`) now evicts a cached `Session` whose own `session_id` no longer matches the requested key, instead of trusting the LRU and returning a stale transcript (which looked like a disappeared session).
- Background title-update/refresh paths only adopt a cached session when its identity matches.
- The compression-checkpoint migration no longer re-stores a stale object under the old lineage id, always stores the live session under the new id, and enforces `SESSIONS_MAX`.

## #3166 — close evicted agents from WebUI cache
- Extracts the inline LRU-eviction cleanup into `_close_evicted_agent_at_session_boundary` and adds `shutdown_memory_provider(messages)` so provider-owned clients (e.g. Hindsight's aiohttp session) close at the eviction boundary instead of leaking until GC.

## Verification
- Full sequential suite: **6983 passed, 7 skipped, 3 xpassed, 0 failed** (`pytest -p no:xdist`).
- Pre-Opus gate: `ast.parse` on streaming.py + models.py, no merge markers, `[Unreleased]` resolves clean. (No JS changed — ESLint gate N/A.)
- **Independent Opus advisor review: SHIP** (no MUST-FIX, no deadlock, no new race). Verified LOCK non-reentrancy is respected (fresh acquisition, no nesting), the TOCTOU eviction uses correct double-checked-locking, `SESSIONS_MAX` enforcement can't evict the just-stored session (it's `move_to_end`'d first), and `shutdown_memory_provider` double-invocation is a swallowed no-op.
- One non-blocking SHOULD-FIX (identity-mismatch eviction sites skip the new teardown helper → bounded FD leak on a rare orphan path, pre-existing shape) filed as follow-up #3215.

🤖 Per-PR attribution preserved in commit trailers.
