### PR TITLE
fix: prevent invisible toast from intercepting clicks on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Invisible notification toast no longer permanently intercepts clicks in the top right.** The notification toast container (`.toast`) sat at `opacity: 0` when hidden, but retained `pointer-events: auto`. Its permanent padding created an invisible click-capturing box in the top right corner that blocked interaction with UI elements underneath it on mobile devices (like the profile action buttons). The base class is now `pointer-events: none` and the `.toast.show` class restores `pointer-events: auto`.
+
 ## [v0.51.293] — 2026-06-06 — Release JI (stage-s5 — thinking card no longer renders twice)
 
 ### Fixed

--- a/static/style.css
+++ b/static/style.css
@@ -1288,8 +1288,8 @@
   .app-dialog-btn.confirm.danger{border-color:var(--error);background:rgba(239,83,80,.12);color:var(--error);}
   .app-dialog-btn.confirm.danger:hover{background:rgba(239,83,80,.2);border-color:var(--error);}
   .app-dialog-btn:focus-visible,.app-dialog-close:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
-  .toast{pointer-events:auto;position:fixed;top:24px;right:24px;left:auto;bottom:auto;transform:translateY(-6px);display:flex;align-items:center;gap:10px;background:color-mix(in srgb,var(--accent) 14%,var(--surface));border:1px solid color-mix(in srgb,var(--accent) 45%,var(--surface));color:var(--accent-text);font-size:13px;font-weight:500;padding:10px 12px 10px 16px;border-radius:10px;opacity:0;transition:opacity .2s,transform .2s;z-index:100;box-shadow:0 6px 24px rgba(0,0,0,.12);letter-spacing:.01em;max-width:min(520px,calc(100vw - 48px));}
-  .toast.show{opacity:1;transform:translateY(0);}
+  .toast{pointer-events:none;position:fixed;top:24px;right:24px;left:auto;bottom:auto;transform:translateY(-6px);display:flex;align-items:center;gap:10px;background:color-mix(in srgb,var(--accent) 14%,var(--surface));border:1px solid color-mix(in srgb,var(--accent) 45%,var(--surface));color:var(--accent-text);font-size:13px;font-weight:500;padding:10px 12px 10px 16px;border-radius:10px;opacity:0;transition:opacity .2s,transform .2s;z-index:100;box-shadow:0 6px 24px rgba(0,0,0,.12);letter-spacing:.01em;max-width:min(520px,calc(100vw - 48px));}
+  .toast.show{opacity:1;transform:translateY(0);pointer-events:auto;}
   .toast.success{background:color-mix(in srgb,var(--success) 14%,var(--surface));border-color:color-mix(in srgb,var(--success) 45%,var(--surface));color:var(--success);}
   .toast.error{background:color-mix(in srgb,var(--error) 14%,var(--surface));border-color:color-mix(in srgb,var(--error) 45%,var(--surface));color:var(--error);}
   .toast-message{min-width:0;overflow-wrap:anywhere;white-space:pre-wrap;}


### PR DESCRIPTION
### Thinking Path
- Hermes WebUI has a notification toast component located in the top right.
- The toast container (`.toast`) sat at `opacity: 0` when hidden, but it retained `pointer-events: auto`.
- The toast has permanent padding which creates an invisible clickable area.
- On mobile layouts, the profile action buttons (like activate, delete) are positioned at the top of the content view, placing them partially or completely underneath this invisible toast container.
- Because the toast intercepted the clicks, the profile action buttons were unclickable except for a tiny sliver at their bottom.
- This PR fixes the issue by setting `pointer-events: none` on the hidden toast container and restoring `pointer-events: auto` only when the `.toast.show` class is applied.
- The result is that the notification toast no longer permanently intercepts clicks, allowing full interaction with the UI underneath when the toast is hidden.

### What Changed
- Changed `.toast` base class in `static/style.css` to use `pointer-events: none;`.
- Changed `.toast.show` active state to add `pointer-events: auto;`.
- Appended fix to `CHANGELOG.md` under `[Unreleased]`.

### Why It Matters
On mobile devices and narrow windows, the toast overlapped the main action buttons in the user profile menu. Because it was invisibly capturing clicks, users were unable to easily switch or delete profiles without precise taps on a tiny exposed sliver. This restores expected mobile interactions.

### Verification (Before / After Visual Evidence)
*(Note: As an AI agent, I cannot attach live screenshots. Please see the visual layout explanation below).*

**Before:**
```text
+------------------------------------+
| [Menu]       Hermes        [Rel]   |
+------------------------------------+
| Profile Name                       |
|           [INVISIBLE TOAST AREA]   |
|           [  (Pointer-Events)  ]   |
| [Activate] [Delete] [Cancel] [Save]| <-- Clicks on top 90% of these buttons 
|                                    |     were swallowed by the toast box!
+------------------------------------+
```

**After:**
```text
+------------------------------------+
| [Menu]       Hermes        [Rel]   |
+------------------------------------+
| Profile Name                       |
|                                    |
|                                    |
| [Activate] [Delete] [Cancel] [Save]| <-- Clicks pass through the invisible
|                                    |     toast cleanly!
+------------------------------------+
```
- Tested locally: The profile header buttons now receive click events reliably on narrow viewports.
- The toast message still captures clicks (e.g. for the copy button) when actively displayed.
- Test suite successfully runs: `pytest tests/ -v`.

### Risks / Follow-ups
- None. This is a targeted CSS fix matching standard hidden-element best practices.

### Model Used
Google AI Studio / Gemini (`gemini-3.1-pro-preview`).
