### PR TITLE
Release GN — v0.51.220 (fix aux title generation 422 with @provider: model ids, #3430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.220] — 2026-06-02 — Release GN (stage-p3c — fix aux title generation with @provider: model ids)
+
+### Fixed
+- Manual session-title regeneration and background auxiliary title generation no longer fail with `422` / `llm_error_aux` when `auxiliary.title_generation.model` in `config.yaml` is set using the WebUI model-picker's `@provider:model` format (e.g. `@gemini:gemini-3.1-flash-lite`). The `@provider:` prefix is now normalized away via the canonical helper before the id reaches the provider API (#3430, @pamnard).
+
 ## [v0.51.219] — 2026-06-02 — Release GM (stage-p3b — extend URI-scheme model-ID fix to backend normalization + matching)
 
 ### Fixed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1801,6 +1801,17 @@ def generate_title_raw_via_aux(
         provider = ''
     model = model or configured.get('model', '') or ''
     base_url = base_url or configured.get('base_url', '') or ''
+    try:
+        from api.profiles import _split_webui_provider_model_value
+
+        normalized_model, normalized_provider = _split_webui_provider_model_value(
+            model or None,
+            provider or None,
+        )
+        model = normalized_model or ''
+        provider = normalized_provider or ''
+    except ValueError:
+        pass
     api_key = ''
     if not caller_supplied_route:
         api_key = str(configured.get('api_key', '') or '').strip()

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -109,6 +109,41 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
             30.0,
         )
 
+    def test_webui_prefixed_model_id_is_stripped_before_aux_call(self):
+        """Regression: @provider:model picker ids must not reach provider APIs verbatim."""
+        from api.streaming import generate_title_raw_via_aux
+
+        mock_resp = types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(content='Gemini Title'),
+                    finish_reason='stop',
+                )
+            ]
+        )
+        captured = {}
+
+        def fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            return mock_resp
+
+        tg_config = {
+            'provider': 'gemini',
+            'model': '@gemini:gemini-3.1-flash-lite',
+            'base_url': '',
+        }
+        with _patch_tg_config(tg_config):
+            with patch('agent.auxiliary_client.call_llm', side_effect=fake_call_llm, create=True):
+                result, status = generate_title_raw_via_aux(
+                    user_text='Как настроить title generation?',
+                    assistant_text='Нужно указать auxiliary.title_generation в config.yaml.',
+                )
+
+        self.assertEqual(result, 'Gemini Title')
+        self.assertEqual(status, 'llm_aux')
+        self.assertEqual(captured.get('provider'), 'gemini')
+        self.assertEqual(captured.get('model'), 'gemini-3.1-flash-lite')
+
     def test_configured_provider_model_and_base_url_are_passed_to_aux_client(self):
         """Regression for #2235: task config must select the first title model.
 


### PR DESCRIPTION
## Release GN — v0.51.220 (stage-p3c)

High-impact backend bug fix — no UI surface. Clean contributor fix.

### PR in this release
- **#3430** (@pamnard) — aux title generation no longer 422s on `@provider:model` config. Manual session-title regeneration (`POST /api/session/title/regenerate`) and background auxiliary title generation failed with `422` / `llm_error_aux` when `auxiliary.title_generation.model` in `config.yaml` was set using the WebUI model-picker's `@provider:model` format (e.g. `@gemini:gemini-3.1-flash-lite`) — the raw `@`-qualified id was forwarded to the provider API verbatim. Now normalized via the canonical `_split_webui_provider_model_value()` helper before the aux call.

### Verification
- Full sequential suite: **7307 passed, 0 failed** (7 skipped, 3 xpassed)
- Agent self-verify (empirical): the helper strips `@gemini:gemini-3.1-flash-lite` → (`gemini-3.1-flash-lite`, `gemini`), and is a **no-op on already-bare working configs** (`gemini-3.1-flash-lite`/`gemini`, `gpt-5.5`/`openai` unchanged) — no regression to working title-generation configs.
- Codex regression gate: **SAFE TO SHIP** (bare/URI configs unchanged, explicit provider wins over `@provider:`, ValueError fallback coherent, all title-aux callers route through the single fixed function)
- Opus advisor: **APPROVE** (uses the project's canonical helper, surgical +51 LOC, no working config path mutated)
- ruff forward gate: clean
