### PR TITLE
fix: clean up turn/run journals on session delete (#3802)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Deleting a conversation now also removes its turn-journal and run-journal files.** `DELETE /api/session/delete` cleared the session JSON, `state.db` rows, and attachment dir, but left the turn journal (`sessions/_turn_journal/{sid}*.jsonl`, which stores the user's messages in plaintext) and the run journal (`sessions/_run_journal/{sid}/`, which stores the full request/response payloads) on disk — so a "deleted" conversation was still fully recoverable from the filesystem. The delete handler now calls two new best-effort cleanup helpers, `turn_journal.delete_turn_journal()` (removes the pid-scoped shards and the legacy single-file shard) and `run_journal.delete_run_journal()` (removes the per-session run directory), each of which is a safe no-op on an invalid id or a missing journal. (#3802)
+
+
 ## [v0.51.325] — 2026-06-08 — Release KO (in-app Help tab)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -7252,6 +7252,23 @@ def handle_post(handler, parsed) -> bool:
             shutil.rmtree(_session_attachment_dir(sid), ignore_errors=True)
         except Exception:
             logger.debug("Failed to clean attachment dir for deleted session %s", sid)
+        # Remove the turn-journal shards and the run-journal directory so a
+        # deleted conversation is not recoverable from disk. The session JSON +
+        # state.db rows are cleared above, but these journals retain the user's
+        # messages (turn journal) and the full request/response payloads (run
+        # journal) in plaintext. (#3802)
+        try:
+            from api.turn_journal import delete_turn_journal
+
+            delete_turn_journal(sid)
+        except Exception:
+            logger.debug("Failed to delete turn journal for deleted session %s", sid)
+        try:
+            from api.run_journal import delete_run_journal
+
+            delete_run_journal(sid)
+        except Exception:
+            logger.debug("Failed to delete run journal for deleted session %s", sid)
         # Prune the per-session agent lock so deleted sessions don't leak
         # Lock entries in SESSION_AGENT_LOCKS forever.
         with SESSION_AGENT_LOCKS_LOCK:

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -256,6 +256,28 @@ def find_run_summary(run_id: str, *, session_dir: Path | None = None) -> dict | 
     return None
 
 
+def delete_run_journal(session_id: str, *, session_dir: Path | None = None) -> bool:
+    """Remove the entire per-session run-journal directory (``_run_journal/{sid}/``).
+
+    The run journal stores one directory per session containing a ``{rid}.jsonl``
+    file per run, so removing the session's directory clears every run's full
+    request/response payloads. Invalid/empty ids and a missing directory are a
+    no-op so callers can invoke this unconditionally on delete. Returns ``True``
+    if a directory was removed, ``False`` otherwise.
+    """
+    import shutil
+
+    sid = str(session_id or "").strip()
+    if not sid or "/" in sid or "\\" in sid or not _SAFE_ID_RE.fullmatch(sid):
+        return False
+    root = Path(session_dir) if session_dir is not None else _default_session_dir()
+    session_journal_dir = root / RUN_JOURNAL_DIR_NAME / sid
+    if not session_journal_dir.exists():
+        return False
+    shutil.rmtree(session_journal_dir, ignore_errors=True)
+    return not session_journal_dir.exists()
+
+
 def stale_interrupted_event(session_id: str, run_id: str, *, after_seq: int | None = None) -> dict | None:
     summary = latest_run_summary(session_id, run_id)
     if summary.get("terminal") or not summary.get("event_count"):

--- a/api/turn_journal.py
+++ b/api/turn_journal.py
@@ -242,5 +242,38 @@ def iter_turn_journal_session_ids(session_dir: Path) -> list[str]:
     return sorted(session_ids)
 
 
+def delete_turn_journal(session_id: str, *, session_dir: Path | None = None) -> int:
+    """Remove every turn-journal shard for ``session_id``.
+
+    Deletes both the pid-scoped shards (``{sid}~{pid}.jsonl``) written by
+    :func:`append_turn_journal_event` and the legacy single-file form
+    (``{sid}.jsonl``) that :func:`read_turn_journal` still merges. Returns the
+    number of files removed. Invalid/empty ids and a missing journal directory
+    are treated as a no-op so callers can invoke this unconditionally on delete.
+    """
+    sid = str(session_id or "").strip()
+    if not sid or "/" in sid or "\\" in sid or not _SESSION_ID_RE.fullmatch(sid):
+        return 0
+    root = Path(session_dir) if session_dir is not None else _default_session_dir()
+    journal_dir = root / TURN_JOURNAL_DIR_NAME
+    if not journal_dir.exists():
+        return 0
+    removed = 0
+    shards = list(journal_dir.glob(f"{sid}~*.jsonl"))
+    legacy = journal_dir / f"{sid}.jsonl"
+    if legacy.exists():
+        shards.append(legacy)
+    for shard in shards:
+        try:
+            shard.unlink()
+            removed += 1
+        except FileNotFoundError:
+            pass
+        except OSError:
+            # Best-effort cleanup; the caller logs the overall delete outcome.
+            pass
+    return removed
+
+
 def is_terminal_turn_event(event: dict) -> bool:
     return str((event or {}).get("event") or "") in _TERMINAL_EVENTS

--- a/tests/test_issue3802_delete_session_journals.py
+++ b/tests/test_issue3802_delete_session_journals.py
@@ -1,0 +1,95 @@
+"""Regression tests for #3802 — deleting a session must remove its journal files.
+
+Deleting a conversation from the WebUI removed the session JSON + state.db rows
+but left the turn journal (`_turn_journal/{sid}*.jsonl`, user messages in
+plaintext) and the run journal (`_run_journal/{sid}/`, full request/response
+payloads) on disk, so the conversation stayed recoverable. These tests pin the
+two cleanup helpers: every shard/dir for the deleted session is removed, and an
+unrelated session's journals are left untouched.
+"""
+import os
+
+from api.run_journal import RunJournalWriter, delete_run_journal, read_run_events
+from api.turn_journal import (
+    append_turn_journal_event,
+    delete_turn_journal,
+    read_turn_journal,
+)
+
+
+def _submit(sid, content, session_dir):
+    return append_turn_journal_event(
+        sid,
+        {"event": "submitted", "turn_id": "t1", "stream_id": "s1", "role": "user", "content": content},
+        session_dir=session_dir,
+    )
+
+
+def test_delete_turn_journal_removes_pid_shard_and_legacy(tmp_path):
+    # pid-scoped shard (written by append) + a legacy single-file shard.
+    _submit("sid-del", "secret message", session_dir=tmp_path)
+    journal_dir = tmp_path / "_turn_journal"
+    legacy = journal_dir / "sid-del.jsonl"
+    legacy.write_text('{"event":"submitted","session_id":"sid-del","content":"old"}\n', encoding="utf-8")
+
+    pid_shard = journal_dir / f"sid-del~{os.getpid()}.jsonl"
+    assert pid_shard.exists()
+    assert legacy.exists()
+
+    removed = delete_turn_journal("sid-del", session_dir=tmp_path)
+
+    assert removed == 2
+    assert not pid_shard.exists()
+    assert not legacy.exists()
+    # read_turn_journal now finds nothing for the deleted session.
+    assert read_turn_journal("sid-del", session_dir=tmp_path)["events"] == []
+
+
+def test_delete_turn_journal_leaves_other_sessions_intact(tmp_path):
+    _submit("sid-keep", "keep me", session_dir=tmp_path)
+    _submit("sid-del", "delete me", session_dir=tmp_path)
+
+    delete_turn_journal("sid-del", session_dir=tmp_path)
+
+    keep_shard = tmp_path / "_turn_journal" / f"sid-keep~{os.getpid()}.jsonl"
+    del_shard = tmp_path / "_turn_journal" / f"sid-del~{os.getpid()}.jsonl"
+    assert keep_shard.exists(), "unrelated session's journal must survive"
+    assert not del_shard.exists()
+    assert read_turn_journal("sid-keep", session_dir=tmp_path)["events"]
+
+
+def test_delete_turn_journal_noop_on_missing_or_invalid(tmp_path):
+    # Missing directory: no error, zero removed.
+    assert delete_turn_journal("nope", session_dir=tmp_path) == 0
+    # Invalid id: no error, zero removed (and never touches the filesystem).
+    assert delete_turn_journal("../etc/passwd", session_dir=tmp_path) == 0
+    assert delete_turn_journal("", session_dir=tmp_path) == 0
+
+
+def test_delete_run_journal_removes_session_directory(tmp_path):
+    writer = RunJournalWriter("sid-del", "run-1", session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "hello"})
+    writer.append_sse_event("done", {"session": {"session_id": "sid-del"}})
+    run_dir = tmp_path / "_run_journal" / "sid-del"
+    assert run_dir.exists()
+
+    assert delete_run_journal("sid-del", session_dir=tmp_path) is True
+    assert not run_dir.exists()
+    # No events recoverable after delete.
+    assert read_run_events("sid-del", "run-1", session_dir=tmp_path)["events"] == []
+
+
+def test_delete_run_journal_leaves_other_sessions_intact(tmp_path):
+    RunJournalWriter("sid-keep", "run-k", session_dir=tmp_path).append_sse_event("token", {"text": "k"})
+    RunJournalWriter("sid-del", "run-d", session_dir=tmp_path).append_sse_event("token", {"text": "d"})
+
+    delete_run_journal("sid-del", session_dir=tmp_path)
+
+    assert (tmp_path / "_run_journal" / "sid-keep").exists()
+    assert not (tmp_path / "_run_journal" / "sid-del").exists()
+
+
+def test_delete_run_journal_noop_on_missing_or_invalid(tmp_path):
+    assert delete_run_journal("nope", session_dir=tmp_path) is False
+    assert delete_run_journal("../escape", session_dir=tmp_path) is False
+    assert delete_run_journal("", session_dir=tmp_path) is False


