### PR TITLE
Release v0.51.264 — Release IF (stage-r14): sidebar cron-overflow + messaging source labels (un-held)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.264] — 2026-06-04 — Release IF (stage-r14 — sidebar cron-overflow + messaging source labels, un-held)
+
+### Fixed
+- **Cron sessions no longer flood the CLI session window in the sidebar** (so Discord/Telegram/Slack sessions stop vanishing from it). `_load_cli_sessions_uncached()` passed `exclude_sources=None`, overriding the default `("cron","webui")` exclusion, so hundreds of cron rows filled the 20-row visible limit. (#3585, @rodboev)
+- **Imported messaging sessions keep their source label after a sidebar refresh, and open + send correctly.** `_load_cli_sessions_uncached()` hardcoded `is_cli_session: True` for every state.db row; it now uses `is_cli_session_row()` so Discord/Telegram/Slack rows classify correctly, and the sidebar open/import path was extended (`_isMessagingSession()`) so opening a reclassified messaging session still imports it (no transient stub → no `/api/chat/start` 404 on the next send). (#3586, @rodboev)
+
 ## [v0.51.263] — 2026-06-04 — Release IE (stage-r13 — codex-runtime slash command + activity-default test)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -23,6 +23,7 @@ from api.workspace import get_last_workspace
 from api.usage import prompt_cache_hit_percent
 from api.agent_sessions import (
     _is_continuation_session,
+    is_cli_session_row,
     read_importable_agent_session_rows,
     read_session_lineage_metadata,
 )
@@ -3490,7 +3491,7 @@ def _load_cli_sessions_uncached(hermes_home: Path, db_path: Path, _cli_profile) 
         db_path,
         limit=CLI_VISIBLE_SESSION_LIMIT,
         log=logger,
-        exclude_sources=None,
+        exclude_sources=("cron",),
     ):
         sid = row['id']
         raw_ts = row['last_activity'] or row['started_at']
@@ -3561,7 +3562,7 @@ def _load_cli_sessions_uncached(hermes_home: Path, db_path: Path, _cli_profile) 
             '_lineage_root_id': row.get('_lineage_root_id'),
             '_lineage_tip_id': row.get('_lineage_tip_id'),
             '_compression_segment_count': row.get('_compression_segment_count'),
-            'is_cli_session': True,
+            'is_cli_session': is_cli_session_row(row),
         })
 
     # --- Second pass: fetch cron sessions that may have been squeezed out
@@ -3645,7 +3646,7 @@ def _load_cli_sessions_uncached(hermes_home: Path, db_path: Path, _cli_profile) 
                 '_lineage_root_id': row.get('_lineage_root_id'),
                 '_lineage_tip_id': row.get('_lineage_tip_id'),
                 '_compression_segment_count': row.get('_compression_segment_count'),
-                'is_cli_session': True,
+                'is_cli_session': is_cli_session_row(row),
             })
             existing_sids.add(sid)
     except Exception:

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1062,6 +1062,16 @@ function _isMessagingSession(session) {
   return _MESSAGING_RAW_SOURCES.has(raw);
 }
 
+/**
+ * Returns true when a session originates from an external channel (CLI bridge,
+ * Discord, Telegram, Slack, etc.) and therefore needs a server-side import
+ * before the WebUI can read or send messages into it.
+ * Covers both legacy CLI sessions and messaging-source sessions.
+ */
+function _isExternalSession(session) {
+  return !!(session && (session.is_cli_session || _isMessagingSession(session)));
+}
+
 function _isReadOnlySession(session) {
   return !!(session && (session.read_only || session.is_read_only));
 }
@@ -3144,8 +3154,9 @@ function startGatewaySSE(){
           }
           // If the active session received new gateway messages, refresh the conversation view.
           // S.busy check prevents stomping on an in-progress WebUI response.
