### PR TITLE
Release GA — v0.51.207 (#2931 Edge TTS as an alternative speech engine)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.207] — 2026-06-02 — Release GA (Edge TTS as an alternative speech engine)
+
+### Added
+- Added an optional server-side **Edge TTS** speech engine (Microsoft neural voices) selectable in Settings → Preferences → TTS Engine, alongside the existing browser speech synthesis. The voice list switches to the Edge neural voices when selected. A new `POST /api/tts` endpoint streams the audio, gated by the same-origin CSRF check + session auth, a per-client rate limit, a 5000-character cap, and a voice allowlist. `edge-tts` is an optional dependency — the endpoint returns a clear install hint (503) when it isn't present, so existing installs are unaffected (#2931, @liuqiangweb-svg).
+
 ## [v0.51.206] — 2026-06-02 — Release FZ (workspace file upload + drag-and-drop with archive extraction)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -5465,6 +5465,9 @@ def handle_post(handler, parsed) -> bool:
     if parsed.path == "/api/transcribe":
         return handle_transcribe(handler)
 
+    if parsed.path == "/api/tts":
+        return _handle_tts(handler, parsed)
+
     if parsed.path == "/api/client-events/log":
         if diag:
             diag.stage("read_client_event_body")
@@ -8162,6 +8165,143 @@ def _serve_file_bytes(handler, target: Path, mime: str, disposition: str, cache_
     return True
 
 
+
+def _handle_tts(handler, parsed):
+    """Generate TTS audio via Edge TTS. POST JSON body only.
+
+    Design note addressing deep review blocker #4 (synchronous I/O):
+    The server uses ThreadingHTTPServer (see server.py:173), so each request
+    already runs in its own dedicated thread. A TTS request therefore occupies
+    only its own thread during Microsoft network I/O + streaming; other clients
+    are unaffected. Combined with early auth, a strict per-client 2 s rate
+    limit, 5000-char cap, and voice allowlist, the blocking cost is bounded and
+    intentional. Streaming chunks directly via stream_sync() keeps memory
+    usage low. A cross-thread pool + queue would add complexity and wfile
+    thread-safety issues with no practical gain under the current model.
+    If the HTTP layer ever moves to asyncio we can adopt edge_tts's native
+    async API at that time.
+    """
+    text = ""
+    voice = "zh-CN-XiaoxiaoNeural"
+    rate_str = ""
+    pitch_str = ""
+
+    if handler.command != "POST":
+        from api.helpers import bad as _bad
+        return _bad(handler, "POST required for /api/tts", 405)
+
+    try:
+        data = read_body(handler)
+        text = (data.get("text") or "").strip()
+        voice = data.get("voice") or voice
+        rate_str = data.get("rate") or ""
+        pitch_str = data.get("pitch") or ""
+    except Exception:
+        from api.helpers import bad as _bad
+        return _bad(handler, "invalid request body", 400)
+
+    if not text:
+        from api.helpers import bad as _bad
+        return _bad(handler, "text is required", 400)
+    if len(text) > 5000:
+        from api.helpers import bad as _bad
+        return _bad(handler, "text too long (max 5000 characters)", 400)
+
+    from api.auth import is_auth_enabled, parse_cookie, verify_session
+    cv = None
+    if is_auth_enabled():
+        cv = parse_cookie(handler)
+        if not (cv and verify_session(cv)):
+            from api.helpers import bad as _bad
+            return _bad(handler, "unauthorized", 401)
+
+    # High-quality per-client rate limiting for TTS.
+    if not hasattr(_handle_tts, "_tts_limiter"):
+        import time as _time, threading as _threading
+        class _TtsRateLimiter:
+            def __init__(self, window_seconds=2.0, prune_interval=50):
+                self.window = window_seconds
+                self.prune_interval = prune_interval
+                self._hits = {}
+                self._lock = _threading.Lock()
+                self._checks = 0
+
+            def _get_client_key(self, h):
+                for hdr in ("X-Forwarded-For", "X-Real-IP", "Forwarded"):
+                    val = h.headers.get(hdr)
+                    if val:
+                        ip = val.split(",")[0].strip().split(";")[0].strip()
+                        if ip:
+                            return ip
+                return getattr(h, "client_address", ("unknown",))[0]
+
+            def check(self, handler, session_cookie=None):
+                key = self._get_client_key(handler)
+                if session_cookie and "." in str(session_cookie):
+                    key = str(session_cookie).split(".", 1)[0]
+                now = _time.time()
+                with self._lock:
+                    self._checks += 1
+                    if self._checks % self.prune_interval == 0:
+                        cutoff = now - (self.window * 10)
+                        self._hits = {k: v for k, v in self._hits.items() if v > cutoff}
+                    last = self._hits.get(key, 0)
+                    if now - last < self.window:
+                        return False
+                    self._hits[key] = now
+                    return True
+
+        _handle_tts._tts_limiter = _TtsRateLimiter(window_seconds=2.0)
+
+    limiter = _handle_tts._tts_limiter
+    if not limiter.check(handler, cv):
+        logger.warning("TTS rate limit hit for client=%s", limiter._get_client_key(handler))
+        from api.helpers import bad as _bad
+        return _bad(handler, "rate limit exceeded — please wait", 429)
+
+    allowed = {
+        "zh-CN-XiaoxiaoNeural", "zh-CN-XiaoyiNeural", "zh-CN-YunxiNeural",
+        "zh-CN-YunjianNeural", "zh-CN-YunyangNeural",
+        "en-US-AriaNeural", "en-US-GuyNeural"
+    }
+    if voice not in allowed:
+        from api.helpers import bad as _bad
+        return _bad(handler, "invalid voice", 400)
+
+    try:
+        try:
+            import edge_tts
+        except ImportError:
+            from api.helpers import bad as _bad
+            return _bad(handler, "edge-tts not installed — see docs", 503)
+
+        kwargs = {}
+        if rate_str:
+            kwargs["rate"] = rate_str
+        if pitch_str:
+            kwargs["pitch"] = pitch_str
+
+        comm = edge_tts.Communicate(text, voice, **kwargs)
+
+        handler.send_response(200)
+        handler.send_header("Content-Type", "audio/mpeg")
+        handler.send_header("Cache-Control", "no-store")
+        handler.end_headers()
+
+        for chunk in comm.stream_sync():
+            if chunk.get("type") == "audio" and chunk.get("data"):
+                try:
+                    handler.wfile.write(chunk["data"])
+                except (BrokenPipeError, ConnectionResetError):
+                    return True
+        return True
+
+    except BrokenPipeError:
+        return True
+    except Exception:
+        logger.exception("Edge TTS generation failed")
+        from api.helpers import bad as _bad
+        return _bad(handler, "TTS generation failed", 500)
 def _html_preview_with_blank_base(raw: bytes) -> bytes:
     base = '<base target="_blank">'
     text = raw.decode("utf-8", errors="replace")

--- a/api/routes.py
+++ b/api/routes.py
@@ -8273,7 +8273,7 @@ def _handle_tts(handler, parsed):
             import edge_tts
         except ImportError:
             from api.helpers import bad as _bad
-            return _bad(handler, "edge-tts not installed — see docs", 503)
+            return _bad(handler, "Edge TTS engine not installed on the server. Install it with: pip install edge-tts", 503)
 
         kwargs = {}
         if rate_str:

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -196,6 +196,7 @@ chown_home_hermeswebui() {
   # ownership alignment.
   find /home/hermeswebui \
     -path "/home/hermeswebui/.hermes/hermes-agent" -prune \
+    -o -name ".git" -prune \
     -o -exec chown -h "${WANTED_UID}:${WANTED_GID}" {} +
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@
 # The server uses PyYAML plus cryptography for optional local passkey/WebAuthn support.
 # All heavy ML/agent deps live in the Hermes agent venv.
 pyyaml>=6.0
+edge-tts
 cryptography>=42.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
 # Hermes Web UI -- minimal Python dependencies
 # The server uses PyYAML plus cryptography for optional local passkey/WebAuthn support.
 # All heavy ML/agent deps live in the Hermes agent venv.
+#
+# OPTIONAL: the Edge TTS speech engine (Settings -> Voice -> TTS Engine -> "Edge TTS")
+# needs `edge-tts`. It is intentionally NOT a hard dependency — the /api/tts
+# endpoint returns 503 with an install hint when it's absent. Install it only if
+# you want server-side Microsoft neural voices:  pip install edge-tts
 pyyaml>=6.0
-edge-tts
 cryptography>=42.0

--- a/static/boot.js
+++ b/static/boot.js
@@ -1,3 +1,6 @@
+// Early boot initialization that must run before any other code.
+// These run during script evaluation to handle server-stopped state
+// and cross-tab shutdown broadcasts as early as possible.
 (function(){
   // Clear stale stop-server flag on successful page load (server is reachable)
   try{localStorage.removeItem('hermes-webui-server-stopped');}catch(_){}
@@ -889,7 +892,48 @@ window._micPendingSend=window._micPendingSend||false;
         .trim();
     }
     if(!clean){ _startListening(); return; }
-
+    const engine=localStorage.getItem("hermes-tts-engine")||"browser";
+    if(engine==="edge"){
+      const voice=localStorage.getItem("hermes-tts-voice")||"zh-CN-XiaoxiaoNeural";
+      const savedRate=parseFloat(localStorage.getItem("hermes-tts-rate"));
+      const savedPitch=parseFloat(localStorage.getItem("hermes-tts-pitch"));
+      let rate='', pitch='';
+      if(!isNaN(savedRate)){const pct=Math.round((savedRate-1)*100);const sign=pct>=0?'+':'';rate=sign+pct+'%';}
+      if(!isNaN(savedPitch)){const hz=Math.round((savedPitch-1)*50);const sign=hz>=0?'+':'';pitch=sign+hz+'Hz';}
+      _ttsSpeaking=true;
+      fetch(new URL('api/tts', document.baseURI || location.href).href, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({text: clean, voice, rate, pitch})
+      })
+      .then(r => {
+        if(!r.ok) throw new Error('TTS request failed: ' + r.status);
+        return r.blob();
+      })
+      .then(blob => {
+        const url = URL.createObjectURL(blob);
+        const audio = new Audio(url);
+        audio.onended = () => {
+          _ttsSpeaking=false;
+          URL.revokeObjectURL(url);
+          if(_voiceModeActive) setTimeout(()=>_startListening(),500);
+        };
+        audio.onerror = () => {
+          _ttsSpeaking=false;
+          URL.revokeObjectURL(url);
+          if(_voiceModeActive) setTimeout(()=>_startListening(),1000);
+        };
+        audio.play().catch(e => {
+          _ttsSpeaking=false;
+          if(_voiceModeActive) setTimeout(()=>_startListening(),1000);
+        });
+      })
+      .catch(() => {
+        _ttsSpeaking=false;
+        if(_voiceModeActive) setTimeout(()=>_startListening(),1000);
+      });
+      return;
+    }
     const utter=new SpeechSynthesisUtterance(clean);
 
     // Apply saved voice preferences
@@ -1911,7 +1955,6 @@ function applyBotName(){
   // Start real-time gateway session sync if setting is enabled
   if(typeof startGatewaySSE==='function') startGatewaySSE();
 })().catch(e=>{
-  console.error('[hermes] boot failed', e);
   try{S._bootReady=true;}catch(_){}
   try{syncTopbar();}catch(_){}
   try{syncWorkspacePanelState();}catch(_){}

--- a/static/boot.js
+++ b/static/boot.js
@@ -1963,6 +1963,7 @@ function applyBotName(){
   // Start real-time gateway session sync if setting is enabled
   if(typeof startGatewaySSE==='function') startGatewaySSE();
 })().catch(e=>{
+  console.error('[hermes] boot failed', e);
   try{S._bootReady=true;}catch(_){}
   try{syncTopbar();}catch(_){}
   try{syncWorkspacePanelState();}catch(_){}

--- a/static/boot.js
+++ b/static/boot.js
@@ -913,18 +913,26 @@ window._micPendingSend=window._micPendingSend||false;
       .then(blob => {
         const url = URL.createObjectURL(blob);
         const audio = new Audio(url);
+        // Register with the shared handle (declared in ui.js, same global scope;
+        // both scripts are fully evaluated before any voice interaction) so
+        // stopTTS() — called from _deactivate() — can actually pause hands-free
+        // Edge playback. Without this the audio is local here and unstoppable.
+        _playingEdgeAudio=audio;
         audio.onended = () => {
           _ttsSpeaking=false;
+          if(_playingEdgeAudio===audio) _playingEdgeAudio=null;
           URL.revokeObjectURL(url);
           if(_voiceModeActive) setTimeout(()=>_startListening(),500);
         };
         audio.onerror = () => {
           _ttsSpeaking=false;
+          if(_playingEdgeAudio===audio) _playingEdgeAudio=null;
           URL.revokeObjectURL(url);
           if(_voiceModeActive) setTimeout(()=>_startListening(),1000);
         };
         audio.play().catch(e => {
           _ttsSpeaking=false;
+          if(_playingEdgeAudio===audio) _playingEdgeAudio=null;
           if(_voiceModeActive) setTimeout(()=>_startListening(),1000);
         });
       })

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -851,6 +851,8 @@ const LOCALES = {
     settings_desc_tts_voice: "Preferred voice. Populated from your browser's available voices.",
     settings_label_tts_rate: 'Speech rate',
     settings_label_tts_pitch: 'Speech pitch',
+    settings_label_tts_engine: 'TTS Engine',
+    settings_desc_tts_engine: 'Choose speech engine. Edge TTS uses Microsoft neural voices via the server.',
     settings_label_notifications: 'Browser notifications',
     settings_desc_notifications: 'Show a system notification when a response completes while the app is in the background.',
     settings_desc_token_usage: 'Displays input/output token count below each assistant reply. Also toggled with /usage.',
@@ -2171,6 +2173,8 @@ const LOCALES = {
     settings_desc_tts_voice: 'Voce preferita. Popolata dalle voci disponibili nel browser.',
     settings_label_tts_rate: 'Velocità voce',
     settings_label_tts_pitch: 'Tono voce',
+    settings_label_tts_engine: 'Motore TTS',
+    settings_desc_tts_engine: 'Scegli il motore vocale. Edge TTS utilizza le voci neurali Microsoft tramite il server.',
     settings_label_notifications: 'Notifiche browser',
     settings_desc_notifications: 'Mostra una notifica di sistema quando una risposta termina mentre l\'app è in background.',
     settings_desc_token_usage: 'Mostra il conteggio token input/output sotto ogni risposta dell\'assistente. Attivabile anche con /usage.',
@@ -3496,6 +3500,8 @@ const LOCALES = {
     settings_desc_tts_voice: '優先する声。ブラウザで利用可能な声から選択されます。',
     settings_label_tts_rate: '読み上げ速度',
     settings_label_tts_pitch: '読み上げピッチ',
+    settings_label_tts_engine: 'TTSエンジン',
+    settings_desc_tts_engine: '音声エンジンを選択してください。Edge TTSはサーバー経由でMicrosoftのニューラル音声を使用します。',
     settings_label_notifications: 'ブラウザ通知',
     settings_desc_notifications: 'アプリがバックグラウンドの間に応答が完了したらシステム通知を表示します。',
     settings_desc_token_usage: 'アシスタント応答の下に入力/出力トークン数を表示します。/usage でも切替可能。',
@@ -5184,6 +5190,8 @@ const LOCALES = {
     settings_desc_tts_voice: 'Выберите голос для синтеза речи',
     settings_label_tts_rate: 'Скорость речи',
     settings_label_tts_pitch: 'Тон речи',
+    settings_label_tts_engine: 'Движок TTS',
+    settings_desc_tts_engine: 'Выберите движок синтеза речи. Edge TTS использует нейронные голоса Microsoft через сервер.',
 
     checkpoint_date: 'Date',  // TODO: translate
     checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
@@ -6429,6 +6437,8 @@ const LOCALES = {
     settings_desc_tts_voice: 'Seleccionar voz para síntesis de voz',
     settings_label_tts_rate: 'Velocidad de voz',
     settings_label_tts_pitch: 'Tono de voz',
+    settings_label_tts_engine: 'Motor TTS',
+    settings_desc_tts_engine: 'Elija el motor de voz. Edge TTS utiliza voces neuronales de Microsoft a través del servidor.',
     checkpoint_date: 'Date',  // TODO: translate
     checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
     checkpoint_diff_no_changes: 'No differences found between this checkpoint and the current workspace.',  // TODO: translate
@@ -7688,6 +7698,8 @@ const LOCALES = {
     settings_desc_tts_voice: 'Stimme für Sprachsynthese auswählen',
     settings_label_tts_rate: 'Sprechgeschwindigkeit',
     settings_label_tts_pitch: 'Tonhöhe',
+    settings_label_tts_engine: 'TTS-Engine',
+    settings_desc_tts_engine: 'Sprach-Engine auswählen. Edge TTS verwendet Microsoft Neural Voices über den Server.',
 
     checkpoint_date: 'Date',  // TODO: translate
     checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
@@ -8942,6 +8954,8 @@ const LOCALES = {
     settings_desc_tts_voice: '选择语音合成声音',
     settings_label_tts_rate: '语速',
     settings_label_tts_pitch: '音调',
+    settings_label_tts_engine: 'TTS 引擎',
+    settings_desc_tts_engine: '选择语音引擎。Edge TTS 通过服务器使用微软神经语音。',
     checkpoint_date: '日期',
     checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
     checkpoint_diff_no_changes: '此检查点与当前工作区之间无差异。',
@@ -10271,6 +10285,8 @@ const LOCALES = {
     settings_desc_tts_voice: '選擇語音合成聲音',
     settings_label_tts_rate: '語速',
     settings_label_tts_pitch: '音調',
+    settings_label_tts_engine: 'TTS 引擎',
+    settings_desc_tts_engine: '选择语音引擎。Edge TTS 通过服务器使用微软神经语音。',
 
     checkpoint_date: 'Date',  // TODO: translate
     checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
@@ -11414,6 +11430,8 @@ const LOCALES = {
     settings_desc_tts_voice: 'Selecionar voz para síntese de voz',
     settings_label_tts_rate: 'Velocidade da fala',
     settings_label_tts_pitch: 'Tom da fala',
+    settings_label_tts_engine: 'Motor TTS',
+    settings_desc_tts_engine: 'Escolha o mecanismo de fala. Edge TTS usa vozes neurais da Microsoft através do servidor.',
     checkpoint_date: 'Date',  // TODO: translate
     checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
     checkpoint_diff_no_changes: 'No differences found between this checkpoint and the current workspace.',  // TODO: translate
@@ -12720,6 +12738,8 @@ const LOCALES = {
     settings_desc_tts_voice: '음성 합성 음성 선택',
     settings_label_tts_rate: '말 속도',
     settings_label_tts_pitch: '말 톤',
+    settings_label_tts_engine: 'TTS 엔진',
+    settings_desc_tts_engine: '음성 엔진을 선택하세요. Edge TTS는 서버를 통해 Microsoft 신경 음성을 사용합니다.',
     checkpoint_date: 'Date',  // TODO: translate
     checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
     checkpoint_diff_no_changes: 'No differences found between this checkpoint and the current workspace.',  // TODO: translate
@@ -13485,6 +13505,8 @@ const LOCALES = {
     settings_desc_tts_voice: 'Voix préférée. Rempli à partir des voix disponibles dans votre navigateur.',
     settings_label_tts_rate: 'Taux de parole',
     settings_label_tts_pitch: 'Emplacement du discours',
+    settings_label_tts_engine: 'Moteur TTS',
+    settings_desc_tts_engine: 'Choisissez le moteur de synthèse vocale. Edge TTS utilise les voix neuronales Microsoft via le serveur.',
     settings_label_notifications: 'Notifications du navigateur',
     settings_desc_notifications: 'Afficher une notification système lorsqu\'une réponse est terminée alors que l\'application est en arrière-plan.',
     settings_desc_token_usage: 'Affiche le nombre de jetons d’entrée/sortie sous chaque réponse de l’assistant. Également basculé avec /usage.',
@@ -15294,6 +15316,8 @@ const LOCALES = {
     settings_desc_tts_voice: 'Ses sentezi sesini seçin',
     settings_label_tts_rate: 'Konuşma hızı',
     settings_label_tts_pitch: 'Konuşma perdesi',
+    settings_label_tts_engine: 'TTS Motoru',
+    settings_desc_tts_engine: 'Ses motorunu seçin. Edge TTS, sunucu üzerinden Microsoft sinirsel seslerini kullanır.',
     checkpoint_date: 'Tarih',
     checkpoint_diff_files_changed: (n) => `${n} dosya değişti`,
     checkpoint_diff_no_changes: 'Bu kontrol noktası ile mevcut çalışma alanı arasında fark bulunamadı.',

--- a/static/index.html
+++ b/static/index.html
@@ -1070,7 +1070,7 @@
               <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_raw_audio">Record and send the original audio file to the agent instead of converting it to text first. The agent can then transcribe it or process the raw audio (emotion, background noise, custom STT). Like Telegram's voice message behavior.</div>
             </div>
             <div class="settings-field">
-              <label for="settingsTtsVoice" data-i18n="settings_label_tts_voice">Voice</label>
+              <label for="settingsTtsEngine" data-i18n="settings_label_tts_engine">TTS Engine</label><select id="settingsTtsEngine" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px"><option value="browser">Browser speech synthesis</option><option value="edge">Edge TTS (server)</option></select><div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_tts_engine">Choose speech engine. Edge TTS uses Microsoft neural voices via the server.</div></div><div class="settings-field"><label for="settingsTtsVoice" data-i18n="settings_label_tts_voice">Voice</label>
               <select id="settingsTtsVoice" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px">
                 <option value="">Default system voice</option>
               </select>

--- a/static/panels.js
+++ b/static/panels.js
@@ -6253,12 +6253,45 @@ async function loadSettingsPanel(){
         if(typeof window._applyVoiceModePref==='function') window._applyVoiceModePref();
       };
     }
-    // Populate voice selector from speechSynthesis
+    // TTS engine selector
+    const ttsEngineSel=$('settingsTtsEngine');
+    if(ttsEngineSel){
+      const saved=localStorage.getItem('hermes-tts-engine')||'browser';
+      ttsEngineSel.value=saved;
+      ttsEngineSel.onchange=function(){
+        localStorage.setItem('hermes-tts-engine',this.value);
+        window._populateTtsVoices();
+      };
+    }
+    // Populate voice selector based on engine
     const ttsVoiceSel=$('settingsTtsVoice');
-    if(ttsVoiceSel&&'speechSynthesis' in window){
-      const populateVoices=()=>{
+    window._populateTtsVoices=function(){
+      if(!ttsVoiceSel) return;
+      const engine=localStorage.getItem('hermes-tts-engine')||'browser';
+      const current=localStorage.getItem('hermes-tts-voice')||'';
+      if(engine==='edge'){
+        const edgeVoices=[
+          {value:'zh-CN-XiaoxiaoNeural',label:'Xiaoxiao (Chinese, Female)'},
+          {value:'zh-CN-XiaoyiNeural',label:'Xiaoyi (Chinese, Female)'},
+          {value:'zh-CN-YunxiNeural',label:'Yunxi (Chinese, Male)'},
+          {value:'zh-CN-YunjianNeural',label:'Yunjian (Chinese, Male)'},
+          {value:'zh-CN-YunyangNeural',label:'Yunyang (Chinese, Male)'},
+          {value:'en-US-AriaNeural',label:'Aria (English, Female)'},
+          {value:'en-US-GuyNeural',label:'Guy (English, Male)'},
+        ];
+        ttsVoiceSel.innerHTML='<option value="">Default (Xiaoxiao)</option>';
+        edgeVoices.forEach(v=>{
+          const opt=document.createElement('option');
+          opt.value=v.value;opt.textContent=v.label;
+          if(v.value===current) opt.selected=true;
+          ttsVoiceSel.appendChild(opt);
+        });
+      } else {
+        if(!('speechSynthesis' in window)){
+          ttsVoiceSel.innerHTML='<option value="">Speech synthesis not available</option>';
+          return;
+        }
         const voices=speechSynthesis.getVoices();
-        const current=localStorage.getItem('hermes-tts-voice')||'';
         ttsVoiceSel.innerHTML='<option value="">Default system voice</option>';
         voices.forEach(v=>{
           const opt=document.createElement('option');
@@ -6266,9 +6299,14 @@ async function loadSettingsPanel(){
           if(v.name===current) opt.selected=true;
           ttsVoiceSel.appendChild(opt);
         });
-      };
-      populateVoices();
-      speechSynthesis.addEventListener('voiceschanged',populateVoices,{once:true});
+      }
+    };
+    if(ttsVoiceSel&&'speechSynthesis' in window){
+      window._populateTtsVoices();
+      speechSynthesis.addEventListener('voiceschanged',function(){
+        const engine=localStorage.getItem('hermes-tts-engine')||'browser';
+        if(engine==='browser') window._populateTtsVoices();
+      },{once:false});
       ttsVoiceSel.onchange=function(){localStorage.setItem('hermes-tts-voice',this.value);};
     }
     // TTS rate/pitch sliders

--- a/static/ui.js
+++ b/static/ui.js
@@ -4421,29 +4421,44 @@ function _playEdgeTts(text, btn){
   const voice=localStorage.getItem('hermes-tts-voice')||'zh-CN-XiaoxiaoNeural';
   const savedRate=parseFloat(localStorage.getItem('hermes-tts-rate'));
   const savedPitch=parseFloat(localStorage.getItem('hermes-tts-pitch'));
-  let rateParam='', pitchParam='';
-  if(!isNaN(savedRate)){
-    const pct=Math.round((savedRate-1)*100);
-    const sign=pct>=0?'+':'';
-    rateParam='&rate='+encodeURIComponent(sign+pct+'%');
-  }
-  if(!isNaN(savedPitch)){
-    const hz=Math.round((savedPitch-1)*50);
-    const sign=hz>=0?'+':'';
-    pitchParam='&pitch='+encodeURIComponent(sign+hz+'Hz');
-  }
-  const url='/api/tts?text='+encodeURIComponent(text)+'&voice='+encodeURIComponent(voice)+rateParam+pitchParam;
+  let rate='', pitch='';
+  if(!isNaN(savedRate)){const pct=Math.round((savedRate-1)*100);const sign=pct>=0?'+':'';rate=sign+pct+'%';}
+  if(!isNaN(savedPitch)){const hz=Math.round((savedPitch-1)*50);const sign=hz>=0?'+':'';pitch=sign+hz+'Hz';}
   if(btn) btn.dataset.speaking='1';
   _ttsSpeaking=true;
-  const audio=new Audio(url);
-  _playingEdgeAudio=audio;
-  audio.onended=function(){_ttsSpeaking=false;_playingEdgeAudio=null;if(btn)btn.dataset.speaking='0';};
-  audio.onerror=function(){_ttsSpeaking=false;_playingEdgeAudio=null;if(btn)btn.dataset.speaking='0';};
-  audio.play().catch(function(e){
+  // /api/tts is POST-only (and behind the same-origin CSRF gate); GET via
+  // new Audio(url) would 405 and silently fail, and would also leak the message
+  // text into the query string / access log. POST the JSON body, then play the
+  // returned audio via an object URL — mirrors the working boot.js edge path.
+  const _fail=function(msg){
     _ttsSpeaking=false;_playingEdgeAudio=null;
     if(btn)btn.dataset.speaking='0';
-    showToast('Edge TTS error: '+e.message);
-  });
+    if(msg&&typeof showToast==='function') showToast(msg,4000,'error');
+  };
+  fetch(new URL('api/tts', document.baseURI || location.href).href, {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({text:text, voice:voice, rate:rate, pitch:pitch})
+  })
+  .then(function(r){
+    if(!r.ok){
+      // Surface the server error (e.g. 503 "edge-tts not installed", 429 rate limit)
+      return r.json().catch(function(){return {};}).then(function(j){
+        throw new Error((j&&j.error)||('TTS request failed: '+r.status));
+      });
+    }
+    return r.blob();
+  })
+  .then(function(blob){
+    const url=URL.createObjectURL(blob);
+    const audio=new Audio(url);
+    _playingEdgeAudio=audio;
+    const _cleanup=function(){_ttsSpeaking=false;_playingEdgeAudio=null;if(btn)btn.dataset.speaking='0';try{URL.revokeObjectURL(url);}catch(_){}};
+    audio.onended=_cleanup;
+    audio.onerror=function(){_cleanup();};
+    audio.play().catch(function(e){_cleanup();showToast('Edge TTS error: '+(e&&e.message||e));});
+  })
+  .catch(function(e){ _fail((e&&e.message)||'Edge TTS failed'); });
 }
 
 function stopTTS(){

--- a/static/ui.js
+++ b/static/ui.js
@@ -4353,6 +4353,8 @@ function _stripForTTS(text){
   text=text.replace(/\[([^\]]+)\]\([^)]+\)/g,'$1');
   // Replace MEDIA: paths with a simple label
   text=text.replace(/MEDIA:[^\s]+/g,'a file');
+  // Strip emoji and emoticons
+  text=text.replace(/[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{FE00}-\u{FE0F}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{200D}]/gu,'');
   // Strip HTML tags that may leak through markdown
   text=text.replace(/<[^>]+>/g,' ');
   // Collapse whitespace
@@ -4362,18 +4364,13 @@ function _stripForTTS(text){
 
 let _ttsSpeaking=false;
 let _ttsCurrentUtterance=null;
+let _playingEdgeAudio=null;
 
 function speakMessage(btn){
-  if(!('speechSynthesis' in window)){
-    showToast(t('tts_not_supported')||'Speech synthesis not supported in this browser.');
-    return;
-  }
-  // If already speaking this message, stop
   if(btn&&btn.dataset.speaking==='1'){
     stopTTS();
     return;
   }
-  // Stop any current speech
   stopTTS();
 
   const row=btn?btn.closest('[data-raw-text]'):null;
@@ -4382,6 +4379,17 @@ function speakMessage(btn){
 
   const clean=_stripForTTS(text);
   if(!clean) return;
+
+  const engine=localStorage.getItem('hermes-tts-engine')||'browser';
+  if(engine==='edge'){
+    _playEdgeTts(clean, btn);
+    return;
+  }
+
+  if(!('speechSynthesis' in window)){
+    showToast(t('tts_not_supported')||'Speech synthesis not supported in this browser.');
+    return;
+  }
 
   const utter=new SpeechSynthesisUtterance(clean);
 
@@ -4409,9 +4417,43 @@ function speakMessage(btn){
   speechSynthesis.speak(utter);
 }
 
+function _playEdgeTts(text, btn){
+  const voice=localStorage.getItem('hermes-tts-voice')||'zh-CN-XiaoxiaoNeural';
+  const savedRate=parseFloat(localStorage.getItem('hermes-tts-rate'));
+  const savedPitch=parseFloat(localStorage.getItem('hermes-tts-pitch'));
+  let rateParam='', pitchParam='';
+  if(!isNaN(savedRate)){
+    const pct=Math.round((savedRate-1)*100);
+    const sign=pct>=0?'+':'';
+    rateParam='&rate='+encodeURIComponent(sign+pct+'%');
+  }
+  if(!isNaN(savedPitch)){
+    const hz=Math.round((savedPitch-1)*50);
+    const sign=hz>=0?'+':'';
+    pitchParam='&pitch='+encodeURIComponent(sign+hz+'Hz');
+  }
+  const url='/api/tts?text='+encodeURIComponent(text)+'&voice='+encodeURIComponent(voice)+rateParam+pitchParam;
+  if(btn) btn.dataset.speaking='1';
+  _ttsSpeaking=true;
+  const audio=new Audio(url);
+  _playingEdgeAudio=audio;
+  audio.onended=function(){_ttsSpeaking=false;_playingEdgeAudio=null;if(btn)btn.dataset.speaking='0';};
+  audio.onerror=function(){_ttsSpeaking=false;_playingEdgeAudio=null;if(btn)btn.dataset.speaking='0';};
+  audio.play().catch(function(e){
+    _ttsSpeaking=false;_playingEdgeAudio=null;
+    if(btn)btn.dataset.speaking='0';
+    showToast('Edge TTS error: '+e.message);
+  });
+}
+
 function stopTTS(){
   if('speechSynthesis' in window){
     speechSynthesis.cancel();
+  }
+  // Stop Edge TTS audio
+  if(_playingEdgeAudio){
+    try{ _playingEdgeAudio.pause(); _playingEdgeAudio.currentTime=0; }catch(_){}
+    _playingEdgeAudio=null;
   }
   _ttsSpeaking=false;
   _ttsCurrentUtterance=null;
@@ -4420,7 +4462,8 @@ function stopTTS(){
 }
 
 function autoReadLastAssistant(){
-  if(!('speechSynthesis' in window)) return;
+  const engine=localStorage.getItem('hermes-tts-engine')||'browser';
+  if(engine==='browser'&&!('speechSynthesis' in window)) return;
   const pref=localStorage.getItem('hermes-tts-auto-read');
   if(pref!=='true') return;
   // Find the last assistant message segment in the DOM
@@ -4431,7 +4474,10 @@ function autoReadLastAssistant(){
   if(!text.trim()) return;
   const clean=_stripForTTS(text);
   if(!clean) return;
-
+  if(engine==='edge'){
+    _playEdgeTts(clean, null);
+    return;
+  }
   const utter=new SpeechSynthesisUtterance(clean);
   const savedVoice=localStorage.getItem('hermes-tts-voice');
   const voices=speechSynthesis.getVoices();

--- a/tests/test_issue2931_edge_tts_endpoint.py
+++ b/tests/test_issue2931_edge_tts_endpoint.py
@@ -1,0 +1,97 @@
+"""Validation + security-path coverage for the Edge TTS endpoint (#2931).
+
+These exercise the guard rails of _handle_tts (method, input cap, voice
+allowlist, rate limiting) in-process via a fake handler — no network and no
+real edge-tts synthesis required, since every rejection happens before the
+edge_tts import / Communicate call.
+"""
+import io
+import json
+
+import api.routes as routes
+
+
+class _FakeHandler:
+    def __init__(self, body: bytes, command: str = "POST", headers=None, client="1.2.3.4"):
+        self.command = command
+        self.rfile = io.BytesIO(body)
+        self.wfile = io.BytesIO()
+        self.headers = headers or {}
+        self.headers.setdefault("Content-Length", str(len(body)))
+        self.client_address = (client, 12345)
+        self.status = None
+        self.sent_headers = {}
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.sent_headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def payload(self):
+        try:
+            return json.loads(self.wfile.getvalue().decode("utf-8"))
+        except Exception:
+            return None
+
+
+def _post(body_dict, **kw):
+    body = json.dumps(body_dict).encode()
+    return _FakeHandler(body, **kw)
+
+
+def _reset_limiter():
+    # Drop any limiter state carried between tests so rate-limit assertions are
+    # deterministic regardless of run order.
+    if hasattr(routes._handle_tts, "_tts_limiter"):
+        del routes._handle_tts._tts_limiter
+
+
+def test_tts_requires_post():
+    _reset_limiter()
+    h = _post({"text": "hello"}, command="GET")
+    routes._handle_tts(h, None)
+    assert h.status == 405
+
+
+def test_tts_requires_text():
+    _reset_limiter()
+    h = _post({"text": "   "})
+    routes._handle_tts(h, None)
+    assert h.status == 400
+    assert "text is required" in (h.payload() or {}).get("error", "")
+
+
+def test_tts_rejects_overlong_text():
+    _reset_limiter()
+    h = _post({"text": "x" * 5001})
+    routes._handle_tts(h, None)
+    assert h.status == 400
+    assert "too long" in (h.payload() or {}).get("error", "")
+
+
+def test_tts_rejects_unknown_voice():
+    _reset_limiter()
+    h = _post({"text": "hello", "voice": "evil-voice-injection"}, client="5.6.7.8")
+    routes._handle_tts(h, None)
+    assert h.status == 400
+    assert "invalid voice" in (h.payload() or {}).get("error", "")
+
+
+def test_tts_rate_limits_second_immediate_request():
+    _reset_limiter()
+    # The limiter runs (and records the client) BEFORE the voice allowlist and
+    # before any edge-tts synthesis. Use an invalid voice so the first request
+    # still registers with the limiter but returns at the allowlist (400) without
+    # making a real network call; the second immediate request from the SAME
+    # client is then throttled (429).
+    h1 = _post({"text": "hello", "voice": "not-a-real-voice"}, client="9.9.9.9")
+    routes._handle_tts(h1, None)
+    assert h1.status == 400  # rejected at allowlist, limiter recorded the client
+    h2 = _post({"text": "hello", "voice": "not-a-real-voice"}, client="9.9.9.9")
+    routes._handle_tts(h2, None)
+    assert h2.status == 429
+    _reset_limiter()

--- a/tests/test_issue2931_edge_tts_endpoint.py
+++ b/tests/test_issue2931_edge_tts_endpoint.py
@@ -8,6 +8,8 @@ edge_tts import / Communicate call.
 import io
 import json
 
+import pytest
+
 import api.routes as routes
 
 
@@ -50,15 +52,23 @@ def _reset_limiter():
         del routes._handle_tts._tts_limiter
 
 
-def test_tts_requires_post():
+@pytest.fixture(autouse=True)
+def _fresh_tts_limiter():
+    # The limiter is a function-attribute singleton that persists across the
+    # whole test session; reset it before AND after every test in this module so
+    # neither prior suite state nor these tests leak rate-limit state.
     _reset_limiter()
+    yield
+    _reset_limiter()
+
+
+def test_tts_requires_post():
     h = _post({"text": "hello"}, command="GET")
     routes._handle_tts(h, None)
     assert h.status == 405
 
 
 def test_tts_requires_text():
-    _reset_limiter()
     h = _post({"text": "   "})
     routes._handle_tts(h, None)
     assert h.status == 400
@@ -66,32 +76,29 @@ def test_tts_requires_text():
 
 
 def test_tts_rejects_overlong_text():
-    _reset_limiter()
-    h = _post({"text": "x" * 5001})
+    h = _post({"text": "x" * 5001}, client="10.0.0.1")
     routes._handle_tts(h, None)
     assert h.status == 400
     assert "too long" in (h.payload() or {}).get("error", "")
 
 
 def test_tts_rejects_unknown_voice():
-    _reset_limiter()
-    h = _post({"text": "hello", "voice": "evil-voice-injection"}, client="5.6.7.8")
+    h = _post({"text": "hello", "voice": "evil-voice-injection"}, client="10.0.0.2")
     routes._handle_tts(h, None)
     assert h.status == 400
     assert "invalid voice" in (h.payload() or {}).get("error", "")
 
 
 def test_tts_rate_limits_second_immediate_request():
-    _reset_limiter()
     # The limiter runs (and records the client) BEFORE the voice allowlist and
     # before any edge-tts synthesis. Use an invalid voice so the first request
     # still registers with the limiter but returns at the allowlist (400) without
     # making a real network call; the second immediate request from the SAME
-    # client is then throttled (429).
-    h1 = _post({"text": "hello", "voice": "not-a-real-voice"}, client="9.9.9.9")
+    # client is then throttled (429). Unique client IP avoids any cross-test key
+    # collision (the autouse fixture also resets the limiter each test).
+    h1 = _post({"text": "hello", "voice": "not-a-real-voice"}, client="10.0.0.3")
     routes._handle_tts(h1, None)
     assert h1.status == 400  # rejected at allowlist, limiter recorded the client
-    h2 = _post({"text": "hello", "voice": "not-a-real-voice"}, client="9.9.9.9")
+    h2 = _post({"text": "hello", "voice": "not-a-real-voice"}, client="10.0.0.3")
     routes._handle_tts(h2, None)
     assert h2.status == 429
-    _reset_limiter()

--- a/tests/test_issue2931_edge_tts_endpoint.py
+++ b/tests/test_issue2931_edge_tts_endpoint.py
@@ -53,10 +53,18 @@ def _reset_limiter():
 
 
 @pytest.fixture(autouse=True)
-def _fresh_tts_limiter():
+def _fresh_tts_limiter(monkeypatch):
     # The limiter is a function-attribute singleton that persists across the
     # whole test session; reset it before AND after every test in this module so
     # neither prior suite state nor these tests leak rate-limit state.
+    # Also force auth OFF: these tests exercise the method/length/voice/rate-limit
+    # guards, which sit before the auth check. Another test in the full suite can
+    # leave is_auth_enabled() True globally, which would 401 these requests before
+    # they reach the path under test. Pin it False so the assertions are
+    # deterministic regardless of suite order.
+    import api.auth as _auth
+    monkeypatch.setattr(_auth, "is_auth_enabled", lambda: False)
+    monkeypatch.setattr(routes, "is_auth_enabled", lambda: False, raising=False)
     _reset_limiter()
     yield
     _reset_limiter()


### PR DESCRIPTION
## Release GA — v0.51.207 (#2931 Edge TTS speech engine)

Single contributor PR, deep-reviewed fresh + maintainer fixes. Adds an optional server-side Edge TTS engine (Microsoft neural voices) as an alternative to browser speech synthesis.

### What's in this release

**#2931 — Edge TTS** (@liuqiangweb-svg)
A "TTS Engine" selector in Settings → Preferences (browser vs Edge), with the voice list switching to Edge neural voices when selected. New `POST /api/tts` streams audio, gated by same-origin CSRF + session auth, a 2s/client rate limit, a 5000-char cap, and a voice allowlist.

### Review + maintainer changes

Cherry-picked onto current master (576 commits stale), resolved a Settings conflict (master's raw-audio checkbox + the new TTS-engine selector now coexist). Both advisors caught real bugs the settings UI couldn't reveal:

- **Playback was broken (Opus MUST-FIX + Codex SILENT):** `_playEdgeTts()` did `new Audio('/api/tts?text=...')` — a GET — but the endpoint is POST-only. The per-message speaker button + auto-read silently failed in Edge mode, and the GET leaked message text into the query string/access log. Rewritten to POST JSON + blob object URL; now surfaces 503/429 errors via toast.
- **Hands-free Edge audio was unstoppable (Codex SILENT):** boot.js's audio wasn't registered with the shared stop handle, so turning voice mode off didn't pause it. Fixed.
- **Dropped boot logging (Codex SILENT):** the PR silently removed `console.error('[hermes] boot failed', e)` from the top-level boot catch. Restored to match master.
- **Optional dependency:** edge-tts was added as a hard base requirement, but the endpoint is optional (503 when absent). Moved it out of requirements.txt with an install hint; fixed the 503 message.
- **No tests in the PR:** added `tests/test_issue2931_edge_tts_endpoint.py` (method/length/voice-allowlist/rate-limit), with an autouse fixture pinning auth-off + resetting the limiter singleton for suite-order determinism.

### Verification
- Pre-Opus gate (node -c, ruff, ESLint runtime, merge-markers) — clean
- Full sequential pytest: **7230 passed, 0 failed**
- Opus advisor: **SHIP-AS-IS** (MUST-FIX resolved)
- Codex regression gate: **SAFE TO SHIP**
- Browser UX review of the engine selector (browser + edge states), vision-verified + maintainer-approved (Telegram, 2026-06-02)

Co-authored-by: liuqiangweb-svg <liuqiangweb-svg@users.noreply.github.com>