### PR TITLE
fix(gateway): clarify cron diagnostics for remote gateway setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 ### Docs
 - Documented an explicit WebUI–Agent compatibility policy: separate the displayed WebUI runtime version from the tested/pinned pair compatibility contract, and clarified Docker upgrade pinning guidance to keep releases aligned until the stable boundary work in #1925/#2491 lands. (#3232, @franksong2702)
+
 ## [v0.51.252] — 2026-06-03 — Release HT (stage-q24 — selection-bleed fix + compatibility docs)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+### Fixed
+- Gateway diagnostic details now distinguish "not configured" from "gateway metadata stale" and remote health failures for Docker gateway-backed setups. The Tasks/Cron and System Settings health copy now reflects the underlying `reason` from the gateway health payload (for example, stale running metadata vs endpoint unreachable) and avoids conflating them with true `Gateway not configured` states. Closes #2785.
+
+### Docs
+- Updated Docker guidance for scheduled jobs to reflect gateway daemon + remote gateway-base URL requirements, and added concrete checks for gateway health reachability (`health/detailed`) and service verification. (#2785)
+
 ## [v0.51.258] — 2026-06-04 — Release HZ (stage-r6 — update banner from any panel + inline thinking on settlement)
 
 ### Fixed
@@ -47,7 +53,6 @@
 
 ### Docs
 - Documented an explicit WebUI–Agent compatibility policy: separate the displayed WebUI runtime version from the tested/pinned pair compatibility contract, and clarified Docker upgrade pinning guidance to keep releases aligned until the stable boundary work in #1925/#2491 lands. (#3232, @franksong2702)
-
 ## [v0.51.252] — 2026-06-03 — Release HT (stage-q24 — selection-bleed fix + compatibility docs)
 
 ### Fixed

--- a/api/agent_health.py
+++ b/api/agent_health.py
@@ -299,10 +299,11 @@ def _runtime_detail_subset(runtime_status: dict[str, Any] | None) -> dict[str, A
 # reachable remote gateway. The Tasks/Cron banner then shows a spurious amber
 # "Gateway not configured" warning.
 #
-# When ``HERMES_API_URL`` is set we treat that as an explicit declaration that
-# the gateway lives elsewhere, and probe it over HTTP before touching any local
-# filesystem / module signal. The probe result is cached briefly so a dashboard
-# rerender that fans out to multiple panels does not hammer the gateway.
+# When a gateway base URL is set in any supported env var, we treat that as an
+# explicit declaration that the gateway lives elsewhere, and probe it over HTTP
+# before touching any local filesystem / module signal. The probe result is
+# cached briefly so a dashboard rerender that fans out to multiple panels does
+# not hammer the gateway.
 
 _REMOTE_PROBE_TIMEOUT_S: float = 2.0
 _REMOTE_PROBE_CACHE_TTL_S: float = 5.0
@@ -318,7 +319,8 @@ _remote_probe_cache: dict[str, Any] = {"url": None, "expires_at": 0.0, "result":
 def _remote_gateway_base_url() -> str | None:
     """Return an explicit remote gateway base URL, or None for local-only setups.
 
-    Priority: GATEWAY_HEALTH_URL > HERMES_GATEWAY_HEALTH_URL > HERMES_API_URL.
+    Priority: GATEWAY_HEALTH_URL > HERMES_GATEWAY_HEALTH_URL > HERMES_API_URL
+    > HERMES_WEBUI_GATEWAY_BASE_URL.
     Returns ``None`` when no env var is set so the caller falls through to
     local PID/state checks.
 
@@ -328,7 +330,12 @@ def _remote_gateway_base_url() -> str | None:
     health-path suffix first so we don't build ``/health/health/detailed``
     (mirrors the normalization in api/updates.py).
     """
-    for var in ("GATEWAY_HEALTH_URL", "HERMES_GATEWAY_HEALTH_URL", "HERMES_API_URL"):
+    for var in (
+        "GATEWAY_HEALTH_URL",
+        "HERMES_GATEWAY_HEALTH_URL",
+        "HERMES_API_URL",
+        "HERMES_WEBUI_GATEWAY_BASE_URL",
+    ):
         val = os.environ.get(var, "").strip()
         if val:
             base = val.rstrip("/")

--- a/api/routes.py
+++ b/api/routes.py
@@ -5902,6 +5902,10 @@ def handle_get(handler, parsed) -> bool:
         #           setup is probably not configured with a gateway
         health = build_agent_health_payload()
         alive = health.get("alive")
+        details = health.get("details") if isinstance(health.get("details"), dict) else {}
+        health_reason = details.get("reason")
+        health_state = details.get("state")
+        health_gateway_state = details.get("gateway_state")
         if alive is True:
             running = True
             configured = True
@@ -5924,10 +5928,9 @@ def handle_get(handler, parsed) -> bool:
             # configured" rather than nagging (#1944). So stale-stopped falls
             # through to the identity_map signal like the genuinely-unconfigured
             # case.
-            details = health.get("details") or {}
             gateway_running_metadata = (
-                details.get("reason") == "gateway_stale_running_state"
-                or details.get("gateway_state") == "running"
+                health_reason == "gateway_stale_running_state"
+                or health_gateway_state == "running"
             )
             configured = True if gateway_running_metadata else bool(identity_map)
             running = bool(identity_map)
@@ -5963,6 +5966,11 @@ def handle_get(handler, parsed) -> bool:
             "platforms": platforms,
             "last_active": last_active,
             "session_count": len(identity_map),
+            "health": {
+                "state": health_state,
+                "reason": health_reason,
+                "gateway_state": health_gateway_state,
+            },
         })
 
     # ── MCP Servers (GET) ──

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -68,9 +68,14 @@ isolated Hermes home and follow
 
 ## Scheduled jobs and the gateway daemon
 
-**Symptom**: Cron jobs created in the Tasks panel never fire. System Settings shows the orange "Gateway not configured" pill, and the Tasks panel shows the same banner above the job list.
+**Symptom**: Cron jobs created in the Tasks panel never fire. System Settings or Tasks shows:
+
+- Orange "Gateway not configured", or
+- Red "Gateway not running" with stale metadata text.
 
 **Cause**: Scheduled cron ticks are not driven by the WebUI itself. The gateway daemon ticks the scheduler every 60 seconds; without one running, scheduled jobs sit idle. "Run now" / "Trigger" buttons still work because the WebUI handles those in-process.
+
+In older gateway builds, or when the daemon runs in a separate container, `gateway_state.json` can become stale and WebUI may lose confidence even if the daemon is up. This is especially visible if only base URLs are configured (e.g. `HERMES_WEBUI_GATEWAY_BASE_URL`) and local daemon state files are not being refreshed.
 
 **Fix**: Run a gateway container alongside the WebUI. The two-container compose file is the recommended path:
 
@@ -84,10 +89,13 @@ The three-container layout adds the dashboard but is otherwise the same shape. I
 **Verify**: Once the gateway is up, the System Settings pill should turn green and the Tasks banner disappear. From the host:
 
 ```bash
+export GATEWAY_BASE_URL="${HERMES_API_URL:-${HERMES_WEBUI_GATEWAY_BASE_URL:-http://hermes:8642}}"
 docker compose -f docker-compose.two-container.yml exec hermes-agent hermes gateway status
+curl -sS "${GATEWAY_BASE_URL%/}/health/detailed" | jq '.gateway_state, .state'
 ```
 
 If the service name differs in your compose file, `docker compose -f docker-compose.two-container.yml ps` lists the running services.
+For container-to-container diagnostics, set one of `HERMES_API_URL` or `HERMES_WEBUI_GATEWAY_BASE_URL` in the WebUI environment when using gateway chat mode (`HERMES_WEBUI_CHAT_BACKEND=gateway`), then restart WebUI.
 
 Refs #2785.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -71,7 +71,8 @@ isolated Hermes home and follow
 **Symptom**: Cron jobs created in the Tasks panel never fire. System Settings or Tasks shows:
 
 - Orange "Gateway not configured", or
-- Red "Gateway not running" with stale metadata text.
+- Red "Gateway not running" with stale metadata text, or
+- Red "Gateway endpoint not reachable" when WebUI has a gateway URL configured but cannot reach its health endpoint.
 
 **Cause**: Scheduled cron ticks are not driven by the WebUI itself. The gateway daemon ticks the scheduler every 60 seconds; without one running, scheduled jobs sit idle. "Run now" / "Trigger" buttons still work because the WebUI handles those in-process.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -71,7 +71,7 @@ isolated Hermes home and follow
 **Symptom**: Cron jobs created in the Tasks panel never fire. System Settings or Tasks shows:
 
 - Orange "Gateway not configured", or
-- Red "Gateway not running" with stale metadata text, or
+- Red "Gateway metadata stale" when runtime metadata is stale, or
 - Red "Gateway endpoint not reachable" when WebUI has a gateway URL configured but cannot reach its health endpoint.
 
 **Cause**: Scheduled cron ticks are not driven by the WebUI itself. The gateway daemon ticks the scheduler every 60 seconds; without one running, scheduled jobs sit idle. "Run now" / "Trigger" buttons still work because the WebUI handles those in-process.

--- a/static/panels.js
+++ b/static/panels.js
@@ -430,17 +430,34 @@ function _cronDiagnostics(job) {
   return JSON.stringify(fields, null, 2);
 }
 
+function _gatewayStatusReason(status) {
+  const health = status && typeof status.health === 'object' ? status.health : null;
+  if (!health) return '';
+  return typeof health.reason === 'string' ? health.reason.trim() : '';
+}
+
 function _cronGatewayNoticeHtml(status) {
   if (!status || (status.configured && status.running)) return '';
+  const reason = _gatewayStatusReason(status);
+  const isStaleMetadata = reason === 'gateway_stale_running_state';
+  const isRemoteUnreachable = reason === 'remote_gateway_unreachable';
   const notConfigured = !status.configured;
   const title = notConfigured
     ? 'Gateway not configured'
-    : 'Gateway not running';
+    : isStaleMetadata
+      ? 'Gateway metadata stale'
+      : isRemoteUnreachable
+        ? 'Gateway endpoint not reachable'
+        : 'Gateway not running';
   const body = notConfigured
     ? 'In Hermes WebUI, scheduled jobs require the Hermes gateway daemon. If this is a single-container Docker install, jobs can be created and run manually here, but scheduled ticks need a gateway container or `hermes gateway` running outside the WebUI.'
-    : 'In Hermes WebUI, scheduled jobs require the Hermes gateway daemon to be running. Start the gateway container or `hermes gateway` before relying on offline scheduled runs.';
+    : isStaleMetadata
+      ? 'The gateway is marked as configured, but its health metadata has gone stale. In Docker, scheduled jobs require a live gateway daemon that refreshes runtime metadata while ticking cron.'
+      : isRemoteUnreachable
+        ? 'The gateway health endpoint is not reachable from WebUI. Verify `HERMES_WEBUI_GATEWAY_BASE_URL` points to a reachable gateway service and network path before relying on cron ticking.'
+        : 'In Hermes WebUI, scheduled jobs require the Hermes gateway daemon to be running. Start the gateway container or `hermes gateway` before relying on offline scheduled runs.';
   const docsHref = 'https://github.com/nesquena/hermes-webui/blob/master/docs/docker.md#scheduled-jobs-and-the-gateway-daemon';
-  const helpLink = notConfigured
+  const helpLink = notConfigured || isRemoteUnreachable || isStaleMetadata
     ? `<p><a href="${docsHref}" target="_blank" rel="noopener">How to enable scheduled jobs in Docker ↗</a></p>`
     : '';
   return `
@@ -8080,7 +8097,13 @@ function loadGatewayStatus(){
       return;
     }
     if(!r.running){
-      card.innerHTML=`<div style="color:var(--muted);font-size:12px;display:flex;align-items:center;gap:6px"><span style="width:8px;height:8px;border-radius:50%;background:#ef4444;display:inline-block"></span>Gateway not running</div>`;
+      const reason = _gatewayStatusReason(r);
+      const statusLabel = reason === 'gateway_stale_running_state'
+        ? 'Gateway metadata stale'
+        : reason === 'remote_gateway_unreachable'
+          ? 'Gateway endpoint not reachable'
+          : 'Gateway not running';
+      card.innerHTML=`<div style="color:var(--muted);font-size:12px;display:flex;align-items:center;gap:6px"><span style="width:8px;height:8px;border-radius:50%;background:#ef4444;display:inline-block"></span>${esc(statusLabel)}</div>`;
       return;
     }
     const platformIcons={telegram:'💬',discord:'🎮',slack:'📝',web:'🌐',api:'🔌'};

--- a/static/panels.js
+++ b/static/panels.js
@@ -454,7 +454,7 @@ function _cronGatewayNoticeHtml(status) {
     : isStaleMetadata
       ? 'The gateway is marked as configured, but its health metadata has gone stale. In Docker, scheduled jobs require a live gateway daemon that refreshes runtime metadata while ticking cron.'
       : isRemoteUnreachable
-        ? 'The gateway health endpoint is not reachable from WebUI. Verify `HERMES_WEBUI_GATEWAY_BASE_URL` points to a reachable gateway service and network path before relying on cron ticking.'
+        ? 'The gateway health endpoint is not reachable from WebUI. Verify the configured gateway URL env var (`GATEWAY_HEALTH_URL`, `HERMES_GATEWAY_HEALTH_URL`, `HERMES_API_URL`, or `HERMES_WEBUI_GATEWAY_BASE_URL`) points to a reachable gateway service and network path before relying on cron ticking.'
         : 'In Hermes WebUI, scheduled jobs require the Hermes gateway daemon to be running. Start the gateway container or `hermes gateway` before relying on offline scheduled runs.';
   const docsHref = 'https://github.com/nesquena/hermes-webui/blob/master/docs/docker.md#scheduled-jobs-and-the-gateway-daemon';
   const helpLink = notConfigured || isRemoteUnreachable || isStaleMetadata

--- a/tests/test_agent_health_remote.py
+++ b/tests/test_agent_health_remote.py
@@ -200,6 +200,26 @@ def test_gateway_health_url_with_health_suffix_is_normalized(monkeypatch):
     assert payload["details"].get("gateway_state") == "running"
 
 
+def test_gateway_webui_base_url_env_is_used_for_remote_probe(monkeypatch):
+    """`HERMES_WEBUI_GATEWAY_BASE_URL` should be treated like a gateway health base URL."""
+    monkeypatch.delenv("HERMES_API_URL", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_HEALTH_URL", raising=False)
+    monkeypatch.delenv("GATEWAY_HEALTH_URL", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://container-gw:8642")
+    seen = []
+
+    def fake_urlopen(req, timeout=None):
+        seen.append(req.full_url)
+        return _FakeResp(200, body=b'{"gateway_state":"running"}')
+
+    with mock.patch.object(agent_health.urllib_request, "urlopen", fake_urlopen):
+        payload = agent_health.build_agent_health_payload()
+
+    assert payload["alive"] is True
+    assert payload["details"]["reason"] == "remote_gateway"
+    assert seen[0].startswith("http://container-gw:8642/")
+
+
 def test_oversized_remote_body_does_not_hang_and_skips_parse(monkeypatch):
     """A 2xx response with a huge body must be capped (not read unbounded) and
     still report the gateway alive, just without a parsed gateway_state."""

--- a/tests/test_gateway_status_agent_health.py
+++ b/tests/test_gateway_status_agent_health.py
@@ -48,7 +48,7 @@ class _FakeHandler:
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
-def _call_gateway_status(monkeypatch, agent_health_alive, identity_map=None):
+def _call_gateway_status(monkeypatch, agent_health_alive, identity_map=None, details=None):
     """Invoke handle_get for /api/gateway/status and return the parsed JSON.
 
     monkeypatches build_agent_health_payload to return the given `alive` value
@@ -62,7 +62,7 @@ def _call_gateway_status(monkeypatch, agent_health_alive, identity_map=None):
         lambda: {
             "alive": agent_health_alive,
             "checked_at": "2026-05-06T12:00:00+00:00",
-            "details": {},
+            "details": details or {},
         },
     )
 
@@ -234,6 +234,25 @@ def test_gateway_status_missing_r_field_handled_by_frontend(monkeypatch):
     result = _call_gateway_status(monkeypatch, agent_health_alive=True, identity_map={})
     assert "running" in result
     assert "configured" in result
+
+
+def test_gateway_status_includes_gateway_health_metadata(monkeypatch):
+    """Expose gateway health reason/state metadata so the UI can render better diagnostics."""
+    result = _call_gateway_status(
+        monkeypatch,
+        agent_health_alive=None,
+        identity_map={},
+        details={
+            "state": "unknown",
+            "reason": "gateway_stale_running_state",
+            "gateway_state": "running",
+        },
+    )
+    assert result["health"] == {
+        "state": "unknown",
+        "reason": "gateway_stale_running_state",
+        "gateway_state": "running",
+    }
 
 
 def test_gateway_status_last_active_empty_when_alive_and_no_sessions_path(monkeypatch):

--- a/tests/test_issue2785_gateway_cron_guidance.py
+++ b/tests/test_issue2785_gateway_cron_guidance.py
@@ -37,6 +37,7 @@ def test_docker_docs_explain_single_container_cron_gateway_boundary():
     assert "single-container setup runs the WebUI only" in docs
     assert "scheduled jobs require the Hermes gateway daemon" in docs
     assert "Gateway not configured" in docs
+    assert "Gateway metadata stale" in docs
     assert "Gateway endpoint not reachable" in docs
     assert "`gateway_state.json` can become stale" in docs
     assert "HERMES_WEBUI_GATEWAY_BASE_URL" in docs

--- a/tests/test_issue2785_gateway_cron_guidance.py
+++ b/tests/test_issue2785_gateway_cron_guidance.py
@@ -34,4 +34,6 @@ def test_docker_docs_explain_single_container_cron_gateway_boundary():
     assert "single-container setup runs the WebUI only" in docs
     assert "scheduled jobs require the Hermes gateway daemon" in docs
     assert "Gateway not configured" in docs
+    assert "`gateway_state.json` can become stale" in docs
+    assert "HERMES_WEBUI_GATEWAY_BASE_URL" in docs
     assert "docker-compose.two-container.yml" in docs

--- a/tests/test_issue2785_gateway_cron_guidance.py
+++ b/tests/test_issue2785_gateway_cron_guidance.py
@@ -24,6 +24,9 @@ def test_cron_panel_loads_gateway_status_for_scheduling_guidance():
     assert "api('/api/gateway/status')" in panels
     assert "Gateway not configured" in panels
     assert "Gateway not running" in panels
+    assert "Gateway endpoint not reachable" in panels
+    assert "configured gateway URL env var" in panels
+    assert "GATEWAY_HEALTH_URL" in panels
     assert "scheduled jobs require the Hermes gateway daemon" in panels
     assert "loadCronGatewayNotice()" in panels
 
@@ -34,6 +37,7 @@ def test_docker_docs_explain_single_container_cron_gateway_boundary():
     assert "single-container setup runs the WebUI only" in docs
     assert "scheduled jobs require the Hermes gateway daemon" in docs
     assert "Gateway not configured" in docs
+    assert "Gateway endpoint not reachable" in docs
     assert "`gateway_state.json` can become stale" in docs
     assert "HERMES_WEBUI_GATEWAY_BASE_URL" in docs
     assert "docker-compose.two-container.yml" in docs


### PR DESCRIPTION
## Thinking Path
Issue #2785 started as scheduled jobs not running because single-container WebUI deployments do not run a gateway daemon. The follow-up report shows a narrower Docker/gateway diagnostic gap: gateway-backed chat can be configured with `HERMES_WEBUI_GATEWAY_BASE_URL`, while the gateway health probe and UI copy can still collapse stale metadata or remote health failures into generic "Gateway not configured" messaging.

## What Changed
- Treat `HERMES_WEBUI_GATEWAY_BASE_URL` as an explicit remote gateway base URL for agent-health probing.
- Expose gateway health detail fields from `/api/gateway/status` so frontend diagnostics can distinguish stale metadata and remote endpoint failures.
- Updated Tasks/Cron and System Settings gateway status copy for:
  - true not-configured state
  - stale gateway metadata
  - unreachable remote gateway endpoint
- Expanded Docker scheduled-job guidance with gateway daemon and remote health-check verification steps.
- Added focused tests for remote gateway env handling, gateway status metadata, and Docker guidance.
- Added changelog entries.

## Why It Matters
Docker users get more accurate guidance when scheduled jobs fail to tick: WebUI no longer implies "not configured" when a gateway URL is configured but health metadata is stale or unreachable. This improves diagnosis without adding a WebUI-owned gateway updater loop or changing Hermes Agent gateway behavior.

## Contract Routing
- Contract family: gateway health diagnostics and Tasks/Cron scheduled-job operator guidance.
- State layer: `/api/gateway/status` health detail payload, agent-health remote probe, frontend gateway status rendering.
- Invariant: WebUI should not conflate true unconfigured state with stale gateway metadata or unreachable remote endpoint.

## Verification
- `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_agent_health_remote.py tests/test_gateway_status_agent_health.py tests/test_issue2785_gateway_cron_guidance.py tests/test_issue3194_gateway_configured_banner.py -q` -> 32 passed
- `node --check static/panels.js`
- `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m py_compile api/agent_health.py api/routes.py`
- `git diff --check`
- `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python scripts/ruff_lint.py --diff origin/master`

## Risks / Follow-ups
- This does not add any new gateway heartbeat/updater loop; stale gateway metadata still has to be corrected by gateway behavior or deployment configuration.
- If multiple gateway URL env vars conflict, existing precedence remains in effect.
- Runtime Docker validation was not performed in this PR; coverage is targeted unit/static verification.

## Model Used
AI-assisted. OpenAI Codex coordinator with a gpt-5.3-codex-spark worker for the focused implementation.

Closes #2785
