### PR TITLE
fix(providers): limit Settings plugin discovery to user-installed dirs

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -27,6 +27,10 @@ from urllib.parse import parse_qs, urlparse
 
 # ── Basic layout ──────────────────────────────────────────────────────────────
 import api.paths as _paths
+from api.plugin_providers import (
+    effective_provider_display_name as _effective_provider_display_name,
+    is_plugin_model_provider as _is_plugin_model_provider,
+)
 
 HOME = _paths.HOME
 _hermes_home_has_webui_state = _paths._hermes_home_has_webui_state
@@ -3191,6 +3195,12 @@ def invalidate_models_cache():
     # Also delete the disk cache so the next cold build starts fresh.
     # Disk delete is outside the lock — file I/O shouldn't block other readers.
     _delete_models_cache_on_disk()
+    try:
+        from api.plugin_providers import invalidate_plugin_model_provider_cache
+
+        invalidate_plugin_model_provider_cache()
+    except Exception:
+        pass
 
 
 def invalidate_credential_pool_cache(provider_id: str):
@@ -3780,7 +3790,9 @@ def get_available_models() -> dict:
                 # aliases; ``isinstance(_provider_cfg, dict)`` accepts custom
                 # entries that supply their own models/api_key/base_url. (#2399)
                 _is_known_provider = (
-                    _canonical in _PROVIDER_MODELS or _canonical in _PROVIDER_DISPLAY
+                    _canonical in _PROVIDER_MODELS
+                    or _canonical in _PROVIDER_DISPLAY
+                    or _is_plugin_model_provider(_canonical)
                 )
                 _is_provider_config = isinstance(_provider_cfg, dict)
                 if not (_is_known_provider or _is_provider_config):
@@ -4235,7 +4247,7 @@ def get_available_models() -> dict:
                                 group["models_endpoint_error"] = _named_custom_errors[pid]
                             groups.append(group)
                     continue
-                provider_name = _PROVIDER_DISPLAY.get(pid, pid.title())
+                provider_name = _effective_provider_display_name(pid, _PROVIDER_DISPLAY)
                 if pid == "openrouter":
                     # OpenRouter has two model surfaces:
                     #   (1) curated tool-supporting catalog via hermes_cli.models.fetch_openrouter_models()
@@ -4538,7 +4550,11 @@ def get_available_models() -> dict:
                                 "models": models,
                             }
                         )
-                elif pid in _PROVIDER_MODELS or pid in _canonical_to_raw_provider_key:
+                elif (
+                    pid in _PROVIDER_MODELS
+                    or pid in _canonical_to_raw_provider_key
+                    or _is_plugin_model_provider(pid)
+                ):
                     # Look up provider_cfg using the original raw key from
                     # config.yaml so that mixed-case / underscore keys like
                     # ``CLIPpoxy`` or ``snake_case_provider`` still resolve

--- a/api/plugin_providers.py
+++ b/api/plugin_providers.py
@@ -1,0 +1,98 @@
+"""Helpers for model-provider plugins (``plugins/model-providers/<name>/``).
+
+The Hermes agent discovers these via ``providers.list_providers()`` and exposes
+them in the CLI model picker.  WebUI must mirror that registry instead of
+relying only on the static ``_PROVIDER_DISPLAY`` / ``_PROVIDER_MODELS`` tables.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_PROFILES_BY_NAME: dict[str, Any] | None = None
+
+
+def _load_profiles_by_name() -> dict[str, Any]:
+    try:
+        from providers import list_providers
+    except Exception:
+        logger.debug("providers package unavailable for plugin discovery", exc_info=True)
+        return {}
+
+    result: dict[str, Any] = {}
+    try:
+        for profile in list_providers():
+            name = str(getattr(profile, "name", "") or "").strip().lower()
+            if name:
+                result[name] = profile
+    except Exception:
+        logger.debug("Failed to enumerate model-provider plugins", exc_info=True)
+        return {}
+    return result
+
+
+def plugin_model_provider_profiles() -> dict[str, Any]:
+    """Return registered model-provider profiles keyed by canonical slug."""
+    global _PROFILES_BY_NAME
+    if _PROFILES_BY_NAME is None:
+        _PROFILES_BY_NAME = _load_profiles_by_name()
+    return _PROFILES_BY_NAME
+
+
+def invalidate_plugin_model_provider_cache() -> None:
+    """Clear cached plugin discovery (e.g. after config reload)."""
+    global _PROFILES_BY_NAME
+    _PROFILES_BY_NAME = None
+
+
+def plugin_model_provider_ids() -> frozenset[str]:
+    return frozenset(plugin_model_provider_profiles().keys())
+
+
+def plugin_model_provider_display_name(provider_id: str) -> str | None:
+    profile = plugin_model_provider_profiles().get((provider_id or "").strip().lower())
+    if profile is None:
+        return None
+    return str(getattr(profile, "display_name", "") or getattr(profile, "name", "") or "").strip() or None
+
+
+def plugin_model_provider_api_key_env_var(provider_id: str) -> str | None:
+    """Return the primary API-key env var for a plugin provider, if any."""
+    profile = plugin_model_provider_profiles().get((provider_id or "").strip().lower())
+    if profile is None:
+        return None
+    env_vars = getattr(profile, "env_vars", ()) or ()
+    for var in env_vars:
+        upper = str(var).upper()
+        if upper.endswith("_BASE_URL") or upper.endswith("_URL"):
+            continue
+        if upper.endswith("_FOLDER_ID"):
+            continue
+        return str(var)
+    return None
+
+
+def effective_provider_env_var(provider_id: str, static_map: dict[str, str]) -> str | None:
+    pid = (provider_id or "").strip().lower()
+    if not pid:
+        return None
+    if pid in static_map:
+        return static_map[pid]
+    return plugin_model_provider_api_key_env_var(pid)
+
+
+def effective_provider_display_name(provider_id: str, static_map: dict[str, str]) -> str:
+    pid = (provider_id or "").strip().lower()
+    if pid in static_map:
+        return static_map[pid]
+    plugin_name = plugin_model_provider_display_name(pid)
+    if plugin_name:
+        return plugin_name
+    return pid.replace("-", " ").title()
+
+
+def is_plugin_model_provider(provider_id: str) -> bool:
+    return (provider_id or "").strip().lower() in plugin_model_provider_profiles()

--- a/api/plugin_providers.py
+++ b/api/plugin_providers.py
@@ -3,6 +3,11 @@
 The Hermes agent discovers these via ``providers.list_providers()`` and exposes
 them in the CLI model picker.  WebUI must mirror that registry instead of
 relying only on the static ``_PROVIDER_DISPLAY`` / ``_PROVIDER_MODELS`` tables.
+
+Bundled agent profiles (gemini, nous, custom, …) also live in
+``list_providers()``.  WebUI already handles those via static tables and
+dedicated code paths — only *plugin-only* slugs (e.g. user-installed yandex)
+should take the plugin discovery path.
 """
 
 from __future__ import annotations
