### PR TITLE
fix(security): gate TTS forwarded IP trust

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -9047,12 +9047,14 @@ def _handle_tts(handler, parsed):
                 self._checks = 0
 
             def _get_client_key(self, h):
-                for hdr in ("X-Forwarded-For", "X-Real-IP", "Forwarded"):
-                    val = h.headers.get(hdr)
-                    if val:
-                        ip = val.split(",")[0].strip().split(";")[0].strip()
-                        if ip:
-                            return ip
+                trust_proxy = os.getenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "").strip().lower()
+                if trust_proxy in ("1", "true", "yes", "on"):
+                    for hdr in ("X-Forwarded-For", "X-Real-IP", "Forwarded"):
+                        val = h.headers.get(hdr)
+                        if val:
+                            ip = val.split(",")[0].strip().split(";")[0].strip()
+                            if ip:
+                                return ip
                 return getattr(h, "client_address", ("unknown",))[0]
 
             def check(self, handler, session_cookie=None):

--- a/tests/test_issue2931_edge_tts_endpoint.py
+++ b/tests/test_issue2931_edge_tts_endpoint.py
@@ -65,6 +65,7 @@ def _fresh_tts_limiter(monkeypatch):
     import api.auth as _auth
     monkeypatch.setattr(_auth, "is_auth_enabled", lambda: False)
     monkeypatch.setattr(routes, "is_auth_enabled", lambda: False, raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", raising=False)
     _reset_limiter()
     yield
     _reset_limiter()
@@ -110,3 +111,41 @@ def test_tts_rate_limits_second_immediate_request():
     h2 = _post({"text": "hello", "voice": "not-a-real-voice"}, client="10.0.0.3")
     routes._handle_tts(h2, None)
     assert h2.status == 429
+
+
+def test_tts_rate_limit_ignores_spoofed_forwarded_for_by_default():
+    h1 = _post(
+        {"text": "hello", "voice": "not-a-real-voice"},
+        headers={"X-Forwarded-For": "203.0.113.10"},
+        client="10.0.0.4",
+    )
+    routes._handle_tts(h1, None)
+    assert h1.status == 400
+
+    h2 = _post(
+        {"text": "hello", "voice": "not-a-real-voice"},
+        headers={"X-Forwarded-For": "203.0.113.11"},
+        client="10.0.0.4",
+    )
+    routes._handle_tts(h2, None)
+    assert h2.status == 429
+
+
+def test_tts_rate_limit_can_trust_forwarded_for_when_opted_in(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+
+    h1 = _post(
+        {"text": "hello", "voice": "not-a-real-voice"},
+        headers={"X-Forwarded-For": "203.0.113.12"},
+        client="10.0.0.5",
+    )
+    routes._handle_tts(h1, None)
+    assert h1.status == 400
+
+    h2 = _post(
+        {"text": "hello", "voice": "not-a-real-voice"},
+        headers={"X-Forwarded-For": "203.0.113.13"},
+        client="10.0.0.5",
+    )
+    routes._handle_tts(h2, None)
+    assert h2.status == 400


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI exposes `/api/tts` as an authenticated or local browser endpoint, and the endpoint has its own per-client throttle.
- The throttle currently trusts `X-Forwarded-For`, `X-Real-IP`, and `Forwarded` on every deployment.
- A direct client can spoof those headers and rotate the rate-limit key, so the two-second guard can be bypassed without changing the TCP peer.
- Other security-sensitive header trust in this repo already uses explicit operator opt-in, such as forwarded-proto handling for auth cookies.
- This PR keeps the safe default on the socket peer and preserves reverse-proxy support behind an explicit opt-in.

## What Changed

- Gate TTS forwarded-client-IP trust behind `HERMES_WEBUI_TRUST_FORWARDED_FOR`.
- Keep the existing `X-Forwarded-For`, `X-Real-IP`, and `Forwarded` parsing only when the operator enables that env var.
- Add regression coverage for both default spoof resistance and opt-in reverse-proxy behavior.

## Why It Matters

This closes a practical rate-limit bypass for deployments where the WebUI is reachable directly or through a proxy that does not strip client-supplied forwarding headers. The default now matches the conservative boundary used elsewhere: do not trust proxy headers unless the operator says that the server is behind a trusted proxy.

## Verification

- `python -m py_compile api\routes.py`
- `uv run --no-project --with ruff python scripts\ruff_lint.py --diff official/master`
- Direct in-process fake-handler check: default spoofed `X-Forwarded-For` sequence returned `400, 429`; opt-in sequence returned `400, 400`.
- Attempted `uv run --no-project --with pytest python -m pytest -o addopts='' tests\test_issue2931_edge_tts_endpoint.py` locally on Windows. The run did not reach these assertions because the official `tests/conftest.py` autouse server fixture could not start the local Hermes Agent test server in this environment; the failure was environmental and independent of the TTS handler logic.

## Risks / Follow-ups

- Operators behind a trusted reverse proxy who rely on per-public-client TTS throttling should set `HERMES_WEBUI_TRUST_FORWARDED_FOR=1` and ensure the proxy strips untrusted inbound forwarding headers.
- No docs were changed because this is a narrow security hardening and the env var is intentionally opt-in.

## Model Used

Provider: OpenAI
Model: GPT-5 Codex
Notable tool use: Codex Security review workflow, GitHub PR/issue inspection, local git/pytest/ruff/py_compile verification.
