### PR TITLE
Add notes-source fallback for LLM Wiki status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+### Added
+- Insights LLM Wiki status can now fall back to a configured third-party notes or knowledge source when no filesystem `WIKI_PATH` is configured, reporting metadata-only status and provider-specific counts when available without exposing note bodies.
+
+### Fixed
+- Joplin Web Clipper requests now retry HTTP 403 header-auth failures with query-token auth while preserving the Authorization header and avoiding credential logging, so notebook metadata endpoints work with stricter clipper builds.
+
 ## [v0.51.191] — 2026-05-31 — Release FK (stage-batch3 — skills-detail markdown styling + launchd duplicate-start guard)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -3234,6 +3234,7 @@ def _handle_logs(handler, parsed) -> bool:
 
 _LLM_WIKI_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/user-guide/skills/bundled/research/research-llm-wiki"
 _LLM_WIKI_PAGE_DIRS = ("entities", "concepts", "comparisons", "queries")
+_LLM_WIKI_JOPLIN_DEFAULT_ROOT_TITLE = "Hermes 🤖"
 
 
 def _llm_wiki_active_hermes_home() -> Path:
@@ -3286,6 +3287,245 @@ def _llm_wiki_config_path() -> str | None:
         _llm_wiki_get_config_path_value(cfg, "skills.config.wiki.path")
         or _llm_wiki_get_config_path_value(cfg, "wiki.path")
     )
