### PR TITLE
Add a signed & notarized macOS desktop app (.dmg packaging)

### DIFF
--- a/packaging/macos/.gitignore
+++ b/packaging/macos/.gitignore
@@ -1,0 +1,4 @@
+build/
+.python-cache/
+*.dmg
+AppIcon.icns

--- a/packaging/macos/HermesApp/main.swift
+++ b/packaging/macos/HermesApp/main.swift
@@ -21,9 +21,18 @@ enum BundlePaths {
     static var resources: URL {
         Bundle.main.resourceURL ?? URL(fileURLWithPath: ".")
     }
-    /// Bundled relocatable Python interpreter.
+    /// Bundled relocatable Python interpreter. A universal build ships one Python
+    /// per arch (python-arm64 / python-x86_64); each native slice of this binary
+    /// picks its matching one. A single-arch build ships just `python`.
     static var python: URL {
-        resources.appendingPathComponent("python/bin/python3")
+        #if arch(arm64)
+        let archDir = "python-arm64"
+        #else
+        let archDir = "python-x86_64"
+        #endif
+        let universal = resources.appendingPathComponent("\(archDir)/bin/python3")
+        if FileManager.default.isExecutableFile(atPath: universal.path) { return universal }
+        return resources.appendingPathComponent("python/bin/python3")
     }
     /// The WebUI checkout shipped inside the app.
     static var supervisor: URL {

--- a/packaging/macos/HermesApp/main.swift
+++ b/packaging/macos/HermesApp/main.swift
@@ -152,12 +152,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         let frame = NSRect(x: 0, y: 0, width: 1180, height: 820)
+        // Standard titlebar (no .fullSizeContentView): the web content sits
+        // BELOW the titlebar so it never overlaps the traffic-light buttons, and
+        // the titlebar gives a draggable region to move the window. (The embedded
+        // WebUI page has no -webkit-app-region:drag strip of its own, so a
+        // full-size-content transparent titlebar would leave the window unmovable.)
         window = NSWindow(
             contentRect: frame,
-            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered, defer: false)
         window.title = "Hermes"
-        window.titlebarAppearsTransparent = true
+        window.isMovableByWindowBackground = true
         window.center()
         window.setFrameAutosaveName("HermesMainWindow")
 

--- a/packaging/macos/HermesApp/main.swift
+++ b/packaging/macos/HermesApp/main.swift
@@ -148,6 +148,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
     private var loadingLabel: NSTextField!
     private var spinner: NSProgressIndicator!
     private var loadingStack: NSStackView!
+    private var chromeTimer: Timer?
     private let supervisor = Supervisor()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -162,6 +163,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered, defer: false)
         window.title = "Hermes"
+        // Seamless titlebar: transparent + no title text so it shows the window
+        // background, which we keep in sync with the page's chrome colour
+        // (--sidebar) below. Content still sits under the titlebar (no
+        // .fullSizeContentView), so nothing overlaps the traffic lights and the
+        // titlebar stays draggable.
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
         window.isMovableByWindowBackground = true
         window.center()
         window.setFrameAutosaveName("HermesMainWindow")
@@ -232,11 +240,57 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
             })
     }
 
+    // Keep the (transparent) titlebar matching the page's chrome colour so the
+    // window reads as one seamless surface, and track in-app theme switches.
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        syncChromeColor()
+        chromeTimer?.invalidate()
+        chromeTimer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: true) { [weak self] _ in
+            self?.syncChromeColor()
+        }
+    }
+
+    private func syncChromeColor() {
+        // The WebUI documents --sidebar as its chrome colour (light/dark aware).
+        let js = """
+        (function(){var cs=getComputedStyle(document.documentElement);
+        var c=(cs.getPropertyValue('--sidebar')||'').trim();
+        return c||getComputedStyle(document.body).backgroundColor;})()
+        """
+        webView.evaluateJavaScript(js) { [weak self] result, _ in
+            guard let self, let s = result as? String, let color = NSColor(cssString: s) else { return }
+            self.window.backgroundColor = color
+        }
+    }
+
     // Quitting when the window closes gives us a single, predictable teardown path.
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
 
     func applicationWillTerminate(_ notification: Notification) {
         supervisor.stop()
+    }
+}
+
+extension NSColor {
+    /// Parse a CSS colour string: `#rgb`, `#rrggbb`, or `rgb()/rgba()`.
+    convenience init?(cssString raw: String) {
+        let s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasPrefix("#") {
+            var hex = String(s.dropFirst())
+            if hex.count == 3 { hex = hex.map { "\($0)\($0)" }.joined() }
+            guard hex.count == 6, let v = Int(hex, radix: 16) else { return nil }
+            self.init(srgbRed: CGFloat((v >> 16) & 0xFF) / 255,
+                      green: CGFloat((v >> 8) & 0xFF) / 255,
+                      blue: CGFloat(v & 0xFF) / 255, alpha: 1)
+        } else if s.hasPrefix("rgb") {
+            let parts = s.components(separatedBy: CharacterSet(charactersIn: "0123456789.").inverted)
+                         .filter { !$0.isEmpty }
+            guard parts.count >= 3, let r = Double(parts[0]), let g = Double(parts[1]),
+                  let b = Double(parts[2]) else { return nil }
+            self.init(srgbRed: CGFloat(r) / 255, green: CGFloat(g) / 255, blue: CGFloat(b) / 255, alpha: 1)
+        } else {
+            return nil
+        }
     }
 }
 

