### PR TITLE
Fix same-session external refresh collapsing long transcripts to the tail window (#3239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Same-session external refresh now preserves the already-loaded transcript width for long conversations instead of collapsing the view back to the default tail window mid-read (#3239).
+
 ## [v0.51.195] — 2026-06-01 — Release FO (stage-batch7 — hide attachment path markers in chat UI)
 
 ### Fixed

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -589,6 +589,7 @@ async function loadSession(sid){
   }
   const forceReload = !!opts.force;
   const currentSid = S.session ? S.session.session_id : null;
+  const sameSessionForceReload = forceReload && currentSid===sid;
   // Clicking the already-open session in the sidebar is a no-op. Reloading it
   // tears down active pane state and can reset the long-session scroll window
   // to the top even though the user did not navigate anywhere. Explicit
@@ -611,6 +612,8 @@ async function loadSession(sid){
     _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
   }
   if (currentSid !== sid || forceReload) {
+    if (sameSessionForceReload) _captureSameSessionForceReloadHint(sid);
+    else _clearSameSessionForceReloadHint();
     S.messages = [];
     S.toolCalls = [];
     _messagesTruncated = false;
@@ -652,12 +655,14 @@ async function loadSession(sid){
         if(typeof showToast==='function') showToast('Failed to load session',3000,'error');
       }
     }
+    _clearSameSessionForceReloadHint(sid);
     if (_loadingSessionId === sid) _loadingSessionId = null;
     return;
   }
   // Guard: api() may have redirected (401) and returned undefined; in that case
   // the browser is already navigating away, so abort the rest of this flow.
   if (!data) {
+    _clearSameSessionForceReloadHint(sid);
     if (_loadingSessionId === sid) _loadingSessionId = null;
     return;
   }