### PR DESCRIPTION
## Summary

Deleting a conversation from the WebUI sidebar removed the session JSON, the `state.db` rows, and the attachment dir, but left two journal artifacts on disk — so a "deleted" conversation stayed fully recoverable:

- **Turn journal** — `sessions/_turn_journal/{sid}~{pid}.jsonl` (plus the legacy `sessions/_turn_journal/{sid}.jsonl`), which stores the user's submitted **messages in plaintext**.
- **Run journal** — `sessions/_run_journal/{sid}/` (one `{rid}.jsonl` per run), which stores the **full request/response payloads** for the session.

Closes #3762's sibling data-privacy gap reported in #3802.

## Fix

Two new best-effort cleanup helpers, each reusing its own journal module's constants/validators rather than rebuilding paths inline:

- `api/turn_journal.py::delete_turn_journal(session_id, *, session_dir=None)` — globs and removes the pid-scoped shards (`{sid}~*.jsonl`) **and** the legacy single-file form (`{sid}.jsonl`) that `read_turn_journal` still merges. Returns the count removed.
- `api/run_journal.py::delete_run_journal(session_id, *, session_dir=None)` — `rmtree`s the per-session directory `_run_journal/{sid}/`.

Both validate the id (rejecting empty / path-traversal ids the same way the existing path builders do) and no-op safely on a missing directory, so the delete handler can call them unconditionally. They're wired into the `/api/session/delete` handler in `api/routes.py` right after the existing attachment-dir cleanup, each wrapped in the same defensive `try/except` + debug-log pattern the surrounding cleanup uses.

## Why a per-session helper instead of inline `os.remove`

The maintainer triage on #3802 flagged that a naive `os.remove("{sid}.jsonl")` would miss every real shard — the turn journal is written as `{sid}~{pid}.jsonl` (pid-scoped) and only falls back to the legacy `{sid}.jsonl`. The helpers reuse `TURN_JOURNAL_DIR_NAME` / `RUN_JOURNAL_DIR_NAME` and the modules' own id validators so the cleanup stays correct if those path conventions change.

## Tests

`tests/test_issue3802_delete_session_journals.py` (6 tests):
- turn journal: removes both pid-scoped + legacy shards; leaves an **unrelated** session's shards intact; no-op on missing/invalid/empty id.
- run journal: removes the session directory; leaves an unrelated session's dir intact; no-op on missing/invalid/empty id.

These are genuinely RED without the fix (the helpers don't exist on master).

## Verification

- New tests: 6 passed.
- **Full suite: 8248 passed, 9 skipped, 3 xpassed, 0 failed** (`pytest tests/ -q`).
- `ruff check` clean on the 3 touched `.py` files; `py_compile` OK including `api/routes.py`.

CHANGELOG updated under `[Unreleased]`.
