### PR TITLE
Fix WebUI codex runtime slash command

### DIFF
--- a/api/commands.py
+++ b/api/commands.py
@@ -24,13 +24,15 @@ _NEVER_EXPOSE: frozenset[str] = frozenset({
 # Narrow agent-side execution allowlist for /api/commands/exec.
 _AGENT_COMMAND_ALIASES = {
     'reload_mcp': 'reload-mcp',
+    'codex_runtime': 'codex-runtime',
 }
-_ALLOWED_AGENT_COMMANDS = frozenset({'reload-mcp'})
+_ALLOWED_AGENT_COMMANDS = frozenset({'reload-mcp', 'codex-runtime'})
 _RELOAD_MCP_LOCK = threading.Lock()
+_CODEX_RUNTIME_LOCK = threading.Lock()
 
 
-def _normalize_agent_command_name(command: str) -> str:
-    """Normalize slash text to a canonical command name."""
+def _parse_agent_command(command: str) -> tuple[str, str]:
+    """Return ``(canonical_name, arg_string)`` from slash-command text."""
 
     raw = str(command or "").strip()
     if not raw:
@@ -42,7 +44,14 @@ def _normalize_agent_command_name(command: str) -> str:
     if not cmd_base:
         raise ValueError("command is required")
 
-    return _AGENT_COMMAND_ALIASES.get(cmd_base, cmd_base)
+    return _AGENT_COMMAND_ALIASES.get(cmd_base, cmd_base), cmd_parts[1] if len(cmd_parts) > 1 else ""
+
+
+def _normalize_agent_command_name(command: str) -> str:
+    """Normalize slash text to a canonical command name."""
+
+    canonical, _arg_string = _parse_agent_command(command)
+    return canonical
 
 
 def list_commands(_registry=None) -> list[dict[str, Any]]:
@@ -105,14 +114,49 @@ def list_commands(_registry=None) -> list[dict[str, Any]]:
 def execute_agent_command(command: str) -> str:
     """Execute a narrow allowlist of agent-side runtime commands."""
 
-    canonical = _normalize_agent_command_name(command)
+    canonical, arg_string = _parse_agent_command(command)
     if canonical not in _ALLOWED_AGENT_COMMANDS:
         raise KeyError(canonical)
 
     if canonical == 'reload-mcp':
         return _run_reload_mcp_command()
+    if canonical == 'codex-runtime':
+        return _run_codex_runtime_command(arg_string)
 
     raise KeyError(canonical)
+
+
+def _run_codex_runtime_command(arg_string: str) -> str:
+    """Execute Hermes' shared Codex runtime switch for the active profile."""
+    try:
+        from hermes_cli.codex_runtime_switch import apply, parse_args
+    except Exception as exc:
+        logger.warning("Codex runtime switch unavailable", exc_info=True)
+        raise RuntimeError("Codex runtime switch unavailable") from exc
+
+    new_value, errors = parse_args(arg_string)
+    if errors:
+        return "\n".join(str(error) for error in errors)
+
+    with _CODEX_RUNTIME_LOCK:
+        try:
+            from api import config as webui_config
+
+            active_config = webui_config.get_config()
+
+            def _persist_config(config_data: dict) -> None:
+                webui_config._save_yaml_config_file(
+                    webui_config._get_config_path(),
+                    config_data,
+                )
+                webui_config.reload_config()
+
+            status = apply(active_config, new_value, persist_callback=_persist_config)
+        except Exception as exc:
+            logger.warning("Failed to execute /codex-runtime", exc_info=True)
+            raise RuntimeError("Failed to update Codex runtime") from exc
+
+    return str(getattr(status, "message", "") or "(no output)")
 
 
 def _run_reload_mcp_command() -> str:

--- a/static/messages.js
+++ b/static/messages.js
@@ -300,7 +300,7 @@ const _sessionTitleProvisionalBySid = new Map();
 // their canonical command is registered on the backend (for example
 // /reload-mcp). Keep this intentionally narrow and include underscore variants
 // observed by users so typing either form still routes through executeAgentCommand.
-const _AGENT_COMMANDS_RUN_ON_WEBUI = new Set(['reload-mcp', 'reload_mcp']);
+const _AGENT_COMMANDS_RUN_ON_WEBUI = new Set(['reload-mcp', 'reload_mcp', 'codex-runtime', 'codex_runtime']);
 
 function _clearStaleBusyStateBeforeSend({compressionRunning=false}={}){
   if(!S||!S.busy||compressionRunning) return false;

--- a/tests/test_cli_only_slash_commands.py
+++ b/tests/test_cli_only_slash_commands.py
@@ -106,6 +106,13 @@ def _run_commands_js(script_body: str) -> dict:
                   aliases: [],
                   cli_only: false,
                   gateway_only: false
+                }},
+                {{
+                  name: 'codex-runtime',
+                  description: 'Toggle Codex app-server runtime',
+                  aliases: ['codex_runtime'],
+                  cli_only: false,
+                  gateway_only: false
                 }}
               ]
             }};
