### PR TITLE
feat(#1952): native Windows support for bootstrap and terminal

### DIFF
--- a/api/terminal.py
+++ b/api/terminal.py
@@ -11,19 +11,28 @@ from __future__ import annotations
 import errno
 import atexit
 import codecs
-import fcntl
 import os
 import queue
-import select
 import shutil
 import signal
 import struct
 import subprocess
-import termios
+import sys
 import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+
+_TERMINAL_SUPPORTED = sys.platform != "win32"
+
+if _TERMINAL_SUPPORTED:
+    import fcntl
+    import select
+    import termios
+else:
+    fcntl = None  # type: ignore[assignment]
+    select = None  # type: ignore[assignment]
+    termios = None  # type: ignore[assignment]
 
 
 def _set_nonblocking(fd: int) -> None:
@@ -175,7 +184,8 @@ def _ensure_spawn_supervisor() -> None:
         _spawn_supervisor_started = True
 
 
-_ensure_spawn_supervisor()
+if _TERMINAL_SUPPORTED:
+    _ensure_spawn_supervisor()
 
 
 # NOTE on parent-death-signal: a previous version of this module set
@@ -257,6 +267,8 @@ def _set_size(term: TerminalSession, rows: int, cols: int) -> None:
 
 def start_terminal(session_id: str, workspace: Path, rows: int = 24, cols: int = 80, restart: bool = False) -> TerminalSession:
     """Start or return the embedded terminal for a WebUI session."""
+    if not _TERMINAL_SUPPORTED:
+        raise NotImplementedError("Embedded terminal is not supported on Windows")
     sid = str(session_id or "").strip()
     if not sid:
         raise ValueError("session_id is required")
@@ -346,6 +358,8 @@ def start_terminal(session_id: str, workspace: Path, rows: int = 24, cols: int =
 
 
 def get_terminal(session_id: str) -> TerminalSession | None:
+    if not _TERMINAL_SUPPORTED:
+        return None
     with _LOCK:
         term = _TERMINALS.get(str(session_id or ""))
         if term and term.is_alive():
@@ -354,6 +368,8 @@ def get_terminal(session_id: str) -> TerminalSession | None:
 
 
 def write_terminal(session_id: str, data: str) -> None:
+    if not _TERMINAL_SUPPORTED:
+        raise NotImplementedError("Embedded terminal is not supported on Windows")
     term = get_terminal(session_id)
     if not term or not term.is_alive():
         raise KeyError("terminal not running")
@@ -361,6 +377,8 @@ def write_terminal(session_id: str, data: str) -> None:
 
 
 def resize_terminal(session_id: str, rows: int, cols: int) -> None:
+    if not _TERMINAL_SUPPORTED:
+        raise NotImplementedError("Embedded terminal is not supported on Windows")
     term = get_terminal(session_id)
     if not term:
         raise KeyError("terminal not running")
@@ -368,6 +386,8 @@ def resize_terminal(session_id: str, rows: int, cols: int) -> None:
 
 
 def close_terminal(session_id: str) -> bool:
+    if not _TERMINAL_SUPPORTED:
+        return False
     sid = str(session_id or "")
     with _LOCK:
         term = _TERMINALS.pop(sid, None)

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -92,9 +92,9 @@ def is_wsl() -> bool:
 
 def ensure_supported_platform() -> None:
     if platform.system() == "Windows" and not is_wsl():
-        raise RuntimeError(
-            "Native Windows is not supported for this bootstrap yet. "
-            "Please run it from Linux, macOS, or inside WSL2."
+        info(
+            "Warning: Native Windows bootstrap is experimental. "
+            "Embedded terminal and auto-install are not supported."
         )
 
 
@@ -270,6 +270,11 @@ def hermes_command_exists() -> bool:
 
 
 def install_hermes_agent() -> None:
+    if platform.system() == "Windows" and not is_wsl():
+        raise RuntimeError(
+            "Auto-install is not supported on native Windows. "
+            "Install hermes-agent manually first."
+        )
     info(f"Hermes Agent not found. Attempting install via {INSTALLER_URL}")
     subprocess.run(
         ["/bin/bash", "-lc", f"curl -fsSL {INSTALLER_URL} | bash"], check=True
@@ -444,8 +449,13 @@ def main() -> int:
                 f"Set HERMES_WEBUI_PYTHON to a working interpreter or fix "
                 f"the agent venv at {agent_dir}."
             )
-        # os.execv replaces the current process image. Anything after this line
-        # only runs if execv itself fails (it raises OSError on failure).
+        # os.execv replaces the current process image. On Windows, execv
+        # spawns a new process instead of replacing (Python calls CreateProcess),
+        # orphaning it from any supervisor. Use Popen + exit there instead.
+        if sys.platform == "win32":
+            subprocess.Popen([python_exe, server_path],
+                             creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+            sys.exit(0)
         os.execv(python_exe, [python_exe, server_path])
         # Unreachable — execv either replaces the process or raises.
         raise RuntimeError("os.execv returned unexpectedly")

--- a/tests/test_windows_native_support.py
+++ b/tests/test_windows_native_support.py
@@ -1,0 +1,209 @@
+"""Tests for native Windows support (terminal.py POSIX guards + bootstrap.py unblock).
+
+terminal.py guards:
+- _TERMINAL_SUPPORTED is False on Windows, True on POSIX
+- Terminal functions raise NotImplementedError on Windows
+- close_terminal returns False (no-op) on Windows
+- get_terminal returns None on Windows
+- Module imports cleanly on Windows (no fcntl/termios ImportError)
+
+bootstrap.py unblock:
+- ensure_supported_platform does not raise on Windows
+- install_hermes_agent raises RuntimeError on Windows (calls /bin/bash)
+- Foreground path uses Popen + sys.exit on Windows instead of os.execv
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+# ── terminal.py tests ────────────────────────────────────────────────────────
+
+
+class TestTerminalPosixGuard:
+    """Verify _TERMINAL_SUPPORTED flag and import guards."""
+
+    def test_terminal_supported_matches_platform(self):
+        from api import terminal
+        if sys.platform == "win32":
+            assert not terminal._TERMINAL_SUPPORTED
+        else:
+            assert terminal._TERMINAL_SUPPORTED
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only check")
+    def test_posix_modules_are_loaded(self):
+        from api import terminal
+        assert terminal.fcntl is not None
+        assert terminal.select is not None
+        assert terminal.termios is not None
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only check")
+    def test_windows_modules_are_none(self):
+        from api import terminal
+        assert terminal.fcntl is None
+        assert terminal.select is None
+        assert terminal.termios is None
+
+
+class TestTerminalWindowsFunctions:
+    """Terminal functions should fail gracefully on Windows."""
+
+    @pytest.fixture(autouse=True)
+    def _force_unsupported(self, monkeypatch):
+        """Force _TERMINAL_SUPPORTED=False regardless of actual platform."""
+        from api import terminal
+        monkeypatch.setattr(terminal, "_TERMINAL_SUPPORTED", False)
+
+    def test_start_terminal_raises(self, tmp_path):
+        from api.terminal import start_terminal
+        with pytest.raises(NotImplementedError, match="not supported on Windows"):
+            start_terminal("test-session", tmp_path)
+
+    def test_write_terminal_raises(self):
+        from api.terminal import write_terminal
+        with pytest.raises(NotImplementedError, match="not supported on Windows"):
+            write_terminal("test-session", "hello")
+
+    def test_resize_terminal_raises(self):
+        from api.terminal import resize_terminal
+        with pytest.raises(NotImplementedError, match="not supported on Windows"):
+            resize_terminal("test-session", 24, 80)
+
+    def test_close_terminal_returns_false(self):
+        from api.terminal import close_terminal
+        assert close_terminal("test-session") is False
+
+    def test_get_terminal_returns_none(self):
+        from api.terminal import get_terminal
+        assert get_terminal("test-session") is None
+
+
+# ── bootstrap.py tests ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def import_bootstrap():
+    """Import bootstrap freshly to avoid module-level state bleed."""
+    if "bootstrap" in sys.modules:
+        del sys.modules["bootstrap"]
+    import bootstrap as bs
+    return bs
+
+
+class TestBootstrapWindowsUnblock:
+
+    def test_ensure_supported_platform_does_not_raise_on_windows(self, import_bootstrap, monkeypatch):
+        monkeypatch.setattr("platform.system", lambda: "Windows")
+        monkeypatch.setattr(import_bootstrap, "is_wsl", lambda: False)
+        # Should print a warning, not raise
+        import_bootstrap.ensure_supported_platform()
+
+    def test_ensure_supported_platform_still_passes_on_posix(self, import_bootstrap, monkeypatch):
+        monkeypatch.setattr("platform.system", lambda: "Linux")
+        import_bootstrap.ensure_supported_platform()
+
+    def test_install_hermes_agent_raises_on_windows(self, import_bootstrap, monkeypatch):
+        monkeypatch.setattr("platform.system", lambda: "Windows")
+        monkeypatch.setattr(import_bootstrap, "is_wsl", lambda: False)
+        with pytest.raises(RuntimeError, match="not supported on native Windows"):
+            import_bootstrap.install_hermes_agent()
+
+    def test_install_hermes_agent_allowed_in_wsl(self, import_bootstrap, monkeypatch):
+        """WSL should still be able to auto-install (it has /bin/bash)."""
+        monkeypatch.setattr("platform.system", lambda: "Windows")
+        monkeypatch.setattr(import_bootstrap, "is_wsl", lambda: True)
+        # Should not raise the Windows guard; may raise from subprocess instead
+        with pytest.raises(Exception) as exc_info:
+            import_bootstrap.install_hermes_agent()
+        assert "not supported on native Windows" not in str(exc_info.value)
+
+
+class TestBootstrapForegroundWindows:
+    """Foreground path uses Popen + sys.exit on Windows instead of os.execv."""
+
+    @pytest.fixture
+    def stub_main_dependencies(self, monkeypatch, tmp_path):
+        import bootstrap as bs
+        monkeypatch.setattr(bs, "ensure_supported_platform", lambda: None)
+        monkeypatch.setattr(bs, "discover_agent_dir", lambda: tmp_path / "agent")
+        monkeypatch.setattr(bs, "hermes_command_exists", lambda: True)
+        python_exe = sys.executable
+        monkeypatch.setattr(bs, "discover_launcher_python", lambda *a: python_exe)
+        monkeypatch.setattr(bs, "ensure_python_has_webui_deps", lambda *a, **kw: a[0])
+        monkeypatch.setattr(bs, "wait_for_health", lambda *a, **kw: True)
+        monkeypatch.setattr(bs, "open_browser", lambda *a, **kw: None)
+        monkeypatch.setenv("HERMES_WEBUI_STATE_DIR", str(tmp_path / "state"))
+        (tmp_path / "agent").mkdir(parents=True, exist_ok=True)
+        return bs
+
+    def test_foreground_uses_popen_on_windows(self, stub_main_dependencies, monkeypatch):
+        """On win32, foreground mode should use Popen + sys.exit, not os.execv."""
+        bs = stub_main_dependencies
+        monkeypatch.setattr(sys, "argv", ["bootstrap.py", "--foreground"])
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(os, "chdir", lambda p: None)
+
+        # Strip supervisor env vars that would interfere
+        for var in ("INVOCATION_ID", "JOURNAL_STREAM", "NOTIFY_SOCKET",
+                    "XPC_SERVICE_NAME", "SUPERVISOR_ENABLED", "HERMES_WEBUI_FOREGROUND"):
+            monkeypatch.delenv(var, raising=False)
+
+        popen_calls = []
+        execv_calls = []
+
+        class FakePopen:
+            pid = 12345
+            def __init__(self, *args, **kwargs):
+                popen_calls.append((args, kwargs))
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setattr(os, "execv", lambda *a: execv_calls.append(a))
+
+        with pytest.raises(SystemExit) as ei:
+            bs.main()
+        assert ei.value.code == 0
+        assert len(popen_calls) == 1, "Windows foreground should use Popen"
+        assert len(execv_calls) == 0, "Windows foreground must NOT use execv"
+
+    def test_foreground_uses_execv_on_posix(self, stub_main_dependencies, monkeypatch):
+        """On POSIX, foreground mode should still use os.execv."""
+        bs = stub_main_dependencies
+        monkeypatch.setattr(sys, "argv", ["bootstrap.py", "--foreground"])
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(os, "chdir", lambda p: None)
+
+        for var in ("INVOCATION_ID", "JOURNAL_STREAM", "NOTIFY_SOCKET",
+                    "XPC_SERVICE_NAME", "SUPERVISOR_ENABLED", "HERMES_WEBUI_FOREGROUND"):
+            monkeypatch.delenv(var, raising=False)
+
+        execv_calls = []
+        popen_calls = []
+
+        def fake_execv(path, argv):
+            execv_calls.append((path, argv))
+            raise SystemExit(0)
+
+        monkeypatch.setattr(os, "execv", fake_execv)
+
+        class FakePopen:
+            pid = 12345
+            def __init__(self, *args, **kwargs):
+                popen_calls.append((args, kwargs))
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+        with pytest.raises(SystemExit) as ei:
+            bs.main()
+        assert ei.value.code == 0
+        assert len(execv_calls) == 1, "POSIX foreground should use execv"
+        assert len(popen_calls) == 0, "POSIX foreground must NOT use Popen"


### PR DESCRIPTION


- `fix(terminal): guard POSIX-only imports for Windows compatibility`
- `feat(bootstrap): unblock native Windows bootstrap`

---

### Thinking Path

- #1952 showed that hermes-webui already runs natively on Windows when you bypass the bootstrap platform check and call `python server.py` directly.
- Since then, four Windows bugs were fixed upstream: #3170 (`O_DIRECTORY`), #3171 (`commonpath`), #2840 (`HERMES_HOME`), #741 (GBK encoding). The codebase is more Windows-ready than the bootstrap guard gives it credit for.
- Two things still block a clean `python bootstrap.py`: (1) `api/terminal.py` hard-imports `fcntl`/`termios`/`select` at module level, crashing the import on Windows even when the terminal is never used; (2) `bootstrap.py:94` raises `RuntimeError` before anything else runs.
- The terminal has no Windows equivalent (`fcntl`/`termios`/`pty` are POSIX-only), but it's optional, just a slash command, not part of core chat. Guarding the imports and raising `NotImplementedError` at the function boundary follows the existing pattern from `api/turn_journal.py:18` and `api/providers.py:28`.
- The bootstrap block can safely become a warning: `discover_agent_dir()`, `ensure_python_has_webui_deps()`, and `api/paths.py` all handle Windows already. Two sub-features need their own guards: `install_hermes_agent()` (calls `/bin/bash`) and the foreground `os.execv` path (on Windows, Python's `execv` uses `CreateProcess` instead of replacing the process image, orphaning the child from supervisors).

### What Changed

- **`api/terminal.py`**: Moved `fcntl`, `select`, `termios` imports behind a `_TERMINAL_SUPPORTED = sys.platform != "win32"` guard. Added `NotImplementedError` early returns to `start_terminal`, `write_terminal`, `resize_terminal`. `close_terminal` returns `False` (no-op), `get_terminal` returns `None`. Guarded the module-level `_ensure_spawn_supervisor()` call. Pattern matches `api/turn_journal.py:18` and `api/providers.py:28`.

- **`bootstrap.py`**: Replaced `RuntimeError` in `ensure_supported_platform()` with a warning via `info()`. Added `RuntimeError` guard in `install_hermes_agent()` (calls `/bin/bash`, which does not exist on native Windows). Added `sys.platform == "win32"` branch in the foreground path to use `subprocess.Popen` + `sys.exit(0)` instead of `os.execv` (which on Windows spawns a child process rather than replacing the image, orphaning it from supervisors).

- **`tests/test_windows_native_support.py`**: 14 tests covering both changes. Terminal tests verify `_TERMINAL_SUPPORTED` flag, `NotImplementedError` on Windows, and graceful no-ops for `close_terminal`/`get_terminal`. Bootstrap tests verify `ensure_supported_platform` does not raise, `install_hermes_agent` raises on Windows, and the foreground path routes to Popen on Windows vs execv on POSIX.

### Why It Matters

Windows users can run `python bootstrap.py` (or `python server.py`) natively without WSL. The chat, model picker, workspace, and all non-terminal features work. The terminal gracefully reports "not supported" instead of crashing the server import.

### Verification

```bash
# Unit tests (--noconftest because upstream conftest.py test_server has a pre-existing
# Windows symlink privilege issue unrelated to this PR)
python -m pytest tests/test_windows_native_support.py -v --timeout=60 --noconftest

# Manual: start the server on Windows
python bootstrap.py --foreground

# Manual: verify terminal endpoint returns clean error
curl -X POST http://127.0.0.1:8787/api/terminal/start -H "Content-Type: application/json" -d '{"session_id":"test","workspace":"C:\\Users"}'
# Expected: 500 with "Embedded terminal is not supported on Windows"
```

### Risks / Follow-ups

- **No PTY on Windows**: The embedded terminal relies on `os.openpty()` and POSIX signals (`SIGHUP`, `SIGWINCH`, `SIGKILL`). A Windows equivalent would need ConPTY or similar, which is a separate feature.
- **`os.killpg` in `close_terminal`/`_reap_abandoned_spawn`**: These POSIX-only calls are unreachable on Windows because `start_terminal` guards early, but a future refactor should consider them.
- **conftest.py symlink issue**: The upstream `tests/conftest.py:537` calls `symlink_to()` which fails on Windows without developer mode. This is pre-existing and unrelated to this PR; tests must run with `--noconftest` on Windows.
- **`scripts/windows/setup_webui_autostart.ps1`**: Existing script targets WSL. A native Windows autostart script (Task Scheduler) could be a follow-up.

### Model Used

Claude Opus 4.6 via Claude Code CLI
