### PR TITLE
fix(providers): add missing /api/models/refresh route for provider cache bust (#3546)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **"Refresh Models" button on Settings > Providers no longer 404s** (#3546). The frontend's `_refreshProviderModels` was POSTing to `/api/models/refresh`, but no route handled that path, so every click showed "Error: Not found". The backend's `invalidate_provider_models_cache` already existed; only the HTTP route was missing. The success path now also calls `_refreshModelDropdownsAfterProviderChange()` so the model picker rebuilds immediately after the cache bust. (@rodboev)
+
 ## [v0.51.252] — 2026-06-03 — Release HT (stage-q24 — selection-bleed fix + compatibility docs)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -6410,6 +6410,14 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, result.get("error", "Unknown error"))
         return j(handler, result)
 
+    if parsed.path == "/api/models/refresh":
+        provider_id = (body.get("provider") or "").strip().lower()
+        if not provider_id:
+            return bad(handler, "provider is required")
+        from api.config import invalidate_provider_models_cache
+        invalidate_provider_models_cache(provider_id)
+        return j(handler, {"ok": True, "provider": provider_id})
+
     if parsed.path == "/api/reasoning":
         # CLI-parity /reasoning handler — writes to the same config.yaml keys
         # the CLI uses (display.show_reasoning, agent.reasoning_effort) so a

--- a/static/panels.js
+++ b/static/panels.js
@@ -7213,7 +7213,7 @@ async function _refreshProviderModels(providerId, btn){
       showToast(res.error||'Failed to refresh models');
     }
   }catch(e){
-    showToast('Error: '+e.message);
+    showToast(e.status===404?'Refresh not available for this provider.':(e.message||'Failed to refresh models'));
   }finally{
     btn.disabled=false;
     btn.innerHTML=orig;

--- a/static/panels.js
+++ b/static/panels.js
@@ -7209,6 +7209,7 @@ async function _refreshProviderModels(providerId, btn){
     const res=await api('/api/models/refresh',{method:'POST',body:JSON.stringify({provider:providerId})});
     if(res.ok){
       showToast(t('providers_models_refreshed')||('Models refreshed for '+res.provider));
+      _refreshModelDropdownsAfterProviderChange();
     }else{
       showToast(res.error||'Failed to refresh models');
     }

--- a/tests/test_issue3546_provider_refresh_route.py
+++ b/tests/test_issue3546_provider_refresh_route.py
@@ -1,0 +1,115 @@
+"""Regression tests for #3546 — POST /api/models/refresh must exist and
+invalidate the per-provider model cache so the "Refresh Models" button
+on Settings > Providers works instead of returning 404.
+
+The bug
+-------
+``static/panels.js`` sends ``POST /api/models/refresh`` from
+``_refreshProviderModels``, but no route handled that path in
+``api/routes.py``. Every click showed "Error: Not found" because the
+server returned 404, which ``workspace.js``'s ``api()`` helper surfaced
+as an error toast.
+
+The fix
+-------
+``api/routes.py`` adds a ``POST /api/models/refresh`` branch that calls
+``invalidate_provider_models_cache(provider_id)`` and returns
+``{"ok": true, "provider": provider_id}``. The frontend success path
+now also calls ``_refreshModelDropdownsAfterProviderChange()`` so the
+model picker rebuilds immediately.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _read_static(name: str) -> str:
+    return (REPO / "static" / name).read_text(encoding="utf-8")
+
+
+def _extract_function_body(src: str, signature: str) -> str:
+    """Return the source of a top-level function declaration via brace-balance."""
+    idx = src.find(signature)
+    if idx == -1:
+        raise AssertionError(f"signature {signature!r} not found in source")
+    open_idx = src.find("{", idx)
+    if open_idx == -1:
+        raise AssertionError(f"could not find opening brace after {signature!r}")
+    depth = 0
+    for i in range(open_idx, len(src)):
+        c = src[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return src[idx : i + 1]
+    raise AssertionError(f"unbalanced braces in {signature!r}")
+
+
+class TestRefreshRouteExists:
+    """The POST /api/models/refresh route must exist in routes.py and follow
+    the same input validation pattern as /api/providers/delete."""
+
+    def test_route_branch_present(self):
+        src = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
+        assert '"/api/models/refresh"' in src, (
+            "POST /api/models/refresh route missing from api/routes.py. "
+            "Without it, the Refresh Models button 404s (#3546)."
+        )
+
+    def test_route_validates_provider_param(self):
+        src = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
+        idx = src.find('"/api/models/refresh"')
+        block = src[idx : idx + 500]
+        assert "provider" in block and "bad(handler" in block, (
+            "/api/models/refresh must validate that 'provider' is present "
+            "and return 400 via bad() when missing."
+        )
+
+    def test_route_calls_invalidate_provider_models_cache(self):
+        src = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
+        idx = src.find('"/api/models/refresh"')
+        block = src[idx : idx + 500]
+        assert "invalidate_provider_models_cache" in block, (
+            "/api/models/refresh must call invalidate_provider_models_cache "
+            "to bust the per-provider TTL cache."
+        )
+
+    def test_route_returns_ok_with_provider(self):
+        src = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
+        idx = src.find('"/api/models/refresh"')
+        block = src[idx : idx + 500]
+        assert '"ok"' in block and '"provider"' in block, (
+            "/api/models/refresh must return {ok: true, provider: provider_id} "
+            "so the frontend can confirm the operation succeeded."
+        )
+
+
+class TestFrontendRefreshPath:
+    """The frontend success path must update the model picker immediately
+    after a cache bust, not wait for the next /api/models poll."""
+
+    def test_refresh_calls_dropdown_updater(self):
+        src = _read_static("panels.js")
+        body = _extract_function_body(src, "async function _refreshProviderModels(")
+        assert "_refreshModelDropdownsAfterProviderChange()" in body, (
+            "_refreshProviderModels must call _refreshModelDropdownsAfterProviderChange() "
+            "on success so the model picker rebuilds immediately after a cache "
+            "bust instead of waiting for the next /api/models call (#3546)."
+        )
+
+    def test_refresh_shows_friendly_404(self):
+        src = _read_static("panels.js")
+        body = _extract_function_body(src, "async function _refreshProviderModels(")
+        assert "e.status===404" in body or "e.status === 404" in body, (
+            "_refreshProviderModels catch block must check e.status===404 to "
+            "show a friendly message when the route is missing on older backends."
+        )


### PR DESCRIPTION
### Thinking Path

- Clicking "Refresh Models" on any provider card in Settings > Providers shows "Error: Not found" every time.
- `panels.js:7209` sends `POST /api/models/refresh`, but no branch in `routes.py` matches that path, so the server returns 404.
- The backend already has `invalidate_provider_models_cache(provider_id)` in `api/config.py:3199`, which is exactly the operation needed: evict the per-provider cache so the next `/api/models` call rebuilds from a fresh upstream fetch.
- The fix is one new `if` branch in the POST handler, adjacent to the existing provider operations.

### What Changed

- `api/routes.py`: added `POST /api/models/refresh` route after `/api/providers/delete`; calls `invalidate_provider_models_cache(provider_id)` and returns `{"ok": true, "provider": provider_id}`; returns 400 if `provider` body param is missing.
- `static/panels.js`: updated `_refreshProviderModels` catch block to show "Refresh not available for this provider." on 404 rather than the raw "Error: Not found"; any other error surfaces `e.message`. Success path now calls `_refreshModelDropdownsAfterProviderChange()` so the model picker rebuilds immediately after a cache bust.
- `tests/test_issue3546_provider_refresh_route.py`: regression tests covering the route contract (presence, validation, cache-bust call, response shape) and the frontend integration (dropdown refresh on success, friendly 404 fallback).

### Why It Matters

Every "Refresh Models" button press on the Providers page produced a confusing error toast. The backend cache-bust function already existed; only the HTTP route was missing.

### Verification

```
pytest tests/test_issue3546_provider_refresh_route.py -v --timeout=60
pytest tests/test_issue1539_provider_removal_dropdown_invalidation.py -v --timeout=60
pytest tests/ -v --timeout=60
```

Manual: Settings > Providers, expand any provider card, click "Refresh Models"; confirm the toast no longer shows "Error: Not found".

### Risks / Follow-ups

- Quota refresh (`_refreshProviderQuota`, `GET /api/provider/quota?refresh=1`) is unaffected. That route already exists at `routes.py:4875`; quota timeout errors reported in #3546 are a separate upstream fetch failure.

### Model Used

Claude Opus 4.8 via Claude Code CLI

Refs #3546
