### PR TITLE
fix(ux): show messaging source badge in chat topbar (#3338)

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -58,7 +58,7 @@ function syncAppTitlebar() {
     mainText = S.session.title || (typeof t === 'function' ? t('untitled') : 'Untitled');
     const vis = Array.isArray(S.messages) ? S.messages.filter(m => m && m.role && m.role !== 'tool') : [];
     if (typeof t === 'function') subText = t('n_messages', vis.length);
-    if (S.session.is_cli_session) sourceLabel = S.session.source_label || S.session.source_tag || S.session.raw_source || '';
+    sourceLabel = S.session.source_label || S.session.source_tag || S.session.raw_source || '';
   } else {
     const key = APP_TITLEBAR_KEYS[panel];
     mainText = key && typeof t === 'function' ? t(key) : (panel.charAt(0).toUpperCase() + panel.slice(1));

--- a/static/ui.js
+++ b/static/ui.js
@@ -5513,7 +5513,7 @@ function syncTopbar(){
   const vis=S.messages.filter(m=>m&&m.role&&m.role!=='tool');
   const _topbarMeta=$('topbarMeta');
   if(_topbarMeta){
-    const sourceLabel=(S.session&&S.session.is_cli_session&&(S.session.source_label||S.session.source_tag||S.session.raw_source))||'';
+    const sourceLabel=(S.session&&(S.session.source_label||S.session.source_tag||S.session.raw_source))||'';
     const metaText=t('n_messages',vis.length);
     _topbarMeta.textContent=metaText;
     if(sourceLabel){

--- a/tests/test_claude_code_session_import.py
+++ b/tests/test_claude_code_session_import.py
@@ -236,6 +236,9 @@ def test_read_only_source_badge_ui_guards_are_present():
     assert "topbar-source-badge" in ui_js
     assert " · read-only" in ui_js
     assert "topbar-source-badge" in panels_js
+    # Messaging sessions keep source_label but is_cli_session is false (#3338).
+    assert "is_cli_session&&(S.session.source_label" not in ui_js
+    assert "if (S.session.is_cli_session) sourceLabel" not in panels_js
     assert "S.session.read_only || S.session.is_read_only" in panels_js
     assert 'data-source-key="claude_code"' in style_css
     assert ".session-item.cli-session.read-only-session:hover::after" in style_css


### PR DESCRIPTION
## Summary

Fixes #3338. Messaging sessions (Telegram, WeChat, etc.) show their platform label in the sidebar, but the badge disappeared from the chat topbar after opening the session because topbar rendering required `is_cli_session`, which is `false` for `source=messaging` rows.

## Problem

Sidebar badges use `data-source` / `_getChannelLabel()` and work for messaging sessions. Topbar logic in `panels.js` and `ui.js` only read `source_label` when `is_cli_session` was true:

```javascript
// panels.js (before)
if (S.session.is_cli_session) sourceLabel = S.session.source_label || ...
```

For messaging imports, `is_cli_session_row()` returns false when `source == "messaging"`, so users saw the platform in the list but not in the active chat header.

## Solution

Show `topbar-source-badge` whenever the session carries `source_label`, `source_tag`, or `raw_source` — independent of `is_cli_session`. Read-only suffix behavior is unchanged.

## Out of scope

- Backend `is_cli_session_row()` semantics for messaging rows
- Sidebar rendering (already correct)
- Profile/provider routing (#3405)

## Test plan

- [x] `python3` static guard: assert topbar paths no longer gate on `is_cli_session` for source labels
- [ ] Manual: open a Telegram/WeChat messaging session → topbar shows the same platform badge as the sidebar
- [ ] Manual: CLI-imported session with `is_cli_session: true` still shows badge + read-only suffix when applicable
- [ ] CI

## Related

- #3338 — original report (detailed root-cause write-up)

Made with [Cursor](https://cursor.com)