### PR TITLE
fix(cancel): render partial tool calls after interruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 # Hermes Web UI -- Changelog
 
 ## [Unreleased]
+### Fixed
+- Client rendering no longer drops assistant-only partial-tool-call rows (`_partial_tool_calls`) from the visible transcript or fallback tool-card reconstruction after cancellation. This keeps interrupted turns visible and ensures interrupted tool calls still render as settled tool cards in history. (#3528, @franksong2702)
 
 ## [v0.51.252] — 2026-06-03 — Release HT (stage-q24 — selection-bleed fix + compatibility docs)
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1512,8 +1512,12 @@ function _syncToolCallsForLoadedMessages(messages, sessionToolCalls){
   const hasMessageToolMetadata=msgs.some(m=>{
     if(!m) return false;
     const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
+    // `_partial_tool_calls` are emitted by interrupted/partial turns and must also
+    // anchor rendering to the owning assistant message, so we can reconstruct
+    // settled tool cards from the message history when available.
+    const hasPartialTc=Array.isArray(m._partial_tool_calls)&&m._partial_tool_calls.length>0;
     const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
-    return hasTc||hasTu;
+    return hasTc||hasPartialTc||hasTu;
   });
   if(!hasMessageToolMetadata&&Array.isArray(sessionToolCalls)&&sessionToolCalls.length){
     S.toolCalls=sessionToolCalls.map(tc=>({...tc,done:true}));

--- a/static/ui.js
+++ b/static/ui.js
@@ -6611,7 +6611,8 @@ function renderMessages(options){
     if(m.role==='assistant'){
       const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
       const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
-      if(hasTc||hasTu||_messageHasReasoningPayload(m)) return true;
+      const hasPartialTc=Array.isArray(m._partial_tool_calls)&&m._partial_tool_calls.length>0;
+      if(hasTc||hasTu||hasPartialTc||_messageHasReasoningPayload(m)) return true;
       if(_assistantMessageHasVisibleContent(m)) return true;
     }
     return m._statusCard||msgContent(m)||m.attachments?.length;
@@ -6642,7 +6643,8 @@ function renderMessages(options){
       if(_isRecoveryControlMessage(m)){ri++;continue;}
       const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
       const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
-      if(msgContent(m)||m._statusCard||m.attachments?.length||(m.role==='assistant'&&(hasTc||hasTu||_messageHasReasoningPayload(m)||_assistantMessageHasVisibleContent(m)))) rebuilt.push({m,rawIdx:ri});
+      const hasPartialTc=Array.isArray(m._partial_tool_calls)&&m._partial_tool_calls.length>0;
+      if(msgContent(m)||m._statusCard||m.attachments?.length||(m.role==='assistant'&&(hasTc||hasTu||hasPartialTc||_messageHasReasoningPayload(m)||_assistantMessageHasVisibleContent(m)))) rebuilt.push({m,rawIdx:ri});
       ri++;
     }
     _visWithIdxCache=rebuilt;
@@ -7018,7 +7020,8 @@ function renderMessages(options){
       if(m.role==='assistant'){
         const hasTopLevelToolCalls=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
         const hasContentToolUse=Array.isArray(m.content)&&m.content.some(p=>p&&typeof p==='object'&&p.type==='tool_use');
-        if(hasTopLevelToolCalls||hasContentToolUse) fallbackToolSources.push({m,rawIdx});
+        const hasPartialToolCalls=Array.isArray(m._partial_tool_calls)&&m._partial_tool_calls.length>0;
+        if(hasTopLevelToolCalls||hasContentToolUse||hasPartialToolCalls) fallbackToolSources.push({m,rawIdx});
       }
     });
     const derived=[];
@@ -7054,6 +7057,31 @@ function renderMessages(options){
           const tid=p.id||'';
           const patchSnippet=_cliPatchSnippetFromArgs(name,args);
           const resultSnippet=resultsByTid[tid]||'';
+          const argsSnap={};
+          if(args && typeof args==='object'){
+            Object.keys(args).slice(0,4).forEach(k=>{ const v=String(args[k]); argsSnap[k]=v.slice(0,120)+(v.length>120?'...':''); });
+          }
+          derived.push({
+            name,
+            snippet:_cliToolCardSnippet(resultSnippet,patchSnippet),
+            is_diff:_cliToolCardHasDiffSnippet(resultSnippet,patchSnippet),
+            tid,
+            assistant_msg_idx:rawIdx,
+            args:argsSnap,
+            done:true,
+          });
+        });
+      }
+      // WebUI-internal partial tool calls captured on cancel/stop
+      // (private shape: name/args/done/preview/snippet, no OpenAI envelope).
+      if(Array.isArray(m._partial_tool_calls)){
+        m._partial_tool_calls.forEach(tc=>{
+          if(!tc||typeof tc!=='object') return;
+          const name=tc.name||'tool';
+          const args=tc.args||{};
+          const tid=tc.id||tc.call_id||tc.tool_call_id||tc.tid||'';
+          const patchSnippet=_cliPatchSnippetFromArgs(name,args);
+          const resultSnippet=_cliToolResultSnippet(tc.snippet||tc.result||tc.output||tc.preview||'');
           const argsSnap={};
           if(args && typeof args==='object'){
             Object.keys(args).slice(0,4).forEach(k=>{ const v=String(args[k]); argsSnap[k]=v.slice(0,120)+(v.length>120?'...':''); });

--- a/tests/test_issue401.py
+++ b/tests/test_issue401.py
@@ -38,7 +38,22 @@ def test_loadsession_uses_session_toolcalls_only_as_fallback():
 def test_rendermessages_treats_openai_toolcall_assistants_as_visible():
     """OpenAI assistant rows with empty content but tool_calls must stay anchorable."""
     assert "const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;" in UI_JS
-    assert "if(hasTc||hasTu||_messageHasReasoningPayload(m)) return true;" in UI_JS
+    assert "if(hasTc||hasTu||hasPartialTc||_messageHasReasoningPayload(m)) return true;" in UI_JS
+
+
+def test_rendermessages_treats_partial_toolcall_assistants_as_visible():
+    """Assistant rows carrying `_partial_tool_calls` must stay anchorable."""
+    assert "const hasPartialTc=Array.isArray(m._partial_tool_calls)&&m._partial_tool_calls.length>0;" in UI_JS
+    assert "if(hasTc||hasTu||hasPartialTc||_messageHasReasoningPayload(m)) return true;" in UI_JS
+
+
+def test_rendermessages_rebuilds_tool_cards_from_partial_tool_calls():
+    """Fallback reconstruction should include private `_partial_tool_calls` rows."""
+    assert "const hasPartialToolCalls=Array.isArray(m._partial_tool_calls)&&m._partial_tool_calls.length>0;" in UI_JS
+    assert "if(hasTopLevelToolCalls||hasContentToolUse||hasPartialToolCalls) fallbackToolSources.push({m,rawIdx});" in UI_JS
+    assert "if(Array.isArray(m._partial_tool_calls)){" in UI_JS
+    assert "tc.snippet||tc.result||tc.output||tc.preview" in UI_JS
+    assert "done:true" in UI_JS
 
 
 def _run_js(script_body: str) -> dict:
@@ -48,8 +63,9 @@ def _run_js(script_body: str) -> dict:
             const hasMessageToolMetadata = filtered.some(m => {{
                 if (!m || m.role !== 'assistant') return false;
                 const hasTc = Array.isArray(m.tool_calls) && m.tool_calls.length > 0;
+                const hasPartialTc = Array.isArray(m._partial_tool_calls) && m._partial_tool_calls.length > 0;
                 const hasTu = Array.isArray(m.content) && m.content.some(p => p && p.type === 'tool_use');
-                return hasTc || hasTu;
+                return hasTc || hasPartialTc || hasTu;
             }});
             const toolCalls = (!hasMessageToolMetadata && sessionToolCalls && sessionToolCalls.length)
                 ? sessionToolCalls.map(tc => ({{ ...tc, done: true }}))
@@ -90,6 +106,32 @@ def test_reload_keeps_empty_assistant_toolcall_anchor():
     assert result["fallback_len"] == 0
     assert result["assistant_tool_idx"] == 1
     assert result["tool_idx"] == 2
+
+
+def test_reload_keeps_empty_assistant_partial_toolcall_anchor():
+    """Partial tool-call rows with empty content must survive reload."""
+    result = _run_js("""
+        const messages = [
+            { role: 'user', content: 'open log' },
+            {
+                role: 'assistant',
+                content: '',
+                _partial_tool_calls: [{ name: 'read_file', args: { path: 'README.md' } }]
+            },
+            { role: 'assistant', content: 'Done.' }
+        ];
+        const loaded = loadSessionShape(messages, [{ name: 'write_file', assistant_msg_idx: 1 }]);
+        process.stdout.write(JSON.stringify({
+            filtered_len: loaded.filtered.length,
+            has_metadata: loaded.hasMessageToolMetadata,
+            fallback_len: loaded.toolCalls.length,
+            partial_tool_idx: loaded.filtered.findIndex(m => m.role === 'assistant' && Array.isArray(m._partial_tool_calls))
+        }));
+    """)
+    assert result["filtered_len"] == 3
+    assert result["has_metadata"] is True
+    assert result["fallback_len"] == 0
+    assert result["partial_tool_idx"] == 1
 
 
 def test_reload_uses_session_summary_when_messages_have_no_tool_metadata():

--- a/tests/test_issue401.py
+++ b/tests/test_issue401.py
@@ -16,6 +16,41 @@ import textwrap
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+_SYNC_TOOL_CALLS_FN_NAME = (
+    "function _syncToolCallsForLoadedMessages(messages, sessionToolCalls){"
+)
+_SYNC_TOOL_CALLS_FN_END_MARKER = "async function _ensureMessagesLoaded"
+_SYNC_TOOL_CALLS_FN_START = SESSIONS_JS.find(_SYNC_TOOL_CALLS_FN_NAME)
+_SYNC_TOOL_CALLS_FN_END = SESSIONS_JS.find(
+    _SYNC_TOOL_CALLS_FN_END_MARKER,
+    _SYNC_TOOL_CALLS_FN_START,
+)
+assert _SYNC_TOOL_CALLS_FN_START >= 0
+assert _SYNC_TOOL_CALLS_FN_END > _SYNC_TOOL_CALLS_FN_START
+_SYNC_TOOL_CALLS_FN = SESSIONS_JS[_SYNC_TOOL_CALLS_FN_START:_SYNC_TOOL_CALLS_FN_END]
+
+
+def _run_sync_tool_calls(messages: list, session_tool_calls: list) -> list:
+    assert _SYNC_TOOL_CALLS_FN_NAME in SESSIONS_JS
+    assert _SYNC_TOOL_CALLS_FN.strip()
+    script = textwrap.dedent(
+        f"""
+        const S = {{}};
+        S.toolCalls = [];
+        {_SYNC_TOOL_CALLS_FN}
+        const messages = {json.dumps(messages)};
+        const sessionToolCalls = {json.dumps(session_tool_calls)};
+        _syncToolCallsForLoadedMessages(messages, sessionToolCalls);
+        process.stdout.write(JSON.stringify(S.toolCalls));
+        """
+    )
+    proc = subprocess.run(
+        ["node", "-e", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(proc.stdout)
 
 
 def test_loadsession_preserves_tool_rows():
@@ -56,127 +91,78 @@ def test_rendermessages_rebuilds_tool_cards_from_partial_tool_calls():
     assert "done:true" in UI_JS
 
 
-def _run_js(script_body: str) -> dict:
-    script = textwrap.dedent(f"""
-        function loadSessionShape(messages, sessionToolCalls) {{
-            const filtered = (messages || []).filter(m => m && m.role);
-            const hasMessageToolMetadata = filtered.some(m => {{
-                if (!m || m.role !== 'assistant') return false;
-                const hasTc = Array.isArray(m.tool_calls) && m.tool_calls.length > 0;
-                const hasPartialTc = Array.isArray(m._partial_tool_calls) && m._partial_tool_calls.length > 0;
-                const hasTu = Array.isArray(m.content) && m.content.some(p => p && p.type === 'tool_use');
-                return hasTc || hasPartialTc || hasTu;
-            }});
-            const toolCalls = (!hasMessageToolMetadata && sessionToolCalls && sessionToolCalls.length)
-                ? sessionToolCalls.map(tc => ({{ ...tc, done: true }}))
-                : [];
-            return {{ filtered, hasMessageToolMetadata, toolCalls }};
-        }}
-
-        {script_body}
-    """)
-    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
-    return json.loads(proc.stdout)
-
-
 def test_reload_keeps_empty_assistant_toolcall_anchor():
     """OpenAI-style assistant {content:'', tool_calls:[...]} must survive reload."""
-    result = _run_js("""
-        const messages = [
-            { role: 'user', content: 'list files' },
-            {
-                role: 'assistant',
-                content: '',
-                tool_calls: [{ id: 'call-1', function: { name: 'terminal', arguments: '{}' } }]
-            },
-            { role: 'tool', tool_call_id: 'call-1', content: '{"output":"ok"}' },
-            { role: 'assistant', content: 'Done.' }
-        ];
-        const loaded = loadSessionShape(messages, [{ name: 'terminal', assistant_msg_idx: 1 }]);
-        process.stdout.write(JSON.stringify({
-            filtered_len: loaded.filtered.length,
-            has_metadata: loaded.hasMessageToolMetadata,
-            fallback_len: loaded.toolCalls.length,
-            assistant_tool_idx: loaded.filtered.findIndex(m => m.role === 'assistant' && m.tool_calls),
-            tool_idx: loaded.filtered.findIndex(m => m.role === 'tool')
-        }));
-    """)
-    assert result["filtered_len"] == 4
-    assert result["has_metadata"] is True
-    assert result["fallback_len"] == 0
-    assert result["assistant_tool_idx"] == 1
-    assert result["tool_idx"] == 2
+    messages = [
+        {"role": "user", "content": "list files"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call-1", "function": {"name": "terminal", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": '{"output":"ok"}'},
+        {"role": "assistant", "content": "Done."},
+    ]
+    filtered = [m for m in messages if m and m.get("role")]
+    tool_calls = _run_sync_tool_calls(
+        messages,
+        [{"name": "terminal", "assistant_msg_idx": 1}],
+    )
+    assert len(filtered) == 4
+    assert tool_calls == []
+    assert filtered[1]["role"] == "assistant" and filtered[1].get("tool_calls")
+    assert filtered[2]["role"] == "tool"
 
 
 def test_reload_keeps_empty_assistant_partial_toolcall_anchor():
     """Partial tool-call rows with empty content must survive reload."""
-    result = _run_js("""
-        const messages = [
-            { role: 'user', content: 'open log' },
-            {
-                role: 'assistant',
-                content: '',
-                _partial_tool_calls: [{ name: 'read_file', args: { path: 'README.md' } }]
-            },
-            { role: 'assistant', content: 'Done.' }
-        ];
-        const loaded = loadSessionShape(messages, [{ name: 'write_file', assistant_msg_idx: 1 }]);
-        process.stdout.write(JSON.stringify({
-            filtered_len: loaded.filtered.length,
-            has_metadata: loaded.hasMessageToolMetadata,
-            fallback_len: loaded.toolCalls.length,
-            partial_tool_idx: loaded.filtered.findIndex(m => m.role === 'assistant' && Array.isArray(m._partial_tool_calls))
-        }));
-    """)
-    assert result["filtered_len"] == 3
-    assert result["has_metadata"] is True
-    assert result["fallback_len"] == 0
-    assert result["partial_tool_idx"] == 1
+    messages = [
+        {"role": "user", "content": "open log"},
+        {
+            "role": "assistant",
+            "content": "",
+            "_partial_tool_calls": [{"name": "read_file", "args": {"path": "README.md"}}],
+        },
+        {"role": "assistant", "content": "Done."},
+    ]
+    filtered = [m for m in messages if m and m.get("role")]
+    tool_calls = _run_sync_tool_calls(
+        messages,
+        [{"name": "write_file", "assistant_msg_idx": 1}],
+    )
+    assert len(filtered) == 3
+    assert tool_calls == []
+    assert filtered[1]["role"] == "assistant"
+    assert isinstance(filtered[1].get("_partial_tool_calls"), list)
+    assert filtered[1]["_partial_tool_calls"][0]["name"] == "read_file"
 
 
 def test_reload_uses_session_summary_when_messages_have_no_tool_metadata():
     """Older sessions should still render from session.tool_calls on reload."""
-    result = _run_js("""
-        const messages = [
-            { role: 'user', content: 'build site' },
-            { role: 'assistant', content: 'Starting.' },
-            { role: 'tool', content: '{"bytes_written": 4955}' },
-            { role: 'assistant', content: '' }
-        ];
-        const sessionToolCalls = [
-            { name: 'write_file', assistant_msg_idx: 1, snippet: 'bytes_written', tid: '' }
-        ];
-        const loaded = loadSessionShape(messages, sessionToolCalls);
-        process.stdout.write(JSON.stringify({
-            has_metadata: loaded.hasMessageToolMetadata,
-            fallback_len: loaded.toolCalls.length,
-            done_flag: loaded.toolCalls[0] && loaded.toolCalls[0].done === true
-        }));
-    """)
-    assert result["has_metadata"] is False
-    assert result["fallback_len"] == 1
-    assert result["done_flag"] is True
+    messages = [
+        {"role": "user", "content": "build site"},
+        {"role": "assistant", "content": "Starting."},
+        {"role": "tool", "content": '{"bytes_written": 4955}'},
+        {"role": "assistant", "content": ""},
+    ]
+    tool_calls = _run_sync_tool_calls(
+        messages,
+        [{"name": "write_file", "assistant_msg_idx": 1, "snippet": "bytes_written", "tid": ""}],
+    )
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["done"] is True
 
 
 def test_rebased_legacy_toolcalls_stay_distinct_in_paged_window():
     """Backend-rebased legacy tool calls must not be rebased a second time."""
-    result = _run_js("""
-        const messages = [
-            { role: 'assistant', content: 'first legacy page row' },
-            { role: 'assistant', content: 'second legacy page row' }
-        ];
-        const sessionToolCalls = [
-            { name: 'first_tool', assistant_msg_idx: 0, snippet: 'first' },
-            { name: 'second_tool', assistant_msg_idx: 1, snippet: 'second' }
-        ];
-        const loaded = loadSessionShape(messages, sessionToolCalls);
-        const renderedRawIdxs = messages.map((_, idx) => idx);
-        process.stdout.write(JSON.stringify({
-            indices: loaded.toolCalls.map(tc => tc.assistant_msg_idx),
-            distinct_indices: new Set(loaded.toolCalls.map(tc => tc.assistant_msg_idx)).size,
-            anchors_visible: loaded.toolCalls.every(tc => renderedRawIdxs.includes(tc.assistant_msg_idx))
-        }));
-    """)
-    assert result["indices"] == [0, 1]
-    assert result["distinct_indices"] == 2
-    assert result["anchors_visible"] is True
+    messages = [
+        {"role": "assistant", "content": "first legacy page row"},
+        {"role": "assistant", "content": "second legacy page row"},
+    ]
+    session_tool_calls = [
+        {"name": "first_tool", "assistant_msg_idx": 0, "snippet": "first"},
+        {"name": "second_tool", "assistant_msg_idx": 1, "snippet": "second"},
+    ]
+    tool_calls = _run_sync_tool_calls(messages, session_tool_calls)
+    assert [tc["assistant_msg_idx"] for tc in tool_calls] == [0, 1]
+    assert len({tc["assistant_msg_idx"] for tc in tool_calls}) == 2


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI needs interrupted turns to remain readable after Stop/Cancel.
- Current `origin/master` already persists cancel-time partial tool calls under `_partial_tool_calls`.
- The remaining break is client-side: the settled renderer hides assistant rows that only carry `_partial_tool_calls`, then the fallback tool-card scanner ignores those same rows.
- This PR keeps that persisted partial metadata visible and reconstructs settled tool cards from it, without changing server cancellation semantics.

## Contract Routing
Task type: runtime/recovery UI bugfix for interrupted turns.
Touched areas: `static/ui.js`, transcript visibility filtering, fallback tool-card reconstruction.
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/UIUX-GUIDE.md`
- `DESIGN.md`
- `docs/rfcs/live-to-final-assistant-replies.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
Scope boundaries: client-side rendering only; no server cancel semantics, SSE protocol, or new visual chrome.
Evidence needed before claiming done: partial-tool assistant rows stay renderable, fallback tool-card reconstruction sees `_partial_tool_calls`, existing partial/cancel tests still pass.

## What Changed
- Treat assistant messages with `_partial_tool_calls` as visible transcript rows in both render filtering paths.
- Include `_partial_tool_calls` in fallback tool-source detection.
- Rebuild settled tool-card entries from cancel-time partial tool metadata.
- Added regression assertions in `tests/test_issue401.py`.
- Added a changelog entry for #3528.

## Why It Matters
A stopped turn should not collapse into only a generic cancellation marker when the server already captured useful tool history. This keeps interrupted tool work visible in history and preserves the transcript/tool-card relationship after reload or settle.

## Verification
- `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue401.py -q` -> `9 passed`
- `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue401.py tests/test_pr1375_partial_tool_calls_sanitize.py tests/test_issue893_cancel_preserves_partial.py tests/test_issue1361_cancel_data_loss.py tests/test_empty_partial_activity_restore.py -q` -> `41 passed`
- `node --check static/ui.js` -> passed
- `git diff --check` -> passed

## Risks / Follow-ups
- Verification is focused/static plus adjacent regression tests; no live browser Stop/Cancel reproduction was run in this pass.
- Malformed `_partial_tool_calls` entries are guarded, but sparse metadata can still produce sparse card previews.

Closes #3528.

## Model Used
OpenAI GPT-5 Codex coordinator with a `gpt-5.3-codex-spark` worker sub-agent. AI assisted with implementation, coordinator review, and verification.
