### PR TITLE
v0.51.197: stop agent replaying edited/undone messages (#3102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.197] — 2026-06-01 — Release FQ (stage-batch9 — stop agent replaying edited/undone messages)
+
+### Fixed
+- Editing or undoing a message no longer lets the agent replay the original pre-edit content from `state.db`: the truncation-watermark filter now also skips replaced/stale rows whose timestamp sorts *below* the watermark, and `POST /api/session/truncate` truncates `context_messages` in sync with `messages` so the agent's context matches the visible transcript after Edit/Regenerate. The earlier `_clamp_context_to_watermark()` approach (which turned the watermark into a permanent ceiling that dropped every new turn) is removed. Closes #2914 (#3102, @AlexeyDsov).
+
 ## [v0.51.196] — 2026-06-01 — Release FP (stage-batch8 — file-manager external sessions + artifacts tool metadata + edge-toggle icon + type hints)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -4056,11 +4056,27 @@ def merge_session_messages_append_only(
                     skipped_state_visible_counts.get(matched_visible_key, 0) + 1
                 )
             continue
+        # Skip rows ABOVE the watermark only while the sidecar has NOT advanced
+        # past the watermark. Because Session.save() no longer auto-clears the
+        # watermark, an unconditional `timestamp > watermark` skip would become
+        # permanent and silently drop legitimate future state.db-only recovery
+        # rows once the session moves forward past the edit boundary. Once the
+        # sidecar's own max timestamp is beyond the watermark (the session has
+        # advanced), allow state rows newer than the sidecar tail to merge.
+        sidecar_advanced_past_watermark = (
+            watermark_timestamp is not None
+            and max_sidecar_timestamp is not None
+            and max_sidecar_timestamp > watermark_timestamp
+        )
         if (
             watermark_timestamp is not None
             and timestamp is not None
             and timestamp > watermark_timestamp
             and key not in seen_message_keys
+            and (
+                not sidecar_advanced_past_watermark
+                or (max_sidecar_timestamp is not None and timestamp <= max_sidecar_timestamp)
+            )
         ):
             continue
         # When a truncation watermark is active, state.db may contain original

--- a/api/models.py
+++ b/api/models.py
@@ -637,18 +637,6 @@ class Session:
     def path(self):
         return SESSION_DIR / f'{self.session_id}.json'
 
-    def _maybe_clear_truncation_watermark(self) -> None:
-        watermark = _message_timestamp_as_float({"timestamp": self.truncation_watermark})
-        if watermark is None:
-            return
-        max_message_timestamp = None
-        for msg in self.messages or []:
-            timestamp = _message_timestamp_as_float(msg)
-            if timestamp is not None:
-                max_message_timestamp = timestamp if max_message_timestamp is None else max(max_message_timestamp, timestamp)
-        if max_message_timestamp is not None and max_message_timestamp > watermark:
-            self.truncation_watermark = None
-
     def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
@@ -671,7 +659,6 @@ class Session:
             )
         if touch_updated_at:
             self.updated_at = time.time()
-        self._maybe_clear_truncation_watermark()
         # Write metadata fields first so load_metadata_only() can read them
         # without parsing the full messages array (which may be 400KB+).
         # Fields are listed in the order they should appear in the JSON file.
@@ -4074,6 +4061,20 @@ def merge_session_messages_append_only(
             and timestamp is not None
             and timestamp > watermark_timestamp
             and key not in seen_message_keys
+        ):
+            continue
+        # When a truncation watermark is active, state.db may contain original
+        # messages that were replaced by Edit (old content with old timestamp).
+        # The timestamp-based filter above catches messages AFTER the watermark,
+        # but messages BEFORE it (like the original pre-edit content) slip through.
+        # If a state.db message's content is not present in the sidecar and its
+        # timestamp is before the watermark, it's a replaced/stale row — skip it.
+        if (
+            watermark_timestamp is not None
+            and timestamp is not None
+            and timestamp < watermark_timestamp
+            and key not in seen_message_keys
+            and _session_message_content_key(msg) not in seen_content_keys
         ):
             continue
         if max_sidecar_timestamp is not None and timestamp is not None and timestamp <= max_sidecar_timestamp:

