### PR TITLE
Coerce reasoning effort to model/provider-supported levels

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2148,6 +2148,8 @@ def _strip_provider_hint_for_reasoning(model_id: str) -> str:
     if model.startswith("@") and ":" in model:
         return model.split(":", 1)[1]
     return model
+
+
 def _reasoning_name_candidates(model_id: str) -> list[str]:
     """Return normalized model-name candidates for heuristic capability checks."""
     bare = str(model_id or "").strip().lower().rsplit("/", 1)[-1]
@@ -2381,11 +2383,12 @@ def resolve_model_reasoning_efforts(
                 return []
             return []
 
+    # _models_dev_reasoning_efforts already applies the provider/model filter
+    # internally, so it is returned as-is here (filtering again would be
+    # redundant — the filter is idempotent but the double pass obscures flow).
     metadata_efforts = _models_dev_reasoning_efforts(hinted_model, provider)
     if metadata_efforts is not None:
-        return _filter_reasoning_efforts_for_provider(
-            metadata_efforts, hinted_model, provider
-        )
+        return metadata_efforts
 
     return _heuristic_reasoning_efforts(hinted_model, provider)
 
@@ -2411,10 +2414,17 @@ def coerce_reasoning_effort_for_model(
     )
     if raw in supported:
         return raw
-    if raw == "max":
-        for fallback in ("xhigh", "high", "medium", "low", "minimal"):
-            if fallback in supported:
-                return fallback
+    # Degrade to the closest *lower* supported level instead of silently
+    # disabling reasoning. e.g. max -> xhigh -> high, or xhigh -> high when the
+    # target model caps below the configured effort. Never escalate.
+    ladder = list(VALID_REASONING_EFFORTS)  # ascending: minimal..max
+    try:
+        raw_idx = ladder.index(raw)
+    except ValueError:
+        return ""
+    for level in reversed(ladder[:raw_idx]):  # strictly lower, highest first
+        if level in supported:
+            return level
     return ""
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -2148,8 +2148,6 @@ def _strip_provider_hint_for_reasoning(model_id: str) -> str:
     if model.startswith("@") and ":" in model:
         return model.split(":", 1)[1]
     return model
-
-
 def _reasoning_name_candidates(model_id: str) -> list[str]:
     """Return normalized model-name candidates for heuristic capability checks."""
     bare = str(model_id or "").strip().lower().rsplit("/", 1)[-1]
@@ -2234,6 +2232,28 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
     return False
 
 
+def _filter_reasoning_efforts_for_provider(
+    efforts: list[str],
+    model_id: str,
+    provider_id: str,
+) -> list[str]:
+    """Apply provider/model quirks to otherwise valid reasoning effort levels."""
+    normalized = [
+        str(eff).strip().lower()
+        for eff in efforts
+        if str(eff).strip().lower() in VALID_REASONING_EFFORTS
+    ]
+    normalized = list(dict.fromkeys(normalized))
+    provider = _resolve_provider_alias(str(provider_id or "").strip().lower())
+    bare = _strip_provider_hint_for_reasoning(model_id).lower().rsplit("/", 1)[-1]
+    if provider == "openai-codex":
+        if bare.startswith(("o1", "o3", "o4")):
+            return [eff for eff in normalized if eff in {"low", "medium", "high"}]
+        if bare.startswith("gpt-5"):
+            return [eff for eff in normalized if eff != "max"]
+    return normalized
+
+
 def _heuristic_reasoning_efforts(model_id: str, provider_id: str) -> list[str]:
     """Fallback when hermes_cli is unavailable."""
     model = _strip_provider_hint_for_reasoning(model_id).lower()
@@ -2244,7 +2264,9 @@ def _heuristic_reasoning_efforts(model_id: str, provider_id: str) -> list[str]:
     if provider == "openai-codex" and bare.startswith(("gpt-5", "o1", "o3", "o4")):
         if bare.startswith(("o1", "o3", "o4")):
             return ["low", "medium", "high"]
-        return list(VALID_REASONING_EFFORTS)
+        return _filter_reasoning_efforts_for_provider(
+            list(VALID_REASONING_EFFORTS), model, provider
+        )
     if provider in {"copilot", "github-copilot"}:
         if bare.startswith(("gpt-5", "o1", "o3", "o4")):
             if bare.startswith(("o1", "o3", "o4")):
@@ -2298,7 +2320,9 @@ def _models_dev_reasoning_efforts(model_id: str, provider_id: str) -> list[str] 
 
     supports_reasoning = getattr(capabilities, "supports_reasoning", None)
     if supports_reasoning is True:
-        return list(VALID_REASONING_EFFORTS)
+        return _filter_reasoning_efforts_for_provider(
+            list(VALID_REASONING_EFFORTS), model, provider
+        )
     if supports_reasoning is False:
         return []
     return None
@@ -2338,7 +2362,9 @@ def resolve_model_reasoning_efforts(
             return _heuristic_reasoning_efforts(hinted_model, provider)
     else:
         if provider in {"copilot", "github-copilot"}:
-            return github_model_reasoning_efforts(hinted_model)
+            return _filter_reasoning_efforts_for_provider(
+                github_model_reasoning_efforts(hinted_model), hinted_model, provider
+            )
 
         if provider == "lmstudio":
             probe_base = resolved_base_url or _get_provider_base_url(provider)
@@ -2348,16 +2374,48 @@ def resolve_model_reasoning_efforts(
                 return []
             level_opts = [opt for opt in normalized if opt in VALID_REASONING_EFFORTS]
             if level_opts:
-                return list(dict.fromkeys(level_opts))
+                return _filter_reasoning_efforts_for_provider(
+                    level_opts, hinted_model, provider
+                )
             if set(normalized).issubset({"off", "on"}):
                 return []
             return []
 
     metadata_efforts = _models_dev_reasoning_efforts(hinted_model, provider)
     if metadata_efforts is not None:
-        return metadata_efforts
+        return _filter_reasoning_efforts_for_provider(
+            metadata_efforts, hinted_model, provider
+        )
 
     return _heuristic_reasoning_efforts(hinted_model, provider)
+
+
+def coerce_reasoning_effort_for_model(
+    effort: str | None,
+    model_id: str | None = None,
+    provider_id: str | None = None,
+    base_url: str | None = None,
+) -> str:
+    """Return the closest supported effort for the target model/provider."""
+    raw = str(effort or "").strip().lower()
+    if not raw:
+        return ""
+    if raw == "none":
+        return "none"
+    if raw not in VALID_REASONING_EFFORTS:
+        return ""
+    supported = resolve_model_reasoning_efforts(
+        model_id,
+        provider_id=provider_id,
+        base_url=base_url,
+    )
+    if raw in supported:
+        return raw
+    if raw == "max":
+        for fallback in ("xhigh", "high", "medium", "low", "minimal"):
+            if fallback in supported:
+                return fallback
+    return ""
 
 
 def get_reasoning_status(

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -36,6 +36,8 @@ from api.config import (
     resolve_custom_provider_connection,
     model_with_provider_context,
     load_settings,
+    parse_reasoning_effort,
+    coerce_reasoning_effort_for_model,
 )
 from api.helpers import redact_session_data, _redact_text
 from api.compression_anchor import is_context_compression_marker, visible_messages_for_anchor
@@ -5099,10 +5101,15 @@ def _run_agent_streaming(
             # `/reasoning <level>`) and hand the parsed dict to AIAgent.  When
             # the key is absent or invalid, pass None → agent uses its default.
             try:
-                from api.config import parse_reasoning_effort as _parse_reff
                 _effort_cfg = _cfg.get('agent', {}) if isinstance(_cfg, dict) else {}
                 _effort_raw = _effort_cfg.get('reasoning_effort') if isinstance(_effort_cfg, dict) else None
-                _reasoning_config = _parse_reff(_effort_raw)
+                _effort = coerce_reasoning_effort_for_model(
+                    _effort_raw,
+                    resolved_model,
+                    provider_id=resolved_provider,
+                    base_url=resolved_base_url,
+                )
+                _reasoning_config = parse_reasoning_effort(_effort)
             except Exception:
                 _reasoning_config = None
 

--- a/tests/test_models_dev_reasoning.py
+++ b/tests/test_models_dev_reasoning.py
@@ -80,7 +80,7 @@ def test_models_dev_false_suppresses_prefix_heuristic(monkeypatch):
     ) == []
 
 
-def test_codex_gpt55_uses_models_dev_including_xhigh(monkeypatch):
+def test_codex_gpt55_uses_models_dev_excluding_unsupported_max(monkeypatch):
     _install_fake_models_dev(
         monkeypatch,
         lambda provider, model: SimpleNamespace(supports_reasoning=True),
@@ -91,8 +91,8 @@ def test_codex_gpt55_uses_models_dev_including_xhigh(monkeypatch):
     result = cfg.resolve_model_reasoning_efforts(
         "gpt-5.5", provider_id="openai-codex"
     )
-    assert result == list(cfg.VALID_REASONING_EFFORTS)
     assert "xhigh" in result
+    assert "max" not in result
 
 
 def test_codex_metadata_false_returns_empty(monkeypatch):

--- a/tests/test_reasoning_effort_model_capabilities.py
+++ b/tests/test_reasoning_effort_model_capabilities.py
@@ -40,6 +40,31 @@ def test_openai_codex_max_effort_is_clamped_before_streaming():
     ) == "xhigh"
 
 
+def test_unsupported_xhigh_degrades_to_high_not_disabled():
+    # o1/o3/o4 on openai-codex cap at low/medium/high. A configured xhigh (or
+    # max) must clamp DOWN to the highest supported level (high), not silently
+    # disable reasoning by returning "".
+    assert cfg.coerce_reasoning_effort_for_model(
+        "xhigh",
+        "o3-mini",
+        provider_id="openai-codex",
+    ) == "high"
+    assert cfg.coerce_reasoning_effort_for_model(
+        "max",
+        "o3-mini",
+        provider_id="openai-codex",
+    ) == "high"
+
+
+def test_coerce_never_escalates_above_configured_effort():
+    # A supported lower effort is returned verbatim; coercion only degrades.
+    assert cfg.coerce_reasoning_effort_for_model(
+        "low",
+        "gpt-5.5",
+        provider_id="openai-codex",
+    ) == "low"
+
+
 def test_github_copilot_gpt5_supports_reasoning_effort_levels():
     efforts = cfg.resolve_model_reasoning_efforts(
         "gpt-5.5",

--- a/tests/test_reasoning_effort_model_capabilities.py
+++ b/tests/test_reasoning_effort_model_capabilities.py
@@ -17,6 +17,8 @@ def test_openai_codex_gpt5_supports_reasoning_effort_levels():
     )
     assert "medium" in efforts
     assert "high" in efforts
+    assert "xhigh" in efforts
+    assert "max" not in efforts
 
 
 def test_openai_codex_prefixed_gpt5_supports_reasoning_effort_levels():
@@ -26,6 +28,16 @@ def test_openai_codex_prefixed_gpt5_supports_reasoning_effort_levels():
     )
     assert "medium" in efforts
     assert "high" in efforts
+    assert "xhigh" in efforts
+    assert "max" not in efforts
+
+
+def test_openai_codex_max_effort_is_clamped_before_streaming():
+    assert cfg.coerce_reasoning_effort_for_model(
+        "max",
+        "gpt-5.5",
+        provider_id="openai-codex",
+    ) == "xhigh"
 
 
 def test_github_copilot_gpt5_supports_reasoning_effort_levels():

--- a/tests/test_reasoning_show_hide.py
+++ b/tests/test_reasoning_show_hide.py
@@ -361,6 +361,10 @@ class TestStreamingReasoningWiring:
             "api/streaming.py must import parse_reasoning_effort to translate "
             "config.yaml agent.reasoning_effort into AIAgent reasoning_config"
         )
+        assert 'coerce_reasoning_effort_for_model' in src, (
+            "api/streaming.py must clamp/drop unsupported model-specific effort "
+            "levels before sending reasoning_config to the provider"
+        )
         assert "reasoning_config" in src and "'reasoning_config' in _agent_params" in src, (
             "api/streaming.py must guard the reasoning_config kwarg with "
             "inspect.signature so older hermes-agent builds don't TypeError"


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI aims for near 1:1 parity with the Hermes CLI in the browser, including the reasoning-effort control for thinking-capable models.
- A configured effort (`agent.reasoning_effort`) is the same across a session, but different models/providers accept different effort levels — e.g. `openai-codex` `gpt-5` rejects `max`, and `o1`/`o3`/`o4` only accept `low`/`medium`/`high`.
- Previously the configured effort was handed to the provider as-is, so an unsupported value could be rejected downstream or silently misbehave.
- This PR clamps the configured effort to the closest level the target model/provider actually supports, before the turn runs.
- The benefit is that switching models no longer requires re-picking an effort level, and an effort the model can't honor degrades predictably instead of failing.

## What Changed

- `api/config.py`
  - `_filter_reasoning_efforts_for_provider()` applies per-provider quirks to an otherwise-valid effort list: strips `max` for `openai-codex` `gpt-5`, restricts `o1`/`o3`/`o4` to `low`/`medium`/`high`. It is threaded through all four resolution paths (heuristic, models.dev, copilot, lmstudio).
  - `coerce_reasoning_effort_for_model()` resolves the supported levels for the target model and returns the configured effort if supported, otherwise **degrades to the closest lower supported level** (e.g. `max → xhigh → high`, `xhigh → high`). It never escalates, and returns `""` only when no lower level exists.
  - `resolve_model_reasoning_efforts()` no longer double-applies the provider filter to the already-filtered `_models_dev_reasoning_efforts()` result.
- `api/streaming.py`
  - `_run_agent_streaming` routes the configured effort through `coerce_reasoning_effort_for_model()` before `parse_reasoning_effort()`, so the agent receives a model-appropriate value.

This is one logical change (reasoning-effort coercion). It was split out of #3401 so it can be reviewed on its own.

## Why It Matters

Without coercion, a configured effort that a model cannot honor is either rejected by the provider or silently disabled. In particular, a user with `reasoning_effort: xhigh` who switched to a model capped at `high` previously got reasoning turned **off** entirely. Clamping down to the nearest supported level keeps reasoning on at the best level the model allows, and removes a class of "why did reasoning stop working when I changed models" confusion.

## Verification

```bash
python -m pytest -q tests/test_reasoning_effort_model_capabilities.py tests/test_models_dev_reasoning.py tests/test_reasoning_show_hide.py
# 47 passed
python3 -m py_compile api/config.py api/streaming.py   # ok
```

Tests cover: `gpt-5` `max → xhigh` clamp, `xhigh → high` / `max → high` degrade on `o1`/`o3`/`o4`, the no-escalation invariant (a supported lower effort is returned verbatim), and the streaming wiring contract. CI runs the full suite on Python 3.11/3.12/3.13.

No user-visible UI change (this is backend effort resolution), so no screenshots apply.

## Risks / Follow-ups

- Behavioral surface is narrow: only the effort value passed to the agent changes, and only when the configured level is unsupported by the target model.
- The provider quirks (`gpt-5` no-`max`, `o*` capped at `high`) are encoded as small explicit rules; new provider quirks would extend `_filter_reasoning_efforts_for_provider()`.
- Not a contract-affecting change: no public contract doc or RFC describes reasoning-effort selection, so no `Contract Routing` / `Contract Change` section is required.

## Model Used

AI-assisted.

- Provider: Anthropic
- Model: Claude Opus 4.8
- Mode/tools: Claude Code agentic session (repo edits, local `pytest`/`py_compile` verification)
