### PR TITLE
test(profiles): pin profile chip↔dropdown source-of-truth invariant (#3635, stacked on #3637)

### DIFF
--- a/tests/test_issue3635_profile_chip_active.py
+++ b/tests/test_issue3635_profile_chip_active.py
@@ -89,3 +89,77 @@ class TestIssue3635ProfileChipActive:
             "expected both syncTopbar chip-label setters to read "
             "S.activeProfile||'default'; found: " + str(setters)
         )
+
+
+def _panels_js() -> str:
+    return (Path(__file__).parent.parent / "static" / "panels.js").read_text(encoding="utf-8")
+
+
+def _render_profile_dropdown_body(src: str) -> str:
+    """Return the source of renderProfileDropdown()."""
+    start = src.find("function renderProfileDropdown(")
+    assert start != -1, "renderProfileDropdown not found in panels.js"
+    i = src.find("{", start)
+    depth = 0
+    for j in range(i, len(src)):
+        if src[j] == "{":
+            depth += 1
+        elif src[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : j + 1]
+    raise AssertionError("could not find end of renderProfileDropdown()")
+
+
+class TestProfileSwitcherSourceOfTruthInvariant:
+    """Standing invariant guard (generalizes #3635).
+
+    The profile chip (the switcher trigger, in syncTopbar()/ui.js) and the
+    profile dropdown's active/checkmark row (renderProfileDropdown()/panels.js)
+    are two renderings of the SAME thing — "which profile is active." They must
+    resolve from the same source of truth (S.activeProfile). #3331 broke this by
+    pointing the chip at S.session.profile while the dropdown still used
+    S.activeProfile, so the switcher trigger and the menu it opens disagreed
+    (#3635). This invariant fails fast if any future change re-splits them.
+    """
+
+    def test_chip_keys_on_active_profile(self):
+        body = _sync_topbar_body(_ui_js())
+        # Every profileChipLabel.textContent assignment must read S.activeProfile.
+        assignments = re.findall(r"profileChipLabel'\);[\s\S]{0,120}?\.textContent=([^;]+);", body)
+        assert assignments, "no profileChipLabel assignment found in syncTopbar()"
+        for expr in assignments:
+            assert "S.activeProfile" in expr and "S.session.profile" not in expr, (
+                "profile chip (switcher trigger) must resolve from S.activeProfile, "
+                "not the loaded session's profile: " + expr.strip()
+            )
+
+    def test_dropdown_active_row_keys_on_active_profile(self):
+        body = _render_profile_dropdown_body(_panels_js())
+        # The dropdown's active row is computed into `const active = ...`.
+        m = re.search(r"const active\s*=\s*([\s\S]*?);", body)
+        assert m, "could not find the `const active =` computation in renderProfileDropdown()"
+        expr = m.group(1)
+        assert "S.activeProfile" in expr, (
+            "dropdown active-row must resolve from S.activeProfile so it agrees "
+            "with the chip (switcher source-of-truth invariant): " + expr.strip()
+        )
+
+    def test_chip_and_dropdown_share_source_of_truth(self):
+        """The chip and the dropdown active-row must BOTH key on S.activeProfile.
+
+        This is the cross-file invariant that #3635 violated: a passing version
+        of this test means the switcher trigger and the menu it opens can never
+        again silently disagree about which profile is active.
+        """
+        chip_body = _sync_topbar_body(_ui_js())
+        dd_body = _render_profile_dropdown_body(_panels_js())
+        chip_ok = "S.activeProfile" in chip_body and \
+            "(S.session&&S.session.profile)||S.activeProfile" not in chip_body
+        dd_ok = "S.activeProfile" in dd_body
+        assert chip_ok and dd_ok, (
+            "profile chip (ui.js syncTopbar) and dropdown active-row "
+            "(panels.js renderProfileDropdown) must share S.activeProfile as the "
+            "single source of truth for 'active profile' (#3635). "
+            f"chip_ok={chip_ok} dd_ok={dd_ok}"
+        )


### PR DESCRIPTION
## Summary

**Stacked on #3637** (base = `fix/3635-profile-chip-active`). This PR is test-only — no production code — and should merge **after** #3637. Once #3637 merges to master, GitHub will retarget this to `master` automatically; the diff is purely the new test.

Adds a standing **source-of-truth invariant** test that generalizes the #3635 fix so the regression can't silently come back.

## Why

#3635 was a UI source-of-truth divergence: the composer **profile chip** (`syncTopbar()` in `ui.js`) and the **profile dropdown's** active/checkmark row (`renderProfileDropdown()` in `panels.js`) are two renderings of the same fact — *which profile is active* — but #3331 pointed the chip at `S.session.profile` while the dropdown kept reading `S.activeProfile`. Opening a cross-profile session made the switcher trigger disagree with the menu it opens, and misrepresented where the next message would route.

#3637 fixes the chip. This PR pins the **invariant** so a future change can't re-split the two surfaces:

## What

`tests/test_issue3635_profile_chip_active.py` gains a `TestProfileSwitcherSourceOfTruthInvariant` class (deterministic JS-source assertions, no browser, runs in the normal pytest suite):

- `test_chip_keys_on_active_profile` — the chip (ui.js `syncTopbar`) resolves from `S.activeProfile`, never `S.session.profile`
- `test_dropdown_active_row_keys_on_active_profile` — the dropdown active row (panels.js `renderProfileDropdown`) resolves from `S.activeProfile`
- `test_chip_and_dropdown_share_source_of_truth` — cross-file check that **both** key on `S.activeProfile`

## Testing

- `tests/test_issue3635_profile_chip_active.py`: **6 passed** (3 from #3637 + 3 new).
- Full suite green on the stacked branch.
- A companion **browser-level** regression gate (drives the real `syncTopbar()` + `renderProfileDropdown()` and asserts the chip equals the dropdown's active row after a cross-profile session load) was added to the private QA harness and RED/GREEN-validated: it fails on the pre-#3637 buggy code (`chip='profileA'` vs `dropdown='profileB'`) and passes on the fix.

Refs #3635
