### PR TITLE
fix: scope session search to active profile

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -8289,6 +8289,15 @@ def _handle_sessions_search(handler, parsed):
     qs = parse_qs(parsed.query)
     q = qs.get("q", [""])[0].lower().strip()
     content_search = qs.get("content", ["1"])[0] == "1"
+    from api.profiles import get_active_profile_name
+    active_profile = get_active_profile_name()
+    all_profiles = _all_profiles_query_flag(parsed)
+    sessions = all_sessions()
+    if not all_profiles:
+        sessions = [
+            s for s in sessions
+            if _profiles_match(s.get("profile"), active_profile)
+        ]
     # Reject a malformed depth instead of letting int() raise ValueError and
     # surface as a confusing 500. Clamp to >= 0 so a negative value can't reach
     # the messages[:depth] slice below — messages[:-n] would silently exclude
@@ -8300,14 +8309,18 @@ def _handle_sessions_search(handler, parsed):
         depth = 5
     if not q:
         safe_sessions = []
-        for s in all_sessions():
+        for s in sessions:
             item = dict(s)
             if isinstance(item.get("title"), str):
                 item["title"] = _redact_text(item["title"])
             safe_sessions.append(item)
-        return j(handler, {"sessions": safe_sessions})
+        return j(handler, {
+            "sessions": safe_sessions,
+            "all_profiles": all_profiles,
+            "active_profile": active_profile,
+        })
     results = []
-    for s in all_sessions():
+    for s in sessions:
         title_match = q in (s.get("title") or "").lower()
         if title_match:
             item = dict(s, match_type="title")
@@ -8332,7 +8345,13 @@ def _handle_sessions_search(handler, parsed):
                         break
             except (KeyError, Exception):
                 pass
-    return j(handler, {"sessions": results, "query": q, "count": len(results)})
+    return j(handler, {
+        "sessions": results,
+        "query": q,
+        "count": len(results),
+        "all_profiles": all_profiles,
+        "active_profile": active_profile,
+    })
 
 
 def _handle_list_dir(handler, parsed):

--- a/tests/test_sessions_search_depth_validation.py
+++ b/tests/test_sessions_search_depth_validation.py
@@ -25,7 +25,7 @@ def _run_search(query):
     lives in its LAST message, capturing the JSON payload/status."""
     import api.routes as routes
 
-    sessions_meta = [{"session_id": "s1", "title": "Untitled"}]
+    sessions_meta = [{"session_id": "s1", "title": "Untitled", "profile": "default"}]
     session = SimpleNamespace(
         session_id="s1",
         messages=[
@@ -42,7 +42,9 @@ def _run_search(query):
 
     with patch("api.routes.all_sessions", return_value=list(sessions_meta)), patch(
         "api.routes.get_session", return_value=session
-    ), patch("api.routes.j", side_effect=fake_j):
+    ), patch("api.profiles.get_active_profile_name", return_value="default"), patch(
+        "api.routes.j", side_effect=fake_j
+    ):
         routes._handle_sessions_search(SimpleNamespace(), urlparse(query))
     return captured
 

--- a/tests/test_sessions_search_profile_scope.py
+++ b/tests/test_sessions_search_profile_scope.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+
+def _run_search(query):
+    import api.routes as routes
+    sessions_meta = [
+        {"session_id": "active-s", "title": "boring", "profile": "default"},
+        {"session_id": "other-s", "title": "secret needle title", "profile": "other"},
+        {"session_id": "other-content-s", "title": "boring", "profile": "other"},
+    ]
+    sessions = {
+        "other-content-s": SimpleNamespace(messages=[{"role": "user", "content": "secret needle body"}]),
+        "active-s": SimpleNamespace(messages=[{"role": "user", "content": "nothing"}]),
+        "other-s": SimpleNamespace(messages=[]),
+    }
+    captured = {}
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        captured["payload"] = payload
+    with patch("api.routes.all_sessions", return_value=list(sessions_meta)), \
+         patch("api.routes.get_session", side_effect=lambda sid: sessions[sid]), \
+         patch("api.profiles.get_active_profile_name", return_value="default"), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes._handle_sessions_search(SimpleNamespace(), urlparse(query))
+    return captured
+
+
+def test_empty_session_search_scopes_to_active_profile():
+    captured = _run_search("/api/sessions/search")
+    assert [s["session_id"] for s in captured["payload"]["sessions"]] == ["active-s"]
+
+
+def test_title_search_should_not_return_other_profile_rows():
+    captured = _run_search("/api/sessions/search?q=needle&content=0")
+    assert captured["payload"]["count"] == 0
+
+
+def test_content_search_should_not_return_other_profile_rows():
+    captured = _run_search("/api/sessions/search?q=needle&content=1&depth=0")
+    assert captured["payload"]["count"] == 0

--- a/tests/test_sessions_search_profile_scope.py
+++ b/tests/test_sessions_search_profile_scope.py
@@ -40,3 +40,13 @@ def test_title_search_should_not_return_other_profile_rows():
 def test_content_search_should_not_return_other_profile_rows():
     captured = _run_search("/api/sessions/search?q=needle&content=1&depth=0")
     assert captured["payload"]["count"] == 0
+
+
+def test_all_profiles_opt_in_keeps_aggregate_session_search():
+    captured = _run_search("/api/sessions/search?all_profiles=1")
+    assert captured["payload"]["all_profiles"] is True
+    assert [s["session_id"] for s in captured["payload"]["sessions"]] == [
+        "active-s",
+        "other-s",
+        "other-content-s",
+    ]


### PR DESCRIPTION
## Summary

Profile-scoped session/project endpoints already default to the active Hermes profile with `?all_profiles=1` as an explicit aggregate opt-in. This applies the same boundary to `/api/sessions/search`.

## Issue

`_handle_sessions_search` searched `all_sessions()` directly. A WebUI session running under one active profile could therefore:

- list session metadata for other profiles through an empty `/api/sessions/search` query;
- match other-profile titles;
- with content search enabled, call `get_session()` for other-profile IDs and inspect transcript messages.

That bypasses the profile isolation model fixed for the main session/project list endpoints.

## Changes

- Resolve the active profile inside `_handle_sessions_search`.
- Filter candidate rows with `_profiles_match(...)` unless `?all_profiles=1` is explicitly requested.
- Preserve explicit all-profile search behavior for callers that opt in.
- Return `active_profile` / `all_profiles` metadata consistently in search responses.
- Add regression coverage for empty, title, content, and explicit aggregate search cases.

## Validation

```bash
git diff --check
python3 -m pytest -q tests/test_sessions_search_profile_scope.py tests/test_sessions_search_depth_validation.py tests/test_issue1611_session_profile_filtering.py tests/test_session_summary_redaction.py
python3 -m pytest -q
```

Focused/profile tests passed:

```text
19 passed, 1 warning
```

Full suite result on this branch:

```text
7736 passed, 17 skipped, 3 xpassed, 1 warning
1 failed: tests/test_profile_skills_stats.py::test_get_profile_skills_stats
```

I verified the same `test_profile_skills_stats` failure reproduces on a clean `origin/master` checkout, so it appears unrelated to this change.
