### PR TITLE
fix(profiles): profile chip reflects active profile, not session's (#3635)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **The composer profile chip again reflects the active profile, not the loaded session's profile.** After #3331 (v0.51.204) the chip label keyed on the *browsed session's* profile, but the chip is the profile-switcher trigger and message/new-chat routing follow the client *active* profile (the `hermes_profile` cookie, set only by `/api/profile/switch`). Since `loadSession()` never updates `S.activeProfile`, opening a session that belongs to a different profile made the chip disagree with the dropdown checkmark and misrepresent where the next message would route. The chip label in `syncTopbar()` now reads `S.activeProfile` in both branches; #3331's project/session-operation profile scoping is unaffected. (#3635)
+
 ## [v0.51.264] — 2026-06-04 — Release IF (stage-r14 — sidebar cron-overflow + messaging source labels, un-held)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -5900,9 +5900,19 @@ function syncTopbar(){
   if(typeof syncWorkspaceDisplays==='function') syncWorkspaceDisplays();
   if(typeof syncTerminalButton==='function') syncTerminalButton();
   // modelSelect already set above
-  // Update profile chip label
+  // Update profile chip label.
+  // The chip is the profile-SWITCHER trigger (it fronts the profile dropdown) and
+  // governs where the next message / new chat routes — both follow the client
+  // active profile (the hermes_profile cookie, set only by /api/profile/switch).
+  // It must therefore reflect S.activeProfile, NOT the loaded session's profile.
+  // #3331 briefly keyed this on S.session.profile so the label would track the
+  // session being browsed, but loadSession() never updates S.activeProfile, so
+  // opening a cross-profile session made the chip disagree with the dropdown
+  // checkmark and lie about message routing (#3635). #3331's legitimate work —
+  // scoping project/session operations to the session's own profile — is
+  // unaffected by this line.
   const profileLabel=$('profileChipLabel');