--- a/packaging/macos/HermesApp/main.swift
+++ b/packaging/macos/HermesApp/main.swift
@@ -1,0 +1,194 @@
+// Hermes — native macOS shell.
+//
+// A thin WKWebView window that owns the whole Hermes lifecycle:
+//   • on launch it starts the Python `supervisor` (which installs the agent on
+//     first run, then starts the WebUI backend),
+//   • it shows a loading screen until the supervisor prints `HERMES-READY`,
+//   • it loads the local WebUI URL,
+//   • on quit (⌘Q, window close, or app termination) it SIGTERMs the supervisor
+//     and SIGKILLs it as a backstop, so the frontend, backend, and Hermes agent
+//     all shut down with the window.
+//
+// Built as a single binary with `swiftc` — see build.sh.
+
+import AppKit
+import WebKit
+
+// MARK: - Bundle layout helpers
+
+enum BundlePaths {
+    /// .../Hermes.app/Contents/Resources
+    static var resources: URL {
+        Bundle.main.resourceURL ?? URL(fileURLWithPath: ".")
+    }
+    /// Bundled relocatable Python interpreter.
+    static var python: URL {
+        resources.appendingPathComponent("python/bin/python3")
+    }
+    /// The WebUI checkout shipped inside the app.
+    static var supervisor: URL {
+        resources.appendingPathComponent("webui/packaging/macos/supervisor.py")
+    }
+    static var webuiDir: URL {
+        resources.appendingPathComponent("webui")
+    }
+}
+
+// MARK: - Supervisor process manager
+
+final class Supervisor {
+    private var process: Process?
+    private(set) var url: URL?
+    private var onReady: ((URL) -> Void)?
+    private var onFailure: ((String) -> Void)?
+
+    func start(onReady: @escaping (URL) -> Void, onFailure: @escaping (String) -> Void) {
+        self.onReady = onReady
+        self.onFailure = onFailure
+
+        let proc = Process()
+        // Prefer the bundled Python; fall back to a discoverable python3 in dev.
+        let py = FileManager.default.isExecutableFile(atPath: BundlePaths.python.path)
+            ? BundlePaths.python
+            : URL(fileURLWithPath: "/usr/bin/env")
+        if py.lastPathComponent == "env" {
+            proc.executableURL = py
+            proc.arguments = ["python3", BundlePaths.supervisor.path]
+        } else {
+            proc.executableURL = py
+            proc.arguments = [BundlePaths.supervisor.path]
+        }
+
+        var env = ProcessInfo.processInfo.environment
+        env["HERMES_WEBUI_DIR"] = BundlePaths.webuiDir.path
+        // Make the bundled python's bin dir discoverable to children.
+        let pyBin = BundlePaths.python.deletingLastPathComponent().path
+        env["PATH"] = pyBin + ":" + (env["PATH"] ?? "/usr/bin:/bin:/usr/local/bin") + ":" + NSHomeDirectory() + "/.local/bin"
+        // NB: deliberately do NOT set HERMES_WEBUI_PYTHON. The bundled Python only
+        // bootstraps; bootstrap.py auto-discovers the agent's venv interpreter
+        // (which carries the heavy ML deps) to run the actual server. Forcing the
+        // bundled Python here would break `from run_agent import AIAgent`.
+        proc.environment = env
+
+        let outPipe = Pipe()
+        proc.standardOutput = outPipe
+        proc.standardError = outPipe
+        outPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+            FileHandle.standardError.write(data)  // forward logs to Console
+            for line in text.split(separator: "\n") {
+                if line.contains("HERMES-READY"),
+                   let range = line.range(of: "url="),
+                   let u = URL(string: String(line[range.upperBound...]).trimmingCharacters(in: .whitespaces)) {
+                    self?.url = u
+                    DispatchQueue.main.async { self?.onReady?(u) }
+                }
+            }
+        }
+
+        proc.terminationHandler = { [weak self] p in
+            if self?.url == nil {
+                DispatchQueue.main.async {
+                    self?.onFailure?("Hermes backend exited before it was ready (code \(p.terminationStatus)).")
+                }
+            }
+        }
+
+        do {
+            try proc.run()
+            process = proc
+        } catch {
+            onFailure("Failed to start Hermes backend: \(error.localizedDescription)")
+        }
+    }
+
+    /// Stop the supervisor (and therefore the whole Hermes process tree).
+    func stop() {
+        guard let proc = process, proc.isRunning else { return }
+        let pid = proc.processIdentifier
+        kill(pid, SIGTERM)  // ask the supervisor to shut everything down gracefully
+        // Give it up to 10s, then force-kill.
+        let deadline = Date().addingTimeInterval(10)
+        while proc.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        if proc.isRunning {
+            kill(pid, SIGKILL)
+            proc.waitUntilExit()
+        }
+        process = nil
+    }
+}
+
+// MARK: - App
+
+final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
+    private var window: NSWindow!
+    private var webView: WKWebView!
+    private var loadingLabel: NSTextField!
+    private let supervisor = Supervisor()
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let frame = NSRect(x: 0, y: 0, width: 1180, height: 820)
+        window = NSWindow(
+            contentRect: frame,
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered, defer: false)
+        window.title = "Hermes"
+        window.titlebarAppearsTransparent = true
+        window.center()
+        window.setFrameAutosaveName("HermesMainWindow")
+
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .default()
+        webView = WKWebView(frame: frame, configuration: config)
+        webView.navigationDelegate = self
+        webView.autoresizingMask = [.width, .height]
+        webView.isHidden = true
+
+        loadingLabel = NSTextField(labelWithString: "Starting Hermes…\nInstalling the agent on first launch can take a few minutes.")
+        loadingLabel.alignment = .center
+        loadingLabel.maximumNumberOfLines = 0
+        loadingLabel.textColor = .secondaryLabelColor
+        loadingLabel.font = .systemFont(ofSize: 14)
+        loadingLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView(frame: frame)
+        container.autoresizingMask = [.width, .height]
+        container.addSubview(webView)
+        container.addSubview(loadingLabel)
+        NSLayoutConstraint.activate([
+            loadingLabel.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            loadingLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            loadingLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 520),
+        ])
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        supervisor.start(
+            onReady: { [weak self] url in
+                guard let self else { return }
+                self.webView.isHidden = false
+                self.loadingLabel.isHidden = true
+                self.webView.load(URLRequest(url: url))
+            },
+            onFailure: { [weak self] message in
+                self?.loadingLabel.stringValue = "⚠️ \(message)\n\nSee Console.app → Hermes for details."
+            })
+    }
+
+    // Quitting when the window closes gives us a single, predictable teardown path.
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        supervisor.stop()
+    }
+}
+
+let app = NSApplication.shared
+let delegate = AppDelegate()
+app.delegate = delegate
+app.setActivationPolicy(.regular)
+app.run()

