### PR TITLE
Fix: /model selection shadowing shorter model names (#3368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- The `/model` slash command no longer selects a longer model variant when a shorter name is a prefix of it (e.g. `/model mimo-v2.5` selecting `mimo-v2.5-pro`). The fuzzy fallback now prefers an exact id/label match and otherwise the shortest matching option, applied to both the main and bare-name (`provider/...`) fallbacks. Closes #3368 (#3394, @vanshaj-pahwa).
+
 ## [v0.51.210] — 2026-06-02 — Release GD (stage-batch1 — model-picker multi-slash fix + extensionless preview highlighting)
 
 ### Fixed

--- a/static/commands.js
+++ b/static/commands.js
@@ -322,6 +322,24 @@ function cmdClear(){
   showToast(t('conversation_cleared'));
 }
 
+// Find the best matching model <option> for a slash-command query.
+// Returns an exact id/label match if present, otherwise the shortest option
+// whose value or label contains the query. Preferring the shortest match keeps
+// a specific query like "mimo-v2.5" from being shadowed by a longer variant
+// such as "mimo-v2.5-pro". See issue #3368.
+function _bestModelMatch(options,query){
+  let best=null;
+  for(const opt of options){
+    const value=opt.value.toLowerCase();
+    const text=opt.textContent.toLowerCase();
+    if(value===query||text===query) return opt.value;
+    if(value.includes(query)||text.includes(query)){
+      if(best===null||opt.value.length<best.length) best=opt.value;
+    }
+  }
+  return best;
+}
+
 async function cmdModel(args){
   if(!args){showToast(t('model_usage'));return;}
   const sel=$('modelSelect');
@@ -348,21 +366,13 @@ async function cmdModel(args){
   let match=(typeof _findModelInDropdown==='function')?_findModelInDropdown(q,sel,preferred):null;
   // Fallback: fuzzy match across all options
   if(!match){
-    for(const opt of sel.options){
-      if(opt.value.toLowerCase().includes(q)||opt.textContent.toLowerCase().includes(q)){
-        match=opt.value;break;
-      }
-    }
+    match=_bestModelMatch(sel.options,q);
   }
   // Fallback: if q has provider/ prefix (e.g. "deepseek/deepseek-v4-flash"),
   // try the bare model name (which is how options appear for the active provider)
   if(!match && q.includes('/')){
     const bare=q.slice(q.lastIndexOf('/')+1);
-    for(const opt of sel.options){
-      if(opt.value.toLowerCase().includes(bare)||opt.textContent.toLowerCase().includes(bare)){
-        match=opt.value;break;
-      }
-    }
+    match=_bestModelMatch(sel.options,bare);
     // Cross-provider fallback: if still no match, the model is from a
     // different provider not in the dropdown. Call /api/session/update directly.
     if(!match && S&&S.session&&S.session.session_id){


### PR DESCRIPTION
## Closes #3368

### Problem
The `/model` slash command's fuzzy fallback in `cmdModel` (`static/commands.js`)
used a substring match that took the **first** option containing the query:

```js
if (opt.value.toLowerCase().includes(q) || opt.textContent.toLowerCase().includes(q)) {
  match = opt.value; break;
}
```

So `/model mimo-v2.5` selected `mimo-v2.5-pro` (it contains the substring and
came first), making the shorter, more specific model unselectable. The same
flawed loop existed twice: the main fallback and the bare-name (`provider/...`)
fallback.

### Change
Replaced both loops with a shared `_bestModelMatch(options, query)` helper that:

- returns an exact id/label match if one exists, and
- otherwise returns the shortest option whose value/label contains the query,

so a specific query wins over a longer variant. The longer variant (e.g.
`mimo-v2.5-pro`) is still selectable by its full name. This matches the
exact-then-shortest approach @nesquena-hermes suggested in the thread.

### Verification
- `npm run lint:runtime` (eslint runtime-guard) on `static/commands.js`: passes, 0 errors.
- Verified the matching logic against the reported case:
  - `mimo-v2.5` → `xiaomi/mimo-v2.5` (no longer shadowed by `-pro`) ✅
  - `mimo-v2.5-pro` → `xiaomi/mimo-v2.5-pro` (still selectable) ✅
  - exact value query → exact option ✅
  - no match → falls through to the existing cross-provider path ✅

### Note on tests
`static/commands.js` is browser global script with no JS unit-test harness in the
repo (the suite is pytest). I kept the matching logic in a small pure helper so
it's easy to cover if you'd like a JS test setup added; happy to follow up.