-  if(profileLabel) profileLabel.textContent=(S.session&&S.session.profile)||S.activeProfile||'default';
+  if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
 }
 
 function msgContent(m){

--- a/tests/test_issue3635_profile_chip_active.py
+++ b/tests/test_issue3635_profile_chip_active.py
@@ -1,0 +1,91 @@
+"""Tests for #3635 — profile chip must reflect the ACTIVE profile, not the
+loaded session's profile.
+
+Regression from #3331 (shipped v0.51.204): #3331 changed the composer profile
+chip label in syncTopbar()'s session-present branch to read
+``(S.session&&S.session.profile)||S.activeProfile`` so the label would track the
+profile of whatever session was being browsed. But the chip is the profile
+*switcher* trigger (it fronts the profile dropdown), and message routing /
+new-chat creation both follow the client active profile (the ``hermes_profile``
+cookie, set only by ``/api/profile/switch``). ``loadSession()`` sets
+``S.session`` but never updates ``S.activeProfile``, so opening a session that
+belongs to a different profile than the active one made the chip diverge from
+the dropdown checkmark and misrepresent where the next message would route.
+
+The fix reverts JUST the chip label to ``S.activeProfile`` in both syncTopbar
+branches. #3331's legitimate project/session-operation scoping (which keys on
+the session's own profile) is unrelated to this line and stays in place.
+"""
+
+from pathlib import Path
+
+import re
+
+
+def _ui_js() -> str:
+    return (Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _sync_topbar_body(src: str) -> str:
+    """Return the full source of the syncTopbar() function."""
+    start = src.find("function syncTopbar(){")
+    assert start != -1, "syncTopbar function not found in ui.js"
+    # Walk braces to find the matching close.
+    i = src.find("{", start)
+    depth = 0
+    for j in range(i, len(src)):
+        if src[j] == "{":
+            depth += 1
+        elif src[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : j + 1]
+    raise AssertionError("could not find end of syncTopbar()")
+
+
+class TestIssue3635ProfileChipActive:
+    def test_session_present_chip_reads_active_profile(self):
+        """The session-present chip-label update must read S.activeProfile."""
+        body = _sync_topbar_body(_ui_js())
+        # There are two profileChipLabel updates: the !S.session early-return
+        # block and the session-present block. Both must key on S.activeProfile.
+        updates = re.findall(
+            r"profileChipLabel'\);\s*\n\s*if\([^)]*\)\s*[^.]*\.textContent=([^;]+);",
+            body,
+        )
+        assert updates, "no profileChipLabel textContent assignment found in syncTopbar"
+        for expr in updates:
+            assert "S.activeProfile" in expr, (
+                "profile chip label must read S.activeProfile, got: " + expr.strip()
+            )
+
+    def test_chip_does_not_key_on_session_profile(self):
+        """Forbid the #3331 regression shape: chip keying on S.session.profile.
+
+        This negative assertion stops a future change from re-pointing the
+        switcher-trigger chip at the loaded session's profile (#3635).
+        """
+        body = _sync_topbar_body(_ui_js())
+        assert "(S.session&&S.session.profile)||S.activeProfile" not in body, (
+            "profile chip label must NOT key on S.session.profile — that is the "
+            "#3331 regression that made the chip diverge from the active profile "
+            "and misrepresent message routing (#3635)."
+        )
+        # Also guard the spaced variant.
+        assert "(S.session && S.session.profile) || S.activeProfile" not in body, (
+            "profile chip label must NOT key on S.session.profile (#3635)."
+        )
+
+    def test_both_chip_setters_consistent(self):
+        """Both the no-session and session-present chip setters must agree.
+
+        Before the fix the early-return (no session) branch read S.activeProfile
+        while the session-present branch read S.session.profile — the
+        inconsistency was the bug. They must now be identical.
+        """
+        body = _sync_topbar_body(_ui_js())
+        setters = re.findall(r"\.textContent=(S\.activeProfile\|\|'default')", body)
+        assert len(setters) >= 2, (
+            "expected both syncTopbar chip-label setters to read "
+            "S.activeProfile||'default'; found: " + str(setters)
+        )


### PR DESCRIPTION
## Summary

The composer **profile chip** could show a different profile than the one that is actually active. Opening a session that belongs to a different profile than your active one made the chip disagree with the profile dropdown's checkmark, and re-switching only stuck until you clicked another cross-profile session. Reported in Discord #webui by @b3nw ("the profile dropdown not matching the active profile even after manually switching").

This is a regression from #3331 (shipped v0.51.204, 2026-06-01) and is **front-end display only** — the backend was always correct.

## Root cause

The chip and the dropdown read from two different sources of truth after #3331:

- **Chip label** (`static/ui.js`, `syncTopbar()`) was changed by #3331 to key on the **session's** profile:
  ```js
  if(profileLabel) profileLabel.textContent=(S.session&&S.session.profile)||S.activeProfile||'default';
  ```
- **Dropdown checkmark** (`static/panels.js`, `renderProfileDropdown()`) still keys on the **client active** profile (`S.activeProfile`).

`loadSession()` (`static/sessions.js`) sets `S.session` but **never updates `S.activeProfile`**. So the moment you open a session belonging to a different profile, the chip flips to the session's profile while the dropdown — and message routing — stay on the active profile.

This matters because the chip is the **profile-switcher trigger**, and message/new-chat routing follows the **active** profile (the `hermes_profile` cookie, set only by `/api/profile/switch`; new sessions are created with `S.activeProfile`). So a chip showing the session's profile actively *misrepresents where the next message will route*.

## Fix

Revert just the chip label to `S.activeProfile` in `syncTopbar()` (the no-session early-return branch already did this — the session-present branch was the inconsistent one). One line + an explanatory comment.

```js
const profileLabel=$('profileChipLabel');
if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
```

#3331's legitimate work — scoping project/session operations (project picker filter, create/rename/move) to the session's own profile so they don't 404 — is in `sessions.js`/`routes.py` and is **unaffected** by this line. The `!sessionInProgress`-guarded `S.session.profile = data.active` retag in the switch path also stays.

This is Option A from the issue's fix-shape analysis (the recommended immediate regression fix). Options B (adopt the session's profile on load) and C (separate non-interactive context label) remain available as a follow-up design decision, but A restores the correct switcher semantics with minimal risk.

## Testing

- **Full suite: 7732 passed, 9 skipped, 0 failures** (added 3 new tests).
- **New regression test** `tests/test_issue3635_profile_chip_active.py`:
  - asserts both `syncTopbar()` chip setters read `S.activeProfile`
  - **forbids** the `(S.session&&S.session.profile)||S.activeProfile` shape (guards against re-introducing the #3331 regression)
  - pins two-branch consistency
- Existing `test_profile_switch_1200.py` (no-session chip update) + `test_issue1614_project_profile_filtering.py` + `test_issue1116_composer_placeholder.py` still green — the fix doesn't disturb #3331's project scoping or the no-session chip behavior.
- **Live browser verification** (worktree on :8789, CDP): with `S.activeProfile='profileB'` and a loaded session `profile:'profileA'`, the chip now shows `profileB` after a cross-profile session load (was `profileA` with the old expression — verified the old vs new expression diverge: `OLD='profileA'`, `NEW='profileB'`).

Closes #3635

Reported by @b3nw (Discord #webui, 2026-06-04).
