### PR TITLE
Release GG — v0.51.213 (keep gateway context visible in chat transcripts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.213] — 2026-06-02 — Release GG (stage-p2b — keep gateway context visible in chat transcripts)
+
+### Fixed
+- Gateway-backed chat now backfills model-context turns into the visible transcript before saving the latest reply, while keeping hidden `[context compaction]` markers out of the visible transcript. Previously a context-compacted gateway session could collapse the sidebar/header message count to a two-message conversation (and drop older visible turns) while the assistant was responding to hidden prior context. Older visible turns are preserved and compaction markers stay hidden from `saved.messages` (#3300, @AJV20).
+
 ## [v0.51.212] — 2026-06-02 — Release GF (stage-batch2 — i18n regenerate-title strings + self-restart argv + todos cold-load)
 
 ### Fixed

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -24,7 +24,7 @@ from api.config import (
     update_active_run,
 )
 from api.helpers import _redact_text, redact_session_data
-from api.models import get_session
+from api.models import get_session, merge_session_messages_append_only
 from api.run_journal import RunJournalWriter
 
 logger = logging.getLogger(__name__)
@@ -384,16 +384,41 @@ def _run_gateway_chat_streaming(
             assistant_msg = {"role": "assistant", "content": assistant_text, "timestamp": assistant_ts}
             previous_context = list(getattr(s, "context_messages", None) or getattr(s, "messages", None) or [])
             s.context_messages = previous_context + [user_msg, assistant_msg]
-            display = list(getattr(s, "messages", None) or [])
-            # Avoid duplicating the eager-save checkpointed user message.
-            if display:
-                latest = display[-1]
-                if isinstance(latest, dict) and latest.get("role") == "user":
-                    latest_text = " ".join(str(latest.get("content") or "").split())
-                    msg_norm = " ".join(str(msg_text or "").split())
-                    if latest_text == msg_norm:
-                        display = display[:-1]
-            s.messages = display + [user_msg, assistant_msg]
+            try:
+                from api.streaming import _is_context_compression_marker
+
+                display_context = [
+                    msg
+                    for msg in previous_context
+                    if not _is_context_compression_marker(msg)
+                ]
+            except Exception:
+                logger.debug("Failed to filter gateway display context markers", exc_info=True)
+                display_context = previous_context
+            display = merge_session_messages_append_only(
+                list(getattr(s, "messages", None) or []),
+                display_context,
+            )
+            try:
+                from api.streaming import _merge_display_messages_after_agent_result
+
+                s.messages = _merge_display_messages_after_agent_result(
+                    display,
+                    previous_context,
+                    s.context_messages,
+                    str(msg_text or ""),
+                )
+            except Exception:
+                logger.debug("Failed to merge gateway display transcript", exc_info=True)
+                # Avoid duplicating the eager-save checkpointed user message.
+                if display:
+                    latest = display[-1]
+                    if isinstance(latest, dict) and latest.get("role") == "user":
+                        latest_text = " ".join(str(latest.get("content") or "").split())
+                        msg_norm = " ".join(str(msg_text or "").split())
+                        if latest_text == msg_norm:
+                            display = display[:-1]
+                s.messages = display + [user_msg, assistant_msg]
             s.active_stream_id = None
             s.pending_user_message = None
             s.pending_attachments = None

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3120,7 +3120,14 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
         if _has_context_only_turns:
             context_keys = [_message_identity(m) for m in previous_context]
             _backfilled = []
-            _emitted = set()
+            # #3300 fix: track ONLY context rows we splice in, so the
+            # visible-display backbone is never suppressed. Sharing one set
+            # between context inserts and display rows (and _message_identity
+            # ignoring timestamps) dropped a legitimate second identical visible
+            # user turn. Display rows are always appended in order; a context
+            # row is backfilled only if it isn't already a display row and
+            # hasn't already been inserted.
+            _context_inserted = set()
             _cursor = 0
             for _display_idx, _dmsg in enumerate(previous_display):
                 _dkey = _message_identity(_dmsg)
@@ -3132,9 +3139,9 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
                         for _k in range(_cursor, _j):
                             _ckey = context_keys[_k]
                             _cmsg = previous_context[_k]
-                            if _ckey is not None and _ckey not in _emitted and not _is_context_compression_marker(_cmsg):
+                            if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg):
                                 _backfilled.append(copy.deepcopy(_cmsg))
-                                _emitted.add(_ckey)
+                                _context_inserted.add(_ckey)
                         _cursor = _j + 1
                     elif not any(
                         _message_identity(_future_dmsg) in context_keys[_cursor:]
@@ -3143,21 +3150,21 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
                         for _k in range(_cursor, len(context_keys)):
                             _ckey = context_keys[_k]
                             _cmsg = previous_context[_k]
-                            if _ckey is not None and _ckey not in _emitted and not _is_context_compression_marker(_cmsg):
+                            if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg):
                                 _backfilled.append(copy.deepcopy(_cmsg))
-                                _emitted.add(_ckey)
+                                _context_inserted.add(_ckey)
                         _cursor = len(context_keys)
-                if _dkey not in _emitted:
-                    _backfilled.append(_dmsg)
-                    if _dkey is not None:
-                        _emitted.add(_dkey)
+                # The display row is the visible backbone — always preserve it,
+                # in order, even when an earlier (identical-content) turn or a
+                # backfilled context row shares its timestamp-less identity.
+                _backfilled.append(_dmsg)
             while _cursor < len(context_keys):
                 _ckey = context_keys[_cursor]
                 _cmsg = previous_context[_cursor]
                 _cursor += 1
-                if _ckey is not None and _ckey not in _emitted and not _is_context_compression_marker(_cmsg):
+                if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg):
                     _backfilled.append(copy.deepcopy(_cmsg))
