### PR TITLE
feat: add operator mission control surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Slice 8 Device Admin Foundations: a manual, read-only operator surface for source-backed host/path allowlist state, dry-run previews, receipt-log visibility, and per-action approval requirements with execution disabled.
+- Added the Slice 7 Docs/Artifact Browser operator panel, a manual read-only browser for allowlisted local plans, briefs, action summaries, manifests, state summaries, and changelog entries with bounded previews, honest missing/stale/unknown states, no fake cards, and no apply path.
+- Added a manual read-only Session Recall operator panel for source-backed saved-session search, stale/historical proof labels, and local-only task or memory/skill review proposals with no apply path and no direct memory/skill mutation.
+- Added a local Memory + Skill Review operator queue for proposed memory/skill mutations, showing reviewable diffs, source evidence, durable/transient classification, stale/expiry state, approve/deny review status, and rollback context without applying changes or mutating memory/skill files.
+- Added a read-only Operator Kanban panel for the `hermes-operator` board that surfaces task status, scratch safety, blockers, receipt/completion metadata, and review state without dispatching or mutating tasks.
+- Added a manual read-only Reverse Prompt v0 proposal surface with `/api/operator/proposals`, source-backed next-action cards, and draft-only handoff controls that do not execute actions.
+- Added a read-only Operator Truth Strip proof layer with `/api/operator/truth` and compact composer chips for live/stale/unknown workspace, profile, WebUI state, Kanban board, and scratch-safety receipts.
+
+### Changed
+
+- Renamed the operator `Actions` chip to `Proposals` and clarified the empty Commitments state so the proposal-to-commitment workflow is discoverable.
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/api/operator_commitments.py
+++ b/api/operator_commitments.py
@@ -1,0 +1,856 @@
+"""Local commitment cards for the Hermes operator surface.
+
+Slice 4 turns source-backed promises into durable local objects. This module is
+intentionally isolated from Kanban, cron, goals, chat execution, shell commands,
+and external services. Promotion writes only to the WebUI local state directory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+STATUS_ORDER = {"live": 0, "stale": 1, "unknown": 2}
+VALID_COMMITMENT_STATUSES = {"active", "blocked", "met", "halted", "superseded"}
+ALLOWED_DISPATCH_KINDS = {"manual", "handoff", "human_review"}
+FORBIDDEN_DISPATCH_TOKENS = {
+    "cron",
+    "goal",
+    "goal_loop",
+    "background",
+    "background_loop",
+    "auto",
+    "auto_dispatch",
+    "dispatcher",
+    "kanban_dispatch",
+    "kanban_dispatcher",
+    "shell",
+    "webhook",
+    "aim",
+    "aim_cron",
+    "aim_runtime",
+}
+PLACEHOLDER_TEXT = {"", "unknown", "none", "null", "tbd", "todo", "unassigned"}
+MAX_TEXT = 500
+MAX_LIST_ITEMS = 12
+STORE_VERSION = 1
+_SESSION_MESSAGE_CONTENT_HASH_RE = re.compile(r"^sha256:[0-9a-fA-F]{64}$")
+_SESSION_MESSAGE_INDEX_RE = re.compile(r"^\d+$")
+_SESSION_MESSAGE_ID_RE = re.compile(r"^[0-9A-Za-z_\-]+$")
+_RAW_SECRET_QUOTE_RE = re.compile(
+    r"""
+    \b(?:
+        password|passwd|pwd|
+        token|access[_\-\s]?token|refresh[_\-\s]?token|auth[_\-\s]?token|
+        api[_\-\s]?key|apikey|
+        secret|client[_\-\s]?secret|private[_\-\s]?key|
+        authorization
+    )\b
+    \s*[:=]\s*
+    (?P<value>["']?[^"'\s,;]+["']?)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_RAW_BEARER_SECRET_QUOTE_RE = re.compile(r"\bBearer\s+(?P<value>[A-Za-z0-9._~+/=-]{16,})(?=$|[\s,;])", re.IGNORECASE)
+_RAW_OPENAI_SECRET_QUOTE_RE = re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_-]{16,}(?=$|[\s,;])", re.IGNORECASE)
+_RAW_SLACK_SECRET_QUOTE_RE = re.compile(r"\bxox[abp]-[0-9A-Za-z-]{10,}(?=$|[\s,;])", re.IGNORECASE)
+_RAW_GITHUB_SECRET_QUOTE_RE = re.compile(r"\b(?:ghp|github_pat)_[A-Za-z0-9_]{16,}(?![A-Za-z0-9_])", re.IGNORECASE)
+_STORE_LOCK = threading.Lock()
+
+
+def commitment_store_path() -> Path:
+    """Return the local WebUI state path for operator commitment cards."""
+    from api import config
+
+    return Path(config.STATE_DIR) / "operator_commitments.json"
+
+
+def build_operator_commitments_payload(
+    *,
+    session_id: str | None = None,
+    ui_board_hint: str | None = None,
+    now: float | None = None,
+    profile: str | None = None,
+) -> dict[str, Any]:
+    """Build a versioned local commitment-card payload.
+
+    Missing, malformed, or invalid local state degrades to unknown/stale. The
+    function never fabricates sample cards and never creates the store while
+    reading.
+    """
+
+    generated_at = float(time.time() if now is None else now)
+    store = commitment_store_path()
+    sources: list[dict[str, Any]] = []
+    issues: list[str] = []
+    notes: list[dict[str, Any]] = []
+
+    truth = _operator_truth_summary(session_id=session_id, ui_board_hint=ui_board_hint, now=generated_at)
+    sources.append({"id": "operator_truth", "kind": "api", "api": "/api/operator/truth", "state": truth.get("status", "unknown")})
+    if truth.get("status") in {"stale", "unknown"}:
+        issues.append(f"operator_truth is {truth.get('status')}")
+    if truth.get("issues"):
+        issues.extend(f"operator_truth: {issue}" for issue in truth.get("issues", [])[:5])
+
+    store_source = _store_source(store)
+    sources.insert(0, store_source)
+    if store_source.get("state") == "unknown":
+        issue = store_source.get("issue") or "missing or unavailable"
+        issues.append(f"commitment_store: {issue}")
+        return _payload(
+            generated_at=generated_at,
+            status="unknown",
+            summary="Commitments unavailable — local store missing or unreadable",
+            commitments=[],
+            notes=notes,
+            truth=truth,
+            sources=sources,
+            issues=_dedupe(issues),
+        )
+
+    data, read_issue = _read_store(store)
+    if read_issue:
+        store_source["state"] = "unknown"
+        store_source["issue"] = read_issue
+        issues.append(f"commitment_store: {read_issue}")
+        return _payload(
+            generated_at=generated_at,
+            status="unknown",
+            summary="Commitments unavailable — local store malformed",
+            commitments=[],
+            notes=notes,
+            truth=truth,
+            sources=sources,
+            issues=_dedupe(issues),
+        )
+
+    raw_items = data.get("commitments", []) if isinstance(data, dict) else []
+    commitments: list[dict[str, Any]] = []
+    status_inputs = ["live", store_source.get("state", "unknown"), truth.get("status", "unknown")]
+    for index, item in enumerate(raw_items):
+        card, note = _normalize_stored_commitment(item, generated_at=generated_at, profile=profile)
+        if card:
+            commitments.append(card)
+        if note:
+            notes.append(note)
+            missing_fields = note.get("missing") if isinstance(note.get("missing"), list) else []
+            missing_text = f" missing={','.join(str(item) for item in missing_fields)}" if missing_fields else ""
+            issues.append(f"commitment_store[{index}]: {note.get('reason', 'invalid commitment')}{missing_text}")
+            status_inputs.append("stale")
+
+    status = _worst_status(status_inputs)
+    summary = f"{len(commitments)} commitment{'s' if len(commitments) != 1 else ''} from local state"
+    if notes:
+        summary += f"; {len(notes)} note{'s' if len(notes) != 1 else ''} need required fields"
+    if not commitments and not notes:
+        summary = "0 commitments from local state"
+
+    return _payload(
+        generated_at=generated_at,
+        status=status,
+        summary=summary,
+        commitments=commitments,
+        notes=notes,
+        truth=truth,
+        sources=sources,
+        issues=_dedupe(issues),
+    )
+
+
+def promote_operator_commitment(
+    body: dict[str, Any],
+    *,
+    now: float | None = None,
+    client_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Promote a source-backed candidate into a local commitment card."""
+
+    generated_at = float(time.time() if now is None else now)
+    request = body if isinstance(body, dict) else {}
+    missing: list[str] = []
+    issues: list[str] = []
+
+    owner = _clean_required_text(request.get("owner"), max_len=120)
+    if not owner:
+        missing.append("owner")
+
+    deadline_at, review_at, date_issue = _normalize_date_fields(request.get("deadline_at"), request.get("review_at"))
+    if date_issue:
+        missing.append("deadline_or_review")
+        issues.append(date_issue)
+
+    dispatch, dispatch_issue = _normalize_dispatch_mechanism(request.get("dispatch_mechanism"))
+    if dispatch_issue:
+        missing.append("dispatch_mechanism")
+        issues.append(dispatch_issue)
+
+    acceptance = _normalize_text_list(request.get("acceptance_criteria"))
+    if not acceptance:
+        missing.append("acceptance_criteria")
+
+    halt_policy = _clean_required_text(request.get("halt_policy"), max_len=1000)
+    if not halt_policy:
+        missing.append("halt_policy")
+
+    status = _clean_text(request.get("status"), "active", max_len=40).lower()
+    if status not in VALID_COMMITMENT_STATUSES:
+        missing.append("status")
+        issues.append("status must be one of: " + ", ".join(sorted(VALID_COMMITMENT_STATUSES)))
+
+    source, source_evidence, source_defaults, source_issue = _resolve_source(request.get("source"), now=generated_at)
+    if source_issue:
+        missing.append("source")
+        issues.append(source_issue)
+
+    extra_evidence = _normalize_evidence(request.get("evidence"))
+    evidence = source_evidence + extra_evidence
+    if not evidence:
+        missing.append("evidence")
+
+    if missing:
+        return {
+            "ok": False,
+            "classification": "note",
+            "missing": sorted(set(missing)),
+            "issues": _dedupe(issues),
+            "would_execute": False,
+        }
+
+    title = _clean_required_text(request.get("title"), max_len=200) or source_defaults.get("title") or "Untitled commitment"
+    summary = _clean_text(request.get("summary"), source_defaults.get("summary", ""), max_len=800)
+    profile = _clean_text(request.get("profile"), "", max_len=80) or _clean_text((client_context or {}).get("profile"), "default", max_len=80) or "default"
+
+    card_seed = json.dumps(
+        {
+            "owner": owner,
+            "deadline_at": deadline_at,
+            "review_at": review_at,
+            "title": title,
+            "source": source,
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    card_id = "c_" + hashlib.sha256(card_seed.encode("utf-8")).hexdigest()[:16]
+    card = {
+        "id": card_id,
+        "created_at": generated_at,
+        "updated_at": generated_at,
+        "profile": profile,
+        "title": title,
+        "summary": summary,
+        "owner": owner,
+        "deadline_at": deadline_at,
+        "review_at": review_at,
+        "dispatch_mechanism": dispatch,
+        "source": source,
+        "acceptance_criteria": acceptance,
+        "halt_policy": halt_policy,
+        "evidence": evidence,
+        "status": status,
+        "would_execute": False,
+    }
+
+    store, store_issue = _load_store_for_write()
+    if store_issue:
+        return {
+            "ok": False,
+            "classification": "unknown",
+            "missing": [],
+            "issues": [store_issue],
+            "would_execute": False,
+        }
+
+    items = store.setdefault("commitments", [])
+    replaced = False
+    for index, existing in enumerate(list(items)):
+        if isinstance(existing, dict) and existing.get("id") == card_id:
+            card["created_at"] = existing.get("created_at", generated_at)
+            items[index] = card
+            replaced = True
+            break
+    if not replaced:
+        items.append(card)
+    store["version"] = STORE_VERSION
+    store["updated_at"] = generated_at
+    _write_store(store)
+
+    return {"ok": True, "commitment": card, "created": not replaced, "would_execute": False}
+
+
+def _payload(
+    *,
+    generated_at: float,
+    status: str,
+    summary: str,
+    commitments: list[dict[str, Any]],
+    notes: list[dict[str, Any]],
+    truth: dict[str, Any],
+    sources: list[dict[str, Any]],
+    issues: list[str],
+) -> dict[str, Any]:
+    return {
+        "version": STORE_VERSION,
+        "generated_at": generated_at,
+        "status": status if status in STATUS_ORDER else "unknown",
+        "summary": summary,
+        "mode": "local-commitment-cards",
+        "would_execute": False,
+        "commitments": commitments,
+        "notes": notes,
+        "truth": truth,
+        "sources": sources,
+        "issues": issues,
+    }
+
+
+def _store_source(path: Path) -> dict[str, Any]:
+    item = {
+        "id": "commitment_store",
+        "kind": "json",
+        "path": str(path),
+        "exists": False,
+        "state": "unknown",
+        "required": False,
+    }
+    try:
+        item["exists"] = path.exists()
+        if not item["exists"]:
+            item["issue"] = "missing"
+            return item
+        if not path.is_file():
+            item["issue"] = "not a regular file"
+            return item
+        stat = path.stat()
+        item["mtime"] = stat.st_mtime
+        item["state"] = "live"
+        return item
+    except Exception as exc:  # pragma: no cover - filesystem edge case
+        item["issue"] = f"unreadable: {_short_error(exc)}"
+        return item
+
+
+def _read_store(path: Path) -> tuple[dict[str, Any], str | None]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
+    except json.JSONDecodeError as exc:
+        return {}, f"malformed JSON: {exc.msg}"
+    except Exception as exc:
+        return {}, f"unreadable: {_short_error(exc)}"
+    if not isinstance(data, dict):
+        return {}, "malformed JSON: top-level object required"
+    if data.get("version") != STORE_VERSION:
+        return {}, f"unsupported version: {data.get('version')!r}"
+    if not isinstance(data.get("commitments"), list):
+        return {}, "malformed JSON: commitments list required"
+    return data, None
+
+
+def _load_store_for_write() -> tuple[dict[str, Any], str | None]:
+    path = commitment_store_path()
+    if not path.exists():
+        return {"version": STORE_VERSION, "updated_at": 0.0, "commitments": []}, None
+    source = _store_source(path)
+    if source.get("state") == "unknown":
+        return {}, f"commitment_store: {source.get('issue') or 'unreadable'}"
+    return _read_store(path)
+
+
+def _write_store(data: dict[str, Any]) -> None:
+    path = commitment_store_path()
+    payload = json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _STORE_LOCK:
+        tmp = path.with_suffix(f".tmp.{os.getpid()}.{threading.current_thread().ident}")
+        try:
+            with open(tmp, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                tmp.unlink(missing_ok=True)
+            except Exception:
+                pass
+            raise
+
+
+def _normalize_stored_commitment(record: Any, *, generated_at: float, profile: str | None) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    if not isinstance(record, dict):
+        return None, {"classification": "note", "reason": "record is not an object", "missing": ["object"]}
+
+    missing: list[str] = []
+    owner = _clean_required_text(record.get("owner"), max_len=120)
+    if not owner:
+        missing.append("owner")
+
+    deadline_at, review_at, date_issue = _normalize_date_fields(record.get("deadline_at"), record.get("review_at"))
+    if date_issue:
+        missing.append("deadline_or_review")
+
+    dispatch, dispatch_issue = _normalize_dispatch_mechanism(record.get("dispatch_mechanism"))
+    if dispatch_issue:
+        missing.append("dispatch_mechanism")
+
+    source = record.get("source") if isinstance(record.get("source"), dict) else None
+    if not _stored_source_has_proof(source):
+        missing.append("source")
+
+    acceptance = _normalize_text_list(record.get("acceptance_criteria"))
+    if not acceptance:
+        missing.append("acceptance_criteria")
+
+    halt_policy = _clean_required_text(record.get("halt_policy"), max_len=1000)
+    if not halt_policy:
+        missing.append("halt_policy")
+
+    evidence = _normalize_evidence(record.get("evidence"))
+    if not _evidence_has_proof(evidence):
+        missing.append("evidence")
+
+    status = _clean_text(record.get("status"), "", max_len=40).lower()
+    if status not in VALID_COMMITMENT_STATUSES:
+        missing.append("status")
+
+    if record.get("would_execute") is not False:
+        missing.append("would_execute_false")
+    if isinstance(record.get("dispatch_mechanism"), dict) and record["dispatch_mechanism"].get("would_execute") is not False:
+        missing.append("dispatch_would_execute_false")
+
+    if missing:
+        title = _clean_text(record.get("title"), _clean_text(record.get("id"), "note", max_len=120), max_len=200)
+        return None, {"id": _clean_text(record.get("id"), "", max_len=80), "title": title, "classification": "note", "missing": sorted(set(missing)), "reason": "missing required commitment fields"}
+
+    card = {
+        "id": _clean_text(record.get("id"), "", max_len=80) or _stable_record_id(record),
+        "created_at": _number(record.get("created_at"), generated_at),
+        "updated_at": _number(record.get("updated_at"), generated_at),
+        "profile": _clean_text(record.get("profile"), profile or "default", max_len=80),
+        "title": _clean_text(record.get("title"), "Untitled commitment", max_len=200),
+        "summary": _clean_text(record.get("summary"), "", max_len=800),
+        "owner": owner,
+        "deadline_at": deadline_at,
+        "review_at": review_at,
+        "dispatch_mechanism": dispatch,
+        "source": _normalize_source_for_display(source),
+        "acceptance_criteria": acceptance,
+        "halt_policy": halt_policy,
+        "evidence": evidence,
+        "status": status,
+        "would_execute": False,
+    }
+    return card, None
+
+
+def _stored_source_has_proof(source: Any) -> bool:
+    if not isinstance(source, dict):
+        return False
+    kind = _clean_text(source.get("kind"), "", max_len=60).lower()
+    content_hash = _clean_required_text(source.get("content_hash"), max_len=140)
+    quote = _clean_required_text(source.get("quote"), max_len=MAX_TEXT)
+    if kind == "operator_proposal":
+        return bool(
+            _clean_required_text(source.get("proposal_id"), max_len=120)
+            and content_hash
+            and quote
+        )
+    if kind == "session_message":
+        session_id = _clean_required_text(source.get("session_id"), max_len=120)
+        index, index_issue = _normalize_session_message_index(source.get("message_index"))
+        strict_content_hash, hash_issue = _normalize_session_message_content_hash(source.get("content_hash"))
+        strict_quote, quote_issue = _normalize_session_message_quote(source.get("quote"))
+        return bool(
+            session_id
+            and _SESSION_MESSAGE_ID_RE.fullmatch(session_id)
+            and index is not None
+            and not index_issue
+            and strict_content_hash
+            and not hash_issue
+            and strict_quote
+            and not quote_issue
+        )
+    return False
+
+
+def _evidence_has_proof(evidence: list[dict[str, Any]]) -> bool:
+    for item in evidence:
+        if not isinstance(item, dict):
+            continue
+        label = _clean_required_text(item.get("label"), max_len=160).lower()
+        state = _clean_text(item.get("state"), "", max_len=40).lower()
+        identifiers = ["path", "api", "proposal_id", "session_id", "message_index", "source_id"]
+        if any(_clean_required_text(item.get(key), max_len=MAX_TEXT) for key in identifiers):
+            return True
+        if label and label not in {"evidence", "unknown"} and state not in PLACEHOLDER_TEXT:
+            return True
+    return False
+
+
+def _resolve_source(value: Any, *, now: float) -> tuple[dict[str, Any] | None, list[dict[str, Any]], dict[str, str], str | None]:
+    if not isinstance(value, dict):
+        return None, [], {}, "source is required"
+    kind = _clean_text(value.get("kind"), "", max_len=60).lower()
+    if kind == "operator_proposal":
+        return _resolve_operator_proposal(value, now=now)
+    if kind == "session_message":
+        return _resolve_session_message(value)
+    return None, [], {}, "source kind must be operator_proposal or session_message"
+
+
+def _resolve_operator_proposal(value: dict[str, Any], *, now: float) -> tuple[dict[str, Any] | None, list[dict[str, Any]], dict[str, str], str | None]:
+    proposal_id = _clean_required_text(value.get("proposal_id"), max_len=120)
+    if not proposal_id:
+        return None, [], {}, "operator proposal source requires proposal_id"
+    session_id = _clean_text(value.get("session_id"), "", max_len=120) or None
+    ui_board_hint = _clean_text(value.get("ui_board"), "", max_len=120) or None
+    try:
+        from api.operator_proposals import build_operator_proposal_payload
+
+        payload = build_operator_proposal_payload(session_id=session_id, ui_board_hint=ui_board_hint, now=now)
+    except Exception as exc:
+        return None, [], {}, f"operator proposal source unavailable: {_short_error(exc)}"
+    proposals = payload.get("proposals") if isinstance(payload, dict) else None
+    if not isinstance(proposals, list):
+        return None, [], {}, "operator proposal source unavailable: malformed proposals payload"
+    proposal = next((item for item in proposals if isinstance(item, dict) and item.get("id") == proposal_id), None)
+    if not proposal:
+        return None, [], {}, f"operator proposal source not found: {proposal_id}"
+
+    quote = _clean_text(proposal.get("summary"), _clean_text(proposal.get("title"), proposal_id, max_len=MAX_TEXT), max_len=MAX_TEXT)
+    digest = _hash_json({"kind": "operator_proposal", "proposal": proposal_id, "summary": quote})
+    source = {
+        "kind": "operator_proposal",
+        "proposal_id": proposal_id,
+        "session_id": session_id,
+        "content_hash": digest,
+        "quote": quote,
+    }
+    evidence = [
+        {
+            "kind": "source",
+            "label": "Operator proposal",
+            "state": _clean_text(payload.get("status"), "unknown", max_len=20),
+            "proposal_id": proposal_id,
+        }
+    ]
+    for ev in _normalize_evidence(proposal.get("evidence"))[:4]:
+        evidence.append(ev)
+    defaults = {
+        "title": _clean_text(proposal.get("title"), proposal_id, max_len=200),
+        "summary": quote,
+    }
+    return source, evidence, defaults, None
+
+
+def _resolve_session_message(value: dict[str, Any]) -> tuple[dict[str, Any] | None, list[dict[str, Any]], dict[str, str], str | None]:
+    """Validate an explicit UI/API session-message proof without reloading sessions."""
+
+    session_id = _clean_required_text(value.get("session_id"), max_len=120)
+    if not session_id:
+        return None, [], {}, "session message source requires session_id"
+    if not _SESSION_MESSAGE_ID_RE.fullmatch(session_id):
+        return None, [], {}, "session message source has invalid session_id"
+
+    index, index_issue = _normalize_session_message_index(value.get("message_index"))
+    if index_issue:
+        return None, [], {}, index_issue
+
+    content_hash, hash_issue = _normalize_session_message_content_hash(value.get("content_hash"))
+    if hash_issue:
+        return None, [], {}, hash_issue
+
+    quote, quote_issue = _normalize_session_message_quote(value.get("quote"))
+    if quote_issue:
+        return None, [], {}, quote_issue
+    if index is None or content_hash is None or quote is None:  # defensive: helpers return an issue with None
+        return None, [], {}, "session message source proof is invalid"
+
+    source: dict[str, Any] = {
+        "kind": "session_message",
+        "session_id": session_id,
+        "message_index": index,
+        "content_hash": content_hash,
+        "quote": quote,
+    }
+    message_role = _clean_required_text(value.get("message_role"), max_len=40)
+    if message_role:
+        source["message_role"] = message_role
+
+    evidence = [
+        {
+            "kind": "source",
+            "label": "Session message",
+            "state": "present",
+            "session_id": session_id,
+            "message_index": index,
+            "content_hash": content_hash,
+        }
+    ]
+    defaults = {"title": quote[:120] or "Session commitment", "summary": quote}
+    return source, evidence, defaults, None
+
+
+def _normalize_session_message_index(value: Any) -> tuple[int | None, str | None]:
+    if isinstance(value, bool):
+        return None, "session message source requires strict non-negative integer message_index"
+    if isinstance(value, int):
+        if value >= 0:
+            return value, None
+        return None, "session message source requires strict non-negative integer message_index"
+    if isinstance(value, str):
+        text = value.strip()
+        if _SESSION_MESSAGE_INDEX_RE.fullmatch(text):
+            return int(text), None
+    return None, "session message source requires strict non-negative integer message_index"
+
+
+def _normalize_session_message_content_hash(value: Any) -> tuple[str | None, str | None]:
+    if not isinstance(value, str):
+        return None, "session message source requires content_hash matching sha256:<64 hex>"
+    text = value.strip()
+    if not _SESSION_MESSAGE_CONTENT_HASH_RE.fullmatch(text):
+        return None, "session message source requires content_hash matching sha256:<64 hex>"
+    return "sha256:" + text.split(":", 1)[1].lower(), None
+
+
+def _normalize_session_message_quote(value: Any) -> tuple[str | None, str | None]:
+    if not isinstance(value, str):
+        return None, "session message source requires bounded redacted quote"
+    quote = re.sub(r"\s+", " ", value).strip()
+    if not quote or quote.lower() in PLACEHOLDER_TEXT:
+        return None, "session message source requires bounded redacted quote"
+    if len(quote) > MAX_TEXT:
+        return None, f"session message source quote must be at most {MAX_TEXT} characters"
+    if _quote_contains_raw_secret(quote):
+        return None, "session message source quote appears to contain a raw secret; use a redacted quote"
+    return quote, None
+
+
+def _quote_contains_raw_secret(quote: str) -> bool:
+    for match in _RAW_SECRET_QUOTE_RE.finditer(quote):
+        if not _is_redacted_secret_value(match.group("value")):
+            return True
+    return any(
+        pattern.search(quote)
+        for pattern in (
+            _RAW_BEARER_SECRET_QUOTE_RE,
+            _RAW_OPENAI_SECRET_QUOTE_RE,
+            _RAW_SLACK_SECRET_QUOTE_RE,
+            _RAW_GITHUB_SECRET_QUOTE_RE,
+        )
+    )
+
+
+def _is_redacted_secret_value(value: str) -> bool:
+    token = value.strip().strip("'\"").strip()
+    normalized = token.strip("[](){}<>").lower()
+    if normalized in {"redacted", "masked", "hidden", "removed", "withheld", "scrubbed"}:
+        return True
+    compact = token.replace(" ", "")
+    return bool(compact) and set(compact) <= {"*", "x", "X", "•", "…"}
+
+
+def _operator_truth_summary(*, session_id: str | None, ui_board_hint: str | None, now: float) -> dict[str, Any]:
+    try:
+        from api.operator_truth import build_operator_truth_payload
+
+        payload = build_operator_truth_payload(session_id=session_id, ui_board_hint=ui_board_hint, now=now)
+    except Exception as exc:
+        return {"status": "unknown", "verified_at": now, "summary": "Truth unavailable", "api": "/api/operator/truth", "issues": [_short_error(exc)]}
+    raw_status = payload.get("status")
+    status = raw_status if isinstance(raw_status, str) and raw_status in STATUS_ORDER else "unknown"
+    return {
+        "status": status,
+        "verified_at": payload.get("verified_at", now),
+        "summary": payload.get("summary") or f"Truth {status}",
+        "api": "/api/operator/truth",
+        "issues": [str(issue) for issue in payload.get("issues", [])[:5]] if isinstance(payload.get("issues"), list) else [],
+    }
+
+
+def _normalize_dispatch_mechanism(value: Any) -> tuple[dict[str, Any] | None, str | None]:
+    if isinstance(value, str):
+        raw_kind = value
+        label = value
+        would_execute = False
+    elif isinstance(value, dict):
+        raw_kind = value.get("kind") or value.get("type") or value.get("mode")
+        label = value.get("label") or raw_kind
+        would_execute = value.get("would_execute", False)
+    else:
+        return None, "dispatch_mechanism is required"
+
+    kind = _clean_text(raw_kind, "", max_len=80).lower().replace("-", "_").replace(" ", "_")
+    label_text = _clean_text(label, kind or "manual", max_len=160)
+    combined = f"{kind} {label_text}".lower()
+    if not kind or kind in PLACEHOLDER_TEXT:
+        return None, "dispatch_mechanism is required"
+    if kind not in ALLOWED_DISPATCH_KINDS:
+        return None, "dispatch_mechanism kind must be one of: " + ", ".join(sorted(ALLOWED_DISPATCH_KINDS))
+    if any(token in combined for token in FORBIDDEN_DISPATCH_TOKENS):
+        return None, "dispatch_mechanism must not describe automation, cron, goal, Kanban dispatch, shell, webhook, or AIM runtime"
+    if would_execute is not False:
+        return None, "dispatch_mechanism.would_execute must be false"
+    return {"kind": kind, "label": label_text, "would_execute": False}, None
+
+
+def _normalize_date_fields(deadline: Any, review: Any) -> tuple[str | None, str | None, str | None]:
+    deadline_text = _clean_text(deadline, "", max_len=80)
+    review_text = _clean_text(review, "", max_len=80)
+    if not deadline_text and not review_text:
+        return None, None, "deadline_at or review_at is required"
+    if deadline_text:
+        normalized = _normalize_isoish_date(deadline_text)
+        if not normalized:
+            return None, None, "deadline_at must be an ISO date or datetime"
+        deadline_text = normalized
+    if review_text:
+        normalized = _normalize_isoish_date(review_text)
+        if not normalized:
+            return None, None, "review_at must be an ISO date or datetime"
+        review_text = normalized
+    return deadline_text or None, review_text or None, None
+
+
+def _normalize_isoish_date(value: str) -> str | None:
+    text = value.strip()
+    try:
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", text):
+            datetime.strptime(text, "%Y-%m-%d")
+            return text
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    except Exception:
+        return None
+
+
+def _normalize_text_list(value: Any) -> list[str]:
+    raw_items: list[Any]
+    if isinstance(value, list):
+        raw_items = value
+    elif isinstance(value, str):
+        raw_items = [line.strip(" -\t") for line in value.splitlines()]
+    else:
+        raw_items = []
+    items = []
+    for item in raw_items:
+        text = _clean_required_text(item, max_len=MAX_TEXT)
+        if text:
+            items.append(text)
+        if len(items) >= MAX_LIST_ITEMS:
+            break
+    return items
+
+
+def _normalize_evidence(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    evidence: list[dict[str, Any]] = []
+    for item in value[:MAX_LIST_ITEMS]:
+        if isinstance(item, dict):
+            label = _clean_text(item.get("label"), _clean_text(item.get("source_id"), "evidence", max_len=120), max_len=160)
+            state = _clean_text(item.get("state") or item.get("status"), "unknown", max_len=40)
+            ev = {"kind": _clean_text(item.get("kind"), "evidence", max_len=60), "label": label, "state": state}
+            for key in ("path", "api", "proposal_id", "session_id", "message_index", "source_id"):
+                if key in item and item.get(key) is not None:
+                    ev[key] = _clean_text(item.get(key), str(item.get(key)), max_len=MAX_TEXT)
+            evidence.append(ev)
+        else:
+            text = _clean_required_text(item, max_len=MAX_TEXT)
+            if text:
+                evidence.append({"kind": "evidence", "label": text, "state": "unknown"})
+    return evidence
+
+
+def _normalize_source_for_display(source: dict[str, Any]) -> dict[str, Any]:
+    result = {}
+    for key in ("kind", "proposal_id", "session_id", "message_index", "message_role", "content_hash", "quote"):
+        if key in source and source.get(key) is not None:
+            result[key] = _clean_text(source.get(key), str(source.get(key)), max_len=MAX_TEXT)
+    return result
+
+
+def _clean_required_text(value: Any, *, max_len: int) -> str:
+    text = _clean_text(value, "", max_len=max_len)
+    if text.strip().lower() in PLACEHOLDER_TEXT:
+        return ""
+    return text
+
+
+def _clean_text(value: Any, fallback: str = "", *, max_len: int = MAX_TEXT) -> str:
+    if value is None:
+        text = fallback
+    else:
+        text = str(value)
+    text = re.sub(r"\s+", " ", text).strip()
+    if not text:
+        text = fallback.strip() if isinstance(fallback, str) else str(fallback).strip()
+    if len(text) > max_len:
+        text = text[: max_len - 1].rstrip() + "…"
+    return text
+
+
+def _message_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict):
+                if isinstance(item.get("text"), str):
+                    parts.append(item["text"])
+                elif isinstance(item.get("content"), str):
+                    parts.append(item["content"])
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(parts)
+    return ""
+
+
+def _number(value: Any, fallback: float) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return fallback
+
+
+def _stable_record_id(record: dict[str, Any]) -> str:
+    return "c_" + hashlib.sha256(json.dumps(record, sort_keys=True, default=str).encode("utf-8")).hexdigest()[:16]
+
+
+def _hash_json(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(json.dumps(value, sort_keys=True, ensure_ascii=False, default=str).encode("utf-8")).hexdigest()
+
+
+def _worst_status(values: list[Any]) -> str:
+    worst = "live"
+    for value in values:
+        status = value if isinstance(value, str) and value in STATUS_ORDER else "unknown"
+        if STATUS_ORDER[status] > STATUS_ORDER[worst]:
+            worst = status
+    return worst
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        text = str(item or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            out.append(text)
+    return out
+
+
+def _short_error(exc: Exception) -> str:
+    return str(exc).splitlines()[0][:180]

--- a/api/operator_device_admin.py
+++ b/api/operator_device_admin.py
@@ -1,0 +1,714 @@
+"""Read-only Device Admin Foundations operator payloads.
+
+Slice 8 models host/path allowlists, dry-run action previews, receipt-log
+availability, and per-action approval requirements. It never executes device
+operations, reads credentials, writes receipts, scans arbitrary paths, or uses
+paths from the allowlist for filesystem access.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+PAYLOAD_VERSION = 1
+MODE = "device-admin-foundations-read-only"
+PREVIEW_MODE = "device-admin-dry-run-preview-read-only"
+MAX_LIST_ITEMS = 50
+MAX_QUERY_LIMIT = 100
+MAX_PREVIEW_BYTES = 24000
+MAX_RECEIPTS = 20
+MAX_SOURCE_AGE_SECONDS = 7 * 24 * 60 * 60
+
+WORKSPACE_ROOT = Path("/mnt/c/Users/malac/.openclaw/workspace/main")
+ALLOWLIST_PATH = WORKSPACE_ROOT / "state" / "operator_device_admin_allowlist.json"
+RECEIPT_LOG_PATH = WORKSPACE_ROOT / "state" / "operator_device_admin_receipts.jsonl"
+
+_ALLOWLIST_DISPLAY_PATH = "state/operator_device_admin_allowlist.json"
+_RECEIPTS_DISPLAY_PATH = "state/operator_device_admin_receipts.jsonl"
+_NO_EXECUTION_TEXT = "No device action was executed. Approval and execution are disabled in Slice 8."
+_SECRET_REDACTION = "[redacted-secret]"
+_PATH_REDACTION = "[redacted-path]"
+_ALLOWED_HOST_KINDS = {"local", "windows", "linux", "mac", "nas", "unknown"}
+_ALLOWED_SOURCE_STATES = {"allowed", "disabled", "unknown"}
+_ALLOWED_ACTIONS = {"copy", "move", "delete", "rename", "mkdir", "inventory", "unknown"}
+_ALLOWED_DRY_RUN_STATES = {"blocked", "draft", "unknown"}
+_ALLOWED_RISKS = {"low", "medium", "high", "unknown"}
+_VALID_RECEIPT_STATUSES = {"dry_run", "blocked", "approved_model_only", "unknown"}
+_REQUIRED_APPROVAL_FIELDS = [
+    "action_id",
+    "host_id",
+    "source_path_id",
+    "destination_path_id",
+    "reason",
+    "approved_by",
+    "approved_at",
+    "expires_at",
+]
+
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"\b[A-Z][A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY|ACCESS[_-]?KEY(?:[_-]?ID)?|SECRET[_-]?ACCESS[_-]?KEY|SESSION[_-]?COOKIE|COOKIE|PASS)\s*[:=]\s*\"?[^\s,;\"']+\"?",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:password|passwd|pwd|pass|api[_-]?key|token|access[_-]?token|refresh[_-]?token|private[_-]?key|access[_-]?key(?:[_-]?id)?|secret[_-]?access[_-]?key|session[_-]?cookie|cookie|secret)\s*[:=]\s*\"?[^\s,;\"']+\"?",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\b(?:password|passwd|pwd|pass|api[_-]?key|token|access[_-]?token|refresh[_-]?token|private[_-]?key|access[_-]?key(?:[_-]?id)?|session[_-]?cookie|cookie|secret)\s+[A-Za-z0-9._~+/=-]{8,}\b", re.IGNORECASE),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{8,}", re.IGNORECASE),
+    re.compile(r"\b(?:sk|xox[baprs]?)-[A-Za-z0-9._/=-]{8,}\b", re.IGNORECASE),
+    re.compile(r"\b(?:ghp|github_pat)_[A-Za-z0-9_.]{8,}(?![A-Za-z0-9_.])", re.IGNORECASE),
+)
+_PATH_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\b[A-Za-z]:[\\/][^\s\"'<>]+"),
+    re.compile(r"\\\\[^\s\"'<>]+\\[^\s\"'<>]+"),
+    re.compile(r"(?<![A-Za-z0-9_:])/(?:[^\s\"'<>]+)"),
+)
+_SECRET_NAME_PATTERN = re.compile(
+    r"\b(?:[A-Z0-9]+[_-])*(?:password|passwd|pwd|pass|api[_-]?key|token|access[_-]?token|refresh[_-]?token|private[_-]?key|access[_-]?key(?:[_-]?id)?|secret[_-]?access[_-]?key|secret|session[_-]?cookie|auth[_-]?cookie|cookie)\b",
+    re.IGNORECASE,
+)
+_OPAQUE_ACTION_ID_PATTERN = re.compile(r"^dda_[0-9a-f]{16}$")
+
+
+def build_operator_device_admin_payload(
+    query_text: Any = "",
+    host: Any = "all",
+    action: Any = "all",
+    limit: Any = MAX_LIST_ITEMS,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Build the Slice 8 read-only Device Admin Foundations catalog payload."""
+
+    generated_at = float(time.time() if now is None else now)
+    raw_query_text = _clean_text(query_text)
+    normalized_host = _clean_filter(host)
+    normalized_action = _clean_filter(action).lower()
+    normalized_limit = _coerce_limit(limit)
+    query = {
+        "text": _redact_text(raw_query_text),
+        "host": _redact_text(normalized_host),
+        "action": _redact_text(normalized_action),
+        "limit": normalized_limit,
+    }
+
+    allowlist = _load_allowlist_catalog(now=generated_at)
+    receipt_source, receipts, receipt_issues = _read_receipts(now=generated_at)
+    sources = [allowlist["source"], receipt_source]
+    issues = [*allowlist["issues"], *receipt_issues]
+
+    hosts = list(allowlist["hosts"])
+    paths = list(allowlist["paths"])
+    dry_runs = list(allowlist["dry_runs"])
+    hosts, paths, dry_runs = _filter_catalog(
+        hosts,
+        paths,
+        dry_runs,
+        query_text=raw_query_text,
+        host=normalized_host,
+        action=normalized_action,
+        limit=normalized_limit,
+    )
+
+    status = _catalog_status(allowlist["source"], receipt_source, dry_runs, issues)
+    summary = _catalog_summary(status, hosts, paths, dry_runs, issues)
+
+    return {
+        "version": PAYLOAD_VERSION,
+        "mode": MODE,
+        "generated_at": generated_at,
+        "status": status,
+        "execution_state": "blocked",
+        "summary": summary,
+        "query": query,
+        "sources": sources,
+        "approval_model": _approval_model(),
+        "hosts": hosts,
+        "paths": paths,
+        "dry_runs": dry_runs,
+        "receipts": receipts,
+        "issues": issues,
+        "would_execute": False,
+    }
+
+
+def build_operator_device_admin_preview_payload(action_id: Any = "", now: float | None = None) -> dict[str, Any]:
+    """Build a blocked dry-run preview for a source-backed opaque action id."""
+
+    generated_at = float(time.time() if now is None else now)
+    raw_action_id = "" if action_id is None else str(action_id)
+    normalized_action_id = _clean_text(action_id)
+    if _is_suspicious_action_id(raw_action_id):
+        return _preview_payload(
+            generated_at=generated_at,
+            status="unknown",
+            action=_unknown_preview_action(""),
+            preview=_empty_preview(),
+            issues=["rejected malformed device-admin dry-run id"],
+        )
+    if not normalized_action_id:
+        return _preview_payload(
+            generated_at=generated_at,
+            status="unknown",
+            action=_unknown_preview_action(""),
+            preview=_empty_preview(),
+            issues=["missing or unknown device-admin dry-run id"],
+        )
+
+    allowlist = _load_allowlist_catalog(now=generated_at)
+    target = next((item for item in allowlist["dry_runs"] if item.get("id") == normalized_action_id), None)
+    if target is None:
+        return _preview_payload(
+            generated_at=generated_at,
+            status="unknown",
+            action=_unknown_preview_action(normalized_action_id),
+            preview=_empty_preview(),
+            issues=["missing or unknown device-admin dry-run id"],
+        )
+
+    action = _preview_action(target)
+    issues = list(target.get("issues") or [])
+    source_state = _clean_text(allowlist["source"].get("state")).lower()
+    status = source_state if source_state in {"live", "stale"} and not issues else "unknown"
+    return _preview_payload(
+        generated_at=generated_at,
+        status=status,
+        action=action,
+        preview=_dry_run_preview(target),
+        issues=issues,
+    )
+
+
+def _is_suspicious_action_id(raw_action_id: str) -> bool:
+    raw = "" if raw_action_id is None else str(raw_action_id)
+    stripped = raw.strip()
+    if not stripped:
+        return False
+    if "\x00" in raw:
+        return True
+    return _OPAQUE_ACTION_ID_PATTERN.fullmatch(stripped) is None
+
+
+def _preview_payload(*, generated_at: float, status: str, action: dict[str, Any], preview: dict[str, Any], issues: list[str]) -> dict[str, Any]:
+    return {
+        "version": PAYLOAD_VERSION,
+        "mode": PREVIEW_MODE,
+        "generated_at": generated_at,
+        "status": status,
+        "execution_state": "blocked",
+        "action": action,
+        "preview": preview,
+        "issues": issues,
+        "would_execute": False,
+    }
+
+
+def _unknown_preview_action(action_id: str) -> dict[str, Any]:
+    if not action_id:
+        return {"id": "", "action": "unknown", "summary": ""}
+    return {"id": _redact_text(action_id), "action": "unknown", "summary": ""}
+
+
+def _preview_action(dry_run: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "id": _redact_text(dry_run.get("id")),
+        "source_action_id": _redact_text(dry_run.get("source_action_id")),
+        "action": _known_value(dry_run.get("action"), _ALLOWED_ACTIONS),
+        "summary": _redact_text(dry_run.get("summary")),
+        "reason": _redact_text(dry_run.get("reason")),
+        "risk": _known_value(dry_run.get("risk"), _ALLOWED_RISKS),
+        "approval_required": True,
+        "state": _known_value(dry_run.get("state"), _ALLOWED_DRY_RUN_STATES, default="blocked"),
+        "would_execute": False,
+    }
+
+
+def _dry_run_preview(dry_run: Mapping[str, Any]) -> dict[str, Any]:
+    lines = [
+        _NO_EXECUTION_TEXT,
+        f"Action: {_redact_text(dry_run.get('action')) or 'unknown'}",
+    ]
+    summary = _redact_text(dry_run.get("summary"))
+    reason = _redact_text(dry_run.get("reason"))
+    risk = _redact_text(dry_run.get("risk"))
+    if summary:
+        lines.append(f"Summary: {summary}")
+    if reason:
+        lines.append(f"Reason: {reason}")
+    if risk:
+        lines.append(f"Risk: {risk}")
+    lines.append("Approval and execution are disabled in Slice 8.")
+    text = "\n".join(lines)
+    encoded = text.encode("utf-8", errors="replace")
+    truncated = len(encoded) > MAX_PREVIEW_BYTES
+    if truncated:
+        encoded = encoded[:MAX_PREVIEW_BYTES]
+        text = encoded.decode("utf-8", errors="replace")
+    return {
+        "format": "dry-run-summary",
+        "text": text,
+        "truncated": truncated,
+        "bytes_read": len(encoded),
+        "max_bytes": MAX_PREVIEW_BYTES,
+    }
+
+
+def _approval_model() -> dict[str, Any]:
+    return {
+        "required": True,
+        "per_action": True,
+        "execution_enabled": False,
+        "required_fields": list(_REQUIRED_APPROVAL_FIELDS),
+    }
+
+
+def _load_allowlist_catalog(*, now: float | None = None) -> dict[str, Any]:
+    source = {
+        "id": "allowlist",
+        "display_path": _ALLOWLIST_DISPLAY_PATH,
+        "state": "unknown",
+        "issue": "missing allowlist",
+        "count": 0,
+    }
+    path = Path(ALLOWLIST_PATH)
+    if not _path_exists(path):
+        return {"source": source, "hosts": [], "paths": [], "dry_runs": [], "issues": ["device admin allowlist is missing"]}
+
+    try:
+        raw_text = path.read_text(encoding="utf-8-sig", errors="replace")
+        data = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        source["issue"] = "malformed allowlist JSON"
+        return {
+            "source": source,
+            "hosts": [],
+            "paths": [],
+            "dry_runs": [],
+            "issues": [f"device admin allowlist is malformed JSON: {exc.msg}"],
+        }
+    except Exception as exc:  # pragma: no cover - permissions/platform edge
+        source["issue"] = "unreadable allowlist"
+        return {
+            "source": source,
+            "hosts": [],
+            "paths": [],
+            "dry_runs": [],
+            "issues": [f"device admin allowlist is unreadable: {_short_error(exc)}"],
+        }
+
+    if not isinstance(data, Mapping):
+        source["issue"] = "malformed allowlist schema"
+        return {"source": source, "hosts": [], "paths": [], "dry_runs": [], "issues": ["device admin allowlist is malformed: expected object"]}
+
+    hosts, paths, host_by_id, path_by_id, parse_issues = _parse_hosts(data.get("hosts"))
+    dry_runs, action_issues = _parse_actions(data.get("proposed_actions"), host_by_id=host_by_id, path_by_id=path_by_id)
+    issues = [*parse_issues, *action_issues]
+    stale_issue = _stale_source_issue(data.get("generated_at"), now=now, label="allowlist")
+    if stale_issue:
+        issues.append(stale_issue)
+    source["count"] = len(hosts) + len(dry_runs)
+    if parse_issues or action_issues:
+        source["state"] = "unknown"
+        source["issue"] = "one or more allowlist records have issues"
+    elif stale_issue:
+        source["state"] = "stale"
+        source["issue"] = stale_issue
+    else:
+        source["state"] = "live"
+        source["issue"] = ""
+    return {"source": source, "hosts": hosts, "paths": paths, "dry_runs": dry_runs, "issues": issues}
+
+
+def _parse_hosts(raw_hosts: Any) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, dict[str, Any]], dict[str, dict[str, Any]], list[str]]:
+    hosts: list[dict[str, Any]] = []
+    paths: list[dict[str, Any]] = []
+    host_by_id: dict[str, dict[str, Any]] = {}
+    path_by_id: dict[str, dict[str, Any]] = {}
+    issues: list[str] = []
+    if raw_hosts is None:
+        raw_hosts = []
+    if not isinstance(raw_hosts, list):
+        return hosts, paths, host_by_id, path_by_id, ["allowlist hosts field is malformed"]
+
+    for index, raw_host in enumerate(raw_hosts):
+        if not isinstance(raw_host, Mapping):
+            issues.append(f"host entry {index} is malformed")
+            continue
+        raw_host_id = _clean_text(raw_host.get("id"))
+        host_issues: list[str] = []
+        if not raw_host_id:
+            host_issues.append("missing host id")
+            issues.append(f"host entry {index}: missing host id")
+        host_id = _redact_text(raw_host_id) if raw_host_id else "unknown"
+        host = {
+            "id": host_id,
+            "label": _redact_text(_clean_text(raw_host.get("label")) or raw_host_id or "unknown"),
+            "kind": _known_value(raw_host.get("kind"), _ALLOWED_HOST_KINDS),
+            "state": "unknown" if host_issues else _known_value(raw_host.get("state"), _ALLOWED_SOURCE_STATES),
+            "path_count": 0,
+            "issues": host_issues,
+        }
+        raw_paths_value = raw_host.get("paths", [])
+        if raw_paths_value is None:
+            raw_paths = []
+        elif not isinstance(raw_paths_value, list):
+            host["issues"].append("host paths field is malformed")
+            host["state"] = "unknown"
+            issues.append(f"host {host_id}: paths field is malformed")
+            raw_paths = []
+        else:
+            raw_paths = raw_paths_value
+        if raw_host_id:
+            host_by_id[raw_host_id] = host
+        hosts.append(host)
+        for path_index, raw_path in enumerate(raw_paths):
+            if not isinstance(raw_path, Mapping):
+                issue = f"host {host_id}: path entry {path_index} is malformed"
+                host["issues"].append(issue)
+                issues.append(issue)
+                continue
+            raw_path_id = _clean_text(raw_path.get("id"))
+            path_id = _redact_text(raw_path_id) if raw_path_id else "unknown"
+            raw_capabilities = raw_path.get("capabilities")
+            path_issues: list[str] = []
+            if not raw_path_id:
+                path_issues.append("missing path id")
+                issues.append(f"host {host_id}: path entry {path_index}: missing path id")
+            if raw_capabilities is None:
+                capabilities = []
+            elif isinstance(raw_capabilities, list):
+                capabilities = raw_capabilities
+            else:
+                capabilities = []
+                path_issues.append("path capabilities field is malformed")
+                issues.append(f"host {host_id}: path {path_id}: capabilities field is malformed")
+            path_record = {
+                "id": path_id,
+                "host_id": host_id,
+                "label": _redact_text(_clean_text(raw_path.get("label")) or raw_path_id or "unknown"),
+                "display_path": _redact_text(_clean_text(raw_path.get("path")) or "unknown"),
+                "capabilities": [_redact_text(_clean_text(capability)) for capability in capabilities if _clean_text(capability)],
+                "state": "unknown" if path_issues else _known_value(raw_path.get("state"), _ALLOWED_SOURCE_STATES),
+                "issues": path_issues,
+            }
+            paths.append(path_record)
+            if raw_path_id:
+                path_by_id[raw_path_id] = path_record
+            host["path_count"] += 1
+    return hosts, paths, host_by_id, path_by_id, issues
+
+
+def _parse_actions(raw_actions: Any, *, host_by_id: Mapping[str, dict[str, Any]], path_by_id: Mapping[str, dict[str, Any]]) -> tuple[list[dict[str, Any]], list[str]]:
+    dry_runs: list[dict[str, Any]] = []
+    issues: list[str] = []
+    if raw_actions is None:
+        raw_actions = []
+    if not isinstance(raw_actions, list):
+        return dry_runs, ["allowlist proposed_actions field is malformed"]
+
+    for index, raw_action in enumerate(raw_actions):
+        if not isinstance(raw_action, Mapping):
+            issues.append(f"proposed action {index} is malformed")
+            continue
+        raw_action_id = _clean_text(raw_action.get("id"))
+        source_action_id = _redact_text(raw_action_id) if raw_action_id else "unknown"
+        raw_host_id = _clean_text(raw_action.get("host_id"))
+        raw_source_path_id = _clean_text(raw_action.get("source_path_id"))
+        raw_destination_path_id = _clean_text(raw_action.get("destination_path_id"))
+        action_issues: list[str] = []
+        if not raw_action_id:
+            action_issues.append("missing action id")
+        if raw_host_id not in host_by_id:
+            action_issues.append(f"missing host reference: {_redact_text(raw_host_id or 'unknown')}")
+        if raw_source_path_id not in path_by_id:
+            action_issues.append(f"missing source path reference: {_redact_text(raw_source_path_id or 'unknown')}")
+        if not raw_destination_path_id:
+            action_issues.append("missing destination path reference: unknown")
+        elif raw_destination_path_id not in path_by_id:
+            action_issues.append(f"missing destination path reference: {_redact_text(raw_destination_path_id)}")
+        raw_action_name = _clean_text(raw_action.get("action")).lower()
+        normalized_action = raw_action_name if raw_action_name in _ALLOWED_ACTIONS else "unknown"
+        if normalized_action == "unknown" and raw_action_name not in {"", "unknown"}:
+            action_issues.append(f"malformed action type: {_redact_text(raw_action_name)}")
+        state = _known_value(raw_action.get("state"), _ALLOWED_DRY_RUN_STATES)
+        if action_issues:
+            state = "blocked"
+        dry_run = {
+            "id": _opaque_action_id(raw_action_id) if raw_action_id else "",
+            "source_action_id": source_action_id,
+            "action": normalized_action,
+            "host_id": _redact_text(raw_host_id),
+            "source_path_id": _redact_text(raw_source_path_id),
+            "destination_path_id": _redact_text(raw_destination_path_id),
+            "summary": _redact_text(_clean_text(raw_action.get("summary"))),
+            "reason": _redact_text(_clean_text(raw_action.get("reason"))),
+            "risk": _known_value(raw_action.get("risk"), _ALLOWED_RISKS),
+            "approval_required": True,
+            "state": state,
+            "issues": action_issues,
+            "preview_available": not action_issues,
+            "would_execute": False,
+        }
+        dry_runs.append(dry_run)
+        issues.extend(f"action {source_action_id}: {issue}" for issue in action_issues)
+    return dry_runs, issues
+
+
+def _read_receipts(*, now: float | None = None) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    source = {
+        "id": "receipts",
+        "display_path": _RECEIPTS_DISPLAY_PATH,
+        "state": "unknown",
+        "issue": "missing receipt log",
+        "count": 0,
+    }
+    if not _path_exists(RECEIPT_LOG_PATH):
+        return source, [], ["device admin receipt log is missing"]
+    try:
+        lines = Path(RECEIPT_LOG_PATH).read_text(encoding="utf-8-sig", errors="replace").splitlines()
+    except Exception as exc:  # pragma: no cover - permissions/platform edge
+        source["issue"] = "unreadable receipt log"
+        return source, [], [f"device admin receipt log is unreadable: {_short_error(exc)}"]
+
+    receipts: list[dict[str, Any]] = []
+    issues: list[str] = []
+    latest_created_at: Any = None
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            raw = json.loads(line)
+        except json.JSONDecodeError:
+            issues.append(f"malformed receipt line {line_number}")
+            continue
+        if not isinstance(raw, Mapping):
+            issues.append(f"malformed receipt line {line_number}: expected object")
+            continue
+        status = _clean_text(raw.get("status")).lower() or "unknown"
+        if status not in _VALID_RECEIPT_STATUSES:
+            issues.append(f"unsupported receipt status on line {line_number}: {_redact_text(status)}")
+            continue
+        created_at = _clean_text(raw.get("created_at"))
+        if created_at:
+            latest_created_at = _newer_timestamp_value(latest_created_at, created_at)
+        receipts.append(
+            {
+                "id": _redact_text(_clean_text(raw.get("id")) or "unknown"),
+                "action_id": _redact_text(_clean_text(raw.get("action_id")) or "unknown"),
+                "status": status,
+                "created_at": _redact_text(created_at),
+                "summary": _redact_text(_clean_text(raw.get("summary"))),
+                "would_execute": False,
+            }
+        )
+
+    stale_issue = _stale_source_issue(latest_created_at, now=now, label="receipt log") if receipts else ""
+    if stale_issue:
+        issues.append(stale_issue)
+    source["count"] = len(receipts)
+    if any("receipt" in issue.lower() and ("malformed" in issue.lower() or "unsupported" in issue.lower()) for issue in issues):
+        source["state"] = "unknown"
+        source["issue"] = f"{len(issues)} receipt issue{'s' if len(issues) != 1 else ''}"
+    elif stale_issue:
+        source["state"] = "stale"
+        source["issue"] = stale_issue
+    else:
+        source["state"] = "live"
+        source["issue"] = ""
+    return source, list(reversed(receipts[-MAX_RECEIPTS:])), issues
+
+
+def _filter_catalog(
+    hosts: list[dict[str, Any]],
+    paths: list[dict[str, Any]],
+    dry_runs: list[dict[str, Any]],
+    *,
+    query_text: str,
+    host: str,
+    action: str,
+    limit: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    query = query_text.lower()
+    filtered_dry_runs = []
+    for dry_run in dry_runs:
+        if host != "all" and dry_run.get("host_id") != host:
+            continue
+        if action != "all" and str(dry_run.get("action") or "").lower() != action:
+            continue
+        if query and query not in _dry_run_haystack(dry_run).lower():
+            continue
+        filtered_dry_runs.append(dry_run)
+    filtered_dry_runs = filtered_dry_runs[:limit]
+
+    filters_active = bool(query) or host != "all" or action != "all"
+    if filters_active:
+        host_ids = {str(item.get("host_id") or "") for item in filtered_dry_runs}
+        path_ids = {str(item.get("source_path_id") or "") for item in filtered_dry_runs}
+        path_ids.update(str(item.get("destination_path_id") or "") for item in filtered_dry_runs)
+        if host != "all":
+            host_ids.add(host)
+        filtered_hosts = [item for item in hosts if item.get("id") in host_ids][:limit]
+        filtered_paths = [item for item in paths if item.get("host_id") in host_ids or item.get("id") in path_ids][:limit]
+        return filtered_hosts, filtered_paths, filtered_dry_runs
+    return hosts[:limit], paths[:limit], filtered_dry_runs
+
+
+def _dry_run_haystack(dry_run: Mapping[str, Any]) -> str:
+    fields = [
+        dry_run.get("source_action_id"),
+        dry_run.get("action"),
+        dry_run.get("host_id"),
+        dry_run.get("source_path_id"),
+        dry_run.get("destination_path_id"),
+        dry_run.get("summary"),
+        dry_run.get("reason"),
+        dry_run.get("risk"),
+        dry_run.get("state"),
+    ]
+    return " ".join(_clean_text(field) for field in fields)
+
+
+def _catalog_status(allowlist_source: Mapping[str, Any], receipt_source: Mapping[str, Any], dry_runs: list[dict[str, Any]], issues: list[str]) -> str:
+    source_states = {_clean_text(allowlist_source.get("state")).lower(), _clean_text(receipt_source.get("state")).lower()}
+    if "unknown" in source_states or "" in source_states:
+        return "unknown"
+    if "stale" in source_states:
+        return "stale"
+    if issues or any(item.get("issues") for item in dry_runs):
+        return "unknown"
+    return "live"
+
+
+def _catalog_summary(status: str, hosts: list[dict[str, Any]], paths: list[dict[str, Any]], dry_runs: list[dict[str, Any]], issues: list[str]) -> str:
+    if status == "live":
+        return f"Device admin foundations loaded {len(hosts)} hosts, {len(paths)} paths, and {len(dry_runs)} dry-run actions; execution remains disabled."
+    if status == "stale":
+        return "Device admin foundations are stale and blocked until fresh allowlist and receipt sources are available; execution remains disabled."
+    if issues:
+        return f"Device admin foundations are blocked with {len(issues)} source issue{'s' if len(issues) != 1 else ''}; execution remains disabled."
+    return "Device admin foundations are blocked until allowlist and per-action approval exist."
+
+
+def _parse_source_timestamp(value: Any) -> float | None:
+    cleaned = _clean_text(value)
+    if not cleaned:
+        return None
+    try:
+        return float(cleaned)
+    except ValueError:
+        pass
+    try:
+        normalized = cleaned.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.timestamp()
+    except ValueError:
+        return None
+
+
+def _stale_source_issue(timestamp_value: Any, *, now: float | None, label: str) -> str:
+    parsed = _parse_source_timestamp(timestamp_value)
+    if parsed is None:
+        return ""
+    current = float(time.time() if now is None else now)
+    if current - parsed > MAX_SOURCE_AGE_SECONDS:
+        return f"stale {label}: source timestamp is older than {MAX_SOURCE_AGE_SECONDS} seconds"
+    return ""
+
+
+def _newer_timestamp_value(current: Any, candidate: Any) -> Any:
+    current_timestamp = _parse_source_timestamp(current)
+    candidate_timestamp = _parse_source_timestamp(candidate)
+    if candidate_timestamp is None:
+        return current
+    if current_timestamp is None or candidate_timestamp > current_timestamp:
+        return candidate
+    return current
+
+
+def _path_exists(path: Any) -> bool:
+    if path is None:
+        return False
+    try:
+        return Path(path).exists()
+    except (OSError, TypeError, ValueError):
+        return False
+
+
+def _empty_preview() -> dict[str, Any]:
+    return {
+        "format": "dry-run-summary",
+        "text": _NO_EXECUTION_TEXT,
+        "truncated": False,
+        "bytes_read": 0,
+        "max_bytes": MAX_PREVIEW_BYTES,
+    }
+
+
+def _opaque_action_id(source_action_id: str) -> str:
+    digest = hashlib.sha256(("device-admin\0" + source_action_id).encode("utf-8", errors="replace")).hexdigest()[:16]
+    return f"dda_{digest}"
+
+
+def _known_value(value: Any, allowed: set[str], default: str = "unknown") -> str:
+    cleaned = _clean_text(value).lower()
+    return cleaned if cleaned in allowed else default
+
+
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).replace("\x00", "").strip()
+
+
+def _clean_filter(value: Any) -> str:
+    cleaned = _clean_text(value)
+    return cleaned or "all"
+
+
+def _coerce_limit(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return MAX_LIST_ITEMS
+    return max(1, min(parsed, MAX_QUERY_LIMIT))
+
+
+def _redact_text(value: Any) -> str:
+    original = _clean_text(value)
+    text = original
+    if not text:
+        return ""
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub(_SECRET_REDACTION, text)
+    if _SECRET_NAME_PATTERN.search(original):
+        return _SECRET_REDACTION
+    if any(pattern.search(original) for pattern in _PATH_PATTERNS):
+        return _PATH_REDACTION
+    return text[:500]
+
+
+def _short_error(exc: Exception) -> str:
+    return _redact_text(str(exc) or exc.__class__.__name__)[:160]
+
+
+__all__ = [
+    "PAYLOAD_VERSION",
+    "MODE",
+    "PREVIEW_MODE",
+    "MAX_LIST_ITEMS",
+    "MAX_PREVIEW_BYTES",
+    "WORKSPACE_ROOT",
+    "ALLOWLIST_PATH",
+    "RECEIPT_LOG_PATH",
+    "build_operator_device_admin_payload",
+    "build_operator_device_admin_preview_payload",
+]

--- a/api/operator_docs_artifacts.py
+++ b/api/operator_docs_artifacts.py
@@ -1,0 +1,865 @@
+"""Read-only Docs/Artifact Browser operator payloads.
+
+Slice 7 catalogs fixed, allowlisted local docs/artifact roots and returns
+metadata-only list cards. Explicit previews are handled separately and remain
+bounded/read-only; this module never executes tools, mutates state, dispatches
+work, or fabricates demo items when sources are missing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+PAYLOAD_VERSION = 1
+MODE = "docs-artifacts-read-only"
+PREVIEW_MODE = "docs-artifacts-preview-read-only"
+MAX_LIST_ITEMS = 50
+MAX_PREVIEW_BYTES = 24000
+MAX_SOURCE_BYTES = 200_000
+RECENT_SECONDS = 30 * 24 * 60 * 60
+SECRET_REDACTION = "[redacted]"
+
+WORKSPACE_ROOT = Path("/mnt/c/Users/malac/.openclaw/workspace/main")
+WEBUI_ROOT = Path(__file__).resolve().parents[1]
+
+SOURCE_SPECS: dict[str, dict[str, Any]] = {
+    "plans": {
+        "type": "directory",
+        "label": "Plans / handoffs",
+        "path": WORKSPACE_ROOT / ".hermes" / "plans",
+        "display_path": ".hermes/plans",
+        "includes": [{"glob": "*.md", "kind": "auto"}],
+    },
+    "deep_research_briefs": {
+        "type": "directory",
+        "label": "Deep research briefs",
+        "path": WORKSPACE_ROOT / "obsidian-vault" / "Agent-Kimi" / "Deep Research Briefs",
+        "display_path": "obsidian-vault/Agent-Kimi/Deep Research Briefs",
+        "includes": [{"glob": "*.md", "kind": "brief"}, {"glob": "manifest.json", "kind": "artifact_manifest"}],
+    },
+    "agent_shared_active_plan": {
+        "type": "file",
+        "label": "Shared active plan",
+        "path": WORKSPACE_ROOT / "obsidian-vault" / "Agent-Shared" / "ACTIVE PLAN.md",
+        "display_path": "obsidian-vault/Agent-Shared/ACTIVE PLAN.md",
+        "kind": "plan",
+    },
+    "generated_artifacts": {
+        "type": "directory",
+        "label": "Generated artifacts",
+        "path": WORKSPACE_ROOT / "artifacts",
+        "display_path": "artifacts",
+        "includes": [{"glob": "*/action-summary.json", "kind": "action_summary"}, {"glob": "*/manifest.json", "kind": "artifact_manifest"}],
+    },
+    "state_summaries": {
+        "type": "directory",
+        "label": "Selected state summaries",
+        "path": WORKSPACE_ROOT / "state",
+        "display_path": "state",
+        "includes": [
+            {"path": "hermes_reverse_prompt_latest.json", "kind": "state_summary"},
+            {"path": "hermes_youtube_recommendations_2026-05-20.json", "kind": "state_summary"},
+            {"path": "hermes_operator_kanban_hardening_2026-05-20.json", "kind": "state_summary"},
+        ],
+    },
+    "webui_changelog": {
+        "type": "file",
+        "label": "WebUI changelog",
+        "path": WEBUI_ROOT / "CHANGELOG.md",
+        "display_path": "CHANGELOG.md",
+        "kind": "changelog",
+    },
+}
+
+EXCLUDED_PARTS = {
+    "raw",
+    "_recovered_historical_workspace_main_20260521t032323z",
+    ".obsidian",
+    "memory",
+    "memory-ledger",
+    "sessions",
+    "attachments",
+    ".git",
+    ".hg",
+    ".svn",
+    "node_modules",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".cache",
+    "build",
+    "dist",
+    ".next",
+}
+
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"\b[A-Za-z0-9_-]*(?:password|passwd|pwd|api[_-]?key|token|access[_-]?token|refresh[_-]?token|secret)\b\s*[:=]\s*[^\s,;]+",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{12,}", re.IGNORECASE),
+    re.compile(r"\b(?:sk|xox[baprs]?)-[A-Za-z0-9._/=-]{12,}\b", re.IGNORECASE),
+    re.compile(r"\b(?:ghp|github_pat)_[A-Za-z0-9_]{12,}(?![A-Za-z0-9_])", re.IGNORECASE),
+)
+_SECRET_NAME_PATTERN = re.compile(
+    r"(?:password|passwd|pwd|api[_-]?key|token|access[_-]?token|refresh[_-]?token|secret)",
+    re.IGNORECASE,
+)
+
+
+def build_operator_docs_artifacts_payload(
+    query_text: Any = "",
+    kind: Any = "all",
+    root: Any = "all",
+    limit: Any = MAX_LIST_ITEMS,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Build a versioned read-only docs/artifacts list payload."""
+
+    generated_at = float(time.time() if now is None else now)
+    normalized_query = _clean_text(query_text)
+    normalized_kind = _clean_filter(kind, default="all")
+    normalized_root = _clean_filter(root, default="all")
+    normalized_limit = _coerce_int_clamped(limit, default=MAX_LIST_ITEMS, minimum=1, maximum=100)
+    query = {
+        "text": normalized_query,
+        "kind": normalized_kind,
+        "root": normalized_root,
+        "limit": normalized_limit,
+    }
+
+    source_specs = SOURCE_SPECS if isinstance(SOURCE_SPECS, Mapping) else {}
+    if not source_specs:
+        return _payload(
+            generated_at=generated_at,
+            status="unknown",
+            summary="Docs/artifacts browser has no configured sources; no items were fabricated.",
+            query=query,
+            sources=[],
+            items=[],
+            issues=["docs/artifacts source registry is empty or unavailable"],
+        )
+
+    all_items: list[dict[str, Any]] = []
+    sources: list[dict[str, Any]] = []
+    issues: list[str] = []
+    for root_id, raw_spec in source_specs.items():
+        source, items = _catalog_source(str(root_id), raw_spec, now=generated_at)
+        sources.append(source)
+        all_items.extend(items)
+        if source.get("issue"):
+            issues.append(f"{source['id']}: {source['issue']}")
+        for item in items:
+            issues.extend(f"{item['root_id']}/{item['relative_path']}: {issue}" for issue in item.get("issues", []))
+
+    filtered_items = _filter_items(
+        all_items,
+        query_text=normalized_query,
+        kind=normalized_kind,
+        root=normalized_root,
+    )
+    filtered_items = sorted(filtered_items, key=lambda item: (-float(item.get("mtime") or 0.0), item.get("display_path", "")))
+    filtered_items = filtered_items[:normalized_limit]
+
+    status = _catalog_status(sources, all_items)
+    source_count = sum(1 for source in sources if source.get("state") != "unknown" and source.get("count", 0) > 0)
+    if filtered_items:
+        summary = f"{len(filtered_items)} docs/artifacts from {source_count} sources"
+    elif issues:
+        summary = f"0 docs/artifacts from configured roots; {len(issues)} source issue{'s' if len(issues) != 1 else ''}"
+    else:
+        summary = "0 docs/artifacts from configured roots"
+
+    return _payload(
+        generated_at=generated_at,
+        status=status,
+        summary=summary,
+        query=query,
+        sources=sources,
+        items=filtered_items,
+        issues=issues,
+    )
+
+
+def build_operator_docs_artifact_preview_payload(item_id: Any, now: float | None = None) -> dict[str, Any]:
+    """Build a read-only preview payload for an opaque catalog item id."""
+
+    generated_at = float(time.time() if now is None else now)
+    raw_item_id = "" if item_id is None else str(item_id)
+    normalized_item_id = _clean_text(item_id)
+    if _is_suspicious_item_id(raw_item_id):
+        return _preview_payload(
+            generated_at=generated_at,
+            status="unknown",
+            item=_unknown_preview_item("[rejected]"),
+            preview=_empty_preview(),
+            issues=["rejected malformed docs/artifacts item id"],
+        )
+
+    if not normalized_item_id:
+        return _preview_payload(
+            generated_at=generated_at,
+            status="unknown",
+            item=_unknown_preview_item(""),
+            preview=_empty_preview(),
+            issues=["missing or unknown docs/artifacts item id"],
+        )
+
+    target = _find_preview_target(normalized_item_id, now=generated_at)
+    if target is None:
+        return _preview_payload(
+            generated_at=generated_at,
+            status="unknown",
+            item=_unknown_preview_item(normalized_item_id),
+            preview=_empty_preview(),
+            issues=[f"missing or unknown docs/artifacts item id: {normalized_item_id}"],
+        )
+
+    item, resolved_path, root = target
+    if not item.get("preview_available"):
+        size = _coerce_int_clamped(item.get("size_bytes"), default=0, minimum=0, maximum=10**15)
+        if size > MAX_SOURCE_BYTES:
+            issue = f"preview unavailable: source exceeds {MAX_SOURCE_BYTES} byte preview limit"
+        else:
+            issue = "preview unavailable for this docs/artifacts item"
+        return _preview_payload(
+            generated_at=generated_at,
+            status="unknown",
+            item=item,
+            preview=_empty_preview(),
+            issues=[issue, *item.get("issues", [])],
+        )
+
+    try:
+        resolved = resolved_path.resolve(strict=True)
+        resolved.relative_to(root)
+        stat = resolved.stat()
+    except Exception as exc:  # pragma: no cover - filesystem race/permission edge
+        return _preview_payload(
+            generated_at=generated_at,
+            status="unknown",
+            item=item,
+            preview=_empty_preview(),
+            issues=[f"preview unavailable: {_short_error(exc)}"],
+        )
+
+    suffix = resolved.suffix.lower()
+    if stat.st_size > MAX_SOURCE_BYTES:
+        return _preview_payload(
+            generated_at=generated_at,
+            status="unknown",
+            item={**item, "preview_available": False, "size_bytes": int(stat.st_size)},
+            preview=_empty_preview(),
+            issues=[f"preview unavailable: source exceeds {MAX_SOURCE_BYTES} byte preview limit"],
+        )
+    if suffix not in {".md", ".txt", ".json"}:
+        return _preview_payload(
+            generated_at=generated_at,
+            status="unknown",
+            item=item,
+            preview=_empty_preview(),
+            issues=["preview unavailable for this file type"],
+        )
+
+    try:
+        if suffix == ".json":
+            preview = _json_preview(resolved, item=item)
+        else:
+            preview = _text_preview(resolved)
+    except json.JSONDecodeError as exc:
+        return _preview_payload(
+            generated_at=generated_at,
+            status="unknown",
+            item={**item, "preview_available": False},
+            preview=_empty_preview(),
+            issues=[f"malformed JSON: {exc.msg}", *item.get("issues", [])],
+        )
+    except Exception as exc:  # pragma: no cover - filesystem race/permission edge
+        return _preview_payload(
+            generated_at=generated_at,
+            status="unknown",
+            item=item,
+            preview=_empty_preview(),
+            issues=[f"preview unavailable: {_short_error(exc)}"],
+        )
+
+    return _preview_payload(
+        generated_at=generated_at,
+        status="live",
+        item=item,
+        preview=preview,
+        issues=item.get("issues", []),
+    )
+
+
+def _catalog_source(root_id: str, raw_spec: Any, *, now: float) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    spec = raw_spec if isinstance(raw_spec, Mapping) else {}
+    source_type = _clean_filter(spec.get("type") or spec.get("kind"), default="directory")
+    display_path = _redact_text(_clean_text(spec.get("display_path") or root_id))
+    source = {
+        "id": _redact_text(_clean_filter(root_id, default="unknown")),
+        "kind": "file" if source_type == "file" else "directory",
+        "label": _redact_text(_clean_text(spec.get("label") or root_id)),
+        "display_path": display_path,
+        "state": "unknown",
+        "count": 0,
+    }
+
+    raw_path = spec.get("path")
+    if raw_path is None:
+        source["issue"] = "path unavailable"
+        return source, []
+
+    path = Path(raw_path)
+    include_issues: list[str] = []
+    try:
+        if source_type == "file":
+            if path.is_symlink():
+                source["issue"] = "source root symlink rejected"
+                return source, []
+            if not path.exists():
+                source["issue"] = "missing"
+                return source, []
+            if not path.is_file():
+                source["issue"] = "not a regular file"
+                return source, []
+            root = path.parent.resolve(strict=True)
+            item = _item_from_path(root_id, spec, root, path, spec.get("kind") or "artifact", now=now)
+            items = [item] if item else []
+        else:
+            if path.is_symlink():
+                source["issue"] = "source root symlink rejected"
+                return source, []
+            if not path.exists():
+                source["issue"] = "missing"
+                return source, []
+            if not path.is_dir():
+                source["issue"] = "not a directory"
+                return source, []
+            root = path.resolve(strict=True)
+            items = []
+            included_paths, include_issues = _iter_included_paths(root, spec)
+            for candidate, include_kind in included_paths:
+                item = _item_from_path(root_id, spec, root, candidate, include_kind, now=now)
+                if item:
+                    items.append(item)
+    except Exception as exc:  # pragma: no cover - platform filesystem edge
+        source["issue"] = f"unreadable: {_short_error(exc)}"
+        return source, []
+
+    source["count"] = len(items)
+    source_has_item_issues = any(item.get("issues") for item in items)
+    source["state"] = "unknown" if include_issues or source_has_item_issues or not items else "live"
+    if include_issues:
+        source["issue"] = "; ".join(_redact_text(issue) for issue in include_issues[:5])
+    elif source_has_item_issues:
+        source["issue"] = "one or more allowlisted files have metadata issues"
+    elif not items:
+        source["issue"] = "no matching allowlisted files"
+    return source, items
+
+
+def _iter_included_paths(root: Path, spec: Mapping[str, Any]) -> tuple[list[tuple[Path, str]], list[str]]:
+    includes = spec.get("includes")
+    if not isinstance(includes, list) or not includes:
+        includes = [{"glob": "*", "kind": spec.get("kind") or "artifact"}]
+    results: list[tuple[Path, str]] = []
+    issues: list[str] = []
+    seen: set[Path] = set()
+    for include in includes:
+        if not isinstance(include, Mapping):
+            continue
+        include_kind = _clean_filter(include.get("kind"), default=_clean_filter(spec.get("kind"), default="artifact"))
+        candidates: list[Path] = []
+        exact_include_path = _clean_text(include.get("path")) if include.get("path") is not None else ""
+        if exact_include_path:
+            candidates = [root / exact_include_path]
+        else:
+            pattern = _clean_text(include.get("glob") or "*")
+            try:
+                candidates = sorted(root.glob(pattern))
+            except Exception as exc:
+                issues.append(f"include glob rejected: {_short_error(exc)}")
+                continue
+        for candidate in candidates:
+            display_candidate = _redact_summary_text(exact_include_path or _safe_relative_label(root, candidate))
+            if candidate in seen:
+                continue
+            if candidate.is_symlink():
+                issues.append(f"symlink include rejected: {display_candidate}")
+                continue
+            if not candidate.exists():
+                if exact_include_path:
+                    issues.append(f"missing include path: {display_candidate}")
+                continue
+            if not candidate.is_file():
+                if exact_include_path:
+                    issues.append(f"include path is not a regular file: {display_candidate}")
+                continue
+            try:
+                rel = candidate.resolve(strict=True).relative_to(root)
+            except Exception:
+                issues.append(f"include path outside allowlisted root rejected: {display_candidate}")
+                continue
+            if _is_excluded_relative(rel):
+                continue
+            seen.add(candidate)
+            results.append((candidate, include_kind))
+    return results, issues
+
+
+def _item_from_path(root_id: str, spec: Mapping[str, Any], root: Path, path: Path, include_kind: Any, *, now: float) -> dict[str, Any] | None:
+    try:
+        resolved = path.resolve(strict=True)
+        rel = resolved.relative_to(root)
+    except Exception:
+        return None
+    if _is_excluded_relative(rel):
+        return None
+
+    rel_original = rel.as_posix()
+    display_base = _clean_text(spec.get("display_path") or root_id)
+    if _clean_filter(spec.get("type"), default="directory") == "file":
+        rel_original = path.name
+        display_original = display_base
+    else:
+        display_original = f"{display_base.rstrip('/')}/{rel_original}" if display_base else rel_original
+
+    stat = resolved.stat()
+    suffix = resolved.suffix.lower()
+    kind = _classify_kind(root_id, rel_original, suffix, include_kind)
+    metadata, metadata_issues = _metadata_for_file(resolved, suffix)
+    issues = [_redact_text(issue) for issue in metadata_issues]
+    has_malformed_json = any("malformed json" in issue.casefold() for issue in issues)
+    freshness = _freshness_label(stat.st_mtime, now=now)
+    if has_malformed_json:
+        freshness = {"label": "unknown", "reason": "malformed JSON metadata"}
+    relative_path = _redact_text(rel_original)
+    display_path = _redact_text(display_original)
+    title = _redact_text(_title_from_path(rel_original, kind))
+    if relative_path != rel_original:
+        title = SECRET_REDACTION
+
+    return {
+        "id": _stable_item_id(root_id, rel_original),
+        "kind": kind,
+        "root_id": _redact_text(root_id),
+        "title": title,
+        "relative_path": relative_path,
+        "display_path": display_path,
+        "extension": suffix,
+        "size_bytes": int(stat.st_size),
+        "mtime": float(stat.st_mtime),
+        "freshness": freshness,
+        "preview_available": bool(stat.st_size <= MAX_SOURCE_BYTES and suffix in {".md", ".txt", ".json"} and not has_malformed_json),
+        "metadata": metadata,
+        "issues": issues,
+    }
+
+
+def _metadata_for_file(path: Path, suffix: str) -> tuple[dict[str, Any], list[str]]:
+    metadata: dict[str, Any] = {"line_count": 0, "json_keys": [], "ranked_action_count": 0, "avoid_count": 0}
+    issues: list[str] = []
+    try:
+        if path.stat().st_size > MAX_SOURCE_BYTES:
+            issues.append(f"source exceeds {MAX_SOURCE_BYTES} byte metadata limit")
+            return metadata, issues
+        text = path.read_text(encoding="utf-8-sig", errors="replace")
+        metadata["line_count"] = len(text.splitlines())
+        if suffix == ".json":
+            data = json.loads(text)
+            if isinstance(data, dict):
+                metadata["json_keys"] = sorted(_redact_metadata_label(key) for key in data.keys())[:20]
+                metadata["ranked_action_count"] = len(data.get("ranked_actions")) if isinstance(data.get("ranked_actions"), list) else 0
+                metadata["avoid_count"] = len(data.get("avoid")) if isinstance(data.get("avoid"), list) else 0
+            else:
+                issues.append("JSON metadata top-level is not an object")
+    except json.JSONDecodeError as exc:
+        issues.append(f"malformed JSON: {exc.msg}")
+    except Exception as exc:  # pragma: no cover - filesystem race/permission edge
+        issues.append(f"unreadable metadata: {_short_error(exc)}")
+    return metadata, issues
+
+
+def _payload(
+    *,
+    generated_at: float,
+    status: str,
+    summary: str,
+    query: dict[str, Any],
+    sources: list[dict[str, Any]],
+    items: list[dict[str, Any]],
+    issues: list[str],
+) -> dict[str, Any]:
+    return {
+        "version": PAYLOAD_VERSION,
+        "mode": MODE,
+        "generated_at": generated_at,
+        "status": status,
+        "summary": summary,
+        "query": query,
+        "sources": sources,
+        "items": items,
+        "count": len(items),
+        "issues": [_redact_text(issue) for issue in issues],
+        "would_execute": False,
+    }
+
+
+def _empty_preview() -> dict[str, Any]:
+    return {
+        "format": "metadata-only",
+        "text": "",
+        "truncated": False,
+        "bytes_read": 0,
+        "max_bytes": MAX_PREVIEW_BYTES,
+    }
+
+
+def _preview_payload(
+    *,
+    generated_at: float,
+    status: str,
+    item: dict[str, Any],
+    preview: dict[str, Any],
+    issues: list[Any],
+) -> dict[str, Any]:
+    return {
+        "version": PAYLOAD_VERSION,
+        "mode": PREVIEW_MODE,
+        "generated_at": generated_at,
+        "status": status,
+        "item": item,
+        "preview": preview,
+        "issues": [_redact_text(issue) for issue in issues],
+        "would_execute": False,
+    }
+
+
+def _unknown_preview_item(item_id: Any) -> dict[str, Any]:
+    return {
+        "id": _redact_text(item_id),
+        "root_id": "unknown",
+        "relative_path": "",
+        "display_path": "",
+        "kind": "unknown",
+        "title": "",
+        "preview_available": False,
+    }
+
+
+def _is_suspicious_item_id(raw_item_id: str) -> bool:
+    text = raw_item_id.strip()
+    if "\x00" in raw_item_id:
+        return True
+    if not text:
+        return False
+    if text.startswith(("/", "\\", "~")):
+        return True
+    if "://" in text:
+        return True
+    if re.match(r"^[A-Za-z]:[\\/]", text):
+        return True
+    return bool(re.search(r"(^|[\\/])\.\.($|[\\/])", text))
+
+
+def _find_preview_target(item_id: str, *, now: float) -> tuple[dict[str, Any], Path, Path] | None:
+    source_specs = SOURCE_SPECS if isinstance(SOURCE_SPECS, Mapping) else {}
+    for root_id, raw_spec in source_specs.items():
+        target = _preview_target_in_source(str(root_id), raw_spec, item_id, now=now)
+        if target is not None:
+            return target
+    return None
+
+
+def _preview_target_in_source(root_id: str, raw_spec: Any, item_id: str, *, now: float) -> tuple[dict[str, Any], Path, Path] | None:
+    spec = raw_spec if isinstance(raw_spec, Mapping) else {}
+    source_type = _clean_filter(spec.get("type") or spec.get("kind"), default="directory")
+    raw_path = spec.get("path")
+    if raw_path is None:
+        return None
+    path = Path(raw_path)
+    try:
+        if source_type == "file":
+            if path.is_symlink() or not path.exists() or not path.is_file():
+                return None
+            root = path.parent.resolve(strict=True)
+            return _preview_target_for_candidate(
+                root_id,
+                spec,
+                root,
+                path,
+                spec.get("kind") or "artifact",
+                item_id,
+                now=now,
+            )
+        if path.is_symlink() or not path.exists() or not path.is_dir():
+            return None
+        root = path.resolve(strict=True)
+        included_paths, _include_issues = _iter_included_paths(root, spec)
+        for candidate, include_kind in included_paths:
+            target = _preview_target_for_candidate(root_id, spec, root, candidate, include_kind, item_id, now=now)
+            if target is not None:
+                return target
+    except Exception:  # pragma: no cover - platform filesystem edge
+        return None
+    return None
+
+
+def _preview_target_for_candidate(
+    root_id: str,
+    spec: Mapping[str, Any],
+    root: Path,
+    candidate: Path,
+    include_kind: Any,
+    item_id: str,
+    *,
+    now: float,
+) -> tuple[dict[str, Any], Path, Path] | None:
+    try:
+        resolved = candidate.resolve(strict=True)
+        rel = resolved.relative_to(root)
+    except Exception:
+        return None
+    if _is_excluded_relative(rel):
+        return None
+    source_type = _clean_filter(spec.get("type"), default="directory")
+    relative_for_id = candidate.name if source_type == "file" else rel.as_posix()
+    if _stable_item_id(root_id, relative_for_id) != item_id:
+        return None
+    item = _item_from_path(root_id, spec, root, candidate, include_kind, now=now)
+    if item is None or item.get("id") != item_id:
+        return None
+    return item, resolved, root
+
+
+def _text_preview(path: Path) -> dict[str, Any]:
+    max_bytes = max(0, int(MAX_PREVIEW_BYTES))
+    size = int(path.stat().st_size)
+    with path.open("rb") as handle:
+        raw = handle.read(max_bytes)
+    text = raw.decode("utf-8-sig", errors="replace")
+    return {
+        "format": "text",
+        "text": _redact_preview_text(text),
+        "truncated": size > len(raw),
+        "bytes_read": len(raw),
+        "max_bytes": max_bytes,
+    }
+
+
+def _json_preview(path: Path, *, item: Mapping[str, Any]) -> dict[str, Any]:
+    max_bytes = max(0, int(MAX_SOURCE_BYTES))
+    size = int(path.stat().st_size)
+    with path.open("rb") as handle:
+        raw = handle.read(max_bytes)
+    text = raw.decode("utf-8-sig", errors="replace")
+    data = json.loads(text)
+    return {
+        "format": "json-summary",
+        "text": _json_summary_text(data, item=item),
+        "truncated": size > len(raw),
+        "bytes_read": len(raw),
+        "max_bytes": max_bytes,
+    }
+
+
+def _json_summary_text(data: Any, *, item: Mapping[str, Any]) -> str:
+    lines: list[str] = []
+    kind = _redact_summary_text(item.get("kind") or "json")
+    if kind:
+        lines.append(f"kind: {kind}")
+
+    if isinstance(data, Mapping):
+        keys = [_redact_metadata_label(key) for key in data.keys()]
+        if keys:
+            shown = sorted(keys)[:20]
+            suffix = f" (+{len(keys) - len(shown)} more)" if len(keys) > len(shown) else ""
+            lines.append(f"top_level_keys: {', '.join(shown)}{suffix}")
+        for key in ("ranked_actions", "avoid", "briefs", "artifacts", "items", "sources", "actions", "recommendations"):
+            if key in data:
+                lines.append(f"{key}: {_json_count_or_summary(data[key])}")
+        for key in (
+            "brief_path",
+            "artifact_dir",
+            "manifest_path",
+            "source_path",
+            "output_path",
+            "workspace_path",
+            "workspace",
+        ):
+            if key in data:
+                lines.append(f"{key}: {_json_scalar_summary(data[key])}")
+        for key in ("generated_at", "created_at", "updated_at", "status", "summary", "title"):
+            if key in data:
+                lines.append(f"{key}: {_json_scalar_summary(data[key])}")
+    elif isinstance(data, list):
+        lines.append(f"json_array: {len(data)}")
+    else:
+        lines.append(f"json_value: {_json_scalar_summary(data)}")
+
+    return _redact_summary_text("\n".join(lines))
+
+
+def _json_count_or_summary(value: Any) -> str:
+    if isinstance(value, list):
+        return str(len(value))
+    if isinstance(value, Mapping):
+        return f"{len(value)} keys"
+    return _json_scalar_summary(value)
+
+
+def _json_scalar_summary(value: Any) -> str:
+    if isinstance(value, str):
+        redacted = _redact_summary_text(value)
+        if redacted != value:
+            return redacted
+        if len(value) > 120:
+            return f"string ({len(value)} chars)"
+        return redacted
+    if isinstance(value, bool) or value is None or isinstance(value, (int, float)):
+        return json.dumps(value)
+    if isinstance(value, list):
+        return f"{len(value)} items"
+    if isinstance(value, Mapping):
+        return f"{len(value)} keys"
+    return _redact_summary_text(type(value).__name__)
+
+
+def _redact_summary_text(value: Any) -> str:
+    text = _redact_text(value)
+    text = re.sub(r"\\\\[^\r\n]+", "[path]", text)
+    text = re.sub(r"\b[A-Za-z]:[\\/][^\r\n]+", "[path]", text)
+    text = re.sub(r"(?<![\w:])/[^\r\n]+", "[path]", text)
+    return text
+
+
+def _redact_preview_text(value: Any) -> str:
+    return _redact_summary_text(value)
+
+
+def _redact_metadata_label(value: Any) -> str:
+    text = _redact_summary_text(value)
+    if _SECRET_NAME_PATTERN.search(text):
+        return SECRET_REDACTION
+    return text
+
+
+def _filter_items(items: list[dict[str, Any]], *, query_text: str, kind: str, root: str) -> list[dict[str, Any]]:
+    query_fold = query_text.casefold()
+    filtered: list[dict[str, Any]] = []
+    for item in items:
+        if kind != "all" and item.get("kind") != kind:
+            continue
+        if root != "all" and item.get("root_id") != root:
+            continue
+        if query_fold:
+            haystack = " ".join(str(item.get(key, "")) for key in ("title", "relative_path", "display_path", "root_id", "kind")).casefold()
+            if query_fold not in haystack:
+                continue
+        filtered.append(item)
+    return filtered
+
+
+def _safe_relative_label(root: Path, candidate: Path) -> str:
+    try:
+        return candidate.relative_to(root).as_posix()
+    except Exception:
+        return candidate.name
+
+
+def _is_excluded_relative(rel: Path) -> bool:
+    parts = {part.casefold() for part in rel.parts}
+    return any(part in EXCLUDED_PARTS for part in parts)
+
+
+def _classify_kind(root_id: str, relative_path: str, suffix: str, include_kind: Any) -> str:
+    raw_kind = _clean_filter(include_kind, default="artifact")
+    if raw_kind != "auto":
+        return raw_kind
+    lower = relative_path.casefold()
+    if root_id == "plans":
+        if "execution-strategy" in lower or "meta" in lower:
+            return "meta_plan"
+        if "handoff" in lower or "slice-" in lower:
+            return "handoff"
+        return "plan"
+    if suffix == ".md":
+        return "brief"
+    if suffix == ".json":
+        return "artifact_manifest"
+    return "artifact"
+
+
+def _title_from_path(relative_path: str, kind: str) -> str:
+    name = Path(relative_path).name
+    stem = name[: -len(Path(name).suffix)] if Path(name).suffix else name
+    stem = re.sub(r"^20\d{2}-\d{2}-\d{2}[_-]\d{6}[_-]?", "", stem)
+    title = stem.replace("_", " ").replace("-", " ").strip()
+    if not title:
+        title = kind.replace("_", " ")
+    if title.isupper():
+        return title
+    return " ".join(word.capitalize() if word else word for word in title.split())
+
+
+def _freshness_label(mtime: float | None, *, now: float) -> dict[str, str]:
+    if not mtime:
+        return {"label": "unknown", "reason": "missing timestamp"}
+    age = max(0.0, now - float(mtime))
+    if age <= RECENT_SECONDS:
+        return {"label": "current", "reason": "file mtime under 30 days old"}
+    return {"label": "historical", "reason": "file mtime older than 30 days"}
+
+
+def _catalog_status(sources: list[dict[str, Any]], items: list[dict[str, Any]]) -> str:
+    if any(source.get("state") == "unknown" for source in sources):
+        return "unknown"
+    if items:
+        return "live"
+    return "unknown"
+
+
+def _stable_item_id(root_id: str, relative_path: str) -> str:
+    digest = hashlib.sha256(f"{root_id}\0{relative_path}".encode("utf-8", errors="replace")).hexdigest()[:16]
+    return f"da_{digest}"
+
+
+def _redact_text(value: Any) -> str:
+    text = _clean_text(value)
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub(SECRET_REDACTION, text)
+    return text
+
+
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).replace("\x00", "").strip()
+
+
+def _clean_filter(value: Any, *, default: str) -> str:
+    cleaned = _clean_text(value)
+    return cleaned or default
+
+
+def _coerce_int_clamped(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        number = default
+    return max(minimum, min(maximum, number))
+
+
+def _short_error(exc: BaseException) -> str:
+    text = str(exc)
+    text = re.sub(r"\\\\[^'\"]+", "[path]", text)
+    text = re.sub(r"[A-Za-z]:[\\/][^'\"]+", "[path]", text)
+    text = re.sub(r"/[^'\"]+", "[path]", text)
+    return _redact_text(text)[:240]

--- a/api/operator_kanban.py
+++ b/api/operator_kanban.py
@@ -1,0 +1,707 @@
+"""Read-only operator Kanban payloads for the hermes-operator board.
+
+Slice 3 is an evidence/safety surface only. This module reads the allowlisted
+local Kanban SQLite DB in SQLite read-only mode, summarizes task/operator
+metadata, and degrades missing or unstructured evidence to ``unknown``/``stale``.
+It does not import Hermes Kanban write helpers, shell out, dispatch, claim, or
+mutate board state.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+BOARD = "hermes-operator"
+ALLOWED_BOARDS = {BOARD}
+BOARD_DB = Path("/home/malac/.hermes/kanban/boards/hermes-operator/kanban.db")
+SAFE_SCRATCH_ROOT = Path("/home/malac/.hermes/kanban/workspaces/hermes-operator")
+WORKSPACE_ROOT = Path("/mnt/c/Users/malac/.openclaw/workspace/main")
+HARDENING_NOTE = WORKSPACE_ROOT / "obsidian-vault" / "Agent-Kimi" / "Hermes Kanban Pilot Hardening.md"
+PROJECT_PATHS = [WORKSPACE_ROOT, Path("/home/malac/hermes-webui")]
+STATUS_ORDER = {"live": 0, "stale": 1, "unknown": 2}
+STALE_AFTER_SECONDS = 72 * 60 * 60
+MAX_TEXT = 500
+MAX_LIST_ITEMS = 12
+_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})(?:[T ]([0-2]\d:[0-5]\d(?::[0-5]\d)?)(?:Z|[+-][0-2]\d:[0-5]\d)?)?\b")
+
+TASK_COLUMNS = [
+    "id",
+    "title",
+    "body",
+    "assignee",
+    "status",
+    "priority",
+    "created_by",
+    "created_at",
+    "started_at",
+    "completed_at",
+    "workspace_kind",
+    "workspace_path",
+    "branch_name",
+    "claim_lock",
+    "claim_expires",
+    "tenant",
+    "result",
+    "consecutive_failures",
+    "worker_pid",
+    "last_failure_error",
+    "max_runtime_seconds",
+    "last_heartbeat_at",
+    "current_run_id",
+    "workflow_template_id",
+    "current_step_key",
+    "skills",
+    "model_override",
+    "max_retries",
+    "session_id",
+]
+RUN_COLUMNS = [
+    "id",
+    "task_id",
+    "profile",
+    "step_key",
+    "status",
+    "claim_lock",
+    "claim_expires",
+    "worker_pid",
+    "max_runtime_seconds",
+    "last_heartbeat_at",
+    "started_at",
+    "ended_at",
+    "outcome",
+    "summary",
+    "metadata",
+    "error",
+]
+EVENT_COLUMNS = ["id", "task_id", "run_id", "kind", "payload", "created_at"]
+COMMENT_COLUMNS = ["id", "task_id", "author", "body", "created_at"]
+REQUIRED_TASK_COLUMNS = {"id", "title", "status", "workspace_kind", "workspace_path"}
+
+
+def build_operator_kanban_payload(
+    *,
+    board: str = BOARD,
+    session_id: str | None = None,
+    ui_board_hint: str | None = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Build the versioned read-only operator Kanban payload."""
+
+    generated_at = float(time.time() if now is None else now)
+    requested_board = str(board or BOARD).strip() or BOARD
+    sources: list[dict[str, Any]] = []
+    issues: list[str] = []
+    counts = _empty_counts()
+    truth = _operator_truth_summary(session_id=session_id, ui_board_hint=ui_board_hint, now=generated_at)
+    sources.append({"id": "operator_truth", "kind": "api", "api": "/api/operator/truth", "state": truth.get("status", "unknown")})
+    if truth.get("issue"):
+        issues.append(f"operator_truth: {truth['issue']}")
+    if truth.get("status") in {"stale", "unknown"}:
+        issues.append(f"operator_truth is {truth.get('status')}")
+
+    hardening_source = _hardening_source(generated_at)
+    sources.append(hardening_source)
+    if hardening_source.get("issue"):
+        issues.append(f"hardening_note: {hardening_source['issue']}")
+
+    board_source = _source_stat("kanban_db", BOARD_DB, kind="sqlite", now=generated_at)
+    sources.insert(0, board_source)
+
+    if requested_board not in ALLOWED_BOARDS:
+        issues.append(f"board {requested_board!r} is not allowlisted for operator Kanban")
+        return _payload(
+            generated_at=generated_at,
+            status="unknown",
+            board=requested_board,
+            summary="Operator Kanban unavailable — board not allowlisted",
+            counts=counts,
+            board_safety=_board_safety([], state="unknown", notes=["Only hermes-operator is allowlisted"]),
+            truth=truth,
+            tasks=[],
+            sources=sources,
+            issues=issues,
+        )
+
+    if board_source.get("state") == "unknown":
+        issue = board_source.get("issue") or "missing or unreadable"
+        issues.append(f"kanban_db: {issue}")
+        return _payload(
+            generated_at=generated_at,
+            status="unknown",
+            board=requested_board,
+            summary="Operator Kanban unavailable — kanban_db unreadable",
+            counts=counts,
+            board_safety=_board_safety([], state="unknown", notes=["Kanban DB missing or unreadable"]),
+            truth=truth,
+            tasks=[],
+            sources=sources,
+            issues=_dedupe(issues),
+        )
+
+    try:
+        with _connect_readonly(BOARD_DB) as conn:
+            columns = _table_columns(conn, "tasks")
+            missing = sorted(REQUIRED_TASK_COLUMNS - columns)
+            if missing:
+                issues.append(f"kanban_db schema missing task columns: {', '.join(missing)}")
+                return _payload(
+                    generated_at=generated_at,
+                    status="unknown",
+                    board=requested_board,
+                    summary="Operator Kanban unavailable — schema missing required columns",
+                    counts=counts,
+                    board_safety=_board_safety([], state="unknown", notes=["Task schema incomplete"]),
+                    truth=truth,
+                    tasks=[],
+                    sources=sources,
+                    issues=_dedupe(issues),
+                )
+            raw_tasks = _read_rows(conn, "tasks", TASK_COLUMNS, order_by="created_at ASC, id ASC")
+            runs = _group_by_task(_read_optional_rows(conn, "task_runs", RUN_COLUMNS, order_by="COALESCE(ended_at, started_at, id) ASC"))
+            events = _group_by_task(_read_optional_rows(conn, "task_events", EVENT_COLUMNS, order_by="created_at ASC, id ASC"))
+            comments = _group_by_task(_read_optional_rows(conn, "task_comments", COMMENT_COLUMNS, order_by="created_at ASC, id ASC"))
+    except Exception as exc:
+        issues.append(f"kanban_db unreadable: {_short_error(exc)}")
+        return _payload(
+            generated_at=generated_at,
+            status="unknown",
+            board=requested_board,
+            summary="Operator Kanban unavailable — kanban_db unreadable",
+            counts=counts,
+            board_safety=_board_safety([], state="unknown", notes=["Kanban DB read failed"]),
+            truth=truth,
+            tasks=[],
+            sources=sources,
+            issues=_dedupe(issues),
+        )
+
+    task_payloads: list[dict[str, Any]] = []
+    status_inputs = ["live", str(hardening_source.get("state") or "unknown"), str(truth.get("status") or "unknown")]
+    for task in raw_tasks:
+        status = _clean_text(task.get("status"), "unknown")
+        counts[status] = counts.get(status, 0) + 1
+        task_runs = runs.get(str(task.get("id")), [])
+        task_events = events.get(str(task.get("id")), [])
+        task_comments = comments.get(str(task.get("id")), [])
+        task_payload = _task_payload(task, task_runs, task_events, task_comments, issues)
+        task_payloads.append(task_payload)
+        status_inputs.append(task_payload["scratch_safety"].get("state", "unknown"))
+        completion = task_payload.get("completion", {})
+        if status == "done" and completion.get("metadata_state") != "structured":
+            issues.append(f"task {task_payload['id']} completion metadata is {completion.get('metadata_state', 'unknown')}")
+            status_inputs.append("stale")
+        if status == "done" and not task_payload.get("receipt_links"):
+            issues.append(f"task {task_payload['id']} receipt links missing")
+            status_inputs.append("stale")
+        if status == "done" and not completion.get("validation"):
+            issues.append(f"task {task_payload['id']} validation metadata missing")
+            status_inputs.append("stale")
+
+    safety = _board_safety([task["scratch_safety"] for task in task_payloads])
+    status_inputs.append(safety.get("state", "unknown"))
+    status = _worst_status(status_inputs)
+    total = len(task_payloads)
+    done = counts.get("done", 0)
+    scratch_text = "scratch safe" if safety.get("state") == "live" else f"scratch {safety.get('state', 'unknown')}"
+    if total:
+        summary = f"{total} task{'s' if total != 1 else ''}, {done} done; {scratch_text}"
+        if status != "live":
+            summary += "; stale/unknown evidence needs review"
+    else:
+        summary = "0 tasks from read-only hermes-operator board"
+
+    return _payload(
+        generated_at=generated_at,
+        status=status,
+        board=requested_board,
+        summary=summary,
+        counts=counts,
+        board_safety=safety,
+        truth=truth,
+        tasks=task_payloads,
+        sources=sources,
+        issues=_dedupe(issues),
+    )
+
+
+def _payload(
+    *,
+    generated_at: float,
+    status: str,
+    board: str,
+    summary: str,
+    counts: dict[str, int],
+    board_safety: dict[str, Any],
+    truth: dict[str, Any],
+    tasks: list[dict[str, Any]],
+    sources: list[dict[str, Any]],
+    issues: list[str],
+) -> dict[str, Any]:
+    return {
+        "version": 1,
+        "generated_at": generated_at,
+        "status": status if status in STATUS_ORDER else "unknown",
+        "mode": "read-only-kanban-operator",
+        "would_execute": False,
+        "board": board,
+        "summary": summary,
+        "counts": counts,
+        "board_safety": board_safety,
+        "truth": truth,
+        "tasks": tasks,
+        "sources": sources,
+        "issues": issues,
+    }
+
+
+def _connect_readonly(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    try:
+        return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+    except Exception:
+        return set()
+
+
+def _read_rows(conn: sqlite3.Connection, table: str, wanted: list[str], *, order_by: str) -> list[dict[str, Any]]:
+    columns = _table_columns(conn, table)
+    selected = [column for column in wanted if column in columns]
+    if not selected:
+        return []
+    order = order_by if order_by else selected[0]
+    query = f"SELECT {', '.join(selected)} FROM {table} ORDER BY {order}"
+    return [dict(row) for row in conn.execute(query).fetchall()]
+
+
+def _read_optional_rows(conn: sqlite3.Connection, table: str, wanted: list[str], *, order_by: str) -> list[dict[str, Any]]:
+    if not _table_columns(conn, table):
+        return []
+    return _read_rows(conn, table, wanted, order_by=order_by)
+
+
+def _group_by_task(rows: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        task_id = str(row.get("task_id") or "")
+        if task_id:
+            grouped.setdefault(task_id, []).append(row)
+    return grouped
+
+
+def _task_payload(
+    task: dict[str, Any],
+    runs: list[dict[str, Any]],
+    events: list[dict[str, Any]],
+    comments: list[dict[str, Any]],
+    issues: list[str],
+) -> dict[str, Any]:
+    task_id = _clean_text(task.get("id"), "unknown")
+    latest_run = _latest_run(runs)
+    completion = _completion_metadata(task, latest_run, runs, events, issues)
+    receipt_links = _receipt_links(completion, runs, issues, task_id)
+    review_state = _review_state(task, completion, latest_run)
+    return {
+        "id": task_id,
+        "title": _truncate(_clean_text(task.get("title"), task_id), 160),
+        "status": _clean_text(task.get("status"), "unknown"),
+        "assignee": _none_if_empty(task.get("assignee")),
+        "profile": _none_if_empty(latest_run.get("profile") if latest_run else None),
+        "tenant": _none_if_empty(task.get("tenant")),
+        "priority": task.get("priority"),
+        "workspace_kind": _clean_text(task.get("workspace_kind"), "unknown"),
+        "workspace_path": _clean_text(task.get("workspace_path"), ""),
+        "scratch_safety": _workspace_safety(task),
+        "blocked_reason": _blocked_reason(task, runs, events),
+        "review_state": review_state,
+        "receipt_links": receipt_links,
+        "completion": completion,
+        "runs": [_run_summary(run, issues, task_id) for run in runs[-3:]],
+        "comment_count": len(comments),
+        "created_at": task.get("created_at"),
+        "started_at": task.get("started_at"),
+        "completed_at": task.get("completed_at"),
+    }
+
+
+def _latest_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not runs:
+        return None
+    return sorted(runs, key=lambda run: (run.get("ended_at") or run.get("started_at") or 0, run.get("id") or 0))[-1]
+
+
+def _run_summary(run: dict[str, Any], issues: list[str], task_id: str) -> dict[str, Any]:
+    metadata = _json_object(run.get("metadata"), issues, f"task {task_id} run {run.get('id')} metadata") or {}
+    return {
+        "id": run.get("id"),
+        "profile": _none_if_empty(run.get("profile")),
+        "step_key": _none_if_empty(run.get("step_key")),
+        "status": _clean_text(run.get("status"), "unknown"),
+        "outcome": _none_if_empty(run.get("outcome")),
+        "started_at": run.get("started_at"),
+        "ended_at": run.get("ended_at"),
+        "summary": _truncate(_clean_text(run.get("summary"), ""), MAX_TEXT),
+        "metadata_state": "structured" if metadata else "missing",
+        "error": _truncate(_clean_text(run.get("error"), ""), 240) or None,
+    }
+
+
+def _workspace_safety(task: dict[str, Any]) -> dict[str, Any]:
+    kind = _clean_text(task.get("workspace_kind"), "unknown")
+    raw_path = _clean_text(task.get("workspace_path"), "")
+    if kind != "scratch":
+        points = _points_to_project(raw_path)
+        return {
+            "state": "stale" if points else "unknown",
+            "kind": "project-bound" if points else (kind or "explicit"),
+            "scratch_points_to_project": points,
+            "reason": "non-scratch workspace; not labelled scratch safe",
+        }
+    if not raw_path:
+        return {"state": "unknown", "scratch_points_to_project": False, "reason": "scratch workspace path missing"}
+    if _same_or_under(raw_path, SAFE_SCRATCH_ROOT):
+        return {"state": "live", "scratch_points_to_project": False, "reason": "scratch workspace under safe board root"}
+    if _points_to_project(raw_path):
+        return {"state": "stale", "scratch_points_to_project": True, "reason": "scratch workspace points at a project/workspace path"}
+    return {"state": "stale", "scratch_points_to_project": False, "reason": "scratch workspace outside safe board root"}
+
+
+def _board_safety(scratch_states: list[dict[str, Any]], *, state: str | None = None, notes: list[str] | None = None) -> dict[str, Any]:
+    scratch_points = any(bool(item.get("scratch_points_to_project")) for item in scratch_states)
+    derived_state = state or _worst_status([str(item.get("state") or "unknown") for item in scratch_states] or ["live"])
+    safety_notes = list(notes or [])
+    if not safety_notes:
+        if not scratch_states:
+            safety_notes.append("No task scratch workspaces to evaluate")
+        elif derived_state == "live":
+            safety_notes.append("All scratch task workspaces are under the safe board root")
+        else:
+            safety_notes.append("One or more task workspaces need operator review")
+    return {
+        "state": derived_state,
+        "board_db": str(BOARD_DB),
+        "safe_scratch_root": str(SAFE_SCRATCH_ROOT),
+        "scratch_points_to_project": scratch_points,
+        "notes": safety_notes,
+    }
+
+
+def _blocked_reason(task: dict[str, Any], runs: list[dict[str, Any]], events: list[dict[str, Any]]) -> str | None:
+    direct = _clean_text(task.get("last_failure_error"), "")
+    if direct:
+        return _truncate(direct, 240)
+    for event in reversed(events):
+        kind = _clean_text(event.get("kind"), "")
+        if kind not in {"blocked", "failed", "crashed", "timed_out"}:
+            continue
+        payload = _json_object(event.get("payload"), [], "event payload") or {}
+        reason = _clean_text(payload.get("reason") or payload.get("error") or payload.get("summary"), "")
+        if reason:
+            return _truncate(reason, 240)
+    for run in reversed(runs):
+        error = _clean_text(run.get("error"), "")
+        if error:
+            return _truncate(error, 240)
+        if _clean_text(run.get("status"), "") == "blocked" or _clean_text(run.get("outcome"), "") == "blocked":
+            summary = _clean_text(run.get("summary"), "")
+            if summary:
+                return _truncate(summary, 240)
+    return None
+
+
+def _completion_metadata(
+    task: dict[str, Any],
+    latest_run: dict[str, Any] | None,
+    runs: list[dict[str, Any]],
+    events: list[dict[str, Any]],
+    issues: list[str],
+) -> dict[str, Any]:
+    result_raw = task.get("result")
+    result_obj = _json_object(result_raw, issues, f"task {task.get('id')} result")
+    result_text = _clean_text(result_raw, "") if result_obj is None else ""
+    run_meta = _json_object(latest_run.get("metadata"), issues, f"task {task.get('id')} run metadata") if latest_run else None
+    run_meta = run_meta or {}
+
+    source_obj = result_obj or {}
+    metadata_state = "structured" if result_obj else ("unstructured" if result_text else ("structured" if run_meta else "missing"))
+    summary = _clean_text(source_obj.get("summary") or source_obj.get("result_summary"), "")
+    if not summary and result_text:
+        summary = result_text
+    if not summary and latest_run:
+        summary = _clean_text(latest_run.get("summary"), "")
+    if not summary:
+        for event in reversed(events):
+            payload = _json_object(event.get("payload"), issues, f"task {task.get('id')} event payload") or {}
+            summary = _clean_text(payload.get("summary"), "")
+            if summary:
+                break
+
+    merged = dict(run_meta)
+    merged.update(source_obj)
+    return {
+        "completed_at": task.get("completed_at") or (latest_run or {}).get("ended_at"),
+        "result_summary": _truncate(summary, MAX_TEXT),
+        "metadata_state": metadata_state,
+        "changed_files": _string_list(merged.get("changed_files")),
+        "receipts": _receipt_values(merged),
+        "validation": _string_list(merged.get("validation")),
+        "side_effects": _string_list(merged.get("side_effects")),
+        "review_state": merged.get("review_state"),
+        "review_required": merged.get("review_required"),
+    }
+
+
+def _receipt_values(data: dict[str, Any]) -> list[Any]:
+    values: list[Any] = []
+    for key in ("receipt_links", "receipts", "receipt"):
+        value = data.get(key)
+        if value is None:
+            continue
+        if isinstance(value, list):
+            values.extend(value)
+        else:
+            values.append(value)
+    return values[:MAX_LIST_ITEMS]
+
+
+def _receipt_links(completion: dict[str, Any], runs: list[dict[str, Any]], issues: list[str], task_id: str) -> list[dict[str, str]]:
+    links: list[dict[str, str]] = []
+    values = list(completion.get("receipts") or [])
+    for run in runs:
+        metadata = _json_object(run.get("metadata"), issues, f"task {task_id} run {run.get('id')} receipt metadata") or {}
+        values.extend(_receipt_values(metadata))
+    for index, value in enumerate(values[:MAX_LIST_ITEMS], start=1):
+        if isinstance(value, dict):
+            path = _clean_text(value.get("path") or value.get("url") or value.get("href") or value.get("receipt"), "")
+            label = _clean_text(value.get("label") or value.get("title"), f"receipt {index}")
+        else:
+            path = _clean_text(value, "")
+            label = f"receipt {index}"
+        if path:
+            links.append({"label": _truncate(label, 80), "path": _truncate(path, 240)})
+    return _dedupe_links(links)
+
+
+def _review_state(task: dict[str, Any], completion: dict[str, Any], latest_run: dict[str, Any] | None) -> dict[str, str]:
+    for source in (completion, latest_run or {}, task):
+        raw = source.get("review_state") if isinstance(source, dict) else None
+        if isinstance(raw, dict):
+            state = _clean_text(raw.get("state"), "unknown")
+            reason = _clean_text(raw.get("reason"), "")
+            return {"state": state if state in {"approved", "required", "unknown", "blocked"} else "unknown", "reason": reason or "structured review metadata found"}
+        if isinstance(raw, str) and raw.strip():
+            state = raw.strip().lower()
+            return {"state": state if state in {"approved", "required", "unknown", "blocked"} else "unknown", "reason": "review state from metadata"}
+        if isinstance(source, dict) and source.get("review_required") is True:
+            return {"state": "required", "reason": "review_required metadata is true"}
+    if _clean_text(task.get("status"), "") == "blocked":
+        return {"state": "required", "reason": "task is blocked"}
+    return {"state": "unknown", "reason": "no structured review metadata found"}
+
+
+def _hardening_source(now: float) -> dict[str, Any]:
+    source = _source_stat("hardening_note", HARDENING_NOTE, kind="markdown", now=now)
+    if source.get("state") == "unknown":
+        return source
+    try:
+        text = _read_bounded_text(HARDENING_NOTE)
+    except Exception as exc:
+        source["state"] = "unknown"
+        source["issue"] = f"unreadable: {_short_error(exc)}"
+        return source
+    embedded = _extract_timestamp(text)
+    if embedded:
+        source["embedded_at"] = embedded.isoformat().replace("+00:00", "Z")
+        if now >= embedded.timestamp() and now - embedded.timestamp() > STALE_AFTER_SECONDS:
+            source["state"] = "stale"
+            source["issue"] = "embedded timestamp is stale"
+    return source
+
+
+def _operator_truth_summary(*, session_id: str | None, ui_board_hint: str | None, now: float) -> dict[str, Any]:
+    try:
+        from api.operator_truth import build_operator_truth_payload
+
+        payload = build_operator_truth_payload(session_id=session_id, ui_board_hint=ui_board_hint, now=now)
+    except Exception as exc:
+        return {"status": "unknown", "verified_at": now, "summary": "Truth unavailable", "api": "/api/operator/truth", "issue": _short_error(exc)}
+    raw_status = payload.get("status")
+    status = raw_status if isinstance(raw_status, str) and raw_status in STATUS_ORDER else "unknown"
+    truth: dict[str, Any] = {
+        "status": status,
+        "verified_at": payload.get("verified_at", now),
+        "summary": payload.get("summary") or f"Truth {status}",
+        "api": "/api/operator/truth",
+    }
+    if payload.get("issues"):
+        truth["issues"] = [str(issue) for issue in payload.get("issues", [])[:5]]
+    return truth
+
+
+def _source_stat(source_id: str, path: Any, *, kind: str, now: float | None = None) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "id": source_id,
+        "kind": kind,
+        "path": str(path) if path else "",
+        "exists": False,
+        "state": "unknown",
+    }
+    if not path:
+        item["issue"] = "path unavailable"
+        return item
+    try:
+        p = Path(path)
+        item["exists"] = p.exists()
+        if not item["exists"]:
+            item["issue"] = "missing"
+            return item
+        if not p.is_file():
+            item["issue"] = "not a regular file"
+            return item
+        item["mtime"] = p.stat().st_mtime
+        item["state"] = "live"
+        return item
+    except Exception as exc:  # pragma: no cover - platform edge case
+        item["issue"] = f"unreadable: {_short_error(exc)}"
+        return item
+
+
+def _read_bounded_text(path: Path, *, max_bytes: int = 200_000) -> str:
+    if path.stat().st_size > max_bytes:
+        raise ValueError(f"source exceeds {max_bytes} byte limit")
+    return path.read_text(encoding="utf-8-sig")
+
+
+def _json_object(value: Any, issues: list[str], label: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if not (text.startswith("{") or text.startswith("[")):
+        return None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        if issues is not None:
+            issues.append(f"{label} malformed JSON: {exc.msg}")
+        return None
+    if isinstance(parsed, dict):
+        return parsed
+    if issues is not None:
+        issues.append(f"{label} JSON is not an object")
+    return None
+
+
+def _extract_timestamp(text: str) -> datetime | None:
+    match = _DATE_RE.search(text[:5000])
+    if not match:
+        return None
+    date = match.group(1)
+    clock = match.group(2) or "00:00:00"
+    if len(clock) == 5:
+        clock += ":00"
+    try:
+        return datetime.fromisoformat(f"{date}T{clock}+00:00").astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _same_or_under(path: str, root: Path) -> bool:
+    if not path:
+        return False
+    try:
+        p = Path(path).expanduser().resolve(strict=False)
+        r = root.expanduser().resolve(strict=False)
+        return p == r or p.is_relative_to(r)
+    except Exception:
+        path_text = str(path).rstrip("/")
+        root_text = str(root).rstrip("/")
+        return path_text == root_text or path_text.startswith(root_text + "/")
+
+
+def _points_to_project(path: str) -> bool:
+    return any(_same_or_under(path, root) for root in PROJECT_PATHS)
+
+
+def _empty_counts() -> dict[str, int]:
+    return {"triage": 0, "todo": 0, "ready": 0, "running": 0, "blocked": 0, "done": 0}
+
+
+def _worst_status(statuses: Iterable[str]) -> str:
+    worst = "live"
+    for status in statuses:
+        normalized = status if status in STATUS_ORDER else "unknown"
+        if STATUS_ORDER[normalized] > STATUS_ORDER[worst]:
+            worst = normalized
+    return worst
+
+
+def _clean_text(value: Any, fallback: str = "") -> str:
+    if value is None:
+        return fallback
+    text = str(value).strip()
+    return text or fallback
+
+
+def _none_if_empty(value: Any) -> Any:
+    text = _clean_text(value, "")
+    return text if text else None
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    raw = value if isinstance(value, list) else [value]
+    items = []
+    for item in raw[:MAX_LIST_ITEMS]:
+        text = _clean_text(item, "")
+        if text:
+            items.append(_truncate(text, 240))
+    return items
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = _clean_text(text, "")
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _short_error(exc: BaseException) -> str:
+    return _truncate(str(exc) or exc.__class__.__name__, 180)
+
+
+def _dedupe(items: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        text = _clean_text(item, "")
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _dedupe_links(links: list[dict[str, str]]) -> list[dict[str, str]]:
+    seen: set[tuple[str, str]] = set()
+    result: list[dict[str, str]] = []
+    for link in links:
+        key = (link.get("label", ""), link.get("path", ""))
+        if key[1] and key not in seen:
+            seen.add(key)
+            result.append(link)
+    return result

--- a/api/operator_memory_skill_review.py
+++ b/api/operator_memory_skill_review.py
@@ -1,0 +1,744 @@
+"""Local memory/skill mutation review queue for the Hermes operator surface.
+
+Slice 5 makes proposed memory/skill changes reviewable. It writes only local
+review queue state and never applies memory/skill mutations.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import re
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from api.helpers import _redact_value
+
+STORE_VERSION = 1
+STATUS_ORDER = {"live": 0, "stale": 1, "unknown": 2}
+VALID_DECISIONS = {"pending", "approved", "denied", "stale", "superseded", "invalid"}
+VALID_DURABILITY = {"durable", "transient", "unknown"}
+VALID_TARGET_KINDS = {"memory", "skill"}
+VALID_MEMORY_SECTIONS = {"memory", "user", "soul"}
+VALID_OPERATIONS = {"append", "edit", "delete"}
+VALID_TRANSIENT_RISK = {"low", "medium", "high"}
+VALID_STALE_STATES = {"current", "review_required", "expired"}
+VALID_EVIDENCE_KINDS = {"session_message", "tool_receipt", "file_receipt", "manual_note"}
+SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.-]{1,64}$")
+SECRETISH_RE = re.compile(r"(?i)(api[_-]?key|api[_-]?token|token|secret|password|passwd|hunter2|sk-[A-Za-z0-9_.-]+)")
+SHA256_RE = re.compile(r"^sha256:[0-9a-fA-F]{64}$")
+RAW_KEYED_SECRET_RE = re.compile(
+    r"""
+    \b(?:
+        password|passwd|pwd|
+        token|access[_\-\s]?token|refresh[_\-\s]?token|auth[_\-\s]?token|
+        api[_\-\s]?key|apikey|
+        secret|client[_\-\s]?secret|private[_\-\s]?key|
+        authorization
+    )\b
+    \s*[:=]\s*
+    (?P<value>["']?[^"'\s,;]+["']?)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+RAW_BEARER_SECRET_RE = re.compile(r"\bBearer\s+(?P<value>[A-Za-z0-9._~+/=-]{8,})(?=$|[^A-Za-z0-9._~+/=-])", re.IGNORECASE)
+RAW_OPENAI_SECRET_RE = re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_-]{16,}(?=$|[^A-Za-z0-9_-])", re.IGNORECASE)
+RAW_SLACK_SECRET_RE = re.compile(r"\bxox[abp]-[0-9A-Za-z-]{10,}(?=$|[^0-9A-Za-z-])", re.IGNORECASE)
+RAW_GITHUB_SECRET_RE = re.compile(r"\b(?:ghp|github_pat)_[A-Za-z0-9_]{16,}(?![A-Za-z0-9_])", re.IGNORECASE)
+_STORE_LOCK = threading.RLock()
+
+
+def review_store_path() -> Path:
+    """Return the local WebUI state path for the memory/skill review queue."""
+    from api import config
+
+    return Path(config.STATE_DIR) / "operator_memory_skill_review.json"
+
+
+def build_operator_memory_skill_review_payload(
+    *,
+    session_id: str | None = None,
+    ui_board_hint: str | None = None,
+    now: float | None = None,
+    profile: str | None = None,
+) -> dict[str, Any]:
+    """Build a versioned local memory/skill review queue payload."""
+
+    generated_at = float(time.time() if now is None else now)
+    store = review_store_path()
+    sources = [{"id": "memory_skill_review_store", "kind": "local_json", "path": str(store), "state": "unknown"}]
+    issues: list[str] = []
+    notes: list[dict[str, Any]] = []
+
+    if not store.exists():
+        issues.append("memory_skill_review_store: missing or unavailable")
+        return _payload(
+            generated_at=generated_at,
+            status="unknown",
+            summary="Memory/skill review queue unavailable — local store missing",
+            items=[],
+            notes=notes,
+            sources=sources,
+            issues=issues,
+        )
+
+    data, read_issue = _read_store(store)
+    if read_issue:
+        sources[0]["issue"] = read_issue
+        issues.append(f"memory_skill_review_store: {read_issue}")
+        return _payload(
+            generated_at=generated_at,
+            status="unknown",
+            summary="Memory/skill review queue unavailable — local store malformed",
+            items=[],
+            notes=notes,
+            sources=sources,
+            issues=issues,
+        )
+
+    sources[0]["state"] = "live"
+    raw_items = data.get("items", []) if isinstance(data, dict) else []
+    items: list[dict[str, Any]] = []
+    status_inputs = ["live"]
+    for index, record in enumerate(raw_items):
+        item, note = _normalize_stored_item(record, generated_at=generated_at, profile=profile)
+        if item:
+            items.append(_redacted_payload(item))
+            stale_state = item.get("stale_risk", {}).get("state") if isinstance(item.get("stale_risk"), dict) else None
+            if stale_state in {"expired", "review_required"}:
+                status_inputs.append("stale")
+                issues.append(f"memory_skill_review_store[{index}]: stale_risk {stale_state}")
+        if note:
+            notes.append(note)
+            missing = note.get("missing") if isinstance(note.get("missing"), list) else []
+            suffix = f" missing={','.join(str(field) for field in missing)}" if missing else ""
+            issues.append(f"memory_skill_review_store[{index}]: {note.get('reason', 'invalid review item')}{suffix}")
+            raw_note_issues = note.get("issues")
+            note_issues = raw_note_issues if isinstance(raw_note_issues, list) else []
+            for issue in note_issues:
+                issues.append(f"memory_skill_review_store[{index}]: {issue}")
+            status_inputs.append("stale")
+
+    summary = f"{len(items)} memory/skill review item{'s' if len(items) != 1 else ''} from local state"
+    if notes:
+        summary += f"; {len(notes)} note{'s' if len(notes) != 1 else ''} need required fields"
+    if not items and not notes:
+        summary = "0 memory/skill review items from local state"
+
+    return _payload(
+        generated_at=generated_at,
+        status=_worst_status(status_inputs),
+        summary=summary,
+        items=items,
+        notes=notes,
+        sources=sources,
+        issues=_dedupe(issues),
+    )
+
+
+def propose_operator_memory_skill_review(
+    body: dict[str, Any],
+    *,
+    now: float | None = None,
+    client_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create or replace a local review-queue item without applying it."""
+
+    generated_at = float(time.time() if now is None else now)
+    request = body if isinstance(body, dict) else {}
+    target, target_issue = _resolve_target_previous_content(request.get("target"))
+    if target_issue:
+        return {"ok": False, "error": target_issue, "issues": [target_issue], "would_execute": False}
+
+    proposed_change = _copy_dict(request.get("proposed_change"))
+    source_evidence = _copy_list(request.get("source_evidence"))
+    classification = _copy_dict(request.get("classification"))
+    stale_risk = _copy_dict(request.get("stale_risk"))
+    raw_secret_fields = _raw_secret_request_fields(
+        proposed_change=proposed_change,
+        classification=classification,
+        stale_risk=stale_risk,
+    )
+    if raw_secret_fields:
+        return {
+            "ok": False,
+            "error": "raw secret-looking text is not allowed in review proposals",
+            "missing": raw_secret_fields,
+            "issues": ["raw secret-looking text is not allowed in review proposals"],
+            "would_execute": False,
+        }
+    previous_content = _sanitize_store_value(target.pop("previous_content", ""))
+
+    item = {
+        "id": "msr_" + hashlib.sha256(
+            json.dumps(
+                {
+                    "profile": _profile_from_context(client_context),
+                    "target": target,
+                    "proposed_change": proposed_change,
+                    "source_evidence": source_evidence,
+                },
+                sort_keys=True,
+                ensure_ascii=False,
+            ).encode("utf-8")
+        ).hexdigest()[:16],
+        "created_at": generated_at,
+        "updated_at": generated_at,
+        "profile": _profile_from_context(client_context),
+        "target": target,
+        "proposed_change": proposed_change,
+        "previous_content": previous_content,
+        "source_evidence": source_evidence,
+        "classification": classification,
+        "stale_risk": stale_risk,
+        "decision": {"state": "pending", "decided_at": None, "decided_by": None, "reason": ""},
+        "rollback": {
+            "previous_hash": _sha256(previous_content),
+            "previous_excerpt": _excerpt(previous_content),
+        },
+        "would_execute": False,
+    }
+
+    normalized, note = _normalize_stored_item(item, generated_at=generated_at, profile=item["profile"])
+    if not normalized:
+        return {
+            "ok": False,
+            "error": note.get("reason", "invalid review item") if note else "invalid review item",
+            "missing": note.get("missing", []) if note else [],
+            "issues": [note.get("reason", "invalid review item")] if note else ["invalid review item"],
+            "would_execute": False,
+        }
+
+    with _STORE_LOCK:
+        store, store_issue = _load_store_for_write()
+        if store_issue:
+            return {"ok": False, "error": store_issue, "issues": [store_issue], "would_execute": False}
+        items = store.setdefault("items", [])
+        replaced = False
+        for index, existing in enumerate(list(items)):
+            if isinstance(existing, dict) and existing.get("id") == normalized["id"]:
+                normalized["created_at"] = existing.get("created_at", normalized["created_at"])
+                normalized["decision"] = existing.get("decision", normalized["decision"])
+                items[index] = normalized
+                replaced = True
+                break
+        if not replaced:
+            items.append(normalized)
+        store["version"] = STORE_VERSION
+        store["updated_at"] = generated_at
+        write_issue = _write_store(store)
+        if write_issue:
+            return {"ok": False, "error": write_issue, "issues": [write_issue], "would_execute": False}
+    return {"ok": True, "id": normalized["id"], "item": _redacted_payload(normalized), "would_execute": False}
+
+
+def decide_operator_memory_skill_review(
+    body: dict[str, Any],
+    *,
+    now: float | None = None,
+    client_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Update only the local review decision state for an existing item."""
+
+    generated_at = float(time.time() if now is None else now)
+    request = body if isinstance(body, dict) else {}
+    item_id = str(request.get("id") or "").strip()
+    decision = str(request.get("decision") or "").strip().lower()
+    reason = str(request.get("reason") or "").strip()[:1000]
+    if not item_id:
+        return {"ok": False, "error": "id is required", "would_execute": False}
+    if decision not in {"approved", "denied"}:
+        return {"ok": False, "error": "decision must be approved or denied", "would_execute": False}
+
+    with _STORE_LOCK:
+        store, store_issue = _load_store_for_write()
+        if store_issue:
+            return {"ok": False, "error": store_issue, "issues": [store_issue], "would_execute": False}
+        items = store.setdefault("items", [])
+        for index, record in enumerate(list(items)):
+            if not isinstance(record, dict) or record.get("id") != item_id:
+                continue
+            normalized, note = _normalize_stored_item(record, generated_at=generated_at, profile=record.get("profile"))
+            if decision == "approved" and (not normalized or _item_is_stale(normalized)):
+                issue = "cannot approve invalid or stale review item"
+                if note:
+                    issue = note.get("reason", issue)
+                return {"ok": False, "error": issue, "issues": [issue], "would_execute": False}
+            updated = copy.deepcopy(record)
+            updated["decision"] = {
+                "state": decision,
+                "decided_at": generated_at,
+                "decided_by": _decider_from_context(client_context),
+                "reason": _sanitize_store_value(reason),
+            }
+            items[index] = updated
+            store["version"] = STORE_VERSION
+            store["updated_at"] = generated_at
+            write_issue = _write_store(store)
+            if write_issue:
+                return {"ok": False, "error": write_issue, "issues": [write_issue], "would_execute": False}
+            return {"ok": True, "id": item_id, "decision": _redacted_payload(updated["decision"]), "would_execute": False}
+    return {"ok": False, "error": "review item not found", "would_execute": False}
+
+
+def _payload(*, generated_at: float, status: str, summary: str, items: list, notes: list, sources: list, issues: list) -> dict[str, Any]:
+    return {
+        "version": STORE_VERSION,
+        "generated_at": generated_at,
+        "mode": "local-memory-skill-review-queue",
+        "status": status if status in STATUS_ORDER else "unknown",
+        "summary": summary,
+        "would_execute": False,
+        "items": items,
+        "notes": notes,
+        "sources": sources,
+        "issues": _dedupe(issues),
+    }
+
+
+def _read_store(path: Path) -> tuple[dict[str, Any], str | None]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
+    except FileNotFoundError:
+        return {}, "missing or unavailable"
+    except Exception as exc:
+        return {}, f"malformed json: {exc}"
+    if not isinstance(data, dict):
+        return {}, "store root must be an object"
+    if data.get("version") != STORE_VERSION:
+        return {}, "unsupported store version"
+    if not isinstance(data.get("items", []), list):
+        return {}, "items must be a list"
+    return data, None
+
+
+def _load_store_for_write() -> tuple[dict[str, Any], str | None]:
+    path = review_store_path()
+    if not path.exists():
+        return {"version": STORE_VERSION, "updated_at": 0.0, "items": []}, None
+    return _read_store(path)
+
+
+def _write_store(data: dict[str, Any]) -> str | None:
+    path = review_store_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False)
+        tmp = path.with_name(f".{path.name}.tmp")
+        with _STORE_LOCK:
+            with tmp.open("w", encoding="utf-8") as fh:
+                fh.write(payload)
+                fh.write("\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, path)
+        return None
+    except Exception as exc:
+        return f"failed to write review store: {exc}"
+
+
+def _normalize_stored_item(record: Any, *, generated_at: float, profile: str | None = None) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    if not isinstance(record, dict):
+        return None, _note(record, reason="review item must be an object", missing=_required_fields())
+    missing = [field for field in _required_fields() if field not in record]
+    issues: list[str] = []
+    target = _copy_dict(record.get("target"))
+    proposed_change = _copy_dict(record.get("proposed_change"))
+    evidence = _copy_list(record.get("source_evidence"))
+    classification = _copy_dict(record.get("classification"))
+    stale_risk = _copy_dict(record.get("stale_risk"))
+    decision = _copy_dict(record.get("decision"))
+    rollback = _copy_dict(record.get("rollback"))
+
+    if not _target_has_proof(target):
+        missing.append("target")
+        issues.append("target must include valid kind and resolved file_path/path")
+    if not _proposed_change_has_proof(proposed_change):
+        missing.append("proposed_change")
+        issues.append("proposed_change must include operation, summary, diff, and proposed content unless delete")
+    if not _source_evidence_has_proof(evidence):
+        missing.append("source_evidence")
+        issues.append("source_evidence must include source-backed quote/hash proof")
+    if not _classification_is_reviewable(classification):
+        missing.append("classification")
+        issues.append("classification must include durability, reason, and transient_risk")
+    stale_state, stale_issue = _stale_risk_state(stale_risk, now=generated_at)
+    if stale_issue:
+        missing.append("stale_risk")
+        issues.append(stale_issue)
+    if not _decision_has_proof(decision):
+        missing.append("decision")
+        issues.append("decision must include a valid state")
+    op = str(proposed_change.get("operation") or "").strip().lower()
+    previous_content = record.get("previous_content")
+    if op in {"edit", "delete"} and not isinstance(previous_content, str):
+        missing.append("previous_content")
+        issues.append(f"{op} proposals require previous_content")
+    if not _rollback_has_proof(rollback):
+        missing.append("rollback")
+        issues.append("rollback must include previous_hash and previous_excerpt")
+
+    if missing:
+        return None, _note(record, reason="invalid memory/skill review item", missing=sorted(set(missing)), issues=_dedupe(issues))
+
+    item = copy.deepcopy(record)
+    item["id"] = str(item.get("id") or _stable_item_id(item))
+    item["created_at"] = _number(item.get("created_at"), generated_at)
+    item["updated_at"] = _number(item.get("updated_at"), item["created_at"])
+    item["profile"] = str(item.get("profile") or profile or "default")
+    item["target"] = target
+    item["proposed_change"] = proposed_change
+    item["source_evidence"] = evidence
+    item["classification"] = classification
+    if stale_state:
+        stale_risk["state"] = stale_state
+    item["stale_risk"] = stale_risk
+    item["decision"] = decision
+    item["rollback"] = rollback
+    item["would_execute"] = False
+    return item, None
+
+
+def _target_has_proof(target: dict[str, Any]) -> bool:
+    kind = str(target.get("kind") or "").strip().lower()
+    if kind not in VALID_TARGET_KINDS:
+        return False
+    if not target.get("file_path") or not target.get("path"):
+        return False
+    if kind == "memory":
+        return str(target.get("section") or "").strip().lower() in VALID_MEMORY_SECTIONS
+    if kind == "skill":
+        return bool(str(target.get("name") or "").strip())
+    return False
+
+
+def _proposed_change_has_proof(change: dict[str, Any]) -> bool:
+    operation = str(change.get("operation") or "").strip().lower()
+    if operation not in VALID_OPERATIONS:
+        return False
+    if not str(change.get("summary") or "").strip():
+        return False
+    if not str(change.get("diff") or "").strip():
+        return False
+    if operation != "delete" and not isinstance(change.get("proposed_content"), str):
+        return False
+    return True
+
+
+def _source_evidence_has_proof(items: list[Any]) -> bool:
+    if not items:
+        return False
+    for entry in items:
+        if not isinstance(entry, dict):
+            return False
+        if not isinstance(entry.get("kind"), str):
+            return False
+        if not isinstance(entry.get("quote"), str):
+            return False
+        if not isinstance(entry.get("content_hash"), str):
+            return False
+        kind = entry.get("kind", "").strip()
+        quote = entry.get("quote", "").strip()
+        content_hash = entry.get("content_hash", "").strip()
+        if kind not in VALID_EVIDENCE_KINDS or not quote or not _is_sha256_hash(content_hash):
+            return False
+        if _quote_contains_raw_secret(quote):
+            return False
+        if kind == "session_message" and not _session_message_evidence_has_proof(entry):
+            return False
+    return True
+
+
+def _session_message_evidence_has_proof(entry: dict[str, Any]) -> bool:
+    if not isinstance(entry.get("session_id"), str):
+        return False
+    session_id = entry.get("session_id", "").strip()
+    if not session_id:
+        return False
+    index = entry.get("message_index")
+    if isinstance(index, bool):
+        return False
+    if isinstance(index, int):
+        return index >= 0
+    if isinstance(index, str):
+        text = index.strip()
+        return text.isdigit()
+    return False
+
+
+def _secret_value_redacted(value: str) -> bool:
+    token = str(value or "").strip().strip("\"'")
+    normalized = token.strip("[](){}<>").lower()
+    if normalized in {"redacted", "masked", "hidden", "removed", "withheld", "scrubbed"}:
+        return True
+    compact = re.sub(r"\s+", "", token)
+    return bool(compact) and bool(re.fullmatch(r"[*xX•…]+", compact))
+
+
+def _quote_contains_raw_secret(quote: str) -> bool:
+    text = str(quote or "")
+    for match in RAW_KEYED_SECRET_RE.finditer(text):
+        if not _secret_value_redacted(match.group("value")):
+            return True
+    for pattern in (RAW_BEARER_SECRET_RE, RAW_OPENAI_SECRET_RE, RAW_SLACK_SECRET_RE, RAW_GITHUB_SECRET_RE):
+        if pattern.search(text):
+            return True
+    return False
+
+
+def _raw_secret_request_fields(*, proposed_change: dict[str, Any], classification: dict[str, Any], stale_risk: dict[str, Any]) -> list[str]:
+    missing: list[str] = []
+    if _payload_contains_raw_secret(proposed_change):
+        missing.append("proposed_change")
+    if _payload_contains_raw_secret(classification):
+        missing.append("classification")
+    if _payload_contains_raw_secret(stale_risk):
+        missing.append("stale_risk")
+    return missing
+
+
+def _payload_contains_raw_secret(value: Any) -> bool:
+    if isinstance(value, str):
+        return _quote_contains_raw_secret(value)
+    if isinstance(value, dict):
+        return any(_payload_contains_raw_secret(key) or _payload_contains_raw_secret(item) for key, item in value.items())
+    if isinstance(value, list):
+        return any(_payload_contains_raw_secret(item) for item in value)
+    return False
+
+
+def _sanitize_store_value(value: Any) -> Any:
+    return _redact_secretish(_redact_value(copy.deepcopy(value)))
+
+
+def _classification_is_reviewable(classification: dict[str, Any]) -> bool:
+    durability = str(classification.get("durability") or "").strip().lower()
+    reason = str(classification.get("reason") or "").strip()
+    risk = str(classification.get("transient_risk") or "").strip().lower()
+    return durability in VALID_DURABILITY and bool(reason) and risk in VALID_TRANSIENT_RISK
+
+
+def _stale_risk_state(stale_risk: dict[str, Any], *, now: float) -> tuple[str | None, str | None]:
+    state = str(stale_risk.get("state") or "").strip().lower()
+    expires_at = str(stale_risk.get("expires_at") or "").strip()
+    reason = str(stale_risk.get("reason") or "").strip()
+    if state not in VALID_STALE_STATES:
+        return None, "stale_risk must include a valid state"
+    if not expires_at:
+        return None, "stale_risk requires expires_at"
+    if not reason:
+        return None, "stale_risk requires reason"
+    expires_ts = _parse_iso_ts(expires_at)
+    if expires_ts is None:
+        return None, "stale_risk expires_at must be an ISO timestamp"
+    if expires_ts <= now:
+        return "expired", None
+    return state, None
+
+
+def _decision_has_proof(decision: dict[str, Any]) -> bool:
+    state = str(decision.get("state") or "").strip().lower()
+    return state in VALID_DECISIONS
+
+
+def _rollback_has_proof(rollback: dict[str, Any]) -> bool:
+    previous_hash = str(rollback.get("previous_hash") or "").strip()
+    excerpt = str(rollback.get("previous_excerpt") or "").strip()
+    return _is_sha256_hash(previous_hash) and bool(excerpt)
+
+
+def _is_sha256_hash(value: str) -> bool:
+    return bool(SHA256_RE.fullmatch(str(value or "").strip()))
+
+
+def _resolve_target_previous_content(raw_target: Any) -> tuple[dict[str, Any], str | None]:
+    target = _copy_dict(raw_target)
+    kind = str(target.get("kind") or "").strip().lower()
+    if kind == "memory":
+        return _resolve_memory_target(target)
+    if kind == "skill":
+        return _resolve_skill_target(target)
+    return {}, "target.kind must be memory or skill"
+
+
+def _resolve_memory_target(target: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    from api.profiles import get_active_hermes_home
+
+    section = str(target.get("section") or "").strip().lower()
+    if section not in VALID_MEMORY_SECTIONS:
+        return {}, "memory target section must be memory, user, or soul"
+    home = Path(get_active_hermes_home()).resolve()
+    if section == "memory":
+        path = home / "memories" / "MEMORY.md"
+        file_path = "MEMORY.md"
+    elif section == "user":
+        path = home / "memories" / "USER.md"
+        file_path = "USER.md"
+    else:
+        path = home / "SOUL.md"
+        file_path = "SOUL.md"
+    previous = _read_text_if_exists(path)
+    return {
+        "kind": "memory",
+        "section": section,
+        "file_path": file_path,
+        "path": str(path),
+        "previous_content": previous,
+    }, None
+
+
+def _resolve_skill_target(target: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    from api.profiles import get_active_hermes_home
+
+    name = str(target.get("name") or "").strip()
+    category = str(target.get("category") or "").strip()
+    if not SAFE_SEGMENT_RE.fullmatch(name):
+        return {}, "skill target name is invalid"
+    if category and not SAFE_SEGMENT_RE.fullmatch(category):
+        return {}, "skill target category is invalid"
+    home = Path(get_active_hermes_home()).resolve()
+    skills_root = (home / "skills").resolve()
+    path = (skills_root / category / name / "SKILL.md").resolve() if category else (skills_root / name / "SKILL.md").resolve()
+    try:
+        path.relative_to(skills_root)
+    except ValueError:
+        return {}, "skill target escapes active profile skills directory"
+    if not path.exists():
+        return {}, "skill target SKILL.md not found"
+    previous = _read_text_if_exists(path)
+    resolved = {
+        "kind": "skill",
+        "name": name,
+        "file_path": "SKILL.md",
+        "path": str(path),
+        "previous_content": previous,
+    }
+    if category:
+        resolved["category"] = category
+    return resolved, None
+
+
+def _redacted_payload(value: Any) -> Any:
+    copied = copy.deepcopy(value)
+    return _redact_secretish(_redact_value(copied))
+
+
+def _redact_secretish(value: Any) -> Any:
+    if isinstance(value, str):
+        if SECRETISH_RE.search(value):
+            return "[redacted sensitive text]"
+        return value
+    if isinstance(value, dict):
+        return {key: _redact_secretish(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_redact_secretish(item) for item in value]
+    return value
+
+
+def _note(record: Any, *, reason: str, missing: list[str], issues: list[str] | None = None) -> dict[str, Any]:
+    return {
+        "id": record.get("id") if isinstance(record, dict) else None,
+        "classification": "invalid",
+        "reason": reason,
+        "missing": sorted(set(missing)),
+        "issues": _dedupe(issues or []),
+        "would_execute": False,
+    }
+
+
+def _required_fields() -> list[str]:
+    return ["target", "proposed_change", "source_evidence", "classification", "stale_risk", "decision", "rollback", "would_execute"]
+
+
+def _item_is_stale(item: dict[str, Any] | None) -> bool:
+    if not item:
+        return True
+    state = item.get("stale_risk", {}).get("state") if isinstance(item.get("stale_risk"), dict) else None
+    return state in {"expired", "review_required"}
+
+
+def _copy_dict(value: Any) -> dict[str, Any]:
+    return copy.deepcopy(value) if isinstance(value, dict) else {}
+
+
+def _copy_list(value: Any) -> list[Any]:
+    return copy.deepcopy(value) if isinstance(value, list) else []
+
+
+def _read_text_if_exists(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8-sig")
+    except FileNotFoundError:
+        return ""
+    except Exception:
+        return ""
+
+
+def _parse_iso_ts(value: str) -> float | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def _number(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return float(default)
+
+
+def _sha256(text: str) -> str:
+    return "sha256:" + hashlib.sha256(str(text or "").encode("utf-8")).hexdigest()
+
+
+def _excerpt(text: str, limit: int = 500) -> str:
+    cleaned = str(text or "").strip()
+    return cleaned[:limit] if cleaned else "[empty previous content]"
+
+
+def _stable_item_id(item: dict[str, Any]) -> str:
+    seed = json.dumps({"target": item.get("target"), "proposed_change": item.get("proposed_change")}, sort_keys=True, ensure_ascii=False)
+    return "msr_" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _profile_from_context(client_context: dict[str, Any] | None) -> str:
+    value = str((client_context or {}).get("profile") or "").strip()
+    return value or "default"
+
+
+def _decider_from_context(client_context: dict[str, Any] | None) -> str:
+    client_ip = str((client_context or {}).get("client_ip") or "").strip()
+    return client_ip or "local"
+
+
+def _dedupe(items: list[Any]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        text = str(item)
+        if text and text not in seen:
+            seen.add(text)
+            out.append(text)
+    return out
+
+
+def _worst_status(statuses: list[str]) -> str:
+    worst = "live"
+    for status in statuses:
+        if STATUS_ORDER.get(status, 2) > STATUS_ORDER.get(worst, 2):
+            worst = status
+    return worst

--- a/api/operator_proposals.py
+++ b/api/operator_proposals.py
@@ -1,0 +1,425 @@
+"""Manual read-only operator proposals for the composer action popover.
+
+Slice 2 deliberately stops at suggestion/drafting. This module reads only the
+allowlisted local sources and Slice 1 truth payload, then returns deterministic
+proposal metadata. It never dispatches, posts, shells out, starts cron, or writes
+approval state.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+WORKSPACE_ROOT = Path("/mnt/c/Users/malac/.openclaw/workspace/main")
+SOURCE_SPECS: dict[str, Path] = {
+    "active_plan": WORKSPACE_ROOT / "obsidian-vault" / "Agent-Shared" / "ACTIVE PLAN.md",
+    "wake_state": WORKSPACE_ROOT / "obsidian-vault" / "Agent-Kimi" / "WAKE_STATE.md",
+    "kanban_hardening": WORKSPACE_ROOT / "obsidian-vault" / "Agent-Kimi" / "Hermes Kanban Pilot Hardening.md",
+    "action_summary": WORKSPACE_ROOT / "artifacts" / "hermes-video-RoBD7Lc-0MI" / "action-summary.json",
+}
+
+MAX_SOURCE_BYTES = 200_000
+MAX_PROPOSALS = 3
+STALE_AFTER_SECONDS = 72 * 60 * 60
+STATUS_ORDER = {"live": 0, "stale": 1, "unknown": 2}
+_REQUIRED_SOURCE_IDS = {"active_plan", "wake_state", "kanban_hardening", "action_summary"}
+_REQUIRED_ACTION_KEYS = {"id", "rank", "type", "title", "summary", "owner", "side_effect_level", "status"}
+_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})(?:[T ][0-2]\d:[0-5]\d(?::[0-5]\d)?Z?)?\b")
+
+
+def build_operator_proposal_payload(
+    *,
+    session_id: str | None = None,
+    ui_board_hint: str | None = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Build the versioned manual Reverse Prompt proposal payload.
+
+    Missing or malformed required sources degrade to ``unknown``. The function
+    may return zero proposals, but it never fabricates fallback actions.
+    """
+
+    generated_at = float(time.time() if now is None else now)
+    source_specs = dict(SOURCE_SPECS)
+    sources: list[dict[str, Any]] = []
+    issues: list[str] = []
+
+    for source_id in ("active_plan", "wake_state", "kanban_hardening"):
+        path = source_specs.get(source_id)
+        _text, source = _read_text_source(source_id, path, now=generated_at)
+        sources.append(source)
+        if source.get("issue"):
+            issues.append(f"{source_id}: {source['issue']}")
+
+    action_data, action_source = _read_json_source("action_summary", source_specs.get("action_summary"), now=generated_at)
+    sources.append(action_source)
+    if action_source.get("issue"):
+        issues.append(f"action_summary: {action_source['issue']}")
+
+    truth = _operator_truth_summary(session_id=session_id, ui_board_hint=ui_board_hint, now=generated_at)
+    if truth.get("issue"):
+        issues.append(f"operator_truth: {truth['issue']}")
+
+    proposals: list[dict[str, Any]] = []
+    action_issue = _validate_action_summary(action_data)
+    if action_issue:
+        issues.append(f"action_summary: {action_issue}")
+        action_source["state"] = "unknown"
+        action_source["issue"] = action_issue
+    elif truth.get("status") == "unknown":
+        issues.append("operator_truth: unknown; refusing to produce proposals without proof state")
+    else:
+        action_summary = action_data if isinstance(action_data, dict) else {}
+        source_map = {source["id"]: source for source in sources}
+        ranked_actions = sorted(
+            [item for item in action_summary.get("ranked_actions", []) if isinstance(item, dict)],
+            key=lambda item: _rank_key(item.get("rank")),
+        )
+        for action in ranked_actions[:MAX_PROPOSALS]:
+            proposals.append(_proposal_from_ranked_action(action, len(proposals) + 1, source_map, truth, action_summary))
+
+    status_inputs = [source.get("state", "unknown") for source in sources]
+    status_inputs.append(str(truth.get("status") or "unknown"))
+    if action_issue or not proposals:
+        status_inputs.append("unknown")
+    status = _worst_status(status_inputs)
+
+    readable_source_count = sum(1 for source in sources if source.get("exists") and source.get("state") != "unknown")
+    if proposals:
+        summary = f"{len(proposals)} proposal{'s' if len(proposals) != 1 else ''} from {readable_source_count} sources"
+    elif status == "unknown":
+        summary = "No safe proposals — source unavailable"
+    else:
+        summary = "No proposals available"
+
+    return {
+        "version": 1,
+        "generated_at": generated_at,
+        "status": status,
+        "summary": summary,
+        "mode": "manual-read-only",
+        "would_execute": False,
+        "truth": truth,
+        "proposals": proposals,
+        "sources": sources,
+        "issues": issues,
+    }
+
+
+def _source_stat(source_id: str, path: Any, *, kind: str, required: bool = True, now: float | None = None) -> dict[str, Any]:
+    state = "unknown"
+    item: dict[str, Any] = {
+        "id": source_id,
+        "kind": kind,
+        "path": _safe_display_path(path),
+        "exists": False,
+        "required": bool(required),
+        "state": state,
+    }
+    if not path:
+        if required:
+            item["issue"] = "path unavailable"
+        return item
+    try:
+        p = Path(path)
+        item["exists"] = p.exists()
+        if not item["exists"]:
+            if required:
+                item["issue"] = "missing"
+            return item
+        if not p.is_file():
+            item["state"] = "unknown"
+            item["issue"] = "not a regular file"
+            return item
+        stat = p.stat()
+        item["mtime"] = stat.st_mtime
+        item["state"] = "live"
+        return item
+    except Exception as exc:  # pragma: no cover - platform/path edge case
+        item["issue"] = f"unreadable: {_short_error(exc)}"
+        return item
+
+
+def _read_text_source(source_id: str, path: Any, *, now: float) -> tuple[str | None, dict[str, Any]]:
+    source = _source_stat(source_id, path, kind="markdown", required=True, now=now)
+    if source.get("state") == "unknown":
+        return None, source
+    try:
+        text = _read_bounded_text(Path(path))
+    except Exception as exc:
+        source["state"] = "unknown"
+        source["issue"] = f"unreadable: {_short_error(exc)}"
+        return None, source
+    embedded = _extract_embedded_timestamp(text)
+    if embedded:
+        source["embedded_at"] = embedded.isoformat().replace("+00:00", "Z")
+        if now >= embedded.timestamp() and now - embedded.timestamp() > STALE_AFTER_SECONDS:
+            source["state"] = "stale"
+            source["issue"] = "embedded timestamp is stale"
+    return text, source
+
+
+def _read_json_source(source_id: str, path: Any, *, now: float) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    source = _source_stat(source_id, path, kind="json", required=True, now=now)
+    if source.get("state") == "unknown":
+        return None, source
+    try:
+        raw = _read_bounded_text(Path(path))
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        source["state"] = "unknown"
+        source["issue"] = f"malformed JSON: {exc.msg}"
+        return None, source
+    except Exception as exc:
+        source["state"] = "unknown"
+        source["issue"] = f"unreadable: {_short_error(exc)}"
+        return None, source
+    if not isinstance(data, dict):
+        source["state"] = "unknown"
+        source["issue"] = "malformed JSON: top-level object required"
+        return None, source
+    embedded = _extract_action_summary_timestamp(data)
+    if embedded:
+        source["embedded_at"] = embedded.isoformat().replace("+00:00", "Z")
+        if now >= embedded.timestamp() and now - embedded.timestamp() > STALE_AFTER_SECONDS:
+            source["state"] = "stale"
+            source["issue"] = "action summary date is stale"
+    return data, source
+
+
+def _read_bounded_text(path: Path) -> str:
+    size = path.stat().st_size
+    if size > MAX_SOURCE_BYTES:
+        raise ValueError(f"source exceeds {MAX_SOURCE_BYTES} byte limit")
+    return path.read_text(encoding="utf-8-sig")
+
+
+def _operator_truth_summary(*, session_id: str | None, ui_board_hint: str | None, now: float) -> dict[str, Any]:
+    try:
+        from api.operator_truth import build_operator_truth_payload
+
+        payload = build_operator_truth_payload(session_id=session_id, ui_board_hint=ui_board_hint, now=now)
+    except Exception as exc:
+        return {
+            "status": "unknown",
+            "verified_at": now,
+            "summary": "Truth unavailable",
+            "api": "/api/operator/truth",
+            "issue": _short_error(exc),
+        }
+    raw_status = payload.get("status")
+    status = raw_status if isinstance(raw_status, str) and raw_status in STATUS_ORDER else "unknown"
+    truth = {
+        "status": status,
+        "verified_at": payload.get("verified_at", now),
+        "summary": payload.get("summary") or _summary_for_truth_status(status),
+        "api": "/api/operator/truth",
+    }
+    if payload.get("issues"):
+        truth["issues"] = [str(issue) for issue in payload.get("issues", [])[:5]]
+    return truth
+
+
+def _validate_action_summary(data: dict[str, Any] | None) -> str | None:
+    if not isinstance(data, dict):
+        return "missing or malformed action summary"
+    ranked_actions = data.get("ranked_actions")
+    if not isinstance(ranked_actions, list) or not ranked_actions:
+        return "ranked_actions missing or empty"
+    seen_ids: set[str] = set()
+    for index, action in enumerate(ranked_actions):
+        if not isinstance(action, dict):
+            return f"ranked_actions[{index}] is not an object"
+        missing = sorted(_REQUIRED_ACTION_KEYS - set(action))
+        if missing:
+            return f"ranked_actions[{index}] missing keys: {', '.join(missing)}"
+        if not isinstance(action.get("rank"), int):
+            return f"ranked_actions[{index}].rank must be an integer"
+        for key in sorted(_REQUIRED_ACTION_KEYS - {"rank"}):
+            if not isinstance(action.get(key), str) or not action.get(key, "").strip():
+                return f"ranked_actions[{index}].{key} must be a non-empty string"
+        action_id = action["id"].strip()
+        if action_id in seen_ids:
+            return f"ranked_actions[{index}].id duplicate: {action_id}"
+        seen_ids.add(action_id)
+    return None
+
+
+def _proposal_from_ranked_action(
+    action: dict[str, Any],
+    rank: int,
+    source_map: dict[str, dict[str, Any]],
+    truth: dict[str, Any],
+    action_data: dict[str, Any],
+) -> dict[str, Any]:
+    proposal_id = _clean_id(action.get("id"))
+    title = _clean_text(action.get("title"), fallback=proposal_id or "Proposal")
+    summary = _clean_text(action.get("summary"), fallback="Source-backed operator proposal.")
+    side_effect_level = _clean_text(action.get("side_effect_level"), fallback="manual draft only")
+    source_index = _source_action_index(action_data.get("ranked_actions", []), action)
+    avoid = [str(item).strip() for item in action_data.get("avoid", []) if str(item).strip()]
+    evidence = [
+        {
+            "source_id": "action_summary",
+            "path": source_map.get("action_summary", {}).get("path", ""),
+            "field": f"ranked_actions[{source_index}]",
+        },
+        {"source_id": "active_plan", "path": source_map.get("active_plan", {}).get("path", "")},
+        {"source_id": "wake_state", "path": source_map.get("wake_state", {}).get("path", "")},
+        {"source_id": "kanban_hardening", "path": source_map.get("kanban_hardening", {}).get("path", "")},
+        {
+            "source_id": "operator_truth",
+            "api": "/api/operator/truth",
+            "status": truth.get("status", "unknown"),
+            "summary": truth.get("summary", ""),
+        },
+    ]
+    safety_notes = [
+        "Manual only; no automatic execution",
+        "Draft handoff only; does not send or execute",
+        "No AIM cron/board/runtime revival",
+    ]
+    safety_notes.extend(f"Avoid: {item}" for item in avoid[:3])
+    return {
+        "id": proposal_id,
+        "rank": rank,
+        "source_rank": action.get("rank"),
+        "title": title,
+        "summary": summary,
+        "type": _clean_text(action.get("type"), fallback="proposal"),
+        "owner": _clean_text(action.get("owner"), fallback="future Hermes session"),
+        "side_effect_level": side_effect_level,
+        "source_status": _clean_text(action.get("status"), fallback="proposal"),
+        "would_execute": False,
+        "approval": {"kind": "draft_only", "label": "Draft handoff", "executes": False},
+        "decline": {"kind": "client_only", "label": "Dismiss", "executes": False},
+        "evidence": evidence,
+        "safety_notes": safety_notes,
+        "handoff_prompt": _build_handoff_prompt(action, truth, source_map, safety_notes),
+    }
+
+
+def _build_handoff_prompt(
+    action: dict[str, Any], truth: dict[str, Any], source_map: dict[str, dict[str, Any]], safety_notes: list[str]
+) -> str:
+    title = _clean_text(action.get("title"), fallback="Manual operator proposal")
+    summary = _clean_text(action.get("summary"), fallback="Review the source-backed proposal and decide next steps.")
+    source_lines = []
+    for source_id in ("active_plan", "wake_state", "kanban_hardening", "action_summary"):
+        path = source_map.get(source_id, {}).get("path", "")
+        source_lines.append(f"- {source_id}: {path}")
+    safety = "\n".join(f"- {note}" for note in safety_notes[:6])
+    return (
+        "Load hermes-agent, test-driven-development, systematic-debugging, and requesting-code-review.\n"
+        f"Review this manual read-only operator proposal without executing it yet: {title}.\n\n"
+        f"Summary: {summary}\n"
+        f"Truth status: {truth.get('status', 'unknown')} — {truth.get('summary', '')}\n\n"
+        "Source receipts:\n"
+        + "\n".join(source_lines)
+        + "\n\nSafety constraints:\n"
+        + safety
+        + "\n\nIf you proceed, use TDD where code changes are required. Do not send, dispatch, create cron jobs, revive AIM runtime, or execute anything automatically from this draft."
+    )
+
+
+def _worst_status(statuses: Iterable[str]) -> str:
+    worst = "live"
+    for status in statuses:
+        normalized = status if status in STATUS_ORDER else "unknown"
+        if STATUS_ORDER[normalized] > STATUS_ORDER[worst]:
+            worst = normalized
+    return worst
+
+
+def _rank_key(rank: Any) -> tuple[int, str]:
+    if isinstance(rank, int):
+        return (rank, "")
+    try:
+        return (int(rank), "")
+    except Exception:
+        return (999_999, str(rank))
+
+
+def _source_action_index(actions: Any, target: dict[str, Any]) -> int:
+    if not isinstance(actions, list):
+        return -1
+    target_id = target.get("id")
+    target_rank = target.get("rank")
+    for index, action in enumerate(actions):
+        if isinstance(action, dict) and action.get("id") == target_id and action.get("rank") == target_rank:
+            return index
+    return -1
+
+
+def _extract_embedded_timestamp(text: str) -> datetime | None:
+    match = _DATE_RE.search(text[:5000])
+    if not match:
+        return None
+    return _parse_date(match.group(1))
+
+
+def _extract_action_summary_timestamp(data: dict[str, Any]) -> datetime | None:
+    raw = data.get("date")
+    if isinstance(raw, str):
+        return _parse_date(raw[:10])
+    return None
+
+
+def _parse_date(text: str) -> datetime | None:
+    try:
+        return datetime.strptime(text, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except Exception:
+        return None
+
+
+def _summary_for_truth_status(status: str) -> str:
+    if status == "live":
+        return "Truth live"
+    if status == "stale":
+        return "Truth stale"
+    return "Truth unknown"
+
+
+def _clean_id(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return "proposal"
+    text = re.sub(r"[^A-Za-z0-9_.-]+", "_", text)
+    return text[:96] or "proposal"
+
+
+def _clean_text(value: Any, *, fallback: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return fallback
+    return " ".join(text.split())[:1000]
+
+
+def _safe_display_path(path: Any) -> str:
+    if not path:
+        return ""
+    text = str(path)
+    try:
+        home = str(Path.home())
+        if text == home:
+            text = "~"
+        elif text.startswith(home + "/"):
+            text = "~" + text[len(home) :]
+    except Exception:
+        pass
+    if len(text) <= 120:
+        return text
+    parts = Path(text).parts
+    if len(parts) >= 4:
+        return "…/" + "/".join(parts[-4:])
+    return "…" + text[-117:]
+
+
+def _short_error(exc: BaseException) -> str:
+    text = str(exc).strip()
+    return text or exc.__class__.__name__

--- a/api/operator_session_recall.py
+++ b/api/operator_session_recall.py
@@ -1,0 +1,447 @@
+"""Read-only Session Recall operator payload and local sidecar search.
+
+Slice 6 keeps recall manual and proof-bearing: it searches local session JSON
+sidecars without invoking agent tools, mutating sessions, or writing memory/skill
+state. Results are bounded, redacted, and include enough evidence for later local
+promotion flows to remain review-only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+PAYLOAD_VERSION = 1
+MODE = "session-recall-read-only"
+_RECENCY_THRESHOLD_SECONDS = 30 * 24 * 60 * 60
+_MAX_TITLE_LEN = 160
+_SOURCE_FAILURE_ISSUE_MAX_LEN = 240
+_SECRET_REDACTION = "[redacted]"
+
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"\b(password|passwd|pwd|api[_-]?key|token|access[_-]?token|refresh[_-]?token|secret)\b\s*[:=]\s*[^\s,;]+",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{12,}", re.IGNORECASE),
+    re.compile(r"\b(?:sk|xox[baprs]?)-[A-Za-z0-9._/=-]{12,}\b", re.IGNORECASE),
+    re.compile(r"\b(?:ghp|github_pat)_[A-Za-z0-9_]{12,}(?![A-Za-z0-9_])", re.IGNORECASE),
+)
+
+
+def build_operator_session_recall_payload(
+    query_text: Any,
+    limit: Any = 20,
+    per_session: Any = 2,
+    all_profiles: bool = False,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Build a read-only Session Recall response payload."""
+
+    generated_at = float(time.time() if now is None else now)
+    normalized_limit = _coerce_int_clamped(limit, default=20, minimum=1, maximum=50)
+    normalized_per_session = _coerce_int_clamped(per_session, default=2, minimum=1, maximum=5)
+    query = _clean_query(query_text)
+    query_payload = {
+        "text": query,
+        "limit": normalized_limit,
+        "per_session": normalized_per_session,
+        "all_profiles": bool(all_profiles),
+    }
+
+    if not query:
+        return _payload(
+            generated_at=generated_at,
+            status="unknown",
+            query=query_payload,
+            sources=[],
+            results=[],
+            issues=["query is required for session recall"],
+        )
+
+    issues: list[str] = []
+    try:
+        session_rows = _read_session_recall_sources(all_profiles=bool(all_profiles))
+    except Exception as exc:  # Keep source failures honest without fabricating results.
+        issue = _source_failure_issue(exc)
+        return _payload(
+            generated_at=generated_at,
+            status="unknown",
+            query=query_payload,
+            sources=[_unknown_source_descriptor(issue)],
+            results=[],
+            issues=[issue],
+        )
+    if not isinstance(session_rows, list):
+        session_rows = []
+
+    results = _search_session_rows(
+        session_rows,
+        query=query,
+        limit=normalized_limit,
+        per_session=normalized_per_session,
+        now=generated_at,
+    )
+
+    return _payload(
+        generated_at=generated_at,
+        status="unknown" if not session_rows else "live",
+        query=query_payload,
+        sources=_source_descriptors(session_rows),
+        results=results,
+        issues=issues,
+    )
+
+
+def _read_session_recall_sources(all_profiles: bool = False) -> list[dict[str, Any]]:
+    """Return read-only local session rows from WebUI sidecar JSON files.
+
+    Kept deliberately narrow and monkeypatchable. Production reads only bounded
+    top-level session JSON sidecars from ``api.config.SESSION_DIR`` and skips
+    private/index files. It avoids broader session enumerators or model loaders
+    because those paths can reconcile, mutate, or otherwise do more than a
+    recall search needs.
+    """
+
+    del all_profiles  # Reserved for a later multi-profile reader.
+    from api import config
+
+    session_dir = Path(getattr(config, "SESSION_DIR"))
+    paths = sorted(
+        (p for p in session_dir.glob("*.json") if not p.name.startswith("_")),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+
+    rows: list[dict[str, Any]] = []
+    for path in paths:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        messages = data.get("messages")
+        rows.append(
+            {
+                "session_id": data.get("session_id") or path.stem,
+                "title": data.get("title"),
+                "profile": data.get("profile"),
+                "source_label": data.get("source_label") or "WebUI",
+                "source_tag": data.get("source_tag") or "webui",
+                "updated_at": data.get("updated_at"),
+                "last_message_at": data.get("last_message_at"),
+                "messages": messages if isinstance(messages, list) else [],
+            }
+        )
+    return rows
+
+
+def _payload(
+    *,
+    generated_at: float,
+    status: str,
+    query: dict[str, Any],
+    sources: list[Any],
+    results: list[Any],
+    issues: list[str],
+) -> dict[str, Any]:
+    return {
+        "version": PAYLOAD_VERSION,
+        "mode": MODE,
+        "generated_at": generated_at,
+        "status": status,
+        "query": query,
+        "sources": sources,
+        "results": results,
+        "count": len(results),
+        "issues": issues,
+        "would_execute": False,
+    }
+
+
+def _search_session_rows(
+    rows: list[dict[str, Any]],
+    *,
+    query: str,
+    limit: int,
+    per_session: int,
+    now: float,
+) -> list[dict[str, Any]]:
+    query_fold = query.casefold()
+    results: list[dict[str, Any]] = []
+
+    for row in rows:
+        if len(results) >= limit:
+            break
+        if not isinstance(row, dict):
+            continue
+        session = _session_payload(row)
+        session_id = session.get("session_id") or ""
+        session_match_count = 0
+
+        messages = row.get("messages")
+        if isinstance(messages, list):
+            for message_index, message in enumerate(messages):
+                if session_match_count >= per_session or len(results) >= limit:
+                    break
+                text = _message_text(message.get("content") if isinstance(message, dict) else message)
+                if not text or query_fold not in text.casefold():
+                    continue
+                role = str(message.get("role") or "unknown") if isinstance(message, dict) else "unknown"
+                timestamp = message.get("timestamp") if isinstance(message, dict) else None
+                content_hash = _content_hash(text)
+                snippet = _bounded_snippet(text, query)
+                results.append(
+                    _result_payload(
+                        session=session,
+                        match={
+                            "type": "message",
+                            "message_index": message_index,
+                            "role": role,
+                            "timestamp": _coerce_timestamp(timestamp),
+                            "content_hash": content_hash,
+                            "snippet": snippet,
+                        },
+                        recency=_recency_label(timestamp, now),
+                        source=_source_evidence(
+                            session_id=session_id,
+                            message_index=message_index,
+                            content_hash=content_hash,
+                            quote=snippet,
+                        ),
+                        query=query,
+                    )
+                )
+                session_match_count += 1
+
+    return results
+
+
+def _result_payload(
+    *,
+    session: dict[str, Any],
+    match: dict[str, Any],
+    recency: dict[str, str],
+    source: dict[str, Any],
+    query: str,
+) -> dict[str, Any]:
+    return {
+        "id": _stable_result_id(
+            session.get("session_id"),
+            match.get("type"),
+            match.get("message_index"),
+            match.get("content_hash"),
+            query,
+        ),
+        "session": session,
+        "match": match,
+        "recency": recency,
+        "promotion": {
+            "task": {
+                "enabled": True,
+                "mode": "local_commitment_draft",
+                "would_execute": False,
+                "source": dict(source),
+            },
+            "memory_review": {
+                "enabled": True,
+                "mode": "local_memory_skill_review_proposal",
+                "would_execute": False,
+                "source_evidence": [dict(source)],
+            },
+        },
+    }
+
+
+def _source_evidence(
+    *,
+    session_id: str,
+    message_index: Any,
+    content_hash: str,
+    quote: str,
+) -> dict[str, Any]:
+    return {
+        "kind": "session_message",
+        "session_id": session_id,
+        "message_index": message_index,
+        "content_hash": content_hash,
+        "quote": quote,
+    }
+
+
+def _session_payload(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "session_id": str(row.get("session_id") or ""),
+        "title": _bounded_title(row.get("title")),
+        "profile": str(row.get("profile") or "default"),
+        "source_label": str(row.get("source_label") or "WebUI"),
+        "source_tag": str(row.get("source_tag") or "webui"),
+    }
+
+
+def _source_descriptors(rows: list[Any]) -> list[dict[str, Any]]:
+    if not rows:
+        return []
+    return [
+        {
+            "id": "webui_sessions",
+            "kind": "session_json",
+            "state": "live",
+            "count": len(rows),
+        }
+    ]
+
+
+def _unknown_source_descriptor(issue: str) -> dict[str, Any]:
+    return {
+        "id": "webui_sessions",
+        "kind": "session_json",
+        "state": "unknown",
+        "issue": issue,
+        "count": 0,
+    }
+
+
+def _source_failure_issue(exc: Exception) -> str:
+    message = _redact_text(_collapse_ws(str(exc)))
+    if message:
+        return _bound_issue(f"session recall source unavailable: {type(exc).__name__}: {message}")
+    return _bound_issue(f"session recall source unavailable: {type(exc).__name__}")
+
+
+def _bound_issue(issue: Any, max_len: int = _SOURCE_FAILURE_ISSUE_MAX_LEN) -> str:
+    text = _redact_text(_collapse_ws(str(issue)))
+    max_len = max(40, int(max_len or _SOURCE_FAILURE_ISSUE_MAX_LEN))
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
+
+def _clean_query(value: Any) -> str:
+    if value is None:
+        return ""
+    return " ".join(str(value).strip().split())
+
+
+def _normalize_query(value: Any) -> str:
+    return _clean_query(value)
+
+
+def _coerce_int_clamped(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, min(parsed, maximum))
+
+
+def _clamp_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+    return _coerce_int_clamped(value, default=default, minimum=minimum, maximum=maximum)
+
+
+def _message_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "\n".join(part for part in (_message_text(item) for item in value) if part)
+    if isinstance(value, dict):
+        if "text" in value and (value.get("type") in (None, "text") or isinstance(value.get("text"), str)):
+            return _message_text(value.get("text"))
+        if "content" in value:
+            return _message_text(value.get("content"))
+        return ""
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    return ""
+
+
+def _bounded_snippet(text: Any, query: Any, max_len: int = 280) -> str:
+    max_len = max(20, int(max_len or 280))
+    normalized = _collapse_ws(_message_text(text))
+    query_text = _clean_query(query)
+    if not normalized:
+        return ""
+
+    redacted = _redact_text(normalized)
+    if len(redacted) <= max_len:
+        return redacted
+
+    idx = redacted.casefold().find(query_text.casefold()) if query_text else -1
+    if idx < 0:
+        body = redacted[: max_len - 1]
+        return body + "…"
+
+    start = max(0, idx - max_len // 2)
+    end = min(len(redacted), start + max_len)
+    start = max(0, end - max_len)
+    prefix = "…" if start > 0 else ""
+    suffix = "…" if end < len(redacted) else ""
+    body_len = max_len - len(prefix) - len(suffix)
+    body = redacted[start : start + body_len]
+    snippet = f"{prefix}{body}{suffix}"
+    return snippet if len(snippet) <= max_len else snippet[: max_len - 1] + "…"
+
+
+def _bounded_title(value: Any, max_len: int = _MAX_TITLE_LEN) -> str:
+    title = _collapse_ws(_message_text(value)) or "Untitled"
+    if len(title) > max_len:
+        title = title[: max_len - 1] + "…"
+    return _redact_text(title)
+
+
+def _collapse_ws(value: str) -> str:
+    return " ".join(str(value or "").split())
+
+
+def _content_hash(text: Any) -> str:
+    raw = _message_text(text)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()
+
+
+def _recency_label(timestamp: Any, now: Any) -> dict[str, str]:
+    parsed = _coerce_timestamp(timestamp)
+    if parsed is None:
+        return {"label": "unknown", "reason": "timestamp missing"}
+    try:
+        now_ts = float(now)
+    except (TypeError, ValueError):
+        now_ts = time.time()
+    if now_ts - parsed >= _RECENCY_THRESHOLD_SECONDS:
+        return {"label": "historical", "reason": "message timestamp is 30+ days old"}
+    return {"label": "recent", "reason": "message timestamp is under 30 days old"}
+
+
+def _coerce_timestamp(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed
+
+
+def _redact_text(value: Any) -> str:
+    text = str(value or "")
+
+    def replace_key_value(match: re.Match[str]) -> str:
+        key = match.group(1)
+        return f"{key}={_SECRET_REDACTION}"
+
+    if _SECRET_PATTERNS:
+        text = _SECRET_PATTERNS[0].sub(replace_key_value, text)
+        for pattern in _SECRET_PATTERNS[1:]:
+            text = pattern.sub(_SECRET_REDACTION, text)
+    return text
+
+
+def _stable_result_id(*parts: Any) -> str:
+    joined = "\x1f".join("" if part is None else str(part) for part in parts)
+    return "sr_" + hashlib.sha256(joined.encode("utf-8", errors="replace")).hexdigest()[:24]

--- a/api/operator_truth.py
+++ b/api/operator_truth.py
@@ -1,0 +1,618 @@
+"""Read-only operator truth payloads for the composer proof strip.
+
+This module is intentionally conservative: every chip is backed by a source read
+performed during the request, and source failures degrade to ``unknown`` or
+``stale`` instead of pretending the operator view is healthy.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+STATE_ORDER = {"live": 0, "unknown": 1, "stale": 2}
+_OPERATOR_TTL_SECONDS = 30
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+_INCIDENT_WORKSPACE = "/mnt/c/Users/malac/.openclaw/workspace/main"
+
+
+def build_operator_truth_payload(
+    *,
+    session_id: str | None = None,
+    ui_board_hint: str | None = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Build the versioned Operator Truth Strip payload.
+
+    The function performs only cheap, read-only probes. A broken source affects
+    its own chip and the overall status; it should not make the whole endpoint
+    return 500.
+    """
+
+    checked_at = float(time.time() if now is None else now)
+    sources: list[dict[str, Any]] = []
+    issues: list[str] = []
+
+    workspace_chip, workspace_info, workspace_sources = _workspace_chip(session_id, checked_at)
+    sources.extend(workspace_sources)
+
+    profile_chip, profile_sources = _profile_chip(checked_at)
+    sources.extend(profile_sources)
+
+    state_chip, state_sources = _webui_state_chip(checked_at)
+    sources.extend(state_sources)
+
+    kanban_chip, board_info, kanban_sources = _kanban_board_chip(ui_board_hint, checked_at)
+    sources.extend(kanban_sources)
+
+    scratch_chip, scratch_sources = _scratch_safety_chip(board_info, workspace_info, checked_at)
+    sources.extend(scratch_sources)
+
+    chips = [workspace_chip, profile_chip, state_chip, kanban_chip, scratch_chip]
+    source_chip = _source_truth_files_chip(sources, checked_at)
+    chips.append(source_chip)
+
+    for chip in chips:
+        issues.extend(str(issue) for issue in chip.get("issues", []) if issue)
+
+    status = _worst_state(chips)
+    return {
+        "version": 1,
+        "verified_at": checked_at,
+        "status": status,
+        "ttl_seconds": _OPERATOR_TTL_SECONDS,
+        "summary": _summary_for_status(status),
+        "chips": chips,
+        "sources": sources,
+        "issues": issues,
+    }
+
+
+def _chip(
+    chip_id: str,
+    label: str,
+    state: str,
+    *,
+    value: str = "",
+    display_path: str = "",
+    source: dict[str, Any] | None = None,
+    checked_at: float,
+    issues: list[str] | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": chip_id,
+        "label": label,
+        "state": state if state in STATE_ORDER else "unknown",
+        "value": value,
+        "source": source or {"kind": "unknown"},
+        "checked_at": checked_at,
+        "issues": list(issues or []),
+    }
+    if display_path:
+        payload["display_path"] = display_path
+    payload.update(extra)
+    return payload
+
+
+def _source_stat(
+    source_id: str,
+    path: Any,
+    *,
+    kind: str,
+    api: str | None = None,
+    symbol: str | None = None,
+    required: bool = True,
+) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "id": source_id,
+        "kind": kind,
+        "path": _safe_display_path(path),
+        "exists": False,
+        "required": bool(required),
+    }
+    if api:
+        item["api"] = api
+    if symbol:
+        item["symbol"] = symbol
+    if not path:
+        item["issue"] = "path unavailable"
+        return item
+    try:
+        p = Path(path)
+        item["exists"] = p.exists()
+        if item["exists"]:
+            item["mtime"] = p.stat().st_mtime
+        elif required:
+            item["issue"] = "missing"
+    except Exception as exc:  # pragma: no cover - platform/path edge cases
+        item["issue"] = f"unreadable: {_short_error(exc)}"
+    return item
+
+
+def _workspace_chip(session_id: str | None, checked_at: float) -> tuple[dict[str, Any], dict[str, Any], list[dict[str, Any]]]:
+    sources: list[dict[str, Any]] = []
+    source: dict[str, Any] = {"kind": "unknown"}
+    workspace_path: str | None = None
+    issues: list[str] = []
+    state = "unknown"
+
+    if session_id:
+        if not _valid_session_id(session_id):
+            issues.append("invalid session_id")
+            source = {"kind": "session", "api": "/api/session"}
+        else:
+            try:
+                models = importlib.import_module("api.models")
+                try:
+                    session = models.get_session(session_id, metadata_only=True)
+                except TypeError:
+                    session = models.get_session(session_id)
+                workspace_path = _field(session, "workspace")
+                session_path = _field(session, "path") or _session_json_path(session_id)
+                sources.append(_source_stat("session", session_path, kind="session", api="/api/session"))
+                source = {"kind": "session", "api": "/api/session", "path": _safe_display_path(session_path)}
+            except Exception as exc:
+                issues.append(f"session source unreadable: {_short_error(exc)}")
+                source = {"kind": "session", "api": "/api/session"}
+
+    if not workspace_path and not issues:
+        try:
+            workspace = importlib.import_module("api.workspace")
+            workspace_path = workspace.get_last_workspace()
+            last_workspace_file = getattr(workspace, "_last_workspace_file", lambda: None)()
+            workspaces_file = getattr(workspace, "_workspaces_file", lambda: None)()
+            if last_workspace_file:
+                sources.append(_source_stat("last_workspace", last_workspace_file, kind="webui_state"))
+            if workspaces_file:
+                sources.append(_source_stat("workspaces", workspaces_file, kind="webui_state"))
+            source = {"kind": "last_workspace", "path": _safe_display_path(last_workspace_file)}
+        except Exception as exc:
+            issues.append(f"workspace source unreadable: {_short_error(exc)}")
+
+    if workspace_path:
+        path = Path(str(workspace_path)).expanduser()
+        display_path = _safe_display_path(path)
+        value = path.name or display_path or "workspace"
+        if path.is_dir():
+            state = "live"
+            if _same_path(path, _INCIDENT_WORKSPACE):
+                issues.append("workspace/main is a recovered partial workspace; do not use it as scratch")
+                state = "stale"
+        else:
+            state = "stale"
+            issues.append("workspace path missing or inaccessible")
+        info = {"path": str(path), "display_path": display_path, "state": state}
+        return (
+            _chip(
+                "workspace",
+                "Workspace",
+                state,
+                value=value,
+                display_path=display_path,
+                source=source,
+                checked_at=checked_at,
+                issues=issues,
+            ),
+            info,
+            sources,
+        )
+
+    info = {"path": None, "display_path": "", "state": "unknown"}
+    return (
+        _chip("workspace", "Workspace", "unknown", value="unknown", source=source, checked_at=checked_at, issues=issues or ["workspace unknown"]),
+        info,
+        sources,
+    )
+
+
+def _profile_chip(checked_at: float) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    try:
+        profiles = importlib.import_module("api.profiles")
+        name = profiles.get_active_profile_name() or "default"
+        hermes_home = profiles.get_active_hermes_home()
+        source = {"kind": "active_profile", "api": "/api/profile/active"}
+        home_exists = bool(hermes_home and Path(hermes_home).exists())
+        state = "live" if name and home_exists else "unknown"
+        issues = [] if state == "live" else ["Hermes home path missing"]
+        return (
+            _chip(
+                "profile",
+                "Profile",
+                state,
+                value=str(name) if name else "unknown",
+                display_path=_safe_display_path(hermes_home),
+                source=source,
+                checked_at=checked_at,
+                issues=issues,
+            ),
+            [_source_stat("hermes_home", hermes_home, kind="active_profile", api="/api/profile/active")],
+        )
+    except Exception as exc:
+        return (
+            _chip(
+                "profile",
+                "Profile",
+                "unknown",
+                value="unknown",
+                source={"kind": "active_profile", "api": "/api/profile/active"},
+                checked_at=checked_at,
+                issues=[f"profile source unreadable: {_short_error(exc)}"],
+            ),
+            [],
+        )
+
+
+def _webui_state_chip(checked_at: float) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    sources: list[dict[str, Any]] = []
+    try:
+        config = importlib.import_module("api.config")
+        state_dir = Path(config.STATE_DIR)
+        session_dir = Path(getattr(config, "SESSION_DIR", state_dir / "sessions"))
+        sources.append(_source_stat("webui_state", state_dir, kind="config", symbol="api.config.STATE_DIR"))
+        sources.append(_source_stat("sessions", session_dir, kind="config", symbol="api.config.SESSION_DIR"))
+        try:
+            workspace = importlib.import_module("api.workspace")
+            workspaces_file = getattr(workspace, "_workspaces_file", lambda: state_dir / "workspaces.json")()
+            last_workspace_file = getattr(workspace, "_last_workspace_file", lambda: state_dir / "last_workspace.txt")()
+        except Exception:
+            workspaces_file = state_dir / "workspaces.json"
+            last_workspace_file = state_dir / "last_workspace.txt"
+        for source_id, path, required in (
+            ("workspaces", workspaces_file, True),
+            ("last_workspace", last_workspace_file, True),
+            ("settings", state_dir / "settings.json", False),
+            ("projects", state_dir / "projects.json", False),
+        ):
+            sources.append(_source_stat(source_id, path, kind="webui_state", required=required))
+        state = "live" if state_dir.exists() else "unknown"
+        issues = [] if state == "live" else ["WebUI state directory missing"]
+        return (
+            _chip(
+                "webui_state",
+                "WebUI state",
+                state,
+                value=state_dir.name or "webui",
+                display_path=_safe_display_path(state_dir),
+                source={"kind": "config", "symbol": "api.config.STATE_DIR"},
+                checked_at=checked_at,
+                issues=issues,
+            ),
+            sources,
+        )
+    except Exception as exc:
+        return (
+            _chip(
+                "webui_state",
+                "WebUI state",
+                "unknown",
+                value="unknown",
+                source={"kind": "config", "symbol": "api.config.STATE_DIR"},
+                checked_at=checked_at,
+                issues=[f"WebUI state source unreadable: {_short_error(exc)}"],
+            ),
+            sources,
+        )
+
+
+def _kanban_board_chip(ui_board_hint: str | None, checked_at: float) -> tuple[dict[str, Any], dict[str, Any], list[dict[str, Any]]]:
+    sources: list[dict[str, Any]] = []
+    try:
+        kb = importlib.import_module("hermes_cli.kanban_db")
+    except Exception as exc:
+        issue = _short_error(exc)
+        return (
+            _chip(
+                "kanban_board",
+                "Board",
+                "unknown",
+                value="unknown",
+                source={"kind": "kanban_db"},
+                checked_at=checked_at,
+                issues=[issue],
+            ),
+            {"available": False, "error": issue},
+            sources,
+        )
+
+    current_path = _call_path(kb, "current_board_path")
+    if current_path:
+        sources.append(_source_stat("kanban_current", current_path, kind="kanban_current", required=False))
+
+    board = "default"
+    source_kind = "default"
+    state = "live"
+    issues: list[str] = []
+
+    env_board = os.environ.get("HERMES_KANBAN_BOARD", "").strip()
+    if env_board:
+        board = env_board
+        source_kind = "env:HERMES_KANBAN_BOARD"
+        if not _safe_board_exists(kb, board):
+            state = "stale"
+            issues.append("HERMES_KANBAN_BOARD points to a missing board")
+    elif current_path and Path(current_path).exists():
+        try:
+            raw = Path(current_path).read_text(encoding="utf-8").strip()
+        except Exception as exc:
+            raw = ""
+            state = "unknown"
+            issues.append(f"current board file unreadable: {_short_error(exc)}")
+        if raw:
+            board = raw
+            source_kind = "kanban_current"
+            if not _safe_board_exists(kb, board):
+                state = "stale"
+                issues.append(f"current board {board!r} does not exist")
+        elif state == "live":
+            board = "default"
+            source_kind = "default"
+    else:
+        board = "default"
+        source_kind = "default"
+        if not _safe_board_exists(kb, board):
+            state = "unknown"
+            issues.append("default board could not be proven")
+
+    if ui_board_hint and ui_board_hint != board:
+        state = "stale"
+        issues.append("browser board hint differs from backend current")
+
+    metadata_path = _call_path(kb, "board_metadata_path", board)
+    db_path = _call_path(kb, "kanban_db_path", board)
+    workspace_root = _call_path(kb, "workspaces_root", board)
+    if metadata_path:
+        sources.append(_source_stat("kanban_board_metadata", metadata_path, kind="kanban_board_metadata"))
+    if db_path:
+        sources.append(_source_stat("kanban_db", db_path, kind="kanban_db"))
+
+    metadata: dict[str, Any] | None = None
+    if state != "stale" or _safe_board_exists(kb, board):
+        try:
+            metadata = kb.read_board_metadata(board)
+        except Exception as exc:
+            metadata = None
+            if state == "live":
+                state = "unknown"
+            issues.append(f"board metadata unreadable: {_short_error(exc)}")
+
+    source = {
+        "kind": source_kind,
+        "path": _safe_display_path(current_path),
+        "metadata_path": _safe_display_path(metadata_path),
+        "db_path": _safe_display_path(db_path),
+    }
+    info = {
+        "available": True,
+        "kb": kb,
+        "board": board,
+        "state": state,
+        "metadata": metadata,
+        "metadata_path": metadata_path,
+        "db_path": db_path,
+        "workspace_root": workspace_root,
+        "allowed_root": Path(current_path).parent if current_path else None,
+    }
+    return (
+        _chip(
+            "kanban_board",
+            "Board",
+            state,
+            value=board,
+            source=source,
+            checked_at=checked_at,
+            issues=issues,
+        ),
+        info,
+        sources,
+    )
+
+
+def _scratch_safety_chip(
+    board_info: dict[str, Any],
+    workspace_info: dict[str, Any],
+    checked_at: float,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    sources: list[dict[str, Any]] = []
+    if not board_info.get("available"):
+        return (
+            _chip(
+                "scratch_safety",
+                "Scratch",
+                "unknown",
+                value="unknown",
+                source={"kind": "kanban_board_metadata"},
+                checked_at=checked_at,
+                issues=[board_info.get("error") or "kanban source unavailable"],
+            ),
+            sources,
+        )
+
+    metadata = board_info.get("metadata") or {}
+    default_workdir = metadata.get("default_workdir") or board_info.get("workspace_root")
+    metadata_path = board_info.get("metadata_path")
+    if metadata_path:
+        sources.append(_source_stat("scratch_metadata", metadata_path, kind="kanban_board_metadata"))
+    if not default_workdir:
+        return (
+            _chip(
+                "scratch_safety",
+                "Scratch",
+                "unknown",
+                value="unknown",
+                source={"kind": "kanban_board_metadata", "path": _safe_display_path(metadata_path)},
+                checked_at=checked_at,
+                issues=["scratch default workdir unknown"],
+            ),
+            sources,
+        )
+
+    target = _safe_resolve(default_workdir)
+    allowed_root = _safe_resolve(board_info.get("allowed_root"))
+    active_workspace = workspace_info.get("path")
+    source = {
+        "kind": "kanban_board_metadata",
+        "default_workdir": _safe_display_path(target),
+        "allowed_root": _safe_display_path(allowed_root),
+        "path": _safe_display_path(metadata_path),
+    }
+
+    issues: list[str] = []
+    state = "live"
+    value = "safe"
+    if active_workspace and _path_contains(active_workspace, target):
+        state = "stale"
+        value = "risky"
+        issues.append("scratch default_workdir points under the active workspace")
+    elif _same_path(target, _INCIDENT_WORKSPACE):
+        state = "stale"
+        value = "risky"
+        issues.append("scratch default_workdir points at recovered workspace/main")
+    elif allowed_root and not _path_contains(allowed_root, target):
+        state = "stale"
+        value = "risky"
+        issues.append("scratch default_workdir is outside Hermes-owned Kanban storage")
+    elif not allowed_root:
+        state = "unknown"
+        value = "unknown"
+        issues.append("Hermes Kanban storage root unknown")
+
+    return (
+        _chip(
+            "scratch_safety",
+            "Scratch",
+            state,
+            value=value,
+            display_path=_safe_display_path(target),
+            source=source,
+            checked_at=checked_at,
+            issues=issues,
+        ),
+        sources,
+    )
+
+
+def _source_truth_files_chip(sources: list[dict[str, Any]], checked_at: float) -> dict[str, Any]:
+    checked = sum(1 for source in sources if source.get("exists"))
+    unreadable = [source for source in sources if source.get("issue")]
+    state = "live" if sources and not unreadable else "unknown"
+    return _chip(
+        "source_truth_files",
+        "Sources",
+        state,
+        value=f"{checked} checked",
+        source={"kind": "aggregate"},
+        checked_at=checked_at,
+        issues=[f"{len(unreadable)} source(s) unreadable"] if unreadable else [],
+    )
+
+
+def _worst_state(chips: list[dict[str, Any]]) -> str:
+    worst = "live"
+    for chip in chips:
+        state = chip.get("state", "unknown")
+        if STATE_ORDER.get(state, 1) > STATE_ORDER[worst]:
+            worst = state
+    return worst
+
+
+def _summary_for_status(status: str) -> str:
+    if status == "live":
+        return "Truth live"
+    if status == "stale":
+        return "Truth stale"
+    return "Truth unknown"
+
+
+def _valid_session_id(session_id: str) -> bool:
+    if not session_id or "/" in session_id or "\\" in session_id or ".." in session_id:
+        return False
+    return bool(_SESSION_ID_RE.match(session_id))
+
+
+def _session_json_path(session_id: str) -> Path | None:
+    try:
+        config = importlib.import_module("api.config")
+        return Path(getattr(config, "SESSION_DIR")) / f"{session_id}.json"
+    except Exception:
+        return None
+
+
+def _field(obj: Any, name: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _safe_board_exists(kb: Any, board: str) -> bool:
+    try:
+        return bool(kb.board_exists(board))
+    except Exception:
+        return False
+
+
+def _call_path(obj: Any, name: str, *args: Any) -> Path | None:
+    try:
+        value = getattr(obj, name)(*args)
+        return Path(value) if value is not None else None
+    except Exception:
+        return None
+
+
+def _safe_resolve(path: Any) -> Path | None:
+    if path is None:
+        return None
+    try:
+        return Path(path).expanduser().resolve(strict=False)
+    except Exception:
+        try:
+            return Path(str(path)).expanduser()
+        except Exception:
+            return None
+
+
+def _path_contains(root: Any, candidate: Any) -> bool:
+    root_path = _safe_resolve(root)
+    candidate_path = _safe_resolve(candidate)
+    if not root_path or not candidate_path:
+        return False
+    try:
+        candidate_path.relative_to(root_path)
+        return True
+    except ValueError:
+        return False
+
+
+def _same_path(left: Any, right: Any) -> bool:
+    left_path = _safe_resolve(left)
+    right_path = _safe_resolve(right)
+    return bool(left_path and right_path and left_path == right_path)
+
+
+def _safe_display_path(path: Any) -> str:
+    if not path:
+        return ""
+    text = str(path)
+    try:
+        home = str(Path.home())
+        if text == home:
+            text = "~"
+        elif text.startswith(home + os.sep):
+            text = "~" + text[len(home) :]
+    except Exception:
+        pass
+    if len(text) <= 88:
+        return text
+    parts = Path(text).parts
+    if len(parts) >= 3:
+        return "…/" + "/".join(parts[-3:])
+    return "…" + text[-85:]
+
+
+def _short_error(exc: BaseException) -> str:
+    text = str(exc).strip()
+    return text or exc.__class__.__name__

--- a/api/routes.py
+++ b/api/routes.py
@@ -7,6 +7,7 @@ import html as _html
 import copy
 import io
 import gzip
+import ipaddress
 import json
 import logging
 import os
@@ -1283,6 +1284,12 @@ def _csrf_exempt_path(path: str) -> bool:
         "/api/auth/passkey/options",
         "/api/auth/passkey/login",
         "/api/csp-report",
+        # Slice 5 local review queue writes are protected by a stricter
+        # loopback/proxy-header guard below. Let that guard produce the
+        # authoritative would_execute:false denial payload instead of the
+        # broader public-origin CSRF path.
+        "/api/operator/memory-skill-review/propose",
+        "/api/operator/memory-skill-review/decision",
     }
 
 
@@ -1365,6 +1372,151 @@ def _check_csrf(handler) -> bool:
     if verify_csrf_token(cookie_val or "", submitted or ""):
         return True
     return _set_csrf_failure_reason(handler, "token_mismatch")
+
+
+def _operator_commitments_is_loopback_host(value: str) -> bool:
+    text = str(value or "").strip().lower()
+    if not text:
+        return False
+    if text == "localhost":
+        return True
+    if text.startswith("[") and "]" in text:
+        text = text[1:text.index("]")]
+    elif ":" in text and text.count(":") == 1:
+        text = text.split(":", 1)[0]
+    try:
+        return ipaddress.ip_address(text).is_loopback
+    except ValueError:
+        return text == "localhost"
+
+
+def _operator_commitments_header_host(value: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if text.startswith("http://") or text.startswith("https://"):
+        try:
+            parsed = urlsplit(text)
+            if parsed.username or parsed.password:
+                return ""
+            return parsed.hostname or ""
+        except Exception:
+            return ""
+    if "@" in text:
+        return ""
+    return text
+
+
+def _operator_commitments_local_write_allowed(handler) -> bool:
+    """Slice 4 local write guard for commitment promotion.
+
+    CSRF can intentionally allow configured public origins. Commitment promotion is
+    narrower: it is a local state write and must stay loopback-only even behind a
+    reverse proxy.
+    """
+
+    try:
+        address = getattr(handler, "client_address", None)
+        client_ip = str(address[0]) if address else ""
+    except Exception:
+        client_ip = ""
+    if not _operator_commitments_is_loopback_host(client_ip):
+        return False
+
+    headers = getattr(handler, "headers", {})
+    forwarded_for = headers.get("X-Forwarded-For", "") if headers else ""
+    for part in str(forwarded_for or "").split(","):
+        item = part.strip()
+        if item and not _operator_commitments_is_loopback_host(item):
+            return False
+    for header in ("X-Real-IP", "X-Forwarded-Host", "X-Real-Host", "Host"):
+        value = headers.get(header, "") if headers else ""
+        if value and not _operator_commitments_is_loopback_host(_operator_commitments_header_host(value)):
+            return False
+    for header in ("Origin", "Referer"):
+        value = headers.get(header, "") if headers else ""
+        if value and not _operator_commitments_is_loopback_host(_operator_commitments_header_host(value)):
+            return False
+    return True
+
+
+def _operator_commitments_client_context(handler) -> dict[str, str]:
+    try:
+        address = getattr(handler, "client_address", None)
+        client_ip = str(address[0]) if address else "unknown"
+    except Exception:
+        client_ip = "unknown"
+    return {"client_ip": client_ip}
+
+
+def _operator_memory_skill_review_is_loopback_host(value: str) -> bool:
+    text = str(value or "").strip().lower()
+    if not text:
+        return False
+    if text == "localhost":
+        return True
+    if text.startswith("[") and "]" in text:
+        text = text[1:text.index("]")]
+    elif ":" in text and text.count(":") == 1:
+        text = text.split(":", 1)[0]
+    try:
+        return ipaddress.ip_address(text).is_loopback
+    except ValueError:
+        return text == "localhost"
+
+
+def _operator_memory_skill_review_header_host(value: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if text.startswith("http://") or text.startswith("https://"):
+        try:
+            parsed = urlsplit(text)
+            if parsed.username or parsed.password:
+                return ""
+            return parsed.hostname or ""
+        except Exception:
+            return ""
+    if "@" in text:
+        return ""
+    return text
+
+
+def _operator_memory_skill_review_local_write_allowed(handler) -> bool:
+    """Slice 5 local write guard for memory/skill review queue state."""
+
+    try:
+        address = getattr(handler, "client_address", None)
+        client_ip = str(address[0]) if address else ""
+    except Exception:
+        client_ip = ""
+    if not _operator_memory_skill_review_is_loopback_host(client_ip):
+        return False
+
+    headers = getattr(handler, "headers", {})
+    forwarded_for = headers.get("X-Forwarded-For", "") if headers else ""
+    for part in str(forwarded_for or "").split(","):
+        item = part.strip()
+        if item and not _operator_memory_skill_review_is_loopback_host(item):
+            return False
+    for header in ("X-Real-IP", "X-Forwarded-Host", "X-Real-Host", "Host"):
+        value = headers.get(header, "") if headers else ""
+        if value and not _operator_memory_skill_review_is_loopback_host(_operator_memory_skill_review_header_host(value)):
+            return False
+    for header in ("Origin", "Referer"):
+        value = headers.get(header, "") if headers else ""
+        if value and not _operator_memory_skill_review_is_loopback_host(_operator_memory_skill_review_header_host(value)):
+            return False
+    return True
+
+
+def _operator_memory_skill_review_client_context(handler) -> dict[str, str]:
+    try:
+        address = getattr(handler, "client_address", None)
+        client_ip = str(address[0]) if address else "unknown"
+    except Exception:
+        client_ip = "unknown"
+    return {"client_ip": client_ip}
 
 
 def _client_ip_for_rate_limit(handler) -> str:
@@ -2487,9 +2639,11 @@ from api.streaming import (
 )
 from api.run_journal import (
     find_run_summary,
+    latest_run_summary_for_session,
     read_run_events,
     stale_interrupted_event,
 )
+from api.run_graph import build_run_graph
 from api.providers import get_providers, get_provider_quota, get_provider_cost_history, set_provider_key, remove_provider_key
 from api.onboarding import (
     apply_onboarding_setup,
@@ -3865,6 +4019,120 @@ def handle_get(handler, parsed) -> bool:
         j(handler, build_system_health_payload())
         return True
 
+    if parsed.path == "/api/operator/truth":
+        from api.operator_truth import build_operator_truth_payload
+
+        qs = parse_qs(parsed.query or "")
+        payload = build_operator_truth_payload(
+            session_id=(qs.get("session_id", [""])[0] or None),
+            ui_board_hint=(qs.get("ui_board", [""])[0] or None),
+        )
+        j(handler, payload)
+        return True
+
+    if parsed.path == "/api/operator/proposals":
+        from api.operator_proposals import build_operator_proposal_payload
+
+        qs = parse_qs(parsed.query or "")
+        payload = build_operator_proposal_payload(
+            session_id=(qs.get("session_id", [""])[0] or None),
+            ui_board_hint=(qs.get("ui_board", [""])[0] or None),
+        )
+        j(handler, payload)
+        return True
+
+    if parsed.path == "/api/operator/kanban":
+        from api.operator_kanban import build_operator_kanban_payload
+
+        qs = parse_qs(parsed.query or "")
+        payload = build_operator_kanban_payload(
+            board=(qs.get("board", [""])[0] or "hermes-operator"),
+            session_id=(qs.get("session_id", [""])[0] or None),
+            ui_board_hint=(qs.get("ui_board", [""])[0] or None),
+        )
+        j(handler, payload)
+        return True
+
+    if parsed.path == "/api/operator/commitments":
+        from api.operator_commitments import build_operator_commitments_payload
+
+        qs = parse_qs(parsed.query or "")
+        payload = build_operator_commitments_payload(
+            session_id=(qs.get("session_id", [""])[0] or None),
+            ui_board_hint=(qs.get("ui_board", [""])[0] or None),
+        )
+        j(handler, payload)
+        return True
+
+    if parsed.path == "/api/operator/memory-skill-review":
+        from api.operator_memory_skill_review import build_operator_memory_skill_review_payload
+
+        qs = parse_qs(parsed.query or "")
+        payload = build_operator_memory_skill_review_payload(
+            session_id=(qs.get("session_id", [""])[0] or None),
+            ui_board_hint=(qs.get("ui_board", [""])[0] or None),
+        )
+        j(handler, payload)
+        return True
+
+    if parsed.path == "/api/operator/session-recall":
+        from api.operator_session_recall import build_operator_session_recall_payload
+
+        qs = parse_qs(parsed.query or "")
+        all_profiles_raw = (qs.get("all_profiles", [""])[0] or "").strip().lower()
+        payload = build_operator_session_recall_payload(
+            query_text=qs.get("q", [""])[0],
+            limit=qs.get("limit", [20])[0],
+            per_session=qs.get("per_session", [2])[0],
+            all_profiles=all_profiles_raw in {"1", "true", "yes", "on"},
+        )
+        j(handler, payload)
+        return True
+
+    if parsed.path == "/api/operator/docs-artifacts":
+        from api.operator_docs_artifacts import build_operator_docs_artifacts_payload
+
+        qs = parse_qs(parsed.query or "")
+        payload = build_operator_docs_artifacts_payload(
+            query_text=qs.get("query", [""])[0],
+            kind=qs.get("kind", ["all"])[0],
+            root=qs.get("root", ["all"])[0],
+            limit=qs.get("limit", [50])[0],
+        )
+        j(handler, payload)
+        return True
+
+    if parsed.path == "/api/operator/docs-artifacts/open":
+        from api.operator_docs_artifacts import build_operator_docs_artifact_preview_payload
+
+        qs = parse_qs(parsed.query or "")
+        payload = build_operator_docs_artifact_preview_payload(
+            item_id=qs.get("id", [""])[0],
+        )
+        j(handler, payload)
+        return True
+
+    if parsed.path == "/api/operator/device-admin":
+        from api.operator_device_admin import build_operator_device_admin_payload
+
+        qs = parse_qs(parsed.query or "")
+        payload = build_operator_device_admin_payload(
+            query_text=qs.get("query", [""])[0],
+            host=qs.get("host", ["all"])[0],
+            action=qs.get("action", ["all"])[0],
+            limit=qs.get("limit", [50])[0],
+        )
+        j(handler, payload)
+        return True
+
+    if parsed.path == "/api/operator/device-admin/preview":
+        from api.operator_device_admin import build_operator_device_admin_preview_payload
+
+        qs = parse_qs(parsed.query or "")
+        payload = build_operator_device_admin_preview_payload(action_id=qs.get("id", [""])[0])
+        j(handler, payload)
+        return True
+
     if parsed.path == "/api/models":
         return j(handler, get_available_models())
 
@@ -4584,6 +4852,47 @@ def handle_get(handler, parsed) -> bool:
             payload["journal"] = _run_journal_status_payload(journal, active=active)
         return j(handler, payload)
 
+    if parsed.path == "/api/run/latest":
+        qs = parse_qs(parsed.query)
+        session_id = qs.get("session_id", [""])[0].strip()
+        if not session_id:
+            return bad(handler, "session_id required")
+        try:
+            summary = latest_run_summary_for_session(session_id)
+        except ValueError as exc:
+            return bad(handler, str(exc))
+        except Exception:
+            logger.exception("/api/run/latest failed for session %s", session_id)
+            summary = None
+        if not summary:
+            return j(handler, {"found": False, "session_id": session_id, "run_id": None, "journal": None})
+        return j(
+            handler,
+            {
+                "found": True,
+                "session_id": summary.get("session_id"),
+                "run_id": summary.get("run_id"),
+                "journal": _run_journal_status_payload(summary, active=False),
+            },
+        )
+
+    if parsed.path == "/api/run/graph":
+        qs = parse_qs(parsed.query)
+        session_id = qs.get("session_id", [""])[0].strip()
+        run_id = qs.get("run_id", [""])[0].strip()
+        if not session_id:
+            return bad(handler, "session_id required")
+        if not run_id:
+            return bad(handler, "run_id required")
+        return j(
+            handler,
+            build_run_graph(
+                session_id,
+                run_id,
+                after_seq=_parse_run_journal_after_seq(qs),
+            ),
+        )
+
     if parsed.path == "/api/chat/cancel":
         stream_id = parse_qs(parsed.query).get("stream_id", [""])[0]
         if not stream_id:
@@ -4931,6 +5240,53 @@ def handle_post(handler, parsed) -> bool:
         from api.session_recovery import repair_safe_session_recovery
         result = repair_safe_session_recovery(SESSION_DIR, state_db_path=_active_state_db_path())
         return j(handler, result, status=200 if result.get("clean") else 409)
+
+    if parsed.path == "/api/operator/commitments/promote":
+        if not _operator_commitments_local_write_allowed(handler):
+            j(handler, {"error": "commitment promotion is loopback-only", "would_execute": False}, status=403)
+            return True
+        from api.operator_commitments import promote_operator_commitment
+
+        result = promote_operator_commitment(
+            body,
+            client_context=_operator_commitments_client_context(handler),
+        )
+        j(handler, result, status=201 if result.get("ok") else 400)
+        return True
+
+    if parsed.path == "/api/operator/memory-skill-review/propose":
+        if not _operator_memory_skill_review_local_write_allowed(handler):
+            j(
+                handler,
+                {"ok": False, "error": "memory/skill review queue writes are loopback-only", "would_execute": False},
+                status=403,
+            )
+            return True
+        from api.operator_memory_skill_review import propose_operator_memory_skill_review
+
+        result = propose_operator_memory_skill_review(
+            body,
+            client_context=_operator_memory_skill_review_client_context(handler),
+        )
+        j(handler, result, status=201 if result.get("ok") else 400)
+        return True
+
+    if parsed.path == "/api/operator/memory-skill-review/decision":
+        if not _operator_memory_skill_review_local_write_allowed(handler):
+            j(
+                handler,
+                {"ok": False, "error": "memory/skill review queue writes are loopback-only", "would_execute": False},
+                status=403,
+            )
+            return True
+        from api.operator_memory_skill_review import decide_operator_memory_skill_review
+
+        result = decide_operator_memory_skill_review(
+            body,
+            client_context=_operator_memory_skill_review_client_context(handler),
+        )
+        j(handler, result, status=200 if result.get("ok") else 400)
+        return True
 
     if parsed.path.startswith("/api/kanban/"):
         from api.kanban_bridge import handle_kanban_post

--- a/api/run_graph.py
+++ b/api/run_graph.py
@@ -1,0 +1,289 @@
+"""Project append-only run-journal events into graph-card data.
+
+The journal is the source of truth.  This module does not invent demo nodes, does
+not inspect live process state, and does not mutate journal files.  It is the
+read-only bridge between the durable SSE journal and a future WebUI "run graph"
+view.
+"""
+from __future__ import annotations
+
+import hashlib
+from collections import OrderedDict
+from typing import Any, Iterable
+
+from api.run_journal import latest_run_summary, read_run_events
+
+_TERMINAL_EVENTS = {"done", "stream_end", "cancel", "apperror", "error"}
+_TOOL_START_EVENTS = {"tool"}
+_TOOL_END_EVENTS = {"tool_complete"}
+_ASSISTANT_EVENTS = {"token", "interim_assistant"}
+_REASONING_EVENTS = {"reasoning"}
+_COMPRESSION_EVENTS = {"compressing", "compressed"}
+_METERING_EVENTS = {"metering"}
+_WARNING_EVENTS = {"warning"}
+
+
+def _safe_str(value: Any, limit: int = 120) -> str:
+    text = str(value or "").strip()
+    if len(text) > limit:
+        return text[: limit - 1] + "…"
+    return text
+
+
+def _event_seq(event: dict) -> int:
+    try:
+        return int(event.get("seq") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _event_time(event: dict) -> float | None:
+    try:
+        raw = event.get("created_at")
+        return float(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _event_name(event: dict) -> str:
+    return str(event.get("event") or event.get("type") or "").strip()
+
+
+def _payload(event: dict) -> dict:
+    payload = event.get("payload")
+    return payload if isinstance(payload, dict) else {}
+
+
+def _hash_key(parts: Iterable[Any]) -> str:
+    raw = "|".join(str(p) for p in parts if p is not None)
+    return hashlib.sha1(raw.encode("utf-8", errors="ignore")).hexdigest()[:12]
+
+
+def _payload_summary(event_name: str, payload: dict) -> dict[str, Any]:
+    """Return bounded metadata for cards without dumping raw logs/tokens."""
+    summary: dict[str, Any] = {}
+    for key in ("name", "tool", "type", "status", "phase", "message", "hint"):
+        if key in payload and payload.get(key) not in (None, ""):
+            summary[key] = _safe_str(payload.get(key))
+    if event_name in _ASSISTANT_EVENTS or event_name in _REASONING_EVENTS:
+        text = payload.get("text") or payload.get("content") or payload.get("delta") or ""
+        summary["text_chars"] = len(str(text))
+    if event_name in _TOOL_START_EVENTS:
+        args = payload.get("args") or payload.get("arguments") or {}
+        if isinstance(args, dict):
+            summary["arg_keys"] = sorted(str(k) for k in args.keys())[:20]
+        elif args:
+            summary["args_chars"] = len(str(args))
+    if event_name in _TOOL_END_EVENTS:
+        result = payload.get("result") or payload.get("output") or payload.get("content") or ""
+        if result:
+            summary["result_chars"] = len(str(result))
+        if "ok" in payload:
+            summary["ok"] = bool(payload.get("ok"))
+    if event_name in _METERING_EVENTS:
+        usage = payload.get("usage")
+        if isinstance(usage, dict):
+            summary["usage"] = {
+                key: usage.get(key)
+                for key in ("input_tokens", "output_tokens", "estimated_cost", "cache_hit_percent")
+                if key in usage
+            }
+    return summary
+
+
+def _status_from_terminal(event_name: str, payload: dict, terminal_state: str | None = None) -> str | None:
+    if event_name == "done":
+        return "succeeded"
+    if event_name == "stream_end":
+        return "succeeded" if terminal_state == "completed" else "completed"
+    if event_name == "cancel":
+        return "interrupted"
+    if event_name in {"apperror", "error"}:
+        err_type = str(payload.get("type") or terminal_state or "").lower()
+        if err_type in {"cancelled", "canceled", "interrupted", "interrupted-by-user", "lost-worker-bookkeeping"}:
+            return "interrupted"
+        return "failed"
+    return None
+
+
+def _new_node(node_id: str, kind: str, label: str, parent_id: str, event: dict, status: str = "running") -> dict[str, Any]:
+    seq = _event_seq(event)
+    created_at = _event_time(event)
+    return {
+        "id": node_id,
+        "kind": kind,
+        "label": label,
+        "status": status,
+        "parent_id": parent_id,
+        "first_seq": seq,
+        "last_seq": seq,
+        "event_count": 0,
+        "started_at": created_at,
+        "finished_at": None,
+        "events": [],
+        "latest": {},
+    }
+
+
+def _touch_node(node: dict[str, Any], event: dict, status: str | None = None) -> None:
+    seq = _event_seq(event)
+    event_name = _event_name(event)
+    payload = _payload(event)
+    node["last_seq"] = max(int(node.get("last_seq") or 0), seq)
+    node["event_count"] = int(node.get("event_count") or 0) + 1
+    node.setdefault("events", []).append({
+        "seq": seq,
+        "event": event_name,
+        "event_id": event.get("event_id"),
+        "created_at": _event_time(event),
+    })
+    node["latest"] = _payload_summary(event_name, payload)
+    if status:
+        node["status"] = status
+    if node.get("status") in {"succeeded", "failed", "interrupted", "completed", "skipped"}:
+        node["finished_at"] = _event_time(event) or node.get("finished_at")
+
+
+def _tool_node_key(event: dict, fallback_index: int) -> str:
+    payload = _payload(event)
+    key = (
+        payload.get("tool_call_id")
+        or payload.get("call_id")
+        or payload.get("id")
+        or payload.get("name")
+        or payload.get("tool")
+    )
+    if key:
+        return _safe_str(key, 80)
+    return f"tool-{fallback_index}"
+
+
+def _tool_label(event: dict) -> str:
+    payload = _payload(event)
+    return _safe_str(payload.get("name") or payload.get("tool") or payload.get("id") or "Tool call")
+
+
+def build_run_graph_from_events(session_id: str, run_id: str, events: Iterable[dict]) -> dict[str, Any]:
+    """Build graph-card data from already-read journal events."""
+    ordered_events = sorted(
+        [event for event in events if isinstance(event, dict)],
+        key=lambda event: (_event_seq(event), _event_time(event) or 0.0),
+    )
+    root_id = f"run:{run_id}"
+    root = {
+        "id": root_id,
+        "kind": "run",
+        "label": "Run",
+        "status": "running" if ordered_events else "unknown",
+        "parent_id": None,
+        "first_seq": _event_seq(ordered_events[0]) if ordered_events else 0,
+        "last_seq": _event_seq(ordered_events[-1]) if ordered_events else 0,
+        "event_count": len(ordered_events),
+        "started_at": _event_time(ordered_events[0]) if ordered_events else None,
+        "finished_at": None,
+        "events": [],
+        "latest": {},
+    }
+
+    nodes: "OrderedDict[str, dict[str, Any]]" = OrderedDict([(root_id, root)])
+    edges: list[dict[str, Any]] = []
+    seen_edges: set[tuple[str, str, str]] = set()
+    tool_index = 0
+
+    def ensure_edge(source: str, target: str, kind: str = "contains") -> None:
+        key = (source, target, kind)
+        if key in seen_edges:
+            return
+        seen_edges.add(key)
+        edges.append({"source": source, "target": target, "kind": kind})
+
+    def ensure_node(node_id: str, kind: str, label: str, event: dict, status: str = "running") -> dict[str, Any]:
+        node = nodes.get(node_id)
+        if node is None:
+            node = _new_node(node_id, kind, label, root_id, event, status=status)
+            nodes[node_id] = node
+            ensure_edge(root_id, node_id)
+        return node
+
+    active_tool_by_key: dict[str, str] = {}
+
+    for event in ordered_events:
+        event_name = _event_name(event)
+        payload = _payload(event)
+        terminal_state = event.get("terminal_state")
+
+        if event_name in _REASONING_EVENTS:
+            node = ensure_node(f"{root_id}:reasoning", "model_reasoning", "Reasoning", event)
+            _touch_node(node, event)
+        elif event_name in _ASSISTANT_EVENTS:
+            node = ensure_node(f"{root_id}:assistant", "assistant_output", "Assistant output", event)
+            _touch_node(node, event)
+        elif event_name in _TOOL_START_EVENTS:
+            tool_index += 1
+            tool_key = _tool_node_key(event, tool_index)
+            node_id = f"{root_id}:tool:{_hash_key([tool_key])}"
+            active_tool_by_key[tool_key] = node_id
+            node = ensure_node(node_id, "tool_call", _tool_label(event), event)
+            _touch_node(node, event, status="running")
+        elif event_name in _TOOL_END_EVENTS:
+            tool_key = _tool_node_key(event, tool_index + 1)
+            node_id = active_tool_by_key.get(tool_key) or f"{root_id}:tool:{_hash_key([tool_key])}"
+            node = ensure_node(node_id, "tool_call", _tool_label(event), event)
+            ok = payload.get("ok")
+            status = "succeeded" if ok is not False else "failed"
+            _touch_node(node, event, status=status)
+        elif event_name in _COMPRESSION_EVENTS:
+            node = ensure_node(f"{root_id}:compression", "compression", "Context compression", event)
+            status = "succeeded" if event_name == "compressed" else "running"
+            _touch_node(node, event, status=status)
+        elif event_name in _METERING_EVENTS:
+            node = ensure_node(f"{root_id}:metering", "metering", "Metering", event)
+            _touch_node(node, event, status="running")
+        elif event_name in _WARNING_EVENTS:
+            node_id = f"{root_id}:warning:{_hash_key([_event_seq(event), payload.get('type'), payload.get('message')])}"
+            node = ensure_node(node_id, "warning", "Warning", event, status="succeeded")
+            _touch_node(node, event, status="succeeded")
+        elif event_name in _TERMINAL_EVENTS:
+            status = _status_from_terminal(event_name, payload, terminal_state) or "completed"
+            node_id = f"{root_id}:terminal"
+            node = ensure_node(node_id, "terminal", _safe_str(event_name or "terminal"), event, status=status)
+            _touch_node(node, event, status=status)
+            root["status"] = status
+            root["finished_at"] = _event_time(event) or root.get("finished_at")
+        else:
+            node_id = f"{root_id}:event:{_hash_key([event_name, _event_seq(event)])}"
+            node = ensure_node(node_id, "event", _safe_str(event_name or "Event"), event, status="succeeded")
+            _touch_node(node, event, status="succeeded")
+
+    if root["status"] == "running":
+        # If the journal stored an explicit terminal state but the terminal event
+        # did not make it through the branch above, preserve that status rather
+        # than guessing a success path.
+        terminal = next((event for event in reversed(ordered_events) if event.get("terminal")), None)
+        if terminal:
+            status = _status_from_terminal(_event_name(terminal), _payload(terminal), terminal.get("terminal_state"))
+            if status:
+                root["status"] = status
+                root["finished_at"] = _event_time(terminal)
+
+    return {
+        "version": 1,
+        "session_id": str(session_id),
+        "run_id": str(run_id),
+        "status": root["status"],
+        "event_count": len(ordered_events),
+        "nodes": list(nodes.values()),
+        "edges": edges,
+    }
+
+
+def build_run_graph(session_id: str, run_id: str, *, after_seq: int | None = None) -> dict[str, Any]:
+    """Read journal events and project them into graph-card data."""
+    journal = read_run_events(session_id, run_id, after_seq=after_seq)
+    graph = build_run_graph_from_events(session_id, run_id, journal.get("events") or [])
+    graph["malformed"] = journal.get("malformed") or []
+    try:
+        graph["summary"] = latest_run_summary(session_id, run_id)
+    except Exception:
+        graph["summary"] = None
+    return graph

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -216,6 +216,7 @@ def read_run_events(
 def _summary_from_events(session_id: str, run_id: str, events: Iterable[dict]) -> dict:
     ordered = [event for event in events if isinstance(event, dict)]
     last = ordered[-1] if ordered else None
+    first = ordered[0] if ordered else None
     terminal_events = [event for event in ordered if event.get("terminal")]
     terminal = next(
         (event for event in reversed(terminal_events) if event.get("event") != "stream_end"),
@@ -232,7 +233,19 @@ def _summary_from_events(session_id: str, run_id: str, events: Iterable[dict]) -
         "terminal": bool(terminal),
         "terminal_state": status,
         "last_event": (last or {}).get("event"),
+        "first_created_at": _event_created_at(first),
+        "last_created_at": _event_created_at(last),
     }
+
+
+def _event_created_at(event: dict | None) -> float | None:
+    if not isinstance(event, dict):
+        return None
+    try:
+        raw = event.get("created_at")
+        return float(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        return None
 
 
 def latest_run_summary(session_id: str, run_id: str, *, session_dir: Path | None = None) -> dict:
@@ -251,6 +264,38 @@ def find_run_summary(run_id: str, *, session_dir: Path | None = None) -> dict | 
         summary["path"] = str(path)
         return summary
     return None
+
+
+def latest_run_summary_for_session(session_id: str, *, session_dir: Path | None = None) -> dict | None:
+    """Return the newest non-empty run journal summary for one session."""
+    sid = _validate_id(session_id, "session_id")
+    root = Path(session_dir) if session_dir is not None else _default_session_dir()
+    session_journal_dir = root / RUN_JOURNAL_DIR_NAME / sid
+    if not session_journal_dir.exists():
+        return None
+
+    latest: dict | None = None
+    latest_key: tuple[float, int, str] | None = None
+    for path in session_journal_dir.glob("*.jsonl"):
+        try:
+            rid = _validate_id(path.stem, "run_id")
+        except ValueError:
+            continue
+        events, _malformed = _read_jsonl(path)
+        if not events:
+            continue
+        summary = _summary_from_events(sid, rid, events)
+        summary["path"] = str(path)
+        try:
+            mtime_ns = path.stat().st_mtime_ns
+        except OSError:
+            mtime_ns = 0
+        latest_at = float(summary.get("last_created_at") or 0.0)
+        key: tuple[float, int, str] = (latest_at, int(mtime_ns), rid)
+        if latest_key is None or key > latest_key:
+            latest_key = key
+            latest = summary
+    return latest
 
 
 def stale_interrupted_event(session_id: str, run_id: str, *, after_seq: int | None = None) -> dict | None:

--- a/static/commands.js
+++ b/static/commands.js
@@ -824,6 +824,7 @@ async function cmdGoal(args){
     appendThinking();setBusy(true);
     setComposerStatus(t('goal_working_toward'));
     S.activeStreamId=r.stream_id;
+    if(typeof rememberSessionRunGraphRun==='function')rememberSessionRunGraphRun(activeSid,r.stream_id);
     if(S.session&&S.session.session_id===activeSid){
       S.session.active_stream_id=r.stream_id;
       if(typeof r.pending_started_at==='number')S.session.pending_started_at=r.pending_started_at;

--- a/static/index.html
+++ b/static/index.html
@@ -603,6 +603,36 @@
                 </button>
               </div>
             </div>
+            <div id="operatorTruthStrip" class="operator-truth-strip" aria-label="Operator truth status" role="group">
+              <button id="operatorTruthSummaryChip" class="operator-truth-chip state-unknown" type="button" title="Operator truth status unknown" onclick="refreshOperatorTruth({force:true,reason:'manual'})">
+                <span class="operator-truth-dot" aria-hidden="true"></span>
+                <span class="operator-truth-chip-label" id="operatorTruthSummaryLabel">Truth unknown</span>
+              </button>
+              <button id="operatorTruthBoardChip" class="operator-truth-chip state-unknown operator-truth-chip-secondary" type="button" onclick="refreshOperatorTruth({force:true,reason:'manual'})" hidden>
+                <span class="operator-truth-chip-label" id="operatorTruthBoardLabel">Board unknown</span>
+              </button>
+              <button id="operatorTruthScratchChip" class="operator-truth-chip state-unknown operator-truth-chip-secondary" type="button" onclick="refreshOperatorTruth({force:true,reason:'manual'})" hidden>
+                <span class="operator-truth-chip-label" id="operatorTruthScratchLabel">Scratch unknown</span>
+              </button>
+              <button id="operatorProposalChip" class="operator-truth-chip operator-proposal-chip state-unknown operator-truth-chip-secondary" type="button" onclick="toggleOperatorProposals({force:true})" title="Manual next-action proposals" hidden>
+                <span class="operator-truth-chip-label" id="operatorProposalLabel">Proposals</span>
+              </button>
+              <button id="operatorCommitmentChip" class="operator-truth-chip operator-commitment-chip state-unknown operator-truth-chip-secondary" type="button" onclick="toggleOperatorCommitments({force:true})" title="Local commitment cards" hidden>
+                <span class="operator-truth-chip-label" id="operatorCommitmentLabel">Commitments</span>
+              </button>
+              <button id="operatorMemorySkillReviewChip" class="operator-truth-chip operator-memory-skill-review-chip state-unknown operator-truth-chip-secondary" type="button" onclick="toggleOperatorMemorySkillReview({force:true})" title="Memory and skill review queue" hidden>
+                <span class="operator-truth-chip-label" id="operatorMemorySkillReviewLabel">Memory Review</span>
+              </button>
+              <button id="operatorSessionRecallChip" class="operator-truth-chip operator-session-recall-chip state-unknown operator-truth-chip-secondary" type="button" onclick="toggleOperatorSessionRecall()" title="Manual session recall" hidden>
+                <span class="operator-truth-chip-label" id="operatorSessionRecallLabel">Recall</span>
+              </button>
+              <button id="operatorDocsArtifactsChip" class="operator-truth-chip operator-docs-artifacts-chip state-unknown operator-truth-chip-secondary" type="button" onclick="toggleOperatorDocsArtifacts()" title="Manual docs and artifacts browser" hidden>
+                <span class="operator-truth-chip-label" id="operatorDocsArtifactsLabel">Docs</span>
+              </button>
+              <button id="operatorDeviceAdminChip" class="operator-truth-chip operator-device-admin-chip state-unknown operator-truth-chip-secondary" type="button" onclick="toggleOperatorDeviceAdmin()" title="Device admin foundations" hidden>
+                <span class="operator-truth-chip-label" id="operatorDeviceAdminLabel">Device Admin</span>
+              </button>
+            </div>
             <button class="icon-btn composer-mobile-config-btn" id="composerMobileConfigBtn" type="button" onclick="toggleMobileComposerConfig()" title="Workspace, model, reasoning, and context settings" aria-label="Workspace, model, reasoning, and context settings" aria-haspopup="true" aria-expanded="false" aria-controls="composerMobileConfigPanel">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
               <span class="composer-mobile-ctx-badge" id="composerMobileCtxBadge" aria-hidden="true" style="display:none">0</span>
@@ -728,6 +758,224 @@
             </div>
           </div>
           <div class="model-dropdown" id="composerModelDropdown"></div>
+          <div id="operatorProposalPopover" class="operator-proposal-popover" hidden aria-label="Manual next-action proposals">
+            <div class="operator-proposal-header">
+              <div>
+                <div class="operator-proposal-title">Proposals</div>
+                <div class="operator-proposal-subtitle" id="operatorProposalSubtitle">Not checked yet</div>
+              </div>
+              <button type="button" class="operator-proposal-close" onclick="hideOperatorProposals()" aria-label="Close proposals">×</button>
+            </div>
+            <div id="operatorProposalList" class="operator-proposal-list"></div>
+          </div>
+          <div id="operatorCommitmentPopover" class="operator-commitment-popover" hidden aria-label="Local commitment cards">
+            <div class="operator-commitment-header">
+              <div>
+                <div class="operator-commitment-title">Commitment Cards</div>
+                <div class="operator-commitment-subtitle" id="operatorCommitmentSubtitle">Not checked yet</div>
+              </div>
+              <button type="button" class="operator-commitment-close" onclick="hideOperatorCommitments()" aria-label="Close commitments">×</button>
+            </div>
+            <div id="operatorCommitmentList" class="operator-commitment-list"></div>
+            <form id="operatorCommitmentForm" class="operator-commitment-form" onsubmit="submitOperatorCommitmentForm(event)" hidden>
+              <input type="hidden" id="operatorCommitmentSource" name="source">
+              <input type="hidden" id="operatorCommitmentEvidence" name="evidence">
+              <div class="operator-commitment-form-title">Promote to commitment</div>
+              <label>Title <input id="operatorCommitmentTitle" name="title" maxlength="200" autocomplete="off"></label>
+              <label>Owner <input id="operatorCommitmentOwner" name="owner" maxlength="120" autocomplete="off" required></label>
+              <div class="operator-commitment-form-row">
+                <label>Deadline <input id="operatorCommitmentDeadline" name="deadline_at" type="date" required></label>
+                <label>Review <input id="operatorCommitmentReview" name="review_at" type="date"></label>
+              </div>
+              <label>Dispatch mechanism
+                <select id="operatorCommitmentDispatch" name="dispatch_mechanism">
+                  <option value="manual">manual</option>
+                  <option value="handoff">handoff</option>
+                  <option value="human_review">human_review</option>
+                </select>
+              </label>
+              <label>Acceptance criteria <textarea id="operatorCommitmentAcceptance" name="acceptance_criteria" rows="3" required></textarea></label>
+              <label>Halt policy <textarea id="operatorCommitmentHaltPolicy" name="halt_policy" rows="2" required></textarea></label>
+              <label>Status
+                <select id="operatorCommitmentStatus" name="status">
+                  <option value="active">active</option>
+                  <option value="blocked">blocked</option>
+                  <option value="halted">halted</option>
+                  <option value="superseded">superseded</option>
+                </select>
+              </label>
+              <div id="operatorCommitmentMissing" class="operator-commitment-missing" aria-live="polite"></div>
+              <div class="operator-commitment-actions">
+                <button type="button" class="operator-commitment-action" onclick="cancelOperatorCommitmentDraft()">Cancel</button>
+                <button type="submit" class="operator-commitment-action primary">Save local commitment</button>
+              </div>
+            </form>
+          </div>
+          <div id="operatorMemorySkillReviewPopover" class="operator-memory-skill-review-popover" hidden aria-label="Memory and skill review queue">
+            <div class="operator-memory-skill-review-header">
+              <div>
+                <div class="operator-memory-skill-review-title">Memory / Skill Review</div>
+                <div class="operator-memory-skill-review-subtitle" id="operatorMemorySkillReviewSubtitle">Not checked yet — local review only, no apply</div>
+              </div>
+              <div class="operator-memory-skill-review-header-actions">
+                <button type="button" id="operatorMemorySkillReviewRefresh" class="operator-memory-skill-review-refresh" onclick="refreshOperatorMemorySkillReview({force:true})">Refresh</button>
+                <button type="button" class="operator-memory-skill-review-close" onclick="hideOperatorMemorySkillReview()" aria-label="Close memory and skill review">×</button>
+              </div>
+            </div>
+            <div id="operatorMemorySkillReviewList" class="operator-memory-skill-review-list"></div>
+          </div>
+          <div id="operatorSessionRecallPopover" class="operator-session-recall-popover" hidden aria-label="Manual session recall">
+            <div class="operator-session-recall-header">
+              <div>
+                <div class="operator-session-recall-title">Session Recall</div>
+                <div class="operator-session-recall-subtitle" id="operatorSessionRecallStatus">Manual shell only — search not wired yet</div>
+              </div>
+              <button type="button" class="operator-session-recall-close" onclick="hideOperatorSessionRecall()" aria-label="Close session recall">×</button>
+            </div>
+            <div class="operator-session-recall-controls">
+              <input id="operatorSessionRecallInput" class="operator-session-recall-input" type="search" autocomplete="off" placeholder="Search saved sessions (coming next)">
+              <button type="button" id="operatorSessionRecallRefresh" class="operator-session-recall-action primary" onclick="refreshOperatorSessionRecall()">Search</button>
+            </div>
+            <div id="operatorSessionRecallMemoryProposalPanel" class="operator-session-recall-memory-proposal" hidden aria-label="Draft memory or skill review proposal">
+              <div class="operator-session-recall-memory-proposal-title">Draft memory/skill review proposal</div>
+              <form id="operatorSessionRecallMemoryProposalForm" class="operator-session-recall-memory-proposal-form" onsubmit="return submitOperatorSessionRecallMemoryProposal(event)">
+                <div class="operator-session-recall-memory-proposal-evidence">
+                  <div class="operator-session-recall-source"><span class="operator-session-recall-source-label">source_session_id</span><span id="operatorSessionRecallMemoryProposalEvidenceSessionId" class="operator-session-recall-source-value"></span></div>
+                  <div class="operator-session-recall-source"><span class="operator-session-recall-source-label">source_message_index</span><span id="operatorSessionRecallMemoryProposalEvidenceMessageIndex" class="operator-session-recall-source-value"></span></div>
+                  <div class="operator-session-recall-source"><span class="operator-session-recall-source-label">source_content_hash</span><span id="operatorSessionRecallMemoryProposalEvidenceContentHash" class="operator-session-recall-source-value"></span></div>
+                  <div class="operator-session-recall-source"><span class="operator-session-recall-source-label">source_quote</span><span id="operatorSessionRecallMemoryProposalEvidenceQuote" class="operator-session-recall-source-value"></span></div>
+                </div>
+                <div class="operator-session-recall-memory-proposal-grid">
+                  <label>Target kind
+                    <select id="operatorSessionRecallMemoryProposalTargetKind" name="target_kind" required>
+                      <option value="">Choose target kind</option>
+                      <option value="memory">memory</option>
+                      <option value="skill">skill</option>
+                    </select>
+                  </label>
+                  <label>Memory section
+                    <select id="operatorSessionRecallMemoryProposalTargetSection" name="target_section">
+                      <option value="">Choose memory section</option>
+                      <option value="memory">memory</option>
+                      <option value="user">user</option>
+                      <option value="soul">soul</option>
+                    </select>
+                  </label>
+                  <label>Skill name <input id="operatorSessionRecallMemoryProposalTargetName" name="target_name" type="text" autocomplete="off"></label>
+                  <label>Skill category <input id="operatorSessionRecallMemoryProposalTargetCategory" name="target_category" type="text" autocomplete="off"></label>
+                  <label>Operation
+                    <select id="operatorSessionRecallMemoryProposalOperation" name="operation" required>
+                      <option value="append">append</option>
+                      <option value="edit">edit</option>
+                      <option value="delete">delete</option>
+                    </select>
+                  </label>
+                  <label>Durability
+                    <select id="operatorSessionRecallMemoryProposalClassificationDurability" name="classification_durability" required>
+                      <option value="durable">durable</option>
+                      <option value="transient">transient</option>
+                      <option value="unknown">unknown</option>
+                    </select>
+                  </label>
+                  <label>Transient risk
+                    <select id="operatorSessionRecallMemoryProposalTransientRisk" name="classification_transient_risk" required>
+                      <option value="low">low</option>
+                      <option value="medium">medium</option>
+                      <option value="high">high</option>
+                    </select>
+                  </label>
+                  <label>Stale state
+                    <select id="operatorSessionRecallMemoryProposalStaleState" name="stale_state" required>
+                      <option value="current">current</option>
+                      <option value="review_required">review_required</option>
+                      <option value="expired">expired</option>
+                    </select>
+                  </label>
+                </div>
+                <label>Proposed summary <textarea id="operatorSessionRecallMemoryProposalSummary" name="proposed_summary" rows="2" required></textarea></label>
+                <label>Proposed content <textarea id="operatorSessionRecallMemoryProposalContent" name="proposed_content" rows="4" required></textarea></label>
+                <label>Classification reason <textarea id="operatorSessionRecallMemoryProposalClassificationReason" name="classification_reason" rows="2" required></textarea></label>
+                <label>Stale expires at <input id="operatorSessionRecallMemoryProposalExpiresAt" name="stale_expires_at" type="text" placeholder="YYYY-MM-DDTHH:MM:SSZ" required></label>
+                <label>Stale reason <textarea id="operatorSessionRecallMemoryProposalStaleReason" name="stale_reason" rows="2" required></textarea></label>
+                <div id="operatorSessionRecallMemoryProposalStatus" class="operator-session-recall-memory-proposal-status" aria-live="polite"></div>
+                <div class="operator-session-recall-memory-proposal-actions">
+                  <button type="button" class="operator-session-recall-action" onclick="cancelOperatorSessionRecallMemoryProposal()">Cancel</button>
+                  <button type="submit" class="operator-session-recall-action primary">Save local review proposal</button>
+                </div>
+              </form>
+            </div>
+            <div id="operatorSessionRecallList" class="operator-session-recall-list" aria-live="polite"></div>
+          </div>
+          <div id="operatorDocsArtifactsPopover" class="operator-docs-artifacts-popover" hidden aria-label="Manual docs and artifacts browser">
+            <div class="operator-docs-artifacts-header">
+              <div>
+                <div class="operator-docs-artifacts-title">Docs / Artifacts</div>
+                <div class="operator-docs-artifacts-subtitle" id="operatorDocsArtifactsStatus">Manual read-only browser — refresh to list allowlisted local sources</div>
+              </div>
+              <button type="button" class="operator-docs-artifacts-close" onclick="hideOperatorDocsArtifacts()" aria-label="Close docs and artifacts">×</button>
+            </div>
+            <div class="operator-docs-artifacts-controls" aria-label="Docs and artifacts filters">
+              <label class="operator-docs-artifacts-field">Search
+                <input id="operatorDocsArtifactsInput" class="operator-docs-artifacts-input" type="search" autocomplete="off" placeholder="Search docs or artifacts">
+              </label>
+              <label class="operator-docs-artifacts-field">Kind
+                <select id="operatorDocsArtifactsKind" class="operator-docs-artifacts-kind">
+                  <option value="all">All</option>
+                  <option value="meta_plan">Meta plan</option>
+                  <option value="plan">Plan</option>
+                  <option value="handoff">Handoff</option>
+                  <option value="brief">Brief</option>
+                  <option value="artifact_manifest">Artifact manifest</option>
+                  <option value="action_summary">Action summary</option>
+                  <option value="state_summary">State summary</option>
+                  <option value="changelog">Changelog</option>
+                </select>
+              </label>
+              <label class="operator-docs-artifacts-field">Root
+                <input id="operatorDocsArtifactsRoot" class="operator-docs-artifacts-root" type="text" autocomplete="off" placeholder="Optional root">
+              </label>
+              <button type="button" id="operatorDocsArtifactsRefresh" class="operator-docs-artifacts-action primary" onclick="refreshOperatorDocsArtifacts()">Refresh</button>
+            </div>
+            <div class="operator-docs-artifacts-body">
+              <div id="operatorDocsArtifactsList" class="operator-docs-artifacts-list" aria-live="polite"></div>
+              <div id="operatorDocsArtifactsPreview" class="operator-docs-artifacts-preview" aria-live="polite"></div>
+            </div>
+          </div>
+          <div id="operatorDeviceAdminPopover" class="operator-device-admin-popover" hidden aria-label="Device admin foundations">
+            <div class="operator-device-admin-header">
+              <div>
+                <div class="operator-device-admin-title">Device Admin Foundations</div>
+                <div class="operator-device-admin-subtitle" id="operatorDeviceAdminStatus">Manual foundations only — no execution</div>
+              </div>
+              <button type="button" class="operator-device-admin-close" onclick="hideOperatorDeviceAdmin()" aria-label="Close device admin">×</button>
+            </div>
+            <div class="operator-device-admin-controls" aria-label="Device admin filters">
+              <label class="operator-device-admin-field">Search
+                <input id="operatorDeviceAdminInput" class="operator-device-admin-input" type="search" autocomplete="off" placeholder="Search source-backed hosts, paths, or dry-runs">
+              </label>
+              <label class="operator-device-admin-field">Host
+                <select id="operatorDeviceAdminHost" class="operator-device-admin-host">
+                  <option value="all">All hosts</option>
+                </select>
+              </label>
+              <label class="operator-device-admin-field">Action
+                <select id="operatorDeviceAdminAction" class="operator-device-admin-action-select">
+                  <option value="all">All actions</option>
+                  <option value="copy">Copy preview</option>
+                  <option value="move">Move preview</option>
+                  <option value="delete">Delete preview</option>
+                  <option value="rename">Rename preview</option>
+                  <option value="mkdir">Mkdir preview</option>
+                  <option value="inventory">Inventory preview</option>
+                </select>
+              </label>
+              <button type="button" id="operatorDeviceAdminRefresh" class="operator-device-admin-action primary" onclick="refreshOperatorDeviceAdmin()">Refresh</button>
+            </div>
+            <div class="operator-device-admin-body">
+              <div id="operatorDeviceAdminList" class="operator-device-admin-list" aria-live="polite"></div>
+              <div id="operatorDeviceAdminPreview" class="operator-device-admin-preview" aria-live="polite"></div>
+            </div>
+          </div>
         </div>
         <div class="upload-bar-wrap" id="uploadBarWrap"><div class="upload-bar" id="uploadBar"></div></div>
       </div>
@@ -808,6 +1056,17 @@
           <button class="panel-head-btn has-tooltip has-tooltip--bottom kanban-nudge-dispatch-btn" id="btnKanbanPreviewDispatcher" onclick="nudgeKanbanDispatcher()" data-tooltip="Preview dispatcher (dry-run)" data-i18n-title="kanban_nudge_dispatcher" aria-label="Preview dispatcher (dry-run)">▶</button>
           <button class="panel-head-btn has-tooltip has-tooltip--bottom kanban-run-dispatch-btn" id="btnKanbanRunDispatcher" onclick="runKanbanDispatcher()" data-tooltip="Run dispatcher — claim Ready tasks" data-i18n-title="kanban_run_dispatcher" aria-label="Run dispatcher"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z"/></svg></button>
         </div>
+      </div>
+      <div id="operatorKanbanPanel" class="operator-kanban-panel state-unknown" role="region" aria-label="Hermes operator Kanban safety panel" aria-live="polite">
+        <div class="operator-kanban-header">
+          <div>
+            <div class="operator-kanban-title">Operator Kanban</div>
+            <div class="operator-kanban-subtitle" id="operatorKanbanSubtitle">Not checked yet</div>
+          </div>
+          <button id="operatorKanbanRefresh" class="operator-kanban-refresh" type="button" onclick="refreshOperatorKanban({force:true,reason:'manual'})">Refresh</button>
+        </div>
+        <div class="operator-kanban-copy">read-only / no dispatch · hermes-operator only</div>
+        <div id="operatorKanbanBody" class="operator-kanban-body"></div>
       </div>
       <div class="kanban-task-preview" id="kanbanTaskPreview" style="display:none"></div>
       <div class="kanban-board-wrap">
@@ -1410,6 +1669,14 @@
 <script src="static/messages.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/panels.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/onboarding.js?v=__WEBUI_VERSION__" defer></script>
+<script src="static/operator_truth.js?v=__WEBUI_VERSION__" defer></script>
+<script src="static/operator_proposals.js?v=__WEBUI_VERSION__" defer></script>
+<script src="static/operator_kanban.js?v=__WEBUI_VERSION__" defer></script>
+<script src="static/operator_commitments.js?v=__WEBUI_VERSION__" defer></script>
+<script src="static/operator_memory_skill_review.js?v=__WEBUI_VERSION__" defer></script>
+<script src="static/operator_session_recall.js?v=__WEBUI_VERSION__" defer></script>
+<script src="static/operator_docs_artifacts.js?v=__WEBUI_VERSION__" defer></script>
+<script src="static/operator_device_admin.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/boot.js?v=__WEBUI_VERSION__" defer></script>
 
 <!-- Kanban: create/rename board modal — used for both flows. -->

--- a/static/messages.js
+++ b/static/messages.js
@@ -630,6 +630,7 @@ function closeOtherLiveStreams(activeSid){
 
 function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!activeSid||!streamId) return;
+  if(typeof rememberSessionRunGraphRun==='function') rememberSessionRunGraphRun(activeSid, streamId);
   const reconnecting=!!options.reconnecting;
   if(!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[...uploaded],toolCalls:[]};
   else {

--- a/static/operator_commitments.js
+++ b/static/operator_commitments.js
@@ -1,0 +1,550 @@
+let _operatorCommitmentLastFetchKey = '';
+let _operatorCommitmentLastPayload = null;
+let _operatorCommitmentInFlight = null;
+let _operatorCommitmentInFlightKey = '';
+let _operatorCommitmentRequestSeq = 0;
+let _operatorCommitmentDraftSource = null;
+let _operatorCommitmentDraftEvidence = [];
+
+function _operatorCommitmentEl(id){
+  if (typeof $ === 'function') return $(id);
+  return document.getElementById(id);
+}
+
+function operatorCommitmentContextKey(){
+  const session = (typeof S !== 'undefined' && S && S.session) || {};
+  const truthKey = (typeof operatorTruthContextKey === 'function') ? operatorTruthContextKey() : '';
+  return JSON.stringify({
+    truth: truthKey,
+    session_id: (typeof operatorTruthSessionId === 'function') ? operatorTruthSessionId() : (session.session_id || session.id || ''),
+    ui_board: (typeof operatorTruthBoardHint === 'function') ? operatorTruthBoardHint() : '',
+    profile: (typeof S !== 'undefined' && S && S.activeProfile) || '',
+    workspace: session.workspace || '',
+  });
+}
+
+function _operatorCommitmentStateClass(state){
+  if (state === 'live') return 'state-live';
+  if (state === 'stale') return 'state-stale';
+  return 'state-unknown';
+}
+
+function _operatorCommitmentText(value, fallback){
+  const text = String(value == null ? '' : value).trim();
+  return text || fallback || '';
+}
+
+function _operatorCommitmentClear(el){
+  if (!el) return;
+  while (el.firstChild) el.removeChild(el.firstChild);
+}
+
+function _operatorCommitmentApplyChip(payload){
+  const chip = _operatorCommitmentEl('operatorCommitmentChip');
+  const label = _operatorCommitmentEl('operatorCommitmentLabel');
+  if (!chip) return;
+  const status = (payload && payload.status) || 'unknown';
+  chip.hidden = false;
+  chip.classList.remove('state-live','state-stale','state-unknown');
+  chip.classList.add(_operatorCommitmentStateClass(status));
+  const count = payload && Array.isArray(payload.commitments) ? payload.commitments.length : 0;
+  if (label) label.textContent = count ? 'Commitments ' + count : 'Commitments';
+  chip.title = (payload && payload.summary) || 'Local commitment cards';
+}
+
+function _operatorCommitmentItem(text, className){
+  const item = document.createElement('div');
+  item.className = className || 'operator-commitment-muted';
+  item.textContent = _operatorCommitmentText(text, 'unknown');
+  return item;
+}
+
+function _operatorCommitmentChip(text, state){
+  const chip = document.createElement('span');
+  chip.className = 'operator-commitment-required ' + _operatorCommitmentStateClass(state || 'unknown');
+  chip.textContent = text;
+  return chip;
+}
+
+function _operatorCommitmentRow(label, value){
+  const row = document.createElement('div');
+  row.className = 'operator-commitment-row';
+  const key = document.createElement('span');
+  key.className = 'operator-commitment-row-key';
+  key.textContent = label;
+  const val = document.createElement('span');
+  val.className = 'operator-commitment-row-value';
+  val.textContent = _operatorCommitmentText(value, 'unknown');
+  row.append(key, val);
+  return row;
+}
+
+function _operatorCommitmentSection(title){
+  const section = document.createElement('div');
+  section.className = 'operator-commitment-section';
+  const heading = document.createElement('div');
+  heading.className = 'operator-commitment-section-title';
+  heading.textContent = title;
+  section.append(heading);
+  return section;
+}
+
+function _operatorCommitmentCard(commitment){
+  const card = document.createElement('div');
+  card.className = 'operator-commitment-card';
+  card.dataset.commitmentId = commitment.id || '';
+
+  const top = document.createElement('div');
+  top.className = 'operator-commitment-card-top';
+  const title = document.createElement('div');
+  title.className = 'operator-commitment-card-title';
+  title.textContent = _operatorCommitmentText(commitment.title, commitment.id || 'Untitled commitment');
+  const noExec = document.createElement('span');
+  noExec.className = 'operator-commitment-no-exec';
+  noExec.textContent = 'would_execute:false';
+  top.append(title, noExec);
+  card.append(top);
+
+  const summary = document.createElement('div');
+  summary.className = 'operator-commitment-summary';
+  summary.textContent = _operatorCommitmentText(commitment.summary, 'No summary available.');
+  card.append(summary);
+
+  const dispatch_mechanism = commitment.dispatch_mechanism || {};
+  const source = commitment.source || {};
+  card.append(_operatorCommitmentRow('Owner', commitment.owner));
+  card.append(_operatorCommitmentRow('Deadline', commitment.deadline_at || commitment.review_at));
+  card.append(_operatorCommitmentRow('Dispatch', _operatorCommitmentText(dispatch_mechanism.kind, 'manual') + ' · local record only'));
+  card.append(_operatorCommitmentRow('Status', commitment.status));
+  card.append(_operatorCommitmentRow('Source', _operatorCommitmentText(source.kind, 'source') + ' · ' + _operatorCommitmentText(source.proposal_id || source.session_id, 'unknown')));
+
+  const acceptance_criteria = Array.isArray(commitment.acceptance_criteria) ? commitment.acceptance_criteria : [];
+  const acceptance = _operatorCommitmentSection('Acceptance criteria');
+  if (!acceptance_criteria.length) acceptance.append(_operatorCommitmentItem('Acceptance criteria missing', 'operator-commitment-missing'));
+  acceptance_criteria.slice(0, 6).forEach(item => acceptance.append(_operatorCommitmentItem(item, 'operator-commitment-muted')));
+  card.append(acceptance);
+
+  const halt = _operatorCommitmentSection('Halt policy');
+  halt.append(_operatorCommitmentItem(commitment.halt_policy, 'operator-commitment-muted'));
+  card.append(halt);
+
+  const evidence = Array.isArray(commitment.evidence) ? commitment.evidence : [];
+  const receipts = _operatorCommitmentSection('Evidence');
+  if (!evidence.length) receipts.append(_operatorCommitmentItem('Evidence missing', 'operator-commitment-missing'));
+  evidence.slice(0, 5).forEach(item => {
+    const label = _operatorCommitmentText(item.label || item.source_id || item.kind, 'evidence');
+    const state = _operatorCommitmentText(item.state || item.status, 'unknown');
+    receipts.append(_operatorCommitmentItem(label + ' · ' + state, 'operator-commitment-muted'));
+  });
+  card.append(receipts);
+  return card;
+}
+
+function _operatorCommitmentRenderIssues(list, payload){
+  const issues = Array.isArray(payload && payload.issues) ? payload.issues : [];
+  issues.slice(0, 6).forEach(issue => list.append(_operatorCommitmentItem(issue, 'operator-commitment-missing')));
+  const notes = Array.isArray(payload && payload.notes) ? payload.notes : [];
+  notes.slice(0, 4).forEach(note => {
+    const missing = Array.isArray(note.missing) ? note.missing.join(', ') : 'required fields';
+    list.append(_operatorCommitmentItem('Note: ' + _operatorCommitmentText(note.reason, 'incomplete') + ' · ' + missing, 'operator-commitment-missing'));
+  });
+}
+
+function renderOperatorCommitments(payload){
+  _operatorCommitmentLastPayload = payload || null;
+  _operatorCommitmentApplyChip(payload);
+  const popover = _operatorCommitmentEl('operatorCommitmentPopover');
+  const subtitle = _operatorCommitmentEl('operatorCommitmentSubtitle');
+  const list = _operatorCommitmentEl('operatorCommitmentList');
+  if (!popover || !list) return;
+  _operatorCommitmentClear(list);
+
+  const status = (payload && payload.status) || 'unknown';
+  popover.classList.remove('state-live','state-stale','state-unknown');
+  popover.classList.add(_operatorCommitmentStateClass(status));
+  if (subtitle) subtitle.textContent = (payload && payload.summary) || 'Not checked yet';
+
+  const top = document.createElement('div');
+  top.className = 'operator-commitment-source-row';
+  top.append(
+    _operatorCommitmentChip('local state', status),
+    _operatorCommitmentChip('would_execute:false', 'live')
+  );
+  list.append(top);
+
+  const commitments = Array.isArray(payload && payload.commitments) ? payload.commitments : [];
+  if (!commitments.length) {
+    const empty = document.createElement('div');
+    empty.className = 'operator-commitment-empty';
+    empty.textContent = status === 'unknown' ? 'No commitment cards — local source unavailable.' : 'No commitments yet. Promote a proposal to create one.';
+    list.append(empty);
+    _operatorCommitmentRenderIssues(list, payload || {});
+    return;
+  }
+
+  commitments.forEach(commitment => list.append(_operatorCommitmentCard(commitment)));
+  _operatorCommitmentRenderIssues(list, payload || {});
+}
+
+function hideOperatorCommitments(){
+  const popover = _operatorCommitmentEl('operatorCommitmentPopover');
+  if (popover) popover.hidden = true;
+}
+
+function toggleOperatorCommitments(opts = {}){
+  const popover = _operatorCommitmentEl('operatorCommitmentPopover');
+  if (!popover) return;
+  const opening = popover.hidden;
+  if (!opening && !opts.force) {
+    hideOperatorCommitments();
+    return;
+  }
+  popover.hidden = false;
+  refreshOperatorCommitments({force: Boolean(opts.force)});
+}
+
+async function refreshOperatorCommitments(opts = {}){
+  const force = Boolean(opts.force);
+  const contextKey = operatorCommitmentContextKey();
+  if (!force && _operatorCommitmentInFlight && contextKey === _operatorCommitmentInFlightKey) return _operatorCommitmentInFlight;
+  if (!force && _operatorCommitmentLastPayload && contextKey === _operatorCommitmentLastFetchKey) {
+    renderOperatorCommitments(_operatorCommitmentLastPayload);
+    return _operatorCommitmentLastPayload;
+  }
+  if (typeof api !== 'function') {
+    const payload = {status:'unknown', summary:'Commitments unavailable — API helper missing', commitments:[], notes:[], issues:['api helper unavailable']};
+    renderOperatorCommitments(payload);
+    return payload;
+  }
+
+  const params = new URLSearchParams();
+  const session = (typeof S !== 'undefined' && S && S.session) || {};
+  const sid = (typeof operatorTruthSessionId === 'function') ? operatorTruthSessionId() : (session.session_id || session.id || '');
+  const board = (typeof operatorTruthBoardHint === 'function') ? operatorTruthBoardHint() : '';
+  if (sid) params.set('session_id', sid);
+  if (board) params.set('ui_board', board);
+  const base = '/api/operator/commitments';
+  const path = base + (params.toString() ? '?' + params.toString() : '');
+  const requestKey = contextKey;
+  const requestSeq = ++_operatorCommitmentRequestSeq;
+  _operatorCommitmentInFlightKey = requestKey;
+
+  _operatorCommitmentInFlight = api(path)
+    .then(payload => {
+      if (requestKey !== operatorCommitmentContextKey() || requestSeq !== _operatorCommitmentRequestSeq) return payload;
+      _operatorCommitmentLastFetchKey = requestKey;
+      renderOperatorCommitments(payload);
+      return payload;
+    })
+    .catch(err => {
+      if (requestKey === operatorCommitmentContextKey() && requestSeq === _operatorCommitmentRequestSeq) {
+        const payload = {status:'unknown', summary:'Commitments unavailable — source read failed', commitments:[], notes:[], issues:[(err && err.message) || 'request failed']};
+        _operatorCommitmentLastFetchKey = requestKey;
+        renderOperatorCommitments(payload);
+      }
+      return null;
+    })
+    .finally(() => {
+      if (requestKey === _operatorCommitmentInFlightKey && requestSeq === _operatorCommitmentRequestSeq) {
+        _operatorCommitmentInFlight = null;
+        _operatorCommitmentInFlightKey = '';
+      }
+    });
+  return _operatorCommitmentInFlight;
+}
+
+function _operatorCommitmentSetValue(id, value){
+  const el = _operatorCommitmentEl(id);
+  if (el) el.value = value == null ? '' : String(value);
+}
+
+function _operatorCommitmentGetValue(id){
+  const el = _operatorCommitmentEl(id);
+  return el ? String(el.value || '').trim() : '';
+}
+
+function _operatorCommitmentSafeJson(value, fallback){
+  try {
+    return JSON.parse(value || '');
+  } catch(_) {
+    return fallback;
+  }
+}
+
+function _operatorCommitmentLines(value){
+  return String(value || '').split('\n').map(line => line.trim().replace(/^[-*]\s*/, '')).filter(Boolean);
+}
+
+function _operatorCommitmentValidMessageIndex(value){
+  if (typeof value === 'number') return Number.isInteger(value) && value >= 0;
+  if (typeof value === 'string') {
+    const text = value.trim();
+    if (!/^\d+$/.test(text)) return false;
+    const numeric = Number(text);
+    return Number.isSafeInteger(numeric) && numeric >= 0;
+  }
+  return false;
+}
+
+function _operatorCommitmentValidContentHash(value){
+  return /^sha256:[0-9a-f]{64}$/i.test(_operatorCommitmentText(value, ''));
+}
+
+function _operatorCommitmentSecretValueRedacted(value){
+  const token = _operatorCommitmentText(value, '').replace(/^["']|["']$/g, '').trim();
+  const normalized = token.replace(/^[\[\](){}<>]+|[\[\](){}<>]+$/g, '').toLowerCase();
+  if (['redacted','masked','hidden','removed','withheld','scrubbed'].includes(normalized)) return true;
+  const compact = token.replace(/\s/g, '');
+  return Boolean(compact) && /^[*xX•…]+$/.test(compact);
+}
+
+function _operatorCommitmentQuoteContainsRawSecret(quote){
+  const text = _operatorCommitmentText(quote, '');
+  const keyedSecret = /\b(?:password|passwd|pwd|token|access[_\-\s]?token|refresh[_\-\s]?token|auth[_\-\s]?token|api[_\-\s]?key|apikey|secret|client[_\-\s]?secret|private[_\-\s]?key|authorization)\b\s*[:=]\s*(["']?[^"'\s,;]+["']?)/ig;
+  let match;
+  while ((match = keyedSecret.exec(text)) !== null) {
+    if (!_operatorCommitmentSecretValueRedacted(match[1])) return true;
+  }
+  return (
+    /\bBearer\s+[A-Za-z0-9._~+/=-]{16,}(?=$|[\s,;])/i.test(text) ||
+    /\bsk-[A-Za-z0-9][A-Za-z0-9_-]{16,}(?=$|[\s,;])/i.test(text) ||
+    /\bxox[abp]-[0-9A-Za-z-]{10,}(?=$|[\s,;])/i.test(text) ||
+    /\bghp_[A-Za-z0-9_]{16,}(?![A-Za-z0-9_])/i.test(text) ||
+    /\bgithub_pat_[A-Za-z0-9_]{16,}(?![A-Za-z0-9_])/i.test(text)
+  );
+}
+
+function _operatorCommitmentSessionMessageProofMissing(source){
+  const missing = [];
+  if (!source || source.kind !== 'session_message') return missing;
+  if (!_operatorCommitmentText(source.session_id, '')) missing.push('session_id');
+  if (source.message_index == null || String(source.message_index).trim() === '' || !_operatorCommitmentValidMessageIndex(source.message_index)) missing.push('message_index');
+  if (!_operatorCommitmentText(source.content_hash, '') || !_operatorCommitmentValidContentHash(source.content_hash)) missing.push('content_hash');
+  const quote = _operatorCommitmentText(source.quote, '');
+  if (!quote) missing.push('quote');
+  else if (_operatorCommitmentQuoteContainsRawSecret(quote)) missing.push('quote raw secret');
+  return missing;
+}
+
+function _operatorCommitmentSourceProofMessage(missingFields){
+  const fields = Array.isArray(missingFields) && missingFields.length ? missingFields.join(', ') : 'session_id, message_index, content_hash, quote';
+  return 'Missing or invalid source proof fields for session_message: ' + fields;
+}
+
+function _operatorCommitmentRejectMissingSourceProof(form, missingFields){
+  const missingEl = _operatorCommitmentEl('operatorCommitmentMissing');
+  if (missingEl) missingEl.textContent = _operatorCommitmentSourceProofMessage(missingFields);
+  if (form) form.hidden = true;
+  return false;
+}
+
+function _operatorCommitmentValidateForm(){
+  const missing = [];
+  const owner = _operatorCommitmentGetValue('operatorCommitmentOwner');
+  const deadline_at = _operatorCommitmentGetValue('operatorCommitmentDeadline');
+  const review_at = _operatorCommitmentGetValue('operatorCommitmentReview');
+  const dispatchKind = _operatorCommitmentGetValue('operatorCommitmentDispatch') || 'manual';
+  const source = _operatorCommitmentSafeJson(_operatorCommitmentGetValue('operatorCommitmentSource'), null);
+  const acceptance_criteria = _operatorCommitmentLines(_operatorCommitmentGetValue('operatorCommitmentAcceptance'));
+  const halt_policy = _operatorCommitmentGetValue('operatorCommitmentHaltPolicy');
+  const evidence = _operatorCommitmentSafeJson(_operatorCommitmentGetValue('operatorCommitmentEvidence'), []);
+  const status = _operatorCommitmentGetValue('operatorCommitmentStatus') || 'active';
+
+  if (!owner) missing.push('owner');
+  if (!deadline_at && !review_at) missing.push('deadline_at');
+  if (!dispatchKind) missing.push('dispatch_mechanism');
+  if (!source || !source.kind) missing.push('source');
+  if (source && source.kind === 'session_message') {
+    const proofMissing = _operatorCommitmentSessionMessageProofMissing(source);
+    if (proofMissing.length) missing.push('source proof fields: ' + proofMissing.join(', '));
+  }
+  if (!acceptance_criteria.length) missing.push('acceptance_criteria');
+  if (!halt_policy) missing.push('halt_policy');
+  if (!Array.isArray(evidence) || !evidence.length) missing.push('evidence');
+  if (!status) missing.push('status');
+
+  const missingEl = _operatorCommitmentEl('operatorCommitmentMissing');
+  if (missing.length) {
+    if (missingEl) missingEl.textContent = 'Missing required fields: ' + missing.join(', ');
+    return null;
+  }
+  if (missingEl) missingEl.textContent = '';
+
+  return {
+    title: _operatorCommitmentGetValue('operatorCommitmentTitle'),
+    owner,
+    deadline_at,
+    review_at,
+    dispatch_mechanism: {kind: dispatchKind, label: dispatchKind + ' local follow-up', would_execute: false},
+    source,
+    acceptance_criteria,
+    halt_policy,
+    evidence,
+    status,
+  };
+}
+
+function _operatorCommitmentEvidenceFromProposal(proposal){
+  const evidence = [];
+  if (proposal && Array.isArray(proposal.evidence)) {
+    proposal.evidence.slice(0, 8).forEach(item => {
+      if (!item) return;
+      evidence.push({
+        kind: _operatorCommitmentText(item.kind, 'proposal_evidence'),
+        label: _operatorCommitmentText(item.label || item.source_id || item.api || item.path, 'Operator proposal evidence'),
+        state: _operatorCommitmentText(item.state || item.status, 'unknown'),
+        source_id: item.source_id || undefined,
+        path: item.path || undefined,
+        api: item.api || undefined,
+      });
+    });
+  }
+  evidence.unshift({kind:'source', label:'Operator proposal', state:'present'});
+  return evidence;
+}
+
+function openOperatorCommitmentPromote(proposal){
+  const form = _operatorCommitmentEl('operatorCommitmentForm');
+  const popover = _operatorCommitmentEl('operatorCommitmentPopover');
+  if (!form || !popover || !proposal) return;
+  const session = (typeof S !== 'undefined' && S && S.session) || {};
+  _operatorCommitmentDraftSource = {
+    kind: 'operator_proposal',
+    proposal_id: proposal.id || '',
+    session_id: (typeof operatorTruthSessionId === 'function') ? operatorTruthSessionId() : (session.session_id || session.id || ''),
+    ui_board: (typeof operatorTruthBoardHint === 'function') ? operatorTruthBoardHint() : '',
+  };
+  _operatorCommitmentDraftEvidence = _operatorCommitmentEvidenceFromProposal(proposal);
+
+  _operatorCommitmentSetValue('operatorCommitmentSource', JSON.stringify(_operatorCommitmentDraftSource));
+  _operatorCommitmentSetValue('operatorCommitmentEvidence', JSON.stringify(_operatorCommitmentDraftEvidence));
+  _operatorCommitmentSetValue('operatorCommitmentTitle', _operatorCommitmentText(proposal.title, proposal.id || 'Operator proposal'));
+  _operatorCommitmentSetValue('operatorCommitmentOwner', _operatorCommitmentText(proposal.owner, ''));
+  _operatorCommitmentSetValue('operatorCommitmentDeadline', '');
+  _operatorCommitmentSetValue('operatorCommitmentReview', '');
+  _operatorCommitmentSetValue('operatorCommitmentDispatch', 'manual');
+  _operatorCommitmentSetValue('operatorCommitmentAcceptance', Array.isArray(proposal.acceptance_criteria) ? proposal.acceptance_criteria.join('\n') : '');
+  _operatorCommitmentSetValue('operatorCommitmentHaltPolicy', 'Stop if source evidence is stale or missing.');
+  _operatorCommitmentSetValue('operatorCommitmentStatus', 'active');
+  const missingEl = _operatorCommitmentEl('operatorCommitmentMissing');
+  if (missingEl) missingEl.textContent = 'Fill owner/deadline/criteria, then save locally. No execution is attached.';
+  form.hidden = false;
+  popover.hidden = false;
+  refreshOperatorCommitments({force:false});
+}
+
+function openOperatorCommitmentPromoteFromRecall(result){
+  const form = _operatorCommitmentEl('operatorCommitmentForm');
+  const popover = _operatorCommitmentEl('operatorCommitmentPopover');
+  if (!form || !popover || !result) return;
+  const session = result.session || {};
+  const promotion = result.promotion || {};
+  const task = promotion.task || {};
+  const sourceHint = (task.source && typeof task.source === 'object') ? task.source : {};
+  const sourceKind = _operatorCommitmentText(sourceHint.kind, '');
+  if (sourceKind !== 'session_message') {
+    _operatorCommitmentRejectMissingSourceProof(form, ['kind', 'session_id', 'message_index', 'content_hash', 'quote']);
+    return false;
+  }
+  const source = {
+    kind:'session_message',
+    session_id: _operatorCommitmentText(sourceHint.session_id, ''),
+    message_index: sourceHint.message_index == null ? '' : sourceHint.message_index,
+    content_hash: _operatorCommitmentText(sourceHint.content_hash, ''),
+    quote: _operatorCommitmentText(sourceHint.quote, ''),
+  };
+  const proofMissing = _operatorCommitmentSessionMessageProofMissing(source);
+  if (proofMissing.length) {
+    _operatorCommitmentRejectMissingSourceProof(form, proofMissing);
+    return false;
+  }
+  const recency = result.recency || {};
+  const recencyState = _operatorCommitmentText(recency.label || result.recency_label, 'unknown').toLowerCase();
+  _operatorCommitmentDraftSource = source;
+  _operatorCommitmentDraftEvidence = [{
+    kind: 'source',
+    label: 'Session recall result',
+    state: recencyState === 'live' ? 'present' : recencyState,
+    session_id: source.session_id,
+    message_index: source.message_index,
+    source_id: result.id || source.content_hash || source.session_id,
+  }];
+
+  const sessionTitle = _operatorCommitmentText(session.title || result.title, 'Session recall');
+  const quoteTitle = _operatorCommitmentText(source.quote, '').slice(0, 90);
+  const title = (sessionTitle + (quoteTitle ? ': ' + quoteTitle : '')).slice(0, 200);
+  _operatorCommitmentSetValue('operatorCommitmentSource', JSON.stringify(_operatorCommitmentDraftSource));
+  _operatorCommitmentSetValue('operatorCommitmentEvidence', JSON.stringify(_operatorCommitmentDraftEvidence));
+  _operatorCommitmentSetValue('operatorCommitmentTitle', title);
+  _operatorCommitmentSetValue('operatorCommitmentOwner', '');
+  _operatorCommitmentSetValue('operatorCommitmentDeadline', '');
+  _operatorCommitmentSetValue('operatorCommitmentReview', '');
+  _operatorCommitmentSetValue('operatorCommitmentDispatch', 'manual');
+  _operatorCommitmentSetValue('operatorCommitmentAcceptance', '');
+  _operatorCommitmentSetValue('operatorCommitmentHaltPolicy', 'Stop if source evidence is stale or missing.');
+  _operatorCommitmentSetValue('operatorCommitmentStatus', 'active');
+  const missingEl = _operatorCommitmentEl('operatorCommitmentMissing');
+  if (missingEl) missingEl.textContent = 'Fill owner, deadline or review date, and acceptance criteria, then save locally. No execution is attached.';
+  form.hidden = false;
+  popover.hidden = false;
+}
+
+function cancelOperatorCommitmentDraft(){
+  const form = _operatorCommitmentEl('operatorCommitmentForm');
+  if (form) form.hidden = true;
+  _operatorCommitmentDraftSource = null;
+  _operatorCommitmentDraftEvidence = [];
+  const missingEl = _operatorCommitmentEl('operatorCommitmentMissing');
+  if (missingEl) missingEl.textContent = '';
+}
+
+async function submitOperatorCommitmentForm(event){
+  if (event && typeof event.preventDefault === 'function') event.preventDefault();
+  const payload = _operatorCommitmentValidateForm();
+  if (!payload) return null;
+  if (typeof api !== 'function') {
+    const missingEl = _operatorCommitmentEl('operatorCommitmentMissing');
+    if (missingEl) missingEl.textContent = 'Cannot save: API helper unavailable.';
+    return null;
+  }
+  try {
+    const result = await api('/api/operator/commitments/promote',{method:'POST',body:JSON.stringify(payload)});
+    if (!result || result.ok !== true) {
+      const missingEl = _operatorCommitmentEl('operatorCommitmentMissing');
+      const missing = result && Array.isArray(result.missing) ? result.missing.join(', ') : 'validation failed';
+      if (missingEl) missingEl.textContent = 'Not saved: ' + missing;
+      return result || null;
+    }
+    cancelOperatorCommitmentDraft();
+    _operatorCommitmentLastFetchKey = '';
+    await refreshOperatorCommitments({force:true});
+    if (typeof showToast === 'function') showToast('Saved local commitment card.', 2400);
+    return result;
+  } catch(err) {
+    const missingEl = _operatorCommitmentEl('operatorCommitmentMissing');
+    if (missingEl) missingEl.textContent = 'Not saved: ' + ((err && err.message) || 'request failed');
+    return null;
+  }
+}
+
+function initOperatorCommitments(){
+  const chip = _operatorCommitmentEl('operatorCommitmentChip');
+  const label = _operatorCommitmentEl('operatorCommitmentLabel');
+  if (chip) {
+    chip.hidden = false;
+    chip.title = 'Local commitment cards · not checked yet';
+  }
+  if (label) label.textContent = 'Commitments';
+}
+
+window.toggleOperatorCommitments = toggleOperatorCommitments;
+window.refreshOperatorCommitments = refreshOperatorCommitments;
+window.renderOperatorCommitments = renderOperatorCommitments;
+window.hideOperatorCommitments = hideOperatorCommitments;
+window.openOperatorCommitmentPromote = openOperatorCommitmentPromote;
+window.openOperatorCommitmentPromoteFromRecall = openOperatorCommitmentPromoteFromRecall;
+window.cancelOperatorCommitmentDraft = cancelOperatorCommitmentDraft;
+window.submitOperatorCommitmentForm = submitOperatorCommitmentForm;
+window.operatorCommitmentContextKey = operatorCommitmentContextKey;
+
+initOperatorCommitments();

--- a/static/operator_device_admin.js
+++ b/static/operator_device_admin.js
@@ -1,0 +1,476 @@
+'use strict';
+
+const OPERATOR_DEVICE_ADMIN_LIST_ENDPOINT = '/api/operator/device-admin';
+const OPERATOR_DEVICE_ADMIN_PREVIEW_ENDPOINT = '/api/operator/device-admin/preview';
+
+let _operatorDeviceAdminLastPayload = null;
+let _operatorDeviceAdminHasLoadedPayload = false;
+let _operatorDeviceAdminRequestSeq = 0;
+let _operatorDeviceAdminPreviewSeq = 0;
+
+function _operatorDeviceAdminEl(id){
+  if (typeof $ === 'function') return $(id);
+  if (typeof document === 'undefined') return null;
+  return document.getElementById(id);
+}
+
+function _operatorDeviceAdminText(value, fallback){
+  const text = String(value == null ? '' : value).trim();
+  return text || fallback || '';
+}
+
+function _operatorDeviceAdminArray(value){
+  return Array.isArray(value) ? value : [];
+}
+
+function _operatorDeviceAdminObject(value){
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function _operatorDeviceAdminClear(el){
+  if (!el) return;
+  while (el.firstChild) el.removeChild(el.firstChild);
+}
+
+function _operatorDeviceAdminCreate(tagName, className, text){
+  if (typeof document === 'undefined') return null;
+  const node = document.createElement(tagName);
+  if (className) node.className = className;
+  if (text != null) node.textContent = String(text);
+  return node;
+}
+
+function _operatorDeviceAdminAppend(parent, node){
+  if (parent && node) parent.appendChild(node);
+  return node;
+}
+
+function _operatorDeviceAdminAppendText(parent, className, text){
+  return _operatorDeviceAdminAppend(parent, _operatorDeviceAdminCreate('div', className, text));
+}
+
+function _operatorDeviceAdminAppendMeta(parent, label, value, className){
+  const rowClass = className ? 'operator-device-admin-source ' + className : 'operator-device-admin-source';
+  const display = _operatorDeviceAdminText(value, 'unknown');
+  return _operatorDeviceAdminAppendText(parent, rowClass, label + ': ' + display);
+}
+
+function _operatorDeviceAdminDefaultPayload(){
+  return {
+    status: 'unknown',
+    execution_state: 'blocked',
+    summary: 'Manual device admin foundations only. No device action was executed.',
+    query: {text: '', host: 'all', action: 'all', limit: 50},
+    sources: [],
+    approval_model: {required: true, per_action: true, execution_enabled: false, required_fields: []},
+    hosts: [],
+    paths: [],
+    dry_runs: [],
+    receipts: [],
+    issues: [],
+    would_execute: false,
+  };
+}
+
+function _operatorDeviceAdminLoadingPayload(){
+  return {
+    status: 'unknown',
+    execution_state: 'blocked',
+    summary: 'Loading source-backed device admin foundations. No device action was executed.',
+    query: _operatorDeviceAdminCurrentQuery(),
+    sources: [],
+    approval_model: {required: true, per_action: true, execution_enabled: false, required_fields: []},
+    hosts: [],
+    paths: [],
+    dry_runs: [],
+    receipts: [],
+    issues: [],
+    would_execute: false,
+  };
+}
+
+function _operatorDeviceAdminErrorPayload(error){
+  return {
+    status: 'unknown',
+    execution_state: 'blocked',
+    summary: 'Device admin foundations request failed. No device action was executed.',
+    query: _operatorDeviceAdminCurrentQuery(),
+    sources: [],
+    approval_model: {required: true, per_action: true, execution_enabled: false, required_fields: []},
+    hosts: [],
+    paths: [],
+    dry_runs: [],
+    receipts: [],
+    issues: [_operatorDeviceAdminText(error && error.message, 'request failed')],
+    would_execute: false,
+  };
+}
+
+function _operatorDeviceAdminKnownStatus(value){
+  const status = _operatorDeviceAdminText(value, 'unknown').toLowerCase();
+  if (status === 'live') return 'live';
+  if (status === 'stale') return 'stale';
+  if (status === 'blocked') return 'blocked';
+  return 'unknown';
+}
+
+function _operatorDeviceAdminStateClass(value){
+  const state = _operatorDeviceAdminText(value, 'unknown').toLowerCase();
+  if (state === 'blocked' || state === 'disabled' || state === 'stale' || state === 'draft') return 'operator-device-admin-blocked';
+  return 'operator-device-admin-unknown';
+}
+
+function _operatorDeviceAdminBoolText(value){
+  if (value === true) return 'true';
+  if (value === false) return 'false';
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true') return 'true';
+    if (normalized === 'false') return 'false';
+  }
+  return 'unknown';
+}
+
+function _operatorDeviceAdminCurrentQuery(){
+  const input = _operatorDeviceAdminEl('operatorDeviceAdminInput');
+  const host = _operatorDeviceAdminEl('operatorDeviceAdminHost');
+  const action = _operatorDeviceAdminEl('operatorDeviceAdminAction');
+  return {
+    text: _operatorDeviceAdminText(input && input.value, ''),
+    host: _operatorDeviceAdminText(host && host.value, 'all'),
+    action: _operatorDeviceAdminText(action && action.value, 'all'),
+    limit: 50,
+  };
+}
+
+function _operatorDeviceAdminQueryString(){
+  const query = _operatorDeviceAdminCurrentQuery();
+  const params = new URLSearchParams();
+  params.set('query', query.text);
+  params.set('host', query.host || 'all');
+  params.set('action', query.action || 'all');
+  params.set('limit', String(query.limit || 50));
+  const encoded = params.toString();
+  return encoded ? '?' + encoded : '';
+}
+
+function _operatorDeviceAdminSetChipState(state, count){
+  const chip = _operatorDeviceAdminEl('operatorDeviceAdminChip');
+  const label = _operatorDeviceAdminEl('operatorDeviceAdminLabel');
+  const normalized = _operatorDeviceAdminKnownStatus(state);
+  if (label) {
+    const suffix = Number.isFinite(Number(count)) && Number(count) > 0 ? ' ' + Number(count) : '';
+    label.textContent = normalized === 'live' ? 'Device Admin' + suffix : 'Device Admin';
+  }
+  if (!chip) return;
+  chip.hidden = false;
+  chip.title = 'Device admin foundations · ' + normalized + ' · execution blocked';
+  if (chip.classList) {
+    chip.classList.remove('state-live', 'state-stale', 'state-unknown');
+    chip.classList.add(normalized === 'live' ? 'state-live' : normalized === 'stale' ? 'state-stale' : 'state-unknown');
+  }
+}
+
+function _operatorDeviceAdminPopulateHostFilter(hosts){
+  const select = _operatorDeviceAdminEl('operatorDeviceAdminHost');
+  if (!select) return;
+  const current = _operatorDeviceAdminText(select.value, 'all');
+  _operatorDeviceAdminClear(select);
+  const allOption = _operatorDeviceAdminCreate('option', '', 'All hosts');
+  if (allOption) allOption.value = 'all';
+  _operatorDeviceAdminAppend(select, allOption);
+  _operatorDeviceAdminArray(hosts).forEach(hostValue => {
+    const host = _operatorDeviceAdminObject(hostValue);
+    const id = _operatorDeviceAdminText(host.id, '');
+    if (!id || id === 'unknown') return;
+    const option = _operatorDeviceAdminCreate('option', '', _operatorDeviceAdminText(host.label, id));
+    if (!option) return;
+    option.value = id;
+    _operatorDeviceAdminAppend(select, option);
+  });
+  const hasCurrent = Array.from(select.options || []).some(option => option.value === current);
+  select.value = hasCurrent ? current : 'all';
+}
+
+function _operatorDeviceAdminRenderIssues(parent, title, issues){
+  const values = _operatorDeviceAdminArray(issues).map(issue => _operatorDeviceAdminText(issue, '')).filter(Boolean);
+  const card = _operatorDeviceAdminCreate('div', 'operator-device-admin-card', null);
+  if (!card) return null;
+  _operatorDeviceAdminAppendText(card, 'operator-device-admin-source', title + ': ' + (values.length ? String(values.length) : 'none'));
+  values.forEach(issue => _operatorDeviceAdminAppendText(card, 'operator-device-admin-source operator-device-admin-blocked', '- ' + issue));
+  return _operatorDeviceAdminAppend(parent, card);
+}
+
+function _operatorDeviceAdminRenderSources(parent, sources){
+  const values = _operatorDeviceAdminArray(sources);
+  const section = _operatorDeviceAdminCreate('div', 'operator-device-admin-card', null);
+  if (!section) return null;
+  _operatorDeviceAdminAppendText(section, 'operator-device-admin-source', 'sources: ' + (values.length ? String(values.length) : 'none'));
+  if (!values.length) {
+    _operatorDeviceAdminAppendText(section, 'operator-device-admin-empty', 'No allowlist or receipt sources were returned.');
+    return _operatorDeviceAdminAppend(parent, section);
+  }
+  values.forEach(sourceValue => {
+    const source = _operatorDeviceAdminObject(sourceValue);
+    const sourceCard = _operatorDeviceAdminCreate('div', 'operator-device-admin-card ' + _operatorDeviceAdminStateClass(source.state), null);
+    if (!sourceCard) return;
+    _operatorDeviceAdminAppendMeta(sourceCard, 'source id', source.id);
+    _operatorDeviceAdminAppendMeta(sourceCard, 'display_path', source.display_path);
+    _operatorDeviceAdminAppendMeta(sourceCard, 'state', source.state);
+    _operatorDeviceAdminAppendMeta(sourceCard, 'issue', source.issue);
+    _operatorDeviceAdminAppend(section, sourceCard);
+  });
+  return _operatorDeviceAdminAppend(parent, section);
+}
+
+function _operatorDeviceAdminRenderApprovalModel(parent, approvalModel){
+  const model = _operatorDeviceAdminObject(approvalModel);
+  const card = _operatorDeviceAdminCreate('div', 'operator-device-admin-card operator-device-admin-blocked', null);
+  if (!card) return null;
+  _operatorDeviceAdminAppendText(card, 'operator-device-admin-source', 'approval_model');
+  _operatorDeviceAdminAppendMeta(card, 'required', _operatorDeviceAdminBoolText(model.required));
+  _operatorDeviceAdminAppendMeta(card, 'per_action', _operatorDeviceAdminBoolText(model.per_action));
+  _operatorDeviceAdminAppendMeta(card, 'execution_enabled', _operatorDeviceAdminBoolText(model.execution_enabled));
+  _operatorDeviceAdminAppendMeta(card, 'required_fields', _operatorDeviceAdminArray(model.required_fields).join(', ') || 'unknown');
+  return _operatorDeviceAdminAppend(parent, card);
+}
+
+function _operatorDeviceAdminRenderHosts(parent, hosts){
+  const values = _operatorDeviceAdminArray(hosts);
+  const section = _operatorDeviceAdminCreate('div', 'operator-device-admin-card', null);
+  if (!section) return null;
+  _operatorDeviceAdminAppendText(section, 'operator-device-admin-source', 'hosts: ' + (values.length ? String(values.length) : 'none'));
+  if (!values.length) {
+    _operatorDeviceAdminAppendText(section, 'operator-device-admin-empty', 'No source-backed hosts are available.');
+    return _operatorDeviceAdminAppend(parent, section);
+  }
+  values.forEach(hostValue => {
+    const host = _operatorDeviceAdminObject(hostValue);
+    const card = _operatorDeviceAdminCreate('div', 'operator-device-admin-card ' + _operatorDeviceAdminStateClass(host.state), null);
+    if (!card) return;
+    _operatorDeviceAdminAppendMeta(card, 'host_id', host.id);
+    _operatorDeviceAdminAppendMeta(card, 'label', host.label);
+    _operatorDeviceAdminAppendMeta(card, 'kind', host.kind);
+    _operatorDeviceAdminAppendMeta(card, 'state', host.state);
+    _operatorDeviceAdminAppend(section, card);
+  });
+  return _operatorDeviceAdminAppend(parent, section);
+}
+
+function _operatorDeviceAdminRenderPaths(parent, paths){
+  const values = _operatorDeviceAdminArray(paths);
+  const section = _operatorDeviceAdminCreate('div', 'operator-device-admin-card', null);
+  if (!section) return null;
+  _operatorDeviceAdminAppendText(section, 'operator-device-admin-source', 'paths: ' + (values.length ? String(values.length) : 'none'));
+  if (!values.length) {
+    _operatorDeviceAdminAppendText(section, 'operator-device-admin-empty', 'No source-backed paths are available.');
+    return _operatorDeviceAdminAppend(parent, section);
+  }
+  values.forEach(pathValue => {
+    const item = _operatorDeviceAdminObject(pathValue);
+    const card = _operatorDeviceAdminCreate('div', 'operator-device-admin-card ' + _operatorDeviceAdminStateClass(item.state), null);
+    if (!card) return;
+    _operatorDeviceAdminAppendMeta(card, 'path_id', item.id);
+    _operatorDeviceAdminAppendMeta(card, 'host_id', item.host_id);
+    _operatorDeviceAdminAppendMeta(card, 'label', item.label);
+    _operatorDeviceAdminAppendMeta(card, 'display_path', item.display_path);
+    _operatorDeviceAdminAppendMeta(card, 'capabilities', _operatorDeviceAdminArray(item.capabilities).join(', ') || 'unknown');
+    _operatorDeviceAdminAppendMeta(card, 'state', item.state);
+    _operatorDeviceAdminAppend(section, card);
+  });
+  return _operatorDeviceAdminAppend(parent, section);
+}
+
+function _operatorDeviceAdminRenderDryRuns(parent, dryRuns){
+  const values = _operatorDeviceAdminArray(dryRuns);
+  const section = _operatorDeviceAdminCreate('div', 'operator-device-admin-card', null);
+  if (!section) return null;
+  _operatorDeviceAdminAppendText(section, 'operator-device-admin-source', 'dry_runs: ' + (values.length ? String(values.length) : 'none'));
+  if (!values.length) {
+    _operatorDeviceAdminAppendText(section, 'operator-device-admin-empty', 'No source-backed dry-run actions are available.');
+    return _operatorDeviceAdminAppend(parent, section);
+  }
+  values.forEach(actionValue => {
+    const action = _operatorDeviceAdminObject(actionValue);
+    const card = _operatorDeviceAdminCreate('div', 'operator-device-admin-card ' + _operatorDeviceAdminStateClass(action.state), null);
+    if (!card) return;
+    _operatorDeviceAdminAppendMeta(card, 'action_id', action.id);
+    _operatorDeviceAdminAppendMeta(card, 'source_action_id', action.source_action_id);
+    _operatorDeviceAdminAppendMeta(card, 'action', action.action);
+    _operatorDeviceAdminAppendMeta(card, 'host_id', action.host_id);
+    _operatorDeviceAdminAppendMeta(card, 'source_path_id', action.source_path_id);
+    _operatorDeviceAdminAppendMeta(card, 'destination_path_id', action.destination_path_id);
+    _operatorDeviceAdminAppendMeta(card, 'summary', action.summary);
+    _operatorDeviceAdminAppendMeta(card, 'risk', action.risk);
+    _operatorDeviceAdminAppendMeta(card, 'state', action.state);
+    _operatorDeviceAdminAppendMeta(card, 'approval_required', _operatorDeviceAdminBoolText(action.approval_required));
+    _operatorDeviceAdminAppendMeta(card, 'would_execute', _operatorDeviceAdminBoolText(action.would_execute));
+    const button = _operatorDeviceAdminCreate('button', 'operator-device-admin-action', 'Dry-run preview');
+    if (button) {
+      button.type = 'button';
+      button.dataset.actionId = _operatorDeviceAdminText(action.id, '');
+      button.addEventListener('click', () => previewOperatorDeviceAdminAction(button.dataset.actionId));
+      _operatorDeviceAdminAppend(card, button);
+    }
+    _operatorDeviceAdminRenderIssues(card, 'action issues', action.issues || []);
+    _operatorDeviceAdminAppend(section, card);
+  });
+  return _operatorDeviceAdminAppend(parent, section);
+}
+
+function _operatorDeviceAdminRenderReceipts(parent, receipts){
+  const values = _operatorDeviceAdminArray(receipts);
+  const section = _operatorDeviceAdminCreate('div', 'operator-device-admin-card', null);
+  if (!section) return null;
+  _operatorDeviceAdminAppendText(section, 'operator-device-admin-source', 'receipts: ' + (values.length ? String(values.length) : 'none'));
+  if (!values.length) {
+    _operatorDeviceAdminAppendText(section, 'operator-device-admin-empty', 'No receipt-log entries were returned.');
+    return _operatorDeviceAdminAppend(parent, section);
+  }
+  values.forEach(receiptValue => {
+    const receipt = _operatorDeviceAdminObject(receiptValue);
+    const card = _operatorDeviceAdminCreate('div', 'operator-device-admin-card ' + _operatorDeviceAdminStateClass(receipt.status), null);
+    if (!card) return;
+    _operatorDeviceAdminAppendMeta(card, 'receipt_id', receipt.id);
+    _operatorDeviceAdminAppendMeta(card, 'action_id', receipt.action_id);
+    _operatorDeviceAdminAppendMeta(card, 'status', receipt.status);
+    _operatorDeviceAdminAppendMeta(card, 'created_at', receipt.created_at);
+    _operatorDeviceAdminAppendMeta(card, 'summary', receipt.summary);
+    _operatorDeviceAdminAppendMeta(card, 'would_execute', _operatorDeviceAdminBoolText(receipt.would_execute));
+    _operatorDeviceAdminAppend(section, card);
+  });
+  return _operatorDeviceAdminAppend(parent, section);
+}
+
+function hideOperatorDeviceAdmin(){
+  const popover = _operatorDeviceAdminEl('operatorDeviceAdminPopover');
+  if (popover) popover.hidden = true;
+}
+
+function toggleOperatorDeviceAdmin(opts = {}){
+  const popover = _operatorDeviceAdminEl('operatorDeviceAdminPopover');
+  if (!popover) return;
+  const shouldOpen = opts && opts.open === true ? true : opts && opts.open === false ? false : popover.hidden;
+  popover.hidden = !shouldOpen;
+  if (!shouldOpen) return;
+  renderOperatorDeviceAdmin(_operatorDeviceAdminLastPayload || _operatorDeviceAdminDefaultPayload());
+  if (!_operatorDeviceAdminHasLoadedPayload || (opts && opts.force === true)) {
+    refreshOperatorDeviceAdmin(opts);
+  }
+}
+
+async function refreshOperatorDeviceAdmin(opts = {}){
+  const requestSeq = ++_operatorDeviceAdminRequestSeq;
+  const queryString = _operatorDeviceAdminQueryString();
+  renderOperatorDeviceAdmin(_operatorDeviceAdminLoadingPayload(), {updateFilters: false});
+  try {
+    if (typeof api !== 'function') throw new Error('api helper unavailable');
+    const payload = await api('/api/operator/device-admin' + queryString);
+    if (requestSeq !== _operatorDeviceAdminRequestSeq) return payload;
+    _operatorDeviceAdminHasLoadedPayload = true;
+    _operatorDeviceAdminLastPayload = payload || _operatorDeviceAdminDefaultPayload();
+    renderOperatorDeviceAdmin(_operatorDeviceAdminLastPayload);
+    return _operatorDeviceAdminLastPayload;
+  } catch (error) {
+    if (requestSeq !== _operatorDeviceAdminRequestSeq) return null;
+    const payload = _operatorDeviceAdminErrorPayload(error);
+    _operatorDeviceAdminHasLoadedPayload = true;
+    _operatorDeviceAdminLastPayload = payload;
+    renderOperatorDeviceAdmin(payload);
+    return payload;
+  }
+}
+
+function renderOperatorDeviceAdmin(payload, opts = {}){
+  const safePayload = _operatorDeviceAdminObject(payload);
+  const finalPayload = Object.keys(safePayload).length ? safePayload : _operatorDeviceAdminDefaultPayload();
+  _operatorDeviceAdminLastPayload = finalPayload;
+  const dryRuns = _operatorDeviceAdminArray(finalPayload.dry_runs);
+  _operatorDeviceAdminSetChipState(finalPayload.status || 'unknown', dryRuns.length);
+  if (!opts || opts.updateFilters !== false) _operatorDeviceAdminPopulateHostFilter(finalPayload.hosts || []);
+  const status = _operatorDeviceAdminEl('operatorDeviceAdminStatus');
+  if (status) status.textContent = _operatorDeviceAdminText(finalPayload.summary, 'Manual foundations only — no execution');
+  const list = _operatorDeviceAdminEl('operatorDeviceAdminList');
+  _operatorDeviceAdminClear(list);
+  _operatorDeviceAdminRenderSources(list, finalPayload.sources || []);
+  _operatorDeviceAdminRenderApprovalModel(list, finalPayload.approval_model || {});
+  _operatorDeviceAdminRenderHosts(list, finalPayload.hosts || []);
+  _operatorDeviceAdminRenderPaths(list, finalPayload.paths || []);
+  _operatorDeviceAdminRenderDryRuns(list, dryRuns);
+  _operatorDeviceAdminRenderReceipts(list, finalPayload.receipts || []);
+  _operatorDeviceAdminRenderIssues(list, 'issues', finalPayload.issues || []);
+  ++_operatorDeviceAdminPreviewSeq;
+  renderOperatorDeviceAdminPreview({
+    status: 'unknown',
+    action: {id: '', action: 'unknown', summary: ''},
+    preview: {text: 'No device action was executed. Select a source-backed dry-run action for preview.'},
+    issues: [],
+    would_execute: false,
+  });
+}
+
+function renderOperatorDeviceAdminPreview(payload){
+  const safePayload = _operatorDeviceAdminObject(payload);
+  const preview = _operatorDeviceAdminObject(safePayload.preview);
+  const action = _operatorDeviceAdminObject(safePayload.action);
+  const panel = _operatorDeviceAdminEl('operatorDeviceAdminPreview');
+  _operatorDeviceAdminClear(panel);
+  const card = _operatorDeviceAdminCreate('div', 'operator-device-admin-card ' + _operatorDeviceAdminStateClass(safePayload.status || 'blocked'), null);
+  if (!card) return;
+  _operatorDeviceAdminAppendText(card, 'operator-device-admin-source operator-device-admin-blocked', 'No device action was executed.');
+  _operatorDeviceAdminAppendMeta(card, 'status', safePayload.status || 'unknown');
+  _operatorDeviceAdminAppendMeta(card, 'action_id', action.id);
+  _operatorDeviceAdminAppendMeta(card, 'action', action.action);
+  _operatorDeviceAdminAppendMeta(card, 'summary', action.summary);
+  _operatorDeviceAdminAppendMeta(card, 'would_execute', _operatorDeviceAdminBoolText(safePayload.would_execute));
+  _operatorDeviceAdminAppendText(card, 'operator-device-admin-preview', _operatorDeviceAdminText(preview.text, 'No preview text returned.'));
+  _operatorDeviceAdminRenderIssues(card, 'preview issues', safePayload.issues || []);
+  _operatorDeviceAdminAppend(panel, card);
+}
+
+async function previewOperatorDeviceAdminAction(actionId){
+  const normalizedActionId = _operatorDeviceAdminText(actionId, '');
+  const previewSeq = ++_operatorDeviceAdminPreviewSeq;
+  renderOperatorDeviceAdminPreview({
+    status: 'unknown',
+    action: {id: normalizedActionId, action: 'unknown', summary: 'Loading dry-run preview'},
+    preview: {text: 'No device action was executed. Loading dry-run preview metadata.'},
+    issues: [],
+    would_execute: false,
+  });
+  try {
+    if (typeof api !== 'function') throw new Error('api helper unavailable');
+    const params = new URLSearchParams();
+    params.set('id', normalizedActionId);
+    const payload = await api('/api/operator/device-admin/preview?' + params.toString());
+    if (previewSeq !== _operatorDeviceAdminPreviewSeq) return payload;
+    renderOperatorDeviceAdminPreview(payload || {});
+    return payload;
+  } catch (error) {
+    if (previewSeq !== _operatorDeviceAdminPreviewSeq) return null;
+    const payload = {
+      status: 'unknown',
+      action: {id: normalizedActionId, action: 'unknown', summary: ''},
+      preview: {text: 'No device action was executed. Preview request failed.'},
+      issues: [_operatorDeviceAdminText(error && error.message, 'preview request failed')],
+      would_execute: false,
+    };
+    renderOperatorDeviceAdminPreview(payload);
+    return payload;
+  }
+}
+
+function initOperatorDeviceAdmin(){
+  _operatorDeviceAdminSetChipState('unknown', 0);
+  renderOperatorDeviceAdmin(_operatorDeviceAdminLastPayload || _operatorDeviceAdminDefaultPayload());
+}
+
+window.toggleOperatorDeviceAdmin = toggleOperatorDeviceAdmin;
+window.hideOperatorDeviceAdmin = hideOperatorDeviceAdmin;
+window.refreshOperatorDeviceAdmin = refreshOperatorDeviceAdmin;
+window.renderOperatorDeviceAdmin = renderOperatorDeviceAdmin;
+window.previewOperatorDeviceAdminAction = previewOperatorDeviceAdminAction;
+window.renderOperatorDeviceAdminPreview = renderOperatorDeviceAdminPreview;
+window.initOperatorDeviceAdmin = initOperatorDeviceAdmin;
+
+if (typeof document !== 'undefined') initOperatorDeviceAdmin();

--- a/static/operator_docs_artifacts.js
+++ b/static/operator_docs_artifacts.js
@@ -1,0 +1,454 @@
+'use strict';
+
+const OPERATOR_DOCS_ARTIFACTS_ALLOWED_ENDPOINTS = {
+  list: '/api/operator/docs-artifacts',
+  open: '/api/operator/docs-artifacts/open',
+};
+const OPERATOR_DOCS_ARTIFACTS_OPEN_ENDPOINT = OPERATOR_DOCS_ARTIFACTS_ALLOWED_ENDPOINTS.open;
+
+let _operatorDocsArtifactsLastPayload = null;
+let _operatorDocsArtifactsRequestSeq = 0;
+let _operatorDocsArtifactsPreviewSeq = 0;
+
+function _operatorDocsArtifactsEl(id){
+  if (typeof $ === 'function') return $(id);
+  if (typeof document === 'undefined') return null;
+  return document.getElementById(id);
+}
+
+function _operatorDocsArtifactsText(value, fallback){
+  const text = String(value == null ? '' : value).trim();
+  return text || fallback || '';
+}
+
+function _operatorDocsArtifactsArray(value){
+  return Array.isArray(value) ? value : [];
+}
+
+function _operatorDocsArtifactsObject(value){
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function _operatorDocsArtifactsHasOwn(obj, key){
+  return Boolean(obj && typeof obj === 'object' && Object.prototype.hasOwnProperty.call(obj, key));
+}
+
+function _operatorDocsArtifactsClear(el){
+  if (!el) return;
+  while (el.firstChild) el.removeChild(el.firstChild);
+}
+
+function _operatorDocsArtifactsCreate(tagName, className, text){
+  if (typeof document === 'undefined') return null;
+  const node = document.createElement(tagName);
+  if (className) node.className = className;
+  if (text != null) node.textContent = String(text);
+  return node;
+}
+
+function _operatorDocsArtifactsAppend(parent, node){
+  if (parent && node) parent.appendChild(node);
+  return node;
+}
+
+function _operatorDocsArtifactsAppendText(parent, className, text){
+  return _operatorDocsArtifactsAppend(parent, _operatorDocsArtifactsCreate('div', className, text));
+}
+
+function _operatorDocsArtifactsAppendMeta(parent, label, value, className){
+  const rowClass = className ? 'operator-docs-artifacts-source ' + className : 'operator-docs-artifacts-source';
+  const display = _operatorDocsArtifactsText(value, 'unknown');
+  return _operatorDocsArtifactsAppendText(parent, rowClass, label + ': ' + display);
+}
+
+function _operatorDocsArtifactsDefaultPayload(){
+  return {
+    status: 'unknown',
+    summary: 'Press Refresh to list allowlisted docs and artifacts.',
+    query: {text: '', kind: 'all', root: 'all', limit: 50},
+    sources: [],
+    items: [],
+    count: 0,
+    issues: [],
+    would_execute: false,
+  };
+}
+
+function _operatorDocsArtifactsLoadingPayload(){
+  return {
+    status: 'unknown',
+    summary: 'Loading docs and artifacts from allowlisted local sources.',
+    query: _operatorDocsArtifactsCurrentQuery(),
+    sources: [],
+    items: [],
+    count: 0,
+    issues: [],
+    would_execute: false,
+  };
+}
+
+function _operatorDocsArtifactsErrorPayload(error){
+  return {
+    status: 'unknown',
+    summary: 'Docs and artifacts request failed.',
+    query: _operatorDocsArtifactsCurrentQuery(),
+    sources: [],
+    items: [],
+    count: 0,
+    issues: [_operatorDocsArtifactsText(error && error.message, 'request failed')],
+    would_execute: false,
+  };
+}
+
+function _operatorDocsArtifactsKnownState(value, fallback){
+  const state = _operatorDocsArtifactsText(value, fallback || 'unknown').toLowerCase();
+  if (state === 'current') return 'current';
+  if (state === 'historical') return 'historical';
+  if (state === 'stale') return 'stale';
+  if (state === 'live') return 'live';
+  return 'unknown';
+}
+
+function _operatorDocsArtifactsStateClass(state){
+  const value = _operatorDocsArtifactsKnownState(state, 'unknown');
+  if (value === 'current' || value === 'live') return 'operator-docs-artifacts-current';
+  if (value === 'historical') return 'operator-docs-artifacts-historical';
+  if (value === 'stale') return 'operator-docs-artifacts-stale';
+  return '';
+}
+
+function _operatorDocsArtifactsBoolState(value){
+  if (value === true) return 'true';
+  if (value === false) return 'false';
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true') return 'true';
+    if (normalized === 'false') return 'false';
+  }
+  return 'unknown';
+}
+
+function _operatorDocsArtifactsMtime(value){
+  if (value == null || value === '') return 'unknown';
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    const millis = numeric > 100000000000 ? numeric : numeric * 1000;
+    const date = new Date(millis);
+    if (!Number.isNaN(date.getTime())) return date.toISOString();
+  }
+  return _operatorDocsArtifactsText(value, 'unknown');
+}
+
+function _operatorDocsArtifactsFreshness(item){
+  const freshness = _operatorDocsArtifactsObject(item && item.freshness);
+  const rawLabel = freshness.label || (item && item.freshness_label);
+  const label = _operatorDocsArtifactsKnownState(rawLabel, 'unknown');
+  const reason = _operatorDocsArtifactsText(freshness.reason || (item && item.freshness_reason), 'reason unknown');
+  return {label, reason};
+}
+
+function _operatorDocsArtifactsCurrentQuery(){
+  const input = _operatorDocsArtifactsEl('operatorDocsArtifactsInput');
+  const kind = _operatorDocsArtifactsEl('operatorDocsArtifactsKind');
+  const root = _operatorDocsArtifactsEl('operatorDocsArtifactsRoot');
+  return {
+    text: _operatorDocsArtifactsText(input && input.value, ''),
+    kind: _operatorDocsArtifactsText(kind && kind.value, 'all'),
+    root: _operatorDocsArtifactsText(root && root.value, 'all'),
+    limit: 50,
+  };
+}
+
+function _operatorDocsArtifactsQueryString(){
+  const query = _operatorDocsArtifactsCurrentQuery();
+  const params = new URLSearchParams();
+  params.set('query', query.text);
+  params.set('kind', query.kind || 'all');
+  params.set('root', query.root || 'all');
+  params.set('limit', String(query.limit || 50));
+  const encoded = params.toString();
+  return encoded ? '?' + encoded : '';
+}
+
+function _operatorDocsArtifactsSetChipState(state, count){
+  const chip = _operatorDocsArtifactsEl('operatorDocsArtifactsChip');
+  const label = _operatorDocsArtifactsEl('operatorDocsArtifactsLabel');
+  const normalized = _operatorDocsArtifactsKnownState(state, 'unknown');
+  if (label) {
+    const suffix = Number.isFinite(Number(count)) && Number(count) > 0 ? ' ' + Number(count) : '';
+    label.textContent = normalized === 'live' || normalized === 'current' ? 'Docs' + suffix : normalized === 'stale' ? 'Docs stale' : 'Docs';
+  }
+  if (!chip) return;
+  chip.hidden = false;
+  chip.title = 'Manual docs and artifacts browser · ' + normalized;
+  if (chip.classList) {
+    chip.classList.remove('state-live', 'state-stale', 'state-unknown');
+    chip.classList.add(normalized === 'live' || normalized === 'current' ? 'state-live' : normalized === 'stale' ? 'state-stale' : 'state-unknown');
+  }
+}
+
+function _operatorDocsArtifactsRenderIssues(parent, title, issues){
+  const values = _operatorDocsArtifactsArray(issues).map(issue => _operatorDocsArtifactsText(issue, '')).filter(Boolean);
+  const card = _operatorDocsArtifactsCreate('div', 'operator-docs-artifacts-card', null);
+  if (!card) return null;
+  _operatorDocsArtifactsAppendText(card, 'operator-docs-artifacts-source', title + ': ' + (values.length ? String(values.length) : 'none'));
+  values.forEach(issue => _operatorDocsArtifactsAppendText(card, 'operator-docs-artifacts-source operator-docs-artifacts-stale', '- ' + issue));
+  return _operatorDocsArtifactsAppend(parent, card);
+}
+
+function _operatorDocsArtifactsRenderSources(parent, sources){
+  const values = _operatorDocsArtifactsArray(sources);
+  const section = _operatorDocsArtifactsCreate('div', 'operator-docs-artifacts-card', null);
+  if (!section) return null;
+  _operatorDocsArtifactsAppendText(section, 'operator-docs-artifacts-source', 'sources: ' + (values.length ? String(values.length) : 'none'));
+  if (!values.length) {
+    _operatorDocsArtifactsAppendText(section, 'operator-docs-artifacts-empty', 'No source registry entries were returned.');
+    return _operatorDocsArtifactsAppend(parent, section);
+  }
+  values.forEach(sourceValue => {
+    const source = _operatorDocsArtifactsObject(sourceValue);
+    const sourceCard = _operatorDocsArtifactsCreate('div', 'operator-docs-artifacts-card ' + _operatorDocsArtifactsStateClass(source.state), null);
+    if (!sourceCard) return;
+    _operatorDocsArtifactsAppendMeta(sourceCard, 'source id', source.id, 'operator-docs-artifacts-current');
+    _operatorDocsArtifactsAppendMeta(sourceCard, 'label', source.label);
+    _operatorDocsArtifactsAppendMeta(sourceCard, 'kind', source.kind);
+    _operatorDocsArtifactsAppendMeta(sourceCard, 'display_path', source.display_path);
+    _operatorDocsArtifactsAppendMeta(sourceCard, 'state', _operatorDocsArtifactsKnownState(source.state, 'unknown'));
+    _operatorDocsArtifactsAppendMeta(sourceCard, 'count', source.count == null ? 'unknown' : source.count);
+    _operatorDocsArtifactsRenderIssues(sourceCard, 'source issues', source.issue ? [source.issue] : []);
+    _operatorDocsArtifactsAppend(section, sourceCard);
+  });
+  return _operatorDocsArtifactsAppend(parent, section);
+}
+
+function _operatorDocsArtifactsItemWouldExecute(item, payload){
+  if (_operatorDocsArtifactsHasOwn(item, 'would_execute')) return _operatorDocsArtifactsBoolState(item.would_execute);
+  if (_operatorDocsArtifactsHasOwn(payload, 'would_execute')) return _operatorDocsArtifactsBoolState(payload.would_execute);
+  return 'unknown';
+}
+
+function _operatorDocsArtifactsRenderItems(parent, items, payload){
+  const values = _operatorDocsArtifactsArray(items);
+  if (!values.length) {
+    _operatorDocsArtifactsAppendText(parent, 'operator-docs-artifacts-empty', 'No docs or artifacts returned for the current filters.');
+    return;
+  }
+  values.forEach(itemValue => {
+    const item = _operatorDocsArtifactsObject(itemValue);
+    const freshness = _operatorDocsArtifactsFreshness(item);
+    const stateClass = _operatorDocsArtifactsStateClass(freshness.label);
+    const card = _operatorDocsArtifactsCreate('div', 'operator-docs-artifacts-card' + (stateClass ? ' ' + stateClass : ''), null);
+    if (!card) return;
+    const title = _operatorDocsArtifactsText(item.title, _operatorDocsArtifactsText(item.display_path, 'Untitled docs/artifacts item'));
+    _operatorDocsArtifactsAppendText(card, 'operator-docs-artifacts-source operator-docs-artifacts-current', title);
+    _operatorDocsArtifactsAppendMeta(card, 'kind', item.kind);
+    _operatorDocsArtifactsAppendMeta(card, 'display_path', item.display_path);
+    _operatorDocsArtifactsAppendMeta(card, 'root_id', item.root_id);
+    _operatorDocsArtifactsAppendMeta(card, 'relative_path', item.relative_path);
+    _operatorDocsArtifactsAppendMeta(card, 'size_bytes', item.size_bytes == null ? 'unknown' : item.size_bytes);
+    _operatorDocsArtifactsAppendMeta(card, 'mtime', _operatorDocsArtifactsMtime(item.mtime));
+    _operatorDocsArtifactsAppendMeta(card, 'freshness', freshness.label + ' — ' + freshness.reason, stateClass);
+    _operatorDocsArtifactsAppendMeta(card, 'preview_available', _operatorDocsArtifactsBoolState(item.preview_available));
+    _operatorDocsArtifactsAppendMeta(card, 'would_execute', _operatorDocsArtifactsItemWouldExecute(item, payload));
+    _operatorDocsArtifactsRenderIssues(card, 'item issues', item.issues);
+    const previewAvailable = item.preview_available === true;
+    const action = _operatorDocsArtifactsCreate('button', 'operator-docs-artifacts-action', previewAvailable ? 'Open preview' : 'Preview unavailable');
+    if (action) {
+      action.type = 'button';
+      action.disabled = !previewAvailable;
+      if (previewAvailable) {
+        action.addEventListener('click', () => openOperatorDocsArtifactPreview(item));
+      } else {
+        action.title = 'Preview unavailable for this item.';
+        action.setAttribute('aria-disabled', 'true');
+      }
+      _operatorDocsArtifactsAppend(card, action);
+    }
+    _operatorDocsArtifactsAppend(parent, card);
+  });
+}
+
+function _operatorDocsArtifactsPreviewId(itemOrId){
+  if (typeof itemOrId === 'string' || typeof itemOrId === 'number') {
+    return _operatorDocsArtifactsText(itemOrId, '');
+  }
+  const item = _operatorDocsArtifactsObject(itemOrId);
+  return _operatorDocsArtifactsText(item.id, '');
+}
+
+function _operatorDocsArtifactsPreviewEmptyPayload(itemOrId, issue){
+  const item = _operatorDocsArtifactsObject(itemOrId);
+  return {
+    status: 'unknown',
+    item,
+    preview: {
+      format: 'metadata-only',
+      text: '',
+      truncated: false,
+      bytes_read: 0,
+      max_bytes: 0,
+    },
+    issues: issue ? [issue] : [],
+    would_execute: false,
+  };
+}
+
+function _operatorDocsArtifactsRenderPreview(payload, requestedItem){
+  const container = _operatorDocsArtifactsEl('operatorDocsArtifactsPreview');
+  _operatorDocsArtifactsClear(container);
+  if (!payload) {
+    _operatorDocsArtifactsAppendText(container, 'operator-docs-artifacts-empty', 'Select an available item preview to open it.');
+    _operatorDocsArtifactsAppendMeta(container, 'status', 'unknown');
+    _operatorDocsArtifactsAppendMeta(container, 'format', 'metadata-only');
+    _operatorDocsArtifactsAppendMeta(container, 'preview_available', 'unknown');
+    return payload;
+  }
+
+  const data = _operatorDocsArtifactsObject(payload);
+  const fallbackItem = _operatorDocsArtifactsObject(requestedItem);
+  const hasItem = _operatorDocsArtifactsHasOwn(data, 'item');
+  const item = hasItem ? _operatorDocsArtifactsObject(data.item) : fallbackItem;
+  const hasPreview = _operatorDocsArtifactsHasOwn(data, 'preview');
+  const preview = _operatorDocsArtifactsObject(data.preview);
+  const previewTextIsString = typeof preview.text === 'string';
+  const hasPreviewText = _operatorDocsArtifactsHasOwn(preview, 'text');
+  const malformed = !hasItem || !hasPreview || (hasPreviewText && !previewTextIsString);
+  const status = _operatorDocsArtifactsText(data.status, 'unknown');
+  const format = _operatorDocsArtifactsText(preview.format, 'metadata-only');
+  const previewText = previewTextIsString ? preview.text : '';
+  const issues = _operatorDocsArtifactsArray(data.issues).slice();
+  if (hasPreviewText && !previewTextIsString) issues.unshift('malformed preview text');
+  if (malformed) issues.unshift('malformed preview payload');
+
+  _operatorDocsArtifactsAppendText(container, 'operator-docs-artifacts-source operator-docs-artifacts-current', _operatorDocsArtifactsText(item.title, 'Selected docs/artifacts item'));
+  _operatorDocsArtifactsAppendMeta(container, 'status', status);
+  _operatorDocsArtifactsAppendMeta(container, 'format', format);
+  _operatorDocsArtifactsAppendMeta(container, 'truncated', _operatorDocsArtifactsBoolState(preview.truncated));
+  _operatorDocsArtifactsAppendMeta(container, 'bytes_read', preview.bytes_read == null ? 'unknown' : preview.bytes_read);
+  _operatorDocsArtifactsAppendMeta(container, 'max_bytes', preview.max_bytes == null ? 'unknown' : preview.max_bytes);
+  _operatorDocsArtifactsAppendMeta(container, 'id', item.id);
+  _operatorDocsArtifactsAppendMeta(container, 'display_path', item.display_path);
+  _operatorDocsArtifactsAppendMeta(container, 'root_id', item.root_id);
+  _operatorDocsArtifactsAppendMeta(container, 'relative_path', item.relative_path);
+  _operatorDocsArtifactsAppendMeta(container, 'preview_available', _operatorDocsArtifactsBoolState(item.preview_available));
+  _operatorDocsArtifactsRenderIssues(container, 'preview issues', issues);
+
+  if (malformed) {
+    _operatorDocsArtifactsAppendText(container, 'operator-docs-artifacts-empty', 'Malformed preview response; no preview body was rendered.');
+    return payload;
+  }
+  if (!previewText) {
+    _operatorDocsArtifactsAppendText(container, 'operator-docs-artifacts-empty', format === 'metadata-only' ? 'Metadata-only response; no preview text returned.' : 'No preview text returned.');
+    return payload;
+  }
+  if (typeof document === 'undefined') return payload;
+  const body = document.createElement('pre');
+  body.className = 'operator-docs-artifacts-source operator-docs-artifacts-preview-body';
+  body.textContent = previewText;
+  _operatorDocsArtifactsAppend(container, body);
+  return payload;
+}
+
+function renderOperatorDocsArtifacts(payload){
+  const data = payload || _operatorDocsArtifactsLastPayload || _operatorDocsArtifactsDefaultPayload();
+  _operatorDocsArtifactsLastPayload = data;
+
+  const sources = _operatorDocsArtifactsArray(data.sources);
+  const items = _operatorDocsArtifactsArray(data.items);
+  const issues = _operatorDocsArtifactsArray(data.issues);
+  const count = data.count == null ? items.length : data.count;
+  const summary = _operatorDocsArtifactsText(data.summary, 'Docs and artifacts state unknown.');
+  const statusText = summary + ' · items: ' + String(count) + ' · would_execute: ' + _operatorDocsArtifactsBoolState(data.would_execute);
+
+  const status = _operatorDocsArtifactsEl('operatorDocsArtifactsStatus');
+  if (status) status.textContent = statusText;
+  _operatorDocsArtifactsSetChipState(data.status, count);
+
+  const list = _operatorDocsArtifactsEl('operatorDocsArtifactsList');
+  _operatorDocsArtifactsClear(list);
+  _operatorDocsArtifactsRenderIssues(list, 'issues', issues);
+  _operatorDocsArtifactsRenderSources(list, sources);
+  _operatorDocsArtifactsRenderItems(list, items, data);
+  _operatorDocsArtifactsPreviewSeq += 1;
+  _operatorDocsArtifactsRenderPreview(null, null);
+
+  return data;
+}
+
+async function refreshOperatorDocsArtifacts(){
+  const requestSeq = ++_operatorDocsArtifactsRequestSeq;
+  const queryString = _operatorDocsArtifactsQueryString();
+  renderOperatorDocsArtifacts(_operatorDocsArtifactsLoadingPayload());
+  try {
+    const payload = await api('/api/operator/docs-artifacts' + queryString);
+    if (requestSeq !== _operatorDocsArtifactsRequestSeq) return _operatorDocsArtifactsLastPayload;
+    return renderOperatorDocsArtifacts(payload);
+  } catch (error) {
+    if (requestSeq !== _operatorDocsArtifactsRequestSeq) return _operatorDocsArtifactsLastPayload;
+    return renderOperatorDocsArtifacts(_operatorDocsArtifactsErrorPayload(error));
+  }
+}
+
+function openOperatorDocsArtifactPreview(itemOrId){
+  const previewSeq = ++_operatorDocsArtifactsPreviewSeq;
+  const id = _operatorDocsArtifactsPreviewId(itemOrId);
+  if (!id) {
+    return _operatorDocsArtifactsRenderPreview(_operatorDocsArtifactsPreviewEmptyPayload(itemOrId, 'missing or unknown docs/artifacts item id'), itemOrId);
+  }
+  const params = new URLSearchParams();
+  params.set('id', id);
+  _operatorDocsArtifactsRenderPreview(_operatorDocsArtifactsPreviewEmptyPayload(itemOrId, 'Loading explicit docs/artifacts preview.'), itemOrId);
+  return api(OPERATOR_DOCS_ARTIFACTS_OPEN_ENDPOINT + '?' + params.toString())
+    .then(payload => {
+      if (previewSeq !== _operatorDocsArtifactsPreviewSeq) return _operatorDocsArtifactsLastPayload;
+      return _operatorDocsArtifactsRenderPreview(payload, itemOrId);
+    })
+    .catch(error => {
+      if (previewSeq !== _operatorDocsArtifactsPreviewSeq) return _operatorDocsArtifactsLastPayload;
+      return _operatorDocsArtifactsRenderPreview(_operatorDocsArtifactsPreviewEmptyPayload(itemOrId, _operatorDocsArtifactsText(error && error.message, 'preview request failed')), itemOrId);
+    });
+}
+
+function hideOperatorDocsArtifacts(){
+  const popover = _operatorDocsArtifactsEl('operatorDocsArtifactsPopover');
+  if (popover) popover.hidden = true;
+}
+
+function toggleOperatorDocsArtifacts(opts = {}){
+  const popover = _operatorDocsArtifactsEl('operatorDocsArtifactsPopover');
+  if (!popover) return;
+  const opening = popover.hidden;
+  if (!opening && !opts.force) {
+    hideOperatorDocsArtifacts();
+    return;
+  }
+  popover.hidden = false;
+  renderOperatorDocsArtifacts(_operatorDocsArtifactsLastPayload || _operatorDocsArtifactsDefaultPayload());
+  const input = _operatorDocsArtifactsEl('operatorDocsArtifactsInput');
+  if (input && typeof input.focus === 'function') input.focus();
+}
+
+function initOperatorDocsArtifacts(){
+  _operatorDocsArtifactsSetChipState('unknown', 0);
+  const input = _operatorDocsArtifactsEl('operatorDocsArtifactsInput');
+  if (input && !input.dataset.docsArtifactsBound) {
+    input.dataset.docsArtifactsBound = '1';
+    input.addEventListener('keydown', event => {
+      if (event.key !== 'Enter') return;
+      event.preventDefault();
+      refreshOperatorDocsArtifacts();
+    });
+  }
+  renderOperatorDocsArtifacts(_operatorDocsArtifactsLastPayload || _operatorDocsArtifactsDefaultPayload());
+}
+
+window.toggleOperatorDocsArtifacts = toggleOperatorDocsArtifacts;
+window.hideOperatorDocsArtifacts = hideOperatorDocsArtifacts;
+window.refreshOperatorDocsArtifacts = refreshOperatorDocsArtifacts;
+window.renderOperatorDocsArtifacts = renderOperatorDocsArtifacts;
+window.openOperatorDocsArtifactPreview = openOperatorDocsArtifactPreview;
+window.initOperatorDocsArtifacts = initOperatorDocsArtifacts;
+
+if (typeof document !== 'undefined') {
+  initOperatorDocsArtifacts();
+}

--- a/static/operator_kanban.js
+++ b/static/operator_kanban.js
@@ -1,0 +1,289 @@
+let _operatorKanbanLastFetchKey = '';
+let _operatorKanbanLastPayload = null;
+let _operatorKanbanInFlight = null;
+let _operatorKanbanInFlightKey = '';
+let _operatorKanbanRequestSeq = 0;
+
+function _operatorKanbanEl(id){
+  if (typeof $ === 'function') return $(id);
+  return document.getElementById(id);
+}
+
+function operatorKanbanBoardParam(){
+  return 'hermes-operator';
+}
+
+function operatorKanbanUiBoardHint(){
+  try {
+    if (typeof _kanbanCurrentBoard !== 'undefined' && _kanbanCurrentBoard) return _kanbanCurrentBoard;
+  } catch(_) {}
+  return '';
+}
+
+function operatorKanbanContextKey(){
+  const session = (typeof S !== 'undefined' && S && S.session) || {};
+  const truthKey = (typeof operatorTruthContextKey === 'function') ? operatorTruthContextKey() : '';
+  return JSON.stringify({
+    truth: truthKey,
+    board: operatorKanbanBoardParam(),
+    ui_board: operatorKanbanUiBoardHint(),
+    session_id: (typeof operatorTruthSessionId === 'function') ? operatorTruthSessionId() : (session.session_id || session.id || ''),
+    profile: (typeof S !== 'undefined' && S && S.activeProfile) || '',
+    workspace: session.workspace || '',
+  });
+}
+
+function _operatorKanbanStateClass(state){
+  if (state === 'live') return 'state-live';
+  if (state === 'stale') return 'state-stale';
+  return 'state-unknown';
+}
+
+function _operatorKanbanText(value, fallback){
+  const text = String(value == null ? '' : value).trim();
+  return text || fallback || '';
+}
+
+function _operatorKanbanTime(value){
+  if (!value) return '';
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return String(value);
+  try {
+    return new Date(numeric * 1000).toLocaleString([], {month:'short', day:'2-digit', hour:'2-digit', minute:'2-digit'});
+  } catch(_) {
+    return String(value);
+  }
+}
+
+function _operatorKanbanClear(el){
+  if (!el) return;
+  while (el.firstChild) el.removeChild(el.firstChild);
+}
+
+function _operatorKanbanChip(text, state){
+  const chip = document.createElement('span');
+  chip.className = 'operator-kanban-chip ' + _operatorKanbanStateClass(state || 'unknown');
+  chip.textContent = text;
+  return chip;
+}
+
+function _operatorKanbanRow(label, value, extraClass){
+  const row = document.createElement('div');
+  row.className = 'operator-kanban-row' + (extraClass ? ' ' + extraClass : '');
+  const key = document.createElement('span');
+  key.className = 'operator-kanban-row-key';
+  key.textContent = label;
+  const val = document.createElement('span');
+  val.className = 'operator-kanban-row-value';
+  val.textContent = _operatorKanbanText(value, 'unknown');
+  row.append(key, val);
+  return row;
+}
+
+function _operatorKanbanSection(title){
+  const section = document.createElement('div');
+  section.className = 'operator-kanban-section';
+  const heading = document.createElement('div');
+  heading.className = 'operator-kanban-section-title';
+  heading.textContent = title;
+  section.append(heading);
+  return section;
+}
+
+function _operatorKanbanListItem(text, className){
+  const item = document.createElement('div');
+  item.className = className || 'operator-kanban-muted';
+  item.textContent = _operatorKanbanText(text, 'unknown');
+  return item;
+}
+
+function _operatorKanbanCompletionText(task){
+  const completion = (task && task.completion) || {};
+  const parts = [];
+  if (completion.metadata_state) parts.push('metadata ' + completion.metadata_state);
+  if (completion.completed_at) parts.push('completed ' + _operatorKanbanTime(completion.completed_at));
+  return parts.join(' · ') || 'completion unknown';
+}
+
+function _operatorKanbanTaskCard(task){
+  const card = document.createElement('div');
+  card.className = 'operator-kanban-task-card';
+  card.dataset.taskId = task.id || '';
+
+  const top = document.createElement('div');
+  top.className = 'operator-kanban-task-top';
+  const title = document.createElement('div');
+  title.className = 'operator-kanban-task-title';
+  title.textContent = _operatorKanbanText(task.title, task.id || 'Untitled task');
+  top.append(title, _operatorKanbanChip(_operatorKanbanText(task.status, 'unknown'), task.status === 'done' ? 'live' : (task.status === 'blocked' ? 'stale' : 'unknown')));
+  card.append(top);
+
+  card.append(_operatorKanbanRow('Assignee / profile', _operatorKanbanText(task.assignee, 'unassigned') + ' / ' + _operatorKanbanText(task.profile, 'unknown')));
+  card.append(_operatorKanbanRow('Workspace', _operatorKanbanText(task.workspace_kind, 'unknown') + ' · ' + _operatorKanbanText(task.workspace_path, 'missing'), 'operator-kanban-path-row'));
+
+  const scratch = (task && task.scratch_safety) || {};
+  card.append(_operatorKanbanRow('Scratch safety', _operatorKanbanText(scratch.state, 'unknown') + ' · ' + _operatorKanbanText(scratch.reason, 'no reason')));
+  card.append(_operatorKanbanRow('Blocked reason', _operatorKanbanText(task.blocked_reason, 'none')));
+  const review = (task && task.review_state) || {};
+  card.append(_operatorKanbanRow('Review state', _operatorKanbanText(review.state, 'unknown') + ' · ' + _operatorKanbanText(review.reason, 'no structured review metadata')));
+
+  const completion = (task && task.completion) || {};
+  const completionSection = _operatorKanbanSection('Completion');
+  completionSection.append(_operatorKanbanListItem(_operatorKanbanCompletionText(task), 'operator-kanban-muted'));
+  if (completion.result_summary) completionSection.append(_operatorKanbanListItem(completion.result_summary, 'operator-kanban-summary'));
+  const changed = Array.isArray(completion.changed_files) ? completion.changed_files : [];
+  completionSection.append(_operatorKanbanListItem(changed.length ? 'Changed: ' + changed.join(', ') : 'Changed files unknown/missing', 'operator-kanban-muted'));
+  const validation = Array.isArray(completion.validation) ? completion.validation : [];
+  completionSection.append(_operatorKanbanListItem(validation.length ? 'Validation: ' + validation.join(', ') : 'Validation unknown/missing', 'operator-kanban-muted'));
+  const sideEffects = Array.isArray(completion.side_effects) ? completion.side_effects : [];
+  completionSection.append(_operatorKanbanListItem(sideEffects.length ? 'Side effects: ' + sideEffects.join(', ') : 'Side effects unknown/missing', 'operator-kanban-muted'));
+  card.append(completionSection);
+
+  const receipts = Array.isArray(task.receipt_links) ? task.receipt_links : [];
+  const receiptSection = _operatorKanbanSection('Receipts');
+  if (!receipts.length) {
+    receiptSection.append(_operatorKanbanListItem('Receipts unknown/missing', 'operator-kanban-issue'));
+  } else {
+    receipts.slice(0, 5).forEach(link => {
+      const text = _operatorKanbanText(link.label, 'receipt') + ': ' + _operatorKanbanText(link.path, 'missing');
+      receiptSection.append(_operatorKanbanListItem(text, 'operator-kanban-receipt'));
+    });
+  }
+  card.append(receiptSection);
+  return card;
+}
+
+function _operatorKanbanRenderCounts(body, payload){
+  const counts = (payload && payload.counts) || {};
+  const wrap = document.createElement('div');
+  wrap.className = 'operator-kanban-counts';
+  ['triage','todo','ready','running','blocked','done'].forEach(status => {
+    const chip = document.createElement('span');
+    chip.className = 'operator-kanban-count';
+    chip.textContent = status + ' ' + String(counts[status] || 0);
+    wrap.append(chip);
+  });
+  body.append(wrap);
+}
+
+function _operatorKanbanRenderSources(body, payload){
+  const sources = Array.isArray(payload && payload.sources) ? payload.sources : [];
+  const wrap = document.createElement('div');
+  wrap.className = 'operator-kanban-sources';
+  sources.slice(0, 5).forEach(source => {
+    const label = _operatorKanbanText(source.id, 'source') + ' ' + _operatorKanbanText(source.state, 'unknown');
+    wrap.append(_operatorKanbanChip(label, source.state));
+  });
+  if (wrap.childNodes.length) body.append(wrap);
+}
+
+function _operatorKanbanRenderIssues(body, payload){
+  const issues = Array.isArray(payload && payload.issues) ? payload.issues : [];
+  if (!issues.length) return;
+  const section = _operatorKanbanSection('Issues');
+  issues.slice(0, 6).forEach(issue => section.append(_operatorKanbanListItem(issue, 'operator-kanban-issue')));
+  body.append(section);
+}
+
+function renderOperatorKanban(payload){
+  _operatorKanbanLastPayload = payload || null;
+  const panel = _operatorKanbanEl('operatorKanbanPanel');
+  const subtitle = _operatorKanbanEl('operatorKanbanSubtitle');
+  const body = _operatorKanbanEl('operatorKanbanBody');
+  if (!panel || !body) return;
+  _operatorKanbanClear(body);
+
+  const status = (payload && payload.status) || 'unknown';
+  panel.classList.remove('state-live','state-stale','state-unknown');
+  panel.classList.add(_operatorKanbanStateClass(status));
+  if (subtitle) subtitle.textContent = (payload && payload.summary) || 'Operator Kanban unknown';
+
+  const safety = (payload && payload.board_safety) || {};
+  const top = document.createElement('div');
+  top.className = 'operator-kanban-topline';
+  top.append(
+    _operatorKanbanChip('board ' + _operatorKanbanText((payload && payload.board), 'hermes-operator'), status),
+    _operatorKanbanChip('scratch ' + _operatorKanbanText(safety.state, 'unknown'), safety.state),
+    _operatorKanbanChip('would_execute:false', 'live'),
+  );
+  body.append(top);
+
+  _operatorKanbanRenderCounts(body, payload);
+  _operatorKanbanRenderSources(body, payload || {});
+
+  const tasks = Array.isArray(payload && payload.tasks) ? payload.tasks : [];
+  if (!tasks.length) {
+    const empty = document.createElement('div');
+    empty.className = 'operator-kanban-empty';
+    empty.textContent = status === 'unknown' ? 'No task cards rendered because source evidence is unavailable.' : 'No tasks found on hermes-operator.';
+    body.append(empty);
+    _operatorKanbanRenderIssues(body, payload || {});
+    return;
+  }
+
+  const list = document.createElement('div');
+  list.className = 'operator-kanban-task-list';
+  tasks.forEach(task => list.append(_operatorKanbanTaskCard(task)));
+  body.append(list);
+  _operatorKanbanRenderIssues(body, payload || {});
+}
+
+async function refreshOperatorKanban(opts = {}){
+  const force = Boolean(opts.force);
+  const contextKey = operatorKanbanContextKey();
+  if (!force && _operatorKanbanInFlight && contextKey === _operatorKanbanInFlightKey) return _operatorKanbanInFlight;
+  if (!force && _operatorKanbanLastPayload && contextKey === _operatorKanbanLastFetchKey) {
+    renderOperatorKanban(_operatorKanbanLastPayload);
+    return _operatorKanbanLastPayload;
+  }
+  if (typeof api !== 'function') {
+    const payload = {status:'unknown', summary:'Operator Kanban unavailable — API helper missing', tasks:[], counts:{}, issues:['api helper unavailable']};
+    renderOperatorKanban(payload);
+    return payload;
+  }
+
+  const params = new URLSearchParams();
+  params.set('board', operatorKanbanBoardParam());
+  const sid = (typeof operatorTruthSessionId === 'function') ? operatorTruthSessionId() : ((typeof S !== 'undefined' && S && S.session && (S.session.session_id || S.session.id)) || '');
+  const uiBoard = operatorKanbanUiBoardHint();
+  if (sid) params.set('session_id', sid);
+  if (uiBoard) params.set('ui_board', uiBoard);
+  const path = '/api/operator/kanban?' + params.toString();
+  const requestKey = contextKey;
+  const requestSeq = ++_operatorKanbanRequestSeq;
+  _operatorKanbanInFlightKey = requestKey;
+
+  _operatorKanbanInFlight = api(path)
+    .then(payload => {
+      if (requestKey !== operatorKanbanContextKey() || requestSeq !== _operatorKanbanRequestSeq) return payload;
+      _operatorKanbanLastFetchKey = requestKey;
+      renderOperatorKanban(payload);
+      return payload;
+    })
+    .catch(err => {
+      if (requestKey === operatorKanbanContextKey() && requestSeq === _operatorKanbanRequestSeq) {
+        const payload = {status:'unknown', summary:'Operator Kanban unavailable — source read failed', tasks:[], counts:{}, issues:[(err && err.message) || 'request failed']};
+        _operatorKanbanLastFetchKey = requestKey;
+        renderOperatorKanban(payload);
+      }
+      return null;
+    })
+    .finally(() => {
+      if (requestKey === _operatorKanbanInFlightKey && requestSeq === _operatorKanbanRequestSeq) {
+        _operatorKanbanInFlight = null;
+        _operatorKanbanInFlightKey = '';
+      }
+    });
+  return _operatorKanbanInFlight;
+}
+
+function initOperatorKanbanPanel(){
+  renderOperatorKanban({status:'unknown', summary:'Not checked yet', board:'hermes-operator', tasks:[], counts:{}, sources:[], issues:['not checked yet']});
+}
+
+window.refreshOperatorKanban = refreshOperatorKanban;
+window.renderOperatorKanban = renderOperatorKanban;
+window.operatorKanbanContextKey = operatorKanbanContextKey;
+window.operatorKanbanBoardParam = operatorKanbanBoardParam;
+
+initOperatorKanbanPanel();

--- a/static/operator_memory_skill_review.js
+++ b/static/operator_memory_skill_review.js
@@ -1,0 +1,315 @@
+let _operatorMemorySkillReviewLastPayload = null;
+let _operatorMemorySkillReviewInFlight = null;
+let _operatorMemorySkillReviewRequestSeq = 0;
+
+function _operatorMemorySkillReviewEl(id){
+  if (typeof $ === 'function') return $(id);
+  return document.getElementById(id);
+}
+
+function _operatorMemorySkillReviewText(value, fallback){
+  const text = String(value == null ? '' : value).trim();
+  return text || fallback || '';
+}
+
+function _operatorMemorySkillReviewStateClass(state){
+  const value = _operatorMemorySkillReviewText(state, 'unknown').toLowerCase();
+  if (value === 'live') return 'state-live';
+  if (value === 'stale') return 'state-stale';
+  return 'state-unknown';
+}
+
+function _operatorMemorySkillReviewClear(el){
+  if (!el) return;
+  while (el.firstChild) el.removeChild(el.firstChild);
+}
+
+function _operatorMemorySkillReviewJoin(parts, fallback){
+  const values = Array.isArray(parts) ? parts.map(part => _operatorMemorySkillReviewText(part, '')).filter(Boolean) : [];
+  return values.join(' · ') || fallback || 'unknown';
+}
+
+function _operatorMemorySkillReviewApplyChip(payload){
+  const chip = _operatorMemorySkillReviewEl('operatorMemorySkillReviewChip');
+  const label = _operatorMemorySkillReviewEl('operatorMemorySkillReviewLabel');
+  if (!chip) return;
+  const status = (payload && payload.status) || 'unknown';
+  const items = payload && Array.isArray(payload.items) ? payload.items : [];
+  chip.hidden = false;
+  chip.classList.remove('state-live','state-stale','state-unknown');
+  chip.classList.add(_operatorMemorySkillReviewStateClass(status));
+  if (label) label.textContent = items.length ? 'Memory Review ' + items.length : 'Memory Review';
+  chip.title = (payload && payload.summary) || 'Memory and skill review queue';
+}
+
+function _operatorMemorySkillReviewRow(label, value, extraClass){
+  const row = document.createElement('div');
+  row.className = 'operator-memory-skill-review-row' + (extraClass ? ' ' + extraClass : '');
+  const key = document.createElement('span');
+  key.className = 'operator-memory-skill-review-row-key';
+  key.textContent = label;
+  const val = document.createElement('span');
+  val.className = 'operator-memory-skill-review-row-value';
+  val.textContent = _operatorMemorySkillReviewText(value, 'unknown');
+  row.append(key, val);
+  return row;
+}
+
+function _operatorMemorySkillReviewSection(title, className){
+  const section = document.createElement('div');
+  section.className = 'operator-memory-skill-review-section ' + className;
+  const heading = document.createElement('div');
+  heading.className = 'operator-memory-skill-review-section-title';
+  heading.textContent = title;
+  section.append(heading);
+  return section;
+}
+
+function _operatorMemorySkillReviewButton(text, className, onClick){
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = className;
+  button.textContent = text;
+  button.onclick = onClick;
+  return button;
+}
+
+function _operatorMemorySkillReviewTargetText(item){
+  const target = (item && item.target) || {};
+  return _operatorMemorySkillReviewJoin([
+    target.kind,
+    target.section || target.name,
+    target.file_path || target.path,
+  ], 'unknown target');
+}
+
+function _operatorMemorySkillReviewEvidenceText(evidence){
+  return _operatorMemorySkillReviewJoin([
+    evidence && evidence.kind,
+    evidence && evidence.session_id,
+    evidence && evidence.message_index,
+    evidence && evidence.content_hash,
+    evidence && evidence.quote,
+  ], 'evidence unavailable');
+}
+
+function _operatorMemorySkillReviewNoteText(note){
+  if (!note) return 'unknown issue';
+  const missing = Array.isArray(note.missing) ? note.missing.join(', ') : '';
+  const issues = Array.isArray(note.issues) ? note.issues.join(', ') : '';
+  return _operatorMemorySkillReviewJoin([note.classification, note.reason, missing, issues], 'unknown issue');
+}
+
+function _operatorMemorySkillReviewIssue(text){
+  const item = document.createElement('div');
+  item.className = 'operator-memory-skill-review-invalid';
+  item.textContent = _operatorMemorySkillReviewText(text, 'unknown issue');
+  return item;
+}
+
+function _operatorMemorySkillReviewCard(item){
+  item = item || {};
+  const proposed_change = (item && item.proposed_change) || {};
+  const source_evidence = item && Array.isArray(item.source_evidence) ? item.source_evidence : [];
+  const classification = (item && item.classification) || {};
+  const stale_risk = (item && item.stale_risk) || {};
+  const decision = (item && item.decision) || {};
+  const rollback = (item && item.rollback) || {};
+  const issues = item && Array.isArray(item.issues) ? item.issues : [];
+  const decisionState = _operatorMemorySkillReviewText(decision.state, 'unknown').toLowerCase();
+  const staleState = _operatorMemorySkillReviewText(stale_risk.state, 'unknown').toLowerCase();
+
+  const card = document.createElement('div');
+  card.className = 'operator-memory-skill-review-card';
+  if (decisionState === 'invalid' || staleState === 'expired' || item.would_execute !== false) {
+    card.classList.add('operator-memory-skill-review-invalid');
+  }
+  if (staleState === 'review_required' || staleState === 'expired') card.classList.add('operator-memory-skill-review-stale');
+  card.dataset.reviewId = item.id || '';
+
+  const top = document.createElement('div');
+  top.className = 'operator-memory-skill-review-card-top';
+  const title = document.createElement('div');
+  title.className = 'operator-memory-skill-review-card-title';
+  title.textContent = _operatorMemorySkillReviewTargetText(item);
+  const noExec = document.createElement('span');
+  noExec.className = 'operator-memory-skill-review-no-exec';
+  noExec.textContent = item.would_execute === false ? 'would_execute:false' : 'would_execute not false';
+  top.append(title, noExec);
+  card.append(top);
+
+  const summary = document.createElement('div');
+  summary.className = 'operator-memory-skill-review-summary';
+  summary.textContent = _operatorMemorySkillReviewText(proposed_change.summary, 'No proposed_change summary.');
+  card.append(summary);
+
+  card.append(_operatorMemorySkillReviewRow('Operation', proposed_change.operation));
+  card.append(_operatorMemorySkillReviewRow('Durability', classification.durability));
+  card.append(_operatorMemorySkillReviewRow('Stale risk', staleState));
+  card.append(_operatorMemorySkillReviewRow('Expires', stale_risk.expires_at));
+  card.append(_operatorMemorySkillReviewRow('Decision', decisionState, 'operator-memory-skill-review-decision-row'));
+  card.append(_operatorMemorySkillReviewRow('Previous content', item.previous_content));
+
+  const diff = document.createElement('pre');
+  diff.className = 'operator-memory-skill-review-diff';
+  diff.textContent = _operatorMemorySkillReviewText(proposed_change.diff || proposed_change.proposed_content, 'No diff available.');
+  card.append(diff);
+
+  const evidenceSection = _operatorMemorySkillReviewSection('Source evidence', 'operator-memory-skill-review-evidence');
+  if (!source_evidence.length) {
+    evidenceSection.append(_operatorMemorySkillReviewIssue('source_evidence missing'));
+  } else {
+    source_evidence.slice(0, 5).forEach(evidence => {
+      const row = document.createElement('div');
+      row.className = 'operator-memory-skill-review-evidence-item';
+      row.textContent = _operatorMemorySkillReviewEvidenceText(evidence);
+      evidenceSection.append(row);
+    });
+  }
+  card.append(evidenceSection);
+
+  const detailSection = _operatorMemorySkillReviewSection('Classification and rollback', 'operator-memory-skill-review-detail');
+  detailSection.append(_operatorMemorySkillReviewRow('Reason', classification.reason));
+  detailSection.append(_operatorMemorySkillReviewRow('Risk', classification.transient_risk));
+  detailSection.append(_operatorMemorySkillReviewRow('Rollback', rollback.previous_hash));
+  detailSection.append(_operatorMemorySkillReviewRow('Rollback excerpt', rollback.previous_excerpt));
+  card.append(detailSection);
+
+  issues.slice(0, 5).forEach(issue => card.append(_operatorMemorySkillReviewIssue(issue)));
+
+  const actions = document.createElement('div');
+  actions.className = 'operator-memory-skill-review-decision';
+  actions.append(
+    _operatorMemorySkillReviewButton('Approve', 'operator-memory-skill-review-action primary', () => submitOperatorMemorySkillReviewDecision(item.id, 'approved')),
+    _operatorMemorySkillReviewButton('Deny', 'operator-memory-skill-review-action', () => submitOperatorMemorySkillReviewDecision(item.id, 'denied')),
+  );
+  card.append(actions);
+  return card;
+}
+
+function renderOperatorMemorySkillReview(payload){
+  _operatorMemorySkillReviewLastPayload = payload || null;
+  _operatorMemorySkillReviewApplyChip(payload);
+  const popover = _operatorMemorySkillReviewEl('operatorMemorySkillReviewPopover');
+  const subtitle = _operatorMemorySkillReviewEl('operatorMemorySkillReviewSubtitle');
+  const list = _operatorMemorySkillReviewEl('operatorMemorySkillReviewList');
+  if (!popover || !list) return;
+  _operatorMemorySkillReviewClear(list);
+
+  const status = (payload && payload.status) || 'unknown';
+  const items = payload && Array.isArray(payload.items) ? payload.items : [];
+  popover.classList.remove('state-live','state-stale','state-unknown');
+  popover.classList.add(_operatorMemorySkillReviewStateClass(status));
+  if (subtitle) {
+    const summary = (payload && payload.summary) || 'Not checked yet';
+    subtitle.textContent = summary + ' · local review only · no apply';
+  }
+
+  if (!items.length) {
+    const empty = document.createElement('div');
+    empty.className = 'operator-memory-skill-review-empty';
+    empty.textContent = status === 'unknown' ? 'No memory or skill review items — source unavailable.' : 'No memory or skill review items.';
+    list.append(empty);
+  } else {
+    items.forEach(item => list.append(_operatorMemorySkillReviewCard(item)));
+  }
+
+  const notes = payload && Array.isArray(payload.notes) ? payload.notes : [];
+  notes.slice(0, 5).forEach(note => list.append(_operatorMemorySkillReviewIssue(_operatorMemorySkillReviewNoteText(note))));
+  const issues = payload && Array.isArray(payload.issues) ? payload.issues : [];
+  issues.slice(0, 5).forEach(issue => list.append(_operatorMemorySkillReviewIssue(issue)));
+}
+
+function hideOperatorMemorySkillReview(){
+  const popover = _operatorMemorySkillReviewEl('operatorMemorySkillReviewPopover');
+  if (popover) popover.hidden = true;
+}
+
+function toggleOperatorMemorySkillReview(opts = {}){
+  const popover = _operatorMemorySkillReviewEl('operatorMemorySkillReviewPopover');
+  if (!popover) return;
+  const opening = popover.hidden;
+  if (!opening && !opts.force) {
+    hideOperatorMemorySkillReview();
+    return;
+  }
+  popover.hidden = false;
+  refreshOperatorMemorySkillReview({force: Boolean(opts.force)});
+}
+
+async function refreshOperatorMemorySkillReview(opts = {}){
+  const force = Boolean(opts.force);
+  if (!force && _operatorMemorySkillReviewInFlight) return _operatorMemorySkillReviewInFlight;
+  if (!force && _operatorMemorySkillReviewLastPayload) {
+    renderOperatorMemorySkillReview(_operatorMemorySkillReviewLastPayload);
+    return _operatorMemorySkillReviewLastPayload;
+  }
+  if (typeof api !== 'function') {
+    const payload = {status:'unknown', summary:'Memory and skill review unavailable — API helper missing', items:[], notes:[], issues:['api helper unavailable'], would_execute:false};
+    renderOperatorMemorySkillReview(payload);
+    return payload;
+  }
+
+  const requestSeq = ++_operatorMemorySkillReviewRequestSeq;
+  _operatorMemorySkillReviewInFlight = api('/api/operator/memory-skill-review')
+    .then(payload => {
+      if (requestSeq !== _operatorMemorySkillReviewRequestSeq) return payload;
+      renderOperatorMemorySkillReview(payload);
+      return payload;
+    })
+    .catch(err => {
+      if (requestSeq === _operatorMemorySkillReviewRequestSeq) {
+        const payload = {status:'unknown', summary:'Memory and skill review unavailable — source read failed', items:[], notes:[], issues:[(err && err.message) || 'request failed'], would_execute:false};
+        renderOperatorMemorySkillReview(payload);
+      }
+      return null;
+    })
+    .finally(() => {
+      if (requestSeq === _operatorMemorySkillReviewRequestSeq) _operatorMemorySkillReviewInFlight = null;
+    });
+  return _operatorMemorySkillReviewInFlight;
+}
+
+async function submitOperatorMemorySkillReviewDecision(itemId, decision){
+  if (!itemId || typeof api !== 'function') return null;
+  const request = {
+    id: itemId,
+    decision: decision,
+    reason: decision === 'approved' ? 'Approved from operator memory/skill review.' : 'Denied from operator memory/skill review.',
+  };
+  try {
+    const result = await api('/api/operator/memory-skill-review/decision',{method:'POST',body:JSON.stringify(request)});
+    if (!result || result.ok !== true) {
+      const message = (result && (result.error || result.message)) || 'decision failed';
+      const list = _operatorMemorySkillReviewEl('operatorMemorySkillReviewList');
+      if (list) list.append(_operatorMemorySkillReviewIssue(message));
+      return result || null;
+    }
+    _operatorMemorySkillReviewLastPayload = null;
+    await refreshOperatorMemorySkillReview({force:true});
+    if (typeof showToast === 'function') showToast('Memory/skill review decision recorded.', 2200);
+    return result;
+  } catch(err) {
+    const list = _operatorMemorySkillReviewEl('operatorMemorySkillReviewList');
+    if (list) list.append(_operatorMemorySkillReviewIssue((err && err.message) || 'decision failed'));
+    return null;
+  }
+}
+
+function initOperatorMemorySkillReview(){
+  const chip = _operatorMemorySkillReviewEl('operatorMemorySkillReviewChip');
+  const label = _operatorMemorySkillReviewEl('operatorMemorySkillReviewLabel');
+  if (chip) {
+    chip.hidden = false;
+    chip.title = 'Memory and skill review queue · not checked yet';
+  }
+  if (label) label.textContent = 'Memory Review';
+}
+
+window.toggleOperatorMemorySkillReview = toggleOperatorMemorySkillReview;
+window.refreshOperatorMemorySkillReview = refreshOperatorMemorySkillReview;
+window.renderOperatorMemorySkillReview = renderOperatorMemorySkillReview;
+window.hideOperatorMemorySkillReview = hideOperatorMemorySkillReview;
+window.submitOperatorMemorySkillReviewDecision = submitOperatorMemorySkillReviewDecision;
+
+initOperatorMemorySkillReview();

--- a/static/operator_proposals.js
+++ b/static/operator_proposals.js
@@ -1,0 +1,297 @@
+let _operatorProposalLastFetchKey = '';
+let _operatorProposalLastPayload = null;
+let _operatorProposalInFlight = null;
+let _operatorProposalInFlightKey = '';
+let _operatorProposalRequestSeq = 0;
+const _operatorProposalHiddenIds = new Set();
+
+function _operatorProposalEl(id){
+  if (typeof $ === 'function') return $(id);
+  return document.getElementById(id);
+}
+
+function operatorProposalContextKey(){
+  if (typeof operatorTruthContextKey === 'function') return operatorTruthContextKey();
+  const session = (S && S.session) || {};
+  return JSON.stringify({
+    session_id: (session.session_id || session.id || ''),
+    ui_board: (typeof operatorTruthBoardHint === 'function') ? operatorTruthBoardHint() : '',
+    profile: (S && S.activeProfile) || '',
+    workspace: session.workspace || '',
+  });
+}
+
+function _operatorProposalStateClass(state){
+  if (state === 'live') return 'state-live';
+  if (state === 'stale') return 'state-stale';
+  return 'state-unknown';
+}
+
+function _operatorProposalApplyChip(payload){
+  const chip = _operatorProposalEl('operatorProposalChip');
+  const label = _operatorProposalEl('operatorProposalLabel');
+  if (!chip) return;
+  const status = (payload && payload.status) || 'unknown';
+  chip.hidden = false;
+  chip.classList.remove('state-live','state-stale','state-unknown');
+  chip.classList.add(_operatorProposalStateClass(status));
+  const count = payload && Array.isArray(payload.proposals) ? payload.proposals.length : 0;
+  if (label) label.textContent = count ? 'Proposals ' + count : 'Proposals';
+  chip.title = (payload && payload.summary) || 'Manual next-action proposals';
+}
+
+function _operatorProposalText(value, fallback){
+  const text = String(value || '').trim();
+  return text || fallback || '';
+}
+
+function _operatorProposalButton(text, className, onClick){
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = className;
+  btn.textContent = text;
+  btn.onclick = onClick;
+  return btn;
+}
+
+function _operatorProposalRow(label, value){
+  const row = document.createElement('div');
+  row.className = 'operator-proposal-row';
+  const key = document.createElement('span');
+  key.className = 'operator-proposal-row-key';
+  key.textContent = label;
+  const val = document.createElement('span');
+  val.className = 'operator-proposal-row-value';
+  val.textContent = value;
+  row.append(key, val);
+  return row;
+}
+
+function _operatorProposalEvidenceText(ev){
+  const parts = [];
+  if (ev && ev.source_id) parts.push(String(ev.source_id));
+  if (ev && ev.status) parts.push(String(ev.status));
+  if (ev && ev.field) parts.push(String(ev.field));
+  if (ev && ev.path) parts.push(String(ev.path));
+  if (ev && ev.api) parts.push(String(ev.api));
+  return parts.join(' · ');
+}
+
+function _operatorProposalCard(proposal){
+  const card = document.createElement('div');
+  card.className = 'operator-proposal-card';
+  card.dataset.proposalId = proposal.id || '';
+
+  const top = document.createElement('div');
+  top.className = 'operator-proposal-card-top';
+  const title = document.createElement('div');
+  title.className = 'operator-proposal-card-title';
+  title.textContent = '#' + _operatorProposalText(proposal.rank, '?') + ' · ' + _operatorProposalText(proposal.title, 'Untitled proposal');
+  const badge = document.createElement('span');
+  badge.className = 'operator-proposal-no-exec';
+  badge.textContent = 'would_execute:false';
+  top.append(title, badge);
+  card.append(top);
+
+  const summary = document.createElement('div');
+  summary.className = 'operator-proposal-summary';
+  summary.textContent = _operatorProposalText(proposal.summary, 'No summary available.');
+  card.append(summary);
+
+  card.append(_operatorProposalRow('Side effect', _operatorProposalText(proposal.side_effect_level, 'manual draft only')));
+  card.append(_operatorProposalRow('Owner', _operatorProposalText(proposal.owner, 'future Hermes session')));
+
+  const evidence = document.createElement('div');
+  evidence.className = 'operator-proposal-evidence';
+  const evidenceTitle = document.createElement('div');
+  evidenceTitle.className = 'operator-proposal-section-title';
+  evidenceTitle.textContent = 'Evidence';
+  evidence.append(evidenceTitle);
+  const evs = Array.isArray(proposal.evidence) ? proposal.evidence.slice(0, 5) : [];
+  if (!evs.length) {
+    const empty = document.createElement('div');
+    empty.className = 'operator-proposal-muted';
+    empty.textContent = 'No evidence listed.';
+    evidence.append(empty);
+  } else {
+    evs.forEach(ev => {
+      const item = document.createElement('div');
+      item.className = 'operator-proposal-evidence-item';
+      item.textContent = _operatorProposalEvidenceText(ev);
+      evidence.append(item);
+    });
+  }
+  card.append(evidence);
+
+  const notes = Array.isArray(proposal.safety_notes) ? proposal.safety_notes.slice(0, 4) : [];
+  if (notes.length) {
+    const safety = document.createElement('div');
+    safety.className = 'operator-proposal-safety';
+    const safetyTitle = document.createElement('div');
+    safetyTitle.className = 'operator-proposal-section-title';
+    safetyTitle.textContent = 'Safety';
+    safety.append(safetyTitle);
+    notes.forEach(note => {
+      const item = document.createElement('div');
+      item.className = 'operator-proposal-muted';
+      item.textContent = String(note || '');
+      safety.append(item);
+    });
+    card.append(safety);
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'operator-proposal-actions';
+  actions.append(
+    _operatorProposalButton('Draft handoff', 'operator-proposal-action primary', () => draftOperatorProposal(proposal.id)),
+    _operatorProposalButton('Promote to commitment', 'operator-proposal-action', () => {
+      if (typeof openOperatorCommitmentPromote === 'function') openOperatorCommitmentPromote(proposal);
+    }),
+    _operatorProposalButton('Dismiss', 'operator-proposal-action', () => dismissOperatorProposal(proposal.id)),
+  );
+  card.append(actions);
+  return card;
+}
+
+function renderOperatorProposals(payload){
+  _operatorProposalLastPayload = payload || null;
+  _operatorProposalApplyChip(payload);
+  const popover = _operatorProposalEl('operatorProposalPopover');
+  const subtitle = _operatorProposalEl('operatorProposalSubtitle');
+  const list = _operatorProposalEl('operatorProposalList');
+  if (!popover || !list) return;
+  while (list.firstChild) list.removeChild(list.firstChild);
+
+  const status = (payload && payload.status) || 'unknown';
+  const proposals = ((payload && Array.isArray(payload.proposals)) ? payload.proposals : [])
+    .filter(item => item && !_operatorProposalHiddenIds.has(item.id));
+  if (subtitle) subtitle.textContent = (payload && payload.summary) || 'Not checked yet';
+  popover.classList.remove('state-live','state-stale','state-unknown');
+  popover.classList.add(_operatorProposalStateClass(status));
+
+  if (!proposals.length) {
+    const empty = document.createElement('div');
+    empty.className = 'operator-proposal-empty';
+    empty.textContent = status === 'unknown' ? 'No safe proposals — source unavailable.' : 'No proposals to show.';
+    list.append(empty);
+    const issues = payload && Array.isArray(payload.issues) ? payload.issues.slice(0, 4) : [];
+    issues.forEach(issue => {
+      const item = document.createElement('div');
+      item.className = 'operator-proposal-issue';
+      item.textContent = String(issue || '');
+      list.append(item);
+    });
+    return;
+  }
+
+  proposals.forEach(proposal => list.append(_operatorProposalCard(proposal)));
+}
+
+function hideOperatorProposals(){
+  const popover = _operatorProposalEl('operatorProposalPopover');
+  if (popover) popover.hidden = true;
+}
+
+function toggleOperatorProposals(opts = {}){
+  const popover = _operatorProposalEl('operatorProposalPopover');
+  if (!popover) return;
+  const opening = popover.hidden;
+  if (!opening && !opts.force) {
+    hideOperatorProposals();
+    return;
+  }
+  popover.hidden = false;
+  refreshOperatorProposals({force: Boolean(opts.force)});
+}
+
+async function refreshOperatorProposals(opts = {}){
+  const force = Boolean(opts.force);
+  const contextKey = operatorProposalContextKey();
+  if (!force && _operatorProposalInFlight && contextKey === _operatorProposalInFlightKey) return _operatorProposalInFlight;
+  if (!force && _operatorProposalLastPayload && contextKey === _operatorProposalLastFetchKey) {
+    renderOperatorProposals(_operatorProposalLastPayload);
+    return _operatorProposalLastPayload;
+  }
+  if (typeof api !== 'function') {
+    const payload = {status:'unknown', summary:'No safe proposals — API helper unavailable', proposals:[], issues:['api helper unavailable']};
+    renderOperatorProposals(payload);
+    return payload;
+  }
+
+  const params = new URLSearchParams();
+  const sid = (typeof operatorTruthSessionId === 'function') ? operatorTruthSessionId() : ((S && S.session && (S.session.session_id || S.session.id)) || '');
+  const board = (typeof operatorTruthBoardHint === 'function') ? operatorTruthBoardHint() : '';
+  if (sid) params.set('session_id', sid);
+  if (board) params.set('ui_board', board);
+  const base = '/api/operator/proposals';
+  const path = base + (params.toString() ? '?' + params.toString() : '');
+  const requestKey = contextKey;
+  const requestSeq = ++_operatorProposalRequestSeq;
+  _operatorProposalInFlightKey = requestKey;
+
+  _operatorProposalInFlight = api(path)
+    .then(payload => {
+      if (requestKey !== operatorProposalContextKey() || requestSeq !== _operatorProposalRequestSeq) return payload;
+      _operatorProposalLastFetchKey = requestKey;
+      _operatorProposalHiddenIds.clear();
+      renderOperatorProposals(payload);
+      return payload;
+    })
+    .catch(err => {
+      if (requestKey === operatorProposalContextKey() && requestSeq === _operatorProposalRequestSeq) {
+        const payload = {status:'unknown', summary:'No safe proposals — source unavailable', proposals:[], issues:[(err && err.message) || 'request failed']};
+        _operatorProposalLastFetchKey = requestKey;
+        renderOperatorProposals(payload);
+      }
+      return null;
+    })
+    .finally(() => {
+      if (requestKey === _operatorProposalInFlightKey && requestSeq === _operatorProposalRequestSeq) {
+        _operatorProposalInFlight = null;
+        _operatorProposalInFlightKey = '';
+      }
+    });
+  return _operatorProposalInFlight;
+}
+
+function _operatorProposalFind(proposalId){
+  const proposals = (_operatorProposalLastPayload && Array.isArray(_operatorProposalLastPayload.proposals)) ? _operatorProposalLastPayload.proposals : [];
+  return proposals.find(item => item && item.id === proposalId) || null;
+}
+
+function draftOperatorProposal(proposalId){
+  const proposal = _operatorProposalFind(proposalId);
+  if (!proposal) return;
+  const msg = _operatorProposalEl('msg');
+  if (!msg) return;
+  msg.value = proposal.handoff_prompt || ('Review proposal: ' + _operatorProposalText(proposal.title, proposal.id || 'operator proposal'));
+  if (typeof autoResize === 'function') autoResize();
+  if (typeof updateSendBtn === 'function') updateSendBtn();
+  msg.focus();
+  if (typeof showToast === 'function') showToast('Drafted handoff in composer. Review before running.', 2400);
+}
+
+function dismissOperatorProposal(proposalId){
+  if (proposalId) _operatorProposalHiddenIds.add(proposalId);
+  renderOperatorProposals(_operatorProposalLastPayload || {status:'unknown', proposals:[], issues:[]});
+}
+
+function initOperatorProposals(){
+  const chip = _operatorProposalEl('operatorProposalChip');
+  const label = _operatorProposalEl('operatorProposalLabel');
+  if (chip) {
+    chip.hidden = false;
+    chip.title = 'Manual next-action proposals · not checked yet';
+  }
+  if (label) label.textContent = 'Proposals';
+}
+
+window.toggleOperatorProposals = toggleOperatorProposals;
+window.refreshOperatorProposals = refreshOperatorProposals;
+window.renderOperatorProposals = renderOperatorProposals;
+window.hideOperatorProposals = hideOperatorProposals;
+window.draftOperatorProposal = draftOperatorProposal;
+window.dismissOperatorProposal = dismissOperatorProposal;
+window.operatorProposalContextKey = operatorProposalContextKey;
+
+initOperatorProposals();

--- a/static/operator_session_recall.js
+++ b/static/operator_session_recall.js
@@ -1,0 +1,649 @@
+let _operatorSessionRecallLastPayload = null;
+let _operatorSessionRecallRequestSeq = 0;
+let _operatorSessionRecallMemoryReviewDraftEvidence = null;
+
+function _operatorSessionRecallEl(id){
+  if (typeof $ === 'function') return $(id);
+  return document.getElementById(id);
+}
+
+function _operatorSessionRecallText(value, fallback){
+  const text = String(value == null ? '' : value).trim();
+  return text || fallback || '';
+}
+
+function _operatorSessionRecallStateClass(state){
+  const value = _operatorSessionRecallText(state, 'unknown').toLowerCase();
+  if (value === 'live') return 'state-live';
+  if (value === 'stale') return 'state-stale';
+  return 'state-unknown';
+}
+
+function _operatorSessionRecallClear(el){
+  if (!el) return;
+  while (el.firstChild) el.removeChild(el.firstChild);
+}
+
+function _operatorSessionRecallDefaultPayload(){
+  return {
+    status: 'unknown',
+    summary: 'Enter a query and press Search to recall saved sessions.',
+    query: {text: ''},
+    sources: [],
+    results: [],
+    count: 0,
+    issues: [],
+    would_execute: false,
+  };
+}
+
+function _operatorSessionRecallBlankPayload(){
+  return {
+    status: 'unknown',
+    summary: 'Enter a query and press Search to recall saved sessions — no source queried yet.',
+    query: {text: ''},
+    sources: [],
+    results: [],
+    count: 0,
+    issues: ['query is required for session recall'],
+    would_execute: false,
+  };
+}
+
+function _operatorSessionRecallUnavailablePayload(query, issue){
+  return {
+    status: 'unknown',
+    summary: 'Session recall source unavailable for query: ' + _operatorSessionRecallText(query, 'unknown'),
+    query: {text: _operatorSessionRecallText(query, '')},
+    sources: [],
+    results: [],
+    count: 0,
+    issues: [_operatorSessionRecallText(issue, 'session recall request failed')],
+    would_execute: false,
+  };
+}
+
+function _operatorSessionRecallQueryText(payload){
+  if (!payload || !payload.query) return '';
+  if (typeof payload.query === 'string') return _operatorSessionRecallText(payload.query, '');
+  return _operatorSessionRecallText(payload.query.text, '');
+}
+
+function _operatorSessionRecallTimestamp(value){
+  const raw = _operatorSessionRecallText(value, '');
+  if (!raw) return 'timestamp unknown';
+  const numeric = Number(raw);
+  if (Number.isFinite(numeric)) {
+    const millis = numeric > 100000000000 ? numeric : numeric * 1000;
+    const date = new Date(millis);
+    if (!Number.isNaN(date.getTime())) return date.toISOString();
+  }
+  return raw;
+}
+
+function _operatorSessionRecallRecency(result){
+  const recency = result && result.recency ? result.recency : {};
+  return _operatorSessionRecallText(recency.label || result.recency_label, 'unknown').toLowerCase();
+}
+
+function _operatorSessionRecallHasOwn(obj, key){
+  return Boolean(obj && typeof obj === 'object' && Object.prototype.hasOwnProperty.call(obj, key));
+}
+
+function _operatorSessionRecallWouldExecuteFieldState(value){
+  if (value === true) return 'true';
+  if (value === false) return 'false';
+  if (typeof value === 'string' && value.trim().toLowerCase() === 'true') return 'true';
+  return 'unknown';
+}
+
+function _operatorSessionRecallWouldExecuteFields(result){
+  const promotion = result && result.promotion ? result.promotion : {};
+  const fields = [];
+  if (_operatorSessionRecallHasOwn(result, 'would_execute')) fields.push(result.would_execute);
+  if (_operatorSessionRecallHasOwn(promotion.task, 'would_execute')) fields.push(promotion.task.would_execute);
+  if (_operatorSessionRecallHasOwn(promotion.memory_review, 'would_execute')) fields.push(promotion.memory_review.would_execute);
+  return fields;
+}
+
+function _operatorSessionRecallWouldExecuteState(result){
+  const states = _operatorSessionRecallWouldExecuteFields(result).map(_operatorSessionRecallWouldExecuteFieldState);
+  if (states.includes('true')) return 'true';
+  if (states.includes('unknown')) return 'unknown';
+  if (states.includes('false')) return 'false';
+  return 'unknown';
+}
+
+function _operatorSessionRecallWouldExecuteFieldsSafe(result){
+  return _operatorSessionRecallWouldExecuteFields(result).every(value => value === false);
+}
+
+function _operatorSessionRecallWouldExecute(result){
+  return _operatorSessionRecallWouldExecuteState(result) === 'true';
+}
+
+function _operatorSessionRecallHasValue(value){
+  return value != null && String(value).trim() !== '';
+}
+
+function _operatorSessionRecallValidMessageIndex(value){
+  if (typeof value === 'number') return Number.isInteger(value) && value >= 0;
+  if (typeof value === 'string') {
+    const text = value.trim();
+    if (!/^\d+$/.test(text)) return false;
+    const numeric = Number(text);
+    return Number.isSafeInteger(numeric) && numeric >= 0;
+  }
+  return false;
+}
+
+function _operatorSessionRecallValidContentHash(value){
+  return /^sha256:[0-9a-f]{64}$/i.test(_operatorSessionRecallText(value, ''));
+}
+
+function _operatorSessionRecallSecretValueRedacted(value){
+  const token = _operatorSessionRecallText(value, '').replace(/^["']|["']$/g, '').trim();
+  const normalized = token.replace(/^[\[\](){}<>]+|[\[\](){}<>]+$/g, '').toLowerCase();
+  if (['redacted','masked','hidden','removed','withheld','scrubbed'].includes(normalized)) return true;
+  const compact = token.replace(/\s/g, '');
+  return Boolean(compact) && /^[*xX•…]+$/.test(compact);
+}
+
+function _operatorSessionRecallQuoteContainsRawSecret(quote){
+  const text = _operatorSessionRecallText(quote, '');
+  const keyedSecret = /\b(?:password|passwd|pwd|token|access[_\-\s]?token|refresh[_\-\s]?token|auth[_\-\s]?token|api[_\-\s]?key|apikey|secret|client[_\-\s]?secret|private[_\-\s]?key|authorization)\b\s*[:=]\s*(["']?[^"'\s,;]+["']?)/ig;
+  let match;
+  while ((match = keyedSecret.exec(text)) !== null) {
+    if (!_operatorSessionRecallSecretValueRedacted(match[1])) return true;
+  }
+  return (
+    /\bBearer\s+[A-Za-z0-9._~+/=-]{16,}(?=$|[^A-Za-z0-9._~+/=-])/i.test(text) ||
+    /\bsk-[A-Za-z0-9][A-Za-z0-9_-]{16,}(?=$|[^A-Za-z0-9_-])/i.test(text) ||
+    /\bxox[abp]-[0-9A-Za-z-]{10,}(?=$|[^0-9A-Za-z-])/i.test(text) ||
+    /\bghp_[A-Za-z0-9_]{16,}(?![A-Za-z0-9_])/i.test(text) ||
+    /\bgithub_pat_[A-Za-z0-9_]{16,}(?![A-Za-z0-9_])/i.test(text)
+  );
+}
+
+function _operatorSessionRecallCommitmentSource(result){
+  result = result || {};
+  const promotion = result.promotion || {};
+  const task = promotion.task || {};
+  const source = (task.source && typeof task.source === 'object') ? task.source : {};
+  return {
+    kind: _operatorSessionRecallText(source.kind, ''),
+    session_id: _operatorSessionRecallText(source.session_id, ''),
+    message_index: source.message_index == null ? '' : source.message_index,
+    content_hash: _operatorSessionRecallText(source.content_hash, ''),
+    quote: _operatorSessionRecallText(source.quote, ''),
+  };
+}
+
+function _operatorSessionRecallHasCompleteSessionMessageProof(source){
+  return Boolean(
+    source &&
+    source.kind === 'session_message' &&
+    _operatorSessionRecallHasValue(source.session_id) &&
+    _operatorSessionRecallValidMessageIndex(source.message_index) &&
+    _operatorSessionRecallValidContentHash(source.content_hash) &&
+    _operatorSessionRecallHasValue(source.quote) &&
+    !_operatorSessionRecallQuoteContainsRawSecret(source.quote)
+  );
+}
+
+function _operatorSessionRecallCanPromoteTask(result){
+  if (!result || !_operatorSessionRecallWouldExecuteFieldsSafe(result)) return false;
+  const promotion = result.promotion || {};
+  const task = promotion.task || {};
+  if (task.enabled !== true) return false;
+  if (_operatorSessionRecallText(task.mode, '') !== 'local_commitment_draft') return false;
+  if (task.would_execute !== false) return false;
+  const source = _operatorSessionRecallCommitmentSource(result);
+  return _operatorSessionRecallHasCompleteSessionMessageProof(source);
+}
+
+function _operatorSessionRecallMemoryReviewSourceEvidence(result){
+  result = result || {};
+  const promotion = result.promotion || {};
+  const memoryReview = promotion.memory_review || {};
+  if (!Array.isArray(memoryReview.source_evidence) || !memoryReview.source_evidence.length) return null;
+  const source = memoryReview.source_evidence[0];
+  if (!source || typeof source !== 'object') return null;
+  if (typeof source.kind !== 'string') return null;
+  if (typeof source.session_id !== 'string') return null;
+  if (typeof source.content_hash !== 'string') return null;
+  if (typeof source.quote !== 'string') return null;
+  if (!(typeof source.message_index === 'number' || typeof source.message_index === 'string')) return null;
+  return {
+    kind: _operatorSessionRecallText(source.kind, ''),
+    session_id: _operatorSessionRecallText(source.session_id, ''),
+    message_index: source.message_index,
+    content_hash: _operatorSessionRecallText(source.content_hash, ''),
+    quote: _operatorSessionRecallText(source.quote, ''),
+  };
+}
+
+function _operatorSessionRecallCanPromoteMemoryReview(result){
+  if (!result || !_operatorSessionRecallWouldExecuteFieldsSafe(result)) return false;
+  const promotion = result.promotion || {};
+  const memoryReview = promotion.memory_review || {};
+  if (memoryReview.enabled === false) return false;
+  if (memoryReview.would_execute !== false) return false;
+  const mode = _operatorSessionRecallText(memoryReview.mode, 'local_memory_skill_review_proposal');
+  if (!['local_memory_skill_review_proposal','memory_skill_review_proposal','local_review_queue_proposal'].includes(mode)) return false;
+  const source = _operatorSessionRecallMemoryReviewSourceEvidence(result);
+  return _operatorSessionRecallHasCompleteSessionMessageProof(source);
+}
+
+function _operatorSessionRecallOpenCommitmentDraft(result){
+  if (typeof window !== 'undefined' && typeof window.openOperatorCommitmentPromoteFromRecall === 'function') {
+    window.openOperatorCommitmentPromoteFromRecall(result);
+    return true;
+  }
+  if (typeof openOperatorCommitmentPromoteFromRecall === 'function') {
+    openOperatorCommitmentPromoteFromRecall(result);
+    return true;
+  }
+  return false;
+}
+
+function _operatorSessionRecallSetText(id, value){
+  const el = _operatorSessionRecallEl(id);
+  if (el) el.textContent = _operatorSessionRecallText(value, '');
+}
+
+function _operatorSessionRecallFieldValue(id){
+  const el = _operatorSessionRecallEl(id);
+  return el ? _operatorSessionRecallText(el.value, '') : '';
+}
+
+function _operatorSessionRecallSetFieldValue(id, value){
+  const el = _operatorSessionRecallEl(id);
+  if (el) el.value = value == null ? '' : String(value);
+}
+
+function _operatorSessionRecallMemoryProposalStatus(message){
+  _operatorSessionRecallSetText('operatorSessionRecallMemoryProposalStatus', message);
+}
+
+function _operatorSessionRecallMemoryProposalDiff(content){
+  const lines = String(content == null ? '' : content).split('\n');
+  const added = lines.map(line => '+' + line).join('\n');
+  return '--- previous\n+++ proposed\n@@\n' + added + '\n';
+}
+
+function _operatorSessionRecallResetMemoryProposalFields(source){
+  _operatorSessionRecallSetFieldValue('operatorSessionRecallMemoryProposalTargetKind', '');
+  _operatorSessionRecallSetFieldValue('operatorSessionRecallMemoryProposalTargetSection', '');
+  _operatorSessionRecallSetFieldValue('operatorSessionRecallMemoryProposalTargetName', '');
+  _operatorSessionRecallSetFieldValue('operatorSessionRecallMemoryProposalTargetCategory', '');
+  _operatorSessionRecallSetFieldValue('operatorSessionRecallMemoryProposalSummary', '');
+  _operatorSessionRecallSetFieldValue('operatorSessionRecallMemoryProposalContent', '');
+  _operatorSessionRecallSetText('operatorSessionRecallMemoryProposalEvidenceSessionId', source.session_id);
+  _operatorSessionRecallSetText('operatorSessionRecallMemoryProposalEvidenceMessageIndex', source.message_index);
+  _operatorSessionRecallSetText('operatorSessionRecallMemoryProposalEvidenceContentHash', source.content_hash);
+  _operatorSessionRecallSetText('operatorSessionRecallMemoryProposalEvidenceQuote', source.quote);
+  _operatorSessionRecallMemoryProposalStatus('Source evidence loaded. Enter target and proposed change fields to save a local proposal.');
+}
+
+function _operatorSessionRecallMemoryProposalTarget(){
+  const kind = _operatorSessionRecallFieldValue('operatorSessionRecallMemoryProposalTargetKind').toLowerCase();
+  if (kind === 'memory') {
+    const section = _operatorSessionRecallFieldValue('operatorSessionRecallMemoryProposalTargetSection').toLowerCase();
+    if (!['memory','user','soul'].includes(section)) return {error: 'target memory section is required'};
+    return {value: {kind: 'memory', section: section}};
+  }
+  if (kind === 'skill') {
+    const name = _operatorSessionRecallFieldValue('operatorSessionRecallMemoryProposalTargetName');
+    if (!name) return {error: 'target skill name is required'};
+    const target = {kind: 'skill', name: name};
+    const category = _operatorSessionRecallFieldValue('operatorSessionRecallMemoryProposalTargetCategory');
+    if (category) target.category = category;
+    return {value: target};
+  }
+  return {error: 'target kind is required'};
+}
+
+function _operatorSessionRecallBuildMemoryProposalPayload(){
+  const source = _operatorSessionRecallMemoryReviewDraftEvidence;
+  if (!_operatorSessionRecallHasCompleteSessionMessageProof(source)) return {error: 'source_evidence session_message proof is required'};
+  const targetResult = _operatorSessionRecallMemoryProposalTarget();
+  if (targetResult.error) return {error: targetResult.error};
+
+  const operation = _operatorSessionRecallFieldValue('operatorSessionRecallMemoryProposalOperation').toLowerCase();
+  if (!['append','edit','delete'].includes(operation)) return {error: 'proposed_change operation is required'};
+  const summary = _operatorSessionRecallFieldValue('operatorSessionRecallMemoryProposalSummary');
+  if (!summary) return {error: 'proposed_change summary is required'};
+  const content = _operatorSessionRecallFieldValue('operatorSessionRecallMemoryProposalContent');
+  if (!content) return {error: 'proposed_change content is required'};
+
+  const durability = _operatorSessionRecallFieldValue('operatorSessionRecallMemoryProposalClassificationDurability').toLowerCase();
+  if (!['durable','transient','unknown'].includes(durability)) return {error: 'classification durability is required'};
+  const classificationReason = _operatorSessionRecallFieldValue('operatorSessionRecallMemoryProposalClassificationReason');
+  if (!classificationReason) return {error: 'classification reason is required'};
+  const transientRisk = _operatorSessionRecallFieldValue('operatorSessionRecallMemoryProposalTransientRisk').toLowerCase();
+  if (!['low','medium','high'].includes(transientRisk)) return {error: 'classification transient risk is required'};
+
+  const staleState = _operatorSessionRecallFieldValue('operatorSessionRecallMemoryProposalStaleState').toLowerCase();
+  if (!['current','review_required','expired'].includes(staleState)) return {error: 'stale_risk state is required'};
+  const expiresAt = _operatorSessionRecallFieldValue('operatorSessionRecallMemoryProposalExpiresAt');
+  if (!expiresAt) return {error: 'stale_risk expires_at is required'};
+  const staleReason = _operatorSessionRecallFieldValue('operatorSessionRecallMemoryProposalStaleReason');
+  if (!staleReason) return {error: 'stale_risk reason is required'};
+
+  return {
+    value: {
+      target: targetResult.value,
+      proposed_change: {
+        operation: operation,
+        summary: summary,
+        diff: _operatorSessionRecallMemoryProposalDiff(content),
+        proposed_content: content,
+      },
+      source_evidence: [source],
+      classification: {
+        durability: durability,
+        reason: classificationReason,
+        transient_risk: transientRisk,
+      },
+      stale_risk: {
+        state: staleState,
+        expires_at: expiresAt,
+        reason: staleReason,
+      },
+      would_execute: false,
+    },
+  };
+}
+
+function openOperatorSessionRecallMemoryProposal(result){
+  const source = _operatorSessionRecallMemoryReviewSourceEvidence(result);
+  if (!_operatorSessionRecallHasCompleteSessionMessageProof(source)) {
+    _operatorSessionRecallMemoryReviewDraftEvidence = null;
+    _operatorSessionRecallMemoryProposalStatus('Cannot draft memory/skill review: explicit safe session_message source_evidence is required.');
+    return false;
+  }
+  _operatorSessionRecallMemoryReviewDraftEvidence = source;
+  _operatorSessionRecallResetMemoryProposalFields(source);
+  const panel = _operatorSessionRecallEl('operatorSessionRecallMemoryProposalPanel');
+  if (panel) panel.hidden = false;
+  return true;
+}
+
+function cancelOperatorSessionRecallMemoryProposal(){
+  _operatorSessionRecallMemoryReviewDraftEvidence = null;
+  const panel = _operatorSessionRecallEl('operatorSessionRecallMemoryProposalPanel');
+  if (panel) panel.hidden = true;
+  _operatorSessionRecallMemoryProposalStatus('');
+}
+
+async function submitOperatorSessionRecallMemoryProposal(event){
+  if (event && typeof event.preventDefault === 'function') event.preventDefault();
+  const built = _operatorSessionRecallBuildMemoryProposalPayload();
+  if (!built.value) {
+    _operatorSessionRecallMemoryProposalStatus(built.error || 'memory/skill review proposal is incomplete');
+    return null;
+  }
+  if (typeof api !== 'function') {
+    _operatorSessionRecallMemoryProposalStatus('api helper unavailable; proposal not saved');
+    return null;
+  }
+  _operatorSessionRecallMemoryProposalStatus('Saving local memory/skill review proposal…');
+  try {
+    const result = await api('/api/operator/memory-skill-review/propose', {method: 'POST', body: JSON.stringify(built.value)});
+    if (!result || result.ok !== true) {
+      const message = (result && (result.error || result.message)) || 'memory/skill review proposal failed';
+      _operatorSessionRecallMemoryProposalStatus(message);
+      return result || null;
+    }
+    _operatorSessionRecallMemoryProposalStatus('Local memory/skill review proposal saved. Nothing was applied.');
+    if (typeof refreshOperatorMemorySkillReview === 'function') {
+      await refreshOperatorMemorySkillReview({force: true});
+    }
+    return result;
+  } catch (err) {
+    _operatorSessionRecallMemoryProposalStatus((err && err.message) || 'memory/skill review proposal failed');
+    return null;
+  }
+}
+
+function _operatorSessionRecallRow(label, value){
+  const row = document.createElement('div');
+  row.className = 'operator-session-recall-source';
+  const key = document.createElement('span');
+  key.className = 'operator-session-recall-source-label';
+  key.textContent = label;
+  const val = document.createElement('span');
+  val.className = 'operator-session-recall-source-value';
+  val.textContent = value;
+  row.append(key, val);
+  return row;
+}
+
+function _operatorSessionRecallEmpty(message, sourceMessage){
+  const empty = document.createElement('div');
+  empty.className = 'operator-session-recall-card operator-session-recall-empty operator-session-recall-stale';
+  const snippet = document.createElement('div');
+  snippet.className = 'operator-session-recall-snippet';
+  snippet.textContent = message;
+  const source = document.createElement('div');
+  source.className = 'operator-session-recall-source operator-session-recall-stale';
+  source.textContent = sourceMessage || 'No session source queried yet.';
+  const action = document.createElement('div');
+  action.className = 'operator-session-recall-action';
+  action.textContent = 'would_execute=false';
+  empty.append(snippet, source, action);
+  return empty;
+}
+
+function _operatorSessionRecallIssue(message){
+  const issue = document.createElement('div');
+  issue.className = 'operator-session-recall-issue operator-session-recall-stale';
+  issue.textContent = _operatorSessionRecallText(message, 'unknown issue');
+  return issue;
+}
+
+function _operatorSessionRecallCard(result){
+  result = result || {};
+  const session = result.session || {};
+  const match = result.match || {};
+  const card = document.createElement('div');
+  card.className = 'operator-session-recall-card';
+
+  const recencyLabel = _operatorSessionRecallRecency(result);
+  if (recencyLabel === 'historical') card.classList.add('operator-session-recall-historical');
+  if (recencyLabel === 'stale' || recencyLabel === 'unknown' || result.stale) card.classList.add('operator-session-recall-stale');
+
+  const top = document.createElement('div');
+  top.className = 'operator-session-recall-source';
+  const title = document.createElement('span');
+  title.className = 'operator-session-recall-title';
+  title.textContent = _operatorSessionRecallText(session.title || result.title, 'Untitled session');
+  const badge = document.createElement('span');
+  badge.className = 'operator-session-recall-action';
+  badge.textContent = 'would_execute=' + _operatorSessionRecallWouldExecuteState(result);
+  top.append(title, badge);
+  card.append(top);
+
+  const snippet = document.createElement('div');
+  snippet.className = 'operator-session-recall-snippet';
+  snippet.textContent = _operatorSessionRecallText(match.snippet || result.snippet, 'No snippet available.');
+  card.append(snippet);
+
+  const sessionId = _operatorSessionRecallText(session.session_id || result.session_id, 'session_id unknown');
+  const sourceLabel = _operatorSessionRecallText(session.source_label || result.source_label || result.source, 'source_label unknown');
+  const timestamp = _operatorSessionRecallTimestamp(match.timestamp || result.timestamp);
+  card.append(
+    _operatorSessionRecallRow('session_id', sessionId),
+    _operatorSessionRecallRow('source_label', sourceLabel),
+    _operatorSessionRecallRow('timestamp', timestamp),
+    _operatorSessionRecallRow('recency', recencyLabel),
+  );
+
+  if (result.recency && result.recency.reason) {
+    card.append(_operatorSessionRecallRow('recency_reason', _operatorSessionRecallText(result.recency.reason, 'unknown')));
+  }
+
+  const actionButtons = [];
+  if (_operatorSessionRecallCanPromoteTask(result)) {
+    const promote = document.createElement('button');
+    promote.type = 'button';
+    promote.className = 'operator-session-recall-action primary';
+    promote.textContent = 'Draft local task';
+    promote.title = 'Open a local commitment draft only; no Kanban or chat action.';
+    promote.addEventListener('click', () => {
+      _operatorSessionRecallOpenCommitmentDraft(result);
+    });
+    actionButtons.push(promote);
+  }
+  if (_operatorSessionRecallCanPromoteMemoryReview(result)) {
+    const proposeMemory = document.createElement('button');
+    proposeMemory.type = 'button';
+    proposeMemory.className = 'operator-session-recall-action primary';
+    proposeMemory.textContent = 'Draft memory/skill review';
+    proposeMemory.title = 'Seed a local memory/skill review proposal only; no apply or file write.';
+    proposeMemory.addEventListener('click', () => {
+      openOperatorSessionRecallMemoryProposal(result);
+    });
+    actionButtons.push(proposeMemory);
+  }
+  if (actionButtons.length) {
+    const actions = document.createElement('div');
+    actions.className = 'operator-session-recall-actions';
+    actionButtons.forEach(button => actions.append(button));
+    card.append(actions);
+  }
+
+  return card;
+}
+
+function renderOperatorSessionRecall(payload){
+  payload = payload || _operatorSessionRecallDefaultPayload();
+  _operatorSessionRecallLastPayload = payload;
+
+  const chip = _operatorSessionRecallEl('operatorSessionRecallChip');
+  const label = _operatorSessionRecallEl('operatorSessionRecallLabel');
+  const results = Array.isArray(payload.results) ? payload.results : [];
+  if (chip) {
+    chip.hidden = false;
+    chip.classList.remove('state-live','state-stale','state-unknown');
+    chip.classList.add(_operatorSessionRecallStateClass(payload.status));
+    chip.title = _operatorSessionRecallText(payload.summary, 'Manual session recall');
+  }
+  if (label) label.textContent = results.length ? 'Recall ' + results.length : 'Recall';
+
+  const popover = _operatorSessionRecallEl('operatorSessionRecallPopover');
+  const status = _operatorSessionRecallEl('operatorSessionRecallStatus');
+  const list = _operatorSessionRecallEl('operatorSessionRecallList');
+  if (!popover || !list) return payload;
+
+  popover.classList.remove('state-live','state-stale','state-unknown');
+  popover.classList.add(_operatorSessionRecallStateClass(payload.status));
+  if (status) status.textContent = _operatorSessionRecallText(payload.summary, 'Manual session recall — search on demand only');
+
+  _operatorSessionRecallClear(list);
+  const query = _operatorSessionRecallQueryText(payload);
+  if (query) {
+    list.append(_operatorSessionRecallRow('query', query));
+  }
+
+  if (!results.length) {
+    const message = query ? 'No source-backed session recall results for this query.' : 'Enter a query and press Search to recall saved sessions.';
+    const sourceMessage = query ? 'Search completed or source unavailable; no fake results shown.' : 'No session source queried yet.';
+    list.append(_operatorSessionRecallEmpty(message, sourceMessage));
+  } else {
+    results.forEach(result => list.append(_operatorSessionRecallCard(result)));
+  }
+
+  const issues = Array.isArray(payload.issues) ? payload.issues : [];
+  issues.slice(0, 5).forEach(issue => list.append(_operatorSessionRecallIssue(issue)));
+  return payload;
+}
+
+async function refreshOperatorSessionRecall(opts = {}){
+  const input = _operatorSessionRecallEl('operatorSessionRecallInput');
+  const query = input ? _operatorSessionRecallText(input.value, '') : '';
+  const force = Boolean(opts.force);
+  if (!query) {
+    _operatorSessionRecallRequestSeq += 1;
+    return renderOperatorSessionRecall(_operatorSessionRecallBlankPayload());
+  }
+  if (typeof api !== 'function') {
+    return renderOperatorSessionRecall(_operatorSessionRecallUnavailablePayload(query, 'api helper unavailable'));
+  }
+
+  const params = new URLSearchParams();
+  params.set('q', query);
+  params.set('limit', '20');
+  params.set('per_session', '2');
+
+  const requestSeq = ++_operatorSessionRecallRequestSeq;
+  const pendingSummary = (force ? 'Refreshing' : 'Searching') + ' saved sessions for query: ' + query;
+  renderOperatorSessionRecall({
+    status: 'stale',
+    summary: pendingSummary,
+    query: {text: query},
+    sources: [],
+    results: [],
+    count: 0,
+    issues: [],
+    would_execute: false,
+  });
+
+  try {
+    const payload = await api('/api/operator/session-recall?' + params.toString());
+    if (requestSeq !== _operatorSessionRecallRequestSeq) return payload;
+    return renderOperatorSessionRecall(payload);
+  } catch (err) {
+    if (requestSeq !== _operatorSessionRecallRequestSeq) return null;
+    const message = err && err.message ? err.message : 'session recall request failed';
+    return renderOperatorSessionRecall(_operatorSessionRecallUnavailablePayload(query, message));
+  }
+}
+
+function hideOperatorSessionRecall(){
+  const popover = _operatorSessionRecallEl('operatorSessionRecallPopover');
+  if (popover) popover.hidden = true;
+}
+
+function toggleOperatorSessionRecall(opts = {}){
+  const popover = _operatorSessionRecallEl('operatorSessionRecallPopover');
+  if (!popover) return;
+  const opening = popover.hidden;
+  if (!opening && !opts.force) {
+    hideOperatorSessionRecall();
+    return;
+  }
+  popover.hidden = false;
+  renderOperatorSessionRecall(_operatorSessionRecallLastPayload);
+  const input = _operatorSessionRecallEl('operatorSessionRecallInput');
+  if (input && typeof input.focus === 'function') input.focus();
+}
+
+function initOperatorSessionRecall(){
+  const chip = _operatorSessionRecallEl('operatorSessionRecallChip');
+  const label = _operatorSessionRecallEl('operatorSessionRecallLabel');
+  const input = _operatorSessionRecallEl('operatorSessionRecallInput');
+  if (chip) {
+    chip.hidden = false;
+    chip.title = 'Manual session recall · search on demand only';
+  }
+  if (label) label.textContent = 'Recall';
+  if (input && !input.dataset.sessionRecallBound) {
+    input.dataset.sessionRecallBound = '1';
+    input.addEventListener('keydown', event => {
+      if (event.key !== 'Enter') return;
+      event.preventDefault();
+      refreshOperatorSessionRecall();
+    });
+  }
+  renderOperatorSessionRecall(_operatorSessionRecallLastPayload);
+}
+
+window.toggleOperatorSessionRecall = toggleOperatorSessionRecall;
+window.refreshOperatorSessionRecall = refreshOperatorSessionRecall;
+window.renderOperatorSessionRecall = renderOperatorSessionRecall;
+window.initOperatorSessionRecall = initOperatorSessionRecall;
+window.hideOperatorSessionRecall = hideOperatorSessionRecall;
+
+initOperatorSessionRecall();

--- a/static/operator_truth.js
+++ b/static/operator_truth.js
@@ -1,0 +1,202 @@
+let _operatorTruthLastFetchAt = 0;
+let _operatorTruthLastFetchKey = '';
+let _operatorTruthInFlight = null;
+let _operatorTruthInFlightKey = '';
+let _operatorTruthRequestSeq = 0;
+const OPERATOR_TRUTH_TTL_MS = 30000;
+
+function operatorTruthSessionId(){
+  return (S && S.session && (S.session.session_id || S.session.id)) || '';
+}
+
+function operatorTruthBoardHint(){
+  try {
+    if (typeof _kanbanCurrentBoard !== 'undefined' && _kanbanCurrentBoard) return _kanbanCurrentBoard;
+  } catch(_) {}
+  return '';
+}
+
+function operatorTruthContextKey(){
+  const session = (S && S.session) || {};
+  return JSON.stringify({
+    session_id: operatorTruthSessionId(),
+    ui_board: operatorTruthBoardHint(),
+    profile: (S && S.activeProfile) || '',
+    workspace: session.workspace || '',
+    profile_default_workspace: (S && S._profileDefaultWorkspace) || '',
+    profile_switch_workspace: (S && S._profileSwitchWorkspace) || '',
+  });
+}
+
+function _operatorTruthChip(payload, id){
+  const chips = (payload && Array.isArray(payload.chips)) ? payload.chips : [];
+  return chips.find(chip => chip && chip.id === id) || null;
+}
+
+function _operatorTruthStateClass(state){
+  if (state === 'live') return 'state-live';
+  if (state === 'stale') return 'state-stale';
+  return 'state-unknown';
+}
+
+function _operatorTruthApplyState(el, state){
+  if (!el) return;
+  el.classList.remove('state-live','state-stale','state-unknown');
+  el.classList.add(_operatorTruthStateClass(state));
+}
+
+function _operatorTruthVerifiedText(ts){
+  if (!ts) return 'Verified unknown';
+  try {
+    return 'Verified ' + new Date(Number(ts) * 1000).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'});
+  } catch(_) {
+    return 'Verified unknown';
+  }
+}
+
+function _operatorTruthIssues(chip){
+  if (!chip || !Array.isArray(chip.issues) || !chip.issues.length) return '';
+  return chip.issues.filter(Boolean).slice(0, 2).join(' · ');
+}
+
+function _operatorTruthSourceText(chip){
+  const source = (chip && chip.source) || {};
+  const bits = [];
+  if (source.kind) bits.push('Source: ' + source.kind);
+  if (source.path) bits.push(source.path);
+  if (source.metadata_path) bits.push(source.metadata_path);
+  return bits.join(' · ');
+}
+
+function _operatorTruthTitle(payload, chip, fallback){
+  const bits = [];
+  if (payload && payload.summary) bits.push(payload.summary);
+  else bits.push(fallback || 'Truth unknown');
+  bits.push(_operatorTruthVerifiedText((payload && payload.verified_at) || (chip && chip.checked_at)));
+  const issueText = _operatorTruthIssues(chip);
+  if (issueText) bits.push(issueText);
+  const sourceText = _operatorTruthSourceText(chip);
+  if (sourceText) bits.push(sourceText);
+  return bits.join(' · ');
+}
+
+function _operatorTruthSetButton(buttonId, labelId, text, state, title, hidden){
+  const button = $(buttonId);
+  const label = $(labelId);
+  if (!button) return;
+  button.hidden = Boolean(hidden);
+  _operatorTruthApplyState(button, state || 'unknown');
+  button.title = title || text || 'Operator truth status unknown';
+  if (label) label.textContent = text || 'Unknown';
+}
+
+function renderOperatorTruth(payload){
+  const status = (payload && payload.status) || 'unknown';
+  const summary = (payload && payload.summary) || 'Truth unknown';
+  const board = _operatorTruthChip(payload, 'kanban_board');
+  const scratch = _operatorTruthChip(payload, 'scratch_safety');
+  const summaryTitle = _operatorTruthTitle(payload, board || scratch, summary);
+
+  _operatorTruthSetButton('operatorTruthSummaryChip', 'operatorTruthSummaryLabel', summary, status, summaryTitle, false);
+
+  if (board) {
+    const boardState = board.state || 'unknown';
+    const boardValue = board.value || 'unknown';
+    _operatorTruthSetButton(
+      'operatorTruthBoardChip',
+      'operatorTruthBoardLabel',
+      boardState === 'live' ? 'Board ' + boardValue : 'Board ' + boardState,
+      boardState,
+      _operatorTruthTitle(payload, board, 'Board unknown'),
+      false,
+    );
+  } else {
+    _operatorTruthSetButton('operatorTruthBoardChip', 'operatorTruthBoardLabel', 'Board unknown', 'unknown', 'Board unknown', true);
+  }
+
+  if (scratch) {
+    const scratchState = scratch.state || 'unknown';
+    const scratchText = scratchState === 'live' ? 'Scratch safe' : (scratchState === 'stale' ? 'Scratch risky' : 'Scratch unknown');
+    _operatorTruthSetButton(
+      'operatorTruthScratchChip',
+      'operatorTruthScratchLabel',
+      scratchText,
+      scratchState,
+      _operatorTruthTitle(payload, scratch, scratchText),
+      false,
+    );
+  } else {
+    _operatorTruthSetButton('operatorTruthScratchChip', 'operatorTruthScratchLabel', 'Scratch unknown', 'unknown', 'Scratch unknown', true);
+  }
+}
+
+function setOperatorTruthUnknown(reason){
+  const detail = reason ? String(reason) : 'truth source unavailable';
+  _operatorTruthSetButton('operatorTruthSummaryChip', 'operatorTruthSummaryLabel', 'Truth unknown', 'unknown', 'Truth unknown · ' + detail, false);
+  _operatorTruthSetButton('operatorTruthBoardChip', 'operatorTruthBoardLabel', 'Board unknown', 'unknown', 'Board unknown · ' + detail, true);
+  _operatorTruthSetButton('operatorTruthScratchChip', 'operatorTruthScratchLabel', 'Scratch unknown', 'unknown', 'Scratch unknown · ' + detail, true);
+}
+
+async function refreshOperatorTruth(opts = {}){
+  const force = Boolean(opts.force);
+  const now = Date.now();
+  const contextKey = operatorTruthContextKey();
+  if (!force && _operatorTruthInFlight && contextKey === _operatorTruthInFlightKey) return _operatorTruthInFlight;
+  if (!force && _operatorTruthLastFetchAt && contextKey === _operatorTruthLastFetchKey && (now - _operatorTruthLastFetchAt) < OPERATOR_TRUTH_TTL_MS) return null;
+  if (typeof api !== 'function') {
+    setOperatorTruthUnknown('api helper unavailable');
+    return null;
+  }
+
+  const params = new URLSearchParams();
+  const sid = operatorTruthSessionId();
+  const board = operatorTruthBoardHint();
+  if (sid) params.set('session_id', sid);
+  if (board) params.set('ui_board', board);
+  const path = '/api/operator/truth' + (params.toString() ? '?' + params.toString() : '');
+  const requestKey = contextKey;
+  const requestSeq = ++_operatorTruthRequestSeq;
+  _operatorTruthInFlightKey = requestKey;
+
+  _operatorTruthInFlight = api(path)
+    .then(payload => {
+      if (requestKey !== operatorTruthContextKey() || requestSeq !== _operatorTruthRequestSeq) return payload;
+      _operatorTruthLastFetchAt = Date.now();
+      _operatorTruthLastFetchKey = requestKey;
+      renderOperatorTruth(payload);
+      return payload;
+    })
+    .catch(err => {
+      if (requestKey === operatorTruthContextKey() && requestSeq === _operatorTruthRequestSeq) {
+        _operatorTruthLastFetchAt = Date.now();
+        _operatorTruthLastFetchKey = requestKey;
+        setOperatorTruthUnknown((err && err.message) || 'fetch failed');
+      }
+      return null;
+    })
+    .finally(() => {
+      if (requestKey === _operatorTruthInFlightKey && requestSeq === _operatorTruthRequestSeq) {
+        _operatorTruthInFlight = null;
+        _operatorTruthInFlightKey = '';
+      }
+    });
+  return _operatorTruthInFlight;
+}
+
+function initOperatorTruthStrip(){
+  setOperatorTruthUnknown('not checked yet');
+  refreshOperatorTruth({force:true, reason:'boot'});
+}
+
+window.refreshOperatorTruth = refreshOperatorTruth;
+window.renderOperatorTruth = renderOperatorTruth;
+window.setOperatorTruthUnknown = setOperatorTruthUnknown;
+window.operatorTruthSessionId = operatorTruthSessionId;
+window.operatorTruthBoardHint = operatorTruthBoardHint;
+window.operatorTruthContextKey = operatorTruthContextKey;
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initOperatorTruthStrip, {once:true});
+} else {
+  initOperatorTruthStrip();
+}

--- a/static/panels.js
+++ b/static/panels.js
@@ -2697,6 +2697,12 @@ async function loadKanbanBoards(){
     _kanbanSetSavedBoard('default');
   }
   _kanbanCurrentBoard = (active === 'default') ? null : active;
+  if (typeof refreshOperatorTruth === 'function') refreshOperatorTruth({force:true, reason:'kanban-board-load'});
+  try {
+    if (typeof refreshOperatorKanban === 'function') {
+      Promise.resolve(refreshOperatorKanban({force:true, reason:'kanban-board-load'})).catch(() => {});
+    }
+  } catch(_) {}
   // The switcher is visible whenever ≥1 non-default board exists OR the
   // current board is non-default. (If you only have 'default', a switcher
   // adds clutter without value.)

--- a/static/style.css
+++ b/static/style.css
@@ -1379,7 +1379,7 @@
   .suggestion:hover{background:var(--accent-bg);color:var(--text);border-color:var(--accent-bg);transform:translateX(2px);}
   /* ── Composer ── */
   .composer-wrap{padding:12px 20px 16px;background:var(--bg);flex-shrink:0;}
-  .composer-box{max-width:clamp(780px,60vw,1100px);margin:0 auto;background:linear-gradient(var(--input-bg),var(--input-bg)),var(--bg);border:1px solid var(--border2);border-radius:16px;display:flex;flex-direction:column;transition:border-color .2s,box-shadow .2s;position:relative;z-index:2;}
+  .composer-box{max-width:clamp(780px,72vw,1320px);margin:0 auto;background:linear-gradient(var(--input-bg),var(--input-bg)),var(--bg);border:1px solid var(--border2);border-radius:16px;display:flex;flex-direction:column;transition:border-color .2s,box-shadow .2s;position:relative;z-index:2;}
   .composer-box:focus-within{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-bg);}
   .composer-wrap.drag-over .composer-box{border-color:var(--accent-text);background:var(--accent-bg);}
   .drop-hint{display:none;position:absolute;inset:0;align-items:center;justify-content:center;background:var(--accent-bg);border:2px dashed var(--accent);border-radius:14px;font-size:14px;color:var(--accent-text);pointer-events:none;z-index:10;flex-direction:column;gap:8px;}
@@ -1401,8 +1401,8 @@
   }
   textarea#msg{width:100%;background:transparent;border:none;outline:none;color:var(--text);font-size:16px;line-height:1.65;padding:12px 16px 6px;resize:none;min-height:44px;max-height:200px;font-family:inherit;}
   textarea#msg::placeholder{color:var(--muted);}
-  .composer-footer{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:6px 10px 10px;position:relative;container-type:inline-size;container-name:composer-footer;}
-  .composer-left{display:flex;align-items:center;gap:4px;min-width:0;flex:1;overflow-x:auto;overflow-y:hidden;scrollbar-width:none;}
+  .composer-footer{display:flex;align-items:flex-end;justify-content:space-between;gap:10px;padding:6px 10px 10px;position:relative;container-type:inline-size;container-name:composer-footer;}
+  .composer-left{display:flex;align-items:center;align-content:center;gap:4px;row-gap:6px;min-width:0;flex:1;flex-wrap:wrap;overflow-x:visible;overflow-y:visible;scrollbar-width:none;}
   .composer-left::-webkit-scrollbar{display:none;}
   .composer-divider{width:1px;height:16px;background:var(--border);margin:0 3px;flex-shrink:0;}
   /* Composer footer chip wraps share position:relative + flex:0 0 auto so
@@ -1482,6 +1482,274 @@
   .provider-quota-chip:hover{background:rgba(34,197,94,.16);border-color:rgba(34,197,94,.35);}
   .provider-quota-chip-dot{width:6px;height:6px;border-radius:999px;background:#22c55e;box-shadow:0 0 0 3px rgba(34,197,94,.12);flex:0 0 auto;}
   .provider-quota-chip-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+  .operator-truth-strip{display:flex;align-items:center;align-content:center;gap:4px;row-gap:4px;flex:1 1 360px;min-width:min(100%,260px);max-width:100%;flex-wrap:wrap;}
+  .operator-truth-chip{display:inline-flex;align-items:center;gap:6px;height:34px;max-width:150px;padding:7px 10px;border:1px solid var(--border2);border-radius:999px;background:transparent;color:var(--muted);font-size:11px;font-weight:650;line-height:1;white-space:nowrap;cursor:pointer;transition:background .12s,border-color .12s,color .12s;}
+  .operator-truth-chip[hidden]{display:none!important;}
+  .operator-truth-chip:hover{background:var(--hover-bg);color:var(--text);}
+  .operator-truth-chip-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+  .operator-truth-dot{width:6px;height:6px;border-radius:999px;background:var(--muted);box-shadow:0 0 0 3px rgba(128,128,128,.10);flex:0 0 auto;}
+  .operator-truth-chip.state-live{color:var(--text);border-color:color-mix(in srgb,var(--success) 35%,transparent);background:color-mix(in srgb,var(--success) 10%,transparent);}
+  .operator-truth-chip.state-live .operator-truth-dot{background:var(--success);box-shadow:0 0 0 3px color-mix(in srgb,var(--success) 18%,transparent);}
+  .operator-truth-chip.state-stale{color:var(--text);border-color:color-mix(in srgb,var(--warning) 42%,transparent);background:color-mix(in srgb,var(--warning) 12%,transparent);}
+  .operator-truth-chip.state-stale .operator-truth-dot{background:var(--warning);box-shadow:0 0 0 3px color-mix(in srgb,var(--warning) 20%,transparent);}
+  .operator-truth-chip.state-unknown{color:var(--muted);border-color:var(--border2);background:transparent;}
+  .operator-truth-chip.state-unknown .operator-truth-dot{background:var(--muted);box-shadow:0 0 0 3px rgba(128,128,128,.10);}
+  @container composer-footer (max-width: 1100px){
+    .operator-truth-strip{order:10;flex-basis:100%;min-width:100%;}
+  }
+  @media (max-width:640px){
+    .operator-truth-chip-secondary{display:none!important;}
+    .operator-truth-chip{max-width:132px;}
+  }
+  .operator-proposal-popover{position:absolute;left:10px;bottom:calc(100% + 8px);z-index:190;width:min(460px,calc(100vw - 24px));max-height:min(560px,70vh);overflow:hidden;display:flex;flex-direction:column;border:1px solid var(--border2);border-radius:12px;background:var(--surface);color:var(--text);box-shadow:0 12px 32px rgba(0,0,0,.28);}
+  .operator-proposal-popover[hidden]{display:none!important;}
+  .operator-proposal-popover.state-stale{border-color:color-mix(in srgb,var(--warning) 40%,var(--border2));}
+  .operator-proposal-popover.state-live{border-color:color-mix(in srgb,var(--success) 32%,var(--border2));}
+  .operator-proposal-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;padding:11px 12px;border-bottom:1px solid var(--border2);background:color-mix(in srgb,var(--surface) 88%,var(--bg));}
+  .operator-proposal-title{font-size:12px;font-weight:750;color:var(--text);letter-spacing:.01em;}
+  .operator-proposal-subtitle{margin-top:2px;font-size:11px;line-height:1.35;color:var(--muted);}
+  .operator-proposal-close{width:24px;height:24px;border-radius:7px;border:1px solid transparent;background:transparent;color:var(--muted);font-size:18px;line-height:1;cursor:pointer;}
+  .operator-proposal-close:hover{background:var(--hover-bg);color:var(--text);border-color:var(--border2);}
+  .operator-proposal-list{display:flex;flex-direction:column;gap:8px;padding:10px;overflow:auto;}
+  .operator-proposal-card{border:1px solid var(--border2);border-radius:10px;background:color-mix(in srgb,var(--surface) 92%,var(--bg));padding:10px;display:flex;flex-direction:column;gap:8px;}
+  .operator-proposal-card-top{display:flex;align-items:flex-start;justify-content:space-between;gap:8px;}
+  .operator-proposal-card-title{font-size:12px;font-weight:750;color:var(--text);line-height:1.35;min-width:0;}
+  .operator-proposal-no-exec{flex:0 0 auto;border:1px solid color-mix(in srgb,var(--success) 28%,var(--border2));border-radius:999px;padding:3px 6px;font-size:10px;font-weight:750;color:var(--success);background:color-mix(in srgb,var(--success) 8%,transparent);}
+  .operator-proposal-summary{font-size:12px;line-height:1.45;color:var(--text);}
+  .operator-proposal-row{display:flex;gap:8px;align-items:baseline;font-size:11px;line-height:1.35;}
+  .operator-proposal-row-key{flex:0 0 auto;color:var(--muted);font-weight:700;}
+  .operator-proposal-row-value{min-width:0;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+  .operator-proposal-section-title{font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.04em;color:var(--muted);margin-bottom:4px;}
+  .operator-proposal-evidence,.operator-proposal-safety{display:flex;flex-direction:column;gap:3px;}
+  .operator-proposal-evidence-item,.operator-proposal-muted,.operator-proposal-issue{font-size:11px;line-height:1.35;color:var(--muted);word-break:break-word;}
+  .operator-proposal-issue{color:var(--warning);}
+  .operator-proposal-empty{font-size:12px;line-height:1.45;color:var(--muted);padding:6px 2px;}
+  .operator-proposal-actions{display:flex;gap:8px;align-items:center;justify-content:flex-end;margin-top:2px;}
+  .operator-proposal-action{border:1px solid var(--border2);border-radius:8px;background:transparent;color:var(--muted);font-size:11px;font-weight:700;padding:6px 9px;cursor:pointer;}
+  .operator-proposal-action:hover{background:var(--hover-bg);color:var(--text);}
+  .operator-proposal-action.primary{border-color:var(--accent-bg-strong);background:var(--accent-bg);color:var(--text);}
+  @media (max-width:640px){
+    .operator-proposal-popover{left:8px;right:8px;width:auto;max-height:62vh;}
+    .operator-proposal-card-top{flex-direction:column;align-items:flex-start;}
+    .operator-proposal-actions{justify-content:flex-start;flex-wrap:wrap;}
+  }
+  .operator-commitment-popover{position:absolute;left:10px;bottom:calc(100% + 8px);z-index:191;width:min(500px,calc(100vw - 24px));max-height:min(640px,78vh);overflow:hidden;display:flex;flex-direction:column;border:1px solid var(--border2);border-radius:12px;background:var(--surface);color:var(--text);box-shadow:0 12px 32px rgba(0,0,0,.30);}
+  .operator-commitment-popover[hidden]{display:none!important;}
+  .operator-commitment-popover.state-live{border-color:color-mix(in srgb,var(--success) 32%,var(--border2));}
+  .operator-commitment-popover.state-stale{border-color:color-mix(in srgb,var(--warning) 42%,var(--border2));}
+  .operator-commitment-popover.state-unknown{border-color:var(--border2);}
+  .operator-commitment-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;padding:11px 12px;border-bottom:1px solid var(--border2);background:color-mix(in srgb,var(--surface) 88%,var(--bg));}
+  .operator-commitment-title{font-size:12px;font-weight:800;color:var(--text);letter-spacing:.02em;text-transform:uppercase;}
+  .operator-commitment-subtitle{margin-top:2px;font-size:11px;line-height:1.35;color:var(--muted);}
+  .operator-commitment-close{width:24px;height:24px;border-radius:7px;border:1px solid transparent;background:transparent;color:var(--muted);font-size:18px;line-height:1;cursor:pointer;}
+  .operator-commitment-close:hover{background:var(--hover-bg);color:var(--text);border-color:var(--border2);}
+  .operator-commitment-list{display:flex;flex-direction:column;gap:8px;padding:10px;overflow:auto;}
+  .operator-commitment-source-row{display:flex;flex-wrap:wrap;gap:6px;align-items:center;}
+  .operator-commitment-card{border:1px solid var(--border2);border-radius:10px;background:color-mix(in srgb,var(--surface) 90%,var(--bg));padding:10px;display:flex;flex-direction:column;gap:8px;min-width:0;}
+  .operator-commitment-card-top{display:flex;align-items:flex-start;justify-content:space-between;gap:8px;}
+  .operator-commitment-card-title{min-width:0;font-size:12px;font-weight:800;line-height:1.35;color:var(--text);}
+  .operator-commitment-no-exec{flex:0 0 auto;border:1px solid color-mix(in srgb,var(--success) 28%,var(--border2));border-radius:999px;padding:3px 6px;font-size:10px;font-weight:800;color:var(--success);background:color-mix(in srgb,var(--success) 8%,transparent);}
+  .operator-commitment-summary{font-size:12px;line-height:1.45;color:var(--text);}
+  .operator-commitment-row{display:flex;gap:8px;align-items:baseline;font-size:11px;line-height:1.35;min-width:0;}
+  .operator-commitment-row-key{flex:0 0 auto;color:var(--muted);font-weight:800;}
+  .operator-commitment-row-value{min-width:0;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+  .operator-commitment-section{display:flex;flex-direction:column;gap:3px;border-top:1px solid var(--border2);padding-top:7px;}
+  .operator-commitment-section-title{font-size:10px;font-weight:850;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);}
+  .operator-commitment-muted,.operator-commitment-empty{font-size:11px;line-height:1.35;color:var(--muted);word-break:break-word;}
+  .operator-commitment-required{display:inline-flex;align-items:center;border:1px solid var(--border2);border-radius:999px;padding:3px 7px;font-size:10px;font-weight:800;color:var(--muted);background:transparent;line-height:1.25;}
+  .operator-commitment-required.state-live{color:var(--success);border-color:color-mix(in srgb,var(--success) 32%,var(--border2));background:color-mix(in srgb,var(--success) 8%,transparent);}
+  .operator-commitment-required.state-stale{color:var(--warning);border-color:color-mix(in srgb,var(--warning) 40%,var(--border2));background:color-mix(in srgb,var(--warning) 9%,transparent);}
+  .operator-commitment-required.state-unknown{color:var(--muted);border-color:var(--border2);background:transparent;}
+  .operator-commitment-missing{font-size:11px;line-height:1.35;color:var(--warning);word-break:break-word;}
+  .operator-commitment-form{border-top:1px solid var(--border2);padding:10px;display:flex;flex-direction:column;gap:8px;background:color-mix(in srgb,var(--surface) 93%,var(--bg));}
+  .operator-commitment-form[hidden]{display:none!important;}
+  .operator-commitment-form-title{font-size:11px;font-weight:850;text-transform:uppercase;letter-spacing:.05em;color:var(--text);}
+  .operator-commitment-form label{display:flex;flex-direction:column;gap:4px;font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.04em;color:var(--muted);}
+  .operator-commitment-form input,.operator-commitment-form textarea,.operator-commitment-form select{border:1px solid var(--border2);border-radius:8px;background:var(--bg);color:var(--text);font:inherit;font-size:12px;font-weight:500;text-transform:none;letter-spacing:0;padding:7px 8px;min-width:0;}
+  .operator-commitment-form textarea{resize:vertical;min-height:48px;}
+  .operator-commitment-form-row{display:grid;grid-template-columns:1fr 1fr;gap:8px;}
+  .operator-commitment-actions{display:flex;justify-content:flex-end;align-items:center;gap:8px;}
+  .operator-commitment-action{border:1px solid var(--border2);border-radius:8px;background:transparent;color:var(--muted);font-size:11px;font-weight:750;padding:6px 9px;cursor:pointer;}
+  .operator-commitment-action:hover{background:var(--hover-bg);color:var(--text);}
+  .operator-commitment-action.primary{border-color:var(--accent-bg-strong);background:var(--accent-bg);color:var(--text);}
+  @media (max-width:640px){
+    .operator-commitment-popover{left:8px;right:8px;width:auto;max-height:68vh;}
+    .operator-commitment-card-top{flex-direction:column;align-items:flex-start;}
+    .operator-commitment-row{flex-direction:column;gap:2px;}
+    .operator-commitment-form-row{grid-template-columns:1fr;}
+    .operator-commitment-actions{justify-content:flex-start;flex-wrap:wrap;}
+  }
+  .operator-memory-skill-review-popover{position:absolute;left:10px;bottom:calc(100% + 8px);z-index:192;width:min(540px,calc(100vw - 24px));max-height:min(680px,78vh);overflow:hidden;display:flex;flex-direction:column;border:1px solid var(--border2);border-radius:12px;background:var(--surface);color:var(--text);box-shadow:0 12px 32px rgba(0,0,0,.30);}
+  .operator-memory-skill-review-popover[hidden]{display:none!important;}
+  .operator-memory-skill-review-popover.state-live{border-color:color-mix(in srgb,var(--success) 32%,var(--border2));}
+  .operator-memory-skill-review-popover.state-stale{border-color:color-mix(in srgb,var(--warning) 42%,var(--border2));}
+  .operator-memory-skill-review-popover.state-unknown{border-color:var(--border2);}
+  .operator-memory-skill-review-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;padding:11px 12px;border-bottom:1px solid var(--border2);background:color-mix(in srgb,var(--surface) 88%,var(--bg));}
+  .operator-memory-skill-review-title{font-size:12px;font-weight:800;color:var(--text);letter-spacing:.02em;text-transform:uppercase;}
+  .operator-memory-skill-review-subtitle{margin-top:2px;font-size:11px;line-height:1.35;color:var(--muted);}
+  .operator-memory-skill-review-header-actions{display:flex;align-items:center;gap:6px;}
+  .operator-memory-skill-review-refresh,.operator-memory-skill-review-close{border:1px solid var(--border2);border-radius:8px;background:transparent;color:var(--muted);font-size:11px;font-weight:750;padding:6px 9px;cursor:pointer;}
+  .operator-memory-skill-review-close{width:26px;height:26px;padding:0;font-size:18px;line-height:1;}
+  .operator-memory-skill-review-refresh:hover,.operator-memory-skill-review-close:hover{background:var(--hover-bg);color:var(--text);}
+  .operator-memory-skill-review-list{display:flex;flex-direction:column;gap:8px;padding:10px;overflow:auto;}
+  .operator-memory-skill-review-card{border:1px solid var(--border2);border-radius:10px;background:color-mix(in srgb,var(--surface) 90%,var(--bg));padding:10px;display:flex;flex-direction:column;gap:8px;min-width:0;}
+  .operator-memory-skill-review-card.operator-memory-skill-review-invalid{border-color:color-mix(in srgb,var(--warning) 44%,var(--border2));}
+  .operator-memory-skill-review-card.operator-memory-skill-review-stale{background:color-mix(in srgb,var(--warning) 7%,var(--surface));}
+  .operator-memory-skill-review-card-top{display:flex;align-items:flex-start;justify-content:space-between;gap:8px;}
+  .operator-memory-skill-review-card-title{min-width:0;font-size:12px;font-weight:800;line-height:1.35;color:var(--text);word-break:break-word;}
+  .operator-memory-skill-review-no-exec{flex:0 0 auto;border:1px solid color-mix(in srgb,var(--success) 28%,var(--border2));border-radius:999px;padding:3px 6px;font-size:10px;font-weight:800;color:var(--success);background:color-mix(in srgb,var(--success) 8%,transparent);}
+  .operator-memory-skill-review-summary{font-size:12px;line-height:1.45;color:var(--text);word-break:break-word;}
+  .operator-memory-skill-review-row{display:flex;gap:8px;align-items:baseline;font-size:11px;line-height:1.35;min-width:0;}
+  .operator-memory-skill-review-row-key{flex:0 0 auto;color:var(--muted);font-weight:800;}
+  .operator-memory-skill-review-row-value{min-width:0;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+  .operator-memory-skill-review-section{display:flex;flex-direction:column;gap:3px;border-top:1px solid var(--border2);padding-top:7px;}
+  .operator-memory-skill-review-section-title{font-size:10px;font-weight:850;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);}
+  .operator-memory-skill-review-diff{border:1px solid var(--border2);border-radius:8px;background:var(--bg);color:var(--text);font-family:var(--font-mono);font-size:10px;line-height:1.35;max-height:150px;overflow:auto;padding:8px;white-space:pre-wrap;word-break:break-word;}
+  .operator-memory-skill-review-evidence{display:flex;flex-direction:column;gap:3px;}
+  .operator-memory-skill-review-evidence-item,.operator-memory-skill-review-empty{font-size:11px;line-height:1.35;color:var(--muted);word-break:break-word;}
+  .operator-memory-skill-review-decision{display:flex;align-items:center;justify-content:flex-end;gap:8px;border-top:1px solid var(--border2);padding-top:8px;}
+  .operator-memory-skill-review-invalid{font-size:11px;line-height:1.35;color:var(--warning);word-break:break-word;}
+  .operator-memory-skill-review-no-exec + .operator-memory-skill-review-invalid{margin-left:6px;}
+  .operator-memory-skill-review-action{border:1px solid var(--border2);border-radius:8px;background:transparent;color:var(--muted);font-size:11px;font-weight:750;padding:6px 9px;cursor:pointer;}
+  .operator-memory-skill-review-action:hover{background:var(--hover-bg);color:var(--text);}
+  .operator-memory-skill-review-action.primary{border-color:var(--accent-bg-strong);background:var(--accent-bg);color:var(--text);}
+  @media (max-width:640px){
+    .operator-memory-skill-review-popover{left:8px;right:8px;width:auto;max-height:68vh;}
+    .operator-memory-skill-review-header{align-items:stretch;}
+    .operator-memory-skill-review-header-actions{flex:0 0 auto;}
+    .operator-memory-skill-review-card-top{flex-direction:column;align-items:flex-start;}
+    .operator-memory-skill-review-row{flex-direction:column;gap:2px;}
+    .operator-memory-skill-review-decision{justify-content:flex-start;flex-wrap:wrap;}
+  }
+  .operator-session-recall-popover{position:absolute;left:10px;bottom:calc(100% + 8px);z-index:193;width:min(520px,calc(100vw - 24px));max-height:min(600px,72vh);overflow:hidden;display:flex;flex-direction:column;border:1px solid var(--border2);border-radius:12px;background:var(--surface);color:var(--text);box-shadow:0 12px 32px rgba(0,0,0,.30);}
+  .operator-session-recall-popover[hidden]{display:none!important;}
+  .operator-session-recall-popover.state-live{border-color:color-mix(in srgb,var(--success) 32%,var(--border2));}
+  .operator-session-recall-popover.state-stale{border-color:color-mix(in srgb,var(--warning) 42%,var(--border2));}
+  .operator-session-recall-popover.state-unknown{border-color:var(--border2);}
+  .operator-session-recall-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;padding:11px 12px;border-bottom:1px solid var(--border2);background:color-mix(in srgb,var(--surface) 88%,var(--bg));}
+  .operator-session-recall-title{font-size:12px;font-weight:800;color:var(--text);letter-spacing:.02em;text-transform:uppercase;}
+  .operator-session-recall-subtitle{margin-top:2px;font-size:11px;line-height:1.35;color:var(--muted);}
+  .operator-session-recall-close{flex:0 0 auto;width:26px;height:26px;border:1px solid var(--border2);border-radius:8px;background:transparent;color:var(--muted);font-size:18px;line-height:1;cursor:pointer;}
+  .operator-session-recall-close:hover{background:var(--hover-bg);color:var(--text);}
+  .operator-session-recall-controls{display:flex;gap:8px;align-items:center;padding:10px 12px;border-bottom:1px solid var(--border2);}
+  .operator-session-recall-input{min-width:0;flex:1;border:1px solid var(--border2);border-radius:9px;background:var(--bg);color:var(--text);font-size:12px;line-height:1.35;padding:7px 9px;outline:none;}
+  .operator-session-recall-input:focus{border-color:var(--accent-bg-strong);}
+  .operator-session-recall-list{display:flex;flex-direction:column;gap:8px;padding:10px;overflow:auto;}
+  .operator-session-recall-card{border:1px solid var(--border2);border-radius:10px;background:color-mix(in srgb,var(--surface) 90%,var(--bg));padding:10px;display:flex;flex-direction:column;gap:6px;min-width:0;}
+  .operator-session-recall-snippet{font-size:12px;line-height:1.45;color:var(--text);word-break:break-word;}
+  .operator-session-recall-source{font-family:var(--font-mono);font-size:10px;line-height:1.35;color:var(--muted);word-break:break-word;}
+  .operator-session-recall-historical{background:color-mix(in srgb,var(--surface) 92%,var(--bg));}
+  .operator-session-recall-stale{color:var(--warning);}
+  .operator-session-recall-issue,.operator-session-recall-empty{font-size:11px;line-height:1.35;color:var(--muted);word-break:break-word;}
+  .operator-session-recall-action{border:1px solid var(--border2);border-radius:8px;background:transparent;color:var(--muted);font-size:11px;font-weight:750;padding:7px 10px;cursor:pointer;}
+  .operator-session-recall-action:hover{background:var(--hover-bg);color:var(--text);}
+  .operator-session-recall-action.primary{border-color:var(--accent-bg-strong);background:var(--accent-bg);color:var(--text);}
+  @media (max-width:640px){
+    .operator-session-recall-popover{left:8px;right:8px;width:auto;max-height:64vh;}
+    .operator-session-recall-header{align-items:stretch;}
+    .operator-session-recall-controls{align-items:stretch;flex-direction:column;}
+    .operator-session-recall-action{width:100%;}
+  }
+  .operator-docs-artifacts-popover{position:absolute;left:10px;bottom:calc(100% + 8px);z-index:194;width:min(560px,calc(100vw - 24px));max-height:min(640px,74vh);overflow:hidden;display:flex;flex-direction:column;border:1px solid var(--border2);border-radius:12px;background:var(--surface);color:var(--text);box-shadow:0 12px 32px rgba(0,0,0,.30);}
+  .operator-docs-artifacts-popover[hidden]{display:none!important;}
+  .operator-docs-artifacts-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;padding:11px 12px;border-bottom:1px solid var(--border2);background:color-mix(in srgb,var(--surface) 88%,var(--bg));}
+  .operator-docs-artifacts-title{font-size:12px;font-weight:800;color:var(--text);letter-spacing:.02em;text-transform:uppercase;}
+  .operator-docs-artifacts-subtitle{margin-top:2px;font-size:11px;line-height:1.35;color:var(--muted);}
+  .operator-docs-artifacts-close{flex:0 0 auto;width:26px;height:26px;border:1px solid var(--border2);border-radius:8px;background:transparent;color:var(--muted);font-size:18px;line-height:1;cursor:pointer;}
+  .operator-docs-artifacts-close:hover{background:var(--hover-bg);color:var(--text);}
+  .operator-docs-artifacts-controls{display:grid;grid-template-columns:minmax(120px,1fr) minmax(96px,auto) minmax(120px,1fr) auto;gap:8px;align-items:end;padding:10px 12px;border-bottom:1px solid var(--border2);}
+  .operator-docs-artifacts-field{display:flex;min-width:0;flex-direction:column;gap:4px;font-size:10px;font-weight:800;letter-spacing:.04em;text-transform:uppercase;color:var(--muted);}
+  .operator-docs-artifacts-input,.operator-docs-artifacts-kind,.operator-docs-artifacts-root{min-width:0;border:1px solid var(--border2);border-radius:9px;background:var(--bg);color:var(--text);font-size:12px;line-height:1.35;padding:7px 9px;outline:none;text-transform:none;letter-spacing:0;font-weight:500;}
+  .operator-docs-artifacts-input:focus,.operator-docs-artifacts-kind:focus,.operator-docs-artifacts-root:focus{border-color:var(--accent-bg-strong);}
+  .operator-docs-artifacts-body{display:grid;grid-template-columns:minmax(0,1fr) minmax(180px,.9fr);min-height:180px;overflow:hidden;}
+  .operator-docs-artifacts-list{display:flex;flex-direction:column;gap:8px;padding:10px;overflow:auto;border-right:1px solid var(--border2);}
+  .operator-docs-artifacts-card{border:1px solid var(--border2);border-radius:10px;background:color-mix(in srgb,var(--surface) 90%,var(--bg));padding:10px;display:flex;flex-direction:column;gap:6px;min-width:0;}
+  .operator-docs-artifacts-source{font-family:var(--font-mono);font-size:10px;line-height:1.35;color:var(--muted);word-break:break-word;}
+  .operator-docs-artifacts-preview{padding:10px;font-size:12px;line-height:1.45;color:var(--muted);overflow:auto;word-break:break-word;background:color-mix(in srgb,var(--surface) 92%,var(--bg));}
+  .operator-docs-artifacts-action{border:1px solid var(--border2);border-radius:8px;background:transparent;color:var(--muted);font-size:11px;font-weight:750;padding:7px 10px;cursor:pointer;}
+  .operator-docs-artifacts-action:hover{background:var(--hover-bg);color:var(--text);}
+  .operator-docs-artifacts-action.primary{border-color:var(--accent-bg-strong);background:var(--accent-bg);color:var(--text);}
+  .operator-docs-artifacts-current{color:var(--success);border-color:color-mix(in srgb,var(--success) 32%,var(--border2));}
+  .operator-docs-artifacts-historical{background:color-mix(in srgb,var(--surface) 92%,var(--bg));}
+  .operator-docs-artifacts-stale{color:var(--warning);border-color:color-mix(in srgb,var(--warning) 40%,var(--border2));}
+  .operator-docs-artifacts-empty{font-size:11px;line-height:1.35;color:var(--muted);word-break:break-word;}
+  @media (max-width:640px){
+    .operator-docs-artifacts-popover{left:8px;right:8px;width:auto;max-height:68vh;}
+    .operator-docs-artifacts-header{align-items:stretch;}
+    .operator-docs-artifacts-controls{grid-template-columns:1fr;align-items:stretch;}
+    .operator-docs-artifacts-body{grid-template-columns:1fr;}
+    .operator-docs-artifacts-list{max-height:30vh;border-right:0;border-bottom:1px solid var(--border2);}
+    .operator-docs-artifacts-action{width:100%;}
+  }
+  .operator-device-admin-popover{position:absolute;left:10px;bottom:calc(100% + 8px);z-index:193;width:min(580px,calc(100vw - 24px));max-height:min(640px,74vh);overflow:hidden;display:flex;flex-direction:column;border:1px solid var(--border2);border-radius:12px;background:var(--surface);color:var(--text);box-shadow:0 12px 32px rgba(0,0,0,.30);}
+  .operator-device-admin-popover[hidden]{display:none!important;}
+  .operator-device-admin-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;padding:11px 12px;border-bottom:1px solid var(--border2);background:color-mix(in srgb,var(--surface) 88%,var(--bg));}
+  .operator-device-admin-title{font-size:12px;font-weight:800;color:var(--text);letter-spacing:.02em;text-transform:uppercase;}
+  .operator-device-admin-subtitle{margin-top:2px;font-size:11px;line-height:1.35;color:var(--muted);}
+  .operator-device-admin-close{flex:0 0 auto;width:26px;height:26px;border:1px solid var(--border2);border-radius:8px;background:transparent;color:var(--muted);font-size:18px;line-height:1;cursor:pointer;}
+  .operator-device-admin-close:hover{background:var(--hover-bg);color:var(--text);}
+  .operator-device-admin-controls{display:grid;grid-template-columns:minmax(120px,1fr) minmax(96px,auto) minmax(112px,auto) auto;gap:8px;align-items:end;padding:10px 12px;border-bottom:1px solid var(--border2);}
+  .operator-device-admin-field{display:flex;min-width:0;flex-direction:column;gap:4px;font-size:10px;font-weight:800;letter-spacing:.04em;text-transform:uppercase;color:var(--muted);}
+  .operator-device-admin-input,.operator-device-admin-host,.operator-device-admin-action-select{min-width:0;border:1px solid var(--border2);border-radius:9px;background:var(--bg);color:var(--text);font-size:12px;line-height:1.35;padding:7px 9px;outline:none;text-transform:none;letter-spacing:0;font-weight:500;}
+  .operator-device-admin-input:focus,.operator-device-admin-host:focus,.operator-device-admin-action-select:focus{border-color:var(--accent-bg-strong);}
+  .operator-device-admin-body{display:grid;grid-template-columns:minmax(0,1fr) minmax(180px,.9fr);min-height:180px;overflow:hidden;}
+  .operator-device-admin-list{display:flex;flex-direction:column;gap:8px;padding:10px;overflow:auto;border-right:1px solid var(--border2);}
+  .operator-device-admin-card{border:1px solid var(--border2);border-radius:10px;background:color-mix(in srgb,var(--surface) 90%,var(--bg));padding:10px;display:flex;flex-direction:column;gap:6px;min-width:0;}
+  .operator-device-admin-source{font-family:var(--font-mono);font-size:10px;line-height:1.35;color:var(--muted);word-break:break-word;}
+  .operator-device-admin-preview{padding:10px;font-size:12px;line-height:1.45;color:var(--muted);overflow:auto;word-break:break-word;background:color-mix(in srgb,var(--surface) 92%,var(--bg));}
+  .operator-device-admin-action{border:1px solid var(--border2);border-radius:8px;background:transparent;color:var(--muted);font-size:11px;font-weight:750;padding:7px 10px;cursor:pointer;}
+  .operator-device-admin-action:hover{background:var(--hover-bg);color:var(--text);}
+  .operator-device-admin-action.primary{border-color:var(--accent-bg-strong);background:var(--accent-bg);color:var(--text);}
+  .operator-device-admin-blocked{color:var(--warning);border-color:color-mix(in srgb,var(--warning) 40%,var(--border2));}
+  .operator-device-admin-unknown{color:var(--muted);border-color:var(--border2);}
+  .operator-device-admin-empty{font-size:11px;line-height:1.35;color:var(--muted);word-break:break-word;}
+  @media (max-width:640px){
+    .operator-device-admin-popover{left:8px;right:8px;width:auto;max-height:68vh;}
+    .operator-device-admin-header{align-items:stretch;}
+    .operator-device-admin-controls{grid-template-columns:1fr;align-items:stretch;}
+    .operator-device-admin-body{grid-template-columns:1fr;}
+    .operator-device-admin-list{max-height:30vh;border-right:0;border-bottom:1px solid var(--border2);}
+    .operator-device-admin-action{width:100%;}
+  }
+  .operator-kanban-panel{flex:0 0 auto;margin:0;padding:12px 14px;border-bottom:1px solid var(--border);background:color-mix(in srgb,var(--surface) 94%,var(--bg));color:var(--text);display:flex;flex-direction:column;gap:9px;}
+  .operator-kanban-panel.state-live{border-bottom-color:color-mix(in srgb,var(--success) 28%,var(--border));}
+  .operator-kanban-panel.state-stale{border-bottom-color:color-mix(in srgb,var(--warning) 38%,var(--border));}
+  .operator-kanban-panel.state-unknown{border-bottom-color:var(--border2);}
+  .operator-kanban-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;}
+  .operator-kanban-title{font-size:12px;font-weight:800;letter-spacing:.02em;color:var(--text);text-transform:uppercase;}
+  .operator-kanban-subtitle{margin-top:2px;font-size:11px;line-height:1.35;color:var(--muted);}
+  .operator-kanban-refresh{flex:0 0 auto;border:1px solid var(--border2);border-radius:8px;background:transparent;color:var(--muted);font-size:11px;font-weight:750;padding:6px 9px;cursor:pointer;}
+  .operator-kanban-refresh:hover{background:var(--hover-bg);color:var(--text);}
+  .operator-kanban-copy{font-size:11px;color:var(--muted);line-height:1.35;}
+  .operator-kanban-body{display:flex;flex-direction:column;gap:8px;max-height:360px;overflow:auto;}
+  .operator-kanban-topline,.operator-kanban-counts,.operator-kanban-sources{display:flex;flex-wrap:wrap;gap:6px;align-items:center;}
+  .operator-kanban-count{display:inline-flex;align-items:center;border:1px solid var(--border2);border-radius:999px;padding:3px 7px;font-size:10px;font-weight:750;color:var(--muted);background:transparent;}
+  .operator-kanban-chip{display:inline-flex;align-items:center;border:1px solid var(--border2);border-radius:999px;padding:3px 7px;font-size:10px;font-weight:800;color:var(--muted);background:transparent;line-height:1.25;}
+  .operator-kanban-chip.state-live{color:var(--success);border-color:color-mix(in srgb,var(--success) 32%,var(--border2));background:color-mix(in srgb,var(--success) 8%,transparent);}
+  .operator-kanban-chip.state-stale{color:var(--warning);border-color:color-mix(in srgb,var(--warning) 40%,var(--border2));background:color-mix(in srgb,var(--warning) 9%,transparent);}
+  .operator-kanban-chip.state-unknown{color:var(--muted);border-color:var(--border2);background:transparent;}
+  .operator-kanban-task-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:8px;}
+  .operator-kanban-task-card{border:1px solid var(--border2);border-radius:10px;background:color-mix(in srgb,var(--surface) 88%,var(--bg));padding:10px;display:flex;flex-direction:column;gap:7px;min-width:0;}
+  .operator-kanban-task-top{display:flex;align-items:flex-start;justify-content:space-between;gap:8px;}
+  .operator-kanban-task-title{min-width:0;font-size:12px;font-weight:800;line-height:1.35;color:var(--text);}
+  .operator-kanban-row{display:flex;gap:8px;align-items:baseline;font-size:11px;line-height:1.35;min-width:0;}
+  .operator-kanban-row-key{flex:0 0 auto;color:var(--muted);font-weight:800;}
+  .operator-kanban-row-value{min-width:0;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+  .operator-kanban-path-row .operator-kanban-row-value{font-family:var(--font-mono);font-size:10px;}
+  .operator-kanban-section{display:flex;flex-direction:column;gap:3px;border-top:1px solid var(--border2);padding-top:7px;}
+  .operator-kanban-section-title{font-size:10px;font-weight:850;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);}
+  .operator-kanban-summary{font-size:11px;line-height:1.4;color:var(--text);word-break:break-word;}
+  .operator-kanban-muted,.operator-kanban-receipt,.operator-kanban-issue,.operator-kanban-empty{font-size:11px;line-height:1.35;color:var(--muted);word-break:break-word;}
+  .operator-kanban-receipt{font-family:var(--font-mono);font-size:10px;color:var(--text);}
+  .operator-kanban-issue{color:var(--warning);}
+  .operator-kanban-empty{padding:4px 0;}
+  @media (max-width:640px){
+    .operator-kanban-panel{padding:10px 12px;}
+    .operator-kanban-header{align-items:stretch;}
+    .operator-kanban-task-list{grid-template-columns:1fr;}
+    .operator-kanban-row{flex-direction:column;gap:2px;}
+    .operator-kanban-body{max-height:52vh;}
+  }
   /* Hide the ambient quota chip below 1400px — the composer footer already
      has profile + workspace + model picker + reasoning + media + send and
      was getting cramped (model picker truncating from "Claude Sonnet 4 7"
@@ -1527,7 +1795,7 @@
   .composer-mobile-context-action.ctx-mid .composer-mobile-config-value{color:var(--warning);}
   .composer-mobile-context-action.ctx-high .composer-mobile-config-value{color:var(--error);}
   .composer-mobile-context-action.ctx-high .composer-mobile-context-compress{border-color:var(--error);color:var(--error);}
-  .composer-right{display:flex;gap:8px;align-items:center;flex-shrink:0;}
+  .composer-right{display:flex;gap:8px;align-items:center;align-self:flex-end;flex-shrink:0;}
   .composer-status{font-size:11px;color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:170px;}
   /* Context usage indicator */
   .ctx-indicator-wrap{position:relative;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;}
@@ -3863,6 +4131,27 @@ main.main > .main-view:not([id="mainChat"]):not([id="mainSettings"]) .main-view-
 .workspace-panel-tab{flex:1;border:1px solid transparent;background:transparent;color:var(--muted);border-radius:7px;padding:5px 8px;font-size:12px;cursor:pointer;}
 .workspace-panel-tab.active{background:var(--surface-subtle);color:var(--text);border-color:var(--border2);}
 .workspace-artifacts{flex:1;overflow:auto;padding:8px;}
+.workspace-run-graph{border:1px solid var(--border);border-radius:10px;background:var(--surface-subtle);padding:9px;margin-bottom:10px;}
+.workspace-run-graph-summary{display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-bottom:8px;}
+.workspace-run-graph-title{font-size:12px;font-weight:700;color:var(--text);letter-spacing:.01em;}
+.workspace-run-graph-subtitle{margin-top:2px;color:var(--muted);font-size:11px;line-height:1.35;word-break:break-word;}
+.workspace-run-graph-grid{display:grid;grid-template-columns:1fr;gap:6px;}
+.workspace-run-graph-card{border:1px solid var(--border);border-radius:8px;background:var(--surface);padding:8px;}
+.workspace-run-graph-card.status-running{border-color:var(--accent-bg-strong);background:var(--accent-bg);}
+.workspace-run-graph-card.status-failed{border-color:color-mix(in srgb,var(--error) 38%,var(--border));background:color-mix(in srgb,var(--error) 8%,var(--surface));}
+.workspace-run-graph-card.status-interrupted{border-color:color-mix(in srgb,var(--warning) 42%,var(--border));background:color-mix(in srgb,var(--warning) 9%,var(--surface));}
+.workspace-run-graph-card.status-succeeded{border-color:color-mix(in srgb,var(--success) 35%,var(--border));}
+.workspace-run-graph-card-head{display:flex;align-items:center;justify-content:space-between;gap:8px;}
+.workspace-run-graph-node-label{font-size:12px;font-weight:650;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.workspace-run-graph-node-status{font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em;flex-shrink:0;}
+.workspace-run-graph-node-meta{margin-top:3px;color:var(--muted);font-size:11px;line-height:1.35;}
+.workspace-run-graph-latest{display:flex;flex-wrap:wrap;gap:4px;margin-top:6px;}
+.workspace-run-graph-latest span{display:inline-flex;gap:3px;max-width:100%;border:1px solid var(--border);border-radius:999px;padding:2px 6px;color:var(--muted);font-size:10px;line-height:1.3;background:var(--surface-subtle);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.workspace-run-graph-latest b{color:var(--text);font-weight:600;}
+.workspace-run-graph-edge{margin-top:7px;color:var(--muted);font-size:10px;text-align:right;}
+.workspace-run-graph-empty{padding:11px 8px;color:var(--muted);font-size:12px;line-height:1.45;text-align:center;}
+.workspace-run-graph-empty.error{color:var(--error);}
+.workspace-run-graph-empty.loading{font-style:italic;}
 .workspace-artifact-empty{padding:16px 8px;color:var(--muted);font-size:12px;line-height:1.5;text-align:center;}
 .workspace-artifact-item{display:block;width:100%;text-align:left;background:var(--surface-subtle);color:var(--text);border:1px solid var(--border);border-radius:8px;padding:8px 10px;margin-bottom:6px;cursor:pointer;}
 .workspace-artifact-item:hover{border-color:var(--accent);}

--- a/static/ui.js
+++ b/static/ui.js
@@ -5012,6 +5012,7 @@ function syncTopbar(){
     // Update profile chip even when no session is active (e.g. right after profile switch)
     const _profileLabel=$('profileChipLabel');
     if(_profileLabel) _profileLabel.textContent=S.activeProfile||'default';
+    if(typeof refreshOperatorTruth === 'function') refreshOperatorTruth({reason:'syncTopbar'});
     return;
   }
   const sessionTitle=S.session.title||t('untitled');
@@ -5123,6 +5124,7 @@ function syncTopbar(){
   // Update profile chip label
   const profileLabel=$('profileChipLabel');
   if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
+  if(typeof refreshOperatorTruth === 'function') refreshOperatorTruth({reason:'syncTopbar'});
 }
 
 function msgContent(m){

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -141,6 +141,185 @@ if(typeof document !== 'undefined'){
   else _setWorkspacePanelTabDataset();
 }
 
+const RUN_GRAPH_LAST_RUN_KEY='hermes-webui-last-run-id-by-session';
+let _runGraphFetchToken=0;
+let _runGraphDisplayState={sessionId:'',runId:'',html:'',status:'idle'};
+
+function _runGraphLastRunStore(){
+  try{
+    const parsed=JSON.parse(localStorage.getItem(RUN_GRAPH_LAST_RUN_KEY)||'{}');
+    return parsed&&typeof parsed==='object'&&!Array.isArray(parsed)?parsed:{};
+  }catch(_){return {};}
+}
+
+function _saveRunGraphLastRunStore(store){
+  try{localStorage.setItem(RUN_GRAPH_LAST_RUN_KEY,JSON.stringify(store||{}));}catch(_){}
+}
+
+function _setRunGraphRememberedRun(sessionId,runId){
+  sessionId=String(sessionId||'').trim();
+  runId=String(runId||'').trim();
+  if(!sessionId||!runId) return false;
+  const store=_runGraphLastRunStore();
+  store[sessionId]=runId;
+  _saveRunGraphLastRunStore(store);
+  if(S.session&&S.session.session_id===sessionId){
+    S.lastRunId=runId;
+    S.lastRunSessionId=sessionId;
+  }
+  return true;
+}
+
+function rememberSessionRunGraphRun(sessionId, runId){
+  if(!_setRunGraphRememberedRun(sessionId,runId)) return;
+  if(_workspacePanelActiveTab==='artifacts') scheduleRenderSessionArtifacts();
+}
+
+async function _fetchLatestRunGraphRunId(sessionId){
+  sessionId=String(sessionId||'').trim();
+  if(!sessionId) return '';
+  const latest=await api(`/api/run/latest?session_id=${encodeURIComponent(sessionId)}`,{timeoutMs:8000});
+  const runId=String((latest&&latest.run_id)||(latest&&latest.journal&&latest.journal.run_id)||'').trim();
+  if(runId) _setRunGraphRememberedRun(sessionId,runId);
+  return runId;
+}
+
+function _runGraphRunId(session){
+  const sid=session&&session.session_id;
+  const inflight=sid&&INFLIGHT[sid];
+  const activeForSession=(S.session&&S.session.session_id===sid)?S.activeStreamId:'';
+  const stored=sid?_runGraphLastRunStore()[sid]:'';
+  const remembered=(S.lastRunSessionId===sid)?S.lastRunId:'';
+  return String(activeForSession||session&&session.active_stream_id||inflight&&inflight.streamId||remembered||stored||'').trim();
+}
+
+function _runGraphStatusClass(status){
+  const value=String(status||'unknown').trim().toLowerCase().replace(/[^a-z0-9_-]+/g,'-');
+  return value||'unknown';
+}
+
+function _runGraphValueText(value){
+  if(value===null||value===undefined||value==='') return '';
+  if(typeof value==='object'){
+    try{return JSON.stringify(value);}catch(_){return String(value);}
+  }
+  return String(value);
+}
+
+function _runGraphLatestHtml(latest){
+  const entries=Object.entries(latest&&typeof latest==='object'?latest:{}).filter(([,value])=>_runGraphValueText(value)).slice(0,4);
+  if(!entries.length) return '';
+  return `<div class="workspace-run-graph-latest">${entries.map(([key,value])=>`<span><b>${esc(key)}</b> ${esc(_runGraphValueText(value))}</span>`).join('')}</div>`;
+}
+
+function _runGraphNodeSeqText(node){
+  const first=Number(node&&node.first_seq||0);
+  const last=Number(node&&node.last_seq||0);
+  if(first&&last&&first!==last) return `seq ${first}–${last}`;
+  if(last) return `seq ${last}`;
+  return '';
+}
+
+function _runGraphNodeHtml(node){
+  node=node||{};
+  const status=_runGraphStatusClass(node.status);
+  const kind=String(node.kind||'event');
+  const count=Number(node.event_count||0);
+  const seq=_runGraphNodeSeqText(node);
+  const meta=[kind,count?`${count} event${count===1?'':'s'}`:'',seq].filter(Boolean).join(' · ');
+  return `<article class="workspace-run-graph-card status-${esc(status)}" data-run-graph-node-kind="${esc(kind)}" data-run-graph-node-status="${esc(status)}">
+    <div class="workspace-run-graph-card-head">
+      <span class="workspace-run-graph-node-label">${esc(node.label||kind)}</span>
+      <span class="workspace-run-graph-node-status">${esc(status)}</span>
+    </div>
+    <div class="workspace-run-graph-node-meta">${esc(meta)}</div>
+    ${_runGraphLatestHtml(node.latest)}
+  </article>`;
+}
+
+function _runGraphCardHtml(graph){
+  graph=graph||{};
+  const nodes=Array.isArray(graph.nodes)?graph.nodes:[];
+  const edges=Array.isArray(graph.edges)?graph.edges:[];
+  if(!nodes.length){
+    return '<div class="workspace-run-graph-empty">No run journal events found for this run yet.</div>';
+  }
+  const root=nodes.find(node=>node&&node.kind==='run')||nodes[0]||{};
+  const childNodes=nodes.filter(node=>node&&node!==root);
+  const status=_runGraphStatusClass(graph.status||root.status);
+  const eventCount=Number(graph.event_count||root.event_count||0);
+  const edgeHtml=edges.length?`<div class="workspace-run-graph-edge">${esc(edges.length)} edge${edges.length===1?'':'s'} projected from journal order</div>`:'';
+  return `<div class="workspace-run-graph-summary status-${esc(status)}">
+      <div>
+        <div class="workspace-run-graph-title">Run graph</div>
+        <div class="workspace-run-graph-subtitle">${esc(graph.run_id||'run')} · ${esc(status)} · ${eventCount} event${eventCount===1?'':'s'}</div>
+      </div>
+    </div>
+    <div class="workspace-run-graph-grid">
+      ${_runGraphNodeHtml(root)}
+      ${childNodes.map(_runGraphNodeHtml).join('')}
+    </div>
+    ${edgeHtml}`;
+}
+
+function _runGraphShellHtml(inner){
+  return `<section class="workspace-run-graph" id="workspaceRunGraph" aria-label="Run graph">${inner||''}</section>`;
+}
+
+function _runGraphPlaceholderHtml(message, tone='empty'){
+  return `<div class="workspace-run-graph-empty ${esc(tone)}">${esc(message||'No run graph available yet.')}</div>`;
+}
+
+function _currentRunGraphShellHtml(){
+  const session=S.session;
+  if(!session) return _runGraphShellHtml(_runGraphPlaceholderHtml('Open a conversation to see the run graph.'));
+  const sessionId=String(session.session_id||'');
+  const runId=_runGraphRunId(session);
+  if(!runId) return _runGraphShellHtml(_runGraphPlaceholderHtml('Looking up latest run graph…','loading'));
+  if(_runGraphDisplayState.sessionId===sessionId&&_runGraphDisplayState.runId===runId&&_runGraphDisplayState.html){
+    return _runGraphShellHtml(_runGraphDisplayState.html);
+  }
+  return _runGraphShellHtml(_runGraphPlaceholderHtml('Loading run graph…','loading'));
+}
+
+async function renderSessionRunGraph(force=false){
+  const root=$('workspaceRunGraph');
+  if(!root) return;
+  const session=S.session;
+  if(!session){root.innerHTML=_runGraphPlaceholderHtml('Open a conversation to see the run graph.');return;}
+  const sessionId=String(session.session_id||'').trim();
+  let runId=_runGraphRunId(session);
+  if(!sessionId){root.innerHTML=_runGraphPlaceholderHtml('No run graph yet. Start a run and journaled events will appear here.');return;}
+  if(!force&&_workspacePanelActiveTab!=='artifacts') return;
+  const token=++_runGraphFetchToken;
+  root.innerHTML=_runGraphDisplayState.sessionId===sessionId&&_runGraphDisplayState.runId===runId&&_runGraphDisplayState.html
+    ? _runGraphDisplayState.html
+    : _runGraphPlaceholderHtml(runId?'Loading run graph…':'Looking up latest run graph…','loading');
+  try{
+    if(!runId){
+      runId=await _fetchLatestRunGraphRunId(sessionId);
+      if(token!==_runGraphFetchToken) return;
+      if(!runId){
+        const html=_runGraphPlaceholderHtml('No run graph yet. Start a run and journaled events will appear here.');
+        _runGraphDisplayState={sessionId,runId:'',html,status:'empty'};
+        root.innerHTML=html;
+        return;
+      }
+    }
+    const graph=await api(`/api/run/graph?session_id=${encodeURIComponent(sessionId)}&run_id=${encodeURIComponent(runId)}`,{timeoutMs:8000});
+    if(token!==_runGraphFetchToken) return;
+    const html=_runGraphCardHtml(graph);
+    _runGraphDisplayState={sessionId,runId,html,status:'loaded'};
+    root.innerHTML=html;
+  }catch(e){
+    if(token!==_runGraphFetchToken) return;
+    const message=e&&e.message?e.message:'Run graph unavailable';
+    const html=_runGraphPlaceholderHtml(`Run graph unavailable: ${message}`,'error');
+    _runGraphDisplayState={sessionId,runId,html,status:'error'};
+    root.innerHTML=html;
+  }
+}
+
 function switchWorkspacePanelTab(tab){
   _workspacePanelActiveTab = tab === 'artifacts' ? 'artifacts' : 'files';
   _setWorkspacePanelTabDataset();
@@ -244,15 +423,17 @@ function renderSessionArtifacts(){
   if(!root) return;
   const items = collectSessionArtifacts();
   if(count) count.textContent = String(items.length);
+  const runGraphHtml = _currentRunGraphShellHtml();
   if(!S.session){
-    root.innerHTML = '<div class="workspace-artifact-empty">Open a conversation to see files changed in this session.</div>';
+    root.innerHTML = runGraphHtml + '<div class="workspace-artifact-empty">Open a conversation to see files changed in this session.</div>';
+    renderSessionRunGraph();
     return;
   }
-  if(!items.length){
-    root.innerHTML = '<div class="workspace-artifact-empty">No artifacts detected yet. Files created or edited during this session will appear here.</div>';
-    return;
-  }
-  root.innerHTML = items.map(item => `<button type="button" class="workspace-artifact-item" data-artifact-path="${esc(item.path)}" onclick="openArtifactPath(this.dataset.artifactPath)"><div class="workspace-artifact-path">${esc(item.path)}</div><div class="workspace-artifact-meta">${esc(item.source || 'session')}</div></button>`).join('');
+  const artifactHtml = items.length
+    ? items.map(item => `<button type="button" class="workspace-artifact-item" data-artifact-path="${esc(item.path)}" onclick="openArtifactPath(this.dataset.artifactPath)"><div class="workspace-artifact-path">${esc(item.path)}</div><div class="workspace-artifact-meta">${esc(item.source || 'session')}</div></button>`).join('')
+    : '<div class="workspace-artifact-empty">No artifacts detected yet. Files created or edited during this session will appear here.</div>';
+  root.innerHTML = runGraphHtml + artifactHtml;
+  renderSessionRunGraph();
 }
 
 function openArtifactPath(path){

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -471,7 +471,20 @@ def test_server():
     real_skills  = HERMES_HOME / 'skills'
     test_skills  = TEST_STATE_DIR / 'skills'
     if real_skills.exists() and not test_skills.exists():
-        test_skills.symlink_to(real_skills)
+        try:
+            test_skills.symlink_to(real_skills, target_is_directory=True)
+        except OSError as exc:
+            # Windows without Developer Mode/admin symlink privileges raises
+            # WinError 1314.  Tests should still run locally, so fall back to a
+            # real copy inside the isolated test home.  Keep this narrow: only
+            # test state is copied, never production state files.
+            if getattr(exc, 'winerror', None) != 1314:
+                raise
+            shutil.copytree(
+                real_skills,
+                test_skills,
+                ignore=shutil.ignore_patterns('__pycache__', '*.pyc', '.git'),
+            )
 
     # Isolated cron state
     (TEST_STATE_DIR / 'cron').mkdir(parents=True, exist_ok=True)

--- a/tests/test_operator_commitments.py
+++ b/tests/test_operator_commitments.py
@@ -1,0 +1,656 @@
+import importlib
+import io
+import json
+import subprocess
+import sys
+import threading
+import types
+from pathlib import Path
+from urllib.parse import urlparse
+from unittest.mock import patch
+
+
+REQUIRED_FIELDS = {
+    "owner",
+    "deadline_at",
+    "dispatch_mechanism",
+    "source",
+    "acceptance_criteria",
+    "halt_policy",
+    "evidence",
+    "status",
+}
+
+
+def _patch_state_dir(monkeypatch, tmp_path):
+    import api.config as config
+
+    state_dir = tmp_path / "webui-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(config, "STATE_DIR", state_dir, raising=False)
+    return state_dir
+
+
+def _write_store(path: Path, commitments):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"version": 1, "updated_at": 123.0, "commitments": commitments}), encoding="utf-8")
+
+
+def _valid_commitment(**overrides):
+    card = {
+        "id": "c_valid",
+        "created_at": 100.0,
+        "updated_at": 100.0,
+        "profile": "default",
+        "title": "Ship commitment cards",
+        "summary": "Record source-backed promises as local commitment cards.",
+        "owner": "Max",
+        "deadline_at": "2026-05-30T17:00:00Z",
+        "review_at": None,
+        "dispatch_mechanism": {"kind": "manual", "label": "Manual WebUI follow-up", "would_execute": False},
+        "source": {
+            "kind": "operator_proposal",
+            "proposal_id": "commitment_cards",
+            "session_id": "abc123",
+            "content_hash": "sha256:abc",
+            "quote": "Commitment cards / promote to commitment",
+        },
+        "acceptance_criteria": ["Targeted tests pass", "No dispatch is wired"],
+        "halt_policy": "Stop if evidence is missing or source cannot be verified.",
+        "evidence": [{"kind": "source", "label": "Operator proposal", "state": "present"}],
+        "status": "active",
+        "would_execute": False,
+    }
+    card.update(overrides)
+    return card
+
+
+def _valid_promote_body(**overrides):
+    body = {
+        "title": "Commitment cards / promote to commitment",
+        "summary": "Turn promises into durable local commitment cards.",
+        "owner": "Max",
+        "deadline_at": "2026-05-30T17:00:00Z",
+        "dispatch_mechanism": {"kind": "manual", "label": "Manual WebUI follow-up", "would_execute": False},
+        "source": {"kind": "operator_proposal", "proposal_id": "commitment_cards", "session_id": "abc123"},
+        "acceptance_criteria": ["Commitment can be read back", "No Kanban mutation occurs"],
+        "halt_policy": "Stop if source proof is missing or stale.",
+        "status": "active",
+    }
+    body.update(overrides)
+    return body
+
+
+def _patch_truth(monkeypatch, *, status="live"):
+    import api.operator_truth as operator_truth
+
+    def fake_truth_payload(*, session_id=None, ui_board_hint=None, now=None):
+        return {
+            "version": 1,
+            "verified_at": now,
+            "status": status,
+            "summary": f"Truth {status}",
+            "chips": [],
+            "sources": [],
+            "issues": [] if status == "live" else [f"truth {status}"],
+        }
+
+    monkeypatch.setattr(operator_truth, "build_operator_truth_payload", fake_truth_payload, raising=False)
+
+
+def _patch_proposals(monkeypatch):
+    import api.operator_proposals as operator_proposals
+
+    def fake_proposals(*, session_id=None, ui_board_hint=None, now=None):
+        return {
+            "version": 1,
+            "generated_at": now,
+            "status": "live",
+            "mode": "manual-read-only",
+            "would_execute": False,
+            "proposals": [
+                {
+                    "id": "commitment_cards",
+                    "rank": 5,
+                    "title": "Commitment cards / promote to commitment",
+                    "summary": "Convert promised work into durable objects with owner/deadline/dispatch/evidence.",
+                    "owner": "future Hermes WebUI task",
+                    "would_execute": False,
+                    "evidence": [{"source_id": "action_summary", "status": "live"}],
+                }
+            ],
+            "sources": [],
+            "issues": [],
+        }
+
+    monkeypatch.setattr(operator_proposals, "build_operator_proposal_payload", fake_proposals, raising=False)
+
+
+def test_operator_commitments_missing_store_returns_unknown_without_fake_cards(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    _patch_state_dir(monkeypatch, tmp_path)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = commitments.build_operator_commitments_payload(now=123.0)
+
+    assert payload["version"] == 1
+    assert payload["generated_at"] == 123.0
+    assert payload["mode"] == "local-commitment-cards"
+    assert payload["would_execute"] is False
+    assert payload["status"] == "unknown"
+    assert payload["commitments"] == []
+    assert not any("sample" in json.dumps(item).lower() or "demo" in json.dumps(item).lower() for item in payload["commitments"])
+    assert any("missing" in issue.lower() or "unavailable" in issue.lower() for issue in payload["issues"])
+    assert not commitments.commitment_store_path().exists()
+
+
+def test_operator_commitments_store_path_is_local_state_not_repo_static_or_kanban(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    state_dir = _patch_state_dir(monkeypatch, tmp_path)
+
+    store = commitments.commitment_store_path()
+
+    assert store == state_dir / "operator_commitments.json"
+    store_text = str(store)
+    assert "/home/malac/hermes-webui" not in store_text
+    assert "/mnt/c/Users/malac/.openclaw/workspace/main" not in store_text
+    assert "/static/" not in store_text
+    assert "/kanban/" not in store_text
+
+
+def test_operator_commitments_existing_cards_require_required_fields_and_classify_notes(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    _patch_state_dir(monkeypatch, tmp_path)
+    _patch_truth(monkeypatch, status="live")
+    invalid_note = {"id": "note_1", "title": "Loose promise", "summary": "missing owner/deadline/dispatch"}
+    _write_store(commitments.commitment_store_path(), [_valid_commitment(), invalid_note])
+
+    payload = commitments.build_operator_commitments_payload(now=200.0)
+
+    assert len(payload["commitments"]) == 1
+    card = payload["commitments"][0]
+    assert REQUIRED_FIELDS.issubset(card.keys())
+    assert card["would_execute"] is False
+    assert card["dispatch_mechanism"]["would_execute"] is False
+    assert payload["notes"]
+    assert payload["notes"][0]["classification"] == "note"
+    assert any("missing" in issue.lower() for issue in payload["issues"])
+
+
+def test_operator_commitments_existing_cards_reject_malformed_source_and_placeholder_evidence(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    _patch_state_dir(monkeypatch, tmp_path)
+    _patch_truth(monkeypatch, status="live")
+    malformed = _valid_commitment(source={"foo": "bar"}, evidence=[{}])
+    _write_store(commitments.commitment_store_path(), [malformed])
+
+    payload = commitments.build_operator_commitments_payload(now=225.0)
+
+    assert payload["commitments"] == []
+    assert payload["notes"]
+    assert payload["notes"][0]["classification"] == "note"
+    assert {"source", "evidence"}.issubset(set(payload["notes"][0]["missing"]))
+    assert payload["status"] != "live"
+    assert any("source" in issue.lower() or "evidence" in issue.lower() for issue in payload["issues"])
+
+
+def test_operator_commitment_promote_rejects_incomplete_payload_as_note_without_writing(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    _patch_state_dir(monkeypatch, tmp_path)
+
+    result = commitments.promote_operator_commitment({"title": "Loose note"}, now=300.0)
+
+    assert result["ok"] is False
+    assert result["classification"] == "note"
+    assert {"owner", "deadline_or_review", "dispatch_mechanism", "source", "acceptance_criteria", "halt_policy"}.issubset(set(result["missing"]))
+    assert not commitments.commitment_store_path().exists()
+
+
+def test_operator_commitment_promote_requires_real_source_proposal_or_session_message(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    _patch_state_dir(monkeypatch, tmp_path)
+    _patch_proposals(monkeypatch)
+
+    bad = commitments.promote_operator_commitment(
+        _valid_promote_body(source={"kind": "operator_proposal", "proposal_id": "missing", "session_id": "abc123"}),
+        now=400.0,
+    )
+    assert bad["ok"] is False
+    assert "source" in bad["missing"] or any("source" in issue.lower() for issue in bad.get("issues", []))
+    assert not commitments.commitment_store_path().exists()
+
+    good = commitments.promote_operator_commitment(
+        _valid_promote_body(source={"kind": "operator_proposal", "proposal_id": "commitment_cards", "session_id": "abc123", "quote": "CLIENT FAKE QUOTE"}),
+        now=401.0,
+    )
+    assert good["ok"] is True
+    card = good["commitment"]
+    assert card["source"]["proposal_id"] == "commitment_cards"
+    assert "CLIENT FAKE QUOTE" not in json.dumps(card)
+    assert "durable objects" in card["source"]["quote"]
+
+
+def test_operator_commitment_promote_accepts_explicit_recall_session_message_without_session_load(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    _patch_state_dir(monkeypatch, tmp_path)
+
+    import api.models as models
+
+    calls = []
+
+    def forbidden_load(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("session_message promotion must not call Session.load")
+
+    monkeypatch.setattr(models.Session, "load", staticmethod(forbidden_load), raising=False)
+    source = {
+        "kind": "session_message",
+        "session_id": "abc123",
+        "message_index": 0,
+        "content_hash": "sha256:" + "a" * 64,
+        "quote": "Redacted source quote",
+    }
+
+    result = commitments.promote_operator_commitment(_valid_promote_body(source=source), now=450.0)
+
+    assert result["ok"] is True
+    assert calls == []
+    card = result["commitment"]
+    assert card["source"] == source
+    assert card["evidence"] == [
+        {
+            "kind": "source",
+            "label": "Session message",
+            "state": "present",
+            "session_id": "abc123",
+            "message_index": 0,
+            "content_hash": source["content_hash"],
+        }
+    ]
+
+    stored = json.loads(commitments.commitment_store_path().read_text(encoding="utf-8"))
+    stored_card = stored["commitments"][0]
+    assert stored_card["source"] == source
+    assert stored_card["source"]["quote"] == "Redacted source quote"
+    assert "password=" not in json.dumps(stored_card).lower()
+
+
+def test_operator_commitment_promote_rejects_session_message_without_explicit_hash_quote_and_strict_index(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    _patch_state_dir(monkeypatch, tmp_path)
+
+    import api.models as models
+
+    def fake_load(_sid):
+        return types.SimpleNamespace(
+            messages=[
+                {"role": "user", "content": "Raw session message zero"},
+                {"role": "assistant", "content": "Raw session message one"},
+            ]
+        )
+
+    monkeypatch.setattr(models.Session, "load", staticmethod(fake_load), raising=False)
+    valid_hash = "sha256:" + "b" * 64
+    base_source = {
+        "kind": "session_message",
+        "session_id": "abc123",
+        "message_index": 0,
+        "content_hash": valid_hash,
+        "quote": "Redacted source quote",
+    }
+    invalid_sources = [
+        ("missing content_hash", {key: value for key, value in base_source.items() if key != "content_hash"}),
+        ("missing quote", {key: value for key, value in base_source.items() if key != "quote"}),
+        ("short hash", {**base_source, "content_hash": "sha256:abc"}),
+        ("not a hash", {**base_source, "content_hash": "not-a-hash"}),
+        ("float index", {**base_source, "message_index": 1.9}),
+        ("negative-ish index", {**base_source, "message_index": -0.2}),
+        ("non-decimal index", {**base_source, "message_index": "0x1"}),
+    ]
+
+    for label, source in invalid_sources:
+        result = commitments.promote_operator_commitment(_valid_promote_body(source=source), now=460.0)
+        assert result["ok"] is False, label
+        assert "source" in result.get("missing", []) or any("source" in issue.lower() for issue in result.get("issues", [])), label
+        assert not commitments.commitment_store_path().exists(), label
+
+
+def test_operator_commitment_promote_rejects_raw_secret_session_message_quote_without_writing(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    _patch_state_dir(monkeypatch, tmp_path)
+
+    import api.models as models
+
+    calls = []
+
+    def forbidden_load(_sid):
+        calls.append(_sid)
+        raise AssertionError("session_message raw-secret validation must not call Session.load")
+
+    monkeypatch.setattr(models.Session, "load", staticmethod(forbidden_load), raising=False)
+
+    def source_for(quote, hash_fill="c"):
+        return {
+            "kind": "session_message",
+            "session_id": "abc123",
+            "message_index": 0,
+            "content_hash": "sha256:" + hash_fill * 64,
+            "quote": quote,
+        }
+
+    raw_secret_quotes = [
+        ("password key-value", "password=supersecret"),
+        ("bearer token", "Bearer abcdefghijklmnop12345"),
+        ("openai token", "sk-" + "a" * 48),
+        ("slack bot token", "xox" + "b-123456789012-123456789012-abcdefghijklmnopqrstuvwx"),
+    ]
+
+    for label, quote in raw_secret_quotes:
+        result = commitments.promote_operator_commitment(
+            _valid_promote_body(source=source_for(quote)),
+            now=470.0,
+        )
+
+        assert result["ok"] is False, label
+        assert "source" in result.get("missing", []) or any("source" in issue.lower() for issue in result.get("issues", [])), label
+        assert not commitments.commitment_store_path().exists(), label
+        assert calls == [], label
+
+    accepted = commitments.promote_operator_commitment(
+        _valid_promote_body(source=source_for("password=[redacted]", hash_fill="d")),
+        now=471.0,
+    )
+
+    assert accepted["ok"] is True
+    assert calls == []
+    stored = json.loads(commitments.commitment_store_path().read_text(encoding="utf-8"))
+    stored_card = stored["commitments"][0]
+    assert stored_card["source"]["quote"] == "password=[redacted]"
+    assert "supersecret" not in json.dumps(stored_card).lower()
+
+
+def test_operator_commitment_promote_rejects_github_token_session_message_quote_without_loading_or_writing(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    _patch_state_dir(monkeypatch, tmp_path)
+
+    import api.models as models
+
+    calls = []
+
+    def forbidden_load(_sid):
+        calls.append(_sid)
+        raise AssertionError("session_message raw-secret validation must not call Session.load")
+
+    monkeypatch.setattr(models.Session, "load", staticmethod(forbidden_load), raising=False)
+
+    def source_for(quote, hash_fill="e"):
+        return {
+            "kind": "session_message",
+            "session_id": "abc123",
+            "message_index": 0,
+            "content_hash": "sha256:" + hash_fill * 64,
+            "quote": quote,
+        }
+
+    raw_classic_pat = "ghp_" + "A" * 36
+    raw_fine_grained_pat = "github_pat_" + "B" * 22 + "_" + "C" * 59
+    token_cases = [
+        ("github classic token", raw_classic_pat),
+        ("github fine-grained token", raw_fine_grained_pat),
+    ]
+    delimiter_cases = [
+        ("end", ""),
+        ("period", "."),
+        ("close paren", ")"),
+        ("close bracket", "]"),
+        ("double quote", '"'),
+        ("newline", "\nnext line"),
+    ]
+    for token_label, raw_token in token_cases:
+        for delimiter_label, delimiter in delimiter_cases:
+            quote = f"{raw_token}{delimiter}"
+            label = f"{token_label} followed by {delimiter_label}"
+            result = commitments.promote_operator_commitment(
+                _valid_promote_body(source=source_for(quote)),
+                now=472.0,
+            )
+
+            assert result["ok"] is False, label
+            assert "source" in result.get("missing", []) or any("source" in issue.lower() for issue in result.get("issues", [])), label
+            assert not commitments.commitment_store_path().exists(), label
+            assert calls == [], label
+
+    for label, quote in [
+        ("github classic token embedded in longer token", raw_classic_pat + "A"),
+        ("github fine-grained token embedded in longer token", raw_fine_grained_pat + "_"),
+    ]:
+        result = commitments.promote_operator_commitment(
+            _valid_promote_body(source=source_for(quote)),
+            now=472.0,
+        )
+
+        assert result["ok"] is False, label
+        assert "source" in result.get("missing", []) or any("source" in issue.lower() for issue in result.get("issues", [])), label
+        assert not commitments.commitment_store_path().exists(), label
+        assert calls == [], label
+
+    accepted = commitments.promote_operator_commitment(
+        _valid_promote_body(source=source_for("github_pat_[redacted]", hash_fill="f")),
+        now=473.0,
+    )
+    assert accepted["ok"] is True
+    assert calls == []
+    stored = json.loads(commitments.commitment_store_path().read_text(encoding="utf-8"))
+    stored_card = stored["commitments"][0]
+    assert stored_card["source"]["quote"] == "github_pat_[redacted]"
+    assert raw_classic_pat not in json.dumps(stored_card)
+    assert raw_fine_grained_pat not in json.dumps(stored_card)
+
+
+def test_operator_commitment_promote_persists_local_card_with_would_execute_false(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    _patch_state_dir(monkeypatch, tmp_path)
+    _patch_proposals(monkeypatch)
+
+    result = commitments.promote_operator_commitment(_valid_promote_body(), now=500.0, client_context={"profile": "default"})
+
+    assert result["ok"] is True
+    card = result["commitment"]
+    assert card["id"].startswith("c_")
+    assert card["created_at"] == 500.0
+    assert card["updated_at"] == 500.0
+    assert card["profile"] == "default"
+    assert card["would_execute"] is False
+    assert card["dispatch_mechanism"] == {"kind": "manual", "label": "Manual WebUI follow-up", "would_execute": False}
+    assert card["source"]["kind"] == "operator_proposal"
+    assert card["evidence"]
+
+    stored = json.loads(commitments.commitment_store_path().read_text(encoding="utf-8"))
+    assert stored["version"] == 1
+    assert stored["commitments"][0]["id"] == card["id"]
+
+
+def test_operator_commitment_promote_rejects_auto_dispatch_cron_goal_aim_mechanisms(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    _patch_state_dir(monkeypatch, tmp_path)
+    _patch_proposals(monkeypatch)
+
+    forbidden = ["cron", "goal_loop", "auto_dispatch", "background_loop", "kanban_dispatcher", "aim_cron", "aim_runtime", "webhook"]
+    for value in forbidden:
+        result = commitments.promote_operator_commitment(
+            _valid_promote_body(dispatch_mechanism={"kind": value, "label": value, "would_execute": False}),
+            now=600.0,
+        )
+        assert result["ok"] is False, value
+        assert "dispatch_mechanism" in result["missing"] or any(value in issue.lower() for issue in result.get("issues", []))
+    assert not commitments.commitment_store_path().exists()
+
+
+def test_operator_commitment_promote_never_calls_dispatch_cron_goal_shell_or_kanban(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    _patch_state_dir(monkeypatch, tmp_path)
+    _patch_proposals(monkeypatch)
+    calls = []
+
+    def forbidden(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("commitment promotion must not dispatch, shell, cron, goal, or mutate Kanban")
+
+    fake_kanban_bridge = types.ModuleType("api.kanban_bridge")
+    for name in ("handle_kanban_post", "handle_kanban_patch", "handle_kanban_delete", "dispatch", "create_task", "claim", "complete"):
+        setattr(fake_kanban_bridge, name, forbidden)
+    fake_cron = types.ModuleType("cron.jobs")
+    setattr(fake_cron, "create", forbidden)
+    fake_goals = types.ModuleType("api.goals")
+    setattr(fake_goals, "set_goal", forbidden)
+    monkeypatch.setitem(sys.modules, "api.kanban_bridge", fake_kanban_bridge)
+    monkeypatch.setitem(sys.modules, "cron.jobs", fake_cron)
+    monkeypatch.setitem(sys.modules, "api.goals", fake_goals)
+    monkeypatch.setattr(subprocess, "run", forbidden)
+    monkeypatch.setattr(subprocess, "Popen", forbidden)
+    monkeypatch.setattr(threading, "Thread", forbidden)
+    monkeypatch.setattr(threading, "Timer", forbidden)
+
+    result = commitments.promote_operator_commitment(_valid_promote_body(), now=700.0)
+
+    assert result["ok"] is True
+    assert calls == []
+
+
+def test_operator_commitments_includes_truth_and_degrades_stale_truth(monkeypatch, tmp_path):
+    commitments = importlib.import_module("api.operator_commitments")
+    _patch_state_dir(monkeypatch, tmp_path)
+    _patch_truth(monkeypatch, status="stale")
+    _write_store(commitments.commitment_store_path(), [_valid_commitment()])
+
+    payload = commitments.build_operator_commitments_payload(session_id="abc123", ui_board_hint="hermes-operator", now=800.0)
+
+    assert payload["truth"]["status"] == "stale"
+    assert payload["status"] != "live"
+    assert any("operator_truth" in issue and "stale" in issue for issue in payload["issues"])
+
+
+def test_operator_commitments_route_get_returns_json(monkeypatch):
+    import api.routes as routes
+
+    expected = {"version": 1, "status": "unknown", "commitments": [], "sources": []}
+    captured = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        captured["payload"] = payload
+        return True
+
+    with patch("api.operator_commitments.build_operator_commitments_payload", return_value=expected) as build_payload, patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        handled = routes.handle_get(
+            types.SimpleNamespace(wfile=io.BytesIO()),
+            urlparse("/api/operator/commitments?session_id=abc123&ui_board=hermes-operator"),
+        )
+
+    assert handled is True
+    assert captured["status"] == 200
+    assert captured["payload"] == expected
+    build_payload.assert_called_once_with(session_id="abc123", ui_board_hint="hermes-operator")
+
+
+class _PostHandler:
+    def __init__(self, body=None, *, client_ip="127.0.0.1", headers=None):
+        raw = json.dumps(body or {}).encode("utf-8")
+        self.rfile = io.BytesIO(raw)
+        self.wfile = io.BytesIO()
+        self.client_address = (client_ip, 54321)
+        base_headers = {"Content-Length": str(len(raw)), "Host": "127.0.0.1:8787"}
+        if headers:
+            base_headers.update(headers)
+        self.headers = base_headers
+
+
+def test_operator_commitments_promote_route_accepts_loopback_localhost_only(monkeypatch):
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        captured["payload"] = payload
+        return True
+
+    def fake_promote(body, *, now=None, client_context=None):
+        captured["body"] = body
+        captured["client_context"] = client_context
+        return {"ok": True, "commitment": {"id": "c_route"}}
+
+    handler = _PostHandler(_valid_promote_body(), headers={"Origin": "http://127.0.0.1:8787"})
+    with patch("api.operator_commitments.promote_operator_commitment", side_effect=fake_promote) as promote, patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        handled = routes.handle_post(handler, urlparse("/api/operator/commitments/promote"))
+
+    assert handled is True
+    assert promote.call_count == 1
+    assert captured["status"] == 201
+    assert captured["body"]["owner"] == "Max"
+    assert captured["client_context"]["client_ip"] == "127.0.0.1"
+
+
+def test_operator_commitments_promote_route_rejects_public_origin_even_when_allowed(monkeypatch):
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        captured["payload"] = payload
+        return True
+
+    def forbidden_promote(*args, **kwargs):
+        raise AssertionError("public commitment writes must not call promote")
+
+    monkeypatch.setenv("HERMES_WEBUI_ALLOWED_ORIGINS", "https://public.example")
+    public_header_cases = [
+        {"Origin": "https://public.example", "Host": "public.example"},
+        {"Origin": "http://127.0.0.1:8787", "Host": "127.0.0.1:8787@public.example"},
+        {"Origin": "http://127.0.0.1:8787@public.example", "Host": "127.0.0.1:8787"},
+    ]
+    with patch("api.operator_commitments.promote_operator_commitment", side_effect=forbidden_promote), patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        for headers in public_header_cases:
+            captured.clear()
+            handler = _PostHandler(
+                _valid_promote_body(),
+                client_ip="127.0.0.1" if "@public.example" in json.dumps(headers) else "203.0.113.10",
+                headers=headers,
+            )
+            handled = routes.handle_post(handler, urlparse("/api/operator/commitments/promote"))
+            assert handled is True
+            assert captured["status"] in {403, 404}
+
+
+def test_operator_commitments_promote_route_rejects_public_x_forwarded_for_proxy(monkeypatch):
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        captured["payload"] = payload
+        return True
+
+    def forbidden_promote(*args, **kwargs):
+        raise AssertionError("proxied public commitment writes must not call promote")
+
+    handler = _PostHandler(
+        _valid_promote_body(),
+        client_ip="127.0.0.1",
+        headers={"Origin": "http://127.0.0.1:8787", "X-Forwarded-For": "203.0.113.11"},
+    )
+    with patch("api.operator_commitments.promote_operator_commitment", side_effect=forbidden_promote), patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        handled = routes.handle_post(handler, urlparse("/api/operator/commitments/promote"))
+
+    assert handled is True
+    assert captured["status"] in {403, 404}

--- a/tests/test_operator_commitments_ui_static.py
+++ b/tests/test_operator_commitments_ui_static.py
@@ -1,0 +1,507 @@
+import re
+import subprocess
+from pathlib import Path
+
+
+def _read(path):
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _js_function_body(js, function_name):
+    match = re.search(rf"function\s+{re.escape(function_name)}\s*\(", js)
+    assert match, f"missing function {function_name}"
+    brace = js.find("{", match.end())
+    assert brace >= 0, f"missing function body for {function_name}"
+    depth = 0
+    for index in range(brace, len(js)):
+        char = js[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return js[brace + 1 : index]
+    raise AssertionError(f"unterminated function body for {function_name}")
+
+
+def test_operator_commitment_markup_exists_near_proposal_chip_and_popover():
+    html = _read("static/index.html")
+
+    assert 'id="operatorCommitmentChip"' in html
+    assert 'id="operatorCommitmentPopover"' in html
+    assert 'id="operatorCommitmentList"' in html
+    assert 'id="operatorCommitmentForm"' in html
+    assert html.index('id="operatorProposalChip"') < html.index('id="operatorCommitmentChip"') < html.index('id="composerMobileConfigBtn"')
+    assert html.index('id="operatorProposalPopover"') < html.index('id="operatorCommitmentPopover"')
+
+
+def test_operator_commitments_script_loaded_after_kanban_before_boot():
+    html = _read("static/index.html")
+
+    assert html.index("static/operator_kanban.js") < html.index("static/operator_commitments.js") < html.index("static/boot.js")
+
+
+def test_operator_commitments_js_uses_operator_commitments_endpoints_only():
+    js = _read("static/operator_commitments.js")
+    compact = js.replace(" ", "")
+
+    assert "'/api/operator/commitments'" in js or '"/api/operator/commitments"' in js
+    assert "'/api/operator/commitments/promote'" in js or '"/api/operator/commitments/promote"' in js
+    assert "http://" not in js
+    assert "https://" not in js
+    assert "fetch(" not in js
+    assert "api(" in js
+    assert "method:'POST'" in compact or 'method:"POST"' in compact
+    assert "/api/operator/commitments/promote" in js
+
+
+def test_operator_commitments_js_no_kanban_chat_cron_goal_dispatch_or_background_tokens():
+    js = _read("static/operator_commitments.js")
+    forbidden = [
+        "/api/kanban/",
+        "/api/kanban/dispatch",
+        "/api/kanban/tasks",
+        "/api/chat/start",
+        "/api/chat",
+        "/api/cron",
+        "/api/crons",
+        "/api/goal",
+        "runKanbanDispatcher",
+        "nudgeKanbanDispatcher",
+        "createKanbanTask",
+        "updateKanbanTask",
+        "addKanbanComment",
+        "setInterval",
+        "setTimeout",
+        "EventSource",
+        "WebSocket",
+        "send(",
+        "sendMessage",
+    ]
+    for token in forbidden:
+        assert token not in js
+
+
+def test_operator_commitments_values_use_text_content_not_inner_html():
+    js = _read("static/operator_commitments.js")
+
+    assert ".textContent" in js
+    assert "document.createElement" in js
+    assert ".innerHTML" not in js
+    assert "payload.innerHTML" not in js
+    assert "commitment.innerHTML" not in js
+
+
+def test_operator_commitments_empty_state_points_to_proposal_promotion():
+    js = _read("static/operator_commitments.js")
+
+    assert "No commitments yet. Promote a proposal to create one." in js
+    assert "No commitment cards yet." not in js
+
+
+def test_operator_commitments_raw_secret_helper_rejects_github_pats_before_punctuation():
+    js = _read("static/operator_commitments.js")
+    body = _js_function_body(js, "_operatorCommitmentQuoteContainsRawSecret")
+
+    assert "ghp_" in body
+    assert "github_pat_" in body
+    assert "(?![A-Za-z0-9_])" in body
+
+    root = Path(__file__).resolve().parents[1]
+    node_script = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert/strict');
+
+const source = fs.readFileSync('static/operator_commitments.js', 'utf8');
+const context = {console, URLSearchParams, Promise};
+context.window = context;
+context.$ = () => null;
+vm.createContext(context);
+vm.runInContext(source, context, {filename: 'operator_commitments.js'});
+
+const classic = 'ghp_' + 'A'.repeat(36);
+const fineGrained = 'github_pat_' + 'B'.repeat(22) + '_' + 'C'.repeat(59);
+for (const [label, token] of [['classic', classic], ['fine-grained', fineGrained]]) {
+  for (const [delimiterLabel, suffix] of [
+    ['period', '.'],
+    ['close paren', ')'],
+    ['close bracket', ']'],
+    ['double quote', '"'],
+    ['newline', '\nnext line'],
+  ]) {
+    assert.equal(
+      context._operatorCommitmentQuoteContainsRawSecret(token + suffix),
+      true,
+      label + ' token followed by ' + delimiterLabel + ' must be treated as raw secret',
+    );
+  }
+}
+assert.equal(
+  context._operatorCommitmentQuoteContainsRawSecret('github_pat_[redacted].'),
+  false,
+  'redacted GitHub PAT placeholders must remain allowed next to punctuation',
+);
+"""
+    completed = subprocess.run(
+        ["node", "-e", node_script],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_operator_commitments_manual_refresh_no_polling_timers_or_eventsource():
+    js = _read("static/operator_commitments.js")
+
+    assert "function toggleOperatorCommitments" in js
+    assert "function refreshOperatorCommitments" in js
+    assert "function renderOperatorCommitments" in js
+    assert "window.toggleOperatorCommitments" in js
+    assert "setInterval" not in js
+    assert "setTimeout" not in js
+    assert "EventSource" not in js
+    assert "DOMContentLoaded" not in js or "refreshOperatorCommitments" not in js.split("DOMContentLoaded", 1)[1]
+
+
+def test_operator_commitments_form_blocks_submit_until_required_fields_present():
+    js = _read("static/operator_commitments.js")
+    compact = js.replace(" ", "")
+
+    for field in [
+        "owner",
+        "deadline_at",
+        "review_at",
+        "dispatch_mechanism",
+        "source",
+        "acceptance_criteria",
+        "halt_policy",
+        "evidence",
+        "status",
+    ]:
+        assert field in js
+    assert "_operatorCommitmentValidateForm" in js
+    assert "missing.length" in js
+    assert "return null" in js
+    assert "api('/api/operator/commitments/promote'" in compact or 'api("/api/operator/commitments/promote"' in compact
+
+
+def test_commitment_recall_helper_exports_session_message_source_without_auto_submit():
+    js = _read("static/operator_commitments.js")
+    body = _js_function_body(js, "openOperatorCommitmentPromoteFromRecall")
+    compact_body = body.replace(" ", "")
+
+    assert "window.openOperatorCommitmentPromoteFromRecall" in js
+    assert "kind:'session_message'" in compact_body or 'kind:"session_message"' in compact_body
+    for source_field in [
+        "session_id",
+        "message_index",
+        "content_hash",
+        "quote",
+    ]:
+        assert source_field in body
+    for forbidden in [
+        "/api/operator/commitments/promote",
+        "api(",
+        "submitOperatorCommitmentForm",
+    ]:
+        assert forbidden not in body
+    assert "operatorCommitmentDispatch" in body
+    assert "'manual'" in body or '"manual"' in body
+    assert "Stop if source evidence is stale or missing." in body
+
+
+def test_commitment_recall_helper_refuses_missing_session_message_proof_and_validation_blocks_it():
+    root = Path(__file__).resolve().parents[1]
+    node_script = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert/strict');
+
+const source = fs.readFileSync('static/operator_commitments.js', 'utf8');
+
+class ClassList {
+  constructor(element) {
+    this.element = element;
+    this.values = new Set();
+  }
+  add(...names) {
+    names.forEach(name => this.values.add(name));
+    this._sync();
+  }
+  remove(...names) {
+    names.forEach(name => this.values.delete(name));
+    this._sync();
+  }
+  contains(name) {
+    return this.values.has(name);
+  }
+  _sync() {
+    this.element.className = Array.from(this.values).join(' ');
+  }
+}
+
+class Element {
+  constructor(id = '', tagName = 'div') {
+    this.id = id;
+    this.tagName = String(tagName).toUpperCase();
+    this.children = [];
+    this.parentNode = null;
+    this.dataset = {};
+    this.hidden = false;
+    this.title = '';
+    this.value = '';
+    this.listeners = {};
+    this._textContent = '';
+    this.className = '';
+    this.classList = new ClassList(this);
+  }
+  get firstChild() {
+    return this.children[0] || null;
+  }
+  append(...nodes) {
+    nodes.forEach(node => this.appendChild(node));
+  }
+  appendChild(node) {
+    if (typeof node === 'string') {
+      const textNode = new Element('', '#text');
+      textNode.textContent = node;
+      node = textNode;
+    }
+    this.children.push(node);
+    node.parentNode = this;
+    return node;
+  }
+  removeChild(node) {
+    const index = this.children.indexOf(node);
+    if (index >= 0) {
+      this.children.splice(index, 1);
+      node.parentNode = null;
+    }
+    return node;
+  }
+  addEventListener(type, handler) {
+    this.listeners[type] = handler;
+  }
+  focus() {}
+  set textContent(value) {
+    this._textContent = String(value == null ? '' : value);
+    this.children = [];
+  }
+  get textContent() {
+    return this._textContent + this.children.map(child => child.textContent).join('');
+  }
+}
+
+const elements = new Map();
+function register(id) {
+  const element = new Element(id);
+  elements.set(id, element);
+  return element;
+}
+[
+  'operatorCommitmentChip',
+  'operatorCommitmentLabel',
+  'operatorCommitmentPopover',
+  'operatorCommitmentList',
+  'operatorCommitmentForm',
+  'operatorCommitmentMissing',
+  'operatorCommitmentSource',
+  'operatorCommitmentEvidence',
+  'operatorCommitmentTitle',
+  'operatorCommitmentOwner',
+  'operatorCommitmentDeadline',
+  'operatorCommitmentReview',
+  'operatorCommitmentDispatch',
+  'operatorCommitmentAcceptance',
+  'operatorCommitmentHaltPolicy',
+  'operatorCommitmentStatus',
+].forEach(register);
+
+elements.get('operatorCommitmentForm').hidden = true;
+elements.get('operatorCommitmentPopover').hidden = true;
+
+const document = {
+  getElementById(id) {
+    return elements.get(id) || null;
+  },
+  createElement(tagName) {
+    return new Element('', tagName);
+  },
+};
+
+const context = {console, document, URLSearchParams, Promise};
+context.window = context;
+context.$ = id => document.getElementById(id);
+context.api = () => Promise.resolve({status:'live', commitments:[], summary:'unused'});
+
+vm.createContext(context);
+vm.runInContext(source, context, {filename: 'operator_commitments.js'});
+
+const form = elements.get('operatorCommitmentForm');
+const popover = elements.get('operatorCommitmentPopover');
+const missing = elements.get('operatorCommitmentMissing');
+
+context.openOperatorCommitmentPromoteFromRecall({});
+assert.equal(form.hidden, true, 'malformed recall promotion must keep the draft form closed');
+assert.equal(popover.hidden, true, 'malformed recall promotion must not open the popover');
+assert.match(missing.textContent, /source proof/i, 'malformed recall promotion should explain the missing source proof');
+
+missing.textContent = '';
+form.hidden = true;
+popover.hidden = true;
+context.openOperatorCommitmentPromoteFromRecall({
+  session: {title:'Synthesized fallback proof is not proof', session_id:'session-synthesized-fallback'},
+  match: {
+    message_index: 0,
+    content_hash: 'sha256:' + 'b'.repeat(64),
+    snippet: 'valid-looking fallback quote must not become source proof',
+    timestamp: 1710000000,
+  },
+  recency: {label:'live'},
+  promotion: {
+    task: {
+      enabled:true,
+      mode:'local_commitment_draft',
+      would_execute:false,
+      source: {kind:'session_message'},
+    },
+  },
+});
+assert.equal(form.hidden, true, 'synthesized fallback proof must keep the draft form closed');
+assert.equal(popover.hidden, true, 'synthesized fallback proof must not open the popover');
+assert.match(missing.textContent, /source proof/i, 'synthesized fallback proof should explain the missing source proof');
+
+elements.get('operatorCommitmentTitle').value = 'Local commitment title';
+elements.get('operatorCommitmentOwner').value = 'operator';
+elements.get('operatorCommitmentDeadline').value = '2026-06-01';
+elements.get('operatorCommitmentReview').value = '';
+elements.get('operatorCommitmentDispatch').value = 'manual';
+elements.get('operatorCommitmentAcceptance').value = 'Verify client validation blocks missing source proof';
+elements.get('operatorCommitmentHaltPolicy').value = 'Stop if source evidence is stale or missing.';
+elements.get('operatorCommitmentEvidence').value = JSON.stringify([{kind:'source', label:'Session recall result', state:'present'}]);
+elements.get('operatorCommitmentStatus').value = 'active';
+elements.get('operatorCommitmentSource').value = JSON.stringify({kind:'session_message'});
+missing.textContent = '';
+
+const payload = context._operatorCommitmentValidateForm();
+assert.equal(payload, null, 'client validation must reject session_message sources without full proof');
+assert.match(missing.textContent, /source proof/i, 'validation error should name the missing source proof');
+assert.match(missing.textContent, /session_id/i, 'validation error should list session_id');
+assert.match(missing.textContent, /message_index/i, 'validation error should list message_index');
+assert.match(missing.textContent, /content_hash/i, 'validation error should list content_hash');
+assert.match(missing.textContent, /quote/i, 'validation error should list quote');
+
+elements.get('operatorCommitmentSource').value = JSON.stringify({
+  kind:'session_message',
+  session_id:'session-bad-proof',
+  message_index:'not-an-index',
+  content_hash:'not-a-hash',
+  quote:'quoted source proof',
+});
+missing.textContent = '';
+
+const malformedPayload = context._operatorCommitmentValidateForm();
+assert.equal(malformedPayload, null, 'client validation must reject malformed non-empty session_message proof');
+assert.match(missing.textContent, /source proof/i, 'malformed validation error should name the source proof');
+assert.match(missing.textContent, /message_index/i, 'malformed validation error should list message_index');
+assert.match(missing.textContent, /content_hash/i, 'malformed validation error should list content_hash');
+
+missing.textContent = '';
+context.openOperatorCommitmentPromoteFromRecall({
+  session: {title:'Bad proof recall', session_id:'session-bad-recall'},
+  match: {snippet:'quoted malformed proof', timestamp:1710000000},
+  recency: {label:'live'},
+  promotion: {
+    task: {
+      enabled:true,
+      mode:'local_commitment_draft',
+      would_execute:false,
+      source: {
+        kind:'session_message',
+        session_id:'session-bad-recall',
+        message_index:'not-an-index',
+        content_hash:'not-a-hash',
+        quote:'quoted malformed proof',
+      },
+    },
+  },
+});
+assert.equal(form.hidden, true, 'malformed recall proof must keep the draft form closed');
+assert.equal(popover.hidden, true, 'malformed recall proof must not open the popover');
+assert.match(missing.textContent, /source proof/i, 'malformed recall proof should explain the invalid source proof');
+assert.match(missing.textContent, /message_index/i, 'malformed recall proof should list message_index');
+assert.match(missing.textContent, /content_hash/i, 'malformed recall proof should list content_hash');
+
+missing.textContent = '';
+form.hidden = true;
+popover.hidden = true;
+context.openOperatorCommitmentPromoteFromRecall({
+  session: {title:'Raw secret recall', session_id:'session-raw-secret'},
+  match: {snippet:'raw secret proof quote', timestamp:1710000000},
+  recency: {label:'live'},
+  promotion: {
+    task: {
+      enabled:true,
+      mode:'local_commitment_draft',
+      would_execute:false,
+      source: {
+        kind:'session_message',
+        session_id:'session-raw-secret',
+        message_index:0,
+        content_hash:'sha256:' + 'c'.repeat(64),
+        quote:'password=supersecret',
+      },
+    },
+  },
+});
+assert.equal(form.hidden, true, 'raw secret recall proof must keep the draft form closed');
+assert.equal(popover.hidden, true, 'raw secret recall proof must not open the popover');
+assert.match(missing.textContent, /source proof/i, 'raw secret recall proof should explain the invalid source proof');
+assert.match(missing.textContent, /secret/i, 'raw secret recall proof should explain that the quote contains a secret');
+
+elements.get('operatorCommitmentSource').value = JSON.stringify({
+  kind:'session_message',
+  session_id:'session-raw-secret-validation',
+  message_index:0,
+  content_hash:'sha256:' + 'd'.repeat(64),
+  quote:'password=supersecret',
+});
+missing.textContent = '';
+
+const rawSecretPayload = context._operatorCommitmentValidateForm();
+assert.equal(rawSecretPayload, null, 'client validation must reject raw-secret session_message proof quotes');
+assert.match(missing.textContent, /source proof/i, 'raw-secret validation error should name the source proof');
+assert.match(missing.textContent, /secret/i, 'raw-secret validation error should mention secret');
+"""
+
+    completed = subprocess.run(
+        ["node", "-e", node_script],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_operator_commitments_css_has_card_form_state_and_mobile_rules():
+    css = _read("static/style.css")
+
+    for selector in [
+        ".operator-commitment-popover",
+        ".operator-commitment-list",
+        ".operator-commitment-card",
+        ".operator-commitment-form",
+        ".operator-commitment-required",
+        ".operator-commitment-no-exec",
+        ".operator-commitment-missing",
+        ".operator-commitment-action",
+    ]:
+        assert selector in css
+    for state in ["state-live", "state-stale", "state-unknown"]:
+        assert state in css
+    assert "max-width:640px" in css

--- a/tests/test_operator_device_admin.py
+++ b/tests/test_operator_device_admin.py
@@ -1,0 +1,794 @@
+import importlib
+import json
+from pathlib import Path
+
+
+def _write_json(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _write_text(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _device_admin_module(monkeypatch, tmp_path, allowlist=None, receipts=None, allowlist_text=None, receipts_text=None):
+    device_admin = importlib.import_module("api.operator_device_admin")
+    allowlist_path = tmp_path / "state" / "operator_device_admin_allowlist.json"
+    receipt_log_path = tmp_path / "state" / "operator_device_admin_receipts.jsonl"
+    if allowlist is not None:
+        _write_json(allowlist_path, allowlist)
+    elif allowlist_text is not None:
+        _write_text(allowlist_path, allowlist_text)
+    if receipts is not None:
+        _write_text(receipt_log_path, "\n".join(json.dumps(receipt) for receipt in receipts))
+    elif receipts_text is not None:
+        _write_text(receipt_log_path, receipts_text)
+    monkeypatch.setattr(device_admin, "ALLOWLIST_PATH", allowlist_path, raising=False)
+    monkeypatch.setattr(device_admin, "RECEIPT_LOG_PATH", receipt_log_path, raising=False)
+    return device_admin
+
+
+def test_device_admin_payload_missing_sources_is_unknown_blocked_and_no_execution(monkeypatch, tmp_path):
+    device_admin = _device_admin_module(monkeypatch, tmp_path)
+
+    payload = device_admin.build_operator_device_admin_payload(now=123.0)
+
+    assert payload["version"] == 1
+    assert payload["mode"] == "device-admin-foundations-read-only"
+    assert payload["generated_at"] == 123.0
+    assert payload["status"] == "unknown"
+    assert payload["execution_state"] == "blocked"
+    assert payload["summary"]
+    assert payload["query"] == {"text": "", "host": "all", "action": "all", "limit": 50}
+    assert payload["would_execute"] is False
+    assert payload["hosts"] == []
+    assert payload["paths"] == []
+    assert payload["dry_runs"] == []
+    assert payload["receipts"] == []
+    assert payload["approval_model"]["required"] is True
+    assert payload["approval_model"]["per_action"] is True
+    assert payload["approval_model"]["execution_enabled"] is False
+    assert "action_id" in payload["approval_model"]["required_fields"]
+    assert "approved_by" in payload["approval_model"]["required_fields"]
+    assert any(source["id"] == "allowlist" and source["state"] == "unknown" for source in payload["sources"])
+    assert any(source["id"] == "receipts" and source["state"] == "unknown" for source in payload["sources"])
+    assert any("allowlist" in issue.lower() and "missing" in issue.lower() for issue in payload["issues"])
+    assert any("receipt" in issue.lower() and "missing" in issue.lower() for issue in payload["issues"])
+
+
+def test_device_admin_preview_empty_id_is_unknown_blocked_and_no_execution(monkeypatch, tmp_path):
+    device_admin = _device_admin_module(monkeypatch, tmp_path)
+
+    payload = device_admin.build_operator_device_admin_preview_payload(action_id="", now=123.0)
+
+    assert payload["version"] == 1
+    assert payload["mode"] == "device-admin-dry-run-preview-read-only"
+    assert payload["generated_at"] == 123.0
+    assert payload["status"] == "unknown"
+    assert payload["execution_state"] == "blocked"
+    assert payload["would_execute"] is False
+    assert payload["action"] == {"id": "", "action": "unknown", "summary": ""}
+    assert payload["preview"] == {
+        "format": "dry-run-summary",
+        "text": "No device action was executed. Approval and execution are disabled in Slice 8.",
+        "truncated": False,
+        "bytes_read": 0,
+        "max_bytes": device_admin.MAX_PREVIEW_BYTES,
+    }
+    assert any("missing" in issue.lower() or "unknown" in issue.lower() for issue in payload["issues"])
+
+
+def test_routes_expose_device_admin_get_routes_after_docs_artifacts_and_no_post():
+    routes = Path("api/routes.py").read_text(encoding="utf-8")
+
+    assert '"/api/operator/device-admin"' in routes
+    assert '"/api/operator/device-admin/preview"' in routes
+    assert routes.index('"/api/operator/docs-artifacts/open"') < routes.index('"/api/operator/device-admin"') < routes.index('"/api/models"')
+    assert routes.index('"/api/operator/device-admin"') < routes.index('"/api/operator/device-admin/preview"') < routes.index('"/api/models"')
+    post_index = routes.index("def handle_post")
+    post_section = routes[post_index:]
+    assert '"/api/operator/device-admin"' not in post_section
+    assert '"/api/operator/device-admin/preview"' not in post_section
+    for forbidden in ["device-admin/apply", "device-admin/approve", "device-admin/execute", "device-admin/run"]:
+        assert forbidden not in routes
+
+
+def test_device_admin_catalogs_source_backed_hosts_paths_and_dry_runs(monkeypatch, tmp_path):
+    raw_path = "/mnt/storage/inbox"
+    allowlist = {
+        "version": 1,
+        "generated_at": "2026-05-27T00:00:00Z",
+        "hosts": [
+            {
+                "id": "h1",
+                "label": "Host One",
+                "kind": "linux",
+                "state": "allowed",
+                "paths": [
+                    {
+                        "id": "p1",
+                        "label": "Inbox",
+                        "path": raw_path,
+                        "capabilities": ["read", "copy_preview"],
+                        "state": "allowed",
+                    }
+                ],
+            }
+        ],
+        "proposed_actions": [
+            {
+                "id": "a1",
+                "action": "copy",
+                "host_id": "h1",
+                "source_path_id": "p1",
+                "destination_path_id": "p1",
+                "summary": "copy preview only",
+                "reason": "operator requested a dry-run only",
+                "risk": "low",
+                "approval_required": True,
+                "state": "blocked",
+            }
+        ],
+    }
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=allowlist, receipts=[])
+
+    payload = device_admin.build_operator_device_admin_payload(now=1.0)
+    payload_text = json.dumps(payload, sort_keys=True)
+
+    assert payload["status"] == "live"
+    assert payload["execution_state"] == "blocked"
+    assert payload["would_execute"] is False
+    assert payload["hosts"][0]["id"] == "h1"
+    assert payload["hosts"][0]["label"] == "Host One"
+    assert payload["paths"][0]["id"] == "p1"
+    assert payload["paths"][0]["host_id"] == "h1"
+    assert payload["paths"][0]["label"] == "Inbox"
+    assert raw_path not in payload_text
+    assert "[redacted" in payload_text
+    dry_run = payload["dry_runs"][0]
+    assert dry_run["id"].startswith("dda_")
+    assert dry_run["source_action_id"] == "a1"
+    assert dry_run["action"] == "copy"
+    assert dry_run["host_id"] == "h1"
+    assert dry_run["approval_required"] is True
+    assert dry_run["state"] == "blocked"
+    assert dry_run["would_execute"] is False
+
+
+def test_device_admin_malformed_allowlist_is_unknown_without_raw_body_leak(monkeypatch, tmp_path):
+    device_admin = _device_admin_module(
+        monkeypatch,
+        tmp_path,
+        allowlist_text='{not json /mnt/secret OPENAI_API_KEY=sk-mal...cret}',
+        receipts=[],
+    )
+
+    payload = device_admin.build_operator_device_admin_payload(now=2.0)
+    payload_text = json.dumps(payload, sort_keys=True)
+
+    assert payload["status"] == "unknown"
+    assert payload["execution_state"] == "blocked"
+    assert payload["hosts"] == []
+    assert payload["paths"] == []
+    assert payload["dry_runs"] == []
+    assert any("malformed" in issue.lower() for issue in payload["issues"])
+    assert "{not json" not in payload_text
+    assert "/mnt/secret" not in payload_text
+    assert "OPENAI_API_KEY" not in payload_text
+    assert "sk-mal...cret" not in payload_text
+
+
+def test_device_admin_stale_allowlist_and_receipts_are_stale_blocked_not_live(monkeypatch, tmp_path):
+    allowlist = {
+        "version": 1,
+        "generated_at": "1970-01-01T00:00:00Z",
+        "hosts": [
+            {
+                "id": "h1",
+                "label": "Host One",
+                "kind": "linux",
+                "state": "allowed",
+                "paths": [{"id": "p1", "label": "One", "path": "/safe", "capabilities": ["read"], "state": "allowed"}],
+            }
+        ],
+        "proposed_actions": [
+            {
+                "id": "a1",
+                "action": "copy",
+                "host_id": "h1",
+                "source_path_id": "p1",
+                "destination_path_id": "p1",
+                "summary": "stale source should not look live",
+                "approval_required": True,
+                "state": "blocked",
+            }
+        ],
+    }
+    receipts = [
+        {"id": "r1", "action_id": "a1", "status": "dry_run", "created_at": "1970-01-01T00:00:00Z", "summary": "old dry-run", "would_execute": False}
+    ]
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=allowlist, receipts=receipts)
+
+    payload = device_admin.build_operator_device_admin_payload(now=2_000_000_000.0)
+    preview = device_admin.build_operator_device_admin_preview_payload(action_id=payload["dry_runs"][0]["id"], now=2_000_000_000.0)
+
+    assert payload["status"] == "stale"
+    assert payload["execution_state"] == "blocked"
+    assert payload["would_execute"] is False
+    assert payload["sources"][0]["id"] == "allowlist"
+    assert payload["sources"][0]["state"] == "stale"
+    assert payload["sources"][1]["id"] == "receipts"
+    assert payload["sources"][1]["state"] == "stale"
+    assert any("stale" in issue.lower() for issue in payload["issues"])
+    assert preview["status"] == "stale"
+    assert preview["execution_state"] == "blocked"
+    assert preview["would_execute"] is False
+
+
+
+def test_device_admin_redacts_paths_and_secretish_values_from_catalog(monkeypatch, tmp_path):
+    allowlist = {
+        "hosts": [
+            {
+                "id": "h-secret",
+                "label": "Bearer abcdefghijklmnop",
+                "kind": "windows",
+                "state": "allowed",
+                "paths": [
+                    {
+                        "id": "p-secret",
+                        "label": "OPENAI_API_KEY=sk-abcdefghijklmnop",
+                        "path": "C:\\Users\\malac\\Secrets\\file.txt",
+                        "capabilities": ["read"],
+                        "state": "allowed",
+                    }
+                ],
+            }
+        ],
+        "proposed_actions": [
+            {
+                "id": "a-secret",
+                "action": "copy",
+                "host_id": "h-secret",
+                "source_path_id": "p-secret",
+                "destination_path_id": "p-secret",
+                "summary": "copy ghp_abcdefghijklmnop from /etc/passwd",
+                "reason": "token=xoxb-abcdefghijklmnop and password=hunter2",
+                "approval_required": True,
+                "state": "blocked",
+            }
+        ],
+    }
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=allowlist, receipts=[])
+
+    payload = device_admin.build_operator_device_admin_payload(now=3.0)
+    payload_text = json.dumps(payload, sort_keys=True)
+
+    for leaked in [
+        "Bearer abcdefghijklmnop",
+        "OPENAI_API_KEY",
+        "sk-abcdefghijklmnop",
+        "C:\\Users\\malac\\Secrets",
+        "ghp_abcdefghijklmnop",
+        "/etc/passwd",
+        "xoxb-abcdefghijklmnop",
+        "hunter2",
+    ]:
+        assert leaked not in payload_text
+    assert "[redacted" in payload_text
+    assert payload["would_execute"] is False
+
+
+def test_device_admin_redacts_path_and_secret_variants_from_catalog(monkeypatch, tmp_path):
+    allowlist = {
+        "hosts": [
+            {
+                "id": "h1",
+                "label": "Host One",
+                "kind": "windows",
+                "state": "allowed",
+                "paths": [
+                    {"id": "p1", "label": "Drive path", "path": "C:/Users/malac/Secrets/file.txt", "capabilities": ["read"], "state": "allowed"},
+                    {"id": "p2", "label": "Spaced drive path", "path": "C:\\Users\\malac\\Secret Folder\\file.txt", "capabilities": ["read"], "state": "allowed"},
+                    {"id": "p3", "label": "Spaced POSIX path", "path": "/mnt/storage/My Drive/file.txt", "capabilities": ["read"], "state": "allowed"},
+                    {"id": "p4", "label": "UNC path", "path": "\\\\nas\\Secret Share\\file.txt", "capabilities": ["read"], "state": "allowed"},
+                ],
+            }
+        ],
+        "proposed_actions": [
+            {
+                "id": "a1",
+                "action": "copy",
+                "host_id": "h1",
+                "source_path_id": "p1",
+                "destination_path_id": "p2",
+                "summary": "copy with password: hunter2 and token abcdefghijklmnop",
+                "reason": "quoted password=\"hunter2\" should be hidden",
+                "approval_required": True,
+                "state": "blocked",
+            }
+        ],
+    }
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=allowlist, receipts=[])
+
+    payload = device_admin.build_operator_device_admin_payload(now=3.5)
+    payload_text = json.dumps(payload, sort_keys=True)
+
+    for leaked in [
+        "C:/Users/malac/Secrets",
+        "C:\\Users\\malac\\Secret Folder",
+        "/mnt/storage/My Drive",
+        "\\\\nas\\Secret Share",
+        "hunter2",
+        "token abcdefghijklmnop",
+    ]:
+        assert leaked not in payload_text
+    assert payload_text.count("[redacted") >= 4
+
+
+def test_device_admin_redacts_delimiter_path_suffixes_and_generic_env_secrets(monkeypatch, tmp_path):
+    allowlist = {
+        "hosts": [
+            {
+                "id": "h1",
+                "label": "AWS_ACCESS_KEY_ID=AKIAULTRALEAKVALUE",
+                "kind": "linux",
+                "state": "allowed",
+                "paths": [
+                    {"id": "p1", "label": "PRIVATE_KEY=abcdef1234567890", "path": "/tmp/project,ultraleaksecret.txt", "capabilities": ["read"], "state": "allowed"},
+                    {"id": "p2", "label": "DB_PASS=letmeinvalue", "path": "C:\\Users\\malac\\Secrets;winleaksecret.txt", "capabilities": ["read"], "state": "allowed"},
+                    {"id": "p3", "label": "SESSION_COOKIE=sessioncookievalue", "path": "\\\\nas\\Share\\folder|uncleaksecret.txt", "capabilities": ["read"], "state": "allowed"},
+                ],
+            }
+        ],
+        "proposed_actions": [
+            {
+                "id": "a1",
+                "action": "copy",
+                "host_id": "h1",
+                "source_path_id": "p1",
+                "destination_path_id": "p2",
+                "summary": "copy /var/tmp/source,summaryleaksecret.txt with AWS_SECRET_ACCESS_KEY=secretaccessvalue",
+                "reason": "use PRIVATE_KEY=abcdef1234567890 and SESSION_COOKIE=sessioncookievalue only in redacted metadata",
+                "approval_required": True,
+                "state": "blocked",
+            }
+        ],
+    }
+    receipts = [
+        {"id": "r1", "action_id": "a1", "status": "dry_run", "created_at": "2026-05-27T00:00:00Z", "summary": "receipt C:/tmp/path,receiptleaksecret.txt DB_PASS=letmeinvalue", "would_execute": False}
+    ]
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=allowlist, receipts=receipts)
+
+    payload = device_admin.build_operator_device_admin_payload(now=3.6)
+    action_id = payload["dry_runs"][0]["id"]
+    preview = device_admin.build_operator_device_admin_preview_payload(action_id=action_id, now=3.6)
+    payload_text = json.dumps({"payload": payload, "preview": preview}, sort_keys=True)
+
+    for leaked in [
+        "ultraleaksecret",
+        "winleaksecret",
+        "uncleaksecret",
+        "summaryleaksecret",
+        "receiptleaksecret",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "PRIVATE_KEY",
+        "SESSION_COOKIE",
+        "DB_PASS",
+        "AKIAULTRALEAKVALUE",
+        "secretaccessvalue",
+        "abcdef1234567890",
+        "sessioncookievalue",
+        "letmeinvalue",
+    ]:
+        assert leaked not in payload_text
+    assert payload_text.count("[redacted") >= 6
+
+
+def test_device_admin_malformed_action_type_degrades_to_blocked_unknown(monkeypatch, tmp_path):
+    allowlist = {
+        "hosts": [
+            {
+                "id": "h1",
+                "label": "Host One",
+                "kind": "linux",
+                "state": "allowed",
+                "paths": [{"id": "p1", "label": "One", "path": "/safe", "capabilities": ["read"], "state": "allowed"}],
+            }
+        ],
+        "proposed_actions": [
+            {
+                "id": "a-ssh",
+                "action": "ssh",
+                "host_id": "h1",
+                "source_path_id": "p1",
+                "destination_path_id": "p1",
+                "summary": "invalid action must not look live",
+                "approval_required": True,
+                "state": "draft",
+            }
+        ],
+    }
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=allowlist, receipts=[])
+
+    payload = device_admin.build_operator_device_admin_payload(now=3.75)
+
+    dry_run = payload["dry_runs"][0]
+    assert payload["status"] == "unknown"
+    assert dry_run["action"] == "unknown"
+    assert dry_run["state"] == "blocked"
+    assert dry_run["would_execute"] is False
+    assert any("malformed action" in issue.lower() or "unknown action" in issue.lower() for issue in dry_run["issues"])
+
+
+def test_device_admin_missing_source_ids_are_unknown_not_fabricated(monkeypatch, tmp_path):
+    allowlist = {
+        "hosts": [
+            {
+                "label": "Host Missing ID",
+                "kind": "linux",
+                "state": "allowed",
+                "paths": [{"label": "Path Missing ID", "path": "/missing-id", "capabilities": ["read"], "state": "allowed"}],
+            }
+        ],
+        "proposed_actions": [
+            {
+                "action": "copy",
+                "host_id": "",
+                "source_path_id": "",
+                "destination_path_id": "",
+                "summary": "missing ids must not be fabricated",
+                "approval_required": True,
+                "state": "draft",
+            }
+        ],
+    }
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=allowlist, receipts=[])
+
+    payload = device_admin.build_operator_device_admin_payload(now=3.9)
+    payload_text = json.dumps(payload, sort_keys=True)
+
+    assert payload["status"] == "unknown"
+    assert "host-0" not in payload_text
+    assert "path-0" not in payload_text
+    assert "action-0" not in payload_text
+    assert any("missing host id" in issue.lower() for issue in payload["issues"])
+    assert any("missing path id" in issue.lower() for issue in payload["issues"])
+    dry_run = payload["dry_runs"][0]
+    assert payload["hosts"][0]["state"] == "unknown"
+    assert payload["paths"][0]["state"] == "unknown"
+    assert dry_run["id"] == ""
+    assert dry_run["source_action_id"] == "unknown"
+    assert dry_run["state"] == "blocked"
+    assert any("missing action id" in issue.lower() for issue in dry_run["issues"])
+
+
+def test_device_admin_mixed_path_and_secret_fields_are_fully_redacted(monkeypatch, tmp_path):
+    allowlist = {
+        "hosts": [
+            {
+                "id": "h1",
+                "label": "Host One",
+                "kind": "linux",
+                "state": "allowed",
+                "paths": [{"id": "p1", "label": "One", "path": "/safe", "capabilities": ["read"], "state": "allowed"}],
+            }
+        ],
+        "proposed_actions": [
+            {
+                "id": "a1",
+                "action": "copy",
+                "host_id": "h1",
+                "source_path_id": "p1",
+                "destination_path_id": "p1",
+                "summary": "copy /tmp/foo with api_key: 'top secret value'",
+                "reason": "move /tmp/bar HERMES_TOKEN='tokensecretvalue' and password=\"top secret\"",
+                "approval_required": True,
+                "state": "blocked",
+            }
+        ],
+    }
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=allowlist, receipts=[])
+
+    payload = device_admin.build_operator_device_admin_payload(now=3.91)
+    payload_text = json.dumps(payload, sort_keys=True)
+
+    for leaked in ["/tmp/foo", "/tmp/bar", "api_key", "top secret", "HERMES_TOKEN", "tokensecretvalue", "password"]:
+        assert leaked not in payload_text
+    assert "[redacted" in payload_text
+
+
+def test_device_admin_malformed_nested_allowlist_fields_are_unknown_not_live(monkeypatch, tmp_path):
+    allowlist = {
+        "hosts": [
+            {"id": "h1", "label": "Bad Paths", "kind": "linux", "state": "allowed", "paths": ""},
+            {
+                "id": "h2",
+                "label": "Bad Capabilities",
+                "kind": "linux",
+                "state": "allowed",
+                "paths": [{"id": "p2", "label": "Two", "path": "/safe", "capabilities": "read", "state": "allowed"}],
+            },
+        ],
+        "proposed_actions": [
+            {"id": "a2", "action": "copy", "host_id": "h2", "source_path_id": "p2", "destination_path_id": "p2", "summary": "bad nested fields", "approval_required": True, "state": "blocked"},
+        ],
+    }
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=allowlist, receipts=[])
+
+    payload = device_admin.build_operator_device_admin_payload(now=3.97)
+
+    assert payload["status"] == "unknown"
+    assert payload["sources"][0]["state"] == "unknown"
+    by_host = {host["id"]: host for host in payload["hosts"]}
+    by_path = {path["id"]: path for path in payload["paths"]}
+    assert by_host["h1"]["state"] == "unknown"
+    assert any("paths field" in issue.lower() for issue in by_host["h1"]["issues"])
+    assert by_path["p2"]["state"] == "unknown"
+    assert any("capabilities" in issue.lower() for issue in by_path["p2"]["issues"])
+    assert any("paths field" in issue.lower() for issue in payload["issues"])
+    assert any("capabilities" in issue.lower() for issue in payload["issues"])
+
+
+def test_device_admin_missing_destination_reference_degrades_to_blocked_unknown(monkeypatch, tmp_path):
+    allowlist = {
+        "hosts": [
+            {
+                "id": "h1",
+                "label": "Host One",
+                "kind": "linux",
+                "state": "allowed",
+                "paths": [{"id": "p1", "label": "One", "path": "/safe", "capabilities": ["read"], "state": "allowed"}],
+            }
+        ],
+        "proposed_actions": [
+            {
+                "id": "a-no-dest",
+                "action": "copy",
+                "host_id": "h1",
+                "source_path_id": "p1",
+                "summary": "destination is required for approval model",
+                "approval_required": True,
+                "state": "draft",
+            }
+        ],
+    }
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=allowlist, receipts=[])
+
+    payload = device_admin.build_operator_device_admin_payload(now=3.95)
+
+    dry_run = payload["dry_runs"][0]
+    assert payload["status"] == "unknown"
+    assert dry_run["state"] == "blocked"
+    assert dry_run["would_execute"] is False
+    assert any("missing destination" in issue.lower() for issue in dry_run["issues"])
+
+
+def test_device_admin_redacts_secretish_labels_keys_and_single_quoted_values(monkeypatch, tmp_path):
+    allowlist = {
+        "hosts": [
+            {
+                "id": "h1",
+                "label": "Secret NAS",
+                "kind": "nas",
+                "state": "allowed",
+                "paths": [
+                    {
+                        "id": "p1",
+                        "label": {"password": "hunter2"},
+                        "path": "/safe",
+                        "capabilities": ["read"],
+                        "state": "allowed",
+                    }
+                ],
+            }
+        ],
+        "proposed_actions": [
+            {
+                "id": "a1",
+                "action": "copy",
+                "host_id": "h1",
+                "source_path_id": "p1",
+                "destination_path_id": "p1",
+                "summary": "api_key: 'top secret value'",
+                "reason": "HERMES_TOKEN='tokensecretvalue' and password='hunter2'",
+                "approval_required": True,
+                "state": "blocked",
+            }
+        ],
+    }
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=allowlist, receipts=[])
+
+    payload = device_admin.build_operator_device_admin_payload(now=3.99)
+    payload_text = json.dumps(payload, sort_keys=True)
+
+    for leaked in ["Secret NAS", "password", "hunter2", "api_key", "top secret value", "HERMES_TOKEN", "tokensecretvalue"]:
+        assert leaked not in payload_text
+    assert "[redacted" in payload_text
+
+
+def test_device_admin_missing_action_references_degrade_to_blocked_unknown(monkeypatch, tmp_path):
+    allowlist = {
+        "hosts": [{"id": "h1", "label": "Host One", "kind": "linux", "state": "allowed", "paths": []}],
+        "proposed_actions": [
+            {
+                "id": "a-bad",
+                "action": "move",
+                "host_id": "missing-host",
+                "source_path_id": "missing-source",
+                "destination_path_id": "missing-destination",
+                "summary": "bad refs must not execute",
+                "approval_required": True,
+                "state": "draft",
+            }
+        ],
+    }
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=allowlist, receipts=[])
+
+    payload = device_admin.build_operator_device_admin_payload(now=4.0)
+
+    dry_run = payload["dry_runs"][0]
+    assert payload["status"] == "unknown"
+    assert dry_run["source_action_id"] == "a-bad"
+    assert dry_run["state"] == "blocked"
+    assert dry_run["would_execute"] is False
+    assert any("missing host" in issue.lower() for issue in dry_run["issues"])
+    assert any("missing source" in issue.lower() for issue in dry_run["issues"])
+    assert any("missing destination" in issue.lower() for issue in dry_run["issues"])
+
+
+def _preview_allowlist():
+    return {
+        "hosts": [
+            {
+                "id": "h1",
+                "label": "Host One",
+                "kind": "linux",
+                "state": "allowed",
+                "paths": [
+                    {"id": "p1", "label": "Source", "path": "/mnt/source", "capabilities": ["read"], "state": "allowed"},
+                    {"id": "p2", "label": "Destination", "path": "/mnt/destination", "capabilities": ["copy_preview"], "state": "allowed"},
+                ],
+            }
+        ],
+        "proposed_actions": [
+            {
+                "id": "a1",
+                "action": "copy",
+                "host_id": "h1",
+                "source_path_id": "p1",
+                "destination_path_id": "p2",
+                "summary": "copy /mnt/source to /mnt/destination preview only",
+                "reason": "operator requested dry run",
+                "risk": "low",
+                "approval_required": True,
+                "state": "blocked",
+            }
+        ],
+    }
+
+
+def test_device_admin_preview_known_action_is_blocked_dry_run(monkeypatch, tmp_path):
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=_preview_allowlist(), receipts=[])
+    action = device_admin.build_operator_device_admin_payload(now=6.0)["dry_runs"][0]
+
+    payload = device_admin.build_operator_device_admin_preview_payload(action_id=action["id"], now=6.0)
+    payload_text = json.dumps(payload, sort_keys=True)
+
+    assert payload["version"] == 1
+    assert payload["mode"] == "device-admin-dry-run-preview-read-only"
+    assert payload["status"] == "live"
+    assert payload["execution_state"] == "blocked"
+    assert payload["action"]["id"] == action["id"]
+    assert payload["action"]["source_action_id"] == "a1"
+    assert payload["action"]["action"] == "copy"
+    assert payload["would_execute"] is False
+    assert payload["preview"]["format"] == "dry-run-summary"
+    assert "No device action was executed" in payload["preview"]["text"]
+    assert "copy" in payload["preview"]["text"]
+    assert payload["preview"]["bytes_read"] <= payload["preview"]["max_bytes"] == device_admin.MAX_PREVIEW_BYTES
+    assert "/mnt/source" not in payload_text
+    assert "/mnt/destination" not in payload_text
+
+
+def test_device_admin_preview_rejects_suspicious_ids_without_path_leak(monkeypatch, tmp_path):
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=_preview_allowlist(), receipts=[])
+
+    for suspicious in [
+        "../x",
+        "/etc/passwd",
+        " /etc/passwd",
+        "~/.ssh/id_rsa",
+        "C:\\Users\\malac\\secret",
+        " C:/Users/malac/secret",
+        "file:///tmp/x",
+        "ftp://host/path",
+        "smb://server/share",
+        "data:text/plain,secret",
+        "javascript:alert(1)",
+        "abc\x00def",
+    ]:
+        payload = device_admin.build_operator_device_admin_preview_payload(action_id=suspicious, now=7.0)
+        payload_text = json.dumps(payload, sort_keys=True)
+
+        assert payload["status"] == "unknown"
+        assert payload["execution_state"] == "blocked"
+        assert payload["would_execute"] is False
+        assert payload["action"]["id"] == ""
+        assert any("rejected" in issue.lower() or "malformed" in issue.lower() for issue in payload["issues"])
+        assert suspicious.replace("\x00", "") not in payload_text
+
+
+def test_device_admin_receipt_log_parses_valid_dry_run_receipts_and_reports_malformed_lines(monkeypatch, tmp_path):
+    valid = {
+        "id": "r1",
+        "action_id": "a1",
+        "status": "dry_run",
+        "created_at": "2026-05-27T00:00:00Z",
+        "summary": "dry run for /mnt/source with HERMES_TOKEN='tokensecretvalue'",
+        "would_execute": False,
+    }
+    model_only = {
+        "id": "r2",
+        "action_id": "a1",
+        "status": "approved_model_only",
+        "created_at": "2026-05-27T00:01:00Z",
+        "summary": "approval model only",
+        "would_execute": True,
+    }
+    invalid_status = {"id": "r3", "action_id": "a1", "status": "executed", "summary": "must not count"}
+    receipts_text = "\n".join([
+        json.dumps(valid),
+        "{bad json /mnt/source HERMES_TOKEN='tokensecretvalue'",
+        json.dumps(invalid_status),
+        json.dumps(model_only),
+    ])
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=_preview_allowlist(), receipts_text=receipts_text)
+
+    payload = device_admin.build_operator_device_admin_payload(now=8.0)
+    payload_text = json.dumps(payload, sort_keys=True)
+
+    assert payload["status"] == "unknown"
+    assert payload["sources"][1]["id"] == "receipts"
+    assert payload["sources"][1]["state"] == "unknown"
+    assert payload["sources"][1]["count"] == 2
+    assert [receipt["id"] for receipt in payload["receipts"]] == ["r2", "r1"]
+    assert {receipt["status"] for receipt in payload["receipts"]} == {"dry_run", "approved_model_only"}
+    assert all(receipt["would_execute"] is False for receipt in payload["receipts"])
+    assert any("malformed receipt" in issue.lower() for issue in payload["issues"])
+    assert any("unsupported receipt status" in issue.lower() for issue in payload["issues"])
+    assert "executed" not in json.dumps(payload["receipts"], sort_keys=True)
+    assert "/mnt/source" not in payload_text
+    assert "HERMES_TOKEN" not in payload_text
+    assert "tokensecretvalue" not in payload_text
+
+
+def test_device_admin_query_filters_host_action_text_and_limit_without_browsing(monkeypatch, tmp_path):
+    allowlist = {
+        "hosts": [
+            {"id": "h1", "label": "Alpha", "kind": "linux", "state": "allowed", "paths": [{"id": "p1", "label": "One", "path": "/alpha", "capabilities": ["read"], "state": "allowed"}]},
+            {"id": "h2", "label": "Beta", "kind": "linux", "state": "allowed", "paths": [{"id": "p2", "label": "Two", "path": "/beta", "capabilities": ["read"], "state": "allowed"}]},
+        ],
+        "proposed_actions": [
+            {"id": "a1", "action": "copy", "host_id": "h1", "source_path_id": "p1", "destination_path_id": "p1", "summary": "Alpha copy", "approval_required": True, "state": "blocked"},
+            {"id": "a2", "action": "delete", "host_id": "h2", "source_path_id": "p2", "destination_path_id": "p2", "summary": "Keep Beta delete dry-run", "approval_required": True, "state": "blocked"},
+            {"id": "a3", "action": "delete", "host_id": "h1", "source_path_id": "p1", "destination_path_id": "p1", "summary": "Other delete", "approval_required": True, "state": "blocked"},
+        ],
+    }
+    device_admin = _device_admin_module(monkeypatch, tmp_path, allowlist=allowlist, receipts=[])
+
+    payload = device_admin.build_operator_device_admin_payload(query_text="Keep", host="h2", action="delete", limit="1", now=5.0)
+    payload_text = json.dumps(payload, sort_keys=True)
+
+    assert payload["query"] == {"text": "Keep", "host": "h2", "action": "delete", "limit": 1}
+    assert [item["id"] for item in payload["hosts"]] == ["h2"]
+    assert [item["id"] for item in payload["paths"]] == ["p2"]
+    assert len(payload["dry_runs"]) == 1
+    assert payload["dry_runs"][0]["source_action_id"] == "a2"
+    assert "/alpha" not in payload_text
+    assert "/beta" not in payload_text

--- a/tests/test_operator_device_admin_ui_static.py
+++ b/tests/test_operator_device_admin_ui_static.py
@@ -1,0 +1,255 @@
+import re
+from pathlib import Path
+
+
+def _read(path):
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _device_admin_js():
+    return _read("static/operator_device_admin.js")
+
+
+def _strip_js_strings_and_comments(js):
+    js = re.sub(r"//.*", "", js)
+    js = re.sub(r"/\*.*?\*/", "", js, flags=re.DOTALL)
+    return re.sub(r"(['\"`])(?:\\.|(?!\1).)*\1", "''", js, flags=re.DOTALL)
+
+
+def _top_level_calls(js, function_name):
+    cleaned = _strip_js_strings_and_comments(js)
+    calls = []
+    depth = 0
+    for line_number, line in enumerate(cleaned.splitlines(), start=1):
+        line_depth = depth
+        if re.search(rf"\bfunction\s+{re.escape(function_name)}\s*\(", line):
+            pass
+        elif line_depth == 0 and re.search(rf"\b{re.escape(function_name)}\s*\(", line):
+            calls.append((line_number, line.strip()))
+        depth += line.count("{") - line.count("}")
+        depth = max(depth, 0)
+    return calls
+
+
+def _function_body(js, function_name):
+    start = js.index(f"function {function_name}")
+    close_paren = js.index(")", start)
+    brace = js.index("{", close_paren)
+    depth = 0
+    for index in range(brace, len(js)):
+        char = js[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return js[brace + 1 : index]
+    raise AssertionError(f"function body not found: {function_name}")
+
+
+def test_device_admin_markup_exists_after_docs_artifacts_chip_and_popover():
+    html = _read("static/index.html")
+
+    for element_id in [
+        "operatorDeviceAdminChip",
+        "operatorDeviceAdminLabel",
+        "operatorDeviceAdminPopover",
+        "operatorDeviceAdminStatus",
+        "operatorDeviceAdminRefresh",
+        "operatorDeviceAdminInput",
+        "operatorDeviceAdminHost",
+        "operatorDeviceAdminAction",
+        "operatorDeviceAdminList",
+        "operatorDeviceAdminPreview",
+    ]:
+        assert f'id="{element_id}"' in html
+
+    assert html.index('id="operatorDocsArtifactsChip"') < html.index('id="operatorDeviceAdminChip"') < html.index('id="composerMobileConfigBtn"')
+    assert html.index('id="operatorDocsArtifactsPopover"') < html.index('id="operatorDeviceAdminPopover"')
+
+
+def test_device_admin_script_loaded_after_docs_artifacts_before_boot():
+    html = _read("static/index.html")
+
+    assert html.index("static/operator_docs_artifacts.js") < html.index("static/operator_device_admin.js") < html.index("static/boot.js")
+
+
+def test_device_admin_css_has_popover_card_source_preview_action_states_and_mobile_rules():
+    css = _read("static/style.css")
+
+    for selector in [
+        ".operator-device-admin-popover",
+        ".operator-device-admin-list",
+        ".operator-device-admin-card",
+        ".operator-device-admin-source",
+        ".operator-device-admin-preview",
+        ".operator-device-admin-action",
+        ".operator-device-admin-blocked",
+        ".operator-device-admin-unknown",
+    ]:
+        assert selector in css
+
+    mobile_starts = [
+        match.start()
+        for match in re.finditer(r"@media\s*\(\s*max-width\s*:\s*640px\s*\)", css)
+    ]
+    assert mobile_starts
+    mobile_sections = [
+        css[start : mobile_starts[index + 1] if index + 1 < len(mobile_starts) else len(css)]
+        for index, start in enumerate(mobile_starts)
+    ]
+    assert any("operator-device-admin" in section for section in mobile_sections)
+
+
+def test_device_admin_js_shell_exports_manual_functions_without_auto_refresh():
+    js = _device_admin_js()
+
+    for name in [
+        "toggleOperatorDeviceAdmin",
+        "hideOperatorDeviceAdmin",
+        "refreshOperatorDeviceAdmin",
+        "renderOperatorDeviceAdmin",
+        "previewOperatorDeviceAdminAction",
+        "initOperatorDeviceAdmin",
+    ]:
+        assert f"window.{name}" in js
+
+    assert "if (typeof document !== 'undefined') initOperatorDeviceAdmin();" in js
+    assert "setInterval" not in js
+    assert "EventSource" not in js
+    assert "WebSocket" not in js
+    assert "Worker(" not in js
+
+
+def test_device_admin_js_uses_only_device_admin_get_endpoints():
+    js = _device_admin_js()
+    allowed_endpoints = {"/api/operator/device-admin", "/api/operator/device-admin/preview"}
+    quoted_api_paths = set(re.findall(r"[\"'`](/api/[A-Za-z0-9_./-]+)", js))
+
+    assert quoted_api_paths == allowed_endpoints
+    assert re.search(r"\bapi\s*\(\s*[\"'`]/api/operator/device-admin\b", js)
+    assert not re.search(r"\bfetch\s*\(", js)
+    assert "XMLHttpRequest" not in js
+    assert "http://" not in js
+    assert "https://" not in js
+    for forbidden in [
+        "POST",
+        "PATCH",
+        "DELETE",
+        "/apply",
+        "/approve",
+        "/execute",
+        "/run",
+        "/dispatch",
+        "/operator/commitments/promote",
+        "/operator/memory-skill-review/decision",
+        "/api/kanban",
+        "/api/chat",
+    ]:
+        assert forbidden not in js
+
+
+def test_device_admin_values_use_text_content_not_inner_html_or_markdown():
+    js = _device_admin_js()
+
+    assert ".textContent" in js
+    assert "document.createElement" in js
+    for forbidden in [
+        ".innerHTML",
+        ".outerHTML",
+        "insertAdjacentHTML",
+        "renderMd(",
+        "renderMarkdown(",
+        "marked(",
+        "markdown",
+        "eval(",
+        "Function(",
+    ]:
+        assert forbidden not in js
+
+
+def test_device_admin_manual_only_no_polling_timers_or_background_transports():
+    js = _device_admin_js()
+
+    for forbidden in [
+        "setInterval",
+        "setTimeout",
+        "EventSource",
+        "WebSocket",
+        "Worker(",
+        "navigator.sendBeacon",
+    ]:
+        assert forbidden not in js
+
+    assert "DOMContentLoaded" not in js or not re.search(
+        r"DOMContentLoaded[\s\S]*refreshOperatorDeviceAdmin\s*\(",
+        js,
+    )
+    assert _top_level_calls(js, "refreshOperatorDeviceAdmin") == []
+
+
+def test_device_admin_js_renders_required_catalog_receipt_and_approval_fields():
+    js = _device_admin_js()
+
+    for required in [
+        "sources",
+        "hosts",
+        "paths",
+        "dry_runs",
+        "receipts",
+        "issues",
+        "approval_model",
+        "required_fields",
+        "execution_state",
+        "would_execute",
+        "blocked",
+        "unknown",
+        "source_path_id",
+        "destination_path_id",
+        "approval_required",
+    ]:
+        assert required in js
+
+    assert "Dry-run preview" in js
+    assert "No device action was executed" in js
+    assert "_operatorDeviceAdminPreviewSeq" in js
+    assert re.search(r"previewSeq\s*!==\s*_operatorDeviceAdminPreviewSeq|seq\s*!==\s*_operatorDeviceAdminPreviewSeq", js)
+
+
+def test_device_admin_list_render_invalidates_inflight_preview_before_resetting_panel():
+    js = _device_admin_js()
+    body = _function_body(js, "renderOperatorDeviceAdmin")
+    invalidation = re.search(r"(?:\+\+_operatorDeviceAdminPreviewSeq|_operatorDeviceAdminPreviewSeq\s*\+=\s*1)", body)
+
+    assert invalidation
+    assert body.index("_operatorDeviceAdminPreviewSeq") < body.index("renderOperatorDeviceAdminPreview")
+
+
+def test_device_admin_first_manual_open_refreshes_even_after_init_default_render():
+    js = _device_admin_js()
+    toggle_body = _function_body(js, "toggleOperatorDeviceAdmin")
+    refresh_body = _function_body(js, "refreshOperatorDeviceAdmin")
+
+    assert "_operatorDeviceAdminHasLoadedPayload" in js
+    assert "!_operatorDeviceAdminHasLoadedPayload" in toggle_body
+    assert "_operatorDeviceAdminHasLoadedPayload = true" in refresh_body
+    assert "!_operatorDeviceAdminLastPayload" not in toggle_body
+
+
+def test_device_admin_path_cards_render_backend_display_path_field():
+    js = _device_admin_js()
+    body = _function_body(js, "_operatorDeviceAdminRenderPaths")
+
+    assert "display_path" in body
+    assert "item.display_path" in body
+    assert "item.path" not in body
+
+
+def test_device_admin_refresh_captures_filter_query_before_loading_render_mutates_filters():
+    js = _device_admin_js()
+    body = _function_body(js, "refreshOperatorDeviceAdmin")
+
+    assert "const queryString = _operatorDeviceAdminQueryString();" in body
+    assert body.index("const queryString = _operatorDeviceAdminQueryString();") < body.index("renderOperatorDeviceAdmin(_operatorDeviceAdminLoadingPayload()")
+    assert "renderOperatorDeviceAdmin(_operatorDeviceAdminLoadingPayload(), {updateFilters: false})" in body
+    assert "api('/api/operator/device-admin' + queryString)" in body

--- a/tests/test_operator_docs_artifacts.py
+++ b/tests/test_operator_docs_artifacts.py
@@ -1,0 +1,747 @@
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _routes_source():
+    return Path("api/routes.py").read_text(encoding="utf-8")
+
+
+def test_docs_artifacts_payload_has_version_mode_timestamp_sources_items_and_no_execution(monkeypatch):
+    docs_artifacts = importlib.import_module("api.operator_docs_artifacts")
+    monkeypatch.setattr(docs_artifacts, "SOURCE_SPECS", {}, raising=False)
+
+    payload = docs_artifacts.build_operator_docs_artifacts_payload(now=123.0)
+
+    assert payload["version"] == 1
+    assert payload["mode"] == "docs-artifacts-read-only"
+    assert payload["generated_at"] == 123.0
+    assert payload["would_execute"] is False
+    assert payload["status"] in {"live", "stale", "unknown"}
+    assert payload["summary"]
+    assert payload["query"] == {"text": "", "kind": "all", "root": "all", "limit": 50}
+    assert payload["sources"] == []
+    assert payload["items"] == []
+    assert payload["count"] == 0
+    assert isinstance(payload["issues"], list)
+
+
+def test_docs_artifacts_preview_payload_rejects_unknown_item_without_fake_preview(monkeypatch):
+    docs_artifacts = importlib.import_module("api.operator_docs_artifacts")
+    monkeypatch.setattr(docs_artifacts, "SOURCE_SPECS", {}, raising=False)
+
+    payload = docs_artifacts.build_operator_docs_artifact_preview_payload(item_id="missing", now=123.0)
+
+    assert payload["version"] == 1
+    assert payload["mode"] == "docs-artifacts-preview-read-only"
+    assert payload["generated_at"] == 123.0
+    assert payload["would_execute"] is False
+    assert payload["status"] == "unknown"
+    assert payload["item"]["id"] == "missing"
+    assert payload["item"]["preview_available"] is False
+    assert payload["preview"] == {
+        "format": "metadata-only",
+        "text": "",
+        "truncated": False,
+        "bytes_read": 0,
+        "max_bytes": docs_artifacts.MAX_PREVIEW_BYTES,
+    }
+    assert any("missing" in issue.lower() or "unknown" in issue.lower() for issue in payload["issues"])
+
+
+def test_routes_expose_docs_artifacts_get_routes_near_operator_routes():
+    routes = _routes_source()
+
+    assert '"/api/operator/docs-artifacts"' in routes
+    assert '"/api/operator/docs-artifacts/open"' in routes
+    assert "build_operator_docs_artifacts_payload" in routes
+    assert "build_operator_docs_artifact_preview_payload" in routes
+
+    session_recall_index = routes.index('parsed.path == "/api/operator/session-recall"')
+    docs_index = routes.index('parsed.path == "/api/operator/docs-artifacts"')
+    docs_open_index = routes.index('parsed.path == "/api/operator/docs-artifacts/open"')
+    models_index = routes.index('parsed.path == "/api/models"')
+    post_index = routes.index('def handle_post(')
+
+    assert session_recall_index < docs_index < docs_open_index < models_index
+    assert docs_open_index < post_index
+    post_section = routes[post_index:]
+    assert '"/api/operator/docs-artifacts"' not in post_section
+    assert '"/api/operator/docs-artifacts/open"' not in post_section
+
+
+def _docs_artifacts_module(monkeypatch, source_specs):
+    docs_artifacts = importlib.import_module("api.operator_docs_artifacts")
+    monkeypatch.setattr(docs_artifacts, "SOURCE_SPECS", source_specs, raising=False)
+    return docs_artifacts
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_json(path, data):
+    return _write(path, json.dumps(data))
+
+
+def _catalog_source_specs(tmp_path):
+    root = tmp_path / "workspace"
+    plans = root / ".hermes" / "plans"
+    research = root / "obsidian-vault" / "Agent-Kimi" / "Deep Research Briefs"
+    active_plan = root / "obsidian-vault" / "Agent-Shared" / "ACTIVE PLAN.md"
+    artifacts = root / "artifacts"
+    state = root / "state"
+    changelog = tmp_path / "webui" / "CHANGELOG.md"
+
+    _write(plans / "2026-05-26_204427-hermes-mission-control-execution-strategy.md", "# Hermes Mission Control Execution Strategy\nreal plan body should stay out of list cards\n")
+    _write(plans / "2026-05-27_103306-slice-7-docs-artifact-browser-handoff.md", "# Slice 7 Docs/Artifact Browser TDD Handoff\nfull handoff body should stay out of list cards\n")
+    _write(research / "agentic-browser-brief.md", "# Agentic Browser Brief\nbrief body should stay out of list cards\n")
+    _write_json(research / "manifest.json", {"generated_at": "2026-05-27T10:00:00Z", "briefs": ["agentic-browser-brief.md"]})
+    _write(research / "raw" / "transcript.txt", "raw transcript must not be cataloged\n")
+    _write(active_plan, "# ACTIVE PLAN\nsource-backed current plan\n")
+    _write_json(artifacts / "hermes-video-RoBD7Lc-0MI" / "action-summary.json", {"ranked_actions": [1, 2, 3], "avoid": ["fake data"]})
+    _write_json(artifacts / "hermes-video-RoBD7Lc-0MI" / "manifest.json", {"artifact_dir": "real-artifacts"})
+    _write(artifacts / "hermes-video-RoBD7Lc-0MI" / "raw" / "transcript.txt", "raw transcript must not be cataloged\n")
+    _write_json(state / "hermes_reverse_prompt_latest.json", {"ok": True})
+    _write_json(state / "hermes_youtube_recommendations_2026-05-20.json", {"ok": True})
+    _write_json(state / "hermes_operator_kanban_hardening_2026-05-20.json", {"ok": True})
+    _write_json(state / "local_model_probe_2026-05-20.json", {"excluded": True})
+    _write(changelog, "## [Unreleased]\n\n### Added\n\n- Existing entry.\n")
+
+    return {
+        "plans": {
+            "type": "directory",
+            "label": "Plans / handoffs",
+            "path": plans,
+            "display_path": ".hermes/plans",
+            "includes": [{"glob": "*.md", "kind": "auto"}],
+        },
+        "deep_research_briefs": {
+            "type": "directory",
+            "label": "Deep research briefs",
+            "path": research,
+            "display_path": "obsidian-vault/Agent-Kimi/Deep Research Briefs",
+            "includes": [{"glob": "*.md", "kind": "brief"}, {"glob": "manifest.json", "kind": "artifact_manifest"}],
+        },
+        "agent_shared_active_plan": {
+            "type": "file",
+            "label": "Shared active plan",
+            "path": active_plan,
+            "display_path": "obsidian-vault/Agent-Shared/ACTIVE PLAN.md",
+            "kind": "plan",
+        },
+        "generated_artifacts": {
+            "type": "directory",
+            "label": "Generated artifacts",
+            "path": artifacts,
+            "display_path": "artifacts",
+            "includes": [{"glob": "*/action-summary.json", "kind": "action_summary"}, {"glob": "*/manifest.json", "kind": "artifact_manifest"}],
+        },
+        "state_summaries": {
+            "type": "directory",
+            "label": "Selected state summaries",
+            "path": state,
+            "display_path": "state",
+            "includes": [
+                {"path": "hermes_reverse_prompt_latest.json", "kind": "state_summary"},
+                {"path": "hermes_youtube_recommendations_2026-05-20.json", "kind": "state_summary"},
+                {"path": "hermes_operator_kanban_hardening_2026-05-20.json", "kind": "state_summary"},
+            ],
+        },
+        "webui_changelog": {
+            "type": "file",
+            "label": "WebUI changelog",
+            "path": changelog,
+            "display_path": "CHANGELOG.md",
+            "kind": "changelog",
+        },
+    }
+
+
+def test_docs_artifacts_catalogs_allowlisted_plans_briefs_artifact_json_state_and_changelog_metadata(monkeypatch, tmp_path):
+    docs_artifacts = _docs_artifacts_module(monkeypatch, _catalog_source_specs(tmp_path))
+
+    payload = docs_artifacts.build_operator_docs_artifacts_payload(now=1234567890.0)
+
+    assert payload["would_execute"] is False
+    assert payload["count"] == len(payload["items"])
+    assert payload["items"]
+    assert {source["id"] for source in payload["sources"]} == {
+        "plans",
+        "deep_research_briefs",
+        "agent_shared_active_plan",
+        "generated_artifacts",
+        "state_summaries",
+        "webui_changelog",
+    }
+
+    by_key = {(item["root_id"], item["relative_path"]): item for item in payload["items"]}
+    expected = {
+        ("plans", "2026-05-26_204427-hermes-mission-control-execution-strategy.md"),
+        ("plans", "2026-05-27_103306-slice-7-docs-artifact-browser-handoff.md"),
+        ("deep_research_briefs", "agentic-browser-brief.md"),
+        ("deep_research_briefs", "manifest.json"),
+        ("agent_shared_active_plan", "ACTIVE PLAN.md"),
+        ("generated_artifacts", "hermes-video-RoBD7Lc-0MI/action-summary.json"),
+        ("generated_artifacts", "hermes-video-RoBD7Lc-0MI/manifest.json"),
+        ("state_summaries", "hermes_reverse_prompt_latest.json"),
+        ("state_summaries", "hermes_youtube_recommendations_2026-05-20.json"),
+        ("state_summaries", "hermes_operator_kanban_hardening_2026-05-20.json"),
+        ("webui_changelog", "CHANGELOG.md"),
+    }
+    assert expected <= set(by_key)
+    assert ("state_summaries", "local_model_probe_2026-05-20.json") not in by_key
+
+    kinds = {item["kind"] for item in payload["items"]}
+    assert {"meta_plan", "handoff", "brief", "artifact_manifest", "action_summary", "state_summary", "changelog"} <= kinds
+
+    for item in payload["items"]:
+        for key in ["id", "kind", "root_id", "title", "relative_path", "display_path", "extension", "size_bytes", "mtime", "freshness", "preview_available", "metadata", "issues"]:
+            assert key in item
+        assert item["id"].startswith("da_")
+        assert isinstance(item["size_bytes"], int)
+        assert isinstance(item["mtime"], float)
+        assert item["freshness"]["label"] in {"current", "historical", "stale", "unknown"}
+        assert "body should stay out of list cards" not in json.dumps(item)
+        assert "raw transcript" not in json.dumps(item)
+
+
+def test_docs_artifacts_missing_root_is_unknown_not_fake_card(monkeypatch, tmp_path):
+    specs = {
+        "workspace_assets": {
+            "type": "directory",
+            "label": "Workspace assets",
+            "path": tmp_path / "missing-assets",
+            "display_path": "assets",
+            "includes": [{"glob": "*.md", "kind": "artifact_manifest"}],
+        }
+    }
+    docs_artifacts = _docs_artifacts_module(monkeypatch, specs)
+
+    payload = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)
+
+    assert payload["status"] == "unknown"
+    assert payload["items"] == []
+    assert payload["count"] == 0
+    assert payload["sources"][0]["id"] == "workspace_assets"
+    assert payload["sources"][0]["state"] == "unknown"
+    assert "missing" in payload["sources"][0]["issue"].lower()
+    assert any("workspace_assets" in issue and "missing" in issue.lower() for issue in payload["issues"])
+
+
+def test_docs_artifacts_excludes_raw_memory_sessions_attachments_and_config_dirs(monkeypatch, tmp_path):
+    source_root = tmp_path / "source"
+    allowed = _write(source_root / "visible.md", "# Visible\n")
+    for rel in [
+        "raw/transcript.md",
+        ".obsidian/workspace.json",
+        "memory/2026-05-27.md",
+        "memory-ledger/claims.json",
+        "sessions/session.json",
+        "attachments/image.txt",
+        "node_modules/pkg/index.js",
+        ".git/config",
+        "__pycache__/x.pyc",
+    ]:
+        _write(source_root / rel, "excluded\n")
+    specs = {
+        "broad_test_root": {
+            "type": "directory",
+            "label": "Broad test root",
+            "path": source_root,
+            "display_path": "source",
+            "includes": [{"glob": "**/*", "kind": "plan"}],
+        }
+    }
+    docs_artifacts = _docs_artifacts_module(monkeypatch, specs)
+
+    payload = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)
+
+    assert [item["relative_path"] for item in payload["items"]] == [allowed.name]
+    serialized = json.dumps(payload)
+    for forbidden in ["raw/", ".obsidian", "memory/", "memory-ledger", "sessions/", "attachments/", "node_modules", ".git", "__pycache__"]:
+        assert forbidden not in serialized
+
+
+def test_docs_artifacts_filters_query_kind_root_and_clamps_limit(monkeypatch, tmp_path):
+    docs_artifacts = _docs_artifacts_module(monkeypatch, _catalog_source_specs(tmp_path))
+
+    payload = docs_artifacts.build_operator_docs_artifacts_payload(
+        query_text="slice-7",
+        kind="handoff",
+        root="plans",
+        limit="500",
+        now=1.0,
+    )
+
+    assert payload["query"] == {"text": "slice-7", "kind": "handoff", "root": "plans", "limit": 100}
+    assert payload["count"] == 1
+    assert payload["items"][0]["root_id"] == "plans"
+    assert payload["items"][0]["kind"] == "handoff"
+    assert "slice-7" in payload["items"][0]["relative_path"]
+
+    low_limit = docs_artifacts.build_operator_docs_artifacts_payload(limit="0", now=1.0)
+    assert low_limit["query"]["limit"] == 1
+    assert low_limit["count"] <= 1
+
+
+def test_docs_artifacts_redacts_secretish_titles_paths_issues(monkeypatch, tmp_path):
+    source_root = tmp_path / "secret-source"
+    secrets = [
+        "password=supersecretvalue",
+        "sk-abcdefghijklmnop",
+        "xoxb-abcdefghijklmnop",
+        "ghp_abcdefghijklmnop",
+        "github_pat_abcdefghijklmnop",
+    ]
+    for secret in secrets:
+        _write(source_root / f"{secret}.md", f"# {secret}\n")
+    specs = {
+        "secret_root": {
+            "type": "directory",
+            "label": "Bearer abcdefghijklmnop",
+            "path": source_root,
+            "display_path": "secret-root",
+            "includes": [{"glob": "*.md", "kind": "plan"}],
+        }
+    }
+    docs_artifacts = _docs_artifacts_module(monkeypatch, specs)
+
+    payload = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)
+    serialized = json.dumps(payload)
+
+    for secret in [*secrets, "Bearer abcdefghijklmnop"]:
+        assert secret not in serialized
+    assert "[redacted]" in serialized
+
+
+def test_docs_artifacts_redacts_normalized_titles_json_keys_and_omitted_display_path(monkeypatch, tmp_path):
+    source_root = tmp_path / "secret-source"
+    _write(source_root / "sk-abc...wxyz.md", "# secret\n")
+    _write(source_root / "xoxb-a...wxyz.md", "# secret\n")
+    _write(source_root / "github...wxyz.md", "# secret\n")
+    _write(source_root / "api_key=abcdefghijklmnopqrstuvwxyz.md", "# secret\n")
+    _write_json(source_root / "manifest.json", {"api_key=abcdefghijklmnopqrstuvwxyz": 1, "safe": 2})
+    specs = {
+        "no_display": {
+            "type": "directory",
+            "label": "No display root",
+            "path": source_root,
+            "includes": [{"glob": "*", "kind": "auto"}],
+        }
+    }
+    docs_artifacts = _docs_artifacts_module(monkeypatch, specs)
+
+    payload = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)
+    serialized = json.dumps(payload)
+
+    assert str(source_root) not in serialized
+    for leaked in [
+        "Sk Abcdefghijklmnopqrstuvwxyz",
+        "Xoxb Abcdefghijklmnopqrstuvwxyz",
+        "Github Pat Abcdefghijklmnopqrstuvwxyz",
+        "Api Key=abcdefghijklmnopqrstuvwxyz",
+        "api_key=abcdefghijklmnopqrstuvwxyz",
+    ]:
+        assert leaked not in serialized
+    assert "[redacted]" in serialized
+
+
+def test_docs_artifacts_redacts_json_metadata_path_keys_and_prefixed_secret_keys(monkeypatch, tmp_path):
+    source_root = tmp_path / "json-source"
+    _write_json(
+        source_root / "manifest.json",
+        {
+            "/tmp/Secret Folder/manifest.md": 1,
+            r"C:\Users\malac\Secret Folder\manifest.md": 2,
+            "OPENAI_API_KEY": 3,
+            "safe": 4,
+        },
+    )
+    docs_artifacts = _docs_artifacts_module(
+        monkeypatch,
+        {
+            "json_source": {
+                "type": "directory",
+                "label": "JSON source",
+                "path": source_root,
+                "display_path": "json-source",
+                "includes": [{"glob": "manifest.json", "kind": "artifact_manifest"}],
+            }
+        },
+    )
+
+    payload = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)
+    item = payload["items"][0]
+    serialized_keys = json.dumps(item["metadata"]["json_keys"])
+
+    assert "safe" in item["metadata"]["json_keys"]
+    for leaked in ["/tmp/Secret Folder", r"C:\Users", "Secret Folder", "OPENAI_API_KEY"]:
+        assert leaked not in serialized_keys
+    assert "[path]" in serialized_keys
+    assert "[redacted]" in serialized_keys
+
+
+def test_docs_artifacts_rejects_source_root_symlink_escape(monkeypatch, tmp_path):
+    outside = tmp_path / "outside"
+    _write(outside / "secret.md", "# outside\n")
+    root_link = tmp_path / "root-link"
+    try:
+        root_link.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlinks unsupported on this platform")
+    specs = {
+        "symlink_root": {
+            "type": "directory",
+            "label": "Symlink root",
+            "path": root_link,
+            "display_path": "symlink-root",
+            "includes": [{"glob": "*.md", "kind": "plan"}],
+        }
+    }
+    docs_artifacts = _docs_artifacts_module(monkeypatch, specs)
+
+    payload = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)
+    serialized = json.dumps(payload)
+
+    assert payload["items"] == []
+    assert payload["sources"][0]["state"] == "unknown"
+    assert "symlink" in payload["sources"][0]["issue"].lower()
+    assert "secret.md" not in serialized
+    assert str(outside) not in serialized
+
+
+def test_docs_artifacts_unreadable_file_issue_does_not_leak_absolute_path(monkeypatch, tmp_path):
+    source_root = tmp_path / "source"
+    denied = _write(source_root / "denied.md", "# denied\n")
+    try:
+        denied.chmod(0)
+    except OSError:
+        pytest.skip("chmod unsupported on this platform")
+    specs = {
+        "permission_root": {
+            "type": "directory",
+            "label": "Permission root",
+            "path": source_root,
+            "display_path": "permission-root",
+            "includes": [{"glob": "*.md", "kind": "plan"}],
+        }
+    }
+    docs_artifacts = _docs_artifacts_module(monkeypatch, specs)
+
+    try:
+        payload = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)
+    finally:
+        denied.chmod(0o600)
+    serialized = json.dumps(payload)
+    if "unreadable" not in serialized and "Permission" not in serialized:
+        pytest.skip("platform allowed reading chmod-000 file")
+
+    assert str(source_root) not in serialized
+    assert str(denied) not in serialized
+    assert "denied.md" in serialized
+
+
+def test_docs_artifacts_short_error_redacts_windows_absolute_paths(monkeypatch):
+    docs_artifacts = _docs_artifacts_module(monkeypatch, {})
+    raw = "Permission denied: 'C:\\Users\\malac\\Secret Folder\\denied.md'"
+
+    message = docs_artifacts._short_error(PermissionError(raw))
+
+    assert "C:\\" not in message
+    assert "Users" not in message
+    assert "Secret Folder" not in message
+    assert "denied.md" not in message
+    assert "[path]" in message
+
+
+def test_docs_artifacts_short_error_redacts_posix_paths_with_spaces_and_unc_paths(monkeypatch):
+    docs_artifacts = _docs_artifacts_module(monkeypatch, {})
+    raw = "Failed '/tmp/Secret Folder/denied.md' and '\\\\server\\share\\Secret Folder\\denied.md'"
+
+    message = docs_artifacts._short_error(PermissionError(raw))
+
+    assert "/tmp" not in message
+    assert "\\\\server" not in message
+    assert "Secret Folder" not in message
+    assert "denied.md" not in message
+    assert message.count("[path]") >= 2
+
+
+def test_docs_artifacts_preview_reads_bounded_redacted_text_for_catalog_item(monkeypatch, tmp_path):
+    docs_artifacts = _docs_artifacts_module(
+        monkeypatch,
+        {
+            "text_root": {
+                "type": "directory",
+                "label": "Text root",
+                "path": tmp_path / "docs",
+                "display_path": "docs",
+                "includes": [{"glob": "*.md", "kind": "plan"}],
+            }
+        },
+    )
+    monkeypatch.setattr(docs_artifacts, "MAX_PREVIEW_BYTES", 72, raising=False)
+    _write(tmp_path / "docs" / "note.md", "needle Bearer abcdefghijklmnop " + "x" * 200)
+    item = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)["items"][0]
+
+    payload = docs_artifacts.build_operator_docs_artifact_preview_payload(item_id=item["id"], now=1.0)
+
+    assert payload["mode"] == "docs-artifacts-preview-read-only"
+    assert payload["would_execute"] is False
+    assert payload["status"] == "live"
+    assert payload["item"]["id"] == item["id"]
+    assert payload["preview"]["format"] == "text"
+    assert "needle" in payload["preview"]["text"]
+    assert "Bearer abcdefghijklmnop" not in payload["preview"]["text"]
+    assert "[redacted]" in payload["preview"]["text"]
+    assert payload["preview"]["truncated"] is True
+    assert payload["preview"]["bytes_read"] == 72
+    assert payload["preview"]["max_bytes"] == 72
+
+
+def test_docs_artifacts_preview_redacts_local_paths_and_prefixed_env_secrets(monkeypatch, tmp_path):
+    docs_artifacts = _docs_artifacts_module(
+        monkeypatch,
+        {
+            "text_root": {
+                "type": "directory",
+                "label": "Text root",
+                "path": tmp_path / "docs",
+                "display_path": "docs",
+                "includes": [{"glob": "*.md", "kind": "plan"}],
+            }
+        },
+    )
+    body = "\n".join(
+        [
+            "keep needle",
+            "unix path /tmp/Secret Folder/brief.md",
+            r"windows path C:\Users\malac\Secret Folder\brief.md",
+            "OPENAI_API_KEY=abcdefghijklmnopqrstuvwxyz",
+            "HERMES_TOKEN=supersecrettokenvalue",
+        ]
+    )
+    _write(tmp_path / "docs" / "paths-and-secrets.md", body)
+    item = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)["items"][0]
+
+    payload = docs_artifacts.build_operator_docs_artifact_preview_payload(item_id=item["id"], now=1.0)
+    text = payload["preview"]["text"]
+
+    assert payload["status"] == "live"
+    assert payload["preview"]["format"] == "text"
+    assert "keep needle" in text
+    for leaked in ["/tmp/Secret Folder", r"C:\Users", "Secret Folder", "abcdefghijklmnopqrstuvwxyz", "supersecrettokenvalue"]:
+        assert leaked not in text
+    assert "[path]" in text
+    assert "[redacted]" in text
+
+
+def test_docs_artifacts_preview_json_summarizes_known_action_summary_without_dumping_raw_values(monkeypatch, tmp_path):
+    long_raw = "raw-value-" * 80
+    action_summary = {
+        "ranked_actions": [{"id": "a"}, {"id": "b"}],
+        "avoid": ["fake data"],
+        "brief_path": "/tmp/Secret Folder/brief.md",
+        "artifact_dir": "/tmp/Secret Folder/artifacts",
+        "raw_transcript": long_raw,
+    }
+    docs_artifacts = _docs_artifacts_module(
+        monkeypatch,
+        {
+            "generated_artifacts": {
+                "type": "directory",
+                "label": "Generated artifacts",
+                "path": tmp_path / "artifacts",
+                "display_path": "artifacts",
+                "includes": [{"glob": "*/action-summary.json", "kind": "action_summary"}],
+            }
+        },
+    )
+    _write_json(tmp_path / "artifacts" / "video" / "action-summary.json", action_summary)
+    item = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)["items"][0]
+
+    payload = docs_artifacts.build_operator_docs_artifact_preview_payload(item_id=item["id"], now=1.0)
+
+    assert payload["status"] == "live"
+    assert payload["preview"]["format"] == "json-summary"
+    text = payload["preview"]["text"]
+    assert "ranked_actions: 2" in text
+    assert "avoid: 1" in text
+    assert "brief_path:" in text
+    assert "artifact_dir:" in text
+    assert long_raw not in text
+    assert "/tmp/Secret Folder" not in text
+
+
+def test_docs_artifacts_preview_malformed_json_is_unknown_metadata_only_and_marks_item_unavailable(monkeypatch, tmp_path):
+    docs_artifacts = _docs_artifacts_module(
+        monkeypatch,
+        {
+            "generated_artifacts": {
+                "type": "directory",
+                "label": "Generated artifacts",
+                "path": tmp_path / "artifacts",
+                "display_path": "artifacts",
+                "includes": [{"glob": "*/action-summary.json", "kind": "action_summary"}],
+            }
+        },
+    )
+    _write(tmp_path / "artifacts" / "video" / "action-summary.json", "{not-json raw body must not leak")
+    item = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)["items"][0]
+
+    payload = docs_artifacts.build_operator_docs_artifact_preview_payload(item_id=item["id"], now=1.0)
+
+    assert payload["status"] == "unknown"
+    assert payload["item"]["preview_available"] is False
+    assert payload["preview"] == {
+        "format": "metadata-only",
+        "text": "",
+        "truncated": False,
+        "bytes_read": 0,
+        "max_bytes": docs_artifacts.MAX_PREVIEW_BYTES,
+    }
+    assert "raw body must not leak" not in json.dumps(payload)
+    assert any("malformed json" in issue.lower() or "preview unavailable" in issue.lower() for issue in payload["issues"])
+
+
+def test_docs_artifacts_preview_rejects_path_traversal_absolute_url_tilde_windows_drive_and_nul(monkeypatch, tmp_path):
+    docs_artifacts = _docs_artifacts_module(monkeypatch, _catalog_source_specs(tmp_path))
+
+    for item_id in ["../secret", "/etc/passwd", "~/.ssh/id_rsa", "C:\\Users\\malac\\secret.txt", "file:///tmp/secret", "da_bad\x00id"]:
+        payload = docs_artifacts.build_operator_docs_artifact_preview_payload(item_id=item_id, now=1.0)
+        serialized = json.dumps(payload)
+        assert payload["status"] == "unknown"
+        assert payload["preview"]["format"] == "metadata-only"
+        assert payload["preview"]["text"] == ""
+        assert payload["would_execute"] is False
+        assert "etc/passwd" not in serialized
+        assert "Users" not in serialized
+        assert any("rejected" in issue.lower() or "unknown" in issue.lower() for issue in payload["issues"])
+
+
+def test_docs_artifacts_preview_rejects_symlink_escape(monkeypatch, tmp_path):
+    root = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    _write(outside / "escape.md", "# outside\n")
+    root.mkdir(parents=True, exist_ok=True)
+    link = root / "escape.md"
+    try:
+        link.symlink_to(outside / "escape.md")
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported on this platform")
+    docs_artifacts = _docs_artifacts_module(
+        monkeypatch,
+        {
+            "allowed": {
+                "type": "directory",
+                "label": "Allowed",
+                "path": root,
+                "display_path": "allowed",
+                "includes": [{"glob": "*.md", "kind": "plan"}],
+            }
+        },
+    )
+
+    catalog = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)
+    guessed_id = docs_artifacts._stable_item_id("allowed", "escape.md")
+    preview = docs_artifacts.build_operator_docs_artifact_preview_payload(item_id=guessed_id, now=1.0)
+
+    assert catalog["items"] == []
+    assert preview["status"] == "unknown"
+    assert preview["preview"]["format"] == "metadata-only"
+    assert str(outside) not in json.dumps(preview)
+
+
+def test_docs_artifacts_preview_oversize_file_is_metadata_only(monkeypatch, tmp_path):
+    docs_artifacts = _docs_artifacts_module(
+        monkeypatch,
+        {
+            "docs": {
+                "type": "directory",
+                "label": "Docs",
+                "path": tmp_path / "docs",
+                "display_path": "docs",
+                "includes": [{"glob": "*.md", "kind": "plan"}],
+            }
+        },
+    )
+    monkeypatch.setattr(docs_artifacts, "MAX_SOURCE_BYTES", 20, raising=False)
+    _write(tmp_path / "docs" / "large.md", "x" * 80)
+    item = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)["items"][0]
+
+    payload = docs_artifacts.build_operator_docs_artifact_preview_payload(item_id=item["id"], now=1.0)
+
+    assert item["preview_available"] is False
+    assert payload["status"] == "unknown"
+    assert payload["preview"] == {
+        "format": "metadata-only",
+        "text": "",
+        "truncated": False,
+        "bytes_read": 0,
+        "max_bytes": docs_artifacts.MAX_PREVIEW_BYTES,
+    }
+    assert any("preview unavailable" in issue.lower() or "exceeds" in issue.lower() for issue in payload["issues"])
+
+
+def test_docs_artifacts_catalog_malformed_json_is_unknown_not_green_or_previewable(monkeypatch, tmp_path):
+    docs_artifacts = _docs_artifacts_module(
+        monkeypatch,
+        {
+            "generated_artifacts": {
+                "type": "directory",
+                "label": "Generated artifacts",
+                "path": tmp_path / "artifacts",
+                "display_path": "artifacts",
+                "includes": [{"glob": "*/action-summary.json", "kind": "action_summary"}],
+            }
+        },
+    )
+    _write(tmp_path / "artifacts" / "video" / "action-summary.json", "{not-json raw body must not leak")
+
+    payload = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)
+
+    serialized = json.dumps(payload)
+    assert payload["status"] == "unknown"
+    assert payload["sources"][0]["state"] == "unknown"
+    assert payload["items"]
+    item = payload["items"][0]
+    assert item["preview_available"] is False
+    assert item["freshness"]["label"] in {"unknown", "stale"}
+    assert any("malformed json" in issue.lower() for issue in item["issues"])
+    assert any("malformed json" in issue.lower() for issue in payload["issues"])
+    assert "raw body must not leak" not in serialized
+
+
+def test_docs_artifacts_exact_include_missing_file_reports_issue_even_when_other_files_exist(monkeypatch, tmp_path):
+    docs_artifacts = _docs_artifacts_module(
+        monkeypatch,
+        {
+            "state_summaries": {
+                "type": "directory",
+                "label": "Selected state summaries",
+                "path": tmp_path / "state",
+                "display_path": "state",
+                "includes": [
+                    {"path": "present.json", "kind": "state_summary"},
+                    {"path": "missing.json", "kind": "state_summary"},
+                ],
+            }
+        },
+    )
+    _write_json(tmp_path / "state" / "present.json", {"ok": True})
+
+    payload = docs_artifacts.build_operator_docs_artifacts_payload(now=1.0)
+
+    serialized = json.dumps(payload)
+    assert payload["status"] == "unknown"
+    assert payload["sources"][0]["state"] == "unknown"
+    assert payload["count"] == 1
+    assert payload["items"][0]["relative_path"] == "present.json"
+    assert "missing.json" in serialized
+    assert str(tmp_path) not in serialized
+    assert any("missing" in issue.lower() and "missing.json" in issue for issue in payload["issues"])

--- a/tests/test_operator_docs_artifacts_ui_static.py
+++ b/tests/test_operator_docs_artifacts_ui_static.py
@@ -1,0 +1,574 @@
+import re
+import subprocess
+from pathlib import Path
+
+
+def _read(path):
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _docs_artifacts_js():
+    return _read("static/operator_docs_artifacts.js")
+
+
+def _strip_js_strings_and_comments(js):
+    js = re.sub(r"//.*", "", js)
+    js = re.sub(r"/\*.*?\*/", "", js, flags=re.DOTALL)
+    return re.sub(r"(['\"`])(?:\\.|(?!\1).)*\1", "''", js, flags=re.DOTALL)
+
+
+def _top_level_calls(js, function_name):
+    cleaned = _strip_js_strings_and_comments(js)
+    calls = []
+    depth = 0
+    for line_number, line in enumerate(cleaned.splitlines(), start=1):
+        line_depth = depth
+        if re.search(rf"\bfunction\s+{re.escape(function_name)}\s*\(", line):
+            pass
+        elif line_depth == 0 and re.search(rf"\b{re.escape(function_name)}\s*\(", line):
+            calls.append((line_number, line.strip()))
+        depth += line.count("{") - line.count("}")
+        depth = max(depth, 0)
+    return calls
+
+
+def test_docs_artifacts_markup_exists_after_session_recall_chip_and_popover():
+    html = _read("static/index.html")
+
+    for element_id in [
+        "operatorDocsArtifactsChip",
+        "operatorDocsArtifactsLabel",
+        "operatorDocsArtifactsPopover",
+        "operatorDocsArtifactsRefresh",
+        "operatorDocsArtifactsInput",
+        "operatorDocsArtifactsKind",
+        "operatorDocsArtifactsRoot",
+        "operatorDocsArtifactsList",
+        "operatorDocsArtifactsPreview",
+    ]:
+        assert f'id="{element_id}"' in html
+
+    assert html.index('id="operatorSessionRecallChip"') < html.index('id="operatorDocsArtifactsChip"') < html.index('id="composerMobileConfigBtn"')
+    assert html.index('id="operatorSessionRecallPopover"') < html.index('id="operatorDocsArtifactsPopover"')
+
+
+def test_docs_artifacts_script_loaded_after_session_recall_before_boot():
+    html = _read("static/index.html")
+
+    assert html.index("static/operator_session_recall.js") < html.index("static/operator_docs_artifacts.js") < html.index("static/boot.js")
+
+
+def test_docs_artifacts_css_has_popover_card_source_preview_action_and_mobile_rules():
+    css = _read("static/style.css")
+
+    for selector in [
+        ".operator-docs-artifacts-popover",
+        ".operator-docs-artifacts-list",
+        ".operator-docs-artifacts-card",
+        ".operator-docs-artifacts-source",
+        ".operator-docs-artifacts-preview",
+        ".operator-docs-artifacts-action",
+        ".operator-docs-artifacts-current",
+        ".operator-docs-artifacts-historical",
+        ".operator-docs-artifacts-stale",
+    ]:
+        assert selector in css
+
+    mobile_starts = [
+        match.start()
+        for match in re.finditer(r"@media\s*\(\s*max-width\s*:\s*640px\s*\)", css)
+    ]
+    assert mobile_starts
+    mobile_sections = [
+        css[start : mobile_starts[index + 1] if index + 1 < len(mobile_starts) else len(css)]
+        for index, start in enumerate(mobile_starts)
+    ]
+    assert any("operator-docs-artifacts" in section for section in mobile_sections)
+
+
+def test_docs_artifacts_kind_filter_options_match_backend_kinds():
+    html = _read("static/index.html")
+    start = html.index('id="operatorDocsArtifactsKind"')
+    end = html.index("</select>", start)
+    select = html[start:end]
+    values = set(re.findall(r'<option\s+value="([^"]+)"', select))
+
+    assert {
+        "all",
+        "meta_plan",
+        "plan",
+        "handoff",
+        "brief",
+        "artifact_manifest",
+        "action_summary",
+        "state_summary",
+        "changelog",
+    } <= values
+
+
+def test_docs_artifacts_markup_copy_does_not_claim_wired_list_search_is_coming_next():
+    html = _read("static/index.html")
+    start = html.index('id="operatorDocsArtifactsPopover"')
+    end = html.index('id="operatorDocsArtifactsPreview"', start)
+    popover = html[start:end]
+
+    for stale_copy in [
+        "list and preview not wired yet",
+        "Search docs or artifacts (coming next)",
+        "coming next",
+    ]:
+        assert stale_copy not in popover
+
+
+def test_docs_artifacts_changelog_mentions_manual_read_only_browser():
+    changelog = _read("CHANGELOG.md")
+    unreleased = changelog.split("## [v0.51.137]", 1)[0]
+
+    assert "Docs/Artifact Browser" in unreleased or "Docs / Artifacts" in unreleased
+    assert "Slice 7" in unreleased
+    assert "manual" in unreleased.lower()
+    assert "read-only" in unreleased.lower()
+    assert "local" in unreleased.lower()
+    assert "no fake" in unreleased.lower() or "without fake" in unreleased.lower()
+    assert "no apply" in unreleased.lower() or "without applying" in unreleased.lower()
+
+
+def test_docs_artifacts_js_shell_exports_manual_functions():
+    js = _docs_artifacts_js()
+
+    for name in [
+        "toggleOperatorDocsArtifacts",
+        "hideOperatorDocsArtifacts",
+        "refreshOperatorDocsArtifacts",
+        "renderOperatorDocsArtifacts",
+        "openOperatorDocsArtifactPreview",
+        "initOperatorDocsArtifacts",
+    ]:
+        assert f"window.{name}" in js
+
+
+def test_docs_artifacts_js_uses_docs_artifacts_endpoints_only():
+    js = _docs_artifacts_js()
+    allowed_endpoints = {"/api/operator/docs-artifacts", "/api/operator/docs-artifacts/open"}
+    quoted_api_paths = set(re.findall(r"[\"'`](/api/[A-Za-z0-9_./-]+)", js))
+
+    assert quoted_api_paths == allowed_endpoints
+    assert re.search(r"\bapi\s*\(\s*[\"'`]/api/operator/docs-artifacts\b", js)
+    assert not re.search(r"\bfetch\s*\(", js)
+    assert "XMLHttpRequest" not in js
+    assert "http://" not in js
+    assert "https://" not in js
+    for forbidden_method in ["POST", "PATCH", "DELETE"]:
+        assert forbidden_method not in js
+
+
+def test_docs_artifacts_values_use_text_content_not_inner_html_or_markdown():
+    js = _docs_artifacts_js()
+
+    assert ".textContent" in js
+    assert "document.createElement" in js
+    for forbidden in [
+        ".innerHTML",
+        ".outerHTML",
+        "insertAdjacentHTML",
+        "renderMd(",
+        "renderMarkdown(",
+        "marked(",
+        "markdownToHtml",
+        "eval(",
+        "Function(",
+    ]:
+        assert forbidden not in js
+
+
+def test_docs_artifacts_manual_only_no_polling_timers_or_eventsource():
+    js = _docs_artifacts_js()
+
+    for forbidden in [
+        "setInterval",
+        "setTimeout",
+        "EventSource",
+        "WebSocket",
+        "Worker(",
+        "navigator.sendBeacon",
+    ]:
+        assert forbidden not in js
+
+    assert "DOMContentLoaded" not in js or not re.search(
+        r"DOMContentLoaded[\s\S]*refreshOperatorDocsArtifacts\s*\(",
+        js,
+    )
+    assert _top_level_calls(js, "refreshOperatorDocsArtifacts") == []
+
+
+def test_docs_artifacts_renders_required_fields_and_honest_states():
+    js = _docs_artifacts_js()
+
+    for required in [
+        "sources",
+        "items",
+        "issues",
+        "root_id",
+        "relative_path",
+        "display_path",
+        "size_bytes",
+        "mtime",
+        "freshness",
+        "current",
+        "historical",
+        "stale",
+        "unknown",
+        "would_execute",
+        "preview_available",
+    ]:
+        assert required in js
+
+
+def test_docs_artifacts_forbids_mutation_dispatch_memory_skill_and_chat_tokens():
+    js = _docs_artifacts_js()
+    forbidden = [
+        "/api/chat",
+        "/api/chat/start",
+        "send(",
+        "sendMessage",
+        "startChat",
+        "submitChat",
+        "window.send",
+        "/api/kanban/",
+        "/api/kanban/tasks",
+        "/api/kanban/dispatch",
+        "createKanbanTask",
+        "updateKanbanTask",
+        "addKanbanComment",
+        "runKanbanDispatcher",
+        "nudgeKanbanDispatcher",
+        "/api/cron",
+        "/api/crons",
+        "/api/goal",
+        "/api/background",
+        "/background",
+        "background",
+        "setInterval",
+        "setTimeout",
+        "EventSource",
+        "WebSocket",
+        "Worker(",
+        "navigator.sendBeacon",
+        "/api/memory/write",
+        "/api/skills/save",
+        "/api/skills/delete",
+        "/api/skills/toggle",
+        "/apply",
+        "would_execute:true",
+        "fetch(",
+        "XMLHttpRequest",
+        "http://",
+        "https://",
+        "POST",
+        "PATCH",
+        "DELETE",
+        ".innerHTML",
+        ".outerHTML",
+        "insertAdjacentHTML",
+        "renderMd(",
+        "renderMarkdown(",
+        "marked(",
+        "markdownToHtml",
+        "eval(",
+        "Function(",
+    ]
+    for token in forbidden:
+        assert token not in js
+
+
+def _function_section(js, function_name):
+    start = js.index(f"function {function_name}")
+    match = re.search(r"\nfunction\s+", js[start + 1 :])
+    if not match:
+        return js[start:]
+    return js[start : start + 1 + match.start()]
+
+
+def test_docs_artifacts_preview_is_explicit_open_only():
+    js = _docs_artifacts_js()
+    open_body = _function_section(js, "openOperatorDocsArtifactPreview")
+
+    assert "OPERATOR_DOCS_ARTIFACTS_OPEN_ENDPOINT" in open_body
+    assert re.search(r"\bapi\s*\(", open_body)
+    assert "URLSearchParams" in open_body or "encodeURIComponent" in open_body
+    assert "disabled" in js
+    assert "preview_available" in js
+
+    for function_name in [
+        "renderOperatorDocsArtifacts",
+        "refreshOperatorDocsArtifacts",
+        "initOperatorDocsArtifacts",
+    ]:
+        body = _function_section(js, function_name)
+        assert "OPERATOR_DOCS_ARTIFACTS_OPEN_ENDPOINT" not in body
+        assert "/api/operator/docs-artifacts/open" not in body
+
+
+def test_docs_artifacts_preview_renders_bounded_text_as_plain_text():
+    js = _docs_artifacts_js()
+
+    assert "document.createElement('pre')" in js or 'document.createElement("pre")' in js
+    assert ".textContent" in js
+    for required in ["truncated", "bytes_read", "max_bytes", "format", "preview.text"]:
+        assert required in js
+    for forbidden in [".innerHTML", "renderMd(", "renderMarkdown(", "marked(", "markdownToHtml"]:
+        assert forbidden not in js
+
+
+def test_docs_artifacts_preview_handles_unknown_or_malformed_without_fake_content():
+    js = _docs_artifacts_js()
+    preview_body = _function_section(js, "_operatorDocsArtifactsRenderPreview")
+
+    for required in ["status", "unknown", "issues", "metadata-only", "malformed"]:
+        assert required in preview_body
+    for fake_copy in ["sample preview", "example artifact", "demo preview", "fake preview"]:
+        assert fake_copy not in js.lower()
+
+
+def _run_docs_artifacts_node(test_body):
+    root = Path(__file__).resolve().parents[1]
+    node_script = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert/strict');
+
+const source = fs.readFileSync('static/operator_docs_artifacts.js', 'utf8');
+
+class ClassList {
+  constructor(element) {
+    this.element = element;
+    this.values = new Set();
+  }
+  add(...names) {
+    names.forEach(name => this.values.add(name));
+    this._sync();
+  }
+  remove(...names) {
+    names.forEach(name => this.values.delete(name));
+    this._sync();
+  }
+  contains(name) {
+    return this.values.has(name);
+  }
+  _sync() {
+    this.element.className = Array.from(this.values).join(' ');
+  }
+}
+
+class Element {
+  constructor(id = '', tagName = 'div') {
+    this.id = id;
+    this.tagName = String(tagName).toUpperCase();
+    this.children = [];
+    this.parentNode = null;
+    this.dataset = {};
+    this.attributes = {};
+    this.hidden = false;
+    this.disabled = false;
+    this.title = '';
+    this.value = '';
+    this.listeners = {};
+    this._textContent = '';
+    this.className = '';
+    this.classList = new ClassList(this);
+  }
+  get firstChild() {
+    return this.children[0] || null;
+  }
+  appendChild(node) {
+    if (typeof node === 'string') {
+      const textNode = new Element('', '#text');
+      textNode.textContent = node;
+      node = textNode;
+    }
+    this.children.push(node);
+    node.parentNode = this;
+    return node;
+  }
+  removeChild(node) {
+    const index = this.children.indexOf(node);
+    if (index >= 0) {
+      this.children.splice(index, 1);
+      node.parentNode = null;
+    }
+    return node;
+  }
+  addEventListener(type, handler) {
+    this.listeners[type] = handler;
+  }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+  focus() {}
+  set textContent(value) {
+    this._textContent = String(value == null ? '' : value);
+    this.children = [];
+  }
+  get textContent() {
+    return this._textContent + this.children.map(child => child.textContent).join('');
+  }
+}
+
+const elements = new Map();
+function register(id, value = '') {
+  const element = new Element(id);
+  element.value = value;
+  elements.set(id, element);
+  return element;
+}
+[
+  'operatorDocsArtifactsInput',
+  'operatorDocsArtifactsKind',
+  'operatorDocsArtifactsRoot',
+  'operatorDocsArtifactsChip',
+  'operatorDocsArtifactsLabel',
+  'operatorDocsArtifactsPopover',
+  'operatorDocsArtifactsStatus',
+  'operatorDocsArtifactsList',
+  'operatorDocsArtifactsPreview',
+].forEach(id => register(id));
+elements.get('operatorDocsArtifactsKind').value = 'all';
+elements.get('operatorDocsArtifactsRoot').value = 'all';
+elements.get('operatorDocsArtifactsPopover').hidden = false;
+
+const document = {
+  getElementById(id) {
+    return elements.get(id) || null;
+  },
+  createElement(tagName) {
+    return new Element('', tagName);
+  },
+};
+
+const apiCalls = [];
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return {promise, resolve, reject};
+}
+
+const context = {
+  console,
+  document,
+  URLSearchParams,
+  Date,
+  Promise,
+  api(url) {
+    const d = deferred();
+    apiCalls.push({url, resolve: d.resolve, reject: d.reject, promise: d.promise});
+    return d.promise;
+  },
+};
+context.window = context;
+context.$ = id => document.getElementById(id);
+
+vm.createContext(context);
+vm.runInContext(source, context, {filename: 'operator_docs_artifacts.js'});
+
+function item(id, title) {
+  return {
+    id,
+    title,
+    kind: 'plan',
+    display_path: 'docs/' + id + '.md',
+    root_id: 'docs',
+    relative_path: id + '.md',
+    preview_available: true,
+  };
+}
+
+function previewPayload(itemValue, text) {
+  return {
+    status: 'live',
+    item: itemValue,
+    preview: {
+      format: 'text',
+      text,
+      truncated: false,
+      bytes_read: typeof text === 'string' ? text.length : 1,
+      max_bytes: 24000,
+    },
+    issues: [],
+    would_execute: false,
+  };
+}
+
+(async () => {
+__TEST_BODY__
+})().catch(error => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});
+""".replace("__TEST_BODY__", test_body)
+    completed = subprocess.run(
+        ["node", "-e", node_script],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_docs_artifacts_preview_ignores_stale_response_when_newer_item_resolves_first():
+    _run_docs_artifacts_node(r"""
+const itemA = item('a', 'Artifact A');
+const itemB = item('b', 'Artifact B');
+const promiseA = context.openOperatorDocsArtifactPreview(itemA);
+const promiseB = context.openOperatorDocsArtifactPreview(itemB);
+assert.equal(apiCalls.length, 2);
+assert.match(apiCalls[0].url, /\/api\/operator\/docs-artifacts\/open\?id=a/);
+assert.match(apiCalls[1].url, /\/api\/operator\/docs-artifacts\/open\?id=b/);
+apiCalls[1].resolve(previewPayload(itemB, 'B body'));
+await promiseB;
+assert.match(elements.get('operatorDocsArtifactsPreview').textContent, /B body/);
+apiCalls[0].resolve(previewPayload(itemA, 'A body'));
+await promiseA;
+const text = elements.get('operatorDocsArtifactsPreview').textContent;
+assert.match(text, /B body/, 'newer preview must remain visible');
+assert.doesNotMatch(text, /A body/, 'stale older preview must not overwrite newer preview');
+""")
+
+
+def test_docs_artifacts_preview_response_after_list_render_is_ignored():
+    _run_docs_artifacts_node(r"""
+const itemC = item('c', 'Artifact C');
+const promiseC = context.openOperatorDocsArtifactPreview(itemC);
+assert.equal(apiCalls.length, 1);
+context.renderOperatorDocsArtifacts({
+  status: 'live',
+  summary: 'manual refresh reset',
+  sources: [],
+  items: [],
+  issues: [],
+  count: 0,
+  would_execute: false,
+});
+apiCalls[0].resolve(previewPayload(itemC, 'C body'));
+await promiseC;
+const text = elements.get('operatorDocsArtifactsPreview').textContent;
+assert.doesNotMatch(text, /C body/, 'preview response from before list render must be ignored');
+assert.match(text, /Select an available item preview|status: unknown/);
+""")
+
+
+def test_docs_artifacts_preview_rejects_non_string_body_without_object_coercion():
+    _run_docs_artifacts_node(r"""
+const itemD = item('d', 'Artifact D');
+const promiseD = context.openOperatorDocsArtifactPreview(itemD);
+assert.equal(apiCalls.length, 1);
+apiCalls[0].resolve(previewPayload(itemD, {not: 'plain text'}));
+await promiseD;
+const text = elements.get('operatorDocsArtifactsPreview').textContent;
+assert.doesNotMatch(text, /\[object Object\]/);
+assert.match(text, /malformed|No preview text|Metadata-only/i);
+""")

--- a/tests/test_operator_kanban.py
+++ b/tests/test_operator_kanban.py
@@ -1,0 +1,509 @@
+import importlib
+import io
+import json
+import sqlite3
+import subprocess
+import sys
+import types
+from pathlib import Path
+from urllib.parse import urlparse
+from unittest.mock import patch
+
+
+def _default_task(**overrides):
+    task = {
+        "id": "t_safe",
+        "title": "Safe operator task",
+        "body": "Do a bounded operator task.",
+        "assignee": "default",
+        "status": "done",
+        "priority": 0,
+        "created_by": "max",
+        "created_at": 100,
+        "started_at": 110,
+        "completed_at": 200,
+        "workspace_kind": "scratch",
+        "workspace_path": "/tmp/hermes-operator-workspaces/t_safe",
+        "branch_name": None,
+        "claim_lock": None,
+        "claim_expires": None,
+        "tenant": "local",
+        "result": "Completed with a concise receipt.",
+        "consecutive_failures": 0,
+        "worker_pid": None,
+        "last_failure_error": None,
+        "max_runtime_seconds": None,
+        "last_heartbeat_at": None,
+        "current_run_id": 1,
+        "workflow_template_id": None,
+        "current_step_key": None,
+        "skills": None,
+        "model_override": None,
+        "max_retries": None,
+        "session_id": "sess_1",
+    }
+    task.update(overrides)
+    return task
+
+
+def _default_run(**overrides):
+    run = {
+        "id": 1,
+        "task_id": "t_safe",
+        "profile": "default",
+        "step_key": None,
+        "status": "done",
+        "claim_lock": None,
+        "claim_expires": None,
+        "worker_pid": None,
+        "max_runtime_seconds": None,
+        "last_heartbeat_at": None,
+        "started_at": 111,
+        "ended_at": 199,
+        "outcome": "completed",
+        "summary": "Run completed.",
+        "metadata": "{}",
+        "error": None,
+    }
+    run.update(overrides)
+    return run
+
+
+def _create_kanban_db(path: Path, *, tasks=None, runs=None, events=None, comments=None):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                body TEXT,
+                assignee TEXT,
+                status TEXT,
+                priority INTEGER,
+                created_by TEXT,
+                created_at INTEGER,
+                started_at INTEGER,
+                completed_at INTEGER,
+                workspace_kind TEXT,
+                workspace_path TEXT,
+                branch_name TEXT,
+                claim_lock TEXT,
+                claim_expires INTEGER,
+                tenant TEXT,
+                result TEXT,
+                consecutive_failures INTEGER,
+                worker_pid INTEGER,
+                last_failure_error TEXT,
+                max_runtime_seconds INTEGER,
+                last_heartbeat_at INTEGER,
+                current_run_id INTEGER,
+                workflow_template_id TEXT,
+                current_step_key TEXT,
+                skills TEXT,
+                model_override TEXT,
+                max_retries INTEGER,
+                session_id TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE task_runs (
+                id INTEGER PRIMARY KEY,
+                task_id TEXT,
+                profile TEXT,
+                step_key TEXT,
+                status TEXT,
+                claim_lock TEXT,
+                claim_expires INTEGER,
+                worker_pid INTEGER,
+                max_runtime_seconds INTEGER,
+                last_heartbeat_at INTEGER,
+                started_at INTEGER,
+                ended_at INTEGER,
+                outcome TEXT,
+                summary TEXT,
+                metadata TEXT,
+                error TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE task_events (
+                id INTEGER PRIMARY KEY,
+                task_id TEXT,
+                run_id INTEGER,
+                kind TEXT,
+                payload TEXT,
+                created_at INTEGER
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE task_comments (
+                id INTEGER PRIMARY KEY,
+                task_id TEXT,
+                author TEXT,
+                body TEXT,
+                created_at INTEGER
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE task_links (
+                parent_id TEXT,
+                child_id TEXT,
+                kind TEXT,
+                created_at INTEGER,
+                PRIMARY KEY (parent_id, child_id)
+            )
+            """
+        )
+        for task in tasks or [_default_task()]:
+            keys = list(task.keys())
+            conn.execute(
+                f"INSERT INTO tasks ({', '.join(keys)}) VALUES ({', '.join('?' for _ in keys)})",
+                [task[key] for key in keys],
+            )
+        for run in runs or [_default_run()]:
+            keys = list(run.keys())
+            conn.execute(
+                f"INSERT INTO task_runs ({', '.join(keys)}) VALUES ({', '.join('?' for _ in keys)})",
+                [run[key] for key in keys],
+            )
+        for event in events or [
+            {"id": 1, "task_id": "t_safe", "run_id": 1, "kind": "completed", "payload": json.dumps({"summary": "Completed."}), "created_at": 200}
+        ]:
+            keys = list(event.keys())
+            conn.execute(
+                f"INSERT INTO task_events ({', '.join(keys)}) VALUES ({', '.join('?' for _ in keys)})",
+                [event[key] for key in keys],
+            )
+        for comment in comments or []:
+            keys = list(comment.keys())
+            conn.execute(
+                f"INSERT INTO task_comments ({', '.join(keys)}) VALUES ({', '.join('?' for _ in keys)})",
+                [comment[key] for key in keys],
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _patch_sources(monkeypatch, operator_kanban, tmp_path, db_path):
+    safe_root = tmp_path / "hermes-operator-workspaces"
+    safe_root.mkdir(parents=True, exist_ok=True)
+    hardening = tmp_path / "Hermes Kanban Pilot Hardening.md"
+    hardening.write_text(
+        "# Hermes Kanban Pilot Hardening\n"
+        "Updated: `2099-01-01T00:00:00Z`\n"
+        "Board: `hermes-operator`\n"
+        f"Safe board default workdir: `{safe_root}`\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(operator_kanban, "BOARD_DB", db_path, raising=False)
+    monkeypatch.setattr(operator_kanban, "SAFE_SCRATCH_ROOT", safe_root, raising=False)
+    monkeypatch.setattr(operator_kanban, "HARDENING_NOTE", hardening, raising=False)
+    monkeypatch.setattr(operator_kanban, "PROJECT_PATHS", [Path("/mnt/c/Users/malac/.openclaw/workspace/main"), Path("/home/malac/hermes-webui")], raising=False)
+    return safe_root
+
+
+def _patch_truth(monkeypatch, *, status="live"):
+    import api.operator_truth as operator_truth
+
+    def fake_truth_payload(*, session_id=None, ui_board_hint=None, now=None):
+        return {
+            "version": 1,
+            "verified_at": now,
+            "status": status,
+            "summary": f"Truth {status}",
+            "chips": [],
+            "sources": [],
+            "issues": [] if status == "live" else [f"truth {status}"],
+        }
+
+    monkeypatch.setattr(operator_truth, "build_operator_truth_payload", fake_truth_payload, raising=False)
+
+
+def test_operator_kanban_payload_has_read_only_contract(monkeypatch, tmp_path):
+    operator_kanban = importlib.import_module("api.operator_kanban")
+    db_path = tmp_path / "kanban.db"
+    safe_root = tmp_path / "hermes-operator-workspaces"
+    _create_kanban_db(db_path, tasks=[_default_task(workspace_path=str(safe_root / "t_safe"))])
+    _patch_sources(monkeypatch, operator_kanban, tmp_path, db_path)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = operator_kanban.build_operator_kanban_payload(now=123.0)
+
+    assert payload["version"] == 1
+    assert payload["generated_at"] == 123.0
+    assert payload["mode"] == "read-only-kanban-operator"
+    assert payload["would_execute"] is False
+    assert payload["board"] == "hermes-operator"
+    assert payload["status"] in {"live", "stale", "unknown"}
+    assert payload["counts"]["done"] == 1
+    assert payload["board_safety"]["board_db"] == str(db_path)
+    assert payload["truth"]["status"] == "live"
+    assert payload["tasks"]
+    assert {"kanban_db", "hardening_note", "operator_truth"} <= {source["id"] for source in payload["sources"]}
+    for task in payload["tasks"]:
+        assert task["status"]
+        assert "assignee" in task
+        assert "profile" in task
+        assert "workspace_path" in task
+        assert "scratch_safety" in task
+        assert "blocked_reason" in task
+        assert "receipt_links" in task
+        assert "review_state" in task
+        assert "completion" in task
+
+
+def test_operator_kanban_opens_sqlite_read_only_and_does_not_init_or_dispatch(monkeypatch, tmp_path):
+    operator_kanban = importlib.import_module("api.operator_kanban")
+    db_path = tmp_path / "kanban.db"
+    safe_root = tmp_path / "hermes-operator-workspaces"
+    _create_kanban_db(db_path, tasks=[_default_task(workspace_path=str(safe_root / "t_safe"))])
+    _patch_sources(monkeypatch, operator_kanban, tmp_path, db_path)
+    _patch_truth(monkeypatch, status="live")
+    seen_connects = []
+    original_connect = operator_kanban.sqlite3.connect
+    calls = []
+
+    def checked_connect(database, *args, **kwargs):
+        seen_connects.append((str(database), kwargs))
+        return original_connect(database, *args, **kwargs)
+
+    def forbidden(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("operator kanban builder must be read-only and shell-free")
+
+    fake_kanban_db = types.ModuleType("hermes_cli.kanban_db")
+    for name in ("init_db", "dispatch", "dispatch_ready_tasks", "claim", "complete", "create_task", "update_task"):
+        setattr(fake_kanban_db, name, forbidden)
+    monkeypatch.setitem(sys.modules, "hermes_cli.kanban_db", fake_kanban_db)
+    monkeypatch.setattr(operator_kanban.sqlite3, "connect", checked_connect)
+    monkeypatch.setattr(subprocess, "run", forbidden)
+    monkeypatch.setattr(subprocess, "Popen", forbidden)
+
+    payload = operator_kanban.build_operator_kanban_payload(now=1.0)
+
+    assert payload["would_execute"] is False
+    assert calls == []
+    assert seen_connects
+    assert all("mode=ro" in database for database, _kwargs in seen_connects)
+    assert all(kwargs.get("uri") is True for _database, kwargs in seen_connects)
+
+
+def test_operator_kanban_marks_scratch_under_safe_root_live(monkeypatch, tmp_path):
+    operator_kanban = importlib.import_module("api.operator_kanban")
+    db_path = tmp_path / "kanban.db"
+    safe_root = tmp_path / "hermes-operator-workspaces"
+    _create_kanban_db(db_path, tasks=[_default_task(workspace_path=str(safe_root / "t_safe"))])
+    _patch_sources(monkeypatch, operator_kanban, tmp_path, db_path)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = operator_kanban.build_operator_kanban_payload(now=1.0)
+
+    task = payload["tasks"][0]
+    assert task["scratch_safety"]["state"] == "live"
+    assert task["scratch_safety"]["scratch_points_to_project"] is False
+    assert "safe board root" in task["scratch_safety"]["reason"]
+
+
+def test_operator_kanban_marks_scratch_pointing_at_project_stale_or_unknown(monkeypatch, tmp_path):
+    operator_kanban = importlib.import_module("api.operator_kanban")
+    db_path = tmp_path / "kanban.db"
+    _create_kanban_db(
+        db_path,
+        tasks=[_default_task(id="t_bad", workspace_path="/mnt/c/Users/malac/.openclaw/workspace/main")],
+        runs=[_default_run(task_id="t_bad")],
+        events=[{"id": 1, "task_id": "t_bad", "run_id": 1, "kind": "completed", "payload": "{}", "created_at": 200}],
+    )
+    _patch_sources(monkeypatch, operator_kanban, tmp_path, db_path)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = operator_kanban.build_operator_kanban_payload(now=1.0)
+
+    assert payload["status"] != "live"
+    task = payload["tasks"][0]
+    assert task["scratch_safety"]["scratch_points_to_project"] is True
+    assert task["scratch_safety"]["state"] in {"stale", "unknown"}
+
+
+def test_operator_kanban_missing_db_returns_unknown_without_fake_tasks(monkeypatch, tmp_path):
+    operator_kanban = importlib.import_module("api.operator_kanban")
+    missing = tmp_path / "missing" / "kanban.db"
+    _patch_sources(monkeypatch, operator_kanban, tmp_path, missing)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = operator_kanban.build_operator_kanban_payload(now=123.0)
+
+    assert payload["status"] == "unknown"
+    assert payload["tasks"] == []
+    assert not missing.exists()
+    assert any("kanban_db" in issue for issue in payload["issues"])
+
+
+def test_operator_kanban_parses_completion_metadata_and_receipts_when_structured(monkeypatch, tmp_path):
+    operator_kanban = importlib.import_module("api.operator_kanban")
+    db_path = tmp_path / "kanban.db"
+    safe_root = tmp_path / "hermes-operator-workspaces"
+    structured_result = json.dumps(
+        {
+            "summary": "Structured completion summary",
+            "changed_files": ["api/operator_kanban.py"],
+            "receipts": [{"label": "receipt", "path": "receipts/operator-kanban.md"}],
+            "validation": ["pytest tests/test_operator_kanban.py"],
+            "side_effects": ["none"],
+        }
+    )
+    _create_kanban_db(db_path, tasks=[_default_task(result=structured_result, workspace_path=str(safe_root / "t_safe"))])
+    _patch_sources(monkeypatch, operator_kanban, tmp_path, db_path)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = operator_kanban.build_operator_kanban_payload(now=1.0)
+
+    task = payload["tasks"][0]
+    assert task["completion"]["metadata_state"] == "structured"
+    assert task["completion"]["result_summary"] == "Structured completion summary"
+    assert task["completion"]["changed_files"] == ["api/operator_kanban.py"]
+    assert task["completion"]["validation"] == ["pytest tests/test_operator_kanban.py"]
+    assert task["completion"]["side_effects"] == ["none"]
+    assert task["receipt_links"]
+    assert task["receipt_links"][0]["path"] == "receipts/operator-kanban.md"
+
+
+def test_operator_kanban_surfaces_structured_review_state_from_task_result(monkeypatch, tmp_path):
+    operator_kanban = importlib.import_module("api.operator_kanban")
+    db_path = tmp_path / "kanban.db"
+    safe_root = tmp_path / "hermes-operator-workspaces"
+    structured_result = json.dumps(
+        {
+            "summary": "Structured completion summary",
+            "review_state": {"state": "required", "reason": "independent review pending"},
+            "receipts": ["receipts/operator-kanban.md"],
+            "validation": ["pytest tests/test_operator_kanban.py"],
+        }
+    )
+    _create_kanban_db(db_path, tasks=[_default_task(result=structured_result, workspace_path=str(safe_root / "t_safe"))])
+    _patch_sources(monkeypatch, operator_kanban, tmp_path, db_path)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = operator_kanban.build_operator_kanban_payload(now=1.0)
+
+    assert payload["tasks"][0]["review_state"] == {"state": "required", "reason": "independent review pending"}
+
+
+def test_operator_kanban_surfaces_review_required_from_run_metadata(monkeypatch, tmp_path):
+    operator_kanban = importlib.import_module("api.operator_kanban")
+    db_path = tmp_path / "kanban.db"
+    safe_root = tmp_path / "hermes-operator-workspaces"
+    _create_kanban_db(
+        db_path,
+        tasks=[_default_task(result="plain text completion", workspace_path=str(safe_root / "t_safe"))],
+        runs=[_default_run(metadata=json.dumps({"review_required": True}))],
+    )
+    _patch_sources(monkeypatch, operator_kanban, tmp_path, db_path)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = operator_kanban.build_operator_kanban_payload(now=1.0)
+
+    assert payload["tasks"][0]["review_state"] == {"state": "required", "reason": "review_required metadata is true"}
+
+
+def test_operator_kanban_plain_text_result_is_unstructured_not_fake_green(monkeypatch, tmp_path):
+    operator_kanban = importlib.import_module("api.operator_kanban")
+    db_path = tmp_path / "kanban.db"
+    safe_root = tmp_path / "hermes-operator-workspaces"
+    _create_kanban_db(db_path, tasks=[_default_task(result="plain text completion", workspace_path=str(safe_root / "t_safe"))])
+    _patch_sources(monkeypatch, operator_kanban, tmp_path, db_path)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = operator_kanban.build_operator_kanban_payload(now=1.0)
+
+    task = payload["tasks"][0]
+    assert payload["status"] == "stale"
+    assert task["completion"]["metadata_state"] == "unstructured"
+    assert task["completion"]["result_summary"] == "plain text completion"
+    assert task["review_state"]["state"] in {"unknown", "required"}
+    assert task["review_state"]["state"] != "approved"
+    assert task["completion"]["changed_files"] == []
+    assert task["completion"]["validation"] == []
+
+
+def test_operator_kanban_blocked_reason_comes_from_real_failure_fields(monkeypatch, tmp_path):
+    operator_kanban = importlib.import_module("api.operator_kanban")
+    db_path = tmp_path / "kanban.db"
+    safe_root = tmp_path / "hermes-operator-workspaces"
+    _create_kanban_db(
+        db_path,
+        tasks=[_default_task(id="t_blocked", status="blocked", last_failure_error="missing receipt", workspace_path=str(safe_root / "t_blocked"))],
+        runs=[_default_run(task_id="t_blocked", status="blocked", outcome="blocked", error="worker blocked on review")],
+        events=[
+            {
+                "id": 1,
+                "task_id": "t_blocked",
+                "run_id": 1,
+                "kind": "blocked",
+                "payload": json.dumps({"reason": "operator requested review"}),
+                "created_at": 201,
+            }
+        ],
+    )
+    _patch_sources(monkeypatch, operator_kanban, tmp_path, db_path)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = operator_kanban.build_operator_kanban_payload(now=1.0)
+
+    task = payload["tasks"][0]
+    assert task["blocked_reason"] == "missing receipt"
+    assert payload["counts"]["blocked"] == 1
+
+
+def test_operator_kanban_disallows_non_hermes_operator_board(monkeypatch, tmp_path):
+    operator_kanban = importlib.import_module("api.operator_kanban")
+    db_path = tmp_path / "kanban.db"
+    _create_kanban_db(db_path)
+    _patch_sources(monkeypatch, operator_kanban, tmp_path, db_path)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = operator_kanban.build_operator_kanban_payload(board="aim-operator-control", now=123.0)
+
+    assert payload["status"] == "unknown"
+    assert payload["board"] == "aim-operator-control"
+    assert payload["tasks"] == []
+    assert any("not allowlisted" in issue.lower() for issue in payload["issues"])
+
+
+def test_operator_kanban_route_returns_json(monkeypatch):
+    import api.routes as routes
+
+    expected = {"version": 1, "status": "unknown", "tasks": [], "sources": []}
+    captured = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        captured["payload"] = payload
+        return True
+
+    with patch("api.operator_kanban.build_operator_kanban_payload", return_value=expected) as build_payload, patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        handled = routes.handle_get(
+            types.SimpleNamespace(wfile=io.BytesIO()),
+            urlparse("/api/operator/kanban?board=hermes-operator&session_id=abc123&ui_board=hermes-operator"),
+        )
+
+    assert handled is True
+    assert captured["status"] == 200
+    assert captured["payload"] == expected
+    build_payload.assert_called_once_with(
+        board="hermes-operator",
+        session_id="abc123",
+        ui_board_hint="hermes-operator",
+    )

--- a/tests/test_operator_kanban_ui_static.py
+++ b/tests/test_operator_kanban_ui_static.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+
+def _read(path):
+    return Path(path).read_text(encoding="utf-8")
+
+
+def test_operator_kanban_markup_exists_inside_kanban_view():
+    html = _read("static/index.html")
+
+    assert 'id="operatorKanbanPanel"' in html
+    assert 'id="operatorKanbanBody"' in html
+    assert 'id="operatorKanbanRefresh"' in html
+    assert html.index('id="mainKanban"') < html.index('id="operatorKanbanPanel"') < html.index('id="kanbanTaskPreview"')
+    assert "read-only" in html[html.index('id="operatorKanbanPanel"') : html.index('id="kanbanTaskPreview"')].lower()
+
+
+def test_operator_kanban_script_loaded_after_proposals_before_boot():
+    html = _read("static/index.html")
+
+    assert html.index("static/operator_proposals.js") < html.index("static/operator_kanban.js") < html.index("static/boot.js")
+
+
+def test_operator_kanban_js_uses_get_endpoint_only_and_no_mutation_tokens():
+    js = _read("static/operator_kanban.js")
+    compact = js.replace(" ", "")
+
+    assert "/api/operator/kanban" in js
+    assert "api(" in js
+    assert "fetch(" not in js
+    assert "http://" not in js
+    assert "https://" not in js
+    for token in ["method:'POST'", 'method:"POST"', "method:'PATCH'", 'method:"PATCH"', "method:'DELETE'", 'method:"DELETE"']:
+        assert token not in compact
+    forbidden = [
+        "/api/kanban/dispatch",
+        "/api/kanban/tasks",
+        "/api/chat/start",
+        "runKanbanDispatcher",
+        "nudgeKanbanDispatcher",
+        "createKanbanTask",
+        "updateKanbanTask",
+        "addKanbanComment",
+        "setInterval",
+        "setTimeout",
+        "EventSource",
+        "send(",
+        "sendMessage",
+    ]
+    for token in forbidden:
+        assert token not in js
+
+
+def test_operator_kanban_js_does_not_assign_raw_payload_inner_html():
+    js = _read("static/operator_kanban.js")
+
+    assert ".textContent" in js
+    assert ".innerHTML" not in js
+    assert "payload.innerHTML" not in js
+    assert "task.innerHTML" not in js
+
+
+def test_operator_kanban_refresh_hook_is_best_effort_from_load_kanban():
+    panels = _read("static/panels.js")
+
+    assert "refreshOperatorKanban" in panels
+    assert "typeof refreshOperatorKanban === 'function'" in panels
+    hook = panels[panels.index("refreshOperatorKanban") - 200 : panels.index("refreshOperatorKanban") + 240]
+    assert "try" in hook
+    assert "catch" in hook
+
+
+def test_operator_kanban_css_exists_and_has_state_rules():
+    css = _read("static/style.css")
+
+    for selector in [
+        ".operator-kanban-panel",
+        ".operator-kanban-header",
+        ".operator-kanban-body",
+        ".operator-kanban-counts",
+        ".operator-kanban-task-card",
+        ".operator-kanban-chip",
+        ".operator-kanban-issue",
+    ]:
+        assert selector in css
+    for state in ["state-live", "state-stale", "state-unknown"]:
+        assert state in css
+    assert "max-width:640px" in css

--- a/tests/test_operator_memory_skill_review.py
+++ b/tests/test_operator_memory_skill_review.py
@@ -1,0 +1,1378 @@
+import importlib
+import io
+import json
+import subprocess
+import sys
+import threading
+import types
+from pathlib import Path
+from urllib.parse import urlparse
+from unittest.mock import patch
+
+
+REQUIRED_REVIEW_FIELDS = {
+    "target",
+    "proposed_change",
+    "source_evidence",
+    "classification",
+    "stale_risk",
+    "decision",
+    "rollback",
+    "would_execute",
+}
+
+
+VALID_EVIDENCE_HASH = "sha256:" + "a" * 64
+VALID_PREVIOUS_HASH = "sha256:" + "b" * 64
+
+
+def _patch_state_dir(monkeypatch, tmp_path):
+    import api.config as config
+
+    state_dir = tmp_path / "webui-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(config, "STATE_DIR", state_dir, raising=False)
+    return state_dir
+
+
+def _write_store(path: Path, items):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"version": 1, "updated_at": 123.0, "items": items}), encoding="utf-8")
+
+
+def _valid_review_item(**overrides):
+    item = {
+        "id": "msr_valid",
+        "created_at": 100.0,
+        "updated_at": 100.0,
+        "profile": "default",
+        "target": {
+            "kind": "memory",
+            "section": "memory",
+            "file_path": "MEMORY.md",
+            "path": "/tmp/hermes-profile/default/MEMORY.md",
+        },
+        "proposed_change": {
+            "operation": "edit",
+            "summary": "Remember a durable operator preference.",
+            "diff": "--- previous\n+++ proposed\n@@\n-Old preference\n+Updated durable preference\n",
+            "proposed_content": "Updated durable preference",
+        },
+        "previous_content": "Old preference",
+        "source_evidence": [
+            {
+                "kind": "session_message",
+                "session_id": "abc123",
+                "message_index": 4,
+                "content_hash": VALID_EVIDENCE_HASH,
+                "quote": "Please remember this durable preference.",
+            }
+        ],
+        "classification": {
+            "durability": "durable",
+            "reason": "The user stated a stable preference that should survive sessions.",
+            "transient_risk": "low",
+        },
+        "stale_risk": {
+            "state": "current",
+            "expires_at": "2026-06-10T00:00:00Z",
+            "reason": "Preference is stable unless the user supersedes it.",
+        },
+        "decision": {
+            "state": "pending",
+            "decided_at": None,
+            "decided_by": None,
+            "reason": "",
+        },
+        "rollback": {
+            "previous_hash": VALID_PREVIOUS_HASH,
+            "previous_excerpt": "Old preference",
+        },
+        "would_execute": False,
+    }
+    item.update(overrides)
+    return item
+
+
+def test_memory_skill_review_missing_store_returns_unknown_without_fake_items(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+
+    payload = review.build_operator_memory_skill_review_payload(now=123.0)
+
+    assert payload["version"] == 1
+    assert payload["generated_at"] == 123.0
+    assert payload["mode"] == "local-memory-skill-review-queue"
+    assert payload["would_execute"] is False
+    assert payload["status"] == "unknown"
+    assert payload["items"] == []
+    assert not any("sample" in json.dumps(item).lower() or "demo" in json.dumps(item).lower() for item in payload["items"])
+    assert any("missing" in issue.lower() or "unavailable" in issue.lower() for issue in payload["issues"])
+    assert not review.review_store_path().exists()
+
+
+def test_memory_skill_review_store_path_is_local_state_not_repo_static_memory_skills_or_kanban(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    state_dir = _patch_state_dir(monkeypatch, tmp_path)
+
+    store = review.review_store_path()
+
+    assert store == state_dir / "operator_memory_skill_review.json"
+    assert store.parent == state_dir
+    store_text = str(store)
+    assert "/home/malac/hermes-webui" not in store_text
+    assert "/mnt/c/Users/malac/.openclaw/workspace/main" not in store_text
+    assert "/static/" not in store_text
+    assert "/memory/" not in store_text
+    assert "/memories/" not in store_text
+    assert "/skills/" not in store_text
+    assert "/kanban/" not in store_text
+    assert "MEMORY.md" not in store_text
+    assert "SKILL.md" not in store_text
+
+
+def test_memory_skill_review_valid_items_require_all_review_fields(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    invalid_note = {"id": "msr_note", "summary": "Loose unsourced memory note"}
+    _write_store(review.review_store_path(), [_valid_review_item(), invalid_note])
+
+    payload = review.build_operator_memory_skill_review_payload(now=200.0)
+
+    assert len(payload["items"]) == 1
+    item = payload["items"][0]
+    assert REQUIRED_REVIEW_FIELDS.issubset(item.keys())
+    assert item["would_execute"] is False
+    assert item["target"]["kind"] in {"memory", "skill"}
+    assert item["target"].get("file_path")
+    assert item["proposed_change"]["operation"] in {"append", "edit", "delete"}
+    assert item["proposed_change"].get("summary")
+    assert item["proposed_change"].get("diff")
+    assert item["proposed_change"].get("proposed_content")
+    assert item.get("previous_content")
+    assert item["source_evidence"]
+    assert item["classification"].get("durability") in {"durable", "transient", "unknown"}
+    assert item["classification"].get("reason")
+    assert item["classification"].get("transient_risk") in {"low", "medium", "high"}
+    assert item["stale_risk"].get("state") in {"current", "review_required", "expired"}
+    assert item["stale_risk"].get("expires_at")
+    assert item["decision"].get("state") == "pending"
+    assert item["rollback"].get("previous_hash", "").startswith("sha256:")
+    assert payload["notes"]
+    assert payload["notes"][0].get("classification") in {"invalid", "note"}
+    assert {"target", "proposed_change", "source_evidence", "classification", "stale_risk", "decision", "rollback"}.issubset(
+        set(payload["notes"][0].get("missing", []))
+    )
+    assert any("missing" in issue.lower() for issue in payload["issues"])
+
+
+def test_memory_skill_review_existing_items_reject_malformed_proof_and_placeholder_evidence(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    malformed_items = [
+        _valid_review_item(id="msr_bad_evidence", source_evidence=[{}]),
+        _valid_review_item(id="msr_bad_target", target={"foo": "bar"}),
+        _valid_review_item(id="msr_bad_classification", classification={"durability": "unknown"}),
+        _valid_review_item(id="msr_bad_stale_risk", stale_risk={"state": "current"}),
+        _valid_review_item(
+            id="msr_bad_proposed_change",
+            proposed_change={"summary": "present but no diff/proposed content"},
+        ),
+        _valid_review_item(id="msr_bad_rollback", rollback={}),
+    ]
+    _write_store(review.review_store_path(), malformed_items)
+
+    payload = review.build_operator_memory_skill_review_payload(now=225.0)
+
+    assert payload["items"] == []
+    assert payload["notes"]
+    assert payload["status"] != "live"
+    serialized_notes = json.dumps(payload["notes"], sort_keys=True).lower()
+    for expected in ["source_evidence", "target", "classification", "stale_risk", "proposed_change", "rollback"]:
+        assert expected in serialized_notes
+    serialized_issues = json.dumps(payload["issues"], sort_keys=True).lower()
+    assert "evidence" in serialized_issues or "source" in serialized_issues
+    assert "target" in serialized_issues
+    assert "classification" in serialized_issues
+    assert "stale" in serialized_issues
+    assert "proposed" in serialized_issues
+    assert "rollback" in serialized_issues
+
+
+def test_memory_skill_review_existing_items_reject_placeholder_sha256_hashes(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    placeholder_evidence = _valid_review_item(
+        id="msr_placeholder_evidence",
+        source_evidence=[
+            {
+                "kind": "session_message",
+                "session_id": "abc123",
+                "message_index": 4,
+                "content_hash": "sha256:",
+                "quote": "Placeholder hashes are not source proof.",
+            }
+        ],
+    )
+    placeholder_rollback = _valid_review_item(
+        id="msr_placeholder_rollback",
+        rollback={"previous_hash": "sha256:", "previous_excerpt": "Old preference"},
+    )
+    _write_store(review.review_store_path(), [placeholder_evidence, placeholder_rollback])
+
+    payload = review.build_operator_memory_skill_review_payload(now=225.0)
+
+    assert payload["items"] == []
+    assert payload["notes"]
+    assert payload["status"] != "live"
+    serialized_notes = json.dumps(payload["notes"], sort_keys=True).lower()
+    assert "source_evidence" in serialized_notes
+    assert "rollback" in serialized_notes
+    serialized_issues = json.dumps(payload["issues"], sort_keys=True).lower()
+    assert "sha256" in serialized_issues or "hash" in serialized_issues
+
+
+def test_memory_skill_review_edit_delete_require_previous_content_and_rollback(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    delete_change = {
+        "operation": "delete",
+        "summary": "Remove obsolete skill guidance.",
+        "diff": "--- previous\n+++ proposed\n@@\n-Obsolete guidance\n",
+    }
+    malformed_items = [
+        _valid_review_item(id="msr_edit_missing_previous", previous_content=None),
+        _valid_review_item(id="msr_edit_missing_rollback", rollback={}),
+        _valid_review_item(id="msr_delete_missing_previous", proposed_change=delete_change, previous_content=None),
+        _valid_review_item(id="msr_delete_missing_rollback", proposed_change=delete_change, rollback={}),
+    ]
+    _write_store(review.review_store_path(), malformed_items)
+
+    payload = review.build_operator_memory_skill_review_payload(now=250.0)
+
+    assert payload["items"] == []
+    assert payload["notes"]
+    assert payload["status"] != "live"
+    serialized_notes = json.dumps(payload["notes"], sort_keys=True).lower()
+    assert "previous_content" in serialized_notes or "previous content" in serialized_notes
+    assert "rollback" in serialized_notes
+    assert "edit" in serialized_notes
+    assert "delete" in serialized_notes
+    assert any("previous" in issue.lower() or "rollback" in issue.lower() for issue in payload["issues"])
+
+
+def test_memory_skill_review_expired_items_degrade_to_stale_with_issues(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    expired = _valid_review_item(
+        stale_risk={
+            "state": "current",
+            "expires_at": "1970-01-01T00:00:01Z",
+            "reason": "This proposal needed prompt review.",
+        }
+    )
+    _write_store(review.review_store_path(), [expired])
+
+    payload = review.build_operator_memory_skill_review_payload(now=123.0)
+
+    assert len(payload["items"]) == 1
+    item = payload["items"][0]
+    assert payload["status"] == "stale"
+    assert item["stale_risk"]["state"] == "expired"
+    assert item["stale_risk"].get("expires_at") == "1970-01-01T00:00:01Z"
+    assert any("expired" in issue.lower() or "stale" in issue.lower() for issue in payload["issues"])
+
+
+def test_memory_skill_review_payload_redacts_previous_and_proposed_sensitive_text(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    raw_previous = "old database password is hunter2-password"
+    raw_proposed = "new api_token=sk-live-abcdef123456 and secret=topsecret-value"
+    sensitive = _valid_review_item(
+        previous_content=raw_previous,
+        proposed_change={
+            "operation": "edit",
+            "summary": "Rotate stored credential guidance without exposing credentials.",
+            "diff": f"--- previous\n+++ proposed\n@@\n-{raw_previous}\n+{raw_proposed}\n",
+            "proposed_content": raw_proposed,
+        },
+        rollback={
+            "previous_hash": VALID_PREVIOUS_HASH,
+            "previous_excerpt": raw_previous,
+        },
+    )
+    _write_store(review.review_store_path(), [sensitive])
+
+    payload = review.build_operator_memory_skill_review_payload(now=275.0)
+
+    assert len(payload["items"]) == 1
+    item = payload["items"][0]
+    serialized = json.dumps(payload, sort_keys=True)
+    for raw in [raw_previous, raw_proposed, "hunter2-password", "sk-live-abcdef123456", "topsecret-value"]:
+        assert raw not in serialized
+    assert item.get("previous_content") != raw_previous
+    assert item["proposed_change"].get("proposed_content") != raw_proposed
+    assert "sk-live-abcdef123456" not in item["proposed_change"].get("diff", "")
+    assert "redact" in serialized.lower()
+    assert payload["would_execute"] is False
+
+
+class _PostHandler:
+    def __init__(self, body=None, *, client_ip="127.0.0.1", headers=None):
+        raw = json.dumps(body or {}).encode("utf-8")
+        self.rfile = io.BytesIO(raw)
+        self.wfile = io.BytesIO()
+        self.client_address = (client_ip, 54321)
+        base_headers = {"Content-Length": str(len(raw)), "Host": "127.0.0.1:8787"}
+        if headers:
+            base_headers.update(headers)
+        self.headers = base_headers
+
+
+def _capture_json_response():
+    captured = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        captured["payload"] = payload
+        captured["extra_headers"] = extra_headers
+        return True
+
+    return captured, fake_j
+
+
+def _valid_propose_body(**overrides):
+    body = {
+        "target": {"kind": "memory", "section": "memory"},
+        "proposed_change": {
+            "operation": "append",
+            "summary": "Add a durable local memory review item.",
+            "diff": "--- previous\n+++ proposed\n@@\n+Proposed durable operator memory.\n",
+            "proposed_content": "Proposed durable operator memory.",
+        },
+        "source_evidence": [
+            {
+                "kind": "session_message",
+                "session_id": "route-session",
+                "message_index": 2,
+                "content_hash": VALID_EVIDENCE_HASH,
+                "quote": "Please remember this durable preference.",
+            }
+        ],
+        "classification": {
+            "durability": "durable",
+            "reason": "The user explicitly asked for a stable memory update.",
+            "transient_risk": "low",
+        },
+        "stale_risk": {
+            "state": "current",
+            "expires_at": "2026-06-10T00:00:00Z",
+            "reason": "The proposal is current unless superseded by the user.",
+        },
+    }
+    body.update(overrides)
+    return body
+
+
+def _valid_session_message_evidence(**overrides):
+    evidence = {
+        "kind": "session_message",
+        "session_id": "route-session",
+        "message_index": 2,
+        "content_hash": VALID_EVIDENCE_HASH,
+        "quote": "Please remember this durable preference.",
+    }
+    evidence.update(overrides)
+    return evidence
+
+
+def test_memory_skill_review_propose_rejects_malformed_session_message_evidence_without_writing(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    state_dir = _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+
+    import api.models as models
+
+    session_load_calls = []
+
+    def forbidden_session_load(*args, **kwargs):
+        session_load_calls.append((args, kwargs))
+        raise AssertionError("memory/skill review proposal validation must not call Session.load")
+
+    monkeypatch.setattr(models.Session, "load", forbidden_session_load, raising=False)
+
+    invalid_evidence_cases = [
+        ("missing_session_id", _valid_session_message_evidence(session_id="")),
+        ("object_session_id", _valid_session_message_evidence(session_id={"value": "route-session"})),
+        ("missing_message_index", {k: v for k, v in _valid_session_message_evidence().items() if k != "message_index"}),
+        ("negative_message_index", _valid_session_message_evidence(message_index=-1)),
+        ("non_integer_message_index", _valid_session_message_evidence(message_index="not-an-index")),
+        ("bool_message_index", _valid_session_message_evidence(message_index=True)),
+        ("missing_content_hash", _valid_session_message_evidence(content_hash="")),
+        ("invalid_content_hash", _valid_session_message_evidence(content_hash="sha256:not-a-real-hash")),
+        ("missing_quote", _valid_session_message_evidence(quote="")),
+        ("object_quote", _valid_session_message_evidence(quote={"text": "Please remember this durable preference."})),
+    ]
+
+    for label, evidence in invalid_evidence_cases:
+        result = review.propose_operator_memory_skill_review(
+            _valid_propose_body(source_evidence=[evidence]),
+            now=300.0,
+            client_context={"profile": "default", "client_ip": "127.0.0.1"},
+        )
+        assert result.get("ok") is False, label
+        assert result.get("would_execute") is False, label
+        assert "source_evidence" in result.get("missing", []), label
+        assert not review.review_store_path().exists(), label
+        assert not (state_dir / "operator_memory_skill_review.json").exists(), label
+        _assert_profile_files_unchanged(files)
+
+    assert session_load_calls == []
+
+
+def test_memory_skill_review_propose_rejects_raw_secret_session_message_quotes_without_writing(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    state_dir = _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+
+    import api.models as models
+
+    session_load_calls = []
+
+    def forbidden_session_load(*args, **kwargs):
+        session_load_calls.append((args, kwargs))
+        raise AssertionError("memory/skill review proposal validation must not call Session.load")
+
+    monkeypatch.setattr(models.Session, "load", forbidden_session_load, raising=False)
+
+    raw_secret_quotes = [
+        "password=hunter2.",
+        "Authorization: Bearer abcdefghijklmnop1234567890.",
+        "sk-" + "A" * 32 + ".",
+        "xoxb-" + "B" * 20 + ".",
+        "ghp_" + "C" * 36 + ".",
+        "github_pat_" + "D" * 22 + "_" + "E" * 59 + ".",
+    ]
+
+    for quote in raw_secret_quotes:
+        result = review.propose_operator_memory_skill_review(
+            _valid_propose_body(source_evidence=[_valid_session_message_evidence(quote=quote)]),
+            now=325.0,
+            client_context={"profile": "default", "client_ip": "127.0.0.1"},
+        )
+        assert result.get("ok") is False, quote
+        assert result.get("would_execute") is False, quote
+        assert "source_evidence" in result.get("missing", []), quote
+        assert not review.review_store_path().exists(), quote
+        assert not (state_dir / "operator_memory_skill_review.json").exists(), quote
+        _assert_profile_files_unchanged(files)
+
+    assert session_load_calls == []
+
+
+def test_memory_skill_review_propose_accepts_redacted_session_message_quote(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+
+    redacted_quote = "User said password=[redacted], Bearer [redacted], ghp_[redacted], and github_pat_[redacted]."
+    body = _valid_propose_body(source_evidence=[_valid_session_message_evidence(quote=redacted_quote)])
+
+    result = review.propose_operator_memory_skill_review(
+        body,
+        now=350.0,
+        client_context={"profile": "default", "client_ip": "127.0.0.1"},
+    )
+
+    assert result.get("ok") is True
+    assert result.get("would_execute") is False
+    stored = json.loads(review.review_store_path().read_text(encoding="utf-8"))
+    assert len(stored["items"]) == 1
+    assert stored["items"][0]["source_evidence"] == body["source_evidence"]
+    _assert_profile_files_unchanged(files)
+
+
+def test_memory_skill_review_propose_rejects_raw_secret_user_fields_without_writing(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    state_dir = _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+
+    raw_field_cases = [
+        (
+            "proposed_change summary",
+            _valid_propose_body(
+                proposed_change={
+                    "operation": "append",
+                    "summary": "Store password=hunter2 in memory.",
+                    "diff": "--- previous\n+++ proposed\n@@\n+Safe proposed text.\n",
+                    "proposed_content": "Safe proposed text.",
+                }
+            ),
+        ),
+        (
+            "proposed_change content",
+            _valid_propose_body(
+                proposed_change={
+                    "operation": "append",
+                    "summary": "Safe summary.",
+                    "diff": "--- previous\n+++ proposed\n@@\n+Bearer abcdefghijklmnop.\n",
+                    "proposed_content": "Bearer abcdefghijklmnop.",
+                }
+            ),
+        ),
+        (
+            "classification reason",
+            _valid_propose_body(
+                classification={"durability": "durable", "reason": "Contains sk-" + "A" * 32 + ".", "transient_risk": "low"}
+            ),
+        ),
+        (
+            "stale risk reason",
+            _valid_propose_body(
+                stale_risk={"state": "current", "expires_at": "2026-06-10T00:00:00Z", "reason": "Contains ghp_" + "B" * 36 + "."}
+            ),
+        ),
+        (
+            "proposed_change raw key",
+            _valid_propose_body(
+                proposed_change={
+                    "operation": "append",
+                    "summary": "Safe summary.",
+                    "diff": "--- previous\n+++ proposed\n@@\n+Safe proposed text.\n",
+                    "proposed_content": "Safe proposed text.",
+                    "password=hunter2": "present as a key",
+                }
+            ),
+        ),
+        (
+            "classification raw key",
+            _valid_propose_body(
+                classification={"durability": "durable", "reason": "Safe reason.", "transient_risk": "low", "token=sk-secret": "present as a key"}
+            ),
+        ),
+        (
+            "stale_risk raw key",
+            _valid_propose_body(
+                stale_risk={"state": "current", "expires_at": "2026-06-10T00:00:00Z", "reason": "Safe reason.", "secret=topsecret": "present as a key"}
+            ),
+        ),
+    ]
+
+    for label, body in raw_field_cases:
+        result = review.propose_operator_memory_skill_review(
+            body,
+            now=360.0,
+            client_context={"profile": "default", "client_ip": "127.0.0.1"},
+        )
+        assert result.get("ok") is False, label
+        assert result.get("would_execute") is False, label
+        assert not review.review_store_path().exists(), label
+        assert not (state_dir / "operator_memory_skill_review.json").exists(), label
+        _assert_profile_files_unchanged(files)
+
+
+def test_memory_skill_review_propose_redacts_existing_target_secrets_before_store(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+    raw_previous = "# Memory\n\nExisting password=hunter2 and token=sk-" + "A" * 32 + ".\n"
+    files["memory_file"].write_text(raw_previous, encoding="utf-8")
+
+    result = review.propose_operator_memory_skill_review(
+        _valid_propose_body(),
+        now=370.0,
+        client_context={"profile": "default", "client_ip": "127.0.0.1"},
+    )
+
+    assert result.get("ok") is True
+    stored_text = review.review_store_path().read_text(encoding="utf-8")
+    assert "hunter2" not in stored_text
+    assert "sk-" + "A" * 32 not in stored_text
+    assert "redact" in stored_text.lower()
+
+
+def test_memory_skill_review_decision_redacts_raw_secret_reason_before_writing(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+    item = _route_review_item("msr_secret_store_decision", files["memory_file"])
+    _write_store(review.review_store_path(), [item])
+    captured, fake_j = _capture_json_response()
+    secret_reason = "denied because password=hunter2 and token=sk-secret should not persist"
+    handler = _PostHandler(
+        {"id": "msr_secret_store_decision", "decision": "denied", "reason": secret_reason},
+        headers={"Host": "localhost:8787", "Origin": "http://localhost:8787"},
+    )
+
+    with patch("api.routes.j", side_effect=fake_j):
+        handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/decision"))
+
+    assert handled is True
+    assert captured["status"] == 200
+    stored_text = review.review_store_path().read_text(encoding="utf-8")
+    assert secret_reason not in stored_text
+    assert "hunter2" not in stored_text
+    assert "redact" in stored_text.lower()
+
+
+def _patch_active_profile_files(monkeypatch, tmp_path):
+    import api.profiles as profiles
+
+    hermes_home = tmp_path / "hermes-home"
+    memories_dir = hermes_home / "memories"
+    skill_dir = hermes_home / "skills" / "review-skill"
+    memories_dir.mkdir(parents=True, exist_ok=True)
+    skill_dir.mkdir(parents=True, exist_ok=True)
+
+    memory_file = memories_dir / "MEMORY.md"
+    user_file = memories_dir / "USER.md"
+    soul_file = hermes_home / "SOUL.md"
+    skill_file = skill_dir / "SKILL.md"
+    kanban_file = tmp_path / "kanban" / "hermes-operator.json"
+
+    original_memory = "# Memory\n\nExisting durable memory.\n"
+    original_user = "# User\n\nExisting user memory.\n"
+    original_soul = "# Soul\n\nExisting soul memory.\n"
+    original_skill = "# Review Skill\n\nExisting skill guidance.\n"
+    original_kanban = '{"board":"hermes-operator","items":[]}'
+
+    memory_file.write_text(original_memory, encoding="utf-8")
+    user_file.write_text(original_user, encoding="utf-8")
+    soul_file.write_text(original_soul, encoding="utf-8")
+    skill_file.write_text(original_skill, encoding="utf-8")
+    kanban_file.parent.mkdir(parents=True, exist_ok=True)
+    kanban_file.write_text(original_kanban, encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_BASE_HOME", str(hermes_home))
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: hermes_home, raising=False)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default", raising=False)
+
+    review_module = sys.modules.get("api.operator_memory_skill_review")
+    if review_module is not None:
+        monkeypatch.setattr(review_module, "get_active_hermes_home", lambda: hermes_home, raising=False)
+        monkeypatch.setattr(review_module, "get_active_profile_name", lambda: "default", raising=False)
+        profile_module = getattr(review_module, "profiles", None)
+        if profile_module is not None:
+            monkeypatch.setattr(profile_module, "get_active_hermes_home", lambda: hermes_home, raising=False)
+            monkeypatch.setattr(profile_module, "get_active_profile_name", lambda: "default", raising=False)
+
+    return {
+        "home": hermes_home,
+        "memory_file": memory_file,
+        "user_file": user_file,
+        "soul_file": soul_file,
+        "skill_file": skill_file,
+        "kanban_file": kanban_file,
+        "original_memory": original_memory,
+        "original_user": original_user,
+        "original_soul": original_soul,
+        "original_skill": original_skill,
+        "original_kanban": original_kanban,
+    }
+
+
+def _assert_profile_files_unchanged(files):
+    assert files["memory_file"].read_text(encoding="utf-8") == files["original_memory"]
+    assert files["user_file"].read_text(encoding="utf-8") == files["original_user"]
+    assert files["soul_file"].read_text(encoding="utf-8") == files["original_soul"]
+    assert files["skill_file"].read_text(encoding="utf-8") == files["original_skill"]
+    assert files["kanban_file"].read_text(encoding="utf-8") == files["original_kanban"]
+
+
+def _assert_valid_stored_propose_item(
+    item,
+    *,
+    target_path: Path,
+    previous_content: str,
+    expected_target,
+    expected_proposed_change,
+    expected_source_evidence,
+    expected_classification,
+    expected_stale_risk,
+):
+    assert REQUIRED_REVIEW_FIELDS.issubset(item.keys())
+    assert item.get("id", "").startswith("msr_")
+    assert isinstance(item.get("created_at"), (int, float))
+    assert item["created_at"] > 0
+    assert isinstance(item.get("updated_at"), (int, float))
+    assert item["updated_at"] >= item["created_at"]
+    assert item.get("profile") == "default"
+    assert item["would_execute"] is False
+    for key, value in expected_target.items():
+        assert item["target"].get(key) == value
+    assert "file_path" in item["target"]
+    assert item["target"]["file_path"]
+    assert item["target"].get("path")
+    assert Path(item["target"]["path"]).is_absolute()
+    assert Path(item["target"]["path"]).resolve() == target_path.resolve()
+    assert item.get("previous_content") == previous_content
+    assert item["proposed_change"] == expected_proposed_change
+    assert item["source_evidence"] == expected_source_evidence
+    assert item["classification"] == expected_classification
+    assert item["stale_risk"] == expected_stale_risk
+    assert item["decision"]["state"] == "pending"
+    assert item["decision"].get("decided_at") is None
+    assert item["decision"].get("decided_by") is None
+    assert item["decision"].get("reason") == ""
+    previous_hash = item["rollback"].get("previous_hash", "")
+    assert previous_hash.startswith("sha256:")
+    assert len(previous_hash) == len("sha256:") + 64
+    previous_excerpt = item["rollback"].get("previous_excerpt", "")
+    assert previous_excerpt
+    assert "Existing" in previous_excerpt
+
+
+def _poison_forbidden_memory_skill_review_side_effects(monkeypatch):
+    calls = []
+
+    def forbidden(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("memory/skill review routes must not shell, thread, cron, goal, mutate Kanban, or write targets directly")
+
+    fake_kanban_bridge = types.ModuleType("api.kanban_bridge")
+    for name in ("handle_kanban_post", "handle_kanban_patch", "handle_kanban_delete", "dispatch", "create_task", "claim", "complete"):
+        setattr(fake_kanban_bridge, name, forbidden)
+    fake_cron_pkg = types.ModuleType("cron")
+    fake_cron_jobs = types.ModuleType("cron.jobs")
+    for name in ("create", "update", "delete", "run", "schedule"):
+        setattr(fake_cron_jobs, name, forbidden)
+    setattr(fake_cron_pkg, "jobs", fake_cron_jobs)
+    fake_goals = types.ModuleType("api.goals")
+    for name in ("set_goal", "create_goal", "update_goal", "delete_goal", "start_goal_loop"):
+        setattr(fake_goals, name, forbidden)
+
+    monkeypatch.setitem(sys.modules, "api.kanban_bridge", fake_kanban_bridge)
+    monkeypatch.setitem(sys.modules, "cron", fake_cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", fake_cron_jobs)
+    monkeypatch.setitem(sys.modules, "api.goals", fake_goals)
+
+    import api as api_pkg
+    import api.routes as routes
+
+    monkeypatch.setattr(api_pkg, "kanban_bridge", fake_kanban_bridge, raising=False)
+    monkeypatch.setattr(api_pkg, "goals", fake_goals, raising=False)
+    for name in ("_handle_memory_write", "_handle_skill_save", "_handle_skill_delete", "_handle_skill_toggle"):
+        monkeypatch.setattr(routes, name, forbidden, raising=False)
+
+    monkeypatch.setattr(subprocess, "run", forbidden)
+    monkeypatch.setattr(subprocess, "Popen", forbidden)
+    monkeypatch.setattr(threading, "Thread", forbidden)
+    monkeypatch.setattr(threading, "Timer", forbidden)
+    return calls
+
+
+def _route_review_item(item_id, target_path, **overrides):
+    item = _valid_review_item(
+        id=item_id,
+        target={
+            "kind": "memory",
+            "section": "memory",
+            "file_path": "MEMORY.md",
+            "path": str(target_path),
+        },
+        proposed_change={
+            "operation": "append",
+            "summary": "Append durable memory through review only.",
+            "diff": "--- previous\n+++ proposed\n@@\n+Approved text must still not be applied.\n",
+            "proposed_content": "Approved text must still not be applied.",
+        },
+        previous_content="Existing durable memory.",
+    )
+    item.update(overrides)
+    return item
+
+
+def test_memory_skill_review_route_get_returns_json(monkeypatch):
+    import api.routes as routes
+
+    expected = {
+        "version": 1,
+        "mode": "local-memory-skill-review-queue",
+        "status": "unknown",
+        "would_execute": False,
+        "items": [],
+        "sources": [],
+        "issues": [],
+    }
+    captured, fake_j = _capture_json_response()
+
+    with patch("api.operator_memory_skill_review.build_operator_memory_skill_review_payload", return_value=expected) as build_payload, patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        handled = routes.handle_get(
+            types.SimpleNamespace(wfile=io.BytesIO()),
+            urlparse("/api/operator/memory-skill-review?session_id=abc123&ui_board=hermes-operator"),
+        )
+
+    assert handled is True
+    assert captured["status"] == 200
+    assert captured["payload"] == expected
+    assert captured["payload"]["mode"] == "local-memory-skill-review-queue"
+    assert captured["payload"]["would_execute"] is False
+    build_payload.assert_called_once_with(session_id="abc123", ui_board_hint="hermes-operator")
+
+
+def test_memory_skill_review_propose_route_accepts_loopback_localhost_only(monkeypatch):
+    import api.routes as routes
+
+    captured, fake_j = _capture_json_response()
+
+    def fake_propose(body, *, now=None, client_context=None):
+        captured["body"] = body
+        captured["client_context"] = client_context
+        return {"ok": True, "id": "msr_route", "would_execute": False}
+
+    handler = _PostHandler(
+        _valid_propose_body(),
+        headers={"Host": "localhost:8787", "Origin": "http://localhost:8787", "Referer": "http://localhost:8787/operator"},
+    )
+    with patch("api.operator_memory_skill_review.propose_operator_memory_skill_review", side_effect=fake_propose) as propose, patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/propose"))
+
+    assert handled is True
+    assert propose.call_count == 1
+    assert captured["status"] == 201
+    assert captured["payload"]["ok"] is True
+    assert captured["payload"]["would_execute"] is False
+    assert captured["body"]["target"] == {"kind": "memory", "section": "memory"}
+    assert captured["client_context"]["client_ip"] == "127.0.0.1"
+
+
+def test_memory_skill_review_propose_route_rejects_public_origin_even_when_allowed(monkeypatch):
+    import api.routes as routes
+
+    captured, fake_j = _capture_json_response()
+
+    def forbidden_propose(*args, **kwargs):
+        raise AssertionError("public memory/skill review writes must not call propose")
+
+    monkeypatch.setenv("HERMES_WEBUI_ALLOWED_ORIGINS", "https://public.example")
+    handler = _PostHandler(
+        _valid_propose_body(),
+        client_ip="203.0.113.10",
+        headers={"Origin": "https://public.example", "Referer": "https://public.example/operator", "Host": "public.example"},
+    )
+    with patch("api.operator_memory_skill_review.propose_operator_memory_skill_review", side_effect=forbidden_propose) as propose, patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/propose"))
+
+    assert handled is True
+    assert propose.call_count == 0
+    assert captured["status"] == 403
+    assert captured["payload"]["would_execute"] is False
+
+
+def test_memory_skill_review_propose_route_rejects_public_client_even_with_loopback_headers(monkeypatch):
+    import api.routes as routes
+
+    captured, fake_j = _capture_json_response()
+
+    def forbidden_propose(*args, **kwargs):
+        raise AssertionError("public memory/skill review clients must not call propose even with loopback headers")
+
+    handler = _PostHandler(
+        _valid_propose_body(),
+        client_ip="203.0.113.10",
+        headers={"Host": "localhost:8787", "Origin": "http://localhost:8787", "Referer": "http://localhost:8787/operator"},
+    )
+    with patch("api.operator_memory_skill_review.propose_operator_memory_skill_review", side_effect=forbidden_propose) as propose, patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/propose"))
+
+    assert handled is True
+    assert propose.call_count == 0
+    assert captured["status"] == 403
+    assert captured["payload"]["would_execute"] is False
+
+
+def test_memory_skill_review_propose_route_rejects_public_host_origin_or_referer_from_loopback(monkeypatch):
+    import api.routes as routes
+
+    captured, fake_j = _capture_json_response()
+
+    def forbidden_propose(*args, **kwargs):
+        raise AssertionError("loopback memory/skill review writes with public headers must not call propose")
+
+    monkeypatch.setenv("HERMES_WEBUI_ALLOWED_ORIGINS", "https://public.example")
+    public_header_cases = [
+        (
+            "host_userinfo_loopback_prefix",
+            {"Host": "127.0.0.1:8787@public.example", "Origin": "http://127.0.0.1:8787", "Referer": "http://127.0.0.1:8787/operator"},
+        ),
+        (
+            "origin_userinfo_loopback_prefix",
+            {"Host": "127.0.0.1:8787", "Origin": "http://127.0.0.1:8787@public.example", "Referer": "http://127.0.0.1:8787/operator"},
+        ),
+        (
+            "host",
+            {"Host": "public.example", "Origin": "http://127.0.0.1:8787", "Referer": "http://127.0.0.1:8787/operator"},
+        ),
+        (
+            "origin",
+            {"Host": "127.0.0.1:8787", "Origin": "https://public.example", "Referer": "http://127.0.0.1:8787/operator"},
+        ),
+        (
+            "referer",
+            {"Host": "127.0.0.1:8787", "Origin": "http://127.0.0.1:8787", "Referer": "https://public.example/operator"},
+        ),
+    ]
+    with patch("api.operator_memory_skill_review.propose_operator_memory_skill_review", side_effect=forbidden_propose) as propose, patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        for label, headers in public_header_cases:
+            captured.clear()
+            handler = _PostHandler(_valid_propose_body(), client_ip="127.0.0.1", headers=headers)
+            handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/propose"))
+            assert handled is True, label
+            assert captured["status"] == 403, label
+            assert captured["payload"]["would_execute"] is False, label
+
+    assert propose.call_count == 0
+
+
+def test_memory_skill_review_propose_route_rejects_public_x_forwarded_for_proxy(monkeypatch):
+    import api.routes as routes
+
+    captured, fake_j = _capture_json_response()
+
+    def forbidden_propose(*args, **kwargs):
+        raise AssertionError("proxied public memory/skill review writes must not call propose")
+
+    public_proxy_headers = [
+        {"X-Forwarded-For": "203.0.113.11"},
+        {"X-Real-IP": "203.0.113.12"},
+        {"X-Forwarded-Host": "public.example"},
+        {"X-Real-Host": "public.example"},
+    ]
+    with patch("api.operator_memory_skill_review.propose_operator_memory_skill_review", side_effect=forbidden_propose) as propose, patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        for proxy_headers in public_proxy_headers:
+            captured.clear()
+            headers = {"Host": "127.0.0.1:8787", "Origin": "http://127.0.0.1:8787"}
+            headers.update(proxy_headers)
+            handler = _PostHandler(_valid_propose_body(), client_ip="127.0.0.1", headers=headers)
+            handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/propose"))
+            assert handled is True
+            assert captured["status"] == 403
+            assert captured["payload"]["would_execute"] is False
+
+    assert propose.call_count == 0
+
+
+def test_memory_skill_review_propose_writes_only_review_queue_not_memory_skill_or_kanban(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    review = importlib.import_module("api.operator_memory_skill_review")
+    state_dir = _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+    calls = _poison_forbidden_memory_skill_review_side_effects(monkeypatch)
+    captured, fake_j = _capture_json_response()
+    proposed_text = "Proposed durable operator memory from the route."
+    body = _valid_propose_body(
+        proposed_change={
+            "operation": "append",
+            "summary": "Append durable memory through review only.",
+            "diff": f"--- previous\n+++ proposed\n@@\n+{proposed_text}\n",
+            "proposed_content": proposed_text,
+        }
+    )
+    handler = _PostHandler(
+        body,
+        headers={"Host": "127.0.0.1:8787", "Origin": "http://127.0.0.1:8787"},
+    )
+
+    with patch("api.routes.j", side_effect=fake_j):
+        handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/propose"))
+
+    assert handled is True
+    assert captured["status"] == 201
+    assert captured["payload"]["ok"] is True
+    assert captured["payload"]["would_execute"] is False
+    store_path = state_dir / "operator_memory_skill_review.json"
+    assert review.review_store_path() == store_path
+    assert store_path.exists()
+    stored = json.loads(store_path.read_text(encoding="utf-8"))
+    assert stored["version"] == 1
+    assert len(stored["items"]) == 1
+    item = stored["items"][0]
+    _assert_valid_stored_propose_item(
+        item,
+        target_path=files["memory_file"],
+        previous_content=files["original_memory"],
+        expected_target=body["target"],
+        expected_proposed_change=body["proposed_change"],
+        expected_source_evidence=body["source_evidence"],
+        expected_classification=body["classification"],
+        expected_stale_risk=body["stale_risk"],
+    )
+    assert proposed_text in json.dumps(item)
+    _assert_profile_files_unchanged(files)
+    assert not files["memory_file"].read_text(encoding="utf-8").endswith(proposed_text)
+    assert calls == []
+
+
+def test_memory_skill_review_propose_valid_skill_target_writes_only_queue_not_skill_file(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    review = importlib.import_module("api.operator_memory_skill_review")
+    state_dir = _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+    calls = _poison_forbidden_memory_skill_review_side_effects(monkeypatch)
+    captured, fake_j = _capture_json_response()
+    proposed_skill = "# Review Skill\n\nExisting skill guidance.\n\nProposed review-only skill guidance.\n"
+    body = _valid_propose_body(
+        target={"kind": "skill", "name": "review-skill"},
+        proposed_change={
+            "operation": "edit",
+            "summary": "Revise review-skill guidance through the local queue only.",
+            "diff": "--- previous\n+++ proposed\n@@\n Existing skill guidance.\n+Proposed review-only skill guidance.\n",
+            "proposed_content": proposed_skill,
+        },
+    )
+    handler = _PostHandler(
+        body,
+        headers={"Host": "127.0.0.1:8787", "Origin": "http://127.0.0.1:8787"},
+    )
+
+    with patch("api.routes.j", side_effect=fake_j):
+        handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/propose"))
+
+    assert handled is True
+    assert captured["status"] == 201
+    assert captured["payload"]["ok"] is True
+    assert captured["payload"]["would_execute"] is False
+    store_path = state_dir / "operator_memory_skill_review.json"
+    assert review.review_store_path() == store_path
+    assert store_path.exists()
+    stored = json.loads(store_path.read_text(encoding="utf-8"))
+    assert stored["version"] == 1
+    assert len(stored["items"]) == 1
+    item = stored["items"][0]
+    _assert_valid_stored_propose_item(
+        item,
+        target_path=files["skill_file"],
+        previous_content=files["original_skill"],
+        expected_target=body["target"],
+        expected_proposed_change=body["proposed_change"],
+        expected_source_evidence=body["source_evidence"],
+        expected_classification=body["classification"],
+        expected_stale_risk=body["stale_risk"],
+    )
+    assert item["proposed_change"]["proposed_content"] == proposed_skill
+    _assert_profile_files_unchanged(files)
+    assert files["skill_file"].read_text(encoding="utf-8") == files["original_skill"]
+    assert calls == []
+
+
+def test_memory_skill_review_propose_rejects_unresolved_or_path_traversal_targets_without_writing(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    review = importlib.import_module("api.operator_memory_skill_review")
+    state_dir = _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+    calls = _poison_forbidden_memory_skill_review_side_effects(monkeypatch)
+    captured, fake_j = _capture_json_response()
+    invalid_bodies = [
+        _valid_propose_body(target={"kind": "memory", "section": "unknown"}),
+        _valid_propose_body(target={"kind": "skill", "name": "../escape"}),
+        _valid_propose_body(target={"kind": "skill", "category": "../../escape", "name": "review-skill"}),
+        _valid_propose_body(target={"kind": "skill", "name": "missing-skill"}),
+    ]
+
+    with patch("api.routes.j", side_effect=fake_j):
+        for body in invalid_bodies:
+            captured.clear()
+            handler = _PostHandler(body, headers={"Host": "127.0.0.1:8787", "Origin": "http://127.0.0.1:8787"})
+            handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/propose"))
+            assert handled is True
+            assert captured["status"] == 400
+            assert captured["payload"].get("ok") is False
+            assert captured["payload"]["would_execute"] is False
+            assert not review.review_store_path().exists()
+            assert not (state_dir / "operator_memory_skill_review.json").exists()
+            _assert_profile_files_unchanged(files)
+
+    assert calls == []
+
+
+def test_memory_skill_review_decision_route_rejects_public_client_or_headers_without_calling_handler(monkeypatch):
+    import api.routes as routes
+
+    captured, fake_j = _capture_json_response()
+
+    def forbidden_decision(*args, **kwargs):
+        raise AssertionError("public memory/skill review decision writes must not call decision handler")
+
+    monkeypatch.setenv("HERMES_WEBUI_ALLOWED_ORIGINS", "https://public.example")
+    public_contexts = [
+        (
+            "client_ip",
+            "203.0.113.10",
+            {"Host": "127.0.0.1:8787", "Origin": "http://127.0.0.1:8787", "Referer": "http://127.0.0.1:8787/operator"},
+        ),
+        (
+            "host",
+            "127.0.0.1",
+            {"Host": "public.example", "Origin": "http://127.0.0.1:8787", "Referer": "http://127.0.0.1:8787/operator"},
+        ),
+        (
+            "origin",
+            "127.0.0.1",
+            {"Host": "127.0.0.1:8787", "Origin": "https://public.example", "Referer": "http://127.0.0.1:8787/operator"},
+        ),
+        (
+            "referer",
+            "127.0.0.1",
+            {"Host": "127.0.0.1:8787", "Origin": "http://127.0.0.1:8787", "Referer": "https://public.example/operator"},
+        ),
+    ]
+    with patch("api.operator_memory_skill_review.decide_operator_memory_skill_review", side_effect=forbidden_decision) as decide, patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        for label, client_ip, headers in public_contexts:
+            captured.clear()
+            handler = _PostHandler(
+                {"id": "msr_public_decision", "decision": "denied", "reason": "No public writes."},
+                client_ip=client_ip,
+                headers=headers,
+            )
+            handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/decision"))
+            assert handled is True, label
+            assert captured["status"] == 403, label
+            assert captured["payload"]["would_execute"] is False, label
+
+    assert decide.call_count == 0
+
+
+def test_memory_skill_review_decision_route_rejects_public_reverse_proxy_headers_without_calling_handler(monkeypatch):
+    import api.routes as routes
+
+    captured, fake_j = _capture_json_response()
+
+    def forbidden_decision(*args, **kwargs):
+        raise AssertionError("proxied public memory/skill review decisions must not call decision handler")
+
+    public_proxy_header_cases = [
+        ("x_forwarded_for", {"X-Forwarded-For": "203.0.113.11"}),
+        ("x_real_ip", {"X-Real-IP": "203.0.113.12"}),
+        ("x_forwarded_host", {"X-Forwarded-Host": "public.example"}),
+        ("x_real_host", {"X-Real-Host": "public.example"}),
+    ]
+    with patch("api.operator_memory_skill_review.decide_operator_memory_skill_review", side_effect=forbidden_decision) as decide, patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        for label, proxy_headers in public_proxy_header_cases:
+            captured.clear()
+            headers = {
+                "Host": "127.0.0.1:8787",
+                "Origin": "http://127.0.0.1:8787",
+                "Referer": "http://127.0.0.1:8787/operator",
+            }
+            headers.update(proxy_headers)
+            handler = _PostHandler(
+                {"id": "msr_proxy_decision", "decision": "denied", "reason": "No proxied public writes."},
+                client_ip="127.0.0.1",
+                headers=headers,
+            )
+            handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/decision"))
+            assert handled is True, label
+            assert captured["status"] == 403, label
+            assert captured["payload"]["would_execute"] is False, label
+
+    assert decide.call_count == 0
+
+
+def test_memory_skill_review_decision_updates_only_local_decision_state(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+    calls = _poison_forbidden_memory_skill_review_side_effects(monkeypatch)
+    item = _route_review_item("msr_decision", files["memory_file"])
+    _write_store(review.review_store_path(), [item])
+    before = json.loads(json.dumps(item, sort_keys=True))
+    captured, fake_j = _capture_json_response()
+    handler = _PostHandler(
+        {"id": "msr_decision", "decision": "approved", "reason": "Looks durable and source-backed."},
+        headers={"Host": "localhost:8787", "Origin": "http://localhost:8787"},
+    )
+
+    with patch("api.routes.j", side_effect=fake_j):
+        handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/decision"))
+
+    assert handled is True
+    assert captured["status"] == 200
+    assert captured["payload"]["ok"] is True
+    assert captured["payload"]["would_execute"] is False
+    stored = json.loads(review.review_store_path().read_text(encoding="utf-8"))
+    assert len(stored["items"]) == 1
+    after = stored["items"][0]
+    assert after["decision"]["state"] == "approved"
+    assert after["decision"]["reason"] == "Looks durable and source-backed."
+    assert after["decision"].get("decided_at")
+    assert after["decision"].get("decided_by")
+    assert {k: v for k, v in after.items() if k != "decision"} == {k: v for k, v in before.items() if k != "decision"}
+    _assert_profile_files_unchanged(files)
+    assert calls == []
+
+
+def test_memory_skill_review_decision_response_redacts_sensitive_reason(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+    item = _route_review_item("msr_secret_decision", files["memory_file"])
+    _write_store(review.review_store_path(), [item])
+    captured, fake_j = _capture_json_response()
+    secret_reason = "denied because password=hunter2 and token=sk-secret should not echo"
+    handler = _PostHandler(
+        {"id": "msr_secret_decision", "decision": "denied", "reason": secret_reason},
+        headers={"Host": "localhost:8787", "Origin": "http://localhost:8787"},
+    )
+
+    with patch("api.routes.j", side_effect=fake_j):
+        handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/decision"))
+
+    assert handled is True
+    assert captured["status"] == 200
+    assert captured["payload"]["ok"] is True
+    assert captured["payload"]["would_execute"] is False
+    assert captured["payload"]["decision"]["state"] == "denied"
+    assert captured["payload"]["decision"]["reason"] == "[redacted sensitive text]"
+    assert secret_reason not in json.dumps(captured["payload"])
+
+
+def test_memory_skill_review_denied_decision_updates_only_local_decision_state(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+    calls = _poison_forbidden_memory_skill_review_side_effects(monkeypatch)
+    item = _route_review_item("msr_denied", files["memory_file"])
+    _write_store(review.review_store_path(), [item])
+    before = json.loads(json.dumps(item, sort_keys=True))
+    captured, fake_j = _capture_json_response()
+    handler = _PostHandler(
+        {"id": "msr_denied", "decision": "denied", "reason": "Not durable enough for memory."},
+        headers={"Host": "localhost:8787", "Origin": "http://localhost:8787"},
+    )
+
+    with patch("api.routes.j", side_effect=fake_j):
+        handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/decision"))
+
+    assert handled is True
+    assert captured["status"] == 200
+    assert captured["payload"]["ok"] is True
+    assert captured["payload"]["would_execute"] is False
+    stored = json.loads(review.review_store_path().read_text(encoding="utf-8"))
+    assert len(stored["items"]) == 1
+    after = stored["items"][0]
+    assert after["decision"]["state"] == "denied"
+    assert after["decision"]["reason"] == "Not durable enough for memory."
+    assert after["decision"].get("decided_at")
+    assert after["decision"].get("decided_by")
+    assert {k: v for k, v in after.items() if k != "decision"} == {k: v for k, v in before.items() if k != "decision"}
+    _assert_profile_files_unchanged(files)
+    assert calls == []
+
+
+def test_memory_skill_review_store_mutations_hold_lock_across_read_modify_write(monkeypatch, tmp_path):
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+    _write_store(review.review_store_path(), [])
+
+    class ProbeLock:
+        def __init__(self):
+            self.depth = 0
+
+        def __enter__(self):
+            self.depth += 1
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.depth -= 1
+
+        @property
+        def locked(self):
+            return self.depth > 0
+
+    probe_lock = ProbeLock()
+    original_read_store = review._read_store
+    read_lock_states = []
+
+    def guarded_read_store(path):
+        read_lock_states.append(probe_lock.locked)
+        return original_read_store(path)
+
+    monkeypatch.setattr(review, "_STORE_LOCK", probe_lock, raising=False)
+    monkeypatch.setattr(review, "_read_store", guarded_read_store, raising=False)
+
+    propose_result = review.propose_operator_memory_skill_review(_valid_propose_body(), now=1779866500.0)
+    assert propose_result["ok"] is True
+    assert read_lock_states and all(read_lock_states)
+
+    read_lock_states.clear()
+    decision_result = review.decide_operator_memory_skill_review(
+        {"id": propose_result["id"], "decision": "denied", "reason": "Do not keep this."},
+        now=1779866501.0,
+    )
+    assert decision_result["ok"] is True
+    assert read_lock_states and all(read_lock_states)
+    _assert_profile_files_unchanged(files)
+
+
+def test_memory_skill_review_approve_rejects_invalid_or_stale_items_without_apply(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    review = importlib.import_module("api.operator_memory_skill_review")
+    _patch_state_dir(monkeypatch, tmp_path)
+    files = _patch_active_profile_files(monkeypatch, tmp_path)
+    calls = _poison_forbidden_memory_skill_review_side_effects(monkeypatch)
+    invalid = _route_review_item("msr_invalid", files["memory_file"], source_evidence=[{}])
+    stale = _route_review_item(
+        "msr_stale",
+        files["memory_file"],
+        stale_risk={
+            "state": "current",
+            "expires_at": "1970-01-01T00:00:01Z",
+            "reason": "This proposal is stale and needs fresh proof before approval.",
+        },
+    )
+    _write_store(review.review_store_path(), [invalid, stale])
+    captured, fake_j = _capture_json_response()
+
+    with patch("api.routes.j", side_effect=fake_j):
+        for item_id in ("msr_invalid", "msr_stale"):
+            captured.clear()
+            handler = _PostHandler(
+                {"id": item_id, "decision": "approved", "reason": "Approve despite invalid state should fail."},
+                headers={"Host": "127.0.0.1:8787", "Origin": "http://127.0.0.1:8787"},
+            )
+            handled = routes.handle_post(handler, urlparse("/api/operator/memory-skill-review/decision"))
+            assert handled is True
+            assert captured["status"] == 400
+            assert captured["payload"].get("ok") is False
+            assert captured["payload"]["would_execute"] is False
+            _assert_profile_files_unchanged(files)
+
+        apply_handler = _PostHandler({"id": "msr_stale"}, headers={"Host": "127.0.0.1:8787", "Origin": "http://127.0.0.1:8787"})
+        assert routes.handle_post(apply_handler, urlparse("/api/operator/memory-skill-review/apply")) is False
+
+    stored = json.loads(review.review_store_path().read_text(encoding="utf-8"))
+    decisions = {item["id"]: item["decision"]["state"] for item in stored["items"]}
+    assert decisions["msr_invalid"] != "approved"
+    assert decisions["msr_stale"] != "approved"
+    _assert_profile_files_unchanged(files)
+    assert calls == []

--- a/tests/test_operator_memory_skill_review_ui_static.py
+++ b/tests/test_operator_memory_skill_review_ui_static.py
@@ -1,0 +1,212 @@
+import re
+from pathlib import Path
+
+
+def _read(path):
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _opening_tag_with_id(markup, element_id):
+    match = re.search(rf"<[a-zA-Z][^>]*\bid=[\"']{re.escape(element_id)}[\"'][^>]*>", markup)
+    assert match, f"opening tag for {element_id} not found"
+    return match.group(0)
+
+
+def test_memory_skill_review_markup_exists_after_commitment_chip_and_popover():
+    html = _read("static/index.html")
+
+    assert 'id="operatorMemorySkillReviewChip"' in html
+    assert 'id="operatorMemorySkillReviewPopover"' in html
+    assert 'id="operatorMemorySkillReviewList"' in html
+    assert 'id="operatorMemorySkillReviewRefresh"' in html
+    chip_tag = _opening_tag_with_id(html, "operatorMemorySkillReviewChip")
+    refresh_tag = _opening_tag_with_id(html, "operatorMemorySkillReviewRefresh")
+    assert 'onclick="toggleOperatorMemorySkillReview' in chip_tag
+    assert 'onclick="refreshOperatorMemorySkillReview' in refresh_tag
+    assert html.index('id="operatorCommitmentChip"') < html.index('id="operatorMemorySkillReviewChip"') < html.index('id="composerMobileConfigBtn"')
+    assert html.index('id="operatorCommitmentPopover"') < html.index('id="operatorMemorySkillReviewPopover"')
+
+
+def test_memory_skill_review_script_loaded_after_commitments_before_boot():
+    html = _read("static/index.html")
+
+    assert html.index("static/operator_commitments.js") < html.index("static/operator_memory_skill_review.js") < html.index("static/boot.js")
+
+
+def test_memory_skill_review_shows_local_only_no_apply_safety_copy():
+    html = _read("static/index.html").lower()
+    js = _read("static/operator_memory_skill_review.js").lower()
+    combined = html + "\n" + js
+
+    assert "local review only" in combined
+    assert "no apply" in combined
+    assert "would_execute:false" in combined
+
+
+def test_memory_skill_review_js_uses_review_queue_endpoints_only():
+    js = _read("static/operator_memory_skill_review.js")
+    compact = "".join(js.split())
+    allowed_endpoints = {
+        "/api/operator/memory-skill-review",
+        "/api/operator/memory-skill-review/decision",
+    }
+
+    for endpoint in allowed_endpoints:
+        assert f"'{endpoint}'" in js or f'"{endpoint}"' in js
+    quoted_endpoints = set(re.findall(r"[\"'`](/api/[^\"'`\s]+)[\"'`]", js))
+    assert quoted_endpoints
+    assert quoted_endpoints <= allowed_endpoints
+    api_substrings = set(re.findall(r"/api/[^\s\"'`),;]+", js))
+    assert api_substrings
+    assert api_substrings <= allowed_endpoints
+    assert "api(" in compact
+    for token in ["fetch(", "XMLHttpRequest", "newRequest", "sendBeacon"]:
+        assert token not in compact
+    assert "http://" not in js
+    assert "https://" not in js
+    assert "method:'POST'" in compact or 'method:"POST"' in compact
+
+
+def test_memory_skill_review_js_no_direct_memory_skill_mutation_apply_kanban_chat_cron_goal_or_background_tokens():
+    js = _read("static/operator_memory_skill_review.js")
+    compact = "".join(js.split())
+    forbidden = [
+        "/api/memory/write",
+        "/api/skills/save",
+        "/api/skills/delete",
+        "/api/skills/toggle",
+        "/apply",
+        "would_execute:true",
+        "/api/chat",
+        "/api/chat/start",
+        "/api/kanban/",
+        "/api/kanban/dispatch",
+        "/api/cron",
+        "/api/crons",
+        "/api/goal",
+        "/api/background",
+        "/background",
+        "background",
+        "runKanbanDispatcher",
+        "nudgeKanbanDispatcher",
+        "createKanbanTask",
+        "updateKanbanTask",
+        "addKanbanComment",
+        "send(",
+        "sendMessage",
+        "startChat",
+        "submitChat",
+        "window.send",
+        "submitMemorySave",
+        "saveSkillForm",
+        "deleteCurrentSkill",
+        "toggleSkill",
+        "setInterval",
+        "setTimeout",
+        "EventSource",
+        "WebSocket",
+        "Worker(",
+        "navigator.sendBeacon",
+        ".innerHTML",
+        ".outerHTML",
+        "insertAdjacentHTML",
+        "renderMd(",
+        "eval(",
+        "Function(",
+    ]
+    for token in forbidden:
+        assert token.replace(" ", "") not in compact
+
+
+def test_memory_skill_review_values_use_text_content_not_inner_html_or_markdown():
+    js = _read("static/operator_memory_skill_review.js")
+
+    assert ".textContent" in js
+    assert "document.createElement" in js
+    for token in [
+        ".innerHTML",
+        ".outerHTML",
+        "insertAdjacentHTML",
+        "renderMd(",
+        "renderMarkdown(",
+        "marked(",
+        "markdownToHtml",
+    ]:
+        assert token not in js
+
+
+def test_memory_skill_review_manual_refresh_no_polling_timers_or_eventsource():
+    js = _read("static/operator_memory_skill_review.js")
+
+    assert "function toggleOperatorMemorySkillReview" in js
+    assert "function refreshOperatorMemorySkillReview" in js
+    assert "function renderOperatorMemorySkillReview" in js
+    assert "window.toggleOperatorMemorySkillReview" in js
+    assert "window.refreshOperatorMemorySkillReview" in js
+    assert not re.search(r"(?m)^\s*refreshOperatorMemorySkillReview\s*\(\s*\)\s*;?\s*$", js)
+    assert not re.search(r"(?m)^\s*window\.refreshOperatorMemorySkillReview\s*\(\s*\)\s*;?\s*$", js)
+    for token in ["setInterval", "setTimeout", "EventSource", "WebSocket", "Worker(", "navigator.sendBeacon"]:
+        assert token not in js
+    if "DOMContentLoaded" in js:
+        after_dom_ready = js.split("DOMContentLoaded", 1)[1]
+        assert "refreshOperatorMemorySkillReview" not in after_dom_ready
+        assert "toggleOperatorMemorySkillReview" not in after_dom_ready
+
+
+def test_memory_skill_review_renders_required_review_fields_and_invalid_states():
+    js = _read("static/operator_memory_skill_review.js")
+
+    for field in [
+        "proposed_change",
+        "source_evidence",
+        "classification",
+        "durability",
+        "stale_risk",
+        "expires_at",
+        "decision",
+        "rollback",
+        "previous_content",
+        "would_execute",
+        "invalid",
+        "stale",
+        "unknown",
+        "issues",
+    ]:
+        assert field in js
+    for class_name in [
+        "operator-memory-skill-review-card",
+        "operator-memory-skill-review-diff",
+        "operator-memory-skill-review-evidence",
+        "operator-memory-skill-review-decision",
+        "operator-memory-skill-review-invalid",
+        "operator-memory-skill-review-no-exec",
+    ]:
+        assert class_name in js
+
+
+def test_memory_skill_review_css_has_card_diff_evidence_decision_invalid_and_mobile_rules():
+    css = _read("static/style.css")
+
+    for selector in [
+        ".operator-memory-skill-review-popover",
+        ".operator-memory-skill-review-list",
+        ".operator-memory-skill-review-card",
+        ".operator-memory-skill-review-diff",
+        ".operator-memory-skill-review-evidence",
+        ".operator-memory-skill-review-decision",
+        ".operator-memory-skill-review-invalid",
+        ".operator-memory-skill-review-no-exec",
+        ".operator-memory-skill-review-action",
+    ]:
+        assert selector in css
+
+    mobile_starts = [
+        match.start()
+        for match in re.finditer(r"@media\s*\(\s*max-width\s*:\s*640px\s*\)", css)
+    ]
+    assert mobile_starts
+    mobile_sections = [
+        css[start : mobile_starts[index + 1] if index + 1 < len(mobile_starts) else len(css)]
+        for index, start in enumerate(mobile_starts)
+    ]
+    assert any("operator-memory-skill-review" in section for section in mobile_sections)

--- a/tests/test_operator_proposals.py
+++ b/tests/test_operator_proposals.py
@@ -1,0 +1,293 @@
+import importlib
+import io
+import json
+import subprocess
+import sys
+import types
+from pathlib import Path
+from urllib.parse import urlparse
+from unittest.mock import patch
+
+
+DEFAULT_ACTIONS = [
+    {
+        "id": "reverse_prompt_v0",
+        "rank": 1,
+        "type": "quick_win",
+        "title": "Manual Reverse Prompt v0",
+        "summary": "Read known source files and propose useful Hermes workflows without executing.",
+        "owner": "future Hermes session",
+        "side_effect_level": "read-only until approved",
+        "status": "proposal",
+    },
+    {
+        "id": "webui_proof_freshness_labels",
+        "rank": 2,
+        "type": "quick_win",
+        "title": "Proof/freshness labels in WebUI",
+        "summary": "Add source/timestamp/stale/receipt chips to important WebUI cards.",
+        "owner": "future Hermes WebUI task",
+        "side_effect_level": "code change",
+        "status": "proposal",
+    },
+    {
+        "id": "goal_cron_safety_template",
+        "rank": 3,
+        "type": "quick_win",
+        "title": "Goal/cron safety template",
+        "summary": "Long-running goals/crons need explicit scope, gates, receipts, and stop conditions.",
+        "owner": "future skill/WebUI task",
+        "side_effect_level": "docs/skill change",
+        "status": "proposal",
+    },
+    {
+        "id": "kanban_operator_panel",
+        "rank": 4,
+        "type": "medium_build",
+        "title": "Kanban operator panel for hermes-operator",
+        "summary": "Surface task states, assignees, dependencies, scratch paths, receipts, and blocked reasons.",
+        "owner": "future Hermes WebUI task",
+        "side_effect_level": "code change",
+        "status": "proposal",
+    },
+]
+
+
+def _source_tree(tmp_path, *, actions=None, omit_action_summary=False, malformed_action_summary=False):
+    root = tmp_path / "workspace"
+    active_plan = root / "obsidian-vault" / "Agent-Shared" / "ACTIVE PLAN.md"
+    wake_state = root / "obsidian-vault" / "Agent-Kimi" / "WAKE_STATE.md"
+    kanban_hardening = root / "obsidian-vault" / "Agent-Kimi" / "Hermes Kanban Pilot Hardening.md"
+    action_summary = root / "artifacts" / "hermes-video-RoBD7Lc-0MI" / "action-summary.json"
+
+    active_plan.parent.mkdir(parents=True, exist_ok=True)
+    wake_state.parent.mkdir(parents=True, exist_ok=True)
+    action_summary.parent.mkdir(parents=True, exist_ok=True)
+
+    active_plan.write_text("# Active Plan\nDo not restart AIM Labs. PRIVATE MARKDOWN BODY SHOULD NOT LEAK.\n", encoding="utf-8")
+    wake_state.write_text("generated_at: 2026-05-21T01:17:12Z\nLive services must be probed before use.\n", encoding="utf-8")
+    kanban_hardening.write_text("# Hermes Kanban Pilot Hardening\nScratch paths must be safe.\n", encoding="utf-8")
+
+    if malformed_action_summary:
+        action_summary.write_text("{not json", encoding="utf-8")
+    elif not omit_action_summary:
+        action_summary.write_text(
+            json.dumps(
+                {
+                    "source_url": "https://youtu.be/RoBD7Lc-0MI?si=fZqI80VZGaovwspS",
+                    "video_id": "RoBD7Lc-0MI",
+                    "date": "2026-05-26",
+                    "brief_path": str(root / "obsidian-vault" / "Agent-Kimi" / "Deep Research Briefs" / "brief.md"),
+                    "artifact_dir": str(action_summary.parent),
+                    "ranked_actions": list(actions if actions is not None else DEFAULT_ACTIONS),
+                    "avoid": [
+                        "Reviving AIM Labs automation or old AIM crons",
+                        "Fake/demo/stale dashboard data",
+                        "Kanban scratch workspaces pointed at real project directories",
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+    return {
+        "active_plan": active_plan,
+        "wake_state": wake_state,
+        "kanban_hardening": kanban_hardening,
+        "action_summary": action_summary,
+    }
+
+
+def _patch_sources(monkeypatch, proposals, source_paths):
+    monkeypatch.setattr(proposals, "SOURCE_SPECS", source_paths, raising=False)
+
+
+def _patch_truth(monkeypatch, *, status="live"):
+    import api.operator_truth as operator_truth
+
+    def fake_truth_payload(*, session_id=None, ui_board_hint=None, now=None):
+        return {
+            "version": 1,
+            "verified_at": now,
+            "status": status,
+            "summary": f"Truth {status}",
+            "chips": [],
+            "sources": [],
+            "issues": [] if status == "live" else [f"truth {status}"],
+        }
+
+    monkeypatch.setattr(operator_truth, "build_operator_truth_payload", fake_truth_payload, raising=False)
+
+
+def test_operator_proposal_payload_has_version_status_sources_and_no_execution(monkeypatch, tmp_path):
+    proposals = importlib.import_module("api.operator_proposals")
+    sources = _source_tree(tmp_path)
+    _patch_sources(monkeypatch, proposals, sources)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = proposals.build_operator_proposal_payload(now=123.0)
+
+    assert payload["version"] == 1
+    assert payload["generated_at"] == 123.0
+    assert payload["mode"] == "manual-read-only"
+    assert payload["would_execute"] is False
+    assert payload["status"] in {"live", "stale", "unknown"}
+    assert payload["proposals"]
+    assert len(payload["proposals"]) <= 3
+    assert all(p["would_execute"] is False for p in payload["proposals"])
+    assert all(p["approval"]["kind"] == "draft_only" and p["approval"]["executes"] is False for p in payload["proposals"])
+    assert all(p["decline"]["kind"] == "client_only" and p["decline"]["executes"] is False for p in payload["proposals"])
+    assert {s["id"] for s in payload["sources"]} >= {"active_plan", "wake_state", "kanban_hardening", "action_summary"}
+
+
+def test_operator_proposals_selects_top_three_ranked_actions_from_action_summary(monkeypatch, tmp_path):
+    proposals = importlib.import_module("api.operator_proposals")
+    shuffled = [DEFAULT_ACTIONS[3], DEFAULT_ACTIONS[1], DEFAULT_ACTIONS[2], DEFAULT_ACTIONS[0]]
+    sources = _source_tree(tmp_path, actions=shuffled)
+    _patch_sources(monkeypatch, proposals, sources)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = proposals.build_operator_proposal_payload(now=1.0)
+
+    assert [p["id"] for p in payload["proposals"]] == [
+        "reverse_prompt_v0",
+        "webui_proof_freshness_labels",
+        "goal_cron_safety_template",
+    ]
+    assert [p["rank"] for p in payload["proposals"]] == [1, 2, 3]
+
+
+def test_operator_proposals_missing_action_summary_returns_unknown_without_fake_actions(monkeypatch, tmp_path):
+    proposals = importlib.import_module("api.operator_proposals")
+    sources = _source_tree(tmp_path, omit_action_summary=True)
+    _patch_sources(monkeypatch, proposals, sources)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = proposals.build_operator_proposal_payload(now=1.0)
+
+    assert payload["status"] == "unknown"
+    assert payload["proposals"] == []
+    assert any("action_summary" in issue for issue in payload["issues"])
+
+
+def test_operator_proposals_malformed_action_summary_returns_unknown(monkeypatch, tmp_path):
+    proposals = importlib.import_module("api.operator_proposals")
+    sources = _source_tree(tmp_path, malformed_action_summary=True)
+    _patch_sources(monkeypatch, proposals, sources)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = proposals.build_operator_proposal_payload(now=1.0)
+
+    assert payload["status"] == "unknown"
+    assert payload["proposals"] == []
+    assert any("malformed" in issue.lower() or "json" in issue.lower() for issue in payload["issues"])
+
+
+def test_operator_proposals_non_file_action_summary_returns_unknown(monkeypatch, tmp_path):
+    proposals = importlib.import_module("api.operator_proposals")
+    sources = _source_tree(tmp_path, omit_action_summary=True)
+    sources["action_summary"].mkdir(parents=True)
+    _patch_sources(monkeypatch, proposals, sources)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = proposals.build_operator_proposal_payload(now=1.0)
+
+    assert payload["status"] == "unknown"
+    assert payload["proposals"] == []
+    assert any("not a regular file" in issue.lower() for issue in payload["issues"])
+
+
+def test_operator_proposals_invalid_ranked_action_fields_return_unknown(monkeypatch, tmp_path):
+    proposals = importlib.import_module("api.operator_proposals")
+    bad_actions = [
+        dict(DEFAULT_ACTIONS[0], id="duplicate_action"),
+        dict(DEFAULT_ACTIONS[1], id="duplicate_action", title=""),
+    ]
+    sources = _source_tree(tmp_path, actions=bad_actions)
+    _patch_sources(monkeypatch, proposals, sources)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = proposals.build_operator_proposal_payload(now=1.0)
+
+    assert payload["status"] == "unknown"
+    assert payload["proposals"] == []
+    assert any("duplicate" in issue.lower() or "non-empty" in issue.lower() for issue in payload["issues"])
+
+
+def test_operator_proposals_includes_operator_truth_as_evidence_and_marks_stale(monkeypatch, tmp_path):
+    proposals = importlib.import_module("api.operator_proposals")
+    sources = _source_tree(tmp_path)
+    _patch_sources(monkeypatch, proposals, sources)
+    _patch_truth(monkeypatch, status="stale")
+
+    payload = proposals.build_operator_proposal_payload(session_id="abc123", ui_board_hint="hermes-operator", now=1.0)
+
+    assert payload["truth"]["status"] == "stale"
+    assert payload["status"] == "stale"
+    assert any(ev.get("source_id") == "operator_truth" for ev in payload["proposals"][0]["evidence"])
+    assert payload["proposals"], "stale truth should warn, not force fake-empty proposals"
+
+
+def test_operator_proposals_do_not_return_full_markdown_source_bodies(monkeypatch, tmp_path):
+    proposals = importlib.import_module("api.operator_proposals")
+    sources = _source_tree(tmp_path)
+    _patch_sources(monkeypatch, proposals, sources)
+    _patch_truth(monkeypatch, status="live")
+
+    payload = proposals.build_operator_proposal_payload(now=1.0)
+    serialized = json.dumps(payload)
+
+    assert "PRIVATE MARKDOWN BODY SHOULD NOT LEAK" not in serialized
+    assert "Do not restart AIM Labs" not in serialized
+    assert "Scratch paths must be safe" not in serialized
+
+
+def test_operator_proposals_never_imports_or_calls_dispatch_cron_or_shell(monkeypatch, tmp_path):
+    proposals = importlib.import_module("api.operator_proposals")
+    sources = _source_tree(tmp_path)
+    _patch_sources(monkeypatch, proposals, sources)
+    _patch_truth(monkeypatch, status="live")
+    calls = []
+
+    def forbidden(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("proposal builder must be read-only and shell-free")
+
+    fake_kanban_bridge = types.ModuleType("api.kanban_bridge")
+    fake_cron = types.ModuleType("cron.jobs")
+    for name in ("dispatch", "dispatch_ready_tasks", "claim", "complete", "create_task"):
+        setattr(fake_kanban_bridge, name, forbidden)
+    setattr(fake_cron, "create", forbidden)
+    monkeypatch.setitem(sys.modules, "api.kanban_bridge", fake_kanban_bridge)
+    monkeypatch.setitem(sys.modules, "cron.jobs", fake_cron)
+    monkeypatch.setattr(subprocess, "run", forbidden)
+    monkeypatch.setattr(subprocess, "Popen", forbidden)
+
+    payload = proposals.build_operator_proposal_payload(now=1.0)
+
+    assert payload["would_execute"] is False
+    assert calls == []
+
+
+def test_operator_proposals_route_returns_json(monkeypatch):
+    import api.routes as routes
+
+    expected = {"version": 1, "status": "unknown", "proposals": [], "sources": []}
+    captured = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        captured["payload"] = payload
+        return True
+
+    with patch("api.operator_proposals.build_operator_proposal_payload", return_value=expected) as build_payload, patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        handled = routes.handle_get(
+            types.SimpleNamespace(wfile=io.BytesIO()),
+            urlparse("/api/operator/proposals?session_id=abc123&ui_board=hermes-operator"),
+        )
+
+    assert handled is True
+    assert captured["status"] == 200
+    assert captured["payload"] == expected
+    build_payload.assert_called_once_with(session_id="abc123", ui_board_hint="hermes-operator")

--- a/tests/test_operator_proposals_ui_static.py
+++ b/tests/test_operator_proposals_ui_static.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+
+
+def _read(path):
+    return Path(path).read_text(encoding="utf-8")
+
+
+def test_operator_proposal_markup_exists_near_truth_strip():
+    html = _read("static/index.html")
+
+    assert 'id="operatorProposalChip"' in html
+    assert 'id="operatorProposalPopover"' in html
+    assert 'id="operatorProposalList"' in html
+    assert html.index('id="operatorTruthStrip"') < html.index('id="operatorTruthScratchChip"') < html.index('id="operatorProposalChip"')
+    assert html.index('id="operatorProposalChip"') < html.index('id="composerMobileConfigBtn"')
+
+
+def test_operator_proposal_chip_uses_proposals_label_not_actions_alias():
+    html = _read("static/index.html")
+    js = _read("static/operator_proposals.js")
+
+    assert 'id="operatorProposalLabel">Proposals</span>' in html
+    assert '<div class="operator-proposal-title">Proposals</div>' in html
+    assert 'id="operatorProposalLabel">Actions</span>' not in html
+    assert "count ? 'Proposals ' + count : 'Proposals'" in js
+    assert "count ? 'Actions ' + count : 'Actions'" not in js
+
+
+def test_operator_proposals_script_loaded_after_truth_before_boot():
+    html = _read("static/index.html")
+
+    assert html.index("static/operator_truth.js") < html.index("static/operator_proposals.js") < html.index("static/boot.js")
+
+
+def test_operator_proposals_js_uses_relative_get_endpoint_only():
+    js = _read("static/operator_proposals.js")
+    compact = js.replace(" ", "")
+
+    assert "'/api/operator/proposals'" in js or '"/api/operator/proposals"' in js
+    assert "http://" not in js
+    assert "https://" not in js
+    assert "method:'POST'" not in compact
+    assert 'method:"POST"' not in compact
+    assert "fetch('/api/operator/proposals'" not in js
+
+
+def test_operator_proposals_payload_values_use_text_content_not_inner_html():
+    js = _read("static/operator_proposals.js")
+
+    assert ".textContent" in js
+    assert ".innerHTML" not in js
+
+
+def test_operator_proposals_never_executes_chat_kanban_cron_or_send():
+    js = _read("static/operator_proposals.js")
+    forbidden = [
+        "/api/chat/start",
+        "/api/chat",
+        "/api/kanban/dispatch",
+        "/api/kanban/tasks",
+        "/api/cron",
+        "cron",
+        "send(",
+        "sendMessage",
+        "submitKanban",
+        "createKanban",
+        "dispatch",
+    ]
+    for token in forbidden:
+        assert token not in js
+
+
+def test_operator_proposals_fetch_is_manual_not_boot_polling():
+    js = _read("static/operator_proposals.js")
+
+    assert "function toggleOperatorProposals" in js
+    assert "function refreshOperatorProposals" in js
+    assert "window.toggleOperatorProposals" in js
+    assert "DOMContentLoaded" not in js or "refreshOperatorProposals" not in js.split("DOMContentLoaded", 1)[1]
+    assert "setInterval" not in js
+    assert "setTimeout(refreshOperatorProposals" not in js
+
+
+def test_operator_proposals_draft_writes_composer_without_sending():
+    js = _read("static/operator_proposals.js")
+    body = js[js.index("function draftOperatorProposal") :]
+
+    assert "msg.value" in body
+    assert "proposal.handoff_prompt" in body
+    assert "focus()" in body
+    assert "updateSendBtn" in body
+    assert "send(" not in body
+    assert "/api/chat" not in body
+
+
+def test_operator_proposals_commitment_promote_is_draft_only_until_form_submit():
+    js = _read("static/operator_proposals.js")
+    compact = js.replace(" ", "")
+
+    assert "Promote to commitment" in js
+    assert "openOperatorCommitmentPromote" in js
+    assert "/api/operator/commitments/promote" not in js
+    assert "method:'POST'" not in compact
+    assert 'method:"POST"' not in compact
+    for token in [
+        "/api/kanban/",
+        "/api/chat/start",
+        "/api/chat",
+        "/api/cron",
+        "/api/crons",
+        "/api/goal",
+        "runKanbanDispatcher",
+        "nudgeKanbanDispatcher",
+        "createKanbanTask",
+        "send(",
+        "sendMessage",
+    ]:
+        assert token not in js
+
+
+def test_operator_proposals_css_has_popover_cards_and_mobile_rules():
+    css = _read("static/style.css")
+
+    assert ".operator-proposal-popover" in css
+    assert ".operator-proposal-card" in css
+    assert ".operator-proposal-actions" in css
+    assert ".operator-proposal-no-exec" in css
+    assert "max-width:640px" in css or "composer-footer (max-width:" in css

--- a/tests/test_operator_session_recall.py
+++ b/tests/test_operator_session_recall.py
@@ -1,0 +1,543 @@
+import importlib
+import re
+import subprocess
+import threading
+from collections import Counter
+from pathlib import Path
+
+
+def test_session_recall_payload_requires_query_and_does_not_dump_sessions(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+
+    def fail_if_sources_are_read(*args, **kwargs):  # pragma: no cover - defensive assertion helper
+        raise AssertionError("blank session recall query must not read or dump sessions")
+
+    monkeypatch.setattr(recall, "_read_session_recall_sources", fail_if_sources_are_read, raising=False)
+
+    payload = recall.build_operator_session_recall_payload(query_text="", now=123.0)
+
+    assert payload["would_execute"] is False
+    assert payload["results"] == []
+    assert payload["count"] == 0
+    assert payload["status"] in {"unknown", "stale"}
+    assert any("query" in issue.lower() and "required" in issue.lower() for issue in payload["issues"])
+
+
+def test_session_recall_payload_has_version_mode_timestamp_sources_and_count(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+    monkeypatch.setattr(recall, "_read_session_recall_sources", lambda all_profiles=False: [], raising=False)
+
+    payload = recall.build_operator_session_recall_payload(
+        query_text="operator commitments",
+        limit=99,
+        per_session=0,
+        all_profiles=True,
+        now=456.5,
+    )
+
+    assert {
+        "version",
+        "mode",
+        "generated_at",
+        "status",
+        "query",
+        "sources",
+        "results",
+        "count",
+        "issues",
+        "would_execute",
+    }.issubset(payload.keys())
+    assert payload["version"] == 1
+    assert payload["mode"] == "session-recall-read-only"
+    assert payload["generated_at"] == 456.5
+    assert payload["would_execute"] is False
+    assert payload["query"] == {
+        "text": "operator commitments",
+        "limit": 50,
+        "per_session": 1,
+        "all_profiles": True,
+    }
+    assert payload["sources"] == []
+    assert payload["results"] == []
+    assert payload["count"] == 0
+
+
+def test_routes_exposes_operator_session_recall_get_near_operator_routes():
+    routes_text = Path("api/routes.py").read_text(encoding="utf-8")
+
+    assert '"/api/operator/session-recall"' in routes_text
+    assert "build_operator_session_recall_payload" in routes_text
+
+    memory_review_idx = routes_text.index('if parsed.path == "/api/operator/memory-skill-review":')
+    session_recall_idx = routes_text.index('if parsed.path == "/api/operator/session-recall":')
+    models_idx = routes_text.index('if parsed.path == "/api/models":')
+    assert memory_review_idx < session_recall_idx < models_idx
+
+    session_recall_block = routes_text[session_recall_idx:models_idx]
+    for param in ('"q"', '"limit"', '"per_session"', '"all_profiles"'):
+        assert param in session_recall_block
+    assert "j(handler, payload)" in session_recall_block
+
+
+def test_session_recall_finds_message_match_with_snippet_timestamp_source_and_hash(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+    long_content = (
+        "intro "
+        + ("before " * 80)
+        + "needle-context proof-bearing detail"
+        + (" after" * 80)
+    )
+    monkeypatch.setattr(
+        recall,
+        "_read_session_recall_sources",
+        lambda all_profiles=False: [
+            {
+                "session_id": "session_alpha",
+                "title": "Research decisions for recall",
+                "profile": "default",
+                "source_label": "WebUI",
+                "source_tag": "webui",
+                "messages": [
+                    {"role": "user", "content": "no match here", "timestamp": 1700000000.0},
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": long_content}],
+                        "timestamp": 1700000123.5,
+                    },
+                ],
+            }
+        ],
+        raising=False,
+    )
+
+    payload = recall.build_operator_session_recall_payload(
+        query_text="needle-context",
+        limit=10,
+        per_session=3,
+        now=1700000200.0,
+    )
+
+    assert payload["would_execute"] is False
+    assert payload["count"] == 1
+    result = payload["results"][0]
+    assert result["session"]["session_id"] == "session_alpha"
+    assert result["session"]["title"] == "Research decisions for recall"
+    assert result["session"]["profile"] == "default"
+    assert result["session"]["source_label"] == "WebUI"
+    assert result["session"]["source_tag"] == "webui"
+    assert result["match"]["type"] == "message"
+    assert result["match"]["message_index"] == 1
+    assert result["match"]["role"] == "assistant"
+    assert result["match"]["timestamp"] == 1700000123.5
+    assert "needle-context proof-bearing detail" in result["match"]["snippet"]
+    assert len(result["match"]["snippet"]) <= 280
+    assert long_content not in result["match"]["snippet"]
+    content_hash = result["match"]["content_hash"]
+    assert content_hash.startswith("sha256:")
+    assert len(content_hash) == len("sha256:") + 64
+    assert result["promotion"]["task"]["would_execute"] is False
+    assert result["promotion"]["memory_review"]["would_execute"] is False
+    task_source = result["promotion"]["task"]["source"]
+    assert task_source["kind"] == "session_message"
+    assert task_source["session_id"] == "session_alpha"
+    assert task_source["message_index"] == 1
+    assert task_source["content_hash"] == content_hash
+    memory_source = result["promotion"]["memory_review"]["source_evidence"][0]
+    assert memory_source["kind"] == "session_message"
+    assert memory_source["session_id"] == "session_alpha"
+    assert memory_source["message_index"] == 1
+    assert memory_source["content_hash"] == content_hash
+
+
+def test_session_recall_does_not_promote_title_only_matches_as_session_message_evidence(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+    monkeypatch.setattr(
+        recall,
+        "_read_session_recall_sources",
+        lambda all_profiles=False: [
+            {
+                "session_id": "session_title_only",
+                "title": "Needle-only planning title",
+                "profile": "default",
+                "messages": [
+                    {"role": "user", "content": "ordinary setup without the search term", "timestamp": 1700000000.0},
+                    {"role": "assistant", "content": "follow-up also lacks that evidence", "timestamp": 1700000001.0},
+                ],
+            }
+        ],
+        raising=False,
+    )
+
+    payload = recall.build_operator_session_recall_payload(query_text="needle-only", now=1700000002.0)
+
+    assert payload["results"] == []
+    assert payload["count"] == 0
+
+
+def test_session_recall_labels_historical_matches_older_than_30_days(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+    now = 1700000000.0
+    old_timestamp = now - (31 * 24 * 60 * 60)
+    monkeypatch.setattr(
+        recall,
+        "_read_session_recall_sources",
+        lambda all_profiles=False: [
+            {
+                "session_id": "session_old",
+                "title": "Old discussion",
+                "messages": [
+                    {"role": "user", "content": "needle old commitment", "timestamp": old_timestamp},
+                ],
+            }
+        ],
+        raising=False,
+    )
+
+    payload = recall.build_operator_session_recall_payload(query_text="needle", now=now)
+
+    assert payload["count"] == 1
+    assert payload["results"][0]["recency"]["label"] == "historical"
+    assert "30" in payload["results"][0]["recency"]["reason"]
+
+
+def test_session_recall_labels_unknown_when_timestamp_missing(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+    monkeypatch.setattr(
+        recall,
+        "_read_session_recall_sources",
+        lambda all_profiles=False: [
+            {
+                "session_id": "session_no_timestamp",
+                "title": "Missing timestamp",
+                "messages": [
+                    {"role": "assistant", "content": "needle without a timestamp"},
+                ],
+            }
+        ],
+        raising=False,
+    )
+
+    payload = recall.build_operator_session_recall_payload(query_text="needle", now=1700000000.0)
+
+    assert payload["count"] == 1
+    assert payload["results"][0]["recency"]["label"] == "unknown"
+    assert "timestamp" in payload["results"][0]["recency"]["reason"].lower()
+
+
+def test_session_recall_redacts_secret_before_snippet_windowing(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+    very_long_secret = "".join(f"SECRET{i:03d}" for i in range(80))
+    leaked_chunk = very_long_secret[500:560]
+    monkeypatch.setattr(
+        recall,
+        "_read_session_recall_sources",
+        lambda all_profiles=False: [
+            {
+                "session_id": "session_secret_window",
+                "title": "Secret window regression",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": f"prefix password={very_long_secret} needle after",
+                        "timestamp": 1700000000.0,
+                    },
+                ],
+            }
+        ],
+        raising=False,
+    )
+
+    payload = recall.build_operator_session_recall_payload(query_text="needle", now=1700000001.0)
+
+    assert payload["count"] == 1
+    snippet = payload["results"][0]["match"]["snippet"]
+    assert leaked_chunk not in snippet
+    assert "[redacted]" in snippet.lower()
+
+
+def test_session_recall_redacts_snippets_and_titles(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+    raw_password = "hunter2-correct-horse"
+    raw_token = "sk-live-abcdef1234567890abcdef1234567890"
+    monkeypatch.setattr(
+        recall,
+        "_read_session_recall_sources",
+        lambda all_profiles=False: [
+            {
+                "session_id": "session_secret",
+                "title": f"Rotate password={raw_password} and api_key={raw_token}",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": f"needle shows token={raw_token} and password: {raw_password}",
+                        "timestamp": 1700000000.0,
+                    },
+                ],
+            }
+        ],
+        raising=False,
+    )
+
+    payload = recall.build_operator_session_recall_payload(query_text="needle", now=1700000001.0)
+
+    assert payload["count"] == 1
+    result = payload["results"][0]
+    assert raw_password not in result["session"]["title"]
+    assert raw_token not in result["session"]["title"]
+    assert raw_password not in result["match"]["snippet"]
+    assert raw_token not in result["match"]["snippet"]
+    assert "[redacted]" in result["session"]["title"].lower()
+    assert "[redacted]" in result["match"]["snippet"].lower()
+
+
+def test_session_recall_redacts_github_token_shapes_from_title_snippet_and_source_quotes(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+    raw_classic_pat = "ghp_" + "A" * 36
+    raw_fine_grained_pat = "github_pat_" + "B" * 22 + "_" + "C" * 59
+    monkeypatch.setattr(
+        recall,
+        "_read_session_recall_sources",
+        lambda all_profiles=False: [
+            {
+                "session_id": "session_github_secret",
+                "title": f"Rotate GitHub tokens {raw_classic_pat} {raw_fine_grained_pat}",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": f"needle must not leak {raw_classic_pat} or {raw_fine_grained_pat}",
+                        "timestamp": 1700000000.0,
+                    },
+                ],
+            }
+        ],
+        raising=False,
+    )
+
+    payload = recall.build_operator_session_recall_payload(query_text="needle", now=1700000001.0)
+
+    assert payload["count"] == 1
+    result = payload["results"][0]
+    fields = [
+        result["session"]["title"],
+        result["match"]["snippet"],
+        result["promotion"]["task"]["source"]["quote"],
+        result["promotion"]["memory_review"]["source_evidence"][0]["quote"],
+    ]
+    for field in fields:
+        assert raw_classic_pat not in field
+        assert raw_fine_grained_pat not in field
+        assert "[redacted]" in field.lower()
+
+
+def test_session_recall_redacts_github_tokens_before_punctuation_boundaries(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+    token_cases = [
+        ("classic", "ghp_" + "A" * 36),
+        ("fine-grained", "github_pat_" + "B" * 22 + "_" + "C" * 59),
+    ]
+    delimiter_cases = [
+        ("period", "."),
+        ("close paren", ")"),
+        ("close bracket", "]"),
+        ("double quote", '"'),
+        ("newline", "\nnext line"),
+    ]
+
+    for token_label, raw_token in token_cases:
+        for delimiter_label, delimiter in delimiter_cases:
+            monkeypatch.setattr(
+                recall,
+                "_read_session_recall_sources",
+                lambda all_profiles=False, raw_token=raw_token, delimiter=delimiter, token_label=token_label, delimiter_label=delimiter_label: [
+                    {
+                        "session_id": f"session_{token_label}_{delimiter_label}".replace(" ", "_"),
+                        "title": f"Rotate token {raw_token}{delimiter} before release",
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": f"needle must redact {raw_token}{delimiter} from all recall surfaces",
+                                "timestamp": 1700000000.0,
+                            },
+                        ],
+                    }
+                ],
+                raising=False,
+            )
+
+            payload = recall.build_operator_session_recall_payload(query_text="needle", now=1700000001.0)
+
+            assert payload["count"] == 1, f"{token_label} followed by {delimiter_label}"
+            result = payload["results"][0]
+            fields = [
+                result["session"]["title"],
+                result["match"]["snippet"],
+                result["promotion"]["task"]["source"]["quote"],
+                result["promotion"]["memory_review"]["source_evidence"][0]["quote"],
+            ]
+            for field in fields:
+                assert raw_token not in field, f"{token_label} followed by {delimiter_label}: {field}"
+                assert "[redacted]" in field.lower(), f"{token_label} followed by {delimiter_label}: {field}"
+
+
+def test_session_recall_clamps_limits_and_per_session(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+    rows = []
+    for session_number in range(12):
+        rows.append(
+            {
+                "session_id": f"session_{session_number}",
+                "title": f"Session {session_number}",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": f"needle match {session_number}-{message_number}",
+                        "timestamp": 1700000000.0 + message_number,
+                    }
+                    for message_number in range(7)
+                ],
+            }
+        )
+    monkeypatch.setattr(
+        recall,
+        "_read_session_recall_sources",
+        lambda all_profiles=False: rows,
+        raising=False,
+    )
+
+    payload = recall.build_operator_session_recall_payload(
+        query_text="needle",
+        limit=999,
+        per_session=999,
+        now=1700000100.0,
+    )
+
+    assert payload["query"]["limit"] == 50
+    assert payload["query"]["per_session"] == 5
+    assert payload["count"] == 50
+    assert len(payload["results"]) == 50
+    counts = Counter(result["session"]["session_id"] for result in payload["results"])
+    assert counts
+    assert max(counts.values()) <= 5
+
+
+def test_session_recall_does_not_call_mutating_helpers(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+    source_text = Path("api/operator_session_recall.py").read_text(encoding="utf-8")
+
+    forbidden_literals = (
+        "all_sessions",
+        "Session.load",
+        ".save(",
+        "write_text",
+        "subprocess",
+        "threading.Thread",
+        "threading.Timer",
+        "kanban",
+        "cron",
+        "goal",
+        "/api/chat",
+        "/api/memory/write",
+        "/api/skills/save",
+        "/apply",
+    )
+    for forbidden_text in forbidden_literals:
+        assert forbidden_text not in source_text
+    assert re.search(r"\bopen\s*\([^\n)]*(?:,\s*|mode\s*=)[\"']w[\"']", source_text) is None
+
+    def fail_if_called(*args, **kwargs):  # pragma: no cover - only runs on regression
+        raise AssertionError("session recall must not call mutating/background helpers")
+
+    monkeypatch.setattr(subprocess, "run", fail_if_called, raising=True)
+    monkeypatch.setattr(subprocess, "Popen", fail_if_called, raising=True)
+    monkeypatch.setattr(threading, "Thread", fail_if_called, raising=True)
+    monkeypatch.setattr(threading, "Timer", fail_if_called, raising=True)
+
+    monkeypatch.setattr(
+        recall,
+        "_read_session_recall_sources",
+        lambda all_profiles=False: [
+            {
+                "session_id": "session_read_only_guard",
+                "title": "Read-only recall guard",
+                "profile": "default",
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": "needle proves the recall path only searches source rows",
+                        "timestamp": 1700000000.0,
+                    }
+                ],
+            }
+        ],
+        raising=False,
+    )
+
+    payload = recall.build_operator_session_recall_payload(query_text="needle", now=1700000001.0)
+
+    assert payload["would_execute"] is False
+    assert payload["count"] == 1
+    assert payload["results"][0]["session"]["session_id"] == "session_read_only_guard"
+
+
+def test_session_recall_handles_source_reader_failure_as_unknown_without_fake_results(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+
+    def fail_source_read(*args, **kwargs):
+        raise RuntimeError("session index unavailable: token=supersecret")
+
+    monkeypatch.setattr(recall, "_read_session_recall_sources", fail_source_read, raising=False)
+
+    payload = recall.build_operator_session_recall_payload(query_text="needle", now=1700000000.0)
+
+    assert payload["status"] == "unknown"
+    assert payload["results"] == []
+    assert payload["count"] == 0
+    assert payload["would_execute"] is False
+
+    source_states = {(source.get("id"), source.get("kind"), source.get("state")) for source in payload["sources"]}
+    issue_text = "\n".join(payload["issues"])
+    assert ("webui_sessions", "session_json", "unknown") in source_states or "session index unavailable" in issue_text
+    assert "RuntimeError" in issue_text
+    assert "session index unavailable" in issue_text
+    payload_text = repr(payload)
+    assert "supersecret" not in payload_text
+
+
+def test_session_recall_reports_real_source_reader_glob_failure_with_sanitized_issue(monkeypatch):
+    recall = importlib.import_module("api.operator_session_recall")
+
+    def fail_glob(*args, **kwargs):
+        raise RuntimeError("session dir unavailable: token=supersecret " + "x" * 1000)
+
+    monkeypatch.setattr(recall.Path, "glob", fail_glob, raising=True)
+
+    payload = recall.build_operator_session_recall_payload(query_text="needle", now=1700000000.0)
+
+    assert payload["status"] == "unknown"
+    assert payload["results"] == []
+    assert payload["count"] == 0
+    assert payload["would_execute"] is False
+
+    source_states = {(source.get("id"), source.get("kind"), source.get("state")) for source in payload["sources"]}
+    assert ("webui_sessions", "session_json", "unknown") in source_states
+
+    issue_text = "\n".join(payload["issues"])
+    source_issue_text = "\n".join(str(source.get("issue", "")) for source in payload["sources"])
+    combined_issue_text = f"{issue_text}\n{source_issue_text}"
+    assert "RuntimeError" in combined_issue_text
+    assert "session dir unavailable" in combined_issue_text
+    assert "supersecret" not in repr(payload)
+    assert payload["issues"]
+    assert all(len(issue) <= 260 for issue in payload["issues"])
+    assert all(len(str(source.get("issue", ""))) <= 260 for source in payload["sources"])
+
+
+def test_session_recall_does_not_modify_existing_sessions_search_contract_static():
+    routes_text = Path("api/routes.py").read_text(encoding="utf-8")
+
+    legacy_idx = routes_text.index('if parsed.path == "/api/sessions/search":')
+    legacy_block = "\n".join(routes_text[legacy_idx:].splitlines()[:3])
+    assert "return _handle_sessions_search(handler, parsed)" in legacy_block
+    assert "build_operator_session_recall_payload" not in legacy_block
+    assert '"/api/operator/session-recall"' in routes_text
+    assert routes_text.index('if parsed.path == "/api/operator/session-recall":') != legacy_idx

--- a/tests/test_operator_session_recall_ui_static.py
+++ b/tests/test_operator_session_recall_ui_static.py
@@ -1,0 +1,1243 @@
+import re
+import subprocess
+from pathlib import Path
+
+
+def _read(path):
+    return Path(path).read_text(encoding="utf-8")
+
+
+def test_session_recall_markup_exists_after_memory_skill_review_chip_and_popover():
+    html = _read("static/index.html")
+
+    for element_id in [
+        "operatorSessionRecallChip",
+        "operatorSessionRecallPopover",
+        "operatorSessionRecallInput",
+        "operatorSessionRecallList",
+        "operatorSessionRecallRefresh",
+    ]:
+        assert f'id="{element_id}"' in html
+
+    assert html.index('id="operatorMemorySkillReviewChip"') < html.index('id="operatorSessionRecallChip"') < html.index('id="composerMobileConfigBtn"')
+    assert html.index('id="operatorMemorySkillReviewPopover"') < html.index('id="operatorSessionRecallPopover"')
+
+
+def test_session_recall_script_loaded_after_memory_skill_review_before_boot():
+    html = _read("static/index.html")
+
+    assert html.index("static/operator_memory_skill_review.js") < html.index("static/operator_session_recall.js") < html.index("static/boot.js")
+
+
+def test_session_recall_css_has_popover_card_snippet_source_action_and_mobile_rules():
+    css = _read("static/style.css")
+
+    for selector in [
+        ".operator-session-recall-popover",
+        ".operator-session-recall-list",
+        ".operator-session-recall-card",
+        ".operator-session-recall-snippet",
+        ".operator-session-recall-source",
+        ".operator-session-recall-historical",
+        ".operator-session-recall-stale",
+        ".operator-session-recall-action",
+    ]:
+        assert selector in css
+
+    mobile_starts = [
+        match.start()
+        for match in re.finditer(r"@media\s*\(\s*max-width\s*:\s*640px\s*\)", css)
+    ]
+    assert mobile_starts
+    mobile_sections = [
+        css[start : mobile_starts[index + 1] if index + 1 < len(mobile_starts) else len(css)]
+        for index, start in enumerate(mobile_starts)
+    ]
+    assert any("operator-session-recall" in section for section in mobile_sections)
+
+
+def _session_recall_js():
+    return _read("static/operator_session_recall.js")
+
+
+def test_session_recall_changelog_mentions_manual_read_only_recall():
+    changelog = _read("CHANGELOG.md")
+    unreleased = changelog.split("## [v0.51.137]", 1)[0]
+
+    assert "Session Recall" in unreleased
+    assert "manual" in unreleased.lower()
+    assert "read-only" in unreleased.lower()
+    assert "local" in unreleased.lower()
+    assert "proposal" in unreleased.lower()
+    assert "no apply" in unreleased.lower() or "without applying" in unreleased.lower()
+
+
+def _strip_js_strings_and_comments(js):
+    js = re.sub(r"//.*", "", js)
+    js = re.sub(r"/\*.*?\*/", "", js, flags=re.DOTALL)
+    return re.sub(r"(['\"`])(?:\\.|(?!\1).)*\1", "''", js, flags=re.DOTALL)
+
+
+def _top_level_calls(js, function_name):
+    cleaned = _strip_js_strings_and_comments(js)
+    calls = []
+    depth = 0
+    for line_number, line in enumerate(cleaned.splitlines(), start=1):
+        line_depth = depth
+        if re.search(rf"\bfunction\s+{re.escape(function_name)}\s*\(", line):
+            pass
+        elif line_depth == 0 and re.search(rf"\b{re.escape(function_name)}\s*\(", line):
+            calls.append((line_number, line.strip()))
+        depth += line.count("{") - line.count("}")
+        depth = max(depth, 0)
+    return calls
+
+
+def test_session_recall_js_uses_operator_session_recall_endpoint_only_for_search():
+    js = _session_recall_js()
+    allowed_endpoints = {"/api/operator/session-recall", "/api/operator/memory-skill-review/propose"}
+    quoted_api_paths = set(re.findall(r"[\"'`](/api/[A-Za-z0-9_./-]+)", js))
+
+    assert quoted_api_paths == allowed_endpoints
+    assert "/api/operator/session-recall" in quoted_api_paths
+    assert "/api/operator/memory-skill-review/propose" in quoted_api_paths
+    assert re.search(r"\bapi\s*\(\s*[\"'`]/api/operator/session-recall\b", js)
+    assert re.search(r"\bapi\s*\(\s*[\"'`]/api/operator/memory-skill-review/propose\b", js)
+    assert not re.search(r"\bfetch\s*\(", js)
+    assert "XMLHttpRequest" not in js
+    assert "http://" not in js
+    assert "https://" not in js
+    for forbidden in [
+        "/api/memory/write",
+        "/api/skills/save",
+        "/api/skills/delete",
+        "/api/skills/toggle",
+        "/apply",
+        "/api/kanban/",
+        "/api/chat",
+        "/api/operator/commitments/",
+        "submitChat",
+        "startChat",
+        "sendMessage",
+        "commitmentForm.submit",
+        "operatorCommitmentForm.submit",
+    ]:
+        assert forbidden not in js
+
+
+def test_session_recall_memory_skill_review_proposal_form_exists_with_user_entered_fields():
+    html = _read("static/index.html")
+    popover_start = html.index('id="operatorSessionRecallPopover"')
+    popover_end = html.index('id="operatorSessionRecallList"', popover_start)
+    popover_form = html[popover_start:popover_end]
+
+    for element_id in [
+        "operatorSessionRecallMemoryProposalPanel",
+        "operatorSessionRecallMemoryProposalForm",
+        "operatorSessionRecallMemoryProposalTargetKind",
+        "operatorSessionRecallMemoryProposalTargetSection",
+        "operatorSessionRecallMemoryProposalTargetName",
+        "operatorSessionRecallMemoryProposalTargetCategory",
+        "operatorSessionRecallMemoryProposalSummary",
+        "operatorSessionRecallMemoryProposalContent",
+        "operatorSessionRecallMemoryProposalStatus",
+    ]:
+        assert f'id="{element_id}"' in popover_form
+
+    for field_name in [
+        "target_kind",
+        "target_section",
+        "target_name",
+        "target_category",
+        "proposed_summary",
+        "proposed_content",
+    ]:
+        assert f'name="{field_name}"' in popover_form
+
+    for fake_value in [
+        "Proposed durable operator memory",
+        "Updated durable preference",
+        "sample",
+        "demo",
+        "fake",
+    ]:
+        assert fake_value not in popover_form
+
+
+def test_session_recall_values_use_text_content_not_inner_html_or_markdown():
+    js = _session_recall_js()
+
+    assert ".textContent" in js
+    assert "document.createElement" in js
+    for forbidden in [
+        ".innerHTML",
+        ".outerHTML",
+        "insertAdjacentHTML",
+        "renderMd(",
+        "renderMarkdown(",
+        "marked(",
+        "eval(",
+        "Function(",
+    ]:
+        assert forbidden not in js
+
+
+def test_session_recall_manual_search_no_polling_timers_or_eventsource():
+    js = _session_recall_js()
+
+    for forbidden in [
+        "setInterval",
+        "setTimeout",
+        "EventSource",
+        "WebSocket",
+        "Worker(",
+        "navigator.sendBeacon",
+    ]:
+        assert forbidden not in js
+
+    assert "DOMContentLoaded" not in js or not re.search(
+        r"DOMContentLoaded[\s\S]*refreshOperatorSessionRecall\s*\(",
+        js,
+    )
+    assert _top_level_calls(js, "refreshOperatorSessionRecall") == []
+
+
+def test_session_recall_renders_required_fields_and_honest_states():
+    js = _session_recall_js()
+
+    for required in [
+        "query",
+        "results",
+        "snippet",
+        "timestamp",
+        "session_id",
+        "source_label",
+        "historical",
+        "stale",
+        "unknown",
+        "would_execute",
+        "issues",
+    ]:
+        assert required in js
+
+
+def test_session_recall_memory_skill_review_proposal_payload_is_draft_only_and_source_backed():
+    js = _session_recall_js()
+    assert "_operatorSessionRecallMemoryReviewSourceEvidence" in js
+    assert "promotion.memory_review" in js
+    assert "source_evidence[0]" in js
+    assert "Draft memory/skill review" in js
+    assert "submitOperatorSessionRecallMemoryProposal" in js
+    assert "would_execute: false" in js
+    for required in [
+        "target",
+        "proposed_change",
+        "source_evidence",
+        "classification",
+        "stale_risk",
+        "would_execute",
+    ]:
+        assert required in js
+
+    start = js.index("function _operatorSessionRecallMemoryReviewSourceEvidence")
+    end = js.index("function _operatorSessionRecallCanPromoteMemoryReview", start)
+    extractor_body = js[start:end]
+    assert "session.title" not in extractor_body
+    assert "match.snippet" not in extractor_body
+
+
+def test_session_recall_task_promotion_uses_local_commitment_draft_not_kanban_or_chat():
+    js = _session_recall_js()
+
+    assert (
+        "openOperatorCommitmentPromoteFromRecall" in js
+        or "openOperatorCommitmentPromote" in js
+    )
+
+    for forbidden in [
+        "/api/kanban/",
+        "createKanbanTask",
+        "updateKanbanTask",
+        "addKanbanComment",
+        "runKanbanDispatcher",
+        "nudgeKanbanDispatcher",
+        "/api/chat",
+        "submitChat",
+        "startChat",
+        "sendMessage",
+        "window.send",
+        "/api/operator/commitments/promote",
+    ]:
+        assert forbidden not in js
+
+
+def test_session_recall_raw_secret_detection_rejects_github_pats_before_punctuation():
+    js = _session_recall_js()
+    start = js.index("function _operatorSessionRecallQuoteContainsRawSecret")
+    end = js.index("function _operatorSessionRecallCommitmentSource", start)
+    body = js[start:end]
+
+    assert "ghp_" in body
+    assert "github_pat_" in body
+    assert "(?![A-Za-z0-9_])" in body
+
+    root = Path(__file__).resolve().parents[1]
+    node_script = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert/strict');
+
+const source = fs.readFileSync('static/operator_session_recall.js', 'utf8');
+const context = {console, URLSearchParams, Date, Promise};
+context.window = context;
+context.$ = () => null;
+vm.createContext(context);
+vm.runInContext(source, context, {filename: 'operator_session_recall.js'});
+
+const classic = 'ghp_' + 'A'.repeat(36);
+const fineGrained = 'github_pat_' + 'B'.repeat(22) + '_' + 'C'.repeat(59);
+for (const [label, token] of [['classic', classic], ['fine-grained', fineGrained]]) {
+  for (const [delimiterLabel, suffix] of [
+    ['period', '.'],
+    ['close paren', ')'],
+    ['close bracket', ']'],
+    ['double quote', '"'],
+    ['newline', '\nnext line'],
+  ]) {
+    assert.equal(
+      context._operatorSessionRecallQuoteContainsRawSecret(token + suffix),
+      true,
+      label + ' token followed by ' + delimiterLabel + ' must be treated as raw secret',
+    );
+  }
+}
+assert.equal(
+  context._operatorSessionRecallQuoteContainsRawSecret('github_pat_[redacted].'),
+  false,
+  'redacted GitHub PAT placeholders must remain allowed next to punctuation',
+);
+"""
+    completed = subprocess.run(
+        ["node", "-e", node_script],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_session_recall_task_promotion_requires_explicit_safe_session_message_proof():
+    root = Path(__file__).resolve().parents[1]
+    node_script = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert/strict');
+
+const source = fs.readFileSync('static/operator_session_recall.js', 'utf8');
+
+class ClassList {
+  constructor(element) {
+    this.element = element;
+    this.values = new Set();
+  }
+  add(...names) {
+    names.forEach(name => this.values.add(name));
+    this._sync();
+  }
+  remove(...names) {
+    names.forEach(name => this.values.delete(name));
+    this._sync();
+  }
+  contains(name) {
+    return this.values.has(name);
+  }
+  _sync() {
+    this.element.className = Array.from(this.values).join(' ');
+  }
+}
+
+class Element {
+  constructor(id = '', tagName = 'div') {
+    this.id = id;
+    this.tagName = String(tagName).toUpperCase();
+    this.children = [];
+    this.parentNode = null;
+    this.dataset = {};
+    this.hidden = false;
+    this.title = '';
+    this.value = '';
+    this.listeners = {};
+    this._textContent = '';
+    this.className = '';
+    this.classList = new ClassList(this);
+  }
+  get firstChild() {
+    return this.children[0] || null;
+  }
+  append(...nodes) {
+    nodes.forEach(node => this.appendChild(node));
+  }
+  appendChild(node) {
+    if (typeof node === 'string') {
+      const textNode = new Element('', '#text');
+      textNode.textContent = node;
+      node = textNode;
+    }
+    this.children.push(node);
+    node.parentNode = this;
+    return node;
+  }
+  removeChild(node) {
+    const index = this.children.indexOf(node);
+    if (index >= 0) {
+      this.children.splice(index, 1);
+      node.parentNode = null;
+    }
+    return node;
+  }
+  addEventListener(type, handler) {
+    this.listeners[type] = handler;
+  }
+  focus() {}
+  set textContent(value) {
+    this._textContent = String(value == null ? '' : value);
+    this.children = [];
+  }
+  get textContent() {
+    return this._textContent + this.children.map(child => child.textContent).join('');
+  }
+}
+
+const elements = new Map();
+function register(id) {
+  const element = new Element(id);
+  elements.set(id, element);
+  return element;
+}
+[
+  'operatorSessionRecallInput',
+  'operatorSessionRecallChip',
+  'operatorSessionRecallLabel',
+  'operatorSessionRecallPopover',
+  'operatorSessionRecallStatus',
+  'operatorSessionRecallList',
+].forEach(register);
+
+const document = {
+  getElementById(id) {
+    return elements.get(id) || null;
+  },
+  createElement(tagName) {
+    return new Element('', tagName);
+  },
+};
+
+const context = {console, document, URLSearchParams, Date, Promise};
+context.window = context;
+context.$ = id => document.getElementById(id);
+
+vm.createContext(context);
+vm.runInContext(source, context, {filename: 'operator_session_recall.js'});
+
+const completeSource = suffix => ({
+  kind: 'session_message',
+  session_id: 'session-' + suffix,
+  message_index: 0,
+  content_hash: 'sha256:' + 'a'.repeat(64),
+  quote: 'source quote ' + suffix,
+});
+
+context.renderOperatorSessionRecall({
+  status: 'live',
+  summary: 'session recall regression payload',
+  query: {text: 'promote safety'},
+  sources: [],
+  results: [
+    {
+      session: {title: 'Missing explicit safe false', session_id: 'session-missing', source_label: 'saved sessions'},
+      match: {snippet: 'malformed missing safe mode snippet', timestamp: 1710000000},
+      recency: {label: 'live'},
+      promotion: {
+        task: {
+          enabled: true,
+          mode: 'local_commitment_draft',
+          source: completeSource('missing'),
+        },
+      },
+    },
+    {
+      session: {title: 'Task string unsafe true', session_id: 'session-task-string', source_label: 'saved sessions'},
+      match: {snippet: 'malformed task string true snippet', timestamp: 1710000001},
+      recency: {label: 'live'},
+      promotion: {
+        task: {
+          enabled: true,
+          mode: 'local_commitment_draft',
+          would_execute: 'true',
+          source: completeSource('task-string'),
+        },
+      },
+    },
+    {
+      session: {title: 'Top level string unsafe true', session_id: 'session-top-string', source_label: 'saved sessions'},
+      match: {snippet: 'malformed top string true snippet', timestamp: 1710000002},
+      recency: {label: 'live'},
+      would_execute: 'true',
+      promotion: {
+        task: {
+          enabled: true,
+          mode: 'local_commitment_draft',
+          would_execute: false,
+          source: completeSource('top-string'),
+        },
+      },
+    },
+    {
+      session: {title: 'Top level numeric unsafe truthy', session_id: 'session-top-numeric', source_label: 'saved sessions'},
+      match: {snippet: 'malformed top numeric truthy snippet', timestamp: 1710000003},
+      recency: {label: 'live'},
+      would_execute: 1,
+      promotion: {
+        task: {
+          enabled: true,
+          mode: 'local_commitment_draft',
+          would_execute: false,
+          source: completeSource('top-numeric'),
+        },
+      },
+    },
+    {
+      session: {title: 'Malformed message index proof', session_id: 'session-bad-index', source_label: 'saved sessions'},
+      match: {snippet: 'bad message index proof snippet', timestamp: 1710000004},
+      recency: {label: 'live'},
+      promotion: {
+        task: {
+          enabled: true,
+          mode: 'local_commitment_draft',
+          would_execute: false,
+          source: {...completeSource('bad-index'), message_index: 'not-an-index'},
+        },
+      },
+    },
+    {
+      session: {title: 'Malformed content hash proof', session_id: 'session-bad-hash', source_label: 'saved sessions'},
+      match: {snippet: 'bad content hash proof snippet', timestamp: 1710000005},
+      recency: {label: 'live'},
+      promotion: {
+        task: {
+          enabled: true,
+          mode: 'local_commitment_draft',
+          would_execute: false,
+          source: {...completeSource('bad-hash'), content_hash: 'not-a-hash'},
+        },
+      },
+    },
+    {
+      session: {title: 'Raw Bearer quote proof', session_id: 'session-raw-bearer', source_label: 'saved sessions'},
+      match: {snippet: 'raw bearer quote proof snippet', timestamp: 1710000006},
+      recency: {label: 'live'},
+      promotion: {
+        task: {
+          enabled: true,
+          mode: 'local_commitment_draft',
+          would_execute: false,
+          source: {...completeSource('raw-bearer'), quote: 'Bearer abcdefghijklmnop12345'},
+        },
+      },
+    },
+    {
+      session: {title: 'Synthesized fallback proof is not proof', session_id: 'session-synthesized-fallback', source_label: 'saved sessions'},
+      match: {
+        message_index: 0,
+        content_hash: 'sha256:' + 'b'.repeat(64),
+        snippet: 'valid-looking fallback quote must not become source proof',
+        timestamp: 1710000007,
+      },
+      recency: {label: 'live'},
+      promotion: {
+        task: {
+          enabled: true,
+          mode: 'local_commitment_draft',
+          would_execute: false,
+          source: {kind: 'session_message'},
+        },
+      },
+    },
+    {
+      session: {title: 'Valid safe local draft', session_id: 'session-valid', source_label: 'saved sessions'},
+      match: {snippet: 'valid safe snippet', timestamp: 1710000008},
+      recency: {label: 'live'},
+      promotion: {
+        task: {
+          enabled: true,
+          mode: 'local_commitment_draft',
+          would_execute: false,
+          source: completeSource('valid'),
+        },
+      },
+    },
+  ],
+  count: 9,
+  issues: [],
+  would_execute: false,
+});
+
+const list = elements.get('operatorSessionRecallList');
+function cardText(title) {
+  const card = list.children.find(child => child.textContent.includes(title));
+  assert.ok(card, 'missing rendered card for ' + title + '\n' + list.textContent);
+  return card.textContent;
+}
+
+const missingSafeText = cardText('Missing explicit safe false');
+assert.doesNotMatch(missingSafeText, /Draft local task/, 'missing promotion.task.would_execute must not render a local task draft');
+assert.doesNotMatch(missingSafeText, /would_execute=false/, 'missing explicit safe false must not be displayed as would_execute=false');
+
+const taskStringText = cardText('Task string unsafe true');
+assert.doesNotMatch(taskStringText, /Draft local task/, 'string true task would_execute must not render a local task draft');
+assert.doesNotMatch(taskStringText, /would_execute=false/, 'string true task would_execute must not be displayed as false');
+assert.match(taskStringText, /would_execute=true/, 'string true task would_execute must be treated as unsafe');
+
+const topStringText = cardText('Top level string unsafe true');
+assert.doesNotMatch(topStringText, /Draft local task/, 'string true top-level would_execute must not render a local task draft');
+assert.doesNotMatch(topStringText, /would_execute=false/, 'string true top-level would_execute must not be displayed as false');
+assert.match(topStringText, /would_execute=true/, 'string true top-level would_execute must be treated as unsafe');
+
+const topNumericText = cardText('Top level numeric unsafe truthy');
+assert.doesNotMatch(topNumericText, /Draft local task/, 'numeric truthy top-level would_execute must not render a local task draft');
+assert.doesNotMatch(topNumericText, /would_execute=false/, 'numeric truthy top-level would_execute must not be displayed as false');
+
+const badIndexText = cardText('Malformed message index proof');
+assert.doesNotMatch(badIndexText, /Draft local task/, 'malformed message_index proof must not render a local task draft');
+
+const badHashText = cardText('Malformed content hash proof');
+assert.doesNotMatch(badHashText, /Draft local task/, 'malformed content_hash proof must not render a local task draft');
+
+const rawBearerText = cardText('Raw Bearer quote proof');
+assert.doesNotMatch(rawBearerText, /Draft local task/, 'raw bearer session_message quote must not render a local task draft');
+
+const synthesizedFallbackText = cardText('Synthesized fallback proof is not proof');
+assert.doesNotMatch(synthesizedFallbackText, /Draft local task/, 'valid-looking session/match fallback fields must not synthesize source proof');
+
+const validText = cardText('Valid safe local draft');
+assert.match(validText, /Draft local task/, 'valid explicit false session-message proof may render a local task draft');
+assert.match(validText, /would_execute=false/, 'valid explicit false session-message proof may display would_execute=false');
+"""
+
+    completed = subprocess.run(
+        ["node", "-e", node_script],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_session_recall_memory_skill_review_proposal_requires_user_fields_and_posts_draft_only():
+    root = Path(__file__).resolve().parents[1]
+    node_script = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert/strict');
+
+const source = fs.readFileSync('static/operator_session_recall.js', 'utf8');
+
+class ClassList {
+  constructor(element) {
+    this.element = element;
+    this.values = new Set();
+  }
+  add(...names) {
+    names.forEach(name => this.values.add(name));
+    this._sync();
+  }
+  remove(...names) {
+    names.forEach(name => this.values.delete(name));
+    this._sync();
+  }
+  contains(name) {
+    return this.values.has(name);
+  }
+  _sync() {
+    this.element.className = Array.from(this.values).join(' ');
+  }
+}
+
+class Element {
+  constructor(id = '', tagName = 'div') {
+    this.id = id;
+    this.tagName = String(tagName).toUpperCase();
+    this.children = [];
+    this.parentNode = null;
+    this.dataset = {};
+    this.hidden = false;
+    this.title = '';
+    this.value = '';
+    this.name = '';
+    this.type = '';
+    this.listeners = {};
+    this._textContent = '';
+    this.className = '';
+    this.classList = new ClassList(this);
+  }
+  get firstChild() {
+    return this.children[0] || null;
+  }
+  append(...nodes) {
+    nodes.forEach(node => this.appendChild(node));
+  }
+  appendChild(node) {
+    if (typeof node === 'string') {
+      const textNode = new Element('', '#text');
+      textNode.textContent = node;
+      node = textNode;
+    }
+    this.children.push(node);
+    node.parentNode = this;
+    return node;
+  }
+  removeChild(node) {
+    const index = this.children.indexOf(node);
+    if (index >= 0) {
+      this.children.splice(index, 1);
+      node.parentNode = null;
+    }
+    return node;
+  }
+  addEventListener(type, handler) {
+    this.listeners[type] = handler;
+  }
+  focus() {}
+  set textContent(value) {
+    this._textContent = String(value == null ? '' : value);
+    this.children = [];
+  }
+  get textContent() {
+    return this._textContent + this.children.map(child => child.textContent).join('');
+  }
+}
+
+const elements = new Map();
+function register(id, value = '') {
+  const element = new Element(id);
+  element.value = value;
+  elements.set(id, element);
+  return element;
+}
+[
+  'operatorSessionRecallInput',
+  'operatorSessionRecallChip',
+  'operatorSessionRecallLabel',
+  'operatorSessionRecallPopover',
+  'operatorSessionRecallStatus',
+  'operatorSessionRecallList',
+  'operatorSessionRecallMemoryProposalPanel',
+  'operatorSessionRecallMemoryProposalForm',
+  'operatorSessionRecallMemoryProposalStatus',
+  'operatorSessionRecallMemoryProposalTargetKind',
+  'operatorSessionRecallMemoryProposalTargetSection',
+  'operatorSessionRecallMemoryProposalTargetName',
+  'operatorSessionRecallMemoryProposalTargetCategory',
+  'operatorSessionRecallMemoryProposalOperation',
+  'operatorSessionRecallMemoryProposalSummary',
+  'operatorSessionRecallMemoryProposalContent',
+  'operatorSessionRecallMemoryProposalClassificationDurability',
+  'operatorSessionRecallMemoryProposalClassificationReason',
+  'operatorSessionRecallMemoryProposalTransientRisk',
+  'operatorSessionRecallMemoryProposalStaleState',
+  'operatorSessionRecallMemoryProposalExpiresAt',
+  'operatorSessionRecallMemoryProposalStaleReason',
+  'operatorSessionRecallMemoryProposalEvidenceSessionId',
+  'operatorSessionRecallMemoryProposalEvidenceMessageIndex',
+  'operatorSessionRecallMemoryProposalEvidenceContentHash',
+  'operatorSessionRecallMemoryProposalEvidenceQuote',
+].forEach(id => register(id));
+elements.get('operatorSessionRecallMemoryProposalPanel').hidden = true;
+elements.get('operatorSessionRecallMemoryProposalOperation').value = 'append';
+elements.get('operatorSessionRecallMemoryProposalClassificationDurability').value = 'durable';
+elements.get('operatorSessionRecallMemoryProposalTransientRisk').value = 'low';
+elements.get('operatorSessionRecallMemoryProposalStaleState').value = 'current';
+
+const document = {
+  getElementById(id) {
+    return elements.get(id) || null;
+  },
+  createElement(tagName) {
+    return new Element('', tagName);
+  },
+};
+
+const apiCalls = [];
+const refreshCalls = [];
+const context = {
+  console,
+  document,
+  URLSearchParams,
+  Date,
+  Promise,
+  api(url, options) {
+    apiCalls.push({url, options: options || {}});
+    return Promise.resolve({ok: true, id: 'msr_from_recall', would_execute: false});
+  },
+  refreshOperatorMemorySkillReview(options) {
+    refreshCalls.push(options);
+    return Promise.resolve({ok: true});
+  },
+};
+context.window = context;
+context.$ = id => document.getElementById(id);
+
+vm.createContext(context);
+vm.runInContext(source, context, {filename: 'operator_session_recall.js'});
+
+const sourceEvidence = {
+  kind: 'session_message',
+  session_id: 'recall-session-1',
+  message_index: 7,
+  content_hash: 'sha256:' + 'c'.repeat(64),
+  quote: 'Please remember that I prefer concise release summaries.',
+};
+
+context.renderOperatorSessionRecall({
+  status: 'live',
+  summary: 'one source-backed memory proposal',
+  query: {text: 'release summaries'},
+  sources: [],
+  results: [{
+    session: {title: 'Release summary preference', session_id: 'recall-session-1', source_label: 'saved sessions'},
+    match: {snippet: 'This snippet must not become proposal content.', timestamp: 1710000000},
+    recency: {label: 'live'},
+    would_execute: false,
+    promotion: {
+      memory_review: {
+        enabled: true,
+        mode: 'local_memory_skill_review_proposal',
+        would_execute: false,
+        source_evidence: [sourceEvidence],
+      },
+    },
+  }],
+  count: 1,
+  issues: [],
+  would_execute: false,
+});
+
+const list = elements.get('operatorSessionRecallList');
+function walk(node, out = []) {
+  out.push(node);
+  node.children.forEach(child => walk(child, out));
+  return out;
+}
+const memoryButton = walk(list).find(node => node.tagName === 'BUTTON' && /Draft memory\/skill review/.test(node.textContent));
+assert.ok(memoryButton, 'eligible recall result must render Draft memory/skill review action');
+assert.equal(apiCalls.length, 0, 'rendering/opening must not POST');
+memoryButton.listeners.click({preventDefault(){}});
+
+assert.equal(elements.get('operatorSessionRecallMemoryProposalPanel').hidden, false, 'click opens inline proposal form');
+assert.equal(elements.get('operatorSessionRecallMemoryProposalEvidenceSessionId').textContent, sourceEvidence.session_id);
+assert.equal(elements.get('operatorSessionRecallMemoryProposalEvidenceMessageIndex').textContent, String(sourceEvidence.message_index));
+assert.equal(elements.get('operatorSessionRecallMemoryProposalEvidenceContentHash').textContent, sourceEvidence.content_hash);
+assert.equal(elements.get('operatorSessionRecallMemoryProposalEvidenceQuote').textContent, sourceEvidence.quote);
+assert.equal(elements.get('operatorSessionRecallMemoryProposalTargetKind').value, '', 'target kind is user-entered only');
+assert.equal(elements.get('operatorSessionRecallMemoryProposalTargetSection').value, '', 'target section is user-entered only');
+assert.equal(elements.get('operatorSessionRecallMemoryProposalTargetName').value, '', 'target name is user-entered only');
+assert.equal(elements.get('operatorSessionRecallMemoryProposalTargetCategory').value, '', 'target category is user-entered only');
+assert.equal(elements.get('operatorSessionRecallMemoryProposalSummary').value, '', 'summary is user-entered only');
+assert.equal(elements.get('operatorSessionRecallMemoryProposalContent').value, '', 'content is user-entered only');
+
+(async () => {
+  await context.submitOperatorSessionRecallMemoryProposal({preventDefault(){}});
+  assert.equal(apiCalls.length, 0, 'submit without user target/proposed fields must not call API');
+  assert.match(elements.get('operatorSessionRecallMemoryProposalStatus').textContent, /target/i);
+
+  elements.get('operatorSessionRecallMemoryProposalTargetKind').value = 'memory';
+  elements.get('operatorSessionRecallMemoryProposalTargetSection').value = 'memory';
+  elements.get('operatorSessionRecallMemoryProposalSummary').value = 'Remember concise release summary preference.';
+  elements.get('operatorSessionRecallMemoryProposalContent').value = 'The user prefers concise release summaries.';
+  elements.get('operatorSessionRecallMemoryProposalClassificationReason').value = 'The user stated a durable writing preference.';
+  elements.get('operatorSessionRecallMemoryProposalExpiresAt').value = '2026-06-10T00:00:00Z';
+  elements.get('operatorSessionRecallMemoryProposalStaleReason').value = 'Preference remains current unless superseded.';
+
+  const result = await context.submitOperatorSessionRecallMemoryProposal({preventDefault(){}});
+  assert.equal(result.ok, true);
+  assert.equal(apiCalls.length, 1, 'filled form must call one local proposal API');
+  assert.equal(apiCalls[0].url, '/api/operator/memory-skill-review/propose');
+  const body = JSON.parse(apiCalls[0].options.body);
+  assert.equal(apiCalls[0].options.method, 'POST');
+  assert.equal(body.would_execute, false);
+  assert.deepEqual(body.source_evidence, [sourceEvidence], 'proposal must preserve exact session-message proof');
+  assert.deepEqual(body.target, {kind: 'memory', section: 'memory'});
+  assert.equal(body.proposed_change.operation, 'append');
+  assert.equal(body.proposed_change.summary, 'Remember concise release summary preference.');
+  assert.equal(body.proposed_change.proposed_content, 'The user prefers concise release summaries.');
+  assert.equal(body.classification.durability, 'durable');
+  assert.equal(body.classification.reason, 'The user stated a durable writing preference.');
+  assert.equal(body.classification.transient_risk, 'low');
+  assert.equal(body.stale_risk.state, 'current');
+  assert.equal(body.stale_risk.expires_at, '2026-06-10T00:00:00Z');
+  assert.equal(body.stale_risk.reason, 'Preference remains current unless superseded.');
+  assert.doesNotMatch(JSON.stringify(body), /This snippet must not become proposal content/);
+  assert.equal(
+    JSON.stringify(refreshCalls),
+    JSON.stringify([{force: true}]),
+    'successful proposal refreshes local review queue when available',
+  );
+})().catch(error => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});
+"""
+
+    completed = subprocess.run(
+        ["node", "-e", node_script],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_session_recall_memory_skill_review_proposal_refuses_missing_or_raw_secret_proof():
+    root = Path(__file__).resolve().parents[1]
+    node_script = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert/strict');
+
+const source = fs.readFileSync('static/operator_session_recall.js', 'utf8');
+class ClassList {
+  constructor(element) { this.element = element; this.values = new Set(); }
+  add(...names) { names.forEach(name => this.values.add(name)); this._sync(); }
+  remove(...names) { names.forEach(name => this.values.delete(name)); this._sync(); }
+  contains(name) { return this.values.has(name); }
+  _sync() { this.element.className = Array.from(this.values).join(' '); }
+}
+class Element {
+  constructor(id = '', tagName = 'div') {
+    this.id = id;
+    this.tagName = String(tagName).toUpperCase();
+    this.children = [];
+    this.parentNode = null;
+    this.dataset = {};
+    this.hidden = false;
+    this.title = '';
+    this.value = '';
+    this.listeners = {};
+    this._textContent = '';
+    this.className = '';
+    this.classList = new ClassList(this);
+  }
+  get firstChild() { return this.children[0] || null; }
+  append(...nodes) { nodes.forEach(node => this.appendChild(node)); }
+  appendChild(node) {
+    if (typeof node === 'string') {
+      const textNode = new Element('', '#text');
+      textNode.textContent = node;
+      node = textNode;
+    }
+    this.children.push(node);
+    node.parentNode = this;
+    return node;
+  }
+  removeChild(node) {
+    const index = this.children.indexOf(node);
+    if (index >= 0) { this.children.splice(index, 1); node.parentNode = null; }
+    return node;
+  }
+  addEventListener(type, handler) { this.listeners[type] = handler; }
+  focus() {}
+  set textContent(value) { this._textContent = String(value == null ? '' : value); this.children = []; }
+  get textContent() { return this._textContent + this.children.map(child => child.textContent).join(''); }
+}
+const elements = new Map();
+function register(id) { const element = new Element(id); elements.set(id, element); return element; }
+[
+  'operatorSessionRecallInput',
+  'operatorSessionRecallChip',
+  'operatorSessionRecallLabel',
+  'operatorSessionRecallPopover',
+  'operatorSessionRecallStatus',
+  'operatorSessionRecallList',
+  'operatorSessionRecallMemoryProposalPanel',
+  'operatorSessionRecallMemoryProposalForm',
+  'operatorSessionRecallMemoryProposalStatus',
+  'operatorSessionRecallMemoryProposalEvidenceSessionId',
+  'operatorSessionRecallMemoryProposalEvidenceMessageIndex',
+  'operatorSessionRecallMemoryProposalEvidenceContentHash',
+  'operatorSessionRecallMemoryProposalEvidenceQuote',
+].forEach(register);
+const document = {
+  getElementById(id) { return elements.get(id) || null; },
+  createElement(tagName) { return new Element('', tagName); },
+};
+const apiCalls = [];
+const context = {console, document, URLSearchParams, Date, Promise, api(url, options){ apiCalls.push({url, options}); return Promise.resolve({ok:true}); }};
+context.window = context;
+context.$ = id => document.getElementById(id);
+vm.createContext(context);
+vm.runInContext(source, context, {filename: 'operator_session_recall.js'});
+
+const proof = {
+  kind: 'session_message',
+  session_id: 'session-safe',
+  message_index: 1,
+  content_hash: 'sha256:' + 'd'.repeat(64),
+  quote: 'safe quote',
+};
+const missingProof = {
+  session: {title: 'Missing proof', session_id: 'session-missing', source_label: 'saved sessions'},
+  match: {message_index: 0, content_hash: 'sha256:' + 'e'.repeat(64), snippet: 'fallback snippet is not source proof'},
+  recency: {label: 'live'},
+  would_execute: false,
+  promotion: {memory_review: {enabled: true, mode: 'local_memory_skill_review_proposal', would_execute: false}},
+};
+const rawSecretProof = {
+  session: {title: 'Raw secret proof', session_id: 'session-secret', source_label: 'saved sessions'},
+  match: {snippet: 'secret snippet', timestamp: 1710000001},
+  recency: {label: 'live'},
+  would_execute: false,
+  promotion: {memory_review: {enabled: true, mode: 'local_memory_skill_review_proposal', would_execute: false, source_evidence: [{...proof, quote: 'password=hunter2.'}]}},
+};
+const objectFieldProof = {
+  session: {title: 'Object field proof', session_id: 'session-object', source_label: 'saved sessions'},
+  match: {snippet: 'object snippet', timestamp: 1710000002},
+  recency: {label: 'live'},
+  would_execute: false,
+  promotion: {memory_review: {enabled: true, mode: 'local_memory_skill_review_proposal', would_execute: false, source_evidence: [{...proof, session_id: {value: 'session-object'}, quote: {text: 'safe quote'}}]}},
+};
+context.renderOperatorSessionRecall({
+  status: 'live',
+  summary: 'malformed proposals',
+  query: {text: 'bad proofs'},
+  sources: [],
+  results: [missingProof, rawSecretProof, objectFieldProof],
+  count: 3,
+  issues: [],
+  would_execute: false,
+});
+const list = elements.get('operatorSessionRecallList');
+assert.match(list.textContent, /Missing proof/);
+assert.match(list.textContent, /Raw secret proof/);
+assert.doesNotMatch(list.textContent, /Draft memory\/skill review/, 'malformed or raw-secret proofs must not render memory proposal buttons');
+assert.equal(context.openOperatorSessionRecallMemoryProposal(missingProof), false, 'missing source_evidence must be refused even with fallback fields');
+assert.equal(context.openOperatorSessionRecallMemoryProposal(rawSecretProof), false, 'raw secret source quote must be refused');
+assert.equal(context.openOperatorSessionRecallMemoryProposal(objectFieldProof), false, 'object session_id/quote proof fields must be refused before coercion');
+assert.equal(apiCalls.length, 0, 'refused proposal must not call API');
+"""
+
+    completed = subprocess.run(
+        ["node", "-e", node_script],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_session_recall_blank_search_invalidates_pending_results():
+    root = Path(__file__).resolve().parents[1]
+    node_script = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert/strict');
+
+const source = fs.readFileSync('static/operator_session_recall.js', 'utf8');
+
+class ClassList {
+  constructor(element) {
+    this.element = element;
+    this.values = new Set();
+  }
+  add(...names) {
+    names.forEach(name => this.values.add(name));
+    this._sync();
+  }
+  remove(...names) {
+    names.forEach(name => this.values.delete(name));
+    this._sync();
+  }
+  contains(name) {
+    return this.values.has(name);
+  }
+  _sync() {
+    this.element.className = Array.from(this.values).join(' ');
+  }
+}
+
+class Element {
+  constructor(id = '', tagName = 'div') {
+    this.id = id;
+    this.tagName = String(tagName).toUpperCase();
+    this.children = [];
+    this.parentNode = null;
+    this.dataset = {};
+    this.hidden = false;
+    this.title = '';
+    this.value = '';
+    this.listeners = {};
+    this._textContent = '';
+    this.className = '';
+    this.classList = new ClassList(this);
+  }
+  get firstChild() {
+    return this.children[0] || null;
+  }
+  append(...nodes) {
+    nodes.forEach(node => this.appendChild(node));
+  }
+  appendChild(node) {
+    if (typeof node === 'string') {
+      const textNode = new Element('', '#text');
+      textNode.textContent = node;
+      node = textNode;
+    }
+    this.children.push(node);
+    node.parentNode = this;
+    return node;
+  }
+  removeChild(node) {
+    const index = this.children.indexOf(node);
+    if (index >= 0) {
+      this.children.splice(index, 1);
+      node.parentNode = null;
+    }
+    return node;
+  }
+  addEventListener(type, handler) {
+    this.listeners[type] = handler;
+  }
+  focus() {}
+  set textContent(value) {
+    this._textContent = String(value == null ? '' : value);
+    this.children = [];
+  }
+  get textContent() {
+    return this._textContent + this.children.map(child => child.textContent).join('');
+  }
+}
+
+const elements = new Map();
+function register(id) {
+  const element = new Element(id);
+  elements.set(id, element);
+  return element;
+}
+[
+  'operatorSessionRecallInput',
+  'operatorSessionRecallChip',
+  'operatorSessionRecallLabel',
+  'operatorSessionRecallPopover',
+  'operatorSessionRecallStatus',
+  'operatorSessionRecallList',
+].forEach(register);
+
+elements.get('operatorSessionRecallPopover').hidden = false;
+
+const document = {
+  getElementById(id) {
+    return elements.get(id) || null;
+  },
+  createElement(tagName) {
+    return new Element('', tagName);
+  },
+};
+
+let resolveApi;
+const apiCalls = [];
+const apiPromise = new Promise(resolve => {
+  resolveApi = resolve;
+});
+
+const context = {
+  console,
+  document,
+  URLSearchParams,
+  Date,
+  Promise,
+  api(url) {
+    apiCalls.push(url);
+    return apiPromise;
+  },
+};
+context.window = context;
+context.$ = id => document.getElementById(id);
+
+vm.createContext(context);
+vm.runInContext(source, context, {filename: 'operator_session_recall.js'});
+
+(async () => {
+  const input = elements.get('operatorSessionRecallInput');
+  const popover = elements.get('operatorSessionRecallPopover');
+  const status = elements.get('operatorSessionRecallStatus');
+  const list = elements.get('operatorSessionRecallList');
+
+  input.value = 'needle';
+  const original = context.refreshOperatorSessionRecall();
+
+  input.value = '';
+  await context.refreshOperatorSessionRecall();
+
+  assert.equal(apiCalls.length, 1, 'blank search should not call the API');
+  assert.ok(popover.classList.contains('state-unknown'), 'blank search should render unknown state');
+  assert.match(status.textContent, /no source queried yet/i);
+  assert.match(list.textContent, /query is required for session recall/i);
+  assert.doesNotMatch(list.textContent, /old snippet/i);
+
+  resolveApi({
+    status: 'live',
+    summary: 'old response',
+    query: {text: 'needle'},
+    sources: [],
+    results: [{
+      session: {
+        title: 'Old Session',
+        session_id: 'old-session',
+        source_label: 'saved sessions',
+      },
+      match: {
+        snippet: 'old snippet',
+        timestamp: 1710000000,
+      },
+      recency: {label: 'historical'},
+      would_execute: false,
+    }],
+    count: 1,
+    issues: [],
+    would_execute: false,
+  });
+  await original;
+  await Promise.resolve();
+
+  assert.ok(
+    popover.classList.contains('state-unknown'),
+    'stale response must not replace blank unknown state',
+  );
+  assert.match(status.textContent, /no source queried yet/i);
+  assert.match(list.textContent, /query is required for session recall/i);
+  assert.doesNotMatch(
+    list.textContent,
+    /old snippet/i,
+    'stale in-flight response rendered old snippet after blank search',
+  );
+})().catch(error => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});
+"""
+
+    completed = subprocess.run(
+        ["node", "-e", node_script],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/test_operator_truth.py
+++ b/tests/test_operator_truth.py
@@ -1,0 +1,350 @@
+import importlib
+import io
+import json
+import sys
+import types
+from pathlib import Path
+from urllib.parse import urlparse
+from unittest.mock import patch
+
+
+def _chip(payload, chip_id):
+    for chip in payload.get("chips", []):
+        if chip.get("id") == chip_id:
+            return chip
+    raise AssertionError(f"missing chip {chip_id!r}: {payload.get('chips')!r}")
+
+
+def _install_fake_kanban(
+    monkeypatch,
+    tmp_path,
+    *,
+    current="hermes-operator",
+    existing_boards=None,
+    default_workdir=None,
+):
+    existing = set(existing_boards if existing_boards is not None else {current, "default"})
+    hermes_home = tmp_path / "hermes-home"
+    kanban_root = hermes_home / "kanban"
+    current_file = kanban_root / "current"
+    current_file.parent.mkdir(parents=True, exist_ok=True)
+    if current is not None:
+        current_file.write_text(current + "\n", encoding="utf-8")
+
+    fake = types.ModuleType("hermes_cli.kanban_db")
+    calls = []
+
+    def _board_dir(slug):
+        return kanban_root / "boards" / (slug or "default")
+
+    def current_board_path():
+        return current_file
+
+    def board_exists(slug=None):
+        return (slug or "default") in existing
+
+    def board_metadata_path(slug=None):
+        return _board_dir(slug) / "board.json"
+
+    def kanban_db_path(slug=None):
+        return _board_dir(slug) / "kanban.db"
+
+    def workspaces_root(slug=None):
+        return kanban_root / "workspaces" / (slug or "default")
+
+    def read_board_metadata(slug=None):
+        board = slug or "default"
+        return {
+            "slug": board,
+            "name": board,
+            "default_workdir": str(default_workdir) if default_workdir is not None else str(workspaces_root(board)),
+        }
+
+    for board in existing:
+        metadata_path = board_metadata_path(board)
+        metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        metadata_path.write_text('{"slug":"%s"}' % board, encoding="utf-8")
+        kanban_db_path(board).touch()
+
+    def forbidden_write(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("truth endpoint must be read-only")
+
+    setattr(fake, "current_board_path", current_board_path)
+    setattr(fake, "board_exists", board_exists)
+    setattr(fake, "board_metadata_path", board_metadata_path)
+    setattr(fake, "kanban_db_path", kanban_db_path)
+    setattr(fake, "workspaces_root", workspaces_root)
+    setattr(fake, "read_board_metadata", read_board_metadata)
+    setattr(fake, "clear_current_board", forbidden_write)
+    setattr(fake, "set_current_board", forbidden_write)
+    setattr(fake, "init_db", forbidden_write)
+    setattr(fake, "_write_calls", calls)
+
+    fake_pkg = types.ModuleType("hermes_cli")
+    setattr(fake_pkg, "kanban_db", fake)
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.kanban_db", fake)
+    return fake
+
+
+def _patch_common_sources(monkeypatch, tmp_path, workspace_path):
+    import api.config as config
+    import api.models as models
+    import api.profiles as profiles
+    import api.workspace as workspace
+
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+
+    state_dir = tmp_path / "webui-state"
+    session_dir = state_dir / "sessions"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    session_dir.mkdir(parents=True, exist_ok=True)
+    session_file = session_dir / "abc123.json"
+    session_file.write_text("{}", encoding="utf-8")
+    workspaces_file = state_dir / "workspaces.json"
+    workspaces_file.write_text("[]", encoding="utf-8")
+    last_workspace_file = state_dir / "last_workspace.txt"
+    last_workspace_file.write_text(str(workspace_path), encoding="utf-8")
+
+    monkeypatch.setattr(config, "STATE_DIR", state_dir, raising=False)
+    monkeypatch.setattr(config, "SESSION_DIR", session_dir, raising=False)
+    monkeypatch.setattr(config, "DEFAULT_WORKSPACE", workspace_path, raising=False)
+    monkeypatch.setattr(workspace, "_workspaces_file", lambda: workspaces_file, raising=False)
+    monkeypatch.setattr(workspace, "_last_workspace_file", lambda: last_workspace_file, raising=False)
+    monkeypatch.setattr(workspace, "get_last_workspace", lambda: str(workspace_path), raising=False)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default", raising=False)
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: hermes_home, raising=False)
+    monkeypatch.setattr(
+        models,
+        "get_session",
+        lambda sid, metadata_only=False: types.SimpleNamespace(
+            session_id=sid,
+            workspace=str(workspace_path),
+            path=session_file,
+        ),
+        raising=False,
+    )
+    return state_dir
+
+
+def test_operator_truth_payload_has_version_timestamp_status_and_chips(monkeypatch, tmp_path):
+    truth = importlib.import_module("api.operator_truth")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _patch_common_sources(monkeypatch, tmp_path, workspace)
+    _install_fake_kanban(monkeypatch, tmp_path)
+
+    payload = truth.build_operator_truth_payload(session_id="abc123", now=1234.5)
+
+    assert payload["version"] == 1
+    assert payload["verified_at"] == 1234.5
+    assert payload["status"] == "live"
+    assert payload["ttl_seconds"] == 30
+    assert payload["summary"] == "Truth live"
+    assert {chip["id"] for chip in payload["chips"]} >= {
+        "workspace",
+        "profile",
+        "webui_state",
+        "kanban_board",
+        "scratch_safety",
+        "source_truth_files",
+    }
+    assert isinstance(payload["sources"], list)
+    assert all(chip.get("checked_at") == 1234.5 for chip in payload["chips"])
+
+
+def test_operator_truth_workspace_uses_session_workspace_when_session_id_present(monkeypatch, tmp_path):
+    truth = importlib.import_module("api.operator_truth")
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    _patch_common_sources(monkeypatch, tmp_path, workspace)
+    _install_fake_kanban(monkeypatch, tmp_path)
+
+    payload = truth.build_operator_truth_payload(session_id="abc123", now=1.0)
+    workspace_chip = _chip(payload, "workspace")
+
+    assert workspace_chip["state"] == "live"
+    assert workspace_chip["source"]["kind"] == "session"
+    assert workspace_chip["value"] == "project"
+    assert workspace_chip["issues"] == []
+
+
+def test_operator_truth_workspace_missing_is_stale_not_live(monkeypatch, tmp_path):
+    truth = importlib.import_module("api.operator_truth")
+    missing_workspace = tmp_path / "missing-project"
+    _patch_common_sources(monkeypatch, tmp_path, missing_workspace)
+    _install_fake_kanban(monkeypatch, tmp_path)
+
+    payload = truth.build_operator_truth_payload(session_id="abc123", now=1.0)
+    workspace_chip = _chip(payload, "workspace")
+
+    assert workspace_chip["state"] == "stale"
+    assert payload["status"] == "stale"
+    assert any("missing" in issue.lower() or "inaccessible" in issue.lower() for issue in workspace_chip["issues"])
+
+
+def test_operator_truth_profile_and_state_paths_are_safely_displayed(monkeypatch, tmp_path):
+    truth = importlib.import_module("api.operator_truth")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _patch_common_sources(monkeypatch, tmp_path, workspace)
+    _install_fake_kanban(monkeypatch, tmp_path)
+
+    payload = truth.build_operator_truth_payload(session_id="abc123", now=1.0)
+    profile_chip = _chip(payload, "profile")
+    state_chip = _chip(payload, "webui_state")
+    serialized = json.dumps(payload)
+
+    assert profile_chip["display_path"]
+    assert state_chip["display_path"]
+    assert ".env" not in serialized
+    assert "auth_token" not in serialized
+    assert "password" not in serialized.lower()
+    assert "secret" not in serialized.lower()
+
+
+def test_operator_truth_profile_home_missing_is_unknown_not_live(monkeypatch, tmp_path):
+    truth = importlib.import_module("api.operator_truth")
+    import api.profiles as profiles
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _patch_common_sources(monkeypatch, tmp_path, workspace)
+    _install_fake_kanban(monkeypatch, tmp_path)
+    missing_home = tmp_path / "missing-hermes-home"
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: missing_home, raising=False)
+
+    payload = truth.build_operator_truth_payload(session_id="abc123", now=1.0)
+    profile_chip = _chip(payload, "profile")
+    source_chip = _chip(payload, "source_truth_files")
+
+    assert profile_chip["state"] == "unknown"
+    assert payload["status"] == "unknown"
+    assert source_chip["state"] == "unknown"
+    assert any("missing" in issue.lower() for issue in profile_chip["issues"])
+
+
+def test_operator_truth_kanban_current_board_read_only_no_repair(monkeypatch, tmp_path):
+    truth = importlib.import_module("api.operator_truth")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _patch_common_sources(monkeypatch, tmp_path, workspace)
+    fake_kanban = _install_fake_kanban(monkeypatch, tmp_path, current="ghost-board", existing_boards={"default"})
+
+    payload = truth.build_operator_truth_payload(session_id="abc123", now=1.0)
+    board_chip = _chip(payload, "kanban_board")
+
+    assert board_chip["state"] == "stale"
+    assert board_chip["value"] == "ghost-board"
+    assert getattr(fake_kanban, "_write_calls") == []
+
+
+def test_operator_truth_kanban_env_override_is_named_in_source(monkeypatch, tmp_path):
+    truth = importlib.import_module("api.operator_truth")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _patch_common_sources(monkeypatch, tmp_path, workspace)
+    _install_fake_kanban(monkeypatch, tmp_path, current="hermes-operator", existing_boards={"default", "env-board"})
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "env-board")
+
+    payload = truth.build_operator_truth_payload(session_id="abc123", now=1.0)
+    board_chip = _chip(payload, "kanban_board")
+
+    assert board_chip["state"] == "live"
+    assert board_chip["value"] == "env-board"
+    assert board_chip["source"]["kind"] == "env:HERMES_KANBAN_BOARD"
+
+
+def test_operator_truth_board_pointer_drift_is_stale(monkeypatch, tmp_path):
+    truth = importlib.import_module("api.operator_truth")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _patch_common_sources(monkeypatch, tmp_path, workspace)
+    _install_fake_kanban(monkeypatch, tmp_path, current="deleted-board", existing_boards={"default"})
+
+    payload = truth.build_operator_truth_payload(session_id="abc123", now=1.0)
+    board_chip = _chip(payload, "kanban_board")
+
+    assert board_chip["state"] == "stale"
+    assert payload["status"] == "stale"
+    assert any("missing" in issue.lower() or "does not exist" in issue.lower() for issue in board_chip["issues"])
+
+
+def test_operator_truth_scratch_default_workdir_under_active_workspace_is_stale(monkeypatch, tmp_path):
+    truth = importlib.import_module("api.operator_truth")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _patch_common_sources(monkeypatch, tmp_path, workspace)
+    _install_fake_kanban(monkeypatch, tmp_path, default_workdir=workspace)
+
+    payload = truth.build_operator_truth_payload(session_id="abc123", now=1.0)
+    scratch_chip = _chip(payload, "scratch_safety")
+
+    assert scratch_chip["state"] == "stale"
+    assert scratch_chip["value"] == "risky"
+    assert any("active workspace" in issue.lower() for issue in scratch_chip["issues"])
+
+
+def test_operator_truth_scratch_under_hermes_kanban_storage_is_live(monkeypatch, tmp_path):
+    truth = importlib.import_module("api.operator_truth")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _patch_common_sources(monkeypatch, tmp_path, workspace)
+    safe_root = tmp_path / "hermes-home" / "kanban" / "workspaces" / "hermes-operator"
+    _install_fake_kanban(monkeypatch, tmp_path, default_workdir=safe_root)
+
+    payload = truth.build_operator_truth_payload(session_id="abc123", now=1.0)
+    scratch_chip = _chip(payload, "scratch_safety")
+
+    assert scratch_chip["state"] == "live"
+    assert scratch_chip["value"] == "safe"
+    assert scratch_chip["issues"] == []
+
+
+def test_operator_truth_source_failure_returns_unknown_chip(monkeypatch, tmp_path):
+    truth = importlib.import_module("api.operator_truth")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _patch_common_sources(monkeypatch, tmp_path, workspace)
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name, package=None):
+        if name == "hermes_cli.kanban_db":
+            raise ImportError("kanban unavailable")
+        return real_import_module(name, package=package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    payload = truth.build_operator_truth_payload(session_id="abc123", now=1.0)
+    board_chip = _chip(payload, "kanban_board")
+    scratch_chip = _chip(payload, "scratch_safety")
+
+    assert payload["status"] == "unknown"
+    assert board_chip["state"] == "unknown"
+    assert scratch_chip["state"] == "unknown"
+    assert any("kanban unavailable" in issue for issue in board_chip["issues"])
+
+
+def test_operator_truth_route_returns_json(monkeypatch):
+    import api.routes as routes
+
+    expected = {"version": 1, "status": "unknown", "chips": [], "sources": []}
+    captured = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        captured["payload"] = payload
+        return True
+
+    with patch("api.operator_truth.build_operator_truth_payload", return_value=expected) as build_payload, patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        handled = routes.handle_get(types.SimpleNamespace(wfile=io.BytesIO()), urlparse("/api/operator/truth?session_id=abc123&ui_board=ui-board"))
+
+    assert handled is True
+    assert captured["status"] == 200
+    assert captured["payload"] == expected
+    build_payload.assert_called_once_with(session_id="abc123", ui_board_hint="ui-board")

--- a/tests/test_operator_truth_ui_static.py
+++ b/tests/test_operator_truth_ui_static.py
@@ -1,0 +1,149 @@
+import re
+from pathlib import Path
+
+
+def _read(path):
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _css_rule(css, selector):
+    match = re.search(rf"{re.escape(selector)}\s*\{{(?P<body>[^}}]*)\}}", css)
+    return match.group("body") if match else ""
+
+
+def _container_block(css, query):
+    match = re.search(rf"@container\s+{re.escape(query)}\s*\{{", css)
+    if not match:
+        return ""
+    start = match.end() - 1
+    depth = 0
+    for index in range(start, len(css)):
+        char = css[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return css[start + 1:index]
+    return ""
+
+
+def test_operator_truth_markup_exists_in_composer_footer():
+    html = _read("static/index.html")
+
+    assert 'id="operatorTruthStrip"' in html
+    assert 'id="operatorTruthSummaryChip"' in html
+    assert 'id="operatorTruthBoardChip"' in html
+    assert 'id="operatorTruthScratchChip"' in html
+    assert html.index('id="composerWorkspaceGroup"') < html.index('id="operatorTruthStrip"') < html.index('id="composerMobileConfigBtn"')
+
+
+def test_operator_truth_script_is_loaded_after_ui_before_boot():
+    html = _read("static/index.html")
+
+    assert html.index("static/ui.js") < html.index("static/operator_truth.js") < html.index("static/boot.js")
+    assert html.index("static/workspace.js") < html.index("static/operator_truth.js")
+    assert html.index("static/panels.js") < html.index("static/operator_truth.js")
+
+
+def test_operator_truth_js_uses_relative_api_endpoint():
+    js = _read("static/operator_truth.js")
+
+    assert "'/api/operator/truth'" in js or '"/api/operator/truth"' in js
+    assert "http://" not in js
+    assert "https://" not in js
+
+
+def test_operator_truth_js_has_live_stale_unknown_states():
+    js = _read("static/operator_truth.js")
+
+    assert "state-live" in js
+    assert "state-stale" in js
+    assert "state-unknown" in js
+
+
+def test_operator_truth_fetch_failure_sets_unknown_not_live():
+    js = _read("static/operator_truth.js")
+
+    assert "function setOperatorTruthUnknown" in js
+    assert "Truth unknown" in js
+    unknown_body = js[js.index("function setOperatorTruthUnknown") :]
+    assert "state-live" not in unknown_body.split("function ", 1)[0]
+
+
+def test_operator_truth_refresh_is_throttled():
+    js = _read("static/operator_truth.js")
+
+    assert "OPERATOR_TRUTH_TTL_MS" in js
+    assert "30000" in js
+    assert "_operatorTruthInFlight" in js
+    assert "_operatorTruthLastFetchAt" in js
+
+
+def test_operator_truth_refresh_cache_is_keyed_to_context():
+    js = _read("static/operator_truth.js")
+
+    assert "function operatorTruthContextKey" in js
+    assert "_operatorTruthLastFetchKey" in js
+    assert "_operatorTruthInFlightKey" in js
+    assert "contextKey === _operatorTruthInFlightKey" in js
+    assert "contextKey === _operatorTruthLastFetchKey" in js
+    assert "requestKey !== operatorTruthContextKey()" in js
+    assert "_profileDefaultWorkspace" in js
+    assert "_profileSwitchWorkspace" in js
+
+
+def test_operator_truth_payload_values_use_text_content_not_inner_html():
+    js = _read("static/operator_truth.js")
+
+    assert ".textContent" in js
+    assert ".innerHTML" not in js
+
+
+def test_sync_topbar_hooks_operator_truth_refresh_guarded():
+    ui = _read("static/ui.js")
+
+    assert "typeof refreshOperatorTruth === 'function'" in ui
+    assert "refreshOperatorTruth({reason:'syncTopbar'})" in ui or 'refreshOperatorTruth({ reason: "syncTopbar" })' in ui
+
+
+def test_kanban_board_load_refreshes_operator_truth_guarded():
+    panels = _read("static/panels.js")
+    load_boards = panels[panels.index("async function loadKanbanBoards") : panels.index("function _kanbanSafeColor")]
+
+    assert "typeof refreshOperatorTruth === 'function'" in load_boards
+    assert "kanban-board-load" in load_boards
+    assert load_boards.index("_kanbanCurrentBoard") < load_boards.index("refreshOperatorTruth")
+
+
+def test_operator_truth_mobile_css_collapses_secondary_chips():
+    css = _read("static/style.css")
+
+    assert ".operator-truth-strip" in css
+    assert ".operator-truth-chip-secondary" in css
+    assert "state-live" in css
+    assert "state-stale" in css
+    assert "state-unknown" in css
+    assert "max-width:640px" in css or "composer-footer (max-width:" in css
+    assert ".operator-truth-chip-secondary{display:none" in css.replace(" ", "") or ".operator-truth-chip-secondary { display: none" in css
+
+
+def test_operator_truth_controls_wrap_in_composer_footer_instead_of_horizontal_treadmill():
+    css = _read("static/style.css")
+    compact = css.replace(" ", "")
+
+    composer_left = _css_rule(css, ".composer-left").replace(" ", "")
+    strip_raw = _css_rule(css, ".operator-truth-strip")
+    strip = strip_raw.replace(" ", "")
+    mid_width = _container_block(css, "composer-footer (max-width: 1100px)").replace(" ", "")
+
+    assert "flex-wrap:wrap" in composer_left
+    assert "overflow-x:visible" in composer_left
+    assert "display:flex" in strip
+    assert "flex-wrap:wrap" in strip
+    assert "flex:1 1" in strip_raw
+    assert "max-width:100%" in strip
+    assert "@containercomposer-footer(max-width:1100px)" in compact
+    assert ".operator-truth-strip" in mid_width
+    assert "flex-basis:100%" in mid_width
+    assert "order:10" in mid_width

--- a/tests/test_run_graph.py
+++ b/tests/test_run_graph.py
@@ -1,0 +1,126 @@
+from api.run_graph import build_run_graph_from_events
+
+
+def _evt(seq, event, payload=None, **extra):
+    return {
+        "version": 1,
+        "event_id": f"run_1:{seq}",
+        "seq": seq,
+        "run_id": "run_1",
+        "session_id": "session_1",
+        "event": event,
+        "type": event,
+        "created_at": float(seq),
+        "terminal": event in {"done", "cancel", "apperror", "error", "stream_end"},
+        "payload": payload or {},
+        **extra,
+    }
+
+
+def _node(graph, kind_or_id):
+    for node in graph["nodes"]:
+        if node["id"] == kind_or_id or node["kind"] == kind_or_id:
+            return node
+    raise AssertionError(f"node not found: {kind_or_id}")
+
+
+def test_build_run_graph_projects_reasoning_tool_output_and_terminal_success():
+    graph = build_run_graph_from_events(
+        "session_1",
+        "run_1",
+        [
+            _evt(1, "reasoning", {"text": "thinking"}),
+            _evt(2, "tool", {"tool_call_id": "call_1", "name": "read_file", "args": {"path": "x"}}),
+            _evt(3, "tool_complete", {"tool_call_id": "call_1", "name": "read_file", "ok": True, "result": "done"}),
+            _evt(4, "token", {"text": "answer"}),
+            _evt(5, "done", {"session": {"session_id": "session_1"}}, terminal_state="completed"),
+        ],
+    )
+
+    assert graph["version"] == 1
+    assert graph["status"] == "succeeded"
+    assert graph["event_count"] == 5
+
+    root = _node(graph, "run:run_1")
+    assert root["kind"] == "run"
+    assert root["status"] == "succeeded"
+    assert root["event_count"] == 5
+
+    reasoning = _node(graph, "model_reasoning")
+    assert reasoning["label"] == "Reasoning"
+    assert reasoning["latest"]["text_chars"] == len("thinking")
+
+    tool = _node(graph, "tool_call")
+    assert tool["label"] == "read_file"
+    assert tool["status"] == "succeeded"
+    assert tool["event_count"] == 2
+    assert tool["latest"]["result_chars"] == len("done")
+
+    assistant = _node(graph, "assistant_output")
+    assert assistant["latest"]["text_chars"] == len("answer")
+
+    assert {edge["source"] for edge in graph["edges"]} == {"run:run_1"}
+
+
+def test_build_run_graph_marks_tool_failure_and_run_failure():
+    graph = build_run_graph_from_events(
+        "session_1",
+        "run_1",
+        [
+            _evt(1, "tool", {"tool_call_id": "call_1", "name": "terminal"}),
+            _evt(2, "tool_complete", {"tool_call_id": "call_1", "name": "terminal", "ok": False, "result": "boom"}),
+            _evt(3, "apperror", {"type": "provider", "message": "model failed"}, terminal_state="errored"),
+        ],
+    )
+
+    assert graph["status"] == "failed"
+    assert _node(graph, "tool_call")["status"] == "failed"
+    terminal = _node(graph, "terminal")
+    assert terminal["status"] == "failed"
+    assert terminal["latest"]["message"] == "model failed"
+
+
+def test_build_run_graph_marks_cancel_as_interrupted():
+    graph = build_run_graph_from_events(
+        "session_1",
+        "run_1",
+        [
+            _evt(1, "token", {"text": "partial"}),
+            _evt(2, "cancel", {"message": "cancelled by user"}, terminal_state="interrupted-by-user"),
+        ],
+    )
+
+    assert graph["status"] == "interrupted"
+    assert _node(graph, "terminal")["status"] == "interrupted"
+
+
+def test_build_run_graph_aggregates_compression_and_metering_without_raw_payload_dump():
+    graph = build_run_graph_from_events(
+        "session_1",
+        "run_1",
+        [
+            _evt(1, "compressing", {"message": "Auto-compressing"}),
+            _evt(2, "compressed", {"message": "Compressed"}),
+            _evt(3, "metering", {"usage": {"input_tokens": 10, "output_tokens": 3, "private": "drop-me"}}),
+        ],
+    )
+
+    compression = _node(graph, "compression")
+    assert compression["status"] == "succeeded"
+    assert compression["event_count"] == 2
+
+    metering = _node(graph, "metering")
+    assert metering["latest"]["usage"] == {"input_tokens": 10, "output_tokens": 3}
+
+
+def test_build_run_graph_unknown_events_become_event_nodes():
+    graph = build_run_graph_from_events(
+        "session_1",
+        "run_1",
+        [_evt(1, "custom_status", {"phase": "weird"})],
+    )
+
+    custom = _node(graph, "event")
+    assert custom["label"] == "custom_status"
+    assert custom["status"] == "succeeded"
+    assert custom["latest"]["phase"] == "weird"

--- a/tests/test_run_graph_routes.py
+++ b/tests/test_run_graph_routes.py
@@ -1,0 +1,126 @@
+import json
+from urllib.parse import urlparse
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.status = None
+        self.sent_headers = []
+        self.body = bytearray()
+        self.wfile = self
+        self.headers = {}
+        self.client_address = ("127.0.0.1", 0)
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.sent_headers.append((name, value))
+
+    def end_headers(self):
+        pass
+
+    def write(self, data):
+        self.body.extend(data)
+
+    def json_body(self):
+        return json.loads(bytes(self.body).decode("utf-8"))
+
+
+def test_run_graph_endpoint_returns_read_only_projection(monkeypatch):
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_build_run_graph(session_id, run_id, *, after_seq=None):
+        captured.update({"session_id": session_id, "run_id": run_id, "after_seq": after_seq})
+        return {
+            "version": 1,
+            "session_id": session_id,
+            "run_id": run_id,
+            "status": "succeeded",
+            "event_count": 2,
+            "nodes": [{"id": f"run:{run_id}", "kind": "run", "label": "Run"}],
+            "edges": [],
+        }
+
+    monkeypatch.setattr(routes, "build_run_graph", fake_build_run_graph, raising=False)
+
+    handler = _FakeHandler()
+    parsed = urlparse("http://example.com/api/run/graph?session_id=session_1&run_id=run_1&after_seq=7")
+
+    routes.handle_get(handler, parsed)
+
+    assert handler.status == 200
+    assert captured == {"session_id": "session_1", "run_id": "run_1", "after_seq": 7}
+    assert handler.json_body()["nodes"][0]["kind"] == "run"
+
+
+def test_run_graph_endpoint_requires_session_id_and_run_id(monkeypatch):
+    import api.routes as routes
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("build_run_graph must not run without required identifiers")
+
+    monkeypatch.setattr(routes, "build_run_graph", fail_if_called, raising=False)
+
+    missing_session = _FakeHandler()
+    routes.handle_get(missing_session, urlparse("http://example.com/api/run/graph?run_id=run_1"))
+    assert missing_session.status == 400
+    assert "session_id required" in missing_session.json_body()["error"]
+
+    missing_run = _FakeHandler()
+    routes.handle_get(missing_run, urlparse("http://example.com/api/run/graph?session_id=session_1"))
+    assert missing_run.status == 400
+    assert "run_id required" in missing_run.json_body()["error"]
+
+
+def test_run_latest_endpoint_returns_latest_journal_for_session(monkeypatch):
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_latest_run_summary_for_session(session_id):
+        captured["session_id"] = session_id
+        return {
+            "session_id": session_id,
+            "run_id": "run_new",
+            "last_seq": 4,
+            "last_event_id": "run_new:4",
+            "last_event": "done",
+            "terminal": True,
+            "terminal_state": "completed",
+        }
+
+    monkeypatch.setattr(routes, "latest_run_summary_for_session", fake_latest_run_summary_for_session, raising=False)
+
+    handler = _FakeHandler()
+    routes.handle_get(handler, urlparse("http://example.com/api/run/latest?session_id=session_1"))
+
+    body = handler.json_body()
+    assert handler.status == 200
+    assert captured == {"session_id": "session_1"}
+    assert body["found"] is True
+    assert body["run_id"] == "run_new"
+    assert body["journal"]["terminal_state"] == "completed"
+
+
+def test_run_latest_endpoint_requires_session_id_and_reports_empty(monkeypatch):
+    import api.routes as routes
+
+    def fake_latest_run_summary_for_session(session_id):
+        assert session_id == "session_1"
+        return None
+
+    monkeypatch.setattr(routes, "latest_run_summary_for_session", fake_latest_run_summary_for_session, raising=False)
+
+    missing_session = _FakeHandler()
+    routes.handle_get(missing_session, urlparse("http://example.com/api/run/latest"))
+    assert missing_session.status == 400
+    assert "session_id required" in missing_session.json_body()["error"]
+
+    empty = _FakeHandler()
+    routes.handle_get(empty, urlparse("http://example.com/api/run/latest?session_id=session_1"))
+    body = empty.json_body()
+    assert empty.status == 200
+    assert body == {"found": False, "session_id": "session_1", "run_id": None, "journal": None}

--- a/tests/test_run_graph_ui_static.py
+++ b/tests/test_run_graph_ui_static.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKSPACE_JS = (ROOT / "static" / "workspace.js").read_text(encoding="utf-8")
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+COMMANDS_JS = (ROOT / "static" / "commands.js").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def test_workspace_artifacts_tab_has_real_run_graph_renderer():
+    assert "function renderSessionRunGraph(" in WORKSPACE_JS
+    assert "function _runGraphRunId(session)" in WORKSPACE_JS
+    assert "function _runGraphCardHtml(graph)" in WORKSPACE_JS
+    assert "workspace-run-graph" in WORKSPACE_JS
+    assert "workspace-run-graph-card" in WORKSPACE_JS
+    assert "data-run-graph-node-kind" in WORKSPACE_JS
+    assert "data-run-graph-node-status" in WORKSPACE_JS
+    assert "renderSessionRunGraph();" in WORKSPACE_JS
+
+
+def test_run_graph_renderer_fetches_read_only_endpoint_with_real_identifiers():
+    assert "/api/run/graph?session_id=${encodeURIComponent(sessionId)}&run_id=${encodeURIComponent(runId)}" in WORKSPACE_JS
+    assert "api(`/api/run/graph?" in WORKSPACE_JS
+    assert "S.activeStreamId" in WORKSPACE_JS
+    assert "session.active_stream_id" in WORKSPACE_JS
+    assert "INFLIGHT[sid]" in WORKSPACE_JS
+    assert "hermes-webui-last-run-id-by-session" in WORKSPACE_JS
+    lowered = WORKSPACE_JS.lower()
+    assert "demo" not in lowered
+    assert "mock" not in lowered
+    assert "sample" not in lowered
+
+
+def test_run_graph_renderer_falls_back_to_backend_latest_run_for_hard_refresh():
+    assert "function _fetchLatestRunGraphRunId(sessionId)" in WORKSPACE_JS
+    assert "/api/run/latest?session_id=${encodeURIComponent(sessionId)}" in WORKSPACE_JS
+    assert "Looking up latest run graph…" in WORKSPACE_JS
+    assert "if(!runId){" in WORKSPACE_JS
+    assert "runId=await _fetchLatestRunGraphRunId(sessionId);" in WORKSPACE_JS
+    assert "_setRunGraphRememberedRun(sessionId,runId);" in WORKSPACE_JS
+
+
+def test_live_streams_remember_run_id_for_settled_graph_fetches():
+    assert "function rememberSessionRunGraphRun(sessionId, runId)" in WORKSPACE_JS
+    assert "rememberSessionRunGraphRun(activeSid, streamId);" in MESSAGES_JS
+    assert "rememberSessionRunGraphRun(activeSid,r.stream_id);" in COMMANDS_JS
+
+
+def test_run_graph_cards_have_dedicated_styles():
+    for selector in (
+        ".workspace-run-graph",
+        ".workspace-run-graph-card",
+        ".workspace-run-graph-card.status-failed",
+        ".workspace-run-graph-card.status-running",
+        ".workspace-run-graph-edge",
+    ):
+        assert selector in STYLE_CSS

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -4,6 +4,7 @@ from api.run_journal import (
     RunJournalWriter,
     append_run_event,
     find_run_summary,
+    latest_run_summary_for_session,
     latest_run_summary,
     read_run_events,
     stale_interrupted_event,
@@ -82,6 +83,20 @@ def test_latest_summary_and_find_run_summary_classify_terminal_state(tmp_path):
     assert summary["last_seq"] == 2
     assert found["session_id"] == "session_1"
     assert found["terminal_state"] == "interrupted-by-user"
+
+
+def test_latest_run_summary_for_session_picks_newest_journal_event(tmp_path):
+    append_run_event("session_1", "run_old", "done", {"session": {}}, session_dir=tmp_path, created_at=20)
+    append_run_event("session_1", "run_new", "token", {"text": "newer"}, session_dir=tmp_path, created_at=30)
+    append_run_event("session_2", "run_other", "done", {"session": {}}, session_dir=tmp_path, created_at=99)
+
+    summary = latest_run_summary_for_session("session_1", session_dir=tmp_path)
+
+    assert summary is not None
+    assert summary["session_id"] == "session_1"
+    assert summary["run_id"] == "run_new"
+    assert summary["event_count"] == 1
+    assert summary["last_created_at"] == 30.0
 
 
 def test_terminal_state_classification_distinguishes_crash_from_user_cancel(tmp_path):


### PR DESCRIPTION
## Summary
- adds source-backed operator mission control surfaces and APIs
- adds operator truth/proposals/commitments/memory/session/docs/device-admin/kanban/run-graph UI modules
- fixes composer operator chips to wrap instead of crowding the send control
- moves local scratch/vendor junk out of the checkout before committing

## Test plan
- `python -m pytest -o addopts= -p no:timeout tests/test_operator*.py tests/test_run_graph*.py tests/test_run_journal.py -q` → 258 passed, 2 skipped
- targeted push-protection fixture check after Slack-token false positive → 1 passed

## Cleanup notes
- branch commit: `3ad78f25`
- local checkout is clean after commit/push
