### PR TITLE
perf(ui): single-pass sidebar session row partitioning

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4093,6 +4093,58 @@ function _resyncSessionVirtualWindowAfterRender(list, expectedScrollTop, virtual
   });
 }
 
+function _sidebarRowHasVisibleMessages(s, activeSidForSidebar){
+  return (s.message_count||0)>0 ||
+    _sessionAttentionState(s) ||
+    _isSessionEffectivelyStreaming(s) ||
+    !!s.active_stream_id ||
+    !!s.pending_user_message ||
+    (activeSidForSidebar&&s.session_id===activeSidForSidebar) ||
+    (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0);
+}
+
+function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
+  let webuiSessionCount=0;
+  let cliSessionCount=0;
+  for(const s of allMatched){
+    if(!_sidebarRowHasVisibleMessages(s, activeSidForSidebar)) continue;
+    if(_isCliSession(s)) cliSessionCount++;
+    else webuiSessionCount++;
+  }
+  if(_sessionSourceFilter==='cli' && !window._showCliSessions && cliSessionCount===0){
+    _sessionSourceFilter='webui';
+  }
+  const showCliOnly=_sessionSourceFilter==='cli';
+  const profileFiltered=[];
+  const projectFiltered=[];
+  const sessionsRaw=[];
+  let archivedCount=0;
+  for(const s of allMatched){
+    if(!_sidebarRowHasVisibleMessages(s, activeSidForSidebar)) continue;
+    const isCli=_isCliSession(s);
+    if(showCliOnly ? !isCli : isCli) continue;
+    if(s.default_hidden&&!(_activeProject&&_activeProject!==NO_PROJECT_FILTER&&s.project_id===_activeProject)) continue;
+    profileFiltered.push(s);
+    if(_activeProject===NO_PROJECT_FILTER){
+      if(s.project_id) continue;
+    } else if(_activeProject){
+      if(s.project_id!==_activeProject) continue;
+    }
+    projectFiltered.push(s);
+    if(s.archived) archivedCount++;
+    if(!_showArchived&&s.archived) continue;
+    sessionsRaw.push(s);
+  }
+  return {
+    webuiSessionCount,
+    cliSessionCount,
+    profileFiltered,
+    projectFiltered,
+    sessionsRaw,
+    archivedCount,
+  };
+}
+
 function renderSessionListFromCache(){
   // Don't re-render while user is actively renaming a session (would destroy the input)
   if(_renamingSid) return;
@@ -4115,49 +4167,15 @@ function renderSessionListFromCache(){
   // session id into another conversation, that content hit should still appear.
   const searchMatches=_sessionSearchMergeMatches(sidebarRows,searchQueryRaw,_contentSearchResults);
   const allMatched=_ensureActiveSessionRowPresent(searchMatches,sidebarRows);
-  // Keep inactive ephemeral 0-message sessions out of the sidebar — they only
-  // become real once the first message is sent. The server already filters them.
-  // Exception: the active freshly-created chat is injected above so it remains
-  // visible/selected until the user sends the first turn or switches away.
-  const withMessages=allMatched.filter(s=>
-    (s.message_count||0)>0 ||
-    _sessionAttentionState(s) ||
-    _isSessionEffectivelyStreaming(s) ||
-    !!s.active_stream_id ||
-    !!s.pending_user_message ||
-    (activeSidForSidebar&&s.session_id===activeSidForSidebar) ||
-    (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0)
-  );
-  const webuiSessionCount = withMessages.filter(s=>!_isCliSession(s)).length;
-  const cliSessionCount = withMessages.filter(s=>_isCliSession(s)).length;
-  if(_sessionSourceFilter==='cli' && !window._showCliSessions && cliSessionCount===0){
-    _sessionSourceFilter='webui';
-  }
-  const sourceFiltered = _sessionSourceFilter==='cli'
-    ? withMessages.filter(s=>_isCliSession(s))
-    : withMessages.filter(s=>!_isCliSession(s));
-  // The server is authoritative for profile scoping (#1611): it filters by
-  // active profile when no query param is set, and returns the aggregate when
-  // we send ?all_profiles=1. The renamed-root cross-alias (a row tagged
-  // 'default' matching active 'kinni' when kinni.is_default) lives server-side
-  // in _profiles_match, and a strict-equality client filter would reject those
-  // rows incorrectly. So we trust the wire data and skip the redundant client
-  // filter entirely.
-  const profileFiltered=sourceFiltered.filter(s=>
-    !s.default_hidden||(_activeProject&&_activeProject!==NO_PROJECT_FILTER&&s.project_id===_activeProject)
-  );
-  // Filter by active project. NO_PROJECT_FILTER sentinel asks for sessions
-  // with no project_id; otherwise filter to the matching project_id, or
-  // pass through when no filter is active.
-  const projectFiltered=
-    _activeProject===NO_PROJECT_FILTER
-      ?profileFiltered.filter(s=>!s.project_id)
-      :(_activeProject?profileFiltered.filter(s=>s.project_id===_activeProject):profileFiltered);
-  // Filter archived unless toggle is on
-  const sessionsRaw=_showArchived?projectFiltered:projectFiltered.filter(s=>!s.archived);
+  const {
+    webuiSessionCount,
+    cliSessionCount,
+    profileFiltered,
+    sessionsRaw,
+    archivedCount,
+  }=_partitionSidebarSessionRows(allMatched, activeSidForSidebar);
   const sessions=_attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw);
   _syncSidebarExpansionForActiveSession(sessions, activeSidForSidebar);
-  const archivedCount=projectFiltered.filter(s=>s.archived).length;
   const list=$('sessionList');
   const animateRefresh=_sessionListRefreshAnimationPending;
   _sessionListRefreshAnimationPending=false;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4116,7 +4116,6 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
   }
   const showCliOnly=_sessionSourceFilter==='cli';
   const profileFiltered=[];
