### PR TITLE
v0.51.191: skills-detail markdown styling (#3284) + launchd duplicate-start guard (#3291) (stage-batch3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.191] — 2026-05-31 — Release FK (stage-batch3 — skills-detail markdown styling + launchd duplicate-start guard)
+
 ### Fixed
-- Skills detail view now renders `SKILL.md` markdown with the same `.preview-md` typography used by Memory and Notes, instead of unstyled `renderMd()` output. Linked markdown skill files use the same wrapper and post-render code/KaTeX enhancement.
+- Skills detail view now renders `SKILL.md` markdown with the same `.preview-md` typography used by Memory and Notes, instead of unstyled `renderMd()` output. Linked markdown skill files opened from the detail view use the same wrapper plus scoped post-render `highlightCode` / KaTeX enhancement (#3284, @pamnard).
+- `ctl.sh start` now refuses to launch a second WebUI instance when a launchd-managed job already owns it (macOS), instead of racing the launchd instance into repeated `Address already in use` churn on port 8787. The guard is macOS/launchd-only, no-ops on every non-launchd path, and can be overridden with `HERMES_WEBUI_CTL_ALLOW_LAUNCHD_CONFLICT=1`; `docs/supervisor.md` documents launchd as the single source of truth. Closes #3289 (#3291, @andrewkangkr).
 
 ## [v0.51.190] — 2026-05-31 — Release FJ (stage-batch2 — Windows upgrade state-stranding hotfix + gateway banner + quiet tool previews)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Skills detail view now renders `SKILL.md` markdown with the same `.preview-md` typography used by Memory and Notes, instead of unstyled `renderMd()` output. Linked markdown skill files use the same wrapper and post-render code/KaTeX enhancement.
+
 ## [v0.51.190] — 2026-05-31 — Release FJ (stage-batch2 — Windows upgrade state-stranding hotfix + gateway banner + quiet tool previews)
 
 ### Fixed

--- a/ctl.sh
+++ b/ctl.sh
@@ -198,6 +198,22 @@ _clear_stale_pid() {
   fi
 }
 
+_pid_listens_on_port() {
+  # Best-effort check that PID $1 has a listening socket on TCP port $2.
+  # macOS (where launchd exists) ships lsof; if we can't determine ownership we
+  # return 2 ("unknown") so the caller can fall back conservatively rather than
+  # guess. Never blocks on a hard failure.
+  local pid="$1" port="$2"
+  [[ "${pid}" =~ ^[0-9]+$ && "${port}" =~ ^[0-9]+$ ]] || return 2
+  if command -v lsof >/dev/null 2>&1; then
+    if lsof -nP -p "${pid}" -iTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1; then
+      return 0   # PID is listening on that port → real conflict
+    fi
+    return 1     # PID is alive but NOT listening on that port → no conflict
+  fi
+  return 2       # can't determine
+}
+
 _launchd_webui_pid() {
   [[ "${HERMES_WEBUI_CTL_ALLOW_LAUNCHD_CONFLICT:-0}" == "1" ]] && return 1
   command -v launchctl >/dev/null 2>&1 || return 1
@@ -209,11 +225,24 @@ _launchd_webui_pid() {
   pid="$(printf '%s\n' "${launchd_out}" | awk '/^[[:space:]]*pid = / {print $3; exit}')"
   [[ "${pid}" =~ ^[0-9]+$ ]] || return 1
   (( pid > 0 )) || return 1
-  if _is_alive "${pid}"; then
-    printf '%s\n' "${pid}"
-    return 0
-  fi
-  return 1
+  _is_alive "${pid}" || return 1
+  # Only treat the launchd job as a conflict for the port we are about to bind.
+  # A second instance on a DIFFERENT port (e.g. HERMES_WEBUI_PORT=8788 for a
+  # test build) does not collide with the launchd-managed default and must be
+  # allowed to start (#3291 over-block fix). When port ownership can't be
+  # determined (no lsof), fall back to the conservative previous behavior of
+  # only guarding the default port so non-default ports are never wrongly blocked.
+  local want_port="${CTL_PORT:-${HERMES_WEBUI_PORT:-8787}}"
+  _pid_listens_on_port "${pid}" "${want_port}"
+  case "$?" in
+    0) printf '%s\n' "${pid}"; return 0 ;;   # launchd job listens on our port → block
+    1) return 1 ;;                            # launchd job on a different port → allow
+    *)                                        # unknown: only guard the default port
+      if [[ "${want_port}" == "8787" ]]; then
+        printf '%s\n' "${pid}"; return 0
+      fi
+      return 1 ;;
+  esac
 }
 
 start_cmd() {

--- a/ctl.sh
+++ b/ctl.sh
@@ -7,6 +7,7 @@ PID_FILE="${HERMES_WEBUI_PID_FILE:-${HERMES_HOME}/webui.pid}"
 LOG_FILE="${HERMES_WEBUI_LOG_FILE:-${HERMES_HOME}/webui.log}"
 STATE_FILE="${HERMES_WEBUI_CTL_STATE_FILE:-${HERMES_HOME}/webui.ctl.env}"
 DEFAULT_STATE_DIR="${HERMES_WEBUI_STATE_DIR:-${HERMES_HOME}/webui}"
+DEFAULT_LAUNCHD_LABEL="${HERMES_WEBUI_LAUNCHD_LABEL:-com.parantoux.hermes-webui}"
 
 usage() {
   cat <<'EOF'
@@ -197,6 +198,24 @@ _clear_stale_pid() {
   fi
 }
 
+_launchd_webui_pid() {
+  [[ "${HERMES_WEBUI_CTL_ALLOW_LAUNCHD_CONFLICT:-0}" == "1" ]] && return 1
+  command -v launchctl >/dev/null 2>&1 || return 1
+  local label="${HERMES_WEBUI_LAUNCHD_LABEL:-${DEFAULT_LAUNCHD_LABEL}}"
+  [[ -n "${label}" ]] || return 1
+  local uid launchd_out pid
+  uid="$(id -u)"
+  launchd_out="$(launchctl print "gui/${uid}/${label}" 2>/dev/null)" || return 1
+  pid="$(printf '%s\n' "${launchd_out}" | awk '/^[[:space:]]*pid = / {print $3; exit}')"
+  [[ "${pid}" =~ ^[0-9]+$ ]] || return 1
+  (( pid > 0 )) || return 1
+  if _is_alive "${pid}"; then
+    printf '%s\n' "${pid}"
+    return 0
+  fi
+  return 1
+}
+
 start_cmd() {
   ensure_home
   _load_repo_dotenv_preserving_env
@@ -211,6 +230,12 @@ start_cmd() {
   if existing_pid="$(_current_pid 2>/dev/null)"; then
     echo "[ctl] Hermes WebUI is already running (PID ${existing_pid})"
     return 0
+  fi
+  local launchd_pid
+  if launchd_pid="$(_launchd_webui_pid 2>/dev/null)"; then
+    echo "[ctl] Refusing to start a second Hermes WebUI while launchd job ${HERMES_WEBUI_LAUNCHD_LABEL:-${DEFAULT_LAUNCHD_LABEL}} is running (PID ${launchd_pid})." >&2
+    echo "[ctl] Use launchctl kickstart -k gui/$(id -u)/${HERMES_WEBUI_LAUNCHD_LABEL:-${DEFAULT_LAUNCHD_LABEL}} or disable the launchd job before using ctl.sh start." >&2
+    return 2
   fi
   _clear_stale_pid >/dev/null 2>&1 || true
 

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -16,6 +16,8 @@ Or set ``HERMES_WEBUI_FOREGROUND=1`` in the environment. The Web UI will
 auto-detect launchd / systemd / supervisord even without the flag, but being
 explicit is safer.
 
+**Important (launchd on macOS):** if the ``com.parantoux.hermes-webui`` LaunchAgent is enabled, treat launchd as the single source of truth for WebUI lifecycle. Do **not** also run ``./ctl.sh start``, ``bash start.sh``, ``python bootstrap.py``, or ``python server.py`` against the same state dir/port, or you can create a second WebUI instance and trigger port-8787 restart churn.
+
 ## Why ``--foreground`` matters
 
 Without it, ``bootstrap.py`` does this:

--- a/static/panels.js
+++ b/static/panels.js
@@ -3640,6 +3640,19 @@ function _stripYamlFrontmatter(content) {
   return { frontmatter: m[1], body: content.slice(m[0].length) };
 }
 
+function _skillMarkdownHtml(markdown) {
+  return `<div class="preview-md">${renderMd(markdown || '')}</div>`;
+}
+
+function _enhanceSkillMarkdown(root) {
+  if (!root) return;
+  requestAnimationFrame(() => {
+    const mdRoot = root.querySelector('.preview-md') || root;
+    if (typeof highlightCode === 'function') highlightCode(mdRoot);
+    if (typeof renderKatexBlocks === 'function') renderKatexBlocks(mdRoot);
+  });
+}
+
 function _renderSkillDetail(name, content, linkedFiles) {
   const title = $('skillDetailTitle');
   const body = $('skillDetailBody');
@@ -3652,7 +3665,7 @@ function _renderSkillDetail(name, content, linkedFiles) {
   if (frontmatter) {
     html += `<details class="skill-frontmatter"><summary>${esc(t('skill_metadata'))}</summary><pre><code>${esc(frontmatter)}</code></pre></details>`;
   }
-  html += renderMd(markdownBody || '(no content)');
+  html += _skillMarkdownHtml(markdownBody || '(no content)');
   const lf = linkedFiles || {};
   const categories = Object.entries(lf).filter(([,files]) => files && files.length > 0);
   if (categories.length) {
@@ -3667,6 +3680,7 @@ function _renderSkillDetail(name, content, linkedFiles) {
     html += '</div>';
   }
   body.innerHTML = `<div class="main-view-content skill-detail-content">${html}</div>`;
+  _enhanceSkillMarkdown(body);
   body.querySelectorAll('.skill-linked-file').forEach(a => {
     a.addEventListener('click', e => { e.preventDefault(); openSkillFile(a.dataset.skillName, a.dataset.skillFile); });
   });
@@ -3738,7 +3752,7 @@ async function openSkillFile(skillName, filePath) {
     const header = `<div class="skill-file-breadcrumb"><a href="#" class="skill-file-back" data-skill-name="${esc(skillName)}">&larr; ${esc(backLabel)}</a><span class="skill-file-path">${esc(filePath)}</span></div>`;
     let content;
     if (isMd) {
-      content = `<div class="main-view-content">${renderMd(data.content || '')}</div>`;
+      content = `<div class="main-view-content">${_skillMarkdownHtml(data.content || '')}</div>`;
     } else {
       const escaped = esc(data.content || '');
       content = `<pre class="skill-file-code"><code>${escaped}</code></pre>`;
@@ -3757,7 +3771,8 @@ async function openSkillFile(skillName, filePath) {
         }
       });
     });
-    if (!isMd) requestAnimationFrame(() => { if (typeof highlightCode === 'function') highlightCode(); });
+    if (isMd) _enhanceSkillMarkdown(body);
+    else requestAnimationFrame(() => { if (typeof highlightCode === 'function') highlightCode(); });
   } catch(e) { setStatus(t('skill_file_load_failed') + e.message); }
 }
 

--- a/tests/test_ctl_script.py
+++ b/tests/test_ctl_script.py
@@ -203,18 +203,14 @@ def test_stale_pid_file_is_removed_without_killing_unrelated_process(tmp_path):
             sleeper.kill()
 
 
-def test_start_refuses_second_instance_when_launchd_job_is_running(tmp_path):
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-
-    sleeper = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+def _write_fake_launchctl(fake_bin, pid):
     launchctl = fake_bin / "launchctl"
     launchctl.write_text(
         textwrap.dedent(
             f"""
             #!/usr/bin/env bash
             if [[ "$1" == "print" ]]; then
-              printf '\tpid = {sleeper.pid}\\n'
+              printf '\\tpid = {pid}\\n'
               exit 0
             fi
             exit 1
@@ -223,6 +219,26 @@ def test_start_refuses_second_instance_when_launchd_job_is_running(tmp_path):
         encoding="utf-8",
     )
     launchctl.chmod(0o755)
+
+
+def _write_fake_lsof(fake_bin, listening):
+    """Fake lsof: exit 0 (PID listens on the port) iff `listening` is True."""
+    lsof = fake_bin / "lsof"
+    lsof.write_text(
+        "#!/usr/bin/env bash\n" + ("exit 0\n" if listening else "exit 1\n"),
+        encoding="utf-8",
+    )
+    lsof.chmod(0o755)
+
+
+def test_start_refuses_second_instance_when_launchd_job_owns_the_port(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    sleeper = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    _write_fake_launchctl(fake_bin, sleeper.pid)
+    # launchd-owned PID IS listening on the requested (default) port → real conflict.
+    _write_fake_lsof(fake_bin, listening=True)
 
     try:
         result = run_ctl(
@@ -239,6 +255,57 @@ def test_start_refuses_second_instance_when_launchd_job_is_running(tmp_path):
         assert "launchctl kickstart -k" in combined
         assert not (tmp_path / ".hermes" / "webui.pid").exists()
     finally:
+        sleeper.terminate()
+        try:
+            sleeper.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            sleeper.kill()
+
+
+def test_start_allows_alternate_port_while_launchd_job_runs_on_default(tmp_path):
+    """A second instance on a DIFFERENT port must not be blocked by the launchd
+    guard, even while the launchd-managed default instance is alive (#3291 fix /
+    Codex regression-gate finding for v0.51.191)."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    sleeper = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    _write_fake_launchctl(fake_bin, sleeper.pid)
+    # launchd-owned PID is alive but NOT listening on our (alternate) port → no conflict.
+    _write_fake_lsof(fake_bin, listening=False)
+
+    # A fake python so `start` "launches" without needing the real server.
+    fake_python = tmp_path / "fake-python"
+    fake_python.write_text(
+        "#!/usr/bin/env bash\ntrap 'exit 0' TERM INT\nwhile true; do sleep 1; done\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    started_pid = None
+    try:
+        result = run_ctl(
+            tmp_path,
+            "start",
+            env={
+                "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
+                "HERMES_WEBUI_LAUNCHD_LABEL": "com.parantoux.hermes-webui",
+                "HERMES_WEBUI_PORT": "18992",
+                "HERMES_WEBUI_PYTHON": str(fake_python),
+            },
+        )
+        combined = result.stdout + result.stderr
+        assert "Refusing to start a second Hermes WebUI" not in combined, combined
+        assert result.returncode == 0, combined
+        pid_file = tmp_path / ".hermes" / "webui.pid"
+        if pid_file.exists():
+            started_pid = int(pid_file.read_text().strip())
+    finally:
+        if started_pid:
+            try:
+                os.kill(started_pid, 15)
+            except ProcessLookupError:
+                pass
         sleeper.terminate()
         try:
             sleeper.wait(timeout=3)

--- a/tests/test_ctl_script.py
+++ b/tests/test_ctl_script.py
@@ -110,6 +110,7 @@ def test_start_writes_pid_under_hermes_home_runs_foreground_no_browser_and_logs(
             "FAKE_PYTHON_LOG": str(fake_log),
             "HERMES_WEBUI_HOST": "0.0.0.0",
             "HERMES_WEBUI_PORT": "18991",
+            "HERMES_WEBUI_CTL_ALLOW_LAUNCHD_CONFLICT": "1",
         },
     )
 
@@ -166,6 +167,7 @@ def test_start_loads_dotenv_but_inline_overrides_win(tmp_path):
             "HERMES_WEBUI_PYTHON": str(fake_python),
             "FAKE_PYTHON_LOG": str(fake_log),
             "HERMES_WEBUI_HOST": "0.0.0.0",
+            "HERMES_WEBUI_CTL_ALLOW_LAUNCHD_CONFLICT": "1",
         },
         repo_root=repo_root,
     )
@@ -193,6 +195,49 @@ def test_stale_pid_file_is_removed_without_killing_unrelated_process(tmp_path):
         assert "stale" in (result.stdout + result.stderr).lower()
         assert sleeper.poll() is None, "ctl.sh must not kill unrelated PIDs"
         assert not pid_file.exists()
+    finally:
+        sleeper.terminate()
+        try:
+            sleeper.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            sleeper.kill()
+
+
+def test_start_refuses_second_instance_when_launchd_job_is_running(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    sleeper = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    launchctl = fake_bin / "launchctl"
+    launchctl.write_text(
+        textwrap.dedent(
+            f"""
+            #!/usr/bin/env bash
+            if [[ "$1" == "print" ]]; then
+              printf '\tpid = {sleeper.pid}\\n'
+              exit 0
+            fi
+            exit 1
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    launchctl.chmod(0o755)
+
+    try:
+        result = run_ctl(
+            tmp_path,
+            "start",
+            env={
+                "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
+                "HERMES_WEBUI_LAUNCHD_LABEL": "com.parantoux.hermes-webui",
+            },
+        )
+        assert result.returncode == 2
+        combined = result.stdout + result.stderr
+        assert "Refusing to start a second Hermes WebUI" in combined
+        assert "launchctl kickstart -k" in combined
+        assert not (tmp_path / ".hermes" / "webui.pid").exists()
     finally:
         sleeper.terminate()
         try:

--- a/tests/test_skill_detail_markdown_styling.py
+++ b/tests/test_skill_detail_markdown_styling.py
@@ -1,0 +1,54 @@
+"""Skills detail markdown must use the shared preview-md styling pipeline."""
+
+from pathlib import Path
+
+
+PANELS_JS = Path("static/panels.js").read_text(encoding="utf-8")
+
+
+def _function_block(name: str) -> str:
+    marker = f"function {name}("
+    start = PANELS_JS.find(marker)
+    assert start != -1, f"{name}() not found"
+    params_end = PANELS_JS.find("){", start)
+    assert params_end != -1, f"{name}() body not found"
+    brace = params_end + 1
+    depth = 0
+    for idx in range(brace, len(PANELS_JS)):
+        ch = PANELS_JS[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return PANELS_JS[start : idx + 1]
+    raise AssertionError(f"{name}() body did not close")
+
+
+def test_skill_detail_wraps_markdown_in_preview_md():
+    block = _function_block("_renderSkillDetail")
+    assert "_skillMarkdownHtml(" in block, "Skill detail must render through the shared markdown wrapper"
+    assert "renderMd(markdownBody" not in block.replace(" ", ""), (
+        "Skill detail must not inject raw renderMd() output without preview-md styling"
+    )
+
+
+def test_skill_markdown_helper_uses_preview_md():
+    block = _function_block("_skillMarkdownHtml")
+    assert 'class="preview-md"' in block.replace("'", '"')
+    assert "renderMd(" in block
+
+
+def test_skill_detail_enhances_markdown_after_render():
+    detail_block = _function_block("_renderSkillDetail")
+    assert "_enhanceSkillMarkdown(body)" in detail_block
+
+    enhance_block = _function_block("_enhanceSkillMarkdown")
+    assert "highlightCode" in enhance_block
+    assert "renderKatexBlocks" in enhance_block
+
+
+def test_open_skill_file_markdown_uses_preview_md():
+    block = _function_block("openSkillFile")
+    assert "_skillMarkdownHtml(" in block
+    assert "if (isMd) _enhanceSkillMarkdown(body)" in block


### PR DESCRIPTION
## v0.51.191 — Release FK (stage-batch3)

2 low-risk contributor PRs (newly arrived since the last pass), dual-gated and tested end-to-end.

### Included PRs
| PR | Title | Author | Notes |
|----|-------|--------|-------|
| #3284 | Fix skills detail markdown styling | @pamnard | Routes SKILL.md through the shared `.preview-md` pipeline + scoped highlight/KaTeX. |
| #3291 | Block duplicate WebUI start when launchd owns 8787 | @andrewkangkr | Closes #3289. Port-aware guard (Codex MUST-FIX applied). |

### Gate results
- pre-Opus gate (node -c, ESLint runtime, py ast, ruff forward gate, merge markers, CHANGELOG, `bash -n ctl.sh`): all green
- pytest full sequential suite (`-p no:xdist`): **7123 passed, 7 skipped, 0 failed** (one boot-cascade flake re-run; clean on re-run)
- **Opus advisor**: APPROVE — verified #3284 is purely additive (no Memory/Notes regression, idempotent enhancement, no throw path) and the launchd guard fail-safe across Linux/non-launchd/dead-job paths.
- **Codex regression gate**: SHIP ONLY WITH FIXES → applied → re-ran → **SAFE TO SHIP**.

### Codex MUST-FIX applied (on #3291)
Codex found (by execution) that the launchd guard blocked **any** `ctl.sh start` while a launchd job was live — including a legitimate second instance on a **different port** (`HERMES_WEBUI_PORT=8788`). Made the guard **port-aware**: `_launchd_webui_pid` now only treats the launchd job as a conflict when its PID is actually listening on the requested `CTL_PORT` (new `_pid_listens_on_port` helper via `lsof`); a different-port start is allowed, and when `lsof` is unavailable it falls back to guarding only the default 8787 port. Added a different-port-allowed regression test + made the existing block test deterministic. Re-gate returned SAFE.

Files: #3284 → static/panels.js; #3291 → ctl.sh + docs/supervisor.md. No overlap.
