### PR TITLE
fix: align project/session operations with session profile instead of global active profile

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -6824,14 +6824,20 @@ def handle_post(handler, parsed) -> bool:
         target_pid = body.get("project_id") or None
         if target_pid:
             from api.profiles import get_active_profile_name
-            active_profile = get_active_profile_name()
+            # Use the session's own profile for authorization, not the global
+            # active profile. A session belongs to a specific profile set at
+            # creation; projects from that profile should always be assignable,
+            # regardless of which profile is "active" at the process level.
+            # Matches the same principle as the profile chip fix — prefer
+            # session-scoped state over global active profile. (#3325 follow-up)
+            _session_profile = getattr(s, 'profile', None) or get_active_profile_name()
             target = next(
                 (p for p in load_projects() if p["project_id"] == target_pid),
                 None,
             )
             if not target:
                 return bad(handler, "Project not found", 404)
-            if not _profiles_match(target.get("profile"), active_profile):
+            if not _profiles_match(target.get("profile"), _session_profile):
                 return bad(handler, "Project not found", 404)
         with _get_session_agent_lock(body["session_id"]):
             s.project_id = target_pid
@@ -6859,7 +6865,7 @@ def handle_post(handler, parsed) -> bool:
             "project_id": uuid.uuid4().hex[:12],
             "name": name,
             "color": color,
-            "profile": get_active_profile_name() or 'default',
+            "profile": body.get('profile') or get_active_profile_name() or 'default',
             "created_at": time.time(),
         }
         projects.append(proj)

