### PR TITLE
fix: restore new chat draft after history navigation (#3333)

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -1069,6 +1069,10 @@ $('btnNewChat').onclick=async()=>{
      && !S.session.pending_user_message){
     $('msg').focus();closeMobileSidebar();return;
   }
+  if(typeof _restoreRememberedNewChatDraftSession==='function'
+     && await _restoreRememberedNewChatDraftSession()){
+    await renderSessionList();closeMobileSidebar();$('msg').focus();return;
+  }
   await newSession();await renderSessionList();closeMobileSidebar();$('msg').focus();
 };
 $('btnDownload').onclick=()=>{

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -31,6 +31,57 @@ let _pendingCarryForwardSnapshot = null;
 // Debounced save — prevents hammering the server on every keystroke.
 let _draftSaveTimer = null;
 const _DRAFT_SAVE_DELAY_MS = 400;
+const NEW_CHAT_DRAFT_SESSION_KEY = 'hermes-new-chat-draft-session';
+
+function _isRestorableNewChatDraftSession(session, requireDraft=false) {
+  if (!session || !session.session_id) return false;
+  const messageCount = Number(session.message_count || 0);
+  if (messageCount !== 0) return false;
+  if (session.active_stream_id || session.pending_user_message || session.worktree_path) return false;
+  const title = session.title || 'Untitled';
+  if (title !== 'Untitled' && title !== 'New Chat') return false;
+  const activeProfile = S.activeProfile || 'default';
+  const sessionProfile = session.profile || 'default';
+  if (sessionProfile !== activeProfile) return false;
+  if (!requireDraft) return true;
+  const draft = session.composer_draft || {};
+  const text = (typeof draft.text === 'string') ? draft.text : '';
+  const files = Array.isArray(draft.files) ? draft.files : [];
+  return !!(text || files.length);
+}
+
+function _rememberNewChatDraftSession(session) {
+  if (!_isRestorableNewChatDraftSession(session)) return;
+  try { localStorage.setItem(NEW_CHAT_DRAFT_SESSION_KEY, session.session_id); } catch (_) {}
+}
+
+function _clearRememberedNewChatDraftSession(sid) {
+  if (!sid) return;
+  try {
+    if (localStorage.getItem(NEW_CHAT_DRAFT_SESSION_KEY) === sid) {
+      localStorage.removeItem(NEW_CHAT_DRAFT_SESSION_KEY);
+    }
+  } catch (_) {}
+}
+
+async function _restoreRememberedNewChatDraftSession() {
+  let sid = '';
+  try { sid = localStorage.getItem(NEW_CHAT_DRAFT_SESSION_KEY) || ''; } catch (_) { sid = ''; }
+  if (!sid || (S.session && S.session.session_id === sid)) return false;
+  try {
+    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`);
+    const session = data && data.session;
+    if (!_isRestorableNewChatDraftSession(session, true)) {
+      _clearRememberedNewChatDraftSession(sid);
+      return false;
+    }
+    await loadSession(sid, {skipLineageResolve:true});
+    return !!(S.session && S.session.session_id === sid);
+  } catch (_) {
+    _clearRememberedNewChatDraftSession(sid);
+    return false;
+  }
+}
 
 function _saveComposerDraft(sid, text, files) {
   if (!sid) return;
@@ -43,11 +94,11 @@ function _saveComposerDraft(sid, text, files) {
   }, _DRAFT_SAVE_DELAY_MS);
 }
 
-// Fire-and-forget immediate save (used before session switches).
+// Immediate save used before session switches.
 function _saveComposerDraftNow(sid, text, files) {
   if (!sid) return;
   clearTimeout(_draftSaveTimer);
-  api('/api/session/draft', {
+  return api('/api/session/draft', {
     method: 'POST',
     body: JSON.stringify({ session_id: sid, text: text || '', files: files || [] }),
   }).catch(() => {});
@@ -97,6 +148,7 @@ function _restoreComposerDraft(draft, targetSid, opts={}) {
 function _clearComposerDraft(sid) {
   if (!sid) return;
   clearTimeout(_draftSaveTimer);
+  _clearRememberedNewChatDraftSession(sid);
   api('/api/session/draft', {
     method: 'POST',
     body: JSON.stringify({ session_id: sid, text: '' }),
@@ -522,6 +574,7 @@ async function newSession(flash, options={}){
     S.session=data.session;S.messages=data.session.messages||[];
     if(_sessionSourceFilter==='cli') _sessionSourceFilter='webui';
     S.lastUsage={...(data.session.last_usage||{})};
+    if(!(options&&options.worktree)) _rememberNewChatDraftSession(S.session);
     if(flash)S.session._flash=true;
     try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
     _setActiveSessionUrl(S.session.session_id);
@@ -618,7 +671,7 @@ async function loadSession(sid){
   // restored when the user switches back (#1060). Save to server now so the
   // draft survives page refresh and syncs across clients.
   if (currentSid && currentSid !== sid) {
-    _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
+    await _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
   }
   if (currentSid !== sid || forceReload) {
     // #3306: When force-reloading the currently-active session (e.g. external

--- a/tests/test_issue_new_chat_draft_restore.py
+++ b/tests/test_issue_new_chat_draft_restore.py
@@ -1,0 +1,89 @@
+"""Regression coverage for New Chat draft-session restoration.
+
+The bug: New Chat -> type draft -> open history -> New Chat created a fresh
+empty session instead of returning to the empty session that owns the draft.
+"""
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+SESSIONS_JS = ROOT.joinpath("static", "sessions.js").read_text(encoding="utf-8")
+BOOT_JS = ROOT.joinpath("static", "boot.js").read_text(encoding="utf-8")
+
+
+def _btn_new_chat_handler() -> str:
+    start = BOOT_JS.find("$('btnNewChat').onclick=async()=>{")
+    end = BOOT_JS.find("$('btnDownload').onclick", start)
+    assert start != -1 and end != -1, "btnNewChat handler block not found"
+    return BOOT_JS[start:end]
+
+
+def test_new_session_remembers_regular_empty_session_id():
+    start = SESSIONS_JS.find("async function newSession(")
+    end = SESSIONS_JS.find("async function loadSession(", start)
+    assert start != -1 and end != -1, "newSession block not found"
+    body = SESSIONS_JS[start:end]
+    assign_idx = body.find("S.session=data.session")
+    remember_idx = body.find("_rememberNewChatDraftSession(S.session)")
+    assert assign_idx != -1, "newSession must assign S.session from the POST response"
+    assert remember_idx > assign_idx, "newSession must remember the created empty session id"
+    assert "if(!(options&&options.worktree)) _rememberNewChatDraftSession(S.session);" in body, (
+        "worktree-backed new sessions must not become New Chat draft candidates"
+    )
+
+
+def test_new_chat_button_restores_remembered_draft_before_creating_session():
+    body = _btn_new_chat_handler()
+    restore_idx = body.find("_restoreRememberedNewChatDraftSession")
+    new_idx = body.find("await newSession()")
+    assert restore_idx != -1, "New Chat button must try the remembered draft session first"
+    assert new_idx != -1, "New Chat button must still fall back to creating a session"
+    assert restore_idx < new_idx, "draft-session restore must happen before newSession fallback"
+    assert "return;" in body[restore_idx:new_idx], (
+        "successful draft-session restore must return instead of also creating a new session"
+    )
+
+
+def test_restore_helper_validates_candidate_with_session_metadata():
+    assert "const NEW_CHAT_DRAFT_SESSION_KEY = 'hermes-new-chat-draft-session';" in SESSIONS_JS
+    assert "async function _restoreRememberedNewChatDraftSession()" in SESSIONS_JS
+    assert "messages=0&resolve_model=0" in SESSIONS_JS, (
+        "helper should validate the hidden zero-message candidate through /api/session metadata"
+    )
+    assert "_isRestorableNewChatDraftSession(session, true)" in SESSIONS_JS, (
+        "candidate must have a non-empty server-side composer_draft before restore"
+    )
+    assert "await loadSession(sid, {skipLineageResolve:true});" in SESSIONS_JS, (
+        "helper should load the exact hidden empty draft session"
+    )
+
+
+def test_session_switch_awaits_immediate_draft_flush_before_loading_target():
+    assert "return api('/api/session/draft'" in SESSIONS_JS, (
+        "_saveComposerDraftNow should return its POST promise so switch-away can await it"
+    )
+    assert "await _saveComposerDraftNow(currentSid" in SESSIONS_JS, (
+        "loadSession must flush the current draft before fetching the next session"
+    )
+
+
+def test_restorable_candidate_rejects_in_flight_worktree_and_cross_profile_sessions():
+    start = SESSIONS_JS.find("function _isRestorableNewChatDraftSession(")
+    end = SESSIONS_JS.find("function _rememberNewChatDraftSession", start)
+    assert start != -1 and end != -1, "restorable candidate helper not found"
+    body = SESSIONS_JS[start:end]
+    assert "messageCount !== 0" in body
+    assert "session.active_stream_id || session.pending_user_message || session.worktree_path" in body
+    assert "sessionProfile !== activeProfile" in body
+    assert "session.composer_draft || {}" in body
+    assert "text || files.length" in body
+
+
+def test_clear_composer_draft_forgets_same_new_chat_candidate():
+    start = SESSIONS_JS.find("function _clearComposerDraft(")
+    end = SESSIONS_JS.find("const SESSION_VIEWED_COUNTS_KEY", start)
+    assert start != -1 and end != -1, "_clearComposerDraft block not found"
+    body = SESSIONS_JS[start:end]
+    assert "_clearRememberedNewChatDraftSession(sid);" in body, (
+        "sending a draft must stop New Chat from restoring that now-cleared candidate"
+    )


### PR DESCRIPTION
# PR Description: Restore New Chat Draft After History Navigation

## Thinking Path

- Hermes WebUI already persists composer drafts per session through the server-side `composer_draft` field.
- The reported bug was not that the draft failed to save; it was that New Chat created a fresh empty session after the user visited history, instead of returning to the empty session that owned the draft.
- Zero-message New Chat sessions are intentionally hidden from the sidebar, so the fix should not make draft-only sessions visible just to recover them.
- This PR keeps the existing draft persistence contract and adds a narrow client-side pointer to the hidden empty draft session.
- When the user clicks New Chat after visiting a history session, WebUI now validates that remembered session through `/api/session` and restores it only if it is still a safe empty draft session.

## What Changed

- Added a small localStorage key, `hermes-new-chat-draft-session`, that stores only the candidate empty New Chat `session_id`.
- Added validation for restorable New Chat draft sessions:
  - zero messages,
  - no active stream,
  - no pending user message,
  - not worktree-backed,
  - matching active profile,
  - non-empty server-side `composer_draft`.
- Updated the New Chat button flow to try restoring the remembered draft session before falling back to creating a fresh session.
- Updated session switching so the current composer draft is flushed before loading the next session, avoiding a race when users type and immediately navigate away.
- Cleared the remembered New Chat draft pointer when the draft is cleared after sending.
- Added focused static regression coverage for the New Chat draft restoration path.

## Why It Matters

Users can now safely start a New Chat draft, inspect a previous conversation, and return to New Chat without losing their unsent prompt. This preserves the current “zero-message sessions stay hidden from the sidebar” behavior while making the New Chat entrypoint route back to the draft session that already exists.

## Screenshots / Manual Evidence

### 1. Creating the New Chat draft
<img width="1841" height="863" alt="input-draft" src="https://github.com/user-attachments/assets/75a06e30-c8b8-40dc-b691-d76256ce5822" />

### 2. Opening a history session
<img width="1768" height="862" alt="see-history-session" src="https://github.com/user-attachments/assets/588e9aac-4d1e-41db-a880-bf1390ef21de" />

### 3. Clicking New Chat restores the previous draft
<img width="1754" height="859" alt="new-session" src="https://github.com/user-attachments/assets/ec3c8802-70e3-4264-8c63-bb4d4f967b22" />

### 4. Sending the draft, then clicking New Chat starts blank
<img width="1544" height="862" alt="send-draft" src="https://github.com/user-attachments/assets/43e08500-a523-4d10-aa13-1e1fc08c50fb" />

## Verification

Automated checks:

```bash
node --check static/sessions.js
node --check static/boot.js
```

```bash
HERMES_HOME='project\hermes-webui\.pytest-hermes-home' \
HERMES_BASE_HOME='project\hermes-webui\.pytest-hermes-home' \
HERMES_WEBUI_TEST_STATE_DIR='project\hermes-webui\.pytest-hermes-state' \
HERMES_WEBUI_STATE_DIR='project\hermes-webui\.pytest-hermes-state' \
python -m pytest -q tests/test_issue_new_chat_draft_restore.py tests/test_1432_newchat_and_1423_profile_input.py tests/test_stage326_composer_draft_validation.py tests/test_api_timeout.py
```

Result:

```text
28 passed
```

Manual checks:

- Started the WebUI server in an isolated agent-free test setup.
- Created a New Chat draft without sending it.
- Opened an existing history session.
- Clicked New Chat and confirmed the previous draft was restored.
- Sent the restored draft, clicked New Chat again, and confirmed a fresh blank session opened instead of restoring the sent draft.

## Contract Routing

Task type: frontend session navigation + composer draft persistence

Touched areas:

- `static/sessions.js`
- `static/boot.js`
- `tests/test_issue_new_chat_draft_restore.py`

Relevant public docs:

- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/canonical-session-resolution.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`

Scope boundaries:

- Does not expose zero-message draft sessions in the sidebar.
- Does not change Cmd/Ctrl+K or slash `/new` semantics.
- Does not make draft autosave count as session activity.
- Does not address the broader refresh, scroll, SSE, or queue persistence work discussed around #3109.

Evidence:

- Regression tests cover the remembered draft-session route and ensure the candidate is validated before restore.
- Existing #1432 New Chat in-flight guard tests remain green.
- Composer draft validation tests remain green.

## Risks / Follow-ups

- File attachment draft restoration remains limited by the existing `_restoreComposerDraft()` behavior, which does not yet rebuild `S.pendingFiles`.
- This PR intentionally handles the New Chat button in-app navigation case only. Keyboard and slash-command new-chat flows continue to mean “start a fresh conversation.”
- The remembered key stores only a `session_id`; if the session is deleted, changed, cross-profile, or no longer has a draft, the key is cleared and WebUI falls back to creating a new session.

## Model Used

AI-assisted with OpenAI Codex (GPT-5) in the local repository.