### PR TITLE
fix: add self-hosted provider setup (Ollama/LM Studio) in Settings → Providers (#3260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Added
+- Self-hosted provider setup (Ollama, LM Studio, Custom OpenAI-compatible) in Settings → Providers. Keyless providers now appear as configurable cards with an endpoint URL field instead of an API key field, matching the onboarding wizard's treatment of `key_optional` providers (#3260, @theherrovn-sys).
+
 ## [v0.51.210] — 2026-06-02 — Release GD (stage-batch1 — model-picker multi-slash fix + extensionless preview highlighting)
 
 ### Fixed

--- a/api/providers.py
+++ b/api/providers.py
@@ -34,6 +34,7 @@ from api.config import (
     _PROVIDER_DISPLAY,
     _PROVIDER_MODELS,
     _custom_provider_slug_from_name,
+    _get_config_path,
     _get_label_for_model,
     _models_from_live_provider_ids,
     _read_live_provider_model_ids,
@@ -1762,6 +1763,17 @@ def get_providers() -> dict[str, Any]:
     # Add OAuth providers even if not in _PROVIDER_DISPLAY
     known_ids.update(_OAUTH_PROVIDERS)
 
+    # Add keyless self-hosted providers from onboarding setups so they
+    # appear in Settings → Providers even when they're not in the
+    # hardcoded _PROVIDER_ENV_VAR mapping (#3260).
+    try:
+        from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+        for spid, setup in _SUPPORTED_PROVIDER_SETUPS.items():
+            if setup.get("key_optional"):
+                known_ids.add(spid)
+    except ImportError:
+        pass
+
     for pid in sorted(known_ids):
         display_name = _PROVIDER_DISPLAY.get(pid, pid.replace("-", " ").title())
         is_oauth = _provider_is_oauth(pid)
@@ -1939,12 +1951,31 @@ def get_providers() -> dict[str, Any]:
                 if pid != "nous":
                     models_total = len(models)
 
+        configurable = not is_oauth and pid in _PROVIDER_ENV_VAR
+        keyless = False
+        base_url = ""
+        try:
+            from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+            setup = _SUPPORTED_PROVIDER_SETUPS.get(pid)
+            if setup and setup.get("key_optional"):
+                configurable = True
+                keyless = True
+                model_cfg = cfg.get("model", {})
+                if isinstance(model_cfg, dict):
+                    base_url = str(model_cfg.get("base_url") or "")
+                if not base_url:
+                    base_url = str(setup.get("default_base_url") or "")
+        except ImportError:
+            pass
+
         providers.append({
             "id": pid,
             "display_name": display_name,
             "has_key": has_key,
-            "configurable": not is_oauth and pid in _PROVIDER_ENV_VAR,
+            "configurable": configurable,
             "is_oauth": is_oauth,
+            "keyless": keyless,
+            "base_url": base_url,
             "key_source": key_source,
             "auth_error": auth_error,
             "models": models,
@@ -2173,3 +2204,62 @@ def _clean_provider_key_from_config(provider_id: str) -> None:
             reload_config()
     except Exception:
         logger.exception("Failed to clean provider key from config.yaml for %s", provider_id)
+
+
+def set_provider_base_url(provider_id: str, base_url: str | None) -> dict[str, Any]:
+    """Set or update the endpoint URL for a keyless self-hosted provider.
+
+    Writes ``model.base_url`` to the active profile's ``config.yaml`` so
+    the agent runtime picks up the endpoint on the next chat.  This matches
+    the write path used by the first-run onboarding wizard (#3260).
+
+    Returns a status dict with the operation result.
+    """
+    provider_id = provider_id.strip().lower()
+
+    if not provider_id:
+        return {"ok": False, "error": "Provider ID is required."}
+
+    try:
+        from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+    except ImportError:
+        return {"ok": False, "error": "Cannot verify provider setup — onboarding module unavailable."}
+
+    setup = _SUPPORTED_PROVIDER_SETUPS.get(provider_id)
+    if not setup or not setup.get("key_optional"):
+        return {
+            "ok": False,
+            "error": f"'{_PROVIDER_DISPLAY.get(provider_id, provider_id)}' is not a self-hosted keyless provider.",
+        }
+
+    if base_url is not None:
+        base_url = base_url.strip().rstrip("/")
+        if not base_url:
+            return {"ok": False, "error": "Endpoint URL must not be empty."}
+        from urllib.parse import urlparse
+        parsed = urlparse(base_url)
+        if parsed.scheme not in {"http", "https"}:
+            return {"ok": False, "error": "Endpoint URL must start with http:// or https://"}
+
+    cfg = get_config()
+    model_cfg = cfg.get("model", {})
+    if not isinstance(model_cfg, dict):
+        model_cfg = {}
+    if base_url is not None:
+        model_cfg["base_url"] = base_url
+    else:
+        model_cfg.pop("base_url", None)
+    cfg["model"] = model_cfg
+
+    config_path = _get_config_path()
+    _save_yaml_config_file(config_path, cfg)
+
+    invalidate_models_cache()
+
+    return {
+        "ok": True,
+        "provider": provider_id,
+        "display_name": _PROVIDER_DISPLAY.get(provider_id, provider_id),
+        "base_url": base_url,
+        "action": "updated" if base_url else "removed",
+    }

--- a/api/routes.py
+++ b/api/routes.py
@@ -2854,7 +2854,7 @@ from api.run_journal import (
     read_run_events,
     stale_interrupted_event,
 )
-from api.providers import get_providers, get_provider_quota, get_provider_cost_history, set_provider_key, remove_provider_key
+from api.providers import get_providers, get_provider_quota, get_provider_cost_history, set_provider_key, remove_provider_key, set_provider_base_url
 from api.onboarding import (
     apply_onboarding_setup,
     get_onboarding_status,
@@ -5853,6 +5853,18 @@ def handle_post(handler, parsed) -> bool:
         if not provider_id:
             return bad(handler, "provider is required")
         result = remove_provider_key(provider_id)
+        if not result.get("ok"):
+            return bad(handler, result.get("error", "Unknown error"))
+        return j(handler, result)
+
+    if parsed.path == "/api/providers/base-url":
+        provider_id = (body.get("provider") or "").strip().lower()
+        base_url = body.get("base_url")
+        if not provider_id:
+            return bad(handler, "provider is required")
+        if base_url is not None:
+            base_url = str(base_url).strip() or None
+        result = set_provider_base_url(provider_id, base_url)
         if not result.get("ok"):
             return bad(handler, result.get("error", "Unknown error"))
         return j(handler, result)

--- a/static/panels.js
+++ b/static/panels.js
@@ -6931,7 +6931,39 @@ function _buildProviderCard(p){
 
   let input=null;
   let saveBtn=null;
-  if(p.configurable){
+  if(p.keyless){
+    const field=document.createElement('div');
+    field.className='provider-card-field';
+    const label=document.createElement('label');
+    label.className='provider-card-label';
+    label.textContent='Endpoint URL';
+    field.appendChild(label);
+
+    const row=document.createElement('div');
+    row.className='provider-card-row';
+    input=document.createElement('input');
+    input.type='text';
+    input.className='provider-card-input';
+    input.placeholder='http://localhost:11434/v1';
+    input.value=p.base_url||'';
+    input.autocomplete='off';
+    saveBtn=document.createElement('button');
+    saveBtn.type='button';
+    saveBtn.className='provider-card-btn provider-card-btn-primary';
+    saveBtn.textContent=t('providers_save');
+    saveBtn.onclick=()=>_saveProviderBaseUrl(p.id);
+    saveBtn.disabled=true;
+    row.appendChild(input);
+    row.appendChild(saveBtn);
+    field.appendChild(row);
+
+    const hint=document.createElement('div');
+    hint.className='provider-card-hint';
+    hint.textContent='Self-hosted provider — no API key required. Configure the endpoint URL for your local model server.';
+    field.appendChild(hint);
+
+    body.appendChild(field);
+  }else if(p.configurable){
     const field=document.createElement('div');
     field.className='provider-card-field';
     const label=document.createElement('label');
@@ -7036,7 +7068,10 @@ function _buildProviderCard(p){
   card.appendChild(body);
 
   if(input&&saveBtn){
-    _providerCardEls.set(p.id,{card,input,saveBtn,hasKey:p.has_key});
+    _providerCardEls.set(p.id,{card,input,saveBtn,hasKey:p.has_key,keyless:!!p.keyless});
+    if(p.keyless){
+      saveBtn.disabled=!input.value.trim();
+    }
     input.addEventListener('input',()=>{saveBtn.disabled=!input.value.trim();});
   }
   header.addEventListener('click',e=>{
@@ -7046,6 +7081,35 @@ function _buildProviderCard(p){
     if(card.classList.contains('open')) setTimeout(()=>input.focus(),0);
   });
   return card;
+}
+
+async function _saveProviderBaseUrl(providerId){
+  const els=_providerCardEls.get(providerId);
+  if(!els) return;
+  const url=els.input.value.trim();
+  if(!url){
+    showToast('Please enter an endpoint URL');
+    return;
+  }
+  els.saveBtn.disabled=true;
+  els.saveBtn.textContent=t('providers_saving');
+  try{
+    const res=await api('/api/providers/base-url',{method:'POST',body:JSON.stringify({provider:providerId,base_url:url})});
+    if(res.ok){
+      showToast(res.display_name+' endpoint URL '+res.action);
+      els.input.value=res.base_url||'';
+      _refreshModelDropdownsAfterProviderChange();
+      await loadProvidersPanel();
+    }else{
+      showToast(res.error||'Failed to save endpoint URL');
+      els.saveBtn.disabled=false;
+      els.saveBtn.textContent=t('providers_save');
+    }
+  }catch(e){
+    showToast('Error: '+e.message);
+    els.saveBtn.disabled=false;
+    els.saveBtn.textContent=t('providers_save');
+  }
 }
 
 async function _saveProviderKey(providerId){


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI lets users configure self-hosted providers (Ollama, LM Studio, Custom OpenAI-compatible) in the first-run onboarding wizard via `_SUPPORTED_PROVIDER_SETUPS` with `key_optional: True`
- These keyless providers were deliberately omitted from `_PROVIDER_ENV_VAR` because they do not require API keys
- As a result, the Settings → Providers tab excluded them entirely (filtered by `configurable: pid in _PROVIDER_ENV_VAR`)
- Users who switched providers post-onboarding had no UI to manage their endpoint URLs
- This PR marks key_optional providers as configurable + keyless, adding an endpoint URL field and save endpoint

## What Changed

### Backend (`api/providers.py`)
- `get_providers()`: providers in `_SUPPORTED_PROVIDER_SETUPS` with `key_optional: True` are now marked `configurable: True` and `keyless: True`, with `base_url` populated from config.yaml or the onboarding default
- `get_providers()`: keyless provider IDs added to `known_ids` so they appear in the response
- New `set_provider_base_url()` function: writes `model.base_url` to config.yaml, matching the onboarding wizard write path

### Routes (`api/routes.py`)
- New `POST /api/providers/base-url` endpoint: accepts `provider` and `base_url`, validates URL scheme, delegates to `set_provider_base_url()`

### Frontend (`static/panels.js`)
- `_buildProviderCard()`: keyless providers (checked via `p.keyless`) now render an endpoint URL text input instead of the API key password field, with a self-hosted hint
- New `_saveProviderBaseUrl()` function: POSTs to `/api/providers/base-url`, refreshes the panel on success
- Save button enabled by default when a base URL is already present

### Docs
- `CHANGELOG.md`: Added entry under [Unreleased]

## Why It Matters

Users can now manage self-hosted provider endpoints directly from Settings → Providers, without needing to re-run the onboarding wizard or edit config.yaml by hand. The endpoint URL field replaces the API key field for these providers, making the UI honest about what needs to be configured.

## Verification

- Python syntax: `python3 -m py_compile api/providers.py` and `api/routes.py` pass
- JavaScript syntax: `node --check static/panels.js` passes
- Manual review: the `keyless` field is added to the provider response; frontend renders accordingly
- Backward compatible: existing configurable providers are unchanged

## Risks / Follow-ups

- The endpoint URL is written to `model.base_url` (global), not per-provider. If a user actively uses multiple self-hosted providers, switching one will overwrite the other. A future change could move this to `providers.<id>.base_url` if needed.
- The "Custom OpenAI-compatible" provider appears with display name "Custom" — this could be improved with a dedicated display name entry.

## Model Used

OpenAI / GPT-5.1-codex-max — with tool use for codebase exploration, search, and editing.