### PR TITLE
fix(streaming): persist reasoning metadata to intermediate assistant messages on settlement (#3587)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4782,7 +4782,7 @@ def _run_agent_streaming(
                 return True
 
             def on_tool(*cb_args, **cb_kwargs):
-                nonlocal _reasoning_segments, _current_reasoning_idx
+                nonlocal _reasoning_segments
                 event_type = None
                 name = None
                 preview = None

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4639,7 +4639,11 @@ def _run_agent_streaming(
         try:
             _token_sent = False  # tracks whether any streamed tokens were sent
             _self_healed = False  # (#1401) prevents infinite self-heal retries
-            _reasoning_text = ''  # accumulates reasoning/thinking trace for persistence
+            # Per-message reasoning: dict maps assistant-message index → accumulated text
+            # (#3587) replaces the flat _reasoning_text string so each intermediate
+            # assistant turn (before tool calls) keeps its own reasoning segment.
+            _reasoning_segments: dict = {}
+            _current_reasoning_idx = 0
             _live_tool_calls = []  # tool progress fallback when final messages omit tool IDs
 
             # Throttle: emit metering events at most every 100 ms so the per-message
@@ -4689,7 +4693,7 @@ def _run_agent_streaming(
                 _emit_metering()
 
             def on_reasoning(text):
-                nonlocal _reasoning_text
+                nonlocal _reasoning_segments, _current_reasoning_idx
                 if text is None:
                     return
                 reasoning_delta = str(text)
@@ -4699,8 +4703,13 @@ def _run_agent_streaming(
                 # same sentence again inside a Thinking card.
                 if _is_visible_output_echo(reasoning_delta):
                     return
-                _reasoning_text += reasoning_delta
-                # Mirror to shared dict so cancel_stream() can persist it (#1361 §A)
+                # Accumulate into the current message's segment (#3587)
+                _reasoning_segments[_current_reasoning_idx] = (
+                    _reasoning_segments.get(_current_reasoning_idx, '') + reasoning_delta
+                )
+                # Mirror full concatenation to shared dict so cancel_stream() can persist
+                # it (#1361 §A). Cancel only creates one partial message, so the flat
+                # concatenation is correct there.
                 if stream_id in STREAM_REASONING_TEXT:
                     STREAM_REASONING_TEXT[stream_id] += reasoning_delta
                 put('reasoning', {'text': reasoning_delta})
@@ -4710,6 +4719,7 @@ def _run_agent_streaming(
                 _emit_metering()
 
             def on_interim_assistant(text, **cb_kwargs):
+                nonlocal _current_reasoning_idx
                 if text is None:
                     return
                 visible = str(text).strip()
@@ -4720,6 +4730,10 @@ def _run_agent_streaming(
                     'text': visible,
                     'already_streamed': already_streamed,
                 })
+                # A new assistant segment is starting after tool results; advance the
+                # per-message reasoning index so subsequent reasoning deltas are
+                # attributed to the next assistant message (#3587).
+                _current_reasoning_idx += 1
 
             # Pre-initialise the activity counter here so on_tool (which
             # closes over it) never captures an unbound name even if this
@@ -4768,7 +4782,7 @@ def _run_agent_streaming(
                 return True
 
             def on_tool(*cb_args, **cb_kwargs):
-                nonlocal _reasoning_text
+                nonlocal _reasoning_segments, _current_reasoning_idx
                 event_type = None
                 name = None
                 preview = None
@@ -4794,8 +4808,11 @@ def _run_agent_streaming(
                         # Suppress those echoes like the dedicated reasoning callback.
                         if _is_visible_output_echo(reason_delta):
                             return
-                        _reasoning_text += reason_delta
-                        # Mirror to shared dict so cancel_stream() can persist it (#1361 §A)
+                        # Accumulate into the current message's segment (#3587)
+                        _reasoning_segments[_current_reasoning_idx] = (
+                            _reasoning_segments.get(_current_reasoning_idx, '') + reason_delta
+                        )
+                        # Mirror full concatenation to shared dict (#1361 §A)
                         if stream_id in STREAM_REASONING_TEXT:
                             STREAM_REASONING_TEXT[stream_id] += reason_delta
                         put('reasoning', {'text': reason_delta})
@@ -6141,11 +6158,17 @@ def _run_agent_streaming(
                 # persisted session file 30-50% and bypassing the thinking card. The
                 # split is leading-only/single-block so mid-body literal tags (e.g. in
                 # a fenced code block) stay visible content.
+                #
+                # #3587: use per-message segments so intermediate assistant turns
+                # (before tool calls) each receive their own reasoning trace rather
+                # than all reasoning being written only to the last assistant message.
                 if s.messages:
-                    for _rm in reversed(s.messages):
+                    _asst_count = 0
+                    for _rm in s.messages:
                         if not (isinstance(_rm, dict) and _rm.get('role') == 'assistant'):
                             continue
-                        _existing_reasoning = _reasoning_text or _rm.get('reasoning') or ''
+                        _seg_reasoning = _reasoning_segments.get(_asst_count, '')
+                        _existing_reasoning = _seg_reasoning or _rm.get('reasoning') or ''
                         _content = _rm.get('content')
                         if isinstance(_content, str) and _content:
                             _new_content, _merged_reasoning = _split_thinking_from_content(
@@ -6156,7 +6179,7 @@ def _run_agent_streaming(
                                 _rm['reasoning'] = _merged_reasoning
                         elif _existing_reasoning:
                             _rm['reasoning'] = _existing_reasoning
-                        break
+                        _asst_count += 1
                 try:
                     _turn_duration_seconds = max(0.0, time.time() - float(_turn_started_at))
                 except Exception:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4720,6 +4720,11 @@ def _run_agent_streaming(
 
             def on_interim_assistant(text, **cb_kwargs):
                 nonlocal _current_reasoning_idx
+                # Advance the per-message reasoning index unconditionally (#3587):
+                # even if this callback fires with empty text, a new assistant
+                # segment is starting and subsequent reasoning must be attributed
+                # to the next message.
+                _current_reasoning_idx += 1
                 if text is None:
                     return
                 visible = str(text).strip()
@@ -4730,10 +4735,6 @@ def _run_agent_streaming(
                     'text': visible,
                     'already_streamed': already_streamed,
                 })
-                # A new assistant segment is starting after tool results; advance the
-                # per-message reasoning index so subsequent reasoning deltas are
-                # attributed to the next assistant message (#3587).
-                _current_reasoning_idx += 1
 
             # Pre-initialise the activity counter here so on_tool (which
             # closes over it) never captures an unbound name even if this

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4644,6 +4644,7 @@ def _run_agent_streaming(
             # assistant turn (before tool calls) keeps its own reasoning segment.
             _reasoning_segments: dict = {}
             _current_reasoning_idx = 0
+            _tool_boundary_advanced = False
             _live_tool_calls = []  # tool progress fallback when final messages omit tool IDs
 
             # Throttle: emit metering events at most every 100 ms so the per-message
@@ -4693,9 +4694,10 @@ def _run_agent_streaming(
                 _emit_metering()
 
             def on_reasoning(text):
-                nonlocal _reasoning_segments, _current_reasoning_idx
+                nonlocal _reasoning_segments, _current_reasoning_idx, _tool_boundary_advanced
                 if text is None:
                     return
+                _tool_boundary_advanced = False
                 reasoning_delta = str(text)
                 # Some runtimes mirror user-visible progress text through the
                 # reasoning channel after it already streamed as normal assistant
@@ -4783,7 +4785,7 @@ def _run_agent_streaming(
                 return True
 
             def on_tool(*cb_args, **cb_kwargs):
-                nonlocal _reasoning_segments
+                nonlocal _reasoning_segments, _current_reasoning_idx, _tool_boundary_advanced
                 event_type = None
                 name = None
                 preview = None
@@ -4821,6 +4823,15 @@ def _run_agent_streaming(
                         meter().record_reasoning(stream_id, _metering_reasoning_deltas[0])
                         _emit_metering()
                     return
+
+                # (#3587) Advance reasoning index at tool-call boundaries.
+                # on_interim_assistant is suppressed for contentless tool-call
+                # messages (run_agent.py:3834), so the index never advances
+                # there. The first tool.started event after reasoning indicates
+                # a new assistant message boundary.
+                if not _tool_boundary_advanced and _current_reasoning_idx in _reasoning_segments:
+                    _current_reasoning_idx += 1
+                    _tool_boundary_advanced = True
 
                 args_snap = _tool_args_snapshot(args)
 
@@ -6163,12 +6174,22 @@ def _run_agent_streaming(
                 # #3587: use per-message segments so intermediate assistant turns
                 # (before tool calls) each receive their own reasoning trace rather
                 # than all reasoning being written only to the last assistant message.
+                # Scope the walk to this turn's newly-appended assistant messages
+                # to prevent cross-turn reasoning clobber (multi-turn off-by-N).
                 if s.messages:
+                    _prev_asst = sum(
+                        1 for m in (_previous_messages or [])
+                        if isinstance(m, dict) and m.get('role') == 'assistant'
+                    )
                     _asst_count = 0
                     for _rm in s.messages:
                         if not (isinstance(_rm, dict) and _rm.get('role') == 'assistant'):
                             continue
-                        _seg_reasoning = _reasoning_segments.get(_asst_count, '')
+                        _turn_idx = _asst_count
+                        _asst_count += 1
+                        if _turn_idx < _prev_asst:
+                            continue  # prior-turn message — never touch its reasoning
+                        _seg_reasoning = _reasoning_segments.get(_turn_idx - _prev_asst, '')
                         _existing_reasoning = _seg_reasoning or _rm.get('reasoning') or ''
                         _content = _rm.get('content')
                         if isinstance(_content, str) and _content:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -6201,7 +6201,6 @@ def _run_agent_streaming(
                                 _rm['reasoning'] = _merged_reasoning
                         elif _existing_reasoning:
                             _rm['reasoning'] = _existing_reasoning
-                        _asst_count += 1
                 try:
                     _turn_duration_seconds = max(0.0, time.time() - float(_turn_started_at))
                 except Exception:

--- a/tests/test_issue3587_intermediate_reasoning.py
+++ b/tests/test_issue3587_intermediate_reasoning.py
@@ -1,0 +1,177 @@
+"""Regression tests for issue #3587: intermediate assistant message reasoning lost.
+
+During multi-turn streaming (assistant reasons → calls tool → reasons again →
+responds), the flat _reasoning_text accumulator was written only to the LAST
+assistant message on settlement. Intermediate assistant messages (before tool
+calls) permanently lost their reasoning traces.
+
+Fix: replace the flat accumulator with a per-message dict (_reasoning_segments),
+track assistant message transitions via on_interim_assistant, and iterate forward
+through s.messages on settlement so each assistant message receives its own
+reasoning segment.
+"""
+
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).parent.parent
+
+
+def read(rel):
+    return (REPO / rel).read_text(encoding='utf-8')
+
+
+# ── 1. Flat accumulator is replaced ──────────────────────────────────────────
+
+
+class TestAccumulatorReplaced:
+    """The flat string accumulator must be replaced by a per-message dict."""
+
+    def test_bare_string_declaration_removed(self):
+        src = read('api/streaming.py')
+        # The old declaration was exactly: _reasoning_text = ''
+        # It must no longer exist as a bare string assignment (the comment that
+        # mentions it by name is allowed, but the assignment itself must be gone).
+        assert "_reasoning_text = ''" not in src, (
+            "_reasoning_text = '' bare declaration must be replaced by the "
+            "per-message _reasoning_segments dict (#3587)"
+        )
+
+    def test_segments_dict_declared(self):
+        src = read('api/streaming.py')
+        assert '_reasoning_segments' in src, (
+            "_reasoning_segments dict must be declared in api/streaming.py"
+        )
+        assert '_current_reasoning_idx' in src, (
+            "_current_reasoning_idx counter must be declared in api/streaming.py"
+        )
+
+    def test_segments_dict_is_dict_type(self):
+        src = read('api/streaming.py')
+        # Declaration must be an empty dict, not a string
+        assert re.search(r'_reasoning_segments\s*(?::\s*dict\s*)?\=\s*\{\}', src), (
+            "_reasoning_segments must be initialized as an empty dict"
+        )
+
+
+# ── 2. on_reasoning indexes into per-message dict ────────────────────────────
+
+
+class TestOnReasoningPerMessageIndexing:
+    """The on_reasoning callback must index into _reasoning_segments using
+    _current_reasoning_idx instead of appending to a flat string."""
+
+    def _on_reasoning_body(self):
+        src = read('api/streaming.py')
+        m = re.search(
+            r'def on_reasoning\(text\):\s*\n(.*?)(?=\n\s{12}def |\n\s{8}def )',
+            src, re.DOTALL,
+        )
+        assert m, "on_reasoning function not found in api/streaming.py"
+        return m.group(1)
+
+    def test_on_reasoning_uses_segments_not_flat_string(self):
+        body = self._on_reasoning_body()
+        assert '_reasoning_segments' in body, (
+            "on_reasoning must accumulate into _reasoning_segments, not a flat string"
+        )
+        assert "_reasoning_text +=" not in body, (
+            "on_reasoning must not use the old flat _reasoning_text += pattern"
+        )
+
+    def test_on_reasoning_indexes_by_current_idx(self):
+        body = self._on_reasoning_body()
+        assert '_current_reasoning_idx' in body, (
+            "on_reasoning must reference _current_reasoning_idx to attribute "
+            "reasoning deltas to the correct assistant message"
+        )
+
+    def test_stream_reasoning_text_mirror_still_present(self):
+        """cancel_stream() uses STREAM_REASONING_TEXT for its own partial-message
+        persist path; this mirror must remain even after the per-message fix."""
+        body = self._on_reasoning_body()
+        assert 'STREAM_REASONING_TEXT' in body, (
+            "on_reasoning must still mirror to STREAM_REASONING_TEXT so "
+            "cancel_stream() can persist reasoning on mid-stream cancellation"
+        )
+
+
+# ── 3. on_interim_assistant advances the index ───────────────────────────────
+
+
+class TestInterimAssistantAdvancesIndex:
+    """on_interim_assistant fires when a new assistant segment starts after tool
+    results. It must increment _current_reasoning_idx so subsequent reasoning
+    deltas are attributed to the next assistant message."""
+
+    def _interim_body(self):
+        src = read('api/streaming.py')
+        m = re.search(
+            r'def on_interim_assistant\(text.*?\):\s*\n(.*?)(?=\n\s{12}def |\n\s{8}def )',
+            src, re.DOTALL,
+        )
+        assert m, "on_interim_assistant function not found in api/streaming.py"
+        return m.group(1)
+
+    def test_interim_assistant_increments_idx(self):
+        body = self._interim_body()
+        assert '_current_reasoning_idx' in body, (
+            "on_interim_assistant must increment _current_reasoning_idx to "
+            "advance the per-message reasoning segment pointer (#3587)"
+        )
+        assert re.search(r'_current_reasoning_idx\s*\+=\s*1', body), (
+            "on_interim_assistant must use += 1 to advance the segment index"
+        )
+
+
+# ── 4. Settlement loop iterates forward, not reversed+break ──────────────────
+
+
+class TestSettlementLoopForward:
+    """The settlement loop must iterate forward through s.messages so each
+    assistant message can be matched to its own reasoning segment by index.
+    The old reversed()+break pattern only wrote reasoning to the last message."""
+
+    def _settlement_block(self):
+        """Extract the reasoning-persistence settlement block from streaming.py."""
+        src = read('api/streaming.py')
+        # Anchor on the comment that appears just before the settlement block
+        start = src.find('# #3587: use per-message segments')
+        assert start >= 0, (
+            "Settlement block comment '#3587: use per-message segments' not found; "
+            "the block may have been moved or the comment changed"
+        )
+        # Grab enough context to cover the loop
+        return src[start:start + 1500]
+
+    def test_settlement_does_not_reverse_iterate_with_break(self):
+        block = self._settlement_block()
+        # The old pattern was: for _rm in reversed(s.messages): ... break
+        # Both conditions must be gone from the settlement block.
+        has_reversed_break = (
+            'reversed(s.messages)' in block and
+            re.search(r'\bbreak\b', block)
+        )
+        assert not has_reversed_break, (
+            "Settlement loop must not use reversed(s.messages)+break; "
+            "that pattern writes reasoning only to the last assistant message"
+        )
+
+    def test_settlement_iterates_forward_with_counter(self):
+        block = self._settlement_block()
+        # Forward iteration with an assistant counter
+        assert 'for _rm in s.messages' in block, (
+            "Settlement loop must iterate forward (for _rm in s.messages) "
+            "to match each assistant message to its reasoning segment"
+        )
+        assert '_asst_count' in block, (
+            "Settlement loop must use an assistant message counter (_asst_count) "
+            "to index into _reasoning_segments"
+        )
+
+    def test_settlement_reads_from_segments_dict(self):
+        block = self._settlement_block()
+        assert '_reasoning_segments.get' in block, (
+            "Settlement loop must read from _reasoning_segments.get(idx) "
+            "to retrieve the per-message reasoning trace"
+        )

--- a/tests/test_issue3587_intermediate_reasoning.py
+++ b/tests/test_issue3587_intermediate_reasoning.py
@@ -175,3 +175,93 @@ class TestSettlementLoopForward:
             "Settlement loop must read from _reasoning_segments.get(idx) "
             "to retrieve the per-message reasoning trace"
         )
+
+
+# ── 5. Multi-turn offset prevents cross-turn reasoning clobber ──────────────
+
+
+class TestMultiTurnOffset:
+    """The settlement loop must skip prior-turn assistant messages so that
+    _reasoning_segments (indexed from 0 for this turn only) doesn't overwrite
+    reasoning stored on earlier turns."""
+
+    def _settlement_block(self):
+        src = read('api/streaming.py')
+        start = src.find('# #3587: use per-message segments')
+        assert start >= 0, 'Settlement block not found'
+        return src[start:start + 1500]
+
+    def test_settlement_computes_prev_asst_offset(self):
+        block = self._settlement_block()
+        assert '_prev_asst' in block, (
+            "Settlement loop must compute _prev_asst (count of assistant "
+            "messages in _previous_messages) to offset the segment index"
+        )
+
+    def test_settlement_skips_prior_turn_messages(self):
+        block = self._settlement_block()
+        assert re.search(r'if\s+_turn_idx\s*<\s*_prev_asst\s*:', block), (
+            "Settlement loop must skip prior-turn messages with "
+            "if _turn_idx < _prev_asst: continue"
+        )
+
+    def test_segment_index_subtracts_offset(self):
+        block = self._settlement_block()
+        assert re.search(r'_turn_idx\s*-\s*_prev_asst', block), (
+            "Segment index must subtract _prev_asst offset so indexing "
+            "starts at 0 for this turn's first assistant message"
+        )
+
+
+# ── 6. Tool-call boundary advances reasoning index ────────────────────────────
+
+
+class TestToolCallBoundary:
+    """on_interim_assistant is suppressed for contentless tool-call assistant
+    messages (run_agent.py:3834 early-returns when content is empty). The
+    reasoning index must advance at tool-call boundaries instead, so reasoning
+    accumulated before a tool-call-only assistant message gets its own segment."""
+
+    def _on_tool_body(self):
+        src = read('api/streaming.py')
+        m = re.search(
+            r'def on_tool\(\*cb_args.*?\):\s*\n(.*?)(?=\n\s{12}def |\n\s{8}def )',
+            src, re.DOTALL,
+        )
+        assert m, "on_tool function not found in api/streaming.py"
+        return m.group(1)
+
+    def test_on_tool_advances_reasoning_idx(self):
+        body = self._on_tool_body()
+        assert '_current_reasoning_idx' in body, (
+            "on_tool must reference _current_reasoning_idx to advance the "
+            "reasoning segment at tool-call boundaries (#3587)"
+        )
+
+    def test_tool_boundary_guard_prevents_double_advance(self):
+        body = self._on_tool_body()
+        assert '_tool_boundary_advanced' in body, (
+            "on_tool must use a _tool_boundary_advanced guard so multiple "
+            "tool calls in one assistant message only advance the index once"
+        )
+
+    def test_tool_boundary_flag_declared(self):
+        src = read('api/streaming.py')
+        assert '_tool_boundary_advanced' in src, (
+            "_tool_boundary_advanced flag must be declared in streaming.py"
+        )
+
+    def test_reasoning_resets_tool_boundary_flag(self):
+        """New reasoning arriving after a tool boundary must reset the guard
+        so the next tool-call batch can advance the index again."""
+        src = read('api/streaming.py')
+        m = re.search(
+            r'def on_reasoning\(text\):\s*\n(.*?)(?=\n\s{12}def |\n\s{8}def )',
+            src, re.DOTALL,
+        )
+        assert m, "on_reasoning function not found"
+        body = m.group(1)
+        assert '_tool_boundary_advanced' in body, (
+            "on_reasoning must reset _tool_boundary_advanced so the next "
+            "tool-call batch can advance the reasoning index"
+        )

--- a/tests/test_issue3587_intermediate_reasoning.py
+++ b/tests/test_issue3587_intermediate_reasoning.py
@@ -265,3 +265,28 @@ class TestToolCallBoundary:
             "on_reasoning must reset _tool_boundary_advanced so the next "
             "tool-call batch can advance the reasoning index"
         )
+
+
+# ── 7. Settlement counter increments exactly once per assistant message ────
+
+
+class TestSettlementCounterSingleIncrement:
+    """_asst_count must increment exactly once per assistant message in the
+    settlement loop. A double increment causes every message after the first
+    to look up a segment index that doesn't exist, silently discarding its
+    reasoning (the exact data-loss scenario the refactor was meant to fix)."""
+
+    def _settlement_block(self):
+        src = read('api/streaming.py')
+        start = src.find('# #3587: use per-message segments')
+        assert start >= 0
+        return src[start:start + 1500]
+
+    def test_single_increment_per_iteration(self):
+        block = self._settlement_block()
+        count = block.count('_asst_count += 1')
+        assert count == 1, (
+            f"_asst_count must be incremented exactly once per loop iteration, "
+            f"found {count} increments. A double increment causes segment index "
+            f"doubling: message N looks up segment 2*N instead of N."
+        )

--- a/tests/test_pr1341_context_window_persistence.py
+++ b/tests/test_pr1341_context_window_persistence.py
@@ -46,7 +46,7 @@ def test_streaming_persists_context_fields_on_session_before_save():
     # structural check (presence of s.save() shortly after the post-merge marker)
     # would be more durable; left as a follow-up. Earlier limits: 9000 (cancellation
     # guards) → 13000 (#3263 v1) → 15000 (#3256/#3263 dual-gate).
-    assert save_call - block_start < 16000, (
+    assert save_call - block_start < 18000, (
         "s.save() should be close to the post-merge marker — block expanded unexpectedly. "
         "If you've added a new pre-save mutation block here, bump this limit."
     )

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -685,16 +685,16 @@ def test_cleanTitle_is_let_not_const():
 
 # ── Sprint 42 additional tests: thinking panel persistence (#427) ────────
 def test_streaming_persists_reasoning_in_session():
-    """streaming.py must accumulate reasoning_text and patch last assistant message."""
+    """streaming.py must accumulate reasoning and patch assistant messages."""
     src = (REPO / 'api' / 'streaming.py').read_text()
 
-    # _reasoning_text must be initialised
-    assert "_reasoning_text = ''" in src, \
-        "_reasoning_text variable not initialised in streaming.py"
+    # #3587: per-message reasoning segments replaced the flat _reasoning_text accumulator
+    assert "_reasoning_segments" in src, \
+        "_reasoning_segments dict not found in streaming.py"
 
-    # on_reasoning must accumulate non-echo reasoning into _reasoning_text
-    assert '_reasoning_text += reasoning_delta' in src, \
-        "on_reasoning callback does not accumulate accepted reasoning deltas into _reasoning_text"
+    # on_reasoning must accumulate non-echo reasoning into segments
+    assert '_reasoning_segments[_current_reasoning_idx]' in src or '_reasoning_segments.get(_current_reasoning_idx' in src, \
+        "on_reasoning callback does not accumulate into per-message _reasoning_segments"
     assert '_is_visible_output_echo(reasoning_delta)' in src, \
         "on_reasoning callback should suppress reasoning deltas that only echo visible streamed output"
 


### PR DESCRIPTION
Closes #3587

## Thinking Path

- During multi-turn tool-calling flows, the model produces multiple assistant messages, each potentially preceded by a reasoning/thinking trace.
- The streaming layer captures all reasoning deltas into a single `_reasoning_text` string accumulator (line 4612 in `api/streaming.py`).
- On settlement, the persistence loop walks `s.messages` in reverse and writes `_reasoning_text` to only the first (i.e., last) assistant message it finds, then breaks. Intermediate assistant messages that had reasoning before issuing tool calls lose that metadata permanently.
- Switching from a flat string to a per-assistant-message dict ensures each assistant segment's reasoning is persisted to its own message.

## What Changed

- `api/streaming.py`: Replaced the single `_reasoning_text` string accumulator with `_reasoning_segments`, a dict keyed by assistant message index. Updated `on_reasoning` to associate reasoning deltas with the current assistant message. Updated the settlement persistence loop to iterate forward through `s.messages` and write each segment's reasoning to its corresponding assistant message.
- `tests/test_issue3587_intermediate_reasoning.py`: Static-analysis test verifying the accumulator is no longer a flat string, the callback indexes into a per-message structure, and the settlement loop does not use `reversed()` with a single `break` to write only the last message.

## Why It Matters

When a model reasons before each tool call in a multi-step flow, all intermediate reasoning traces are silently discarded on settlement. Users who expand the thinking card on an intermediate assistant message see nothing, even though the reasoning was visible during streaming. This is especially confusing with "show reasoning" enabled, since the thinking cards appear during streaming and vanish on settlement.

## Verification

```
pytest tests/test_issue3587_intermediate_reasoning.py -v --timeout=60
pytest tests/ -v --timeout=60
```

Manual: start a multi-turn chat that triggers tool calls (e.g., "search for X then summarize") with a reasoning model. Verify that after the response settles, expanding the thinking card on the intermediate assistant message (before the tool call) shows the reasoning trace, not empty content.

## Risks / Follow-ups

- The `STREAM_REASONING_TEXT` dict (used by `cancel_stream` for mid-stream cancellation) still needs the full concatenated text. The implementation keeps this mirror updated with the combined string across all segments.
- `_restore_reasoning_metadata` operates on per-message `reasoning` fields and does not need changes, since the fix writes per-message fields at persistence time.
- The `_split_thinking_from_content` call in the settlement loop now runs on each assistant message that has reasoning, not just the last.

## Model Used

Claude Opus 4.8 via Claude Code CLI