### PR TITLE
fix: project chip context menu inaccessible on mobile (long-press to delete)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4360,6 +4360,41 @@ function renderSessionListFromCache(){
       };
       chip.ondblclick=(e)=>{e.stopPropagation();clearTimeout(_pClickTimer);_pClickTimer=null;_startProjectRename(p,chip);};
       chip.oncontextmenu=(e)=>{e.preventDefault();_showProjectContextMenu(e,p,chip);};
+      // Touch long-press → context menu (mobile UX, #3733)
+      let _lpTimer=null;
+      let _lpHandled=false;
+      let _lpStartX=0,_lpStartY=0;
+      chip.addEventListener('touchstart',(e)=>{
+        const t=e.changedTouches&&e.changedTouches[0];
+        if(!t) return;
+        _lpHandled=false;_lpStartX=t.clientX;_lpStartY=t.clientY;
+        chip.classList.add('long-pressing');
+        _lpTimer=setTimeout(()=>{
+          _lpHandled=true;
+          chip.classList.remove('long-pressing');
+          clearTimeout(_pClickTimer);_pClickTimer=null;
+          const syn={clientX:t.clientX,clientY:t.clientY,preventDefault:()=>{}};
+          _showProjectContextMenu(syn,p,chip);
+        },500);
+      },{passive:true});
+      chip.addEventListener('touchmove',(e)=>{
+        if(!_lpTimer) return;
+        const t=e.changedTouches&&e.changedTouches[0];
+        if(!t) return;
+        if(Math.abs(t.clientX-_lpStartX)>10||Math.abs(t.clientY-_lpStartY)>10){
+          clearTimeout(_lpTimer);_lpTimer=null;
+          chip.classList.remove('long-pressing');
+        }
+      },{passive:true});
+      chip.addEventListener('touchend',(e)=>{
+        clearTimeout(_lpTimer);_lpTimer=null;
+        chip.classList.remove('long-pressing');
+        if(_lpHandled){e.preventDefault();e.stopPropagation();}
+      },{passive:false});
+      chip.addEventListener('touchcancel',()=>{
+        clearTimeout(_lpTimer);_lpTimer=null;_lpHandled=false;
+        chip.classList.remove('long-pressing');
+      },{passive:true});
       bar.appendChild(chip);
     }
     // Create button

--- a/static/style.css
+++ b/static/style.css
@@ -3860,7 +3860,7 @@ main.main > #mainPlugin{display:none;}
 .session-source-tab.active{background:var(--accent-bg);color:var(--accent-text);border-color:var(--accent-bg);}
 .session-empty-note{padding:20px 14px;color:var(--muted);font-size:12px;text-align:center;opacity:.7;}
 .project-bar{display:flex;gap:4px;padding:4px 10px 8px;flex-wrap:wrap;align-items:center;flex-shrink:0;}
-.project-chip{font-size:10px;font-weight:600;padding:3px 8px;border-radius:12px;cursor:pointer;border:1px solid var(--border2);background:var(--input-bg);color:var(--muted);transition:all .15s;white-space:nowrap;display:inline-flex;align-items:center;gap:4px;}
+.project-chip{font-size:10px;font-weight:600;padding:3px 8px;border-radius:12px;cursor:pointer;border:1px solid var(--border2);background:var(--input-bg);color:var(--muted);transition:all .15s;white-space:nowrap;display:inline-flex;align-items:center;gap:4px;-webkit-user-select:none;user-select:none;-webkit-touch-callout:none;touch-action:manipulation;}
 .project-chip:hover{background:rgba(255,255,255,.08);color:var(--text);}
 .project-chip.active{background:var(--accent-bg);color:var(--accent-text);border-color:var(--accent-bg);}
 .project-chip.long-pressing{background:var(--accent-bg);color:var(--accent-text);border-color:var(--accent-bg-strong);transform:scale(1.05);}

--- a/static/style.css
+++ b/static/style.css
@@ -3863,6 +3863,7 @@ main.main > #mainPlugin{display:none;}
 .project-chip{font-size:10px;font-weight:600;padding:3px 8px;border-radius:12px;cursor:pointer;border:1px solid var(--border2);background:var(--input-bg);color:var(--muted);transition:all .15s;white-space:nowrap;display:inline-flex;align-items:center;gap:4px;}
 .project-chip:hover{background:rgba(255,255,255,.08);color:var(--text);}
 .project-chip.active{background:var(--accent-bg);color:var(--accent-text);border-color:var(--accent-bg);}
+.project-chip.long-pressing{background:var(--accent-bg);color:var(--accent-text);border-color:var(--accent-bg-strong);transform:scale(1.05);}
 /* "Unassigned" filter chip — dashed border distinguishes it from real
    project chips so it reads as a meta-filter ("things without a project")
    rather than another project. Keeps full color treatment in the active


### PR DESCRIPTION
## Problem

The project filter chips in the sessions sidebar (e.g. "LeadPilot", "Khl", "Cron Jobs") can only be deleted via right-click context menu — `oncontextmenu` fires `_showProjectContextMenu()` which offers Rename / Color / Delete.

On mobile/touch devices (iPhone Safari, iPad, Android), there is **no right-click**. The chips only respond to:
- Tap → filter by that project
- Double-tap → rename

Users can **add** projects via the "+" button but have **no way to delete** a project from the mobile UI. The project list grows forever.

## Fix

Add touch gesture handlers to each project chip that detect a **500ms long-press**:

- `touchstart` → start 500ms timer + add `.long-pressing` CSS class for visual feedback
- `touchmove` → cancel timer if finger drags >10px (prevents scroll false-triggers)
- `touchend` → cancel timer on short tap (normal filter click proceeds); if long-press was handled, `preventDefault()` + `stopPropagation()` to suppress the following synthetic click
- `touchcancel` → cleanup

When the timer fires, calls `_showProjectContextMenu()` with synthetic mouse coordinates from the touch position, and cancels the pending single-click timer so filtering does not also fire.

Also adds `.project-chip.long-pressing` CSS rule for visual feedback during the hold (accent background + slight scale), matching the `.session-item.long-pressing` pattern already used in session list items.

## Before / After

**Before**: Mobile users can only add projects, can never delete or recolor them.
**After**: Long-press (hold ~0.5s) on any project chip opens the context menu with Rename / Color picker / Delete, same as desktop right-click.

## Verification

- Desktop right-click still works unchanged
- Double-tap rename still works unchanged
- Single tap still filters by that project
- Long-press with finger drag >10px cancels (safe during scroll)
- `node --check static/sessions.js` passes (syntax valid)

Closes #3733