### PR TITLE
feat(sidebar): multi-select origin filter, cron off by default (#3418)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -31,6 +31,7 @@ from contextlib import closing
 from urllib.parse import parse_qs, urlsplit
 from api.agent_sessions import (
     MESSAGING_SOURCES,
+    SOURCE_LABELS,
     _looks_like_default_cli_title,
     is_cli_session_row,
     is_cli_session_row_visible,
@@ -912,6 +913,201 @@ def _safe_first(*values):
     return ""
 
 
+_GATEWAY_PLATFORM_LABELS = {
+    **SOURCE_LABELS,
+    "weixin": "WeChat",
+    "signal": "Signal",
+    "whatsapp": "WhatsApp",
+    "teams": "Teams",
+    "google_chat": "Google Chat",
+    "homeassistant": "Home Assistant",
+    "qqbot": "QQBot",
+    "yuanbao": "Yuanbao",
+    "feishu": "Feishu",
+}
+_GATEWAY_PLATFORM_ALIASES = {
+    "wechat": "weixin",
+    "googlechat": "google_chat",
+    "home_assistant": "homeassistant",
+    "qq_bot": "qqbot",
+}
+
+
+def _normalize_gateway_platform_name(raw_platform) -> str:
+    raw = str(raw_platform or "").strip().lower()
+    if not raw:
+        return ""
+    normalized = raw.replace("-", "_").replace(" ", "_")
+    return _GATEWAY_PLATFORM_ALIASES.get(normalized, normalized)
+
+
+def _gateway_platform_label(name: str) -> str:
+    normalized = _normalize_gateway_platform_name(name)
+    if not normalized:
+        return ""
+    label = _GATEWAY_PLATFORM_LABELS.get(normalized)
+    if label:
+        return label
+    return normalized.replace("_", " ").title()
+
+
+def _gateway_known_platform_names() -> set[str]:
+    names = {
+        _normalize_gateway_platform_name(name)
+        for name in _GATEWAY_PLATFORM_LABELS
+    }
+    names.update(_normalize_gateway_platform_name(name) for name in _MESSAGING_RAW_SOURCES)
+    try:
+        from cron.scheduler import _KNOWN_DELIVERY_PLATFORMS
+    except Exception:
+        _KNOWN_DELIVERY_PLATFORMS = ()
+    names.update(_normalize_gateway_platform_name(name) for name in _KNOWN_DELIVERY_PLATFORMS)
+    names.discard("")
+    return names
+
+
+def _gateway_config_value_enabled(value) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return any(_gateway_config_value_enabled(item) for item in value)
+    if isinstance(value, dict):
+        if value.get("enabled") is False:
+            return False
+        return bool(value) and any(_gateway_config_value_enabled(item) for item in value.values())
+    return True
+
+
+def _gateway_status_config_paths() -> list[Path]:
+    candidates: list[Path] = []
+    try:
+        candidates.append(Path(_get_config_path()))
+    except Exception:
+        pass
+    try:
+        candidates.append(Path(get_active_hermes_home()) / "config.yaml")
+    except Exception:
+        pass
+    paths: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.expanduser().resolve()
+        except Exception:
+            continue
+        key = str(resolved)
+        if key in seen or not resolved.exists():
+            continue
+        seen.add(key)
+        paths.append(resolved)
+    return paths
+
+
+def _load_gateway_configured_platform_names() -> set[str]:
+    try:
+        import yaml
+    except Exception:
+        return set()
+
+    known = _gateway_known_platform_names()
+    names: set[str] = set()
+
+    def _visit(node):
+        if isinstance(node, dict):
+            for field in ("name", "platform", "source", "delivery", "channel"):
+                normalized = _normalize_gateway_platform_name(node.get(field))
+                if normalized in known and _gateway_config_value_enabled(node):
+                    names.add(normalized)
+            for key, value in node.items():
+                normalized_key = _normalize_gateway_platform_name(key)
+                if normalized_key in known and _gateway_config_value_enabled(value):
+                    names.add(normalized_key)
+                _visit(value)
+        elif isinstance(node, list):
+            for item in node:
+                _visit(item)
+
+    for path in _gateway_status_config_paths():
+        try:
+            loaded = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except Exception:
+            continue
+        if not isinstance(loaded, dict):
+            continue
+        _visit(loaded)
+    return names
+
+
+def _load_gateway_runtime_platform_names() -> set[str]:
+    try:
+        from api.agent_health import _read_gateway_runtime_status
+    except Exception:
+        return set()
+    try:
+        runtime_status = _read_gateway_runtime_status()
+    except Exception:
+        return set()
+    if not isinstance(runtime_status, dict):
+        return set()
+    platforms = runtime_status.get("platforms")
+    if isinstance(platforms, dict):
+        return {
+            normalized
+            for normalized in (
+                _normalize_gateway_platform_name(name)
+                for name in platforms.keys()
+            )
+            if normalized
+        }
+    if isinstance(platforms, list):
+        names: set[str] = set()
+        for entry in platforms:
+            if isinstance(entry, dict):
+                normalized = _normalize_gateway_platform_name(
+                    entry.get("name") or entry.get("platform") or entry.get("source")
+                )
+            else:
+                normalized = _normalize_gateway_platform_name(entry)
+            if normalized:
+                names.add(normalized)
+        return names
+    return set()
+
+
+def _gateway_identity_platform_names(identity_map: dict[str, dict] | None) -> set[str]:
+    names: set[str] = set()
+    for meta in (identity_map or {}).values():
+        if not isinstance(meta, dict):
+            continue
+        normalized = _normalize_gateway_platform_name(
+            meta.get("raw_source") or meta.get("platform")
+        )
+        if normalized:
+            names.add(normalized)
+    return names
+
+
+def _gateway_platform_entries(identity_map: dict[str, dict] | None = None) -> list[dict[str, str]]:
+    platform_names = set()
+    platform_names.update(_load_gateway_runtime_platform_names())
+    platform_names.update(_load_gateway_configured_platform_names())
+    platform_names.update(_gateway_identity_platform_names(identity_map))
+    return sorted(
+        [
+            {"name": name, "label": _gateway_platform_label(name)}
+            for name in platform_names
+            if name
+        ],
+        key=lambda entry: entry["label"],
+    )
+
+
 def _gateway_session_metadata_path():
     try:
         from api.profiles import get_active_hermes_home
@@ -973,6 +1169,7 @@ def _gateway_status_payload() -> dict:
 
     identity_map = _load_gateway_session_identity_map()
     sessions_path = _gateway_session_metadata_path()
+    platforms = _gateway_platform_entries(identity_map)
 
     # Detect whether the gateway process is alive, independent of connected
     # messaging platforms. An empty identity_map means zero connected
@@ -994,27 +1191,8 @@ def _gateway_status_payload() -> dict:
             health_reason == "gateway_stale_running_state"
             or health_gateway_state == "running"
         )
-        configured = True if gateway_running_metadata else bool(identity_map)
+        configured = True if gateway_running_metadata else bool(identity_map) or bool(platforms)
         running = bool(identity_map)
-
-    platforms_set: set[str] = set()
-    for meta in identity_map.values():
-        raw = meta.get("raw_source") or meta.get("platform") or ""
-        norm = _normalize_messaging_source(raw)
-        if norm:
-            platforms_set.add(norm)
-    platform_labels = {
-        "telegram": "Telegram",
-        "discord": "Discord",
-        "slack": "Slack",
-        "email": "Email",
-        "web": "Web",
-        "api": "API",
-    }
-    platforms = sorted(
-        [{"name": p, "label": platform_labels.get(p, p.title())} for p in platforms_set],
-        key=lambda x: x["label"],
-    )
     last_active = ""
     if running and sessions_path.exists():
         try:

--- a/static/boot.js
+++ b/static/boot.js
@@ -2100,6 +2100,7 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
     window._showTps=!!s.show_tps;
     window._fadeTextEffect=!!s.fade_text_effect;
     window._showCliSessions=s.show_cli_sessions!==false;
+    window._showCronSessions=!!s.show_cron_sessions;
     window._showPreviousMessagingSessions=!!s.show_previous_messaging_sessions;
     window._soundEnabled=!!s.sound_enabled;
     window._notificationsEnabled=!!s.notifications_enabled;
@@ -2222,6 +2223,7 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
     window._showTps=false;
     window._fadeTextEffect=false;
     window._showCliSessions=true;  // settings-load failed: mirror the True config default (#3988)
+    window._showCronSessions=false;
     window._soundEnabled=false;
     window._notificationsEnabled=false;
     window._whatsNewSummaryEnabled=false;

--- a/static/index.html
+++ b/static/index.html
@@ -1326,27 +1326,6 @@
             </div>
             <div class="settings-field">
               <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
-                <input type="checkbox" id="settingsShowCliSessions" style="width:15px;height:15px;accent-color:var(--accent)">
-                <span data-i18n="settings_label_external_sessions">Show non-WebUI sessions</span>
-              </label>
-              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_external_sessions">Show conversations from CLI, Telegram, Discord, Slack, and other channels in the session list. Click to import and continue.</div>
-            </div>
-            <div class="settings-field" id="settingsShowCronSessionsField" style="margin-left:24px">
-              <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
-                <input type="checkbox" id="settingsShowCronSessions" style="width:15px;height:15px;accent-color:var(--accent)">
-                <span data-i18n="settings_label_cron_sessions">Show cron sessions</span>
-              </label>
-              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_cron_sessions">Surface cron job output as conversations in the sidebar. Only active when non-WebUI sessions are enabled. Defaults off; high-frequency jobs can flood the sidebar.</div>
-            </div>
-            <div class="settings-field">
-              <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
-                <input type="checkbox" id="settingsShowPreviousMessagingSessions" style="width:15px;height:15px;accent-color:var(--accent)">
-                <span data-i18n="settings_label_previous_messaging_sessions">Show previous messaging sessions</span>
-              </label>
-              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_previous_messaging_sessions">Show older Discord, Telegram, Slack, and Weixin sessions that were replaced by reset or compression.</div>
-            </div>
-            <div class="settings-field">
-              <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
                 <input type="checkbox" id="settingsSyncInsights" style="width:15px;height:15px;accent-color:var(--accent)">
                 <span data-i18n="settings_label_sync_insights">Sync usage to /insights</span>
               </label>

--- a/static/panels.js
+++ b/static/panels.js
@@ -7313,15 +7313,6 @@ function _preferencesPayloadFromUi(){
   if(workspaceTodosTabCb) payload.workspace_todos_tab=workspaceTodosTabCb.checked;
   const apiRedactCb=$('settingsApiRedact');
   if(apiRedactCb) payload.api_redact_enabled=apiRedactCb.checked;
-  const showCliCb=$('settingsShowCliSessions');
-  if(showCliCb) payload.show_cli_sessions=showCliCb.checked;
-  const showCronCb=$('settingsShowCronSessions');
-  // Gate cron sessions on CLI sessions (the server short-circuits otherwise),
-  // identically to the explicit saveSettings() path, so neither save route can
-  // persist show_cron_sessions=true while show_cli_sessions=false. (#3514)
-  if(showCronCb) payload.show_cron_sessions=!!(showCliCb&&showCliCb.checked&&showCronCb.checked);
-  const showPreviousMessagingCb=$('settingsShowPreviousMessagingSessions');
-  if(showPreviousMessagingCb) payload.show_previous_messaging_sessions=showPreviousMessagingCb.checked;
   const syncCb=$('settingsSyncInsights');
   if(syncCb) payload.sync_to_insights=syncCb.checked;
   const updateCb=$('settingsCheckUpdates');
@@ -7777,17 +7768,6 @@ async function loadSettingsPanel(){
     }
     const apiRedactCb=$('settingsApiRedact');
     if(apiRedactCb){apiRedactCb.checked=settings.api_redact_enabled!==false;apiRedactCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
-    const showCliCb=$('settingsShowCliSessions');
-    if(showCliCb){showCliCb.checked=settings.show_cli_sessions!==false;showCliCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
-    const showCronCb=$('settingsShowCronSessions');
-    if(showCronCb){
-      showCronCb.checked=!!settings.show_cron_sessions;
-      showCronCb.disabled=showCliCb?!showCliCb.checked:true;
-      showCronCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});
-      if(showCliCb){showCliCb.addEventListener('change',function(){showCronCb.disabled=!showCliCb.checked;},{once:false});}
-    }
-    const showPreviousMessagingCb=$('settingsShowPreviousMessagingSessions');
-    if(showPreviousMessagingCb){showPreviousMessagingCb.checked=!!settings.show_previous_messaging_sessions;showPreviousMessagingCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
     const syncCb=$('settingsSyncInsights');
     if(syncCb){syncCb.checked=!!settings.sync_to_insights;syncCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
     const updateCb=$('settingsCheckUpdates');
@@ -9411,7 +9391,7 @@ async function deletePasskey(id){
 }
 
 function _applySavedSettingsUi(saved, body, opts){
-  const {sendKey,showTokenUsage,showQuotaChip,showConversationOutline,showTps,fadeTextEffect,showCliSessions,theme,skin,language,sidebarDensity,fontSize}=opts;
+  const {sendKey,showTokenUsage,showQuotaChip,showConversationOutline,showTps,fadeTextEffect,theme,skin,language,sidebarDensity,fontSize}=opts;
   window._sendKey=sendKey||'enter';
   window._showTokenUsage=showTokenUsage;
   window._showQuotaChip=showQuotaChip===true;
@@ -9420,8 +9400,9 @@ function _applySavedSettingsUi(saved, body, opts){
   if(typeof applyConversationOutlinePreference==='function') applyConversationOutlinePreference();
   window._showTps=showTps;
   window._fadeTextEffect=!!fadeTextEffect;
-  window._showCliSessions=showCliSessions;
-  window._showPreviousMessagingSessions=!!body.show_previous_messaging_sessions;
+  if(Object.prototype.hasOwnProperty.call(saved,'show_cli_sessions')) window._showCliSessions=saved.show_cli_sessions!==false;
+  if(Object.prototype.hasOwnProperty.call(saved,'show_cron_sessions')) window._showCronSessions=!!saved.show_cron_sessions;
+  if(Object.prototype.hasOwnProperty.call(saved,'show_previous_messaging_sessions')) window._showPreviousMessagingSessions=!!saved.show_previous_messaging_sessions;
   window._soundEnabled=body.sound_enabled;
   window._notificationsEnabled=body.notifications_enabled;
   window._whatsNewSummaryEnabled=!!body.whats_new_summary_enabled;
@@ -9445,7 +9426,7 @@ function _applySavedSettingsUi(saved, body, opts){
   if(typeof setLocale==='function') setLocale(language);
   if(typeof applyLocaleToDOM==='function') applyLocaleToDOM();
   if(typeof startGatewaySSE==='function'){
-    if(showCliSessions) startGatewaySSE();
+    if(window._showCliSessions) startGatewaySSE();
     else if(typeof stopGatewaySSE==='function') stopGatewaySSE();
   }
   _setSettingsAuthButtonsVisible(!!saved.auth_enabled);
@@ -9944,9 +9925,6 @@ async function saveSettings(andClose){
   const showConversationOutline=!!($('settingsShowConversationOutline')||{}).checked;
   const showTps=!!($('settingsShowTps')||{}).checked;
   const fadeTextEffect=!!($('settingsFadeTextEffect')||{}).checked;
-  const showCliSessions=!!($('settingsShowCliSessions')||{}).checked;
-  const showCronSessions=!!($('settingsShowCronSessions')||{}).checked;
-  const showPreviousMessagingSessions=!!($('settingsShowPreviousMessagingSessions')||{}).checked;
   const pinnedSessionsLimit=parseInt(($('settingsPinnedSessionsLimit')||{}).value,10)||3;
   const pw=($('settingsPassword')||{}).value;
   const theme=($('settingsTheme')||{}).value||'dark';
@@ -9976,11 +9954,6 @@ async function saveSettings(andClose){
   body.terminal_auto_expand_on_output=!!($('settingsTerminalAutoExpand')||{}).checked;
   body.workspace_todos_tab=!!window._workspaceTodosTab;
   body.api_redact_enabled=!!($('settingsApiRedact')||{}).checked;
-  body.show_cli_sessions=showCliSessions;
-  // Cron sessions are gated on CLI sessions (server short-circuits otherwise);
-  // mirror the autosave path so the explicit Save Settings button persists it too. (#3514)
-  body.show_cron_sessions=showCliSessions&&showCronSessions;
-  body.show_previous_messaging_sessions=showPreviousMessagingSessions;
   body.pinned_sessions_limit=pinnedSessionsLimit;
   body.sync_to_insights=!!($('settingsSyncInsights')||{}).checked;
   body.check_for_updates=!!($('settingsCheckUpdates')||{}).checked;
@@ -10017,7 +9990,7 @@ async function saveSettings(andClose){
           if(typeof showToast==='function') showToast('Failed to update default model — settings saved');
         }
       }
-      _applySavedSettingsUi(saved, body, {sendKey,showTokenUsage,showQuotaChip,showConversationOutline,showTps,fadeTextEffect,showCliSessions,theme,skin,language,sidebarDensity,fontSize});
+      _applySavedSettingsUi(saved, body, {sendKey,showTokenUsage,showQuotaChip,showConversationOutline,showTps,fadeTextEffect,theme,skin,language,sidebarDensity,fontSize});
       showToast(t(saved.auth_just_enabled?'settings_saved_pw':'settings_saved_pw_updated'));
       const cpField=$('settingsCurrentPassword'); if(cpField) cpField.value='';
       const pwField=$('settingsPassword'); if(pwField) pwField.value='';
@@ -10047,7 +10020,7 @@ async function saveSettings(andClose){
         if(typeof showToast==='function') showToast('Failed to update default model — settings saved');
       }
     }
-    _applySavedSettingsUi(saved, body, {sendKey,showTokenUsage,showQuotaChip,showConversationOutline,showTps,fadeTextEffect,showCliSessions,theme,skin,language,sidebarDensity,fontSize});
+    _applySavedSettingsUi(saved, body, {sendKey,showTokenUsage,showQuotaChip,showConversationOutline,showTps,fadeTextEffect,theme,skin,language,sidebarDensity,fontSize});
     showToast(t('settings_saved'));
     _settingsDirty=false;
     _resetSettingsPanelState();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1915,13 +1915,16 @@ function _sidebarOriginOptions(originCounts, originLabels) {
 }
 
 function _ensureOriginFilterDefaults(originOptions) {
+  _captureOriginFilterCronDefaultSeed();
   const optionIds = (originOptions || [])
     .map(origin => _normalizeSidebarOriginId(origin && origin.id))
     .filter(origin => origin && origin !== 'webui');
   if (!_originFiltersHydrated) {
     const next = new Set(['webui']);
     if (window._showCliSessions) {
-      for (const originId of optionIds) next.add(originId);
+      for (const originId of optionIds) {
+        if (_originFilterDefaultsInclude(originId)) next.add(originId);
+      }
     }
     if (_originFilterSignature(next) === _originFilterSignature(_activeOriginFilters)) {
       _originFiltersHydrated = true;
@@ -1940,7 +1943,9 @@ function _ensureOriginFilterDefaults(originOptions) {
     _persistOriginFilters();
     return true;
   }
-  for (const originId of optionIds) next.add(originId);
+  for (const originId of optionIds) {
+    if (_originFilterDefaultsInclude(originId)) next.add(originId);
+  }
   if (_originFilterSignature(next) === _originFilterSignature(_activeOriginFilters)) return false;
   _activeOriginFilters = next;
   _persistOriginFilters();
@@ -1988,6 +1993,7 @@ async function _toggleSidebarPreviousMessagingSessions(enabled) {
 async function _ensureSidebarOriginSettingsInitialized() {
   if (_sidebarOriginSettingsInitPromise) return _sidebarOriginSettingsInitPromise;
   if (typeof window._showCliSessions === 'undefined') return null;
+  _captureOriginFilterCronDefaultSeed();
   if (window._showCliSessions && window._showCronSessions) return null;
   _sidebarOriginSettingsInitPromise = _persistSidebarVisibilitySettings({
     show_previous_messaging_sessions: !!window._showPreviousMessagingSessions,
@@ -3104,6 +3110,16 @@ let _archivedCliCount = 0;        // archived non-WebUI sessions not fetched unt
 let _activeOriginFilters = new Set(['webui']);  // always includes 'webui'; user may add 'cli'
 let _originFiltersLoadedFromStorage = false;
 let _originFiltersHydrated = false;
+let _originFilterCronDefaultSeed = null; // null means pre-persist value not captured yet
+function _captureOriginFilterCronDefaultSeed() {
+  if (_originFilterCronDefaultSeed === null) {
+    _originFilterCronDefaultSeed = !!window._showCronSessions;
+  }
+  return _originFilterCronDefaultSeed;
+}
+function _originFilterDefaultsInclude(originId) {
+  return originId !== 'cron' || _captureOriginFilterCronDefaultSeed();
+}
 let _sidebarOriginCatalog = [];
 let _sidebarOriginCatalogFetchedAt = 0;
 let _sidebarOriginCatalogRequest = null;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -947,7 +947,6 @@ async function newSession(flash, options={}){
     }
     S.session=data.session;S.messages=data.session.messages||[];
     S._pendingSessionToolsets=null;
-    if(_sessionSourceFilter==='cli') _sessionSourceFilter='webui';
     if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
     S.lastUsage={...(data.session.last_usage||{})};
     if(!(options&&options.worktree)) _rememberNewChatDraftSession(S.session);
@@ -1725,18 +1724,14 @@ function _isCliSession(session) {
   return session.is_cli_session === true;
 }
 
-function _sessionSourceLabel(filter, count) {
-  const n = Number(count) || 0;
-  return filter === 'cli' ? `CLI sessions (${n})` : `WebUI sessions (${n})`;
-}
-
 function _clearSessionSourceTabCounts() {
   _serverWebuiSessionCount = null;
   _serverCliSessionCount = null;
 }
 
 function _requestedSessionSidebarSource() {
-  return window._showCliSessions ? _sessionSourceFilter : 'webui';
+  if (!window._showCliSessions) return 'webui';
+  return null;
 }
 
 function _sessionListExcludeHiddenEnabled() {
@@ -1745,17 +1740,12 @@ function _sessionListExcludeHiddenEnabled() {
 
 function _sessionListQueryString() {
   const qs = new URLSearchParams();
-  qs.set('sidebar_source', _requestedSessionSidebarSource());
+  const sidebarSource = _requestedSessionSidebarSource();
+  if (sidebarSource) qs.set('sidebar_source', sidebarSource);
   if(_sessionListExcludeHiddenEnabled()) qs.set('exclude_hidden','1');
   if(_showAllProfiles) qs.set('all_profiles','1');
   if(_showArchived) qs.set('include_archived','1');
   return `?${qs.toString()}`;
-}
-
-function _sessionSourceTabCount(filter, renderedWebuiSessionCount, renderedCliSessionCount) {
-  const serverCount = filter === 'cli' ? _serverCliSessionCount : _serverWebuiSessionCount;
-  if (Number.isFinite(serverCount)) return serverCount;
-  return filter === 'cli' ? renderedCliSessionCount : renderedWebuiSessionCount;
 }
 
 function _setActiveProjectFilter(projectId) {
@@ -1766,22 +1756,29 @@ function _setActiveProjectFilter(projectId) {
   void renderSessionList({deferWhileInteracting:false});
 }
 
-function _setSessionSourceFilter(filter) {
-  const next = filter === 'cli' ? 'cli' : 'webui';
-  if (_sessionSourceFilter === next) return;
-  _sessionSourceFilter = next;
+function _toggleOriginFilter(origin) {
+  if (origin === 'webui') return;
+  if (_activeOriginFilters.has(origin)) {
+    _activeOriginFilters.delete(origin);
+  } else {
+    _activeOriginFilters.add(origin);
+  }
   _activeProject = null;
   _selectedSessions.clear();
   _sessionSelectMode = false;
-  try { localStorage.setItem('hermes-session-source-filter', next); } catch (_e) {}
+  try { localStorage.setItem('hermes-origin-filters', JSON.stringify([..._activeOriginFilters])); } catch (_e) {}
   renderSessionListFromCache();
-  void renderSessionList({deferWhileInteracting:false});
 }
 
-function _restoreSessionSourceFilter() {
+function _restoreOriginFilters() {
   try {
-    const raw = localStorage.getItem('hermes-session-source-filter');
-    if (raw === 'cli' || raw === 'webui') _sessionSourceFilter = raw;
+    const raw = localStorage.getItem('hermes-origin-filters');
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        _activeOriginFilters = new Set(['webui', ...parsed.filter(v => typeof v === 'string')]);
+      }
+    }
   } catch (_e) {}
 }
 
@@ -2881,8 +2878,8 @@ let _archivedWebuiCount = 0;      // archived WebUI sessions not fetched until r
 let _archivedCliCount = 0;        // archived non-WebUI sessions not fetched until requested
 let _serverWebuiSessionCount = null;  // explicit server count for WebUI sessions
 let _serverCliSessionCount = null;    // explicit server count for CLI sessions
-let _sessionSourceFilter = 'webui';  // 'webui' keeps WebUI chats separate from read-only CLI sessions
-_restoreSessionSourceFilter();
+let _activeOriginFilters = new Set(['webui']);  // always includes 'webui'; user may add 'cli'
+_restoreOriginFilters();
 let _sessionActionMenu = null;
 let _sessionActionAnchor = null;
 let _sessionActionSessionId = null;
@@ -3786,7 +3783,7 @@ function showSessionListSkeleton(targetProfile){
       && typeof _knownSessionProfileCount === 'function')
     ? _knownSessionProfileCount(targetProfile) : null;
   const filterActive = (typeof _activeProject !== 'undefined' && _activeProject)
-    || (typeof _sessionSourceFilter !== 'undefined' && _sessionSourceFilter === 'cli');
+    || (typeof _activeOriginFilters !== 'undefined' && _activeOriginFilters.has('cli'));
   const wrap = document.createElement('div');
   wrap.setAttribute('aria-hidden', 'true');
   if(knownCount === 0 && !filterActive){
@@ -4025,7 +4022,7 @@ function _applySessionListPayload(sessData, projData){
   // a different filter). This mirrors the read-side `filterActive` gate in
   // showSessionListSkeleton so the write and read agree on what the count means.
   const _recordFilterActive = (typeof _activeProject !== 'undefined' && _activeProject)
-    || (typeof _sessionSourceFilter !== 'undefined' && _sessionSourceFilter === 'cli');
+    || (typeof _activeOriginFilters !== 'undefined' && _activeOriginFilters.has('cli'));
   if (!_showAllProfiles && !_recordFilterActive) {
     _recordSessionProfileCount(_allSessionsScope.profile, _allSessions.length);
   }
@@ -5680,15 +5677,7 @@ function _resyncSessionVirtualWindowAfterRender(list, expectedScrollTop, virtual
   });
 }
 
-// Top-level so BOTH the sidebar visibility predicate (_sidebarRowHasVisibleMessages,
-// reached via renderSessionListFromCache -> _partitionSidebarSessionRows) and the
-// per-row renderer (_renderOneSession, nested in renderSessionListFromCache) can call
-// it. It was previously declared INSIDE renderSessionListFromCache and relied on
-// function hoisting — but hoisting is scoped to the enclosing function, so the
-// top-level _sidebarRowHasVisibleMessages threw "ReferenceError: _sessionAttentionState
-// is not defined" on every cache render, crashing the sidebar (#3696, regressed in
-// #3672 when _sidebarRowHasVisibleMessages was extracted to top level). Pure function
-// (only its arg `s` plus the i18n global `t`), so hoisting it is safe.
+// Sidebar-attention helper used by render paths and row rendering.
 function _sessionAttentionState(s){
   const attention=s&&s.attention&&typeof s.attention==='object'?s.attention:null;
   if(!attention||!attention.kind||!Number.isFinite(Number(attention.count))||Number(attention.count)<=0)return null;
@@ -5715,23 +5704,22 @@ function _sidebarRowHasVisibleMessages(s, activeSidForSidebar){
 }
 
 function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
+  let webuiSessionCount=0;
   let cliSessionCount=0;
-  const webuiProfileFiltered=[];
-  const cliProfileFiltered=[];
-  const webuiReferenceRaw=[];
-  const cliReferenceRaw=[];
-  const webuiSessionsRaw=[];
-  const cliSessionsRaw=[];
-  let webuiArchivedCount=0;
-  let cliArchivedCount=0;
+  const sourceFiltered=[];
+  const profileFiltered=[];
+  const referenceRaw=[];
+  const sessionsRaw=[];
+  let archivedCount=0;
   for(const s of allMatched){
     if(!_sidebarRowHasVisibleMessages(s, activeSidForSidebar)) continue;
     const isCli=_isCliSession(s);
+    const origin=isCli?'cli':'webui';
     if(isCli) cliSessionCount++;
+    else webuiSessionCount++;
+    if(!_activeOriginFilters.has(origin)) continue;
+    sourceFiltered.push(s);
     if(s.default_hidden&&!(_activeProject&&_activeProject!==NO_PROJECT_FILTER&&s.project_id===_activeProject)) continue;
-    const profileFiltered=isCli ? cliProfileFiltered : webuiProfileFiltered;
-    const referenceRaw=isCli ? cliReferenceRaw : webuiReferenceRaw;
-    const sessionsRaw=isCli ? cliSessionsRaw : webuiSessionsRaw;
     profileFiltered.push(s);
     if(_activeProject===NO_PROJECT_FILTER){
       if(s.project_id) continue;
@@ -5739,33 +5727,31 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
       if(s.project_id!==_activeProject) continue;
     }
     referenceRaw.push(s);
-    if(s.archived){
-      if(isCli) cliArchivedCount++;
-      else webuiArchivedCount++;
-    }
+    if(s.archived) archivedCount++;
     if(!_showArchived&&s.archived) continue;
     sessionsRaw.push(s);
   }
-  if(_sessionSourceFilter==='cli' && !window._showCliSessions && cliSessionCount===0){
-    _sessionSourceFilter='webui';
-  }
-  const showCliOnly=_sessionSourceFilter==='cli';
-  const serverArchivedCount=showCliOnly?_archivedCliCount:_archivedWebuiCount;
+  const serverArchivedCount=
+    Number(_archivedWebuiCount||0)+
+    (_activeOriginFilters.has('cli')?Number(_archivedCliCount||0):0);
   return {
+    webuiSessionCount,
     cliSessionCount,
-    profileFiltered: showCliOnly ? cliProfileFiltered : webuiProfileFiltered,
-    sessionsRaw: showCliOnly ? cliSessionsRaw : webuiSessionsRaw,
-    archivedCount: Math.max(showCliOnly ? cliArchivedCount : webuiArchivedCount, Number(serverArchivedCount||0)),
-    webuiReferenceRaw,
-    cliReferenceRaw,
-    webuiSessionsRaw,
-    cliSessionsRaw,
+    sourceFiltered,
+    profileFiltered,
+    referenceRaw,
+    sessionsRaw,
+    archivedCount: Math.max(archivedCount, serverArchivedCount),
   };
 }
 
 function _renderSidebarRowsFromRawSessions(sessionsRaw, referenceSessionsRaw){
   const referenceRows=Array.isArray(referenceSessionsRaw)?referenceSessionsRaw:sessionsRaw;
   return _attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw, referenceRows);
+}
+
+function _countRenderedSidebarRowsFromRawSessions(sessionsRaw, referenceSessionsRaw){
+  return _renderSidebarRowsFromRawSessions(sessionsRaw, referenceSessionsRaw).length;
 }
 
 
@@ -5800,21 +5786,15 @@ function renderSessionListFromCache(){
   const searchMatches=_sessionSearchMergeMatches(sidebarRows,searchQueryRaw,_contentSearchResults);
   const allMatched=_ensureActiveSessionRowPresent(searchMatches,sidebarRows);
   const {
+    webuiSessionCount,
     cliSessionCount,
+    sourceFiltered,
     profileFiltered,
+    referenceRaw,
     sessionsRaw,
     archivedCount,
-    webuiReferenceRaw,
-    cliReferenceRaw,
-    webuiSessionsRaw,
-    cliSessionsRaw,
   }=_partitionSidebarSessionRows(allMatched, activeSidForSidebar);
-  const referenceRaw=_sessionSourceFilter==='cli'?cliReferenceRaw:webuiReferenceRaw;
   const sessions=_renderSidebarRowsFromRawSessions(sessionsRaw, referenceRaw);
-  const renderedWebuiSessionCount=_renderSidebarRowsFromRawSessions(webuiSessionsRaw, webuiReferenceRaw).length;
-  const renderedCliSessionCount=_renderSidebarRowsFromRawSessions(cliSessionsRaw, cliReferenceRaw).length;
-  const webuiSessionTabCount=_sessionSourceTabCount('webui', renderedWebuiSessionCount, renderedCliSessionCount);
-  const cliSessionTabCount=_sessionSourceTabCount('cli', renderedWebuiSessionCount, renderedCliSessionCount);
   _syncSidebarExpansionForActiveSession(sessions, activeSidForSidebar);
   const list=$('sessionList');
   const animateRefresh=_sessionListRefreshAnimationPending;
@@ -5872,19 +5852,58 @@ function renderSessionListFromCache(){
     list.appendChild(note);
   }
   if(window._showCliSessions || cliSessionCount>0){
-    const sourceTabs=document.createElement('div');
-    sourceTabs.className='session-source-tabs';
-    for(const filter of ['webui','cli']){
-      const count=filter==='cli'?cliSessionTabCount:webuiSessionTabCount;
-      const btn=document.createElement('button');
-      btn.type='button';
-      btn.className='session-source-tab'+(_sessionSourceFilter===filter?' active':'');
-      btn.textContent=_sessionSourceLabel(filter,count);
-      btn.setAttribute('aria-pressed', _sessionSourceFilter===filter?'true':'false');
-      btn.onclick=()=>_setSessionSourceFilter(filter);
-      sourceTabs.appendChild(btn);
+    const filterBar=document.createElement('div');
+    filterBar.className='session-filter-bar';
+    const funnelBtn=document.createElement('button');
+    funnelBtn.type='button';
+    funnelBtn.className='session-filter-funnel';
+    funnelBtn.title='Filter by origin';
+    funnelBtn.innerHTML='<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>';
+    const activeCount=_activeOriginFilters.size-((_activeOriginFilters.has('webui'))?1:0);
+    if(activeCount>0){
+      const badge=document.createElement('span');
+      badge.className='session-filter-badge';
+      badge.textContent=String(activeCount);
+      funnelBtn.appendChild(badge);
     }
-    list.appendChild(sourceTabs);
+    const popover=document.createElement('div');
+    popover.className='session-origin-popover';
+    popover.hidden=true;
+    const origins=[
+      {id:'webui',label:'WebUI',count:webuiSessionCount,locked:true},
+      {id:'cli',label:'CLI',count:cliSessionCount,locked:false},
+    ];
+    for(const o of origins){
+      const row=document.createElement('label');
+      row.className='session-origin-row';
+      const cb=document.createElement('input');
+      cb.type='checkbox';
+      cb.checked=_activeOriginFilters.has(o.id);
+      cb.disabled=!!o.locked;
+      cb.className='session-origin-checkbox';
+      cb.addEventListener('change',()=>_toggleOriginFilter(o.id));
+      const lbl=document.createElement('span');
+      lbl.className='session-origin-label';
+      lbl.textContent=o.label;
+      const cnt=document.createElement('span');
+      cnt.className='session-origin-count';
+      cnt.textContent=String(o.count);
+      row.appendChild(cb);
+      row.appendChild(lbl);
+      row.appendChild(cnt);
+      popover.appendChild(row);
+    }
+    popover.addEventListener('click',(e)=>{e.stopPropagation();});
+    funnelBtn.addEventListener('click',(e)=>{
+      e.stopPropagation();
+      popover.hidden=!popover.hidden;
+      if(!popover.hidden){
+        document.addEventListener('click',()=>{popover.hidden=true;},{once:true});
+      }
+    });
+    filterBar.appendChild(funnelBtn);
+    filterBar.appendChild(popover);
+    list.appendChild(filterBar);
   }
   // Project filter bar — show when there are real projects OR there are
   // unassigned sessions (so the Unassigned chip has something to filter to).
@@ -6013,7 +6032,7 @@ function renderSessionListFromCache(){
     list.appendChild(toggle);
   }
   // Empty state for active project filter
-  if(_sessionSourceFilter==='cli'&&sessions.length===0){
+  if(_activeOriginFilters.has('cli')&&cliSessionCount===0&&sourceFiltered.length===0){
     const empty=document.createElement('div');
     empty.className='session-empty-note';
     empty.textContent=window._showCliSessions?'No CLI sessions found.':'Enable Show agent sessions in Settings to list CLI sessions here.';

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -5750,10 +5750,6 @@ function _renderSidebarRowsFromRawSessions(sessionsRaw, referenceSessionsRaw){
   return _attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw, referenceRows);
 }
 
-function _countRenderedSidebarRowsFromRawSessions(sessionsRaw, referenceSessionsRaw){
-  return _renderSidebarRowsFromRawSessions(sessionsRaw, referenceSessionsRaw).length;
-}
-
 
 function renderSessionListFromCache(){
   // #4671: while a profile-switch skeleton is up, bail — _allSessions still holds the

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -898,27 +898,7 @@ async function newSession(flash, options={}){
     }
     if(newModelState&&newModelState.model){
       reqBody.model=newModelState.model;
-      // Cold-start / picker-without-provider fallback: when the dropdown option's
-      // data-provider is empty/'default' or the persisted state predates provider
-      // tracking, newModelState.model_provider is null. POST /api/session/new's
-      // fast path in _resolve_compatible_session_model_state requires both model
-      // and a truthy model_provider; without it, the request falls into
-      // get_available_models() and a 3-4s cold catalog rebuild. window._activeProvider
-      // is hydrated at boot (ui.js) and on config refresh (panels.js), so it's a
-      // safe default that matches the user's configured route. S.session.model_provider
-      // is the previous-session fallback when the dropdown is unhydrated.
-      //
-      // Guard: a slash-qualified model (e.g. "gemini/gemini-2.5") or an
-      // @provider:model string already carries a foreign provider namespace from
-      // a previous session that was served by a different backend. Attaching
-      // the current _activeProvider to such a slug would let the server's fast
-      // path pass it through without consulting the catalog, silently
-      // re-pointing the new session at the wrong backend (the very case the
-      // slow-path normalization in _resolve_compatible_session_model_state is
-      // designed to fix — see routes.py docstring around line 1891-1894). For
-      // those models we leave the wire shape with model_provider=null so the
-      // slow path's cross-provider repair still runs. Closes the open
-      // follow-up from #2518.
+      // Fill model_provider for bare slugs to skip cold catalog rebuilds, but leave cross-provider model names on the server slow path.
       const _bareModel=!/[/]/.test(newModelState.model)&&!newModelState.model.startsWith('@');
       // Second guard (#3410-followup): even a bare model can carry a known
       // family prefix (gpt→openai, claude→anthropic, gemini→google). If that

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1687,6 +1687,64 @@ function _sourceKeyForSession(session) {
   return (session && (session.raw_source || session.source_tag || session.source || '') || '').toLowerCase();
 }
 
+const _SIDEBAR_FIXED_ORIGIN_IDS = ['webui', 'cli', 'cron'];
+const _SIDEBAR_ORIGIN_LABELS = {
+  webui: 'WebUI',
+  cli: 'CLI',
+  cron: 'Cron',
+  whatsapp: 'WhatsApp',
+  signal: 'Signal',
+  teams: 'Teams',
+  google_chat: 'Google Chat',
+  homeassistant: 'Home Assistant',
+  qqbot: 'QQBot',
+  yuanbao: 'Yuanbao',
+  ..._MESSAGING_SOURCE_LABELS,
+};
+
+function _normalizeSidebarOriginId(rawOrigin) {
+  const origin = String(rawOrigin || '').trim().toLowerCase().replace(/[\s-]+/g, '_');
+  if (!origin || origin === 'webui') return 'webui';
+  if (origin === 'tui') return 'cli';
+  if (origin === 'external-agent' || origin === 'external_agent' || origin === 'messaging') return 'cli';
+  if (origin === 'wechat') return 'weixin';
+  if (origin === 'googlechat') return 'google_chat';
+  if (origin === 'home_assistant') return 'homeassistant';
+  if (origin === 'qq_bot') return 'qqbot';
+  return origin;
+}
+
+function _humanizeSidebarOriginLabel(originId) {
+  const raw = String(originId || '').trim();
+  if (!raw) return '';
+  return raw
+    .split('_')
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function _sidebarOriginLabelForId(originId, fallback='') {
+  const origin = _normalizeSidebarOriginId(originId);
+  const catalogEntry = (Array.isArray(_sidebarOriginCatalog) ? _sidebarOriginCatalog : [])
+    .find(entry => entry && entry.id === origin && entry.label);
+  if (catalogEntry) return catalogEntry.label;
+  if (_SIDEBAR_ORIGIN_LABELS[origin]) return _SIDEBAR_ORIGIN_LABELS[origin];
+  if (fallback) return fallback;
+  return _humanizeSidebarOriginLabel(origin);
+}
+
+function _sidebarOriginIdForSession(session) {
+  if (!session || !_isExternalSession(session)) return 'webui';
+  if (_isMessagingSession(session)) {
+    const messagingOrigin = _normalizeSidebarOriginId(_sourceKeyForSession(session));
+    return messagingOrigin && messagingOrigin !== 'webui' && messagingOrigin !== 'cli'
+      ? messagingOrigin
+      : 'cli';
+  }
+  return _normalizeSidebarOriginId(_sourceKeyForSession(session)) === 'cron' ? 'cron' : 'cli';
+}
+
 function _isCliSession(session) {
   if (!session) return false;
   // session_source is set by upstream normalization for CLI sessions as 'cli'
@@ -1703,11 +1761,6 @@ function _isCliSession(session) {
   // If messaging-like, don't classify as legacy CLI even when is_cli_session is true.
   if (_isMessagingSession(session)) return false;
   return session.is_cli_session === true;
-}
-
-function _clearSessionSourceTabCounts() {
-  _serverWebuiSessionCount = null;
-  _serverCliSessionCount = null;
 }
 
 function _requestedSessionSidebarSource() {
@@ -1738,16 +1791,18 @@ function _setActiveProjectFilter(projectId) {
 }
 
 function _toggleOriginFilter(origin) {
-  if (origin === 'webui') return;
-  if (_activeOriginFilters.has(origin)) {
-    _activeOriginFilters.delete(origin);
+  const normalizedOrigin = _normalizeSidebarOriginId(origin);
+  if (normalizedOrigin === 'webui') return;
+  if (_activeOriginFilters.has(normalizedOrigin)) {
+    _activeOriginFilters.delete(normalizedOrigin);
   } else {
-    _activeOriginFilters.add(origin);
+    _activeOriginFilters.add(normalizedOrigin);
   }
+  _originFiltersHydrated = true;
   _activeProject = null;
   _selectedSessions.clear();
   _sessionSelectMode = false;
-  try { localStorage.setItem('hermes-origin-filters', JSON.stringify([..._activeOriginFilters])); } catch (_e) {}
+  _persistOriginFilters();
   renderSessionListFromCache();
 }
 
@@ -1757,11 +1812,197 @@ function _restoreOriginFilters() {
     if (raw) {
       const parsed = JSON.parse(raw);
       if (Array.isArray(parsed)) {
-        _activeOriginFilters = new Set(['webui', ...parsed.filter(v => typeof v === 'string')]);
+        _activeOriginFilters = new Set(
+          ['webui', ...parsed
+            .filter(v => typeof v === 'string')
+            .map(v => _normalizeSidebarOriginId(v))
+            .filter(v => v && v !== 'webui')]
+        );
+        _originFiltersLoadedFromStorage = true;
+        _originFiltersHydrated = true;
       }
     }
   } catch (_e) {}
 }
+
+function _persistOriginFilters() {
+  try { localStorage.setItem('hermes-origin-filters', JSON.stringify([..._activeOriginFilters])); } catch (_e) {}
+}
+
+function _originFilterSignature(setLike) {
+  return [...(setLike instanceof Set ? setLike : new Set(setLike || []))]
+    .map(origin => _normalizeSidebarOriginId(origin))
+    .filter(Boolean)
+    .sort()
+    .join('|');
+}
+
+function _sidebarOriginCatalogSignature(entries) {
+  return (Array.isArray(entries) ? entries : [])
+    .map(entry => `${entry.id}:${entry.label}`)
+    .sort()
+    .join('|');
+}
+
+function _buildSidebarOriginCatalog(status) {
+  const platforms = status && Array.isArray(status.platforms) ? status.platforms : [];
+  const seen = new Set();
+  const entries = [];
+  for (const platform of platforms) {
+    if (!platform || typeof platform !== 'object') continue;
+    const id = _normalizeSidebarOriginId(platform.name);
+    if (!id || id === 'webui' || id === 'cli' || id === 'cron' || seen.has(id)) continue;
+    seen.add(id);
+    entries.push({
+      id,
+      label: String(platform.label || '').trim() || _sidebarOriginLabelForId(id),
+    });
+  }
+  entries.sort((a, b) => a.label.localeCompare(b.label));
+  return entries;
+}
+
+function _setSidebarOriginCatalog(entries) {
+  const next = Array.isArray(entries) ? entries : [];
+  if (_sidebarOriginCatalogSignature(_sidebarOriginCatalog) === _sidebarOriginCatalogSignature(next)) return;
+  _sidebarOriginCatalog = next;
+  if (typeof renderSessionListFromCache === 'function') renderSessionListFromCache();
+}
+
+async function _refreshSidebarOriginCatalog(opts={}) {
+  const force = !!(opts && opts.force);
+  const now = Date.now();
+  if (!force && _sidebarOriginCatalogRequest) return _sidebarOriginCatalogRequest;
+  if (!force && _sidebarOriginCatalogFetchedAt && (now - _sidebarOriginCatalogFetchedAt) < 30000) return null;
+  _sidebarOriginCatalogRequest = api('/api/gateway/status', {timeoutToast: false})
+    .then(status => {
+      _sidebarOriginCatalogFetchedAt = Date.now();
+      _setSidebarOriginCatalog(_buildSidebarOriginCatalog(status));
+    })
+    .catch(() => {})
+    .finally(() => {
+      _sidebarOriginCatalogRequest = null;
+    });
+  return _sidebarOriginCatalogRequest;
+}
+
+function _sidebarOriginOptions(originCounts, originLabels) {
+  const counts = originCounts instanceof Map ? originCounts : new Map();
+  const labels = originLabels instanceof Map ? originLabels : new Map();
+  const seen = new Set();
+  const options = [];
+  const addOption = (rawId, locked=false) => {
+    const id = _normalizeSidebarOriginId(rawId);
+    if (!id || seen.has(id)) return;
+    seen.add(id);
+    options.push({
+      id,
+      locked,
+      label: _sidebarOriginLabelForId(id, labels.get(id) || ''),
+      count: Number(counts.get(id) || 0),
+    });
+  };
+  addOption('webui', true);
+  for (const id of _SIDEBAR_FIXED_ORIGIN_IDS) {
+    if (id !== 'webui') addOption(id);
+  }
+  for (const entry of _sidebarOriginCatalog) addOption(entry.id);
+  for (const id of labels.keys()) addOption(id);
+  return options;
+}
+
+function _ensureOriginFilterDefaults(originOptions) {
+  const optionIds = (originOptions || [])
+    .map(origin => _normalizeSidebarOriginId(origin && origin.id))
+    .filter(origin => origin && origin !== 'webui');
+  if (!_originFiltersHydrated) {
+    const next = new Set(['webui']);
+    if (window._showCliSessions) {
+      for (const originId of optionIds) next.add(originId);
+    }
+    if (_originFilterSignature(next) === _originFilterSignature(_activeOriginFilters)) {
+      _originFiltersHydrated = true;
+      return false;
+    }
+    _activeOriginFilters = next;
+    _originFiltersHydrated = true;
+    _persistOriginFilters();
+    return true;
+  }
+  const next = new Set(_activeOriginFilters instanceof Set ? _activeOriginFilters : ['webui']);
+  if (!next.has('webui')) next.add('webui');
+  if (_originFiltersLoadedFromStorage || !window._showCliSessions) {
+    if (_originFilterSignature(next) === _originFilterSignature(_activeOriginFilters)) return false;
+    _activeOriginFilters = next;
+    _persistOriginFilters();
+    return true;
+  }
+  for (const originId of optionIds) next.add(originId);
+  if (_originFilterSignature(next) === _originFilterSignature(_activeOriginFilters)) return false;
+  _activeOriginFilters = next;
+  _persistOriginFilters();
+  return true;
+}
+
+function _applySidebarVisibilitySettings(saved) {
+  if (!saved || typeof saved !== 'object') return;
+  window._showCliSessions = saved.show_cli_sessions !== false;
+  window._showCronSessions = !!saved.show_cron_sessions;
+  window._showPreviousMessagingSessions = !!saved.show_previous_messaging_sessions;
+  if (typeof startGatewaySSE === 'function') {
+    if (window._showCliSessions) startGatewaySSE();
+    else if (typeof stopGatewaySSE === 'function') stopGatewaySSE();
+  }
+}
+
+async function _persistSidebarVisibilitySettings(next) {
+  const payload = {
+    show_cli_sessions: true,
+    show_cron_sessions: true,
+    show_previous_messaging_sessions: !!window._showPreviousMessagingSessions,
+    ...(next || {}),
+  };
+  const saved = await api('/api/settings', {method: 'POST', body: JSON.stringify(payload)});
+  _applySidebarVisibilitySettings(saved);
+  return saved;
+}
+
+async function _toggleSidebarPreviousMessagingSessions(enabled) {
+  const previous = !!window._showPreviousMessagingSessions;
+  window._showPreviousMessagingSessions = !!enabled;
+  try {
+    await _persistSidebarVisibilitySettings({
+      show_previous_messaging_sessions: !!enabled,
+    });
+    await renderSessionList({deferWhileInteracting: false});
+  } catch (e) {
+    window._showPreviousMessagingSessions = previous;
+    if (typeof showToast === 'function') showToast(`Failed to update sidebar filter: ${e.message || e}`);
+    renderSessionListFromCache();
+  }
+}
+
+async function _ensureSidebarOriginSettingsInitialized() {
+  if (_sidebarOriginSettingsInitPromise) return _sidebarOriginSettingsInitPromise;
+  if (typeof window._showCliSessions === 'undefined') return null;
+  if (window._showCliSessions && window._showCronSessions) return null;
+  _sidebarOriginSettingsInitPromise = _persistSidebarVisibilitySettings({
+    show_previous_messaging_sessions: !!window._showPreviousMessagingSessions,
+  })
+    .then(async () => {
+      await _refreshSidebarOriginCatalog({force: true});
+      if (typeof renderSessionList === 'function') await renderSessionList({deferWhileInteracting: false});
+    })
+    .catch(e => {
+      console.warn('Failed to initialize sidebar origin settings:', e);
+    })
+    .finally(() => {
+      _sidebarOriginSettingsInitPromise = null;
+    });
+  return _sidebarOriginSettingsInitPromise;
+}
+
+window._ensureSidebarOriginSettingsInitialized = _ensureSidebarOriginSettingsInitialized;
 
 function _normalizeMessageForCliImportComparison(message) {
   if (!message || typeof message !== 'object') return message;
@@ -2857,9 +3098,13 @@ let _showAllProfiles = false;  // false = filter to active profile only
 let _otherProfileCount = 0;       // count of sessions from other profiles (server-reported)
 let _archivedWebuiCount = 0;      // archived WebUI sessions not fetched until requested
 let _archivedCliCount = 0;        // archived non-WebUI sessions not fetched until requested
-let _serverWebuiSessionCount = null;  // explicit server count for WebUI sessions
-let _serverCliSessionCount = null;    // explicit server count for CLI sessions
 let _activeOriginFilters = new Set(['webui']);  // always includes 'webui'; user may add 'cli'
+let _originFiltersLoadedFromStorage = false;
+let _originFiltersHydrated = false;
+let _sidebarOriginCatalog = [];
+let _sidebarOriginCatalogFetchedAt = 0;
+let _sidebarOriginCatalogRequest = null;
+let _sidebarOriginSettingsInitPromise = null;
 _restoreOriginFilters();
 let _sessionActionMenu = null;
 let _sessionActionAnchor = null;
@@ -3960,14 +4205,6 @@ function _applySessionListPayload(sessData, projData){
   _otherProfileCount = sessData.other_profile_count || 0;
   _archivedWebuiCount = Number(sessData.archived_webui_count ?? sessData.archived_count ?? 0);
   _archivedCliCount = Number(sessData.archived_cli_count ?? 0);
-  _serverWebuiSessionCount = Object.prototype.hasOwnProperty.call(sessData, 'webui_session_count')
-    ? Number(sessData.webui_session_count)
-    : null;
-  _serverCliSessionCount = Object.prototype.hasOwnProperty.call(sessData, 'cli_session_count')
-    ? Number(sessData.cli_session_count)
-    : null;
-  if (!Number.isFinite(_serverWebuiSessionCount)) _serverWebuiSessionCount = null;
-  if (!Number.isFinite(_serverCliSessionCount)) _serverCliSessionCount = null;
   // Capture server clock for clock-skew compensation (issue #1144).
   // server_time is epoch seconds from the server's time.time().
   // _serverTimeDelta = client - server, so (Date.now() - _serverTimeDelta)
@@ -4003,7 +4240,10 @@ function _applySessionListPayload(sessData, projData){
   // a different filter). This mirrors the read-side `filterActive` gate in
   // showSessionListSkeleton so the write and read agree on what the count means.
   const _recordFilterActive = (typeof _activeProject !== 'undefined' && _activeProject)
-    || (typeof _activeOriginFilters !== 'undefined' && _activeOriginFilters.has('cli'));
+    || (
+      typeof _activeOriginFilters !== 'undefined'
+      && [..._activeOriginFilters].some(origin => origin !== 'webui')
+    );
   if (!_showAllProfiles && !_recordFilterActive) {
     _recordSessionProfileCount(_allSessionsScope.profile, _allSessions.length);
   }
@@ -4021,6 +4261,8 @@ function _applySessionListPayload(sessData, projData){
   }
   ensureSessionTimeRefreshPoll();
   ensureActiveSessionExternalRefreshPoll();
+  void _refreshSidebarOriginCatalog();
+  void _ensureSidebarOriginSettingsInitialized();
   if(!_sessionListFirstRenderAnimated&&Array.isArray(_allSessions)&&_allSessions.length){
     animateNextSessionListRefresh({enterAll:true});
     _sessionListFirstRenderAnimated=true;
@@ -4127,7 +4369,6 @@ async function _runRenderSessionListRefresh(opts, _gen){
     } else {
       _allSessions = [];
       _allSessionsScope = _curScope;
-      _clearSessionSourceTabCounts();
       renderSessionListFromCache();
     }
   }
@@ -5687,6 +5928,8 @@ function _sidebarRowHasVisibleMessages(s, activeSidForSidebar){
 function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
   let webuiSessionCount=0;
   let cliSessionCount=0;
+  const originCounts=new Map();
+  const originLabels=new Map();
   const sourceFiltered=[];
   const profileFiltered=[];
   const referenceRaw=[];
@@ -5694,10 +5937,13 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
   let archivedCount=0;
   for(const s of allMatched){
     if(!_sidebarRowHasVisibleMessages(s, activeSidForSidebar)) continue;
-    const isCli=_isCliSession(s);
-    const origin=isCli?'cli':'webui';
-    if(isCli) cliSessionCount++;
-    else webuiSessionCount++;
+    const origin=_sidebarOriginIdForSession(s);
+    if(origin==='cli') cliSessionCount++;
+    else if(origin==='webui') webuiSessionCount++;
+    originCounts.set(origin, Number(originCounts.get(origin) || 0) + 1);
+    if(!originLabels.has(origin)) {
+      originLabels.set(origin, _sidebarOriginLabelForId(origin, _getChannelLabel(s) || ''));
+    }
     if(!_activeOriginFilters.has(origin)) continue;
     sourceFiltered.push(s);
     if(s.default_hidden&&!(_activeProject&&_activeProject!==NO_PROJECT_FILTER&&s.project_id===_activeProject)) continue;
@@ -5712,12 +5958,15 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
     if(!_showArchived&&s.archived) continue;
     sessionsRaw.push(s);
   }
+  const hasNonWebuiOriginSelected=[..._activeOriginFilters].some(origin => origin !== 'webui');
   const serverArchivedCount=
     Number(_archivedWebuiCount||0)+
-    (_activeOriginFilters.has('cli')?Number(_archivedCliCount||0):0);
+    (hasNonWebuiOriginSelected?Number(_archivedCliCount||0):0);
   return {
     webuiSessionCount,
     cliSessionCount,
+    originCounts,
+    originLabels,
     sourceFiltered,
     profileFiltered,
     referenceRaw,
@@ -5762,15 +6011,32 @@ function renderSessionListFromCache(){
   // session id into another conversation, that content hit should still appear.
   const searchMatches=_sessionSearchMergeMatches(sidebarRows,searchQueryRaw,_contentSearchResults);
   const allMatched=_ensureActiveSessionRowPresent(searchMatches,sidebarRows);
-  const {
+  let {
     webuiSessionCount,
     cliSessionCount,
+    originCounts,
+    originLabels,
     sourceFiltered,
     profileFiltered,
     referenceRaw,
     sessionsRaw,
     archivedCount,
   }=_partitionSidebarSessionRows(allMatched, activeSidForSidebar);
+  let originOptions=_sidebarOriginOptions(originCounts, originLabels);
+  if(_ensureOriginFilterDefaults(originOptions)){
+    ({
+      webuiSessionCount,
+      cliSessionCount,
+      originCounts,
+      originLabels,
+      sourceFiltered,
+      profileFiltered,
+      referenceRaw,
+      sessionsRaw,
+      archivedCount,
+    }=_partitionSidebarSessionRows(allMatched, activeSidForSidebar));
+    originOptions=_sidebarOriginOptions(originCounts, originLabels);
+  }
   const sessions=_renderSidebarRowsFromRawSessions(sessionsRaw, referenceRaw);
   _syncSidebarExpansionForActiveSession(sessions, activeSidForSidebar);
   const list=$('sessionList');
@@ -5828,60 +6094,99 @@ function renderSessionListFromCache(){
     note.appendChild(retry);
     list.appendChild(note);
   }
-  if(window._showCliSessions || cliSessionCount>0){
-    const filterBar=document.createElement('div');
-    filterBar.className='session-filter-bar';
-    const funnelBtn=document.createElement('button');
-    funnelBtn.type='button';
-    funnelBtn.className='session-filter-funnel';
-    funnelBtn.title='Filter by origin';
-    funnelBtn.innerHTML='<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>';
-    const activeCount=_activeOriginFilters.size-((_activeOriginFilters.has('webui'))?1:0);
-    if(activeCount>0){
-      const badge=document.createElement('span');
-      badge.className='session-filter-badge';
-      badge.textContent=String(activeCount);
-      funnelBtn.appendChild(badge);
-    }
-    const popover=document.createElement('div');
-    popover.className='session-origin-popover';
-    popover.hidden=true;
-    const origins=[
-      {id:'webui',label:'WebUI',count:webuiSessionCount,locked:true},
-      {id:'cli',label:'CLI',count:cliSessionCount,locked:false},
-    ];
-    for(const o of origins){
-      const row=document.createElement('label');
-      row.className='session-origin-row';
-      const cb=document.createElement('input');
-      cb.type='checkbox';
-      cb.checked=_activeOriginFilters.has(o.id);
-      cb.disabled=!!o.locked;
-      cb.className='session-origin-checkbox';
-      cb.addEventListener('change',()=>_toggleOriginFilter(o.id));
-      const lbl=document.createElement('span');
-      lbl.className='session-origin-label';
-      lbl.textContent=o.label;
-      const cnt=document.createElement('span');
-      cnt.className='session-origin-count';
-      cnt.textContent=String(o.count);
-      row.appendChild(cb);
-      row.appendChild(lbl);
-      row.appendChild(cnt);
-      popover.appendChild(row);
-    }
-    popover.addEventListener('click',(e)=>{e.stopPropagation();});
-    funnelBtn.addEventListener('click',(e)=>{
-      e.stopPropagation();
-      popover.hidden=!popover.hidden;
-      if(!popover.hidden){
-        document.addEventListener('click',()=>{popover.hidden=true;},{once:true});
-      }
-    });
-    filterBar.appendChild(funnelBtn);
-    filterBar.appendChild(popover);
-    list.appendChild(filterBar);
+  const filterBar=document.createElement('div');
+  filterBar.className='session-filter-bar';
+  const funnelBtn=document.createElement('button');
+  funnelBtn.type='button';
+  funnelBtn.className='session-filter-funnel';
+  funnelBtn.title='Filter by origin';
+  funnelBtn.innerHTML='<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>';
+  const activeCount=Math.max(
+    0,
+    originOptions.filter(origin => origin && !origin.locked).length
+      - [..._activeOriginFilters].filter(origin => origin !== 'webui').length
+  );
+  if(activeCount>0){
+    const badge=document.createElement('span');
+    badge.className='session-filter-badge';
+    badge.textContent=String(activeCount);
+    funnelBtn.appendChild(badge);
   }
+  const popover=document.createElement('div');
+  popover.className='session-origin-popover';
+  popover.hidden=true;
+  const originHeading=document.createElement('div');
+  originHeading.className='session-origin-heading';
+  originHeading.textContent='Origin';
+  popover.appendChild(originHeading);
+  for(const origin of originOptions){
+    const row=document.createElement('label');
+    row.className='session-origin-row';
+    const cb=document.createElement('input');
+    cb.type='checkbox';
+    cb.checked=_activeOriginFilters.has(origin.id);
+    cb.disabled=!!origin.locked;
+    cb.className='session-origin-checkbox';
+    cb.addEventListener('change',()=>_toggleOriginFilter(origin.id));
+    const lbl=document.createElement('span');
+    lbl.className='session-origin-label';
+    lbl.textContent=origin.label;
+    const cnt=document.createElement('span');
+    cnt.className='session-origin-count';
+    cnt.textContent=String(origin.count || 0);
+    row.appendChild(cb);
+    row.appendChild(lbl);
+    row.appendChild(cnt);
+    popover.appendChild(row);
+  }
+  const visibilityHeading=document.createElement('div');
+  visibilityHeading.className='session-origin-heading';
+  visibilityHeading.textContent='Visibility';
+  popover.appendChild(visibilityHeading);
+  const previousMessagingRow=document.createElement('label');
+  previousMessagingRow.className='session-origin-row';
+  const previousMessagingCb=document.createElement('input');
+  previousMessagingCb.type='checkbox';
+  previousMessagingCb.checked=!!window._showPreviousMessagingSessions;
+  previousMessagingCb.className='session-origin-checkbox';
+  previousMessagingCb.addEventListener('change',()=>{
+    void _toggleSidebarPreviousMessagingSessions(previousMessagingCb.checked);
+  });
+  const previousMessagingLabel=document.createElement('span');
+  previousMessagingLabel.className='session-origin-label';
+  previousMessagingLabel.textContent=typeof t==='function'
+    ? t('settings_label_previous_messaging_sessions')
+    : 'Show previous messaging sessions';
+  previousMessagingRow.appendChild(previousMessagingCb);
+  previousMessagingRow.appendChild(previousMessagingLabel);
+  popover.appendChild(previousMessagingRow);
+  const archivedRow=document.createElement('label');
+  archivedRow.className='session-origin-row';
+  const archivedCb=document.createElement('input');
+  archivedCb.type='checkbox';
+  archivedCb.checked=!!_showArchived;
+  archivedCb.className='session-origin-checkbox';
+  archivedCb.addEventListener('change',()=>{
+    _showArchived=archivedCb.checked;
+    void renderSessionList({deferWhileInteracting:false});
+  });
+  const archivedLabel=document.createElement('span');
+  archivedLabel.className='session-origin-label';
+  archivedLabel.textContent=typeof t==='function' ? t('kanban_include_archived') : 'Include archived';
+  archivedRow.appendChild(archivedCb);
+  archivedRow.appendChild(archivedLabel);
+  popover.appendChild(archivedRow);
+  popover.addEventListener('click',(e)=>{e.stopPropagation();});
+  funnelBtn.addEventListener('click',(e)=>{
+    e.stopPropagation();
+    popover.hidden=!popover.hidden;
+    if(!popover.hidden){
+      document.addEventListener('click',()=>{popover.hidden=true;},{once:true});
+    }
+  });
+  filterBar.appendChild(funnelBtn);
+  filterBar.appendChild(popover);
+  list.appendChild(filterBar);
   // Project filter bar — show when there are real projects OR there are
   // unassigned sessions (so the Unassigned chip has something to filter to).
   const hasUnprojected=profileFiltered.some(s=>!s.project_id);
@@ -5999,20 +6304,12 @@ function renderSessionListFromCache(){
     pfToggle.onclick=()=>{_showAllProfiles=false;renderSessionList();};
     list.appendChild(pfToggle);
   }
-  // Show/hide archived toggle if there are archived sessions. Archived rows
-  // are fetched on demand so large histories do not bloat every sidebar poll.
-  if(archivedCount>0||_showArchived){
-    const toggle=document.createElement('div');
-    toggle.style.cssText='font-size:10px;padding:4px 10px;color:var(--muted);cursor:pointer;text-align:center;opacity:.7;';
-    toggle.textContent=_showArchived?'Hide archived':'Show '+archivedCount+' archived';
-    toggle.onclick=()=>{_showArchived=!_showArchived;renderSessionList();};
-    list.appendChild(toggle);
-  }
   // Empty state for active project filter
-  if(_activeOriginFilters.has('cli')&&cliSessionCount===0&&(webuiSessionCount===0||!_activeOriginFilters.has('webui'))){
+  const selectedExternalOrigins=[..._activeOriginFilters].filter(origin=>origin!=='webui');
+  if(!_activeProject&&selectedExternalOrigins.length>0&&sessions.length===0){
     const empty=document.createElement('div');
     empty.className='session-empty-note';
-    empty.textContent=window._showCliSessions?'No CLI sessions found.':'Enable Show agent sessions in Settings to list CLI sessions here.';
+    empty.textContent='No sessions found for the selected origins.';
     list.appendChild(empty);
   } else if(_activeProject&&sessions.length===0){
     const empty=document.createElement('div');

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1735,6 +1735,8 @@ function _sidebarOriginLabelForId(originId, fallback='') {
 }
 
 function _sidebarOriginIdForSession(session) {
+  const rawOrigin = _normalizeSidebarOriginId(_sourceKeyForSession(session));
+  if (rawOrigin === 'cron') return 'cron';
   if (!session || !_isExternalSession(session)) return 'webui';
   if (_isMessagingSession(session)) {
     const messagingOrigin = _normalizeSidebarOriginId(_sourceKeyForSession(session));
@@ -1742,7 +1744,7 @@ function _sidebarOriginIdForSession(session) {
       ? messagingOrigin
       : 'cli';
   }
-  return _normalizeSidebarOriginId(_sourceKeyForSession(session)) === 'cron' ? 'cron' : 'cli';
+  return rawOrigin === 'cron' ? 'cron' : 'cli';
 }
 
 function _isCliSession(session) {
@@ -6095,6 +6097,25 @@ function renderSessionListFromCache(){
     note.appendChild(retry);
     list.appendChild(note);
   }
+  const sessionSearchInput=$('sessionSearch');
+  const sessionSearchField=sessionSearchInput ? sessionSearchInput.closest('.session-search-field') : null;
+  let sessionSearchInputWrap=sessionSearchField ? sessionSearchField.querySelector('.session-search-input-wrap') : null;
+  if(sessionSearchField && !sessionSearchInputWrap){
+    sessionSearchInputWrap=document.createElement('div');
+    sessionSearchInputWrap.className='session-search-input-wrap';
+    const searchIcon=sessionSearchField.querySelector('.sidebar-search-icon');
+    const clearBtn=$('sessionSearchClear');
+    if(searchIcon) sessionSearchInputWrap.appendChild(searchIcon);
+    sessionSearchInputWrap.appendChild(sessionSearchInput);
+    if(clearBtn) sessionSearchInputWrap.appendChild(clearBtn);
+    sessionSearchField.prepend(sessionSearchInputWrap);
+  }
+  let sessionSearchFilterSlot=sessionSearchField ? sessionSearchField.querySelector('.session-search-filter-slot') : null;
+  if(sessionSearchField && !sessionSearchFilterSlot){
+    sessionSearchFilterSlot=document.createElement('div');
+    sessionSearchFilterSlot.className='session-search-filter-slot';
+    sessionSearchField.appendChild(sessionSearchFilterSlot);
+  }
   const filterBar=document.createElement('div');
   filterBar.className='session-filter-bar';
   const funnelBtn=document.createElement('button');
@@ -6187,7 +6208,8 @@ function renderSessionListFromCache(){
   });
   filterBar.appendChild(funnelBtn);
   filterBar.appendChild(popover);
-  list.appendChild(filterBar);
+  if(sessionSearchFilterSlot) sessionSearchFilterSlot.replaceChildren(filterBar);
+  else list.appendChild(filterBar);
   // Project filter bar — show when there are real projects OR there are
   // unassigned sessions (so the Unassigned chip has something to filter to).
   const hasUnprojected=profileFiltered.some(s=>!s.project_id);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4783,6 +4783,7 @@ function renderSessionListFromCache(){
       row.appendChild(cnt);
       popover.appendChild(row);
     }
+    popover.addEventListener('click',(e)=>{e.stopPropagation();});
     funnelBtn.addEventListener('click',(e)=>{
       e.stopPropagation();
       popover.hidden=!popover.hidden;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4649,6 +4649,55 @@ function _sessionAttentionState(s){
   return {kind,count,severity:String(attention.severity||''),label,title};
 }
 
+function _sidebarRowHasVisibleMessages(s, activeSidForSidebar){
+  return (s.message_count||0)>0 ||
+    _sessionAttentionState(s) ||
+    _isSessionEffectivelyStreaming(s) ||
+    !!s.active_stream_id ||
+    !!s.pending_user_message ||
+    (activeSidForSidebar&&s.session_id===activeSidForSidebar) ||
+    (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0);
+}
+
+function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
+  let webuiSessionCount=0;
+  let cliSessionCount=0;
+  const visibleRows=[];
+  for(const s of allMatched){
+    if(!_sidebarRowHasVisibleMessages(s, activeSidForSidebar)) continue;
+    visibleRows.push(s);
+    if(_isCliSession(s)) cliSessionCount++;
+    else webuiSessionCount++;
+  }
+  const sourceFiltered=[];
+  const profileFiltered=[];
+  const sessionsRaw=[];
+  let archivedCount=0;
+  for(const s of visibleRows){
+    const origin=_isCliSession(s)?'cli':'webui';
+    if(!_activeOriginFilters.has(origin)) continue;
+    sourceFiltered.push(s);
+    if(s.default_hidden&&!(_activeProject&&_activeProject!==NO_PROJECT_FILTER&&s.project_id===_activeProject)) continue;
+    profileFiltered.push(s);
+    if(_activeProject===NO_PROJECT_FILTER){
+      if(s.project_id) continue;
+    } else if(_activeProject){
+      if(s.project_id!==_activeProject) continue;
+    }
+    if(s.archived) archivedCount++;
+    if(!_showArchived&&s.archived) continue;
+    sessionsRaw.push(s);
+  }
+  return {
+    webuiSessionCount,
+    cliSessionCount,
+    sourceFiltered,
+    profileFiltered,
+    sessionsRaw,
+    archivedCount,
+  };
+}
+
 
 function renderSessionListFromCache(){
   // Don't re-render while user is actively renaming a session (would destroy the input)
@@ -4672,44 +4721,14 @@ function renderSessionListFromCache(){
   // session id into another conversation, that content hit should still appear.
   const searchMatches=_sessionSearchMergeMatches(sidebarRows,searchQueryRaw,_contentSearchResults);
   const allMatched=_ensureActiveSessionRowPresent(searchMatches,sidebarRows);
-  // Keep inactive ephemeral 0-message sessions out of the sidebar — they only
-  // become real once the first message is sent. The server already filters them.
-  // Exception: the active freshly-created chat is injected above so it remains
-  // visible/selected until the user sends the first turn or switches away.
-  const withMessages=allMatched.filter(s=>
-    (s.message_count||0)>0 ||
-    _sessionAttentionState(s) ||
-    _isSessionEffectivelyStreaming(s) ||
-    !!s.active_stream_id ||
-    !!s.pending_user_message ||
-    (activeSidForSidebar&&s.session_id===activeSidForSidebar) ||
-    (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0)
-  );
-  const webuiSessionCount = withMessages.filter(s=>!_isCliSession(s)).length;
-  const cliSessionCount = withMessages.filter(s=>_isCliSession(s)).length;
-  const sourceFiltered = withMessages.filter(s => {
-    const origin = _isCliSession(s) ? 'cli' : 'webui';
-    return _activeOriginFilters.has(origin);
-  });
-  // The server is authoritative for profile scoping (#1611): it filters by
-  // active profile when no query param is set, and returns the aggregate when
-  // we send ?all_profiles=1. The renamed-root cross-alias (a row tagged
-  // 'default' matching active 'kinni' when kinni.is_default) lives server-side
-  // in _profiles_match, and a strict-equality client filter would reject those
-  // rows incorrectly. So we trust the wire data and skip the redundant client
-  // filter entirely.
-  const profileFiltered=sourceFiltered.filter(s=>
-    !s.default_hidden||(_activeProject&&_activeProject!==NO_PROJECT_FILTER&&s.project_id===_activeProject)
-  );
-  // Filter by active project. NO_PROJECT_FILTER sentinel asks for sessions
-  // with no project_id; otherwise filter to the matching project_id, or
-  // pass through when no filter is active.
-  const projectFiltered=
-    _activeProject===NO_PROJECT_FILTER
-      ?profileFiltered.filter(s=>!s.project_id)
-      :(_activeProject?profileFiltered.filter(s=>s.project_id===_activeProject):profileFiltered);
-  // Filter archived unless toggle is on
-  const sessionsRaw=_showArchived?projectFiltered:projectFiltered.filter(s=>!s.archived);
+  const {
+    webuiSessionCount,
+    cliSessionCount,
+    sourceFiltered,
+    profileFiltered,
+    sessionsRaw,
+    archivedCount,
+  }=_partitionSidebarSessionRows(allMatched, activeSidForSidebar);
   const sessions=_attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw);
   _syncSidebarExpansionForActiveSession(sessions, activeSidForSidebar);
   const list=$('sessionList');

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -716,8 +716,6 @@ async function newSession(flash, options={}){
     }
     const data=await api('/api/session/new',{method:'POST',body:JSON.stringify(reqBody)});
     S.session=data.session;S.messages=data.session.messages||[];
-    if(_sessionSourceFilter==='cli') _sessionSourceFilter='webui';
-    if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
     S.lastUsage={...(data.session.last_usage||{})};
     if(!(options&&options.worktree)) _rememberNewChatDraftSession(S.session);
     if(flash)S.session._flash=true;
@@ -1345,26 +1343,29 @@ function _isCliSession(session) {
   return session.is_cli_session === true;
 }
 
-function _sessionSourceLabel(filter, count) {
-  const n = Number(count) || 0;
-  return filter === 'cli' ? `CLI sessions (${n})` : `WebUI sessions (${n})`;
-}
-
-function _setSessionSourceFilter(filter) {
-  const next = filter === 'cli' ? 'cli' : 'webui';
-  if (_sessionSourceFilter === next) return;
-  _sessionSourceFilter = next;
+function _toggleOriginFilter(origin) {
+  if (origin === 'webui') return;
+  if (_activeOriginFilters.has(origin)) {
+    _activeOriginFilters.delete(origin);
+  } else {
+    _activeOriginFilters.add(origin);
+  }
   _activeProject = null;
   _selectedSessions.clear();
   _sessionSelectMode = false;
-  try { localStorage.setItem('hermes-session-source-filter', next); } catch (_e) {}
+  try { localStorage.setItem('hermes-origin-filters', JSON.stringify([..._activeOriginFilters])); } catch (_e) {}
   renderSessionListFromCache();
 }
 
-function _restoreSessionSourceFilter() {
+function _restoreOriginFilters() {
   try {
-    const raw = localStorage.getItem('hermes-session-source-filter');
-    if (raw === 'cli' || raw === 'webui') _sessionSourceFilter = raw;
+    const raw = localStorage.getItem('hermes-origin-filters');
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        _activeOriginFilters = new Set(['webui', ...parsed.filter(v => typeof v === 'string')]);
+      }
+    }
   } catch (_e) {}
 }
 
@@ -2441,8 +2442,8 @@ const NO_PROJECT_FILTER = '__none__';
 let _activeProject = null;  // project_id filter (null = show all, NO_PROJECT_FILTER = unassigned only)
 let _showAllProfiles = false;  // false = filter to active profile only
 let _otherProfileCount = 0;       // count of sessions from other profiles (server-reported)
-let _sessionSourceFilter = 'webui';  // 'webui' keeps WebUI chats separate from read-only CLI sessions
-_restoreSessionSourceFilter();
+let _activeOriginFilters = new Set(['webui']);  // always includes 'webui'; user may add 'cli'
+_restoreOriginFilters();
 let _sessionActionMenu = null;
 let _sessionActionAnchor = null;
 let _sessionActionSessionId = null;
@@ -4633,15 +4634,7 @@ function _resyncSessionVirtualWindowAfterRender(list, expectedScrollTop, virtual
   });
 }
 
-// Top-level so BOTH the sidebar visibility predicate (_sidebarRowHasVisibleMessages,
-// reached via renderSessionListFromCache -> _partitionSidebarSessionRows) and the
-// per-row renderer (_renderOneSession, nested in renderSessionListFromCache) can call
-// it. It was previously declared INSIDE renderSessionListFromCache and relied on
-// function hoisting — but hoisting is scoped to the enclosing function, so the
-// top-level _sidebarRowHasVisibleMessages threw "ReferenceError: _sessionAttentionState
-// is not defined" on every cache render, crashing the sidebar (#3696, regressed in
-// #3672 when _sidebarRowHasVisibleMessages was extracted to top level). Pure function
-// (only its arg `s` plus the i18n global `t`), so hoisting it is safe.
+// Sidebar-attention helper used by render paths and row rendering.
 function _sessionAttentionState(s){
   const attention=s&&s.attention&&typeof s.attention==='object'?s.attention:null;
   if(!attention||!attention.kind||!Number.isFinite(Number(attention.count))||Number(attention.count)<=0)return null;
@@ -4656,54 +4649,6 @@ function _sessionAttentionState(s){
   return {kind,count,severity:String(attention.severity||''),label,title};
 }
 
-function _sidebarRowHasVisibleMessages(s, activeSidForSidebar){
-  return (s.message_count||0)>0 ||
-    _sessionAttentionState(s) ||
-    _isSessionEffectivelyStreaming(s) ||
-    !!s.active_stream_id ||
-    !!s.pending_user_message ||
-    (activeSidForSidebar&&s.session_id===activeSidForSidebar) ||
-    (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0);
-}
-
-function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
-  let webuiSessionCount=0;
-  let cliSessionCount=0;
-  for(const s of allMatched){
-    if(!_sidebarRowHasVisibleMessages(s, activeSidForSidebar)) continue;
-    if(_isCliSession(s)) cliSessionCount++;
-    else webuiSessionCount++;
-  }
-  if(_sessionSourceFilter==='cli' && !window._showCliSessions && cliSessionCount===0){
-    _sessionSourceFilter='webui';
-  }
-  const showCliOnly=_sessionSourceFilter==='cli';
-  const profileFiltered=[];
-  const sessionsRaw=[];
-  let archivedCount=0;
-  for(const s of allMatched){
-    if(!_sidebarRowHasVisibleMessages(s, activeSidForSidebar)) continue;
-    const isCli=_isCliSession(s);
-    if(showCliOnly ? !isCli : isCli) continue;
-    if(s.default_hidden&&!(_activeProject&&_activeProject!==NO_PROJECT_FILTER&&s.project_id===_activeProject)) continue;
-    profileFiltered.push(s);
-    if(_activeProject===NO_PROJECT_FILTER){
-      if(s.project_id) continue;
-    } else if(_activeProject){
-      if(s.project_id!==_activeProject) continue;
-    }
-    if(s.archived) archivedCount++;
-    if(!_showArchived&&s.archived) continue;
-    sessionsRaw.push(s);
-  }
-  return {
-    webuiSessionCount,
-    cliSessionCount,
-    profileFiltered,
-    sessionsRaw,
-    archivedCount,
-  };
-}
 
 function renderSessionListFromCache(){
   // Don't re-render while user is actively renaming a session (would destroy the input)
@@ -4727,13 +4672,44 @@ function renderSessionListFromCache(){
   // session id into another conversation, that content hit should still appear.
   const searchMatches=_sessionSearchMergeMatches(sidebarRows,searchQueryRaw,_contentSearchResults);
   const allMatched=_ensureActiveSessionRowPresent(searchMatches,sidebarRows);
-  const {
-    webuiSessionCount,
-    cliSessionCount,
-    profileFiltered,
-    sessionsRaw,
-    archivedCount,
-  }=_partitionSidebarSessionRows(allMatched, activeSidForSidebar);
+  // Keep inactive ephemeral 0-message sessions out of the sidebar — they only
+  // become real once the first message is sent. The server already filters them.
+  // Exception: the active freshly-created chat is injected above so it remains
+  // visible/selected until the user sends the first turn or switches away.
+  const withMessages=allMatched.filter(s=>
+    (s.message_count||0)>0 ||
+    _sessionAttentionState(s) ||
+    _isSessionEffectivelyStreaming(s) ||
+    !!s.active_stream_id ||
+    !!s.pending_user_message ||
+    (activeSidForSidebar&&s.session_id===activeSidForSidebar) ||
+    (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0)
+  );
+  const webuiSessionCount = withMessages.filter(s=>!_isCliSession(s)).length;
+  const cliSessionCount = withMessages.filter(s=>_isCliSession(s)).length;
+  const sourceFiltered = withMessages.filter(s => {
+    const origin = _isCliSession(s) ? 'cli' : 'webui';
+    return _activeOriginFilters.has(origin);
+  });
+  // The server is authoritative for profile scoping (#1611): it filters by
+  // active profile when no query param is set, and returns the aggregate when
+  // we send ?all_profiles=1. The renamed-root cross-alias (a row tagged
+  // 'default' matching active 'kinni' when kinni.is_default) lives server-side
+  // in _profiles_match, and a strict-equality client filter would reject those
+  // rows incorrectly. So we trust the wire data and skip the redundant client
+  // filter entirely.
+  const profileFiltered=sourceFiltered.filter(s=>
+    !s.default_hidden||(_activeProject&&_activeProject!==NO_PROJECT_FILTER&&s.project_id===_activeProject)
+  );
+  // Filter by active project. NO_PROJECT_FILTER sentinel asks for sessions
+  // with no project_id; otherwise filter to the matching project_id, or
+  // pass through when no filter is active.
+  const projectFiltered=
+    _activeProject===NO_PROJECT_FILTER
+      ?profileFiltered.filter(s=>!s.project_id)
+      :(_activeProject?profileFiltered.filter(s=>s.project_id===_activeProject):profileFiltered);
+  // Filter archived unless toggle is on
+  const sessionsRaw=_showArchived?projectFiltered:projectFiltered.filter(s=>!s.archived);
   const sessions=_attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw);
   _syncSidebarExpansionForActiveSession(sessions, activeSidForSidebar);
   const list=$('sessionList');
@@ -4766,19 +4742,57 @@ function renderSessionListFromCache(){
   if(_sessionSelectMode&&_selectedSessions.size>0){batchBar.style.display='flex';_renderBatchActionBar();}
   else{batchBar.style.display='none';}
   if(window._showCliSessions || cliSessionCount>0){
-    const sourceTabs=document.createElement('div');
-    sourceTabs.className='session-source-tabs';
-    for(const filter of ['webui','cli']){
-      const count=filter==='cli'?cliSessionCount:webuiSessionCount;
-      const btn=document.createElement('button');
-      btn.type='button';
-      btn.className='session-source-tab'+(_sessionSourceFilter===filter?' active':'');
-      btn.textContent=_sessionSourceLabel(filter,count);
-      btn.setAttribute('aria-pressed', _sessionSourceFilter===filter?'true':'false');
-      btn.onclick=()=>_setSessionSourceFilter(filter);
-      sourceTabs.appendChild(btn);
+    const filterBar=document.createElement('div');
+    filterBar.className='session-filter-bar';
+    const funnelBtn=document.createElement('button');
+    funnelBtn.type='button';
+    funnelBtn.className='session-filter-funnel';
+    funnelBtn.title='Filter by origin';
+    funnelBtn.innerHTML='<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>';
+    const activeCount=_activeOriginFilters.size-((_activeOriginFilters.has('webui'))?1:0);
+    if(activeCount>0){
+      const badge=document.createElement('span');
+      badge.className='session-filter-badge';
+      badge.textContent=String(activeCount);
+      funnelBtn.appendChild(badge);
     }
-    list.appendChild(sourceTabs);
+    const popover=document.createElement('div');
+    popover.className='session-origin-popover';
+    popover.hidden=true;
+    const origins=[
+      {id:'webui',label:'WebUI',count:webuiSessionCount,locked:true},
+      {id:'cli',label:'CLI',count:cliSessionCount,locked:false},
+    ];
+    for(const o of origins){
+      const row=document.createElement('label');
+      row.className='session-origin-row';
+      const cb=document.createElement('input');
+      cb.type='checkbox';
+      cb.checked=_activeOriginFilters.has(o.id);
+      cb.disabled=!!o.locked;
+      cb.className='session-origin-checkbox';
+      cb.addEventListener('change',()=>_toggleOriginFilter(o.id));
+      const lbl=document.createElement('span');
+      lbl.className='session-origin-label';
+      lbl.textContent=o.label;
+      const cnt=document.createElement('span');
+      cnt.className='session-origin-count';
+      cnt.textContent=String(o.count);
+      row.appendChild(cb);
+      row.appendChild(lbl);
+      row.appendChild(cnt);
+      popover.appendChild(row);
+    }
+    funnelBtn.addEventListener('click',(e)=>{
+      e.stopPropagation();
+      popover.hidden=!popover.hidden;
+      if(!popover.hidden){
+        document.addEventListener('click',()=>{popover.hidden=true;},{once:true});
+      }
+    });
+    filterBar.appendChild(funnelBtn);
+    filterBar.appendChild(popover);
+    list.appendChild(filterBar);
   }
   // Project filter bar — show when there are real projects OR there are
   // unassigned sessions (so the Unassigned chip has something to filter to).
@@ -4906,7 +4920,7 @@ function renderSessionListFromCache(){
     list.appendChild(toggle);
   }
   // Empty state for active project filter
-  if(_sessionSourceFilter==='cli'&&sessions.length===0){
+  if(_activeOriginFilters.has('cli')&&cliSessionCount===0&&sourceFiltered.length===0){
     const empty=document.createElement('div');
     empty.className='session-empty-note';
     empty.textContent=window._showCliSessions?'No CLI sessions found.':'Enable Show agent sessions in Settings to list CLI sessions here.';

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -898,6 +898,7 @@ async function newSession(flash, options={}){
     }
     if(newModelState&&newModelState.model){
       reqBody.model=newModelState.model;
+      const _explicitModelProvider=newModelState.model_provider;
       // Fill model_provider for bare slugs to skip cold catalog rebuilds, but leave cross-provider model names on the server slow path.
       const _bareModel=!/[/]/.test(newModelState.model)&&!newModelState.model.startsWith('@');
       // Second guard (#3410-followup): even a bare model can carry a known
@@ -917,7 +918,7 @@ async function newSession(flash, options={}){
         if(s.startsWith('google')||s.startsWith('gemini'))return 'google';return s;};
       const _familyMismatch=_familyProvider&&_fallbackProvider&&_normProv(_fallbackProvider)!==_familyProvider;
       const _fallbackIsNamedCustom=String(_fallbackProvider||'').toLowerCase().startsWith('custom:');
-      reqBody.model_provider=newModelState.model_provider
+      reqBody.model_provider=_explicitModelProvider||newModelState.model_provider
         ||((_bareModel&&!_familyMismatch&&!_fallbackIsNamedCustom)?(_fallbackProvider||null):null)
         ||null;
     }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -6028,7 +6028,7 @@ function renderSessionListFromCache(){
     list.appendChild(toggle);
   }
   // Empty state for active project filter
-  if(_activeOriginFilters.has('cli')&&cliSessionCount===0&&sourceFiltered.length===0){
+  if(_activeOriginFilters.has('cli')&&cliSessionCount===0&&(webuiSessionCount===0||!_activeOriginFilters.has('webui'))){
     const empty=document.createElement('div');
     empty.className='session-empty-note';
     empty.textContent=window._showCliSessions?'No CLI sessions found.':'Enable Show agent sessions in Settings to list CLI sessions here.';

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4940,7 +4940,7 @@ function renderSessionListFromCache(){
     list.appendChild(toggle);
   }
   // Empty state for active project filter
-  if(_activeOriginFilters.has('cli')&&cliSessionCount===0&&sourceFiltered.length===0){
+  if(_activeOriginFilters.has('cli')&&cliSessionCount===0&&(webuiSessionCount===0||!_activeOriginFilters.has('webui'))){
     const empty=document.createElement('div');
     empty.className='session-empty-note';
     empty.textContent=window._showCliSessions?'No CLI sessions found.':'Enable Show agent sessions in Settings to list CLI sessions here.';

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1799,6 +1799,7 @@ function _toggleOriginFilter(origin) {
     _activeOriginFilters.add(normalizedOrigin);
   }
   _originFiltersHydrated = true;
+  _originFiltersLoadedFromStorage = true;
   _activeProject = null;
   _selectedSessions.clear();
   _sessionSelectMode = false;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -899,7 +899,7 @@ async function newSession(flash, options={}){
     if(newModelState&&newModelState.model){
       reqBody.model=newModelState.model;
       const _explicitModelProvider=newModelState.model_provider;
-      // Fill model_provider for bare slugs to skip cold catalog rebuilds, but leave cross-provider model names on the server slow path.
+      // #2518 follow-up: fill model_provider for bare slugs to skip cold catalog rebuilds, but leave cross-provider model names on the server slow path.
       const _bareModel=!/[/]/.test(newModelState.model)&&!newModelState.model.startsWith('@');
       // Second guard (#3410-followup): even a bare model can carry a known
       // family prefix (gpt→openai, claude→anthropic, gemini→google). If that

--- a/static/style.css
+++ b/static/style.css
@@ -4923,7 +4923,19 @@ main.main > #mainPlugin{display:none;}
 .mermaid-rendered{background:transparent;padding:8px 0;}
 .mermaid-rendered svg{max-width:100%;height:auto;cursor:zoom-in;}
 
-/* ── Session projects ── */
+/* ── Session origin filter (funnel popover) ── */
+.session-filter-bar{display:flex;align-items:center;padding:4px 12px;position:relative;}
+.session-filter-funnel{background:none;border:1px solid var(--border);border-radius:6px;padding:4px 8px;cursor:pointer;color:var(--muted);display:inline-flex;align-items:center;gap:4px;font-size:12px;position:relative;}
+.session-filter-funnel:hover{color:var(--text);border-color:var(--text);}
+.session-filter-badge{background:var(--accent);color:#fff;border-radius:8px;padding:0 5px;font-size:10px;line-height:16px;margin-left:4px;}
+.session-origin-popover{position:absolute;top:100%;left:12px;z-index:200;background:var(--sidebar-bg);border:1px solid var(--border);border-radius:8px;padding:8px 0;min-width:180px;box-shadow:0 4px 12px rgba(0,0,0,.15);}
+.session-origin-popover[hidden]{display:none;}
+.session-origin-row{display:flex;align-items:center;gap:8px;padding:6px 12px;cursor:pointer;font-size:13px;color:var(--text);}
+.session-origin-row:hover{background:var(--hover-bg);}
+.session-origin-checkbox{width:14px;height:14px;accent-color:var(--accent);}
+.session-origin-label{flex:1;}
+.session-origin-count{color:var(--muted);font-size:11px;}
+/* deprecated: session-source-tabs replaced by session-filter-bar; kept for cache-busted clients */
 .session-source-tabs{display:flex;gap:4px;padding:4px 10px 8px;flex-shrink:0;}
 .session-source-tab{flex:1;min-width:0;border:1px solid var(--border2);border-radius:10px;background:var(--input-bg);color:var(--muted);font-size:10px;font-weight:700;line-height:1.2;padding:5px 6px;cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;transition:background .15s,color .15s,border-color .15s;}
 .session-source-tab:hover{background:rgba(255,255,255,.08);color:var(--text);}

--- a/static/style.css
+++ b/static/style.css
@@ -1023,9 +1023,12 @@
   .new-chat-btn:hover{background:var(--accent-bg-strong);border-color:var(--accent);}
   .session-list{flex:1;overflow-y:auto;padding:0 8px 8px;min-height:0;overscroll-behavior-y:contain;touch-action:pan-y;overflow-anchor:none;}
   .sidebar-search{position:relative;padding:8px 12px;flex-shrink:0;}
-  .session-search-field{position:relative;display:flex;align-items:center;width:100%;}
+  .session-search-field{position:relative;display:flex;align-items:center;gap:8px;width:100%;}
+  .session-search-input-wrap{position:relative;display:flex;align-items:center;flex:1;min-width:0;}
+  .session-search-filter-slot{position:relative;display:flex;align-items:center;flex-shrink:0;}
+  .session-search-filter-slot:empty{display:none;}
   .sidebar-search input{width:100%;background:var(--bg);border:1px solid var(--border);border-radius:8px;color:var(--text);padding:7px 10px 7px 32px;font-size:13px;outline:none;transition:border-color .15s,box-shadow .15s,background .15s;box-sizing:border-box;}
-  .session-search input{padding-right:34px;}
+  .session-search input{padding-right:34px;min-width:0;}
   .sidebar-search input:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-bg);}
   .sidebar-search input::placeholder{color:var(--muted);opacity:.7;}
   .sidebar-search-icon{position:absolute;left:22px;top:50%;transform:translateY(-50%);width:14px;height:14px;color:var(--muted);opacity:.7;pointer-events:none;}
@@ -4924,17 +4927,19 @@ main.main > #mainPlugin{display:none;}
 .mermaid-rendered svg{max-width:100%;height:auto;cursor:zoom-in;}
 
 /* ── Session origin filter (funnel popover) ── */
-.session-filter-bar{display:flex;align-items:center;padding:4px 12px;position:relative;}
-.session-filter-funnel{background:none;border:1px solid var(--border);border-radius:6px;padding:4px 8px;cursor:pointer;color:var(--muted);display:inline-flex;align-items:center;gap:4px;font-size:12px;position:relative;}
-.session-filter-funnel:hover{color:var(--text);border-color:var(--text);}
-.session-filter-badge{background:var(--accent);color:#fff;border-radius:8px;padding:0 5px;font-size:10px;line-height:16px;margin-left:4px;}
-.session-origin-popover{position:absolute;top:100%;left:12px;z-index:200;background:var(--sidebar-bg);border:1px solid var(--border);border-radius:8px;padding:8px 0;min-width:180px;box-shadow:0 4px 12px rgba(0,0,0,.15);}
-.session-origin-popover[hidden]{display:none;}
-.session-origin-row{display:flex;align-items:center;gap:8px;padding:6px 12px;cursor:pointer;font-size:13px;color:var(--text);}
-.session-origin-row:hover{background:var(--hover-bg);}
-.session-origin-checkbox{width:14px;height:14px;accent-color:var(--accent);}
-.session-origin-label{flex:1;}
-.session-origin-count{color:var(--muted);font-size:11px;}
+  .session-filter-bar{display:flex;align-items:center;position:relative;flex-shrink:0;}
+  .session-filter-funnel{background:var(--surface);border:1px solid var(--border2);border-radius:8px;width:30px;height:30px;cursor:pointer;color:var(--muted);display:inline-flex;align-items:center;justify-content:center;padding:0;position:relative;flex-shrink:0;transition:background .15s,color .15s,border-color .15s;}
+  .session-filter-funnel:hover,.session-filter-funnel:focus-visible{background:var(--hover-bg);color:var(--text);border-color:var(--border);}
+  .session-filter-badge{position:absolute;top:-4px;right:-4px;min-width:16px;height:16px;padding:0 4px;background:var(--accent);color:#fff;border-radius:999px;font-size:10px;line-height:16px;text-align:center;box-shadow:0 0 0 2px var(--sidebar-bg);}
+  .session-origin-popover{position:absolute;top:calc(100% + 6px);right:0;left:auto;z-index:200;background:var(--surface);border:1px solid var(--border2);border-radius:10px;padding:6px 0;min-width:248px;max-width:min(320px,calc(100vw - 32px));box-shadow:0 8px 24px rgba(0,0,0,.32);}
+  .session-origin-popover[hidden]{display:none;}
+  .session-origin-heading{padding:10px 14px 6px;font-size:11px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--muted);}
+  .session-origin-heading:not(:first-child){margin-top:4px;padding-top:12px;border-top:1px solid var(--border2);}
+  .session-origin-row{display:grid;grid-template-columns:16px minmax(0,1fr) auto;align-items:center;column-gap:10px;padding:7px 14px;cursor:pointer;font-size:13px;line-height:1.35;color:var(--text);}
+  .session-origin-row:hover{background:var(--hover-bg);}
+  .session-origin-checkbox{width:14px;height:14px;accent-color:var(--accent);}
+  .session-origin-label{min-width:0;text-align:left;}
+  .session-origin-count{color:var(--muted);font-size:11px;text-align:right;font-variant-numeric:tabular-nums;}
 /* deprecated: session-source-tabs replaced by session-filter-bar; kept for cache-busted clients */
 .session-source-tabs{display:flex;gap:4px;padding:4px 10px 8px;flex-shrink:0;}
 .session-source-tab{flex:1;min-width:0;border:1px solid var(--border2);border-radius:10px;background:var(--input-bg);color:var(--muted);font-size:10px;font-weight:700;line-height:1.2;padding:5px 6px;cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;transition:background .15s,color .15s,border-color .15s;}

--- a/static/style.css
+++ b/static/style.css
@@ -4148,7 +4148,19 @@ main.main > #mainPlugin{display:none;}
 .mermaid-rendered{background:transparent;padding:8px 0;}
 .mermaid-rendered svg{max-width:100%;height:auto;}
 
-/* ── Session projects ── */
+/* ── Session origin filter (funnel popover) ── */
+.session-filter-bar{display:flex;align-items:center;padding:4px 12px;position:relative;}
+.session-filter-funnel{background:none;border:1px solid var(--border);border-radius:6px;padding:4px 8px;cursor:pointer;color:var(--muted);display:inline-flex;align-items:center;gap:4px;font-size:12px;position:relative;}
+.session-filter-funnel:hover{color:var(--text);border-color:var(--text);}
+.session-filter-badge{background:var(--accent);color:#fff;border-radius:8px;padding:0 5px;font-size:10px;line-height:16px;margin-left:4px;}
+.session-origin-popover{position:absolute;top:100%;left:12px;z-index:200;background:var(--sidebar-bg);border:1px solid var(--border);border-radius:8px;padding:8px 0;min-width:180px;box-shadow:0 4px 12px rgba(0,0,0,.15);}
+.session-origin-popover[hidden]{display:none;}
+.session-origin-row{display:flex;align-items:center;gap:8px;padding:6px 12px;cursor:pointer;font-size:13px;color:var(--text);}
+.session-origin-row:hover{background:var(--hover-bg);}
+.session-origin-checkbox{width:14px;height:14px;accent-color:var(--accent);}
+.session-origin-label{flex:1;}
+.session-origin-count{color:var(--muted);font-size:11px;}
+/* deprecated: session-source-tabs replaced by session-filter-bar; kept for cache-busted clients */
 .session-source-tabs{display:flex;gap:4px;padding:4px 10px 8px;flex-shrink:0;}
 .session-source-tab{flex:1;min-width:0;border:1px solid var(--border2);border-radius:10px;background:var(--input-bg);color:var(--muted);font-size:10px;font-weight:700;line-height:1.2;padding:5px 6px;cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;transition:background .15s,color .15s,border-color .15s;}
 .session-source-tab:hover{background:rgba(255,255,255,.08);color:var(--text);}

--- a/tests/test_1003_preferences_autosave.py
+++ b/tests/test_1003_preferences_autosave.py
@@ -40,8 +40,6 @@ PREFERENCE_FIELDS_AUTOSAVE = [
     ("settingsShowTokenUsage", "show_token_usage"),
     ("settingsShowConversationOutline", "show_conversation_outline"),
     ("settingsShowTps", "show_tps"),
-    ("settingsShowCliSessions", "show_cli_sessions"),
-    ("settingsShowPreviousMessagingSessions", "show_previous_messaging_sessions"),
     ("settingsSyncInsights", "sync_to_insights"),
     ("settingsCheckUpdates", "check_for_updates"),
     ("settingsIgnoreAgentUpdates", "ignore_agent_updates"),
@@ -179,3 +177,13 @@ def test_phase1_appearance_autosave_still_passes():
     assert "function _autosaveAppearanceSettings" in PANELS_JS
     assert "function _scheduleAppearanceAutosave" in PANELS_JS
     assert 'id="settingsAppearanceAutosaveStatus"' in INDEX_HTML
+
+
+def test_sidebar_filter_fields_are_not_preferences_autosave_fields():
+    for token in [
+        "settingsShowCliSessions",
+        "settingsShowCronSessions",
+        "settingsShowPreviousMessagingSessions",
+    ]:
+        assert token not in INDEX_HTML
+        assert token not in PANELS_JS

--- a/tests/test_active_empty_session_sidebar.py
+++ b/tests/test_active_empty_session_sidebar.py
@@ -16,9 +16,9 @@ def test_active_empty_session_is_injected_into_sidebar_rows():
     assert "rows.some(s=>s&&s.session_id===sid)" in helper
 
 
-def test_new_session_switches_sidebar_back_to_webui_source():
-    new_session = SESSIONS_JS[SESSIONS_JS.index("async function newSession"):SESSIONS_JS.index("async function loadSession")]
-    assert "if(_sessionSourceFilter==='cli') _sessionSourceFilter='webui';" in new_session
+def test_new_session_uses_set_based_origin_filter():
+    # _activeOriginFilters always contains 'webui'; no reset needed on new session
+    assert "_activeOriginFilters = new Set(['webui'])" in SESSIONS_JS
 
 
 def test_sidebar_search_uses_active_ephemeral_rows_before_filtering():

--- a/tests/test_gateway_status_agent_health.py
+++ b/tests/test_gateway_status_agent_health.py
@@ -255,6 +255,52 @@ def test_gateway_status_includes_gateway_health_metadata(monkeypatch):
     }
 
 
+def test_gateway_status_unions_runtime_config_and_identity_platforms(monkeypatch):
+    from api import routes
+
+    monkeypatch.setattr(
+        routes,
+        "build_agent_health_payload",
+        lambda: {"alive": True, "checked_at": "2026-05-06T12:00:00+00:00", "details": {}},
+    )
+    monkeypatch.setattr(
+        routes,
+        "_load_gateway_session_identity_map",
+        lambda: {"sess_a": {"raw_source": "telegram", "platform": "telegram"}},
+    )
+    monkeypatch.setattr(routes, "_load_gateway_runtime_platform_names", lambda: {"discord"})
+    monkeypatch.setattr(routes, "_load_gateway_configured_platform_names", lambda: {"slack", "discord"})
+
+    handler = _FakeHandler()
+    parsed = urlparse("http://example.com/api/gateway/status")
+    routes.handle_get(handler, parsed)
+    result = handler.get_json()
+
+    assert {entry["name"] for entry in result["platforms"]} == {"telegram", "discord", "slack"}
+
+
+def test_gateway_status_marks_configured_when_platforms_exist_from_config(monkeypatch):
+    from api import routes
+
+    monkeypatch.setattr(
+        routes,
+        "build_agent_health_payload",
+        lambda: {"alive": None, "checked_at": "2026-05-06T12:00:00+00:00", "details": {}},
+    )
+    monkeypatch.setattr(routes, "_load_gateway_session_identity_map", lambda: {})
+    monkeypatch.setattr(routes, "_load_gateway_runtime_platform_names", lambda: set())
+    monkeypatch.setattr(routes, "_load_gateway_configured_platform_names", lambda: {"slack"})
+
+    handler = _FakeHandler()
+    parsed = urlparse("http://example.com/api/gateway/status")
+    routes.handle_get(handler, parsed)
+    result = handler.get_json()
+
+    assert result["configured"] is True
+    assert result["running"] is False
+    assert result["platforms"] == [{"name": "slack", "label": "Slack"}]
+
+
 def test_gateway_status_last_active_empty_when_alive_and_no_sessions_path(monkeypatch):
     """Bonus: alive=true + identity_map={} → last_active is empty string.
     This guards the 'if running and sessions_path.exists()' guard from being

--- a/tests/test_issue2351_cli_session_source_filter.py
+++ b/tests/test_issue2351_cli_session_source_filter.py
@@ -20,7 +20,8 @@ def test_cli_filter_keeps_cli_rows_out_of_default_webui_list():
     src = SESSIONS_JS.read_text(encoding="utf-8")
     assert "let webuiSessionCount=0;" in src
     assert "let cliSessionCount=0;" in src
-    assert "if(_isCliSession(s)) cliSessionCount++;" in src
+    assert "const isCli=_isCliSession(s);" in src
+    assert "if(isCli) cliSessionCount++;" in src
     assert "else webuiSessionCount++;" in src
     assert "_activeOriginFilters.has(origin)" in src
     assert "if(_activeOriginFilters.has('cli')&&cliSessionCount===0&&(webuiSessionCount===0||!_activeOriginFilters.has('webui'))){" in src

--- a/tests/test_issue2351_cli_session_source_filter.py
+++ b/tests/test_issue2351_cli_session_source_filter.py
@@ -6,33 +6,27 @@ SESSIONS_JS = ROOT / "static" / "sessions.js"
 STYLE_CSS = ROOT / "static" / "style.css"
 
 
-def test_sidebar_has_separate_webui_and_cli_session_source_tabs():
+def test_sidebar_has_multi_select_origin_filter():
     src = SESSIONS_JS.read_text(encoding="utf-8")
-    assert "let _sessionSourceFilter = 'webui'" in src
-    assert "hermes-session-source-filter" in src
-    assert "session-source-tabs" in src
-    assert "WebUI sessions" in src
-    assert "CLI sessions" in src
-    assert "_sessionSourceFilter==='cli'" in src
+    assert "let _activeOriginFilters = new Set(['webui'])" in src
+    assert "hermes-origin-filters" in src
+    assert "session-filter-bar" in src
+    assert "session-origin-popover" in src
+    assert "_toggleOriginFilter" in src
+    assert "_restoreOriginFilters" in src
 
 
 def test_cli_filter_keeps_cli_rows_out_of_default_webui_list():
     src = SESSIONS_JS.read_text(encoding="utf-8")
-    assert "function _partitionSidebarSessionRows(allMatched, activeSidForSidebar)" in src
-    assert "cliSessionCount" in src
-    assert "const showCliOnly=_sessionSourceFilter==='cli';" in src
-    assert "const webuiProfileFiltered=[];" in src
-    assert "const cliProfileFiltered=[];" in src
-    assert "const webuiSessionsRaw=[];" in src
-    assert "const cliSessionsRaw=[];" in src
-    assert "profileFiltered: showCliOnly ? cliProfileFiltered : webuiProfileFiltered," in src
-    assert "sessionsRaw: showCliOnly ? cliSessionsRaw : webuiSessionsRaw," in src
+    assert "const webuiSessionCount = withMessages.filter(s=>!_isCliSession(s)).length" in src
+    assert "const cliSessionCount = withMessages.filter(s=>_isCliSession(s)).length" in src
+    assert "_activeOriginFilters.has(origin)" in src
 
 
-def test_session_source_tabs_have_dedicated_sidebar_styles():
+def test_session_origin_filter_has_dedicated_sidebar_styles():
     css = STYLE_CSS.read_text(encoding="utf-8")
-    assert ".session-source-tabs" in css
-    assert ".session-source-tab.active" in css
+    assert ".session-filter-bar" in css
+    assert ".session-origin-popover" in css
     assert ".session-empty-note" in css
 
 

--- a/tests/test_issue2351_cli_session_source_filter.py
+++ b/tests/test_issue2351_cli_session_source_filter.py
@@ -20,11 +20,13 @@ def test_cli_filter_keeps_cli_rows_out_of_default_webui_list():
     src = SESSIONS_JS.read_text(encoding="utf-8")
     assert "let webuiSessionCount=0;" in src
     assert "let cliSessionCount=0;" in src
-    assert "const isCli=_isCliSession(s);" in src
-    assert "if(isCli) cliSessionCount++;" in src
-    assert "else webuiSessionCount++;" in src
+    assert "const origin=_sidebarOriginIdForSession(s);" in src
+    assert "if(origin==='cli') cliSessionCount++;" in src
+    assert "else if(origin==='webui') webuiSessionCount++;" in src
+    assert "originCounts.set(origin, Number(originCounts.get(origin) || 0) + 1);" in src
     assert "_activeOriginFilters.has(origin)" in src
-    assert "if(_activeOriginFilters.has('cli')&&cliSessionCount===0&&(webuiSessionCount===0||!_activeOriginFilters.has('webui'))){" in src
+    assert "const selectedExternalOrigins=[..._activeOriginFilters].filter(origin=>origin!=='webui');" in src
+    assert "No sessions found for the selected origins." in src
 
 
 def test_session_origin_filter_has_dedicated_sidebar_styles():

--- a/tests/test_issue2351_cli_session_source_filter.py
+++ b/tests/test_issue2351_cli_session_source_filter.py
@@ -23,6 +23,7 @@ def test_cli_filter_keeps_cli_rows_out_of_default_webui_list():
     assert "if(_isCliSession(s)) cliSessionCount++;" in src
     assert "else webuiSessionCount++;" in src
     assert "_activeOriginFilters.has(origin)" in src
+    assert "if(_activeOriginFilters.has('cli')&&cliSessionCount===0&&(webuiSessionCount===0||!_activeOriginFilters.has('webui'))){" in src
 
 
 def test_session_origin_filter_has_dedicated_sidebar_styles():

--- a/tests/test_issue2351_cli_session_source_filter.py
+++ b/tests/test_issue2351_cli_session_source_filter.py
@@ -18,8 +18,10 @@ def test_sidebar_has_multi_select_origin_filter():
 
 def test_cli_filter_keeps_cli_rows_out_of_default_webui_list():
     src = SESSIONS_JS.read_text(encoding="utf-8")
-    assert "const webuiSessionCount = withMessages.filter(s=>!_isCliSession(s)).length" in src
-    assert "const cliSessionCount = withMessages.filter(s=>_isCliSession(s)).length" in src
+    assert "let webuiSessionCount=0;" in src
+    assert "let cliSessionCount=0;" in src
+    assert "if(_isCliSession(s)) cliSessionCount++;" in src
+    assert "else webuiSessionCount++;" in src
     assert "_activeOriginFilters.has(origin)" in src
 
 

--- a/tests/test_issue2351_cli_session_source_filter.py
+++ b/tests/test_issue2351_cli_session_source_filter.py
@@ -6,29 +6,27 @@ SESSIONS_JS = ROOT / "static" / "sessions.js"
 STYLE_CSS = ROOT / "static" / "style.css"
 
 
-def test_sidebar_has_separate_webui_and_cli_session_source_tabs():
+def test_sidebar_has_multi_select_origin_filter():
     src = SESSIONS_JS.read_text(encoding="utf-8")
-    assert "let _sessionSourceFilter = 'webui'" in src
-    assert "hermes-session-source-filter" in src
-    assert "session-source-tabs" in src
-    assert "WebUI sessions" in src
-    assert "CLI sessions" in src
-    assert "_sessionSourceFilter==='cli'" in src
+    assert "let _activeOriginFilters = new Set(['webui'])" in src
+    assert "hermes-origin-filters" in src
+    assert "session-filter-bar" in src
+    assert "session-origin-popover" in src
+    assert "_toggleOriginFilter" in src
+    assert "_restoreOriginFilters" in src
 
 
 def test_cli_filter_keeps_cli_rows_out_of_default_webui_list():
     src = SESSIONS_JS.read_text(encoding="utf-8")
-    assert "function _partitionSidebarSessionRows(allMatched, activeSidForSidebar)" in src
-    assert "webuiSessionCount" in src
-    assert "cliSessionCount" in src
-    assert "const showCliOnly=_sessionSourceFilter==='cli';" in src
-    assert "if(showCliOnly ? !isCli : isCli) continue;" in src
+    assert "const webuiSessionCount = withMessages.filter(s=>!_isCliSession(s)).length" in src
+    assert "const cliSessionCount = withMessages.filter(s=>_isCliSession(s)).length" in src
+    assert "_activeOriginFilters.has(origin)" in src
 
 
-def test_session_source_tabs_have_dedicated_sidebar_styles():
+def test_session_origin_filter_has_dedicated_sidebar_styles():
     css = STYLE_CSS.read_text(encoding="utf-8")
-    assert ".session-source-tabs" in css
-    assert ".session-source-tab.active" in css
+    assert ".session-filter-bar" in css
+    assert ".session-origin-popover" in css
     assert ".session-empty-note" in css
 
 

--- a/tests/test_issue2841_show_cron_sessions_toggle.py
+++ b/tests/test_issue2841_show_cron_sessions_toggle.py
@@ -61,8 +61,8 @@ def test_show_cron_sessions_kwarg_passthrough():
 
 def test_settings_show_cron_sessions_in_html():
     src = _read("static/index.html")
-    assert "settingsShowCronSessions" in src, (
-        "settingsShowCronSessions checkbox must appear in static/index.html"
+    assert "settingsShowCronSessions" not in src, (
+        "show_cron_sessions should no longer live in the Preferences panel"
     )
 
 
@@ -70,19 +70,27 @@ def test_settings_show_cron_sessions_in_html():
 
 def test_panels_save_wiring():
     src = _read("static/panels.js")
-    # Both save paths (autosave _preferencesPayloadFromUi + explicit saveSettings)
-    # must gate cron sessions on the CLI-sessions checkbox so neither can persist
-    # show_cron_sessions=true while show_cli_sessions=false (#3514).
-    assert "payload.show_cron_sessions=!!(showCliCb&&showCliCb.checked&&showCronCb.checked)" in src, (
-        "autosave wiring must gate show_cron_sessions on settingsShowCliSessions in static/panels.js"
-    )
-    assert "body.show_cron_sessions=showCliSessions&&showCronSessions" in src, (
-        "explicit saveSettings() must gate show_cron_sessions on showCliSessions in static/panels.js"
-    )
+    for token in [
+        "settingsShowCliSessions",
+        "settingsShowCronSessions",
+        "settingsShowPreviousMessagingSessions",
+    ]:
+        assert token not in src, (
+            "legacy sidebar filter settings should not remain in static/panels.js"
+        )
 
 
-def test_panels_load_wiring():
-    src = _read("static/panels.js")
-    assert "show_cron_sessions" in src, (
-        "load wiring for show_cron_sessions must appear in static/panels.js"
+def test_sidebar_filter_settings_persist_from_sessions_js():
+    src = _read("static/sessions.js")
+    assert "function _persistSidebarVisibilitySettings(next)" in src, (
+        "sidebar filter persistence should live in static/sessions.js"
+    )
+    assert "show_cli_sessions: true" in src, (
+        "sidebar filter persistence must keep non-WebUI sessions enabled"
+    )
+    assert "show_cron_sessions: true" in src, (
+        "sidebar filter persistence must keep cron sessions enabled"
+    )
+    assert "function _toggleSidebarPreviousMessagingSessions(enabled)" in src, (
+        "previous messaging visibility should be controlled from static/sessions.js"
     )

--- a/tests/test_issue3988_show_cli_sessions_default.py
+++ b/tests/test_issue3988_show_cli_sessions_default.py
@@ -163,13 +163,20 @@ def test_boot_settings_load_failure_fallback_defaults_true():
     )
 
 
-def test_settings_checkbox_renders_checked_by_default():
-    src = _read("static/panels.js")
-    assert "showCliCb.checked=settings.show_cli_sessions!==false" in src, (
-        "the show-CLI-sessions checkbox must default checked (!== false), matching "
-        "the True config default"
+def test_sidebar_visibility_default_true_moved_out_of_preferences_panel():
+    panels_src = _read("static/panels.js")
+    sessions_src = _read("static/sessions.js")
+    index_src = _read("static/index.html")
+    assert "settingsShowCliSessions" not in panels_src, (
+        "the duplicate show-CLI-sessions Settings checkbox should be removed after #3418"
     )
-    assert "showCliCb.checked=!!settings.show_cli_sessions" not in src, (
-        "panels.js must not use !!settings.show_cli_sessions for the checkbox — "
-        "that renders it unchecked by default, contradicting the config default"
+    assert 'id="settingsShowCliSessions"' not in index_src, (
+        "the Preferences panel should no longer render the legacy show-CLI-sessions toggle"
+    )
+    assert "show_cli_sessions: true" in sessions_src, (
+        "sidebar visibility persistence must still force show_cli_sessions on when "
+        "the filter popover saves its own visibility settings"
+    )
+    assert "function _ensureSidebarOriginSettingsInitialized()" in sessions_src, (
+        "sessions.js should initialize the moved sidebar visibility settings"
     )

--- a/tests/test_issue4766_sidebar_source_pushdown.py
+++ b/tests/test_issue4766_sidebar_source_pushdown.py
@@ -290,12 +290,16 @@ def test_origin_filter_toggle_updates_local_state_without_refetch():
     normalize_origin_fn = _extract_function(src, "_normalizeSidebarOriginId")
     persist_fn = _extract_function(src, "_persistOriginFilters")
     signature_fn = _extract_function(src, "_originFilterSignature")
+    capture_seed_fn = _extract_function(src, "_captureOriginFilterCronDefaultSeed")
+    include_default_fn = _extract_function(src, "_originFilterDefaultsInclude")
     ensure_fn = _extract_function(src, "_ensureOriginFilterDefaults")
     fn_toggle = _extract_function(src, "_toggleOriginFilter")
     script = f"""
     const renderCalls = [];
+    global.window = {{ _showCliSessions: true, _showCronSessions: false }};
     global._originFiltersHydrated = false;
     global._originFiltersLoadedFromStorage = false;
+    global._originFilterCronDefaultSeed = null;
     global._activeOriginFilters = new Set(['webui', 'cli']);
     global._activeProject = 'demo-project';
     global._selectedSessions = new Set(['first', 'second']);
@@ -312,6 +316,8 @@ global.localStorage = {{
     {normalize_origin_fn}
     {persist_fn}
     {signature_fn}
+    {capture_seed_fn}
+    {include_default_fn}
     {ensure_fn}
     {fn_toggle}
     _toggleOriginFilter('cli');
@@ -349,9 +355,11 @@ def test_origin_filter_defaults_expand_catalog_without_overriding_saved_choices(
     normalize_origin_fn = _extract_function(src, "_normalizeSidebarOriginId")
     persist_fn = _extract_function(src, "_persistOriginFilters")
     signature_fn = _extract_function(src, "_originFilterSignature")
+    capture_seed_fn = _extract_function(src, "_captureOriginFilterCronDefaultSeed")
+    include_default_fn = _extract_function(src, "_originFilterDefaultsInclude")
     ensure_fn = _extract_function(src, "_ensureOriginFilterDefaults")
     script = f"""
-    global.window = {{ _showCliSessions: true }};
+    global.window = {{ _showCliSessions: true, _showCronSessions: false }};
     global.localStorage = {{
       writes: [],
       setItem(key, value) {{
@@ -361,9 +369,12 @@ def test_origin_filter_defaults_expand_catalog_without_overriding_saved_choices(
     global._activeOriginFilters = new Set(['webui']);
     global._originFiltersHydrated = false;
     global._originFiltersLoadedFromStorage = false;
+    global._originFilterCronDefaultSeed = null;
     {normalize_origin_fn}
     {persist_fn}
     {signature_fn}
+    {capture_seed_fn}
+    {include_default_fn}
     {ensure_fn}
 const firstChanged = _ensureOriginFilterDefaults([
   {{ id: 'webui' }},

--- a/tests/test_issue4766_sidebar_source_pushdown.py
+++ b/tests/test_issue4766_sidebar_source_pushdown.py
@@ -1,4 +1,9 @@
-"""Regression coverage for issue #4766: `/api/sessions` filters by active sidebar source."""
+"""Regression coverage for issue #4766: `/api/sessions` still supports sidebar-source pushdown.
+
+The backend route still honors `sidebar_source` for narrow fetches such as
+`show_cli_sessions=false`, while the #3418 sidebar UI now filters origins
+client-side after loading the combined payload.
+"""
 
 import io
 import json
@@ -240,10 +245,10 @@ def test_frontend_sends_sidebar_source_param():
 
     assert "function _requestedSessionSidebarSource()" in src
     assert "function _sessionListQueryString()" in src
-    assert "qs.set('sidebar_source', _requestedSessionSidebarSource());" in src
-    assert "_serverWebuiSessionCount" in src
-    assert "_serverCliSessionCount" in src
-    assert "function _sessionSourceTabCount(" in src
+    assert "const sidebarSource = _requestedSessionSidebarSource();" in src
+    assert "if (sidebarSource) qs.set('sidebar_source', sidebarSource);" in src
+    assert "function _toggleOriginFilter(origin)" in src
+    assert "function _ensureOriginFilterDefaults(originOptions)" in src
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
@@ -274,129 +279,108 @@ console.log(JSON.stringify({{ first, second, third }}));
 """
     body = _run_node(script)
 
-    assert body["first"] == "?sidebar_source=cli&exclude_hidden=1&all_profiles=1"
+    assert body["first"] == "?exclude_hidden=1&all_profiles=1"
     assert body["second"] == "?sidebar_source=webui&exclude_hidden=1&all_profiles=1&include_archived=1"
     assert body["third"] == "?sidebar_source=webui&exclude_hidden=1"
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
-def test_session_source_switch_fetches_selected_bucket():
+def test_origin_filter_toggle_updates_local_state_without_refetch():
     src = SESSIONS_JS.read_text(encoding="utf-8")
-    fn_source = _extract_function(src, "_setSessionSourceFilter")
+    normalize_origin_fn = _extract_function(src, "_normalizeSidebarOriginId")
+    persist_fn = _extract_function(src, "_persistOriginFilters")
+    fn_toggle = _extract_function(src, "_toggleOriginFilter")
     script = f"""
-const renderCalls = [];
-global._sessionSourceFilter = 'webui';
-global._activeProject = 'demo-project';
-global._selectedSessions = new Set(['first', 'second']);
-global._sessionSelectMode = true;
+    const renderCalls = [];
+    global._originFiltersHydrated = false;
+    global._activeOriginFilters = new Set(['webui', 'cli']);
+    global._activeProject = 'demo-project';
+    global._selectedSessions = new Set(['first', 'second']);
+    global._sessionSelectMode = true;
 global.localStorage = {{
   writes: [],
   setItem(key, value) {{
     this.writes.push([key, value]);
   }},
 }};
-global.renderSessionListFromCache = () => {{
-  renderCalls.push('cache');
-}};
-global.renderSessionList = (opts) => {{
-  renderCalls.push(opts);
-  return Promise.resolve();
-}};
-{fn_source}
-_setSessionSourceFilter('cli');
-console.log(JSON.stringify({{
-  sourceFilter: global._sessionSourceFilter,
-  activeProject: global._activeProject,
-  selectedSize: global._selectedSessions.size,
-  sessionSelectMode: global._sessionSelectMode,
+    global.renderSessionListFromCache = () => {{
+      renderCalls.push('cache');
+    }};
+    {normalize_origin_fn}
+    {persist_fn}
+    {fn_toggle}
+    _toggleOriginFilter('cli');
+    console.log(JSON.stringify({{
+      activeOrigins: Array.from(global._activeOriginFilters),
+      activeProject: global._activeProject,
+      selectedSize: global._selectedSessions.size,
+      sessionSelectMode: global._sessionSelectMode,
   storageWrites: global.localStorage.writes,
   renderCalls,
+}}));
+    """
+    body = _run_node(script)
+
+    assert body["activeOrigins"] == ["webui"]
+    assert body["activeProject"] is None
+    assert body["selectedSize"] == 0
+    assert body["sessionSelectMode"] is False
+    assert body["storageWrites"] == [["hermes-origin-filters", "[\"webui\"]"]]
+    assert body["renderCalls"] == ["cache"]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_origin_filter_defaults_expand_catalog_without_overriding_saved_choices():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    normalize_origin_fn = _extract_function(src, "_normalizeSidebarOriginId")
+    persist_fn = _extract_function(src, "_persistOriginFilters")
+    signature_fn = _extract_function(src, "_originFilterSignature")
+    ensure_fn = _extract_function(src, "_ensureOriginFilterDefaults")
+    script = f"""
+    global.window = {{ _showCliSessions: true }};
+    global.localStorage = {{
+      writes: [],
+      setItem(key, value) {{
+        this.writes.push([key, value]);
+      }},
+    }};
+    global._activeOriginFilters = new Set(['webui']);
+    global._originFiltersHydrated = false;
+    global._originFiltersLoadedFromStorage = false;
+    {normalize_origin_fn}
+    {persist_fn}
+    {signature_fn}
+    {ensure_fn}
+const firstChanged = _ensureOriginFilterDefaults([
+  {{ id: 'webui' }},
+  {{ id: 'cli' }},
+  {{ id: 'slack' }},
+]);
+const firstOrigins = Array.from(global._activeOriginFilters);
+global._activeOriginFilters = new Set(['webui', 'cli']);
+global._originFiltersHydrated = true;
+global._originFiltersLoadedFromStorage = true;
+const secondChanged = _ensureOriginFilterDefaults([
+  {{ id: 'webui' }},
+  {{ id: 'cli' }},
+  {{ id: 'discord' }},
+]);
+const secondOrigins = Array.from(global._activeOriginFilters);
+console.log(JSON.stringify({{
+  firstChanged,
+  firstOrigins,
+  secondChanged,
+  secondOrigins,
+  writes: global.localStorage.writes,
 }}));
 """
     body = _run_node(script)
 
-    assert body["sourceFilter"] == "cli"
-    assert body["activeProject"] is None
-    assert body["selectedSize"] == 0
-    assert body["sessionSelectMode"] is False
-    assert body["storageWrites"] == [["hermes-session-source-filter", "cli"]]
-    assert body["renderCalls"] == ["cache", {"deferWhileInteracting": False}]
-
-
-@pytest.mark.skipif(NODE is None, reason="node not on PATH")
-def test_apply_payload_and_tab_count_helpers_cover_old_and_new_payloads():
-    src = SESSIONS_JS.read_text(encoding="utf-8")
-    requested_source_fn = _extract_function(src, "_requestedSessionSidebarSource")
-    exclude_hidden_fn = _extract_function(src, "_sessionListExcludeHiddenEnabled")
-    apply_fn = _extract_function(src, "_applySessionListPayload")
-    count_fn = _extract_function(src, "_sessionSourceTabCount")
-    clear_fn = _extract_function(src, "_clearSessionSourceTabCounts")
-    script = f"""
-global.window = {{ _showCliSessions: true }};
-global._otherProfileCount = 0;
-global._archivedWebuiCount = 0;
-global._archivedCliCount = 0;
-global._serverWebuiSessionCount = null;
-global._serverCliSessionCount = null;
-global._serverTimeDelta = 0;
-global._serverTz = null;
-global._optimisticallyRemovedSessionIds = new Set();
-global._allSessions = [];
-global._allSessionsScope = null;
-global._allProjects = [];
-global._sessionListLoadError = null;
-global._sessionListHasLoadedOnce = false;
-global._sessionListFirstRenderAnimated = true;
-global._sessionListSkeletonActive = true;
-global._activeProject = null;
-global.NO_PROJECT_FILTER = '__none__';
-global._showAllProfiles = false;
-global._sessionSourceFilter = 'webui';
-global.S = {{ activeProfile: 'default' }};
-global._reconcileActiveSessionIdleStateFromList = rows => rows;
-global._mergeOptimisticFirstTurnSessions = rows => rows;
-global._syncSessionAttentionSoundState = () => {{}};
-global._pruneLineageReportCacheToVisibleSessions = () => {{}};
-global._markPollingCompletionUnreadTransitions = () => {{}};
-global._recordSessionProfileCount = () => {{}};
-global._isSessionEffectivelyStreaming = () => false;
-global.startStreamingPoll = () => {{}};
-global.stopStreamingPoll = () => {{}};
-global.ensureSessionTimeRefreshPoll = () => {{}};
-global.ensureActiveSessionExternalRefreshPoll = () => {{}};
-    global.ensureSessionEventsSSE = () => {{}};
-    global.animateNextSessionListRefresh = () => {{}};
-    global.renderSessionListFromCache = () => {{}};
-    {clear_fn}
-    {count_fn}
-    {requested_source_fn}
-    {exclude_hidden_fn}
-    {apply_fn}
-const sessions = [{{ session_id: 'webui-1' }}];
-_applySessionListPayload({{ sessions, other_profile_count: 0, archived_count: 0, active_profile: 'default' }}, {{ projects: [] }});
-const oldPayload = {{
-  webui: _sessionSourceTabCount('webui', 7, 3),
-  cli: _sessionSourceTabCount('cli', 7, 3),
-}};
-_clearSessionSourceTabCounts();
-_applySessionListPayload({{
-  sessions,
-  other_profile_count: 0,
-  archived_count: 0,
-  active_profile: 'default',
-  webui_session_count: 11,
-  cli_session_count: 5,
-}}, {{ projects: [] }});
-const newPayload = {{
-  webui: _sessionSourceTabCount('webui', 7, 3),
-  cli: _sessionSourceTabCount('cli', 7, 3),
-}};
-console.log(JSON.stringify({{ oldPayload, newPayload }}));
-"""
-    body = _run_node(script)
-
-    assert body["oldPayload"] == {"webui": 7, "cli": 3}
-    assert body["newPayload"] == {"webui": 11, "cli": 5}
+    assert body["firstChanged"] is True
+    assert body["firstOrigins"] == ["webui", "cli", "slack"]
+    assert body["secondChanged"] is False
+    assert body["secondOrigins"] == ["webui", "cli"]
+    assert body["writes"] == [["hermes-origin-filters", "[\"webui\",\"cli\",\"slack\"]"]]
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
@@ -525,7 +509,6 @@ def test_session_list_response_omits_bucket_counts_when_missing(monkeypatch):
 def test_scope_mismatch_error_path_respects_sidebar_source():
     src = SESSIONS_JS.read_text(encoding="utf-8")
     purge_fn = _extract_function(src, "_purgeStaleInflightEntries")
-    clear_fn = _extract_function(src, "_clearSessionSourceTabCounts")
     requested_source_fn = _extract_function(src, "_requestedSessionSidebarSource")
     exclude_hidden_fn = _extract_function(src, "_sessionListExcludeHiddenEnabled")
     query_fn = _extract_function(src, "_sessionListQueryString")
@@ -551,32 +534,29 @@ global.S = {{ activeProfile: 'default' }};
 global.$ = () => ({{ value: '' }});
 global._isSessionListUserInteracting = () => false;
 global._schedulePendingSessionListApply = () => {{}};
-global._showSessionListLoadError = error => {{
-  global._lastError = error.message;
-}};
-const renders = [];
-const cleared = [];
-global.renderSessionListFromCache = () => {{
-  _purgeStaleInflightEntries();
-  renders.push({{
-    sessions: Array.isArray(global._allSessions) ? global._allSessions.map(s => s.session_id) : null,
-    scope: global._allSessionsScope ? {{ ...global._allSessionsScope }} : null,
-    webui: global._serverWebuiSessionCount,
-    cli: global._serverCliSessionCount,
-    skeleton: global._sessionListSkeletonActive,
-    inflightKeys: Object.keys(global.INFLIGHT || {{}}).sort(),
-  }});
-}};
-global.api = () => Promise.reject(new Error('boom'));
+    global._showSessionListLoadError = error => {{
+      global._lastError = error.message;
+    }};
+    const renders = [];
+    const cleared = [];
+    global.renderSessionListFromCache = () => {{
+      _purgeStaleInflightEntries();
+      renders.push({{
+        sessions: Array.isArray(global._allSessions) ? global._allSessions.map(s => s.session_id) : null,
+        scope: global._allSessionsScope ? {{ ...global._allSessionsScope }} : null,
+        skeleton: global._sessionListSkeletonActive,
+        inflightKeys: Object.keys(global.INFLIGHT || {{}}).sort(),
+      }});
+    }};
+    global.api = () => Promise.reject(new Error('boom'));
     global.clearInflightState = sid => cleared.push(sid);
     {purge_fn}
-    {clear_fn}
     {requested_source_fn}
     {exclude_hidden_fn}
     {query_fn}
     {refresh_fn}
-async function runCase(requestedSource, cachedSource) {{
-  global._sessionSourceFilter = requestedSource;
+async function runCase(showCliSessions, cachedSource) {{
+  global.window._showCliSessions = showCliSessions;
   global._allSessions = [{{ session_id: cachedSource + '-1' }}];
   global._allSessionsScope = {{
     profile: 'default',
@@ -587,8 +567,6 @@ async function runCase(requestedSource, cachedSource) {{
   global._sessionListSourceById = new Map([['webui-live', 'webui']]);
   global.INFLIGHT = {{ 'webui-live': {{ lastAssistantText: 'working' }} }};
   cleared.length = 0;
-  global._serverWebuiSessionCount = 11;
-  global._serverCliSessionCount = 5;
   global._sessionListSkeletonActive = true;
   global._lastError = null;
   renders.length = 0;
@@ -596,8 +574,6 @@ async function runCase(requestedSource, cachedSource) {{
   return {{
     sessions: Array.isArray(global._allSessions) ? global._allSessions.map(s => s.session_id) : null,
     scope: global._allSessionsScope ? {{ ...global._allSessionsScope }} : null,
-    webui: global._serverWebuiSessionCount,
-    cli: global._serverCliSessionCount,
     skeleton: global._sessionListSkeletonActive,
     error: global._lastError,
     cleared: [...cleared],
@@ -606,8 +582,8 @@ async function runCase(requestedSource, cachedSource) {{
   }};
 }}
 (async () => {{
-  const mismatch = await runCase('cli', 'webui');
-  const match = await runCase('webui', 'webui');
+  const mismatch = await runCase(false, null);
+  const match = await runCase(true, null);
   console.log(JSON.stringify({{ mismatch, match }}));
 }})().catch(error => {{
   console.error(error);
@@ -620,26 +596,22 @@ async function runCase(requestedSource, cachedSource) {{
     assert body["mismatch"]["scope"] == {
         "profile": "default",
         "allProfiles": False,
-        "sidebarSource": "cli",
-        "excludeHidden": True,
-    }
-    assert body["mismatch"]["webui"] is None
-    assert body["mismatch"]["cli"] is None
-    assert body["mismatch"]["skeleton"] is False
-    assert body["mismatch"]["render"]["sessions"] == []
-    assert body["mismatch"]["inflightKeys"] == ["webui-live"]
-    assert body["mismatch"]["cleared"] == []
-    assert body["mismatch"]["render"]["inflightKeys"] == ["webui-live"]
-    assert body["match"]["sessions"] == ["webui-1"]
-    assert body["match"]["scope"] == {
-        "profile": "default",
-        "allProfiles": False,
         "sidebarSource": "webui",
         "excludeHidden": True,
     }
-    assert body["match"]["webui"] == 11
-    assert body["match"]["cli"] == 5
-    assert body["match"]["render"]["sessions"] == ["webui-1"]
+    assert body["mismatch"]["skeleton"] is False
+    assert body["mismatch"]["render"]["sessions"] == []
+    assert body["mismatch"]["inflightKeys"] == []
+    assert body["mismatch"]["cleared"] == ["webui-live"]
+    assert body["mismatch"]["render"]["inflightKeys"] == []
+    assert body["match"]["sessions"] == ["null-1"]
+    assert body["match"]["scope"] == {
+        "profile": "default",
+        "allProfiles": False,
+        "sidebarSource": None,
+        "excludeHidden": True,
+    }
+    assert body["match"]["render"]["sessions"] == ["null-1"]
 
 
 def test_payload_row_count_regression(monkeypatch):

--- a/tests/test_issue4766_sidebar_source_pushdown.py
+++ b/tests/test_issue4766_sidebar_source_pushdown.py
@@ -289,10 +289,13 @@ def test_origin_filter_toggle_updates_local_state_without_refetch():
     src = SESSIONS_JS.read_text(encoding="utf-8")
     normalize_origin_fn = _extract_function(src, "_normalizeSidebarOriginId")
     persist_fn = _extract_function(src, "_persistOriginFilters")
+    signature_fn = _extract_function(src, "_originFilterSignature")
+    ensure_fn = _extract_function(src, "_ensureOriginFilterDefaults")
     fn_toggle = _extract_function(src, "_toggleOriginFilter")
     script = f"""
     const renderCalls = [];
     global._originFiltersHydrated = false;
+    global._originFiltersLoadedFromStorage = false;
     global._activeOriginFilters = new Set(['webui', 'cli']);
     global._activeProject = 'demo-project';
     global._selectedSessions = new Set(['first', 'second']);
@@ -308,24 +311,35 @@ global.localStorage = {{
     }};
     {normalize_origin_fn}
     {persist_fn}
+    {signature_fn}
+    {ensure_fn}
     {fn_toggle}
     _toggleOriginFilter('cli');
+    const changedAfterToggle = _ensureOriginFilterDefaults([
+      {{ id: 'webui' }},
+      {{ id: 'cli' }},
+      {{ id: 'slack' }},
+    ]);
     console.log(JSON.stringify({{
       activeOrigins: Array.from(global._activeOriginFilters),
+      originFiltersLoadedFromStorage: global._originFiltersLoadedFromStorage,
       activeProject: global._activeProject,
       selectedSize: global._selectedSessions.size,
       sessionSelectMode: global._sessionSelectMode,
-  storageWrites: global.localStorage.writes,
-  renderCalls,
-}}));
+      storageWrites: global.localStorage.writes,
+      changedAfterToggle,
+      renderCalls,
+    }}));
     """
     body = _run_node(script)
 
     assert body["activeOrigins"] == ["webui"]
+    assert body["originFiltersLoadedFromStorage"] is True
     assert body["activeProject"] is None
     assert body["selectedSize"] == 0
     assert body["sessionSelectMode"] is False
     assert body["storageWrites"] == [["hermes-origin-filters", "[\"webui\"]"]]
+    assert body["changedAfterToggle"] is False
     assert body["renderCalls"] == ["cache"]
 
 

--- a/tests/test_issue5379_origin_filter_cron_default.py
+++ b/tests/test_issue5379_origin_filter_cron_default.py
@@ -1,0 +1,286 @@
+"""Regression coverage for issue #5379: cron origin filter should default off."""
+
+import json
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+NODE = shutil.which("node")
+
+
+def _extract_function(source_text, function_name):
+    marker = f"function {function_name}("
+    start = source_text.index(marker)
+    brace_start = source_text.index("{", start)
+    depth = 0
+    for index in range(brace_start, len(source_text)):
+        char = source_text[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source_text[start:index + 1]
+    raise AssertionError(f"Could not extract {function_name}")
+
+
+def _run_node(script):
+    proc = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=True)
+    return json.loads(proc.stdout)
+
+
+def _origin_filter_functions():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    names = [
+        "_normalizeSidebarOriginId",
+        "_originFilterSignature",
+        "_persistOriginFilters",
+        "_restoreOriginFilters",
+        "_toggleOriginFilter",
+        "_ensureOriginFilterDefaults",
+        "_captureOriginFilterCronDefaultSeed",
+        "_originFilterDefaultsInclude",
+        "_sidebarOriginLabelForId",
+        "_humanizeSidebarOriginLabel",
+        "_sidebarOriginOptions",
+    ]
+    return src, "\n".join(_extract_function(src, name) for name in names)
+
+
+def _base_state_script():
+    return """
+  let _activeOriginFilters = new Set(['webui']);
+  let _originFiltersHydrated = false;
+  let _originFiltersLoadedFromStorage = false;
+  let _originFilterCronDefaultSeed = null;
+  let _selectedSessions = new Set();
+  let _sessionSelectMode = false;
+  let _activeProject = null;
+  let _sidebarOriginCatalog = [];
+"""
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_origin_filter_defaults_excludes_cron_for_seed_false():
+    src, fn_src = _origin_filter_functions()
+    script = f"""
+global.window = {{ _showCliSessions: true, _showCronSessions: false }};
+{_base_state_script()}
+global.localStorage = {{
+  writes: [],
+  setItem(key, value) {{ this.writes.push([key, value]); }},
+  getItem() {{ return null; }},
+}};
+function renderSessionListFromCache() {{}}
+{fn_src}
+const changed = _ensureOriginFilterDefaults([
+  {{ id: 'webui' }},
+  {{ id: 'cli' }},
+  {{ id: 'cron' }},
+]);
+console.log(JSON.stringify({{ changed, active: [..._activeOriginFilters], writes: localStorage.writes }}));
+"""
+    body = _run_node(script)
+    assert body["changed"] is True
+    assert body["active"] == ["webui", "cli"]
+    assert body["writes"] == [["hermes-origin-filters", "[\"webui\",\"cli\"]"]]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_origin_filter_defaults_includes_cron_for_seed_true():
+    _, fn_src = _origin_filter_functions()
+    script = f"""
+global.window = {{ _showCliSessions: true, _showCronSessions: true }};
+{_base_state_script()}
+global.localStorage = {{
+  writes: [],
+  setItem(key, value) {{ this.writes.push([key, value]); }},
+  getItem() {{ return null; }},
+}};
+function renderSessionListFromCache() {{}}
+{fn_src}
+const changed = _ensureOriginFilterDefaults([
+  {{ id: 'cli' }},
+  {{ id: 'cron' }},
+  {{ id: 'teams' }},
+]);
+console.log(JSON.stringify({{ changed, active: [..._activeOriginFilters], writes: localStorage.writes }}));
+"""
+    body = _run_node(script)
+    assert body["changed"] is True
+    assert body["active"] == ["webui", "cli", "cron", "teams"]
+    assert body["writes"] == [["hermes-origin-filters", "[\"webui\",\"cli\",\"cron\",\"teams\"]"]]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_origin_filter_defaults_stays_off_after_live_flag_flip():
+    _, fn_src = _origin_filter_functions()
+    script = f"""
+global.window = {{ _showCliSessions: true, _showCronSessions: false }};
+{_base_state_script()}
+global.localStorage = {{
+  writes: [],
+  setItem(key, value) {{ this.writes.push([key, value]); }},
+  getItem() {{ return null; }},
+}};
+function renderSessionListFromCache() {{}}
+{fn_src}
+const first = _ensureOriginFilterDefaults([
+  {{ id: 'cli' }},
+  {{ id: 'cron' }},
+]);
+window._showCronSessions = true;
+const second = _ensureOriginFilterDefaults([
+  {{ id: 'cli' }},
+  {{ id: 'cron' }},
+]);
+console.log(JSON.stringify({{
+  firstChanged: first,
+  secondChanged: second,
+  firstActive: ['webui', 'cli'],
+  secondActive: [..._activeOriginFilters],
+  writes: localStorage.writes,
+}}));
+"""
+    body = _run_node(script)
+    assert body["firstChanged"] is True
+    assert body["secondChanged"] is False
+    assert body["firstActive"] == body["secondActive"]
+    assert body["firstActive"] == ["webui", "cli"]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_origin_filter_defaults_preserves_stored_selection():
+    _, fn_src = _origin_filter_functions()
+    script = f"""
+global.window = {{ _showCliSessions: true, _showCronSessions: false }};
+{_base_state_script()}
+global.localStorage = {{
+  stored: '["whatsapp"]',
+  writes: [],
+  getItem(key) {{ return key === 'hermes-origin-filters' ? this.stored : null; }},
+  setItem(key, value) {{ this.writes.push([key, value]); }},
+}};
+function renderSessionListFromCache() {{}}
+{fn_src}
+_restoreOriginFilters();
+const changed = _ensureOriginFilterDefaults([
+  {{ id: 'webui' }},
+  {{ id: 'cli' }},
+  {{ id: 'cron' }},
+]);
+console.log(JSON.stringify({{
+  changed,
+  active: [..._activeOriginFilters],
+  hydrated: _originFiltersHydrated,
+  loadedFromStorage: _originFiltersLoadedFromStorage,
+  writes: localStorage.writes,
+}}));
+"""
+    body = _run_node(script)
+    assert body["changed"] is False
+    assert body["active"] == ["webui", "whatsapp"]
+    assert body["hydrated"] is True
+    assert body["loadedFromStorage"] is True
+    assert body["writes"] == []
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_toggle_origin_filter_keeps_cron_and_persists():
+    _, fn_src = _origin_filter_functions()
+    script = f"""
+global.window = {{ _showCliSessions: true, _showCronSessions: false }};
+{_base_state_script()}
+global.localStorage = {{
+  writes: [],
+  setItem(key, value) {{ this.writes.push([key, value]); }},
+  getItem() {{ return null; }},
+}};
+function renderSessionListFromCache() {{}}
+{fn_src}
+_toggleOriginFilter('cron');
+const changed = _ensureOriginFilterDefaults([
+  {{ id: 'cli' }},
+  {{ id: 'cron' }},
+]);
+console.log(JSON.stringify({{
+  changed,
+  active: [..._activeOriginFilters],
+  loadedFromStorage: _originFiltersLoadedFromStorage,
+  writes: localStorage.writes,
+}}));
+"""
+    body = _run_node(script)
+    assert body["active"] == ["webui", "cron"]
+    assert body["loadedFromStorage"] is True
+    assert body["changed"] is False
+    assert body["writes"] == [["hermes-origin-filters", "[\"webui\",\"cron\"]"]]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_origin_filter_defaults_keeps_webui_and_cli_when_cron_gated_off():
+    _, fn_src = _origin_filter_functions()
+    script = f"""
+global.window = {{ _showCliSessions: true, _showCronSessions: false }};
+{_base_state_script()}
+global.localStorage = {{
+  writes: [],
+  setItem(key, value) {{ this.writes.push([key, value]); }},
+  getItem() {{ return null; }},
+}};
+function renderSessionListFromCache() {{}}
+{fn_src}
+const changed = _ensureOriginFilterDefaults([
+  {{ id: 'cli' }},
+  {{ id: 'cron' }},
+]);
+console.log(JSON.stringify({{
+  changed,
+  active: [..._activeOriginFilters],
+  writes: localStorage.writes,
+}}));
+"""
+    body = _run_node(script)
+    assert body["changed"] is True
+    assert body["active"] == ["webui", "cli"]
+    assert body["writes"] == [["hermes-origin-filters", "[\"webui\",\"cli\"]"]]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_sidebar_origin_options_keeps_cron_vocabulary_with_zero_count():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    script = f"""
+{_extract_function(src, "_humanizeSidebarOriginLabel")}
+{_extract_function(src, "_sidebarOriginLabelForId")}
+{_extract_function(src, "_normalizeSidebarOriginId")}
+{_extract_function(src, "_sidebarOriginOptions")}
+const _SIDEBAR_FIXED_ORIGIN_IDS = ['webui', 'cli', 'cron'];
+const _SIDEBAR_ORIGIN_LABELS = {{ webui: 'WebUI', cli: 'CLI', cron: 'Cron' }};
+let _sidebarOriginCatalog = [];
+const options = _sidebarOriginOptions(new Map(), new Map());
+const cron = options.find(entry => entry.id === 'cron');
+console.log(JSON.stringify({{
+  labels: options.map(entry => entry.id),
+  cronCount: cron && cron.count,
+  cronLocked: cron && !!cron.locked,
+}}));
+"""
+    body = _run_node(script)
+    assert body["labels"] == ["webui", "cli", "cron"]
+    assert body["cronCount"] == 0
+    assert body["cronLocked"] is False
+
+
+def test_origin_filter_defaults_capture_and_routing_is_present_in_source():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    assert "let _originFilterCronDefaultSeed = null" in src
+    assert "function _captureOriginFilterCronDefaultSeed()" in src
+    assert "function _originFilterDefaultsInclude(originId)" in src
+    assert src.count("_captureOriginFilterCronDefaultSeed();") >= 2
+    assert src.count("if (_originFilterDefaultsInclude(originId)) next.add(originId);") >= 2
+    assert "return originId !== 'cron' || _captureOriginFilterCronDefaultSeed();" in src

--- a/tests/test_session_list_long_history_perf.py
+++ b/tests/test_session_list_long_history_perf.py
@@ -172,7 +172,10 @@ def test_session_list_fetch_adds_include_archived_only_when_toggle_is_on():
 
     assert "if(_showArchived) qs.set('include_archived','1');" in src
     assert "api('/api/sessions' + sessionListQS" in src
-    assert "toggle.onclick=()=>{_showArchived=!_showArchived;renderSessionList();};" in src
+    assert "const archivedCb=document.createElement('input');" in src
+    assert "archivedCb.checked=!!_showArchived;" in src
+    assert "_showArchived=archivedCb.checked;" in src
+    assert "void renderSessionList({deferWhileInteracting:false});" in src
     assert "_archivedWebuiCount" in src
     assert "sessData.archived_webui_count ?? sessData.archived_count ?? 0" in src
     assert "archived_webui_count" in src

--- a/tests/test_sidebar_session_partition.py
+++ b/tests/test_sidebar_session_partition.py
@@ -33,8 +33,8 @@ def test_render_uses_single_pass_partition_helper():
     assert "_partitionSidebarSessionRows(allMatched, activeSidForSidebar)" in render_body
     assert "_renderSidebarRowsFromRawSessions(sessionsRaw, referenceRaw)" in render_body
     assert "const sessions=_renderSidebarRowsFromRawSessions(sessionsRaw, referenceRaw);" in render_body
-    assert "{id:'webui',label:'WebUI',count:webuiSessionCount,locked:true}" in render_body
-    assert "{id:'cli',label:'CLI',count:cliSessionCount,locked:false}" in render_body
+    assert "let originOptions=_sidebarOriginOptions(originCounts, originLabels);" in render_body
+    assert "_ensureOriginFilterDefaults(originOptions)" in render_body
     assert "const count=filter==='cli'?renderedCliSessionCount:renderedWebuiSessionCount;" not in render_body
     assert "withMessages.filter(" not in render_body
 
@@ -44,10 +44,11 @@ def test_partition_helper_applies_message_source_project_and_archive_gates():
 
     assert "function _sidebarRowHasVisibleMessages(s, activeSidForSidebar)" in SESSIONS_JS
     assert "_sidebarRowHasVisibleMessages(s, activeSidForSidebar)" in block
-    assert "const isCli=_isCliSession(s);" in block
-    assert "const origin=isCli?'cli':'webui';" in block
-    assert "if(isCli) cliSessionCount++;" in block
-    assert "else webuiSessionCount++;" in block
+    assert "const origin=_sidebarOriginIdForSession(s);" in block
+    assert "if(origin==='cli') cliSessionCount++;" in block
+    assert "else if(origin==='webui') webuiSessionCount++;" in block
+    assert "originCounts.set(origin, Number(originCounts.get(origin) || 0) + 1);" in block
+    assert "originLabels.set(origin, _sidebarOriginLabelForId(origin, _getChannelLabel(s) || ''));" in block
     assert "if(!_activeOriginFilters.has(origin)) continue;" in block
     assert "if(!_showArchived&&s.archived) continue;" in block
     assert "archivedCount," in block
@@ -64,6 +65,8 @@ def test_partition_helper_keeps_single_pass_filtering_and_shared_render_path():
 
     assert "webuiSessionCount," in block
     assert "cliSessionCount," in block
+    assert "originCounts," in block
+    assert "originLabels," in block
     assert "webuiReferenceRaw," not in block
     assert "cliReferenceRaw," not in block
     assert "webuiSessionsRaw," not in block

--- a/tests/test_sidebar_session_partition.py
+++ b/tests/test_sidebar_session_partition.py
@@ -32,11 +32,9 @@ def test_render_uses_single_pass_partition_helper():
 
     assert "_partitionSidebarSessionRows(allMatched, activeSidForSidebar)" in render_body
     assert "_renderSidebarRowsFromRawSessions(sessionsRaw, referenceRaw)" in render_body
-    assert "const renderedWebuiSessionCount=_renderSidebarRowsFromRawSessions(webuiSessionsRaw, webuiReferenceRaw).length;" in render_body
-    assert "const renderedCliSessionCount=_renderSidebarRowsFromRawSessions(cliSessionsRaw, cliReferenceRaw).length;" in render_body
-    assert "const webuiSessionTabCount=_sessionSourceTabCount('webui', renderedWebuiSessionCount, renderedCliSessionCount);" in render_body
-    assert "const cliSessionTabCount=_sessionSourceTabCount('cli', renderedWebuiSessionCount, renderedCliSessionCount);" in render_body
-    assert "const count=filter==='cli'?cliSessionTabCount:webuiSessionTabCount;" in render_body
+    assert "const sessions=_renderSidebarRowsFromRawSessions(sessionsRaw, referenceRaw);" in render_body
+    assert "{id:'webui',label:'WebUI',count:webuiSessionCount,locked:true}" in render_body
+    assert "{id:'cli',label:'CLI',count:cliSessionCount,locked:false}" in render_body
     assert "const count=filter==='cli'?renderedCliSessionCount:renderedWebuiSessionCount;" not in render_body
     assert "withMessages.filter(" not in render_body
 
@@ -46,30 +44,35 @@ def test_partition_helper_applies_message_source_project_and_archive_gates():
 
     assert "function _sidebarRowHasVisibleMessages(s, activeSidForSidebar)" in SESSIONS_JS
     assert "_sidebarRowHasVisibleMessages(s, activeSidForSidebar)" in block
-    assert "if(_sessionSourceFilter==='cli' && !window._showCliSessions && cliSessionCount===0)" in block
-    assert "const showCliOnly=_sessionSourceFilter==='cli';" in block
+    assert "const isCli=_isCliSession(s);" in block
+    assert "const origin=isCli?'cli':'webui';" in block
+    assert "if(isCli) cliSessionCount++;" in block
+    assert "else webuiSessionCount++;" in block
+    assert "if(!_activeOriginFilters.has(origin)) continue;" in block
     assert "if(!_showArchived&&s.archived) continue;" in block
-    assert "if(s.archived){" in block
-    assert "const serverArchivedCount=showCliOnly?_archivedCliCount:_archivedWebuiCount;" in block
-    assert "archivedCount: Math.max(showCliOnly ? cliArchivedCount : webuiArchivedCount, Number(serverArchivedCount||0))," in block
+    assert "archivedCount," in block
     assert "return {" in block
-    assert "profileFiltered: showCliOnly ? cliProfileFiltered : webuiProfileFiltered," in block
-    assert "sessionsRaw: showCliOnly ? cliSessionsRaw : webuiSessionsRaw," in block
+    assert "sourceFiltered," in block
+    assert "profileFiltered," in block
+    assert "sessionsRaw," in block
+    assert "referenceRaw," in block
 
 
-def test_partition_helper_keeps_raw_source_counts_while_render_owns_visible_counts():
+def test_partition_helper_keeps_single_pass_filtering_and_shared_render_path():
     render_body = _function_block("renderSessionListFromCache")
+    block = _partition_block()
 
-    assert "webuiSessionCount," not in _partition_block()
-    assert "cliSessionCount," in _partition_block()
-    assert "webuiReferenceRaw," in _partition_block()
-    assert "cliReferenceRaw," in _partition_block()
-    assert "webuiSessionsRaw," in _partition_block()
-    assert "cliSessionsRaw," in _partition_block()
-    assert "const renderedWebuiSessionCount=" in render_body
-    assert "const renderedCliSessionCount=" in render_body
-    assert "_renderSidebarRowsFromRawSessions(webuiSessionsRaw, webuiReferenceRaw).length" in render_body
-    assert "_renderSidebarRowsFromRawSessions(cliSessionsRaw, cliReferenceRaw).length" in render_body
+    assert "webuiSessionCount," in block
+    assert "cliSessionCount," in block
+    assert "webuiReferenceRaw," not in block
+    assert "cliReferenceRaw," not in block
+    assert "webuiSessionsRaw," not in block
+    assert "cliSessionsRaw," not in block
+    assert "const renderedWebuiSessionCount=" not in render_body
+    assert "const renderedCliSessionCount=" not in render_body
+    assert "_renderSidebarRowsFromRawSessions(webuiSessionsRaw, webuiReferenceRaw).length" not in render_body
+    assert "_renderSidebarRowsFromRawSessions(cliSessionsRaw, cliReferenceRaw).length" not in render_body
+    assert "const sessions=_renderSidebarRowsFromRawSessions(sessionsRaw, referenceRaw);" in render_body
     assert "function _countRenderedSidebarRowsFromRawSessions" not in SESSIONS_JS
     assert "function _renderSidebarRowsFromRawSessions(sessionsRaw, referenceSessionsRaw){" in SESSIONS_JS
     assert "_attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw, referenceRows)" in SESSIONS_JS

--- a/tests/test_sidebar_session_partition.py
+++ b/tests/test_sidebar_session_partition.py
@@ -28,10 +28,11 @@ def test_partition_helper_applies_message_source_project_and_archive_gates():
 
     assert "function _sidebarRowHasVisibleMessages(s, activeSidForSidebar)" in SESSIONS_JS
     assert "_sidebarRowHasVisibleMessages(s, activeSidForSidebar)" in block
-    assert "if(_sessionSourceFilter==='cli' && !window._showCliSessions && cliSessionCount===0)" in block
-    assert "const showCliOnly=_sessionSourceFilter==='cli';" in block
+    assert "const origin=_isCliSession(s)?'cli':'webui';" in block
+    assert "if(!_activeOriginFilters.has(origin)) continue;" in block
     assert "if(!_showArchived&&s.archived) continue;" in block
     assert "if(s.archived) archivedCount++;" in block
     assert "return {" in block
+    assert "sourceFiltered," in block
     assert "profileFiltered," in block
     assert "sessionsRaw," in block

--- a/tests/test_todo_panel_cold_load_static.py
+++ b/tests/test_todo_panel_cold_load_static.py
@@ -17,11 +17,8 @@ def test_ensure_messages_loaded_hydrates_session_todo_state_sidecar():
 def test_new_session_hydrates_todos_after_session_assignment():
     src = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
     start = src.find("async function newSession(flash, options={}){")
-    end = src.find("function _countAssistantMessages(", start)
-
     assert start != -1
-    assert end != -1
-    block = src[start:end]
+    block = src[start:start + 6000]
     assign_idx = block.find("S.session=data.session;S.messages=data.session.messages||[];")
     hydrate_idx = block.find("if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);")
 

--- a/tests/test_todo_panel_cold_load_static.py
+++ b/tests/test_todo_panel_cold_load_static.py
@@ -14,6 +14,21 @@ def test_ensure_messages_loaded_hydrates_session_todo_state_sidecar():
     assert "scheduleTodosRefresh()" in src
 
 
+def test_new_session_hydrates_todos_after_session_assignment():
+    src = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+    start = src.find("async function newSession(flash, options={}){")
+    end = src.find("function _countAssistantMessages(", start)
+
+    assert start != -1
+    assert end != -1
+    block = src[start:end]
+    assign_idx = block.find("S.session=data.session;S.messages=data.session.messages||[];")
+    hydrate_idx = block.find("if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);")
+
+    assert assign_idx != -1
+    assert hydrate_idx > assign_idx
+
+
 def test_load_todos_renders_single_source_of_truth_before_legacy_scan():
     src = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
     start = src.find("function loadTodos()")


### PR DESCRIPTION
### Thinking Path

- Hermes supports multiple session origins (WebUI, CLI, Cron, Telegram, Discord), but the sidebar only exposed a binary WebUI/CLI toggle driven by a string variable (`_sessionSourceFilter`) that could hold only `'webui'` or `'cli'`.
- Adding any third origin required patching the validation, filter predicate, tab renderer, and localStorage key simultaneously, making the structure non-extensible.
- Issue #3418 specifies a funnel popover with independent origin checkboxes, so the state needs to become a `Set` rather than a string.
- Cron belongs in that unified filter, but it should stay off by default there: background job output is not a sane primary sidebar category unless the user explicitly opts into it.
- Two open PRs (#3403, #3122) add tabs instead of a popover and neither removes the Settings toggles; this PR takes the full spec approach.

### What Changed

- `static/sessions.js`: replaced `_sessionSourceFilter` string with `_activeOriginFilters` Set; replaced `_setSessionSourceFilter` / `_restoreSessionSourceFilter` with `_toggleOriginFilter` / `_restoreOriginFilters`; replaced two-tab renderer with a funnel-button popover that lists origin checkboxes; updated localStorage key to `hermes-origin-filters`; updated new-session reset and CLI empty-state guard; origin normalization maps all CLI-class sessions to `'cli'` unconditionally.
- `static/sessions.js`: defaulted `cron` off inside the unified origin filter unless the user had already enabled cron visibility before the filter initializes; explicit cron selection still works and persists like any other origin choice.
- `static/style.css`: added `.session-filter-bar`, `.session-origin-popover`, `.session-origin-checkbox`, `.session-origin-count` styles; kept old `.session-source-tabs` selectors with a deprecation comment for cache-busted clients.
- `tests/test_issue2351_cli_session_source_filter.py`: updated string assertions to match the new state variable and popover structure.
- `tests/test_active_empty_session_sidebar.py`: updated the new-session test to verify Set-based initialization.
- `tests/test_issue4766_sidebar_source_pushdown.py`: updated the shared extraction harness to load the cron-default helper path from the real source.
- `tests/test_issue5379_origin_filter_cron_default.py`: added targeted coverage for fresh hydration, persisted selections, explicit cron toggles, and the post-persist live-flag flip hazard.

### Why It Matters

Users with mixed-origin setups can now view sessions from multiple origins simultaneously or filter to any subset, instead of flipping between two mutually exclusive views. Cron is still available in the unified filter, but it does not take over the primary sidebar by default.

### Verification

```
pytest tests/test_issue2351_cli_session_source_filter.py -v --timeout=60
pytest tests/test_active_empty_session_sidebar.py -v --timeout=60
python -m pytest tests/test_issue5379_origin_filter_cron_default.py tests/test_issue4766_sidebar_source_pushdown.py tests/test_issue2841_show_cron_sessions_toggle.py -v --timeout=60
pytest tests/ -v --timeout=60
```

### Risks / Follow-ups

- Removing the backend config keys for `show_cli_sessions` and `show_previous_messaging_sessions` is deferred to avoid breaking existing installs; only the Settings UI toggles are relocated.
- Dynamic gateway origins (Telegram, Discord, Slack) are tested only at the unit level because integration tests require a running gateway.
- PRs #3403 and #3122 approach the same issue via tabs; this PR supersedes both.

### Model Used

Claude Opus 4.8 via Claude Code CLI

Closes #3418