### PR TITLE
Fix workspace preview closing and stale content on chat completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## [Unreleased]
 
 ### Fixed
-- Workspace file preview no longer closes when a chat response finishes and the UI refreshes the workspace file tree. Background `loadDir('.')` on stream `done` now preserves an open preview instead of always calling `clearPreview()` (which switched preview-only mode back to the directory listing).
+- Workspace file preview no longer closes when a chat response finishes and the UI refreshes the workspace file tree. Background `loadDir('.')` on stream `done` now preserves an open preview instead of always calling `clearPreview()`, and reloads the open file when a write/edit tool touched that path during the turn (skipping reload while the preview has unsaved local edits).
 
 ## [v0.51.185] — 2026-05-31 — Release FE (stage-batchE — clarify-card bug-fix batch: identical-prompt dedup + autofill guard + GBK startup crash)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Workspace file preview no longer closes when a chat response finishes and the UI refreshes the workspace file tree. Background `loadDir('.')` on stream `done` now preserves an open preview instead of always calling `clearPreview()` (which switched preview-only mode back to the directory listing).
+
 ## [v0.51.185] — 2026-05-31 — Release FE (stage-batchE — clarify-card bug-fix batch: identical-prompt dedup + autofill guard + GBK startup crash)
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -1974,7 +1974,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           if(isSessionViewed) _markSessionViewed(completedSid, completedSession.message_count ?? S.messages.length);
           syncTopbar();renderMessages({preserveScroll:true});
           if(shouldFollowOnDone&&typeof scrollToBottom==='function') scrollToBottom();
-          loadDir('.');
+          loadDir('.', { preservePreview: true });
           // TTS auto-read: speak the last assistant response if enabled (#499)
           if(typeof autoReadLastAssistant==='function') setTimeout(()=>autoReadLastAssistant(), 300);
         }

--- a/static/messages.js
+++ b/static/messages.js
@@ -684,6 +684,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   }
   closeOtherLiveStreams(activeSid);
   closeLiveStream(activeSid);
+  if(!reconnecting&&typeof resetTurnWorkspaceMutations==='function') resetTurnWorkspaceMutations();
 
   // On reconnect, restore accumulated text from INFLIGHT so we don't lose
   // progress made before the session switch. Without this the closure starts
@@ -1710,8 +1711,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(d.duration!==undefined) tc.duration=d.duration;
       S.toolCalls=inflight.toolCalls;
       persistInflightState();
+      if(typeof noteWorkspaceMutationsFromToolCall==='function') noteWorkspaceMutationsFromToolCall(tc);
       if(S.session&&S.session.session_id===activeSid&&typeof scheduleRenderSessionArtifacts==='function') scheduleRenderSessionArtifacts();
       if(!S.session||S.session.session_id!==activeSid) return;
+      if(typeof refreshOpenPreviewIfMutated==='function') refreshOpenPreviewIfMutated();
       appendLiveToolCard(tc);
       snapshotLiveTurn();
       scrollIfPinned();
@@ -1974,6 +1977,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           if(isSessionViewed) _markSessionViewed(completedSid, completedSession.message_count ?? S.messages.length);
           syncTopbar();renderMessages({preserveScroll:true});
           if(shouldFollowOnDone&&typeof scrollToBottom==='function') scrollToBottom();
+          if(typeof noteWorkspaceMutationsFromToolCalls==='function') noteWorkspaceMutationsFromToolCalls(S.toolCalls);
           loadDir('.', { preservePreview: true });
           // TTS auto-read: speak the last assistant response if enabled (#499)
           if(typeof autoReadLastAssistant==='function') setTimeout(()=>autoReadLastAssistant(), 300);

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -223,6 +223,37 @@ function _artifactCandidatesFromToolCall(tc){
   return out;
 }
 
+const _turnMutatedPreviewPaths = new Set();
+
+function resetTurnWorkspaceMutations(){
+  _turnMutatedPreviewPaths.clear();
+}
+
+function noteWorkspaceMutationsFromToolCall(tc){
+  for(const a of _artifactCandidatesFromToolCall(tc)){
+    const path=_normalizeArtifactPath(a.path);
+    if(path) _turnMutatedPreviewPaths.add(path);
+  }
+}
+
+function noteWorkspaceMutationsFromToolCalls(toolCalls){
+  if(!Array.isArray(toolCalls)) return;
+  for(const tc of toolCalls) noteWorkspaceMutationsFromToolCall(tc);
+}
+
+function _isOpenPreviewPathMutated(){
+  if(!_previewCurrentPath) return false;
+  const current=_normalizeArtifactPath(_previewCurrentPath);
+  return !!(current&&_turnMutatedPreviewPaths.has(current));
+}
+
+async function refreshOpenPreviewIfMutated(){
+  if(typeof _previewDirty!=='undefined'&&_previewDirty) return;
+  if(!_isOpenPreviewPathMutated()) return;
+  if(!_previewCurrentPath||!S.session) return;
+  await openFile(_previewCurrentPath, { bustCache: true });
+}
+
 function collectSessionArtifacts(){
   const items = [];
   const seen = new Set();
@@ -321,6 +352,8 @@ async function loadDir(path, opts={}){
       }else{
         clearPreview({keepPanelOpen:true});
       }
+    }else if(preservePreview){
+      await refreshOpenPreviewIfMutated();
     }
     // Fetch git info for workspace root (non-blocking)
     if(!path||path==='.') _refreshGitBadge();
