### PR TITLE
docs(runtime): define runner process gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Changed
+- The #1925 runtime-adapter RFC now marks the configured runner-client boundary as shipped in v0.51.188 (#3073 / #3274) and defines the next Slice 4g gate for a supervised local runner process harness: real runner-owned `AIAgent` execution, restart/reattach proof, bounded runner health diagnostics, and no new WebUI runtime-surrogate globals.
+
 ## [v0.51.195] — 2026-06-01 — Release FO (stage-batch7 — hide attachment path markers in chat UI)
 
 ### Fixed

--- a/docs/rfcs/hermes-run-adapter-contract.md
+++ b/docs/rfcs/hermes-run-adapter-contract.md
@@ -956,28 +956,34 @@ Non-goals for Slice 4e:
 
 #### Slice 4f: Supervised local runner client backend gate
 
-Status as of 2026-05-28: client transport proposed in #3073 behind
-`HERMES_WEBUI_RUNNER_BASE_URL`; it should be described as under review until a
-release PR actually ships it.
-`runner-local` still remains default-off and returns the bounded not-configured
-path unless that endpoint is explicitly configured. When configured, WebUI uses a
-JSON HTTP client boundary for start / observe / status / controls and bridges
-observed runner events through the existing SSE stream route rather than adding
-main-process runner-owned maps.
+Status as of 2026-05-31: shipped in v0.51.188 via #3073 / #3274. The client
+transport is now implemented behind `HERMES_WEBUI_RUNNER_BASE_URL` and remains
+default-off. With no endpoint configured, `runner-local` still returns the
+bounded not-configured path and the live in-process `_run_agent_streaming` path
+is unchanged. When configured, WebUI uses a JSON HTTP client boundary for start /
+observe / status / controls and bridges observed runner events through the
+existing SSE stream route rather than adding main-process runner-owned maps.
+
+The release added two security hardening checks while absorbing #3073:
+`HttpRunnerClient` rejects non-`http(s)` base URL schemes and uses an opener that
+does not follow redirects, so a misconfigured or compromised runner cannot leak a
+Bearer token to a redirected host. The release gate reported full pytest passing
+and independent default-off/inert-path review.
+
 This bridge is intentionally a WebUI consumer transport seam: the configured
 runner must emit events that are already compatible with the browser SSE event
 names/payloads, or a later runner-owned normalization layer must translate
 Hermes runtime families such as `token.delta`, `tool.started`, and `done` before
 they reach this route.
 
-After the route-selection harness ships, the next reviewable step is not to make
-`runner-local` the default. It is to define the first concrete supervised/local
-runner client backend that can replace the bounded 501 path under the existing
-feature flag and prove execution ownership has moved out of the main WebUI
-request process.
+After the configured runner-client boundary ships, the next reviewable step is
+not to make `runner-local` the default. It is to define the first supervised
+runner process harness that can actually own `AIAgent` execution behind that
+client boundary and prove restart/reattach with a real local runner, not just a
+configured external endpoint or fake-runner fixture.
 
-This slice is a contract gate before backend code lands. The goal is to pin the
-minimum runner client behavior so the implementation cannot become a renamed
+This slice was the client-boundary implementation gate. The goal was to pin the
+minimum runner client behavior so the implementation could not become a renamed
 `STREAMS` / `CANCEL_FLAGS` / cached `AIAgent` surrogate inside `api/routes.py`.
 
 Scope:
@@ -1026,6 +1032,59 @@ Non-goals for Slice 4f:
 - no server-side queue scheduler just for adapter symmetry;
 - no permanent WebUI-owned active-run discovery cache that duplicates runner or
   future Hermes Runtime API responsibility.
