### PR TITLE
v0.51.201: colored diff lines in tool-card snippets (#3336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.201] — 2026-06-01 — Release FU (stage-batch13 — colored diff lines in tool-card snippets)
+
+### Added
+- Tool-card result snippets that contain a unified diff now render with the same green/red/cyan diff coloring already used for diffs in chat messages (reusing the existing `.diff-block` styles), with an expand/collapse toggle that preserves the coloring. Non-diff snippets are unchanged (#3336, @mysoul12138).
+
 ## [v0.51.200] — 2026-06-01 — Release FT (stage-batch12 — remote-gateway health probe + ephemeral-turn-field preservation)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -7144,12 +7144,51 @@ function buildToolCard(tc){
           Object.entries(tc.args).map(([k,v])=>`<div><span class="tool-arg-key">${esc(k)}</span> <span class="tool-arg-val">${esc(String(v))}</span></div>`).join('')
         }</div>`:''}
         ${displaySnippet?`<div class="tool-card-result">
-          <pre>${esc(displaySnippet)}</pre>
-          ${hasMore?`<button class="tool-card-more" data-full="${esc(tc.snippet||'').replace(/"/g,'&quot;')}" data-short="${esc(displaySnippet||'').replace(/"/g,'&quot;')}" data-more-label="${esc(moreLabel)}" data-less-label="${esc(lessLabel)}" onclick="event.stopPropagation();const p=this.previousElementSibling;const full=this.dataset.full;const short=this.dataset.short;p.textContent=p.textContent===short?full:short;this.textContent=p.textContent===short?this.dataset.moreLabel:this.dataset.lessLabel">${esc(moreLabel)}</button>`:''}
+          <pre>${tc.is_diff||_snippetLooksLikeDiff(displaySnippet)?`<code class="diff-block" data-highlighted="1">${_colorDiffLines(displaySnippet)}</code>`:esc(displaySnippet)}</pre>
+          ${hasMore?`<button class="tool-card-more" data-full="${esc(tc.snippet||'').replace(/"/g,'&quot;')}" data-short="${esc(displaySnippet||'').replace(/"/g,'&quot;')}" data-is-diff="${tc.is_diff||_snippetLooksLikeDiff(displaySnippet)?1:0}" data-more-label="${esc(moreLabel)}" data-less-label="${esc(lessLabel)}" onclick="event.stopPropagation();_toggleToolDiff(this)">${esc(moreLabel)}</button>`:''}
         </div>`:''}
       </div>`:''}
     </div>`;
   return row;
+}
+
+function _colorDiffLines(text){
+  if(typeof text !== 'string') return esc(String(text||''));
+  return esc(text).split('\n').map(line=>{
+    if(line.startsWith('@@')) return `<span class="diff-line diff-hunk">${line}</span>`;
+    if(line.startsWith('+')&&!line.startsWith('+++')) return `<span class="diff-line diff-plus">${line}</span>`;
+    if(line.startsWith('-')&&!line.startsWith('---')) return `<span class="diff-line diff-minus">${line}</span>`;
+    return `<span class="diff-line">${line}</span>`;
+  }).join('\n');
+}
+
+// Detect if text looks like a unified diff (has @@ hunk headers and +/- lines).
+function _snippetLooksLikeDiff(text){
+  if(typeof text!=='string'||text.length<10) return false;
+  if(!/^@@\s/.test(text)) return false;
+  const lines=text.split('\n');
+  let plusMinus=0;
+  for(let i=0;i<lines.length&&i<50;i++){
+    const l=lines[i];
+    if(l.startsWith('+')||l.startsWith('-')) plusMinus++;
+  }
+  return plusMinus>=2;
+}
+
+function _toggleToolDiff(btn){
+  const pre=btn.closest('.tool-card-result')?.querySelector('pre');
+  if(!pre) return;
+  const isDiff=btn.dataset.isDiff==='1';
+  const expanded=btn.textContent===btn.dataset.moreLabel;
+  const raw=expanded?btn.dataset.full:btn.dataset.short;
+  if(isDiff){
+    let code=pre.querySelector('code');
+    if(!code){code=document.createElement('code');code.className='diff-block';pre.textContent='';pre.appendChild(code);}
+    code.innerHTML=_colorDiffLines(raw);
+  }else{
+    pre.textContent=raw;
+  }
+  btn.textContent=expanded?btn.dataset.lessLabel:btn.dataset.moreLabel;
 }
 
 function _syncToolCallGroupSummary(group){

--- a/tests/test_issue1824_cli_patch_diff_rendering.py
+++ b/tests/test_issue1824_cli_patch_diff_rendering.py
@@ -113,6 +113,9 @@ def test_rendered_apply_patch_tool_card_html_contains_diff_lines():
         "_toolArgPreviewKeyIsHidden",
         "_formatToolArgPreview",
         "_toolCardPreviewText",
+        # #3336: buildToolCard now wraps diff snippets via these helpers.
+        "_snippetLooksLikeDiff",
+        "_colorDiffLines",
         "buildToolCard",
     ]
     functions = "\n".join(_function_source(UI_JS, name) for name in function_names)


### PR DESCRIPTION
## v0.51.201 — colored diff lines in tool-card snippets

Single front-end PR #3336 (stage-batch13). Was CI-red on a real test failure (not a flake) — diagnosed + fixed by the maintainer.

### Included PR
| PR | Title | Author |
|----|-------|--------|
| #3336 | Color diff lines in tool-card result snippets | @mysoul12138 |

### What it does
`buildToolCard()` now renders unified-diff tool-card snippets with the same green/red/cyan coloring already used for diffs in chat messages, reusing the existing `.diff-block` CSS classes. Adds `_colorDiffLines`, `_snippetLooksLikeDiff` (heuristic: `/^@@\s/` + ≥2 `+`/`-` lines), and a `_toggleToolDiff` expand/collapse that preserves coloring. Non-diff snippets unchanged.

### Maintainer fix applied
The PR was CI-red because it added 2 new helpers (`_snippetLooksLikeDiff`, `_colorDiffLines`) that `buildToolCard` now calls, but didn't add them to the `function_names` extraction list in `tests/test_issue1824_cli_patch_diff_rendering.py` — so the node-driven test threw "not defined". Added the two helpers to the extraction list (the PR's HTML output still satisfies the existing `-old`/`+new`/`Show diff` assertions).

### Gate results
- Pre-Opus gate: `node -c` ✓, ESLint runtime gate ✓
- pytest (full sequential): **7190 passed, 7 skipped, 3 xpassed, 0 failed**
- Opus advisor: **Ship it** — verified XSS-safe (diff content `esc()`'d before span-wrapping), `_toggleToolDiff` reachable from inline onclick (top-level fn, classic deferred script), `_snippetLooksLikeDiff` near-zero false-positive rate, CSS classes pre-existing
- Codex regression gate: **SAFE TO SHIP**

Reuses an existing visual contract (the chat-message diff coloring) applied to a new location — no new design surface.
