### PR TITLE
Release v0.51.231 — Release GY (stage-q1): /model extras-tail + plugins-tab auto-hide + search-depth guard + symlink-home suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 ## [Unreleased]
 
+## [v0.51.231] — 2026-06-03 — Release GY (stage-q1 — /model extras-tail resolution + plugins-tab auto-hide + search-depth guard + symlink-home suggestions)
+
+### Fixed
+- `/model <name>` can now select a model that lives in the **truncated `extra_models` tail** of a large provider catalog, completing the #3368 fix that v0.51.229 left half-done. On Nous-style catalogs with >25 models the picker renders only a featured subset as `<option>` entries and pushes the rest into `extra_models`; the `/model` resolver previously matched only against the rendered `sel.options`, so a bare model living only in the extras tail (e.g. `xiaomi/mimo-v2.5` alongside the featured `xiaomi/mimo-v2.5-pro`) was un-selectable and produced a misleading "did you mean -pro?" toast. A new `_buildModelCandidates()` (`static/commands.js`) now builds the candidate set from the full `/api/models` catalog (featured `models` + `extra_models`) — the same complete list the CLI and `/model` autocomplete use — and an extras-only winner is injected via `_ensureModelOptionInDropdown()` before selection so the correct `model` + `model_provider` persist end-to-end. The #3437 tier-guard is fully preserved: a genuinely off-catalog versioned name still refuses to snap to a `-pro`/`-flash` tier and shows the suggestion toast (#3368, @nesquena-hermes; with @garyd9, confirmation @yutaotie).
+- The **Plugins** tab in Settings is now auto-hidden when no plugins are installed (`/api/plugins` returns `empty: true`), and deep-linking to the hidden plugins pane falls back to the Conversation section. The tab reappears automatically when plugins are detected (#3457, @pix0127).
+- `GET /api/sessions/search?...&depth=<x>` no longer returns a confusing HTTP 500 on a non-numeric `depth` (e.g. `?depth=deep`) and no longer silently excludes the newest messages on a negative `depth` (which sliced as `messages[:-n]`). `depth` is now parsed defensively and clamped to `>= 0` (0 keeps its existing "search the full transcript" meaning), mirroring the guard sibling handlers already use (#3474, @Mubashirrrr).
+- Workspace path autocomplete now expands `~/` suggestions even when the WebUI process home path is a symlink or alias of the trusted home root, so prefixes like `~/Doc` still list home-directory matches instead of returning an empty dropdown. The typed `~` target is now resolved before the trust comparison (#3433, @sjh9714).
+
 ## [v0.51.230] — 2026-06-03 — Release GX (stage-p14 — extract <think> blocks to m.reasoning + LLM Wiki last-writer)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -8188,7 +8188,15 @@ def _handle_sessions_search(handler, parsed):
     qs = parse_qs(parsed.query)
     q = qs.get("q", [""])[0].lower().strip()
     content_search = qs.get("content", ["1"])[0] == "1"
-    depth = int(qs.get("depth", ["5"])[0])
+    # Reject a malformed depth instead of letting int() raise ValueError and
+    # surface as a confusing 500. Clamp to >= 0 so a negative value can't reach
+    # the messages[:depth] slice below — messages[:-n] would silently exclude
+    # the most recent messages from the content search instead of capping it.
+    # (depth == 0 keeps its existing meaning: search the full transcript.)
+    try:
+        depth = max(0, int(qs.get("depth", ["5"])[0]))
+    except (ValueError, TypeError):
+        depth = 5
     if not q:
         safe_sessions = []
         for s in all_sessions():

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -466,7 +466,12 @@ def list_workspace_suggestions(prefix: str = "", limit: int = 12) -> list[str]:
     else:
         target = Path.home() / raw
 
-    normalized = str(target)
+    try:
+        match_target = target.expanduser().resolve()
+    except Exception:
+        match_target = target
+
+    normalized = str(match_target)
     normalized_lower = normalized.lower()
     preserve_tilde = raw.startswith("~")
     home_root: Path | None = None

--- a/static/commands.js
+++ b/static/commands.js
@@ -339,6 +339,39 @@ function _looksLikeVersionedModel(query){
   // e.g. "mimo-v2.5", "gpt-5.5", "claude-opus-4.6" — ends in a digit.
   return /\d$/.test(String(query||''));
 }
+// Build the full /model candidate set from the catalog groups returned by
+// /api/models: featured `models` PLUS the truncated `extra_models` tail. Large
+// provider catalogs (e.g. a Nous Portal subscription with >25 models) only
+// render a "featured" subset as <option> entries — the rest live in
+// extra_models and never become <select> options (see _build_nous_featured_set
+// in api/config.py). The slash command exists precisely so power users can reach
+// ANY catalog model by name, the same way the CLI/autocomplete can, so /model
+// must resolve against this full list — not just the rendered picker options.
+// Falls back to the live <select> options when the catalog fetch failed.
+// Each entry mimics the <option> shape (value + textContent) so it can be passed
+// straight to _bestModelMatch / _nearestModelSuggestion. Also returns a
+// value->provider_id map so an extras-only winner can be injected with the right
+// provider. (#3368)
+function _buildModelCandidates(sel,groups){
+  const options=[];
+  const providerMap={};
+  if(Array.isArray(groups)&&groups.length){
+    for(const g of groups){
+      const pid=(g&&g.provider_id)||'';
+      const push=m=>{
+        if(!m||!m.id) return;
+        options.push({value:m.id,textContent:m.label||m.id});
+        if(pid&&!(m.id in providerMap)) providerMap[m.id]=pid;
+      };
+      for(const m of (Array.isArray(g.models)?g.models:[])) push(m);
+      for(const m of (Array.isArray(g.extra_models)?g.extra_models:[])) push(m);
+    }
+  }
+  if(!options.length&&sel){
+    for(const o of Array.from(sel.options||[])) options.push({value:o.value,textContent:o.textContent});
+  }
+  return {options,providerMap};
+}
 function _bestModelMatch(options,query){
   let best=null;
   const versioned=_looksLikeVersionedModel(query);
@@ -384,13 +417,19 @@ async function cmdModel(args){
   const sel=$('modelSelect');
   if(!sel)return;
   let q=args.toLowerCase();
-  // Resolve alias before fuzzy matching the dropdown.
-  // Fetch /api/models which now includes an "aliases" key.
+  // Fetch /api/models once: it carries both the alias map AND the full catalog
+  // groups (featured `models` + truncated `extra_models`). Resolve aliases, then
+  // build the full candidate set so /model can reach ANY catalog model by name —
+  // not just the subset rendered as <option> entries. On large provider catalogs
+  // (e.g. a Nous Portal subscription) the picker only renders ~25 "featured"
+  // models; the rest live in extra_models and are absent from sel.options. The
+  // CLI resolves against the full catalog, so /model must too. (#3368)
+  let modelsData=null;
   try {
     const resp=await fetch('/api/models');
     if(resp.ok){
-      const data=await resp.json();
-      const aliases=data.aliases||{};
+      modelsData=await resp.json();
+      const aliases=modelsData.aliases||{};
       for(const [alias,modelId] of Object.entries(aliases)){
         if(alias.toLowerCase()===q){
           q=modelId.toLowerCase(); // resolve alias to real model id e.g. "deepseek/deepseek-v4-flash"
@@ -399,25 +438,28 @@ async function cmdModel(args){
       }
     }
   } catch(_){/* non-critical, fall through to fuzzy match */}
+  const {options:candidates,providerMap}=_buildModelCandidates(sel,modelsData&&modelsData.groups);
   // First: try exact match within active provider's optgroup.
   // Use _findModelInDropdown (ui.js) which supports preferredProviderId.
   const preferred=(S&&S.session&&S.session.model_provider)||window._activeProvider||null;
   let match=(typeof _findModelInDropdown==='function')?_findModelInDropdown(q,sel,preferred):null;
-  // Fallback: fuzzy match across all options
+  // Fallback: fuzzy match across the FULL catalog (featured + extras), so an
+  // exact bare model living in the extras tail (e.g. "mimo-v2.5" alongside the
+  // featured "mimo-v2.5-pro") still wins — exact/shortest-match in _bestModelMatch.
   if(!match){
-    match=_bestModelMatch(sel.options,q);
+    match=_bestModelMatch(candidates,q);
   }
   // Fallback: if q has provider/ prefix (e.g. "deepseek/deepseek-v4-flash"),
   // try the bare model name (which is how options appear for the active provider)
   if(!match && q.includes('/')){
     const bare=q.slice(q.lastIndexOf('/')+1);
-    match=_bestModelMatch(sel.options,bare);
+    match=_bestModelMatch(candidates,bare);
     // #3368: a versioned slash-qualified query whose only near catalog entry is a
     // rejected tier variant (e.g. "xiaomi/mimo-v2.5" when only "xiaomi/mimo-v2.5-pro"
     // exists) must NOT silently direct-update to the invalid name — fall through to
     // the no-match/"did you mean?" toast instead. The cross-provider direct-update
     // path below is only for genuinely off-catalog providers with no near variant.
-    const nearSuggestion=_nearestModelSuggestion(sel.options,q)||_nearestModelSuggestion(sel.options,bare);
+    const nearSuggestion=_nearestModelSuggestion(candidates,q)||_nearestModelSuggestion(candidates,bare);
     const versionedNoSnap=_looksLikeVersionedModel(bare)&&nearSuggestion;
     // Cross-provider fallback: if still no match, the model is from a
     // different provider not in the dropdown. Call /api/session/update directly.
@@ -449,7 +491,7 @@ async function cmdModel(args){
     // to it — say no-match and suggest the near variant so the user can opt in.
     // no_model_match already ends with an opening quote, so close it with args+".
     let msg=t('no_model_match')+`${args}"`;
-    const suggestion=_nearestModelSuggestion(sel.options,q);
+    const suggestion=_nearestModelSuggestion(candidates,q);
     if(suggestion){
       // model_did_you_mean is a placeholder template; t() invokes it with the
       // suggestion as its arg. (Calling t() without the arg renders "undefined".)
@@ -458,7 +500,17 @@ async function cmdModel(args){
     showToast(msg);
     return;
   }
-  sel.value=match;
+  // The winning model may live in the extras tail (not a rendered <option>), so
+  // a bare `sel.value=match` would silently no-op. Inject the option with its
+  // provider before selecting so onchange() persists the correct model+provider
+  // end-to-end. _ensureModelOptionInDropdown reuses the existing option when one
+  // is already rendered. (#3368)
+  const hasOption=Array.from(sel.options||[]).some(o=>o.value===match);
+  if(!hasOption && typeof _ensureModelOptionInDropdown==='function'){
+    _ensureModelOptionInDropdown(match,sel,providerMap[match]||null);
+  }else{
+    sel.value=match;
+  }
   await sel.onchange();
   showToast(t('switched_to')+match);
 }

--- a/static/panels.js
+++ b/static/panels.js
@@ -5723,7 +5723,16 @@ function switchSettingsSection(name){
       });
     }
   }
-  const section=(name==='appearance'||name==='preferences'||name==='providers'||name==='plugins'||name==='system')?name:'conversation';
+  let section=(name==='appearance'||name==='preferences'||name==='providers'||name==='plugins'||name==='system')?name:'conversation';
+  // Deep-linking to the Plugins pane when the tab is hidden (no plugins
+  // installed, #3457) falls back to Conversation. Resolve this BEFORE toggling
+  // panes/sidebar/dropdown below so every downstream selection uses the
+  // corrected section — otherwise the plugins pane would still render active
+  // but empty. (#3457)
+  if(section==='plugins'){
+    const pluginsTabBtn=document.querySelector('[data-settings-section="plugins"]');
+    if(pluginsTabBtn && pluginsTabBtn.style.display==='none') section='conversation';
+  }
   _settingsSection=section;
   _currentSettingsSection=section;
   const map={conversation:'Conversation',appearance:'Appearance',preferences:'Preferences',providers:'Providers',plugins:'Plugins',system:'System'};
@@ -6457,6 +6466,9 @@ async function loadPluginsPanel(){
   try{
     const data=await api('/api/plugins');
     const plugins=Array.isArray((data||{}).plugins)?data.plugins:[];
+    // Hide the Plugins tab when no plugins are installed (#3457)
+    const tabBtn=document.querySelector('[data-settings-section="plugins"]');
+    if(tabBtn) tabBtn.style.display=(data&&data.empty)?'none':'';
     list.innerHTML='';
     if(plugins.length===0){
       list.style.display='none';

--- a/tests/test_issue3368_model_prefix_shadowing.py
+++ b/tests/test_issue3368_model_prefix_shadowing.py
@@ -111,6 +111,66 @@ def best_driver(tmp_path_factory):
     return str(p)
 
 
+# ── driver for _buildModelCandidates + _bestModelMatch over the FULL catalog ──
+# This is the layer the reporter's case actually needed: on large provider
+# catalogs the bare model lives in `extra_models` (not a rendered <option>), so
+# /model must resolve against featured `models` PLUS `extra_models`. (#3368)
+
+_CATALOG_DRIVER = r"""
+const fs = require('fs');
+const cmds = fs.readFileSync(process.argv[2], 'utf8');
+function extractFunc(src, name){
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start); let depth = 1; i++;
+  while (depth > 0 && i < src.length){ if(src[i]==='{')depth++; else if(src[i]==='}')depth--; i++; }
+  return src.slice(start, i);
+}
+eval(extractFunc(cmds, '_buildModelCandidates'));
+eval(extractFunc(cmds, '_looksLikeVersionedModel'));
+eval(extractFunc(cmds, '_bestModelMatch'));
+eval(extractFunc(cmds, '_nearestModelSuggestion'));
+const args = JSON.parse(process.argv[3]);
+// args.groups: [{provider_id, models:[{id,label}], extra_models:[{id,label}]}]
+// args.selOptions: ids rendered as <option> (the featured subset)
+const sel = { options: (args.selOptions||[]).map(v => ({value: v, textContent: v})) };
+const { options: candidates, providerMap } = _buildModelCandidates(sel, args.groups);
+// Mirror cmdModel's fallback chain for a query (skipping _findModelInDropdown,
+// which is exercised by the find_driver tests and returns null for these cases).
+let q = String(args.query||'').toLowerCase();
+let match = _bestModelMatch(candidates, q);
+if(!match && q.includes('/')){
+  const bare = q.slice(q.lastIndexOf('/')+1);
+  match = _bestModelMatch(candidates, bare);
+}
+process.stdout.write(JSON.stringify({
+  candidateCount: candidates.length,
+  match,
+  provider: match ? (providerMap[match]||null) : null,
+  suggestion: _nearestModelSuggestion(candidates, q),
+}));
+"""
+
+
+@pytest.fixture(scope="module")
+def catalog_driver(tmp_path_factory):
+    p = tmp_path_factory.mktemp("catalog3368") / "driver.js"
+    p.write_text(_CATALOG_DRIVER, encoding="utf-8")
+    return str(p)
+
+
+def _resolve(driver, query, groups, sel_options):
+    r = subprocess.run(
+        [NODE, driver, str(COMMANDS_JS_PATH),
+         json.dumps({"query": query, "groups": groups, "selOptions": sel_options})],
+        capture_output=True, text=True, timeout=10,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(f"node driver failed: {r.stderr}")
+    return json.loads(r.stdout)
+
+
 def _find(driver, model_id, options, preferred=None):
     r = subprocess.run(
         [NODE, driver, str(UI_JS_PATH),
@@ -300,3 +360,139 @@ class TestSlashQualifiedVersionedNoSnap:
             "the /api/session/update cross-provider fallback must be gated on "
             "!versionedNoSnap so a versioned tier-variant near-miss doesn't silently persist"
         )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# FULL-CATALOG resolution — garyd9's actual case (#3368 reopened correction)
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# garyd9 (Nous Portal subscriber) confirmed `xiaomi/mimo-v2.5` is a REAL,
+# distinct, separately-selectable model — selectable in the TUI and CLI. His
+# Nous catalog (>25 models) gets truncated by _build_nous_featured_set
+# (api/config.py): the curated flagship set carries mimo-v2.5-PRO so that's a
+# rendered <option>, while the bare mimo-v2.5 lands in `extra_models` and is
+# NOT a <select> option. The pre-fix /model resolved only against sel.options,
+# so the bare model was unreachable and the #3437 tier-guard fired a misleading
+# "did you mean mimo-v2.5-pro?" toast on a model that actually exists.
+#
+# The fix: /model resolves against the FULL catalog (featured `models` +
+# `extra_models`) — the same complete list the CLI and autocomplete use. With
+# the bare model in the candidate set, exact/shortest-match wins and lands on
+# mimo-v2.5, while mimo-v2.5-pro stays reachable by its full name.
+
+
+class TestFullCatalogResolution:
+    """The bare model lives in extra_models (truncated catalog tail). /model must
+    still resolve to it end-to-end — this is garyd9's exact reported case."""
+
+    # A realistic truncated Nous catalog: -pro is featured (rendered <option>),
+    # bare mimo-v2.5 is in the extras tail (absent from sel.options).
+    GROUPS = [{
+        "provider": "Nous Portal (3 of 6)",
+        "provider_id": "nous",
+        "models": [
+            {"id": "@nous:anthropic/claude-opus-4.8", "label": "Claude Opus 4.8 (via Nous)"},
+            {"id": "@nous:openai/gpt-5.5", "label": "GPT-5.5 (via Nous)"},
+            {"id": "@nous:xiaomi/mimo-v2.5-pro", "label": "Mimo V2.5 Pro (via Nous)"},
+        ],
+        "extra_models": [
+            {"id": "@nous:xiaomi/mimo-v2.5", "label": "Mimo V2.5 (via Nous)"},
+            {"id": "@nous:xiaomi/mimo-v2-pro", "label": "Mimo V2 Pro (via Nous)"},
+            {"id": "@nous:deepseek/deepseek-v4-flash", "label": "DeepSeek V4 Flash (via Nous)"},
+        ],
+    }]
+    # What the picker actually renders (featured only).
+    SEL = [
+        "@nous:anthropic/claude-opus-4.8",
+        "@nous:openai/gpt-5.5",
+        "@nous:xiaomi/mimo-v2.5-pro",
+    ]
+
+    def test_candidate_set_includes_extras(self, catalog_driver):
+        out = _resolve(catalog_driver, "mimo-v2.5", self.GROUPS, self.SEL)
+        # 3 featured + 3 extras = 6; the bare model must be reachable.
+        assert out["candidateCount"] == 6
+
+    def test_bare_mimo_v25_resolves_from_extras(self, catalog_driver):
+        """garyd9's exact case: /model mimo-v2.5 lands on the bare model, NOT -pro."""
+        out = _resolve(catalog_driver, "mimo-v2.5", self.GROUPS, self.SEL)
+        assert out["match"] == "@nous:xiaomi/mimo-v2.5", (
+            f"bare mimo-v2.5 must resolve to itself from the extras tail, got {out['match']!r}"
+        )
+        assert out["provider"] == "nous", "resolved model must carry its provider for routing"
+
+    def test_qualified_bare_resolves_from_extras(self, catalog_driver):
+        out = _resolve(catalog_driver, "xiaomi/mimo-v2.5", self.GROUPS, self.SEL)
+        assert out["match"] == "@nous:xiaomi/mimo-v2.5"
+        assert out["provider"] == "nous"
+
+    def test_pro_still_reachable_by_full_name(self, catalog_driver):
+        out = _resolve(catalog_driver, "mimo-v2.5-pro", self.GROUPS, self.SEL)
+        assert out["match"] == "@nous:xiaomi/mimo-v2.5-pro"
+
+    def test_qualified_pro_still_reachable(self, catalog_driver):
+        out = _resolve(catalog_driver, "xiaomi/mimo-v2.5-pro", self.GROUPS, self.SEL)
+        assert out["match"] == "@nous:xiaomi/mimo-v2.5-pro"
+
+    def test_extras_only_model_reachable(self, catalog_driver):
+        """A non-versioned extras-only model (deepseek-v4-flash) is also reachable."""
+        out = _resolve(catalog_driver, "deepseek-v4-flash", self.GROUPS, self.SEL)
+        assert out["match"] == "@nous:deepseek/deepseek-v4-flash"
+
+    def test_incomplete_version_continues_to_longer(self, catalog_driver):
+        """mimo-v2 is an incomplete version; resolving to the shortest continuation
+        (bare mimo-v2.5) is correct now that it's in the catalog."""
+        out = _resolve(catalog_driver, "mimo-v2", self.GROUPS, self.SEL)
+        assert out["match"] == "@nous:xiaomi/mimo-v2.5"
+
+    def test_truly_absent_bare_still_no_snap_and_suggests(self, catalog_driver):
+        """When the bare model is genuinely absent (only -pro in BOTH featured and
+        extras), the tier-guard still fires: no snap, and -pro is suggested."""
+        groups = [{
+            "provider": "Nous Portal",
+            "provider_id": "nous",
+            "models": [{"id": "@nous:xiaomi/mimo-v2.5-pro", "label": "Mimo V2.5 Pro"}],
+            "extra_models": [],
+        }]
+        out = _resolve(catalog_driver, "mimo-v2.5", groups, ["@nous:xiaomi/mimo-v2.5-pro"])
+        assert out["match"] is None, "must not snap to -pro when bare model truly absent"
+        assert out["suggestion"] == "@nous:xiaomi/mimo-v2.5-pro"
+
+    def test_falls_back_to_sel_options_when_no_groups(self, catalog_driver):
+        """If the /api/models fetch failed (no groups), candidates fall back to the
+        live <select> options so /model still works in a degraded state."""
+        out = _resolve(catalog_driver, "gpt-5.5", None, self.SEL)
+        assert out["candidateCount"] == 3
+        assert out["match"] == "@nous:openai/gpt-5.5"
+
+
+class TestCmdModelFullCatalogWiring:
+    """Source-level guards: cmdModel must build candidates from the catalog and
+    inject the option before selecting, so an extras-only winner is honored."""
+
+    @pytest.fixture(scope="class")
+    def commands_src(self):
+        import pathlib
+        root = pathlib.Path(__file__).resolve().parents[1]
+        return (root / "static" / "commands.js").read_text(encoding="utf-8")
+
+    def test_builds_candidates_from_catalog_groups(self, commands_src):
+        assert "_buildModelCandidates(sel,modelsData&&modelsData.groups)" in commands_src
+
+    def test_helper_reads_models_and_extra_models(self, commands_src):
+        idx = commands_src.find("function _buildModelCandidates")
+        assert idx != -1
+        window = commands_src[idx:idx + 900]
+        assert "g.models" in window and "g.extra_models" in window, (
+            "the candidate builder must read both featured models and the extras tail"
+        )
+
+    def test_resolves_against_candidates_not_sel_options(self, commands_src):
+        # The fuzzy fallbacks must run over the full candidate set, not sel.options.
+        assert "_bestModelMatch(candidates,q)" in commands_src
+        assert "_bestModelMatch(sel.options,q)" not in commands_src
+
+    def test_injects_option_for_extras_only_winner(self, commands_src):
+        # An extras-only match isn't a rendered <option>; cmdModel must inject it
+        # (with provider) before selecting, or sel.value=match silently no-ops.
+        assert "_ensureModelOptionInDropdown(match,sel,providerMap[match]||null)" in commands_src

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -523,3 +523,23 @@ class TestPluginCollisionDetection:
 
         assert "plugins_active_provider:" in i18n
         assert "plugins_provider_no_hooks:" in i18n
+
+
+class TestAutoHidePluginsTab:
+    """Tests for issue #3457: auto-hide Plugins tab when no plugins installed."""
+
+    def test_loadPluginsPanel_hides_tab_when_empty(self):
+        js = read("static/panels.js")
+        segment = js[js.find("async function loadPluginsPanel"):js.find("function _buildPluginCard")]
+
+        assert "data-settings-section=\"plugins\"" in segment
+        assert ".empty" in segment
+        assert "style.display='none'" in segment
+
+    def test_switchSettingsSection_fallback_when_hidden(self):
+        js = read("static/panels.js")
+        segment = js[js.find("function switchSettingsSection"):js.find("function _syncHermesPanelSessionActions")]
+
+        assert "section==='plugins'" in segment
+        assert "display==='none'" in segment
+        assert "section='conversation'" in segment

--- a/tests/test_sessions_search_depth_validation.py
+++ b/tests/test_sessions_search_depth_validation.py
@@ -1,0 +1,72 @@
+"""Regression: a malformed/negative ``depth`` on the session content-search
+endpoint must not crash or silently exclude the newest messages.
+
+``GET /api/sessions/search?...&depth=<x>`` parsed ``depth`` with a bare
+``int()``. A non-numeric value (e.g. ``?depth=deep``) raised ValueError, which
+propagated to the top-level request handler and surfaced as a generic HTTP 500.
+
+``depth`` caps how many leading messages are scanned per session
+(``sess.messages[:depth]``). A negative value sliced as ``messages[:-n]``,
+silently dropping the *most recent* messages from the search instead of capping
+the scan — so a match in a session's latest turn would be missed. depth is now
+clamped to ``>= 0`` (0 keeps its existing "search the whole transcript"
+meaning), mirroring the guard sibling handlers already use.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+
+def _run_search(query):
+    """Invoke _handle_sessions_search against one synthetic session whose match
+    lives in its LAST message, capturing the JSON payload/status."""
+    import api.routes as routes
+
+    sessions_meta = [{"session_id": "s1", "title": "Untitled"}]
+    session = SimpleNamespace(
+        session_id="s1",
+        messages=[
+            {"role": "user", "content": "first message"},
+            {"role": "assistant", "content": "second message"},
+            {"role": "user", "content": "NEEDLE in the latest message"},
+        ],
+    )
+    captured = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        captured["payload"] = payload
+
+    with patch("api.routes.all_sessions", return_value=list(sessions_meta)), patch(
+        "api.routes.get_session", return_value=session
+    ), patch("api.routes.j", side_effect=fake_j):
+        routes._handle_sessions_search(SimpleNamespace(), urlparse(query))
+    return captured
+
+
+def test_search_non_numeric_depth_does_not_500():
+    # Before the fix this raised ValueError -> 500.
+    captured = _run_search("/api/sessions/search?q=needle&content=1&depth=deep")
+    assert captured["status"] == 200
+    # depth falls back to 5 (>= 3 messages here), so the needle is found.
+    assert captured["payload"]["count"] == 1
+
+
+def test_search_negative_depth_still_scans_newest_message():
+    # depth=-2 with 3 messages: an unclamped messages[:-2] scan would look only
+    # at the first message and MISS the needle in the latest one. Clamped to a
+    # default >= 0, the newest message is searched and the match is found.
+    captured = _run_search("/api/sessions/search?q=needle&content=1&depth=-2")
+    assert captured["status"] == 200
+    assert captured["payload"]["count"] == 1
+
+
+def test_search_valid_depth_still_caps_scan():
+    # depth=1 scans only the first message, which does NOT contain the needle,
+    # so no match — proving the cap still works for well-formed input.
+    captured = _run_search("/api/sessions/search?q=needle&content=1&depth=1")
+    assert captured["status"] == 200
+    assert captured["payload"]["count"] == 0

--- a/tests/test_sprint5.py
+++ b/tests/test_sprint5.py
@@ -1,6 +1,7 @@
 """Sprint 5 tests: workspace CRUD, file save, session index, JS serving."""
 import json, pathlib, uuid, urllib.request, urllib.error, urllib.parse
 import os
+import pytest
 
 from tests._pytest_port import BASE
 
@@ -136,6 +137,26 @@ def test_workspace_suggest_preserves_tilde_prefix_for_partial_child(monkeypatch,
     suggestions = workspace.list_workspace_suggestions("~/Pro")
 
     assert suggestions == ["~/Projects"]
+
+
+def test_workspace_suggest_expands_tilde_when_home_is_symlink(monkeypatch, tmp_path):
+    from api import workspace
+
+    actual_home = tmp_path / "actual-home"
+    child = actual_home / "Documents"
+    child.mkdir(parents=True)
+    link_home = tmp_path / "link-home"
+    try:
+        link_home.symlink_to(actual_home, target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks are not available in this environment: {exc}")
+
+    monkeypatch.setenv("HOME", str(link_home))
+    monkeypatch.setattr(workspace, "_trusted_workspace_roots", lambda: [actual_home.resolve()])
+
+    suggestions = workspace.list_workspace_suggestions("~/Doc")
+
+    assert suggestions == ["~/Documents"]
 
 
 def test_workspace_suggest_keeps_absolute_prefix_absolute(monkeypatch, tmp_path):


### PR DESCRIPTION
## Release v0.51.231 — Release GY (stage-q1)

Four independent, low-risk fixes batched into one release. All gates green.

### Fixes
| PR | Author | Fix |
|----|--------|-----|
| #3368 | @nesquena-hermes | `/model` resolves models from the truncated `extra_models` tail of a large provider catalog (completes the half-done #3368 fix; @garyd9's `mimo-v2.5` case) |
| #3457 | @pix0127 | Auto-hide the Plugins settings tab when no plugins are installed; deep-link fallback to Conversation |
| #3474 | @Mubashirrrr | Guard malformed/negative `depth` on `/api/sessions/search` (no more 500 on `?depth=deep`, no silent newest-message drop on negative) |
| #3433 | @sjh9714 | Resolve symlinked home before the trust comparison so `~/` workspace suggestions work when the process home is a symlink |

### Note on #3457
The original contributor patch reassigned a `const section` (a **runtime `TypeError` brick** on the settings panel) and placed the hidden-tab fallback *after* the panes were already toggled. Refactored to `let` + hoist the fallback above all consumers of `section`. ESLint runtime gate now clean.

### Gate results
- **Full pytest suite**: 7441 passed, 7 skipped, 3 xpassed, **0 failed**
- **ESLint runtime gate**: CLEAN (caught + fixed the #3457 const-reassign)
- **ruff forward gate**: CLEAN (no new violations on changed lines)
- **browser-smoke gate**: CLEAN (`/`, `/#settings`, `/#sessions` — zero console errors)
- **Codex (regression)**: SAFE TO SHIP
- **Opus (correctness)**: SAFE TO SHIP

Closes #3368. Closes #3457. Closes #3433.

Co-authored-by: pix0127 <pix0127@users.noreply.github.com>
Co-authored-by: Mubashirrrr <Mubashirrrr@users.noreply.github.com>
Co-authored-by: sjh9714 <sjh9714@users.noreply.github.com>