### PR TITLE
fix: /model resolves models from the truncated extra_models tail (#3368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- `/model <name>` can now select a model that lives in the **truncated `extra_models` tail** of a large provider catalog. On catalogs with more than ~25 models (e.g. a Nous Portal subscription), the picker renders only a *featured* subset as `<option>` entries and pushes the rest into `extra_models` (`_build_nous_featured_set`, `api/config.py`). The curated flagship set carries `xiaomi/mimo-v2.5-pro` but not the bare `xiaomi/mimo-v2.5`, so the bare model existed only in the extras tail — and `cmdModel` resolved only against the rendered `<select>` options, never the full catalog. Result: `/model mimo-v2.5` could not reach the real (cheaper) `mimo-v2.5` tier — it either snapped to `-pro` (pre-#3437) or was rejected with a misleading *"did you mean mimo-v2.5-pro?"* toast (#3437), even though the model is genuinely selectable from the CLI/TUI. `cmdModel` now builds its candidate set from the full `/api/models` catalog (featured `models` + `extra_models`) via a new `_buildModelCandidates()` helper — the same complete list the CLI and the `/model` autocomplete already use — so an exact bare model in the extras tail wins via the existing exact/shortest-match logic. When the resolved model is an extras-only entry (not a rendered `<option>`), the option is injected with its provider before selection so `onchange()` persists `model` + `model_provider` end-to-end. The #3437 tier-guard is preserved: when the bare model is genuinely absent, `/model` still refuses to snap to `-pro` and offers the suggestion toast instead. `mimo-v2.5-pro` stays reachable by its full name and legit shorthand is unchanged. Verified end-to-end in a real headless browser against a synthetic Nous catalog (#3368, with @garyd9; thanks @yutaotie for confirmation).
+
+
 ## [v0.51.230] — 2026-06-03 — Release GX (stage-p14 — extract <think> blocks to m.reasoning + LLM Wiki last-writer)
 
 ### Fixed

--- a/static/commands.js
+++ b/static/commands.js
@@ -339,6 +339,39 @@ function _looksLikeVersionedModel(query){
   // e.g. "mimo-v2.5", "gpt-5.5", "claude-opus-4.6" — ends in a digit.
   return /\d$/.test(String(query||''));
 }
+// Build the full /model candidate set from the catalog groups returned by
+// /api/models: featured `models` PLUS the truncated `extra_models` tail. Large
+// provider catalogs (e.g. a Nous Portal subscription with >25 models) only
+// render a "featured" subset as <option> entries — the rest live in
+// extra_models and never become <select> options (see _build_nous_featured_set
+// in api/config.py). The slash command exists precisely so power users can reach
+// ANY catalog model by name, the same way the CLI/autocomplete can, so /model
+// must resolve against this full list — not just the rendered picker options.
+// Falls back to the live <select> options when the catalog fetch failed.
+// Each entry mimics the <option> shape (value + textContent) so it can be passed
+// straight to _bestModelMatch / _nearestModelSuggestion. Also returns a
+// value->provider_id map so an extras-only winner can be injected with the right
+// provider. (#3368)
+function _buildModelCandidates(sel,groups){
+  const options=[];
+  const providerMap={};
+  if(Array.isArray(groups)&&groups.length){
+    for(const g of groups){
+      const pid=(g&&g.provider_id)||'';
+      const push=m=>{
+        if(!m||!m.id) return;
+        options.push({value:m.id,textContent:m.label||m.id});
+        if(pid&&!(m.id in providerMap)) providerMap[m.id]=pid;
+      };
+      for(const m of (Array.isArray(g.models)?g.models:[])) push(m);
+      for(const m of (Array.isArray(g.extra_models)?g.extra_models:[])) push(m);
+    }
+  }
+  if(!options.length&&sel){
+    for(const o of Array.from(sel.options||[])) options.push({value:o.value,textContent:o.textContent});
+  }
+  return {options,providerMap};
+}
 function _bestModelMatch(options,query){
   let best=null;
   const versioned=_looksLikeVersionedModel(query);
@@ -384,13 +417,19 @@ async function cmdModel(args){
   const sel=$('modelSelect');
   if(!sel)return;
   let q=args.toLowerCase();
-  // Resolve alias before fuzzy matching the dropdown.
-  // Fetch /api/models which now includes an "aliases" key.
+  // Fetch /api/models once: it carries both the alias map AND the full catalog
+  // groups (featured `models` + truncated `extra_models`). Resolve aliases, then
+  // build the full candidate set so /model can reach ANY catalog model by name —
+  // not just the subset rendered as <option> entries. On large provider catalogs
+  // (e.g. a Nous Portal subscription) the picker only renders ~25 "featured"
+  // models; the rest live in extra_models and are absent from sel.options. The
+  // CLI resolves against the full catalog, so /model must too. (#3368)
+  let modelsData=null;
   try {
     const resp=await fetch('/api/models');
     if(resp.ok){
-      const data=await resp.json();
-      const aliases=data.aliases||{};
+      modelsData=await resp.json();
+      const aliases=modelsData.aliases||{};
       for(const [alias,modelId] of Object.entries(aliases)){
         if(alias.toLowerCase()===q){
           q=modelId.toLowerCase(); // resolve alias to real model id e.g. "deepseek/deepseek-v4-flash"
@@ -399,25 +438,28 @@ async function cmdModel(args){
       }
     }
   } catch(_){/* non-critical, fall through to fuzzy match */}
+  const {options:candidates,providerMap}=_buildModelCandidates(sel,modelsData&&modelsData.groups);
   // First: try exact match within active provider's optgroup.
   // Use _findModelInDropdown (ui.js) which supports preferredProviderId.
   const preferred=(S&&S.session&&S.session.model_provider)||window._activeProvider||null;
   let match=(typeof _findModelInDropdown==='function')?_findModelInDropdown(q,sel,preferred):null;
-  // Fallback: fuzzy match across all options
+  // Fallback: fuzzy match across the FULL catalog (featured + extras), so an
+  // exact bare model living in the extras tail (e.g. "mimo-v2.5" alongside the
+  // featured "mimo-v2.5-pro") still wins — exact/shortest-match in _bestModelMatch.
   if(!match){
-    match=_bestModelMatch(sel.options,q);
+    match=_bestModelMatch(candidates,q);
   }
   // Fallback: if q has provider/ prefix (e.g. "deepseek/deepseek-v4-flash"),
   // try the bare model name (which is how options appear for the active provider)
   if(!match && q.includes('/')){
     const bare=q.slice(q.lastIndexOf('/')+1);
-    match=_bestModelMatch(sel.options,bare);
+    match=_bestModelMatch(candidates,bare);
     // #3368: a versioned slash-qualified query whose only near catalog entry is a
     // rejected tier variant (e.g. "xiaomi/mimo-v2.5" when only "xiaomi/mimo-v2.5-pro"
     // exists) must NOT silently direct-update to the invalid name — fall through to
     // the no-match/"did you mean?" toast instead. The cross-provider direct-update
     // path below is only for genuinely off-catalog providers with no near variant.
-    const nearSuggestion=_nearestModelSuggestion(sel.options,q)||_nearestModelSuggestion(sel.options,bare);
+    const nearSuggestion=_nearestModelSuggestion(candidates,q)||_nearestModelSuggestion(candidates,bare);
     const versionedNoSnap=_looksLikeVersionedModel(bare)&&nearSuggestion;
     // Cross-provider fallback: if still no match, the model is from a
     // different provider not in the dropdown. Call /api/session/update directly.
@@ -449,7 +491,7 @@ async function cmdModel(args){
     // to it — say no-match and suggest the near variant so the user can opt in.
     // no_model_match already ends with an opening quote, so close it with args+".
     let msg=t('no_model_match')+`${args}"`;
-    const suggestion=_nearestModelSuggestion(sel.options,q);
+    const suggestion=_nearestModelSuggestion(candidates,q);
     if(suggestion){
       // model_did_you_mean is a placeholder template; t() invokes it with the
       // suggestion as its arg. (Calling t() without the arg renders "undefined".)
@@ -458,7 +500,17 @@ async function cmdModel(args){
     showToast(msg);
     return;
   }
-  sel.value=match;
+  // The winning model may live in the extras tail (not a rendered <option>), so
+  // a bare `sel.value=match` would silently no-op. Inject the option with its
+  // provider before selecting so onchange() persists the correct model+provider
+  // end-to-end. _ensureModelOptionInDropdown reuses the existing option when one
+  // is already rendered. (#3368)
+  const hasOption=Array.from(sel.options||[]).some(o=>o.value===match);
+  if(!hasOption && typeof _ensureModelOptionInDropdown==='function'){
+    _ensureModelOptionInDropdown(match,sel,providerMap[match]||null);
+  }else{
+    sel.value=match;
+  }
   await sel.onchange();
   showToast(t('switched_to')+match);
 }

--- a/tests/test_issue3368_model_prefix_shadowing.py
+++ b/tests/test_issue3368_model_prefix_shadowing.py
@@ -111,6 +111,66 @@ def best_driver(tmp_path_factory):
     return str(p)
 
 
+# ── driver for _buildModelCandidates + _bestModelMatch over the FULL catalog ──
+# This is the layer the reporter's case actually needed: on large provider
+# catalogs the bare model lives in `extra_models` (not a rendered <option>), so
+# /model must resolve against featured `models` PLUS `extra_models`. (#3368)
+
+_CATALOG_DRIVER = r"""
+const fs = require('fs');
+const cmds = fs.readFileSync(process.argv[2], 'utf8');
+function extractFunc(src, name){
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start); let depth = 1; i++;
+  while (depth > 0 && i < src.length){ if(src[i]==='{')depth++; else if(src[i]==='}')depth--; i++; }
+  return src.slice(start, i);
+}
+eval(extractFunc(cmds, '_buildModelCandidates'));
+eval(extractFunc(cmds, '_looksLikeVersionedModel'));
+eval(extractFunc(cmds, '_bestModelMatch'));
+eval(extractFunc(cmds, '_nearestModelSuggestion'));
+const args = JSON.parse(process.argv[3]);
+// args.groups: [{provider_id, models:[{id,label}], extra_models:[{id,label}]}]
+// args.selOptions: ids rendered as <option> (the featured subset)
+const sel = { options: (args.selOptions||[]).map(v => ({value: v, textContent: v})) };
+const { options: candidates, providerMap } = _buildModelCandidates(sel, args.groups);
+// Mirror cmdModel's fallback chain for a query (skipping _findModelInDropdown,
+// which is exercised by the find_driver tests and returns null for these cases).
+let q = String(args.query||'').toLowerCase();
+let match = _bestModelMatch(candidates, q);
+if(!match && q.includes('/')){
+  const bare = q.slice(q.lastIndexOf('/')+1);
+  match = _bestModelMatch(candidates, bare);
+}
+process.stdout.write(JSON.stringify({
+  candidateCount: candidates.length,
+  match,
+  provider: match ? (providerMap[match]||null) : null,
+  suggestion: _nearestModelSuggestion(candidates, q),
+}));
+"""
+
+
+@pytest.fixture(scope="module")
+def catalog_driver(tmp_path_factory):
+    p = tmp_path_factory.mktemp("catalog3368") / "driver.js"
+    p.write_text(_CATALOG_DRIVER, encoding="utf-8")
+    return str(p)
+
+
+def _resolve(driver, query, groups, sel_options):
+    r = subprocess.run(
+        [NODE, driver, str(COMMANDS_JS_PATH),
+         json.dumps({"query": query, "groups": groups, "selOptions": sel_options})],
+        capture_output=True, text=True, timeout=10,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(f"node driver failed: {r.stderr}")
+    return json.loads(r.stdout)
+
+
 def _find(driver, model_id, options, preferred=None):
     r = subprocess.run(
         [NODE, driver, str(UI_JS_PATH),
@@ -300,3 +360,139 @@ class TestSlashQualifiedVersionedNoSnap:
             "the /api/session/update cross-provider fallback must be gated on "
             "!versionedNoSnap so a versioned tier-variant near-miss doesn't silently persist"
         )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# FULL-CATALOG resolution — garyd9's actual case (#3368 reopened correction)
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# garyd9 (Nous Portal subscriber) confirmed `xiaomi/mimo-v2.5` is a REAL,
+# distinct, separately-selectable model — selectable in the TUI and CLI. His
+# Nous catalog (>25 models) gets truncated by _build_nous_featured_set
+# (api/config.py): the curated flagship set carries mimo-v2.5-PRO so that's a
+# rendered <option>, while the bare mimo-v2.5 lands in `extra_models` and is
+# NOT a <select> option. The pre-fix /model resolved only against sel.options,
+# so the bare model was unreachable and the #3437 tier-guard fired a misleading
+# "did you mean mimo-v2.5-pro?" toast on a model that actually exists.
+#
+# The fix: /model resolves against the FULL catalog (featured `models` +
+# `extra_models`) — the same complete list the CLI and autocomplete use. With
+# the bare model in the candidate set, exact/shortest-match wins and lands on
+# mimo-v2.5, while mimo-v2.5-pro stays reachable by its full name.
+
+
+class TestFullCatalogResolution:
+    """The bare model lives in extra_models (truncated catalog tail). /model must
+    still resolve to it end-to-end — this is garyd9's exact reported case."""
+
+    # A realistic truncated Nous catalog: -pro is featured (rendered <option>),
+    # bare mimo-v2.5 is in the extras tail (absent from sel.options).
+    GROUPS = [{
+        "provider": "Nous Portal (3 of 6)",
+        "provider_id": "nous",
+        "models": [
+            {"id": "@nous:anthropic/claude-opus-4.8", "label": "Claude Opus 4.8 (via Nous)"},
+            {"id": "@nous:openai/gpt-5.5", "label": "GPT-5.5 (via Nous)"},
+            {"id": "@nous:xiaomi/mimo-v2.5-pro", "label": "Mimo V2.5 Pro (via Nous)"},
+        ],
+        "extra_models": [
+            {"id": "@nous:xiaomi/mimo-v2.5", "label": "Mimo V2.5 (via Nous)"},
+            {"id": "@nous:xiaomi/mimo-v2-pro", "label": "Mimo V2 Pro (via Nous)"},
+            {"id": "@nous:deepseek/deepseek-v4-flash", "label": "DeepSeek V4 Flash (via Nous)"},
+        ],
+    }]
+    # What the picker actually renders (featured only).
+    SEL = [
+        "@nous:anthropic/claude-opus-4.8",
+        "@nous:openai/gpt-5.5",
+        "@nous:xiaomi/mimo-v2.5-pro",
+    ]
+
+    def test_candidate_set_includes_extras(self, catalog_driver):
+        out = _resolve(catalog_driver, "mimo-v2.5", self.GROUPS, self.SEL)
+        # 3 featured + 3 extras = 6; the bare model must be reachable.
+        assert out["candidateCount"] == 6
+
+    def test_bare_mimo_v25_resolves_from_extras(self, catalog_driver):
+        """garyd9's exact case: /model mimo-v2.5 lands on the bare model, NOT -pro."""
+        out = _resolve(catalog_driver, "mimo-v2.5", self.GROUPS, self.SEL)
+        assert out["match"] == "@nous:xiaomi/mimo-v2.5", (
+            f"bare mimo-v2.5 must resolve to itself from the extras tail, got {out['match']!r}"
+        )
+        assert out["provider"] == "nous", "resolved model must carry its provider for routing"
+
+    def test_qualified_bare_resolves_from_extras(self, catalog_driver):
+        out = _resolve(catalog_driver, "xiaomi/mimo-v2.5", self.GROUPS, self.SEL)
+        assert out["match"] == "@nous:xiaomi/mimo-v2.5"
+        assert out["provider"] == "nous"
+
+    def test_pro_still_reachable_by_full_name(self, catalog_driver):
+        out = _resolve(catalog_driver, "mimo-v2.5-pro", self.GROUPS, self.SEL)
+        assert out["match"] == "@nous:xiaomi/mimo-v2.5-pro"
+
+    def test_qualified_pro_still_reachable(self, catalog_driver):
+        out = _resolve(catalog_driver, "xiaomi/mimo-v2.5-pro", self.GROUPS, self.SEL)
+        assert out["match"] == "@nous:xiaomi/mimo-v2.5-pro"
+
+    def test_extras_only_model_reachable(self, catalog_driver):
+        """A non-versioned extras-only model (deepseek-v4-flash) is also reachable."""
+        out = _resolve(catalog_driver, "deepseek-v4-flash", self.GROUPS, self.SEL)
+        assert out["match"] == "@nous:deepseek/deepseek-v4-flash"
+
+    def test_incomplete_version_continues_to_longer(self, catalog_driver):
+        """mimo-v2 is an incomplete version; resolving to the shortest continuation
+        (bare mimo-v2.5) is correct now that it's in the catalog."""
+        out = _resolve(catalog_driver, "mimo-v2", self.GROUPS, self.SEL)
+        assert out["match"] == "@nous:xiaomi/mimo-v2.5"
+
+    def test_truly_absent_bare_still_no_snap_and_suggests(self, catalog_driver):
+        """When the bare model is genuinely absent (only -pro in BOTH featured and
+        extras), the tier-guard still fires: no snap, and -pro is suggested."""
+        groups = [{
+            "provider": "Nous Portal",
+            "provider_id": "nous",
+            "models": [{"id": "@nous:xiaomi/mimo-v2.5-pro", "label": "Mimo V2.5 Pro"}],
+            "extra_models": [],
+        }]
+        out = _resolve(catalog_driver, "mimo-v2.5", groups, ["@nous:xiaomi/mimo-v2.5-pro"])
+        assert out["match"] is None, "must not snap to -pro when bare model truly absent"
+        assert out["suggestion"] == "@nous:xiaomi/mimo-v2.5-pro"
+
+    def test_falls_back_to_sel_options_when_no_groups(self, catalog_driver):
+        """If the /api/models fetch failed (no groups), candidates fall back to the
+        live <select> options so /model still works in a degraded state."""
+        out = _resolve(catalog_driver, "gpt-5.5", None, self.SEL)
+        assert out["candidateCount"] == 3
+        assert out["match"] == "@nous:openai/gpt-5.5"
+
+
+class TestCmdModelFullCatalogWiring:
+    """Source-level guards: cmdModel must build candidates from the catalog and
+    inject the option before selecting, so an extras-only winner is honored."""
+
+    @pytest.fixture(scope="class")
+    def commands_src(self):
+        import pathlib
+        root = pathlib.Path(__file__).resolve().parents[1]
+        return (root / "static" / "commands.js").read_text(encoding="utf-8")
+
+    def test_builds_candidates_from_catalog_groups(self, commands_src):
+        assert "_buildModelCandidates(sel,modelsData&&modelsData.groups)" in commands_src
+
+    def test_helper_reads_models_and_extra_models(self, commands_src):
+        idx = commands_src.find("function _buildModelCandidates")
+        assert idx != -1
+        window = commands_src[idx:idx + 900]
+        assert "g.models" in window and "g.extra_models" in window, (
+            "the candidate builder must read both featured models and the extras tail"
+        )
+
+    def test_resolves_against_candidates_not_sel_options(self, commands_src):
+        # The fuzzy fallbacks must run over the full candidate set, not sel.options.
+        assert "_bestModelMatch(candidates,q)" in commands_src
+        assert "_bestModelMatch(sel.options,q)" not in commands_src
+
+    def test_injects_option_for_extras_only_winner(self, commands_src):
+        # An extras-only match isn't a rendered <option>; cmdModel must inject it
+        # (with provider) before selecting, or sel.value=match silently no-ops.
+        assert "_ensureModelOptionInDropdown(match,sel,providerMap[match]||null)" in commands_src


### PR DESCRIPTION
## Summary

`/model <name>` can now select a model that lives in the **truncated `extra_models` tail** of a large provider catalog. This completes the #3368 fix that v0.51.229 (#3437) left half-done — and resolves @garyd9's latest correction that `xiaomi/mimo-v2.5` is a **real, selectable model** that should resolve, not be rejected.

Closes #3368.

## The bug @garyd9 reported

After v0.51.229, `/model mimo-v2.5` still didn't work — it showed *"No model matching 'mimo-v2.5' — did you mean 'mimo-v2.5-pro'?"*. But `xiaomi/mimo-v2.5` is a genuine, distinct (cheaper) Nous Portal tier, selectable in the TUI and the CLI. As he put it: *"If it can resolve mimo-v2.5-pro it should be able to resolve mimo-v2.5."* He's right.

## Root cause (verified end-to-end)

This was never really a matcher problem — it was a **catalog-coverage** problem.

- On Nous catalogs with >25 models, `_build_nous_featured_set` (`api/config.py`) renders only a *featured* subset as `<select>` `<option>` entries and pushes the rest into `extra_models` (so the dropdown stays scannable — #1567).
- The curated flagship set carries `xiaomi/mimo-v2.5-pro` but **not** the bare `xiaomi/mimo-v2.5`, so the bare model lived **only in the extras tail**.
- `cmdModel` (`static/commands.js`) resolved only against `sel.options` — the *rendered* subset — so the bare model was unreachable. It then either snapped to `-pro` (pre-#3437) or hit the #3437 tier-guard and produced the misleading "did you mean -pro?" toast.

The CLI and the `/model` **autocomplete** already resolve against the full catalog (`models` + `extra_models`). The resolver was the one place that didn't. So `/model mimo-v2.5` could be *suggested* but not *selected*.

## The fix (`static/commands.js`)

1. **New `_buildModelCandidates(sel, groups)`** — builds the candidate set from the full `/api/models` catalog (featured `models` **+** `extra_models`), the same complete list the CLI and autocomplete use. Returns `{options, providerMap}`; falls back to the live `sel.options` if the `/api/models` fetch failed.
2. **`cmdModel` resolves against the full candidate set** instead of `sel.options`. It already fetched `/api/models` (for the alias map) — now it reuses that payload, so there's no extra request. The existing `_bestModelMatch` / `_nearestModelSuggestion` fallbacks run unchanged over the fuller list, so an exact bare model in the extras tail wins via exact/shortest-match.
3. **Extras-only winners are injected before selection.** When the resolved model isn't a rendered `<option>` (it's in the extras tail), `_ensureModelOptionInDropdown(match, sel, providerMap[match])` injects it with its provider, so `onchange()` persists `model` + `model_provider` end-to-end. (A bare `sel.value=match` on a non-existent option silently no-ops — that's what made the model unselectable.)

**The #3437 tier-guard is fully preserved.** When the bare model is *genuinely* absent from the whole catalog, `_bestModelMatch` still refuses to snap a complete versioned name to a `-pro`/`-flash` tier, and `/model` still shows the suggestion toast. `mimo-v2.5-pro` stays reachable by its full name; legit shorthand (`/model gpt-5`, `/model claude`, `/model mimo-v2`) is unchanged.

## Verification

**End-to-end in a real headless Chromium** against a synthetic truncated Nous catalog where `mimo-v2.5` is only in `extra_models` (the picker renders `mimo-v2.5-pro` but not the bare model — exactly @garyd9's situation):

- `/model mimo-v2.5` → `S.session.model = "@nous:xiaomi/mimo-v2.5"`, provider `nous`
- the real `/api/session/update` POST carried `{model: "@nous:xiaomi/mimo-v2.5", model_provider: "nous"}` — selected **and** persisted
- `<option>` injected, `<select>` value set
- `mimo-v2.5-pro` still reachable by full name
- zero console errors

**Tests:** 32 in `tests/test_issue3368_model_prefix_shadowing.py` (19 existing + 13 new — full-catalog resolution + extras-injection wiring) + `test_nous_portal_routing.py` all green. `node -c`, ESLint runtime gate, ruff forward gate, and the browser-smoke gate all CLEAN.

Thanks @garyd9 for pushing back on the premature close instead of letting it stand, and @yutaotie for the independent confirmation. 🙏
