### PR TITLE
Release v0.51.291 — Release JG (stage-s2 — preserve live turn content on switch-away #3668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.291] — 2026-06-06 — Release JG (stage-s2 — preserve live turn content when switching away mid-stream)
+
+### Fixed
+- **Switching away from a streaming session no longer loses the in-progress thinking/tool content.** When you clicked to another chat while a session was streaming during a quiet window (mid tool-execution or silent reasoning, between content events) and then switched back, the live turn's tool cards and thinking could disappear permanently — only the elapsed-time clock survived — until the response finished and the transcript re-rendered from the server. Cause: the live-turn DOM snapshot was only captured on content/`tool_complete` SSE events, so the switch-away teardown could run with a stale-or-absent snapshot, and the switch-back fallback rebuilt an empty thinking card. `closeLiveStream()` now snapshots the live turn **before** tearing the stream down, so switching back restores the exact state shown at switch-away. (#3668)
+
 ## [v0.51.290] — 2026-06-06 — Release JF (stage-s1 — profile provider/model now respected in session resolution)
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -787,6 +787,15 @@ function closeLiveStream(sessionId, streamId, source){
   if(!live) return;
   if(streamId&&live.streamId!==streamId) return;
   if(source&&live.source!==source) return;
+  // Snapshot the current live-turn DOM BEFORE tearing the stream down. The
+  // per-event snapshot (snapshotLiveTurn) only fires on content/tool_complete
+  // SSE events, so switching away during a quiet window (mid tool-exec, silent
+  // thinking) would leave a stale-or-absent snapshot — on switch-back
+  // restoreLiveTurnHtmlForSession() then fails and loadSession()'s fallback
+  // rebuilds with an EMPTY appendThinking(), permanently losing the streamed
+  // thinking/tool content (only the elapsed clock survives). Capturing here
+  // guarantees switch-back restores the exact state shown at switch-away. (#3668)
+  if(typeof snapshotLiveTurnHtmlForSession==='function') snapshotLiveTurnHtmlForSession(sessionId);
   try{live.source.close();}catch(_){ }
   delete LIVE_STREAMS[sessionId];
   // closeLiveStream() is called during session-switch teardown for any session

--- a/tests/test_issue3668_prompt_card_reshow_on_switch.py
+++ b/tests/test_issue3668_prompt_card_reshow_on_switch.py
@@ -229,3 +229,44 @@ def test_sse_initial_event_reshows_pending_prompt():
     assert "showApprovalForSession(sid" in MESSAGES_JS
     # the 'initial' SSE event specifically is wired (not only the live event).
     assert "addEventListener('initial'" in MESSAGES_JS
+
+
+def test_close_live_stream_snapshots_turn_before_teardown():
+    """#3668 'stays gone' variant: switching away from a streaming session during
+    a quiet window (mid tool-exec / silent thinking, between content SSE events)
+    must still preserve the live thinking/tool content on switch-back.
+
+    The per-event snapshot (snapshotLiveTurn) only fires on content/tool_complete
+    events, so closeLiveStream() — the switch-away teardown — must capture a DOM
+    snapshot BEFORE closing the source. Otherwise restoreLiveTurnHtmlForSession()
+    finds no/stale snapshot and loadSession()'s fallback rebuilds with an EMPTY
+    appendThinking(), permanently losing the streamed content (only the elapsed
+    clock survives — the reported signature).
+    """
+    # Extract the closeLiveStream body and assert the snapshot precedes teardown.
+    start = MESSAGES_JS.index("function closeLiveStream(")
+    brace = MESSAGES_JS.index("{", start)
+    depth = 0
+    body = ""
+    for i in range(brace, len(MESSAGES_JS)):
+        if MESSAGES_JS[i] == "{":
+            depth += 1
+        elif MESSAGES_JS[i] == "}":
+            depth -= 1
+            if depth == 0:
+                body = MESSAGES_JS[brace + 1 : i]
+                break
+    assert body, "closeLiveStream body not found"
+    snap_idx = body.find("snapshotLiveTurnHtmlForSession(sessionId)")
+    close_idx = body.find("live.source.close()")
+    delete_idx = body.find("delete LIVE_STREAMS[sessionId]")
+    assert snap_idx != -1, (
+        "closeLiveStream() must snapshot the live turn (snapshotLiveTurnHtmlForSession) "
+        "before tearing the stream down, or switch-away during a quiet window loses content (#3668)."
+    )
+    assert close_idx != -1 and snap_idx < close_idx, (
+        "the snapshot must be taken BEFORE live.source.close()."
+    )
+    assert delete_idx != -1 and snap_idx < delete_idx, (
+        "the snapshot must be taken BEFORE LIVE_STREAMS teardown."
+    )


### PR DESCRIPTION
# Release stage-s2 (v0.51.291) — fix #3668: preserve live turn content on switch-away mid-stream

Agent-authored fix (no contributor PR existed). Serious UX bug, reopened after an independent
report (@b3nw, 2026-06-06).

## The bug (the "stays gone" variant)
Switching to another chat while a session is streaming, during a QUIET window (mid tool-exec or
silent reasoning — between content/tool_complete SSE events), then switching back: the live
turn's thinking + tool cards vanish permanently (only the elapsed clock survives) until the
stream finishes and the transcript re-renders from server data.

## Root cause (traced in static/messages.js)
- The live-turn DOM snapshot (`INFLIGHT[sid].liveTurnHtml` via `snapshotLiveTurnHtmlForSession`)
  is only captured by the per-event `snapshotLiveTurn()` wrapper, fired on content/tool_complete
  SSE events.
- `closeLiveStream(sessionId)` — the switch-away teardown — set `INFLIGHT[sid].reattach=true`
  but did NOT snapshot first. So if you switched away in a quiet window, the snapshot was
  stale/absent.
- On switch-back, `loadSession()`'s active-stream branch calls
  `restoreLiveTurnHtmlForSession(sid)`; when that returns false (no/stale snapshot) the fallback
  runs `appendThinking()` (EMPTY card) + `clearLiveToolCards()` + re-append from INFLIGHT.toolCalls
  — so thinking text is lost and tool cards only partially recover. The elapsed clock is restarted
  from `pending_started_at`, independent of content — matching the reported signature exactly.

## The fix
`closeLiveStream()` now calls `snapshotLiveTurnHtmlForSession(sessionId)` BEFORE
`live.source.close()` and the `LIVE_STREAMS` teardown, so switch-back always has a current
snapshot to restore. `snapshotLiveTurnHtmlForSession` internally guards on
`turn.dataset.sessionId === sid`, so it only captures when the displayed live turn belongs to
the torn-down session (safe at switch-away time, before the new session loads).

## What to check
- Codex (regression): does snapshotting in closeLiveStream ever capture the WRONG session's turn
  (guard correctness), double-snapshot harmfully, or interact badly with the clean-terminate path
  where INFLIGHT[sid] is already deleted (`_clearOwnerInflightState`)? Confirm no perf/teardown
  regression. SAFE TO SHIP or MUST-FIX.
- Opus (correctness): the snapshot-before-teardown ordering is sound; restore-on-switch-back now
  reliably succeeds; the elapsed-clock-only signature is resolved. Focused read + small check; no
  extensive harnesses.

Files: static/messages.js (closeLiveStream), tests/test_issue3668_prompt_card_reshow_on_switch.py
(new regression). Fixes #3668 (stays-gone variant; the temporary-vanish + clarify/approval reshow
halves were already handled per the prior investigation).
