### PR TITLE
Fix sidebar visibility for stale compression snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **The sidebar no longer hides fuller pre-compression snapshots when `_index.json` is stale.** Snapshot rows now refresh their sidecar metadata before lineage visibility chooses between an archived parent and its continuation, so conversations whose parent sidecar received later transcript rows do not appear to lose messages after compaction.
+
 ## [v0.51.310] — 2026-06-07 — Release JZ (stage-3760 — long-press project chips to delete on touch)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -2550,13 +2550,19 @@ def _prefer_fuller_snapshots_for_sidebar(sessions: list[dict]) -> list[dict]:
 
         newest_visible_ts = max(_session_sort_timestamp(session) for session in visible)
         snapshot_ts = _session_sort_timestamp(best_snapshot)
-        # Keep the active continuation visible when it has newer activity than
-        # the archived snapshot. A fuller snapshot can still be older than a
-        # continuation that contains the latest turns after compression.
+        snapshot_id = str(best_snapshot.get('session_id') or '')
+        if not snapshot_id:
+            continue
+
+        snapshot_ids_to_show.add(snapshot_id)
+        # If the continuation is newer, keep it visible too. That means the
+        # lineage is split-brain-ish: the snapshot has more transcript rows, but
+        # the continuation may still contain the newest post-compression turn.
+        # Showing both is less tidy than hiding one, but it preserves every
+        # reachable message. Tidy and wrong is how users start doubting reality.
         if newest_visible_ts > snapshot_ts:
             continue
 
