### PR TITLE
fix(security): validate TTS prosody inputs

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -8984,6 +8984,18 @@ def _serve_file_bytes(handler, target: Path, mime: str, disposition: str, cache_
 
 
 
+def _normalize_tts_prosody(value, *, unit: str) -> str | None:
+    if not value:
+        return ""
+    value = str(value).strip()
+    if not re.fullmatch(r"[+-]?\d{1,3}" + re.escape(unit), value):
+        return None
+    amount = int(value[: -len(unit)])
+    if -100 <= amount <= 100:
+        return value
+    return None
+
+
 def _handle_tts(handler, parsed):
     """Generate TTS audio via Edge TTS. POST JSON body only.
 
@@ -9014,11 +9026,18 @@ def _handle_tts(handler, parsed):
         data = read_body(handler)
         text = (data.get("text") or "").strip()
         voice = data.get("voice") or voice
-        rate_str = data.get("rate") or ""
-        pitch_str = data.get("pitch") or ""
+        rate_str = _normalize_tts_prosody(data.get("rate"), unit="%")
+        pitch_str = _normalize_tts_prosody(data.get("pitch"), unit="Hz")
     except Exception:
         from api.helpers import bad as _bad
         return _bad(handler, "invalid request body", 400)
+
+    if rate_str is None:
+        from api.helpers import bad as _bad
+        return _bad(handler, "invalid rate", 400)
+    if pitch_str is None:
+        from api.helpers import bad as _bad
+        return _bad(handler, "invalid pitch", 400)
 
     if not text:
         from api.helpers import bad as _bad

--- a/tests/test_issue2931_edge_tts_endpoint.py
+++ b/tests/test_issue2931_edge_tts_endpoint.py
@@ -7,6 +7,8 @@ edge_tts import / Communicate call.
 """
 import io
 import json
+import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -95,6 +97,51 @@ def test_tts_rejects_unknown_voice():
     routes._handle_tts(h, None)
     assert h.status == 400
     assert "invalid voice" in (h.payload() or {}).get("error", "")
+
+
+def test_tts_rejects_invalid_rate_before_engine():
+    h = _post({"text": "hello", "voice": "en-US-AriaNeural", "rate": "<break/>"}, client="10.0.0.6")
+    routes._handle_tts(h, None)
+    assert h.status == 400
+    assert "invalid rate" in (h.payload() or {}).get("error", "")
+
+
+def test_tts_rejects_invalid_pitch_before_engine():
+    h = _post({"text": "hello", "voice": "en-US-AriaNeural", "pitch": "+500Hz"}, client="10.0.0.7")
+    routes._handle_tts(h, None)
+    assert h.status == 400
+    assert "invalid pitch" in (h.payload() or {}).get("error", "")
+
+
+def test_tts_accepts_ui_prosody_shape(monkeypatch):
+    captured = {}
+
+    class FakeCommunicate:
+        def __init__(self, text, voice, **kwargs):
+            captured["text"] = text
+            captured["voice"] = voice
+            captured["kwargs"] = kwargs
+
+        def stream_sync(self):
+            yield {"type": "audio", "data": b"abc"}
+
+    monkeypatch.setitem(sys.modules, "edge_tts", SimpleNamespace(Communicate=FakeCommunicate))
+
+    h = _post(
+        {
+            "text": "hello",
+            "voice": "en-US-AriaNeural",
+            "rate": "+10%",
+            "pitch": "-5Hz",
+        },
+        client="10.0.0.8",
+    )
+    routes._handle_tts(h, None)
+
+    assert h.status == 200
+    assert captured["text"] == "hello"
+    assert captured["voice"] == "en-US-AriaNeural"
+    assert captured["kwargs"] == {"rate": "+10%", "pitch": "-5Hz"}
 
 
 def test_tts_rate_limits_second_immediate_request():


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI accepts browser-provided TTS settings and passes Edge TTS prosody values into `edge_tts.Communicate`.
- The UI only generates compact prosody strings such as `+10%` for rate and `-5Hz` for pitch.
- The backend previously accepted arbitrary strings for both values and forwarded them to the TTS library.
- Even when the downstream library is well behaved, a server boundary should validate small structured inputs before they reach an external formatter or network client.
- This PR keeps the current UI contract and rejects malformed or out-of-range prosody values early.

## What Changed

- Add `_normalize_tts_prosody()` for Edge TTS rate and pitch values.
- Accept only optional sign plus integer units: percent for `rate`, Hz for `pitch`.
- Bound accepted numeric values to `-100..100`.
- Return `400 invalid rate` or `400 invalid pitch` before importing or calling `edge_tts` when the value is malformed.
- Add regression coverage for malicious-looking rate input, out-of-range pitch input, and the valid UI-generated shape reaching a fake `edge_tts.Communicate` implementation unchanged.

## Why It Matters

This closes a narrow input-validation gap in the server-side TTS endpoint. The endpoint already validates text length and voice allowlist; this adds the same style of boundary check to the remaining structured user-controlled fields before they reach the external TTS engine.

## Verification

- `python -m py_compile api\routes.py`
- `uv run --no-project --with ruff python scripts\ruff_lint.py --diff official/master`
- `git diff --check` returned only local LF-to-CRLF working-copy warnings.
- Direct in-process fake-handler check returned `400 invalid rate` for `<break/>`, `400 invalid pitch` for `+500Hz`, and `200` with captured kwargs `{'rate': '+10%', 'pitch': '-5Hz'}` when a fake `edge_tts` module was installed.
- Focused pytest was not rerun after the earlier local Windows validation showed the official `tests/conftest.py` autouse test server fixture cannot start the local Hermes Agent test server in this environment before reaching unit assertions.

## Risks / Follow-ups

- Manual API callers that send non-UI prosody strings now receive 400. The accepted form matches the current WebUI-generated Edge TTS values and keeps a conservative numeric range.
- No docs were changed because this is a small server-side validation hardening and does not alter the visible settings UI.

## Model Used

Provider: OpenAI
Model: GPT-5 Codex
Notable tool use: Codex Security review workflow, GitHub PR/issue inspection, local git/ruff/py_compile verification, direct fake-handler TTS validation.
