### PR TITLE
fix(css): increase specificity of .pre-header+pre margin-top override

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1654,7 +1654,7 @@
   }
   .pre-header{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);padding:8px 16px 8px;background:var(--input-bg);border-radius:10px 10px 0 0;border:1px solid var(--border);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:6px;}
   .pre-header::before{content:'';width:8px;height:8px;border-radius:50%;background:var(--muted);opacity:.4;}
-  .pre-header+pre{border-radius:0 0 10px 10px;border-top:none;margin-top:0;}
+  .msg-body .pre-header+pre{border-radius:0 0 10px 10px;border-top:none;margin-top:0;}
   /* Diff/patch viewer */
   .diff-block{margin:0;counter-reset:diff-line;}
   .diff-block .diff-line{display:block;padding:0 16px;min-height:1.4em;white-space:pre;}


### PR DESCRIPTION
## Problem

The `.pre-header+pre { margin-top: 0 }` rule is overridden by `.msg-body pre { margin-top: 10px }` because the latter has equal or higher specificity. This causes an unwanted 10px gap between the file header bar and the code block.

## Fix

Prefix the selector with `.msg-body` to increase specificity:

```css
/* Before */
.pre-header+pre { ... margin-top: 0; }

/* After */
.msg-body .pre-header+pre { ... margin-top: 0; }
```

This ensures the code block sits flush against the header bar as intended.