### PR TITLE
[security] fix(git): anchor discard untracked deletes

### DIFF
--- a/api/workspace_git.py
+++ b/api/workspace_git.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import difflib
 import os
-import shutil
 import subprocess
 import tempfile
 import threading
@@ -18,7 +17,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-from api.workspace import safe_resolve_ws
+from api.workspace import rmtree_anchored, safe_resolve_ws, unlink_anchored
 
 
 GIT_TIMEOUT = 5
@@ -978,9 +977,16 @@ def git_discard(workspace: str | Path, paths: Iterable[str], *, delete_untracked
                     raise GitWorkspaceError("Untracked files require delete_untracked=true")
                 target = safe_resolve_ws(ctx.workspace, workspace_rel)
                 if target.is_dir():
-                    shutil.rmtree(target)
+                    rmtree_anchored(ctx.workspace, target)
                 else:
-                    target.unlink(missing_ok=True)
+                    try:
+                        unlink_anchored(ctx.workspace, target)
+                    except FileNotFoundError:
+                        # Preserve the previous Path.unlink(missing_ok=True)
+                        # behavior for benign races where another process
+                        # removes the untracked file after git_status() has
+                        # reported it but before this discard reaches unlink.
+                        pass
                 continue
             _run_git(ctx, ["restore", "--worktree", "--", repo_rel], check=True)
     return git_status(workspace)

--- a/tests/test_workspace_git.py
+++ b/tests/test_workspace_git.py
@@ -292,6 +292,33 @@ def test_git_status_reports_untracked_files_inside_directories(tmp_path):
     assert not (nested / "a.txt").exists()
 
 
+def test_git_discard_untracked_file_tolerates_concurrent_missing_file(tmp_path, monkeypatch):
+    import api.workspace_git as workspace_git
+
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "tracked.txt").write_text("one\n", encoding="utf-8")
+    _commit_all(repo)
+    transient = repo / "transient.txt"
+    transient.write_text("gone soon\n", encoding="utf-8")
+
+    original_unlink_anchored = workspace_git.unlink_anchored
+    raced = {"seen": False}
+
+    def remove_before_unlink(root, target):
+        if target == transient:
+            raced["seen"] = True
+            transient.unlink()
+        return original_unlink_anchored(root, target)
+
+    monkeypatch.setattr(workspace_git, "unlink_anchored", remove_before_unlink)
+
+    status = workspace_git.git_discard(repo, ["transient.txt"], delete_untracked=True)
+
+    assert raced["seen"] is True
+    assert not transient.exists()
+    assert status["totals"]["changed"] == 0
+
+
 def test_git_status_reports_ignored_files_without_counting_them_as_changed(tmp_path):
     from api.workspace_git import git_status
 
@@ -827,6 +854,48 @@ def test_git_routes_selected_commit_and_structured_error(cleanup_test_sessions):
     assert committed["ok"] is True
     assert committed["paths"] == ["selected.txt"]
     assert _git(repo, "show", "--name-only", "--format=", "HEAD").splitlines() == ["selected.txt"]
