### PR TITLE
fix: preserve scroll on CLI import refresh

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2548,8 +2548,17 @@ function startGatewaySSE(){
                     if (next.length < prev) return;
                     if (prev > 0 && !_isCliImportRefreshPrefixMatch(S.messages, next)) return;
                     S.messages = next;
+                    if(S.session && S.session.session_id === activeSid){
+                      S.session.message_count = next.length;
+                      const newest = next.length ? next[next.length - 1] : null;
+                      const newestTs = Number((newest && (newest.timestamp || newest._ts)) || 0);
+                      if(newestTs){
+                        S.session.last_message_at = newestTs;
+                        S.session.updated_at = newestTs;
+                      }
+                    }
                     if(S.messages.length !== prev){
-                      renderMessages();
+                      renderMessages({preserveScroll:true});
                       if(typeof highlightCode==='function') highlightCode();
                     }
                   }

--- a/tests/test_session_import_cli_sse_refresh.py
+++ b/tests/test_session_import_cli_sse_refresh.py
@@ -17,6 +17,8 @@ def test_sse_import_cli_guard_skips_shorter_transcript_overwrite():
     assert "if (next.length < prev) return;" in sse_block
     assert "if (prev > 0 && !_isCliImportRefreshPrefixMatch(S.messages, next)) return;" in sse_block
     assert "S.messages = next;" in sse_block
+    assert "S.session.message_count = next.length;" in sse_block
+    assert "renderMessages({preserveScroll:true});" in sse_block
 
 
 def test_sse_import_cli_refresh_prefix_helper_ignores_timestamps():


### PR DESCRIPTION
## Summary
- preserve transcript scroll during same-session CLI/gateway import refreshes
- sync active session metadata when accepting the refreshed transcript
- add regression coverage for the CLI import SSE refresh path

## Test Plan
- [x] `pytest -q tests/test_session_import_cli_sse_refresh.py tests/test_tars_scroll_reset_regressions.py tests/test_webui_external_refresh_frontend.py`

Closes #3236
