### PR TITLE
test: skip terminal cleanup collection on non-POSIX hosts

### DIFF
--- a/tests/test_terminal_process_cleanup.py
+++ b/tests/test_terminal_process_cleanup.py
@@ -5,6 +5,9 @@ import time
 
 import pytest
 
+if os.name != "posix":
+    pytest.skip("terminal process cleanup tests require POSIX terminal support", allow_module_level=True)
+
 import api.terminal as terminal
 
 


### PR DESCRIPTION
## Thinking Path
- `tests/test_terminal_process_cleanup.py` is POSIX-terminal coverage and imports `api.terminal`, which imports `fcntl` at module import time.
- On non-POSIX hosts, collection fails before the existing POSIX-only test skip can run.
- The smallest fix is a module-level skip before importing `api.terminal` when `os.name != posix`.

## What Changed
- Added a non-POSIX module-level skip in `tests/test_terminal_process_cleanup.py` before importing `api.terminal`.

## Why It Matters
- Windows/native contributors can collect targeted tests without hitting a POSIX-only import error.
- Linux/POSIX behavior and terminal lifecycle assertions are unchanged.

## Verification
- `python -m ruff check tests/test_terminal_process_cleanup.py`
- `PYTHONUTF8=1 HERMES_WEBUI_PYTHON=.venv\\Scripts\\python.exe HERMES_HOME=<isolated temp> HERMES_WEBUI_TEST_STATE_DIR=<isolated temp> python -m pytest tests/test_terminal_process_cleanup.py tests/test_opencode_providers.py -q --timeout=60` -> `11 passed, 1 skipped`

## Risks / Follow-ups
- Low risk: test-only change.
- Full Windows suite still has unrelated environment/platform failures; this PR only fixes the terminal cleanup collection guard.

## Model Used
OpenAI GPT-5 Codex in Codex Desktop, with local shell/git/gh tooling.