### PR TITLE
feat(composer): surface session-control actions as visible buttons when busy (#1804)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -462,6 +462,25 @@
       <div id="queueCard" class="queue-card" role="region" aria-label="Queued messages" aria-live="polite">
         <div id="queueChips" class="queue-card-inner"></div>
       </div>
+      <!-- Busy hint bar: visible when agent is busy, surfaces /interrupt, /queue, /steer, New Chat -->
+      <div id="busyHintBar" class="busy-hint-bar" hidden aria-label="Available actions while agent is responding">
+        <button class="busy-hint-pill" data-action="interrupt" onclick="_handleBusyHintPill('interrupt')" title="Interrupt the current response and send your draft" aria-label="Interrupt and send">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 4v16"/><path d="M6.029 4.285A2 2 0 0 0 3 6v12a2 2 0 0 0 3.029 1.715l9.997-5.998a2 2 0 0 0 .003-3.432z"/></svg>
+          <span data-i18n="composer_interrupt">Interrupt and send</span>
+        </button>
+        <button class="busy-hint-pill" data-action="queue" onclick="_handleBusyHintPill('queue')" title="Queue a message to send after the current response" aria-label="Queue message">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 5H3"/><path d="M16 12H3"/><path d="M9 19H3"/><path d="m16 16-3 3 3 3"/><path d="M21 5v12a2 2 0 0 1-2 2h-6"/></svg>
+          <span data-i18n="composer_queue">Queue message</span>
+        </button>
+        <button class="busy-hint-pill" data-action="steer" onclick="_handleBusyHintPill('steer')" title="Steer the current response" aria-label="Steer current response">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="m16.24 7.76-1.804 5.411a2 2 0 0 1-1.265 1.265L7.76 16.24l1.804-5.411a2 2 0 0 1 1.265-1.265z"/></svg>
+          <span data-i18n="composer_steer">Steer current response</span>
+        </button>
+        <button class="busy-hint-pill busy-hint-pill--new-chat" data-action="new_chat" onclick="_handleBusyHintPill('new_chat')" title="Start a new conversation in parallel" aria-label="New conversation">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          <span data-i18n="new_conversation">New conversation</span>
+        </button>
+      </div>
       <div class="approval-card" id="approvalCard" role="alertdialog" aria-labelledby="approvalHeading" aria-describedby="approvalDesc">
         <div class="approval-inner">
           <div class="approval-header">

--- a/static/style.css
+++ b/static/style.css
@@ -1381,6 +1381,7 @@
   .queue-card-file-badge{display:flex;align-items:center;gap:2px;}
   /* ── Busy hint bar ─────────────────────────────────────────────────── */
   .busy-hint-bar{display:flex;align-items:center;gap:4px;padding:4px 10px;flex-wrap:wrap;border-top:1px solid var(--border);background:var(--bg);}
+  .busy-hint-bar[hidden]{display:none;}
   .busy-hint-pill{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:10px;border:1px solid var(--border);background:transparent;color:var(--muted);font-size:0.75em;cursor:pointer;transition:background .15s,color .15s;white-space:nowrap;}
   .busy-hint-pill:hover{background:var(--hover);color:var(--fg);}
   .busy-hint-pill--new-chat{margin-left:auto;}

--- a/static/style.css
+++ b/static/style.css
@@ -1383,6 +1383,7 @@
   .busy-hint-bar{display:flex;align-items:center;gap:4px;padding:4px 10px;flex-wrap:wrap;border-top:1px solid var(--border);background:var(--bg);}
   .busy-hint-bar[hidden]{display:none;}
   .busy-hint-pill{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:10px;border:1px solid var(--border);background:transparent;color:var(--muted);font-size:0.75em;cursor:pointer;transition:background .15s,color .15s;white-space:nowrap;}
+  .busy-hint-pill[hidden]{display:none;}
   .busy-hint-pill:hover{background:var(--hover);color:var(--fg);}
   .busy-hint-pill--new-chat{margin-left:auto;}
   .approval-btn-icon{font-size:13px;line-height:1;}

--- a/static/style.css
+++ b/static/style.css
@@ -1367,6 +1367,11 @@
   .queue-card-text:focus{white-space:pre-wrap;overflow:auto;text-overflow:clip;}
   .queue-card-badges{display:flex;align-items:center;gap:5px;flex-shrink:0;font-size:10px;color:var(--muted);opacity:.6;}
   .queue-card-file-badge{display:flex;align-items:center;gap:2px;}
+  /* ── Busy hint bar ─────────────────────────────────────────────────── */
+  .busy-hint-bar{display:flex;align-items:center;gap:4px;padding:4px 10px;flex-wrap:wrap;border-top:1px solid var(--border);background:var(--bg);}
+  .busy-hint-pill{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:10px;border:1px solid var(--border);background:transparent;color:var(--muted);font-size:0.75em;cursor:pointer;transition:background .15s,color .15s;white-space:nowrap;}
+  .busy-hint-pill:hover{background:var(--hover);color:var(--fg);}
+  .busy-hint-pill--new-chat{margin-left:auto;}
   .approval-btn-icon{font-size:13px;line-height:1;}
   .approval-btn-label{line-height:1;}
   .approval-kbd{display:inline-flex;align-items:center;justify-content:center;padding:1px 5px;border-radius:4px;font-size:10px;font-family:inherit;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.15);color:var(--muted);line-height:1.4;margin-left:2px;}

