### PR TITLE
Fix workspace panel edge arrow direction

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1323,7 +1323,7 @@
     </div>
   </main>
   <button class="workspace-panel-edge-toggle has-tooltip has-tooltip--left" id="btnWorkspacePanelEdgeToggle" type="button" onclick="toggleWorkspacePanel(true)" data-tooltip="Show workspace panel" aria-label="Show workspace panel" aria-expanded="false">
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
   </button>
   <aside class="rightpanel">
     <div class="resize-handle" id="rightpanelResize"></div>


### PR DESCRIPTION
## Summary
- Flip the workspace panel edge toggle icon so it points left from the right edge.
- Keep the existing button behavior, tooltip, and workspace panel state logic unchanged.

## Why
The edge toggle sits on the right side of the viewport and opens the workspace panel toward the left, so the icon should use a left-pointing chevron instead of a right-pointing one.

## Testing
- Not run: `python -m pytest tests/test_issue2211_workspace_panel_reopen.py` (`pytest` is not installed in this environment).

Refs #2211
