### PR TITLE
fix: keep collapsed tool previews quiet

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -7018,6 +7018,51 @@ function toolIcon(name){
   return icons[name]||li('wrench');
 }
 
+function _toolArgPreviewValue(value){
+  if(value===null||value===undefined) return '';
+  if(Array.isArray(value)){
+    if(!value.length) return '[]';
+    if(value.length<=3&&value.every(v=>v===null||['string','number','boolean'].includes(typeof v))){
+      return value.map(v=>String(v)).join(', ');
+    }
+    return `${value.length} items`;
+  }
+  if(typeof value==='object') return 'object';
+  return String(value).replace(/\s+/g,' ').trim();
+}
+function _formatToolArgPreview(args){
+  if(!args||typeof args!=='object') return '';
+  const preferred=['path','file_path','target','pattern','query','url','urls','name','ref','command','action','mode','schedule','workdir'];
+  const hidden=new Set(['content','file_content','new_string','old_string','patch','text','message','prompt','code','script','cookies','headers','auth','api_key','password','token','secret']);
+  const keys=[];
+  for(const key of preferred){
+    if(Object.prototype.hasOwnProperty.call(args,key)&&!hidden.has(key)) keys.push(key);
+  }
+  for(const key of Object.keys(args)){
+    if(keys.length>=3) break;
+    if(keys.includes(key)||hidden.has(key)) continue;
+    keys.push(key);
+  }
+  const parts=[];
+  for(const key of keys){
+    const raw=_toolArgPreviewValue(args[key]);
+    if(!raw) continue;
+    const val=raw.length>96?`${raw.slice(0,93)}…`:raw;
+    parts.push(`${key}=${val}`);
+    if(parts.join(' · ').length>=150) break;
+  }
+  const out=parts.join(' · ');
+  return out.length>180?`${out.slice(0,177)}…`:out;
+}
+function _toolCardPreviewText(tc, displaySnippet){
+  const explicit=String(tc&&tc.preview||'').trim();
+  if(explicit) return explicit;
+  const argPreview=_formatToolArgPreview(tc&&tc.args);
+  if(argPreview) return argPreview;
+  if(tc&&tc.done===false) return 'Running';
+  if(tc&&tc.is_error) return 'Failed';
+  return 'Completed';
+}
 function buildToolCard(tc){
   const row=document.createElement('div');
   row.className='tool-card-row';
@@ -7042,7 +7087,7 @@ function buildToolCard(tc){
   const cardClass='tool-card'+(tc.done===false?' tool-card-running':'')+(isSubagent?' tool-card-subagent':'');
   // Clean up legacy subagent prefixes since the Lucide icon already shows it
   let displayName=_toolDisplayName(tc);
-  let previewText=tc.preview||displaySnippet||'';
+  let previewText=_toolCardPreviewText(tc, displaySnippet);
   if(isSubagent) previewText=previewText.replace(/^(?:\u{1F500}|↳)\s*/u,'');
   row.innerHTML=`
     <div class="${cardClass}">

--- a/tests/test_issue1824_cli_patch_diff_rendering.py
+++ b/tests/test_issue1824_cli_patch_diff_rendering.py
@@ -109,6 +109,8 @@ def test_rendered_apply_patch_tool_card_html_contains_diff_lines():
         "_cliPatchSnippetFromArgs",
         "_cliToolCardSnippet",
         "_cliToolCardHasDiffSnippet",
+        "_formatToolArgPreview",
+        "_toolCardPreviewText",
         "buildToolCard",
     ]
     functions = "\n".join(_function_source(UI_JS, name) for name in function_names)

--- a/tests/test_tool_card_preview_summary.py
+++ b/tests/test_tool_card_preview_summary.py
@@ -1,0 +1,105 @@
+"""Regression coverage for quiet collapsed tool-card previews.
+
+Collapsed tool rows are transcript metadata.  They should summarize the action
+(arguments/status) and keep verbose result JSON inside the expandable detail
+body; otherwise long tool-heavy turns visually turn into raw debug logs.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+_DRIVER_SRC = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+eval(extractFunc('_toolArgPreviewValue'));
+eval(extractFunc('_formatToolArgPreview'));
+eval(extractFunc('_toolCardPreviewText'));
+let buf = '';
+process.stdin.on('data', c => { buf += c; });
+process.stdin.on('end', () => {
+  const payload = JSON.parse(buf || '{}');
+  process.stdout.write(_toolCardPreviewText(payload.tc || {}, payload.displaySnippet || ''));
+});
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    p = tmp_path_factory.mktemp("tool_preview_driver") / "driver.js"
+    p.write_text(_DRIVER_SRC, encoding="utf-8")
+    return str(p)
+
+
+def _preview(driver_path: str, tc: dict, display_snippet: str = "") -> str:
+    assert NODE is not None
+    result = subprocess.run(
+        [NODE, driver_path, str(UI_JS_PATH)],
+        input=json.dumps({"tc": tc, "displaySnippet": display_snippet}),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+    return result.stdout
+
+
+def test_collapsed_tool_header_prefers_argument_summary_over_result_json(driver_path):
+    preview = _preview(
+        driver_path,
+        {
+            "name": "search_files",
+            "args": {
+                "target": "content",
+                "pattern": "Hattest du https://github.com/huggingface/speech-to-speech",
+                "path": "/tmp/hermes-webui",
+                "limit": "20",
+            },
+            "snippet": '{"total_count": 26, "matches": [{"path": "..."}]}',
+            "done": True,
+        },
+        '{"total_count": 26, "matches": [{"path": "..."}]}',
+    )
+
+    assert "pattern=" in preview
+    assert "/tmp/hermes-webui" in preview
+    assert "total_count" not in preview
+    assert "matches" not in preview
+
+
+def test_collapsed_tool_header_uses_status_when_no_preview_or_args(driver_path):
+    preview = _preview(driver_path, {"name": "terminal", "done": True}, "long stdout that belongs in detail")
+    assert preview == "Completed"
+
+
+def test_explicit_progress_preview_still_wins(driver_path):
+    preview = _preview(
+        driver_path,
+        {"name": "terminal", "preview": "Running command", "args": {"command": "pytest"}, "done": False},
+        "stdout",
+    )
+    assert preview == "Running command"


### PR DESCRIPTION
## Summary
- Keep collapsed tool-call previews quiet instead of exposing raw argument-ish text in settled chat rendering.
- Adds focused source-level regression coverage for the collapsed preview summary path.

## Validation
- `python3 -m pytest -q tests/test_tool_card_preview_summary.py`
- `node --check static/ui.js`
- `git diff --check`
- Added-line public hygiene scan for private/local markers: `0` hits
