### PR TITLE
fix(sidebar): render messaging source badges as chips, not just CLI ones

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4398,7 +4398,7 @@ function renderSessionListFromCache(){
     if(animateRefresh&&(enterAllAnimatedRows||!(flipBefore&&flipBefore.has(s.session_id)))){
       el.classList.add('session-list-flip-enter');
     }
-    if(s.is_cli_session){
+    if(s.is_cli_session||_isMessagingSession(s)){
       el.classList.add('cli-session');
       el.dataset.source=_getChannelLabel(s)||'CLI';
       el.dataset.sourceKey=_sourceKeyForSession(s)||'cli';
@@ -4535,6 +4535,14 @@ function renderSessionListFromCache(){
       };
       titleRow.appendChild(childCountEl);
     }
+    if(s.is_cli_session||_isMessagingSession(s)){
+      const chipLabel=_getChannelLabel(s)||'CLI';
+      const chip=document.createElement('span');
+      chip.className='session-source-chip';
+      chip.textContent=chipLabel;
+      chip.dataset.sourceKey=_sourceKeyForSession(s)||'cli';
+      titleRow.appendChild(chip);
+    }
     titleRow.appendChild(ts);
     sessionText.appendChild(titleRow);
     if(density==='detailed'){
@@ -4548,7 +4556,7 @@ function renderSessionListFromCache(){
       const modelMeta=_formatSessionModelWithGateway(s);
       if(modelMeta) metaBits.push(modelMeta);
       const sourceLabel=_getChannelLabel(s);
-      if(s.is_cli_session&&sourceLabel) metaBits.push(sourceLabel);
+      if(sourceLabel&&(s.is_cli_session||_isMessagingSession(s))) metaBits.push(sourceLabel);
       if(readOnly) metaBits.push('read-only');
       if(_showAllProfiles&&s.profile) metaBits.push(s.profile);
       const meta=document.createElement('div');

--- a/static/style.css
+++ b/static/style.css
@@ -3844,38 +3844,42 @@ main.main > #mainPlugin{display:none;}
 
 /* ── CLI / Agent session items in sidebar ── */
 .session-item.cli-session {
-  padding-right: 40px; /* make room for the session actions trigger */
+  padding-right: 6px;
 }
-.session-item.cli-session::after {
-  content: attr(data-source);
+/* Source chip (pill) in the sidebar title row */
+.session-source-chip {
   font-size: 9px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: .04em;
   color: var(--accent-text);
-  opacity: .5;
-  margin-left: auto;
+  opacity: .65;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: rgba(128, 128, 128, 0.12);
+  background: color-mix(in srgb, var(--accent-text) 12%, transparent);
   flex-shrink: 0;
-  pointer-events: none; /* don't block clicks on session-actions beneath */
+  line-height: 1.4;
+  white-space: nowrap;
 }
-.session-item.cli-session:not(.read-only-session):hover::after {
-  display: none; /* hide badge on hover so the session menu trigger stays clear */
+.session-item:not(.read-only-session):hover .session-source-chip {
+  display: none;
 }
-.session-item.cli-session.read-only-session:hover::after {
-  opacity: .75;
+.session-item.read-only-session:hover .session-source-chip {
+  opacity: .85;
 }
-.session-item.cli-session.menu-open::after {
+.session-item.menu-open .session-source-chip {
   display: none;
 }
 /* Source-specific colors for gateway sessions */
 .session-item.cli-session[data-source-key="telegram"] { border-left-color: rgba(0, 136, 204, 0.55); }
-.session-item.cli-session[data-source-key="telegram"]::after { color: rgba(0, 136, 204, 0.55); }
+.session-source-chip[data-source-key="telegram"] { color: rgba(0, 136, 204, 0.85); background: rgba(0, 136, 204, 0.12); }
 .session-item.cli-session[data-source-key="discord"] { border-left-color: #5865F2; }
-.session-item.cli-session[data-source-key="discord"]::after { color: #5865F2; }
+.session-source-chip[data-source-key="discord"] { color: #5865F2; background: rgba(88, 101, 242, 0.12); }
 .session-item.cli-session[data-source-key="slack"] { border-left-color: #4A154B; }
-.session-item.cli-session[data-source-key="slack"]::after { color: #4A154B; }
+.session-source-chip[data-source-key="slack"] { color: #4A154B; background: rgba(74, 21, 75, 0.12); }
 .session-item.cli-session[data-source-key="claude_code"] { border-left-color: rgba(217, 119, 6, 0.65); }
-.session-item.cli-session[data-source-key="claude_code"]::after { color: rgba(217, 119, 6, 0.85); }
+.session-source-chip[data-source-key="claude_code"] { color: rgba(217, 119, 6, 0.85); background: rgba(217, 119, 6, 0.12); }
 
 /* ═══════════════════════════════════════════════════════════════════
    Messages redesign — additive overrides for the transcript area.

--- a/tests/test_claude_code_session_import.py
+++ b/tests/test_claude_code_session_import.py
@@ -238,7 +238,7 @@ def test_read_only_source_badge_ui_guards_are_present():
     assert "topbar-source-badge" in panels_js
     assert "S.session.read_only || S.session.is_read_only" in panels_js
     assert 'data-source-key="claude_code"' in style_css
-    assert ".session-item.cli-session.read-only-session:hover::after" in style_css
+    assert ".session-item.read-only-session:hover .session-source-chip" in style_css
     assert "Read-only imported sessions cannot be deleted" in routes_py
     assert "Read-only imported sessions cannot be archived" in routes_py
 
@@ -258,3 +258,21 @@ def test_messaging_source_badge_not_gated_on_is_cli_session():
     # (source_label 'WebUI' from api/session_recovery.py) don't badge the chat pane (#3338).
     assert "/^webui$/i.test(sourceLabel)" in ui_js
     assert "/^webui$/i.test(sourceLabel)" in panels_js
+
+
+def test_messaging_source_badge_in_sidebar_not_gated_on_is_cli_session():
+    sessions_js = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+    style_css = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+    assert "function _isMessagingSession" in sessions_js
+    assert sessions_js.count("if(s.is_cli_session||_isMessagingSession(s)){") == 2
+    assert "if(s.is_cli_session&&sourceLabel) metaBits.push(sourceLabel);" not in sessions_js
+    assert (
+        "if(sourceLabel&&(s.is_cli_session||_isMessagingSession(s))) metaBits.push(sourceLabel);"
+        in sessions_js
+    )
+    assert "session-source-chip" in sessions_js
+    assert ".session-source-chip" in style_css
+    assert '.session-source-chip[data-source-key="telegram"]' in style_css
+    assert '.session-source-chip[data-source-key="discord"]' in style_css
+    assert '.session-item.cli-session[data-source-key="telegram"]' in style_css


### PR DESCRIPTION
## Thinking Path

- #3502 made the chat-pane topbar source badge render for messaging sessions by decoupling it from `is_cli_session`, but it only touched the topbar (`static/panels.js`, `static/ui.js`). The sidebar rows are built separately in `static/sessions.js` and still gate the badge on `is_cli_session`.
- The sidebar badge was a `::after` pseudo-element on `.session-item.cli-session` using `content: attr(data-source)`, positioned with `margin-left: auto` at the far right of the row. In the `renderSessionListFromCache` row builder, `sessions.js` sets the `cli-session` class and data attributes only inside `if(s.is_cli_session)`, and the detailed-density meta source label is gated the same way.
- `is_cli_session_row()` (`api/agent_sessions.py`) intentionally returns `False` for messaging sources, so messaging rows reach the sidebar with `is_cli_session=false`, never get the class or attribute, and render no badge, even though `source_label`/`source_tag`/`raw_source` are populated and the CSS already ships per-platform colors.
- The predicate is coupled to the wrong semantic, exactly as in #3502: it asks "is this a CLI session?" when it should ask "does this session have a displayable source?" The fix reuses the existing `_isMessagingSession()` helper to extend both gates to messaging, leaving the CLI path and the backend `is_cli_session_row()` contract unchanged.
- While decoupling, the old `::after` pseudo-element badge was replaced with a real DOM element (`.session-source-chip`) inside the title row, rendered as a pill/chip to the left of the timestamp. This improves visual hierarchy: the badge sits inline with the title instead of floating at the row edge with awkward spacing. The per-platform colors now apply to the chip background and text, and the left-border accent colors remain on the row.

## What Changed

- **`static/sessions.js`** (`renderSessionListFromCache` row builder): the badge-attribute block (`cli-session` class + `data-source` + `data-source-key`) now runs for `s.is_cli_session||_isMessagingSession(s)` instead of `s.is_cli_session` alone. A new `<span class="session-source-chip">` element is appended to the title row (before the timestamp) for sessions with a displayable source. The detailed-density meta source label uses the same union gate. The CLI-only import-on-click path is untouched.
- **`static/style.css`**: the `::after` pseudo-element badge is replaced by `.session-source-chip` styles (pill shape, uppercase 9px text, `color-mix` background, per-platform colors for telegram/discord/slack/claude_code). The chip hides on hover and menu-open to keep the actions trigger clear, matching the old `::after` behavior. The `padding-right: 40px` override (no longer needed without the `::after`) is replaced with the base 6px to align timestamps across rows.
- **`tests/test_claude_code_session_import.py`**: updated `test_messaging_source_badge_in_sidebar_not_gated_on_is_cli_session` to assert the chip element class exists in both JS and CSS, per-platform chip color rules exist, and the sidebar left-border colors are preserved. Mirrors the existing topbar test pattern.

## Why It Matters

Messaging sessions (Telegram, WeChat, Discord) now show their platform badge in the sidebar as a chip, matching the topbar fix from #3502 so a session's origin is visible in both places. This is the sidebar half of #3338, flagged in a follow-up comment after #3502 shipped.

## Verification

- `pytest tests/test_claude_code_session_import.py -v --timeout=60`
- `pytest tests/ -q --timeout=60 --continue-on-collection-errors` (full suite; the real gate is CI on Linux. Locally on Windows ~20 unrelated files fail collection with `UnicodeDecodeError: 'charmap'`, a pre-existing issue not from this change.)
- `node --check static/sessions.js`
- Manual: with a messaging session present, confirm the sidebar row shows its platform chip (for example "DISCORD" or "TELEGRAM") with per-platform coloring to the left of the timestamp; confirm CLI sessions still show their chip and plain WebUI sessions show none.

## Screenshots

- Before:
<img width="1934" height="1259" alt="before" src="https://github.com/user-attachments/assets/823f9e47-70f0-4c47-bbff-840dd95dc795" />

- After:
<img width="1934" height="1259" alt="after" src="https://github.com/user-attachments/assets/958ff2fe-79d4-4ee9-ae7d-d42a44c6f6f6" />

## Risks / Follow-ups

- The `cli-session` CSS class is reused as the badge hook for messaging rows. It is a pure styling hook (no JS reads the class back), so reusing it for messaging rows lights up the existing left-border color with no behavioral change. The class name is now a slight misnomer for messaging rows; renaming it is a broader CSS change left out of scope.
- WeChat (`weixin`) and Email rows render the chip in the default accent color; per-platform colors currently exist only for telegram/discord/slack/claude_code. Adding `weixin`/`email` tints is an optional follow-up.
- Sessions that are both `is_cli_session` and messaging-classed (gateway sessions) are unaffected: the OR is still true and renders one chip as before.
- The test asserts on source text rather than the runtime DOM, matching the existing source-badge tests; the live render is covered by manual and screenshot verification.

## Model Used

Claude Opus 4.6 via Claude Code CLI
