### PR TITLE
Release GL — v0.51.218 (fix getModelLabel mangling URI-scheme model IDs, #3429 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.218] — 2026-06-02 — Release GL (stage-p3a — fix getModelLabel mangling URI-scheme model IDs)
+
+### Fixed
+- The composer model chip no longer shows env-var path junk for model IDs that use a URI scheme (e.g. Yandex `gpt://${FOLDER}/deepseek-v4-flash/latest`). A regression from #3366 (v0.51.210): `getModelLabel()` stripped the first `/`-segment, which for a `scheme://` id landed inside the `://` and left `/${FOLDER}/…`. The label now detects a URI scheme, drops scheme + authority, and takes the last meaningful path segment (skipping `${…}` placeholders and bare version tails like `latest`); non-URI multi-slash IDs keep their #3360 behavior (#3429).
+
 ## [v0.51.217] — 2026-06-02 — Release GK (stage-p2f — decode and complete zh-Hant locale strings)
 
 ### Changed

--- a/static/ui.js
+++ b/static/ui.js
@@ -2900,7 +2900,29 @@ function getModelLabel(modelId){
   if(STATIC_LABELS[modelId]) return STATIC_LABELS[modelId];
   // Safe Ollama-tag fallback: strip only the first slash-segment (provider
   // prefix) so multi-slash IDs preserve their vendor hierarchy (#3360).
-  let _last = modelId.includes('/') ? (modelId.slice(modelId.indexOf('/')+1) || modelId) : modelId;
+  // URI-scheme ids (e.g. `gpt://${FOLDER}/deepseek-v4-flash/latest`, provider
+  // `yandex:gpt`) must NOT be first-segment-stripped — `indexOf('/')` would
+  // land inside the `://` and leave `/${FOLDER}/...` path junk (#3429). For a
+  // `scheme://` id, drop the scheme + authority and take the last meaningful
+  // path segment (ignoring a bare version tail like `latest`/`stable`).
+  let _last;
+  const _uriMatch = /^[a-z][a-z0-9+.-]*:\/\/(.+)$/i.exec(modelId);
+  if (_uriMatch) {
+    const _segs = _uriMatch[1].split('/').filter(Boolean);
+    const _isVersionTail = (s) => /^(latest|stable|current|default|v?\d[\w.-]*)$/i.test(s);
+    let _pick = '';
+    for (let _i = _segs.length - 1; _i >= 0; _i--) {
+      // Skip env-var placeholders (${...}) and bare version tails; prefer the
+      // last segment that actually looks like a model name.
+      if (/\$\{[^}]*\}/.test(_segs[_i])) continue;
+      if (_isVersionTail(_segs[_i]) && _pick) continue;
+      if (!_pick) _pick = _segs[_i];
+      if (!_isVersionTail(_segs[_i])) { _pick = _segs[_i]; break; }
+    }
+    _last = _pick || _segs[_segs.length - 1] || modelId;
+  } else {
+    _last = modelId.includes('/') ? (modelId.slice(modelId.indexOf('/')+1) || modelId) : modelId;
+  }
   // Strip @provider: prefix if present (e.g. @ollama-cloud:kimi-k2.6)
   if (_last.startsWith('@') && _last.includes(':')) _last = _last.split(':').slice(1).join(':');
   const looksLikeOllamaTag = /^[a-z0-9][\w.-]*:[\w.-]+$/i.test(_last);

--- a/static/ui.js
+++ b/static/ui.js
@@ -2930,9 +2930,12 @@ function getModelLabel(modelId){
       if (!_lastUsable) _lastUsable = _seg;
       if (!_isVersionTail(_seg)) { _pick = _seg; break; }
     }
-    // Fallbacks: last non-placeholder path segment, else the literal last path
-    // segment, else the authority, else the raw id. Never an env-var placeholder.
-    _last = _pick || _lastUsable || _path[_path.length - 1] || _all[0] || modelId;
+    // Fallbacks: the chosen non-version segment, else the last non-placeholder
+    // path segment. NEVER the authority and NEVER a `${...}` placeholder — for
+    // a degenerate id (`gpt://folder123`, `gpt://folder123/${MODEL}`) fall all
+    // the way back to the raw id rather than leak the folder/host or env var.
+    const _lastPath = _path[_path.length - 1] || '';
+    _last = _pick || _lastUsable || (_lastPath && !_isPlaceholder(_lastPath) ? _lastPath : '') || modelId;
   } else {
     _last = modelId.includes('/') ? (modelId.slice(modelId.indexOf('/')+1) || modelId) : modelId;
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -2903,23 +2903,36 @@ function getModelLabel(modelId){
   // URI-scheme ids (e.g. `gpt://${FOLDER}/deepseek-v4-flash/latest`, provider
   // `yandex:gpt`) must NOT be first-segment-stripped — `indexOf('/')` would
   // land inside the `://` and leave `/${FOLDER}/...` path junk (#3429). For a
-  // `scheme://` id, drop the scheme + authority and take the last meaningful
-  // path segment (ignoring a bare version tail like `latest`/`stable`).
+  // `scheme://authority/path...` id, drop the scheme AND the authority, then
+  // pick the model name from the PATH segments only. A version/channel tail
+  // (`latest`/`stable`/numeric) is skipped only when a real model segment
+  // precedes it — never promoting the authority or a container folder (#3429).
   let _last;
   const _uriMatch = /^[a-z][a-z0-9+.-]*:\/\/(.+)$/i.exec(modelId);
   if (_uriMatch) {
-    const _segs = _uriMatch[1].split('/').filter(Boolean);
-    const _isVersionTail = (s) => /^(latest|stable|current|default|v?\d[\w.-]*)$/i.test(s);
+    const _all = _uriMatch[1].split('/').filter(Boolean);
+    // _all[0] is the authority (folder/host); the model lives in the path tail.
+    const _path = _all.slice(1);
+    // A pure version/channel tail: named channels, or a bare version number
+    // (`v4`, `1.2`, `20231231`) — NOT a mixed model name that merely starts
+    // with a digit (`2026-model`, `4o-mini`), which must be kept as the label.
+    const _isVersionTail = (s) => /^(latest|stable|current|default|v\d[\d.]*|\d[\d.]*)$/i.test(s);
+    const _isPlaceholder = (s) => /\$\{[^}]*\}/.test(s);
+    // Walk path segments right-to-left; the model name is the LAST segment that
+    // is neither a version/channel tail (`latest`, `v4`, `1.2`) nor a `${...}`
+    // env-var placeholder. Fall back to the last non-placeholder segment, then
+    // the literal last segment. Never returns the authority (`_all[0]`).
     let _pick = '';
-    for (let _i = _segs.length - 1; _i >= 0; _i--) {
-      // Skip env-var placeholders (${...}) and bare version tails; prefer the
-      // last segment that actually looks like a model name.
-      if (/\$\{[^}]*\}/.test(_segs[_i])) continue;
-      if (_isVersionTail(_segs[_i]) && _pick) continue;
-      if (!_pick) _pick = _segs[_i];
-      if (!_isVersionTail(_segs[_i])) { _pick = _segs[_i]; break; }
+    let _lastUsable = '';
+    for (let _i = _path.length - 1; _i >= 0; _i--) {
+      const _seg = _path[_i];
+      if (_isPlaceholder(_seg)) continue;
+      if (!_lastUsable) _lastUsable = _seg;
+      if (!_isVersionTail(_seg)) { _pick = _seg; break; }
     }
-    _last = _pick || _segs[_segs.length - 1] || modelId;
+    // Fallbacks: last non-placeholder path segment, else the literal last path
+    // segment, else the authority, else the raw id. Never an env-var placeholder.
+    _last = _pick || _lastUsable || _path[_path.length - 1] || _all[0] || modelId;
   } else {
     _last = modelId.includes('/') ? (modelId.slice(modelId.indexOf('/')+1) || modelId) : modelId;
   }

--- a/tests/test_issue3429_uri_scheme_model_label.py
+++ b/tests/test_issue3429_uri_scheme_model_label.py
@@ -88,6 +88,20 @@ def test_uri_label_edge_cases_never_return_authority_or_drop_digit_models():
         assert label != "folder123", "authority/folder leaked into label"
 
 
+def test_uri_degenerate_ids_fall_back_to_raw_not_authority_or_placeholder():
+    """#3429 follow-up 2 (Codex gate): a URI with no usable model segment must
+    fall back to the raw id — never the authority/folder, never a ${...} env-var."""
+    out = _labels([
+        "gpt://folder123",              # authority only, no path
+        "gpt://folder123/${MODEL}",     # path is only an env-var placeholder
+    ])
+    assert out["gpt://folder123"] == "gpt://folder123"
+    assert out["gpt://folder123/${MODEL}"] == "gpt://folder123/${MODEL}"
+    for label in out.values():
+        assert label != "folder123", "authority leaked into label"
+        assert label not in ("${MODEL}",), "env-var placeholder leaked into label"
+
+
 def test_uri_fix_does_not_regress_multi_slash_or_bare_ids():
     """#3360 multi-slash hierarchy + single-slash/bare ids stay correct."""
     out = _labels([

--- a/tests/test_issue3429_uri_scheme_model_label.py
+++ b/tests/test_issue3429_uri_scheme_model_label.py
@@ -71,6 +71,23 @@ def test_uri_scheme_model_id_label_is_model_name_not_path_junk():
         assert "${" not in label, f"env-var placeholder leaked into label: {label!r}"
 
 
+def test_uri_label_edge_cases_never_return_authority_or_drop_digit_models():
+    """#3429 follow-up (Codex gate): a single path segment is kept even when it
+    looks version-like, a digit-leading model name (2026-model) is NOT mistaken
+    for a version tail, and the authority/folder is never returned as the label."""
+    out = _labels([
+        "gpt://folder123/v4",            # single path seg — keep it, don't fall back to authority
+        "gpt://folder123/latest",        # single path seg — keep it
+        "gpt://folder123/2026-model/latest",  # digit-leading real model name
+    ])
+    assert out["gpt://folder123/v4"] == "v4"
+    assert out["gpt://folder123/latest"] == "latest"
+    assert out["gpt://folder123/2026-model/latest"] == "2026-model"
+    # The authority/folder must never be promoted to the label.
+    for label in out.values():
+        assert label != "folder123", "authority/folder leaked into label"
+
+
 def test_uri_fix_does_not_regress_multi_slash_or_bare_ids():
     """#3360 multi-slash hierarchy + single-slash/bare ids stay correct."""
     out = _labels([

--- a/tests/test_issue3429_uri_scheme_model_label.py
+++ b/tests/test_issue3429_uri_scheme_model_label.py
@@ -1,0 +1,82 @@
+"""Regression test for #3429 — getModelLabel() mangles URI-scheme model IDs.
+
+PR #3366 (fix for #3360) changed getModelLabel() to strip only the first
+``/``-segment instead of ``split('/').pop()``. That fixed multi-slash proxy IDs
+but regressed URI-scheme IDs (e.g. Yandex ``gpt://${FOLDER}/deepseek-v4-flash/latest``)
+because ``indexOf('/')`` lands inside the ``://`` and leaves ``/${FOLDER}/...``
+path junk in the composer model chip.
+
+The fix detects a ``scheme://`` id and takes the last meaningful path segment
+(skipping ``${...}`` env-var placeholders and bare version tails like ``latest``),
+while NOT touching the #3360 multi-slash behavior for non-URI ids.
+
+Runs the live getModelLabel() via Node so drift between the test and the real
+code is caught immediately.
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+_DRIVER = r"""
+const fs = require('fs');
+const ui = fs.readFileSync(process.argv[1], 'utf8');
+// Slice getModelLabel() by function boundaries (regex literals inside it defeat
+// a naive brace counter, so bound it by the next top-level function instead).
+const start = ui.indexOf('function getModelLabel(');
+if (start < 0) throw new Error('getModelLabel not found');
+const after = ui.indexOf('\nfunction _gatewayProviderName(', start);
+if (after < 0) throw new Error('getModelLabel end boundary not found');
+const fnSrc = ui.slice(start, after);
+const _dynamicModelLabels = {};
+function _fmtOllamaLabel(s){ return s; }
+eval(fnSrc);
+const out = {};
+for (const m of JSON.parse(process.argv[2])) out[m] = getModelLabel(m);
+process.stdout.write(JSON.stringify(out));
+"""
+
+
+def _labels(model_ids):
+    import json
+    proc = subprocess.run(
+        [NODE, "-e", _DRIVER, str(UI_JS_PATH), json.dumps(model_ids)],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert proc.returncode == 0, f"node driver failed: {proc.stderr}"
+    return json.loads(proc.stdout)
+
+
+def test_uri_scheme_model_id_label_is_model_name_not_path_junk():
+    """#3429: a gpt://.../model/latest id must label as the model name."""
+    out = _labels([
+        "gpt://${YANDEX_FOLDER_ID}/deepseek-v4-flash/latest",
+        "gpt://folder123/deepseek-v4-flash/latest",
+        "openrouter://acct/qwen-3-coder",
+        "gpt://${F}/qwen-3-coder",
+    ])
+    assert out["gpt://${YANDEX_FOLDER_ID}/deepseek-v4-flash/latest"] == "deepseek-v4-flash"
+    assert out["gpt://folder123/deepseek-v4-flash/latest"] == "deepseek-v4-flash"
+    assert out["openrouter://acct/qwen-3-coder"] == "qwen-3-coder"
+    assert out["gpt://${F}/qwen-3-coder"] == "qwen-3-coder"
+    # The env-var placeholder must never leak into the label.
+    for label in out.values():
+        assert "${" not in label, f"env-var placeholder leaked into label: {label!r}"
+
+
+def test_uri_fix_does_not_regress_multi_slash_or_bare_ids():
+    """#3360 multi-slash hierarchy + single-slash/bare ids stay correct."""
+    out = _labels([
+        "vendor_a/deepseek/deepseek-v4-pro",  # #3360: keep vendor hierarchy
+        "claude-sonnet-4-6",                  # bare id unchanged
+    ])
+    # Non-URI multi-slash id keeps everything after the first segment (#3360).
+    assert out["vendor_a/deepseek/deepseek-v4-pro"] == "deepseek/deepseek-v4-pro"
+    assert out["claude-sonnet-4-6"] == "claude-sonnet-4-6"


### PR DESCRIPTION
## Release GL — v0.51.218 (stage-p3a)

A high-impact regression fix — no new UI/UX surface. This corrects a bug **we shipped** in #3366 (v0.51.210).

### PR in this release
- **#3429 fix** — `getModelLabel()` no longer mangles URI-scheme model IDs. #3366 changed the function to strip only the first `/`-segment (fixing #3360 multi-slash proxy IDs), which regressed URI-scheme IDs like Yandex `gpt://${FOLDER}/deepseek-v4-flash/latest` — `indexOf('/')` landed inside the `://` and left `/${FOLDER}/…` env-var path junk in the composer model chip. The label now detects a `scheme://` id, drops scheme + authority, and takes the last meaningful path segment (skipping `${…}` placeholders and bare version tails like `latest`/`v4`); non-URI multi-slash IDs keep their #3360 behavior. Closes #3429.

### Two MUST-FIX rounds applied during the gate
The Codex regression gate caught (and I fixed inline) two edge classes in the first cut:
1. The candidate segment list included the URI authority, so `gpt://folder123/v4` / `.../latest` returned the folder, and `2026-model` (a digit-leading real model name) was mistaken for a version tail and dropped. Fixed: build path from after the authority; tightened the version-tail regex to pure version tokens only.
2. Degenerate URIs still leaked — `gpt://folder123` returned the authority, `gpt://folder123/${MODEL}` returned the placeholder. Fixed: removed the authority fallback and guarded the literal-last-path fallback against placeholders; a URI with no usable model segment falls back to the raw id.

Opus independently flagged the same authority edge; both are resolved.

### Verification
- Full sequential suite: **7302 passed, 0 failed** (7 skipped, 3 xpassed)
- Codex regression gate: **SAFE TO SHIP** (authority never returned, no placeholder leak, non-URI byte-identical, #3360 unchanged)
- Opus advisor: **APPROVE**
- ESLint runtime gate + ruff forward gate: clean
- Node-driven regression test covers: #3429 URI case, `2026-model` digit-leading, single-segment `v4`/`latest`, degenerate `gpt://folder123` + `${MODEL}`, and the #3360 non-URI non-regression
