### PR TITLE
fix(profile): correct profile chip label on session switch and empty-session profile switch

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -5322,6 +5322,7 @@ async function switchToProfile(name) {
       if (S.session && !sessionInProgress) {
         S.session.model = modelToUse;
         S.session.model_provider = modelState.model_provider||providerId||null;
+        S.session.profile = data.active || name;
       }
     }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -5394,7 +5394,7 @@ function syncTopbar(){
   // modelSelect already set above
   // Update profile chip label
   const profileLabel=$('profileChipLabel');
-  if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
+  if(profileLabel) profileLabel.textContent=(S.session&&S.session.profile)||S.activeProfile||'default';
 }
 
 function msgContent(m){


### PR DESCRIPTION
Two complementary fixes for the profile chip label in the composer footer.

## Changes

### Commit 1 — Session switch chip fix (static/ui.js)
syncTopbar() now reads S.session.profile (current session's profile) over S.activeProfile (global active profile). When switching between sessions that belong to different profiles, the chip previously always showed the global active profile, not the viewed session's profile.

### Commit 2 — Empty-session profile switch fix (static/panels.js)
switchToProfile() now updates S.session.profile alongside model and model_provider when reusing an empty session in-place. Previously the chip would briefly flash the new profile name then revert to the stale one.

## Testing
- 85 profile/session tests passed, 0 regressions
- node --check passes on both modified files
- Manually verified on live WebUI instance

## Risk
Low. Both changes follow existing code patterns. No backend changes.