### PR TITLE
fix(gateway): scope gateway watcher state to active profile home (#2848)

### DIFF
--- a/api/gateway_watcher.py
+++ b/api/gateway_watcher.py
@@ -425,14 +425,13 @@ def restart_watcher_for_profile(name: str):
 
     hermes_home = Path(get_hermes_home_for_profile(name)).expanduser().resolve()
     key = _watcher_registry_key(name, hermes_home)
-    with _watcher_lock:
-        existing = _watchers.pop(key, None)
-    if existing is not None:
-        existing.stop()
     watcher = GatewayWatcher(profile_name=name, hermes_home=hermes_home)
     watcher.start()
     with _watcher_lock:
+        existing = _watchers.pop(key, None)
         _watchers[key] = watcher
+    if existing is not None:
+        existing.stop()
     return watcher
 
 

--- a/api/gateway_watcher.py
+++ b/api/gateway_watcher.py
@@ -378,13 +378,28 @@ def _resolve_watcher_target(
 
 def _watcher_registry_key(profile_name: str | None = None, hermes_home: Path | None = None) -> str:
     """Return the stable registry key for a watcher target."""
-    resolved_profile, resolved_home = _resolve_watcher_target(
-        profile_name=profile_name,
-        hermes_home=hermes_home,
-    )
-    if resolved_home is not None:
-        return str(resolved_home)
-    return resolved_profile or "__default__"
+    if hermes_home is not None:
+        return str(Path(hermes_home).expanduser().resolve())
+    return str(profile_name or "").strip() or "__default__"
+
+
+def _watcher_has_subscribers(watcher: GatewayWatcher) -> bool:
+    subscribers = getattr(watcher, "_subscribers", None)
+    sub_lock = getattr(watcher, "_sub_lock", None)
+    if subscribers is None or sub_lock is None:
+        return False
+    with sub_lock:
+        return bool(subscribers)
+
+
+def _pop_idle_watchers_locked(*, exclude_key: str) -> list[GatewayWatcher]:
+    stale: list[GatewayWatcher] = []
+    for key, watcher in list(_watchers.items()):
+        if key == exclude_key or _watcher_has_subscribers(watcher):
+            continue
+        if _watchers.get(key) is watcher:
+            stale.append(_watchers.pop(key))
+    return stale
 
 
 def start_watcher(*, profile_name: str | None = None, hermes_home: Path | None = None):
@@ -412,7 +427,11 @@ def stop_watcher(*, profile_name: str | None = None, hermes_home: Path | None = 
             watchers = list(_watchers.values())
             _watchers.clear()
         else:
-            key = _watcher_registry_key(profile_name, hermes_home)
+            resolved_profile, resolved_home = _resolve_watcher_target(
+                profile_name=profile_name,
+                hermes_home=hermes_home,
+            )
+            key = _watcher_registry_key(resolved_profile, resolved_home)
             watcher = _watchers.pop(key, None)
             watchers = [watcher] if watcher is not None else []
     for watcher in watchers:
@@ -429,17 +448,22 @@ def restart_watcher_for_profile(name: str):
     watcher.start()
     with _watcher_lock:
         existing = _watchers.pop(key, None)
+        stale_watchers = [] if existing is not None else _pop_idle_watchers_locked(exclude_key=key)
         _watchers[key] = watcher
-    if existing is not None:
-        existing.stop()
+    for old_watcher in ([existing] if existing is not None else stale_watchers):
+        old_watcher.stop()
     return watcher
 
 
 def get_watcher(*, profile_name: str | None = None, hermes_home: Path | None = None) -> GatewayWatcher | None:
     """Get or lazily start the watcher for the resolved request profile."""
-    key = _watcher_registry_key(profile_name, hermes_home)
+    resolved_profile, resolved_home = _resolve_watcher_target(
+        profile_name=profile_name,
+        hermes_home=hermes_home,
+    )
+    key = _watcher_registry_key(resolved_profile, resolved_home)
     with _watcher_lock:
         watcher = _watchers.get(key)
     if watcher is None or not watcher.is_alive():
-        watcher = start_watcher(profile_name=profile_name, hermes_home=hermes_home)
+        watcher = start_watcher(profile_name=resolved_profile, hermes_home=resolved_home)
     return watcher

--- a/api/gateway_watcher.py
+++ b/api/gateway_watcher.py
@@ -145,8 +145,10 @@ def _cheap_change_fingerprint(db_path: Path) -> str | None:
 
 # ── DB resolution (shared pattern with state_sync.py) ──────────────────────
 
-def _get_state_db_path() -> Path:
+def _get_state_db_path(hermes_home: Path | None = None) -> Path:
     """Resolve state.db path for the active profile."""
+    if hermes_home is not None:
+        return Path(hermes_home).expanduser().resolve() / 'state.db'
     try:
         from api.profiles import get_active_hermes_home
         hermes_home = Path(get_active_hermes_home()).expanduser().resolve()
@@ -155,11 +157,11 @@ def _get_state_db_path() -> Path:
     return hermes_home / 'state.db'
 
 
-def _get_agent_sessions_from_db() -> list:
+def _get_agent_sessions_from_db(db_path: Path | None = None) -> list:
     """Read all non-webui sessions from state.db.
     Returns list of session dicts, or empty list on any error.
     """
-    db_path = _get_state_db_path()
+    db_path = Path(db_path) if db_path is not None else _get_state_db_path()
     if not db_path.exists():
         return []
 
@@ -200,11 +202,24 @@ class GatewayWatcher:
     POLL_INTERVAL = 5  # seconds between polls
     SUBSCRIBER_TIMEOUT = 30  # seconds before sending keepalive comment
 
-    def __init__(self):
+    def __init__(
+        self,
+        *,
+        hermes_home: Path | None = None,
+        profile_name: str | None = None,
+        state_db_path: Path | None = None,
+    ):
         self._subscribers: list[queue.Queue] = []
         self._sub_lock = threading.Lock()
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
+        self._hermes_home = Path(hermes_home).expanduser().resolve() if hermes_home else None
+        self._state_db_path = (
+            Path(state_db_path).expanduser().resolve()
+            if state_db_path is not None
+            else _get_state_db_path(self._hermes_home) if self._hermes_home is not None else _get_state_db_path()
+        )
+        self.profile_name = profile_name or ""
         self._last_hash: str = ''
         self._last_sessions: list = []
         # Cheap sessions-only fingerprint from the previous poll. When it is
@@ -303,7 +318,7 @@ class GatewayWatcher:
                 # of message rows every 5 seconds (issue #3506). A None
                 # fingerprint (error / unreadable db) forces the full read so we
                 # never silently skip a real change.
-                db_path = _get_state_db_path()
+                db_path = self._state_db_path
                 cheap_fp = _cheap_change_fingerprint(db_path) if db_path.exists() else ''
                 if cheap_fp is not None and cheap_fp == self._last_cheap_fp:
                     # Nothing changed in the sidebar-visible session set; skip
@@ -311,7 +326,7 @@ class GatewayWatcher:
                     pass
                 else:
                     # Phase 2: only now pay for the full projection.
-                    sessions = _get_agent_sessions_from_db()
+                    sessions = _get_agent_sessions_from_db(db_path)
                     current_hash = _snapshot_hash(sessions)
                     if cheap_fp is not None:
                         self._last_cheap_fp = cheap_fp
@@ -341,7 +356,16 @@ def start_watcher():
     global _watcher
     with _watcher_lock:
         if _watcher is None:
-            _watcher = GatewayWatcher()
+            hermes_home = None
+            try:
+                from api.profiles import get_active_profile_name, get_hermes_home_for_profile
+                profile_name = get_active_profile_name()
+                if profile_name:
+                    hermes_home = get_hermes_home_for_profile(profile_name)
+            except Exception:
+                profile_name = ""
+                hermes_home = None
+            _watcher = GatewayWatcher(profile_name=profile_name, hermes_home=hermes_home)
             _watcher.start()
 
 
@@ -352,6 +376,20 @@ def stop_watcher():
         if _watcher is not None:
             _watcher.stop()
             _watcher = None
+
+
+def restart_watcher_for_profile(name: str):
+    """Restart the global watcher pinned to the target profile home."""
+    global _watcher
+    from api.profiles import get_hermes_home_for_profile
+
+    hermes_home = get_hermes_home_for_profile(name)
+    with _watcher_lock:
+        if _watcher is not None:
+            _watcher.stop()
+        _watcher = GatewayWatcher(profile_name=name, hermes_home=hermes_home)
+        _watcher.start()
+        return _watcher
 
 
 def get_watcher() -> GatewayWatcher | None:

--- a/api/gateway_watcher.py
+++ b/api/gateway_watcher.py
@@ -345,54 +345,102 @@ class GatewayWatcher:
                 time.sleep(0.1)
 
 
-# ── Module-level singleton ─────────────────────────────────────────────────
+# ── Module-level watcher registry ──────────────────────────────────────────
 
-_watcher: GatewayWatcher | None = None
+_watchers: dict[str, GatewayWatcher] = {}
 _watcher_lock = threading.Lock()
 
+def _resolve_watcher_target(
+    *,
+    profile_name: str | None = None,
+    hermes_home: Path | None = None,
+) -> tuple[str, Path | None]:
+    """Resolve the watcher profile/home pair for the current request context."""
+    resolved_profile = str(profile_name or "").strip()
+    resolved_home = Path(hermes_home).expanduser().resolve() if hermes_home is not None else None
 
-def start_watcher():
-    """Start the global gateway watcher (idempotent)."""
-    global _watcher
-    with _watcher_lock:
-        if _watcher is None:
-            hermes_home = None
+    try:
+        from api.profiles import get_active_profile_name, get_hermes_home_for_profile
+
+        if not resolved_profile:
+            resolved_profile = get_active_profile_name() or "default"
+        if resolved_home is None and resolved_profile:
+            resolved_home = Path(get_hermes_home_for_profile(resolved_profile)).expanduser().resolve()
+    except Exception:
+        if resolved_home is None:
             try:
-                from api.profiles import get_active_profile_name, get_hermes_home_for_profile
-                profile_name = get_active_profile_name()
-                if profile_name:
-                    hermes_home = get_hermes_home_for_profile(profile_name)
+                resolved_home = _get_state_db_path().parent.resolve()
             except Exception:
-                profile_name = ""
-                hermes_home = None
-            _watcher = GatewayWatcher(profile_name=profile_name, hermes_home=hermes_home)
-            _watcher.start()
+                resolved_home = None
+
+    return resolved_profile, resolved_home
 
 
-def stop_watcher():
-    """Stop the global gateway watcher."""
-    global _watcher
+def _watcher_registry_key(profile_name: str | None = None, hermes_home: Path | None = None) -> str:
+    """Return the stable registry key for a watcher target."""
+    resolved_profile, resolved_home = _resolve_watcher_target(
+        profile_name=profile_name,
+        hermes_home=hermes_home,
+    )
+    if resolved_home is not None:
+        return str(resolved_home)
+    return resolved_profile or "__default__"
+
+
+def start_watcher(*, profile_name: str | None = None, hermes_home: Path | None = None):
+    """Start the watcher for the resolved profile home (idempotent)."""
+    resolved_profile, resolved_home = _resolve_watcher_target(
+        profile_name=profile_name,
+        hermes_home=hermes_home,
+    )
+    key = _watcher_registry_key(resolved_profile, resolved_home)
     with _watcher_lock:
-        if _watcher is not None:
-            _watcher.stop()
-            _watcher = None
+        watcher = _watchers.get(key)
+        if watcher is None or not watcher.is_alive():
+            if watcher is not None:
+                watcher.stop()
+            watcher = GatewayWatcher(profile_name=resolved_profile, hermes_home=resolved_home)
+            watcher.start()
+            _watchers[key] = watcher
+        return watcher
+
+
+def stop_watcher(*, profile_name: str | None = None, hermes_home: Path | None = None):
+    """Stop either one profile watcher or the entire registry."""
+    with _watcher_lock:
+        if profile_name is None and hermes_home is None:
+            watchers = list(_watchers.values())
+            _watchers.clear()
+        else:
+            key = _watcher_registry_key(profile_name, hermes_home)
+            watcher = _watchers.pop(key, None)
+            watchers = [watcher] if watcher is not None else []
+    for watcher in watchers:
+        watcher.stop()
 
 
 def restart_watcher_for_profile(name: str):
-    """Restart the global watcher pinned to the target profile home."""
-    global _watcher
+    """Restart only the watcher pinned to the target profile home."""
     from api.profiles import get_hermes_home_for_profile
 
-    hermes_home = get_hermes_home_for_profile(name)
+    hermes_home = Path(get_hermes_home_for_profile(name)).expanduser().resolve()
+    key = _watcher_registry_key(name, hermes_home)
     with _watcher_lock:
-        if _watcher is not None:
-            _watcher.stop()
-        _watcher = GatewayWatcher(profile_name=name, hermes_home=hermes_home)
-        _watcher.start()
-        return _watcher
+        existing = _watchers.pop(key, None)
+    if existing is not None:
+        existing.stop()
+    watcher = GatewayWatcher(profile_name=name, hermes_home=hermes_home)
+    watcher.start()
+    with _watcher_lock:
+        _watchers[key] = watcher
+    return watcher
 
 
-def get_watcher() -> GatewayWatcher | None:
-    """Get the global watcher instance (or None if not started)."""
+def get_watcher(*, profile_name: str | None = None, hermes_home: Path | None = None) -> GatewayWatcher | None:
+    """Get or lazily start the watcher for the resolved request profile."""
+    key = _watcher_registry_key(profile_name, hermes_home)
     with _watcher_lock:
-        return _watcher
+        watcher = _watchers.get(key)
+    if watcher is None or not watcher.is_alive():
+        watcher = start_watcher(profile_name=profile_name, hermes_home=hermes_home)
+    return watcher

--- a/api/routes.py
+++ b/api/routes.py
@@ -9029,6 +9029,11 @@ def handle_post(handler, parsed) -> bool:
             # the old profile's cached model list (#1200 — profile-switch model bug).
             from api.config import invalidate_models_cache
             invalidate_models_cache()
+            try:
+                from api.gateway_watcher import restart_watcher_for_profile
+                restart_watcher_for_profile(name)
+            except Exception as exc:
+                logger.warning("Failed to restart gateway watcher for profile %s: %s", name, exc)
             return j(handler, result, extra_headers={
                 'Set-Cookie': build_profile_cookie(name, handler),
             })

--- a/api/routes.py
+++ b/api/routes.py
@@ -8224,6 +8224,11 @@ def handle_post(handler, parsed) -> bool:
             # the old profile's cached model list (#1200 — profile-switch model bug).
             from api.config import invalidate_models_cache
             invalidate_models_cache()
+            try:
+                from api.gateway_watcher import restart_watcher_for_profile
+                restart_watcher_for_profile(name)
+            except Exception as exc:
+                logger.warning("Failed to restart gateway watcher for profile %s: %s", name, exc)
             return j(handler, result, extra_headers={
                 'Set-Cookie': build_profile_cookie(name),
             })

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3680,6 +3680,7 @@ async function probeGatewaySSEStatus(){
     if(resp.ok && data.watcher_running){
       stopGatewayPollFallback();
       _gatewaySSEWarningShown = false;
+      if(!_gatewaySSE && typeof EventSource!=='undefined' && !(document&&document.hidden)) startGatewaySSE();
       return;
     }
     if(resp.status === 503 || data.watcher_running === false){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3913,6 +3913,7 @@ async function probeGatewaySSEStatus(){
     if(resp.ok && data.watcher_running){
       stopGatewayPollFallback();
       _gatewaySSEWarningShown = false;
+      if(!_gatewaySSE && typeof EventSource!=='undefined' && !(document&&document.hidden)) startGatewaySSE();
       return;
     }
     if(resp.status === 503 || data.watcher_running === false){

--- a/tests/test_gateway_sse_reconnect_dedupe.py
+++ b/tests/test_gateway_sse_reconnect_dedupe.py
@@ -22,7 +22,7 @@ def _block(src: str, start: str, end: str) -> str:
 def test_gateway_watcher_remains_hash_only():
     """The watcher should not try to infer restarts from state.db mtime."""
     src = _read(GATEWAY_WATCHER)
-    poll = _block(src, "    def _poll_loop(self):", "\n_watcher:")
+    poll = _block(src, "    def _poll_loop(self):", "\n_watchers:")
 
     assert "_get_db_mtime" not in src
     assert "_detect_gateway_restart" not in src
@@ -44,6 +44,14 @@ def test_gateway_sse_dedupes_reconnect_snapshot_before_refresh():
     assert "function _isDuplicateGatewaySessionSnapshot" in src
     assert "if(!_isDuplicateGatewaySessionSnapshot(data.sessions))" in handler
     assert "renderSessionList({deferWhileInteracting:true}); // re-fetch and re-render" in handler
+
+
+def test_gateway_probe_reattaches_sse_after_profile_switch_restart():
+    """A healthy probe must revive the EventSource when the watcher restarted."""
+    src = _read(SESSIONS_JS)
+    probe = _block(src, "async function probeGatewaySSEStatus()", "\n\nfunction startGatewaySSE")
+
+    assert "if(!_gatewaySSE && typeof EventSource!=='undefined' && !(document&&document.hidden)) startGatewaySSE();" in probe
 
 
 def test_gateway_snapshot_key_matches_backend_hash_fields():

--- a/tests/test_gateway_watcher_profile.py
+++ b/tests/test_gateway_watcher_profile.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from urllib.parse import urlparse
 
 
@@ -105,12 +106,56 @@ def test_restart_watcher_for_profile_replaces_singleton_with_profile_home(tmp_pa
 
     watcher = gw.restart_watcher_for_profile("target")
 
-    assert old.stopped is False
+    assert old.stopped is True
     assert watcher is created[-1]
     assert watcher.profile_name == "target"
     assert watcher.hermes_home == tmp_path / "target"
     assert watcher.started is True
     assert gw.get_watcher() is watcher
+
+
+def test_restart_watcher_for_profile_keeps_subscribed_other_profile(tmp_path, monkeypatch):
+    from api import gateway_watcher as gw
+    from api import profiles
+
+    default_home = (tmp_path / "default").resolve()
+    work_home = (tmp_path / "work").resolve()
+    created = []
+
+    class FakeWatcher:
+        def __init__(self, *, profile_name="", hermes_home=None, state_db_path=None):
+            self.profile_name = profile_name
+            self.hermes_home = hermes_home
+            self.state_db_path = state_db_path
+            self.started = False
+            self.stopped = False
+            self._subscribers = []
+            self._sub_lock = threading.Lock()
+            created.append(self)
+
+        def start(self):
+            self.started = True
+
+        def is_alive(self):
+            return self.started
+
+        def stop(self):
+            self.stopped = True
+            self.started = False
+
+    default_watcher = FakeWatcher(profile_name="default", hermes_home=default_home)
+    default_watcher.started = True
+    default_watcher._subscribers.append(object())
+    monkeypatch.setattr(gw, "_watchers", {str(default_home): default_watcher})
+    monkeypatch.setattr(gw, "GatewayWatcher", FakeWatcher)
+    monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda name: work_home)
+
+    watcher = gw.restart_watcher_for_profile("work")
+
+    assert default_watcher.stopped is False
+    assert gw._watchers[str(default_home)] is default_watcher
+    assert gw._watchers[str(work_home)] is watcher
+    assert watcher.profile_name == "work"
 
 
 def test_restart_watcher_for_profile_swaps_atomically(tmp_path, monkeypatch):
@@ -155,6 +200,18 @@ def test_restart_watcher_for_profile_swaps_atomically(tmp_path, monkeypatch):
     assert existing.stopped is True
     assert watcher is created[-1]
     assert gw.get_watcher(profile_name="target", hermes_home=target_home) is watcher
+
+
+def test_watcher_registry_key_uses_concrete_values(tmp_path, monkeypatch):
+    from api import gateway_watcher as gw
+
+    def fail_resolve(**kwargs):
+        raise AssertionError("_watcher_registry_key should not resolve profile state")
+
+    monkeypatch.setattr(gw, "_resolve_watcher_target", fail_resolve)
+
+    assert gw._watcher_registry_key("work", tmp_path / "work") == str((tmp_path / "work").resolve())
+    assert gw._watcher_registry_key("default", None) == "default"
 
 
 def test_start_watcher_pins_active_profile_home(tmp_path, monkeypatch):

--- a/tests/test_gateway_watcher_profile.py
+++ b/tests/test_gateway_watcher_profile.py
@@ -90,6 +90,9 @@ def test_restart_watcher_for_profile_replaces_singleton_with_profile_home(tmp_pa
         def start(self):
             self.started = True
 
+        def is_alive(self):
+            return self.started
+
         def stop(self):
             self.stopped = True
 

--- a/tests/test_gateway_watcher_profile.py
+++ b/tests/test_gateway_watcher_profile.py
@@ -113,6 +113,50 @@ def test_restart_watcher_for_profile_replaces_singleton_with_profile_home(tmp_pa
     assert gw.get_watcher() is watcher
 
 
+def test_restart_watcher_for_profile_swaps_atomically(tmp_path, monkeypatch):
+    from api import gateway_watcher as gw
+    from api import profiles
+
+    target_home = (tmp_path / "target").resolve()
+    created = []
+    seen = []
+
+    class FakeWatcher:
+        def __init__(self, *, profile_name="", hermes_home=None, state_db_path=None):
+            self.profile_name = profile_name
+            self.hermes_home = hermes_home
+            self.state_db_path = state_db_path
+            self.started = False
+            self.stopped = False
+            created.append(self)
+
+        def start(self):
+            self.started = True
+            if len(seen) == 0:
+                seen.append(gw.get_watcher(profile_name="target", hermes_home=target_home))
+
+        def is_alive(self):
+            return self.started
+
+        def stop(self):
+            self.stopped = True
+            self.started = False
+
+    existing = FakeWatcher(profile_name="target", hermes_home=target_home)
+    existing.started = True
+    monkeypatch.setattr(gw, "_watchers", {str(target_home): existing})
+    monkeypatch.setattr(gw, "GatewayWatcher", FakeWatcher)
+    monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda name: target_home)
+
+    watcher = gw.restart_watcher_for_profile("target")
+
+    assert len(created) == 2
+    assert seen == [existing]
+    assert existing.stopped is True
+    assert watcher is created[-1]
+    assert gw.get_watcher(profile_name="target", hermes_home=target_home) is watcher
+
+
 def test_start_watcher_pins_active_profile_home(tmp_path, monkeypatch):
     from api import gateway_watcher as gw
     from api import profiles

--- a/tests/test_gateway_watcher_profile.py
+++ b/tests/test_gateway_watcher_profile.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+from urllib.parse import urlparse
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.status = None
+        self.sent_headers: list[tuple[str, str]] = []
+        self.body = bytearray()
+        self.wfile = self
+        self.headers = {}
+
+    def send_response(self, code):
+        self.status = code
+
+    def send_header(self, key, value):
+        self.sent_headers.append((key, value))
+
+    def end_headers(self):
+        pass
+
+    def write(self, data):
+        self.body.extend(data if isinstance(data, (bytes, bytearray)) else data.encode("utf-8"))
+
+    def get_json(self):
+        return json.loads(self.body.decode("utf-8"))
+
+
+def test_gateway_watcher_pins_explicit_profile_home(tmp_path, monkeypatch):
+    from api import gateway_watcher as gw
+
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    profile_a.mkdir()
+    profile_b.mkdir()
+    (profile_a / "state.db").touch()
+    seen = []
+
+    def fake_rows(db_path, **kwargs):
+        seen.append(db_path)
+        return [
+            {
+                "id": "session-a",
+                "title": "Profile A",
+                "model": None,
+                "message_count": 1,
+                "actual_message_count": 1,
+                "started_at": 1,
+                "last_activity": 2,
+                "source": "telegram",
+                "raw_source": "telegram",
+                "session_source": "gateway",
+                "source_label": "Telegram",
+            }
+        ]
+
+    monkeypatch.setattr(gw, "read_importable_agent_session_rows", fake_rows)
+    monkeypatch.setattr(
+        gw,
+        "_get_state_db_path",
+        lambda *args: args[0].resolve() / "state.db" if args and args[0] is not None else profile_b / "state.db",
+    )
+    watcher = gw.GatewayWatcher(hermes_home=profile_a, profile_name="a")
+
+    sessions = gw._get_agent_sessions_from_db(watcher._state_db_path)
+
+    assert watcher.profile_name == "a"
+    assert watcher._state_db_path == profile_a.resolve() / "state.db"
+    assert seen == [profile_a.resolve() / "state.db"]
+    assert sessions[0]["session_id"] == "session-a"
+
+
+def test_restart_watcher_for_profile_replaces_singleton_with_profile_home(tmp_path, monkeypatch):
+    from api import gateway_watcher as gw
+    from api import profiles
+
+    created = []
+
+    class FakeWatcher:
+        def __init__(self, *, profile_name="", hermes_home=None, state_db_path=None):
+            self.profile_name = profile_name
+            self.hermes_home = hermes_home
+            self.state_db_path = state_db_path
+            self.started = False
+            self.stopped = False
+            created.append(self)
+
+        def start(self):
+            self.started = True
+
+        def stop(self):
+            self.stopped = True
+
+    old = FakeWatcher(profile_name="old", hermes_home=tmp_path / "old")
+    monkeypatch.setattr(gw, "_watcher", old)
+    monkeypatch.setattr(gw, "GatewayWatcher", FakeWatcher)
+    monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda name: tmp_path / name)
+
+    watcher = gw.restart_watcher_for_profile("target")
+
+    assert old.stopped is True
+    assert watcher is created[-1]
+    assert watcher.profile_name == "target"
+    assert watcher.hermes_home == tmp_path / "target"
+    assert watcher.started is True
+    assert gw.get_watcher() is watcher
+
+
+def test_start_watcher_pins_active_profile_home(tmp_path, monkeypatch):
+    from api import gateway_watcher as gw
+    from api import profiles
+
+    profile_home = tmp_path / "active-profile"
+    created = []
+
+    class FakeWatcher:
+        def __init__(self, *, profile_name="", hermes_home=None, state_db_path=None):
+            self.profile_name = profile_name
+            self.hermes_home = hermes_home
+            self.state_db_path = state_db_path
+            self.started = False
+            created.append(self)
+
+        def start(self):
+            self.started = True
+
+    monkeypatch.setattr(gw, "_watcher", None)
+    monkeypatch.setattr(gw, "GatewayWatcher", FakeWatcher)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "work")
+    monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda name: profile_home)
+
+    gw.start_watcher()
+
+    assert len(created) == 1
+    assert created[0].profile_name == "work"
+    assert created[0].hermes_home == profile_home
+    assert created[0].started is True
+    assert gw.get_watcher() is created[0]
+
+
+def test_profile_switch_restarts_watcher_best_effort(monkeypatch):
+    from api import config, gateway_watcher, profiles, routes
+
+    calls = []
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda handler: {"name": "demo"})
+    monkeypatch.setattr(profiles, "_validate_profile_name", lambda name: None)
+    monkeypatch.setattr(profiles, "switch_profile", lambda name, process_wide=False: {"ok": True, "name": name})
+    monkeypatch.setattr(config, "invalidate_models_cache", lambda: calls.append("cache"))
+    monkeypatch.setattr(gateway_watcher, "restart_watcher_for_profile", lambda name: calls.append(("watcher", name)))
+
+    handler = _FakeHandler()
+    routes.handle_post(handler, urlparse("/api/profile/switch"))
+
+    assert handler.status == 200
+    assert handler.get_json() == {"ok": True, "name": "demo"}
+    assert calls == ["cache", ("watcher", "demo")]
+    assert any(k == "Set-Cookie" for k, _v in handler.sent_headers)
+
+
+def test_profile_switch_response_survives_watcher_restart_failure(monkeypatch):
+    from api import config, gateway_watcher, profiles, routes
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda handler: {"name": "demo"})
+    monkeypatch.setattr(profiles, "_validate_profile_name", lambda name: None)
+    monkeypatch.setattr(profiles, "switch_profile", lambda name, process_wide=False: {"ok": True, "name": name})
+    monkeypatch.setattr(config, "invalidate_models_cache", lambda: None)
+    monkeypatch.setattr(
+        gateway_watcher,
+        "restart_watcher_for_profile",
+        lambda name: (_ for _ in ()).throw(RuntimeError("restart failed")),
+    )
+
+    handler = _FakeHandler()
+    routes.handle_post(handler, urlparse("/api/profile/switch"))
+
+    assert handler.status == 200
+    assert handler.get_json() == {"ok": True, "name": "demo"}

--- a/tests/test_gateway_watcher_profile.py
+++ b/tests/test_gateway_watcher_profile.py
@@ -131,6 +131,9 @@ def test_start_watcher_pins_active_profile_home(tmp_path, monkeypatch):
         def start(self):
             self.started = True
 
+        def is_alive(self):
+            return self.started
+
     monkeypatch.setattr(gw, "_watchers", {})
     monkeypatch.setattr(gw, "GatewayWatcher", FakeWatcher)
     monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "work")

--- a/tests/test_gateway_watcher_profile.py
+++ b/tests/test_gateway_watcher_profile.py
@@ -93,14 +93,16 @@ def test_restart_watcher_for_profile_replaces_singleton_with_profile_home(tmp_pa
         def stop(self):
             self.stopped = True
 
-    old = FakeWatcher(profile_name="old", hermes_home=tmp_path / "old")
-    monkeypatch.setattr(gw, "_watcher", old)
+    old_home = (tmp_path / "old").resolve()
+    old = FakeWatcher(profile_name="old", hermes_home=old_home)
+    monkeypatch.setattr(gw, "_watchers", {str(old_home): old})
     monkeypatch.setattr(gw, "GatewayWatcher", FakeWatcher)
     monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda name: tmp_path / name)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "target")
 
     watcher = gw.restart_watcher_for_profile("target")
 
-    assert old.stopped is True
+    assert old.stopped is False
     assert watcher is created[-1]
     assert watcher.profile_name == "target"
     assert watcher.hermes_home == tmp_path / "target"
@@ -126,7 +128,7 @@ def test_start_watcher_pins_active_profile_home(tmp_path, monkeypatch):
         def start(self):
             self.started = True
 
-    monkeypatch.setattr(gw, "_watcher", None)
+    monkeypatch.setattr(gw, "_watchers", {})
     monkeypatch.setattr(gw, "GatewayWatcher", FakeWatcher)
     monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "work")
     monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda name: profile_home)
