### PR TITLE
fix: thinking card for messages without tool calls should use Activity group

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -7448,13 +7448,6 @@ function renderMessages(options){
       const activityIdxs=[...new Set([...Object.keys(byAssistant).map(k=>parseInt(k)), ...assistantThinking.keys()])].sort((a,b)=>a-b);
       for(const aIdx of activityIdxs){
         const cards=byAssistant[aIdx]||[];
-        if(!cards.length&&assistantThinking.has(aIdx)){
-          const anchorRow=assistantSegments.get(aIdx);
-          if(anchorRow&&window._showThinking!==false){
-            anchorRow.insertAdjacentHTML('beforeend',_thinkingCardHtml(assistantThinking.get(aIdx)));
-          }
-          continue;
-        }
         let anchorRow=assistantSegments.get(aIdx)||null;
         if(!anchorRow&&assistantIdxs.length){
           if(aIdx<assistantIdxs[0]) continue;


### PR DESCRIPTION
## Problem

When an assistant message has thinking/reasoning content but no tool cards, the thinking card is inserted directly into the message segment (via `insertAdjacentHTML('beforeend')`) instead of being placed in an Activity group. This is an upstream bug in `renderMessages` (ui.js ~L7451).

The early-return path at line 7451-7456 skips the `ensureActivityGroup` call when `!cards.length && assistantThinking.has(aIdx)`, causing the thinking card to appear inline in the message rather than in a collapsible Activity group.

## Fix

Remove the 7-line early-return branch so all thinking cards go through the Activity group path (`ensureActivityGroup` + `_thinkingActivityNode`), consistent with how thinking is rendered when tool cards are present.

## Before/After

- **Before**: Thinking card appears directly below the message text (not in Activity)
- **After**: Thinking card appears inside a collapsed Activity group, same as messages with tool calls

## Testing

- Verified on local instance: messages with thinking + no tool calls now show thinking in Activity group
- Messages with thinking + tool calls unaffected (already used Activity group path)