-  const projectFiltered=[];
   const sessionsRaw=[];
   let archivedCount=0;
   for(const s of allMatched){
@@ -4130,7 +4129,6 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
     } else if(_activeProject){
       if(s.project_id!==_activeProject) continue;
     }
-    projectFiltered.push(s);
     if(s.archived) archivedCount++;
     if(!_showArchived&&s.archived) continue;
     sessionsRaw.push(s);
@@ -4139,7 +4137,6 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
     webuiSessionCount,
     cliSessionCount,
     profileFiltered,
-    projectFiltered,
     sessionsRaw,
     archivedCount,
   };

--- a/tests/test_issue2351_cli_session_source_filter.py
+++ b/tests/test_issue2351_cli_session_source_filter.py
@@ -18,10 +18,11 @@ def test_sidebar_has_separate_webui_and_cli_session_source_tabs():
 
 def test_cli_filter_keeps_cli_rows_out_of_default_webui_list():
     src = SESSIONS_JS.read_text(encoding="utf-8")
-    assert "const webuiSessionCount = withMessages.filter(s=>!_isCliSession(s)).length" in src
-    assert "const cliSessionCount = withMessages.filter(s=>_isCliSession(s)).length" in src
-    assert "? withMessages.filter(s=>_isCliSession(s))" in src
-    assert ": withMessages.filter(s=>!_isCliSession(s))" in src
+    assert "function _partitionSidebarSessionRows(allMatched, activeSidForSidebar)" in src
+    assert "webuiSessionCount" in src
+    assert "cliSessionCount" in src
+    assert "const showCliOnly=_sessionSourceFilter==='cli';" in src
+    assert "if(showCliOnly ? !isCli : isCli) continue;" in src
 
 
 def test_session_source_tabs_have_dedicated_sidebar_styles():

