### PR TITLE
fix: reject cross-script drifted auto-generated session titles (#3293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Auto-generated session titles no longer persist in the wrong language. The title-language guard previously only rejected English titles for *German* conversation starts, so an English chat whose LLM-generated title came back in Chinese, Russian, or another script sailed through and was saved. `_title_language_mismatch` now also does a language-agnostic cross-script check: when the conversation start has a clear dominant writing script and the generated title introduces a substantial amount of a different script (CJK / Cyrillic / Arabic / etc.), the title is rejected and generation falls back to the deterministic topic title. The threshold tolerates a borrowed technical term (a CJK title with one English word still trips; an English title with a single foreign place-name does not), and the legacy German→English heuristic is preserved (closes #3293).
+
 ## [v0.51.212] — 2026-06-02 — Release GF (stage-batch2 — i18n regenerate-title strings + self-restart argv + todos cold-load)
 
 ### Fixed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1570,24 +1570,109 @@ def _detect_title_language(text: str) -> str:
     return ''
 
 
+def _script_counts(text: str) -> dict:
+    """Return per-script alphabetic character counts for *text*.
+
+    Buckets: ``latin``, ``cjk`` (Han/Hiragana/Katakana/Hangul), ``cyrillic``,
+    ``arabic``, ``hebrew``, ``greek``, ``devanagari``. Non-alphabetic and
+    unclassified characters are ignored.
+    """
+    counts: dict[str, int] = {}
+    for ch in str(text or ''):
+        if not ch.isalpha():
+            continue
+        o = ord(ch)
+        if (0x0041 <= o <= 0x024F) or (0x1E00 <= o <= 0x1EFF):
+            bucket = 'latin'
+        elif (
+            (0x4E00 <= o <= 0x9FFF) or (0x3400 <= o <= 0x4DBF)   # Han
+            or (0x3040 <= o <= 0x30FF)                            # Hiragana/Katakana
+            or (0xAC00 <= o <= 0xD7A3) or (0x1100 <= o <= 0x11FF) # Hangul
+        ):
+            bucket = 'cjk'
+        elif 0x0400 <= o <= 0x04FF:
+            bucket = 'cyrillic'
+        elif (0x0600 <= o <= 0x06FF) or (0x0750 <= o <= 0x077F):
+            bucket = 'arabic'
+        elif 0x0590 <= o <= 0x05FF:
+            bucket = 'hebrew'
+        elif 0x0370 <= o <= 0x03FF:
+            bucket = 'greek'
+        elif 0x0900 <= o <= 0x097F:
+            bucket = 'devanagari'
+        else:
+            continue
+        counts[bucket] = counts.get(bucket, 0) + 1
+    return counts
+
+
+def _dominant_script(text: str) -> str:
+    """Return a coarse writing-script bucket for *text*, or '' when undecidable.
+
+    Script-level (not language-level) classification is cheap and dependency-free.
+    Returns the dominant script only when it holds a clear (≥60%) majority of the
+    alphabetic characters, so mixed/borrowed text doesn't flip the bucket. Used
+    to establish the conversation start's expected script for cross-script title
+    drift detection (#3293).
+    """
+    counts = _script_counts(text)
+    total = sum(counts.values())
+    if total < 2:
+        return ''
+    top, top_n = max(counts.items(), key=lambda kv: kv[1])
+    if top_n / total >= 0.6:
+        return top
+    return ''
+
+
 def _title_prompt_language_rule(user_text: str) -> str:
     return "Match the language of the user question.\n"
 
 
 def _title_language_mismatch(user_text: str, title: str) -> bool:
-    """Reject obvious English titles for German conversation starts."""
-    if _detect_title_language(user_text) != 'de':
-        return False
-    candidate = str(title or '').strip().lower()
+    """Reject titles whose language clearly diverges from the conversation start.
+
+    Two independent signals:
+    1. Cross-script drift (#3293): when the conversation start has a clear
+       dominant writing script (e.g. latin/English) and the generated title
+       introduces a *substantial* amount of a different script (e.g. CJK or
+       Cyrillic), reject. This is language-agnostic and catches the common
+       "English chat -> Chinese/Spanish/Russian title" drift. Because titles are
+       short and frequently embed a borrowed Latin technical term (e.g. a CJK
+       title containing the word "Python"), the title side uses a proportion
+       threshold (>=35% of the title's alphabetic characters in a non-start
+       script, min 2 chars) rather than a strict majority -- so a CJK title with
+       one English word still trips, while an English title with a single
+       foreign place-name does not.
+    2. The legacy German-start → English-title heuristic, preserved verbatim so
+       the original behavior keeps working for same-script (latin) drift that
+       the script check can't see.
+    """
+    candidate = str(title or '').strip()
     if not candidate:
         return False
-    if _detect_title_language(candidate) == 'de':
+
+    # (1) Cross-script mismatch — language-agnostic.
+    user_script = _dominant_script(user_text)
+    if user_script:
+        title_counts = _script_counts(candidate)
+        title_total = sum(title_counts.values())
+        if title_total >= 2:
+            for script, n in title_counts.items():
+                if script != user_script and n >= 2 and (n / title_total) >= 0.35:
+                    return True
+
+    # (2) Legacy same-script German→English heuristic.
+    if _detect_title_language(user_text) != 'de':
+        return False
+    candidate_lower = candidate.lower()
+    if _detect_title_language(candidate_lower) == 'de':
         return False
     english_markers = {
         'old', 'image', 'display', 'issue', 'problem', 'discussion', 'conversation',
         'session', 'title', 'fix', 'bug', 'attachment', 'attachments', 'context',
     }
-    tokens = re.findall(r'[a-z]+', candidate)
+    tokens = re.findall(r'[a-z]+', candidate_lower)
     english_hits = sum(1 for tok in tokens if tok in english_markers)
     return english_hits >= 2
 

--- a/tests/test_issue3293_title_language_drift.py
+++ b/tests/test_issue3293_title_language_drift.py
@@ -1,0 +1,141 @@
+"""Regression coverage for #3293 — auto-generated WebUI titles drift into the
+wrong language.
+
+`_title_language_mismatch` previously only rejected English titles for *German*
+conversation starts (`_detect_title_language` returns 'de' or ''). An English
+start whose LLM-generated title came back in Chinese / Spanish / Russian sailed
+through and persisted with a mismatched language.
+
+The fix generalizes from a German-specific binary to a language-agnostic
+cross-script check: when the conversation start has a clear dominant writing
+script and the title introduces a substantial amount of a different script, the
+title is rejected (and generation falls back to the deterministic topic title).
+The legacy German→English same-script heuristic is preserved.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+# ── _dominant_script ────────────────────────────────────────────────────────
+
+def test_dominant_script_basic_buckets():
+    from api.streaming import _dominant_script
+
+    assert _dominant_script("How do I fix this bug") == "latin"
+    assert _dominant_script("如何修复这个错误问题") == "cjk"
+    assert _dominant_script("Привет как дела сегодня") == "cyrillic"
+    assert _dominant_script("日本語のテキストです") == "cjk"  # JP folds into cjk
+
+
+def test_dominant_script_undecidable_returns_empty():
+    from api.streaming import _dominant_script
+
+    # No meaningful alphabetic signal.
+    assert _dominant_script("") == ""
+    assert _dominant_script("12345 !@#") == ""
+    assert _dominant_script("a") == ""  # below the 2-char floor
+    # Evenly mixed text has no clear majority (2 latin / 2 cjk = 0.5 < 0.6).
+    assert _dominant_script("ab字漢") == ""
+
+
+# ── _title_language_mismatch: the #3293 cross-script drift ──────────────────
+
+def test_english_start_chinese_title_is_rejected():
+    """The reporter's exact class: English conversation, Chinese title (even
+    with a borrowed Latin technical term embedded)."""
+    from api.streaming import _title_language_mismatch
+
+    assert _title_language_mismatch(
+        "How do I fix this Python bug in my code?", "修复 Python 代码错误"
+    ) is True
+
+
+def test_english_start_cyrillic_title_is_rejected():
+    from api.streaming import _title_language_mismatch
+
+    assert _title_language_mismatch(
+        "What time does the meeting start tomorrow?", "Встреча Завтра Утром"
+    ) is True
+
+
+def test_cjk_start_english_title_is_rejected():
+    from api.streaming import _title_language_mismatch
+
+    assert _title_language_mismatch("如何修复这个错误问题", "Fixing the Bug") is True
+
+
+# ── regression guards: legitimate same-script titles must NOT be rejected ───
+
+def test_english_start_english_title_allowed():
+    from api.streaming import _title_language_mismatch
+
+    assert _title_language_mismatch(
+        "Why are old images not displayed here?", "Old Image Display Issue"
+    ) is False
+
+
+def test_english_start_spanish_title_allowed():
+    """Same (latin) script — language differs but the script check must not flag
+    it; only a clearly different script is a mismatch signal."""
+    from api.streaming import _title_language_mismatch
+
+    assert _title_language_mismatch(
+        "How do I fix this Python bug in my code?", "Arreglar error de Python"
+    ) is False
+
+
+def test_english_title_with_one_foreign_placename_allowed():
+    """An otherwise-English title containing a single CJK place name stays below
+    the proportion threshold and is not flagged."""
+    from api.streaming import _title_language_mismatch
+
+    assert _title_language_mismatch(
+        "What is the best dataset for model training?", "Using 北京 Dataset Notes"
+    ) is False
+
+
+def test_same_cjk_script_title_allowed():
+    from api.streaming import _title_language_mismatch
+
+    assert _title_language_mismatch("如何修复这个错误问题", "代码错误修复") is False
+    assert _title_language_mismatch("日本語で質問があります", "日本語のチャット") is False
+
+
+def test_empty_title_is_not_a_mismatch():
+    from api.streaming import _title_language_mismatch
+
+    assert _title_language_mismatch("Hello there my friend", "") is False
+    assert _title_language_mismatch("Hello there", "   ") is False
+
+
+def test_tiny_start_without_script_signal_allows_title():
+    """A start too short to establish a dominant script must not gate the title."""
+    from api.streaming import _title_language_mismatch
+
+    assert _title_language_mismatch("hi", "Quick Chat") is False
+
+
+# ── legacy German→English heuristic preserved ───────────────────────────────
+
+def test_legacy_german_start_english_title_still_rejected():
+    from api.streaming import _title_language_mismatch
+
+    assert _title_language_mismatch(
+        "Warum werden alte Bilder hier nicht mehr angezeigt?",
+        "Old Image Display Issue",
+    ) is True
+
+
+def test_legacy_german_start_german_title_allowed():
+    from api.streaming import _title_language_mismatch
+
+    assert _title_language_mismatch(
+        "Warum werden alte Bilder angezeigt?", "Alte Bilder Anzeige"
+    ) is False


### PR DESCRIPTION
# fix: reject cross-script drifted auto-generated session titles

Closes #3293

## What was broken

Auto-generated WebUI session titles could switch into the wrong language — an English conversation start would get a title generated in Chinese or Spanish, and it persisted with `llm_title_generated: true`.

## Root cause

`_detect_title_language` only knew two states: German (`de`) or empty. `_title_language_mismatch` early-returned `False` whenever the start wasn't German:

```python
def _title_language_mismatch(user_text, title):
    if _detect_title_language(user_text) != 'de':
        return False
    ...
```

So the rejection only ever fired for German conversation starts producing English titles. An English start titled in Chinese/Spanish/Russian sailed straight through — the German case was the only one covered because that's the one prior report it was built for.

## The fix

Generalize from a German-specific binary to a language-agnostic **cross-script** check:

- New `_script_counts()` + `_dominant_script()` — cheap, dependency-free Unicode-block classification into coarse buckets (`latin`, `cjk` [Han/Kana/Hangul], `cyrillic`, `arabic`, `hebrew`, `greek`, `devanagari`).
- `_title_language_mismatch` now rejects a title that introduces a substantial amount of a script different from the conversation start's dominant script.

The start side requires a clear dominant script (≥60% majority) so a too-short or mixed start doesn't gate anything. The title side uses a **proportion threshold** (≥35% of the title's alphabetic chars in a non-start script, min 2 chars) rather than a strict majority — because titles are short and frequently embed a borrowed Latin technical term. That tolerance is deliberate:

- a CJK title containing the word "Python" → **still flagged** (CJK dominates)
- an English title containing one foreign place-name → **not flagged** (stays below threshold)

The legacy German→English same-script heuristic is preserved verbatim (the script check can't see same-script drift).

When a mismatch is detected the existing behavior takes over: generation returns `llm_language_mismatch` and falls back to the deterministic topic-extraction title. Both call sites already gate on the boolean, so no call-site changes.

## Tests

`tests/test_issue3293_title_language_drift.py` (13 tests):
- `_dominant_script` buckets + undecidable/empty cases
- English→Chinese, English→Cyrillic, CJK→English all rejected (the bug class)
- regression guards: English→English, English→Spanish (same latin script), English title with one CJK place-name, same-CJK title, empty/whitespace title, tiny start without a script signal — all **allowed**
- legacy German→English still rejected; German→German still allowed

Kept `api/streaming.py` ASCII-only to satisfy the existing `test_title_generation_source_has_no_cjk_literals` guard (all CJK examples live in the test file). Ran the full title/sanitization suite: 293 passed, 0 failed. Ruff forward gate clean.

Co-authored with @andrewkangkr (clear repro on real saved sessions).