+
+
+def _llm_wiki_joplin_root_title() -> str:
+    try:
+        from api.config import get_config as _get_cfg
+        cfg = _get_cfg()
+    except Exception:
+        cfg = {}
+    return (
+        _llm_wiki_get_config_path_value(cfg, "skills.config.wiki.joplin_root_title")
+        or _llm_wiki_get_config_path_value(cfg, "wiki.joplin_root_title")
+        or os.getenv("HERMES_WEBUI_LLM_WIKI_JOPLIN_ROOT_TITLE")
+        or _LLM_WIKI_JOPLIN_DEFAULT_ROOT_TITLE
+    )
+
+
+def _llm_wiki_notes_fallback_enabled() -> bool:
+    raw = (
+        os.getenv("HERMES_WEBUI_LLM_WIKI_NOTES_FALLBACK", "")
+        or os.getenv("HERMES_WEBUI_LLM_WIKI_JOPLIN_FALLBACK", "")
+    )
+    if raw:
+        return _webui_truthy(raw)
+    try:
+        from api.config import get_config as _get_cfg
+        cfg = _get_cfg()
+    except Exception:
+        cfg = {}
+    configured = (
+        _llm_wiki_get_config_path_value(cfg, "skills.config.wiki.notes_fallback")
+        or _llm_wiki_get_config_path_value(cfg, "wiki.notes_fallback")
+        or _llm_wiki_get_config_path_value(cfg, "skills.config.wiki.joplin_fallback")
+        or _llm_wiki_get_config_path_value(cfg, "wiki.joplin_fallback")
+    )
+    if configured is not None:
+        return _webui_truthy(configured)
+    return True
+
+
+def _llm_wiki_joplin_ms_to_iso(value) -> str | None:
+    try:
+        millis = int(value)
+    except Exception:
+        return None
+    if millis <= 0:
+        return None
+    return _llm_wiki_safe_iso(millis / 1000.0)
+
+
+def _llm_wiki_joplin_status(base: dict) -> dict | None:
+    """Summarize a configured Joplin knowledge notebook as an LLM Wiki source.
+
+    This is metadata-only: it reads notebook/note titles and timestamps, never note bodies.
+    """
+    if not _llm_wiki_notes_fallback_enabled():
+        return None
+    try:
+        folders_data = _joplin_api_get("/folders", {
+            "fields": "id,title,parent_id,updated_time",
+            "limit": 100,
+        })
+    except Exception:
+        return None
+    folders = folders_data.get("items") if isinstance(folders_data, dict) else []
+    if not isinstance(folders, list):
+        return None
+
+    root_title = str(_llm_wiki_joplin_root_title() or "").strip()
+    root = None
+    for row in folders:
+        if not isinstance(row, dict):
+            continue
+        if str(row.get("title") or "").strip() == root_title:
+            root = row
+            break
+    if root is None and root_title == _LLM_WIKI_JOPLIN_DEFAULT_ROOT_TITLE:
+        for row in folders:
+            if isinstance(row, dict) and "hermes" in str(row.get("title") or "").lower():
+                root = row
+                break
+    if not isinstance(root, dict) or not root.get("id"):
+        return None
+
+    by_parent: dict[str, list[dict]] = {}
+    by_id: dict[str, dict] = {}
+    latest_ms = 0
+    for row in folders:
+        if not isinstance(row, dict):
+            continue
+        fid = str(row.get("id") or "").strip()
+        if not fid:
+            continue
+        by_id[fid] = row
+        by_parent.setdefault(str(row.get("parent_id") or ""), []).append(row)
+        try:
+            latest_ms = max(latest_ms, int(row.get("updated_time") or 0))
+        except Exception:
+            pass
+
+    root_id = str(root.get("id") or "")
+    folder_ids: list[str] = []
+    stack = [root_id]
+    while stack and len(folder_ids) < 1000:
+        fid = stack.pop()
+        if fid in folder_ids:
+            continue
+        folder_ids.append(fid)
+        stack.extend(str(child.get("id") or "") for child in by_parent.get(fid, []) if child.get("id"))
+
+    raw_folder_ids = {
+        fid for fid in folder_ids
+        if str(by_id.get(fid, {}).get("title") or "").strip().lower() in {"raw captures", "raw", "sources"}
+    }
+    note_count = 0
+    raw_count = 0
+    for fid in folder_ids:
+        if note_count > _LLM_WIKI_MAX_FILES:
+            break
+        try:
+            notes_data = _joplin_api_get(f"/folders/{fid}/notes", {
+                "fields": "id,title,updated_time,parent_id",
+                "limit": 100,
+            })
+        except Exception:
+            continue
+        rows = notes_data.get("items") if isinstance(notes_data, dict) else []
+        if not isinstance(rows, list):
+            continue
+        for note in rows:
+            if not isinstance(note, dict) or not note.get("id"):
+                continue
+            note_count += 1
+            if fid in raw_folder_ids:
+                raw_count += 1
+            try:
+                latest_ms = max(latest_ms, int(note.get("updated_time") or 0))
+            except Exception:
+                pass
+            if note_count > _LLM_WIKI_MAX_FILES:
+                break
+
+    out = dict(base)
+    out.update({
+        "available": True,
+        "enabled": True,
+        "status": "ready" if note_count else "empty",
+        "entry_count": note_count,
+        "page_count": note_count,
+        "raw_source_count": raw_count,
+        "last_updated": _llm_wiki_joplin_ms_to_iso(latest_ms),
+        "last_writer": "Joplin",
+        "path_configured": True,
+        "path_source": "notes",
+        "source_kind": "joplin",
+        "source_label": "Joplin",
+        "source_count_available": True,
+        "toggle_reason": "Using configured third-party notes as the knowledge-base source because no filesystem LLM Wiki is configured.",
+    })
+    return out
+
+
+def _llm_wiki_preferred_notes_source() -> str | None:
+    try:
+        cfg = get_config()
+    except Exception:
+        cfg = {}
+    value = (
+        _llm_wiki_get_config_path_value(cfg, "skills.config.wiki.notes_source")
+        or _llm_wiki_get_config_path_value(cfg, "wiki.notes_source")
+        or os.getenv("HERMES_WEBUI_LLM_WIKI_NOTES_SOURCE")
+    )
+    return str(value).strip().lower() if value else None
+
+
+def _llm_wiki_configured_notes_status(base: dict) -> dict | None:
+    """Return a generic configured notes/knowledge source when rich counts are unavailable."""
+    if not _llm_wiki_notes_fallback_enabled():
+        return None
+    try:
+        cfg = get_config()
+    except Exception:
+        cfg = {}
+    servers = cfg.get("mcp_servers", {}) if isinstance(cfg, dict) else {}
+    if not isinstance(servers, dict):
+        return None
+
+    preferred = _llm_wiki_preferred_notes_source()
+    candidates: list[tuple[str, dict]] = []
+    for name, server_cfg in servers.items():
+        server_name = str(name or "").strip()
+        if not server_name or not isinstance(server_cfg, dict):
+            continue
+        try:
+            is_notes_source = _looks_like_notes_source(server_name, [])
+        except Exception:
+            lowered = server_name.lower()
+            is_notes_source = any(hint in lowered for hint in ("joplin", "obsidian", "notion", "wiki", "note", "knowledge", "logseq"))
+        if is_notes_source:
+            candidates.append((server_name, server_cfg))
+    if not candidates:
+        return None
+
+    selected_name, selected_cfg = candidates[0]
+    if preferred:
+        for name, server_cfg in candidates:
+            if name.lower() == preferred:
+                selected_name, selected_cfg = name, server_cfg
+                break
+    try:
+        source_label = _note_source_label(selected_name)
+    except Exception:
+        source_label = selected_name.replace("_", " ").replace("-", " ").title()
+
+    out = dict(base)
+    out.update({
+        "available": True,
+        "enabled": bool(selected_cfg.get("enabled", True)),
+        "status": "configured",
+        "entry_count": 0,
+        "page_count": 0,
+        "raw_source_count": 0,
+        "last_updated": None,
+        "last_writer": source_label,
+        "path_configured": True,
+        "path_source": "notes",
+        "source_kind": selected_name.lower(),
+        "source_label": source_label,
+        "source_count_available": False,
+        "toggle_reason": "Using a configured third-party notes/knowledge source because no filesystem LLM Wiki is configured; detailed counts depend on provider-specific support.",
+    })
+    return out
+
+
+def _llm_wiki_notes_status(base: dict) -> dict | None:
+    """Return provider-neutral third-party notes status, using rich provider metadata when available."""
+    rich_joplin = _llm_wiki_joplin_status(base)
+    if rich_joplin is not None:
+        return rich_joplin
+    return _llm_wiki_configured_notes_status(base)
 
 
 # Cap WIKI walks to prevent self-DoS if WIKI_PATH points at /, /etc, /home, etc.
