### PR TITLE
fix: resolve branchy compression lineage tips

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -279,23 +279,50 @@ def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
         children.sort(key=lambda row: row.get('started_at') or 0, reverse=True)
 
     def compression_tip(row: dict) -> tuple[dict | None, int]:
-        current = row
-        seen = {row['id']}
+        """Return the freshest importable continuation descendant for ``row``.
+
+        Compression parents can have multiple continuation-looking children when
+        a stale segment is resumed after a newer compressed branch already
+        exists. Picking the newest *direct* child can hide the branch whose
+        deeper descendant has the actual latest activity. Walk all reachable
+        continuation descendants and select by real message activity instead.
+        """
         latest_importable = row if (row.get('actual_message_count') or 0) > 0 else None
-        segment_count = 1
-        for _ in range(len(rows_by_id) + 1):
-            candidates = [
-                child for child in children_by_parent.get(current['id'], [])
-                if child['id'] not in seen and _is_continuation_session(current, child)
-            ]
-            if not candidates:
-                return latest_importable, segment_count
-            current = candidates[0]
-            seen.add(current['id'])
+        segment_count = 0
+        best_depth = 1
+        best_score = (
+            latest_importable.get('last_activity') or latest_importable.get('started_at') or 0
+            if latest_importable
+            else 0
+        )
+        stack: list[tuple[dict, int]] = [(row, 1)]
+        seen: set[str] = set()
+
+        while stack:
+            current, depth = stack.pop()
+            current_id = current.get('id')
+            if not current_id or current_id in seen:
+                continue
+            seen.add(current_id)
             segment_count += 1
-            if (current.get('actual_message_count') or 0) > 0:
+
+            current_score = current.get('last_activity') or current.get('started_at') or 0
+            if (
+                (current.get('actual_message_count') or 0) > 0
+                and (current_score > best_score or (current_score == best_score and depth >= best_depth))
+            ):
                 latest_importable = current
-        return latest_importable, segment_count
+                best_depth = depth
+                best_score = current_score
+            for child in children_by_parent.get(current_id, []):
+                child_id = child.get('id')
+                if not child_id or child_id in seen:
+                    continue
+                if not _is_continuation_session(current, child):
+                    continue
+                stack.append((child, depth + 1))
+
+        return latest_importable, max(segment_count, 1)
 
     projected = []
     for row in rows:
@@ -346,7 +373,7 @@ def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
 
 def read_importable_agent_session_rows(
     db_path: Path,
-    limit: int = 200,
+    limit: int | None = 200,
     log=None,
     exclude_sources: tuple[str, ...] | None = ("cron", "webui"),
 ) -> list[dict]:
@@ -684,6 +711,8 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
             if 'parent_session_id' not in session_cols or 'end_reason' not in session_cols:
                 return {}
             session_source_expr = _optional_col('session_source', session_cols)
+            source_expr = _optional_col('source', session_cols)
+            message_count_expr = _optional_col('message_count', session_cols, '0')
             # Scoped fetch via PRIMARY KEY + idx_sessions_parent rather than a
             # full table scan. The sessions table grows unbounded over time
             # (1000+ rows is normal, 10000+ for power users), and this function
@@ -692,7 +721,9 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
             #
             # Fetch the wanted ids first, then chase parent_session_id chains
             # in batches until no new ids appear. Each batch hits PRIMARY KEY
-            # so it's effectively O(N) lookups.
+            # so it's effectively O(N) lookups. Then walk continuation children
+            # from the materialized ancestors so branchy compression lineages can
+            # mark the real freshest tip, not just the newest direct sibling.
             #
             # IN-clause is chunked to 500 to stay under SQLITE_MAX_VARIABLE_NUMBER
             # on older sqlite (Python 3.9 ships sqlite 3.31 which defaults to 999;
