### PR TITLE
Release v0.51.226 — Release GT (stage-p9 — mobile composer context-usage ring #3062 + activity-feed default-expand setting #3080)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 ## [Unreleased]
 
+## [v0.51.226] — 2026-06-03 — Release GT (stage-p9 — mobile composer context-usage ring + activity-feed default-expand setting)
+
+### Added
+- **Settings → Appearance: "Expand activity feed by default"** — a new checkbox (default off) that expands new Activity disclosures by default as turns arrive. Manual per-turn collapse/expand still wins (an explicit user toggle is preserved), and live "Waiting on model" rows now explain what the agent is doing before and after tool calls (#3080, @AJV20).
+
+### Changed
+- The mobile composer's config button now shows a **context-usage ring** (an SVG progress ring with a centered percentage) in place of the static sliders icon, color-coded green (≤50%) / orange (≤85%) / red (>85%) and reset to 0% on a new session, so context-window pressure is visible at a glance on mobile (#3062, @NottheGuy007).
+
 ## [v0.51.225] — 2026-06-03 — Release GS (stage-p7 — remote gateway health probe resolves gateway_state)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -4949,6 +4949,7 @@ _SETTINGS_DEFAULTS = {
     "font_size": "default",  # small | default | large | xlarge
     "session_jump_buttons": False,  # show Start/End transcript jump pills
     "session_endless_scroll": False,  # auto-load older transcript pages while scrolling upward
+    "activity_feed_expanded_default": False,  # expand Activity disclosures by default for new turns
     "pinned_sessions_limit": 3,  # maximum active pinned sessions shown in the sidebar
     "inflight_state_max_sessions": 8,  # max active-stream recovery snapshots kept in browser localStorage
     "inflight_state_max_messages": 24,  # max recent messages kept per recovery snapshot
@@ -5113,6 +5114,7 @@ _SETTINGS_BOOL_KEYS = {
     "api_redact_enabled",
     "session_jump_buttons",
     "session_endless_scroll",
+    "activity_feed_expanded_default",
 }
 # Language codes are validated as short alphanumeric BCP-47-like tags (e.g. 'en', 'zh', 'fr')
 _SETTINGS_LANG_RE = __import__("re").compile(r"^[a-zA-Z]{2,10}(-[a-zA-Z0-9]{2,8})?$")

--- a/static/boot.js
+++ b/static/boot.js
@@ -1682,6 +1682,7 @@ function applyBotName(){
     window._whatsNewSummaryEnabled=!!s.whats_new_summary_enabled;
     window._showThinking=s.show_thinking!==false;
     window._simplifiedToolCalling=s.simplified_tool_calling!==false;
+    window._activityFeedExpandedDefault=!!s.activity_feed_expanded_default;
     window._sidebarDensity=(s.sidebar_density==='detailed'?'detailed':'compact');
     window._pinnedSessionsLimit=parseInt(s.pinned_sessions_limit||3,10)||3;
     window._inflightStateLimits={

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -539,6 +539,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Load older messages while scrolling up',
 
     settings_desc_session_endless_scroll: 'When enabled, older messages load automatically as you scroll upward. When disabled, use the older-messages button.',
+    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
+    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Sidebar tabs',
     settings_desc_tab_visibility: 'Choose which tabs appear in the sidebar and rail. Chat and Settings are always visible.',
@@ -1870,6 +1872,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Carica messaggi precedenti scorrendo in alto',
 
     settings_desc_session_endless_scroll: 'Se abilitato, i messaggi precedenti si caricano automaticamente scorrendo in alto. Se disabilitato, usa il pulsante messaggi precedenti.',
+    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
+    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Schede della barra laterale',
     settings_desc_tab_visibility: 'Scegli quali schede mostrare nella barra laterale e nel rail. Chat e Impostazioni sono sempre visibili.',
@@ -3193,6 +3197,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: '上スクロールで古いメッセージを読み込む',
 
     settings_desc_session_endless_scroll: '有効にすると、上にスクロールしたとき古いメッセージを自動で読み込みます。無効の場合は古いメッセージボタンを使います。',
+    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
+    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'サイドバータブ',
     settings_desc_tab_visibility: 'サイドバーとレールに表示するタブを選択します。チャットと設定は常に表示されます。',
@@ -5090,6 +5096,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Загружать старые сообщения при прокрутке вверх',
 
     settings_desc_session_endless_scroll: 'Если включено, старые сообщения загружаются автоматически при прокрутке вверх. Если выключено, используйте кнопку загрузки старых сообщений.',
+    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
+    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Вкладки боковой панели',
     settings_desc_tab_visibility: 'Выберите, какие вкладки отображаются на боковой панели и в рейле. Чат и настройки всегда видны.',
@@ -6338,6 +6346,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Cargar mensajes antiguos al desplazarse hacia arriba',
 
     settings_desc_session_endless_scroll: 'Si está activado, los mensajes antiguos se cargan automáticamente al desplazarte hacia arriba. Si está desactivado, usa el botón de mensajes antiguos.',
+    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
+    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Pestañas de la barra lateral',
     settings_desc_tab_visibility: 'Elige qué pestañas aparecen en la barra lateral y el rail. Chat y Configuración siempre están visibles.',
@@ -7299,6 +7309,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Ältere Nachrichten beim Hochscrollen laden',
 
     settings_desc_session_endless_scroll: 'Wenn aktiviert, werden ältere Nachrichten beim Hochscrollen automatisch geladen. Wenn deaktiviert, nutzt du den Button für ältere Nachrichten.',
+    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
+    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Seitenleiste-Tabs',
     settings_desc_tab_visibility: 'Wähle, welche Tabs in der Seitenleiste und im Rail angezeigt werden. Chat und Einstellungen sind immer sichtbar.',
@@ -8869,6 +8881,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: '向上滚动时加载更早的消息',
 
     settings_desc_session_endless_scroll: '启用后，向上滚动时会自动加载更早的消息。禁用时请使用加载更早消息按钮。',
+    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
+    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: '侧边栏标签',
     settings_desc_tab_visibility: '选择在侧边栏和导航栏中显示哪些标签。聊天和设置始终可见。',
@@ -9557,6 +9571,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: '向上捲動時載入較早訊息',
 
     settings_desc_session_endless_scroll: '啟用後，向上捲動時會自動載入較早訊息。停用時請使用載入較早訊息按鈕。',
+    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
+    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: '側邊欄標籤',
     settings_desc_tab_visibility: '選擇在側邊欄和導覽列中顯示哪些標籤。聊天和設定始終可見。',
@@ -10771,6 +10787,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Carregar mensagens antigas ao rolar para cima',
 
     settings_desc_session_endless_scroll: 'Quando ativado, mensagens antigas carregam automaticamente ao rolar para cima. Quando desativado, use o botão de mensagens antigas.',
+    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
+    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Abas da barra lateral',
     settings_desc_tab_visibility: 'Escolha quais abas aparecem na barra lateral e no rail. Chat e Configurações estão sempre visíveis.',
@@ -11996,6 +12014,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: '위로 스크롤할 때 이전 메시지 불러오기',
 
     settings_desc_session_endless_scroll: '활성화하면 위로 스크롤할 때 이전 메시지를 자동으로 불러옵니다. 비활성화하면 이전 메시지 버튼을 사용합니다.',
+    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
+    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: '사이드바 탭',
     settings_desc_tab_visibility: '사이드바와 레일에 표시할 탭을 선택하세요. 채팅과 설정은 항상 표시됩니다.',
@@ -13237,6 +13257,8 @@ const LOCALES = {
     settings_desc_session_jump_buttons: 'Affichez les boutons flottants de début et de fin lors de la lecture de longs historiques de session.',
     settings_label_session_endless_scroll: 'Charger les anciens messages en faisant défiler vers le haut',
     settings_desc_session_endless_scroll: 'Lorsqu\'ils sont activés, les anciens messages se chargent automatiquement lorsque vous faites défiler vers le haut. Lorsqu\'il est désactivé, utilisez le bouton des messages plus anciens.',
+    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
+    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Onglets de la barre latérale',
     settings_desc_tab_visibility: 'Choisissez quels onglets apparaissent dans la barre latérale et le rail. Chat et Paramètres sont toujours visibles.',
@@ -14579,6 +14601,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Yukarı kaydırırken eski mesajları yükle',
 
     settings_desc_session_endless_scroll: 'Etkinleştirildiğinde, yukarı doğru kaydırdığınızda eski mesajlar otomatik olarak yüklenir. Devre dışı bırakıldığında eski mesajlar düğmesini kullanın.',
+    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
+    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Kenar çubuğu sekmeleri',
     settings_desc_tab_visibility: 'Kenar çubuğunda ve rayda hangi sekmelerin görüneceğini seçin. Sohbet ve Ayarlar her zaman görünür durumdadır.',

--- a/static/index.html
+++ b/static/index.html
@@ -988,6 +988,13 @@
               </label>
               <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_session_endless_scroll">When enabled, older messages load automatically as you scroll upward. When disabled, use the older-messages button.</div>
             </div>
+            <div class="settings-field" style="margin-top:8px">
+              <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+                <input type="checkbox" id="settingsActivityFeedExpandedDefault" style="width:15px;height:15px;accent-color:var(--accent)">
+                <span data-i18n="settings_label_activity_feed_expanded_default">Expand activity feed by default</span>
+              </label>
+              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_activity_feed_expanded_default">Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.</div>
+            </div>
             <div class="settings-field">
               <label id="tabVisibilityLabel" data-i18n="settings_label_tab_visibility">Sidebar tabs</label>
               <div id="tabVisibilityChips" class="tab-visibility-chips" role="group" aria-labelledby="tabVisibilityLabel"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -604,8 +604,7 @@
               </div>
             </div>
             <button class="icon-btn composer-mobile-config-btn" id="composerMobileConfigBtn" type="button" onclick="toggleMobileComposerConfig()" title="Workspace, model, reasoning, and context settings" aria-label="Workspace, model, reasoning, and context settings" aria-haspopup="true" aria-expanded="false" aria-controls="composerMobileConfigPanel">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
-              <span class="composer-mobile-ctx-badge" id="composerMobileCtxBadge" aria-hidden="true" style="display:none">0</span>
+              <svg id="composerMobileCtxRing" viewBox="0 0 36 36" width="24" height="24" style="display:block;overflow:visible;transform:rotate(-90deg)" aria-hidden="true"><circle cx="18" cy="18" r="14" fill="none" stroke="currentColor" stroke-width="3.5" opacity="0.2"/><circle id="ctx-arc" cx="18" cy="18" r="14" fill="none" stroke="#22c55e" stroke-width="3.5" stroke-dasharray="87.96 87.96" stroke-dashoffset="87.96" stroke-linecap="round"/><text id="ctx-num" x="18" y="18" text-anchor="middle" dominant-baseline="middle" style="transform:rotate(90deg);transform-origin:18px 18px;font-size:9px;font-weight:700;fill:currentColor;stroke:none">0</text></svg>
             </button>
             <div class="composer-model-wrap">
               <button class="composer-model-chip" id="composerModelChip" type="button" onclick="toggleModelDropdown()" title="Conversation model">

--- a/static/panels.js
+++ b/static/panels.js
@@ -5849,6 +5849,7 @@ function _appearancePayloadFromUi(){
     font_size: ($('settingsFontSize')||{}).value || localStorage.getItem('hermes-font-size') || 'default',
     session_jump_buttons: !!($('settingsSessionJumpButtons')||{}).checked,
     session_endless_scroll: !!($('settingsSessionEndlessScroll')||{}).checked,
+    activity_feed_expanded_default: !!($('settingsActivityFeedExpandedDefault')||{}).checked,
     hidden_tabs: _getHiddenTabs(),
   };
 }
@@ -5902,6 +5903,9 @@ async function _autosaveAppearanceSettings(payload){
       if(typeof _applySessionNavigationPrefs==='function') _applySessionNavigationPrefs();
     }
     window._sessionEndlessScrollEnabled=!!(saved&&saved.session_endless_scroll);
+    if(saved&&Object.prototype.hasOwnProperty.call(saved,'activity_feed_expanded_default')){
+      window._activityFeedExpandedDefault=!!saved.activity_feed_expanded_default;
+    }
     _setAppearanceAutosaveStatus('saved');
   }catch(e){
     console.warn('[settings] appearance autosave failed', e);
@@ -6113,6 +6117,15 @@ async function loadSettingsPanel(){
       window._sessionEndlessScrollEnabled=endlessScrollCb.checked;
       endlessScrollCb.onchange=function(){
         window._sessionEndlessScrollEnabled=this.checked;
+        _scheduleAppearanceAutosave();
+      };
+    }
+    const activityExpandedCb=$('settingsActivityFeedExpandedDefault');
+    if(activityExpandedCb){
+      activityExpandedCb.checked=!!settings.activity_feed_expanded_default;
+      window._activityFeedExpandedDefault=activityExpandedCb.checked;
+      activityExpandedCb.onchange=function(){
+        window._activityFeedExpandedDefault=this.checked;
         _scheduleAppearanceAutosave();
       };
     }

--- a/static/style.css
+++ b/static/style.css
@@ -1756,9 +1756,6 @@
      also matches. Without this, the button shows at desktop width — see #1381 review. */
   .icon-btn.composer-mobile-config-btn{display:none;}
   .composer-mobile-config-btn.active{background:var(--accent-bg);border-color:var(--accent-bg-strong);color:var(--text);opacity:1;}
-  .composer-mobile-ctx-badge{position:absolute;right:2px;bottom:2px;display:inline-flex;align-items:center;justify-content:center;min-width:16px;height:16px;padding:0 3px;border-radius:999px;background:var(--surface);border:1px solid var(--border2);color:var(--muted);font-size:8px;font-weight:700;line-height:1;font-variant-numeric:tabular-nums;box-shadow:0 1px 4px rgba(0,0,0,.28);pointer-events:none;}
-  .composer-mobile-ctx-badge.ctx-mid{color:var(--warning);border-color:var(--warning);}
-  .composer-mobile-ctx-badge.ctx-high{color:var(--error);border-color:var(--error);}
   .composer-mobile-config-panel{display:none;position:absolute;left:8px;right:8px;bottom:calc(100% + 6px);z-index:180;padding:8px;gap:8px;align-items:stretch;justify-content:flex-start;flex-wrap:wrap;background:var(--surface);border:1px solid var(--border2);border-radius:12px;box-shadow:0 -6px 28px rgba(0,0,0,.35);overflow:visible;}
   .composer-mobile-config-action{box-sizing:border-box;display:inline-flex;align-items:center;gap:10px;min-width:0;min-height:44px;padding:8px 10px;border-radius:10px;border:1px solid transparent;background:transparent;color:var(--muted);font:inherit;text-align:left;cursor:pointer;overflow:hidden;}
   .composer-mobile-config-action.active{background:var(--accent-bg);border-color:var(--accent-bg-strong);color:var(--text);}
@@ -2077,6 +2074,8 @@
     .composer-workspace-group{min-height:44px;}
     .composer-workspace-files-btn{min-width:44px;padding:6px 8px;}
     .composer-divider{display:none;}
+    .ctx-indicator-wrap{display:none!important;}
+    .ctx-indicator-wrap{display:none!important;}
   }
 
   @container composer-footer (max-width: 520px){
@@ -4816,3 +4815,5 @@ main.main.showing-logs > #mainLogs{display:flex;}
 @media (min-width:1600px) {
   .composer-box{max-width:1600px;margin:0 auto;}
 }
+
+#composerMobileCtxBadge { display: none !important; }

--- a/static/ui.js
+++ b/static/ui.js
@@ -5754,10 +5754,13 @@ function ensureActivityGroup(inner, opts){
   if(!group){
     group=document.createElement('div');
     let collapsed=opts.collapsed!==false;
+    if(window._activityFeedExpandedDefault===true) collapsed=false;
     const savedState=_readActivityDisclosureState(activityKey);
     // Restore the user's explicit expand intent when recreating the live
     // activity group within the same turn (#1298), then let persisted chat/turn
-    // state win across session switches and reloads.
+    // state win across session switches and reloads. Saved closed-state should
+    // override the default-expanded preference for settled groups the user has
+    // explicitly collapsed.
     if(live && _liveActivityUserExpanded === true) collapsed=false;
     else if(live && _liveActivityUserExpanded === false) collapsed=true;
     if(savedState==='open') collapsed=false;
@@ -7420,14 +7423,33 @@ function _activityProgressLabelForToolName(name){
   return 'Working';
 }
 
+function _activityLatestToolName(group){
+  if(!group) return '';
+  const running=group.querySelector('.tool-card.tool-card-running .tool-card-name');
+  const latest=running || Array.from(group.querySelectorAll('.tool-card-name')).pop();
+  return latest?String(latest.textContent||'').trim():'';
+}
+
+function _activityWaitingDetail(group,label=''){
+  const toolName=_activityLatestToolName(group);
+  if(toolName){
+    const action=_activityProgressLabelForToolName(toolName);
+    if(group&&group.querySelector('.tool-card.tool-card-running')) return `${action}: ${toolName}. Results will appear here.`;
+    return `Last step: ${action} (${toolName}); now choosing the next action or composing a response.`;
+  }
+  if(String(label||'').toLowerCase().includes('model')) return 'Reviewing the prompt and context, then choosing the next action or composing the response.';
+  return 'The agent is running; tool results and response text will appear here.';
+}
+
 function _activityLiveProgressLabel(group){
   if(!group||group.getAttribute('data-live-tool-call-group')!=='1') return '';
   const idleAge=_activityLastObservedAge(group);
   if(idleAge!==null&&idleAge>=90) return `No recent activity for ${_formatActiveElapsedTimer(idleAge)}`;
   const running=group.querySelector('.tool-card.tool-card-running .tool-card-name');
-  const latest=running || Array.from(group.querySelectorAll('.tool-card-name')).pop();
+  const latest=running?String(running.textContent||'').trim():_activityLatestToolName(group);
   const waiting=group.querySelector('.agent-activity-status-waiting .agent-activity-status-label');
-  if(latest) return _activityProgressLabelForToolName(latest.textContent);
+  if(latest) return _activityProgressLabelForToolName(latest);
+  if(waiting&&waiting.textContent&&String(waiting.textContent).toLowerCase().includes('model')) return 'Reviewing prompt and context';
   if(waiting&&waiting.textContent) return waiting.textContent;
   return 'Starting agent';
 }
@@ -7506,8 +7528,13 @@ function appendLiveToolCard(tc){
     status:toolDone?(tc.is_error?'error':'done'):'waiting',
     ts:_activityNowSeconds(),
   });
-  const waiting=body.querySelector('.agent-activity-status[data-activity-event-id="thinking-placeholder"] .agent-activity-status-label');
-  if(waiting&&!toolDone) waiting.textContent='Waiting on tool result';
+  const waiting=body.querySelector('.agent-activity-status[data-activity-event-id="thinking-placeholder"]');
+  if(waiting&&!toolDone){
+    const labelEl=waiting.querySelector('.agent-activity-status-label');
+    const detailEl=waiting.querySelector('.agent-activity-status-detail');
+    if(labelEl) labelEl.textContent='Waiting on tool result';
+    if(detailEl) detailEl.textContent=`${_activityProgressLabelForToolName(toolName)}: ${toolName}. Results will appear here.`;
+  }
   // Update existing card in place (tool_complete after tool_start)
   if(tid){
     const existing=body.querySelector(`.tool-card-row[data-live-tid="${CSS.escape(tid)}"]`);
@@ -8302,7 +8329,7 @@ function finalizeThinkingCard(){
     // when the user has not manually expanded this turn's activity group, or
     // has manually collapsed it. Otherwise the panel snaps shut whenever new
     // activity arrives, even mid-read.
-    if(_liveActivityUserExpanded !== true){
+    if(_liveActivityUserExpanded !== true && !(window._activityFeedExpandedDefault === true && _liveActivityUserExpanded !== false)){
       group.classList.add('tool-call-group-collapsed');
       const summary=group.querySelector('.tool-call-group-summary');
       if(summary) summary.setAttribute('aria-expanded','false');
@@ -8380,10 +8407,10 @@ function appendThinking(text='', options){
       detail='Creating the stream and sending your message…';
     }else if(hasRunningTool){
       label='Waiting on tool result';
-      detail='The tool is still running; the response will continue after it completes.';
+      detail=_activityWaitingDetail(group,label);
     }else if(hasToolCard){
       label='Waiting on model';
-      detail='Tool finished; waiting for the model to continue.';
+      detail=_activityWaitingDetail(group,label);
     }else{
       label='Waiting for first model token';
       detail='Stream connected; no model output has arrived yet.';

--- a/static/ui.js
+++ b/static/ui.js
@@ -2599,7 +2599,6 @@ function _setCtxCompressButton(btn,text){
 }
 
 function _syncMobileCtxDisplay(state){
-  const badge=$('composerMobileCtxBadge');
   const mobileConfigBtn=$('composerMobileConfigBtn');
   const row=$('composerMobileContextAction');
   const usageLine=$('composerMobileContextUsage');
@@ -2608,22 +2607,34 @@ function _syncMobileCtxDisplay(state){
   const costLine=$('composerMobileContextCost');
   const compressBtn=$('composerMobileCtxCompressBtn');
   if(!state||!state.visible){
-    if(badge)badge.style.display='none';
     if(row)row.style.display='none';
     if(mobileConfigBtn){
       mobileConfigBtn.setAttribute('aria-label',_MOBILE_CONFIG_BASE_LABEL);
       mobileConfigBtn.setAttribute('title',_MOBILE_CONFIG_BASE_LABEL);
     }
     _setCtxCompressButton(compressBtn,'');
+    // Reset context ring to 0% to clear any stale values from previous sessions
+    var arc = document.getElementById('ctx-arc');
+    var num = document.getElementById('ctx-num');
+    if (arc && num) {
+      var circumference = 87.96;
+      arc.setAttribute('stroke-dashoffset', circumference);
+      num.textContent = '0';
+      arc.setAttribute('stroke', '#22c55e');
+    }
     return;
   }
-  if(badge){
-    badge.style.display='inline-flex';
-    badge.textContent=state.hasPromptTok?String(state.pct):'\u00b7';
-    badge.classList.toggle('ctx-mid',state.pct>50&&state.pct<=75);
-    badge.classList.toggle('ctx-high',state.pct>75);
-    badge.setAttribute('title',state.label);
-  }
+  (function updateCtxRing(pct) {
+    var arc = document.getElementById('ctx-arc');
+    var num = document.getElementById('ctx-num');
+    if (!arc || !num) return;
+    var offset = 87.96 * (1 - Math.min(pct, 100) / 100);
+    arc.setAttribute('stroke-dashoffset', offset);
+    num.textContent = Math.round(pct);
+    arc.setAttribute('stroke',
+      pct <= 50 ? '#22c55e' : pct <= 85 ? '#f97316' : '#ef4444'
+    );
+  })(state.pct);
   if(mobileConfigBtn){
     mobileConfigBtn.setAttribute('aria-label',`${_MOBILE_CONFIG_BASE_LABEL}; ${state.label}`);
     mobileConfigBtn.setAttribute('title',`${_MOBILE_CONFIG_BASE_LABEL} \u00b7 ${state.label}`);

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -29,9 +29,10 @@ def test_empty_thinking_placeholder_becomes_status_row_not_raw_thinking_card():
     assert "Waiting for first model token" in UI_JS
     assert "Stream connected; no model output has arrived yet." in UI_JS
     assert "Waiting on model" in UI_JS
-    assert "Tool finished; waiting for the model to continue." in UI_JS
+    assert "Reviewing the prompt and context, then choosing the next action or composing the response." in UI_JS
+    assert "Reviewing prompt and context" in UI_JS
     assert "Waiting on tool result" in UI_JS
-    assert "The tool is still running; the response will continue after it completes." in UI_JS
+    assert "Last step: ${action} (${toolName}); now choosing the next action or composing a response." in UI_JS
     assert "_thinkingActivityNode(thinkingText, false)" in UI_JS
 
 
@@ -43,6 +44,23 @@ def test_stream_start_refreshes_waiting_status_after_stream_id_arrives():
     assert refresh_idx != -1
     assert attach_idx != -1
     assert refresh_idx < attach_idx
+
+
+def test_activity_feed_default_expand_setting_is_wired():
+    index_html = (REPO / "static" / "index.html").read_text(encoding="utf-8")
+    panels_js = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
+    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    config_py = (REPO / "api" / "config.py").read_text(encoding="utf-8")
+
+    assert 'id="settingsActivityFeedExpandedDefault"' in index_html
+    assert "settings_label_activity_feed_expanded_default" in index_html
+    assert '"activity_feed_expanded_default": False' in config_py
+    assert "activity_feed_expanded_default" in panels_js
+    assert "window._activityFeedExpandedDefault=!!s.activity_feed_expanded_default;" in boot_js
+    assert "if(window._activityFeedExpandedDefault===true) collapsed=false;" in UI_JS
+    finalize_fn = UI_JS.split("function finalizeThinkingCard")[1].split("\nfunction ")[0]
+    assert "_activityFeedExpandedDefault" in finalize_fn
+    assert "_liveActivityUserExpanded !== false" in finalize_fn
 
 
 def test_tool_events_update_activity_timeline_and_summary():

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -1114,13 +1114,21 @@ def test_mobile_composer_primary_controls_keep_touch_friendly_sizing():
     assert ctx_wrap.get("display") == "none!important", \
         "context indicator must not add a late-appearing composer-right slot on phones"
 
-    ctx_badge = _declarations(_rule_body(CSS, ".composer-mobile-ctx-badge"))
-    assert ctx_badge.get("position") == "absolute", \
-        "mobile context usage should be shown as a badge on the config button, not a separate slot"
-    assert ctx_badge.get("pointer-events") == "none", \
-        "mobile context badge must not shrink or steal the config button touch target"
-    assert 'id="composerMobileCtxBadge"' in HTML, \
-        "mobile context badge element must exist in the composer config button"
+    # #3062 replaced the old text badge (composerMobileCtxBadge / .composer-mobile-ctx-badge)
+    # with an SVG context-usage ring overlaid on the config button. The invariant is the
+    # same: the ring is a visual indicator hosted ON the 44px config button (whose sizing is
+    # asserted above), and it must not steal/shrink that touch target. The ring SVG is
+    # aria-hidden and uses currentColor; it carries no pointer events of its own.
+    assert 'id="composerMobileCtxRing"' in HTML, \
+        "mobile context-usage ring element must exist in the composer config button"
+    assert 'id="composerMobileCtxBadge"' not in HTML, \
+        "old text badge should be fully replaced by the ring, not left dangling"
+    # Locate the ring's markup and confirm it does not become an interactive/sized control
+    # that would compete with the config button's 44px target.
+    _ring_idx = HTML.find('id="composerMobileCtxRing"')
+    _ring_tag = HTML[HTML.rfind("<", 0, _ring_idx):HTML.find(">", _ring_idx) + 1]
+    assert "aria-hidden" in _ring_tag, \
+        "the context ring is decorative overlay — it must be aria-hidden so it doesn't steal the config button's role/touch target"
 
     icon_btn = _declarations(_rule_body(mobile_css, ".icon-btn"))
     assert icon_btn.get("min-width") == "44px", \


### PR DESCRIPTION
## Release v0.51.226 — Release GT (stage-p9)

Two small UI additions, both **screenshot-approved by Nathan** (Telegram, 2026-06-03) in a populated test environment. Cherry-picked as squashed net diffs (both PR branches' tip commits were deletes of files absent from our tree).

### Added
**#3080 — "Expand activity feed by default" appearance setting** (@AJV20). A new Settings → Appearance checkbox (default off) that expands new Activity disclosures automatically as turns arrive, so tool/model progress is visible without an extra click. Manual per-turn collapse/expand still wins (an explicit user toggle is preserved). Live "Waiting on model" rows now describe what the agent is doing before and after tool calls.

### Changed
**#3062 — mobile composer context-usage ring** (@NottheGuy007). The mobile composer's config button now shows an SVG context-usage ring (progress arc + centered percentage) in place of the static sliders icon, color-coded green (≤50%) / orange (≤85%) / red (>85%) and reset to 0% on a new session, so context-window pressure is visible at a glance on mobile.

### Review notes
- **Test fix (agent):** #3062 removed the old `composerMobileCtxBadge` text badge but left 3 stale references in `tests/test_mobile_layout.py`. The full suite caught `test_mobile_composer_primary_controls_keep_touch_friendly_sizing` asserting the removed `.composer-mobile-ctx-badge`. Updated the assertion to the new ring (`composerMobileCtxRing`): confirms it exists, the old badge is fully gone, and the ring SVG is `aria-hidden` so it stays a decorative overlay that doesn't steal the config button's 44px touch target (still asserted via `.composer-mobile-config-btn`). 56/56 mobile-layout tests pass.

### Gates
- Full suite: **7367 passed**, 0 failures.
- **Codex: SAFE TO SHIP** — verified ring math (0→full offset, >100 capped upstream, no NaN/negative), no production JS dereferences the removed badge, default-expand applies before saved state so explicit per-turn collapse still wins, no dangling `ask_widget.js`/`ask.py` refs.
- ESLint runtime gate + ruff forward gate: clean.
- Screenshots vision-verified + Nathan-approved (mobile ring in a loaded conversation; desktop Settings → Appearance with populated sidebar).

Closes #3062, #3080.
Co-authored-by: NottheGuy007 <NottheGuy007@users.noreply.github.com>
Co-authored-by: AJV20 <AJV20@users.noreply.github.com>
