### PR TITLE
Release v0.51.240 — Release HH (stage-q12): mobile swipe-up stops streaming auto-scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.240] — 2026-06-03 — Release HH (stage-q12 — mobile swipe-up stops streaming auto-scroll)
+
+### Fixed
+- On mobile/touch devices you can now swipe up to stop the auto-scroll-during-streaming behavior. Previously the stream snapped back to the bottom on every token and there was no way to read earlier content while a response was arriving: `_recordNonMessageScrollIntent()` only detected upward intent on the wheel path (`typeof e.deltaY === 'number'`), but touch events carry no `deltaY`, so a finger swipe never unpinned the view. The handler now tracks the `touchstart` Y position and treats a `touchmove` that moves the finger up by >8px as upward-scroll intent — the same authoritative unpin (`_messageUserUnpinned`) the wheel path uses — so auto-follow stops until you scroll back to the bottom or tap the ↓ button. (#3470, @cnogrin)
+
 ## [v0.51.239] — 2026-06-03 — Release HG (stage-q10 — ignore SIGPIPE so a dropped client can't kill the server)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -2269,6 +2269,7 @@ let _lastNonMessageScrollIntentMs=-Infinity;
 let _messageUserUnpinned=false;
 let _bottomSettleToken=0;
 const NON_MESSAGE_SCROLL_INTENT_SUPPRESS_MS=350;
+let _touchStartY=null;
 function _cancelBottomSettle(){ _bottomSettleToken++; }
 function _recordNonMessageScrollIntent(e){
   const el=document.getElementById('messages');
@@ -2281,6 +2282,18 @@ function _recordNonMessageScrollIntent(e){
       _messageUserUnpinned=true;
       _nearBottomCount=0;
       _scrollPinned=false;
+    } else if(e.type==='touchmove'&&_touchStartY!==null&&e.touches&&e.touches[0]){
+      // Detect upward-scroll intent on touch: dragging the finger DOWN the
+      // screen scrolls the content up into earlier history (scrollTop
+      // decreases) — the same "user scrolled away" signal the wheel deltaY<0
+      // branch and the scroll listener's movedUp branch use. dy>0 = finger
+      // moved down = reveal earlier content = unpin.
+      const dy=e.touches[0].clientY-_touchStartY;
+      if(dy>8){
+        _messageUserUnpinned=true;
+        _nearBottomCount=0;
+        _scrollPinned=false;
+      }
     }
   }
 }
