### PR TITLE
v0.51.202: filter interrupted-recovery control text from visible transcript (#3321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.202] — 2026-06-01 — Release FV (stage-batch14 — filter interrupted-recovery control text from visible transcript)
+
+### Fixed
+- Interrupted SSE-recovery control text (the synthetic `stale_interrupted_event` run-journal payload) is now kept out of the visible chat transcript instead of being replayed as a message: it's marked `recovery_control` on the backend and filtered across the `msgContent()` render path, the SSE settle/error handlers, and final transcript filtering, so platform-only control state no longer leaks into the conversation (#3321, @franksong2702).
+
 ## [v0.51.201] — 2026-06-01 — Release FU (stage-batch13 — colored diff lines in tool-card snippets)
 
 ### Added

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -262,6 +262,7 @@ def stale_interrupted_event(session_id: str, run_id: str, *, after_seq: int | No
         return None
     payload = {
         "type": "interrupted",
+        "recovery_control": True,
         "message": "The live worker stopped before this run finished.",
         "hint": "The transcript was restored to the last journaled event. Start a new turn if you still need the task to continue.",
         "session_id": session_id,

--- a/static/messages.js
+++ b/static/messages.js
@@ -765,9 +765,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _streamRecoveryControlMessage(m){
     if(!m||m.role==='tool') return false;
     if(m.recovery_control===true) return true;
+    // Backward-compat ONLY for pre-marker persisted sessions: match the two
+    // fully-anchored synthetic recovery strings. Do NOT fall back to
+    // provider_details_label — a genuine "Response interrupted" card the user
+    // SHOULD see also carries the 'Interruption details' label, and filtering
+    // on it would drop a real interruption from the transcript (the inverse
+    // data-loss class flagged on the sibling #3300). Marker + strict text only.
     const text=String(typeof msgContent==='function'?msgContent(m):(m.content||''));
-    if(_streamRecoveryControlMessageText(text)) return true;
-    return !!(m.provider_details_label && String(m.provider_details_label).toLowerCase()==='interruption details');
+    return _streamRecoveryControlMessageText(text);
   }
   function _filterRecoveryControlMessages(messages){
     if(!Array.isArray(messages)) return [];

--- a/static/messages.js
+++ b/static/messages.js
@@ -753,6 +753,26 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     return typeof _isPreservedCompressionTaskListMarkerOnlyText==='function'
       && _isPreservedCompressionTaskListMarkerOnlyText(text);
   }
+  function _streamRecoveryControlMessageText(text){
+    const normalized=String(text||'').replace(/\s+/g,' ').trim();
+    if(!normalized) return false;
+    const systemRecovery=/^\[System:/i.test(normalized)
+      && /previous response was cut off by a network error/i.test(normalized)
+      && /continue exactly where you left off/i.test(normalized);
+    const backendRecovery=/^the live worker stopped before this run finished\.?$/i.test(normalized);
+    return !!(systemRecovery || backendRecovery);
+  }
+  function _streamRecoveryControlMessage(m){
+    if(!m||m.role==='tool') return false;
+    if(m.recovery_control===true) return true;
+    const text=String(typeof msgContent==='function'?msgContent(m):(m.content||''));
+    if(_streamRecoveryControlMessageText(text)) return true;
+    return !!(m.provider_details_label && String(m.provider_details_label).toLowerCase()==='interruption details');
+  }
+  function _filterRecoveryControlMessages(messages){
+    if(!Array.isArray(messages)) return [];
+    return messages.filter((m)=>!_streamRecoveryControlMessage(m));
+  }
   function _replaceMarkerOnlyAssistantWithStreamError(messages){
     if(!Array.isArray(messages)) return false;
     const msg=[...messages].reverse().find(m=>m&&m.role==='assistant');
@@ -1884,6 +1904,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const _prevCacheRead=(S.session&&S.session.cache_read_tokens)||0;
           const _prevCacheWrite=(S.session&&S.session.cache_write_tokens)||0;
           S.session=d.session;S.messages=_carryForwardEphemeralTurnFields(S.messages||[], d.session.messages||[]);if(typeof _messagesTruncated!=='undefined')_messagesTruncated=!!d.session._messages_truncated;
+          S.messages=_filterRecoveryControlMessages(S.messages || []);
           if(S.session&&S.session.session_id){
             try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
             if(typeof _setActiveSessionUrl==='function') _setActiveSessionUrl(S.session.session_id);
@@ -2169,6 +2190,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(S.session&&S.session.session_id===activeSid){
         S.activeStreamId=null;
         clearLiveToolCards();if(!assistantText)removeThinking();
+        let isRecoveryControlMessage=false;
         try{
           const d=JSON.parse(e.data);
           const isRateLimit=d.type==='rate_limit';
@@ -2178,17 +2200,33 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const isModelNotFound=d.type==='model_not_found';
           const isCancelled=d.type==='cancelled';
           const isInterrupted=d.type==='interrupted';
+          isRecoveryControlMessage=isInterrupted && (d.recovery_control===true || _streamRecoveryControlMessageText(d.message));
           const isNoResponse=d.type==='no_response'||d.type==='silent_failure';
           const label=isCancelled?'Task cancelled':isInterrupted?'Response interrupted':isQuotaExhausted?'Out of credits':isRateLimit?'Rate limit reached':isGatewayAuthError?(typeof t==='function'?t('gateway_auth_label'):'Gateway authentication failed'):isAuthMismatch?(typeof t==='function'?t('provider_mismatch_label'):'Provider mismatch'):isModelNotFound?(typeof t==='function'?t('model_not_found_label'):'Model not found'):isNoResponse?'No response from provider':'Error';
           const hint=d.hint?`\n\n*${d.hint}*`:'';
           const details=d.details?String(d.details).replace(/```/g,'`\u200b``'):'';
           const detailsLabel=isCancelled?'Cancellation details':isInterrupted?'Interruption details':undefined;
-          S.messages.push({role:'assistant',content:`**${label}:** ${d.message}${hint}`,provider_details:details,provider_details_label:detailsLabel});
+          if(isRecoveryControlMessage){
+            if(typeof showToast==='function') showToast('Stream recovery signal received. Restoring transcript...',3500,'error');
+          } else {
+            S.messages.push({role:'assistant',content:`**${label}:** ${d.message}${hint}`,provider_details:details,provider_details_label:detailsLabel});
+          }
         }catch(_){
           S.messages.push({role:'assistant',content:'**Error:** An error occurred. Check server logs.'});
         }
-        _markSessionViewed(activeSid, S.messages.length);
-        renderMessages({preserveScroll:true});
+        if(isRecoveryControlMessage){
+          (async()=>{
+            if(await _restoreSettledSession(source)) return;
+            if(S.session&&S.session.session_id===activeSid){
+              S.messages=_filterRecoveryControlMessages(S.messages||[]);
+              _markSessionViewed(activeSid, S.messages.length);
+              renderMessages({preserveScroll:true});
+            }
+          })();
+        } else {
+          _markSessionViewed(activeSid, S.messages.length);
+          renderMessages({preserveScroll:true});
+        }
       }else if(typeof trackBackgroundError==='function'){
         const _errTitle=(typeof _allSessions!=='undefined'&&_allSessions.find(s=>s.session_id===activeSid)||{}).title||null;
         try{const d=JSON.parse(e.data);trackBackgroundError(activeSid,_errTitle,d.message||'Error');}
@@ -2381,6 +2419,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         S.session=session;
         const _nextMsgs3018=(session.messages||[]).filter(m=>m&&m.role);
         S.messages=_carryForwardEphemeralTurnFields(S.messages||[], _nextMsgs3018);
+        S.messages=_filterRecoveryControlMessages(S.messages || []);
         if(S.session&&S.session.session_id){
           try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
           if(typeof _setActiveSessionUrl==='function') _setActiveSessionUrl(S.session.session_id);

--- a/static/ui.js
+++ b/static/ui.js
@@ -5440,8 +5440,10 @@ function _isRecoveryControlMessageText(text){
 function _isRecoveryControlMessage(m){
   if(!m||m.role==='tool') return false;
   if(m.recovery_control===true) return true;
-  if(_isRecoveryControlMessageText(msgContent(m)||String(m.content||''))) return true;
-  return !!(m.provider_details_label && String(m.provider_details_label).toLowerCase()==='interruption details');
+  // Backward-compat ONLY: strict fully-anchored text match for pre-marker
+  // persisted sessions. NOT provider_details_label — a real "Response
+  // interrupted" card carries 'Interruption details' and must stay visible.
+  return _isRecoveryControlMessageText(msgContent(m)||String(m.content||''));
 }
 function _assistantMessageHasVisibleContent(m){
   if(!m||m.role!=='assistant') return false;

--- a/static/ui.js
+++ b/static/ui.js
@@ -5428,6 +5428,27 @@ function msgContent(m){
   return String(c).trim();
 }
 
+function _isRecoveryControlMessageText(text){
+  const normalized=String(text||'').replace(/\s+/g,' ').trim();
+  if(!normalized) return false;
+  const systemRecovery=/^\[System:/i.test(normalized)
+    && /previous response was cut off by a network error/i.test(normalized)
+    && /continue exactly where you left off/i.test(normalized);
+  const backendRecovery=/^the live worker stopped before this run finished\.?$/i.test(normalized);
+  return !!(systemRecovery || backendRecovery);
+}
+function _isRecoveryControlMessage(m){
+  if(!m||m.role==='tool') return false;
+  if(m.recovery_control===true) return true;
+  if(_isRecoveryControlMessageText(msgContent(m)||String(m.content||''))) return true;
+  return !!(m.provider_details_label && String(m.provider_details_label).toLowerCase()==='interruption details');
+}
+function _assistantMessageHasVisibleContent(m){
+  if(!m||m.role!=='assistant') return false;
+  if(_isRecoveryControlMessage(m)) return false;
+  return !!msgContent(m);
+}
+
 function _fmtDateSep(d){
   const todayStart=new Date();todayStart.setHours(0,0,0,0);
   const dStart=new Date(d);dStart.setHours(0,0,0,0);
@@ -6380,10 +6401,12 @@ function renderMessages(options){
     if(!m||!m.role||m.role==='tool')return false;
     if(_isContextCompactionMessage(m)) return false;
     if(_isPreservedCompressionTaskListMessage(m)) return false;
+    if(_isRecoveryControlMessage(m)) return false;
     if(m.role==='assistant'){
       const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
       const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
       if(hasTc||hasTu||_messageHasReasoningPayload(m)) return true;
+      if(_assistantMessageHasVisibleContent(m)) return true;
     }
     return m._statusCard||msgContent(m)||m.attachments?.length;
   });
@@ -6410,9 +6433,10 @@ function renderMessages(options){
     for(const m of S.messages){
       if(!m||!m.role||m.role==='tool'){ri++;continue;}
       if(_isPreservedCompressionTaskListMessage(m)){ri++;continue;}
+      if(_isRecoveryControlMessage(m)){ri++;continue;}
       const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
       const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
-      if(msgContent(m)||m._statusCard||m.attachments?.length||(m.role==='assistant'&&(hasTc||hasTu||_messageHasReasoningPayload(m)))) rebuilt.push({m,rawIdx:ri});
+      if(msgContent(m)||m._statusCard||m.attachments?.length||(m.role==='assistant'&&(hasTc||hasTu||_messageHasReasoningPayload(m)||_assistantMessageHasVisibleContent(m)))) rebuilt.push({m,rawIdx:ri});
       ri++;
     }
     _visWithIdxCache=rebuilt;

--- a/tests/test_live_stream_ux.py
+++ b/tests/test_live_stream_ux.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+RUN_JOURNAL_PY = (ROOT / "api" / "run_journal.py").read_text(encoding="utf-8")
+
+def test_stale_interrupted_event_marks_recovery_control():
+    assert "\"recovery_control\": True" in RUN_JOURNAL_PY
+
+
+def test_done_and_restore_filters_recovery_messages_from_frontend_state():
+    assert "_filterRecoveryControlMessages(S.messages || [])" in MESSAGES_JS
+    assert "if(!m||m.role==='tool') return false;" in MESSAGES_JS
+    assert "if(m.recovery_control===true) return true;" in MESSAGES_JS
+    assert "previous response was cut off by a network error" in MESSAGES_JS
+    assert "continue exactly where you left off" in MESSAGES_JS
+
+
+def test_apererror_recovers_on_recovery_control_event():
+    assert "isRecoveryControlMessage=isInterrupted && (d.recovery_control===true || _streamRecoveryControlMessageText(d.message));" in MESSAGES_JS
+    assert "Stream recovery signal received. Restoring transcript..." in MESSAGES_JS
+    assert "if(await _restoreSettledSession(source)) return;" in MESSAGES_JS
+
+
+def test_ui_rejects_recovery_control_as_visible_assistant_content():
+    assert "function _isRecoveryControlMessageText" in UI_JS
+    assert "function _assistantMessageHasVisibleContent" in UI_JS
+    assert "if(_isRecoveryControlMessage(m)) return false;" in UI_JS
+    assert "if(_isRecoveryControlMessage(m)){ri++;continue;}" in UI_JS
+    assert "_assistantMessageHasVisibleContent(m)" in UI_JS
+
+
+def test_recovery_control_detection_is_not_broad_phrase_matching():
+    assert "|| /continue exactly where you left off/i.test(normalized)" not in UI_JS
+    assert "|| /continue exactly where you left off/i.test(normalized)" not in MESSAGES_JS
+    assert "const systemRecovery=/^\\[System:/i.test(normalized)" in UI_JS
+    assert "const backendRecovery=/^the live worker stopped before this run finished\\.?$/i.test(normalized)" in UI_JS

--- a/tests/test_live_stream_ux.py
+++ b/tests/test_live_stream_ux.py
@@ -36,3 +36,56 @@ def test_recovery_control_detection_is_not_broad_phrase_matching():
     assert "|| /continue exactly where you left off/i.test(normalized)" not in MESSAGES_JS
     assert "const systemRecovery=/^\\[System:/i.test(normalized)" in UI_JS
     assert "const backendRecovery=/^the live worker stopped before this run finished\\.?$/i.test(normalized)" in UI_JS
+
+
+def test_recovery_control_does_not_filter_genuine_interruption_card():
+    """A real 'Response interrupted' card carries provider_details_label
+    'Interruption details' but is NOT a recovery-control row — it must stay
+    visible. Earlier drafts filtered on that label, which would drop a genuine
+    interruption the user should see (the inverse-#3300 data-loss class). Drive
+    the ACTUAL _isRecoveryControlMessage() from ui.js via node.
+    """
+    import shutil, subprocess, json, re
+    node = shutil.which("node")
+    if node is None:
+        import pytest
+        pytest.skip("node not on PATH")
+
+    def _fn(src, name):
+        start = src.index(f"function {name}(")
+        brace = src.index("{", start)
+        depth = 0
+        for i in range(brace, len(src)):
+            if src[i] == "{":
+                depth += 1
+            elif src[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    return src[start:i + 1]
+        raise AssertionError(name)
+
+    fns = "\n".join(_fn(UI_JS, n) for n in ("_isRecoveryControlMessageText", "_isRecoveryControlMessage"))
+    driver = (
+        "function msgContent(m){return (m&&m.content)||'';}\n"
+        + fns + "\n"
+        + "const cases = JSON.parse(process.argv[1]);\n"
+        + "process.stdout.write(JSON.stringify(cases.map(_isRecoveryControlMessage)));\n"
+    )
+    cases = [
+        # genuine interruption card the user MUST see — label set, no marker, normal text
+        {"role": "assistant", "content": "**Response interrupted:** the model stopped early",
+         "provider_details_label": "Interruption details"},
+        # a real user turn that merely mentions interruption — must stay
+        {"role": "user", "content": "my previous response was cut off, can you continue?"},
+        # explicit server marker — IS recovery control
+        {"role": "assistant", "content": "anything", "recovery_control": True},
+        # strict synthetic backend text — IS recovery control (backward-compat)
+        {"role": "assistant", "content": "The live worker stopped before this run finished."},
+    ]
+    r = subprocess.run([node, "-e", driver, json.dumps(cases)], capture_output=True, text=True, timeout=15)
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out == [False, False, True, True], (
+        "genuine interruption card (label only) and a real user turn must NOT be "
+        f"filtered; only the explicit marker + strict synthetic text are. Got {out}"
+    )

--- a/tests/test_live_stream_ux.py
+++ b/tests/test_live_stream_ux.py
@@ -45,7 +45,7 @@ def test_recovery_control_does_not_filter_genuine_interruption_card():
     interruption the user should see (the inverse-#3300 data-loss class). Drive
     the ACTUAL _isRecoveryControlMessage() from ui.js via node.
     """
-    import shutil, subprocess, json, re
+    import shutil, subprocess, json
     node = shutil.which("node")
     if node is None:
         import pytest

--- a/tests/test_session_rotate_url_sync.py
+++ b/tests/test_session_rotate_url_sync.py
@@ -17,8 +17,8 @@ def test_stream_completion_syncs_rotated_session_id_to_tab_state():
     assert completion_pos != -1
     assert settled_pos != -1
 
-    completion_block = MESSAGES_JS[completion_pos : completion_pos + 500]
-    settled_block = MESSAGES_JS[settled_pos : settled_pos + 500]
+    completion_block = MESSAGES_JS[completion_pos : completion_pos + 900]
+    settled_block = MESSAGES_JS[settled_pos : settled_pos + 900]
 
     for block in (completion_block, settled_block):
         assert "localStorage.setItem('hermes-webui-session',S.session.session_id);" in block


### PR DESCRIPTION
## v0.51.202 — filter interrupted-recovery control text from visible transcript

Single PR #3321 (@franksong2702, stage-batch14). Sensitive transcript-display path — same subsystem as the held #3300 — so it got extra gate scrutiny.

### Included PR
| PR | Title | Author |
|----|-------|--------|
| #3321 | Filter interrupted SSE-recovery control text from the visible transcript | @franksong2702 |

The synthetic `stale_interrupted_event` run-journal payload is marked `recovery_control` on the backend and filtered across `msgContent()` / the SSE settle+error handlers / `_restoreSettledSession`, so platform-only control state no longer leaks into the conversation.

### Maintainer fix applied (Codex + Opus both flagged — data-loss class)
Both gates caught that `_isRecoveryControlMessage` / `_streamRecoveryControlMessage` fell back to matching `provider_details_label === 'interruption details'`. But a **genuine** "Response interrupted" card (Stop button, real provider crash) carries that exact label — so the filter would have dropped a real user-facing interruption from the transcript on the next render/restore (the inverse of the #3300 data-loss class). Fix: require the explicit server-set `recovery_control` marker; keep only the two fully-anchored synthetic-text matches for pre-marker backward-compat. Added a node-driven regression test (revert-verified RED→GREEN) asserting a label-only interruption card and a real user turn stay visible while marker + strict text are filtered.

### Gate results
- Pre-Opus gate: `node -c` ✓, ESLint runtime gate ✓, ruff forward gate ✓
- pytest (full sequential): **7196 passed, 7 skipped, 3 xpassed, 0 failed**
- Opus advisor: flagged the `provider_details_label` over-filter → fixed
- Codex regression gate: **SAFE TO SHIP** (after fix; predicate probe returns `[false,false,true,true]` — genuine interruption + user mention stay visible)
