### PR TITLE
Release v0.51.248 — Release HP (stage-q20): self-heal deleted WebUI sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.248] — 2026-06-03 — Release HP (stage-q20 — self-heal deleted WebUI sessions instead of bricking the chat)
+
+### Fixed
+- A WebUI session whose sidecar was deleted server-side (e.g. after `docker compose --force-recreate`) but whose messages still live in `state.db` no longer **bricks the chat** — it looked alive (`GET /api/session` returned 200 from a synthesized CLI stub) while every action failed (`POST /api/session/draft` and `/api/chat/start` returned 404). Now the GET handler consults `_index.json` (the canonical WebUI session registry): if the id was a WebUI-origin session (empty/`webui`/`fork` source) whose sidecar is gone, it returns 404 so the client can self-heal — clearing the saved session id and stripping the stale `/session/<id>` URL — and falls through to the welcome screen. Genuine CLI-origin sessions keep their existing read-only stub. The client self-heal now also covers the mid-session case (the current session's sidecar disappearing), not just boot. (#2782, @rodboev)
+
 ## [v0.51.247] — 2026-06-03 — Release HO (stage-q19 — coerce reasoning effort to model-supported levels)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -5234,7 +5234,55 @@ def handle_get(handler, parsed) -> bool:
                 )
             return resp
         except KeyError:
-            # Not a WebUI session -- try CLI store
+            # Not a WebUI session -- try CLI store.
+            # Before synthesising a read-only CLI stub, verify the id was not a
+            # deleted WebUI session. _index.json is the canonical WebUI session
+            # registry; an entry there with a webui, fork, or empty source means the
+            # session once had a sidecar that is now gone. Returning 404 lets the
+            # client self-heal: strip the stale /session/<id> URL and clear
+            # localStorage. Otherwise GET would keep returning 200 from the CLI
+            # stub while POST /api/session/draft and /api/chat/start 404, leaving
+            # the UI bricked (#2782). Genuine CLI-origin sessions (absent from the
+            # index, or tagged with a non-webui source) keep the existing 200 path.
+            _was_webui_session = False
+            if SESSION_INDEX_FILE.exists():
+                try:
+                    _index_entries = json.loads(SESSION_INDEX_FILE.read_text(encoding="utf-8"))
+                    for _ie in _index_entries if isinstance(_index_entries, list) else []:
+                        if _ie.get("session_id") == sid:
+                            # Classify PER source field, not on a collapsed
+                            # `a or b or c` — a legacy CLI/imported row can carry
+                            # is_cli_session:true with BLANK source fields, and
+                            # collapsing-then-defaulting-to-WebUI would wrongly
+                            # 404 it (it should keep its read-only CLI stub).
+                            _srcs = [
+                                str(_ie.get("source_tag") or "").strip().lower(),
+                                str(_ie.get("raw_source") or "").strip().lower(),
+                                str(_ie.get("session_source") or "").strip().lower(),
+                            ]
+                            _explicit = [s for s in _srcs if s]
+                            if any(s in ("webui", "fork") for s in _explicit):
+                                # Explicit WebUI-origin (incl. forks, which
+                                # /api/session/branch stamps session_source="fork")
+                                # — a deleted sidecar bricks identically. 404.
+                                _was_webui_session = True
+                            elif _explicit:
+                                # Explicit non-WebUI source (cli, telegram,
+                                # claude_code, ...) — a genuine foreign session.
+                                # Keep the existing 200 CLI/read-only stub path.
+                                _was_webui_session = False
+                            else:
+                                # All source fields blank: WebUI-origin UNLESS the
+                                # row is a legacy CLI/imported session marked only
+                                # by is_cli_session / read_only.
+                                _is_cli = _ie.get("is_cli_session") is True
+                                _ro = bool(_ie.get("read_only") or _ie.get("is_read_only"))
+                                _was_webui_session = not (_is_cli or _ro)
+                            break
+                except Exception:
+                    pass
+            if _was_webui_session:
+                return bad(handler, "Session not found", 404)
             cli_meta = _lookup_cli_session_metadata(sid)
             msgs = get_cli_session_messages(sid)
             if msgs:

