### PR TITLE
fix: reuse index message counts during metadata refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Sidebar session refreshes no longer repeatedly re-parse `_index.json` for legacy lineage rows.** When stale sidecar metadata needs indexed `message_count` hints, the WebUI now reuses the `_index.json` rows already loaded by `/api/sessions` instead of reading the index once per refreshed row. This preserves the scoped sidecar refresh behavior while avoiding accidental O(n²)-style polling on large session histories. (#3814, @ai-ag2026)
+
 ## [v0.51.325] — 2026-06-08 — Release KO (in-app Help tab)
 
 ### Added

--- a/api/models.py
+++ b/api/models.py
@@ -513,24 +513,41 @@ def _read_metadata_json_prefix(path, max_prefix_bytes=65536):
 
 def _lookup_index_message_count(session_id):
     """Return the indexed message count without loading the full session file."""
-    try:
-        entries = json.loads(SESSION_INDEX_FILE.read_text(encoding='utf-8'))
-    except Exception:
-        return None
+    return _index_message_count_map().get(str(session_id))
+
+
+def _index_message_count_map(entries=None) -> dict[str, int]:
+    """Return indexed message counts keyed by session id.
+
+    ``load_metadata_only()`` is called in loops for stale lineage/sidebar rows.
+    Reading and parsing ``_index.json`` once per row turns /api/sessions into an
+    accidental O(n²) poll for old sidecars that predate persisted
+    ``message_count``. Accepting already-loaded index rows lets callers reuse
+    the index they just parsed.
+    """
+    if entries is None:
+        try:
+            entries = json.loads(SESSION_INDEX_FILE.read_text(encoding='utf-8'))
+        except Exception:
+            return {}
     if not isinstance(entries, list):
-        return None
+        return {}
+    counts: dict[str, int] = {}
     for entry in entries:
-        if entry.get('session_id') != session_id:
+        if not isinstance(entry, dict):
+            continue
+        sid = str(entry.get('session_id') or '')
+        if not sid:
             continue
         count = entry.get('message_count')
-        if isinstance(count, int) and count >= 0:
-            return count
-        try:
-            count = int(count)
-        except (TypeError, ValueError):
-            return None
-        return count if count >= 0 else None
-    return None
+        if not isinstance(count, int):
+            try:
+                count = int(count)
+            except (TypeError, ValueError):
+                continue
+        if count >= 0:
+            counts[sid] = count
+    return counts
 
 
 def _parse_nonnegative_int(value):
@@ -791,7 +808,7 @@ class Session:
         return session
 
     @classmethod
-    def load_metadata_only(cls, sid):
+    def load_metadata_only(cls, sid, *, index_message_counts=None):
         """Load only the compact metadata fields, skipping the messages array.
 
         Session JSON files have metadata fields (session_id, title, model, etc.)
@@ -820,7 +837,10 @@ class Session:
             sidecar_message_count = _parse_nonnegative_int(parsed.get('message_count'))
             index_message_count = None
             if sidecar_message_count is None:
-                index_message_count = _lookup_index_message_count(sid)
+                if index_message_counts is not None:
+                    index_message_count = index_message_counts.get(str(sid))
+                else:
+                    index_message_count = _lookup_index_message_count(sid)
             # Modern sidecars carry an accurate message_count, so it is the
             # source of truth and we skip the per-row _index.json read in the
             # common case. The sidebar index is only a cache (it can lag behind
@@ -2689,7 +2709,11 @@ def _stale_snapshot_metadata_refresh_ids(sessions: list[dict]) -> set[str]:
     return refresh_ids
 
 
-def _refresh_index_rows_from_sidecar_metadata(sessions: list[dict]) -> list[dict]:
+def _refresh_index_rows_from_sidecar_metadata(
+    sessions: list[dict],
+    *,
+    index_message_counts: dict[str, int] | None = None,
+) -> list[dict]:
     """Overlay fuller sidecar metadata onto stale sidebar index rows.
 
     ``_index.json`` is a cache and can lag behind the canonical session sidecar
@@ -2710,7 +2734,10 @@ def _refresh_index_rows_from_sidecar_metadata(sessions: list[dict]) -> list[dict
         if not sid:
             out.append(session)
             continue
-        sidecar = Session.load_metadata_only(sid)
+        sidecar = Session.load_metadata_only(
+            sid,
+            index_message_counts=index_message_counts,
+        )
         if not sidecar:
             out.append(session)
             continue
@@ -3012,7 +3039,11 @@ def all_sessions(diag=None):
                         active_stream_ids=active_stream_ids,
                     )
             _diag_stage(diag, "all_sessions.refresh_sidecar_metadata")
-            refreshed_index_rows = _refresh_index_rows_from_sidecar_metadata(list(index_map.values()))
+            index_message_counts = _index_message_count_map(index)
+            refreshed_index_rows = _refresh_index_rows_from_sidecar_metadata(
+                list(index_map.values()),
+                index_message_counts=index_message_counts,
+            )
             index_map = {
                 row['session_id']: row
                 for row in refreshed_index_rows

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -944,6 +944,67 @@ def test_load_metadata_only_skips_index_read_when_sidecar_has_message_count(monk
     assert meta.compact()["message_count"] == 1
 
 
+
+
+def test_all_sessions_reuses_loaded_index_counts_for_legacy_sidecar_refresh(monkeypatch):
+    """Refreshing multiple legacy lineage rows must not parse _index.json per row."""
+    index_file = models.SESSION_INDEX_FILE
+    rows = []
+    for sid, count in (("legacy_lineage_a", 3), ("legacy_lineage_b", 4)):
+        payload = {
+            "session_id": sid,
+            "title": sid,
+            "workspace": "/tmp",
+            "model": "test",
+            "created_at": 100.0,
+            "updated_at": 200.0,
+            "pinned": False,
+            "archived": False,
+            "parent_session_id": "lineage_parent",
+            "messages": [{"role": "user", "content": "legacy"}],
+            "tool_calls": [],
+        }
+        # Deliberately bypass Session.save(): pre-fix legacy sidecars do not have
+        # a persisted message_count field in their metadata prefix.
+        (models.SESSION_DIR / f"{sid}.json").write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        rows.append({
+            "session_id": sid,
+            "title": sid,
+            "workspace": "/tmp",
+            "model": "test",
+            "created_at": 100.0,
+            "updated_at": 100.0,
+            "last_message_at": 100.0,
+            "message_count": count,
+            "pinned": False,
+            "archived": False,
+            "parent_session_id": "lineage_parent",
+        })
+    _write_index_file(index_file, rows)
+
+    original_read_text = Path.read_text
+    index_reads = 0
+
+    def _counting_read_text(self, *args, **kwargs):
+        nonlocal index_reads
+        if self == index_file:
+            index_reads += 1
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _counting_read_text)
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    result = models.all_sessions()
+
+    counts = {row["session_id"]: row["message_count"] for row in result}
+    assert counts["legacy_lineage_a"] == 3
+    assert counts["legacy_lineage_b"] == 4
+    assert index_reads == 1
+
+
 def test_session_save_does_not_persist_metadata_message_count_hint():
     s = Session(
         session_id="sess_private_hint",


### PR DESCRIPTION
## Thinking Path
A local `/api/sessions` latency incident showed that the stale sidecar metadata refresh path was doing repeated `_index.json` reads for legacy sidecars that lack persisted `message_count`. The WebUI had already loaded the index rows for the sidebar response, so the smallest fix is to reuse that data during the scoped refresh instead of adding a broader cache or hydrating transcripts.

## What Changed
- Added `_index_message_count_map()` to build reusable indexed message-count hints from already-loaded index rows.
- Passed those hints through `_refresh_index_rows_from_sidecar_metadata()` into `Session.load_metadata_only()`.
- Kept `_lookup_index_message_count()` as the direct fallback for standalone metadata loads.
- Added a release-note-ready `CHANGELOG.md` entry.
- Added a regression test proving multiple legacy lineage rows refresh with only one `_index.json` read.

## Why It Matters
This preserves the existing lineage-scoped sidecar refresh behavior while avoiding accidental O(n²)-style sidebar polling on large session histories.

## Contract Routing
Task type: narrow session metadata performance fix.
Touched areas: session sidebar metadata/index fast path.
Relevant public docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/rfcs/README.md`.
Scope boundaries: no session persistence format change; no recovery/streaming semantics change; no UI behavior change beyond faster metadata refresh.
Evidence needed before claiming done: regression test that indexed counts are reused, focused session-index suite, syntax check, diff/hygiene checks, hosted CI.

## Verification
- `/home/manfred/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/test_session_index.py::test_load_metadata_only_skips_index_read_when_sidecar_has_message_count tests/test_session_index.py::test_all_sessions_reuses_loaded_index_counts_for_legacy_sidecar_refresh tests/test_session_index.py::test_all_sessions_does_not_refresh_plain_branch_fork_from_sidecar -q` -> 3 passed
- `/home/manfred/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/test_session_index.py -q` -> 35 passed
- `/home/manfred/.hermes/hermes-agent/venv/bin/python -m py_compile api/models.py` -> passed
- `git diff --check origin/master...HEAD` -> passed
- added-line public hygiene scan -> 0 marker hits
- Hosted CI after initial open was green before the changelog/PR-body compliance amend; this amended head is expected to rerun the same checks.

## Risks / Follow-ups
- Low risk: the map is derived from the index rows already read for the same sidebar request.
- If a stale row has an invalid indexed count, behavior matches the previous fallback semantics by ignoring invalid/non-negative failures.

## Model Used
OpenAI GPT-5.5 via Hermes Agent, with terminal/git/pytest tooling.