### PR TITLE
fix(session): sync WebUI rename through to agent state.db title (#3225)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -6440,6 +6440,7 @@ def handle_post(handler, parsed) -> bool:
         with _get_session_agent_lock(body["session_id"]):
             s.title = str(body["title"]).strip()[:80] or "Untitled"
             s.save()
+        _sync_session_title_to_insights(s)
         publish_session_list_changed("session_rename")
         return j(handler, {"session": s.compact()})
 

--- a/tests/test_issue3225_rename_sync.py
+++ b/tests/test_issue3225_rename_sync.py
@@ -1,0 +1,31 @@
+"""Regression coverage: WebUI session rename writes through to state.db (#3225).
+
+The /api/session/rename handler must call _sync_session_title_to_insights(s),
+just like the sibling /api/session/title/regenerate handler does, so a rename
+propagates the new title to the agent's state.db. Without it the TUI and CLI
+keep showing the stale name. Static source-text assertion that mirrors
+test_regenerate_endpoint_syncs_title_to_state_db_when_enabled.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTES_PY = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+
+
+def test_rename_endpoint_syncs_title_to_state_db():
+    start_idx = ROUTES_PY.index('"/api/session/rename"')
+    end_idx = ROUTES_PY.index('"/api/session/title/regenerate"', start_idx)
+    block = ROUTES_PY[start_idx:end_idx]
+    assert "_sync_session_title_to_insights(s)" in block, (
+        "rename handler must call _sync_session_title_to_insights(s) so the "
+        "new title reaches state.db, matching the regenerate handler"
+    )
+    assert 'publish_session_list_changed("session_rename")' in block
+    # Sync must run BEFORE the list-changed publish, matching the regenerate
+    # handler, so SSE subscribers refresh after state.db holds the new title.
+    sync_idx = block.index("_sync_session_title_to_insights(s)")
+    publish_idx = block.index('publish_session_list_changed("session_rename")')
+    assert sync_idx < publish_idx, (
+        "rename must sync to state.db before publishing the list-changed event"
+    )


### PR DESCRIPTION

## Thinking Path

- Renaming a session in the WebUI updates the WebUI JSON store but the TUI and CLI keep showing the old name.
- The `/api/session/rename` handler (`api/routes.py:6441`) calls `s.save()` and `publish_session_list_changed`, then returns, without pushing the title to `state.db`.
- The sibling `/api/session/title/regenerate` handler (line 6448) does the same save but calls `_sync_session_title_to_insights(s)` (line 6469) *before* `publish_session_list_changed`, which is exactly the missing step, and the ordering to mirror so SSE subscribers refresh after `state.db` already holds the new title.
- The helper is defined at line 6409, just above both handlers, guards internally on `sync_to_insights`, and forwards the `profile` kwarg for #2762 parity, so the fix is a one-line call in the rename handler.

## What Changed

- **`api/routes.py`** (rename handler, line 6441): added `_sync_session_title_to_insights(s)` immediately before `publish_session_list_changed("session_rename")`, mirroring the regenerate handler's sync-then-publish order so the list-changed event fires after `state.db` holds the new title.
- **`tests/test_issue3225_rename_sync.py`** (new): static source-text assertions that the helper is called inside the rename handler block and that the sync call precedes the `publish_session_list_changed` call (mirrors `test_regenerate_endpoint_syncs_title_to_state_db_when_enabled`).

## Why It Matters

A WebUI rename now propagates to `state.db`, so the TUI and CLI show the new title without requiring a title regenerate. Without this, the WebUI and the agent's own views drift apart on something as basic as the session name.

## Verification

- `pytest tests/test_issue3225_rename_sync.py -v --timeout=60`
- `pytest tests/ -v --timeout=60`
- Manual (with `sync_to_insights` enabled): rename in the WebUI, confirm the TUI/CLI reflects the new title from `state.db`.

## Risks / Follow-ups

- `_sync_session_title_to_insights` is a nested function defined above the rename handler in the same scope, so there is no scope issue.
- No-op when `sync_to_insights` is off (default), so deployments without `state.db` are unaffected; real-world impact is narrow but the fix is minimal and matches the established pattern.
- `_sync_session_title_to_insights` forwards the session's own accumulated `input_tokens`/`output_tokens`/`estimated_cost`, and `sync_session_usage` writes them with `absolute=True`; on a rename these are the session's current totals (not zeros), so the title update does not disturb existing usage data. This is the identical call the merged regenerate handler already makes, so the rename inherits its established, maintainer-reviewed behavior.

## Model Used

Claude Opus 4.8 via Claude Code CLI
