### PR TITLE
fix(models): prefer Agent Codex catalog over local cache

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3319,10 +3319,11 @@ def _models_from_live_provider_ids(provider_id: str, live_ids: list[str]) -> lis
 def _read_visible_codex_cache_model_ids() -> list[str]:
     """Return visible model slugs from Codex's local models_cache.json.
 
-    The agent's provider_model_ids('openai-codex') intentionally filters IDs
-    with ``supported_in_api: false``. Codex CLI still lists some of those models
-    in its picker (notably ``gpt-5.3-codex-spark`` from #1680), so the WebUI
-    merges this visible local catalog to stay in sync with Codex itself.
+    This is a **fallback** source only. Hermes Agent's
+    ``provider_model_ids('openai-codex')`` is the authoritative catalog; this
+    function is used when Agent returns an empty list or raises an exception.
+    It is NOT merged over a non-empty Agent result — doing so would reintroduce
+    stale/dead models that Agent no longer advertises.
     """
     codex_home = Path(os.getenv("CODEX_HOME", "").strip() or (HOME / ".codex")).expanduser()
     cache_path = codex_home / "models_cache.json"
@@ -4331,11 +4332,13 @@ def get_available_models() -> dict:
                         )
                 elif pid == "openai-codex":
                     # Codex account catalogs drift faster than WebUI releases
-                    # (for example gpt-5.3-codex-spark in #1680). Ask the
-                    # agent's Codex resolver first so /api/models inherits the
-                    # live Codex API / local ~/.codex cache / static fallback
-                    # chain instead of freezing the picker to WebUI's curated
-                    # _PROVIDER_MODELS snapshot.
+                    # (for example gpt-5.3-codex-spark in #1680).  Hermes Agent
+                    # is the authoritative source: when it returns a non-empty
+                    # list, use it exactly — do NOT merge local Codex cache
+                    # entries on top, as that can reintroduce stale/dead models
+                    # that Agent no longer advertises.  The local Codex cache
+                    # and static fallback are only used when Agent returns
+                    # nothing or raises.
                     raw_models = []
                     codex_ids = []
                     try:
@@ -4345,9 +4348,8 @@ def get_available_models() -> dict:
                     except Exception:
                         logger.warning("Failed to load OpenAI Codex models from hermes_cli")
 
