### PR TITLE
Release v0.51.246 — Release HN (stage-q18): WebUI rename syncs to agent state.db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.246] — 2026-06-03 — Release HN (stage-q18 — WebUI rename syncs to agent state.db)
+
+### Fixed
+- Renaming a session in the WebUI now writes the new title through to the agent's `state.db`, so the TUI and CLI no longer keep showing the old name. The `/api/session/rename` handler now calls `_sync_session_title_to_insights()` (gated on the `sync_to_insights` setting) — exactly like the sibling `/api/session/title/regenerate` handler already did. (#3225, @rodboev)
+
 ## [v0.51.245] — 2026-06-03 — Release HM (stage-q17 — messaging source badge in chat topbar)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -6441,6 +6441,7 @@ def handle_post(handler, parsed) -> bool:
         with _get_session_agent_lock(body["session_id"]):
             s.title = str(body["title"]).strip()[:80] or "Untitled"
             s.save()
+        _sync_session_title_to_insights(s)
         publish_session_list_changed("session_rename")
         return j(handler, {"session": s.compact()})
 

--- a/tests/test_issue3225_rename_sync.py
+++ b/tests/test_issue3225_rename_sync.py
@@ -1,0 +1,31 @@
+"""Regression coverage: WebUI session rename writes through to state.db (#3225).
+
+The /api/session/rename handler must call _sync_session_title_to_insights(s),
+just like the sibling /api/session/title/regenerate handler does, so a rename
+propagates the new title to the agent's state.db. Without it the TUI and CLI
+keep showing the stale name. Static source-text assertion that mirrors
+test_regenerate_endpoint_syncs_title_to_state_db_when_enabled.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTES_PY = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+
+
+def test_rename_endpoint_syncs_title_to_state_db():
+    start_idx = ROUTES_PY.index('"/api/session/rename"')
+    end_idx = ROUTES_PY.index('"/api/session/title/regenerate"', start_idx)
+    block = ROUTES_PY[start_idx:end_idx]
+    assert "_sync_session_title_to_insights(s)" in block, (
+        "rename handler must call _sync_session_title_to_insights(s) so the "
+        "new title reaches state.db, matching the regenerate handler"
+    )
+    assert 'publish_session_list_changed("session_rename")' in block
+    # Sync must run BEFORE the list-changed publish, matching the regenerate
+    # handler, so SSE subscribers refresh after state.db holds the new title.
+    sync_idx = block.index("_sync_session_title_to_insights(s)")
+    publish_idx = block.index('publish_session_list_changed("session_rename")')
+    assert sync_idx < publish_idx, (
+        "rename must sync to state.db before publishing the list-changed event"
+    )


### PR DESCRIPTION
## Release v0.51.246 — Release HN (stage-q18)

Backend bug-fix.

### Fixed
| Issue | Author | Fix |
|-------|--------|-----|
| #3225 | @rodboev | **WebUI session rename now syncs the new title to the agent's `state.db`**, so the TUI/CLI stop showing the stale name. `/api/session/rename` now calls `_sync_session_title_to_insights(s)` after `s.save()` and before `publish_session_list_changed` — exactly mirroring the sibling `/api/session/title/regenerate` handler. Gated on the `sync_to_insights` setting and exception-contained (a sync failure can't break the rename). |

### Gate
- Full pytest suite: **7544 passed, 0 failed**
- ruff: CLEAN · 1 new regression test (call present + sync-before-publish ordering) + 82 rename/title-sync tests pass
- Codex (regression): **SAFE TO SHIP** — mirrors the regenerate handler (sync after lock release, gated, exception-contained), no deadlock, no stale data

Co-authored-by: rodboev <rodboev@users.noreply.github.com>