-        snapshot_ids_to_show.add(str(best_snapshot.get('session_id')))
         continuation_ids_to_hide.update(
             str(session.get('session_id'))
             for session in visible
@@ -2583,28 +2589,88 @@ def _strip_sidebar_internal_flags(sessions: list[dict]) -> None:
         session.pop('_show_pre_compression_snapshot', None)
 
 
-def _row_may_need_sidecar_metadata_refresh(session: dict) -> bool:
+def _row_may_need_sidecar_metadata_refresh(
+    session: dict,
+    *,
+    stale_snapshot_ids: set[str] | None = None,
+) -> bool:
     """Return True when a row needs canonical sidecar runtime/snapshot metadata.
 
     Compression lineage fields are enriched from state.db in one batched query
     later in all_sessions(). Loading hundreds of lineage sidecars on every
     /api/sessions poll turns the sidebar into molasses, so keep this refresh
-    limited to the few rows whose transient runtime or snapshot state is not
-    cheaply available from state.db.
+    limited to rows with transient runtime state, missing snapshot sidebar
+    metadata, or a stale snapshot candidate that can affect the visibility
+    decision for its lineage.
     """
     is_runtime_row = bool(
         session.get('active_stream_id')
         or session.get('has_pending_user_message')
         or session.get('pending_user_message')
     )
-    snapshot_missing_sidebar_metadata = bool(
-        session.get('pre_compression_snapshot')
-        and (
-            session.get('message_count') is None
-            or session.get('last_message_at') is None
-        )
-    )
-    return is_runtime_row or snapshot_missing_sidebar_metadata
+    if is_runtime_row:
+        return True
+    if not session.get('pre_compression_snapshot'):
+        return False
+    if session.get('message_count') is None or session.get('last_message_at') is None:
+        return True
+    sid = str(session.get('session_id') or '')
+    return bool(sid and stale_snapshot_ids and sid in stale_snapshot_ids)
+
+
+def _sidecar_mtime_after_index_timestamp(session: dict) -> bool:
+    sid = str(session.get('session_id') or '')
+    if not sid or not is_safe_session_id(sid):
+        return False
+    try:
+        sidecar_mtime = (SESSION_DIR / f'{sid}.json').stat().st_mtime
+    except OSError:
+        return False
+    indexed_ts = _session_sort_timestamp(session)
+    return sidecar_mtime > indexed_ts + 0.001
+
+
+def _stale_snapshot_metadata_refresh_ids(sessions: list[dict]) -> set[str]:
+    """Return pre-compression snapshots worth a sidecar metadata refresh.
+
+    Most snapshot rows can be decided from the index: either their indexed count
+    already beats the visible continuation, or they are normal older snapshots
+    that should remain hidden. Only stat candidate sidecars when a hidden
+    snapshot has a visible continuation in the same lineage and its indexed
+    metadata would otherwise fail to expose it.
+    """
+    sessions_by_id = {
+        str(session.get('session_id')): session
+        for session in sessions
+        if session.get('session_id')
+    }
+    groups: dict[str, list[dict]] = {}
+    for session in sessions:
+        sid = str(session.get('session_id') or '')
+        source = session.get('source_tag') or session.get('source')
+        if source == 'cron' or sid.startswith('cron_'):
+            continue
+        root = _sidebar_lineage_root_id(session, sessions_by_id)
+        groups.setdefault(root, []).append(session)
+
+    refresh_ids: set[str] = set()
+    for group in groups.values():
+        visible = [session for session in group if not session.get('pre_compression_snapshot')]
+        snapshots = [session for session in group if session.get('pre_compression_snapshot')]
+        if not visible or not snapshots:
+            continue
+        if any(_has_live_sidebar_state(session) for session in visible):
+            continue
+        best_visible_count = max(_sidebar_message_count(session) for session in visible)
+        for snapshot in snapshots:
+            sid = str(snapshot.get('session_id') or '')
+            if not sid:
+                continue
+            if _sidebar_message_count(snapshot) > best_visible_count:
+                continue
+            if _sidecar_mtime_after_index_timestamp(snapshot):
+                refresh_ids.add(sid)
+    return refresh_ids
 
 
 def _refresh_index_rows_from_sidecar_metadata(sessions: list[dict]) -> list[dict]:
@@ -2616,8 +2682,12 @@ def _refresh_index_rows_from_sidecar_metadata(sessions: list[dict]) -> list[dict
     historical transcript.
     """
     out: list[dict] = []
+    stale_snapshot_ids = _stale_snapshot_metadata_refresh_ids(sessions)
     for session in sessions:
-        if not _row_may_need_sidecar_metadata_refresh(session):
+        if not _row_may_need_sidecar_metadata_refresh(
+            session,
+            stale_snapshot_ids=stale_snapshot_ids,
+        ):
             out.append(session)
             continue
         sid = session.get('session_id')

--- a/api/routes.py
+++ b/api/routes.py
@@ -2866,16 +2866,57 @@ def _message_window_for_display(messages, msg_limit=None, msg_before=None) -> tu
     return window, start_idx
 
 
+def _webui_sidecar_lineage_messages_for_display(session, *, max_hops: int = 20) -> list:
+    """Return WebUI sidecar messages stitched across compression snapshots.
+
+    WebUI compression continuations persist the archived transcript in a parent
+    sidecar marked ``pre_compression_snapshot`` and keep subsequent turns in the
+    child sidecar. Opening the child alone makes older turns look lost. Stitch
+    only those snapshot parents for display; ordinary forks also carry
+    ``parent_session_id`` but must remain independent conversations.
+    """
+    segments = []
+    current = session
+    seen = {str(getattr(session, "session_id", "") or "")}
+    for _ in range(max(0, int(max_hops))):
+        parent_id = str(getattr(current, "parent_session_id", "") or "").strip()
+        if not parent_id or parent_id in seen or not is_safe_session_id(parent_id):
+            break
+        parent = Session.load(parent_id)
+        if not parent or not getattr(parent, "pre_compression_snapshot", False):
+            break
+        segments.append(parent)
+        seen.add(parent_id)
+        current = parent
+
+    if not segments:
+        return list(getattr(session, "messages", []) or [])
+
+    merged = []
+    for segment in reversed(segments):
+        merged = merge_session_messages_append_only(
+            merged,
+            getattr(segment, "messages", []) or [],
+            truncation_watermark=getattr(segment, "truncation_watermark", None),
+        )
+    return merge_session_messages_append_only(
+        merged,
+        getattr(session, "messages", []) or [],
+        truncation_watermark=getattr(session, "truncation_watermark", None),
+    )
+
+
 def _merged_session_messages_for_display(session, cli_messages=None) -> list:
     """Return the message coordinate space exposed by ``GET /api/session``.
 
     Messaging sessions can have a WebUI sidecar transcript plus messages from
-    the Agent/CLI store. The frontend computes fork keep-counts against this
-    merged display list, so branch/fork must slice the same list rather than
-    the sidecar-only ``session.messages`` array.
+    the Agent/CLI store. WebUI compression continuations can have an archived
+    snapshot parent plus a child continuation sidecar. The frontend computes
+    fork keep-counts against this merged display list, so branch/fork must slice
+    the same list rather than the sidecar-only ``session.messages`` array.
     """
     cli_messages = list(cli_messages or [])
-    sidecar_messages = list(getattr(session, "messages", []) or [])
+    sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)
     if cli_messages:
         if sidecar_messages and sidecar_messages != cli_messages:
             if len(sidecar_messages) >= len(cli_messages):
@@ -5358,7 +5399,7 @@ def handle_get(handler, parsed) -> bool:
                     _all_msgs = _merged_session_messages_for_display(s, cli_messages)
                 else:
                     _all_msgs = merge_session_messages_append_only(
-                        s.messages,
+                        _webui_sidecar_lineage_messages_for_display(s),
                         state_db_messages,
                         truncation_watermark=getattr(s, "truncation_watermark", None),
                     )

--- a/tests/test_session_import_cli_fallback_model.py
+++ b/tests/test_session_import_cli_fallback_model.py
@@ -396,5 +396,5 @@ def test_messaging_session_loader_prefers_longer_sidecar_transcript():
     assert old not in handler
     assert "_all_msgs = _merged_session_messages_for_display(s, cli_messages)" in handler
     src = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
-    assert "sidecar_messages = list(getattr(session, \"messages\", []) or [])" in src
+    assert "sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)" in src
     assert "len(sidecar_messages) > len(cli_messages)" in src

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -477,12 +477,189 @@ def test_fuller_pre_compression_snapshot_replaces_shorter_visible_segment(monkey
     assert rows[0]["pre_compression_snapshot"] is True
 
 
-def test_newer_continuation_beats_older_fuller_snapshot(monkeypatch):
-    """Do not hide a newer continuation behind an older fuller snapshot.
+def test_stale_index_fuller_pre_compression_snapshot_uses_sidecar_metadata(monkeypatch):
+    """A stale index must not hide the fuller pre-compression sidecar.
+
+    Compression can leave _index.json with the snapshot's old count/timestamp
+    while the sidecar later contains more transcript rows than the visible
+    continuation. all_sessions() must refresh snapshot metadata before deciding
+    whether to hide it, or the sidebar makes messages look lost.
+    """
+    snapshot = Session(
+        session_id="stale_full_parent",
+        title="Long Conversation",
+        messages=[
+            {"role": "user", "content": "first", "timestamp": 100.0},
+            {"role": "assistant", "content": "second", "timestamp": 101.0},
+            {"role": "user", "content": "latest user", "timestamp": 300.0},
+            {"role": "assistant", "content": "latest answer", "timestamp": 301.0},
+        ],
+        pre_compression_snapshot=True,
+        parent_session_id="root_sid",
+        updated_at=301.0,
+    )
+    continuation = Session(
+        session_id="stale_short_child",
+        title="Long Conversation",
+        messages=[
+            {"role": "user", "content": "first", "timestamp": 100.0},
+            {"role": "assistant", "content": "second", "timestamp": 101.0},
+        ],
+        parent_session_id="stale_full_parent",
+        updated_at=250.0,
+    )
+    snapshot.save(touch_updated_at=False)
+    continuation.save(touch_updated_at=False)
+    _write_index_file(
+        models.SESSION_INDEX_FILE,
+        [
+            {
+                "session_id": "stale_full_parent",
+                "title": "Long Conversation",
+                "message_count": 2,
+                "created_at": 100.0,
+                "updated_at": 200.0,
+                "last_message_at": 200.0,
+                "pinned": False,
+                "archived": False,
+                "pre_compression_snapshot": True,
+                "parent_session_id": "root_sid",
+            },
+            {
+                "session_id": "stale_short_child",
+                "title": "Long Conversation",
+                "message_count": 2,
+                "created_at": 250.0,
+                "updated_at": 250.0,
+                "last_message_at": 250.0,
+                "pinned": False,
+                "archived": False,
+                "parent_session_id": "stale_full_parent",
+            },
+        ],
+    )
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    rows = models.all_sessions()
+
+    assert [row["session_id"] for row in rows] == ["stale_full_parent"]
+    assert rows[0]["message_count"] == 4
+    assert rows[0]["last_message_at"] == 301.0
+    assert rows[0]["pre_compression_snapshot"] is True
+
+
+def test_indexed_fuller_pre_compression_snapshot_does_not_refresh_sidecar(monkeypatch):
+    """A truthful index row must not read the snapshot sidecar on every poll."""
+    snapshot = Session(
+        session_id="indexed_full_parent",
+        title="Long Conversation",
+        messages=[
+            {"role": "user", "content": "first", "timestamp": 100.0},
+            {"role": "assistant", "content": "second", "timestamp": 101.0},
+            {"role": "user", "content": "latest user", "timestamp": 300.0},
+            {"role": "assistant", "content": "latest answer", "timestamp": 301.0},
+        ],
+        pre_compression_snapshot=True,
+        parent_session_id="root_sid",
+        updated_at=301.0,
+    )
+    continuation = Session(
+        session_id="indexed_short_child",
+        title="Long Conversation",
+        messages=[
+            {"role": "user", "content": "first", "timestamp": 100.0},
+            {"role": "assistant", "content": "second", "timestamp": 101.0},
+        ],
+        parent_session_id="indexed_full_parent",
+        updated_at=250.0,
+    )
+    snapshot.save(touch_updated_at=False)
+    continuation.save(touch_updated_at=False)
+    _write_index_file(
+        models.SESSION_INDEX_FILE,
+        [
+            {
+                "session_id": "indexed_full_parent",
+                "title": "Long Conversation",
+                "message_count": 4,
+                "created_at": 100.0,
+                "updated_at": 301.0,
+                "last_message_at": 301.0,
+                "pinned": False,
+                "archived": False,
+                "pre_compression_snapshot": True,
+                "parent_session_id": "root_sid",
+            },
+            {
+                "session_id": "indexed_short_child",
+                "title": "Long Conversation",
+                "message_count": 2,
+                "created_at": 250.0,
+                "updated_at": 250.0,
+                "last_message_at": 250.0,
+                "pinned": False,
+                "archived": False,
+                "parent_session_id": "indexed_full_parent",
+            },
+        ],
+    )
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    with patch.object(Session, "load_metadata_only", side_effect=AssertionError("truthful snapshot index should not refresh sidecar")):
+        rows = models.all_sessions()
+
+    assert [row["session_id"] for row in rows] == ["indexed_full_parent"]
+    assert rows[0]["message_count"] == 4
+
+
+def test_orphan_pre_compression_snapshot_does_not_refresh_sidecar(monkeypatch):
+    """Snapshot refresh stays scoped to lineages with a visible continuation."""
+    _write_index_file(
+        models.SESSION_INDEX_FILE,
+        [
+            {
+                "session_id": "orphan_snapshot",
+                "title": "Archived Segment",
+                "message_count": 3,
+                "created_at": 100.0,
+                "updated_at": 100.0,
+                "last_message_at": 100.0,
+                "pinned": False,
+                "archived": False,
+                "pre_compression_snapshot": True,
+                "parent_session_id": "root_sid",
+            },
+        ],
+    )
+    (models.SESSION_DIR / "orphan_snapshot.json").write_text(
+        json.dumps(
+            {
+                "session_id": "orphan_snapshot",
+                "title": "Archived Segment",
+                "messages": [{"role": "user", "content": "sidecar"}],
+                "message_count": 99,
+                "updated_at": 999.0,
+                "pre_compression_snapshot": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    with patch.object(Session, "load_metadata_only", side_effect=AssertionError("orphan snapshots must not refresh sidecars")):
+        rows = models.all_sessions()
+
+    assert [row["session_id"] for row in rows] == ["orphan_snapshot"]
+    assert rows[0]["message_count"] == 3
+
+
+def test_newer_continuation_stays_visible_alongside_older_fuller_snapshot(monkeypatch):
+    """Do not hide either side when recency and completeness disagree.
 
     Compression snapshots can have a higher message count while still being
     older than the continuation that contains the latest user-visible turns.
-    The sidebar should keep the newer continuation visible in that case.
+    The sidebar should keep the newer continuation visible and also expose the
+    fuller snapshot so neither side of a split lineage looks lost.
     """
     snapshot = Session(
         session_id="older_full_parent",
@@ -514,9 +691,14 @@ def test_newer_continuation_beats_older_fuller_snapshot(monkeypatch):
 
     rows = models.all_sessions()
 
-    assert [row["session_id"] for row in rows] == ["newer_short_child"]
+    assert [row["session_id"] for row in rows] == [
+        "newer_short_child",
+        "older_full_parent",
+    ]
     assert rows[0]["pre_compression_snapshot"] is False
     assert rows[0]["message_count"] == 2
+    assert rows[1]["pre_compression_snapshot"] is True
+    assert rows[1]["message_count"] == 4
 
 
 def test_all_sessions_uses_sidecar_metadata_for_runtime_rows_when_index_message_count_is_stale(monkeypatch):

--- a/tests/test_session_lineage_full_transcript.py
+++ b/tests/test_session_lineage_full_transcript.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from types import SimpleNamespace
 
 import api.models as models
 import api.routes as routes
@@ -184,3 +185,92 @@ def test_cli_continuation_session_opens_nonempty(monkeypatch, tmp_path):
     messages = models.get_cli_session_messages('child-session')
 
     assert [message['content'] for message in messages] == ['parent turn', 'child reply']
+
+
+def test_webui_continuation_session_opens_with_snapshot_parent_messages(monkeypatch):
+    """Opening a WebUI compression child should expose the archived parent transcript."""
+    parent = SimpleNamespace(
+        session_id="parent-webui",
+        parent_session_id=None,
+        pre_compression_snapshot=True,
+        truncation_watermark=None,
+        messages=[
+            {"role": "user", "content": "make the LLM settings table", "timestamp": 1.0},
+            {"role": "assistant", "content": "LLM Settings Table", "timestamp": 2.0},
+        ],
+    )
+    child = SimpleNamespace(
+        session_id="child-webui",
+        parent_session_id="parent-webui",
+        pre_compression_snapshot=False,
+        truncation_watermark=None,
+        messages=[
+            {"role": "user", "content": "continue after compression", "timestamp": 3.0},
+            {"role": "assistant", "content": "child reply", "timestamp": 4.0},
+        ],
+        tool_calls=[],
+        active_stream_id=None,
+        pending_user_message=None,
+        pending_attachments=[],
+        pending_started_at=None,
+        context_length=0,
+        threshold_tokens=0,
+        last_prompt_tokens=0,
+        model="openai/gpt-5",
+        profile="default",
+    )
+    child.compact = lambda: {"session_id": "child-webui", "title": "Child", "model": "openai/gpt-5"}
+
+    captured = {}
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: child)
+    monkeypatch.setattr(routes, "_clear_stale_stream_state", lambda s: None)
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda sid: {})
+    monkeypatch.setattr(routes, "_is_messaging_session_record", lambda s: False)
+    monkeypatch.setattr(routes, "get_state_db_session_messages", lambda sid, profile=None: [])
+    monkeypatch.setattr(routes.Session, "load", lambda sid: parent if sid == "parent-webui" else None)
+    monkeypatch.setattr(routes, "_resolve_effective_session_model_for_display", lambda s: getattr(s, "model", None))
+    monkeypatch.setattr(routes, "_resolve_effective_session_model_provider_for_display", lambda s: None)
+    monkeypatch.setattr(routes, "_merge_cli_sidebar_metadata", lambda raw, meta: raw)
+    monkeypatch.setattr(routes, "redact_session_data", lambda raw: raw)
+    monkeypatch.setattr(routes, "j", lambda handler, payload, status=200: captured.setdefault("payload", payload))
+
+    class Handler:
+        pass
+
+    class Parsed:
+        path = "/api/session"
+        query = "session_id=child-webui"
+
+    routes.handle_get(Handler(), Parsed())
+
+    contents = [m["content"] for m in captured["payload"]["session"]["messages"]]
+    assert contents == [
+        "make the LLM settings table",
+        "LLM Settings Table",
+        "continue after compression",
+        "child reply",
+    ]
+
+
+def test_webui_fork_session_does_not_stitch_non_snapshot_parent(monkeypatch):
+    """A normal fork's parent_session_id is provenance, not a transcript stitch request."""
+    parent = SimpleNamespace(
+        session_id="parent-fork",
+        parent_session_id=None,
+        pre_compression_snapshot=False,
+        truncation_watermark=None,
+        messages=[{"role": "user", "content": "parent should stay separate", "timestamp": 1.0}],
+    )
+    child = SimpleNamespace(
+        session_id="child-fork",
+        parent_session_id="parent-fork",
+        pre_compression_snapshot=False,
+        truncation_watermark=None,
+        messages=[{"role": "user", "content": "fork child only", "timestamp": 2.0}],
+    )
+
+    monkeypatch.setattr(routes.Session, "load", lambda sid: parent if sid == "parent-fork" else None)
+
+    assert [m["content"] for m in routes._webui_sidecar_lineage_messages_for_display(child)] == [
+        "fork child only",
+    ]


### PR DESCRIPTION
## Summary
- Refresh pre-compression snapshot sidecar metadata before sidebar lineage visibility decisions.
- Keep both rows visible when a snapshot is fuller but a continuation is newer, so split lineages do not make messages appear lost.
- Add a regression test for stale `_index.json` hiding the fuller pre-compression sidecar.

## Validation
- `python -m compileall -q api/models.py api/routes.py`
- `python -m pytest -q -o addopts='' tests/test_session_index.py tests/test_webui_state_db_reconciliation.py`
- `python -m pytest -q -o addopts='' tests/test_session_index.py tests/test_webui_state_db_reconciliation.py tests/test_session_lineage_metadata_api.py tests/test_session_lineage_full_transcript.py tests/test_session_lineage_collapse.py tests/test_session_lineage_report.py tests/test_import_cli_session_lineage.py` → 91 passed
