### PR TITLE
fix: malformed/negative depth on /api/sessions/search crashes or skips newest messages

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -8188,7 +8188,15 @@ def _handle_sessions_search(handler, parsed):
     qs = parse_qs(parsed.query)
     q = qs.get("q", [""])[0].lower().strip()
     content_search = qs.get("content", ["1"])[0] == "1"
-    depth = int(qs.get("depth", ["5"])[0])
+    # Reject a malformed depth instead of letting int() raise ValueError and
+    # surface as a confusing 500. Clamp to >= 0 so a negative value can't reach
+    # the messages[:depth] slice below — messages[:-n] would silently exclude
+    # the most recent messages from the content search instead of capping it.
+    # (depth == 0 keeps its existing meaning: search the full transcript.)
+    try:
+        depth = max(0, int(qs.get("depth", ["5"])[0]))
+    except (ValueError, TypeError):
+        depth = 5
     if not q:
         safe_sessions = []
         for s in all_sessions():

--- a/tests/test_sessions_search_depth_validation.py
+++ b/tests/test_sessions_search_depth_validation.py
@@ -1,0 +1,72 @@
+"""Regression: a malformed/negative ``depth`` on the session content-search
+endpoint must not crash or silently exclude the newest messages.
+
+``GET /api/sessions/search?...&depth=<x>`` parsed ``depth`` with a bare
+``int()``. A non-numeric value (e.g. ``?depth=deep``) raised ValueError, which
+propagated to the top-level request handler and surfaced as a generic HTTP 500.
+
+``depth`` caps how many leading messages are scanned per session
+(``sess.messages[:depth]``). A negative value sliced as ``messages[:-n]``,
+silently dropping the *most recent* messages from the search instead of capping
+the scan — so a match in a session's latest turn would be missed. depth is now
+clamped to ``>= 0`` (0 keeps its existing "search the whole transcript"
+meaning), mirroring the guard sibling handlers already use.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+
+def _run_search(query):
+    """Invoke _handle_sessions_search against one synthetic session whose match
+    lives in its LAST message, capturing the JSON payload/status."""
+    import api.routes as routes
+
+    sessions_meta = [{"session_id": "s1", "title": "Untitled"}]
+    session = SimpleNamespace(
+        session_id="s1",
+        messages=[
+            {"role": "user", "content": "first message"},
+            {"role": "assistant", "content": "second message"},
+            {"role": "user", "content": "NEEDLE in the latest message"},
+        ],
+    )
+    captured = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        captured["payload"] = payload
+
+    with patch("api.routes.all_sessions", return_value=list(sessions_meta)), patch(
+        "api.routes.get_session", return_value=session
+    ), patch("api.routes.j", side_effect=fake_j):
+        routes._handle_sessions_search(SimpleNamespace(), urlparse(query))
+    return captured
+
+
+def test_search_non_numeric_depth_does_not_500():
+    # Before the fix this raised ValueError -> 500.
+    captured = _run_search("/api/sessions/search?q=needle&content=1&depth=deep")
+    assert captured["status"] == 200
+    # depth falls back to 5 (>= 3 messages here), so the needle is found.
+    assert captured["payload"]["count"] == 1
+
+
+def test_search_negative_depth_still_scans_newest_message():
+    # depth=-2 with 3 messages: an unclamped messages[:-2] scan would look only
+    # at the first message and MISS the needle in the latest one. Clamped to a
+    # default >= 0, the newest message is searched and the match is found.
+    captured = _run_search("/api/sessions/search?q=needle&content=1&depth=-2")
+    assert captured["status"] == 200
+    assert captured["payload"]["count"] == 1
+
+
+def test_search_valid_depth_still_caps_scan():
+    # depth=1 scans only the first message, which does NOT contain the needle,
+    # so no match — proving the cap still works for well-formed input.
+    captured = _run_search("/api/sessions/search?q=needle&content=1&depth=1")
+    assert captured["status"] == 200
+    assert captured["payload"]["count"] == 0


### PR DESCRIPTION
## Bug

`GET /api/sessions/search?...&depth=<x>` parses `depth` with a bare `int()`:

```python
depth = int(qs.get("depth", ["5"])[0])
```

Two problems:

1. **HTTP 500 on non-numeric input.** `?depth=deep` → `int("deep")` raises `ValueError` → propagates to the top-level handler → generic `500`. (The per-session `try/except` later in the function is *after* this line, so it does not catch it.)
2. **Negative `depth` silently skips the newest messages.** `depth` caps how many leading messages are scanned per session: `sess.messages[:depth]`. A negative value slices as `messages[:-n]`, which *excludes the most recent n messages* from the content search rather than capping the scan — so a match in a session's latest turn is missed (e.g. `depth=-2` on a 3-message session scans only the first message).

Sibling query-param handlers (`_handle_insights`, `_handle_notes_search`, `_handle_cron_run_detail`) already guard this pattern with `try/except (ValueError, TypeError)` and a default fallback.

## Reproduction

```
GET /api/sessions/search?q=needle&content=1&depth=deep  -> ValueError -> 500
GET /api/sessions/search?q=needle&content=1&depth=-2     -> misses a match in the newest message
```

## Fix

```python
try:
    depth = max(0, int(qs.get("depth", ["5"])[0]))
except (ValueError, TypeError):
    depth = 5
```

`depth == 0` keeps its existing meaning ("search the full transcript", via the `messages[:depth] if depth else messages` branch). Positive values are unchanged.

## Regression test

`tests/test_sessions_search_depth_validation.py` builds a synthetic session whose only match lives in its *last* message and asserts:
- non-numeric `depth` → `200` and the match is still found (no 500),
- negative `depth` → the newest message is still scanned (match found),
- valid `depth=1` still caps the scan (match in a later message is correctly *not* found).

The two bug-path tests fail before this change and pass after; the cap test passes both ways. Full non-integration suite stays green (`7274 passed`).