### PR TITLE
fix(topbar): show source badge for messaging sessions in the chat pane (#3338)

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -58,7 +58,9 @@ function syncAppTitlebar() {
     mainText = S.session.title || (typeof t === 'function' ? t('untitled') : 'Untitled');
     const vis = Array.isArray(S.messages) ? S.messages.filter(m => m && m.role && m.role !== 'tool') : [];
     if (typeof t === 'function') subText = t('n_messages', vis.length);
-    if (S.session.is_cli_session) sourceLabel = S.session.source_label || S.session.source_tag || S.session.raw_source || '';
+    sourceLabel = S.session.source_label || S.session.source_tag || S.session.raw_source || '';
+    // Recovered sidecars stamp source_label 'WebUI' (api/session_recovery.py); don't badge a native session as its own source (#3338).
+    if (/^webui$/i.test(sourceLabel)) sourceLabel = '';
   } else {
     const key = APP_TITLEBAR_KEYS[panel];
     mainText = key && typeof t === 'function' ? t(key) : (panel.charAt(0).toUpperCase() + panel.slice(1));

--- a/static/ui.js
+++ b/static/ui.js
@@ -5513,7 +5513,9 @@ function syncTopbar(){
   const vis=S.messages.filter(m=>m&&m.role&&m.role!=='tool');
   const _topbarMeta=$('topbarMeta');
   if(_topbarMeta){
-    const sourceLabel=(S.session&&S.session.is_cli_session&&(S.session.source_label||S.session.source_tag||S.session.raw_source))||'';
+    let sourceLabel=(S.session&&(S.session.source_label||S.session.source_tag||S.session.raw_source))||'';
+    // Recovered sidecars stamp source_label 'WebUI' (api/session_recovery.py); don't badge a native session as its own source (#3338).
+    if(/^webui$/i.test(sourceLabel)) sourceLabel='';
     const metaText=t('n_messages',vis.length);
     _topbarMeta.textContent=metaText;
     if(sourceLabel){

--- a/tests/test_claude_code_session_import.py
+++ b/tests/test_claude_code_session_import.py
@@ -241,3 +241,20 @@ def test_read_only_source_badge_ui_guards_are_present():
     assert ".session-item.cli-session.read-only-session:hover::after" in style_css
     assert "Read-only imported sessions cannot be deleted" in routes_py
     assert "Read-only imported sessions cannot be archived" in routes_py
+
+
+def test_messaging_source_badge_not_gated_on_is_cli_session():
+    # Messaging sessions (Telegram, WeChat, Discord) populate source_label/source_tag/raw_source
+    # but reach the chat pane with is_cli_session=false, so the topbar badge must not be gated on
+    # is_cli_session or it never renders for them (#3338).
+    ui_js = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+    panels_js = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+
+    assert "S.session.is_cli_session&&(S.session.source_label" not in ui_js
+    assert "if (S.session.is_cli_session) sourceLabel" not in panels_js
+    assert "S.session.source_label||S.session.source_tag||S.session.raw_source" in ui_js
+    assert "S.session.source_label || S.session.source_tag || S.session.raw_source" in panels_js
+    # The native WebUI self-source must be suppressed so recovered sidecars
+    # (source_label 'WebUI' from api/session_recovery.py) don't badge the chat pane (#3338).
+    assert "/^webui$/i.test(sourceLabel)" in ui_js
+    assert "/^webui$/i.test(sourceLabel)" in panels_js


### PR DESCRIPTION

## Thinking Path

- The chat-pane topbar source badge is meant to show where a session came from, but it is gated on `S.session.is_cli_session` at `static/panels.js:61` and `static/ui.js:5516`.
- `is_cli_session_row()` (`api/agent_sessions.py`) intentionally returns `False` for messaging sources (discord, email, slack, telegram, weixin) to keep them out of the CLI sidebar bucket, so messaging sessions reach the chat pane with `is_cli_session = false`.
- The badge predicate is therefore coupled to the wrong semantic: it asks "is this a CLI session?" when it should ask "does this session have a displayable source label?"
- `source_label` / `source_tag` / `raw_source` are already populated for messaging sessions, and `.topbar-source-badge` already exists in CSS, so the core of the fix is to decouple the predicate from `is_cli_session` at both call sites.
- One self-source case needs guarding: when a WebUI session's sidecar is gone but `state.db` survives, `recover_missing_sidecars_from_state_db` rebuilds the sidecar via `_state_db_row_to_sidecar` (`api/session_recovery.py`), which runs `normalize_agent_session_source('webui')` and writes `source_label='WebUI'` / `raw_source='webui'` into the recovered JSON. With the gate removed, those recovered sessions would render a spurious "WebUI" badge in the chat pane. So both sites suppress the native WebUI self-source (`/^webui$/i`) after computing the label. Sessions that were never recovered carry empty source fields and rendered no badge before or after.
- The backend contract stays unchanged: `is_cli_session_row()`'s exclusion of messaging sessions is deliberate sidebar/visibility policy, and the maintainer confirmed that exclusion is intentional. The self-source suppression is kept on the client, inside the two chat-pane sites this PR already touches, rather than altering the recovery writer or the sidebar.

## What Changed

- **`static/panels.js`** (line 61): in `syncAppTitlebar`, drop the `is_cli_session` guard and set `sourceLabel` from `source_label || source_tag || raw_source`, then blank it when it matches the WebUI self-source (`if (/^webui$/i.test(sourceLabel)) sourceLabel = '';`).
- **`static/ui.js`** (line 5516): the same decouple and self-source suppression in the topbar meta update path (changing the `const` to `let` so the label can be cleared), so both code paths that render the badge agree regardless of which one fires.
- **`tests/test_claude_code_session_import.py`**: new `test_messaging_source_badge_not_gated_on_is_cli_session`, asserting neither file gates `sourceLabel` on `is_cli_session`, both use the unconditional source-field form, and both apply the `/^webui$/i.test(sourceLabel)` self-source suppression. It mirrors the existing `test_read_only_source_badge_ui_guards_are_present`, which reads the JS files as text and checks for code patterns.

## Why It Matters

Messaging sessions (Telegram, WeChat, Discord) show their origin badge in the sidebar but lose it the moment you open them, so the chat pane gives no indication you are looking at a messaging conversation. This makes the topbar consistent with the sidebar, closing #3338, while keeping native and recovered WebUI sessions badge-free.

## Verification

- `pytest tests/test_claude_code_session_import.py -v --timeout=60` (on Windows, run with `--noconftest`; the new static-analysis test does not depend on the conftest fixtures, and the file's one unrelated failure, `test_claude_code_scan_skips_symlinks_and_oversized_files`, is the pre-existing `WinError 1314` symlink-privilege issue, not this change).
- `pytest tests/ -v --timeout=60` (full suite; the real gate is CI on Linux).
- Manual: open a messaging session, confirm the topbar badge now appears and matches the sidebar; open a plain WebUI session and a recovered WebUI session, confirm neither shows a spurious "WebUI" badge.

## Screenshots

Before/after capture is pending manual verification on a running WebUI instance with a messaging session. Expected: in "before", the topbar of an opened messaging session shows no source badge; in "after", it shows the same badge as the sidebar (for example "Telegram").

- Before (messaging session topbar, badge absent): _[placeholder — to be captured manually]_
- After (messaging session topbar, badge present): _[placeholder — to be captured manually]_

## Risks / Follow-ups

- Anonymous sessions with all three source fields empty render no badge before and after, so there is no false-positive for unsourced sessions.
- Recovered WebUI sessions: the `/^webui$/i` suppression is the only thing keeping them badge-free after the gate removal, since `_state_db_row_to_sidecar` stamps `source_label='WebUI'`. If a future source label ever legitimately started with "webui", this would hide it; that is not currently possible (`'webui'` is the exact self-source value), but a more targeted check on `session_source==='webui'` is a possible follow-up if the recovery writer's labelling changes.
- Cron/tool/api sessions surfaced through the recovery path carry their own labels ("Cron"/"Tool"/"API") and will now show those badges in the chat pane; this is consistent with the sidebar and is the intended outcome of decoupling from `is_cli_session`.
- The test asserts on source text rather than the runtime topbar; both call sites change identically to keep rendering consistent regardless of which path updates it.

## Model Used

Claude Opus 4.8 via Claude Code CLI
