### PR TITLE
feat(config): expand ${VAR} references in config.yaml at load time

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -249,6 +249,18 @@ else:
     _HERMES_FOUND = False
 
 # ── Config file (reloadable -- supports profile switching) ──────────────────
+
+def _expand_env_vars(obj):
+    """Recursively expand ${VAR} references in config values using os.environ."""
+    if isinstance(obj, str):
+        return re.sub(r"\${([^}]+)}", lambda m: os.environ.get(m.group(1), m.group(0)), obj)
+    if isinstance(obj, dict):
+        return {k: _expand_env_vars(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_expand_env_vars(item) for item in obj]
+    return obj
+
+
 _cfg_cache = {}
 _cfg_lock = threading.Lock()
 _cfg_mtime: float = 0.0  # last known mtime of config.yaml; 0 = never loaded
@@ -372,7 +384,7 @@ def reload_config() -> None:
             if config_path.exists():
                 loaded = _yaml.safe_load(config_path.read_text(encoding="utf-8"))
                 if isinstance(loaded, dict):
-                    _cfg_cache.update(loaded)
+                    _cfg_cache.update(_expand_env_vars(loaded))
                     try:
                         _cfg_mtime = Path(config_path).stat().st_mtime
                     except OSError:
@@ -399,7 +411,7 @@ def _load_yaml_config_file(config_path: Path) -> dict:
         return {}
     try:
         loaded = _yaml.safe_load(config_path.read_text(encoding="utf-8"))
-        return loaded if isinstance(loaded, dict) else {}
+        return _expand_env_vars(loaded) if isinstance(loaded, dict) else {}
     except Exception:
         logger.debug("Failed to parse yaml config from %s", config_path)
         return {}


### PR DESCRIPTION
## Problem

`config.yaml` already supports `${ENV_VAR}` substitution in **hermes-agent** (via `_expand_env_vars` in `hermes_cli/config.py`). However, the WebUI's own config loader (`api/config.py`) called `yaml.safe_load()` and stored the raw dict directly — leaving literal `${...}` strings in place.

This caused a silent but painful failure: users who placed credentials in their profile `.env` (e.g. `NEWAPI_BASE_URL=http://10.x.x.x/v1`) and referenced them via `${NEWAPI_BASE_URL}` in `config.yaml` would see the agent fail immediately with:

```
🌐 Endpoint: ${NEWAPI_BASE_URL}
📝 Error: Connection error.
```

The unexpanded string was being passed as the OpenAI client's `base_url`, making every API call fail with a connection error, even though the `.env` file was correctly populated.

## Fix

Add a small recursive `_expand_env_vars()` helper that mirrors the one already in `hermes_cli/config.py`:

```python
def _expand_env_vars(obj):
    """Recursively expand ${VAR} references in config values using os.environ."""
    if isinstance(obj, str):
        return re.sub(r"\${([^}]+)}", lambda m: os.environ.get(m.group(1), m.group(0)), obj)
    if isinstance(obj, dict):
        return {k: _expand_env_vars(v) for k, v in obj.items()}
    if isinstance(obj, list):
        return [_expand_env_vars(item) for item in obj]
    return obj
```

Apply it in both config load paths:
- `reload_config()` — the main cached loader triggered on profile switch and file mtime change
- `_load_yaml_config_file()` — the per-profile-home loader used by worker threads for non-default profiles

Unresolved references (variable not set in `os.environ`) are left verbatim, matching hermes-agent's existing behaviour.

## Notes

- `re` and `os` are already imported in `api/config.py` — no new dependencies introduced
- 14 lines added, 2 lines changed; fully backward-compatible (no-op when no `${...}` references are present)

## Test plan

- [ ] Place `NEWAPI_BASE_URL=http://your-endpoint/v1` in `~/.hermes/profiles/<name>/.env`
- [ ] Reference it as `base_url: ${NEWAPI_BASE_URL}` in `profiles/<name>/config.yaml`
- [ ] Start a chat session in the WebUI under that profile — agent should connect successfully (no `Endpoint: ${NEWAPI_BASE_URL}` error)
- [ ] Profiles with no `${...}` references in config continue to work unchanged

---

最后，真诚地感谢 @nesquena 对 hermes-webui 项目的持续投入与无私奉献。这个项目架构清晰、文档完整、代码质量极高，是一个非常值得学习的开源项目。能在这样用心维护的代码库上做贡献，感到非常荣幸。感谢你愿意花时间和精力打磨这个工具，并慷慨地分享给整个社区！🙏