### PR TITLE
Fix reload-mcp WebUI dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+### Fixed
+- `/reload-mcp` now executes through `/api/commands/exec` using a narrow,
+  allowlisted agent-side command path instead of falling through to the normal
+  LLM prompt path. Unknown and CLI-only commands are still rejected unless
+  explicitly enabled.
+
 ## [v0.51.252] — 2026-06-03 — Release HT (stage-q24 — selection-bleed fix + compatibility docs)
 
 ### Fixed

--- a/api/commands.py
+++ b/api/commands.py
@@ -6,6 +6,7 @@ so the frontend can still load with WEBUI_ONLY commands.
 """
 from __future__ import annotations
 import logging
+import threading
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -25,6 +26,7 @@ _AGENT_COMMAND_ALIASES = {
     'reload_mcp': 'reload-mcp',
 }
 _ALLOWED_AGENT_COMMANDS = frozenset({'reload-mcp'})
+_RELOAD_MCP_LOCK = threading.Lock()
 
 
 def _normalize_agent_command_name(command: str) -> str:
@@ -115,25 +117,25 @@ def execute_agent_command(command: str) -> str:
 
 def _run_reload_mcp_command() -> str:
     """Execute the MCP reconnect path and return a short user-facing summary."""
+    with _RELOAD_MCP_LOCK:
+        try:
+            from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
+        except Exception as exc:
+            logger.warning("Failed to import MCP runtime for /reload-mcp", exc_info=True)
+            raise RuntimeError("MCP runtime unavailable") from exc
 
-    try:
-        from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
-    except Exception as exc:
-        logger.warning("Failed to import MCP runtime for /reload-mcp", exc_info=exc)
-        raise RuntimeError("MCP runtime unavailable") from exc
+        try:
+            with _lock:
+                old_servers = set(_servers.keys())
 
-    try:
-        with _lock:
-            old_servers = set(_servers.keys())
+            shutdown_mcp_servers()
+            new_tools = discover_mcp_tools()
 
-        shutdown_mcp_servers()
-        new_tools = discover_mcp_tools()
-
-        with _lock:
-            connected_servers = set(_servers.keys())
-    except Exception as exc:
-        logger.warning("/reload-mcp failed", exc_info=exc)
-        raise RuntimeError(f"/reload-mcp failed: {exc}") from exc
+            with _lock:
+                connected_servers = set(_servers.keys())
+        except Exception as exc:
+            logger.warning("Failed to reload MCP servers", exc_info=True)
+            raise RuntimeError("Failed to reload MCP servers") from exc
 
     added = connected_servers - old_servers
     removed = old_servers - connected_servers
@@ -183,12 +185,14 @@ def execute_plugin_command(command: str) -> str:
             resolve_plugin_command_result,
         )
     except ImportError as exc:
+        logger.warning("Plugin command runtime unavailable", exc_info=True)
         raise RuntimeError("plugin command runtime unavailable") from exc
 
     try:
         handler = get_plugin_command_handler(cmd_base)
     except Exception as exc:
-        raise RuntimeError(f"plugin command lookup failed: {exc}") from exc
+        logger.warning("Plugin command lookup failed for %r", cmd_base, exc_info=True)
+        raise RuntimeError("plugin command lookup failed") from exc
 
     if not handler:
         raise KeyError(cmd_base)
@@ -200,5 +204,5 @@ def execute_plugin_command(command: str) -> str:
         # Don't leak raw exception str (paths, env, internal state) to the
         # user-facing chat. Type name is enough for the user to know what
         # class of failure occurred; full traceback lives in the server log.
-        logger.warning("Plugin command %r failed", cmd_base, exc_info=exc)
+        logger.warning("Plugin command %r execution failed", cmd_base, exc_info=True)
         return f"Plugin command error: {type(exc).__name__}"

--- a/api/commands.py
+++ b/api/commands.py
@@ -20,6 +20,29 @@ _NEVER_EXPOSE: frozenset[str] = frozenset({
 })
 
 
+# Narrow agent-side execution allowlist for /api/commands/exec.
+_AGENT_COMMAND_ALIASES = {
+    'reload_mcp': 'reload-mcp',
+}
+_ALLOWED_AGENT_COMMANDS = frozenset({'reload-mcp'})
+
+
+def _normalize_agent_command_name(command: str) -> str:
+    """Normalize slash text to a canonical command name."""
+
+    raw = str(command or "").strip()
+    if not raw:
+        raise ValueError("command is required")
+
+    cmd_text = raw[1:] if raw.startswith("/") else raw
+    cmd_parts = cmd_text.split(maxsplit=1)
+    cmd_base = (cmd_parts[0] if cmd_parts else "").strip().lower()
+    if not cmd_base:
+        raise ValueError("command is required")
+
+    return _AGENT_COMMAND_ALIASES.get(cmd_base, cmd_base)
+
+
 def list_commands(_registry=None) -> list[dict[str, Any]]:
     """Return COMMAND_REGISTRY entries as JSON-friendly dicts.
 
