### PR TITLE
Release v0.51.300 — stage-3726 (context-length indicator honors provider per-model overrides #3726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.300] — 2026-06-06 — Release JP (stage-3726 — context-length indicator honors provider per-model overrides)
+
+### Fixed
+- **The context-length indicator now honors per-model `context_length` overrides configured under a specific provider.** A `providers.<name>.models.<model>.context_length` override (standard provider, no `base_url`) was invisible to the session model's context resolver, so the usage indicator showed and persisted the wrong window — and could trip auto-compression at the wrong threshold. The resolver now collects the effective provider config, base URL, and custom-provider metadata across all three paths (route load, session save, live SSE usage), resolving provider-scoped overrides by provider-name match and forwarding them as `config_context_length` (which the agent returns before any base-URL-gated probe). `custom_providers`-with-`base_url` per-model overrides continue to resolve as before. (#3726 fixes #3717, @rodboev)
+
 ## [v0.51.299] — 2026-06-06 — Release JO (stage-3713 — update flow waits for a genuinely new server instance)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -1894,6 +1894,223 @@ def _model_matches_configured_default(
     return True
 
 
+class _ContextLengthLookupInputs:
+    __slots__ = ("config_context_length", "custom_providers", "base_url", "provider")
+
+    def __init__(
+        self,
+        *,
+        config_context_length: int | None = None,
+        custom_providers: list | None = None,
+        base_url: str = "",
+        provider: str = "",
+    ) -> None:
+        self.config_context_length = config_context_length
+        self.custom_providers = custom_providers
+        self.base_url = base_url
+        self.provider = provider
+
+
+def _positive_context_length(value) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _model_lookup_candidates(model: str) -> tuple[str, ...]:
+    raw = str(model or "").strip()
+    candidates = []
+    for candidate in (raw, _split_provider_qualified_model(raw)[0]):
+        if candidate and candidate not in candidates:
+            candidates.append(candidate)
+        if "/" in candidate:
+            bare = candidate.split("/", 1)[1].strip()
+            if bare and bare not in candidates:
+                candidates.append(bare)
+    return tuple(candidates)
+
+
+def _models_config_context_length(models_cfg, model: str) -> int | None:
+    candidates = _model_lookup_candidates(model)
+    if isinstance(models_cfg, dict):
+        for candidate in candidates:
+            entry = models_cfg.get(candidate)
+            raw_ctx = entry.get("context_length") if isinstance(entry, dict) else entry
+            ctx = _positive_context_length(raw_ctx)
+            if ctx is not None:
+                return ctx
+    if isinstance(models_cfg, list):
+        for entry in models_cfg:
+            if not isinstance(entry, dict):
+                continue
+            entry_model = str(entry.get("id") or entry.get("model") or entry.get("name") or "").strip()
+            if entry_model in candidates:
+                ctx = _positive_context_length(entry.get("context_length"))
+                if ctx is not None:
+                    return ctx
+    return None
+
+
+def _canonical_context_provider(value: str | None) -> str:
+    provider = _clean_session_model_provider(value) or ""
+    if not provider:
+        return ""
+    try:
+        from api.config import _resolve_provider_alias
+
+        provider = _resolve_provider_alias(provider)
+    except Exception:
+        pass
+    return str(provider or "").strip().lower()
+
+
+def _custom_provider_slug_for_context(name: object) -> str:
+    try:
+        from api.config import _custom_provider_slug_from_name
+
+        return _custom_provider_slug_from_name(name)
+    except Exception:
+        raw = str(name or "").strip().lower()
+        if not raw:
+            return ""
+        if raw.startswith("custom:"):
+            return raw
+        slug = re.sub(r"[^a-z0-9._-]+", "-", raw).strip("-")
+        slug = re.sub(r"-{2,}", "-", slug)
+        return f"custom:{slug}" if slug else ""
+
+
+def _providers_match_for_context(config_key: object, requested_provider: str) -> bool:
+    if not requested_provider:
+        return False
+    raw_key = str(config_key or "").strip().lower()
+    key = _canonical_context_provider(raw_key)
+    requested = _canonical_context_provider(requested_provider)
+    return bool(
+        requested
+        and (
+            raw_key == requested
+            or key == requested
+            or raw_key == str(requested_provider or "").strip().lower()
+        )
+    )
+
+
+def _context_length_lookup_inputs_for_model(
+    model: str | None,
+    provider: str | None = None,
+    *,
+    base_url: str | None = None,
+    cfg: dict | None = None,
+) -> _ContextLengthLookupInputs:
+    """Return the effective metadata resolver inputs for a WebUI model.
+
+    ``agent.model_metadata.get_model_context_length`` understands global
+    ``config_context_length`` and custom-provider overrides, but only when the
+    matching base URL is supplied. WebUI also owns ``providers.<provider>.models``
+    overrides, so normalize those here and keep route/session-save/SSE aligned.
+    """
+    model_for_lookup = str(model or "").strip()
+    if not model_for_lookup:
+        return _ContextLengthLookupInputs()
+
+    if cfg is None:
+        try:
+            from api.config import get_config as _get_config_for_cl
+
+            cfg = _get_config_for_cl()
+        except Exception:
+            cfg = {}
+    cfg = cfg if isinstance(cfg, dict) else {}
+
+    bare_model, explicit_provider = _split_provider_qualified_model(model_for_lookup)
+    effective_provider = _canonical_context_provider(provider or explicit_provider)
+    effective_base_url = str(base_url or "").strip()
+
+    model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
+    if isinstance(model_cfg, dict):
+        if not effective_provider:
+            effective_provider = _canonical_context_provider(model_cfg.get("provider"))
+        if not effective_base_url:
+            effective_base_url = str(model_cfg.get("base_url") or "").strip()
+
+    custom_providers = cfg.get("custom_providers") if isinstance(cfg, dict) else None
+    if not isinstance(custom_providers, list):
+        custom_providers = None
+
+    provider_context_length = None
+    providers_cfg = cfg.get("providers", {}) if isinstance(cfg, dict) else {}
+    if isinstance(providers_cfg, dict):
+        for provider_key, provider_cfg in providers_cfg.items():
+            if not isinstance(provider_cfg, dict):
+                continue
+            if not _providers_match_for_context(provider_key, effective_provider):
+                continue
+            if not effective_base_url:
+                effective_base_url = str(provider_cfg.get("base_url") or "").strip()
+            provider_context_length = _models_config_context_length(
+                provider_cfg.get("models"),
+                bare_model or model_for_lookup,
+            )
+            break
+
+    custom_context_length = None
+    if custom_providers:
+        target_base = effective_base_url.rstrip("/")
+        model_candidates = set(_model_lookup_candidates(bare_model or model_for_lookup))
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            entry_name = str(entry.get("name") or "").strip()
+            entry_slug = _custom_provider_slug_for_context(entry_name)
+            entry_base = str(entry.get("base_url") or "").strip()
+            entry_base_norm = entry_base.rstrip("/")
+            provider_matches = bool(
+                effective_provider
+                and (
+                    effective_provider == entry_slug
+                    or effective_provider == entry_name.lower()
+                    or (effective_provider == "custom" and len(custom_providers) == 1)
+                )
+            )
+            base_matches = bool(target_base and entry_base_norm and target_base == entry_base_norm)
+            model_matches = bool(model_candidates.intersection(set(_model_lookup_candidates(entry.get("model")))))
+            models_cfg = entry.get("models")
+            if isinstance(models_cfg, dict):
+                model_matches = model_matches or any(candidate in models_cfg for candidate in model_candidates)
+            if not (provider_matches or base_matches or (not effective_provider and model_matches)):
+                continue
+            if not effective_provider and entry_slug:
+                effective_provider = entry_slug
+            if not effective_base_url and entry_base:
+                effective_base_url = entry_base
+            custom_context_length = _models_config_context_length(models_cfg, bare_model or model_for_lookup)
+            break
+
+    global_context_length = None
+    if isinstance(model_cfg, dict):
+        cfg_default_model = str(model_cfg.get("default") or "").strip()
+        raw_cfg_ctx = model_cfg.get("context_length")
+        if raw_cfg_ctx is not None and (
+            not cfg_default_model
+            or _model_matches_configured_default(
+                model_for_lookup,
+                cfg_default_model,
+                effective_provider,
+            )
+        ):
+            global_context_length = _positive_context_length(raw_cfg_ctx)
+
+    return _ContextLengthLookupInputs(
+        config_context_length=provider_context_length or custom_context_length or global_context_length,
+        custom_providers=custom_providers,
+        base_url=effective_base_url,
+        provider=effective_provider,
+    )
+
+
 
 def _should_attach_codex_provider_context(model: str, raw_active_provider: str, catalog: dict) -> bool:
     """Return True when a bare Codex model needs separate provider context.
@@ -2283,43 +2500,22 @@ def _resolve_context_length_for_session_model(
         from api.config import get_config as _get_config_for_cl
 
         _cfg_for_cl = _get_config_for_cl()
-        _cfg_ctx_len_load = None
-        _cfg_custom_providers_load = None
-        try:
-            _model_cfg_load = _cfg_for_cl.get('model', {}) if isinstance(_cfg_for_cl, dict) else {}
-            if isinstance(_model_cfg_load, dict):
-                # Only apply the global model.context_length override when the
-                # session model matches model.default. Otherwise a global cap
-                # set for the default model (e.g. 232000) silently clobbers
-                # other models' real metadata (e.g. a 1M-context variant).
-                _cfg_default_model = str(_model_cfg_load.get('default') or '').strip()
-                _raw_cfg_ctx_load = _model_cfg_load.get('context_length')
-                if _raw_cfg_ctx_load is not None and (
-                    not _cfg_default_model
-                    or _model_matches_configured_default(model_for_lookup, _cfg_default_model, provider)
-                ):
-                    try:
-                        _parsed_load = int(_raw_cfg_ctx_load)
-                        if _parsed_load > 0:
-                            _cfg_ctx_len_load = _parsed_load
-                    except (TypeError, ValueError):
-                        pass
-            _raw_cp_load = _cfg_for_cl.get('custom_providers') if isinstance(_cfg_for_cl, dict) else None
-            if isinstance(_raw_cp_load, list):
-                _cfg_custom_providers_load = _raw_cp_load
-        except Exception:
-            pass
+        _ctx_lookup = _context_length_lookup_inputs_for_model(
+            model_for_lookup,
+            provider,
+            cfg=_cfg_for_cl if isinstance(_cfg_for_cl, dict) else {},
+        )
         try:
             return _get_cl(
                 model_for_lookup,
-                "",
-                config_context_length=_cfg_ctx_len_load,
-                provider=provider or "",
-                custom_providers=_cfg_custom_providers_load,
+                _ctx_lookup.base_url,
+                config_context_length=_ctx_lookup.config_context_length,
+                provider=_ctx_lookup.provider or provider or "",
+                custom_providers=_ctx_lookup.custom_providers,
             ) or 0
         except TypeError:
             # Older hermes-agent builds: legacy 2-arg form.
-            return _get_cl(model_for_lookup, "") or 0
+            return _get_cl(model_for_lookup, _ctx_lookup.base_url) or 0
     except Exception:
         return 0
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -6711,44 +6711,23 @@ def _run_agent_streaming(
                 if (not getattr(s, 'context_length', 0)) or _skip_cc_cl:
                     try:
                         from agent.model_metadata import get_model_context_length
-                        _cfg_ctx_len = None
-                        _cfg_custom_providers = None
-                        try:
-                            _model_cfg_for_ctx = _cfg.get('model', {}) if isinstance(_cfg, dict) else {}
-                            if isinstance(_model_cfg_for_ctx, dict):
-                                _raw_cfg_ctx = _model_cfg_for_ctx.get('context_length')
-                                # Default-only guard: only apply the global
-                                # model.context_length cap when the session
-                                # model equals model.default. Otherwise the
-                                # cap (e.g. 232K set for the default model)
-                                # silently shrinks other models' real metadata.
-                                _cfg_default_ctx = str(_model_cfg_for_ctx.get('default') or '').strip()
-                                _sess_model_ctx = str(getattr(agent, 'model', resolved_model or '') or '').strip()
-                                from api.routes import _model_matches_configured_default as _mmcd_ctx
-                                _apply_cfg_ctx = (
-                                    not _cfg_default_ctx
-                                    or not _sess_model_ctx
-                                    or _mmcd_ctx(_sess_model_ctx, _cfg_default_ctx, resolved_provider or '')
-                                )
-                                if _raw_cfg_ctx is not None and _apply_cfg_ctx:
-                                    try:
-                                        _parsed_cfg_ctx = int(_raw_cfg_ctx)
-                                        if _parsed_cfg_ctx > 0:
-                                            _cfg_ctx_len = _parsed_cfg_ctx
-                                    except (TypeError, ValueError):
-                                        # Invalid config — let the resolver fall
-                                        # through to provider/registry probing.
-                                        pass
-                            _raw_cp = _cfg.get('custom_providers') if isinstance(_cfg, dict) else None
-                            if isinstance(_raw_cp, list):
-                                _cfg_custom_providers = _raw_cp
-                        except Exception:
-                            pass
+                        from api.routes import _context_length_lookup_inputs_for_model
+                        _cfg_base_url = getattr(agent, 'base_url', '') or resolved_base_url or ''
+                        _ctx_lookup = _context_length_lookup_inputs_for_model(
+                            getattr(agent, 'model', resolved_model or '') or '',
+                            resolved_provider,
+                            base_url=_cfg_base_url,
+                            cfg=_cfg if isinstance(_cfg, dict) else {},
+                        )
+                        _cfg_ctx_len = _ctx_lookup.config_context_length
+                        _cfg_custom_providers = _ctx_lookup.custom_providers
+                        _cfg_base_url = _ctx_lookup.base_url or _cfg_base_url
+                        _cfg_provider = _ctx_lookup.provider or resolved_provider or ''
                         _resolved_cl = get_model_context_length(
                             getattr(agent, 'model', resolved_model or '') or '',
-                            getattr(agent, 'base_url', '') or '',
+                            _cfg_base_url,
                             config_context_length=_cfg_ctx_len,
-                            provider=resolved_provider or '',
+                            provider=_cfg_provider,
                             custom_providers=_cfg_custom_providers,
                         )
                         if _resolved_cl:
@@ -6762,7 +6741,7 @@ def _run_agent_streaming(
                             from agent.model_metadata import get_model_context_length as _legacy_cl
                             _resolved_cl = _legacy_cl(
                                 getattr(agent, 'model', resolved_model or '') or '',
-                                getattr(agent, 'base_url', '') or '',
+                                _cfg_base_url,
                             )
                             if _resolved_cl:
                                 s.context_length = _resolved_cl
@@ -6991,49 +6970,30 @@ def _run_agent_streaming(
             if not usage.get('context_length'):
                 try:
                     from agent.model_metadata import get_model_context_length as _get_cl
-                    _cfg_ctx_len = None
-                    _cfg_custom_providers = None
-                    try:
-                        _model_cfg_for_ctx = _cfg.get('model', {}) if isinstance(_cfg, dict) else {}
-                        if isinstance(_model_cfg_for_ctx, dict):
-                            _raw_cfg_ctx = _model_cfg_for_ctx.get('context_length')
-                            # Default-only guard (see #3256): the global
-                            # model.context_length cap only applies to
-                            # model.default; other models keep their real
-                            # metadata.
-                            _cfg_default_ctx = str(_model_cfg_for_ctx.get('default') or '').strip()
-                            _sess_model_ctx = str(getattr(agent, 'model', resolved_model or '') or '').strip()
-                            from api.routes import _model_matches_configured_default as _mmcd_sfb
-                            _apply_cfg_ctx = (
-                                not _cfg_default_ctx
-                                or not _sess_model_ctx
-                                or _mmcd_sfb(_sess_model_ctx, _cfg_default_ctx, resolved_provider or '')
-                            )
-                            if _raw_cfg_ctx is not None and _apply_cfg_ctx:
-                                try:
-                                    _parsed_cfg_ctx = int(_raw_cfg_ctx)
-                                    if _parsed_cfg_ctx > 0:
-                                        _cfg_ctx_len = _parsed_cfg_ctx
-                                except (TypeError, ValueError):
-                                    pass
-                        _raw_cp = _cfg.get('custom_providers') if isinstance(_cfg, dict) else None
-                        if isinstance(_raw_cp, list):
-                            _cfg_custom_providers = _raw_cp
-                    except Exception:
-                        pass
+                    from api.routes import _context_length_lookup_inputs_for_model
+                    _ctx_lookup = _context_length_lookup_inputs_for_model(
+                        getattr(agent, 'model', resolved_model or '') or '',
+                        resolved_provider,
+                        base_url=getattr(agent, 'base_url', '') or resolved_base_url or '',
+                        cfg=_cfg if isinstance(_cfg, dict) else {},
+                    )
+                    _cfg_ctx_len = _ctx_lookup.config_context_length
+                    _cfg_custom_providers = _ctx_lookup.custom_providers
+                    _cfg_base_url = _ctx_lookup.base_url
+                    _cfg_provider = _ctx_lookup.provider or resolved_provider or ''
                     try:
                         _fb_cl = _get_cl(
                             getattr(agent, 'model', resolved_model or '') or '',
-                            getattr(agent, 'base_url', '') or '',
+                            _cfg_base_url,
                             config_context_length=_cfg_ctx_len,
-                            provider=resolved_provider or '',
+                            provider=_cfg_provider,
                             custom_providers=_cfg_custom_providers,
                         )
                     except TypeError:
                         # Older hermes-agent builds: fall back to legacy 2-arg form.
                         _fb_cl = _get_cl(
                             getattr(agent, 'model', resolved_model or '') or '',
-                            getattr(agent, 'base_url', '') or '',
+                            _cfg_base_url,
                         )
                     if _fb_cl:
                         usage['context_length'] = _fb_cl

--- a/tests/test_issue1896_context_length_fallback_args.py
+++ b/tests/test_issue1896_context_length_fallback_args.py
@@ -30,7 +30,7 @@ STREAMING_PY = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")
 # Both fallback callsites must pass these kwargs into get_model_context_length.
 _REQUIRED_KWARGS = (
     "config_context_length=_cfg_ctx_len",
-    "provider=resolved_provider or ''",
+    "provider=_cfg_provider",
     "custom_providers=_cfg_custom_providers",
 )
 
@@ -120,11 +120,11 @@ def test_both_callsites_pass_config_context_length():
 
 
 def test_both_callsites_pass_provider():
-    """Both callsites must pass `provider=resolved_provider or ''`."""
+    """Both callsites must pass the effective provider into the resolver."""
     blocks = _both_callsites()
     for i, block in enumerate(blocks):
-        assert "provider=resolved_provider" in block, (
-            f"Callsite #{i+1} is missing `provider=resolved_provider...`. "
+        assert "provider=_cfg_provider" in block, (
+            f"Callsite #{i+1} is missing `provider=_cfg_provider`. "
             f"Provider is needed for the registry lookup step (models.dev "
             f"provider-aware lookup). See #1896.\n\nBlock:\n{block}"
         )
@@ -170,13 +170,15 @@ def test_cfg_custom_providers_resolved_from_cfg_dict():
     """The kwargs source must be the per-profile config (`_cfg`), not a
     module-level snapshot — otherwise profile switches with different
     custom_providers wouldn't take effect."""
-    # Look for the resolution pattern.
-    assert "_cfg.get('custom_providers')" in STREAMING_PY, (
-        "_cfg_custom_providers must be sourced from `_cfg.get('custom_providers')` "
+    # The parsing now lives in the shared route helper so session-load,
+    # session-save, and SSE fallbacks cannot drift.
+    assert "_context_length_lookup_inputs_for_model(" in STREAMING_PY
+    assert 'cfg.get("custom_providers")' in ROUTES_PY, (
+        "_cfg_custom_providers must be sourced from `cfg.get('custom_providers')` "
         "(per-profile config) so profile-scoped custom_providers entries work."
     )
-    assert "_cfg.get('model', {})" in STREAMING_PY, (
-        "_cfg_ctx_len must be sourced from `_cfg.get('model', {}).get('context_length')` "
+    assert 'cfg.get("model", {})' in ROUTES_PY, (
+        "_cfg_ctx_len must be sourced from `cfg.get('model', {}).get('context_length')` "
         "(per-profile config) so profile-scoped model.context_length overrides work."
     )
 
@@ -218,7 +220,7 @@ def test_routes_session_load_fallback_passes_config_overrides():
         "session-load fallback in api/routes.py must pass config_context_length= "
         "so user-set model.context_length wins over the 256K default. See #1896."
     )
-    assert "provider=provider or" in helper, (
+    assert "provider=_ctx_lookup.provider or provider or" in helper, (
         "session-load fallback in api/routes.py must pass provider= "
         "so the registry lookup is provider-aware. See #1896."
     )

--- a/tests/test_issue3717_context_length_provider_overrides.py
+++ b/tests/test_issue3717_context_length_provider_overrides.py
@@ -1,0 +1,198 @@
+"""Regression coverage for #3717 provider-scoped context-length overrides."""
+
+import sys
+import types
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+STREAMING_PY = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")
+ROUTES_PY = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
+
+
+def _install_fake_context_resolver(monkeypatch):
+    calls = []
+    mod = types.ModuleType("agent.model_metadata")
+
+    def _fake(
+        model,
+        base_url="",
+        *args,
+        config_context_length=None,
+        provider="",
+        custom_providers=None,
+        **kwargs,
+    ):
+        calls.append(
+            {
+                "model": model,
+                "base_url": base_url,
+                "config_context_length": config_context_length,
+                "provider": provider,
+                "custom_providers": custom_providers,
+            }
+        )
+        return config_context_length or 256000
+
+    mod.get_model_context_length = _fake
+    if "agent" not in sys.modules:
+        agent_pkg = types.ModuleType("agent")
+        agent_pkg.__path__ = []
+        monkeypatch.setitem(sys.modules, "agent", agent_pkg)
+    monkeypatch.setitem(sys.modules, "agent.model_metadata", mod)
+    return calls
+
+
+def test_route_resolver_uses_provider_model_context_length(monkeypatch):
+    import api.config as config
+    import api.routes as routes
+
+    calls = _install_fake_context_resolver(monkeypatch)
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda *a, **k: {
+            "model": {
+                "default": "default-model",
+                "context_length": 123456,
+            },
+            "providers": {
+                "openrouter": {
+                    "base_url": "https://openrouter.example/v1",
+                    "models": {
+                        "provider-model": {"context_length": 777000},
+                    },
+                },
+            },
+            "custom_providers": [],
+        },
+    )
+
+    result = routes._resolve_context_length_for_session_model(
+        "provider-model",
+        "openrouter",
+    )
+
+    assert result == 777000
+    assert calls[-1]["config_context_length"] == 777000
+    assert calls[-1]["base_url"] == "https://openrouter.example/v1"
+    assert calls[-1]["provider"] == "openrouter"
+
+
+def test_route_resolver_uses_provider_model_context_length_without_base_url(monkeypatch):
+    import api.config as config
+    import api.routes as routes
+
+    calls = _install_fake_context_resolver(monkeypatch)
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda *a, **k: {
+            "model": {
+                "default": "default-model",
+                "context_length": 123456,
+            },
+            "providers": {
+                "anthropic": {
+                    "models": {
+                        "provider-model": {"context_length": 777000},
+                    },
+                },
+            },
+            "custom_providers": [],
+        },
+    )
+
+    result = routes._resolve_context_length_for_session_model(
+        "provider-model",
+        "anthropic",
+    )
+
+    assert result == 777000
+    assert calls[-1]["config_context_length"] == 777000
+    assert calls[-1]["base_url"] == ""
+    assert calls[-1]["provider"] == "anthropic"
+
+
+def test_route_resolver_uses_named_custom_provider_base_url(monkeypatch):
+    import api.config as config
+    import api.routes as routes
+
+    custom_providers = [
+        {
+            "name": "ZenMux",
+            "base_url": "https://zenmux.example/v1",
+            "models": {
+                "custom-model": {"context_length": "888000"},
+            },
+        }
+    ]
+    calls = _install_fake_context_resolver(monkeypatch)
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda *a, **k: {
+            "model": {
+                "default": "default-model",
+                "context_length": 123456,
+            },
+            "custom_providers": custom_providers,
+        },
+    )
+
+    result = routes._resolve_context_length_for_session_model(
+        "custom-model",
+        "custom:zenmux",
+    )
+
+    assert result == 888000
+    assert calls[-1]["config_context_length"] == 888000
+    assert calls[-1]["base_url"] == "https://zenmux.example/v1"
+    assert calls[-1]["provider"] == "custom:zenmux"
+    assert calls[-1]["custom_providers"] is custom_providers
+
+
+def test_global_context_length_remains_default_model_only(monkeypatch):
+    import api.config as config
+    import api.routes as routes
+
+    calls = _install_fake_context_resolver(monkeypatch)
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda *a, **k: {
+            "model": {
+                "default": "default-model",
+                "context_length": 123456,
+            },
+            "providers": {
+                "openai": {
+                    "base_url": "https://openai.example/v1",
+                    "models": {},
+                },
+            },
+        },
+    )
+
+    result = routes._resolve_context_length_for_session_model("other-model", "openai")
+
+    assert result == 256000
+    assert calls[-1]["config_context_length"] is None
+    assert calls[-1]["base_url"] == "https://openai.example/v1"
+
+
+def test_streaming_fallbacks_use_shared_provider_context_helper():
+    assert STREAMING_PY.count("_context_length_lookup_inputs_for_model(") >= 2
+    assert "_cfg_base_url = getattr(agent, 'base_url', '') or resolved_base_url or ''" in STREAMING_PY
+    assert "base_url=_cfg_base_url" in STREAMING_PY
+    assert "config_context_length=_cfg_ctx_len" in STREAMING_PY
+    assert "provider=_cfg_provider" in STREAMING_PY
+    assert "custom_providers=_cfg_custom_providers" in STREAMING_PY
+    assert "_cfg_base_url" in STREAMING_PY
+
+
+def test_route_helper_keeps_all_context_length_sources_aligned():
+    assert "def _context_length_lookup_inputs_for_model" in ROUTES_PY
+    assert 'cfg.get("providers", {})' in ROUTES_PY
+    assert 'cfg.get("custom_providers")' in ROUTES_PY
+    assert "_model_matches_configured_default" in ROUTES_PY


