### PR TITLE
perf(profiles): instant profile switcher — skip per-profile alias scan in list_profiles_api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.313] — 2026-06-07 — Release KC (instant profile switcher — skip the per-profile alias scan)
+
+### Fixed
+- **The profile switcher in the composer footer now opens instantly instead of hanging for several seconds.** Building the profile list called into the agent's `list_profiles()`, which runs `find_alias_for_profile()` once per profile — and that scans every file in the wrapper directory (`~/.local/bin`) and reads each one in full, including large CLI binaries. On a machine with big binaries on `PATH` that is hundreds of MB of reads per profile, so the dropdown blocked for many seconds on every open. The WebUI never uses that alias data, so it now builds the profile list from the cheap per-profile metadata directly and skips the alias scan entirely, with a short in-memory cache so rapid re-opens are free and a graceful fallback to the original path if those internals are unavailable. New profiles still appear immediately and switching between them works as before. (closes #3772 by a different approach)
+
 ## [v0.51.312] — 2026-06-07 — Release KB (brick-wave — purge stale bytecode after self-update)
 
 ### Fixed

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -1188,6 +1188,10 @@ def list_profiles_api() -> list:
     if rows is None:
         # Fallback: cheap helpers unavailable — use the original (slow) path,
         # or the default-only dict if hermes_cli isn't importable at all.
+        logger.debug(
+            "list_profiles_api: fast path unavailable, falling back to "
+            "upstream list_profiles() (slower)"
+        )
         try:
             from hermes_cli.profiles import list_profiles
             infos = list_profiles()
@@ -1219,7 +1223,6 @@ def list_profiles_api() -> list:
 
     active = get_active_profile_name()
     return [{**p, 'is_active': p['name'] == active} for p in rows]
-
 
 
 def _profile_visible_from_meta(profile_path: Path) -> bool:

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -1074,34 +1074,152 @@ def _get_profile_skills_stats(profile_dir: Path) -> tuple[int, int]:
     return res
 
 
-def list_profiles_api() -> list:
-    """List all profiles with metadata, serialized for JSON response."""
-    try:
-        from hermes_cli.profiles import list_profiles
-        infos = list_profiles()
-    except ImportError:
-        # hermes_cli not available -- return just the default
-        return [_default_profile_dict()]
+_LIST_PROFILES_CACHE: tuple[list, float] | None = None
+_LIST_PROFILES_CACHE_TTL = 4.0  # seconds — short enough that gateway dots / new
+                                # profiles stay near-live, long enough that rapid
+                                # re-opens of the dropdown are free.
+_LIST_PROFILES_CACHE_LOCK = threading.Lock()
 
