### PR TITLE
feat(ux): surface memory and skill saves in the activity summary

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -7247,6 +7247,14 @@ function renderMessages(options){
   }
 }
 
+const _MEMORY_SKILL_TOOLS = new Set(['memory', 'skill_manage']);
+const _MEMORY_SKILL_WRITE_ACTIONS = new Set(['save', 'create', 'update', 'upsert']);
+function _isMemorySkillWrite(tc) {
+  if (!tc || !_MEMORY_SKILL_TOOLS.has(tc.name)) return false;
+  if (tc.done === false || tc.is_error) return false;
+  const action = tc.args && (tc.args.action || tc.args.command || '');
+  return _MEMORY_SKILL_WRITE_ACTIONS.has(String(action).toLowerCase());
+}
 function _toolDisplayName(tc){
   const name=(tc&&tc.name)||'tool';
   if(name==='subagent_progress') return 'Subagent';
@@ -7379,6 +7387,7 @@ function buildToolCard(tc){
         </div>`:''}
       </div>`:''}
     </div>`;
+  row._tcData = tc;
   return row;
 }
 
@@ -7428,9 +7437,16 @@ function _syncToolCallGroupSummary(group){
   const label=group.querySelector('.tool-call-group-label');
   const durationEl=group.querySelector('.tool-call-group-duration');
   if(label){
+    const allRows = Array.from(group.querySelectorAll('.tool-card-row'));
+    const memCount = allRows.filter(c => c._tcData && _isMemorySkillWrite(c._tcData) && c._tcData.name === 'memory').length;
+    const skillCount = allRows.filter(c => c._tcData && _isMemorySkillWrite(c._tcData) && c._tcData.name === 'skill_manage').length;
+    const otherCount = toolCount - memCount - skillCount;
+    let suffix = '';
+    if (memCount) suffix += `, ${memCount} ${memCount===1?'memory':'memories'} saved`;
+    if (skillCount) suffix += `, ${skillCount} ${skillCount===1?'skill':'skills'} updated`;
     if(group.getAttribute('data-live-tool-call-group')==='1'){
-      label.textContent=toolCount?`Activity: ${toolCount} tool${toolCount===1?'':'s'}`:'Activity · Running';
-    }else if(toolCount) label.textContent=`Activity: ${toolCount} tool${toolCount===1?'':'s'}`;
+      label.textContent=otherCount?`Activity: ${otherCount} tool${otherCount===1?'':'s'}${suffix}`:(suffix?'Activity'+suffix:'Activity · Running');
+    }else if(otherCount||suffix) label.textContent=otherCount?`Activity: ${otherCount} tool${otherCount===1?'':'s'}${suffix}`:'Activity'+suffix;
     else label.textContent='Activity';
     label.setAttribute('data-sweep-label', label.textContent);
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -7445,8 +7445,8 @@ function _syncToolCallGroupSummary(group){
     if (memCount) suffix += `, ${memCount} ${memCount===1?'memory':'memories'} saved`;
     if (skillCount) suffix += `, ${skillCount} ${skillCount===1?'skill':'skills'} updated`;
     if(group.getAttribute('data-live-tool-call-group')==='1'){
-      label.textContent=otherCount?`Activity: ${otherCount} tool${otherCount===1?'':'s'}${suffix}`:(suffix?'Activity'+suffix:'Activity · Running');
-    }else if(otherCount||suffix) label.textContent=otherCount?`Activity: ${otherCount} tool${otherCount===1?'':'s'}${suffix}`:'Activity'+suffix;
+      label.textContent=otherCount?`Activity: ${otherCount} tool${otherCount===1?'':'s'}${suffix}`:(suffix?'Activity: '+suffix.slice(2):'Activity · Running');
+    }else if(otherCount||suffix) label.textContent=otherCount?`Activity: ${otherCount} tool${otherCount===1?'':'s'}${suffix}`:'Activity: '+suffix.slice(2);
     else label.textContent='Activity';
     label.setAttribute('data-sweep-label', label.textContent);
   }

--- a/tests/test_memory_skill_badge.py
+++ b/tests/test_memory_skill_badge.py
@@ -1,0 +1,25 @@
+import pathlib
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_memory_skill_tools_constant():
+    src = (_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+    assert "_MEMORY_SKILL_TOOLS" in src
+    assert "'memory'" in src or '"memory"' in src
+
+
+def test_is_memory_skill_write_helper():
+    src = (_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+    assert "_isMemorySkillWrite" in src
+
+
+def test_sync_summary_includes_memory_suffix():
+    src = (_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+    assert "memories" in src
+    assert "saved" in src
+
+
+def test_build_tool_card_attaches_tc_data():
+    src = (_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+    assert "_tcData" in src


### PR DESCRIPTION
### Thinking Path

- Memory writes and skill mutations happen inside collapsed tool cards, with no visual signal to the user that persistent state changed. The issue (#3340) asks for a notification so users know what was saved.
- The maintainer endorsed "the existing toast/activity surface" as the natural home. The Activity group summary ("Activity: N tools") is the closest existing pattern, always visible above each response.
- Rather than a badge, pill, or separate toggle, the simplest approach is to append memory/skill counts directly to the Activity label text with a comma: "Activity: 4 tools, 1 memory saved". No styling changes, no emoji, consistent with the existing label typography.
- Detection checks `tc.name` in `{memory, skill_manage}`, `tc.args.action` in `{save, create, update, upsert}`, and requires `tc.done !== false` and `!tc.is_error`, so running or failed calls are excluded from the count.

### What Changed

- **`static/ui.js`**: Added `_MEMORY_SKILL_TOOLS` and `_MEMORY_SKILL_WRITE_ACTIONS` constant sets, `_isMemorySkillWrite(tc)` detection helper (gates on completed non-error calls). Modified `_syncToolCallGroupSummary` to count memory/skill write cards and append ", N memories saved" / ", N skills updated" to the Activity label text. Memory and skill write counts are subtracted from the total so the tool count reflects only non-memory tools (e.g., 3 visible cards = "2 tools, 1 memory saved"). Modified `buildToolCard` to attach `_tcData = tc` on the row element so the summary function can inspect tool name and args.
- **`tests/`**: Static source assertions verifying key code patterns (`_MEMORY_SKILL_TOOLS`, `_isMemorySkillWrite`, label suffix text, `_tcData`).

### Why It Matters

Users get immediate feedback in the collapsed Activity summary when the agent saves a memory or updates a skill. The count is visible at a glance without expanding the group, and clicking to expand reveals the full tool card with entry details.

### Verification

```bash
pytest tests/test_memory_skill_badge.py -v --timeout=60
pytest tests/ -v --timeout=60
# Manual: start a session, prompt the agent to save a memory
# Verify: Activity label reads "Activity: N tools, 1 memory saved"
```

### Risks / Follow-ups

- `_tcData` attaches a reference to the `tc` object on the DOM element. This is a common pattern in the codebase (e.g., `row.dataset.liveTid`), but a future maintainer might prefer a WeakMap. Low risk since tool cards are short-lived DOM nodes.
- The suffix counts completed writes only; in-progress memory saves show as regular tool cards until done.
- A richer display (expandable memory content preview, like ChatGPT's "Saved to memory" block) is a natural follow-up. This PR establishes the detection infrastructure; the display can evolve.
- Review/undo affordance (mentioned in the issue) is out of scope. It needs a backend handle on the saved entry.

### Screenshots

- Before (Activity group with no memory indication):

<img width="1620" height="1215" alt="before" src="https://github.com/user-attachments/assets/9cf18338-383f-4498-ace6-d731ce833a69" />

* * *

- After (label reads "Activity: 1 tool, 1 memory saved"):

<img width="1620" height="1215" alt="after" src="https://github.com/user-attachments/assets/d3d9c51a-c229-47e4-9e75-eb7beffab75d" />

### Model Used

Claude Opus 4.8 via Claude Code CLI

Closes #3340