### PR TITLE
Release v0.51.301 — stage-3710 (hide test-helper console windows on Windows #3710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.301] — 2026-06-06 — Release JQ (stage-3710 — hide test-helper console windows on Windows)
+
+### Changed
+- **Developer experience (Windows):** the test suite's long-lived helper subprocesses (main test server, browser-smoke server, TLS helper, and the `ctl` test helpers) now spawn with `CREATE_NO_WINDOW` on Windows, so a local `pytest` run no longer pops up several focus-stealing console windows. Windows-only (`sys.platform == "win32"` guard); no behavior change on macOS/Linux. (#3710 fixes #3706, @rodboev)
+
 ## [v0.51.300] — 2026-06-06 — Release JP (stage-3726 — context-length indicator honors provider per-model overrides)
 
 ### Fixed

--- a/tests/browser_smoke.py
+++ b/tests/browser_smoke.py
@@ -114,7 +114,7 @@ def main():
     proc = subprocess.Popen(
         [sys.executable, server_py], cwd=repo_root, env=env,
         stdout=log, stderr=subprocess.STDOUT,
-        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+        **({"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {}),
     )
     try:
         if not _wait_for_health(timeout=30):

--- a/tests/browser_smoke.py
+++ b/tests/browser_smoke.py
@@ -114,6 +114,7 @@ def main():
     proc = subprocess.Popen(
         [sys.executable, server_py], cwd=repo_root, env=env,
         stdout=log, stderr=subprocess.STDOUT,
+        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
     )
     try:
         if not _wait_for_health(timeout=30):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -636,6 +636,7 @@ def test_server():
         env=env,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
     )
 
     if not _wait_for_server(TEST_BASE, timeout=20):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -636,7 +636,7 @@ def test_server():
         env=env,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+        **({"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {}),
     )
 
     if not _wait_for_server(TEST_BASE, timeout=20):

--- a/tests/test_ctl_script.py
+++ b/tests/test_ctl_script.py
@@ -143,7 +143,10 @@ def windows_pid(pid: int) -> int | None:
 
 
 def start_fake_launchd_process() -> subprocess.Popen:
-    return subprocess.Popen(["bash", "-lc", "exec sleep 30"])
+    return subprocess.Popen(
+        ["bash", "-lc", "exec sleep 30"],
+        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+    )
 
 
 def _kill_tree(pid: int) -> None:
@@ -316,7 +319,10 @@ def test_stale_pid_file_is_removed_without_killing_unrelated_process(tmp_path):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
     pid_file = hermes_home / "webui.pid"
-    sleeper = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    sleeper = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+    )
     try:
         pid_file.write_text(str(sleeper.pid), encoding="utf-8")
         result = run_ctl(tmp_path, "stop")

--- a/tests/test_ctl_script.py
+++ b/tests/test_ctl_script.py
@@ -145,7 +145,7 @@ def windows_pid(pid: int) -> int | None:
 def start_fake_launchd_process() -> subprocess.Popen:
     return subprocess.Popen(
         ["bash", "-lc", "exec sleep 30"],
-        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+        **({"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {}),
     )
 
 
@@ -321,7 +321,7 @@ def test_stale_pid_file_is_removed_without_killing_unrelated_process(tmp_path):
     pid_file = hermes_home / "webui.pid"
     sleeper = subprocess.Popen(
         [sys.executable, "-c", "import time; time.sleep(30)"],
-        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+        **({"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {}),
     )
     try:
         pid_file.write_text(str(sleeper.pid), encoding="utf-8")

--- a/tests/test_tls_support.py
+++ b/tests/test_tls_support.py
@@ -6,6 +6,7 @@ Tests use a self-signed certificate generated at test time via openssl.
 import http.client
 import json
 import os
+import sys
 import ssl
 import subprocess
 import textwrap
@@ -79,6 +80,7 @@ def _start_server(port: int, cert: str = None, key: str = None) -> subprocess.Po
         [os.sys.executable, str(ROOT / "server.py")],
         env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         text=True,
+        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
     )
     return proc
 

--- a/tests/test_tls_support.py
+++ b/tests/test_tls_support.py
@@ -6,12 +6,12 @@ Tests use a self-signed certificate generated at test time via openssl.
 import http.client
 import json
 import os
-import sys
 import ssl
 import subprocess
+import sys
+import tempfile
 import textwrap
 import time
-import tempfile
 import unittest
 from contextlib import suppress
 from pathlib import Path
@@ -80,7 +80,7 @@ def _start_server(port: int, cert: str = None, key: str = None) -> subprocess.Po
         [os.sys.executable, str(ROOT / "server.py")],
         env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         text=True,
-        **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
+        **({"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {}),
     )
     return proc
 


### PR DESCRIPTION
Release stage for **v0.51.301** — test-only, Windows dev-experience.

## #3710 → fixes #3706 — hide test-helper console windows on Windows
@rodboev, +13/−3, 4 test files only. Windows local `pytest` runs spawn long-lived helper subprocesses (test server, browser-smoke, TLS helper, ctl helpers) via `subprocess.Popen`; each unflagged child opened a visible console window. Each spawn now adds `CREATE_NO_WINDOW` on Windows.

All changes are `**({"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {})` — on macOS/Linux they expand to `**{}` (literal no-op). **Zero production code, zero non-Windows behavior change.**

## Gate (all green)
- Full suite: **8116 passed, 0 failed**
- Codex regression: **SAFE TO SHIP** (all 5 spawn sites win32-guarded; no unconditional CREATE_NO_WINDOW that would NameError on Linux; existing Popen kwargs preserved; no production files touched)
- Ruff forward gate: CLEAN
- revert-guard: origin/master is an ancestor

(#3710 fixes #3706)