### PR TITLE
v0.51.189: ruff lint gate + SSE refresh dedupe + tooltip i18n (stage-batch1)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,36 @@ on:
     branches: [master]
 
 jobs:
+  # Forward-looking Python lint gate (ruff). The Python twin of the ESLint runtime
+  # guard. Runs the curated [tool.ruff] ruleset (E9 + F + B) but only on lines this
+  # PR adds/modifies vs the merge-base — so it keeps NEW code clean without demanding
+  # a reformat of the existing tree's cosmetic backlog (#3273). Fast, fails early.
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need history so the gate can diff against the merge-base with master.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Ensure origin/master ref is available for the diff gate
+        run: git fetch --no-tags --depth=1 origin master || true
+
+      - name: Ruff forward gate (new/changed lines only)
+        run: python3 scripts/ruff_lint.py --diff origin/master
+
+      - name: Ruff whole-tree report (informational — never blocks)
+        if: always()
+        run: python3 scripts/ruff_lint.py --all
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -41,6 +71,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install "pyyaml>=6.0" pytest pytest-timeout pytest-asyncio pytest-shard
+          # ruff is installed so tests/test_ruff_forward_lint.py runs its E9/F821
+          # tree-clean assertions in-suite (mirrors how eslint is available for
+          # tests/test_static_js_runtime_lint.py). If install fails the test
+          # skips cleanly — it never blocks the matrix.
+          pip install ruff || echo "ruff install failed — test_ruff_forward_lint.py will skip"
           # Install the `mcp` package so tests/test_mcp_server.py runs in CI.
           # The package is an optional runtime dep of mcp_server.py — users
           # who run the MCP integration install it themselves; CI installs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+- **Forward-looking Python lint gate (ruff).** A curated `[tool.ruff]` ruleset (E9 syntax/runtime + F pyflakes + B bugbear — high-signal correctness rules, no style/formatting families) now gates **new and changed Python code** in CI (`tests.yml` `lint` job) and as part of the maintainer pre-release pre-gate. It is the Python twin of the existing ESLint runtime guard for `static/*.js`. Crucially it is **line-scoped** (`scripts/ruff_lint.py --diff`): it flags violations only on lines a change adds or modifies, so it keeps incoming code clean **without** reformatting the existing tree's cosmetic backlog (a separate, deferred, maintainer-run decision). `tests/test_ruff_forward_lint.py` additionally holds the whole tree free of E9 errors and skips cleanly when ruff isn't installed. See TESTING.md > "Python lint gate (ruff)". Closes #3273.
+
+
 ## [v0.51.188] — 2026-05-31 — Release FH (stage-batchH — configured runner-client boundary, default-off)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@
 
 ## [Unreleased]
 
-### Added
-- **Forward-looking Python lint gate (ruff).** A curated `[tool.ruff]` ruleset (E9 syntax/runtime + F pyflakes + B bugbear — high-signal correctness rules, no style/formatting families) now gates **new and changed Python code** in CI (`tests.yml` `lint` job) and as part of the maintainer pre-release pre-gate. It is the Python twin of the existing ESLint runtime guard for `static/*.js`. Crucially it is **line-scoped** (`scripts/ruff_lint.py --diff`): it flags violations only on lines a change adds or modifies, so it keeps incoming code clean **without** reformatting the existing tree's cosmetic backlog (a separate, deferred, maintainer-run decision). `tests/test_ruff_forward_lint.py` additionally holds the whole tree free of E9 errors and skips cleanly when ruff isn't installed. See TESTING.md > "Python lint gate (ruff)". Closes #3273.
+## [v0.51.189] — 2026-05-31 — Release FI (stage-batch1 — ruff lint gate + SSE refresh dedupe + tooltip i18n)
 