@@ -74,8 +97,65 @@ def list_commands(_registry=None) -> list[dict[str, Any]]:
             })
     except Exception:
         pass
-
     return out
+
+
+def execute_agent_command(command: str) -> str:
+    """Execute a narrow allowlist of agent-side runtime commands."""
+
+    canonical = _normalize_agent_command_name(command)
+    if canonical not in _ALLOWED_AGENT_COMMANDS:
+        raise KeyError(canonical)
+
+    if canonical == 'reload-mcp':
+        return _run_reload_mcp_command()
+
+    raise KeyError(canonical)
+
+
+def _run_reload_mcp_command() -> str:
+    """Execute the MCP reconnect path and return a short user-facing summary."""
+
+    try:
+        from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
+    except Exception as exc:
+        logger.warning("Failed to import MCP runtime for /reload-mcp", exc_info=exc)
+        raise RuntimeError("MCP runtime unavailable") from exc
+
+    try:
+        with _lock:
+            old_servers = set(_servers.keys())
+
+        shutdown_mcp_servers()
+        new_tools = discover_mcp_tools()
+
+        with _lock:
+            connected_servers = set(_servers.keys())
+    except Exception as exc:
+        logger.warning("/reload-mcp failed", exc_info=exc)
+        raise RuntimeError(f"/reload-mcp failed: {exc}") from exc
+
+    added = connected_servers - old_servers
+    removed = old_servers - connected_servers
+    reconnected = connected_servers & old_servers
+
+    lines = ["Reloaded MCP servers from configuration."]
+    if reconnected:
+        lines.append(f"Reconnected: {', '.join(sorted(reconnected))}")
+    if added:
+        lines.append(f"Added: {', '.join(sorted(added))}")
+    if removed:
+        lines.append(f"Removed: {', '.join(sorted(removed))}")
+
+    if connected_servers:
+        lines.append(f"{len(new_tools or [])} tool(s) available across {len(connected_servers)} server(s)")
+    else:
+        lines.append("No MCP servers connected")
+
+    if not reconnected and not added and not removed:
+        lines.append("Tooling state was already current")
+
+    return "\n".join(lines)
 
 
 def execute_plugin_command(command: str) -> str:

--- a/api/routes.py
+++ b/api/routes.py
@@ -7197,11 +7197,21 @@ def handle_post(handler, parsed) -> bool:
 
     # ── Commands (POST) ──
     if parsed.path == "/api/commands/exec":
-        from api.commands import execute_plugin_command
+        from api.commands import execute_agent_command, execute_plugin_command
 
         command = str(body.get("command", "") or "").strip()
         if not command:
             return bad(handler, "command is required")
