### PR TITLE
Release v0.51.309 — Release JY (#3763 — replay restored live tool cards on reconnect, fixes #3707)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.309] — 2026-06-07 — Release JY (stage-a5b — restore reconnect replays live tool cards)
+
+### Fixed
+- **Switching back to a long-running session during reconnect no longer drops the live tool cards.** After the #3401 live-to-final redesign (epic #3400), when a running session was restored from its in-memory live-turn snapshot and then reattached to the SSE stream, the restore-success path skipped replaying persisted live tool calls — so you'd return to restored live text and thinking but an empty Worklog until a later SSE event or the final render rebuilt the turn. The persisted tool-card replay now also runs on the restore-success + reconnect path (not only the fallback path). To avoid double-painting, an unkeyed persisted tool is skipped when the restored snapshot already shows tool rows, `appendLiveToolCard()` dedupes across all known tool-id aliases (`tid`/`id`/`tool_call_id`/`tool_use_id`/`call_id`), and both replay sites pass the session/stream ownership guard so a switched-away session can't repaint stale tools. (#3763 fixes #3707, @franksong2702)
+
 ## [v0.51.308] — 2026-06-07 — Release JX (consistency — gate onboarding-complete like its siblings)
 
 ### Changed

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -961,9 +961,24 @@ async function loadSession(sid){
     // replaying persisted live tools so the compact Activity count survives
     // switching away from and back to an active chat (#1715).
     S.activeStreamId=activeStreamId;
+    const liveToolReplayId=(tc)=>String(tc&&(tc.tid||tc.id||tc.tool_call_id||tc.tool_use_id||tc.call_id||'')||'').trim();
+    const replayPersistedLiveToolCards=(opts)=>{
+      const liveToolCalls=Array.isArray(S.toolCalls)
+        ? S.toolCalls
+        : (Array.isArray(INFLIGHT[sid]&&INFLIGHT[sid].toolCalls)?INFLIGHT[sid].toolCalls:[]);
+      const skipUnkeyedRestoredDuplicates=!!(opts&&opts.skipUnkeyedRestoredDuplicates);
+      const restoredLiveTurn=skipUnkeyedRestoredDuplicates?document.getElementById('liveAssistantTurn'):null;
+      const hasRestoredLiveToolRows=!!(restoredLiveTurn&&restoredLiveTurn.querySelector('.tool-card-row'));
+      for(const tc of (liveToolCalls||[])){
+        if(skipUnkeyedRestoredDuplicates&&hasRestoredLiveToolRows&&!liveToolReplayId(tc)) continue;
+        if(tc&&tc.name) appendLiveToolCard(tc,{sessionId:sid,streamId:activeStreamId});
+      }
+    };
+    let didReconnect=false;
     if(INFLIGHT[sid].reattach&&activeStreamId&&typeof attachLiveStream==='function'){
       INFLIGHT[sid].reattach=false;
       if (_loadingSessionId !== sid) return;
+      didReconnect=true;
       attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
     }
     syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
@@ -992,14 +1007,15 @@ async function loadSession(sid){
         else restoredLiveTurn=restoreLiveTurnHtmlForSession(sid);
       }
     }
+    if(restoredLiveTurn&&didReconnect){
+      replayPersistedLiveToolCards({skipUnkeyedRestoredDuplicates:true});
+    }
     if(!restoredLiveTurn){
       clearLiveToolCards();
       if(typeof placeLiveToolCardsHost==='function') placeLiveToolCardsHost();
       if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
       else appendThinking();
-      for(const tc of (S.toolCalls||[])){
-        if(tc&&tc.name) appendLiveToolCard(tc);
-      }
+      replayPersistedLiveToolCards();
     }
     if(typeof ensureLiveWorklogShell==='function'){
       const liveTurn=document.getElementById('liveAssistantTurn');

--- a/static/ui.js
+++ b/static/ui.js
@@ -9219,7 +9219,7 @@ function appendLiveToolCard(tc){
   }
   const inner=_assistantTurnBlocks(turn);
   if(!inner) return;
-  const tid=tc.tid||'';
+  const tid=tc.tid||tc.id||tc.tool_call_id||tc.tool_use_id||tc.call_id||'';
   const children=Array.from(inner.children);
   const burstId=tc.activityBurstId!==undefined&&tc.activityBurstId!==null&&String(tc.activityBurstId)!=='0'?String(tc.activityBurstId):'';
   const segmentSeq=tc.activitySegmentSeq!==undefined&&tc.activitySegmentSeq!==null&&String(tc.activitySegmentSeq)!=='0'?String(tc.activitySegmentSeq):'';

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -869,7 +869,7 @@ def test_load_session_restores_worklog_shell_before_reattach_replay():
     clear_pos = fallback_block.find("clearLiveToolCards();")
     shell_pos = fallback_block.find("ensureLiveWorklogShell()")
     legacy_pos = fallback_block.find("else appendThinking();")
-    replay_pos = fallback_block.find("appendLiveToolCard(tc);")
+    replay_pos = fallback_block.find("replayPersistedLiveToolCards();")
     invariant_pos = fallback_block.find("!liveTurn||!liveTurn.querySelector")
     assert clear_pos != -1, "fallback must clear stale live tool DOM first"
     assert shell_pos != -1, "fallback must restore a quiet live Worklog shell"
@@ -878,6 +878,57 @@ def test_load_session_restores_worklog_shell_before_reattach_replay():
     assert invariant_pos != -1, "reattach must enforce a Worklog shell even after an empty restored snapshot"
     assert clear_pos < shell_pos < replay_pos
     assert replay_pos < invariant_pos
+
+
+def test_restore_succeeded_reconnect_replays_tool_cards():
+    """When reconnect replay succeeds in restoring the live turn HTML, tool cards
+    are still repainted from the persisted live-call list instead of waiting for a
+    future SSE event to reintroduce them."""
+    body = _function_body(SESSIONS_JS, "loadSession")
+    replay_fn = body.find("const replayPersistedLiveToolCards=(opts)=>{")
+    reattach_pos = body.find("if(INFLIGHT[sid].reattach&&activeStreamId&&typeof attachLiveStream==='function')")
+    restore_pos = body.find("if(typeof restoreLiveTurnHtmlForSession==='function'){", reattach_pos if reattach_pos != -1 else 0)
+    fallback_pos = body.find("if(!restoredLiveTurn){", restore_pos)
+    restore_replay_pos = body.find("if(restoredLiveTurn&&didReconnect){", restore_pos)
+    restore_replay_block = body[restore_replay_pos:fallback_pos]
+    helper_replay_call = restore_replay_block.find("replayPersistedLiveToolCards({skipUnkeyedRestoredDuplicates:true});")
+    assert reattach_pos != -1, "loadSession must keep the reconnect reattach branch"
+    assert replay_fn != -1, "loadSession should extract live tool replay into a helper"
+    assert restore_pos != -1, "loadSession must still execute restoreLiveTurnHtmlForSession"
+    assert reattach_pos > replay_fn, "live-tool replay helper must be defined before reattach branch"
+    assert restore_pos > reattach_pos, "restore/fallback branch should be after reattach handling in INFLIGHT flow"
+    assert restore_replay_pos != -1, "restored live turns must explicitly replay tools on reconnect"
+    assert helper_replay_call != -1, "replay helper must be executed so reconnect can repopulate tool cards"
+    assert replay_fn < restore_replay_pos < fallback_pos, "restore+reconnect replay should run before fallback"
+    assert restore_replay_block.strip().startswith("if(restoredLiveTurn&&didReconnect){")
+    assert (
+        "if(restoredLiveTurn&&didReconnect){"
+        "replayPersistedLiveToolCards({skipUnkeyedRestoredDuplicates:true});"
+        "}"
+    ) in re.sub(r"\s+", "", restore_replay_block)
+
+
+def test_restore_succeeded_reconnect_skips_unkeyed_restored_tool_duplicates():
+    """Restored snapshots can already contain legacy tool rows without live tids.
+
+    Replaying an unkeyed persisted tool over that restored DOM would append a
+    duplicate, so the restore-success reconnect path should only replay unkeyed
+    tools when the restored turn has no visible tool rows to preserve.
+    """
+    body = _function_body(SESSIONS_JS, "loadSession")
+    replay_fn = body.find("const replayPersistedLiveToolCards=(opts)=>{")
+    restore_replay_pos = body.find("if(restoredLiveTurn&&didReconnect){")
+    fallback_pos = body.find("if(!restoredLiveTurn){", restore_replay_pos)
+    assert replay_fn != -1, "loadSession should keep replay options on the helper"
+    assert "const liveToolReplayId=(tc)=>" in body
+    assert "tc.tid||tc.id||tc.tool_call_id||tc.tool_use_id||tc.call_id" in body
+    helper_block = body[replay_fn:restore_replay_pos]
+    assert "skipUnkeyedRestoredDuplicates" in helper_block
+    assert "restoredLiveTurn.querySelector('.tool-card-row')" in helper_block
+    assert "hasRestoredLiveToolRows&&!liveToolReplayId(tc)" in helper_block
+    restore_block = body[restore_replay_pos:fallback_pos]
+    assert "replayPersistedLiveToolCards({skipUnkeyedRestoredDuplicates:true});" in restore_block
+    assert "replayPersistedLiveToolCards();" in body[fallback_pos:body.find("loadDir('.')", fallback_pos)]
 
 
 def test_merge_inflight_tail_preserves_all_segmented_live_progress():

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -760,12 +760,12 @@ def test_loadSession_inflight_sets_active_stream_before_replaying_live_tool_card
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
     inflight_block = src[inflight_idx:inflight_idx+4200]
     active_pos = inflight_block.find("S.activeStreamId=activeStreamId;")
-    replay_pos = inflight_block.find("appendLiveToolCard(tc);")
+    replay_pos = inflight_block.find("const replayPersistedLiveToolCards=(opts)=>{")
     attach_pos = inflight_block.find("attachLiveStream(sid, activeStreamId")
     assert active_pos >= 0, "loadSession INFLIGHT branch must restore S.activeStreamId"
     assert replay_pos >= 0, "loadSession INFLIGHT branch must replay persisted live tool cards"
     assert active_pos < replay_pos, \
-        "S.activeStreamId must be restored before appendLiveToolCard() replays persisted tools"
+        "S.activeStreamId must be restored before replaying persisted tools"
     assert attach_pos < 0 or active_pos < attach_pos, \
         "S.activeStreamId should also be restored before SSE reattach can deliver more tool events"
 

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -260,6 +260,9 @@ class TestToolCallGroupingStatic:
         assert "data-live-tid" in live_fn, (
             "Live grouping must preserve data-live-tid so tool_start/tool_complete updates still replace the correct card."
         )
+        assert "tc.tid||tc.id||tc.tool_call_id||tc.tool_use_id||tc.call_id" in live_fn, (
+            "Live replay should replace restored cards for all known tool id aliases, not only tc.tid."
+        )
 
     def test_activity_disclosure_state_is_session_and_turn_scoped(self):
         helper = _function_body(UI_JS, "ensureActivityGroup")


### PR DESCRIPTION
## Release v0.51.309 — Release JY (#3763, fixes #3707)

Part of the #3400 live-to-final epic — the correct post-#3401 fix for #3707 (proper successor to the closed #3724, whose pre-refactor mechanism no longer existed). Re-gated fresh on current master after the author settled.

### Fixed
- **#3763** (@franksong2702) — switching back to a long-running session during reconnect no longer drops the live tool cards. The restore-success + reconnect path now replays persisted live tool calls (was: only the `!restoredLiveTurn` fallback), so the Worklog isn't empty until a later SSE event. Dedup is handled two ways: `skipUnkeyedRestoredDuplicates` skips an unkeyed persisted tool when the restored snapshot already shows tool rows, and `appendLiveToolCard()` + the new `liveToolReplayId()` both key on the full 5-alias set (`tid`/`id`/`tool_call_id`/`tool_use_id`/`call_id`) so keyed cards replace-by-`data-live-tid` instead of duplicating. Both replay sites pass the session/stream ownership guard.

### Gates (re-gated fresh on master after v0.51.302→308 shipped under it)
- Full suite: **8163 passed**, 0 failed
- Codex: **SAFE TO SHIP** — verified restored rows keep `data-live-tid` through the `outerHTML` restore so keyed replay replaces rather than duplicates
- Opus: **SAFE TO SHIP** — confirmed keyed-replace, skip-unkeyed safety, fallback preserved, ordering+ownership intact (one transient self-healing edge noted: a memory-only snapshot straddling this deploy under the old 4-alias keying, resolves on next state save)
- ESLint runtime + scope-undef + ruff + browser-smoke: CLEAN
- Revert-guard: origin/master is ancestor

Closes #3763, fixes #3707.