### PR TITLE
Add mobile titlebar new chat action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+- Added a **mobile-only titlebar quick action** for New Conversation, positioned before the titlebar reload control and reusing the existing `btnNewChat` handler/logic and `new_conversation` label translation. This keeps desktop and non-mobile layouts unchanged while restoring a fast chat-entry path for phone users. (#3226)
+
 ## [v0.51.287] — 2026-06-06 — Release JC (stage-r22 — WeCom session classification + worker-profile picker hiding)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## [Unreleased]
 
+### Fixed
 - Added a **mobile-only titlebar quick action** for New Conversation, positioned before the titlebar reload control and reusing the existing `btnNewChat` handler/logic and `new_conversation` label translation. This keeps desktop and non-mobile layouts unchanged while restoring a fast chat-entry path for phone users. (#3226)
 
 ## [v0.51.287] — 2026-06-06 — Release JC (stage-r22 — WeCom session classification + worker-profile picker hiding)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## [Unreleased]
 
-### Fixed
+### Added
 - Added a **mobile-only titlebar quick action** for New Conversation, positioned before the titlebar reload control and reusing the existing `btnNewChat` handler/logic and `new_conversation` label translation. This keeps desktop and non-mobile layouts unchanged while restoring a fast chat-entry path for phone users. (#3226)
 
 ## [v0.51.287] — 2026-06-06 — Release JC (stage-r22 — WeCom session classification + worker-profile picker hiding)

--- a/static/index.html
+++ b/static/index.html
@@ -140,6 +140,12 @@
     <span class="app-titlebar-sub" id="appTitlebarSub" hidden></span>
   </div>
   <div class="app-titlebar-spacer" aria-hidden="true"></div>
+  <button class="app-titlebar-new-chat" id="btnTitlebarNewChat" onclick="$('btnNewChat').onclick && $('btnNewChat').onclick()" type="button" aria-label="New conversation" data-i18n-title="new_conversation" data-i18n-aria-label="new_conversation" title="New conversation">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" width="16" height="16">
+      <line x1="12" y1="5" x2="12" y2="19"/>
+      <line x1="5" y1="12" x2="19" y2="12"/>
+    </svg>
+  </button>
   <button class="app-titlebar-reload" id="btnReload" onclick="window.location.reload()" type="button" aria-label="Reload" title="Reload page">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" width="16" height="16">
       <polyline points="23 4 23 10 17 10"/>

--- a/static/index.html
+++ b/static/index.html
@@ -140,7 +140,7 @@
     <span class="app-titlebar-sub" id="appTitlebarSub" hidden></span>
   </div>
   <div class="app-titlebar-spacer" aria-hidden="true"></div>
-  <button class="app-titlebar-new-chat" id="btnTitlebarNewChat" onclick="$('btnNewChat').onclick && $('btnNewChat').onclick()" type="button" aria-label="New conversation" data-i18n-title="new_conversation" data-i18n-aria-label="new_conversation" title="New conversation">
+  <button class="app-titlebar-new-chat" id="btnTitlebarNewChat" onclick="$('btnNewChat') && $('btnNewChat').click()" type="button" aria-label="New conversation" data-i18n-title="new_conversation" data-i18n-aria-label="new_conversation" title="New conversation">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" width="16" height="16">
       <line x1="12" y1="5" x2="12" y2="19"/>
       <line x1="5" y1="12" x2="19" y2="12"/>

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -566,8 +566,10 @@ function _markPollingCompletionUnreadTransitions(sessions) {
 let _newSessionInFlight=null;
 const _newSessionPendingText=()=>t('new_session_creating')||'Creating new conversation…';
 function _setNewSessionPending(pending){
-  const btn=$('btnNewChat');
-  if(btn){
+  const ids=['btnNewChat','btnTitlebarNewChat'];
+  for (let i=0;i<ids.length;i++){
+    const btn=$(ids[i]);
+    if(!btn) continue;
     btn.disabled=!!pending;
     btn.setAttribute('aria-busy',pending?'true':'false');
   }

--- a/static/style.css
+++ b/static/style.css
@@ -929,6 +929,7 @@
   :root{--app-titlebar-safe-top:0px;}
   .pwa-standalone{overscroll-behavior:none;}
   .pwa-standalone body{-webkit-tap-highlight-color:transparent;}
+  .app-titlebar-new-chat{display:none;}
   .pwa-standalone .app-titlebar-reload{display:inline-flex;}
   .pwa-offline .app-titlebar::after{content:'';position:absolute;left:50%;bottom:5px;width:5px;height:5px;border-radius:999px;background:var(--warning);box-shadow:0 0 0 3px color-mix(in srgb,var(--warning) 22%,transparent);transform:translateX(-50%);}
   .pwa-resumed .app-titlebar-title{animation:pwa-title-resume .6s ease-out;}
@@ -944,7 +945,9 @@
     .pull-to-refresh-indicator .ptr-icon{display:inline-block;transition:transform .2s;font-size:16px;}
     .pull-to-refresh-indicator .ptr-icon.ready{transform:rotate(180deg);color:var(--accent);}
     /* Reload button — visible only in PWA standalone / fullscreen */
+    .app-titlebar-new-chat,
     .app-titlebar-reload{display:none;align-items:center;justify-content:center;width:32px;height:32px;flex-shrink:0;background:none;border:none;color:var(--muted);border-radius:8px;cursor:pointer;padding:0;-webkit-tap-highlight-color:transparent;transition:background-color .15s,color .15s;}
+    .app-titlebar-new-chat:hover,
     .app-titlebar-reload:hover{background:var(--hover-bg);color:var(--text);}
     @media (display-mode: standalone), (display-mode: fullscreen){
       :root{--app-titlebar-safe-top:env(safe-area-inset-top,0px);}
@@ -2348,6 +2351,7 @@
     /* Hamburger button (in app titlebar on mobile) */
     .app-titlebar{justify-content:space-between;}
     .app-titlebar-hamburger,.app-titlebar-spacer{display:flex;}
+    .app-titlebar-new-chat{display:inline-flex;}
     .app-titlebar-inner{flex:1 1 auto;}
     .system-health-panel.insights-card{gap:10px;padding:12px;}
     .system-health-head{align-items:flex-start;}

--- a/static/style.css
+++ b/static/style.css
@@ -944,7 +944,7 @@
     .pull-to-refresh-indicator.active{opacity:1;transform:translateY(0);}
     .pull-to-refresh-indicator .ptr-icon{display:inline-block;transition:transform .2s;font-size:16px;}
     .pull-to-refresh-indicator .ptr-icon.ready{transform:rotate(180deg);color:var(--accent);}
-    /* Reload button — visible only in PWA standalone / fullscreen */
+    /* Reload and mobile new-chat titlebar controls with shared icon-button styles */
     .app-titlebar-new-chat,
     .app-titlebar-reload{display:none;align-items:center;justify-content:center;width:32px;height:32px;flex-shrink:0;background:none;border:none;color:var(--muted);border-radius:8px;cursor:pointer;padding:0;-webkit-tap-highlight-color:transparent;transition:background-color .15s,color .15s;}
     .app-titlebar-new-chat:hover,

--- a/static/style.css
+++ b/static/style.css
@@ -3338,6 +3338,8 @@ main.main > #mainPlugin{display:none;}
 .panel-head-btn:hover{background:var(--accent-bg);color:var(--accent-text);}
 .panel-head-btn:disabled,.panel-head-btn[aria-busy="true"]{opacity:.5;cursor:wait;}
 .panel-head-btn:disabled:hover,.panel-head-btn[aria-busy="true"]:hover{background:transparent;color:var(--muted);}
+.app-titlebar-new-chat:disabled,.app-titlebar-new-chat[aria-busy="true"]{opacity:.5;cursor:wait;}
+.app-titlebar-new-chat:disabled:hover,.app-titlebar-new-chat[aria-busy="true"]:hover{background:transparent;color:var(--muted);}
 .panel-head-btn svg{width:14px;height:14px;display:block;}
 .panel-head-sub{padding:6px 12px 8px;font-size:11px;color:var(--muted);flex-shrink:0;}
 .side-menu{display:flex;flex-direction:column;gap:2px;padding:8px;overflow-y:auto;}

--- a/tests/test_issue2518_new_session_inflight.py
+++ b/tests/test_issue2518_new_session_inflight.py
@@ -25,6 +25,8 @@ def test_new_session_sets_visible_pending_state_for_cold_catalog_wait():
     assert "function _setNewSessionPending(pending)" in src
     assert "btn.disabled=!!pending" in src
     assert "btn.setAttribute('aria-busy',pending?'true':'false')" in src
+    assert "const ids=['btnNewChat','btnTitlebarNewChat']" in src
+    assert "btnTitlebarNewChat" in src
     assert "setComposerStatus(pendingText)" in src
     assert "t('new_session_creating')" in src
 
@@ -33,5 +35,6 @@ def test_new_session_pending_button_style_and_copy_exist():
     css = _source("static/style.css")
     i18n = _source("static/i18n.js")
     assert '.panel-head-btn:disabled,.panel-head-btn[aria-busy="true"]' in css
+    assert '.app-titlebar-new-chat:disabled,.app-titlebar-new-chat[aria-busy="true"]' in css
     assert "cursor:wait" in css
     assert "new_session_creating: 'Creating new conversation…'" in i18n

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -619,6 +619,54 @@ def test_new_conversation_shortcut_works_while_busy():
     )
 
 
+def test_mobile_titlebar_has_new_conversation_button():
+    """Mobile titlebar shows the New Conversation action and keeps it next to reload."""
+    header_match = re.search(
+        r'<header class="app-titlebar"[^>]*>(?P<body>.*?)</header>',
+        HTML,
+        re.S,
+    )
+    assert header_match, "app-titlebar header block missing"
+    header_html = header_match.group("body")
+
+    idx_btn = header_html.find('id="btnTitlebarNewChat"')
+    idx_reload = header_html.find('id="btnReload"')
+    idx_spacer = header_html.find('class="app-titlebar-spacer"')
+
+    assert idx_btn != -1, "titlebar mobile new chat button should exist"
+    assert idx_reload != -1, "titlebar reload button should remain present"
+    assert idx_spacer != -1, "titlebar spacer should remain present"
+    assert idx_spacer < idx_btn < idx_reload, (
+        "titlebar new chat button must sit left of the reload button on mobile"
+    )
+    assert "btnTitlebarNewChat" in header_html
+    assert "data-i18n-title=\"new_conversation\"" in header_html
+    assert "data-i18n-aria-label=\"new_conversation\"" in header_html
+    assert "aria-label=\"New conversation\"" in header_html
+    assert "title=\"New conversation\"" in header_html
+    assert "$('btnNewChat').onclick && $('btnNewChat').onclick()" in header_html
+
+
+def test_titlebar_new_chat_button_mobile_visibility_css():
+    """Keep the titlebar new-chat control mobile-only and reuse reload button styling."""
+    base_rule = _declarations(_rule_body(CSS, ".app-titlebar-new-chat"))
+    assert base_rule.get("display") == "none", "app-titlebar new chat button must be hidden by default"
+    mobile_blocks = "".join(_max_width_media_blocks(640))
+    mobile_rule = _declarations(_rule_body(mobile_blocks, ".app-titlebar-new-chat"))
+    assert mobile_rule.get("display") == "inline-flex", (
+        "app-titlebar new chat button must be visible in mobile layout rules"
+    )
+    desktop_css = re.sub(
+        r"@media\(max-width:640px\).*",
+        "",
+        CSS,
+        flags=re.S,
+    )
+    assert ".app-titlebar-new-chat{display:inline-flex;}" not in desktop_css, (
+        "titlebar new chat button must not be exposed by desktop PWA/fullscreen rules"
+    )
+
+
 # ── Viewport and scroll safety ────────────────────────────────────────────────
 
 def test_body_overflow_hidden():

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -644,7 +644,7 @@ def test_mobile_titlebar_has_new_conversation_button():
     assert "data-i18n-aria-label=\"new_conversation\"" in header_html
     assert "aria-label=\"New conversation\"" in header_html
     assert "title=\"New conversation\"" in header_html
-    assert "$('btnNewChat').onclick && $('btnNewChat').onclick()" in header_html
+    assert "$('btnNewChat').click()" in header_html
 
 
 def test_titlebar_new_chat_button_mobile_visibility_css():


### PR DESCRIPTION
## Thinking Path
On mobile, opening a new conversation requires reaching the sidebar/panel action. The titlebar already exposes mobile chrome controls, so adding a small mobile-only New Conversation action immediately left of reload gives phone users the same quick path without changing desktop layout.

## What Changed
- Added `btnTitlebarNewChat` to the app titlebar immediately before `btnReload`.
- Reused the existing `btnNewChat` handler instead of duplicating new-chat behavior.
- Kept the new button hidden by default and visible only in the `max-width:640px` mobile layout.
- Added i18n bindings for title and aria-label.
- Added static regression tests for markup order, handler delegation, i18n/accessibility attributes, and mobile-only CSS visibility.
- Updated `CHANGELOG.md`.

## Why It Matters
Mobile users get a fast one-tap New Conversation action in the visible titlebar, while desktop and non-mobile PWA/fullscreen titlebars remain unchanged.

## Verification
- `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_mobile_layout.py -q` — 58 passed, 1 warning.
- `node --check static/boot.js` — passed.
- `git diff --check` — passed.

Before/after evidence:
- Before: `static/index.html` titlebar had `app-titlebar-spacer` followed directly by `btnReload`; no titlebar new-chat button existed.
- After: `btnTitlebarNewChat` sits between the spacer and reload button, delegates to `btnNewChat`, and is visible only in the mobile `@media(max-width:640px)` CSS block.
- Regression evidence: `test_mobile_titlebar_has_new_conversation_button` and `test_titlebar_new_chat_button_mobile_visibility_css` assert the before/after interaction contract.

## Risks / Follow-ups
- This is intentionally mobile-only. If maintainers want the same action in desktop PWA titlebar, that should be a separate UX decision.
- No runtime state or session persistence behavior is changed.

## Model Used
AI-assisted. Coordinator: OpenAI GPT-5 Codex. Implementation sub-agent: OpenAI `gpt-5.3-codex-spark`. Coordinator reviewed the diff, fixed the mobile-only CSS boundary, added i18n aria coverage, and ran verification.

Fixes #3226
