### PR TITLE
fix: guard importable-session SQL against minimal state.db schemas (#3762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Minimal/older `state.db` schemas no longer hide every imported session from the sidebar.** `read_importable_agent_session_rows()` built its projection SQL with unconditional references to the `messages` table and `messages.timestamp` (`MAX(m.timestamp)`, the `LEFT JOIN messages`, and the `ORDER BY MAX(m.timestamp)`). On a `state.db` with no `messages` table — or a `messages` table without a `timestamp` (or `session_id`) column — the query raised `sqlite3.OperationalError`, which `get_cli_sessions()` catches and converts into an empty list, so **all** imported/CLI/agent sessions silently disappeared from the sidebar with no error shown. The projection now detects the `messages` columns up front (mirroring `read_session_lineage_metadata`) and degrades gracefully: it only joins/aggregates `messages` when it's usable, falls back to the denormalized `s.message_count` and `s.started_at` ordering otherwise, and only selects `MAX(m.timestamp)` when that column exists. (#3762)
+
+
 ## [v0.51.325] — 2026-06-08 — Release KO (in-app Help tab)
 
 ### Added

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -447,11 +447,51 @@ def read_importable_agent_session_rows(
         origin_chat_id_expr = _optional_col('origin_chat_id', session_cols)
         origin_user_id_expr = _optional_col('origin_user_id', session_cols)
         platform_expr = _optional_col('platform', session_cols)
-        user_message_count_expr = (
-            "COUNT(CASE WHEN LOWER(m.role) = 'user' THEN 1 END)"
-            if 'role' in message_cols
-            else "COUNT(m.id)"
-        )
+        # Older/minimal state.db schemas can have NO ``messages`` table at all,
+        # or a ``messages`` table without a ``session_id`` / ``timestamp`` column.
+        # The projection SQL below joins ``messages`` and aggregates
+        # ``MAX(m.timestamp)`` unconditionally, so on those schemas the query
+        # raised ``sqlite3.OperationalError`` — which the caller
+        # (``get_cli_sessions``) swallows into an empty list, silently hiding
+        # ALL imported/CLI/agent sessions from the sidebar. Detect the columns
+        # and degrade gracefully (mirrors ``read_session_lineage_metadata``):
+        # only join/aggregate ``messages`` when it's actually usable, otherwise
+        # fall back to the per-session ``s.message_count`` / ``s.started_at``. (#3762)
+        messages_has_session_id = 'session_id' in message_cols
+        messages_has_timestamp = 'timestamp' in message_cols
+        use_messages_join = messages_has_session_id
+        count_col = 'id' if 'id' in message_cols else 'session_id'
+
+        if use_messages_join:
+            actual_count_expr = f"COUNT(m.{count_col})"
+            if 'role' in message_cols:
+                user_message_count_expr = "COUNT(CASE WHEN LOWER(m.role) = 'user' THEN 1 END)"
+            else:
+                user_message_count_expr = f"COUNT(m.{count_col})"
+            last_activity_expr = "MAX(m.timestamp)" if messages_has_timestamp else "NULL"
+            join_clause = "LEFT JOIN messages m ON m.session_id = s.id"
+            group_by_clause = "GROUP BY s.id"
+        else:
+            # No usable messages table: use the denormalized per-session counts
+            # and ``started_at`` so the rows still surface in the sidebar.
+            actual_count_expr = "s.message_count"
+            user_message_count_expr = "s.message_count"
+            last_activity_expr = "NULL"
+            join_clause = ""
+            group_by_clause = ""
+
+        if use_messages_join and messages_has_timestamp:
+            order_by_clause = "ORDER BY COALESCE(MAX(m.timestamp), s.started_at) DESC"
+            candidate_order_clause = (
+                "ORDER BY COALESCE(\n"
+                "                        (SELECT MAX(mx.timestamp) FROM messages mx WHERE mx.session_id = s.id),\n"
+                "                        s.started_at\n"
+                "                    ) DESC,\n"
+                "                    s.started_at DESC"
+            )
+        else:
+            order_by_clause = "ORDER BY s.started_at DESC"
+            candidate_order_clause = "ORDER BY s.started_at DESC"
 
         where_clauses = ["s.source IS NOT NULL"]
         params: list[object] = []
@@ -477,9 +517,9 @@ def read_importable_agent_session_rows(
                    {parent_expr},
                    {ended_expr},
                    {end_reason_expr},
-                   COUNT(m.id) AS actual_message_count,
+                   {actual_count_expr} AS actual_message_count,
                    {user_message_count_expr} AS actual_user_message_count,
-                   MAX(m.timestamp) AS last_activity
+                   {last_activity_expr} AS last_activity
         """
         if limit is not None:
             result_limit = max(0, int(limit))
@@ -500,19 +540,15 @@ def read_importable_agent_session_rows(
                     SELECT s.id
                     FROM sessions s
                     WHERE {' AND '.join(where_clauses)}
-                    ORDER BY COALESCE(
-                        (SELECT MAX(mx.timestamp) FROM messages mx WHERE mx.session_id = s.id),
-                        s.started_at
-                    ) DESC,
-                    s.started_at DESC
+                    {candidate_order_clause}
                     LIMIT ?
                 )
                 {select_sql}
                 FROM sessions s
                 JOIN candidates c ON c.id = s.id
-                LEFT JOIN messages m ON m.session_id = s.id
-                GROUP BY s.id
-                ORDER BY COALESCE(MAX(m.timestamp), s.started_at) DESC
+                {join_clause}
+                {group_by_clause}
+                {order_by_clause}
                 """,
                 [*params, candidate_limit],
             )
@@ -521,10 +557,10 @@ def read_importable_agent_session_rows(
                 f"""
                 {select_sql}
                 FROM sessions s
-                LEFT JOIN messages m ON m.session_id = s.id
+                {join_clause}
                 WHERE {' AND '.join(where_clauses)}
-                GROUP BY s.id
-                ORDER BY COALESCE(MAX(m.timestamp), s.started_at) DESC
+                {group_by_clause}
+                {order_by_clause}
                 """,
                 params,
             )

--- a/tests/test_issue3762_importable_rows_schema_guard.py
+++ b/tests/test_issue3762_importable_rows_schema_guard.py
@@ -1,0 +1,132 @@
+"""Regression tests for #3762 — minimal state.db schemas must not hide all sessions.
+
+`read_importable_agent_session_rows()` built its projection SQL with
+unconditional references to the `messages` table and `messages.timestamp`
+(`MAX(m.timestamp)`, `COUNT(m.id)`, the `LEFT JOIN messages`, and the
+`ORDER BY MAX(m.timestamp)`). On a `state.db` that has no `messages` table — or
+a `messages` table without a `timestamp` column — that query raised
+`sqlite3.OperationalError`, which `get_cli_sessions()` catches and turns into an
+empty list, so EVERY imported/CLI/agent session silently vanished from the
+sidebar. These tests build minimal schemas directly and assert the rows still
+come back instead of the query exploding.
+"""
+import sqlite3
+
+import pytest
+
+from api.agent_sessions import read_importable_agent_session_rows
+
+
+def _make_db(path, *, with_messages_table, with_timestamp, with_session_id=True,
+             sessions=None, messages=None):
+    """Build a minimal state.db.
+
+    sessions: list of (id, title, model, message_count, started_at, source, session_source)
+    messages: list of (session_id, role[, timestamp]) — inserted only when the
+              messages table is created with the matching columns.
+    """
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY, title TEXT, model TEXT, message_count INTEGER,
+            started_at REAL, source TEXT, session_source TEXT
+        )
+        """
+    )
+    for r in (sessions or []):
+        conn.execute(
+            "INSERT INTO sessions (id, title, model, message_count, started_at, source, session_source) "
+            "VALUES (?,?,?,?,?,?,?)",
+            r,
+        )
+    if with_messages_table:
+        cols = ["id INTEGER PRIMARY KEY"]
+        if with_session_id:
+            cols.append("session_id TEXT")
+        cols.append("role TEXT")
+        if with_timestamp:
+            cols.append("timestamp REAL")
+        conn.execute(f"CREATE TABLE messages ({', '.join(cols)})")
+        for m in (messages or []):
+            if with_session_id and with_timestamp:
+                conn.execute("INSERT INTO messages (session_id, role, timestamp) VALUES (?,?,?)", m)
+            elif with_session_id:
+                conn.execute("INSERT INTO messages (session_id, role) VALUES (?,?)", m[:2])
+    conn.commit()
+    conn.close()
+
+
+def test_full_schema_returns_rows_baseline(tmp_path):
+    db = tmp_path / "state.db"
+    _make_db(
+        db, with_messages_table=True, with_timestamp=True,
+        sessions=[("cli-1", "Hello", "gpt", 3, 1000.0, "cli", "cli")],
+        messages=[("cli-1", "user", 1001.0), ("cli-1", "assistant", 1002.0)],
+    )
+    out = read_importable_agent_session_rows(db, exclude_sources=None)
+    assert "cli-1" in {r["id"] for r in out}
+
+
+def test_messages_table_without_timestamp_does_not_hide_sessions(tmp_path):
+    """The exact #3762 repro: messages table exists but has no timestamp column.
+
+    On master this raised sqlite3.OperationalError on MAX(m.timestamp) and the
+    whole list collapsed to empty. The COUNT join still works, so the session
+    must surface with its real message count and a NULL last_activity.
+    """
+    db = tmp_path / "state.db"
+    _make_db(
+        db, with_messages_table=True, with_timestamp=False,
+        sessions=[("cli-1", "Hello", "gpt", 2, 1000.0, "cli", "cli")],
+        messages=[("cli-1", "user"), ("cli-1", "assistant")],
+    )
+    out = read_importable_agent_session_rows(db, exclude_sources=None)
+    assert {r["id"] for r in out} == {"cli-1"}
+    assert out[0].get("last_activity") is None
+
+
+def test_no_messages_table_does_not_hide_sessions(tmp_path):
+    """state.db with a sessions table but NO messages table at all.
+
+    With no join possible we fall back to the denormalized s.message_count, so
+    non-empty sessions still surface.
+    """
+    db = tmp_path / "state.db"
+    _make_db(
+        db, with_messages_table=False, with_timestamp=False,
+        sessions=[
+            ("cli-1", "First", "gpt", 2, 1000.0, "cli", "cli"),
+            ("cli-2", "Second", "gpt", 7, 2000.0, "cli", "cli"),
+        ],
+    )
+    out = read_importable_agent_session_rows(db, exclude_sources=None)
+    assert {r["id"] for r in out} == {"cli-1", "cli-2"}
+
+
+def test_messages_table_without_session_id_does_not_hide_sessions(tmp_path):
+    """A messages table that can't be joined (no session_id) degrades to s.message_count."""
+    db = tmp_path / "state.db"
+    _make_db(
+        db, with_messages_table=True, with_timestamp=True, with_session_id=False,
+        sessions=[("cli-1", "Hello", "gpt", 4, 1000.0, "cli", "cli")],
+    )
+    out = read_importable_agent_session_rows(db, exclude_sources=None)
+    assert {r["id"] for r in out} == {"cli-1"}
+
+
+@pytest.mark.parametrize("with_timestamp", [True, False])
+def test_limit_path_also_guarded(tmp_path, with_timestamp):
+    """The bounded (limit set) candidate-CTE branch must be column-aware too."""
+    db = tmp_path / "state.db"
+    sessions = [(f"cli-{i}", f"T{i}", "gpt", 2, 1000.0 + i, "cli", "cli") for i in range(5)]
+    messages = []
+    for i in range(5):
+        if with_timestamp:
+            messages += [(f"cli-{i}", "user", 1000.0 + i), (f"cli-{i}", "assistant", 1000.5 + i)]
+        else:
+            messages += [(f"cli-{i}", "user"), (f"cli-{i}", "assistant")]
+    _make_db(db, with_messages_table=True, with_timestamp=with_timestamp,
+             sessions=sessions, messages=messages)
+    out = read_importable_agent_session_rows(db, limit=3, exclude_sources=None)
+    assert len(out) == 3


### PR DESCRIPTION
## Summary

`read_importable_agent_session_rows()` (in `api/agent_sessions.py`) — the shared projection behind both `GET /api/sessions` and the gateway SSE watcher — built its SQL with **unconditional** references to the `messages` table and `messages.timestamp`:

- `MAX(m.timestamp) AS last_activity` in the SELECT list
- the candidate subquery `(SELECT MAX(mx.timestamp) FROM messages mx WHERE mx.session_id = s.id)`
- `LEFT JOIN messages m ON m.session_id = s.id` (both the bounded and unbounded branches)
- `ORDER BY COALESCE(MAX(m.timestamp), s.started_at) DESC` (both branches)

On a `state.db` that has **no `messages` table** — or a `messages` table **without a `timestamp` column** (or without `session_id`) — that query raises `sqlite3.OperationalError`. `get_cli_sessions()` catches any exception and returns `[]`, logging only at WARNING — so **every** imported / CLI / agent session silently disappears from the sidebar with no visible error. Closes #3762.

This was a pre-existing latent gap on `master` (surfaced by the release gate while reviewing #3751; that PR didn't touch this SQL, so it was filed separately rather than expanding its scope).

## Fix

The function already detects `message_cols` via `PRAGMA table_info(messages)` but only consumed it for the role-aware count. The fix extends that detection and makes the whole projection column-aware, mirroring the existing graceful-degradation pattern in `read_session_lineage_metadata()`:

- `messages_has_session_id` / `messages_has_timestamp` / `count_col` computed from `message_cols`.
- **Usable messages table** → join + aggregate as before, but `last_activity` only selects `MAX(m.timestamp)` when the column exists (NULL otherwise).
- **No usable messages table** → drop the join, fall back to the denormalized `s.message_count` for counts and `s.started_at` for ordering, so non-empty sessions still surface.

Applied to **both** the bounded (candidate-CTE) and unbounded query branches.

## Tests

`tests/test_issue3762_importable_rows_schema_guard.py` (6 tests) builds minimal `state.db` files directly:
- full schema baseline (regression guard);
- **messages table without `timestamp`** — the exact repro; raised `OperationalError: no such column: mx.timestamp` on master, now surfaces the session with NULL `last_activity`;
- no `messages` table at all → falls back to `s.message_count`;
- messages table without `session_id` → degrades safely;
- the bounded `limit` path, parametrized over with/without timestamp.

I verified the no-timestamp case is genuinely RED on `master` (it raises `OperationalError` before this fix).

## Verification

- New tests: 6 passed.
- **Full suite: 8248 passed, 9 skipped, 3 xpassed, 0 failed** (`pytest tests/ -q`).
- `ruff check` clean; `py_compile` OK.

CHANGELOG updated under `[Unreleased]`.