--- a/static/messages.js
+++ b/static/messages.js
@@ -594,6 +594,33 @@ async function send(){
     }
   }catch(e){
     const errMsg=String((e&&e.message)||'');
+    // If /api/chat/start returns 404, the session was deleted server-side
+    // (its sidecar is gone) while GET kept returning a CLI stub (#2782). Strip
+    // the stale /session/<id> URL and clear localStorage so a reload does not
+    // re-inject the dead id via _sessionIdFromLocation(), then reset to the
+    // empty state instead of pushing a confusing error bubble into the chat.
+    if(e&&e.status===404){
+      try{ localStorage.removeItem('hermes-webui-session'); }catch(_){ }
+      try{
+        if(typeof _appRootPath==='function') history.replaceState(null,'',_appRootPath());
+        else history.replaceState(null,'',window.location.pathname.replace(/\/session\/[^/]+/,'')+window.location.search);
+      }catch(_){ }
+      delete INFLIGHT[activeSid];
+      if(typeof clearInflightState==='function') clearInflightState(activeSid);
+      stopApprovalPolling();
+      stopClarifyPolling();
+      if(!_approvalSessionId || _approvalSessionId===activeSid) hideApprovalCard(true);
+      if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
+      removeThinking();
+      S.session=null;S.messages=[];
+      setBusy(false);setComposerStatus('');
+      if(typeof clearOptimisticSessionStreaming==='function') clearOptimisticSessionStreaming(activeSid);
+      if(typeof renderMessages==='function') renderMessages();
+      if($('emptyState')) $('emptyState').style.display='';
+      if($('msgInner')) $('msgInner').innerHTML='';
+      if(typeof renderSessionList==='function') void renderSessionList();
+      return;
+    }
     const conflictActiveStream=/session already has an active stream/i.test(errMsg);
     if(conflictActiveStream){
       delete INFLIGHT[activeSid];

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -764,14 +764,24 @@ async function loadSession(sid){
     if(_msgInner){
       if(e.status===404){
         _msgInner.innerHTML='<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Session not available in web UI.</div>';
-        // Option A (#2798): for boot-time stale URL/localStorage session IDs,
-        // always clear persisted session, strip /session/{id} from URL, and
-        // rethrow so boot can deterministically fall through to empty-state.
-        if(!currentSid){
+        // Self-heal (clear saved id + strip /session/<id> URL) only when the
+        // 404'd id is the one we are activating: a boot-time restore
+        // (!currentSid, #2798) or a mid-session reload of the *current* session
+        // whose sidecar was deleted server-side (#2782). A click into a
+        // *different* dead session (currentSid && currentSid!==sid) must not run
+        // it: localStorage and the URL still point at the live session (both are
+        // only updated on a successful load), so wiping them would log the user
+        // out of a healthy session. The URL strip is needed in the self-heal
+        // case because _sessionIdFromLocation() re-injects the id on reload.
+        // Only the rethrow stays gated on !currentSid: boot rethrows to fall
+        // through to empty-state; mid-session there is no boot path to reach.
+        if(!currentSid || currentSid===sid){
           try{ localStorage.removeItem('hermes-webui-session'); }catch(_){ }
           try{ history.replaceState(null,'',_appRootPath()); }catch(_){ }
           if (_loadingSessionId === sid) _loadingSessionId = null;
-          throw e;
+          if(!currentSid){
+            throw e;
+          }
         }
       } else {
         _msgInner.innerHTML='<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load session. Try switching sessions or refreshing.</div>';

--- a/tests/test_stale_empty_session_restore.py
+++ b/tests/test_stale_empty_session_restore.py
@@ -10,17 +10,26 @@ These tests lock in:
   1. ``api()`` attaches HTTP context (``.status``, ``.statusText``, ``.body``)
      to thrown errors so callers can branch on status without re-parsing text.
   2. ``loadSession()`` clears the stale ``hermes-webui-session`` key on a 404
-     for the currently-saved session and rethrows, so boot can fall through
-     to the empty state.
+     and strips the ``/session/<id>`` URL, then rethrows only at boot time so
+     boot can fall through to the empty state (#2798, #2782).
+  3. The server 404s a deleted *WebUI* session on ``GET /api/session`` instead
+     of synthesising a read-only CLI stub, so ``GET`` and the ``POST`` write
+     paths agree on whether a session exists and the client can self-heal
+     (#2782). A genuine CLI-origin session still returns 200 after its sidecar
+     is gone.
 """
 
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
 import re
 
 
 REPO = Path(__file__).parent.parent
 WORKSPACE_JS = (REPO / "static" / "workspace.js").read_text(encoding="utf-8")
 SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
 
 
 def _api_body() -> str:
@@ -37,6 +46,29 @@ def _load_session_error_block() -> str:
     end = SESSIONS_JS.find("return;", catch_idx)
     assert end > catch_idx, "loadSession metadata catch return not found"
     return SESSIONS_JS[catch_idx:end]
+
+
+def _load_session_404_block() -> str:
+    """The body of the `if(e.status===404){ ... }` arm only."""
+    block = _load_session_error_block()
+    start = block.find("if(e.status===404){")
+    assert start >= 0, "loadSession 404 arm not found"
+    # The 404 arm is closed by the `} else {` of the outer status check.
+    end = block.find("} else {", start)
+    assert end > start, "loadSession 404 arm terminator not found"
+    return block[start:end]
+
+
+def _send_catch_block() -> str:
+    """The catch(e) body of send() after POST /api/chat/start."""
+    start = MESSAGES_JS.find("const startData=await api('/api/chat/start'")
+    assert start > 0, "send() /api/chat/start call not found"
+    catch_idx = MESSAGES_JS.find("}catch(e){", start)
+    assert catch_idx > start, "send() catch block not found"
+    # Stop at the conflictActiveStream marker; the 404 branch must precede it.
+    end = MESSAGES_JS.find("const conflictActiveStream", catch_idx)
+    assert end > catch_idx, "send() catch conflictActiveStream marker not found"
+    return MESSAGES_JS[catch_idx:end]
 
 
 def test_api_http_errors_preserve_response_status():
@@ -57,15 +89,6 @@ def test_load_session_clears_saved_stale_404_and_rethrows_to_boot():
     """A missing saved session should be removed and let boot show the empty state."""
     block = _load_session_error_block()
     assert "e.status===404" in block, "loadSession must keep a 404-specific branch"
-    # PR #2808 (#2798): boot-time 404 cleanup is now gated on `!currentSid` alone
-    # (the request was for the saved active session), not on the additional
-    # `localStorage.getItem('hermes-webui-session')===sid` equality check.
-    # The previous gate failed when the stale sid came from /session/{id} URL
-    # while localStorage was empty (post state-reset).
-    assert "!currentSid" in block, (
-        "loadSession must keep the !currentSid gate so click-into 404s don't "
-        "wipe the saved active-session key"
-    )
     assert "localStorage.removeItem('hermes-webui-session')" in block, (
         "loadSession must clear stale saved session IDs on 404"
     )
@@ -74,7 +97,11 @@ def test_load_session_clears_saved_stale_404_and_rethrows_to_boot():
         "doesn't re-trigger the 404 loop"
     )
     assert "_loadingSessionId = null" in block, (
-        "loadSession must clear the in-flight load marker before rethrowing"
+        "loadSession must clear the in-flight load marker on 404"
+    )
+    # Boot-time (!currentSid) rethrow so boot falls through to the empty state.
+    assert "!currentSid" in block, (
+        "loadSession must keep the !currentSid gate around the boot-time rethrow"
     )
     assert re.search(r"throw\s+e", block), (
         "loadSession must rethrow the stale saved-session 404 so boot can fall "
@@ -82,12 +109,181 @@ def test_load_session_clears_saved_stale_404_and_rethrows_to_boot():
     )
 
 
-def test_click_into_404_does_not_clear_saved_session():
-    """A 404 from a click into a different session must NOT clear the saved active key."""
-    block = _load_session_error_block()
-    # The clearing branch is gated on `!currentSid` — i.e. only when the
-    # request was for the *saved* active session, not a user click on another.
-    assert "!currentSid" in block, (
-        "404 cleanup must be gated on !currentSid so user-initiated clicks "
-        "into a missing session don't wipe the saved active-session key"
+def test_load_session_404_self_heal_gated_to_active_or_boot():
+    """#2782: the localStorage clear + URL strip self-heal runs only when the
+    404'd id is the one being activated, gated on (!currentSid || currentSid===sid):
+    a boot-time restore (#2798) or a reload of the *current* session whose sidecar
+    was deleted. A click into a *different* dead session preserves the live
+    session's saved id and URL. Only the rethrow stays gated on !currentSid."""
+    arm = _load_session_404_block()
+    self_heal = "if(!currentSid || currentSid===sid)"
+    assert self_heal in arm, (
+        "self-heal must be gated to boot or the active session, not unconditional"
+    )
+    heal_idx = arm.find(self_heal)
+    clear_idx = arm.find("localStorage.removeItem('hermes-webui-session')")
+    strip_idx = arm.find("history.replaceState")
+    assert clear_idx > heal_idx, "localStorage clear must run inside the self-heal gate"
+    assert strip_idx > heal_idx, "URL strip must run inside the self-heal gate"
+    # The boot-time rethrow stays nested on !currentSid, inside the self-heal gate.
+    rethrow_gate_idx = arm.find("if(!currentSid)")
+    assert rethrow_gate_idx > heal_idx, "the !currentSid rethrow gate must remain"
+    assert re.search(r"throw\s+e", arm[rethrow_gate_idx:]), (
+        "the !currentSid gate must still contain the boot-time rethrow"
+    )
+
+
+def test_send_chat_start_404_self_heals_instead_of_error_bubble():
+    """#2782: POST /api/chat/start 404 (deleted sidecar) must clear localStorage,
+    strip the URL, and reset to empty state, before the generic error path that
+    would otherwise push an "Error:" bubble into the chat."""
+    block = _send_catch_block()
+    assert "e.status===404" in block, (
+        "send() must branch on a 404 from /api/chat/start before the generic path"
+    )
+    assert "localStorage.removeItem('hermes-webui-session')" in block, (
+        "send() 404 branch must clear the saved session key"
+    )
+    assert "history.replaceState" in block, (
+        "send() 404 branch must strip the stale /session/<id> URL"
+    )
+    assert re.search(r"return\s*;", block), (
+        "send() 404 branch must return before pushing an error bubble"
+    )
+    # The error bubble (`**Error:**`) lives after the conflictActiveStream
+    # marker, so confirming the 404 branch + return precede that marker is
+    # enough to prove no bubble is appended on a 404.
+    assert "**Error:**" not in block, (
+        "the 404 self-heal branch must run before the error-bubble path"
+    )
+
+
+# ── Server: GET /api/session 404s a deleted WebUI session (#2782) ──
+
+
+def _invoke_api_session_keyerror(*, index_json, cli_messages):
+    """Drive GET /api/session with get_session() raising KeyError (the deleted-
+    session fallthrough) and a patched _index.json. Returns the captured status.
+    """
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_j(_handler, data, status=200, extra_headers=None):
+        captured["data"] = data
+        captured["status"] = status
+        return data
+
+    def fake_bad(_handler, msg, status=400):
+        captured["data"] = {"error": msg}
+        captured["status"] = status
+        return {"error": msg}
+
+    class _FakeIndexFile:
+        def exists(self):
+            return index_json is not None
+
+        def read_text(self, encoding="utf-8"):
+            return index_json
+
+    parsed = urlparse("/api/session?session_id=gone_001&messages=0&resolve_model=0")
+    with patch("api.routes.get_session", side_effect=KeyError("gone_001")), \
+         patch("api.routes.SESSION_INDEX_FILE", _FakeIndexFile()), \
+         patch("api.routes._lookup_cli_session_metadata", return_value={}), \
+         patch("api.routes.get_cli_session_messages", return_value=cli_messages), \
+         patch("api.routes.j", side_effect=fake_j), \
+         patch("api.routes.bad", side_effect=fake_bad):
+        routes.handle_get(SimpleNamespace(), parsed)
+    return captured
+
+
+def test_get_session_404s_deleted_webui_session():
+    """A WebUI session in _index.json (no/webui source) whose sidecar is gone
+    must 404 on GET, not synthesise a read-only CLI stub, so the client can
+    self-heal and POST/GET agree (#2782)."""
+    index = '[{"session_id": "gone_001", "source_tag": null, "raw_source": null, "session_source": null}]'
+    captured = _invoke_api_session_keyerror(
+        index_json=index,
+        cli_messages=[{"role": "user", "content": "hi", "timestamp": 1}],
+    )
+    assert captured["status"] == 404, (
+        "a deleted WebUI session must return 404, not a 200 CLI stub"
+    )
+
+
+def test_get_session_404s_deleted_fork_session():
+    """A forked WebUI session is stamped session_source='fork' (the /api/session/
+    branch handler); its deleted sidecar must 404 too, not fall through to a 200
+    CLI stub, since a fork is WebUI-origin and bricks identically (#2782)."""
+    index = '[{"session_id": "gone_001", "source_tag": null, "raw_source": null, "session_source": "fork"}]'
+    captured = _invoke_api_session_keyerror(
+        index_json=index,
+        cli_messages=[{"role": "user", "content": "hi", "timestamp": 1}],
+    )
+    assert captured["status"] == 404, (
+        "a deleted fork (WebUI-origin) session must return 404, not a 200 CLI stub"
+    )
+
+
+def test_get_session_keeps_200_for_genuine_cli_session():
+    """A genuine CLI-origin session (source_tag set to a non-webui value in the
+    index) still returns the 200 CLI stub after its sidecar is gone (#2782)."""
+    index = '[{"session_id": "gone_001", "source_tag": "claude-code", "raw_source": "claude-code", "session_source": "cli"}]'
+    captured = _invoke_api_session_keyerror(
+        index_json=index,
+        cli_messages=[{"role": "user", "content": "hi", "timestamp": 1}],
+    )
+    assert captured["status"] == 200, (
+        "a genuine CLI session must keep the 200 CLI-stub path"
+    )
+    assert captured["data"]["session"]["session_id"] == "gone_001"
+
+
+def test_get_session_keeps_200_when_id_absent_from_index():
+    """An id absent from _index.json was never a WebUI session, so the existing
+    CLI-store 200 path is preserved (no false-positive 404)."""
+    captured = _invoke_api_session_keyerror(
+        index_json='[{"session_id": "other_999", "source_tag": null}]',
+        cli_messages=[{"role": "user", "content": "hi", "timestamp": 1}],
+    )
+    assert captured["status"] == 200, (
+        "an id not in the index must keep the CLI-store 200 path"
+    )
+
+
+def test_get_session_keeps_200_for_legacy_cli_row_with_blank_source():
+    """Regression (#3501 review, Codex CORE catch): a legacy CLI/imported session
+    can be present in _index.json with is_cli_session:true but BLANK source fields
+    (source_tag/raw_source/session_source all null). The earlier
+    `source_tag or raw_source or session_source or ""` collapse defaulted blank to
+    WebUI and would WRONGLY 404 it. Per-field classification must treat a blank-
+    source row marked is_cli_session (or read_only) as a genuine CLI session and
+    keep the 200 stub."""
+    index = (
+        '[{"session_id": "gone_001", "source_tag": null, "raw_source": null, '
+        '"session_source": null, "is_cli_session": true}]'
+    )
+    captured = _invoke_api_session_keyerror(
+        index_json=index,
+        cli_messages=[{"role": "user", "content": "hi", "timestamp": 1}],
+    )
+    assert captured["status"] == 200, (
+        "a legacy CLI row (is_cli_session:true, blank source) must keep the 200 "
+        "CLI-stub path, not be 404'd as a deleted WebUI session"
+    )
+
+
+def test_get_session_keeps_200_for_read_only_row_with_blank_source():
+    """A read-only imported session with blank source fields is also CLI-origin
+    and must keep the 200 stub (companion to the is_cli_session case)."""
+    index = (
+        '[{"session_id": "gone_001", "source_tag": null, "raw_source": null, '
+        '"session_source": null, "read_only": true}]'
+    )
+    captured = _invoke_api_session_keyerror(
+        index_json=index,
+        cli_messages=[{"role": "user", "content": "hi", "timestamp": 1}],
+    )
+    assert captured["status"] == 200, (
+        "a read-only imported row (blank source) must keep the 200 CLI-stub path"
     )


### PR DESCRIPTION
## Release v0.51.248 — Release HP (stage-q20)

Bug-fix.

### Fixed
| Issue | Author | Fix |
|-------|--------|-----|
| #2782 | @rodboev | **A WebUI session whose sidecar was deleted server-side (e.g. `docker compose --force-recreate`) but whose messages remain in `state.db` no longer bricks the chat.** It used to look alive (`GET` 200 from a CLI stub) while every action 404'd (`POST /api/session/draft`, `/api/chat/start`). The GET handler now consults `_index.json`: a deleted **WebUI-origin** session (webui/fork/blank-non-CLI source) returns 404 so the client self-heals (clears saved id, strips the stale `/session/<id>` URL, falls through to the welcome screen). Genuine CLI/imported sessions keep their 200 read-only stub. Client self-heal now also covers mid-session sidecar deletion of the current session. |

### Review fix absorbed (Codex CORE catch)
The first cut collapsed `source_tag or raw_source or session_source or ""`, defaulting a **blank-source** row to WebUI — which would wrongly 404 a **legacy CLI/imported** session that carries `is_cli_session:true` with blank source fields. Now classified **per-field**: any `webui`/`fork` → 404; any explicit non-WebUI source → keep the 200 CLI stub; all-blank → 404 only when NOT `is_cli_session` and NOT `read_only`. + 2 regression tests.

### Gate
- Full pytest suite: **7555 passed, 0 failed**
- ESLint: CLEAN · ruff: CLEAN · browser-smoke: CLEAN · 10 stale-session-restore tests (incl. 2 Codex-catch regressions)
- Codex (regression): CORE legacy-CLI false-404 → per-field fix → **SAFE TO SHIP**

Co-authored-by: rodboev <rodboev@users.noreply.github.com>