### PR TITLE
fix(update): wait for a new server instance before reload (#3619)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Update reload now falls through on the first healthy uptime-only `/health` response after an identity-bearing baseline.** When the pre-update server exposed `server_started_at` but the replacement came back with only `uptime_seconds`, the browser could otherwise keep polling until timeout because there was no longer a comparable started-at field. The reload gate now treats that healthy uptime-only response as sufficient evidence that the replacement server is up. (#3619)
+
 ## [v0.51.289] — 2026-06-06 — Release JE (hotfix — sidebar ReferenceError #3696 + scope-undef prevention gate)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -5793,13 +5793,15 @@ async function _waitForServerThenReload(opts){
           }
           if(
             nextServerIdentity===null &&
-            baselineServerIdentity.serverStartedAt!==null &&
-            baselineServerIdentity.uptimeSeconds===null
+            (
+              baselineServerIdentity.serverStartedAt!==null ||
+              baselineServerIdentity.uptimeSeconds!==null
+            )
           ){
             // If the replacement server comes back healthy without either
-            // identity field, but the baseline only had server_started_at,
-            // treat that healthy response as the new server instead of
-            // timing out on an uncomparable identity shape.
+            // identity field after the baseline exposed a comparable identity,
+            // treat that healthy response as the new server instead of timing
+            // out on an uncomparable identity shape.
             location.reload();
             return;
           }

