### PR TITLE
[security] fix cron output job id validation

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -10437,7 +10437,7 @@ def _handle_cron_output(handler, parsed):
     # Match the job_id boundary enforced by the newer cron history/detail
     # handlers.  This endpoint also builds CRON_OUT / job_id before globbing
     # markdown outputs, so reject traversal-shaped IDs before path resolution.
-    if not _re.fullmatch(r"[A-Za-z0-9_-][A-Za-z0-9_.-]{0,63}", job_id) or job_id in (".", ".."):
+    if not _re.fullmatch(r"[A-Za-z0-9_-][A-Za-z0-9_.-]{0,63}", job_id):
         return j(handler, {"error": "invalid job_id"}, status=400)
     # Reject malformed limit instead of letting int() raise ValueError and
     # surface as a confusing 500. Clamp to a safe range; a negative value must

--- a/api/routes.py
+++ b/api/routes.py
@@ -10428,11 +10428,17 @@ def _cron_output_snippet(text: str, limit: int = 600) -> str:
 
 def _handle_cron_output(handler, parsed):
     from cron.jobs import OUTPUT_DIR as CRON_OUT
+    import re as _re
 
     qs = parse_qs(parsed.query)
     job_id = qs.get("job_id", [""])[0]
     if not job_id:
         return j(handler, {"error": "job_id required"}, status=400)
+    # Match the job_id boundary enforced by the newer cron history/detail
+    # handlers.  This endpoint also builds CRON_OUT / job_id before globbing
+    # markdown outputs, so reject traversal-shaped IDs before path resolution.
+    if not _re.fullmatch(r"[A-Za-z0-9_-][A-Za-z0-9_.-]{0,63}", job_id) or job_id in (".", ".."):
+        return j(handler, {"error": "invalid job_id"}, status=400)
     # Reject malformed limit instead of letting int() raise ValueError and
     # surface as a confusing 500. Clamp to a safe range; a negative value must
     # never reach the slice below — files is sorted newest-first, so a negative

