### PR TITLE
[security] fix(workspace): keep file API reads inside the selected workspace

### DIFF
--- a/api/workspace.py
+++ b/api/workspace.py
@@ -671,32 +671,17 @@ def validate_workspace_to_add(path: str) -> Path:
 def safe_resolve_ws(root: Path, requested: str) -> Path:
     """Resolve a relative path inside a workspace root, raising ValueError on traversal.
 
-    Symlinks whose *unresolved* path is within the workspace root are allowed —
-    the user placed them there intentionally.  Only raw ``..`` traversal outside
-    the root is blocked.
+    Both raw ``..`` traversal and symlink escapes are blocked.  Workspace file
+    APIs can be reached by browser UI actions and agent/tool calls, so a symlink
+    inside the workspace must not expand the trusted workspace boundary to an
+    arbitrary host path.
     """
-    import os
-    unresolved = root / requested
-    resolved = unresolved.resolve()
-    # Fast path: resolved path is inside root (covers most cases)
+    root_resolved = root.resolve()
+    resolved = (root / requested).resolve()
     try:
-        resolved.relative_to(root.resolve())
-        return resolved
-    except ValueError:
-        pass
-    # Symlink path: normalize '..' (without following symlinks) and check
-    # os.path.normpath collapses '..' but does NOT follow symlinks.
-    norm = Path(os.path.normpath(str(unresolved)))
-    try:
-        norm.relative_to(root)
+        resolved.relative_to(root_resolved)
     except ValueError:
         raise ValueError(f"Path traversal blocked: {requested}")
-    # Symlink points outside workspace root — additionally block system directories.
-    # Even if the user placed the symlink intentionally, prevent reads from
-    # /etc, /proc, /sys, /dev and other blocked roots (LLM agents can call
-    # read_file_content via tool calls, not just human users).
-    if _is_blocked_system_path(resolved):
-        raise ValueError(f"Path traversal blocked (system dir): {requested}")
     return resolved
 
 

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -690,26 +690,45 @@ def list_dir(workspace: Path, rel: str='.'):
     if not target.is_dir():
         raise FileNotFoundError(f"Not a directory: {rel}")
     ws_resolved = workspace.resolve()
+    target_resolved = target.resolve()
     entries = []
-    for item in sorted(target.iterdir(), key=lambda p: (not p.is_symlink(), p.is_file(), p.name.lower())):
+
+    def _sort_key(p: Path):
+        is_link = p.is_symlink()
+        is_file = False
+        if not is_link:
+            try:
+                is_file = p.is_file()
+            except OSError:
+                pass
+        return (not is_link, is_file, p.name.lower())
+
+    for item in sorted(target.iterdir(), key=_sort_key):
         if item.is_symlink():
             # Resolve the symlink target and check if it stays within workspace
             try:
                 link_target = item.resolve()
-            except OSError:
+            except (OSError, RuntimeError):
                 continue
             # Cycle detection: skip if symlink points back to current dir,
             # workspace root, or any ancestor of current dir.
             # This must run REGARDLESS of whether target is inside workspace.