@@ -739,7 +744,7 @@ async function loadSession(sid){
     // replaying persisted live tools so the compact Activity count survives
     // switching away from and back to an active chat (#1715).
     S.activeStreamId=activeStreamId;
-    syncTopbar();renderMessages();
+    syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
     const restoredLiveTurn=typeof restoreLiveTurnHtmlForSession==='function'&&restoreLiveTurnHtmlForSession(sid);
     if(!restoredLiveTurn){
       appendThinking();
@@ -823,7 +828,7 @@ async function loadSession(sid){
       updateSendBtn();
       setStatus('');
       setComposerStatus('');
-      syncTopbar();renderMessages();appendThinking();loadDir('.');
+      syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);appendThinking();loadDir('.');
       updateQueueBadge(sid);
       startApprovalPolling(sid);
       if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
@@ -837,7 +842,7 @@ async function loadSession(sid){
       setStatus('');
       setComposerStatus('');
       updateQueueBadge(sid);
-      syncTopbar();renderMessages();
+      syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
       if(typeof resumeManualCompressionForSession==='function') resumeManualCompressionForSession(sid);
       const _dirP=loadDir('.');
       // Workspace refresh is guarded by session id inside loadDir(); do not
@@ -1317,6 +1322,57 @@ let _messagesTruncated = false;
 // msg_limit (default 30): only fetch the last N messages for fast switching.
 // Older messages are loaded on-demand via _loadOlderMessages().
 const _INITIAL_MSG_LIMIT = 30;
+let _sameSessionForceReloadHint = null;
+
+function _currentLoadedRenderableMessageCount(){
+  if(typeof _messageRenderableMessageCount==='function'){
+    try{return Math.max(0,Number(_messageRenderableMessageCount())||0);}
+    catch(_){}
+  }
+  let count=0;
+  for(const m of (S.messages||[])){
+    if(m&&m.role&&m.role!=='tool') count++;
+  }
+  return count;
+}
+
+function _captureSameSessionForceReloadHint(sid){
+  const loadedRenderableCount=_currentLoadedRenderableMessageCount();
+  const loadedMessageCount=Array.isArray(S.messages)?S.messages.length:0;
+  const knownMessageCount=Number(S.session&&S.session.session_id===sid&&S.session.message_count)||loadedMessageCount;
+  if(!sid || (loadedRenderableCount<=0 && loadedMessageCount<=0)){
+    _sameSessionForceReloadHint=null;
+    return;
+  }
+  _sameSessionForceReloadHint={
+    session_id:sid,
+    loaded_renderable_count:loadedRenderableCount,
+    loaded_message_count:loadedMessageCount,
+    message_count:knownMessageCount,
+    truncated:!!_messagesTruncated,
+  };
+}
+
+function _clearSameSessionForceReloadHint(sid){
+  if(!_sameSessionForceReloadHint) return;
+  if(!sid || _sameSessionForceReloadHint.session_id===sid) _sameSessionForceReloadHint=null;
+}
+
+function _messageReloadLimitForSession(sid){
+  const hint=_sameSessionForceReloadHint;
+  if(hint&&hint.session_id===sid){
+    const loadedRenderableCount=Math.max(0,Number(hint.loaded_renderable_count)||0);
+    const loadedMessageCount=Math.max(0,Number(hint.loaded_message_count)||0);
+    if(loadedRenderableCount>0 || loadedMessageCount>0){
+      if(!hint.truncated) return null;
+      const previousMessageCount=Math.max(0,Number(hint.message_count)||0);
+      const currentMessageCount=Math.max(0,Number(S.session&&S.session.session_id===sid&&S.session.message_count)||0);
+      const appendedMessageCount=Math.max(0,currentMessageCount-previousMessageCount);
+      return Math.max(_INITIAL_MSG_LIMIT,loadedRenderableCount,loadedMessageCount+appendedMessageCount);
+    }
+  }
+  return _INITIAL_MSG_LIMIT;
+}
 
 function _syncToolCallsForLoadedMessages(messages, sessionToolCalls){
   const msgs=Array.isArray(messages)?messages:[];
@@ -1336,10 +1392,18 @@ function _syncToolCallsForLoadedMessages(messages, sessionToolCalls){
 async function _ensureMessagesLoaded(sid) {
   // Already have messages? (e.g. from INFLIGHT restore path, already set)
   if (S.messages && S.messages.length > 0 && S.messages[0] && S.messages[0].role) {
+    _clearSameSessionForceReloadHint(sid);
     return;
   }
   // Fetch session messages with a tail window for fast initial load.
-  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${_INITIAL_MSG_LIMIT}`);
+  const reloadLimit = _messageReloadLimitForSession(sid); // defaults to _INITIAL_MSG_LIMIT
+  const reloadLimitParam = reloadLimit ? `&msg_limit=${reloadLimit}` : '';
+  let data;
+  try {
+    data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0${reloadLimitParam}`);
+  } finally {
+    _clearSameSessionForceReloadHint(sid);
+  }
   // Guard: api() may have redirected (401) and returned undefined.
   if (!data || !data.session) return;
   _messagesTruncated = !!data.session._messages_truncated;
@@ -1357,6 +1421,7 @@ async function _ensureMessagesLoaded(sid) {
   if(typeof window._carryForwardEphemeralTurnFields==='function'){
     msgs=window._carryForwardEphemeralTurnFields(S.messages||[], msgs);
   }
+  if(typeof clearVisibleMessageRowCache==='function') clearVisibleMessageRowCache();
   S.messages = msgs;
   if(S.session&&S.session.session_id===sid){
     S.session.message_count=Number(data.session.message_count || msgs.length);

--- a/static/ui.js
+++ b/static/ui.js
@@ -268,12 +268,15 @@ let _messageRenderWindowSize=MESSAGE_RENDER_WINDOW_DEFAULT;
 // Cached visWithIdx array — invalidated when S.messages.length changes.
 let _visWithIdxCache=null;
 let _visWithIdxCacheLen=0;
+function clearVisibleMessageRowCache(){
+  _visWithIdxCache=null;
+  _visWithIdxCacheLen=0;
+}
 function _resetMessageRenderWindow(sid){
   _messageRenderWindowSid=sid||null;
   _messageRenderWindowSize=MESSAGE_RENDER_WINDOW_DEFAULT;
   _clearRenderCache();
-  _visWithIdxCache=null;
-  _visWithIdxCacheLen=0;
+  clearVisibleMessageRowCache();
 }
 
 // ── renderMd / _renderUserFencedBlocks cache ──────────────────────────────
@@ -6110,6 +6113,7 @@ let _sessionHtmlCacheSid=null; // session_id currently rendered in the DOM
 function clearMessageRenderCache(){
   _sessionHtmlCache.clear();
   _sessionHtmlCacheSid=null;
+  clearVisibleMessageRowCache();
 }
 
 function _messageRenderCacheSignature(){

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -77,3 +77,46 @@ def test_same_session_force_reload_preserves_non_empty_composer_input():
     assert "const preserveActiveInput = !!(opts && opts.preserveActiveInput);" in SESSIONS_JS
     assert "if (preserveActiveInput && current && current !== text) return;" in SESSIONS_JS
     assert "_restoreComposerDraft(_draft, sid, {preserveActiveInput:currentSid===sid&&forceReload});" in SESSIONS_JS
+
+
+def test_same_session_force_reload_keeps_loaded_transcript_width_hint():
+    """Same-session force refresh must not collapse a long transcript to the tail."""
+    assert "let _sameSessionForceReloadHint = null;" in SESSIONS_JS
+    assert "function _captureSameSessionForceReloadHint(sid)" in SESSIONS_JS
+    assert "loaded_renderable_count:loadedRenderableCount" in SESSIONS_JS
+    assert "message_count:knownMessageCount" in SESSIONS_JS
+    assert "truncated:!!_messagesTruncated" in SESSIONS_JS
+    assert "function _messageReloadLimitForSession(sid)" in SESSIONS_JS
+    assert "if(!hint.truncated) return null;" in SESSIONS_JS
+    assert "const appendedMessageCount=Math.max(0,currentMessageCount-previousMessageCount);" in SESSIONS_JS
+    assert "return Math.max(_INITIAL_MSG_LIMIT,loadedRenderableCount,loadedMessageCount+appendedMessageCount);" in SESSIONS_JS
+    assert "const reloadLimit = _messageReloadLimitForSession(sid);" in SESSIONS_JS
+    assert "const reloadLimitParam = reloadLimit ? `&msg_limit=${reloadLimit}` : '';" in SESSIONS_JS
+    assert "finally {\n    _clearSameSessionForceReloadHint(sid);\n  }" in SESSIONS_JS
+
+    load_start = SESSIONS_JS.index("async function loadSession(sid)")
+    load_end = SESSIONS_JS.index("// ── Handoff hint logic", load_start)
+    load_body = SESSIONS_JS[load_start:load_end]
+    capture_pos = load_body.index("if (sameSessionForceReload) _captureSameSessionForceReloadHint(sid);")
+    clear_pos = load_body.index("else _clearSameSessionForceReloadHint();", capture_pos)
+    reset_pos = load_body.index("S.messages = [];", clear_pos)
+    assert capture_pos < clear_pos < reset_pos
+    assert "const sameSessionForceReload = forceReload && currentSid===sid;" in load_body
+    assert "renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined)" in load_body
+
+
+def test_same_width_force_reload_invalidates_visible_message_cache():
+    """Replacing a transcript with the same length must still refresh cached rows."""
+    clear_start = UI_JS.index("function clearVisibleMessageRowCache()")
+    clear_end = UI_JS.index("function _resetMessageRenderWindow", clear_start)
+    clear_body = UI_JS[clear_start:clear_end]
+    assert "_visWithIdxCache=null;" in clear_body
+    assert "_visWithIdxCacheLen=0;" in clear_body
+    assert "clearVisibleMessageRowCache();" in UI_JS[UI_JS.index("function clearMessageRenderCache()") :]
+
+    ensure_start = SESSIONS_JS.index("async function _ensureMessagesLoaded(sid)")
+    ensure_end = SESSIONS_JS.index("function _messageComparableText", ensure_start)
+    ensure_body = SESSIONS_JS[ensure_start:ensure_end]
+    invalidate_pos = ensure_body.index("if(typeof clearVisibleMessageRowCache==='function') clearVisibleMessageRowCache();")
+    replace_pos = ensure_body.index("S.messages = msgs;")
+    assert invalidate_pos < replace_pos


### PR DESCRIPTION
Fixes #3239.

## Thinking Path
`refreshActiveSessionIfExternallyUpdated()` calls `loadSession(sid, {force:true})`, which clears `S.messages` and `_messagesTruncated` before `_ensureMessagesLoaded()` re-fetches. With nothing loaded, the reload falls back to the default `msg_limit=30`, so a long session that had older messages loaded is rebuilt from only the tail window. Under the preserved `scrollTop` the DOM shape changes and the reader lands in a different middle section.

## Fix
Capture a same-session force-reload hint (loaded renderable count, loaded message count, known message count, truncation flag) BEFORE clearing the in-memory transcript. `_messageReloadLimitForSession()` then uses that hint to request a reload width that preserves what was loaded (accounting for messages appended since), and the hint is cleared in a `finally` after the authoritative reload. Same-session force reloads now render with `{preserveScroll:true}`. The visible-message-row cache is also invalidated when the transcript is replaced, so a same-length replacement still refreshes cached rows.

## Before / After
- Before: scroll into the middle of a long session, trigger a same-session external refresh, and the viewport jumps to a different tail slice.
- After: the already-loaded transcript width and scroll position are preserved, so the visible slice does not collapse back to the default tail window.

## Tests
Added `test_same_session_force_reload_keeps_loaded_transcript_width_hint` and `test_same_width_force_reload_invalidates_visible_message_cache`, asserting the capture-before-clear ordering, the reload-limit contract, and cache invalidation before transcript replacement. Full frontend refresh suite green.

Prepared with AI assistance.