### PR TITLE
Release v0.51.296 — stage-3731 (remote-workspace blocked-root security fix #3731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 
 ## [Unreleased]
 
+## [v0.51.296] — 2026-06-06 — Release JL (stage-3731 — remote-workspace blocked-root security fix)
+
+### Security
+- **Remote-terminal workspace resolution now rejects blocked system roots.** `_remote_terminal_workspace_candidate()` returned early for paths under the configured remote terminal cwd *before* the blocked-root guard ran, so an SSH/remote terminal profile whose target-side cwd was a system directory (e.g. `/etc`) could have that root accepted as a local workspace — after which workspace file helpers (which treat `s.workspace` as a local `Path`) could read local system files. The blocked-root guard now runs for both the candidate and the base path, so registration and trusted-workspace resolution reject these roots consistently. (#3731, @Hinotoi-agent)
+
+## [v0.51.295] — 2026-06-06 — Release JK (stage-3739/3742 — model-pick revert fix + session-status revert)
+
+### Fixed
+- **The composer model picker no longer silently reverts your selection on send.** When you explicitly picked a model whose family differed from the active profile's provider (e.g. a `gpt-*` model under an `anthropic`-bound profile), the server's profile-aware resolution (v0.51.290, #3448) rewrote it to the profile default and the dropdown snapped back with no warning. An explicit pick is now honored across both resolution paths (the profile-provider branch and the legacy bare-prefix branch), and if the model genuinely must change (a real provider mismatch) a toast explains it instead of silently swapping. The legitimate stale-session repair path is preserved. (#3739 fixes #3737, @someaka)
+
 ### Removed
 - **Reverted the manual per-session status labels (Todo / In Progress / Done).** The feature added in v0.51.284 (#3570) stored the chosen status only in browser `localStorage`, keyed by session id, with no server-side backing — so labels silently did not persist across browsers or devices (a user who labeled sessions on one machine saw none of them after switching to a laptop). It also rendered the three statuses as flat top-level entries in the session context menu alongside Copy/Rename/Pin/etc., which crowded the root menu. Removed entirely for now (JS state + cycle logic, context-menu entries, sidebar badge render, CSS, and all locale strings); the feature can be reintroduced later with proper server-side persistence and a less intrusive menu treatment. (reverts #3570)
 

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -93,6 +93,8 @@ def _remote_terminal_workspace_candidate(path: str | Path) -> Path | None:
         return None
     candidate = Path(raw).expanduser().resolve()
     base = Path(cwd).expanduser().resolve()
+    if _is_blocked_workspace_path(candidate, raw) or _is_blocked_workspace_path(base, cwd):
+        return None
     if candidate == base or _is_within(candidate, base):
         return candidate
     return None

--- a/tests/test_remote_terminal_workspace.py
+++ b/tests/test_remote_terminal_workspace.py
@@ -55,3 +55,13 @@ def test_remote_terminal_workspace_paths_outside_cwd_still_reject(monkeypatch):
 
     with pytest.raises(ValueError, match="Path does not exist"):
         workspace.resolve_trusted_workspace("/Users/other/projects/demo")
+
+
+def test_remote_terminal_workspace_system_roots_still_reject(monkeypatch):
+    monkeypatch.setattr(api_config, "get_config", lambda: _remote_config(terminal={"backend": "ssh", "cwd": "/etc"}))
+
+    with pytest.raises(ValueError, match="Path points to a system directory|Path does not exist"):
+        workspace.validate_workspace_to_add("/etc")
+
+    with pytest.raises(ValueError, match="Path points to a system directory|Path does not exist"):
+        workspace.resolve_trusted_workspace("/etc")

--- a/tests/test_remote_terminal_workspace.py
+++ b/tests/test_remote_terminal_workspace.py
@@ -57,11 +57,12 @@ def test_remote_terminal_workspace_paths_outside_cwd_still_reject(monkeypatch):
         workspace.resolve_trusted_workspace("/Users/other/projects/demo")
 
 
-def test_remote_terminal_workspace_system_roots_still_reject(monkeypatch):
+@pytest.mark.parametrize("workspace_path", ["/etc", "/etc/ssh"])
+def test_remote_terminal_workspace_system_roots_still_reject(monkeypatch, workspace_path):
     monkeypatch.setattr(api_config, "get_config", lambda: _remote_config(terminal={"backend": "ssh", "cwd": "/etc"}))
 
-    with pytest.raises(ValueError, match="Path points to a system directory|Path does not exist"):
-        workspace.validate_workspace_to_add("/etc")
+    with pytest.raises(ValueError, match="Path points to a system directory"):
+        workspace.validate_workspace_to_add(workspace_path)
 
-    with pytest.raises(ValueError, match="Path points to a system directory|Path does not exist"):
-        workspace.resolve_trusted_workspace("/etc")
+    with pytest.raises(ValueError, match="Path points to a system directory"):
+        workspace.resolve_trusted_workspace(workspace_path)


### PR DESCRIPTION
Release stage for **v0.51.296** — single backend-only security fix.

## #3731 → security: reject blocked roots for remote workspaces
@Hinotoi-agent, +13/−0 (api/workspace.py +2, test +11).

`_remote_terminal_workspace_candidate()` returned early for paths under the configured remote terminal cwd **before** the blocked-root guard ran. So an SSH/remote terminal profile whose target-side cwd is a system directory (e.g. `/etc`) could have that root accepted as a local workspace — after which workspace file helpers (which treat `s.workspace` as a local `Path`) could read local system files (PoC in the source PR read `/etc/hosts`). The fix runs the blocked-root guard for both the candidate and the base path before the accept.

## Gate (all green)
- Full suite: **8092 passed, 0 failed**
- Codex regression (diff vs master): **SAFE TO SHIP** (guard correctly placed post-resolve/pre-accept; no over-block; `/var/tmp` + macOS temp carve-outs preserved)
- Opus correctness: **SAFE TO SHIP** (false-positive analysis: common remote cwds unaffected; borderline paths match existing local-workspace behavior — restored invariant, not new restriction)
- Ruff forward gate: CLEAN; security test (`/etc` + `/etc/ssh`) passes
- revert-guard: origin/master is an ancestor
- Coordination: confirmed #3711 (terminal pair) does NOT touch api/workspace.py — no double-apply

Also backfills the v0.51.295 CHANGELOG block (a stage-rebuild had dropped the #3739 entry from the prior release's changelog). (#3731)