### PR TITLE
Release v0.51.299 — stage-3713 (update flow waits for new server instance #3713)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.299] — 2026-06-06 — Release JO (stage-3713 — update flow waits for a genuinely new server instance)
+
+### Fixed
+- **"Update now" no longer reloads onto the old server process (or shows a premature error toast).** The post-update reload waited for the first healthy `/health` response, but didn't confirm the server *instance* had actually changed — so on a slow restart the client could reload too early and land back on the old process, or surface an upgrade error that resolved itself after a manual refresh. The update trigger now captures a baseline server identity (from `/health`'s already-present `server_started_at` / `SERVER_START_TIME`) and `_waitForServerThenReload()` only reloads once it observes a *changed* identity. (#3713 fixes #3619, @rodboev)
+
 ## [v0.51.298] — 2026-06-06 — Release JN (stage-3719 — live model probe for custom providers with model config)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -5790,6 +5790,14 @@ async function _waitForServerThenReload(opts){
   if(msgEl) msgEl.textContent='⏳ Restarting… please wait';
   if(banner) banner.classList.add('visible');
   const deadline=Date.now()+maxMs;
+  // Track whether we ever observed the server become unreachable. A restart
+  // outage (one or more failed /health probes) followed by a healthy response is
+  // a reliable new-instance signal even when only uptime_seconds is comparable
+  // and the replacement's uptime is not strictly lower than the captured baseline
+  // (e.g. a deployment that strips server_started_at and whose baseline uptime
+  // was very low). Without this, the uptime-only `< baseline` check could never
+  // fire and the user would be stranded on the restart banner. (#3713 Codex catch)
+  let _observedOutage=false;
   // Give the server a moment to actually begin its restart before the first
   // probe — otherwise the old process may still respond ok on the first poll.
   await new Promise(r=>setTimeout(r, interval));
@@ -5842,10 +5850,24 @@ async function _waitForServerThenReload(opts){
             location.reload();
             return;
           }
+          if(
+            _observedOutage &&
+            nextServerIdentity!==null &&
+            baselineServerIdentity.serverStartedAt===null &&
+            nextServerIdentity.serverStartedAt===null &&
+            baselineServerIdentity.uptimeSeconds!==null &&
+            nextServerIdentity.uptimeSeconds!==null
+          ){
+            // Uptime-only on both sides AND we saw the server go unreachable and
+            // come back: that outage is the restart, so reload even though the
+            // replacement uptime is not strictly lower than a very-low baseline.
+            location.reload();
+            return;
+          }
           // Keep polling while /health still describes the pre-restart process.
         }
       }
-    }catch(_){ /* socket closed during restart — retry */ }
+    }catch(_){ _observedOutage=true; /* socket closed during restart — retry */ }
     await new Promise(r=>setTimeout(r, interval));
   }
   if(msgEl) msgEl.textContent='⚠️ Server is taking longer than expected — click Reload when ready';

--- a/static/ui.js
+++ b/static/ui.js
@@ -5712,12 +5712,22 @@ function _normalizeHealthServerIdentity(rawIdentity){
   return Number.isFinite(numeric) ? String(numeric) : null;
 }
 
