### PR TITLE
fix: prevent browser autofill on clarify input

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -496,7 +496,7 @@
           <div class="clarify-question" id="clarifyQuestion"></div>
           <div class="clarify-choices" id="clarifyChoices"></div>
           <div class="clarify-response">
-            <input class="clarify-input" id="clarifyInput" type="text" data-i18n-placeholder="clarify_input_placeholder" placeholder="Type your response…">
+            <input class="clarify-input" id="clarifyInput" type="text" autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" data-i18n-placeholder="clarify_input_placeholder" placeholder="Type your response…">
             <button class="clarify-submit" id="clarifySubmit" onclick="respondClarify()" data-i18n="clarify_send">Send</button>
           </div>
           <div class="clarify-hint" id="clarifyHint" data-i18n="clarify_hint">Pick a choice, or type your own answer below.</div>

--- a/static/messages.js
+++ b/static/messages.js
@@ -2834,7 +2834,7 @@ function _ensureClarifyCardDom() {
       <div class="clarify-question" id="clarifyQuestion"></div>
       <div class="clarify-choices" id="clarifyChoices"></div>
       <div class="clarify-response">
-        <input class="clarify-input" id="clarifyInput" type="text" data-i18n-placeholder="clarify_input_placeholder" placeholder="Type your response…">
+        <input class="clarify-input" id="clarifyInput" type="text" autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" data-i18n-placeholder="clarify_input_placeholder" placeholder="Type your response…">
         <button class="clarify-submit" id="clarifySubmit" data-i18n="clarify_send">Send</button>
       </div>
       <div class="clarify-hint" id="clarifyHint" data-i18n="clarify_hint">Please choose one option, or type your own response below.</div>
@@ -3137,6 +3137,7 @@ function showClarifyCard(pending) {
   if (input) {
     if (!sameClarify) input.value = '';
     input.disabled = false;
+    input.removeAttribute('readonly');
     input.onkeydown = (e) => {
       if (e.key === 'Enter') {
         e.preventDefault();


### PR DESCRIPTION
## Problem

Chrome's password manager aggressively autofills the clarify card's `<input>` field with saved credentials — typically a provider base URL.

This causes two bugs:

1. **Phantom "Clarification closed" toast on every session completion.** `_stashClarifyDraft()` reads the autofilled value and treats it as a user draft, showing "Clarification closed. Your draft was kept in the composer." even when no clarification was ever requested or shown.

2. **Saved URL injected into the main composer.** The autofilled URL gets appended to the composer text via `_stashClarifyDraft`, confusing the user.

## Root Cause

The clarify input has no protection against browser autofill. `autocomplete="off"` alone is ignored by Chrome's password manager, which matches the field by heuristic patterns and fills it with saved credentials.

## Fix

Add `readonly` attribute to the clarify input so Chrome's autofill skips it. When `showClarifyCard()` makes the card visible (i.e. an actual clarification prompt arrives), `readonly` is removed programmatically so the user can type normally.

Both the static HTML (`index.html`) and the dynamic DOM creation (`_ensureClarifyCardDom` in `messages.js`) are patched.

## Verification

1. Configure a custom provider with a base URL in Chrome
2. Save the credentials when prompted by Chrome
3. Send a message and wait for completion
4. Before: `document.getElementById('clarifyInput').value` returns the saved URL; "Clarification closed" toast appears
5. After: `document.getElementById('clarifyInput').value` is empty; no phantom toast

## Files Changed

- `static/index.html` — add `autocomplete="off" readonly onfocus="this.removeAttribute('readonly')"` to clarify input
- `static/messages.js` — same fix in `_ensureClarifyCardDom` template + `input.removeAttribute('readonly')` in `showClarifyCard()`
