### PR TITLE
fix: hide retired default profile in webui

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -1001,6 +1001,18 @@ def list_profiles_api() -> list:
     active = get_active_profile_name()
     result = []
     for p in infos:
+        # When the root/default profile has been retired for a named-profile
+        # workspace, keep it out of the WebUI profile list entirely.  This
+        # prevents stale browser bundles or cached panel state from showing a
+        # dead "default" card beside the active operator profile.
+        if (
+            p.name == 'default'
+            and active != 'default'
+            and not p.gateway_running
+            and not p.model
+            and not p.provider
+        ):
+            continue
         result.append({
             'name': p.name,
             'path': str(p.path),

--- a/static/panels.js
+++ b/static/panels.js
@@ -5017,7 +5017,17 @@ async function loadProfilesPanel() {
       </div>`;
     explainer.onclick = () => _renderProfileConceptHelp(data.active || 'default');
     panel.appendChild(explainer);
-    if (!data.profiles || !data.profiles.length) {
+    const visibleProfiles = (data.profiles || []).filter((profile) => {
+      // If the default profile has been retired (no model/provider and no
+      // gateway), hide it from the active workspace lane instead of keeping a
+      // dead profile card beside the real operator profile.
+      return !(profile.name === 'default'
+        && data.active !== 'default'
+        && !profile.gateway_running
+        && !profile.model
+        && !profile.provider);
+    });
+    if (!visibleProfiles.length) {
       const emptyMsg = document.createElement('div');
       emptyMsg.style.cssText = 'padding:16px;color:var(--muted);font-size:12px';
       emptyMsg.textContent = t('profiles_no_profiles');
@@ -5025,10 +5035,10 @@ async function loadProfilesPanel() {
       if (_profileMode !== 'create') _clearProfileDetail();
       return;
     }
-    const activeName = (S.activeProfile && data.profiles.some(p => p.name === S.activeProfile))
+    const activeName = (S.activeProfile && visibleProfiles.some(p => p.name === S.activeProfile))
       ? S.activeProfile
-      : (data.active || 'default');
-    for (const p of data.profiles) {
+      : (data.active || visibleProfiles[0].name);
+    for (const p of visibleProfiles) {
       const card = document.createElement('div');
       card.className = 'profile-card';
       card.dataset.name = p.name;


### PR DESCRIPTION
## Summary
- Hide retired root/default profile from WebUI profile API when a named profile is active
- Keep the client-side profile panel filtering aligned with the API
- Prevent stale/dead default profile card from appearing beside the active operator profile

## Verification
- python3 -m py_compile api/profiles.py
- ./ctl.sh restart
- curl -fsS http://127.0.0.1:8787/health
- curl -fsS http://127.0.0.1:8787/api/profiles returned only mac-naomi in the active local lane