### PR TITLE
fix(server): disable SO_REUSEADDR to prevent silent port sharing (#3289)

### DIFF
--- a/server.py
+++ b/server.py
@@ -173,7 +173,6 @@ from api.updates import WEBUI_VERSION
 
 class QuietHTTPServer(ThreadingHTTPServer):
     """Custom HTTP server that silently handles common network errors."""
-    allow_reuse_address = False  # prevent silent port sharing (#3289)
     daemon_threads = True
     request_queue_size = 64
 
@@ -184,6 +183,13 @@ class QuietHTTPServer(ThreadingHTTPServer):
         super().__init__(*args, **kwargs)
         self.accept_loop_requests_total = 0
         self.accept_loop_last_request_at = 0.0
+
+    def server_bind(self):
+        if sys.platform == 'win32':
+            self.allow_reuse_address = False
+            SO_EXCLUSIVEADDRUSE = getattr(socket, 'SO_EXCLUSIVEADDRUSE', -5)
+            self.socket.setsockopt(socket.SOL_SOCKET, SO_EXCLUSIVEADDRUSE, 1)
+        super().server_bind()
 
     def _handle_request_noblock(self):
         """Record accept-loop progress before dispatching a request handler.
@@ -478,6 +484,25 @@ def _log_shutdown_audit(reason: str = "serve_forever_exit") -> None:
     )
 
 
+def _abort_if_already_serving(host: str, port: int) -> None:
+    """Refuse to start if a live HTTP server is already responding on this port."""
+    probe_host = '127.0.0.1' if host in ('0.0.0.0', '', '::') else host
+    try:
+        with socket.create_connection((probe_host, port), timeout=2) as s:
+            s.sendall(b'GET /health HTTP/1.0\r\nHost: localhost\r\n\r\n')
+            s.settimeout(2)
+            data = s.recv(512)
+            if data:
+                print(
+                    f'[!!] FATAL: Another server is already responding on'
+                    f' {probe_host}:{port}. Stop the existing instance first.',
+                    flush=True,
+                )
+                sys.exit(1)
+    except (ConnectionRefusedError, ConnectionResetError, OSError, socket.timeout):
+        pass
+
+
 def main() -> None:
     from api.config import print_startup_config, verify_hermes_imports, _HERMES_FOUND
 
@@ -573,6 +598,7 @@ def main() -> None:
     except Exception as e:
         print(f'[!!] WARNING: Plugin loading failed: {e}', flush=True)
 
+    _abort_if_already_serving(HOST, PORT)
     httpd = QuietHTTPServer((HOST, PORT), Handler)
 
     # ── TLS/HTTPS setup (optional) ─────────────────────────────────────────
@@ -598,6 +624,7 @@ def main() -> None:
     try:
         httpd.serve_forever()
     finally:
+        httpd.server_close()
         _log_shutdown_audit()
         # Stop the gateway watcher on shutdown
         try:

--- a/server.py
+++ b/server.py
@@ -173,6 +173,7 @@ from api.updates import WEBUI_VERSION
 
 class QuietHTTPServer(ThreadingHTTPServer):
     """Custom HTTP server that silently handles common network errors."""
+    allow_reuse_address = False  # prevent silent port sharing (#3289)
     daemon_threads = True
     request_queue_size = 64
 

--- a/tests/test_server_no_reuse_address.py
+++ b/tests/test_server_no_reuse_address.py
@@ -1,7 +1,0 @@
-"""QuietHTTPServer must NOT set SO_REUSEADDR — a second instance on the
-same port should fail loudly, not silently share traffic."""
-
-
-def test_allow_reuse_address_is_false():
-    from server import QuietHTTPServer
-    assert QuietHTTPServer.allow_reuse_address is False

--- a/tests/test_server_no_reuse_address.py
+++ b/tests/test_server_no_reuse_address.py
@@ -1,0 +1,7 @@
+"""QuietHTTPServer must NOT set SO_REUSEADDR — a second instance on the
+same port should fail loudly, not silently share traffic."""
+
+
+def test_allow_reuse_address_is_false():
+    from server import QuietHTTPServer
+    assert QuietHTTPServer.allow_reuse_address is False

--- a/tests/test_server_port_exclusivity.py
+++ b/tests/test_server_port_exclusivity.py
@@ -1,0 +1,90 @@
+"""Duplicate-instance guard: a second server on the same port must be detected
+and refused before bind, not silently shared (#3289)."""
+
+from __future__ import annotations
+
+import socket
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from tests._pytest_port import BASE
+
+
+# ── SO_EXCLUSIVEADDRUSE on Windows ──────────────────────────────────────────
+
+@pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only socket option')
+def test_exclusive_addr_use_set_on_windows():
+    from server import QuietHTTPServer
+    port = BASE + 901
+    httpd = QuietHTTPServer(('127.0.0.1', port), BaseHTTPRequestHandler)
+    try:
+        val = httpd.socket.getsockopt(
+            socket.SOL_SOCKET,
+            getattr(socket, 'SO_EXCLUSIVEADDRUSE', -5),
+        )
+        assert val != 0, 'SO_EXCLUSIVEADDRUSE should be set on Windows'
+    finally:
+        httpd.server_close()
+
+
+# ── Live-listener probe ─────────────────────────────────────────────────────
+
+def test_probe_detects_live_server():
+    """_abort_if_already_serving must call sys.exit when a live server responds."""
+    from server import _abort_if_already_serving
+
+    port = BASE + 902
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'ok')
+        def log_message(self, *a):
+            pass
+
+    httpd = HTTPServer(('127.0.0.1', port), Handler)
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        with pytest.raises(SystemExit):
+            _abort_if_already_serving('127.0.0.1', port)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def test_probe_allows_startup_when_nothing_listening():
+    """_abort_if_already_serving must return normally on a free port."""
+    from server import _abort_if_already_serving
+
+    port = BASE + 903
+    _abort_if_already_serving('127.0.0.1', port)
+
+
+def test_probe_allows_startup_on_unresponsive_socket():
+    """A socket that accepts but never responds (e.g. dying instance still in
+    kernel backlog) should not block startup."""
+    from server import _abort_if_already_serving
+
+    port = BASE + 904
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(('127.0.0.1', port))
+    srv.listen(1)
+    try:
+        _abort_if_already_serving('127.0.0.1', port)
+    finally:
+        srv.close()
+
+
+def test_probe_normalizes_wildcard_host():
+    """0.0.0.0 and :: should probe 127.0.0.1, not the literal wildcard."""
+    from server import _abort_if_already_serving
+
+    port = BASE + 905
+    _abort_if_already_serving('0.0.0.0', port)
+    _abort_if_already_serving('::', port)

--- a/tests/test_server_port_exclusivity.py
+++ b/tests/test_server_port_exclusivity.py
@@ -10,7 +10,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
-from tests._pytest_port import BASE
+from tests._pytest_port import TEST_PORT
 
 
 # ── SO_EXCLUSIVEADDRUSE on Windows ──────────────────────────────────────────
@@ -18,7 +18,7 @@ from tests._pytest_port import BASE
 @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only socket option')
 def test_exclusive_addr_use_set_on_windows():
     from server import QuietHTTPServer
-    port = BASE + 901
+    port = TEST_PORT + 901
     httpd = QuietHTTPServer(('127.0.0.1', port), BaseHTTPRequestHandler)
     try:
         val = httpd.socket.getsockopt(
@@ -36,7 +36,7 @@ def test_probe_detects_live_server():
     """_abort_if_already_serving must call sys.exit when a live server responds."""
     from server import _abort_if_already_serving
 
-    port = BASE + 902
+    port = TEST_PORT + 902
 
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self):  # noqa: N802
@@ -61,7 +61,7 @@ def test_probe_allows_startup_when_nothing_listening():
     """_abort_if_already_serving must return normally on a free port."""
     from server import _abort_if_already_serving
 
-    port = BASE + 903
+    port = TEST_PORT + 903
     _abort_if_already_serving('127.0.0.1', port)
 
 
@@ -70,7 +70,7 @@ def test_probe_allows_startup_on_unresponsive_socket():
     kernel backlog) should not block startup."""
     from server import _abort_if_already_serving
 
-    port = BASE + 904
+    port = TEST_PORT + 904
     srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     srv.bind(('127.0.0.1', port))
@@ -85,6 +85,6 @@ def test_probe_normalizes_wildcard_host():
     """0.0.0.0 and :: should probe 127.0.0.1, not the literal wildcard."""
     from server import _abort_if_already_serving
 
-    port = BASE + 905
+    port = TEST_PORT + 905
     _abort_if_already_serving('0.0.0.0', port)
     _abort_if_already_serving('::', port)


### PR DESCRIPTION
## Thinking Path

- On Windows, `SO_REUSEADDR` allows multiple processes to bind the same port simultaneously; requests route unpredictably between them. On macOS, #3289 documented the same symptom between a manually started instance and a launchd-managed one.
- The original approach, setting `allow_reuse_address = False`, catches the double-bind but breaks legitimate fast restart: after any accepted connection, the socket enters TIME_WAIT for ~60s on Linux/macOS, so `ctl.sh restart` and the `os.execv` self-update path in `api/updates.py` both fail with EADDRINUSE.
- The reworked approach separates the two concerns: a **live-listener probe** before bind detects actively-serving instances (connect + `GET /health`), while `SO_REUSEADDR` stays enabled for TIME_WAIT rebind. On Windows specifically, `SO_EXCLUSIVEADDRUSE` replaces the `SO_REUSEADDR` suppression to prevent port hijacking at the kernel level.
- A dying instance, one that's past `serve_forever()`, accepts TCP connections via kernel backlog but never processes HTTP requests. The probe times out and startup proceeds. That's what makes it safe for `ctl.sh restart` during the brief overlap between stop and start.
- Added `httpd.server_close()` to the shutdown `finally` block so the listening socket is released immediately rather than lingering through cleanup.

## What Changed

- **`server.py`**: Removed `allow_reuse_address = False`. Added `_abort_if_already_serving(host, port)`, a pre-bind probe that connects to the port, sends `GET /health`, and aborts startup only if a live HTTP response comes back. Added `server_bind()` override on `QuietHTTPServer` that sets `SO_EXCLUSIVEADDRUSE` on Windows. Added `httpd.server_close()` to the shutdown path.
- **`tests/test_server_port_exclusivity.py`** (new, replaces `test_server_no_reuse_address.py`): Probe detection (live server → SystemExit), probe passthrough (free port, unresponsive socket, wildcard host normalization), and `SO_EXCLUSIVEADDRUSE` assertion on Windows.

## Why It Matters

A second webui instance silently sharing the same port causes unpredictable request routing, split session state, and confusing behavior that is difficult to diagnose. The fix detects live instances before bind without breaking the fast-restart paths that `ctl.sh` and the self-update mechanism depend on.

## Verification

- `python -m pytest tests/test_server_port_exclusivity.py -v --timeout=60`
- Manual: start the webui, then attempt to start a second instance on the same port; confirm it prints `[!!] FATAL: Another server is already responding on ...` and exits.
- Manual: `ctl.sh restart` completes without EADDRINUSE on Linux/macOS.

## Risks / Follow-ups

- **Probe timeout adds ~2s worst-case to cold start** when something is listening on the port but not responding to HTTP. In practice this only happens during the brief `ctl.sh restart` overlap, and the 2s is concurrent with the old instance's shutdown cleanup.
- **`ctl.sh` already has its own pidfile-based guard** (`_current_pid` in `start_cmd`). The Python-level probe catches cases that bypass `ctl.sh`: direct `python server.py` invocations, Windows Task Scheduler, and the `os.execv` self-update path.
- **`SO_EXCLUSIVEADDRUSE` is Windows-only.** On Linux/macOS the probe is the sole guard, which is sufficient since POSIX `SO_REUSEADDR` only affects TIME_WAIT, not active-listener sharing.

## Model Used

Claude Opus 4.6 via Claude Code CLI