### PR TITLE
Fix early-cancel live stream race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## [Unreleased]
 
+### Fixed
+- Cancelling a live turn now still works after the browser SSE stream has
+  detached, as long as the worker is still registered in the active-run
+  registry. The session payload also now reports run-journal activity from the
+  real live registry instead of treating any persisted `active_stream_id` as
+  proof that the worker is still alive.
+
 ## [v0.51.230] — 2026-06-03 — Release GX (stage-p14 — extract <think> blocks to m.reasoning + LLM Wiki last-writer)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -2861,6 +2861,7 @@ from api.models import (
     get_state_db_session_summary,
     merge_session_messages_append_only,
     _session_message_merge_key,
+    _active_stream_ids,
     _is_empty_partial_activity_message,
     _hide_from_default_sidebar,
     prune_session_from_index,
@@ -5146,7 +5147,15 @@ def handle_get(handler, parsed) -> bool:
                     )
                 except (TypeError, ValueError):
                     _merged_last_message_at = 0
-            raw = s.compact() | {
+            active_stream_ids = _active_stream_ids()
+            try:
+                compact_session = s.compact(
+                    include_runtime=True,
+                    active_stream_ids=active_stream_ids,
+                )
+            except TypeError:
+                compact_session = s.compact()
+            raw = compact_session | {
                 "messages": _truncated_msgs,
                 "message_count": _merged_message_count,
                 "tool_calls": _session_tool_calls,
@@ -5164,9 +5173,10 @@ def handle_get(handler, parsed) -> bool:
                 except Exception:
                     journal = None
                 if journal:
+                    journal_active = bool(original_stream_id in active_stream_ids)
                     raw["runtime_journal"] = _run_journal_status_payload(
                         journal,
-                        active=bool(getattr(s, "active_stream_id", None)),
+                        active=journal_active,
                     )
             # Cold-load: derive the latest settled todo snapshot from the full
             # merged transcript, not the truncated display window. This keeps

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -6970,7 +6970,7 @@ def _handle_chat_steer(handler, body: dict) -> bool:
 
 
 def cancel_stream(stream_id: str) -> bool:
-    """Signal an in-flight stream to cancel. Returns True if the stream existed.
+    """Signal an in-flight stream to cancel. Returns True if work was found.
 
     Eagerly releases the session lock (pops STREAMS/CANCEL_FLAGS/AGENT_INSTANCES
     and clears session.active_stream_id) so new /api/chat/start requests succeed
@@ -6999,88 +6999,124 @@ def cancel_stream(stream_id: str) -> bool:
         partial_texts = _live_config.STREAM_PARTIAL_TEXT
         streams_lock = _live_config.STREAMS_LOCK
 
+    active_run_entry = None
+    active_run_session_id = None
+    stream_present = False
+    agent = None
+    q = None
+
     with streams_lock:
-        if stream_id not in streams:
-            return False
-
-        # Set WebUI layer cancel flag
-        flag = cancel_flags.get(stream_id)
-        if flag:
-            flag.set()
-
-        # Interrupt the AIAgent instance to stop tool execution
-        agent = agent_instances.get(stream_id)
-        if agent:
-            try:
-                agent.interrupt("Cancelled by user")
-            except Exception as e:
-                # Log but don't block the cancel flow
-                import logging
-                logging.getLogger(__name__).debug(
-                    f"Failed to interrupt agent for stream {stream_id}: {e}"
-                )
+        stream_present = stream_id in streams
+        if stream_present:
+            q = streams.get(stream_id)
         else:
-            # Agent not yet stored - cancel_event flag will be checked by agent thread
+            try:
+                with _live_config.ACTIVE_RUNS_LOCK:
+                    active_run_entry = dict((_live_config.ACTIVE_RUNS or {}).get(stream_id) or {})
+            except Exception:
+                active_run_entry = None
+            if not active_run_entry:
+                return False
+            active_run_session_id = str(active_run_entry.get("session_id") or "").strip() or None
+
+    if active_run_entry is None:
+        try:
+            with _live_config.ACTIVE_RUNS_LOCK:
+                active_run_entry = dict((_live_config.ACTIVE_RUNS or {}).get(stream_id) or {})
+        except Exception:
+            active_run_entry = None
+        if active_run_entry and not active_run_session_id:
+            active_run_session_id = str(active_run_entry.get("session_id") or "").strip() or None
+
+    # Set WebUI layer cancel flag
+    flag = cancel_flags.get(stream_id)
+    if flag:
+        flag.set()
+
+    # Interrupt the AIAgent instance to stop tool execution
+    agent = agent_instances.get(stream_id)
+    if agent is None and active_run_session_id:
+        try:
+            with _live_config.SESSION_AGENT_CACHE_LOCK:
+                cached = _live_config.SESSION_AGENT_CACHE.get(active_run_session_id)
+            if cached and _cached_agent_matches_session(cached[0], active_run_session_id):
+                agent = cached[0]
+        except Exception:
+            pass
+    if agent:
+        try:
+            agent.interrupt("Cancelled by user")
+        except Exception as e:
+            # Log but don't block the cancel flow
             import logging
             logging.getLogger(__name__).debug(
-                f"Cancel requested for stream {stream_id} before agent ready - "
-                f"cancel_event flag set, will be checked on agent startup"
+                f"Failed to interrupt agent for stream {stream_id}: {e}"
             )
+    elif stream_present:
+        # Agent not yet stored - cancel_event flag will be checked by agent thread
+        import logging
+        logging.getLogger(__name__).debug(
+            f"Cancel requested for stream {stream_id} before agent ready - "
+            f"cancel_event flag set, will be checked on agent startup"
+        )
 
-        # Clear any pending clarify prompt so the blocked tool call can unwind.
-        try:
-            from api.clarify import clear_pending as _clear_clarify_pending
+    # Clear any pending clarify prompt so the blocked tool call can unwind.
+    try:
+        from api.clarify import clear_pending as _clear_clarify_pending
 
-            if agent and getattr(agent, "session_id", None):
-                _clear_clarify_pending(agent.session_id)
-        except Exception:
-            logger.debug("Failed to clear clarify prompt during cancel")
+        _clarify_session_id = getattr(agent, "session_id", None) if agent else active_run_session_id
+        if _clarify_session_id:
+            _clear_clarify_pending(_clarify_session_id)
+    except Exception:
+        logger.debug("Failed to clear clarify prompt during cancel")
 
-        # Capture the queue while the stream still exists, but do not emit the
-        # terminal cancel event until the session cleanup below confirms the turn
-        # is still active. Otherwise a late Stop click can race with a successful
-        # worker save and show cancel in the client while persistence says done.
-        q = streams.get(stream_id)
-        _emit_cancel_event = True
+    # Capture the queue while the stream still exists, but do not emit the
+    # terminal cancel event until the session cleanup below confirms the turn
+    # is still active. Otherwise a late Stop click can race with a successful
+    # worker save and show cancel in the client while persistence says done.
+    _emit_cancel_event = True
 
-        # ── Eager session lock release (fixes #653) ──────────────────────────
-        # Pop stream state now so the 409 guard in routes.py sees the session
-        # as idle and allows new /api/chat/start immediately after cancel,
-        # even if the agent thread is still blocked in a C-level syscall.
-        # The worker thread's finally block uses .pop(key, None) too, so a
-        # double-pop here is safe (no-op).
+    # ── Eager session lock release (fixes #653) ──────────────────────────
+    # Pop stream state now so the 409 guard in routes.py sees the session
+    # as idle and allows new /api/chat/start immediately after cancel,
+    # even if the agent thread is still blocked in a C-level syscall.
+    # The worker thread's finally block uses .pop(key, None) too, so a
+    # double-pop here is safe (no-op).
+    if stream_present:
         streams.pop(stream_id, None)
         cancel_flags.pop(stream_id, None)
         agent_instances.pop(stream_id, None)
-        # STREAM_PARTIAL_TEXT is intentionally NOT popped here — the agent thread may
-        # still be appending tokens. We capture the snapshot two lines below; the
-        # streaming finally block handles the cleanup when the thread exits.
+    # STREAM_PARTIAL_TEXT is intentionally NOT popped here — the agent thread may
+    # still be appending tokens. We capture the snapshot two lines below; the
+    # streaming finally block handles the cleanup when the thread exits.
 
-        # Capture partial text and session_id while holding STREAMS_LOCK (avoids a
-        # race where the agent thread deallocates the agent object or clears the
-        # partial text after we release).
-        # Session cleanup (get_session + save) must happen OUTSIDE the lock —
-        # get_session() acquires LOCK, and the streaming thread does LOCK first
-        # then STREAMS_LOCK, so inverting the order here would cause deadlock.
-        _cancel_session_id = getattr(agent, 'session_id', None) if agent else None
-        _cancel_partial_text = partial_texts.get(stream_id, '')
-        # Fallback: check the live config's partial text map if we used an alias
-        # and the text wasn't found in the alias (defensive, matches streams fallback above).
-        if not _cancel_partial_text:
-            live_partials = getattr(_live_config, 'STREAM_PARTIAL_TEXT', partial_texts)
-            if live_partials is not partial_texts:
-                _cancel_partial_text = live_partials.get(stream_id, '')
-        # Capture reasoning trace and live tool calls (#1361 §A + §B)
-        _cancel_reasoning = STREAM_REASONING_TEXT.get(stream_id, '')
-        if not _cancel_reasoning:
-            live_reasoning = getattr(_live_config, 'STREAM_REASONING_TEXT', STREAM_REASONING_TEXT)
-            if live_reasoning is not STREAM_REASONING_TEXT:
-                _cancel_reasoning = live_reasoning.get(stream_id, '')
-        _cancel_tool_calls = STREAM_LIVE_TOOL_CALLS.get(stream_id, [])
-        if not _cancel_tool_calls:
-            live_tools = getattr(_live_config, 'STREAM_LIVE_TOOL_CALLS', STREAM_LIVE_TOOL_CALLS)
-            if live_tools is not STREAM_LIVE_TOOL_CALLS:
-                _cancel_tool_calls = live_tools.get(stream_id, [])
+    # Capture partial text and session_id while holding STREAMS_LOCK (avoids a
+    # race where the agent thread deallocates the agent object or clears the
+    # partial text after we release).
+    # Session cleanup (get_session + save) must happen OUTSIDE the lock —
+    # get_session() acquires LOCK, and the streaming thread does LOCK first
+    # then STREAMS_LOCK, so inverting the order here would cause deadlock.
+    _cancel_session_id = getattr(agent, 'session_id', None) if agent else None
+    if not _cancel_session_id and active_run_session_id:
+        _cancel_session_id = active_run_session_id
+    _cancel_partial_text = partial_texts.get(stream_id, '')
+    # Fallback: check the live config's partial text map if we used an alias
+    # and the text wasn't found in the alias (defensive, matches streams fallback above).
+    if not _cancel_partial_text:
+        live_partials = getattr(_live_config, 'STREAM_PARTIAL_TEXT', partial_texts)
+        if live_partials is not partial_texts:
+            _cancel_partial_text = live_partials.get(stream_id, '')
+    # Capture reasoning trace and live tool calls (#1361 §A + §B)
+    _cancel_reasoning = STREAM_REASONING_TEXT.get(stream_id, '')
+    if not _cancel_reasoning:
+        live_reasoning = getattr(_live_config, 'STREAM_REASONING_TEXT', STREAM_REASONING_TEXT)
+        if live_reasoning is not STREAM_REASONING_TEXT:
+            _cancel_reasoning = live_reasoning.get(stream_id, '')
+    _cancel_tool_calls = STREAM_LIVE_TOOL_CALLS.get(stream_id, [])
+    if not _cancel_tool_calls:
+        live_tools = getattr(_live_config, 'STREAM_LIVE_TOOL_CALLS', STREAM_LIVE_TOOL_CALLS)
+        if live_tools is not STREAM_LIVE_TOOL_CALLS:
+            _cancel_tool_calls = live_tools.get(stream_id, [])
 
     # Session cleanup outside STREAMS_LOCK to preserve lock ordering.
     # Acquire the per-session _agent_lock too, mirroring every other session

--- a/tests/test_cancel_interrupt.py
+++ b/tests/test_cancel_interrupt.py
@@ -2,13 +2,12 @@
 Unit tests for cancel/interrupt functionality.
 Tests the integration between cancel_stream() and agent.interrupt().
 """
-import pytest
 import queue
 import threading
 from unittest.mock import Mock
 
 from api.streaming import cancel_stream
-from api.config import AGENT_INSTANCES, STREAMS, CANCEL_FLAGS
+from api.config import AGENT_INSTANCES, STREAMS, CANCEL_FLAGS, ACTIVE_RUNS, SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
 
 
 class TestCancelInterrupt:
@@ -19,12 +18,18 @@ class TestCancelInterrupt:
         AGENT_INSTANCES.clear()
         STREAMS.clear()
         CANCEL_FLAGS.clear()
+        ACTIVE_RUNS.clear()
+        with SESSION_AGENT_CACHE_LOCK:
+            SESSION_AGENT_CACHE.clear()
 
     def teardown_method(self):
         """Clean up after each test"""
         AGENT_INSTANCES.clear()
         STREAMS.clear()
         CANCEL_FLAGS.clear()
+        ACTIVE_RUNS.clear()
+        with SESSION_AGENT_CACHE_LOCK:
+            SESSION_AGENT_CACHE.clear()
 
     def test_cancel_calls_agent_interrupt(self):
         """Verify that cancel_stream() calls agent.interrupt() when agent exists"""
@@ -90,6 +95,44 @@ class TestCancelInterrupt:
         """Test cancel for a stream that doesn't exist"""
         result = cancel_stream("nonexistent_stream")
         assert result is False
+
+    def test_cancel_falls_back_to_active_run_registry(self):
+        """Cancel should still work when STREAMS is gone but the worker is alive."""
+        from unittest.mock import patch
+
+        stream_id = "detached_stream_123"
+        session_id = "sess_detached_123"
+        mock_agent = Mock()
+        mock_agent.interrupt = Mock()
+        mock_agent.session_id = session_id
+
+        mock_session = Mock()
+        mock_session.session_id = session_id
+        mock_session.active_stream_id = stream_id
+        mock_session.pending_user_message = "hello"
+        mock_session.pending_attachments = ["file.txt"]
+        mock_session.pending_started_at = 1234567890.0
+        mock_session.messages = []
+        mock_session.save = Mock()
+
+        ACTIVE_RUNS[stream_id] = {
+            "session_id": session_id,
+            "started_at": 1234567890.0,
+            "phase": "running",
+        }
+        with SESSION_AGENT_CACHE_LOCK:
+            SESSION_AGENT_CACHE[session_id] = (mock_agent, "sig")
+
+        with patch("api.streaming.get_session", return_value=mock_session):
+            result = cancel_stream(stream_id)
+
+        assert result is True
+        mock_agent.interrupt.assert_called_once_with("Cancelled by user")
+        assert mock_session.active_stream_id is None
+        assert mock_session.pending_user_message is None
+        assert mock_session.pending_attachments == []
+        assert mock_session.pending_started_at is None
+        mock_session.save.assert_called_once()
 
     def test_cancel_sets_cancel_event(self):
         """Verify that cancel_stream() sets the cancel_event flag"""

--- a/tests/test_run_journal_routes.py
+++ b/tests/test_run_journal_routes.py
@@ -41,6 +41,8 @@ def test_session_payload_exposes_runtime_journal_for_stale_streams():
     assert "original_stream_id = getattr(s, \"active_stream_id\", None)" in ROUTES_SRC
     assert '"runtime_journal"' in ROUTES_SRC
     assert 'terminal_state = "lost-worker-bookkeeping"' in ROUTES_SRC
+    assert "active=journal_active" in ROUTES_SRC
+    assert "journal_active = bool(original_stream_id in active_stream_ids)" in ROUTES_SRC
 
 
 def test_status_payload_marks_non_terminal_dead_journal_as_stale():


### PR DESCRIPTION
Closes #3475

Thinking Path
- Live turn cancellation should stop the worker, not just the browser transport.
- The observed bug was an early-cancel startup race: the SSE could detach before the worker was fully reflected in the live stream registry.
- The fix stays narrow: reconcile cancel against the active-run registry/session cache and report run-journal activity from the live registry.
- This is distinct from the double-streaming transport bug in #3401; it is a state-consistency fix for cancel/recovery.

What Changed
- `api/streaming.py`: `cancel_stream()` now falls back to `ACTIVE_RUNS` and the session agent cache when `STREAMS` has already detached, so the worker still receives `interrupt("Cancelled by user")` and the session is cleaned up.
- `api/routes.py`: `/api/session` now reports run-journal active state from the live active-run registry instead of treating any persisted `active_stream_id` as proof that the worker is still alive.
- `tests/test_cancel_interrupt.py`: adds a regression for canceling after `STREAMS` has been removed but the worker is still registered as active.
- `tests/test_run_journal_routes.py`: locks the session payload invariant for the runtime journal active flag.
- `CHANGELOG.md`: records the user-visible behavior fix.

Why It Matters
- Immediate cancel after a message send is a real user action, not an edge case to ignore.
- Before this fix, the UI could keep showing a running spinner while the session page was blank, because the browser stream and worker state had split.
- After this fix, cancel is reconciled against the real live worker state, so the session settles to a cancelled state instead of an inconsistent half-running one.

Verification
- `./.venv/bin/python -m pytest -q tests/test_cancel_interrupt.py tests/test_run_journal_routes.py`
- `git diff --check`
- Live repro was the session startup/cancel race on `8787` where cancel was pressed immediately after send.

Risks / Follow-ups
- This is intentionally scoped to the startup-race cancel path and session-state reconciliation.
- It does not change the broader live-stream transport ownership model or the #3401 double-streaming fix.
- If a future runtime path introduces a new source of live worker state, it should be threaded into the same reconciliation path instead of reintroducing a split-brain cancel state.

Contract Routing
Task type: bugfix for live-stream cancellation / session-state reconciliation
Touched areas: `api/streaming.py`, `api/routes.py`, `tests/test_cancel_interrupt.py`, `tests/test_run_journal_routes.py`, `CHANGELOG.md`
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
Scope boundaries: startup-race cancel/state reconciliation only; no live-stream redesign, no double-streaming transport change
Evidence needed before claiming done: targeted regression tests, diff check, and the user-visible cancel path on the running session

Model Used
- OpenAI Codex (GPT-5)
- Used local repo inspection, `gh`, and targeted pytest to validate the fix.
