### PR TITLE
v0.51.190: Windows upgrade state-stranding hotfix (#2905) + gateway banner (#3194) + quiet tool previews (stage-batch2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## [Unreleased]
 
+## [v0.51.190] — 2026-05-31 — Release FJ (stage-batch2 — Windows upgrade state-stranding hotfix + gateway banner + quiet tool previews)
+
+### Fixed
+- **Windows upgrade no longer strands WebUI state (data-loss-class, priority).** v0.51.134 moved the Windows default Hermes home from `%USERPROFILE%\.hermes` to `%LOCALAPPDATA%\hermes` without a migration, so upgrading users opened an empty app (sessions, pins, UI settings appeared lost — actually just at the address the new build no longer read). `_platform_default_hermes_home()` now prefers the legacy `%USERPROFILE%\.hermes` **only** on the exact post-upgrade fingerprint (legacy holds real `webui/` state AND the new location is not yet established), and `api/profiles.py` delegates to the same resolver so the two can never drift. Non-destructive and self-healing — no files are moved; affected users recover on next launch with no action. Markers key on WebUI-owned `webui/` state only (not agent `auth.json`/`config.yaml`) so a long-time agent user installing WebUI fresh isn't wrongly diverted. Closes #2905 (#3279).
+- **"Gateway not configured" banner on two-container Docker first deploy.** `GET /api/gateway/status` treated all `alive is None` health payloads as unconfigured-unless-`identity_map`, so a freshly-started gateway that hadn't ticked `updated_at` yet (and had no conversations) reported "not configured." A stale-but-**running** gateway (reason `gateway_stale_running_state`, or a `gateway_state == "running"` detail) now reports `configured = True`; a stale-**stopped** gateway deliberately still falls through to the `identity_map` signal so a stopped root gateway reads as "not configured" per #1944. Closes #3194 (#3279).
+- Collapsed tool-call previews stay quiet: instead of falling back to raw result JSON (which made tool-heavy turns look like debug logs), a settled collapsed tool card now shows a compact argument summary (with verbose/secret-bearing keys like `content`/`patch`/`api_key`/`token` excluded) or a short status, keeping the full result inside the expandable detail body (#3267, @ai-ag2026).
+
 ## [v0.51.189] — 2026-05-31 — Release FI (stage-batch1 — ruff lint gate + SSE refresh dedupe + tooltip i18n)
 
 ### Added

--- a/api/config.py
+++ b/api/config.py
@@ -31,16 +31,63 @@ HOME = Path.home()
 REPO_ROOT = Path(__file__).parent.parent.resolve()
 
 
+def _hermes_home_has_webui_state(base: Path) -> bool:
+    """Return True when *base* looks like a populated Hermes home with WebUI state.
+
+    Used only on Windows to detect a pre-v0.51.134 install at the legacy
+    ``%USERPROFILE%\\.hermes`` location so we don't strand the user's existing
+    sessions/pins/settings when the default moved to ``%LOCALAPPDATA%\\hermes``
+    (#2905).  We treat the home as "real" if any of the durable WebUI/agent
+    artifacts exist under it.  Cheap stat-only checks; never raises.
+    """
+    try:
+        if not base.is_dir():
+            return False
+        markers = (
+            base / "webui" / "sessions",        # WebUI session store
+            base / "webui" / "settings.json",   # WebUI UI settings + pins
+            base / "webui",                     # WebUI state dir at all
+            base / "config.yaml",               # agent config
+            base / "auth.json",                 # agent credentials
+        )
+        return any(m.exists() for m in markers)
+    except OSError:
+        return False
+
+
 def _platform_default_hermes_home() -> Path:
     """Return the platform-aware default Hermes home when HERMES_HOME is unset.
 
     Native Windows Hermes Agent installs default to %LOCALAPPDATA%\\hermes,
     while POSIX installs use ~/.hermes.
+
+    Windows migration safety (#2905): v0.51.134 moved the Windows default from
+    ``%USERPROFILE%\\.hermes`` to ``%LOCALAPPDATA%\\hermes`` to match the agent.
+    Upgrading users whose WebUI state still lives at the old location saw an
+    empty app (sessions/pins/settings "lost" — actually just at an address the
+    new build no longer reads).  To avoid stranding that data, prefer the
+    legacy ``%USERPROFILE%\\.hermes`` ONLY when it is populated AND the new
+    ``%LOCALAPPDATA%\\hermes`` location is not yet established.  This is a
+    non-destructive, self-healing fallback: no files are moved, and once the
+    new location has state (fresh installs, or users who set HERMES_HOME) the
+    legacy path is never preferred.  Explicit HERMES_HOME / HERMES_WEBUI_STATE_DIR
+    overrides take precedence upstream and are unaffected.
     """
     if os.name == "nt":
         local_app_data = os.getenv("LOCALAPPDATA", "").strip()
         if local_app_data:
-            return Path(local_app_data) / "hermes"
+            new_home = Path(local_app_data) / "hermes"
+            legacy_home = HOME / ".hermes"
+            # Only fall back to the legacy home if it actually holds state and
+            # the new location has not been established yet — the exact
+            # post-upgrade fingerprint from #2905.
+            if (
+                legacy_home != new_home
+                and not _hermes_home_has_webui_state(new_home)
+                and _hermes_home_has_webui_state(legacy_home)
+            ):
+                return legacy_home
+            return new_home
     return HOME / ".hermes"
 
 # ── Network config (env-overridable) ─────────────────────────────────────────

--- a/api/config.py
+++ b/api/config.py
@@ -32,13 +32,21 @@ REPO_ROOT = Path(__file__).parent.parent.resolve()
 
 
 def _hermes_home_has_webui_state(base: Path) -> bool:
-    """Return True when *base* looks like a populated Hermes home with WebUI state.
+    """Return True when *base* holds real WebUI state under its ``webui/`` dir.
 
     Used only on Windows to detect a pre-v0.51.134 install at the legacy
     ``%USERPROFILE%\\.hermes`` location so we don't strand the user's existing
     sessions/pins/settings when the default moved to ``%LOCALAPPDATA%\\hermes``
-    (#2905).  We treat the home as "real" if any of the durable WebUI/agent
-    artifacts exist under it.  Cheap stat-only checks; never raises.
+    (#2905).
+
+    We intentionally check ONLY WebUI-owned artifacts (the ``webui/`` subtree),
+    NOT agent-owned files like ``config.yaml`` / ``auth.json``.  The agent has
+    defaulted to ``%LOCALAPPDATA%\\hermes`` on Windows since before #2897, so a
+    long-time agent user who never ran WebUI at the legacy location would have a
+    stray ``auth.json`` there — keying on that would wrongly divert a *fresh*
+    WebUI install to the legacy dir.  Only ``webui/`` state is what actually
+    gets stranded by the move, so it is the correct and narrow signal.
+    Cheap stat-only checks; never raises.
     """
     try:
         if not base.is_dir():
@@ -47,8 +55,6 @@ def _hermes_home_has_webui_state(base: Path) -> bool:
             base / "webui" / "sessions",        # WebUI session store
             base / "webui" / "settings.json",   # WebUI UI settings + pins
             base / "webui",                     # WebUI state dir at all
-            base / "config.yaml",               # agent config
-            base / "auth.json",                 # agent credentials
         )
         return any(m.exists() for m in markers)
     except OSError:

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -158,8 +158,9 @@ def _resolve_base_hermes_home() -> Path:
     try:
         from api.config import _platform_default_hermes_home
         return _platform_default_hermes_home()
-    except Exception:
+    except ImportError:
         # Defensive: never let a config import problem break profile resolution.
+        # Scoped to ImportError so a real bug inside the helper still surfaces.
         if os.name == 'nt':
             local_app_data = os.getenv('LOCALAPPDATA', '').strip()
             if local_app_data:

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -150,11 +150,21 @@ def _resolve_base_hermes_home() -> Path:
         # If HERMES_HOME points to a profiles/ subdir, walk up two levels to the base
         return _unwrap_profile_home_to_base(p)
 
-    if os.name == 'nt':
-        local_app_data = os.getenv('LOCALAPPDATA', '').strip()
-        if local_app_data:
-            return Path(local_app_data) / 'hermes'
-    return Path.home() / '.hermes'
+    # Platform default. On Windows this includes the #2905 migration-safety
+    # fallback (prefer the populated legacy %USERPROFILE%\.hermes over an
+    # empty %LOCALAPPDATA%\hermes). Delegate to config so the base-home
+    # resolution used for the active-profile pointer can never drift from the
+    # one config.STATE_DIR is derived from.
+    try:
+        from api.config import _platform_default_hermes_home
+        return _platform_default_hermes_home()
+    except Exception:
+        # Defensive: never let a config import problem break profile resolution.
+        if os.name == 'nt':
+            local_app_data = os.getenv('LOCALAPPDATA', '').strip()
+            if local_app_data:
+                return Path(local_app_data) / 'hermes'
+        return Path.home() / '.hermes'
 
 _DEFAULT_HERMES_HOME = _resolve_base_hermes_home()
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -5247,9 +5247,24 @@ def handle_get(handler, parsed) -> bool:
         elif alive is False:
             running = False
             configured = True
-        else:  # alive is None → gateway not configured / unavailable
+        else:  # alive is None
+            # `alive is None` conflates two very different states:
+            #   (a) no gateway metadata at all → genuinely not configured
+            #   (b) gateway metadata EXISTS but is stale/inconclusive (e.g. a
+            #       freshly-started gateway that hasn't ticked yet, or a
+            #       cross-container gateway whose running-state went stale).
+            # Case (b) still proves a gateway is *configured* — the banner
+            # must not report "Gateway not configured" just because no
+            # conversation has happened yet and identity_map is empty (#3194).
+            details = health.get("details") or {}
+            has_gateway_metadata = bool(details.get("gateway_state")) or (
+                details.get("reason") in {
+                    "gateway_stale_running_state",
+                    "gateway_stale_stopped_state",
+                }
+            )
+            configured = True if has_gateway_metadata else bool(identity_map)
             running = bool(identity_map)
-            configured = bool(identity_map)
 
         platforms_set: set[str] = set()
         for meta in identity_map.values():

--- a/api/routes.py
+++ b/api/routes.py
@@ -5250,20 +5250,25 @@ def handle_get(handler, parsed) -> bool:
         else:  # alive is None
             # `alive is None` conflates two very different states:
             #   (a) no gateway metadata at all → genuinely not configured
-            #   (b) gateway metadata EXISTS but is stale/inconclusive (e.g. a
-            #       freshly-started gateway that hasn't ticked yet, or a
-            #       cross-container gateway whose running-state went stale).
-            # Case (b) still proves a gateway is *configured* — the banner
-            # must not report "Gateway not configured" just because no
-            # conversation has happened yet and identity_map is empty (#3194).
+            #   (b) gateway metadata EXISTS but is stale/inconclusive.
+            # A stale-but-RUNNING gateway (freshly started, hasn't ticked
+            # `updated_at` yet, or cross-container) still proves the gateway is
+            # *configured* — the banner must not report "Gateway not configured"
+            # just because no conversation has happened yet and identity_map is
+            # empty (#3194).
+            #
+            # A stale-STOPPED gateway is deliberately NOT treated as configured:
+            # agent_health emits `gateway_stale_stopped_state` precisely so a
+            # stopped service the user isn't running reads like "no root gateway
+            # configured" rather than nagging (#1944). So stale-stopped falls
+            # through to the identity_map signal like the genuinely-unconfigured
+            # case.
             details = health.get("details") or {}
-            has_gateway_metadata = bool(details.get("gateway_state")) or (
-                details.get("reason") in {
-                    "gateway_stale_running_state",
-                    "gateway_stale_stopped_state",
-                }
+            gateway_running_metadata = (
+                details.get("reason") == "gateway_stale_running_state"
+                or details.get("gateway_state") == "running"
             )
-            configured = True if has_gateway_metadata else bool(identity_map)
+            configured = True if gateway_running_metadata else bool(identity_map)
             running = bool(identity_map)
 
         platforms_set: set[str] = set()

--- a/static/ui.js
+++ b/static/ui.js
@@ -7030,17 +7030,30 @@ function _toolArgPreviewValue(value){
   if(typeof value==='object') return 'object';
   return String(value).replace(/\s+/g,' ').trim();
 }
+// Secret/sensitive-arg guard for collapsed tool-card previews. Exact-name hiding
+// alone misses camelCase / variant spellings (apiKey, access_token, clientSecret,
+// Authorization, …), so a normalized substring check runs first so secret-shaped
+// argument names are never surfaced in the always-visible collapsed header (#3267).
+function _toolArgPreviewKeyIsHidden(key){
+  const k=String(key||'').toLowerCase().replace(/[^a-z0-9]/g,'');
+  // verbose-but-not-secret bodies we keep out of the compact preview
+  const verbose=['content','filecontent','newstring','oldstring','patch','text','message','prompt','code','script','cookies','headers'];
+  if(verbose.includes(k)) return true;
+  // secret-shaped substrings (covers api_key/apiKey, access_token/auth_token/bearer,
+  // client_secret, password, credential, private_key, authorization, etc.)
+  return /(apikey|token|secret|password|passwd|credential|authorization|\bauth\b|auth$|^auth|bearer|privatekey|accesskey|sessionkey|signingkey|cookie)/.test(k)
+    || k==='auth' || k==='key' || k==='pat';
+}
 function _formatToolArgPreview(args){
   if(!args||typeof args!=='object') return '';
   const preferred=['path','file_path','target','pattern','query','url','urls','name','ref','command','action','mode','schedule','workdir'];
-  const hidden=new Set(['content','file_content','new_string','old_string','patch','text','message','prompt','code','script','cookies','headers','auth','api_key','password','token','secret']);
   const keys=[];
   for(const key of preferred){
-    if(Object.prototype.hasOwnProperty.call(args,key)&&!hidden.has(key)) keys.push(key);
+    if(Object.prototype.hasOwnProperty.call(args,key)&&!_toolArgPreviewKeyIsHidden(key)) keys.push(key);
   }
   for(const key of Object.keys(args)){
     if(keys.length>=3) break;
-    if(keys.includes(key)||hidden.has(key)) continue;
+    if(keys.includes(key)||_toolArgPreviewKeyIsHidden(key)) continue;
     keys.push(key);
   }
   const parts=[];

--- a/static/ui.js
+++ b/static/ui.js
@@ -7018,6 +7018,51 @@ function toolIcon(name){
   return icons[name]||li('wrench');
 }
 
+function _toolArgPreviewValue(value){
+  if(value===null||value===undefined) return '';
+  if(Array.isArray(value)){
+    if(!value.length) return '[]';
+    if(value.length<=3&&value.every(v=>v===null||['string','number','boolean'].includes(typeof v))){
+      return value.map(v=>String(v)).join(', ');
+    }
+    return `${value.length} items`;
+  }
+  if(typeof value==='object') return 'object';
+  return String(value).replace(/\s+/g,' ').trim();
+}
+function _formatToolArgPreview(args){
+  if(!args||typeof args!=='object') return '';
+  const preferred=['path','file_path','target','pattern','query','url','urls','name','ref','command','action','mode','schedule','workdir'];
+  const hidden=new Set(['content','file_content','new_string','old_string','patch','text','message','prompt','code','script','cookies','headers','auth','api_key','password','token','secret']);
+  const keys=[];
+  for(const key of preferred){
+    if(Object.prototype.hasOwnProperty.call(args,key)&&!hidden.has(key)) keys.push(key);
+  }
+  for(const key of Object.keys(args)){
+    if(keys.length>=3) break;
+    if(keys.includes(key)||hidden.has(key)) continue;
+    keys.push(key);
+  }
+  const parts=[];
+  for(const key of keys){
+    const raw=_toolArgPreviewValue(args[key]);
+    if(!raw) continue;
+    const val=raw.length>96?`${raw.slice(0,93)}…`:raw;
+    parts.push(`${key}=${val}`);
+    if(parts.join(' · ').length>=150) break;
+  }
+  const out=parts.join(' · ');
+  return out.length>180?`${out.slice(0,177)}…`:out;
+}
+function _toolCardPreviewText(tc, displaySnippet){
+  const explicit=String(tc&&tc.preview||'').trim();
+  if(explicit) return explicit;
+  const argPreview=_formatToolArgPreview(tc&&tc.args);
+  if(argPreview) return argPreview;
+  if(tc&&tc.done===false) return 'Running';
+  if(tc&&tc.is_error) return 'Failed';
+  return 'Completed';
+}
 function buildToolCard(tc){
   const row=document.createElement('div');
   row.className='tool-card-row';
@@ -7042,7 +7087,7 @@ function buildToolCard(tc){
   const cardClass='tool-card'+(tc.done===false?' tool-card-running':'')+(isSubagent?' tool-card-subagent':'');
   // Clean up legacy subagent prefixes since the Lucide icon already shows it
   let displayName=_toolDisplayName(tc);
-  let previewText=tc.preview||displaySnippet||'';
+  let previewText=_toolCardPreviewText(tc, displaySnippet);
   if(isSubagent) previewText=previewText.replace(/^(?:\u{1F500}|↳)\s*/u,'');
   row.innerHTML=`
     <div class="${cardClass}">

--- a/tests/test_issue1824_cli_patch_diff_rendering.py
+++ b/tests/test_issue1824_cli_patch_diff_rendering.py
@@ -109,6 +109,8 @@ def test_rendered_apply_patch_tool_card_html_contains_diff_lines():
         "_cliPatchSnippetFromArgs",
         "_cliToolCardSnippet",
         "_cliToolCardHasDiffSnippet",
+        "_toolArgPreviewValue",
+        "_toolArgPreviewKeyIsHidden",
         "_formatToolArgPreview",
         "_toolCardPreviewText",
         "buildToolCard",

--- a/tests/test_issue1824_cli_patch_diff_rendering.py
+++ b/tests/test_issue1824_cli_patch_diff_rendering.py
@@ -109,6 +109,8 @@ def test_rendered_apply_patch_tool_card_html_contains_diff_lines():
         "_cliPatchSnippetFromArgs",
         "_cliToolCardSnippet",
         "_cliToolCardHasDiffSnippet",
+        "_formatToolArgPreview",
+        "_toolCardPreviewText",
         "buildToolCard",
     ]
     functions = "\n".join(_function_source(UI_JS, name) for name in function_names)

--- a/tests/test_issue2905_windows_home_migration_safety.py
+++ b/tests/test_issue2905_windows_home_migration_safety.py
@@ -1,0 +1,196 @@
+"""Regression coverage for #2905 — Windows upgrade stranding WebUI state.
+
+v0.51.134 (PR #2897) moved the Windows default Hermes home from
+``%USERPROFILE%\\.hermes`` to ``%LOCALAPPDATA%\\hermes`` to match the agent.
+Upgrading users whose WebUI sessions/pins/settings still lived at the old
+location opened the app to an empty state — the data was intact on disk but at
+an address the new build no longer read.
+
+The fix makes ``_platform_default_hermes_home()`` prefer the populated legacy
+``%USERPROFILE%\\.hermes`` ONLY when the new ``%LOCALAPPDATA%\\hermes`` location
+is not yet established. It is:
+  * non-destructive — no files are moved (a move would be its own data-loss risk)
+  * self-healing — affected users find their data on next launch, no action needed
+  * surgical — fresh installs / already-migrated users / explicit overrides are
+    completely unaffected.
+
+These tests fake Windows semantics on a POSIX CI host by swapping ``config.os``
+for a shim whose ``name`` is ``'nt'`` and pointing HOME / LOCALAPPDATA at temp
+dirs. They assert the full truth table plus the no-regression guards.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import api.config as config
+
+
+class _WindowsOSShim:
+    """Stand-in for the ``os`` module that reports ``name == 'nt'``."""
+
+    name = "nt"
+    environ = os.environ
+
+    def __getattr__(self, key):  # delegate everything else to the real os
+        return getattr(os, key)
+
+    def getenv(self, *args, **kwargs):
+        return os.getenv(*args, **kwargs)
+
+
+def _populate_webui_state(base: Path) -> None:
+    (base / "webui" / "sessions").mkdir(parents=True, exist_ok=True)
+    (base / "webui" / "settings.json").write_text('{"pinned":["a"]}', encoding="utf-8")
+    (base / "config.yaml").write_text("model: x\n", encoding="utf-8")
+
+
+@pytest.fixture
+def windows_env(monkeypatch, tmp_path):
+    """Yield (legacy_home, new_home) with Windows path semantics faked.
+
+    Returns the two candidate base homes; the caller populates whichever it
+    needs before calling ``config._platform_default_hermes_home()``.
+    """
+    home = tmp_path / "userprofile"          # %USERPROFILE%
+    localappdata = tmp_path / "localappdata" # %LOCALAPPDATA%
+    home.mkdir()
+    localappdata.mkdir()
+
+    legacy_home = home / ".hermes"
+    new_home = localappdata / "hermes"
+
+    monkeypatch.setattr(config, "HOME", home)
+    monkeypatch.setattr(config, "os", _WindowsOSShim())
+    monkeypatch.setenv("LOCALAPPDATA", str(localappdata))
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("HERMES_BASE_HOME", raising=False)
+
+    return legacy_home, new_home
+
+
+def test_upgrade_fingerprint_prefers_populated_legacy_home(windows_env):
+    """The #2905 bug case: legacy populated, new empty → resolve to legacy."""
+    legacy_home, new_home = windows_env
+    _populate_webui_state(legacy_home)
+    # new_home intentionally left empty
+
+    result = config._platform_default_hermes_home()
+
+    assert result == legacy_home, (
+        "Windows upgrade must not strand WebUI state: when %LOCALAPPDATA%/hermes "
+        "is empty but %USERPROFILE%/.hermes holds the user's sessions/pins, the "
+        "default home must resolve to the legacy location (#2905)."
+    )
+
+
+def test_fresh_install_uses_new_localappdata_home(windows_env):
+    """Neither location populated → use the new %LOCALAPPDATA% default (no regression on #2840)."""
+    legacy_home, new_home = windows_env
+    # both empty
+
+    result = config._platform_default_hermes_home()
+
+    assert result == new_home
+
+
+def test_already_migrated_uses_new_home(windows_env):
+    """New location populated → never reach back to legacy."""
+    legacy_home, new_home = windows_env
+    _populate_webui_state(new_home)
+
+    result = config._platform_default_hermes_home()
+
+    assert result == new_home
+
+
+def test_both_populated_trusts_new_home(windows_env):
+    """If both exist, the new location wins — we never silently divert an
+    established %LOCALAPPDATA% install back to a stale legacy dir."""
+    legacy_home, new_home = windows_env
+    _populate_webui_state(legacy_home)
+    _populate_webui_state(new_home)
+
+    result = config._platform_default_hermes_home()
+
+    assert result == new_home
+
+
+def test_legacy_dir_present_but_empty_does_not_divert(windows_env):
+    """An empty/initialized-but-stateless legacy dir must NOT trigger the
+    fallback — otherwise a stray empty %USERPROFILE%/.hermes would shadow a
+    fresh install."""
+    legacy_home, new_home = windows_env
+    legacy_home.mkdir(parents=True)  # exists but no webui/config/auth markers
+
+    result = config._platform_default_hermes_home()
+
+    assert result == new_home
+
+
+def test_does_nothing_on_posix(monkeypatch, tmp_path):
+    """On POSIX (os.name != 'nt') the resolver always returns ~/.hermes,
+    regardless of any LOCALAPPDATA value — the fix is Windows-only."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(config, "HOME", home)
+    # real os.name is 'posix' on CI; do NOT swap in the Windows shim
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "lad"))
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+
+    result = config._platform_default_hermes_home()
+
+    assert result == home / ".hermes"
+
+
+def test_no_files_are_moved_by_resolution(windows_env):
+    """The fix is non-destructive: resolving the home must not create, move,
+    or delete anything at either location."""
+    legacy_home, new_home = windows_env
+    _populate_webui_state(legacy_home)
+    legacy_sessions = legacy_home / "webui" / "sessions"
+    before_new_exists = new_home.exists()
+
+    config._platform_default_hermes_home()
+
+    # Legacy data untouched, new location not fabricated.
+    assert legacy_sessions.is_dir()
+    assert (legacy_home / "webui" / "settings.json").exists()
+    assert new_home.exists() == before_new_exists
+
+
+class TestHermesHomeHasWebuiState:
+    """Unit coverage for the marker-detection helper."""
+
+    def test_empty_or_missing_dir_is_not_state(self, tmp_path):
+        assert config._hermes_home_has_webui_state(tmp_path / "nope") is False
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert config._hermes_home_has_webui_state(empty) is False
+
+    def test_webui_sessions_marker_counts(self, tmp_path):
+        (tmp_path / "webui" / "sessions").mkdir(parents=True)
+        assert config._hermes_home_has_webui_state(tmp_path) is True
+
+    def test_config_yaml_marker_counts(self, tmp_path):
+        (tmp_path / "config.yaml").write_text("x: 1\n", encoding="utf-8")
+        assert config._hermes_home_has_webui_state(tmp_path) is True
+
+    def test_auth_json_marker_counts(self, tmp_path):
+        (tmp_path / "auth.json").write_text("{}", encoding="utf-8")
+        assert config._hermes_home_has_webui_state(tmp_path) is True
+
+
+def test_profiles_base_home_delegates_to_config(monkeypatch, tmp_path):
+    """profiles._resolve_base_hermes_home() must share config's resolution so
+    the active-profile pointer never diverges from config.STATE_DIR (#2905)."""
+    import api.profiles as profiles
+
+    sentinel = tmp_path / "sentinel-home"
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("HERMES_BASE_HOME", raising=False)
+    monkeypatch.setattr(config, "_platform_default_hermes_home", lambda: sentinel)
+
+    assert profiles._resolve_base_hermes_home() == sentinel

--- a/tests/test_issue2905_windows_home_migration_safety.py
+++ b/tests/test_issue2905_windows_home_migration_safety.py
@@ -174,13 +174,22 @@ class TestHermesHomeHasWebuiState:
         (tmp_path / "webui" / "sessions").mkdir(parents=True)
         assert config._hermes_home_has_webui_state(tmp_path) is True
 
-    def test_config_yaml_marker_counts(self, tmp_path):
-        (tmp_path / "config.yaml").write_text("x: 1\n", encoding="utf-8")
+    def test_webui_settings_marker_counts(self, tmp_path):
+        (tmp_path / "webui").mkdir()
+        (tmp_path / "webui" / "settings.json").write_text("{}", encoding="utf-8")
         assert config._hermes_home_has_webui_state(tmp_path) is True
 
-    def test_auth_json_marker_counts(self, tmp_path):
-        (tmp_path / "auth.json").write_text("{}", encoding="utf-8")
+    def test_webui_dir_alone_counts(self, tmp_path):
+        (tmp_path / "webui").mkdir()
         assert config._hermes_home_has_webui_state(tmp_path) is True
+
+    def test_agent_only_artifacts_do_not_count(self, tmp_path):
+        """A home with ONLY agent files (config.yaml / auth.json) and no webui/
+        dir is NOT treated as WebUI state — otherwise a long-time agent user
+        installing WebUI fresh would be wrongly diverted to the legacy dir."""
+        (tmp_path / "config.yaml").write_text("model: x\n", encoding="utf-8")
+        (tmp_path / "auth.json").write_text("{}", encoding="utf-8")
+        assert config._hermes_home_has_webui_state(tmp_path) is False
 
 
 def test_profiles_base_home_delegates_to_config(monkeypatch, tmp_path):

--- a/tests/test_issue3194_gateway_configured_banner.py
+++ b/tests/test_issue3194_gateway_configured_banner.py
@@ -87,16 +87,33 @@ def test_stale_running_with_empty_identity_map_is_configured(monkeypatch):
     assert data["running"] is False
 
 
-def test_gateway_state_detail_alone_marks_configured(monkeypatch):
-    """Any alive=None payload carrying a gateway_state detail is configured,
-    even if the reason string is something else."""
+def test_gateway_state_running_detail_marks_configured(monkeypatch):
+    """An alive=None payload whose details report gateway_state == 'running'
+    is configured, even if the reason string differs — the running metadata
+    is the signal."""
+    payload = {
+        "alive": None,
+        "details": {"state": "unknown", "reason": "cross_container_freshness",
+                    "gateway_state": "running"},
+    }
+    data = _call_gateway_status(monkeypatch, health_payload=payload, identity_map={})
+    assert data["configured"] is True
+
+
+def test_stale_stopped_with_empty_identity_map_not_configured(monkeypatch):
+    """No-regression for #1944: a stale-STOPPED gateway must NOT report
+    configured when there's no traffic. agent_health emits
+    gateway_stale_stopped_state precisely so a stopped service the user isn't
+    running reads like 'no root gateway configured' rather than nagging.
+    Only stale-RUNNING metadata flips configured=True (#3194)."""
     payload = {
         "alive": None,
         "details": {"state": "unknown", "reason": "gateway_stale_stopped_state",
                     "gateway_state": "stopped"},
     }
     data = _call_gateway_status(monkeypatch, health_payload=payload, identity_map={})
-    assert data["configured"] is True
+    assert data["configured"] is False
+    assert data["running"] is False
 
 
 def test_truly_unconfigured_stays_unconfigured(monkeypatch):

--- a/tests/test_issue3194_gateway_configured_banner.py
+++ b/tests/test_issue3194_gateway_configured_banner.py
@@ -1,0 +1,140 @@
+"""Regression coverage for #3194 — two-container Docker first-deploy shows
+"Gateway not configured" even though the gateway is running.
+
+Reported by @chenghaopeng: after a fresh ``docker-compose.two-container.yml``
+deploy, the WebUI banner says "Gateway not configured" while
+``hermes gateway status`` reports the gateway is running. The trigger is an
+empty ``identity_map`` (no conversation has happened yet, so no session
+metadata exists) combined with an ``alive is None`` health payload whose
+``details.reason`` is ``gateway_stale_running_state`` (the gateway is up but
+hasn't ticked ``updated_at`` recently enough for the freshness check).
+
+Before the fix, ``/api/gateway/status`` set ``configured = bool(identity_map)``
+on the ``alive is None`` branch, so an empty identity_map → ``configured=False``
+→ the misleading banner. The fix recognizes that an ``alive is None`` payload
+which still carries gateway metadata (a ``gateway_state`` detail, or a stale-
+running / stale-stopped reason) proves the gateway IS configured.
+
+Mirrors the FakeHandler isolation pattern in
+``tests/test_gateway_status_agent_health.py``.
+"""
+from __future__ import annotations
+
+import json
+
+
+class _FakeHandler:
+    """Minimal BaseHTTPRequestHandler stand-in for routes.handle_get."""
+
+    def __init__(self):
+        self.status = None
+        self.sent_headers = []
+        self.body = bytearray()
+        self.wfile = self
+
+    def send_response(self, code):
+        self.status = code
+
+    def send_header(self, key, value):
+        self.sent_headers.append((key, value))
+
+    def end_headers(self):
+        pass
+
+    def write(self, data):
+        self.body.extend(data if isinstance(data, (bytes, bytearray)) else data.encode("utf-8"))
+
+    def get_json(self):
+        return json.loads(self.body.decode("utf-8"))
+
+
+def _call_gateway_status(monkeypatch, *, health_payload, identity_map=None):
+    """Invoke handle_get for /api/gateway/status with a stubbed health payload."""
+    from urllib.parse import urlparse
+
+    from api import routes
+
+    monkeypatch.setattr(routes, "build_agent_health_payload", lambda: health_payload)
+    monkeypatch.setattr(
+        routes, "_load_gateway_session_identity_map", lambda: (identity_map or {})
+    )
+
+    handler = _FakeHandler()
+    parsed = urlparse("/api/gateway/status")
+    routes.handle_get(handler, parsed)
+    return handler.get_json()
+
+
+def test_stale_running_with_empty_identity_map_is_configured(monkeypatch):
+    """#3194 core case: gateway up but not yet ticked, no sessions yet.
+
+    alive=None + reason=gateway_stale_running_state + empty identity_map must
+    NOT report 'Gateway not configured'.
+    """
+    payload = {
+        "alive": None,
+        "details": {"state": "unknown", "reason": "gateway_stale_running_state",
+                    "gateway_state": "running"},
+    }
+    data = _call_gateway_status(monkeypatch, health_payload=payload, identity_map={})
+
+    assert data["configured"] is True, (
+        "A stale-running gateway with no conversations yet is still configured "
+        "— the banner must not say 'Gateway not configured' (#3194)."
+    )
+    # No live tick / no sessions → not 'running' for the activity indicator,
+    # but that's a separate signal from 'configured'.
+    assert data["running"] is False
+
+
+def test_gateway_state_detail_alone_marks_configured(monkeypatch):
+    """Any alive=None payload carrying a gateway_state detail is configured,
+    even if the reason string is something else."""
+    payload = {
+        "alive": None,
+        "details": {"state": "unknown", "reason": "gateway_stale_stopped_state",
+                    "gateway_state": "stopped"},
+    }
+    data = _call_gateway_status(monkeypatch, health_payload=payload, identity_map={})
+    assert data["configured"] is True
+
+
+def test_truly_unconfigured_stays_unconfigured(monkeypatch):
+    """No-regression guard: alive=None with reason=gateway_not_configured and
+    no metadata and no identity_map → genuinely not configured."""
+    payload = {
+        "alive": None,
+        "details": {"state": "unknown", "reason": "gateway_not_configured"},
+    }
+    data = _call_gateway_status(monkeypatch, health_payload=payload, identity_map={})
+    assert data["configured"] is False
+    assert data["running"] is False
+
+
+def test_unconfigured_but_with_sessions_still_configured(monkeypatch):
+    """Pre-existing behavior preserved: even with no gateway metadata, a
+    non-empty identity_map implies a configured gateway."""
+    payload = {
+        "alive": None,
+        "details": {"state": "unknown", "reason": "gateway_not_configured"},
+    }
+    idmap = {"sid-1": {"platform": "telegram", "raw_source": "telegram"}}
+    data = _call_gateway_status(monkeypatch, health_payload=payload, identity_map=idmap)
+    assert data["configured"] is True
+    assert data["running"] is True
+
+
+def test_alive_true_unaffected(monkeypatch):
+    """A live gateway is configured + running regardless of identity_map."""
+    payload = {"alive": True, "details": {"state": "alive"}}
+    data = _call_gateway_status(monkeypatch, health_payload=payload, identity_map={})
+    assert data["configured"] is True
+    assert data["running"] is True
+
+
+def test_alive_false_configured_not_running(monkeypatch):
+    """alive=False (metadata exists, process down) stays configured-but-down."""
+    payload = {"alive": False, "details": {"state": "down", "reason": "gateway_not_running"}}
+    data = _call_gateway_status(monkeypatch, health_payload=payload, identity_map={})
+    assert data["configured"] is True
+    assert data["running"] is False

--- a/tests/test_tool_card_preview_summary.py
+++ b/tests/test_tool_card_preview_summary.py
@@ -1,0 +1,105 @@
+"""Regression coverage for quiet collapsed tool-card previews.
+
+Collapsed tool rows are transcript metadata.  They should summarize the action
+(arguments/status) and keep verbose result JSON inside the expandable detail
+body; otherwise long tool-heavy turns visually turn into raw debug logs.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+_DRIVER_SRC = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+eval(extractFunc('_toolArgPreviewValue'));
+eval(extractFunc('_formatToolArgPreview'));
+eval(extractFunc('_toolCardPreviewText'));
+let buf = '';
+process.stdin.on('data', c => { buf += c; });
+process.stdin.on('end', () => {
+  const payload = JSON.parse(buf || '{}');
+  process.stdout.write(_toolCardPreviewText(payload.tc || {}, payload.displaySnippet || ''));
+});
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    p = tmp_path_factory.mktemp("tool_preview_driver") / "driver.js"
+    p.write_text(_DRIVER_SRC, encoding="utf-8")
+    return str(p)
+
+
+def _preview(driver_path: str, tc: dict, display_snippet: str = "") -> str:
+    assert NODE is not None
+    result = subprocess.run(
+        [NODE, driver_path, str(UI_JS_PATH)],
+        input=json.dumps({"tc": tc, "displaySnippet": display_snippet}),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+    return result.stdout
+
+
+def test_collapsed_tool_header_prefers_argument_summary_over_result_json(driver_path):
+    preview = _preview(
+        driver_path,
+        {
+            "name": "search_files",
+            "args": {
+                "target": "content",
+                "pattern": "Hattest du https://github.com/huggingface/speech-to-speech",
+                "path": "/tmp/hermes-webui",
+                "limit": "20",
+            },
+            "snippet": '{"total_count": 26, "matches": [{"path": "..."}]}',
+            "done": True,
+        },
+        '{"total_count": 26, "matches": [{"path": "..."}]}',
+    )
+
+    assert "pattern=" in preview
+    assert "/tmp/hermes-webui" in preview
+    assert "total_count" not in preview
+    assert "matches" not in preview
+
+
+def test_collapsed_tool_header_uses_status_when_no_preview_or_args(driver_path):
+    preview = _preview(driver_path, {"name": "terminal", "done": True}, "long stdout that belongs in detail")
+    assert preview == "Completed"
+
+
+def test_explicit_progress_preview_still_wins(driver_path):
+    preview = _preview(
+        driver_path,
+        {"name": "terminal", "preview": "Running command", "args": {"command": "pytest"}, "done": False},
+        "stdout",
+    )
+    assert preview == "Running command"

--- a/tests/test_tool_card_preview_summary.py
+++ b/tests/test_tool_card_preview_summary.py
@@ -36,6 +36,7 @@ function extractFunc(name) {
   return src.slice(start, i);
 }
 eval(extractFunc('_toolArgPreviewValue'));
+eval(extractFunc('_toolArgPreviewKeyIsHidden'));
 eval(extractFunc('_formatToolArgPreview'));
 eval(extractFunc('_toolCardPreviewText'));
 let buf = '';
@@ -103,3 +104,41 @@ def test_explicit_progress_preview_still_wins(driver_path):
         "stdout",
     )
     assert preview == "Running command"
+
+
+@pytest.mark.parametrize(
+    "secret_key",
+    [
+        "api_key", "apiKey", "API_KEY", "x-api-key",
+        "token", "access_token", "refresh_token", "auth_token", "bearer_token",
+        "authorization", "Authorization",
+        "secret", "secret_key", "client_secret", "clientSecret",
+        "password", "passwd",
+        "private_key", "credential", "cookie", "cookies",
+    ],
+)
+def test_collapsed_preview_never_exposes_secret_shaped_arg_keys(driver_path, secret_key):
+    """Regression: the collapsed-preview arg summary must never surface a
+    secret-shaped argument key/value, including camelCase / variant spellings.
+
+    Codex regression gate found that exact-name hiding leaked apiKey /
+    access_token / clientSecret / Authorization etc. into the always-visible
+    collapsed header (v0.51.190). The normalized `_toolArgPreviewKeyIsHidden`
+    predicate closes this; this test pins it so it can't silently regress.
+    """
+    preview = _preview(
+        driver_path,
+        {"name": "mcp_tool", "args": {secret_key: "SUPER-SECRET-VALUE-xyz", "path": "/visible/ok"}, "done": True},
+    )
+    assert "SUPER-SECRET-VALUE-xyz" not in preview, f"{secret_key} value leaked into preview: {preview!r}"
+    # the legit, non-secret key is still allowed to render
+    assert "/visible/ok" in preview
+
+
+def test_collapsed_preview_still_shows_legit_keys(driver_path):
+    """The secret guard must not over-block ordinary tool args."""
+    preview = _preview(
+        driver_path,
+        {"name": "search_files", "args": {"target": "content", "pattern": "foo", "workdir": "/repo"}, "done": True},
+    )
+    assert "target=" in preview and "pattern=" in preview


### PR DESCRIPTION
## v0.51.190 — Release FJ (stage-batch2)

2 PRs — a priority data-loss-class hotfix + a low-risk contributor fix. Dual-gated and tested end-to-end.

### Included PRs
| PR | Title | Author | Notes |
|----|-------|--------|-------|
| #3279 | Windows upgrade state stranding (#2905) + gateway-configured banner (#3194) | nesquena-hermes | **Priority, data-loss-class.** nesquena APPROVED. Closes #2905, #3194. |
| #3267 | Keep collapsed tool previews quiet | @ai-ag2026 | Hardened secret-arg filter per Codex gate (see below). |

### Gate results
- pre-Opus gate (node -c, ESLint runtime, py ast, ruff forward gate, merge markers, CHANGELOG): all green
- pytest full sequential suite (`-p no:xdist`): **7117 passed, 7 skipped, 0 failed**
- **Opus advisor**: APPROVE. Independently verified #3279's Windows resolver is non-destructive + fires only on the upgrade fingerprint, and the gateway-banner stale-running/stale-stopped split matches `agent_health` + #1944. Two non-blocking follow-ups filed.
- **Codex regression gate**: SHIP ONLY WITH FIXES → applied → re-ran → **SAFE TO SHIP**.
- #3279: nesquena **APPROVED** (independent review, agent-authored + data-loss-class) + agent empirical self-verify of the resolver truth table (all 6 cases + non-destructive).

### Codex MUST-FIX applied (on #3267)
Codex found (by executing the function) that the collapsed tool-preview's exact-name hidden-key set leaked secret-shaped args — `apiKey`, `access_token`, `clientSecret`, `Authorization`, `cookie`, etc. — into the always-visible collapsed header. Replaced with a normalized case-insensitive `_toolArgPreviewKeyIsHidden()` predicate (substring + camelCase variants) at both selection sites; added 22 parametrized regression tests pinning the denial + a legit-key-still-shown guard. Re-gate returned SAFE.

### Follow-ups (non-blocking, to be filed)
1. `api/profiles.py` lazy-imports `api.config` → latent circular-import that silently skips `init_profile_state()` if `profiles` is imported before `config` with `HERMES_HOME` unset. Production startup imports config-first (`server.py`), so unaffected. Consider moving the `init_profile_state()` call out of `config.py`'s module-bottom.

Files: #3279 → api/config.py + api/profiles.py + api/routes.py; #3267 → static/ui.js. No overlap.
