### PR TITLE
fix: stop iOS Safari scroll jump to top during streaming and clamp clarify card height

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1404,9 +1404,10 @@
   .approval-btn.deny:hover{background:rgba(239,83,80,.12);border-color:var(--error);}
   .approval-btn.loading{opacity:.7;cursor:wait;}
   /* ── Clarify card ── */
-  .clarify-card{position:absolute;left:0;right:0;bottom:-24px;max-width:var(--msg-max);margin:0 auto;padding:0 20px;box-sizing:border-box;width:100%;overflow:hidden;pointer-events:none;max-height:min(calc(100vh - 280px),420px);}
+  .clarify-card{position:absolute;left:0;right:0;bottom:-24px;max-width:var(--msg-max);margin:0 auto;padding:0 20px;box-sizing:border-box;width:100%;overflow:hidden;pointer-events:none;max-height:clamp(180px,min(68vh,calc(100vh - 220px)),420px);}
   .clarify-card.visible{pointer-events:auto;}
-  .clarify-card .clarify-inner{max-height:min(calc(100vh - 280px),420px);overflow-y:auto;transform:translateY(100%);opacity:0;transition:transform .4s cubic-bezier(.32,.72,.16,1),opacity .25s ease,max-height .2s ease;}
+  .clarify-card .clarify-inner{max-height:clamp(180px,min(68vh,calc(100vh - 220px)),420px);overflow-y:auto;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;box-sizing:border-box;transform:translateY(100%);opacity:0;transition:transform .4s cubic-bezier(.32,.72,.16,1),opacity .25s ease,max-height .2s ease;}
+  @supports (height:100dvh){.clarify-card,.clarify-card .clarify-inner{max-height:clamp(180px,min(68dvh,calc(100dvh - 220px)),420px);}}
   .clarify-card.visible .clarify-inner{transform:translateY(0);opacity:1;}
   .clarify-inner{background:var(--surface);backdrop-filter:blur(8px);border:1px solid var(--accent-bg-strong);border-radius:12px;padding:12px 14px 36px;box-shadow:0 1px 0 rgba(255,255,255,.02) inset;}
   .clarify-header{display:flex;align-items:center;gap:8px;margin-bottom:10px;font-size:12px;font-weight:700;color:var(--blue);letter-spacing:.01em;}
@@ -2430,7 +2431,9 @@
     .approval-btn{padding:8px 12px;font-size:12px;min-height:44px;}
     .approval-kbd{display:none;}
     /* Clarify card */
-    .clarify-card{padding-left:10px;padding-right:10px;}
+    .clarify-card{padding-left:10px;padding-right:10px;max-height:clamp(180px,min(62vh,calc(100vh - 180px)),360px);}
+    .clarify-card .clarify-inner{max-height:clamp(180px,min(62vh,calc(100vh - 180px)),360px);}
+    @supports (height:100dvh){.clarify-card,.clarify-card .clarify-inner{max-height:clamp(180px,min(62dvh,calc(100dvh - 180px)),360px);}}
     .clarify-inner{padding:12px 12px 13px;}
     .clarify-response{flex-direction:column;align-items:stretch;}
     .clarify-input,.clarify-submit{width:100%;min-height:44px;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -5028,7 +5028,7 @@ async function refreshSession() {
     if(pendingMsg) S.messages.push(pendingMsg);
     S.activeStreamId=data.session.active_stream_id||null;
 
-    syncTopbar(); renderMessages();
+    syncTopbar(); _renderMessagesWithScrollSnapshot();
     showToast('Conversation refreshed');
   } catch(e) { setStatus('Refresh failed: ' + e.message); }
 }
