### PR TITLE
Release v0.51.290 — Release JF (stage-s1 — profile provider/model resolution #3448 fixes #3405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.290] — 2026-06-06 — Release JF (stage-s1 — profile provider/model now respected in session resolution)
+
+### Fixed
+- **Profile-bound sessions now resolve their provider and model from the profile** instead of silently falling back to the global active provider. Previously, when a chat was started under a profile and the model string was not `@provider:`-qualified (and no explicit provider was sent), the backend used the catalog's global active provider — so a profile wired to one provider/key could silently run on a different one, causing **wrong credentials/billing** and **silent context truncation** (the global default model's advertised context window could differ from what the provider actually served, so the provider dropped the oldest messages and long chats "forgot" earlier content). Resolution is now authoritative from the profile across all four runtime entry points (chat start, streaming worker incl. background/btw runs, and both deferred `/api/session` display resolvers); stale models are still repaired under the profile provider — including the `openai-codex` profile + stale `openai/…` slash-model case — while native slash IDs on OpenRouter/custom providers are preserved and explicit `@provider:` qualifiers still win. (#3448, @rodboev; fixes #3405)
+
 ## [v0.51.289] — 2026-06-06 — Release JE (hotfix — sidebar ReferenceError #3696 + scope-undef prevention gate)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -1918,9 +1918,43 @@ def _should_attach_codex_provider_context(model: str, raw_active_provider: str, 
     return False
 
 
+def _read_profile_model_config(
+    session, requested_provider: str | None,
+) -> tuple[str | None, str | None]:
+    """Read model.provider and model.default from the session's profile config.
+
+    Returns (profile_provider, profile_default_model). Both are None when
+    the session has no profile, the profile config is unreadable, or an
+    explicit ``requested_provider`` is already set (profile should not
+    override explicit selections).
+    """
+    if _clean_session_model_provider(requested_provider) or not getattr(session, "profile", None):
+        return None, None
+    try:
+        from api.profiles import get_hermes_home_for_profile
+        _profile_home = get_hermes_home_for_profile(session.profile)
+        _profile_cfg_path = os.path.join(str(_profile_home), "config.yaml")
+        if not os.path.isfile(_profile_cfg_path):
+            return None, None
+        import yaml
+        with open(_profile_cfg_path, encoding="utf-8") as _f:
+            _pcfg = yaml.safe_load(_f) or {}
+        if not isinstance(_pcfg, dict):
+            return None, None
+        _provider = (_pcfg.get("model", {}).get("provider") or "").strip() or None
+        _default = (_pcfg.get("model", {}).get("default") or "").strip() or None
+        return _provider, _default
+    except Exception:
+        logger.warning("profile provider read failed for %r", getattr(session, "profile", None), exc_info=True)
+        return None, None
+
+
 def _resolve_compatible_session_model_state(
     model_id: str | None,
     model_provider: str | None = None,
+    *,
+    profile_provider: str | None = None,
+    profile_default_model: str | None = None,
 ) -> tuple[str, str | None, bool]:
     """Return (effective_model, effective_provider, model_was_normalized).
 
@@ -1960,6 +1994,55 @@ def _resolve_compatible_session_model_state(
 
     catalog = get_available_models()
     default_model = str(catalog.get("default_model") or DEFAULT_MODEL or "").strip()
+
+    # Profile-aware resolution: when the caller supplies profile context
+    # (not an explicit per-chat override), use the profile's provider and
+    # default model as the resolution context instead of the catalog's
+    # active_provider / default_model. This preserves the repair path
+    # (stale models still get normalized) but normalizes to the profile's
+    # default model under the profile's provider rather than the global default.
+    bare_model, explicit_provider = _split_provider_qualified_model(model) if model else ("", None)
+    if profile_provider and not explicit_provider:
+        _profile_provider_normalized = _normalize_provider_id(profile_provider)
+        _profile_default = str(profile_default_model or "").strip()
+        if not model:
+            _fallback = _profile_default or default_model
+            return _fallback, profile_provider, bool(_fallback)
+
+        model_prefix = model.split("/", 1)[0].strip().lower() if "/" in model else ""
+        model_provider_from_name = _normalize_provider_id(model_prefix) if "/" in model else ""
+
+        model_family = ""
+        model_lower = model.lower()
+        for bare_prefix in ("gpt", "claude", "gemini"):
+            if model_lower.startswith(bare_prefix):
+                model_family = _normalize_provider_id(bare_prefix)
+                break
+
+        if model_family and model_family != _profile_provider_normalized:
+            _target = _profile_default or default_model
+            return _target, profile_provider, True
+
+        if (
+            "/" in model
+            and str(profile_provider).strip().lower() == "openai-codex"
+            and model_provider_from_name == "openai"
+        ):
+            _target = _profile_default or default_model
+            return _target, profile_provider, True
+
+        # Slash-qualified models (e.g. openai/gpt-5.4-mini) are native IDs on
+        # OpenRouter and custom providers, not cross-provider artifacts. Only
+        # repair when the profile provider actually requires a different family.
+        if "/" in model and _profile_provider_normalized in {"openrouter", "custom", ""}:
+            return model, profile_provider, False
+
+        if "/" in model and model_provider_from_name and model_provider_from_name != _profile_provider_normalized:
+            _target = _profile_default or default_model
+            return _target, profile_provider, True
+
+        return model, profile_provider, False
+
     if not model:
         return default_model, requested_provider, bool(default_model)
 
@@ -2151,17 +2234,25 @@ def _resolve_effective_session_model_for_display(session) -> str:
     effective model for the response payload only and leave disk state alone.
     """
     original_model = getattr(session, "model", None) or ""
+    requested_provider = getattr(session, "model_provider", None)
+    _pp_provider, _pp_default = _read_profile_model_config(session, requested_provider)
     effective_model, _provider, _changed = _resolve_compatible_session_model_state(
         original_model or None,
-        getattr(session, "model_provider", None),
+        requested_provider,
+        profile_provider=_pp_provider,
+        profile_default_model=_pp_default,
     )
     return effective_model or original_model
 
 def _resolve_effective_session_model_provider_for_display(session) -> str | None:
     original_model = getattr(session, "model", None) or ""
+    requested_provider = getattr(session, "model_provider", None)
+    _pp_provider, _pp_default = _read_profile_model_config(session, requested_provider)
     _model, provider, _changed = _resolve_compatible_session_model_state(
         original_model or None,
-        getattr(session, "model_provider", None),
+        requested_provider,
+        profile_provider=_pp_provider,
+        profile_default_model=_pp_default,
     )
     return provider
 
@@ -11084,9 +11175,12 @@ def _handle_goal_command(handler, body):
             if "model_provider" in body
             else getattr(s, "model_provider", None)
         )
