### PR TITLE
fix: prune orphaned imported-CLI sidecars from the WebUI sidebar (#3238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- WebUI sidebar now reconciles orphaned imported-CLI sessions. When a CLI/agent session is opened in the WebUI it gets a WebUI-owned sidecar so it can render and reopen; previously, if the user then deleted that session from the CLI / local Hermes storage, nothing pruned the sidecar and the stale row lingered in the sidebar indefinitely (there is no WebUI delete affordance for CLI rows). The sidebar list now drops a CLI-imported row whose backing agent `state.db` row is genuinely gone and self-heals `_index.json`. The check probes `state.db` directly via a new `agent_session_row_exists()` (exact, uncapped) rather than the recent-session window from `get_cli_sessions()` (capped at 20), so a still-existing session that merely fell out of the window is never pruned; WebUI-native sessions that only have a CLI ancestor are also never pruned; and any probe error degrades to "keep the row" so a transient failure can't cause data loss (closes #3238).
+
 ## [v0.51.212] — 2026-06-02 — Release GF (stage-batch2 — i18n regenerate-title strings + self-restart argv + todos cold-load)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -2714,6 +2714,49 @@ def _active_state_db_path() -> Path:
     return hermes_home / 'state.db'
 
 
+def agent_session_row_exists(session_id: str, *, profile=None) -> bool:
+    """Return True if ``session_id`` still has a backing row in the agent state.db.
+
+    Used to detect orphaned imported-CLI sidecars (#3238): the WebUI sidebar
+    must NOT rely on the session's presence in ``get_cli_sessions()`` to decide
+    whether its backing CLI row still exists, because that helper caps at
+    ``CLI_VISIBLE_SESSION_LIMIT`` (20) rows — a still-existing session can fall
+    out of the recent window and look "deleted." This is an exact, uncapped
+    existence probe against the ``sessions`` table.
+
+    Degrades safely to ``True`` (assume present) on any error or when the DB is
+    unreadable, so a transient failure never causes a stale-pruning data loss.
+    """
+    sid = str(session_id or "").strip()
+    if not sid:
+        return False
+    try:
+        import sqlite3
+    except ImportError:
+        return True
+    if isinstance(profile, str) and profile:
+        db_path = _get_profile_home(profile) / 'state.db'
+        if not db_path.exists():
+            db_path = _active_state_db_path()
+    else:
+        db_path = _active_state_db_path()
+    if not db_path.exists():
+        # No agent DB at all on this instance — can't claim the row is gone.
+        return True
+    try:
+        with closing(sqlite3.connect(str(db_path))) as conn:
+            cur = conn.cursor()
+            cur.execute("PRAGMA table_info(sessions)")
+            cols = {str(row[1]) for row in cur.fetchall()}
+            if 'id' not in cols:
+                return True
+            cur.execute("SELECT 1 FROM sessions WHERE id = ? LIMIT 1", (sid,))
+            return cur.fetchone() is not None
+    except Exception:
+        logger.debug("agent_session_row_exists probe failed for %s", sid, exc_info=True)
+        return True
+
+
 def _sidebar_title_is_generic_webui(title: str | None) -> bool:
     text = ' '.join(str(title or '').split())
     if text == 'Hermes WebUI':

--- a/api/routes.py
+++ b/api/routes.py
@@ -2820,6 +2820,7 @@ from api.models import (
     _is_empty_partial_activity_message,
     _hide_from_default_sidebar,
     prune_session_from_index,
+    agent_session_row_exists,
     ensure_cron_project,
     is_cron_session,
     is_safe_session_id,
@@ -4868,6 +4869,37 @@ def handle_get(handler, parsed) -> bool:
                 cli = get_cli_sessions()
                 diag.stage("merge_cli_sessions")
                 cli_by_id = {s["session_id"]: s for s in cli}
+                # #3238: reconcile orphaned imported-CLI sidecars. When a CLI
+                # session was clicked in WebUI it gets a WebUI-owned sidecar that
+                # all_sessions() returns independently of state.db. If the user
+                # later deletes the backing CLI session from the command line,
+                # the sidecar is never pruned and the stale row lingers in the
+                # sidebar forever (there is no WebUI delete affordance for it).
+                # Drop rows whose backing agent row is genuinely gone. We probe
+                # state.db directly (agent_session_row_exists) rather than trust
+                # cli_by_id absence, because get_cli_sessions() caps at
+                # CLI_VISIBLE_SESSION_LIMIT (20) — an existing session can fall
+                # out of that window and look deleted. Native WebUI sessions
+                # (source == "webui") that merely have a CLI ancestor are never
+                # pruned.
+                _kept_after_orphan_prune = []
+                for s in webui_sessions:
+                    _sid = s.get("session_id")
+                    if (
+                        _sid
+                        and is_cli_session_row(s)
+                        and not _session_source_is_webui(s)
+                        and _sid not in cli_by_id
+                        and not agent_session_row_exists(_sid, profile=s.get("profile"))
+                    ):
+                        try:
+                            prune_session_from_index(_sid)
+                        except Exception:
+                            logger.debug("Failed to prune orphaned CLI sidecar %s", _sid, exc_info=True)
+                        diag.stage("prune_orphaned_cli_sidecar")
+                        continue
+                    _kept_after_orphan_prune.append(s)
+                webui_sessions = _kept_after_orphan_prune
                 for s in webui_sessions:
                     meta = cli_by_id.get(s.get("session_id"))
                     if not meta:

--- a/tests/test_issue3238_orphaned_cli_sidecar_prune.py
+++ b/tests/test_issue3238_orphaned_cli_sidecar_prune.py
@@ -1,0 +1,156 @@
+"""Regression coverage for #3238 — WebUI does not sync when CLI sessions are
+deleted outside WebUI.
+
+When a CLI/agent session is clicked in the WebUI sidebar it gets a WebUI-owned
+sidecar (`webui/sessions/<id>.json` + an `_index.json` row) so it can render and
+be reopened. From then on `all_sessions()` returns it independently of the agent
+`state.db`. If the user later deletes that session from the CLI / local Hermes
+storage, nothing prunes the orphaned sidecar, so the stale row lingers in the
+sidebar forever — there is no WebUI delete affordance for CLI rows.
+
+The fix probes `state.db` directly via `agent_session_row_exists()` (an exact,
+uncapped existence check) and prunes the sidecar only when the backing row is
+genuinely gone. It must NOT rely on the session's presence in
+`get_cli_sessions()`, which caps at `CLI_VISIBLE_SESSION_LIMIT` (20) — an
+existing session can fall out of that window and look deleted.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _make_state_db(path: Path, session_ids):
+    """Create a minimal agent state.db with a `sessions` table + given ids."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, "
+            "started_at REAL, last_activity REAL)"
+        )
+        for sid in session_ids:
+            conn.execute(
+                "INSERT INTO sessions (id, source, started_at, last_activity) "
+                "VALUES (?, 'cli', 0, 0)",
+                (sid,),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_agent_session_row_exists_true_for_present_row(tmp_path, monkeypatch):
+    from api import models
+
+    home = tmp_path / "home"
+    home.mkdir()
+    _make_state_db(home / "state.db", ["sess-present"])
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: home / "state.db")
+
+    assert models.agent_session_row_exists("sess-present") is True
+
+
+def test_agent_session_row_exists_false_for_deleted_row(tmp_path, monkeypatch):
+    """The core fix: a session id that is NOT in state.db is reported gone."""
+    from api import models
+
+    home = tmp_path / "home"
+    home.mkdir()
+    _make_state_db(home / "state.db", ["other-session"])
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: home / "state.db")
+
+    assert models.agent_session_row_exists("sess-deleted") is False
+
+
+def test_agent_session_row_exists_safe_true_when_db_missing(tmp_path, monkeypatch):
+    """No agent DB on this instance -> never claim a row is gone (no data loss)."""
+    from api import models
+
+    monkeypatch.setattr(
+        models, "_active_state_db_path", lambda: tmp_path / "nope" / "state.db"
+    )
+    assert models.agent_session_row_exists("anything") is True
+
+
+def test_agent_session_row_exists_empty_id_is_false(tmp_path, monkeypatch):
+    from api import models
+
+    home = tmp_path / "home"
+    home.mkdir()
+    _make_state_db(home / "state.db", ["x"])
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: home / "state.db")
+    assert models.agent_session_row_exists("") is False
+    assert models.agent_session_row_exists(None) is False
+
+
+def test_agent_session_row_exists_handles_missing_sessions_table(tmp_path, monkeypatch):
+    """A state.db without a `sessions` table degrades to safe-True."""
+    from api import models
+
+    home = tmp_path / "home"
+    home.mkdir()
+    db = home / "state.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE unrelated (x TEXT)")
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db)
+    assert models.agent_session_row_exists("whatever") is True
+
+
+# ── Orphan-prune decision predicate (mirrors the sidebar merge-loop guard) ──
+
+
+def _is_orphaned_cli_sidecar(row, cli_by_id, exists_fn):
+    """Replicates the routes.py merge-loop predicate so the decision logic is
+    covered without standing up the full HTTP sidebar endpoint."""
+    from api.agent_sessions import is_cli_session_row
+    from api.routes import _session_source_is_webui
+
+    sid = row.get("session_id")
+    return bool(
+        sid
+        and is_cli_session_row(row)
+        and not _session_source_is_webui(row)
+        and sid not in cli_by_id
+        and not exists_fn(sid)
+    )
+
+
+def test_orphaned_imported_cli_sidecar_is_pruned():
+    """import-sourced CLI row, not in cli_by_id, backing state.db row gone."""
+    row = {"session_id": "cli-orphan", "source_tag": "cli", "is_cli_session": True}
+    assert _is_orphaned_cli_sidecar(row, {}, exists_fn=lambda sid: False) is True
+
+
+def test_native_webui_session_with_cli_ancestor_is_never_pruned():
+    """Regression guard: a WebUI-native row must survive even if absent from
+    cli_by_id and its (ancestor) id isn't in state.db."""
+    row = {
+        "session_id": "webui-native",
+        "source_tag": "webui",
+        "session_source": "webui",
+        "is_cli_session": False,
+    }
+    assert _is_orphaned_cli_sidecar(row, {}, exists_fn=lambda sid: False) is False
+
+
+def test_cli_row_still_backed_in_state_db_is_not_pruned():
+    """Falls out of the recent-20 window (absent from cli_by_id) BUT still exists
+    in state.db -> must NOT be pruned. This is the cap-window false-positive the
+    direct state.db probe defends against."""
+    row = {"session_id": "cli-old", "source_tag": "cli", "is_cli_session": True}
+    assert _is_orphaned_cli_sidecar(row, {}, exists_fn=lambda sid: True) is False
+
+
+def test_cli_row_present_in_cli_by_id_is_not_pruned():
+    """Still in the live CLI list -> obviously not orphaned."""
+    row = {"session_id": "cli-live", "source_tag": "cli", "is_cli_session": True}
+    cli_by_id = {"cli-live": {"session_id": "cli-live"}}
+    assert _is_orphaned_cli_sidecar(row, cli_by_id, exists_fn=lambda sid: False) is False


