### PR TITLE
perf(session): skip fuzzy matching for giant merge payloads

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -4040,7 +4040,6 @@ def _session_message_visible_key(msg: dict):
 
 def _build_visible_duplicate_lookup(visible_keys: set[tuple]) -> dict:
     by_role = {}
-    loose_by_key = {}
     for key in visible_keys:
         try:
             role = key[0]
@@ -4050,8 +4049,10 @@ def _build_visible_duplicate_lookup(visible_keys: set[tuple]) -> dict:
         if not content:
             continue
         by_role.setdefault(role, []).append(key)
-        loose_by_key[key] = _loose_session_message_content(content)
-    return {"keys": visible_keys, "by_role": by_role, "loose_by_key": loose_by_key}
+    # Keep loose_by_key lazy.  Some transcripts contain multi-megabyte tool
+    # outputs; eagerly casefolding + regex-tokenizing every visible key on every
+    # duplicate probe made /api/session take 10s+ and blocked /api/sessions.
+    return {"keys": visible_keys, "by_role": by_role, "loose_by_key": {}}
 
 
 def _matching_visible_duplicate(visible_key: tuple, visible_keys: set[tuple], lookup: dict | None = None):
@@ -4064,16 +4065,28 @@ def _matching_visible_duplicate(visible_key: tuple, visible_keys: set[tuple], lo
     if lookup is None:
         lookup = _build_visible_duplicate_lookup(visible_keys)
     loose_content = None
+    loose_by_key = lookup.setdefault("loose_by_key", {})
     for existing_key in lookup.get("by_role", {}).get(role, []):
         existing_role = existing_key[0]
         existing_content = existing_key[1] if len(existing_key) > 1 else ""
         if role != existing_role or not existing_content:
             continue
+        # Exact visible-key equality was checked above.  For very large payloads
+        # (tool logs / request dumps), fuzzy substring/token comparisons are both
+        # expensive and low-value; doing them repeatedly made session loading
+        # block the whole WebUI for many seconds.  Keep fuzzy matching for normal
+        # chat-sized text, but do exact-only matching for giant payloads.
+        if max(len(content), len(existing_content)) > 200_000:
+            continue
         if content in existing_content or existing_content in content:
             return existing_key
         if loose_content is None:
             loose_content = _loose_session_message_content(content)
-        loose_existing = lookup.get("loose_by_key", {}).get(existing_key, "")
+        if existing_key in loose_by_key:
+            loose_existing = loose_by_key.get(existing_key, "")
+        else:
+            loose_existing = _loose_session_message_content(existing_content)
+            loose_by_key[existing_key] = loose_existing
         if loose_content and loose_existing and (
             loose_content in loose_existing or loose_existing in loose_content
         ):

--- a/api/models.py
+++ b/api/models.py
@@ -4071,20 +4071,20 @@ def _matching_visible_duplicate(visible_key: tuple, visible_keys: set[tuple], lo
         existing_content = existing_key[1] if len(existing_key) > 1 else ""
         if role != existing_role or not existing_content:
             continue
-        # Exact visible-key equality was checked above.  For very large payloads
-        # (tool logs / request dumps), fuzzy substring/token comparisons are both
-        # expensive and low-value; doing them repeatedly made session loading
-        # block the whole WebUI for many seconds.  Keep fuzzy matching for normal
-        # chat-sized text, but do exact-only matching for giant payloads.
+        # Exact visible-key equality was checked above. For very large payloads
+        # (tool logs / request dumps), Python-in substring and fuzzy-token
+        # comparisons are both expensive and low-value; doing them repeatedly
+        # made session loading block the whole WebUI for many seconds. Keep
+        # fuzzy matching for normal chat-sized text, but do exact-only matching
+        # for giant payloads.
         if max(len(content), len(existing_content)) > 200_000:
             continue
         if content in existing_content or existing_content in content:
             return existing_key
         if loose_content is None:
             loose_content = _loose_session_message_content(content)
-        if existing_key in loose_by_key:
-            loose_existing = loose_by_key.get(existing_key, "")
-        else:
+        loose_existing = loose_by_key.get(existing_key)
+        if loose_existing is None:
             loose_existing = _loose_session_message_content(existing_content)
             loose_by_key[existing_key] = loose_existing
         if loose_content and loose_existing and (

--- a/tests/test_merge_key_tool_calls.py
+++ b/tests/test_merge_key_tool_calls.py
@@ -10,6 +10,7 @@ a single key, losing tool calls during merge.
 """
 from __future__ import annotations
 
+from api import models
 from api.models import (
     _matching_visible_duplicate,
     _session_message_dedup_key,
@@ -130,3 +131,43 @@ class TestMergeToolCallsEndToEnd:
         msg = {"role": "assistant", "content": "hello", "timestamp": 1000}
         result = merge_session_messages_append_only([msg], [msg])
         assert len(result) == 1
+
+
+# ── large-payload duplicate matching performance ────────────────────────────
+
+
+class TestVisibleDuplicateLargePayloadPerformance:
+    def test_large_nonmatching_payload_skips_loose_normalizer(self, monkeypatch):
+        """Giant tool/log payloads must not be regex-tokenized for fuzzy matching.
+
+        Exact visible-key equality is checked before this path. For non-exact
+        multi-hundred-KB payloads, fuzzy substring/token matching is too costly
+        for the /api/session hot path and low-value for deduplication.
+        """
+        def fail_if_called(_content):
+            raise AssertionError("large payloads should not hit loose normalizer")
+
+        monkeypatch.setattr(models, "_loose_session_message_content", fail_if_called)
+
+        large_state = ("state output\n" * 25_000).strip()
+        large_sidecar = ("sidecar output\n" * 25_000).strip()
+        visible_key = ("assistant", large_state, "")
+        sidecar_key = ("assistant", large_sidecar, "")
+
+        assert _matching_visible_duplicate(visible_key, {sidecar_key}) is None
+
+    def test_small_nonmatching_payload_keeps_loose_matching(self, monkeypatch):
+        """The large-payload guard must not disable legacy fuzzy matching."""
+        calls = []
+
+        def counted_loose(content):
+            calls.append(content)
+            return " ".join(str(content).lower().replace(",", "").replace("!", "").split())
+
+        monkeypatch.setattr(models, "_loose_session_message_content", counted_loose)
+
+        visible_key = ("assistant", "hello world", "")
+        sidecar_key = ("assistant", "HELLO, WORLD!!", "")
+
+        assert _matching_visible_duplicate(visible_key, {sidecar_key}) == sidecar_key
+        assert len(calls) == 2


### PR DESCRIPTION
## Summary
- Avoid eager regex/casefold normalization for every visible key in `_matching_visible_duplicate()`.
- Keep loose-content normalization lazy and cached only when a small-text candidate reaches the fuzzy path.
- Skip substring/loose fuzzy matching for non-exact payloads larger than 200KB; exact visible-key matches still short-circuit before the guard.

## Why
A production WebUI session with large tool/log payloads made `/api/session?messages=1&msg_limit=30` spend ~13s in `merge_session_messages_append_only()`. While that request was running, `/api/sessions` requests used by the sidebar/"Loading conversations" also stalled for ~19s.

Profiling showed the hot path was repeated `_loose_session_message_content()` calls (`casefold()` + regex `findall`) over multi-megabyte message contents.

This is related to the previously closed #2898, but this PR keeps the change smaller and adds the regression tests requested there: large payloads do not hit loose normalization, while small text still uses the legacy fuzzy path.

## Measurements
Local reproduction on the affected session:

- Before: `merge_session_messages_append_only()` ~13.2s
- After: `merge_session_messages_append_only()` ~0.27s
- Session shape: sidecar=145 messages, state.db=103 messages, merged=145 messages

## Test plan
```text
python -m pytest tests/test_merge_key_tool_calls.py tests/test_session_duplicate_edit.py tests/test_sprint43.py -q -o 'addopts='
# 33 passed, 1 warning, 8 subtests passed
```
