### PR TITLE
Normalize WebUI prefill user tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+### Fixed
+- Normalized WebUI recall/session prefill in both streaming and Gateway chat paths so
+  a trailing `user` context message is removed before appending the live user turn.
+  This prevents adjacent user roles from reaching strict chat templates (for example
+  Mistral/Gemma/Jinja 500s) and fixes #3432.
+
 ## [v0.51.252] — 2026-06-03 — Release HT (stage-q24 — selection-bleed fix + compatibility docs)
 
 ### Fixed

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -270,11 +270,12 @@ def _run_gateway_chat_streaming(
                 },
                 config_data=cfg,
             )
+            prefill_messages = _prefill_messages_with_webui_context(prefill_context, cfg)
+            prefill_messages = _normalize_prefill_messages_before_user_turn(prefill_messages)
             prefill_messages = [
                 {"role": "system", "content": _gateway_system_prompt},
-                *_prefill_messages_with_webui_context(prefill_context, cfg),
+                *prefill_messages,
             ]
-            prefill_messages = _normalize_prefill_messages_before_user_turn(prefill_messages)
             put_gateway_event("context_status", {
                 "session_id": session_id,
                 "prefill": _public_prefill_context_status(prefill_context),

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -249,6 +249,7 @@ def _run_gateway_chat_streaming(
             from api.streaming import (
                 _load_webui_prefill_context,
                 _prefill_messages_with_webui_context,
+                _normalize_prefill_messages_before_user_turn,
                 _public_prefill_context_status,
                 _webui_ephemeral_system_prompt,
             )
@@ -273,6 +274,7 @@ def _run_gateway_chat_streaming(
                 {"role": "system", "content": _gateway_system_prompt},
                 *_prefill_messages_with_webui_context(prefill_context, cfg),
             ]
+            prefill_messages = _normalize_prefill_messages_before_user_turn(prefill_messages)
             put_gateway_event("context_status", {
                 "session_id": session_id,
                 "prefill": _public_prefill_context_status(prefill_context),

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -607,6 +607,7 @@ def _normalize_prefill_messages_before_user_turn(prefill_messages: list[dict]) -
     just before that boundary; earlier roles remain untouched.
     """
     sanitized = list(prefill_messages or [])
+    n_dropped = 0
     while sanitized:
         last_message = sanitized[-1]
         if not isinstance(last_message, dict):
@@ -614,6 +615,9 @@ def _normalize_prefill_messages_before_user_turn(prefill_messages: list[dict]) -
         if str(last_message.get("role") or "").strip().lower() != "user":
             break
         sanitized.pop()
+        n_dropped += 1
+    if n_dropped:
+        logger.debug("Dropped %d trailing user message(s) from prefill", n_dropped)
     return sanitized
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -594,6 +594,29 @@ def _prefill_messages_with_webui_context(prefill_context: dict, config_data: Opt
     return list(prefill_context.get("messages") or [])
 
 
+def _normalize_prefill_messages_before_user_turn(prefill_messages: list[dict]) -> list[dict]:
+    """Ensure WebUI prefill does not end with user role before an appended turn.
+
+    Some upstream prefill sources can end with `role: user` (for example,
+    session context or recall snippets). WebUI always appends the current user
+    turn after prefill in the streaming path, so a terminal user role creates an
+    adjacent user/user sequence that strict chat templates (Gemma, Mistral/Jinja)
+    reject.
+
+    To keep behavior scoped, only consecutive terminal user messages are removed
+    just before that boundary; earlier roles remain untouched.
+    """
+    sanitized = list(prefill_messages or [])
+    while sanitized:
+        last_message = sanitized[-1]
+        if not isinstance(last_message, dict):
+            break
+        if str(last_message.get("role") or "").strip().lower() != "user":
+            break
+        sanitized.pop()
+    return sanitized
+
+
 def _has_new_assistant_reply(all_messages: list, prev_count: int) -> bool:
     """Return True if *new* messages (beyond ``prev_count``) contain an
     assistant message with non-empty content.
@@ -4973,6 +4996,7 @@ def _run_agent_streaming(
                 _cfg = _get_config()
             _prefill_context = _load_webui_prefill_context(_cfg)
             _prefill_messages = _prefill_messages_with_webui_context(_prefill_context, _cfg)
+            _prefill_messages = _normalize_prefill_messages_before_user_turn(_prefill_messages)
             put('context_status', {
                 'session_id': session_id,
                 'prefill': _public_prefill_context_status(_prefill_context),

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -333,6 +333,77 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     }) in events
 
 
+def test_gateway_chat_worker_normalizes_prefill_slice_before_system_prefix(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    captured = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield b'data: {"choices":[{"delta":{"content":"done"}}]}\n\n'
+            yield b'data: [DONE]\n\n'
+
+    prefill_raw = [
+        {"role": "assistant", "content": "prefill summary"},
+        {"role": "user", "content": "first terminal user"},
+        {"role": "user", "content": "second terminal user"},
+    ]
+
+    def fake_urlopen(req, timeout=0):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return FakeResponse()
+
+    original_normalizer = streaming._normalize_prefill_messages_before_user_turn
+
+    def recording_normalizer(messages):
+        captured["normalizer_input"] = list(messages)
+        return original_normalizer(messages)
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {
+        "status": "loaded",
+        "source": "test",
+        "label": "test",
+        "message_count": len(prefill_raw),
+        "messages": prefill_raw,
+    })
+    monkeypatch.setattr(streaming, "_prefill_messages_with_webui_context", lambda ctx, cfg: list(ctx["messages"]))
+    monkeypatch.setattr(streaming, "_normalize_prefill_messages_before_user_turn", recording_normalizer)
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", fake_urlopen)
+
+    s = new_session()
+    stream_id = "stream-gateway-prefill-slice-test"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.save()
+    STREAMS[stream_id] = create_stream_channel()
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+    )
+
+    assert captured["normalizer_input"] == prefill_raw
+    payload_messages = captured["body"]["messages"]
+    assert [m["role"] for m in payload_messages] == ["system", "assistant", "user"]
+    assert [m["content"] for m in payload_messages[1:]] == ["prefill summary", "Say hello"]
+
+
 def test_gateway_chat_worker_backfills_context_only_turns_into_display(tmp_path, monkeypatch):
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -247,7 +247,16 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
 
     monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
     monkeypatch.setenv("HERMES_WEBUI_GATEWAY_API_KEY", "secret-token")
-    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {"status": "loaded", "source": "test", "label": "test", "message_count": 1, "messages": [{"role": "user", "content": "prefill"}]})
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {
+        "status": "loaded",
+        "source": "test",
+        "label": "test",
+        "message_count": 2,
+        "messages": [
+            {"role": "assistant", "content": "prefill summary"},
+            {"role": "user", "content": "prefill"},
+        ],
+    })
     monkeypatch.setattr(streaming, "_prefill_messages_with_webui_context", lambda ctx, cfg: list(ctx["messages"]) + [{"role": "user", "content": "webui session context"}])
     monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", fake_urlopen)
 
@@ -296,12 +305,13 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     # The moved session/delivery context must be present in the system prompt.
     assert "Connected Platforms:" in system_msg["content"]
     assert "Delivery options for scheduled tasks:" in system_msg["content"]
-    # The recall prefill + the actual user turn follow the system message.
+    # The gateway path keeps safe recall prefill context while removing
+    # terminal user-role prefill before the actual browser user turn.
     assert [m["content"] for m in payload["messages"][1:]] == [
-        "prefill",
-        "webui session context",
+        "prefill summary",
         "Say hello",
     ]
+    assert [m["role"] for m in payload["messages"]] == ["system", "assistant", "user"]
     events = []
     while not subscriber.empty():
         events.append(subscriber.get_nowait())
@@ -583,7 +593,9 @@ def test_gateway_chat_worker_forwards_image_attachments_as_multimodal_parts(tmp_
     content = captured["body"]["messages"][-1]["content"]
     assert captured["body"]["messages"][0]["role"] == "system"
     assert "Final visible assistant replies" in captured["body"]["messages"][0]["content"]
-    assert captured["body"]["messages"][1] == {"role": "user", "content": "webui session context"}
+    image_payload = captured["body"]["messages"][1]
+    assert image_payload["role"] == "user"
+    assert image_payload["content"][0] == {"type": "text", "text": "What is in this image?"}
     assert content[0] == {"type": "text", "text": "What is in this image?"}
     assert content[1]["type"] == "image_url"
     assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")

--- a/tests/test_webui_state_db_context_reconciliation.py
+++ b/tests/test_webui_state_db_context_reconciliation.py
@@ -130,3 +130,83 @@ def test_next_webui_turn_context_includes_state_db_external_messages(monkeypatch
         "external gateway user",
         "external gateway assistant",
     ]
+
+
+def test_webui_streaming_normalizes_trailing_prefill_user_before_current_turn(monkeypatch, tmp_path):
+    import api.config as config
+    import api.models as models
+    import api.streaming as streaming
+    from api.models import new_session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict(), raising=False)
+    monkeypatch.setattr(config, "SESSION_DIR", session_dir, raising=False)
+    monkeypatch.setattr(config, "SESSION_INDEX_FILE", index_file, raising=False)
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir, raising=False)
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: tmp_path / "state.db", raising=False)
+    config.STREAMS.clear()
+    config.CANCEL_FLAGS.clear()
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, prefill_messages=None, **kwargs):
+            captured["prefill_messages"] = kwargs.get("prefill_messages")
+            if prefill_messages is not None:
+                captured["prefill_messages"] = prefill_messages
+            self.context_compressor = None
+            self.ephemeral_system_prompt = None
+
+        def run_conversation(self, **kwargs):
+            return {
+                "completed": True,
+                "final_response": "ok",
+                "messages": [
+                    {"role": "user", "content": kwargs.get("persist_user_message", "")},
+                    {"role": "assistant", "content": "ok"},
+                ],
+            }
+
+    monkeypatch.setattr(streaming, "_get_ai_agent", lambda: FakeAgent)
+    monkeypatch.setattr(streaming, "resolve_model_provider", lambda *args, **kwargs: ("test-model", None, None))
+    monkeypatch.setattr(streaming, "get_config", lambda: {})
+    monkeypatch.setattr(config, "get_config", lambda: {})
+    monkeypatch.setattr(config, "_resolve_cli_toolsets", lambda *args, **kwargs: [])
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {
+        "status": "loaded",
+        "source": "test",
+        "label": "test",
+        "message_count": 2,
+        "messages": [
+            {"role": "assistant", "content": "prefill summary"},
+            {"role": "user", "content": "webui session context"},
+        ],
+    })
+
+    s = new_session(workspace=str(tmp_path))
+    stream_id = "stream-prefill-boundary-normalization"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "new webui turn"
+    s.pending_started_at = 0.0
+    s.save(touch_updated_at=False)
+    models.SESSIONS[s.session_id] = s
+
+    config.STREAMS[stream_id] = queue.Queue()
+    try:
+        streaming._run_agent_streaming(
+            session_id=s.session_id,
+            msg_text="new webui turn",
+            model="test-model",
+            workspace=str(tmp_path),
+            stream_id=stream_id,
+            attachments=[],
+        )
+    finally:
+        config.STREAMS.pop(stream_id, None)
+
+    prefill = captured.get("prefill_messages") or []
+    assert prefill == [{"role": "assistant", "content": "prefill summary"}]

