### PR TITLE
fix(ui): auto-hide Plugins settings tab when no plugins installed (#3457)

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -5741,7 +5741,14 @@ function switchSettingsSection(name){
   if(dd && dd.value!==section) dd.value=section;
   // Lazy-load integration panels when their tabs are opened
   if(section==='providers') loadProvidersPanel();
-  if(section==='plugins') loadPluginsPanel();
+  if(section==='plugins'){
+    const tabBtn=document.querySelector('[data-settings-section="plugins"]');
+    if(tabBtn && tabBtn.style.display==='none'){
+      section='conversation';
+    } else {
+      loadPluginsPanel();
+    }
+  }
 }
 
 function _syncHermesPanelSessionActions(){
@@ -6457,6 +6464,9 @@ async function loadPluginsPanel(){
   try{
     const data=await api('/api/plugins');
     const plugins=Array.isArray((data||{}).plugins)?data.plugins:[];
+    // Hide the Plugins tab when no plugins are installed (#3457)
+    const tabBtn=document.querySelector('[data-settings-section="plugins"]');
+    if(tabBtn) tabBtn.style.display=(data&&data.empty)?'none':'';
     list.innerHTML='';
     if(plugins.length===0){
       list.style.display='none';

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -523,3 +523,23 @@ class TestPluginCollisionDetection:
 
         assert "plugins_active_provider:" in i18n
         assert "plugins_provider_no_hooks:" in i18n
+
+
+class TestAutoHidePluginsTab:
+    """Tests for issue #3457: auto-hide Plugins tab when no plugins installed."""
+
+    def test_loadPluginsPanel_hides_tab_when_empty(self):
+        js = read("static/panels.js")
+        segment = js[js.find("async function loadPluginsPanel"):js.find("function _buildPluginCard")]
+
+        assert "data-settings-section=\"plugins\"" in segment
+        assert ".empty" in segment
+        assert "style.display='none'" in segment
+
+    def test_switchSettingsSection_fallback_when_hidden(self):
+        js = read("static/panels.js")
+        segment = js[js.find("function switchSettingsSection"):js.find("function _syncHermesPanelSessionActions")]
+
+        assert "section==='plugins'" in segment
+        assert "display==='none'" in segment
+        assert "section='conversation'" in segment


### PR DESCRIPTION
Closes #3457

When /api/plugins returns empty:true, hide the Plugins tab button
in the Settings sidebar. The tab reappears when plugins are detected.
Also guard against deep-linking to a hidden plugins pane (fallback
to conversation section).