### PR TITLE
Fix pinned chat scroll after message rebuild

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -2758,12 +2758,23 @@ function _setMessageScrollToBottom(){
   _lastScrollTop=el.scrollTop;
   _nearBottomCount=2;
   _scrollPinned=true;
-  requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+  requestAnimationFrame(()=>{
+    el.scrollTop=el.scrollHeight;
+    _lastScrollTop=el.scrollTop;
+    _nearBottomCount=2;
+    _scrollPinned=true;
+    requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+  });
 }
 function _isMessagePaneNearBottom(threshold=250){
   const el=$('messages');
   if(!el) return false;
   return el.scrollHeight-el.scrollTop-el.clientHeight<=threshold;
+}
+function _messageBottomDistance(){
+  const el=$('messages');
+  if(!el) return 0;
+  return el.scrollHeight-el.scrollTop-el.clientHeight;
 }
 function _shouldFollowMessagesOnDomReplace(){
   return !_messageUserUnpinned && (_scrollPinned || _isMessagePaneNearBottom(1200));
@@ -2793,6 +2804,7 @@ function _settleMessageScrollToBottom(force){
 function scrollIfPinned(){
   if(!_scrollPinned) return;
   if(_recentNonMessageScrollIntent()) return;
+  if(_messageBottomDistance()>500) _setMessageScrollToBottom();
   _settleMessageScrollToBottom(false);
 }
 function scrollToBottom(){

--- a/tests/test_issue3319_pinned_scroll_jump.py
+++ b/tests/test_issue3319_pinned_scroll_jump.py
@@ -1,0 +1,39 @@
+"""Regression coverage for #3319: pinned chat should recover after DOM rebuilds."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _extract_fn(src: str, name: str) -> str:
+    marker = f"function {name}"
+    start = src.find(marker)
+    assert start >= 0, f"{name} not found"
+    brace = src.find("{", start)
+    assert brace >= 0, f"{name} body not found"
+    depth = 0
+    for i in range(brace, len(src)):
+        ch = src[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise AssertionError(f"{name} body did not close")
+
+
+def test_scroll_to_bottom_retries_after_next_layout_frame():
+    fn = _extract_fn(UI_JS, "_setMessageScrollToBottom")
+    assert "el.scrollTop=el.scrollHeight;" in fn
+    assert "requestAnimationFrame(()=>{" in fn
+    assert fn.count("el.scrollTop=el.scrollHeight;") >= 2
+    assert fn.count("_lastScrollTop=el.scrollTop;") >= 2
+
+
+def test_scroll_if_pinned_recovers_when_far_from_bottom():
+    fn = _extract_fn(UI_JS, "scrollIfPinned")
+    assert "_messageBottomDistance()>500" in fn
+    assert "_setMessageScrollToBottom();" in fn
+    assert fn.index("_messageBottomDistance()>500") < fn.index("_settleMessageScrollToBottom(false)")
+


### PR DESCRIPTION
Fixes #3319.

## Thinking Path
- The issue is that the chat is still pinned to the bottom, but after a message rebuild the browser can leave the scroll position far above the newest message.
- This should stay a small vanilla JS fix. No new build step, dependency, or UI rewrite is needed.
- The fix restores the pinned-bottom invariant after layout has had a frame to settle.

## What Changed
- Kept the existing immediate scroll-to-bottom write.
- Added one requestAnimationFrame retry after layout settles.
- When the chat still thinks it is pinned but is far from the bottom, it restores the bottom position before the normal settle pass.
- Added a focused regression test for this scroll recovery case.

## Why It Matters
Users who are reading or sending at the bottom of the chat should not get jumped back up by a DOM rebuild.

## Verification
- `node --check static/ui.js`
- `uv run --with pytest pytest tests/test_issue3319_pinned_scroll_jump.py tests/test_streaming_sidebar_scroll.py`
- Manual browser check on local WebUI: reproduced the jump condition by forcing the message list far from bottom, then confirmed `scrollIfPinned()` restored the bottom position.
- Full suite attempt: `uv run --with pytest --with pytest-timeout --with pyyaml --with cryptography pytest tests/ -v --timeout=60` completed with 6997 passed, 96 skipped, 8 failed. The failures were in onboarding/network/default-model/git-CRLF tests, not in this scroll path.
- UI evidence: issue #3319 shows the before behavior. After-check screenshot:

<img width="1280" height="900" alt="Manual UI verification screenshot for pinned scroll recovery" src="https://github.com/user-attachments/assets/0f82fdd6-dca8-4fc9-900a-5bd3a130eb61" />

## Risks / Follow-ups
- Low risk: the change only runs when the existing pinned-bottom state is active.
- No docs or changelog update included because this is a narrow bug fix, not a new workflow or user-facing feature.

## Model Used
Provider: OpenAI.
Model: GPT-5 via Codex.
Notable tool use: local shell, GitHub CLI, browser/manual UI check.