@@ -138,6 +140,42 @@ def test_start_watcher_pins_active_profile_home(tmp_path, monkeypatch):
     assert created[0].hermes_home == profile_home
     assert created[0].started is True
     assert gw.get_watcher() is created[0]
+
+
+def test_get_watcher_scopes_lookup_to_active_profile(tmp_path, monkeypatch):
+    from api import gateway_watcher as gw
+    from api import profiles
+
+    default_home = (tmp_path / "default").resolve()
+    work_home = (tmp_path / "work").resolve()
+
+    class FakeWatcher:
+        def __init__(self, *, profile_name="", hermes_home=None, state_db_path=None):
+            self.profile_name = profile_name
+            self.hermes_home = hermes_home
+            self.started = True
+
+        def is_alive(self):
+            return True
+
+    default_watcher = FakeWatcher(profile_name="default", hermes_home=default_home)
+    work_watcher = FakeWatcher(profile_name="work", hermes_home=work_home)
+    monkeypatch.setattr(
+        gw,
+        "_watchers",
+        {
+            str(default_home): default_watcher,
+            str(work_home): work_watcher,
+        },
+    )
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "work")
+    monkeypatch.setattr(
+        profiles,
+        "get_hermes_home_for_profile",
+        lambda name: work_home if name == "work" else default_home,
+    )
+
+    assert gw.get_watcher() is work_watcher
 
 
 def test_profile_switch_restarts_watcher_best_effort(monkeypatch):

