### PR TITLE
feat(profiles): hide worker profiles from chat picker (#3623)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Profiles can now opt out of the chat picker with `visible: false` in `profile.yaml`.** Hidden profiles remain available in the Profiles management panel, where they are labeled as hidden from chat. (#3623, @rodboev)
+
 ## [v0.51.272] — 2026-06-05 — Release IN (stage-p3a — conflict-safe self-update recovery)
 
 ### Fixed

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -19,6 +19,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
 
+import yaml
+
 from api.session_events import publish_session_list_changed
 
 logger = logging.getLogger(__name__)
@@ -1094,11 +1096,27 @@ def list_profiles_api() -> list:
             'model': p.model,
             'provider': p.provider,
             'has_env': p.has_env,
+            'visible': _profile_visible_from_meta(p.path),
             'skill_count': enabled_count,
             'enabled_skills': enabled_count,
             'total_skills': total_count,
         })
     return result
+
+
+def _profile_visible_from_meta(profile_path: Path) -> bool:
+    """Return False only for an explicit boolean ``visible: false`` in profile.yaml."""
+    try:
+        meta_path = Path(profile_path) / 'profile.yaml'
+        if not meta_path.exists():
+            return True
+        data = yaml.safe_load(meta_path.read_text(encoding='utf-8'))
+    except Exception:
+        return True
+    if not isinstance(data, dict):
+        return True
+    visible = data.get('visible')
+    return visible is not False
 
 
 def _default_profile_dict() -> dict:
@@ -1113,6 +1131,7 @@ def _default_profile_dict() -> dict:
         'model': None,
         'provider': None,
         'has_env': (_DEFAULT_HERMES_HOME / '.env').exists(),
+        'visible': True,
         'skill_count': enabled_count,
         'enabled_skills': enabled_count,
         'total_skills': compatible_count,

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -16,7 +16,6 @@ import shutil
 import sys
 import threading
 from contextlib import contextmanager
-from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
@@ -1107,18 +1106,11 @@ def list_profiles_api() -> list:
 
 def _profile_visible_from_meta(profile_path: Path) -> bool:
     """Return False only for an explicit boolean ``visible: false`` in profile.yaml."""
-    meta_path = Path(profile_path) / 'profile.yaml'
     try:
-        stat = meta_path.stat()
-    except OSError:
-        return True
-    return _profile_visible_from_meta_cached(str(meta_path), stat.st_mtime_ns, stat.st_size)
-
-
-@lru_cache(maxsize=256)
-def _profile_visible_from_meta_cached(meta_path: str, mtime_ns: int, size: int) -> bool:
-    try:
-        data = yaml.safe_load(Path(meta_path).read_text(encoding='utf-8'))
+        meta_path = Path(profile_path) / 'profile.yaml'
+        if not meta_path.exists():
+            return True
+        data = yaml.safe_load(meta_path.read_text(encoding='utf-8'))
     except Exception:
         return True
     if not isinstance(data, dict):

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -16,6 +16,7 @@ import shutil
 import sys
 import threading
 from contextlib import contextmanager
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
@@ -1106,11 +1107,18 @@ def list_profiles_api() -> list:
 
 def _profile_visible_from_meta(profile_path: Path) -> bool:
     """Return False only for an explicit boolean ``visible: false`` in profile.yaml."""
+    meta_path = Path(profile_path) / 'profile.yaml'
     try:
