### PR TITLE
fix(session): self-heal GET 200 / POST 404 asymmetry for deleted WebUI sessions (#2782)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -5233,7 +5233,38 @@ def handle_get(handler, parsed) -> bool:
                 )
             return resp
         except KeyError:
-            # Not a WebUI session -- try CLI store
+            # Not a WebUI session -- try CLI store.
+            # Before synthesising a read-only CLI stub, verify the id was not a
+            # deleted WebUI session. _index.json is the canonical WebUI session
+            # registry; an entry there with a webui, fork, or empty source means the
+            # session once had a sidecar that is now gone. Returning 404 lets the
+            # client self-heal: strip the stale /session/<id> URL and clear
+            # localStorage. Otherwise GET would keep returning 200 from the CLI
+            # stub while POST /api/session/draft and /api/chat/start 404, leaving
+            # the UI bricked (#2782). Genuine CLI-origin sessions (absent from the
+            # index, or tagged with a non-webui source) keep the existing 200 path.
+            _was_webui_session = False
+            if SESSION_INDEX_FILE.exists():
+                try:
+                    _index_entries = json.loads(SESSION_INDEX_FILE.read_text(encoding="utf-8"))
+                    for _ie in _index_entries if isinstance(_index_entries, list) else []:
+                        if _ie.get("session_id") == sid:
+                            _src = str(
+                                _ie.get("source_tag")
+                                or _ie.get("raw_source")
+                                or _ie.get("session_source")
+                                or ""
+                            ).strip().lower()
+                            # fork sessions are WebUI-origin (session_source="fork"
+                            # is set by the /api/session/branch handler) and brick
+                            # identically; empty source = native WebUI session.
+                            if not _src or _src in ("webui", "fork"):
+                                _was_webui_session = True
+                            break
+                except Exception:
+                    pass
+            if _was_webui_session:
+                return bad(handler, "Session not found", 404)
             cli_meta = _lookup_cli_session_metadata(sid)
             msgs = get_cli_session_messages(sid)
             if msgs:

--- a/static/messages.js
+++ b/static/messages.js
@@ -594,6 +594,33 @@ async function send(){
     }
   }catch(e){
     const errMsg=String((e&&e.message)||'');
+    // If /api/chat/start returns 404, the session was deleted server-side
+    // (its sidecar is gone) while GET kept returning a CLI stub (#2782). Strip
+    // the stale /session/<id> URL and clear localStorage so a reload does not
+    // re-inject the dead id via _sessionIdFromLocation(), then reset to the
+    // empty state instead of pushing a confusing error bubble into the chat.
+    if(e&&e.status===404){
+      try{ localStorage.removeItem('hermes-webui-session'); }catch(_){ }
+      try{
+        if(typeof _appRootPath==='function') history.replaceState(null,'',_appRootPath());
+        else history.replaceState(null,'',window.location.pathname.replace(/\/session\/[^/]+/,'')+window.location.search);
+      }catch(_){ }
+      delete INFLIGHT[activeSid];
+      if(typeof clearInflightState==='function') clearInflightState(activeSid);
+      stopApprovalPolling();
+      stopClarifyPolling();
+      if(!_approvalSessionId || _approvalSessionId===activeSid) hideApprovalCard(true);
+      if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
+      removeThinking();
+      S.session=null;S.messages=[];
+      setBusy(false);setComposerStatus('');
+      if(typeof clearOptimisticSessionStreaming==='function') clearOptimisticSessionStreaming(activeSid);
+      if(typeof renderMessages==='function') renderMessages();
+      if($('emptyState')) $('emptyState').style.display='';
+      if($('msgInner')) $('msgInner').innerHTML='';
+      if(typeof renderSessionList==='function') void renderSessionList();
+      return;
+    }
     const conflictActiveStream=/session already has an active stream/i.test(errMsg);
     if(conflictActiveStream){
       delete INFLIGHT[activeSid];

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -764,14 +764,24 @@ async function loadSession(sid){
     if(_msgInner){
       if(e.status===404){
         _msgInner.innerHTML='<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Session not available in web UI.</div>';
-        // Option A (#2798): for boot-time stale URL/localStorage session IDs,
-        // always clear persisted session, strip /session/{id} from URL, and
-        // rethrow so boot can deterministically fall through to empty-state.
-        if(!currentSid){
+        // Self-heal (clear saved id + strip /session/<id> URL) only when the
+        // 404'd id is the one we are activating: a boot-time restore
+        // (!currentSid, #2798) or a mid-session reload of the *current* session
+        // whose sidecar was deleted server-side (#2782). A click into a
+        // *different* dead session (currentSid && currentSid!==sid) must not run
+        // it: localStorage and the URL still point at the live session (both are
+        // only updated on a successful load), so wiping them would log the user
+        // out of a healthy session. The URL strip is needed in the self-heal
+        // case because _sessionIdFromLocation() re-injects the id on reload.
+        // Only the rethrow stays gated on !currentSid: boot rethrows to fall
+        // through to empty-state; mid-session there is no boot path to reach.
+        if(!currentSid || currentSid===sid){
           try{ localStorage.removeItem('hermes-webui-session'); }catch(_){ }
           try{ history.replaceState(null,'',_appRootPath()); }catch(_){ }
           if (_loadingSessionId === sid) _loadingSessionId = null;
-          throw e;
+          if(!currentSid){
+            throw e;
+          }
         }
       } else {
         _msgInner.innerHTML='<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load session. Try switching sessions or refreshing.</div>';

--- a/tests/test_stale_empty_session_restore.py
+++ b/tests/test_stale_empty_session_restore.py
@@ -10,17 +10,26 @@ These tests lock in:
   1. ``api()`` attaches HTTP context (``.status``, ``.statusText``, ``.body``)
      to thrown errors so callers can branch on status without re-parsing text.
   2. ``loadSession()`` clears the stale ``hermes-webui-session`` key on a 404
-     for the currently-saved session and rethrows, so boot can fall through
-     to the empty state.
+     and strips the ``/session/<id>`` URL, then rethrows only at boot time so
+     boot can fall through to the empty state (#2798, #2782).
+  3. The server 404s a deleted *WebUI* session on ``GET /api/session`` instead
+     of synthesising a read-only CLI stub, so ``GET`` and the ``POST`` write
+     paths agree on whether a session exists and the client can self-heal
+     (#2782). A genuine CLI-origin session still returns 200 after its sidecar
+     is gone.
 """
 
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
 import re
 
 
 REPO = Path(__file__).parent.parent
 WORKSPACE_JS = (REPO / "static" / "workspace.js").read_text(encoding="utf-8")
 SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
 
 
 def _api_body() -> str:
@@ -37,6 +46,29 @@ def _load_session_error_block() -> str:
     end = SESSIONS_JS.find("return;", catch_idx)
     assert end > catch_idx, "loadSession metadata catch return not found"
     return SESSIONS_JS[catch_idx:end]
+
+
+def _load_session_404_block() -> str:
+    """The body of the `if(e.status===404){ ... }` arm only."""
+    block = _load_session_error_block()
+    start = block.find("if(e.status===404){")
+    assert start >= 0, "loadSession 404 arm not found"
+    # The 404 arm is closed by the `} else {` of the outer status check.
+    end = block.find("} else {", start)
+    assert end > start, "loadSession 404 arm terminator not found"
+    return block[start:end]
+
+
+def _send_catch_block() -> str:
+    """The catch(e) body of send() after POST /api/chat/start."""
+    start = MESSAGES_JS.find("const startData=await api('/api/chat/start'")
+    assert start > 0, "send() /api/chat/start call not found"
+    catch_idx = MESSAGES_JS.find("}catch(e){", start)
+    assert catch_idx > start, "send() catch block not found"
+    # Stop at the conflictActiveStream marker; the 404 branch must precede it.
+    end = MESSAGES_JS.find("const conflictActiveStream", catch_idx)
+    assert end > catch_idx, "send() catch conflictActiveStream marker not found"
+    return MESSAGES_JS[catch_idx:end]
 
 
 def test_api_http_errors_preserve_response_status():
@@ -57,15 +89,6 @@ def test_load_session_clears_saved_stale_404_and_rethrows_to_boot():
     """A missing saved session should be removed and let boot show the empty state."""
     block = _load_session_error_block()
     assert "e.status===404" in block, "loadSession must keep a 404-specific branch"
-    # PR #2808 (#2798): boot-time 404 cleanup is now gated on `!currentSid` alone
-    # (the request was for the saved active session), not on the additional
-    # `localStorage.getItem('hermes-webui-session')===sid` equality check.
-    # The previous gate failed when the stale sid came from /session/{id} URL
-    # while localStorage was empty (post state-reset).
-    assert "!currentSid" in block, (
-        "loadSession must keep the !currentSid gate so click-into 404s don't "
-        "wipe the saved active-session key"
-    )
     assert "localStorage.removeItem('hermes-webui-session')" in block, (
         "loadSession must clear stale saved session IDs on 404"
     )
@@ -74,7 +97,11 @@ def test_load_session_clears_saved_stale_404_and_rethrows_to_boot():
         "doesn't re-trigger the 404 loop"
     )
     assert "_loadingSessionId = null" in block, (
-        "loadSession must clear the in-flight load marker before rethrowing"
+        "loadSession must clear the in-flight load marker on 404"
+    )
+    # Boot-time (!currentSid) rethrow so boot falls through to the empty state.
+    assert "!currentSid" in block, (
+        "loadSession must keep the !currentSid gate around the boot-time rethrow"
     )
     assert re.search(r"throw\s+e", block), (
         "loadSession must rethrow the stale saved-session 404 so boot can fall "
@@ -82,12 +109,143 @@ def test_load_session_clears_saved_stale_404_and_rethrows_to_boot():
     )
 
 
-def test_click_into_404_does_not_clear_saved_session():
-    """A 404 from a click into a different session must NOT clear the saved active key."""
-    block = _load_session_error_block()
-    # The clearing branch is gated on `!currentSid` — i.e. only when the
-    # request was for the *saved* active session, not a user click on another.
-    assert "!currentSid" in block, (
-        "404 cleanup must be gated on !currentSid so user-initiated clicks "
-        "into a missing session don't wipe the saved active-session key"
+def test_load_session_404_self_heal_gated_to_active_or_boot():
+    """#2782: the localStorage clear + URL strip self-heal runs only when the
+    404'd id is the one being activated, gated on (!currentSid || currentSid===sid):
+    a boot-time restore (#2798) or a reload of the *current* session whose sidecar
+    was deleted. A click into a *different* dead session preserves the live
+    session's saved id and URL. Only the rethrow stays gated on !currentSid."""
+    arm = _load_session_404_block()
+    self_heal = "if(!currentSid || currentSid===sid)"
+    assert self_heal in arm, (
+        "self-heal must be gated to boot or the active session, not unconditional"
+    )
+    heal_idx = arm.find(self_heal)
+    clear_idx = arm.find("localStorage.removeItem('hermes-webui-session')")
+    strip_idx = arm.find("history.replaceState")
+    assert clear_idx > heal_idx, "localStorage clear must run inside the self-heal gate"
+    assert strip_idx > heal_idx, "URL strip must run inside the self-heal gate"
+    # The boot-time rethrow stays nested on !currentSid, inside the self-heal gate.
+    rethrow_gate_idx = arm.find("if(!currentSid)")
+    assert rethrow_gate_idx > heal_idx, "the !currentSid rethrow gate must remain"
+    assert re.search(r"throw\s+e", arm[rethrow_gate_idx:]), (
+        "the !currentSid gate must still contain the boot-time rethrow"
+    )
+
+
+def test_send_chat_start_404_self_heals_instead_of_error_bubble():
+    """#2782: POST /api/chat/start 404 (deleted sidecar) must clear localStorage,
+    strip the URL, and reset to empty state, before the generic error path that
+    would otherwise push an "Error:" bubble into the chat."""
+    block = _send_catch_block()
+    assert "e.status===404" in block, (
+        "send() must branch on a 404 from /api/chat/start before the generic path"
+    )
+    assert "localStorage.removeItem('hermes-webui-session')" in block, (
+        "send() 404 branch must clear the saved session key"
+    )
+    assert "history.replaceState" in block, (
+        "send() 404 branch must strip the stale /session/<id> URL"
+    )
+    assert re.search(r"return\s*;", block), (
+        "send() 404 branch must return before pushing an error bubble"
+    )
+    # The error bubble (`**Error:**`) lives after the conflictActiveStream
+    # marker, so confirming the 404 branch + return precede that marker is
+    # enough to prove no bubble is appended on a 404.
+    assert "**Error:**" not in block, (
+        "the 404 self-heal branch must run before the error-bubble path"
+    )
+
+
+# ── Server: GET /api/session 404s a deleted WebUI session (#2782) ──
+
+
+def _invoke_api_session_keyerror(*, index_json, cli_messages):
+    """Drive GET /api/session with get_session() raising KeyError (the deleted-
+    session fallthrough) and a patched _index.json. Returns the captured status.
+    """
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_j(_handler, data, status=200, extra_headers=None):
+        captured["data"] = data
+        captured["status"] = status
+        return data
+
+    def fake_bad(_handler, msg, status=400):
+        captured["data"] = {"error": msg}
+        captured["status"] = status
+        return {"error": msg}
+
+    class _FakeIndexFile:
+        def exists(self):
+            return index_json is not None
+
+        def read_text(self, encoding="utf-8"):
+            return index_json
+
+    parsed = urlparse("/api/session?session_id=gone_001&messages=0&resolve_model=0")
+    with patch("api.routes.get_session", side_effect=KeyError("gone_001")), \
+         patch("api.routes.SESSION_INDEX_FILE", _FakeIndexFile()), \
+         patch("api.routes._lookup_cli_session_metadata", return_value={}), \
+         patch("api.routes.get_cli_session_messages", return_value=cli_messages), \
+         patch("api.routes.j", side_effect=fake_j), \
+         patch("api.routes.bad", side_effect=fake_bad):
+        routes.handle_get(SimpleNamespace(), parsed)
+    return captured
+
+
+def test_get_session_404s_deleted_webui_session():
+    """A WebUI session in _index.json (no/webui source) whose sidecar is gone
+    must 404 on GET, not synthesise a read-only CLI stub, so the client can
+    self-heal and POST/GET agree (#2782)."""
+    index = '[{"session_id": "gone_001", "source_tag": null, "raw_source": null, "session_source": null}]'
+    captured = _invoke_api_session_keyerror(
+        index_json=index,
+        cli_messages=[{"role": "user", "content": "hi", "timestamp": 1}],
+    )
+    assert captured["status"] == 404, (
+        "a deleted WebUI session must return 404, not a 200 CLI stub"
+    )
+
+
+def test_get_session_404s_deleted_fork_session():
+    """A forked WebUI session is stamped session_source='fork' (the /api/session/
+    branch handler); its deleted sidecar must 404 too, not fall through to a 200
+    CLI stub, since a fork is WebUI-origin and bricks identically (#2782)."""
+    index = '[{"session_id": "gone_001", "source_tag": null, "raw_source": null, "session_source": "fork"}]'
+    captured = _invoke_api_session_keyerror(
+        index_json=index,
+        cli_messages=[{"role": "user", "content": "hi", "timestamp": 1}],
+    )
+    assert captured["status"] == 404, (
+        "a deleted fork (WebUI-origin) session must return 404, not a 200 CLI stub"
+    )
+
+
+def test_get_session_keeps_200_for_genuine_cli_session():
+    """A genuine CLI-origin session (source_tag set to a non-webui value in the
+    index) still returns the 200 CLI stub after its sidecar is gone (#2782)."""
+    index = '[{"session_id": "gone_001", "source_tag": "claude-code", "raw_source": "claude-code", "session_source": "cli"}]'
+    captured = _invoke_api_session_keyerror(
+        index_json=index,
+        cli_messages=[{"role": "user", "content": "hi", "timestamp": 1}],
+    )
+    assert captured["status"] == 200, (
+        "a genuine CLI session must keep the 200 CLI-stub path"
+    )
+    assert captured["data"]["session"]["session_id"] == "gone_001"
+
+
+def test_get_session_keeps_200_when_id_absent_from_index():
+    """An id absent from _index.json was never a WebUI session, so the existing
+    CLI-store 200 path is preserved (no false-positive 404)."""
+    captured = _invoke_api_session_keyerror(
+        index_json='[{"session_id": "other_999", "source_tag": null}]',
+        cli_messages=[{"role": "user", "content": "hi", "timestamp": 1}],
+    )
+    assert captured["status"] == 200, (
+        "an id not in the index must keep the CLI-store 200 path"
     )


### PR DESCRIPTION

## Thinking Path

- A WebUI session whose sidecar is gone (for example after `docker compose --force-recreate`) but whose messages still live in `state.db` resolves inconsistently: `GET /api/session` returns 200 while `POST /api/session/draft` and `POST /api/chat/start` return 404 for the same id, so the chat looks alive but every action fails (#2782).
- The GET handler catches the in-memory `KeyError` from `get_session()`, falls through to the CLI-store lookup at `api/routes.py:5235`, finds rows via `get_cli_session_messages(sid)`, and synthesises a read-only "CLI Session" stub, so it never 404s.
- Because GET stays 200, the client poll never reaches the `loadSession()` 404 self-heal branch (`static/sessions.js:765`) that strips the URL and clears localStorage, so the UI is bricked until a manual fork.
- Server arm: before synthesising the CLI stub, consult `_index.json` (the canonical WebUI session registry, written from `Session.compact()`); if the id is present there with a `webui`, `fork`, or empty source it was a WebUI-origin session whose sidecar is now gone, so return 404. A genuine CLI-origin session (absent from the index, or tagged with a non-WebUI source) keeps the existing 200 path. `fork` is included because the `/api/session/branch` handler stamps forked sessions with `session_source="fork"`, and a deleted fork bricks identically to any other WebUI session.
- Client arm: clearing localStorage alone is not enough because `_sessionIdFromLocation()` re-injects `/session/<id>` from the pathname on every reload, so both the GET 404 branch and the POST `/api/chat/start` 404 path must also strip the URL via the existing `_appRootPath()` helper.
- PR #2808 (#2798, merged in v0.51.119) already added the localStorage clear and URL strip to the `loadSession()` 404 branch, but gated the whole thing on `!currentSid`, so it only fired at boot. This change extends the self-heal to the mid-session case by gating the clear + strip on `(!currentSid || currentSid===sid)`: it runs at boot, or when the session being reloaded is the current one whose sidecar just disappeared. It deliberately does not run on a click into a *different* dead session, because localStorage and the URL still point at the healthy active session (both are only written on a successful load), so wiping them there would log the user out of a session that is fine. Only the boot-time rethrow stays gated on `!currentSid`.

## What Changed

- **`api/routes.py`** (GET `/api/session` `KeyError` fallthrough, line 5235): before the CLI-stub path, read `_index.json` via the already-imported `SESSION_INDEX_FILE` and return `bad(handler, "Session not found", 404)` when the id appears with an empty, `webui`, or `fork` source (checked across `source_tag`/`raw_source`/`session_source`). The lookup mirrors the existing direct `SESSION_INDEX_FILE` read pattern already used elsewhere in `routes.py` rather than importing a helper. The branch is only reached after `get_session()` already raised `KeyError`, so a live or not-yet-loaded session cannot reach it.
- **`static/sessions.js`** (`loadSession()` 404 branch, line 765): the `localStorage.removeItem('hermes-webui-session')` clear, the `history.replaceState(null,'',_appRootPath())` URL strip, and the `_loadingSessionId` reset now run inside an `if(!currentSid || currentSid===sid)` self-heal gate, so a boot-time restore and a mid-session reload of the current dead session both recover, while a click into a different missing session leaves the live session's saved id and URL intact. Only `throw e` stays nested in the inner `if(!currentSid)` gate so boot still falls through to the empty state.
- **`static/messages.js`** (`send()` catch after `POST /api/chat/start`, line 596): added an `if(e&&e.status===404){...}` branch before the generic error path. It clears localStorage, strips the URL via `_appRootPath()` (with the literal regex strip as a fallback), tears down inflight and polling state (`delete INFLIGHT[activeSid]`, `clearInflightState`, `stopApprovalPolling`, `stopClarifyPolling`, `removeThinking`, `clearOptimisticSessionStreaming`), resets to the empty state (`S.session=null`, `S.messages=[]`, `setBusy(false)`, `setComposerStatus('')`, re-render messages and session list, show `emptyState`), then returns, instead of appending an `**Error:**` bubble to the chat.
- **`tests/test_stale_empty_session_restore.py`**: added server tests asserting GET `/api/session` returns 404 for a deleted WebUI session (id in `_index.json` with no/`webui` source and `get_session()` raising `KeyError`), 404 for a deleted `fork` session, 200 for a genuine CLI session (`source_tag='claude-code'`), and 200 for an id absent from the index. Added client static-analysis tests asserting the `sessions.js` 404 arm gates the clear + strip on `(!currentSid || currentSid===sid)` with only the rethrow inside the inner `!currentSid` gate, and that the `messages.js` 404 branch self-heals and returns before the error-bubble path. Replaced the prior `test_click_into_404_does_not_clear_saved_session` test: its intent (a click into a missing session must not wipe the saved active session) is now upheld by the `currentSid===sid` gate rather than by the old boot-only gate, so the assertion is restated against the new contract.

## Why It Matters

A deleted-but-resurrectable session currently traps the user: the chat loads, every send 404s, and there is no recovery path short of forking. This makes GET and the POST write paths agree on whether a session exists and lets the client recover automatically by clearing the stale id and dropping to the empty state, without disturbing a healthy session when the user merely clicks a stale sidebar row.

## Verification

- `pytest tests/test_stale_empty_session_restore.py -v --timeout=60` — all pass (the `routes.handle_get` server tests and the JS static-analysis tests are self-contained). On Windows the repo `conftest.py` cannot create its test-home symlink without the symlink privilege (`WinError 1314`), so the local run used `--noconftest`, which these tests do not depend on.
- `pytest tests/ -v --timeout=60` — the full suite is the real gate on CI (Linux, Python 3.11/3.12/3.13). Locally on Windows the suite needs `--noconftest` plus `PYTHONUTF8=1` (several existing string-scanning tests read static JS with the platform default codepage), so a clean local full-suite signal is not available; CI is unaffected.
- Manual: start a session, send a message, delete its sidecar (or recreate the container), reload. Confirm GET now 404s, the URL drops `/session/<id>`, localStorage is cleared, and the UI shows the empty state instead of a stuck chat. Send into a now-deleted session and confirm `/api/chat/start` 404 resets to the empty state rather than printing an `**Error:**` bubble. Separately, with a healthy active session open, click a stale (deleted) sidebar row and confirm the active session's saved id and URL survive.

## Risks / Follow-ups

- Index staleness race: a freshly created session not yet flushed to `_index.json` could in theory be read as a deleted WebUI session. The window is small (`_write_session_index()` runs from `Session.save()` on creation) and the branch is only reached after `get_session()` already raised `KeyError`, which a live session does not. If this ever surfaces, gate on the `SESSIONS` LRU first.
- The `messages.js` 404 branch resets `S.session` to null, discarding any unsent composer text. The maintainer's sketch does not call for preserving it, so it is left as a follow-up: stash the composer draft before clearing so a send into a since-deleted session does not lose the typed message.
- The client static-analysis tests assert on source text rather than runtime behavior (the suite has no JS test harness); a jsdom/Playwright test exercising `loadSession()` and `send()` against mocked `api`/`history`/`localStorage` would prove the runtime self-heal directly and is a reasonable follow-up.
- Extra `_index.json` read only on the GET `KeyError` path; negligible for live sessions, and no size guard is required for correctness.

## Model Used

Claude Opus 4.8 via Claude Code CLI