@@ -2290,6 +2303,11 @@ function _recentNonMessageScrollIntent(){
 if(typeof document!=='undefined'){
   document.addEventListener('wheel',_recordNonMessageScrollIntent,{capture:true,passive:true});
   document.addEventListener('touchmove',_recordNonMessageScrollIntent,{capture:true,passive:true});
+  document.addEventListener('touchstart',function(e){
+    if(e.touches&&e.touches[0]) _touchStartY=e.touches[0].clientY;
+  },{capture:true,passive:true});
+  document.addEventListener('touchend',function(){ _touchStartY=null; },{capture:true,passive:true});
+  document.addEventListener('touchcancel',function(){ _touchStartY=null; },{capture:true,passive:true});
 }
 // Reset hook for session-switch — called from sessions.js loadSession() to
 // prevent the new chat's first scroll comparing against the previous chat's
@@ -2299,6 +2317,7 @@ function _resetScrollDirectionTracker(){
   _messageUserUnpinned=false;
   _scrollPinned=true;
   _nearBottomCount=0;
+  _touchStartY=null;
 }
 function _resetStreamScrollFollow(){
   _messageUserUnpinned=false;

--- a/tests/test_issue3470_touch_unpin_streaming_scroll.py
+++ b/tests/test_issue3470_touch_unpin_streaming_scroll.py
@@ -1,0 +1,97 @@
+"""Regression: mobile touch swipe-up must unpin streaming auto-scroll (#3470).
+
+On touch devices the auto-scroll-during-streaming behavior could not be
+dismissed: ``_recordNonMessageScrollIntent`` only set ``_messageUserUnpinned``
+on the wheel path (``typeof e.deltaY === 'number'``), but touch events never
+carry ``deltaY``, so a finger swipe-up never unpinned the stream and it kept
+snapping to the bottom on every token.
+
+The fix tracks ``_touchStartY`` on ``touchstart`` and, on ``touchmove``, treats
+a finger that moved up by >8px as upward-scroll intent — the same effect as the
+wheel ``deltaY < 0`` branch — setting ``_messageUserUnpinned=true`` /
+``_scrollPinned=false``. ``_touchStartY`` is cleared on ``touchend`` /
+``touchcancel`` and in ``_resetScrollDirectionTracker``.
+
+These are source-structure assertions (the project has no JS test runtime),
+matching the sibling sticky-unpin regressions (test_issue1731 / test_issue3250).
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _record_intent_fn() -> str:
+    start = UI_JS.index("function _recordNonMessageScrollIntent")
+    end = UI_JS.index("function _recentNonMessageScrollIntent")
+    return UI_JS[start:end]
+
+
+def test_touchmove_branch_sets_user_unpinned():
+    """The touchmove branch must set the same authoritative unpin flags the
+    wheel deltaY<0 branch sets."""
+    fn = _record_intent_fn()
+    compact = fn.replace(" ", "").replace("\n", "")
+    # The touchmove branch is gated on event type + a recorded start Y + a live touch point.
+    assert "e.type==='touchmove'" in compact, "must handle the touchmove event type"
+    assert "_touchStartY!==null" in compact, (
+        "touchmove must compare against a recorded _touchStartY start position"
+    )
+    # Upward intent (finger moved up) flips the same flags as the wheel path.
+    assert "_messageUserUnpinned=true" in compact, (
+        "touch swipe-up must set _messageUserUnpinned (the authoritative unpin signal)"
+    )
+    assert "_scrollPinned=false" in compact, "touch swipe-up must clear _scrollPinned"
+
+
+def test_touchmove_uses_correct_downward_finger_threshold():
+    """Upward-scroll intent on touch = finger dragged DOWN the screen (dy>0),
+    which scrolls content up into earlier history (scrollTop decreases) — the
+    same direction the scroll listener's movedUp branch unpins on. A >8px
+    deadzone avoids tap/jitter. (The original PR had the sign inverted —
+    dy<-8 — which would have unpinned on a follow-the-stream upward swipe;
+    Codex caught it. This test pins the corrected direction.)"""
+    fn = _record_intent_fn().replace(" ", "").replace("\n", "")
+    assert "_touchStartY" in fn and "clientY" in fn, (
+        "touch delta must be computed from clientY vs _touchStartY"
+    )
+    assert "dy=e.touches[0].clientY-_touchStartY" in fn, "dy = current clientY - start clientY"
+    assert "if(dy>8)" in fn, (
+        "unpin must fire on dy>8 (finger moved DOWN -> scroll up into history); "
+        "dy<-8 would be backwards and unpin while the user follows the stream"
+    )
+    assert "if(dy<-8)" not in fn, "the inverted dy<-8 sign must NOT be present"
+
+
+def test_touchstart_records_start_y():
+    """A touchstart listener must record the initial Y so touchmove has a baseline."""
+    compact = UI_JS.replace(" ", "").replace("\n", "")
+    assert "addEventListener('touchstart'" in compact or 'addEventListener("touchstart"' in compact, (
+        "must register a touchstart listener to seed _touchStartY"
+    )
+    assert "_touchStartY=e.touches[0].clientY" in compact, (
+        "touchstart must record the finger's start clientY into _touchStartY"
+    )
+
+
+def test_touch_end_and_cancel_clear_start_y():
+    """_touchStartY must be cleared when the gesture ends so a later touchmove
+    in a different gesture doesn't compare against a stale baseline."""
+    compact = UI_JS.replace(" ", "").replace("\n", "")
+    assert "addEventListener('touchend'" in compact or 'addEventListener("touchend"' in compact
+    assert "addEventListener('touchcancel'" in compact or 'addEventListener("touchcancel"' in compact
+    # Both handlers reset the baseline.
+    assert compact.count("_touchStartY=null") >= 2, (
+        "touchend and touchcancel (and the reset hook) must clear _touchStartY"
+    )
+
+
+def test_reset_scroll_direction_tracker_clears_touch_start_y():
+    """Session switch / reset must also clear _touchStartY (no cross-chat bleed)."""
+    start = UI_JS.index("function _resetScrollDirectionTracker")
+    end = UI_JS.index("}", UI_JS.index("{", start))
+    fn = UI_JS[start:end].replace(" ", "").replace("\n", "")
+    assert "_touchStartY=null" in fn, (
+        "_resetScrollDirectionTracker must clear _touchStartY on session switch"
+    )


### PR DESCRIPTION
## Release v0.51.240 — Release HH (stage-q12)

Mobile UX bug-fix — UX-approved via Telegram.

### Fixed
| PR | Author | Fix |
|----|--------|-----|
| #3470 | @cnogrin | On mobile/touch, you can now **swipe up to stop streaming auto-scroll**. Previously the view snapped to the bottom on every token with no way to read earlier content while a response streamed — `_recordNonMessageScrollIntent()` only detected upward intent on the wheel path (`e.deltaY`), and touch events have no `deltaY`. Now tracks `_touchStartY` on `touchstart` and treats a `touchmove` that drags the finger down >8px (= scroll up into history, `scrollTop` decreases) as upward intent, setting the same `_messageUserUnpinned` flag the wheel path + scroll listener use. |

### Why this is safe for existing installs
- **Only ADDS a touch-unpin path** — wheel + desktop behavior completely untouched, no existing branch modified.
- New `touchstart`/`touchend`/`touchcancel` listeners are **passive + capture-only** (they only write `_touchStartY`), so they can't interfere with existing touch handling.
- Net effect for users: mobile users *gain* the ability to scroll up during streaming (which was simply broken before). No one's working flow changes.

### Absorbed on review (Codex CORE MUST-FIX)
The contributor's gesture sign was inverted (`dy<-8` = finger up = *follow* the stream), which would have unpinned in the wrong direction. Corrected to `dy>8` to match the existing scroll listener's `movedUp` semantics; fixed the comment; strengthened the regression test to pin the gesture direction.

### Gate
- Full pytest suite: **7503 passed, 9 skipped, 3 xpassed, 0 failed**
- ESLint runtime gate: CLEAN · browser-smoke: CLEAN
- Codex (regression): SHIP-ONLY-WITH-FIXES (inverted sign) → fixed → re-reviewed **SAFE TO SHIP**
- Regression test `tests/test_issue3470_touch_unpin_streaming_scroll.py` (verified to fail against master)

UX-approved via Telegram (mobile touch-gesture behavior, no visual/layout delta to screenshot).

Co-authored-by: cnogrin <cnogrin@users.noreply.github.com>