### PR TITLE
[security] harden workspace Git config execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Security
+- **Workspace Git operations now run with hardened Git config and non-interactive authentication defaults.** WebUI ignores repository-local executable Git config such as `core.fsmonitor`, `core.askPass`, `credential.helper`, and `protocol.ext.allow=always`, removes inherited askpass/SSH command environment overrides, and sets `GIT_TERMINAL_PROMPT=0` so private HTTPS remotes fail fast instead of blocking on a prompt. Private HTTPS remotes that rely on a stored credential helper should use an SSH remote or another externally authenticated transport from WebUI.
+
 ## [v0.51.310] — 2026-06-07 — Release JZ (stage-3760 — long-press project chips to delete on touch)
 
 ### Fixed

--- a/api/workspace_git.py
+++ b/api/workspace_git.py
@@ -33,6 +33,8 @@ _GIT_ENV_SCRUB_KEYS = (
     "GIT_CONFIG_SYSTEM",
     "GIT_CONFIG_COUNT",
     "GIT_CONFIG_PARAMETERS",
+    "GIT_ASKPASS",
+    "SSH_ASKPASS",
     "GIT_SSH",
     "GIT_SSH_COMMAND",
 )
@@ -44,6 +46,7 @@ _GIT_HARDENED_CONFIG = (
     # from turning read/status/fetch calls into host command execution.
     ("core.fsmonitor", "false"),
     ("core.sshCommand", "ssh"),
+    ("core.askPass", ""),
     ("credential.helper", ""),
     ("protocol.ext.allow", "never"),
 )

--- a/api/workspace_git.py
+++ b/api/workspace_git.py
@@ -33,9 +33,27 @@ _GIT_ENV_SCRUB_KEYS = (
     "GIT_CONFIG_SYSTEM",
     "GIT_CONFIG_COUNT",
     "GIT_CONFIG_PARAMETERS",
+    "GIT_SSH",
+    "GIT_SSH_COMMAND",
 )
 _GIT_ENV_SCRUB_PREFIXES = ("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")
 _HERMES_BRANCH_SWITCH_STASH_PREFIX = "hermes-webui branch switch"
+_GIT_HARDENED_CONFIG = (
+    # Workspace Git operations can run against repositories provided by agents,
+    # restored sessions, or mounted workspaces. Keep repo-local configuration
+    # from turning read/status/fetch calls into host command execution.
+    ("core.fsmonitor", "false"),
+    ("core.sshCommand", "ssh"),
+    ("protocol.ext.allow", "never"),
+)
+
+
+def _hardened_git_argv(args: list[str]) -> list[str]:
+    argv = ["git"]
+    for key, value in _GIT_HARDENED_CONFIG:
+        argv.extend(["-c", f"{key}={value}"])
+    argv.extend(args)
+    return argv
 
 
 def workspace_git_destructive_enabled() -> bool:
