### PR TITLE
fix: remove duplicate session context prefill that breaks strict chat templates (Mistral, Gemma)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -581,7 +581,11 @@ def _webui_session_context_message(config_data: Optional[dict] = None) -> dict:
 def _prefill_messages_with_webui_context(prefill_context: dict, config_data: Optional[dict] = None) -> list[dict]:
     """Combine recall prefill with WebUI's gateway-like session context."""
     messages = list(prefill_context.get("messages") or [])
-    messages.append(_webui_session_context_message(config_data))
+    # Session context is NOT added here as a user message — it is already
+    # injected via _webui_ephemeral_system_prompt / ephemeral_system_prompt
+    # in _run_agent_streaming.  Adding it a second time as a user message
+    # creates two consecutive user messages (prefill + actual turn) which
+    # strict chat templates (Mistral, Gemma) reject with a Jinja 500.
     return messages
 
 
@@ -2443,6 +2447,36 @@ def _is_reasoning_only_assistant_message(msg) -> bool:
     return _content_has_reasoning_only_parts(content)
 
 
+def _merge_consecutive_same_role_messages(messages):
+    """Merge consecutive user/user or assistant/assistant messages.
+
+    Strict chat templates (Mistral, Gemma) enforce alternating user/assistant
+    roles.  WebUI prefill can produce consecutive user messages (prefill + actual
+    turn) which triggers a Jinja 500 from those models.  Merging them preserves
+    all content without violating alternation.
+    """
+    if not messages:
+        return messages
+    merged = [messages[0]]
+    for msg in messages[1:]:
+        role = msg.get('role')
+        if role in ('user', 'assistant') and merged[-1].get('role') == role:
+            prev = merged[-1]
+            prev_content = str(prev.get('content') or '').strip()
+            cur_content = str(msg.get('content') or '').strip()
+            if prev_content and cur_content:
+                prev['content'] = prev_content + '\n\n' + cur_content
+            elif cur_content:
+                prev['content'] = cur_content
+            # Keep tool_calls from the first message if the second has none,
+            # otherwise the second message stays as a separate entry.
+            if not prev.get('tool_calls') and msg.get('tool_calls'):
+                prev['tool_calls'] = msg.get('tool_calls')
+        else:
+            merged.append(msg)
+    return merged
+
+
 def _sanitize_messages_for_api(messages, *, cfg: dict = None):
     """Return a deep copy of messages with only API-safe fields.
 
@@ -2507,7 +2541,7 @@ def _sanitize_messages_for_api(messages, *, cfg: dict = None):
             sanitized['content'] = _strip_native_image_parts_from_content(sanitized.get('content'))
         if sanitized.get('role'):
             clean.append(sanitized)
-    return clean
+    return _merge_consecutive_same_role_messages(clean)
 
 
 def _api_safe_message_positions(messages):


### PR DESCRIPTION
## Description

Fixes consecutive user messages sent to models with strict chat templates
(Mistral, Gemma) when used via llama.cpp server. The `_webui_session_context_message()`
injected a `user`-role "Current Session Context" message into `prefill_messages`,
but this context was **already** available in the system prompt via
`_webui_ephemeral_system_prompt` / `ephemeral_system_prompt`.

The duplicate `user` message produced an alternating violation:

```
system → user (session context) → user (actual message)
```

Triggering a Jinja 500 from Mistral's template.

## Changes

1. **`api/streaming.py` — `_prefill_messages_with_webui_context()`** (line 581)
   Removed the `messages.append(_webui_session_context_message())` call.
   The session context is already injected elsewhere via ephemeral_system_prompt.

2. **`api/streaming.py` — `_merge_consecutive_same_role_messages()`** (line 2444)
   New safety-net helper that merges consecutive `user`/`user` or
   `assistant`/`assistant` messages into one, preventing the Jinja error
   from any other code path. Applied at the end of `_sanitize_messages_for_api()`.

## Testing

- The remaining safety merge was verified with unit tests covering:
  user+user, assistant+assistant, 3+ consecutive, alternating (no-op),
  tool message preservation, empty/single input.
- Tested against a real `ministral-3-14b-q4` GGUF via llama-server — 500
  error is gone and normal chat works end-to-end.

Closes #3276