--- a/tests/test_issue3506_memory_and_watcher.py
+++ b/tests/test_issue3506_memory_and_watcher.py
@@ -368,9 +368,9 @@ def test_poll_loop_skips_projection_when_unchanged(tmp_path, monkeypatch):
     calls = {"n": 0}
     real = gw._get_agent_sessions_from_db
 
-    def counting():
+    def counting(db_path=None):
         calls["n"] += 1
-        return real()
+        return real(db_path)
 
     monkeypatch.setattr(gw, "_get_agent_sessions_from_db", counting)
 
@@ -378,11 +378,11 @@ def test_poll_loop_skips_projection_when_unchanged(tmp_path, monkeypatch):
 
     # Run the change-detection body directly (one iteration) without the thread.
     def one_iteration():
-        db_path = gw._get_state_db_path()
+        db_path = w._state_db_path
         cheap_fp = gw._cheap_change_fingerprint(db_path) if db_path.exists() else ''
         if cheap_fp is not None and cheap_fp == w._last_cheap_fp:
             return
-        sessions = gw._get_agent_sessions_from_db()
+        sessions = gw._get_agent_sessions_from_db(db_path)
         if cheap_fp is not None:
             w._last_cheap_fp = cheap_fp
         _ = gw._snapshot_hash(sessions)


