### PR TITLE
fix: skip first-segment slash strip for URI-scheme model IDs (#3429)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3112,8 +3112,10 @@ def _get_label_for_model(model_id: str, existing_groups: list) -> str:
     if lookup_id.startswith("@") and ":" in lookup_id:
         lookup_id = lookup_id.split(":", 1)[1]
 
-    # Check existing groups for a matching label
-    _norm = lambda s: (s.split("/", 1)[-1] if "/" in s else s).replace("-", ".").lower()
+    # Check existing groups for a matching label.
+    # Skip slash stripping for URI-scheme IDs (e.g. gpt://folder/model) (#3429).
+    _has_scheme = lambda s: "://" in s
+    _norm = lambda s: (s.split("/", 1)[-1] if ("/" in s and not _has_scheme(s)) else s).replace("-", ".").lower()
     norm_lookup = _norm(lookup_id)
     for g in existing_groups:
         for m in g.get("models", []):
@@ -3122,7 +3124,8 @@ def _get_label_for_model(model_id: str, existing_groups: list) -> str:
 
     # Fall back: strip only the first slash-segment (provider prefix),
     # preserving vendor hierarchy for multi-slash IDs (#3360).
-    bare = lookup_id.split("/", 1)[1] if "/" in lookup_id else lookup_id
+    # Skip for URI-scheme IDs whose slashes are path separators (#3429).
+    bare = lookup_id.split("/", 1)[1] if ("/" in lookup_id and not _has_scheme(lookup_id)) else lookup_id
     return " ".join(
         w.upper() if (len(w) <= 3 and w.replace(".", "").isalnum() and not w.isdigit()) else w.capitalize()
         for w in bare.replace("_", "-").split("-")
@@ -3275,14 +3278,18 @@ def get_available_models() -> dict:
             if s.startswith("@") and ":" in s:
                 parts = s.split(":")
                 s = parts[-1] or s
-            # Strip only the first slash-segment (provider prefix), preserving
-            # any remaining vendor hierarchy.  Using parts[-1] here previously
-            # discarded ALL segments except the last, collapsing distinct
-            # multi-slash IDs like 'vendor_a/deepseek-v4-pro' and
-            # 'vendor_b/deepseek/deepseek-v4-pro' to the same key (#3360).
-            if "/" in s:
-                stripped = s.split("/", 1)[1]
-                s = stripped or s
+            # Skip slash-based stripping for URI-scheme IDs (e.g.
+            # gpt://folder/model/latest) whose slashes are path separators,
+            # not provider delimiters (#3429).
+            if "://" not in s:
+                # Strip only the first slash-segment (provider prefix), preserving
+                # any remaining vendor hierarchy.  Using parts[-1] here previously
+                # discarded ALL segments except the last, collapsing distinct
+                # multi-slash IDs like 'vendor_a/deepseek-v4-pro' and
+                # 'vendor_b/deepseek/deepseek-v4-pro' to the same key (#3360).
+                if "/" in s:
+                    stripped = s.split("/", 1)[1]
+                    s = stripped or s
             return s.replace("-", ".")
 
         def _build_configured_model_badges() -> dict[str, dict[str, str]]:

--- a/static/ui.js
+++ b/static/ui.js
@@ -1434,21 +1434,26 @@ function _normalizeConfiguredModelKey(modelId){
   // Defensive: trailing-colon / trailing-slash falls back to the original key
   // so malformed configs don't collapse distinct ids to '' (matches backend _norm_model_id).
   if(s.startsWith('@')&&s.includes(':')){const last=s.split(':').pop();s=last||s;}
-  // Strip provider-qualified prefixes that contain colons before the first
-  // slash (e.g. 'custom:llm-proxy/model' → 'model').  Without this, badge-
-  // key variants like 'custom:llm-proxy/opencode_go/deepseek-v4-pro' and the
-  // bare 'opencode_go/deepseek-v4-pro' produce different normalized keys and
-  // aren't deduped in the configured section (#3360).
-  if(s.includes('/')&&s.indexOf(':')!==-1&&s.indexOf(':')<s.indexOf('/')){
-    s=s.slice(s.indexOf('/')+1)||s;
+  // Skip slash-based stripping for URI-scheme IDs (e.g. gpt://folder/model)
+  // whose slashes are path separators, not provider delimiters (#3429).
+  const _hasScheme=/^[a-z][a-z0-9+.-]*:\/\//i.test(s);
+  if(!_hasScheme){
+    // Strip provider-qualified prefixes that contain colons before the first
+    // slash (e.g. 'custom:llm-proxy/model' → 'model').  Without this, badge-
+    // key variants like 'custom:llm-proxy/opencode_go/deepseek-v4-pro' and the
+    // bare 'opencode_go/deepseek-v4-pro' produce different normalized keys and
+    // aren't deduped in the configured section (#3360).
+    if(s.includes('/')&&s.indexOf(':')!==-1&&s.indexOf(':')<s.indexOf('/')){
+      s=s.slice(s.indexOf('/')+1)||s;
+    }
+    // Strip only the first slash-segment (provider prefix), preserving any
+    // remaining vendor hierarchy. Using split('/').pop() here previously
+    // discarded ALL segments except the last, collapsing distinct multi-slash
+    // IDs like 'vendor_a/deepseek-v4-pro' and 'vendor_b/deepseek/deepseek-v4-pro'
+    // to the same key, causing badge misattribution and configured-entry
+    // suppression (#3360).
+    if(s.includes('/')) s=s.replace(/^[^/]+\//, '')||s;
   }
-  // Strip only the first slash-segment (provider prefix), preserving any
-  // remaining vendor hierarchy. Using split('/').pop() here previously
-  // discarded ALL segments except the last, collapsing distinct multi-slash
-  // IDs like 'vendor_a/deepseek-v4-pro' and 'vendor_b/deepseek/deepseek-v4-pro'
-  // to the same key, causing badge misattribution and configured-entry
-  // suppression (#3360).
-  if(s.includes('/')) s=s.replace(/^[^/]+\//, '')||s;
   return s.replace(/-/g,'.');
 }
 
@@ -2900,7 +2905,10 @@ function getModelLabel(modelId){
   if(STATIC_LABELS[modelId]) return STATIC_LABELS[modelId];
   // Safe Ollama-tag fallback: strip only the first slash-segment (provider
   // prefix) so multi-slash IDs preserve their vendor hierarchy (#3360).
-  let _last = modelId.includes('/') ? (modelId.slice(modelId.indexOf('/')+1) || modelId) : modelId;
+  // Skip stripping for URI-scheme IDs (e.g. gpt://folder/model/latest) whose
+  // slashes are path separators, not provider delimiters (#3429).
+  const _hasUriScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(modelId);
+  let _last = (!_hasUriScheme && modelId.includes('/')) ? (modelId.slice(modelId.indexOf('/')+1) || modelId) : modelId;
   // Strip @provider: prefix if present (e.g. @ollama-cloud:kimi-k2.6)
   if (_last.startsWith('@') && _last.includes(':')) _last = _last.split(':').slice(1).join(':');
   const looksLikeOllamaTag = /^[a-z0-9][\w.-]*:[\w.-]+$/i.test(_last);

--- a/tests/test_issue3429_uri_scheme_model_ids.py
+++ b/tests/test_issue3429_uri_scheme_model_ids.py
@@ -1,0 +1,258 @@
+"""
+Regression tests for #3429 — getModelLabel breaks URI-scheme model IDs.
+
+The #3360 fix introduced first-segment slash stripping in getModelLabel,
+_normalizeConfiguredModelKey, and _norm_model_id.  This correctly handles
+provider-prefixed IDs (e.g. openai/gpt-5.5) but breaks URI-shaped model
+IDs like gpt://${YANDEX_FOLDER_ID}/deepseek-v4-flash/latest — the scheme
+portion (gpt:) is treated as the provider prefix, and the stripped result
+starts with /${YANDEX_FOLDER_ID}/... instead of preserving the full URI.
+
+Fix: detect URI-scheme IDs (matching ^[a-z][a-z0-9+.-]*://) and skip the
+first-segment slash stripping entirely for those inputs.
+
+Tests run the live JS functions via Node and the live Python function via
+exec, so drift between the test and the real code is caught immediately.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
+CONFIG_PY = (REPO_ROOT / "api" / "config.py").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+# ── JS driver for getModelLabel ─────────────────────────────────────────────
+
+_LABEL_DRIVER = r"""
+const fs = require('fs');
+const ui = fs.readFileSync(process.argv[2], 'utf8');
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = ui.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = ui.indexOf('{', start); let depth = 1; i++;
+  while (depth > 0 && i < ui.length) { if (ui[i]==='{') depth++; else if (ui[i]==='}') depth--; i++; }
+  return ui.slice(start, i);
+}
+// Stub dependencies
+const _dynamicModelLabels = {};
+function _fmtOllamaLabel(s) { return s; }
+function $(id) { return null; }
+eval(extractFunc('getModelLabel'));
+const ids = JSON.parse(process.argv[3]);
+const result = {};
+for (const id of ids) { result[id] = getModelLabel(id); }
+process.stdout.write(JSON.stringify(result));
+"""
+
+
+# ── JS driver for _normalizeConfiguredModelKey ──────────────────────────────
+
+_NORM_KEY_DRIVER = r"""
+const fs = require('fs');
+const ui = fs.readFileSync(process.argv[2], 'utf8');
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = ui.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = ui.indexOf('{', start); let depth = 1; i++;
+  while (depth > 0 && i < ui.length) { if (ui[i]==='{') depth++; else if (ui[i]==='}') depth--; i++; }
+  return ui.slice(start, i);
+}
+eval(extractFunc('_normalizeConfiguredModelKey'));
+const ids = JSON.parse(process.argv[3]);
+const result = {};
+for (const id of ids) { result[id] = _normalizeConfiguredModelKey(id); }
+process.stdout.write(JSON.stringify(result));
+"""
+
+
+@pytest.fixture(scope="module")
+def label_driver(tmp_path_factory):
+    p = tmp_path_factory.mktemp("label_driver") / "driver.js"
+    p.write_text(_LABEL_DRIVER, encoding="utf-8")
+    return str(p)
+
+
+@pytest.fixture(scope="module")
+def norm_driver(tmp_path_factory):
+    p = tmp_path_factory.mktemp("norm_driver") / "driver.js"
+    p.write_text(_NORM_KEY_DRIVER, encoding="utf-8")
+    return str(p)
+
+
+def _labels(driver_path, ids):
+    result = subprocess.run(
+        [NODE, driver_path, str(UI_JS_PATH), json.dumps(ids)],
+        capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed: {result.stderr}")
+    return json.loads(result.stdout)
+
+
+def _norm_keys(driver_path, ids):
+    result = subprocess.run(
+        [NODE, driver_path, str(UI_JS_PATH), json.dumps(ids)],
+        capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed: {result.stderr}")
+    return json.loads(result.stdout)
+
+
+def _backend_norm():
+    """Extract and exec the backend _norm_model_id function."""
+    start_marker = "def _norm_model_id(model_id: str) -> str:"
+    end_marker = "def _build_configured_model_badges"
+    s = CONFIG_PY.find(start_marker)
+    e = CONFIG_PY.find(end_marker, s)
+    assert s != -1 and e != -1
+    body = CONFIG_PY[s:e]
+    lines = body.splitlines()
+    indent = None
+    for ln in lines:
+        if ln.strip():
+            indent = len(ln) - len(ln.lstrip())
+            break
+    dedented = "\n".join(ln[indent:] if len(ln) >= indent else ln for ln in lines)
+    ns = {}
+    exec(dedented, ns)
+    return ns["_norm_model_id"]
+
+
+def _backend_label(model_id):
+    """Extract and exec the backend _get_label_for_model function."""
+    start_marker = "def _get_label_for_model(model_id: str, existing_groups: list) -> str:"
+    # Find the end by looking for the next top-level def
+    s = CONFIG_PY.find(start_marker)
+    assert s != -1
+    # Find the next unindented def after the start
+    rest = CONFIG_PY[s + len(start_marker):]
+    lines = rest.splitlines()
+    end_offset = 0
+    for i, ln in enumerate(lines):
+        if i > 0 and ln.startswith("def "):
+            end_offset = sum(len(l) + 1 for l in lines[:i])
+            break
+    body = CONFIG_PY[s:s + len(start_marker) + end_offset]
+    ns = {}
+    exec(body, ns)
+    return ns["_get_label_for_model"](model_id, [])
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# getModelLabel — URI-scheme model IDs must not be stripped
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGetModelLabelUriScheme:
+    """URI-shaped model IDs must pass through without first-segment
+    slash stripping (#3429)."""
+
+    def test_yandex_gpt_uri_preserved(self, label_driver):
+        """The original bug report: gpt://folder_id/model/latest must not
+        become /folder_id/model/latest."""
+        ids = ["gpt://b1g12345abcdef/deepseek-v4-flash/latest"]
+        labels = _labels(label_driver, ids)
+        result = labels[ids[0]]
+        assert not result.startswith("/"), (
+            f"URI-scheme ID had scheme stripped: got {result!r}"
+        )
+        assert "b1g12345abcdef" in result
+
+    def test_multiple_uri_schemes(self, label_driver):
+        """Various URI schemes must all be preserved."""
+        ids = [
+            "gpt://folder/model-name/latest",
+            "http://api.example.com/v1/models/gpt4",
+            "https://my-proxy.internal/models/deepseek-v4",
+            "ollama+http://localhost:11434/llama3",
+        ]
+        labels = _labels(label_driver, ids)
+        for model_id in ids:
+            assert not labels[model_id].startswith("/"), (
+                f"{model_id} had scheme stripped: {labels[model_id]!r}"
+            )
+
+    def test_non_uri_slash_ids_still_stripped(self, label_driver):
+        """Regular provider/model IDs must still strip the provider prefix."""
+        ids = ["openai/gpt-5.5", "vendor_a/deepseek/deepseek-v4-pro"]
+        labels = _labels(label_driver, ids)
+        assert "openai" not in labels["openai/gpt-5.5"].lower()
+        assert "vendor_a" not in labels["vendor_a/deepseek/deepseek-v4-pro"].lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# _normalizeConfiguredModelKey — URI-scheme model IDs must not be stripped
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestNormalizeConfiguredModelKeyUriScheme:
+    """URI-scheme IDs must normalize without slash stripping."""
+
+    def test_uri_scheme_preserved_in_normalization(self, norm_driver):
+        """URI IDs must not have their scheme+authority stripped."""
+        ids = [
+            "gpt://b1g12345/deepseek-v4-flash/latest",
+            "https://proxy.internal/models/gpt4",
+        ]
+        keys = _norm_keys(norm_driver, ids)
+        for model_id in ids:
+            assert "://" in keys[model_id], (
+                f"URI scheme was stripped from normalized key: "
+                f"{model_id!r} → {keys[model_id]!r}"
+            )
+
+    def test_regular_slash_ids_still_normalize(self, norm_driver):
+        """Non-URI slash IDs must still have provider prefix stripped."""
+        ids = ["openai/gpt-5.5", "vendor_a/deepseek-v4-pro"]
+        keys = _norm_keys(norm_driver, ids)
+        assert keys["openai/gpt-5.5"] == "gpt.5.5"
+        assert keys["vendor_a/deepseek-v4-pro"] == "deepseek.v4.pro"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Backend / frontend parity for URI-scheme IDs
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestBackendFrontendUriSchemeParity:
+    """Python _norm_model_id must match JS _normalizeConfiguredModelKey
+    for URI-scheme inputs."""
+
+    def test_parity_uri_scheme_ids(self, norm_driver):
+        ids = [
+            "gpt://b1g12345/deepseek-v4-flash/latest",
+            "https://proxy.internal/v1/gpt4",
+            "openai/gpt-5.5",
+            "vendor_b/deepseek/deepseek-v4-pro",
+        ]
+        js_keys = _norm_keys(norm_driver, ids)
+        py_norm = _backend_norm()
+        for model_id in ids:
+            py_result = py_norm(model_id)
+            js_result = js_keys[model_id]
+            assert py_result == js_result, (
+                f"Parity mismatch for {model_id!r}: "
+                f"Python={py_result!r}, JS={js_result!r}"
+            )
+
+
+class TestBackendGetLabelUriScheme:
+    """Python _get_label_for_model must not strip URI scheme."""
+
+    def test_yandex_gpt_uri_label(self):
+        label = _backend_label("gpt://b1g12345abcdef/deepseek-v4-flash/latest")
+        assert not label.startswith("/"), (
+            f"Backend label for URI-scheme ID starts with /: {label!r}"
+        )
+        assert "b1g12345abcdef" in label.lower()


### PR DESCRIPTION
# fix: getModelLabel breaks URI-scheme model IDs (#3429)

Closes #3429

## Thinking Path

- Hermes WebUI supports custom providers that expose models via URI-shaped identifiers (e.g. Yandex GPT uses `gpt://${FOLDER_ID}/model/version`)
- PR #3366 (shipped in v0.51.210) fixed multi-slash model ID collisions by replacing `split('/').pop()` with first-segment-only stripping in `getModelLabel`, `_normalizeConfiguredModelKey`, and `_norm_model_id`
- That fix assumes the first slash-segment is always a provider prefix — but URI-scheme IDs like `gpt://folder/model/latest` have `://` in the scheme, and the first `/` after `gpt:` is part of the URI authority, not a provider delimiter
- The result is that `getModelLabel("gpt://b1g12345/deepseek-v4-flash/latest")` strips `gpt:` and returns `//b1g12345/deepseek-v4-flash/latest` — a broken label shown in the composer chip
- This PR guards all four slash-stripping locations with a URI-scheme detection check (`://` presence), preserving both the #3360 multi-slash fix and correct handling of URI-shaped model IDs
- The benefit is that users with Yandex GPT, custom HTTP endpoint proxies, or any URI-scheme-based model IDs see correct labels again

## What Changed

### Fix 1 — `getModelLabel` (static/ui.js)

Added a regex check (`/^[a-z][a-z0-9+.-]*:\/\//i`) before the first-segment slash strip. When the model ID has a URI scheme, the entire ID is passed through without stripping.

### Fix 2 — `_normalizeConfiguredModelKey` (static/ui.js)

Wrapped the existing colon-prefix strip and slash-strip logic in a URI-scheme guard. URI-scheme IDs normalize with their full structure preserved (hyphens still replaced with dots for consistency).

### Fix 3 — `_norm_model_id` (api/config.py)

Added a `"://" not in s` check before the first-segment slash strip. Simple, dependency-free — no regex import needed in the nested function scope.

### Fix 4 — `_get_label_for_model` (api/config.py)

Added a `_has_scheme` lambda (`"://" in s`) that guards both the `_norm` helper used for group label lookup and the `bare` fallback used for title-casing.

### Files changed

| File | Lines | Description |
|------|-------|-------------|
| static/ui.js | +40/−16 | URI-scheme guards in `getModelLabel` and `_normalizeConfiguredModelKey` |
| api/config.py | +29/−11 | URI-scheme guards in `_norm_model_id` and `_get_label_for_model` |
| tests/test_issue3429_uri_scheme_model_ids.py | +258 (new) | 7 regression tests across 4 test classes |

## Why It Matters

Any user running Yandex GPT (`gpt://` scheme), a custom HTTP-endpoint proxy (`https://` scheme), or any provider that uses URI-formatted model identifiers will see broken labels in the composer chip and potentially mismatched normalization in badge assignment and configured-entry dedup. The regression was introduced in v0.51.210 and affects all users with URI-scheme model IDs.

## Verification

### Automated tests

```bash
pytest tests/test_issue3429_uri_scheme_model_ids.py \
       tests/test_issue3360_multi_slash_model_collision.py \
       tests/test_norm_model_id_trailing_empty_guard.py \
       tests/test_issue1188_fuzzy_match.py \
       tests/test_issue1228_model_picker_duplicate_ids.py \
       -v
# 49 passed
```

**New tests** (`test_issue3429`):

- `TestGetModelLabelUriScheme` — 3 tests: Yandex gpt:// preserved, multiple URI schemes preserved, non-URI slash IDs still stripped
- `TestNormalizeConfiguredModelKeyUriScheme` — 2 tests: URI scheme preserved in normalization, regular slash IDs still normalize
- `TestBackendFrontendUriSchemeParity` — 1 test: Python `_norm_model_id` produces identical output to JS `_normalizeConfiguredModelKey` for URI and non-URI inputs
- `TestBackendGetLabelUriScheme` — 1 test: Python `_get_label_for_model` does not strip URI scheme

**Existing test suites** — all pass unmodified:

- `test_issue3360_multi_slash_model_collision` (9 tests) — multi-slash fix preserved
- `test_norm_model_id_trailing_empty_guard` (5 tests) — trailing-empty guard preserved
- `test_issue1188_fuzzy_match` (11 tests) — fuzzy match unaffected
- `test_issue1228_model_picker_duplicate_ids` (17 tests) — provider-aware preference unaffected

## Risks / Follow-ups

- **Low risk**: The URI detection uses simple `://` substring check (backend) and regex (frontend). This correctly distinguishes `gpt://folder/model` from `openai/gpt-5.5` — no known false positives since normal provider/model IDs never contain `://`.
- **Edge case**: A hypothetical model ID like `custom://` (URI scheme with no path) would skip stripping and normalize to itself — strictly better than the broken empty-string behavior.
- **Not addressed**: The `_findModelInDropdown` function doesn't need a URI guard because it operates on option values via exact match or normalized comparison — the normalization is already guarded.

## AI Usage Disclosure

- **Provider**: Anthropic
- **Model**: Claude Opus 4.6
- **Tool**: Cursor IDE (agentic pair-programming)
- **Usage**: Root cause analysis of the #3429 regression, implementation of URI-scheme guards across all four affected functions, test authoring, and verification were done collaboratively. All changes reviewed and tested by a human before commit.