-                    _emitted.add(_ckey)
+                    _context_inserted.add(_ckey)
             if len(_backfilled) > len(previous_display):
                 logger.debug(
                     "Backfilled %d context-only turns into previous_display (was %d, now %d)",

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3111,14 +3111,18 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
     # match are context-only gaps that get spliced in before the display msg.
     if previous_display and previous_context:
         _display_id_set = {_message_identity(m) for m in previous_display}
-        _context_id_set = {_message_identity(m) for m in previous_context}
+        _context_id_set = {
+            _message_identity(m)
+            for m in previous_context
+            if not _is_context_compression_marker(m)
+        }
         _has_context_only_turns = bool(_context_id_set - _display_id_set)
         if _has_context_only_turns:
             context_keys = [_message_identity(m) for m in previous_context]
             _backfilled = []
             _emitted = set()
             _cursor = 0
-            for _dmsg in previous_display:
+            for _display_idx, _dmsg in enumerate(previous_display):
                 _dkey = _message_identity(_dmsg)
                 if _dkey is not None:
                     _j = _cursor
@@ -3132,6 +3136,17 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
                                 _backfilled.append(copy.deepcopy(_cmsg))
                                 _emitted.add(_ckey)
                         _cursor = _j + 1
+                    elif not any(
+                        _message_identity(_future_dmsg) in context_keys[_cursor:]
+                        for _future_dmsg in previous_display[_display_idx + 1:]
+                    ):
+                        for _k in range(_cursor, len(context_keys)):
+                            _ckey = context_keys[_k]
+                            _cmsg = previous_context[_k]
+                            if _ckey is not None and _ckey not in _emitted and not _is_context_compression_marker(_cmsg):
+                                _backfilled.append(copy.deepcopy(_cmsg))
+                                _emitted.add(_ckey)
+                        _cursor = len(context_keys)
                 if _dkey not in _emitted:
                     _backfilled.append(_dmsg)
                     if _dkey is not None:

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -315,6 +315,143 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     }) in events
 
 
+def test_gateway_chat_worker_backfills_context_only_turns_into_display(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield b'data: {"choices":[{"delta":{"content":"done"}}]}\n\n'
+            yield b'data: [DONE]\n\n'
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {"status": "not_configured", "source": "none", "label": "", "message_count": 0, "messages": []})
+    monkeypatch.setattr(streaming, "_prefill_messages_with_webui_context", lambda ctx, cfg: [])
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", lambda req, timeout=0: FakeResponse())
+
+    s = new_session()
+    s.context_messages = [
+        {
+            "role": "assistant",
+            "content": "[context compaction] Hidden summary for model continuity.",
+            "timestamp": 9.5,
+        },
+        {"role": "user", "content": "delete the matrix apps", "timestamp": 10.0},
+        {"role": "assistant", "content": "I will verify the Matrix cleanup targets.", "timestamp": 10.1},
+    ]
+    s.messages = [
+        {"role": "user", "content": "when done also delete tunesync", "timestamp": 11.0},
+    ]
+    stream_id = "stream-gateway-context-backfill-test"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "when done also delete tunesync"
+    s.pending_attachments = []
+    s.save()
+    STREAMS[stream_id] = create_stream_channel()
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "when done also delete tunesync",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+    )
+
+    saved = models.get_session(s.session_id)
+    assert [m["content"] for m in saved.messages] == [
+        "delete the matrix apps",
+        "I will verify the Matrix cleanup targets.",
+        "when done also delete tunesync",
+        "done",
+    ]
+    assert len(saved.messages) == 4
+    assert not any("context compaction" in m["content"] for m in saved.messages)
+
+
+def test_gateway_chat_worker_preserves_old_visible_turns_when_context_is_compacted(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield b'data: {"choices":[{"delta":{"content":"new answer"}}]}\n\n'
+            yield b'data: [DONE]\n\n'
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {"status": "not_configured", "source": "none", "label": "", "message_count": 0, "messages": []})
+    monkeypatch.setattr(streaming, "_prefill_messages_with_webui_context", lambda ctx, cfg: [])
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", lambda req, timeout=0: FakeResponse())
+
+    s = new_session()
+    old_visible_turns = [
+        {"role": "user", "content": "turn one", "timestamp": 1.0},
+        {"role": "assistant", "content": "answer one", "timestamp": 1.1},
+        {"role": "user", "content": "turn two", "timestamp": 2.0},
+        {"role": "assistant", "content": "answer two", "timestamp": 2.1},
+        {"role": "user", "content": "recent turn", "timestamp": 3.0},
+        {"role": "assistant", "content": "recent answer", "timestamp": 3.1},
+    ]
+    s.messages = old_visible_turns + [
+        {"role": "user", "content": "new question", "timestamp": 4.0},
+    ]
+    s.context_messages = [
+        {
+            "role": "assistant",
+            "content": "[context compaction] Hidden summary for model continuity.",
+            "timestamp": 2.9,
+        },
+        old_visible_turns[-2],
+        old_visible_turns[-1],
+    ]
+    stream_id = "stream-gateway-compacted-visible-preserve-test"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "new question"
+    s.pending_attachments = []
+    s.save()
+    STREAMS[stream_id] = create_stream_channel()
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "new question",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+    )
+
+    saved = models.get_session(s.session_id)
+    assert [m["content"] for m in saved.messages] == [
+        "turn one",
+        "answer one",
+        "turn two",
+        "answer two",
+        "recent turn",
+        "recent answer",
+        "new question",
+        "new answer",
+    ]
+    assert not any("context compaction" in m["content"] for m in saved.messages)
+
+
 def test_gateway_chat_worker_forwards_image_attachments_as_multimodal_parts(tmp_path, monkeypatch):
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -452,6 +452,77 @@ def test_gateway_chat_worker_preserves_old_visible_turns_when_context_is_compact
     assert not any("context compaction" in m["content"] for m in saved.messages)
 
 
