### PR TITLE
fix: respect profile toolset/skill config on the WebUI streaming worker (#3294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Profile tool/skill restrictions are now respected for WebUI chats even when the per-session "Tool Restrictions" field is left blank. The streaming agent runs on a detached worker thread that does not inherit the per-request thread-local profile context, so the ambient `get_config()` resolved the process-global `default` profile and loaded its `platform_toolsets.cli` (all tools) instead of the session profile's configured list — inflating a tools-disabled profile's prompt from ~400 to ~15K input tokens. The worker now reads the session's own profile config explicitly via a new `get_config_for_profile_home()` helper (a race-free direct disk read, with no shared-cache mutation), so toolsets, prefill context, and fallback chains all match the profile the session actually runs under (closes #3294).
+
 ## [v0.51.212] — 2026-06-02 — Release GF (stage-batch2 — i18n regenerate-title strings + self-restart argv + todos cold-load)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -382,6 +382,43 @@ def _load_yaml_config_file(config_path: Path) -> dict:
         return {}
 
 
+def get_config_for_profile_home(profile_home: "Path | str | None") -> dict:
+    """Return the config dict for an explicit profile home directory.
+
+    The streaming agent runs on a detached worker thread that does NOT inherit
+    the per-request thread-local profile context (set from the ``hermes_profile``
+    cookie on the HTTP handler thread). On that worker, the ambient
+    ``get_config()`` resolves through ``get_active_profile_name()`` which falls
+    back to the process-global ``_active_profile`` (usually ``default``) — so a
+    session running under a non-default profile would silently read the
+    **default** profile's ``config.yaml`` for toolsets, prefill context, and
+    fallback chains (issue #3294).
+
+    This helper reads the config for a *known* profile home directly off disk,
+    bypassing the thread-local resolver entirely. When ``profile_home`` matches
+    the path the ambient resolver would pick (the common single-profile case),
+    we return the cached ``get_config()`` to preserve in-memory overrides used
+    by tests and runtime callers. Only when the session's profile home diverges
+    from the ambient path do we read the session profile's file directly — a
+    pure read with no global cache mutation, so it is race-free across
+    concurrent sessions on different profiles.
+    """
+    if not profile_home:
+        return get_config()
+    try:
+        target = Path(profile_home).expanduser()
+    except Exception:
+        return get_config()
+    # If the ambient resolver already points at this profile home, defer to
+    # get_config() so in-memory overrides (monkeypatched cfg) are honored.
+    try:
+        if _get_config_path().parent == target:
+            return get_config()
+    except Exception:
+        pass
+    return _load_yaml_config_file(target / "config.yaml")
+
+
 def _save_yaml_config_file(config_path: Path, config_data: dict) -> None:
     try:
         import yaml as _yaml

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4768,9 +4768,20 @@ def _run_agent_streaming(
                 resolved_provider, resolved_api_key, resolved_base_url
             )
 
-            # Read per-profile config at call time (not module-level snapshot)
-            from api.config import get_config as _get_config
-            _cfg = _get_config()
+            # Read per-profile config at call time (not module-level snapshot).
+            # The streaming worker is a detached thread that does NOT inherit the
+            # per-request thread-local profile context, so the ambient
+            # get_config() would resolve the process-global (default) profile and
+            # leak the wrong profile's toolsets / prefill / fallback config into
+            # this run (issue #3294). Read the SESSION's own profile home
+            # explicitly so toolsets and context match the profile the session
+            # actually runs under.
+            from api.config import get_config_for_profile_home as _get_config_for_home
+            try:
+                _cfg = _get_config_for_home(_profile_home)
+            except Exception:
+                from api.config import get_config as _get_config
+                _cfg = _get_config()
             _prefill_context = _load_webui_prefill_context(_cfg)
             _prefill_messages = _prefill_messages_with_webui_context(_prefill_context, _cfg)
             put('context_status', {

--- a/tests/test_issue3294_profile_toolset_scoping.py
+++ b/tests/test_issue3294_profile_toolset_scoping.py
@@ -1,0 +1,134 @@
+"""Regression coverage for #3294 — profile tool configuration not respected in WebUI.
+
+When a non-default profile leaves the per-session "Tool Restrictions"
+(`enabled_toolsets`) blank, the streaming worker must resolve toolsets (and the
+rest of the per-profile config: prefill context, fallback chains) from the
+*session's own profile* config.yaml — not from the process-global ``default``
+profile.
+
+Root cause: the streaming agent runs on a detached ``threading.Thread`` that
+does NOT inherit the per-request thread-local profile context (set from the
+``hermes_profile`` cookie on the HTTP handler thread). On that worker the
+ambient ``get_config()`` resolves through ``get_active_profile_name()`` which
+falls back to the process-global ``_active_profile`` (usually ``default``). A
+profile B with an empty ``platform_toolsets.cli`` would therefore load the
+default profile's full toolset list, inflating the prompt from ~400 to ~15K
+tokens (the reporter's symptom).
+
+Fix: ``api.config.get_config_for_profile_home(profile_home)`` reads the config
+for an explicit profile home directly off disk, bypassing the thread-local
+resolver. The streaming worker passes the session's own resolved profile home.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _write_cfg(home: Path, cli_toolsets) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    import yaml
+
+    home.joinpath("config.yaml").write_text(
+        yaml.safe_dump({"platform_toolsets": {"cli": cli_toolsets}}, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def _two_profiles(tmp_path, monkeypatch):
+    """default profile = all tools; profile B = empty toolset list."""
+    from api import config as cfg
+
+    default_home = tmp_path / "default"
+    profile_b_home = tmp_path / "profiles" / "b"
+    _write_cfg(default_home, ["terminal", "file", "web", "search", "browser"])
+    _write_cfg(profile_b_home, [])
+
+    # Point the ambient resolver at the DEFAULT profile, simulating a worker
+    # thread that fell back to the process-global default profile.
+    monkeypatch.setenv("HERMES_CONFIG_PATH", str(default_home / "config.yaml"))
+    cfg.reload_config()
+    yield cfg, default_home, profile_b_home
+
+
+def test_ambient_get_config_reads_default_profile(_two_profiles):
+    """Baseline: the ambient resolver sees the DEFAULT profile (the bug source)."""
+    cfg, default_home, profile_b_home = _two_profiles
+    ambient = cfg.get_config()
+    assert ambient.get("platform_toolsets", {}).get("cli") == [
+        "terminal",
+        "file",
+        "web",
+        "search",
+        "browser",
+    ]
+
+
+def test_get_config_for_profile_home_reads_session_profile(_two_profiles):
+    """The fix: explicitly resolving profile B's home reads B's empty toolsets,
+    even though the ambient resolver still points at the default profile."""
+    cfg, default_home, profile_b_home = _two_profiles
+
+    profile_b_cfg = cfg.get_config_for_profile_home(profile_b_home)
+    assert profile_b_cfg.get("platform_toolsets", {}).get("cli") == []
+
+    # And the toolset resolver run against profile B's config must yield a
+    # strictly smaller set than the default profile's — the token-inflation
+    # the reporter observed comes from resolving against the wrong (default)
+    # profile's full list.
+    default_toolsets = set(cfg._resolve_cli_toolsets(cfg.get_config()))
+    profile_b_toolsets = set(cfg._resolve_cli_toolsets(profile_b_cfg))
+    assert profile_b_toolsets < default_toolsets
+    assert "terminal" in default_toolsets
+    assert "terminal" not in profile_b_toolsets
+    assert "browser" not in profile_b_toolsets
+
+
+def test_matching_home_defers_to_get_config(_two_profiles):
+    """When the requested home matches the ambient path, defer to get_config()
+    so in-memory overrides (monkeypatched cfg / runtime overrides) are honored."""
+    cfg, default_home, profile_b_home = _two_profiles
+    same = cfg.get_config_for_profile_home(default_home)
+    # Same dict identity path as get_config() (cached) — verify it returns the
+    # default profile's config, not a fresh disk read that could miss overrides.
+    assert same.get("platform_toolsets", {}).get("cli") == [
+        "terminal",
+        "file",
+        "web",
+        "search",
+        "browser",
+    ]
+
+
+def test_empty_or_none_home_falls_back_to_get_config(_two_profiles):
+    """A missing/empty profile home (ImportError fallback path in the worker)
+    must not crash — it falls back to the ambient get_config()."""
+    cfg, default_home, profile_b_home = _two_profiles
+    assert cfg.get_config_for_profile_home(None) == cfg.get_config()
+    assert cfg.get_config_for_profile_home("") == cfg.get_config()
+
+
+def test_nonexistent_profile_home_returns_empty_not_default(_two_profiles):
+    """A profile home that diverges from ambient but has no config.yaml yet
+    returns an empty dict (the profile's own absent config) rather than silently
+    inheriting the default profile's tools."""
+    cfg, default_home, profile_b_home = _two_profiles
+    ghost = profile_b_home.parent / "ghost"
+    result = cfg.get_config_for_profile_home(ghost)
+    assert result == {}
+    # Critically: it does NOT return the default profile's full toolset list.
+    assert result.get("platform_toolsets", {}).get("cli") != [
+        "terminal",
+        "file",
+        "web",
+        "search",
+        "browser",
+    ]


### PR DESCRIPTION
# fix: respect profile toolset/skill config on the WebUI streaming worker

Closes #3294

## What was broken

When a user created a second profile with all tools/skills disabled and left the per-session **Tool Restrictions** field blank, a simple `Hi` prompt in the WebUI consumed ~15,000 input tokens — the same prompt in the CLI under that profile used ~400. The profile's tool configuration was silently ignored in the WebUI only.

## Root cause

The streaming agent runs on a detached `threading.Thread` (`_run_agent_streaming`). That worker thread does **not** inherit the per-request thread-local profile context, which is set from the `hermes_profile` cookie on the HTTP handler thread (`set_request_profile`, issue #798).

On the worker, toolsets are resolved from `_cfg = get_config()` (`api/streaming.py`). `get_config()` resolves its path through `get_active_profile_name()`, which is thread-local-first, process-global-second:

```python
tls_name = getattr(_tls, 'profile', None)
if tls_name is not None:
    return tls_name
return _active_profile          # process-global, stays 'default'
```

Because WebUI profile switches are cookie-scoped (`switch_profile(name, process_wide=False)`), the process-global `_active_profile` stays `default`. So on the worker thread `get_config()` loads the **default** profile's `config.yaml` and `_resolve_cli_toolsets(_cfg)` returns the default profile's full `platform_toolsets.cli` (all tools) instead of the session profile's empty list — inflating the prompt.

The worker already sets `os.environ['HERMES_HOME']` to the session profile, but `_get_config_path()` keys off the profile *name* via `get_active_hermes_home()`, not `HERMES_HOME`, so the env mutation doesn't redirect config reads. That asymmetry is the leak.

Setting an explicit Tool Restrictions value worked around it only because that writes the session's `enabled_toolsets`, which takes a per-session override branch that skips the mis-scoped `_resolve_cli_toolsets(_cfg)` call entirely.

## The fix

New `api.config.get_config_for_profile_home(profile_home)` reads the config for an **explicit** profile home directly off disk, bypassing the thread-local resolver:

- When the requested home matches the path the ambient resolver would pick (the common single-profile case), it defers to `get_config()` so in-memory overrides (monkeypatched `cfg`, runtime overrides) are preserved.
- Only when the session's profile home diverges from the ambient path does it read that profile's `config.yaml` directly — a **pure read with no global cache mutation**, so it is race-free across concurrent sessions on different profiles (no `_cfg_cache` clobber, unlike a `set_request_profile` + reload approach).

The streaming worker now resolves `_cfg` from the session's own profile home (`_profile_home`, already reliably resolved from `s.profile` at the top of the run). This fixes **toolsets, prefill context, and fallback chains** in one place — all three read from the same `_cfg`.

## Why this layer (and not `set_request_profile` on the worker)

The maintainer triage comment outlined two options. I took option 1 (direct profile read) over option 2 (set the worker's TLS profile + reload) deliberately: option 2 mutates the process-wide `_cfg_cache` (keyed on path), which can race a concurrent request on a different profile. The direct read touches no shared state.

## Tests

`tests/test_issue3294_profile_toolset_scoping.py` (5 tests):
- baseline — ambient `get_config()` reads the **default** profile (reproduces the bug source)
- the fix — resolving profile B's home reads B's empty toolsets, and `_resolve_cli_toolsets(B)` yields a strictly smaller set than the default profile's (no `terminal`/`browser` leak)
- matching-home path defers to `get_config()` (override preservation)
- empty/`None` home falls back to `get_config()` (the worker's ImportError fallback path won't crash)
- a divergent-but-config-less profile home returns `{}`, **not** the default profile's tool list

Also ran the adjacent profile-scoping / config / streaming suites (299 passed, 0 failed). Ruff forward gate clean.

## Empirical verification (production reader path)

Verified the helper end-to-end against two real on-disk profile homes (default = full toolset, profile B = `[]`): `get_config_for_profile_home(B)` returns B's empty list while ambient `get_config()` still returns the default's full list, and `_resolve_cli_toolsets` resolves `['kanban']` (the MCP floor) for B vs the full set for default.

Co-authored with @gottipx (precise repro + root-cause breakdown).
