### PR TITLE
fix: harden WebUI security-sensitive defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+### Security
+- Hardened unauthenticated first-run onboarding gates so spoofed `X-Forwarded-For` / `X-Real-IP` headers are ignored unless `HERMES_WEBUI_TRUST_FORWARDED_FOR=1` is explicitly set behind a trusted proxy.
+- Docker startup now refuses public binds without authentication by default via `HERMES_WEBUI_REQUIRE_AUTH_FOR_PUBLIC_BIND=1`, and Docker init logs now mask password/secret-like environment variable names.
+- Update checks that perform git/network refreshes now use `POST /api/updates/check`; `GET /api/updates/check` is cache-only.
+- `/api/media` no longer treats all of `/tmp` as a default allowed root; temporary artifacts require an exact session `MEDIA:` grant or an explicit `MEDIA_ALLOWED_ROOTS` operator allow-list.
+
 ## [v0.51.303] — 2026-06-06 — Release JS (stage-p1a — low-risk fixes: cron toggle, config var expansion, git-discard hardening)
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN echo "__version__ = '${HERMES_VERSION}'" > /apptoo/api/_version.py
 # Default to binding all interfaces (required for container networking)
 ENV HERMES_WEBUI_HOST=0.0.0.0
 ENV HERMES_WEBUI_PORT=8787
+ENV HERMES_WEBUI_REQUIRE_AUTH_FOR_PUBLIC_BIND=1
 
 EXPOSE 8787
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1585,7 +1585,7 @@ def _onboarding_request_is_local(handler) -> bool:
     candidates = []
     if _truthy_env("HERMES_WEBUI_TRUST_FORWARDED_FOR"):
         candidates.extend([
-            handler.headers.get("X-Forwarded-For", "").split(",")[0].strip(),
+            handler.headers.get("X-Forwarded-For", "").split(",")[-1].strip(),
             handler.headers.get("X-Real-IP", "").strip(),
         ])
     candidates.append(_request_client_ip(handler))

--- a/api/routes.py
+++ b/api/routes.py
@@ -1558,6 +1558,56 @@ def _client_ip_for_rate_limit(handler) -> str:
     return "unknown"
 
 
+def _truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _request_client_ip(handler) -> str:
+    try:
+        address = getattr(handler, "client_address", None)
+        if address:
+            return str(address[0] or "")
+    except Exception:
+        pass
+    return ""
+
+
+def _onboarding_request_is_local(handler) -> bool:
+    """Return True when an unauthenticated onboarding request is local/private.
+
+    Forwarded client-IP headers are ignored by default because direct clients can
+    spoof them. Operators behind a trusted reverse proxy may opt in with
+    HERMES_WEBUI_TRUST_FORWARDED_FOR=1, matching the explicit forwarded-header
+    trust model used elsewhere in the server.
+    """
+    import ipaddress
+
+    candidates = []
+    if _truthy_env("HERMES_WEBUI_TRUST_FORWARDED_FOR"):
+        candidates.extend([
+            handler.headers.get("X-Forwarded-For", "").split(",")[0].strip(),
+            handler.headers.get("X-Real-IP", "").strip(),
+        ])
+    candidates.append(_request_client_ip(handler))
+    for raw in candidates:
+        if not raw:
+            continue
+        try:
+            addr = ipaddress.ip_address(raw)
+        except ValueError:
+            continue
+        return bool(addr.is_loopback or addr.is_private)
+    return False
+
+
+def _onboarding_gate_allows(handler) -> bool:
+    from api.auth import is_auth_enabled
+
+    if is_auth_enabled() or _truthy_env("HERMES_WEBUI_ONBOARDING_OPEN"):
+        return True
+    return _onboarding_request_is_local(handler)
+
+
 def _csp_report_rate_limited(handler, *, now: float | None = None) -> bool:
     now = time.time() if now is None else now
     key = _client_ip_for_rate_limit(handler)
@@ -5879,7 +5929,6 @@ def handle_get(handler, parsed) -> bool:
             return j(handler, {"disabled": True})
         include_agent_updates = not bool(settings.get("ignore_agent_updates"))
         qs = parse_qs(parsed.query)
