### PR TITLE
Release GC — v0.51.209 (#2622 WebUI dashboard plugin system with iframe isolation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Added
+- WebUI dashboard plugins: plugins that ship a UI under `~/.hermes/plugins/<name>/dashboard/` (with a `manifest.json`) now appear as cards in Settings → Plugins with an **Open** button that renders the plugin page inside a sandboxed iframe (`sandbox="allow-scripts allow-forms allow-popups"` — no `allow-same-origin`, so plugin JS/CSS/modals stay fully isolated from the parent app). New `/plugins/` (shared assets) and `/dashboard-plugins/<name>/` (per-plugin assets) static routes serve plugin files with path-traversal protection. Display-only — no plugin backend/subprocess execution (#2622, @pix0127).
+
 ## [v0.51.208] — 2026-06-02 — Release GB (workspace upload hardening hotfix)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 
 ## [Unreleased]
 
+## [v0.51.209] — 2026-06-02 — Release GC (WebUI dashboard plugin system with iframe isolation)
+
 ### Added
-- WebUI dashboard plugins: plugins that ship a UI under `~/.hermes/plugins/<name>/dashboard/` (with a `manifest.json`) now appear as cards in Settings → Plugins with an **Open** button that renders the plugin page inside a sandboxed iframe (`sandbox="allow-scripts allow-forms allow-popups"` — no `allow-same-origin`, so plugin JS/CSS/modals stay fully isolated from the parent app). New `/plugins/` (shared assets) and `/dashboard-plugins/<name>/` (per-plugin assets) static routes serve plugin files with path-traversal protection. Display-only — no plugin backend/subprocess execution (#2622, @pix0127).
+- WebUI dashboard plugins: plugins that ship a UI under `~/.hermes/plugins/<name>/dashboard/` (with a `manifest.json`) now appear as opt-in cards in Settings → Plugins (default off). Once enabled, an **Open** button renders the plugin page inside a sandboxed iframe (`sandbox="allow-scripts allow-forms allow-popups"` — no `allow-same-origin`, so plugin JS/CSS/modals stay fully isolated from the parent app). New `/plugins/` (shared assets) and `/dashboard-plugins/<name>/` (per-plugin assets) static routes serve only built `dist/`/`static/` files with path-traversal, dotfile, and extension-allowlist protection (plugin source/config such as `plugin_api.py`/`manifest.json`/`.env` is never served), and both the page and asset routes are gated server-side on the enable state + an HTTP `sandbox` CSP + `nosniff`. Plugin `name` and `tab.path` are validated at load. Display-only — no plugin backend/subprocess execution (#2622, @pix0127).
 
 ## [v0.51.208] — 2026-06-02 — Release GB (workspace upload hardening hotfix)
 

--- a/api/config.py
+++ b/api/config.py
@@ -4866,6 +4866,7 @@ _SETTINGS_DEFAULTS = {
     "show_thinking": True,  # show/hide thinking/reasoning blocks in chat view
     "simplified_tool_calling": True,  # render tools/thinking as compact inline timeline activity
     "api_redact_enabled": True,  # redact sensitive data (API keys, secrets) from API responses
+    "dashboard_plugins": {},  # plugin_name -> bool, opt-in per plugin (default off per PF-10b)
     "sidebar_density": "compact",  # compact | detailed
     "auto_title_refresh_every": "0",  # adaptive title refresh: 0=off, 5/10/20=every N exchanges
     "busy_input_mode": "queue",  # behavior when sending while agent is running: queue | interrupt | steer
@@ -5037,8 +5038,16 @@ def save_settings(settings: dict) -> dict:
     if settings.pop("_clear_password", False):
         current["password_hash"] = None
         _password_changed = True
+    # Deep-merge dashboard_plugins dict (plugin_name -> bool)
+    _dashboard_plugins = settings.get("dashboard_plugins")
+    if isinstance(_dashboard_plugins, dict):
+        current_dash = current.get("dashboard_plugins", {})
+        if isinstance(current_dash, dict):
+            current_dash.update(_dashboard_plugins)
+            current["dashboard_plugins"] = current_dash
     for k, v in settings.items():
-        if k in _SETTINGS_ALLOWED_KEYS:
+        if k == "dashboard_plugins":
+            continue
             if k == "theme":
                 if isinstance(v, str) and v.strip():
                     pending_theme = v

--- a/api/config.py
+++ b/api/config.py
@@ -5043,7 +5043,9 @@ def save_settings(settings: dict) -> dict:
     if isinstance(_dashboard_plugins, dict):
         current_dash = current.get("dashboard_plugins", {})
         if isinstance(current_dash, dict):
-            current_dash.update(_dashboard_plugins)
+            # Coerce values to bool + keep only str keys so settings.json can't be
+            # polluted with non-bool/non-str junk from a crafted POST.
+            current_dash.update({k: bool(v) for k, v in _dashboard_plugins.items() if isinstance(k, str)})
             current["dashboard_plugins"] = current_dash
     for k, v in settings.items():
         # dashboard_plugins is deep-merged above (not a flat allowlisted scalar).

--- a/api/config.py
+++ b/api/config.py
@@ -5046,8 +5046,10 @@ def save_settings(settings: dict) -> dict:
             current_dash.update(_dashboard_plugins)
             current["dashboard_plugins"] = current_dash
     for k, v in settings.items():
+        # dashboard_plugins is deep-merged above (not a flat allowlisted scalar).
         if k == "dashboard_plugins":
             continue
+        if k in _SETTINGS_ALLOWED_KEYS:
             if k == "theme":
                 if isinstance(v, str) and v.strip():
                     pending_theme = v

--- a/api/plugins.py
+++ b/api/plugins.py
@@ -98,9 +98,15 @@ def load_plugins() -> None:
 
 def serve_plugin_static(plugin_name: str, rel_path: str) -> tuple[bytes, str] | None:
     """
-    Serve a static file from a plugin's dist/ directory.
+    Serve a built static asset from a plugin's dashboard/dist/ (or static/) dir.
 
     Returns (file_bytes, content_type) on success, None on not found.
+
+    Security: _PLUGIN_STATIC_ROOTS points at the plugin's whole dashboard/ dir
+    (the page route needs that), but the asset route must NOT expose plugin
+    source/config — e.g. dashboard/plugin_api.py, manifest.json, .env. So we
+    constrain served files to the built-asset subtrees (dist/ or static/), reject
+    dotfiles, and require a known static extension.
     """
     root = _PLUGIN_STATIC_ROOTS.get(plugin_name)
     if not root:
@@ -112,11 +118,29 @@ def serve_plugin_static(plugin_name: str, rel_path: str) -> tuple[bytes, str] | 
     except ValueError:
         return None  # path traversal attempt
 
+    # Only built-asset subtrees are servable (not the dashboard root itself,
+    # which holds plugin_api.py / manifest.json / config).
+    rel = safe.relative_to(root)
+    if not rel.parts or rel.parts[0] not in ("dist", "static"):
+        return None
+    # No dotfiles (.env, .git, etc.) anywhere in the path.
+    if any(part.startswith(".") for part in rel.parts):
+        return None
+
     if not safe.is_file():
         return None
 
-    data = safe.read_bytes()
+    # Allowlist of static asset extensions — refuse source/config (.py, .json,
+    # .toml, .env, .sh, ...) even if somehow placed under dist/.
     ext = os.path.splitext(rel_path.lower())[1]
+    _STATIC_EXTS = {
+        ".js", ".css", ".html", ".png", ".jpg", ".jpeg", ".gif", ".svg",
+        ".ico", ".webp", ".woff", ".woff2", ".ttf", ".otf", ".map", ".txt",
+    }
+    if ext not in _STATIC_EXTS:
+        return None
+
+    data = safe.read_bytes()
     content_type = {
         ".js": "application/javascript; charset=utf-8",
         ".css": "text/css; charset=utf-8",

--- a/api/plugins.py
+++ b/api/plugins.py
@@ -12,11 +12,9 @@ Each plugin may have:
       style.css     -- optional plugin stylesheet
     plugin_api.py   -- optional backend API (not used in WebUI MVP)
 """
-import importlib
 import json
 import logging
 import os
-import sys
 from pathlib import Path
 
 logger = logging.getLogger(__name__)

--- a/api/plugins.py
+++ b/api/plugins.py
@@ -24,10 +24,11 @@ logger = logging.getLogger(__name__)
 # a settings key). Lowercase alnum + - / _, 1-64 chars, must start with a letter.
 _VALID_PLUGIN_NAME = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 
-# Valid tab.path: a clean same-origin absolute path. Must start with '/', then
-# only safe path chars — no quotes, whitespace, control chars, query ('?') or
-# fragment ('#') so it can't break out of a JS-string nav arg or shadow routes.
-_VALID_PLUGIN_TAB_PATH = re.compile(r"^/[A-Za-z0-9._~/-]{0,255}$")
+# Valid tab.path: a clean same-origin absolute path. Must start with a single
+# '/' (NOT '//' — a leading '//' is a protocol-relative URL that would resolve
+# to a remote origin when assigned to iframe.src), then only safe path chars —
+# no quotes, whitespace, control chars, query ('?') or fragment ('#').
+_VALID_PLUGIN_TAB_PATH = re.compile(r"^/(?!/)[A-Za-z0-9._~/-]{0,255}$")
 
 # plugin_name -> manifest dict (as loaded from manifest.json)
 PLUGIN_MANIFESTS: dict[str, dict] = {}

--- a/api/plugins.py
+++ b/api/plugins.py
@@ -24,6 +24,11 @@ logger = logging.getLogger(__name__)
 # a settings key). Lowercase alnum + - / _, 1-64 chars, must start with a letter.
 _VALID_PLUGIN_NAME = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 
+# Valid tab.path: a clean same-origin absolute path. Must start with '/', then
+# only safe path chars — no quotes, whitespace, control chars, query ('?') or
+# fragment ('#') so it can't break out of a JS-string nav arg or shadow routes.
+_VALID_PLUGIN_TAB_PATH = re.compile(r"^/[A-Za-z0-9._~/-]{0,255}$")
+
 # plugin_name -> manifest dict (as loaded from manifest.json)
 PLUGIN_MANIFESTS: dict[str, dict] = {}
 
@@ -66,6 +71,14 @@ def load_plugins() -> None:
 
         tab = manifest.get("tab", {})
         tab_path = tab.get("path", f"/{name}")
+
+        # Validate tab.path: it's a same-origin route the plugin page is served
+        # at AND a value passed into client-side navigation. Require a clean
+        # absolute path — no quotes/control chars/query/fragment — so a hostile
+        # manifest can't shadow odd routes or inject via the path.
+        if not _VALID_PLUGIN_TAB_PATH.match(str(tab_path)):
+            logger.warning("Skipping plugin %s with invalid tab.path %r (must match %s)", name, tab_path, _VALID_PLUGIN_TAB_PATH.pattern)
+            continue
 
         if name in PLUGIN_MANIFESTS:
             logger.warning("Duplicate plugin name skipped: %s (already loaded)", name)

--- a/api/plugins.py
+++ b/api/plugins.py
@@ -1,0 +1,137 @@
+"""
+Plugin discovery and static serving for Hermes Web UI.
+
+Scans ~/.hermes/plugins/<name>/dashboard/ for manifest.json files,
+matching the official Hermes dashboard plugin format.
+
+Each plugin may have:
+  dashboard/
+    manifest.json   -- tab definition and entry point
+    dist/
+      index.js      -- plugin JS bundle (IIFE)
+      style.css     -- optional plugin stylesheet
+    plugin_api.py   -- optional backend API (not used in WebUI MVP)
+"""
+import importlib
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# plugin_name -> manifest dict (as loaded from manifest.json)
+PLUGIN_MANIFESTS: dict[str, dict] = {}
+
+# plugin_name -> resolved static root dir
+_PLUGIN_STATIC_ROOTS: dict[str, Path] = {}
+
+
+def _get_plugin_base() -> Path:
+    return Path(os.environ.get("HERMES_WEBUI_PLUGINS_DIR", str(Path.home() / ".hermes" / "plugins")))
+
+
+def load_plugins() -> None:
+    """Scan plugin directories and load manifest.json for each dashboard plugin."""
+    plugin_base = _get_plugin_base()
+    if not plugin_base.is_dir():
+        logger.debug("No plugins directory at %s", plugin_base)
+        return
+
+    for entry in sorted(plugin_base.iterdir()):
+        if not entry.is_dir():
+            continue
+        manifest_path = entry / "dashboard" / "manifest.json"
+        if not manifest_path.is_file():
+            continue
+
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except Exception:
+            logger.exception("Failed to parse manifest for plugin %s", entry.name)
+            continue
+
+        name = manifest.get("name") or entry.name
+
+        tab = manifest.get("tab", {})
+        tab_path = tab.get("path", f"/{name}")
+
+        if name in PLUGIN_MANIFESTS:
+            logger.warning("Duplicate plugin name skipped: %s (already loaded)", name)
+            continue
+        if tab_path in (m.get("tab", {}).get("path") for m in PLUGIN_MANIFESTS.values()):
+            logger.warning("Plugin %s tab.path %r conflicts with another plugin; skipped", name, tab_path)
+            continue
+
+        PLUGIN_MANIFESTS[name] = manifest
+        logger.info("Loaded dashboard plugin: %s (label=%s)", name, manifest.get("label", ""))
+
+        # Pre-compute static root for fast serving (points to dashboard/)
+        dashboard_dir = entry / "dashboard"
+        if dashboard_dir.is_dir():
+            _PLUGIN_STATIC_ROOTS[name] = dashboard_dir.resolve()
+
+
+def serve_plugin_static(plugin_name: str, rel_path: str) -> tuple[bytes, str] | None:
+    """
+    Serve a static file from a plugin's dist/ directory.
+
+    Returns (file_bytes, content_type) on success, None on not found.
+    """
+    root = _PLUGIN_STATIC_ROOTS.get(plugin_name)
+    if not root:
+        return None
+
+    safe = (root / rel_path.lstrip("/")).resolve()
+    try:
+        safe.relative_to(root)
+    except ValueError:
+        return None  # path traversal attempt
+
+    if not safe.is_file():
+        return None
+
+    data = safe.read_bytes()
+    ext = os.path.splitext(rel_path.lower())[1]
+    content_type = {
+        ".js": "application/javascript; charset=utf-8",
+        ".css": "text/css; charset=utf-8",
+        ".html": "text/html; charset=utf-8",
+        ".json": "application/json; charset=utf-8",
+        ".png": "image/png",
+        ".svg": "image/svg+xml",
+        ".ico": "image/x-icon",
+    }.get(ext, "application/octet-stream")
+
+    return data, content_type
+
+
+def get_plugin_metadata() -> list[dict]:
+    """
+    Return a list of plugin metadata suitable for the Settings → Plugins tab.
+    Each entry includes name, key, version, description, and tab info for linking.
+
+    Per-plugin enabled state is stored in settings.json under `dashboard_plugins`.
+    A plugin is enabled only if the user has explicitly toggled it on (default off).
+    """
+    from api.config import load_settings
+
+    plugin_settings = load_settings().get("dashboard_plugins", {})
+    plugins = []
+    for name, manifest in sorted(PLUGIN_MANIFESTS.items()):
+        tab = manifest.get("tab", {})
+        path = tab.get("path", f"/{name}")
+        plugins.append({
+            "name": manifest.get("label") or manifest.get("name") or name,
+            "key": name,
+            "version": manifest.get("version", "0.0.0"),
+            "description": manifest.get("description", ""),
+            "tab": {
+                "path": path,
+                "label": tab.get("label") or manifest.get("label") or name,
+            },
+            "enabled": bool(plugin_settings.get(name, False)),
+            "hooks": [],
+        })
+    return plugins

--- a/api/plugins.py
+++ b/api/plugins.py
@@ -15,9 +15,14 @@ Each plugin may have:
 import json
 import logging
 import os
+import re
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# Valid dashboard-plugin name: a safe slug (it becomes a URL path component and
+# a settings key). Lowercase alnum + - / _, 1-64 chars, must start with a letter.
+_VALID_PLUGIN_NAME = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 
 # plugin_name -> manifest dict (as loaded from manifest.json)
 PLUGIN_MANIFESTS: dict[str, dict] = {}
@@ -51,6 +56,13 @@ def load_plugins() -> None:
             continue
 
         name = manifest.get("name") or entry.name
+
+        # Validate the plugin name: it becomes a URL path component
+        # (/dashboard-plugins/<name>/...) and a settings key. Restrict to a safe
+        # slug so a manifest like name:"../foo" can't make the URL-space ambiguous.
+        if not _VALID_PLUGIN_NAME.match(str(name)):
+            logger.warning("Skipping plugin with invalid name %r (must match %s)", name, _VALID_PLUGIN_NAME.pattern)
+            continue
 
         tab = manifest.get("tab", {})
         tab_path = tab.get("path", f"/{name}")

--- a/api/routes.py
+++ b/api/routes.py
@@ -4014,6 +4014,8 @@ def _plugin_visibility_payload(manager=None) -> dict:
     manager.discover_and_load(force=False)
 
     plugins = []
+
+    # Hermes Agent lifecycle-hook plugins
     raw_plugins = getattr(manager, "_plugins", {}) or {}
     for key, loaded in sorted(raw_plugins.items(), key=lambda item: str(item[0])):
         manifest = getattr(loaded, "manifest", None)
@@ -4061,9 +4063,26 @@ def _plugin_visibility_payload(manager=None) -> dict:
     }
 
 
+# WebUI dashboard plugins (from manifest.json discovery)
+def _webui_plugin_payload() -> list[dict]:
+    try:
+        from api.plugins import get_plugin_metadata
+        return get_plugin_metadata()
+    except Exception:
+        return []
+
+
 def _handle_plugins(handler, parsed) -> bool:
     try:
-        return j(handler, _plugin_visibility_payload())
+        hermes_plugins = _plugin_visibility_payload()
+        webui = _webui_plugin_payload()
+        all_plugins = hermes_plugins["plugins"] + webui
+        return j(handler, {
+            "plugins": all_plugins,
+            "empty": not bool(all_plugins),
+            "supported_hooks": hermes_plugins["supported_hooks"],
+            "read_only": True,
+        })
     except Exception as exc:
         logger.warning("Failed to build plugin visibility payload: %s", exc)
         return j(
@@ -5422,6 +5441,116 @@ def handle_get(handler, parsed) -> bool:
         except Exception as e:
             logger.exception("rollback/diff failed")
             return bad(handler, str(e), status=500)
+
+    # ── Plugin shared assets (e.g. /plugins/plugin.css) ──
+    # Restricted to shared plugin assets only — no cross-plugin file access.
+    if parsed.path.startswith("/plugins/"):
+        from api.plugins import _get_plugin_base
+        plugin_base = _get_plugin_base()
+        rel = parsed.path[len("/plugins/"):]
+        allowed = {"plugin.css"}
+        if rel not in allowed:
+            return False  # 404
+        safe = (plugin_base / rel).resolve()
+        try:
+            safe.relative_to(plugin_base.resolve())
+        except ValueError:
+            return False  # path traversal — 404
+        if safe.is_file():
+            import os as _os
+            data = safe.read_bytes()
+            ext = _os.path.splitext(rel.lower())[1]
+            ct = {
+                ".css": "text/css; charset=utf-8",
+                ".js": "application/javascript; charset=utf-8",
+                ".json": "application/json; charset=utf-8",
+                ".png": "image/png",
+                ".svg": "image/svg+xml",
+            }.get(ext, "application/octet-stream")
+            handler.send_response(200)
+            handler.send_header("Content-Type", ct)
+            handler.send_header("Content-Length", str(len(data)))
+            handler.end_headers()
+            handler.wfile.write(data)
+            return True
+
+    # ── Plugin static assets ──
+    if parsed.path.startswith("/dashboard-plugins/"):
+        parts = parsed.path.split("/", 3)
+        if len(parts) >= 3:
+            plugin_name = parts[2]
+            rel_path = parts[3] if len(parts) > 3 else ""
+            from api.plugins import serve_plugin_static
+            result = serve_plugin_static(plugin_name, rel_path)
+            if result:
+                data, content_type = result
+                handler.send_response(200)
+                handler.send_header("Content-Type", content_type)
+                handler.send_header("Content-Length", str(len(data)))
+                handler.end_headers()
+                handler.wfile.write(data)
+                return True
+
+    # ── Plugin pages (HTML shell) ──
+    from api.plugins import PLUGIN_MANIFESTS, _PLUGIN_STATIC_ROOTS
+    for name, manifest in PLUGIN_MANIFESTS.items():
+        tab = manifest.get("tab", {})
+        tab_path = tab.get("path", f"/{name}")
+        if parsed.path == tab_path:
+            dashboard_dir = _PLUGIN_STATIC_ROOTS.get(name)
+            if dashboard_dir:
+                # 1) dashboard/dist/index.html (full SPA build)
+                index_html = dashboard_dir / "dist" / "index.html"
+                if index_html.is_file():
+                    data = index_html.read_bytes()
+                    handler.send_response(200)
+                    handler.send_header("Content-Type", "text/html; charset=utf-8")
+                    handler.send_header("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-popups")
+                    handler.send_header("Content-Length", str(len(data)))
+                    handler.end_headers()
+                    handler.wfile.write(data)
+                    return True
+                # 2) static/index.html in plugin root (content page for IIFE loader)
+                plugin_root = dashboard_dir.parent
+                static_html = plugin_root / "static" / "index.html"
+                if static_html.is_file():
+                    data = static_html.read_bytes()
+                    handler.send_response(200)
+                    handler.send_header("Content-Type", "text/html; charset=utf-8")
+                    handler.send_header("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-popups")
+                    handler.send_header("Content-Length", str(len(data)))
+                    handler.end_headers()
+                    handler.wfile.write(data)
+                    return True
+                # 3) Fallback: generate shell that loads the IIFE bundle
+                index_js = dashboard_dir / "dist" / "index.js"
+                if index_js.is_file():
+                    import html
+                    label = html.escape(manifest.get("label") or name)
+                    css = html.escape(manifest.get("css", ""))
+                    name_escaped = html.escape(name)
+                    css_tag = f'<link rel="stylesheet" href="/dashboard-plugins/{name_escaped}/{css}">' if css else ""
+                    html_content = (
+                        f"<!doctype html>\n"
+                        f"<html lang=\"en\">\n"
+                        f"<head>\n"
+                        f"  <meta charset=\"utf-8\">\n"
+                        f"  <title>{label}</title>\n"
+                        f"  {css_tag}\n"
+                        f"</head>\n"
+                        f"<body>\n"
+                        f'  <div id="pluginPageContainer"></div>\n'
+                        f'  <script src="/dashboard-plugins/{name_escaped}/dist/index.js"></script>\n'
+                        f"</body>\n"
+                        f"</html>\n"
+                    ).encode("utf-8")
+                    handler.send_response(200)
+                    handler.send_header("Content-Type", "text/html; charset=utf-8")
+                    handler.send_header("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-popups")
+                    handler.send_header("Content-Length", str(len(html_content)))
+                    handler.end_headers()
+                    handler.wfile.write(html_content)
+                    return True
 
     return False  # 404
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -4064,6 +4064,21 @@ def _plugin_visibility_payload(manager=None) -> dict:
 
 
 # WebUI dashboard plugins (from manifest.json discovery)
+def _dashboard_plugin_enabled(plugin_name: str) -> bool:
+    """True if a dashboard plugin is enabled in settings.
+
+    Dashboard plugins are opt-in (default off). Enforced server-side so a
+    disabled plugin's page + asset URLs are fully 404'd, not merely hidden in
+    the Settings UI.
+    """
+    try:
+        from api.config import load_settings
+        prefs = (load_settings() or {}).get("dashboard_plugins", {}) or {}
+        return bool(prefs.get(plugin_name, False))
+    except Exception:
+        return False
+
+
 def _webui_plugin_payload() -> list[dict]:
     try:
         from api.plugins import get_plugin_metadata
@@ -5480,12 +5495,23 @@ def handle_get(handler, parsed) -> bool:
         if len(parts) >= 3:
             plugin_name = parts[2]
             rel_path = parts[3] if len(parts) > 3 else ""
+            # Server-side enable-gate: a plugin disabled in Settings must have its
+            # entire URL surface shut off, not merely hidden in the UI.
+            if not _dashboard_plugin_enabled(plugin_name):
+                return False  # 404 — disabled plugins serve nothing
             from api.plugins import serve_plugin_static
             result = serve_plugin_static(plugin_name, rel_path)
             if result:
                 data, content_type = result
                 handler.send_response(200)
                 handler.send_header("Content-Type", content_type)
+                # Defense-in-depth: plugin-controlled assets are served from the
+                # WebUI's own origin. Sandbox them (null origin) so a plugin's
+                # .html/.svg can't run privileged same-origin script if navigated
+                # to directly (the in-panel iframe sandbox doesn't cover direct
+                # navigation). nosniff prevents content-type confusion.
+                handler.send_header("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-popups")
+                handler.send_header("X-Content-Type-Options", "nosniff")
                 handler.send_header("Content-Length", str(len(data)))
                 handler.end_headers()
                 handler.wfile.write(data)
@@ -5497,6 +5523,9 @@ def handle_get(handler, parsed) -> bool:
         tab = manifest.get("tab", {})
         tab_path = tab.get("path", f"/{name}")
         if parsed.path == tab_path:
+            # Server-side enable-gate (opt-in): a disabled plugin's page 404s.
+            if not _dashboard_plugin_enabled(name):
+                return False
             dashboard_dir = _PLUGIN_STATIC_ROOTS.get(name)
             if dashboard_dir:
                 # 1) dashboard/dist/index.html (full SPA build)

--- a/server.py
+++ b/server.py
@@ -565,6 +565,13 @@ def main() -> None:
     except Exception as e:
         print(f'[!!] WARNING: Gateway watcher failed to start: {e}', flush=True)
 
+    # Load WebUI dashboard plugins
+    try:
+        from api.plugins import load_plugins
+        load_plugins()
+    except Exception as e:
+        print(f'[!!] WARNING: Plugin loading failed: {e}', flush=True)
+
     httpd = QuietHTTPServer((HOST, PORT), Handler)
 
     # ── TLS/HTTPS setup (optional) ─────────────────────────────────────────

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -553,6 +553,7 @@ const LOCALES = {
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
     settings_plugins_title: 'Plugins',
+    settings_plugins_enable_toggle: 'Enable',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',
     settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',
     plugins_unnamed: 'Unnamed plugin',

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -553,7 +553,7 @@ const LOCALES = {
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
     settings_plugins_title: 'Plugins',
-    settings_plugins_enable_toggle: 'Enable',
+    plugins_enable_toggle: 'Enable',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',
     settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',
     plugins_unnamed: 'Unnamed plugin',
@@ -1884,6 +1884,7 @@ const LOCALES = {
     settings_tab_preferences: 'Preferenze',
     settings_tab_plugins: 'Plugin',
     settings_plugins_title: 'Plugins',  // TODO: translate
+    plugins_enable_toggle: 'Abilita',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
     settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
     plugins_unnamed: 'Unnamed plugin',  // TODO: translate
@@ -3206,6 +3207,7 @@ const LOCALES = {
     settings_tab_preferences: '環境設定',
     settings_tab_plugins: 'プラグイン',
     settings_plugins_title: 'Plugins',  // TODO: translate
+    plugins_enable_toggle: '有効化',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
     settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
     plugins_unnamed: 'Unnamed plugin',  // TODO: translate
@@ -5098,6 +5100,7 @@ const LOCALES = {
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Плагины',
     settings_plugins_title: 'Plugins',  // TODO: translate
+    plugins_enable_toggle: 'Включить',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
     settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
     plugins_unnamed: 'Unnamed plugin',  // TODO: translate
@@ -6345,6 +6348,7 @@ const LOCALES = {
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
     settings_plugins_title: 'Plugins',  // TODO: translate
+    plugins_enable_toggle: 'Activar',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
     settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
     plugins_unnamed: 'Unnamed plugin',  // TODO: translate
@@ -7308,6 +7312,7 @@ const LOCALES = {
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
     settings_plugins_title: 'Plugins',  // TODO: translate
+    plugins_enable_toggle: 'Aktivieren',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
     settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
     plugins_unnamed: 'Unnamed plugin',  // TODO: translate
@@ -8024,6 +8029,7 @@ const LOCALES = {
     settings_busy_input_mode_interrupt: '中断当前轮次',
     settings_busy_input_mode_steer: '引导（中间修正）',
     settings_plugins_title: '插件',
+    plugins_enable_toggle: '启用',
     settings_plugins_meta: '查看已安装的 Hermes 插件及其注册的生命周期挂钩。此面板为只读。',
     settings_plugins_empty: '当前没有可见的 Hermes 插件。通过 Hermes CLI/配置文件安装或启用插件后即可在此查看。',
     plugins_unnamed: '未命名插件',
@@ -9386,6 +9392,7 @@ const LOCALES = {
     settings_tab_preferences: '偏好設定',
     settings_tab_plugins: '外掛',
     settings_plugins_title: '外掛',
+    plugins_enable_toggle: '啟用',
     settings_plugins_meta: '檢視已安裝的 Hermes 外掛及其註冊的生命週期鉤子。此面板為唯讀。',
     settings_plugins_empty: '目前沒有可見的 Hermes 外掛。透過 Hermes CLI/設定檔安裝或啟用外掛後即可在此檢視。',
     plugins_unnamed: '未命名外掛',
@@ -10786,6 +10793,7 @@ const LOCALES = {
     settings_tab_preferences: 'Preferências',
     settings_tab_plugins: 'Plugins',
     settings_plugins_title: 'Plugins',  // TODO: translate
+    plugins_enable_toggle: 'Ativar',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
     settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
     plugins_unnamed: 'Unnamed plugin',  // TODO: translate
@@ -12010,6 +12018,7 @@ const LOCALES = {
     settings_tab_preferences: '환경설정',
     settings_tab_plugins: '플러그인',
     settings_plugins_title: 'Plugins',  // TODO: translate
+    plugins_enable_toggle: '활성화',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
     settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
     plugins_unnamed: 'Unnamed plugin',  // TODO: translate
@@ -13249,6 +13258,7 @@ const LOCALES = {
     settings_tab_preferences: 'Préférences',
     settings_tab_plugins: 'Plugins',
     settings_plugins_title: 'Plugins',  // TODO: translate
+    plugins_enable_toggle: 'Activer',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
     settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
     plugins_unnamed: 'Unnamed plugin',  // TODO: translate
@@ -14590,6 +14600,7 @@ const LOCALES = {
     settings_tab_preferences: 'Tercihler',
     settings_tab_plugins: 'Eklentiler',
     settings_plugins_title: 'Eklentiler',
+    plugins_enable_toggle: 'Etkinleştir',
     settings_plugins_meta: 'Yüklü Hermes eklentilerini ve yaşam döngüsü kancalarını görüntüleyin. Bu panel salt okunurdur.',
     settings_plugins_empty: 'Görünür Hermes eklentisi yok. Burada görmek için Hermes CLI/config üzerinden yükleyin veya etkinleştirin.',
     plugins_unnamed: 'Adsız eklenti',

--- a/static/index.html
+++ b/static/index.html
@@ -876,6 +876,14 @@
         </div>
       </div>
     </div>
+    <div id="mainPlugin" class="main-view">
+      <div class="main-view-header">
+        <div class="main-view-title" id="pluginPageTitle">Plugin</div>
+      </div>
+      <div class="main-view-body">
+        <div id="pluginPageContainer"></div>
+      </div>
+    </div>
     <div id="mainSettings" class="main-view">
       <div class="settings-main">
           <div class="settings-pane active" id="settingsPaneConversation">

--- a/static/panels.js
+++ b/static/panels.js
@@ -6471,14 +6471,18 @@ function _buildPluginCard(plugin){
 const enabled=plugin&&plugin.enabled!==false;
   const tab=plugin&&plugin.tab;
   const isDashboardPlugin=!!(tab&&tab.path);
+  // No inline onclick/onchange: an inline handler interpolates tab.path/key into
+  // a JS-string-in-attribute context where HTML-escaping is insufficient (a
+  // crafted value could break out). Render inert markup + bind listeners below
+  // with the raw closure values.
   const openBtn=enabled&&tab&&tab.path
-    ? `<a href="${esc(tab.path)}" class="plugin-open-btn" onclick="switchPluginPage(event,'${esc(tab.path)}','${esc(tab.label||plugin.name)}');return false;">${esc(tab.label||plugin.name||'Open')} \u2197</a>`
+    ? `<a href="${esc(tab.path)}" class="plugin-open-btn">${esc(tab.label||plugin.name||'Open')} \u2197</a>`
     : '';
   const toggleHtml=enabled&&isDashboardPlugin
     ? `<div class="plugin-card-footer-row">
          <span class="plugin-toggle-label">${t('plugins_enable_toggle')||'Enabled'}</span>
          <label class="plugin-toggle-switch">
-           <input type="checkbox" checked onchange="handlePluginEnableToggle('${esc(plugin.key)}',this.checked)">
+           <input type="checkbox" class="plugin-enable-toggle" checked>
            <span class="plugin-toggle-slider"></span>
          </label>
        </div>`
@@ -6486,7 +6490,7 @@ const enabled=plugin&&plugin.enabled!==false;
     ? `<div class="plugin-card-footer-row">
          <span class="plugin-toggle-label">${t('plugins_enable_toggle')||'Enable'}</span>
          <label class="plugin-toggle-switch">
-           <input type="checkbox" onchange="handlePluginEnableToggle('${esc(plugin.key)}',this.checked)">
+           <input type="checkbox" class="plugin-enable-toggle">
            <span class="plugin-toggle-slider"></span>
          </label>
        </div>`
@@ -6520,6 +6524,22 @@ const enabled=plugin&&plugin.enabled!==false;
       ${toggleHtml}
     </div>
   `;
+  // Bind handlers with the RAW closure values (not interpolated into inline JS),
+  // so a hostile tab.path/key can't break out of a JS-string attribute context.
+  if(tab&&tab.path){
+    const _openEl=card.querySelector('.plugin-open-btn');
+    if(_openEl){
+      const _p=tab.path, _l=tab.label||plugin.name;
+      _openEl.addEventListener('click', function(ev){ switchPluginPage(ev, _p, _l); });
+    }
+  }
+  if(isDashboardPlugin){
+    const _tog=card.querySelector('.plugin-enable-toggle');
+    if(_tog){
+      const _k=plugin.key;
+      _tog.addEventListener('change', function(){ handlePluginEnableToggle(_k, this.checked); });
+    }
+  }
   return card;
 }
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -243,7 +243,7 @@ async function switchPanel(name, opts = {}) {
   // showing-<name> class on <main>; no class means chat (the default).
   const mainEl = document.querySelector('main.main');
   if (mainEl) {
-    ['settings','skills','memory','tasks','kanban','workspaces','profiles','insights','logs'].forEach(p => {
+    ['settings','skills','memory','tasks','kanban','workspaces','profiles','insights','logs','plugin'].forEach(p => {
       mainEl.classList.toggle('showing-' + p, nextPanel === p);
     });
   }
@@ -5700,6 +5700,16 @@ function _toggleTabVisibilityChip(panel){
 }
 
 function switchSettingsSection(name){
+  // If the main content is not showing settings, switch back first
+  if (_currentPanel !== 'settings') {
+    _currentPanel = 'settings';
+    var mainEl = document.querySelector('main.main');
+    if (mainEl) {
+      ['settings','skills','memory','tasks','kanban','workspaces','profiles','insights','logs','plugin'].forEach(function(p) {
+        mainEl.classList.toggle('showing-' + p, p === 'settings');
+      });
+    }
+  }
   const section=(name==='appearance'||name==='preferences'||name==='providers'||name==='plugins'||name==='system')?name:'conversation';
   _settingsSection=section;
   _currentSettingsSection=section;
@@ -6403,6 +6413,17 @@ async function loadSettingsPanel(){
 
 // ── Plugins panel (read-only plugin/hook visibility) ───────────────────────
 
+async function handlePluginEnableToggle(pluginKey, checked){
+  try{
+    const body={dashboard_plugins:{}};
+    body.dashboard_plugins[pluginKey]=!!checked;
+    await api('/api/settings',{method:'POST',body:JSON.stringify(body)});
+    loadPluginsPanel();
+  }catch(e){
+    showToast(t('settings_save_failed')+e.message);
+  }
+}
+
 async function loadPluginsPanel(){
   const list=$('pluginsList');
   const empty=$('pluginsEmpty');
@@ -6447,6 +6468,29 @@ function _buildPluginCard(plugin){
     : '<span class="plugin-hook-empty">'+t(isProvider?'plugins_provider_no_hooks':'plugins_no_hooks')+'</span>';
   const version=(plugin&&plugin.version)?' · v'+esc(plugin.version):'';
   const desc=(plugin&&plugin.description)?esc(plugin.description):t('plugins_no_description');
+const enabled=plugin&&plugin.enabled!==false;
+  const tab=plugin&&plugin.tab;
+  const isDashboardPlugin=!!(tab&&tab.path);
+  const openBtn=enabled&&tab&&tab.path
+    ? `<a href="${esc(tab.path)}" class="plugin-open-btn" onclick="switchPluginPage(event,'${esc(tab.path)}','${esc(tab.label||plugin.name)}');return false;">${esc(tab.label||plugin.name||'Open')} \u2197</a>`
+    : '';
+  const toggleHtml=enabled&&isDashboardPlugin
+    ? `<div class="plugin-card-footer-row">
+         <span class="plugin-toggle-label">${t('plugins_enable_toggle')||'Enabled'}</span>
+         <label class="plugin-toggle-switch">
+           <input type="checkbox" checked onchange="handlePluginEnableToggle('${esc(plugin.key)}',this.checked)">
+           <span class="plugin-toggle-slider"></span>
+         </label>
+       </div>`
+    : (isDashboardPlugin
+    ? `<div class="plugin-card-footer-row">
+         <span class="plugin-toggle-label">${t('plugins_enable_toggle')||'Enable'}</span>
+         <label class="plugin-toggle-switch">
+           <input type="checkbox" onchange="handlePluginEnableToggle('${esc(plugin.key)}',this.checked)">
+           <span class="plugin-toggle-slider"></span>
+         </label>
+       </div>`
+    : '');
   let badgeText;
   let badgeClass;
   if(isProvider){
@@ -6465,18 +6509,63 @@ function _buildPluginCard(plugin){
         <div class="provider-card-name">${esc((plugin&&plugin.name)||t('plugins_unnamed'))}</div>
         <div class="provider-card-meta">${esc((plugin&&plugin.key)||'plugin')}${version}</div>
       </div>
+      ${isDashboardPlugin?`<span class="provider-card-badge ${enabled?'':'plugin-card-badge-disabled'}">${enabled?t('plugins_enabled'):t('plugins_disabled')}</span>`:''}
       <span class="provider-card-badge ${badgeClass}">${badgeText}</span>
     </div>
     <div class="provider-card-body plugin-card-body">
       <div class="provider-card-hint">${desc}</div>
       <div class="provider-card-label">${t('plugins_registered_hooks')}</div>
       <div class="plugin-hook-list">${hookHtml}</div>
+      ${openBtn ? `<div class="plugin-card-footer">${openBtn}</div>` : ''}
+      ${toggleHtml}
     </div>
   `;
   return card;
 }
 
-// ── Providers panel ───────────────────────────────────────────────────────
+// ── Plugin pages ─────────────────────────────────────────────────────────────
+
+let _currentPluginPage = null;
+
+async function switchPluginPage(event, path, label) {
+  if (event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+  if (!_currentPluginPage || _currentPluginPage.path !== path) {
+    await _loadPluginPage(path, label);
+  }
+  // Update _currentPanel so clicking sidebar items won't short-circuit,
+  // but keep the sidebar panel views intact (no panelPlugin exists).
+  _currentPanel = 'plugin';
+  const mainEl = document.querySelector('main.main');
+  if (mainEl) {
+    ['settings','skills','memory','tasks','kanban','workspaces','profiles','insights','logs','plugin'].forEach(p => {
+      mainEl.classList.toggle('showing-' + p, p === 'plugin');
+    });
+  }
+}
+
+async function _loadPluginPage(path, label) {
+  const container = $('pluginPageContainer');
+  const titleEl = $('pluginPageTitle');
+  if (!container) return;
+  if (titleEl) titleEl.textContent = label || path;
+  container.innerHTML = '';
+
+  // Use an iframe for full isolation (styles, scripts, modals stay sandboxed).
+  // Security note: plugins are locally-installed (~/.hermes/plugins/), similar
+  // trust model to VS Code extensions — only install plugins you trust.
+  const iframe = document.createElement('iframe');
+  iframe.src = path;
+  iframe.style.cssText = 'width:100%;height:100%;border:none;display:block;';
+  iframe.setAttribute('title', label || 'Plugin');
+  iframe.setAttribute('sandbox', 'allow-scripts allow-forms allow-popups');
+  container.appendChild(iframe);
+  _currentPluginPage = { path, label };
+}
+
+// ── Providers panel ─────────────────────────────────────────────────────────
 
 const _providerCardEls = new Map(); // providerId → {card, statusDot, input, saveBtn, removeBtn}
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -6513,7 +6513,6 @@ const enabled=plugin&&plugin.enabled!==false;
         <div class="provider-card-name">${esc((plugin&&plugin.name)||t('plugins_unnamed'))}</div>
         <div class="provider-card-meta">${esc((plugin&&plugin.key)||'plugin')}${version}</div>
       </div>
-      ${isDashboardPlugin?`<span class="provider-card-badge ${enabled?'':'plugin-card-badge-disabled'}">${enabled?t('plugins_enabled'):t('plugins_disabled')}</span>`:''}
       <span class="provider-card-badge ${badgeClass}">${badgeText}</span>
     </div>
     <div class="provider-card-body plugin-card-body">

--- a/static/style.css
+++ b/static/style.css
@@ -3099,7 +3099,7 @@ main.main > #mainWorkspaces,
 main.main > #mainProfiles,
 main.main > #mainInsights,
 main.main > #mainLogs{display:none;}
-main.main:not(.showing-settings):not(.showing-skills):not(.showing-memory):not(.showing-tasks):not(.showing-kanban):not(.showing-workspaces):not(.showing-profiles):not(.showing-insights):not(.showing-logs) > #mainChat{display:flex;}
+main.main:not(.showing-settings):not(.showing-skills):not(.showing-memory):not(.showing-tasks):not(.showing-kanban):not(.showing-workspaces):not(.showing-profiles):not(.showing-insights):not(.showing-logs):not(.showing-plugin) > #mainChat{display:flex;}
 main.main.showing-settings > #mainSettings{display:flex;overflow-y:auto;}
 main.main.showing-skills > #mainSkills{display:flex;}
 main.main.showing-memory > #mainMemory{display:flex;}
@@ -3108,6 +3108,10 @@ main.main.showing-kanban > #mainKanban{display:flex;overflow-y:auto;}
 main.main.showing-workspaces > #mainWorkspaces{display:flex;}
 main.main.showing-profiles > #mainProfiles{display:flex;}
 main.main.showing-logs > #mainLogs{display:flex;}
+main.main.showing-plugin > #mainPlugin{display:flex;}
+main.main > #mainPlugin{display:none;}
+#mainPlugin .main-view-body{flex:1;display:flex;flex-direction:column;overflow:hidden;}
+#pluginPageContainer{flex:1;display:flex;flex-direction:column;min-height:0;}
 #mainSettings{overflow-y:auto;}
 
 /* Sidebar menu (lives in the left sidebar under the cog panel) */
@@ -3482,6 +3486,17 @@ main.main.showing-logs > #mainLogs{display:flex;}
 .plugin-hook-list{display:flex;flex-wrap:wrap;gap:6px;margin-top:6px;}
 .plugin-hook-badge{display:inline-flex;align-items:center;border:1px solid var(--border2);background:var(--code-bg);color:var(--text);border-radius:999px;padding:3px 8px;font-size:11px;font-family:var(--font-mono);}
 .plugin-hook-empty{font-size:12px;color:var(--muted);font-style:italic;}
+.plugin-card-footer{margin-top:10px;padding-top:10px;border-top:1px solid var(--border);}
+.plugin-card-footer-row{display:flex;align-items:center;justify-content:space-between;margin-top:8px;padding-top:8px;border-top:1px solid var(--border);}
+.plugin-toggle-label{font-size:12px;color:var(--muted);}
+.plugin-toggle-switch{position:relative;display:inline-block;width:32px;height:18px;flex-shrink:0;}
+.plugin-toggle-switch input{opacity:0;width:0;height:0;}
+.plugin-toggle-slider{position:absolute;cursor:pointer;inset:0;background:var(--border2);border-radius:9px;transition:background .2s;}
+.plugin-toggle-slider::before{content:'';position:absolute;height:12px;width:12px;left:3px;bottom:3px;background:#fff;border-radius:50%;transition:transform .2s;}
+.plugin-toggle-switch input:checked+.plugin-toggle-slider{background:var(--accent);}
+.plugin-toggle-switch input:checked+.plugin-toggle-slider::before{transform:translateX(14px);}
+.plugin-open-btn{display:inline-flex;align-items:center;gap:6px;padding:7px 14px;background:var(--accent);color:var(--accent-text);border:none;border-radius:7px;font-size:13px;font-weight:500;cursor:pointer;text-decoration:none;}
+.plugin-open-btn:hover{opacity:.85;}
 
 /* ── Provider model tags ── */
 .provider-card-models{

--- a/static/style.css
+++ b/static/style.css
@@ -3492,11 +3492,15 @@ main.main > #mainPlugin{display:none;}
 .plugin-toggle-switch{position:relative;display:inline-block;width:32px;height:18px;flex-shrink:0;}
 .plugin-toggle-switch input{opacity:0;width:0;height:0;}
 .plugin-toggle-slider{position:absolute;cursor:pointer;inset:0;background:var(--border2);border-radius:9px;transition:background .2s;}
-.plugin-toggle-slider::before{content:'';position:absolute;height:12px;width:12px;left:3px;bottom:3px;background:#fff;border-radius:50%;transition:transform .2s;}
+.plugin-toggle-slider::before{content:'';position:absolute;height:12px;width:12px;left:3px;bottom:3px;background:#fff;border-radius:50%;transition:transform .2s;box-shadow:0 1px 2px rgba(0,0,0,.45);}
 .plugin-toggle-switch input:checked+.plugin-toggle-slider{background:var(--accent);}
 .plugin-toggle-switch input:checked+.plugin-toggle-slider::before{transform:translateX(14px);}
-.plugin-open-btn{display:inline-flex;align-items:center;gap:6px;padding:7px 14px;background:var(--accent);color:var(--accent-text);border:none;border-radius:7px;font-size:13px;font-weight:500;cursor:pointer;text-decoration:none;}
-.plugin-open-btn:hover{opacity:.85;}
+/* Ghost/outline button: --accent-text is not guaranteed to contrast against
+   --accent in every theme (e.g. it equals --accent in the default gold theme,
+   which renders invisible text on a filled block). Use the accent as the text +
+   border colour on the card's own surface, which is always legible. */
+.plugin-open-btn{display:inline-flex;align-items:center;gap:6px;padding:6px 14px;background:transparent;color:var(--accent);border:1px solid var(--accent);border-radius:7px;font-size:13px;font-weight:600;cursor:pointer;text-decoration:none;}
+.plugin-open-btn:hover{background:var(--accent);color:var(--bg);}
 
 /* ── Provider model tags ── */
 .provider-card-models{

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -428,6 +428,7 @@ class TestPluginNameValidation:
         assert not plugins._VALID_PLUGIN_TAB_PATH.match("/x?y=1")         # query
         assert not plugins._VALID_PLUGIN_TAB_PATH.match("/x#frag")        # fragment
         assert not plugins._VALID_PLUGIN_TAB_PATH.match("/x y")           # whitespace
+        assert not plugins._VALID_PLUGIN_TAB_PATH.match("//evil.example/p")  # protocol-relative
 
     def test_open_button_and_toggle_use_no_inline_handlers(self):
         # tab.path / plugin.key must not be interpolated into inline onclick/

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -1,11 +1,15 @@
 """Regression coverage for issue #539: Settings plugin/hook visibility."""
 
+import json
+import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlparse
 
+import pytest
+
 
 def read(path: str) -> str:
-    from pathlib import Path
     return Path(path).read_text(encoding="utf-8")
 
 
@@ -219,9 +223,137 @@ class TestPluginsSettingsUi:
         assert "_buildPluginCard" in js
         assert "plugin-hook-badge" in js
         assert "esc(plugin.description" in js
-        segment = js[js.find("function _buildPluginCard"):js.find("// ── Providers panel")]
-        assert ".path" not in segment
+        segment = js[js.find("function _buildPluginCard"):js.find("// ── Plugin pages")]
         assert ".callback" not in segment
+        assert ".path" not in segment or "tab.path" in segment  # tab.path is allowed (whitelisted)
+
+
+class TestDashboardPluginsSecurity:
+    """Tests for dashboard plugin iframe sandbox and CSP security properties."""
+
+    def test_plugins_list_has_per_plugin_enable_toggle(self):
+        js = read("static/panels.js")
+        assert "handlePluginEnableToggle" in js
+        assert "plugin-toggle-switch" in js
+        assert "plugin-toggle-slider" in js
+
+    def test_open_button_requires_enabled_plugin(self):
+        js = read("static/panels.js")
+        segment = js[js.find("function _buildPluginCard"):js.find("// ── Plugin pages")]
+        assert "plugin-open-btn" in segment
+        assert "enabled&&tab&&tab.path" in segment
+
+    def test_loadPluginPage_sets_sandbox_attribute(self):
+        js = read("static/panels.js")
+        assert "iframe.setAttribute('sandbox'" in js
+        assert "allow-scripts" in js
+        assert "allow-forms" in js
+        assert "allow-popups" in js
+
+    def test_plugins_api_returns_per_plugin_enabled_state(self):
+        import api.routes as routes
+
+        captured = {}
+
+        def fake_j(handler, payload, status=200, extra_headers=None):
+            captured["payload"] = payload
+            captured["status"] = status
+            return True
+
+        handler = MagicMock()
+        with patch("api.routes.j", side_effect=fake_j), \
+             patch("api.routes._get_plugin_manager_for_visibility", return_value=_FakePluginManager({})):
+            handled = routes.handle_get(handler, urlparse("/api/plugins"))
+
+        assert handled is True
+        payload = captured["payload"]
+        assert isinstance(payload["plugins"], list)
+        for plugin in payload["plugins"]:
+            if plugin.get("tab") and plugin["tab"].get("path"):
+                assert isinstance(plugin.get("enabled"), bool)
+
+
+class TestDashboardPluginsEnforcement:
+    """Unit tests for plugin enablement enforcement via settings.json."""
+
+    def test_plugin_enabled_false_by_default_in_settings(self):
+        from api.plugins import get_plugin_metadata
+
+        with tempfile.TemporaryDirectory() as td:
+            plugin_dir = Path(td) / "testplugin" / "dashboard"
+            plugin_dir.mkdir(parents=True)
+            manifest = {"name": "testplugin", "tab": {"path": "/testplugin"}, "label": "Test Plugin"}
+            (plugin_dir / "manifest.json").write_text(json.dumps(manifest))
+
+            with patch.dict("os.environ", {"HERMES_WEBUI_PLUGINS_DIR": td}):
+                from api.plugins import load_plugins, PLUGIN_MANIFESTS
+                PLUGIN_MANIFESTS.clear()
+                load_plugins()
+
+                plugins = get_plugin_metadata()
+                assert len(plugins) == 1
+                assert plugins[0]["enabled"] is False
+
+    def test_dashboard_plugins_deep_merged_in_save_settings(self):
+        import api.config as config
+
+        original = config.load_settings()
+        original_plugins = original.get("dashboard_plugins", {})
+
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td) / "webui"
+            state_dir.mkdir()
+            settings_file = state_dir / "settings.json"
+            original_file = config.SETTINGS_FILE
+
+            try:
+                config.SETTINGS_FILE = settings_file
+                config.save_settings({"dashboard_plugins": {"testplugin": True}})
+
+                result = config.load_settings()
+                assert result["dashboard_plugins"].get("testplugin") is True
+
+                config.save_settings({"dashboard_plugins": {"testplugin2": True}})
+                result2 = config.load_settings()
+                assert result2["dashboard_plugins"].get("testplugin") is True
+                assert result2["dashboard_plugins"].get("testplugin2") is True
+            finally:
+                config.SETTINGS_FILE = original_file
+
+
+class TestPluginStaticServing:
+    """Tests for plugin static file serving path traversal protection."""
+
+    def test_plugins_route_restricted_to_plugin_css(self):
+        js = read("static/panels.js")
+        allowed = {"plugin.css"}
+        assert all(ext in js or True for ext in ["plugin.css"])
+
+    def test_manifest_label_escaped_in_iife_shell(self):
+        js = read("static/panels.js")
+        iife_segment = js[js.find("html_content"):js.find("// ── Plugin pages")] if "html_content" in js else js
+        assert ".escape" in js or "esc(" in js or "html.escape" in js or True
+
+
+class TestPluginCollisionDetection:
+    """Tests for plugin name and tab.path collision detection."""
+
+    def test_duplicate_plugin_name_logs_warning(self):
+        import logging
+        from api.plugins import load_plugins, PLUGIN_MANIFESTS
+
+        with tempfile.TemporaryDirectory() as td:
+            plugin_dir = Path(td) / "testplugin" / "dashboard"
+            plugin_dir.mkdir(parents=True)
+            manifest = {"name": "testplugin", "tab": {"path": "/testplugin-duplicate"}}
+            (plugin_dir / "manifest.json").write_text(json.dumps(manifest))
+
+            with patch.dict("os.environ", {"HERMES_WEBUI_PLUGINS_DIR": td}):
+                PLUGIN_MANIFESTS.clear()
+                with patch.object(logging, "warning") as mock_warn:
+                    load_plugins()
+                    assert mock_warn.called or len(PLUGIN_MANIFESTS) >= 0
+
 
     def test_plugins_panel_renders_active_provider_badge(self):
         # The card must distinguish exclusive/provider activation from a plain

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -373,6 +373,52 @@ class TestPluginAssetIsolationHardening:
         assert "_dashboard_plugin_enabled" in page_seg
 
 
+class TestSettingsAllowlistGuard:
+    """The dashboard_plugins save path must not weaken the settings allowlist.
+
+    Regression for the #2622 hardening: an earlier revision replaced the
+    `if k in _SETTINGS_ALLOWED_KEYS` guard with `if k == "dashboard_plugins":
+    continue` and orphaned the validation body, which (a) broke saves for every
+    other key and (b) let any client-supplied key be written (e.g. password_hash).
+    """
+
+    def _isolated(self):
+        import tempfile
+        import api.config as cfg
+        cfg.SETTINGS_FILE = Path(tempfile.mkdtemp()) / "settings.json"
+        return cfg
+
+    def test_allowlisted_key_persists(self):
+        cfg = self._isolated()
+        r = cfg.save_settings({"language": "ru"})
+        assert r.get("language") == "ru"
+
+    def test_non_allowlisted_key_rejected(self):
+        cfg = self._isolated()
+        r = cfg.save_settings({"password_hash": "INJECTED", "signing_key_evil": "x"})
+        assert r.get("password_hash") != "INJECTED"
+        assert "signing_key_evil" not in r
+
+    def test_dashboard_plugins_deep_merges(self):
+        cfg = self._isolated()
+        cfg.save_settings({"dashboard_plugins": {"p1": True}})
+        r = cfg.save_settings({"dashboard_plugins": {"p2": True}})
+        dp = r.get("dashboard_plugins", {})
+        assert dp.get("p1") is True and dp.get("p2") is True
+
+
+class TestPluginNameValidation:
+    def test_invalid_plugin_name_rejected(self):
+        import api.plugins as plugins
+        assert plugins._VALID_PLUGIN_NAME.match("nic-branch-sync")
+        assert plugins._VALID_PLUGIN_NAME.match("demo_dashboard")
+        assert not plugins._VALID_PLUGIN_NAME.match("../foo")
+        assert not plugins._VALID_PLUGIN_NAME.match("/etc/passwd")
+        assert not plugins._VALID_PLUGIN_NAME.match("UPPER")
+        assert not plugins._VALID_PLUGIN_NAME.match("")
+        assert not plugins._VALID_PLUGIN_NAME.match("1leading-digit")
+
+
 class TestPluginCollisionDetection:
     """Tests for plugin name and tab.path collision detection."""
 

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -6,8 +6,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlparse
 
-import pytest
-
 
 def read(path: str) -> str:
     return Path(path).read_text(encoding="utf-8")
@@ -298,7 +296,7 @@ class TestDashboardPluginsEnforcement:
         import api.config as config
 
         original = config.load_settings()
-        original_plugins = original.get("dashboard_plugins", {})
+        assert isinstance(original, dict)
 
         with tempfile.TemporaryDirectory() as td:
             state_dir = Path(td) / "webui"
@@ -325,14 +323,18 @@ class TestPluginStaticServing:
     """Tests for plugin static file serving path traversal protection."""
 
     def test_plugins_route_restricted_to_plugin_css(self):
-        js = read("static/panels.js")
-        allowed = {"plugin.css"}
-        assert all(ext in js or True for ext in ["plugin.css"])
+        # The /plugins/ shared-asset route must allowlist plugin.css and guard
+        # against path traversal (resolve + relative_to).
+        routes = read("api/routes.py")
+        assert '"/plugins/"' in routes
+        assert "plugin.css" in routes
+        assert "relative_to" in routes
 
     def test_manifest_label_escaped_in_iife_shell(self):
-        js = read("static/panels.js")
-        iife_segment = js[js.find("html_content"):js.find("// ── Plugin pages")] if "html_content" in js else js
-        assert ".escape" in js or "esc(" in js or "html.escape" in js or True
+        # Manifest-supplied label/name/css must be HTML-escaped before being
+        # interpolated into the generated IIFE shell page (no injection).
+        routes = read("api/routes.py")
+        assert "html.escape(" in routes
 
 
 class TestPluginCollisionDetection:

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -441,6 +441,45 @@ class TestPluginNameValidation:
         assert "addEventListener('click'" in seg
         assert "addEventListener('change'" in seg
 
+    def test_asset_route_only_serves_built_assets_not_source_or_config(self):
+        # serve_plugin_static must NOT expose plugin source/config that lives in
+        # the dashboard/ root (plugin_api.py, manifest.json) or dotfiles/source
+        # under dist/ — only built static assets.
+        import json
+        import os
+        import tempfile
+        from pathlib import Path
+        import api.plugins as plugins
+
+        with tempfile.TemporaryDirectory() as td:
+            prev = os.environ.get("HERMES_WEBUI_PLUGINS_DIR")
+            os.environ["HERMES_WEBUI_PLUGINS_DIR"] = td
+            try:
+                root = Path(td) / "tplug" / "dashboard"
+                (root / "dist").mkdir(parents=True)
+                (root / "manifest.json").write_text(json.dumps({"name": "tplug", "tab": {"path": "/tplug"}}), encoding="utf-8")
+                (root / "plugin_api.py").write_text("SECRET = 'x'", encoding="utf-8")
+                (root / "dist" / "app.js").write_text("console.log(1)", encoding="utf-8")
+                (root / "dist" / ".env").write_text("SECRET=x", encoding="utf-8")
+                (root / "dist" / "config.py").write_text("SECRET='x'", encoding="utf-8")
+                plugins.PLUGIN_MANIFESTS.clear()
+                plugins._PLUGIN_STATIC_ROOTS.clear()
+                plugins.load_plugins()
+                # Source / config / dotfiles → blocked.
+                assert plugins.serve_plugin_static("tplug", "plugin_api.py") is None
+                assert plugins.serve_plugin_static("tplug", "manifest.json") is None
+                assert plugins.serve_plugin_static("tplug", "dist/.env") is None
+                assert plugins.serve_plugin_static("tplug", "dist/config.py") is None
+                # Built static asset → served.
+                assert plugins.serve_plugin_static("tplug", "dist/app.js") is not None
+            finally:
+                plugins.PLUGIN_MANIFESTS.clear()
+                plugins._PLUGIN_STATIC_ROOTS.clear()
+                if prev is None:
+                    os.environ.pop("HERMES_WEBUI_PLUGINS_DIR", None)
+                else:
+                    os.environ["HERMES_WEBUI_PLUGINS_DIR"] = prev
+
 
 class TestPluginCollisionDetection:
     """Tests for plugin name and tab.path collision detection."""

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -418,6 +418,29 @@ class TestPluginNameValidation:
         assert not plugins._VALID_PLUGIN_NAME.match("")
         assert not plugins._VALID_PLUGIN_NAME.match("1leading-digit")
 
+    def test_invalid_tab_path_rejected(self):
+        import api.plugins as plugins
+        assert plugins._VALID_PLUGIN_TAB_PATH.match("/demo-dashboard")
+        assert plugins._VALID_PLUGIN_TAB_PATH.match("/nic/branch_sync")
+        # Must be absolute, no quotes/JS-breakout/query/fragment/control chars.
+        assert not plugins._VALID_PLUGIN_TAB_PATH.match("demo")          # not absolute
+        assert not plugins._VALID_PLUGIN_TAB_PATH.match("/x');alert(1)//")  # quote breakout
+        assert not plugins._VALID_PLUGIN_TAB_PATH.match("/x?y=1")         # query
+        assert not plugins._VALID_PLUGIN_TAB_PATH.match("/x#frag")        # fragment
+        assert not plugins._VALID_PLUGIN_TAB_PATH.match("/x y")           # whitespace
+
+    def test_open_button_and_toggle_use_no_inline_handlers(self):
+        # tab.path / plugin.key must not be interpolated into inline onclick/
+        # onchange JS (HTML-escaping is insufficient for a JS-string context).
+        # They're bound via addEventListener with raw closure values instead.
+        js = read("static/panels.js")
+        start = js.find("function _buildPluginCard")
+        seg = js[start:js.find("return card;", start)]
+        assert "onclick=\"switchPluginPage" not in seg
+        assert "onchange=\"handlePluginEnableToggle" not in seg
+        assert "addEventListener('click'" in seg
+        assert "addEventListener('change'" in seg
+
 
 class TestPluginCollisionDetection:
     """Tests for plugin name and tab.path collision detection."""

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -337,6 +337,42 @@ class TestPluginStaticServing:
         assert "html.escape(" in routes
 
 
+class TestPluginAssetIsolationHardening:
+    """Regression coverage for the v0.51.x #2622 hardening pass."""
+
+    def test_dashboard_plugin_disabled_by_default(self):
+        # Opt-in: an unknown/unconfigured plugin is NOT enabled.
+        import api.routes as routes
+        with patch("api.config.load_settings", return_value={}):
+            assert routes._dashboard_plugin_enabled("anything") is False
+
+    def test_dashboard_plugin_enable_gate_reads_settings(self):
+        import api.routes as routes
+        with patch("api.config.load_settings", return_value={"dashboard_plugins": {"foo": True, "bar": False}}):
+            assert routes._dashboard_plugin_enabled("foo") is True
+            assert routes._dashboard_plugin_enabled("bar") is False
+            assert routes._dashboard_plugin_enabled("missing") is False
+
+    def test_asset_route_sends_sandbox_csp_and_nosniff(self):
+        # Plugin-controlled assets are served same-origin; the response MUST carry
+        # the sandbox CSP (null origin) + nosniff so a plugin .html/.svg can't run
+        # privileged same-origin script on direct navigation.
+        routes = read("api/routes.py")
+        seg = routes[routes.find('"/dashboard-plugins/"'):routes.find("# ── Plugin pages")]
+        assert "Content-Security-Policy" in seg
+        assert "sandbox allow-scripts" in seg
+        assert "X-Content-Type-Options" in seg and "nosniff" in seg
+
+    def test_both_plugin_routes_enforce_enable_gate_server_side(self):
+        # Both the asset route and the page route must 404 a disabled plugin —
+        # "disabled" cannot be UI-only.
+        routes = read("api/routes.py")
+        asset_seg = routes[routes.find('"/dashboard-plugins/"'):routes.find("# ── Plugin pages")]
+        page_seg = routes[routes.find("# ── Plugin pages"):routes.find("# ── Plugin pages") + 2000]
+        assert "_dashboard_plugin_enabled" in asset_seg
+        assert "_dashboard_plugin_enabled" in page_seg
+
+
 class TestPluginCollisionDetection:
     """Tests for plugin name and tab.path collision detection."""
 


### PR DESCRIPTION
## Release GC — v0.51.209 (#2622 WebUI dashboard plugin system)

Single contributor PR, taken through a full deep-review hardening pass. Adds a display-only, iframe-isolated dashboard plugin system: a plugin shipping `~/.hermes/plugins/<name>/dashboard/` (with `manifest.json`) appears as an opt-in card in Settings → Plugins; once enabled, an **Open** button renders the plugin page inside a sandboxed iframe.

### What's in this release

**#2622 — dashboard plugin system** (@pix0127)
Discovery + serving + iframe-isolated rendering for dashboard plugins. Opt-in (default off), display-only (no plugin backend/subprocess execution — that was deferred to a future RFC).

### Review + maintainer hardening

Cherry-picked onto current master (the branch was ~643 commits stale). The deep review found and fixed **6 real issues**, each verified with a live repro + regression test:

1. **Same-origin XSS** — plugin `.html`/`.svg` assets were served unsandboxed at the WebUI origin on direct navigation (only the in-panel iframe was sandboxed). Added `Content-Security-Policy: sandbox …` + `X-Content-Type-Options: nosniff` to the asset response.
2. **"Disabled" was UI-only** — a disabled plugin kept serving its pages/assets. Added a server-side `_dashboard_plugin_enabled()` gate that 404s both the page and asset routes (opt-in, default off).
3. **Settings allowlist guard deleted** (severe) — the PR's `save_settings()` edit had dropped the `_SETTINGS_ALLOWED_KEYS` guard (orphaned under a `continue`), breaking saves for every other key and letting any client-supplied key (incl. `password_hash`) be written. Restored.
4. **Inline `onclick` JS-string breakout** — `tab.path`/`key` were interpolated into inline handlers where HTML-escaping is insufficient. Converted to `addEventListener` with raw closure values.
5. **`name` / `tab.path` unvalidated** — added strict load-time regexes (`name` ^[a-z][a-z0-9_-]{0,63}$; `tab.path` absolute, no `//`/quotes/query/fragment).
6. **Asset route served plugin source/config** (CORE) — `serve_plugin_static` served any file under `dashboard/` (leaking `plugin_api.py`, `manifest.json`, `.env`). Constrained to built `dist/`/`static/` subtrees + dotfile denial + static-extension allowlist.

UX (maintainer fixes after screenshot review): single "Enabled" badge (was duplicated), Open button switched to a theme-driven outline style (the filled-accent version rendered invisible text because `--accent-text` equals `--accent` in the default theme), visible toggle knob. Verified legible in both dark and light themes.

### Verification
- Pre-Opus gate (node -c, ast, ruff, ESLint runtime, merge-markers) — clean
- Full sequential pytest: **7254 passed, 0 failed**
- Opus advisor: **SHIP-AS-IS** (all HALT-level concerns resolved with regression tests)
- Codex regression gate: **SAFE TO SHIP** ("no regression risks found")
- Deep browser review of the plugin card + sandboxed iframe page, vision-verified, isolation confirmed (cross-frame access throws SecurityError)
- UX approved by maintainer (Telegram, 2026-06-02)

Co-authored-by: pix0127 <pix0127@users.noreply.github.com>