+
+        try:
+            return j(handler, {"output": execute_agent_command(command)})
+        except KeyError:
+            pass
+        except ValueError as e:
+            return bad(handler, str(e), 400)
+        except RuntimeError as e:
+            return bad(handler, _sanitize_error(e), 500)
+
         try:
             return j(handler, {"output": execute_plugin_command(command)})
         except ValueError as e:

--- a/static/commands.js
+++ b/static/commands.js
@@ -244,16 +244,14 @@ function cliOnlyCommandResponse(cmdName, meta){
 }
 
 async function executeAgentCommand(text,_meta){
-  const command=String(text||'').trim();
-  if(!command) throw new Error('command is required');
-  const data=await api('/api/commands/exec',{
-    method:'POST',
-    body:JSON.stringify({command})
-  });
-  return String(data&&data.output||'(no output)');
+  return _runAgentCommandTransport(text,_meta);
 }
 
 async function executeAgentPluginCommand(text,_meta){
+  return _runAgentCommandTransport(text,_meta);
+}
+
+async function _runAgentCommandTransport(text,_meta){
   const command=String(text||'').trim();
   if(!command) throw new Error('command is required');
   const data=await api('/api/commands/exec',{

--- a/static/commands.js
+++ b/static/commands.js
@@ -243,6 +243,16 @@ function cliOnlyCommandResponse(cmdName, meta){
   return `\`/${name}\` is a Hermes CLI-only command and cannot run inside the WebUI.${detail}${extra}`;
 }
 
+async function executeAgentCommand(text,_meta){
+  const command=String(text||'').trim();
+  if(!command) throw new Error('command is required');
+  const data=await api('/api/commands/exec',{
+    method:'POST',
+    body:JSON.stringify({command})
+  });
+  return String(data&&data.output||'(no output)');
+}
+
 async function executeAgentPluginCommand(text,_meta){
   const command=String(text||'').trim();
   if(!command) throw new Error('command is required');

--- a/static/messages.js
+++ b/static/messages.js
@@ -208,6 +208,7 @@ if(typeof document!=='undefined'){
 let _sendInProgress = false;
 let _sendInProgressSid = null;  // session_id of the in-flight send
 const _sessionTitleProvisionalBySid = new Map();
+const _AGENT_COMMANDS_RUN_ON_WEBUI = new Set(['reload-mcp']);
 
 function _clearStaleBusyStateBeforeSend({compressionRunning=false}={}){
   if(!S||!S.busy||compressionRunning) return false;
@@ -420,6 +421,22 @@ async function send(){
         if(!S.session){await newSession();await renderSessionList();}
         S.messages.push({role:'user',content:text,_ts:Date.now()/1000});
         S.messages.push({role:'assistant',content:cliOnlyCommandResponse(_parsedCmd.name,_agentCmd),_ts:Date.now()/1000});
+        renderMessages();
+        $('msg').value='';autoResize();hideCmdDropdown();return;
+      }
+      const _agentCmdName=String(_agentCmd&&_agentCmd.name||_parsedCmd&&_parsedCmd.name||'').trim().toLowerCase();
+      if(_agentCmd&&_AGENT_COMMANDS_RUN_ON_WEBUI.has(_agentCmdName)){
+        if(!S.session){await newSession();await renderSessionList();}
+        S.messages.push({role:'user',content:text,_ts:Date.now()/1000});
+        let _agentOutput='(no output)';
+        try{
+          _agentOutput=typeof executeAgentCommand==='function'
+            ? await executeAgentCommand(text,_agentCmd)
+            : 'Agent command runtime unavailable in WebUI.';
+        }catch(e){
+          _agentOutput=`Agent command error: ${e&&e.message||e}`;
+        }
+        S.messages.push({role:'assistant',content:String(_agentOutput||'(no output)'),_ts:Date.now()/1000});
         renderMessages();
         $('msg').value='';autoResize();hideCmdDropdown();return;
       }

--- a/static/messages.js
+++ b/static/messages.js
@@ -208,7 +208,11 @@ if(typeof document!=='undefined'){
 let _sendInProgress = false;
 let _sendInProgressSid = null;  // session_id of the in-flight send
 const _sessionTitleProvisionalBySid = new Map();
-const _AGENT_COMMANDS_RUN_ON_WEBUI = new Set(['reload-mcp']);
+// Agent commands that are safe to execute directly in the WebUI even though
+// their canonical command is registered on the backend (for example
+// /reload-mcp). Keep this intentionally narrow and include underscore variants
+// observed by users so typing either form still routes through executeAgentCommand.
+const _AGENT_COMMANDS_RUN_ON_WEBUI = new Set(['reload-mcp', 'reload_mcp']);
 
 function _clearStaleBusyStateBeforeSend({compressionRunning=false}={}){
   if(!S||!S.busy||compressionRunning) return false;
@@ -425,13 +429,13 @@ async function send(){
         $('msg').value='';autoResize();hideCmdDropdown();return;
       }
       const _agentCmdName=String(_agentCmd&&_agentCmd.name||_parsedCmd&&_parsedCmd.name||'').trim().toLowerCase();
-      if(_agentCmd&&_AGENT_COMMANDS_RUN_ON_WEBUI.has(_agentCmdName)){
+      if(_AGENT_COMMANDS_RUN_ON_WEBUI.has(_agentCmdName)){
         if(!S.session){await newSession();await renderSessionList();}
         S.messages.push({role:'user',content:text,_ts:Date.now()/1000});
         let _agentOutput='(no output)';
         try{
           _agentOutput=typeof executeAgentCommand==='function'
-            ? await executeAgentCommand(text,_agentCmd)
+            ? await executeAgentCommand(text,_agentCmd||{name:_agentCmdName})
             : 'Agent command runtime unavailable in WebUI.';
         }catch(e){
           _agentOutput=`Agent command error: ${e&&e.message||e}`;

--- a/tests/test_cli_only_slash_commands.py
+++ b/tests/test_cli_only_slash_commands.py
@@ -61,7 +61,10 @@ def test_frontend_matches_agent_command_aliases():
 
 def test_frontend_can_execute_agent_commands_via_api_endpoint():
     assert "async function executeAgentCommand" in COMMANDS_JS
+    assert "async function executeAgentPluginCommand" in COMMANDS_JS
+    assert "async function _runAgentCommandTransport" in COMMANDS_JS
     assert "api('/api/commands/exec'" in COMMANDS_JS
+    assert COMMANDS_JS.count("api('/api/commands/exec'") == 1
 
 
 def test_cli_only_response_mentions_webui_and_cli_scope():

--- a/tests/test_cli_only_slash_commands.py
+++ b/tests/test_cli_only_slash_commands.py
@@ -183,8 +183,15 @@ def test_send_intercepts_reload_mcp_agent_command_before_agent_round_trip():
     assert normal_send_idx != -1
     intercept = MESSAGES_JS[intercept_idx:normal_send_idx]
 
-    assert "if(_agentCmd&&_AGENT_COMMANDS_RUN_ON_WEBUI.has(_agentCmdName))" in intercept
-    assert "executeAgentCommand(text,_agentCmd)" in intercept
+    assert "const _agentCmdName=String(_agentCmd&&_agentCmd.name||_parsedCmd&&_parsedCmd.name||'')" in intercept
+    assert "if(_AGENT_COMMANDS_RUN_ON_WEBUI.has(_agentCmdName))" in intercept
+    assert "executeAgentCommand(text,_agentCmd||{name:_agentCmdName})" in intercept
+
+
+def test_reload_mcp_webui_intercept_aliases_are_defined_in_js_whitelist():
+    assert "'reload-mcp'" in MESSAGES_JS
+    assert "'reload_mcp'" in MESSAGES_JS
+    assert "if(_agentCmd&&_AGENT_COMMANDS_RUN_ON_WEBUI.has(_agentCmdName))" not in MESSAGES_JS
 
 
 def test_unknown_slash_commands_still_fall_through_to_agent():
@@ -194,7 +201,7 @@ def test_unknown_slash_commands_still_fall_through_to_agent():
     intercept = MESSAGES_JS[intercept_idx:normal_send_idx]
 
     assert "if(_agentCmd&&_agentCmd.cli_only)" in intercept
-    assert "if(_agentCmd&&_AGENT_COMMANDS_RUN_ON_WEBUI.has(_agentCmdName))" in intercept
+    assert "if(_AGENT_COMMANDS_RUN_ON_WEBUI.has(_agentCmdName))" in intercept
     assert "if(_agentCmd&&_agentCmd.category==='Plugin')" in intercept
     assert "if(_parsedCmd&&!_cmd)" in intercept
     assert "if(!_agentCmd" not in intercept

--- a/tests/test_cli_only_slash_commands.py
+++ b/tests/test_cli_only_slash_commands.py
@@ -59,6 +59,11 @@ def test_frontend_matches_agent_command_aliases():
     assert "some(a=>String(a||'').toLowerCase()===needle)" in helper
 
 
+def test_frontend_can_execute_agent_commands_via_api_endpoint():
+    assert "async function executeAgentCommand" in COMMANDS_JS
+    assert "api('/api/commands/exec'" in COMMANDS_JS
+
+
 def test_cli_only_response_mentions_webui_and_cli_scope():
     assert "function cliOnlyCommandResponse" in COMMANDS_JS
     assert "Hermes CLI-only command" in COMMANDS_JS
@@ -169,6 +174,16 @@ def test_send_intercepts_cli_only_commands_before_agent_round_trip():
     assert "return;" in intercept
 
 
+def test_send_intercepts_reload_mcp_agent_command_before_agent_round_trip():
+    intercept_idx = MESSAGES_JS.find("Slash command intercept")
+    normal_send_idx = MESSAGES_JS.find("const activeSid=S.session.session_id", intercept_idx)
+    assert normal_send_idx != -1
+    intercept = MESSAGES_JS[intercept_idx:normal_send_idx]
+
+    assert "if(_agentCmd&&_AGENT_COMMANDS_RUN_ON_WEBUI.has(_agentCmdName))" in intercept
+    assert "executeAgentCommand(text,_agentCmd)" in intercept
+
+
 def test_unknown_slash_commands_still_fall_through_to_agent():
     """Only explicitly supported metadata-backed commands should be intercepted."""
     intercept_idx = MESSAGES_JS.find("Slash command intercept")
@@ -176,6 +191,7 @@ def test_unknown_slash_commands_still_fall_through_to_agent():
     intercept = MESSAGES_JS[intercept_idx:normal_send_idx]
 
     assert "if(_agentCmd&&_agentCmd.cli_only)" in intercept
+    assert "if(_agentCmd&&_AGENT_COMMANDS_RUN_ON_WEBUI.has(_agentCmdName))" in intercept
     assert "if(_agentCmd&&_agentCmd.category==='Plugin')" in intercept
     assert "if(_parsedCmd&&!_cmd)" in intercept
     assert "if(!_agentCmd" not in intercept

--- a/tests/test_commands_endpoint.py
+++ b/tests/test_commands_endpoint.py
@@ -2,10 +2,27 @@
 import json
 import urllib.error
 import urllib.request
+import threading
+import time
+from types import ModuleType
 
 import pytest
 
 from tests.conftest import TEST_BASE, requires_agent_modules
+
+
+def _install_fake_mcp_tool(monkeypatch, shutdown, discover, servers=None, lock=None):
+    import sys
+    tools_pkg = ModuleType("tools")
+    tools_pkg.__path__ = []
+    mcp_tool = ModuleType("tools.mcp_tool")
+    mcp_tool.shutdown_mcp_servers = shutdown
+    mcp_tool.discover_mcp_tools = discover
+    mcp_tool._servers = servers if servers is not None else {}
+    mcp_tool._lock = lock if lock is not None else threading.Lock()
+    monkeypatch.setitem(sys.modules, "tools", tools_pkg)
+    monkeypatch.setitem(sys.modules, "tools.mcp_tool", mcp_tool)
+    return mcp_tool
 
 
 def _get(path):
@@ -99,6 +116,105 @@ def test_commands_exec_runs_reload_mcp_alias():
     assert status == 200
     assert 'output' in body
     assert isinstance(body['output'], str)
+
+
+def test_reload_mcp_error_is_generic(monkeypatch):
+    """`/reload-mcp` errors must return a generic message, not raw internals."""
+    calls = []
+
+    def shutdown():
+        calls.append("shutdown")
+        raise RuntimeError("db_dsn=postgresql://user:pass@localhost/secret")
+
+    def discover():
+        calls.append("discover")
+        return []
+
+    _install_fake_mcp_tool(
+        monkeypatch,
+        shutdown=shutdown,
+        discover=discover,
+        servers={"old": object()},
+    )
+
+    from api.commands import execute_agent_command
+
+    with pytest.raises(RuntimeError) as exc:
+        execute_agent_command('/reload-mcp')
+
+    assert str(exc.value) == "Failed to reload MCP servers"
+    assert 'postgresql://user:pass' not in str(exc.value)
+    assert 'pass@' not in str(exc.value)
+    assert calls == ["shutdown"]
+
+
+def test_concurrent_reload_mcp_calls_are_serialized(monkeypatch):
+    """Concurrent `/reload-mcp` calls cannot run shutdown/discover interleaved."""
+    state = {"active": 0, "max_active": 0}
+    lock = threading.Lock()
+    ready = threading.Event()
+
+    def _track():
+        with lock:
+            state["active"] += 1
+            if state["active"] > state["max_active"]:
+                state["max_active"] = state["active"]
+        time.sleep(0.12)
+        with lock:
+            state["active"] -= 1
+
+    def shutdown():
+        ready.set()
+        _track()
+
+    def discover():
+        _track()
+        return ["tool-a", "tool-b"]
+
+    _install_fake_mcp_tool(
+        monkeypatch,
+        shutdown=shutdown,
+        discover=discover,
+        servers={"old": object()},
+        lock=threading.Lock(),
+    )
+
+    from api.commands import execute_agent_command
+
+    errors = []
+    t2_started = threading.Event()
+
+    def _call():
+        try:
+            execute_agent_command('/reload-mcp')
+        except Exception as exc:
+            errors.append(exc)
+
+    def _call2():
+        t2_started.set()
+        try:
+            execute_agent_command('/reload-mcp')
+        except Exception as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=_call, name="reload-1")
+    t2 = threading.Thread(target=_call2, name="reload-2")
+
+    t1.start()
+    assert ready.wait(1), "first reload did not start"
+
+    t2.start()
+    assert t2_started.wait(1), "second reload did not start"
+    time.sleep(0.05)
+
+    with lock:
+        observed_max = state["max_active"]
+    assert observed_max == 1
+
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+    assert not t1.is_alive() and not t2.is_alive()
+    assert not errors
 
 
 @requires_agent_modules

--- a/tests/test_commands_endpoint.py
+++ b/tests/test_commands_endpoint.py
@@ -1,5 +1,6 @@
 """Tests for GET /api/commands -- exposes hermes-agent COMMAND_REGISTRY."""
 import json
+import urllib.error
 import urllib.request
 
 import pytest
@@ -11,6 +12,24 @@ def _get(path):
     """GET helper -- returns parsed JSON or raises HTTPError."""
     with urllib.request.urlopen(TEST_BASE + path, timeout=10) as r:
         return json.loads(r.read())
+
+
+def _post(path, body):
+    payload = json.dumps(body or {}).encode()
+    req = urllib.request.Request(
+        TEST_BASE + path,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return getattr(r, 'status', 200), json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read())
+        except Exception:
+            return e.code, {}
 
 
 @requires_agent_modules
@@ -62,6 +81,40 @@ def test_commands_endpoint_keeps_new_with_reset_alias():
     body = _get('/api/commands')
     new_cmd = next(c for c in body['commands'] if c['name'] == 'new')
     assert 'reset' in new_cmd['aliases']
+
+
+@requires_agent_modules
+def test_commands_exec_runs_allowlisted_agent_command():
+    """Allowed agent-side commands execute through /api/commands/exec."""
+    status, body = _post('/api/commands/exec', {'command': '/reload-mcp'})
+    assert status == 200
+    assert 'output' in body
+    assert isinstance(body['output'], str)
+
+
+@requires_agent_modules
+def test_commands_exec_runs_reload_mcp_alias():
+    """Telegram-style underscore alias resolves to the same allowlisted command."""
+    status, body = _post('/api/commands/exec', {'command': '/reload_mcp'})
+    assert status == 200
+    assert 'output' in body
+    assert isinstance(body['output'], str)
+
+
+@requires_agent_modules
+def test_commands_exec_cli_only_command_returns_404():
+    """CLI-only commands should stay blocked from the generic execution endpoint."""
+    status, body = _post('/api/commands/exec', {'command': '/clear'})
+    assert status == 404
+    assert isinstance(body, dict)
+
+
+@requires_agent_modules
+def test_commands_exec_regular_agent_command_returns_404():
+    """Non-allowlisted agent commands must not become generic WebUI exec targets."""
+    status, body = _post('/api/commands/exec', {'command': '/help'})
+    assert status == 404
+    assert isinstance(body, dict)
 
 
 def test_list_commands_returns_empty_for_empty_registry():


### PR DESCRIPTION
## Thinking Path
`/reload-mcp` is exposed by `/api/commands` and therefore appears in WebUI slash autocomplete, but it is not a built-in client command and was not marked `cli_only`. The client command path therefore let it fall through as a normal LLM prompt. The fix keeps the command visible and adds a narrow WebUI-safe execution path for this one runtime command.

## What Changed
- Added a narrow allowlist for WebUI-executable agent commands containing only `reload-mcp` / `reload_mcp`.
- Wired `/api/commands/exec` to try that allowlist before the existing plugin-command execution path.
- Added frontend dispatch so `/reload-mcp` executes through the command endpoint instead of the normal send path.
- Added regression coverage for allowlisted execution, alias execution, blocked CLI-only commands, blocked non-allowlisted commands, and frontend dispatch.
- Updated `CHANGELOG.md`.

## Why It Matters
Users can reload MCP servers from WebUI without accidentally sending `/reload-mcp` to the model as prompt text, while `/api/commands/exec` still does not become a generic slash-command execution endpoint.

## Verification
- `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/test_commands_endpoint.py tests/test_cli_only_slash_commands.py` — 23 passed, 1 warning.
- `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m py_compile api/commands.py api/routes.py` — passed.
- `node --check static/commands.js` — passed.
- `node --check static/messages.js` — passed.
- `git diff --check` — passed.

## Risks / Follow-ups
- `/reload-mcp` uses the same MCP runtime internals as the Hermes CLI/gateway reload path. If the agent-side MCP module changes those internals, this WebUI wrapper may need to follow.
- Security boundary: only `reload-mcp` is allowlisted; CLI-only, gateway-only, unknown, and ordinary registry commands remain blocked from generic execution.

## Model Used
AI-assisted. Coordinator: OpenAI GPT-5 Codex. Implementation sub-agent: OpenAI `gpt-5.3-codex-spark`. Coordinator reviewed the diff, added boundary tests, and ran verification.

Fixes #3508