+        _pp_provider, _pp_default = _read_profile_model_config(s, requested_provider)
         model, model_provider, normalized_model = _resolve_compatible_session_model_state(
             requested_model,
             requested_provider,
+            profile_provider=_pp_provider,
+            profile_default_model=_pp_default,
         )
         previous_goal_state = goal_state_snapshot(s.session_id, profile_home=profile_home)
 
@@ -11132,9 +11226,12 @@ def _handle_goal_command(handler, body):
                 if "model_provider" in body
                 else getattr(s, "model_provider", None)
             )
+            _pp_provider, _pp_default = _read_profile_model_config(s, requested_provider)
             model, model_provider, normalized_model = _resolve_compatible_session_model_state(
                 requested_model,
                 requested_provider,
+                profile_provider=_pp_provider,
+                profile_default_model=_pp_default,
             )
         stream_response = _start_chat_stream_for_session(
             s,
@@ -11207,10 +11304,13 @@ def _handle_chat_start(handler, body, diag=None):
             if "model_provider" in body
             else getattr(s, "model_provider", None)
         )
+        _pp_provider, _pp_default = _read_profile_model_config(s, requested_provider)
         diag.stage("resolve_model_provider") if diag else None
         model, model_provider, normalized_model = _resolve_compatible_session_model_state(
             requested_model,
             requested_provider,
+            profile_provider=_pp_provider,
+            profile_default_model=_pp_default,
         )
         from api.runtime_adapter import (
             LegacyJournalRuntimeAdapter,
@@ -11339,9 +11439,15 @@ def _handle_chat_sync(handler, body):
         return bad(handler, str(e))
     with _get_session_agent_lock(s.session_id):
         s.workspace = workspace
+        _sync_requested_provider = (
+            body.get("model_provider") if "model_provider" in body else getattr(s, "model_provider", None)
+        )
+        _pp_provider, _pp_default = _read_profile_model_config(s, _sync_requested_provider)
         model, model_provider = _resolve_compatible_session_model_state(
             body.get("model") or s.model,
-            body.get("model_provider") if "model_provider" in body else getattr(s, "model_provider", None),
+            _sync_requested_provider,
+            profile_provider=_pp_provider,
+            profile_default_model=_pp_default,
         )[:2]
         s.model = model
         s.model_provider = model_provider

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -128,6 +128,83 @@ def _persistent_state_changes(before: dict | None, after: dict | None) -> dict:
     return {"memory_saved": memory_changed, "skills": skills[:10]}
 
 
+def _apply_profile_provider_context_to_streaming_model(
+    model: str | None,
+    provider_context: str | None,
+    profile_provider: str | None,
+    profile_default_model: str | None,
+) -> tuple[str | None, str | None, bool]:
+    """Attach profile provider context and repair stale cross-provider models."""
+    if provider_context or not profile_provider:
+        return model, provider_context, False
+
+    provider_context = profile_provider.lower()
+    if not profile_default_model:
+        return model, provider_context, False
+
+    from api.routes import _normalize_provider_id
+
+    profile_provider_normalized = _normalize_provider_id(profile_provider)
+    model_lower = (model or "").lower()
+    for prefix in ("gpt", "claude", "gemini"):
+        if model_lower.startswith(prefix):
+            if _normalize_provider_id(prefix) != profile_provider_normalized:
+                return profile_default_model, provider_context, True
+            return model, provider_context, False
+
+    if "/" in model_lower:
+        slash_prefix = model_lower.split("/", 1)[0]
+        if provider_context == "openai-codex" and slash_prefix == "openai":
+            return profile_default_model, provider_context, True
+
+        slash_provider = _normalize_provider_id(slash_prefix)
+        if (
+            slash_provider
+            and slash_provider != profile_provider_normalized
+            and profile_provider_normalized not in {"openrouter", "custom", ""}
+        ):
+            return profile_default_model, provider_context, True
+
+    return model, provider_context, False
+
+
+def _apply_profile_home_context_to_streaming_model(
+    model: str | None,
+    provider_context: str | None,
+    profile_home: str | None,
+    has_profile: bool,
+) -> tuple[str | None, str | None, bool]:
+    """Apply profile provider/model context from a profile config if present."""
+    if not (profile_home and has_profile and not provider_context):
+        return model, provider_context, False
+
+    try:
+        import yaml as _yaml_pp
+
+        _pp_cfg_path = Path(profile_home) / "config.yaml"
+        if not _pp_cfg_path.is_file():
+            return model, provider_context, False
+
+        _pp_cfg = _yaml_pp.safe_load(_pp_cfg_path.read_text(encoding="utf-8")) or {}
+        if not isinstance(_pp_cfg, dict):
+            return model, provider_context, False
+
+        _pp = (_pp_cfg.get("model", {}).get("provider") or "").strip()
+        if not _pp:
+            return model, provider_context, False
+
+        _pp_default = (_pp_cfg.get("model", {}).get("default") or "").strip()
+        return _apply_profile_provider_context_to_streaming_model(
+            model,
+            provider_context,
+            _pp,
+            _pp_default,
+        )
+    except Exception:
+        logger.warning("profile provider read failed", exc_info=True)
+        return model, provider_context, False
+
+
 def _resolve_custom_provider_runtime_overrides(
     resolved_provider: str | None,
     resolved_api_key: str | None,
@@ -4629,7 +4706,20 @@ def _run_agent_streaming(
             _profile_home = os.environ.get('HERMES_HOME', '')
             _profile_runtime_env = {}
             patch_skill_home_modules = None
-        
+
+        # Profile-aware provider/model enrichment: when the session belongs
+        # to a profile that specifies model.provider and model.default, use
+        # those to set provider_context and repair stale models.
+        model, provider_context, _repaired = _apply_profile_home_context_to_streaming_model(
+            model=model,
+            provider_context=provider_context,
+            profile_home=_profile_home,
+            has_profile=bool(getattr(s, "profile", None)),
+        )
+        s.model_provider = provider_context
+        if _repaired and model != (s.model or ""):
+            s.model = model
+
         # Capture the resolved profile name now, while profile context is
         # reliable. Used in the compression migration block to stamp s.profile
         # on the continuation session. We resolve it here rather than calling

--- a/tests/test_goal_command_webui.py
+++ b/tests/test_goal_command_webui.py
@@ -201,7 +201,7 @@ def test_goal_endpoint_sets_goal_and_starts_kickoff_stream(monkeypatch, tmp_path
     monkeypatch.setattr(
         routes,
         "_resolve_compatible_session_model_state",
-        lambda model, provider: (model, provider, False),
+        lambda model, provider, **_: (model, provider, False),
     )
     started = []
 
@@ -316,7 +316,7 @@ def test_goal_endpoint_adapter_keeps_full_set_text_and_legacy_payload_status(mon
     monkeypatch.setattr(
         routes,
         "_resolve_compatible_session_model_state",
-        lambda model, provider: (model, provider, False),
+        lambda model, provider, **_: (model, provider, False),
     )
     monkeypatch.setattr(
         routes,

--- a/tests/test_issue3405_profile_provider_resolution.py
+++ b/tests/test_issue3405_profile_provider_resolution.py
@@ -1,0 +1,619 @@
+"""Tests for issue #3405 — profile provider resolution.
+
+When a session's profile configures ``model.provider`` (e.g. ``anthropic``),
+the session's model should be resolved through that provider. Stale models
+from a different provider family (e.g. ``openai/gpt-5.4-mini`` under an
+anthropic profile) should be repaired to the profile's ``model.default``.
+
+The profile provider must NOT trigger the explicit-provider fast path
+(#1855): that path skips the catalog and stale-model repair entirely.
+Instead, the profile context is passed via keyword-only parameters
+``profile_provider`` and ``profile_default_model`` to
+``_resolve_compatible_session_model_state``, which runs the full catalog
+path and applies profile-aware repair.
+
+Coverage:
+
+1. Stale slash-qualified model repairs to profile default (maintainer repro)
+2. Stale bare model repairs to profile default
+3. Compatible model passes through with profile provider
+4. Profile provider does not skip catalog (not fast path)
+5. Explicit body provider still triggers fast path (regression guard)
+6. @provider:model override wins over profile provider
+7. No profile falls back to global default (regression guard)
+8. Missing/empty profile config results in no injection
+9. Streaming worker enrichment tests
+"""
+from pathlib import Path
+from unittest.mock import patch
+
+
+class TestProfileProviderResolution:
+    """Profile provider passes through the repair path, not the fast path."""
+
+    def test_stale_slash_model_with_profile_provider_repairs_to_profile_default(self):
+        """Maintainer repro: openai/gpt-5.4-mini + profile_provider='anthropic'
+        + profile_default='claude-sonnet-4.6' repairs to claude-sonnet-4.6."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "copilot",
+                "default_model": "gpt-5.5",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "openai/gpt-5.4-mini",
+                None,
+                profile_provider="anthropic",
+                profile_default_model="claude-sonnet-4.6",
+            )
+
+        assert result[0] == "claude-sonnet-4.6"
+        assert result[1] == "anthropic"
+        assert result[2] is True
+
+    def test_stale_openai_slash_model_with_openai_codex_profile_repairs(self):
+        """openai/... under an openai-codex profile repairs to the profile default."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "anthropic",
+                "default_model": "claude-sonnet-4.6",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "openai/gpt-5.4-mini",
+                None,
+                profile_provider="openai-codex",
+                profile_default_model="gpt-5.5",
+            )
+
+        assert result[0] == "gpt-5.5"
+        assert result[1] == "openai-codex"
+        assert result[2] is True
+
+    def test_stale_bare_model_with_profile_provider_repairs(self):
+        """gpt-5.5 + profile_provider='anthropic' repairs because gpt-* is
+        not anthropic-family."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "copilot",
+                "default_model": "gpt-5.5",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "gpt-5.5",
+                None,
+                profile_provider="anthropic",
+                profile_default_model="claude-sonnet-4.6",
+            )
+
+        assert result[0] == "claude-sonnet-4.6"
+        assert result[1] == "anthropic"
+        assert result[2] is True
+
+    def test_compatible_model_with_profile_provider_passes_through(self):
+        """claude-sonnet-4.6 + profile_provider='anthropic' passes through."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "copilot",
+                "default_model": "gpt-5.5",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "claude-sonnet-4.6",
+                None,
+                profile_provider="anthropic",
+                profile_default_model="claude-sonnet-4.6",
+            )
+
+        assert result[0] == "claude-sonnet-4.6"
+        assert result[1] == "anthropic"
+        assert result[2] is False
+
+    def test_profile_provider_does_not_skip_catalog(self):
+        """profile_provider must NOT trigger the fast path; catalog must load."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "copilot",
+                "default_model": "gpt-5.5",
+                "groups": [],
+            }
+            _resolve_compatible_session_model_state(
+                "openai/gpt-5.4-mini",
+                None,
+                profile_provider="anthropic",
+                profile_default_model="claude-sonnet-4.6",
+            )
+
+        assert mock_catalog.call_count == 1
+
+    def test_explicit_provider_still_uses_fast_path(self):
+        """Explicit model_provider must still take the fast path per #1855."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            result = _resolve_compatible_session_model_state(
+                "gpt-5.5",
+                "openai-codex",
+                profile_provider="anthropic",
+                profile_default_model="claude-sonnet-4.6",
+            )
+
+        assert mock_catalog.call_count == 0
+        assert result == ("gpt-5.5", "openai-codex", False)
+
+    def test_at_qualified_model_wins_over_profile(self):
+        """@openrouter:deepseek/deepseek-v4 routes through openrouter, not
+        the profile's anthropic."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "anthropic",
+                "default_model": "claude-sonnet-4.6",
+                "groups": [{"provider_id": "openrouter"}],
+            }
+            result = _resolve_compatible_session_model_state(
+                "@openrouter:deepseek/deepseek-v4",
+                None,
+                profile_provider="anthropic",
+                profile_default_model="claude-sonnet-4.6",
+            )
+
+        # Falls through to the @-handler, which sees openrouter in catalog
+        assert result[1] == "openrouter"
+        assert result[2] is False
+
+    def test_no_profile_falls_back_to_global(self):
+        """No profile_provider uses the catalog's active_provider/default_model."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "anthropic",
+                "default_model": "claude-sonnet-4.6",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "gpt-5.5",
+                None,
+            )
+
+        # gpt-* under anthropic active_provider repairs to default
+        assert result[0] == "claude-sonnet-4.6"
+        assert result[2] is True
+
+    def test_empty_model_with_profile_returns_profile_default(self):
+        """Empty model + profile_provider returns profile default model."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "copilot",
+                "default_model": "gpt-5.5",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "",
+                None,
+                profile_provider="anthropic",
+                profile_default_model="claude-sonnet-4.6",
+            )
+
+        assert result[0] == "claude-sonnet-4.6"
+        assert result[1] == "anthropic"
+        assert result[2] is True
+
+    def test_empty_model_with_profile_no_default_returns_catalog_default(self):
+        """Empty model + profile_provider but no profile default falls back
+        to catalog default_model."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "copilot",
+                "default_model": "gpt-5.5",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "",
+                None,
+                profile_provider="anthropic",
+                profile_default_model=None,
+            )
+
+        assert result[0] == "gpt-5.5"
+        assert result[1] == "anthropic"
+        assert result[2] is True
+
+    def test_gemini_model_under_openai_profile_repairs(self):
+        """gemini-2.5-pro under openai profile repairs to profile default."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "copilot",
+                "default_model": "gpt-5.5",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "gemini-2.5-pro",
+                None,
+                profile_provider="openai",
+                profile_default_model="gpt-5.5",
+            )
+
+        assert result[0] == "gpt-5.5"
+        assert result[1] == "openai"
+        assert result[2] is True
+
+    def test_unknown_model_family_passes_through_with_profile(self):
+        """Models without a known bare prefix (gpt/claude/gemini) and no
+        slash pass through with the profile provider attached."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "copilot",
+                "default_model": "gpt-5.5",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "deepseek-v4-flash",
+                None,
+                profile_provider="anthropic",
+                profile_default_model="claude-sonnet-4.6",
+            )
+
+        assert result[0] == "deepseek-v4-flash"
+        assert result[1] == "anthropic"
+        assert result[2] is False
+
+
+class TestReadProfileModelConfig:
+    """Tests for the _read_profile_model_config helper."""
+
+    def test_returns_none_when_no_profile(self):
+        """No session profile returns (None, None)."""
+        from api.routes import _read_profile_model_config
+
+        class FakeSession:
+            profile = None
+
+        result = _read_profile_model_config(FakeSession(), None)
+        assert result == (None, None)
+
+    def test_returns_none_when_explicit_provider(self):
+        """Explicit requested_provider skips profile config read."""
+        from api.routes import _read_profile_model_config
+
+        class FakeSession:
+            profile = "work"
+
+        result = _read_profile_model_config(FakeSession(), "openai-codex")
+        assert result == (None, None)
+
+    def test_reads_profile_config(self, tmp_path):
+        """Reads model.provider and model.default from profile config.yaml."""
+        from api.routes import _read_profile_model_config
+        import yaml
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.dump({"model": {"provider": "anthropic", "default": "claude-sonnet-4.6"}}),
+            encoding="utf-8",
+        )
+
+        class FakeSession:
+            profile = "work"
+
+        with patch("api.profiles.get_hermes_home_for_profile", return_value=tmp_path):
+            result = _read_profile_model_config(FakeSession(), None)
+
+        assert result == ("anthropic", "claude-sonnet-4.6")
+
+    def test_missing_config_returns_none(self):
+        """Missing config.yaml returns (None, None)."""
+        from api.routes import _read_profile_model_config
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            class FakeSession:
+                profile = "work"
+
+            with patch("api.profiles.get_hermes_home_for_profile", return_value=Path(td)):
+                result = _read_profile_model_config(FakeSession(), None)
+
+        assert result == (None, None)
+
+    def test_empty_provider_returns_none(self, tmp_path):
+        """Empty model.provider in config returns (None, None)."""
+        from api.routes import _read_profile_model_config
+        import yaml
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.dump({"model": {"provider": "", "default": "claude-sonnet-4.6"}}),
+            encoding="utf-8",
+        )
+
+        class FakeSession:
+            profile = "work"
+
+        with patch("api.profiles.get_hermes_home_for_profile", return_value=tmp_path):
+            result = _read_profile_model_config(FakeSession(), None)
+
+        assert result == (None, "claude-sonnet-4.6")
+
+
+class TestStreamingWorkerEnrichment:
+    """Tests for profile-aware provider/model enrichment in the streaming worker."""
+
+    def test_streaming_enrichment_skips_non_profile_session(self, tmp_path):
+        from api.streaming import _apply_profile_home_context_to_streaming_model
+
+        # Even if the default home has a model provider configured, a session
+        # without an explicit profile must not inherit that provider context.
+        model_cfg = tmp_path / "config.yaml"
+        model_cfg.write_text(
+            "model:\n  provider: openai-codex\n  default: gpt-5.5\n",
+            encoding="utf-8",
+        )
+
+        model, provider_context, changed = _apply_profile_home_context_to_streaming_model(
+            "openai/gpt-5.4-mini",
+            None,
+            str(tmp_path),
+            has_profile=False,
+        )
+
+        assert model == "openai/gpt-5.4-mini"
+        assert provider_context is None
+        assert changed is False
+
+    def test_stale_model_substituted_in_streaming(self):
+        """The streaming worker should substitute a stale model when the
+        profile provider does not match the model's family."""
+        from api.routes import _normalize_provider_id
+
+        # Simulate the streaming logic inline
+        model = "gpt-5.5"
+        provider_context = None
+        _pp = "anthropic"
+        _pp_default = "claude-sonnet-4.6"
+
+        if not provider_context and _pp:
+            provider_context = _pp.lower()
+            if _pp_default:
+                _m_lower = (model or "").lower()
+                _pp_norm = _normalize_provider_id(_pp)
+                for _prefix in ("gpt", "claude", "gemini"):
+                    if _m_lower.startswith(_prefix):
+                        if _normalize_provider_id(_prefix) != _pp_norm:
+                            model = _pp_default
+                        break
+
+        assert model == "claude-sonnet-4.6"
+        assert provider_context == "anthropic"
+
+    def test_compatible_model_not_substituted_in_streaming(self):
+        """Compatible models should not be substituted in streaming worker."""
+        from api.routes import _normalize_provider_id
+
+        model = "claude-sonnet-4.6"
+        provider_context = None
+        _pp = "anthropic"
+        _pp_default = "claude-sonnet-4.6"
+
+        if not provider_context and _pp:
+            provider_context = _pp.lower()
+            if _pp_default:
+                _m_lower = (model or "").lower()
+                _pp_norm = _normalize_provider_id(_pp)
+                for _prefix in ("gpt", "claude", "gemini"):
+                    if _m_lower.startswith(_prefix):
+                        if _normalize_provider_id(_prefix) != _pp_norm:
+                            model = _pp_default
+                        break
+
+        assert model == "claude-sonnet-4.6"
+        assert provider_context == "anthropic"
+
+    def test_explicit_provider_context_skips_profile_enrichment(self):
+        """When provider_context is already set (explicit provider), the
+        profile enrichment block should not fire."""
+        model = "gpt-5.5"
+        provider_context = "openai-codex"
+        _pp = "anthropic"
+        _pp_default = "claude-sonnet-4.6"
+
+        # The guard: `if not provider_context and _profile_home:`
+        # prevents enrichment when provider_context is already set
+        if not provider_context and _pp:
+            provider_context = _pp.lower()
+
+        assert model == "gpt-5.5"
+        assert provider_context == "openai-codex"
+
+
+class TestSlashQualifiedOpenRouterPassthrough:
+    """Slash-qualified IDs are native on OpenRouter/custom providers and must
+    not be repaired. They should only be repaired when the profile provider
+    is a concrete family (anthropic, openai, etc.)."""
+
+    def test_openrouter_profile_preserves_slash_qualified_model(self):
+        """openai/gpt-5.4-mini under openrouter profile passes through."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "openrouter",
+                "default_model": "deepseek/deepseek-v4",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "openai/gpt-5.4-mini",
+                None,
+                profile_provider="openrouter",
+                profile_default_model="deepseek/deepseek-v4",
+            )
+
+        assert result[0] == "openai/gpt-5.4-mini"
+        assert result[1] == "openrouter"
+        assert result[2] is False
+
+    def test_openrouter_profile_repairs_bare_prefix_mismatch(self):
+        """Bare claude-sonnet-4.6 under openrouter profile is repaired because
+        the bare-prefix family (anthropic) doesn't match openrouter."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "openrouter",
+                "default_model": "deepseek/deepseek-v4",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "claude-sonnet-4.6",
+                None,
+                profile_provider="openrouter",
+                profile_default_model="deepseek/deepseek-v4",
+            )
+
+        assert result[0] == "deepseek/deepseek-v4"
+        assert result[1] == "openrouter"
+        assert result[2] is True
+
+    def test_anthropic_profile_repairs_slash_qualified_openai(self):
+        """openai/gpt-5.4-mini under anthropic profile is repaired (slash
+        prefix mismatch on a concrete provider)."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "copilot",
+                "default_model": "gpt-5.5",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "openai/gpt-5.4-mini",
+                None,
+                profile_provider="anthropic",
+                profile_default_model="claude-sonnet-4.6",
+            )
+
+        assert result[0] == "claude-sonnet-4.6"
+        assert result[1] == "anthropic"
+        assert result[2] is True
+
+    def test_custom_profile_preserves_slash_qualified_model(self):
+        """custom provider also preserves slash-qualified IDs."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "custom:lmstudio",
+                "default_model": "local-model",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "openai/gpt-5.4-mini",
+                None,
+                profile_provider="custom:lmstudio",
+                profile_default_model="local-model",
+            )
+
+        assert result[0] == "openai/gpt-5.4-mini"
+        assert result[1] == "custom:lmstudio"
+        assert result[2] is False
+
+
+class TestStreamingSlashQualifiedRepair:
+    """Streaming worker must detect slash-qualified stale models and handle
+    openrouter/custom passthrough correctly."""
+
+    def test_streaming_repairs_slash_model_under_anthropic(self):
+        """openai/gpt-5.4-mini under anthropic profile is repaired."""
+        from api.routes import _normalize_provider_id
+
+        model = "openai/gpt-5.4-mini"
+        provider_context = None
+        _pp = "anthropic"
+        _pp_default = "claude-sonnet-4.6"
+
+        if not provider_context and _pp:
+            provider_context = _pp.lower()
+            if _pp_default:
+                _m_lower = (model or "").lower()
+                _pp_norm = _normalize_provider_id(_pp)
+                _repaired = False
+                for _prefix in ("gpt", "claude", "gemini"):
+                    if _m_lower.startswith(_prefix):
+                        if _normalize_provider_id(_prefix) != _pp_norm:
+                            model = _pp_default
+                            _repaired = True
+                        break
+                if not _repaired and "/" in _m_lower:
+                    _slash_prefix = _m_lower.split("/", 1)[0]
+                    _slash_provider = _normalize_provider_id(_slash_prefix)
+                    if _slash_provider and _slash_provider != _pp_norm and _pp_norm not in {"openrouter", "custom", ""}:
+                        model = _pp_default
+
+        assert model == "claude-sonnet-4.6"
+        assert provider_context == "anthropic"
+
+    def test_streaming_preserves_slash_model_under_openrouter(self):
+        """openai/gpt-5.4-mini under openrouter profile is NOT repaired."""
+        from api.routes import _normalize_provider_id
+
+        model = "openai/gpt-5.4-mini"
+        provider_context = None
+        _pp = "openrouter"
+        _pp_default = "deepseek/deepseek-v4"
+
+        if not provider_context and _pp:
+            provider_context = _pp.lower()
+            if _pp_default:
+                _m_lower = (model or "").lower()
+                _pp_norm = _normalize_provider_id(_pp)
+                _repaired = False
+                for _prefix in ("gpt", "claude", "gemini"):
+                    if _m_lower.startswith(_prefix):
+                        if _normalize_provider_id(_prefix) != _pp_norm:
+                            model = _pp_default
+                            _repaired = True
+                        break
+                if not _repaired and "/" in _m_lower:
+                    _slash_prefix = _m_lower.split("/", 1)[0]
+                    _slash_provider = _normalize_provider_id(_slash_prefix)
+                    if _slash_provider and _slash_provider != _pp_norm and _pp_norm not in {"openrouter", "custom", ""}:
+                        model = _pp_default
+
+        assert model == "openai/gpt-5.4-mini"
+        assert provider_context == "openrouter"
+
+    def test_streaming_repairs_openai_slash_model_under_openai_codex(self):
+        """openai/... under an openai-codex profile repairs to the profile default."""
+        from api.streaming import _apply_profile_provider_context_to_streaming_model
+
+        model, provider_context, changed = (
+            _apply_profile_provider_context_to_streaming_model(
+                "openai/gpt-5.4-mini",
+                None,
+                "openai-codex",
+                "gpt-5.5",
+            )
+        )
+
+        assert model == "gpt-5.5"
+        assert provider_context == "openai-codex"
+        assert changed is True

