### PR TITLE
Release v0.51.266 — Release IH (stage-r16): profile-chip active + intermediate reasoning + session-event scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## [Unreleased]
 
+## [v0.51.266] — 2026-06-04 — Release IH (stage-r16 — profile-chip active fix + intermediate reasoning + session-event scoping)
+
+### Fixed
+- **The composer profile chip now always matches the active profile (and message routing).** A #3331 regression keyed the chip label on the loaded session's profile, so opening a cross-profile session made the chip disagree with the profile-dropdown checkmark and misrepresent where the next message would route. The chip reads `S.activeProfile` again (#3331's project/session operation scoping is unaffected). (#3635, @nesquena-hermes; reported by @b3nw)
+- **Reasoning/thinking traces are persisted to the correct intermediate assistant message in multi-turn tool flows.** The per-message reasoning index only advanced in `on_interim_assistant`, which the agent suppresses for contentless tool-call assistant messages — so post-tool reasoning was mis-attributed to the previous turn. The index now also advances at the tool-call boundary (`on_tool`), guarded against over-incrementing. (#3587, @rodboev)
+- **Session-event SSE broadcasts no longer wake every connected tab across profiles, and never drop a relevant refresh.** Profile identity is attached when known; root/`default` aliases stay unscoped (a browser tab can't infer every renamed-root alias); and the bounded (`maxsize=1`) subscriber queue now falls back to an unscoped refresh-all when coalescing would replace a pending event with a different-profile one (so an A-tab can't miss its refresh). (#2660, @franksong2702)
+
 ## [v0.51.265] — 2026-06-04 — Release IG (stage-r15 — owner-aware cancelStream(), un-held)
 
 ### Fixed

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -425,7 +425,13 @@ def install_cron_scheduler_profile_isolation() -> None:
             with cron_profile_context_for_home(_home_for_scheduled_cron_job(job)):
                 return original(job, *args, **kwargs)
         finally:
-            publish_session_list_changed("cron_complete")
+            event_profile = str((job or {}).get("profile") or "").strip() or None
+            try:
+                publish_session_list_changed("cron_complete", profile=event_profile)
+            except TypeError:
+                # Focused tests and older integrations may patch the publisher
+                # with the historical one-argument shape.
+                publish_session_list_changed("cron_complete")
 
     _webui_profile_isolated_run_job._webui_profile_isolated = True
     _webui_profile_isolated_run_job._webui_original_run_job = original
@@ -984,6 +990,7 @@ def switch_profile(name: str, *, process_wide: bool = True) -> dict:
     return {
         'profiles': list_profiles_api(),
         'active': name,
+        'is_default': _is_root_profile(name),
         'default_model': default_model,
         'default_model_provider': default_model_provider,
         'default_workspace': default_workspace,

--- a/api/routes.py
+++ b/api/routes.py
@@ -40,6 +40,21 @@ from api.session_events import (
 
 logger = logging.getLogger(__name__)
 
+
+def _publish_session_list_changed(reason: str, *, profile: str | None = None) -> None:
+    """Publish profile-scoped session changes while tolerating legacy test doubles."""
+    if not profile:
+        publish_session_list_changed(reason)
+        return
+    try:
+        publish_session_list_changed(reason, profile=profile)
+    except TypeError:
+        # Some focused tests monkeypatch the route-level publisher with the
+        # historical one-argument shape. Preserve the old signal instead of
+        # turning unrelated session mutations into 500s.
+        publish_session_list_changed(reason)
+
+
 # ── Cron run tracking ────────────────────────────────────────────────────────
 # Track job IDs currently being executed so the frontend can poll status.
 _RUNNING_CRON_JOBS: dict[str, float] = {}  # job_id → start_timestamp
@@ -772,6 +787,16 @@ def _profile_home_for_cron_job(job: dict):
     return get_hermes_home_for_profile(raw)
 
 
+def _event_profile_for_cron_job(job: dict) -> str | None:
+    """Return the profile identity browsers should refresh for a manual cron run."""
+    raw = str((job or {}).get("profile") or "").strip()
+    if not raw:
+        return None
+    if raw not in _available_cron_profile_names():
+        return None
+    return raw
+
+
 def _cron_job_subprocess_main(job, execution_profile_home, result_queue):
     """Run one cron job inside a child process pinned to a profile home."""
     try:
@@ -880,7 +905,12 @@ def _run_cron_job_in_profile_subprocess(job, execution_profile_home):
     raise RuntimeError(message)
 
 
-def _run_cron_tracked(job, profile_home=None, execution_profile_home=None):
+def _run_cron_tracked(
+    job,
+    profile_home=None,
+    execution_profile_home=None,
+    event_profile=None,
+):
     """Wrapper that tracks running state around cron.scheduler.run_job.
 
     ``profile_home`` is the cron store that owns the job row/output metadata.
@@ -961,7 +991,7 @@ def _run_cron_tracked(job, profile_home=None, execution_profile_home=None):
             logger.debug("Failed to mark manual cron run failure for %s", job_id)
     finally:
         _mark_cron_done(job_id)
-        publish_session_list_changed("cron_complete")
+        _publish_session_list_changed("cron_complete", profile=event_profile)
 
 _PROVIDER_ALIASES = {
     "claude": "anthropic",
@@ -5872,11 +5902,20 @@ def handle_get(handler, parsed) -> bool:
         )
 
     if parsed.path == "/api/profile/active":
-        from api.profiles import get_active_profile_name, get_active_hermes_home
+        from api.profiles import (
+            _is_root_profile,
+            get_active_hermes_home,
+            get_active_profile_name,
+        )
 
+        active_profile_name = get_active_profile_name()
         return j(
             handler,
-            {"name": get_active_profile_name(), "path": str(get_active_hermes_home())},
+            {
+                "name": active_profile_name,
+                "path": str(get_active_hermes_home()),
+                "is_default": _is_root_profile(active_profile_name),
+            },
         )
 
     # ── Gateway Status (GET) ──
@@ -6282,7 +6321,7 @@ def handle_post(handler, parsed) -> bool:
             worktree_info=worktree_info,
         )
         if worktree_info:
-            publish_session_list_changed("session_new")
+            publish_session_list_changed("session_new", profile=getattr(s, "profile", None))
         return j(handler, {"session": s.compact() | {"messages": s.messages}})
 
     if parsed.path == "/api/session/duplicate":
@@ -6363,7 +6402,7 @@ def handle_post(handler, parsed) -> bool:
             # Without this explicit save, the duplicate is in-memory only — if the user
             # refreshes before sending a turn, the duplicate vanishes.
             copied_session.save()
-            publish_session_list_changed("session_duplicate")
+            publish_session_list_changed("session_duplicate", profile=getattr(copied_session, "profile", None))
 
             return j(handler, {"session": copied_session.compact() | {"messages": copied_session.messages}})
         except Exception as e:
@@ -6506,7 +6545,7 @@ def handle_post(handler, parsed) -> bool:
             s.title = str(body["title"]).strip()[:80] or "Untitled"
             s.save()
         _sync_session_title_to_insights(s)
-        publish_session_list_changed("session_rename")
+        publish_session_list_changed("session_rename", profile=getattr(s, "profile", None))
         return j(handler, {"session": s.compact()})
 
 
@@ -6532,7 +6571,7 @@ def handle_post(handler, parsed) -> bool:
             s.llm_title_generated = True
             s.save(touch_updated_at=False)
         _sync_session_title_to_insights(s)
-        publish_session_list_changed("session_title_regenerate")
+        publish_session_list_changed("session_title_regenerate", profile=getattr(s, "profile", None))
         return j(handler, {
             "session": s.compact(),
             "title": s.title,
@@ -6762,6 +6801,13 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, "Read-only imported sessions cannot be deleted from WebUI", 400)
         is_messaging_session = _is_messaging_session_id(sid)
         worktree_retained = _worktree_retained_payload_for_session_id(sid)
+        try:
+            event_profile = getattr(get_session(sid, metadata_only=True), "profile", None)
+        except KeyError:
+            event_profile = None
+        except Exception:
+            logger.debug("Failed to resolve profile for deleted session %s", sid, exc_info=True)
+            event_profile = None
         # Delete from WebUI session store
         with LOCK:
             SESSIONS.pop(sid, None)
@@ -6806,7 +6852,7 @@ def handle_post(handler, parsed) -> bool:
                 delete_cli_session(sid)
             except Exception:
                 logger.debug("Failed to delete CLI session %s", sid)
-        publish_session_list_changed("session_delete")
+        _publish_session_list_changed("session_delete", profile=event_profile)
         return j(handler, {"ok": True, **worktree_retained})
 
     if parsed.path == "/api/session/clear":
@@ -6977,7 +7023,7 @@ def handle_post(handler, parsed) -> bool:
         # Persist only if there are messages (matches new_session pattern)
         if forked_messages:
             branch.save()
-            publish_session_list_changed("session_branch")
+            publish_session_list_changed("session_branch", profile=getattr(branch, "profile", None))
 
         return j(handler, {
             "session_id": branch.session_id,
@@ -7568,7 +7614,7 @@ def handle_post(handler, parsed) -> bool:
             with _get_session_agent_lock(body["session_id"]):
                 s.pinned = pin_requested
                 s.save()
-        publish_session_list_changed("session_pin")
+        publish_session_list_changed("session_pin", profile=getattr(s, "profile", None))
         return j(handler, {"ok": True, "session": s.compact()})
 
     # ── Session archive (POST) ──
@@ -7645,7 +7691,7 @@ def handle_post(handler, parsed) -> bool:
         with _get_session_agent_lock(sid):
             s.archived = bool(body.get("archived", True))
             s.save(touch_updated_at=False)
-        publish_session_list_changed("session_archive")
+        publish_session_list_changed("session_archive", profile=getattr(s, "profile", None))
         return j(handler, {"ok": True, "session": s.compact(), **_worktree_retained_payload(s)})
 
     # ── Session move to project (POST) ──
@@ -7680,7 +7726,7 @@ def handle_post(handler, parsed) -> bool:
         with _get_session_agent_lock(body["session_id"]):
             s.project_id = target_pid
             s.save()
-        publish_session_list_changed("session_move")
+        publish_session_list_changed("session_move", profile=getattr(s, "profile", None))
         return j(handler, {"ok": True, "session": s.compact()})
 
     # ── Project CRUD (POST) ──
@@ -10804,7 +10850,7 @@ def _start_chat_stream_for_session(
             stream_id=stream_id,
         )
     if was_hidden_empty_session:
-        publish_session_list_changed("session_new")
+        publish_session_list_changed("session_new", profile=getattr(s, "profile", None))
     diag.stage("turn_journal_submitted") if diag else None
     journal_event = {}
     try:
@@ -11521,7 +11567,8 @@ def _handle_cron_run(handler, body):
 
     _profile_home = get_active_hermes_home()
     _execution_profile_home = _profile_home_for_cron_job(job)
-    threading.Thread(target=_run_cron_tracked, args=(job, _profile_home, _execution_profile_home), daemon=True).start()
+    _event_profile = _event_profile_for_cron_job(job)
+    threading.Thread(target=_run_cron_tracked, args=(job, _profile_home, _execution_profile_home, _event_profile), daemon=True).start()
     return j(handler, {"ok": True, "job_id": job_id, "status": "running"})
 
 
@@ -14075,7 +14122,10 @@ def _handle_session_import_cli(handler, body):
                     changed = True
         if changed:
             existing.save(touch_updated_at=False)
-            publish_session_list_changed("session_import_cli")
+            publish_session_list_changed(
+                "session_import_cli",
+                profile=getattr(existing, "profile", None),
+            )
         return j(
             handler,
             {
@@ -14192,7 +14242,10 @@ def _handle_session_import_cli(handler, body):
     s.platform = cli_platform
     s._cli_origin = sid
     s.save(touch_updated_at=False)
-    publish_session_list_changed("session_import_cli")
+    publish_session_list_changed(
+        "session_import_cli",
+        profile=getattr(s, "profile", None),
+    )
     return j(
         handler,
         {

--- a/api/session_events.py
+++ b/api/session_events.py
@@ -8,27 +8,89 @@ _SESSION_EVENTS_SUBSCRIBERS: set[queue.Queue] = set()
 _SESSION_EVENTS_VERSION = 0
 
 
-def publish_session_list_changed(reason: str = "session_changed") -> None:
+def _profile_is_root_alias(profile: str | None) -> bool:
+    name = str(profile or "").strip()
+    if not name:
+        return False
+    if name == "default":
+        return True
+    try:
+        from api.profiles import _is_root_profile
+
+        return bool(_is_root_profile(name))
+    except Exception:
+        return False
+
+
+def _sessions_changed_payload(
+    *,
+    reason: str,
+    version: int,
+    profile: str | None = None,
+) -> dict:
+    payload = {
+        "type": "sessions_changed",
+        "version": version,
+        "reason": reason,
+    }
+    normalized_profile = str(profile or "").strip()
+    # Root/default aliases must stay unscoped: browser tabs cannot infer every
+    # renamed-root alias, and an unscoped refresh preserves the old fail-safe.
+    if normalized_profile and not _profile_is_root_alias(normalized_profile):
+        payload["profile"] = normalized_profile
+    return payload
+
+
+def _payload_profile(payload: dict | None) -> str | None:
+    value = payload.get("profile") if isinstance(payload, dict) else None
+    value = str(value or "").strip()
+    return value or None
+
+
+def _coalesced_sessions_changed_payload(pending: dict | None, incoming: dict) -> dict:
+    """Merge bounded-queue refresh events without dropping profile-relevant work.
+
+    A maxsize=1 queue is safe only while all events are interchangeable. Once
+    events can be profile-scoped, replacing profile A with profile B can make
+    an A tab ignore the queued event and miss the refresh entirely. On any
+    scope mismatch, fall back to an unscoped refresh-all event.
+    """
+    if pending is None:
+        return incoming
+    pending_profile = _payload_profile(pending)
+    incoming_profile = _payload_profile(incoming)
+    if pending_profile == incoming_profile:
+        return incoming
+    merged = dict(incoming)
+    merged.pop("profile", None)
+    return merged
+
+
+def publish_session_list_changed(
+    reason: str = "session_changed",
+    profile: str | None = None,
+) -> None:
     """Notify connected browsers that the session sidebar may be stale."""
     global _SESSION_EVENTS_VERSION
     with _SESSION_EVENTS_LOCK:
         _SESSION_EVENTS_VERSION += 1
-        payload = {
-            "type": "sessions_changed",
-            "version": _SESSION_EVENTS_VERSION,
-            "reason": reason,
-        }
+        payload = _sessions_changed_payload(
+            reason=reason,
+            version=_SESSION_EVENTS_VERSION,
+            profile=profile,
+        )
         subscribers = list(_SESSION_EVENTS_SUBSCRIBERS)
     for q in subscribers:
         try:
             q.put_nowait(payload)
         except queue.Full:
+            pending = None
             try:
-                q.get_nowait()
+                pending = q.get_nowait()
             except queue.Empty:
                 pass
             try:
-                q.put_nowait(payload)
+                q.put_nowait(_coalesced_sessions_changed_payload(pending, payload))
             except queue.Full:
                 pass
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4782,7 +4782,12 @@ def _run_agent_streaming(
         try:
             _token_sent = False  # tracks whether any streamed tokens were sent
             _self_healed = False  # (#1401) prevents infinite self-heal retries
-            _reasoning_text = ''  # accumulates reasoning/thinking trace for persistence
+            # Per-message reasoning: dict maps assistant-message index → accumulated text
+            # (#3587) replaces the flat _reasoning_text string so each intermediate
+            # assistant turn (before tool calls) keeps its own reasoning segment.
+            _reasoning_segments: dict = {}
+            _current_reasoning_idx = 0
+            _tool_boundary_advanced = False
             _live_tool_calls = []  # tool progress fallback when final messages omit tool IDs
 
             # Throttle: emit metering events at most every 100 ms so the per-message
@@ -4832,9 +4837,10 @@ def _run_agent_streaming(
                 _emit_metering()
 
             def on_reasoning(text):
-                nonlocal _reasoning_text
+                nonlocal _reasoning_segments, _current_reasoning_idx, _tool_boundary_advanced
                 if text is None:
                     return
+                _tool_boundary_advanced = False
                 reasoning_delta = str(text)
                 # Some runtimes mirror user-visible progress text through the
                 # reasoning channel after it already streamed as normal assistant
@@ -4842,8 +4848,13 @@ def _run_agent_streaming(
                 # same sentence again inside a Thinking card.
                 if _is_visible_output_echo(reasoning_delta):
                     return
-                _reasoning_text += reasoning_delta
-                # Mirror to shared dict so cancel_stream() can persist it (#1361 §A)
+                # Accumulate into the current message's segment (#3587)
+                _reasoning_segments[_current_reasoning_idx] = (
+                    _reasoning_segments.get(_current_reasoning_idx, '') + reasoning_delta
+                )
+                # Mirror full concatenation to shared dict so cancel_stream() can persist
+                # it (#1361 §A). Cancel only creates one partial message, so the flat
+                # concatenation is correct there.
                 if stream_id in STREAM_REASONING_TEXT:
                     STREAM_REASONING_TEXT[stream_id] += reasoning_delta
                 put('reasoning', {'text': reasoning_delta})
@@ -4853,6 +4864,12 @@ def _run_agent_streaming(
                 _emit_metering()
 
             def on_interim_assistant(text, **cb_kwargs):
+                nonlocal _current_reasoning_idx
+                # Advance the per-message reasoning index unconditionally (#3587):
+                # even if this callback fires with empty text, a new assistant
+                # segment is starting and subsequent reasoning must be attributed
+                # to the next message.
+                _current_reasoning_idx += 1
                 if text is None:
                     return
                 visible = str(text).strip()
@@ -4911,7 +4928,7 @@ def _run_agent_streaming(
                 return True
 
             def on_tool(*cb_args, **cb_kwargs):
-                nonlocal _reasoning_text
+                nonlocal _reasoning_segments, _current_reasoning_idx, _tool_boundary_advanced
                 event_type = None
                 name = None
                 preview = None
@@ -4937,8 +4954,11 @@ def _run_agent_streaming(
                         # Suppress those echoes like the dedicated reasoning callback.
                         if _is_visible_output_echo(reason_delta):
                             return
-                        _reasoning_text += reason_delta
-                        # Mirror to shared dict so cancel_stream() can persist it (#1361 §A)
+                        # Accumulate into the current message's segment (#3587)
+                        _reasoning_segments[_current_reasoning_idx] = (
+                            _reasoning_segments.get(_current_reasoning_idx, '') + reason_delta
+                        )
+                        # Mirror full concatenation to shared dict (#1361 §A)
                         if stream_id in STREAM_REASONING_TEXT:
                             STREAM_REASONING_TEXT[stream_id] += reason_delta
                         put('reasoning', {'text': reason_delta})
@@ -4946,6 +4966,15 @@ def _run_agent_streaming(
                         meter().record_reasoning(stream_id, _metering_reasoning_deltas[0])
                         _emit_metering()
                     return
+
+                # (#3587) Advance reasoning index at tool-call boundaries.
+                # on_interim_assistant is suppressed for contentless tool-call
+                # messages (run_agent.py:3834), so the index never advances
+                # there. The first tool.started event after reasoning indicates
+                # a new assistant message boundary.
+                if not _tool_boundary_advanced and _current_reasoning_idx in _reasoning_segments:
+                    _current_reasoning_idx += 1
+                    _tool_boundary_advanced = True
 
                 args_snap = _tool_args_snapshot(args)
 
@@ -6329,11 +6358,27 @@ def _run_agent_streaming(
                 # persisted session file 30-50% and bypassing the thinking card. The
                 # split is leading-only/single-block so mid-body literal tags (e.g. in
                 # a fenced code block) stay visible content.
+                #
+                # #3587: use per-message segments so intermediate assistant turns
+                # (before tool calls) each receive their own reasoning trace rather
+                # than all reasoning being written only to the last assistant message.
+                # Scope the walk to this turn's newly-appended assistant messages
+                # to prevent cross-turn reasoning clobber (multi-turn off-by-N).
                 if s.messages:
-                    for _rm in reversed(s.messages):
+                    _prev_asst = sum(
+                        1 for m in (_previous_messages or [])
+                        if isinstance(m, dict) and m.get('role') == 'assistant'
+                    )
+                    _asst_count = 0
+                    for _rm in s.messages:
                         if not (isinstance(_rm, dict) and _rm.get('role') == 'assistant'):
                             continue
-                        _existing_reasoning = _reasoning_text or _rm.get('reasoning') or ''
+                        _turn_idx = _asst_count
+                        _asst_count += 1
+                        if _turn_idx < _prev_asst:
+                            continue  # prior-turn message — never touch its reasoning
+                        _seg_reasoning = _reasoning_segments.get(_turn_idx - _prev_asst, '')
+                        _existing_reasoning = _seg_reasoning or _rm.get('reasoning') or ''
                         _content = _rm.get('content')
                         if isinstance(_content, str) and _content:
                             _new_content, _merged_reasoning = _split_thinking_from_content(
@@ -6344,7 +6389,6 @@ def _run_agent_streaming(
                                 _rm['reasoning'] = _merged_reasoning
                         elif _existing_reasoning:
                             _rm['reasoning'] = _existing_reasoning
-                        break
                 try:
                     _turn_duration_seconds = max(0.0, time.time() - float(_turn_started_at))
                 except Exception:

--- a/static/boot.js
+++ b/static/boot.js
@@ -1842,7 +1842,7 @@ function applyBotName(){
     api(_checkUrl).then(d=>{if(!_testUpdates)sessionStorage.setItem('hermes-update-checked','1');if((d.webui&&d.webui.behind>0)||(d.agent&&d.agent.behind>0))_showUpdateBanner(d);}).catch(()=>{});
   }
   // Fetch active profile
-  try{const p=await api('/api/profile/active');S.activeProfile=p.name||'default';}catch(e){S.activeProfile='default';}
+  try{const p=await api('/api/profile/active');S.activeProfile=p.name||'default';S.activeProfileIsDefault=!!p.is_default;}catch(e){S.activeProfile='default';S.activeProfileIsDefault=true;}
   applyBotName();
   // Update profile chip label immediately
   const profileLabel=$('profileChipLabel');

--- a/static/panels.js
+++ b/static/panels.js
@@ -5345,6 +5345,7 @@ async function switchToProfile(name) {
     const data = await api('/api/profile/switch', { method: 'POST', body: JSON.stringify({ name }) });
     if (_switchGen !== _profileSwitchGeneration) return;
     S.activeProfile = data.active || name;
+    S.activeProfileIsDefault = !!data.is_default;
 
     // Update composer placeholder and title bar while the core profile-switch
     // state is still close to the profile API response.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -33,6 +33,18 @@ let _draftSaveTimer = null;
 const _DRAFT_SAVE_DELAY_MS = 400;
 const NEW_CHAT_DRAFT_SESSION_KEY = 'hermes-new-chat-draft-session';
 
+function _profileMatchesActiveProfile(profile, activeProfile){
+  const eventName = (typeof profile === 'string' && profile.trim()) ? profile.trim() : 'default';
+  const activeName = (typeof activeProfile === 'string' && activeProfile.trim()) ? activeProfile.trim() : 'default';
+  if(eventName === activeName) return true;
+  return eventName === 'default' && !!S.activeProfileIsDefault;
+}
+
+function _sessionEventProfilesMatch(eventProfile, activeProfile){
+  if(!(typeof eventProfile === 'string' && eventProfile.trim())) return true;
+  return _profileMatchesActiveProfile(eventProfile, activeProfile);
+}
+
 function _isRestorableNewChatDraftSession(session, requireDraft=false) {
   if (!session || !session.session_id) return false;
   const messageCount = Number(session.message_count || 0);
@@ -42,7 +54,7 @@ function _isRestorableNewChatDraftSession(session, requireDraft=false) {
   if (title !== 'Untitled' && title !== 'New Chat') return false;
   const activeProfile = S.activeProfile || 'default';
   const sessionProfile = session.profile || 'default';
-  if (sessionProfile !== activeProfile) return false;
+  if (!_profileMatchesActiveProfile(sessionProfile, activeProfile)) return false;
   if (!requireDraft) return true;
   const draft = session.composer_draft || {};
   const text = (typeof draft.text === 'string') ? draft.text : '';
@@ -3051,7 +3063,18 @@ function ensureSessionEventsSSE(){
       _sessionEventsNeedsRefreshOnOpen = false;
       void refreshSessionList('reconnect');
     };
-    _sessionEventsSSE.addEventListener('sessions_changed', () => {
+    _sessionEventsSSE.addEventListener('sessions_changed', (ev) => {
+      const activeProfile = S.activeProfile || 'default';
+      try {
+        const payload = typeof ev?.data === 'string' ? JSON.parse(ev.data) : {};
+        const eventProfile = payload && typeof payload.profile === 'string' ? payload.profile : '';
+        if (!_sessionEventProfilesMatch(eventProfile, activeProfile)) {
+          return;
+        }
+      } catch (_err) {
+        // Non-JSON payload (or transient malformed event). Keep legacy behavior:
+        // refresh once event was seen.
+      }
       _scheduleSessionEventsRefresh('event');
     });
     _sessionEventsSSE.onerror = () => {

--- a/static/ui.js
+++ b/static/ui.js
@@ -5,7 +5,7 @@
 // legacy reverse-scan over S.messages — that keeps new clients working
 // against old servers (Phase 1 may not yet be deployed everywhere).
 // See api/todo_state.py for the wire contract.
-const S={session:null,messages:[],entries:[],busy:false,pendingFiles:[],toolCalls:[],activeStreamId:null,currentDir:'.',activeProfile:'default',showHiddenWorkspaceFiles:false,todos:[],todoStateMeta:null};
+const S={session:null,messages:[],entries:[],busy:false,pendingFiles:[],toolCalls:[],activeStreamId:null,currentDir:'.',activeProfile:'default',activeProfileIsDefault:true,showHiddenWorkspaceFiles:false,todos:[],todoStateMeta:null};
 
 function assistantDisplayName(){
   if(S.activeProfile&&S.activeProfile!=='default') return S.activeProfile.charAt(0).toUpperCase()+S.activeProfile.slice(1);
@@ -5900,9 +5900,19 @@ function syncTopbar(){
   if(typeof syncWorkspaceDisplays==='function') syncWorkspaceDisplays();
   if(typeof syncTerminalButton==='function') syncTerminalButton();
   // modelSelect already set above
-  // Update profile chip label
+  // Update profile chip label.
+  // The chip is the profile-SWITCHER trigger (it fronts the profile dropdown) and
+  // governs where the next message / new chat routes — both follow the client
+  // active profile (the hermes_profile cookie, set only by /api/profile/switch).
+  // It must therefore reflect S.activeProfile, NOT the loaded session's profile.
+  // #3331 briefly keyed this on S.session.profile so the label would track the
+  // session being browsed, but loadSession() never updates S.activeProfile, so
+  // opening a cross-profile session made the chip disagree with the dropdown
+  // checkmark and lie about message routing (#3635). #3331's legitimate work —
+  // scoping project/session operations to the session's own profile — is
+  // unaffected by this line.
   const profileLabel=$('profileChipLabel');
-  if(profileLabel) profileLabel.textContent=(S.session&&S.session.profile)||S.activeProfile||'default';
+  if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
 }
 
 function msgContent(m){

--- a/tests/test_issue3225_rename_sync.py
+++ b/tests/test_issue3225_rename_sync.py
@@ -21,11 +21,11 @@ def test_rename_endpoint_syncs_title_to_state_db():
         "rename handler must call _sync_session_title_to_insights(s) so the "
         "new title reaches state.db, matching the regenerate handler"
     )
-    assert 'publish_session_list_changed("session_rename")' in block
+    assert 'publish_session_list_changed("session_rename", profile=getattr(s, "profile", None))' in block
     # Sync must run BEFORE the list-changed publish, matching the regenerate
     # handler, so SSE subscribers refresh after state.db holds the new title.
     sync_idx = block.index("_sync_session_title_to_insights(s)")
-    publish_idx = block.index('publish_session_list_changed("session_rename")')
+    publish_idx = block.index('publish_session_list_changed("session_rename", profile=getattr(s, "profile", None))')
     assert sync_idx < publish_idx, (
         "rename must sync to state.db before publishing the list-changed event"
     )

--- a/tests/test_issue3587_intermediate_reasoning.py
+++ b/tests/test_issue3587_intermediate_reasoning.py
@@ -1,0 +1,292 @@
+"""Regression tests for issue #3587: intermediate assistant message reasoning lost.
+
+During multi-turn streaming (assistant reasons → calls tool → reasons again →
+responds), the flat _reasoning_text accumulator was written only to the LAST
+assistant message on settlement. Intermediate assistant messages (before tool
+calls) permanently lost their reasoning traces.
+
+Fix: replace the flat accumulator with a per-message dict (_reasoning_segments),
+track assistant message transitions via on_interim_assistant, and iterate forward
+through s.messages on settlement so each assistant message receives its own
+reasoning segment.
+"""
+
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).parent.parent
+
+
+def read(rel):
+    return (REPO / rel).read_text(encoding='utf-8')
+
+
+# ── 1. Flat accumulator is replaced ──────────────────────────────────────────
+
+
+class TestAccumulatorReplaced:
+    """The flat string accumulator must be replaced by a per-message dict."""
+
+    def test_bare_string_declaration_removed(self):
+        src = read('api/streaming.py')
+        # The old declaration was exactly: _reasoning_text = ''
+        # It must no longer exist as a bare string assignment (the comment that
+        # mentions it by name is allowed, but the assignment itself must be gone).
+        assert "_reasoning_text = ''" not in src, (
+            "_reasoning_text = '' bare declaration must be replaced by the "
+            "per-message _reasoning_segments dict (#3587)"
+        )
+
+    def test_segments_dict_declared(self):
+        src = read('api/streaming.py')
+        assert '_reasoning_segments' in src, (
+            "_reasoning_segments dict must be declared in api/streaming.py"
+        )
+        assert '_current_reasoning_idx' in src, (
+            "_current_reasoning_idx counter must be declared in api/streaming.py"
+        )
+
+    def test_segments_dict_is_dict_type(self):
+        src = read('api/streaming.py')
+        # Declaration must be an empty dict, not a string
+        assert re.search(r'_reasoning_segments\s*(?::\s*dict\s*)?\=\s*\{\}', src), (
+            "_reasoning_segments must be initialized as an empty dict"
+        )
+
+
+# ── 2. on_reasoning indexes into per-message dict ────────────────────────────
+
+
+class TestOnReasoningPerMessageIndexing:
+    """The on_reasoning callback must index into _reasoning_segments using
+    _current_reasoning_idx instead of appending to a flat string."""
+
+    def _on_reasoning_body(self):
+        src = read('api/streaming.py')
+        m = re.search(
+            r'def on_reasoning\(text\):\s*\n(.*?)(?=\n\s{12}def |\n\s{8}def )',
+            src, re.DOTALL,
+        )
+        assert m, "on_reasoning function not found in api/streaming.py"
+        return m.group(1)
+
+    def test_on_reasoning_uses_segments_not_flat_string(self):
+        body = self._on_reasoning_body()
+        assert '_reasoning_segments' in body, (
+            "on_reasoning must accumulate into _reasoning_segments, not a flat string"
+        )
+        assert "_reasoning_text +=" not in body, (
+            "on_reasoning must not use the old flat _reasoning_text += pattern"
+        )
+
+    def test_on_reasoning_indexes_by_current_idx(self):
+        body = self._on_reasoning_body()
+        assert '_current_reasoning_idx' in body, (
+            "on_reasoning must reference _current_reasoning_idx to attribute "
+            "reasoning deltas to the correct assistant message"
+        )
+
+    def test_stream_reasoning_text_mirror_still_present(self):
+        """cancel_stream() uses STREAM_REASONING_TEXT for its own partial-message
+        persist path; this mirror must remain even after the per-message fix."""
+        body = self._on_reasoning_body()
+        assert 'STREAM_REASONING_TEXT' in body, (
+            "on_reasoning must still mirror to STREAM_REASONING_TEXT so "
+            "cancel_stream() can persist reasoning on mid-stream cancellation"
+        )
+
+
+# ── 3. on_interim_assistant advances the index ───────────────────────────────
+
+
+class TestInterimAssistantAdvancesIndex:
+    """on_interim_assistant fires when a new assistant segment starts after tool
+    results. It must increment _current_reasoning_idx so subsequent reasoning
+    deltas are attributed to the next assistant message."""
+
+    def _interim_body(self):
+        src = read('api/streaming.py')
+        m = re.search(
+            r'def on_interim_assistant\(text.*?\):\s*\n(.*?)(?=\n\s{12}def |\n\s{8}def )',
+            src, re.DOTALL,
+        )
+        assert m, "on_interim_assistant function not found in api/streaming.py"
+        return m.group(1)
+
+    def test_interim_assistant_increments_idx(self):
+        body = self._interim_body()
+        assert '_current_reasoning_idx' in body, (
+            "on_interim_assistant must increment _current_reasoning_idx to "
+            "advance the per-message reasoning segment pointer (#3587)"
+        )
+        assert re.search(r'_current_reasoning_idx\s*\+=\s*1', body), (
+            "on_interim_assistant must use += 1 to advance the segment index"
+        )
+
+
+# ── 4. Settlement loop iterates forward, not reversed+break ──────────────────
+
+
+class TestSettlementLoopForward:
+    """The settlement loop must iterate forward through s.messages so each
+    assistant message can be matched to its own reasoning segment by index.
+    The old reversed()+break pattern only wrote reasoning to the last message."""
+
+    def _settlement_block(self):
+        """Extract the reasoning-persistence settlement block from streaming.py."""
+        src = read('api/streaming.py')
+        # Anchor on the comment that appears just before the settlement block
+        start = src.find('# #3587: use per-message segments')
+        assert start >= 0, (
+            "Settlement block comment '#3587: use per-message segments' not found; "
+            "the block may have been moved or the comment changed"
+        )
+        # Grab enough context to cover the loop
+        return src[start:start + 1500]
+
+    def test_settlement_does_not_reverse_iterate_with_break(self):
+        block = self._settlement_block()
+        # The old pattern was: for _rm in reversed(s.messages): ... break
+        # Both conditions must be gone from the settlement block.
+        has_reversed_break = (
+            'reversed(s.messages)' in block and
+            re.search(r'\bbreak\b', block)
+        )
+        assert not has_reversed_break, (
+            "Settlement loop must not use reversed(s.messages)+break; "
+            "that pattern writes reasoning only to the last assistant message"
+        )
+
+    def test_settlement_iterates_forward_with_counter(self):
+        block = self._settlement_block()
+        # Forward iteration with an assistant counter
+        assert 'for _rm in s.messages' in block, (
+            "Settlement loop must iterate forward (for _rm in s.messages) "
+            "to match each assistant message to its reasoning segment"
+        )
+        assert '_asst_count' in block, (
+            "Settlement loop must use an assistant message counter (_asst_count) "
+            "to index into _reasoning_segments"
+        )
+
+    def test_settlement_reads_from_segments_dict(self):
+        block = self._settlement_block()
+        assert '_reasoning_segments.get' in block, (
+            "Settlement loop must read from _reasoning_segments.get(idx) "
+            "to retrieve the per-message reasoning trace"
+        )
+
+
+# ── 5. Multi-turn offset prevents cross-turn reasoning clobber ──────────────
+
+
+class TestMultiTurnOffset:
+    """The settlement loop must skip prior-turn assistant messages so that
+    _reasoning_segments (indexed from 0 for this turn only) doesn't overwrite
+    reasoning stored on earlier turns."""
+
+    def _settlement_block(self):
+        src = read('api/streaming.py')
+        start = src.find('# #3587: use per-message segments')
+        assert start >= 0, 'Settlement block not found'
+        return src[start:start + 1500]
+
+    def test_settlement_computes_prev_asst_offset(self):
+        block = self._settlement_block()
+        assert '_prev_asst' in block, (
+            "Settlement loop must compute _prev_asst (count of assistant "
+            "messages in _previous_messages) to offset the segment index"
+        )
+
+    def test_settlement_skips_prior_turn_messages(self):
+        block = self._settlement_block()
+        assert re.search(r'if\s+_turn_idx\s*<\s*_prev_asst\s*:', block), (
+            "Settlement loop must skip prior-turn messages with "
+            "if _turn_idx < _prev_asst: continue"
+        )
+
+    def test_segment_index_subtracts_offset(self):
+        block = self._settlement_block()
+        assert re.search(r'_turn_idx\s*-\s*_prev_asst', block), (
+            "Segment index must subtract _prev_asst offset so indexing "
+            "starts at 0 for this turn's first assistant message"
+        )
+
+
+# ── 6. Tool-call boundary advances reasoning index ────────────────────────────
+
+
+class TestToolCallBoundary:
+    """on_interim_assistant is suppressed for contentless tool-call assistant
+    messages (run_agent.py:3834 early-returns when content is empty). The
+    reasoning index must advance at tool-call boundaries instead, so reasoning
+    accumulated before a tool-call-only assistant message gets its own segment."""
+
+    def _on_tool_body(self):
+        src = read('api/streaming.py')
+        m = re.search(
+            r'def on_tool\(\*cb_args.*?\):\s*\n(.*?)(?=\n\s{12}def |\n\s{8}def )',
+            src, re.DOTALL,
+        )
+        assert m, "on_tool function not found in api/streaming.py"
+        return m.group(1)
+
+    def test_on_tool_advances_reasoning_idx(self):
+        body = self._on_tool_body()
+        assert '_current_reasoning_idx' in body, (
+            "on_tool must reference _current_reasoning_idx to advance the "
+            "reasoning segment at tool-call boundaries (#3587)"
+        )
+
+    def test_tool_boundary_guard_prevents_double_advance(self):
+        body = self._on_tool_body()
+        assert '_tool_boundary_advanced' in body, (
+            "on_tool must use a _tool_boundary_advanced guard so multiple "
+            "tool calls in one assistant message only advance the index once"
+        )
+
+    def test_tool_boundary_flag_declared(self):
+        src = read('api/streaming.py')
+        assert '_tool_boundary_advanced' in src, (
+            "_tool_boundary_advanced flag must be declared in streaming.py"
+        )
+
+    def test_reasoning_resets_tool_boundary_flag(self):
+        """New reasoning arriving after a tool boundary must reset the guard
+        so the next tool-call batch can advance the index again."""
+        src = read('api/streaming.py')
+        m = re.search(
+            r'def on_reasoning\(text\):\s*\n(.*?)(?=\n\s{12}def |\n\s{8}def )',
+            src, re.DOTALL,
+        )
+        assert m, "on_reasoning function not found"
+        body = m.group(1)
+        assert '_tool_boundary_advanced' in body, (
+            "on_reasoning must reset _tool_boundary_advanced so the next "
+            "tool-call batch can advance the reasoning index"
+        )
+
+
+# ── 7. Settlement counter increments exactly once per assistant message ────
+
+
+class TestSettlementCounterSingleIncrement:
+    """_asst_count must increment exactly once per assistant message in the
+    settlement loop. A double increment causes every message after the first
+    to look up a segment index that doesn't exist, silently discarding its
+    reasoning (the exact data-loss scenario the refactor was meant to fix)."""
+
+    def _settlement_block(self):
+        src = read('api/streaming.py')
+        start = src.find('# #3587: use per-message segments')
+        assert start >= 0
+        return src[start:start + 1500]
+
+    def test_single_increment_per_iteration(self):
+        block = self._settlement_block()
+        count = block.count('_asst_count += 1')
+        assert count == 1, (
+            f"_asst_count must be incremented exactly once per loop iteration, "
+            f"found {count} increments. A double increment causes segment index "
+            f"doubling: message N looks up segment 2*N instead of N."
+        )

--- a/tests/test_issue3635_profile_chip_active.py
+++ b/tests/test_issue3635_profile_chip_active.py
@@ -1,0 +1,91 @@
+"""Tests for #3635 — profile chip must reflect the ACTIVE profile, not the
+loaded session's profile.
+
+Regression from #3331 (shipped v0.51.204): #3331 changed the composer profile
+chip label in syncTopbar()'s session-present branch to read
+``(S.session&&S.session.profile)||S.activeProfile`` so the label would track the
+profile of whatever session was being browsed. But the chip is the profile
+*switcher* trigger (it fronts the profile dropdown), and message routing /
+new-chat creation both follow the client active profile (the ``hermes_profile``
+cookie, set only by ``/api/profile/switch``). ``loadSession()`` sets
+``S.session`` but never updates ``S.activeProfile``, so opening a session that
+belongs to a different profile than the active one made the chip diverge from
+the dropdown checkmark and misrepresent where the next message would route.
+
+The fix reverts JUST the chip label to ``S.activeProfile`` in both syncTopbar
+branches. #3331's legitimate project/session-operation scoping (which keys on
+the session's own profile) is unrelated to this line and stays in place.
+"""
+
+from pathlib import Path
+
+import re
+
+
+def _ui_js() -> str:
+    return (Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _sync_topbar_body(src: str) -> str:
+    """Return the full source of the syncTopbar() function."""
+    start = src.find("function syncTopbar(){")
+    assert start != -1, "syncTopbar function not found in ui.js"
+    # Walk braces to find the matching close.
+    i = src.find("{", start)
+    depth = 0
+    for j in range(i, len(src)):
+        if src[j] == "{":
+            depth += 1
+        elif src[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : j + 1]
+    raise AssertionError("could not find end of syncTopbar()")
+
+
+class TestIssue3635ProfileChipActive:
+    def test_session_present_chip_reads_active_profile(self):
+        """The session-present chip-label update must read S.activeProfile."""
+        body = _sync_topbar_body(_ui_js())
+        # There are two profileChipLabel updates: the !S.session early-return
+        # block and the session-present block. Both must key on S.activeProfile.
+        updates = re.findall(
+            r"profileChipLabel'\);\s*\n\s*if\([^)]*\)\s*[^.]*\.textContent=([^;]+);",
+            body,
+        )
+        assert updates, "no profileChipLabel textContent assignment found in syncTopbar"
+        for expr in updates:
+            assert "S.activeProfile" in expr, (
+                "profile chip label must read S.activeProfile, got: " + expr.strip()
+            )
+
+    def test_chip_does_not_key_on_session_profile(self):
+        """Forbid the #3331 regression shape: chip keying on S.session.profile.
+
+        This negative assertion stops a future change from re-pointing the
+        switcher-trigger chip at the loaded session's profile (#3635).
+        """
+        body = _sync_topbar_body(_ui_js())
+        assert "(S.session&&S.session.profile)||S.activeProfile" not in body, (
+            "profile chip label must NOT key on S.session.profile — that is the "
+            "#3331 regression that made the chip diverge from the active profile "
+            "and misrepresent message routing (#3635)."
+        )
+        # Also guard the spaced variant.
+        assert "(S.session && S.session.profile) || S.activeProfile" not in body, (
+            "profile chip label must NOT key on S.session.profile (#3635)."
+        )
+
+    def test_both_chip_setters_consistent(self):
+        """Both the no-session and session-present chip setters must agree.
+
+        Before the fix the early-return (no session) branch read S.activeProfile
+        while the session-present branch read S.session.profile — the
+        inconsistency was the bug. They must now be identical.
+        """
+        body = _sync_topbar_body(_ui_js())
+        setters = re.findall(r"\.textContent=(S\.activeProfile\|\|'default')", body)
+        assert len(setters) >= 2, (
+            "expected both syncTopbar chip-label setters to read "
+            "S.activeProfile||'default'; found: " + str(setters)
+        )

--- a/tests/test_issue_new_chat_draft_restore.py
+++ b/tests/test_issue_new_chat_draft_restore.py
@@ -97,7 +97,7 @@ def test_restorable_candidate_rejects_in_flight_worktree_and_cross_profile_sessi
     body = SESSIONS_JS[start:end]
     assert "messageCount !== 0" in body
     assert "session.active_stream_id || session.pending_user_message || session.worktree_path" in body
-    assert "sessionProfile !== activeProfile" in body
+    assert "_profileMatchesActiveProfile(sessionProfile, activeProfile)" in body
     assert "session.composer_draft || {}" in body
     assert "text || files.length" in body
 

--- a/tests/test_pr1341_context_window_persistence.py
+++ b/tests/test_pr1341_context_window_persistence.py
@@ -46,7 +46,7 @@ def test_streaming_persists_context_fields_on_session_before_save():
     # structural check (presence of s.save() shortly after the post-merge marker)
     # would be more durable; left as a follow-up. Earlier limits: 9000 (cancellation
     # guards) → 13000 (#3263 v1) → 15000 (#3256/#3263 dual-gate).
-    assert save_call - block_start < 16000, (
+    assert save_call - block_start < 18000, (
         "s.save() should be close to the post-merge marker — block expanded unexpectedly. "
         "If you've added a new pre-save mutation block here, bump this limit."
     )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -339,7 +339,7 @@ def test_server_delete_removes_session_bak_snapshot(cleanup_test_sessions):
         routes_src.find('if parsed.path == "/api/session/delete":'),
     )
     assert delete_idx >= 0, "session/delete handler not found in api/routes.py"
-    delete_block = routes_src[delete_idx:delete_idx+1400]
+    delete_block = routes_src[delete_idx:delete_idx+1800]
     assert "with_suffix('.json.bak').unlink" in delete_block or 'with_suffix(".json.bak").unlink' in delete_block, \
         "session/delete must unlink <sid>.json.bak to avoid later orphan-backup recovery"
 

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -199,6 +199,17 @@ def test_cron_run_does_not_silently_swallow_profile_resolution_errors():
     )
 
 
+def test_manual_cron_event_profile_uses_job_profile(monkeypatch):
+    from api import routes
+
+    monkeypatch.setattr(routes, "_available_cron_profile_names", lambda: {"default", "research"})
+
+    assert routes._event_profile_for_cron_job({"profile": "research"}) == "research"
+    assert routes._event_profile_for_cron_job({"profile": " default "}) == "default"
+    assert routes._event_profile_for_cron_job({"profile": ""}) is None
+    assert routes._event_profile_for_cron_job({"profile": "deleted"}) is None
+
+
 def test_webui_installs_profile_context_on_in_process_scheduler_run_job(tmp_path, monkeypatch):
     """If WebUI ever runs cron.scheduler.tick in-process, scheduled run_job calls
     must execute under the job's selected profile home, not the process-global

--- a/tests/test_session_events.py
+++ b/tests/test_session_events.py
@@ -1,3 +1,4 @@
+import queue
 from pathlib import Path
 
 
@@ -25,27 +26,146 @@ def test_session_events_publish_for_minimal_sidebar_mutations():
         "session_move",
         "session_pin",
         "session_rename",
+        "session_title_regenerate",
+        "session_branch",
     ):
-        assert f'publish_session_list_changed("{reason}")' in ROUTES
+        if reason == "session_import_cli":
+            assert f'publish_session_list_changed(\n        "{reason}",' in ROUTES, reason
+        elif reason == "session_import":
+            assert f'publish_session_list_changed("{reason}")' in ROUTES, reason
+        else:
+            assert f'publish_session_list_changed("{reason}",' in ROUTES, reason
 
-    assert 'if worktree_info:\n            publish_session_list_changed("session_new")' in ROUTES
+    assert 'if worktree_info:\n            publish_session_list_changed("session_new", profile=getattr(s, "profile", None))' in ROUTES
     assert "was_hidden_empty_session = _is_hidden_empty_session(s)" in ROUTES
-    assert 'if was_hidden_empty_session:\n        publish_session_list_changed("session_new")' in ROUTES
+    assert 'if was_hidden_empty_session:\n        publish_session_list_changed("session_new", profile=getattr(s, "profile", None))' in ROUTES
+    assert 'publish_session_list_changed("session_duplicate", profile=getattr(copied_session, "profile", None))' in ROUTES
+    assert 'publish_session_list_changed("session_rename", profile=getattr(s, "profile", None))' in ROUTES
+    assert 'publish_session_list_changed("session_title_regenerate", profile=getattr(s, "profile", None))' in ROUTES
+    assert 'event_profile = getattr(get_session(sid, metadata_only=True), "profile", None)' in ROUTES
+    assert "Failed to resolve profile for deleted session" in ROUTES
+    assert '_publish_session_list_changed("session_delete", profile=event_profile)' in ROUTES
+    assert 'publish_session_list_changed("session_branch", profile=getattr(branch, "profile", None))' in ROUTES
+    assert 'publish_session_list_changed("session_pin", profile=getattr(s, "profile", None))' in ROUTES
+    assert 'publish_session_list_changed("session_archive", profile=getattr(s, "profile", None))' in ROUTES
+    assert 'publish_session_list_changed("session_move", profile=getattr(s, "profile", None))' in ROUTES
+    assert 'profile=getattr(s, "profile", None)' in ROUTES
     assert 'publish_session_list_changed("chat_start")' not in ROUTES
-    assert 'publish_session_list_changed("cron_complete")' in ROUTES
-    assert 'publish_session_list_changed("cron_complete")' in PROFILES
+    assert '_publish_session_list_changed("cron_complete",' in ROUTES
+    assert 'publish_session_list_changed("cron_complete",' in PROFILES
 
 
-def test_session_event_queue_is_bounded_and_latest_wins():
+def test_session_event_queue_same_profile_is_bounded_and_latest_wins():
     from api import session_events
 
     q = session_events.subscribe_session_events()
     try:
-        session_events.publish_session_list_changed("first")
-        session_events.publish_session_list_changed("second")
+        session_events.publish_session_list_changed("first", profile="profile-a")
+        session_events.publish_session_list_changed("second", profile="profile-a")
         payload = q.get_nowait()
         assert payload["type"] == "sessions_changed"
         assert payload["reason"] == "second"
+        assert payload["profile"] == "profile-a"
         assert q.empty()
+    finally:
+        session_events.unsubscribe_session_events(q)
+
+
+def test_session_event_queue_profile_mismatch_coalesces_to_unscoped_refresh_all():
+    from api import session_events
+
+    q = session_events.subscribe_session_events()
+    try:
+        session_events.publish_session_list_changed("profile_a", profile="profile-a")
+        session_events.publish_session_list_changed("profile_b", profile="profile-b")
+        payload = q.get_nowait()
+        assert payload["type"] == "sessions_changed"
+        assert payload["reason"] == "profile_b"
+        assert "profile" not in payload
+        assert q.empty()
+    finally:
+        session_events.unsubscribe_session_events(q)
+
+
+def test_session_event_queue_unscoped_pending_stays_unscoped_when_followed_by_scoped():
+    from api import session_events
+
+    q = session_events.subscribe_session_events()
+    try:
+        session_events.publish_session_list_changed("all_profiles")
+        session_events.publish_session_list_changed("profile_b", profile="profile-b")
+        payload = q.get_nowait()
+        assert payload["type"] == "sessions_changed"
+        assert payload["reason"] == "profile_b"
+        assert "profile" not in payload
+        assert q.empty()
+    finally:
+        session_events.unsubscribe_session_events(q)
+
+
+def test_session_event_queue_drain_race_preserves_incoming_profile():
+    from api import session_events
+
+    class DrainedQueue:
+        def __init__(self):
+            self.payloads = []
+            self.put_attempts = 0
+
+        def put_nowait(self, payload):
+            self.put_attempts += 1
+            if self.put_attempts == 1:
+                raise queue.Full()
+            self.payloads.append(payload)
+
+        def get_nowait(self):
+            raise queue.Empty()
+
+    q = DrainedQueue()
+    with session_events._SESSION_EVENTS_LOCK:
+        session_events._SESSION_EVENTS_SUBSCRIBERS.add(q)
+    try:
+        session_events.publish_session_list_changed("profile_b", profile="profile-b")
+        assert len(q.payloads) == 1
+        payload = q.payloads[0]
+        assert payload["type"] == "sessions_changed"
+        assert payload["reason"] == "profile_b"
+        assert payload["profile"] == "profile-b"
+    finally:
+        with session_events._SESSION_EVENTS_LOCK:
+            session_events._SESSION_EVENTS_SUBSCRIBERS.discard(q)
+
+
+def test_session_events_payload_tracks_profile_when_available():
+    from api import session_events
+
+    q = session_events.subscribe_session_events()
+    try:
+        session_events.publish_session_list_changed("no_profile")
+        payload = q.get_nowait()
+        assert payload["type"] == "sessions_changed"
+        assert payload["reason"] == "no_profile"
+        assert "profile" not in payload
+
+        session_events.publish_session_list_changed("with_profile", profile="profile-b")
+        payload = q.get_nowait()
+        assert payload["type"] == "sessions_changed"
+        assert payload["reason"] == "with_profile"
+        assert payload["profile"] == "profile-b"
+    finally:
+        session_events.unsubscribe_session_events(q)
+
+
+def test_session_events_payload_omits_profile_for_default_root_alias(monkeypatch):
+    from api import session_events
+
+    monkeypatch.setattr(session_events, "_profile_is_root_alias", lambda profile: profile == "kinni")
+
+    q = session_events.subscribe_session_events()
+    try:
+        session_events.publish_session_list_changed("renamed_root", profile="kinni")
+        payload = q.get_nowait()
+        assert payload["type"] == "sessions_changed"
+        assert payload["reason"] == "renamed_root"
+        assert "profile" not in payload
     finally:
         session_events.unsubscribe_session_events(q)

--- a/tests/test_session_title_regenerate_controls.py
+++ b/tests/test_session_title_regenerate_controls.py
@@ -59,7 +59,7 @@ def test_regenerate_endpoint_persists_generated_title_without_reordering_sidebar
     assert "s.llm_title_generated = True" in block
     assert "s.save(touch_updated_at=False)" in block
     assert "_sync_session_title_to_insights(s)" in block
-    assert 'publish_session_list_changed("session_title_regenerate")' in block
+    assert 'publish_session_list_changed("session_title_regenerate", profile=getattr(s, "profile", None))' in block
     assert "Read-only imported sessions cannot be renamed" in block
 
 

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -685,16 +685,16 @@ def test_cleanTitle_is_let_not_const():
 
 # ── Sprint 42 additional tests: thinking panel persistence (#427) ────────
 def test_streaming_persists_reasoning_in_session():
-    """streaming.py must accumulate reasoning_text and patch last assistant message."""
+    """streaming.py must accumulate reasoning and patch assistant messages."""
     src = (REPO / 'api' / 'streaming.py').read_text()
 
-    # _reasoning_text must be initialised
-    assert "_reasoning_text = ''" in src, \
-        "_reasoning_text variable not initialised in streaming.py"
+    # #3587: per-message reasoning segments replaced the flat _reasoning_text accumulator
+    assert "_reasoning_segments" in src, \
+        "_reasoning_segments dict not found in streaming.py"
 
-    # on_reasoning must accumulate non-echo reasoning into _reasoning_text
-    assert '_reasoning_text += reasoning_delta' in src, \
-        "on_reasoning callback does not accumulate accepted reasoning deltas into _reasoning_text"
+    # on_reasoning must accumulate non-echo reasoning into segments
+    assert '_reasoning_segments[_current_reasoning_idx]' in src or '_reasoning_segments.get(_current_reasoning_idx' in src, \
+        "on_reasoning callback does not accumulate into per-message _reasoning_segments"
     assert '_is_visible_output_echo(reasoning_delta)' in src, \
         "on_reasoning callback should suppress reasoning deltas that only echo visible streamed output"
 

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 SESSIONS_JS = Path("static/sessions.js").read_text(encoding="utf-8")
 UI_JS = Path("static/ui.js").read_text(encoding="utf-8")
+BOOT_JS = Path("static/boot.js").read_text(encoding="utf-8")
+PANELS_JS = Path("static/panels.js").read_text(encoding="utf-8")
 
 
 def test_load_session_supports_force_reload_for_external_refresh():
@@ -47,6 +49,21 @@ def test_session_list_external_refresh_uses_sse_invalidation_not_polling():
     ensure_fn = SESSIONS_JS[SESSIONS_JS.find("function ensureSessionEventsSSE()") :]
     assert ensure_fn.find("document._hermesSessionEventsVisibilityHook") < ensure_fn.find("document.hidden) return")
     assert "_sessionListExternalRefreshMs" not in SESSIONS_JS
+    assert "addEventListener('sessions_changed', (ev) => {" in ensure_fn
+    assert "const activeProfile = S.activeProfile || 'default';" in ensure_fn
+    assert "const payload = typeof ev?.data === 'string' ? JSON.parse(ev.data) : {};" in ensure_fn
+    assert "const eventProfile = payload && typeof payload.profile === 'string' ? payload.profile : '';" in ensure_fn
+    assert "if (!_sessionEventProfilesMatch(eventProfile, activeProfile)) {" in ensure_fn
+
+
+def test_session_event_profile_filter_tolerates_default_root_aliases():
+    assert "function _profileMatchesActiveProfile(profile, activeProfile)" in SESSIONS_JS
+    assert "return eventName === 'default' && !!S.activeProfileIsDefault;" in SESSIONS_JS
+    assert "function _sessionEventProfilesMatch(eventProfile, activeProfile)" in SESSIONS_JS
+    assert "if (!_profileMatchesActiveProfile(sessionProfile, activeProfile)) return false;" in SESSIONS_JS
+    assert "activeProfileIsDefault:true" in UI_JS
+    assert "S.activeProfileIsDefault=!!p.is_default;" in BOOT_JS
+    assert "S.activeProfileIsDefault = !!data.is_default;" in PANELS_JS
 
 
 def test_pwa_pull_to_refresh_refreshes_session_list_not_page_when_available():


### PR DESCRIPTION
## Release v0.51.266 — Release IH (stage-r16)

One agent-authored APPROVED fix + two un-held streaming/SSE fixes.

### Fixed
| Issue/PR | Author | Fix |
|----------|--------|-----|
| #3635 (#3637) | @nesquena-hermes (nesquena APPROVED) | Composer profile chip reads `S.activeProfile` again — a #3331 regression keyed it on the loaded session's profile, so opening a cross-profile session made the chip disagree with the dropdown checkmark and misrepresent where the next message routes. #3331's project/session-op scoping is unaffected. |
| #3587 (#3605) | @rodboev | Reasoning persists to the correct intermediate assistant message in multi-turn tool flows. The index only advanced in `on_interim_assistant` (suppressed for contentless tool-call messages) → post-tool reasoning was mis-attributed; it now also advances at the `on_tool` boundary, guarded against over-increment. **(un-held — finding resolved)** |
| #2660 (#3558) | @franksong2702 | Session-event SSE no longer wakes every tab across profiles and never drops a relevant refresh — profile attached when known, root/`default` aliases stay unscoped, and the `maxsize=1` queue falls back to unscoped refresh-all on a profile-mismatch coalesce. **(un-held — both findings resolved)** |

### Gate
- Full pytest suite: **7770 passed, 0 failed**
- ESLint: CLEAN · ruff: CLEAN · browser-smoke: CLEAN
- Codex (regression): **SAFE TO SHIP** — chip matches dropdown/routing (no #3331 scoping regression), reasoning-index advance composes with the agent's tool/interim callback ordering, session-events coalesce safely with no dropped refresh and no profile data leak (`/api/sessions` still server-side filtered).

Co-authored-by: nesquena <nesquena@users.noreply.github.com>
Co-authored-by: rodboev <rodboev@users.noreply.github.com>
Co-authored-by: franksong2702 <franksong2702@users.noreply.github.com>