+function _healthResponseServerIdentity(data){
+  if(!data||typeof data!=='object') return null;
+  const serverStartedAt=_normalizeHealthServerIdentity(data.server_started_at);
+  const hasUptimeSeconds=data.uptime_seconds!==null&&data.uptime_seconds!==undefined;
+  const uptimeSeconds=hasUptimeSeconds?Number(data.uptime_seconds):NaN;
+  const normalizedUptime=Number.isFinite(uptimeSeconds)&&uptimeSeconds>=0 ? uptimeSeconds : null;
+  if(serverStartedAt===null&&normalizedUptime===null) return null;
+  return {serverStartedAt,uptimeSeconds:normalizedUptime};
+}
+
 async function _readHealthServerIdentity() {
   try {
     const r=await fetch(new URL('health', document.baseURI||location.href).href,{cache:'no-store'});
     if(!r.ok) return null;
     const data=await r.json();
-    return _normalizeHealthServerIdentity(data&&data.server_started_at);
+    return _healthResponseServerIdentity(data);
   } catch (_) {
     return null;
   }
@@ -5762,7 +5772,18 @@ async function _waitForServerThenReload(opts){
   opts=opts||{};
   const interval=opts.interval||500;
   const maxMs=opts.maxMs||15000;
-  const baselineServerIdentity=_normalizeHealthServerIdentity(opts.baselineServerIdentity);
+  const baselineServerIdentity=(()=>{
+    const rawIdentity=opts.baselineServerIdentity;
+    if(!rawIdentity||typeof rawIdentity!=='object'){
+      const normalizedServerStartedAt=_normalizeHealthServerIdentity(rawIdentity);
+      return normalizedServerStartedAt===null ? null : {serverStartedAt:normalizedServerStartedAt,uptimeSeconds:null};
+    }
+    const normalizedIdentity={
+      serverStartedAt:_normalizeHealthServerIdentity(rawIdentity.serverStartedAt),
+      uptimeSeconds:Number.isFinite(Number(rawIdentity.uptimeSeconds))&&Number(rawIdentity.uptimeSeconds)>=0 ? Number(rawIdentity.uptimeSeconds) : null,
+    };
+    return normalizedIdentity.serverStartedAt===null&&normalizedIdentity.uptimeSeconds===null ? null : normalizedIdentity;
+  })();
   window._restartingForUpdate=true;
   const msgEl=$('reconnectMsg');
   const banner=$('reconnectBanner');
@@ -5779,16 +5800,49 @@ async function _waitForServerThenReload(opts){
         let data={};
         try{ data=await r.json(); }catch(_){}
         if(data && data.status==='ok'){
-          const nextServerIdentity=_normalizeHealthServerIdentity(data&&data.server_started_at);
+          const nextServerIdentity=_healthResponseServerIdentity(data);
           if (baselineServerIdentity===null){
             location.reload();
             return;
           }
-          if (nextServerIdentity!==null && nextServerIdentity !== baselineServerIdentity){
+          if(
+            nextServerIdentity===null &&
+            (
+              baselineServerIdentity.serverStartedAt!==null ||
+              baselineServerIdentity.uptimeSeconds!==null
+            )
+          ){
+            // If the replacement server comes back healthy without either
+            // identity field after the baseline exposed a comparable identity,
+            // treat that healthy response as the new server instead of timing
+            // out on an uncomparable identity shape.
             location.reload();
             return;
           }
-          // Keep polling while the server keeps reporting the same (pre-restart) process identity
+          if(
+            nextServerIdentity!==null &&
+            baselineServerIdentity.serverStartedAt!==null &&
+            nextServerIdentity.serverStartedAt===null &&
+            nextServerIdentity.uptimeSeconds!==null
+          ){
+            // If the baseline exposed server_started_at but the replacement
+            // health response degrades to uptime-only, there is no longer a
+            // comparable started_at field. Treat the first healthy uptime-only
+            // response as the new server instead of timing out.
+            location.reload();
+            return;
+          }
+          if(
+            nextServerIdentity!==null&&(
+              (baselineServerIdentity.serverStartedAt===null&&nextServerIdentity.serverStartedAt!==null)||
+              (baselineServerIdentity.serverStartedAt!==null&&nextServerIdentity.serverStartedAt!==null&&nextServerIdentity.serverStartedAt!==baselineServerIdentity.serverStartedAt)||
+              (baselineServerIdentity.uptimeSeconds!==null&&nextServerIdentity.uptimeSeconds!==null&&nextServerIdentity.uptimeSeconds<baselineServerIdentity.uptimeSeconds)
+            )
+          ){
+            location.reload();
+            return;
+          }
+          // Keep polling while /health still describes the pre-restart process.
         }
       }
     }catch(_){ /* socket closed during restart — retry */ }

--- a/static/ui.js
+++ b/static/ui.js
@@ -5790,14 +5790,18 @@ async function _waitForServerThenReload(opts){
   if(msgEl) msgEl.textContent='⏳ Restarting… please wait';
   if(banner) banner.classList.add('visible');
   const deadline=Date.now()+maxMs;
-  // Track whether we ever observed the server become unreachable. A restart
-  // outage (one or more failed /health probes) followed by a healthy response is
-  // a reliable new-instance signal even when only uptime_seconds is comparable
-  // and the replacement's uptime is not strictly lower than the captured baseline
-  // (e.g. a deployment that strips server_started_at and whose baseline uptime
-  // was very low). Without this, the uptime-only `< baseline` check could never
-  // fire and the user would be stranded on the restart banner. (#3713 Codex catch)
-  let _observedOutage=false;
+  // Track restart-outage evidence. An outage (failed or non-OK /health probes)
+  // followed by a healthy response is a reliable new-instance signal even when
+  // only uptime_seconds is comparable and the replacement's uptime is not strictly
+  // lower than the captured baseline (e.g. a deployment that strips
+  // server_started_at and whose baseline uptime was very low). We require at least
+  // TWO consecutive outage probes before trusting it, so a single transient network
+  // blip (with the OLD process still up and its uptime merely increasing) cannot
+  // trigger a premature reload onto the old server. Both thrown fetch errors AND
+  // non-OK responses (e.g. a reverse-proxy 502/503 during restart) count as outage
+  // evidence. (#3713 Codex catches)
+  let _consecutiveOutages=0;
+  const _restartOutageObserved=()=>_consecutiveOutages>=2;
   // Give the server a moment to actually begin its restart before the first
   // probe — otherwise the old process may still respond ok on the first poll.
   await new Promise(r=>setTimeout(r, interval));
@@ -5851,23 +5855,35 @@ async function _waitForServerThenReload(opts){
             return;
           }
           if(
-            _observedOutage &&
+            _restartOutageObserved() &&
             nextServerIdentity!==null &&
             baselineServerIdentity.serverStartedAt===null &&
             nextServerIdentity.serverStartedAt===null &&
             baselineServerIdentity.uptimeSeconds!==null &&
             nextServerIdentity.uptimeSeconds!==null
           ){
-            // Uptime-only on both sides AND we saw the server go unreachable and
-            // come back: that outage is the restart, so reload even though the
+            // Uptime-only on both sides AND we saw a sustained restart outage
+            // (>=2 consecutive failed/non-OK probes) before this healthy response:
+            // treat that outage as the restart, so reload even though the
             // replacement uptime is not strictly lower than a very-low baseline.
             location.reload();
             return;
           }
+          // Healthy response still describing the pre-restart process: this is the
+          // OLD server answering, so any earlier outage was a transient blip, not a
+          // restart — reset the outage evidence so it can't accumulate into a false
+          // positive across unrelated blips.
+          _consecutiveOutages=0;
           // Keep polling while /health still describes the pre-restart process.
+        }else{
+          // Reachable but not status:ok (still starting up) — counts as outage.
+          _consecutiveOutages++;
         }
+      }else{
+        // Non-OK HTTP (e.g. reverse-proxy 502/503 during restart) — outage evidence.
+        _consecutiveOutages++;
       }
-    }catch(_){ _observedOutage=true; /* socket closed during restart — retry */ }
+    }catch(_){ _consecutiveOutages++; /* socket closed during restart — retry */ }
     await new Promise(r=>setTimeout(r, interval));
   }
   if(msgEl) msgEl.textContent='⚠️ Server is taking longer than expected — click Reload when ready';

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -993,6 +993,32 @@ class TestUiJsUpdateBanner:
             "_waitForServerThenReload() should fallback to existing behavior when baseline is unavailable"
         )
 