### PR DESCRIPTION
# fix: prune orphaned imported-CLI sidecars from the WebUI sidebar

Closes #3238

## What was broken

On Windows (and any platform), with `show_cli_sessions: true`, the WebUI sidebar kept showing CLI/imported sessions after the user deleted them from the command line / local Hermes storage. There's no obvious WebUI delete action for CLI rows, so deleting from the CLI seems like the natural workaround — but the sidebar never synced, and the stale rows lingered indefinitely.

## Root cause

When a CLI session is clicked in WebUI, `_handle_session_import_cli` → `import_cli_session` writes a **WebUI-owned sidecar** (`webui/sessions/<id>.json` + an `_index.json` row). From then on `all_sessions()` returns it independently of the agent `state.db`.

The sidebar merge loop only overlays CLI metadata when a matching `state.db` row still exists (`cli_by_id.get(...)`); once the backing CLI row is deleted, the lookup returns `None` and the loop `continue`s — **nothing prunes the orphaned sidecar**. `is_cli_session_row_visible` keeps any row with `message_count > 0`, so the stale row persists forever. `prune_session_from_index` is only wired to `/api/session/delete`, which the sidebar never exposes for CLI rows.

## The fix (half 1 of the issue's two-half plan: reconcile-on-list)

In the `show_cli_sessions` merge block, drop a row that is **all** of:
- `is_cli_session_row(s)` — a CLI-imported row,
- **not** `_session_source_is_webui(s)` — not a WebUI-native session (the regression guard; a native session with a CLI ancestor is never pruned),
- absent from `cli_by_id`,
- and whose backing `state.db` row is **genuinely gone**.

