### PR TITLE
docs: document tested hermes-agent compatibility policy (#3232)

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,16 @@ Full design notes and the endpoint catalog are in [`ARCHITECTURE.md`](ARCHITECTU
 
 ---
 
+## Compatibility
+
+The WebUI is tested against the current hermes-agent release at the time of each WebUI release. Until [#2491](https://github.com/nesquena/hermes-webui/issues/2491) lands a stable agent API, the WebUI imports agent Python modules directly (`api/config.py`, `api/providers.py`, `api/streaming.py`), so version skew can cause silent import errors or incorrect behaviour.
+
+**Upgrade both together.** When you update WebUI, update hermes-agent to the same release date. Running a pinned older agent against a newer WebUI (or vice versa) is untested and unsupported until #2491.
+
+**Docker users: pin both image tags** rather than using `latest` on one and a fixed tag on the other. When upgrading the multi-container setup, follow the agent-image upgrade procedure in [`docs/docker.md`](docs/docker.md) (which requires dropping the `hermes-agent-src` volume before recreating). The current agent/WebUI coupling is tracked in [`docs/rfcs/agent-source-boundary.md`](docs/rfcs/agent-source-boundary.md).
+
+---
+
 ## Docs
 
 **Start here**

--- a/tests/test_readme_compat_section.py
+++ b/tests/test_readme_compat_section.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+def test_readme_has_compatibility_section():
+    repo_root = Path(__file__).resolve().parents[1]
+    readme = (repo_root / "README.md").read_text(encoding="utf-8")
+
+    assert "## Compatibility" in readme, (
+        "README.md must contain a ## Compatibility section documenting the "
+        "tested hermes-agent compatibility policy"
+    )
+
+    assert "Upgrade both together" in readme, (
+        "README.md Compatibility section must include upgrade-together guidance "
+        '("Upgrade both together")'
+    )
+
+    assert "pin both image tags" in readme, (
+        "README.md Compatibility section must include Docker pin guidance "
+        '("pin both image tags")'
+    )
+
+    assert "docs/docker.md" in readme, (
+        "README.md Compatibility section must cross-link to docs/docker.md"
+    )
+
+    assert "docs/rfcs/agent-source-boundary.md" in readme, (
+        "README.md Compatibility section must cross-link to "
+        "docs/rfcs/agent-source-boundary.md"
+    )
+
+    assert "#2491" in readme, (
+        "README.md Compatibility section must reference issue #2491"
+    )


### PR DESCRIPTION
Closes #3232

## Thinking Path

- The WebUI imports hermes-agent Python modules directly at three points: `api/config.py:221-223` appends the agent directory to `sys.path` at module load time; `api/providers.py:157` executes a top-level `from agent.account_usage import fetch_account_usage` unconditionally at import; `api/streaming.py:1769` (and multiple later lazy imports) brings in agent modules inside function bodies.
- That coupling means any version skew between WebUI and the agent can produce silent import errors or wrong runtime behaviour, with no documented guidance for operators on how to avoid it.
- The issue (#3232) was filed by a community member noting that the README documents how to display the running agent version badge, but says nothing about which agent version a given WebUI release is tested against or whether they must be upgraded together.
- The maintainer confirmed the gap ("you've identified a real gap") and endorsed exactly this fix: a short Compatibility section in README stating the tested-version policy and upgrade-together guidance, with the longer-term answer being #2491 (a stable agent API).
- A per-release version table was considered and rejected because it goes stale whenever a release ships without an update; policy prose is both more durable and more actionable for operators.
- The existing agent-boundary narrative lives in `docs/rfcs/agent-source-boundary.md` and the Docker upgrade procedure in `docs/docker.md:239-263`; cross-linking both avoids duplication and keeps each document authoritative for its own topic.
- The new section is inserted between the Architecture and Docs sections of README.md (after line 536, before line 538), which is the natural location for deployment-affecting constraints that precede the docs index.

## What Changed

- **`README.md`**: added a `## Compatibility` section (about 10 lines) between the Architecture `---` separator and the `## Docs` section. The section states: (1) the WebUI is tested against the current hermes-agent release at each WebUI release; (2) until #2491 lands, upgrade both together; (3) Docker users should pin both image tags rather than using `latest` on one. Cross-links `docs/docker.md` and `docs/rfcs/agent-source-boundary.md`.
- **`tests/test_readme_compat_section.py`**: new test file that reads `README.md` as text and asserts the section header, upgrade-together guidance, Docker pin guidance, and all three cross-links are present.

## Why It Matters

Docker and homelab operators pinning one image while running latest on the other have no documented guidance today, so silent import errors appear as mysterious WebUI failures. The Compatibility section closes that gap while #2491 works toward eliminating the coupling entirely.

## Verification

- Targeted: `C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_readme_compat_section.py -v --timeout=60 --noconftest`: 1 passed (conftest WinError 1314 symlink-privilege failure is pre-existing on Windows; --noconftest bypasses it).
- Full suite: `C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/ -v --timeout=60 --noconftest`: 19 collection errors, all pre-existing UnicodeDecodeError on static JS/Python files (Windows cp1252 vs UTF-8), none attributable to this change. No new failures introduced.
- Manual: open `README.md` in a markdown renderer and confirm the Compatibility section renders correctly between Architecture and Docs, that all three links resolve, and that the section does not repeat or contradict `docs/docker.md`.

## Risks / Follow-ups

- Policy prose is preferred over a per-release version table because the table goes stale when maintainers forget to update it at release time.
- The section does not duplicate or contradict `docs/docker.md:239-263`; it cross-links it.
- When #2491 lands a stable agent API, the Compatibility section will need a follow-up update to reflect the new compatibility guarantee. That is out of scope for this PR.
- Documentation-only; zero regression surface in Python or JavaScript code.

## Model Used

Claude Opus 4.8 via Claude Code CLI