-        force = qs.get("force", ["0"])[0] == "1"
         # ?simulate=1 returns fake behind counts for UI testing (localhost only)
         if (
             qs.get("simulate", ["0"])[0] == "1"
@@ -5910,9 +5959,9 @@ def handle_get(handler, parsed) -> bool:
                     "checked_at": 0,
                 },
             )
-        from api.updates import check_for_updates
+        from api.updates import cached_update_status
 
-        return j(handler, check_for_updates(force=force, include_agent=include_agent_updates))
+        return j(handler, cached_update_status(include_agent=include_agent_updates))
 
     if parsed.path == "/api/chat/stream/status":
         stream_id = parse_qs(parsed.query).get("stream_id", [""])[0]
@@ -6482,6 +6531,16 @@ def handle_post(handler, parsed) -> bool:
         if diag:
             diag.finish()
         raise
+
+    if parsed.path == "/api/updates/check":
+        settings = load_settings()
+        if not settings.get("check_for_updates", True):
+            return j(handler, {"disabled": True})
+        include_agent_updates = not bool(settings.get("ignore_agent_updates"))
+        force = bool(body.get("force", False))
+        from api.updates import check_for_updates
+
+        return j(handler, check_for_updates(force=force, include_agent=include_agent_updates))
 
     if parsed.path == "/api/session/recovery/repair-safe":
         from api.session_recovery import repair_safe_session_recovery
@@ -7707,20 +7766,8 @@ def handle_post(handler, parsed) -> bool:
         return True
 
     if parsed.path == "/api/onboarding/oauth/start":
-        from api.auth import is_auth_enabled
-        import os as _os
-        if not is_auth_enabled() and not _os.getenv("HERMES_WEBUI_ONBOARDING_OPEN"):
-            import ipaddress
-            try:
-                _xff = handler.headers.get("X-Forwarded-For", "").split(",")[0].strip()
-                _xri = handler.headers.get("X-Real-IP", "").strip()
-                _raw = handler.client_address[0]
-                addr = ipaddress.ip_address(_xff or _xri or _raw)
-                is_local = addr.is_loopback or addr.is_private
-            except ValueError:
-                is_local = False
-            if not is_local:
-                return bad(handler, "Onboarding OAuth is only available from local networks when auth is not enabled. To bypass this on a remote server, set HERMES_WEBUI_ONBOARDING_OPEN=1.", 403)
+        if not _onboarding_gate_allows(handler):
+            return bad(handler, "Onboarding OAuth is only available from local networks when auth is not enabled. To bypass this on a remote server, set HERMES_WEBUI_ONBOARDING_OPEN=1.", 403)
         try:
             return j(handler, start_onboarding_oauth_flow(body), extra_headers={"Cache-Control": "no-store"})
         except ValueError as e:
@@ -7742,22 +7789,8 @@ def handle_post(handler, parsed) -> bool:
         # carries the real origin IP — read it first before falling back to the raw socket addr.
         # HERMES_WEBUI_ONBOARDING_OPEN=1 lets operators on remote servers explicitly bypass
         # the check when they control network access themselves (e.g. firewall + VPN).
-        from api.auth import is_auth_enabled
-        import os as _os
-        if not is_auth_enabled() and not _os.getenv("HERMES_WEBUI_ONBOARDING_OPEN"):
-            import ipaddress
-            try:
-                # Prefer forwarded headers set by reverse proxies
-                _xff = handler.headers.get("X-Forwarded-For", "").split(",")[0].strip()
-                _xri = handler.headers.get("X-Real-IP", "").strip()
-                _raw = handler.client_address[0]
-                _ip_str = _xff or _xri or _raw
-                addr = ipaddress.ip_address(_ip_str)
-                is_local = addr.is_loopback or addr.is_private
-            except ValueError:
-                is_local = False
-            if not is_local:
-                return bad(handler, "Onboarding setup is only available from local networks when auth is not enabled. To bypass this on a remote server, set HERMES_WEBUI_ONBOARDING_OPEN=1.", 403)
+        if not _onboarding_gate_allows(handler):
+            return bad(handler, "Onboarding setup is only available from local networks when auth is not enabled. To bypass this on a remote server, set HERMES_WEBUI_ONBOARDING_OPEN=1.", 403)
         try:
             return j(handler, apply_onboarding_setup(body))
         except ValueError as e:
@@ -7775,21 +7808,8 @@ def handle_post(handler, parsed) -> bool:
         # Read-only: no config.yaml or .env writes happen here.  Same local-
         # network gate as /api/onboarding/setup (also writing-adjacent in
         # spirit because it carries an api_key the user typed).
-        from api.auth import is_auth_enabled
-        import os as _os
-        if not is_auth_enabled() and not _os.getenv("HERMES_WEBUI_ONBOARDING_OPEN"):
-            import ipaddress
-            try:
-                _xff = handler.headers.get("X-Forwarded-For", "").split(",")[0].strip()
-                _xri = handler.headers.get("X-Real-IP", "").strip()
-                _raw = handler.client_address[0]
-                _ip_str = _xff or _xri or _raw
-                addr = ipaddress.ip_address(_ip_str)
-                is_local = addr.is_loopback or addr.is_private
-            except ValueError:
-                is_local = False
-            if not is_local:
-                return bad(handler, "Onboarding probe is only available from local networks when auth is not enabled. To bypass this on a remote server, set HERMES_WEBUI_ONBOARDING_OPEN=1.", 403)
+        if not _onboarding_gate_allows(handler):
+            return bad(handler, "Onboarding probe is only available from local networks when auth is not enabled. To bypass this on a remote server, set HERMES_WEBUI_ONBOARDING_OPEN=1.", 403)
         provider = str((body or {}).get("provider") or "").strip().lower()
         base_url = str((body or {}).get("base_url") or "")
         api_key = str((body or {}).get("api_key") or "").strip() or None
@@ -9685,12 +9705,15 @@ def _handle_media(handler, parsed):
     except Exception:
         return bad(handler, "Invalid path", 400)
 
-    # Allowed roots: hermes home, /tmp, and active workspace.
+    # Allowed roots: hermes home and active workspace. Do not allow all of /tmp
+    # by default: other local users/processes commonly place sensitive scratch
+    # files there. Temporary chat artifacts should be served via exact session
+    # MEDIA: tokens, or operators can opt into explicit roots with
+    # MEDIA_ALLOWED_ROOTS.
     # Intentionally NOT the entire home dir — that would expose ~/.ssh,
     # ~/.aws, browser profiles, etc. to any authenticated user.
     allowed_roots = [
         _HERMES_HOME.resolve(),
-        Path("/tmp").resolve(),
         (_HOME / ".hermes").resolve(),
     ]
     # Also allow the active workspace directory (where screenshots land)

--- a/api/updates.py
+++ b/api/updates.py
@@ -686,6 +686,18 @@ def _ignored_agent_update_info() -> dict:
     return {'name': 'agent', 'behind': 0, 'ignored': True}
 
 
+def cached_update_status(*, include_agent=True):
+    """Return cached update status without performing network or git mutations."""
+    include_agent = bool(include_agent)
+    with _cache_lock:
+        cached = dict(_update_cache)
+    if cached.get('include_agent') != include_agent:
+        cached['include_agent'] = include_agent
+        cached['agent'] = _ignored_agent_update_info() if not include_agent else None
+    cached['cached'] = True
+    return cached
+
+
 def check_for_updates(force=False, *, include_agent=True):
     """Return cached update status for webui and agent repos."""
     global _check_in_progress

--- a/api/updates.py
+++ b/api/updates.py
@@ -693,7 +693,8 @@ def cached_update_status(*, include_agent=True):
         cached = dict(_update_cache)
     if cached.get('include_agent') != include_agent:
         cached['include_agent'] = include_agent
-        cached['agent'] = _ignored_agent_update_info() if not include_agent else None
+        if not include_agent:
+            cached['agent'] = _ignored_agent_update_info()
     cached['cached'] = True
     return cached
 

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -19,7 +19,7 @@ ok_exit() {
 # Ignore list: variables to ignore when loading environment variables from user to user
 export ENV_IGNORELIST="HOME PWD USER SHLVL TERM OLDPWD SHELL _ SUDO_COMMAND HOSTNAME LOGNAME MAIL SUDO_GID SUDO_UID SUDO_USER CHECK_NV_CUDNN_VERSION VIRTUAL_ENV VIRTUAL_ENV_PROMPT ENV_IGNORELIST ENV_OBFUSCATE_PART"
 # Obfuscate part: part of the key to obfuscate when loading environment variables from user to user, ex: HF_TOKEN, ...
-export ENV_OBFUSCATE_PART="TOKEN API KEY"
+export ENV_OBFUSCATE_PART="TOKEN API KEY PASSWORD SECRET CREDENTIAL COOKIE SESSION"
 
 # Check for ENV_IGNORELIST and ENV_OBFUSCATE_PART
 if [ -z "${ENV_IGNORELIST+x}" ]; then error_exit "ENV_IGNORELIST not set"; fi

--- a/server.py
+++ b/server.py
@@ -522,6 +522,25 @@ def _log_shutdown_audit(reason: str = "serve_forever_exit") -> None:
     )
 
 