+    def test_wait_for_server_reloads_on_outage_when_uptime_only_not_lower(self):
+        """Codex regression (#3713): when BOTH baseline and replacement expose only
+        uptime_seconds (server_started_at stripped) and the replacement's uptime is
+        NOT strictly lower than a very-low baseline, the `uptime < baseline` check
+        never fires. An observed outage (a failed /health probe) followed by a healthy
+        response is the reliable restart signal in that case — without it the user is
+        stranded on the restart banner until they manually reload."""
+        src = read('static/ui.js')
+        fn = extract_js_function(src, '_waitForServerThenReload')
+        compact = re.sub(r'\s+', '', fn)
+        # The catch arm must record that the server went unreachable.
+        assert '_observedOutage=true' in compact, (
+            "the /health probe catch arm must set _observedOutage=true so a restart "
+            "outage can be used as a new-instance signal"
+        )
+        # And there must be an outage-gated reload for the uptime-only-both-sides case.
+        assert '_observedOutage&&' in compact, (
+            "_waitForServerThenReload() must reload on an observed outage when only "
+            "uptime_seconds is comparable and it is not strictly lower than baseline"
+        )
+        assert ('baselineServerIdentity.serverStartedAt===null&&nextServerIdentity.serverStartedAt===null'
+                in compact), (
+            "the outage fallback must be scoped to the uptime-only-on-both-sides case"
+        )
+
+
     def test_wait_for_server_fallbacks_to_ready_on_missing_baseline(self):
         """Healthy /health should reload immediately when baseline identity is missing."""
         src = read('static/ui.js')

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -30,6 +30,35 @@ def read(rel):
     return (REPO / rel).read_text(encoding='utf-8')
 
 
