### PR TITLE
fix: filter GITHUB_TOKEN env var from Copilot credential pool

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1250,21 +1250,29 @@ _PROVIDER_MODELS = {
 
 _AMBIENT_GH_CLI_MARKERS = frozenset({"gh_cli", "gh auth token"})
 
+# Environment variable sources that are auto-detected and should be filtered
+# when the token is a classic PAT (ghp_*) that Copilot API doesn't support.
+# Note: COPILOT_GITHUB_TOKEN is NOT included here - it's user-specific config.
+_AMBIENT_GH_ENV_SOURCES = frozenset({"env:github_token", "env:gh_token"})
+
 
 def _is_ambient_gh_cli_entry(source: str, label: str, key_source: str) -> bool:
     """True when a credential-pool entry is a seeded gh-cli token rather than
     one the user added explicitly. Filter these so Copilot doesn't appear in
     the dropdown just because `gh` is installed on the system.
 
-    Also filters GITHUB_TOKEN env var entries, which are auto-detected from
-    the environment and should not cause Copilot to appear in the picker
-    when the token is a classic PAT (ghp_*) that Copilot API doesn't support.
+    Also filters GITHUB_TOKEN and GH_TOKEN env var entries, which are
+    auto-detected from the environment and should not cause Copilot to appear
+    in the picker when the token is a classic PAT (ghp_*) that Copilot API
+    doesn't support.
+
+    Note: COPILOT_GITHUB_TOKEN is NOT filtered - it's user-specific config
+    that should always be respected.
     """
     source_lower = source.strip().lower()
     return (
         source_lower in _AMBIENT_GH_CLI_MARKERS
-        # Filter GITHUB_TOKEN env var entries (source="env:GITHUB_TOKEN")
-        or source_lower == "env:github_token"
+        or source_lower in _AMBIENT_GH_ENV_SOURCES
         or label.strip().lower() == "gh auth token"
         or key_source.strip().lower() == "gh auth token"
     )

--- a/api/config.py
+++ b/api/config.py
@@ -1255,9 +1255,16 @@ def _is_ambient_gh_cli_entry(source: str, label: str, key_source: str) -> bool:
     """True when a credential-pool entry is a seeded gh-cli token rather than
     one the user added explicitly. Filter these so Copilot doesn't appear in
     the dropdown just because `gh` is installed on the system.
+
+    Also filters GITHUB_TOKEN env var entries, which are auto-detected from
+    the environment and should not cause Copilot to appear in the picker
+    when the token is a classic PAT (ghp_*) that Copilot API doesn't support.
     """
+    source_lower = source.strip().lower()
     return (
-        source.strip().lower() in _AMBIENT_GH_CLI_MARKERS
+        source_lower in _AMBIENT_GH_CLI_MARKERS
+        # Filter GITHUB_TOKEN env var entries (source="env:GITHUB_TOKEN")
+        or source_lower == "env:github_token"
         or label.strip().lower() == "gh auth token"
         or key_source.strip().lower() == "gh auth token"
     )


### PR DESCRIPTION
## Problem

When `GITHUB_TOKEN` environment variable contains a classic PAT (`ghp_*`), Copilot appears in the WebUI model picker dropdown even though the Copilot API does not support classic PATs (only OAuth tokens `gho_*` or fine-grained PATs `github_pat_*`).

This happens because:
1. Hermes CLI detects `GITHUB_TOKEN` and adds a copilot entry to `auth.json` credential_pool with `source="env:GITHUB_TOKEN"`
2. WebUI's `_is_ambient_gh_cli_entry()` function only filtered entries with `source="gh_cli"` or `source="gh auth token"`
3. The `env:GITHUB_TOKEN` source was not filtered, so Copilot was incorrectly added to `detected_providers`

## Solution

Extend `_is_ambient_gh_cli_entry()` to also filter entries with `source="env:GITHUB_TOKEN"`, treating them as ambient/auto-detected credentials rather than user-explicitly-added ones.

## Testing

```python
# New test case passes
_is_ambient_gh_cli_entry("env:GITHUB_TOKEN", "GITHUB_TOKEN", "") == True
_is_ambient_gh_cli_entry("env:github_token", "test", "") == True  # case-insensitive
```

## Impact

- Users with `GITHUB_TOKEN` set to a classic PAT will no longer see a non-functional "GitHub Copilot" group in the model picker
- Users who have explicitly configured Copilot via OAuth (`copilot login`) will still see the Copilot group correctly