### PR TITLE
Release v0.51.308 — Release JX (#3765 — gate onboarding-complete like its siblings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.308] — 2026-06-07 — Release JX (consistency — gate onboarding-complete like its siblings)
+
+### Changed
+- **`/api/onboarding/complete` now applies the same local-network gate as the other onboarding endpoints, for consistency.** `oauth/start`, `setup`, and `probe` already refused unauthenticated non-local requests; `complete` (which persists `onboarding_completed=true` to hide the first-run wizard) did not, so all four onboarding mutators now behave alike — `complete` returns 403 unless the request is local, auth is enabled, or `HERMES_WEBUI_ONBOARDING_OPEN=1`. This is a consistency tidy, **not** a security boundary: the same flag is still settable via `POST /api/settings` (one of ~25 settings keys broadly writable on a passwordless public bind), and the real protection for a public bind is to run with authentication or refuse the bind. Low impact regardless — the flag only toggles a UI wizard, not credentials or access. (#3765, surfaced by the #3758 release gate)
+
 ## [v0.51.307] — 2026-06-06 — Release JW (stage-a3 — onboarding forwarded-IP spoof fix + update-check CSRF hardening)
 
 ### Security

--- a/api/routes.py
+++ b/api/routes.py
@@ -7830,6 +7830,12 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, str(e), 500)
 
     if parsed.path == "/api/onboarding/complete":
+        # Marking onboarding complete flips the first-run wizard off (persists
+        # onboarding_completed=True). Gate it on the same local-network check as
+        # the other onboarding mutators so an unauthenticated public client on a
+        # passwordless bind can't hide the first-run wizard. (#3765)
+        if not _onboarding_gate_allows(handler):
+            return bad(handler, "Onboarding is only available from local networks when auth is not enabled. To bypass this on a remote server, set HERMES_WEBUI_ONBOARDING_OPEN=1.", 403)
         return j(handler, complete_onboarding())
 
     if parsed.path == "/api/onboarding/probe":

--- a/tests/test_onboarding_network.py
+++ b/tests/test_onboarding_network.py
@@ -30,7 +30,18 @@ from tests._pytest_port import BASE
 # Unit tests — directly test the IP-resolution + guard logic in routes.py
 # without needing a live server. We replicate the logic to keep tests fast
 # and independent of server startup.
-# ---------------------------------------------------------------------------
+#
+# ⚠️ STALE CONTRACT (see #3765): this mirror encodes the PRE-#3758 model where an
+# unauthenticated `X-Forwarded-For` / `X-Real-IP` was trusted to establish
+# locality (`_xff or _xri or raw_ip`). As of #3758 (v0.51.307) the real gate
+# `api.routes._onboarding_request_is_local()` IGNORES forwarded headers unless
+# `HERMES_WEBUI_TRUST_FORWARDED_FOR=1`, and only loopback counts as local when an
+# untrusted forwarded header is present. The authoritative trust-matrix tests now
+# live in `tests/test_security_review_fixes.py`. This mirror + its
+# `TestOnboardingIPLogic` cases are retained only as historical fast-path unit
+# coverage of the IP-parsing shape; DO NOT treat them as the current security
+# contract. (Migrating them to delegate to the real helper is tracked as
+# follow-up test debt, intentionally out of scope for the #3765 hotfix.)
 
 def _is_local_from_handler(
     raw_ip: str,
@@ -40,9 +51,9 @@ def _is_local_from_handler(
     open_env: bool = False,
 ) -> bool | str:
     """
-    Mirror of the onboarding IP check in api/routes.py.
-    Returns True if the request would be allowed, False if blocked,
-    or the error message string if blocked.
+    Mirror of the LEGACY (pre-#3758) onboarding IP check. See the stale-contract
+    note above — the live gate no longer trusts forwarded headers by default.
+    Returns True if the request would be allowed, False if blocked.
     """
     import ipaddress
 

--- a/tests/test_security_review_fixes.py
+++ b/tests/test_security_review_fixes.py
@@ -176,3 +176,48 @@ def test_onboarding_direct_loopback_without_forwarded_headers_is_local(monkeypat
 
     handler_public = _Handler(client_ip="8.8.8.8", headers={})
     assert routes._onboarding_request_is_local(handler_public) is False
+
+
+def test_onboarding_complete_is_gated_against_public_clients(monkeypatch):
+    """POST /api/onboarding/complete flips the first-run wizard off
+    (onboarding_completed=True). On a passwordless bind it must be gated on the
+    same local-network check as setup/oauth/probe, so an unauthenticated public
+    client can't hide the wizard. (#3765 — sibling-path gap left by #3758.)
+    """
+    from api import routes
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setenv("HERMES_WEBUI_ONBOARDING_OPEN", "")
+    monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", raising=False)
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: False)
+
+    called = {"n": 0}
+    def fake_complete():
+        called["n"] += 1
+        return {"completed": True}
+    monkeypatch.setattr(routes, "complete_onboarding", fake_complete)
+
+    # Public client (no forwarded headers) → 403, complete_onboarding NOT called
+    pub = _Handler(client_ip="8.8.8.8", body=b"{}", headers={"Content-Length": "2"})
+    routes.handle_post(pub, SimpleNamespace(path="/api/onboarding/complete", query=""))
+    assert pub.status == 403
+    assert called["n"] == 0
+
+    # Genuine loopback client → allowed
+    loop = _Handler(client_ip="127.0.0.1", body=b"{}", headers={"Content-Length": "2"})
+    routes.handle_post(loop, SimpleNamespace(path="/api/onboarding/complete", query=""))
+    assert loop.status == 200
+    assert called["n"] == 1
+
+
+def test_onboarding_complete_allowed_when_auth_enabled(monkeypatch):
+    """With auth configured, onboarding endpoints are reachable normally."""
+    from api import routes
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: True)
+    monkeypatch.setattr(routes, "complete_onboarding", lambda: {"completed": True})
+
+    h = _Handler(client_ip="8.8.8.8", body=b"{}", headers={"Content-Length": "2"})
+    routes.handle_post(h, SimpleNamespace(path="/api/onboarding/complete", query=""))
+    assert h.status == 200


### PR DESCRIPTION
## Release v0.51.308 — Release JX (#3765)

Gate `/api/onboarding/complete` on the same local-network check as its sibling onboarding endpoints, for **consistency** — surfaced by the #3758 release gate (a delayed Codex verdict caught it as the one ungated onboarding mutator).

### Changed
- `/api/onboarding/complete` now applies `_onboarding_gate_allows()` (→ 403 unless local, auth-enabled, or `HERMES_WEBUI_ONBOARDING_OPEN=1`), matching `oauth/start`, `setup`, and `probe`. The flag it sets (`onboarding_completed`, which hides the first-run wizard) is the least-sensitive of the onboarding mutators.

### Framing — this is a consistency tidy, NOT a security boundary
Codex confirmed (and I verified empirically) that the same flag is still settable via `POST /api/settings {"onboarding_completed":true}` — it's 1 of ~25 settings keys broadly writable by an unauthenticated client on a **passwordless public bind**. Gating only this one flag in `/api/settings` would be whack-a-mole; the real protection for a public bind is to run with auth or refuse the bind (the `HERMES_WEBUI_REQUIRE_AUTH_FOR_PUBLIC_BIND` slice held back from #3758). So this PR is shipped honestly as "all four onboarding mutators behave alike," and stands as another argument for landing the held bind-gate. Worst case of the gap regardless: a hidden first-run wizard.

### Tests
- `tests/test_security_review_fixes.py`: public client (no forwarded headers) → 403 + `complete_onboarding` NOT called; loopback → 200; auth-enabled → 200. Verified failing without the gate.
- Annotated the legacy `_is_local_from_handler` mirror in `test_onboarding_network.py` as a stale pre-#3758 contract (points to the authoritative trust-matrix tests); full migration tracked as out-of-scope test debt.

### Gates
- Full suite: **8161 passed**, 0 failed
- Codex: identified the gap (this PR closes the flagged endpoint; the `/api/settings` path is documented above as out-of-scope-by-design, not a regression)
- Opus: **SAFE TO SHIP** (gate mirrors siblings, legit local/auth/ONBOARDING_OPEN flows unaffected)
- Ruff: CLEAN · Revert-guard: origin/master is ancestor

Follow-up noted: `oauth/cancel` is the only remaining ungated onboarding endpoint (a no-op without a gated `oauth/start` flow_id) — minor consistency tidy for later.

Addresses #3765.