### PR TITLE
fix(updates): prevent startup crash on non-UTF-8 (GBK) locales

### DIFF
--- a/api/updates.py
+++ b/api/updates.py
@@ -166,9 +166,13 @@ def _run_git(args, cwd, timeout=10):
         r = subprocess.run(
             ['git'] + args, cwd=str(cwd), capture_output=True,
             text=True, timeout=timeout,
+            encoding='utf-8', errors='replace',
         )
-        stdout = r.stdout.strip()
-        stderr = r.stderr.strip()
+        # On non-UTF-8 locales (e.g. Chinese Windows GBK), a binary git
+        # output that fails to decode used to leave r.stdout = None and crash
+        # the whole import with AttributeError. Guard against None defensively.
+        stdout = (r.stdout or '').strip()
+        stderr = (r.stderr or '').strip()
         if r.returncode == 0:
             return stdout, True
         return stderr or stdout or f"git exited with status {r.returncode}", False


### PR DESCRIPTION
## Problem

On non-UTF-8 Windows locales (e.g. Chinese / GBK codepage), `server.py` crashes on startup before it can bind its port. The traceback:

```
File "api/updates.py", line 211, in _describe_git_version
    return out + _dirty_suffix(path, timeout=dirty_timeout)
File "api/updates.py", line 198, in _dirty_suffix
    diff, diff_ok = _run_git(['diff', '--binary', 'HEAD', '--'], path, timeout=timeout)
File "api/updates.py", line 170, in _run_git
    stdout = r.stdout.strip()
AttributeError: 'NoneType' object has no attribute 'strip'
```

preceded by, in the subprocess reader thread:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 851: illegal multibyte sequence
```

## Root cause

`_run_git()` calls `subprocess.run(..., text=True)` **without an explicit `encoding`**. With `text=True`, Python decodes the child's stdout using the locale preferred encoding, which on Chinese Windows is GBK. `_dirty_suffix()` runs `git diff --binary HEAD`, and the **binary** diff output contains bytes that are not valid GBK. The decode raises `UnicodeDecodeError` inside the stdout reader thread, leaving `r.stdout = None`. The subsequent `r.stdout.strip()` then raises `AttributeError`, which propagates out of the module-level `_detect_webui_version()` call during `import api.updates`, taking down the whole server.

It's intermittent/flaky because it only triggers when `git diff --binary` actually emits non-decodable bytes (depends on the working-tree contents), which makes it easy to misdiagnose as "something is killing the process."

## Fix

Force UTF-8 decoding with `errors='replace'` so git output always decodes, and defensively guard against `None` streams:

```python
r = subprocess.run(
    ['git'] + args, cwd=str(cwd), capture_output=True,
    text=True, timeout=timeout,
    encoding='utf-8', errors='replace',
)
stdout = (r.stdout or '').strip()
stderr = (r.stderr or '').strip()
```

This is safe on all platforms: git's text output is UTF-8, and the version digest already uses `errors='replace'`, so byte-exactness of the binary diff isn't required here.

## Testing

- Reproduced the crash on Chinese Windows (GBK locale): `server.py` exited during import, never binding the source `server.py` instance.
- After the fix: server starts and serves normally; `git describe` / dirty-suffix version detection works.