@@ -188,10 +195,32 @@ def test_send_intercepts_reload_mcp_agent_command_before_agent_round_trip():
     assert "executeAgentCommand(text,_agentCmd||{name:_agentCmdName})" in intercept
 
 
-def test_reload_mcp_webui_intercept_aliases_are_defined_in_js_whitelist():
+def test_reload_mcp_and_codex_runtime_webui_intercept_aliases_are_defined_in_js_whitelist():
     assert "'reload-mcp'" in MESSAGES_JS
     assert "'reload_mcp'" in MESSAGES_JS
+    assert "'codex-runtime'" in MESSAGES_JS
+    assert "'codex_runtime'" in MESSAGES_JS
     assert "if(_agentCmd&&_AGENT_COMMANDS_RUN_ON_WEBUI.has(_agentCmdName))" not in MESSAGES_JS
+
+
+def test_codex_runtime_agent_command_metadata_resolves_alias():
+    result = _run_commands_js(
+        """
+        const byName = await getAgentCommandMetadata('codex-runtime');
+        const byAlias = await getAgentCommandMetadata('codex_runtime');
+        return {
+          by_name: byName && byName.name,
+          by_alias: byAlias && byAlias.name,
+          cli_only: byAlias && byAlias.cli_only === true
+        };
+        """
+    )
+
+    assert result == {
+        "by_name": "codex-runtime",
+        "by_alias": "codex-runtime",
+        "cli_only": False,
+    }
 
 
 def test_unknown_slash_commands_still_fall_through_to_agent():