@@ -15,6 +20,26 @@ logger = logging.getLogger(__name__)
 
 _PROFILES_LOCK = threading.Lock()
 _PROFILES_BY_NAME: dict[str, Any] | None = None
+_WEBUI_STATIC_PROVIDER_IDS: frozenset[str] | None = None
+
+
+def _webui_static_provider_ids() -> frozenset[str]:
+    """Provider slugs already owned by WebUI static tables / special cases."""
+    global _WEBUI_STATIC_PROVIDER_IDS
+    if _WEBUI_STATIC_PROVIDER_IDS is not None:
+        return _WEBUI_STATIC_PROVIDER_IDS
+    try:
+        from api.config import _PROVIDER_DISPLAY, _PROVIDER_MODELS
+
+        static = (
+            frozenset(_PROVIDER_DISPLAY.keys())
+            | frozenset(_PROVIDER_MODELS.keys())
+            | frozenset({"custom"})
+        )
+    except Exception:
+        static = frozenset({"custom"})
+    _WEBUI_STATIC_PROVIDER_IDS = static
+    return static
 
 
 def _load_profiles_by_name() -> dict[str, Any]:
@@ -56,7 +81,11 @@ def invalidate_plugin_model_provider_cache() -> None:
 
 
 def plugin_model_provider_ids() -> frozenset[str]:
-    return frozenset(plugin_model_provider_profiles().keys())
+    """Slugs from ``list_providers()`` that are not already WebUI-static."""
+    static = _webui_static_provider_ids()
+    return frozenset(
+        pid for pid in plugin_model_provider_profiles().keys() if pid not in static
+    )
 
 
 def plugin_model_provider_display_name(provider_id: str) -> str | None:
@@ -88,6 +117,8 @@ def effective_provider_env_var(provider_id: str, static_map: dict[str, str]) -> 
         return None
     if pid in static_map:
         return static_map[pid]
+    if not is_plugin_model_provider(pid):
+        return None
     return plugin_model_provider_api_key_env_var(pid)
 
 
