### PR TITLE
fix(stream): replay active run activity on reconnect

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -4643,7 +4643,7 @@ class StreamChannel:
         self._subscribers: list[queue.Queue] = []
         self._offline_buffer: list[tuple[str, object]] = []
 
-    def subscribe(self) -> queue.Queue:
+    def subscribe(self, *, replay_buffer: bool = True) -> queue.Queue:
         q: queue.Queue = queue.Queue()
         with self._lock:
             # Replay buffered events to the new subscriber INSIDE the lock so a
@@ -4651,8 +4651,9 @@ class StreamChannel:
             # finish replaying the older buffered tail. queue.Queue.put_nowait
             # is non-blocking on an unbounded queue, so holding the lock here
             # is safe. Per Opus advisor on stage-292.
-            for item in self._offline_buffer:
-                q.put_nowait(item)
+            if replay_buffer:
+                for item in self._offline_buffer:
+                    q.put_nowait(item)
             self._subscribers.append(q)
         return q
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -7635,7 +7635,13 @@ def _parse_run_journal_after_seq(qs: dict, stream_id: str | None = None) -> int 
         return 0
 
 
-def _replay_run_journal(handler, stream_id: str, after_seq: int | None) -> bool:
+def _replay_run_journal(
+    handler,
+    stream_id: str,
+    after_seq: int | None,
+    *,
+    include_stale: bool = True,
+) -> bool:
     summary = find_run_summary(stream_id)
     if not summary:
         return False
@@ -7651,7 +7657,7 @@ def _replay_run_journal(handler, stream_id: str, after_seq: int | None) -> bool:
             entry.get("payload"),
             entry.get("event_id"),
         )
-    if not summary.get("terminal"):
+    if include_stale and not summary.get("terminal"):
         stale = stale_interrupted_event(
             str(summary.get("session_id") or ""),
             stream_id,
@@ -7787,6 +7793,25 @@ def _handle_sse_stream(handler, parsed):
     handler.send_header("Connection", "close")
     handler.end_headers()
     try:
+        # Active WebUI-owned streams can still have already-journaled events
+        # (for example, when a user opens a session after the gateway worker has
+        # started running tools, or when the browser reconnects after losing the
+        # first EventSource). Subscribe first so future live events queue up,
+        # then replay durable history without synthesizing the stale-worker
+        # interruption marker that is only valid after the in-memory stream is
+        # gone. Without this active-stream replay, late subscribers see an empty
+        # Activity area until the next tool event even though /health reports an
+        # active gateway-tool run.
+        try:
+            _replay_run_journal(
+                handler,
+                stream_id,
+                _parse_run_journal_after_seq(qs, stream_id),
+                include_stale=False,
+            )
+            handler.wfile.flush()
+        except Exception:
+            logger.debug("Failed to replay active run journal for stream %s", stream_id, exc_info=True)
         while True:
             try:
                 event, data = subscriber.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)

--- a/api/routes.py
+++ b/api/routes.py
@@ -7785,7 +7785,7 @@ def _handle_sse_stream(handler, parsed):
         except _CLIENT_DISCONNECT_ERRORS:
             pass
         return True
-    subscriber = stream.subscribe() if hasattr(stream, "subscribe") else stream
+    subscriber = stream.subscribe(replay_buffer=False) if hasattr(stream, "subscribe") else stream
     handler.send_response(200)
     handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
     handler.send_header("Cache-Control", "no-cache")
@@ -7801,7 +7801,10 @@ def _handle_sse_stream(handler, parsed):
         # interruption marker that is only valid after the in-memory stream is
         # gone. Without this active-stream replay, late subscribers see an empty
         # Activity area until the next tool event even though /health reports an
-        # active gateway-tool run.
+        # active gateway-tool run. Do not also preload StreamChannel's offline
+        # buffer for this subscriber: those gap events are journaled by the
+        # producer before they are queued, so replaying both sources would emit
+        # the same tool/token frames twice on late attach.
         try:
             _replay_run_journal(
                 handler,

--- a/static/messages.js
+++ b/static/messages.js
@@ -916,7 +916,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
           if(st.active){
             setComposerStatus('Reconnected');
-            _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}`,document.baseURI||location.href).href,{withCredentials:true}));
+            _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${_runJournalReplayParams()}`,document.baseURI||location.href).href,{withCredentials:true}));
             return;
           }
         }
@@ -2280,7 +2280,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
             if(st.active){
               setComposerStatus('Reconnected');
-              _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}`,document.baseURI||location.href).href,{withCredentials:true}));
+              _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${_runJournalReplayParams()}`,document.baseURI||location.href).href,{withCredentials:true}));
               return;
             }
             if(st.replay_available){
@@ -2512,7 +2512,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }
       }catch(_){}
     }