@@ -3393,6 +3633,10 @@ def _build_llm_wiki_status() -> dict:
             "docs_url": _LLM_WIKI_DOCS_URL,
         }
         if not wiki_path.exists():
+            if not path_configured:
+                notes_status = _llm_wiki_notes_status(base)
+                if notes_status is not None:
+                    return notes_status
             return base
         if not wiki_path.is_dir():
             base["status"] = "not_directory"
@@ -13555,18 +13799,33 @@ def _joplin_api_get(path: str, params: dict | None = None) -> dict:
         raise ValueError("Joplin token is not configured")
     safe_path = "/" + str(path or "").lstrip("/")
     query = dict(params or {})
-    # Joplin Web Clipper builds can reject header-only auth on /search even when
-    # they accept it elsewhere. Keep the Authorization header for defense in
-    # depth and add the query token only for /search compatibility.
+    # Joplin Web Clipper builds can reject header-only auth. Keep the
+    # Authorization header for defense in depth, add query-token auth for
+    # /search up front for compatibility, and retry other 403s with a query
+    # token without logging the URL or credential.
     if safe_path == "/search":
         query["token"] = token
-    url = f"{base_url}{safe_path}?{urlencode(query)}"
-    request = Request(url, headers={"Authorization": f"token {token}"})
-    try:
+
+    def _read_with_query(query_params: dict) -> str:
+        url = f"{base_url}{safe_path}?{urlencode(query_params)}"
+        request = Request(url, headers={"Authorization": f"token {token}"})
         with urlopen(request, timeout=8) as response:
-            raw = response.read(2_000_000).decode("utf-8", errors="replace")
+            return response.read(2_000_000).decode("utf-8", errors="replace")
+
+    try:
+        raw = _read_with_query(query)
     except HTTPError as exc:
-        raise ValueError(f"Joplin API returned HTTP {exc.code}") from None
+        if exc.code == 403 and "token" not in query:
+            retry_query = dict(query)
+            retry_query["token"] = token
+            try:
+                raw = _read_with_query(retry_query)
+            except HTTPError as retry_exc:
+                raise ValueError(f"Joplin API returned HTTP {retry_exc.code}") from None
+            except (URLError, TimeoutError):
+                raise ValueError("Joplin API is not reachable") from None
+        else:
+            raise ValueError(f"Joplin API returned HTTP {exc.code}") from None
     except (URLError, TimeoutError) as exc:
         # A bare socket-connect TimeoutError from urlopen(timeout=8) is NOT
         # always URLError-wrapped, so catch it explicitly here. Otherwise it

