### PR TITLE
feat(approval): make the approval card collapsible (#3007)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -461,7 +461,7 @@
           <div class="approval-desc" id="approvalDesc"></div>
           <div class="approval-cmd" id="approvalCmd"></div>
           <div class="approval-counter" id="approvalCounter" style="display:none;font-size:0.75em;opacity:0.6;margin-top:4px;"></div>
-          <div class="approval-btns">
+          <div class="approval-btns" id="approvalBtns">
             <button class="approval-btn once" id="approvalBtnOnce" onclick="respondApproval('once')" title="Allow this one command (Enter)" data-i18n-title="approval_btn_once_title">
               <span class="approval-btn-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg></span>
               <span class="approval-btn-label" data-i18n="approval_btn_once">Allow once</span>

--- a/static/index.html
+++ b/static/index.html
@@ -456,6 +456,7 @@
           <div class="approval-header">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
             <span id="approvalHeading" data-i18n="approval_heading">Approval required</span>
+            <button type="button" class="approval-collapse" id="approvalCollapse" aria-expanded="true" aria-label="Collapse approval" aria-controls="approvalDesc approvalCmd approvalCounter approvalBtns" onclick="toggleApprovalCardCollapsed()" title="Collapse approval"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg></button>
           </div>
           <div class="approval-desc" id="approvalDesc"></div>
           <div class="approval-cmd" id="approvalCmd"></div>

--- a/static/messages.js
+++ b/static/messages.js
@@ -2671,6 +2671,8 @@ function hideApprovalCard(force=false) {
   _approvalSessionId = null;
   _resetApprovalCardState();
   card.classList.remove("visible");
+  card.classList.remove("collapsed");
+  _syncApprovalTranscriptSpace(null);
   $("approvalCmd").textContent = "";
   $("approvalDesc").textContent = "";
 }
@@ -2752,11 +2754,72 @@ function showApprovalCard(pending, pendingCount) {
     const b = $(id); if (b) { b.disabled = false; b.classList.remove("loading"); }
   });
   card.classList.add("visible");
+  _syncApprovalCollapseButton(card);
+  _syncApprovalTranscriptSpace(card, {immediate: true});
   if (typeof applyLocaleToDOM === "function") applyLocaleToDOM();
   const onceBtn = $("approvalBtnOnce");
   if (onceBtn && document.activeElement !== $('msg')) {
     setTimeout(() => onceBtn.focus({preventScroll: true}), 50);
   }
