### PR TITLE
fix: reject inline math when $ is followed by digit (currency false positive)

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -3098,9 +3098,10 @@ function renderMd(raw){
   s=s.replace(/\$\$([\s\S]+?)\$\$/g,(_,m)=>{math_stash.push({type:'display',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
   // Match a single literal backslash before the display delimiter (the common LLM form).
   s=s.replace(/\\\[([\s\S]+?)\\\]/g,(_,m)=>{math_stash.push({type:'display',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
-  // Inline math: $...$ — require non-space at boundaries to avoid false positives
-  // e.g. "costs $5 and $10" should not trigger (space after opening $)
-  s=s.replace(/\$([^\s$\n][^$\n]*?[^\s$\n]|\S)\$/g,(_,m)=>{if(m.includes(' | '))return '\$'+m+'\$';math_stash.push({type:'inline',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
+  // Inline math: $...$ — require non-space/non-digit at opening boundary to avoid
+  // false positives on currency like "$1,000 xuống ~$95" or "costs $5 and $10".
+  // Aligns with smd's se() guard which also rejects $ followed by digits.
+  s=s.replace(/\$([^\s$\d\n][^$\n]*?[^\s$\n]|[^\s\d])\$/g,(_,m)=>{if(m.includes(' | '))return '\$'+m+'\$';math_stash.push({type:'inline',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
   // Also stash \(...\) LaTeX delimiters.
   // Match a single literal backslash before the delimiter (the common LLM form).
   s=s.replace(/\\\((.+?)\\\)/g,(_,m)=>{math_stash.push({type:'inline',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});

--- a/tests/test_issue347.py
+++ b/tests/test_issue347.py
@@ -429,6 +429,24 @@ def test_inline_math_regex_requires_non_space_boundaries():
         f"Inline math regex must exclude spaces at boundaries to prevent false "
         f"positives on currency like $5. Found: {inline_line[:120]}"
     )
+def test_inline_math_regex_rejects_digit_after_opening_dollar():
+    """The $...$ inline regex must reject $ followed by a digit.
+
+    Currency like '$1,000 xuống ~$95' must NOT be parsed as math.
+    The opening $ followed by a digit (0-9) is a strong currency signal.
+    Aligns with smd's se() guard which also rejects $ + digit.
+    """
+    inline_push_idx = UI_JS.find("type:'inline',src:m")
+    assert inline_push_idx != -1
+    line_start = UI_JS.rfind('\n', 0, inline_push_idx) + 1
+    inline_line = UI_JS[line_start:inline_push_idx + 50]
+    # The regex character class for the first char must exclude \d
+    assert '\\d' in inline_line, (
+        f"Inline math regex must exclude digits at opening boundary to prevent "
+        f"false positives on currency like $1,000. Found: {inline_line[:120]}"
+    )
+
+
 def test_display_math_stashed_before_inline():
     """$$...$$ display math must be stashed before $...$ inline math.
 


### PR DESCRIPTION
## Summary

- Fix `renderMd()` inline math regex falsely matching currency amounts as KaTeX math expressions
- Text like `$1,000 xuống ~$95` was rendered as garbled math instead of literal text
- Add structural test to guard against regression

## Problem

<img width="1542" height="1644" alt="CleanShot 2026-06-01 at 13 23 19@2x" src="https://github.com/user-attachments/assets/1d88a637-5fbe-4e69-a8aa-923592d537a1" />

The `$...$` inline math regex in `renderMd()` (`static/ui.js:3103`) matched `$1,000 xuống ~$` as an inline math expression because:

1. Opening `$` followed by `1` satisfied `[^\s$\n]` (non-space, non-dollar, non-newline)
2. `,000 xuống ` matched the middle `[^$\n]*?`
3. `~` before closing `$` satisfied `[^\s$\n]`

This caused the `$` signs to be consumed, the content between them to render as KaTeX math (italic text with `~` as subscript operator), and `95` to appear detached after the closing delimiter.

The **streaming-markdown (smd)** library already handles this correctly via its `se()` function which rejects `$` followed by digits. But `renderMd()` (used for finalized/history messages) lacked this guard.

## Fix

**Regex change** in `static/ui.js`:

| Part | Before | After |
|------|--------|-------|
| First char after `$` | `[^\s$\n]` | `[^\s$\d\n]` |
| Single-char alternate | `\S` | `[^\s\d]` |

Adding `\d` to the exclusion class rejects math when the first character after `$` is a digit (0-9), which is a strong currency signal (`$1,000`, `$50`, `$99.99`).

Legitimate math expressions like `$x^2$`, `$\alpha + \beta$` are unaffected since they start with letters or backslash.

## Test plan

- [x] New structural test: `test_inline_math_regex_rejects_digit_after_opening_dollar`
- [x] All 35 tests in `test_issue347.py` pass
- [x] All 106 tests in `test_renderer_comprehensive.py` + `test_renderer_js_behaviour.py` pass (no regression)
- [ ] Manual test: load a chat session containing `$1,000 xuống ~$95` and verify literal rendering