--- a/tests/test_webui_surface_context.py
+++ b/tests/test_webui_surface_context.py
@@ -99,6 +99,13 @@ def test_prefill_boundary_normalizer_removes_terminal_user_tail():
         {"role": "user", "content": "legacy user"},
         {"role": "assistant", "content": "assistant follow-up"},
     ]
+    assert _normalize_prefill_messages_before_user_turn([
+        {"role": "assistant", "content": "tail",},
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "second"},
+    ]) == [
+        {"role": "assistant", "content": "tail",},
+    ]
     assert _normalize_prefill_messages_before_user_turn([]) == []
     assert _normalize_prefill_messages_before_user_turn([{"role": "user", "content": "only user"}]) == []
 

--- a/tests/test_webui_surface_context.py
+++ b/tests/test_webui_surface_context.py
@@ -79,6 +79,30 @@ def test_prefill_no_longer_adds_session_context_user_message():
     assert "Connected Platforms" not in result[0].get("content", "")
 
 
+def test_prefill_boundary_normalizer_removes_terminal_user_tail():
+    from api.streaming import _normalize_prefill_messages_before_user_turn
+
+    raw = [
+        {"role": "assistant", "content": "recall summary"},
+        {"role": "user", "content": "session context"},
+    ]
+
+    assert _normalize_prefill_messages_before_user_turn(raw) == [
+        {"role": "assistant", "content": "recall summary"},
+    ]
+    assert _normalize_prefill_messages_before_user_turn([
+        {"role": "assistant", "content": "prefill"},
+        {"role": "user", "content": "legacy user"},
+        {"role": "assistant", "content": "assistant follow-up"},
+    ]) == [
+        {"role": "assistant", "content": "prefill"},
+        {"role": "user", "content": "legacy user"},
+        {"role": "assistant", "content": "assistant follow-up"},
+    ]
+    assert _normalize_prefill_messages_before_user_turn([]) == []
+    assert _normalize_prefill_messages_before_user_turn([{"role": "user", "content": "only user"}]) == []
+
+
 def test_prefill_preserves_empty_and_none_messages():
     """Edge cases: empty prefill stays empty, missing key returns empty."""
     assert _prefill_messages_with_webui_context({"messages": []}) == []