@@ -717,7 +748,7 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
                     placeholders = ','.join('?' * len(chunk))
                     cur.execute(
                         f"""
-                        SELECT s.id, s.source, {session_source_expr}, s.title, s.started_at, s.parent_session_id, s.ended_at, s.end_reason
+                        SELECT s.id, {source_expr}, {session_source_expr}, s.title, s.started_at, s.parent_session_id, s.ended_at, s.end_reason, {message_count_expr}
                         FROM sessions s
                         WHERE s.id IN ({placeholders})
                         """,
@@ -730,9 +761,123 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
                     parent_id = rows.get(sid, {}).get('parent_session_id')
                     if parent_id and parent_id not in rows and parent_id not in to_fetch:
                         to_fetch.add(parent_id)
+
+            # Fetch descendants from the discovered ancestors using the parent
+            # index. This keeps the sidebar read scoped while still giving the
+            # collapse metadata enough information to choose the active branch.
+            to_expand = set(rows)
+            expanded: set[str] = set()
+            for _hop in range(20):
+                frontier = [sid for sid in to_expand if sid not in expanded]
+                if not frontier:
+                    break
+                to_expand = set()
+                for i in range(0, len(frontier), IN_CHUNK):
+                    chunk = frontier[i:i + IN_CHUNK]
+                    placeholders = ','.join('?' * len(chunk))
+                    cur.execute(
+                        f"""
+                        SELECT s.id, {source_expr}, {session_source_expr}, s.title, s.started_at, s.parent_session_id, s.ended_at, s.end_reason, {message_count_expr}
+                        FROM sessions s
+                        WHERE s.parent_session_id IN ({placeholders})
+                        """,
+                        chunk,
+                    )
+                    for row in cur.fetchall():
+                        child = dict(row)
+                        rows[child['id']] = child
+                        parent_id = child.get('parent_session_id')
+                        parent = rows.get(str(parent_id)) if parent_id else None
+                        if parent and child['id'] not in expanded and _is_continuation_session(parent, child):
+                            to_expand.add(child['id'])
+                expanded.update(frontier)
+
+            message_stats: dict[str, dict] = {}
+            cur.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'messages'")
+            has_messages_table = cur.fetchone() is not None
+            row_ids = list(rows)
+            if has_messages_table:
+                for i in range(0, len(row_ids), IN_CHUNK):
+                    chunk = row_ids[i:i + IN_CHUNK]
+                    placeholders = ','.join('?' * len(chunk))
+                    cur.execute(
+                        f"""
+                        SELECT session_id, COUNT(*) AS actual_message_count, MAX(timestamp) AS last_message_at
+                        FROM messages
+                        WHERE session_id IN ({placeholders})
+                        GROUP BY session_id
+                        """,
+                        chunk,
+                    )
+                    for row in cur.fetchall():
+                        message_stats[row['session_id']] = dict(row)
+            for sid, row in rows.items():
+                stats = message_stats.get(sid) or {}
+                if has_messages_table:
+                    row['actual_message_count'] = int(stats.get('actual_message_count') or 0)
+                else:
+                    row['actual_message_count'] = int(row.get('message_count') or 0)
+                row['last_message_at'] = stats.get('last_message_at')
     except Exception:
         return {}
 
+    children_by_parent: dict[str, list[dict]] = {}
+    for row in rows.values():
+        parent_id = row.get('parent_session_id')
+        if parent_id:
+            children_by_parent.setdefault(parent_id, []).append(row)
+
+    def continuation_root_and_depth(sid: str) -> tuple[str, int]:
+        root_id = sid
+        current_id = sid
+        depth = 1
+        seen = {sid}
+        while True:
+            current = rows.get(current_id)
+            raw_parent_id = current.get('parent_session_id') if current else None
+            parent_id = str(raw_parent_id) if raw_parent_id else ''
+            if not parent_id:
+                break
+            parent = rows.get(parent_id)
+            if not parent or parent_id in seen:
+                break
+            if not _is_continuation_session(parent, current):
+                break
+            root_id = parent_id
+            current_id = parent_id
+            seen.add(parent_id)
+            depth += 1
+        return root_id, depth
+
+    def freshest_continuation_tip(root_id: str) -> tuple[str, int]:
+        best_id = root_id
+        best_depth = 1
+        segment_count = 0
+        best_score = float(rows.get(root_id, {}).get('last_message_at') or rows.get(root_id, {}).get('started_at') or 0)
+        stack: list[tuple[str, int]] = [(root_id, 1)]
+        seen: set[str] = set()
+        while stack:
+            current_id, depth = stack.pop()
+            if current_id in seen:
+                continue
+            seen.add(current_id)
+            current = rows.get(current_id)
+            if not current:
+                continue
+            segment_count += 1
+            actual_count = int(current.get('actual_message_count') or 0)
+            score = float(current.get('last_message_at') or current.get('started_at') or 0)
+            if actual_count > 0 and (score > best_score or (score == best_score and depth >= best_depth)):
+                best_id = current_id
+                best_depth = depth
+                best_score = score
+            for child in children_by_parent.get(current_id, []):
+                if _is_continuation_session(current, child):
+                    stack.append((child['id'], depth + 1))
+
+        return best_id, max(segment_count, best_depth)
+
+    lineage_tip_cache: dict[str, tuple[str, int]] = {}
     metadata: dict[str, dict] = {}
     for sid in wanted:
         row = rows.get(sid)
@@ -770,26 +915,15 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
                     entry['_parent_lineage_root_id'] = parent_root
                 continue
 
-        root_id = sid
-        current_id = sid
-        segment_count = 1
-        seen = {sid}
-        while True:
-            current = rows.get(current_id)
-            parent_id = current.get('parent_session_id') if current else None
-            parent = rows.get(parent_id) if parent_id else None
-            if not parent or parent_id in seen:
-                break
-            if not _is_continuation_session(parent, current):
-                break
-            root_id = parent_id
-            current_id = parent_id
-            seen.add(parent_id)
-            segment_count += 1
+        root_id, segment_count = continuation_root_and_depth(sid)
 
         if root_id != sid:
             entry = metadata.setdefault(sid, {})
             entry['_lineage_root_id'] = root_id
-            entry['_compression_segment_count'] = segment_count
+            if root_id not in lineage_tip_cache:
+                lineage_tip_cache[root_id] = freshest_continuation_tip(root_id)
+            tip_id, tip_depth = lineage_tip_cache[root_id]
+            entry['_lineage_tip_id'] = tip_id
+            entry['_compression_segment_count'] = max(segment_count, tip_depth)
 
     return metadata

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -427,6 +427,144 @@ def test_compression_chain_collapses_to_latest_tip_in_sidebar():
         post('/api/settings', {'show_cli_sessions': False})
 
 
+def test_compression_lineage_prefers_freshest_descendant_over_newer_direct_sibling():
+    """A later-started stale sibling must not hide a deeper active branch."""
+    conn = _ensure_state_db()
+    ids_to_remove = (
+        'branch_root_001',
+        'branch_old_mid_001',
+        'branch_fresh_tip_001',
+        'branch_empty_stale_tip_001',
+        'branch_newer_direct_sibling_001',
+    )
+    t0 = time.time() - 800
+    try:
+        _insert_agent_session_row(
+            conn,
+            'branch_root_001',
+            title='Qwen Routing Audit',
+            started_at=t0,
+            ended_at=t0 + 100,
+            end_reason='compression',
+            messages=2,
+        )
+        _insert_agent_session_row(
+            conn,
+            'branch_old_mid_001',
+            title='Qwen Routing Audit #2',
+            started_at=t0 + 101,
+            parent_session_id='branch_root_001',
+            ended_at=t0 + 200,
+            end_reason='compression',
+            messages=2,
+        )
+        _insert_agent_session_row(
+            conn,
+            'branch_newer_direct_sibling_001',
+            title='Qwen Routing Audit #3 stale sibling',
+            started_at=t0 + 150,
+            parent_session_id='branch_root_001',
+            messages=2,
+        )
+        _insert_agent_session_row(
+            conn,
+            'branch_fresh_tip_001',
+            title='Qwen Routing Audit #4 freshest tip',
+            started_at=t0 + 500,
+            parent_session_id='branch_old_mid_001',
+            messages=2,
+        )
+        _insert_agent_session_row(
+            conn,
+            'branch_empty_stale_tip_001',
+            title='Qwen Routing Audit #5 empty stale tip',
+            started_at=t0 + 700,
+            parent_session_id='branch_old_mid_001',
+            messages=0,
+        )
+        conn.execute(
+            "UPDATE sessions SET message_count = 3 WHERE id = ?",
+            ('branch_empty_stale_tip_001',),
+        )
+        conn.commit()
+
+        post('/api/settings', {'show_cli_sessions': True})
+        data, status = get('/api/sessions')
+        assert status == 200
+        ids = {s.get('session_id') for s in data.get('sessions', [])}
+        tip = next((s for s in data.get('sessions', []) if s.get('session_id') == 'branch_fresh_tip_001'), None)
+
+        assert 'branch_fresh_tip_001' in ids
+        assert 'branch_newer_direct_sibling_001' not in ids
+        assert 'branch_empty_stale_tip_001' not in ids
+        assert tip is not None
+        assert tip.get('title') == 'Qwen Routing Audit'
+        assert abs(tip.get('updated_at') - (t0 + 501)) < 0.01
+        assert tip.get('_lineage_root_id') == 'branch_root_001'
+        assert tip.get('_lineage_tip_id') == 'branch_fresh_tip_001'
+        assert tip.get('_compression_segment_count') == 5
+
+        from api.agent_sessions import read_importable_agent_session_rows
+
+        rows = read_importable_agent_session_rows(_get_state_db_path(), limit=None)
+        projected_tip = next((row for row in rows if row.get('id') == 'branch_fresh_tip_001'), None)
+        assert projected_tip is not None
+        assert projected_tip.get('_lineage_root_id') == 'branch_root_001'
+        assert projected_tip.get('_lineage_tip_id') == 'branch_fresh_tip_001'
+        assert projected_tip.get('_compression_segment_count') == 5
+
+        from api.agent_sessions import read_session_lineage_metadata
+
+        metadata = read_session_lineage_metadata(
+            _get_state_db_path(),
+            {'branch_old_mid_001', 'branch_fresh_tip_001', 'branch_empty_stale_tip_001', 'branch_newer_direct_sibling_001'},
+        )
+        assert metadata['branch_old_mid_001'].get('_lineage_tip_id') == 'branch_fresh_tip_001'
+        assert metadata['branch_empty_stale_tip_001'].get('_lineage_tip_id') == 'branch_fresh_tip_001'
+        assert metadata['branch_newer_direct_sibling_001'].get('_lineage_tip_id') == 'branch_fresh_tip_001'
+        assert metadata['branch_newer_direct_sibling_001'].get('_compression_segment_count') == 5
+    finally:
+        try:
+            _remove_test_sessions(conn, *ids_to_remove)
+            conn.close()
+        except Exception:
+            pass
+        post('/api/settings', {'show_cli_sessions': False})
+
+
+def test_compression_projection_handles_deep_lineage_iteratively():
+    """Very deep compression chains should not depend on Python recursion depth."""
+    from api.agent_sessions import _project_agent_session_rows
+
+    rows = []
+    previous = None
+    for idx in range(1100):
+        sid = f'deep_chain_{idx:04d}'
+        started_at = float(idx * 2)
+        rows.append({
+            'id': sid,
+            'title': 'Deep Chain' if idx == 0 else f'Deep Chain #{idx + 1}',
+            'source': 'cli',
+            'started_at': started_at,
+            'parent_session_id': previous,
+            'ended_at': started_at + 1 if idx < 1099 else None,
+            'end_reason': 'compression' if idx < 1099 else None,
+            'actual_message_count': 1,
+            'actual_user_message_count': 1,
+            'message_count': 1,
+            'last_activity': started_at + 0.5,
+        })
+        previous = sid
+
+    projected = _project_agent_session_rows(rows)
+
+    assert len(projected) == 1
+    assert projected[0]['id'] == 'deep_chain_1099'
+    assert projected[0]['_lineage_root_id'] == 'deep_chain_0000'
+    assert projected[0]['_lineage_tip_id'] == 'deep_chain_1099'
+    assert projected[0]['_compression_segment_count'] == 1100
+
+
 def test_compression_chain_with_empty_latest_tip_falls_back_to_latest_importable_segment():
     """Empty latest tips should not make the whole conversation disappear."""
     conn = _ensure_state_db()

--- a/tests/test_pr1370_lineage_metadata_perf_and_orphan.py
+++ b/tests/test_pr1370_lineage_metadata_perf_and_orphan.py
@@ -132,6 +132,42 @@ def test_orphan_parent_reference_not_exposed_in_metadata(tmp_path):
     )
 
 