-    const replayParams=replayOnly?_runJournalReplayParams():'';
+    const replayParams=reconnecting?_runJournalReplayParams():'';
     _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${replayParams}`,document.baseURI||location.href).href,{withCredentials:true}));
   })();
 

--- a/tests/test_issue_1584_multitab_sse.py
+++ b/tests/test_issue_1584_multitab_sse.py
@@ -133,3 +133,46 @@ def test_active_stream_replays_journaled_activity_for_late_subscribers(tmp_path,
     finally:
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)
+
+
+def test_active_stream_late_subscriber_deduplicates_journal_and_offline_buffer(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+
+    session_id = "late-subscriber-dedup-session"
+    stream_id = "late-subscriber-dedup-stream"
+    tool_payload = {
+        "name": "terminal",
+        "preview": "terminal: pytest",
+        "args": {},
+        "is_error": False,
+        "tid": "call-1",
+    }
+    append_run_event(session_id, stream_id, "tool", tool_payload)
+
+    stream = create_stream_channel()
+    stream.put_nowait(("tool", tool_payload))
+    with STREAMS_LOCK:
+        STREAMS[stream_id] = stream
+    handler = _FakeHandler()
+    thread = threading.Thread(
+        target=_handle_sse_stream,
+        args=(handler, SimpleNamespace(query=f"stream_id={stream_id}&after_seq=0")),
+        daemon=True,
+    )
+
+    try:
+        thread.start()
+        stream.put_nowait(("stream_end", {"status": "done"}))
+        thread.join(timeout=1)
+        assert not thread.is_alive(), "active stream should finish after live stream_end"
+
+        payload = handler.wfile.getvalue().decode("utf-8")
+        assert handler.status == 200
+        assert payload.count("event: tool") == 1
+        assert payload.count('"tid": "call-1"') == 1
+        assert "event: stream_end" in payload
+    finally:
+        with STREAMS_LOCK:
+            STREAMS.pop(stream_id, None)

--- a/tests/test_issue_1584_multitab_sse.py
+++ b/tests/test_issue_1584_multitab_sse.py
@@ -2,7 +2,9 @@ import io
 import threading
 from types import SimpleNamespace
 
+import api.models as models
 from api.config import STREAMS, STREAMS_LOCK, create_stream_channel
+from api.run_journal import append_run_event
 from api.routes import _handle_sse_stream
 
 
@@ -78,6 +80,56 @@ def test_same_stream_in_two_tabs_receives_identical_token_sequence():
             assert '"text": "H"' in payload
             assert '"text": "allo"' in payload
             assert "event: stream_end" in payload
+    finally:
+        with STREAMS_LOCK:
+            STREAMS.pop(stream_id, None)
+
+
+def test_active_stream_replays_journaled_activity_for_late_subscribers(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+
+    session_id = "late-subscriber-session"
+    stream_id = "late-subscriber-stream"
+    append_run_event(
+        session_id,
+        stream_id,
+        "tool",
+        {
+            "name": "terminal",
+            "preview": "terminal: pytest",
+            "args": {},
+            "is_error": False,
+            "tid": "call-1",
+        },
+    )
+
+    stream = create_stream_channel()
+    with STREAMS_LOCK:
+        STREAMS[stream_id] = stream
+    handler = _FakeHandler()
+    thread = threading.Thread(
+        target=_handle_sse_stream,
+        args=(handler, SimpleNamespace(query=f"stream_id={stream_id}&after_seq=0")),
+        daemon=True,
+    )
+
+    try:
+        thread.start()
+        stream.put_nowait(("token", {"text": "later"}))
+        stream.put_nowait(("stream_end", {"status": "done"}))
+        thread.join(timeout=1)
+        assert not thread.is_alive(), "active stream should finish after live stream_end"
+
+        payload = handler.wfile.getvalue().decode("utf-8")
+        assert handler.status == 200
+        assert f"id: {stream_id}:1" in payload
+        assert "event: tool" in payload
+        assert '"name": "terminal"' in payload
+        assert '"preview": "terminal: pytest"' in payload
+        assert '"text": "later"' in payload
+        assert "interrupted" not in payload
     finally:
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -11,7 +11,7 @@ def test_reattach_path_uses_replay_when_status_reports_journal():
 
     assert "st.replay_available" in block
     assert "replayOnly=true" in block
-    assert "replayOnly?_runJournalReplayParams():''" in block
+    assert "reconnecting?_runJournalReplayParams():''" in block
     assert "_clearOwnerInflightState()" in block
 
 


### PR DESCRIPTION
## Summary
- replay already-journaled run events when a browser attaches to an active WebUI stream
- keep stale-worker interruption synthesis disabled for still-active streams
- add a regression test covering late subscribers seeing prior tool activity plus future live events

## Tests
- `python3 -m pytest tests/test_issue_1584_multitab_sse.py tests/test_webui_gateway_chat_backend.py tests/test_gateway_sse_reconnect_dedupe.py -q`
- `python3 -m py_compile api/routes.py api/run_journal.py api/gateway_chat.py`
- `git diff --check origin/master...HEAD`
