### PR TITLE
perf(sessions): batch orphan sidecar state.db existence probes

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -2723,6 +2723,71 @@ def _active_state_db_path() -> Path:
     return hermes_home / 'state.db'
 
 
+def _agent_state_db_path(*, profile=None) -> Path | None:
+    """Return agent ``state.db`` for *profile*, or ``None`` when unavailable."""
+    if isinstance(profile, str) and profile:
+        db_path = _get_profile_home(profile) / 'state.db'
+        if not db_path.exists():
+            db_path = _active_state_db_path()
+    else:
+        db_path = _active_state_db_path()
+    if not db_path.exists():
+        return None
+    return db_path
+
+
+def agent_session_rows_existing(
+    session_ids: list[str] | set[str] | frozenset[str],
+    *,
+    profile=None,
+) -> frozenset[str]:
+    """Return session ids confirmed present in the agent ``sessions`` table.
+
+    Used by the sidebar orphan-prune path (#3238) to batch existence probes
+    instead of opening one SQLite connection per candidate row.
+
+    Degrades safely to ``frozenset(wanted)`` (assume all present) on any error,
+    when the DB is missing, or when the ``sessions`` table is absent — matching
+    ``agent_session_row_exists()`` so a transient failure never causes pruning.
+    """
+    wanted = {str(sid).strip() for sid in (session_ids or []) if str(sid or "").strip()}
+    if not wanted:
+        return frozenset()
+    try:
+        import sqlite3
+    except ImportError:
+        return frozenset(wanted)
+    db_path = _agent_state_db_path(profile=profile)
+    if db_path is None:
+        return frozenset(wanted)
+    try:
+        with closing(sqlite3.connect(str(db_path))) as conn:
+            cur = conn.cursor()
+            cur.execute("PRAGMA table_info(sessions)")
+            cols = {str(row[1]) for row in cur.fetchall()}
+            if 'id' not in cols:
+                return frozenset(wanted)
+            existing: set[str] = set()
+            ids = list(wanted)
+            chunk_size = 500
+            for i in range(0, len(ids), chunk_size):
+                chunk = ids[i:i + chunk_size]
+                placeholders = ','.join('?' * len(chunk))
+                cur.execute(
+                    f"SELECT id FROM sessions WHERE id IN ({placeholders})",
+                    chunk,
+                )
+                existing.update(str(row[0]) for row in cur.fetchall())
+            return frozenset(existing)
+    except Exception:
+        logger.debug(
+            "agent_session_rows_existing probe failed for %d ids",
+            len(wanted),
+            exc_info=True,
+        )
+        return frozenset(wanted)
+
+
 def agent_session_row_exists(session_id: str, *, profile=None) -> bool:
     """Return True if ``session_id`` still has a backing row in the agent state.db.
 
@@ -2739,31 +2804,7 @@ def agent_session_row_exists(session_id: str, *, profile=None) -> bool:
     sid = str(session_id or "").strip()
     if not sid:
         return False
-    try:
-        import sqlite3
-    except ImportError:
-        return True
-    if isinstance(profile, str) and profile:
-        db_path = _get_profile_home(profile) / 'state.db'
-        if not db_path.exists():
-            db_path = _active_state_db_path()
-    else:
-        db_path = _active_state_db_path()
-    if not db_path.exists():
-        # No agent DB at all on this instance — can't claim the row is gone.
-        return True
-    try:
-        with closing(sqlite3.connect(str(db_path))) as conn:
-            cur = conn.cursor()
-            cur.execute("PRAGMA table_info(sessions)")
-            cols = {str(row[1]) for row in cur.fetchall()}
-            if 'id' not in cols:
-                return True
-            cur.execute("SELECT 1 FROM sessions WHERE id = ? LIMIT 1", (sid,))
-            return cur.fetchone() is not None
-    except Exception:
-        logger.debug("agent_session_row_exists probe failed for %s", sid, exc_info=True)
-        return True
+    return sid in agent_session_rows_existing([sid], profile=profile)
 
 
 def _sidebar_title_is_generic_webui(title: str | None) -> bool:

--- a/api/models.py
+++ b/api/models.py
@@ -2777,7 +2777,7 @@ def agent_session_rows_existing(
                     f"SELECT id FROM sessions WHERE id IN ({placeholders})",
                     chunk,
                 )
-                existing.update(str(row[0]) for row in cur.fetchall())
+                existing.update(str(row[0]).strip() for row in cur.fetchall())
             return frozenset(existing)
     except Exception:
         logger.debug(

--- a/api/routes.py
+++ b/api/routes.py
@@ -2900,7 +2900,7 @@ from api.models import (
     _is_empty_partial_activity_message,
     _hide_from_default_sidebar,
     prune_session_from_index,
-    agent_session_row_exists,
+    agent_session_rows_existing,
     ensure_cron_project,
     is_cron_session,
     is_safe_session_id,
@@ -5422,12 +5422,13 @@ def handle_get(handler, parsed) -> bool:
                 # the sidecar is never pruned and the stale row lingers in the
                 # sidebar forever (there is no WebUI delete affordance for it).
                 # Drop rows whose backing agent row is genuinely gone. We probe
-                # state.db directly (agent_session_row_exists) rather than trust
+                # state.db directly (agent_session_rows_existing) rather than trust
                 # cli_by_id absence, because get_cli_sessions() caps at
                 # CLI_VISIBLE_SESSION_LIMIT (20) — an existing session can fall
                 # out of that window and look deleted. Native WebUI sessions
                 # (source == "webui") that merely have a CLI ancestor are never
                 # pruned.
+                _orphan_probe_rows = []
                 _kept_after_orphan_prune = []
                 for s in webui_sessions:
                     _sid = s.get("session_id")
@@ -5436,15 +5437,45 @@ def handle_get(handler, parsed) -> bool:
                         and is_cli_session_row(s)
                         and not _session_source_is_webui(s)
                         and _sid not in cli_by_id
-                        and not agent_session_row_exists(_sid, profile=s.get("profile"))
                     ):
-                        try:
-                            prune_session_from_index(_sid)
-                        except Exception:
-                            logger.debug("Failed to prune orphaned CLI sidecar %s", _sid, exc_info=True)
-                        diag.stage("prune_orphaned_cli_sidecar")
-                        continue
-                    _kept_after_orphan_prune.append(s)
+                        _orphan_probe_rows.append(s)
+                    else:
+                        _kept_after_orphan_prune.append(s)
+                if _orphan_probe_rows:
+                    from collections import defaultdict
+
+                    rows_by_profile: dict[object, list[dict]] = defaultdict(list)
+                    for row in _orphan_probe_rows:
+                        rows_by_profile[row.get("profile")].append(row)
+                    missing_orphan_ids: set[str] = set()
+                    for profile_key, rows in rows_by_profile.items():
+                        probe_ids = [
+                            str(row.get("session_id"))
+                            for row in rows
+                            if row.get("session_id")
+                        ]
+                        existing = agent_session_rows_existing(
+                            probe_ids,
+                            profile=profile_key if isinstance(profile_key, str) and profile_key else None,
+                        )
+                        for row in rows:
+                            sid = str(row.get("session_id") or "")
+                            if sid and sid not in existing:
+                                missing_orphan_ids.add(sid)
+                    for s in _orphan_probe_rows:
+                        _sid = s.get("session_id")
+                        if _sid in missing_orphan_ids:
+                            try:
+                                prune_session_from_index(_sid)
+                            except Exception:
+                                logger.debug(
+                                    "Failed to prune orphaned CLI sidecar %s",
+                                    _sid,
+                                    exc_info=True,
+                                )
+                            diag.stage("prune_orphaned_cli_sidecar")
+                            continue
+                        _kept_after_orphan_prune.append(s)
                 webui_sessions = _kept_after_orphan_prune
                 for s in webui_sessions:
                     meta = cli_by_id.get(s.get("session_id"))

--- a/api/routes.py
+++ b/api/routes.py
@@ -22,6 +22,7 @@ import threading
 import time
 import uuid
 import re
+from collections import defaultdict
 from pathlib import Path
 from contextlib import closing
 from urllib.parse import parse_qs, urlsplit
@@ -5442,28 +5443,26 @@ def handle_get(handler, parsed) -> bool:
                     else:
                         _kept_after_orphan_prune.append(s)
                 if _orphan_probe_rows:
-                    from collections import defaultdict
-
                     rows_by_profile: dict[object, list[dict]] = defaultdict(list)
                     for row in _orphan_probe_rows:
                         rows_by_profile[row.get("profile")].append(row)
                     missing_orphan_ids: set[str] = set()
                     for profile_key, rows in rows_by_profile.items():
                         probe_ids = [
-                            str(row.get("session_id"))
+                            str(row.get("session_id")).strip()
                             for row in rows
-                            if row.get("session_id")
+                            if str(row.get("session_id") or "").strip()
                         ]
                         existing = agent_session_rows_existing(
                             probe_ids,
                             profile=profile_key if isinstance(profile_key, str) and profile_key else None,
                         )
                         for row in rows:
-                            sid = str(row.get("session_id") or "")
+                            sid = str(row.get("session_id") or "").strip()
                             if sid and sid not in existing:
                                 missing_orphan_ids.add(sid)
                     for s in _orphan_probe_rows:
-                        _sid = s.get("session_id")
+                        _sid = str(s.get("session_id") or "").strip()
                         if _sid in missing_orphan_ids:
                             try:
                                 prune_session_from_index(_sid)

--- a/tests/test_issue3238_orphaned_cli_sidecar_prune.py
+++ b/tests/test_issue3238_orphaned_cli_sidecar_prune.py
@@ -104,6 +104,43 @@ def test_agent_session_row_exists_handles_missing_sessions_table(tmp_path, monke
     assert models.agent_session_row_exists("whatever") is True
 
 
+def test_agent_session_rows_existing_returns_present_subset(tmp_path, monkeypatch):
+    from api import models
+
+    home = tmp_path / "home"
+    home.mkdir()
+    _make_state_db(home / "state.db", ["sess-a", "sess-b"])
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: home / "state.db")
+
+    existing = models.agent_session_rows_existing(
+        ["sess-a", "sess-b", "sess-missing", "", None]
+    )
+    assert existing == frozenset({"sess-a", "sess-b"})
+
+
+def test_agent_session_rows_existing_safe_when_db_missing(tmp_path, monkeypatch):
+    from api import models
+
+    monkeypatch.setattr(
+        models, "_active_state_db_path", lambda: tmp_path / "nope" / "state.db"
+    )
+    wanted = ["orphan-a", "orphan-b"]
+    assert models.agent_session_rows_existing(wanted) == frozenset(wanted)
+
+
+def test_agent_session_rows_existing_batches_over_500_ids(tmp_path, monkeypatch):
+    from api import models
+
+    home = tmp_path / "home"
+    home.mkdir()
+    ids = [f"sess-{i:04d}" for i in range(600)]
+    _make_state_db(home / "state.db", ids[:300])
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: home / "state.db")
+
+    existing = models.agent_session_rows_existing(ids)
+    assert existing == frozenset(ids[:300])
+
+
 # ── Orphan-prune decision predicate (mirrors the sidebar merge-loop guard) ──
 
 

--- a/tests/test_issue3238_orphaned_cli_sidecar_prune.py
+++ b/tests/test_issue3238_orphaned_cli_sidecar_prune.py
@@ -141,6 +141,18 @@ def test_agent_session_rows_existing_batches_over_500_ids(tmp_path, monkeypatch)
     assert existing == frozenset(ids[:300])
 
 
+def test_agent_session_rows_existing_normalizes_whitespace_in_probe_ids(tmp_path, monkeypatch):
+    from api import models
+
+    home = tmp_path / "home"
+    home.mkdir()
+    _make_state_db(home / "state.db", ["cli-padded"])
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: home / "state.db")
+
+    existing = models.agent_session_rows_existing(["  cli-padded  "])
+    assert existing == frozenset({"cli-padded"})
+
+
 # ── Orphan-prune decision predicate (mirrors the sidebar merge-loop guard) ──
 
 


### PR DESCRIPTION
## Summary
- Add `agent_session_rows_existing()` with chunked `IN (...)` lookups against agent `state.db`.
- Refactor the `/api/sessions` orphaned CLI sidecar prune path to batch probes per profile instead of opening one SQLite connection per candidate row.
- Keep the same safe-degrade semantics as `agent_session_row_exists()` (assume present on error/missing DB).

## Test plan
- [x] `pytest tests/test_issue3238_orphaned_cli_sidecar_prune.py -q --timeout=60`