+def test_old_schema_without_source_or_messages_table_keeps_lineage(tmp_path):
+    """Old state.db schemas may lack optional source/message tables but still carry lineage."""
+    from api.agent_sessions import read_session_lineage_metadata
+
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript("""
+    CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        title TEXT,
+        started_at REAL NOT NULL,
+        parent_session_id TEXT,
+        ended_at REAL,
+        end_reason TEXT
+    );
+    CREATE INDEX idx_sessions_parent ON sessions(parent_session_id);
+    """)
+    t0 = time.time() - 100
+    conn.execute(
+        "INSERT INTO sessions (id, title, started_at, ended_at, end_reason) VALUES (?, ?, ?, ?, ?)",
+        ("old_root", "old_root", t0, t0 + 5, "compression"),
+    )
+    conn.execute(
+        "INSERT INTO sessions (id, title, started_at, parent_session_id) VALUES (?, ?, ?, ?)",
+        ("old_tip", "old_tip", t0 + 6, "old_root"),
+    )
+    conn.commit()
+    conn.close()
+
+    result = read_session_lineage_metadata(db, ["old_tip"])
+
+    assert result["old_tip"]["parent_session_id"] == "old_root"
+    assert result["old_tip"]["_lineage_root_id"] == "old_root"
+    assert result["old_tip"]["_compression_segment_count"] == 2
+
+
 def test_cycle_in_parent_chain_terminates(tmp_path):
     """Pathological data with a parent cycle (A→B→A) must not infinite-loop."""
     from api.agent_sessions import read_session_lineage_metadata