--- a/api/routes.py
+++ b/api/routes.py
@@ -6058,13 +6058,28 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, "Session not found", 404)
         keep = int(body["keep_count"])
         with _get_session_agent_lock(body["session_id"]):
+            old_msg_count = len(s.messages or [])
+            old_ctx_count = len(getattr(s, 'context_messages', None) or [])
             s.messages = s.messages[:keep]
+            # Truncate context_messages in sync with messages so the agent's
+            # model-facing context doesn't retain rows the user removed via
+            # Edit / Regenerate.  Without this, context_messages still contains
+            # the full pre-truncation history and the agent sees "deleted"
+            # turns on the next turn (#2914).
+            if isinstance(getattr(s, 'context_messages', None), list):
+                s.context_messages = s.context_messages[:keep]
             try:
                 from api.session_ops import _truncation_watermark_for
                 s.truncation_watermark = _truncation_watermark_for(s.messages)
             except Exception:
                 s.truncation_watermark = 0.0
             s.save()
+            logger.info(
+                "truncate %s: messages %d→%d, context_messages %d→%d, watermark=%.2f",
+                body["session_id"], old_msg_count, len(s.messages or []),
+                old_ctx_count, len(getattr(s, 'context_messages', None) or []),
+                s.truncation_watermark or 0,
+            )
         return j(
             handler, {"ok": True, "session": s.compact() | {"messages": s.messages}}
         )

--- a/tests/test_issue2914_truncation_watermark.py
+++ b/tests/test_issue2914_truncation_watermark.py
@@ -74,3 +74,537 @@ def test_undo_persists_truncation_watermark_at_new_tail(monkeypatch, tmp_path):
     assert loaded is not None
     assert [m["content"] for m in loaded.messages] == ["first", "reply first"]
     assert loaded.truncation_watermark == 2.0
