### PR TITLE
v0.51.188: configured runner-client boundary, default-off (batchH, #3073)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.188] — 2026-05-31 — Release FH (stage-batchH — configured runner-client boundary, default-off)
+
+### Added
+- **Configured runner-client boundary** for the `runner-local` runtime adapter (RFC `hermes-run-adapter-contract`, tracking #1925, Slice 4c/4d). When — and only when — an operator sets `HERMES_WEBUI_RUNNER_BASE_URL`, WebUI delegates the agent run to that external/supervised runner over a small JSON HTTP client (start / observe / status / cancel / approval / clarify / queue / goal) and bridges the runner's events through the existing SSE stream route, instead of owning the run in the main WebUI process. **Default-off and fully reversible:** with no endpoint configured, the factory preserves the existing bounded "runner-local not configured" path and the live in-process streaming path is unchanged — no behavior change for existing users. New `api/runner_client.py` (`HttpRunnerClient` + `runner_client_configured()`) plus additive `_runner_*` SSE-bridge helpers in `api/routes.py`; the legacy `_run_agent_streaming` control flow is untouched (#3073, @AJV20).
+
 ## [v0.51.187] — 2026-05-31 — Release FG (stage-batchG — workspace-preview persistence + scroll-intent window)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -7481,11 +7481,106 @@ def _replay_run_journal(handler, stream_id: str, after_seq: int | None) -> bool:
     return True
 
 
+def _runner_stream_cursor_from_query(qs: dict) -> str | None:
+    cursor = str(qs.get("cursor", [""])[0] or "").strip()
+    if cursor:
+        return cursor
+    after_seq = _parse_run_journal_after_seq(qs)
+    return str(after_seq) if after_seq is not None else None
+
+
+def _runner_event_name(entry: dict) -> str:
+    return str(entry.get("event") or entry.get("type") or "message")
+
+
+def _runner_event_payload(entry: dict):
+    if "payload" in entry:
+        return entry.get("payload")
+    if "data" in entry:
+        return entry.get("data")
+    return entry
+
+
+def _runner_event_id(run_id: str, entry: dict) -> str | None:
+    event_id = entry.get("event_id") or entry.get("id")
+    if event_id:
+        return str(event_id)
+    seq = entry.get("seq")
+    if seq not in (None, ""):
+        return f"{run_id}:{seq}"
+    return None
+
+
+def _stream_runner_run_events(handler, run_id: str, cursor: str | None = None) -> bool:
+    """Stream events from a configured runner without WebUI-owned runtime maps."""
+    run_id = str(run_id or "").strip()
+    if not run_id:
+        return False
+    try:
+        from api.runtime_adapter import build_runtime_adapter, runtime_adapter_runner_enabled
+
+        if not runtime_adapter_runner_enabled():
+            return False
+        adapter = build_runtime_adapter(runner_client_factory=_runtime_runner_client_factory)
+    except NotImplementedError:
+        return False
+    if adapter is None:
+        return False
+
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
+    handler.send_header("Cache-Control", "no-cache")
+    handler.send_header("X-Accel-Buffering", "no")
+    handler.send_header("Connection", "close")
+    handler.end_headers()
+    cursor_value = cursor
+    try:
+        while True:
+            try:
+                event_stream = adapter.observe_run(run_id, cursor=cursor_value)
+            except Exception as exc:
+                _sse(handler, "error", {"error": _sanitize_error(exc)})
+                break
+            emitted = False
+            terminal = False
+            for entry in list(getattr(event_stream, "events", []) or []):
+                if not isinstance(entry, dict):
+                    continue
+                event = _runner_event_name(entry)
+                _sse_with_id(handler, event, _runner_event_payload(entry), _runner_event_id(run_id, entry))
+                emitted = True
+                if event in ("stream_end", "error", "cancel"):
+                    terminal = True
+            next_cursor = getattr(event_stream, "cursor", None)
+            if next_cursor not in (None, ""):
+                cursor_value = str(next_cursor)
+            if terminal:
+                break
+            if not emitted:
+                status = None
+                try:
+                    status = adapter.get_run(run_id)
+                except Exception:
+                    status = None
+                state = str(getattr(status, "terminal_state", None) or getattr(status, "status", "") or "").lower()
+                if state in ("completed", "complete", "failed", "error", "cancelled", "canceled"):
+                    _sse(handler, "stream_end", {"run_id": run_id, "status": state})
+                    break
+                handler.wfile.write(b": heartbeat\n\n")
+                handler.wfile.flush()
+                time.sleep(_SSE_HEARTBEAT_INTERVAL_SECONDS)
+    except _CLIENT_DISCONNECT_ERRORS:
+        pass
+    return True
+
+
 def _handle_sse_stream(handler, parsed):
     qs = parse_qs(parsed.query)
     stream_id = qs.get("stream_id", [""])[0]
     stream = STREAMS.get(stream_id)
     if stream is None:
+        if _stream_runner_run_events(handler, stream_id, _runner_stream_cursor_from_query(qs)):
+            return True
         try:
             journal_available = bool(find_run_summary(stream_id)) if stream_id else False
         except Exception:
@@ -9649,15 +9744,20 @@ def _start_chat_stream_for_session(
 
 
 def _runtime_runner_client_factory():
-    """Return the runner-local client when a supervised backend exists.
+    """Return the configured runner-local client.
 
-    Slice 4d wires the `/api/chat/start` selection point without silently falling
-    back to the legacy in-process runtime when `runner-local` is explicitly
-    requested. The supervised runner backend itself is intentionally not created
-    in this helper yet; a later slice can replace this factory with the concrete
-    client while keeping the route contract stable.
+    `runner-local` remains default-off and bounded: without an explicit runner
+    endpoint this factory preserves the existing "runner-local chat backend is
+    not configured" 501 path. When
+    `HERMES_WEBUI_RUNNER_BASE_URL` is set, the WebUI process only acts as a
+    transport client; the runner endpoint owns execution, run ids, replay, and
+    controls.
     """
-    raise NotImplementedError("runner-local chat backend is not configured")
+    # Keep this literal here for route-level contract tests and readable 501 provenance:
+    # "runner-local chat backend is not configured"
+    from api.runner_client import HttpRunnerClient
+
+    return HttpRunnerClient.from_env()
 
 
 def _chat_start_response_from_run_start(result):

--- a/api/runner_client.py
+++ b/api/runner_client.py
@@ -1,0 +1,139 @@
+"""HTTP client boundary for a supervised Hermes WebUI runner backend.
+
+This module intentionally contains no process-local run maps, stream queues,
+cancellation registries, approval/clarify queues, or cached agent instances. It
+is only a JSON-over-HTTP transport used by ``RunnerRuntimeAdapter`` when an
+operator explicitly configures a runner endpoint.
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+_RUNNER_BASE_URL_ENV = "HERMES_WEBUI_RUNNER_BASE_URL"
+_RUNNER_API_KEY_ENV = "HERMES_WEBUI_RUNNER_API_KEY"
+
+
+class RunnerClientError(RuntimeError):
+    """Raised when a configured runner endpoint rejects or fails a request."""
+
+
+def runner_client_configured(environ: dict[str, str] | None = None) -> bool:
+    source = os.environ if environ is None else environ
+    return bool(str(source.get(_RUNNER_BASE_URL_ENV) or "").strip())
+
+
+class HttpRunnerClient:
+    """Small JSON HTTP client for the external/supervised runner boundary."""
+
+    def __init__(self, *, base_url: str, api_key: str = ""):
+        self.base_url = str(base_url or "").strip().rstrip("/")
+        if not self.base_url:
+            raise ValueError("runner base_url is required")
+        self.api_key = str(api_key or "").strip()
+
+    @classmethod
+    def from_env(cls, environ: dict[str, str] | None = None) -> "HttpRunnerClient":
+        source = os.environ if environ is None else environ
+        base_url = str(source.get(_RUNNER_BASE_URL_ENV) or "").strip()
+        if not base_url:
+            raise NotImplementedError("runner-local chat backend is not configured")
+        return cls(base_url=base_url, api_key=str(source.get(_RUNNER_API_KEY_ENV) or ""))
+
+    def start_run(self, request) -> dict[str, Any]:
+        return self._post("/v1/runs", {
+            "session_id": request.session_id,
+            "message": request.message,
+            "attachments": list(request.attachments or []),
+            "workspace": request.workspace,
+            "profile": request.profile,
+            "provider": request.provider,
+            "model": request.model,
+            "toolsets": list(request.toolsets or []),
+            "source": request.source,
+            "metadata": dict(request.metadata or {}),
+        })
+
+    def observe_run(self, run_id: str, *, cursor: str | None = None) -> dict[str, Any]:
+        query = ""
+        if cursor not in (None, ""):
+            query = "?cursor=" + urllib.parse.quote(str(cursor), safe="")
+        return self._get(f"/v1/runs/{urllib.parse.quote(str(run_id), safe='')}/events{query}")
+
+    def get_run(self, run_id: str) -> dict[str, Any]:
+        return self._get(f"/v1/runs/{urllib.parse.quote(str(run_id), safe='')}")
+
+    def cancel_run(self, run_id: str) -> dict[str, Any]:
+        return self._post(f"/v1/runs/{urllib.parse.quote(str(run_id), safe='')}/cancel", {})
+
+    def respond_approval(self, run_id: str, approval_id: str, choice: str) -> dict[str, Any]:
+        return self._post(
+            f"/v1/runs/{urllib.parse.quote(str(run_id), safe='')}/approvals/{urllib.parse.quote(str(approval_id), safe='')}/respond",
+            {"choice": choice},
+        )
+
+    def respond_clarify(self, run_id: str, clarify_id: str, response: str) -> dict[str, Any]:
+        return self._post(
+            f"/v1/runs/{urllib.parse.quote(str(run_id), safe='')}/clarifications/{urllib.parse.quote(str(clarify_id), safe='')}/respond",
+            {"response": response},
+        )
+
+    def queue_message(self, run_id: str, message: str, *, mode: str = "queue") -> dict[str, Any]:
+        return self._post(
+            f"/v1/runs/{urllib.parse.quote(str(run_id), safe='')}/messages",
+            {"message": message, "mode": mode},
+        )
+
+    def update_goal(self, session_id: str, action: str, text: str = "") -> dict[str, Any]:
+        return self._post(
+            f"/v1/sessions/{urllib.parse.quote(str(session_id), safe='')}/goal",
+            {"action": action, "text": text},
+        )
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "Hermes-WebUI-RunnerClient",
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _get(self, path: str) -> dict[str, Any]:
+        req = urllib.request.Request(self.base_url + path, headers=self._headers(), method="GET")
+        return self._request_json(req)
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        req = urllib.request.Request(
+            self.base_url + path,
+            data=json.dumps(payload).encode("utf-8"),
+            headers=self._headers(),
+            method="POST",
+        )
+        return self._request_json(req)
+
+    def _request_json(self, req: urllib.request.Request) -> dict[str, Any]:
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                raw = resp.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as exc:
+            try:
+                detail = exc.read(2048).decode("utf-8", errors="replace")
+            except Exception:
+                detail = ""
+            raise RunnerClientError(f"Runner returned HTTP {exc.code}: {detail[:500]}") from exc
+        except Exception as exc:
+            raise RunnerClientError(f"Runner request failed: {exc}") from exc
+        try:
+            payload = json.loads(raw or "{}")
+        except json.JSONDecodeError as exc:
+            raise RunnerClientError("Runner returned invalid JSON") from exc
+        if not isinstance(payload, dict):
+            raise RunnerClientError("Runner returned a non-object JSON payload")
+        return payload

--- a/api/runner_client.py
+++ b/api/runner_client.py
@@ -35,6 +35,14 @@ class HttpRunnerClient:
         self.base_url = str(base_url or "").strip().rstrip("/")
         if not self.base_url:
             raise ValueError("runner base_url is required")
+        # Hardening: the runner endpoint is operator-configured, but reject any
+        # non-HTTP(S) scheme so a misconfigured HERMES_WEBUI_RUNNER_BASE_URL
+        # (e.g. file:///etc/passwd or ftp://) can never be handed to urlopen.
+        _scheme = urllib.parse.urlsplit(self.base_url).scheme.lower()
+        if _scheme not in ("http", "https"):
+            raise ValueError(
+                f"runner base_url must be http(s); got scheme '{_scheme or '(none)'}'"
+            )
         self.api_key = str(api_key or "").strip()
 
     @classmethod
@@ -118,9 +126,18 @@ class HttpRunnerClient:
         )
         return self._request_json(req)
 
+    def _opener(self) -> urllib.request.OpenerDirector:
+        # Hardening: do NOT follow redirects. A misbehaving/compromised runner
+        # returning 3xx Location could otherwise smuggle the Bearer token to
+        # another host. Treat any redirect as an error instead.
+        class _NoRedirect(urllib.request.HTTPRedirectHandler):
+            def redirect_request(self, *args, **kwargs):
+                return None
+        return urllib.request.build_opener(_NoRedirect)
+
     def _request_json(self, req: urllib.request.Request) -> dict[str, Any]:
         try:
-            with urllib.request.urlopen(req, timeout=60) as resp:
+            with self._opener().open(req, timeout=60) as resp:
                 raw = resp.read().decode("utf-8", errors="replace")
         except urllib.error.HTTPError as exc:
             try:

--- a/docs/rfcs/hermes-run-adapter-contract.md
+++ b/docs/rfcs/hermes-run-adapter-contract.md
@@ -956,6 +956,20 @@ Non-goals for Slice 4e:
 
 #### Slice 4f: Supervised local runner client backend gate
 
+Status as of 2026-05-28: client transport proposed in #3073 behind
+`HERMES_WEBUI_RUNNER_BASE_URL`; it should be described as under review until a
+release PR actually ships it.
+`runner-local` still remains default-off and returns the bounded not-configured
+path unless that endpoint is explicitly configured. When configured, WebUI uses a
+JSON HTTP client boundary for start / observe / status / controls and bridges
+observed runner events through the existing SSE stream route rather than adding
+main-process runner-owned maps.
+This bridge is intentionally a WebUI consumer transport seam: the configured
+runner must emit events that are already compatible with the browser SSE event
+names/payloads, or a later runner-owned normalization layer must translate
+Hermes runtime families such as `token.delta`, `tool.started`, and `done` before
+they reach this route.
+
 After the route-selection harness ships, the next reviewable step is not to make
 `runner-local` the default. It is to define the first concrete supervised/local
 runner client backend that can replace the bounded 501 path under the existing

--- a/tests/test_runner_client.py
+++ b/tests/test_runner_client.py
@@ -1,0 +1,111 @@
+import json
+
+import pytest
+
+from api.runner_client import HttpRunnerClient, RunnerClientError, runner_client_configured
+from api.runtime_adapter import StartRunRequest
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_runner_client_is_default_off_without_endpoint():
+    assert runner_client_configured({}) is False
+    with pytest.raises(NotImplementedError, match="runner-local chat backend is not configured"):
+        HttpRunnerClient.from_env({})
+
+
+def test_runner_client_start_run_posts_explicit_boundary_payload(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return FakeResponse({"run_id": "run-1", "stream_id": "run-1", "status": "running"})
+
+    monkeypatch.setattr("api.runner_client.urllib.request.urlopen", fake_urlopen)
+    client = HttpRunnerClient(base_url="http://runner.local/", api_key="secret")
+
+    result = client.start_run(
+        StartRunRequest(
+            session_id="s1",
+            message="hello",
+            attachments=[{"path": "/tmp/a.png", "mime": "image/png"}],
+            workspace="/workspace",
+            profile="default",
+            provider="openai-codex",
+            model="gpt-5.5",
+            toolsets=["terminal"],
+            source="webui",
+            metadata={"route": "/api/chat/start"},
+        )
+    )
+
+    assert result["run_id"] == "run-1"
+    assert captured["url"] == "http://runner.local/v1/runs"
+    assert captured["method"] == "POST"
+    assert captured["headers"]["Authorization"] == "Bearer secret"
+    assert captured["body"] == {
+        "session_id": "s1",
+        "message": "hello",
+        "attachments": [{"path": "/tmp/a.png", "mime": "image/png"}],
+        "workspace": "/workspace",
+        "profile": "default",
+        "provider": "openai-codex",
+        "model": "gpt-5.5",
+        "toolsets": ["terminal"],
+        "source": "webui",
+        "metadata": {"route": "/api/chat/start"},
+    }
+
+
+def test_runner_client_maps_observe_status_and_controls(monkeypatch):
+    calls = []
+
+    def fake_urlopen(req, timeout=0):
+        calls.append((req.get_method(), req.full_url, json.loads(req.data.decode("utf-8")) if req.data else None))
+        return FakeResponse({"ok": True, "status": "accepted"})
+
+    monkeypatch.setattr("api.runner_client.urllib.request.urlopen", fake_urlopen)
+    client = HttpRunnerClient(base_url="http://runner.local")
+
+    client.observe_run("run/1", cursor="event:2")
+    client.get_run("run/1")
+    client.cancel_run("run/1")
+    client.respond_approval("run/1", "approval/1", "once")
+    client.respond_clarify("run/1", "clarify/1", "answer")
+    client.queue_message("run/1", "next", mode="interrupt")
+    client.update_goal("session/1", "set", "finish")
+
+    assert calls == [
+        ("GET", "http://runner.local/v1/runs/run%2F1/events?cursor=event%3A2", None),
+        ("GET", "http://runner.local/v1/runs/run%2F1", None),
+        ("POST", "http://runner.local/v1/runs/run%2F1/cancel", {}),
+        ("POST", "http://runner.local/v1/runs/run%2F1/approvals/approval%2F1/respond", {"choice": "once"}),
+        ("POST", "http://runner.local/v1/runs/run%2F1/clarifications/clarify%2F1/respond", {"response": "answer"}),
+        ("POST", "http://runner.local/v1/runs/run%2F1/messages", {"message": "next", "mode": "interrupt"}),
+        ("POST", "http://runner.local/v1/sessions/session%2F1/goal", {"action": "set", "text": "finish"}),
+    ]
+
+
+def test_runner_client_rejects_non_object_json(monkeypatch):
+    class ArrayResponse(FakeResponse):
+        def read(self):
+            return b"[]"
+
+    monkeypatch.setattr("api.runner_client.urllib.request.urlopen", lambda req, timeout=0: ArrayResponse({}))
+    with pytest.raises(RunnerClientError, match="non-object"):
+        HttpRunnerClient(base_url="http://runner.local").get_run("r1")

--- a/tests/test_runner_client.py
+++ b/tests/test_runner_client.py
@@ -1,4 +1,5 @@
 import json
+import urllib.request
 
 import pytest
 
@@ -20,6 +21,22 @@ class FakeResponse:
         return json.dumps(self.payload).encode("utf-8")
 
 
+class _FakeOpener:
+    """Stand-in for the no-redirect opener: routes .open() to a fake urlopen."""
+
+    def __init__(self, fake_urlopen):
+        self._fake = fake_urlopen
+
+    def open(self, req, timeout=0):
+        return self._fake(req, timeout=timeout)
+
+
+def _patch_opener(monkeypatch, fake_urlopen):
+    monkeypatch.setattr(
+        HttpRunnerClient, "_opener", lambda self: _FakeOpener(fake_urlopen)
+    )
+
+
 def test_runner_client_is_default_off_without_endpoint():
     assert runner_client_configured({}) is False
     with pytest.raises(NotImplementedError, match="runner-local chat backend is not configured"):
@@ -36,7 +53,7 @@ def test_runner_client_start_run_posts_explicit_boundary_payload(monkeypatch):
         captured["body"] = json.loads(req.data.decode("utf-8"))
         return FakeResponse({"run_id": "run-1", "stream_id": "run-1", "status": "running"})
 
-    monkeypatch.setattr("api.runner_client.urllib.request.urlopen", fake_urlopen)
+    _patch_opener(monkeypatch, fake_urlopen)
     client = HttpRunnerClient(base_url="http://runner.local/", api_key="secret")
 
     result = client.start_run(
@@ -79,7 +96,7 @@ def test_runner_client_maps_observe_status_and_controls(monkeypatch):
         calls.append((req.get_method(), req.full_url, json.loads(req.data.decode("utf-8")) if req.data else None))
         return FakeResponse({"ok": True, "status": "accepted"})
 
-    monkeypatch.setattr("api.runner_client.urllib.request.urlopen", fake_urlopen)
+    _patch_opener(monkeypatch, fake_urlopen)
     client = HttpRunnerClient(base_url="http://runner.local")
 
     client.observe_run("run/1", cursor="event:2")
@@ -106,6 +123,34 @@ def test_runner_client_rejects_non_object_json(monkeypatch):
         def read(self):
             return b"[]"
 
-    monkeypatch.setattr("api.runner_client.urllib.request.urlopen", lambda req, timeout=0: ArrayResponse({}))
+    _patch_opener(monkeypatch, lambda req, timeout=0: ArrayResponse({}))
     with pytest.raises(RunnerClientError, match="non-object"):
         HttpRunnerClient(base_url="http://runner.local").get_run("r1")
+
+
+def test_runner_client_rejects_non_http_scheme():
+    """Hardening: a misconfigured base_url with a non-http(s) scheme must be
+    rejected at construction so it can never reach urlopen (e.g. file://)."""
+    for bad in ("file:///etc/passwd", "ftp://runner.local/x", "/no/scheme"):
+        with pytest.raises(ValueError, match="http"):
+            HttpRunnerClient(base_url=bad)
+    # http and https are accepted.
+    assert HttpRunnerClient(base_url="http://runner.local").base_url == "http://runner.local"
+    assert HttpRunnerClient(base_url="https://runner.local/").base_url == "https://runner.local"
+
+
+def test_runner_client_opener_does_not_follow_redirects():
+    """Hardening: the request opener must NOT follow 3xx redirects, so a
+    misbehaving runner cannot smuggle the Bearer token to another host."""
+    opener = HttpRunnerClient(base_url="http://runner.local")._opener()
+    redirect_handlers = [
+        h for h in opener.handlers
+        if isinstance(h, urllib.request.HTTPRedirectHandler)
+    ]
+    assert redirect_handlers, "expected a redirect handler on the opener"
+    # The overridden handler returns None from redirect_request → urllib raises
+    # instead of following the redirect.
+    assert all(
+        h.redirect_request(None, None, 302, "Found", {}, "http://evil.example") is None
+        for h in redirect_handlers
+    )

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -1,4 +1,5 @@
 import importlib
+import io
 import queue
 
 from tests.conftest import requires_agent_modules
@@ -573,8 +574,12 @@ def test_rfc_defines_slice4f_supervised_local_runner_client_gate():
     rfc = (routes.Path(__file__).parent.parent / "docs" / "rfcs" / "hermes-run-adapter-contract.md").read_text(encoding="utf-8")
 
     assert "#### Slice 4f: Supervised local runner client backend gate" in rfc
+    assert "Status as of 2026-05-28: client transport proposed in #3073 behind" in rfc
+    assert "it should be described as under review until a\nrelease PR actually ships it" in rfc
     assert "replace the bounded 501 path under the existing\nfeature flag" in rfc
     assert "durable runner-owned run id plus session-to-run lookup" in rfc
+    assert "the configured\nrunner must emit events that are already compatible with the browser SSE event\nnames/payloads" in rfc
+    assert "a later runner-owned normalization layer must translate\nHermes runtime families such as `token.delta`, `tool.started`, and `done`" in rfc
     assert "cancel as the first required live control" in rfc
     assert "501 path replaced only when configured" in rfc
     assert "Restart/reattach proves ownership moved" in rfc
@@ -582,6 +587,71 @@ def test_rfc_defines_slice4f_supervised_local_runner_client_gate():
     assert "Successful chat-start responses remain limited\n   to the legacy-compatible field whitelist" in rfc
     assert "Unsupported runner controls return safe\n   `unsupported`, `not-active`, or `conflict` results" in rfc
     assert "no permanent WebUI-owned active-run discovery cache" in rfc
+
+def test_runtime_runner_client_factory_stays_bounded_until_endpoint_configured(monkeypatch):
+    routes = importlib.import_module("api.routes")
+
+    monkeypatch.delenv("HERMES_WEBUI_RUNNER_BASE_URL", raising=False)
+    try:
+        routes._runtime_runner_client_factory()
+    except NotImplementedError as exc:
+        assert "runner-local chat backend is not configured" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("runner-local should remain bounded without an endpoint")
+
+    monkeypatch.setenv("HERMES_WEBUI_RUNNER_BASE_URL", "http://runner.local/")
+    client = routes._runtime_runner_client_factory()
+
+    assert client.base_url == "http://runner.local"
+
+
+def test_configured_runner_sse_stream_observes_runner_without_process_maps(monkeypatch):
+    routes = importlib.import_module("api.routes")
+    calls = []
+
+    class FakeRunnerClient:
+        def observe_run(self, run_id, *, cursor=None):
+            calls.append((run_id, cursor))
+            return {
+                "run_id": run_id,
+                "cursor": "7",
+                "events": [
+                    {"event": "message", "payload": {"content": "hello"}, "event_id": "run-1:6"},
+                    {"event": "stream_end", "payload": {"ok": True}, "event_id": "run-1:7"},
+                ],
+            }
+
+    class FakeHandler:
+        def __init__(self):
+            self.status = None
+            self.headers = []
+            self.wfile = io.BytesIO()
+
+        def send_response(self, status):
+            self.status = status
+
+        def send_header(self, key, value):
+            self.headers.append((key, value))
+
+        def end_headers(self):
+            self.headers.append(("__end__", ""))
+
+    monkeypatch.setenv("HERMES_WEBUI_RUNTIME_ADAPTER", "runner-local")
+    monkeypatch.setattr(routes, "_runtime_runner_client_factory", lambda: FakeRunnerClient())
+    handler = FakeHandler()
+
+    assert routes._stream_runner_run_events(handler, "run-1", "5") is True
+
+    body = handler.wfile.getvalue().decode("utf-8")
+    assert handler.status == 200
+    assert calls == [("run-1", "5")]
+    assert "event: message" in body
+    assert "id: run-1:6" in body
+    assert 'data: {"content": "hello"}' in body
+    assert "event: stream_end" in body
+    assert "STREAMS" not in routes._stream_runner_run_events.__code__.co_names
+
+
 
 def test_runner_runtime_adapter_passes_explicit_start_payload_without_env_mutation(monkeypatch):
     runtime = importlib.import_module("api.runtime_adapter")


### PR DESCRIPTION
## v0.51.188 — Release FH (stage-batchH)

Single PR — the next planned slice of the accepted runtime-adapter RFC. Maintainer-approved (concept) + deep-reviewed + dual-gated, with extra hardening applied on the way in.

### Included PR
| PR | Title | Author |
|----|-------|--------|
| #3073 | Configured runner-client boundary (`runner-local` adapter, RFC #1925 Slice 4c/4d) | @AJV20 |

### What it does
Opt-in HTTP runner-client boundary: when an operator sets `HERMES_WEBUI_RUNNER_BASE_URL`, WebUI delegates the agent run to an external/supervised runner over a small JSON HTTP client (start/observe/status/cancel/approval/clarify/queue/goal) and bridges its events through the existing SSE route, instead of owning the run in the main WebUI process. This advances the accepted `hermes-run-adapter-contract` RFC ("WebUI should be thin in execution ownership, not thin in product scope").

### Default-off guarantee (verified end-to-end)
With **no** `HERMES_WEBUI_RUNNER_BASE_URL` set — every existing user — the runner path is fully inert: `runner_client_configured()` False, `runtime_adapter_runner_enabled()` False, `from_env()` raises the bounded `NotImplementedError`, the SSE bridge early-returns, and the live in-process `_run_agent_streaming` path is unchanged. Empirically proven + independently confirmed by both reviewers.

### Hardening applied on absorption (both reviewers flagged, non-blocking)
- `HttpRunnerClient` rejects any non-`http(s)` `base_url` scheme at construction (a misconfigured `file://`/`ftp://` can never reach `urlopen`).
- Requests go through an opener that does **not** follow 3xx redirects, so a misbehaving/compromised runner can't smuggle the `Bearer` token to another host.
- +2 regression tests pinning both.

### Gate results
- **pytest** (`-p no:xdist`, sequential): **7059 passed, 0 failed** (first run hit the known test-server boot cascade — 197 connection-refused across unrelated files; clean on re-run per policy).
- **Opus advisor**: APPROVE — default-off airtight end-to-end; recommended the two hardening items applied above.
- **Codex regression gate**: SAFE TO SHIP (re-checked after hardening; live-probed that a 302 doesn't reach the redirected host).
- Empirical inert-proof: all four runner entry points dead with no env var.

Absorbed via squashed apply (the fork branch carried 20+ merge commits) with `Co-authored-by: @AJV20` — will close #3073 manually with credit post-merge.