### PR TITLE
fix(models): map openai-api provider slug to openai picker group

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -704,6 +704,7 @@ _PROVIDER_DISPLAY = {
     "openrouter": "OpenRouter",
     "anthropic": "Anthropic",
     "openai": "OpenAI",
+    "openai-api": "OpenAI API",
     "openai-codex": "OpenAI Codex",
     "xai-oauth": "xAI Grok OAuth",
     "copilot": "GitHub Copilot",
@@ -786,12 +787,6 @@ _PROVIDER_ALIASES = {
     # lets the agent's auxiliary client take the ``no-key-required``
     # OpenAI-compat path. See #1384.
     "local": "custom",
-    # hermes-agent's built-in OpenAI provider (activated by OPENAI_API_KEY /
-    # OPENAI_BASE_URL env vars) registers as ``openai-api`` in
-    # ``hermes_cli.auth.PROVIDER_REGISTRY``.  Without this alias, GPT models
-    # from that slug fall through the group builder and are invisible in the
-    # picker.  Same shape as #815 and #1384.
-    "openai-api": "openai",
 }
 
 
@@ -1062,6 +1057,12 @@ _PROVIDER_MODELS = {
         {"id": "claude-haiku-4-5", "label": "Claude Haiku 4.5"},
     ],
     "openai": [
+        {"id": "gpt-5.5",      "label": "GPT-5.5"},
+        {"id": "gpt-5.5-mini", "label": "GPT-5.5 Mini"},
+        {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
+        {"id": "gpt-5.4",      "label": "GPT-5.4"},
+    ],
+    "openai-api": [
         {"id": "gpt-5.5",      "label": "GPT-5.5"},
         {"id": "gpt-5.5-mini", "label": "GPT-5.5 Mini"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},

--- a/api/config.py
+++ b/api/config.py
@@ -786,6 +786,12 @@ _PROVIDER_ALIASES = {
     # lets the agent's auxiliary client take the ``no-key-required``
     # OpenAI-compat path. See #1384.
     "local": "custom",
+    # hermes-agent's built-in OpenAI provider (activated by OPENAI_API_KEY /
+    # OPENAI_BASE_URL env vars) registers as ``openai-api`` in
+    # ``hermes_cli.auth.PROVIDER_REGISTRY``.  Without this alias, GPT models
+    # from that slug fall through the group builder and are invisible in the
+    # picker.  Same shape as #815 and #1384.
+    "openai-api": "openai",
 }
 
 

--- a/tests/test_openai_api_provider_alias.py
+++ b/tests/test_openai_api_provider_alias.py
@@ -1,33 +1,56 @@
-"""openai-api → openai provider alias.
+"""openai-api as a first-class picker provider.
 
-hermes-agent reports its built-in OpenAI provider as ``openai-api``
-(the slug in ``hermes_cli.auth.PROVIDER_REGISTRY``).  Without an alias,
-GPT models from that provider slug are invisible in the WebUI model
-picker because the slug doesn't match the ``openai`` group key in
-``_PROVIDER_MODELS``.
+hermes-agent registers its built-in OpenAI provider as ``openai-api`` in
+``hermes_cli.auth.PROVIDER_REGISTRY``.  The WebUI must recognise this
+slug in ``_PROVIDER_DISPLAY`` and ``_PROVIDER_MODELS`` so that GPT
+models appear in the picker AND the session ``model_provider`` stays
+``openai-api`` on the send path (where the agent resolves it against
+its own registry).
 
-Same shape as #815 (``z.ai`` → ``zai``) and #1384 (``local`` →
-``custom``).
+An alias-only approach (``openai-api`` → ``openai``) fixes display but
+breaks the send path because ``openai`` is not a registered provider in
+the agent.  See PR review discussion on #3444.
 """
 
 import api.config as cfg
 
 
-class TestOpenaiApiProviderAlias:
-    """``_resolve_provider_alias`` must rewrite ``openai-api`` → ``openai``."""
+class TestOpenaiApiPickerProvider:
+    """openai-api must be a first-class picker provider, not an alias."""
 
-    def test_openai_api_resolves_to_openai(self):
-        assert cfg._resolve_provider_alias("openai-api") == "openai"
+    def test_provider_display_registered(self):
+        assert "openai-api" in cfg._PROVIDER_DISPLAY
 
-    def test_openai_api_case_insensitive(self):
-        assert cfg._resolve_provider_alias("OPENAI-API") == "openai"
-        assert cfg._resolve_provider_alias("OpenAI-API") == "openai"
+    def test_provider_models_registered(self):
+        assert "openai-api" in cfg._PROVIDER_MODELS
+        assert len(cfg._PROVIDER_MODELS["openai-api"]) > 0
 
-    def test_alias_table_contains_entry(self):
-        assert cfg._PROVIDER_ALIASES.get("openai-api") == "openai", (
-            "_PROVIDER_ALIASES must map 'openai-api' → 'openai'"
-        )
+    def test_not_aliased(self):
+        assert "openai-api" not in cfg._PROVIDER_ALIASES
+
+    def test_canonicalise_preserves_slug(self):
+        assert cfg._canonicalise_provider_id("openai-api") == "openai-api"
 
     def test_openai_canonical_unchanged(self):
-        """The canonical slug 'openai' must pass through unchanged."""
-        assert cfg._resolve_provider_alias("openai") == "openai"
+        assert cfg._canonicalise_provider_id("openai") == "openai"
+
+    def test_openai_codex_unchanged(self):
+        assert cfg._canonicalise_provider_id("openai-codex") == "openai-codex"
+
+
+class TestOpenaiApiSendPath:
+    """The send path must preserve openai-api, not collapse it to openai."""
+
+    def test_resolve_model_provider_preserves_openai_api(self, monkeypatch):
+        monkeypatch.setattr(cfg, "cfg", {
+            "model": {"provider": "openai-api", "default": "gpt-5.5"},
+        })
+        _model, provider, _base_url = cfg.resolve_model_provider("gpt-5.5")
+        assert provider == "openai-api"
+
+    def test_model_with_provider_context_preserves_openai_api(self, monkeypatch):
+        monkeypatch.setattr(cfg, "cfg", {
+            "model": {"provider": "openai-api", "default": "gpt-5.5"},
+        })
+        result = cfg.model_with_provider_context("gpt-5.5", "openai-api")
+        assert "openai" not in result or "openai-api" in result

--- a/tests/test_openai_api_provider_alias.py
+++ b/tests/test_openai_api_provider_alias.py
@@ -1,0 +1,33 @@
+"""openai-api → openai provider alias.
+
+hermes-agent reports its built-in OpenAI provider as ``openai-api``
+(the slug in ``hermes_cli.auth.PROVIDER_REGISTRY``).  Without an alias,
+GPT models from that provider slug are invisible in the WebUI model
+picker because the slug doesn't match the ``openai`` group key in
+``_PROVIDER_MODELS``.
+
+Same shape as #815 (``z.ai`` → ``zai``) and #1384 (``local`` →
+``custom``).
+"""
+
+import api.config as cfg
+
+
+class TestOpenaiApiProviderAlias:
+    """``_resolve_provider_alias`` must rewrite ``openai-api`` → ``openai``."""
+
+    def test_openai_api_resolves_to_openai(self):
+        assert cfg._resolve_provider_alias("openai-api") == "openai"
+
+    def test_openai_api_case_insensitive(self):
+        assert cfg._resolve_provider_alias("OPENAI-API") == "openai"
+        assert cfg._resolve_provider_alias("OpenAI-API") == "openai"
+
+    def test_alias_table_contains_entry(self):
+        assert cfg._PROVIDER_ALIASES.get("openai-api") == "openai", (
+            "_PROVIDER_ALIASES must map 'openai-api' → 'openai'"
+        )
+
+    def test_openai_canonical_unchanged(self):
+        """The canonical slug 'openai' must pass through unchanged."""
+        assert cfg._resolve_provider_alias("openai") == "openai"


### PR DESCRIPTION
Fixes #3443.

## Thinking Path

- hermes-agent's `PROVIDER_REGISTRY` uses the slug `openai-api` for its built-in OpenAI provider (the one activated by `OPENAI_API_KEY` / `OPENAI_BASE_URL` env vars, distinct from `openai-codex` which reads `~/.codex/auth.json`).
- The WebUI model picker groups models by canonical provider slug via `_resolve_provider_alias`, but `_PROVIDER_ALIASES` has no entry for `openai-api`. The slug passes through unchanged, doesn't match the `openai` key in `_PROVIDER_MODELS`, and falls into the `else` branch of the group builder.
- GPT models from the `openai-api` provider are either silently dropped from the picker or misattributed to OpenRouter (if OR also lists them).
- This is the same shape as #815 (`z.ai` → `zai`) and #1384 (`local` → `custom`): a provider slug mismatch resolved by a one-line alias table entry.

## What Changed

- **`api/config.py`** — Added `"openai-api": "openai"` to `_PROVIDER_ALIASES` with a comment explaining the provenance of the slug and referencing #815 and #1384 as precedent.
- **`tests/test_openai_api_provider_alias.py`** — New test file (4 tests) following the pattern of `test_issue1384_local_provider.py`:
  - `test_openai_api_resolves_to_openai` — the alias resolves correctly
  - `test_openai_api_case_insensitive` — uppercase and mixed-case variants also resolve
  - `test_alias_table_contains_entry` — the raw dict entry exists (guards against accidental removal)
  - `test_openai_canonical_unchanged` — the canonical slug `openai` passes through unchanged

## Why It Matters

Users who configure hermes-agent with `OPENAI_API_KEY` + `OPENAI_BASE_URL` (the `openai-api` provider path) see their GPT models missing from the WebUI model picker. The models are available to the agent but invisible in the UI.

## Verification

```
pytest tests/test_openai_api_provider_alias.py -v --timeout=60
pytest tests/test_byok_model_dropdown.py -v --timeout=60
pytest tests/test_issue1384_local_provider.py -v --timeout=60
```

All 33 tests pass (4 new + 20 existing BYOK + 9 existing #1384).

Manual: configure `OPENAI_API_KEY` and `OPENAI_BASE_URL` in `.env`, open the model picker, confirm GPT models appear under the OpenAI group.

## Risks / Follow-ups

- **Low risk.** One data entry in an alias table with clear precedent. No logic changes.
- The adjacent slug `openai-codex` (auto-discovered from `~/.codex/auth.json`) is already handled by hermes-agent's own provider registry and doesn't need a WebUI alias, but could be added defensively in a future PR.

## Model Used

Claude Opus 4.6 via Claude Code CLI