@@ -5979,6 +5979,7 @@ function _compressionCardsNode(state){
 }
 function appendLiveCompressionCard(state){
   if(!S.session||!S.activeStreamId||!state) return false;
+  const scrollSnapshot=_captureMessageScrollSnapshot();
   let turn=$('liveAssistantTurn');
   if(!turn){
     turn=_createAssistantTurn();
@@ -6014,6 +6015,7 @@ function appendLiveCompressionCard(state){
   const existing=inner.querySelector('[data-live-compression-card="1"]');
   if(existing) existing.replaceWith(node);
   else inner.appendChild(node);
+  _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
   if(typeof scrollIfPinned==='function') scrollIfPinned();
   return true;
 }
@@ -6280,7 +6282,7 @@ function _handoffStateForCurrentSession(){
 }
 function clearHandoffUi(){
   window._handoffUi=null;
-  renderMessages();
+  _renderMessagesWithScrollSnapshot();
 }
 function setHandoffUi(state){
   if(!state){
@@ -6288,7 +6290,7 @@ function setHandoffUi(state){
     return;
   }
   window._handoffUi={...state};
-  renderMessages();
+  _renderMessagesWithScrollSnapshot();
 }
 function _handoffCardsHtml(state){
   if(!state) return '';
@@ -6521,7 +6523,13 @@ function _cliToolCardHasDiffSnippet(resultSnippet, patchSnippet){
 function _captureMessageScrollSnapshot(){
   const el=$('messages');
   if(!el) return null;
-  return {top:el.scrollTop};
+  const bottom=Math.max(0,el.scrollHeight-el.scrollTop-el.clientHeight);
+  return {
+    top:el.scrollTop,
+    bottom,
+    pinned:_shouldFollowMessagesOnDomReplace(),
+    userUnpinned:_messageUserUnpinned,
+  };
 }
 function _restoreMessageScrollSnapshot(snapshot){
   const el=$('messages');
@@ -6532,6 +6540,33 @@ function _restoreMessageScrollSnapshot(snapshot){
   // Sync _lastScrollTop after programmatic restore so sticky-unpin does not false-trigger (#1731).
   _lastScrollTop=el.scrollTop;
   requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+}
+function _restoreMessageScrollSnapshotSameFrame(snapshot){
+  const el=$('messages');
+  if(!el||!snapshot) return;
+  const maxTop=Math.max(0,el.scrollHeight-el.clientHeight);
+  const bottom=Number(snapshot.bottom);
+  const target=(snapshot.pinned===true&&Number.isFinite(bottom))
+    ? maxTop-Math.max(0,bottom)
+    : Number(snapshot.top)||0;
+  _programmaticScroll=true;
+  el.scrollTop=Math.max(0,Math.min(target,maxTop));
+  _lastScrollTop=el.scrollTop;
+  if(snapshot.pinned===true){
+    _messageUserUnpinned=false;
+    _scrollPinned=true;
+    _nearBottomCount=2;
+  }else if(snapshot.userUnpinned===true){
+    _messageUserUnpinned=true;
+    _scrollPinned=false;
+    _nearBottomCount=0;
+  }
+  requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+}
+function _renderMessagesWithScrollSnapshot(options){
+  const scrollSnapshot=_captureMessageScrollSnapshot();
+  renderMessages({...(options||{}),preserveScroll:true});
+  _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
 }
 function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
   // Terminal stream renders can happen after S.activeStreamId is cleared.

--- a/tests/test_issue3479_ios_stream_scroll_jump.py
+++ b/tests/test_issue3479_ios_stream_scroll_jump.py
@@ -1,0 +1,90 @@
+"""Regression coverage for #3479: iOS Safari must not see a top-scroll frame.
+
+The live token path writes into an existing streaming-markdown DOM node. The
+jump came from discrete transcript rebuilds and card replacement paths, so these
+tests pin those call sites rather than the per-token renderer.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, name: str) -> str:
+    marker = f"function {name}"
+    start = src.find(marker)
+    assert start >= 0, f"{name} not found"
+    brace = src.find("{", start)
+    assert brace >= 0, f"{name} body not found"
+    depth = 0
+    for pos in range(brace, len(src)):
+        ch = src[pos]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : pos + 1]
+    raise AssertionError(f"{name} body did not terminate")
+
+
+def _compact(text: str) -> str:
+    return "".join(text.split())
+
+
+def test_refresh_session_uses_same_frame_scroll_snapshot_restore():
+    body = _function_body(UI_JS, "refreshSession")
+
+    assert "syncTopbar(); _renderMessagesWithScrollSnapshot();" in body
+    assert "syncTopbar(); renderMessages();" not in body
+
+
+def test_handoff_rebuilds_use_same_frame_scroll_snapshot_restore():
+    clear_body = _function_body(UI_JS, "clearHandoffUi")
+    set_body = _function_body(UI_JS, "setHandoffUi")
+
+    assert "_renderMessagesWithScrollSnapshot();" in clear_body
+    assert "_renderMessagesWithScrollSnapshot();" in set_body
+    assert "renderMessages();" not in clear_body
+    assert "renderMessages();" not in set_body
+
+
+def test_live_compression_card_replacement_restores_snapshot_before_follow_settle():
+    body = _function_body(UI_JS, "appendLiveCompressionCard")
+
+    capture_idx = body.index("const scrollSnapshot=_captureMessageScrollSnapshot();")
+    replace_idx = body.index("if(existing) existing.replaceWith(node);")
+    restore_idx = body.index("_restoreMessageScrollSnapshotSameFrame(scrollSnapshot);")
+    settle_idx = body.index("if(typeof scrollIfPinned==='function') scrollIfPinned();")
+
+    assert capture_idx < replace_idx < restore_idx < settle_idx
+
+
+def test_same_frame_snapshot_preserves_bottom_distance_and_unpinned_state():
+    capture = _function_body(UI_JS, "_captureMessageScrollSnapshot")
+    restore = _function_body(UI_JS, "_restoreMessageScrollSnapshotSameFrame")
+    wrapper = _function_body(UI_JS, "_renderMessagesWithScrollSnapshot")
+
+    assert "bottom" in capture
+    assert "pinned:_shouldFollowMessagesOnDomReplace()" in _compact(capture)
+    assert "userUnpinned:_messageUserUnpinned" in _compact(capture)
+    assert "maxTop-Math.max(0,bottom)" in restore
+    assert "_messageUserUnpinned=true" in restore
+    assert "_scrollPinned=false" in restore
+    assert "renderMessages({...(options||{}),preserveScroll:true});" in wrapper
+    assert "_restoreMessageScrollSnapshotSameFrame(scrollSnapshot);" in wrapper
+
+
+def test_clarify_card_is_height_clamped_and_scrollable_on_mobile_viewports():
+    compact = _compact(STYLE_CSS)
+
+    assert ".clarify-card" in STYLE_CSS
+    assert "max-height:clamp(180px,min(68vh,calc(100vh-220px)),420px)" in compact
+    assert "@supports(height:100dvh)" in compact
+    assert "max-height:clamp(180px,min(62dvh,calc(100dvh-180px)),360px)" in compact
+    assert "overflow-y:auto" in compact
+    assert "-webkit-overflow-scrolling:touch" in compact
+    assert "overscroll-behavior:contain" in compact


### PR DESCRIPTION
## Summary

On iPhone Safari, inserting a handoff or compression card mid-stream, or reconnecting via `refreshSession()`, no longer snaps the conversation to the top: these rebuild paths in `static/ui.js` now capture the message-container scroll offset before clearing `msgInner` and restore it in the same frame. The clarify card is height-clamped in `static/style.css` so it no longer covers the whole mobile viewport.

## Why this matters

Issue [#3479](https://github.com/nesquena/hermes-webui/issues/3479) reports the viewport jumping to the top while the assistant streams, making the WebUI nearly unusable on phones, plus the clarify card covering the screen. The maintainer corrected the root cause: per-token live writes go through the streaming-markdown parser into an existing node and do not rebuild, so the jump comes from the discrete-event paths (`setHandoffUi`/`clearHandoffUi`, compression cards, and `refreshSession()`) that clear `msgInner` and paint a `scrollTop=0` frame before the too-late `scrollIfPinned()` recovery. The fix is scoped to those named paths; the per-token smd write path is untouched, and a user who has scrolled up is not force-scrolled.

## Testing

`tests/test_issue3479_ios_stream_scroll_jump.py` covers the pinned-scroll-preserved, reconnect-restore, and unpinned-not-forced cases. The existing scroll-hardening tests (`test_issue3319_pinned_scroll_jump`, `test_issue3470_touch_unpin_streaming_scroll`) still pass. Before/after mobile screenshots are attached per CONTRIBUTING.md. Full suite runs in CI.

Fixes #3479

AI-Assisted: Anthropic Claude Opus 4.8 (Claude Code) — code generation and research assistance.