--- a/tests/test_profile_switch_1200.py
+++ b/tests/test_profile_switch_1200.py
@@ -482,7 +482,7 @@ def test_chat_start_retags_empty_session_to_request_profile(monkeypatch, tmp_pat
     monkeypatch.setattr(
         routes,
         "_resolve_compatible_session_model_state",
-        lambda model, provider: (model, provider, False),
+        lambda model, provider, **_: (model, provider, False),
     )
     monkeypatch.setattr(routes, "set_last_workspace", lambda workspace: None)
     monkeypatch.setattr(routes, "create_stream_channel", lambda: object())
@@ -554,7 +554,7 @@ def test_chat_start_does_not_retag_non_empty_session(monkeypatch, tmp_path):
     monkeypatch.setattr(
         routes,
         "_resolve_compatible_session_model_state",
-        lambda model, provider: (model, provider, False),
+        lambda model, provider, **_: (model, provider, False),
     )
     monkeypatch.setattr(routes, "set_last_workspace", lambda workspace: None)
     monkeypatch.setattr(routes, "create_stream_channel", lambda: object())

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -161,6 +161,60 @@ def test_metadata_poll_uses_sidecar_message_count_for_external_updates(monkeypat
     assert session["last_message_at"] == 1001.0
 
 
+def test_deferred_session_model_resolution_uses_profile_provider(monkeypatch, tmp_path):
+    """Deferred GET /api/session resolution must repair against profile config."""
+    import api.profiles as profiles
+    import api.routes as routes
+
+    sid = "webui_profile_resolve_model_001"
+    session = _install_test_session(monkeypatch, tmp_path, sid, [])
+    session.model = "openai/gpt-5.4-mini"
+    session.model_provider = None
+    session.profile = "anthropic"
+    session.save(touch_updated_at=False)
+
+    profile_home = tmp_path / "profiles" / "anthropic"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: anthropic\n"
+        "  default: claude-sonnet-4.6\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        profiles,
+        "get_hermes_home_for_profile",
+        lambda name: profile_home,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_available_models",
+        lambda: {
+            "active_provider": "openai-codex",
+            "default_model": "gpt-5.5",
+            "groups": [],
+        },
+    )
+    monkeypatch.setattr(
+        routes,
+        "_resolve_context_length_for_session_model",
+        lambda *_args, **_kwargs: 0,
+    )
+
+    session_path = tmp_path / "sessions" / f"{sid}.json"
+    before = session_path.read_text(encoding="utf-8")
+
+    handler = _GetHandler(f"/api/session?session_id={sid}&messages=0&resolve_model=1")
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    payload = handler.response_json["session"]
+    assert payload["model"] == "claude-sonnet-4.6"
+    assert payload["model_provider"] == "anthropic"
+    assert session_path.read_text(encoding="utf-8") == before
+
+
 def test_metadata_poll_prefers_sidecar_count_when_index_is_stale(monkeypatch, tmp_path):
     """A stale sidebar index must not hide externally appended sidecar turns."""
     import api.config as config


### PR DESCRIPTION
# Release stage-s1 (v0.51.290) — fix #3405: profile provider/model not respected (#3448)

Un-hold of a verified-fixed contributor PR (@rodboev). HIGH-IMPACT serious bug:
profile-bound sessions silently fell back to the GLOBAL active provider when the model
string wasn't @provider:-qualified — causing (a) wrong credentials/billing (a profile wired
to an Anthropic key ran on GitHub Copilot) and (b) silent context truncation (global default
model's advertised context_length differs from what the provider serves → provider drops
oldest messages, chat "forgets" earlier content).

