### PR TITLE
fix: keep repaired messaging sidecar order

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -4146,6 +4146,8 @@ def get_state_db_session_messages(sid, *, stitch_continuations: bool = False, pr
                     'content': row['content'],
                     'timestamp': row['timestamp'],
                 }
+                if 'id' in row.keys() and row['id'] not in (None, ''):
+                    msg['id'] = row['id']
                 for col in optional:
                     if col not in row.keys():
                         continue

--- a/api/routes.py
+++ b/api/routes.py
@@ -3560,6 +3560,12 @@ def _webui_sidecar_lineage_messages_for_display(session, *, max_hops: int = 20) 
     )
 
 
+def _session_message_stable_id(msg) -> str:
+    if not isinstance(msg, dict):
+        return ""
+    return str(msg.get("id") or msg.get("message_id") or "")
+
+
 def _merged_session_messages_for_display(session, cli_messages=None) -> list:
     """Return the message coordinate space exposed by ``GET /api/session``.
 
@@ -3568,33 +3574,106 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
     snapshot parent plus a child continuation sidecar. The frontend computes
     fork keep-counts against this merged display list, so branch/fork must slice
     the same list rather than the sidecar-only ``session.messages`` array.
+
+    Treat the sidecar as the authoritative repaired ordering when both sources
+    exist: preserve it verbatim, then add only non-overlapping CLI rows before
+    the first sidecar timestamp or after the last sidecar timestamp. Sorting the
+    whole union by timestamp replays older compression-lineage rows into the
+    middle/tail of repaired messaging sidecars and makes repeated user turns
+    appear after reload.
     """
     cli_messages = list(cli_messages or [])
     sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)
-    if cli_messages:
-        if sidecar_messages and sidecar_messages != cli_messages:
-            if len(sidecar_messages) >= len(cli_messages):
-                return merge_session_messages_append_only(
-                    sidecar_messages,
-                    cli_messages,
-                    truncation_watermark=getattr(session, "truncation_watermark", None),
-                )
-            merged_messages = []
-            seen_message_keys = set()
-            for msg in sorted(list(cli_messages) + list(sidecar_messages), key=lambda m: (
-                float(m.get("timestamp") or 0),
-                str(m.get("role") or ""),
-                str(m.get("content") or ""),
-            )):
-                key = _session_message_merge_key(msg)
-                if key in seen_message_keys:
-                    continue
-                seen_message_keys.add(key)
-                merged_messages.append(msg)
-            return merged_messages
-        return sidecar_messages if len(sidecar_messages) > len(cli_messages) else cli_messages
-    return sidecar_messages
+    if not cli_messages:
+        return sidecar_messages
+    if not sidecar_messages:
+        return cli_messages
+    if sidecar_messages == cli_messages:
+        return sidecar_messages
 
+    sidecar_ids = {
+        stable_id
+        for msg in sidecar_messages
+        if (stable_id := _session_message_stable_id(msg))
+    }
+    sidecar_exact_keys = {
+        (_session_message_visible_key(msg), ts)
+        for msg in sidecar_messages
+        if (ts := _message_timestamp_as_float(msg)) is not None
+    }
+    sidecar_timestamps = [
+        ts for msg in sidecar_messages
+        if (ts := _message_timestamp_as_float(msg)) is not None
+    ]
+    if not sidecar_timestamps:
+        return merge_session_messages_append_only(
+            sidecar_messages,
+            cli_messages,
+            truncation_watermark=getattr(session, "truncation_watermark", None),
+        )
+    first_sidecar_ts = min(sidecar_timestamps)
+    last_sidecar_ts = max(sidecar_timestamps)
+    watermark_ts = _message_timestamp_as_float({"timestamp": getattr(session, "truncation_watermark", None)})
+    sidecar_advanced_past_watermark = watermark_ts is not None and last_sidecar_ts > watermark_ts
+
+    prefix = []
+    in_window_distinct = []
+    suffix = []
+    seen_ids = set(sidecar_ids)
+    for msg in cli_messages:
+        key = _session_message_visible_key(msg)
+        msg_id = _session_message_stable_id(msg)
+        timestamp = _message_timestamp_as_float(msg)
+        if msg_id and msg_id in seen_ids:
+            continue
+        if timestamp is None:
+            prefix.append(msg)
+            if msg_id:
+                seen_ids.add(msg_id)
+            continue
+        if (
+            watermark_ts is not None
+            and timestamp > watermark_ts
+            and not sidecar_advanced_past_watermark
+        ):
+            continue
+        if (key, timestamp) in sidecar_exact_keys and not (
+            msg_id and msg_id not in sidecar_ids and first_sidecar_ts <= timestamp <= last_sidecar_ts
+        ):
+            continue
+        if timestamp < first_sidecar_ts:
+            prefix.append(msg)
+            if msg_id:
+                seen_ids.add(msg_id)
+        elif timestamp > last_sidecar_ts:
+            suffix.append(msg)
+            if msg_id:
+                seen_ids.add(msg_id)
+        else:
+            in_window_distinct.append(msg)
+            if msg_id:
+                seen_ids.add(msg_id)
+
+    def sort_key(m):
+        return (
+            float(m.get("timestamp") or 0),
+            str(m.get("role") or ""),
+            str(m.get("content") or ""),
+        )
+
+    prefix.sort(key=sort_key)
+    suffix.sort(key=sort_key)
+    in_window_distinct.sort(key=sort_key)
+    merged_sidecar = []
+    pending_window = list(in_window_distinct)
+    for sidecar_msg in sidecar_messages:
+        sidecar_ts = _message_timestamp_as_float(sidecar_msg)
+        if sidecar_ts is not None:
+            while pending_window and (_message_timestamp_as_float(pending_window[0]) or 0) < sidecar_ts:
+                merged_sidecar.append(pending_window.pop(0))
+        merged_sidecar.append(sidecar_msg)
+    merged_sidecar.extend(pending_window)
+    return prefix + merged_sidecar + suffix
 
 
 def _merged_webui_lineage_messages_for_display(session, messages=None) -> list:
