### PR TITLE
v0.51.193: ctl dotenv opt-out + workspace inline-open + gateway reply polish (3 PRs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.193] — 2026-06-01 — Release FM (stage-batch5 — ctl dotenv opt-out + workspace inline-open + gateway reply polish)
+
 ### Fixed
-- `ctl.sh` now honors `HERMES_WEBUI_NO_DOTENV=1`, letting tests and scripted launches opt out of repo-local `.env` loading so host-specific `HERMES_WEBUI_STATE_DIR` values do not make the ctl test suite flaky (#3246).
-- Gateway-backed chat now carries the same WebUI final-answer polish guidance as the in-process chat paths, so terse scratchpad fragments such as "Need script" are not encouraged as visible assistant replies.
+- `ctl.sh` now honors `HERMES_WEBUI_NO_DOTENV=1`, letting tests and scripted launches opt out of repo-local `.env` loading so host-specific `HERMES_WEBUI_STATE_DIR` values do not make the ctl test suite flaky. Closes #3246 (#3304, @AJV20).
+- Workspace **Open in browser** now opens HTML files inline (with the same `inline=1` + CSP sandbox isolation as the file preview) instead of forcing a download, and uses `noopener` for the new tab (#3305, @xz-dev).
+- Gateway-backed chat now carries the same WebUI final-answer polish guidance as the in-process chat paths, so terse scratchpad fragments such as "Need script" are not encouraged as visible assistant replies (#3301, @AJV20).
 
 ## [v0.51.192] — 2026-05-31 — Release FL (stage-batch4 — per-model context_length default-only guard)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- `ctl.sh` now honors `HERMES_WEBUI_NO_DOTENV=1`, letting tests and scripted launches opt out of repo-local `.env` loading so host-specific `HERMES_WEBUI_STATE_DIR` values do not make the ctl test suite flaky (#3246).
+
 ## [v0.51.192] — 2026-05-31 — Release FL (stage-batch4 — per-model context_length default-only guard)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 - `ctl.sh` now honors `HERMES_WEBUI_NO_DOTENV=1`, letting tests and scripted launches opt out of repo-local `.env` loading so host-specific `HERMES_WEBUI_STATE_DIR` values do not make the ctl test suite flaky (#3246).
+- Gateway-backed chat now carries the same WebUI final-answer polish guidance as the in-process chat paths, so terse scratchpad fragments such as "Need script" are not encouraged as visible assistant replies.
 
 ## [v0.51.192] — 2026-05-31 — Release FL (stage-batch4 — per-model context_length default-only guard)
 

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -247,13 +247,17 @@ def _run_gateway_chat_streaming(
         cfg = get_config()
         try:
             from api.streaming import (
+                _WEBUI_PROGRESS_PROMPT,
                 _load_webui_prefill_context,
                 _prefill_messages_with_webui_context,
                 _public_prefill_context_status,
             )
 
             prefill_context = _load_webui_prefill_context(cfg)
-            prefill_messages = _prefill_messages_with_webui_context(prefill_context, cfg)
+            prefill_messages = [
+                {"role": "system", "content": _WEBUI_PROGRESS_PROMPT},
+                *_prefill_messages_with_webui_context(prefill_context, cfg),
+            ]
             put_gateway_event("context_status", {
                 "session_id": session_id,
                 "prefill": _public_prefill_context_status(prefill_context),

--- a/api/routes.py
+++ b/api/routes.py
@@ -8677,10 +8677,11 @@ def _handle_file_raw(handler, parsed):
     # CSP sandbox directive applies the same isolation server-side: without
     # allow-same-origin, the document is treated as a unique opaque origin and
     # cannot read WebUI cookies, localStorage, or postMessage to the parent.
-    csp = "sandbox allow-scripts allow-popups allow-popups-to-escape-sandbox" if html_inline_ok else None
+    sandbox_csp = "sandbox allow-scripts allow-popups allow-popups-to-escape-sandbox"
+    csp = sandbox_csp if (inline_preview and not force_download and disposition == "inline") else None
     # _serve_file_bytes sends Content-Security-Policy when csp is set.
     if html_inline_ok:
-        return _serve_inline_html_preview(handler, target, "no-store", csp=csp)
+        return _serve_inline_html_preview(handler, target, "no-store", csp=sandbox_csp)
     return _serve_file_bytes(handler, target, mime, disposition, "no-store", csp=csp)
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -203,7 +203,8 @@ WebUI progress guidance:
 - Each update should say what you are about to check, what you just confirmed, or why the next tool call is needed.
 - Keep updates concise, factual, and in the user's language. One or two short sentences are enough.
 - Do not reveal hidden reasoning, chain-of-thought, private scratchpads, secrets, raw logs, or long tool output.
-- Do not include terse planning fragments or scratchpad shorthand in visible assistant text. Avoid fragments like "Need check logs", "Need inspect email", or "maybe invite"; either omit them or rewrite them as clear user-facing progress.
+- Final visible assistant replies must be clear user-facing English, not private planning notes.
+- Do not include terse planning fragments or scratchpad shorthand in visible assistant text. Avoid fragments like "Need script", "Need check logs", "Need inspect email", or "maybe invite"; either omit them or rewrite them as clear user-facing progress.
 - For direct answers or very short tasks, skip progress updates and answer normally.
 """.strip()
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -203,7 +203,7 @@ WebUI progress guidance:
 - Each update should say what you are about to check, what you just confirmed, or why the next tool call is needed.
 - Keep updates concise, factual, and in the user's language. One or two short sentences are enough.
 - Do not reveal hidden reasoning, chain-of-thought, private scratchpads, secrets, raw logs, or long tool output.
-- Final visible assistant replies must be clear user-facing English, not private planning notes.
+- Final visible assistant replies must be clear, user-facing, and in the user's language, not private planning notes.
 - Do not include terse planning fragments or scratchpad shorthand in visible assistant text. Avoid fragments like "Need script", "Need check logs", "Need inspect email", or "maybe invite"; either omit them or rewrite them as clear user-facing progress.
 - For direct answers or very short tasks, skip progress updates and answer normally.
 """.strip()

--- a/ctl.sh
+++ b/ctl.sh
@@ -28,6 +28,7 @@ ensure_home() {
 }
 
 _load_repo_dotenv_preserving_env() {
+  [[ "${HERMES_WEBUI_NO_DOTENV:-0}" == "1" ]] && return 0
   local env_file="${REPO_ROOT}/.env"
   [[ -f "${env_file}" ]] || return 0
 

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -675,6 +675,6 @@ function renderFileBreadcrumb(filePath) {
 
 function openInBrowser(){
   if(!_previewCurrentPath||!S.session) return;
-  const url=`api/file/raw?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(_previewCurrentPath)}`;
-  window.open(url,'_blank');
+  const url=`api/file/raw?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(_previewCurrentPath)}&inline=1`;
+  window.open(url,'_blank','noopener');
 }

--- a/tests/test_779_html_preview.py
+++ b/tests/test_779_html_preview.py
@@ -33,6 +33,23 @@ def test_iframe_uses_inline_param():
     )
 
 
+def test_open_in_browser_uses_unconditional_inline_param():
+    """Workspace Open in browser must use the explicit inline/sandbox open path."""
+    content = _get_workspace_js()
+    idx = content.find("function openInBrowser()")
+    assert idx != -1, "openInBrowser() must exist"
+    block = content[idx:idx + 700]
+    assert "&inline=1" in block, (
+        "openInBrowser() must include inline=1 so HTML opens instead of downloading"
+    )
+    assert "download=1" not in block, (
+        "openInBrowser() must not reuse the Download button path"
+    )
+    assert "window.open(url,'_blank','noopener')" in block or 'window.open(url,"_blank","noopener")' in block, (
+        "openInBrowser() should use noopener for the new tab"
+    )
+
+
 def test_html_preview_iframe_exists_in_html():
     """The previewHtmlIframe element must be present in index.html."""
     content = _get_index_html()
@@ -105,3 +122,15 @@ def test_inline_html_response_sets_csp_sandbox():
             assert "allow-same-origin" not in line, (
                 "CSP sandbox must NOT include allow-same-origin — that would defeat the isolation"
             )
+
+
+def test_file_raw_inline_responses_use_sandbox_csp():
+    """The explicit inline-open contract should sandbox non-download raw files."""
+    content = _get_routes_content()
+    idx = content.find("def _handle_file_raw")
+    assert idx != -1, "_handle_file_raw not found"
+    block = content[idx:idx + 2200]
+    assert "sandbox_csp" in block
+    assert "inline_preview" in block
+    assert "disposition == \"inline\"" in block
+    assert "csp=sandbox_csp" in block or "csp=csp" in block

--- a/tests/test_ctl_script.py
+++ b/tests/test_ctl_script.py
@@ -17,6 +17,7 @@ def run_ctl(
     env: dict[str, str] | None = None,
     timeout: float = 5.0,
     repo_root: Path = REPO_ROOT,
+    load_dotenv: bool = False,
 ):
     merged = os.environ.copy()
     for key in (
@@ -27,6 +28,7 @@ def run_ctl(
         "HERMES_WEBUI_PID_FILE",
         "HERMES_WEBUI_LOG_FILE",
         "HERMES_WEBUI_CTL_STATE_FILE",
+        "HERMES_WEBUI_NO_DOTENV",
     ):
         merged.pop(key, None)
     merged.update(
@@ -34,6 +36,7 @@ def run_ctl(
             "HOME": str(home),
             "HERMES_HOME": str(home / ".hermes"),
             "PATH": os.environ.get("PATH", ""),
+            "HERMES_WEBUI_NO_DOTENV": "0" if load_dotenv else "1",
         }
     )
     if env:
@@ -146,6 +149,42 @@ def test_start_uses_nohup_so_daemon_survives_launcher_exit():
     assert 'exec nohup "${python_exe}"' in ctl_text
 
 
+def test_start_can_ignore_repo_dotenv_for_authoritative_test_env(tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    shutil.copy2(CTL, repo_root / "ctl.sh")
+    (repo_root / "bootstrap.py").write_text("# fake bootstrap target\n", encoding="utf-8")
+    (repo_root / ".env").write_text(
+        f"HERMES_WEBUI_STATE_DIR={tmp_path / 'host-specific-webui'}\n",
+        encoding="utf-8",
+    )
+    fake_python = tmp_path / "fake-python"
+    fake_log = tmp_path / "fake-python.log"
+    write_fake_python(fake_python)
+
+    result = run_ctl(
+        tmp_path,
+        "start",
+        env={
+            "HERMES_WEBUI_PYTHON": str(fake_python),
+            "FAKE_PYTHON_LOG": str(fake_log),
+            "HERMES_WEBUI_CTL_ALLOW_LAUNCHD_CONFLICT": "1",
+        },
+        repo_root=repo_root,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    pid = wait_for_pid_file(tmp_path / ".hermes" / "webui.pid")
+    try:
+        fake_output = wait_for_file_text(fake_log)
+        assert str(tmp_path / ".hermes" / "webui") in fake_output
+        assert "host-specific-webui" not in fake_output
+    finally:
+        stop = run_ctl(tmp_path, "stop", repo_root=repo_root)
+        assert stop.returncode == 0, stop.stderr + stop.stdout
+        assert_process_exits(pid)
+
+
 def test_start_loads_dotenv_but_inline_overrides_win(tmp_path):
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
@@ -170,6 +209,7 @@ def test_start_loads_dotenv_but_inline_overrides_win(tmp_path):
             "HERMES_WEBUI_CTL_ALLOW_LAUNCHD_CONFLICT": "1",
         },
         repo_root=repo_root,
+        load_dotenv=True,
     )
     assert result.returncode == 0, result.stderr + result.stdout
     pid = wait_for_pid_file(tmp_path / ".hermes" / "webui.pid")

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -286,10 +286,14 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     assert '"stream": true' in captured["body"]
     payload = json.loads(captured["body"])
     assert [m["content"] for m in payload["messages"]] == [
+        streaming._WEBUI_PROGRESS_PROMPT,
         "prefill",
         "webui session context",
         "Say hello",
     ]
+    assert payload["messages"][0]["role"] == "system"
+    assert "Final visible assistant replies" in payload["messages"][0]["content"]
+    assert "Need script" in payload["messages"][0]["content"]
     events = []
     while not subscriber.empty():
         events.append(subscriber.get_nowait())
@@ -361,7 +365,9 @@ def test_gateway_chat_worker_forwards_image_attachments_as_multimodal_parts(tmp_
     )
 
     content = captured["body"]["messages"][-1]["content"]
-    assert captured["body"]["messages"][0] == {"role": "user", "content": "webui session context"}
+    assert captured["body"]["messages"][0]["role"] == "system"
+    assert "Final visible assistant replies" in captured["body"]["messages"][0]["content"]
+    assert captured["body"]["messages"][1] == {"role": "user", "content": "webui session context"}
     assert content[0] == {"type": "text", "text": "What is in this image?"}
     assert content[1]["type"] == "image_url"
     assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")

--- a/tests/test_webui_surface_context.py
+++ b/tests/test_webui_surface_context.py
@@ -26,6 +26,8 @@ def test_webui_ephemeral_prompt_includes_browser_surface_context():
     assert "explicit captures" in prompt
     assert "durable user preferences" in prompt
     assert "Do not include terse planning fragments" in prompt
+    assert "Final visible assistant replies" in prompt
+    assert "Need script" in prompt
     assert "Need inspect email" in prompt
     assert "clear user-facing progress" in prompt
 

--- a/tests/test_webui_surface_context.py
+++ b/tests/test_webui_surface_context.py
@@ -27,6 +27,8 @@ def test_webui_ephemeral_prompt_includes_browser_surface_context():
     assert "durable user preferences" in prompt
     assert "Do not include terse planning fragments" in prompt
     assert "Final visible assistant replies" in prompt
+    assert "user-facing English" not in prompt
+    assert "in the user's language" in prompt
     assert "Need script" in prompt
     assert "Need inspect email" in prompt
     assert "clear user-facing progress" in prompt


### PR DESCRIPTION
## v0.51.193 — Release FM (stage-batch5)

Batch of 3 low-risk contributor PRs, reviewed + tested end-to-end. Phase-1 concentric sweep.

### Included PRs
| PR | Title | Author | Notes |
|----|-------|--------|-------|
| #3304 | test(ctl): allow dotenv-free launches | @AJV20 | `HERMES_WEBUI_NO_DOTENV=1` opt-out; default path fully inert. Closes #3246 |
| #3305 | Fix workspace Open-in-browser inline sandbox | @xz-dev | inline=1 + CSP sandbox + noopener; download path unchanged |
| #3301 | Apply WebUI reply-polish guidance to gateway chat | @AJV20 | prepend progress-prompt system msg to gateway prefill |

### Gate results
- **pytest** (full sequential, `-p no:xdist`): 7141 passed, 7 skipped, 3 xpassed, 0 failed
- **Pre-Opus gate**: node -c + ast.parse clean; ESLint runtime gate CLEAN; ruff forward gate CLEAN (0 new violations)
- **Opus advisor**: APPROVE — no blockers
- **Codex regression gate**: SAFE TO SHIP — no regression risk (verified download-stays-attachment, inline-HTML-stays-sandboxed, gateway message ordering preserved)
