### PR TITLE
fix: highlight extensionless workspace code files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Workspace file previews now syntax-highlight common code/config filenames without useful extensions, including `Dockerfile`, `Dockerfile.*`, `Makefile`, `GNUmakefile`, `CMakeLists.txt`, `.gitignore`, and `.dockerignore`.
+
 ## [v0.51.206] — 2026-06-02 — Release FZ (workspace file upload + drag-and-drop with archive extraction)
 
 ### Added

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -594,7 +594,15 @@ const _PRISM_LANG_MAP={
   diff:'diff',patch:'diff',
   txt:'',log:'',csv:'',tsv:'',
 };
+const _PRISM_BASENAME_LANG_MAP={
+  'dockerfile':'docker','makefile':'makefile','gnumakefile':'makefile',
+  'cmakelists.txt':'cmake',
+  '.gitignore':'ignore','.dockerignore':'ignore',
+};
 function _prismLanguageForPath(path){
+  const base=String(path||'').split(/[\\/]/).pop().toLowerCase();
+  if(base.startsWith('dockerfile.')) return 'docker';
+  if(_PRISM_BASENAME_LANG_MAP[base]!==undefined) return _PRISM_BASENAME_LANG_MAP[base];
   const ext=fileExt(path).replace(/^\./,'');
   return _PRISM_LANG_MAP[ext]!==undefined?_PRISM_LANG_MAP[ext]:'plaintext';
 }

--- a/tests/test_issue3337_workspace_preview_highlight.py
+++ b/tests/test_issue3337_workspace_preview_highlight.py
@@ -33,6 +33,25 @@ def test_prism_language_map_covers_common_extensions():
     assert "txt:''" in WORKSPACE_JS
 
 
+def test_prism_language_path_fallback_covers_extensionless_code_filenames():
+    """Common code/config filenames without useful extensions should still
+    activate Prism grammar selection in workspace previews (#3365).
+    """
+    assert "_PRISM_BASENAME_LANG_MAP" in WORKSPACE_JS
+    expected = {
+        "Dockerfile": "docker",
+        "Makefile": "makefile",
+        "makefile": "makefile",
+        "GNUmakefile": "makefile",
+        "CMakeLists.txt": "cmake",
+        ".gitignore": "ignore",
+        ".dockerignore": "ignore",
+    }
+    for filename, language in expected.items():
+        assert f"{filename.lower()!r}:{language!r}" in WORKSPACE_JS
+    assert "base.startsWith('dockerfile.')" in WORKSPACE_JS
+
+
 def test_plain_text_files_do_not_inherit_prior_file_highlighting():
     """Cross-file leak fix: a plain-text preview after a code preview must not
     inherit the previous file's language. Two guards make this hold:


### PR DESCRIPTION
## Thinking Path
- Issue #3365 identifies that workspace preview syntax highlighting only checked file extensions.
- Common code/config filenames such as Dockerfile and Makefile have no useful extension, so they fell back to plain text.

## What Changed
- Adds a basename language map for common extensionless code/config filenames.
- Handles Dockerfile variants such as Dockerfile.prod before falling back to extension-based detection.
- Adds regression coverage alongside the existing workspace preview syntax-highlighting tests.

## Why It Matters
- Workspace previews now highlight common project files instead of showing them as plain text.

## Verification
- python3 -m pytest tests/test_issue3337_workspace_preview_highlight.py -q
- node --check static/workspace.js
- git diff --check

Closes #3365
