### PR TITLE
fix: render file artifact links as media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Render assistant-emitted `file://` image artifact links inline through the authenticated `/api/media` route, so browser clients can view generated local images instead of seeing unusable server-local file paths.
+
 ## [v0.51.180] — 2026-05-30 — Release EZ (stage-batch62 — session/agent cache ownership hardening)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -3014,6 +3014,16 @@ function renderMd(raw){
     media_stash.push(raw_ref);
     return '\x00D'+(media_stash.length-1)+'\x00';
   });
+  // Some gateway/tool surfaces still emit file:// links for local artifacts
+  // instead of MEDIA: tokens. Browser clients cannot open the server's
+  // filesystem directly, so treat bare file:// URLs as media artifacts and
+  // route them through /api/media. This intentionally runs only for bare URLs
+  // (line-start or whitespace-delimited), not inside markdown links, so normal
+  // [label](file://...) anchors continue to use the link path below.
+  s=s.replace(/(^|\s)(file:\/\/[^\s<>"')\]]+)/g,(_,lead,raw_ref)=>{
+    media_stash.push(raw_ref);
+    return lead+'\x00D'+(media_stash.length-1)+'\x00';
+  });
   // ── End MEDIA stash ─────────────────────────────────────────────────────────
   // Pre-pass: decode HTML entities first so markdown processing works correctly.
   // This prevents double-escaping when LLM outputs entities like &lt; &gt; &amp;
@@ -3449,7 +3459,7 @@ function renderMd(raw){
   s=s.replace(/\x00E(\d+)\x00/g,(_,i)=>_pre_stash[+i]);
   // ── Restore MEDIA stash → inline images or download links ─────────────────
   s=s.replace(/\x00D(\d+)\x00/g,(_,i)=>{
-    const ref=media_stash[+i];
+    let ref=media_stash[+i];
     // Keep this logic self-contained: some tests extract renderMd() alone and
     // execute it in node, without the top-level helper functions from ui.js.
     const mediaKindForName=(name='')=>{
@@ -3468,6 +3478,15 @@ function renderMd(raw){
         : `<audio class="msg-media-player msg-media-audio" src="${safeSrc}" controls preload="metadata" title="${safeName}"></audio>`;
       return `<div class="msg-media-editor msg-media-editor--${kind}" data-media-kind="${kind}">${tag}<div class="msg-media-meta"><span class="msg-media-name">${safeName}</span></div></div>`;
     };
+    if(/^file:\/\//i.test(ref)){
+      try{
+        const u=new URL(ref);
+        ref=decodeURIComponent(u.pathname||ref.replace(/^file:\/\//i,''));
+      }catch(_){
+        try{ref=decodeURIComponent(ref.replace(/^file:\/\//i,''));}
+        catch(__){ref=ref.replace(/^file:\/\//i,'');}
+      }
+    }
     // HTTP(S) URL
     if(/^https?:\/\//i.test(ref)){
       // Rewrite localhost/127.0.0.1 to the actual server base URL so remote

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -41,6 +41,15 @@ class TestMediaRenderMdStash(unittest.TestCase):
         self.assertIn("MEDIA:", UI_JS,
                       "MEDIA: token regex must be present in renderMd()")
 
+    def test_bare_file_urls_are_stashed_as_media_artifacts(self):
+        self.assertIn("file:// links for local artifacts", UI_JS)
+        self.assertIn("file:\\/\\/[^\\s<>", UI_JS)
+
+    def test_file_urls_are_rewritten_through_media_endpoint(self):
+        self.assertIn("new URL(ref)", UI_JS)
+        self.assertIn("u.pathname", UI_JS)
+        self.assertIn("api/media?path=", UI_JS)
+
     def test_media_restore_produces_img_tag(self):
         self.assertIn("msg-media-img", UI_JS,
                       "restore pass must produce <img class='msg-media-img'>")


### PR DESCRIPTION
## Summary
- Render bare `file://` artifact URLs as WebUI media previews instead of leaving browser-unusable local file links.
- Decode `file://` media references before routing them through the existing authenticated `/api/media` endpoint.
- Add regression coverage for file artifact handling in the media renderer tests.

## Test Plan
- `python -m py_compile api/routes.py`
- `node --check static/ui.js`
- `python -m pytest tests/test_media_inline.py -q -o 'addopts='`
- `git diff --check`
- Node smoke: `renderMd('Movies:\nfile:///tmp/generated-movies-tv/movies.png')` returns an inline `msg-media-img` using `/api/media`.