--- a/static/panels.js
+++ b/static/panels.js
@@ -5322,6 +5322,7 @@ async function switchToProfile(name) {
       if (S.session && !sessionInProgress) {
         S.session.model = modelToUse;
         S.session.model_provider = modelState.model_provider||providerId||null;
+        S.session.profile = data.active || name;
       }
     }
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4931,19 +4931,25 @@ function _showProjectPicker(session, anchorEl){
   none.onclick=async()=>{
     picker.remove();
     document.removeEventListener('click',close);
-    await api('/api/session/move',{method:'POST',body:JSON.stringify({session_id:session.session_id,project_id:null})});
-    // Sidebar rows are shallow copies of _allSessions entries (see
-    // _attachChildSessionsToSidebarRows), so mutating `session` only updates
-    // the discarded copy. Write into the authoritative cache so the next
-    // renderSessionListFromCache() reflects the move. (#2551)
-    const idx=_allSessions.findIndex(s=>s&&s.session_id===session.session_id);
-    if(idx>=0) _allSessions[idx].project_id=null;
-    renderSessionListFromCache();
-    showToast('Removed from project');
+    try {
+      await api('/api/session/move',{method:'POST',body:JSON.stringify({session_id:session.session_id,project_id:null})});
+      // Sidebar rows are shallow copies of _allSessions entries (see
+      // _attachChildSessionsToSidebarRows), so mutating `session` only updates
+      // the discarded copy. Write into the authoritative cache so the next
+      // renderSessionListFromCache() reflects the move. (#2551)
+      const idx=_allSessions.findIndex(s=>s&&s.session_id===session.session_id);
+      if(idx>=0) _allSessions[idx].project_id=null;
+      renderSessionListFromCache();
+      showToast('Removed from project');
+    } catch(e) {
+      showToast('Unassign failed: '+(e.message||e));
+    }
   };
   picker.appendChild(none);
-  // Project options
+  // Project options — only show projects matching the session's profile
+  const sessionProfile = session ? (session.profile || undefined) : undefined;
   for(const p of _allProjects){
+    if (sessionProfile && p.profile && p.profile !== sessionProfile) continue;
     const item=document.createElement('div');
     item.className='project-picker-item'+(session.project_id===p.project_id?' active':'');
     if(p.color){
@@ -4958,12 +4964,14 @@ function _showProjectPicker(session, anchorEl){
     item.onclick=async()=>{
       picker.remove();
       document.removeEventListener('click',close);
-      await api('/api/session/move',{method:'POST',body:JSON.stringify({session_id:session.session_id,project_id:p.project_id})});
-      // See #2551 — write to _allSessions, not the shallow sidebar copy.
-      const idx=_allSessions.findIndex(s=>s&&s.session_id===session.session_id);
-      if(idx>=0) _allSessions[idx].project_id=p.project_id;
-      renderSessionListFromCache();
-      showToast('Moved to '+p.name);
+      try{
+        await api('/api/session/move',{method:'POST',body:JSON.stringify({session_id:session.session_id,project_id:p.project_id})});
+        // See #2551 — write to _allSessions, not the shallow sidebar copy.
+        const idx=_allSessions.findIndex(s=>s&&s.session_id===session.session_id);
+        if(idx>=0) _allSessions[idx].project_id=p.project_id;
+        renderSessionListFromCache();
+        showToast('Moved to '+p.name);
+      }catch(e){showToast('Move failed: '+(e.message||e));}
     };
     picker.appendChild(item);
   }
@@ -4981,7 +4989,8 @@ function _showProjectPicker(session, anchorEl){
     });
     if(!name||!name.trim()) return;
     const color=PROJECT_COLORS[_allProjects.length%PROJECT_COLORS.length];
-    const res=await api('/api/projects/create',{method:'POST',body:JSON.stringify({name:name.trim(),color})});
+    const profile = session.profile || undefined;
+    const res=await api('/api/projects/create',{method:'POST',body:JSON.stringify({name:name.trim(),color,profile})});
     if(res.project){
       _allProjects.push(res.project);
       // Now move session into it
@@ -5072,9 +5081,13 @@ function _startProjectRename(proj, chip){
   inp.value=proj.name;
   const finish=async(save)=>{
     if(save&&inp.value.trim()&&inp.value.trim()!==proj.name){
-      await api('/api/projects/rename',{method:'POST',body:JSON.stringify({project_id:proj.project_id,name:inp.value.trim()})});
-      await renderSessionList();
-      showToast('Project renamed');
+      try {
+        await api('/api/projects/rename',{method:'POST',body:JSON.stringify({project_id:proj.project_id,name:inp.value.trim()})});
+        await renderSessionList();
+        showToast('Project renamed');
+      } catch(e) {
+        showToast('Rename failed: '+(e.message||e));
+      }
     }else{
       renderSessionListFromCache();
     }
@@ -5125,9 +5138,13 @@ function _showProjectContextMenu(e, proj, chip){
     if(hex===(proj.color||'')) dot.style.outline='2px solid var(--text)';
     dot.onclick=async()=>{
       menu.remove();
-      await api('/api/projects/rename',{method:'POST',body:JSON.stringify({project_id:proj.project_id,name:proj.name,color:hex})});
-      await renderSessionList();
-      showToast('Color updated');
+      try {
+        await api('/api/projects/rename',{method:'POST',body:JSON.stringify({project_id:proj.project_id,name:proj.name,color:hex})});
+        await renderSessionList();
+        showToast('Color updated');
+      } catch(e) {
+        showToast('Color update failed: '+(e.message||e));
+      }
     };
     colorRow.appendChild(dot);
   });
@@ -5157,10 +5174,14 @@ async function _confirmDeleteProject(proj){
     danger:true
   });
   if(!ok){return;}
-  await api('/api/projects/delete',{method:'POST',body:JSON.stringify({project_id:proj.project_id})});
-  if(_activeProject===proj.project_id) _activeProject=null;
-  await renderSessionList();
-  showToast('Project deleted');
+  try {
+    await api('/api/projects/delete',{method:'POST',body:JSON.stringify({project_id:proj.project_id})});
+    if(_activeProject===proj.project_id) _activeProject=null;
+    await renderSessionList();
+    showToast('Project deleted');
+  } catch(e) {
+    showToast('Delete failed: '+(e.message||e));
+  }
 }
 
 // Global Escape handler for batch select mode

--- a/static/ui.js
+++ b/static/ui.js
@@ -5394,7 +5394,7 @@ function syncTopbar(){
   // modelSelect already set above
   // Update profile chip label
   const profileLabel=$('profileChipLabel');
-  if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
+  if(profileLabel) profileLabel.textContent=(S.session&&S.session.profile)||S.activeProfile||'default';
 }
 
 function msgContent(m){

--- a/tests/test_issue1614_project_profile_filtering.py
+++ b/tests/test_issue1614_project_profile_filtering.py
@@ -234,8 +234,8 @@ def test_profile_field_on_project_dict_default_create(monkeypatch):
     assert create_idx > 0
     next_handler_idx = src.find('"/api/projects/rename"', create_idx)
     create_block = src[create_idx:next_handler_idx]
-    assert '"profile": get_active_profile_name() or \'default\'' in create_block, (
-        "Project create must stamp the active profile (#1614)"
+    assert '"profile": body.get(\'profile\') or get_active_profile_name() or \'default\'' in create_block, (
+        "Project create must stamp the active profile or accept profile from body (#1614)"
     )
 
 
@@ -265,16 +265,16 @@ def test_project_delete_rejects_cross_profile():
     )
 
 
-def test_session_move_rejects_cross_profile_project():
-    """/api/session/move must refuse moves into a project from another profile."""
+def test_session_move_uses_session_profile():
+    """/api/session/move must use session.profile instead of active_profile for authorization."""
     from pathlib import Path
     src = (Path(__file__).parent.parent / 'api' / 'routes.py').read_text(encoding='utf-8')
 
     move_idx = src.find('"/api/session/move"')
     assert move_idx > 0
     move_block = src[move_idx:move_idx + 2000]
-    assert '_profiles_match(target.get("profile"), active_profile)' in move_block, (
-        "session/move must check target project's active-profile ownership"
+    assert '_profiles_match(target.get("profile"), _session_profile)' in move_block, (
+        "session/move must use session-scoped profile (not active_profile) for authorization"
     )
 
 


### PR DESCRIPTION
Profile isolation (#1614, PR #1629) added `get_active_profile_name()` checks to project CRUD and session move, but the global 'active profile' differs from the session's actual profile when users switch between sessions from different profiles. This caused silent 404s and misleading chip labels.

## Changes

### Profile chip (static/ui.js, static/panels.js)
Chip now reads `S.session.profile` over `S.activeProfile`, so switching between sessions from different profiles shows the correct profile name.

### Session move (api/routes.py /api/session/move)
Authorization check uses `getattr(s, 'profile', None)` (session's own profile) instead of global `get_active_profile_name()`.

### Project creation (api/routes.py /api/projects/create)
Accepts optional `profile` body field. When creating a new project from the project picker, the frontend passes `session.profile` so the project inherits the correct profile tag.

### Project picker (static/sessions.js)
- Filters out projects whose profile doesn't match the session's profile
- "+ New project" passes the session's profile to the create endpoint
- 5 API call paths (delete, rename, color, unassign, move) now show error toast on failure instead of silent 404

### Tests
- Updated `test_session_move_uses_session_profile` to match new auth behavior
- All existing tests pass, 0 regressions

## Commits
Single squashed commit. Supersedes PR #3325 (chip fix) and PR #3331 (original session move fix).