### PR TITLE
Release v0.51.287 — Release JC (stage-r22 — WeCom session classification #3653 + worker-profile picker hiding #3662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 ## [Unreleased]
 
+## [v0.51.287] — 2026-06-06 — Release JC (stage-r22 — WeCom session classification + worker-profile picker hiding)
+
+### Fixed
+- **WeCom gateway sessions are now classified as messaging conversations.** Rows arriving with raw sources `wecom` / `wecom_callback` are normalized into the messaging category (alongside weixin/telegram/discord/slack/email) and given proper "WeCom" / "WeCom Callback" display names, so they group and surface correctly in the sidebar. (#3653, @franksong2702)
+
+### Changed
+- **Worker profiles are hidden from the chat profile picker.** Worker profiles (used for orchestrator/Kanban dispatch) are no longer offered as normal human chat targets in the picker, while still appearing in the profile management view with a "Hidden from chat" badge. The active profile is never hidden. (#3662, @Chukwuebuka-20)
+
 ## [v0.51.286] — 2026-06-06 — Release JB (stage-r21 — sidebar tab reordering)
 
 ### Added

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -10,6 +10,8 @@ logger = logging.getLogger(__name__)
 MESSAGING_SOURCES = {
     'discord',
     'email',
+    'wecom',
+    'wecom_callback',
     'slack',
     'telegram',
     'weixin',
@@ -24,6 +26,8 @@ SOURCE_LABELS = {
     'cron': 'Cron',
     'discord': 'Discord',
     'email': 'Email',
+    'wecom': 'WeCom',
+    'wecom_callback': 'WeCom Callback',
     'slack': 'Slack',
     'telegram': 'Telegram',
     'tool': 'Tool',

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -19,6 +19,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
 
+import yaml
+
 from api.session_events import publish_session_list_changed
 
 logger = logging.getLogger(__name__)
@@ -1094,11 +1096,27 @@ def list_profiles_api() -> list:
             'model': p.model,
             'provider': p.provider,
             'has_env': p.has_env,
+            'visible': _profile_visible_from_meta(p.path),
             'skill_count': enabled_count,
             'enabled_skills': enabled_count,
             'total_skills': total_count,
         })
     return result
+
+
+def _profile_visible_from_meta(profile_path: Path) -> bool:
+    """Return False only for an explicit boolean ``visible: false`` in profile.yaml."""
+    try:
+        meta_path = Path(profile_path) / 'profile.yaml'
+        if not meta_path.exists():
+            return True
+        data = yaml.safe_load(meta_path.read_text(encoding='utf-8'))
+    except Exception:
+        return True
+    if not isinstance(data, dict):
+        return True
+    visible = data.get('visible')
+    return visible is not False
 
 
 def _default_profile_dict() -> dict:
@@ -1113,6 +1131,7 @@ def _default_profile_dict() -> dict:
         'model': None,
         'provider': None,
         'has_env': (_DEFAULT_HERMES_HOME / '.env').exists(),
+        'visible': True,
         'skill_count': enabled_count,
         'enabled_skills': enabled_count,
         'total_skills': compatible_count,

--- a/static/panels.js
+++ b/static/panels.js
@@ -5113,10 +5113,11 @@ async function loadProfilesPanel() {
       const isActive = p.name === activeName;
       const activeBadge = isActive ? `<span style="color:var(--link);font-size:10px;font-weight:600;margin-left:6px">${esc(t('profile_active'))}</span>` : '';
       const defaultBadge = p.is_default ? ` <span style="opacity:.5">${esc(t('profile_default_label'))}</span>` : '';
+      const hiddenBadge = p.visible === false ? ' <span class="detail-badge" title="Hidden from chat">Hidden from chat</span>' : '';
       card.innerHTML = `
         <div class="profile-card-header">
           <div style="min-width:0;flex:1">
-            <div class="profile-card-name${isActive ? ' is-active' : ''}">${gwDot}${esc(p.name)}${defaultBadge}${activeBadge}</div>
+            <div class="profile-card-name${isActive ? ' is-active' : ''}">${gwDot}${esc(p.name)}${defaultBadge}${activeBadge}${hiddenBadge}</div>
             ${meta.length ? `<div class="profile-card-meta">${esc(meta.join(' \u00b7 '))}</div>` : `<div class="profile-card-meta">${esc(t('profile_no_configuration'))}</div>`}
           </div>
         </div>`;
@@ -5261,10 +5262,11 @@ function renderProfileDropdown(data) {
   const dd = $('profileDropdown');
   if (!dd) return;
   dd.innerHTML = '';
-  const profiles = data.profiles || [];
-  const active = (S.activeProfile && profiles.some(p => p.name === S.activeProfile))
+  const allProfiles = data.profiles || [];
+  const active = (S.activeProfile && allProfiles.some(p => p.name === S.activeProfile))
     ? S.activeProfile
     : (data.active || 'default');
+  const profiles = allProfiles.filter(p => p && (p.visible !== false || p.name === active));
   for (const p of profiles) {
     const opt = document.createElement('div');
     opt.className = 'profile-opt' + (p.name === active ? ' active' : '');

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1096,13 +1096,15 @@ const _HANDOFF_THRESHOLD = 10;  // conversation rounds
 const _HANDOFF_STORAGE_PREFIX = 'handoff:';
 const _HANDOFF_SUFFIX_DISMISSED_AT = 'dismissed_at';
 const _HANDOFF_SUFFIX_SUMMARY_HANDLED_AT = 'summary_handled_at';
-const _MESSAGING_RAW_SOURCES = new Set(['weixin', 'telegram', 'discord', 'slack', 'email']);
+const _MESSAGING_RAW_SOURCES = new Set(['weixin', 'telegram', 'discord', 'slack', 'email', 'wecom', 'wecom_callback']);
 const _MESSAGING_SOURCE_LABELS = {
   weixin: 'WeChat',
   telegram: 'Telegram',
   discord: 'Discord',
   slack: 'Slack',
   email: 'Email',
+  wecom: 'WeCom',
+  wecom_callback: 'WeCom Callback',
 };
 
 function _isMessagingSession(session) {

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -12,6 +12,7 @@ Tests are ordered TDD-style:
 import json
 import os
 import pathlib
+import subprocess
 import sqlite3
 import time
 import urllib.error
@@ -798,6 +799,8 @@ def test_agent_session_source_normalization_contract():
     cases = {
         'cli': ('cli', 'CLI'),
         'email': ('messaging', 'Email'),
+        'wecom': ('messaging', 'WeCom'),
+        'wecom_callback': ('messaging', 'WeCom Callback'),
         'weixin': ('messaging', 'Weixin'),
         'telegram': ('messaging', 'Telegram'),
         'discord': ('messaging', 'Discord'),
@@ -823,8 +826,39 @@ def test_sessions_js_treats_email_as_messaging_source():
     """Email gateway sessions should receive the same sidebar metadata as other messaging channels."""
     src = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 
-    assert "'email'" in src[src.find("_MESSAGING_RAW_SOURCES"):src.find("function _isMessagingSession")]
-    assert "email: 'Email'" in src[src.find("_MESSAGING_SOURCE_LABELS"):src.find("function _isMessagingSession")]
+    raw_section = src[src.find("_MESSAGING_RAW_SOURCES"):src.find("function _isMessagingSession")]
+    label_section = src[src.find("_MESSAGING_SOURCE_LABELS"):src.find("function _isMessagingSession")]
+
+    for raw_source in ("email", "wecom", "wecom_callback"):
+        assert f"'{raw_source}'" in raw_section, f"Missing raw source {raw_source!r} in _MESSAGING_RAW_SOURCES"
+
+    assert "email: 'Email'" in label_section
+    assert "wecom: 'WeCom'" in label_section
+    assert "wecom_callback: 'WeCom Callback'" in label_section
+
+
+def test_sessions_js_treats_wecom_sidecars_as_messaging_behaviorally():
+    """Stale WeCom sidecars with session_source=other should still route as messaging."""
+    src = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+    start = src.index("const _MESSAGING_RAW_SOURCES")
+    end = src.index("/**", start)
+    block = src[start:end]
+    script = f"""
+{block}
+const cases = [
+  {{ session_source: 'other', source: 'wecom' }},
+  {{ session_source: 'other', raw_source: 'wecom_callback' }},
+  {{ session_source: 'other', source_tag: 'wecom' }},
+  {{ session_source: 'messaging', source: 'anything' }},
+];
+for (const c of cases) {{
+  if (!_isMessagingSession(c)) throw new Error('expected messaging for '+JSON.stringify(c));
+}}
+if (_isMessagingSession({{ session_source: 'other', source: 'cli' }})) {{
+  throw new Error('cli should not be treated as messaging');
+}}
+"""
+    subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
 
 
 def test_empty_active_gateway_session_does_not_hide_messaging_history(monkeypatch):

--- a/tests/test_issue3623_profile_visibility.py
+++ b/tests/test_issue3623_profile_visibility.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _profile_row(name: str, path: Path, *, is_default: bool = False):
+    return SimpleNamespace(
+        name=name,
+        path=path,
+        is_default=is_default,
+        gateway_running=False,
+        model=None,
+        provider=None,
+        has_env=False,
+    )
+
+
+def _install_fake_hermes_profiles(monkeypatch, rows):
+    hermes_cli = types.ModuleType("hermes_cli")
+    profiles_mod = types.ModuleType("hermes_cli.profiles")
+    profiles_mod.list_profiles = lambda: rows
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.profiles", profiles_mod)
+
+
+def test_profile_yaml_visible_false_is_exposed_as_hidden(monkeypatch, tmp_path):
+    import api.profiles as profiles
+
+    hidden = tmp_path / "profiles" / "worker-coder"
+    visible = tmp_path / "profiles" / "human"
+    missing = tmp_path / "profiles" / "missing-meta"
+    malformed = tmp_path / "profiles" / "malformed"
+    string_false = tmp_path / "profiles" / "string-false"
+    for path in (hidden, visible, missing, malformed, string_false):
+        path.mkdir(parents=True)
+    (hidden / "profile.yaml").write_text("visible: false\n", encoding="utf-8")
+    (visible / "profile.yaml").write_text("visible: true\n", encoding="utf-8")
+    (malformed / "profile.yaml").write_text("visible: [\n", encoding="utf-8")
+    (string_false / "profile.yaml").write_text('visible: "false"\n', encoding="utf-8")
+
+    rows = [
+        _profile_row("worker-coder", hidden),
+        _profile_row("human", visible),
+        _profile_row("missing-meta", missing),
+        _profile_row("malformed", malformed),
+        _profile_row("string-false", string_false),
+    ]
+    _install_fake_hermes_profiles(monkeypatch, rows)
+    monkeypatch.setattr(profiles, "_get_profile_skills_stats", lambda _path: (0, 0))
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "human")
+
+    result = {row["name"]: row["visible"] for row in profiles.list_profiles_api()}
+
+    assert result == {
+        "worker-coder": False,
+        "human": True,
+        "missing-meta": True,
+        "malformed": True,
+        "string-false": True,
+    }
+
+
+def test_default_profile_fallback_stays_visible(monkeypatch):
+    import api.profiles as profiles
+
+    monkeypatch.setattr(profiles, "_get_profile_skills_stats", lambda _path: (0, 0))
+
+    assert profiles._default_profile_dict()["visible"] is True
+
+
+def _panels_js() -> str:
+    return (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.find(signature)
+    assert start != -1, f"{signature} not found"
+    i = src.find("{", start)
+    depth = 0
+    for j in range(i, len(src)):
+        if src[j] == "{":
+            depth += 1
+        elif src[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : j + 1]
+    raise AssertionError(f"could not find end of {signature}")
+
+
+def test_profile_dropdown_filters_hidden_profiles_but_preserves_active():
+    body = _function_body(_panels_js(), "function renderProfileDropdown(data)")
+
+    assert "const allProfiles = data.profiles || [];" in body
+    assert "allProfiles.some(p => p.name === S.activeProfile)" in body
+    assert "const profiles = allProfiles.filter(p => p && (p.visible !== false || p.name === active));" in body
+
+
+def test_profiles_management_panel_still_renders_all_profiles():
+    body = _function_body(_panels_js(), "async function loadProfilesPanel()")
+
+    assert "for (const p of data.profiles)" in body
+    assert "visible !== false" not in body


### PR DESCRIPTION
# Release stage-r22 (v0.51.287) — WeCom session classification + worker-profile picker hiding

Two small, low-visible-risk medium-round PRs (both were CONFLICTING; self-rebased onto fresh
master, rebase fidelity verified identical to PR head). Both ship on dual-gate (backend-logic
with minimal visible surface).

## PRs
1. **#3653** (api/agent_sessions.py + static/sessions.js + test, 47L) — classify WeCom gateway
   sessions as messaging. `_MESSAGING_RAW_SOURCES` gains `wecom`/`wecom_callback`; display-name
   map gains "WeCom"/"WeCom Callback". Pure source-classification, no chrome change.
   RISK: confirm the new raw sources don't collide with existing classification and the
   server-side normalization in agent_sessions.py matches the client allowlist.

2. **#3662** (api/profiles.py + static/panels.js + test, 136L) — hide worker profiles from the
   chat profile picker. `profiles.py` exposes a `visible` flag (worker profiles → false);
   panels.js filters the PICKER to `p.visible !== false || p.name === active` (active profile
   never hidden) while the management view still lists them with a "Hidden from chat" badge.
   RISK: confirm a worker profile that IS the active profile still shows (no lockout), the filter
   can't hide ALL profiles, and the `visible` flag derivation is correct (worker-only).

## What to check
- Codex (regression): #3653 classification doesn't misroute non-WeCom sessions; #3662 filter
  can't empty the picker or hide the active/only profile; both server+client agree. SAFE TO SHIP
  or MUST-FIX.
- Opus (correctness): WeCom rows normalize correctly both server + client; worker-profile
  visibility derivation is correct and the active-profile escape hatch holds. Focused code read +
  one small targeted check only; do NOT write extensive reproduction harnesses.

Files: api/agent_sessions.py, api/profiles.py, static/sessions.js, static/panels.js,
tests/test_gateway_sync.py, tests/test_issue3623_profile_visibility.py.