## History
I held this twice. Round 1: the fix wasn't threaded into the deferred session-open DISPLAY
resolvers (sibling-path gap) — author fixed. Round 2 (my last hold): the `openai-codex`
profile + stale `openai/...` slash model still wasn't repaired because
`_normalize_provider_id("openai-codex") == "openai"` made the slash-compat check pass it
through. Author pushed the fix (06-06).

## Verified THIS round (5-scenario resolver repro, all pass)
`_resolve_compatible_session_model_state`:
1. profile=anthropic, bare 'claude-sonnet-4' → resolves under anthropic (not global). ✓
2. profile=openai-codex, 'openai/gpt-5.4-mini' (my flagged edge) → REPAIRS to gpt-5.5,
   provider=openai-codex, repaired=True. ✓ (was unrepaired before)
3. profile=anthropic, 'gpt-4o' (cross-family) → repairs to profile default. ✓
4. profile=openrouter, 'anthropic/claude-3.5' (native slash) → KEPT, not repaired. ✓
5. explicit '@anthropic:...' qualifier → overrides profile (slow path). ✓
PR's own test_issue3405_profile_provider_resolution.py: 28 passed.

## What to check
- Codex (regression): the profile-aware branch can't mis-repair a legitimate native slash
  model (openrouter/custom), can't break the explicit-@provider fast path, and the stale-repair
  still fires for every cross-provider/cross-family case. Confirm the openai-codex special-case
  doesn't over-match. The fast-path `stale_codex_openai_slash_id` guard must not let other
  stale slash models slip the early-return.
- Opus (correctness): provider resolution is now authoritative from the profile for
  unset/implicit fields; no path silently inherits the global active provider for a
  profile-bound session. Focused read + small checks; no extensive harnesses.

Files: api/routes.py (_resolve_compatible_session_model_state + display resolvers),
api/streaming.py, tests (4 modified + test_issue3405 new). Closes #3405.