+def extract_js_function(src: str, name: str) -> str:
+    match = re.search(rf'(async\s+)?function\s+{re.escape(name)}\b', src)
+    assert match, f"{name}() not found"
+    open_paren = src.index("(", match.start())
+    paren_depth = 1
+    idx = open_paren + 1
+    while paren_depth > 0 and idx < len(src):
+        ch = src[idx]
+        if ch == "(":
+            paren_depth += 1
+        elif ch == ")":
+            paren_depth -= 1
+        idx += 1
+    brace = src.index("{", idx)
+    depth = 0
+    end = None
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                end = idx + 1
+                break
+    assert end is not None, f"{name}() body was not balanced"
+    return src[match.start():end]
+
+
 # ── api/updates.py ────────────────────────────────────────────────────────────
 
 class TestUpdateChecker:
@@ -671,6 +700,21 @@ class TestForceUpdateRoute:
         )
 
 
+class TestHealthRouteContract:
+    def test_health_payload_includes_server_started_at(self):
+        src = read('api/routes.py')
+        health_start = src.index('def _handle_health')
+        payload_start = src.index('payload = {', health_start)
+        payload_end = src.index('if "oldest_run_age_seconds" in run_check:', payload_start)
+        payload = src[payload_start:payload_end]
+        assert '"server_started_at": SERVER_START_TIME' in payload, (
+            "/health must expose server_started_at sourced from SERVER_START_TIME"
+        )
+        assert '"uptime_seconds": round(time.time() - SERVER_START_TIME, 1)' in payload, (
+            "/health must keep exposing uptime_seconds alongside server_started_at"
+        )
+
+
 class TestUpdateSummaryRouteModelSelection:
     """Update summaries should use a known text auxiliary model before main model fallback."""
 
@@ -934,37 +978,27 @@ class TestUiJsUpdateBanner:
 
     def test_wait_for_server_requires_new_process_identity(self):
         src = read('static/ui.js')
-        m = re.search(r'function\s+_waitForServerThenReload\b.*?\n\}', src, re.DOTALL)
-        assert m, "_waitForServerThenReload() not found"
-        fn = m.group(0)
+        fn = extract_js_function(src, '_waitForServerThenReload')
         assert 'baselineServerIdentity' in fn, (
             "_waitForServerThenReload() should capture and compare a baseline process identity"
         )
