### PR TITLE
fix(streaming): preserve restored live tool cards on reconnect (#3707)

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1139,6 +1139,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(targetText===currentText) return true;
     _restoredReconnectDisplayActive=false;
     assistantBody.classList.remove('stream-fade-active');
+    _smdReconnect=true;
     assistantBody.innerHTML='';
     return false;
   }

--- a/static/messages.js
+++ b/static/messages.js
@@ -824,6 +824,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!activeSid||!streamId) return;
   const reconnecting=!!options.reconnecting;
   const restoredLiveTurn=reconnecting&&!!options.restoredLiveTurn;
+  let _restoredReconnectDisplayActive=restoredLiveTurn;
   if(!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[...uploaded],toolCalls:[]};
   else {
     if(uploaded.length) INFLIGHT[activeSid].uploaded=[...uploaded];
@@ -1108,10 +1109,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   }
   function _replayRestoredLiveToolCardsIfMissing(){
     if(!restoredLiveTurn||!_isActiveSession()) return false;
-    const inner=(typeof _assistantTurnBlocks==='function')?_assistantTurnBlocks($('liveAssistantTurn')):null;
-    if(inner&&inner.querySelector('.tool-card-row[data-live-tid]')) return true;
     const calls=_knownReconnectToolCalls();
-    if(!calls.length) return false;
+    if(!calls.length){
+      const inner=(typeof _assistantTurnBlocks==='function')?_assistantTurnBlocks($('liveAssistantTurn')):null;
+      return !!(inner&&inner.querySelector('.tool-card-row[data-live-tid]'));
+    }
     if(typeof replayLiveToolCardsFromState==='function') return replayLiveToolCardsFromState(calls);
     if(typeof placeLiveToolCardsHost==='function') placeLiveToolCardsHost();
     let replayed=false;
@@ -1127,7 +1129,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     return String(text||'').replace(/\s+/g,' ').trim();
   }
   function _renderRestoredReconnectDisplay(displayText, fade=false){
-    if(!restoredLiveTurn||!assistantBody) return false;
+    if(!_restoredReconnectDisplayActive||!assistantBody) return false;
     const target=String(displayText||'');
     const currentText=_normalizedRestoredText(assistantBody.textContent||'');
     const targetText=_normalizedRestoredText(target);
@@ -1135,9 +1137,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(fade) _streamFadeVisibleText=target;
     assistantBody.classList.toggle('stream-fade-active',!!fade);
     if(targetText===currentText) return true;
+    _restoredReconnectDisplayActive=false;
+    assistantBody.classList.remove('stream-fade-active');
     assistantBody.innerHTML=renderMd ? renderMd(target) : esc(target);
     _sanitizeSmdLinks(assistantBody);
-    return true;
+    return false;
   }
 
   // ── Shared SSE handler wiring (used for initial connection and reconnect) ──

--- a/static/messages.js
+++ b/static/messages.js
@@ -1134,11 +1134,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const currentText=_normalizedRestoredText(assistantBody.textContent||'');
     const targetText=_normalizedRestoredText(target);
     if(!currentText||!targetText) return false;
-    if(fade) _streamFadeVisibleText=target;
     assistantBody.classList.toggle('stream-fade-active',!!fade);
-    if(targetText===currentText) return true;
+    if(targetText===currentText){
+      if(fade) _streamFadeVisibleText=target;
+      return true;
+    }
     _restoredReconnectDisplayActive=false;
     assistantBody.classList.remove('stream-fade-active');
+    _streamFadeVisibleText='';
     _smdReconnect=true;
     assistantBody.innerHTML='';
     return false;