+
+
+def test_git_discard_untracked_delete_uses_anchored_unlink_after_validation_race(tmp_path, monkeypatch):
+    import os
+    import shutil
+
+    import api.workspace_git as workspace_git
+    from api.workspace import safe_resolve_ws as real_safe_resolve_ws
+
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+    _commit_all(repo)
+
+    (repo / "d").mkdir()
+    (repo / "d" / "f").write_text("workspace untracked\n", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "f"
+    victim.write_text("outside victim\n", encoding="utf-8")
+
+    state = {"calls": 0, "swapped": False}
+
+    def racing_safe_resolve(root, requested):
+        target = real_safe_resolve_ws(root, requested)
+        if requested == "d/f":
+            state["calls"] += 1
+        # git_discard validates once for the Git pathspec and once immediately
+        # before deletion. Race the second validation-to-use window.
+        if requested == "d/f" and state["calls"] == 2 and not state["swapped"]:
+            shutil.rmtree(repo / "d")
+            os.symlink(outside, repo / "d")
+            state["swapped"] = True
+        return target
+
+    monkeypatch.setattr(workspace_git, "safe_resolve_ws", racing_safe_resolve)
+
+    with pytest.raises(ValueError, match="Path traversal blocked"):
+        workspace_git.git_discard(repo, ["d/f"], delete_untracked=True)
+
+    assert state["swapped"] is True
+    assert victim.exists()
+    assert victim.read_text(encoding="utf-8") == "outside victim\n"
 
 
 def test_git_env_scrub_removes_redirecting_vars_and_preserves_temp_index(monkeypatch):


### PR DESCRIPTION
## Summary

This PR hardens the Git workspace discard boundary for untracked-file deletion.

- Fixes a validation-to-use symlink-swap window in `git_discard(..., delete_untracked=True)`.
- Reuses the existing workspace anchored deletion helpers instead of adding a separate Git-specific guard.
- Preserves the prior `missing_ok=True` behavior for benign races where an untracked file disappears before unlink.
- Adds regression coverage showing both the symlink-swap block and the concurrent-missing-file tolerance.
- This is a sibling hardening area to prior workspace symlink-containment work, but the affected code path here is `api/workspace_git.py` Git discard cleanup.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Git discard untracked-delete symlink race | A workspace-controlled path component can be swapped after validation so an untracked-file discard attempts to delete an outside path | Medium |

## Before this PR

- `git_discard()` resolved and validated the requested workspace path with `safe_resolve_ws()`.
- The untracked-delete branch then deleted through the resolved pathname with `Path.unlink()` or `shutil.rmtree()`.
- That left a race window between containment validation and filesystem use.
- There was no regression test proving Git discard untracked-delete stayed anchored at the workspace boundary under a symlink swap.

## After this PR

- Untracked-file deletion uses `unlink_anchored(ctx.workspace, target)` while still tolerating `FileNotFoundError` for benign concurrent removal.
- Untracked-directory deletion uses `rmtree_anchored(ctx.workspace, target)`.
- The final delete operation now shares the existing workspace anchored boundary instead of trusting only the earlier resolved pathname.
- A regression test simulates the validation-to-use race and locks in the blocked behavior.

## Why this matters

Hermes WebUI can expose workspace operations through the browser. A discard operation that deletes untracked paths should only affect files inside the configured workspace, even if another process can modify that workspace concurrently.

Before this fix, a local workspace writer could replace a validated path component with a symlink before the direct pathname delete occurred. In that race, Git discard cleanup could target a file outside the workspace boundary.

## How this differs from related issue/PR

I found related prior hardening work in #3450 for `api/routes.py` file-API endpoints.

This PR covers a different surface:

- component: `api/workspace_git.py`
- trigger: `git_discard(..., delete_untracked=True)`
- unsafe operation: direct pathname delete after workspace validation
- fix pattern: reuse existing anchored delete helpers for the Git discard cleanup path

The earlier route-file hardening does not cover this Git discard untracked-delete branch, so this small follow-up is still needed.

## Attack flow

```text
Workspace writer can modify path components during discard
    -> WebUI Git discard deletes an untracked path
        -> path is validated with safe_resolve_ws()
            -> path component is swapped to a symlink before direct pathname deletion
                -> delete can affect an outside file instead of staying inside the workspace
```

## Affected code

| Issue | Files |
|-------|-------|
| Git discard untracked-delete symlink race | `api/workspace_git.py`, `tests/test_workspace_git.py` |

## Root cause

Issue: Git discard untracked-delete symlink race

- The code correctly performed a workspace containment check before deletion.
- The final deletion still used the normal pathname APIs, so it could observe a different filesystem graph than the one validated earlier.
- The Git discard path did not reuse the existing anchored workspace deletion helpers, creating a sibling boundary that could drift from the rest of the workspace hardening.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Git discard untracked-delete symlink race | 5.0 Medium | `CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:C/C:N/I:L/A:H` |

Rationale:

- The attacker condition is local/workspace-adjacent: the attacker needs the ability to modify the workspace path during the discard operation.
- Exploitation also requires winning a race, so attack complexity is high.
- The impact is bounded to filesystem effects reachable through the raced delete path; the proof demonstrates outside-file deletion rather than code execution or secret disclosure.

## Safe reproduction steps

The issue was reproduced locally with a temporary workspace proof, without production paths or secrets:

1. Create a temporary Git repo workspace.
2. Create an untracked workspace file at `repo/d/f`.
3. Create an outside victim file at `outside/f`.
4. Patch `api.workspace_git.safe_resolve_ws` in the proof harness so that after `git_discard()` performs its second validation for `d/f`, the harness replaces `repo/d` with a symlink to `outside`.
5. Call the real `git_discard(repo, ["d/f"], delete_untracked=True)`.
6. Observe the pre-patch behavior deletes the outside victim file.

## Expected vulnerable behavior

Pre-patch proof signal:

```text
RESULT=OUTSIDE_FILE_DELETED
```

That signal means the untracked discard operation deleted the outside victim file after the path component was swapped between validation and use.

After this PR, the same raced path is blocked by the anchored helper:

```text
ValueError: Path traversal blocked
```

The regression test also asserts the outside victim file still exists and its contents are unchanged.

## Changes in this PR

- Imports `unlink_anchored` and `rmtree_anchored` from `api.workspace`.
- Replaces direct untracked-file deletion with `unlink_anchored(ctx.workspace, target)`.
- Replaces direct untracked-directory deletion with `rmtree_anchored(ctx.workspace, target)`.
- Removes the now-unused `shutil` import from `api/workspace_git.py`.
- Adds a regression test for the symlink-swap validation-to-use race in Git discard cleanup.
- Adds a regression test for the `missing_ok=True` compatibility path when an untracked file disappears concurrently.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Security fix | `api/workspace_git.py` | Reused anchored delete helpers for untracked Git discard cleanup |
| Tests | `tests/test_workspace_git.py` | Added race regression tests for outside-victim preservation and concurrent missing-file tolerance |

## Maintainer impact

- The patch is intentionally small and limited to untracked cleanup inside `git_discard()`; it keeps the previous benign missing-file behavior for ordinary concurrent-delete races.
- Tracked-file discard still delegates to `git restore`.
- No frontend, API schema, dependency, or public workflow changes are included.
- Reusing the existing workspace anchored helpers keeps this boundary aligned with the rest of the path-containment hardening and reduces future drift.

## Fix rationale

The security boundary being enforced is the configured workspace root. That boundary should hold at the point of deletion, not only at an earlier validation step.

Using the existing anchored helpers is the narrowest durable fix because those helpers already encode the repository's intended symlink-containment behavior for workspace deletes. The new test then exercises the specific Git discard branch that previously bypassed that final anchored operation.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Git discard regression test for the symlink-swap race.
- [x] Git discard regression test for concurrent untracked-file disappearance.
- [x] Existing workspace symlink containment tests.

Executed with:

```bash
python -m pytest tests/test_workspace_git.py tests/test_workspace_symlink_containment.py -q
```

Result:

```text
Running 50 items in this shard
.............................................s....                       [100%]
49 passed, 1 skipped, 1 warning in 11.91s
```

## Disclosure notes

- This PR is based on local code review and a safe temporary-workspace reproduction.
- No production systems, real user workspaces, or secrets were used.
- No unrelated files were changed.
- The patch intentionally shares the existing workspace anchored delete boundary instead of adding a parallel Git-specific implementation.

