### PR TITLE
[security] reject blocked roots for remote workspaces

### DIFF
--- a/api/workspace.py
+++ b/api/workspace.py
@@ -93,6 +93,8 @@ def _remote_terminal_workspace_candidate(path: str | Path) -> Path | None:
         return None
     candidate = Path(raw).expanduser().resolve()
     base = Path(cwd).expanduser().resolve()
+    if _is_blocked_workspace_path(candidate, raw) or _is_blocked_workspace_path(base, cwd):
+        return None
     if candidate == base or _is_within(candidate, base):
         return candidate
     return None

--- a/tests/test_remote_terminal_workspace.py
+++ b/tests/test_remote_terminal_workspace.py
@@ -55,3 +55,13 @@ def test_remote_terminal_workspace_paths_outside_cwd_still_reject(monkeypatch):
 
     with pytest.raises(ValueError, match="Path does not exist"):
         workspace.resolve_trusted_workspace("/Users/other/projects/demo")
+
+
+def test_remote_terminal_workspace_system_roots_still_reject(monkeypatch):
+    monkeypatch.setattr(api_config, "get_config", lambda: _remote_config(terminal={"backend": "ssh", "cwd": "/etc"}))
+
+    with pytest.raises(ValueError, match="Path points to a system directory|Path does not exist"):
+        workspace.validate_workspace_to_add("/etc")
+
+    with pytest.raises(ValueError, match="Path points to a system directory|Path does not exist"):
+        workspace.resolve_trusted_workspace("/etc")

--- a/tests/test_remote_terminal_workspace.py
+++ b/tests/test_remote_terminal_workspace.py
@@ -57,11 +57,12 @@ def test_remote_terminal_workspace_paths_outside_cwd_still_reject(monkeypatch):
         workspace.resolve_trusted_workspace("/Users/other/projects/demo")
 
 
-def test_remote_terminal_workspace_system_roots_still_reject(monkeypatch):
+@pytest.mark.parametrize("workspace_path", ["/etc", "/etc/ssh"])
+def test_remote_terminal_workspace_system_roots_still_reject(monkeypatch, workspace_path):
     monkeypatch.setattr(api_config, "get_config", lambda: _remote_config(terminal={"backend": "ssh", "cwd": "/etc"}))
 
-    with pytest.raises(ValueError, match="Path points to a system directory|Path does not exist"):
-        workspace.validate_workspace_to_add("/etc")
+    with pytest.raises(ValueError, match="Path points to a system directory"):
+        workspace.validate_workspace_to_add(workspace_path)
 
-    with pytest.raises(ValueError, match="Path points to a system directory|Path does not exist"):
-        workspace.resolve_trusted_workspace("/etc")
+    with pytest.raises(ValueError, match="Path points to a system directory"):
+        workspace.resolve_trusted_workspace(workspace_path)


### PR DESCRIPTION
## Summary

This hardens remote-terminal workspace resolution so the remote-workspace shortcut cannot accept blocked local system roots such as `/etc` when the configured remote terminal cwd is also under that root.

The normal local workspace path already rejects these roots, but `_remote_terminal_workspace_candidate()` returned early for paths under the remote cwd before the blocked-root guard ran. Later workspace file operations use `s.workspace` as a local `Path`, so accepting a remote cwd like `/etc` can convert the intended remote-side path into a trusted local workspace root.

## Security impact

Before this change, with an SSH/remote terminal profile whose target-side cwd is `/etc`, workspace resolution accepted `/etc` as `/private/etc` on macOS. A session created with that workspace could then pass the workspace to local file helpers, allowing reads from local system files such as `hosts` through workspace file-read paths.

Redacted local proof before the fix:

```text
remote_terminal_backend=ssh
remote_terminal_cwd=/etc
accepted_workspace=/private/etc
session_workspace=/private/etc
file_read_path=hosts
file_read_size=213
file_read_contains_localhost=True
file_read_first_line=##
```

After the fix, both registration and trusted workspace resolution reject the same root:

```text
validate_workspace_to_add=REJECTED ValueError: Path points to a system directory: /private/etc
resolve_trusted_workspace=REJECTED ValueError: Path points to a system directory: /private/etc
```

## Fix

- Apply the existing `_is_blocked_workspace_path()` guard inside `_remote_terminal_workspace_candidate()` before accepting candidate paths under the remote cwd.
- Check both the requested candidate and the configured remote cwd/base path.
- Add regression coverage for an SSH backend configured with `/etc` as cwd.

## Validation

```text
python3 -m pytest tests/test_remote_terminal_workspace.py tests/test_workspace_blocked_roots_macos.py tests/test_workspace_inaccessible_paths.py -q
41 passed, 1 warning in 2.09s
```

```text
python3 -m pytest tests/test_remote_terminal_workspace.py tests/test_workspace_blocked_roots_macos.py tests/test_workspace_inaccessible_paths.py tests/test_workspace_symlink_containment.py tests/test_workspace_upload.py tests/test_workspace_git.py -q
108 passed, 1 skipped, 1 warning in 12.97s
```

## Duplicate check

I checked public issue/PR searches for remote terminal workspace/system-root wording and did not find an exact duplicate. The closest visible issue was #3673, but that appears to cover terminal backend behavior rather than this blocked-root workspace/file-boundary case.