+
+
+def test_truncate_endpoint_also_truncates_context_messages(monkeypatch, tmp_path):
+    """POST /api/session/truncate must truncate context_messages in sync with
+    messages so the agent's model-facing context doesn't retain rows the user
+    removed via Edit / Regenerate (#2914).
+
+    Integration test: calls the real handle_post route, not a simulation.
+    """
+    import json
+    from io import BytesIO
+    from types import SimpleNamespace
+
+    import api.models as models
+    import api.routes as routes
+    from api.models import Session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    session = Session(
+        session_id="issue2914truncate",
+        messages=[
+            _msg("user", "first", 1.0, "u1"),
+            _msg("assistant", "reply first", 2.0, "a1"),
+            _msg("user", "second", 3.0, "u2"),
+            _msg("assistant", "reply second", 4.0, "a2"),
+        ],
+        context_messages=[
+            _msg("user", "first", 1.0, "u1"),
+            _msg("assistant", "reply first", 2.0, "a1"),
+            _msg("user", "second", 3.0, "u2"),
+            _msg("assistant", "reply second", 4.0, "a2"),
+        ],
+    )
+    session.save()
+
+    # Call the real truncate endpoint via handle_post
+    body = {"session_id": "issue2914truncate", "keep_count": 2}
+    body_bytes = json.dumps(body).encode()
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+
+    captured_response = {}
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured_response["payload"] = payload
+    monkeypatch.setattr(routes, "j", fake_j)
+
+    handler = SimpleNamespace(
+        headers={"Content-Length": str(len(body_bytes))},
+        rfile=BytesIO(body_bytes),
+    )
+    routes.handle_post(handler, SimpleNamespace(path="/api/session/truncate"))
+
+    assert captured_response["payload"].get("ok") is True
+
+    loaded = Session.load("issue2914truncate")
+    assert loaded is not None
+    assert [m["content"] for m in loaded.messages] == ["first", "reply first"]
+    assert [m["content"] for m in loaded.context_messages] == ["first", "reply first"]
+    assert loaded.truncation_watermark == 2.0
+
+
+def test_truncate_without_context_messages_truncation_leaks_to_agent(monkeypatch, tmp_path):
+    """Prove the bug: if context_messages is NOT truncated, agent sees old rows."""
+    import api.models as models
+    from api.models import Session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    session = Session(
+        session_id="issue2914leak",
+        messages=[
+            _msg("user", "first", 1.0, "u1"),
+            _msg("assistant", "reply first", 2.0, "a1"),
+            _msg("user", "second", 3.0, "u2"),
+            _msg("assistant", "reply second", 4.0, "a2"),
+        ],
+        context_messages=[
+            _msg("user", "first", 1.0, "u1"),
+            _msg("assistant", "reply first", 2.0, "a1"),
+            _msg("user", "second", 3.0, "u2"),
+            _msg("assistant", "reply second", 4.0, "a2"),
+        ],
+    )
+    session.save()
+
+    # BUGGY path: truncate messages but NOT context_messages
+    from api.config import _get_session_agent_lock
+    with _get_session_agent_lock("issue2914leak"):
+        keep = 2
+        session.messages = session.messages[:keep]
+        # Intentionally NOT truncating context_messages (the old buggy behavior)
+        try:
+            from api.session_ops import _truncation_watermark_for
+            session.truncation_watermark = _truncation_watermark_for(session.messages)
+        except Exception:
+            session.truncation_watermark = 0.0
+        session.save()
+
+    loaded = Session.load("issue2914leak")
+    # messages is truncated correctly
+    assert [m["content"] for m in loaded.messages] == ["first", "reply first"]
+    # But context_messages still has all 4 — agent will see "second" and "reply second"
+    assert [m["content"] for m in loaded.context_messages] == [
+        "first", "reply first", "second", "reply second"
+    ]
+
+
+def test_edit_then_new_turn_then_undo_leaks_original_via_state_db(monkeypatch, tmp_path):
+    """Reproduce #2914: Edit changes message content but original stays in state.db.
+
+    Scenario:
+    1. Send "triangle" (ts=100)
+    2. Edit to "square" (ts=200, watermark=200)
+    3. Send "light speed" (ts=300)
+    4. Undo (removes "light speed", watermark=200)
+    5. Send "list all" — agent sees original "triangle" from state.db
+
+    Root cause: watermark filters m_ts > watermark, but original "triangle"
+    has ts=100 < watermark=200, so it passes through.
+    """
+    import api.models as models
+    from api.models import Session, reconciled_state_db_messages_for_session
+    from api.session_ops import undo_last
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    # Step 1: Initial message "triangle"
+    session = Session(
+        session_id="edit_undo_leak",
+        messages=[
+            _msg("user", "triangle", 100.0, "u1"),
+            _msg("assistant", "180°", 101.0, "a1"),
+        ],
+        context_messages=[
+            _msg("user", "triangle", 100.0, "u1"),
+            _msg("assistant", "180°", 101.0, "a1"),
+        ],
+    )
+    session.save()
+
+    # state.db has the original message
+    state_db = [
+        _msg("user", "triangle", 100.0, "state-u1"),
+        _msg("assistant", "180°", 101.0, "state-a1"),
+    ]
+
+    # Step 2: Edit "triangle" → "square" (new timestamp 200)
+    # Truncate endpoint: keep_count=0, then new message appended
+    from api.config import _get_session_agent_lock
+    with _get_session_agent_lock("edit_undo_leak"):
+        session.messages = []
+        session.context_messages = []
+        session.truncation_watermark = 0.0
+        session.save()
+
+    # New message "square" with new timestamp
+    session.messages = [
+        _msg("user", "square", 200.0, "u2"),
+        _msg("assistant", "360°", 201.0, "a2"),
+    ]
+    session.context_messages = [
+        _msg("user", "square", 200.0, "u2"),
+        _msg("assistant", "360°", 201.0, "a2"),
+    ]
+    session.truncation_watermark = 200.0
+    session.save()
+
+    # state.db now has both original and edited
+    state_db = [
+        _msg("user", "triangle", 100.0, "state-u1"),
+        _msg("assistant", "180°", 101.0, "state-a1"),
+        _msg("user", "square", 200.0, "state-u2"),
+        _msg("assistant", "360°", 201.0, "state-a2"),
+    ]
+
+    # Step 3: New message "light speed"
+    session.messages = [
+        _msg("user", "square", 200.0, "u2"),
+        _msg("assistant", "360°", 201.0, "a2"),
+        _msg("user", "light speed", 300.0, "u3"),
+        _msg("assistant", "300000 km/s", 301.0, "a3"),
+    ]
+    session.context_messages = [
+        _msg("user", "square", 200.0, "u2"),
+        _msg("assistant", "360°", 201.0, "a2"),
+        _msg("user", "light speed", 300.0, "u3"),
+        _msg("assistant", "300000 km/s", 301.0, "a3"),
+    ]
+    session.truncation_watermark = 301.0
+    session.save()
+
+    # state.db has everything
+    state_db = [
+        _msg("user", "triangle", 100.0, "state-u1"),
+        _msg("assistant", "180°", 101.0, "state-a1"),
+        _msg("user", "square", 200.0, "state-u2"),
+        _msg("assistant", "360°", 201.0, "state-a2"),
+        _msg("user", "light speed", 300.0, "state-u3"),
+        _msg("assistant", "300000 km/s", 301.0, "state-a3"),
+    ]
+
+    # Step 4: Undo — removes "light speed"
+    undo_last("edit_undo_leak")
+    loaded = Session.load("edit_undo_leak")
+
+    # After undo: messages should be ["square", "360°"]
+    assert [m["content"] for m in loaded.messages] == ["square", "360°"]
+    assert [m["content"] for m in loaded.context_messages] == ["square", "360°"]
+    assert loaded.truncation_watermark == 201.0
+
+    # Step 5: New turn — agent context should NOT include "triangle"
+    merged = reconciled_state_db_messages_for_session(
+        loaded, state_messages=state_db, prefer_context=True,
+    )
+
+    contents = [m["content"] for m in merged]
+
+    # "triangle" must NOT leak through — it was replaced by "square" via Edit
+    assert "triangle" not in contents, \
+        f"Original 'triangle' leaked through watermark filter! Contents: {contents}"
+    assert "square" in contents
+    # "light speed" properly filtered by watermark
+    assert "light speed" not in contents
+
+
+# ── save() watermark invariant ─────────────────────────────────────────────
+
+
+def test_save_does_not_auto_clear_truncation_watermark(monkeypatch, tmp_path):
+    """save() must NOT auto-clear truncation_watermark when messages have
+    timestamps beyond the watermark (#2914).
+
+    A future save() that appends newer messages must NOT silently remove the
+    watermark — that would let state.db replay the rows the user deliberately
+    removed.
+    """
+    import api.models as models
+    from api.models import Session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    session = Session(
+        session_id="watermark_no_clear",
+        messages=[
+            _msg("user", "first", 1.0, "u1"),
+            _msg("assistant", "reply", 2.0, "a1"),
+            _msg("user", "newer", 3.0, "u2"),  # ts > watermark
+        ],
+        truncation_watermark=2.0,
+    )
+    session.save()
+
+    loaded = Session.load("watermark_no_clear")
+    assert loaded is not None
+    # Watermark must NOT be cleared even though max message ts (3.0) > watermark (2.0)
+    assert loaded.truncation_watermark == 2.0, \
+        f"Watermark was cleared on save! Got {loaded.truncation_watermark}"
+
+
+# ── Streaming finalize: watermark must not become permanent ceiling ──
+
+
+def test_streaming_finalize_preserves_new_turns_after_edit(monkeypatch, tmp_path):
+    """Integration: simulate the full streaming finalize pipeline for two
+    consecutive turns after Edit, verifying that context_messages retains
+    all new turns (not just the pre-Edit history).
+
+    This exercises the actual finalize chain:
+      _restore_reasoning_metadata → _dedupe_replayed_context_messages
+      → _deduplicate_context_messages
+
+    Scenario:
+    1. Edit sets watermark = 101.0, context_messages = [pre-edit messages]
+    2. Turn 1: agent returns [pre-edit + Turn 1] → finalize → save context_messages
+    3. Turn 2: agent returns [pre-edit + Turn 1 + Turn 2] → finalize → save
+    4. Assert context_messages after Turn 2 contains Turn 1 + Turn 2
+    """
+    import api.models as models
+    from api.models import Session
+    from api.streaming import (
+        _restore_reasoning_metadata,
+        _dedupe_replayed_context_messages,
+        _deduplicate_context_messages,
+    )
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    # Pre-Edit context (after Edit, watermark = 101.0)
+    pre_edit = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+    ]
+
+    session = Session(
+        session_id="finalize_two_turns",
+        messages=list(pre_edit),
+        context_messages=list(pre_edit),
+        truncation_watermark=101.0,
+    )
+    session.save()
+    models.SESSIONS["finalize_two_turns"] = session
+
+    # ── Turn 1: agent returns [pre-edit + Turn 1] ──
+    _previous_context = list(session.context_messages)
+    _result_messages_turn1 = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+        _msg("user", "what is circle", 200.0, "ctx-u2"),
+        _msg("assistant", "360 degrees", 201.0, "ctx-a2"),
+    ]
+
+    # Run the finalize chain
+    _next = _restore_reasoning_metadata(_previous_context, _result_messages_turn1)
+    _next = _dedupe_replayed_context_messages(_previous_context, _next)
+    session.context_messages = _deduplicate_context_messages(_next)
+
+    # Turn 1: context must contain the new turn
+    turn1_contents = [m["content"] for m in session.context_messages]
+    assert "what is circle" in turn1_contents, \
+        f"Turn 1 lost after finalize! Contents: {turn1_contents}"
+    assert "360 degrees" in turn1_contents, \
+        f"Turn 1 reply lost after finalize! Contents: {turn1_contents}"
+
+    # ── Turn 2: agent returns [pre-edit + Turn 1 + Turn 2] ──
+    _previous_context = list(session.context_messages)
+    _result_messages_turn2 = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+        _msg("user", "what is circle", 200.0, "ctx-u2"),
+        _msg("assistant", "360 degrees", 201.0, "ctx-a2"),
+        _msg("user", "list all shapes", 300.0, "ctx-u3"),
+        _msg("assistant", "square, circle", 301.0, "ctx-a3"),
+    ]
+
+    # Run the finalize chain again
+    _next = _restore_reasoning_metadata(_previous_context, _result_messages_turn2)
+    _next = _dedupe_replayed_context_messages(_previous_context, _next)
+    session.context_messages = _deduplicate_context_messages(_next)
+
+    # Turn 2: context must contain BOTH Turn 1 and Turn 2
+    turn2_contents = [m["content"] for m in session.context_messages]
+    assert "what is circle" in turn2_contents, \
+        f"Turn 1 lost after Turn 2 finalize! Contents: {turn2_contents}"
+    assert "360 degrees" in turn2_contents, \
+        f"Turn 1 reply lost after Turn 2 finalize! Contents: {turn2_contents}"
+    assert "list all shapes" in turn2_contents, \
+        f"Turn 2 lost after finalize! Contents: {turn2_contents}"
+    assert "square, circle" in turn2_contents, \
+        f"Turn 2 reply lost after finalize! Contents: {turn2_contents}"
+
+
+def test_streaming_finalize_does_not_leak_original_after_edit(monkeypatch, tmp_path):
+    """After Edit, the original replaced message must NOT appear in context_messages
+    after streaming finalize (#2914).
+
+    This exercises the actual finalize chain:
+      _restore_reasoning_metadata → _dedupe_replayed_context_messages
+      → _deduplicate_context_messages
+
+    Scenario:
+    1. Edit sets watermark = 101.0, context_messages = [pre-edit messages]
+    2. Turn 1: agent returns [pre-edit + Turn 1] → finalize
+    3. Turn 2: agent returns [pre-edit + Turn 1 + Turn 2] → finalize
+    4. Assert context_messages after Turn 2 contains Turn 1 + Turn 2
+    """
+    import api.models as models
+    from api.models import Session
+    from api.streaming import (
+        _restore_reasoning_metadata,
+        _dedupe_replayed_context_messages,
+        _deduplicate_context_messages,
+    )
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    # Pre-Edit context (after Edit, watermark = 101.0)
+    pre_edit = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+    ]
+
+    session = Session(
+        session_id="finalize_two_turns",
+        messages=list(pre_edit),
+        context_messages=list(pre_edit),
+        truncation_watermark=101.0,
+    )
+    session.save()
+    models.SESSIONS["finalize_two_turns"] = session
+
+    # ── Turn 1: agent returns [pre-edit + Turn 1] ──
+    _previous_context = list(session.context_messages)
+    _result_messages_turn1 = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+        _msg("user", "what is circle", 200.0, "ctx-u2"),
+        _msg("assistant", "360 degrees", 201.0, "ctx-a2"),
+    ]
+
+    # Run the finalize chain
+    _next = _restore_reasoning_metadata(_previous_context, _result_messages_turn1)
+    _next = _dedupe_replayed_context_messages(_previous_context, _next)
+    session.context_messages = _deduplicate_context_messages(_next)
+
+    # Turn 1: context must contain the new turn
+    turn1_contents = [m["content"] for m in session.context_messages]
+    assert "what is circle" in turn1_contents, \
+        f"Turn 1 lost after finalize! Contents: {turn1_contents}"
+    assert "360 degrees" in turn1_contents, \
+        f"Turn 1 reply lost after finalize! Contents: {turn1_contents}"
+
+    # ── Turn 2: agent returns [pre-edit + Turn 1 + Turn 2] ──
+    _previous_context = list(session.context_messages)
+    _result_messages_turn2 = [
+        _msg("user", "square", 100.0, "ctx-u1"),
+        _msg("assistant", "360°", 101.0, "ctx-a1"),
+        _msg("user", "what is circle", 200.0, "ctx-u2"),
+        _msg("assistant", "360 degrees", 201.0, "ctx-a2"),
+        _msg("user", "list all shapes", 300.0, "ctx-u3"),
+        _msg("assistant", "square, circle", 301.0, "ctx-a3"),
+    ]
+
+    # Run the finalize chain again
+    _next = _restore_reasoning_metadata(_previous_context, _result_messages_turn2)
+    _next = _dedupe_replayed_context_messages(_previous_context, _next)
+    session.context_messages = _deduplicate_context_messages(_next)
+
+    # Turn 2: context must contain BOTH Turn 1 and Turn 2
+    turn2_contents = [m["content"] for m in session.context_messages]
+    assert "what is circle" in turn2_contents, \
+        f"Turn 1 lost after Turn 2 finalize! Contents: {turn2_contents}"
+    assert "360 degrees" in turn2_contents, \
+        f"Turn 1 reply lost after Turn 2 finalize! Contents: {turn2_contents}"
+    assert "list all shapes" in turn2_contents, \
+        f"Turn 2 lost after finalize! Contents: {turn2_contents}"
+    assert "square, circle" in turn2_contents, \
+        f"Turn 2 reply lost after finalize! Contents: {turn2_contents}"
+
+
+def test_edit_does_not_leak_original_message_into_context_via_reconcile(monkeypatch, tmp_path):
+    """After Edit, the original replaced message must NOT appear in agent context
+    when reconciling state.db with sidecar (#2914).
+
+    This is the core regression: Edit replaces message content but state.db
+    keeps the original forever. Without the sub-watermark filter in
+    merge_session_messages_append_only, the original message leaks back
+    into context_messages on the next turn.
+
+    Scenario:
+    1. Send "triangle" (ts=100) → agent replies "180°" (ts=101)
+    2. Edit to "square" (ts=200) → agent replies "360°" (ts=201), watermark=200
+    3. Send "list all" (ts=300) → agent replies "square, list" (ts=301)
+    4. Reconcile state.db (which has both "triangle" and "square") with sidecar
+    5. Assert "triangle" does NOT appear in merged context
+    """
+    import api.models as models
+    from api.models import Session, reconciled_state_db_messages_for_session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    # After Edit + new turn, sidecar has:
+    # - "square" (edited, ts=200)
+    # - "360°" (ts=201)
+    # - "list all" (ts=300)
+    # - "square, list" (ts=301)
+    # Watermark = 301.0 (covers everything in sidecar)
+    sidecar = [
+        _msg("user", "square", 200.0, "side-u1"),
+        _msg("assistant", "360°", 201.0, "side-a1"),
+        _msg("user", "list all", 300.0, "side-u2"),
+        _msg("assistant", "square, list", 301.0, "side-a2"),
+    ]
+
+    session = Session(
+        session_id="edit_no_leak",
+        messages=list(sidecar),
+        context_messages=list(sidecar),
+        truncation_watermark=301.0,
+    )
+    session.save()
+
+    # state.db has BOTH original "triangle" AND edited "square"
+    state_db = [
+        _msg("user", "triangle", 100.0, "state-u1"),  # original, ts < watermark
+        _msg("assistant", "180°", 101.0, "state-a1"),  # original, ts < watermark
+        _msg("user", "square", 200.0, "state-u2"),     # edited, ts <= watermark
+        _msg("assistant", "360°", 201.0, "state-a2"),  # edited, ts <= watermark
+        _msg("user", "list all", 300.0, "state-u3"),   # new turn
+        _msg("assistant", "square, list", 301.0, "state-a4"),
+    ]
+
+    merged = reconciled_state_db_messages_for_session(
+        session, state_messages=state_db, prefer_context=True,
+    )
+
+    contents = [m["content"] for m in merged]
+
+    # "triangle" must NOT leak — it was replaced by "square" via Edit
+    assert "triangle" not in contents, \
+        f"Original 'triangle' leaked into context! Contents: {contents}"
+    # "square" must be present
+    assert "square" in contents
+    # All sidecar messages must be present
+    assert "360°" in contents
+    assert "list all" in contents
+    assert "square, list" in contents

