### PR TITLE
docs(changelog): stamp v0.51.289 (#3696 hotfix + scope gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+## [v0.51.289] — 2026-06-06 — Release JE (hotfix — sidebar ReferenceError #3696 + scope-undef prevention gate)
+
 ### Fixed
 - **Sidebar no longer crashes with `ReferenceError: _sessionAttentionState is not defined`.** The session-attention helper was declared *inside* `renderSessionListFromCache()` and relied on function hoisting, but the top-level `_sidebarRowHasVisibleMessages` (reached via `renderSessionListFromCache` → `_partitionSidebarSessionRows`) called it bare — and hoisting is scoped to the enclosing function, so every sidebar cache-render threw and the session list went blank. `_sessionAttentionState` is now a top-level function reachable by both call sites. Regressed in #3672 (v0.51.269). (#3696)
 - **Stale-stream terminal events no longer risk a `ReferenceError: source is not defined`.** `_bailOutOfTerminalEventsFromStaleStream` (declared inside `attachLiveStream`) called `_closeSource(source)` against a `source` that was not in its lexical scope — it would have thrown on the late-finalizing-stream path when the user is back in an active session. `source` is now threaded as an explicit parameter. Found by the new scope gate below during review. (#3696)


### PR DESCRIPTION
## What

Stamps the CHANGELOG `[Unreleased]` section to the **v0.51.289** release header.

The v0.51.289 tag (commit `da5bf69a`) ships the #3696 sidebar-crash hotfix + the `scope_undef_gate` prevention gate, merged in #3698. The code already landed on master; this is the CHANGELOG version stamp that accompanies the tag.

**Docs-only** — touches `CHANGELOG.md` exclusively, no code. The `[Unreleased]` bullets (sidebar `_sessionAttentionState` ReferenceError fix, the stale-stream `source`-param fix, and the new scope gate) are moved under the `## [v0.51.289]` header; a fresh empty `[Unreleased]` remains on top.

Relates to #3696, #3698.