--- a/static/panels.js
+++ b/static/panels.js
@@ -3258,10 +3258,13 @@ function _renderSystemHealthPanel() {
 function _renderLlmWikiStatus(d) {
   const status = d || {status:'error'};
   const isReady = status.available && status.status === 'ready';
+  const isConfigured = status.available && status.status === 'configured';
   const isEmpty = status.available && status.status === 'empty';
   const isError = status.status === 'error';
-  const badgeClass = isReady ? 'ok' : isError ? 'err' : isEmpty ? 'warn' : 'muted';
-  const badgeText = isReady ? 'Available' : isError ? 'Error' : isEmpty ? 'Empty' : 'Unavailable';
+  const isNotesSource = status.path_source === 'notes' || status.path_source === 'joplin';
+  const sourceLabel = status.source_label || (status.path_source === 'joplin' ? 'Joplin' : 'Notes');
+  const badgeClass = isReady ? 'ok' : isConfigured ? 'warn' : isError ? 'err' : isEmpty ? 'warn' : 'muted';
+  const badgeText = isReady ? (isNotesSource ? sourceLabel : 'Available') : isConfigured ? 'Configured' : isError ? 'Error' : isEmpty ? 'Empty' : 'Unavailable';
   const rawDocsUrl = status.docs_url || 'https://hermes-agent.nousresearch.com/docs/user-guide/skills/bundled/research/research-llm-wiki';
   // Guard against unsafe URL schemes (e.g. js: / data:) if docs_url ever
   // becomes config-driven. esc() HTML-escapes but doesn't validate URL scheme.
@@ -3270,12 +3273,18 @@ function _renderLlmWikiStatus(d) {
     ? 'Toggle available from configured Hermes Agent setting.'
     : (status.toggle_reason || 'No stable LLM Wiki on/off config flag was detected, so this panel is read-only.');
   const statusNote = isReady
-    ? 'LLM Wiki is configured and page metadata is visible without exposing wiki content.'
-    : isEmpty
-      ? 'LLM Wiki exists but has no entity, concept, comparison, or query pages yet.'
-      : isError
-        ? `Unable to inspect LLM Wiki status${status.error ? ': ' + status.error : ''}.`
-        : 'No LLM Wiki directory was found. Set WIKI_PATH or skills.config.wiki.path to enable status visibility.';
+    ? (isNotesSource
+      ? `${sourceLabel} is configured as the knowledge-base source; metadata is visible without exposing note bodies.`
+      : 'LLM Wiki is configured and page metadata is visible without exposing wiki content.')
+    : isConfigured
+      ? `${sourceLabel} is configured as a knowledge-base source; detailed counts depend on provider-specific support.`
+      : isEmpty
+        ? (isNotesSource
+          ? `${sourceLabel} is connected but the configured knowledge source has no notes yet.`
+          : 'LLM Wiki exists but has no entity, concept, comparison, or query pages yet.')
+        : isError
+          ? `Unable to inspect LLM Wiki status${status.error ? ': ' + status.error : ''}.`
+          : 'No LLM Wiki directory or third-party notes knowledge source was found. Set WIKI_PATH, skills.config.wiki.path, or configure a notes source.';
   return `
     <div class="insights-card wiki-status-card" id="llmWikiStatusCard">
       <div class="wiki-status-head">
@@ -3290,7 +3299,7 @@ function _renderLlmWikiStatus(d) {
         <div><span>Enabled</span><strong>${status.enabled ? 'Yes' : 'No'}</strong></div>
         <div><span>Entries</span><strong>${Number(status.entry_count || 0).toLocaleString()}</strong></div>
         <div><span>Pages</span><strong>${Number(status.page_count || 0).toLocaleString()}</strong></div>
-        <div><span>raw/ files</span><strong>${Number(status.raw_source_count || 0).toLocaleString()}</strong></div>
+        <div><span>${isNotesSource ? 'Raw notes' : 'raw/ files'}</span><strong>${Number(status.raw_source_count || 0).toLocaleString()}</strong></div>
         <div><span>Last updated</span><strong>${esc(_formatLlmWikiTimestamp(status.last_updated))}</strong></div>
         <div><span>Last writer</span><strong>${esc(status.last_writer || 'Not available')}</strong></div>
       </div>

--- a/tests/test_issue1257_llm_wiki_status.py
+++ b/tests/test_issue1257_llm_wiki_status.py
@@ -87,6 +87,83 @@ def test_api_wiki_status_route_is_registered(monkeypatch, tmp_path):
     assert captured["payload"]["entry_count"] == 1
 
 
+def test_llm_wiki_status_can_fall_back_to_joplin_metadata(monkeypatch, tmp_path):
+    """When no filesystem wiki is configured, Joplin can be the knowledge source."""
+    import api.routes as routes
+
+    missing = tmp_path / "wiki"
+    monkeypatch.delenv("WIKI_PATH", raising=False)
+    monkeypatch.setattr(routes, "_llm_wiki_resolve_path", lambda: (missing, "default", False))
+    monkeypatch.setattr(routes, "_llm_wiki_joplin_root_title", lambda: "Hermes 🤖")
+    monkeypatch.setattr(routes, "_llm_wiki_notes_fallback_enabled", lambda: True)
+
+    def fake_joplin_get(path, params=None):
+        if path == "/folders":
+            return {"items": [
+                {"id": "root", "title": "Hermes 🤖", "parent_id": "", "updated_time": 1000},
+                {"id": "knowledge", "title": "10 Knowledge", "parent_id": "root", "updated_time": 2000},
+                {"id": "raw", "title": "Raw Captures", "parent_id": "knowledge", "updated_time": 3000},
+            ]}
+        if path == "/folders/root/notes":
+            return {"items": [{"id": "n1", "title": "Index", "updated_time": 4000}]}
+        if path == "/folders/knowledge/notes":
+            return {"items": [{"id": "n2", "title": "Agent Memory", "updated_time": 5000}]}
+        if path == "/folders/raw/notes":
+            return {"items": [{"id": "n3", "title": "Capture", "updated_time": 6000}]}
+        raise AssertionError(path)
+
+    monkeypatch.setattr(routes, "_joplin_api_get", fake_joplin_get)
+
+    status = routes._build_llm_wiki_status()
+
+    assert status["available"] is True
+    assert status["enabled"] is True
+    assert status["status"] == "ready"
+    assert status["path_source"] == "notes"
+    assert status["source_kind"] == "joplin"
+    assert status["source_label"] == "Joplin"
+    assert status["source_count_available"] is True
+    assert status["entry_count"] == 3
+    assert status["page_count"] == 3
+    assert status["raw_source_count"] == 1
+    assert status["last_writer"] == "Joplin"
+    serialized = repr(status)
+    assert "Agent Memory" not in serialized
+    assert "Capture" not in serialized
+
+
+def test_llm_wiki_status_reports_generic_configured_notes_source(monkeypatch, tmp_path):
+    """Non-Joplin note providers can still surface as configured knowledge sources."""
+    import api.routes as routes
+
+    missing = tmp_path / "wiki"
+    monkeypatch.delenv("WIKI_PATH", raising=False)
+    monkeypatch.setattr(routes, "_llm_wiki_resolve_path", lambda: (missing, "default", False))
+    monkeypatch.setattr(routes, "_llm_wiki_notes_fallback_enabled", lambda: True)
+    monkeypatch.setattr(routes, "_llm_wiki_joplin_status", lambda base: None)
+    monkeypatch.setattr(routes, "_llm_wiki_preferred_notes_source", lambda: "obsidian")
+    monkeypatch.setattr(routes, "_looks_like_notes_source", lambda name, tools: name == "obsidian")
+    monkeypatch.setattr(routes, "_note_source_label", lambda name: "Obsidian")
+    monkeypatch.setattr(routes, "get_config", lambda: {
+        "mcp_servers": {
+            "filesystem": {"enabled": True},
+            "obsidian": {"enabled": True},
+        }
+    })
+
+    status = routes._build_llm_wiki_status()
+
+    assert status["available"] is True
+    assert status["enabled"] is True
+    assert status["status"] == "configured"
+    assert status["path_source"] == "notes"
+    assert status["source_kind"] == "obsidian"
+    assert status["source_label"] == "Obsidian"
+    assert status["source_count_available"] is False
+    assert status["entry_count"] == 0
+    assert status["last_writer"] == "Obsidian"
+
+
 def test_insights_panel_fetches_and_renders_llm_wiki_status_card():
     panels_src = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
     index_src = (REPO / "static" / "index.html").read_text(encoding="utf-8")
@@ -97,4 +174,7 @@ def test_insights_panel_fetches_and_renders_llm_wiki_status_card():
     assert "llmWikiStatusCard" in index_src
     assert "wiki-status-card" in style_src
     assert "raw/" in panels_src
+    assert "third-party notes knowledge source" in panels_src
+    assert "detailed counts depend on provider-specific support" in panels_src
+    assert "Raw notes" in panels_src
     assert "recent_entries" not in panels_src

--- a/tests/test_webui_notes_sources.py
+++ b/tests/test_webui_notes_sources.py
@@ -155,7 +155,7 @@ def test_joplin_api_get_converts_bare_timeout_to_valueerror(monkeypatch):
     def fake_urlopen(request, timeout):
         raise TimeoutError("timed out")
 
-    monkeypatch.setattr(routes, "_joplin_connection_from_config", lambda: ("http://127.0.0.1:41184", "secret-token"))
+    monkeypatch.setattr(routes, "_joplin_connection_from_config", lambda: ("http://127.0.0.1:41184", "clipper-test-token"))
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
     with pytest.raises(ValueError, match="not reachable"):
@@ -183,16 +183,16 @@ def test_joplin_api_get_sends_header_and_query_token_for_clip_search_compat(monk
         captured["timeout"] = timeout
         return FakeResponse()
 
-    monkeypatch.setattr(routes, "_joplin_connection_from_config", lambda: ("http://127.0.0.1:41184", "secret-token"))
+    monkeypatch.setattr(routes, "_joplin_connection_from_config", lambda: ("http://127.0.0.1:41184", "clipper-test-token"))
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
     data = routes._joplin_api_get("/search", {"query": "hello world"})
 
     assert data == {"ok": True}
     assert captured["timeout"] == 8
-    assert "token=secret-token" in captured["url"]
+    assert "token=clipper-test-token" in captured["url"]
     assert "query=hello+world" in captured["url"]
-    assert captured["authorization"] == "token secret-token"
+    assert captured["authorization"] == "token clipper-test-token"
 
 
 def test_joplin_api_get_keeps_non_search_token_out_of_url(monkeypatch):
@@ -215,14 +215,54 @@ def test_joplin_api_get_keeps_non_search_token_out_of_url(monkeypatch):
         captured["authorization"] = request.get_header("Authorization")
         return FakeResponse()
 
-    monkeypatch.setattr(routes, "_joplin_connection_from_config", lambda: ("http://127.0.0.1:41184", "secret-token"))
+    monkeypatch.setattr(routes, "_joplin_connection_from_config", lambda: ("http://127.0.0.1:41184", "clipper-test-token"))
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
     routes._joplin_api_get("/notes", {"query": "hello world"})
 
     assert "token=" not in captured["url"]
     assert "query=hello+world" in captured["url"]
-    assert captured["authorization"] == "token secret-token"
+    assert captured["authorization"] == "token clipper-test-token"
+
+
+def test_joplin_api_get_retries_non_search_403_with_query_token(monkeypatch):
+    from email.message import Message
+    from urllib.error import HTTPError
+    from api import routes
+
+    captured = []
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self, _limit):
+            return b'{"ok": true}'
+
+    def fake_urlopen(request, timeout):
+        captured.append({
+            "url": request.full_url,
+            "authorization": request.get_header("Authorization"),
+            "timeout": timeout,
+        })
+        if len(captured) == 1:
+            raise HTTPError(request.full_url, 403, "Forbidden", hdrs=Message(), fp=None)
+        return FakeResponse()
+
+    monkeypatch.setattr(routes, "_joplin_connection_from_config", lambda: ("http://127.0.0.1:41184", "clipper-test-token"))
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    data = routes._joplin_api_get("/folders", {"limit": 100})
+
+    assert data == {"ok": True}
+    assert len(captured) == 2
+    assert "token=" not in captured[0]["url"]
+    assert "token=clipper-test-token" in captured[1]["url"]
+    assert captured[0]["authorization"] == "token clipper-test-token"
+    assert captured[1]["authorization"] == "token clipper-test-token"
 
 
 def test_joplin_recent_ai_notes_uses_configured_prefill_script(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- allow the LLM Wiki status endpoint to report a configured third-party notes or knowledge source when no filesystem wiki path is configured
- keep the status payload metadata-only so note bodies and note titles are not exposed
- use provider-specific rich metadata when available, including Joplin notebook/note counts, while showing a safe configured state for other note providers
- update the Insights card copy for notes-backed knowledge bases
- retry Joplin Web Clipper header-auth 403 responses with query-token compatibility while preserving the Authorization header

## Test Plan
- `python -m py_compile api/routes.py`
- `node --check static/panels.js`
- `python -m pytest tests/test_issue1257_llm_wiki_status.py tests/test_webui_notes_sources.py -q -o 'addopts='`