+### Added
+- **Forward-looking Python lint gate (ruff).** A curated `[tool.ruff]` ruleset (E9 syntax/runtime + F pyflakes + B bugbear — high-signal correctness rules, no style/formatting families) now gates **new and changed Python code** in CI (`tests.yml` `lint` job) and as part of the maintainer pre-release pre-gate. It is the Python twin of the existing ESLint runtime guard for `static/*.js`. Crucially it is **line-scoped** (`scripts/ruff_lint.py --diff`): it flags violations only on lines a change adds or modifies, so it keeps incoming code clean **without** reformatting the existing tree's cosmetic backlog (a separate, deferred, maintainer-run decision). `tests/test_ruff_forward_lint.py` additionally holds the whole tree free of E9 errors and skips cleanly when ruff isn't installed. See TESTING.md > "Python lint gate (ruff)". Closes #3273 (#3275).
+
+### Fixed
+- Gateway SSE reconnect no longer triggers a phantom "new dialog created" sidebar refresh: the initial sessions snapshot pushed on every reconnect is now compared against the current gateway-session set and `renderSessionList()` is skipped when nothing changed (#3270, @PINKIIILQWQ).
+- Raw-audio recording mic tooltip now uses a recording-specific i18n key instead of the dictation "Stop" label; sidebar lineage/child tooltip suffixes are localized across the locale catalog; and the localized read-only title hover hint for imported sessions is restored. Closes #3242, #3214 (#3272, @ai-ag2026).
 
 ## [v0.51.188] — 2026-05-31 — Release FH (stage-batchH — configured runner-client boundary, default-off)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -36,6 +36,38 @@ npm run lint:runtime
 npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"
 ```
 
+## Python lint gate (ruff) — forward-looking, new-code-only
+
+The Python twin of the ESLint runtime guard. A curated `ruff` ruleset
+(`[tool.ruff]` in `pyproject.toml`) catches latent-bug shapes — unused imports
+(F401), undefined/unused names (F841/F821), redefinitions (F811), mutable default
+args (B006), raise-without-from (B904), loop-variable capture in closures (B023) —
+**plus** real syntax/runtime errors (E9). It is **not** a style/formatting linter:
+the pure-style families (line-length, whitespace) are intentionally OFF so the gate
+never demands a reformat of existing code.
+
+The existing tree carries a cosmetic backlog (mostly unused-import F401) that is
+deliberately **not** reformatted. So the gate is enforced **only on the lines a
+change adds or modifies** (`scripts/ruff_lint.py --diff`), which keeps new code
+clean without touching the backlog. Cleaning the backlog is a separate,
+maintainer-run, safe-fixes-only decision (tracked in #3273).
+
+```bash
+# one-time dev setup (ruff is a dev-only tool):
+pip install ruff            # or: uv tool install ruff / uvx ruff ...
+# the gate (only flags violations on lines you added/changed vs origin/master):
+python3 scripts/ruff_lint.py --diff origin/master
+# whole-tree backlog report (informational — never blocks):
+python3 scripts/ruff_lint.py --all
+```
+
+`tests/test_ruff_forward_lint.py` holds the **whole tree** free of E9 (real
+syntax/runtime) findings and verifies the curated config shape; it runs in-suite
+when ruff is present and **skips gracefully** when it isn't — so environments
+without ruff aren't blocked, while CI (which installs ruff) enforces it. The
+diff-scoped gate runs as the `lint` job in `.github/workflows/tests.yml` and is
+also part of the maintainer pre-release pre-gate.
+
 ## Automated browser smoke (runtime brick-class gate)
 
 The ESLint guard above catches `const`-reassign / import-assign statically. The

--- a/api/config.py
+++ b/api/config.py
@@ -2527,7 +2527,7 @@ _cache_build_in_progress = False  # True while a cold path is actively building
 # session is expensive (~10s for zai due to endpoint probing).  The credential pool
 # only changes when the user adds/removes credentials, which is rare; a 24h TTL
 # is plenty safe and ensures get_available_models() cold paths are fast.
-_CREDENTIAL_POOL_CACHE: dict[str, tuple[float, "CredentialPool"]] = {}  # pid -> (ts, pool)
+_CREDENTIAL_POOL_CACHE: dict[str, tuple[float, "CredentialPool"]] = {}  # noqa: F821  forward-ref string annotation, resolved at runtime  # pid -> (ts, pool)
 _provider_models_invalidated_ts: dict[str, float] = {}  # provider_id -> timestamp of last invalidation
 
 # Disk-backed in-memory cache for get_available_models().

--- a/api/routes.py
+++ b/api/routes.py
@@ -912,7 +912,7 @@ def _run_cron_tracked(job, profile_home=None, execution_profile_home=None):
     except Exception as e:
         logger.exception("Manual cron run failed for job %s", job_id)
         try:
-            _with_cron_home(profile_home, lambda: mark_job_run(job_id, False, str(e)))
+            _with_cron_home(profile_home, lambda: mark_job_run(job_id, False, str(e)))  # noqa: F821  e is bound by the enclosing `except ... as e` and the lambda runs synchronously here
         except Exception:
             logger.debug("Failed to mark manual cron run failure for %s", job_id)
     finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,56 @@
+# Hermes WebUI — Python tooling config.
+#
+# This project is NOT a packaged distribution. The app is a plain Python + vanilla
+# JavaScript server with no build step and no bundler (see AGENTS.md / README). This
+# file exists only to configure dev tooling — currently ruff, used as a curated,
+# forward-looking lint gate over the Python codebase. There is intentionally no
+# [build-system] section: nothing pip-installs this directory.
+#
+# The ruff gate is the Python twin of the ESLint runtime guard (package.json
+# `lint:runtime` + eslint.runtime-guard.config.mjs + tests/test_static_js_runtime_lint.py).
+# It is enforced on NEW/CHANGED code only — see scripts/ruff_lint.py and TESTING.md
+# > "Python lint gate (ruff)". The existing tree carries a cosmetic backlog (mostly
+# unused-import F401) that is deliberately NOT reformatted here; cleaning it is a
+# separate, maintainer-run, safe-fixes-only decision (tracked in #3273).
+
+[tool.ruff]
+# Match the Python versions exercised in CI (tests.yml matrix: 3.11–3.13).
+target-version = "py311"
+# Keep the linter scoped to the application + tests; never crawl vendored or
+# generated trees. (These are belt-and-suspenders; the gate passes explicit files.)
+extend-exclude = [
+    "node_modules",
+    "static",
+    ".git",
+    "scripts/windows",
+    "scripts/wsl",
+]
+
+[tool.ruff.lint]
+# Curated, correctness-leaning ruleset — high signal, low noise. We deliberately do
+# NOT enable the pure-style families (E1/E2/E5/E7 line-length & whitespace) so the
+# gate never demands a whitespace reformat of existing code.
+#
+#   E9  — syntax / IO / runtime errors (E999 etc). The whole tree is already clean
+#         of these and the in-suite test (tests/test_ruff_forward_lint.py) keeps it
+#         that way across every shard.
+#   F   — pyflakes: unused imports (F401), unused/undefined names (F841/F821),
+#         redefinitions (F811), f-strings with no placeholders (F541). The most
+#         valuable family for keeping NEW code clean.
+#   B   — flake8-bugbear: genuine latent-bug shapes — mutable default args (B006),
+#         raise-without-from (B904), loop-variable capture in closures (B023),
+#         zip-without-strict (B905). This is where the real future-regression-
+#         prevention value lives.
+select = ["E9", "F", "B"]
+
+# No global `ignore` of F401/F841/etc. The existing-tree backlog is handled by
+# line-scoping the gate to changed lines (scripts/ruff_lint.py), NOT by globally
+# disabling the rules — disabling them would blind the gate to the single most
+# common new-code defect (a stray unused import). Forward enforcement of the full
+# curated set is the whole point.
+
+[tool.ruff.lint.per-file-ignores]
+# Tests legitimately use `assert False` as an explicit failure marker (B011) and
+# occasionally shadow loop vars in table-driven cases (B007); that's idiomatic in a
+# test suite and not a production-code risk.
+"tests/**" = ["B011", "B007"]

--- a/scripts/ruff_lint.py
+++ b/scripts/ruff_lint.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Forward-looking ruff lint gate for hermes-webui.
+
+The Python twin of the ESLint runtime guard (``npm run lint:runtime``). It runs the
+curated ``[tool.ruff]`` ruleset from ``pyproject.toml`` (E9 + F + B) but enforces it
+**only on new / changed code**, so it keeps incoming PRs clean without demanding a
+big-bang reformat of the existing tree (which still carries a cosmetic
+unused-import backlog — see issue #3273).
+
+Two modes:
+
+  --diff [BASE]   Line-scoped gate (default mode). Only report findings on lines
+                  that this branch ADDED or MODIFIED relative to the merge-base
+                  with BASE (default: origin/master). Editing a legacy file that
+                  has pre-existing violations elsewhere is safe — only your own
+                  new lines are gated. Exit 1 if any new finding, else 0.
+
+  --all           Whole-tree report (informational). Runs the curated ruleset over
+                  every tracked .py file and prints the backlog. Exit 0 always
+                  unless --strict is also passed. Useful for tracking the cleanup
+                  progress of #3273; NOT used as a release blocker.
+
+Usage::
+
+    python3 scripts/ruff_lint.py --diff origin/master     # the CI / pre-release gate
+    python3 scripts/ruff_lint.py --all                    # backlog report
+    python3 scripts/ruff_lint.py --all --strict           # fail on ANY tree finding
+
+ruff is resolved from PATH, or run via ``uvx ruff`` / ``python -m ruff`` as a
+fallback. If ruff cannot be found at all the gate prints a notice and exits 0 (a
+dev without ruff is not blocked; CI installs ruff so enforcement still holds there —
+same contract as the ESLint guard).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _run(cmd: list[str], **kw) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd, cwd=REPO_ROOT, capture_output=True, text=True, **kw
+    )
+
+
+def _ruff_cmd() -> list[str] | None:
+    """Return the argv prefix that invokes ruff, or None if unavailable."""
+    if shutil.which("ruff"):
+        return ["ruff"]
+    # `python -m ruff` works when ruff is pip-installed in the active interpreter.
+    probe = _run([sys.executable, "-m", "ruff", "--version"])
+    if probe.returncode == 0:
+        return [sys.executable, "-m", "ruff"]
+    # uvx pulls a pinned ruff on demand (used in local dev boxes without a global ruff).
+    if shutil.which("uvx"):
+        probe = _run(["uvx", "ruff", "--version"])
+        if probe.returncode == 0:
+            return ["uvx", "ruff"]
+    return None
+
+
+def _changed_py_files(base: str) -> tuple[str, list[str]]:
+    """Resolve the merge-base with `base` and return (merge_base, changed .py files)."""
+    mb = _run(["git", "merge-base", base, "HEAD"])
+    merge_base = mb.stdout.strip() if mb.returncode == 0 and mb.stdout.strip() else base
+    diff = _run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", merge_base, "HEAD"]
+    )
+    files = [
+        f
+        for f in diff.stdout.splitlines()
+        if f.endswith(".py") and os.path.exists(os.path.join(REPO_ROOT, f))
+    ]
+    return merge_base, files
+
+
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def _added_lines(merge_base: str, path: str) -> set[int]:
+    """Set of NEW-file line numbers added or modified in `path` since merge_base."""
+    diff = _run(["git", "diff", "--unified=0", merge_base, "HEAD", "--", path])
+    added: set[int] = set()
+    new_ln = 0
+    for line in diff.stdout.splitlines():
+        m = _HUNK_RE.match(line)
+        if m:
+            new_ln = int(m.group(1))
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            added.add(new_ln)
+            new_ln += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            # deletion: new-file pointer does not advance
+            continue
+        elif not line.startswith(("@@", "diff ", "index ", "--- ", "+++ ")):
+            new_ln += 1
+    return added
+
+
+def _ruff_check_json(ruff: list[str], files: list[str]) -> list[dict]:
+    """Run ruff over `files` with the project config, return parsed JSON findings."""
+    if not files:
+        return []
+    proc = _run(ruff + ["check", "--output-format", "json", "--no-cache", *files])
+    out = proc.stdout.strip()
+    if not out:
+        return []
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        sys.stderr.write(
+            "ruff_lint: could not parse ruff JSON output:\n" + proc.stdout + proc.stderr
+        )
+        # Be conservative: surface as a failure so a broken invocation never
+        # silently green-lights a PR.
+        raise
+
+
+def _print_findings(findings: list[dict]) -> None:
+    by_file: dict[str, list[dict]] = defaultdict(list)
+    for f in findings:
+        by_file[f.get("filename", "?")].append(f)
+    for fname in sorted(by_file):
+        rel = os.path.relpath(fname, REPO_ROOT)
+        for f in sorted(by_file[fname], key=lambda x: (x["location"]["row"], x["location"]["column"])):
+            loc = f["location"]
+            code = f.get("code") or "?"
+            msg = f.get("message", "").strip()
+            print(f"  {rel}:{loc['row']}:{loc['column']}  {code}  {msg}")
+
+
+def run_diff(base: str) -> int:
+    ruff = _ruff_cmd()
+    if ruff is None:
+        print("ruff_lint: ruff not found on PATH — skipping (CI installs ruff). OK.")
+        return 0
+    merge_base, files = _changed_py_files(base)
+    if not files:
+        print(f"ruff_lint: no changed .py files vs {base} ({merge_base[:12]}). OK.")
+        return 0
+
+    all_findings = _ruff_check_json(ruff, files)
+    # Build the added-line map once per file, intersect.
+    added_map = {f: _added_lines(merge_base, f) for f in files}
+    new_findings = []
+    for finding in all_findings:
+        rel = os.path.relpath(finding.get("filename", ""), REPO_ROOT)
+        row = finding.get("location", {}).get("row")
+        if rel in added_map and row in added_map[rel]:
+            new_findings.append(finding)
+
+    print(
+        f"ruff_lint (diff vs {base}): {len(files)} changed .py file(s), "
+        f"{len(all_findings)} total finding(s) in them, "
+        f"{len(new_findings)} on added/modified lines."
+    )
+    if new_findings:
+        print("\nNew ruff violations introduced by this change:\n")
+        _print_findings(new_findings)
+        print(
+            "\nThe curated ruff gate (E9+F+B) flags NEW code only. Fix the lines above, "
+            "or — if a finding is a genuine false positive — add a scoped "
+            "`# noqa: <CODE>` with a one-line reason. Config: pyproject.toml [tool.ruff]."
+        )
+        return 1
+    print("ruff_lint: no new violations on added/modified lines. OK.")
+    return 0
+
+
+def run_all(strict: bool) -> int:
+    ruff = _ruff_cmd()
+    if ruff is None:
+        print("ruff_lint: ruff not found on PATH — skipping. OK.")
+        return 0
+    proc = _run(ruff + ["check", "--statistics", "--no-cache", "."])
+    sys.stdout.write(proc.stdout)
+    sys.stderr.write(proc.stderr)
+    if strict and proc.returncode != 0:
+        return proc.returncode
+    print(
+        "\nruff_lint --all is informational (existing-tree backlog tracked in #3273). "
+        "Pass --strict to fail on any finding."
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    g = p.add_mutually_exclusive_group()
+    g.add_argument(
+        "--diff",
+        nargs="?",
+        const="origin/master",
+        metavar="BASE",
+        help="Line-scoped gate vs merge-base with BASE (default origin/master).",
+    )
+    g.add_argument("--all", action="store_true", help="Whole-tree backlog report.")
+    p.add_argument("--strict", action="store_true", help="With --all: fail on any finding.")
+    args = p.parse_args(argv)
+
+    if args.all:
+        return run_all(args.strict)
+    base = args.diff or "origin/master"
+    return run_diff(base)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/static/boot.js
+++ b/static/boot.js
@@ -479,7 +479,7 @@ $('btnAttach').onclick=e=>{if(e&&e.preventDefault)e.preventDefault();$('fileInpu
     btn.classList.toggle('recording',on);
     // Active-state title flips so the tooltip is honest about what
     // pressing the button will do (#1488).
-    _setButtonTooltipAndKey(btn, on ? 'voice_dictate_active' : (_rawAudioMode ? 'voice_send_raw' : 'voice_dictate'));
+    _setButtonTooltipAndKey(btn, on ? (_rawAudioMode ? 'voice_recording_active' : 'voice_dictate_active') : (_rawAudioMode ? 'voice_send_raw' : 'voice_dictate'));
     status.style.display=on?'':'none';
     if(statusText) statusText.textContent=on?'Listening':'Listening';
     if(!on){ _finalText=''; _prefix=''; }

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -25,6 +25,7 @@ const LOCALES = {
     // Composer voice buttons (#1488 — distinct labels for dictation vs voice mode)
     voice_dictate: 'Dictate',
     voice_dictate_active: 'Stop dictation',
+    voice_recording_active: 'Stop recording',
     voice_mode_toggle: 'Voice mode',
     voice_mode_toggle_active: 'Exit voice mode',
     // Turn-based voice mode (#1333)
@@ -806,6 +807,10 @@ const LOCALES = {
     // 'segment' in the default visible badge. User-facing copy remains
     // translatable for locales that prefer a different wording. (#2155)
     session_meta_segments: (n) => `${n} prior turn${n === 1 ? '' : 's'}`,
+    session_lineage_toggle_hint: '{0} — earlier context turns are collapsed here. Click to show or hide them.',
+    session_lineage_static_hint: '{0} — earlier context turns are collapsed here.',
+    session_child_toggle_hint: '{0} — child conversations spawned from this session. Click to show or hide them.',
+    session_readonly_title_hint: 'Read-only imported session — {0}',
     session_lineage_segment_untitled: 'Untitled segment',
     session_lineage_segment_open: 'Open lineage segment',
     new_profile: 'New profile',
@@ -1340,6 +1345,7 @@ const LOCALES = {
     // Composer voice buttons (#1488 — distinct labels for dictation vs voice mode)
     voice_dictate: 'Detta',
     voice_dictate_active: 'Interrompi dettatura',
+    voice_recording_active: 'Interrompi registrazione',
     voice_mode_toggle: 'Modalità vocale',
     voice_mode_toggle_active: 'Esci dalla modalità vocale',
     // Turn-based voice mode (#1333)
@@ -2113,6 +2119,10 @@ const LOCALES = {
     session_meta_messages: (n) => `${n} msg`,
     session_meta_children: (n) => `${n} figli${n === 1 ? 'o' : ''}`,
     session_meta_segments: (n) => `${n} segment${n === 1 ? 'o' : 'i'}`,
+    session_lineage_toggle_hint: '{0} — i turni di contesto precedenti sono compressi qui. Fai clic per mostrarli o nasconderli.',
+    session_lineage_static_hint: '{0} — i turni di contesto precedenti sono compressi qui.',
+    session_child_toggle_hint: '{0} — conversazioni figlie generate da questa sessione. Fai clic per mostrarle o nasconderle.',
+    session_readonly_title_hint: 'Sessione importata in sola lettura — {0}',
     session_lineage_segment_untitled: 'Segmento senza titolo',
     session_lineage_segment_open: 'Apri segmento genealogia',
     new_profile: 'Nuovo profilo',
@@ -2648,6 +2658,7 @@ const LOCALES = {
     // Composer voice buttons (#1488)
     voice_dictate: 'ディクテーション',
     voice_dictate_active: 'ディクテーション停止',
+    voice_recording_active: '録音を停止',
     voice_mode_toggle: '音声モード',
     voice_mode_toggle_active: '音声モードを終了',
     voice_listening: '聞き取り中…',
@@ -3425,6 +3436,10 @@ const LOCALES = {
     session_meta_messages: (n) => `${n} 件`,
     session_meta_children: (n) => `${n} 子`,
     session_meta_segments: (n) => `${n} セグメント`,
+    session_lineage_toggle_hint: '{0} — 以前のコンテキストターンはここに折りたたまれています。クリックして表示/非表示を切り替えます。',
+    session_lineage_static_hint: '{0} — 以前のコンテキストターンはここに折りたたまれています。',
+    session_child_toggle_hint: '{0} — このセッションから作成された子会話です。クリックして表示/非表示を切り替えます。',
+    session_readonly_title_hint: '読み取り専用のインポート済みセッション — {0}',
     session_lineage_segment_untitled: '無題のセグメント',
     session_lineage_segment_open: '系譜セグメントを開く',
     new_profile: '新規プロファイル',
@@ -3958,6 +3973,7 @@ const LOCALES = {
     // Composer voice buttons (#1488)
     voice_dictate: 'Диктовка',
     voice_dictate_active: 'Остановить диктовку',
+    voice_recording_active: 'Остановить запись',
     voice_mode_toggle: 'Голосовой режим',
     voice_mode_toggle_active: 'Выйти из голосового режима',
     voice_listening: 'Слушаю…',
@@ -4491,6 +4507,10 @@ const LOCALES = {
     session_meta_messages: (n) => `${n} сообщ.`,
     session_meta_children: (n) => `${n} ${n === 1 ? 'дочерн.' : 'дочерн.'}`,
     session_meta_segments: (n) => `${n} сегм.`,
+    session_lineage_toggle_hint: '{0} — предыдущие ходы контекста свернуты здесь. Нажмите, чтобы показать или скрыть их.',
+    session_lineage_static_hint: '{0} — предыдущие ходы контекста свернуты здесь.',
+    session_child_toggle_hint: '{0} — дочерние разговоры, созданные из этого сеанса. Нажмите, чтобы показать или скрыть их.',
+    session_readonly_title_hint: 'Импортированный сеанс только для чтения — {0}',
     session_lineage_segment_untitled: 'Сегмент без названия',
     session_lineage_segment_open: 'Открыть сегмент цепочки',
     new_profile: 'Новый профиль',
@@ -5736,6 +5756,10 @@ const LOCALES = {
     session_meta_messages: (n) => `${n} mens.`,
     session_meta_children: (n) => `${n} ${n === 1 ? 'hijo' : 'hijos'}`,
     session_meta_segments: (n) => `${n} ${n === 1 ? 'segmento' : 'segmentos'}`,
+    session_lineage_toggle_hint: '{0} — los turnos de contexto anteriores están contraídos aquí. Haz clic para mostrarlos u ocultarlos.',
+    session_lineage_static_hint: '{0} — los turnos de contexto anteriores están contraídos aquí.',
+    session_child_toggle_hint: '{0} — conversaciones hijas creadas desde esta sesión. Haz clic para mostrarlas u ocultarlas.',
+    session_readonly_title_hint: 'Sesión importada de solo lectura — {0}',
     session_lineage_segment_untitled: 'Segmento sin título',
     session_lineage_segment_open: 'Abrir segmento de linaje',
     new_profile: 'Nuevo perfil',
@@ -6424,7 +6448,8 @@ const LOCALES = {
     voice_thinking: 'Thinking…',  // TODO: translate
     // Composer voice buttons (#1488)
     voice_dictate: 'Dictate',  // TODO: translate
-    voice_dictate_active: 'Stop dictation',  // TODO: translate
+    voice_dictate_active: 'Stop dictation',
+    voice_recording_active: 'Detener grabación',  // TODO: translate
     voice_mode_toggle: 'Voice mode',  // TODO: translate
     voice_mode_toggle_active: 'Exit voice mode',  // TODO: translate
     subagent_children: 'Subagent sessions',  // TODO: translate
@@ -6954,6 +6979,10 @@ const LOCALES = {
     session_meta_messages: (n) => `${n} Nachr.`,
     session_meta_children: (n) => `${n} ${n === 1 ? 'Subagent' : 'Subagents'}`,
     session_meta_segments: (n) => `${n} Segment${n === 1 ? '' : 'e'}`,
+    session_lineage_toggle_hint: '{0} — frühere Kontext-Turns sind hier eingeklappt. Klicken, um sie ein- oder auszublenden.',
+    session_lineage_static_hint: '{0} — frühere Kontext-Turns sind hier eingeklappt.',
+    session_child_toggle_hint: '{0} — aus dieser Sitzung erzeugte Kind-Unterhaltungen. Klicken, um sie ein- oder auszublenden.',
+    session_readonly_title_hint: 'Schreibgeschützte importierte Sitzung — {0}',
     session_lineage_segment_untitled: 'Unbenanntes Segment',
     session_lineage_segment_open: 'Liniensegment öffnen',
     new_profile: 'Neues Profil',
@@ -7671,7 +7700,8 @@ const LOCALES = {
     voice_thinking: 'Thinking…',  // TODO: translate
     // Composer voice buttons (#1488)
     voice_dictate: 'Dictate',  // TODO: translate
-    voice_dictate_active: 'Stop dictation',  // TODO: translate
+    voice_dictate_active: 'Stop dictation',
+    voice_recording_active: 'Aufnahme stoppen',  // TODO: translate
     voice_mode_toggle: 'Voice mode',  // TODO: translate
     voice_mode_toggle_active: 'Exit voice mode',  // TODO: translate
     subagent_children: 'Subagent sessions',  // TODO: translate
@@ -8236,6 +8266,10 @@ const LOCALES = {
     session_meta_messages: (n) => `${n} 条消息`,
     session_meta_children: (n) => `${n} 子会话`,
     session_meta_segments: (n) => `${n} 段`,
+    session_lineage_toggle_hint: '{0} — 较早的上下文轮次已折叠在这里。点击显示或隐藏。',
+    session_lineage_static_hint: '{0} — 较早的上下文轮次已折叠在这里。',
+    session_child_toggle_hint: '{0} — 从此会话派生的子对话。点击显示或隐藏。',
+    session_readonly_title_hint: '只读导入会话 — {0}',
     session_lineage_segment_untitled: '未命名段',
     session_lineage_segment_open: '打开脉络段',
     new_profile: '新配置',
@@ -8912,6 +8946,7 @@ const LOCALES = {
     // Composer voice buttons (#1488)
     voice_dictate: '听写',
     voice_dictate_active: '停止听写',
+    voice_recording_active: '停止录音',
     voice_mode_toggle: '语音模式',
     voice_mode_toggle_active: '退出语音模式',
     subagent_children: '子代理会话',
@@ -9469,6 +9504,10 @@ const LOCALES = {
     session_meta_messages: (n) => `${n} 則訊息`,
     session_meta_children: (n) => `${n} 則子`,
     session_meta_segments: (n) => `${n} 段`,
+    session_lineage_toggle_hint: '{0} — 較早的上下文輪次已摺疊在這裡。點擊可顯示或隱藏。',
+    session_lineage_static_hint: '{0} — 較早的上下文輪次已摺疊在這裡。',
+    session_child_toggle_hint: '{0} — 從此工作階段衍生的子對話。點擊可顯示或隱藏。',
+    session_readonly_title_hint: '唯讀匯入工作階段 — {0}',
     session_lineage_segment_untitled: '未命名段',
     session_lineage_segment_open: '開啟脈絡段',
     new_profile: '\u65b0\u914d\u7f6e\u6a94',
@@ -10226,7 +10265,8 @@ const LOCALES = {
     voice_thinking: 'Thinking…',  // TODO: translate
     // Composer voice buttons (#1488)
     voice_dictate: 'Dictate',  // TODO: translate
-    voice_dictate_active: 'Stop dictation',  // TODO: translate
+    voice_dictate_active: 'Stop dictation',
+    voice_recording_active: '停止錄音',  // TODO: translate
     voice_mode_toggle: 'Voice mode',  // TODO: translate
     voice_mode_toggle_active: 'Exit voice mode',  // TODO: translate
     subagent_children: 'Subagent sessions',  // TODO: translate
@@ -10871,6 +10911,10 @@ const LOCALES = {
     session_meta_messages: (n) => `${n} msg${n === 1 ? '' : 's'}`,
     session_meta_children: (n) => `${n} child${n === 1 ? '' : 'ren'}`,
     session_meta_segments: (n) => `${n} segment${n === 1 ? '' : 's'}`,
+    session_lineage_toggle_hint: '{0} — turnos de contexto anteriores estão recolhidos aqui. Clique para mostrar ou ocultar.',
+    session_lineage_static_hint: '{0} — turnos de contexto anteriores estão recolhidos aqui.',
+    session_child_toggle_hint: '{0} — conversas filhas criadas a partir desta sessão. Clique para mostrar ou ocultar.',
+    session_readonly_title_hint: 'Sessão importada somente leitura — {0}',
     session_lineage_segment_untitled: 'Segmento sem título',
     session_lineage_segment_open: 'Abrir segmento de linhagem',
     new_profile: 'Novo perfil',
@@ -11349,7 +11393,8 @@ const LOCALES = {
     voice_thinking: 'Thinking…',  // TODO: translate
     // Composer voice buttons (#1488)
     voice_dictate: 'Dictate',  // TODO: translate
-    voice_dictate_active: 'Stop dictation',  // TODO: translate
+    voice_dictate_active: 'Stop dictation',
+    voice_recording_active: 'Parar gravação',  // TODO: translate
     voice_mode_toggle: 'Voice mode',  // TODO: translate
     voice_mode_toggle_active: 'Exit voice mode',  // TODO: translate
     subagent_children: 'Subagent sessions',  // TODO: translate
@@ -12080,6 +12125,10 @@ const LOCALES = {
     session_meta_messages: (n) => `${n} msg${n === 1 ? '' : 's'}`,
     session_meta_children: (n) => `${n} child${n === 1 ? '' : 'ren'}`,
     session_meta_segments: (n) => `${n} segment${n === 1 ? '' : 's'}`,
+    session_lineage_toggle_hint: '{0} — 이전 컨텍스트 턴이 여기에 접혀 있습니다. 클릭하여 표시하거나 숨기세요.',
+    session_lineage_static_hint: '{0} — 이전 컨텍스트 턴이 여기에 접혀 있습니다.',
+    session_child_toggle_hint: '{0} — 이 세션에서 생성된 하위 대화입니다. 클릭하여 표시하거나 숨기세요.',
+    session_readonly_title_hint: '읽기 전용으로 가져온 세션 — {0}',
     session_lineage_segment_untitled: '제목 없는 세그먼트',
     session_lineage_segment_open: '계보 세그먼트 열기',
     new_profile: 'New profile',
@@ -12649,7 +12698,8 @@ const LOCALES = {
     voice_thinking: 'Thinking…',  // TODO: translate
     // Composer voice buttons (#1488)
     voice_dictate: 'Dictate',  // TODO: translate
-    voice_dictate_active: 'Stop dictation',  // TODO: translate
+    voice_dictate_active: 'Stop dictation',
+    voice_recording_active: '녹음 중지',  // TODO: translate
     voice_mode_toggle: 'Voice mode',  // TODO: translate
     voice_mode_toggle_active: 'Exit voice mode',  // TODO: translate
     subagent_children: 'Subagent sessions',  // TODO: translate
@@ -12674,6 +12724,7 @@ const LOCALES = {
     mic_error: 'Erreur de saisie vocale :',
     voice_dictate: 'Dicter',
     voice_dictate_active: 'Arrêter la dictée',
+    voice_recording_active: 'Arrêter l’enregistrement',
     voice_mode_toggle: 'Mode vocal',
     voice_mode_toggle_active: 'Quitter le mode vocal',
     voice_listening: 'Écoute…',
@@ -13312,6 +13363,10 @@ const LOCALES = {
     insights_skill_usage_col_share: 'Usage %',  // TODO: translate
     insights_skill_usage_col_patches: 'Patches',  // TODO: translate
     workspace_desc: 'Ajoutez et changez d\'espace de travail pour vos sessions.',
+    session_lineage_toggle_hint: '{0} — les tours de contexte précédents sont repliés ici. Cliquez pour les afficher ou les masquer.',
+    session_lineage_static_hint: '{0} — les tours de contexte précédents sont repliés ici.',
+    session_child_toggle_hint: '{0} — conversations enfants créées depuis cette session. Cliquez pour les afficher ou les masquer.',
+    session_readonly_title_hint: 'Session importée en lecture seule — {0}',
     session_lineage_segment_untitled: 'Segment sans titre',
     session_lineage_segment_open: 'Segment de lignée ouverte',
     new_profile: 'Nouveau profil',
@@ -13915,6 +13970,7 @@ const LOCALES = {
     mic_error: 'Ses girişi hatası:',
     voice_dictate: 'Dikte',
     voice_dictate_active: 'Dikteyi durdur',
+    voice_recording_active: 'Kaydı durdur',
     voice_mode_toggle: 'Ses modu',
     voice_mode_toggle_active: 'Ses modundan çık',
     voice_listening: 'Dinleniyor\u2026',
@@ -14628,6 +14684,10 @@ const LOCALES = {
     session_meta_messages: (n) => `${n} mesaj${n === 1 ? '' : 'S'}`,
     session_meta_children: (n) => `${n} çocuk${n === 1 ? '' : 'ren'}`,
     session_meta_segments: (n) => `${n} segment${n === 1 ? '' : 'S'}`,
+    session_lineage_toggle_hint: '{0} — önceki bağlam turları burada daraltıldı. Göstermek veya gizlemek için tıklayın.',
+    session_lineage_static_hint: '{0} — önceki bağlam turları burada daraltıldı.',
+    session_child_toggle_hint: '{0} — bu oturumdan oluşturulan alt konuşmalar. Göstermek veya gizlemek için tıklayın.',
+    session_readonly_title_hint: 'Salt okunur içe aktarılmış oturum — {0}',
     session_lineage_segment_untitled: 'Başlıksız segment',
     session_lineage_segment_open: 'Soy segmentini aç',
     new_profile: 'Yeni profil',

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3373,11 +3373,12 @@ function _sessionTitleForForkParent(parentSid){
   return title;
 }
 
-function _sessionFullTitleTooltip(rawTitle, cleanTitle){
+function _sessionFullTitleTooltip(rawTitle, cleanTitle, session){
   const fallback=String(cleanTitle||'Untitled').trim()||'Untitled';
   const full=String(rawTitle||fallback).trim()||fallback;
-  if(full.startsWith('[SYSTEM:')) return fallback;
-  return full;
+  const title=full.startsWith('[SYSTEM:') ? fallback : full;
+  if(typeof t==='function'&&_isReadOnlySession(session)) return t('session_readonly_title_hint', title);
+  return title;
 }
 
 function _sessionForkTooltip(parentLabel){
@@ -3391,14 +3392,18 @@ function _sessionForkTooltip(parentLabel){
 
 function _sessionLineageBadgeTooltip(label, canExpand){
   const base=String(label||'Prior turns').trim()||'Prior turns';
-  return canExpand
-    ? `${base} — earlier context turns are collapsed here. Click to show or hide them.`
-    : `${base} — earlier context turns are collapsed here.`;
+  if(typeof t==='function'){
+    return canExpand
+      ? t('session_lineage_toggle_hint', base)
+      : t('session_lineage_static_hint', base);
+  }
+  return base;
 }
 
 function _sessionChildBadgeTooltip(label){
   const base=String(label||'Child sessions').trim()||'Child sessions';
-  return `${base} — child conversations spawned from this session. Click to show or hide them.`;
+  if(typeof t==='function') return t('session_child_toggle_hint', base);
+  return base;
 }
 
 function _sessionStateTooltip({isStreaming=false,hasUnread=false}={}){
@@ -4131,7 +4136,7 @@ function renderSessionListFromCache(){
     const titleMatched=Boolean(searchQueryRaw&&displayTitle.toLowerCase().includes(searchQueryRaw.toLowerCase()));
     if(titleMatched) _appendHighlightedText(title,displayTitle,searchQueryRaw,'session-search-hit');
     else title.textContent=displayTitle;
-    title.title=_sessionFullTitleTooltip(rawTitle,cleanTitle);
+    title.title=_sessionFullTitleTooltip(rawTitle,cleanTitle,s);
     const tsMs=_sessionTimestampMs(s);
     const ts=document.createElement('span');
     const hasAttentionState=isStreaming||hasUnread||Boolean(attention);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2762,6 +2762,29 @@ function stopGatewayPollFallback(){
   }
 }
 
+function _gatewaySessionSnapshotKey(sessions){
+  return (Array.isArray(sessions)?sessions:[])
+    .filter(s=>s&&s.session_id)
+    .map(s=>`${s.session_id}:${s.updated_at||0}:${s.message_count||0}`)
+    .sort()
+    .join('|');
+}
+
+function _isGatewaySessionForSnapshot(session){
+  if(!session) return false;
+  if(typeof _isCliSession==='function'&&_isCliSession(session)) return true;
+  if(typeof _isMessagingSession==='function'&&_isMessagingSession(session)) return true;
+  const source=String(session.session_source||session.raw_source||session.source_tag||session.source||'').toLowerCase();
+  return !!source&&source!=='webui';
+}
+
+function _isDuplicateGatewaySessionSnapshot(sessions){
+  const incoming=(Array.isArray(sessions)?sessions:[]).filter(_isGatewaySessionForSnapshot);
+  const currentGatewaySessions=(Array.isArray(_allSessions)?_allSessions:[]).filter(_isGatewaySessionForSnapshot);
+  if(!incoming.length&&!currentGatewaySessions.length) return true;
+  return _gatewaySessionSnapshotKey(incoming)===_gatewaySessionSnapshotKey(currentGatewaySessions);
+}
+
 async function probeGatewaySSEStatus(){
   if(_gatewayProbeInFlight || !window._showCliSessions) return;
   _gatewayProbeInFlight = true;
@@ -2803,7 +2826,9 @@ function startGatewaySSE(){
         if(data.sessions){
           stopGatewayPollFallback();
           _gatewaySSEWarningShown = false;
-          renderSessionList({deferWhileInteracting:true}); // re-fetch and re-render
+          if(!_isDuplicateGatewaySessionSnapshot(data.sessions)){
+            renderSessionList({deferWhileInteracting:true}); // re-fetch and re-render
+          }
           // If the active session received new gateway messages, refresh the conversation view.
           // S.busy check prevents stomping on an in-progress WebUI response.
           // is_cli_session check ensures we only poll import_cli for CLI-originated sessions.

--- a/tests/test_gateway_sse_reconnect_dedupe.py
+++ b/tests/test_gateway_sse_reconnect_dedupe.py
@@ -1,0 +1,129 @@
+"""Regression coverage for gateway SSE reconnect refresh dedupe."""
+
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+GATEWAY_WATCHER = ROOT / "api" / "gateway_watcher.py"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _block(src: str, start: str, end: str) -> str:
+    i = src.index(start)
+    j = src.index(end, i)
+    return src[i:j]
+
+
+def test_gateway_watcher_remains_hash_only():
+    """The watcher should not try to infer restarts from state.db mtime."""
+    src = _read(GATEWAY_WATCHER)
+    poll = _block(src, "    def _poll_loop(self):", "\n_watcher:")
+
+    assert "_get_db_mtime" not in src
+    assert "_detect_gateway_restart" not in src
+    assert "current_hash = _snapshot_hash(sessions)" in poll
+    assert "if current_hash != self._last_hash:" in poll
+    assert "_notify_subscribers(sessions)" in poll
+
+
+def test_gateway_sse_dedupes_reconnect_snapshot_before_refresh():
+    """Reconnect initial snapshots should not force a sidebar refetch."""
+    src = _read(SESSIONS_JS)
+    handler = _block(
+        src,
+        "_gatewaySSE.addEventListener('sessions_changed'",
+        "_gatewaySSE.onerror",
+    )
+
+    assert "function _gatewaySessionSnapshotKey" in src
+    assert "function _isDuplicateGatewaySessionSnapshot" in src
+    assert "if(!_isDuplicateGatewaySessionSnapshot(data.sessions))" in handler
+    assert "renderSessionList({deferWhileInteracting:true}); // re-fetch and re-render" in handler
+
+
+def test_gateway_snapshot_key_matches_backend_hash_fields():
+    """Frontend dedupe must compare the same fields that drive watcher events."""
+    src = _read(SESSIONS_JS)
+    key_fn = _block(
+        src,
+        "function _gatewaySessionSnapshotKey",
+        "\n\nfunction _isGatewaySessionForSnapshot",
+    )
+
+    assert "s.session_id" in key_fn
+    assert "s.updated_at||0" in key_fn
+    assert "s.message_count||0" in key_fn
+    assert ".sort()" in key_fn
+
+
+def test_gateway_snapshot_dedupe_logic_filters_symmetrically():
+    """Exercise the dedupe helpers, including null and webui noise."""
+    script = r"""
+function _isCliSession(session) {
+  return session && (session.session_source === 'cli' || session.raw_source === 'cli' || session.is_cli_session === true);
+}
+function _isMessagingSession(session) {
+  return session && session.session_source === 'messaging';
+}
+function _gatewaySessionSnapshotKey(sessions){
+  return (Array.isArray(sessions)?sessions:[])
+    .filter(s=>s&&s.session_id)
+    .map(s=>`${s.session_id}:${s.updated_at||0}:${s.message_count||0}`)
+    .sort()
+    .join('|');
+}
+function _isGatewaySessionForSnapshot(session){
+  if(!session) return false;
+  if(typeof _isCliSession==='function'&&_isCliSession(session)) return true;
+  if(typeof _isMessagingSession==='function'&&_isMessagingSession(session)) return true;
+  const source=String(session.session_source||session.raw_source||session.source_tag||session.source||'').toLowerCase();
+  return !!source&&source!=='webui';
+}
+function _isDuplicateGatewaySessionSnapshot(sessions){
+  const incoming=(Array.isArray(sessions)?sessions:[]).filter(_isGatewaySessionForSnapshot);
+  const currentGatewaySessions=(Array.isArray(globalThis._allSessions)?globalThis._allSessions:[]).filter(_isGatewaySessionForSnapshot);
+  if(!incoming.length&&!currentGatewaySessions.length) return true;
+  return _gatewaySessionSnapshotKey(incoming)===_gatewaySessionSnapshotKey(currentGatewaySessions);
+}
+
+globalThis._allSessions = [
+  {session_id:'cli-1', updated_at:10, message_count:2, session_source:'cli'},
+  {session_id:'msg-1', updated_at:20, message_count:5, session_source:'messaging'},
+  {session_id:'web-1', updated_at:30, message_count:1, session_source:'webui'},
+  null,
+];
+
+const duplicateWithNoise = [
+  null,
+  {session_id:'web-2', updated_at:99, message_count:1, session_source:'webui'},
+  {session_id:'msg-1', updated_at:20, message_count:5, session_source:'messaging'},
+  {session_id:'cli-1', updated_at:10, message_count:2, session_source:'cli'},
+];
+if(!_isDuplicateGatewaySessionSnapshot(duplicateWithNoise)) throw new Error('expected duplicate snapshot');
+
+const changed = [
+  {session_id:'cli-1', updated_at:10, message_count:3, session_source:'cli'},
+  {session_id:'msg-1', updated_at:20, message_count:5, session_source:'messaging'},
+];
+if(_isDuplicateGatewaySessionSnapshot(changed)) throw new Error('expected changed snapshot');
+
+globalThis._allSessions = [{session_id:'web-1', updated_at:1, message_count:1, session_source:'webui'}];
+if(!_isDuplicateGatewaySessionSnapshot([null, {session_id:'web-2', session_source:'webui'}])) throw new Error('expected empty gateway snapshot duplicate');
+"""
+    subprocess.run(["node", "-e", script], check=True)
+
+
+def test_load_session_persists_only_after_metadata_loads():
+    """Do not overwrite the last good localStorage sid before /api/session succeeds."""
+    src = _read(SESSIONS_JS)
+    load = _block(src, "async function loadSession(sid)", "\n  const activeStreamId=")
+    api_pos = load.index("data = await api(`/api/session")
+    persist_pos = load.index("localStorage.setItem('hermes-webui-session',S.session.session_id)")
+
+    assert "_persistActiveSession" not in src
+    assert persist_pos > api_pos

--- a/tests/test_issue3242_3214_i18n_tooltips.py
+++ b/tests/test_issue3242_3214_i18n_tooltips.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+I18N_JS = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+LOCALE_COUNT = 12
+
+
+def test_raw_audio_active_recording_uses_dedicated_i18n_key():
+    assert "voice_recording_active" in I18N_JS
+    assert I18N_JS.count("voice_recording_active") == LOCALE_COUNT
+    assert "on ? (_rawAudioMode ? 'voice_recording_active' : 'voice_dictate_active')" in BOOT_JS
+
+
+def test_sidebar_lineage_tooltip_suffixes_are_localized():
+    assert I18N_JS.count("session_lineage_toggle_hint") == LOCALE_COUNT
+    assert I18N_JS.count("session_lineage_static_hint") == LOCALE_COUNT
+    assert "t('session_lineage_toggle_hint', base)" in SESSIONS_JS
+    assert "t('session_lineage_static_hint', base)" in SESSIONS_JS
+    assert "earlier context turns are collapsed here. Click to show or hide them" not in SESSIONS_JS
+
+
+def test_sidebar_child_tooltip_suffix_is_localized():
+    assert I18N_JS.count("session_child_toggle_hint") == LOCALE_COUNT
+    assert "t('session_child_toggle_hint', base)" in SESSIONS_JS
+    assert "child conversations spawned from this session. Click to show or hide them" not in SESSIONS_JS
+
+
+def test_read_only_session_title_hint_is_localized():
+    assert I18N_JS.count("session_readonly_title_hint") == LOCALE_COUNT
+    assert "function _sessionFullTitleTooltip(rawTitle, cleanTitle, session)" in SESSIONS_JS
+    assert "_isReadOnlySession(session)" in SESSIONS_JS
+    assert "t('session_readonly_title_hint', title)" in SESSIONS_JS
+    assert "title.title=_sessionFullTitleTooltip(rawTitle,cleanTitle,s);" in SESSIONS_JS

--- a/tests/test_ruff_forward_lint.py
+++ b/tests/test_ruff_forward_lint.py
@@ -1,0 +1,133 @@
+"""Forward-looking ruff lint gate — in-suite enforcement.
+
+The Python twin of ``tests/test_static_js_runtime_lint.py`` (the ESLint runtime
+guard). Issue #3273.
+
+What this asserts:
+
+1. The whole tree is free of E9 (real syntax / IO / runtime-error) findings. This
+   is the one ruleset we hold green tree-wide — there is no backlog of E9 errors,
+   and a new one is always a genuine bug. (The F/B families have a known cosmetic
+   backlog in the existing tree, deliberately NOT reformatted — see #3273 — so we
+   do NOT assert those are tree-clean; they are enforced on NEW code only by
+   ``scripts/ruff_lint.py --diff``, which runs in CI and the pre-release gate.)
+
+2. The curated ruff config is present and shaped as intended (E9 + F + B selected,
+   no global ignore of the F/B rules that would blind the new-code gate).
+
+3. The line-scoped gate runner imports and its diff machinery works.
+
+Skips cleanly when ruff is not installed, so a contributor without the dev tool is
+never blocked — CI installs ruff so enforcement holds there. Same contract as the
+ESLint guard.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _ruff_argv():
+    """Resolve a runnable ruff invocation, or None."""
+    if shutil.which("ruff"):
+        return ["ruff"]
+    probe = subprocess.run(
+        [sys.executable, "-m", "ruff", "--version"], capture_output=True, text=True
+    )
+    if probe.returncode == 0:
+        return [sys.executable, "-m", "ruff"]
+    if shutil.which("uvx"):
+        probe = subprocess.run(["uvx", "ruff", "--version"], capture_output=True, text=True)
+        if probe.returncode == 0:
+            return ["uvx", "ruff"]
+    return None
+
+
+RUFF = _ruff_argv()
+ruff_required = pytest.mark.skipif(RUFF is None, reason="ruff not installed (dev-only tool; CI installs it)")
+
+
+def test_pyproject_ruff_config_present_and_shaped():
+    """The curated [tool.ruff] config exists and selects the intended families."""
+    path = os.path.join(REPO_ROOT, "pyproject.toml")
+    assert os.path.exists(path), "pyproject.toml with [tool.ruff] config is required (#3273)"
+    text = open(path, encoding="utf-8").read()
+    assert "[tool.ruff]" in text, "[tool.ruff] section missing"
+    assert "[tool.ruff.lint]" in text, "[tool.ruff.lint] section missing"
+    # The curated correctness-leaning set: pyflakes + syntax + bugbear.
+    assert '"E9"' in text and '"F"' in text and '"B"' in text, (
+        "ruff select must include E9, F, B (curated correctness ruleset)"
+    )
+    # Guard the design intent: no GLOBAL ignore of F401/F841 etc. A blanket ignore
+    # would defeat the new-code gate (a stray unused import is the single most
+    # common new-code defect). Per-file-ignores for tests are fine.
+    lint_section = text.split("[tool.ruff.lint]", 1)[1]
+    before_subtables = lint_section.split("[tool.ruff.lint.", 1)[0]
+    assert "ignore = [" not in before_subtables and "ignore=[" not in before_subtables, (
+        "do not globally ignore F/B rules — that blinds the forward gate; "
+        "use per-file-ignores or scoped # noqa instead"
+    )
+
+
+@ruff_required
+def test_tree_is_E9_clean():
+    """No real syntax / IO / runtime-error (E9) findings anywhere in the tree.
+
+    E9 is the one ruleset held green tree-wide: there is no backlog, and any new
+    E9 finding is a genuine bug (the kind that bricks a module on import).
+    """
+    proc = subprocess.run(
+        RUFF + ["check", "--select", "E9", "--output-format", "json", "--no-cache", "."],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    findings = json.loads(proc.stdout) if proc.stdout.strip() else []
+    if findings:
+        lines = [
+            f"  {os.path.relpath(f['filename'], REPO_ROOT)}:{f['location']['row']}  "
+            f"{f.get('code')}  {f.get('message', '').strip()}"
+            for f in findings
+        ]
+        pytest.fail("ruff E9 (syntax/runtime) findings present:\n" + "\n".join(lines))
+
+
+@ruff_required
+def test_known_F821_false_positives_are_noqa_suppressed():
+    """The two known F821 false positives carry scoped # noqa, keeping the tree F821-clean.
+
+    Regression guard: if someone strips a noqa or reintroduces the bare pattern,
+    this catches it. (#3273 documented exactly two F821 hits, both false positives.)
+    """
+    proc = subprocess.run(
+        RUFF + ["check", "--select", "F821", "--output-format", "json", "--no-cache", "."],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    findings = json.loads(proc.stdout) if proc.stdout.strip() else []
+    locs = [f"{os.path.relpath(f['filename'], REPO_ROOT)}:{f['location']['row']}" for f in findings]
+    assert not findings, f"unexpected F821 findings (annotate genuine false positives with # noqa): {locs}"
+
+
+def test_ruff_lint_runner_importable_and_has_modes():
+    """scripts/ruff_lint.py imports and exposes the --diff / --all entry points."""
+    scripts_dir = os.path.join(REPO_ROOT, "scripts")
+    sys.path.insert(0, scripts_dir)
+    try:
+        import ruff_lint  # noqa: PLC0415  intentional local import for test
+    finally:
+        sys.path.remove(scripts_dir)
+    assert hasattr(ruff_lint, "run_diff")
+    assert hasattr(ruff_lint, "run_all")
+    assert hasattr(ruff_lint, "_added_lines")
+    # The hunk-line parser is the gate's safety-critical core (only NEW lines gated).
+    # Smoke-test it against a synthetic unified diff via the module's regex.
+    assert ruff_lint._HUNK_RE.match("@@ -1,0 +5,3 @@ def f():").group(1) == "5"

--- a/tests/test_sidebar_tooltips.py
+++ b/tests/test_sidebar_tooltips.py
@@ -17,7 +17,8 @@ def test_session_title_hover_shows_full_title_not_rename_hint():
     """
     js = _sessions_js()
     assert "Double-click to rename" not in js
-    assert "title.title=_sessionFullTitleTooltip(rawTitle,cleanTitle);" in js
+    assert "title.title=_sessionFullTitleTooltip(rawTitle,cleanTitle,s);" in js
+    assert "function _sessionFullTitleTooltip(rawTitle, cleanTitle, session)" in js
 
 
 def test_sidebar_status_badges_have_explanatory_tooltips():


### PR DESCRIPTION
## v0.51.189 — Release FI (stage-batch1)

Phase 1 low-risk batch — 3 PRs reviewed, fixed, dual-gated, and tested end-to-end.

### Included PRs
| PR | Title | Author | Notes |
|----|-------|--------|-------|
| #3275 | Forward-looking ruff lint gate (E9+F+B, new-code-only) | nesquena-hermes | Closes #3273. CI `lint` job + pre-release gate + in-suite test. No app-runtime change. |
| #3270 | Suppress phantom sidebar refresh on gateway SSE reconnect | @PINKIIILQWQ | Snapshot-dedup in `static/sessions.js`; hash recipe matches backend `_snapshot_hash`. |
| #3272 | Localize WebUI tooltip quick wins | @ai-ag2026 | Closes #3242, #3214. i18n keys added to all 12 locales. |

### Gate results
- pre-Opus gate (node -c, ESLint runtime, py ast, merge markers, CHANGELOG): all green
- **ruff forward gate** (the new gate, dogfooded on its own stage): CLEAN — 0 new violations
- pytest full sequential suite (`-p no:xdist`): **7072 passed, 7 skipped, 0 failed**
- **Opus advisor**: APPROVE (no cross-PR conflict, #3270 dedup verified fail-safe, both noqa annotations verified correct)
- **Codex regression gate**: VERDICT SAFE TO SHIP

Files do not overlap in hunks across the three PRs.
