### PR TITLE
fix: resolve 564 ruff lint errors across Python source files

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -18,10 +18,8 @@ import queue
 import sys
 import threading
 import time
-import traceback
-import uuid
 from pathlib import Path
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 
 # ── Basic layout ──────────────────────────────────────────────────────────────
 HOME = Path.home()
@@ -430,7 +428,6 @@ DEFAULT_MODEL = os.getenv("HERMES_WEBUI_DEFAULT_MODEL", "")  # Empty = use provi
 def print_startup_config() -> None:
     """Print detected configuration at startup so the user can verify what was found."""
     ok = "\033[32m[ok]\033[0m"
-    warn = "\033[33m[!!]\033[0m"
     err = "\033[31m[XX]\033[0m"
 
     lines = [
@@ -1961,7 +1958,7 @@ _cache_build_in_progress = False  # True while a cold path is actively building
 # session is expensive (~10s for zai due to endpoint probing).  The credential pool
 # only changes when the user adds/removes credentials, which is rare; a 24h TTL
 # is plenty safe and ensures get_available_models() cold paths are fast.
-_CREDENTIAL_POOL_CACHE: dict[str, tuple[float, "CredentialPool"]] = {}  # pid -> (ts, pool)
+_CREDENTIAL_POOL_CACHE: dict[str, tuple[float, "CredentialPool"]] = {}  # pid -> (ts, pool)  # noqa: F821
 _provider_models_invalidated_ts: dict[str, float] = {}  # provider_id -> timestamp of last invalidation
 
 # Disk-backed in-memory cache for get_available_models().
@@ -2313,7 +2310,8 @@ def _get_label_for_model(model_id: str, existing_groups: list) -> str:
         lookup_id = lookup_id.split(":", 1)[1]
 
     # Check existing groups for a matching label
-    _norm = lambda s: (s.split("/", 1)[-1] if "/" in s else s).replace("-", ".").lower()
+    def _norm(s):
+        return (s.split("/", 1)[-1] if "/" in s else s).replace("-", ".").lower()
     norm_lookup = _norm(lookup_id)
     for g in existing_groups:
         for m in g.get("models", []):
@@ -3660,7 +3658,6 @@ SERVER_START_TIME = time.time()
 # LRU cache with size limit to prevent memory bloat.
 # All cache operations (get, set, move_to_end, popitem) are protected by
 # SESSION_AGENT_CACHE_LOCK for thread safety in multi-threaded ASGI servers.
-import collections
 SESSION_AGENT_CACHE: collections.OrderedDict = collections.OrderedDict()  # LRU cache
 SESSION_AGENT_CACHE_MAX = 50  # Maximum cached agents (each holds full conversation history)
 SESSION_AGENT_CACHE_LOCK = threading.Lock()

--- a/api/gateway_watcher.py
+++ b/api/gateway_watcher.py
@@ -9,7 +9,6 @@ This enables real-time session list updates in the sidebar without
 requiring any changes to hermes-agent.
 """
 import hashlib
-import json
 import logging
 import os
 import queue

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -5,7 +5,6 @@ import json as _json
 import os
 import re as _re
 from pathlib import Path
-from api.config import IMAGE_EXTS, MD_EXTS
 
 
 def require(body: dict, *fields) -> None:

--- a/api/models.py
+++ b/api/models.py
@@ -1,5 +1,4 @@
 """Hermes Web UI -- Session model and in-memory session store."""
-import collections
 import datetime
 import hashlib
 import json
@@ -11,7 +10,6 @@ import uuid
 from contextlib import closing
 from pathlib import Path
 
-import api.config as _cfg
 from api.config import (
     SESSION_DIR, SESSION_INDEX_FILE, SESSIONS, SESSIONS_MAX,
     LOCK, STREAMS, STREAMS_LOCK, DEFAULT_WORKSPACE, DEFAULT_MODEL, PROJECTS_FILE, HOME,
@@ -1054,15 +1052,18 @@ def all_sessions(diag=None):
     _diag_stage(diag, "all_sessions.full_scan")
     out = []
     for p in SESSION_DIR.glob('*.json'):
-        if p.name.startswith('_'): continue
+        if p.name.startswith('_'):
+            continue
         try:
             s = Session.load(p.stem)
-            if s: out.append(s)
+            if s:
+                out.append(s)
         except Exception:
             logger.debug("Failed to load session from %s", p)
     _diag_stage(diag, "all_sessions.full_scan_overlay")
     for s in SESSIONS.values():
-        if all(s.session_id != x.session_id for x in out): out.append(s)
+        if all(s.session_id != x.session_id for x in out):
+            out.append(s)
     _diag_stage(diag, "all_sessions.full_scan_sort_filter")
     out.sort(key=lambda s: (getattr(s, 'pinned', False), _session_sort_timestamp(s)), reverse=True)
     # Hide empty Untitled sessions from the UI entirely — kept consistent with the
@@ -1751,7 +1752,9 @@ def count_conversation_rounds(sid: str, since: float | None = None) -> int:
     int
         Number of complete conversation rounds.
     """
-    import os, sqlite3, datetime
+    import os
+    import sqlite3
+    import datetime
 
     try:
         from api.profiles import get_active_hermes_home

--- a/api/providers.py
+++ b/api/providers.py
@@ -22,7 +22,6 @@ from typing import Any
 from api.config import (
     _PROVIDER_DISPLAY,
     _PROVIDER_MODELS,
-    _get_label_for_model,
     _models_from_live_provider_ids,
     _read_live_provider_model_ids,
     _read_visible_codex_cache_model_ids,
@@ -234,7 +233,7 @@ def _write_env_file(env_path: Path, updates: dict[str, str | None]) -> None:
                 new_keys.append(f"{key}={clean}")
 
         # Remove deleted lines (None sentinels)
-        output_lines = [l for l in output_lines if l is not None]
+        output_lines = [ln for ln in output_lines if ln is not None]
 
         # Append new keys after a blank-line separator
         if new_keys:

--- a/api/rollback.py
+++ b/api/rollback.py
@@ -7,13 +7,12 @@ created by the Hermes agent's CheckpointManager.  Checkpoints live at
 """
 
 import hashlib
-import json
 import logging
 import os
 import re
 import shutil
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -237,7 +236,7 @@ def get_checkpoint_diff(workspace: str, checkpoint: str) -> dict[str, Any]:
             # File exists in checkpoint but not in workspace (deleted)
             files_changed.append({"file": rel_path, "status": "deleted"})
             diff_lines.append(f"--- a/{rel_path}")
-            diff_lines.append(f"+++ /dev/null")
+            diff_lines.append("+++ /dev/null")
             diff_lines.append("@@ -1,{lines} +0,0 @@".format(lines=len(ckpt_content.splitlines())))
             for line in ckpt_content.splitlines():
                 diff_lines.append(f"-{line}")

--- a/api/routes.py
+++ b/api/routes.py
@@ -14,11 +14,9 @@ import platform
 import shutil
 import sqlite3
 import subprocess
-import sys
 import threading
 import time
 import uuid
-import re
 from pathlib import Path
 from contextlib import closing
 from urllib.parse import parse_qs
@@ -670,8 +668,9 @@ def _run_cron_tracked(job, profile_home=None, execution_profile_home=None):
         _with_cron_home(profile_home, _persist_success)
     except Exception as e:
         logger.exception("Manual cron run failed for job %s", job_id)
+        err_msg = str(e)
         try:
-            _with_cron_home(profile_home, lambda: mark_job_run(job_id, False, str(e)))
+            _with_cron_home(profile_home, lambda: mark_job_run(job_id, False, err_msg))
         except Exception:
             logger.debug("Failed to mark manual cron run failure for %s", job_id)
     finally:
@@ -746,8 +745,7 @@ def _clear_live_models_cache() -> None:
     with _LIVE_MODELS_CACHE_LOCK:
         _LIVE_MODELS_CACHE.clear()
 
-from api.config import (
-    STATE_DIR,
+from api.config import (  # noqa: E402
     SESSION_DIR,
     DEFAULT_WORKSPACE,
     DEFAULT_MODEL,
@@ -756,16 +754,11 @@ from api.config import (
     LOCK,
     STREAMS,
     STREAMS_LOCK,
-    CANCEL_FLAGS,
     SERVER_START_TIME,
     _resolve_cli_toolsets,
     _INDEX_HTML_PATH,
     get_available_models,
-    IMAGE_EXTS,
-    MD_EXTS,
     MIME_MAP,
-    MAX_FILE_BYTES,
-    MAX_UPLOAD_BYTES,
     CHAT_LOCK,
     _get_session_agent_lock,
     SESSION_AGENT_LOCKS,
@@ -782,7 +775,7 @@ from api.config import (
     STREAM_GOAL_RELATED,
     PENDING_GOAL_CONTINUATION,
 )
-from api.helpers import (
+from api.helpers import (  # noqa: E402
     require,
     bad,
     safe_resolve,
@@ -794,9 +787,9 @@ from api.helpers import (
     redact_session_data,
     _redact_text,
 )
-from api.agent_health import build_agent_health_payload
-from api.request_diagnostics import RequestDiagnostics
-from api.system_health import build_system_health_payload
+from api.agent_health import build_agent_health_payload  # noqa: E402
+from api.request_diagnostics import RequestDiagnostics  # noqa: E402
+from api.system_health import build_system_health_payload  # noqa: E402
 
 
 def _kanban_unknown_endpoint(handler, parsed, method: str) -> bool:
@@ -915,7 +908,7 @@ def _clear_stale_stream_state(session) -> bool:
     return True
 
 # ── CSRF: validate Origin/Referer on POST ────────────────────────────────────
-import re as _re
+import re as _re  # noqa: E402
 
 
 def _normalize_host_port(value: str) -> tuple[str, str | None]:
@@ -1685,13 +1678,12 @@ def _keep_latest_messaging_session_per_source(sessions: list[dict]) -> list[dict
     return kept
 
 
-from api.models import (
+from api.models import (  # noqa: E402
     Session,
     get_session,
     new_session,
     all_sessions,
     title_from,
-    _write_session_index,
     SESSION_INDEX_FILE,
     _active_state_db_path,
     load_projects,
@@ -1702,7 +1694,7 @@ from api.models import (
     ensure_cron_project,
     is_cron_session,
 )
-from api.workspace import (
+from api.workspace import (  # noqa: E402
     load_workspaces,
     save_workspaces,
     get_last_workspace,
@@ -1710,28 +1702,26 @@ from api.workspace import (
     list_dir,
     list_workspace_suggestions,
     read_file_content,
-    safe_resolve_ws,
     resolve_trusted_workspace,
     validate_workspace_to_add,
     _is_blocked_system_path,
     _strip_surrounding_quotes,
-    _workspace_blocked_roots,
 )
-from api.upload import handle_upload, handle_upload_extract, handle_transcribe
-from api.streaming import (
+from api.upload import handle_upload, handle_upload_extract, handle_transcribe  # noqa: E402
+from api.streaming import (  # noqa: E402
     _sse,
     _run_agent_streaming,
     cancel_stream,
     _materialize_pending_user_turn_before_error,
 )
-from api.providers import get_providers, get_provider_quota, set_provider_key, remove_provider_key
-from api.onboarding import (
+from api.providers import get_providers, get_provider_quota, set_provider_key, remove_provider_key  # noqa: E402
+from api.onboarding import (  # noqa: E402
     apply_onboarding_setup,
     get_onboarding_status,
     complete_onboarding,
     probe_provider_endpoint,
 )
-from api.oauth import (
+from api.oauth import (  # noqa: E402
     cancel_onboarding_oauth_flow,
     poll_onboarding_oauth_flow,
     start_onboarding_oauth_flow,
@@ -1754,15 +1744,24 @@ try:
         is_session_yolo_enabled,
     )
 except ImportError:
-    _submit_pending_raw = lambda *a, **k: None
-    approve_session = lambda *a, **k: None
-    approve_permanent = lambda *a, **k: None
-    save_permanent_allowlist = lambda *a, **k: None
-    is_approved = lambda *a, **k: True
-    resolve_gateway_approval = lambda *a, **k: 0
-    enable_session_yolo = lambda *a, **k: None
-    disable_session_yolo = lambda *a, **k: None
-    is_session_yolo_enabled = lambda *a, **k: False
+    def _submit_pending_raw(*a, **k):
+        return None
+    def approve_session(*a, **k):
+        return None
+    def approve_permanent(*a, **k):
+        return None
+    def save_permanent_allowlist(*a, **k):
+        return None
+    def is_approved(*a, **k):
+        return True
+    def resolve_gateway_approval(*a, **k):
+        return 0
+    def enable_session_yolo(*a, **k):
+        return None
+    def disable_session_yolo(*a, **k):
+        return None
+    def is_session_yolo_enabled(*a, **k):
+        return False
     _pending = {}
     _lock = threading.Lock()
     _permanent_approved = set()
@@ -1870,10 +1869,13 @@ try:
         sse_unsubscribe as clarify_sse_unsubscribe,
     )
 except ImportError:
-    submit_clarify_pending = lambda *a, **k: None
-    get_clarify_pending = lambda *a, **k: None
+    def submit_clarify_pending(*a, **k):
+        return None
+    def get_clarify_pending(*a, **k):
+        return None
     clarify_sse_subscribe = None
-    resolve_clarify = lambda *a, **k: 0
+    def resolve_clarify(*a, **k):
+        return 0
 
 
 # ── Login page locale strings ─────────────────────────────────────────────────
@@ -8733,7 +8735,7 @@ def _handle_session_import(handler, body):
 
 
 # ── MCP Server helpers ──
-from api.config import get_config, _save_yaml_config_file, _get_config_path, reload_config
+from api.config import get_config, _save_yaml_config_file, _get_config_path, reload_config  # noqa: E402
 
 def _mask_secrets(obj):
     """Mask sensitive values in env vars and headers."""

--- a/api/startup.py
+++ b/api/startup.py
@@ -1,6 +1,9 @@
 """Hermes Web UI -- startup helpers."""
 from __future__ import annotations
-import os, stat, subprocess, sys
+import os
+import stat
+import subprocess
+import sys
 from pathlib import Path
 
 # Credential files that should never be world-readable

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8,7 +8,6 @@ import json
 import logging
 import mimetypes
 import os
-import queue
 import re
 import threading
 import time
@@ -19,19 +18,18 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-from api.config import (
+from api.config import (  # noqa: E402
     STREAMS, STREAMS_LOCK, CANCEL_FLAGS, AGENT_INSTANCES, STREAM_PARTIAL_TEXT,
     STREAM_REASONING_TEXT, STREAM_LIVE_TOOL_CALLS,
     STREAM_GOAL_RELATED, PENDING_GOAL_CONTINUATION,
-    LOCK, SESSIONS, SESSION_DIR,
-    _get_session_agent_lock, _set_thread_env, _clear_thread_env,
+    LOCK, SESSIONS, _get_session_agent_lock, _set_thread_env, _clear_thread_env,
     SESSION_AGENT_LOCKS, SESSION_AGENT_LOCKS_LOCK,
     resolve_model_provider,
     resolve_custom_provider_connection,
     model_with_provider_context,
 )
-from api.helpers import redact_session_data, _redact_text
-from api.metering import meter
+from api.helpers import redact_session_data, _redact_text  # noqa: E402
+from api.metering import meter  # noqa: E402
 
 # Global lock for os.environ writes. Per-session locks (_agent_lock) prevent
 # concurrent runs of the SAME session, but two DIFFERENT sessions can still
@@ -219,8 +217,7 @@ def _aiagent_import_error_detail() -> str:
     lines.append("")
     lines.append('  Full troubleshooting: docs/troubleshooting.md ("AIAgent not available")')
     return "\n".join(lines)
-from api.models import get_session, title_from
-from api.workspace import set_last_workspace
+from api.models import get_session, title_from  # noqa: E402
 
 # Fields that are safe to send to LLM provider APIs.
 # Everything else (attachments, timestamp, _ts, etc.) is display-only
@@ -3391,16 +3388,26 @@ def _run_agent_streaming(
                     logger.debug("Failed to unregister clarify callback")
             with _ENV_LOCK:
                 for _key, _old_value in old_profile_env.items():
-                    if _old_value is None: os.environ.pop(_key, None)
-                    else: os.environ[_key] = _old_value
-                if old_cwd is None: os.environ.pop('TERMINAL_CWD', None)
-                else: os.environ['TERMINAL_CWD'] = old_cwd
-                if old_exec_ask is None: os.environ.pop('HERMES_EXEC_ASK', None)
-                else: os.environ['HERMES_EXEC_ASK'] = old_exec_ask
-                if old_session_key is None: os.environ.pop('HERMES_SESSION_KEY', None)
-                else: os.environ['HERMES_SESSION_KEY'] = old_session_key
-                if old_hermes_home is None: os.environ.pop('HERMES_HOME', None)
-                else: os.environ['HERMES_HOME'] = old_hermes_home
+                    if _old_value is None:
+                        os.environ.pop(_key, None)
+                    else:
+                        os.environ[_key] = _old_value
+                if old_cwd is None:
+                    os.environ.pop('TERMINAL_CWD', None)
+                else:
+                    os.environ['TERMINAL_CWD'] = old_cwd
+                if old_exec_ask is None:
+                    os.environ.pop('HERMES_EXEC_ASK', None)
+                else:
+                    os.environ['HERMES_EXEC_ASK'] = old_exec_ask
+                if old_session_key is None:
+                    os.environ.pop('HERMES_SESSION_KEY', None)
+                else:
+                    os.environ['HERMES_SESSION_KEY'] = old_session_key
+                if old_hermes_home is None:
+                    os.environ.pop('HERMES_HOME', None)
+                else:
+                    os.environ['HERMES_HOME'] = old_hermes_home
 
     except Exception as e:
         print('[webui] stream error:\n' + traceback.format_exc(), flush=True)

--- a/api/upload.py
+++ b/api/upload.py
@@ -3,18 +3,18 @@ Hermes Web UI -- File upload: multipart parser and upload handler.
 """
 import mimetypes
 import re as _re
-import email.parser
 import tempfile
 from pathlib import Path
 
 from api.config import MAX_UPLOAD_BYTES
-from api.helpers import j, bad
+from api.helpers import j
 from api.models import get_session
 from api.workspace import safe_resolve_ws
 
 
 def parse_multipart(rfile, content_type, content_length) -> tuple:
-    import re as _re, email.parser as _ep
+    import re as _re
+    import email.parser as _ep
     m = _re.search(r'boundary=([^;\s]+)', content_type)
     if not m:
         raise ValueError('No boundary in Content-Type')
@@ -23,7 +23,7 @@ def parse_multipart(rfile, content_type, content_length) -> tuple:
     fields = {}
     files = {}
     delimiter = b'--' + boundary
-    end_marker = b'--' + boundary + b'--'
+    b'--' + boundary + b'--'
     parts = raw.split(delimiter)
     for part in parts[1:]:
         stripped = part.lstrip(b'\r\n')
@@ -107,7 +107,10 @@ def extract_archive(file_bytes: bytes, filename: str, workspace: Path):
     Returns a dict with ``extracted`` (int), ``files`` (list[str]).
     Raises ValueError on zip-slip or unsupported format.
     """
-    import zipfile, tarfile, io, os, shutil
+    import zipfile
+    import tarfile
+    import io
+    import shutil
 
     name = Path(filename).name
     stem = Path(filename).stem  # strip .zip / .tar.gz etc.
@@ -123,7 +126,8 @@ def extract_archive(file_bytes: bytes, filename: str, workspace: Path):
     dest_dir = safe_resolve_ws(workspace, stem)
     # Avoid overwriting existing files by appending a suffix
     if dest_dir.exists():
-        import string, random
+        import string
+        import random
         while dest_dir.exists():
             suffix = ''.join(random.choices(string.digits, k=3))
             dest_dir = dest_dir.with_name(stem + '_' + suffix)

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -17,11 +17,11 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-from api.config import (
+from api.config import (  # noqa: E402
     WORKSPACES_FILE as _GLOBAL_WS_FILE,
     LAST_WORKSPACE_FILE as _GLOBAL_LW_FILE,
     DEFAULT_WORKSPACE as _BOOT_DEFAULT_WORKSPACE,
-    MAX_FILE_BYTES, IMAGE_EXTS, MD_EXTS
+    MAX_FILE_BYTES
 )
 
 
@@ -783,9 +783,9 @@ def git_info_for_workspace(workspace: Path) -> dict:
         return int(r) if r and r.isdigit() else 0
     def _status():
         out = _run_git(['status', '--porcelain'], workspace) or ''
-        lines = [l for l in out.splitlines() if l]
-        modified = sum(1 for l in lines if len(l) >= 2 and (l[0] in 'MAR' or l[1] in 'MAR'))
-        untracked = sum(1 for l in lines if l.startswith('??'))
+        lines = [ln for ln in out.splitlines() if ln]
+        modified = sum(1 for ln in lines if len(ln) >= 2 and (ln[0] in 'MAR' or ln[1] in 'MAR'))
+        untracked = sum(1 for ln in lines if ln.startswith('??'))
         return len(lines), modified, untracked
     with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
         f_status = pool.submit(_status)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -51,12 +51,11 @@ _args, _unknown = _parser.parse_known_args()
 _profile_arg = _args.profile
 
 # ── Import webui canonical modules (after path setup) ─────────────────────
-import api.config as _cfg
-from api.config import (
-    STATE_DIR, SESSION_DIR, SESSION_INDEX_FILE, PROJECTS_FILE, HOME,
+from api.config import (  # noqa: E402
+    SESSION_DIR, SESSION_INDEX_FILE,
 )
-from api.models import load_projects, save_projects
-from api.profiles import get_active_profile_name, _is_root_profile, _profiles_match
+from api.models import load_projects, save_projects  # noqa: E402
+from api.profiles import get_active_profile_name, _profiles_match  # noqa: E402
 
 # ── Apply --profile override before any module uses get_active_profile_name
 if _profile_arg is not None:

--- a/server.py
+++ b/server.py
@@ -18,13 +18,13 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
-from api.auth import check_auth
-from api.config import HOST, PORT, STATE_DIR, SESSION_DIR, DEFAULT_WORKSPACE
-from api.helpers import j, get_profile_cookie
-from api.profiles import set_request_profile, clear_request_profile
-from api.routes import handle_delete, handle_get, handle_patch, handle_post
-from api.startup import auto_install_agent_deps, fix_credential_permissions
-from api.updates import WEBUI_VERSION
+from api.auth import check_auth  # noqa: E402
+from api.config import HOST, PORT, STATE_DIR, SESSION_DIR, DEFAULT_WORKSPACE  # noqa: E402
+from api.helpers import j, get_profile_cookie  # noqa: E402
+from api.profiles import set_request_profile, clear_request_profile  # noqa: E402
+from api.routes import handle_delete, handle_get, handle_patch, handle_post  # noqa: E402
+from api.startup import auto_install_agent_deps, fix_credential_permissions  # noqa: E402
+from api.updates import WEBUI_VERSION  # noqa: E402
 
 
 class QuietHTTPServer(ThreadingHTTPServer):
@@ -130,11 +130,12 @@ class Handler(BaseHTTPRequestHandler):
             set_request_profile(cookie_profile)
         try:
             parsed = urlparse(self.path)
-            if not check_auth(self, parsed): return
+            if not check_auth(self, parsed):
+                return
             result = handle_get(self, parsed)
             if result is False:
                 return j(self, {'error': 'not found'}, status=404)
-        except Exception as e:
+        except Exception:
             print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc(), flush=True)
             return j(self, {'error': 'Internal server error'}, status=500)
         finally:
@@ -148,11 +149,12 @@ class Handler(BaseHTTPRequestHandler):
             set_request_profile(cookie_profile)
         try:
             parsed = urlparse(self.path)
-            if not check_auth(self, parsed): return
+            if not check_auth(self, parsed):
+                return
             result = route_func(self, parsed)
             if result is False:
                 return j(self, {'error': 'not found'}, status=404)
-        except Exception as e:
+        except Exception:
             print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc(), flush=True)
             return j(self, {'error': 'Internal server error'}, status=500)
         finally:
@@ -231,7 +233,7 @@ def main() -> None:
     within_container = False
     # Check for the "/.within_container" file to determine if we're running inside a container; this file is created in the Dockerfile
     try:
-        with open('/.within_container', 'r') as f:
+        with open('/.within_container', 'r'):
             within_container = True
     except FileNotFoundError:
         pass
@@ -243,15 +245,15 @@ def main() -> None:
     from api.auth import is_auth_enabled
     if HOST not in ('127.0.0.1', '::1', 'localhost') and not is_auth_enabled():
         print(f'[!!] WARNING: Binding to {HOST} with NO PASSWORD SET.', flush=True)
-        print(f'     Anyone on the network can access your filesystem and agent.', flush=True)
-        print(f'     Set a password via Settings or HERMES_WEBUI_PASSWORD env var.', flush=True)
-        print(f'     To suppress: bind to 127.0.0.1 or set a password.', flush=True)
+        print('     Anyone on the network can access your filesystem and agent.', flush=True)
+        print('     Set a password via Settings or HERMES_WEBUI_PASSWORD env var.', flush=True)
+        print('     To suppress: bind to 127.0.0.1 or set a password.', flush=True)
         if within_container:
-            print(f'     Note: You are running within a container, must bind to 0.0.0.0 (IPv4) or :: (IPv6) to publish the port.', flush=True)
+            print('     Note: You are running within a container, must bind to 0.0.0.0 (IPv4) or :: (IPv6) to publish the port.', flush=True)
     elif not is_auth_enabled():
-        print(f'  [tip] No password set. Any process on this machine can read sessions', flush=True)
-        print(f'        and memory via the local API. Set HERMES_WEBUI_PASSWORD to', flush=True)
-        print(f'        enable authentication.', flush=True)
+        print('  [tip] No password set. Any process on this machine can read sessions', flush=True)
+        print('        and memory via the local API. Set HERMES_WEBUI_PASSWORD to', flush=True)
+        print('        enable authentication.', flush=True)
 
     ok, missing, errors = verify_hermes_imports()
     if not ok and _HERMES_FOUND:

--- a/tests/test_1038_pwa_auth_redirect.py
+++ b/tests/test_1038_pwa_auth_redirect.py
@@ -11,7 +11,6 @@ These are static regression tests that verify the JS source contains the
 correct guard patterns.
 """
 
-import re
 from pathlib import Path
 
 ROOT = Path(__file__).parent.parent

--- a/tests/test_1058_adaptive_title_refresh.py
+++ b/tests/test_1058_adaptive_title_refresh.py
@@ -10,8 +10,6 @@ Covers all five new functions added to api/streaming.py:
 import sys
 import os
 import threading
-import types
-import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -384,7 +382,6 @@ class TestMaybeScheduleTitleRefresh:
     def test_spawns_thread_at_exact_interval(self):
         """Refresh fires when exchange_count == refresh_interval."""
         with patch('api.streaming._get_title_refresh_interval', return_value=5):
-            spawned = []
             with patch('threading.Thread') as mock_thread_cls:
                 mock_thread = MagicMock()
                 mock_thread_cls.return_value = mock_thread

--- a/tests/test_1079_cron_session_project.py
+++ b/tests/test_1079_cron_session_project.py
@@ -2,12 +2,9 @@
 
 import json
 import pathlib
-import shutil
-import tempfile
 
 import pytest
 
-from tests.conftest import TEST_STATE_DIR, _post, TEST_BASE
 
 pytestmark = pytest.mark.usefixtures("test_server")
 

--- a/tests/test_1432_newchat_and_1423_profile_input.py
+++ b/tests/test_1432_newchat_and_1423_profile_input.py
@@ -117,6 +117,6 @@ class TestIssue1423ProfileFormAutocapitalize:
         html = self._profile_input_html('profileFormBaseUrl')
         assert html, "profileFormBaseUrl input not found"
         assert 'autocapitalize="none"' in html, \
-            f"profileFormBaseUrl missing autocapitalize=\"none\" (#1423)"
+            "profileFormBaseUrl missing autocapitalize=\"none\" (#1423)"
         assert 'spellcheck="false"' in html, \
-            f"profileFormBaseUrl missing spellcheck=\"false\" (#1423)"
+            "profileFormBaseUrl missing spellcheck=\"false\" (#1423)"

--- a/tests/test_1560_password_env_var_no_op.py
+++ b/tests/test_1560_password_env_var_no_op.py
@@ -20,7 +20,6 @@ the silent-no-op UX bug.
 
 import io
 import json
-import os
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -219,7 +218,7 @@ def test_post_set_password_settings_hash_unchanged_after_409(monkeypatch):
     monkeypatch.setenv("HERMES_WEBUI_PASSWORD", "shadow-pw")
 
     # Seed settings.json with a known sentinel hash so we can detect any write.
-    from api.config import load_settings, save_settings
+    from api.config import load_settings
     # Don't go through save_settings (it would re-route _set_password) — write
     # the file directly via the same path load_settings reads from.
     import api.config as cfg

--- a/tests/test_1695_aiagent_import_error_detail.py
+++ b/tests/test_1695_aiagent_import_error_detail.py
@@ -20,11 +20,9 @@ This test suite locks the diagnostic shape of the new error message:
 Behavioural test for the actual raise path lives in the streaming integration
 suite; this file only exercises the helper.
 """
-import os
 import sys
 from pathlib import Path
 
-import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_1710_folder_tooltip.py
+++ b/tests/test_1710_folder_tooltip.py
@@ -7,7 +7,6 @@ Folder rename is still reachable via the right-click context menu.
 """
 from pathlib import Path
 
-import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_1764_context_menu_essentials.py
+++ b/tests/test_1764_context_menu_essentials.py
@@ -230,11 +230,11 @@ class TestRevealFailedTostIncludesPath:
 # ════════════════════════════════════════════════════════════════════
 
 
-import json
-import pathlib
-import sys
-import urllib.error
-import urllib.request
+import json  # noqa: E402
+import pathlib  # noqa: E402
+import sys  # noqa: E402
+import urllib.error  # noqa: E402
+import urllib.request  # noqa: E402
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
 

--- a/tests/test_499_tts_playback.py
+++ b/tests/test_499_tts_playback.py
@@ -71,7 +71,7 @@ class TestTtsSpeakerButton:
         """ttsBtn must only be added for non-user (assistant) messages."""
         src = _read('ui.js')
         # Find the ttsBtn definition — it should have !isUser guard
-        tts_line = [l for l in src.splitlines() if 'msg-tts-btn' in l][0]
+        tts_line = [ln for ln in src.splitlines() if 'msg-tts-btn' in ln][0]
         assert '!isUser' in tts_line or 'isUser' in tts_line, \
             "TTS button should have user-check guard"
 
@@ -79,14 +79,14 @@ class TestTtsSpeakerButton:
         """ttsBtn must be included in the msg-actions span."""
         src = _read('ui.js')
         # The footHtml line should include ttsBtn
-        foot_lines = [l for l in src.splitlines() if 'footHtml' in l and 'msg-actions' in l]
-        assert any('ttsBtn' in l for l in foot_lines), \
+        foot_lines = [ln for ln in src.splitlines() if 'footHtml' in ln and 'msg-actions' in ln]
+        assert any('ttsBtn' in ln for ln in foot_lines), \
             "ttsBtn not included in footHtml msg-actions"
 
     def test_tts_button_uses_volume_icon(self):
         """Speaker button should use volume-2 icon."""
         src = _read('ui.js')
-        tts_line = [l for l in src.splitlines() if 'msg-tts-btn' in l][0]
+        tts_line = [ln for ln in src.splitlines() if 'msg-tts-btn' in ln][0]
         assert 'volume-2' in tts_line, \
             "TTS button should use volume-2 icon"
 

--- a/tests/test_745_code_block_newlines.py
+++ b/tests/test_745_code_block_newlines.py
@@ -6,9 +6,7 @@ Root cause: the paragraph-splitter in renderMd() replaced \n with <br> inside
 text. The fix stashes <pre> blocks (and pre-header divs, mermaid, katex) before
 the paragraph split and restores them afterwards.
 """
-import re
 import subprocess
-import sys
 import os
 
 UI_JS = os.path.join(os.path.dirname(__file__), '..', 'static', 'ui.js')
@@ -53,8 +51,8 @@ class TestCodeBlockNewlinePreservation:
         src = get_ui_js()
         # The map line must check for \x00E in its bypass condition
         map_line = next(
-            l for l in src.splitlines()
-            if 'parts.map' in l and '<br>' in l
+            ln for ln in src.splitlines()
+            if 'parts.map' in ln and '<br>' in ln
         )
         assert r'\x00E' in map_line or r'\x00[E' in map_line, (
             r"paragraph map must bypass \x00E stash tokens (literally or as "

--- a/tests/test_779_html_preview.py
+++ b/tests/test_779_html_preview.py
@@ -1,5 +1,4 @@
 """Tests for inline HTML preview in workspace panel (issue #779)."""
-import pytest
 
 
 def _get_routes_content():

--- a/tests/test_approval_queue.py
+++ b/tests/test_approval_queue.py
@@ -4,7 +4,6 @@ Previously _pending[sid] held one entry, so simultaneous approvals overwrote
 each other. This PR changes submit_pending() to append to a list and adds
 approval_id so /api/approval/respond can target a specific entry.
 """
-import json
 import pathlib
 import re
 import sys
@@ -120,7 +119,6 @@ def test_approval_counter_element_exists():
 
 def test_multiple_approvals_both_surfaced():
     """Two submit_pending calls must produce two queued entries, not one."""
-    import threading
     from api import routes as r
 
     # Reset state

--- a/tests/test_approval_sse.py
+++ b/tests/test_approval_sse.py
@@ -11,7 +11,6 @@ Verifies:
   - Frontend EventSource / fallback polling patterns
 """
 
-import json
 import pathlib
 import queue
 import re

--- a/tests/test_approval_unblock.py
+++ b/tests/test_approval_unblock.py
@@ -6,7 +6,6 @@ need to prevent the UI getting stuck in "Thinking…" during dangerous commands.
 """
 
 import json
-import threading
 import uuid
 import urllib.request
 import urllib.error
@@ -26,7 +25,6 @@ try:
         _gateway_notify_cbs,
         _lock,
         _ApprovalEntry,
-        submit_pending,
     )
     # has_pending and pop_pending were removed from tools.approval when the
     # agent renamed has_pending -> has_blocking_approval (gateway queue check)
@@ -41,7 +39,7 @@ pytestmark = pytest.mark.skipif(
     reason="tools.approval not available in this environment"
 )
 
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE  # noqa: E402
 
 
 def get(path):

--- a/tests/test_auth_session_persistence.py
+++ b/tests/test_auth_session_persistence.py
@@ -20,7 +20,7 @@ os.environ["HERMES_WEBUI_STATE_DIR"] = str(_TEST_STATE)
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-import api.auth as auth
+import api.auth as auth  # noqa: E402
 
 
 class TestSessionPersistence(unittest.TestCase):

--- a/tests/test_auth_sessions.py
+++ b/tests/test_auth_sessions.py
@@ -12,10 +12,10 @@ import os
 _TEST_STATE = Path(tempfile.mkdtemp())
 os.environ["HERMES_WEBUI_STATE_DIR"] = str(_TEST_STATE)
 
-import sys
+import sys  # noqa: E402
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-import importlib
+import importlib  # noqa: E402
 
 # Force re-import of auth module so it picks up our TEST_STATE_DIR
 auth = importlib.import_module("api.auth")

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -20,12 +20,9 @@ tracker until they resolve.
 """
 from __future__ import annotations
 
-import os
 import pathlib
 import sys
-import time
 import unittest
-from unittest.mock import patch
 
 
 # Ensure the repo root is importable without relying on CWD.

--- a/tests/test_blockquote_rendering.py
+++ b/tests/test_blockquote_rendering.py
@@ -19,7 +19,7 @@ UI_JS = (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text(en
 # Python mirror of the new blockquote rule + inlineMd (for behavioural tests)
 # ---------------------------------------------------------------------------
 
-import html as _html
+import html as _html  # noqa: E402
 
 
 def _esc(s):
@@ -47,8 +47,8 @@ def _apply_blockquote(s):
                 break
             lines.pop()
         processed = []
-        for l in lines:
-            stripped = re.sub(r"^>[ \t]?", "", l)
+        for ln in lines:
+            stripped = re.sub(r"^>[ \t]?", "", ln)
             if stripped.strip() == "":
                 processed.append("<br>")
             else:

--- a/tests/test_bootstrap_dotenv.py
+++ b/tests/test_bootstrap_dotenv.py
@@ -18,11 +18,9 @@ Covers:
   10. Structural: loader is called before DEFAULT_HOST/DEFAULT_PORT
 """
 import os
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 REPO_ROOT = Path(__file__).parent.parent
 

--- a/tests/test_bootstrap_foreground.py
+++ b/tests/test_bootstrap_foreground.py
@@ -58,7 +58,6 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_byok_model_dropdown.py
+++ b/tests/test_byok_model_dropdown.py
@@ -219,7 +219,6 @@ class TestLiveModelsCustomProviderFallback:
             return True
         monkeypatch.setattr(r, "j", fake_j)
 
-        from urllib.parse import urlparse
         parsed = mock.MagicMock()
         parsed.query = "provider=custom"
 

--- a/tests/test_cancel_interrupt.py
+++ b/tests/test_cancel_interrupt.py
@@ -2,7 +2,6 @@
 Unit tests for cancel/interrupt functionality.
 Tests the integration between cancel_stream() and agent.interrupt().
 """
-import pytest
 import queue
 import threading
 from unittest.mock import Mock

--- a/tests/test_clarify_sse.py
+++ b/tests/test_clarify_sse.py
@@ -9,7 +9,6 @@ Covers:
 import os
 import queue
 import threading
-import textwrap
 
 import pytest
 
@@ -142,7 +141,7 @@ class TestClarifySSEUnit:
 
     def test_multiple_subscribers_same_session(self, clarify_mod):
         q1 = clarify_mod.sse_subscribe("s1")
-        q2 = clarify_mod.sse_subscribe("s1")
+        clarify_mod.sse_subscribe("s1")
         assert len(clarify_mod._clarify_sse_subscribers["s1"]) == 2
         clarify_mod.sse_unsubscribe("s1", q1)
         assert len(clarify_mod._clarify_sse_subscribers["s1"]) == 1

--- a/tests/test_cmd_idle_fallback.py
+++ b/tests/test_cmd_idle_fallback.py
@@ -8,7 +8,6 @@ fall through to a direct send() call, matching CLI behaviour:
   - /interrupt msg → send when idle, cancel+requeue when busy+streaming
   - /steer msg  → send when idle, inject mid-turn when busy+streaming
 """
-import re
 import pathlib
 
 COMMANDS_JS = (pathlib.Path(__file__).parent.parent / "static" / "commands.js").read_text(encoding="utf-8")

--- a/tests/test_commands_endpoint.py
+++ b/tests/test_commands_endpoint.py
@@ -2,7 +2,6 @@
 import json
 import urllib.request
 
-import pytest
 
 from tests.conftest import TEST_BASE, requires_agent_modules
 

--- a/tests/test_cron_no_agent_edit.py
+++ b/tests/test_cron_no_agent_edit.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_cron_run_job_import.py
+++ b/tests/test_cron_run_job_import.py
@@ -6,7 +6,6 @@ Before the fix, run_job was only imported inside _handle_cron_run
 (a local scope invisible to _run_cron_tracked), causing NameError.
 """
 import ast
-import inspect
 from pathlib import Path
 
 import pytest
@@ -38,7 +37,7 @@ class TestRunCronTrackedImport:
             def visit_Name(self, node):
                 names_used.add(node.id)
 
-        ImportCollector = type(
+        type(
             "ImportCollector",
             (ast.NodeVisitor,),
             {

--- a/tests/test_css_tooltips.py
+++ b/tests/test_css_tooltips.py
@@ -458,7 +458,7 @@ class RailTooltipCascadeTests(unittest.TestCase):
         )
         self.assertEqual(
             missing, [],
-            f"Rail buttons without working tooltip markup:\n  " +
+            "Rail buttons without working tooltip markup:\n  " +
             "\n  ".join(f"{reason}: {attrs}" for reason, attrs in missing),
         )
 

--- a/tests/test_custom_providers_in_panel.py
+++ b/tests/test_custom_providers_in_panel.py
@@ -4,14 +4,11 @@ Verifies that config.yaml custom_providers entries (e.g. glmcode, timicc)
 are surfaced in the /api/providers response alongside built-in providers.
 """
 
-import json
-import os
 import sys
 import types
 
 import api.config as config
 import api.profiles as profiles
-from tests._pytest_port import BASE
 
 
 def _install_fake_hermes_cli(monkeypatch):

--- a/tests/test_default_workspace_fallback.py
+++ b/tests/test_default_workspace_fallback.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 import api.config as config
 
@@ -52,7 +51,8 @@ def test_resolve_default_workspace_creates_home_workspace_when_missing(monkeypat
 
 def test_resolve_default_workspace_raises_when_all_candidates_fail(monkeypatch, tmp_path):
     """RuntimeError is raised when every candidate is unwritable."""
-    import stat, pytest
+    import stat
+    import pytest
     # Make tmp_path read-only so mkdir inside it fails
     tmp_path.chmod(stat.S_IRUSR | stat.S_IXUSR)
     state_dir = tmp_path / "state"

--- a/tests/test_empty_session_no_disk_write.py
+++ b/tests/test_empty_session_no_disk_write.py
@@ -19,14 +19,12 @@ session is lost. There were no messages to lose, so this is an explicit
 trade-off documented in ``new_session``'s docstring.
 """
 import json
-import time
 
 import pytest
 
 import api.models as models
 from api.models import (
     SESSIONS,
-    Session,
     all_sessions,
     get_session,
     new_session,

--- a/tests/test_excalidraw_inline_embed.py
+++ b/tests/test_excalidraw_inline_embed.py
@@ -1,5 +1,4 @@
 """Test: Excalidraw inline embed (#479)"""
-import re
 
 
 def test_excalidraw_extension_regex():

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -10,7 +10,6 @@ Tests are ordered TDD-style:
   6. Settings UI has renamed label
 """
 import json
-import os
 import pathlib
 import sqlite3
 import time
@@ -18,7 +17,7 @@ import urllib.error
 import urllib.request
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE  # noqa: E402
 
 
 def get(path):
@@ -1519,7 +1518,7 @@ def test_gateway_session_messages_readable():
 
         post('/api/settings', {'show_cli_sessions': True})
 
-        data, status = get(f'/api/session?session_id=gw_read_001')
+        data, status = get('/api/session?session_id=gw_read_001')
         assert status == 200
         msgs = data.get('session', {}).get('messages', [])
         assert len(msgs) >= 2, f"Expected at least 2 messages, got {len(msgs)}"
@@ -1872,10 +1871,10 @@ def test_cli_sessions_still_work():
 # These replace the deleted repo-root test_gateway_sse_probe_unit.py and account
 # for the watcher_alive check (thread existence + is_alive()).
 
-import sys
-import threading
+import sys  # noqa: E402
+import threading  # noqa: E402
 sys.path.insert(0, str(REPO_ROOT))
-from api.routes import _gateway_sse_probe_payload
+from api.routes import _gateway_sse_probe_payload  # noqa: E402
 
 
 def test_probe_payload_when_disabled():
@@ -1919,7 +1918,6 @@ def test_probe_payload_when_watcher_thread_alive():
     t.start()
     w._thread = t
     # Thread may finish fast — loop-start a live daemon thread for reliability
-    import time as _time
     done = threading.Event()
     live = threading.Thread(target=done.wait, daemon=True)
     live.start()

--- a/tests/test_goal_command_webui.py
+++ b/tests/test_goal_command_webui.py
@@ -1,11 +1,7 @@
 """Regression tests for first-class WebUI /goal command parity."""
 
-import io
-import json
 from pathlib import Path
-from types import SimpleNamespace
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 COMMANDS_JS = (REPO_ROOT / "static" / "commands.js").read_text(encoding="utf-8")

--- a/tests/test_ime_composition.py
+++ b/tests/test_ime_composition.py
@@ -28,7 +28,7 @@ def _ime_guarded_enter_pattern(event_var_pattern, require_no_shift=False):
     return (
         rf"if\s*\(\s*{event_var_pattern}\.key\s*===\s*'Enter'{no_shift}\s*\)\s*\{{\s*"
         + guard +
-        rf"(?:\{{\s*return\s*;?\s*\}}|return\s*;?)"
+        r"(?:\{\s*return\s*;?\s*\}|return\s*;?)"
     )
 
 

--- a/tests/test_issue1095_pasted_images.py
+++ b/tests/test_issue1095_pasted_images.py
@@ -5,7 +5,6 @@ Bug 2: Chat history renders uploaded images as broken <img> (wrong endpoint / de
 """
 import os
 import re
-import pytest
 
 
 def _read_js(name):

--- a/tests/test_issue1105_ssrf_custom_providers.py
+++ b/tests/test_issue1105_ssrf_custom_providers.py
@@ -5,8 +5,6 @@ hardcoded allowlist. This fix extracts hostnames from custom_providers config
 and adds them to the trusted set, so user-explicitly configured local endpoints
 (ollama, llama.cpp, vLLM, TabbyAPI, etc.) are not blocked.
 """
-import os
-import pytest
 
 
 # ---------- Source-code analysis tests ----------

--- a/tests/test_issue1106_custom_providers_models.py
+++ b/tests/test_issue1106_custom_providers_models.py
@@ -1,5 +1,4 @@
 """Tests for #1106 — custom_providers[].models dict keys populate model dropdown."""
-import pytest
 import api.config as config
 
 

--- a/tests/test_issue1139_password_remote.py
+++ b/tests/test_issue1139_password_remote.py
@@ -5,7 +5,6 @@ Users in Settings > System could type a new password but had no way to submit it
 Disable Auth and Sign Out buttons existed but Save was missing.
 """
 
-import pytest
 
 
 def test_system_pane_has_save_button():

--- a/tests/test_issue1140_cron_badge_per_job.py
+++ b/tests/test_issue1140_cron_badge_per_job.py
@@ -8,7 +8,6 @@ Verifies that:
 5. _renderCronDetail() adds has-new-run class to Last Output card
 """
 
-import pytest
 
 # ── Static file tests (no server needed) ──
 

--- a/tests/test_issue1144_session_time_sync.py
+++ b/tests/test_issue1144_session_time_sync.py
@@ -18,7 +18,6 @@ import subprocess
 import textwrap
 import time
 
-import pytest
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")

--- a/tests/test_issue1195_session_profile_routing.py
+++ b/tests/test_issue1195_session_profile_routing.py
@@ -1,8 +1,6 @@
 """Tests for issue #1195: sessions must route to the correct profile directory
 even when that profile directory does not exist yet on disk."""
 
-import os
-import tempfile
 from pathlib import Path
 from unittest.mock import patch
 

--- a/tests/test_issue1202_oauth_provider_status.py
+++ b/tests/test_issue1202_oauth_provider_status.py
@@ -14,11 +14,10 @@ Fixes:
   5. static/i18n.js: new i18n keys for config_yaml and not_configured hints
 """
 
-import re
 import sys
 import types
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 REPO_ROOT = Path(__file__).parent.parent.resolve()
 
@@ -173,7 +172,8 @@ class TestBuildProviderCardJs:
         assert idx != -1, "_buildProviderCard not found in panels.js"
         depth = 0
         for i, ch in enumerate(self.JS[idx:], idx):
-            if ch == "{": depth += 1
+            if ch == "{":
+                depth += 1
             elif ch == "}":
                 depth -= 1
                 if depth == 0:

--- a/tests/test_issue1298_cancel_and_activity.py
+++ b/tests/test_issue1298_cancel_and_activity.py
@@ -19,7 +19,6 @@ import pytest
 
 import api.config as config
 import api.models as models
-import api.streaming as streaming
 from api.models import Session
 from api.streaming import cancel_stream
 

--- a/tests/test_issue1361_cancel_data_loss.py
+++ b/tests/test_issue1361_cancel_data_loss.py
@@ -15,15 +15,13 @@ All three fix the same "tokens-paid-for-data-loss" class of bug.
 
 import pathlib
 import queue
-import re
 import threading
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
 import api.config as config
 import api.models as models
-import api.streaming as streaming
 from api.models import Session
 from api.streaming import cancel_stream
 
@@ -118,7 +116,7 @@ class TestCancelPreservesReasoningText:
         """Cancel during reasoning phase (no visible tokens) should persist reasoning."""
         sid = "test_1361_a1"
         stream_id = "stream_a1"
-        s = _make_session(session_id=sid)
+        _make_session(session_id=sid)
         _setup_cancel_state(sid, stream_id)
 
         # Simulate: reasoning was accumulated but no visible tokens
@@ -143,7 +141,7 @@ class TestCancelPreservesReasoningText:
         """Cancel mid-stream with both reasoning and some visible tokens."""
         sid = "test_1361_a2"
         stream_id = "stream_a2"
-        s = _make_session(session_id=sid)
+        _make_session(session_id=sid)
         _setup_cancel_state(sid, stream_id)
 
         reasoning = "Let me analyze the code..."
@@ -167,7 +165,7 @@ class TestCancelPreservesReasoningText:
         """If STREAM_REASONING_TEXT doesn't exist yet (pre-fix), cancel still works."""
         sid = "test_1361_a3"
         stream_id = "stream_a3"
-        s = _make_session(session_id=sid)
+        _make_session(session_id=sid)
         _setup_cancel_state(sid, stream_id)
 
         config.STREAM_PARTIAL_TEXT[stream_id] = "Some partial text"
@@ -198,7 +196,7 @@ class TestCancelPreservesToolCalls:
         """Cancel after tool execution should preserve the tool call info."""
         sid = "test_1361_b1"
         stream_id = "stream_b1"
-        s = _make_session(session_id=sid)
+        _make_session(session_id=sid)
         _setup_cancel_state(sid, stream_id)
 
         config.STREAM_PARTIAL_TEXT[stream_id] = ""
@@ -221,7 +219,7 @@ class TestCancelPreservesToolCalls:
         """Cancel after tools + partial text should keep both."""
         sid = "test_1361_b2"
         stream_id = "stream_b2"
-        s = _make_session(session_id=sid)
+        _make_session(session_id=sid)
         _setup_cancel_state(sid, stream_id)
 
         config.STREAM_PARTIAL_TEXT[stream_id] = "Here's what I found:"
@@ -255,7 +253,7 @@ class TestCancelWithReasoningOnlyNoText:
         """Cancel after reasoning-only output should still create a partial msg."""
         sid = "test_1361_c1"
         stream_id = "stream_c1"
-        s = _make_session(session_id=sid)
+        _make_session(session_id=sid)
         _setup_cancel_state(sid, stream_id)
 
         # Only reasoning, no visible tokens at all
@@ -277,7 +275,7 @@ class TestCancelWithReasoningOnlyNoText:
         """Cancel after tool-only output (no text, no reasoning) should still create a partial msg."""
         sid = "test_1361_c2"
         stream_id = "stream_c2"
-        s = _make_session(session_id=sid)
+        _make_session(session_id=sid)
         _setup_cancel_state(sid, stream_id)
 
         config.STREAM_PARTIAL_TEXT[stream_id] = ""
@@ -299,7 +297,7 @@ class TestCancelWithReasoningOnlyNoText:
         """Cancel with no reasoning and no tools and no text = only cancel marker (no change)."""
         sid = "test_1361_c3"
         stream_id = "stream_c3"
-        s = _make_session(session_id=sid)
+        _make_session(session_id=sid)
         _setup_cancel_state(sid, stream_id)
 
         config.STREAM_PARTIAL_TEXT[stream_id] = ""

--- a/tests/test_issue1384_local_provider.py
+++ b/tests/test_issue1384_local_provider.py
@@ -26,7 +26,6 @@ healed automatically:
 import re
 from pathlib import Path
 
-import pytest
 
 import api.config as cfg
 

--- a/tests/test_issue1436_context_indicator_load_path.py
+++ b/tests/test_issue1436_context_indicator_load_path.py
@@ -28,7 +28,6 @@ Reported by @AvidFuturist in Discord (May 1 2026, "the 100 comes up way too
 often").  Confirmed live on the dev server: 23 of 75 sessions had
 `context_length=0` + `input_tokens > 128K`, all rendering >100%.
 """
-import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlparse

--- a/tests/test_issue1438_fence_anchoring.py
+++ b/tests/test_issue1438_fence_anchoring.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import pytest
 
 from tests.test_sprint16 import render_md  # Python mirror of renderMd()
 

--- a/tests/test_issue1499_keyless_onboarding.py
+++ b/tests/test_issue1499_keyless_onboarding.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import sys
 import types
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_issue1500_lmstudio_env_var_alignment.py
+++ b/tests/test_issue1500_lmstudio_env_var_alignment.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import sys
 import types
-from pathlib import Path
 
 import api.config as config
 import api.profiles as profiles

--- a/tests/test_issue1511_dedup_shared_reference.py
+++ b/tests/test_issue1511_dedup_shared_reference.py
@@ -147,7 +147,6 @@ def test_get_models_grouped_unconfigured_providers_get_independent_dicts(monkeyp
     A regression of the deepcopy() removal causes the `is not` assertion
     to flip immediately.
     """
-    import importlib
 
     import api.config as cfg_mod
 

--- a/tests/test_issue1539_provider_removal_dropdown_invalidation.py
+++ b/tests/test_issue1539_provider_removal_dropdown_invalidation.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import pytest
 
 
 REPO = Path(__file__).resolve().parent.parent

--- a/tests/test_issue1579_whats_new_link_404.py
+++ b/tests/test_issue1579_whats_new_link_404.py
@@ -16,7 +16,6 @@ Fix:
   suppresses the link rather than emitting a known-broken URL.
 """
 
-import os
 import re
 import subprocess
 import sys
@@ -239,7 +238,7 @@ def test_reporter_url_shape_no_longer_produces_invalid_compare_url(tmp_path):
     base_sha = _short_sha(repo, 'HEAD~2')  # the merge-base
 
     # The compare URL the JS would build
-    cur, latest = result['current_sha'], result['latest_sha']
+    cur, _latest = result['current_sha'], result['latest_sha']
     # In a real run repo_url is converted from origin's URL; in this test the
     # value will be a file:// path, but that's fine — what we care about is
     # the cur and latest shas.

--- a/tests/test_issue1612_renamed_root_profile.py
+++ b/tests/test_issue1612_renamed_root_profile.py
@@ -11,9 +11,6 @@ Fix: centralize the "is this the root?" check in `_is_root_profile(name)`
 and replace each scattered `if name == 'default':` with it.
 """
 
-import os
-from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_issue1614_project_profile_filtering.py
+++ b/tests/test_issue1614_project_profile_filtering.py
@@ -17,7 +17,6 @@ Fix:
 import json
 import threading
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -226,7 +225,6 @@ def test_profile_field_on_project_dict_default_create(monkeypatch):
     instead we pin the file-level invariant: the create handler now stamps
     `profile` on the created dict.
     """
-    from pathlib import Path
     src = (Path(__file__).parent.parent / 'api' / 'routes.py').read_text(encoding='utf-8')
 
     # The create handler must now include get_active_profile_name() for the new dict
@@ -241,7 +239,6 @@ def test_profile_field_on_project_dict_default_create(monkeypatch):
 
 def test_project_rename_rejects_cross_profile():
     """Source-string check that rename's active-profile guard is in place."""
-    from pathlib import Path
     src = (Path(__file__).parent.parent / 'api' / 'routes.py').read_text(encoding='utf-8')
 
     rename_idx = src.find('"/api/projects/rename"')
@@ -254,7 +251,6 @@ def test_project_rename_rejects_cross_profile():
 
 
 def test_project_delete_rejects_cross_profile():
-    from pathlib import Path
     src = (Path(__file__).parent.parent / 'api' / 'routes.py').read_text(encoding='utf-8')
 
     delete_idx = src.find('"/api/projects/delete"')
@@ -267,7 +263,6 @@ def test_project_delete_rejects_cross_profile():
 
 def test_session_move_rejects_cross_profile_project():
     """/api/session/move must refuse moves into a project from another profile."""
-    from pathlib import Path
     src = (Path(__file__).parent.parent / 'api' / 'routes.py').read_text(encoding='utf-8')
 
     move_idx = src.find('"/api/session/move"')

--- a/tests/test_issue1618_yaml_json_diff_newline_preserve.py
+++ b/tests/test_issue1618_yaml_json_diff_newline_preserve.py
@@ -293,7 +293,7 @@ def test_yaml_block_renders_multiline_html_shape(driver_path):
 
     pre_inner = _extract_pre_inner(out)
     # Split on \n to count rendered lines. Empty trailing line tolerated.
-    rendered_lines = [l for l in pre_inner.split("\n") if l.strip()]
+    rendered_lines = [ln for ln in pre_inner.split("\n") if ln.strip()]
 
     assert len(rendered_lines) == 5, (
         f"YAML block should preserve 5 lines, got {len(rendered_lines)}: {rendered_lines}.  "

--- a/tests/test_issue1624_repair_stale_pending_grace.py
+++ b/tests/test_issue1624_repair_stale_pending_grace.py
@@ -15,10 +15,7 @@ treated as "old enough" to preserve current legacy-data recovery semantics.
 """
 
 import time
-import threading
-from unittest.mock import patch
 
-import pytest
 
 
 # ── _repair_stale_pending grace guard ───────────────────────────────────
@@ -110,7 +107,7 @@ def test_repair_fires_when_pending_started_at_missing(tmp_path, monkeypatch):
 def test_repair_fires_when_pending_started_at_zero(tmp_path, monkeypatch):
     """Falsy 0 must also be treated as 'old enough' (defense against accidental zeroing)."""
     import api.models as models
-    calls = _setup_repair_environment(monkeypatch, tmp_path)
+    _setup_repair_environment(monkeypatch, tmp_path)
 
     s = _FakeSession(pending_started_at=0)
     result = models._repair_stale_pending(s)
@@ -120,7 +117,7 @@ def test_repair_fires_when_pending_started_at_zero(tmp_path, monkeypatch):
 def test_repair_fires_when_pending_started_at_garbage(tmp_path, monkeypatch):
     """Garbage values (string, dict, etc.) shouldn't crash and shouldn't block repair."""
     import api.models as models
-    calls = _setup_repair_environment(monkeypatch, tmp_path)
+    _setup_repair_environment(monkeypatch, tmp_path)
 
     s = _FakeSession(pending_started_at="not-a-number")
     result = models._repair_stale_pending(s)

--- a/tests/test_issue1633_models_cache_version_stamp.py
+++ b/tests/test_issue1633_models_cache_version_stamp.py
@@ -14,8 +14,6 @@ the cache on the very next /api/models call instead of lingering for 24h.
 
 import json
 import sys
-import tempfile
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_issue1823_kanban_not_found.py
+++ b/tests/test_issue1823_kanban_not_found.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import io
 import json
 import pytest
-from types import SimpleNamespace
 from urllib.parse import urlparse
 
 from api import routes

--- a/tests/test_issue342.py
+++ b/tests/test_issue342.py
@@ -5,7 +5,6 @@ These are structural tests that verify the fix is present in static/ui.js
 without requiring a running server or JavaScript engine.
 """
 import os
-import re
 
 UI_JS = os.path.join(os.path.dirname(__file__), '..', 'static', 'ui.js')
 

--- a/tests/test_issue347.py
+++ b/tests/test_issue347.py
@@ -204,7 +204,7 @@ def test_katex_throw_on_error_false():
 def test_render_katex_blocks_wired_into_raf():
     """renderKatexBlocks() must be called in the same requestAnimationFrame as renderMermaidBlocks()."""
     # Check that renderKatexBlocks appears somewhere near requestAnimationFrame
-    raf_idx = UI_JS.find('requestAnimationFrame')
+    UI_JS.find('requestAnimationFrame')
     # Find the rAF call that also contains renderKatexBlocks
     has_katex_in_raf = any(
         'renderKatexBlocks' in UI_JS[m.start():m.start()+200]

--- a/tests/test_issue357.py
+++ b/tests/test_issue357.py
@@ -64,7 +64,7 @@ class TestDockerfileUvPreinstall:
         which the hermeswebui user at runtime can't see.
         """
         lines = DOCKERFILE.splitlines()
-        uv_line_idx = next(i for i, l in enumerate(lines) if "uv/install.sh" in l)
+        uv_line_idx = next(i for i, ln in enumerate(lines) if "uv/install.sh" in ln)
         # Find the last USER directive before the uv install line
         user_before = None
         for i in range(uv_line_idx - 1, -1, -1):

--- a/tests/test_issue467_yolo_mode_toggle.py
+++ b/tests/test_issue467_yolo_mode_toggle.py
@@ -12,7 +12,6 @@ Covers:
 import os
 import re
 import json
-import pathlib
 import pytest
 
 from tests.conftest import requires_agent_modules
@@ -21,7 +20,8 @@ TEST_BASE = f"http://127.0.0.1:{os.environ.get('HERMES_WEBUI_TEST_PORT', '8788')
 
 
 def _get(path, expect_ok=True):
-    import urllib.request, urllib.error
+    import urllib.request
+    import urllib.error
     try:
         with urllib.request.urlopen(TEST_BASE + path, timeout=10) as r:
             return json.loads(r.read())
@@ -36,7 +36,8 @@ def _get(path, expect_ok=True):
 
 
 def _post(path, body=None, expect_ok=True):
-    import urllib.request, urllib.error
+    import urllib.request
+    import urllib.error
     data = json.dumps(body or {}).encode()
     req = urllib.request.Request(
         TEST_BASE + path, data=data, headers={"Content-Type": "application/json"}

--- a/tests/test_issue470.py
+++ b/tests/test_issue470.py
@@ -240,7 +240,6 @@ def test_link_not_broken_by_prior_autolink():
 def test_href_quote_sanitized():
     """A URL containing a double-quote must have it percent-encoded in href to prevent attribute breakout."""
     # This would break out of href="..." and inject an event handler without the fix
-    url = 'https://evil.com" onmouseover="alert(1)'
     # The [label](url) regex captures up to the closing ), so we test via the render helper
     # by constructing a URL that contains a literal quote character
     safe_url = 'https://example.com/path"with"quotes'

--- a/tests/test_issue483_inline_diff_viewer.py
+++ b/tests/test_issue483_inline_diff_viewer.py
@@ -1,5 +1,4 @@
 """Tests for issue #483 — inline diff/patch viewer."""
-import pytest
 
 
 class TestFencedDiffRenderer:

--- a/tests/test_issue484_json_tree_viewer.py
+++ b/tests/test_issue484_json_tree_viewer.py
@@ -1,5 +1,4 @@
 """Tests for issue #484 — collapsible JSON/YAML tree viewer."""
-import pytest
 
 
 class TestTreeRenderer:

--- a/tests/test_issue487b.py
+++ b/tests/test_issue487b.py
@@ -28,7 +28,7 @@ def test_al_stash_includes_img_tags():
 
 # ── Behaviour tests (Python mirror of fixed pipeline) ─────────────────────────
 
-import html as _html
+import html as _html  # noqa: E402
 def esc(s): return _html.escape(str(s), quote=True)
 
 SAFE_TAGS = re.compile(

--- a/tests/test_issue492_workspace_reorder.py
+++ b/tests/test_issue492_workspace_reorder.py
@@ -1,6 +1,5 @@
 """Tests for issue #492 — workspace drag-to-reorder."""
-import json, pytest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 from api.routes import _handle_workspace_reorder
 
 

--- a/tests/test_issue538_mcp_management.py
+++ b/tests/test_issue538_mcp_management.py
@@ -1,6 +1,6 @@
 """Tests for issue #538 — MCP server management API."""
-import json, pytest
-from unittest.mock import patch, MagicMock, call
+import json
+from unittest.mock import patch, MagicMock
 from api.routes import (
     _handle_mcp_servers_list,
     _handle_mcp_server_update,

--- a/tests/test_issue569_579.py
+++ b/tests/test_issue569_579.py
@@ -8,7 +8,6 @@ Tests for fixes:
          in a gated detailed-density mode by #673.
 """
 import pathlib
-import re
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 INIT_SH   = (REPO_ROOT / "docker_init.bash").read_text(encoding="utf-8")

--- a/tests/test_issue570_permission.py
+++ b/tests/test_issue570_permission.py
@@ -8,7 +8,6 @@ load_settings() must treat that as "file not accessible = use defaults" rather
 than propagating the exception up to crash the request handler.
 """
 import stat
-import pytest
 import api.config as config
 
 

--- a/tests/test_issue572.py
+++ b/tests/test_issue572.py
@@ -17,13 +17,11 @@ Covers:
 """
 from __future__ import annotations
 
-import os
 import pathlib
 import sys
 import types
 from unittest import mock
 
-import pytest
 
 
 def _inject_hermes_cli_auth(get_auth_status_return):
@@ -96,7 +94,7 @@ class TestProviderApiKeyPresentFallback:
 
     def test_supported_provider_still_works_without_fallback(self):
         """openrouter with env key must still succeed via the original path."""
-        from api.onboarding import _provider_api_key_present, _SUPPORTED_PROVIDER_SETUPS
+        from api.onboarding import _provider_api_key_present
         env_values = {"OPENROUTER_API_KEY": "sk-test"}
         result = _provider_api_key_present("openrouter", {}, env_values)
         assert result is True

--- a/tests/test_issue603_provider_categories.py
+++ b/tests/test_issue603_provider_categories.py
@@ -11,8 +11,8 @@ Validates:
   - Fallback when categories are empty
 """
 
-import pytest
-import sys, os
+import sys
+import os
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -203,7 +203,7 @@ class TestApplyBaseURL:
     def test_requires_base_url_writes_user_url(self, tmp_path, monkeypatch):
         """Providers with requires_base_url=True should write user-provided base_url."""
         config_path = str(tmp_path / "config.yaml")
-        env_path = str(tmp_path / ".env")
+        str(tmp_path / ".env")
 
         monkeypatch.setattr("api.onboarding._get_config_path", lambda: config_path)
         monkeypatch.setattr("api.onboarding._get_active_hermes_home", lambda: tmp_path)

--- a/tests/test_issue607.py
+++ b/tests/test_issue607.py
@@ -1,7 +1,5 @@
 """Tests for PR #648 — Gemma 4 thinking token stripping (closes #607)."""
-import re
 import pathlib
-import pytest
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue609.py
+++ b/tests/test_issue609.py
@@ -11,7 +11,6 @@ Two independent bugs were fixed:
      Docker volume mount outside the user's home directory.  Any path under
      the boot-time default should be trusted automatically.
 """
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_issue634.py
+++ b/tests/test_issue634.py
@@ -11,7 +11,6 @@ Fixes:
 2. Exception path: log a warning instead of silently returning [].
 """
 import pathlib
-import re
 
 MODELS_PY = pathlib.Path(__file__).parent.parent / 'api' / 'models.py'
 AGENT_SESSIONS_PY = pathlib.Path(__file__).parent.parent / 'api' / 'agent_sessions.py'

--- a/tests/test_issue644.py
+++ b/tests/test_issue644.py
@@ -59,10 +59,10 @@ class TestConfigYamlModelsLoading:
             },
         }
         result = _available_models_with_cfg(cfg)
-        groups = {g["provider"]: g["models"] for g in result["groups"]}
+        {g["provider"]: g["models"] for g in result["groups"]}
         # Provider should appear (previously it was silently skipped)
         provider_names = [g["provider"] for g in result["groups"]]
-        found = any("my-custom-llm" in n.lower() or "My-Custom-Llm" in n for n in provider_names)
+        any("my-custom-llm" in n.lower() or "My-Custom-Llm" in n for n in provider_names)
         # If it appears, its models must include our cfg models
         for g in result["groups"]:
             if "custom" in g["provider"].lower():

--- a/tests/test_issue646.py
+++ b/tests/test_issue646.py
@@ -1,5 +1,4 @@
 """Tests for PR #649 — empty DEFAULT_MODEL does not inject blank model entries."""
-import pytest
 from api import config as cfg
 
 

--- a/tests/test_issue673.py
+++ b/tests/test_issue673.py
@@ -14,7 +14,6 @@ Covers:
 
 import json
 import pathlib
-import re
 import unittest
 import urllib.error
 import urllib.request
@@ -28,7 +27,7 @@ SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
 I18N_JS = (REPO_ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
 
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE  # noqa: E402
 
 
 def _get(path):

--- a/tests/test_issue739_652_653.py
+++ b/tests/test_issue739_652_653.py
@@ -6,7 +6,6 @@ Tests for streaming error handling fixes:
 
 All static tests (no live server required).
 """
-import ast
 import re
 import pathlib
 

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -200,7 +200,7 @@ class TestPeriodicCheckpoint:
 
     def test_checkpoint_stops_on_signal(self):
         """Checkpoint thread exits cleanly when stop event is set."""
-        s = _make_session("ckpt3")
+        _make_session("ckpt3")
         stop_event = threading.Event()
         iterations = [0]
 

--- a/tests/test_issue789.py
+++ b/tests/test_issue789.py
@@ -189,9 +189,9 @@ def test_titled_session_with_no_messages_old_is_visible():
 def test_mixed_sessions_correct_visibility():
     """With a mix of sessions, only sessions with messages OR titled sessions
     are surfaced (#1171). Both new and old Untitled+empty sessions are hidden."""
-    new_ghost = _make_untitled_session(age_seconds=5, session_id="new_ghost")
-    old_ghost = _make_untitled_session(age_seconds=200, session_id="old_ghost")
-    real_session = _make_titled_session(age_seconds=500, session_id="real_session")
+    _make_untitled_session(age_seconds=5, session_id="new_ghost")
+    _make_untitled_session(age_seconds=200, session_id="old_ghost")
+    _make_titled_session(age_seconds=500, session_id="real_session")
 
     result = all_sessions()
     ids = {s["session_id"] for s in result}

--- a/tests/test_issue798.py
+++ b/tests/test_issue798.py
@@ -17,7 +17,6 @@ import threading
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 
 # ── R19: get_hermes_home_for_profile ─────────────────────────────────────────
@@ -246,8 +245,10 @@ def test_concurrent_new_sessions_get_correct_profiles():
     with patch.object(m.Session, 'save', return_value=None):
         t1 = threading.Thread(target=make_session, args=('alice', 'alice'))
         t2 = threading.Thread(target=make_session, args=('bob', 'bob'))
-        t1.start(); t2.start()
-        t1.join(timeout=5); t2.join(timeout=5)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
 
     assert not errors, f"Threads raised: {errors}"
     assert results.get('alice') == 'alice', f"alice session had profile {results.get('alice')!r}"

--- a/tests/test_issue803.py
+++ b/tests/test_issue803.py
@@ -15,10 +15,8 @@ Covers:
 """
 import os
 import threading
-from pathlib import Path
 from unittest.mock import MagicMock
 
-import pytest
 
 
 # ── 1. Cookie build/parse roundtrip ──────────────────────────────────────────
@@ -207,8 +205,10 @@ def test_concurrent_threads_see_independent_profiles():
 
     t1 = threading.Thread(target=worker, args=('alice', 'alice'))
     t2 = threading.Thread(target=worker, args=('bob', 'bob'))
-    t1.start(); t2.start()
-    t1.join(timeout=10); t2.join(timeout=10)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
 
     assert not errors, f"Workers raised: {errors}"
     assert results.get('alice') == 'alice', f"alice thread saw {results.get('alice')!r}"

--- a/tests/test_issue893_cancel_preserves_partial.py
+++ b/tests/test_issue893_cancel_preserves_partial.py
@@ -15,12 +15,10 @@ After this fix:
 - The cancel marker itself keeps _error=True so the model does not see it
 """
 import threading
-import time
 
 import pytest
 
 import api.config as config
-import api.streaming as streaming
 from api.config import STREAM_PARTIAL_TEXT, STREAMS_LOCK
 
 

--- a/tests/test_issue895_894_nous_prefix.py
+++ b/tests/test_issue895_894_nous_prefix.py
@@ -2,7 +2,6 @@
 Regression tests for #895 (set_hermes_default_model strips @nous: prefix + blocks on live fetch)
 and #894 (resolve_model_provider strips cross-namespace prefix for portal providers with base_url).
 """
-import threading
 import pytest
 from pathlib import Path
 

--- a/tests/test_issue_1932_goal_hook_unrelated_turns.py
+++ b/tests/test_issue_1932_goal_hook_unrelated_turns.py
@@ -7,7 +7,6 @@ messages like "what time is it" must NOT:
   - trigger goal_continue SSE events
   - burn the goal budget
 """
-import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -212,13 +211,13 @@ def test_goal_evaluate_after_turn_only_increments_for_user_initiated(monkeypatch
     monkeypatch.setattr(webui_goals, "_default_max_turns", lambda: 10)
 
     # user_initiated=True should increment
-    result1 = webui_goals.evaluate_goal_after_turn(
+    webui_goals.evaluate_goal_after_turn(
         "sid-1", "goal response", user_initiated=True, profile_home=None
     )
     assert len(turns_incremented) == 1
 
     # user_initiated=False should NOT increment
-    result2 = webui_goals.evaluate_goal_after_turn(
+    webui_goals.evaluate_goal_after_turn(
         "sid-1", "unrelated response", user_initiated=False, profile_home=None
     )
     assert len(turns_incremented) == 1, (

--- a/tests/test_issues_373_374_375.py
+++ b/tests/test_issues_373_374_375.py
@@ -6,7 +6,6 @@ Tests for issues #373, #374, and #375.
 #375: Model dropdown should fetch live models from provider
 """
 import pathlib
-import re
 
 REPO = pathlib.Path(__file__).parent.parent
 STREAMING_PY = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")

--- a/tests/test_kanban_bridge.py
+++ b/tests/test_kanban_bridge.py
@@ -321,11 +321,16 @@ class FakeKanbanDB:
         if slug not in boards:
             raise LookupError(f"board {slug!r} does not exist")
         meta = dict(boards[slug])
-        if name is not None: meta["name"] = name
-        if description is not None: meta["description"] = description
-        if icon is not None: meta["icon"] = icon
-        if color is not None: meta["color"] = color
-        if archived is not None: meta["archived"] = bool(archived)
+        if name is not None:
+            meta["name"] = name
+        if description is not None:
+            meta["description"] = description
+        if icon is not None:
+            meta["icon"] = icon
+        if color is not None:
+            meta["color"] = color
+        if archived is not None:
+            meta["archived"] = bool(archived)
         boards[slug] = meta
         return dict(meta)
 

--- a/tests/test_logs_ui_static.py
+++ b/tests/test_logs_ui_static.py
@@ -82,7 +82,7 @@ def test_logs_tab_is_wired_between_insights_and_settings_in_rail_and_mobile_nav(
 
 def test_logs_panel_fetches_allowlisted_api_and_exposes_controls():
     load_fn = _function_body(PANELS, "loadLogs")
-    render_fn = _function_body(PANELS, "_renderLogs")
+    _function_body(PANELS, "_renderLogs")
     selected_file_fn = _function_body(PANELS, "_selectedLogsFile")
     selected_tail_fn = _function_body(PANELS, "_selectedLogsTail")
     assert "api('/api/logs" in load_fn or 'api("/api/logs' in load_fn

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -12,7 +12,6 @@ import json
 import os
 import sys
 import tempfile
-import uuid
 from pathlib import Path
 
 import pytest
@@ -188,7 +187,6 @@ def _reimport_mcp():
     # object as `mcp_server.get_active_profile_name`'s closure reference.
     # We need to mutate the closure-bound module so mcp_server sees our
     # _active_profile assignment.
-    import api.profiles as fresh_profiles_via_import
     # mcp_server.get_active_profile_name is bound at first-import time and
     # reads `_active_profile` from its own module's globals via closure.
     # That module is the function's __globals__["__name__"] entry in
@@ -775,9 +773,9 @@ class TestProfileCliOrdering:
 # and capture (path, body) from the requests our handlers issue. This is
 # the thing that would have caught the original 8788 vs 8787 mismatch.
 
-import http.server
-import socket
-import threading
+import http.server  # noqa: E402
+import socket  # noqa: E402
+import threading  # noqa: E402
 
 
 class _RecordingHandler(http.server.BaseHTTPRequestHandler):

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -12,14 +12,13 @@ Covers:
 from __future__ import annotations
 
 import json
-import os
 import pathlib
 import tempfile
 import unittest
 import urllib.error
 import urllib.request
 
-from tests._pytest_port import BASE, TEST_STATE_DIR
+from tests._pytest_port import BASE
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")

--- a/tests/test_metadata_save_wipe_1558.py
+++ b/tests/test_metadata_save_wipe_1558.py
@@ -18,8 +18,6 @@ restart could wipe a 1000-message conversation in a single round-trip.
 This test reproduces the data loss path against the on-disk session file.
 """
 import json
-import sys
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -7,7 +7,6 @@ Covers:
   - @minimax: provider hint routing works correctly
   - minimax/MiniMax-M2.7 (slash format) is routed via openrouter when active provider differs
 """
-import os
 import pytest
 import api.config as config
 
@@ -152,7 +151,7 @@ def test_minimax_api_key_in_env_scan_tuple():
     """MINIMAX_API_KEY must be included in the env var scan performed by
     get_available_models(), so users who export MINIMAX_API_KEY see the
     MiniMax provider in the dropdown without editing ~/.hermes/.env."""
-    import inspect, ast, textwrap
+    import inspect
     src = inspect.getsource(config.get_available_models)
     assert 'MINIMAX_API_KEY' in src, (
         "MINIMAX_API_KEY not found in get_available_models() source — "

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -239,7 +239,8 @@ def test_no_duplicate_when_default_model_is_prefixed():
     }
     try:
         result = _cfg.get_available_models()
-        norm = lambda mid: mid.split('/', 1)[-1] if '/' in mid else mid
+        def norm(mid):
+            return mid.split('/', 1)[-1] if '/' in mid else mid
         # Check each group individually: no group should have two entries that
         # normalize to the same bare model name
         for g in result['groups']:
@@ -311,7 +312,8 @@ def _available_models_with_full_cfg(provider, default, base_url):
 def test_no_phantom_custom_group_when_active_provider_is_set(monkeypatch):
     """Issue: with provider=openai-codex + base_url set, gpt-5.4 was landing
     under a phantom "Custom" group instead of the "OpenAI Codex" group."""
-    import sys, types
+    import sys
+    import types
 
     # Force hermes_cli to report both the real provider and the phantom
     # 'custom' as authenticated, simulating what list_available_providers()
@@ -349,7 +351,8 @@ def test_default_model_lands_under_active_provider_group(monkeypatch):
     to groups[0] — which, when another provider sorted earlier
     alphabetically (e.g. 'anthropic'), placed gpt-5.4 in the WRONG group.
     """
-    import sys, types
+    import sys
+    import types
     fake_mod = types.ModuleType('hermes_cli.models')
     fake_mod.list_available_providers = lambda: [
         {'id': 'anthropic',    'authenticated': True},  # sorts before openai-codex
@@ -368,7 +371,8 @@ def test_default_model_lands_under_active_provider_group(monkeypatch):
     )
     groups = {g['provider']: [m['id'] for m in g['models']] for g in result['groups']}
     assert 'OpenAI Codex' in groups, f"OpenAI Codex group missing: {list(groups)}"
-    norm = lambda mid: mid.split('/', 1)[-1].split(':', 1)[-1]
+    def norm(mid):
+        return mid.split('/', 1)[-1].split(':', 1)[-1]
     assert 'gpt-5.4' in {norm(mid) for mid in groups['OpenAI Codex']}, (
         f"gpt-5.4 not in OpenAI Codex group; contents: {groups['OpenAI Codex']}"
     )
@@ -387,7 +391,8 @@ def test_unknown_providers_do_not_inherit_default_model(monkeypatch):
     gpt-5.4-mini even though those providers do not serve it. Minimax-Cn is
     now known and should show its own catalog instead.
     """
-    import sys, types
+    import sys
+    import types
 
     fake_mod = types.ModuleType('hermes_cli.models')
     fake_mod.list_available_providers = lambda: [
@@ -406,7 +411,8 @@ def test_unknown_providers_do_not_inherit_default_model(monkeypatch):
         base_url='',
     )
     groups = {g['provider']: [m['id'] for m in g['models']] for g in result['groups']}
-    norm = lambda mid: mid.split('/', 1)[-1].split(':', 1)[-1]
+    def norm(mid):
+        return mid.split('/', 1)[-1].split(':', 1)[-1]
 
     assert 'Alibaba' not in groups, (
         f"Alibaba should not inherit the default model placeholder: {groups}"

--- a/tests/test_native_image_attachments.py
+++ b/tests/test_native_image_attachments.py
@@ -7,11 +7,9 @@ fallback cases the maintainer asked about.
 """
 import base64
 import os
-import struct
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-import pytest
 
 from api.streaming import (
     _attachment_name,
@@ -334,7 +332,7 @@ class TestBuildNativeMultimodalMessage:
 
 # ── _is_valid_image magic-byte checks ────────────────────────────────────────
 
-from api.streaming import _is_valid_image
+from api.streaming import _is_valid_image  # noqa: E402
 
 
 class TestIsValidImage:

--- a/tests/test_nous_portal_routing.py
+++ b/tests/test_nous_portal_routing.py
@@ -12,8 +12,6 @@ provider/model path as the canonical name at their inference endpoint.
 Stripping the prefix to a bare name is exactly Bug 1, so the fix for Bug 2
 must not reintroduce it.
 """
-import sys
-import types
 
 
 def _models_with_provider(provider, monkeypatch):

--- a/tests/test_onboarding_existing_config.py
+++ b/tests/test_onboarding_existing_config.py
@@ -22,7 +22,7 @@ import pytest
 
 # Skip tests that call apply_onboarding_setup → _save_yaml_config when PyYAML is missing
 try:
-    import yaml as _yaml
+    import yaml as _yaml  # noqa: F401
     _HAS_YAML = True
 except ImportError:
     _HAS_YAML = False
@@ -35,7 +35,6 @@ _needs_yaml = pytest.mark.skipif(not _HAS_YAML, reason="PyYAML not installed —
 
 def _make_status(*, config_exists: bool, chat_ready: bool, onboarding_done: bool = False):
     """Call get_onboarding_status() with a controlled filesystem + settings."""
-    import importlib
 
     # Import fresh copies each call so module-level state doesn't bleed across
     import api.onboarding as mod
@@ -256,7 +255,7 @@ class TestApplyOnboardingSetupGuard:
 # Integration tests — require the live test server on port 8788
 # ---------------------------------------------------------------------------
 
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE  # noqa: E402
 
 
 def _http_get(path):

--- a/tests/test_onboarding_mvp.py
+++ b/tests/test_onboarding_mvp.py
@@ -7,7 +7,6 @@ lacks pyyaml.
 """
 import json
 import pathlib
-import sys
 import urllib.error
 import urllib.request
 
@@ -17,7 +16,7 @@ from tests._pytest_port import BASE
 
 # Check if pyyaml is available — onboarding setup tests need it on the server
 try:
-    import yaml as _yaml
+    import yaml as _yaml  # noqa: F401
     _HAS_YAML = True
 except ImportError:
     _HAS_YAML = False

--- a/tests/test_onboarding_network.py
+++ b/tests/test_onboarding_network.py
@@ -14,9 +14,7 @@ Covers:
 """
 
 import json
-import os
 import pathlib
-import sys
 import unittest.mock
 import urllib.error
 import urllib.request
@@ -24,7 +22,7 @@ import urllib.request
 import pytest
 
 REPO = pathlib.Path(__file__).parent.parent
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Unit tests — directly test the IP-resolution + guard logic in routes.py
@@ -160,7 +158,6 @@ class TestOnboardingSetupEndpoint:
         # The test server runs on 127.0.0.1:{TEST_PORT} so client_address[0] is 127.0.0.1.
         # A valid setup payload with a mock provider should not be rejected for IP reasons.
         # We patch apply_onboarding_setup to avoid actually writing any config.
-        import unittest.mock
         with unittest.mock.patch("api.onboarding.apply_onboarding_setup", return_value={"ok": True}):
             status, body = self._post(
                 "/api/onboarding/setup",
@@ -174,7 +171,6 @@ class TestOnboardingSetupEndpoint:
         Simulated reverse proxy: raw TCP is 127.0.0.1 but X-Forwarded-For is also
         127.0.0.1. Should be allowed.
         """
-        import unittest.mock
         with unittest.mock.patch("api.onboarding.apply_onboarding_setup", return_value={"ok": True}):
             status, body = self._post(
                 "/api/onboarding/setup",

--- a/tests/test_opencode_providers.py
+++ b/tests/test_opencode_providers.py
@@ -3,7 +3,6 @@ Tests for OpenCode Zen and OpenCode Go provider support.
 Verifies provider registration in display/model catalogs and
 env-var fallback detection.
 """
-import os
 import sys
 import types
 import pytest

--- a/tests/test_orphaned_tool_messages.py
+++ b/tests/test_orphaned_tool_messages.py
@@ -10,7 +10,7 @@ import pathlib
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(REPO_ROOT))
 
-from api.streaming import _sanitize_messages_for_api
+from api.streaming import _sanitize_messages_for_api  # noqa: E402
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pdf_html_preview.py
+++ b/tests/test_pdf_html_preview.py
@@ -6,7 +6,6 @@ and that CSS classes are defined.
 """
 import os
 import re
-import pytest
 
 
 def _read_js(name):

--- a/tests/test_pr1318_context_length_fallback.py
+++ b/tests/test_pr1318_context_length_fallback.py
@@ -17,7 +17,6 @@ Tests:
 4. Fallback exception is silently swallowed (older agent builds)
 5. Fallback runs before s.save() so the value is persisted
 """
-import re
 from pathlib import Path
 
 STREAMING = Path(__file__).resolve().parent.parent / "api" / "streaming.py"

--- a/tests/test_pr1339_fallback_providers_list.py
+++ b/tests/test_pr1339_fallback_providers_list.py
@@ -8,7 +8,6 @@ which would raise `AttributeError: 'list' object has no attribute 'get'`.
 The fix makes streaming.py handle both legacy dict form and new list form, picking
 the first entry from the list when given a list.
 """
-import re
 from pathlib import Path
 
 STREAMING_PY = Path(__file__).resolve().parent.parent / "api" / "streaming.py"

--- a/tests/test_pr1350_sse_notify_correctness.py
+++ b/tests/test_pr1350_sse_notify_correctness.py
@@ -27,9 +27,7 @@ The fix:
 """
 
 import pathlib
-import queue
 import sys
-import time
 import uuid
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()

--- a/tests/test_pr1370_lineage_metadata_perf_and_orphan.py
+++ b/tests/test_pr1370_lineage_metadata_perf_and_orphan.py
@@ -13,11 +13,9 @@ output, because #1358's frontend `_sessionLineageKey` falls through to
 group orphans by a key no other session shares (cosmetic dead state).
 """
 
-import os
 import sqlite3
 import time
 
-import pytest
 
 
 def _make_db(path):

--- a/tests/test_pr1375_partial_tool_calls_sanitize.py
+++ b/tests/test_pr1375_partial_tool_calls_sanitize.py
@@ -20,7 +20,6 @@ sanitize-for-API.
 import pathlib
 import sys
 
-import pytest
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_pr1445_opus_followups.py
+++ b/tests/test_pr1445_opus_followups.py
@@ -8,7 +8,6 @@ These tests pin the defense-in-depth additions from the Opus advisor review:
 """
 
 import logging
-from pathlib import Path
 from types import SimpleNamespace
 
 

--- a/tests/test_profile_env_isolation.py
+++ b/tests/test_profile_env_isolation.py
@@ -1,7 +1,6 @@
 import importlib
 import os
 import sys
-from pathlib import Path
 
 
 def test_profile_switch_clears_previous_profile_env_vars(monkeypatch, tmp_path):

--- a/tests/test_profile_switch_1200.py
+++ b/tests/test_profile_switch_1200.py
@@ -11,9 +11,7 @@ Bug 2: /api/models returned stale results after a profile switch because the
 These tests verify both fixes.
 """
 import os
-import json
 import tempfile
-import textwrap
 from pathlib import Path
 
 
@@ -203,7 +201,6 @@ no active session), the early-return branch ran without updating the chip.
 This caused the chip to keep showing the old profile name after switchToProfile().
 """
 
-import re
 
 
 def test_syncTopbar_early_return_updates_profile_chip():
@@ -290,7 +287,7 @@ def test_regression_switch_profile_default_workspace_not_from_process_global(tmp
             "switch_profile() is reading from the wrong profile."
         )
         assert str(old_ws) not in ws, (
-            f"REGRESSION: Returned old profile workspace. Bug 1 regressed."
+            "REGRESSION: Returned old profile workspace. Bug 1 regressed."
         )
     finally:
         profiles._DEFAULT_HERMES_HOME = orig_default
@@ -362,13 +359,13 @@ def test_regression_switch_profile_returns_target_model():
     """
     import api.profiles as profiles
     from pathlib import Path
-    import tempfile
 
     with tempfile.TemporaryDirectory() as tmp:
         base = Path(tmp)
         target = base / "profiles" / "myp"
         target.mkdir(parents=True)
-        ws = base / "mypws"; ws.mkdir()
+        ws = base / "mypws"
+        ws.mkdir()
         (target / "config.yaml").write_text(
             f"model:\n  default: my-target-model\nterminal:\n  cwd: {ws}\n",
             encoding="utf-8",

--- a/tests/test_profile_switch_ux.py
+++ b/tests/test_profile_switch_ux.py
@@ -23,7 +23,8 @@ class TestProfileSwitchSpinner:
         assert idx != -1, "switchToProfile not found in panels.js"
         depth = 0
         for i, ch in enumerate(self.JS[idx:], idx):
-            if ch == "{": depth += 1
+            if ch == "{":
+                depth += 1
             elif ch == "}":
                 depth -= 1
                 if depth == 0:
@@ -88,7 +89,8 @@ class TestParallelizedFetches:
         assert idx != -1
         depth = 0
         for i, ch in enumerate(self.JS[idx:], idx):
-            if ch == "{": depth += 1
+            if ch == "{":
+                depth += 1
             elif ch == "}":
                 depth -= 1
                 if depth == 0:

--- a/tests/test_profile_terminal_env.py
+++ b/tests/test_profile_terminal_env.py
@@ -1,4 +1,3 @@
-import os
 import re
 from pathlib import Path
 

--- a/tests/test_provider_management.py
+++ b/tests/test_provider_management.py
@@ -121,7 +121,7 @@ class TestGetProviders:
         try:
             result = get_providers()
             for p in result["providers"]:
-                assert "id" in p, f"Missing 'id' in provider entry"
+                assert "id" in p, "Missing 'id' in provider entry"
                 assert "display_name" in p, f"Missing 'display_name' for {p['id']}"
                 assert "has_key" in p, f"Missing 'has_key' for {p['id']}"
                 assert "configurable" in p, f"Missing 'configurable' for {p['id']}"

--- a/tests/test_provider_mismatch.py
+++ b/tests/test_provider_mismatch.py
@@ -17,7 +17,7 @@ import urllib.request
 from tests.conftest import TEST_STATE_DIR
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE  # noqa: E402
 
 
 def _read(rel_path: str) -> str:

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -16,7 +16,6 @@ emitted so the frontend can queue the leftover text as a next-turn message.
 """
 import sys
 import os
-import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_reasoning_chip_js_behaviour.py
+++ b/tests/test_reasoning_chip_js_behaviour.py
@@ -10,7 +10,6 @@ label fell through to a wrong value for an unknown input.
 This file pins the actual rendered output for every effort state so the
 chip's None/Default visibility cannot silently regress.
 """
-import os
 import shutil
 import subprocess
 from pathlib import Path

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -7,13 +7,12 @@ Each test is tagged with the sprint/commit where the bug was found and fixed.
 import json
 import os
 import pathlib
-import time
 import urllib.error
 import urllib.request
 import urllib.parse
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE  # noqa: E402
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
@@ -208,7 +207,7 @@ def test_all_api_modules_importable(cleanup_test_sessions):
     """All api/ modules must be importable without NameError or ImportError.
     Catches missing imports introduced during future module splits.
     """
-    import ast, pathlib
+    import ast
     api_dir = REPO_ROOT / "api"
     for module_file in api_dir.glob("*.py"):
         src = module_file.read_text()
@@ -220,7 +219,7 @@ def test_all_api_modules_importable(cleanup_test_sessions):
 
 def test_server_py_importable(cleanup_test_sessions):
     """server.py must parse without syntax errors after any split."""
-    import ast, pathlib
+    import ast
     src = (REPO_ROOT / "server.py").read_text()
     try:
         ast.parse(src)

--- a/tests/test_renderer_comprehensive.py
+++ b/tests/test_renderer_comprehensive.py
@@ -12,7 +12,7 @@ import pathlib
 
 UI_JS = (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
 
-import html as _html
+import html as _html  # noqa: E402
 
 
 def _esc(s):
@@ -40,26 +40,31 @@ def _apply_blockquotes(src):
         lines = block.split("\n")
         while lines and (lines[-1].strip() in (">", "")):
             if lines[-1].strip() == ">":
-                lines.pop(); break
+                lines.pop()
+                break
             lines.pop()
-        stripped = [re.sub(r"^>[ \t]?", "", l) for l in lines]
+        stripped = [re.sub(r"^>[ \t]?", "", ln) for ln in lines]
         inner_raw = "\n".join(stripped)
         if re.search(r"^>", inner_raw, re.MULTILINE):
             inner = _apply_blockquotes(inner_raw)
         elif re.search(r"^(  )?[-*+] .+", inner_raw, re.MULTILINE):
             def inner_list(lb):
-                ll = lb.strip().split("\n"); h = "<ul>"
+                ll = lb.strip().split("\n")
+                h = "<ul>"
                 for li in ll:
                     txt = re.sub(r"^ {0,4}[-*+] ", "", li)
-                    if re.match(r"\[x\] ", txt, re.I): ih = f"✅ {_inline_md(txt[4:])}"
-                    elif txt.startswith("[ ] "): ih = f"☐ {_inline_md(txt[4:])}"
-                    else: ih = _inline_md(txt)
+                    if re.match(r"\[x\] ", txt, re.I):
+                        ih = f"✅ {_inline_md(txt[4:])}"
+                    elif txt.startswith("[ ] "):
+                        ih = f"☐ {_inline_md(txt[4:])}"
+                    else:
+                        ih = _inline_md(txt)
                     h += f"<li>{ih}</li>"
                 return h + "</ul>"
             inner = re.sub(r"((?:^(?:  )?[-*+] .+\n?)+)", lambda m2: inner_list(m2.group(0)),
                            inner_raw, flags=re.MULTILINE)
         else:
-            inner = "\n".join("<br>" if l.strip() == "" else _inline_md(l) for l in stripped)
+            inner = "\n".join("<br>" if ln.strip() == "" else _inline_md(ln) for ln in stripped)
         return f"<blockquote>{inner}</blockquote>"
     return re.sub(r"((?:^>[^\n]*(?:\n|$))+)", replacer, src, flags=re.MULTILINE)
 
@@ -265,8 +270,8 @@ class TestTaskLists:
     def _apply_list(self, block):
         lines = block.strip().split("\n")
         html = "<ul>"
-        for l in lines:
-            text = re.sub(r"^ {0,4}[-*+] ", "", l)
+        for ln in lines:
+            text = re.sub(r"^ {0,4}[-*+] ", "", ln)
             if re.match(r"\[x\] ", text, re.I):
                 html += f"<li>✅ {_inline_md(text[4:])}</li>"
             elif text.startswith("[ ] "):

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -12,11 +12,9 @@ asserting the rendered HTML for the most common LLM-output shapes.
 Add a case here whenever the renderer fix targets a class of input the
 Python mirror cannot exercise faithfully.
 """
-import os
 import re
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest

--- a/tests/test_resolve_model_provider_free_suffix.py
+++ b/tests/test_resolve_model_provider_free_suffix.py
@@ -41,7 +41,6 @@ def _restore_config(old, cfg_mod):
 
 def test_openrouter_free_suffix_survives_provider_qualification():
     """tencent/hy3-preview:free must resolve correctly when qualified."""
-    import api.config as cfg_mod
     old, cfg_mod = _set_config_provider("anthropic")
     try:
         qualified = model_with_provider_context("tencent/hy3-preview:free", "openrouter")
@@ -54,7 +53,6 @@ def test_openrouter_free_suffix_survives_provider_qualification():
 
 def test_openrouter_free_suffix_nvidia():
     """nvidia/nemotron-3-super-120b-a12b:free — same bug class."""
-    import api.config as cfg_mod
     old, cfg_mod = _set_config_provider("anthropic")
     try:
         qualified = model_with_provider_context("nvidia/nemotron-3-super-120b-a12b:free", "openrouter")
@@ -67,7 +65,6 @@ def test_openrouter_free_suffix_nvidia():
 
 def test_openrouter_free_suffix_arcee():
     """arcee-ai/trinity-large-preview:free — same bug class."""
-    import api.config as cfg_mod
     old, cfg_mod = _set_config_provider("anthropic")
     try:
         qualified = model_with_provider_context("arcee-ai/trinity-large-preview:free", "openrouter")
@@ -80,7 +77,6 @@ def test_openrouter_free_suffix_arcee():
 
 def test_openrouter_thinking_suffix():
     """Models ending in :thinking should also be preserved."""
-    import api.config as cfg_mod
     old, cfg_mod = _set_config_provider("anthropic")
     try:
         qualified = model_with_provider_context("some/model:thinking", "openrouter")

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -14,7 +14,6 @@ import os
 import pathlib
 import sys
 import threading
-from unittest import mock
 
 import pytest
 
@@ -147,8 +146,10 @@ def test_cron_profile_context_serializes_concurrent_access(tmp_path):
 
     t1 = threading.Thread(target=worker, args=(home_a, "A"))
     t2 = threading.Thread(target=worker, args=(home_b, "B"))
-    t1.start(); t2.start()
-    t1.join(); t2.join()
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
 
     # Every enter must be immediately followed by its matching exit (no
     # interleaving), because the lock serializes the two contexts.

--- a/tests/test_security_redaction.py
+++ b/tests/test_security_redaction.py
@@ -35,7 +35,7 @@ def _server_is_up(port: int = 8788) -> bool:
 # The skipif is evaluated lazily via the fixture, not at collection time.
 _needs_server = pytest.mark.usefixtures("test_server")
 
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE  # noqa: E402
 
 # Sample credentials that should be masked in every API response
 _FAKE_GITHUB_PAT = "ghp_TestFakeCredential1234567890ab"
@@ -194,7 +194,8 @@ def _create_session_with_credentials() -> str:
     from disk, exercising the redaction code path on load.
     Uses TEST_STATE_DIR from conftest.py (the isolated test server state directory).
     """
-    import time, uuid
+    import time
+    import uuid
     try:
         from conftest import TEST_STATE_DIR
         sessions_dir = TEST_STATE_DIR / "sessions"
@@ -253,7 +254,7 @@ def test_api_session_redacts_title():
     }
     result = redact_session_data(session)
     assert _FAKE_GITHUB_PAT not in result["title"], (
-        f"redact_session_data must mask credentials in title field"
+        "redact_session_data must mask credentials in title field"
     )
     assert result["session_id"] == "abc123"  # safe fields preserved
 
@@ -300,7 +301,6 @@ def test_api_memory_redacts_via_write_read(test_server):
 
 def test_fix_credential_permissions_corrects_loose_files(tmp_path, monkeypatch):
     """fix_credential_permissions() tightens group/other read bits."""
-    import os
     from api.startup import fix_credential_permissions
 
     env_file = tmp_path / ".env"

--- a/tests/test_session_batch_select.py
+++ b/tests/test_session_batch_select.py
@@ -1,5 +1,4 @@
 """Test: session batch select mode functions exist in sessions.js (#568)"""
-import re
 
 
 def test_batch_select_state_variables():
@@ -189,9 +188,9 @@ def test_batch_select_i18n_keys():
         for locale in locales:
             # Check if the key exists in the locale block
             if locale == 'zh-Hant':
-                pattern = rf"'{locale}'\s*:.*?{key}"
+                pass
             else:
-                pattern = rf"{locale}\s*:.*?{key}"
+                pass
             # Simpler check: just verify the key string with colon exists
             assert f"{key}:" in src, f"Missing i18n key '{key}' in i18n.js"
     # Count occurrences - each key should appear in all 7 locales

--- a/tests/test_session_duplicate.py
+++ b/tests/test_session_duplicate.py
@@ -8,18 +8,11 @@ Tests verify that:
 4. Error handling works properly
 """
 import json
-import pathlib
-import shutil
-import subprocess
-import time
 import urllib.request
 import urllib.error
-import uuid
-import tempfile
 
-import pytest
 
-from tests.conftest import TEST_BASE, TEST_STATE_DIR, _post, TEST_WORKSPACE, _wait_for_server
+from tests.conftest import TEST_BASE, _post
 
 
 def _get(path):

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -13,7 +13,6 @@ Validates:
 import json
 import os
 import threading
-import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -134,7 +133,6 @@ def test_incremental_patch_correctness():
 
     # We need to get the fixture values — but since it's autouse, the monkeypatch
     # has already been applied. Access the patched values directly.
-    session_dir = models.SESSION_DIR
     index_file = models.SESSION_INDEX_FILE
 
     # Create 3 sessions with different timestamps
@@ -180,7 +178,6 @@ def test_new_session_appended_to_index():
     """Pre-write index with sessions A, B. Call _write_session_index(updates=[C])
     where C is not in the existing index. Verify C appears in the index.
     """
-    session_dir = models.SESSION_DIR
     index_file = models.SESSION_INDEX_FILE
 
     sA = _make_session("sess_a", "Alpha", updated_at=100.0)
@@ -297,7 +294,6 @@ def test_first_call_full_rebuild():
     """When no index file exists, calling _write_session_index(updates=[session])
     should fall back to full rebuild and create the index.
     """
-    session_dir = models.SESSION_DIR
     index_file = models.SESSION_INDEX_FILE
 
     # No index file yet
@@ -324,7 +320,6 @@ def test_corrupt_index_fallback():
     _write_session_index(updates=[session]). Verify it falls back to
     full rebuild and the result is valid JSON with correct entries.
     """
-    session_dir = models.SESSION_DIR
     index_file = models.SESSION_INDEX_FILE
 
     # Write corrupt data
@@ -352,7 +347,6 @@ def test_concurrent_saves_dont_lose_data():
     with a pre-existing index. Use a threading.Event barrier to force them
     to run concurrently. Assert both updates are present in the final index.
     """
-    session_dir = models.SESSION_DIR
     index_file = models.SESSION_INDEX_FILE
 
     sA = _make_session("sess_a", "Alpha", updated_at=100.0)
@@ -413,7 +407,6 @@ def test_atomic_write_no_tmp_remains():
     in SESSION_DIR.
     """
     session_dir = models.SESSION_DIR
-    index_file = models.SESSION_INDEX_FILE
 
     sA = _make_session("sess_a", "Alpha", updated_at=100.0)
     sA.path.write_text(json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -442,7 +435,6 @@ def test_deadlock_guard_on_fallback():
     This tests that the fallback path (corrupt index -> full rebuild)
     is called outside the LOCK, so it doesn't deadlock.
     """
-    session_dir = models.SESSION_DIR
     index_file = models.SESSION_INDEX_FILE
 
     # Create a valid index file so the incremental path is attempted
@@ -497,7 +489,6 @@ def test_deadlock_guard_on_fallback():
 
 def test_incremental_index_disk_io_runs_outside_lock(monkeypatch):
     """Fast-path disk I/O (fsync/replace) must run after releasing LOCK."""
-    index_file = models.SESSION_INDEX_FILE
 
     sA = _make_session("sess_a", "Alpha", updated_at=100.0)
     sA.path.write_text(json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/tests/test_session_ops.py
+++ b/tests/test_session_ops.py
@@ -138,7 +138,7 @@ def test_retry_concurrent_requests_are_safe(cleanup_test_sessions):
 
     with ThreadPoolExecutor(max_workers=4) as ex:
         futures = [ex.submit(_do_retry) for _ in range(4)]
-        results = [f.result() for f in futures]
+        [f.result() for f in futures]
 
     # Each call either succeeds (truncating further) or raises 'no previous
     # message to retry' once nothing is left. After the dust settles, the

--- a/tests/test_session_sidecar_repair.py
+++ b/tests/test_session_sidecar_repair.py
@@ -1,7 +1,6 @@
 """Regression tests for session sidecar repair logic."""
 import json
 import queue
-import os
 import sys
 import threading
 import time
@@ -16,7 +15,6 @@ from api.models import (
     _get_profile_home,
     _apply_core_sync_or_error_marker,
     _repair_stale_pending,
-    _active_stream_ids,
 )
 import api.config as config
 import api.streaming as streaming

--- a/tests/test_session_summary_redaction.py
+++ b/tests/test_session_summary_redaction.py
@@ -11,7 +11,7 @@ import pytest
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent))
 
 _needs_server = pytest.mark.usefixtures("test_server")
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE  # noqa: E402
 _FULL_SECRET = "sk-" + ("B" * 24)
 
 

--- a/tests/test_simplified_tool_calling_setting.py
+++ b/tests/test_simplified_tool_calling_setting.py
@@ -1,6 +1,5 @@
 """Regression tests for the Simplified tool calling setting."""
 
-import importlib
 import json
 
 

--- a/tests/test_skills_category_collapse.py
+++ b/tests/test_skills_category_collapse.py
@@ -5,7 +5,6 @@ with chevron toggles, click handlers, and persisted collapse state.
 """
 import os
 import re
-import pytest
 
 
 def _readpanels():

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -14,14 +14,12 @@ No mocking required for session CRUD, upload parser, or approval API.
 
 import io
 import json
-import os
 import sys
 import time
 import uuid
 import urllib.request
 import urllib.parse
 import urllib.error
-import tempfile
 import pathlib
 
 # Allow importing server modules directly for unit tests
@@ -78,7 +76,8 @@ def post_multipart(path, fields, files):
 def make_session_tracked(created_list, ws=None):
     """Create a session and register it with the cleanup fixture."""
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)
@@ -219,7 +218,7 @@ def test_parse_multipart_text_file():
     sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent))
     # Import the function directly from the server module
     import importlib.util
-    spec = importlib.util.spec_from_file_location(
+    importlib.util.spec_from_file_location(
         "server",
         str(pathlib.Path(__file__).parent.parent / "server.py")
     )
@@ -236,7 +235,6 @@ def test_parse_multipart_text_file():
     parse_multipart = ns["parse_multipart"]
 
     # Build a minimal multipart body
-    boundary = b"testboundary"
     body = (
         b"--testboundary\r\n"
         b"Content-Disposition: form-data; name=\"session_id\"\r\n\r\n"
@@ -270,7 +268,6 @@ def test_parse_multipart_binary_file():
 
     # Fake PNG: first 8 bytes of PNG magic
     png_magic = b"\x89PNG\r\n\x1a\n"
-    boundary = b"binboundary"
     body = (
         b"--binboundary\r\n"
         b"Content-Disposition: form-data; name=\"session_id\"\r\n\r\n"

--- a/tests/test_sprint10.py
+++ b/tests/test_sprint10.py
@@ -1,10 +1,14 @@
 """
 Sprint 10 Tests: server.py split, cancel endpoint, cron history, tool card polish.
 """
-import json, pathlib, urllib.error, urllib.request, urllib.parse
+import json
+import pathlib
+import urllib.error
+import urllib.request
+import urllib.parse
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE  # noqa: E402
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:

--- a/tests/test_sprint11.py
+++ b/tests/test_sprint11.py
@@ -1,10 +1,14 @@
 """
 Sprint 11 Tests: multi-provider model support, streaming smoothness, routes extraction.
 """
-import json, pathlib, urllib.error, urllib.request, urllib.parse
+import json
+import pathlib
+import urllib.error
+import urllib.request
+import urllib.parse
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE  # noqa: E402
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:

--- a/tests/test_sprint12.py
+++ b/tests/test_sprint12.py
@@ -1,7 +1,10 @@
 """
 Sprint 12 Tests: settings panel, session pinning, session import, SSE reconnect.
 """
-import json, pathlib, urllib.error, urllib.request, urllib.parse
+import json
+import urllib.error
+import urllib.request
+import urllib.parse
 
 from tests._pytest_port import BASE, TEST_DEFAULT_MODEL
 

--- a/tests/test_sprint13.py
+++ b/tests/test_sprint13.py
@@ -1,7 +1,10 @@
 """
 Sprint 13 Tests: cron recent endpoint, session duplicate, background alerts.
 """
-import json, pathlib, urllib.error, urllib.request
+import json
+import pathlib
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
 

--- a/tests/test_sprint14.py
+++ b/tests/test_sprint14.py
@@ -1,7 +1,9 @@
 """
 Sprint 14 Tests: file rename, folder create, session archive, session tags, mermaid, timestamps.
 """
-import json, os, pathlib, shutil, tempfile, urllib.error, urllib.request
+import json
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
 

--- a/tests/test_sprint15.py
+++ b/tests/test_sprint15.py
@@ -1,7 +1,9 @@
 """
 Sprint 15 Tests: session projects (CRUD, move, backward compat).
 """
-import json, urllib.error, urllib.request
+import json
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
 

--- a/tests/test_sprint16.py
+++ b/tests/test_sprint16.py
@@ -100,9 +100,9 @@ def render_md(raw):
     def handle_ul(block):
         lines = block.strip().split("\n")
         out = "<ul>"
-        for l in lines:
-            indent = bool(re.match(r"^ {2,}", l))
-            text = re.sub(r"^ {0,4}[-*+] ", "", l)
+        for ln in lines:
+            indent = bool(re.match(r"^ {2,}", ln))
+            text = re.sub(r"^ {0,4}[-*+] ", "", ln)
             style = ' style="margin-left:16px"' if indent else ""
             out += f"<li{style}>{inline_md(text)}</li>"
         return out + "</ul>"
@@ -112,8 +112,8 @@ def render_md(raw):
     def handle_ol(block):
         lines = block.strip().split("\n")
         out = "<ol>"
-        for l in lines:
-            text = re.sub(r"^ {0,4}\d+\. ", "", l)
+        for ln in lines:
+            text = re.sub(r"^ {0,4}\d+\. ", "", ln)
             out += f"<li>{inline_md(text)}</li>"
         return out + "</ol>"
 
@@ -126,8 +126,10 @@ def render_md(raw):
     parts = s.split("\n\n")
     def wrap(p):
         p = p.strip()
-        if not p: return ""
-        if re.match(r"^<(h[1-6]|ul|ol|pre|hr|blockquote)", p): return p
+        if not p:
+            return ""
+        if re.match(r"^<(h[1-6]|ul|ol|pre|hr|blockquote)", p):
+            return p
         return "<p>" + p.replace("\n", "<br>") + "</p>"
     s = "\n".join(wrap(p) for p in parts)
     return s

--- a/tests/test_sprint17.py
+++ b/tests/test_sprint17.py
@@ -1,7 +1,9 @@
 """
 Sprint 17 Tests: send_key setting, commands.js static file, workspace subdir listing.
 """
-import json, urllib.error, urllib.request
+import json
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
 

--- a/tests/test_sprint19.py
+++ b/tests/test_sprint19.py
@@ -1,7 +1,9 @@
 """
 Sprint 19 Tests: auth/login, security headers, request size limit.
 """
-import json, urllib.error, urllib.request
+import json
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
 

--- a/tests/test_sprint2.py
+++ b/tests/test_sprint2.py
@@ -1,5 +1,7 @@
 """Sprint 2 tests: image preview, file types, markdown. Uses cleanup_test_sessions fixture."""
-import io, json, uuid, urllib.request, urllib.error, pathlib
+import json
+import urllib.request
+import urllib.error
 
 from tests._pytest_port import BASE
 
@@ -24,7 +26,8 @@ def make_session_tracked(created_list, ws=None):
     """Create a session and register it with the cleanup fixture."""
     import pathlib as _pathlib
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)

--- a/tests/test_sprint20.py
+++ b/tests/test_sprint20.py
@@ -7,7 +7,6 @@ the browser with no server-side component.
 """
 import re
 import urllib.request
-import json
 import pathlib
 
 from tests._pytest_port import BASE

--- a/tests/test_sprint23.py
+++ b/tests/test_sprint23.py
@@ -2,7 +2,9 @@
 Sprint 23 Tests: agentic transparency — token/cost display, session usage fields,
 subagent card names, skill picker in cron, skill linked files.
 """
-import json, urllib.error, urllib.request
+import json
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
 

--- a/tests/test_sprint26.py
+++ b/tests/test_sprint26.py
@@ -2,7 +2,9 @@
 Sprint 26 Tests: canonical appearance settings persist and legacy theme names
 map onto the new theme + skin system.
 """
-import json, urllib.error, urllib.request
+import json
+import urllib.error
+import urllib.request
 import pathlib
 import sys
 
@@ -12,7 +14,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from api import config
+from api import config  # noqa: E402
 
 
 def get(path):

--- a/tests/test_sprint29.py
+++ b/tests/test_sprint29.py
@@ -15,7 +15,6 @@ Covers:
   11. SSRF DNS check logic (unit test on helper function)
   12. ENV_LOCK export — _ENV_LOCK importable from streaming module
 """
-import importlib
 import json
 import pathlib
 import sys
@@ -25,7 +24,6 @@ import urllib.parse
 import urllib.request
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
-from conftest import TEST_STATE_DIR
 
 from tests._pytest_port import BASE
 
@@ -315,13 +313,11 @@ class TestCSRFHelpers:
 class TestLoginRateLimit:
     def test_rate_limit_triggers_429(self):
         """More than 5 failed login attempts from same IP must yield 429."""
-        from api.auth import _login_attempts, _LOGIN_WINDOW
 
         # Force the rate limiter state: inject 5 stale-now timestamps so next call is fresh
         # Actually easier: just hit the endpoint 6 times with wrong password
         # But we can't set a password in a test without config file.
         # Instead test the helper directly.
-        import time
         from api import auth as _auth
 
         # Reset state for a fake IP
@@ -367,7 +363,7 @@ class TestSessionIDValidation:
         """A valid hex session ID gets past the validation check."""
         import sys
         sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
-        from api.models import Session, SESSION_DIR
+        from api.models import Session
         valid_hex = "deadbeef" * 8  # 64 hex chars
         # Should not raise — returns None only if file doesn't exist (it won't)
         result = Session.load(valid_hex)
@@ -518,7 +514,8 @@ class TestSkillsPathTraversal:
         })
         # 500 = skills module not available (hermes-agent not installed) — skip
         if status == 500:
-            import pytest; pytest.skip("skills module requires hermes-agent")
+            import pytest
+            pytest.skip("skills module requires hermes-agent")
         # Should succeed (200) or need auth (401/403) — not path error (400)
         assert status in (200, 401, 403, 404), \
             f"Valid skill save got unexpected status {status}: {body}"
@@ -536,8 +533,6 @@ class TestSkillsPathTraversal:
 class TestContentDisposition:
     def test_html_file_forced_download(self, webui_server, tmp_path):
         """HTML files served via /api/file/raw must have Content-Disposition: attachment."""
-        import urllib.request
-        import urllib.error
 
         # Use a session to create an HTML file in the workspace
         sessions_body, _ = post("/api/sessions/new", {})
@@ -547,14 +542,12 @@ class TestContentDisposition:
 
         # Can't easily create a file via the test server without a workspace,
         # so test the logic directly instead.
-        from api.routes import _handle_file_raw
         dangerous_types = {'text/html', 'application/xhtml+xml', 'image/svg+xml'}
         for mime in dangerous_types:
             assert mime in dangerous_types, f"{mime} should be in dangerous_types set"
 
     def test_dangerous_mime_types_set_complete(self):
         """The set of dangerous MIME types must include html, xhtml, and svg."""
-        import ast
         import pathlib
         routes_src = pathlib.Path(__file__).parent.parent / "api" / "routes.py"
         src = routes_src.read_text()
@@ -651,7 +644,6 @@ class TestPasswordHashing:
     def test_save_settings_stores_64char_hex_hash(self):
         """save_settings with _set_password must store a 64-char hex hash (PBKDF2)."""
         from api.config import save_settings, load_settings, SETTINGS_FILE
-        import json
 
         # Remember original content so we can restore it
         original = None
@@ -721,14 +713,13 @@ class TestENVLock:
     def test_env_lock_importable_in_routes(self):
         """api.routes must be able to import _ENV_LOCK from api.streaming."""
         # If routes.py fails to import, this will raise ImportError
-        import importlib
         import api.routes  # noqa: F401 -- just checking import works
         # No error means the circular import is OK
 
 
 # ── Fixture ────────────────────────────────────────────────────────────────
 
-import pytest
+import pytest  # noqa: E402
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_sprint3.py
+++ b/tests/test_sprint3.py
@@ -1,5 +1,7 @@
 """Sprint 3 tests: cron API, skills API, memory API, input validation."""
-import json, uuid, urllib.request, urllib.error
+import json
+import urllib.request
+import urllib.error
 
 from tests._pytest_port import BASE
 
@@ -20,7 +22,8 @@ def make_session_tracked(created_list, ws=None):
     """Create a session and register it with the cleanup fixture."""
     import pathlib as _pathlib
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)
@@ -34,7 +37,8 @@ def test_crons_list():
 
 def test_crons_list_has_required_fields():
     data, _ = get("/api/crons")
-    if not data["jobs"]: return
+    if not data["jobs"]:
+        return
     job = data["jobs"][0]
     for field in ("id", "name", "prompt", "enabled", "schedule_display"):
         assert field in job
@@ -48,7 +52,8 @@ def test_crons_output_requires_job_id():
 
 def test_crons_output_real_job():
     data, _ = get("/api/crons")
-    if not data["jobs"]: return
+    if not data["jobs"]:
+        return
     job_id = data["jobs"][0]["id"]
     out, status = get(f"/api/crons/output?job_id={job_id}&limit=3")
     assert status == 200

--- a/tests/test_sprint31.py
+++ b/tests/test_sprint31.py
@@ -68,7 +68,7 @@ class TestWriteEndpointToConfig:
 
 # ── 6-7: API integration tests ────────────────────────────────────────────────
 
-from tests._pytest_port import BASE as _TEST_BASE
+from tests._pytest_port import BASE as _TEST_BASE  # noqa: E402
 
 
 def _post(path, body=None):

--- a/tests/test_sprint32.py
+++ b/tests/test_sprint32.py
@@ -1,8 +1,7 @@
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 import subprocess
 import os
-from api.startup import auto_install_agent_deps, _trusted_agent_dir
+from api.startup import auto_install_agent_deps
 
 
 class TestAutoInstallAgentDeps:

--- a/tests/test_sprint34.py
+++ b/tests/test_sprint34.py
@@ -19,10 +19,9 @@ import pathlib
 import tempfile
 import unittest.mock
 
-import pytest
 
 REPO = pathlib.Path(__file__).parent.parent
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE  # noqa: E402
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -169,7 +168,6 @@ class TestStatusFromRuntimeOAuth:
         We mock hermes_cli.auth to be unavailable so the function falls through
         to the auth.json path.  With no auth.json the result must be False.
         """
-        import unittest.mock
 
         # Prevent the hermes_cli fast path from finding real credentials
         with unittest.mock.patch(
@@ -269,7 +267,8 @@ class TestApplyOnboardingSetupUnsupportedProvider:
     """
 
     def _call(self, provider: str) -> dict:
-        import sys, pathlib, unittest.mock, tempfile, os
+        import sys
+        import pathlib
         repo = pathlib.Path(__file__).parent.parent
         if str(repo) not in sys.path:
             sys.path.insert(0, str(repo))

--- a/tests/test_sprint35.py
+++ b/tests/test_sprint35.py
@@ -13,7 +13,6 @@ Covers:
 """
 
 import pathlib
-import re
 
 REPO = pathlib.Path(__file__).parent.parent
 

--- a/tests/test_sprint36.py
+++ b/tests/test_sprint36.py
@@ -98,7 +98,7 @@ class TestCancelStreamCleanup:
         block = self._get_cancel_block()
         # The S.activeStreamId=null and setBusy(false) must appear after the try/catch
         # Verify they are NOT only inside the try block by checking position relative to catch
-        try_idx = block.find("try{")
+        block.find("try{")
         catch_idx = block.find("}catch(")
         cleanup_idx = block.find("S.activeStreamId=null")
         if cleanup_idx == -1:

--- a/tests/test_sprint37.py
+++ b/tests/test_sprint37.py
@@ -2,7 +2,6 @@
 Sprint 37 Tests: Workspace panel open/closed state persists across refreshes via localStorage.
 """
 import pathlib
-import re
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 BOOT_JS   = (REPO_ROOT / "static" / "boot.js").read_text()

--- a/tests/test_sprint4.py
+++ b/tests/test_sprint4.py
@@ -1,5 +1,8 @@
 """Sprint 4 tests: relocation, session rename, search, file ops, validation."""
-import json, pathlib, uuid, urllib.request, urllib.error
+import json
+import uuid
+import urllib.request
+import urllib.error
 
 from tests._pytest_port import BASE
 
@@ -24,7 +27,8 @@ def make_session_tracked(created_list, ws=None):
     """Create a session and register it with the cleanup fixture."""
     import pathlib as _pathlib
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)

--- a/tests/test_sprint40.py
+++ b/tests/test_sprint40.py
@@ -9,7 +9,6 @@ Covers:
 - i18n.js contains all required OAuth onboarding keys in both English and Spanish
 """
 import pathlib
-import re
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_sprint40_ui_polish.py
+++ b/tests/test_sprint40_ui_polish.py
@@ -5,12 +5,9 @@ Covers:
 - .session-item.active .session-title uses var(--gold) instead of hardcoded #e8a030
 - The hardcoded amber color #e8a030 is NOT present in the active session title rule
 """
-import os
 import pathlib
-import re
 import sys
 import unittest
-from unittest import mock
 
 # Ensure repo is on sys.path so api.config can be imported
 _REPO_ROOT = pathlib.Path(__file__).parent.parent

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -10,7 +10,6 @@ Covers:
 """
 import ast
 import pathlib
-import re
 import queue
 import sys
 import types

--- a/tests/test_sprint43.py
+++ b/tests/test_sprint43.py
@@ -11,10 +11,8 @@ Covers:
 - Logging: at least 5 modules add a module-level logger (B110 remediation)
 - routes.py: session titles redacted in /api/sessions list response
 """
-import ast
 import pathlib
 import re
-import sys
 import unittest
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
@@ -46,7 +44,6 @@ class TestMD5SecurityFix(unittest.TestCase):
     def test_gateway_watcher_md5_pattern(self):
         """Exact pattern: hashlib.md5(..., usedforsecurity=False)."""
         # Use re.search with DOTALL since the arg may span parens internally
-        import re
         self.assertIsNotNone(
             re.search(r"hashlib\.md5\(.*?usedforsecurity=False\)", GATEWAY_WATCHER_PY, re.DOTALL),
             "MD5 call must include usedforsecurity=False kwarg",
@@ -216,7 +213,6 @@ class TestQuietHTTPServer(unittest.TestCase):
 
     def test_sys_imported_in_server(self):
         """server.py must import sys (needed for sys.exc_info)."""
-        import re
         self.assertIsNotNone(
             re.search(r"^import sys", SERVER_PY, re.MULTILINE),
             "server.py: sys must be imported",

--- a/tests/test_sprint46.py
+++ b/tests/test_sprint46.py
@@ -11,7 +11,6 @@ import types
 from api.models import Session
 from api.config import SESSION_DIR
 from api.routes import _handle_session_compress
-from tests._pytest_port import BASE
 
 
 class _FakeHandler:

--- a/tests/test_sprint48.py
+++ b/tests/test_sprint48.py
@@ -27,7 +27,8 @@ class TestXmlToolCallStrip:
     def _load_fn(self):
         """Import the helper from streaming.py without triggering full server
         initialisation (which would fail in unit-test contexts)."""
-        import importlib, sys, types
+        import sys
+        import types
 
         # Stub heavy transitive imports so we can import the module cleanly.
         for mod in ('api.config', 'api.helpers', 'api.models', 'api.workspace'):

--- a/tests/test_sprint49.py
+++ b/tests/test_sprint49.py
@@ -10,7 +10,6 @@ Covers:
 """
 
 import pathlib
-import re
 
 from api.streaming import _restore_reasoning_metadata
 

--- a/tests/test_sprint5.py
+++ b/tests/test_sprint5.py
@@ -1,5 +1,10 @@
 """Sprint 5 tests: workspace CRUD, file save, session index, JS serving."""
-import json, pathlib, uuid, urllib.request, urllib.error, urllib.parse
+import json
+import pathlib
+import uuid
+import urllib.request
+import urllib.error
+import urllib.parse
 import os
 
 from tests._pytest_port import BASE
@@ -25,7 +30,8 @@ def make_session_tracked(created_list, ws=None):
     """Create a session and register it with the cleanup fixture."""
     import pathlib as _pathlib
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)
@@ -83,7 +89,7 @@ def test_workspace_add_requires_path():
 def test_workspace_suggest_returns_trusted_directories(cleanup_test_sessions):
     _, ws = make_session_tracked(cleanup_test_sessions)
     child = make_workspace_child(ws, f"workspace-suggest-{uuid.uuid4().hex[:6]}")
-    nested = make_workspace_child(child, "nested")
+    make_workspace_child(child, "nested")
     prefix = str(child.parent / child.name[:12])
     data, status = get(f"/api/workspaces/suggest?prefix={urllib.parse.quote(prefix)}")
     assert status == 200
@@ -162,7 +168,7 @@ def test_file_save_path_traversal_blocked(cleanup_test_sessions):
 def test_session_index_created_after_save(cleanup_test_sessions):
     # Index is created in the TEST state dir, not the production dir
     test_state_dir = pathlib.Path(os.environ.get("HERMES_WEBUI_TEST_STATE_DIR", str(pathlib.Path.home() / ".hermes" / "webui-mvp-test")))
-    index_path = test_state_dir / "sessions" / "_index.json"
+    test_state_dir / "sessions" / "_index.json"
     make_session_tracked(cleanup_test_sessions)
     # Index may not exist yet if cleanup already wiped it -- just check the endpoint works
     data, status = get("/api/sessions")

--- a/tests/test_sprint51.py
+++ b/tests/test_sprint51.py
@@ -11,13 +11,12 @@ These tests verify that after cancel_stream() is called:
 All tests are isolated and clean up after themselves.
 """
 
-import pytest
 import queue
 import threading
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 
 from api.streaming import cancel_stream
-from api.config import AGENT_INSTANCES, STREAMS, STREAMS_LOCK, CANCEL_FLAGS
+from api.config import AGENT_INSTANCES, STREAMS, CANCEL_FLAGS
 
 
 class TestCancelStreamEagerRelease:

--- a/tests/test_sprint6.py
+++ b/tests/test_sprint6.py
@@ -1,8 +1,12 @@
 """Sprint 6 tests: Escape from editor, Phase D validation, HTML extraction, cron create, session export."""
-import json, uuid, pathlib, urllib.request, urllib.error
+import json
+import uuid
+import pathlib
+import urllib.request
+import urllib.error
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE  # noqa: E402
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
@@ -23,7 +27,8 @@ def post(path, body=None):
 
 def make_session_tracked(created_list, ws=None):
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)

--- a/tests/test_sprint7.py
+++ b/tests/test_sprint7.py
@@ -1,7 +1,11 @@
 """
 Sprint 7 Tests: Cron CRUD, Skill CRUD, Memory Write, Session Content Search, Health
 """
-import json, pathlib, urllib.error, urllib.parse, urllib.request
+import json
+import pathlib
+import urllib.error
+import urllib.parse
+import urllib.request
 
 from tests._pytest_port import BASE
 
@@ -20,7 +24,8 @@ def post(path, body=None):
 
 def make_session_tracked(created_list, ws=None):
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)

--- a/tests/test_sprint8.py
+++ b/tests/test_sprint8.py
@@ -1,7 +1,10 @@
 """
 Sprint 8 Tests: Edit/regenerate, clear conversation, truncate, reconnect banner fix, syntax highlight.
 """
-import json, pathlib, urllib.error, urllib.parse, urllib.request
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
 
 from tests._pytest_port import BASE
 

--- a/tests/test_sprint9.py
+++ b/tests/test_sprint9.py
@@ -2,7 +2,9 @@
 Sprint 9 Tests: app.js module split verification, tool cards, todo panel.
 Run: python -m pytest tests/test_sprint9.py -v
 """
-import json, pathlib, urllib.error, urllib.request
+import json
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
 
@@ -99,7 +101,6 @@ def test_no_duplicate_function_definitions(cleanup_test_sessions):
 
 def test_all_functions_present_across_modules(cleanup_test_sessions):
     """Key functions must be present somewhere in the split modules."""
-    import re
     modules = ["ui.js", "workspace.js", "sessions.js", "messages.js", "panels.js", "boot.js"]
     all_src = ""
     for m in modules:

--- a/tests/test_stage326_composer_draft_validation.py
+++ b/tests/test_stage326_composer_draft_validation.py
@@ -8,12 +8,6 @@ debounced auto-save. The hardening:
 - text: must be str; clamped to 50 KB
 - files: must be list; clamped to 50 entries
 """
-import json
-import os
-import sys
-import threading
-import urllib.request
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import pytest

--- a/tests/test_streaming_session_sidebar.py
+++ b/tests/test_streaming_session_sidebar.py
@@ -13,7 +13,6 @@ import api.models as models
 from api.models import (
     SESSIONS,
     STREAMS,
-    Session,
     all_sessions,
     new_session,
 )

--- a/tests/test_symlink_cycle_detection.py
+++ b/tests/test_symlink_cycle_detection.py
@@ -12,11 +12,9 @@ recursion.  Covers:
 - Browsing into a symlink directory via workspace-relative path works
 """
 import json
-import os
 import pathlib
 import urllib.request
 import urllib.error
-import tempfile
 
 from tests._pytest_port import BASE
 

--- a/tests/test_tls_support.py
+++ b/tests/test_tls_support.py
@@ -200,7 +200,6 @@ class TestTLSEndToEnd(unittest.TestCase):
             "HTTP fallback server did not start after TLS failure",
         )
         # Confirm TLS warning was printed
-        import fcntl
         os.set_blocking(self._proc.stdout.fileno(), False)
         output = ""
         try:

--- a/tests/test_tool_call_persistence.py
+++ b/tests/test_tool_call_persistence.py
@@ -6,7 +6,7 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(REPO_ROOT))
 
-from api.streaming import _extract_tool_calls_from_messages, _tool_result_snippet
+from api.streaming import _extract_tool_calls_from_messages, _tool_result_snippet  # noqa: E402
 
 
 def test_extract_tool_calls_from_openai_message_linkage():

--- a/tests/test_ttl_cache.py
+++ b/tests/test_ttl_cache.py
@@ -85,7 +85,7 @@ def test_ttl_expiry():
         config._cfg_mtime = 0.0
 
     # First call populates cache
-    result1 = config.get_available_models()
+    config.get_available_models()
     assert config._available_models_cache is not None, "Cache should be populated"
 
     # Record the cache timestamp
@@ -96,7 +96,7 @@ def test_ttl_expiry():
     offset = config._AVAILABLE_MODELS_CACHE_TTL + 10.0  # 70s past the real monotonic
 
     with patch.object(time, "monotonic", side_effect=lambda: original_monotonic() + offset):
-        result2 = config.get_available_models()
+        config.get_available_models()
 
     # The cache should have been refreshed — the timestamp must be newer
     assert config._available_models_cache_ts > cache_ts, (
@@ -122,7 +122,7 @@ def test_mtime_invalidation():
     config._cfg_mtime = real_mtime
 
     # First call populates cache
-    result1 = config.get_available_models()
+    config.get_available_models()
     assert config._available_models_cache is not None
 
     # Simulate config.yaml changed on disk by setting _cfg_mtime to 0
@@ -130,10 +130,8 @@ def test_mtime_invalidation():
     config._cfg_mtime = 0.0
 
     # The next call should detect mtime mismatch, reload, and invalidate cache
-    old_cache = config._available_models_cache
-    old_ts = config._available_models_cache_ts
 
-    result2 = config.get_available_models()
+    config.get_available_models()
 
     # Cache must have been refreshed — timestamp advanced since we reset it
     # to 0.0 on invalidation.
@@ -204,7 +202,7 @@ def test_invalidate_models_cache_direct():
         config._cfg_mtime = 0.0
 
     # First call populates cache
-    result1 = config.get_available_models()
+    config.get_available_models()
     assert config._available_models_cache is not None, "Cache should be populated"
     first_ts = config._available_models_cache_ts
 
@@ -217,7 +215,7 @@ def test_invalidate_models_cache_direct():
     )
 
     # Next call should re-scan and produce a fresh cache
-    result2 = config.get_available_models()
+    config.get_available_models()
     assert config._available_models_cache is not None, "Cache should be re-populated"
     assert config._available_models_cache_ts >= first_ts, (
         "Cache timestamp should be updated after re-scan"

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -14,9 +14,7 @@ Covers:
 
 import pathlib
 import re
-import threading
 import time
-import sys
 import os
 
 REPO = pathlib.Path(__file__).parent.parent
@@ -180,7 +178,6 @@ class TestScheduleRestart:
 
         # Monkeypatch os.execv inside the module's thread closure
         import os as _os
-        original_execv = _os.execv
 
         monkeypatch.setattr(_os, 'execv', fake_execv)
 

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -8,11 +8,8 @@ Tests cover the four new branches in _apply_update_inner():
   3. pull fails + no upstream tracking  → recovery command with set-upstream-to
   4. pull fails + generic fallback  → raw git output truncated at 300 chars
 """
-from pathlib import Path
-from unittest.mock import patch, call
-import subprocess
+from unittest.mock import patch
 
-import pytest
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_v050255_opus_followups.py
+++ b/tests/test_v050255_opus_followups.py
@@ -26,7 +26,6 @@ The v0.50.255 batch (#1390 + #1405) had four Opus advisor findings:
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
@@ -126,7 +125,7 @@ def test_redact_session_data_threads_enabled_once_across_recursion():
     from api import helpers
 
     call_count = [0]
-    real_load_settings = helpers.__dict__.get("load_settings")
+    helpers.__dict__.get("load_settings")
 
     def counting_load_settings():
         call_count[0] += 1

--- a/tests/test_v050257_opus_followups.py
+++ b/tests/test_v050257_opus_followups.py
@@ -37,7 +37,6 @@ import sys
 import tempfile
 from pathlib import Path
 
-import pytest
 
 REPO = Path(__file__).resolve().parents[1]
 
@@ -176,7 +175,6 @@ def test_session_load_metadata_only_returns_instance_not_dict():
     if a future change converts it to a dict."""
     sys.path.insert(0, str(REPO))
     from api.models import Session
-    import tempfile
 
     with tempfile.TemporaryDirectory() as tmpd:
         # Create a fake session file

--- a/tests/test_v050258_opus_followups.py
+++ b/tests/test_v050258_opus_followups.py
@@ -29,7 +29,6 @@ path-with-query string that the browser auto-decodes once.
 
 from __future__ import annotations
 
-import re
 import urllib.parse as _urlparse
 from pathlib import Path
 

--- a/tests/test_v050259_sessiondb_fd_leak.py
+++ b/tests/test_v050259_sessiondb_fd_leak.py
@@ -17,7 +17,6 @@ finalizes the agent — which on a long-running server may be never.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/test_version_badge.py
+++ b/tests/test_version_badge.py
@@ -10,9 +10,6 @@ Covers:
   6. static/panels.js: loadSettingsPanel() populates both version badges from settings
   7. server.py: server_version is not the old hardcoded string
 """
-import importlib
-import sys
-import types
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 

--- a/tests/test_workspace_add_quote_strip.py
+++ b/tests/test_workspace_add_quote_strip.py
@@ -12,7 +12,6 @@ This file pins the behaviour:
   - Mismatched / unpaired quotes are preserved (path may legitimately contain one).
   - Whitespace outside the quotes is also handled.
 """
-import pytest
 
 from api.workspace import _strip_surrounding_quotes
 


### PR DESCRIPTION
## Summary

- Ran `ruff check . --fix` and `--unsafe-fixes` to auto-resolve 417 fixable violations (F401 unused imports, F841 unused variables, E401 multi-import lines, F541 bare f-strings)
- Manually fixed E402 (module-import-not-at-top, 65 cases) with `# noqa: E402` suppression on intentional deferred/lazy imports
- Manually split E701/E702 (47 compound statements) to multi-line form
- Renamed E741 ambiguous variable names (`l` -> `ln`, 17 cases)
- Fixed F811 redundant imports in test_resolve_model_provider_free_suffix.py (4 cases)
- Fixed F401 unused imports in 3 test files
- Fixed F821 undefined-name bugs: added `as e` capture and pre-lambda `err_msg` capture in api/routes.py; added `# noqa: F821` for string forward reference in api/config.py

## Test plan

- [ ] Run `ruff check .` — all checks pass
- [ ] Run existing test suite to confirm no behavior changes

Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/
task-type: lint-fix
task-title: Linter Fixes
provider: claude
score: 0.3
cost-tier: Low (10-50k)
iterations: 1
duration: 14m4s
run-started: 2026-05-31T02:00:04-05:00
nightshift:metadata -->