--- a/packaging/macos/HermesApp/main.swift
+++ b/packaging/macos/HermesApp/main.swift
@@ -41,9 +41,13 @@ final class Supervisor {
     private(set) var url: URL?
     private var onReady: ((URL) -> Void)?
     private var onFailure: ((String) -> Void)?
+    private var onProgress: ((String) -> Void)?
 
-    func start(onReady: @escaping (URL) -> Void, onFailure: @escaping (String) -> Void) {
+    func start(onReady: @escaping (URL) -> Void,
+               onProgress: @escaping (String) -> Void,
+               onFailure: @escaping (String) -> Void) {
         self.onReady = onReady
+        self.onProgress = onProgress
         self.onFailure = onFailure
 
         let proc = Process()
@@ -83,6 +87,11 @@ final class Supervisor {
                    let u = URL(string: String(line[range.upperBound...]).trimmingCharacters(in: .whitespaces)) {
                     self?.url = u
                     DispatchQueue.main.async { self?.onReady?(u) }
+                } else if let range = line.range(of: "HERMES-PROGRESS ") {
+                    let msg = String(line[range.upperBound...]).trimmingCharacters(in: .whitespaces)
+                    if !msg.isEmpty {
+                        DispatchQueue.main.async { self?.onProgress?(msg) }
+                    }
                 }
             }
         }
@@ -126,7 +135,10 @@ final class Supervisor {
 final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
     private var window: NSWindow!
     private var webView: WKWebView!
+    private var loadingTitle: NSTextField!
     private var loadingLabel: NSTextField!
+    private var spinner: NSProgressIndicator!
+    private var loadingStack: NSStackView!
     private let supervisor = Supervisor()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -147,21 +159,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
         webView.autoresizingMask = [.width, .height]
         webView.isHidden = true
 
-        loadingLabel = NSTextField(labelWithString: "Starting Hermes…\nInstalling the agent on first launch can take a few minutes.")
+        loadingTitle = NSTextField(labelWithString: "Setting up Hermes")
+        loadingTitle.alignment = .center
+        loadingTitle.font = .systemFont(ofSize: 19, weight: .semibold)
+        loadingTitle.textColor = .labelColor
+        loadingTitle.translatesAutoresizingMaskIntoConstraints = false
+
+        spinner = NSProgressIndicator()
+        spinner.style = .spinning
+        spinner.controlSize = .regular
+        spinner.isIndeterminate = true
+        spinner.startAnimation(nil)
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+
+        loadingLabel = NSTextField(labelWithString: "Starting…")
         loadingLabel.alignment = .center
-        loadingLabel.maximumNumberOfLines = 0
+        loadingLabel.maximumNumberOfLines = 3
+        loadingLabel.lineBreakMode = .byTruncatingTail
         loadingLabel.textColor = .secondaryLabelColor
-        loadingLabel.font = .systemFont(ofSize: 14)
+        loadingLabel.font = .systemFont(ofSize: 13)
         loadingLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        loadingStack = NSStackView(views: [loadingTitle, spinner, loadingLabel])
+        loadingStack.orientation = .vertical
+        loadingStack.alignment = .centerX
+        loadingStack.spacing = 16
+        loadingStack.translatesAutoresizingMaskIntoConstraints = false
 
         let container = NSView(frame: frame)
         container.autoresizingMask = [.width, .height]
         container.addSubview(webView)
-        container.addSubview(loadingLabel)
+        container.addSubview(loadingStack)
         NSLayoutConstraint.activate([
-            loadingLabel.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-            loadingLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-            loadingLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 520),
+            loadingStack.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            loadingStack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            loadingStack.widthAnchor.constraint(lessThanOrEqualToConstant: 560),
+            loadingLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 560),
         ])
         window.contentView = container
         window.makeKeyAndOrderFront(nil)
@@ -170,12 +203,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
         supervisor.start(
             onReady: { [weak self] url in
                 guard let self else { return }
+                self.spinner.stopAnimation(nil)
+                self.loadingStack.isHidden = true
                 self.webView.isHidden = false
-                self.loadingLabel.isHidden = true
                 self.webView.load(URLRequest(url: url))
             },
+            onProgress: { [weak self] message in
+                self?.loadingLabel.stringValue = message
+            },
             onFailure: { [weak self] message in
-                self?.loadingLabel.stringValue = "⚠️ \(message)\n\nSee Console.app → Hermes for details."
+                self?.spinner.stopAnimation(nil)
+                self?.loadingTitle.stringValue = "Couldn’t start Hermes"
+                self?.loadingLabel.stringValue = "⚠️ \(message)\nSee Console.app → Hermes for details."
             })
     }
 

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key>
+  <string>Hermes</string>
+  <key>CFBundleDisplayName</key>
+  <string>Hermes</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.nousresearch.hermes.webui</string>
+  <key>CFBundleVersion</key>
+  <string>__BUILD_VERSION__</string>
+  <key>CFBundleShortVersionString</key>
+  <string>__BUILD_VERSION__</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleExecutable</key>
+  <string>Hermes</string>
+  <key>CFBundleIconFile</key>
+  <string>AppIcon</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>12.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>NSPrincipalClass</key>
+  <string>NSApplication</string>
+  <!-- Local backend talks over http://127.0.0.1 — allow loopback cleartext. -->
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsLocalNetworking</key>
+    <true/>
+  </dict>
+</dict>
+</plist>

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -1,0 +1,67 @@
+# Hermes.app — macOS desktop packaging
+
+Wraps the Hermes WebUI in a native macOS window (`.app`) and ships it as a
+`.dmg`. The app owns the whole lifecycle: launching it starts the backend (and
+installs the Hermes agent on first run); **quitting it stops the frontend, the
+backend, and the Hermes agent** — nothing lingers.
+
+## Pieces
+
+| File | Role |
+|------|------|
+| `HermesApp/main.swift` | Native `WKWebView` window. Starts `supervisor.py`, shows a loading screen until it prints `HERMES-READY`, loads the local URL, and on quit tears the supervisor (and its whole process tree) down. |
+| `supervisor.py` | The lifecycle manager the app launches. Installs the agent on first run, starts the WebUI in its own process group, health-checks it, and on SIGTERM / parent-death stops the WebUI **and** any background `hermes gateway`. Includes a watchdog so a force-quit of the app still cleans up. |
+| `Info.plist` / `entitlements.plist` | Bundle metadata + hardened-runtime entitlements the bundled Python needs. |
+| `build.sh` | Fetches a relocatable CPython, assembles the bundle, compiles the Swift shell, optionally signs + notarizes, and builds the DMG. |
+
+## How "close → everything stops" works
+
+```
+Hermes.app (Swift)                    ⌘Q / close window / force-quit
+   └─ supervisor.py  ◄── SIGTERM ──┘   (or watchdog: getppid()==1)
+        └─ bootstrap.py / server.py    ← WebUI, runs the agent in-process
+             └─ agent + terminal subprocesses   (same process group)
+```
+
+On quit the app SIGTERMs the supervisor; the supervisor SIGTERMs the WebUI
+process group, runs `hermes gateway stop`, then SIGKILLs the group as a backstop.
+The WebUI runs the agent **in-process** (`from run_agent import AIAgent`), so
+stopping the WebUI stops the agent.
+
+## Build
+
+Prereqs: Xcode command-line tools, `create-dmg` (`brew install create-dmg`),
+network access (downloads CPython + installs the agent on first app launch).
+
+```bash
+cd packaging/macos
+
+# 1) Local test build (unsigned) — runs only on THIS Mac (Gatekeeper will warn).
+./build.sh
+
+# 2) Signed build for distribution to others.
+export SIGN_IDENTITY="Developer ID Application: bo wang (772APYS786)"
+./build.sh --sign
+
+# 3) Signed + notarized + stapled DMG (what you actually ship).
+#    One-time: store your notarization credentials in the keychain:
+xcrun notarytool store-credentials hermes-notary \
+  --apple-id YOUR_APPLE_ID --team-id 772APYS786 --password APP_SPECIFIC_PASSWORD
+export SIGN_IDENTITY="Developer ID Application: bo wang (772APYS786)"
+./build.sh --notarize          # uses keychain profile "hermes-notary"
+```
+
+Output: `build/Hermes.app` and `build/Hermes-<version>.dmg`.
+
+## Notes / gotchas
+
+- **The agent is NOT bundled** (its ML venv is multi-GB and arch-specific). The
+  app installs it on first launch via the official installer into `~/.hermes`.
+  First launch therefore needs internet and takes a few minutes.
+- **Notarization needs an Apple Developer account** ($99/yr) and an app-specific
+  password. Without notarization, other users get a Gatekeeper "damaged" warning.
+- **Architecture**: `build.sh` bundles CPython for the *host* arch. Build on an
+  Apple-Silicon Mac for an arm64 app; build on / for Intel separately, or extend
+  the script to assemble a universal Python if you need a single fat binary.
+- **App icon**: drop an `AppIcon.icns` in this folder before building to brand it.
+- `HERMES_PY_MINOR` (default `3.12`) selects the bundled CPython series.

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -39,17 +39,26 @@ cd packaging/macos
 # 1) Local test build (unsigned) — runs only on THIS Mac (Gatekeeper will warn).
 ./build.sh
 
-# 2) Signed build for distribution to others.
-export SIGN_IDENTITY="Developer ID Application: bo wang (772APYS786)"
-./build.sh --sign
+# 2) Universal (Intel + Apple Silicon) build — one DMG for everyone.
+./build.sh --universal
 
-# 3) Signed + notarized + stapled DMG (what you actually ship).
+# 3) Signed build for distribution to others.
+export SIGN_IDENTITY="Developer ID Application: bo wang (772APYS786)"
+./build.sh --universal --sign
+
+# 4) Signed + notarized + stapled DMG (what you actually ship).
 #    One-time: store your notarization credentials in the keychain:
 xcrun notarytool store-credentials hermes-notary \
   --apple-id YOUR_APPLE_ID --team-id 772APYS786 --password APP_SPECIFIC_PASSWORD
 export SIGN_IDENTITY="Developer ID Application: bo wang (772APYS786)"
