### PR TITLE
fix: distinguish identical clarify prompts by id

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -2989,6 +2989,7 @@ function showClarifyCard(pending) {
     question,
     choices,
     sid: pending._session_id || (S.session && S.session.session_id) || null,
+    clarify_id: pending.clarify_id || null,
   });
   const card = _ensureClarifyCardDom();
   if (!card) return;

--- a/tests/test_sprint30.py
+++ b/tests/test_sprint30.py
@@ -664,3 +664,5 @@ class TestClarifyCardTimerLogic:
         body = m.group(0)
         assert 'JSON.stringify' in body, 'showClarifyCard must compute a signature via JSON.stringify'
         assert '_clarifySignature' in body, 'showClarifyCard must check/set _clarifySignature'
+        assert 'clarify_id: pending.clarify_id || null' in body, \
+            'showClarifyCard signature must include clarify_id so a newly queued identical prompt is not mistaken for the previous one'


### PR DESCRIPTION
## Summary
- include `clarify_id` in the WebUI clarify-card dedupe signature
- prevent a newly queued text-identical clarify prompt from being mistaken for the previous one
- add regression coverage for the clarify signature inputs

## Root cause
`showClarifyCard()` used a signature based on question/choices/session id, but not `clarify_id`.

When the next queued clarify prompt was text-identical to the previous one, the frontend could treat it as the same prompt, preserving stale visible card/input state even after the earlier response had already been accepted.

## Testing
- `pytest tests/test_sprint30.py -q`
- `pytest tests/test_clarify_unblock.py -q`

Closes #3241
