### PR TITLE
perf(sessions): batch lineage report child fetch by parent ids

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -595,7 +595,10 @@ def read_session_lineage_report(db_path: Path, session_id: str | None, max_hops:
 
             segment_ids = {row['id'] for row in segments}
             child_rows: list[dict] = []
-            for parent in segments:
+            parent_ids = [row['id'] for row in segments]
+            children_by_parent: dict[str, list[dict]] = {pid: [] for pid in parent_ids}
+            if parent_ids:
+                placeholders = ','.join('?' * len(parent_ids))
                 cur.execute(
                     f"""
                     SELECT s.id,
@@ -607,13 +610,19 @@ def read_session_lineage_report(db_path: Path, session_id: str | None, max_hops:
                            {ended_expr},
                            {end_reason_expr}
                     FROM sessions s
-                    WHERE s.parent_session_id = ?
-                    ORDER BY s.started_at DESC
+                    WHERE s.parent_session_id IN ({placeholders})
                     """,
-                    (parent['id'],),
+                    parent_ids,
                 )
                 for child_row in cur.fetchall():
                     child = dict(child_row)
+                    parent_id = child.get('parent_session_id')
+                    if parent_id in children_by_parent:
+                        children_by_parent[parent_id].append(child)
+            for parent in segments:
+                parent_children = children_by_parent.get(parent['id'], [])
+                parent_children.sort(key=lambda row: row.get('started_at') or 0, reverse=True)
+                for child in parent_children:
                     if child['id'] in segment_ids:
                         continue
                     if _is_continuation_session(parent, child):

--- a/tests/test_session_lineage_report.py
+++ b/tests/test_session_lineage_report.py
@@ -265,15 +265,8 @@ def test_lineage_report_endpoint_returns_404_for_unknown_session(tmp_path):
     assert captured == {"status": 404, "message": "Session not found"}
 
 
-def test_lineage_report_batches_child_fetch_by_parent_ids():
-    import inspect
-
-    src = inspect.getsource(agent_sessions.read_session_lineage_report)
-    assert "WHERE s.parent_session_id IN ({placeholders})" in src
-    assert "WHERE s.parent_session_id = ?" not in src
-
-
 def test_lineage_report_preserves_child_order_for_each_segment_parent(tmp_path):
+    """Behavioural coverage for batched child fetch: started_at DESC per parent."""
     conn = _ensure_state_db(tmp_path / "state.db")
     t0 = time.time() - 200
     try:

--- a/tests/test_session_lineage_report.py
+++ b/tests/test_session_lineage_report.py
@@ -263,3 +263,37 @@ def test_lineage_report_endpoint_returns_404_for_unknown_session(tmp_path):
         routes.handle_get(handler, parsed)
 
     assert captured == {"status": 404, "message": "Session not found"}
+
+
+def test_lineage_report_batches_child_fetch_by_parent_ids():
+    import inspect
+
+    src = inspect.getsource(agent_sessions.read_session_lineage_report)
+    assert "WHERE s.parent_session_id IN ({placeholders})" in src
+    assert "WHERE s.parent_session_id = ?" not in src
+
+
+def test_lineage_report_preserves_child_order_for_each_segment_parent(tmp_path):
+    conn = _ensure_state_db(tmp_path / "state.db")
+    t0 = time.time() - 200
+    try:
+        _insert_state_row(conn, "lineage_report_root", started_at=t0, ended_at=t0 + 5, end_reason="compression")
+        _insert_state_row(
+            conn,
+            "lineage_report_tip",
+            parent="lineage_report_root",
+            started_at=t0 + 6,
+            ended_at=t0 + 15,
+            end_reason="user_stop",
+        )
+        _insert_state_row(conn, "lineage_report_child_old", parent="lineage_report_tip", started_at=t0 + 8)
+        _insert_state_row(conn, "lineage_report_child_new", parent="lineage_report_tip", started_at=t0 + 20)
+
+        report = agent_sessions.read_session_lineage_report(tmp_path / "state.db", "lineage_report_tip")
+
+        assert [child["session_id"] for child in report["children"]] == [
+            "lineage_report_child_new",
+            "lineage_report_child_old",
+        ]
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- Fetch lineage-report child rows with one `WHERE parent_session_id IN (...)` query instead of one query per segment parent.
- Preserve per-parent `started_at DESC` ordering and existing continuation/manual-review semantics in memory.

## Test plan
- [x] `pytest tests/test_session_lineage_report.py -q --timeout=60`