### PR TITLE
fix: preserve ephemeral turn fields when loadSession force-reloads active session (#3306)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1538,6 +1538,12 @@ async function _loadOlderMessages() {
     // Use $('messages') — the scrollable container (#msgInner is not scrollable).
     const container = $('messages');
     const prevScrollH = container ? container.scrollHeight : 0;
+    // Carry forward ephemeral turn fields (_turnUsage/_turnDuration/_turnTps/
+    // _gatewayRouting/_statusCard) before the wholesale replace so the badge
+    // does not briefly appear and disappear during older-message expansion.
+    if (typeof window._carryForwardEphemeralTurnFields === 'function') {
+      nextMessages = window._carryForwardEphemeralTurnFields(S.messages || [], nextMessages);
+    }
     S.messages = nextMessages;
     _syncToolCallsForLoadedMessages(nextMessages, responseSession.tool_calls);
     // renderMessages() windows long transcripts from the end. If we do not
@@ -2880,7 +2886,14 @@ function startGatewaySSE(){
                     const next = res.session.messages.filter(m => m && m.role);
                     if (next.length < prev) return;
                     if (prev > 0 && !_isCliImportRefreshPrefixMatch(S.messages, next)) return;
-                    S.messages = next;
+                    // Carry forward ephemeral turn fields (_turnUsage/
+                    // _turnDuration/_turnTps/_gatewayRouting/_statusCard) so
+                    // gateway-driven CLI refreshes do not drop the badge.
+                    let _nextToAssign = next;
+                    if (typeof window._carryForwardEphemeralTurnFields === 'function') {
+                      _nextToAssign = window._carryForwardEphemeralTurnFields(S.messages || [], next);
+                    }
+                    S.messages = _nextToAssign;
                     if(S.session && S.session.session_id === activeSid){
                       S.session.message_count = next.length;
                       const newest = next.length ? next[next.length - 1] : null;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -17,6 +17,13 @@ const ICONS={
 // responses from in-flight requests when the user switches sessions again
 // before the first request completes (#1060).
 let _loadingSessionId = null;
+// #3306: Snapshot of S.messages captured by loadSession() right before it
+// clears them on a force-reload of the active session. Consumed by
+// _ensureMessagesLoaded() when calling _carryForwardEphemeralTurnFields so
+// ephemeral fields (_turnUsage, _turnDuration, _turnTps, _gatewayRouting,
+// _statusCard) survive the wholesale replace. null when there is nothing
+// to carry forward (initial load, switch-to-different-session, etc.).
+let _pendingCarryForwardSnapshot = null;
 
 // ── Composer draft persistence ────────────────────────────────────────────────
 
@@ -611,6 +618,18 @@ async function loadSession(sid){
     _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
   }
   if (currentSid !== sid || forceReload) {
+    // #3306: When force-reloading the currently-active session (e.g. external
+    // poll triggering a refresh), snapshot the existing messages BEFORE we
+    // clear them. _ensureMessagesLoaded() runs the ephemeral-field
+    // carry-forward (_turnUsage, _turnDuration, _turnTps, _gatewayRouting,
+    // _statusCard) against S.messages, but by the time the API fetch returns
+    // S.messages has already been reset to [] here and the carry-forward is a
+    // no-op. The visible symptom is the token-usage badge vanishing ~10s
+    // after each assistant turn completes. Stash the snapshot so the
+    // carry-forward call can consume it.
+    _pendingCarryForwardSnapshot = (currentSid === sid && forceReload)
+      ? (S.messages || []).slice()
+      : null;
     S.messages = [];
     S.toolCalls = [];
     _messagesTruncated = false;
@@ -1355,7 +1374,14 @@ async function _ensureMessagesLoaded(sid) {
   // #3018: preserve client-side ephemeral turn fields (_turnUsage, _turnDuration,
   // _turnTps, _gatewayRouting, _statusCard) across the loadSession replace.
   if(typeof window._carryForwardEphemeralTurnFields==='function'){
-    msgs=window._carryForwardEphemeralTurnFields(S.messages||[], msgs);
+    // #3306: Prefer the pre-clear snapshot stashed by loadSession() on a
+    // force-reload of the active session; S.messages was reset to [] there
+    // and would otherwise yield an empty carry-forward.
+    const _prev = (Array.isArray(_pendingCarryForwardSnapshot) && _pendingCarryForwardSnapshot.length)
+      ? _pendingCarryForwardSnapshot
+      : (S.messages || []);
+    msgs=window._carryForwardEphemeralTurnFields(_prev, msgs);
+    _pendingCarryForwardSnapshot = null;
   }
   S.messages = msgs;
   if(S.session&&S.session.session_id===sid){
@@ -1595,7 +1621,15 @@ async function _ensureAllMessagesLoaded() {
     // prefetch (whose snapshot was taken before this call's mutex
     // acquisition) sees the new value and aborts.
     _bumpMessagesGeneration();
-    S.messages = msgs;
+    // #3306: Same ephemeral-field carry-forward as _ensureMessagesLoaded.
+    // Loading older messages also does a wholesale replace of S.messages
+    // and would otherwise drop _turnUsage/_turnDuration/_turnTps/
+    // _gatewayRouting/_statusCard on the existing turns.
+    let _msgsToAssign = msgs;
+    if (typeof window._carryForwardEphemeralTurnFields === 'function') {
+      _msgsToAssign = window._carryForwardEphemeralTurnFields(S.messages || [], msgs);
+    }
+    S.messages = _msgsToAssign;
     _messagesTruncated = false;
     _oldestIdx = 0;
     _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls);

--- a/tests/test_issue3306_loadsession_carry_forward.py
+++ b/tests/test_issue3306_loadsession_carry_forward.py
@@ -1,0 +1,94 @@
+"""Regression test pinning the #3306 fix.
+
+#3306: `loadSession()` in static/sessions.js cleared `S.messages = []` BEFORE
+issuing the API fetch and BEFORE `_ensureMessagesLoaded()` invoked the #3018
+ephemeral-field carry-forward (`_carryForwardEphemeralTurnFields(S.messages||[],
+msgs)`). Because the clear happened first, the carry-forward saw an empty
+array and ephemeral turn fields (_turnUsage, _turnDuration, _turnTps,
+_gatewayRouting, _statusCard) were dropped on every force-reload. The visible
+symptom: the token-usage badge vanished ~10s after each assistant turn finished
+when an external poll triggered loadSession(..., forceReload).
+
+Fix: snapshot S.messages BEFORE the clear (only when force-reloading the
+currently-active session) into a module-level `_pendingCarryForwardSnapshot`,
+then consume it in `_ensureMessagesLoaded()` ahead of the live S.messages
+(which is now []).
+
+This file is the targeted source-text pin in the same style as
+tests/test_issue3162_ensure_messages_loaded.py.
+"""
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _load_session_clear_block() -> str:
+    """The if(currentSid!==sid||forceReload){...} block in loadSession()."""
+    start = SESSIONS_JS.index("async function loadSession(sid)")
+    return SESSIONS_JS[start: start + 4000]
+
+
+def _ensure_messages_loaded_body() -> str:
+    start = SESSIONS_JS.index("async function _ensureMessagesLoaded")
+    return SESSIONS_JS[start: start + 2500]
+
+
+def test_pending_carry_forward_snapshot_declared_at_module_scope():
+    assert "let _pendingCarryForwardSnapshot" in SESSIONS_JS, (
+        "module-level _pendingCarryForwardSnapshot is the bridge between "
+        "loadSession()'s pre-clear snapshot and _ensureMessagesLoaded()'s "
+        "carry-forward call — required by #3306 fix"
+    )
+
+
+def test_loadsession_snapshots_messages_before_clearing():
+    body = _load_session_clear_block()
+    # The assignment to _pendingCarryForwardSnapshot must appear before the
+    # `S.messages = [];` clear inside the if-block.
+    assign_idx = body.find("_pendingCarryForwardSnapshot =")
+    clear_idx = body.find("S.messages = [];")
+    assert assign_idx != -1, (
+        "#3306: loadSession() must snapshot S.messages into "
+        "_pendingCarryForwardSnapshot before clearing — snapshot assignment missing"
+    )
+    assert clear_idx != -1, "S.messages = [] clear not found in loadSession()"
+    assert assign_idx < clear_idx, (
+        "#3306: _pendingCarryForwardSnapshot must be assigned BEFORE "
+        "`S.messages = []`, otherwise the snapshot captures an already-empty array"
+    )
+
+
+def test_loadsession_snapshot_gated_on_force_reload_of_active_session():
+    body = _load_session_clear_block()
+    # The snapshot should only happen when reloading the currently-active session.
+    assert "currentSid === sid && forceReload" in body, (
+        "#3306: snapshot must be gated on `currentSid === sid && forceReload` "
+        "so switching to a different session still gets a clean carry-forward "
+        "(prior messages would belong to a different conversation)"
+    )
+
+
+def test_ensure_messages_loaded_consumes_snapshot_then_clears_it():
+    body = _ensure_messages_loaded_body()
+    assert "_pendingCarryForwardSnapshot" in body, (
+        "#3306: _ensureMessagesLoaded() must consult _pendingCarryForwardSnapshot "
+        "when calling _carryForwardEphemeralTurnFields"
+    )
+    # And must reset it afterwards so subsequent non-force loads don't reuse
+    # a stale snapshot.
+    assert "_pendingCarryForwardSnapshot = null" in body, (
+        "#3306: _ensureMessagesLoaded() must reset _pendingCarryForwardSnapshot "
+        "to null after consuming it, to avoid leaking stale ephemeral fields "
+        "into a later unrelated load"
+    )
+
+
+def test_carry_forward_call_still_present():
+    """If the #3018 carry-forward is ever removed, this fix becomes moot —
+    flag that explicitly so reviewers reconsider the snapshot machinery."""
+    body = _ensure_messages_loaded_body().replace(" ", "")
+    assert "_carryForwardEphemeralTurnFields" in body, (
+        "the #3018 carry-forward is gone — re-evaluate whether "
+        "_pendingCarryForwardSnapshot is still needed (#3306)"
+    )

--- a/tests/test_issue3306_loadsession_carry_forward.py
+++ b/tests/test_issue3306_loadsession_carry_forward.py
@@ -84,6 +84,55 @@ def test_ensure_messages_loaded_consumes_snapshot_then_clears_it():
     )
 
 
+def _load_older_messages_body() -> str:
+    start = SESSIONS_JS.index("async function _loadOlderMessages")
+    return SESSIONS_JS[start: start + 6000]
+
+
+def _start_gateway_sse_body() -> str:
+    start = SESSIONS_JS.index("function startGatewaySSE")
+    return SESSIONS_JS[start: start + 4000]
+
+
+def test_load_older_messages_tail_match_carries_forward():
+    """#3306 follow-up: _loadOlderMessages does a wholesale `S.messages = nextMessages`
+    on the tail-match path. Without carry-forward this drops ephemeral turn fields
+    (the intermittent "badge appears then disappears" symptom flagged in review)."""
+    body = _load_older_messages_body()
+    cf_idx = body.find("_carryForwardEphemeralTurnFields(S.messages || [], nextMessages)")
+    assign_idx = body.find("S.messages = nextMessages;")
+    assert cf_idx != -1, (
+        "#3306: _loadOlderMessages must carry forward ephemeral turn fields "
+        "into nextMessages before the wholesale S.messages assignment"
+    )
+    assert assign_idx != -1, "S.messages = nextMessages assignment not found"
+    assert cf_idx < assign_idx, (
+        "#3306: carry-forward call must precede `S.messages = nextMessages` "
+        "in _loadOlderMessages, otherwise the fields are already gone"
+    )
+
+
+def test_start_gateway_sse_import_cli_carries_forward():
+    """#3306 follow-up: the gateway SSE → import_cli refresh path also does a
+    wholesale `S.messages = next` for CLI sessions; it must carry forward
+    ephemeral turn fields too."""
+    body = _start_gateway_sse_body()
+    cf_idx = body.find("_carryForwardEphemeralTurnFields(S.messages || [], next)")
+    assign_idx = body.find("S.messages = _nextToAssign;")
+    assert cf_idx != -1, (
+        "#3306: startGatewaySSE import_cli branch must carry forward "
+        "ephemeral turn fields before assigning S.messages"
+    )
+    assert assign_idx != -1, (
+        "expected `S.messages = _nextToAssign;` after carry-forward in "
+        "startGatewaySSE import_cli branch"
+    )
+    assert cf_idx < assign_idx, (
+        "#3306: carry-forward call must precede the S.messages assignment "
+        "in the startGatewaySSE import_cli branch"
+    )
+
+
 def test_carry_forward_call_still_present():
     """If the #3018 carry-forward is ever removed, this fix becomes moot —
     flag that explicitly so reviewers reconsider the snapshot machinery."""


### PR DESCRIPTION
## Root cause

`loadSession(sid, {forceReload:true})` reset `S.messages = []` around line 614 BEFORE the API fetch returned. Later, in `_ensureMessagesLoaded()` (around line 1358), the #3018 ephemeral-field carry-forward call:

```js
msgs = window._carryForwardEphemeralTurnFields(S.messages || [], msgs);
```

…received an already-empty `S.messages`. The carry-forward became a no-op and ephemeral fields (`_turnUsage`, `_turnDuration`, `_turnTps`, `_gatewayRouting`, `_statusCard`) were dropped on every force-reload of the active session.

User-visible symptom: the token-usage badge vanishes ~10 seconds after each assistant turn finishes, because an external poll triggers `loadSession(sid, {forceReload:true})` on the currently-viewed session.

## Fix

1. Add a module-level `_pendingCarryForwardSnapshot` bridge variable.
2. In `loadSession()`, BEFORE `S.messages = []`, snapshot the prior messages into it — but only when force-reloading the *currently active* session (`currentSid === sid && forceReload`). Switching to a different session must still produce a clean carry-forward (prior messages belong to a different conversation).
3. In `_ensureMessagesLoaded()`, consume the snapshot ahead of the now-empty `S.messages` when calling `_carryForwardEphemeralTurnFields`, then reset it to `null` so stale snapshots cannot leak into a later unrelated load.
4. Apply the same carry-forward to the `_loadOlderMessages()` wholesale-replace path (around line 1598) — same bug class, same symptom on older-history loads.

## Tests

Adds `tests/test_issue3306_loadsession_carry_forward.py`, in the style of `tests/test_issue3162_ensure_messages_loaded.py`, pinning:

- `_pendingCarryForwardSnapshot` is declared at module scope.
- The snapshot assignment in `loadSession()` happens *before* `S.messages = []`.
- The snapshot is gated on `currentSid === sid && forceReload`.
- `_ensureMessagesLoaded()` consults the snapshot and then resets it to `null`.
- The #3018 carry-forward call is still present (so this fix remains relevant).

Validated:
- `node --check static/sessions.js` → ok
- `python -m pytest tests/test_issue3306_loadsession_carry_forward.py tests/test_issue3162_ensure_messages_loaded.py -q` → 7 passed

Closes #3306