+
+#### Slice 4g: Supervised local runner process harness gate
+
+After #3073 / #3274, WebUI has an explicit configured-runner HTTP client and SSE
+consumer bridge, but it still does not ship the supervised runner process itself.
+The next gate should define the smallest local runner harness that can own
+`AIAgent` execution outside the main WebUI request process while being consumed
+through the already-shipped `runner-local` client boundary.
+
+Scope:
+
+- define the local runner process lifecycle: spawn/start, health check, run
+  ownership, graceful shutdown, crash classification, and cleanup;
+- keep WebUI as a client of `HERMES_WEBUI_RUNNER_BASE_URL`, not the owner of
+  process-local runner execution state;
+- persist run/session lookup, ordered events, terminal state, and active controls
+  in runner-owned or journal-backed state that a restarted WebUI can discover;
+- carry explicit profile, workspace, attachments, provider/model, toolset,
+  source, and metadata payloads into the runner without WebUI process-global
+  environment mutation;
+- prove cancel as the first live control for active runner-owned runs, with
+  approval, clarify, goal, and queue either mapped to explicit runner
+  capabilities or returned as bounded unsupported/conflict `ControlResult`
+  values.
+
+Acceptance tests for Slice 4g:
+
+1. **Process ownership moved.** A local runner process, not `hermes-webui`, owns
+   `AIAgent` construction/reuse and active run execution for `runner-local` runs.
+2. **Restart/reattach with a real runner.** Start a non-trivial `runner-local`
+   run, restart only `hermes-webui`, reload the session, rediscover the active or
+   terminal runner-owned run, replay/catch up from cursor without duplicate
+   transcript/tool/reasoning state, and preserve cancel if still active.
+3. **No runtime-surrogate globals in WebUI.** The main WebUI server still does not
+   gain new module-level maps for runner-owned streams, cancel flags,
+   approval/clarify callbacks, cached agents, child process run registries, goal
+   state, or queue schedulers.
+4. **Default-off and reversible.** Unset `HERMES_WEBUI_RUNNER_BASE_URL` or switch
+   the adapter mode back to legacy and the existing in-process path remains
+   available without session or journal migration.
+5. **Runner health and failure are observable.** A missing, unhealthy, or crashed
+   runner returns bounded diagnostics and terminal/interrupted state rather than
+   silently falling back to WebUI-owned execution for a runner-selected run.
+
+Non-goals for Slice 4g:
+
+- no default-on runner mode;
+- no removal of `legacy-direct` or `legacy-journal`;
+- no server-side queue scheduler just for adapter symmetry;
+- no broad WebUI product-surface migration;
+- no claim that this is the canonical Hermes Agent Runtime API; if Hermes Agent
+  later ships `/v1/runs`, this local runner remains a replaceable backend behind
+  the same adapter/client boundary.
 
 ## First Meaningful Success Criteria
 

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -574,12 +574,14 @@ def test_rfc_defines_slice4f_supervised_local_runner_client_gate():
     rfc = (routes.Path(__file__).parent.parent / "docs" / "rfcs" / "hermes-run-adapter-contract.md").read_text(encoding="utf-8")
 
     assert "#### Slice 4f: Supervised local runner client backend gate" in rfc
-    assert "Status as of 2026-05-28: client transport proposed in #3073 behind" in rfc
-    assert "it should be described as under review until a\nrelease PR actually ships it" in rfc
-    assert "replace the bounded 501 path under the existing\nfeature flag" in rfc
-    assert "durable runner-owned run id plus session-to-run lookup" in rfc
+    assert "Status as of 2026-05-31: shipped in v0.51.188 via #3073 / #3274" in rfc
+    assert "The client\ntransport is now implemented behind `HERMES_WEBUI_RUNNER_BASE_URL`" in rfc
+    assert "`HttpRunnerClient` rejects non-`http(s)` base URL schemes" in rfc
+    assert "uses an opener that\ndoes not follow redirects" in rfc
     assert "the configured\nrunner must emit events that are already compatible with the browser SSE event\nnames/payloads" in rfc
     assert "a later runner-owned normalization layer must translate\nHermes runtime families such as `token.delta`, `tool.started`, and `done`" in rfc
+    assert "After the configured runner-client boundary ships" in rfc
+    assert "configured external endpoint or fake-runner fixture" in rfc
     assert "cancel as the first required live control" in rfc
     assert "501 path replaced only when configured" in rfc
     assert "Restart/reattach proves ownership moved" in rfc
@@ -587,6 +589,24 @@ def test_rfc_defines_slice4f_supervised_local_runner_client_gate():
     assert "Successful chat-start responses remain limited\n   to the legacy-compatible field whitelist" in rfc
     assert "Unsupported runner controls return safe\n   `unsupported`, `not-active`, or `conflict` results" in rfc
     assert "no permanent WebUI-owned active-run discovery cache" in rfc