@@ -140,7 +158,7 @@ def _run_git(
     run_env = _clean_git_env(env)
     try:
         result = subprocess.run(
-            ["git", *args],
+            _hardened_git_argv(args),
             cwd=str(cwd),
             shell=False,
             capture_output=True,
@@ -1047,12 +1065,12 @@ def _selected_temp_index_env(ctx: GitContext, specs: list[str]) -> tuple[dict[st
 def _selected_files(ctx: GitContext, paths: Iterable[str]) -> tuple[list[str], list[str], list[dict]]:
     requested = _clean_paths(paths)
     requested_specs = [_repo_rel(ctx, path) for path in requested]
-    workspace_paths = [_workspace_rel(ctx, spec) or path for spec, path in zip(requested_specs, requested)]
+    workspace_paths = [_workspace_rel(ctx, spec) or path for spec, path in zip(requested_specs, requested, strict=True)]
     status = git_status(ctx.workspace)
     by_path = {f["path"]: f for f in status.get("files", [])}
     specs: list[str] = []
     selected = []
-    for path, repo_rel in zip(workspace_paths, requested_specs):
+    for path, repo_rel in zip(workspace_paths, requested_specs, strict=True):
         state = by_path.get(path)
         if not state:
             continue

--- a/api/workspace_git.py
+++ b/api/workspace_git.py
@@ -44,6 +44,7 @@ _GIT_HARDENED_CONFIG = (
     # from turning read/status/fetch calls into host command execution.
     ("core.fsmonitor", "false"),
     ("core.sshCommand", "ssh"),
+    ("credential.helper", ""),
     ("protocol.ext.allow", "never"),
 )
 

--- a/api/workspace_git.py
+++ b/api/workspace_git.py
@@ -78,6 +78,7 @@ def _clean_git_env(extra: dict[str, str] | None = None) -> dict[str, str]:
     for key in list(env):
         if key.startswith(_GIT_ENV_SCRUB_PREFIXES):
             env.pop(key, None)
+    env["GIT_TERMINAL_PROMPT"] = "0"
     return env
 
 

--- a/docs/workspace-git.md
+++ b/docs/workspace-git.md
@@ -61,8 +61,11 @@ second timeout. Remote operations such as fetch, pull, and push use a 60 second 
 
 Before any Git subprocess starts, WebUI removes inherited `GIT_DIR`, `GIT_WORK_TREE`,
 `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM`, `GIT_CONFIG_COUNT`, `GIT_CONFIG_PARAMETERS`, and injected
-`GIT_CONFIG_KEY_*` / `GIT_CONFIG_VALUE_*` values from the environment. Those variables can redirect
-Git to a different repository or inject config, so WebUI does not trust them from the parent process.
+`GIT_CONFIG_KEY_*` / `GIT_CONFIG_VALUE_*` values from the environment. It also removes inherited
+`GIT_ASKPASS`, `SSH_ASKPASS`, `GIT_SSH`, and `GIT_SSH_COMMAND` values, then sets
+`GIT_TERMINAL_PROMPT=0` so remote authentication failures fail fast instead of blocking on an
+interactive prompt. Those variables can redirect Git to a different repository, inject config, or run
+helper commands, so WebUI does not trust them from the parent process.
 
 `GIT_INDEX_FILE` is the intentional exception. Selected-file commits use a temporary index so WebUI
 can commit only the requested files, then remove the temporary index afterward.
@@ -90,3 +93,7 @@ from general Git failures.
 If a hook fails, the API returns a structured Git error instead of hiding the failure. Other classified
 failures include authentication errors, missing upstream branches, conflicts, dirty worktrees, invalid
 refs, missing Git binaries, and timeouts.
+
+Repository-local credential helpers and askpass commands are disabled for workspace Git operations.
+Private HTTPS remotes that depend on a stored credential helper may fail to fetch, pull, or push from
+WebUI; use an SSH remote or another externally authenticated transport for those workflows.

--- a/tests/test_workspace_git.py
+++ b/tests/test_workspace_git.py
@@ -1012,6 +1012,57 @@ def test_git_fetch_blocks_repo_local_credential_helper_execution(tmp_path):
     assert not marker.exists()
 
 
+def test_git_fetch_blocks_repo_local_askpass_execution(tmp_path):
+    import os
+    import sys
+
+    if os.name == "nt":
+        pytest.skip("executable askpass helper setup is POSIX-only")
+
+    from api.workspace_git import GitWorkspaceError, git_fetch
+
+    class AuthRequiredHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="hermes-test"')
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            del format, args
+
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "tracked.txt").write_text("one\n", encoding="utf-8")
+    _commit_all(repo)
+    marker = tmp_path / "askpass-ran"
+    helper = tmp_path / "askpass_helper.py"
+    helper.write_text(
+        "#!/usr/bin/env python3\n"
+        "import pathlib, sys\n"
+        "pathlib.Path(sys.argv[1]).write_text('askpass executed', encoding='utf-8')\n"
+        "print('pw')\n",
+        encoding="utf-8",
+    )
+    helper.chmod(0o755)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), AuthRequiredHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/repo.git"
+        _git(repo, "remote", "add", "origin", url)
+        _git(repo, "config", "core.askPass", f"{sys.executable} {helper} {marker}")
+
+        with pytest.raises(GitWorkspaceError) as exc:
+            git_fetch(repo)
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert exc.value.code == "auth_failed"
+    assert not marker.exists()
+
+
 def test_git_env_scrub_removes_redirecting_vars_and_preserves_temp_index(monkeypatch):
     from api.workspace_git import _clean_git_env
 
@@ -1023,6 +1074,8 @@ def test_git_env_scrub_removes_redirecting_vars_and_preserves_temp_index(monkeyp
     monkeypatch.setenv("GIT_CONFIG_KEY_0", "core.sshCommand")
     monkeypatch.setenv("GIT_CONFIG_VALUE_0", "ssh -i /tmp/evil-key")
     monkeypatch.setenv("GIT_CONFIG_PARAMETERS", "'core.sshCommand=ssh -i /tmp/evil-key'")
+    monkeypatch.setenv("GIT_ASKPASS", "/tmp/evil-askpass")
+    monkeypatch.setenv("SSH_ASKPASS", "/tmp/evil-ssh-askpass")
     monkeypatch.setenv("GIT_SSH", "/tmp/evil-ssh")
     monkeypatch.setenv("GIT_SSH_COMMAND", "ssh -i /tmp/evil-key")
 
@@ -1036,6 +1089,8 @@ def test_git_env_scrub_removes_redirecting_vars_and_preserves_temp_index(monkeyp
     assert "GIT_CONFIG_KEY_0" not in env
     assert "GIT_CONFIG_VALUE_0" not in env
     assert "GIT_CONFIG_PARAMETERS" not in env
+    assert "GIT_ASKPASS" not in env
+    assert "SSH_ASKPASS" not in env
     assert "GIT_SSH" not in env
     assert "GIT_SSH_COMMAND" not in env
     assert env["GIT_INDEX_FILE"] == "/tmp/hermes-index"

--- a/tests/test_workspace_git.py
+++ b/tests/test_workspace_git.py
@@ -1078,6 +1078,7 @@ def test_git_env_scrub_removes_redirecting_vars_and_preserves_temp_index(monkeyp
     monkeypatch.setenv("SSH_ASKPASS", "/tmp/evil-ssh-askpass")
     monkeypatch.setenv("GIT_SSH", "/tmp/evil-ssh")
     monkeypatch.setenv("GIT_SSH_COMMAND", "ssh -i /tmp/evil-key")
+    monkeypatch.setenv("GIT_TERMINAL_PROMPT", "1")
 
     env = _clean_git_env({"GIT_INDEX_FILE": "/tmp/hermes-index"})
 
@@ -1093,6 +1094,7 @@ def test_git_env_scrub_removes_redirecting_vars_and_preserves_temp_index(monkeyp
     assert "SSH_ASKPASS" not in env
     assert "GIT_SSH" not in env
     assert "GIT_SSH_COMMAND" not in env
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
     assert env["GIT_INDEX_FILE"] == "/tmp/hermes-index"
 
 

--- a/tests/test_workspace_git.py
+++ b/tests/test_workspace_git.py
@@ -1,11 +1,13 @@
 import json
 import pathlib
 import subprocess
+import threading
 import types
 import uuid
 import urllib.error
 import urllib.parse
 import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from io import BytesIO
 
 import pytest
@@ -957,6 +959,56 @@ def test_git_fetch_blocks_repo_local_ext_transport_execution(tmp_path):
         git_fetch(repo)
 
     assert exc.value.code == "git_failed"
+    assert not marker.exists()
+
+
+def test_git_fetch_blocks_repo_local_credential_helper_execution(tmp_path):
+    import os
+    import sys
+
+    if os.name == "nt":
+        pytest.skip("executable credential helper setup is POSIX-only")
+
+    from api.workspace_git import GitWorkspaceError, git_fetch
+
+    class AuthRequiredHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="hermes-test"')
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            del format, args
+
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "tracked.txt").write_text("one\n", encoding="utf-8")
+    _commit_all(repo)
+    marker = tmp_path / "credential-helper-ran"
+    helper = tmp_path / "credential_helper.py"
+    helper.write_text(
+        "#!/usr/bin/env python3\n"
+        "import pathlib, sys\n"
+        "pathlib.Path(sys.argv[1]).write_text('credential helper executed', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    helper.chmod(0o755)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), AuthRequiredHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/repo.git"
+        _git(repo, "remote", "add", "origin", url)
+        _git(repo, "config", "credential.helper", f"!{sys.executable} {helper} {marker}")
+
+        with pytest.raises(GitWorkspaceError) as exc:
+            git_fetch(repo)
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert exc.value.code == "auth_failed"
     assert not marker.exists()
 
 

--- a/tests/test_workspace_git.py
+++ b/tests/test_workspace_git.py
@@ -898,6 +898,68 @@ def test_git_discard_untracked_delete_uses_anchored_unlink_after_validation_race
     assert victim.read_text(encoding="utf-8") == "outside victim\n"
 
 
+def test_git_status_ignores_repo_local_fsmonitor_command(tmp_path):
+    import os
+    import sys
+
+    if os.name == "nt":
+        pytest.skip("executable fsmonitor helper setup is POSIX-only")
+
+    from api.workspace_git import git_status
+
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "tracked.txt").write_text("one\n", encoding="utf-8")
+    _commit_all(repo)
+    marker = tmp_path / "fsmonitor-ran"
+    helper = tmp_path / "fsmonitor_helper.py"
+    helper.write_text(
+        "#!/usr/bin/env python3\n"
+        "import pathlib, sys\n"
+        "pathlib.Path(sys.argv[1]).write_text('fsmonitor executed', encoding='utf-8')\n"
+        "print('')\n",
+        encoding="utf-8",
+    )
+    helper.chmod(0o755)
+    _git(repo, "config", "core.fsmonitor", f"{sys.executable} {helper} {marker}")
+
+    status = git_status(repo)
+
+    assert status["is_git"] is True
+    assert not marker.exists()
+
+
+def test_git_fetch_blocks_repo_local_ext_transport_execution(tmp_path):
+    import os
+    import sys
+
+    if os.name == "nt":
+        pytest.skip("ext transport helper setup is POSIX-only")
+
+    from api.workspace_git import GitWorkspaceError, git_fetch
+
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "tracked.txt").write_text("one\n", encoding="utf-8")
+    _commit_all(repo)
+    marker = tmp_path / "ext-transport-ran"
+    helper = tmp_path / "ext_helper.py"
+    helper.write_text(
+        "#!/usr/bin/env python3\n"
+        "import pathlib, sys\n"
+        "pathlib.Path(sys.argv[1]).write_text('ext executed: ' + ' '.join(sys.argv[2:]), encoding='utf-8')\n"
+        "sys.exit(1)\n",
+        encoding="utf-8",
+    )
+    helper.chmod(0o755)
+    _git(repo, "config", "protocol.ext.allow", "always")
+    _git(repo, "remote", "add", "origin", f"ext::{sys.executable} {helper} {marker} %S foo")
+
+    with pytest.raises(GitWorkspaceError) as exc:
+        git_fetch(repo)
+
+    assert exc.value.code == "git_failed"
+    assert not marker.exists()
+
+
 def test_git_env_scrub_removes_redirecting_vars_and_preserves_temp_index(monkeypatch):
     from api.workspace_git import _clean_git_env
 
@@ -909,6 +971,8 @@ def test_git_env_scrub_removes_redirecting_vars_and_preserves_temp_index(monkeyp
     monkeypatch.setenv("GIT_CONFIG_KEY_0", "core.sshCommand")
     monkeypatch.setenv("GIT_CONFIG_VALUE_0", "ssh -i /tmp/evil-key")
     monkeypatch.setenv("GIT_CONFIG_PARAMETERS", "'core.sshCommand=ssh -i /tmp/evil-key'")
+    monkeypatch.setenv("GIT_SSH", "/tmp/evil-ssh")
+    monkeypatch.setenv("GIT_SSH_COMMAND", "ssh -i /tmp/evil-key")
 
     env = _clean_git_env({"GIT_INDEX_FILE": "/tmp/hermes-index"})
 
@@ -920,6 +984,8 @@ def test_git_env_scrub_removes_redirecting_vars_and_preserves_temp_index(monkeyp
     assert "GIT_CONFIG_KEY_0" not in env
     assert "GIT_CONFIG_VALUE_0" not in env
     assert "GIT_CONFIG_PARAMETERS" not in env
+    assert "GIT_SSH" not in env
+    assert "GIT_SSH_COMMAND" not in env
     assert env["GIT_INDEX_FILE"] == "/tmp/hermes-index"
 
 


### PR DESCRIPTION
## Summary
This PR hardens workspace Git operations so a repository's local Git configuration cannot turn WebUI status/fetch calls into host command execution.

- Blocks a validated read-only `git status` issue where repo-local `core.fsmonitor` executed an arbitrary helper during workspace status refresh.
- Blocks a validated default-enabled `git fetch --prune` issue where repo-local transport/SSH/authentication configuration could execute an arbitrary helper from `.git/config`.
- Adds regression tests that set malicious repo-local config and assert the helper marker is not created.
- Sets `GIT_TERMINAL_PROMPT=0` so disabled credential helpers fail fast instead of hanging on an interactive prompt.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Read-only workspace Git status honors repo-local `core.fsmonitor` | A malicious/restored workspace repository can execute a local helper when the UI/API asks for status, even though the operation is presented as read-only. | High |
| Default-enabled workspace Git fetch honors repo-local executable transport/auth config | A malicious/restored workspace repository can execute a local helper when `/api/git/fetch` invokes `git fetch --prune`, without requiring destructive workspace Git mode. | High |

## Before this PR
- `_run_git()` scrubbed selected inherited Git environment variables but still invoked `git` in a way that honored repo-local executable config.
- `git_status()` could execute `core.fsmonitor` from `.git/config` during a read-only status refresh.
- `git_fetch()` could execute repo-local fetch-related config such as an enabled `ext::` transport helper, `core.sshCommand`, `core.askPass`, or `credential.helper`.
- Regression coverage checked environment scrubbing, but not repo-local Git configuration that Git itself loads after process startup.

## After this PR
- All workspace Git subprocesses are invoked with hardened command-line config:
  - `core.fsmonitor=false`
  - `core.sshCommand=ssh`
  - `core.askPass=`
  - `credential.helper=`
  - `protocol.ext.allow=never`
- Inherited `GIT_ASKPASS`, `SSH_ASKPASS`, `GIT_SSH`, and `GIT_SSH_COMMAND` are scrubbed alongside the existing Git config environment variables.
- `GIT_TERMINAL_PROMPT=0` is forced for workspace Git subprocesses so HTTPS auth failures fail fast rather than waiting for a terminal prompt.
- New tests cover validated executable config classes:
  - status ignores a malicious repo-local `core.fsmonitor` helper
  - fetch refuses a repo-local `ext::` transport helper even when the repo config enables it
  - fetch ignores repo-local `credential.helper` and `core.askPass` helpers
  - environment hardening preserves `GIT_INDEX_FILE` while forcing `GIT_TERMINAL_PROMPT=0`

## Why this matters
```text
attacker-controlled or restored workspace repository
    -> workspace Git status/fetch API path
        -> Git loads repo-local .git/config
            -> executable Git config runs a helper command
                -> host command execution in the WebUI process environment
```

The affected calls are especially sensitive because status is read-only and fetch is allowed without `HERMES_WEBUI_WORKSPACE_GIT_DESTRUCTIVE=1`, so operators may not expect them to execute repository-provided helpers.

## Affected code

| Issue | Files |
|-------|-------|
| Repo-local Git config execution from status/fetch | `api/workspace_git.py` |
| Regression coverage | `tests/test_workspace_git.py` |
| Behavior documentation and changelog note | `docs/workspace-git.md`, `CHANGELOG.md` |

## Root cause
Issue 1: read-only Git status executes `core.fsmonitor`
- `git status` honors `core.fsmonitor` from repo-local Git config.
- The workspace Git wrapper did not override that config before running status-oriented commands.

Issue 2: default-enabled Git fetch executes repo-local transport/auth config
- `git fetch --prune` honors remote URL/protocol and authentication helper configuration stored in repo-local Git config.
- `/api/git/fetch` is intentionally not gated as destructive, but the underlying Git invocation still allowed executable transport/authentication configuration.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Read-only status / `core.fsmonitor` execution | 8.0 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:N` |
| Default-enabled fetch / executable transport/auth config | 8.0 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:N` |

Rationale: the attacker must already be able to influence the workspace repository or restored session state, but once that condition is met, a read/status/fetch action can execute code in the WebUI host context. Scope is changed because repository content/config crosses into host process execution.

## Safe reproduction steps
### 1. Read-only `core.fsmonitor` execution
1. Create a workspace repository with a repo-local `core.fsmonitor` command that writes a marker file.
2. Call the workspace Git status helper/API.
3. Vulnerable behavior: the marker file is created during a read-only status operation.
4. Patched behavior: status completes and the marker file is not created.

### 2. Fetch transport helper execution
1. Create a workspace repository with `protocol.ext.allow=always` and an `origin` URL using an `ext::` helper that writes a marker file.
2. Call the workspace Git fetch helper/API.
3. Vulnerable behavior: Git invokes the helper and creates the marker file.
4. Patched behavior: fetch fails as a Git error and the marker file is not created.

### 3. Fetch authentication helper execution
1. Create a workspace repository with an HTTPS remote that returns 401 and repo-local `credential.helper` or `core.askPass` pointing to a marker-writing helper.
2. Call the workspace Git fetch helper/API.
3. Vulnerable behavior: Git may invoke the helper during authentication.
4. Patched behavior: fetch fails as an auth error, no helper marker is created, and Git cannot block on a terminal prompt.

## Changes in this PR
- Adds `_GIT_HARDENED_CONFIG` and `_hardened_git_argv()` so workspace Git commands consistently pass safe command-line config to Git.
- Overrides repo-local `core.fsmonitor`, `core.sshCommand`, `core.askPass`, `credential.helper`, and `protocol.ext.allow` for workspace Git subprocesses.
- Scrubs inherited `GIT_ASKPASS`, `SSH_ASKPASS`, `GIT_SSH`, and `GIT_SSH_COMMAND` from the Git subprocess environment.
- Forces `GIT_TERMINAL_PROMPT=0` for workspace Git subprocesses.
- Adds regression tests for repo-local config execution paths and environment hardening.
- Documents the HTTPS credential-helper behavior change in `docs/workspace-git.md` and `CHANGELOG.md`.
- Adds `strict=True` to nearby `zip()` calls so the touched file passes the existing ruff gate.

## Maintainer impact
- Patch scope is limited to workspace Git subprocess invocation, workspace Git docs/changelog, and tests.
- Frontend, sessions, model providers, uploads, and unrelated API routes are untouched.
- SSH fetches use the normal `ssh` binary instead of allowing repo-local `core.sshCommand` overrides; `SSH_AUTH_SOCK` is not scrubbed, so ssh-agent based remotes continue to work.
- `ext::` transports, repo-local askpass commands, and repo-local credential helpers remain blocked for workspace Git operations, which is the safe default for untrusted/restored workspaces.
- Private HTTPS remotes that rely on a stored credential helper may need to use an SSH remote or another externally authenticated transport from WebUI.

## Fix rationale
- Command-line `git -c` config has higher precedence than repo-local config, making it a narrow and durable place to enforce this boundary.
- Keeping the hardening inside `_run_git()` protects all workspace Git callers consistently, including future status/diff/fetch wrappers.
- Forcing `GIT_TERMINAL_PROMPT=0` prevents auth failures from holding the remote-operation lock until timeout.
- The regression tests assert the important security property directly: malicious helper marker files are not created.

## Type of change
- [x] Security fix
- [x] Tests
- [x] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] `python -m pytest tests/test_workspace_git.py -q`
- [x] `python -m ruff check api/workspace_git.py tests/test_workspace_git.py`
- [ ] Full project test suite was not run; this PR changes only workspace Git subprocess hardening/docs and the targeted workspace Git test module was run.

## Disclosure notes
- No production systems were tested.
- The reproduction payloads use local marker files only; no secrets or external targets are required.
- No unrelated application areas were changed.
