### PR TITLE
fix: don't stash clarify draft while submission is in progress

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -3284,6 +3284,8 @@ function _startClarifyCountdown(pending) {
 
 function _stashClarifyDraft(reason) {
   if (reason !== "expired" && reason !== "terminal") return false;
+  const submit = $("clarifySubmit");
+  if (submit && submit.classList.contains("loading")) return false;
   const input = $("clarifyInput");
   const draft = String((input && input.value) || "").trim();
   if (!draft) return false;

--- a/tests/test_sprint30.py
+++ b/tests/test_sprint30.py
@@ -608,6 +608,17 @@ class TestClarifyCardTimerLogic:
         assert '\\n\\n${draft}' in body, \
             'preserved clarify drafts should be separated from existing composer text'
 
+    def test_stash_clarify_draft_skips_while_submit_in_flight(self):
+        src = self._get_js().read_text()
+        m = re.search(r'function _stashClarifyDraft.*?(?=\nfunction |\nasync function |\Z)',
+                      src, re.DOTALL)
+        assert m, '_stashClarifyDraft function not found'
+        body = m.group(0)
+        assert 'classList.contains("loading")' in body, \
+            'must not stash draft while a clarify submit is in flight (#3651)'
+        assert body.index('classList.contains("loading")') < body.index('clarifyInput'), \
+            'loading guard must short-circuit before reading the draft'
+
     def test_cancel_stream_does_not_preserve_clarify_draft(self):
         src = self._get_js().read_text()
         m = re.search(r"source\.addEventListener\('cancel'.*?\n    \}\);",


### PR DESCRIPTION
## Bug

When a user types a response in the clarify popup and presses Enter, their text can end up copied into the **main composer textarea** instead of being silently submitted through the popup. This is confusing: the popup closes, and the user sees their reply sitting in the bottom input box — leaving them unsure whether the clarification was actually received by the agent.

## Root cause — race condition between submit and `done` SSE event

The sequence that triggers the bug:

1. User types in `#clarifyInput` and presses Enter.
2. `respondClarify()` calls `_clarifySetControlsDisabled(true, true)`, which **disables** `#clarifySubmit` and adds the `.loading` class, then starts an async `POST /api/clarify/respond`.
3. Before the API response arrives, the agent's `done` SSE event fires (the backend has already acted on the clarify response and finished its turn).
4. The `done` handler calls `_clearClarifyForOwner('terminal')` → `hideClarifyCard(true, 'terminal')` → `_stashClarifyDraft('terminal')`.
5. `_stashClarifyDraft` reads `clarifyInput.value` — which still contains the user's text because the input was only *disabled*, not cleared — and copies it into the main composer textarea (`#msg`), showing a "Clarification closed. Your draft was kept in the composer." toast.
6. The `POST` eventually returns `{ok: true}`, but the popup is already gone.

The draft-stash feature exists to protect unsent text when the popup closes unexpectedly (timeout, session change, terminal close). The problem is it has no way to distinguish "closed before the user could submit" from "closed because a submit is already in flight."

## Fix

Check whether the submit button carries the `.loading` class before stashing. If it does, a submission is already in progress and the draft should not be copied to the composer.

```js
// static/messages.js — _stashClarifyDraft()
function _stashClarifyDraft(reason) {
  if (reason !== "expired" && reason !== "terminal") return false;
+ const submit = $("clarifySubmit");
+ if (submit && submit.classList.contains("loading")) return false;
  const input = $("clarifyInput");
  ...
```

On success the existing `hideClarifyCard(true, 'sent')` path discards the draft cleanly. On failure the error-recovery path in `respondClarify` re-enables the controls, so a subsequent `terminal`/`expired` close will still stash the draft correctly.

## Testing

Reproduce with any agent that calls the `clarify` tool and takes a measurable follow-up action (so the `done` event fires shortly after the clarify response is submitted). Before this fix the reply appears in the main composer; after the fix it does not.