### PR TITLE
fix(help): keep Help card buttons readable on hover in all themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Help tab buttons stay readable on hover across every theme.** The secondary Help card button ("Open GitHub Issues") filled with the accent color on hover but set its text to `--accent-text`, which in most themes equals the accent itself — so the label vanished (same-color text on the fill). Hover text now uses the page-background color (`--bg`), which the accent is designed to contrast against, restoring a readable solid-fill hover in all themes. (#3518 follow-up)
+
 ## [v0.51.325] — 2026-06-08 — Release KO (in-app Help tab)
 
 ### Added

--- a/static/style.css
+++ b/static/style.css
@@ -1566,7 +1566,13 @@
   .help-card-title{font-size:13.5px;font-weight:650;color:var(--text);margin-bottom:3px;}
   .help-card-desc{font-size:12px;color:var(--muted);line-height:1.45;margin-bottom:11px;}
   .help-card-link{display:inline-flex;align-items:center;gap:6px;text-decoration:none;padding:7px 13px;border-radius:7px;font-size:12px;font-weight:600;background:var(--input-bg);border:1px solid var(--border);color:var(--text);transition:all .15s;}
-  .help-card-link:hover{background:var(--accent);border-color:var(--accent);color:var(--accent-text,#1a1a1a);}
+  /* On hover the button fills with --accent; text must contrast against that fill.
+     --accent-text is an accent-on-background link color (often == --accent), so using
+     it here produces same-color text on the accent fill (invisible — e.g. slate/gold/
+     ares/mono dark). --bg is the page background, which --accent is designed to contrast
+     against, so background-colored text on an accent fill stays readable in every theme. */
+  .help-card-link:hover{background:var(--accent);border-color:var(--accent);color:var(--bg);}
+  .help-card-link:hover svg{opacity:1;}
   .help-card-link svg{flex:0 0 auto;opacity:.8;}
   .main{flex:1;display:flex;flex-direction:column;overflow:hidden;min-width:0;min-height:0;background:var(--main-bg);}
   .topbar{padding:12px 20px;border-bottom:1px solid var(--border);background:var(--topbar-bg);backdrop-filter:blur(12px);display:flex;align-items:center;justify-content:space-between;flex-shrink:0;position:relative;z-index:10;}

--- a/tests/test_issue3227_help_tab.py
+++ b/tests/test_issue3227_help_tab.py
@@ -4,6 +4,7 @@ ROOT = Path(__file__).resolve().parents[1]
 INDEX_HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
 PANELS_JS  = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 I18N_JS    = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
+STYLE_CSS  = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
 
 LOCALE_COUNT = 13  # en, it, ja, ru, es, de, zh, zh-TW, pt, ko, fr, tr, pl
 
@@ -46,3 +47,27 @@ def test_i18n_help_keys_present_in_all_locales():
     assert I18N_JS.count("settings_help_issue_label") == LOCALE_COUNT
     assert I18N_JS.count("settings_help_docs_link") == LOCALE_COUNT
     assert I18N_JS.count("settings_help_issue_link") == LOCALE_COUNT
+
+
+def test_help_card_link_hover_is_contrast_safe():
+    """The hover fill is var(--accent); the text color must NOT be var(--accent-text).
+
+    In most themes --accent-text equals (or nearly equals) --accent — it is an
+    accent-on-background link color, not a contrasting color for text sitting ON
+    an accent fill. Using it on the accent-filled hover state produced same-color
+    text on the fill (invisible) across nearly every theme (slate/gold/ares/mono/
+    sisyphus/catppuccin dark all had accent == accent-text). The fix uses
+    var(--bg) — the page background — which --accent is designed to contrast
+    against, so the text stays readable in every theme.
+    """
+    import re
+    m = re.search(r"\.help-card-link:hover\s*\{([^}]*)\}", STYLE_CSS)
+    assert m, "expected a .help-card-link:hover rule in style.css"
+    rule = m.group(1)
+    assert "background:var(--accent)" in rule.replace(" ", "")
+    # The bug: accent-text on accent fill. Must not reappear.
+    assert "--accent-text" not in rule, (
+        "hover text uses var(--accent-text) on an accent fill — invisible in most "
+        "themes; use var(--bg) for theme-agnostic contrast"
+    )
+    assert "color:var(--bg)" in rule.replace(" ", "")


### PR DESCRIPTION
## Problem

On the Settings → **Help** tab (shipped today in #3518 / v0.51.325), hovering the secondary card button (**Open GitHub Issues**) makes its label disappear. The button fills with the accent color on hover but the text color flips to an accent-colored value too, so you get same-color text on the fill.

Reported on the **slate dark** theme but it affects nearly every theme.

## Root cause

`static/style.css`:
```css
.help-card-link:hover{background:var(--accent);border-color:var(--accent);color:var(--accent-text,#1a1a1a);}
```

`--accent-text` is an **accent-on-background link color** (used for things like `.msg-body a`, active session items), *not* a contrasting color for text sitting **on top of** an accent fill. In most themes the two tokens are literally identical, so the hover text matches the hover fill exactly.

I checked every theme's `--accent` vs `--accent-text` contrast (WCAG): **29 theme variants fall below 3.0**, most at **1.00** (identical colors). e.g.:

| theme | --accent | --accent-text | contrast |
|---|---|---|---|
| slate dark | `#94A3B8` | `#94A3B8` | 1.00 |
| gold dark (default) | `#FFD700` | `#FFD700` | 1.00 |
| ares dark | `#FF4444` | `#FF4444` | 1.00 |
| mono / sisyphus / catppuccin dark | == | == | 1.00 |

## Fix

Use `var(--bg)` (the page background) for the hover text. `--accent` is *designed* to contrast against the page background, and contrast is symmetric, so background-colored text on an accent fill is readable in **every** theme. Same `--accent` vs `--bg` check: 28/29 themes land at 4.1–18.1 contrast; the one outlier (Sienna light) is 2.96 — still legible with the bold weight, and identical behavior to the existing app-wide `.plugin-open-btn:hover` precedent.

```css
.help-card-link:hover{background:var(--accent);border-color:var(--accent);color:var(--bg);}
```

This matches how the app's other solid-accent buttons (Send, Save Settings, New Chat) already handle text-on-accent, and the look stays a clean solid-fill hover.

## Verification

Drove the live Help tab in a headless browser across **gold-dark, slate-dark, sienna-light, ares-dark** and hovered the second button in each. Text is readable in all four (computed: text = `--bg`, fill = `--accent`).

| before (slate dark) | after (slate dark) |
|---|---|
| label invisible (gray-on-gray) | dark text on light slate, readable |

- Full test suite: **8243 passed, 9 skipped, 3 xpassed, 0 failures**.
- Added a regression test (`test_help_card_link_hover_is_contrast_safe`) asserting the hover rule never reintroduces `--accent-text` on the accent fill and uses `--bg`.

Follow-up to #3518.
