### PR TITLE
fix: Artifacts tab cannot open files when messages carry structured tool metadata

### DIFF
--- a/static/workspace.js
+++ b/static/workspace.js
@@ -268,12 +268,41 @@ function collectSessionArtifacts(){
     if(!path || seen.has(path)) return;
     seen.add(path); items.push({path, source});
   };
+  // Source 1: session-level tool call summaries (may be empty when messages
+  // carry their own tool metadata — see _syncToolCallsForLoadedMessages).
   for(const tc of (S.toolCalls || [])){
     for(const a of _artifactCandidatesFromToolCall(tc)) push(a.path, a.kind || tc.name || 'tool');
   }
+  // Source 2 & 3: message-level data — both text-mined diffs and structured
+  // tool_calls / tool_use content blocks that survive the S.toolCalls clear.
   for(const msg of (S.messages || [])){
-    const text = msg && (msg.content || msg.text || msg.message || '');
-    for(const a of _artifactCandidatesFromText(text)) push(a.path, a.kind);
+    if(!msg) continue;
+    const text = msg.content || msg.text || msg.message || '';
+    // Text-mined diff/patch fences (existing path).
+    if(typeof text === 'string'){
+      for(const a of _artifactCandidatesFromText(text)) push(a.path, a.kind);
+    }
+    // Structured tool_calls array (OpenAI format: {function:{name,arguments}}).
+    if(Array.isArray(msg.tool_calls)){
+      for(const tc of msg.tool_calls){
+        const fn = tc.function || tc;
+        const name = fn.name || tc.name || '';
+        let args = fn.arguments || tc.arguments || tc.args || tc.input || {};
+        if(typeof args === 'string'){ try{ args = JSON.parse(args); }catch(_){} }
+        const fakeTc = {name, args, result: tc.result || tc.output || ''};
+        for(const a of _artifactCandidatesFromToolCall(fakeTc)) push(a.path, a.kind || name || 'tool');
+      }
+    }
+    // Structured content array with tool_use blocks (Anthropic format).
+    if(Array.isArray(msg.content)){
+      for(const block of msg.content){
+        if(!block || block.type !== 'tool_use') continue;
+        let inp = block.input || {};
+        if(typeof inp === 'string'){ try{ inp = JSON.parse(inp); }catch(_){} }
+        const fakeTc = {name: block.name || '', args: inp, result: block.result || ''};
+        for(const a of _artifactCandidatesFromToolCall(fakeTc)) push(a.path, a.kind || block.name || 'tool');
+      }
+    }
   }
   return items.slice(0, 50);
 }
@@ -292,7 +321,14 @@ function renderSessionArtifacts(){
     root.innerHTML = '<div class="workspace-artifact-empty">No artifacts detected yet. Files created or edited during this session will appear here.</div>';
     return;
   }
-  root.innerHTML = items.map(item => `<button type="button" class="workspace-artifact-item" data-artifact-path="${esc(item.path)}" onclick="openArtifactPath(this.dataset.artifactPath)"><div class="workspace-artifact-path">${esc(item.path)}</div><div class="workspace-artifact-meta">${esc(item.source || 'session')}</div></button>`).join('');
+  // Strip workspace prefix for display so long absolute paths don't clutter the list.
+  const ws = S.session && S.session.workspace;
+  const normWs = ws ? ws.replace(/\/+$/,'') + '/' : '';
+  const displayPath = (p) => {
+    if(normWs && p.startsWith(normWs)) return p.slice(normWs.length);
+    return p;
+  };
+  root.innerHTML = items.map(item => `<button type="button" class="workspace-artifact-item" data-artifact-path="${esc(item.path)}" onclick="openArtifactPath(this.dataset.artifactPath)"><div class="workspace-artifact-path">${esc(displayPath(item.path))}</div><div class="workspace-artifact-meta">${esc(item.source || 'session')}</div></button>`).join('');
 }
 
 async function _workspacePathExists(path){
@@ -308,7 +344,15 @@ async function _workspacePathExists(path){
 async function openArtifactPath(path){
   if(!path) return;
   switchWorkspacePanelTab('files');
-  const rel = path.replace(/^~\//,'').replace(/^\.\//,'');
+  let rel = path.replace(/^~\//,'').replace(/^\.\/+/,'');
+  // Strip workspace prefix so /api/list receives a workspace-relative path.
+  const ws = S.session && S.session.workspace;
+  if(ws){
+    const normWs = ws.replace(/\/+$/,'') + '/';
+    if(rel.startsWith(normWs)) rel = rel.slice(normWs.length);
+    else if(rel === ws.replace(/\/+$/,'')) rel = '.';
+  }
+  if(!rel) rel = '.';
   try{
     if(!(await _workspacePathExists(rel))){
       setStatus(t('file_open_failed'));


### PR DESCRIPTION
## Problem

Clicking an artifact entry in the Artifacts tab shows "Could not open file" even when the file exists in the workspace.

## Root Cause

Two bugs in `static/workspace.js`:

### Bug 1: `collectSessionArtifacts()` misses artifacts when `S.toolCalls` is empty

`_syncToolCallsForLoadedMessages()` clears `S.toolCalls` when messages carry their own structured `tool_calls` / `tool_use` metadata (the common case for sessions loaded from history). `collectSessionArtifacts()` only read `S.toolCalls` and message text (diff/patch fences), so mutation tool paths embedded in structured message metadata were never collected.

### Bug 2: `openArtifactPath()` passes absolute paths to `/api/list`

When the agent records absolute paths in tool arguments (e.g. `/mnt/e/.../workspace/file.js`), `openArtifactPath()` only stripped `~/` and `./` prefixes. The full absolute path was passed to `/api/list?path=...`, which returned 404.

## Fix

1. **`collectSessionArtifacts()`**: Added two new extraction paths — scan `msg.tool_calls` (OpenAI format) and `msg.content` with `type: 'tool_use'` blocks (Anthropic format), reusing the existing `_artifactCandidatesFromToolCall` helper.

2. **`openArtifactPath()`**: Strip the session's `S.session.workspace` prefix from the path before calling `_workspacePathExists()`, so `/api/list` receives a workspace-relative path.

3. **`renderSessionArtifacts()`**: Display workspace-relative paths instead of full absolute paths in the artifact list.

## Verification

- `node --check static/workspace.js` ✅
- `tests/test_issue2655_frontend.py` (4 tests) ✅
- `tests/test_issue3262_artifact_path_canonicalization.py` (2 tests) ✅
- Browser live: loaded session with `patch` tool calls, `collectSessionArtifacts()` returned 1 artifact (previously 0), `openArtifactPath()` correctly stripped workspace prefix, file preview opened successfully.