@@ -4011,6 +4090,7 @@ from api.models import (
     _active_stream_ids,
     _session_message_merge_key,
     _session_message_visible_key,
+    _message_timestamp_as_float,
     _is_empty_partial_activity_message,
     _hide_from_default_sidebar,
     prune_session_from_index,

--- a/tests/test_issue2472_fork_from_here_messaging.py
+++ b/tests/test_issue2472_fork_from_here_messaging.py
@@ -67,25 +67,25 @@ def test_messaging_merge_helper_dedupes_equivalent_timestamp_formats():
 
 
 def test_messaging_merge_preserves_longer_sidecar_order_when_timestamps_collapse():
-    """A repaired messaging sidecar can preserve order but lose subsecond timestamps.
+    """A repaired messaging sidecar can preserve order while state.db has subsecond mirrors.
 
-    Re-sorting those messages by ``(timestamp, role, content)`` groups assistant
-    and tool rows before user rows, making the WebUI look like replies vanished.
+    Stable IDs prove the CLI rows are mirrors, so the repaired sidecar order stays
+    authoritative instead of re-sorting the union by timestamp.
     """
     session = SimpleNamespace(
         messages=[
-            {"role": "assistant", "content": "prior answer", "timestamp": 100.0},
-            {"role": "user", "content": "first prompt", "timestamp": 101.0},
-            {"role": "assistant", "content": "first answer", "timestamp": 101.0},
-            {"role": "user", "content": "second prompt", "timestamp": 101.0},
-            {"role": "assistant", "content": "second answer", "timestamp": 101.0},
+            {"id": "m0", "role": "assistant", "content": "prior answer", "timestamp": 100.0},
+            {"id": "m1", "role": "user", "content": "first prompt", "timestamp": 101.0},
+            {"id": "m2", "role": "assistant", "content": "first answer", "timestamp": 101.0},
+            {"id": "m3", "role": "user", "content": "second prompt", "timestamp": 101.0},
+            {"id": "m4", "role": "assistant", "content": "second answer", "timestamp": 101.0},
         ]
     )
     cli_messages = [
-        {"role": "user", "content": "first prompt", "timestamp": 101.1},
-        {"role": "assistant", "content": "first answer", "timestamp": 101.2},
-        {"role": "user", "content": "second prompt", "timestamp": 101.3},
-        {"role": "assistant", "content": "second answer", "timestamp": 101.4},
+        {"id": "m1", "role": "user", "content": "first prompt", "timestamp": 101.1},
+        {"id": "m2", "role": "assistant", "content": "first answer", "timestamp": 101.2},
+        {"id": "m3", "role": "user", "content": "second prompt", "timestamp": 101.3},
+        {"id": "m4", "role": "assistant", "content": "second answer", "timestamp": 101.4},
     ]
 
     merged = routes._merged_session_messages_for_display(session, cli_messages)
@@ -96,6 +96,37 @@ def test_messaging_merge_preserves_longer_sidecar_order_when_timestamps_collapse
         "first answer",
         "second prompt",
         "second answer",
+    ]
+
+
+def test_messaging_merge_preserves_ambiguous_repeated_cli_tail_after_repaired_sidecar():
+    """No-ID same-visible/different-timestamp CLI suffix rows may be genuine repeats."""
+    session = SimpleNamespace(
+        messages=[
+            {"role": "user", "content": "start", "timestamp": 100},
+            {"role": "assistant", "content": "ready", "timestamp": 101},
+            {"role": "user", "content": "latest question", "timestamp": 200},
+            {"role": "assistant", "content": "latest answer", "timestamp": 201},
+        ]
+    )
+    cli_messages = [
+        {"role": "user", "content": "start", "timestamp": 100},
+        {"role": "assistant", "content": "ready", "timestamp": 101},
+        {"role": "user", "content": "latest question", "timestamp": 300},
+        {"role": "assistant", "content": "latest answer", "timestamp": 301},
+        {"role": "user", "content": "latest question", "timestamp": 302},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [m["content"] for m in merged] == [
+        "start",
+        "ready",
+        "latest question",
+        "latest answer",
+        "latest question",
+        "latest answer",
+        "latest question",
     ]
 
 

--- a/tests/test_session_import_cli_fallback_model.py
+++ b/tests/test_session_import_cli_fallback_model.py
@@ -389,12 +389,179 @@ def test_sessions_endpoint_suppresses_duplicate_webui_state_projection(monkeypat
     assert "telegram_tip" in session_ids
 
 
-def test_messaging_session_loader_prefers_longer_sidecar_transcript():
-    """Pin the /api/session invariant that repaired sidecars can be longer than state.db segments."""
+def test_messaging_session_loader_prefers_repaired_sidecar_transcript():
+    """Pin the /api/session invariant that repaired sidecars keep authoritative order."""
     handler = _extract_handler("handle_get")
     old = "if is_messaging_session and cli_messages:\n                    _all_msgs = cli_messages"
     assert old not in handler
     assert "_all_msgs = _merged_session_messages_for_display(s, cli_messages)" in handler
     src = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
     assert "sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)" in src
-    assert "len(sidecar_messages) > len(cli_messages)" in src
+    assert "return prefix + merged_sidecar + suffix" in src
+
+
+
+def test_messaging_merge_applies_truncation_watermark_before_sidecar_advances():
+    import types
+    import api.routes as routes
+
+    session = types.SimpleNamespace(
+        messages=[
+            {"role": "user", "content": "kept", "timestamp": 10.0},
+            {"role": "assistant", "content": "kept answer", "timestamp": 20.0},
+        ],
+        truncation_watermark=20.0,
+    )
+    cli_messages = [
+        {"role": "user", "content": "kept", "timestamp": 10.0},
+        {"role": "assistant", "content": "kept answer", "timestamp": 20.0},
+        {"role": "user", "content": "stale after truncation", "timestamp": 30.0},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [m["content"] for m in merged] == ["kept", "kept answer"]
+
+
+def test_messaging_merge_preserves_timestamp_less_cli_rows_at_prefix():
+    import types
+    import api.routes as routes
+
+    session = types.SimpleNamespace(
+        messages=[{"role": "assistant", "content": "sidecar", "timestamp": 10.0}],
+        truncation_watermark=None,
+    )
+    cli_messages = [
+        {"role": "user", "content": "legacy no timestamp"},
+        {"role": "assistant", "content": "sidecar", "timestamp": 10.0},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [m["content"] for m in merged] == ["legacy no timestamp", "sidecar"]
+
+
+def test_messaging_merge_places_same_timestamp_cli_extras_after_sidecar_row():
+    import types
+    import api.routes as routes
+
+    session = types.SimpleNamespace(
+        messages=[{"id": "sidecar-a", "role": "assistant", "content": "sidecar", "timestamp": 10.0}],
+        truncation_watermark=None,
+    )
+    cli_messages = [
+        {"id": "sidecar-a", "role": "assistant", "content": "sidecar", "timestamp": 10.0},
+        {"id": "cli-extra", "role": "assistant", "content": "cli extra", "timestamp": 10.0},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [m["content"] for m in merged] == ["sidecar", "cli extra"]
+
+def test_messaging_merge_preserves_same_visible_suffix_turn_with_distinct_timestamp():
+    import types
+    import api.routes as routes
+
+    session = types.SimpleNamespace(
+        messages=[
+            {"role": "user", "content": "hello", "timestamp": 100.0},
+            {"role": "assistant", "content": "hi", "timestamp": 101.0},
+            {"role": "user", "content": "alpha", "timestamp": 102.0},
+            {"role": "assistant", "content": "r", "timestamp": 103.0},
+        ],
+        truncation_watermark=None,
+    )
+    cli_messages = list(session.messages) + [
+        {"role": "user", "content": "alpha", "timestamp": 200.0},
+        {"role": "assistant", "content": "two", "timestamp": 201.0},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [(m["role"], m["content"], m.get("timestamp")) for m in merged] == [
+        ("user", "hello", 100.0),
+        ("assistant", "hi", 101.0),
+        ("user", "alpha", 102.0),
+        ("assistant", "r", 103.0),
+        ("user", "alpha", 200.0),
+        ("assistant", "two", 201.0),
+    ]
+
+
+def test_messaging_merge_preserves_timestamp_less_cli_row_without_poisoning_later_repeat():
+    import types
+    import api.routes as routes
+
+    session = types.SimpleNamespace(
+        messages=[{"role": "assistant", "content": "sidecar", "timestamp": 100.0}],
+        truncation_watermark=None,
+    )
+    cli_messages = [
+        {"role": "user", "content": "alpha"},
+        {"role": "assistant", "content": "sidecar", "timestamp": 100.0},
+        {"role": "user", "content": "alpha", "timestamp": 200.0},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [(m["role"], m["content"], m.get("timestamp")) for m in merged] == [
+        ("user", "alpha", None),
+        ("assistant", "sidecar", 100.0),
+        ("user", "alpha", 200.0),
+    ]
+
+
+def test_messaging_merge_dedupes_timestamp_less_cli_row_when_stable_id_matches_sidecar():
+    import types
+    import api.routes as routes
+
+    session = types.SimpleNamespace(
+        messages=[{"message_id": "m1", "role": "user", "content": "alpha", "timestamp": 100.0}],
+        truncation_watermark=None,
+    )
+    cli_messages = [{"message_id": "m1", "role": "user", "content": "alpha"}]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [(m.get("message_id"), m["content"]) for m in merged] == [("m1", "alpha")]
+
+
+def test_messaging_merge_honors_message_id_alias_for_distinct_repeated_suffix_turn():
+    import types
+    import api.routes as routes
+
+    session = types.SimpleNamespace(
+        messages=[{"message_id": "s1", "role": "user", "content": "alpha", "timestamp": 100.0}],
+        truncation_watermark=None,
+    )
+    cli_messages = [
+        {"message_id": "s1", "role": "user", "content": "alpha", "timestamp": 100.0},
+        {"message_id": "c2", "role": "user", "content": "alpha", "timestamp": 200.0},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [(m.get("message_id"), m["content"], m.get("timestamp")) for m in merged] == [
+        ("s1", "alpha", 100.0),
+        ("c2", "alpha", 200.0),
+    ]
+
+def test_state_db_session_messages_preserve_message_id(monkeypatch, tmp_path):
+    import sqlite3
+    import api.models as models
+
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE messages (id TEXT PRIMARY KEY, session_id TEXT, role TEXT, content TEXT, timestamp REAL)"
+        )
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?, ?, ?, ?, ?)",
+            ("msg-1", "sid-1", "user", "hello", 1.0),
+        )
+
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db_path)
+
+    messages = models.get_state_db_session_messages("sid-1")
+
+    assert messages == [{"id": "msg-1", "role": "user", "content": "hello", "timestamp": 1.0}]

--- a/tests/test_session_lineage_full_transcript.py
+++ b/tests/test_session_lineage_full_transcript.py
@@ -126,7 +126,7 @@ def test_session_endpoint_preserves_distinct_messages_with_different_ids(monkeyp
 
     session = captured["payload"]["session"]
     retry_messages = [m for m in session["messages"] if m.get("content") == "retry the same request"]
-    assert [m.get("id") for m in retry_messages] == ["cli-retry", "sidecar-retry"]
+    assert [m.get("id") for m in retry_messages] == ["sidecar-retry", "cli-retry"]
 
 
 


### PR DESCRIPTION
## Summary
- Treat repaired messaging sidecars as the authoritative in-range ordering when merging with CLI/state rows for display.
- Keep only non-overlapping CLI rows outside the sidecar timestamp window, avoiding replayed old tails after a repaired sidecar.
- Adds a regression that preserves repaired sidecar order instead of re-appending stale CLI tail rows.

## Validation
- `python3 -m pytest -q tests/test_issue2472_fork_from_here_messaging.py tests/test_session_import_cli_fallback_model.py`
- `python3 -m py_compile api/routes.py`
- `git diff --check`
- Added-line public hygiene scan for private/local markers: `0` hits
