### PR TITLE
v0.51.195: hide attachment path markers in chat UI (#3296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.195] — 2026-06-01 — Release FO (stage-batch7 — hide attachment path markers in chat UI)
+
+### Fixed
+- Uploaded image attachment path context (`[Attached files: …]`) remains available to the agent in the stored message, but the chat transcript, sidebar display title, and server-derived provisional titles no longer show the raw path suffix to the user (#3296, @AJV20).
+
 ## [v0.51.194] — 2026-06-01 — Release FN (stage-batch6 — profiles config-import-cycle fix)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -2858,6 +2858,10 @@ def all_sessions(diag=None):
     return result
 
 
+def _strip_attached_files_marker(text: str) -> str:
+    return re.sub(r"\n\n\[Attached files: [^\]]+\]$", "", str(text or "")).strip()
+
+
 def title_from(messages, fallback: str='Untitled'):
     """Derive a session title from the first user message."""
     for m in messages:
@@ -2865,7 +2869,7 @@ def title_from(messages, fallback: str='Untitled'):
             c = m.get('content', '')
             if isinstance(c, list):
                 c = ' '.join(p.get('text', '') for p in c if isinstance(p, dict) and p.get('type') == 'text')
-            text = str(c).strip()
+            text = _strip_attached_files_marker(str(c))
             if text:
                 return text[:64]
     return fallback

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3508,7 +3508,11 @@ function _collapseSessionLineageForSidebar(sessions){
 }
 
 function _sessionDisplayTitle(s){
-  const title=String((s&&(s.display_title||s._state_db_title||s.title))||'Untitled').trim();
+  const rawTitle=String((s&&(s.display_title||s._state_db_title||s.title))||'Untitled').trim();
+  const strip=(typeof _stripAttachedFilesMarker==='function')
+    ? _stripAttachedFilesMarker
+    : (text)=>String(text||'').replace(/\n\n\[Attached files: [^\]]+\]$/,'').trim();
+  const title=strip(rawTitle);
   return title||'Untitled';
 }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -3564,6 +3564,10 @@ function renderMd(raw){
   return s;
 }
 
+function _stripAttachedFilesMarkerForDisplay(text){
+  return String(text||'').replace(/\n\n\[Attached files: [^\]]+\]$/,'').trim();
+}
+
 function setStatus(t){
   if(!t)return;
   showToast(t, 4000);
@@ -6530,7 +6534,7 @@ function renderMessages(options){
     if(!isUser&&_isMarkerOnlyAssistantCompressionMessage(m)){
       content='**Error:** No response received after context compression. Please retry.';
     }
-    const displayContent=isUser?_stripWorkspaceDisplayPrefix(content):content;
+    const displayContent=isUser?_stripAttachedFilesMarkerForDisplay(_stripWorkspaceDisplayPrefix(content)):content;
     if(thinkingText&&!isUser){
       thinkingText=_stripVisibleAssistantEchoFromThinking(thinkingText, displayContent);
     }

--- a/tests/test_chat_upload_attachment_paths.py
+++ b/tests/test_chat_upload_attachment_paths.py
@@ -22,6 +22,40 @@ def test_image_uploads_use_server_path_in_attached_files_context():
     assert "uploadedPaths=uploaded.map(u=>u&&u.path?u.path" in src
 
 
+def test_attached_files_context_is_hidden_from_user_message_display():
+    """Persist full attachment paths for the agent without showing them in chat."""
+    ui_src = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+    assert "function _stripAttachedFilesMarkerForDisplay" in ui_src
+    assert "_stripAttachedFilesMarkerForDisplay(_stripWorkspaceDisplayPrefix(content))" in ui_src
+    assert "dataset.rawText=String(displayContent).trim()" in ui_src
+
+
+def test_attached_files_context_is_hidden_from_sidebar_titles():
+    """Sidebar rows should not expose absolute uploaded image paths in titles."""
+    sessions_src = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+    assert "function _stripAttachedFilesMarker" in sessions_src
+    assert "? _stripAttachedFilesMarker" in sessions_src
+    assert "replace(/\\n\\n\\[Attached files: [^\\]]+\\]$/" in sessions_src
+
+
+def test_server_provisional_titles_strip_attached_files_context():
+    """Server-generated provisional titles must not include the path suffix."""
+    from api.models import title_from
+
+    title = title_from([
+        {
+            "role": "user",
+            "content": "why is llm wiki not working?\n\n[Attached files: /tmp/private/Screenshot.png]",
+        }
+    ])
+
+    assert title == "why is llm wiki not working?"
+    assert "Attached files" not in title
+    assert "/tmp/private" not in title
+
+
 def test_duplicate_upload_response_reports_actual_stored_filename(tmp_path, monkeypatch):
     """Duplicate upload names should report the suffixed stored basename."""
     monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(tmp_path))

--- a/tests/test_workspace_display_prefix.py
+++ b/tests/test_workspace_display_prefix.py
@@ -35,7 +35,7 @@ def test_user_render_uses_stripped_display_content_without_preempting_context_ca
     assert loop_end != -1, "assistant render branch not found after user branch"
     render_prefix = src[loop_start:loop_end]
 
-    display_idx = render_prefix.find("const displayContent=isUser?_stripWorkspaceDisplayPrefix(content):content;")
+    display_idx = render_prefix.find("const displayContent=isUser?_stripAttachedFilesMarkerForDisplay(_stripWorkspaceDisplayPrefix(content)):content;")
     context_idx = render_prefix.find("if(_isContextCompactionMessage(m))")
     user_idx = render_prefix.find("if(isUser)")
     assert display_idx != -1, "display content stripper not used in render loop"


### PR DESCRIPTION
## v0.51.195 — Release FO (stage-batch7)

Single low-risk contributor PR. Phase-1 concentric sweep (extra low-risk pass).

### Included PR
| PR | Title | Author | Notes |
|----|-------|--------|-------|
| #3296 | Hide attachment path markers in chat UI | @AJV20 | strips trailing `[Attached files: …]` from chat display / sidebar titles / server provisional titles / `dataset.rawText`; stored agent-facing content unchanged |

### Gate results
- **pytest** (full sequential, `-p no:xdist`): 7145 passed, 7 skipped, 3 xpassed, 0 failed
- **Pre-Opus gate**: node -c + ast.parse clean; ESLint runtime gate CLEAN; ruff forward gate CLEAN
- **Opus advisor**: APPROVE — regex end-anchored, all 4 display surfaces consistent, stored content + regenerate path intact
- **Codex regression gate** (pinned to stage HEAD `c1a3c3ef`): SAFE TO SHIP — agent-facing content preserved through full send/persist path; copy uses displayed text, edit resends clean text, regenerate uses `msgContent()` not `dataset.rawText`
- **Self-verify**: regex over-strip test (mid-text/start-of-text occurrences preserved); copy/TTS consumers behave correctly
