### PR TITLE
fix: clarify lazy-loaded transcript counts

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -5487,6 +5487,20 @@ async function checkInflightOnBoot(sid) {
   } catch(e) { clearInflight(); }
 }
 
+function _topbarLoadedMessageCount(){
+  const messages=Array.isArray(S.messages)?S.messages:[];
+  return messages.filter(m=>m&&m.role&&m.role!=='tool').length;
+}
+function _topbarMessageMetaText(){
+  const loadedCount=_topbarLoadedMessageCount();
+  const totalCount=Number(S.session&&S.session.message_count);
+  const hasTotal=Number.isFinite(totalCount)&&totalCount>0;
+  const isTruncated=!!(typeof _messagesTruncated!=='undefined'&&_messagesTruncated);
+  if(isTruncated&&hasTotal&&totalCount>loadedCount){
+    return `${loadedCount} loaded of ${totalCount} messages`;
+  }
+  return t('n_messages',hasTotal?totalCount:loadedCount);
+}
 function syncTopbar(){
   if(!S.session){
     document.title=assistantDisplayName();
@@ -5510,13 +5524,12 @@ function syncTopbar(){
   const sessionTitle=S.session.title||t('untitled');
   const _topbarTitle=$('topbarTitle');if(_topbarTitle)_topbarTitle.textContent=sessionTitle;
   document.title=sessionTitle+' \u2014 '+assistantDisplayName();
-  const vis=S.messages.filter(m=>m&&m.role&&m.role!=='tool');
   const _topbarMeta=$('topbarMeta');
   if(_topbarMeta){
     let sourceLabel=(S.session&&(S.session.source_label||S.session.source_tag||S.session.raw_source))||'';
     // Recovered sidecars stamp source_label 'WebUI' (api/session_recovery.py); don't badge a native session as its own source (#3338).
     if(/^webui$/i.test(sourceLabel)) sourceLabel='';
-    const metaText=t('n_messages',vis.length);
+    const metaText=_topbarMessageMetaText();
     _topbarMeta.textContent=metaText;
     if(sourceLabel){
       const badge=document.createElement('span');
@@ -6665,6 +6678,7 @@ function renderMessages(options){
   const renderVisWithIdx=visWithIdx.slice(windowStart);
   const firstRenderedRawIdx=renderVisWithIdx.length?renderVisWithIdx[0].rawIdx:Infinity;
   const hasServerOlder=!!(typeof _messagesTruncated!=='undefined' && _messagesTruncated && S.messages.length>0);
+  const serverOlderCount=hasServerOlder&&Number.isFinite(Number(_oldestIdx))?Math.max(0,Number(_oldestIdx)):0;
   if(typeof _applySessionNavigationPrefs==='function') _applySessionNavigationPrefs();
   if(hiddenBeforeCount>0 || hasServerOlder){
     const indicator=document.createElement('button');
@@ -6673,7 +6687,9 @@ function renderMessages(options){
     indicator.className='load-older-indicator message-window-load-earlier';
     indicator.textContent=hiddenBeforeCount>0
       ? `Load earlier messages (${hiddenBeforeCount} hidden)`
-      : (typeof t==='function'?t('load_older_messages'):'Load earlier messages');
+      : (serverOlderCount>0
+        ? `Load earlier messages (${serverOlderCount} older)`
+        : (typeof t==='function'?t('load_older_messages'):'Load earlier messages'));
     indicator.onclick=()=>{
       if(hiddenBeforeCount>0) _showEarlierRenderedMessages();
       else if(typeof _loadOlderMessages==='function') _loadOlderMessages();

--- a/tests/test_issue1771_session_model_switch_sync.py
+++ b/tests/test_issue1771_session_model_switch_sync.py
@@ -99,6 +99,7 @@ function fetch(url, opts) { calls.fetches.push({url: String(url), body: opts && 
 
 for (const name of [
   'assistantDisplayName',
+  '_topbarLoadedMessageCount', '_topbarMessageMetaText',
   '_getOptionProviderId', '_providerFromModelValue', '_modelStateForSelect',
   '_findModelInDropdown', '_refreshOpenModelDropdown', '_applyModelToDropdown',
   '_modelStateFromAppliedDropdown', '_persistSessionModelCorrection',

--- a/tests/test_issue569_579.py
+++ b/tests/test_issue569_579.py
@@ -127,12 +127,12 @@ def test_579_topbar_filters_tool_messages():
     sidebar count display entirely; the topbar was already correct.
     This test locks in the existing topbar filter so it can't regress.
     """
-    # Find the topbarMeta assignment
-    meta_pos = UI_JS.find("topbarMeta")
-    assert meta_pos != -1, "topbarMeta assignment not found in ui.js"
+    # Find the helper used by syncTopbar() to compute the topbar message count.
+    helper_pos = UI_JS.find("function _topbarLoadedMessageCount")
+    assert helper_pos != -1, "topbar message-count helper not found in ui.js"
 
-    # Find the filter that precedes it — should exclude role==='tool'
-    context = UI_JS[max(0, meta_pos - 400):meta_pos + 100]
+    # The helper must exclude role==='tool' from the loaded browser window.
+    context = UI_JS[helper_pos:helper_pos + 900]
     assert "role" in context and "tool" in context, (
         "topbarMeta count must filter by role — "
         "messages with role='tool' must be excluded from the displayed count"

--- a/tests/test_topbar_lazy_message_count.py
+++ b/tests/test_topbar_lazy_message_count.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text()
+
+
+def test_topbar_uses_session_total_for_lazy_loaded_transcripts():
+    assert "function _topbarMessageMetaText()" in UI_JS
+    assert "const isTruncated=!!(typeof _messagesTruncated!=='undefined'&&_messagesTruncated);" in UI_JS
+    assert "return `${loadedCount} loaded of ${totalCount} messages`;" in UI_JS
+    assert "return t('n_messages',hasTotal?totalCount:loadedCount);" in UI_JS
+
+
+def test_load_earlier_indicator_names_server_side_older_count():
+    assert "const serverOlderCount=hasServerOlder&&Number.isFinite(Number(_oldestIdx))?Math.max(0,Number(_oldestIdx)):0;" in UI_JS
+    assert "Load earlier messages (${serverOlderCount} older)" in UI_JS
+
+
+def test_sync_topbar_does_not_count_only_loaded_tail_messages():
+    block = UI_JS[UI_JS.index("function syncTopbar(){") : UI_JS.index("function msgContent", UI_JS.index("function syncTopbar(){"))]
+    assert "const metaText=_topbarMessageMetaText();" in block
+    assert "t('n_messages',vis.length)" not in block
+    assert "S.messages.filter(m=>m&&m.role&&m.role!=='tool')" not in block


### PR DESCRIPTION
## Summary

- Clarify the topbar count when a long transcript is only partially loaded in the browser.
- Use the server-side `session.message_count` when available, while labeling truncated transcripts as `loaded of total` instead of implying the loaded tail is the full conversation.
- Show the server-side older-message count in the `Load earlier messages` affordance when `_oldestIdx` is available.

## Why

For long sessions the WebUI initially loads only the tail window, while the backend/session metadata can already know the full transcript count. The old topbar path counted only `S.messages` in the browser, so a session with thousands of persisted messages could display a misleading small count such as `15 messages`. That reads like data loss even when the older messages are still available through pagination.

## Validation

- `node --check static/ui.js`
- `python3 -m pytest tests/test_topbar_lazy_message_count.py tests/test_issue2184_fork_from_here_absolute_index.py -q`
- Added-line private marker scan: `0`
