### PR TITLE
docs(docker): add opt-in GPU runtime image path (#3243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Optional GPU runtime image path for Docker users.** `INSTALL_GPU_LIBS=1` now builds an opt-in image with VA-API user-space libraries, Docker docs cover Intel/AMD `/dev/dri` and NVIDIA runtime passthrough, and the container init preserves supplemental device groups when dropping to the `hermeswebui` runtime user. (#3243)
+
 ## [v0.51.293] — 2026-06-06 — Release JI (stage-s5 — thinking card no longer renders twice)
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,26 @@ RUN apt-get update -y --fix-missing --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Optional GPU user-space acceleration libraries for users who pass through
+# host GPU devices. The default image remains CPU-only.
+ARG INSTALL_GPU_LIBS=0
+RUN if [ "$INSTALL_GPU_LIBS" = "1" ]; then \
+        apt-get update -y --fix-missing --no-install-recommends \
+        && apt-get install -y --no-install-recommends \
+            libva2 \
+            vainfo \
+            mesa-va-drivers \
+        && if apt-cache show intel-media-va-driver-non-free >/dev/null 2>&1; then \
+            apt-get install -y --no-install-recommends intel-media-va-driver-non-free; \
+        else \
+            echo "intel-media-va-driver-non-free is not available from the configured Debian repositories; skipping Intel non-free VA-API driver."; \
+        fi \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*; \
+    else \
+        echo "Skipping optional GPU user-space acceleration libraries (INSTALL_GPU_LIBS=0)."; \
+    fi
+
 # UTF-8
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG=en_US.utf8

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -278,6 +278,10 @@ if [ "A${whoami}" == "Aroot" ]; then
       groupadd -g "$gid" "$group_name" 2>/dev/null || true
       group_name="$(getent group "$gid" | cut -d: -f1 || true)"
     fi
+    if [ -z "$group_name" ]; then
+      echo "!! WARNING: Could not create supplemental group for GID $gid; GPU device access may be unavailable"
+      continue
+    fi
     if [ -n "$group_name" ]; then
       usermod -a -G "$group_name" hermeswebui 2>/dev/null || echo "!! WARNING: Could not add hermeswebui to supplemental group $group_name ($gid)"
     fi

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -264,6 +264,25 @@ if [ "A${whoami}" == "Aroot" ]; then
   chmod 600 "$ENV_FILE" || error_exit "Failed to secure $ENV_FILE"
   export _HW_ROOT_ENV_PATH="$ENV_FILE"
 
+  # Preserve Docker --group-add supplemental groups (for example render/video
+  # for /dev/dri GPU access) when dropping privileges. `su` rebuilds the target
+  # user's groups from /etc/group, so host-passed numeric groups must be made
+  # visible to hermeswebui before re-entering as the runtime user.
+  for gid in $(id -G); do
+    if [ "$gid" = "0" ] || [ "$gid" = "$WANTED_GID" ]; then
+      continue
+    fi
+    group_name="$(getent group "$gid" | cut -d: -f1 || true)"
+    if [ -z "$group_name" ]; then
+      group_name="hostgpu${gid}"
+      groupadd -g "$gid" "$group_name" 2>/dev/null || true
+      group_name="$(getent group "$gid" | cut -d: -f1 || true)"
+    fi
+    if [ -n "$group_name" ]; then
+      usermod -a -G "$group_name" hermeswebui 2>/dev/null || echo "!! WARNING: Could not add hermeswebui to supplemental group $group_name ($gid)"
+    fi
+  done
+
   # restart the script as hermeswebui set with the correct UID/GID this time
   echo "-- Restarting as hermeswebui user with UID ${WANTED_UID} GID ${WANTED_GID}"
   exec su -s /bin/bash -c "exec \"${script_fullname}\"" hermeswebui || error_exit "subscript failed"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -113,7 +113,9 @@ services:
 ```
 
 `vainfo` should list the VA-API driver and supported profiles when the host
-driver stack and container permissions are correct.
+driver stack and container permissions are correct. The container entrypoint
+preserves Docker-provided supplemental groups before it drops privileges to the
+`hermeswebui` runtime user, so the WebUI process keeps access to `/dev/dri`.
 
 ### NVIDIA
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -66,6 +66,78 @@ isolated Hermes home and follow
 > for a one-off root run, use `sudo -E docker compose up -d` and verify the
 > rendered mount with `docker compose config` first.
 
+## Optional GPU runtime image
+
+The default Hermes WebUI Docker image stays CPU-only. GPU user-space packages
+are installed only when you build a custom image with the opt-in build arg:
+
+```bash
+docker build --build-arg INSTALL_GPU_LIBS=1 -t hermes-webui:gpu .
+```
+
+That build path installs VA-API basics (`libva2`, `vainfo`), AMD Mesa VA-API
+drivers (`mesa-va-drivers`), and the Intel non-free media driver when that
+package is available from the configured Debian repositories. NVIDIA host
+runtime tooling is not installed into the app image; use the NVIDIA Container
+Toolkit on the host and pass GPUs through at runtime.
+
+GPU passthrough still depends on host drivers, Docker runtime support, and
+device mappings. The commands below are configuration guidance for a suitable
+Linux Docker host; they are not a claim that native GPU passthrough was verified
+in this workspace.
+
+### Intel and AMD VA-API
+
+Expose the host render devices and add the runtime user to the common video and
+render groups:
+
+```bash
+docker run --rm \
+  --device /dev/dri:/dev/dri \
+  --group-add video \
+  --group-add render \
+  hermes-webui:gpu vainfo
+```
+
+For Compose, add the same mapping to a custom service definition:
+
+```yaml
+services:
+  hermes-webui:
+    image: hermes-webui:gpu
+    devices:
+      - /dev/dri:/dev/dri
+    group_add:
+      - video
+      - render
+```
+
+`vainfo` should list the VA-API driver and supported profiles when the host
+driver stack and container permissions are correct.
+
+### NVIDIA
+
+Install and configure the NVIDIA Container Toolkit on the host first, then use
+Docker's GPU runtime flag:
+
+```bash
+docker run --rm --gpus all hermes-webui:gpu nvidia-smi
+```
+
+For Compose, use a custom service with GPU access enabled:
+
+```yaml
+services:
+  hermes-webui:
+    image: hermes-webui:gpu
+    gpus: all
+```
+
+If `nvidia-smi` is unavailable or reports no devices, fix the host NVIDIA driver
+and container toolkit setup before debugging Hermes WebUI. The container image
+only supplies the WebUI plus optional user-space media libraries; it cannot
+provide host kernel drivers or the NVIDIA runtime.
+
 ## Scheduled jobs and the gateway daemon
 
 **Symptom**: Cron jobs created in the Tasks panel never fire. System Settings or Tasks shows:
@@ -347,6 +419,7 @@ volumes:
 - #1399 — UID alignment in compose files (fixed in v0.50.260 via PR #1428 + this guide)
 - #3012 — host `localhost` API URLs fail from Docker containers (use `host.docker.internal` / `host.containers.internal`)
 - #3006 — `sudo docker compose` can mount `/root/.hermes` instead of the user's Hermes home
+- #3243 — optional GPU runtime image/docs for containerized acceleration workloads
 - #858 — two-container `/opt/hermes` path confusion
 - #681 — tools running in WebUI container, not agent container (architectural)
 - #668 — auto-detect UID/GID from mounted volume

--- a/tests/test_docker_gpu_runtime_docs.py
+++ b/tests/test_docker_gpu_runtime_docs.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+DOCKERFILE = (REPO / "Dockerfile").read_text(encoding="utf-8")
+DOCKER_DOCS = (REPO / "docs" / "docker.md").read_text(encoding="utf-8")
+
+
+def test_dockerfile_gpu_libraries_are_opt_in():
+    """The production image must stay CPU-only unless the GPU build arg is set."""
+    assert "ARG INSTALL_GPU_LIBS=0" in DOCKERFILE
+    assert 'if [ "$INSTALL_GPU_LIBS" = "1" ]' in DOCKERFILE
+
+    opt_in_block = DOCKERFILE[DOCKERFILE.index("ARG INSTALL_GPU_LIBS=0"):]
+    for package in (
+        "libva2",
+        "vainfo",
+        "mesa-va-drivers",
+        "intel-media-va-driver-non-free",
+    ):
+        assert package in opt_in_block, (
+            f"{package} must only appear in the INSTALL_GPU_LIBS opt-in block."
+        )
+        assert package not in DOCKERFILE[:DOCKERFILE.index("ARG INSTALL_GPU_LIBS=0")]
+
+
+def test_dockerfile_handles_missing_intel_non_free_driver():
+    """Debian slim repos may not expose the non-free Intel VA-API package."""
+    assert "apt-cache show intel-media-va-driver-non-free" in DOCKERFILE
+    assert "skipping Intel non-free VA-API driver" in DOCKERFILE
+
+
+def test_docker_docs_show_gpu_build_command():
+    assert "Optional GPU runtime image" in DOCKER_DOCS
+    assert "--build-arg INSTALL_GPU_LIBS=1" in DOCKER_DOCS
+    assert "default Hermes WebUI Docker image stays CPU-only" in DOCKER_DOCS
+
+
+def test_docker_docs_cover_intel_amd_dri_mapping():
+    assert "Intel and AMD VA-API" in DOCKER_DOCS
+    assert "--device /dev/dri:/dev/dri" in DOCKER_DOCS
+    assert "/dev/dri:/dev/dri" in DOCKER_DOCS
+    assert "group_add:" in DOCKER_DOCS
+    assert "video" in DOCKER_DOCS
+    assert "render" in DOCKER_DOCS
+    assert "vainfo" in DOCKER_DOCS
+
+
+def test_docker_docs_cover_nvidia_host_runtime_guidance():
+    assert "NVIDIA Container Toolkit" in DOCKER_DOCS
+    assert "--gpus all" in DOCKER_DOCS
+    assert "gpus: all" in DOCKER_DOCS
+    assert "host NVIDIA driver" in DOCKER_DOCS
+    assert "host kernel drivers" in DOCKER_DOCS
+    assert "NVIDIA runtime" in DOCKER_DOCS
+
+
+def test_docker_docs_do_not_claim_native_gpu_passthrough_verification():
+    assert "not a claim that native GPU passthrough was verified" in DOCKER_DOCS
+    assert "depends on host drivers" in DOCKER_DOCS

--- a/tests/test_docker_gpu_runtime_docs.py
+++ b/tests/test_docker_gpu_runtime_docs.py
@@ -5,6 +5,8 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 DOCKERFILE = (REPO / "Dockerfile").read_text(encoding="utf-8")
 DOCKER_DOCS = (REPO / "docs" / "docker.md").read_text(encoding="utf-8")
+DOCKER_INIT = (REPO / "docker_init.bash").read_text(encoding="utf-8")
+CHANGELOG = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
 
 
 def test_dockerfile_gpu_libraries_are_opt_in():
@@ -45,6 +47,7 @@ def test_docker_docs_cover_intel_amd_dri_mapping():
     assert "video" in DOCKER_DOCS
     assert "render" in DOCKER_DOCS
     assert "vainfo" in DOCKER_DOCS
+    assert "preserves Docker-provided supplemental groups" in DOCKER_DOCS
 
 
 def test_docker_docs_cover_nvidia_host_runtime_guidance():
@@ -59,3 +62,20 @@ def test_docker_docs_cover_nvidia_host_runtime_guidance():
 def test_docker_docs_do_not_claim_native_gpu_passthrough_verification():
     assert "not a claim that native GPU passthrough was verified" in DOCKER_DOCS
     assert "depends on host drivers" in DOCKER_DOCS
+
+
+def test_docker_init_preserves_supplemental_device_groups_for_runtime_user():
+    root_phase = DOCKER_INIT[:DOCKER_INIT.index("exec su -s /bin/bash")]
+
+    assert "for gid in $(id -G)" in root_phase
+    assert "groupadd -g \"$gid\"" in root_phase
+    assert "usermod -a -G \"$group_name\" hermeswebui" in root_phase
+    assert "Docker --group-add supplemental groups" in root_phase
+
+
+def test_changelog_mentions_optional_gpu_runtime_path():
+    unreleased = CHANGELOG[CHANGELOG.index("## [Unreleased]"):CHANGELOG.index("## [v0.51.293]")]
+
+    assert "Optional GPU runtime image path" in unreleased
+    assert "INSTALL_GPU_LIBS=1" in unreleased
+    assert "supplemental device groups" in unreleased

--- a/tests/test_docker_gpu_runtime_docs.py
+++ b/tests/test_docker_gpu_runtime_docs.py
@@ -3,18 +3,20 @@ from __future__ import annotations
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
-DOCKERFILE = (REPO / "Dockerfile").read_text(encoding="utf-8")
-DOCKER_DOCS = (REPO / "docs" / "docker.md").read_text(encoding="utf-8")
-DOCKER_INIT = (REPO / "docker_init.bash").read_text(encoding="utf-8")
-CHANGELOG = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
+
+
+def _repo_text(path):
+    return (REPO / path).read_text(encoding="utf-8")
 
 
 def test_dockerfile_gpu_libraries_are_opt_in():
     """The production image must stay CPU-only unless the GPU build arg is set."""
-    assert "ARG INSTALL_GPU_LIBS=0" in DOCKERFILE
-    assert 'if [ "$INSTALL_GPU_LIBS" = "1" ]' in DOCKERFILE
+    dockerfile = _repo_text("Dockerfile")
 
-    opt_in_block = DOCKERFILE[DOCKERFILE.index("ARG INSTALL_GPU_LIBS=0"):]
+    assert "ARG INSTALL_GPU_LIBS=0" in dockerfile
+    assert 'if [ "$INSTALL_GPU_LIBS" = "1" ]' in dockerfile
+
+    opt_in_block = dockerfile[dockerfile.index("ARG INSTALL_GPU_LIBS=0"):]
     for package in (
         "libva2",
         "vainfo",
@@ -24,48 +26,59 @@ def test_dockerfile_gpu_libraries_are_opt_in():
         assert package in opt_in_block, (
             f"{package} must only appear in the INSTALL_GPU_LIBS opt-in block."
         )
-        assert package not in DOCKERFILE[:DOCKERFILE.index("ARG INSTALL_GPU_LIBS=0")]
+        assert package not in dockerfile[:dockerfile.index("ARG INSTALL_GPU_LIBS=0")]
 
 
 def test_dockerfile_handles_missing_intel_non_free_driver():
     """Debian slim repos may not expose the non-free Intel VA-API package."""
-    assert "apt-cache show intel-media-va-driver-non-free" in DOCKERFILE
-    assert "skipping Intel non-free VA-API driver" in DOCKERFILE
+    dockerfile = _repo_text("Dockerfile")
+
+    assert "apt-cache show intel-media-va-driver-non-free" in dockerfile
+    assert "skipping Intel non-free VA-API driver" in dockerfile
 
 
 def test_docker_docs_show_gpu_build_command():
-    assert "Optional GPU runtime image" in DOCKER_DOCS
-    assert "--build-arg INSTALL_GPU_LIBS=1" in DOCKER_DOCS
-    assert "default Hermes WebUI Docker image stays CPU-only" in DOCKER_DOCS
+    docker_docs = _repo_text("docs/docker.md")
+
+    assert "Optional GPU runtime image" in docker_docs
+    assert "--build-arg INSTALL_GPU_LIBS=1" in docker_docs
+    assert "default Hermes WebUI Docker image stays CPU-only" in docker_docs
 
 
 def test_docker_docs_cover_intel_amd_dri_mapping():
-    assert "Intel and AMD VA-API" in DOCKER_DOCS
-    assert "--device /dev/dri:/dev/dri" in DOCKER_DOCS
-    assert "/dev/dri:/dev/dri" in DOCKER_DOCS
-    assert "group_add:" in DOCKER_DOCS
-    assert "video" in DOCKER_DOCS
-    assert "render" in DOCKER_DOCS
-    assert "vainfo" in DOCKER_DOCS
-    assert "preserves Docker-provided supplemental groups" in DOCKER_DOCS
+    docker_docs = _repo_text("docs/docker.md")
+
+    assert "Intel and AMD VA-API" in docker_docs
+    assert "--device /dev/dri:/dev/dri" in docker_docs
+    assert "/dev/dri:/dev/dri" in docker_docs
+    assert "group_add:" in docker_docs
+    assert "video" in docker_docs
+    assert "render" in docker_docs
+    assert "vainfo" in docker_docs
+    assert "preserves Docker-provided supplemental groups" in docker_docs
 
 
 def test_docker_docs_cover_nvidia_host_runtime_guidance():
-    assert "NVIDIA Container Toolkit" in DOCKER_DOCS
-    assert "--gpus all" in DOCKER_DOCS
-    assert "gpus: all" in DOCKER_DOCS
-    assert "host NVIDIA driver" in DOCKER_DOCS
-    assert "host kernel drivers" in DOCKER_DOCS
-    assert "NVIDIA runtime" in DOCKER_DOCS
+    docker_docs = _repo_text("docs/docker.md")
+
+    assert "NVIDIA Container Toolkit" in docker_docs
+    assert "--gpus all" in docker_docs
+    assert "gpus: all" in docker_docs
+    assert "host NVIDIA driver" in docker_docs
+    assert "host kernel drivers" in docker_docs
+    assert "NVIDIA runtime" in docker_docs
 
 
 def test_docker_docs_do_not_claim_native_gpu_passthrough_verification():
-    assert "not a claim that native GPU passthrough was verified" in DOCKER_DOCS
-    assert "depends on host drivers" in DOCKER_DOCS
+    docker_docs = _repo_text("docs/docker.md")
+
+    assert "not a claim that native GPU passthrough was verified" in docker_docs
+    assert "depends on host drivers" in docker_docs
 
 
 def test_docker_init_preserves_supplemental_device_groups_for_runtime_user():
-    root_phase = DOCKER_INIT[:DOCKER_INIT.index("exec su -s /bin/bash")]
+    docker_init = _repo_text("docker_init.bash")
+    root_phase = docker_init[:docker_init.index("exec su -s /bin/bash")]
 
     assert "for gid in $(id -G)" in root_phase
     assert "groupadd -g \"$gid\"" in root_phase
@@ -75,7 +88,8 @@ def test_docker_init_preserves_supplemental_device_groups_for_runtime_user():
 
 
 def test_changelog_mentions_optional_gpu_runtime_path():
-    unreleased = CHANGELOG[CHANGELOG.index("## [Unreleased]"):CHANGELOG.index("## [v0.51.293]")]
+    changelog = _repo_text("CHANGELOG.md")
+    unreleased = changelog[changelog.index("## [Unreleased]"):changelog.index("## [v0.51.293]")]
 
     assert "Optional GPU runtime image path" in unreleased
     assert "INSTALL_GPU_LIBS=1" in unreleased

--- a/tests/test_docker_gpu_runtime_docs.py
+++ b/tests/test_docker_gpu_runtime_docs.py
@@ -69,6 +69,7 @@ def test_docker_init_preserves_supplemental_device_groups_for_runtime_user():
 
     assert "for gid in $(id -G)" in root_phase
     assert "groupadd -g \"$gid\"" in root_phase
+    assert "Could not create supplemental group for GID $gid" in root_phase
     assert "usermod -a -G \"$group_name\" hermeswebui" in root_phase
     assert "Docker --group-add supplemental groups" in root_phase
 


### PR DESCRIPTION

## Thinking Path

- GPU users need user-space acceleration libraries and device mapping guidance, but most WebUI users should not pay default image-size cost.
- The maintainer explicitly preferred an opt-in build arg or separate GPU Dockerfile rather than installing GPU packages unconditionally.
- This PR keeps CPU-only defaults intact and adds a documented GPU build/runtime path.

## What Changed

- `Dockerfile`: add an opt-in GPU package install path guarded by a build arg.
- `docker_init.bash`: preserve Docker-provided supplemental groups before dropping to the `hermeswebui` runtime user, so `/dev/dri` group access survives startup.
- `docs/docker.md`: document GPU image build, Intel/AMD `/dev/dri` mapping, NVIDIA host runtime prerequisites, and verification caveats.
- `CHANGELOG.md`: add an Unreleased note for the optional GPU image path.
- `tests/test_docker_gpu_runtime_docs.py`: add static coverage for the opt-in behavior and docs.

## Why It Matters

Users running media or inference workloads in containers get a supported starting point without bloating or changing the default image for everyone else.

## Verification

```
python -m pytest tests/test_docker_gpu_runtime_docs.py -q --timeout=60
bash -n docker_init.bash
python scripts/ruff_lint.py --diff origin/master
git diff --check origin/master...HEAD
```

If Docker is available:

```
docker build --build-arg INSTALL_GPU_LIBS=1 -t hermes-webui:gpu-smoke .
```

## Risks / Follow-ups

- Hardware passthrough cannot be honestly verified from this Windows workspace unless run on a Linux Docker host with Intel/AMD/NVIDIA devices. The PR should state docs/build verification only if native hardware is not tested.

## Model Used

GPT-5.5 via Codex CLI; implementation and adversarial review assisted by Codex/Claude agents.