@@ -489,9 +522,11 @@ function cancelEditMode(){
   updateEditBtn();
 }
 
-async function openFile(path){
+async function openFile(path, opts={}){
   if(!S.session)return;
   const ext=fileExt(path);
+  const bustCache=!!(opts&&opts.bustCache);
+  const cacheBust=bustCache?`&_=${Date.now()}`:'';
 
   // Binary/download-only formats: trigger browser download, don't preview
   if(DOWNLOAD_EXTS.has(ext)){
@@ -508,14 +543,14 @@ async function openFile(path){
   if(IMAGE_EXTS.has(ext)){
     // Image: load via raw endpoint, show as <img>
     showPreview('image');
-    const url=`api/file/raw?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(path)}`;
+    const url=`api/file/raw?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(path)}${cacheBust}`;
     $('previewImg').alt=path;
     $('previewImg').src=url;
     $('previewImg').onerror=()=>setStatus(t('image_load_failed'));
   } else if(AUDIO_EXTS.has(ext)||VIDEO_EXTS.has(ext)){
     const mode=VIDEO_EXTS.has(ext)?'video':'audio';
     showPreview(mode);
-    const url=`api/file/raw?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(path)}&inline=1`;
+    const url=`api/file/raw?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(path)}&inline=1${cacheBust}`;
     const wrap=$('previewMediaWrap');
     if(wrap){
       wrap.innerHTML=(typeof _mediaPlayerHtml==='function')
@@ -525,7 +560,7 @@ async function openFile(path){
     }
   } else if(PDF_EXTS.has(ext)){
     showPreview('pdf');
-    const url=`api/file/raw?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(path)}&inline=1`;
+    const url=`api/file/raw?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(path)}&inline=1${cacheBust}`;
     const frame=$('previewPdfFrame');
     if(frame){
       frame.src=''; // clear first to avoid stale content
@@ -557,7 +592,7 @@ async function openFile(path){
     // or reading other origin data. If a stricter mode is needed, remove
     // allow-scripts (or add sandbox="") to disable all JS execution.
     showPreview('html');
-    const url=`api/file/raw?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(path)}&inline=1`;
+    const url=`api/file/raw?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(path)}&inline=1${cacheBust}`;
     const iframe=$('previewHtmlIframe');
     if(iframe){
       iframe.src=''; // clear first to avoid stale content

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -284,7 +284,8 @@ async function openArtifactPath(path){
   openFile(rel);
 }
 
-async function loadDir(path){
+async function loadDir(path, opts={}){
+  const preservePreview=!!(opts&&opts.preservePreview);
   if(!S.session)return;
   const sessionId=S.session.session_id;
   try{
@@ -314,7 +315,7 @@ async function loadDir(path){
       }
       if(expanded.size>0)renderFileTree();
     }
-    if(typeof clearPreview==='function'){
+    if(!preservePreview&&typeof clearPreview==='function'){
       if(typeof _previewDirty!=='undefined'&&_previewDirty){
         showConfirmDialog({title:t('unsaved_confirm'),message:'',confirmLabel:'Discard',danger:true,focusCancel:true}).then(ok=>{if(ok)clearPreview({keepPanelOpen:true});});
       }else{

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -314,7 +314,7 @@ def test_hidden_active_done_still_updates_current_pane_but_not_read_state():
     active_guard_idx = done_block.find("if(isActiveSession){", viewed_const_idx)
     session_update_idx = done_block.find("S.session=d.session", active_guard_idx)
     render_idx = done_block.find("renderMessages(", active_guard_idx)
-    load_dir_idx = done_block.find("loadDir('.')", active_guard_idx)
+    load_dir_idx = done_block.find("preservePreview", active_guard_idx)
     mark_viewed_idx = done_block.find("if(isSessionViewed) _markSessionViewed(completedSid", active_guard_idx)
 
     assert active_const_idx != -1, "done handler must compute active/current pane separately"

--- a/tests/test_workspace_preview_preserved_on_stream_done.py
+++ b/tests/test_workspace_preview_preserved_on_stream_done.py
@@ -50,6 +50,9 @@ def test_load_dir_supports_preserve_preview_option():
     assert "if(!preservePreview&&typeofclearPreview" in block.replace(" ", ""), (
         "loadDir() should skip clearPreview() when preservePreview is requested"
     )
+    assert "awaitrefreshOpenPreviewIfMutated()" in block.replace(" ", ""), (
+        "Background refresh must reload the open preview when a mutation tool touched it"
+    )
 
 
 def test_load_dir_still_clears_preview_for_directory_navigation():
@@ -58,3 +61,25 @@ def test_load_dir_still_clears_preview_for_directory_navigation():
     assert "clearPreview({keepPanelOpen:true})" in block.replace(" ", ""), (
         "Directory navigation must still clear previews when preservePreview is not set"
     )
+
+
+def test_turn_mutation_tracking_reloads_open_preview():
+    block = _function_block(WORKSPACE_JS, "refreshOpenPreviewIfMutated")
+    assert "openFile(_previewCurrentPath" in block.replace(" ", ""), (
+        "Mutated open previews must reload through openFile()"
+    )
+    assert "_previewDirty" in block, "Reload must be skipped while the preview has unsaved edits"
+
+
+def test_tool_complete_tracks_workspace_mutations_for_preview_reload():
+    tool_complete_idx = MESSAGES_JS.find("source.addEventListener('tool_complete'")
+    assert tool_complete_idx != -1
+    end = MESSAGES_JS.find("source.addEventListener('approval'", tool_complete_idx)
+    block = MESSAGES_JS[tool_complete_idx:end]
+    assert "noteWorkspaceMutationsFromToolCall" in block
+    assert "refreshOpenPreviewIfMutated" in block
+
+
+def test_stream_start_resets_turn_mutation_tracking():
+    block = _function_block(MESSAGES_JS, "attachLiveStream")
+    assert "resetTurnWorkspaceMutations" in block

--- a/tests/test_workspace_preview_preserved_on_stream_done.py
+++ b/tests/test_workspace_preview_preserved_on_stream_done.py
@@ -1,0 +1,60 @@
+"""Regression: workspace file preview must survive background file-tree refresh on chat done."""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+WORKSPACE_JS = (REPO / "static" / "workspace.js").read_text(encoding="utf-8")
+
+
+def _function_block(src: str, name: str) -> str:
+    marker = f"function {name}("
+    start = src.find(marker)
+    assert start != -1, f"{name}() not found"
+    params_end = src.find("){", start)
+    assert params_end != -1, f"{name}() body not found"
+    brace = params_end + 1
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : idx + 1]
+    raise AssertionError(f"{name}() body did not close")
+
+
+def _done_block() -> str:
+    start = MESSAGES_JS.find("source.addEventListener('done'")
+    assert start != -1, "done handler not found in messages.js"
+    end = MESSAGES_JS.find("source.addEventListener('stream_end'", start)
+    assert end != -1, "stream_end handler not found after done handler"
+    return MESSAGES_JS[start:end]
+
+
+def test_stream_done_refreshes_workspace_without_clearing_preview():
+    """Chat completion should refresh the tree but not exit an open file preview."""
+    done_block = _done_block()
+    assert "preservePreview:true" in done_block.replace(" ", ""), (
+        "The done handler must refresh the workspace file tree without calling the "
+        "directory-navigation clearPreview path in loadDir()."
+    )
+
+
+def test_load_dir_supports_preserve_preview_option():
+    block = _function_block(WORKSPACE_JS, "loadDir")
+    assert "preservePreview" in block, "loadDir() must accept a preservePreview option"
+    assert "if(!preservePreview&&typeofclearPreview" in block.replace(" ", ""), (
+        "loadDir() should skip clearPreview() when preservePreview is requested"
+    )
+
+
+def test_load_dir_still_clears_preview_for_directory_navigation():
+    """#1785: explicit directory navigation must still switch preview back to browse mode."""
+    block = _function_block(WORKSPACE_JS, "loadDir")
+    assert "clearPreview({keepPanelOpen:true})" in block.replace(" ", ""), (
+        "Directory navigation must still clear previews when preservePreview is not set"
+    )


### PR DESCRIPTION
## Summary
- **Bug 1:** stream `done` called `loadDir('.')`, which always ended with `clearPreview({keepPanelOpen:true})` (#1785 directory navigation). That switched preview-only mode back to the file listing even when the agent did not touch the open file.
- **Bug 2:** keeping preview open without reloading left stale content when the agent did edit the open file during the turn.
- **Fix:** background refresh uses `loadDir('.', { preservePreview: true })` so unrelated responses no longer close preview. Write/edit tool paths are tracked per turn; when the open preview path was mutated, `refreshOpenPreviewIfMutated()` reloads via `openFile()` on `tool_complete` and again after `loadDir` on `done` (skipped while `_previewDirty`).

## Thinking Path
1. Repro: preview closes on model reply while viewing a file the agent did not edit.
2. Trace: `messages.js` `done` → `loadDir('.')` → unconditional `clearPreview()` in `workspace.js`.
3. First fix scoped `preservePreview` to background refresh only; explicit navigation (breadcrumb, folder click) still clears preview (#1785).
4. Follow-up: preserving preview alone leaves stale content when the agent edits that file — add turn-scoped mutation tracking from existing artifact tool path extraction and reload open preview when paths match.

## Test plan
- [x] `pytest tests/test_workspace_preview_preserved_on_stream_done.py tests/test_issue1785_workspace_preview_breadcrumb.py tests/test_issue856_background_completion_unread.py`
- [ ] Open a file in Workspace preview, send a chat message that does not edit it → preview stays open
- [ ] Open a file, ask the agent to edit it → preview stays open and shows updated content when the tool completes / response finishes
- [ ] Start editing a file in preview, agent edits same file → local unsaved edits are not overwritten