### PR TITLE
fix: avoid snapping to bottom after reader scrolls during streaming

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -2871,7 +2871,11 @@ function _messageBottomDistance(){
   return el.scrollHeight-el.scrollTop-el.clientHeight;
 }
 function _shouldFollowMessagesOnDomReplace(){
-  return !_messageUserUnpinned && (_scrollPinned || _isMessagePaneNearBottom(1200));
+  // Final stream settlement replaces the live DOM with persisted messages. Keep
+  // following only for users who are still pinned or effectively at the tail.
+  // A broad near-bottom window causes long answers/mobile readers who scroll up
+  // a little to read mid-stream to get snapped back to the bottom on completion.
+  return !_messageUserUnpinned && (_scrollPinned || _isMessagePaneNearBottom(120));
 }
 function _settleMessageScrollToBottom(force){
   // Markdown post-processing (Prism, tables, Mermaid/KaTeX/PDF placeholders)

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -26,6 +26,7 @@ import subprocess
 
 REPO = pathlib.Path(__file__).parent.parent
 MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 INDEX_HTML = (REPO / "static" / "index.html").read_text(encoding="utf-8")
 
 
@@ -548,6 +549,20 @@ class TestDoneEventSmd:
             "Done follow capture must include a near-bottom DOM check, not only "
             "the possibly-stale _scrollPinned flag."
         )
+
+    def test_dom_replace_follow_threshold_is_not_broad_reader_zone(self):
+        """Completion must not snap readers who scrolled slightly up mid-stream.
+
+        The done handler uses _shouldFollowMessagesOnDomReplace() before replacing
+        the live stream DOM. A wide near-bottom threshold (for example 1200px)
+        treats normal mobile reading position as still-following and jumps the
+        user to the bottom when the response completes.
+        """
+        start = UI_JS.index("function _shouldFollowMessagesOnDomReplace")
+        end = UI_JS.index("function _settleMessageScrollToBottom", start)
+        fn = UI_JS[start:end]
+        assert "_isMessagePaneNearBottom(120)" in fn
+        assert "_isMessagePaneNearBottom(1200)" not in fn
 
     def test_done_handler_prefers_message_tool_metadata_for_settled_render(self):
         """If final messages already contain tool metadata, renderMessages()


### PR DESCRIPTION
## Summary

Fixes a scroll UX issue where long streaming responses could snap back to the bottom after completion, even if the user had scrolled up to read.

The WebUI should keep auto-scrolling when the user is still following the live response, but hold the reader's place if they manually scroll up.

Fixes #3525

## Testing

- Added a regression test for the completion follow threshold.
- Verified JS syntax with:
  - `node --check static/ui.js`
  - `node --check static/messages.js`

Could not run the pytest suite locally in this environment because `pytest` is not installed.