@@ -95,11 +126,16 @@ def effective_provider_display_name(provider_id: str, static_map: dict[str, str]
     pid = (provider_id or "").strip().lower()
     if pid in static_map:
         return static_map[pid]
-    plugin_name = plugin_model_provider_display_name(pid)
-    if plugin_name:
-        return plugin_name
+    if is_plugin_model_provider(pid):
+        plugin_name = plugin_model_provider_display_name(pid)
+        if plugin_name:
+            return plugin_name
     return pid.replace("-", " ").title()
 
 
 def is_plugin_model_provider(provider_id: str) -> bool:
-    return (provider_id or "").strip().lower() in plugin_model_provider_profiles()
+    """True for plugin-only providers (not already in WebUI static tables)."""
+    pid = (provider_id or "").strip().lower()
+    if not pid or pid in _webui_static_provider_ids():
+        return False
+    return pid in plugin_model_provider_profiles()

--- a/api/plugin_providers.py
+++ b/api/plugin_providers.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -86,6 +87,42 @@ def plugin_model_provider_ids() -> frozenset[str]:
     return frozenset(
         pid for pid in plugin_model_provider_profiles().keys() if pid not in static
     )
+
+
+def _user_model_provider_plugins_dir() -> Path | None:
+    """Return ``$HERMES_HOME/plugins/model-providers/`` when present."""
+    try:
+        from api.profiles import get_active_hermes_home
+
+        root = get_active_hermes_home() / "plugins" / "model-providers"
+        return root if root.is_dir() else None
+    except Exception:
+        logger.debug("Failed to resolve user model-provider plugins dir", exc_info=True)
+        return None
+
+
+def user_installed_plugin_model_provider_ids() -> frozenset[str]:
+    """Slugs for user-installed plugins under ``$HERMES_HOME/plugins/model-providers/``.
+
+    Settings → Providers should surface these directories only.  Bundled
+    agent-only profiles from ``list_providers()`` stay out of the panel so
+    ``get_providers()`` does not live-fetch catalogs for every bundled slug.
+    """
+    root = _user_model_provider_plugins_dir()
+    if root is None:
+        return frozenset()
+    return frozenset(
+        child.name.strip().lower()
+        for child in sorted(root.iterdir())
+        if child.is_dir()
+        and not child.name.startswith(("_", "."))
+        and (child / "__init__.py").is_file()
+    )
+
+
+def is_user_installed_plugin_model_provider(provider_id: str) -> bool:
+    pid = (provider_id or "").strip().lower()
+    return bool(pid) and pid in user_installed_plugin_model_provider_ids()
 
 
 def plugin_model_provider_display_name(provider_id: str) -> str | None:

--- a/api/plugin_providers.py
+++ b/api/plugin_providers.py
@@ -8,10 +8,12 @@ relying only on the static ``_PROVIDER_DISPLAY`` / ``_PROVIDER_MODELS`` tables.
 from __future__ import annotations
 
 import logging
+import threading
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_PROFILES_LOCK = threading.Lock()
 _PROFILES_BY_NAME: dict[str, Any] | None = None
 
 
@@ -37,15 +39,20 @@ def _load_profiles_by_name() -> dict[str, Any]:
 def plugin_model_provider_profiles() -> dict[str, Any]:
     """Return registered model-provider profiles keyed by canonical slug."""
     global _PROFILES_BY_NAME
-    if _PROFILES_BY_NAME is None:
-        _PROFILES_BY_NAME = _load_profiles_by_name()
-    return _PROFILES_BY_NAME
+    cached = _PROFILES_BY_NAME
+    if cached is not None:
+        return cached
+    with _PROFILES_LOCK:
+        if _PROFILES_BY_NAME is None:
+            _PROFILES_BY_NAME = _load_profiles_by_name()
+        return _PROFILES_BY_NAME
 
 
 def invalidate_plugin_model_provider_cache() -> None:
     """Clear cached plugin discovery (e.g. after config reload)."""
     global _PROFILES_BY_NAME
-    _PROFILES_BY_NAME = None
+    with _PROFILES_LOCK:
+        _PROFILES_BY_NAME = None
 
 
 def plugin_model_provider_ids() -> frozenset[str]:

--- a/api/providers.py
+++ b/api/providers.py
@@ -43,8 +43,19 @@ from api.config import (
     invalidate_models_cache,
     reload_config,
 )
+from api.plugin_providers import (
+    effective_provider_display_name,
+    effective_provider_env_var,
+    is_plugin_model_provider,
+    plugin_model_provider_ids,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _provider_env_var_for(provider_id: str) -> str | None:
+    """Resolve the API-key env var for a provider (static table + plugin profiles)."""
+    return effective_provider_env_var(provider_id, _PROVIDER_ENV_VAR)
 
 
 def _custom_provider_name_matches(provider_id: str, name: object) -> bool:
@@ -782,7 +793,7 @@ def _provider_has_shadowed_codex_oauth_value(provider_id: str) -> bool:
     if (provider_id or "").strip().lower() != "openai":
         return False
     values: list[object] = []
-    env_var = _PROVIDER_ENV_VAR.get(provider_id)
+    env_var = _provider_env_var_for(provider_id)
     if env_var:
         env_path = _get_hermes_home() / ".env"
         env_values = _load_env_file(env_path)
@@ -923,7 +934,7 @@ def _provider_has_key(provider_id: str) -> bool:
     4. ``config.yaml → providers.<id>.api_key``
     5. ``config.yaml → custom_providers[].api_key`` (for custom providers)
     """
-    env_var = _PROVIDER_ENV_VAR.get(provider_id)
+    env_var = _provider_env_var_for(provider_id)
     if env_var:
         env_path = _get_hermes_home() / ".env"
         env_values = _load_env_file(env_path)
@@ -973,7 +984,7 @@ def _provider_has_key(provider_id: str) -> bool:
 def _get_provider_api_key(provider_id: str) -> str | None:
     """Return a configured provider API key without exposing it to callers."""
     provider_id = (provider_id or "").strip().lower()
-    env_var = _PROVIDER_ENV_VAR.get(provider_id)
+    env_var = _provider_env_var_for(provider_id)
     if env_var:
         env_path = _get_hermes_home() / ".env"
         env_values = _load_env_file(env_path)
@@ -1129,7 +1140,7 @@ def _account_usage_subprocess_env(home: Path, provider: str, api_key: str | None
         if value:
             env[key] = value
 
-    env_var = _PROVIDER_ENV_VAR.get((provider or "").strip().lower())
+    env_var = _provider_env_var_for((provider or "").strip().lower())
     if env_var and api_key:
         env[env_var] = api_key
 
@@ -1752,6 +1763,7 @@ def get_providers() -> dict[str, Any]:
 
     # Collect all known provider IDs from multiple sources
     known_ids = set(_PROVIDER_DISPLAY.keys()) | set(_PROVIDER_MODELS.keys())
+    known_ids.update(plugin_model_provider_ids())
 
     # Also detect providers from config.yaml providers section
     cfg = get_config()
@@ -1763,9 +1775,19 @@ def get_providers() -> dict[str, Any]:
     known_ids.update(_OAUTH_PROVIDERS)
 
     for pid in sorted(known_ids):
-        display_name = _PROVIDER_DISPLAY.get(pid, pid.replace("-", " ").title())
+        display_name = effective_provider_display_name(pid, _PROVIDER_DISPLAY)
         is_oauth = _provider_is_oauth(pid)
         has_key = _provider_has_key(pid)
+        if not has_key and is_plugin_model_provider(pid):
+            try:
+                from hermes_cli.auth import get_auth_status as _gas_plugin
+                _plugin_status = _gas_plugin(pid)
+                if isinstance(_plugin_status, dict) and (
+                    _plugin_status.get("logged_in") or _plugin_status.get("configured")
+                ):
+                    has_key = True
+            except Exception:
+                logger.debug("Plugin provider auth check failed for %s", pid, exc_info=True)
 
         # Determine key source
         key_source = "none"
@@ -1797,7 +1819,7 @@ def get_providers() -> dict[str, Any]:
                 logger.debug("hermes_cli auth check failed for %s", pid, exc_info=True)
                 # keep has_key from _provider_has_key()
         elif has_key:
-            env_var = _PROVIDER_ENV_VAR.get(pid)
+            env_var = _provider_env_var_for(pid)
             if env_var:
                 env_path = _get_hermes_home() / ".env"
                 env_values = _load_env_file(env_path)
@@ -1824,16 +1846,16 @@ def get_providers() -> dict[str, Any]:
                         key_source = "config_yaml"
             else:
                 key_source = "config_yaml"
-        elif pid not in _PROVIDER_ENV_VAR:
+        elif not _provider_env_var_for(pid):
             # Fallback: provider is not a known API-key provider and not in
             # the hardcoded _OAUTH_PROVIDERS set.  It may be a custom or
             # newly-added OAuth provider (e.g. Anthropic connected via OAuth).
             # Check live auth status so the Providers tab agrees with the
             # model picker (#1212).
             #
-            # IMPORTANT: we skip providers in _PROVIDER_ENV_VAR because they
-            # are pure API-key providers — calling get_auth_status() for every
-            # unconfigured API-key provider would add unnecessary latency
+            # IMPORTANT: we skip providers with a known API-key env var because
+            # they are pure API-key providers — calling get_auth_status() for
+            # every unconfigured API-key provider would add unnecessary latency
             # (network round-trip per provider) on the Settings page.
             # Validate pid looks like a real provider before probing
             import re as _re
@@ -1922,6 +1944,21 @@ def get_providers() -> dict[str, Any]:
                     models_total = len(models)
             except Exception:
                 logger.debug("Failed to load LM Studio models from hermes_cli")
+        if is_plugin_model_provider(pid):
+            try:
+                live_models = _models_from_live_provider_ids(
+                    pid,
+                    _read_live_provider_model_ids(pid),
+                )
+                if live_models:
+                    models = live_models
+                    models_total = len(models)
+            except Exception:
+                logger.debug(
+                    "Failed to load plugin model-provider catalog for %s",
+                    pid,
+                    exc_info=True,
+                )
         # Also include models from config.yaml providers section
         if isinstance(providers_cfg, dict):
             provider_cfg = providers_cfg.get(pid, {})
@@ -1943,7 +1980,7 @@ def get_providers() -> dict[str, Any]:
             "id": pid,
             "display_name": display_name,
             "has_key": has_key,
-            "configurable": not is_oauth and pid in _PROVIDER_ENV_VAR,
+            "configurable": not is_oauth and bool(_provider_env_var_for(pid)),
             "is_oauth": is_oauth,
             "key_source": key_source,
             "auth_error": auth_error,
@@ -2040,11 +2077,11 @@ def set_provider_key(provider_id: str, api_key: str | None) -> dict[str, Any]:
                      f"Use `hermes model` in the terminal to configure it.",
         }
 
-    env_var = _PROVIDER_ENV_VAR.get(provider_id)
+    env_var = _provider_env_var_for(provider_id)
     if not env_var:
         return {
             "ok": False,
-            "error": f"Cannot configure API key for '{_PROVIDER_DISPLAY.get(provider_id, provider_id)}'. "
+            "error": f"Cannot configure API key for '{effective_provider_display_name(provider_id, _PROVIDER_DISPLAY)}'. "
                      f"This provider does not have a known env var mapping.",
         }
 

--- a/api/providers.py
+++ b/api/providers.py
@@ -1778,6 +1778,7 @@ def get_providers() -> dict[str, Any]:
         display_name = effective_provider_display_name(pid, _PROVIDER_DISPLAY)
         is_oauth = _provider_is_oauth(pid)
         has_key = _provider_has_key(pid)
+        plugin_auth_status: dict[str, Any] | None = None
         if not has_key and is_plugin_model_provider(pid):
             try:
                 from hermes_cli.auth import get_auth_status as _gas_plugin
@@ -1786,6 +1787,7 @@ def get_providers() -> dict[str, Any]:
                     _plugin_status.get("logged_in") or _plugin_status.get("configured")
                 ):
                     has_key = True
+                    plugin_auth_status = _plugin_status
             except Exception:
                 logger.debug("Plugin provider auth check failed for %s", pid, exc_info=True)
 
@@ -1843,9 +1845,19 @@ def get_providers() -> dict[str, Any]:
                             aliased = True
                             break
                     if not aliased:
-                        key_source = "config_yaml"
+                        _plugin_ks = (
+                            str(plugin_auth_status.get("key_source") or "").strip()
+                            if isinstance(plugin_auth_status, dict)
+                            else ""
+                        )
+                        key_source = _plugin_ks or "config_yaml"
             else:
-                key_source = "config_yaml"
+                _plugin_ks = (
+                    str(plugin_auth_status.get("key_source") or "").strip()
+                    if isinstance(plugin_auth_status, dict)
+                    else ""
+                )
+                key_source = _plugin_ks or "config_yaml"
         elif not _provider_env_var_for(pid):
             # Fallback: provider is not a known API-key provider and not in
             # the hardcoded _OAUTH_PROVIDERS set.  It may be a custom or

--- a/api/providers.py
+++ b/api/providers.py
@@ -47,7 +47,8 @@ from api.plugin_providers import (
     effective_provider_display_name,
     effective_provider_env_var,
     is_plugin_model_provider,
-    plugin_model_provider_ids,
+    is_user_installed_plugin_model_provider,
+    user_installed_plugin_model_provider_ids,
 )
 
 logger = logging.getLogger(__name__)
@@ -1763,7 +1764,7 @@ def get_providers() -> dict[str, Any]:
 
     # Collect all known provider IDs from multiple sources
     known_ids = set(_PROVIDER_DISPLAY.keys()) | set(_PROVIDER_MODELS.keys())
-    known_ids.update(plugin_model_provider_ids())
+    known_ids.update(user_installed_plugin_model_provider_ids())
 
     # Also detect providers from config.yaml providers section
     cfg = get_config()
@@ -1956,7 +1957,7 @@ def get_providers() -> dict[str, Any]:
                     models_total = len(models)
             except Exception:
                 logger.debug("Failed to load LM Studio models from hermes_cli")
-        if is_plugin_model_provider(pid):
+        if is_user_installed_plugin_model_provider(pid) and has_key:
             try:
                 live_models = _models_from_live_provider_ids(
                     pid,
@@ -1988,13 +1989,12 @@ def get_providers() -> dict[str, Any]:
                 if pid != "nous":
                     models_total = len(models)
 
-        _is_plugin = is_plugin_model_provider(pid)
         providers.append({
             "id": pid,
             "display_name": display_name,
             "has_key": has_key,
             "configurable": not is_oauth and bool(_provider_env_var_for(pid)),
-            "is_plugin_provider": _is_plugin,
+            "is_plugin_provider": is_user_installed_plugin_model_provider(pid),
             "is_oauth": is_oauth,
             "key_source": key_source,
             "auth_error": auth_error,

--- a/api/providers.py
+++ b/api/providers.py
@@ -1976,11 +1976,13 @@ def get_providers() -> dict[str, Any]:
                 if pid != "nous":
                     models_total = len(models)
 
+        _is_plugin = is_plugin_model_provider(pid)
         providers.append({
             "id": pid,
             "display_name": display_name,
             "has_key": has_key,
             "configurable": not is_oauth and bool(_provider_env_var_for(pid)),
+            "is_plugin_provider": _is_plugin,
             "is_oauth": is_oauth,
             "key_source": key_source,
             "auth_error": auth_error,

--- a/static/panels.js
+++ b/static/panels.js
@@ -6660,7 +6660,7 @@ async function loadProvidersPanel(){
   try{
     const data=await api('/api/providers');
     const quota=await _fetchProviderQuotaStatus(false).catch(e=>({ok:false,status:'unavailable',quota:null,message:e.message||t('provider_quota_unavailable'),client_fetched_at:new Date().toISOString()}));
-    const providers=(data.providers||[]).filter(p=>p.configurable||p.is_oauth||p.is_custom);
+    const providers=(data.providers||[]).filter(p=>p.configurable||p.is_oauth||p.is_custom||p.is_plugin_provider);
     list.innerHTML='';
     _providerCardEls.clear();
     const quotaCard=_buildProviderQuotaCard(quota);

--- a/tests/test_custom_providers_in_panel.py
+++ b/tests/test_custom_providers_in_panel.py
@@ -107,7 +107,7 @@ class TestCustomProvidersInGetProviders:
     def test_providers_panel_renders_config_yaml_custom_providers(self):
         """Settings → Providers must not filter out read-only custom providers."""
         src = open("static/panels.js", encoding="utf-8").read()
-        assert "filter(p=>p.configurable||p.is_oauth||p.is_custom)" in src
+        assert "filter(p=>p.configurable||p.is_oauth||p.is_custom||p.is_plugin_provider)" in src
         assert "Custom provider loaded from config.yaml / hermes model" in src
         assert "if(p.configurable){" in src
 

--- a/tests/test_issue1202_oauth_provider_status.py
+++ b/tests/test_issue1202_oauth_provider_status.py
@@ -290,9 +290,16 @@ class TestProviderListFilter:
             "This excludes ALL OAuth providers (openai-codex, nous, copilot) from the "
             "Settings → Providers panel. The filter must be 'filter(p=>p.configurable||p.is_oauth)'."
         )
-        fixed_filter_idx = self.JS.find("filter(p=>p.configurable||p.is_oauth)")
-        extended_filter_idx = self.JS.find("filter(p=>p.configurable||p.is_oauth||p.is_custom)")
-        assert fixed_filter_idx != -1 or extended_filter_idx != -1, (
+        assert "p.is_oauth" in self.JS, (
             "The provider filter must include p.is_oauth in panels.js. "
             "OAuth providers will not appear in Settings → Providers."
+        )
+        # Current filter also includes is_custom and is_plugin_provider; require
+        # the full expression so partial regressions are caught.
+        assert (
+            "filter(p=>p.configurable||p.is_oauth||p.is_custom||p.is_plugin_provider)"
+            in self.JS
+        ), (
+            "Settings → Providers filter must keep OAuth, custom, and plugin "
+            "model-provider entries visible."
         )

--- a/tests/test_plugin_model_providers.py
+++ b/tests/test_plugin_model_providers.py
@@ -16,6 +16,12 @@ import api.profiles as profiles
 from api.plugin_providers import invalidate_plugin_model_provider_cache
 
 
+def _install_user_yandex_plugin_dir(tmp_path):
+    root = tmp_path / "plugins" / "model-providers" / "yandex"
+    root.mkdir(parents=True)
+    (root / "__init__.py").write_text("# user-installed model-provider plugin\n", encoding="utf-8")
+
+
 def _install_fake_yandex_plugin(monkeypatch):
     profile = SimpleNamespace(
         name="yandex",
@@ -69,6 +75,7 @@ class TestPluginModelProvidersSettings:
     def test_get_providers_includes_plugin_model_provider(self, monkeypatch, tmp_path):
         _install_fake_yandex_plugin(monkeypatch)
         _install_fake_hermes_cli(monkeypatch, model_ids=["deepseek-v4-flash/latest"])
+        _install_user_yandex_plugin_dir(tmp_path)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
 
         env_path = tmp_path / ".env"
@@ -103,6 +110,7 @@ class TestPluginModelProvidersSettings:
     def test_get_providers_plugin_key_source_from_auth_store(self, monkeypatch, tmp_path):
         """Credential-pool auth must not be misreported as config_yaml."""
         _install_fake_yandex_plugin(monkeypatch)
+        _install_user_yandex_plugin_dir(tmp_path)
 
         fake_pkg = types.ModuleType("hermes_cli")
         fake_pkg.__path__ = []
@@ -150,6 +158,7 @@ class TestPluginModelProvidersSettings:
 
     def test_set_provider_key_accepts_plugin_env_var(self, monkeypatch, tmp_path):
         _install_fake_yandex_plugin(monkeypatch)
+        _install_user_yandex_plugin_dir(tmp_path)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
 
         from api.providers import set_provider_key
@@ -158,6 +167,96 @@ class TestPluginModelProvidersSettings:
         assert result["ok"] is True
         env_text = (tmp_path / ".env").read_text(encoding="utf-8")
         assert "YANDEX_API_KEY=test-yandex-key-abcdef" in env_text
+
+
+    def test_get_providers_skips_bundled_plugin_without_user_install_dir(
+        self, monkeypatch, tmp_path
+    ):
+        """Bundled agent-only slugs must not inflate Settings → Providers."""
+        profile = SimpleNamespace(
+            name="xai",
+            display_name="xAI",
+            env_vars=("XAI_API_KEY",),
+            auth_type="api_key",
+            aliases=(),
+        )
+
+        def _fake_list_providers():
+            return [profile]
+
+        fake_providers = types.ModuleType("providers")
+        fake_providers.list_providers = _fake_list_providers
+        monkeypatch.setitem(sys.modules, "providers", fake_providers)
+        invalidate_plugin_model_provider_cache()
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        config.cfg["model"] = {}
+        try:
+            config._cfg_mtime = 0.0
+        except Exception:
+            config._cfg_mtime = 0.0
+
+        from api.providers import get_providers
+
+        try:
+            result = get_providers()
+            assert next((p for p in result["providers"] if p["id"] == "xai"), None) is None
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime
+            config.invalidate_models_cache()
+
+    def test_get_providers_skips_live_fetch_without_key(self, monkeypatch, tmp_path):
+        _install_fake_yandex_plugin(monkeypatch)
+        _install_user_yandex_plugin_dir(tmp_path)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.delenv("YANDEX_API_KEY", raising=False)
+        monkeypatch.delenv("YANDEX_FOLDER_ID", raising=False)
+
+        calls: list[str] = []
+
+        def _track_provider_model_ids(pid):
+            calls.append(pid)
+            return ["should-not-run"]
+
+        fake_pkg = types.ModuleType("hermes_cli")
+        fake_pkg.__path__ = []
+        fake_models = types.ModuleType("hermes_cli.models")
+        fake_models.list_available_providers = lambda: []
+        fake_models.provider_model_ids = _track_provider_model_ids
+        fake_auth = types.ModuleType("hermes_cli.auth")
+        fake_auth.get_auth_status = lambda pid: {}
+        monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+        monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+        monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        config.cfg["model"] = {}
+        try:
+            config._cfg_mtime = 0.0
+        except Exception:
+            config._cfg_mtime = 0.0
+
+        from api.providers import get_providers
+
+        try:
+            result = get_providers()
+            yandex = next((p for p in result["providers"] if p["id"] == "yandex"), None)
+            assert yandex is not None
+            assert yandex["has_key"] is False
+            assert yandex["models_total"] == 0
+            assert "yandex" not in calls
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime
+            config.invalidate_models_cache()
 
 
 class TestPluginOnlyExcludesStaticProviders:

--- a/tests/test_plugin_model_providers.py
+++ b/tests/test_plugin_model_providers.py
@@ -1,0 +1,149 @@
+"""Regression tests for model-provider plugin discovery in WebUI.
+
+Plugin profiles under ``plugins/model-providers/<name>/`` are auto-registered
+in the Hermes agent CLI.  WebUI must expose them in Settings → Providers and
+the model picker without hardcoding each slug.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+
+import api.config as config
+import api.profiles as profiles
+from api.plugin_providers import invalidate_plugin_model_provider_cache
+
+
+def _install_fake_yandex_plugin(monkeypatch):
+    profile = SimpleNamespace(
+        name="yandex",
+        display_name="Yandex AI Studio",
+        env_vars=("YANDEX_API_KEY", "YANDEX_FOLDER_ID"),
+        auth_type="api_key",
+        aliases=("yandex-ai-studio",),
+    )
+
+    def _fake_list_providers():
+        return [profile]
+
+    fake_providers = types.ModuleType("providers")
+    fake_providers.list_providers = _fake_list_providers
+    monkeypatch.setitem(sys.modules, "providers", fake_providers)
+    invalidate_plugin_model_provider_cache()
+
+
+def _install_fake_hermes_cli(monkeypatch, *, authenticated: bool = True, model_ids: list[str] | None = None):
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models.list_available_providers = lambda: [
+        {
+            "id": "yandex",
+            "label": "Yandex AI Studio",
+            "aliases": [],
+            "authenticated": authenticated,
+        }
+    ]
+    fake_models.provider_model_ids = lambda pid: list(model_ids or []) if pid == "yandex" else []
+
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda pid: (
+        {
+            "logged_in": True,
+            "configured": True,
+            "key_source": "YANDEX_API_KEY",
+        }
+        if pid == "yandex"
+        else {}
+    )
+
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+
+
+class TestPluginModelProvidersSettings:
+    def test_get_providers_includes_plugin_model_provider(self, monkeypatch, tmp_path):
+        _install_fake_yandex_plugin(monkeypatch)
+        _install_fake_hermes_cli(monkeypatch, model_ids=["deepseek-v4-flash/latest"])
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("YANDEX_API_KEY=test-yandex-key-12345\n", encoding="utf-8")
+
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        config.cfg["model"] = {"provider": "gemini"}
+        try:
+            config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+        except Exception:
+            config._cfg_mtime = 0.0
+
+        from api.providers import get_providers
+
+        try:
+            result = get_providers()
+            yandex = next((p for p in result["providers"] if p["id"] == "yandex"), None)
+            assert yandex is not None, "plugin model-provider must appear in Settings → Providers"
+            assert yandex["display_name"] == "Yandex AI Studio"
+            assert yandex["has_key"] is True
+            assert yandex["configurable"] is True
+            assert yandex["models_total"] >= 1
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime
+            config.invalidate_models_cache()
+
+    def test_set_provider_key_accepts_plugin_env_var(self, monkeypatch, tmp_path):
+        _install_fake_yandex_plugin(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        from api.providers import set_provider_key
+
+        result = set_provider_key("yandex", "test-yandex-key-abcdef")
+        assert result["ok"] is True
+        env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+        assert "YANDEX_API_KEY=test-yandex-key-abcdef" in env_text
+
+
+class TestPluginModelProvidersPicker:
+    def test_model_picker_includes_authenticated_plugin_provider(self, monkeypatch, tmp_path):
+        _install_fake_yandex_plugin(monkeypatch)
+        _install_fake_hermes_cli(
+            monkeypatch,
+            authenticated=True,
+            model_ids=["gpt://folder/deepseek-v4-flash/latest"],
+        )
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        config.cfg["model"] = {"provider": "gemini", "default": "gemini-2.5-flash"}
+        config.cfg["providers"] = {}
+        try:
+            config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+        except Exception:
+            config._cfg_mtime = 0.0
+
+        config.invalidate_models_cache()
+        try:
+            models = config.get_available_models()
+            yandex_group = next(
+                (g for g in models.get("groups", []) if g.get("provider_id") == "yandex"),
+                None,
+            )
+            assert yandex_group is not None, "authenticated plugin provider must appear in picker"
+            assert yandex_group["provider"] == "Yandex AI Studio"
+            assert len(yandex_group.get("models") or []) >= 1
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime
+            config.invalidate_models_cache()

--- a/tests/test_plugin_model_providers.py
+++ b/tests/test_plugin_model_providers.py
@@ -160,6 +160,26 @@ class TestPluginModelProvidersSettings:
         assert "YANDEX_API_KEY=test-yandex-key-abcdef" in env_text
 
 
+class TestPluginOnlyExcludesStaticProviders:
+    def test_bundled_agent_profiles_are_not_plugin_only(self, monkeypatch):
+        """Agent bundled profiles must not hijack WebUI static/custom paths."""
+        _install_fake_yandex_plugin(monkeypatch)
+        from api.plugin_providers import (
+            effective_provider_display_name,
+            is_plugin_model_provider,
+            plugin_model_provider_ids,
+        )
+        from api.config import _PROVIDER_DISPLAY
+
+        assert is_plugin_model_provider("yandex") is True
+        assert "yandex" in plugin_model_provider_ids()
+        for static_pid in ("custom", "gemini", "nous", "anthropic"):
+            assert is_plugin_model_provider(static_pid) is False, static_pid
+            assert static_pid not in plugin_model_provider_ids()
+        assert effective_provider_display_name("custom", _PROVIDER_DISPLAY) == "Custom"
+        assert effective_provider_display_name("gemini", _PROVIDER_DISPLAY) == "Gemini"
+
+
 class TestPluginModelProvidersPanelFilter:
     def test_providers_panel_includes_plugin_model_providers(self):
         src = open("static/panels.js", encoding="utf-8").read()

--- a/tests/test_plugin_model_providers.py
+++ b/tests/test_plugin_model_providers.py
@@ -100,6 +100,54 @@ class TestPluginModelProvidersSettings:
             config._cfg_mtime = old_mtime
             config.invalidate_models_cache()
 
+    def test_get_providers_plugin_key_source_from_auth_store(self, monkeypatch, tmp_path):
+        """Credential-pool auth must not be misreported as config_yaml."""
+        _install_fake_yandex_plugin(monkeypatch)
+
+        fake_pkg = types.ModuleType("hermes_cli")
+        fake_pkg.__path__ = []
+        fake_models = types.ModuleType("hermes_cli.models")
+        fake_models.list_available_providers = lambda: []
+        fake_models.provider_model_ids = lambda pid: []
+        fake_auth = types.ModuleType("hermes_cli.auth")
+        fake_auth.get_auth_status = lambda pid: (
+            {
+                "logged_in": True,
+                "configured": True,
+                "key_source": "credential_pool:yandex",
+            }
+            if pid == "yandex"
+            else {}
+        )
+        monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+        monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+        monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        config.cfg["model"] = {}
+        try:
+            config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+        except Exception:
+            config._cfg_mtime = 0.0
+
+        from api.providers import get_providers
+
+        try:
+            result = get_providers()
+            yandex = next((p for p in result["providers"] if p["id"] == "yandex"), None)
+            assert yandex is not None
+            assert yandex["has_key"] is True
+            assert yandex["key_source"] == "credential_pool:yandex"
+            assert yandex["key_source"] != "config_yaml"
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime
+            config.invalidate_models_cache()
+
     def test_set_provider_key_accepts_plugin_env_var(self, monkeypatch, tmp_path):
         _install_fake_yandex_plugin(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)

--- a/tests/test_plugin_model_providers.py
+++ b/tests/test_plugin_model_providers.py
@@ -92,6 +92,7 @@ class TestPluginModelProvidersSettings:
             assert yandex["display_name"] == "Yandex AI Studio"
             assert yandex["has_key"] is True
             assert yandex["configurable"] is True
+            assert yandex.get("is_plugin_provider") is True
             assert yandex["models_total"] >= 1
         finally:
             config.cfg.clear()
@@ -109,6 +110,13 @@ class TestPluginModelProvidersSettings:
         assert result["ok"] is True
         env_text = (tmp_path / ".env").read_text(encoding="utf-8")
         assert "YANDEX_API_KEY=test-yandex-key-abcdef" in env_text
+
+
+class TestPluginModelProvidersPanelFilter:
+    def test_providers_panel_includes_plugin_model_providers(self):
+        src = open("static/panels.js", encoding="utf-8").read()
+        assert "p.is_plugin_provider" in src
+        assert "filter(p=>p.configurable||p.is_oauth||p.is_custom||p.is_plugin_provider)" in src
 
 
 class TestPluginModelProvidersPicker:


### PR DESCRIPTION
## Depends on #3613

**Do not merge until #3613 is merged.** After #3613 lands, this branch will be rebased to a single commit on `master`.

Review the perf-only diff now (1 commit):

https://github.com/pamnard/hermes-webui/compare/fix/plugin-model-providers...fix/settings-plugin-discovery-perf

## Summary

- Settings → Providers scans only user-installed plugins under `$HERMES_HOME/plugins/model-providers/`, not every bundled plugin-only slug from `providers.list_providers()`.
- Live model catalog fetch for plugin providers runs only when `has_key` is true.
- Cuts `/api/providers` latency ~2× on setups with many bundled agent-only profiles.

## Context

#3613 exposed plugin model-providers correctly but `get_providers()` live-fetched catalogs for all plugin-only slugs without keys, blocking Settings for tens of seconds.

## Test plan

- [x] `pytest tests/test_plugin_model_providers.py -q`
- [x] `pytest tests/test_provider_management.py tests/test_custom_provider_display_name.py -q`
- [x] Manual: Settings → Providers ~3–4s vs ~minute before; only user-installed plugin cards (e.g. Yandex)