-        assert 'nextServerIdentity!==null&&nextServerIdentity!==baselineServerIdentity' in fn.replace(' ', ''), (
-            "_waitForServerThenReload() should only reload when health process identity changes"
+        compact = re.sub(r'\s+', '', fn)
+        assert 'baselineServerIdentity.serverStartedAt!==null&&nextServerIdentity.serverStartedAt!==null&&nextServerIdentity.serverStartedAt!==baselineServerIdentity.serverStartedAt' in compact, (
+            "_waitForServerThenReload() should compare server_started_at when it is available"
         )
-        assert 'baselineServerIdentity===null' in fn.replace(' ', ''), (
+        assert 'baselineServerIdentity.uptimeSeconds!==null&&nextServerIdentity.uptimeSeconds!==null&&nextServerIdentity.uptimeSeconds<baselineServerIdentity.uptimeSeconds' in compact, (
+            "_waitForServerThenReload() should fall back to uptime_seconds when server_started_at is unavailable"
+        )
+        assert 'baselineServerIdentity===null' in compact, (
             "_waitForServerThenReload() should fallback to existing behavior when baseline is unavailable"
         )
 
     def test_wait_for_server_fallbacks_to_ready_on_missing_baseline(self):
         """Healthy /health should reload immediately when baseline identity is missing."""
         src = read('static/ui.js')
-        start = src.index("async function _waitForServerThenReload")
-        brace = src.index("{", start)
-        depth = 0
-        end = None
-        for idx in range(brace, len(src)):
-            ch = src[idx]
-            if ch == "{":
-                depth += 1
-            elif ch == "}":
-                depth -= 1
-                if depth == 0:
-                    end = idx + 1
-                    break
-        assert end is not None, "_waitForServerThenReload body was not balanced"
-        fn = src[start:end]
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
 
         script = f"""
 let now = 0;
@@ -973,9 +1007,6 @@ let fetches = 0;
 const responses = [
   {{ ok: true, data: {{ status: 'ok', server_started_at: null, uptime_seconds: 120 }} }},
 ];
-const _normalizeHealthServerIdentity = (rawIdentity) => rawIdentity===undefined||rawIdentity===null ? null :
-  (typeof rawIdentity==='string' ? (rawIdentity.trim() ? rawIdentity.trim() : null) :
-   Number.isFinite(Number(rawIdentity)) ? String(Number(rawIdentity)) : null);
 global.window = {{}};
 global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
 global.location = {{ reload: () => {{ reloads += 1; }} }};
@@ -991,7 +1022,9 @@ global.fetch = async () => {{
     json: async () => next.data,
   }};
 }};
-{fn}
+{normalize_fn}
+{identity_fn}
+{wait_fn}
 (async () => {{
   await _waitForServerThenReload({{ interval: 1, maxMs: 10, baselineServerIdentity: null }});
   if (fetches !== 1) throw new Error('expected fallback baseline to reload on first healthy probe, got '+fetches);
@@ -1003,21 +1036,9 @@ global.fetch = async () => {{
     def test_wait_for_server_ignores_old_identity_and_reloads_on_new_identity(self):
         """Healthy /health from the old process should not reload until identity changes."""
         src = read('static/ui.js')
-        start = src.index("async function _waitForServerThenReload")
-        brace = src.index("{", start)
-        depth = 0
-        end = None
-        for idx in range(brace, len(src)):
-            ch = src[idx]
-            if ch == "{":
-                depth += 1
-            elif ch == "}":
-                depth -= 1
-                if depth == 0:
-                    end = idx + 1
-                    break
-        assert end is not None, "_waitForServerThenReload body was not balanced"
-        fn = src[start:end]
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
 
         script = f"""
 let now = 0;
@@ -1028,9 +1049,6 @@ const responses = [
   {{ ok: true, data: {{ status: 'ok', server_started_at: '1001.234', uptime_seconds: 2000 }} }},
   {{ ok: true, data: {{ status: 'ok', server_started_at: '1001.235', uptime_seconds: 2010 }} }},
 ];
-const _normalizeHealthServerIdentity = (rawIdentity) => rawIdentity===undefined||rawIdentity===null ? null :
-  (typeof rawIdentity==='string' ? (rawIdentity.trim() ? rawIdentity.trim() : null) :
-   Number.isFinite(Number(rawIdentity)) ? String(Number(rawIdentity)) : null);
 global.window = {{}};
 global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
 global.location = {{ reload: () => {{ reloads += 1; }} }};
@@ -1046,11 +1064,209 @@ global.fetch = async () => {{
     json: async () => next.data,
   }};
 }};
-{fn}
+{normalize_fn}
+{identity_fn}
+{wait_fn}
 (async () => {{
-  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: '1001.234' }});
+  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: '1001.234', uptimeSeconds: 999 }} }});
   if (fetches !== 3) throw new Error('expected old-process health to be ignored before identity changes, got '+fetches);
   if (reloads !== 1) throw new Error('expected exactly one reload after new identity, got '+reloads);
