### PR TITLE
v0.51.196: file-manager external sessions + artifacts tool metadata + edge-toggle icon + type hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 
 ## [Unreleased]
 
+## [v0.51.196] — 2026-06-01 — Release FP (stage-batch8 — file-manager external sessions + artifacts tool metadata + edge-toggle icon + type hints)
+
+### Fixed
+- File manager (folder download, raw file fetch, and related handlers) now falls back to a `state.db` lookup for sessions created by Telegram/CLI rather than the WebUI, resolving them against the active WebUI workspace instead of returning a 404. Closes #3280 (#3314, @Sanjays2402).
+- Artifacts tab now detects files from structured `tool_calls` (OpenAI format) and `tool_use` content blocks (Anthropic format) on messages, not just text-mined diff fences, so artifacts surface even when `S.toolCalls` is cleared after a reload; display paths are trimmed of the workspace prefix (#3329, @mysoul12138).
+- Workspace panel edge-toggle chevron now points left (toward the panel it reveals) instead of right (#3318, @xz-dev).
+
+### Internal
+- `api/state_sync.py` now uses `Optional[T]` annotations for parameters defaulting to `None` instead of the implicit `T = None` form (#3323, @kuishou68).
+
 ## [v0.51.195] — 2026-06-01 — Release FO (stage-batch7 — hide attachment path markers in chat UI)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -2655,6 +2655,68 @@ def _refresh_index_rows_from_sidecar_metadata(sessions: list[dict]) -> list[dict
     return out
 
 
+def state_db_has_session(sid: str) -> bool:
+    """Return True when ``sid`` exists in the active state.db sessions table.
+
+    Used by file-manager handlers to fall back to a state.db lookup when
+    ``get_session`` raises ``KeyError`` because the session was created by
+    Telegram/CLI (external) rather than the WebUI (issue #3280). The state.db
+    schema stores only metadata (id/title/model/source/...), not a workspace
+    path — the workspace is shared across session storage backends and is
+    resolved separately via ``get_last_workspace()``.
+    """
+    if not sid:
+        return False
+    try:
+        import sqlite3
+    except ImportError:
+        return False
+    db_path = _active_state_db_path()
+    if not db_path.exists():
+        return False
+    try:
+        with closing(sqlite3.connect(str(db_path))) as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT 1 FROM sessions WHERE id = ? LIMIT 1", (str(sid),))
+            return cur.fetchone() is not None
+    except Exception:
+        return False
+
+
+class _ExternalSessionView:
+    """Minimal session-shaped view for external (Telegram/CLI) sessions.
+
+    Only exposes the fields file-manager handlers need (``session_id`` and
+    ``workspace``). The workspace falls back to the WebUI's last-used
+    workspace because state.db does not persist a per-session workspace path
+    and the file browser is intentionally workspace-scoped, not
+    session-storage-scoped (issue #3280).
+    """
+
+    __slots__ = ("session_id", "workspace")
+
+    def __init__(self, session_id: str, workspace: str):
+        self.session_id = session_id
+        self.workspace = workspace
+
+
+def get_session_for_file_ops(sid: str):
+    """Return a session-like object for file-manager handlers.
+
+    Tries ``get_session`` first (preserves all existing behavior for WebUI
+    sessions). If that raises ``KeyError``, checks state.db; when the session
+    exists there, returns an ``_ExternalSessionView`` whose ``workspace`` is
+    the active WebUI workspace. If neither has the session, re-raises
+    ``KeyError`` so callers continue to return their existing 404.
+    """
+    try:
+        return get_session(sid, metadata_only=True)
+    except KeyError:
+        if state_db_has_session(sid):
+            return _ExternalSessionView(str(sid), str(get_last_workspace()))
+        raise
+
+
 def _active_state_db_path() -> Path:
     """Return state.db for the active Hermes profile, degrading to HERMES_HOME."""
     try:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2801,6 +2801,7 @@ def _keep_latest_messaging_session_per_source(
 from api.models import (
     Session,
     get_session,
+    get_session_for_file_ops,
     new_session,
     all_sessions,
     title_from,
@@ -8579,7 +8580,7 @@ def _handle_folder_download(handler, parsed):
     if not sid:
         return bad(handler, "session_id is required")
     try:
-        s = get_session(sid)
+        s = get_session_for_file_ops(sid)
     except KeyError:
         return bad(handler, "Session not found", 404)
 
@@ -8652,7 +8653,7 @@ def _handle_file_raw(handler, parsed):
     if not sid:
         return bad(handler, "session_id is required")
     try:
-        s = get_session(sid)
+        s = get_session_for_file_ops(sid)
     except KeyError:
         return bad(handler, "Session not found", 404)
     rel = qs.get("path", [""])[0]
@@ -8691,7 +8692,7 @@ def _handle_file_read(handler, parsed):
     if not sid:
         return bad(handler, "session_id is required")
     try:
-        s = get_session(sid)
+        s = get_session_for_file_ops(sid)
     except KeyError:
         return bad(handler, "Session not found", 404)
     rel = qs.get("path", [""])[0]
@@ -11012,7 +11013,7 @@ def _handle_file_delete(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session(body["session_id"])
+        s = get_session_for_file_ops(body["session_id"])
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -11036,7 +11037,7 @@ def _handle_file_save(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session(body["session_id"])
+        s = get_session_for_file_ops(body["session_id"])
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -11059,7 +11060,7 @@ def _handle_file_create(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session(body["session_id"])
+        s = get_session_for_file_ops(body["session_id"])
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -11081,7 +11082,7 @@ def _handle_file_rename(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session(body["session_id"])
+        s = get_session_for_file_ops(body["session_id"])
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -11107,7 +11108,7 @@ def _handle_create_dir(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session(body["session_id"])
+        s = get_session_for_file_ops(body["session_id"])
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -11128,7 +11129,7 @@ def _handle_file_reveal(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session(body["session_id"])
+        s = get_session_for_file_ops(body["session_id"])
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -11175,7 +11176,7 @@ def _handle_file_path(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session(body["session_id"])
+        s = get_session_for_file_ops(body["session_id"])
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -11205,7 +11206,7 @@ def _handle_file_open_vscode(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session(body["session_id"])
+        s = get_session_for_file_ops(body["session_id"])
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:

--- a/api/state_sync.py
+++ b/api/state_sync.py
@@ -16,11 +16,12 @@ any double-counting risk.
 import logging
 import os
 from pathlib import Path
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
-def _get_state_db(profile: str=None):
+def _get_state_db(profile: Optional[str] = None):
     """Get a SessionDB instance for a profile's state.db.
 
     When ``profile`` is provided the function resolves *that* profile's
@@ -104,7 +105,7 @@ def _get_state_db(profile: str=None):
         return None
 
 
-def sync_session_start(session_id: str, model=None, profile: str=None) -> None:
+def sync_session_start(session_id: str, model=None, profile: Optional[str] = None) -> None:
     """Register a WebUI session in state.db (idempotent).
     Called when a session's first message is sent.
 
@@ -132,8 +133,8 @@ def sync_session_start(session_id: str, model=None, profile: str=None) -> None:
 
 
 def sync_session_usage(session_id: str, input_tokens: int=0, output_tokens: int=0,
-                       estimated_cost=None, model=None, title: str=None,
-                       message_count: int=None, profile: str=None) -> None:
+                       estimated_cost=None, model=None, title: Optional[str] = None,
+                       message_count: Optional[int] = None, profile: Optional[str] = None) -> None:
     """Update token usage and title for a WebUI session in state.db.
     Called after each turn completes. Uses absolute=True to set totals
     (the WebUI Session already accumulates across turns).

--- a/static/index.html
+++ b/static/index.html
@@ -1323,7 +1323,7 @@
     </div>
   </main>
   <button class="workspace-panel-edge-toggle has-tooltip has-tooltip--left" id="btnWorkspacePanelEdgeToggle" type="button" onclick="toggleWorkspacePanel(true)" data-tooltip="Show workspace panel" aria-label="Show workspace panel" aria-expanded="false">
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
   </button>
   <aside class="rightpanel">
     <div class="resize-handle" id="rightpanelResize"></div>

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -268,12 +268,41 @@ function collectSessionArtifacts(){
     if(!path || seen.has(path)) return;
     seen.add(path); items.push({path, source});
   };
+  // Source 1: session-level tool call summaries (may be empty when messages
+  // carry their own tool metadata — see _syncToolCallsForLoadedMessages).
   for(const tc of (S.toolCalls || [])){
     for(const a of _artifactCandidatesFromToolCall(tc)) push(a.path, a.kind || tc.name || 'tool');
   }
+  // Source 2 & 3: message-level data — both text-mined diffs and structured
+  // tool_calls / tool_use content blocks that survive the S.toolCalls clear.
   for(const msg of (S.messages || [])){
-    const text = msg && (msg.content || msg.text || msg.message || '');
-    for(const a of _artifactCandidatesFromText(text)) push(a.path, a.kind);
+    if(!msg) continue;
+    const text = msg.content || msg.text || msg.message || '';
+    // Text-mined diff/patch fences (existing path).
+    if(typeof text === 'string'){
+      for(const a of _artifactCandidatesFromText(text)) push(a.path, a.kind);
+    }
+    // Structured tool_calls array (OpenAI format: {function:{name,arguments}}).
+    if(Array.isArray(msg.tool_calls)){
+      for(const tc of msg.tool_calls){
+        const fn = tc.function || tc;
+        const name = fn.name || tc.name || '';
+        let args = fn.arguments || tc.arguments || tc.args || tc.input || {};
+        if(typeof args === 'string'){ try{ args = JSON.parse(args); }catch(_){} }
+        const fakeTc = {name, args, result: tc.result || tc.output || ''};
+        for(const a of _artifactCandidatesFromToolCall(fakeTc)) push(a.path, a.kind || name || 'tool');
+      }
+    }
+    // Structured content array with tool_use blocks (Anthropic format).
+    if(Array.isArray(msg.content)){
+      for(const block of msg.content){
+        if(!block || block.type !== 'tool_use') continue;
+        let inp = block.input || {};
+        if(typeof inp === 'string'){ try{ inp = JSON.parse(inp); }catch(_){} }
+        const fakeTc = {name: block.name || '', args: inp, result: block.result || ''};
+        for(const a of _artifactCandidatesFromToolCall(fakeTc)) push(a.path, a.kind || block.name || 'tool');
+      }
+    }
   }
   return items.slice(0, 50);
 }
@@ -292,7 +321,14 @@ function renderSessionArtifacts(){
     root.innerHTML = '<div class="workspace-artifact-empty">No artifacts detected yet. Files created or edited during this session will appear here.</div>';
     return;
   }
-  root.innerHTML = items.map(item => `<button type="button" class="workspace-artifact-item" data-artifact-path="${esc(item.path)}" onclick="openArtifactPath(this.dataset.artifactPath)"><div class="workspace-artifact-path">${esc(item.path)}</div><div class="workspace-artifact-meta">${esc(item.source || 'session')}</div></button>`).join('');
+  // Strip workspace prefix for display so long absolute paths don't clutter the list.
+  const ws = S.session && S.session.workspace;
+  const normWs = ws ? ws.replace(/\/+$/,'') + '/' : '';
+  const displayPath = (p) => {
+    if(normWs && p.startsWith(normWs)) return p.slice(normWs.length);
+    return p;
+  };
+  root.innerHTML = items.map(item => `<button type="button" class="workspace-artifact-item" data-artifact-path="${esc(item.path)}" onclick="openArtifactPath(this.dataset.artifactPath)"><div class="workspace-artifact-path">${esc(displayPath(item.path))}</div><div class="workspace-artifact-meta">${esc(item.source || 'session')}</div></button>`).join('');
 }
 
 async function _workspacePathExists(path){
@@ -308,7 +344,15 @@ async function _workspacePathExists(path){
 async function openArtifactPath(path){
   if(!path) return;
   switchWorkspacePanelTab('files');
-  const rel = path.replace(/^~\//,'').replace(/^\.\//,'');
+  let rel = path.replace(/^~\//,'').replace(/^\.\/+/,'');
+  // Strip workspace prefix so /api/list receives a workspace-relative path.
+  const ws = S.session && S.session.workspace;
+  if(ws){
+    const normWs = ws.replace(/\/+$/,'') + '/';
+    if(rel.startsWith(normWs)) rel = rel.slice(normWs.length);
+    else if(rel === ws.replace(/\/+$/,'')) rel = '.';
+  }
+  if(!rel) rel = '.';
   try{
     if(!(await _workspacePathExists(rel))){
       setStatus(t('file_open_failed'));

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -285,7 +285,8 @@ function collectSessionArtifacts(){
     // Structured tool_calls array (OpenAI format: {function:{name,arguments}}).
     if(Array.isArray(msg.tool_calls)){
       for(const tc of msg.tool_calls){
-        const fn = tc.function || tc;
+        if(!tc || typeof tc !== 'object') continue;
+        const fn = (tc.function && typeof tc.function === 'object') ? tc.function : tc;
         const name = fn.name || tc.name || '';
         let args = fn.arguments || tc.arguments || tc.args || tc.input || {};
         if(typeof args === 'string'){ try{ args = JSON.parse(args); }catch(_){} }

--- a/tests/test_file_manager_external_session.py
+++ b/tests/test_file_manager_external_session.py
@@ -1,0 +1,185 @@
+"""Regression tests for #3280 — file manager falls back to state.db for
+external (Telegram/CLI) sessions instead of returning 404.
+
+Covers:
+  (a) WebUI session — existing behavior preserved (get_session path).
+  (b) state.db-only session — fallback returns a workspace-bearing view.
+  (c) Unknown session — KeyError still propagates so callers 404.
+  (d) Static check: every file-manager handler in api/routes.py calls
+      get_session_for_file_ops, not the raw get_session.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTES_PY = ROOT / "api" / "routes.py"
+
+
+FILE_HANDLERS = [
+    "_handle_folder_download",
+    "_handle_file_raw",
+    "_handle_file_read",
+    "_handle_file_delete",
+    "_handle_file_save",
+    "_handle_file_create",
+    "_handle_file_rename",
+    "_handle_create_dir",
+    "_handle_file_reveal",
+    "_handle_file_path",
+    "_handle_file_open_vscode",
+]
+
+
+def _handler_body(src: str, name: str) -> str:
+    start = src.index(f"def {name}(")
+    # next top-level def or class
+    m = re.search(r"\n(?:def |class )", src[start + 1 :])
+    end = (start + 1 + m.start()) if m else len(src)
+    return src[start:end]
+
+
+def test_routes_file_handlers_use_fallback():
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    assert "get_session_for_file_ops" in src, "fallback helper must be imported"
+    missing = []
+    for name in FILE_HANDLERS:
+        body = _handler_body(src, name)
+        # Must not call get_session(...) directly inside the handler.
+        # (get_session_for_file_ops also contains "get_session(" as a substring,
+        # so check word-boundary occurrences.)
+        bare = re.findall(r"(?<!_)\bget_session\(", body)
+        # Strip occurrences that are actually get_session_for_file_ops( — the
+        # regex above already excludes underscore prefix, so any remaining
+        # match is a raw get_session call.
+        if bare:
+            missing.append(name)
+    assert not missing, f"raw get_session() still used in: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Functional tests against api.models.get_session_for_file_ops
+# ---------------------------------------------------------------------------
+
+pytestmark_models = pytest.mark.requires_agent_modules
+
+
+def _make_state_db(path: Path, sid: str) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            title TEXT,
+            model TEXT,
+            message_count INTEGER DEFAULT 0,
+            started_at TEXT,
+            source TEXT
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp TEXT
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO sessions (id, title, model, message_count, started_at, source) "
+        "VALUES (?, 'telegram session', 'gpt-x', 1, '2026-01-01T00:00:00Z', 'telegram')",
+        (sid,),
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def models_module():
+    return pytest.importorskip("api.models")
+
+
+def test_get_session_for_file_ops_webui_passthrough(models_module, monkeypatch):
+    """(a) WebUI session — delegates to get_session, no state.db consulted."""
+    sentinel = object()
+    called = {"get_session": 0, "state_db": 0}
+
+    def fake_get_session(sid, metadata_only=False):
+        called["get_session"] += 1
+        return sentinel
+
+    def fake_has(_sid):
+        called["state_db"] += 1
+        return True
+
+    monkeypatch.setattr(models_module, "get_session", fake_get_session)
+    monkeypatch.setattr(models_module, "state_db_has_session", fake_has)
+    result = models_module.get_session_for_file_ops("webui-sid")
+    assert result is sentinel
+    assert called == {"get_session": 1, "state_db": 0}
+
+
+def test_get_session_for_file_ops_state_db_fallback(
+    models_module, monkeypatch, tmp_path
+):
+    """(b) state.db-only session — returns view with workspace populated."""
+    db = tmp_path / "state.db"
+    _make_state_db(db, "tg-123")
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "hello.txt").write_text("hi from telegram session")
+
+    def raise_key(sid, metadata_only=False):
+        raise KeyError(sid)
+
+    monkeypatch.setattr(models_module, "get_session", raise_key)
+    monkeypatch.setattr(models_module, "_active_state_db_path", lambda: db)
+    monkeypatch.setattr(
+        models_module, "get_last_workspace", lambda: str(workspace)
+    )
+
+    view = models_module.get_session_for_file_ops("tg-123")
+    assert view.session_id == "tg-123"
+    assert Path(view.workspace) == workspace
+    # The workspace is real and readable — file-manager handlers will
+    # successfully serve files relative to it instead of returning 404.
+    assert (Path(view.workspace) / "hello.txt").read_text() == "hi from telegram session"
+
+
+def test_get_session_for_file_ops_unknown_session_raises(
+    models_module, monkeypatch, tmp_path
+):
+    """(c) Unknown session — KeyError propagates so callers still 404."""
+    db = tmp_path / "state.db"
+    _make_state_db(db, "tg-123")
+
+    def raise_key(sid, metadata_only=False):
+        raise KeyError(sid)
+
+    monkeypatch.setattr(models_module, "get_session", raise_key)
+    monkeypatch.setattr(models_module, "_active_state_db_path", lambda: db)
+    monkeypatch.setattr(models_module, "get_last_workspace", lambda: str(tmp_path))
+
+    with pytest.raises(KeyError):
+        models_module.get_session_for_file_ops("does-not-exist")
+
+
+def test_state_db_has_session_missing_db(models_module, monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        models_module, "_active_state_db_path", lambda: tmp_path / "missing.db"
+    )
+    assert models_module.state_db_has_session("any") is False
+
+
+def test_state_db_has_session_present(models_module, monkeypatch, tmp_path):
+    db = tmp_path / "state.db"
+    _make_state_db(db, "cli-9")
+    monkeypatch.setattr(models_module, "_active_state_db_path", lambda: db)
+    assert models_module.state_db_has_session("cli-9") is True
+    assert models_module.state_db_has_session("nope") is False

--- a/tests/test_issue3329_artifact_tool_metadata_guard.py
+++ b/tests/test_issue3329_artifact_tool_metadata_guard.py
@@ -1,0 +1,101 @@
+"""Regression: collectSessionArtifacts() tolerates malformed tool_calls entries (#3329).
+
+#3329 taught the Artifacts tab to read structured tool metadata from messages
+(OpenAI `tool_calls` + Anthropic `tool_use` content blocks) in addition to
+text-mined diff fences. The pre-release Codex regression gate flagged that the
+OpenAI `tool_calls` loop dereferenced ``tc.function`` with no null/type guard,
+so a session whose persisted ``message.tool_calls`` array contained a null or
+non-object entry (truncated/corrupt sidecar, partial stream) would throw
+"Cannot read properties of null", aborting artifact collection for the whole
+session. The Anthropic `tool_use` loop already had a ``if(!block ...) continue``
+guard; this test pins the symmetric guard on the OpenAI loop.
+
+Drives the ACTUAL collectSessionArtifacts() from static/workspace.js via node
+(with its private helpers + a stubbed ``S``) so it cannot drift from a mirror.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+WORKSPACE_JS = (REPO / "static" / "workspace.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _extract_fn(name: str) -> str:
+    start = WORKSPACE_JS.index(f"function {name}(")
+    brace = WORKSPACE_JS.index("{", start)
+    depth = 0
+    for i in range(brace, len(WORKSPACE_JS)):
+        c = WORKSPACE_JS[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return WORKSPACE_JS[start:i + 1]
+    raise AssertionError(f"function {name} did not close")
+
+
+def _collect_via_node(messages):
+    # Pull in the function under test plus the helpers it transitively calls.
+    import re
+    consts = []
+    for name in ("ARTIFACT_IGNORE_RE", "ARTIFACT_MUTATION_TOOLS"):
+        m = re.search(rf"const {name} = .*?;", WORKSPACE_JS)
+        assert m, f"{name} not found"
+        consts.append(m.group(0))
+    fns = "\n".join(consts) + "\n" + "\n".join(
+        _extract_fn(n)
+        for n in (
+            "_normalizeArtifactPath",
+            "_artifactCandidatesFromText",
+            "_artifactCandidatesFromToolCall",
+            "collectSessionArtifacts",
+        )
+    )
+    driver = (
+        "const S = { toolCalls: [], messages: JSON.parse(process.argv[1]), "
+        "session: { workspace: '/ws' } };\n"
+        + fns + "\n"
+        + "const out = collectSessionArtifacts();\n"
+        + "process.stdout.write(JSON.stringify(out.map(x => x.path)));\n"
+    )
+    r = subprocess.run(
+        [NODE, "-e", driver, json.dumps(messages)],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert r.returncode == 0, f"node threw (the #3329 guard regressed): {r.stderr}"
+    return json.loads(r.stdout)
+
+
+def test_malformed_tool_calls_entries_do_not_throw():
+    """A null / non-object tool_calls entry must be skipped, not throw."""
+    messages = [
+        {"tool_calls": [
+            None,
+            "not-an-object",
+            42,
+            {"function": {"name": "edit_file", "arguments": json.dumps({"path": "real.py"})}},
+        ]},
+    ]
+    # The assertion that matters is that node returns 0 (no throw). The valid
+    # entry's path extraction depends on _artifactCandidatesFromToolCall's
+    # argument heuristics, which we don't pin here — only the no-throw guarantee.
+    paths = _collect_via_node(messages)
+    assert isinstance(paths, list)
+
+
+def test_guard_present_in_source():
+    """Pin the explicit guard so it can't be silently removed."""
+    fn = _extract_fn("collectSessionArtifacts")
+    assert "if(!tc || typeof tc !== 'object') continue;" in fn, (
+        "OpenAI tool_calls loop must guard malformed entries before "
+        "dereferencing tc.function (#3329 Codex regression-gate finding)"
+    )


### PR DESCRIPTION
## v0.51.196 — file-manager external sessions + artifacts tool metadata + edge-toggle icon + type hints

Batch of 4 contributor PRs reviewed, fixed, and tested end-to-end (stage-batch8).

### Included PRs
| PR | Title | Author | Notes |
|----|-------|--------|-------|
| #3314 | File manager falls back to state.db for external Telegram/CLI sessions | @Sanjays2402 | Closes #3280. Backend fallback: tries `get_session` first, only falls through to a state.db probe on `KeyError`, resolves to the active WebUI workspace; preserves existing 404. |
| #3329 | Artifacts tab reads structured tool metadata | @mysoul12138 | Detects `tool_calls` (OpenAI) + `tool_use` blocks (Anthropic) on messages, not just text-mined diffs. **Maintainer fix applied:** added a null/type guard on malformed `tool_calls` entries (Codex regression-gate finding) + a node-driven regression test. |
| #3318 | Workspace panel edge-toggle chevron direction | @xz-dev | One-line SVG flip — chevron now points toward the panel it reveals. |
| #3323 | `Optional[T]` type hints in api/state_sync.py | @kuishou68 | Pure annotation cleanup, no runtime change. |

### Gate results
- Pre-Opus gate: JS `node -c` ✓, ESLint runtime gate ✓, ruff forward gate ✓, no merge markers, CHANGELOG `[Unreleased]` empty
- pytest (full sequential, `-p no:xdist`): **7153 passed, 7 skipped, 3 xpassed, 0 failed**
- Opus advisor: no blocking issues — #3314 fallback verified safe (cannot expose files the authenticated user can't already reach, path traversal blocked, workspace resolution matches pre-existing `/api/list`)
- Codex regression gate: **SAFE TO SHIP** (after the #3329 guard fix was applied + re-verified on stage HEAD)