+def _public_bind_requires_auth(host: str, *, within_container: bool, auth_enabled: bool) -> bool:
+    """Whether startup should refuse a public bind without authentication.
+
+    This is opt-in for bare-metal/dev hosts, but Docker enables it by default in
+    the image because container networking commonly publishes 0.0.0.0 beyond the
+    local machine.
+    """
+    if auth_enabled:
+        return False
+    if host in ('127.0.0.1', '::1', 'localhost'):
+        return False
+    flag = os.getenv('HERMES_WEBUI_REQUIRE_AUTH_FOR_PUBLIC_BIND', '').strip().lower()
+    if flag in ('0', 'false', 'no', 'off'):
+        return False
+    if flag in ('1', 'true', 'yes', 'on'):
+        return True
+    return bool(within_container)
+
+
 def _abort_if_already_serving(host: str, port: int) -> None:
     """Refuse to start if a live HTTP server is already responding on this port."""
     probe_host = '127.0.0.1' if host in ('0.0.0.0', '', '::') else host
@@ -588,16 +607,24 @@ def main() -> None:
     if within_container:
         print('[ok] Running within container.', flush=True)
 
-    # Security: warn if binding non-loopback without authentication
+    # Security: warn/refuse if binding non-loopback without authentication
     from api.auth import is_auth_enabled
-    if HOST not in ('127.0.0.1', '::1', 'localhost') and not is_auth_enabled():
+    auth_enabled = is_auth_enabled()
+    if _public_bind_requires_auth(HOST, within_container=within_container, auth_enabled=auth_enabled):
+        print(f'[!!] FATAL: Refusing to bind {HOST} without authentication.', flush=True)
+        print(f'     Set HERMES_WEBUI_PASSWORD, configure a password in settings,', flush=True)
+        print(f'     bind to 127.0.0.1, or explicitly set', flush=True)
+        print(f'     HERMES_WEBUI_REQUIRE_AUTH_FOR_PUBLIC_BIND=0 if another layer', flush=True)
+        print(f'     already enforces access control.', flush=True)
+        sys.exit(1)
+    if HOST not in ('127.0.0.1', '::1', 'localhost') and not auth_enabled:
         print(f'[!!] WARNING: Binding to {HOST} with NO PASSWORD SET.', flush=True)
         print(f'     Anyone on the network can access your filesystem and agent.', flush=True)
         print(f'     Set a password via Settings or HERMES_WEBUI_PASSWORD env var.', flush=True)
         print(f'     To suppress: bind to 127.0.0.1 or set a password.', flush=True)
         if within_container:
             print(f'     Note: You are running within a container, must bind to 0.0.0.0 (IPv4) or :: (IPv6) to publish the port.', flush=True)
-    elif not is_auth_enabled():
+    elif not auth_enabled:
         print(f'  [tip] No password set. Any process on this machine can read sessions', flush=True)
         print(f'        and memory via the local API. Set HERMES_WEBUI_PASSWORD to', flush=True)
         print(f'        enable authentication.', flush=True)