-            if (link_target == target.resolve() or link_target == target
+            if (link_target == target_resolved or link_target == target
                     or link_target == ws_resolved):
                 continue
             try:
-                target.resolve().relative_to(link_target)
+                target_resolved.relative_to(link_target)
                 # target is under link_target — link_target is an ancestor → cycle
                 continue
             except ValueError:
                 pass
+            # Hide symlinks that resolve outside the workspace. Traversing them
+            # would be blocked by safe_resolve_ws anyway, so listing them would
+            # advertise entries that can never be opened.
+            try:
+                link_target.relative_to(ws_resolved)
+            except ValueError:
+                continue
             # Block symlinks that resolve to system directories.
             if _is_blocked_system_path(link_target):
                 continue

--- a/tests/test_symlink_cycle_detection.py
+++ b/tests/test_symlink_cycle_detection.py
@@ -74,18 +74,19 @@ class TestSymlinkCycleDetection:
         assert ext[0]["is_dir"] is True
         assert ext[0]["target"] == str(target)
 
-    def test_external_symlink_browsable(self, cleanup_test_sessions, tmp_path_factory):
-        """Listing inside an external symlink dir returns its contents."""
+    def test_external_symlink_not_browsable(self, cleanup_test_sessions, tmp_path_factory):
+        """Listing inside an external symlink dir is blocked at the workspace boundary."""
         ws = tmp_path_factory.mktemp("ws")
         target = tmp_path_factory.mktemp("target")
         (target / "inner.txt").write_text("data")
         (ws / "ext").symlink_to(target)
 
         sid, _ = make_session(cleanup_test_sessions, ws)
-        listing = get(f"/api/list?session_id={sid}&path=ext")
-        entries = listing["entries"]
-        names = [e["name"] for e in entries]
-        assert "inner.txt" in names
+        try:
+            get(f"/api/list?session_id={sid}&path=ext")
+            assert False, "External symlink traversal should be blocked"
+        except urllib.error.HTTPError as e:
+            assert e.code in (400, 404, 500)
 
     def test_self_referencing_symlink_filtered(self, cleanup_test_sessions, tmp_path_factory):
         """Symlink pointing to the workspace root itself must be filtered out."""
@@ -113,7 +114,7 @@ class TestSymlinkCycleDetection:
         assert "up" not in names, "Ancestor symlink should be filtered"
 
     def test_symlink_cycle_in_subdir(self, cleanup_test_sessions, tmp_path_factory):
-        """Symlink cycle inside a symlink target's subtree must not recurse."""
+        """External symlink subpaths must be blocked instead of traversed."""
         ws = tmp_path_factory.mktemp("ws")
         target = tmp_path_factory.mktemp("target")
         (target / "subdir").mkdir()
@@ -127,10 +128,12 @@ class TestSymlinkCycleDetection:
         names = [e["name"] for e in listing["entries"]]
         assert "ext" in names
 
-        # List inside ext/subdir — 'back' should be filtered
-        listing2 = get(f"/api/list?session_id={sid}&path=ext/subdir")
-        names2 = [e["name"] for e in listing2["entries"]]
-        assert "back" not in names2, "Cycle symlink inside external target should be filtered"
+        # Traversing into ext/subdir crosses the workspace boundary and is blocked.
+        try:
+            get(f"/api/list?session_id={sid}&path=ext/subdir")
+            assert False, "External symlink subpath traversal should be blocked"
+        except urllib.error.HTTPError as e:
+            assert e.code in (400, 404, 500)
 
     def test_symlink_file_entry(self, cleanup_test_sessions, tmp_path_factory):
         """Symlink to a file should have is_dir=False and include size."""

--- a/tests/test_symlink_cycle_detection.py
+++ b/tests/test_symlink_cycle_detection.py
@@ -8,8 +8,8 @@ recursion.  Covers:
 - External symlink dirs (e.g. ln -s /some/path ~/workspace/link)
 - Self-referencing symlink (ln -s . ~/workspace/loop)
 - Ancestor symlink (ln -s .. ~/workspace/up)
-- Symlink entries carry correct type / is_dir / target fields
-- Browsing into a symlink directory via workspace-relative path works
+- Internal symlink entries carry correct type / is_dir / target fields
+- External symlink directories are hidden from listings and cannot be traversed
 """
 import json
 import os
@@ -57,8 +57,8 @@ def make_session(created_list, ws=None):
 class TestSymlinkCycleDetection:
     """Symlink cycle detection in list_dir / safe_resolve_ws."""
 
-    def test_external_symlink_listed_as_symlink(self, cleanup_test_sessions, tmp_path_factory):
-        """External symlink dir should appear with type='symlink', is_dir=True."""
+    def test_external_symlink_filtered_from_listing(self, cleanup_test_sessions, tmp_path_factory):
+        """External symlink dirs should be hidden from workspace listings."""
         ws = tmp_path_factory.mktemp("ws")
         target = tmp_path_factory.mktemp("target")
         (target / "file.txt").write_text("hello")
@@ -67,12 +67,26 @@ class TestSymlinkCycleDetection:
 
         sid, _ = make_session(cleanup_test_sessions, ws)
         listing = get(f"/api/list?session_id={sid}&path=.")
+        names = [e["name"] for e in listing["entries"]]
+        assert "ext" not in names
+
+    def test_internal_symlink_listed_as_symlink(self, cleanup_test_sessions, tmp_path_factory):
+        """Internal symlink dirs should appear with type='symlink', is_dir=True."""
+        ws = tmp_path_factory.mktemp("ws")
+        target = ws / "target"
+        target.mkdir()
+        (target / "file.txt").write_text("hello")
+        link = ws / "internal"
+        link.symlink_to(target)
+
+        sid, _ = make_session(cleanup_test_sessions, ws)
+        listing = get(f"/api/list?session_id={sid}&path=.")
         entries = listing["entries"]
-        ext = [e for e in entries if e["name"] == "ext"]
-        assert len(ext) == 1
-        assert ext[0]["type"] == "symlink"
-        assert ext[0]["is_dir"] is True
-        assert ext[0]["target"] == str(target)
+        internal = [e for e in entries if e["name"] == "internal"]
+        assert len(internal) == 1
+        assert internal[0]["type"] == "symlink"
+        assert internal[0]["is_dir"] is True
+        assert internal[0]["target"] == str(target)
 
     def test_external_symlink_not_browsable(self, cleanup_test_sessions, tmp_path_factory):
         """Listing inside an external symlink dir is blocked at the workspace boundary."""
@@ -113,6 +127,18 @@ class TestSymlinkCycleDetection:
         names = [e["name"] for e in listing["entries"]]
         assert "up" not in names, "Ancestor symlink should be filtered"
 
+    def test_mutual_symlink_loop_filtered(self, cleanup_test_sessions, tmp_path_factory):
+        """Mutually recursive symlinks should be skipped instead of raising RuntimeError."""
+        ws = tmp_path_factory.mktemp("ws")
+        (ws / "a").symlink_to(ws / "b")
+        (ws / "b").symlink_to(ws / "a")
+
+        sid, _ = make_session(cleanup_test_sessions, ws)
+        listing = get(f"/api/list?session_id={sid}&path=.")
+        names = [e["name"] for e in listing["entries"]]
+        assert "a" not in names
+        assert "b" not in names
+
     def test_symlink_cycle_in_subdir(self, cleanup_test_sessions, tmp_path_factory):
         """External symlink subpaths must be blocked instead of traversed."""
         ws = tmp_path_factory.mktemp("ws")
@@ -123,10 +149,10 @@ class TestSymlinkCycleDetection:
         (ws / "ext").symlink_to(target)
 
         sid, _ = make_session(cleanup_test_sessions, ws)
-        # List root — should show ext but not recurse
+        # List root — should hide the external symlink and not recurse.
         listing = get(f"/api/list?session_id={sid}&path=.")
         names = [e["name"] for e in listing["entries"]]
-        assert "ext" in names
+        assert "ext" not in names
 
         # Traversing into ext/subdir crosses the workspace boundary and is blocked.
         try:
@@ -135,10 +161,11 @@ class TestSymlinkCycleDetection:
         except urllib.error.HTTPError as e:
             assert e.code in (400, 404, 500)
 
-    def test_symlink_file_entry(self, cleanup_test_sessions, tmp_path_factory):
-        """Symlink to a file should have is_dir=False and include size."""
+    def test_internal_symlink_file_entry(self, cleanup_test_sessions, tmp_path_factory):
+        """Internal symlink to a file should have is_dir=False and include size."""
         ws = tmp_path_factory.mktemp("ws")
-        real = tmp_path_factory.mktemp("real")
+        real = ws / "real"
+        real.mkdir()
         (real / "data.txt").write_text("hello world")
         (ws / "link.txt").symlink_to(real / "data.txt")
 
@@ -149,6 +176,18 @@ class TestSymlinkCycleDetection:
         assert link[0]["type"] == "symlink"
         assert link[0]["is_dir"] is False
         assert link[0]["size"] == 11  # len("hello world")
+
+    def test_external_symlink_file_filtered_from_listing(self, cleanup_test_sessions, tmp_path_factory):
+        """External symlink files should be hidden from workspace listings."""
+        ws = tmp_path_factory.mktemp("ws")
+        real = tmp_path_factory.mktemp("real")
+        (real / "data.txt").write_text("hello world")
+        (ws / "link.txt").symlink_to(real / "data.txt")
+
+        sid, _ = make_session(cleanup_test_sessions, ws)
+        listing = get(f"/api/list?session_id={sid}&path=.")
+        names = [e["name"] for e in listing["entries"]]
+        assert "link.txt" not in names
 
     def test_path_traversal_still_blocked(self, cleanup_test_sessions, tmp_path_factory):
         """Raw .. traversal must still be blocked even with symlink support."""

--- a/tests/test_workspace_symlink_containment.py
+++ b/tests/test_workspace_symlink_containment.py
@@ -17,6 +17,8 @@ def test_safe_resolve_blocks_external_symlink_directory(tmp_path):
     with pytest.raises(ValueError, match="Path traversal blocked"):
         list_dir(workspace, "escape")
 
+    assert "escape" not in {entry["name"] for entry in list_dir(workspace, ".")}
+
 
 def test_read_file_blocks_external_symlink_file(tmp_path):
     workspace = tmp_path / "workspace"
@@ -28,6 +30,8 @@ def test_read_file_blocks_external_symlink_file(tmp_path):
 
     with pytest.raises(ValueError, match="Path traversal blocked"):
         read_file_content(workspace, "secret-link.txt")
+
+    assert "secret-link.txt" not in {entry["name"] for entry in list_dir(workspace, ".")}
 
 
 def test_internal_symlink_still_resolves_within_workspace(tmp_path):
@@ -42,3 +46,4 @@ def test_internal_symlink_still_resolves_within_workspace(tmp_path):
 
     assert resolved == (nested / "inside.txt").resolve()
     assert read_file_content(workspace, "inside-link.txt")["content"] == "inside"
+    assert "inside-link.txt" in {entry["name"] for entry in list_dir(workspace, ".")}

--- a/tests/test_workspace_symlink_containment.py
+++ b/tests/test_workspace_symlink_containment.py
@@ -1,0 +1,44 @@
+import pytest
+
+from api.workspace import list_dir, read_file_content, safe_resolve_ws
+
+
+def test_safe_resolve_blocks_external_symlink_directory(tmp_path):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    (outside / "secret.txt").write_text("outside", encoding="utf-8")
+    (workspace / "escape").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="Path traversal blocked"):
+        safe_resolve_ws(workspace, "escape")
+
+    with pytest.raises(ValueError, match="Path traversal blocked"):
+        list_dir(workspace, "escape")
+
+
+def test_read_file_blocks_external_symlink_file(tmp_path):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    (outside / "secret.txt").write_text("outside", encoding="utf-8")
+    (workspace / "secret-link.txt").symlink_to(outside / "secret.txt")
+
+    with pytest.raises(ValueError, match="Path traversal blocked"):
+        read_file_content(workspace, "secret-link.txt")
+
+
+def test_internal_symlink_still_resolves_within_workspace(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    nested = workspace / "nested"
+    nested.mkdir()
+    (nested / "inside.txt").write_text("inside", encoding="utf-8")
+    (workspace / "inside-link.txt").symlink_to(nested / "inside.txt")
+
+    resolved = safe_resolve_ws(workspace, "inside-link.txt")
+
+    assert resolved == (nested / "inside.txt").resolve()
+    assert read_file_content(workspace, "inside-link.txt")["content"] == "inside"


### PR DESCRIPTION
## Summary
This PR hardens the workspace file boundary so workspace browsing and file reads stay inside the selected workspace after symlink resolution.

- Blocks external symlinks inside a workspace from escaping to host paths outside the workspace root.
- Preserves internal symlinks that resolve back under the selected workspace.
- Adds focused regression coverage for `/api/list` / workspace resolution behavior and updates cycle-detection expectations.
- Keeps the change scoped to workspace path containment; no frontend, upload extraction, or agent-runtime behavior is changed.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Workspace symlink escape through file/list APIs | A workspace containing a symlink to an outside directory could allow read-only listing or file disclosure outside the selected workspace through normal workspace file API flows. | Medium generally; High in deployments where a malicious workspace can be selected and the Web UI is exposed to another user/session. |

## Before this PR
- Workspace path resolution allowed symlinks that resolved outside the selected workspace unless they matched a small system-directory denylist.
- Workspace listing/read helpers trusted the resolved path returned by `safe_resolve_ws`.
- A symlink placed inside the selected workspace could therefore point the file APIs at content outside that workspace.
- Regression tests covered symlink cycles and inaccessible/system paths, but not the general resolved-path containment invariant.

## After this PR
- `safe_resolve_ws(root, requested)` resolves both the workspace root and requested path.
- The resolved requested path must remain under the resolved workspace root.
- External symlink traversal now raises `ValueError("Path traversal blocked: <requested>")` before list/read helpers use the target.
- Internal symlinks that still resolve within the selected workspace continue to work.
- New focused tests lock both external-symlink rejection and internal-symlink compatibility.

## Why this matters
Hermes WebUI can expose workspace contents through browser and agent-facing workspace APIs. The intended trust boundary is the selected workspace, not every path reachable by a symlink inside it. If a malicious or untrusted workspace can be selected, following external symlinks can disclose host files outside the workspace that the server process can read.

The validated impact is read-only disclosure/listing outside the selected workspace. This PR does not claim write/delete/RCE impact or an app-native symlink planting primitive.

## How this differs from related issue/PR
This is related to the same general symlink-safety family as PR #1149, but it addresses a different boundary:

- PR #1149 covered symlink recursion/cycle behavior.
- This PR enforces resolved-path containment for workspace file/list targets.
- The issue fixed here is not merely infinite recursion; it is that a resolved path outside the selected workspace was still treated as an acceptable workspace target.

Both protections are useful: cycle handling prevents traversal loops, while this PR prevents crossing the workspace root boundary.

## Attack flow
```text
Attacker-controlled or untrusted workspace contains symlink -> outside readable directory
    -> user/session selects that workspace in Hermes WebUI
        -> workspace file/list API resolves the symlink target
            -> resolved target is outside the workspace but still used
                -> outside directory entries or file contents are disclosed read-only
```

## Affected code

| Issue | Files |
|-------|-------|
| Workspace symlink escape | `api/workspace.py`, `tests/test_workspace_symlink_containment.py`, `tests/test_symlink_cycle_detection.py` |

## Root cause
Workspace symlink escape through file/list APIs:
- `safe_resolve_ws` resolved requested workspace paths but did not require the resolved target to remain under the resolved workspace root.
- The prior guard relied on traversal checks plus a small system-directory blocklist, which is narrower than the actual selected-workspace boundary.
- Routes/helpers that used the resolved path inherited that broader-than-intended trust decision.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Workspace symlink escape through file/list APIs | 6.5 Medium generally; up to 8.1 High under malicious-workspace/exposed-Web-UI assumptions | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` |

Rationale:
- The proof requires the application to serve a selected workspace containing an attacker-controlled or otherwise untrusted symlink.
- The validated impact is confidentiality-only: outside-workspace listing/file disclosure readable by the server process.
- Severity is deployment-dependent because some deployments are purely local/single-user, while others may expose the Web UI behind auth or a reverse proxy.

## Safe reproduction steps
1. On a vulnerable build, create a workspace directory with a symlink pointing to another local directory containing a harmless marker file.
2. Start Hermes WebUI with isolated test state and select the symlink-containing workspace.
3. Request the linked directory through the workspace list/read API path.
4. Observe that the outside marker path/content can be reached through the selected workspace API even though it is not under the workspace root.

Use only temporary directories and harmless marker files. Do not test against real secrets or production paths.

## Expected vulnerable behavior
- A path like `link_out/secret.txt`, where `link_out` is a symlink to a directory outside the workspace, is accepted as a workspace path.
- The API can list or read the outside target read-only.
- The safe proof signal is a temporary marker file outside the selected workspace becoming visible through the workspace API.

## Changes in this PR
- Tightens `safe_resolve_ws(root, requested)` to compare resolved paths against the resolved workspace root.
- Raises a path-traversal error when a symlink target escapes the workspace boundary.
- Keeps legitimate internal symlinks working when their final target remains under the workspace root.
- Adds `tests/test_workspace_symlink_containment.py` for external directory/file symlink blocking and internal symlink allowance.
- Updates symlink cycle tests so external symlink browsing is rejected instead of traversed.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Path containment | `api/workspace.py` | Enforces resolved requested path under resolved workspace root. |
| Regression tests | `tests/test_workspace_symlink_containment.py` | Adds focused external/internal symlink containment coverage. |
| Existing symlink tests | `tests/test_symlink_cycle_detection.py` | Aligns expectations with the stricter workspace-root boundary. |

## Maintainer impact
- The patch is intentionally narrow and limited to workspace path resolution/test coverage.
- Internal symlinks inside the workspace continue to work.
- External symlinks inside a workspace are no longer browsable through workspace file/list APIs.
- No new dependencies or frontend build steps are introduced.
- No unrelated upload, auth, streaming, or agent-runtime behavior is changed.

## Fix rationale
The selected workspace root is the durable security boundary. A denylist for a few system paths is not sufficient because arbitrary outside directories can still contain sensitive project, user, or machine-local files. Comparing the resolved requested path to the resolved workspace root handles normal `..` traversal and symlink traversal with the same invariant while preserving in-workspace symlinks.

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] `python3 -m pytest tests/test_workspace_symlink_containment.py tests/test_symlink_cycle_detection.py tests/test_workspace_dir_signature.py -q` — `12 passed, 1 warning in 1.87s`
- [x] `python3 scripts/ruff_lint.py --diff origin/master` — no new violations on added/modified lines
- [x] `git diff --check` — no whitespace errors

Full `pytest tests/ -v --timeout=60` was not run locally for this PR; the focused workspace/symlink tests cover the changed behavior directly.

## Contract Routing
- Contract family: workspace file/list path containment.
- Evidence: focused workspace symlink containment tests plus existing workspace directory signature coverage.
- This changes behavior for external symlinks inside a selected workspace: they are now blocked instead of followed. That is intentional because the selected workspace root is the security boundary.

## AI assistance disclosure
AI assistance was used to inspect the code paths, prepare the focused patch, and draft this PR description. No credentials, production secrets, or private files are included in this PR body.

## Disclosure notes
- Claims are bounded to read-only outside-workspace listing/file disclosure through workspace file APIs.
- No write/delete/RCE impact is claimed.
- No app-native symlink planting primitive is claimed.
- The proof and tests use temporary paths/marker files, not real secrets.
- This PR is intentionally scoped to resolved-path containment for the selected workspace boundary.
