### PR TITLE
feat: syntax highlighting in workspace file preview

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1957,6 +1957,7 @@
   .preview-area.visible{display:flex;opacity:1;}
   .preview-path{font-size:11px;color:var(--muted);padding-bottom:8px;border-bottom:1px solid var(--border);flex-shrink:0;}
   .preview-code{font-family:"SF Mono","Fira Code",ui-monospace,monospace;font-size:12px;line-height:1.6;white-space:pre-wrap;word-break:break-word;color:var(--pre-text);}
+  .preview-code code[class*="language-"]{background:var(--code-bg) !important;}
   /* Image preview */
   .preview-img-wrap{display:flex;align-items:center;justify-content:center;flex:1;padding:8px 0;min-height:0;}
   .preview-img{max-width:100%;max-height:100%;object-fit:contain;border-radius:6px;box-shadow:0 2px 12px rgba(0,0,0,.4);}

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -528,6 +528,32 @@ function cancelEditMode(){
   updateEditBtn();
 }
 
+// Map file extensions to Prism.js language identifiers.
+// Prism autoloader fetches missing language components from CDN on demand.
+const _PRISM_LANG_MAP={
+  js:'javascript',mjs:'javascript',jsx:'jsx',ts:'typescript',tsx:'tsx',
+  py:'python',pyw:'python',pyi:'python',
+  rb:'ruby',go:'go',rs:'rust',java:'java',kt:'kotlin',kts:'kotlin',
+  c:'c',h:'c',cpp:'cpp',cxx:'cpp',hpp:'cpp',cc:'cpp',
+  cs:'csharp',swift:'swift',scala:'scala',
+  php:'php',pl:'perl',pm:'perl',r:'r',lua:'lua',
+  sh:'bash',bash:'bash',zsh:'bash',fish:'bash',
+  ps1:'powershell',psm1:'powershell',
+  sql:'sql',graphql:'graphql',
+  json:'json',yaml:'yaml',yml:'yaml',toml:'toml',xml:'xml',
+  html:'markup',htm:'markup',svg:'markup',vue:'markup',
+  css:'css',scss:'scss',sass:'sass',less:'less',
+  md:'markdown',markdown:'markdown',
+  dockerfile:'docker',makefile:'makefile',cmake:'cmake',
+  ini:'ini',cfg:'ini',conf:'ini',properties:'properties',
+  diff:'diff',patch:'diff',
+  txt:'',log:'',csv:'',tsv:'',
+};
+function _prismLanguageForPath(path){
+  const ext=fileExt(path).replace(/^\./,'');
+  return _PRISM_LANG_MAP[ext]!==undefined?_PRISM_LANG_MAP[ext]:'plaintext';
+}
+
 async function openFile(path, opts={}){
   if(!S.session)return;
   const ext=fileExt(path);
@@ -614,7 +640,17 @@ async function openFile(path, opts={}){
         return;
       }
       showPreview('code');
-      $('previewCode').textContent=data.content;
+      // Syntax highlighting with Prism.js (already loaded on the page).
+      const codeEl=document.createElement('code');
+      codeEl.textContent=data.content;
+      const lang=_prismLanguageForPath(path);
+      if(lang) codeEl.className='language-'+lang;
+      const pre=$('previewCode');
+      pre.textContent='';
+      pre.appendChild(codeEl);
+      if(typeof Prism!=='undefined'&&typeof Prism.highlightElement==='function'){
+        Prism.highlightElement(codeEl);
+      }
     }catch(e){
       // If it's a 400/too-large error, offer download instead
       downloadFile(path);


### PR DESCRIPTION
## What

Workspace file preview now uses Prism.js for syntax highlighting. Files opened from the workspace panel display with language-aware color coding (keywords, strings, comments, etc.).

## Why

Previously `openFile()` used `textContent` to display code as plain text — zero highlighting. Prism.js was already loaded on the page for chat message code blocks but wasn't used by the workspace preview.

## How

- Added `_prismLanguageForPath()` mapping 40+ file extensions to Prism language identifiers
- `openFile()` creates `<code class="language-xxx">` inside the `<pre>` and calls `Prism.highlightElement()`
- Prism autoloader fetches missing language components from CDN on demand
- Added CSS override for `.preview-code code[class*="language-"]` background to match skin's `--code-bg`

## Stats

2 files, +38/-1. Zero new dependencies (reuses existing Prism.js + autoloader).