+}
+
+function _syncApprovalCollapseButton(card) {
+  const collapse = $("approvalCollapse");
+  if (!collapse || !card) return;
+  const collapsed = card.classList.contains("collapsed");
+  collapse.setAttribute("aria-expanded", collapsed ? "false" : "true");
+  // Icon swap: chevron-down when expanded (click to collapse), chevron-up when collapsed (click to expand)
+  const polyline = collapse.querySelector("svg polyline");
+  if (polyline) polyline.setAttribute("points", collapsed ? "18 15 12 9 6 15" : "6 9 12 15 18 9");
+  const label = collapsed ? "Expand approval" : "Collapse approval";
+  collapse.setAttribute("aria-label", label);
+  collapse.title = label;
+}
+
+function _approvalMessagesNearBottom(messages) {
+  if (!messages) return false;
+  return messages.scrollHeight - messages.scrollTop - messages.clientHeight < 150;
+}
+
+function _syncApprovalTranscriptSpace(card, opts) {
+  opts = opts || {};
+  const messages = $("messages");
+  if (!messages) return;
+  const wasNearBottom = _approvalMessagesNearBottom(messages);
+  if (!card || !card.classList.contains("visible")) {
+    messages.classList.remove("approval-open");
+    messages.classList.remove("approval-collapsed");
+    messages.style.removeProperty("--approval-card-height");
+    messages.style.removeProperty("--approval-dock-height");
+    if (wasNearBottom && typeof scrollToBottom === "function" && typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(scrollToBottom);
+    }
+    return;
+  }
+  const collapsed = card.classList.contains("collapsed");
+  messages.classList.add("approval-open");
+  messages.classList.toggle("approval-collapsed", collapsed);
+  const measure = () => {
+    if (!card.classList.contains("visible")) return;
+    const target = collapsed ? card : (card.querySelector(".approval-inner") || card);
+    const h = target && target.getBoundingClientRect().height;
+    if (h > 0) {
+      messages.style.setProperty(collapsed ? "--approval-dock-height" : "--approval-card-height", Math.ceil(h + 24) + "px");
+    }
+    if (wasNearBottom && typeof scrollToBottom === "function") scrollToBottom();
+  };
+  if (opts.immediate) measure();
+  if (typeof requestAnimationFrame === "function") requestAnimationFrame(measure);
+  setTimeout(measure, 420);
+}
+
+function toggleApprovalCardCollapsed(forceCollapsed) {
+  const card = $("approvalCard");
+  if (!card) return;
+  const collapsed = typeof forceCollapsed === "boolean" ? forceCollapsed : !card.classList.contains("collapsed");
+  card.classList.toggle("collapsed", collapsed);
+  _syncApprovalCollapseButton(card);
+  _syncApprovalTranscriptSpace(card, {immediate: true});
 }
 
 async function respondApproval(choice) {

--- a/static/style.css
+++ b/static/style.css
@@ -1321,9 +1321,9 @@
   .approval-card.visible .approval-inner{transform:translateY(0);opacity:1;}
   .approval-header{display:flex;align-items:center;gap:8px;margin-bottom:10px;font-size:13px;font-weight:600;color:var(--error);}
   .approval-collapse{margin-left:auto;display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border:1px solid var(--border2);border-radius:999px;background:var(--surface);color:var(--muted);font:inherit;padding:0;cursor:pointer;}
-  .approval-collapse:hover,.approval-collapse:focus-visible{color:var(--text);border-color:var(--accent-bg-strong);outline:none;}
+  .approval-collapse:hover{color:var(--text);border-color:var(--accent-bg-strong);}
   .approval-collapse svg{width:14px;height:14px;display:block;}
-  .approval-collapse:focus{outline:2px solid var(--blue);outline-offset:2px;}
+  .approval-collapse:focus-visible{outline:2px solid var(--blue);outline-offset:2px;}
   .approval-card.collapsed{max-height:56px;bottom:8px;}
   .approval-card.collapsed .approval-inner{max-height:48px;overflow:hidden;padding:10px 14px;}
   .approval-card.collapsed .approval-header{margin-bottom:0;}

--- a/static/style.css
+++ b/static/style.css
@@ -1320,6 +1320,14 @@
   .approval-inner{background:var(--surface);backdrop-filter:blur(8px);border:1px solid var(--accent-bg-strong);border-radius:14px;padding:16px 18px 40px;transform:translateY(100%);opacity:0;transition:transform .4s cubic-bezier(.32,.72,.16,1),opacity .25s ease;}
   .approval-card.visible .approval-inner{transform:translateY(0);opacity:1;}
   .approval-header{display:flex;align-items:center;gap:8px;margin-bottom:10px;font-size:13px;font-weight:600;color:var(--error);}
+  .approval-collapse{margin-left:auto;display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border:1px solid var(--border2);border-radius:999px;background:var(--surface);color:var(--muted);font:inherit;padding:0;cursor:pointer;}
+  .approval-collapse:hover,.approval-collapse:focus-visible{color:var(--text);border-color:var(--accent-bg-strong);outline:none;}
+  .approval-collapse svg{width:14px;height:14px;display:block;}
+  .approval-collapse:focus{outline:2px solid var(--blue);outline-offset:2px;}
+  .approval-card.collapsed{max-height:56px;bottom:8px;}
+  .approval-card.collapsed .approval-inner{max-height:48px;overflow:hidden;padding:10px 14px;}
+  .approval-card.collapsed .approval-header{margin-bottom:0;}
+  .approval-card.collapsed .approval-desc,.approval-card.collapsed .approval-cmd,.approval-card.collapsed .approval-counter,.approval-card.collapsed .approval-btns{display:none;}
   .approval-desc{font-size:12px;color:var(--muted);margin-bottom:8px;line-height:1.5;}
   .approval-cmd{background:var(--code-bg);border:1px solid var(--border);border-radius:8px;padding:8px 12px;font-family:"SF Mono",ui-monospace,monospace;font-size:12px;color:var(--pre-text);white-space:pre-wrap;word-break:break-all;margin-bottom:14px;max-height:120px;overflow-y:auto;}
   .approval-btns{display:flex;gap:8px;flex-wrap:wrap;align-items:center;}
@@ -1347,6 +1355,8 @@
   .messages.handoff-dock-visible{padding-bottom:var(--handoff-dock-height,72px);scroll-padding-bottom:var(--handoff-dock-height,72px);transition:padding-bottom .22s cubic-bezier(.2,.8,.2,1);}
   .messages.clarify-open{padding-bottom:var(--clarify-card-height,320px);scroll-padding-bottom:var(--clarify-card-height,320px);transition:padding-bottom .22s cubic-bezier(.2,.8,.2,1);}
   .messages.clarify-collapsed{padding-bottom:var(--clarify-dock-height,72px);scroll-padding-bottom:var(--clarify-dock-height,72px);}
+  .messages.approval-open{padding-bottom:var(--approval-card-height,260px);scroll-padding-bottom:var(--approval-card-height,260px);transition:padding-bottom .22s cubic-bezier(.2,.8,.2,1);}
+  .messages.approval-collapsed{padding-bottom:var(--approval-dock-height,72px);scroll-padding-bottom:var(--approval-dock-height,72px);}
   .messages.terminal-expanding-from-dock{transition:none!important;}
   .queue-card-inner{background:var(--surface);border:1px solid var(--border);border-bottom:none;border-radius:14px 14px 0 0;contain:paint;transform:translateY(100%);opacity:0;transition:transform .35s cubic-bezier(.32,.72,.16,1),opacity .2s ease;overflow:hidden;max-height:240px;overflow-y:auto;padding-bottom:4px;}
   .queue-card.visible .queue-card-inner{transform:translateY(0);opacity:1;}

--- a/tests/test_3007_approval_card_collapse.py
+++ b/tests/test_3007_approval_card_collapse.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+INDEX_HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+
+
+def _compact(text: str) -> str:
+    return "".join(text.split())
+
+
+def test_toggle_approval_card_collapsed_defined():
+    assert "function toggleApprovalCardCollapsed(" in MESSAGES_JS
+
+
+def test_sync_approval_collapse_button_defined():
+    assert "function _syncApprovalCollapseButton(" in MESSAGES_JS
+
+
+def test_sync_approval_transcript_space_defined():
+    assert "function _syncApprovalTranscriptSpace(" in MESSAGES_JS
+
+
+def test_approval_collapsed_toggle_in_messages_js():
+    compact_js = _compact(MESSAGES_JS)
+    assert 'card.classList.toggle("collapsed",collapsed)' in compact_js
+
+
+def test_approval_collapsed_cleared_in_hide():
+    # hideApprovalCard must reset collapse state so next approval opens expanded
+    compact_js = _compact(MESSAGES_JS)
+    assert 'card.classList.remove("collapsed")' in compact_js
+
+
+def test_messages_approval_open_in_css():
+    assert ".messages.approval-open" in STYLE_CSS
+
+
+def test_messages_approval_collapsed_in_css():
+    assert ".messages.approval-collapsed" in STYLE_CSS
+
+
+def test_approval_dock_height_padding_in_css():
+    compact_css = _compact(STYLE_CSS)
+    assert "padding-bottom:var(--approval-dock-height,72px)" in compact_css
+
+
+def test_approval_card_collapsed_header_margin_in_css():
+    assert ".approval-card.collapsed .approval-header" in STYLE_CSS
+
+
+def test_approval_card_collapsed_desc_hidden_in_css():
+    assert ".approval-card.collapsed .approval-desc" in STYLE_CSS
+
+
+def test_approval_collapse_button_in_html():
+    assert 'id="approvalCollapse"' in INDEX_HTML
+
+
+def test_approval_collapse_aria_expanded_in_html():
+    assert 'aria-expanded="true"' in INDEX_HTML
+
+
+def test_approval_collapse_onclick_in_html():
+    assert 'onclick="toggleApprovalCardCollapsed()"' in INDEX_HTML
+
+
+def test_sync_approval_transcript_space_called_in_show_and_hide():
+    # Must be called from both showApprovalCard and hideApprovalCard
+    compact_js = _compact(MESSAGES_JS)
+    assert compact_js.count("_syncApprovalTranscriptSpace(") >= 3  # show, hide, toggle
+    assert "_syncApprovalTranscriptSpace(null)" in MESSAGES_JS
+    # show mirrors the merged clarify card: mark visible first, then sync immediately so the transcript reserves space on first paint
+    assert 'card.classList.add("visible");_syncApprovalCollapseButton(card);_syncApprovalTranscriptSpace(card,{immediate:true})' in compact_js


### PR DESCRIPTION
Closes #3007

## Thinking Path

- The approval card (`static/index.html:454`, `role="alertdialog"`) slides up from behind the composer and occupies its full height whenever a tool-call approval is pending. Users reported that this obscures the tool-call rationale and context scrolled just above it. The request is to let them collapse the card to a thin header strip so the transcript remains readable.
- The clarify card already has a working collapse pattern (shipped in #2765): a chevron button in `.clarify-header` calls `toggleClarifyCardCollapsed()`, which toggles a `.collapsed` class, updates `aria-expanded`, rotates the chevron via `_syncClarifyCollapseButton`, and adjusts the `.messages` padding-bottom via `_syncClarifyTranscriptSpace` so the last message is not hidden behind the dock. The approval card has none of these pieces.
- Mirroring the clarify pattern exactly minimizes divergence and reviewer surface: the three clarify helpers (`_syncClarifyCollapseButton`, `_syncClarifyTranscriptSpace`, `toggleClarifyCardCollapsed`) have one-to-one approval equivalents. The CSS collapsed rules follow the same max-height approach.
- Two a11y constraints shape the implementation. First, `role="alertdialog"` requires that the heading stays visible when collapsed (the `.approval-header` containing the warning icon and "Approval required" span must never be hidden). Second, `aria-expanded` on the chevron button must flip on toggle so screen readers announce the state change. Both constraints are satisfied by hiding only `.approval-desc`, `.approval-cmd`, `.approval-counter`, and `.approval-btns` via `display:none` under `.approval-card.collapsed`, while leaving `.approval-header` untouched.
- The Enter shortcut for "Allow once" works via `onceBtn.focus()` in `showApprovalCard` (line 2757), not a document-level keydown. The button retains focus when the card opens, so the shortcut survives collapse without any special handling.
- `hideApprovalCard` must clear `.collapsed` so the next approval always opens expanded. The `sameApproval` guard in `showApprovalCard` (line 2730) compares `.visible` and `_approvalSignature` before any class changes; clearing `.collapsed` in `hideApprovalCard` (before `.visible` is removed) does not interfere with that guard.
- The transcript-space management (`_syncApprovalTranscriptSpace`) must be called from both `showApprovalCard` (to add `approval-open` to `.messages`) and `hideApprovalCard` (to remove it and `approval-collapsed`), mirroring how `_syncClarifyTranscriptSpace` is called from `showClarifyCard` / `hideClarifyCard`.

## What Changed

- **`static/index.html`** (line 458, inside `.approval-header`): added `<button type="button" class="approval-collapse" id="approvalCollapse" aria-expanded="true" aria-label="Collapse approval" aria-controls="approvalDesc approvalCmd approvalCounter approvalBtns" onclick="toggleApprovalCardCollapsed()" title="Collapse approval">` with a chevron SVG, mirroring the `clarifyCollapse` button at line 494.
- **`static/messages.js`** (after `showApprovalCard`): added `_syncApprovalCollapseButton(card)`, `_syncApprovalTranscriptSpace(card, opts)`, and `toggleApprovalCardCollapsed(forceCollapsed)` -- three helpers mirroring the clarify equivalents at lines 2949-3018.
- **`static/messages.js`** (`hideApprovalCard`): added `card.classList.remove("collapsed")` after removing `.visible`, and a `_syncApprovalTranscriptSpace(null)` call to remove `approval-open` / `approval-collapsed` from `.messages` when the card hides.
- **`static/messages.js`** (`showApprovalCard`): after `card.classList.add("visible")`, call `_syncApprovalCollapseButton(card)` then `_syncApprovalTranscriptSpace(card, {immediate: true})`, matching the order `showClarifyCard` uses. Ordering matters: `_syncApprovalTranscriptSpace` early-returns on a card that is not yet `.visible`, so syncing after the class is added is what actually adds `approval-open` to `.messages` and reserves transcript space on first paint.
- **`static/style.css`** (after `.approval-header` at line 1322): added `.approval-collapse` button styles mirroring `.clarify-collapse`; added `.approval-card.collapsed` max-height rules; added `display:none` for `.approval-desc`, `.approval-cmd`, `.approval-counter`, `.approval-btns` under `.approval-card.collapsed`; added `.messages.approval-open` and `.messages.approval-collapsed` padding-bottom rules alongside the clarify equivalents at line 1349.
- **`tests/test_3007_approval_card_collapse.py`** (new): static-assertion test confirming all structural invariants -- the three new JS functions are defined, `.collapsed` is cleared in `hideApprovalCard`, the CSS collapsed and transcript-space rules are present, and the `approvalCollapse` button appears in `index.html` with the correct `aria-expanded` and `onclick` attributes.

## Why It Matters

When a tool triggers an approval request, the card can cover a significant portion of the transcript, hiding the tool-call output or rationale that informs the decision. A single-click collapse to a header strip lets users read the context without dismissing or responding to the approval, bringing the approval card to parity with the clarify card that shipped in #2765.

## Verification

```
C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_3007_approval_card_collapse.py -v --timeout=60
C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/ -v --timeout=60
```

On Windows, if pytest fails to collect due to the pre-existing conftest symlink-privilege issue, retry with `--noconftest`. The new static-assertion test does not depend on conftest fixtures.

Manual verification steps:
1. Trigger a tool that requires approval; verify the chevron button appears in the approval card header.
2. Click the chevron; confirm the card collapses to a thin header strip showing only the warning icon and "Approval required" heading, and that the transcript above is scrollable.
3. Click the chevron again; confirm the card expands and "Allow once" is re-focusable via Tab or Enter.
4. Approve or deny; trigger a new approval; confirm the card opens expanded (not in the previously-collapsed state).
5. With a screen reader: confirm `aria-expanded` is announced as "false" when collapsed and "true" when expanded.

## Risks / Follow-ups

- `role="alertdialog"` signals modal intent; the heading and warning icon remain visible when collapsed, satisfying the assistive-technology expectation that the alert context is not hidden.
- No browser-driven approval-UI tests exist in origin/master; the new test is a static-assertion test, consistent with the pattern in `test_approval_card_layering.py` and `test_issue2883_clarify_padding.py`. A Playwright-based test for the collapse toggle would be a useful follow-up.
- The `sameApproval` guard in `showApprovalCard` is unaffected: it evaluates `.visible` and `_approvalSignature` before any class changes, and `.collapsed` is cleared only in `hideApprovalCard`.
- If a future change adds an approval card `max-height` constraint (analogous to the clarify-card `max-height:min(calc(100vh - 280px),420px)`), the `_syncApprovalTranscriptSpace` measurement path would need updating too.
- Unlike the clarify card, this PR does not add an `_ensureApprovalResizeListener` equivalent, so the reserved `--approval-card-height` is not recomputed on a window resize while the card stays open. The CSS fallback (`var(--approval-card-height,260px)`) keeps space reserved in that window, and the value re-measures on the next show or collapse toggle. Adding a resize listener that mirrors the clarify one is a reasonable follow-up if it proves noticeable.

## Model Used

Claude Opus 4.8 via Claude Code CLI
