### PR TITLE
Release v0.51.319 — Release KI (Phase 3 light: refresh stale continuation metadata, #3789)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.319] — 2026-06-07 — Release KI (Phase 3 light — refresh stale continuation metadata)
+
+### Fixed
+- **A compression continuation no longer looks like it lost recent messages when `_index.json` is stale.** Complementing the snapshot-side fix, the sidebar now also refreshes a continuation row's sidecar metadata when the row is part of a compression lineage and its sidecar file is newer than the indexed timestamp — so recent turns that landed in the sidecar after the last index write are reflected in the row's count/last-activity instead of showing a stale (lower) message count. The refresh stays scoped to lineage-shaped rows, so ordinary sidebar polls don't hydrate every historical transcript. (#3789, refs #3740, @ai-ag2026)
+
 ## [v0.51.318] — 2026-06-07 — Release KH (Phase 3 light — warm account-usage probe worker pool)
 
 ### Changed

--- a/api/models.py
+++ b/api/models.py
@@ -2610,11 +2610,16 @@ def _row_may_need_sidecar_metadata_refresh(
     )
     if is_runtime_row:
         return True
+    sid = str(session.get('session_id') or '')
     if not session.get('pre_compression_snapshot'):
-        return False
+        lineage_shaped = bool(
+            session.get('parent_session_id')
+            or session.get('_lineage_root_id')
+            or session.get('_compression_segment_count')
+        )
+        return bool(lineage_shaped and sid and _sidecar_mtime_after_index_timestamp(session))
     if session.get('message_count') is None or session.get('last_message_at') is None:
         return True
-    sid = str(session.get('session_id') or '')
     return bool(sid and stale_snapshot_ids and sid in stale_snapshot_ids)
 
 

--- a/api/models.py
+++ b/api/models.py
@@ -2612,6 +2612,17 @@ def _row_may_need_sidecar_metadata_refresh(
         return True
     sid = str(session.get('session_id') or '')
     if not session.get('pre_compression_snapshot'):
+        # Refresh a stale-indexed COMPRESSION CONTINUATION row from its sidecar.
+        # Gate tightly: a plain /branch fork also carries parent_session_id
+        # (#1342) but has no compression sidecar drift to correct, and its file
+        # mtime routinely exceeds the indexed logical last_message_at — so
+        # including forks here would call load_metadata_only() on every fork row
+        # on every /api/sessions poll (the molasses #3770 guards against, per the
+        # #3789 release gate). Exclude session_source == 'fork'
+        # (the marker /api/session/branch stamps; see _is_continuation_session)
+        # so only true continuations are eligible.
+        if str(session.get('session_source') or '').strip().lower() == 'fork':
+            return False
         lineage_shaped = bool(
             session.get('parent_session_id')
             or session.get('_lineage_root_id')

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -869,6 +869,61 @@ def test_all_sessions_refreshes_stale_visible_continuation_metadata(monkeypatch)
     assert rows[0]["last_message_at"] == 103.0
 
 
+def test_all_sessions_does_not_refresh_plain_branch_fork_from_sidecar(monkeypatch):
+    """A plain /branch fork (session_source='fork') must NOT trigger a sidecar refresh.
+
+    Forks carry parent_session_id (#1342) but have no compression sidecar drift
+    to correct. Including them in the continuation refresh gate would call
+    load_metadata_only() on every fork row on every /api/sessions poll (the
+    molasses #3770 guards against). The gate must exclude session_source='fork'
+    so a fork's stale-looking index row is left alone.
+    """
+    session = Session(
+        session_id="plain_fork_child",
+        title="Forked Conversation",
+        messages=[
+            {"role": "user", "content": "a", "timestamp": 100.0},
+            {"role": "assistant", "content": "b", "timestamp": 101.0},
+            {"role": "user", "content": "c", "timestamp": 102.0},
+            {"role": "assistant", "content": "d", "timestamp": 103.0},
+        ],
+        parent_session_id="some_parent",
+        session_source="fork",
+        updated_at=103.0,
+        last_message_at=103.0,
+    )
+    session.save(touch_updated_at=False)
+    _write_index_file(
+        models.SESSION_INDEX_FILE,
+        [
+            {
+                "session_id": "plain_fork_child",
+                "title": "Forked Conversation",
+                "message_count": 2,
+                "created_at": 100.0,
+                "updated_at": 100.0,
+                "last_message_at": 100.0,
+                "pinned": False,
+                "archived": False,
+                "parent_session_id": "some_parent",
+                "session_source": "fork",
+            }
+        ],
+    )
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    # A fork that has not been hydrated must not be promoted from the (stale)
+    # indexed count — the row stays as the index reports it (no sidecar refresh).
+    def _fail_load(_sid):
+        raise AssertionError("plain fork must not trigger load_metadata_only refresh")
+
+    monkeypatch.setattr(models.Session, "load_metadata_only", staticmethod(_fail_load))
+
+    rows = models.all_sessions()
+    fork_row = next(r for r in rows if r["session_id"] == "plain_fork_child")
+    assert fork_row["message_count"] == 2  # left at the indexed value, not refreshed
+
+
 def test_load_metadata_only_skips_index_read_when_sidecar_has_message_count(monkeypatch):
     """Modern sidecars already carry message_count; avoid an _index.json read per row."""
     session = Session(

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -779,8 +779,8 @@ def test_all_sessions_sidecar_refresh_stays_metadata_only(monkeypatch):
     assert rows[0]["last_message_at"] == 102.0
 
 
-def test_all_sessions_does_not_refresh_lineage_rows_from_sidecars(monkeypatch):
-    """Lineage rows are enriched from state.db; do not read every sidecar per poll."""
+def test_all_sessions_does_not_refresh_fresh_lineage_rows_from_sidecars(monkeypatch):
+    """Fresh lineage rows are enriched from state.db; do not read every sidecar per poll."""
     _write_index_file(
         models.SESSION_INDEX_FILE,
         [
@@ -789,8 +789,8 @@ def test_all_sessions_does_not_refresh_lineage_rows_from_sidecars(monkeypatch):
                 "title": "Lineage Row",
                 "message_count": 7,
                 "created_at": 100.0,
-                "updated_at": 101.0,
-                "last_message_at": 101.0,
+                "updated_at": time.time() + 60.0,
+                "last_message_at": time.time() + 60.0,
                 "pinned": False,
                 "archived": False,
                 "parent_session_id": "parent_sid",
@@ -813,11 +813,60 @@ def test_all_sessions_does_not_refresh_lineage_rows_from_sidecars(monkeypatch):
     )
     monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
 
-    with patch.object(Session, "load_metadata_only", side_effect=AssertionError("lineage rows must not refresh sidecars")):
+    with patch.object(Session, "load_metadata_only", side_effect=AssertionError("fresh lineage rows must not refresh sidecars")):
         rows = models.all_sessions()
 
     assert rows[0]["session_id"] == "lineage_sid"
     assert rows[0]["message_count"] == 7
+
+
+def test_all_sessions_refreshes_stale_visible_continuation_metadata(monkeypatch):
+    """A visible continuation whose sidecar advanced after _index.json must refresh metadata.
+
+    Compression lineage rows can remain the active sidebar representative while
+    their sidecar gains the latest assistant turn. If the index row stays stale,
+    the sidebar/topbar reports an old message count and the UI can look like the
+    newest messages disappeared.
+    """
+    session = Session(
+        session_id="stale_visible_child",
+        title="Long Conversation",
+        messages=[
+            {"role": "user", "content": "first", "timestamp": 100.0},
+            {"role": "assistant", "content": "second", "timestamp": 101.0},
+            {"role": "user", "content": "latest", "timestamp": 102.0},
+            {"role": "assistant", "content": "latest answer", "timestamp": 103.0},
+        ],
+        parent_session_id="snapshot_parent",
+        updated_at=103.0,
+        last_message_at=103.0,
+    )
+    session.save(touch_updated_at=False)
+    _write_index_file(
+        models.SESSION_INDEX_FILE,
+        [
+            {
+                "session_id": "stale_visible_child",
+                "title": "Long Conversation",
+                "message_count": 2,
+                "created_at": 100.0,
+                "updated_at": 100.0,
+                "last_message_at": 100.0,
+                "pinned": False,
+                "archived": False,
+                "parent_session_id": "snapshot_parent",
+                "_lineage_root_id": "snapshot_parent",
+                "_compression_segment_count": 2,
+            }
+        ],
+    )
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    rows = models.all_sessions()
+
+    assert rows[0]["session_id"] == "stale_visible_child"
+    assert rows[0]["message_count"] == 4
+    assert rows[0]["last_message_at"] == 103.0
 
 
 def test_load_metadata_only_skips_index_read_when_sidecar_has_message_count(monkeypatch):


### PR DESCRIPTION
## Release v0.51.319 — Release KI (Phase 3 light: refresh stale continuation metadata)

Phase-3-LOW compression-lineage sidebar fix (backend-only, no UI). Rebased clean onto fresh master, byte-identical to PR head, then hardened per the release gate.

### #3789 (@ai-ag2026) — refresh stale continuation metadata (refs #3740)
Continuation-side complement to the shipped #3770. A compression continuation whose recent turns landed in its sidecar after the last `_index.json` write showed a stale (low) message_count → looked like it lost messages. `_row_may_need_sidecar_metadata_refresh` now refreshes a lineage-shaped continuation row from its sidecar when the sidecar mtime is newer than the indexed timestamp.

### Release-gate hardening (MUST-FIX applied)
Codex flagged that `parent_session_id` is set on every `/branch` fork (#1342), so the original gate would call `load_metadata_only()` per fork row per `/api/sessions` poll — the "molasses" #3770 guards against. **Fix:** exclude `session_source == 'fork'` so only true compression continuations are eligible; added `test_all_sessions_does_not_refresh_plain_branch_fork_from_sidecar`. Empirically verified: settled non-fork child rows cost one cheap `stat()` (no load); the only rows that escalate to a load are genuinely-drifted ones that *should* refresh.

### Gate
- Full suite **8213 passed, 0 failed**.
- **Opus: SHIP** — verified the #3770 snapshot path is byte-identical, the continuation fix still works, and the per-fork regression is resolved (residual is a bounded stat()).
- **Codex:** flagged the fork gate (MUST-FIX, applied) + a residual non-fork-child class — empirically confirmed that residual is a cheap stat() when settled and a *correct* refresh when drifted, so shipping per Opus.
- ruff clean; rebased clean; CI confirmed before merge.

Co-authored-by: ai-ag2026 <ai-ag2026@users.noreply.github.com>