+
+
+def test_rfc_defines_slice4g_supervised_local_runner_process_gate():
+    routes = importlib.import_module("api.routes")
+    rfc = (routes.Path(__file__).parent.parent / "docs" / "rfcs" / "hermes-run-adapter-contract.md").read_text(encoding="utf-8")
+
+    assert "#### Slice 4g: Supervised local runner process harness gate" in rfc
+    assert "After #3073 / #3274, WebUI has an explicit configured-runner HTTP client" in rfc
+    assert "still does not ship the supervised runner process itself" in rfc
+    assert "own\n`AIAgent` execution outside the main WebUI request process" in rfc
+    assert "keep WebUI as a client of `HERMES_WEBUI_RUNNER_BASE_URL`" in rfc
+    assert "without WebUI process-global\n  environment mutation" in rfc
+    assert "Process ownership moved" in rfc
+    assert "Restart/reattach with a real runner" in rfc
+    assert "No runtime-surrogate globals in WebUI" in rfc
+    assert "Default-off and reversible" in rfc
+    assert "Runner health and failure are observable" in rfc
+    assert "no claim that this is the canonical Hermes Agent Runtime API" in rfc
 
 def test_runtime_runner_client_factory_stays_bounded_until_endpoint_configured(monkeypatch):
     routes = importlib.import_module("api.routes")


### PR DESCRIPTION
## Thinking Path

- #1925 has moved through the journal/replay baseline, RuntimeAdapter seam, control-routing slices, route-selection harness, and now the configured runner-client boundary.
- PR #3073 shipped via #3274 / v0.51.188 as a default-off WebUI consumer transport over `HERMES_WEBUI_RUNNER_BASE_URL`.
- The shipped client boundary is useful, but it still does not include the supervised local runner process that owns `AIAgent` execution outside `hermes-webui`.
- The next safe step is another narrow docs/test gate: mark Slice 4f shipped, then define Slice 4g acceptance before runner-process code lands.

## What Changed

- Updated `docs/rfcs/hermes-run-adapter-contract.md` to mark Slice 4f shipped in v0.51.188 via #3073 / #3274.
- Captured the shipped hardening notes from #3274: non-`http(s)` runner URLs are rejected and runner HTTP redirects are not followed.
- Added Slice 4g, a supervised local runner process harness gate covering process lifecycle, restart/reattach, cancel as the first live control, explicit context payloads, and no WebUI runtime-surrogate globals.
- Updated `tests/test_runtime_adapter_seam.py` so the RFC status and new Slice 4g gate are pinned.
- Added a release-note-ready changelog entry.

## Why It Matters

This keeps #1925 moving without jumping straight from “configured external runner client exists” to “make runner-local the default.” The next implementation needs to prove real process ownership moved: WebUI can restart, rediscover the runner-owned run, replay/catch up, and still cancel without rebuilding `STREAMS` / `CANCEL_FLAGS` / cached-agent state under new names.

## Contract Routing

Task type: #1925 runtime-adapter RFC / migration gate update.

Touched areas:
- `docs/rfcs/hermes-run-adapter-contract.md`
- `tests/test_runtime_adapter_seam.py`
- `CHANGELOG.md`

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/README.md`
- `docs/rfcs/hermes-run-adapter-contract.md`

Scope boundaries:
- Docs/test only.
- Does not implement a supervised runner process.
- Does not enable `runner-local` by default.
- Does not remove `legacy-direct` or `legacy-journal`.
- Does not claim this is the canonical Hermes Agent Runtime API; it stays a replaceable backend behind the adapter/client boundary.

Evidence needed before claiming done:
- RFC source test for Slice 4f shipped wording and Slice 4g gate content.
- Full WebUI pytest suite with config isolation.
- `git diff --check`.

## Verification

- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_runtime_adapter_seam.py -q -o addopts=` → `33 passed`
- `git diff --check` → clean
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q -o addopts=` → `7145 passed, 8 skipped, 3 xpassed, 16 subtests passed`

## Risks / Follow-ups

- The exact supervised runner implementation remains a later slice; this PR intentionally only defines the gate.
- Slice 4g should stay default-off and reversible until restart/reattach with a real runner is demonstrated.
- If Hermes Agent ships a canonical `/v1/runs` runtime before this local runner lands, the local runner should remain replaceable rather than becoming a permanent divergent runtime contract.

## Model Used

OpenAI Codex / GPT-5.5 via Hermes Agent, with terminal, file, and GitHub CLI tools.

Refs #1925