+}})().catch(err => {{ console.error(err.stack || err.message); process.exit(1); }});
+"""
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+    def test_wait_for_server_falls_back_to_uptime_when_started_at_is_missing(self):
+        src = read('static/ui.js')
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
+
+        script = f"""
+let now = 0;
+let reloads = 0;
+let fetches = 0;
+const responses = [
+  {{ ok: true, data: {{ status: 'ok', server_started_at: null, uptime_seconds: 120 }} }},
+  {{ ok: true, data: {{ status: 'ok', server_started_at: null, uptime_seconds: 2 }} }},
+];
+global.window = {{}};
+global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
+global.location = {{ reload: () => {{ reloads += 1; }} }};
+global.$ = () => null;
+global.Date = {{ now: () => now }};
+global.setTimeout = (cb, ms) => {{ now += ms || 0; cb(); return 0; }};
+global.fetch = async () => {{
+  fetches += 1;
+  const next = responses.shift();
+  if (!next) throw new Error('unexpected extra fetch');
+  return {{
+    ok: next.ok,
+    json: async () => next.data,
+  }};
+}};
+{normalize_fn}
+{identity_fn}
+{wait_fn}
+(async () => {{
+  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: null, uptimeSeconds: 120 }} }});
+  if (fetches !== 2) throw new Error('expected uptime fallback to wait for a lower uptime, got '+fetches);
+  if (reloads !== 1) throw new Error('expected exactly one reload after uptime fallback identified a new process, got '+reloads);
+}})().catch(err => {{ console.error(err.stack || err.message); process.exit(1); }});
+"""
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+    def test_wait_for_server_accepts_new_started_at_when_baseline_lacked_one(self):
+        src = read('static/ui.js')
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
+
+        script = f"""
+let now = 0;
+let reloads = 0;
+let fetches = 0;
+const responses = [
+  {{ ok: true, data: {{ status: 'ok', server_started_at: '1001.300', uptime_seconds: 120 }} }},
+];
+global.window = {{}};
+global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
+global.location = {{ reload: () => {{ reloads += 1; }} }};
+global.$ = () => null;
+global.Date = {{ now: () => now }};
+global.setTimeout = (cb, ms) => {{ now += ms || 0; cb(); return 0; }};
+global.fetch = async () => {{
+  fetches += 1;
+  const next = responses.shift();
+  if (!next) throw new Error('unexpected extra fetch');
+  return {{
+    ok: next.ok,
+    json: async () => next.data,
+  }};
+}};
+{normalize_fn}
+{identity_fn}
+{wait_fn}
+(async () => {{
+  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: null, uptimeSeconds: 120 }} }});
+  if (fetches !== 1) throw new Error('expected new server_started_at to trigger reload on first healthy probe, got '+fetches);
+  if (reloads !== 1) throw new Error('expected exactly one reload when replacement server exposes server_started_at, got '+reloads);
+}})().catch(err => {{ console.error(err.stack || err.message); process.exit(1); }});
+"""
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+    def test_wait_for_server_reloads_when_replacement_health_has_no_identity_fields(self):
+        src = read('static/ui.js')
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
+
+        script = f"""
+let now = 0;
+let reloads = 0;
+let fetches = 0;
+const responses = [
+  {{ ok: true, data: {{ status: 'ok', server_started_at: null, uptime_seconds: null }} }},
+];
+global.window = {{}};
+global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
+global.location = {{ reload: () => {{ reloads += 1; }} }};
+global.$ = () => null;
+global.Date = {{ now: () => now }};
+global.setTimeout = (cb, ms) => {{ now += ms || 0; cb(); return 0; }};
+global.fetch = async () => {{
+  fetches += 1;
+  const next = responses.shift();
+  if (!next) throw new Error('unexpected extra fetch');
+  return {{
+    ok: next.ok,
+    json: async () => next.data,
+  }};
+}};
+{normalize_fn}
+{identity_fn}
+{wait_fn}
+(async () => {{
+  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: '1001.234', uptimeSeconds: null }} }});
+  if (fetches !== 1) throw new Error('expected identity-less healthy replacement to trigger reload on first probe, got '+fetches);
+  if (reloads !== 1) throw new Error('expected exactly one reload when replacement health exposes no identity fields, got '+reloads);
+}})().catch(err => {{ console.error(err.stack || err.message); process.exit(1); }});
+"""
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+    def test_wait_for_server_reloads_when_full_baseline_loses_all_identity_fields(self):
+        src = read('static/ui.js')
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
+
+        script = f"""
+let now = 0;
+let reloads = 0;
+let fetches = 0;
+const responses = [
+  {{ ok: true, data: {{ status: 'ok', server_started_at: null, uptime_seconds: null }} }},
+];
+global.window = {{}};
+global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
+global.location = {{ reload: () => {{ reloads += 1; }} }};
+global.$ = () => null;
+global.Date = {{ now: () => now }};
+global.setTimeout = (cb, ms) => {{ now += ms || 0; cb(); return 0; }};
+global.fetch = async () => {{
+  fetches += 1;
+  const next = responses.shift();
+  if (!next) throw new Error('unexpected extra fetch');
+  return {{
+    ok: next.ok,
+    json: async () => next.data,
+  }};
+}};
+{normalize_fn}
+{identity_fn}
+{wait_fn}
+(async () => {{
+  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: '1001.234', uptimeSeconds: 120 }} }});
+  if (fetches !== 1) throw new Error('expected full-baseline identity loss to trigger reload on first probe, got '+fetches);
+  if (reloads !== 1) throw new Error('expected exactly one reload when replacement health drops all identity fields after a full baseline, got '+reloads);
+}})().catch(err => {{ console.error(err.stack || err.message); process.exit(1); }});
+"""
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+    def test_wait_for_server_reloads_when_baseline_started_at_degrades_to_uptime_only(self):
+        src = read('static/ui.js')
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+        wait_fn = extract_js_function(src, '_waitForServerThenReload')
+
+        script = f"""
+let now = 0;
+let reloads = 0;
+let fetches = 0;
+const responses = [
+  {{ ok: true, data: {{ status: 'ok', server_started_at: null, uptime_seconds: 12 }} }},
+];
+global.window = {{}};
+global.document = {{ baseURI: 'http://127.0.0.1:8788/' }};
+global.location = {{ reload: () => {{ reloads += 1; }} }};
+global.$ = () => null;
+global.Date = {{ now: () => now }};
+global.setTimeout = (cb, ms) => {{ now += ms || 0; cb(); return 0; }};
+global.fetch = async () => {{
+  fetches += 1;
+  const next = responses.shift();
+  if (!next) throw new Error('unexpected extra fetch');
+  return {{
+    ok: next.ok,
+    json: async () => next.data,
+  }};
+}};
+{normalize_fn}
+{identity_fn}
+{wait_fn}
+(async () => {{
+  await _waitForServerThenReload({{ interval: 1, maxMs: 20, baselineServerIdentity: {{ serverStartedAt: '1001.234', uptimeSeconds: 120 }} }});
+  if (fetches !== 1) throw new Error('expected uptime-only healthy replacement to trigger reload on first probe, got '+fetches);
+  if (reloads !== 1) throw new Error('expected exactly one reload when started_at degrades to uptime-only health, got '+reloads);
 }})().catch(err => {{ console.error(err.stack || err.message); process.exit(1); }});
 """
         subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
@@ -1081,6 +1297,31 @@ global.fetch = async () => {{
         assert force_body.index('_readHealthServerIdentity()') < force_body.index("const res=await api('/api/updates/force'"), (
             "forceUpdate() must capture baseline before force POST"
         )
+
+    def test_health_identity_helper_prefers_server_started_at_and_keeps_uptime_fallback(self):
+        src = read('static/ui.js')
+        normalize_fn = extract_js_function(src, '_normalizeHealthServerIdentity')
+        identity_fn = extract_js_function(src, '_healthResponseServerIdentity')
+
+        script = f"""
+{normalize_fn}
+{identity_fn}
+const preferred = _healthResponseServerIdentity({{ server_started_at: '1001.234', uptime_seconds: 900 }});
+if (!preferred || preferred.serverStartedAt !== '1001.234') {{
+  throw new Error('expected server_started_at to be the preferred identity field');
+}}
+if (preferred.uptimeSeconds !== 900) {{
+  throw new Error('expected uptime_seconds to remain available for fallback comparisons');
+}}
+const fallback = _healthResponseServerIdentity({{ server_started_at: null, uptime_seconds: 120 }});
+if (!fallback || fallback.serverStartedAt !== null || fallback.uptimeSeconds !== 120) {{
+  throw new Error('expected uptime_seconds fallback identity when server_started_at is unavailable');
+}}
+if (_healthResponseServerIdentity({{ server_started_at: null, uptime_seconds: null }}) !== null) {{
+  throw new Error('expected null identity when /health exposes neither started_at nor uptime');
+}}
+"""
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
 
     def test_refresh_session_handles_restart_mode(self):
         """When _restartingForUpdate flag is set, refreshSession() must do a

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -997,21 +997,30 @@ class TestUiJsUpdateBanner:
         """Codex regression (#3713): when BOTH baseline and replacement expose only
         uptime_seconds (server_started_at stripped) and the replacement's uptime is
         NOT strictly lower than a very-low baseline, the `uptime < baseline` check
-        never fires. An observed outage (a failed /health probe) followed by a healthy
-        response is the reliable restart signal in that case — without it the user is
-        stranded on the restart banner until they manually reload."""
+        never fires. A SUSTAINED restart outage (>=2 consecutive failed/non-OK probes)
+        followed by a healthy response is the reliable restart signal in that case —
+        without it the user is stranded on the restart banner until they manually
+        reload. The >=2 threshold + outage reset on a healthy old-server response
+        prevent a single transient network blip from reloading onto the old process."""
         src = read('static/ui.js')
         fn = extract_js_function(src, '_waitForServerThenReload')
         compact = re.sub(r'\s+', '', fn)
-        # The catch arm must record that the server went unreachable.
-        assert '_observedOutage=true' in compact, (
-            "the /health probe catch arm must set _observedOutage=true so a restart "
-            "outage can be used as a new-instance signal"
+        # Outage counter incremented on thrown fetch errors AND non-OK responses.
+        assert '_consecutiveOutages++' in compact, (
+            "the /health probe must count failed/non-OK responses as outage evidence"
         )
-        # And there must be an outage-gated reload for the uptime-only-both-sides case.
-        assert '_observedOutage&&' in compact, (
-            "_waitForServerThenReload() must reload on an observed outage when only "
-            "uptime_seconds is comparable and it is not strictly lower than baseline"
+        # Sustained-outage threshold (>=2) gates the uptime-only fallback — not a single blip.
+        assert '_consecutiveOutages>=2' in compact, (
+            "the outage fallback must require >=2 consecutive outages so a single "
+            "transient blip can't trigger a premature reload onto the old server"
+        )
+        assert '_restartOutageObserved()&&' in compact, (
+            "_waitForServerThenReload() must gate the uptime-only reload on a sustained outage"
+        )
+        # Outage evidence resets when the OLD server answers healthy (blip, not restart).
+        assert '_consecutiveOutages=0' in compact, (
+            "a healthy pre-restart-process response must reset the outage counter so "
+            "unrelated blips can't accumulate into a false positive"
         )
         assert ('baselineServerIdentity.serverStartedAt===null&&nextServerIdentity.serverStartedAt===null'
                 in compact), (


### PR DESCRIPTION
Release stage for **v0.51.299** — frontend-only update-flow fix.

## #3713 → fixes #3619 — "Update now" waits for a genuinely new server instance
@rodboev, ui.js +~110, test +~360. The post-update reload waited for the first healthy `/health` without confirming the server *instance* changed, so a slow restart could reload onto the old process or show a premature error toast. Now captures a baseline server identity (from `/health`'s existing `server_started_at`) at update-trigger time and only reloads on a changed identity.

## Deep-review hardening (2 Codex rounds, fixed in-stage)
- **Round 1:** the uptime-only fallback (when a deployment strips `server_started_at`) only reloaded on `next.uptime < baseline.uptime` — if baseline uptime was very low, that never fired → user stranded on the restart banner. Added an outage-then-healthy fallback.
- **Round 2:** hardened that fallback — a single transient blip could reload onto the still-up old server, and reverse-proxy 502/503 (`r.ok===false`, not a thrown error) didn't register as outage. Now uses a `_consecutiveOutages` counter requiring **≥2 consecutive outages**, counts both thrown errors AND non-OK responses, and resets on a healthy old-server response so unrelated blips can't accumulate.

## Gate (all green)
- Full suite: **8110 passed, 0 failed**
- Codex regression: **SAFE TO SHIP** (round 2 — both findings resolved)
- Opus correctness: **SAFE TO SHIP**
- ESLint runtime + scope-undef: CLEAN
- revert-guard: origin/master is an ancestor

ui.js verified byte-identical to the PR head before the two in-stage hardening commits. (#3713 fixes #3619)