When pruned, it also calls `prune_session_from_index(sid)` so `_index.json` self-heals.

### The critical correctness detail

I do **not** prune on `cli_by_id` absence alone. `get_cli_sessions()` caps at `CLI_VISIBLE_SESSION_LIMIT` (20) — a still-existing session can simply fall out of the recent-20 window and look "deleted." Pruning on that would delete live sessions and lose data.

Instead I added `api.models.agent_session_row_exists(session_id, *, profile=None)` — an exact, uncapped existence probe against the `state.db` `sessions` table. It degrades to **`True` (assume present)** on any error, missing DB, or missing `sessions` table, so a transient failure can never cause stale-pruning data loss.

## Tests

`tests/test_issue3238_orphaned_cli_sidecar_prune.py` (9 tests):

`agent_session_row_exists`:
- True for a present row, False for a deleted row
- safe-True when the DB is missing entirely (no false "gone")
- empty/`None` id → False
- safe-True when the `sessions` table is absent

Orphan-prune decision predicate (mirrors the merge-loop guard):
- import-sourced CLI row + gone from state.db → **pruned**
- WebUI-native row with a CLI ancestor → **never pruned** (regression guard)
- CLI row that fell out of the recent-20 window but still exists in state.db → **not pruned** (the cap-window false-positive defense)
- CLI row still present in `cli_by_id` → not pruned

Also ran the adjacent CLI-session / sidebar / import suites: 239 passed, 0 failed. Ruff forward gate clean.

## Note on the issue's half 2

The issue proposed a second half — a removal affordance routing CLI rows through `/api/session/delete`. This PR is the lower-risk reconcile-on-list half, which auto-heals without requiring any new UI. The delete-affordance half can follow separately if desired.

Co-authored with @Luxciax (thorough report; the storage-location breakdown made the root cause easy to trace).
