### PR TITLE
streaming: emit SSE id: and honor Last-Event-ID for deterministic resume

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -4698,6 +4698,36 @@ STREAM_REASONING_TEXT: dict = {}  # stream_id -> reasoning trace accumulated dur
 STREAM_LIVE_TOOL_CALLS: dict = {}  # stream_id -> live tool calls accumulated during streaming (#1361 §B)
 STREAM_GOAL_RELATED: dict = {}  # stream_id -> bool: only evaluate goal for goal-related turns (#1932)
 STREAM_LAST_EVENT_ID: dict = {}  # stream_id -> latest journal event_id for `id:` field on live SSE frames (stage-364)
+
+
+class SSEEventPayload(dict):
+    """Dict payload subclass carrying a non-serialized SSE event id.
+
+    The stream queue contract stays as a 2-tuple ``(event, data)`` so older
+    tests and non-SSE queue consumers keep working.  When ``data`` is a dict,
+    the journal ``event_id`` travels as an attribute on this dict subclass;
+    JSON serialization and ordinary dict equality ignore the attribute.
+    """
+
+
+def attach_sse_event_id(data, event_id):
+    """Return *data* with an attached non-serialized SSE event id when safe."""
+    if not event_id or not isinstance(data, dict):
+        return data
+    try:
+        payload = SSEEventPayload(data)
+        payload._sse_event_id = str(event_id)
+        return payload
+    except Exception:
+        return data
+
+
+def extract_sse_event_id(data) -> str | None:
+    """Read an SSE event id attached by :func:`attach_sse_event_id`."""
+    event_id = getattr(data, "_sse_event_id", None)
+    return str(event_id) if event_id else None
+
+
 PENDING_GOAL_CONTINUATION: set = set()  # session_ids awaiting a goal continuation turn (#1932)
 
 # Active agent-run registry. This intentionally tracks worker lifecycle rather

--- a/api/routes.py
+++ b/api/routes.py
@@ -999,7 +999,7 @@ from api.config import (
     STREAMS,
     STREAMS_LOCK,
     CANCEL_FLAGS,
-    STREAM_LAST_EVENT_ID,
+    STREAM_LAST_EVENT_ID, extract_sse_event_id,
     SERVER_START_TIME,
     _resolve_cli_toolsets,
     _INDEX_HTML_PATH,
@@ -7758,9 +7758,24 @@ def _handle_list_dir(handler, parsed):
 
 
 def _sse_with_id(handler, event, data, event_id=None):
-    if event_id:
-        handler.wfile.write(f"id: {event_id}\n".encode("utf-8"))
-    _sse(handler, event, data)
+    _sse(handler, event, data, event_id=event_id)
+
+
+def _stream_item_parts(item):
+    """Return ``(event, data, event_id)`` for legacy and id-aware stream items."""
+    event_id = None
+    if isinstance(item, (tuple, list)) and len(item) == 3:
+        event, data, event_id = item
+    else:
+        event, data = item
+    return event, data, event_id or extract_sse_event_id(data)
+
+
+def _handler_header(handler, name: str) -> str | None:
+    headers = getattr(handler, "headers", None)
+    if hasattr(headers, "get"):
+        return headers.get(name)
+    return None
 
 
 def _parse_run_journal_event_id(raw: str | None) -> tuple[str | None, int | None]:
@@ -7778,8 +7793,9 @@ def _parse_run_journal_event_id(raw: str | None) -> tuple[str | None, int | None
     return run_id or None, seq
 
 
-def _parse_run_journal_after_seq(qs: dict, stream_id: str | None = None) -> int | None:
-    event_run_id, event_seq = _parse_run_journal_event_id(qs.get("after_event_id", [None])[0])
+def _parse_run_journal_after_seq(qs: dict, stream_id: str | None = None, last_event_id: str | None = None) -> int | None:
+    raw_event_id = qs.get("after_event_id", [None])[0] or last_event_id
+    event_run_id, event_seq = _parse_run_journal_event_id(raw_event_id)
     if event_run_id:
         if stream_id and event_run_id != stream_id:
             return None
@@ -7820,11 +7836,11 @@ def _replay_run_journal(handler, stream_id: str, after_seq: int | None) -> bool:
     return True
 
 
-def _runner_stream_cursor_from_query(qs: dict) -> str | None:
+def _runner_stream_cursor_from_query(qs: dict, last_event_id: str | None = None) -> str | None:
     cursor = str(qs.get("cursor", [""])[0] or "").strip()
     if cursor:
         return cursor
-    after_seq = _parse_run_journal_after_seq(qs)
+    after_seq = _parse_run_journal_after_seq(qs, last_event_id=last_event_id)
     return str(after_seq) if after_seq is not None else None
 
 
@@ -7916,9 +7932,10 @@ def _stream_runner_run_events(handler, run_id: str, cursor: str | None = None) -
 def _handle_sse_stream(handler, parsed):
     qs = parse_qs(parsed.query)
     stream_id = qs.get("stream_id", [""])[0]
+    last_event_id = _handler_header(handler, "Last-Event-ID")
     stream = STREAMS.get(stream_id)
     if stream is None:
-        if _stream_runner_run_events(handler, stream_id, _runner_stream_cursor_from_query(qs)):
+        if _stream_runner_run_events(handler, stream_id, _runner_stream_cursor_from_query(qs, last_event_id)):
             return True
         try:
             journal_available = bool(find_run_summary(stream_id)) if stream_id else False
@@ -7933,7 +7950,7 @@ def _handle_sse_stream(handler, parsed):
         handler.send_header("Connection", "close")
         handler.end_headers()
         try:
-            _replay_run_journal(handler, stream_id, _parse_run_journal_after_seq(qs, stream_id))
+            _replay_run_journal(handler, stream_id, _parse_run_journal_after_seq(qs, stream_id, last_event_id))
         except _CLIENT_DISCONNECT_ERRORS:
             pass
         return True
@@ -7947,20 +7964,18 @@ def _handle_sse_stream(handler, parsed):
     try:
         while True:
             try:
-                event, data = subscriber.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)
+                item = subscriber.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)
+                event, data, event_id = _stream_item_parts(item)
             except queue.Empty:
                 handler.wfile.write(b": heartbeat\n\n")
                 handler.wfile.flush()
                 continue