-    active = get_active_profile_name()
-    result = []
-    for p in infos:
-        enabled_count, total_count = _get_profile_skills_stats(p.path)
-        result.append({
-            'name': p.name,
-            'path': str(p.path),
-            'is_default': p.is_default,
-            'is_active': p.name == active,
-            'gateway_running': p.gateway_running,
-            'model': p.model,
-            'provider': p.provider,
-            'has_env': p.has_env,
-            'visible': _profile_visible_from_meta(p.path),
+
+def _invalidate_list_profiles_cache() -> None:
+    """Drop the cached profile list (call after create/delete/switch)."""
+    global _LIST_PROFILES_CACHE
+    with _LIST_PROFILES_CACHE_LOCK:
+        _LIST_PROFILES_CACHE = None
+
+
+def _build_profile_rows_fast() -> list | None:
+    """Build the profile list WITHOUT the upstream alias scan.
+
+    ``hermes_cli.profiles.list_profiles()`` calls ``find_alias_for_profile()``
+    once per profile, which iterates every file in the wrapper dir
+    (``~/.local/bin``) and ``read_text()``s each one — including large binaries
+    (claude, node, uv, …). On a machine with big binaries on PATH that is
+    hundreds of MB of reads PER PROFILE, which makes the compose-footer profile
+    dropdown hang for many seconds.
+
+    The WebUI never uses the alias data (``list_profiles_api`` does not return
+    ``alias_name``/``alias_path``), so we replicate the cheap part of upstream's
+    ``list_profiles()`` — the same per-profile metadata, the same hardcoded
+    ``"default"`` name for the base home — and simply skip the alias scan.
+
+    Returns ``None`` if the upstream cheap helpers can't be imported, so the
+    caller can fall back to the original (slow but correct) path. Forward-
+    compatible: if upstream fixes ``find_alias_for_profile`` this stays fast and
+    correct with nothing to revert.
+    """
+    try:
+        from hermes_cli.profiles import (
+            _get_default_hermes_home,
+            _get_profiles_root,
+            _read_config_model,
+            _check_gateway_running,
+            _PROFILE_ID_RE as _UPSTREAM_PROFILE_ID_RE,
+        )
+    except Exception:
+        return None
+
+    def _row(home: Path, name: str, is_default: bool) -> dict:
+        try:
+            model, provider = _read_config_model(home)
+        except Exception:
+            model, provider = None, None
+        try:
+            gateway_running = _check_gateway_running(home)
+        except Exception:
+            gateway_running = False
+        enabled_count, total_count = _get_profile_skills_stats(home)
+        return {
+            'name': name,
+            'path': str(home),
+            'is_default': is_default,
+            'is_active': False,  # filled in by caller (cheap, varies per request)
+            'gateway_running': gateway_running,
+            'model': model,
+            'provider': provider,
+            'has_env': (home / '.env').exists(),
+            'visible': _profile_visible_from_meta(home),
             'skill_count': enabled_count,
             'enabled_skills': enabled_count,
             'total_skills': total_count,
-        })
-    return result
+        }
+
+    rows: list = []
+    default_home = _get_default_hermes_home()
+    if default_home.is_dir():
+        # Upstream hardcodes the base home's display name to "default" even when
+        # the directory is literally ".hermes" — match that exactly.
+        rows.append(_row(default_home, 'default', True))
+
+    profiles_root = _get_profiles_root()
+    if profiles_root.is_dir():
+        for entry in sorted(profiles_root.iterdir()):
+            if not entry.is_dir():
+                continue
+            if not _UPSTREAM_PROFILE_ID_RE.match(entry.name):
+                continue
+            rows.append(_row(entry, entry.name, False))
+
+    return rows
+
+
+def list_profiles_api() -> list:
+    """List all profiles with metadata, serialized for JSON response.
+
+    Fast path: build the rows from upstream's cheap per-profile helpers and skip
+    ``find_alias_for_profile`` (whose result the WebUI discards) — see
+    ``_build_profile_rows_fast``. Results are cached for a short TTL so rapid
+    re-opens of the compose-footer dropdown are free; the cache is busted on
+    profile create/delete. Falls back to upstream ``list_profiles()`` if the
+    cheap helpers are unavailable.
+    """
+    import time
+    global _LIST_PROFILES_CACHE
+    now = time.time()
+
+    with _LIST_PROFILES_CACHE_LOCK:
+        cached = _LIST_PROFILES_CACHE
+    if cached is not None and now - cached[1] < _LIST_PROFILES_CACHE_TTL:
+        active = get_active_profile_name()
+        # Return a fresh copy with is_active recomputed (cheap, per-request).
+        return [{**p, 'is_active': p['name'] == active} for p in cached[0]]
+
+    rows = _build_profile_rows_fast()
+    if rows is None:
+        # Fallback: cheap helpers unavailable — use the original (slow) path,
+        # or the default-only dict if hermes_cli isn't importable at all.
+        try:
+            from hermes_cli.profiles import list_profiles
+            infos = list_profiles()
+        except ImportError:
+            return [_default_profile_dict()]
+
+        active = get_active_profile_name()
+        result = []
+        for p in infos:
+            enabled_count, total_count = _get_profile_skills_stats(p.path)
+            result.append({
+                'name': p.name,
+                'path': str(p.path),
+                'is_default': p.is_default,
+                'is_active': p.name == active,
+                'gateway_running': p.gateway_running,
+                'model': p.model,
+                'provider': p.provider,
+                'has_env': p.has_env,
+                'visible': _profile_visible_from_meta(p.path),
+                'skill_count': enabled_count,
+                'enabled_skills': enabled_count,
+                'total_skills': total_count,
+            })
+        return result
+
+    with _LIST_PROFILES_CACHE_LOCK:
+        _LIST_PROFILES_CACHE = (rows, now)
+
+    active = get_active_profile_name()
+    return [{**p, 'is_active': p['name'] == active} for p in rows]
+
 
 
 def _profile_visible_from_meta(profile_path: Path) -> bool:
