### PR TITLE
Release v0.51.185 — Release FE (stage-batchE): clarify-card bug-fix batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## [Unreleased]
 
+## [v0.51.185] — 2026-05-31 — Release FE (stage-batchE — clarify-card bug-fix batch: identical-prompt dedup + autofill guard + GBK startup crash)
+
+### Fixed
+- The clarify popup could remain visible with stale input state after sending a response when the next queued clarification prompt was text-identical to the previous one. The dedupe signature now includes the prompt's `clarify_id`, so a newly queued identical prompt is treated as new instead of being mistaken for the one already answered (#3245, closes #3241).
+- Chrome's password manager could autofill the clarify-card input with saved credentials (typically a provider base URL), causing a phantom "Clarification closed" toast on every session completion and injecting the saved URL into the main composer. The clarify input now carries `autocomplete="off"` plus a `readonly` guard that is lifted only when an actual clarification prompt is shown (or on focus), so the browser's heuristic autofill skips it (#3247).
+- Prevent a server startup crash on non-UTF-8 Windows locales (e.g. Chinese GBK codepage): `_run_git()` now decodes git subprocess output as UTF-8 with `errors='replace'` and defensively guards against `None` streams, instead of letting a `UnicodeDecodeError` on binary `git diff --binary` output leave `stdout=None` and take down `import api.updates` with an `AttributeError` (#3249).
+
 ## [v0.51.184] — 2026-05-31 — Release FD (stage-batchD — raw audio upload mode + scroll-preserve + non-POSIX test skip)
 
 ### Added

--- a/api/updates.py
+++ b/api/updates.py
@@ -166,9 +166,13 @@ def _run_git(args, cwd, timeout=10):
         r = subprocess.run(
             ['git'] + args, cwd=str(cwd), capture_output=True,
             text=True, timeout=timeout,
+            encoding='utf-8', errors='replace',
         )
-        stdout = r.stdout.strip()
-        stderr = r.stderr.strip()
+        # On non-UTF-8 locales (e.g. Chinese Windows GBK), a binary git
+        # output that fails to decode used to leave r.stdout = None and crash
+        # the whole import with AttributeError. Guard against None defensively.
+        stdout = (r.stdout or '').strip()
+        stderr = (r.stderr or '').strip()
         if r.returncode == 0:
             return stdout, True
         return stderr or stdout or f"git exited with status {r.returncode}", False

--- a/static/index.html
+++ b/static/index.html
@@ -496,7 +496,7 @@
           <div class="clarify-question" id="clarifyQuestion"></div>
           <div class="clarify-choices" id="clarifyChoices"></div>
           <div class="clarify-response">
-            <input class="clarify-input" id="clarifyInput" type="text" data-i18n-placeholder="clarify_input_placeholder" placeholder="Type your response…">
+            <input class="clarify-input" id="clarifyInput" type="text" autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" data-i18n-placeholder="clarify_input_placeholder" placeholder="Type your response…">
             <button class="clarify-submit" id="clarifySubmit" onclick="respondClarify()" data-i18n="clarify_send">Send</button>
           </div>
           <div class="clarify-hint" id="clarifyHint" data-i18n="clarify_hint">Pick a choice, or type your own answer below.</div>

--- a/static/messages.js
+++ b/static/messages.js
@@ -2989,6 +2989,7 @@ function showClarifyCard(pending) {
     question,
     choices,
     sid: pending._session_id || (S.session && S.session.session_id) || null,
+    clarify_id: pending.clarify_id || null,
   });
   const card = _ensureClarifyCardDom();
   if (!card) return;

--- a/static/messages.js
+++ b/static/messages.js
@@ -2834,7 +2834,7 @@ function _ensureClarifyCardDom() {
       <div class="clarify-question" id="clarifyQuestion"></div>
       <div class="clarify-choices" id="clarifyChoices"></div>
       <div class="clarify-response">
-        <input class="clarify-input" id="clarifyInput" type="text" data-i18n-placeholder="clarify_input_placeholder" placeholder="Type your response…">
+        <input class="clarify-input" id="clarifyInput" type="text" autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" data-i18n-placeholder="clarify_input_placeholder" placeholder="Type your response…">
         <button class="clarify-submit" id="clarifySubmit" data-i18n="clarify_send">Send</button>
       </div>
       <div class="clarify-hint" id="clarifyHint" data-i18n="clarify_hint">Please choose one option, or type your own response below.</div>
@@ -3137,6 +3137,7 @@ function showClarifyCard(pending) {
   if (input) {
     if (!sameClarify) input.value = '';
     input.disabled = false;
+    input.removeAttribute('readonly');
     input.onkeydown = (e) => {
       if (e.key === 'Enter') {
         e.preventDefault();

--- a/tests/test_sprint30.py
+++ b/tests/test_sprint30.py
@@ -664,3 +664,5 @@ class TestClarifyCardTimerLogic:
         body = m.group(0)
         assert 'JSON.stringify' in body, 'showClarifyCard must compute a signature via JSON.stringify'
         assert '_clarifySignature' in body, 'showClarifyCard must check/set _clarifySignature'
+        assert 'clarify_id: pending.clarify_id || null' in body, \
+            'showClarifyCard signature must include clarify_id so a newly queued identical prompt is not mistaken for the previous one'


### PR DESCRIPTION
## Release v0.51.185 — Release FE (stage-batchE)

Clarify-card bug-fix batch — three small, isolated contributor fixes.

### Included PRs
- **#3245** (@andrewkangkr) — include `clarify_id` in the clarify-card dedupe signature so a newly queued text-identical prompt isn't mistaken for the previous one (closes #3241).
- **#3247** (@mysoul12138) — guard the clarify input against Chrome password-manager autofill (`autocomplete="off"` + `readonly`/`onfocus` lift), fixing the phantom "Clarification closed" toast and saved-URL injection into the composer.
- **#3249** (@allenliang2022) — prevent a server startup crash on non-UTF-8 (GBK) Windows locales by decoding git subprocess output as UTF-8 with `errors='replace'` and guarding `None` streams in `_run_git()`.

### Verification
- Full sequential suite: **7035 passed, 0 failed** (`pytest -p no:xdist`).
- Codex regression gate: **SAFE TO SHIP**.
- Opus advisor: **APPROVE**.
- Pre-Opus gate: `node -c`, ESLint runtime gate, `ast.parse`, merge-marker scan all clean.

Combined diff: 4 files, +12/-4.