--- a/static/ui.js
+++ b/static/ui.js
@@ -5806,6 +5806,20 @@ async function _waitForServerThenReload(opts){
             return;
           }
           if(
+            nextServerIdentity!==null &&
+            baselineServerIdentity.serverStartedAt!==null &&
+            baselineServerIdentity.uptimeSeconds===null &&
+            nextServerIdentity.serverStartedAt===null &&
+            nextServerIdentity.uptimeSeconds!==null
+          ){
+            // If the baseline only exposed server_started_at but the
+            // replacement health response degrades to uptime-only, there is no
+            // longer a comparable started_at field. Treat the first healthy
+            // uptime-only response as the new server instead of timing out.
+            location.reload();
+            return;
+          }
+          if(
             nextServerIdentity!==null&&(
               (baselineServerIdentity.serverStartedAt===null&&nextServerIdentity.serverStartedAt!==null)||
               (baselineServerIdentity.serverStartedAt!==null&&nextServerIdentity.serverStartedAt!==null&&nextServerIdentity.serverStartedAt!==baselineServerIdentity.serverStartedAt)||

--- a/static/ui.js
+++ b/static/ui.js
@@ -5698,12 +5698,22 @@ function _normalizeHealthServerIdentity(rawIdentity){
   return Number.isFinite(numeric) ? String(numeric) : null;
 }
 
+function _healthResponseServerIdentity(data){
+  if(!data||typeof data!=='object') return null;
+  const serverStartedAt=_normalizeHealthServerIdentity(data.server_started_at);
+  const hasUptimeSeconds=data.uptime_seconds!==null&&data.uptime_seconds!==undefined;
+  const uptimeSeconds=hasUptimeSeconds?Number(data.uptime_seconds):NaN;
+  const normalizedUptime=Number.isFinite(uptimeSeconds)&&uptimeSeconds>=0 ? uptimeSeconds : null;
+  if(serverStartedAt===null&&normalizedUptime===null) return null;
+  return {serverStartedAt,uptimeSeconds:normalizedUptime};
+}
+
 async function _readHealthServerIdentity() {
   try {
     const r=await fetch(new URL('health', document.baseURI||location.href).href,{cache:'no-store'});
     if(!r.ok) return null;
     const data=await r.json();
-    return _normalizeHealthServerIdentity(data&&data.server_started_at);
+    return _healthResponseServerIdentity(data);
   } catch (_) {
     return null;
   }
@@ -5748,7 +5758,18 @@ async function _waitForServerThenReload(opts){
   opts=opts||{};
   const interval=opts.interval||500;
   const maxMs=opts.maxMs||15000;
-  const baselineServerIdentity=_normalizeHealthServerIdentity(opts.baselineServerIdentity);
+  const baselineServerIdentity=(()=>{
+    const rawIdentity=opts.baselineServerIdentity;
+    if(!rawIdentity||typeof rawIdentity!=='object'){
+      const normalizedServerStartedAt=_normalizeHealthServerIdentity(rawIdentity);
+      return normalizedServerStartedAt===null ? null : {serverStartedAt:normalizedServerStartedAt,uptimeSeconds:null};
+    }
+    const normalizedIdentity={
+      serverStartedAt:_normalizeHealthServerIdentity(rawIdentity.serverStartedAt),
+      uptimeSeconds:Number.isFinite(Number(rawIdentity.uptimeSeconds))&&Number(rawIdentity.uptimeSeconds)>=0 ? Number(rawIdentity.uptimeSeconds) : null,
+    };
+    return normalizedIdentity.serverStartedAt===null&&normalizedIdentity.uptimeSeconds===null ? null : normalizedIdentity;
+  })();
   window._restartingForUpdate=true;
   const msgEl=$('reconnectMsg');
   const banner=$('reconnectBanner');
@@ -5765,16 +5786,22 @@ async function _waitForServerThenReload(opts){
         let data={};
         try{ data=await r.json(); }catch(_){}
         if(data && data.status==='ok'){
-          const nextServerIdentity=_normalizeHealthServerIdentity(data&&data.server_started_at);
+          const nextServerIdentity=_healthResponseServerIdentity(data);
           if (baselineServerIdentity===null){
             location.reload();
             return;
           }
-          if (nextServerIdentity!==null && nextServerIdentity !== baselineServerIdentity){
+          if(
+            nextServerIdentity!==null&&(
+              (baselineServerIdentity.serverStartedAt===null&&nextServerIdentity.serverStartedAt!==null)||
+              (baselineServerIdentity.serverStartedAt!==null&&nextServerIdentity.serverStartedAt!==null&&nextServerIdentity.serverStartedAt!==baselineServerIdentity.serverStartedAt)||
+              (baselineServerIdentity.uptimeSeconds!==null&&nextServerIdentity.uptimeSeconds!==null&&nextServerIdentity.uptimeSeconds<baselineServerIdentity.uptimeSeconds)
+            )
+          ){
             location.reload();
             return;
           }
-          // Keep polling while the server keeps reporting the same (pre-restart) process identity
+          // Keep polling while /health still describes the pre-restart process.
         }
       }
     }catch(_){ /* socket closed during restart — retry */ }

--- a/static/ui.js
+++ b/static/ui.js
@@ -5792,6 +5792,18 @@ async function _waitForServerThenReload(opts){
             return;
           }
           if(
+            nextServerIdentity===null &&
+            baselineServerIdentity.serverStartedAt!==null &&
+            baselineServerIdentity.uptimeSeconds===null
+          ){
+            // If the replacement server comes back healthy without either
+            // identity field, but the baseline only had server_started_at,
+            // treat that healthy response as the new server instead of
+            // timing out on an uncomparable identity shape.
+            location.reload();
+            return;
+          }
+          if(
             nextServerIdentity!==null&&(
               (baselineServerIdentity.serverStartedAt===null&&nextServerIdentity.serverStartedAt!==null)||
               (baselineServerIdentity.serverStartedAt!==null&&nextServerIdentity.serverStartedAt!==null&&nextServerIdentity.serverStartedAt!==baselineServerIdentity.serverStartedAt)||

--- a/static/ui.js
+++ b/static/ui.js
@@ -5808,14 +5808,13 @@ async function _waitForServerThenReload(opts){
           if(
             nextServerIdentity!==null &&
             baselineServerIdentity.serverStartedAt!==null &&
-            baselineServerIdentity.uptimeSeconds===null &&
             nextServerIdentity.serverStartedAt===null &&
             nextServerIdentity.uptimeSeconds!==null
           ){
-            // If the baseline only exposed server_started_at but the
-            // replacement health response degrades to uptime-only, there is no
-            // longer a comparable started_at field. Treat the first healthy
-            // uptime-only response as the new server instead of timing out.
+            // If the baseline exposed server_started_at but the replacement
+            // health response degrades to uptime-only, there is no longer a
+            // comparable started_at field. Treat the first healthy uptime-only
+            // response as the new server instead of timing out.
             location.reload();
             return;
           }

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -1183,6 +1183,45 @@ global.fetch = async () => {{
 """
         subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
 
+    def test_wait_for_server_reloads_when_full_baseline_loses_all_identity_fields(self):
+        src = read('static/ui.js')
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
+
+        script = f"""
+let now = 0;
+let reloads = 0;
+let fetches = 0;
+const responses = [
+  {{ ok: true, data: {{ status: 'ok', server_started_at: null, uptime_seconds: null }} }},
+];
+global.window = {{}};
+global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
+global.location = {{ reload: () => {{ reloads += 1; }} }};
+global.$ = () => null;
+global.Date = {{ now: () => now }};
+global.setTimeout = (cb, ms) => {{ now += ms || 0; cb(); return 0; }};
+global.fetch = async () => {{
+  fetches += 1;
+  const next = responses.shift();
+  if (!next) throw new Error('unexpected extra fetch');
+  return {{
+    ok: next.ok,
+    json: async () => next.data,
+  }};
+}};
+{normalize_fn}
+{identity_fn}
+{wait_fn}
+(async () => {{
+  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: '1001.234', uptimeSeconds: 120 }} }});
+  if (fetches !== 1) throw new Error('expected full-baseline identity loss to trigger reload on first probe, got '+fetches);
+  if (reloads !== 1) throw new Error('expected exactly one reload when replacement health drops all identity fields after a full baseline, got '+reloads);
+}})().catch(err => {{ console.error(err.stack || err.message); process.exit(1); }});
+"""
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
     def test_apply_and_force_updates_capture_identity(self):
         src = read('static/ui.js')
         apply_fn = re.search(r'function\s+applyUpdates\b.*?\n\}', src, re.DOTALL)

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -30,6 +30,25 @@ def read(rel):
     return (REPO / rel).read_text(encoding='utf-8')
 
 
+def extract_js_function(src: str, name: str) -> str:
+    match = re.search(rf'(async\s+)?function\s+{re.escape(name)}\b', src)
+    assert match, f"{name}() not found"
+    brace = src.index("{", match.start())
+    depth = 0
+    end = None
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                end = idx + 1
+                break
+    assert end is not None, f"{name}() body was not balanced"
+    return src[match.start():end]
+
+
 # ── api/updates.py ────────────────────────────────────────────────────────────
 
 class TestUpdateChecker:
@@ -671,6 +690,21 @@ class TestForceUpdateRoute:
         )
 
 
+class TestHealthRouteContract:
+    def test_health_payload_includes_server_started_at(self):
+        src = read('api/routes.py')
+        health_start = src.index('def _handle_health')
+        payload_start = src.index('payload = {', health_start)
+        payload_end = src.index('if "oldest_run_age_seconds" in run_check:', payload_start)
+        payload = src[payload_start:payload_end]
+        assert '"server_started_at": SERVER_START_TIME' in payload, (
+            "/health must expose server_started_at sourced from SERVER_START_TIME"
+        )
+        assert '"uptime_seconds": round(time.time() - SERVER_START_TIME, 1)' in payload, (
+            "/health must keep exposing uptime_seconds alongside server_started_at"
+        )
+
+
 class TestUpdateSummaryRouteModelSelection:
     """Update summaries should use a known text auxiliary model before main model fallback."""
 
@@ -934,37 +968,27 @@ class TestUiJsUpdateBanner:
 
     def test_wait_for_server_requires_new_process_identity(self):
         src = read('static/ui.js')
-        m = re.search(r'function\s+_waitForServerThenReload\b.*?\n\}', src, re.DOTALL)
-        assert m, "_waitForServerThenReload() not found"
-        fn = m.group(0)
+        fn = extract_js_function(src, '_waitForServerThenReload')
         assert 'baselineServerIdentity' in fn, (
             "_waitForServerThenReload() should capture and compare a baseline process identity"
         )
-        assert 'nextServerIdentity!==null&&nextServerIdentity!==baselineServerIdentity' in fn.replace(' ', ''), (
-            "_waitForServerThenReload() should only reload when health process identity changes"
+        compact = re.sub(r'\s+', '', fn)
+        assert 'baselineServerIdentity.serverStartedAt!==null&&nextServerIdentity.serverStartedAt!==null&&nextServerIdentity.serverStartedAt!==baselineServerIdentity.serverStartedAt' in compact, (
+            "_waitForServerThenReload() should compare server_started_at when it is available"
         )
-        assert 'baselineServerIdentity===null' in fn.replace(' ', ''), (
+        assert 'baselineServerIdentity.uptimeSeconds!==null&&nextServerIdentity.uptimeSeconds!==null&&nextServerIdentity.uptimeSeconds<baselineServerIdentity.uptimeSeconds' in compact, (
+            "_waitForServerThenReload() should fall back to uptime_seconds when server_started_at is unavailable"
+        )
+        assert 'baselineServerIdentity===null' in compact, (
             "_waitForServerThenReload() should fallback to existing behavior when baseline is unavailable"
         )
 
     def test_wait_for_server_fallbacks_to_ready_on_missing_baseline(self):
         """Healthy /health should reload immediately when baseline identity is missing."""
         src = read('static/ui.js')
-        start = src.index("async function _waitForServerThenReload")
-        brace = src.index("{", start)
-        depth = 0
-        end = None
-        for idx in range(brace, len(src)):
-            ch = src[idx]
-            if ch == "{":
-                depth += 1
-            elif ch == "}":
-                depth -= 1
-                if depth == 0:
-                    end = idx + 1
-                    break
-        assert end is not None, "_waitForServerThenReload body was not balanced"
-        fn = src[start:end]
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
 
         script = f"""
 let now = 0;
@@ -973,9 +997,6 @@ let fetches = 0;
 const responses = [
   {{ ok: true, data: {{ status: 'ok', server_started_at: null, uptime_seconds: 120 }} }},
 ];
-const _normalizeHealthServerIdentity = (rawIdentity) => rawIdentity===undefined||rawIdentity===null ? null :
-  (typeof rawIdentity==='string' ? (rawIdentity.trim() ? rawIdentity.trim() : null) :
-   Number.isFinite(Number(rawIdentity)) ? String(Number(rawIdentity)) : null);
 global.window = {{}};
 global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
 global.location = {{ reload: () => {{ reloads += 1; }} }};
@@ -991,7 +1012,9 @@ global.fetch = async () => {{
     json: async () => next.data,
   }};
 }};
-{fn}
+{normalize_fn}
+{identity_fn}
+{wait_fn}
 (async () => {{
   await _waitForServerThenReload({{ interval: 1, maxMs: 10, baselineServerIdentity: null }});
   if (fetches !== 1) throw new Error('expected fallback baseline to reload on first healthy probe, got '+fetches);
@@ -1003,21 +1026,9 @@ global.fetch = async () => {{
     def test_wait_for_server_ignores_old_identity_and_reloads_on_new_identity(self):
         """Healthy /health from the old process should not reload until identity changes."""
         src = read('static/ui.js')
-        start = src.index("async function _waitForServerThenReload")
-        brace = src.index("{", start)
-        depth = 0
-        end = None
-        for idx in range(brace, len(src)):
-            ch = src[idx]
-            if ch == "{":
-                depth += 1
-            elif ch == "}":
-                depth -= 1
-                if depth == 0:
-                    end = idx + 1
-                    break
-        assert end is not None, "_waitForServerThenReload body was not balanced"
-        fn = src[start:end]
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
 
         script = f"""
 let now = 0;
@@ -1028,9 +1039,6 @@ const responses = [
   {{ ok: true, data: {{ status: 'ok', server_started_at: '1001.234', uptime_seconds: 2000 }} }},
   {{ ok: true, data: {{ status: 'ok', server_started_at: '1001.235', uptime_seconds: 2010 }} }},
 ];
-const _normalizeHealthServerIdentity = (rawIdentity) => rawIdentity===undefined||rawIdentity===null ? null :
-  (typeof rawIdentity==='string' ? (rawIdentity.trim() ? rawIdentity.trim() : null) :
-   Number.isFinite(Number(rawIdentity)) ? String(Number(rawIdentity)) : null);
 global.window = {{}};
 global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
 global.location = {{ reload: () => {{ reloads += 1; }} }};
@@ -1046,11 +1054,92 @@ global.fetch = async () => {{
     json: async () => next.data,
   }};
 }};
-{fn}
+{normalize_fn}
+{identity_fn}
+{wait_fn}
 (async () => {{
-  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: '1001.234' }});
+  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: '1001.234', uptimeSeconds: 999 }} }});
   if (fetches !== 3) throw new Error('expected old-process health to be ignored before identity changes, got '+fetches);
   if (reloads !== 1) throw new Error('expected exactly one reload after new identity, got '+reloads);
+}})().catch(err => {{ console.error(err.stack || err.message); process.exit(1); }});
+"""
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+    def test_wait_for_server_falls_back_to_uptime_when_started_at_is_missing(self):
+        src = read('static/ui.js')
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
+
+        script = f"""
+let now = 0;
+let reloads = 0;
+let fetches = 0;
+const responses = [
+  {{ ok: true, data: {{ status: 'ok', server_started_at: null, uptime_seconds: 120 }} }},
+  {{ ok: true, data: {{ status: 'ok', server_started_at: null, uptime_seconds: 2 }} }},
+];
+global.window = {{}};
+global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
+global.location = {{ reload: () => {{ reloads += 1; }} }};
+global.$ = () => null;
+global.Date = {{ now: () => now }};
+global.setTimeout = (cb, ms) => {{ now += ms || 0; cb(); return 0; }};
+global.fetch = async () => {{
+  fetches += 1;
+  const next = responses.shift();
+  if (!next) throw new Error('unexpected extra fetch');
+  return {{
+    ok: next.ok,
+    json: async () => next.data,
+  }};
+}};
+{normalize_fn}
+{identity_fn}
+{wait_fn}
+(async () => {{
+  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: null, uptimeSeconds: 120 }} }});
+  if (fetches !== 2) throw new Error('expected uptime fallback to wait for a lower uptime, got '+fetches);
+  if (reloads !== 1) throw new Error('expected exactly one reload after uptime fallback identified a new process, got '+reloads);
+}})().catch(err => {{ console.error(err.stack || err.message); process.exit(1); }});
+"""
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+    def test_wait_for_server_accepts_new_started_at_when_baseline_lacked_one(self):
+        src = read('static/ui.js')
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
+
+        script = f"""
+let now = 0;
+let reloads = 0;
+let fetches = 0;
+const responses = [
+  {{ ok: true, data: {{ status: 'ok', server_started_at: '1001.300', uptime_seconds: 120 }} }},
+];
+global.window = {{}};
+global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
+global.location = {{ reload: () => {{ reloads += 1; }} }};
+global.$ = () => null;
+global.Date = {{ now: () => now }};
+global.setTimeout = (cb, ms) => {{ now += ms || 0; cb(); return 0; }};
+global.fetch = async () => {{
+  fetches += 1;
+  const next = responses.shift();
+  if (!next) throw new Error('unexpected extra fetch');
+  return {{
+    ok: next.ok,
+    json: async () => next.data,
+  }};
+}};
+{normalize_fn}
+{identity_fn}
+{wait_fn}
+(async () => {{
+  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: null, uptimeSeconds: 120 }} }});
+  if (fetches !== 1) throw new Error('expected new server_started_at to trigger reload on first healthy probe, got '+fetches);
+  if (reloads !== 1) throw new Error('expected exactly one reload when replacement server exposes server_started_at, got '+reloads);
 }})().catch(err => {{ console.error(err.stack || err.message); process.exit(1); }});
 """
         subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
@@ -1081,6 +1170,31 @@ global.fetch = async () => {{
         assert force_body.index('_readHealthServerIdentity()') < force_body.index("const res=await api('/api/updates/force'"), (
             "forceUpdate() must capture baseline before force POST"
         )
+
+    def test_health_identity_helper_prefers_server_started_at_and_keeps_uptime_fallback(self):
+        src = read('static/ui.js')
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+
+        script = f"""
+{normalize_fn}
+{identity_fn}
+const preferred = _healthResponseServerIdentity({{ server_started_at: '1001.234', uptime_seconds: 900 }});
+if (!preferred || preferred.serverStartedAt !== '1001.234') {{
+  throw new Error('expected server_started_at to be the preferred identity field');
+}}
+if (preferred.uptimeSeconds !== 900) {{
+  throw new Error('expected uptime_seconds to remain available for fallback comparisons');
+}}
+const fallback = _healthResponseServerIdentity({{ server_started_at: null, uptime_seconds: 120 }});
+if (!fallback || fallback.serverStartedAt !== null || fallback.uptimeSeconds !== 120) {{
+  throw new Error('expected uptime_seconds fallback identity when server_started_at is unavailable');
+}}
+if (_healthResponseServerIdentity({{ server_started_at: null, uptime_seconds: null }}) !== null) {{
+  throw new Error('expected null identity when /health exposes neither started_at nor uptime');
+}}
+"""
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
 
     def test_refresh_session_handles_restart_mode(self):
         """When _restartingForUpdate flag is set, refreshSession() must do a

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -1222,6 +1222,45 @@ global.fetch = async () => {{
 """
         subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
 
+    def test_wait_for_server_reloads_when_baseline_started_at_degrades_to_uptime_only(self):
+        src = read('static/ui.js')
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
+
+        script = f"""
+let now = 0;
+let reloads = 0;
+let fetches = 0;
+const responses = [
+  {{ ok: true, data: {{ status: 'ok', server_started_at: null, uptime_seconds: 12 }} }},
+];
+global.window = {{}};
+global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
+global.location = {{ reload: () => {{ reloads += 1; }} }};
+global.$ = () => null;
+global.Date = {{ now: () => now }};
+global.setTimeout = (cb, ms) => {{ now += ms || 0; cb(); return 0; }};
+global.fetch = async () => {{
+  fetches += 1;
+  const next = responses.shift();
+  if (!next) throw new Error('unexpected extra fetch');
+  return {{
+    ok: next.ok,
+    json: async () => next.data,
+  }};
+}};
+{normalize_fn}
+{identity_fn}
+{wait_fn}
+(async () => {{
+  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: '1001.234', uptimeSeconds: null }} }});
+  if (fetches !== 1) throw new Error('expected uptime-only healthy replacement to trigger reload on first probe, got '+fetches);
+  if (reloads !== 1) throw new Error('expected exactly one reload when started_at degrades to uptime-only health, got '+reloads);
+}})().catch(err => {{ console.error(err.stack || err.message); process.exit(1); }});
+"""
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
     def test_apply_and_force_updates_capture_identity(self):
         src = read('static/ui.js')
         apply_fn = re.search(r'function\s+applyUpdates\b.*?\n\}', src, re.DOTALL)

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -1144,6 +1144,45 @@ global.fetch = async () => {{
 """
         subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
 
+    def test_wait_for_server_reloads_when_replacement_health_has_no_identity_fields(self):
+        src = read('static/ui.js')
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
+
+        script = f"""
+let now = 0;
+let reloads = 0;
+let fetches = 0;
+const responses = [
+  {{ ok: true, data: {{ status: 'ok', server_started_at: null, uptime_seconds: null }} }},
+];
+global.window = {{}};
+global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
+global.location = {{ reload: () => {{ reloads += 1; }} }};
+global.$ = () => null;
+global.Date = {{ now: () => now }};
+global.setTimeout = (cb, ms) => {{ now += ms || 0; cb(); return 0; }};
+global.fetch = async () => {{
+  fetches += 1;
+  const next = responses.shift();
+  if (!next) throw new Error('unexpected extra fetch');
+  return {{
+    ok: next.ok,
+    json: async () => next.data,
+  }};
+}};
+{normalize_fn}
+{identity_fn}
+{wait_fn}
+(async () => {{
+  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: '1001.234', uptimeSeconds: null }} }});
+  if (fetches !== 1) throw new Error('expected identity-less healthy replacement to trigger reload on first probe, got '+fetches);
+  if (reloads !== 1) throw new Error('expected exactly one reload when replacement health exposes no identity fields, got '+reloads);
+}})().catch(err => {{ console.error(err.stack || err.message); process.exit(1); }});
+"""
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
     def test_apply_and_force_updates_capture_identity(self):
         src = read('static/ui.js')
         apply_fn = re.search(r'function\s+applyUpdates\b.*?\n\}', src, re.DOTALL)

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -33,7 +33,17 @@ def read(rel):
 def extract_js_function(src: str, name: str) -> str:
     match = re.search(rf'(async\s+)?function\s+{re.escape(name)}\b', src)
     assert match, f"{name}() not found"
-    brace = src.index("{", match.start())
+    open_paren = src.index("(", match.start())
+    paren_depth = 1
+    idx = open_paren + 1
+    while paren_depth > 0 and idx < len(src):
+        ch = src[idx]
+        if ch == "(":
+            paren_depth += 1
+        elif ch == ")":
+            paren_depth -= 1
+        idx += 1
+    brace = src.index("{", idx)
     depth = 0
     end = None
     for idx in range(brace, len(src)):
@@ -1254,7 +1264,7 @@ global.fetch = async () => {{
 {identity_fn}
 {wait_fn}
 (async () => {{
-  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: '1001.234', uptimeSeconds: null }} }});
+  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: '1001.234', uptimeSeconds: 120 }} }});
   if (fetches !== 1) throw new Error('expected uptime-only healthy replacement to trigger reload on first probe, got '+fetches);
   if (reloads !== 1) throw new Error('expected exactly one reload when started_at degrades to uptime-only health, got '+reloads);
 }})().catch(err => {{ console.error(err.stack || err.message); process.exit(1); }});


### PR DESCRIPTION

## Thinking Path

- The old fixed timeout is gone, but the replacement still reloads on the first healthy `/health` response without verifying that the server instance actually changed.
- `/health` already emits enough lifecycle data to cheaply add a stable identity marker using `SERVER_START_TIME`.
- The minimal fix is to thread a baseline identity from the update trigger into `_waitForServerThenReload()` and gate reload on an actual instance change.

## What Changed

- `api/routes.py`: add `server_started_at` to `/health`
- `static/ui.js`: capture a baseline identity before update/force-update and require a changed identity before reloading
- `tests/test_update_banner_fixes.py`: pin the new backend/frontend identity contract

## Why It Matters

Without an identity check, the client can still reload too early and land back on the old process. This closes the remaining race without expanding the update flow beyond a cheap `/health` contract.

## Verification

```bash
pytest tests/test_update_banner_fixes.py -v --timeout=60
pytest tests/ -v --timeout=60
```

## Risks / Follow-ups

- If a deployment strips `server_started_at` from `/health`, the client should degrade gracefully rather than hanging forever; keep the current timeout/warning path.

## Model Used

OpenAI GPT-5 Codex
