### PR TITLE
chore: add GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: nesquena


### PR DESCRIPTION
## What

Adds `.github/FUNDING.yml` to enable the **Sponsor** button on the repository.

```yaml
github: nesquena
```

## Why

GitHub displays a "Sponsor" button at the top of the repo and on each release/issue when a `FUNDING.yml` is present, giving the community a clear way to financially support the project. This enables GitHub Sponsors for `@nesquena`.

## Scope

- Single new file: `.github/FUNDING.yml`
- GitHub-only funding for now (other platforms can be added later)
- No application code changes, no tests affected
