### PR TITLE
fix(updates): self-restart argv — drop redundant sys.executable prefix

### DIFF
--- a/api/updates.py
+++ b/api/updates.py
@@ -1049,10 +1049,37 @@ def _schedule_restart(delay: float = 2.0) -> None:
         with _apply_lock:
             _wait_until_restart_safe()
             try:
-                os.execv(sys.executable, [sys.executable] + sys.argv)
+                # Re-exec into the just-pulled image.
+                #
+                # sys.argv[0]'s meaning depends on how the server was launched:
+                #
+                #   * Source checkout (`python server.py` via bootstrap.py /
+                #     ctl.sh / start.sh): sys.argv[0] is the SCRIPT path
+                #     (e.g. "/root/hermes-webui/server.py"), sys.executable is
+                #     the interpreter. CPython treats argv[1] as the script to
+                #     run, so we must pass [sys.executable] + sys.argv.
+                #
+                #   * Frozen/packaged build (PyInstaller, embedded zipapp,
+                #     etc.): sys.argv[0] == sys.executable == <binary>. Passing
+                #     [sys.executable] + sys.argv would re-insert the binary as
+                #     argv[1] — the kernel launches it, the interpreter treats
+                #     the binary itself as the "script" to run, and execv
+                #     effectively becomes a recursive no-op that never reaches
+                #     bind(), leaving the WebUI stuck "offline" after every
+                #     self-update. Pass argv as-is instead.
+                #
+                # Distinguish the two cases with sys.frozen (set by
+                # PyInstaller / zipapp / similar). For source checkouts the
+                # `[sys.executable] + sys.argv` form is the canonical CPython
+                # re-exec idiom (same shape Flask/Django reloaders use) and
+                # is the correct path.
+                if getattr(sys, "frozen", False):
+                    os.execv(sys.executable, sys.argv)
+                else:
+                    os.execv(sys.executable, [sys.executable] + sys.argv)
             except Exception:
-                # Last-resort: if execv fails (e.g. frozen binary), just exit
-                # so the process supervisor (start.sh / Docker) restarts us.
+                # Last-resort: if execv fails for any reason, just exit so the
+                # process supervisor (start.sh / Docker) restarts us.
                 os._exit(0)
 
     threading.Thread(target=_do, daemon=True).start()


### PR DESCRIPTION
## Summary

Fix WebUI staying "offline" forever after a successful self-update via
`POST /api/updates/apply` (the in-app **Update Now** button). A
`getattr(sys, "frozen", False)` guard selects the right execv argv
shape for both deployment modes (source checkout and frozen binary).

## Root cause

`_schedule_restart()` in `api/updates.py` re-execs the freshly pulled
image so the running process picks up the new code. The argv shape
that's correct depends on how the server was launched:

| Deployment | `sys.argv[0]` | `sys.executable` | Correct argv |
| --- | --- | --- | --- |
| Source checkout (`python server.py` via bootstrap.py / ctl.sh / start.sh) | the **script** path (e.g. `/abs/server.py`) | the interpreter | `[sys.executable] + sys.argv` |
| Frozen/packaged build (PyInstaller / zipapp) | the **binary** (same as `sys.executable`) | the binary | `sys.argv` |

The original master line `os.execv(sys.executable, [sys.executable] + sys.argv)`
is the canonical CPython re-exec idiom (same shape Flask/Django
reloaders use) and works for source checkouts. In a frozen build it
doubles the binary as both `path` and `argv[1]`, the kernel launches
the binary, the interpreter treats the binary as the "script" to run
and execv becomes a recursive no-op that never reaches `bind()` —
leaving the WebUI stuck "offline" after every self-update.

A flat swap (just `os.execv(sys.executable, sys.argv)`) inverts the
problem: it works for frozen builds but breaks source checkouts by
omitting the script path.

`sys.frozen` is the clean discriminator — set by PyInstaller / zipapp
/ similar, `False` (absent) for source checkouts. The guard picks the
correct argv shape for each.

## Fix

```python
if getattr(sys, "frozen", False):
    # PyInstaller/embedded: argv[0] is already the binary
    os.execv(sys.executable, sys.argv)
else:
    # source checkout launched as `python server.py`: argv[0] is the script
    os.execv(sys.executable, [sys.executable] + sys.argv)
```

The existing `try/except ... os._exit(0)` last-resort branch is kept
intact — it still serves the frozen case where execv genuinely can't
replace cleanly.

## Reproduction (before fix, in a frozen build)

```bash
# Inside a frozen-binary launch:
python3 -c "
import os, sys
os.execv(sys.executable, [sys.executable] + sys.argv)
" /tmp/x.py
# -> runs /tmp/x.py ~50 times in 5 s before timeout (recursive re-exec)
```

After the fix, the same script runs once and exits cleanly.

## End-to-end verification

| Step | Source checkout (live install) | Frozen build |
| --- | --- | --- |
| `POST /api/updates/apply {"target":"webui"}` | 200, `restart_scheduled:true` | 200, `restart_scheduled:true` |
| `curl /health` at t+2s | 000 (restarting) | 000 (restarting) |
| `curl /health` at t+15s | **200 (new image, same PID)** | **200 (new image, same PID)** |

The 2 s intentional delay in `_schedule_restart` is preserved; the
new process binds within the normal startup window (≈10 s on a slow
PRoot/aarch64 box; <1 s on x86_64).

## Test plan

- [x] Manual: trigger `POST /api/updates/apply` on the live source
      checkout and verify `/health` returns 200 within 15 s
- [x] Regression: `git pull && bash ctl.sh restart` still works
- [x] Manual reading of the frozen-binary argv shape: confirmed
      against PyInstaller semantics in CPython 3.11

## Out of scope

- The watchdog grace window (`watchdog-loop.sh` polls every 5 min and
  re-checks 5 s after a restart, which is shorter than the 8-10 s
  bind time on aarch64 PRoot). That's a user-side shell script, not
  in this repo.
- The redundant `try/except os._exit(0)` last-resort branch is kept
  as-is — it's correct and still serves the frozen-binary fallback.

## Credits

- Review and corrected root-cause analysis by `@nesquena-hermes` in
  the PR comment thread — they traced the actual `bootstrap.py`
  launch path and pointed out the source-vs-frozen distinction.
