### PR TITLE
fix(streaming): strip orphaned tool_calls from CLI bridge message reconstruction (#3583)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2684,7 +2684,35 @@ def _sanitize_messages_for_api(messages, *, cfg: dict = None):
             sanitized['content'] = _strip_native_image_parts_from_content(sanitized.get('content'))
         if sanitized.get('role'):
             clean.append(sanitized)
-    return clean
+
+    # Third pass: strip orphaned tool_calls from assistant messages — calls whose id
+    # has no matching tool-role response in the clean list.  Strict providers (DeepSeek,
+    # newer OpenAI) reject with 400 when an assistant message references a tool call that
+    # was never answered (e.g. session aborted before results flushed).
+    answered_ids: set = set()
+    for msg in clean:
+        if msg.get('role') == 'tool':
+            tid = msg.get('tool_call_id') or ''
+            if tid:
+                answered_ids.add(tid)
+
+    filtered_clean = []
+    for msg in clean:
+        if msg.get('role') == 'assistant' and msg.get('tool_calls'):
+            kept = [
+                tc for tc in msg['tool_calls']
+                if isinstance(tc, dict) and
+                (tc.get('id') or tc.get('call_id') or '') in answered_ids
+            ]
+            if not kept:
+                # All calls orphaned: drop tool_calls key; if no content, drop message.
+                msg = {k: v for k, v in msg.items() if k != 'tool_calls'}
+                if not str(msg.get('content') or '').strip():
+                    continue
+            else:
+                msg = dict(msg, tool_calls=kept)
+        filtered_clean.append(msg)
+    return filtered_clean
 
 
 def _api_safe_message_positions(messages):
@@ -2718,7 +2746,32 @@ def _api_safe_message_positions(messages):
         sanitized = {k: v for k, v in msg.items() if k in _API_SAFE_MSG_KEYS}
         if sanitized.get('role'):
             out.append((idx, sanitized))
-    return out
+
+    # Third pass: strip orphaned tool_calls from assistant messages (mirrors
+    # _sanitize_messages_for_api pass 3).
+    answered_ids: set = set()
+    for _idx, msg in out:
+        if msg.get('role') == 'tool':
+            tid = msg.get('tool_call_id') or ''
+            if tid:
+                answered_ids.add(tid)
+
+    filtered_out = []
+    for idx, msg in out:
+        if msg.get('role') == 'assistant' and msg.get('tool_calls'):
+            kept = [
+                tc for tc in msg['tool_calls']
+                if isinstance(tc, dict) and
+                (tc.get('id') or tc.get('call_id') or '') in answered_ids
+            ]
+            if not kept:
+                msg = {k: v for k, v in msg.items() if k != 'tool_calls'}
+                if not str(msg.get('content') or '').strip():
+                    continue
+            else:
+                msg = dict(msg, tool_calls=kept)
+        filtered_out.append((idx, msg))
+    return filtered_out
 
 
 def _deduplicate_context_messages(messages):

--- a/tests/test_issue3583_orphaned_tool_calls.py
+++ b/tests/test_issue3583_orphaned_tool_calls.py
@@ -1,0 +1,203 @@
+"""Tests for orphaned tool_calls stripping in _sanitize_messages_for_api.
+
+When a session is aborted before tool results flush, assistant messages may
+contain tool_calls entries that have no matching tool-role response. Strict
+APIs (DeepSeek, newer OpenAI) reject these histories with HTTP 400. The third
+pass in _sanitize_messages_for_api and _api_safe_message_positions removes
+those dangling entries.
+"""
+
+from api.streaming import _sanitize_messages_for_api, _api_safe_message_positions
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _asst(content=None, tool_calls=None):
+    msg = {'role': 'assistant'}
+    if content is not None:
+        msg['content'] = content
+    if tool_calls is not None:
+        msg['tool_calls'] = tool_calls
+    return msg
+
+
+def _tool_call(call_id, name='fn'):
+    return {'id': call_id, 'type': 'function', 'function': {'name': name, 'arguments': '{}'}}
+
+
+def _tool_call_anthropic(call_id, name='fn'):
+    # Anthropic format uses 'call_id' instead of 'id'
+    return {'call_id': call_id, 'type': 'function', 'function': {'name': name, 'arguments': '{}'}}
+
+
+def _tool_resp(call_id, content='result'):
+    return {'role': 'tool', 'tool_call_id': call_id, 'content': content}
+
+
+# ---------------------------------------------------------------------------
+# Test 1: basic orphan strip — one answered, one orphaned
+# ---------------------------------------------------------------------------
+
+def test_partial_orphan_strip():
+    """Assistant references two tool calls; only one has a tool response.
+    The orphaned call should be removed; the answered one must stay."""
+    messages = [
+        {'role': 'user', 'content': 'run two tools'},
+        _asst(content='', tool_calls=[_tool_call('tc-1'), _tool_call('tc-2')]),
+        _tool_resp('tc-1', 'first result'),
+        # tc-2 response was never flushed (session aborted)
+    ]
+    result = _sanitize_messages_for_api(messages)
+    asst_msgs = [m for m in result if m.get('role') == 'assistant']
+    assert len(asst_msgs) == 1
+    tc_ids = [tc.get('id') for tc in asst_msgs[0].get('tool_calls', [])]
+    assert 'tc-1' in tc_ids, "answered call must be kept"
+    assert 'tc-2' not in tc_ids, "orphaned call must be stripped"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: all calls orphaned — with and without content
+# ---------------------------------------------------------------------------
+
+def test_all_orphaned_with_content_keeps_message():
+    """All tool_calls orphaned but assistant message has text content.
+    The message should remain with tool_calls removed."""
+    messages = [
+        {'role': 'user', 'content': 'hi'},
+        _asst(content='Let me check...', tool_calls=[_tool_call('tc-orphan')]),
+        # no tool response at all
+    ]
+    result = _sanitize_messages_for_api(messages)
+    asst_msgs = [m for m in result if m.get('role') == 'assistant']
+    assert len(asst_msgs) == 1, "message with content must survive"
+    assert 'tool_calls' not in asst_msgs[0], "tool_calls key must be removed"
+
+
+def test_all_orphaned_no_content_drops_message():
+    """All tool_calls orphaned and no content. Message should be removed entirely."""
+    messages = [
+        {'role': 'user', 'content': 'hi'},
+        _asst(content='', tool_calls=[_tool_call('tc-orphan')]),
+        # no tool response
+    ]
+    result = _sanitize_messages_for_api(messages)
+    asst_msgs = [m for m in result if m.get('role') == 'assistant']
+    assert len(asst_msgs) == 0, "content-less fully-orphaned assistant message must be dropped"
+
+
+def test_all_orphaned_none_content_drops_message():
+    """Same as above but content is None rather than empty string."""
+    messages = [
+        {'role': 'user', 'content': 'hi'},
+        _asst(content=None, tool_calls=[_tool_call('tc-orphan')]),
+    ]
+    result = _sanitize_messages_for_api(messages)
+    asst_msgs = [m for m in result if m.get('role') == 'assistant']
+    assert len(asst_msgs) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 3: no orphans — complete round-trip unchanged
+# ---------------------------------------------------------------------------
+
+def test_no_orphans_unchanged():
+    """Complete tool round-trip. Nothing should be stripped."""
+    messages = [
+        {'role': 'user', 'content': 'use a tool'},
+        _asst(content='', tool_calls=[_tool_call('tc-ok')]),
+        _tool_resp('tc-ok', 'done'),
+        _asst(content='All done'),
+    ]
+    result = _sanitize_messages_for_api(messages)
+    asst_msgs = [m for m in result if m.get('role') == 'assistant']
+    # Both assistant messages present
+    assert len(asst_msgs) == 2
+    first = asst_msgs[0]
+    assert 'tool_calls' in first
+    assert first['tool_calls'][0]['id'] == 'tc-ok'
+
+
+# ---------------------------------------------------------------------------
+# Test 4: mixed — multiple assistant messages, selective stripping
+# ---------------------------------------------------------------------------
+
+def test_mixed_selective_stripping():
+    """Multiple assistant messages: some complete, some orphaned. Only orphans stripped."""
+    messages = [
+        {'role': 'user', 'content': 'go'},
+        _asst(content='', tool_calls=[_tool_call('tc-a')]),
+        _tool_resp('tc-a', 'a-result'),
+        _asst(content='', tool_calls=[_tool_call('tc-b'), _tool_call('tc-c')]),
+        _tool_resp('tc-b', 'b-result'),
+        # tc-c never answered
+        _asst(content='Summary'),
+    ]
+    result = _sanitize_messages_for_api(messages)
+    asst_msgs = [m for m in result if m.get('role') == 'assistant']
+    assert len(asst_msgs) == 3
+
+    # First: complete, tc-a retained
+    assert asst_msgs[0].get('tool_calls', [{}])[0].get('id') == 'tc-a'
+
+    # Second: tc-b kept, tc-c stripped
+    second_ids = [tc.get('id') for tc in asst_msgs[1].get('tool_calls', [])]
+    assert 'tc-b' in second_ids
+    assert 'tc-c' not in second_ids
+
+    # Third: plain text, no tool_calls
+    assert 'tool_calls' not in asst_msgs[2]
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Anthropic call_id format
+# ---------------------------------------------------------------------------
+
+def test_anthropic_call_id_format():
+    """Tool calls using call_id (Anthropic format) are stripped correctly."""
+    messages = [
+        {'role': 'user', 'content': 'anthropic test'},
+        _asst(content='', tool_calls=[
+            _tool_call_anthropic('ac-answered'),
+            _tool_call_anthropic('ac-orphaned'),
+        ]),
+        _tool_resp('ac-answered', 'ok'),
+        # ac-orphaned never answered
+    ]
+    result = _sanitize_messages_for_api(messages)
+    asst_msgs = [m for m in result if m.get('role') == 'assistant']
+    assert len(asst_msgs) == 1
+    tc_call_ids = [tc.get('call_id') for tc in asst_msgs[0].get('tool_calls', [])]
+    assert 'ac-answered' in tc_call_ids
+    assert 'ac-orphaned' not in tc_call_ids
+
+
+# ---------------------------------------------------------------------------
+# _api_safe_message_positions mirrors the same logic
+# ---------------------------------------------------------------------------
+
+def test_positions_partial_orphan_strip():
+    """_api_safe_message_positions also strips the orphaned call."""
+    messages = [
+        {'role': 'user', 'content': 'run two tools'},
+        _asst(content='', tool_calls=[_tool_call('tc-1'), _tool_call('tc-2')]),
+        _tool_resp('tc-1', 'first result'),
+    ]
+    positions = _api_safe_message_positions(messages)
+    asst_entries = [(i, m) for i, m in positions if m.get('role') == 'assistant']
+    assert len(asst_entries) == 1
+    tc_ids = [tc.get('id') for tc in asst_entries[0][1].get('tool_calls', [])]
+    assert 'tc-1' in tc_ids
+    assert 'tc-2' not in tc_ids
+
+
+def test_positions_all_orphaned_no_content_drops():
+    """_api_safe_message_positions drops a fully-orphaned no-content assistant message."""
+    messages = [
+        {'role': 'user', 'content': 'hi'},
+        _asst(content='', tool_calls=[_tool_call('tc-orphan')]),
+    ]
+    positions = _api_safe_message_positions(messages)
+    asst_entries = [(i, m) for i, m in positions if m.get('role') == 'assistant']
+    assert len(asst_entries) == 0


### PR DESCRIPTION
Closes #3583

## Thinking Path

- CLI bridge mode aborts can interrupt the bridge before tool results are written to the session store, leaving assistant messages with `tool_calls` entries that have no matching `tool` role responses.
- `_sanitize_messages_for_api` already strips orphaned `tool` responses (dangling results without a matching assistant `tool_calls`), but does not handle the inverse direction.
- Strict providers (DeepSeek, OpenAI) reject the resulting message array with a 400 Bad Request because they require every `tool_calls` entry to have a downstream `tool` response.
- Adding a reverse-direction strip pass after the existing logic closes the gap without changing abort timing or bridge behavior.

## What Changed

- `api/streaming.py`: extended `_sanitize_messages_for_api` and `_api_safe_message_positions` with a third pass that collects answered `tool_call_id`s from surviving `tool` role messages, then strips unanswered entries from assistant `tool_calls` arrays. Messages left with an empty `tool_calls` list have the key removed; content-less messages with no remaining `tool_calls` are dropped entirely.
- `tests/test_issue3583_orphaned_tool_calls.py`: new test file covering basic orphan strip, all-orphaned, no-orphans, mixed, and Anthropic `call_id` format scenarios.

## Why It Matters

Any CLI bridge abort that races tool result persistence breaks subsequent turns for the session on strict providers. This is a silent, session-corrupting failure that requires manual message editing or session abandonment to recover from.

## Verification

```
pytest tests/test_issue3583_orphaned_tool_calls.py -v --timeout=60
pytest tests/ -v --timeout=60
```

## Risks / Follow-ups

- The strip is lossy; orphaned tool calls are silently removed rather than surfaced to the user. A follow-up could log a warning or inject a system note so the user knows context was dropped.
- This does not prevent the root cause (abort timing). A complementary fix in the bridge abort path to flush pending tool results before disconnecting would reduce the frequency of orphaned calls.

## Model Used

Claude Opus 4.8 via Claude Code CLI