### PR TITLE
fix: skip non-backup sessions during startup recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **WebUI startup recovery no longer parses every session sidecar when no backup exists.** Startup `.bak` recovery now skips clean live sessions without a matching `.json.bak` file, while preserving orphan-backup recovery and missing-index rebuild behavior. This keeps recovery semantics intact and avoids a slow boot-time scan across large historical session directories. (#3815, @ai-ag2026)
+
 ## [v0.51.325] — 2026-06-08 — Release KO (in-app Help tab)
 
 ### Added

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -588,18 +588,20 @@ def recover_all_sessions_on_startup(
     """
     if not session_dir.exists():
         return {"scanned": 0, "restored": 0, "orphaned_backups": 0, "details": []}
-    scanned = 0
     restored = 0
     details: list[dict] = []
     live_paths = [path for path in sorted(session_dir.glob('*.json')) if not path.name.startswith('_')]
     orphan_paths = _orphaned_backup_live_paths(session_dir, state_db_path=state_db_path)
-    for path in [*live_paths, *orphan_paths]:
-        # Skip non-session JSON files in the same dir:
-        # - ``_index.json`` is a top-level list of session metadata
-        # - any future non-session JSON marked with the ``_`` convention is
-        #   skipped automatically (project convention for system files in
-        #   directories that otherwise hold user data)
-        scanned += 1
+    # Only sessions with a backup can be restored through this startup path.
+    # Older code called recover_session() for every live sidecar, and
+    # inspect_session_recovery_status() read the complete JSON file before even
+    # checking whether <sid>.json.bak existed. Large WebUI installs therefore
+    # parsed the entire session corpus on every boot even when there was
+    # nothing to recover. Keep the public scanned count compatible, but limit
+    # expensive reads to actual recovery candidates.
+    recovery_paths = [path for path in live_paths if path.with_suffix('.json.bak').exists()]
+    scanned = len(live_paths) + len(orphan_paths)
+    for path in [*recovery_paths, *orphan_paths]:
         try:
             result = recover_session(path)
         except Exception as exc:

--- a/tests/test_metadata_save_wipe_1558.py
+++ b/tests/test_metadata_save_wipe_1558.py
@@ -348,6 +348,37 @@ def test_recover_all_sessions_on_startup_is_idempotent_no_op_on_clean_state(temp
     assert live_before == live_after
 
 
+def test_recover_all_sessions_on_startup_does_not_read_live_files_without_backup(temp_session_dir, monkeypatch):
+    """Clean live sidecars without .bak are not recovery candidates at startup."""
+    clean_sid = _make_session_on_disk(temp_session_dir, sid="clean_no_bak", n_msgs=500)
+    backed_sid = _make_session_on_disk(temp_session_dir, sid="backed_candidate", n_msgs=4)
+    clean_path = temp_session_dir / f"{clean_sid}.json"
+    backed_path = temp_session_dir / f"{backed_sid}.json"
+    backed_path.with_suffix('.json.bak').write_text(
+        backed_path.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    import api.session_recovery as sr
+
+    real_msg_count = sr._msg_count
+    msg_count_paths = []
+
+    def tracking_msg_count(path):
+        msg_count_paths.append(path)
+        return real_msg_count(path)
+
+    monkeypatch.setattr(sr, "_msg_count", tracking_msg_count)
+
+    result = sr.recover_all_sessions_on_startup(temp_session_dir)
+
+    assert result["restored"] == 0
+    assert result["scanned"] == 2
+    assert clean_path not in msg_count_paths
+    assert backed_path in msg_count_paths
+    assert backed_path.with_suffix('.json.bak') in msg_count_paths
+
+
 def test_recover_all_sessions_on_startup_skips_non_session_index_json(temp_session_dir):
     """Regression for v0.50.284 startup: ``_index.json`` is a top-level list
     (not a dict), and the recovery scanner globs ``*.json``. Without the


### PR DESCRIPTION
## Thinking Path
A local WebUI startup latency incident showed that `recover_all_sessions_on_startup()` called `recover_session()` for every live session sidecar. `recover_session()` then read the full JSON before discovering that most sessions had no `.json.bak` and therefore could not be restored. The smallest safe fix is to identify recovery candidates by backup presence first, while keeping public counters and orphan-backup behavior compatible.

## What Changed
- Startup recovery now limits expensive `recover_session()` calls to live sessions that have a matching `.json.bak` file.
- The public `scanned` count still reports all live sessions plus orphan backup candidates.
- Orphan-backup recovery and missing-index rebuild behavior remain intact.
- Added a release-note-ready `CHANGELOG.md` entry.
- Added a regression test proving clean live sidecars without `.bak` are not read during startup recovery.

## Why It Matters
Large WebUI installs can have thousands of historical session files but only a small number of backup candidates. This keeps startup recovery semantics intact without parsing every historical transcript on every boot.

## Contract Routing
Task type: narrow startup recovery performance fix.
Touched areas: session backup recovery and recovery-index rebuild path.
Relevant public docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/rfcs/README.md`.
Scope boundaries: no new recovery class; no state.db contract change; orphan backups and missing-index rebuilds remain covered.
Evidence needed before claiming done: regression test for non-backup live sidecars, existing orphan/index recovery tests, focused recovery suite, syntax check, diff/hygiene checks, hosted CI.

## Verification
- `/home/manfred/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/test_metadata_save_wipe_1558.py::test_recover_all_sessions_on_startup_rebuilds_missing_index_without_restores tests/test_metadata_save_wipe_1558.py::test_recover_all_sessions_on_startup_rebuilds_index_after_orphan_restore tests/test_metadata_save_wipe_1558.py::test_recover_all_sessions_on_startup_does_not_read_live_files_without_backup tests/test_metadata_save_wipe_1558.py::test_recover_all_sessions_on_startup_skips_non_session_index_json -q` -> 4 passed
- `/home/manfred/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/test_metadata_save_wipe_1558.py -q` -> 17 passed
- `/home/manfred/.hermes/hermes-agent/venv/bin/python -m py_compile api/session_recovery.py` -> passed
- `git diff --check origin/master...HEAD` -> passed
- added-line public hygiene scan -> 0 marker hits
- Hosted CI after initial open was green before the changelog/PR-body compliance amend; this amended head is expected to rerun the same checks.

## Risks / Follow-ups
- Low risk: startup recovery could only restore sessions that have a backup sidecar, so skipping non-backup live files avoids wasted reads rather than changing repair eligibility.
- The `scanned` value remains compatibility-oriented; it is not the count of expensive recovery candidates.

## Model Used
OpenAI GPT-5.5 via Hermes Agent, with terminal/git/pytest tooling.