--- a/static/boot.js
+++ b/static/boot.js
@@ -1842,7 +1842,7 @@ function applyBotName(){
   const _testUpdates=new URLSearchParams(location.search).get('test_updates')==='1';
   if(_testUpdates||(_bootSettings.check_for_updates!==false&&!sessionStorage.getItem('hermes-update-checked')&&!sessionStorage.getItem('hermes-update-dismissed'))){
     const _checkUrl='api/updates/check'+(_testUpdates?'?simulate=1':'');
-    api(_checkUrl).then(d=>{if(!_testUpdates)sessionStorage.setItem('hermes-update-checked','1');if((d.webui&&d.webui.behind>0)||(d.agent&&d.agent.behind>0))_showUpdateBanner(d);}).catch(()=>{});
+    api(_checkUrl,{method:_testUpdates?'GET':'POST',body:_testUpdates?undefined:JSON.stringify({force:false})}).then(d=>{if(!_testUpdates)sessionStorage.setItem('hermes-update-checked','1');if((d.webui&&d.webui.behind>0)||(d.agent&&d.agent.behind>0))_showUpdateBanner(d);}).catch(()=>{});
   }
   // Fetch active profile
   try{const p=await api('/api/profile/active');S.activeProfile=p.name||'default';S.activeProfileIsDefault=!!p.is_default;}catch(e){S.activeProfile='default';S.activeProfileIsDefault=true;}

--- a/static/panels.js
+++ b/static/panels.js
@@ -7571,7 +7571,7 @@ async function checkUpdatesNow(){
   if(label) label.textContent=t('settings_checking');
   if(status) status.textContent='';
   try {
-    const data=await api('/api/updates/check?force=1',{timeoutMs:60000});
+    const data=await api('/api/updates/check',{method:'POST',body:JSON.stringify({force:true}),timeoutMs:60000});
     if(data.disabled){
       if(status){status.textContent=t('settings_updates_disabled');status.style.color='var(--muted)';}
     } else {

--- a/tests/test_api_timeout.py
+++ b/tests/test_api_timeout.py
@@ -211,7 +211,7 @@ def test_update_flows_keep_explicit_longer_timeouts():
     """Legitimately long update flows should not inherit the generic 30s guard."""
     src = _source(UI_JS)
     panels = _source(PANELS_JS)
-    assert "api('/api/updates/check?force=1',{timeoutMs:60000})" in panels
+    assert "api('/api/updates/check',{method:'POST',body:JSON.stringify({force:true}),timeoutMs:60000})" in panels
     assert "api('/api/updates/summary',{method:'POST',body:JSON.stringify({updates:scopedUpdates,target:target||null}),timeoutMs:60000})" in src
     assert "api('/api/updates/apply',{method:'POST',body:JSON.stringify({target}),timeoutMs:120000})" in src
     assert "api('/api/updates/force',{method:'POST',body:JSON.stringify({target}),timeoutMs:120000})" in src

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -597,7 +597,7 @@ class TestMediaEndpointIntegration(unittest.TestCase):
 
     def test_nonexistent_file_returns_404(self):
         _, status, _ = self._get("/api/media?path=/tmp/__hermes_nonexistent_12345.png")
-        self.assertEqual(status, 404)
+        self.assertIn(status, {403, 404})
 
     def test_path_outside_allowed_root_rejected(self):
         # /etc/passwd is outside allowed roots
@@ -621,10 +621,7 @@ class TestMediaEndpointIntegration(unittest.TestCase):
             body, status, headers = self._get(
                 f"/api/media?path={urllib.request.quote(tmp_path)}"
             )
-            self.assertEqual(status, 200, f"Expected 200, got {status}")
-            ct = headers.get("Content-Type", "")
-            self.assertIn("image/png", ct, f"Expected image/png, got {ct}")
-            self.assertEqual(body, png_bytes)
+            self.assertEqual(status, 403, f"bare /tmp media requires a session MEDIA: grant or MEDIA_ALLOWED_ROOTS, got {status}")
         finally:
             pathlib.Path(tmp_path).unlink(missing_ok=True)
 
@@ -639,19 +636,7 @@ class TestMediaEndpointIntegration(unittest.TestCase):
         try:
             encoded = urllib.request.quote(tmp_path)
             body, status, headers = self._get(f"/api/media?path={encoded}&inline=1")
-            self.assertEqual(status, 200)
-            self.assertIn("audio/wav", headers.get("Content-Type", ""))
-            self.assertIn("inline", headers.get("Content-Disposition", ""))
-            self.assertEqual(headers.get("Accept-Ranges"), "bytes")
-            self.assertEqual(body, audio_bytes)
-
-            body, status, headers = self._get(
-                f"/api/media?path={encoded}&inline=1",
-                headers={"Range": "bytes=0-3"},
-            )
-            self.assertEqual(status, 206)
-            self.assertEqual(body, b"RIFF")
-            self.assertEqual(headers.get("Content-Range"), f"bytes 0-3/{len(audio_bytes)}")
+            self.assertEqual(status, 403)
         finally:
             pathlib.Path(tmp_path).unlink(missing_ok=True)
 
@@ -667,24 +652,10 @@ class TestMediaEndpointIntegration(unittest.TestCase):
             encoded = urllib.request.quote(tmp_path)
 
             body, status, headers = self._get(f"/api/media?path={encoded}")
-            self.assertEqual(status, 200)
-            self.assertIn("text/html", headers.get("Content-Type", ""))
-            self.assertIn("attachment", headers.get("Content-Disposition", ""))
-            self.assertIn("DENY", headers.get_all("X-Frame-Options", []))
-            self.assertFalse(
-                any("sandbox allow-scripts" == h for h in headers.get_all("Content-Security-Policy", []))
-            )
-            self.assertEqual(body, html_bytes)
+            self.assertEqual(status, 403)
 
             body, status, headers = self._get(f"/api/media?path={encoded}&inline=1")
-            self.assertEqual(status, 200)
-            self.assertIn("text/html", headers.get("Content-Type", ""))
-            self.assertIn("inline", headers.get("Content-Disposition", ""))
-            self.assertEqual(headers.get_all("X-Frame-Options", []), [])
-            self.assertTrue(
-                any("sandbox allow-scripts" == h for h in headers.get_all("Content-Security-Policy", []))
-            )
-            self.assertEqual(body, html_bytes)
+            self.assertEqual(status, 403)
         finally:
             pathlib.Path(tmp_path).unlink(missing_ok=True)
 
@@ -735,13 +706,10 @@ class TestMediaEndpointIntegration(unittest.TestCase):
             sess_file.unlink(missing_ok=True)
 
     def test_deny_list_does_not_overblock_legitimate_media(self):
-        """#3234 follow-up: the state/secret deny-list must NOT block ordinary
-        media that merely shares a sensitive basename but lives OUTSIDE any
-        Hermes state root (e.g. a user artifact in /tmp named settings.json).
+        """The state/secret deny-list must not be the only /tmp protection.
 
-        The deny is scoped to files under a Hermes root; a /tmp PNG named
-        settings.png — or even settings.json — is the user's own content and
-        must still be served (200), not 403.
+        Bare /tmp paths now require an exact session MEDIA: grant or an explicit
+        MEDIA_ALLOWED_ROOTS opt-in, even if the file name is ordinary media.
         """
         png_bytes = (
             b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01'
@@ -759,11 +727,7 @@ class TestMediaEndpointIntegration(unittest.TestCase):
             body, status, headers = self._get(
                 f"/api/media?path={urllib.request.quote(tmp_path)}"
             )
-            self.assertEqual(
-                status, 200,
-                f"a /tmp PNG outside any Hermes root must serve, got {status}",
-            )
-            self.assertIn("image/png", headers.get("Content-Type", ""))
+            self.assertEqual(status, 403)
         finally:
             pathlib.Path(tmp_path).unlink(missing_ok=True)
 

--- a/tests/test_security_review_fixes.py
+++ b/tests/test_security_review_fixes.py
@@ -1,0 +1,125 @@
+import io
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+from urllib.parse import quote, urlsplit
+
+import pytest
+
+
+class _Headers(dict):
+    def get(self, key, default=None):
+        for k, v in self.items():
+            if k.lower() == key.lower():
+                return v
+        return default
+
+
+class _Handler:
+    def __init__(self, *, client_ip="8.8.8.8", headers=None, body=b"{}"):
+        self.client_address = (client_ip, 12345)
+        self.headers = _Headers(headers or {})
+        self.rfile = io.BytesIO(body)
+        self.wfile = io.BytesIO()
+        self.status = None
+        self.sent_headers = []
+
+    def send_response(self, code):
+        self.status = code
+
+    def send_header(self, key, value):
+        self.sent_headers.append((key, value))
+
+    def end_headers(self):
+        pass
+
+
+def test_onboarding_local_gate_ignores_forwarded_ip_unless_trusted(monkeypatch):
+    from api import routes
+
+    monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", raising=False)
+    handler = _Handler(
+        client_ip="8.8.8.8",
+        headers={"X-Forwarded-For": "127.0.0.1", "X-Real-IP": "10.0.0.2"},
+    )
+
+    assert routes._onboarding_request_is_local(handler) is False
+
+
+def test_onboarding_local_gate_uses_forwarded_ip_when_explicitly_trusted(monkeypatch):
+    from api import routes
+
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    handler = _Handler(
+        client_ip="8.8.8.8",
+        headers={"X-Forwarded-For": "10.0.0.2", "X-Real-IP": "203.0.113.11"},
+    )
+
+    assert routes._onboarding_request_is_local(handler) is True
+
+
+def test_docker_env_log_obfuscates_password_and_secret_names():
+    src = Path("docker_init.bash").read_text(encoding="utf-8")
+    line = next(l for l in src.splitlines() if l.startswith("export ENV_OBFUSCATE_PART="))
+
+    assert "PASSWORD" in line
+    assert "SECRET" in line
+    assert "TOKEN" in line
+    assert "API" in line
+    assert "KEY" in line
+
+
+def test_public_bind_auth_requirement_helper_blocks_passwordless_container(monkeypatch):
+    import server
+
+    monkeypatch.setenv("HERMES_WEBUI_REQUIRE_AUTH_FOR_PUBLIC_BIND", "1")
+    assert server._public_bind_requires_auth("0.0.0.0", within_container=True, auth_enabled=False) is True
+    assert server._public_bind_requires_auth("127.0.0.1", within_container=True, auth_enabled=False) is False
+    assert server._public_bind_requires_auth("0.0.0.0", within_container=True, auth_enabled=True) is False
+
+
+def test_get_update_check_returns_cache_without_fetch(monkeypatch):
+    from api import routes, updates
+
+    monkeypatch.setattr(routes, "load_settings", lambda: {"check_for_updates": True})
+    monkeypatch.setattr(updates, "cached_update_status", lambda include_agent=True: {"checked_at": 123, "webui": None, "agent": None, "include_agent": include_agent})
+    monkeypatch.setattr(updates, "check_for_updates", lambda *a, **k: (_ for _ in ()).throw(AssertionError("GET must not fetch")))
+
+    handler = _Handler(client_ip="127.0.0.1")
+    routes.handle_get(handler, urlsplit("/api/updates/check?force=1"))
+    assert handler.status == 200
+
+
+def test_post_update_check_performs_forced_fetch(monkeypatch):
+    from api import routes
+
+    calls = []
+    monkeypatch.setattr(routes, "load_settings", lambda: {"check_for_updates": True})
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+
+    def fake_check(*, force=False, include_agent=True):
+        calls.append((force, include_agent))
+        return {"checked_at": 456, "webui": None, "agent": None}
+
+    monkeypatch.setattr("api.updates.check_for_updates", fake_check)
+    body = b'{"force": true}'
+    handler = _Handler(client_ip="127.0.0.1", body=body, headers={"Content-Length": str(len(body))})
+    routes.handle_post(handler, SimpleNamespace(path="/api/updates/check", query=""))
+    assert handler.status == 200
+    assert calls == [(True, True)]
+
+
+def test_tmp_media_requires_session_token_or_explicit_extra_root(tmp_path, monkeypatch):
+    from api import routes
+
+    target = tmp_path / "notes.txt"
+    target.write_text("not a chat artifact", encoding="utf-8")
+    monkeypatch.delenv("MEDIA_ALLOWED_ROOTS", raising=False)
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: False)
+    monkeypatch.setattr(routes, "get_last_workspace", lambda: str(tmp_path / "other-workspace"))
+
+    handler = _Handler(client_ip="127.0.0.1")
+    routes._handle_media(handler, SimpleNamespace(path="/api/media", query=f"path={quote(str(target))}"))
+
+    assert handler.status == 403

--- a/tests/test_security_review_fixes.py
+++ b/tests/test_security_review_fixes.py
@@ -59,6 +59,18 @@ def test_onboarding_local_gate_uses_forwarded_ip_when_explicitly_trusted(monkeyp
     assert routes._onboarding_request_is_local(handler) is True
 
 
+def test_onboarding_trusted_forwarded_for_uses_proxy_appended_rightmost_ip(monkeypatch):
+    from api import routes
+
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    handler = _Handler(
+        client_ip="10.0.0.10",
+        headers={"X-Forwarded-For": "127.0.0.1, 8.8.8.8"},
+    )
+
+    assert routes._onboarding_request_is_local(handler) is False
+
+
 def test_docker_env_log_obfuscates_password_and_secret_names():
     src = Path("docker_init.bash").read_text(encoding="utf-8")
     line = next(l for l in src.splitlines() if l.startswith("export ENV_OBFUSCATE_PART="))
@@ -89,6 +101,26 @@ def test_get_update_check_returns_cache_without_fetch(monkeypatch):
     handler = _Handler(client_ip="127.0.0.1")
     routes.handle_get(handler, urlsplit("/api/updates/check?force=1"))
     assert handler.status == 200
+
+
+def test_cached_update_status_does_not_drop_agent_info_when_reenabled(monkeypatch):
+    from api import updates
+
+    cached_agent = {"name": "agent", "behind": 2}
+    monkeypatch.setattr(
+        updates,
+        "_update_cache",
+        {
+            "webui": {"name": "webui", "behind": 0},
+            "agent": cached_agent,
+            "checked_at": 123,
+            "include_agent": False,
+        },
+    )
+
+    result = updates.cached_update_status(include_agent=True)
+
+    assert result["agent"] == cached_agent
 
 
 def test_post_update_check_performs_forced_fetch(monkeypatch):


### PR DESCRIPTION
## Thinking Path
A security review found several high-risk default/path trust issues around first-run onboarding, Docker exposure, update checks, and media file serving. This PR keeps the changes scoped to those reviewed surfaces and adds regression coverage for the new security contracts.

## What Changed
- Ignore `X-Forwarded-For` / `X-Real-IP` for unauthenticated onboarding local-network checks unless `HERMES_WEBUI_TRUST_FORWARDED_FOR=1` is explicitly set.
- Add Docker/public-bind guard: Docker images set `HERMES_WEBUI_REQUIRE_AUTH_FOR_PUBLIC_BIND=1`, and startup refuses non-loopback passwordless binds unless explicitly disabled.
- Expand Docker init log masking to include password/secret/credential/cookie/session-like environment variable names.
- Make `GET /api/updates/check` cache-only and move git/network refreshes to `POST /api/updates/check`.
- Remove all-of-`/tmp` from default `/api/media` allowed roots; temporary files now require session `MEDIA:` grants or explicit `MEDIA_ALLOWED_ROOTS`.
- Update browser callers, tests, and changelog for the changed contracts.

## Why It Matters
- Prevents spoofed forwarded headers from bypassing local-only unauthenticated onboarding gates.
- Prevents the Docker default `0.0.0.0` bind from exposing a passwordless WebUI by default.
- Reduces accidental credential disclosure in init logs.
- Keeps GET update status read-only/cache-only instead of causing `git fetch` side effects.
- Reduces arbitrary local file disclosure risk through broad `/tmp` media reads.

## Verification
- `pytest tests/test_security_review_fixes.py tests/test_update_checker.py tests/test_update_check_ui.py tests/test_api_timeout.py -q`
- `pytest tests/test_media_inline.py tests/test_security_review_fixes.py tests/test_update_checker.py tests/test_update_check_ui.py tests/test_api_timeout.py tests/test_v050260_docker_invariants.py tests/test_issue2453_agent_source_boundary.py -q`
- `python3 -m py_compile api/routes.py api/updates.py server.py`

## Risks / Follow-ups
- Bare `/tmp` media URLs are now denied unless represented by a session media grant or explicit `MEDIA_ALLOWED_ROOTS`. This is intentionally stricter and may require operators with custom scratch directories to configure an explicit allow-list.
- This PR does not attempt the larger supply-chain pinning work for installer scripts, base image digests, actions SHAs, or dependency lockfiles; that should be handled separately to avoid mixing deployment policy changes with runtime security fixes.

## Contract Routing
Task type: security hardening
Touched areas: onboarding gates, Docker startup defaults/logging, update checks, media serving
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `CHANGELOG.md`
Scope boundaries: no UI layout changes, no installer pinning, no full dependency policy rewrite
Evidence needed before claiming done: targeted regression tests plus Python compile checks

## Model Used
AI-assisted: OpenAI gpt-5.5 via Hermes Agent/Codex tool workflow.
