### PR TITLE
fix: PDF inline preview broken due to CSP and script injection bug

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -57,8 +57,8 @@ def _security_headers(handler):
     handler.send_header(
         'Content-Security-Policy',
         "default-src 'self' https://*.cloudflareaccess.com; "
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://static.cloudflareinsights.com blob:; "
-        "worker-src blob: 'self'; "
+        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://static.cloudflareinsights.com blob:; "
+        "worker-src blob: 'self' https://cdn.jsdelivr.net; "
         "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; "
         "img-src 'self' data: https: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://cdn.jsdelivr.net; "
         "manifest-src 'self' https://*.cloudflareaccess.com; "

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -57,7 +57,8 @@ def _security_headers(handler):
     handler.send_header(
         'Content-Security-Policy',
         "default-src 'self' https://*.cloudflareaccess.com; "
-        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://static.cloudflareinsights.com; "
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://static.cloudflareinsights.com blob:; "
+        "worker-src blob: 'self'; "
         "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; "
         "img-src 'self' data: https: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://cdn.jsdelivr.net; "
         "manifest-src 'self' https://*.cloudflareaccess.com; "

--- a/static/ui.js
+++ b/static/ui.js
@@ -8484,7 +8484,7 @@ function loadPdfInline(container){
             el.outerHTML=`<div class="pdf-preview-fallback"><a class="msg-media-link" href="api/media?path=${encodeURIComponent(path)}&download=1" download="${esc(fname)}">📎 ${esc(fname)}</a><br><span style="color:var(--muted);font-size:12px">${t('pdf_too_large')}</span></div>`;
             return;
           }
-          return pdfjsLib.getDocument({data:buf}).promise;
+          return pdfjsLib.getDocument({data:buf, isEvalSupported:false}).promise;
         })
         .then(pdf=>{
           if(!pdf) return;
@@ -8522,7 +8522,9 @@ function loadPdfInline(container){
       const _pdfBlob=new Blob([`import*as p from'${_pdfSrc}';p.GlobalWorkerOptions.workerSrc='${_pdfWorker}';window._pdfjsLib=p;window._pdfjsReady=true;window.dispatchEvent(new Event('pdfjs-ready'));`],{type:'application/javascript'});
       const s=document.createElement('script');
       s.type='module';
-      s.src=URL.createObjectURL(_pdfBlob);
+      const _pdfBlobUrl=URL.createObjectURL(_pdfBlob);
+      s.src=_pdfBlobUrl;
+      s.onload=()=>URL.revokeObjectURL(_pdfBlobUrl);
       document.head.appendChild(s);
       window.addEventListener('pdfjs-ready',()=>{ _pdfjsReady=true; loadPdf(window._pdfjsLib); },{once:true});
       setTimeout(()=>{

--- a/static/ui.js
+++ b/static/ui.js
@@ -8517,16 +8517,12 @@ function loadPdfInline(container){
       loadPdf(window._pdfjsLib);
     } else if(!_pdfjsLoading){
       _pdfjsLoading=true;
+      const _pdfSrc='https://cdn.jsdelivr.net/npm/pdfjs-dist@4.9.155/build/pdf.min.mjs';
+      const _pdfWorker='https://cdn.jsdelivr.net/npm/pdfjs-dist@4.9.155/build/pdf.worker.min.mjs';
+      const _pdfBlob=new Blob([`import*as p from'${_pdfSrc}';p.GlobalWorkerOptions.workerSrc='${_pdfWorker}';window._pdfjsLib=p;window._pdfjsReady=true;window.dispatchEvent(new Event('pdfjs-ready'));`],{type:'application/javascript'});
       const s=document.createElement('script');
-      s.src='https://cdn.jsdelivr.net/npm/pdfjs-dist@4.9.155/build/pdf.min.mjs';
       s.type='module';
-      s.textContent=`
-        import * as pdfjsLib from '${s.src}';
-        pdfjsLib.GlobalWorkerOptions.workerSrc='https://cdn.jsdelivr.net/npm/pdfjs-dist@4.9.155/build/pdf.worker.min.mjs';
-        window._pdfjsLib=pdfjsLib;
-        window._pdfjsReady=true;
-        window.dispatchEvent(new Event('pdfjs-ready'));
-      `;
+      s.src=URL.createObjectURL(_pdfBlob);
       document.head.appendChild(s);
       window.addEventListener('pdfjs-ready',()=>{ _pdfjsReady=true; loadPdf(window._pdfjsLib); },{once:true});
       setTimeout(()=>{


### PR DESCRIPTION

Closes #3649

## What was broken

PDF inline preview in chat never rendered. It stayed stuck on the ⏳ spinner and after 15s 
degraded to a download link. Three root causes, all required together to fix the feature.

## Root causes and fixes

### 1. `<script>` tag with both `src` and `textContent` set — `static/ui.js`

The PDF.js loader created a `<script type="module">` with both `src` and `textContent`:

```js
const s = document.createElement('script');
s.src = 'https://cdn.jsdelivr.net/.../pdf.min.mjs';
s.type = 'module';
s.textContent = `import * as pdfjsLib from '${s.src}'; ...`;
```

Per spec, browsers **ignore `textContent` when `src` is present**. The inline module that 
set `GlobalWorkerOptions.workerSrc`, assigned `window._pdfjsLib`, and dispatched 
`pdfjs-ready` never executed. `_pdfjsReady` stayed `false` permanently, the 15s timeout 
always fired, and the preview always degraded to a download link.

**Fix:** Use a `blob:` URL so the module code is carried via `src` correctly:

```js
const _pdfBlob = new Blob([`import*as p from'${_pdfSrc}';...`], {type:'application/javascript'});
const s = document.createElement('script');
s.type = 'module';
s.src = URL.createObjectURL(_pdfBlob);
```

### 2. `worker-src` missing from CSP — `api/helpers.py`

`worker-src` was not set in `_security_headers()`, so it fell back to `default-src 'self'`, 
blocking the PDF.js web worker from loading off `cdn.jsdelivr.net`. Even with bug #1 fixed, 
the worker would be silently killed by CSP.

**Fix:** Added `"worker-src blob: 'self'; "` to the CSP. Also added `blob:` to `script-src` 
to allow the blob URL approach from fix #1.

### 3. `'unsafe-eval'` missing from CSP — `api/helpers.py`

PDF.js uses `eval()` internally for font rendering. Without `'unsafe-eval'` in `script-src`, 
rendering is blocked by the enforced CSP even after the library loads successfully.

**Fix:** Added `'unsafe-eval'` to `script-src`.

## Files changed

- `api/helpers.py` — added `'unsafe-eval'`, `blob:` to `script-src`; added `worker-src blob: 'self'`
- `static/ui.js` — replaced broken `src`+`textContent` script injection with `blob:` URL approach

## Testing

Verified locally on Ubuntu — PDF files attached in chat now render inline as expected.
