### PR TITLE
test(windows): hide test helper console windows (#3706)

### DIFF
--- a/tests/browser_smoke.py
+++ b/tests/browser_smoke.py
@@ -114,7 +114,7 @@ def main():
     proc = subprocess.Popen(
         [sys.executable, server_py], cwd=repo_root, env=env,
         stdout=log, stderr=subprocess.STDOUT,
-        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+        **({"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {}),
     )
     try:
         if not _wait_for_health(timeout=30):

--- a/tests/browser_smoke.py
+++ b/tests/browser_smoke.py
@@ -114,6 +114,7 @@ def main():
     proc = subprocess.Popen(
         [sys.executable, server_py], cwd=repo_root, env=env,
         stdout=log, stderr=subprocess.STDOUT,
+        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
     )
     try:
         if not _wait_for_health(timeout=30):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -636,6 +636,7 @@ def test_server():
         env=env,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
     )
 
     if not _wait_for_server(TEST_BASE, timeout=20):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -636,7 +636,7 @@ def test_server():
         env=env,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+        **({"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {}),
     )
 
     if not _wait_for_server(TEST_BASE, timeout=20):

--- a/tests/test_ctl_script.py
+++ b/tests/test_ctl_script.py
@@ -143,7 +143,10 @@ def windows_pid(pid: int) -> int | None:
 
 
 def start_fake_launchd_process() -> subprocess.Popen:
-    return subprocess.Popen(["bash", "-lc", "exec sleep 30"])
+    return subprocess.Popen(
+        ["bash", "-lc", "exec sleep 30"],
+        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+    )
 
 
 def _kill_tree(pid: int) -> None:
@@ -316,7 +319,10 @@ def test_stale_pid_file_is_removed_without_killing_unrelated_process(tmp_path):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
     pid_file = hermes_home / "webui.pid"
-    sleeper = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    sleeper = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+    )
     try:
         pid_file.write_text(str(sleeper.pid), encoding="utf-8")
         result = run_ctl(tmp_path, "stop")

--- a/tests/test_ctl_script.py
+++ b/tests/test_ctl_script.py
@@ -145,7 +145,7 @@ def windows_pid(pid: int) -> int | None:
 def start_fake_launchd_process() -> subprocess.Popen:
     return subprocess.Popen(
         ["bash", "-lc", "exec sleep 30"],
-        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+        **({"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {}),
     )
 
 
@@ -321,7 +321,7 @@ def test_stale_pid_file_is_removed_without_killing_unrelated_process(tmp_path):
     pid_file = hermes_home / "webui.pid"
     sleeper = subprocess.Popen(
         [sys.executable, "-c", "import time; time.sleep(30)"],
-        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+        **({"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {}),
     )
     try:
         pid_file.write_text(str(sleeper.pid), encoding="utf-8")

--- a/tests/test_tls_support.py
+++ b/tests/test_tls_support.py
@@ -6,6 +6,7 @@ Tests use a self-signed certificate generated at test time via openssl.
 import http.client
 import json
 import os
+import sys
 import ssl
 import subprocess
 import textwrap
@@ -79,6 +80,7 @@ def _start_server(port: int, cert: str = None, key: str = None) -> subprocess.Po
         [os.sys.executable, str(ROOT / "server.py")],
         env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         text=True,
+        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
     )
     return proc
 

--- a/tests/test_tls_support.py
+++ b/tests/test_tls_support.py
@@ -6,12 +6,12 @@ Tests use a self-signed certificate generated at test time via openssl.
 import http.client
 import json
 import os
-import sys
 import ssl
 import subprocess
+import sys
+import tempfile
 import textwrap
 import time
-import tempfile
 import unittest
 from contextlib import suppress
 from pathlib import Path
@@ -80,7 +80,7 @@ def _start_server(port: int, cert: str = None, key: str = None) -> subprocess.Po
         [os.sys.executable, str(ROOT / "server.py")],
         env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         text=True,
-        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+        **({"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {}),
     )
     return proc
 


### PR DESCRIPTION

## Thinking Path

- Windows local suite runs currently start several long-lived helper processes through `subprocess.Popen`, and each unflagged child opens a visible console window.
- The root cause is repeated launch-site duplication rather than a single fixture bug, so fixing only `conftest.py` and `browser_smoke.py` would leave other focus-stealing helpers behind.
- The narrow upstream-safe fix is to add Windows-only `CREATE_NO_WINDOW` kwargs at each known helper spawn and leave all non-Windows behavior untouched.

## What Changed

- `tests/conftest.py`: hide the main test server fixture subprocess on Windows.
- `tests/browser_smoke.py`: hide the browser smoke server subprocess on Windows.
- `tests/test_tls_support.py`: hide the TLS helper server subprocess on Windows.
- `tests/test_ctl_script.py`: hide both long-lived helper subprocesses used by the ctl tests on Windows.

## Why It Matters

Windows full-suite runs stop spawning foreground console windows for each helper process, so parallel local testing no longer steals focus or makes the machine unusable. The change is test-only and preserves existing behavior everywhere else.

## Verification

```text
pytest tests/test_tls_support.py tests/test_ctl_script.py -v --timeout=60
```

- Manual: On Windows, run the targeted tests and confirm none of the helper launches opens a new console window.
- Windows local baseline note: `tests/test_tls_support.py::TestTLSEndToEnd::test_tls_startup_failure_fallback_to_http` still fails on clean `origin/master` because it imports `fcntl`, which is not available on Windows. This branch does not change that assertion path.

## Risks / Follow-ups

- This only covers the currently known `subprocess.Popen` test helpers; future long-lived test subprocesses should follow the same Windows launch pattern.

## Model Used

GPT-5.5 via Codex CLI