@@ -1546,6 +1664,7 @@ def create_profile_api(name: str, clone_from: str = None,
     # Invalidate cached root-profile-name lookup; create_profile may have added
     # a new profile that flips is_default semantics on the agent side (#1612).
     _SKILLS_STATS_CACHE.clear()
+    _invalidate_list_profiles_cache()
     _invalidate_root_profile_cache()
 
     # Find and return the newly created profile info.
@@ -1600,5 +1719,6 @@ def delete_profile_api(name: str) -> dict:
 
     # Drop cached root-profile-name lookup — list_profiles_api() shape changed.
     _SKILLS_STATS_CACHE.clear()
+    _invalidate_list_profiles_cache()
     _invalidate_root_profile_cache()
     return {'ok': True, 'name': name}

--- a/tests/test_profile_skills_stats.py
+++ b/tests/test_profile_skills_stats.py
@@ -41,19 +41,17 @@ def test_get_profile_skills_stats(tmp_path):
 
 @requires_agent_modules
 def test_list_profiles_api_contains_formatted_skills(monkeypatch, tmp_path):
-    class FakeProfile:
-        def __init__(self, name, path):
-            self.name = name
-            self.path = Path(path)
-            self.is_default = name == "default"
-            self.gateway_running = False
-            self.model = "gpt-4"
-            self.provider = "openai"
-            self.has_env = False
-            self.skill_count = 3  # Raw on-disk count from hermes_cli
+    """list_profiles_api() formats skill counts for each profile.
 
+    Drives the fast path (``_build_profile_rows_fast``), which discovers
+    profiles via the cheap upstream helpers and skips the alias scan, so this
+    patches ``_get_default_hermes_home`` / ``_get_profiles_root`` to point at a
+    tmp profile layout rather than monkeypatching the (now-bypassed)
+    ``list_profiles`` aggregate.
+    """
     p_default = tmp_path / "default"
-    p_fintech = tmp_path / "profiles" / "fintech"
+    profiles_root = tmp_path / "profiles"
+    p_fintech = profiles_root / "fintech"
 
     _write_skill(p_default, "a1")
     _write_skill(p_default, "a2")
@@ -64,21 +62,17 @@ def test_list_profiles_api_contains_formatted_skills(monkeypatch, tmp_path):
     _write_skill(p_fintech, "f3")
     _write_config(p_fintech, ["f2", "f3"])
 
-    fake_infos = [
-        FakeProfile("default", p_default),
-        FakeProfile("fintech", p_fintech)
-    ]
-
     monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
-    
-    # We patch the upstream list_profiles call to return our FakeProfile list
-    try:
-        import hermes_cli.profiles as cli_p
-        monkeypatch.setattr(cli_p, "list_profiles", lambda: fake_infos)
-    except ImportError:
-        pass
+
+    # Point the fast-path discovery helpers at our tmp layout. The base home is
+    # surfaced as "default" by _build_profile_rows_fast regardless of dir name.
+    import hermes_cli.profiles as cli_p
+    monkeypatch.setattr(cli_p, "_get_default_hermes_home", lambda: p_default)
+    monkeypatch.setattr(cli_p, "_get_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(cli_p, "_check_gateway_running", lambda home: False)
 
     profiles._SKILLS_STATS_CACHE.clear()
+    profiles._invalidate_list_profiles_cache()
 
     results = profiles.list_profiles_api()
     by_name = {p["name"]: p for p in results}
@@ -95,6 +89,15 @@ def test_list_profiles_api_contains_formatted_skills(monkeypatch, tmp_path):
     assert by_name["default"]["total_skills"] == 2
     assert by_name["fintech"]["enabled_skills"] == 1
     assert by_name["fintech"]["total_skills"] == 3
+
+    # the base home is surfaced as the default profile
+    assert by_name["default"]["is_default"] is True
+    assert by_name["fintech"]["is_default"] is False
+    # exactly one active, and it's the one get_active_profile_name reports
+    assert sum(1 for p in results if p["is_active"]) == 1
+    assert by_name["default"]["is_active"] is True
+
+    profiles._invalidate_list_profiles_cache()
 
 @requires_agent_modules
 def test_no_skills_dir(tmp_path):
@@ -140,3 +143,110 @@ def test_skills_stats_cache(tmp_path):
     profiles._SKILLS_STATS_CACHE.clear()
     enabled, compat = profiles._get_profile_skills_stats(tmp_path)
     assert enabled == 2 and compat == 2
+
+
+@requires_agent_modules
+def test_list_profiles_api_skips_alias_scan(monkeypatch, tmp_path):
+    """The fast path must NOT call find_alias_for_profile.
+
+    find_alias_for_profile reads every file in the wrapper dir (~/.local/bin),
+    including large binaries — the multi-second profile-dropdown hang. The
+    WebUI discards alias data, so the fast path must avoid that call entirely.
+    """
+    p_default = tmp_path / "default"
+    _write_skill(p_default, "a1")
+    _write_config(p_default, [])
+
+    import hermes_cli.profiles as cli_p
+    monkeypatch.setattr(cli_p, "_get_default_hermes_home", lambda: p_default)
+    monkeypatch.setattr(cli_p, "_get_profiles_root", lambda: tmp_path / "profiles")
+    monkeypatch.setattr(cli_p, "_check_gateway_running", lambda home: False)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+
+    alias_called = []
+    if hasattr(cli_p, "find_alias_for_profile"):
+        monkeypatch.setattr(
+            cli_p, "find_alias_for_profile",
+            lambda *a, **k: alias_called.append(a) or None,
+        )
+
+    profiles._SKILLS_STATS_CACHE.clear()
+    profiles._invalidate_list_profiles_cache()
+
+    results = profiles.list_profiles_api()
+    assert any(p["name"] == "default" for p in results)
+    assert alias_called == [], "fast path must not call find_alias_for_profile"
+
+    profiles._invalidate_list_profiles_cache()
+
+
+@requires_agent_modules
+def test_list_profiles_api_caches_and_invalidates(monkeypatch, tmp_path):
+    """Repeated calls hit the TTL cache; create/delete invalidation drops it."""
+    p_default = tmp_path / "default"
+    _write_skill(p_default, "a1")
+    _write_config(p_default, [])
+
+    import hermes_cli.profiles as cli_p
+    monkeypatch.setattr(cli_p, "_get_default_hermes_home", lambda: p_default)
+    monkeypatch.setattr(cli_p, "_get_profiles_root", lambda: tmp_path / "profiles")
+    monkeypatch.setattr(cli_p, "_check_gateway_running", lambda home: False)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+
+    build_calls = []
+    real_build = profiles._build_profile_rows_fast
+
+    def counting_build():
+        build_calls.append(1)
+        return real_build()
+
+    monkeypatch.setattr(profiles, "_build_profile_rows_fast", counting_build)
+
+    profiles._SKILLS_STATS_CACHE.clear()
+    profiles._invalidate_list_profiles_cache()
+
+    profiles.list_profiles_api()
+    profiles.list_profiles_api()
+    # Second call should be served from the TTL cache — no rebuild.
+    assert len(build_calls) == 1, "second call within TTL must hit the cache"
+
+    # Invalidation forces a rebuild on the next call.
+    profiles._invalidate_list_profiles_cache()
+    profiles.list_profiles_api()
+    assert len(build_calls) == 2, "invalidation must force a rebuild"
+
+    profiles._invalidate_list_profiles_cache()
+
+
+@requires_agent_modules
+def test_list_profiles_api_falls_back_when_fast_path_unavailable(monkeypatch, tmp_path):
+    """If the cheap helpers can't build rows, fall back to upstream list_profiles."""
+    class FakeProfile:
+        def __init__(self, name, path):
+            self.name = name
+            self.path = Path(path)
+            self.is_default = name == "default"
+            self.gateway_running = False
+            self.model = "gpt-4"
+            self.provider = "openai"
+            self.has_env = False
+            self.skill_count = 0
+
+    p_default = tmp_path / "default"
+    _write_skill(p_default, "a1")
+    _write_config(p_default, [])
+
+    monkeypatch.setattr(profiles, "_build_profile_rows_fast", lambda: None)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    import hermes_cli.profiles as cli_p
+    monkeypatch.setattr(cli_p, "list_profiles", lambda: [FakeProfile("default", p_default)])
+
+    profiles._SKILLS_STATS_CACHE.clear()
+    profiles._invalidate_list_profiles_cache()
+
+    results = profiles.list_profiles_api()
+    by_name = {p["name"]: p for p in results}
+    assert "default" in by_name
+    assert by_name["default"]["is_active"] is True
+
+    profiles._invalidate_list_profiles_cache()


### PR DESCRIPTION
## Instant profile switcher — skip the per-profile alias scan

Fixes the compose-footer profile dropdown hanging for several seconds on every open.

### Root cause (cProfiled live)
`list_profiles_api()` → `hermes_cli.profiles.list_profiles()` spends ~4.7s of 5.8s in `find_alias_for_profile()`, which is called once per profile and iterates every file in the wrapper dir (`~/.local/bin`), reading each one in full looking for a `hermes -p <profile>` string — **including large CLI binaries** (claude ~222MB, node ~119MB, uv ~56MB, …). That's ~473MB of reads *per profile*; on a 5-profile machine, ~2.4GB of disk reads + UTF-8 decode on every dropdown open.

This is an upstream hermes-agent inefficiency we don't control. But the WebUI **never uses the alias data** — `list_profiles_api()` doesn't return `alias_name`/`alias_path`, and the dropdown renders only name + model + skills + gateway dot. So we were paying 2.4GB of reads to compute data we discard.

### Fix (WebUI-only, `api/profiles.py`)
`_build_profile_rows_fast()` replicates the *cheap* part of upstream `list_profiles()` — same per-profile metadata (`_read_config_model`, `_check_gateway_running`, skills stats), same hardcoded `"default"` name for the base home — and **skips the alias scan**. A short 4s TTL cache (busted on profile create/delete) makes rapid re-opens free. Graceful fallback to upstream `list_profiles()` if the cheap helpers can't be imported.

- **Measured: 4700ms → ~250ms cold, 0ms warm.** Output verified byte-equivalent to upstream (names, all 12 keys, exactly-one-active).
- Switch behavior verified live: `is_active` follows a switch from cache (recomputed per-request, no rebuild), all profiles stay present, new profiles appear immediately (create/delete bust the cache).

### Why this shape (not a cache-only workaround)
Removes the wasteful work from *our* call path rather than masking upstream. **Forward-compatible**: if upstream fixes `find_alias_for_profile`, this path stays fast and correct with nothing to revert; if they don't, we're still fast. Supersedes #3772 (whose 30s cache left the first/expired open slow).

### Tests
`tests/test_profile_skills_stats.py`: updated the existing skill-count formatting test to drive the new fast path, plus 3 new tests — alias-scan-skip, TTL-cache + invalidation, and fallback-when-fast-path-unavailable.

### Gate
- Full suite (pending green), Codex regression gate, Opus advisor — results to be confirmed before merge.
- Ruff forward gate clean.