### PR TITLE
fix: detect upward touch intent to unpin scroll during streaming

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -2269,6 +2269,7 @@ let _lastNonMessageScrollIntentMs=-Infinity;
 let _messageUserUnpinned=false;
 let _bottomSettleToken=0;
 const NON_MESSAGE_SCROLL_INTENT_SUPPRESS_MS=350;
+let _touchStartY=null;
 function _cancelBottomSettle(){ _bottomSettleToken++; }
 function _recordNonMessageScrollIntent(e){
   const el=document.getElementById('messages');
@@ -2281,6 +2282,14 @@ function _recordNonMessageScrollIntent(e){
       _messageUserUnpinned=true;
       _nearBottomCount=0;
       _scrollPinned=false;
+    } else if(e.type==='touchmove'&&_touchStartY!==null&&e.touches&&e.touches[0]){
+      // Detect upward touch intent: finger moving down on screen = scrolling up
+      const dy=e.touches[0].clientY-_touchStartY;
+      if(dy<-8){
+        _messageUserUnpinned=true;
+        _nearBottomCount=0;
+        _scrollPinned=false;
+      }
     }
   }
 }
@@ -2290,6 +2299,11 @@ function _recentNonMessageScrollIntent(){
 if(typeof document!=='undefined'){
   document.addEventListener('wheel',_recordNonMessageScrollIntent,{capture:true,passive:true});
   document.addEventListener('touchmove',_recordNonMessageScrollIntent,{capture:true,passive:true});
+  document.addEventListener('touchstart',function(e){
+    if(e.touches&&e.touches[0]) _touchStartY=e.touches[0].clientY;
+  },{capture:true,passive:true});
+  document.addEventListener('touchend',function(){ _touchStartY=null; },{capture:true,passive:true});
+  document.addEventListener('touchcancel',function(){ _touchStartY=null; },{capture:true,passive:true});
 }
 // Reset hook for session-switch — called from sessions.js loadSession() to
 // prevent the new chat's first scroll comparing against the previous chat's
@@ -2299,6 +2313,7 @@ function _resetScrollDirectionTracker(){
   _messageUserUnpinned=false;
   _scrollPinned=true;
   _nearBottomCount=0;
+  _touchStartY=null;
 }
 function _resetStreamScrollFollow(){
   _messageUserUnpinned=false;


### PR DESCRIPTION
## Problem

On mobile touch devices, the auto-scroll-during-streaming behavior cannot be dismissed by scrolling up. The stream keeps snapping to the bottom with every new token, making it impossible to read the response as it arrives.

## Root Cause

In `_recordNonMessageScrollIntent()`, when a `touchmove` event fires inside the messages area, the code enters the outer branch (matched by `e.type==='touchmove'`) and calls `_cancelBottomSettle()`, but the inner condition checks `typeof e.deltaY === 'number'` — **touch events never have `deltaY`**. So `_messageUserUnpinned` was never set from touch input.

The scroll listener (line ~2393) does detect upward scroll, but it races against `_programmaticScroll=true` set by `_setMessageScrollToBottom()` — the programmatic scroll suppresses the handler before it can detect `movedUp`.

## Fix

1. **Track `touchstart` Y position** (`_touchStartY`) so subsequent `touchmove` events can compare against it
2. **Detect upward scroll intent on touch**: if the finger moved up by >8px during `touchmove`, set `_messageUserUnpinned=true` and `_scrollPinned=false` — same effect as the wheel `deltaY < 0` branch
3. **Cleanup** `_touchStartY` on `touchend`/`touchcancel` and in `_resetScrollDirectionTracker()`

This makes the sticky-unpin model work correctly on mobile: swipe up during streaming → auto-follow stops → tap ↓ button or scroll back to bottom to re-engage.