-                    for mid in _read_visible_codex_cache_model_ids():
-                        if mid not in codex_ids:
-                            codex_ids.append(mid)
+                    if not codex_ids:
+                        codex_ids = _read_visible_codex_cache_model_ids()
 
                     raw_models = [
                         {"id": mid, "label": _get_label_for_model(mid, [])}

--- a/tests/test_issue1680_codex_spark.py
+++ b/tests/test_issue1680_codex_spark.py
@@ -1,4 +1,11 @@
-"""Regression tests for #1680 — Codex model picker uses live Codex discovery."""
+"""Regression tests for #1680 — Codex model picker uses live Codex discovery.
+
+Hermes Agent is the authoritative source for the Codex model catalog.
+When Agent returns a non-empty list, WebUI must use that list exactly
+and must NOT merge stale local Codex cache models on top.  The local
+Codex cache is a fallback only, used when Agent returns an empty list
+or raises an exception.
+"""
 
 import json
 import sys
@@ -54,11 +61,6 @@ def test_openai_codex_group_uses_provider_model_ids_for_spark(monkeypatch, tmp_p
     result = config.get_available_models()
 
     codex_groups = [g for g in result["groups"] if g.get("provider_id") == "openai-codex"]
-    # Resilient to test-isolation pollution: when a sibling test replaces
-    # sys.modules['hermes_cli.models'] without restoring it, list_available_providers
-    # may report a different provider list and `calls` won't be ['openai-codex'].
-    # Skip rather than fail — the contract under test is "Codex group surfaces
-    # gpt-5.3-codex-spark when hermes_cli.provider_model_ids returns it".
     if calls != ["openai-codex"]:
         import pytest
         pytest.skip(f"hermes_cli stub not active for openai-codex (likely test-isolation pollution from sibling test). Got calls={calls}")
@@ -67,17 +69,59 @@ def test_openai_codex_group_uses_provider_model_ids_for_spark(monkeypatch, tmp_p
     assert codex_groups[0]["models"][0]["label"] == "GPT 5.4"
 
 
-def test_openai_codex_group_merges_visible_codex_cache_models(monkeypatch, tmp_path):
-    """Visible Codex CLI cache models should appear even if API-filtered.
+def test_agent_catalog_supersedes_codex_cache(monkeypatch, tmp_path):
+    """When Hermes Agent returns a non-empty Codex catalog, stale local
+    Codex cache entries must not be merged into the picker.
 
-    Michael's local Codex cache lists ``gpt-5.3-codex-spark`` with
-    ``supported_in_api: false``.  The agent helper currently filters those IDs
-    out, but the WebUI picker is a Codex-model selection surface and should
-    mirror the visible Codex catalog instead of hiding Spark.
+    Regression guard: the old code unconditionally merged visible cache
+    entries over the Agent list, which could reintroduce dead/stale models
+    like gpt-5.3-codex or gpt-5.2 that Agent no longer advertises.
+    """
+    agent_ids = ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"]
+
+    def provider_model_ids(provider):
+        if provider == "openai-codex":
+            return agent_ids
+        return []
+
+    _install_fake_hermes_models(monkeypatch, provider_model_ids)
+    _configure_codex(monkeypatch, tmp_path, default="gpt-5.5")
+
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "models_cache.json").write_text(
+        json.dumps(
+            {
+                "models": [
+                    {"slug": "gpt-5.5", "visibility": "list", "priority": 0},
+                    {"slug": "gpt-5.3-codex", "visibility": "list", "priority": 5},
+                    {"slug": "gpt-5.2", "visibility": "list", "priority": 8},
+                    {"slug": "hidden-cached-model", "visibility": "hide", "priority": 9},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    result = config.get_available_models()
+
+    codex_groups = [g for g in result["groups"] if g.get("provider_id") == "openai-codex"]
+    ids = _flatten_ids(codex_groups)
+    assert ids == agent_ids, f"Codex IDs should match Agent catalog exactly, got {ids}"
+    assert "gpt-5.3-codex" not in ids, "stale cache model must not appear when Agent catalog is non-empty"
+    assert "gpt-5.2" not in ids, "stale cache model must not appear when Agent catalog is non-empty"
+    assert "hidden-cached-model" not in ids
+
+
+def test_codex_cache_fallback_when_agent_returns_empty(monkeypatch, tmp_path):
+    """When Hermes Agent returns an empty catalog, visible Codex cache
+    models should still appear; hidden cache models must be excluded.
     """
     def provider_model_ids(provider):
-        assert provider == "openai-codex"
-        return ["gpt-5.4", "gpt-5.3-codex"]
+        if provider == "openai-codex":
+            return []
+        return []
 
     _install_fake_hermes_models(monkeypatch, provider_model_ids)
     _configure_codex(monkeypatch, tmp_path, default="gpt-5.4")
@@ -107,5 +151,46 @@ def test_openai_codex_group_merges_visible_codex_cache_models(monkeypatch, tmp_p
 
     codex_groups = [g for g in result["groups"] if g.get("provider_id") == "openai-codex"]
     ids = _flatten_ids(codex_groups)
-    assert "gpt-5.3-codex-spark" in ids
+    assert "gpt-5.4" in ids
+    assert "gpt-5.3-codex-spark" in ids, "visible cache model should appear when Agent catalog is empty"
+    assert "hidden-test-model" not in ids
+
+
+def test_codex_cache_fallback_when_agent_raises(monkeypatch, tmp_path):
+    """When Hermes Agent raises an exception, visible Codex cache models
+    should still appear as fallback; hidden cache models must be excluded.
+    """
+    def provider_model_ids(provider):
+        raise RuntimeError("hermes_cli unavailable")
+
+    _install_fake_hermes_models(monkeypatch, provider_model_ids)
+    _configure_codex(monkeypatch, tmp_path, default="gpt-5.4")
+
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "models_cache.json").write_text(
+        json.dumps(
+            {
+                "models": [
+                    {"slug": "gpt-5.4", "visibility": "list", "priority": 0},
+                    {
+                        "slug": "gpt-5.3-codex-spark",
+                        "visibility": "list",
+                        "supported_in_api": False,
+                        "priority": 7,
+                    },
+                    {"slug": "hidden-test-model", "visibility": "hide", "priority": 8},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    result = config.get_available_models()
+
+    codex_groups = [g for g in result["groups"] if g.get("provider_id") == "openai-codex"]
+    ids = _flatten_ids(codex_groups)
+    assert "gpt-5.4" in ids
+    assert "gpt-5.3-codex-spark" in ids, "visible cache model should appear when Agent raises"
     assert "hidden-test-model" not in ids


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI should follow Hermes Agent as the source of truth for provider model catalogs when Agent can return a current catalog.
- OpenAI Codex already asked Agent for `provider_model_ids("openai-codex")`, but then appended visible entries from the local Codex cache.
- That fallback merge could reintroduce stale/dead local cache models after Agent had already filtered the current Codex catalog.
- The narrow fix is to make the local Codex cache fallback-only: use it when Agent returns nothing or raises, but never merge it over a non-empty Agent result.
- Static WebUI Codex models remain the final degraded fallback; OpenRouter, Nous, custom-provider, and other provider catalog paths are unchanged.

## What Changed

- Updated the OpenAI Codex branch in `/api/models` catalog building so non-empty Hermes Agent Codex results are used exactly.
- Kept visible Codex cache models as fallback when Agent returns an empty catalog or cannot be loaded.
- Updated Codex cache helper comments to document fallback-only behavior.
- Added regression coverage for Agent-catalog precedence, empty-Agent cache fallback, and Agent-exception cache fallback.

## Why It Matters

- Prevents the model picker from showing stale Codex entries that Hermes Agent no longer advertises.
- Keeps WebUI and Agent aligned for current Codex account catalogs.
- Preserves existing fallback behavior for environments where Agent catalog lookup is unavailable.
- Avoids whack-a-mole removal of individual stale model slugs from WebUI static lists.

## Screenshots

Not included: this changes backend model-catalog precedence only, with no frontend rendering or layout change. The picker-entry behavior is covered by targeted `/api/models` regression tests.

## Verification

Targeted regression tests:

```text
python -m pytest tests/test_issue1680_codex_spark.py tests/test_issue1807_codex_provider_card_live_models.py -q
# 6 passed in 4.11s
```

Syntax / hygiene:

```text
python -m py_compile api/config.py
# passed

git diff --check
# passed
```

TDD red check before the production fix:

```text
python -m pytest tests/test_issue1680_codex_spark.py -q
# 1 failed, 3 passed
# failing test showed stale cache models gpt-5.3-codex and gpt-5.2 were appended over a non-empty Agent catalog
```

## Risks / Follow-ups

- If Codex CLI exposes a visible model that Agent intentionally filters out, WebUI will now follow Agent until that policy is moved into Agent itself.
- The WebUI static Codex list remains only a degraded fallback; broader static catalog cleanup is intentionally out of scope.

## Model Used

- OpenAI / GPT-5.5 for investigation, specification, orchestration, and verification.
- OpenCode / GLM-5.1 for implementation from the attached spec.
