### PR TITLE
fix: use Optional[T] for default None parameters in api/state_sync.py

### DIFF
--- a/api/state_sync.py
+++ b/api/state_sync.py
@@ -16,11 +16,12 @@ any double-counting risk.
 import logging
 import os
 from pathlib import Path
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
-def _get_state_db(profile: str=None):
+def _get_state_db(profile: Optional[str] = None):
     """Get a SessionDB instance for a profile's state.db.
 
     When ``profile`` is provided the function resolves *that* profile's
@@ -104,7 +105,7 @@ def _get_state_db(profile: str=None):
         return None
 
 
-def sync_session_start(session_id: str, model=None, profile: str=None) -> None:
+def sync_session_start(session_id: str, model=None, profile: Optional[str] = None) -> None:
     """Register a WebUI session in state.db (idempotent).
     Called when a session's first message is sent.
 
@@ -132,8 +133,8 @@ def sync_session_start(session_id: str, model=None, profile: str=None) -> None:
 
 
 def sync_session_usage(session_id: str, input_tokens: int=0, output_tokens: int=0,
-                       estimated_cost=None, model=None, title: str=None,
-                       message_count: int=None, profile: str=None) -> None:
+                       estimated_cost=None, model=None, title: Optional[str] = None,
+                       message_count: Optional[int] = None, profile: Optional[str] = None) -> None:
     """Update token usage and title for a WebUI session in state.db.
     Called after each turn completes. Uses absolute=True to set totals
     (the WebUI Session already accumulates across turns).


### PR DESCRIPTION
## Description

Fixes type annotation errors in `api/state_sync.py` where non-optional types (`str`, `int`) are used with `None` defaults. These should use `Optional[T] = None` for correct type checking.

### Changes

- Added `from typing import Optional` import
- `_get_state_db(profile: str=None)` → `_get_state_db(profile: Optional[str] = None)`
- `sync_session_start(..., profile: str=None)` → `sync_session_start(..., profile: Optional[str] = None)`
- `sync_session_usage(..., title: str=None, message_count: int=None, profile: str=None)` → uses `Optional[str]` and `Optional[int]`

### Why

Using `str=None` as a type hint is misleading — it suggests the parameter is always a string, but it can also be `None`. Type checkers like mypy and pyright flag this as an error. Using `Optional[str] = None` correctly indicates the parameter accepts either a `str` or `None`.

Closes #3322