-        meta_path = Path(profile_path) / 'profile.yaml'
-        if not meta_path.exists():
-            return True
-        data = yaml.safe_load(meta_path.read_text(encoding='utf-8'))
+        stat = meta_path.stat()
+    except OSError:
+        return True
+    return _profile_visible_from_meta_cached(str(meta_path), stat.st_mtime_ns, stat.st_size)
+
+
+@lru_cache(maxsize=256)
+def _profile_visible_from_meta_cached(meta_path: str, mtime_ns: int, size: int) -> bool:
+    try:
+        data = yaml.safe_load(Path(meta_path).read_text(encoding='utf-8'))
     except Exception:
         return True
     if not isinstance(data, dict):

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -1212,6 +1212,7 @@ const LOCALES = {
     profile_gateway_running: 'Gateway running',
     profile_gateway_stopped: 'Gateway stopped',
     profile_active: 'ACTIVE',
+    profile_hidden_from_chat: 'Hidden from chat',
     profile_no_configuration: 'No configuration',
     profile_skill_count: (count) => `${count} skill${count === 1 ? '' : 's'}`,
     profile_use: 'Use',

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -1212,7 +1212,6 @@ const LOCALES = {
     profile_gateway_running: 'Gateway running',
     profile_gateway_stopped: 'Gateway stopped',
     profile_active: 'ACTIVE',
-    profile_hidden_from_chat: 'Hidden from chat',
     profile_no_configuration: 'No configuration',
     profile_skill_count: (count) => `${count} skill${count === 1 ? '' : 's'}`,
     profile_use: 'Use',

--- a/static/panels.js
+++ b/static/panels.js
@@ -5109,10 +5109,11 @@ async function loadProfilesPanel() {
       const isActive = p.name === activeName;
       const activeBadge = isActive ? `<span style="color:var(--link);font-size:10px;font-weight:600;margin-left:6px">${esc(t('profile_active'))}</span>` : '';
       const defaultBadge = p.is_default ? ` <span style="opacity:.5">${esc(t('profile_default_label'))}</span>` : '';
+      const hiddenBadge = p.visible === false ? ' <span class="detail-badge" title="Hidden from chat">Hidden from chat</span>' : '';
       card.innerHTML = `
         <div class="profile-card-header">
           <div style="min-width:0;flex:1">
-            <div class="profile-card-name${isActive ? ' is-active' : ''}">${gwDot}${esc(p.name)}${defaultBadge}${activeBadge}</div>
+            <div class="profile-card-name${isActive ? ' is-active' : ''}">${gwDot}${esc(p.name)}${defaultBadge}${activeBadge}${hiddenBadge}</div>
             ${meta.length ? `<div class="profile-card-meta">${esc(meta.join(' \u00b7 '))}</div>` : `<div class="profile-card-meta">${esc(t('profile_no_configuration'))}</div>`}
           </div>
         </div>`;

--- a/static/panels.js
+++ b/static/panels.js
@@ -5257,10 +5257,11 @@ function renderProfileDropdown(data) {
   const dd = $('profileDropdown');
   if (!dd) return;
   dd.innerHTML = '';
-  const profiles = data.profiles || [];
-  const active = (S.activeProfile && profiles.some(p => p.name === S.activeProfile))
+  const allProfiles = data.profiles || [];
+  const active = (S.activeProfile && allProfiles.some(p => p.name === S.activeProfile))
     ? S.activeProfile
     : (data.active || 'default');
+  const profiles = allProfiles.filter(p => p && (p.visible !== false || p.name === active));
   for (const p of profiles) {
     const opt = document.createElement('div');
     opt.className = 'profile-opt' + (p.name === active ? ' active' : '');

--- a/static/panels.js
+++ b/static/panels.js
@@ -5109,11 +5109,10 @@ async function loadProfilesPanel() {
       const isActive = p.name === activeName;
       const activeBadge = isActive ? `<span style="color:var(--link);font-size:10px;font-weight:600;margin-left:6px">${esc(t('profile_active'))}</span>` : '';
       const defaultBadge = p.is_default ? ` <span style="opacity:.5">${esc(t('profile_default_label'))}</span>` : '';
-      const hiddenBadge = p.visible === false ? ` <span class="detail-badge" title="${esc(t('profile_hidden_from_chat'))}">${esc(t('profile_hidden_from_chat'))}</span>` : '';
       card.innerHTML = `
         <div class="profile-card-header">
           <div style="min-width:0;flex:1">
-            <div class="profile-card-name${isActive ? ' is-active' : ''}">${gwDot}${esc(p.name)}${defaultBadge}${activeBadge}${hiddenBadge}</div>
+            <div class="profile-card-name${isActive ? ' is-active' : ''}">${gwDot}${esc(p.name)}${defaultBadge}${activeBadge}</div>
             ${meta.length ? `<div class="profile-card-meta">${esc(meta.join(' \u00b7 '))}</div>` : `<div class="profile-card-meta">${esc(t('profile_no_configuration'))}</div>`}
           </div>
         </div>`;

--- a/static/panels.js
+++ b/static/panels.js
@@ -5109,10 +5109,11 @@ async function loadProfilesPanel() {
       const isActive = p.name === activeName;
       const activeBadge = isActive ? `<span style="color:var(--link);font-size:10px;font-weight:600;margin-left:6px">${esc(t('profile_active'))}</span>` : '';
       const defaultBadge = p.is_default ? ` <span style="opacity:.5">${esc(t('profile_default_label'))}</span>` : '';
+      const hiddenBadge = p.visible === false ? ` <span class="detail-badge" title="${esc(t('profile_hidden_from_chat'))}">${esc(t('profile_hidden_from_chat'))}</span>` : '';
       card.innerHTML = `
         <div class="profile-card-header">
           <div style="min-width:0;flex:1">
-            <div class="profile-card-name${isActive ? ' is-active' : ''}">${gwDot}${esc(p.name)}${defaultBadge}${activeBadge}</div>
+            <div class="profile-card-name${isActive ? ' is-active' : ''}">${gwDot}${esc(p.name)}${defaultBadge}${activeBadge}${hiddenBadge}</div>
             ${meta.length ? `<div class="profile-card-meta">${esc(meta.join(' \u00b7 '))}</div>` : `<div class="profile-card-meta">${esc(t('profile_no_configuration'))}</div>`}
           </div>
         </div>`;

--- a/tests/test_issue3623_profile_visibility.py
+++ b/tests/test_issue3623_profile_visibility.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _profile_row(name: str, path: Path, *, is_default: bool = False):
+    return SimpleNamespace(
+        name=name,
+        path=path,
+        is_default=is_default,
+        gateway_running=False,
+        model=None,
+        provider=None,
+        has_env=False,
+    )
+
+
+def _install_fake_hermes_profiles(monkeypatch, rows):
+    hermes_cli = types.ModuleType("hermes_cli")
+    profiles_mod = types.ModuleType("hermes_cli.profiles")
+    profiles_mod.list_profiles = lambda: rows
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.profiles", profiles_mod)
+
+
+def test_profile_yaml_visible_false_is_exposed_as_hidden(monkeypatch, tmp_path):
+    import api.profiles as profiles
+
+    hidden = tmp_path / "profiles" / "worker-coder"
+    visible = tmp_path / "profiles" / "human"
+    missing = tmp_path / "profiles" / "missing-meta"
+    malformed = tmp_path / "profiles" / "malformed"
+    string_false = tmp_path / "profiles" / "string-false"
+    for path in (hidden, visible, missing, malformed, string_false):
+        path.mkdir(parents=True)
+    (hidden / "profile.yaml").write_text("visible: false\n", encoding="utf-8")
+    (visible / "profile.yaml").write_text("visible: true\n", encoding="utf-8")
+    (malformed / "profile.yaml").write_text("visible: [\n", encoding="utf-8")
+    (string_false / "profile.yaml").write_text('visible: "false"\n', encoding="utf-8")
+
+    rows = [
+        _profile_row("worker-coder", hidden),
+        _profile_row("human", visible),
+        _profile_row("missing-meta", missing),
+        _profile_row("malformed", malformed),
+        _profile_row("string-false", string_false),
+    ]
+    _install_fake_hermes_profiles(monkeypatch, rows)
+    monkeypatch.setattr(profiles, "_get_profile_skills_stats", lambda _path: (0, 0))
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "human")
+
+    result = {row["name"]: row["visible"] for row in profiles.list_profiles_api()}
+
+    assert result == {
+        "worker-coder": False,
+        "human": True,
+        "missing-meta": True,
+        "malformed": True,
+        "string-false": True,
+    }
+
+
+def test_default_profile_fallback_stays_visible(monkeypatch):
+    import api.profiles as profiles
+
+    monkeypatch.setattr(profiles, "_get_profile_skills_stats", lambda _path: (0, 0))
+
+    assert profiles._default_profile_dict()["visible"] is True
+
+
+def _panels_js() -> str:
+    return (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.find(signature)
+    assert start != -1, f"{signature} not found"
+    i = src.find("{", start)
+    depth = 0
+    for j in range(i, len(src)):
+        if src[j] == "{":
+            depth += 1
+        elif src[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : j + 1]
+    raise AssertionError(f"could not find end of {signature}")
+
+
+def test_profile_dropdown_filters_hidden_profiles_but_preserves_active():
+    body = _function_body(_panels_js(), "function renderProfileDropdown(data)")
+
+    assert "const allProfiles = data.profiles || [];" in body
+    assert "allProfiles.some(p => p.name === S.activeProfile)" in body
+    assert "const profiles = allProfiles.filter(p => p && (p.visible !== false || p.name === active));" in body
+
+
+def test_profiles_management_panel_still_renders_all_profiles():
+    body = _function_body(_panels_js(), "async function loadProfilesPanel()")
+
+    assert "for (const p of data.profiles)" in body
+    assert "visible !== false" not in body

--- a/tests/test_issue3623_profile_visibility.py
+++ b/tests/test_issue3623_profile_visibility.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import sys
-import subprocess
-import textwrap
 import types
 from pathlib import Path
 from types import SimpleNamespace
@@ -31,10 +29,9 @@ def _install_fake_hermes_profiles(monkeypatch, rows):
     monkeypatch.setitem(sys.modules, "hermes_cli.profiles", profiles_mod)
 
 
-def test_api_visible_flag_from_profile_yaml(monkeypatch, tmp_path):
+def test_profile_yaml_visible_false_is_exposed_as_hidden(monkeypatch, tmp_path):
     import api.profiles as profiles
 
-    profiles._profile_visible_from_meta_cached.cache_clear()
     hidden = tmp_path / "profiles" / "worker-coder"
     visible = tmp_path / "profiles" / "human"
     missing = tmp_path / "profiles" / "missing-meta"
@@ -68,11 +65,8 @@ def test_api_visible_flag_from_profile_yaml(monkeypatch, tmp_path):
         "string-false": True,
     }
 
-    (hidden / "profile.yaml").write_text("visible: true\n", encoding="utf-8")
-    assert profiles._profile_visible_from_meta(hidden) is True
 
-
-def test_default_profile_is_visible(monkeypatch):
+def test_default_profile_fallback_stays_visible(monkeypatch):
     import api.profiles as profiles
 
     monkeypatch.setattr(profiles, "_get_profile_skills_stats", lambda _path: (0, 0))
@@ -84,169 +78,31 @@ def _panels_js() -> str:
     return (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 
 
-def _run_node(script: str) -> None:
-    result = subprocess.run(
-        ["node", "-e", textwrap.dedent(script)],
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    assert result.returncode == 0, result.stdout + result.stderr
+def _function_body(src: str, signature: str) -> str:
+    start = src.find(signature)
+    assert start != -1, f"{signature} not found"
+    i = src.find("{", start)
+    depth = 0
+    for j in range(i, len(src)):
+        if src[j] == "{":
+            depth += 1
+        elif src[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : j + 1]
+    raise AssertionError(f"could not find end of {signature}")
 
 
-def test_dropdown_filters_hidden_profiles():
-    _run_node(
-        r"""
-        const fs = require('fs');
-        const src = fs.readFileSync('static/panels.js', 'utf8');
+def test_profile_dropdown_filters_hidden_profiles_but_preserves_active():
+    body = _function_body(_panels_js(), "function renderProfileDropdown(data)")
 
-        function extractFunction(signature) {
-          const start = src.indexOf(signature);
-          if (start < 0) throw new Error(signature + ' not found');
-          const open = src.indexOf('{', start);
-          let depth = 0;
-          for (let i = open; i < src.length; i++) {
-            if (src[i] === '{') depth++;
-            else if (src[i] === '}') {
-              depth--;
-              if (depth === 0) return src.slice(start, i + 1);
-            }
-          }
-          throw new Error('could not find end of ' + signature);
-        }
-
-        const dropdown = {
-          children: [],
-          _html: '',
-          set innerHTML(value) { this._html = value; if (value === '') this.children = []; },
-          get innerHTML() { return this._html; },
-          appendChild(el) { this.children.push(el); },
-        };
-        function $(id) { return id === 'profileDropdown' ? dropdown : null; }
-        const S = { activeProfile: 'worker-active' };
-        const document = {
-          createElement() {
-            return {
-              className: '',
-              _html: '',
-              set innerHTML(value) { this._html = value; },
-              get innerHTML() { return this._html; },
-              onclick: null,
-            };
-          },
-        };
-        function esc(value) { return String(value); }
-        function t(key, value) { return key === 'profile_skill_count' ? `${value} skills` : key; }
-        function li() { return ''; }
-        function closeProfileDropdown() {}
-        function switchToProfile() {}
-        function mobileSwitchPanel() {}
-
-        eval(extractFunction('function renderProfileDropdown(data)'));
-        renderProfileDropdown({
-          active: 'worker-active',
-          profiles: [
-            { name: 'worker-idle', visible: false, gateway_running: false },
-            { name: 'worker-active', visible: false, gateway_running: false },
-            { name: 'human', visible: true, gateway_running: true },
-          ],
-        });
-
-        const profileOptions = dropdown.children.filter((child) => (
-          child.className.startsWith('profile-opt') && !child.className.includes('ws-manage')
-        ));
-        const html = profileOptions.map((child) => child.innerHTML).join('\n');
-        if (profileOptions.length !== 2) throw new Error('expected two rendered profile options');
-        if (!html.includes('worker-active')) throw new Error('active hidden profile was not preserved');
-        if (!html.includes('human')) throw new Error('visible profile was not rendered');
-        if (html.includes('worker-idle')) throw new Error('inactive hidden profile was rendered');
-        if (!profileOptions[0].className.includes('active')) throw new Error('active option was not marked active');
-        """
-    )
+    assert "const allProfiles = data.profiles || [];" in body
+    assert "allProfiles.some(p => p.name === S.activeProfile)" in body
+    assert "const profiles = allProfiles.filter(p => p && (p.visible !== false || p.name === active));" in body
 
 
-def test_profiles_panel_marks_hidden_profiles():
-    _run_node(
-        r"""
-        const fs = require('fs');
-        const src = fs.readFileSync('static/panels.js', 'utf8');
+def test_profiles_management_panel_still_renders_all_profiles():
+    body = _function_body(_panels_js(), "async function loadProfilesPanel()")
 
-        function extractFunction(signature) {
-          const start = src.indexOf(signature);
-          if (start < 0) throw new Error(signature + ' not found');
-          const open = src.indexOf('{', start);
-          let depth = 0;
-          for (let i = open; i < src.length; i++) {
-            if (src[i] === '{') depth++;
-            else if (src[i] === '}') {
-              depth--;
-              if (depth === 0) return src.slice(start, i + 1);
-            }
-          }
-          throw new Error('could not find end of ' + signature);
-        }
-
-        const panel = {
-          children: [],
-          _html: '',
-          set innerHTML(value) { this._html = value; if (value === '') this.children = []; },
-          get innerHTML() { return this._html; },
-          appendChild(el) { this.children.push(el); },
-        };
-        function $(id) { return id === 'profilesPanel' ? panel : null; }
-        var _profilesCache = null;
-        var _profileMode = 'read';
-        var _currentProfileDetail = null;
-        const S = { activeProfile: 'human' };
-        const document = {
-          createElement() {
-            return {
-              className: '',
-              dataset: {},
-              style: {},
-              _html: '',
-              set innerHTML(value) { this._html = value; },
-              get innerHTML() { return this._html; },
-              onclick: null,
-            };
-          },
-        };
-        function esc(value) { return String(value); }
-        function t(key, value) {
-          const labels = {
-            profile_active: 'ACTIVE',
-            profile_hidden_from_chat: 'Hidden from chat',
-            profile_no_configuration: 'No configuration',
-            profile_gateway_running: 'Gateway running',
-            profile_gateway_stopped: 'Gateway stopped',
-            profile_skill_count: `${value} skills`,
-          };
-          return labels[key] || key;
-        }
-        async function api() {
-          return {
-            active: 'human',
-            profiles: [
-              { name: 'worker-idle', visible: false, gateway_running: false },
-              { name: 'human', visible: true, gateway_running: true },
-            ],
-          };
-        }
-
-        eval(extractFunction('async function loadProfilesPanel()'));
-        (async () => {
-          await loadProfilesPanel();
-          const cards = panel.children.filter((child) => child.dataset && child.dataset.name);
-          const names = cards.map((card) => card.dataset.name).sort().join(',');
-          if (names !== 'human,worker-idle') throw new Error('management panel did not render all profiles: ' + names);
-          const hidden = cards.find((card) => card.dataset.name === 'worker-idle');
-          const human = cards.find((card) => card.dataset.name === 'human');
-          if (!hidden.innerHTML.includes('Hidden from chat')) throw new Error('hidden management badge missing');
-          if (human.innerHTML.includes('Hidden from chat')) throw new Error('visible profile was marked hidden');
-        })().catch((err) => {
-          console.error(err.stack || err.message);
-          process.exit(1);
-        });
-        """
-    )
+    assert "for (const p of data.profiles)" in body
+    assert "visible !== false" not in body

--- a/tests/test_issue3623_profile_visibility.py
+++ b/tests/test_issue3623_profile_visibility.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import sys
+import subprocess
+import textwrap
 import types
 from pathlib import Path
 from types import SimpleNamespace
@@ -32,6 +34,7 @@ def _install_fake_hermes_profiles(monkeypatch, rows):
 def test_profile_yaml_visible_false_is_exposed_as_hidden(monkeypatch, tmp_path):
     import api.profiles as profiles
 
+    profiles._profile_visible_from_meta_cached.cache_clear()
     hidden = tmp_path / "profiles" / "worker-coder"
     visible = tmp_path / "profiles" / "human"
     missing = tmp_path / "profiles" / "missing-meta"
@@ -66,6 +69,21 @@ def test_profile_yaml_visible_false_is_exposed_as_hidden(monkeypatch, tmp_path):
     }
 
 
+def test_profile_yaml_visibility_cache_invalidates_when_file_changes(tmp_path):
+    import api.profiles as profiles
+
+    profiles._profile_visible_from_meta_cached.cache_clear()
+    profile = tmp_path / "profiles" / "worker-coder"
+    profile.mkdir(parents=True)
+    meta = profile / "profile.yaml"
+
+    meta.write_text("visible: false\n", encoding="utf-8")
+    assert profiles._profile_visible_from_meta(profile) is False
+
+    meta.write_text("visible: true\n", encoding="utf-8")
+    assert profiles._profile_visible_from_meta(profile) is True
+
+
 def test_default_profile_fallback_stays_visible(monkeypatch):
     import api.profiles as profiles
 
@@ -78,31 +96,169 @@ def _panels_js() -> str:
     return (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 
 
-def _function_body(src: str, signature: str) -> str:
-    start = src.find(signature)
-    assert start != -1, f"{signature} not found"
-    i = src.find("{", start)
-    depth = 0
-    for j in range(i, len(src)):
-        if src[j] == "{":
-            depth += 1
-        elif src[j] == "}":
-            depth -= 1
-            if depth == 0:
-                return src[start : j + 1]
-    raise AssertionError(f"could not find end of {signature}")
+def _run_node(script: str) -> None:
+    result = subprocess.run(
+        ["node", "-e", textwrap.dedent(script)],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_profile_dropdown_filters_hidden_profiles_but_preserves_active():
-    body = _function_body(_panels_js(), "function renderProfileDropdown(data)")
+    _run_node(
+        r"""
+        const fs = require('fs');
+        const src = fs.readFileSync('static/panels.js', 'utf8');
 
-    assert "const allProfiles = data.profiles || [];" in body
-    assert "allProfiles.some(p => p.name === S.activeProfile)" in body
-    assert "const profiles = allProfiles.filter(p => p && (p.visible !== false || p.name === active));" in body
+        function extractFunction(signature) {
+          const start = src.indexOf(signature);
+          if (start < 0) throw new Error(signature + ' not found');
+          const open = src.indexOf('{', start);
+          let depth = 0;
+          for (let i = open; i < src.length; i++) {
+            if (src[i] === '{') depth++;
+            else if (src[i] === '}') {
+              depth--;
+              if (depth === 0) return src.slice(start, i + 1);
+            }
+          }
+          throw new Error('could not find end of ' + signature);
+        }
+
+        const dropdown = {
+          children: [],
+          _html: '',
+          set innerHTML(value) { this._html = value; if (value === '') this.children = []; },
+          get innerHTML() { return this._html; },
+          appendChild(el) { this.children.push(el); },
+        };
+        function $(id) { return id === 'profileDropdown' ? dropdown : null; }
+        const S = { activeProfile: 'worker-active' };
+        const document = {
+          createElement() {
+            return {
+              className: '',
+              _html: '',
+              set innerHTML(value) { this._html = value; },
+              get innerHTML() { return this._html; },
+              onclick: null,
+            };
+          },
+        };
+        function esc(value) { return String(value); }
+        function t(key, value) { return key === 'profile_skill_count' ? `${value} skills` : key; }
+        function li() { return ''; }
+        function closeProfileDropdown() {}
+        function switchToProfile() {}
+        function mobileSwitchPanel() {}
+
+        eval(extractFunction('function renderProfileDropdown(data)'));
+        renderProfileDropdown({
+          active: 'worker-active',
+          profiles: [
+            { name: 'worker-idle', visible: false, gateway_running: false },
+            { name: 'worker-active', visible: false, gateway_running: false },
+            { name: 'human', visible: true, gateway_running: true },
+          ],
+        });
+
+        const profileOptions = dropdown.children.filter((child) => (
+          child.className.startsWith('profile-opt') && !child.className.includes('ws-manage')
+        ));
+        const html = profileOptions.map((child) => child.innerHTML).join('\n');
+        if (profileOptions.length !== 2) throw new Error('expected two rendered profile options');
+        if (!html.includes('worker-active')) throw new Error('active hidden profile was not preserved');
+        if (!html.includes('human')) throw new Error('visible profile was not rendered');
+        if (html.includes('worker-idle')) throw new Error('inactive hidden profile was rendered');
+        if (!profileOptions[0].className.includes('active')) throw new Error('active option was not marked active');
+        """
+    )
 
 
-def test_profiles_management_panel_still_renders_all_profiles():
-    body = _function_body(_panels_js(), "async function loadProfilesPanel()")
+def test_profiles_management_panel_renders_all_profiles_and_marks_hidden():
+    _run_node(
+        r"""
+        const fs = require('fs');
+        const src = fs.readFileSync('static/panels.js', 'utf8');
 
-    assert "for (const p of data.profiles)" in body
-    assert "visible !== false" not in body
+        function extractFunction(signature) {
+          const start = src.indexOf(signature);
+          if (start < 0) throw new Error(signature + ' not found');
+          const open = src.indexOf('{', start);
+          let depth = 0;
+          for (let i = open; i < src.length; i++) {
+            if (src[i] === '{') depth++;
+            else if (src[i] === '}') {
+              depth--;
+              if (depth === 0) return src.slice(start, i + 1);
+            }
+          }
+          throw new Error('could not find end of ' + signature);
+        }
+
+        const panel = {
+          children: [],
+          _html: '',
+          set innerHTML(value) { this._html = value; if (value === '') this.children = []; },
+          get innerHTML() { return this._html; },
+          appendChild(el) { this.children.push(el); },
+        };
+        function $(id) { return id === 'profilesPanel' ? panel : null; }
+        var _profilesCache = null;
+        var _profileMode = 'read';
+        var _currentProfileDetail = null;
+        const S = { activeProfile: 'human' };
+        const document = {
+          createElement() {
+            return {
+              className: '',
+              dataset: {},
+              style: {},
+              _html: '',
+              set innerHTML(value) { this._html = value; },
+              get innerHTML() { return this._html; },
+              onclick: null,
+            };
+          },
+        };
+        function esc(value) { return String(value); }
+        function t(key, value) {
+          const labels = {
+            profile_active: 'ACTIVE',
+            profile_hidden_from_chat: 'Hidden from chat',
+            profile_no_configuration: 'No configuration',
+            profile_gateway_running: 'Gateway running',
+            profile_gateway_stopped: 'Gateway stopped',
+            profile_skill_count: `${value} skills`,
+          };
+          return labels[key] || key;
+        }
+        async function api() {
+          return {
+            active: 'human',
+            profiles: [
+              { name: 'worker-idle', visible: false, gateway_running: false },
+              { name: 'human', visible: true, gateway_running: true },
+            ],
+          };
+        }
+
+        eval(extractFunction('async function loadProfilesPanel()'));
+        (async () => {
+          await loadProfilesPanel();
+          const cards = panel.children.filter((child) => child.dataset && child.dataset.name);
+          const names = cards.map((card) => card.dataset.name).sort().join(',');
+          if (names !== 'human,worker-idle') throw new Error('management panel did not render all profiles: ' + names);
+          const hidden = cards.find((card) => card.dataset.name === 'worker-idle');
+          const human = cards.find((card) => card.dataset.name === 'human');
+          if (!hidden.innerHTML.includes('Hidden from chat')) throw new Error('hidden management badge missing');
+          if (human.innerHTML.includes('Hidden from chat')) throw new Error('visible profile was marked hidden');
+        })().catch((err) => {
+          console.error(err.stack || err.message);
+          process.exit(1);
+        });
+        """
+    )

--- a/tests/test_issue3623_profile_visibility.py
+++ b/tests/test_issue3623_profile_visibility.py
@@ -31,7 +31,7 @@ def _install_fake_hermes_profiles(monkeypatch, rows):
     monkeypatch.setitem(sys.modules, "hermes_cli.profiles", profiles_mod)
 
 
-def test_profile_yaml_visible_false_is_exposed_as_hidden(monkeypatch, tmp_path):
+def test_api_visible_flag_from_profile_yaml(monkeypatch, tmp_path):
     import api.profiles as profiles
 
     profiles._profile_visible_from_meta_cached.cache_clear()
@@ -68,23 +68,11 @@ def test_profile_yaml_visible_false_is_exposed_as_hidden(monkeypatch, tmp_path):
         "string-false": True,
     }
 
-
-def test_profile_yaml_visibility_cache_invalidates_when_file_changes(tmp_path):
-    import api.profiles as profiles
-
-    profiles._profile_visible_from_meta_cached.cache_clear()
-    profile = tmp_path / "profiles" / "worker-coder"
-    profile.mkdir(parents=True)
-    meta = profile / "profile.yaml"
-
-    meta.write_text("visible: false\n", encoding="utf-8")
-    assert profiles._profile_visible_from_meta(profile) is False
-
-    meta.write_text("visible: true\n", encoding="utf-8")
-    assert profiles._profile_visible_from_meta(profile) is True
+    (hidden / "profile.yaml").write_text("visible: true\n", encoding="utf-8")
+    assert profiles._profile_visible_from_meta(hidden) is True
 
 
-def test_default_profile_fallback_stays_visible(monkeypatch):
+def test_default_profile_is_visible(monkeypatch):
     import api.profiles as profiles
 
     monkeypatch.setattr(profiles, "_get_profile_skills_stats", lambda _path: (0, 0))
@@ -107,7 +95,7 @@ def _run_node(script: str) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_profile_dropdown_filters_hidden_profiles_but_preserves_active():
+def test_dropdown_filters_hidden_profiles():
     _run_node(
         r"""
         const fs = require('fs');
@@ -178,7 +166,7 @@ def test_profile_dropdown_filters_hidden_profiles_but_preserves_active():
     )
 
 
-def test_profiles_management_panel_renders_all_profiles_and_marks_hidden():
+def test_profiles_panel_marks_hidden_profiles():
     _run_node(
         r"""
         const fs = require('fs');


### PR DESCRIPTION

## Thinking Path

- Worker profiles are useful for orchestrator and Kanban dispatch flows, but they should not be presented as normal human chat targets.
- The existing profile metadata path already lives in each profile's `profile.yaml`, so a boolean `visible: false` flag is enough to express the intent without inventing a second settings surface.
- The API should still return every profile for management views, and only the chat profile dropdown should filter hidden profiles.

## What Changed

- `api/profiles.py`: reads boolean `visible` metadata from profile YAML and includes it in `/api/profiles` rows, defaulting to visible.
- `static/panels.js`: filters the topbar chat profile dropdown to exclude hidden profiles while preserving the active profile row.
- `tests/test_issue3623_profile_visibility.py`: pins the API response shape and frontend dropdown-only filtering contract.

## Why It Matters

Users with worker-only profiles can keep those profiles available for delegation and maintenance without cluttering the main chat profile selector.

## Verification

```
$env:PYTHONUTF8 = '1'
..\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_issue3623_profile_visibility.py -v --timeout=60
..\hermes-agent\venv\Scripts\python.exe -m pytest tests/ -v --timeout=60
```

## Risks / Follow-ups

- Hidden profiles remain visible in the management panel by design, so this does not create an access-control boundary.
- A future follow-up could add a UI toggle for editing this metadata, but this slice only honors `profile.yaml`.

## Model Used

GPT-5.5 via Codex CLI
