### PR TITLE
feat(settings): add terminal auto-expand-on-output toggle (#2974)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -4966,6 +4966,7 @@ _SETTINGS_DEFAULTS = {
     "notifications_enabled": False,  # browser notification when tab is in background
     "show_thinking": True,  # show/hide thinking/reasoning blocks in chat view
     "simplified_tool_calling": True,  # render tools/thinking as compact inline timeline activity
+    "terminal_auto_expand_on_output": False,  # auto-expand terminal panel when output arrives while collapsed
     "api_redact_enabled": True,  # redact sensitive data (API keys, secrets) from API responses
     "dashboard_plugins": {},  # plugin_name -> bool, opt-in per plugin (default off per PF-10b)
     "sidebar_density": "compact",  # compact | detailed
@@ -5111,6 +5112,7 @@ _SETTINGS_BOOL_KEYS = {
     "notifications_enabled",
     "show_thinking",
     "simplified_tool_calling",
+    "terminal_auto_expand_on_output",
     "api_redact_enabled",
     "session_jump_buttons",
     "session_endless_scroll",

--- a/static/boot.js
+++ b/static/boot.js
@@ -1686,6 +1686,7 @@ function applyBotName(){
     window._whatsNewSummaryEnabled=!!s.whats_new_summary_enabled;
     window._showThinking=s.show_thinking!==false;
     window._simplifiedToolCalling=s.simplified_tool_calling!==false;
+    window._terminalAutoExpandOnOutput=!!s.terminal_auto_expand_on_output;
     window._activityFeedExpandedDefault=!!s.activity_feed_expanded_default;
     window._sidebarDensity=(s.sidebar_density==='detailed'?'detailed':'compact');
     window._pinnedSessionsLimit=parseInt(s.pinned_sessions_limit||3,10)||3;
@@ -1783,6 +1784,7 @@ function applyBotName(){
     window._whatsNewSummaryEnabled=false;
     window._showThinking=true;
     window._simplifiedToolCalling=true;
+    window._terminalAutoExpandOnOutput=false;
     window._sessionJumpButtonsEnabled=false;
     window._sidebarDensity='compact';
     window._pinnedSessionsLimit=3;

--- a/static/index.html
+++ b/static/index.html
@@ -1148,6 +1148,13 @@
             </div>
             <div class="settings-field">
               <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+                <input type="checkbox" id="settingsTerminalAutoExpand" style="width:15px;height:15px;accent-color:var(--accent)">
+                <span>Auto-expand terminal on output</span>
+              </label>
+              <div style="font-size:11px;color:var(--muted);margin-top:4px">Expand the collapsed terminal panel automatically when a running command emits new output.</div>
+            </div>
+            <div class="settings-field">
+              <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
                 <input type="checkbox" id="settingsApiRedact" checked style="width:15px;height:15px;accent-color:var(--accent)">
                 <span data-i18n="settings_label_api_redact">Redact sensitive data in API responses</span>
               </label>

--- a/static/panels.js
+++ b/static/panels.js
@@ -5948,6 +5948,8 @@ function _preferencesPayloadFromUi(){
   if(fadeTextCb) payload.fade_text_effect=fadeTextCb.checked;
   const simplifiedToolCb=$('settingsSimplifiedToolCalling');
   if(simplifiedToolCb) payload.simplified_tool_calling=simplifiedToolCb.checked;
+  const terminalAutoExpandCb=$('settingsTerminalAutoExpand');
+  if(terminalAutoExpandCb) payload.terminal_auto_expand_on_output=terminalAutoExpandCb.checked;
   const apiRedactCb=$('settingsApiRedact');
   if(apiRedactCb) payload.api_redact_enabled=apiRedactCb.checked;
   const showCliCb=$('settingsShowCliSessions');
@@ -6021,6 +6023,9 @@ async function _autosavePreferencesSettings(payload){
       window._simplifiedToolCalling=(saved&&saved.simplified_tool_calling!==false);
       if(typeof clearMessageRenderCache==='function') clearMessageRenderCache();
       if(typeof renderMessages==='function') renderMessages();
+    }
+    if(payload&&payload.terminal_auto_expand_on_output!==undefined){
+      window._terminalAutoExpandOnOutput=!!(saved&&saved.terminal_auto_expand_on_output);
     }
     if(payload&&Object.prototype.hasOwnProperty.call(payload,'fade_text_effect')) window._fadeTextEffect=!!payload.fade_text_effect;
     if(saved&&Object.prototype.hasOwnProperty.call(saved,'pinned_sessions_limit')) window._pinnedSessionsLimit=parseInt(saved.pinned_sessions_limit,10)||3;
@@ -6252,6 +6257,8 @@ async function loadSettingsPanel(){
     if(fadeTextCb){fadeTextCb.checked=!!settings.fade_text_effect;window._fadeTextEffect=fadeTextCb.checked;fadeTextCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
     const simplifiedToolCb=$('settingsSimplifiedToolCalling');
     if(simplifiedToolCb){simplifiedToolCb.checked=settings.simplified_tool_calling!==false;simplifiedToolCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
+    const terminalAutoExpandCb=$('settingsTerminalAutoExpand');
+    if(terminalAutoExpandCb){terminalAutoExpandCb.checked=!!settings.terminal_auto_expand_on_output;window._terminalAutoExpandOnOutput=terminalAutoExpandCb.checked;terminalAutoExpandCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
     const apiRedactCb=$('settingsApiRedact');
     if(apiRedactCb){apiRedactCb.checked=settings.api_redact_enabled!==false;apiRedactCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
     const showCliCb=$('settingsShowCliSessions');
@@ -7309,6 +7316,7 @@ function _applySavedSettingsUi(saved, body, opts){
   window._whatsNewSummaryEnabled=!!body.whats_new_summary_enabled;
   window._showThinking=body.show_thinking!==false;
   window._simplifiedToolCalling=body.simplified_tool_calling!==false;
+  window._terminalAutoExpandOnOutput=!!body.terminal_auto_expand_on_output;
   window._sessionJumpButtonsEnabled=!!body.session_jump_buttons;
   if(typeof _applySessionNavigationPrefs==='function') _applySessionNavigationPrefs();
   window._sidebarDensity=sidebarDensity==='detailed'?'detailed':'compact';
@@ -7649,6 +7657,7 @@ async function saveSettings(andClose){
   body.show_tps=showTps;
   body.fade_text_effect=fadeTextEffect;
   body.simplified_tool_calling=!!($('settingsSimplifiedToolCalling')||{}).checked;
+  body.terminal_auto_expand_on_output=!!($('settingsTerminalAutoExpand')||{}).checked;
   body.api_redact_enabled=!!($('settingsApiRedact')||{}).checked;
   body.show_cli_sessions=showCliSessions;
   body.show_previous_messaging_sessions=showPreviousMessagingSessions;

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -383,6 +383,7 @@ function _connectTerminalOutput(){
     try{text=(JSON.parse(ev.data)||{}).text||'';}
     catch(_){text=ev.data||'';}
     if(TERMINAL_UI.term&&text)TERMINAL_UI.term.write(text);
+    if(text&&window._terminalAutoExpandOnOutput&&TERMINAL_UI.open&&TERMINAL_UI.collapsed)expandComposerTerminal({focus:false});
   });
   source.addEventListener('terminal_closed',()=>{
     if(TERMINAL_UI.source!==source)return;
@@ -476,8 +477,9 @@ function collapseComposerTerminal(){
   syncTerminalButton();
 }
 
-function expandComposerTerminal(){
+function expandComposerTerminal(opts){
   if(!TERMINAL_UI.open)return;
+  const focus = !opts || opts.focus !== false;
   const {panel}= _terminalEls();
   const messages=_terminalMessagesEl();
   TERMINAL_UI.collapsed=false;
@@ -490,7 +492,7 @@ function expandComposerTerminal(){
   _resetTerminalHeightForViewport();
   requestAnimationFrame(()=>{
     _fitTerminal();
-    focusComposerTerminalInput();
+    if(focus) focusComposerTerminalInput();
     setTimeout(()=>{
       if(panel)panel.classList.remove('is-expanding-from-dock');
       if(messages)messages.classList.remove('terminal-expanding-from-dock');

--- a/tests/test_terminal_auto_expand_setting.py
+++ b/tests/test_terminal_auto_expand_setting.py
@@ -1,0 +1,29 @@
+"""Regression tests for the terminal auto-expand-on-output setting."""
+
+import json
+
+
+def test_terminal_auto_expand_on_output_defaults_disabled_and_round_trips(monkeypatch, tmp_path):
+    import api.config as config
+
+    settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(config, "SETTINGS_FILE", settings_path)
+
+    loaded = config.load_settings()
+    assert loaded["terminal_auto_expand_on_output"] is False
+
+    saved = config.save_settings({"terminal_auto_expand_on_output": False})
+    assert saved["terminal_auto_expand_on_output"] is False
+    assert json.loads(settings_path.read_text(encoding="utf-8"))["terminal_auto_expand_on_output"] is False
+
+    saved = config.save_settings({"terminal_auto_expand_on_output": True})
+    assert saved["terminal_auto_expand_on_output"] is True
+    assert json.loads(settings_path.read_text(encoding="utf-8"))["terminal_auto_expand_on_output"] is True
+
+
+def test_terminal_auto_expand_on_output_is_a_valid_boolean_setting():
+    import api.config as config
+
+    assert "terminal_auto_expand_on_output" in config._SETTINGS_DEFAULTS
+    assert "terminal_auto_expand_on_output" in config._SETTINGS_BOOL_KEYS
+    assert "terminal_auto_expand_on_output" in config._SETTINGS_ALLOWED_KEYS


### PR DESCRIPTION

## Thinking Path

- The Terminal panel stays collapsed when new output arrives; nothing hooks the write path to expand it, and there is no persisted preference to opt into that behavior.
- Users running long commands miss output unless they manually expand the panel each time.
- The thinking-panel half of the issue is already covered by the existing "Compact tool activity" setting, so only the terminal needs a new flag.
- The cleanest pattern is the existing `simplified_tool_calling` setting: a backend-persisted boolean plumbed through five JS sites, plus a settings checkbox; the new flag mirrors it exactly.
- The write-path hook calls the existing `expandComposerTerminal()` helper, guarded so it fires once per stream (only when open and collapsed), not per output chunk.
- Default-off means no behavior change on upgrade.

## What Changed

- **`api/config.py`**: added `terminal_auto_expand_on_output` (default `False`) to `_SETTINGS_DEFAULTS` and to `_SETTINGS_BOOL_KEYS` (the allowlist is derived from defaults).
- **`static/boot.js`**: hydrate `window._terminalAutoExpandOnOutput` from settings, plus the settings-failed-to-load fallback default (`false`), so the flag never diverges on the error path; both mirror `window._simplifiedToolCalling`.
- **`static/panels.js`**: plumb the flag through the same five sites as `simplified_tool_calling` (save payload, autosave hot-update, populate-UI, API-response hydration, settings-form save).
- **`static/terminal.js`** (line 385): after writing output, call `expandComposerTerminal()` when the flag is on and the panel is open but collapsed.
- **`static/index.html`**: a settings checkbox after the Compact tool activity field.
- **`tests/test_terminal_auto_expand_setting.py`** (new): default-off round-trip plus presence in the three config sets (mirrors `test_simplified_tool_calling_setting.py`).

## Why It Matters

Users who run long-output commands in the embedded terminal can opt into having the panel surface itself when output starts, instead of silently collecting output behind a collapsed panel.

## Verification

- `pytest tests/test_terminal_auto_expand_setting.py -v --timeout=60` — both new tests pass: the default-off round-trip and the presence-in-config-sets assertion.
- `pytest tests/ -v --timeout=60` — full suite; on CI (Linux, Python 3.11/3.12/3.13) this runs unmodified.
- Manual: enable the toggle, collapse the terminal, run a command that emits output, confirm a single auto-expand; disable, confirm it stays collapsed; confirm the setting round-trips across reload and via the settings autosave path.

### Screenshots

UI change; before/after capture is pending manual verification on a running server. Placeholders below to be replaced before submission:

- [PENDING] Settings panel showing the new "Auto-expand terminal on output" checkbox below "Compact tool activity".
- [PENDING] Short clip or before/after pair of the collapsed terminal auto-expanding once when a running command emits output, with the toggle enabled.

### Local environment note

This change was developed on Windows, where two pre-existing, change-independent issues affect the local test run: the suite's `conftest.py` session fixture creates a symlink that fails with `WinError 1314` (symlink privilege not held), and several string-scanning tests call `Path.read_text()` without an explicit encoding, which fails under the cp1252 default codepage on UTF-8 source files. Both are sidestepped locally with `--noconftest` and `PYTHONUTF8=1`; neither is triggered by this change, and CI (Linux + UTF-8 locale) is unaffected.

## Risks / Follow-ups

- `expandComposerTerminal()` does layout work and focuses the terminal input; the open-and-collapsed guard prevents per-chunk re-fire, but verify it does not steal focus while typing in the composer.
- Five `panels.js` sites must stay in sync; the config-set test covers the backend, manual round-trip covers the JS plumbing.
- Default-off, so no migration is needed.

## Model Used

Claude Opus 4.8 via Claude Code CLI