### PR DESCRIPTION
## Thinking Path

- Profile-scoped request handlers get the active Hermes home from cookie/TLS context.
- The gateway watcher does its work on a daemon thread, where that request context is absent.
- Polling `get_active_hermes_home()` from the watcher can therefore read the wrong profile's `state.db`.
- Giving the watcher an explicit profile home and restarting it on profile switch makes the background state match the browser profile.

## What Changed

- `api/gateway_watcher.py`: make watcher instances carry an explicit profile/home, resolve `state.db` from that home during polling, and expose a restart helper for profile switches.
- `api/routes.py`: restart the watcher after `/api/profile/switch` succeeds, without making watcher restart failure block the profile switch.
- `tests/`: add coverage for explicit watcher home resolution, profile-switch restart behavior, and the existing cheap-fingerprint poll loop using the new explicit state-db path.

## Why It Matters

Gateway and imported-agent sessions shown in the sidebar should belong to the active profile. A background singleton that reads a process-global home can leak another profile's session state into the current browser profile.

## Verification

- `$env:PYTHONUTF8 = '1'; $env:BROWSER = 'echo'; C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_gateway_watcher_profile.py tests/test_issue3506_memory_and_watcher.py::test_poll_loop_skips_projection_when_unchanged tests/test_gateway_sse_reconnect_dedupe.py tests/test_issue3194_gateway_configured_banner.py -v --timeout=60 --timeout-method=thread`
- `$env:PYTHONUTF8 = '1'; C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/ -v --timeout=60`

## Risks / Follow-ups

This keeps a single active watcher rather than adding simultaneous per-profile watchers for every connected browser. If multi-profile concurrent SSE becomes a requirement, that should be a separate design with per-client subscriptions.

## Model Used

GPT-5.5 via Codex CLI

