### PR TITLE
fix(terminal): reap embedded terminal descendants (#2577)

### DIFF
--- a/api/terminal.py
+++ b/api/terminal.py
@@ -89,6 +89,8 @@ _spawn_queue: queue.Queue = queue.Queue()
 _spawn_supervisor_started = False
 _spawn_supervisor_lock = threading.Lock()
 _spawn_supervisor_thread: threading.Thread | None = None
+_terminal_descendant_reaper_lock = threading.Lock()
+_TERMINAL_DESCENDANT_REAPER_LIMIT = 64
 
 
 @dataclass
@@ -129,6 +131,29 @@ def _reap_abandoned_spawn(proc: subprocess.Popen) -> bool:
         print("terminal abandoned spawn cleanup failed", flush=True)
         return False
     return True
+
+
+def _reap_terminal_descendants(limit: int = _TERMINAL_DESCENDANT_REAPER_LIMIT) -> int:
+    """Reap exited terminal descendants that have been reparented to WebUI."""
+    if not _TERMINAL_SUPPORTED:
+        return 0
+    reaped = 0
+    with _terminal_descendant_reaper_lock:
+        for _ in range(max(0, int(limit))):
+            try:
+                pid, _status = os.waitpid(-1, os.WNOHANG)
+            except ChildProcessError:
+                break
+            except InterruptedError:
+                continue
+            except OSError as exc:
+                if exc.errno in (errno.ECHILD, errno.EINTR):
+                    break
+                break
+            if pid == 0:
+                break
+            reaped += 1
+    return reaped
 
 
 def _spawn_supervisor_loop() -> None:
@@ -248,6 +273,7 @@ def _reader_loop(term: TerminalSession) -> None:
     finally:
         term.closed.set()
         code = term.proc.poll()
+        _reap_terminal_descendants()
         term.put_output("terminal_closed", {"exit_code": code})
 
 
@@ -416,6 +442,7 @@ def close_terminal(session_id: str) -> bool:
             os.close(term.master_fd)
         except OSError:
             pass
+        _reap_terminal_descendants()
     return True
 
 
@@ -425,6 +452,7 @@ def close_all_terminals() -> None:
         session_ids = list(_TERMINALS)
     for session_id in session_ids:
         close_terminal(session_id)
+    _reap_terminal_descendants()
 
 
 atexit.register(close_all_terminals)

--- a/api/terminal.py
+++ b/api/terminal.py
@@ -133,22 +133,25 @@ def _reap_abandoned_spawn(proc: subprocess.Popen) -> bool:
     return True
 
 
-def _reap_terminal_descendants(limit: int = _TERMINAL_DESCENDANT_REAPER_LIMIT) -> int:
-    """Reap exited terminal descendants that have been reparented to WebUI."""
+def _reap_terminal_descendants(
+    terminal_pgid: int,
+    limit: int = _TERMINAL_DESCENDANT_REAPER_LIMIT,
+) -> int:
+    """Reap exited descendants that still belong to a terminal-owned process group."""
     if not _TERMINAL_SUPPORTED:
+        return 0
+    try:
+        terminal_pgid = abs(int(terminal_pgid))
+    except (TypeError, ValueError):
+        return 0
+    if terminal_pgid <= 0:
         return 0
     reaped = 0
     with _terminal_descendant_reaper_lock:
         for _ in range(max(0, int(limit))):
             try:
-                pid, _status = os.waitpid(-1, os.WNOHANG)
-            except ChildProcessError:
-                break
-            except InterruptedError:
-                continue
-            except OSError as exc:
-                if exc.errno in (errno.ECHILD, errno.EINTR):
-                    break
+                pid, _status = os.waitpid(-terminal_pgid, os.WNOHANG)
+            except (ChildProcessError, OSError):
                 break
             if pid == 0:
                 break
@@ -273,7 +276,7 @@ def _reader_loop(term: TerminalSession) -> None:
     finally:
         term.closed.set()
         code = term.proc.poll()
-        _reap_terminal_descendants()
+        _reap_terminal_descendants(term.proc.pid)
         term.put_output("terminal_closed", {"exit_code": code})
 
 
@@ -442,7 +445,7 @@ def close_terminal(session_id: str) -> bool:
             os.close(term.master_fd)
         except OSError:
             pass
-        _reap_terminal_descendants()
+        _reap_terminal_descendants(term.proc.pid)
     return True
 
 
@@ -452,7 +455,6 @@ def close_all_terminals() -> None:
         session_ids = list(_TERMINALS)
     for session_id in session_ids:
         close_terminal(session_id)
-    _reap_terminal_descendants()
 
 
 atexit.register(close_all_terminals)

--- a/tests/test_terminal_zombie_reaper.py
+++ b/tests/test_terminal_zombie_reaper.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import sys
 import time
 

--- a/tests/test_terminal_zombie_reaper.py
+++ b/tests/test_terminal_zombie_reaper.py
@@ -1,0 +1,117 @@
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt"
+    or not sys.platform.startswith("linux")
+    or not getattr(__import__("api.terminal", fromlist=["_TERMINAL_SUPPORTED"]), "_TERMINAL_SUPPORTED", False),
+    reason="Linux-only terminal zombie reaper coverage",
+)
+
+import api.terminal as terminal
+
+
+def _wait_until_waitable(pid: int, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = os.waitid(os.P_PID, pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
+        if result is not None and result.si_pid == pid:
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"child {pid} did not exit before timeout")
+
+
+def test_reap_terminal_descendants_reaps_exited_child():
+    pid = os.fork()
+    if pid == 0:
+        os._exit(0)
+
+    reaped = False
+    try:
+        _wait_until_waitable(pid)
+
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            terminal._reap_terminal_descendants()
+            try:
+                os.waitid(os.P_PID, pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
+            except ChildProcessError:
+                reaped = True
+                break
+            time.sleep(0.01)
+
+        assert reaped, "terminal descendant reaper did not reap the exited child"
+    finally:
+        if not reaped:
+            try:
+                os.waitpid(pid, 0)
+            except ChildProcessError:
+                pass
+
+
+def test_close_terminal_reaps_descendants_after_shell_wait(monkeypatch):
+    class FakeProc:
+        pid = 987654
+
+        def __init__(self):
+            self.wait_calls = []
+            self.returncode = None
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self, timeout=None):
+            self.wait_calls.append(timeout)
+            self.returncode = -1
+            return self.returncode
+
+    proc = FakeProc()
+    term = terminal.TerminalSession(
+        session_id="term-descendant-reap",
+        workspace="/tmp",
+        proc=proc,
+        master_fd=12345,
+    )
+    terminal._TERMINALS["term-descendant-reap"] = term
+    kills = []
+    reaped = []
+
+    monkeypatch.setattr(terminal.os, "killpg", lambda pid, sig: kills.append((pid, sig)))
+    monkeypatch.setattr(terminal.os, "close", lambda fd: None)
+    monkeypatch.setattr(terminal, "_reap_terminal_descendants", lambda: reaped.append(True) or 0)
+
+    assert terminal.close_terminal("term-descendant-reap") is True
+
+    assert kills == [(proc.pid, terminal.signal.SIGHUP)]
+    assert proc.wait_calls == [1.5]
+    assert reaped == [True]
+
+
+def test_reap_terminal_descendants_ignores_expected_waitpid_errors(monkeypatch):
+    calls = []
+
+    def fake_waitpid(pid, flags):
+        calls.append((pid, flags))
+        raise ChildProcessError()
+
+    monkeypatch.setattr(terminal.os, "waitpid", fake_waitpid)
+
+    assert terminal._reap_terminal_descendants() == 0
+    assert calls == [(-1, os.WNOHANG)]
+
+
+def test_reap_terminal_descendants_is_bounded(monkeypatch):
+    calls = []
+
+    def fake_waitpid(pid, flags):
+        calls.append((pid, flags))
+        return (len(calls), 0)
+
+    monkeypatch.setattr(terminal.os, "waitpid", fake_waitpid)
+
+    assert terminal._reap_terminal_descendants(limit=3) == 3
+    assert calls == [(-1, os.WNOHANG), (-1, os.WNOHANG), (-1, os.WNOHANG)]

--- a/tests/test_terminal_zombie_reaper.py
+++ b/tests/test_terminal_zombie_reaper.py
@@ -25,17 +25,25 @@ def _wait_until_waitable(pid: int, timeout: float = 2.0) -> None:
 
 
 def test_reap_terminal_descendants_reaps_exited_child():
+    ready_r, ready_w = os.pipe()
     pid = os.fork()
     if pid == 0:
+        os.close(ready_r)
+        os.setpgid(0, 0)
+        os.write(ready_w, b"1")
+        os.close(ready_w)
         os._exit(0)
 
     reaped = False
     try:
+        os.close(ready_w)
+        assert os.read(ready_r, 1) == b"1"
+        os.close(ready_r)
         _wait_until_waitable(pid)
 
         deadline = time.monotonic() + 2.0
         while time.monotonic() < deadline:
-            terminal._reap_terminal_descendants()
+            terminal._reap_terminal_descendants(pid)
             try:
                 os.waitid(os.P_PID, pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
             except ChildProcessError:
@@ -81,13 +89,13 @@ def test_close_terminal_reaps_descendants_after_shell_wait(monkeypatch):
 
     monkeypatch.setattr(terminal.os, "killpg", lambda pid, sig: kills.append((pid, sig)))
     monkeypatch.setattr(terminal.os, "close", lambda fd: None)
-    monkeypatch.setattr(terminal, "_reap_terminal_descendants", lambda: reaped.append(True) or 0)
+    monkeypatch.setattr(terminal, "_reap_terminal_descendants", lambda pgid: reaped.append(pgid) or 0)
 
     assert terminal.close_terminal("term-descendant-reap") is True
 
     assert kills == [(proc.pid, terminal.signal.SIGHUP)]
     assert proc.wait_calls == [1.5]
-    assert reaped == [True]
+    assert reaped == [proc.pid]
 
 
 def test_reap_terminal_descendants_ignores_expected_waitpid_errors(monkeypatch):
@@ -99,8 +107,8 @@ def test_reap_terminal_descendants_ignores_expected_waitpid_errors(monkeypatch):
 
     monkeypatch.setattr(terminal.os, "waitpid", fake_waitpid)
 
-    assert terminal._reap_terminal_descendants() == 0
-    assert calls == [(-1, os.WNOHANG)]
+    assert terminal._reap_terminal_descendants(123) == 0
+    assert calls == [(-123, os.WNOHANG)]
 
 
 def test_reap_terminal_descendants_is_bounded(monkeypatch):
@@ -112,5 +120,5 @@ def test_reap_terminal_descendants_is_bounded(monkeypatch):
 
     monkeypatch.setattr(terminal.os, "waitpid", fake_waitpid)
 
-    assert terminal._reap_terminal_descendants(limit=3) == 3
-    assert calls == [(-1, os.WNOHANG), (-1, os.WNOHANG), (-1, os.WNOHANG)]
+    assert terminal._reap_terminal_descendants(123, limit=3) == 3
+    assert calls == [(-123, os.WNOHANG), (-123, os.WNOHANG), (-123, os.WNOHANG)]


### PR DESCRIPTION
## Thinking Path

- The already-shipped terminal cleanup handles the PTY shell that WebUI directly owns, but #2577 still tracks zombie descendants that can be reparented to the long-running WebUI process.
- `PR_SET_PDEATHSIG` is explicitly forbidden in the current terminal module because request-thread parentage killed new terminals immediately on Linux.
- The least invasive remaining slice is a bounded lifecycle reaper that calls `waitpid(-1, WNOHANG)` from terminal close and reader cleanup paths.

## What Changed

- `api/terminal.py`: add a bounded POSIX descendant reaper and call it after terminal shell shutdown paths.
- `tests/test_terminal_zombie_reaper.py`: add Linux-only coverage for reaping an exited child without requiring Node.

## Why It Matters

Long-running WebUI processes should not accumulate defunct descendants from embedded terminal sessions. This closes the remaining #2577 scope without regressing the Linux terminal startup fix that removed parent-death signals.

## Verification

Local tests were skipped for this push so CI can provide the concrete validation result without Windows console-window interference.

## Risks / Follow-ups

- This does not try to manage arbitrary detached daemons that remain alive after the terminal closes; it only reaps children that have already exited and been reparented to WebUI.

## Model Used

GPT 5.5 via Codex CLI