-./build.sh --notarize          # uses keychain profile "hermes-notary"
+./build.sh --universal --notarize     # uses keychain profile "hermes-notary"
 ```
+
+`--universal` bundles one CPython per arch (`Resources/python-arm64` +
+`python-x86_64`) and a fat Swift binary; each native slice picks its matching
+Python at runtime. On an Apple-Silicon build host the x86_64 deps install via
+Rosetta (`softwareupdate --install-rosetta`), falling back to cross-resolved
+wheels if Rosetta is absent. Universal DMG ≈ 88 MB vs ≈ 55 MB single-arch.
 
 Output: `build/Hermes.app` and `build/Hermes-<version>.dmg`.
 
@@ -60,8 +69,8 @@ Output: `build/Hermes.app` and `build/Hermes-<version>.dmg`.
   First launch therefore needs internet and takes a few minutes.
 - **Notarization needs an Apple Developer account** ($99/yr) and an app-specific
   password. Without notarization, other users get a Gatekeeper "damaged" warning.
-- **Architecture**: `build.sh` bundles CPython for the *host* arch. Build on an
-  Apple-Silicon Mac for an arm64 app; build on / for Intel separately, or extend
-  the script to assemble a universal Python if you need a single fat binary.
+- **Architecture**: plain `build.sh` bundles CPython for the *host* arch only.
+  Use `--universal` to ship a single DMG that runs natively on both Apple Silicon
+  and Intel (bundles both Pythons + a fat Swift binary).
 - **App icon**: drop an `AppIcon.icns` in this folder before building to brand it.
 - `HERMES_PY_MINOR` (default `3.12`) selects the bundled CPython series.

--- a/packaging/macos/appicon.svg
+++ b/packaging/macos/appicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- Official Hermes Agent / Nous Research mark: white triangle on a black disc.
+       Matches hermes-agent.nousresearch.com favicon. Pure vector → crisp at any
+       icon size. -->
+  <circle cx="256" cy="256" r="256" fill="#000000"/>
+  <path d="M256 165 L368 352 L144 352 Z" fill="#FFFFFF" stroke="#FFFFFF"
+        stroke-width="10" stroke-linejoin="round"/>
+</svg>

--- a/packaging/macos/build.sh
+++ b/packaging/macos/build.sh
@@ -198,15 +198,36 @@ make_dmg() {
     "${DMG}" "${APP}" || hdiutil create -volname Hermes -srcfolder "${APP}" -ov -format UDZO "${DMG}"
 }
 
+# Submit to the notary service with retries — the multipart upload to Apple's
+# S3 bucket occasionally dies with a connectTimeout/abortedUpload mid-flight, and
+# that is worth retrying (a genuine rejection is rare once signing is correct and
+# will simply exhaust the retries). Each retry re-uploads from scratch.
+notarize() {  # $1 = path to submit (.zip or .dmg)
+  local target="$1" attempt
+  for attempt in 1 2 3; do
+    if xcrun notarytool submit "${target}" --keychain-profile "${NOTARY_PROFILE}" --wait; then
+      return 0
+    fi
+    say "Notary upload failed (attempt ${attempt}/3) — retrying in 20s…"
+    sleep 20
+  done
+  echo "Notarization failed after 3 attempts for $(basename "${target}")" >&2
+  return 1
+}
+
 if [ "${DO_NOTARIZE}" = 1 ]; then
-  make_dmg
-  say "Submitting DMG to Apple notary service (profile: ${NOTARY_PROFILE})…"
-  xcrun notarytool submit "${DMG}" --keychain-profile "${NOTARY_PROFILE}" --wait
-  say "Stapling tickets"
+  # 1) Notarize the .app itself, then staple it — so the app inside the shipped
+  #    DMG carries its own ticket and validates offline.
+  APPZIP="${BUILD_DIR}/Hermes-notarize.zip"
+  ditto -c -k --keepParent "${APP}" "${APPZIP}"
+  say "Submitting app to Apple notary service (profile: ${NOTARY_PROFILE})…"
+  notarize "${APPZIP}"
   xcrun stapler staple "${APP}"
-  xcrun stapler staple "${DMG}"
-  say "Re-building DMG with stapled app"
+  rm -f "${APPZIP}"
+  # 2) Build the DMG from the now-stapled app, then notarize + staple the DMG.
   make_dmg
+  say "Submitting DMG to Apple notary service…"
+  notarize "${DMG}"
   xcrun stapler staple "${DMG}"
 elif [ "${DO_SIGN}" = 1 ]; then
   make_dmg

--- a/packaging/macos/build.sh
+++ b/packaging/macos/build.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Build Hermes.app and (optionally) a signed, notarized DMG for distribution.
+#
+# Stages:
+#   1. Fetch a relocatable CPython (python-build-standalone) for the host arch.
+#   2. Stage the .app bundle: Swift shell binary + bundled Python + WebUI source.
+#   3. Install the WebUI's light deps into the bundled Python.
+#   4. Compile main.swift.
+#   5. (--sign)     codesign nested code then the app, hardened runtime.
+#   6. (--notarize) submit to Apple notary service, staple the ticket.
+#   7. Build a DMG with create-dmg.
+#
+# Usage:
+#   ./build.sh                      # unsigned local build (for testing on THIS Mac)
+#   ./build.sh --sign               # sign with Developer ID (set SIGN_IDENTITY)
+#   ./build.sh --sign --notarize    # sign + notarize + staple + DMG (for others)
+#
+# Required for --sign / --notarize:
+#   SIGN_IDENTITY  e.g. "Developer ID Application: bo wang (772APYS786)"
+#   NOTARY_PROFILE keychain profile created once via:
+#       xcrun notarytool store-credentials hermes-notary \
+#         --apple-id you@example.com --team-id 772APYS786 --password <app-specific-pw>
+#
+set -euo pipefail
+
+# ── Config ───────────────────────────────────────────────────────────────────
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/../.." && pwd)"
+BUILD_DIR="${HERE}/build"
+APP="${BUILD_DIR}/Hermes.app"
+PY_MINOR="${HERMES_PY_MINOR:-3.12}"            # CPython series to bundle
+ARCH="$(uname -m)"                             # arm64 | x86_64
+SIGN_IDENTITY="${SIGN_IDENTITY:-}"
+NOTARY_PROFILE="${NOTARY_PROFILE:-hermes-notary}"
+BUNDLE_ID="com.nousresearch.hermes.webui"
+VERSION="$(cd "${REPO_ROOT}" && git describe --tags --always 2>/dev/null || echo 0.0.0)"
+
+DO_SIGN=0; DO_NOTARIZE=0
+for a in "$@"; do
+  case "$a" in
+    --sign) DO_SIGN=1 ;;
+    --notarize) DO_SIGN=1; DO_NOTARIZE=1 ;;
+    *) echo "unknown arg: $a" >&2; exit 1 ;;
+  esac
+done
+
+say() { printf '\033[1;36m▶ %s\033[0m\n' "$*" >&2; }
+
+# ── 1. Fetch relocatable CPython ─────────────────────────────────────────────
+fetch_python() {
+  local cache="${HERE}/.python-cache"; mkdir -p "${cache}"
+  case "${ARCH}" in
+    arm64)  local pbs_arch="aarch64-apple-darwin" ;;
+    x86_64) local pbs_arch="x86_64-apple-darwin" ;;
+    *) echo "unsupported arch ${ARCH}" >&2; exit 1 ;;
+  esac
+  # Resolve the newest python-build-standalone asset for this series + arch.
+  say "Resolving python-build-standalone (${PY_MINOR}, ${pbs_arch})…"
+  local api="https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest"
+  local asset_url
+  # NB: GitHub URL-encodes the '+' in the version as %2B, so match either form.
+  asset_url="$(curl -fsSL "${api}" \
+    | grep -oE "https://[^\"]*cpython-${PY_MINOR}\.[0-9]+(%2B|\+)[0-9]+-${pbs_arch}-install_only\.tar\.gz" \
+    | head -1)"
+  [ -n "${asset_url}" ] || { echo "could not find a CPython ${PY_MINOR} ${pbs_arch} asset" >&2; exit 1; }
+  local tarball="${cache}/$(basename "${asset_url}")"
+  [ -f "${tarball}" ] || { say "Downloading ${asset_url##*/}"; curl -fsSL "${asset_url}" -o "${tarball}"; }
+  rm -rf "${cache}/python"
+  tar -xzf "${tarball}" -C "${cache}"   # extracts to ${cache}/python
+  echo "${cache}/python"
+}
+
+# ── 2-4. Stage bundle + compile ──────────────────────────────────────────────
+say "Cleaning ${BUILD_DIR}"
+rm -rf "${BUILD_DIR}"; mkdir -p "${APP}/Contents/MacOS" "${APP}/Contents/Resources"
+
+PY_SRC="$(fetch_python)"
+say "Bundling Python from ${PY_SRC}"
+cp -R "${PY_SRC}" "${APP}/Contents/Resources/python"
+PY_BIN="${APP}/Contents/Resources/python/bin/python3"
+
+say "Installing WebUI deps into bundled Python"
+"${PY_BIN}" -m pip install --upgrade pip >/dev/null
+"${PY_BIN}" -m pip install -r "${REPO_ROOT}/requirements.txt" >/dev/null
+
+say "Copying WebUI source into bundle"
+rsync -a --delete \
+  --exclude '.git' --exclude 'node_modules' --exclude '*.venv' --exclude 'venv' \
+  --exclude '__pycache__' --exclude 'packaging/macos/build' \
+  --exclude 'packaging/macos/.python-cache' \
+  "${REPO_ROOT}/" "${APP}/Contents/Resources/webui/"
+
+say "Compiling Swift shell"
+swiftc -O -o "${APP}/Contents/MacOS/Hermes" \
+  -framework AppKit -framework WebKit \
+  "${HERE}/HermesApp/main.swift"
+
+say "Writing Info.plist (version ${VERSION})"
+sed "s/__BUILD_VERSION__/${VERSION#v}/g" "${HERE}/Info.plist" > "${APP}/Contents/Info.plist"
+
+# Optional icon
+[ -f "${HERE}/AppIcon.icns" ] && cp "${HERE}/AppIcon.icns" "${APP}/Contents/Resources/AppIcon.icns"
+
+# ── 5. Sign ──────────────────────────────────────────────────────────────────
+if [ "${DO_SIGN}" = 1 ]; then
+  [ -n "${SIGN_IDENTITY}" ] || { echo "SIGN_IDENTITY is required for --sign" >&2; exit 1; }
+  local_ent="${HERE}/entitlements.plist"
+  say "Signing nested code (Python + dylibs)…"
+  # Sign every Mach-O inside the bundled Python first (deepest first), then the app.
+  find "${APP}/Contents/Resources/python" \( -name '*.dylib' -o -name '*.so' -o -perm -u+x -type f \) -print0 \
+    | while IFS= read -r -d '' f; do
+        if file "$f" | grep -q 'Mach-O'; then
+          codesign --force --timestamp --options runtime \
+            --entitlements "${local_ent}" -s "${SIGN_IDENTITY}" "$f" 2>/dev/null || true
+        fi
+      done
+  say "Signing app bundle…"
+  codesign --force --deep --timestamp --options runtime \
+    --entitlements "${local_ent}" -s "${SIGN_IDENTITY}" "${APP}"
+  codesign --verify --deep --strict --verbose=2 "${APP}"
+fi
+
+# ── 6. Notarize + staple ─────────────────────────────────────────────────────
+DMG="${BUILD_DIR}/Hermes-${VERSION#v}.dmg"
+make_dmg() {
+  say "Building DMG"
+  rm -f "${DMG}"
+  create-dmg \
+    --volname "Hermes" \
+    --window-size 540 380 \
+    --icon-size 110 \
+    --icon "Hermes.app" 150 180 \
+    --app-drop-link 390 180 \
+    --hide-extension "Hermes.app" \
+    "${DMG}" "${APP}" || hdiutil create -volname Hermes -srcfolder "${APP}" -ov -format UDZO "${DMG}"
+}
+
+if [ "${DO_NOTARIZE}" = 1 ]; then
+  make_dmg
+  say "Submitting DMG to Apple notary service (profile: ${NOTARY_PROFILE})…"
+  xcrun notarytool submit "${DMG}" --keychain-profile "${NOTARY_PROFILE}" --wait
+  say "Stapling tickets"
+  xcrun stapler staple "${APP}"
+  xcrun stapler staple "${DMG}"
+  say "Re-building DMG with stapled app"
+  make_dmg
+  xcrun stapler staple "${DMG}"
+elif [ "${DO_SIGN}" = 1 ]; then
+  make_dmg
+else
+  make_dmg
+fi
+
+say "Done → ${DMG}"
+say "App  → ${APP}"

--- a/packaging/macos/build.sh
+++ b/packaging/macos/build.sh
@@ -36,26 +36,28 @@ NOTARY_PROFILE="${NOTARY_PROFILE:-hermes-notary}"
 BUNDLE_ID="com.nousresearch.hermes.webui"
 VERSION="$(cd "${REPO_ROOT}" && git describe --tags --always 2>/dev/null || echo 0.0.0)"
 
-DO_SIGN=0; DO_NOTARIZE=0
+DO_SIGN=0; DO_NOTARIZE=0; UNIVERSAL=0
 for a in "$@"; do
   case "$a" in
     --sign) DO_SIGN=1 ;;
     --notarize) DO_SIGN=1; DO_NOTARIZE=1 ;;
+    --universal) UNIVERSAL=1 ;;
     *) echo "unknown arg: $a" >&2; exit 1 ;;
   esac
 done
 
+# Arches to bundle. A universal build ships both Pythons + a fat Swift binary so
+# one DMG runs natively on Apple Silicon and Intel; otherwise just the host arch.
+if [ "${UNIVERSAL}" = 1 ]; then ARCHES="arm64 x86_64"; else ARCHES="${ARCH}"; fi
+pbs_arch_of() { case "$1" in arm64) echo aarch64-apple-darwin ;; x86_64) echo x86_64-apple-darwin ;; esac; }
+swift_target_of() { case "$1" in arm64) echo arm64-apple-macosx12.0 ;; x86_64) echo x86_64-apple-macosx12.0 ;; esac; }
+
 say() { printf '\033[1;36m▶ %s\033[0m\n' "$*" >&2; }
 
-# ── 1. Fetch relocatable CPython ─────────────────────────────────────────────
-fetch_python() {
+# ── 1. Fetch relocatable CPython for a given arch ────────────────────────────
+fetch_python() {  # $1 = arch (arm64|x86_64) → prints extracted python dir
+  local arch="$1"; local pbs_arch; pbs_arch="$(pbs_arch_of "${arch}")"
   local cache="${HERE}/.python-cache"; mkdir -p "${cache}"
-  case "${ARCH}" in
-    arm64)  local pbs_arch="aarch64-apple-darwin" ;;
-    x86_64) local pbs_arch="x86_64-apple-darwin" ;;
-    *) echo "unsupported arch ${ARCH}" >&2; exit 1 ;;
-  esac
-  # Resolve the newest python-build-standalone asset for this series + arch.
   say "Resolving python-build-standalone (${PY_MINOR}, ${pbs_arch})…"
   local api="https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest"
   local asset_url
@@ -66,23 +68,44 @@ fetch_python() {
   [ -n "${asset_url}" ] || { echo "could not find a CPython ${PY_MINOR} ${pbs_arch} asset" >&2; exit 1; }
   local tarball="${cache}/$(basename "${asset_url}")"
   [ -f "${tarball}" ] || { say "Downloading ${asset_url##*/}"; curl -fsSL "${asset_url}" -o "${tarball}"; }
-  rm -rf "${cache}/python"
-  tar -xzf "${tarball}" -C "${cache}"   # extracts to ${cache}/python
-  echo "${cache}/python"
+  local out="${cache}/python-${arch}"
+  rm -rf "${out}"; mkdir -p "${out}"
+  tar -xzf "${tarball}" -C "${out}" --strip-components=1   # python/* → ${out}/*
+  echo "${out}"
+}
+
+# Install the WebUI's light deps into a bundled Python tree (host-arch runs it
+# directly; a foreign arch is installed via Rosetta, else cross-resolved wheels).
+install_deps() {  # $1 = python dir, $2 = arch
+  local pydir="$1"; local arch="$2"; local pybin="${pydir}/bin/python3"
+  if [ "${arch}" = "${ARCH}" ]; then
+    "${pybin}" -m pip install --upgrade pip >/dev/null
+    "${pybin}" -m pip install -r "${REPO_ROOT}/requirements.txt" >/dev/null
+  elif arch -"${arch}" /usr/bin/true 2>/dev/null; then
+    say "Installing deps for ${arch} via Rosetta"
+    arch -"${arch}" "${pybin}" -m pip install --upgrade pip >/dev/null
+    arch -"${arch}" "${pybin}" -m pip install -r "${REPO_ROOT}/requirements.txt" >/dev/null
+  else
+    say "Rosetta unavailable — cross-installing ${arch} wheels"
+    local sp="${pydir}/lib/python${PY_MINOR}/site-packages"
+    python3 -m pip install --only-binary=:all: --platform "macosx_11_0_${arch}" \
+      --implementation cp --python-version "${PY_MINOR}" --target "${sp}" \
+      -r "${REPO_ROOT}/requirements.txt" >/dev/null
+  fi
 }
 
 # ── 2-4. Stage bundle + compile ──────────────────────────────────────────────
 say "Cleaning ${BUILD_DIR}"
 rm -rf "${BUILD_DIR}"; mkdir -p "${APP}/Contents/MacOS" "${APP}/Contents/Resources"
 
-PY_SRC="$(fetch_python)"
-say "Bundling Python from ${PY_SRC}"
-cp -R "${PY_SRC}" "${APP}/Contents/Resources/python"
-PY_BIN="${APP}/Contents/Resources/python/bin/python3"
-
-say "Installing WebUI deps into bundled Python"
-"${PY_BIN}" -m pip install --upgrade pip >/dev/null
-"${PY_BIN}" -m pip install -r "${REPO_ROOT}/requirements.txt" >/dev/null
+for a in ${ARCHES}; do
+  PY_SRC="$(fetch_python "${a}")"
+  if [ "${UNIVERSAL}" = 1 ]; then dest="${APP}/Contents/Resources/python-${a}"; else dest="${APP}/Contents/Resources/python"; fi
+  say "Bundling Python (${a}) → $(basename "${dest}")"
+  cp -R "${PY_SRC}" "${dest}"
+  say "Installing WebUI deps into bundled Python (${a})"
+  install_deps "${dest}" "${a}"
+done
 
 say "Copying WebUI source into bundle"
 rsync -a --delete \
@@ -91,10 +114,20 @@ rsync -a --delete \
   --exclude 'packaging/macos/.python-cache' \
   "${REPO_ROOT}/" "${APP}/Contents/Resources/webui/"
 
-say "Compiling Swift shell"
-swiftc -O -o "${APP}/Contents/MacOS/Hermes" \
-  -framework AppKit -framework WebKit \
-  "${HERE}/HermesApp/main.swift"
+say "Compiling Swift shell (${ARCHES})"
+SWIFT_OUT="${APP}/Contents/MacOS/Hermes"
+if [ "${UNIVERSAL}" = 1 ]; then
+  slices=""
+  for a in ${ARCHES}; do
+    swiftc -O -target "$(swift_target_of "${a}")" -framework AppKit -framework WebKit \
+      -o "${BUILD_DIR}/Hermes.${a}" "${HERE}/HermesApp/main.swift"
+    slices="${slices} ${BUILD_DIR}/Hermes.${a}"
+  done
+  lipo -create -output "${SWIFT_OUT}" ${slices}
+  rm -f ${slices}
+else
+  swiftc -O -framework AppKit -framework WebKit -o "${SWIFT_OUT}" "${HERE}/HermesApp/main.swift"
+fi
 
 say "Writing Info.plist (version ${VERSION})"
 sed "s/__BUILD_VERSION__/${VERSION#v}/g" "${HERE}/Info.plist" > "${APP}/Contents/Info.plist"
@@ -135,8 +168,9 @@ if [ "${DO_SIGN}" = 1 ]; then
   [ -n "${SIGN_IDENTITY}" ] || { echo "SIGN_IDENTITY is required for --sign" >&2; exit 1; }
   local_ent="${HERE}/entitlements.plist"
   say "Signing nested code (Python + dylibs)…"
-  # Sign every Mach-O inside the bundled Python first (deepest first), then the app.
-  find "${APP}/Contents/Resources/python" \( -name '*.dylib' -o -name '*.so' -o -perm -u+x -type f \) -print0 \
+  # Sign every Mach-O inside the bundled Python(s) first, then the app. The glob
+  # covers both single-arch (python) and universal (python-arm64/python-x86_64).
+  find "${APP}/Contents/Resources/"python* \( -name '*.dylib' -o -name '*.so' -o -perm -u+x -type f \) -print0 \
     | while IFS= read -r -d '' f; do
         if file "$f" | grep -q 'Mach-O'; then
           codesign --force --timestamp --options runtime \

--- a/packaging/macos/build.sh
+++ b/packaging/macos/build.sh
@@ -99,8 +99,36 @@ swiftc -O -o "${APP}/Contents/MacOS/Hermes" \
 say "Writing Info.plist (version ${VERSION})"
 sed "s/__BUILD_VERSION__/${VERSION#v}/g" "${HERE}/Info.plist" > "${APP}/Contents/Info.plist"
 
-# Optional icon
-[ -f "${HERE}/AppIcon.icns" ] && cp "${HERE}/AppIcon.icns" "${APP}/Contents/Resources/AppIcon.icns"
+# App icon — generated from the Hermes brand mark (static/favicon-512.svg).
+build_icon() {
+  # Prefer the dedicated app-icon source (official Hermes/Nous mark); fall back
+  # to the WebUI brand favicon.
+  local svg="${HERE}/appicon.svg"
+  [ -f "${svg}" ] || svg="${REPO_ROOT}/static/favicon-512.svg"
+  local png="${REPO_ROOT}/static/favicon-512.png"
+  local iconset="${BUILD_DIR}/Hermes.iconset"
+  rm -rf "${iconset}"; mkdir -p "${iconset}"
+  # size:filename pairs the iconset format requires.
+  local specs="16:icon_16x16 32:icon_16x16@2x 32:icon_32x32 64:icon_32x32@2x \
+128:icon_128x128 256:icon_128x128@2x 256:icon_256x256 512:icon_256x256@2x \
+512:icon_512x512 1024:icon_512x512@2x"
+  for spec in ${specs}; do
+    local px="${spec%%:*}"; local name="${spec##*:}"
+    if command -v rsvg-convert >/dev/null 2>&1 && [ -f "${svg}" ]; then
+      rsvg-convert -w "${px}" -h "${px}" "${svg}" -o "${iconset}/${name}.png"
+    else  # fallback: rescale the 512 PNG (slight quality loss above 512)
+      sips -z "${px}" "${px}" "${png}" --out "${iconset}/${name}.png" >/dev/null 2>&1
+    fi
+  done
+  iconutil -c icns "${iconset}" -o "${APP}/Contents/Resources/AppIcon.icns"
+  rm -rf "${iconset}"
+}
+if [ -f "${REPO_ROOT}/static/favicon-512.svg" ] || [ -f "${REPO_ROOT}/static/favicon-512.png" ]; then
+  say "Generating AppIcon.icns from Hermes brand mark"
+  build_icon
+elif [ -f "${HERE}/AppIcon.icns" ]; then
+  cp "${HERE}/AppIcon.icns" "${APP}/Contents/Resources/AppIcon.icns"
+fi
 
 # ── 5. Sign ──────────────────────────────────────────────────────────────────
 if [ "${DO_SIGN}" = 1 ]; then

--- a/packaging/macos/entitlements.plist
+++ b/packaging/macos/entitlements.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- The bundled CPython JITs nothing but does map writable+executable pages
+       for some C extensions; these keep it runnable under the hardened runtime. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <!-- The agent's venv (installed at runtime into ~/.hermes) loads native .so
+       modules we did not sign; allow loading them. -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <!-- Python reads DYLD_*/PYTHONPATH-style env to locate its stdlib. -->
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+</dict>
+</plist>

--- a/packaging/macos/supervisor.py
+++ b/packaging/macos/supervisor.py
@@ -56,6 +56,38 @@ def log(msg: str) -> None:
     print(f"[supervisor] {msg}", flush=True)
 
 
+_last_progress = 0.0
+
+
+def progress(msg: str, *, force: bool = False) -> None:
+    """Emit a user-facing status line the native shell shows on the loading view.
+
+    Throttled to ~2/sec so streaming a noisy installer doesn't spam, except for
+    `force` phase markers which always go through.
+    """
+    global _last_progress
+    now = time.time()
+    if force or now - _last_progress > 0.45:
+        _last_progress = now
+        # One line only; the shell renders the latest as the status text.
+        print(f"HERMES-PROGRESS {msg.strip()[:160]}", flush=True)
+
+
+def _stream_subprocess(cmd: list[str], **popen_kwargs) -> int:
+    """Run a command, forwarding its output live as throttled progress lines."""
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, bufsize=1, **popen_kwargs,
+    )
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        line = line.rstrip()
+        if line:
+            log(line)             # full detail → Console.app
+            progress(line)        # latest line → loading screen
+    return proc.wait()
+
+
 def hermes_available() -> bool:
     if shutil.which("hermes"):
         return True
@@ -65,16 +97,22 @@ def hermes_available() -> bool:
 
 def ensure_agent_installed() -> None:
     """Run the official Hermes Agent installer when no agent is present."""
+    progress("Checking for Hermes agent…", force=True)
     if hermes_available():
         log("Hermes agent already present.")
         return
+    progress("Installing Hermes agent — first run downloads ~300 MB, "
+             "this can take several minutes…", force=True)
     log(f"Hermes agent not found — installing via {INSTALLER_URL}")
-    # The installer is interactive-friendly but works headless via `bash`.
-    subprocess.run(["/bin/bash", "-lc", f"curl -fsSL {INSTALLER_URL} | bash"], check=True)
+    # Stream the installer's output so the loading screen shows live progress.
+    rc = _stream_subprocess(["/bin/bash", "-lc", f"curl -fsSL {INSTALLER_URL} | bash"])
+    if rc != 0:
+        raise RuntimeError(f"agent installer exited with code {rc}")
     # Make the freshly-installed CLI reachable for this process and children.
     local_bin = str(Path.home() / ".local" / "bin")
     if local_bin not in os.environ.get("PATH", ""):
         os.environ["PATH"] = local_bin + os.pathsep + os.environ.get("PATH", "")
+    progress("Hermes agent installed.", force=True)
     log("Hermes agent install finished.")
 
 
@@ -174,8 +212,10 @@ def main() -> int:
         return 2
 
     global _child
+    progress("Starting Hermes backend…", force=True)
     _child = start_webui()
 
+    progress("Waiting for the server to come up…", force=True)
     if wait_for_health(time.time() + READY_TIMEOUT):
         print(f"HERMES-READY port={PORT} url=http://{HOST}:{PORT}", flush=True)
         log("WebUI is healthy.")

--- a/packaging/macos/supervisor.py
+++ b/packaging/macos/supervisor.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Hermes desktop supervisor.
+
+Single process the macOS .app launches and owns. It:
+
+  1. Makes sure the Hermes Agent is installed (runs the official installer on
+     first launch when `hermes` / the agent dir is missing).
+  2. Starts the WebUI server (which runs the agent in-process) as a child in
+     its OWN process group, so the whole tree can be torn down atomically.
+  3. Waits for the server's /health endpoint, then prints a machine-readable
+     ``HERMES-READY port=<n> url=<u>`` line on stdout so the native shell knows
+     when to load the page.
+  4. Blocks until it is asked to stop — via SIGTERM/SIGINT (sent by the app on
+     quit) OR via the watchdog (the app process dying / re-parenting to launchd).
+  5. On stop, shuts EVERYTHING down in order: graceful SIGTERM to the WebUI
+     process group, `hermes gateway stop` to reap any background gateway the
+     agent installer may have started, then SIGKILL as a backstop.
+
+The design goal is the user's requirement: closing the app reliably stops the
+frontend, the backend, AND the Hermes agent — with no lingering processes.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+# --- Configuration (overridable via environment) -----------------------------
+
+HOST = os.environ.get("HERMES_WEBUI_HOST", "127.0.0.1")
+PORT = int(os.environ.get("HERMES_WEBUI_PORT", "8787"))
+HEALTH_URL = f"http://{HOST}:{PORT}/health"
+READY_TIMEOUT = float(os.environ.get("HERMES_SUPERVISOR_READY_TIMEOUT", "240"))
+INSTALLER_URL = (
+    "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh"
+)
+
+# WebUI repo root. In a bundled .app this is .../Contents/Resources/webui; in a
+# dev checkout it is the repo containing this file (../../ from packaging/macos).
+WEBUI_DIR = Path(
+    os.environ.get("HERMES_WEBUI_DIR", "")
+    or (Path(__file__).resolve().parents[2])
+).resolve()
+
+_stop_requested = False
+_child: subprocess.Popen | None = None
+
+
+def log(msg: str) -> None:
+    print(f"[supervisor] {msg}", flush=True)
+
+
+def hermes_available() -> bool:
+    if shutil.which("hermes"):
+        return True
+    # The installer drops the CLI in ~/.local/bin which may not be on PATH yet.
+    return (Path.home() / ".local" / "bin" / "hermes").exists()
+
+
+def ensure_agent_installed() -> None:
+    """Run the official Hermes Agent installer when no agent is present."""
+    if hermes_available():
+        log("Hermes agent already present.")
+        return
+    log(f"Hermes agent not found — installing via {INSTALLER_URL}")
+    # The installer is interactive-friendly but works headless via `bash`.
+    subprocess.run(["/bin/bash", "-lc", f"curl -fsSL {INSTALLER_URL} | bash"], check=True)
+    # Make the freshly-installed CLI reachable for this process and children.
+    local_bin = str(Path.home() / ".local" / "bin")
+    if local_bin not in os.environ.get("PATH", ""):
+        os.environ["PATH"] = local_bin + os.pathsep + os.environ.get("PATH", "")
+    log("Hermes agent install finished.")
+
+
+def start_webui() -> subprocess.Popen:
+    """Start the WebUI server in its own process group (new session)."""
+    python_exe = os.environ.get("HERMES_WEBUI_PYTHON") or sys.executable
+    bootstrap = WEBUI_DIR / "bootstrap.py"
+    if not bootstrap.exists():
+        raise FileNotFoundError(f"bootstrap.py not found under {WEBUI_DIR}")
+    env = os.environ.copy()
+    env["HERMES_WEBUI_HOST"] = HOST
+    env["HERMES_WEBUI_PORT"] = str(PORT)
+    log(f"Starting WebUI: {python_exe} {bootstrap} (port {PORT})")
+    # --foreground keeps bootstrap attached as the running server; --no-browser
+    # because the native shell renders the UI itself. start_new_session=True puts
+    # the server + any agent/terminal subprocesses in one killable process group.
+    return subprocess.Popen(
+        [python_exe, str(bootstrap), "--no-browser", "--foreground",
+         "--host", HOST, str(PORT)],
+        cwd=str(WEBUI_DIR),
+        env=env,
+        start_new_session=True,
+    )
+
+
+def wait_for_health(deadline: float) -> bool:
+    while time.time() < deadline:
+        if _stop_requested:
+            return False
+        try:
+            with urllib.request.urlopen(HEALTH_URL, timeout=3) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(1.0)
+    return False
+
+
+def stop_everything() -> None:
+    """Tear down the WebUI process group and any background gateway."""
+    global _child
+    log("Shutting down…")
+
+    # 1) Graceful: SIGTERM the WebUI process group.
+    if _child and _child.poll() is None:
+        try:
+            pgid = os.getpgid(_child.pid)
+            os.killpg(pgid, signal.SIGTERM)
+            log(f"Sent SIGTERM to WebUI process group {pgid}")
+        except ProcessLookupError:
+            pass
+
+    # 2) Stop any background agent gateway the installer/agent may have started
+    #    (launchd-managed) so nothing Hermes lingers after the app quits.
+    if hermes_available():
+        hermes = shutil.which("hermes") or str(Path.home() / ".local" / "bin" / "hermes")
+        try:
+            subprocess.run([hermes, "gateway", "stop"], timeout=30,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            log("Requested `hermes gateway stop`.")
+        except Exception as exc:
+            log(f"gateway stop note: {exc}")
+
+    # 3) Give the WebUI up to 8s to exit, then SIGKILL the group as a backstop.
+    if _child:
+        for _ in range(80):
+            if _child.poll() is not None:
+                break
+            time.sleep(0.1)
+        if _child.poll() is None:
+            try:
+                os.killpg(os.getpgid(_child.pid), signal.SIGKILL)
+                log("Force-killed WebUI process group.")
+            except ProcessLookupError:
+                pass
+    log("Shutdown complete.")
+
+
+def _handle_signal(signum, _frame):
+    global _stop_requested
+    _stop_requested = True
+    log(f"Received signal {signum}.")
+
+
+def main() -> int:
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    parent_pid = os.getppid()  # the native app; if it dies we self-terminate
+    log(f"Supervisor up (pid={os.getpid()}, parent={parent_pid}, webui_dir={WEBUI_DIR})")
+
+    try:
+        ensure_agent_installed()
+    except Exception as exc:
+        log(f"Agent install failed: {exc}")
+        return 2
+
+    global _child
+    _child = start_webui()
+
+    if wait_for_health(time.time() + READY_TIMEOUT):
+        print(f"HERMES-READY port={PORT} url=http://{HOST}:{PORT}", flush=True)
+        log("WebUI is healthy.")
+    else:
+        if not _stop_requested:
+            log("WebUI did not become healthy in time.")
+            stop_everything()
+            return 3
+
+    # Main loop: exit when asked to stop, the WebUI dies, or the parent app dies.
+    while not _stop_requested:
+        if _child.poll() is not None:
+            log(f"WebUI exited (code={_child.returncode}); shutting down.")
+            break
+        if os.getppid() != parent_pid:  # watchdog: app was force-quit / re-parented
+            log("Parent app exited; shutting down.")
+            break
+        time.sleep(0.5)
+
+    stop_everything()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packaging/macos/supervisor.py
+++ b/packaging/macos/supervisor.py
@@ -22,13 +22,14 @@ frontend, the backend, AND the Hermes agent — with no lingering processes.
 
 from __future__ import annotations
 
+import http.client
 import os
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import time
-import urllib.request
 from pathlib import Path
 
 # --- Configuration (overridable via environment) -----------------------------
@@ -88,6 +89,24 @@ def _stream_subprocess(cmd: list[str], **popen_kwargs) -> int:
     return proc.wait()
 
 
+def _port_free(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind((HOST, port))
+            return True
+        except OSError:
+            return False
+
+
+def pick_port(start: int) -> int:
+    """Return the first free port at or above ``start`` (so a busy 8787 — e.g. a
+    leftover dev server — doesn't wedge first launch)."""
+    for p in range(start, start + 50):
+        if _port_free(p):
+            return p
+    return start
+
+
 def hermes_available() -> bool:
     if shutil.which("hermes"):
         return True
@@ -138,16 +157,34 @@ def start_webui() -> subprocess.Popen:
     )
 
 
+def _health_ok() -> bool:
+    """GET /health via http.client.
+
+    NB: do NOT use urllib.request here — the WebUI's HTTP server closes the
+    connection without a response for urllib's requests (works fine for
+    http.client, raw sockets, curl, and the WKWebView). urllib would make the
+    health check never succeed and wedge the app on "waiting for the server".
+    """
+    try:
+        conn = http.client.HTTPConnection(HOST, PORT, timeout=3)
+        conn.request("GET", "/health")
+        ok = conn.getresponse().status == 200
+        conn.close()
+        return ok
+    except Exception:
+        return False
+
+
 def wait_for_health(deadline: float) -> bool:
     while time.time() < deadline:
         if _stop_requested:
             return False
-        try:
-            with urllib.request.urlopen(HEALTH_URL, timeout=3) as resp:
-                if resp.status == 200:
-                    return True
-        except Exception:
-            pass
+        # Fail fast if the backend process died instead of polling for 4 minutes.
+        if _child is not None and _child.poll() is not None:
+            log(f"Backend exited early (code {_child.returncode}).")
+            return False
+        if _health_ok():
+            return True
         time.sleep(1.0)
     return False
 
@@ -211,6 +248,13 @@ def main() -> int:
         log(f"Agent install failed: {exc}")
         return 2
 
+    # Pick a free port so a busy 8787 (leftover dev server, another app) can't
+    # wedge launch. The shell loads whatever URL we report below, so the actual
+    # port doesn't matter to it.
+    global PORT, HEALTH_URL
+    PORT = pick_port(PORT)
+    HEALTH_URL = f"http://{HOST}:{PORT}/health"
+
     global _child
     progress("Starting Hermes backend…", force=True)
     _child = start_webui()
@@ -221,7 +265,13 @@ def main() -> int:
         log("WebUI is healthy.")
     else:
         if not _stop_requested:
-            log("WebUI did not become healthy in time.")
+            if _child.poll() is not None:
+                progress("Hermes backend failed to start — see Console.app → Hermes.",
+                         force=True)
+                log("WebUI process exited before becoming healthy.")
+            else:
+                progress("Hermes backend didn't respond in time.", force=True)
+                log("WebUI did not become healthy in time.")
             stop_everything()
             return 3
 


### PR DESCRIPTION
## What

Adds a native macOS desktop wrapper for the WebUI under `packaging/macos/`, plus
a build script that produces a signed, notarized, universal `.dmg`. All changes
are additive and self-contained — nothing outside `packaging/macos/` is touched.

The app wraps the WebUI in a native `WKWebView` window and **owns the whole
Hermes lifecycle**: launching it installs the agent on first run and starts the
backend; quitting it stops the frontend, backend, **and** the agent — no
lingering processes.

## Pieces

- **`supervisor.py`** — the lifecycle manager the app launches. Installs the
  agent if missing (official installer), starts the WebUI in its own process
  group, health-checks it, and on quit / parent-death stops the WebUI process
  group + `hermes gateway stop` + a SIGKILL backstop. Auto-selects a free port,
  fails fast if the backend dies, and streams first-run install progress.
- **`HermesApp/main.swift`** — native window shell. Shows a live progress screen
  (phases + streamed installer output) until the backend is healthy, then loads
  the local URL. Seamless titlebar that tracks the page's chrome colour.
- **`build.sh`** — fetches a relocatable CPython (per arch), assembles the
  bundle, compiles the Swift shell, generates the app icon, and optionally
  codesigns (Developer ID + hardened runtime), notarizes (with upload retries),
  staples, and builds the DMG via create-dmg. `--universal` ships one DMG for
  both Apple Silicon and Intel.
- `Info.plist`, `entitlements.plist`, `appicon.svg`, `README.md`, `.gitignore`.

## Notes

- The agent is **not** bundled (its venv is large and arch-specific); the app
  installs it on first launch into `~/.hermes`, with a live progress UI.
- Build/sign/notarize instructions and caveats are in
  `packaging/macos/README.md`.
- Verified end-to-end on Apple Silicon: universal build, Developer ID signing +
  notarization (`spctl: accepted`), and full-lifecycle teardown on quit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)