--- a/tests/test_webui_surface_context.py
+++ b/tests/test_webui_surface_context.py
@@ -1,4 +1,10 @@
-from api.streaming import _webui_ephemeral_system_prompt, _prefill_messages_with_webui_context
+import logging
+
+from api.streaming import (
+    _normalize_prefill_messages_before_user_turn,
+    _prefill_messages_with_webui_context,
+    _webui_ephemeral_system_prompt,
+)
 
 
 def test_webui_ephemeral_prompt_includes_browser_surface_context():
@@ -80,7 +86,7 @@ def test_prefill_no_longer_adds_session_context_user_message():
 
 
 def test_prefill_boundary_normalizer_removes_terminal_user_tail():
-    from api.streaming import _normalize_prefill_messages_before_user_turn
+    """Trailing user messages are removed until the first non-user boundary."""
 
     raw = [
         {"role": "assistant", "content": "recall summary"},
@@ -108,6 +114,38 @@ def test_prefill_boundary_normalizer_removes_terminal_user_tail():
     ]
     assert _normalize_prefill_messages_before_user_turn([]) == []
     assert _normalize_prefill_messages_before_user_turn([{"role": "user", "content": "only user"}]) == []
+
+
+def test_prefill_boundary_normalizer_logs_when_user_tail_dropped(caplog):
+    """Dropping trailing user messages is logged with the count."""
+    caplog.set_level(logging.DEBUG, logger="api.streaming")
+
+    messages = [
+        {"role": "assistant", "content": "prefill"},
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "second"},
+    ]
+
+    assert _normalize_prefill_messages_before_user_turn(messages) == [
+        {"role": "assistant", "content": "prefill"},
+    ]
+    assert any(
+        rec.message == "Dropped 2 trailing user message(s) from prefill" for rec in caplog.records
+    )
+
+
+def test_prefill_boundary_normalizer_no_log_when_no_terminal_user(caplog):
+    """No-op normalization must not emit the prefill-dropping debug log."""
+    caplog.set_level(logging.DEBUG, logger="api.streaming")
+
+    messages = [
+        {"role": "assistant", "content": "turn 1"},
+        {"role": "user", "content": "turn 2"},
+        {"role": "assistant", "content": "turn 3"},
+    ]
+
+    assert _normalize_prefill_messages_before_user_turn(messages) == messages
+    assert len(caplog.records) == 0
 
 
 def test_prefill_preserves_empty_and_none_messages():