--- a/static/messages.js
+++ b/static/messages.js
@@ -1109,7 +1109,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _replayRestoredLiveToolCardsIfMissing(){
     if(!restoredLiveTurn||!_isActiveSession()) return false;
     const inner=(typeof _assistantTurnBlocks==='function')?_assistantTurnBlocks($('liveAssistantTurn')):null;
-    if(inner&&inner.querySelector('.tool-card-row[data-live-tid],.tool-call-group[data-live-tool-call-group]')) return true;
+    if(inner&&inner.querySelector('.tool-card-row[data-live-tid]')) return true;
     const calls=_knownReconnectToolCalls();
     if(!calls.length) return false;
     if(typeof replayLiveToolCardsFromState==='function') return replayLiveToolCardsFromState(calls);

--- a/static/messages.js
+++ b/static/messages.js
@@ -1128,11 +1128,18 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _normalizedRestoredText(text){
     return String(text||'').replace(/\s+/g,' ').trim();
   }
+  function _normalizedRestoredMarkdownText(markdown){
+    const source=String(markdown||'');
+    if(typeof document==='undefined'||typeof renderMd!=='function') return _normalizedRestoredText(source);
+    const scratch=document.createElement('div');
+    scratch.innerHTML=renderMd(source);
+    return _normalizedRestoredText(scratch.textContent||'');
+  }
   function _renderRestoredReconnectDisplay(displayText, fade=false){
     if(!_restoredReconnectDisplayActive||!assistantBody) return false;
     const target=String(displayText||'');
     const currentText=_normalizedRestoredText(assistantBody.textContent||'');
-    const targetText=_normalizedRestoredText(target);
+    const targetText=_normalizedRestoredMarkdownText(target);
     if(!currentText||!targetText) return false;
     assistantBody.classList.toggle('stream-fade-active',!!fade);
     if(targetText===currentText){

--- a/static/messages.js
+++ b/static/messages.js
@@ -1139,8 +1139,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(targetText===currentText) return true;
     _restoredReconnectDisplayActive=false;
     assistantBody.classList.remove('stream-fade-active');
-    assistantBody.innerHTML=renderMd ? renderMd(target) : esc(target);
-    _sanitizeSmdLinks(assistantBody);
+    assistantBody.innerHTML='';
     return false;
   }
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -823,6 +823,7 @@ function closeOtherLiveStreams(activeSid){
 function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!activeSid||!streamId) return;
   const reconnecting=!!options.reconnecting;
+  const restoredLiveTurn=reconnecting&&!!options.restoredLiveTurn;
   if(!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[...uploaded],toolCalls:[]};
   else {
     if(uploaded.length) INFLIGHT[activeSid].uploaded=[...uploaded];
@@ -866,7 +867,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let _streamingKatexTimer=null; // throttles live KaTeX scans while smd writes deltas
   // On reconnect, the assistantBody already has partial smd-rendered content.
   // We clear it on first new token and restart the parser from the reconnect point.
-  let _smdReconnect=reconnecting;
+  let _smdReconnect=reconnecting&&!restoredLiveTurn;
   // Thinking tag patterns for streaming display
   const _thinkPairs=[
     {open:'<think>',close:'</think>'},
@@ -1100,6 +1101,45 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _freshSegment=false; // consumed — next reuse check is normal again
   }
 
+  function _knownReconnectToolCalls(){
+    const inflight=INFLIGHT[activeSid];
+    if(inflight&&Array.isArray(inflight.toolCalls)&&inflight.toolCalls.length) return inflight.toolCalls;
+    return Array.isArray(S.toolCalls)?S.toolCalls:[];
+  }
+  function _replayRestoredLiveToolCardsIfMissing(){
+    if(!restoredLiveTurn||!_isActiveSession()) return false;
+    const inner=(typeof _assistantTurnBlocks==='function')?_assistantTurnBlocks($('liveAssistantTurn')):null;
+    if(inner&&inner.querySelector('.tool-card-row[data-live-tid],.tool-call-group[data-live-tool-call-group]')) return true;
+    const calls=_knownReconnectToolCalls();
+    if(!calls.length) return false;
+    if(typeof replayLiveToolCardsFromState==='function') return replayLiveToolCardsFromState(calls);
+    if(typeof placeLiveToolCardsHost==='function') placeLiveToolCardsHost();
+    let replayed=false;
+    for(const tc of calls){
+      if(tc&&tc.name&&typeof appendLiveToolCard==='function'){
+        appendLiveToolCard(tc);
+        replayed=true;
+      }
+    }
+    return replayed;
+  }
+  function _normalizedRestoredText(text){
+    return String(text||'').replace(/\s+/g,' ').trim();
+  }
+  function _renderRestoredReconnectDisplay(displayText, fade=false){
+    if(!restoredLiveTurn||!assistantBody) return false;
+    const target=String(displayText||'');
+    const currentText=_normalizedRestoredText(assistantBody.textContent||'');
+    const targetText=_normalizedRestoredText(target);
+    if(!currentText||!targetText) return false;
+    if(fade) _streamFadeVisibleText=target;
+    assistantBody.classList.toggle('stream-fade-active',!!fade);
+    if(targetText===currentText) return true;
+    assistantBody.innerHTML=renderMd ? renderMd(target) : esc(target);
+    _sanitizeSmdLinks(assistantBody);
+    return true;
+  }
+
   // ── Shared SSE handler wiring (used for initial connection and reconnect) ──
   let _reconnectAttempted=false;
   let _terminalStateReached=false;
@@ -1119,6 +1159,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
           if(st.active){
             setComposerStatus('Reconnected');
+            _replayRestoredLiveToolCardsIfMissing();
             _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}`,document.baseURI||location.href).href,{withCredentials:true}));
             return;
           }
@@ -1626,6 +1667,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   }
   function _renderStreamingFadeMarkdown(displayText){
     if(!assistantBody) return true;
+    if(_renderRestoredReconnectDisplay(displayText,true)) return true;
     const next=_streamFadeNextText(displayText);
     if(!next.changed) return next.caughtUp;
     assistantBody.classList.add('stream-fade-active');
@@ -1759,7 +1801,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         } else {
           assistantBody.classList.remove('stream-fade-active');
           _resetStreamFadeState();
-          if(!_smdParser&&window.smd){
+          if(_renderRestoredReconnectDisplay(displayText,false)){
+            // Restored live DOM already represents this prefix; keep it visible
+            // until the next token requires a full markdown repaint.
+          } else if(!_smdParser&&window.smd){
             // On reconnect: prior content in assistantBody came from a different smd parser run.
             // Clear it and start fresh — renderMessages() on done will restore the full content.
             if(_smdReconnect){assistantBody.innerHTML='';_smdReconnect=false;}
@@ -2593,6 +2638,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
             if(st.active){
               setComposerStatus('Reconnected');
+              _replayRestoredLiveToolCardsIfMissing();
               _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}`,document.baseURI||location.href).href,{withCredentials:true}));
               return;
             }
