### PR TITLE
fix: deduplicate appended legacy state messages

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -4128,8 +4128,7 @@ def merge_session_messages_append_only(
             and timestamp <= max_sidecar_timestamp
         ):
             continue
-        if key[0] == "message_id":
-            seen_message_keys.add(key)
+        seen_message_keys.add(key)
         seen_content_keys.add(_session_message_content_key(msg))
         seen_visible_keys.add(visible_key)
         merged_messages.append(msg)

--- a/tests/test_issue3346_session_legacy_dedup.py
+++ b/tests/test_issue3346_session_legacy_dedup.py
@@ -1,0 +1,19 @@
+"""Regression coverage for legacy state-message deduplication."""
+
+from api.models import merge_session_messages_append_only
+
+
+def test_merge_deduplicates_repeated_legacy_state_messages():
+    """A state row appended once must not be appended again with the same key."""
+    sidecar = [{"role": "system", "content": "sys", "id": "s1"}]
+    state = [
+        {"role": "user", "content": "hello"},
+        {"role": "user", "content": "hello"},
+    ]
+
+    merged = merge_session_messages_append_only(sidecar, state)
+
+    assert merged == [
+        {"role": "system", "content": "sys", "id": "s1"},
+        {"role": "user", "content": "hello"},
+    ]


### PR DESCRIPTION
## Summary
- record every appended state-message merge key, including legacy keys without explicit IDs
- prevent repeated legacy state rows from appearing twice when a sidecar is present
- add regression coverage for the confirmed non-empty-sidecar case

This intentionally leaves the separately discussed empty-sidecar early-return behavior unchanged.

## Tests
- `.venv/bin/pytest tests/test_issue3346_session_legacy_dedup.py -q`
- `.venv/bin/python scripts/ruff_lint.py --all`
- `git diff --check`

Closes #3346