### PR TITLE
Classify WeCom gateway sessions as messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **WebUI now classifies WeCom and WeCom Callback sources as messaging sources instead of CLI/other.** `wecom` and `wecom_callback` are included in the shared messaging source allowlist and label maps, so gateway/sidecar rows (including stale or callback variants) keep messaging classification and readable channel labels in sidebar and chat metadata paths. (#3622)
+
 ## [v0.51.283] — 2026-06-05 — Release IY (stage-w2 — composer queue hint during auto-compaction)
 
 ### Fixed
@@ -103,6 +106,7 @@
 ### Internal
 - **Added a static-analysis contract test pinning the DOM-INFLIGHT reattach persistence invariant** (#3040): every `INFLIGHT[activeSid]` write in `send()` is paired with a `saveInflightState()` call so a reconnect/session-switch reseeds from durable state. (#3572, @rodboev)
 - **Added a regression test asserting `MiniMax-M3` is present in the MiniMax fallback model catalog.** (#3627, @rodboev)
+
 
 ## [v0.51.267] — 2026-06-04 — Release II (stage-r17 — TTS + CSRF forwarded-header security hardening)
 

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -10,6 +10,8 @@ logger = logging.getLogger(__name__)
 MESSAGING_SOURCES = {
     'discord',
     'email',
+    'wecom',
+    'wecom_callback',
     'slack',
     'telegram',
     'weixin',
@@ -24,6 +26,8 @@ SOURCE_LABELS = {
     'cron': 'Cron',
     'discord': 'Discord',
     'email': 'Email',
+    'wecom': 'WeCom',
+    'wecom_callback': 'WeCom Callback',
     'slack': 'Slack',
     'telegram': 'Telegram',
     'tool': 'Tool',

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1058,13 +1058,15 @@ const _HANDOFF_THRESHOLD = 10;  // conversation rounds
 const _HANDOFF_STORAGE_PREFIX = 'handoff:';
 const _HANDOFF_SUFFIX_DISMISSED_AT = 'dismissed_at';
 const _HANDOFF_SUFFIX_SUMMARY_HANDLED_AT = 'summary_handled_at';
-const _MESSAGING_RAW_SOURCES = new Set(['weixin', 'telegram', 'discord', 'slack', 'email']);
+const _MESSAGING_RAW_SOURCES = new Set(['weixin', 'telegram', 'discord', 'slack', 'email', 'wecom', 'wecom_callback']);
 const _MESSAGING_SOURCE_LABELS = {
   weixin: 'WeChat',
   telegram: 'Telegram',
   discord: 'Discord',
   slack: 'Slack',
   email: 'Email',
+  wecom: 'WeCom',
+  wecom_callback: 'WeCom Callback',
 };
 
 function _isMessagingSession(session) {

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -12,6 +12,7 @@ Tests are ordered TDD-style:
 import json
 import os
 import pathlib
+import subprocess
 import sqlite3
 import time
 import urllib.error
@@ -798,6 +799,8 @@ def test_agent_session_source_normalization_contract():
     cases = {
         'cli': ('cli', 'CLI'),
         'email': ('messaging', 'Email'),
+        'wecom': ('messaging', 'WeCom'),
+        'wecom_callback': ('messaging', 'WeCom Callback'),
         'weixin': ('messaging', 'Weixin'),
         'telegram': ('messaging', 'Telegram'),
         'discord': ('messaging', 'Discord'),
@@ -823,8 +826,39 @@ def test_sessions_js_treats_email_as_messaging_source():
     """Email gateway sessions should receive the same sidebar metadata as other messaging channels."""
     src = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 
-    assert "'email'" in src[src.find("_MESSAGING_RAW_SOURCES"):src.find("function _isMessagingSession")]
-    assert "email: 'Email'" in src[src.find("_MESSAGING_SOURCE_LABELS"):src.find("function _isMessagingSession")]
+    raw_section = src[src.find("_MESSAGING_RAW_SOURCES"):src.find("function _isMessagingSession")]
+    label_section = src[src.find("_MESSAGING_SOURCE_LABELS"):src.find("function _isMessagingSession")]
+
+    for raw_source in ("email", "wecom", "wecom_callback"):
+        assert f"'{raw_source}'" in raw_section, f"Missing raw source {raw_source!r} in _MESSAGING_RAW_SOURCES"
+
+    assert "email: 'Email'" in label_section
+    assert "wecom: 'WeCom'" in label_section
+    assert "wecom_callback: 'WeCom Callback'" in label_section
+
+
+def test_sessions_js_treats_wecom_sidecars_as_messaging_behaviorally():
+    """Stale WeCom sidecars with session_source=other should still route as messaging."""
+    src = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+    start = src.index("const _MESSAGING_RAW_SOURCES")
+    end = src.index("/**", start)
+    block = src[start:end]
+    script = f"""
+{block}
+const cases = [
+  {{ session_source: 'other', source: 'wecom' }},
+  {{ session_source: 'other', raw_source: 'wecom_callback' }},
+  {{ session_source: 'other', source_tag: 'wecom' }},
+  {{ session_source: 'messaging', source: 'anything' }},
+];
+for (const c of cases) {{
+  if (!_isMessagingSession(c)) throw new Error('expected messaging for '+JSON.stringify(c));
+}}
+if (_isMessagingSession({{ session_source: 'other', source: 'cli' }})) {{
+  throw new Error('cli should not be treated as messaging');
+}}
+"""
+    subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
 
 
 def test_empty_active_gateway_session_does_not_hide_messaging_history(monkeypatch):


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI normalizes Hermes Agent raw session sources into stable WebUI categories.
- WeCom gateway rows currently arrive with raw sources such as `wecom` and `wecom_callback`, but those values were missing from WebUI's messaging allowlists.
- The backend normalization and frontend stale-sidecar fallback both need to agree, otherwise old sidecars can still appear as CLI/other after the backend fix.
- This PR keeps the fix intentionally narrow: map the WeCom raw source values to the existing `messaging` category and add readable labels.

## What Changed
- Added `wecom` and `wecom_callback` to `MESSAGING_SOURCES`.
- Added backend source labels: `WeCom` and `WeCom Callback`.
- Added the same raw values and labels to the frontend messaging fallback maps in `static/sessions.js`.
- Extended backend normalization coverage for both WeCom variants.
- Added a Node-driven frontend behavior test proving stale sidecars with `session_source: "other"` still classify as messaging based on raw WeCom source values.
- Added a release-note-ready `CHANGELOG.md` entry.

## Why It Matters
- WeCom and WeCom Callback sessions now stay in the messaging classification path instead of falling through to CLI/other behavior.
- Existing stale sidecars are covered by the frontend fallback, not only newly normalized backend rows.
- The change avoids broader gateway or schema work.

## Verification
- `python -m pytest tests/test_gateway_sync.py -k "agent_session_source_normalization_contract or sessions_js_treats_email_as_messaging_source or sessions_js_treats_wecom_sidecars_as_messaging_behaviorally" -q`
- `python -m pytest tests/test_gateway_sync.py tests/test_issue3586_cli_session_source_label.py tests/test_issue3603_external_session_import_gate.py -q`
- `node --check static/sessions.js`
- `git diff --check`

## Risks / Follow-ups
- This is the cheap, WebUI-local fix. A future durable improvement could derive supported messaging platforms from the Hermes Agent platform enum instead of maintaining parallel allowlists.
- No gateway daemon behavior, state.db schema, or sidebar redesign is changed.

## Model Used
- AI-assisted.
- Coordinator: OpenAI GPT-5 Codex.
- Worker sub-agent: OpenAI `gpt-5.3-codex-spark` (Mill).
- Coordinator added the final behavior-level acceptance test and ran verification.

Fixes #3622
