### PR TITLE
fix(updates): fall through when agent release tag is not ff-reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Agent self-update no longer advertises or applies unreachable release tags when the checkout tracks `main` past an older tag but the newest published tag lives on a divergent side branch (for example `v2026.5.29` → `v2026.5.29.2`). The update checker and apply path now fall through to the configured upstream branch when `git pull --ff-only <latest-tag>` cannot fast-forward, matching the existing #2653/#3140 release-vs-branch routing.
+
 ## [v0.51.185] — 2026-05-31 — Release FE (stage-batchE — clarify-card bug-fix batch: identical-prompt dedup + autofill guard + GBK startup crash)
 
 ### Fixed

--- a/api/updates.py
+++ b/api/updates.py
@@ -466,6 +466,14 @@ def _head_contains_ref(path, ref):
     return bool(ok)
 
 
+def _can_fast_forward_to(path, ref):
+    """Return True when ``ref`` is a descendant of HEAD (``git pull --ff-only`` can reach it)."""
+    if not ref:
+        return False
+    _, ok = _run_git(['merge-base', '--is-ancestor', 'HEAD', ref], path)
+    return bool(ok)
+
+
 def _select_apply_compare_ref(path):
     """Return the same remote ref family that the update check reports.
 
@@ -497,6 +505,8 @@ def _select_apply_compare_ref(path):
             behind == 0 and _head_is_past_latest_tag(path, current_tag)
         ) or (
             behind > 0 and _head_contains_ref(path, latest_tag)
+        ) or (
+            behind > 0 and not _can_fast_forward_to(path, latest_tag)
         ):
             pass
         else:
@@ -535,6 +545,12 @@ def _check_repo_release(path, name):
     # Fall through to the branch check so the banner compares against the
     # configured upstream instead of advertising a tag that cannot fast-forward.
     if behind > 0 and _head_contains_ref(path, latest_tag):
+        return None
+
+    # Patch releases can land on a side branch while day-to-day installs track
+    # main past an older tag. A positive tag-name gap then advertises an update
+    # that `git pull --ff-only <latest-tag>` cannot reach.
+    if behind > 0 and not _can_fast_forward_to(path, latest_tag):
         return None
 
     remote_url, _ = _run_git(['remote', 'get-url', 'origin'], path)

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -224,6 +224,8 @@ class TestUpdateChecker:
                 return 'v0.51.35\nv0.51.34\nv0.51.33', True
             if args[:3] == ['describe', '--tags', '--abbrev=0']:
                 return 'v0.51.34', True
+            if args == ['merge-base', '--is-ancestor', 'HEAD', 'v0.51.35']:
+                return '', True
             if args[:2] == ['remote', 'get-url']:
                 return 'https://github.com/nesquena/hermes-webui.git', True
             return '', False

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -13,6 +13,8 @@ def _fake_git_for_release_fetch_failure(args, cwd, timeout=10):
         return 'v0.51.103', True
     if args == ['merge-base', '--is-ancestor', 'v0.51.106', 'HEAD']:
         return '', False
+    if args == ['merge-base', '--is-ancestor', 'HEAD', 'v0.51.106']:
+        return '', True
     if args == ['remote', 'get-url', 'origin']:
         return 'https://github.com/nesquena/hermes-webui.git', True
     raise AssertionError(f'unexpected git args: {args!r}')
@@ -649,4 +651,58 @@ def test_select_apply_compare_ref_case_d_older_tag_with_commits_and_newer_tag_ex
         'should advance to the newer tag, not silently fall through to '
         'origin/<branch>. Regression for Opus-flagged drift in #2855.'
     )
+
+
+def test_check_repo_release_falls_through_when_latest_tag_is_not_ff_reachable(tmp_path):
+    """Main-tracking HEAD past an older tag cannot ff to a patch release tag.
+
+    Repro: installer puts agent on main at v2026.5.29+N-g..., maintainers cut
+    v2026.5.29.2 from a side branch. Tag gap is positive, but
+    ``git pull --ff-only v2026.5.29.2`` fails with diverging branches.
+    The release check must fall through to the upstream branch comparison.
+    """
+    (tmp_path / '.git').mkdir()
+
+    def fake_git(args, cwd, timeout=10):
+        if args == ['tag', '--list', 'v*', '--sort=-v:refname']:
+            return 'v2026.5.29.2\nv2026.5.29', True
+        if args == ['describe', '--tags', '--abbrev=0']:
+            return 'v2026.5.29', True
+        if args == ['describe', '--tags', '--always']:
+            return 'v2026.5.29-265-g5921d6678', True
+        if args == ['merge-base', '--is-ancestor', 'v2026.5.29.2', 'HEAD']:
+            return '', False
+        if args == ['merge-base', '--is-ancestor', 'HEAD', 'v2026.5.29.2']:
+            return '', False
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    with patch.object(updates, '_run_git', side_effect=fake_git):
+        result = updates._check_repo_release(tmp_path, 'agent')
+
+    assert result is None
+
+
+def test_select_apply_compare_ref_falls_through_when_latest_tag_is_not_ff_reachable(tmp_path):
+    """Apply path mirrors the ff-unreachable release-tag fall-through."""
+    (tmp_path / '.git').mkdir()
+
+    def fake_git(args, cwd, timeout=10):
+        if args == ['tag', '--list', 'v*', '--sort=-v:refname']:
+            return 'v2026.5.29.2\nv2026.5.29', True
+        if args == ['describe', '--tags', '--abbrev=0']:
+            return 'v2026.5.29', True
+        if args == ['describe', '--tags', '--always']:
+            return 'v2026.5.29-265-g5921d6678', True
+        if args == ['merge-base', '--is-ancestor', 'v2026.5.29.2', 'HEAD']:
+            return '', False
+        if args == ['merge-base', '--is-ancestor', 'HEAD', 'v2026.5.29.2']:
+            return '', False
+        if args == ['rev-parse', '--abbrev-ref', '@{upstream}']:
+            return 'origin/main', True
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    with patch.object(updates, '_run_git', side_effect=fake_git):
+        ref = updates._select_apply_compare_ref(tmp_path)
+
+    assert ref == 'origin/main'
 


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI self-update should only advertise updates that `git pull --ff-only` can actually apply
- Official agent installs often track `origin/main` while release tags (for example `v2026.5.29.2`) are cut from side branches
- Existing fall-through logic covers HEAD past the same tag (#2653) and HEAD already containing the newest tag (#3140)
- Missing case: positive tag gap where the newest tag is **not** a descendant of HEAD (diverged histories)
- The banner then shows `v2026.5.29 -> v2026.5.29.2`, but Update Now runs `git pull --ff-only v2026.5.29.2` and fails with diverging branches
- This PR adds an ff-reachability check so check and apply both fall through to the configured upstream branch

## What Changed

- Added `_can_fast_forward_to()` in `api/updates.py`
- `_check_repo_release()` and `_select_apply_compare_ref()` now fall through when `behind > 0` but HEAD cannot ff to `latest_tag`
- Added regression tests mirroring the main-tracking + patch-tag divergence scenario
- Updated existing mocks/tests that exercise release-gap checks
- Added an `[Unreleased]` CHANGELOG entry

## Why It Matters

Operators on main-tracking agent installs get a broken Update Now button and a misleading release banner even when `git pull --ff-only origin main` is the correct update path. Check and apply were out of sync with git reality.

## Verification

```bash
pytest tests/test_updates.py tests/test_update_checker.py -q --timeout=60
pytest tests/test_update_banner_fixes.py::TestUpdateChecker::test_release_check_counts_release_gap -q --timeout=60
```

Manual repro on a main-tracking `~/.hermes/hermes-agent` checkout:
- before: banner advertised `v2026.5.29 -> v2026.5.29.2`, Update Now failed
- after: update check falls through to `origin/main`; apply ref is `origin/main`

## Risks / Follow-ups

- Release-line checkouts that genuinely need a newer tag but cannot ff (local commits on top of an older tag) will now fall through to branch comparison instead of targeting the tag. Case D coverage remains: ff-reachable tag updates still target the tag.
- No UI/layout changes; no before/after screenshots needed.

## Model Used

Cursor / Claude — assisted with root-cause analysis, patch, tests, and PR prep.