### PR DESCRIPTION
Release stage for **v0.51.300** — backend-only context-length resolver fix.

## #3726 → fixes #3717 — context-length indicator honors provider per-model overrides
@rodboev, +469/−110. A `providers.<name>.models.<model>.context_length` override (standard provider, **no** `base_url`) was invisible to the session context resolver, so the usage indicator showed/persisted the wrong window and could trip auto-compression at the wrong threshold (cascading into 429s on large-context models). New `_context_length_lookup_inputs_for_model` helper resolves the effective provider config / base URL / custom-provider metadata across all three callsites (route load, session save, live SSE usage); provider-scoped overrides match by **provider name** (not base_url) and forward as `config_context_length`, which the agent returns before any base-URL-gated probe.

## Maintainer pre-merge items — both already satisfied in the PR head
- No-base_url regression test present (`test_route_resolver_uses_provider_model_context_length_without_base_url` — asserts `config_context_length=777000`, `base_url=""`), locking in the previously-unfixable standard-provider case.
- Session-save `_cfg_base_url` is assigned *before* the helper call (`streaming.py:6715`), so the `except TypeError` legacy-agent fallback can't `NameError`. (Confirmed by both Codex and Opus across all 3 callsites.)
- CHANGELOG line added (this PR's only addition on top of the contributor's work).

## Gate (all green)
- Full suite: **8116 passed, 0 failed** (first run hit the known boot-cascade flake — ConnectionRefused across unrelated files; re-run clean)
- Codex regression: **SAFE TO SHIP** (provider match is alias-normalized not substring — `openai`≠`openai-codex`; default-model guard preserved; 3 callsites aligned; legacy TypeError fallback safe at all sites)
- Opus correctness: **SAFE TO SHIP** (35 context-length tests pass; provider canonicalization more correct than before)
- Ruff + scope-undef: CLEAN
- revert-guard: origin/master is an ancestor

api code verified byte-identical to the PR head. (#3726 fixes #3717)