### PR TITLE
docs: clarify WebUI-Agent compatibility policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Docs
+- Documented an explicit WebUI–Agent compatibility policy: separate the displayed WebUI runtime version from the tested/pinned pair compatibility contract, and clarified Docker upgrade pinning guidance to keep releases aligned until the stable boundary work in #1925/#2491 lands. (#3232, @franksong2702)
+
 ## [v0.51.252] — 2026-06-03 — Release HT (stage-q24 — selection-bleed fix + compatibility docs)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -537,11 +537,17 @@ Full design notes and the endpoint catalog are in [`ARCHITECTURE.md`](ARCHITECTU
 
 ## Compatibility
 
-The WebUI is tested against the current hermes-agent release at the time of each WebUI release. Until [#2491](https://github.com/nesquena/hermes-webui/issues/2491) lands a stable agent API, the WebUI imports agent Python modules directly (`api/config.py`, `api/providers.py`, `api/streaming.py`), so version skew can cause silent import errors or incorrect behaviour.
+The version shown in the WebUI runtime status is the **WebUI version only** (build/image/tag currently running). It is not a full compatibility map.
 
-**Upgrade both together.** When you update WebUI, update hermes-agent to the same release date. Running a pinned older agent against a newer WebUI (or vice versa) is untested and unsupported until #2491.
+The WebUI is still coupled to Hermes Agent internals for runtime execution, provider/model access, and state/schema usage until the stable agent boundary work in [#1925](https://github.com/nesquena/hermes-webui/issues/1925) and [#2491](https://github.com/nesquena/hermes-webui/issues/2491) land. In practice, the WebUI imports Agent modules directly (`api/config.py`, `api/providers.py`, `api/streaming.py`) and reads Agent state layout directly, so version skew can cause import or behavior drift.
 
-**Docker users: pin both image tags** rather than using `latest` on one and a fixed tag on the other. When upgrading the multi-container setup, follow the agent-image upgrade procedure in [`docs/docker.md`](docs/docker.md) (which requires dropping the `hermes-agent-src` volume before recreating). The current agent/WebUI coupling is tracked in [`docs/rfcs/agent-source-boundary.md`](docs/rfcs/agent-source-boundary.md).
+**Compatibility policy**
+- WebUI release branches are tested against the matching Hermes Agent release available at that WebUI release time.
+- **Upgrade or pin WebUI and hermes-agent together** (same release train/version/date), especially before enabling production traffic.
+- Running pinned older/newer combinations is **untested and unsupported** until the stable API boundary work in [#1925](https://github.com/nesquena/hermes-webui/issues/1925) / [#2491](https://github.com/nesquena/hermes-webui/issues/2491) is in place.
+- Record the full `hermes-agent` + `hermes-webui` versions in issue reports when upgrade mismatches are suspected.
+
+**Docker users**: pin both image tags (or corresponding pinned source revisions) rather than using `latest` on one side and a fixed tag on the other. When upgrading the multi-container setup, follow the agent-image upgrade procedure in [`docs/docker.md`](docs/docker.md) (which requires dropping the `hermes-agent-src` volume before recreating). The current source-boundary status is tracked in [`docs/rfcs/agent-source-boundary.md`](docs/rfcs/agent-source-boundary.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ The WebUI is still coupled to Hermes Agent internals for runtime execution, prov
 
 **Compatibility policy**
 - WebUI release branches are tested against the matching Hermes Agent release available at that WebUI release time.
-- **Upgrade or pin WebUI and hermes-agent together** (same release train/version/date), especially before enabling production traffic.
+- **Upgrade both together**: upgrade or pin WebUI and hermes-agent together (same release train/version/date), especially before enabling production traffic.
 - Running pinned older/newer combinations is **untested and unsupported** until the stable API boundary work in [#1925](https://github.com/nesquena/hermes-webui/issues/1925) / [#2491](https://github.com/nesquena/hermes-webui/issues/2491) is in place.
 - Record the full `hermes-agent` + `hermes-webui` versions in issue reports when upgrade mismatches are suspected.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -93,6 +93,20 @@ Refs #2785.
 
 ## What goes wrong (and how to fix it)
 
+### Compatibility policy and version pinning
+
+WebUI shows the version it is currently running, but that display does not in itself guarantee tested compatibility with your agent release.
+
+Until the compatibility boundary work in [#1925](https://github.com/nesquena/hermes-webui/issues/1925) and [#2491](https://github.com/nesquena/hermes-webui/issues/2491) land, the WebUI and Hermes Agent deployment should be treated as a release pair: the WebUI release is tested against its matching agent release and should be upgraded/pinned together.
+
+If you use `latest`, apply the same pinning discipline on both sides and avoid mixing:
+- fixed WebUI tag + `hermes-agent:latest`
+- `hermes-webui:latest` + fixed `hermes-agent` tag
+
+In multi-container setups, if you must run a pinned pair, prefer the matching tag in `docker-compose.two-container.yml`/`three-container.yml` and perform the agent-volume refresh workflow in [Upgrading the agent container](#upgrading-the-agent-container) whenever you upgrade the agent image.
+
+If you see behavior issues after a mixed-version upgrade, capture both WebUI and hermes-agent versions and the compose layout in the issue.
+
 ### 1. "Permission denied" at startup
 
 **Symptom**: Container starts but immediately crashes, logs show:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -99,11 +99,11 @@ WebUI shows the version it is currently running, but that display does not in it
 
 Until the compatibility boundary work in [#1925](https://github.com/nesquena/hermes-webui/issues/1925) and [#2491](https://github.com/nesquena/hermes-webui/issues/2491) land, the WebUI and Hermes Agent deployment should be treated as a release pair: the WebUI release is tested against its matching agent release and should be upgraded/pinned together.
 
-If you use `latest`, apply the same pinning discipline on both sides and avoid mixing:
+If you use `latest`, use it consistently on both sides and avoid mixing a fixed tag with `latest`:
 - fixed WebUI tag + `hermes-agent:latest`
 - `hermes-webui:latest` + fixed `hermes-agent` tag
 
-In multi-container setups, if you must run a pinned pair, prefer the matching tag in `docker-compose.two-container.yml`/`three-container.yml` and perform the agent-volume refresh workflow in [Upgrading the agent container](#upgrading-the-agent-container) whenever you upgrade the agent image.
+In multi-container setups, if you must run a pinned pair, prefer the matching tag in `docker-compose.two-container.yml`/`docker-compose.three-container.yml` and perform the agent-volume refresh workflow in [Upgrading the agent container](#upgrading-the-agent-container) whenever you upgrade the agent image.
 
 If you see behavior issues after a mixed-version upgrade, capture both WebUI and hermes-agent versions and the compose layout in the issue.
 


### PR DESCRIPTION
## Thinking Path
Issue #3232 points out that the UI can show a running WebUI version, but operators still lack a clear policy for which Hermes Agent versions a WebUI release is tested against. Current WebUI still imports Agent modules and reads Agent state/schema directly, so the safest docs fix is explicit upgrade/pinning guidance until #1925 / #2491 land.

## What Changed
- Expanded the README Compatibility section to distinguish displayed runtime version from tested WebUI-Agent compatibility.
- Clarified that WebUI and Hermes Agent should be upgraded or pinned together while the source/state/schema coupling remains.
- Added Docker-specific pinning guidance for avoiding mixed `latest`/fixed-tag deployments.
- Added a release-note-ready changelog entry.

## Why It Matters
Pinned, Docker, and homelab deployments can now distinguish local misconfiguration from unsupported version skew. This makes upgrade reports more actionable and reduces guesswork when WebUI and Hermes Agent move at different cadences.

## Contract Routing
- Contract family: contributor/operator documentation, Docker deployment guidance, WebUI-Agent compatibility policy.
- Evidence: README Compatibility section and docs/docker.md version-pinning guidance.
- This PR documents current support expectations; it does not change runtime behavior or claim a stable Agent API exists.

## Verification
- `git diff --check`
- Manual doc review of README, docs/docker.md, and CHANGELOG.md for consistent compatibility wording.

## Risks / Follow-ups
- This is textual policy only; it does not add a tested-version matrix.
- #1925 / #2491 remain the durable path for reducing the WebUI-Agent coupling.

## Model Used
AI-assisted. OpenAI Codex coordinator with a gpt-5.3-codex-spark worker for the focused docs patch.

Closes #3232
