### PR TITLE
fix(context): scope global model.context_length to model.default only (+ live-usage-snapshot perf cache)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -2045,8 +2045,16 @@ def _resolve_context_length_for_session_model(
         try:
             _model_cfg_load = _cfg_for_cl.get('model', {}) if isinstance(_cfg_for_cl, dict) else {}
             if isinstance(_model_cfg_load, dict):
+                # Only apply the global model.context_length override when the
+                # session model matches model.default. Otherwise a global cap
+                # set for the default model (e.g. 232000) silently clobbers
+                # other models' real metadata (e.g. a 1M-context variant).
+                _cfg_default_model = str(_model_cfg_load.get('default') or '').strip()
                 _raw_cfg_ctx_load = _model_cfg_load.get('context_length')
-                if _raw_cfg_ctx_load is not None:
+                if _raw_cfg_ctx_load is not None and (
+                    not _cfg_default_model
+                    or _cfg_default_model == model_for_lookup
+                ):
                     try:
                         _parsed_load = int(_raw_cfg_ctx_load)
                         if _parsed_load > 0:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4046,10 +4046,26 @@ def _run_agent_streaming(
                         _real_ctx_cache[0] = _resolved_real
                     # Apply the cached real cap when the guard determined one.
                     if _real_ctx_cache[0]:
+                        # Also rescale threshold_tokens by the same ratio so the
+                        # auto-compress trigger reflects the real window, not
+                        # the stale global cap (e.g. 197.2k @ 232K cap → ~850k
+                        # @ 1M real cap).
+                        _orig_cc_cl = getattr(_cc, 'context_length', 0) or 0
+                        _orig_thresh = getattr(_cc, 'threshold_tokens', 0) or 0
                         _cc_cl_u = _real_ctx_cache[0]
-                    _usage['context_length'] = _cc_cl_u
-                    _usage['threshold_tokens'] = getattr(_cc, 'threshold_tokens', 0) or 0
-                    _usage['last_prompt_tokens'] = getattr(_cc, 'last_prompt_tokens', 0) or 0
+                        if _orig_cc_cl > 0 and _orig_thresh > 0:
+                            _scaled_thresh = int(_orig_thresh * _real_ctx_cache[0] / _orig_cc_cl)
+                            _usage['context_length'] = _cc_cl_u
+                            _usage['threshold_tokens'] = _scaled_thresh
+                            _usage['last_prompt_tokens'] = getattr(_cc, 'last_prompt_tokens', 0) or 0
+                        else:
+                            _usage['context_length'] = _cc_cl_u
+                            _usage['threshold_tokens'] = _orig_thresh
+                            _usage['last_prompt_tokens'] = getattr(_cc, 'last_prompt_tokens', 0) or 0
+                    else:
+                        _usage['context_length'] = _cc_cl_u
+                        _usage['threshold_tokens'] = getattr(_cc, 'threshold_tokens', 0) or 0
+                        _usage['last_prompt_tokens'] = getattr(_cc, 'last_prompt_tokens', 0) or 0
             except Exception:
                 pass
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3988,7 +3988,47 @@ def _run_agent_streaming(
             try:
                 _cc = getattr(_agent, 'context_compressor', None)
                 if _cc:
-                    _usage['context_length'] = getattr(_cc, 'context_length', 0) or 0
+                    _cc_cl_u = getattr(_cc, 'context_length', 0) or 0
+                    # Default-only guard (#3256): the agent-side compressor is
+                    # built in agent_init with the global model.context_length
+                    # applied unconditionally — for non-default models that
+                    # value is the stale global cap (e.g. 232K). Drop it here
+                    # so the live usage payload doesn't surface the wrong cap.
+                    try:
+                        from api.config import get_config as _gc_u
+                        _cfg_u = _gc_u()
+                        _mcfg_u = _cfg_u.get('model', {}) if isinstance(_cfg_u, dict) else {}
+                        if isinstance(_mcfg_u, dict):
+                            _def_u = str(_mcfg_u.get('default') or '').strip()
+                            _raw_u = _mcfg_u.get('context_length')
+                            try:
+                                _cl_u = int(_raw_u) if _raw_u is not None else 0
+                            except (TypeError, ValueError):
+                                _cl_u = 0
+                            _sm_u = str(getattr(_agent, 'model', '') or '').strip()
+                            if (
+                                _cl_u > 0
+                                and _cc_cl_u == _cl_u
+                                and _def_u
+                                and _sm_u
+                                and _def_u != _sm_u
+                            ):
+                                # Recompute from real per-model metadata.
+                                try:
+                                    from agent.model_metadata import get_model_context_length as _g_u
+                                    _real_u = _g_u(
+                                        _sm_u,
+                                        getattr(_agent, 'base_url', '') or '',
+                                        config_context_length=None,
+                                        provider=getattr(_agent, 'provider', '') or '',
+                                    ) or 0
+                                    if _real_u:
+                                        _cc_cl_u = _real_u
+                                except Exception:
+                                    pass
+                    except Exception:
+                        pass
+                    _usage['context_length'] = _cc_cl_u
                     _usage['threshold_tokens'] = getattr(_cc, 'threshold_tokens', 0) or 0
                     _usage['last_prompt_tokens'] = getattr(_cc, 'last_prompt_tokens', 0) or 0
             except Exception:
@@ -5794,7 +5834,37 @@ def _run_agent_streaming(
                 # returns them on reload instead of falling back to 0.
                 _cc_for_save = getattr(agent, 'context_compressor', None)
                 if _cc_for_save:
-                    s.context_length = getattr(_cc_for_save, 'context_length', 0) or 0
+                    _cc_cl = getattr(_cc_for_save, 'context_length', 0) or 0
+                    # Same guard as routes._resolve_context_length_for_session_model:
+                    # the agent-side context_compressor was constructed with the
+                    # global model.context_length applied to EVERY model. If the
+                    # session's model isn't model.default, that value is a stale
+                    # cap (e.g. 232K) that would clobber the real 1M metadata
+                    # on every stream end. In that case skip the compressor
+                    # value and let the fallback resolver below recompute.
+                    _skip_cc_cl = False
+                    try:
+                        _model_cfg_cc = _cfg.get('model', {}) if isinstance(_cfg, dict) else {}
+                        if isinstance(_model_cfg_cc, dict):
+                            _cfg_default_cc = str(_model_cfg_cc.get('default') or '').strip()
+                            _raw_cfg_cl_cc = _model_cfg_cc.get('context_length')
+                            try:
+                                _cfg_cl_cc = int(_raw_cfg_cl_cc) if _raw_cfg_cl_cc is not None else 0
+                            except (TypeError, ValueError):
+                                _cfg_cl_cc = 0
+                            _sess_model_cc = str(getattr(agent, 'model', resolved_model or '') or '').strip()
+                            if (
+                                _cfg_cl_cc > 0
+                                and _cc_cl == _cfg_cl_cc
+                                and _cfg_default_cc
+                                and _sess_model_cc
+                                and _cfg_default_cc != _sess_model_cc
+                            ):
+                                _skip_cc_cl = True
+                    except Exception:
+                        pass
+                    if not _skip_cc_cl:
+                        s.context_length = _cc_cl
                     s.threshold_tokens = getattr(_cc_for_save, 'threshold_tokens', 0) or 0
                     s.last_prompt_tokens = getattr(_cc_for_save, 'last_prompt_tokens', 0) or 0
                 # Fallback: if the compressor didn't report a context_length
@@ -5821,7 +5891,19 @@ def _run_agent_streaming(
                             _model_cfg_for_ctx = _cfg.get('model', {}) if isinstance(_cfg, dict) else {}
                             if isinstance(_model_cfg_for_ctx, dict):
                                 _raw_cfg_ctx = _model_cfg_for_ctx.get('context_length')
-                                if _raw_cfg_ctx is not None:
+                                # Default-only guard: only apply the global
+                                # model.context_length cap when the session
+                                # model equals model.default. Otherwise the
+                                # cap (e.g. 232K set for the default model)
+                                # silently shrinks other models' real metadata.
+                                _cfg_default_ctx = str(_model_cfg_for_ctx.get('default') or '').strip()
+                                _sess_model_ctx = str(getattr(agent, 'model', resolved_model or '') or '').strip()
+                                _apply_cfg_ctx = (
+                                    not _cfg_default_ctx
+                                    or not _sess_model_ctx
+                                    or _cfg_default_ctx == _sess_model_ctx
+                                )
+                                if _raw_cfg_ctx is not None and _apply_cfg_ctx:
                                     try:
                                         _parsed_cfg_ctx = int(_raw_cfg_ctx)
                                         if _parsed_cfg_ctx > 0:
@@ -5991,7 +6073,36 @@ def _run_agent_streaming(
             # survive a page reload; this block only populates the live SSE usage payload.
             _cc = getattr(agent, 'context_compressor', None)
             if _cc:
-                usage['context_length'] = getattr(_cc, 'context_length', 0) or 0
+                _cc_cl_sse = getattr(_cc, 'context_length', 0) or 0
+                # Default-only guard (#3256): the agent-side context_compressor
+                # is constructed in agent_init with the global model.context_length
+                # applied unconditionally, so for non-default models its
+                # context_length is the stale global cap (e.g. 232K) — surfacing
+                # it via SSE makes the indicator show the wrong window even
+                # after the session was correctly resized. Drop the compressor
+                # value in that case and let the fallback resolver below recompute.
+                try:
+                    _model_cfg_sse = _cfg.get('model', {}) if isinstance(_cfg, dict) else {}
+                    if isinstance(_model_cfg_sse, dict):
+                        _cfg_default_sse = str(_model_cfg_sse.get('default') or '').strip()
+                        _raw_cfg_cl_sse = _model_cfg_sse.get('context_length')
+                        try:
+                            _cfg_cl_sse = int(_raw_cfg_cl_sse) if _raw_cfg_cl_sse is not None else 0
+                        except (TypeError, ValueError):
+                            _cfg_cl_sse = 0
+                        _sess_model_sse = str(getattr(agent, 'model', resolved_model or '') or '').strip()
+                        if (
+                            _cfg_cl_sse > 0
+                            and _cc_cl_sse == _cfg_cl_sse
+                            and _cfg_default_sse
+                            and _sess_model_sse
+                            and _cfg_default_sse != _sess_model_sse
+                        ):
+                            _cc_cl_sse = 0
+                except Exception:
+                    pass
+                if _cc_cl_sse:
+                    usage['context_length'] = _cc_cl_sse
                 usage['threshold_tokens'] = getattr(_cc, 'threshold_tokens', 0) or 0
                 usage['last_prompt_tokens'] = getattr(_cc, 'last_prompt_tokens', 0) or 0
             # Fallback: when the compressor is absent or reports context_length=0,
@@ -6013,7 +6124,18 @@ def _run_agent_streaming(
                         _model_cfg_for_ctx = _cfg.get('model', {}) if isinstance(_cfg, dict) else {}
                         if isinstance(_model_cfg_for_ctx, dict):
                             _raw_cfg_ctx = _model_cfg_for_ctx.get('context_length')
-                            if _raw_cfg_ctx is not None:
+                            # Default-only guard (see #3256): the global
+                            # model.context_length cap only applies to
+                            # model.default; other models keep their real
+                            # metadata.
+                            _cfg_default_ctx = str(_model_cfg_for_ctx.get('default') or '').strip()
+                            _sess_model_ctx = str(getattr(agent, 'model', resolved_model or '') or '').strip()
+                            _apply_cfg_ctx = (
+                                not _cfg_default_ctx
+                                or not _sess_model_ctx
+                                or _cfg_default_ctx == _sess_model_ctx
+                            )
+                            if _raw_cfg_ctx is not None and _apply_cfg_ctx:
                                 try:
                                     _parsed_cfg_ctx = int(_raw_cfg_ctx)
                                     if _parsed_cfg_ctx > 0:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3912,6 +3912,15 @@ def _run_agent_streaming(
     _live_prompt_exact_tokens = [0]
     _live_prompt_estimate_tool_delta_tokens = [0]
     _live_prompt_estimate_seen_ids = set()
+    # Per-stream cache for the real per-model context_length (#3256 perf).
+    # _live_usage_snapshot() runs on every metering tick (~10x/sec during
+    # streaming); recomputing get_model_context_length() there triggered a
+    # config read + potential metadata/network probe on every token for
+    # non-default models (e.g. claude-opus-4.7-1m), freezing the stream while
+    # the default model was unaffected. The value is constant for a given
+    # (model, base_url, provider) within one stream, so resolve it at most
+    # once. Sentinel: None=not computed, 0=not applicable/failed, >0=real cap.
+    _real_ctx_cache = [None]
 
     def _seed_live_prompt_estimate() -> int:
         """Capture the latest exact prompt size before adding live tool deltas."""
@@ -3994,40 +4003,50 @@ def _run_agent_streaming(
                     # applied unconditionally — for non-default models that
                     # value is the stale global cap (e.g. 232K). Drop it here
                     # so the live usage payload doesn't surface the wrong cap.
-                    try:
-                        from api.config import get_config as _gc_u
-                        _cfg_u = _gc_u()
-                        _mcfg_u = _cfg_u.get('model', {}) if isinstance(_cfg_u, dict) else {}
-                        if isinstance(_mcfg_u, dict):
-                            _def_u = str(_mcfg_u.get('default') or '').strip()
-                            _raw_u = _mcfg_u.get('context_length')
-                            try:
-                                _cl_u = int(_raw_u) if _raw_u is not None else 0
-                            except (TypeError, ValueError):
-                                _cl_u = 0
-                            _sm_u = str(getattr(_agent, 'model', '') or '').strip()
-                            if (
-                                _cl_u > 0
-                                and _cc_cl_u == _cl_u
-                                and _def_u
-                                and _sm_u
-                                and _def_u != _sm_u
-                            ):
-                                # Recompute from real per-model metadata.
+                    # PERF: resolve the real per-model cap at most once per
+                    # stream (cached in _real_ctx_cache). This snapshot runs on
+                    # every metering tick; doing the config read + metadata
+                    # lookup per tick froze non-default-model streams.
+                    if _real_ctx_cache[0] is None:
+                        _resolved_real = 0  # 0 = guard not applicable / failed
+                        try:
+                            from api.config import get_config as _gc_u
+                            _cfg_u = _gc_u()
+                            _mcfg_u = _cfg_u.get('model', {}) if isinstance(_cfg_u, dict) else {}
+                            if isinstance(_mcfg_u, dict):
+                                _def_u = str(_mcfg_u.get('default') or '').strip()
+                                _raw_u = _mcfg_u.get('context_length')
                                 try:
-                                    from agent.model_metadata import get_model_context_length as _g_u
-                                    _real_u = _g_u(
-                                        _sm_u,
-                                        getattr(_agent, 'base_url', '') or '',
-                                        config_context_length=None,
-                                        provider=getattr(_agent, 'provider', '') or '',
-                                    ) or 0
-                                    if _real_u:
-                                        _cc_cl_u = _real_u
-                                except Exception:
-                                    pass
-                    except Exception:
-                        pass
+                                    _cl_u = int(_raw_u) if _raw_u is not None else 0
+                                except (TypeError, ValueError):
+                                    _cl_u = 0
+                                _sm_u = str(getattr(_agent, 'model', '') or '').strip()
+                                if (
+                                    _cl_u > 0
+                                    and _cc_cl_u == _cl_u
+                                    and _def_u
+                                    and _sm_u
+                                    and _def_u != _sm_u
+                                ):
+                                    # Recompute from real per-model metadata.
+                                    try:
+                                        from agent.model_metadata import get_model_context_length as _g_u
+                                        _real_u = _g_u(
+                                            _sm_u,
+                                            getattr(_agent, 'base_url', '') or '',
+                                            config_context_length=None,
+                                            provider=getattr(_agent, 'provider', '') or '',
+                                        ) or 0
+                                        if _real_u:
+                                            _resolved_real = _real_u
+                                    except Exception:
+                                        pass
+                        except Exception:
+                            _resolved_real = 0
+                        _real_ctx_cache[0] = _resolved_real
+                    # Apply the cached real cap when the guard determined one.
+                    if _real_ctx_cache[0]:
+                        _cc_cl_u = _real_ctx_cache[0]
                     _usage['context_length'] = _cc_cl_u
                     _usage['threshold_tokens'] = getattr(_cc, 'threshold_tokens', 0) or 0
                     _usage['last_prompt_tokens'] = getattr(_cc, 'last_prompt_tokens', 0) or 0


### PR DESCRIPTION
## Summary

Two related backend-only fixes for non-default models whose real `context_length` differs from the global `model.context_length` config cap (e.g. a non-default model with 1M context while `model.default` is a smaller-window model with config cap 232000).

### Commit 1: `fix(context): scope global model.context_length to model.default only`

`config.model.context_length` was being applied unconditionally to every session, silently shrinking the real per-model context window for any model that is *not* `model.default`. After this fix, the global cap only applies when the session model equals `model.default`; other models keep their real metadata (from `agent.model_metadata.get_model_context_length`).

Touches `api/routes.py` (`_resolve_context_length_for_session_model`) and three spots in `api/streaming.py` (session save, SSE usage payload, live usage snapshot) so the corrected value isn't overwritten back to the stale global cap on every turn end / SSE tick.

### Commit 2: `perf(context): cache real per-model context_length in live usage snapshot`

The guard added by commit 1 inside `_live_usage_snapshot()` did a `get_config()` + `get_model_context_length()` call on **every metering tick** (~10× per second during streaming). For non-default models that triggered the guard branch, this meant a config read + potential metadata/network probe on every token, freezing the stream.

The symptom was extremely model-asymmetric and looked like a model-side issue: the non-default 1M-context model streamed glacially, while the configured default (whose guard short-circuited) streamed normally on the exact same backend.

Fix: closure-scoped `_real_ctx_cache = [None]` sentinel (`None` = not computed, `0` = guard not applicable / failed, `>0` = real cap) resolves the value at most once per stream. The other two guard sites (session save, terminal SSE) are one-shot and don't need caching.

## Scope

- Backend only — zero frontend / zero render-path changes.
- Two files: `api/routes.py` (+10), `api/streaming.py` (+~140 spread across 4 sites + the cache var).
- Behavior change is limited to deployments where `model.context_length` is set in config **and** the session model differs from `model.default`. Single-model deployments are unaffected.

## How I verified

1. **Display correctness:** With a 232000 context cap on the configured default, switching a session to a non-default 1M-context model now shows 1M (real metadata) in the context indicator, not 232K. Before the fix it showed 232K.
2. **Performance:** With commit 1 alone, the same non-default 1M-context session was visibly stuck/laggy during streaming while the configured default on the same backend was smooth — a classic "default-vs-non-default" asymmetry caused by the guard running per-tick. After commit 2 (caching), both models stream at the same fluid rate.

## Notes

cc @nesquena — happy to split into two PRs, rebase, or rework if you'd prefer the cache to live elsewhere (e.g. a module-level LRU on `(model, base_url, provider)` so the value also survives across streams in the same process). The current closure approach is the smallest possible change.