--- a/tests/test_issue3019_cron_project_sessions.py
+++ b/tests/test_issue3019_cron_project_sessions.py
@@ -91,4 +91,5 @@ def test_agent_side_cron_rows_keep_project_chip_visibility():
 def test_session_list_project_filter_can_reveal_default_hidden_cron_rows():
     src = ( __import__("pathlib").Path(__file__).parent.parent / "static" / "sessions.js").read_text(encoding="utf-8")
 
-    assert "!s.default_hidden||(_activeProject&&_activeProject!==NO_PROJECT_FILTER&&s.project_id===_activeProject)" in src
+    assert "function _partitionSidebarSessionRows(allMatched, activeSidForSidebar)" in src
+    assert "if(s.default_hidden&&!(_activeProject&&_activeProject!==NO_PROJECT_FILTER&&s.project_id===_activeProject)) continue;" in src

--- a/tests/test_sidebar_session_partition.py
+++ b/tests/test_sidebar_session_partition.py
@@ -1,0 +1,37 @@
+"""Regression coverage for single-pass sidebar session partitioning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _partition_block() -> str:
+    start = SESSIONS_JS.index("function _partitionSidebarSessionRows(")
+    end = SESSIONS_JS.index("function renderSessionListFromCache()", start)
+    return SESSIONS_JS[start:end]
+
+
+def test_render_uses_single_pass_partition_helper():
+    render_start = SESSIONS_JS.index("function renderSessionListFromCache()")
+    render_end = SESSIONS_JS.index("function _showProjectPicker", render_start)
+    render_body = SESSIONS_JS[render_start:render_end]
+
+    assert "_partitionSidebarSessionRows(allMatched, activeSidForSidebar)" in render_body
+    assert "withMessages.filter(" not in render_body
+
+
+def test_partition_helper_applies_message_source_project_and_archive_gates():
+    block = _partition_block()
+
+    assert "function _sidebarRowHasVisibleMessages(s, activeSidForSidebar)" in SESSIONS_JS
+    assert "_sidebarRowHasVisibleMessages(s, activeSidForSidebar)" in block
+    assert "if(_sessionSourceFilter==='cli' && !window._showCliSessions && cliSessionCount===0)" in block
+    assert "const showCliOnly=_sessionSourceFilter==='cli';" in block
+    assert "if(!_showArchived&&s.archived) continue;" in block
+    assert "if(s.archived) archivedCount++;" in block
+    assert "return {" in block
+    assert "profileFiltered," in block
+    assert "sessionsRaw," in block

--- a/tests/test_sidebar_unassigned_filter.py
+++ b/tests/test_sidebar_unassigned_filter.py
@@ -58,8 +58,11 @@ def test_unassigned_chip_filter_logic():
     assert "_activeProject===NO_PROJECT_FILTER" in js, (
         "renderSessionListFromCache must branch on the NO_PROJECT_FILTER sentinel"
     )
-    assert "profileFiltered.filter(s=>!s.project_id)" in js, (
+    assert "if(_activeProject===NO_PROJECT_FILTER){" in js, (
         "The Unassigned filter must select sessions without a project_id"
+    )
+    assert "if(s.project_id) continue;" in js, (
+        "The Unassigned filter must skip sessions with a project_id"
     )
 
 


### PR DESCRIPTION
## Summary
- Add `_partitionSidebarSessionRows()` to apply message/source/profile/project/archive gates in two passes over the matched session list.
- Replace the chained `.filter()` pipeline in `renderSessionListFromCache()` (previously 6–8 scans per refresh) while preserving existing sidebar semantics.

## Test plan
- [x] `pytest tests/test_sidebar_session_partition.py tests/test_issue2351_cli_session_source_filter.py tests/test_sidebar_unassigned_filter.py tests/test_active_empty_session_sidebar.py tests/test_issue500_session_list_virtualization.py tests/test_issue1611_session_profile_filtering.py -q --timeout=60`