--- a/static/style.css
+++ b/static/style.css
@@ -1379,6 +1379,11 @@
   .queue-card-text:focus{white-space:pre-wrap;overflow:auto;text-overflow:clip;}
   .queue-card-badges{display:flex;align-items:center;gap:5px;flex-shrink:0;font-size:10px;color:var(--muted);opacity:.6;}
   .queue-card-file-badge{display:flex;align-items:center;gap:2px;}
+  /* ── Busy hint bar ─────────────────────────────────────────────────── */
+  .busy-hint-bar{display:flex;align-items:center;gap:4px;padding:4px 10px;flex-wrap:wrap;border-top:1px solid var(--border);background:var(--bg);}
+  .busy-hint-pill{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:10px;border:1px solid var(--border);background:transparent;color:var(--muted);font-size:0.75em;cursor:pointer;transition:background .15s,color .15s;white-space:nowrap;}
+  .busy-hint-pill:hover{background:var(--hover);color:var(--fg);}
+  .busy-hint-pill--new-chat{margin-left:auto;}
   .approval-btn-icon{font-size:13px;line-height:1;}
   .approval-btn-label{line-height:1;}
   .approval-kbd{display:inline-flex;align-items:center;justify-content:center;padding:1px 5px;border-radius:4px;font-size:10px;font-family:inherit;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.15);color:var(--muted);line-height:1.4;margin-left:2px;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -4166,7 +4166,8 @@ function updateSendBtn(){
 function _updateBusyHintBar(){
   const bar=$('busyHintBar');
   if(!bar) return;
-  const isBusy=!!S.busy;
+  const compressionRunning=typeof isCompressionUiRunning==='function'&&isCompressionUiRunning();
+  const isBusy=!!S.busy||compressionRunning;
   bar.hidden=!isBusy;
   if(!isBusy) return;
   const canInterrupt=!!(S.activeStreamId&&typeof cancelStream==='function');

--- a/static/ui.js
+++ b/static/ui.js
@@ -5184,13 +5184,13 @@ function _updateBusyHintBar(){
 }
 
 function _handleBusyHintPill(action){
-  const msg=$('msg');
-  if(!msg) return;
   if(action==='new_chat'){
     const btn=$('btnNewChat');
     if(btn) btn.click();
     return;
   }
+  const msg=$('msg');
+  if(!msg) return;
   if(!msg.value.trim()){
     msg.value='/'+action+' ';
     msg.dispatchEvent(new Event('input',{bubbles:true}));

--- a/static/ui.js
+++ b/static/ui.js
@@ -5170,7 +5170,8 @@ function updateSendBtn(){
 function _updateBusyHintBar(){
   const bar=$('busyHintBar');
   if(!bar) return;
-  const isBusy=!!S.busy;
+  const compressionRunning=typeof isCompressionUiRunning==='function'&&isCompressionUiRunning();
+  const isBusy=!!S.busy||compressionRunning;
   bar.hidden=!isBusy;
   if(!isBusy) return;
   const canInterrupt=!!(S.activeStreamId&&typeof cancelStream==='function');

--- a/static/ui.js
+++ b/static/ui.js
@@ -4180,13 +4180,13 @@ function _updateBusyHintBar(){
 }
 
 function _handleBusyHintPill(action){
-  const msg=$('msg');
-  if(!msg) return;
   if(action==='new_chat'){
     const btn=$('btnNewChat');
     if(btn) btn.click();
     return;
   }
+  const msg=$('msg');
+  if(!msg) return;
   if(!msg.value.trim()){
     msg.value='/'+action+' ';
     msg.dispatchEvent(new Event('input',{bubbles:true}));

--- a/static/ui.js
+++ b/static/ui.js
@@ -4160,6 +4160,40 @@ function updateSendBtn(){
   } else if(action==='disabled'){
     btn.classList.remove('visible');
   }
+  if(typeof _updateBusyHintBar==='function') _updateBusyHintBar();
+}
+
+function _updateBusyHintBar(){
+  const bar=$('busyHintBar');
+  if(!bar) return;
+  const isBusy=!!S.busy;
+  bar.hidden=!isBusy;
+  if(!isBusy) return;
+  const canInterrupt=!!(S.activeStreamId&&typeof cancelStream==='function');
+  const canSteer=!!(S.activeStreamId&&typeof _trySteer==='function');
+  const pills=bar.querySelectorAll('.busy-hint-pill');
+  pills.forEach(pill=>{
+    const action=pill.dataset.action;
+    if(action==='interrupt') pill.hidden=!canInterrupt;
+    if(action==='steer') pill.hidden=!canSteer;
+  });
+}
+
+function _handleBusyHintPill(action){
+  const msg=$('msg');
+  if(!msg) return;
+  if(action==='new_chat'){
+    const btn=$('btnNewChat');
+    if(btn) btn.click();
+    return;
+  }
+  if(!msg.value.trim()){
+    msg.value='/'+action+' ';
+    msg.dispatchEvent(new Event('input',{bubbles:true}));
+    if(typeof autoResize==='function') autoResize();
+    msg.focus();
+    msg.setSelectionRange(msg.value.length,msg.value.length);
+  }
 }
 
 async function handleComposerPrimaryAction(){

--- a/static/ui.js
+++ b/static/ui.js
@@ -5164,6 +5164,40 @@ function updateSendBtn(){
   } else if(action==='disabled'){
     btn.classList.remove('visible');
   }
+  if(typeof _updateBusyHintBar==='function') _updateBusyHintBar();
+}
+
+function _updateBusyHintBar(){
+  const bar=$('busyHintBar');
+  if(!bar) return;
+  const isBusy=!!S.busy;
+  bar.hidden=!isBusy;
+  if(!isBusy) return;
+  const canInterrupt=!!(S.activeStreamId&&typeof cancelStream==='function');
+  const canSteer=!!(S.activeStreamId&&typeof _trySteer==='function');
+  const pills=bar.querySelectorAll('.busy-hint-pill');
+  pills.forEach(pill=>{
+    const action=pill.dataset.action;
+    if(action==='interrupt') pill.hidden=!canInterrupt;
+    if(action==='steer') pill.hidden=!canSteer;
+  });
+}
+
+function _handleBusyHintPill(action){
+  const msg=$('msg');
+  if(!msg) return;
+  if(action==='new_chat'){
+    const btn=$('btnNewChat');
+    if(btn) btn.click();
+    return;
+  }
+  if(!msg.value.trim()){
+    msg.value='/'+action+' ';
+    msg.dispatchEvent(new Event('input',{bubbles:true}));
+    if(typeof autoResize==='function') autoResize();
+    msg.focus();
+    msg.setSelectionRange(msg.value.length,msg.value.length);
+  }
 }
 
 async function handleComposerPrimaryAction(){

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -352,12 +352,12 @@ class TestSendBusyBranchDispatch:
 
     def test_busy_hint_bar_uses_same_busy_definition_as_primary_action(self):
         """The busy hint bar must stay visible during compression-only busy states."""
-        start = MESSAGES_JS.find("function getComposerPrimaryAction()")
-        end = MESSAGES_JS.find("function _setComposerPrimaryButtonIcon", start)
-        primary = MESSAGES_JS[start:end]
-        hint_start = MESSAGES_JS.find("function _updateBusyHintBar()")
-        hint_end = MESSAGES_JS.find("function _handleBusyHintPill", hint_start)
-        hint = MESSAGES_JS[hint_start:hint_end]
+        start = UI_JS.find("function getComposerPrimaryAction()")
+        end = UI_JS.find("function _setComposerPrimaryButtonIcon", start)
+        primary = UI_JS[start:end]
+        hint_start = UI_JS.find("function _updateBusyHintBar()")
+        hint_end = UI_JS.find("function _handleBusyHintPill", hint_start)
+        hint = UI_JS[hint_start:hint_end]
 
         assert "const compressionRunning=typeof isCompressionUiRunning==='function'&&isCompressionUiRunning();" in primary
         assert "const isBusy=!!S.busy||compressionRunning;" in primary

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -356,12 +356,12 @@ class TestSendBusyBranchDispatch:
 
     def test_busy_hint_bar_uses_same_busy_definition_as_primary_action(self):
         """The busy hint bar must stay visible during compression-only busy states."""
-        start = MESSAGES_JS.find("function getComposerPrimaryAction()")
-        end = MESSAGES_JS.find("function _setComposerPrimaryButtonIcon", start)
-        primary = MESSAGES_JS[start:end]
-        hint_start = MESSAGES_JS.find("function _updateBusyHintBar()")
-        hint_end = MESSAGES_JS.find("function _handleBusyHintPill", hint_start)
-        hint = MESSAGES_JS[hint_start:hint_end]
+        start = UI_JS.find("function getComposerPrimaryAction()")
+        end = UI_JS.find("function _setComposerPrimaryButtonIcon", start)
+        primary = UI_JS[start:end]
+        hint_start = UI_JS.find("function _updateBusyHintBar()")
+        hint_end = UI_JS.find("function _handleBusyHintPill", hint_start)
+        hint = UI_JS[hint_start:hint_end]
 
         assert "const compressionRunning=typeof isCompressionUiRunning==='function'&&isCompressionUiRunning();" in primary
         assert "const isBusy=!!S.busy||compressionRunning;" in primary

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -354,6 +354,23 @@ class TestSendBusyBranchDispatch:
             "otherwise a reflexive Enter press during the await re-fires the command"
         )
 
+    def test_busy_hint_bar_uses_same_busy_definition_as_primary_action(self):
+        """The busy hint bar must stay visible during compression-only busy states."""
+        start = MESSAGES_JS.find("function getComposerPrimaryAction()")
+        end = MESSAGES_JS.find("function _setComposerPrimaryButtonIcon", start)
+        primary = MESSAGES_JS[start:end]
+        hint_start = MESSAGES_JS.find("function _updateBusyHintBar()")
+        hint_end = MESSAGES_JS.find("function _handleBusyHintPill", hint_start)
+        hint = MESSAGES_JS[hint_start:hint_end]
+
+        assert "const compressionRunning=typeof isCompressionUiRunning==='function'&&isCompressionUiRunning();" in primary
+        assert "const isBusy=!!S.busy||compressionRunning;" in primary
+        assert "const compressionRunning=typeof isCompressionUiRunning==='function'&&isCompressionUiRunning();" in hint
+        assert "const isBusy=!!S.busy||compressionRunning;" in hint, (
+            "_updateBusyHintBar must mirror getComposerPrimaryAction's busy "
+            "definition so the queue hint stays visible during compression-only busy states"
+        )
+
 
 # ── Boot init + settings panel wiring ───────────────────────────────────
 

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -350,6 +350,23 @@ class TestSendBusyBranchDispatch:
             "otherwise a reflexive Enter press during the await re-fires the command"
         )
 
+    def test_busy_hint_bar_uses_same_busy_definition_as_primary_action(self):
+        """The busy hint bar must stay visible during compression-only busy states."""
+        start = MESSAGES_JS.find("function getComposerPrimaryAction()")
+        end = MESSAGES_JS.find("function _setComposerPrimaryButtonIcon", start)
+        primary = MESSAGES_JS[start:end]
+        hint_start = MESSAGES_JS.find("function _updateBusyHintBar()")
+        hint_end = MESSAGES_JS.find("function _handleBusyHintPill", hint_start)
+        hint = MESSAGES_JS[hint_start:hint_end]
+
+        assert "const compressionRunning=typeof isCompressionUiRunning==='function'&&isCompressionUiRunning();" in primary
+        assert "const isBusy=!!S.busy||compressionRunning;" in primary
+        assert "const compressionRunning=typeof isCompressionUiRunning==='function'&&isCompressionUiRunning();" in hint
+        assert "const isBusy=!!S.busy||compressionRunning;" in hint, (
+            "_updateBusyHintBar must mirror getComposerPrimaryAction's busy "
+            "definition so the queue hint stays visible during compression-only busy states"
+        )
+
 
 # ── Boot init + settings panel wiring ───────────────────────────────────
 

--- a/tests/test_busy_hint_bar.py
+++ b/tests/test_busy_hint_bar.py
@@ -21,6 +21,7 @@ def test_busy_hint_bar_in_html():
 def test_busy_hint_bar_css():
     src = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
     assert ".busy-hint-bar" in src
+    assert ".busy-hint-bar[hidden]" in src
     assert ".busy-hint-pill" in src
 
 

--- a/tests/test_busy_hint_bar.py
+++ b/tests/test_busy_hint_bar.py
@@ -23,6 +23,7 @@ def test_busy_hint_bar_css():
     assert ".busy-hint-bar" in src
     assert ".busy-hint-bar[hidden]" in src
     assert ".busy-hint-pill" in src
+    assert ".busy-hint-pill[hidden]" in src
 
 
 def test_busy_hint_pills_have_actions():

--- a/tests/test_busy_hint_bar.py
+++ b/tests/test_busy_hint_bar.py
@@ -1,0 +1,30 @@
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_update_busy_hint_bar_exists():
+    src = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+    assert "_updateBusyHintBar" in src
+
+
+def test_handle_busy_hint_pill_exists():
+    src = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+    assert "_handleBusyHintPill" in src
+
+
+def test_busy_hint_bar_in_html():
+    src = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+    assert "busyHintBar" in src
+
+
+def test_busy_hint_bar_css():
+    src = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+    assert ".busy-hint-bar" in src
+    assert ".busy-hint-pill" in src
+
+
+def test_busy_hint_pills_have_actions():
+    src = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+    for action in ["interrupt", "queue", "steer", "new_chat"]:
+        assert f'data-action="{action}"' in src, f"Missing pill for action: {action}"


### PR DESCRIPTION
### Thinking Path

- When the agent is streaming, users have three meaningful actions: queue, interrupt, steer. These exist as slash-command prefixes and as `_busyInputMode` cycling behind the send button icon, but neither surface is discoverable without reading docs.
- The maintainer scoped Phase 1 on #1804: New Chat visible during busy, and a composer affordance for /interrupt, /queue, /steer. Stop already exists as the send button. Phase 2 (per-message retry/undo toolbar) is deferred.
- The natural insertion point is inside `.composer-flyout`, which already hosts the queue card and approval card as slide-up panels. A `#busyHintBar` in the same slot is shown/hidden by `setBusy` without touching message layout.
- Clicking a pill when the composer is empty prefills it with the slash prefix (e.g., `/queue `) and focuses. New Chat delegates to `$('btnNewChat').click()`, reusing the full click handler in `boot.js` including the empty-session guard.
- All label strings reuse existing i18n keys (`composer_interrupt`, `composer_queue`, `composer_steer`, `new_conversation`) that are already translated in all 12 locales. No new translation work needed.

### What Changed

- **`static/index.html`**: Added `#busyHintBar` div inside `.composer-flyout`, with four `.busy-hint-pill` buttons for interrupt, queue, steer, and new conversation. SVG icons match the existing send-button icon set. Starts `hidden`.
- **`static/ui.js`**: Added `_updateBusyHintBar()` to show/hide the bar and individual pills based on stream availability. Added `_handleBusyHintPill(action)` to prefill the composer (with `input` event dispatch for dependent listeners) or delegate to btnNewChat. Called from `updateSendBtn`, which `setBusy` invokes.
- **`static/style.css`**: Added `.busy-hint-bar` and `.busy-hint-pill` classes; New Chat pill floats right via `margin-left:auto` on `.busy-hint-pill--new-chat`.
- **`tests/test_busy_hint_bar.py`**: Static source assertions for key identifiers and CSS classes.

### Why It Matters

Users who are not familiar with `/queue`, `/interrupt`, or `/steer` slash commands have no way to discover that parallel interaction is possible while the agent responds. The hint bar makes the most important busy-state actions visible at a glance without adding permanent chrome.

### Verification

```bash
pytest tests/test_busy_hint_bar.py -v --timeout=60
pytest tests/ -v --timeout=60
# Manual: start a long-running agent response. Confirm the hint bar appears
# above the composer with Interrupt, Queue, Steer, and New Chat pills.
# Click Queue with an empty composer: verify /queue is prefilled.
# Click New Chat: verify a new session opens in the sidebar.
```

### Risks / Follow-ups

- Phase 2 (per-message hover toolbar for /retry, /undo) is deferred per issue scope.
- Clicking a pill when the composer already has content is a no-op (guard on empty). Inserting at cursor position is a follow-up.
- `/steer` pill hides when `_trySteer` is unavailable, matching `getComposerPrimaryAction` gating. If `_trySteer` is absent in some builds, the pill is cleanly absent.
- No new i18n keys: all four labels reuse existing translated strings.

### Model Used

Claude Opus 4.8 via Claude Code CLI

Closes #1804
