### PR TITLE
perf(providers): O(1) codex cache merge membership checks

### DIFF
--- a/api/providers.py
+++ b/api/providers.py
@@ -1866,8 +1866,10 @@ def get_providers() -> dict[str, Any]:
         # follow-up to v0.51.19 #1812.)
         if pid == "openai-codex":
             live_ids = _read_live_provider_model_ids("openai-codex")
+            live_id_set = set(live_ids)
             for mid in _read_visible_codex_cache_model_ids():
-                if mid not in live_ids:
+                if mid not in live_id_set:
+                    live_id_set.add(mid)
                     live_ids.append(mid)
             live_models = _models_from_live_provider_ids(pid, live_ids)
             if live_models:


### PR DESCRIPTION
## Summary
- Use a side `set` when merging visible Codex cache model IDs into the live `openai-codex` catalog in `get_providers()`.
- Keeps model list ordering identical while making duplicate checks O(1) instead of O(n) per cache entry.

## Test plan
- [x] `pytest tests/test_issue1807_codex_provider_card_live_models.py tests/test_issue1680_codex_spark.py -q --timeout=60`