### PR TITLE
fix(providers): preserve named custom provider binding in model picker (#3620)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -604,8 +604,9 @@ async function newSession(flash, options={}){
         if(s.startsWith('openai'))return 'openai';if(s.startsWith('anthropic')||s.startsWith('claude'))return 'anthropic';
         if(s.startsWith('google')||s.startsWith('gemini'))return 'google';return s;};
       const _familyMismatch=_familyProvider&&_fallbackProvider&&_normProv(_fallbackProvider)!==_familyProvider;
+      const _fallbackIsNamedCustom=String(_fallbackProvider||'').toLowerCase().startsWith('custom:');
       reqBody.model_provider=newModelState.model_provider
-        ||((_bareModel&&!_familyMismatch)?(_fallbackProvider||null):null)
+        ||((_bareModel&&!_familyMismatch&&!_fallbackIsNamedCustom)?(_fallbackProvider||null):null)
         ||null;
     }
     const data=await api('/api/session/new',{method:'POST',body:JSON.stringify(reqBody)});

--- a/static/ui.js
+++ b/static/ui.js
@@ -1376,13 +1376,13 @@ function _addLiveModelsToSelect(provider, models, sel){
   if(!providerGroup){
     providerGroup=document.createElement('optgroup');
     providerGroup.label=provider.charAt(0).toUpperCase()+provider.slice(1)+' (live)';
+    providerGroup.dataset.provider=provider;
     sel.appendChild(providerGroup);
+  }else if(!providerGroup.dataset.provider){
+    providerGroup.dataset.provider=provider;
   }
   const existingIds=new Set([...sel.options].map(o=>o.value));
-  // Normalized dedup: strip @provider: prefix and namespace so
-  // 'minimax/minimax-m2.7' matches '@nous:minimax/minimax-m2.7' (#907).
-  // Named custom IDs (@custom:name:model) have a known two-segment prefix
-  // and must strip both to dedup against bare model IDs (#3478).
+  // Normalized dedup strips provider/custom prefixes and namespaces (#907, #3478).
   const _normId=id=>{
     let s=String(id||'');
     if(s.startsWith('@')&&s.includes(':')){
@@ -1412,6 +1412,7 @@ function _addLiveModelsToSelect(provider, models, sel){
     opt.value=mid;
     opt.textContent=m.label||m.id;
     opt.title='Live model — fetched from provider';
+    opt.dataset.provider=provider;
     providerGroup.appendChild(opt);
     _dynamicModelLabels[mid]=m.label||m.id;
     added++;

--- a/tests/test_chat_start_provider_fallback.py
+++ b/tests/test_chat_start_provider_fallback.py
@@ -104,7 +104,11 @@ modelSelect = makeSelect(args.options || [], args.initialValue || '');
 if (args.persisted) localStorage.setItem(MODEL_STATE_KEY, JSON.stringify(args.persisted));
 var S = {session: {model_provider: args.sessionProvider || null}};
 
-process.stdout.write(JSON.stringify({provider: _modelProviderForSend(args.model)}));
+if (args.mode === 'modelState') {
+  process.stdout.write(JSON.stringify(_modelStateForSelect(modelSelect, args.model)));
+} else {
+  process.stdout.write(JSON.stringify({provider: _modelProviderForSend(args.model)}));
+}
 """
 
 node_test = pytest.mark.skipif(NODE is None, reason="node not on PATH")
@@ -127,6 +131,19 @@ def _run_helper(driver_path, payload):
     if result.returncode != 0:
         raise RuntimeError(f"node driver failed:\nSTDOUT={result.stdout}\nSTDERR={result.stderr}")
     return json.loads(result.stdout)["provider"]
+
+
+def _run_model_state_helper(driver_path, payload):
+    payload = {"mode": "modelState", **payload}
+    result = subprocess.run(
+        [NODE, driver_path, str(UI_JS_PATH), json.dumps(payload)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed:\nSTDOUT={result.stdout}\nSTDERR={result.stderr}")
+    return json.loads(result.stdout)
 
 
 @node_test
@@ -181,3 +198,40 @@ def test_model_provider_for_send_uses_only_matching_persisted_state(driver_path)
 
     assert matching == "xai-oauth"
     assert unrelated is None
+
+
+@node_test
+def test_model_state_reads_live_custom_provider_from_option_metadata(driver_path):
+    state = _run_model_state_helper(driver_path, {
+        "model": "llama-3.3-custom",
+        "initialValue": "llama-3.3-custom",
+        "options": [{
+            "provider": "custom:lab",
+            "optionProvider": "custom:lab",
+            "value": "llama-3.3-custom",
+        }],
+    })
+
+    assert state == {"model": "llama-3.3-custom", "model_provider": "custom:lab"}
+
+
+def test_live_custom_models_are_tagged_with_provider_metadata():
+    ui_src = UI_JS_PATH.read_text(encoding="utf-8")
+    start = ui_src.index("function _addLiveModelsToSelect")
+    body = ui_src[start:ui_src.index("async function _fetchLiveModels", start)]
+
+    assert "providerGroup.dataset.provider=provider;" in body
+    assert "opt.dataset.provider=provider;" in body
+
+
+def test_new_session_does_not_fallback_to_stale_named_custom_provider():
+    sessions_src = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+    start = sessions_src.index("async function newSession(")
+    body = sessions_src[start:sessions_src.index("const data=await api('/api/session/new'", start)]
+    assignment = body[body.index("reqBody.model_provider="):].split(";", 1)[0]
+
+    assert "const _fallbackIsNamedCustom=String(_fallbackProvider||'').toLowerCase().startsWith('custom:');" in body
+    assert "newModelState.model_provider" in assignment
+    assert "!_familyMismatch" in assignment
+    assert "!_fallbackIsNamedCustom" in assignment
+    assert "_fallbackProvider||null" in assignment


### PR DESCRIPTION
## Thinking Path

- Named custom providers cannot be identified by model ID alone because multiple configured or live catalogs can expose the same bare model name.
- The send path already preserves `(model, model_provider)` when the selected option carries provider metadata.
- The remaining drift is in the live-model optgroup path and the new-session fallback path, where missing provider metadata can fall through to `window._activeProvider`.
- The fix keeps provider metadata attached to custom live options and prevents null-provider named-custom selections from rebinding to a different active provider.

## What Changed

- `static/ui.js`: tag live-model optgroups and options with the provider ID, including `custom:<name>`, so `_getOptionProviderId()` can recover the route.
- `static/sessions.js`: keep the legacy cold-start fallback for safe routes, but avoid borrowing an unrelated named custom active provider for a bare model whose selected state has no provider.
- `tests/test_chat_start_provider_fallback.py`: add regression coverage for named custom provider selection and the stale/null-provider fallback case.

## Why It Matters

Users with multiple custom gateways can otherwise see a valid model label while the session starts against a different provider than the picker implied. Preserving the `(provider, model)` pair makes the UI and chat-start payload agree.

## Verification

- `$env:PYTHONUTF8 = '1'; C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_chat_start_provider_fallback.py -v --timeout=60`
- `$env:PYTHONUTF8 = '1'; C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/ -v --timeout=60`
- Manual: configure two `custom:<name>` providers with an overlapping bare model ID, select the model from one provider group, start a new chat, and confirm the request uses that provider.

## Risks / Follow-ups

The broader source-of-truth work in #1240 and catalog merge policy in #2640 are intentionally left alone. This only fixes provider binding for the current picker and chat-start path.

## Model Used

GPT-5.5 via Codex CLI