--- a/tests/test_sprint10.py
+++ b/tests/test_sprint10.py
@@ -2,6 +2,8 @@
 Sprint 10 Tests: server.py split, cancel endpoint, cron history, tool card polish.
 """
 import json, pathlib, urllib.error, urllib.request, urllib.parse
+from io import BytesIO
+
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
 from tests._pytest_port import BASE
@@ -23,6 +25,25 @@ def post(path, body=None):
             return json.loads(r.read()), r.status
     except urllib.error.HTTPError as e:
         return json.loads(e.read()), e.code
+
+
+class CaptureHandler:
+    headers = {}
+
+    def __init__(self):
+        self.status = None
+        self.response_headers = []
+        self.wfile = BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.response_headers.append((name, value))
+
+    def end_headers(self):
+        pass
+
 
 def make_session(created_list):
     d, _ = post("/api/session/new", {})
@@ -109,24 +130,6 @@ def test_crons_output_rejects_traversal_job_id(monkeypatch, tmp_path):
     """Cron output listing must not read markdown files outside OUTPUT_DIR."""
     from api.routes import _handle_cron_output
     import cron.jobs
-    from io import BytesIO
-
-    class CaptureHandler:
-        headers = {}
-
-        def __init__(self):
-            self.status = None
-            self.response_headers = []
-            self.wfile = BytesIO()
-
-        def send_response(self, status):
-            self.status = status
-
-        def send_header(self, name, value):
-            self.response_headers.append((name, value))
-
-        def end_headers(self):
-            pass
 
     output_dir = tmp_path / "cron" / "output"
     secret_dir = tmp_path / "memories"
@@ -149,24 +152,6 @@ def test_crons_output_still_returns_valid_job_outputs(monkeypatch, tmp_path):
     """Valid job ids still list recent markdown output content."""
     from api.routes import _handle_cron_output
     import cron.jobs
-    from io import BytesIO
-
-    class CaptureHandler:
-        headers = {}
-
-        def __init__(self):
-            self.status = None
-            self.response_headers = []
-            self.wfile = BytesIO()
-
-        def send_response(self, status):
-            self.status = status
-
-        def send_header(self, name, value):
-            self.response_headers.append((name, value))
-
-        def end_headers(self):
-            pass
 
     output_dir = tmp_path / "cron" / "output"
     job_dir = output_dir / "job_123"

--- a/tests/test_sprint10.py
+++ b/tests/test_sprint10.py
@@ -104,6 +104,85 @@ def test_crons_output_limit_param(cleanup_test_sessions):
     # 404 or 200 with empty -- both acceptable for nonexistent job
     assert status in (200, 404)
 
+
+def test_crons_output_rejects_traversal_job_id(monkeypatch, tmp_path):
+    """Cron output listing must not read markdown files outside OUTPUT_DIR."""
+    from api.routes import _handle_cron_output
+    import cron.jobs
+    from io import BytesIO
+
+    class CaptureHandler:
+        headers = {}
+
+        def __init__(self):
+            self.status = None
+            self.response_headers = []
+            self.wfile = BytesIO()
+
+        def send_response(self, status):
+            self.status = status
+
+        def send_header(self, name, value):
+            self.response_headers.append((name, value))
+
+        def end_headers(self):
+            pass
+
+    output_dir = tmp_path / "cron" / "output"
+    secret_dir = tmp_path / "memories"
+    output_dir.mkdir(parents=True)
+    secret_dir.mkdir()
+    (secret_dir / "MEMORY.md").write_text("SECRET_MARKDOWN_TOKEN\n", encoding="utf-8")
+    monkeypatch.setattr(cron.jobs, "OUTPUT_DIR", output_dir)
+
+    handler = CaptureHandler()
+    parsed = urllib.parse.urlparse("/api/crons/output?job_id=../../memories&limit=5")
+    _handle_cron_output(handler, parsed)
+
+    body = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert handler.status == 400
+    assert body == {"error": "invalid job_id"}
+    assert "SECRET_MARKDOWN_TOKEN" not in handler.wfile.getvalue().decode("utf-8")
+
+
+def test_crons_output_still_returns_valid_job_outputs(monkeypatch, tmp_path):
+    """Valid job ids still list recent markdown output content."""
+    from api.routes import _handle_cron_output
+    import cron.jobs
+    from io import BytesIO
+
+    class CaptureHandler:
+        headers = {}
+
+        def __init__(self):
+            self.status = None
+            self.response_headers = []
+            self.wfile = BytesIO()
+
+        def send_response(self, status):
+            self.status = status
+
+        def send_header(self, name, value):
+            self.response_headers.append((name, value))
+
+        def end_headers(self):
+            pass
+
+    output_dir = tmp_path / "cron" / "output"
+    job_dir = output_dir / "job_123"
+    job_dir.mkdir(parents=True)
+    (job_dir / "run.md").write_text("# Cron Job\n\n## Response\nexpected output\n", encoding="utf-8")
+    monkeypatch.setattr(cron.jobs, "OUTPUT_DIR", output_dir)
+
+    handler = CaptureHandler()
+    parsed = urllib.parse.urlparse("/api/crons/output?job_id=job_123&limit=5")
+    _handle_cron_output(handler, parsed)
+
+    body = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert handler.status == 200
+    assert body["job_id"] == "job_123"
+    assert body["outputs"] == [{"filename": "run.md", "content": "# Cron Job\n\n## Response\nexpected output\n"}]
+
 def test_cron_history_button_in_panels_js(cleanup_test_sessions):
     src, _ = get_text("/static/panels.js")
     # After the main-view refactor, cron runs load inline into the detail card


### PR DESCRIPTION
## Summary

This PR hardens a cron output listing variant of the job-id traversal family previously addressed in #1417.

`GET /api/crons/output` accepted the caller-supplied `job_id` and built `CRON_OUT / job_id` before globbing markdown output files. Unlike `/api/crons/history` and `/api/crons/run`, this endpoint did not validate the job id first, so traversal-shaped values could make the handler enumerate and return markdown files outside the cron output directory.

The patch applies the same job-id boundary already used by the newer cron history/detail handlers and adds regression coverage for both the rejected traversal case and a valid job output listing.

## Security issues covered

| Issue | Status |
| --- | --- |
| Cron output listing accepts traversal-shaped `job_id` values and can read markdown files outside the cron output directory | Fixed by validating `job_id` before constructing `CRON_OUT / job_id` |

## Before this PR

- `/api/crons/output?job_id=...` only checked that `job_id` was non-empty.
- The handler then evaluated `CRON_OUT / job_id` and globbed `*.md` files from that directory.
- A traversal-shaped id such as `../../memories` could select a sibling markdown directory relative to the cron output root and return matching file content through the API response.

## After this PR

- `/api/crons/output` rejects malformed or traversal-shaped `job_id` values with `400` before path construction.
- The validation mirrors `/api/crons/history` and `/api/crons/run` for consistent cron API behavior.
- Valid job ids continue to return recent markdown cron output content.

## Why this matters

Cron output APIs expose markdown run output to the WebUI. Because Hermes stores other sensitive user-facing state as markdown-like documents in nearby profile directories, accepting traversal-shaped job ids could turn a cron output preview endpoint into a local markdown file disclosure primitive.

The issue is limited by the endpoint's `*.md` glob and by the caller's ability to reach the WebUI API, but it still crosses the intended cron-output directory boundary.

## How this differs from #1417

#1417 already fixed the same trust-boundary family in two related endpoints:

- `_handle_cron_history`
- `_handle_cron_run_detail`

This PR covers a residual endpoint that remained outside that fix:

- `_handle_cron_output`

The vulnerable code path is different because it lists and returns recent output content from `CRON_OUT / job_id` directly. The prior fix does not protect this handler, so the same parameter boundary needs to be enforced here as well.

## Attack flow

1. A caller with access to the WebUI API requests `/api/crons/output`.
2. The caller supplies a traversal-shaped `job_id`, for example `../../memories`.
3. The vulnerable handler constructs `CRON_OUT / job_id` without validating the id.
4. The handler globs `*.md` files in the attacker-selected directory.
5. Matching markdown content is returned in the JSON `outputs` array.

## Affected code

- `api/routes.py`
  - `_handle_cron_output(handler, parsed)`

## Root cause

- `job_id` was treated as a directory name without enforcing the scheduler's expected id shape.
- The endpoint performed filesystem selection before validating that the caller-selected path represented a real cron output directory id.
- Related cron endpoints had already gained validation, but this listing endpoint had not.

## CVSS assessment

- Issue: cron output `job_id` traversal leading to markdown file disclosure
- CVSS v3.1: 6.5 Medium
- Vector: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N`
- Rationale: a network-reachable WebUI caller with API access can trigger the issue without user interaction; impact is bounded to confidentiality of readable markdown files selected through the traversal/glob behavior.

## Safe reproduction steps

A safe local reproduction can be performed with a temporary cron output root:

1. Point `cron.jobs.OUTPUT_DIR` at a temp directory such as `<tmp>/cron/output`.
2. Create a sibling markdown file such as `<tmp>/memories/MEMORY.md` containing a sentinel string.
3. Call `_handle_cron_output` with `/api/crons/output?job_id=../../memories&limit=5`.
4. On vulnerable code, the response is `200` and includes the sentinel markdown content.
5. With this PR, the same request returns `400` with `{"error": "invalid job_id"}`.

## Expected vulnerable behavior

On vulnerable code, the traversal-shaped `job_id` is accepted and the response can include content from markdown files outside the cron output directory.

## Changes in this PR

- Adds `job_id` shape validation to `_handle_cron_output`.
- Reuses the same regex boundary already applied in cron history/detail handlers.
- Returns `400` for malformed or traversal-shaped ids before path construction.
- Adds regression tests for the rejected traversal case and valid output behavior.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| API hardening | `api/routes.py` | Validate `job_id` in `_handle_cron_output` before using it as a path segment |
| Regression tests | `tests/test_sprint10.py` | Cover traversal rejection and valid job output listing |

## Maintainer impact

The change is intentionally narrow:

- It does not alter cron output file formats.
- It does not change successful responses for valid job ids.
- It makes `/api/crons/output` consistent with the existing validation in adjacent cron endpoints.

Clients that pass traversal-shaped or otherwise malformed job ids will now receive `400` instead of an empty or out-of-scope listing.

## Fix rationale

The cron API should treat `job_id` as an identifier, not a filesystem path. Enforcing the expected identifier shape at the parameter boundary is simpler and safer than trying to reason about path containment after an attacker-controlled directory has already been selected for globbing.

## Type of change

- [x] Security hardening
- [x] Bug fix
- [x] Regression tests
- [ ] Breaking change

## Test plan

Commands run:

```bash
python3 -m pytest tests/test_sprint10.py -k 'crons_output_rejects_traversal_job_id or crons_output_still_returns_valid_job_outputs' -q
python3 -m pytest tests/test_sprint10.py -q
```

Observed result:

- Focused regression tests: `2 passed, 22 deselected`
- Full `tests/test_sprint10.py`: `24 passed`

## Disclosure notes

This PR is intentionally bounded to a residual cron-output listing variant of the already-public job-id traversal hardening family in #1417. It does not claim broader arbitrary file read beyond the endpoint's markdown glob behavior and the caller's WebUI API access.
