### PR TITLE
fix(security): require opt-in for forwarded CSRF host

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1510,18 +1510,23 @@ def _check_csrf(handler) -> bool:
     if origin_value in _allowed_public_origins():
         origin_allowed = True
     if not origin_allowed:
-        # Allow same-origin: check Host, X-Forwarded-Host (reverse proxy), and
-        # X-Real-Host against the origin. Reverse proxies (Caddy, nginx) set
-        # X-Forwarded-Host to the client's original Host header.
+        # Allow same-origin Host by default. Forwarded host headers are only
+        # trustworthy behind a proxy that strips untrusted inbound copies.
         allowed_hosts = [
             h.strip()
-            for h in [
-                host,
-                handler.headers.get("X-Forwarded-Host", ""),
-                handler.headers.get("X-Real-Host", ""),
-            ]
+            for h in [host]
             if h.strip()
         ]
+        trust_forwarded_host = os.getenv("HERMES_WEBUI_TRUST_FORWARDED_HOST", "").strip().lower()
+        if trust_forwarded_host in ("1", "true", "yes", "on"):
+            allowed_hosts.extend(
+                h.strip()
+                for h in [
+                    handler.headers.get("X-Forwarded-Host", ""),
+                    handler.headers.get("X-Real-Host", ""),
+                ]
+                if h.strip()
+            )
         for allowed in allowed_hosts:
             allowed_name, allowed_port = _normalize_host_port(allowed)
             if origin_name == allowed_name and _ports_match(origin_scheme, origin_port, allowed_port):

