### PR TITLE
fix(reasoning): add GLM and Claude family-before-version names to heuristic family list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Reasoning-effort detection now recognises GLM models (`zai.glm-5`, `zai.glm-4.7`, `glm-5`, etc.) and Claude family-before-version names (`claude-opus-4-8`, `claude-haiku-4-5`, `anthropic.claude-opus-4-8`) as thinking-capable when accessed through named custom providers. Both were missed by PR #3327's family list even though the dot-namespace stripping it introduced correctly surfaces the bare model name.
+
 ## [v0.51.210] — 2026-06-02 — Release GD (stage-batch1 — model-picker multi-slash fix + extensionless preview highlighting)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -2140,11 +2140,17 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
         return True
     if normalized.startswith(("kimi-k2", "kimi-thinking", "claude-3", "claude-4")):
         return True
+    # claude-opus-4-8 / claude-haiku-4-5 style (family-before-version)
+    if normalized.startswith("claude-") and token_set & {"3", "4"}:
+        return True
     if normalized.startswith("qwen3") or "qwen3" in token_set:
         return True
     if normalized.startswith(("deepseek-v3", "deepseek-v4", "deepseek-r1", "deepseek-r2")):
         return True
     if len(tokens) >= 2 and tokens[0] == "deepseek" and tokens[1] in {"v3", "v4", "r1", "r2"}:
+        return True
+    # GLM models (ZAI / Zhipu AI) — all modern generations (4.5+) support reasoning
+    if normalized.startswith("glm-"):
         return True
     return False
 

--- a/tests/test_custom_provider_bare_model_reasoning.py
+++ b/tests/test_custom_provider_bare_model_reasoning.py
@@ -127,6 +127,51 @@ def test_vendor_prefix_keyword_does_not_trigger_reasoning(model_id):
     ) == []
 
 
+# ── GLM models (ZAI / Zhipu AI) ──────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "zai.glm-5",
+        "zai.glm-4.7",
+        "zai.glm-4.6",
+        "zai.glm-4.7-flash",
+        "glm-5",
+        "glm-4.5",
+    ],
+)
+def test_glm_dot_separated_custom_provider(model_id):
+    efforts = cfg.resolve_model_reasoning_efforts(
+        model_id,
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}, (
+        f"{model_id} via custom provider should expose reasoning efforts"
+    )
+
+
+# ── Claude family-before-version naming (claude-opus-4-8, claude-haiku-4-5) ──
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "anthropic.claude-opus-4-8",
+        "anthropic.claude-haiku-4-5",
+        "anthropic.claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-haiku-4-5",
+    ],
+)
+def test_claude_family_version_naming_custom_provider(model_id):
+    efforts = cfg.resolve_model_reasoning_efforts(
+        model_id,
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}, (
+        f"{model_id} via custom provider should expose reasoning efforts"
+    )
+
+
 # ── slash-prefixed names must still work (no regression) ─────────────────────
 
 def test_deepseek_slash_prefix_still_works():


### PR DESCRIPTION
## What

PR #3327 added dot-separator normalization so custom-provider model IDs like `deepseek.v3.2` correctly surface the reasoning-effort selector. However, two model families were left out of `_candidate_supports_reasoning` and remain broken after that fix.

**GLM (ZAI / Zhipu AI)** — `zai.glm-5`, `zai.glm-4.7`, `glm-5`, etc.
All modern GLM generations (4.5+) have `reasoning: true` in models.dev, but `glm` was never added to the heuristic family list. The dot-stripping from #3327 correctly surfaces `glm-5` as a candidate — it just has nowhere to match.

**Claude family-before-version naming** — `claude-opus-4-8`, `claude-haiku-4-5`, `anthropic.claude-opus-4-8`
The existing check is `startswith("claude-3", "claude-4")`, which matches the old `claude-3-5-sonnet-...` format. The newer naming convention puts the family before the version (`claude-opus-4-8`), so it starts with `claude-opus`, not `claude-4`, and silently misses.

## Changes

- `api/config.py` — two additions to `_candidate_supports_reasoning`:
  - `glm-` prefix for the GLM family
  - `claude-` + `{3, 4}` token intersection for the new Claude naming convention
- `tests/test_custom_provider_bare_model_reasoning.py` — 11 new parametrized cases (28 total, all pass)
- `CHANGELOG.md` — user-visible entry

## Verification

```
28 passed in 3.74s
```

Models now correctly detected (were all `[]` before):
| Model ID | Before | After |
|---|---|---|
| `zai.glm-5` | `[]` | full efforts |
| `zai.glm-4.7` | `[]` | full efforts |
| `anthropic.claude-opus-4-8` | `[]` | full efforts |
| `anthropic.claude-haiku-4-5` | `[]` | full efforts |
| `deepseek.v3.2` | ✓ (from #3327) | ✓ |

Non-reasoning models unchanged (`meta.llama-3.1-70b`, `thinkinghub.*` → `[]`).

---

## Note on the underlying design

This is a targeted fix but also a band-aid. The heuristic family list (`_candidate_supports_reasoning`) will need a new entry every time a provider uses an unfamiliar naming convention — GLM and Claude are the two that surfaced this week, but there will be more.

A more durable solution would be to allow **per-model capability overrides** in the custom provider config, so users (or aggregator presets) can declare `reasoning: true` without requiring a code change. Happy to prototype that if maintainers think it's worth pursuing — just want to flag the root cause before closing it with another patch.