### PR TITLE
Filter interrupted recovery control text from visible transcript

### DIFF
--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -262,6 +262,7 @@ def stale_interrupted_event(session_id: str, run_id: str, *, after_seq: int | No
         return None
     payload = {
         "type": "interrupted",
+        "recovery_control": True,
         "message": "The live worker stopped before this run finished.",
         "hint": "The transcript was restored to the last journaled event. Start a new turn if you still need the task to continue.",
         "session_id": session_id,

--- a/static/messages.js
+++ b/static/messages.js
@@ -756,15 +756,15 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _isRecoveryControlMessageText(text){
     const normalized=String(text||'').replace(/\s+/g,' ').trim();
     if(!normalized) return false;
-    if(/^\[System:/i.test(normalized) && /continue exactly where you left off/i.test(normalized)){
-      return true;
-    }
-    return /the live worker stopped before this run finished\./i.test(normalized)
-      || /previous response was cut off by a network error/i.test(normalized)
-      || /continue exactly where you left off/i.test(normalized);
+    const systemRecovery=/^\[System:/i.test(normalized)
+      && /previous response was cut off by a network error/i.test(normalized)
+      && /continue exactly where you left off/i.test(normalized);
+    const backendRecovery=/^the live worker stopped before this run finished\.?$/i.test(normalized);
+    return !!(systemRecovery || backendRecovery);
   }
   function _isRecoveryControlMessage(m){
-    if(!m||m.role!=='assistant') return false;
+    if(!m||m.role==='tool') return false;
+    if(m.recovery_control===true) return true;
     const text=String(typeof msgContent==='function'?msgContent(m):(m.content||''));
     if(_isRecoveryControlMessageText(text)) return true;
     return !!(m.provider_details_label && String(m.provider_details_label).toLowerCase()==='interruption details');

--- a/static/messages.js
+++ b/static/messages.js
@@ -753,7 +753,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     return typeof _isPreservedCompressionTaskListMarkerOnlyText==='function'
       && _isPreservedCompressionTaskListMarkerOnlyText(text);
   }
-  function _isRecoveryControlMessageText(text){
+  function _streamRecoveryControlMessageText(text){
     const normalized=String(text||'').replace(/\s+/g,' ').trim();
     if(!normalized) return false;
     const systemRecovery=/^\[System:/i.test(normalized)
@@ -762,16 +762,16 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const backendRecovery=/^the live worker stopped before this run finished\.?$/i.test(normalized);
     return !!(systemRecovery || backendRecovery);
   }
-  function _isRecoveryControlMessage(m){
+  function _streamRecoveryControlMessage(m){
     if(!m||m.role==='tool') return false;
     if(m.recovery_control===true) return true;
     const text=String(typeof msgContent==='function'?msgContent(m):(m.content||''));
-    if(_isRecoveryControlMessageText(text)) return true;
+    if(_streamRecoveryControlMessageText(text)) return true;
     return !!(m.provider_details_label && String(m.provider_details_label).toLowerCase()==='interruption details');
   }
   function _filterRecoveryControlMessages(messages){
     if(!Array.isArray(messages)) return [];
-    return messages.filter((m)=>!_isRecoveryControlMessage(m));
+    return messages.filter((m)=>!_streamRecoveryControlMessage(m));
   }
   function _replaceMarkerOnlyAssistantWithStreamError(messages){
     if(!Array.isArray(messages)) return false;
@@ -2200,7 +2200,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const isModelNotFound=d.type==='model_not_found';
           const isCancelled=d.type==='cancelled';
           const isInterrupted=d.type==='interrupted';
-          isRecoveryControlMessage=isInterrupted && (d.recovery_control===true || _isRecoveryControlMessageText(d.message));
+          isRecoveryControlMessage=isInterrupted && (d.recovery_control===true || _streamRecoveryControlMessageText(d.message));
           const isNoResponse=d.type==='no_response'||d.type==='silent_failure';
           const label=isCancelled?'Task cancelled':isInterrupted?'Response interrupted':isQuotaExhausted?'Out of credits':isRateLimit?'Rate limit reached':isGatewayAuthError?(typeof t==='function'?t('gateway_auth_label'):'Gateway authentication failed'):isAuthMismatch?(typeof t==='function'?t('provider_mismatch_label'):'Provider mismatch'):isModelNotFound?(typeof t==='function'?t('model_not_found_label'):'Model not found'):isNoResponse?'No response from provider':'Error';
           const hint=d.hint?`\n\n*${d.hint}*`:'';

--- a/static/messages.js
+++ b/static/messages.js
@@ -753,6 +753,26 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     return typeof _isPreservedCompressionTaskListMarkerOnlyText==='function'
       && _isPreservedCompressionTaskListMarkerOnlyText(text);
   }
+  function _isRecoveryControlMessageText(text){
+    const normalized=String(text||'').replace(/\s+/g,' ').trim();
+    if(!normalized) return false;
+    if(/^\[System:/i.test(normalized) && /continue exactly where you left off/i.test(normalized)){
+      return true;
+    }
+    return /the live worker stopped before this run finished\./i.test(normalized)
+      || /previous response was cut off by a network error/i.test(normalized)
+      || /continue exactly where you left off/i.test(normalized);
+  }
+  function _isRecoveryControlMessage(m){
+    if(!m||m.role!=='assistant') return false;
+    const text=String(typeof msgContent==='function'?msgContent(m):(m.content||''));
+    if(_isRecoveryControlMessageText(text)) return true;
+    return !!(m.provider_details_label && String(m.provider_details_label).toLowerCase()==='interruption details');
+  }
+  function _filterRecoveryControlMessages(messages){
+    if(!Array.isArray(messages)) return [];
+    return messages.filter((m)=>!_isRecoveryControlMessage(m));
+  }
   function _replaceMarkerOnlyAssistantWithStreamError(messages){
     if(!Array.isArray(messages)) return false;
     const msg=[...messages].reverse().find(m=>m&&m.role==='assistant');
@@ -1884,6 +1904,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const _prevCacheRead=(S.session&&S.session.cache_read_tokens)||0;
           const _prevCacheWrite=(S.session&&S.session.cache_write_tokens)||0;
           S.session=d.session;S.messages=_carryForwardEphemeralTurnFields(S.messages||[], d.session.messages||[]);if(typeof _messagesTruncated!=='undefined')_messagesTruncated=!!d.session._messages_truncated;
+          S.messages=_filterRecoveryControlMessages(S.messages || []);
           if(S.session&&S.session.session_id){
             try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
             if(typeof _setActiveSessionUrl==='function') _setActiveSessionUrl(S.session.session_id);
@@ -2169,6 +2190,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(S.session&&S.session.session_id===activeSid){
         S.activeStreamId=null;
         clearLiveToolCards();if(!assistantText)removeThinking();
+        let isRecoveryControlMessage=false;
         try{
           const d=JSON.parse(e.data);
           const isRateLimit=d.type==='rate_limit';
@@ -2178,17 +2200,33 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const isModelNotFound=d.type==='model_not_found';
           const isCancelled=d.type==='cancelled';
           const isInterrupted=d.type==='interrupted';
+          isRecoveryControlMessage=isInterrupted && (d.recovery_control===true || _isRecoveryControlMessageText(d.message));
           const isNoResponse=d.type==='no_response'||d.type==='silent_failure';
           const label=isCancelled?'Task cancelled':isInterrupted?'Response interrupted':isQuotaExhausted?'Out of credits':isRateLimit?'Rate limit reached':isGatewayAuthError?(typeof t==='function'?t('gateway_auth_label'):'Gateway authentication failed'):isAuthMismatch?(typeof t==='function'?t('provider_mismatch_label'):'Provider mismatch'):isModelNotFound?(typeof t==='function'?t('model_not_found_label'):'Model not found'):isNoResponse?'No response from provider':'Error';
           const hint=d.hint?`\n\n*${d.hint}*`:'';
           const details=d.details?String(d.details).replace(/```/g,'`\u200b``'):'';
           const detailsLabel=isCancelled?'Cancellation details':isInterrupted?'Interruption details':undefined;
-          S.messages.push({role:'assistant',content:`**${label}:** ${d.message}${hint}`,provider_details:details,provider_details_label:detailsLabel});
+          if(isRecoveryControlMessage){
+            if(typeof showToast==='function') showToast('Stream recovery signal received. Restoring transcript...',3500,'error');
+          } else {
+            S.messages.push({role:'assistant',content:`**${label}:** ${d.message}${hint}`,provider_details:details,provider_details_label:detailsLabel});
+          }
         }catch(_){
           S.messages.push({role:'assistant',content:'**Error:** An error occurred. Check server logs.'});
         }
-        _markSessionViewed(activeSid, S.messages.length);
-        renderMessages({preserveScroll:true});
+        if(isRecoveryControlMessage){
+          (async()=>{
+            if(await _restoreSettledSession(source)) return;
+            if(S.session&&S.session.session_id===activeSid){
+              S.messages=_filterRecoveryControlMessages(S.messages||[]);
+              _markSessionViewed(activeSid, S.messages.length);
+              renderMessages({preserveScroll:true});
+            }
+          })();
+        } else {
+          _markSessionViewed(activeSid, S.messages.length);
+          renderMessages({preserveScroll:true});
+        }
       }else if(typeof trackBackgroundError==='function'){
         const _errTitle=(typeof _allSessions!=='undefined'&&_allSessions.find(s=>s.session_id===activeSid)||{}).title||null;
         try{const d=JSON.parse(e.data);trackBackgroundError(activeSid,_errTitle,d.message||'Error');}
@@ -2381,6 +2419,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         S.session=session;
         const _nextMsgs3018=(session.messages||[]).filter(m=>m&&m.role);
         S.messages=_carryForwardEphemeralTurnFields(S.messages||[], _nextMsgs3018);
+        S.messages=_filterRecoveryControlMessages(S.messages || []);
         if(S.session&&S.session.session_id){
           try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
           if(typeof _setActiveSessionUrl==='function') _setActiveSessionUrl(S.session.session_id);

--- a/static/ui.js
+++ b/static/ui.js
@@ -5407,15 +5407,15 @@ function msgContent(m){
 function _isRecoveryControlMessageText(text){
   const normalized=String(text||'').replace(/\s+/g,' ').trim();
   if(!normalized) return false;
-  if(/^\[System:/i.test(normalized) && /continue exactly where you left off/i.test(normalized)){
-    return true;
-  }
-  return /the live worker stopped before this run finished\./i.test(normalized)
-    || /previous response was cut off by a network error/i.test(normalized)
-    || /continue exactly where you left off/i.test(normalized);
+  const systemRecovery=/^\[System:/i.test(normalized)
+    && /previous response was cut off by a network error/i.test(normalized)
+    && /continue exactly where you left off/i.test(normalized);
+  const backendRecovery=/^the live worker stopped before this run finished\.?$/i.test(normalized);
+  return !!(systemRecovery || backendRecovery);
 }
 function _isRecoveryControlMessage(m){
-  if(!m||m.role!=='assistant') return false;
+  if(!m||m.role==='tool') return false;
+  if(m.recovery_control===true) return true;
   if(_isRecoveryControlMessageText(msgContent(m)||String(m.content||''))) return true;
   return !!(m.provider_details_label && String(m.provider_details_label).toLowerCase()==='interruption details');
 }
@@ -6377,6 +6377,7 @@ function renderMessages(options){
     if(!m||!m.role||m.role==='tool')return false;
     if(_isContextCompactionMessage(m)) return false;
     if(_isPreservedCompressionTaskListMessage(m)) return false;
+    if(_isRecoveryControlMessage(m)) return false;
     if(m.role==='assistant'){
       const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
       const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
@@ -6408,6 +6409,7 @@ function renderMessages(options){
     for(const m of S.messages){
       if(!m||!m.role||m.role==='tool'){ri++;continue;}
       if(_isPreservedCompressionTaskListMessage(m)){ri++;continue;}
+      if(_isRecoveryControlMessage(m)){ri++;continue;}
       const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
       const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
       if(msgContent(m)||m._statusCard||m.attachments?.length||(m.role==='assistant'&&(hasTc||hasTu||_messageHasReasoningPayload(m)||_assistantMessageHasVisibleContent(m)))) rebuilt.push({m,rawIdx:ri});

--- a/static/ui.js
+++ b/static/ui.js
@@ -5404,6 +5404,27 @@ function msgContent(m){
   return String(c).trim();
 }
 
+function _isRecoveryControlMessageText(text){
+  const normalized=String(text||'').replace(/\s+/g,' ').trim();
+  if(!normalized) return false;
+  if(/^\[System:/i.test(normalized) && /continue exactly where you left off/i.test(normalized)){
+    return true;
+  }
+  return /the live worker stopped before this run finished\./i.test(normalized)
+    || /previous response was cut off by a network error/i.test(normalized)
+    || /continue exactly where you left off/i.test(normalized);
+}
+function _isRecoveryControlMessage(m){
+  if(!m||m.role!=='assistant') return false;
+  if(_isRecoveryControlMessageText(msgContent(m)||String(m.content||''))) return true;
+  return !!(m.provider_details_label && String(m.provider_details_label).toLowerCase()==='interruption details');
+}
+function _assistantMessageHasVisibleContent(m){
+  if(!m||m.role!=='assistant') return false;
+  if(_isRecoveryControlMessage(m)) return false;
+  return !!msgContent(m);
+}
+
 function _fmtDateSep(d){
   const todayStart=new Date();todayStart.setHours(0,0,0,0);
   const dStart=new Date(d);dStart.setHours(0,0,0,0);
@@ -6360,6 +6381,7 @@ function renderMessages(options){
       const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
       const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
       if(hasTc||hasTu||_messageHasReasoningPayload(m)) return true;
+      if(_assistantMessageHasVisibleContent(m)) return true;
     }
     return m._statusCard||msgContent(m)||m.attachments?.length;
   });
@@ -6388,7 +6410,7 @@ function renderMessages(options){
       if(_isPreservedCompressionTaskListMessage(m)){ri++;continue;}
       const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
       const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
-      if(msgContent(m)||m._statusCard||m.attachments?.length||(m.role==='assistant'&&(hasTc||hasTu||_messageHasReasoningPayload(m)))) rebuilt.push({m,rawIdx:ri});
+      if(msgContent(m)||m._statusCard||m.attachments?.length||(m.role==='assistant'&&(hasTc||hasTu||_messageHasReasoningPayload(m)||_assistantMessageHasVisibleContent(m)))) rebuilt.push({m,rawIdx:ri});
       ri++;
     }
     _visWithIdxCache=rebuilt;

--- a/tests/test_live_stream_ux.py
+++ b/tests/test_live_stream_ux.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+RUN_JOURNAL_PY = (ROOT / "api" / "run_journal.py").read_text(encoding="utf-8")
+
+def test_stale_interrupted_event_marks_recovery_control():
+    assert "\"recovery_control\": True" in RUN_JOURNAL_PY
+
+
+def test_done_and_restore_filters_recovery_messages_from_frontend_state():
+    assert "_filterRecoveryControlMessages(S.messages || [])" in MESSAGES_JS
+
+
+def test_apererror_recovers_on_recovery_control_event():
+    assert "isRecoveryControlMessage=isInterrupted && (d.recovery_control===true || _isRecoveryControlMessageText(d.message));" in MESSAGES_JS
+    assert "Stream recovery signal received. Restoring transcript..." in MESSAGES_JS
+    assert "if(await _restoreSettledSession(source)) return;" in MESSAGES_JS
+
+
+def test_ui_rejects_recovery_control_as_visible_assistant_content():
+    assert "function _isRecoveryControlMessageText" in UI_JS
+    assert "function _assistantMessageHasVisibleContent" in UI_JS
+    assert "if(_isRecoveryControlMessage(m)) return false;" in UI_JS
+    assert "_assistantMessageHasVisibleContent(m)" in UI_JS

--- a/tests/test_live_stream_ux.py
+++ b/tests/test_live_stream_ux.py
@@ -11,6 +11,10 @@ def test_stale_interrupted_event_marks_recovery_control():
 
 def test_done_and_restore_filters_recovery_messages_from_frontend_state():
     assert "_filterRecoveryControlMessages(S.messages || [])" in MESSAGES_JS
+    assert "if(!m||m.role==='tool') return false;" in MESSAGES_JS
+    assert "if(m.recovery_control===true) return true;" in MESSAGES_JS
+    assert "previous response was cut off by a network error" in MESSAGES_JS
+    assert "continue exactly where you left off" in MESSAGES_JS
 
 
 def test_apererror_recovers_on_recovery_control_event():
@@ -23,4 +27,12 @@ def test_ui_rejects_recovery_control_as_visible_assistant_content():
     assert "function _isRecoveryControlMessageText" in UI_JS
     assert "function _assistantMessageHasVisibleContent" in UI_JS
     assert "if(_isRecoveryControlMessage(m)) return false;" in UI_JS
+    assert "if(_isRecoveryControlMessage(m)){ri++;continue;}" in UI_JS
     assert "_assistantMessageHasVisibleContent(m)" in UI_JS
+
+
+def test_recovery_control_detection_is_not_broad_phrase_matching():
+    assert "|| /continue exactly where you left off/i.test(normalized)" not in UI_JS
+    assert "|| /continue exactly where you left off/i.test(normalized)" not in MESSAGES_JS
+    assert "const systemRecovery=/^\\[System:/i.test(normalized)" in UI_JS
+    assert "const backendRecovery=/^the live worker stopped before this run finished\\.?$/i.test(normalized)" in UI_JS

--- a/tests/test_live_stream_ux.py
+++ b/tests/test_live_stream_ux.py
@@ -18,7 +18,7 @@ def test_done_and_restore_filters_recovery_messages_from_frontend_state():
 
 
 def test_apererror_recovers_on_recovery_control_event():
-    assert "isRecoveryControlMessage=isInterrupted && (d.recovery_control===true || _isRecoveryControlMessageText(d.message));" in MESSAGES_JS
+    assert "isRecoveryControlMessage=isInterrupted && (d.recovery_control===true || _streamRecoveryControlMessageText(d.message));" in MESSAGES_JS
     assert "Stream recovery signal received. Restoring transcript..." in MESSAGES_JS
     assert "if(await _restoreSettledSession(source)) return;" in MESSAGES_JS
 

--- a/tests/test_session_rotate_url_sync.py
+++ b/tests/test_session_rotate_url_sync.py
@@ -17,8 +17,8 @@ def test_stream_completion_syncs_rotated_session_id_to_tab_state():
     assert completion_pos != -1
     assert settled_pos != -1
 
-    completion_block = MESSAGES_JS[completion_pos : completion_pos + 500]
-    settled_block = MESSAGES_JS[settled_pos : settled_pos + 500]
+    completion_block = MESSAGES_JS[completion_pos : completion_pos + 900]
+    settled_block = MESSAGES_JS[settled_pos : settled_pos + 900]
 
     for block in (completion_block, settled_block):
         assert "localStorage.setItem('hermes-webui-session',S.session.session_id);" in block


### PR DESCRIPTION
## Thinking Path
- Reproduced the reported shape from session `e30f2cc1efe0`: interrupted SSE recovery text can be replayed into the visible transcript instead of staying platform-only control state.
- Traced the lifecycle from backend synthetic run-journal payload (`stale_interrupted_event`) through `static/messages.js` SSE settle/error handlers and `static/ui.js` final transcript filtering.
- Tightened the first draft after review: the original guard only covered assistant content helpers, so the generic `msgContent(m)` path could still render the recovery text; it also missed the system-like/user-message leak shape.

## Contract Routing
- Contract area: streaming / SSE recovery / transcript rendering.
- Mutated state layers: durable run journal payload metadata, frontend `S.messages` during `done` / `apperror` / `_restoreSettledSession`, and render-time visible transcript indexing.
- Invariant: recovery-control instructions are never user-visible transcript content, while real user/assistant text, tool calls, and settled transcript restoration remain replayable and idempotent.

## What Changed
- `api/run_journal.py`
  - Marked `stale_interrupted_event` synthetic interrupted payloads with `recovery_control: True`.
- `static/messages.js`
  - Added strict recovery-control detection helpers.
  - Filters recovery-control rows from settled frontend state after `done`, recovery-control `apperror`, and `_restoreSettledSession`.
  - Treats backend recovery-control `apperror` as a restore signal instead of appending a visible synthetic assistant error.
- `static/ui.js`
  - Filters recovery-control messages before both visible transcript filtering and cached visible-index rebuild.
  - Handles system-like/user-message recovery prompts as control text while avoiding broad matching on ordinary user phrases.
- `tests/test_live_stream_ux.py` and `tests/test_session_rotate_url_sync.py`
  - Added regression assertions for backend tagging, frontend settle filtering, UI visible-index filtering, and non-broad phrase matching.
  - Updated the rotate-url static assertion window so the added settle filter does not create a false negative.

## Why It Matters
- Prevents platform-injected recovery instructions from being presented as user or assistant transcript text.
- Keeps `done`, restore, and recovery-control `apperror` paths aligned with the same transcript visibility invariant.

## Verification
- `python -m pytest tests/test_live_stream_ux.py -q`
- `python -m pytest tests/test_live_stream_ux.py tests/test_static_js_runtime_lint.py tests/test_cancelled_turn_status.py -q`
- `python -m pytest tests/test_run_journal.py tests/test_run_journal_streaming_static.py tests/test_run_journal_routes.py tests/test_run_journal_frontend_static.py tests/test_issue765_streaming_persistence.py tests/test_stale_stream_pending_recovery.py tests/test_stale_stream_writeback.py -q`
- `python -m pytest tests/test_session_rotate_url_sync.py tests/test_live_stream_ux.py -q`
- `python -m pytest tests/test_live_stream_ux.py tests/test_session_rotate_url_sync.py tests/test_sprint9.py::test_no_duplicate_function_definitions -q`
- `python -m pytest tests/ -q --timeout=60 --shard-id=2 --num-shards=3`
- `git diff --check`

## Risks / Follow-ups
- Manual SSE reconnect validation is still useful in a stable UI session to confirm the user-facing status wording around restore.
- If future providers introduce new recovery-control text variants, they should be server-classified with `recovery_control: True` rather than added as broad frontend phrase matches.

## AI usage
- Provider: OpenAI
- Model: GPT-5 via Codex
- Notable tools: local code inspection, targeted patching, pytest execution, GitHub CLI.