--- a/tests/test_issue1909_csrf_token.py
+++ b/tests/test_issue1909_csrf_token.py
@@ -89,6 +89,7 @@ def test_authenticated_reverse_proxy_same_origin_accepts_valid_csrf_token(monkey
     cookie = _signed_cookie("g" * 64)
     token = auth.csrf_token_for_session(cookie)
     monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_HOST", "1")
     try:
         headers = {
             "Origin": "https://example.com",
@@ -100,6 +101,24 @@ def test_authenticated_reverse_proxy_same_origin_accepts_valid_csrf_token(monkey
         assert routes._check_csrf(_FakeHandler(headers))
     finally:
         auth._sessions.pop("g" * 64, None)
+
+
+def test_authenticated_forwarded_host_is_ignored_without_proxy_opt_in(monkeypatch):
+    cookie = _signed_cookie("h" * 64)
+    token = auth.csrf_token_for_session(cookie)
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+    monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_HOST", raising=False)
+    try:
+        headers = {
+            "Origin": "https://example.com",
+            "Host": "127.0.0.1:8787",
+            "X-Forwarded-Host": "example.com:443",
+            "Cookie": f"{auth.COOKIE_NAME}={cookie}",
+            auth.CSRF_HEADER_NAME: token,
+        }
+        assert not routes._check_csrf(_FakeHandler(headers))
+    finally:
+        auth._sessions.pop("h" * 64, None)
 
 
 def test_non_browser_mcp_style_authenticated_post_remains_compatible(monkeypatch):

--- a/tests/test_sprint29.py
+++ b/tests/test_sprint29.py
@@ -119,7 +119,7 @@ class TestCSRF:
         )
         assert status != 403, f"Expected non-403 for same-referer request, got {status}"
 
-    def test_proxy_host_default_https_port_matches_http_origin(self):
+    def test_proxy_host_default_https_port_matches_http_origin(self, monkeypatch):
         """http:// origin without port must NOT match X-Forwarded-Host with :443.
 
         After the scheme-aware _ports_match fix: http:// absent port = :80,
@@ -129,20 +129,23 @@ class TestCSRF:
         See test_proxy_host_default_https_port_matches_https_origin for the
         real-world proxy case that should pass.
         """
+        monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_HOST", "1")
         assert not self._csrf_allowed({
             "Origin": "http://example.com",
             "X-Forwarded-Host": "example.com:443",
         }), 'http origin (port :80) must not match https host (:443)'
 
-    def test_proxy_host_default_https_port_matches_https_origin(self):
+    def test_proxy_host_default_https_port_matches_https_origin(self, monkeypatch):
         """HTTPS Origin without port should match X-Forwarded-Host with explicit :443."""
+        monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_HOST", "1")
         assert self._csrf_allowed({
             "Origin": "https://example.com",
             "X-Forwarded-Host": "example.com:443",
         })
 
-    def test_proxy_host_port_normalization_still_rejects_other_host(self):
+    def test_proxy_host_port_normalization_still_rejects_other_host(self, monkeypatch):
         """Port normalization must not allow different hosts through."""
+        monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_HOST", "1")
         assert not self._csrf_allowed({
             "Origin": "https://evil.com",
             "X-Forwarded-Host": "example.com:443",
@@ -168,19 +171,21 @@ class TestCSRF:
 
     # ── Port normalization: scheme-aware (M-1 fix) ────────────────────────────
 
-    def test_cross_protocol_port_not_confused_http_origin_https_host(self):
+    def test_cross_protocol_port_not_confused_http_origin_https_host(self, monkeypatch):
         """http:// origin must NOT match a host with :443 (HTTPS default).
 
         Before M-1 fix, _ports_match treated both 80 and 443 as equivalent to
         absent port, allowing http://host to match https://host:443 servers.
         """
+        monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_HOST", "1")
         assert not self._csrf_allowed({
             'Origin': 'http://example.com',     # http, no port = :80
             'X-Forwarded-Host': 'example.com:443',  # HTTPS port
         }), 'http origin should NOT match host advertising port 443'
 
-    def test_cross_protocol_port_not_confused_https_origin_http_host(self):
+    def test_cross_protocol_port_not_confused_https_origin_http_host(self, monkeypatch):
         """https:// origin must NOT match a host with :80 (HTTP default)."""
+        monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_HOST", "1")
         assert not self._csrf_allowed({
             'Origin': 'https://example.com',    # https, no port = :443
             'X-Forwarded-Host': 'example.com:80',   # HTTP port


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI rejects browser unsafe requests when Origin or Referer does not match the intended host.
- The current CSRF check accepts `X-Forwarded-Host` and `X-Real-Host` on every deployment.
- Those headers are only trustworthy when a known reverse proxy overwrites or strips untrusted inbound copies.
- A direct deployment or weak proxy boundary should not let a caller decide the host value used by CSRF same-origin checks.
- This PR keeps normal `Host` behavior unchanged and makes forwarded host trust explicit.

## What Changed

- Use the request `Host` header for same-origin CSRF checks by default.
- Add `HERMES_WEBUI_TRUST_FORWARDED_HOST` as the explicit opt-in for `X-Forwarded-Host` and `X-Real-Host`.
- Update reverse-proxy CSRF regression tests so proxy success cases opt in deliberately.
- Add authenticated coverage proving forwarded host is ignored without that opt-in.

## Why It Matters

This reduces header-spoofing risk around CSRF origin validation. Reverse-proxy deployments are still supported, but only after the operator opts into trusting proxy-managed forwarded host headers.

## Verification

- `python -m py_compile api\routes.py`
- `uv run --no-project --with ruff python scripts\ruff_lint.py --diff official/master`
- `git diff --check` returned only local LF-to-CRLF working-copy warnings.
- Direct in-process fake-handler check: same authenticated request with `Origin: https://example.com`, `Host: 127.0.0.1:8787`, and `X-Forwarded-Host: example.com:443` returned `False` by default and `True` with `HERMES_WEBUI_TRUST_FORWARDED_HOST=1`.
- Focused pytest was not rerun after the earlier local Windows validation showed the official `tests/conftest.py` autouse test server fixture cannot start the local Hermes Agent test server in this environment before reaching unit assertions.

## Risks / Follow-ups

- Reverse-proxy operators who depend on forwarded host matching should set `HERMES_WEBUI_TRUST_FORWARDED_HOST=1` and ensure the proxy strips untrusted inbound `X-Forwarded-Host` and `X-Real-Host` values.
- `HERMES_WEBUI_ALLOWED_ORIGINS` remains the explicit public-origin allowlist for deployments that need a stable external origin without trusting forwarded host headers.

## Model Used

Provider: OpenAI
Model: GPT-5 Codex
Notable tool use: Codex Security review workflow, GitHub PR/issue inspection, local git/ruff/py_compile verification, direct fake-handler CSRF validation.
