### PR TITLE
fix(settings): show update banner from any panel, not just Chat (#3597)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1276,7 +1276,7 @@
                 <div class="settings-section-title" data-i18n="settings_section_system_title">System</div>
                 <div class="settings-section-meta" data-i18n="settings_section_system_meta">Instance version and access controls.</div>
               </div>
-              <div id="checkUpdatesBlock" style="display:flex;flex-wrap:wrap;align-items:center;gap:0.5em">
+              <div id="checkUpdatesBlock">
                 <span class="settings-version-badge" id="settings-webui-version-badge">WebUI: —</span>
                 <span class="settings-version-badge" id="settings-agent-version-badge">Agent: not detected</span>
                 <button class="btn-tiny" id="btnCheckUpdatesNow" onclick="checkUpdatesNow()" title="Check for updates now" data-i18n-title="settings_check_now"><svg id="checkUpdatesSpinner" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="spinner-xs" aria-hidden="true"><path d="M21 12a9 9 0 1 1-6.219-8.56"/><polyline points="21 3 21 9 15 9"/></svg><span id="checkUpdatesLabel" data-i18n="settings_check_now">Check now</span></button>

--- a/static/index.html
+++ b/static/index.html
@@ -371,6 +371,22 @@
   <div class="resize-handle" id="sidebarResize"></div>
   </aside>
   <main class="main">
+    <div class="update-banner" id="updateBanner">
+      <div style="display:flex;flex-direction:column;flex:1;min-width:0">
+        <span id="updateMsg"></span>
+        <div id="updateWhatsNewLinks" style="display:none;font-size:11px;margin-left:8px;white-space:nowrap"></div>
+        <div id="updateSummaryPanel" style="display:none;font-size:12px;line-height:1.45;margin-top:6px;padding:8px 10px;border:1px solid var(--border2);border-radius:8px;background:rgba(255,255,255,.04);max-width:720px;white-space:normal">
+          <div id="updateSummaryText"></div>
+          <div id="updateSummaryDiffLinks" style="display:none;font-size:11px;margin-top:8px"></div>
+        </div>
+        <div id="updateError" style="display:none;font-size:12px;color:var(--error,#e05);margin-top:4px;word-break:break-word"></div>
+      </div>
+      <div style="display:flex;gap:8px;flex-shrink:0;flex-wrap:wrap">
+        <button class="update-btn" onclick="dismissUpdate()">Later</button>
+        <button class="update-btn update-primary" id="btnApplyUpdate" onclick="applyUpdates()">Update Now</button>
+        <button class="update-btn" id="btnForceUpdate" style="display:none;background:var(--error,#e05);color:#fff;border-color:var(--error,#e05)" onclick="forceUpdate(this)">Force update</button>
+      </div>
+    </div>
     <div id="mainChat" class="main-view">
     <div class="messages-shell">
       <button id="jumpToSessionStartBtn" class="session-jump-btn session-jump-btn--start" aria-label="Jump to beginning of session" data-i18n-aria-label="session_jump_start_label" data-i18n-title="session_jump_start_label" onclick="jumpToSessionStart()" style="display:none"><span aria-hidden="true">↑</span><span data-i18n="session_jump_start">Start</span></button>
@@ -406,22 +422,6 @@
       <div id="liveCompressionCards" class="live-compression-cards"></div>
       <div id="liveToolCards" style="display:none;max-width:800px;margin:0 auto;width:100%;padding:0 24px;"></div>
     </div>
-    </div>
-    <div class="update-banner" id="updateBanner">
-      <div style="display:flex;flex-direction:column;flex:1;min-width:0">
-        <span id="updateMsg"></span>
-        <div id="updateWhatsNewLinks" style="display:none;font-size:11px;margin-left:8px;white-space:nowrap"></div>
-        <div id="updateSummaryPanel" style="display:none;font-size:12px;line-height:1.45;margin-top:6px;padding:8px 10px;border:1px solid var(--border2);border-radius:8px;background:rgba(255,255,255,.04);max-width:720px;white-space:normal">
-          <div id="updateSummaryText"></div>
-          <div id="updateSummaryDiffLinks" style="display:none;font-size:11px;margin-top:8px"></div>
-        </div>
-        <div id="updateError" style="display:none;font-size:12px;color:var(--error,#e05);margin-top:4px;word-break:break-word"></div>
-      </div>
-      <div style="display:flex;gap:8px;flex-shrink:0;flex-wrap:wrap">
-        <button class="update-btn" onclick="dismissUpdate()">Later</button>
-        <button class="update-btn update-primary" id="btnApplyUpdate" onclick="applyUpdates()">Update Now</button>
-        <button class="update-btn" id="btnForceUpdate" style="display:none;background:var(--error,#e05);color:#fff;border-color:var(--error,#e05)" onclick="forceUpdate(this)">Force update</button>
-      </div>
     </div>
     <div class="reconnect-banner" id="reconnectBanner">
       <span id="reconnectMsg"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align:-1px"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg> A response may have been in progress when you last left. Reload messages?</span>
@@ -1276,7 +1276,7 @@
                 <div class="settings-section-title" data-i18n="settings_section_system_title">System</div>
                 <div class="settings-section-meta" data-i18n="settings_section_system_meta">Instance version and access controls.</div>
               </div>
-              <div id="checkUpdatesBlock">
+              <div id="checkUpdatesBlock" style="display:flex;flex-wrap:wrap;align-items:center;gap:0.5em">
                 <span class="settings-version-badge" id="settings-webui-version-badge">WebUI: —</span>
                 <span class="settings-version-badge" id="settings-agent-version-badge">Agent: not detected</span>
                 <button class="btn-tiny" id="btnCheckUpdatesNow" onclick="checkUpdatesNow()" title="Check for updates now" data-i18n-title="settings_check_now"><svg id="checkUpdatesSpinner" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="spinner-xs" aria-hidden="true"><path d="M21 12a9 9 0 1 1-6.219-8.56"/><polyline points="21 3 21 9 15 9"/></svg><span id="checkUpdatesLabel" data-i18n="settings_check_now">Check now</span></button>

--- a/static/style.css
+++ b/static/style.css
@@ -1334,7 +1334,6 @@
   #updateWhatsNewLinks{white-space:normal!important;margin-left:0!important;}
   .update-banner>div:last-child{margin-left:auto;}
   @media (max-width:600px){.update-banner{width:calc(100% - 16px);padding:10px 12px;gap:10px;}.update-banner>div:last-child{width:100%;justify-content:flex-end;}}
-  #checkUpdatesStatus{flex-basis:100%;margin-top:0.25em;font-size:0.85em;}
   .update-btn{padding:6px 12px;border-radius:8px;font-size:12px;font-weight:600;background:var(--accent-bg);border:1px solid var(--accent-bg-strong);color:var(--accent-text);cursor:pointer;transition:background .15s;}
   .update-btn:hover{background:var(--accent-bg-strong);}
   .update-primary{background:var(--accent-bg-strong);border-color:var(--accent);}
@@ -3306,12 +3305,12 @@ main.main > #mainPlugin{display:none;}
 .settings-section-title{font-size:18px;font-weight:600;letter-spacing:-.01em;color:var(--text);line-height:1.3;margin-bottom:4px;}
 .settings-section-meta{font-size:13px;color:var(--muted);line-height:1.55;}
 .settings-version-badge{display:inline-flex;align-items:center;padding:3px 8px;border-radius:999px;background:var(--surface);color:var(--muted);font-size:11px;font-weight:600;font-family:'SF Mono',ui-monospace,SFMono-Regular,Menlo,monospace;flex-shrink:0;align-self:flex-start;letter-spacing:.02em;}
-#checkUpdatesBlock{display:inline-flex;align-items:center;gap:6px;font-size:12px;flex-shrink:0;align-self:flex-start;}
+#checkUpdatesBlock{display:inline-flex;align-items:center;gap:0.5em;font-size:12px;flex-shrink:0;align-self:flex-start;flex-wrap:wrap;}
 #checkUpdatesBlock .btn-tiny{padding:4px 10px;border-radius:8px;border:1px solid var(--border);background:var(--surface);color:var(--text);font-size:11px;font-weight:500;cursor:pointer;display:inline-flex;align-items:center;gap:5px;transition:border-color .15s,color .15s;}
 #checkUpdatesBlock .btn-tiny:hover{border-color:var(--accent);color:var(--accent);}
 #checkUpdatesBlock .btn-tiny:disabled{opacity:.5;cursor:default;}
 #checkUpdatesBlock .btn-tiny .spinner-xs{width:12px;height:12px;border:2px solid var(--border);border-top-color:var(--text);border-radius:50%;animation:spin .6s linear infinite;display:none;}
-#checkUpdatesStatus{font-size:11px;font-weight:500;white-space:nowrap;}
+#checkUpdatesStatus{font-size:11px;font-weight:500;white-space:nowrap;flex-basis:100%;margin-top:0.25em;}
 
 /* Each logical form row is a card surface. Stack with comfortable gap. */
 #mainSettings .settings-field{margin-bottom:12px;padding:16px;border:1px solid var(--border);border-radius:12px;background:var(--sidebar);}

--- a/static/style.css
+++ b/static/style.css
@@ -1334,6 +1334,7 @@
   #updateWhatsNewLinks{white-space:normal!important;margin-left:0!important;}
   .update-banner>div:last-child{margin-left:auto;}
   @media (max-width:600px){.update-banner{width:calc(100% - 16px);padding:10px 12px;gap:10px;}.update-banner>div:last-child{width:100%;justify-content:flex-end;}}
+  #checkUpdatesStatus{flex-basis:100%;margin-top:0.25em;font-size:0.85em;}
   .update-btn{padding:6px 12px;border-radius:8px;font-size:12px;font-weight:600;background:var(--accent-bg);border:1px solid var(--accent-bg-strong);color:var(--accent-text);cursor:pointer;transition:background .15s;}
   .update-btn:hover{background:var(--accent-bg-strong);}
   .update-primary{background:var(--accent-bg-strong);border-color:var(--accent);}

--- a/tests/test_issue3597_update_banner_position.py
+++ b/tests/test_issue3597_update_banner_position.py
@@ -19,6 +19,11 @@ def test_update_banner_outside_main_chat():
 def test_update_banner_inside_main_element():
     src = INDEX.read_text(encoding="utf-8")
     main_pos = src.find('<main class="main">')
+    main_end = src.find('</main>')
     banner_pos = src.find('id="updateBanner"')
     assert main_pos != -1, "<main class='main'> not found"
-    assert banner_pos > main_pos, "#updateBanner must be inside <main>"
+    assert main_end != -1, "</main> not found"
+    assert main_pos < banner_pos < main_end, (
+        "#updateBanner must be inside <main class='main'>, "
+        "not before it or after the closing </main>"
+    )

--- a/tests/test_issue3597_update_banner_position.py
+++ b/tests/test_issue3597_update_banner_position.py
@@ -1,0 +1,24 @@
+"""Verify #updateBanner lives outside #mainChat so it is visible from any panel."""
+import pathlib
+
+INDEX = pathlib.Path(__file__).resolve().parent.parent / "static" / "index.html"
+
+
+def test_update_banner_outside_main_chat():
+    src = INDEX.read_text(encoding="utf-8")
+    banner_pos = src.find('id="updateBanner"')
+    main_chat_pos = src.find('id="mainChat"')
+    assert banner_pos != -1, "#updateBanner not found in index.html"
+    assert main_chat_pos != -1, "#mainChat not found in index.html"
+    assert banner_pos < main_chat_pos, (
+        "#updateBanner must appear before #mainChat in the DOM "
+        "so it is not hidden when non-Chat panels are active"
+    )
+
+
+def test_update_banner_inside_main_element():
+    src = INDEX.read_text(encoding="utf-8")
+    main_pos = src.find('<main class="main">')
+    banner_pos = src.find('id="updateBanner"')
+    assert main_pos != -1, "<main class='main'> not found"
+    assert banner_pos > main_pos, "#updateBanner must be inside <main>"


### PR DESCRIPTION
Closes #3597

## Thinking Path

- Settings -> System has a "Check now" button that calls `checkUpdatesNow()` (panels.js:7362), which POSTs to `/api/updates/check?force=1` and calls `_showUpdateBanner(data)` (ui.js:5320) on success.
- `_showUpdateBanner` adds `.visible` to `#updateBanner`, but the banner lives inside `#mainChat` (index.html:410), which is hidden when Settings is active via `switchPanel()`'s `showing-settings` class on `<main>`.
- Moving the banner out of `#mainChat` to be a direct child of `<main class="main">` makes it visible regardless of which panel is active.
- The inline `#checkUpdatesStatus` span also overflows on long version strings because `#checkUpdatesBlock` has no wrapping behavior.

## What Changed

- `static/index.html`: moved `#updateBanner` from inside `#mainChat` to directly after `<main class="main">`, before any `.main-view` div.
- `static/style.css`: added `flex-wrap:wrap` and updated gap to `0.5em` on `#checkUpdatesBlock` (in the stylesheet, not inline, to preserve the existing `inline-flex` display type). Added `flex-basis:100%` to `#checkUpdatesStatus` so long status text wraps below the badges and button.
- `tests/test_issue3597_update_banner_position.py`: new structural test verifying the banner is inside `<main>` but not inside `#mainChat`.

## Why It Matters

Users clicking "Check now" in Settings see the update text but have no way to act on it without navigating back to Chat. This forces a round-trip that should not be necessary.

## Verification

```
pytest tests/test_issue3597_update_banner_position.py -v --timeout=60
pytest tests/ -v --timeout=60
```

Manual: open Settings -> System, click "Check now", confirm the update banner appears with "Update Now" / "Later" buttons visible without leaving Settings.

## Risks / Follow-ups

- The banner's CSS (`.update-banner`, style.css:1330) uses `display:none` / `display:flex` via `.visible`, independent of the panel-switching mechanism. Moving it outside `#mainChat` means it renders above all panels. The existing `position: relative` and document flow should handle this, but edge cases on narrow viewports may need adjustment.
- `dismissUpdate()` uses `sessionStorage`, so a dismissed banner stays dismissed for the tab session regardless of panel switches. No change needed there.

## Model Used

Claude Opus 4.8 via Claude Code CLI