@@ -2841,6 +2887,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }catch(_){}
     }
     const replayParams=replayOnly?_runJournalReplayParams():'';
+    _replayRestoredLiveToolCardsIfMissing();
     _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${replayParams}`,document.baseURI||location.href).href,{withCredentials:true}));
   })();
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -957,7 +957,7 @@ async function loadSession(sid){
     if(INFLIGHT[sid].reattach&&activeStreamId&&typeof attachLiveStream==='function'){
       INFLIGHT[sid].reattach=false;
       if (_loadingSessionId !== sid) return;
-      attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
+      attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true,restoredLiveTurn});
     }
   }else{
     // Phase 2b: Idle session — load full messages lazily for rendering.

--- a/static/ui.js
+++ b/static/ui.js
@@ -8212,6 +8212,26 @@ function appendLiveToolCard(tc){
   if(typeof scrollIfPinned==='function') scrollIfPinned();
 }
 
+function replayLiveToolCardsFromState(toolCalls){
+  if(!Array.isArray(toolCalls)||!toolCalls.length) return false;
+  if(!S.session||!S.activeStreamId) return false;
+  if(typeof placeLiveToolCardsHost==='function') placeLiveToolCardsHost();
+  let replayed=false;
+  for(const tc of toolCalls){
+    if(!tc||!tc.name) continue;
+    const tid=tc.tid||'';
+    const turn=$('liveAssistantTurn');
+    const inner=_assistantTurnBlocks(turn);
+    const existing=tid&&inner
+      ? inner.querySelector(`.tool-card-row[data-live-tid="${CSS.escape(tid)}"]`)
+      : null;
+    if(existing) continue;
+    appendLiveToolCard(tc);
+    replayed=true;
+  }
+  return replayed;
+}
+
 function clearLiveToolCards(){
   if(typeof _clearActivityElapsedTimer==='function') _clearActivityElapsedTimer();
   const inner=_assistantTurnBlocks($('liveAssistantTurn'));

--- a/tests/test_live_reconnect_restore.py
+++ b/tests/test_live_reconnect_restore.py
@@ -61,6 +61,7 @@ def test_restored_reconnect_display_deactivates_after_new_text_arrives():
     assert "if(!_restoredReconnectDisplayActive||!assistantBody) return false;" in helper_block
     assert "_restoredReconnectDisplayActive=false;" in helper_block
     divergent_block = helper_block[helper_block.index("_restoredReconnectDisplayActive=false;") :]
+    assert "_smdReconnect=true;" in divergent_block
     assert "assistantBody.innerHTML='';" in divergent_block
     assert "renderMd(target)" not in helper_block
     assert "return false;" in divergent_block

--- a/tests/test_live_reconnect_restore.py
+++ b/tests/test_live_reconnect_restore.py
@@ -31,7 +31,8 @@ def test_restored_reconnect_replays_known_tool_cards_before_sse_attach():
     helper_pos = MESSAGES_SRC.index("function _replayRestoredLiveToolCardsIfMissing")
     helper_block = MESSAGES_SRC[helper_pos : helper_pos + 900]
 
-    assert "inner.querySelector('.tool-card-row[data-live-tid],.tool-call-group[data-live-tool-call-group]')" in helper_block
+    assert "inner.querySelector('.tool-card-row[data-live-tid]')" in helper_block
+    assert ".tool-call-group[data-live-tool-call-group]" not in helper_block
     assert "replayLiveToolCardsFromState(calls)" in helper_block
     assert "appendLiveToolCard(tc)" in helper_block
 

--- a/tests/test_live_reconnect_restore.py
+++ b/tests/test_live_reconnect_restore.py
@@ -59,6 +59,9 @@ def test_restored_reconnect_display_deactivates_after_new_text_arrives():
 
     assert "let _restoredReconnectDisplayActive=restoredLiveTurn;" in messages_src[option_pos : option_pos + 140]
     assert "if(!_restoredReconnectDisplayActive||!assistantBody) return false;" in helper_block
+    assert "function _normalizedRestoredMarkdownText(markdown)" in messages_src
+    assert "scratch.innerHTML=renderMd(source);" in messages_src
+    assert "const targetText=_normalizedRestoredMarkdownText(target);" in helper_block
     assert "_restoredReconnectDisplayActive=false;" in helper_block
     divergent_block = helper_block[helper_block.index("_restoredReconnectDisplayActive=false;") :]
     matching_block = helper_block[helper_block.index("if(targetText===currentText){") : helper_block.index("_restoredReconnectDisplayActive=false;")]

--- a/tests/test_live_reconnect_restore.py
+++ b/tests/test_live_reconnect_restore.py
@@ -2,49 +2,72 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-SESSIONS_SRC = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
-MESSAGES_SRC = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
-UI_SRC = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _static_source(path):
+    return (ROOT / "static" / path).read_text(encoding="utf-8")
 
 
 def test_session_load_passes_restored_live_turn_to_reconnect_attach():
-    restore_pos = SESSIONS_SRC.index("const restoredLiveTurn=")
-    attach_pos = SESSIONS_SRC.index("attachLiveStream(sid, activeStreamId", restore_pos)
-    attach_call = SESSIONS_SRC[attach_pos : attach_pos + 220]
+    sessions_src = _static_source("sessions.js")
 
-    assert "restoreLiveTurnHtmlForSession(sid)" in SESSIONS_SRC[restore_pos : restore_pos + 160]
+    restore_pos = sessions_src.index("const restoredLiveTurn=")
+    attach_pos = sessions_src.index("attachLiveStream(sid, activeStreamId", restore_pos)
+    attach_call = sessions_src[attach_pos : attach_pos + 220]
+
+    assert "restoreLiveTurnHtmlForSession(sid)" in sessions_src[restore_pos : restore_pos + 160]
     assert "{reconnecting:true,restoredLiveTurn}" in attach_call
 
 
 def test_restored_reconnect_does_not_arm_first_streaming_markdown_clear():
-    option_pos = MESSAGES_SRC.index("const restoredLiveTurn=reconnecting&&!!options.restoredLiveTurn")
-    smd_pos = MESSAGES_SRC.index("let _smdReconnect=", option_pos)
-    render_helper_pos = MESSAGES_SRC.index("function _renderRestoredReconnectDisplay", option_pos)
-    render_path_pos = MESSAGES_SRC.index("_renderRestoredReconnectDisplay(displayText,false)", render_helper_pos)
-    clear_pos = MESSAGES_SRC.index("if(_smdReconnect){assistantBody.innerHTML='';_smdReconnect=false;}", render_path_pos)
+    messages_src = _static_source("messages.js")
 
-    assert "let _smdReconnect=reconnecting&&!restoredLiveTurn;" in MESSAGES_SRC[smd_pos : smd_pos + 80]
+    option_pos = messages_src.index("const restoredLiveTurn=reconnecting&&!!options.restoredLiveTurn")
+    smd_pos = messages_src.index("let _smdReconnect=", option_pos)
+    render_helper_pos = messages_src.index("function _renderRestoredReconnectDisplay", option_pos)
+    render_path_pos = messages_src.index("_renderRestoredReconnectDisplay(displayText,false)", render_helper_pos)
+    clear_pos = messages_src.index("if(_smdReconnect){assistantBody.innerHTML='';_smdReconnect=false;}", render_path_pos)
+
+    assert "let _smdReconnect=reconnecting&&!restoredLiveTurn;" in messages_src[smd_pos : smd_pos + 80]
     assert render_path_pos < clear_pos
 
 
 def test_restored_reconnect_replays_known_tool_cards_before_sse_attach():
-    helper_pos = MESSAGES_SRC.index("function _replayRestoredLiveToolCardsIfMissing")
-    helper_block = MESSAGES_SRC[helper_pos : helper_pos + 900]
+    messages_src = _static_source("messages.js")
+
+    helper_pos = messages_src.index("function _replayRestoredLiveToolCardsIfMissing")
+    helper_block = messages_src[helper_pos : helper_pos + 900]
 
     assert "inner.querySelector('.tool-card-row[data-live-tid]')" in helper_block
     assert ".tool-call-group[data-live-tool-call-group]" not in helper_block
+    assert "querySelector('.tool-card-row[data-live-tid]')) return true" not in helper_block
     assert "replayLiveToolCardsFromState(calls)" in helper_block
     assert "appendLiveToolCard(tc)" in helper_block
 
-    preflight_pos = MESSAGES_SRC.index("const replayParams=replayOnly?_runJournalReplayParams():'';")
-    preflight_block = MESSAGES_SRC[preflight_pos : preflight_pos + 300]
+    preflight_pos = messages_src.index("const replayParams=replayOnly?_runJournalReplayParams():'';")
+    preflight_block = messages_src[preflight_pos : preflight_pos + 300]
     assert "_replayRestoredLiveToolCardsIfMissing();" in preflight_block
     assert preflight_block.index("_replayRestoredLiveToolCardsIfMissing();") < preflight_block.index("_wireSSE(")
 
 
+def test_restored_reconnect_display_deactivates_after_new_text_arrives():
+    messages_src = _static_source("messages.js")
+
+    option_pos = messages_src.index("const restoredLiveTurn=reconnecting&&!!options.restoredLiveTurn")
+    helper_pos = messages_src.index("function _renderRestoredReconnectDisplay", option_pos)
+    helper_block = messages_src[helper_pos : messages_src.index("Shared SSE handler", helper_pos)]
+
+    assert "let _restoredReconnectDisplayActive=restoredLiveTurn;" in messages_src[option_pos : option_pos + 140]
+    assert "if(!_restoredReconnectDisplayActive||!assistantBody) return false;" in helper_block
+    assert "_restoredReconnectDisplayActive=false;" in helper_block
+    assert "return false;" in helper_block[helper_block.index("_restoredReconnectDisplayActive=false;") :]
+
+
 def test_live_tool_replay_helper_is_idempotent_for_restored_tids():
-    helper_pos = UI_SRC.index("function replayLiveToolCardsFromState")
-    helper_block = UI_SRC[helper_pos : UI_SRC.index("function clearLiveToolCards", helper_pos)]
+    ui_src = _static_source("ui.js")
+
+    helper_pos = ui_src.index("function replayLiveToolCardsFromState")
+    helper_block = ui_src[helper_pos : ui_src.index("function clearLiveToolCards", helper_pos)]
 
     assert ".tool-card-row[data-live-tid=" in helper_block
     assert "if(existing) continue;" in helper_block

--- a/tests/test_live_reconnect_restore.py
+++ b/tests/test_live_reconnect_restore.py
@@ -61,6 +61,9 @@ def test_restored_reconnect_display_deactivates_after_new_text_arrives():
     assert "if(!_restoredReconnectDisplayActive||!assistantBody) return false;" in helper_block
     assert "_restoredReconnectDisplayActive=false;" in helper_block
     divergent_block = helper_block[helper_block.index("_restoredReconnectDisplayActive=false;") :]
+    matching_block = helper_block[helper_block.index("if(targetText===currentText){") : helper_block.index("_restoredReconnectDisplayActive=false;")]
+    assert "if(fade) _streamFadeVisibleText=target;" in matching_block
+    assert "_streamFadeVisibleText='';" in divergent_block
     assert "_smdReconnect=true;" in divergent_block
     assert "assistantBody.innerHTML='';" in divergent_block
     assert "renderMd(target)" not in helper_block

--- a/tests/test_live_reconnect_restore.py
+++ b/tests/test_live_reconnect_restore.py
@@ -60,7 +60,10 @@ def test_restored_reconnect_display_deactivates_after_new_text_arrives():
     assert "let _restoredReconnectDisplayActive=restoredLiveTurn;" in messages_src[option_pos : option_pos + 140]
     assert "if(!_restoredReconnectDisplayActive||!assistantBody) return false;" in helper_block
     assert "_restoredReconnectDisplayActive=false;" in helper_block
-    assert "return false;" in helper_block[helper_block.index("_restoredReconnectDisplayActive=false;") :]
+    divergent_block = helper_block[helper_block.index("_restoredReconnectDisplayActive=false;") :]
+    assert "assistantBody.innerHTML='';" in divergent_block
+    assert "renderMd(target)" not in helper_block
+    assert "return false;" in divergent_block
 
 
 def test_live_tool_replay_helper_is_idempotent_for_restored_tids():

--- a/tests/test_live_reconnect_restore.py
+++ b/tests/test_live_reconnect_restore.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_SRC = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+MESSAGES_SRC = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+UI_SRC = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def test_session_load_passes_restored_live_turn_to_reconnect_attach():
+    restore_pos = SESSIONS_SRC.index("const restoredLiveTurn=")
+    attach_pos = SESSIONS_SRC.index("attachLiveStream(sid, activeStreamId", restore_pos)
+    attach_call = SESSIONS_SRC[attach_pos : attach_pos + 220]
+
+    assert "restoreLiveTurnHtmlForSession(sid)" in SESSIONS_SRC[restore_pos : restore_pos + 160]
+    assert "{reconnecting:true,restoredLiveTurn}" in attach_call
+
+
+def test_restored_reconnect_does_not_arm_first_streaming_markdown_clear():
+    option_pos = MESSAGES_SRC.index("const restoredLiveTurn=reconnecting&&!!options.restoredLiveTurn")
+    smd_pos = MESSAGES_SRC.index("let _smdReconnect=", option_pos)
+    render_helper_pos = MESSAGES_SRC.index("function _renderRestoredReconnectDisplay", option_pos)
+    render_path_pos = MESSAGES_SRC.index("_renderRestoredReconnectDisplay(displayText,false)", render_helper_pos)
+    clear_pos = MESSAGES_SRC.index("if(_smdReconnect){assistantBody.innerHTML='';_smdReconnect=false;}", render_path_pos)
+
+    assert "let _smdReconnect=reconnecting&&!restoredLiveTurn;" in MESSAGES_SRC[smd_pos : smd_pos + 80]
+    assert render_path_pos < clear_pos
+
+
+def test_restored_reconnect_replays_known_tool_cards_before_sse_attach():
+    helper_pos = MESSAGES_SRC.index("function _replayRestoredLiveToolCardsIfMissing")
+    helper_block = MESSAGES_SRC[helper_pos : helper_pos + 900]
+
+    assert "inner.querySelector('.tool-card-row[data-live-tid],.tool-call-group[data-live-tool-call-group]')" in helper_block
+    assert "replayLiveToolCardsFromState(calls)" in helper_block
+    assert "appendLiveToolCard(tc)" in helper_block
+
+    preflight_pos = MESSAGES_SRC.index("const replayParams=replayOnly?_runJournalReplayParams():'';")
+    preflight_block = MESSAGES_SRC[preflight_pos : preflight_pos + 300]
+    assert "_replayRestoredLiveToolCardsIfMissing();" in preflight_block
+    assert preflight_block.index("_replayRestoredLiveToolCardsIfMissing();") < preflight_block.index("_wireSSE(")
+
+
+def test_live_tool_replay_helper_is_idempotent_for_restored_tids():
+    helper_pos = UI_SRC.index("function replayLiveToolCardsFromState")
+    helper_block = UI_SRC[helper_pos : UI_SRC.index("function clearLiveToolCards", helper_pos)]
+
+    assert ".tool-card-row[data-live-tid=" in helper_block
+    assert "if(existing) continue;" in helper_block
+    assert "appendLiveToolCard(tc);" in helper_block


### PR DESCRIPTION

## Thinking Path

- The v0.51.291 snapshot fix restored live thinking/text when switching back to an active session, but the follow-up report shows live tool cards are still stripped until another stream update arrives.
- `loadSession()` can successfully restore the saved live turn and then immediately reattach the stream; reconnect cleanup still treats those restored tool cards as stale live chrome.
- The fix keeps reconnect cleanup reconciled with the restored snapshot, replaying known tool calls only when needed and avoiding a visible empty-card gap.

## What Changed

- `static/sessions.js`: pass restored-live-turn state into reconnect setup.
- `static/messages.js`: preserve or immediately replay restored live tool cards/text during reconnect.
- `static/ui.js`: add a small helper if needed so live tool-card replay stays centralized.
- `tests/test_live_reconnect_restore.py`: add regression coverage for restored snapshot plus reconnect cleanup.

## Why It Matters

Users switching between long-running sessions should see the same live progress they already saw, not a partially reset transcript. This closes the remaining residual from the live-turn restore bug without waiting for broad live-to-final redesign work.

## Verification

```
python -m pytest tests/test_live_reconnect_restore.py -q --timeout=60
node --check static/messages.js
node --check static/sessions.js
node --check static/ui.js
git diff --check origin/master...HEAD
```

## Risks / Follow-ups

- This intentionally does not redesign live-to-final rendering or resolve broader #3400 work; it only preserves already-restored live state during reconnect.

## Model Used

GPT-5.5 via Codex CLI; implementation and adversarial review assisted by Codex/Claude agents.
