### PR TITLE
fix: resolve symlinked home for workspace suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Workspace path autocomplete now expands `~/` suggestions even when the WebUI process home path is a symlink or alias of the trusted home root, so prefixes like `~/Doc` still list home-directory matches instead of returning an empty dropdown (#3433).
+
 ## [v0.51.230] — 2026-06-03 — Release GX (stage-p14 — extract <think> blocks to m.reasoning + LLM Wiki last-writer)
 
 ### Fixed

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -466,7 +466,12 @@ def list_workspace_suggestions(prefix: str = "", limit: int = 12) -> list[str]:
     else:
         target = Path.home() / raw
 
-    normalized = str(target)
+    try:
+        match_target = target.expanduser().resolve()
+    except Exception:
+        match_target = target
+
+    normalized = str(match_target)
     normalized_lower = normalized.lower()
     preserve_tilde = raw.startswith("~")
     home_root: Path | None = None

--- a/tests/test_sprint5.py
+++ b/tests/test_sprint5.py
@@ -1,6 +1,7 @@
 """Sprint 5 tests: workspace CRUD, file save, session index, JS serving."""
 import json, pathlib, uuid, urllib.request, urllib.error, urllib.parse
 import os
+import pytest
 
 from tests._pytest_port import BASE
 
@@ -136,6 +137,26 @@ def test_workspace_suggest_preserves_tilde_prefix_for_partial_child(monkeypatch,
     suggestions = workspace.list_workspace_suggestions("~/Pro")
 
     assert suggestions == ["~/Projects"]
+
+
+def test_workspace_suggest_expands_tilde_when_home_is_symlink(monkeypatch, tmp_path):
+    from api import workspace
+
+    actual_home = tmp_path / "actual-home"
+    child = actual_home / "Documents"
+    child.mkdir(parents=True)
+    link_home = tmp_path / "link-home"
+    try:
+        link_home.symlink_to(actual_home, target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks are not available in this environment: {exc}")
+
+    monkeypatch.setenv("HOME", str(link_home))
+    monkeypatch.setattr(workspace, "_trusted_workspace_roots", lambda: [actual_home.resolve()])
+
+    suggestions = workspace.list_workspace_suggestions("~/Doc")
+
+    assert suggestions == ["~/Documents"]
 
 
 def test_workspace_suggest_keeps_absolute_prefix_absolute(monkeypatch, tmp_path):


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI keeps workspace path autocomplete under trusted workspace roots.
- The suggestion roots are resolved paths, but the typed `~` target was compared before resolution.
- When the WebUI process home is a symlink or path alias, a prefix like `~/Doc` can expand to the alias path while the trusted home root is the resolved path.
- Resolving the target before the trust comparison lets the endpoint find the trusted root while preserving the existing `~/...` suggestion formatting.

Refs #3433.

## What Changed

- Resolve the workspace suggestion target before comparing it with trusted roots.
- Add regression coverage for partial `~/Doc` suggestions when `HOME` points at a symlinked home directory.
- Add a changelog note for the user-visible autocomplete fix.

## Why It Matters

Users with symlinked or aliased home paths can see an empty workspace path dropdown for `~/...` prefixes even though the matching home directories are trusted. This keeps the trust boundary unchanged and only normalizes the path used for matching.

## Verification

- `/tmp/hermes-webui-pr-venv/bin/python -m pytest tests/test_sprint5.py::test_workspace_suggest_expands_tilde_when_home_is_symlink -v --timeout=60` (failed before the production fix, passed after)
- `/tmp/hermes-webui-pr-venv/bin/python -m pytest tests/test_sprint5.py -k 'workspace_suggest' -v --timeout=60`
- `/tmp/hermes-webui-pr-venv/bin/python -m pytest tests/test_sprint5.py -v --timeout=60`
- `/tmp/hermes-webui-pr-venv/bin/python scripts/ruff_lint.py --diff origin/master`
- `git diff --check`
- `git diff --check origin/master...HEAD`

## Risks / Follow-ups

This addresses the symlink/alias home-root case behind an empty `~/...` completion list. It does not change behavior when the WebUI server is running as a different user or inside a container whose home directory genuinely differs from the browser user's home.

The full-file ruff check still reports existing backlog outside the changed lines in `api/workspace.py` and `tests/test_sprint5.py`; the repo's diff-scoped lint gate passes with zero new violations.

## Model Used

Provider: OpenAI  
Model: GPT-5 via Codex desktop  
Notable tool use: local shell/git/GitHub CLI; no parallel editing agents.