### PR DESCRIPTION
## Summary
- Resolve branchy compression lineages to the freshest real messageful continuation descendant instead of the newest direct child.
- Expose the same canonical `_lineage_tip_id` through state-db lineage metadata so WebUI JSON/sidebar collapse chooses the same tip.
- Preserve older/minimal state.db compatibility by treating `source`, `message_count`, and the `messages` table as optional.

## Root cause
Compression parents can have multiple continuation-looking children when a stale segment is resumed after a newer compressed branch already exists. The previous projection followed the newest direct child only, so it could hide the deeper branch with the latest real activity and make a conversation look missing or stale after compaction/session rotation.

## Related reconnaissance
- Related umbrella/context: #2361, #2734, #2761.
- Adjacent PRs checked:
  - #2980 handles stale pre-compression snapshot reloads and continuation hints; it does not choose the freshest descendant across branchy state-db lineages.
  - #3563 touches `api/agent_sessions.py` / `tests/test_gateway_sync.py` for cron session surfacing; hunk intent is separate.
- This PR is intentionally a narrow backend lineage invariant, not the larger canonical session-ledger/RFC rewrite.

## Validation
- `python3 -m pytest -q tests/test_pr1370_lineage_metadata_perf_and_orphan.py tests/test_session_lineage_metadata_api.py tests/test_gateway_sync.py::test_compression_lineage_prefers_freshest_descendant_over_newer_direct_sibling tests/test_gateway_sync.py::test_compression_chain_collapses_to_latest_tip_in_sidebar` → `19 passed`
- `env -u HERMES_WEBUI_PASSWORD TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 python3 -m pytest -q` → `7989 passed, 75 skipped, 3 xpassed, 16 subtests passed`
- `python3 -m py_compile api/agent_sessions.py`
- `git diff --check`
- Added-line scan for secrets/risky patterns/private markers → `0` findings
- Independent blocker-only audit verdict: commit-safe
