### PR TITLE
fix(models): add MiniMax-M3 to WebUI MiniMax fallback catalog (#3412)

### DIFF
--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -115,6 +115,15 @@ def test_minimax_fallback_provider_label():
 
 # ── _PROVIDER_MODELS ──────────────────────────────────────────────────────────
 
+def test_minimax_provider_models_has_m3():
+    """_PROVIDER_MODELS['minimax'] must include MiniMax-M3."""
+    models = config._PROVIDER_MODELS.get('minimax', [])
+    ids = [m['id'] for m in models]
+    assert 'MiniMax-M3' in ids, (
+        f"MiniMax-M3 missing from _PROVIDER_MODELS['minimax']. Found: {ids}"
+    )
+
+
 def test_minimax_provider_models_has_m2_7():
     """_PROVIDER_MODELS['minimax'] must include MiniMax-M2.7."""
     models = config._PROVIDER_MODELS.get('minimax', [])


### PR DESCRIPTION
## Thinking Path

- MiniMax-M3 needs to be selectable even when live catalog enrichment is unavailable or an older bundled agent cannot return it.
- Current `origin/master` already has MiniMax-M3 in the WebUI registry and both MiniMax fallback lists.
- The missing piece is a direct regular-Minimax regression assertion, so the static fallback cannot lose M3 in a future catalog edit.

## What Changed

- `tests/test_minimax_provider.py`: add a direct assertion that `_PROVIDER_MODELS["minimax"]` includes `MiniMax-M3`.
- `api/config.py`: unchanged because STEP 0 confirmed the dropdown registry plus both `minimax` and `minimax-cn` fallback lists already contain MiniMax-M3.

## Why It Matters

MiniMax does not have a standard live `/models` discovery endpoint, so the WebUI static fallback remains the offline and older-agent safety net. A dedicated test keeps MiniMax-M3 visible in that fallback catalog.

## Verification

- `$env:PYTHONUTF8 = '1'; C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_minimax_provider.py -v --timeout=60`
- `$env:PYTHONUTF8 = '1'; C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/ -v --timeout=60`

## Risks / Follow-ups

The durable auto-refresh fix belongs in hermes-agent by adding MiniMax providers to the models.dev preferred path. This WebUI PR only locks the WebUI fallback catalog.

## Model Used

GPT-5.5 via Codex CLI