--- a/tests/test_issue2914_truncation_watermark.py
+++ b/tests/test_issue2914_truncation_watermark.py
@@ -608,3 +608,58 @@ def test_edit_does_not_leak_original_message_into_context_via_reconcile(monkeypa
     assert "360°" in contents
     assert "list all" in contents
     assert "square, list" in contents
+
+
+def test_above_watermark_state_row_merges_once_sidecar_advances():
+    """A genuine future state.db-only row must merge after the session advances.
+
+    Because Session.save() no longer auto-clears the truncation_watermark, an
+    unconditional `timestamp > watermark` skip in merge_session_messages_append_only
+    would become a PERMANENT ceiling: once the user edits/undoes (setting the
+    watermark) and then keeps chatting, a later turn that lands in state.db but
+    is missed by the sidecar (recovery/compaction) would be silently dropped from
+    /api/session and model-context reconstruction forever. The fix only applies the
+    above-watermark skip while the sidecar has NOT advanced past the watermark.
+    Codex regression-gate finding on #3102 (v0.51.197).
+    """
+    from api.models import merge_session_messages_append_only as merge
+
+    # Session edited at watermark=2.0, then advanced: sidecar tail is now 4.1.
+    sidecar = [
+        _msg("user", "q1", 1.0, "s-u1"),
+        _msg("assistant", "a1", 2.0, "s-a1"),
+        _msg("user", "q2 after edit", 4.0, "s-u2"),
+        _msg("assistant", "a2 after edit", 4.1, "s-a2"),
+    ]
+    # state.db carries a genuine NEWER row (5.0) the sidecar hasn't observed yet.
+    state = sidecar + [_msg("assistant", "future recovery row", 5.0, "st-recov")]
+
+    merged = merge(sidecar, state, truncation_watermark=2.0)
+    contents = [m["content"] for m in merged]
+    assert "future recovery row" in contents, (
+        "After the session advanced past the watermark, a future state.db-only "
+        f"recovery row must merge, not be permanently dropped. Got: {contents}"
+    )
+
+
+def test_above_watermark_deleted_tail_still_filtered_when_sidecar_not_advanced():
+    """The #2914 deleted-tail filter must still hold when the sidecar has NOT advanced.
+
+    Counterpart to the test above: if the user edited/truncated (watermark=2.0)
+    and the sidecar tail is still at/below the watermark, a stale deleted-tail row
+    in state.db ABOVE the watermark must NOT reappear.
+    """
+    from api.models import merge_session_messages_append_only as merge
+
+    sidecar = [
+        _msg("user", "q1", 1.0, "s-u1"),
+        _msg("assistant", "a1", 2.0, "s-a1"),
+    ]
+    state = sidecar + [_msg("assistant", "deleted tail", 5.0, "st-deleted")]
+
+    merged = merge(sidecar, state, truncation_watermark=2.0)
+    contents = [m["content"] for m in merged]
+    assert "deleted tail" not in contents, (
+        "A stale deleted-tail row above the watermark must stay filtered while "
+        f"the sidecar has not advanced past the watermark. Got: {contents}"
+    )


### PR DESCRIPTION
## v0.51.197 — stop agent replaying edited/undone messages

Single contributor PR (#3102) reviewed, fixed, and tested end-to-end (stage-batch9). Two other PRs originally staged with it (#3268, #3300) were dropped after the regression gate found data-loss issues in each — both held with `changes-requested` + empirical repros.

### Included PR
| PR | Title | Author | Notes |
|----|-------|--------|-------|
| #3102 | Stop agent replaying edited/undone messages from state.db (closes #2914) | @AlexeyDsov | Removed the `_clamp_context_to_watermark()` permanent-ceiling; timestamp filter skips stale pre-edit rows below the watermark; `POST /api/session/truncate` syncs `context_messages` truncation. **Maintainer fix applied:** the persisted watermark could permanently drop future state.db-only recovery rows (Codex finding) — the above-watermark skip now only fires while the sidecar hasn't advanced past the watermark, with 2 revert-verified regression tests. |

### Gate results
- Pre-Opus gate: Python `ast.parse` ✓, ruff forward gate ✓, no merge markers, CHANGELOG `[Unreleased]` empty
- pytest (full sequential, `-p no:xdist`): **7162 passed, 7 skipped, 3 xpassed, 0 failed**
- Opus advisor: no blocking issues — #3102 resolves #2914 without reintroducing the brick class; the truncation is strictly better than master (which never truncated `context_messages`)
- Codex regression gate: **SAFE TO SHIP** — re-verified by execution that the watermark-ceiling fix keeps future recovery rows after the session advances while preserving the #2914 deleted-tail filtering

### Dropped from this batch (held with empirical repros)
- **#3268** — the `_merged_session_messages_for_display` rewrite removed the watermark stale-row filtering master had + the edge-replay drop still drops legitimately-repeated turns by visible-text alone (same data-loss class it was originally dropped for).
- **#3300** — in a context-compacted gateway session, using the compressed context as the display backbone permanently drops older visible transcript turns and `s.save()` persists the shortened transcript (transcript-loss regression).
