### PR TITLE
fix: resolve issue #3340

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Added
+- Chat now shows a small success toast when an agent turn saves memory or creates/updates a skill, so persistent state changes are visible during normal WebUI turns (#3340).
+
 ## [v0.51.195] — 2026-06-01 — Release FO (stage-batch7 — hide attachment path markers in chat UI)
 
 ### Fixed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -61,6 +61,68 @@ _ENV_LOCK = threading.Lock()
 
 _KEYLESS_CUSTOM_API_KEY = "dummy-key"
 
+_PERSISTENT_MEMORY_FILES = (
+    ("memory", ("memories", "MEMORY.md")),
+    ("user", ("memories", "USER.md")),
+    ("soul", ("SOUL.md",)),
+)
+
+
+def _file_signature(path: Path) -> tuple[int, int] | None:
+    try:
+        st = path.stat()
+        return (int(st.st_mtime_ns), int(st.st_size))
+    except OSError:
+        return None
+
+
+def _persistent_state_snapshot(profile_home: str | None) -> dict:
+    """Capture lightweight memory/skill file signatures for save toasts."""
+    if not profile_home:
+        return {"memory": {}, "skills": {}}
+    root = Path(profile_home)
+    memory = {}
+    for key, parts in _PERSISTENT_MEMORY_FILES:
+        sig = _file_signature(root.joinpath(*parts))
+        if sig is not None:
+            memory[key] = sig
+    skills = {}
+    skills_dir = root / "skills"
+    try:
+        for skill_md in skills_dir.rglob("SKILL.md"):
+            try:
+                rel = str(skill_md.relative_to(skills_dir)).replace("\\", "/")
+            except ValueError:
+                rel = str(skill_md)
+            sig = _file_signature(skill_md)
+            if sig is not None:
+                skills[rel] = sig
+    except OSError:
+        pass
+    return {"memory": memory, "skills": skills}
+
+
+def _persistent_state_changes(before: dict | None, after: dict | None) -> dict:
+    before = before or {"memory": {}, "skills": {}}
+    after = after or {"memory": {}, "skills": {}}
+    memory_before = before.get("memory") or {}
+    memory_after = after.get("memory") or {}
+    skills_before = before.get("skills") or {}
+    skills_after = after.get("skills") or {}
+    memory_changed = any(memory_before.get(key) != sig for key, sig in memory_after.items())
+    skills = []
+    for rel, sig in skills_after.items():
+        old_sig = skills_before.get(rel)
+        if old_sig == sig:
+            continue
+        name = Path(rel).parent.name or Path(rel).stem
+        skills.append({
+            "name": name,
+            "path": rel,
+            "action": "created" if old_sig is None else "updated",
+        })
+    return {"memory_saved": memory_changed, "skills": skills[:10]}
+
 
 def _resolve_custom_provider_runtime_overrides(
     resolved_provider: str | None,
@@ -5222,6 +5284,7 @@ def _run_agent_streaming(
             if _process_notifications:
                 _agent_msg_text = "\n\n".join([*_process_notifications, msg_text]).strip()
             user_message = _build_native_multimodal_message(workspace_ctx, _agent_msg_text, attachments, workspace, cfg=_cfg)
+            _persistent_state_before = _persistent_state_snapshot(_profile_home)
             result = agent.run_conversation(
                 user_message=user_message,
                 system_message=workspace_system_msg,
@@ -6101,6 +6164,26 @@ def _run_agent_streaming(
                         mark_turn_completed(s.session_id, agent=agent)
                     except Exception:
                         logger.debug("Memory lifecycle mark failed for session %s", s.session_id, exc_info=True)
+                try:
+                    _persistent_changes = _persistent_state_changes(
+                        _persistent_state_before,
+                        _persistent_state_snapshot(_profile_home),
+                    )
+                    if _persistent_changes.get("memory_saved"):
+                        put("state_saved", {
+                            "session_id": session_id,
+                            "kind": "memory",
+                            "action": "saved",
+                        })
+                    for _skill_change in _persistent_changes.get("skills") or []:
+                        put("state_saved", {
+                            "session_id": session_id,
+                            "kind": "skill",
+                            "action": _skill_change.get("action") or "updated",
+                            "name": _skill_change.get("name") or "",
+                        })
+                except Exception:
+                    logger.debug("Persistent state change detection failed for session %s", s.session_id, exc_info=True)
             # Sync to state.db for /insights (opt-in setting)
             try:
                 from api.config import load_settings as _load_settings

--- a/static/messages.js
+++ b/static/messages.js
@@ -74,6 +74,94 @@ if(_msgEl) _msgEl.addEventListener('blur', ()=>{ if('speechSynthesis' in window 
 let _selectedTextReplyBtn=null;
 let _selectedTextReplyText='';
 let _selectedTextReplyRaf=0;
+const _persistentStateToastSeen=new Set();
+
+function _persistentToastText(value){
+  if(value===null||value===undefined)return '';
+  if(typeof value==='string')return value;
+  try{return JSON.stringify(value);}catch(_){return String(value||'');}
+}
+
+function _persistentToastToolName(tool){
+  return String(tool&&tool.name||'').trim();
+}
+
+function _persistentToastArgs(tool){
+  const args=tool&&tool.args;
+  return args&&typeof args==='object'?args:{};
+}
+
+function _persistentToastPreview(tool){
+  return [
+    _persistentToastText(tool&&tool.preview),
+    _persistentToastText(tool&&tool.snippet),
+  ].filter(Boolean).join('\n');
+}
+
+function _persistentToastHasWriteIntent(name, text){
+  const nameWords=String(name||'').replace(/_/g,' ');
+  const haystack=`${nameWords}\n${text}`.toLowerCase();
+  if(/\b(read|list|view|search|lookup|get|fetch|load|usage|toggle|delete|remove)\b/.test(nameWords))return false;
+  if(/\b(no|not|nothing)\s+(?:was\s+)?(?:saved|updated|created|written|stored|changed)\b/.test(haystack))return false;
+  if(/\b(?:unchanged|skipped|dry[- ]run|failed|error)\b/.test(haystack))return false;
+  return /\b(save|saved|write|wrote|written|update|updated|create|created|store|stored|persist|persisted|remember|remembered)\b/.test(haystack);
+}
+
+function _persistentToastSkillName(tool){
+  const args=_persistentToastArgs(tool);
+  const raw=args.name||args.skill_name||args.skill||args.title||'';
+  const direct=String(raw||'').trim();
+  if(direct)return direct;
+  const text=_persistentToastPreview(tool);
+  const match=text.match(/\bskill(?:\s+updated|\s+created|\s+saved)?\s*[:=]\s*["'`]?([A-Za-z0-9_.-]{2,80})/i);
+  return match?match[1]:'';
+}
+
+function _maybeNotifyPersistentStateSaved(tool){
+  if(!tool||tool.is_error||typeof showToast!=='function')return;
+  const name=_persistentToastToolName(tool);
+  if(!name)return;
+  const nameKey=name.toLowerCase().replace(/[^a-z0-9]+/g,'_');
+  const preview=_persistentToastPreview(tool);
+  const argsText=_persistentToastText(_persistentToastArgs(tool));
+  const text=`${preview}\n${argsText}`;
+  if(!_persistentToastHasWriteIntent(nameKey, text))return;
+
+  const nameWords=nameKey.replace(/_/g,' ');
+  const isSkill=/\bskills?\b/.test(nameWords);
+  const isMemory=/\b(memory|memories|remember|profile)\b/.test(nameWords);
+  if(!isSkill&&!isMemory)return;
+  const skillName=isSkill?_persistentToastSkillName(tool):'';
+  if(isSkill&&!skillName)return;
+  _showPersistentStateToast(isSkill?'skill':'memory', skillName, {
+    created: isSkill&&/\b(create|created|new)\b/.test(`${nameKey}\n${preview}`.toLowerCase()),
+  });
+}
+
+function _showPersistentStateToast(kind, name, options){
+  if(typeof showToast!=='function')return;
+  const normalizedKind=String(kind||'').toLowerCase();
+  if(normalizedKind!=='skill'&&normalizedKind!=='memory')return;
+  const itemName=String(name||'').trim();
+  const dedupeKey=[
+    S&&S.session&&S.session.session_id||'',
+    normalizedKind,
+    itemName||'memory',
+  ].join(':');
+  if(_persistentStateToastSeen.has(dedupeKey))return;
+  _persistentStateToastSeen.add(dedupeKey);
+  if(_persistentStateToastSeen.size>200){
+    const first=_persistentStateToastSeen.values().next().value;
+    _persistentStateToastSeen.delete(first);
+  }
+
+  if(normalizedKind==='skill'){
+    const base=options&&options.created?t('skill_created'):t('skill_updated');
+    showToast(itemName?`${base}: ${itemName}`:base,4200,'success');
+    return;
+  }
+  showToast(t('memory_saved'),3600,'success');
+}
 
 function _selectedTextReplyT(key, fallback){
   try{
@@ -1714,6 +1802,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(typeof noteWorkspaceMutationsFromToolCall==='function') noteWorkspaceMutationsFromToolCall(tc);
       if(S.session&&S.session.session_id===activeSid&&typeof scheduleRenderSessionArtifacts==='function') scheduleRenderSessionArtifacts();
       if(!S.session||S.session.session_id!==activeSid) return;
+      _maybeNotifyPersistentStateSaved(tc);
       if(typeof refreshOpenPreviewIfMutated==='function') refreshOpenPreviewIfMutated();
       appendLiveToolCard(tc);
       snapshotLiveTurn();
@@ -1732,6 +1821,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       showClarifyForSession(activeSid, d);
       playAttentionSound(_attentionSoundKey(activeSid,'clarify',1));
       sendBrowserNotification('Clarification needed',d.question||'Tool clarification needed');
+    });
+
+    source.addEventListener('state_saved',e=>{
+      let d={};
+      try{ d=JSON.parse(e.data||'{}'); }catch(_){}
+      if((d.session_id||activeSid)!==activeSid) return;
+      if(!S.session||S.session.session_id!==activeSid) return;
+      _showPersistentStateToast(d.kind, d.name||'', {created:String(d.action||'').toLowerCase()==='created'});
     });
 
     source.addEventListener('title',e=>{
@@ -2303,7 +2400,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _setActivePaneIdleIfOwner();
     });
 
-    for(const _runJournalEventName of ['token','interim_assistant','reasoning','tool','tool_complete','approval','clarify','title','title_status','context_status','goal','goal_continue','done','stream_end','pending_steer_leftover','compressing','compressed','metering','apperror','warning','error','cancel']){
+    for(const _runJournalEventName of ['token','interim_assistant','reasoning','tool','tool_complete','approval','clarify','state_saved','title','title_status','context_status','goal','goal_continue','done','stream_end','pending_steer_leftover','compressing','compressed','metering','apperror','warning','error','cancel']){
       source.addEventListener(_runJournalEventName,_rememberRunJournalCursor);
     }
   }

--- a/tests/test_issue3340_persistent_state_toasts.py
+++ b/tests/test_issue3340_persistent_state_toasts.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+STREAMING_PY = (ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
+CHANGELOG = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+
+def _tool_complete_listener_block() -> str:
+    start = MESSAGES_JS.index("source.addEventListener('tool_complete'")
+    end = MESSAGES_JS.index("source.addEventListener('approval'", start)
+    return MESSAGES_JS[start:end]
+
+
+def test_tool_complete_notifies_on_persistent_state_writes():
+    assert "function _maybeNotifyPersistentStateSaved(tool)" in MESSAGES_JS
+    block = _tool_complete_listener_block()
+
+    assert "_maybeNotifyPersistentStateSaved(tc);" in block
+    assert block.index("tc.is_error=!!d.is_error;") < block.index("_maybeNotifyPersistentStateSaved(tc);")
+    assert block.index("if(!S.session||S.session.session_id!==activeSid) return;") < block.index("_maybeNotifyPersistentStateSaved(tc);")
+    assert block.index("_maybeNotifyPersistentStateSaved(tc);") < block.index("refreshOpenPreviewIfMutated")
+
+
+def test_persistent_state_toast_classifier_is_write_only_and_deduped():
+    helper_start = MESSAGES_JS.index("function _persistentToastHasWriteIntent")
+    helper_end = MESSAGES_JS.index("function _persistentToastSkillName", helper_start)
+    helper = MESSAGES_JS[helper_start:helper_end]
+
+    assert "read|list|view|search|lookup|get|fetch|load|usage|toggle|delete|remove" in helper
+    assert "save|saved|write|wrote|written|update|updated|create|created|store|stored|persist|persisted|remember|remembered" in helper
+    assert "_persistentStateToastSeen.has(dedupeKey)" in MESSAGES_JS
+    assert "_persistentStateToastSeen.add(dedupeKey)" in MESSAGES_JS
+    assert "_showPersistentStateToast(isSkill?'skill':'memory'" in MESSAGES_JS
+    assert "if(isSkill&&!skillName)return;" in MESSAGES_JS
+
+
+def test_persistent_state_toasts_use_existing_user_visible_labels():
+    notify_start = MESSAGES_JS.index("function _maybeNotifyPersistentStateSaved")
+    notify_end = MESSAGES_JS.index("function _selectedTextReplyT", notify_start)
+    notify = MESSAGES_JS[notify_start:notify_end]
+
+    assert "t('memory_saved')" in notify
+    assert "t('skill_created')" in notify
+    assert "t('skill_updated')" in notify
+    assert "showToast(itemName?`${base}: ${itemName}`:base,4200,'success')" in notify
+    assert "showToast(t('memory_saved'),3600,'success')" in notify
+
+
+def test_backend_emits_state_saved_sse_from_file_snapshots():
+    assert "def _persistent_state_snapshot" in STREAMING_PY
+    assert "def _persistent_state_changes" in STREAMING_PY
+    assert '_persistent_state_before = _persistent_state_snapshot(_profile_home)' in STREAMING_PY
+    assert 'put("state_saved", {' in STREAMING_PY
+    assert '"kind": "memory"' in STREAMING_PY
+    assert '"kind": "skill"' in STREAMING_PY
+
+
+def test_frontend_handles_state_saved_sse_and_reuses_dedupe():
+    start = MESSAGES_JS.index("source.addEventListener('state_saved'")
+    end = MESSAGES_JS.index("source.addEventListener('title'", start)
+    block = MESSAGES_JS[start:end]
+
+    assert "_showPersistentStateToast(d.kind, d.name||''" in block
+    assert "String(d.action||'').toLowerCase()==='created'" in block
+    assert "if((d.session_id||activeSid)!==activeSid) return;" in block
+    assert "'state_saved'" in MESSAGES_JS
+
+
+def test_issue_3340_changelog_entry_present():
+    assert "#3340" in CHANGELOG
+    assert "saved memory" in CHANGELOG
+    assert "created/updated a skill" in CHANGELOG


### PR DESCRIPTION
This pull request adds a new feature that displays a small success toast notification in the chat UI whenever an agent turn saves memory or creates/updates a skill, making persistent state changes visible to users during normal WebUI turns. The implementation includes both backend detection of persistent state changes and frontend toast display logic, with tests to ensure correct behavior.

**Persistent State Change Detection and Notification:**

* The backend (`api/streaming.py`) now snapshots and compares key memory and skill files before and after each agent turn to detect if memory was saved or a skill was created/updated. When such changes are detected, a `state_saved` event is emitted via SSE with relevant details. [[1]](diffhunk://#diff-d81246f98c6b9443cd26d958c779cc59e76b75d4867bd90c3268856953cc4c39R64-R125) [[2]](diffhunk://#diff-d81246f98c6b9443cd26d958c779cc59e76b75d4867bd90c3268856953cc4c39R5287) [[3]](diffhunk://#diff-d81246f98c6b9443cd26d958c779cc59e76b75d4867bd90c3268856953cc4c39R6167-R6186)

* The frontend (`static/messages.js`) listens for `state_saved` events and displays a deduplicated toast notification to the user, using user-friendly labels for memory and skill changes. It also heuristically detects persistent state changes from tool calls for additional robustness. [[1]](diffhunk://#diff-b9e1f230f6a7e7a4a059a27f652dd4d69320d339394543c82976f6e9cebe02c2R77-R164) [[2]](diffhunk://#diff-b9e1f230f6a7e7a4a059a27f652dd4d69320d339394543c82976f6e9cebe02c2R1805) [[3]](diffhunk://#diff-b9e1f230f6a7e7a4a059a27f652dd4d69320d339394543c82976f6e9cebe02c2R1826-R1833) [[4]](diffhunk://#diff-b9e1f230f6a7e7a4a059a27f652dd4d69320d339394543c82976f6e9cebe02c2L2306-R2403)

**Testing and Documentation:**

* A new test file (`tests/test_issue3340_persistent_state_toasts.py`) verifies backend detection, frontend notification logic, deduplication, user-visible labels, and presence of a changelog entry.

* The changelog (`CHANGELOG.md`) documents the new feature for visibility.