+def test_gateway_chat_worker_keeps_repeated_identical_visible_turns(tmp_path, monkeypatch):
+    """#3300 regression (Codex gate): two identical visible user turns must BOTH
+    survive gateway finalization even when context-only rows are backfilled.
+    _message_identity ignores timestamps, so a shared identity must not let the
+    backfill dedup suppress the second visible turn."""
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield b'data: {"choices":[{"delta":{"content":"answer"}}]}\n\n'
+            yield b'data: [DONE]\n\n'
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {"status": "not_configured", "source": "none", "label": "", "message_count": 0, "messages": []})
+    monkeypatch.setattr(streaming, "_prefill_messages_with_webui_context", lambda ctx, cfg: [])
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", lambda req, timeout=0: FakeResponse())
+
+    s = new_session()
+    # Two identical visible "same" user turns surround a context-only gap that
+    # only lives in context_messages (plus a hidden compaction marker).
+    s.messages = [
+        {"role": "user", "content": "same", "timestamp": 1.0},
+        {"role": "assistant", "content": "first reply", "timestamp": 1.1},
+        {"role": "user", "content": "same", "timestamp": 3.0},
+        {"role": "user", "content": "new question", "timestamp": 4.0},
+    ]
+    s.context_messages = [
+        {"role": "assistant", "content": "[context compaction] hidden", "timestamp": 0.9},
+        {"role": "user", "content": "same", "timestamp": 1.0},
+        {"role": "assistant", "content": "first reply", "timestamp": 1.1},
+        {"role": "user", "content": "context only gap", "timestamp": 2.0},
+        {"role": "user", "content": "same", "timestamp": 3.0},
+    ]
+    stream_id = "stream-gateway-repeated-identical-turns-test"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "new question"
+    s.pending_attachments = []
+    s.save()
+    STREAMS[stream_id] = create_stream_channel()
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "new question",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+    )
+
+    saved = models.get_session(s.session_id)
+    contents = [m["content"] for m in saved.messages]
+    # BOTH identical "same" visible turns must survive (the original bug dropped one).
+    assert contents.count("same") == 2, contents
+    # The context-only gap is backfilled into the visible transcript.
+    assert "context only gap" in contents
+    # The latest turn + reply are present.
+    assert contents[-2:] == ["new question", "answer"]
+    # No compaction marker leaks into the visible transcript.
+    assert not any("context compaction" in c for c in contents)
+
+
 def test_gateway_chat_worker_forwards_image_attachments_as_multimodal_parts(tmp_path, monkeypatch):
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()


