### PR TITLE
fix(tests): kill orphan fake-python process trees on Windows

### DIFF
--- a/tests/test_ctl_script.py
+++ b/tests/test_ctl_script.py
@@ -89,6 +89,16 @@ def wait_for_file_text(path: Path, timeout: float = 3.0) -> str:
     raise AssertionError(f"File was not written: {path}")
 
 
+def _kill_tree(pid: int) -> None:
+    if sys.platform == "win32":
+        subprocess.run(["taskkill", "/F", "/T", "/PID", str(pid)], capture_output=True)
+    else:
+        try:
+            os.kill(pid, 9)
+        except ProcessLookupError:
+            pass
+
+
 def assert_process_exits(pid: int, timeout: float = 3.0) -> None:
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -97,6 +107,7 @@ def assert_process_exits(pid: int, timeout: float = 3.0) -> None:
         except ProcessLookupError:
             return
         time.sleep(0.05)
+    _kill_tree(pid)
     raise AssertionError(f"process {pid} did not exit")
 
 


### PR DESCRIPTION
### Thinking Path

- `test_ctl_script.py` spawns fake-python bash loops as daemon stand-ins for `ctl.sh` integration tests. Each fake-python runs `while true; do sleep 0.1; done` with a SIGTERM trap.
- On Windows, `ctl.sh stop` sends `kill $pid` via Git Bash, but MSYS2 signal propagation to child processes is unreliable: the bash parent may exit while its forked `sleep.exe` child survives.
- `assert_process_exits` polls `os.kill(pid, 0)` for 3 seconds, then raises without killing the tree. Orphaned bash loops keep forking new `sleep.exe` children every 100ms.
- In parallel worktree runs (4-8 agents running pytest simultaneously), orphans accumulate into hundreds of process creates/destroys per second, saturating the Windows kernel and stalling all subprocess operations, including the pytest runs themselves.
- The fix adds a `_kill_tree` helper that force-kills the entire process tree (`taskkill /F /T` on Windows, `SIGKILL` on POSIX) before `assert_process_exits` raises, ensuring no orphans survive a failed teardown.

### What Changed

- **`tests/test_ctl_script.py`**: Added `_kill_tree(pid)` helper that calls `taskkill /F /T /PID` on Windows and `os.kill(pid, 9)` on POSIX. Modified `assert_process_exits` to invoke `_kill_tree` before raising `AssertionError`, so orphaned process trees are always cleaned up even when the graceful SIGTERM path fails.

### Why It Matters

Parallel pytest runs on Windows (CI or local worktree orchestration) no longer leak orphan bash/sleep.exe processes that compound into a resource exhaustion feedback loop. Tests that previously timed out due to process table saturation now pass reliably.

### Verification

```bash
pytest tests/test_ctl_script.py -v --timeout=60
pytest tests/ -v --timeout=60
# On Windows: confirm no orphan bash.exe/sleep.exe processes remain after the suite
```

### Risks / Follow-ups

- POSIX behavior is unchanged in practice: the `SIGKILL` fallback fires only when the process didn't exit after `ctl.sh stop` already sent `SIGTERM`, which is the same failure mode the current code hits (but without cleanup).
- `taskkill /F /T` kills the entire tree rooted at `pid`. If a test's fake-python PID is somehow shared with another process, that process would also die. This is not a concern in practice because each test creates its own fake-python in an isolated temp directory.
- The POSIX `_kill_tree` branch sends SIGKILL to the parent PID only, not `os.killpg` for the full process group. This is intentional: on POSIX, `ctl.sh stop` already signals the process group correctly via bash signal propagation, and the SIGKILL fallback is a last-resort cleanup that rarely fires. A full `os.killpg` extension is a possible follow-up if POSIX orphans surface in practice.
- A deeper fix would be to replace the bash fake-python with a native Python subprocess (`while True: time.sleep(0.1)` with signal handling), eliminating the MSYS2 signal propagation issue entirely. That's a larger change and a separate follow-up.

### Model Used

Claude Opus 4.8 via Claude Code CLI

Closes #3534