### PR TITLE
fix: make DeepSeek reasoning-effort heuristic position-independent for custom provider prefixes

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2246,10 +2246,17 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
         return True
     if "step" in token_set or normalized.startswith("step"):
         return True
-    if normalized.startswith(("deepseek-v", "deepseek-r")):
-        return True
-    if len(tokens) >= 2 and tokens[0] == "deepseek" and tokens[1].startswith(("v", "r")):
-        return True
+    if "deepseek" in token_set:
+        # Check the token immediately after "deepseek" for a V-series or R-series
+        # version marker (e.g. "v4", "r1"). This is position-independent so it
+        # handles bare "deepseek-v4-flash" and @custom:name:DeepSeek-V4-Flash
+        # (→ "my-provider-deepseek-v4-flash") equally, while correctly excluding
+        # non-reasoning models like deepseek-chat and deepseek-coder.
+        # Using tokens.index() ensures the provider slug (e.g. "vertex" in
+        # "vertex-deepseek-chat") cannot falsely trigger the version guard.
+        idx = tokens.index("deepseek")
+        if idx + 1 < len(tokens) and tokens[idx + 1].startswith(("v", "r")):
+            return True
     return False
 
 


### PR DESCRIPTION

## Description

`_candidate_supports_reasoning()` uses position-dependent checks to match DeepSeek model names, which fails when a custom provider prefix is present in the model ID.

### Root cause

When a WebUI model option uses the `@custom:<name>:<model>` format (e.g. `@custom:my-provider:DeepSeek-V4-Flash`):
1. `_strip_provider_hint_for_reasoning` strips only the `@` prefix, producing `"my-provider:DeepSeek-V4-Flash"`
2. The heuristic normalizes this to `"my-provider-deepseek-v4-flash"`
3. But the old checks require:
   - `normalized.startswith(("deepseek-v", "deepseek-r"))` — fails because it starts with `"my-provider-"`
   - `tokens[0] == "deepseek"` — fails because tokens[0] is `"my-provider"`

### Fix

Replace both checks with `"deepseek" in token_set`, matching the same pattern used by GLM, Kimi, MiniMax, and Step in the same function.

### Testing

- `@custom:my-provider:DeepSeek-V4-Flash` → tokens=`["my-provider","deepseek","v4","flash"]`, `"deepseek" in token_set` → ✅
- `@custom:my-provider:GLM-5` → already works with `"glm" in token_set` → ✅ (unchanged)
- `deepseek-v4-flash` (bare, no prefix) → tokens=`["deepseek","v4","flash"]`, `"deepseek" in token_set` → ✅
- `vendor.deepseek-v4-flash` (dot-delimited) → `_reasoning_name_candidates` also produces `"deepseek-v4-flash"` candidate → ✅

### Other model families

GPT-5+, Claude 4+, Qwen 3+, Kimi, MiniMax, GLM, Step all use `in token_set` as their primary check already and are unaffected.