-          // is_cli_session check ensures we only poll import_cli for CLI-originated sessions.
-          if(S.session && !S.busy && S.session.is_cli_session){
+          // _isExternalSession covers CLI-originated and messaging-source sessions
+          // that need a server-side import before WebUI can read them.
+          if(S.session && !S.busy && _isExternalSession(S.session)){
             const changedIds = new Set((data.sessions||[]).map(s=>s.session_id));
             if(changedIds.has(S.session.session_id)){
               // Capture active session ID before async fetch — race guard.
@@ -4625,7 +4636,7 @@ function renderSessionListFromCache(){
         row.title=t('session_lineage_segment_open');
         row.onclick=async(e)=>{
           e.stopPropagation();
-          if(seg.is_cli_session){
+          if(_isExternalSession(seg)){
             try{await api('/api/session/import_cli',{method:'POST',body:JSON.stringify({session_id:seg.session_id})});}
             catch(_e){ /* read-only fallback */ }
           }
@@ -4652,7 +4663,7 @@ function renderSessionListFromCache(){
         row.title='Open child session';
         row.onclick=async(e)=>{
           e.stopPropagation();
-          if(child.is_cli_session){
+          if(_isExternalSession(child)){
             try{await api('/api/session/import_cli',{method:'POST',body:JSON.stringify({session_id:child.session_id})});}
             catch(_e){ /* read-only fallback */ }
           }
@@ -5042,8 +5053,9 @@ function renderSessionListFromCache(){
         _tapTimer=null;
         _lastTapTime=0;
         if(_renamingSid) return;
-        // For CLI sessions, import into WebUI store first (idempotent)
-        if(s.is_cli_session){
+        // For external sessions (CLI, Discord, Telegram, Slack), import into
+        // WebUI store first so /api/chat/start finds a persisted session.
+        if(_isExternalSession(s)){
           try{
             await api('/api/session/import_cli',{method:'POST',body:JSON.stringify({session_id:s.session_id})});
           }catch(e){ /* import failed -- fall through to read-only view */ }

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -245,15 +245,15 @@ def test_gateway_sessions_appear_when_enabled():
 
 
 def test_webui_state_db_session_without_sidecar_appears_when_agent_sessions_enabled():
-    """Regression: WebUI-origin rows in state.db can recover missing JSON sidecars."""
+    """Regression: state.db rows without JSON sidecars can be recovered via agent bridge."""
     conn = _ensure_state_db()
-    sid = 'webui_state_only_001'
+    sid = 'cli_state_only_001'
     try:
         _insert_agent_session_row(
             conn,
             session_id=sid,
-            source='webui',
-            title='Recovered WebUI Session',
+            source='cli',
+            title='Recovered CLI Session',
             model='openai/gpt-5',
             messages=2,
         )
@@ -265,10 +265,10 @@ def test_webui_state_db_session_without_sidecar_appears_when_agent_sessions_enab
         sessions = data.get('sessions', [])
         recovered = [s for s in sessions if s.get('session_id') == sid]
         assert len(recovered) == 1, (
-            "WebUI-origin sessions that exist in state.db but have no JSON sidecar "
+            "State.db sessions without a JSON sidecar "
             "should be surfaced through the agent-session bridge for recovery."
         )
-        assert recovered[0].get('source_tag') == 'webui'
+        assert recovered[0].get('source_tag') == 'cli'
         assert recovered[0].get('is_cli_session') is True
     finally:
         try:
@@ -780,7 +780,7 @@ def test_gateway_session_has_correct_metadata():
         assert gw.get('raw_source') == 'telegram'
         assert gw.get('session_source') == 'messaging'
         assert gw.get('source_label') == 'Telegram'
-        assert gw.get('is_cli_session') is True, "is_cli_session should be True for agent sessions"
+        assert gw.get('is_cli_session') is False, "is_cli_session should be False for messaging (telegram) sessions"
         assert gw.get('title') == 'Meta Test'
     finally:
         try:

--- a/tests/test_issue3585_cron_session_overflow.py
+++ b/tests/test_issue3585_cron_session_overflow.py
@@ -1,0 +1,203 @@
+"""Regression coverage for cron sessions squeezing out Discord/Telegram rows (#3585).
+
+When ``_load_cli_sessions_uncached`` passed ``exclude_sources=None`` to
+``read_importable_agent_session_rows``, the 20-row window filled with cron
+entries, hiding Discord/Telegram sessions entirely.  The fix narrows the
+exclusion to ``("cron",)`` so cron rows stay out of the main pass (the cron
+second-pass recovers them independently) while ``source='webui'`` rows remain
+visible for sidecar-less recovery.
+"""
+
+import pathlib
+import sqlite3
+import time
+from unittest import mock
+
+import api.models as models
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _make_state_db(path, *, cron_count=15, discord_count=5):
+    """Create a state.db with cron and discord sessions.
+
+    Cron sessions are created with newer timestamps so they dominate the
+    ORDER BY window when ``exclude_sources`` is not applied.
+    """
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            session_source TEXT,
+            title TEXT,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            parent_session_id TEXT,
+            ended_at REAL,
+            end_reason TEXT
+        );
+        CREATE INDEX idx_sessions_started ON sessions(started_at);
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        );
+        CREATE INDEX idx_messages_session ON messages(session_id, timestamp);
+        """
+    )
+    # Cron sessions: newest timestamps (highest integers) to dominate window
+    now = time.time()
+    for i in range(cron_count):
+        sid = f"cron_job_{i:04d}_{int(now) + i}"
+        started = now + i  # newer than discord sessions
+        conn.execute(
+            """
+            INSERT INTO sessions
+            (id, source, session_source, title, model, started_at, message_count,
+             parent_session_id, ended_at, end_reason)
+            VALUES (?, 'cron', 'cron', ?, 'deepseek/deepseek-chat', ?, 1, NULL, NULL, NULL)
+            """,
+            (sid, f"Cron job {i}", started),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp)"
+            " VALUES (?, ?, 'user', 'cron task', ?)",
+            (f"cron_msg_{i:04d}", sid, started),
+        )
+
+    # Discord sessions: older timestamps so they lose to cron in raw ORDER BY
+    for i in range(discord_count):
+        sid = f"discord_{i:04d}"
+        started = now - 100 + i  # older than cron sessions
+        conn.execute(
+            """
+            INSERT INTO sessions
+            (id, source, session_source, title, model, started_at, message_count,
+             parent_session_id, ended_at, end_reason)
+            VALUES (?, 'discord', 'discord', ?, 'deepseek/deepseek-chat', ?, 1, NULL, NULL, NULL)
+            """,
+            (sid, f"Discord chat {i}", started),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp)"
+            " VALUES (?, ?, 'user', 'hello from discord', ?)",
+            (f"discord_msg_{i:04d}", sid, started),
+        )
+
+    conn.commit()
+    conn.close()
+
+
+def test_discord_sessions_not_squeezed_out_by_cron(tmp_path):
+    """Discord sessions must appear in the main pass even when cron rows are newer."""
+    db = tmp_path / "state.db"
+    _make_state_db(db, cron_count=15, discord_count=5)
+
+    with (
+        mock.patch("api.models.get_claude_code_sessions", return_value=[]),
+        mock.patch("api.models.get_last_workspace", return_value=tmp_path),
+        mock.patch("api.models.ensure_cron_project", return_value="cron-project-id"),
+        mock.patch("api.models.Session.load_metadata_only", return_value=None),
+    ):
+        result = models._load_cli_sessions_uncached(tmp_path, db, _cli_profile=None)
+
+    source_tags = {s["source_tag"] for s in result}
+    session_ids = {s["session_id"] for s in result}
+
+    discord_ids = {f"discord_{i:04d}" for i in range(5)}
+    assert discord_ids <= session_ids, (
+        "Discord sessions were squeezed out of the sidebar by cron entries. "
+        f"Missing: {discord_ids - session_ids}"
+    )
+    assert "discord" in source_tags
+
+
+def test_cron_sessions_recovered_by_second_pass(tmp_path):
+    """Cron sessions must still appear via the second pass after the main-pass exclusion."""
+    db = tmp_path / "state.db"
+    _make_state_db(db, cron_count=15, discord_count=5)
+
+    with (
+        mock.patch("api.models.get_claude_code_sessions", return_value=[]),
+        mock.patch("api.models.get_last_workspace", return_value=tmp_path),
+        mock.patch("api.models.ensure_cron_project", return_value="cron-project-id"),
+        mock.patch("api.models.Session.load_metadata_only", return_value=None),
+    ):
+        result = models._load_cli_sessions_uncached(tmp_path, db, _cli_profile=None)
+
+    cron_sessions = [s for s in result if s["source_tag"] == "cron"]
+    assert len(cron_sessions) > 0, "Cron sessions should be recovered by the second pass"
+
+
+def test_webui_sidecarless_sessions_not_excluded(tmp_path):
+    """WebUI sessions in state.db without JSON sidecars must remain visible.
+
+    The exclude_sources must only filter cron, not webui. A source='webui'
+    row with messages but no JSON sidecar file needs to appear in the sidebar
+    so the session_recovery path can materialize the sidecar on demand.
+    """
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            session_source TEXT,
+            title TEXT,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            parent_session_id TEXT,
+            ended_at REAL,
+            end_reason TEXT
+        );
+        CREATE INDEX idx_sessions_started ON sessions(started_at);
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        );
+        CREATE INDEX idx_messages_session ON messages(session_id, timestamp);
+        """
+    )
+    now = time.time()
+    conn.execute(
+        """
+        INSERT INTO sessions
+        (id, source, session_source, title, model, started_at, message_count,
+         parent_session_id, ended_at, end_reason)
+        VALUES ('webui_orphan_001', 'webui', 'webui', 'Lost sidecar session',
+                'claude-sonnet-4.6', ?, 3, NULL, NULL, NULL)
+        """,
+        (now,),
+    )
+    for i in range(3):
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp)"
+            " VALUES (?, 'webui_orphan_001', 'user', 'message', ?)",
+            (f"webui_msg_{i}", now + i),
+        )
+    conn.commit()
+    conn.close()
+
+    with (
+        mock.patch("api.models.get_claude_code_sessions", return_value=[]),
+        mock.patch("api.models.get_last_workspace", return_value=tmp_path),
+        mock.patch("api.models.ensure_cron_project", return_value="cron-project-id"),
+        mock.patch("api.models.Session.load_metadata_only", return_value=None),
+    ):
+        result = models._load_cli_sessions_uncached(tmp_path, db, _cli_profile=None)
+
+    webui_ids = {s["session_id"] for s in result if s["source_tag"] == "webui"}
+    assert "webui_orphan_001" in webui_ids, (
+        "WebUI sidecar-less sessions must not be excluded from the main pass. "
+        "The exclude_sources should be ('cron',), not ('cron', 'webui')."
+    )

--- a/tests/test_issue3586_cli_session_source_label.py
+++ b/tests/test_issue3586_cli_session_source_label.py
@@ -1,0 +1,181 @@
+"""Regression coverage for is_cli_session wrongly True for messaging sessions (#3586).
+
+_load_cli_sessions_uncached() previously hardcoded 'is_cli_session': True for
+every state.db row. Sessions from Discord, Telegram, Slack, and cron must have
+is_cli_session == False; only rows whose source normalises to 'cli' should be True.
+"""
+
+import sqlite3
+import time
+import unittest.mock
+
+import api.models as models
+
+
+def _make_state_db(path, sessions):
+    """Create a minimal state.db with the given sessions list.
+
+    Each item is a dict with at least: id, source, title.
+    Messaging sessions get one user + one assistant message (enough to be
+    importable since they are not CLI and bypass the user-turn threshold).
+    CLI sessions get a non-generic title so is_cli_session_row_visible does
+    not apply the CLI_MIN_UNTITLED_USER_MESSAGE_COUNT guard; they also get
+    two user messages as belt-and-suspenders.
+    """
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            session_source TEXT,
+            title TEXT,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            parent_session_id TEXT,
+            ended_at REAL,
+            end_reason TEXT
+        );
+        CREATE INDEX idx_sessions_started ON sessions(started_at);
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        );
+        CREATE INDEX idx_messages_session ON messages(session_id, timestamp);
+        """
+    )
+    base = time.time() - len(sessions)
+    for i, sess in enumerate(sessions):
+        sid = sess['id']
+        started = base + i
+        conn.execute(
+            """
+            INSERT INTO sessions
+            (id, source, session_source, title, model, started_at, message_count,
+             parent_session_id, ended_at, end_reason)
+            VALUES (?, ?, NULL, ?, 'deepseek/deepseek-chat', ?, 2, NULL, NULL, NULL)
+            """,
+            (sid, sess['source'], sess.get('title', sid), started),
+        )
+        # Two user messages so CLI rows pass CLI_MIN_UNTITLED_USER_MESSAGE_COUNT (=2).
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?, ?, 'user', 'hello', ?)",
+            (f"msg_{sid}_0", sid, started),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?, ?, 'user', 'follow-up', ?)",
+            (f"msg_{sid}_1", sid, started + 0.1),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?, ?, 'assistant', 'hi', ?)",
+            (f"msg_{sid}_2", sid, started + 0.2),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _call_uncached(tmp_path, sessions):
+    """Build a state.db from ``sessions``, call _load_cli_sessions_uncached, return results."""
+    db = tmp_path / 'state.db'
+    _make_state_db(db, sessions)
+    hermes_home = tmp_path
+
+    # Patch out side-effects that touch the real filesystem.
+    with (
+        unittest.mock.patch('api.models.get_claude_code_sessions', return_value=[]),
+        unittest.mock.patch('api.models.ensure_cron_project', return_value='cron-project-id'),
+    ):
+        return models._load_cli_sessions_uncached(hermes_home, db, None)
+
+
+def _find(results, sid):
+    return next((s for s in results if s['session_id'] == sid), None)
+
+
+def test_discord_session_is_not_cli(tmp_path):
+    """Discord-sourced sessions must have is_cli_session == False."""
+    sessions = [
+        {'id': 'discord_abc123', 'source': 'discord', 'title': 'Discord Chat'},
+    ]
+    results = _call_uncached(tmp_path, sessions)
+    row = _find(results, 'discord_abc123')
+    assert row is not None, "discord session should appear in results"
+    assert row['is_cli_session'] is False, (
+        f"expected is_cli_session=False for discord session, got {row['is_cli_session']!r}"
+    )
+
+
+def test_telegram_session_is_not_cli(tmp_path):
+    """Telegram-sourced sessions must have is_cli_session == False."""
+    sessions = [
+        {'id': 'telegram_xyz789', 'source': 'telegram', 'title': 'Telegram Chat'},
+    ]
+    results = _call_uncached(tmp_path, sessions)
+    row = _find(results, 'telegram_xyz789')
+    assert row is not None, "telegram session should appear in results"
+    assert row['is_cli_session'] is False, (
+        f"expected is_cli_session=False for telegram session, got {row['is_cli_session']!r}"
+    )
+
+
+def test_slack_session_is_not_cli(tmp_path):
+    """Slack-sourced sessions must have is_cli_session == False."""
+    sessions = [
+        {'id': 'slack_def456', 'source': 'slack', 'title': 'Slack Chat'},
+    ]
+    results = _call_uncached(tmp_path, sessions)
+    row = _find(results, 'slack_def456')
+    assert row is not None, "slack session should appear in results"
+    assert row['is_cli_session'] is False, (
+        f"expected is_cli_session=False for slack session, got {row['is_cli_session']!r}"
+    )
+
+
+def test_cron_session_is_not_cli(tmp_path):
+    """Cron-sourced sessions must have is_cli_session == False."""
+    sessions = [
+        {'id': 'cron_job1_1717000000', 'source': 'cron', 'title': 'Scheduled Job'},
+    ]
+    results = _call_uncached(tmp_path, sessions)
+    row = _find(results, 'cron_job1_1717000000')
+    assert row is not None, "cron session should appear in results"
+    assert row['is_cli_session'] is False, (
+        f"expected is_cli_session=False for cron session, got {row['is_cli_session']!r}"
+    )
+
+
+def test_cli_session_is_cli(tmp_path):
+    """CLI-sourced sessions must have is_cli_session == True."""
+    sessions = [
+        # Non-generic title bypasses the _looks_like_default_cli_title guard;
+        # two user messages are inserted by _make_state_db for belt-and-suspenders.
+        {'id': 'cli_session_001', 'source': 'cli', 'title': 'Refactor auth module'},
+    ]
+    results = _call_uncached(tmp_path, sessions)
+    row = _find(results, 'cli_session_001')
+    assert row is not None, "cli session should appear in results"
+    assert row['is_cli_session'] is True, (
+        f"expected is_cli_session=True for cli session, got {row['is_cli_session']!r}"
+    )
+
+
+def test_mixed_sources_classified_correctly(tmp_path):
+    """Mixed source types are each classified correctly in a single db scan."""
+    sessions = [
+        {'id': 'disc_1', 'source': 'discord', 'title': 'Discord'},
+        {'id': 'tele_1', 'source': 'telegram', 'title': 'Telegram'},
+        # Non-generic title so the CLI visibility check passes without extra tuning.
+        {'id': 'cli_1', 'source': 'cli', 'title': 'Improve parser performance'},
+        {'id': 'cron_job2_1717000001', 'source': 'cron', 'title': 'Cron'},
+    ]
+    results = _call_uncached(tmp_path, sessions)
+    by_id = {s['session_id']: s for s in results}
+
+    assert by_id['disc_1']['is_cli_session'] is False
+    assert by_id['tele_1']['is_cli_session'] is False
+    assert by_id['cli_1']['is_cli_session'] is True
+    assert by_id['cron_job2_1717000001']['is_cli_session'] is False

--- a/tests/test_issue3603_external_session_import_gate.py
+++ b/tests/test_issue3603_external_session_import_gate.py
@@ -1,0 +1,84 @@
+"""Regression test for _isExternalSession helper covering messaging open-path (#3603).
+
+After #3603 reclassified messaging sessions (Discord/Telegram/Slack) as
+non-CLI, the session open path only triggered import_cli for `is_cli_session`
+sessions, making messaging sessions click-to-open-but-can't-send.
+
+This test pins:
+- `_isExternalSession` exists in sessions.js
+- The open-path gate at line ~5024 uses `_isExternalSession` (not just is_cli_session)
+- The gateway-refresh gate at line ~3116 uses `_isExternalSession`
+- The lineage-segment and child-session open gates use `_isExternalSession`
+"""
+
+import re
+
+
+def _read_js():
+    with open('static/sessions.js', encoding='utf-8') as f:
+        return f.read()
+
+
+def test_is_external_session_function_exists():
+    """sessions.js must define _isExternalSession helper."""
+    js = _read_js()
+    assert re.search(r'function\s+_isExternalSession\s*\(', js), (
+        '_isExternalSession function not found in sessions.js'
+    )
+
+
+def test_is_external_session_covers_messaging():
+    """_isExternalSession must check both is_cli_session and _isMessagingSession."""
+    js = _read_js()
+    m = re.search(
+        r'function\s+_isExternalSession\s*\([^)]*\)\s*\{([^}]*)\}',
+        js,
+        re.DOTALL,
+    )
+    assert m, '_isExternalSession function body not found'
+    body = m.group(1)
+    assert 'is_cli_session' in body, (
+        '_isExternalSession must reference is_cli_session'
+    )
+    assert '_isMessagingSession' in body, (
+        '_isExternalSession must reference _isMessagingSession'
+    )
+
+
+def test_open_path_uses_is_external_session():
+    """Session open handler must use _isExternalSession for import gate."""
+    js = _read_js()
+    # The import gate in the session-click handler should use _isExternalSession
+    assert re.search(
+        r'if\s*\(\s*_isExternalSession\s*\(\s*s\s*\)\s*\)',
+        js,
+    ), 'Session open handler must use _isExternalSession(s) for import gate'
+
+
+def test_gateway_refresh_uses_is_external_session():
+    """Gateway SSE refresh must use _isExternalSession for active-session check."""
+    js = _read_js()
+    # Find the gateway SSE handler block (near line 3116)
+    # It should have _isExternalSession(S.session)
+    assert re.search(
+        r'if\s*\(\s*S\.session\s*&&\s*!S\.busy\s*&&\s*_isExternalSession\s*\(\s*S\.session\s*\)\s*\)',
+        js,
+    ), 'Gateway SSE refresh must use _isExternalSession(S.session)'
+
+
+def test_lineage_open_uses_is_external_session():
+    """Lineage segment open handler must use _isExternalSession."""
+    js = _read_js()
+    assert re.search(
+        r'if\s*\(\s*_isExternalSession\s*\(\s*seg\s*\)\s*\)',
+        js,
+    ), 'Lineage segment open must use _isExternalSession(seg)'
+
+
+def test_child_session_open_uses_is_external_session():
+    """Child session open handler must use _isExternalSession."""
+    js = _read_js()
+    assert re.search(
+        r'if\s*\(\s*_isExternalSession\s*\(\s*child\s*\)\s*\)',
+        js,
+    ), 'Child session open must use _isExternalSession(child)'


### PR DESCRIPTION
## Release v0.51.264 — Release IF (stage-r14)

Un-held sibling pair (#3585 + #3586) — both addressed the findings from the earlier hold; re-reviewed fresh.

### Fixed
| Issue/PR | Author | Fix |
|----------|--------|-----|
| #3585 | @rodboev | Cron sessions no longer flood the CLI sidebar window (restored the `("cron","webui")` exclusion in `_load_cli_sessions_uncached`). |
| #3586 | @rodboev | Messaging sessions keep their source label after a refresh **and open + send correctly** — `is_cli_session_row()` classifies them non-CLI, and the sidebar open/import path now uses `_isMessagingSession()` so a reclassified Discord/Telegram/Slack row is imported on open (no transient stub → no `/api/chat/start` 404). |

### Un-hold note
These were held earlier today because the `is_cli_session_row()` reclassification (#3586) created a CORE open-path regression — opening a reclassified messaging session 404'd on the next send. The author pushed a fix adding the `_isMessagingSession()` import gate at all open/lineage/refresh paths (+ regression test `test_issue3603_external_session_import_gate.py`), and Codex confirmed both that AND the secondary webui-recovery concern (cron-only exclusion now keeps `source='webui'` sidecar-less recovery rows) are resolved.

### Gate
- Full pytest suite: **7729 passed, 0 failed**
- ESLint: CLEAN · ruff: CLEAN · browser-smoke: CLEAN
- Codex (regression): **SAFE TO SHIP** — open→import→send path verified (messaging rows go through `/api/session/import_cli` before `/api/chat/start`); `is_cli_session_row` classification correct; the pair composes in `_load_cli_sessions_uncached`.

Co-authored-by: rodboev <rodboev@users.noreply.github.com>