-            # Stage-364: emit `id:` from STREAM_LAST_EVENT_ID side-channel so
-            # the frontend's `_lastRunJournalSeq` cursor advances during live
-            # streaming. Without this, mid-stream error→replay would arrive
-            # with after_seq=0 and double-render every journaled event.
-            event_id = STREAM_LAST_EVENT_ID.get(stream_id)
-            if event_id:
-                _sse_with_id(handler, event, data, event_id)
-            else:
-                _sse(handler, event, data)
+            # Prefer the id attached to this exact queued payload. The legacy
+            # STREAM_LAST_EVENT_ID side channel remains as a fallback for
+            # non-dict payloads, but must not overwrite per-event ids when the
+            # producer outruns the SSE consumer.
+            event_id = event_id or STREAM_LAST_EVENT_ID.get(stream_id)
+            _sse(handler, event, data, event_id=event_id)
             if event in ("stream_end", "error", "cancel"):
                 break
     except _CLIENT_DISCONNECT_ERRORS:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -27,7 +27,7 @@ from api.config import (
     STREAMS, STREAMS_LOCK, CANCEL_FLAGS, AGENT_INSTANCES, STREAM_PARTIAL_TEXT,
     STREAM_REASONING_TEXT, STREAM_LIVE_TOOL_CALLS,
     STREAM_GOAL_RELATED, PENDING_GOAL_CONTINUATION,
-    STREAM_LAST_EVENT_ID,
+    STREAM_LAST_EVENT_ID, attach_sse_event_id,
     LOCK, SESSIONS, SESSIONS_MAX, SESSION_DIR,
     _get_session_agent_lock, _set_thread_env, _clear_thread_env,
     register_active_run, update_active_run, unregister_active_run,
@@ -3496,9 +3496,19 @@ def _partial_marker_already_present(messages, candidate: dict, *, before_idx: in
     return False
 
 
-def _sse(handler, event, data):
-    """Write one SSE event to the response stream."""
-    payload = f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
+def _sse(handler, event, data, event_id=None):
+    """Write one SSE event to the response stream.
+
+    ``event_id`` maps to the native SSE ``id:`` field.  Keeping this at the
+    low-level writer makes chat-stream, replay, and any wrapper path share the
+    same browser-native Last-Event-ID behavior.
+    """
+    id_line = ""
+    if event_id not in (None, ""):
+        safe_event_id = str(event_id).replace("\r", "").replace("\n", "")
+        if safe_event_id:
+            id_line = f"id: {safe_event_id}\n"
+    payload = f"{id_line}event: {event}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
     handler.wfile.write(payload.encode('utf-8'))
     handler.wfile.flush()
 
@@ -4149,24 +4159,24 @@ def _run_agent_streaming(
         # If cancelled, drop all further events except the cancel event itself
         if cancel_event.is_set() and event not in ('cancel', 'error'):
             return
+        event_id = None
         if run_journal is not None:
             try:
                 journaled = run_journal.append_sse_event(event, data)
-                # Stage-364: propagate journal event_id via a side-channel dict
-                # (STREAM_LAST_EVENT_ID) instead of changing the queue tuple
-                # shape — keeping the 2-tuple shape preserves backward
-                # compatibility for tests and any non-SSE queue consumer. The
-                # SSE handler reads this dict at emit time to populate `id:`
-                # on every live frame, which lets the frontend's cursor
-                # advance during live streaming and prevents replay from
-                # double-rendering tokens after a mid-stream error→reconnect.
+                # Stage-364 follow-up: keep the public queue shape as the
+                # 2-tuple (event, data), but bind the journal id to the payload
+                # object itself. A single latest-id side channel can go stale
+                # when the producer outruns the SSE consumer; attaching the id
+                # to each queued payload preserves deterministic ordering for
+                # browser-native Last-Event-ID resume. STREAM_LAST_EVENT_ID is
+                # retained only as a compatibility fallback for non-dict data.
                 event_id = (journaled or {}).get('event_id') if isinstance(journaled, dict) else None
                 if event_id:
                     STREAM_LAST_EVENT_ID[stream_id] = event_id
             except Exception:
                 logger.debug("Failed to append run journal event %s for stream %s", event, stream_id, exc_info=True)
         try:
-            q.put_nowait((event, data))
+            q.put_nowait((event, attach_sse_event_id(data, event_id)))
         except Exception:
             logger.debug("Failed to put event to queue")
 

--- a/tests/test_1466_sse_last_event_id.py
+++ b/tests/test_1466_sse_last_event_id.py
@@ -1,0 +1,85 @@
+import io
+from types import SimpleNamespace
+
+from api.config import STREAMS, STREAMS_LOCK, STREAM_LAST_EVENT_ID, attach_sse_event_id, create_stream_channel
+from api.routes import _handle_sse_stream, _parse_run_journal_after_seq, _runner_stream_cursor_from_query, _sse
+from api.streaming import _sse as _streaming_sse
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.status = None
+        self.headers = {}
+        self.sent_headers = []
+        self.wfile = io.BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.sent_headers.append((key, value))
+
+    def end_headers(self):
+        return None
+
+
+def test_last_event_id_is_used_as_replay_cursor_when_query_is_absent():
+    assert _parse_run_journal_after_seq({}, stream_id="run-1", last_event_id="run-1:41") == 41
+
+
+def test_mismatched_last_event_id_is_ignored_for_run_journal_replay():
+    assert _parse_run_journal_after_seq({}, stream_id="run-1", last_event_id="run-2:41") is None
+
+
+def test_query_after_event_id_takes_precedence_over_last_event_id():
+    qs = {"after_event_id": ["run-1:7"]}
+    assert _parse_run_journal_after_seq(qs, stream_id="run-1", last_event_id="run-1:41") == 7
+
+
+def test_runner_cursor_uses_last_event_id_fallback():
+    assert _runner_stream_cursor_from_query({}, last_event_id="run-9:12") == "12"
+
+
+def test_routes_sse_emits_native_id_field():
+    handler = _FakeHandler()
+    _sse(handler, "token", {"text": "hi"}, event_id="run-1:1")
+    payload = handler.wfile.getvalue().decode("utf-8")
+    assert payload.startswith("id: run-1:1\nevent: token\n")
+    assert 'data: {"text": "hi"}' in payload
+
+
+def test_streaming_sse_emits_native_id_field():
+    handler = _FakeHandler()
+    _streaming_sse(handler, "token", {"text": "hi"}, event_id="run-1:1")
+    payload = handler.wfile.getvalue().decode("utf-8")
+    assert payload.startswith("id: run-1:1\nevent: token\n")
+
+
+def test_live_chat_stream_uses_per_event_payload_id_not_stale_side_channel():
+    stream_id = "run-live-id-test"
+    stream = create_stream_channel()
+    stream.put_nowait(("token", attach_sse_event_id({"text": "A"}, "run-live-id-test:1")))
+    stream.put_nowait(("token", attach_sse_event_id({"text": "B"}, "run-live-id-test:2")))
+    stream.put_nowait(("stream_end", attach_sse_event_id({"status": "done"}, "run-live-id-test:3")))
+
+    handler = _FakeHandler()
+    with STREAMS_LOCK:
+        previous = dict(STREAMS)
+        previous_ids = dict(STREAM_LAST_EVENT_ID)
+        STREAMS.clear()
+        STREAM_LAST_EVENT_ID.clear()
+        STREAMS[stream_id] = stream
+        STREAM_LAST_EVENT_ID[stream_id] = "run-live-id-test:99"
+    try:
+        assert _handle_sse_stream(handler, SimpleNamespace(query=f"stream_id={stream_id}")) is True
+        payload = handler.wfile.getvalue().decode("utf-8")
+        assert "id: run-live-id-test:1\nevent: token" in payload
+        assert "id: run-live-id-test:2\nevent: token" in payload
+        assert "id: run-live-id-test:3\nevent: stream_end" in payload
+        assert "id: run-live-id-test:99" not in payload
+    finally:
+        with STREAMS_LOCK:
+            STREAMS.clear()
+            STREAMS.update(previous)
+            STREAM_LAST_EVENT_ID.clear()
+            STREAM_LAST_EVENT_ID.update(previous_ids)


### PR DESCRIPTION
### Summary
Emit native SSE `id:` fields on every live and replayed event frame, and honor the browser-standard `Last-Event-ID` request header as a fallback cursor for deterministic stream resume after mid-stream disconnects.

### Changes
- **`api/config.py`**: Introduce `SSEEventPayload(dict)` subclass that carries a non-serialized `_sse_event_id` attribute alongside normal dict data. Add `attach_sse_event_id()` and `extract_sse_event_id()` helpers so the queue contract stays as a 2-tuple `(event, data)` while each payload carries its own journal event id.
- **`api/streaming.py`**: Extend the low-level `_sse(handler, event, data, event_id=None)` writer to emit `id: <event_id>\n` when present. Update the producer's `put()` to `attach_sse_event_id(data, event_id)` so each queued payload carries a deterministic id instead of relying solely on the `STREAM_LAST_EVENT_ID` side-channel dict (which can go stale when the producer outruns the consumer).
- **`api/routes.py`**: Add `_stream_item_parts()` and `_handler_header()` helpers. Plumb `last_event_id` through `_parse_run_journal_after_seq()`, `_runner_stream_cursor_from_query()`, and `_handle_sse_stream()` so the SSE handler reads the `Last-Event-ID` request header and uses it as a replay/cursor fallback when no `after_event_id` query param is present. The live subscriber loop now prefers per-event payload ids over the stale side-channel.

### Testing
- `tests/test_1466_sse_last_event_id.py` — 7 tests covering:
  - `Last-Event-ID` used as replay cursor when query param is absent
  - Mismatched run id in `Last-Event-ID` is correctly ignored
  - Query `after_event_id` takes precedence over `Last-Event-ID`
  - Runner cursor uses `Last-Event-ID` fallback
  - Both `api.routes._sse` and `api.streaming._sse` emit native `id:` field
  - Live chat stream uses per-event payload id instead of stale side-channel

### Risk
Medium — touches the SSE write path and the stream subscriber loop, but the change is additive (new `id:` line) and backwards-compatible (2-tuple queue shape preserved).