### PR DESCRIPTION
## Release GG — v0.51.213 (stage-p2b)

Phase 2 unhold pickup. #3300 was held from the v0.51.197 batch for a data-loss regression; @AJV20 pushed a fix, I rebased it onto fresh master and took it through the full gate. Single PR.

### PR in this release
- **#3300** (@AJV20) — keep gateway context visible in chat transcripts. Gateway-backed chat now backfills model-context turns into the visible transcript before saving the latest reply, while keeping hidden `[context compaction]` markers out of the visible transcript. Fixes a context-compacted gateway session collapsing the sidebar/header message count to a two-message conversation and dropping older visible turns.

### Maintainer fix applied during the gate
The Codex regression gate flagged a CORE data-loss edge in the original fix: `_merge_display_messages_after_agent_result` shared one `_emitted` set between context-backfill rows and the visible-display backbone, and `_message_identity` ignores timestamps — so **two identical visible user turns** lost the second one on save. Fixed: the display backbone is now always appended in order; a separate `_context_inserted` set + a `_display_id_set` guard dedupe only the spliced-in context rows. Added a regression test (two identical visible turns + a context-only gap → both survive, gap backfilled, no marker leak). Verified no double-append.

### Verification
- Full sequential suite: **7281 passed, 0 failed** (7 skipped, 3 xpassed)
- Codex regression gate: **SAFE TO SHIP** (after the MUST-FIX applied + re-check — confirmed repeated turns preserved, no double-append, no marker leak, normal path intact)
- Opus advisor: **APPROVE**
- ruff forward gate: clean