--- a/tests/test_commands_endpoint.py
+++ b/tests/test_commands_endpoint.py
@@ -4,7 +4,8 @@ import urllib.error
 import urllib.request
 import threading
 import time
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -23,6 +24,40 @@ def _install_fake_mcp_tool(monkeypatch, shutdown, discover, servers=None, lock=N
     monkeypatch.setitem(sys.modules, "tools", tools_pkg)
     monkeypatch.setitem(sys.modules, "tools.mcp_tool", mcp_tool)
     return mcp_tool
+
+
+def _install_fake_codex_runtime_switch(monkeypatch):
+    import sys
+    hermes_cli_pkg = sys.modules.get("hermes_cli") or ModuleType("hermes_cli")
+    hermes_cli_pkg.__path__ = []
+    codex_runtime_switch = ModuleType("hermes_cli.codex_runtime_switch")
+    calls = []
+
+    def parse_args(arg_string):
+        calls.append(("parse_args", arg_string))
+        if arg_string in ("on", "codex_app_server"):
+            return "codex_app_server", []
+        if arg_string in ("", None):
+            return None, []
+        return None, [f"bad arg: {arg_string}"]
+
+    def apply(config, new_value, *, persist_callback=None):
+        calls.append(("apply", new_value, config.get("model", {}).get("openai_runtime")))
+        if new_value is not None:
+            config.setdefault("model", {})["openai_runtime"] = new_value
+            if persist_callback:
+                persist_callback(config)
+        return SimpleNamespace(
+            success=True,
+            message=f"codex runtime -> {new_value or config.get('model', {}).get('openai_runtime', 'auto')}",
+        )
+
+    codex_runtime_switch_any = cast(Any, codex_runtime_switch)
+    codex_runtime_switch_any.parse_args = parse_args
+    codex_runtime_switch_any.apply = apply
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.codex_runtime_switch", codex_runtime_switch)
+    return calls
 
 
 def _get(path):
@@ -116,6 +151,66 @@ def test_commands_exec_runs_reload_mcp_alias():
     assert status == 200
     assert 'output' in body
     assert isinstance(body['output'], str)
+
+
+def test_codex_runtime_command_uses_shared_switch_and_persists(monkeypatch, tmp_path):
+    """`/codex-runtime` executes through the same shared switch as CLI/gateway."""
+    calls = _install_fake_codex_runtime_switch(monkeypatch)
+    saved = []
+
+    from api import config as webui_config
+    from api.commands import execute_agent_command
+
+    config_data = {"model": {"openai_runtime": "auto"}}
+    monkeypatch.setattr(webui_config, "get_config", lambda: config_data)
+    monkeypatch.setattr(webui_config, "_get_config_path", lambda: tmp_path / "config.yaml")
+    monkeypatch.setattr(
+        webui_config,
+        "_save_yaml_config_file",
+        lambda path, data: saved.append((path, data.copy())),
+    )
+    monkeypatch.setattr(webui_config, "reload_config", lambda: saved.append(("reload", None)))
+
+    output = execute_agent_command('/codex-runtime on')
+
+    assert output == "codex runtime -> codex_app_server"
+    assert config_data["model"]["openai_runtime"] == "codex_app_server"
+    assert calls == [
+        ("parse_args", "on"),
+        ("apply", "codex_app_server", "auto"),
+    ]
+    assert saved[0][0] == tmp_path / "config.yaml"
+    assert saved[0][1] == {"model": {"openai_runtime": "codex_app_server"}}
+    assert saved[1] == ("reload", None)
+
+
+def test_codex_runtime_command_accepts_underscore_alias(monkeypatch):
+    """Telegram/WebUI underscore spelling routes to the canonical command."""
+    calls = _install_fake_codex_runtime_switch(monkeypatch)
+
+    from api import config as webui_config
+    from api.commands import execute_agent_command
+
+    monkeypatch.setattr(webui_config, "get_config", lambda: {"model": {"openai_runtime": "auto"}})
+    monkeypatch.setattr(webui_config, "_save_yaml_config_file", lambda path, data: None)
+    monkeypatch.setattr(webui_config, "reload_config", lambda: None)
+
+    output = execute_agent_command('/codex_runtime codex_app_server')
+
+    assert output == "codex runtime -> codex_app_server"
+    assert calls[0] == ("parse_args", "codex_app_server")
+
+
+def test_codex_runtime_invalid_argument_returns_switch_message(monkeypatch):
+    """Argument validation stays in the shared switch and returns user text."""
+    calls = _install_fake_codex_runtime_switch(monkeypatch)
+
+    from api.commands import execute_agent_command
+
+    output = execute_agent_command('/codex-runtime nope')
+
+    assert output == "bad arg: nope"
+    assert calls == [("parse_args", "nope")]
 
 
 def test_reload_mcp_error_is_generic(monkeypatch):


### PR DESCRIPTION
## Summary
- Route `/codex-runtime` and `/codex_runtime` through the WebUI slash-command executor instead of sending them as normal chat messages.
- Reuse Hermes Agent's shared `hermes_cli.codex_runtime_switch` parser/apply logic for status, validation, and config persistence.
- Add backend and frontend regression coverage for canonical and underscore aliases.

## Tests
- `python -m pytest tests/test_commands_endpoint.py tests/test_cli_only_slash_commands.py -q` → 30 passed
- `python -m ruff check api/commands.py tests/test_commands_endpoint.py tests/test_cli_only_slash_commands.py` → all checks passed
- `npm run lint:runtime` → passed
- Manual temp-config checks:
  - `/codex-runtime` returns current runtime without changing temp config
  - `/codex-runtime codex_app_server` persists `model.openai_runtime: codex_app_server` in temp config

## Full-suite note
- `python -m pytest -q` in this container currently reports 19 failures unrelated to this change (bootstrap executable checks, HERMES_HOME path expectations, ctl fake process cleanup, TLS fallback startup, etc.). The command still completed 7,635 passing tests plus skips/xpasses before those environment/pre-existing failures.