### PR DESCRIPTION
## Thinking Path
#3324 moved WebUI delivery/session context into the ephemeral system prompt, but configured recall prefill could still end with `role: user`. Both in-process streaming and Gateway chat then append the live browser user turn, producing adjacent `user` roles that strict chat templates reject. The fix normalizes only that prefill/current-user boundary.

## What Changed
- Added `_normalize_prefill_messages_before_user_turn()` to drop consecutive terminal `user` messages from prefill immediately before WebUI appends the live user turn.
- Applied the normalizer in both `api/streaming.py` and `api/gateway_chat.py`.
- Added regression coverage for the helper, the in-process streaming path, and Gateway payload assembly.
- Strengthened Gateway coverage to prove safe assistant prefill context is preserved while only the terminal user tail is removed.
- Updated `CHANGELOG.md`.

## Why It Matters
WebUI no longer sends adjacent `user` roles to strict chat templates when recall prefill is configured, preventing avoidable Mistral/Gemma/Jinja chat-template failures while preserving safe prefill context.

## Verification
- `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/test_webui_surface_context.py tests/test_webui_gateway_chat_backend.py tests/test_webui_state_db_context_reconciliation.py` — 28 passed, 1 warning.
- `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m py_compile api/streaming.py api/gateway_chat.py` — passed.
- `git diff --check` — passed.

## Risks / Follow-ups
- The normalizer intentionally drops consecutive terminal `user` prefill turns. This matches the issue's suggested fix shape for strict templates, but custom prefill sources that intentionally encode essential context as a trailing user turn should move that context earlier or use an assistant/system-like representation.
- State layer: transient prompt/prefill payload assembly only. Persisted session messages and state DB contents are not mutated.

## Model Used
AI-assisted. Coordinator: OpenAI GPT-5 Codex. Implementation sub-agent: OpenAI `gpt-5.3-codex-spark`. Coordinator reviewed the diff, strengthened Gateway regression coverage, and ran verification.

Fixes #3432
