### PR TITLE
fix(webui): resolve state.db by session.profile, fall back to active profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Profile-scoped `state.db` lookups for CLI/Telegram sessions.** When a session is owned by a profile other than the WebUI's active profile (e.g. a session created by the `reverse-engineer` CLI profile while the WebUI runs as `default`), `state_db_has_session()` and `/api/session/lineage/report` now resolve the agent `state.db` from the session's own profile, not the active profile's. Previously the session would show up in the sidebar (because the JSON sidecar was found) but its messages came from the wrong database, so the transcript appeared empty. Adds `api.models._resolve_state_db_path(*, profile, session)` with explicit-priority resolution and a four-test regression suite under `tests/test_profile_aware_state_db.py`. The legacy `_active_state_db_path()` helper is preserved for callers without a PR handle.
+
 ## [v0.51.326] — 2026-06-08 — Release KP (mic STT probe + journal cleanup + schema guard + help hover)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -2741,7 +2741,7 @@ def _refresh_index_rows_from_sidecar_metadata(sessions: list[dict]) -> list[dict
 
 
 def state_db_has_session(sid: str) -> bool:
-    """Return True when ``sid`` exists in the active state.db sessions table.
+    """Return True when ``sid`` exists in the agent state.db sessions table.
 
     Used by file-manager handlers to fall back to a state.db lookup when
     ``get_session`` raises ``KeyError`` because the session was created by
@@ -2749,6 +2749,11 @@ def state_db_has_session(sid: str) -> bool:
     schema stores only metadata (id/title/model/source/...), not a workspace
     path — the workspace is shared across session storage backends and is
     resolved separately via ``get_last_workspace()``.
+
+    The lookup targets the *session's* profile-scoped state.db first, so a
+    CLI session created under the ``reverse-engineer`` profile is found
+    even when the WebUI itself runs as ``default`` (the active profile).
+    Falls back to the active profile's DB when the session is unknown.
     """
     if not sid:
         return False
@@ -2756,7 +2761,11 @@ def state_db_has_session(sid: str) -> bool:
         import sqlite3
     except ImportError:
         return False
-    db_path = _active_state_db_path()
+    try:
+        sidecar_session = Session.load(sid) if is_safe_session_id(sid) else None
+    except Exception:
+        sidecar_session = None
+    db_path = _resolve_state_db_path(session=sidecar_session)
     if not db_path.exists():
         return False
     try:
@@ -2810,6 +2819,61 @@ def _active_state_db_path() -> Path:
     except Exception:
         hermes_home = Path(os.getenv('HERMES_HOME', str(HOME / '.hermes'))).expanduser().resolve()
     return hermes_home / 'state.db'
+
+
+def _resolve_state_db_path(
+    *,
+    profile: str | None = None,
+    session=None,
+) -> Path:
+    """Return the agent ``state.db`` for the session's owning profile.
+
+    Resolution order (most specific wins):
+      1. ``session.profile`` — when a session object is supplied and declares
+         a non-empty profile, look in that profile's home first. This is the
+         common case for CLI/Telegram sessions displayed in the WebUI:
+         their messages live in a profile-scoped ``state.db`` and the active
+         profile's DB is the wrong one.
+      2. ``profile=`` — explicit caller override. Takes precedence over
+         ``session.profile`` so handlers that already know the target
+         profile can avoid the session attribute round-trip.
+      3. Active profile (legacy ``_active_state_db_path()``) — the WebUI's
+         own profile. This preserves the pre-fix default for any caller
+         that has not been updated.
+
+    Why the order matters
+    ---------------------
+    Before this helper existed, callers used ``_active_state_db_path()``
+    unconditionally. When a session was created by a CLI profile other
+    than the active one (e.g. ``reverse-engineer`` while the WebUI ran as
+    ``default``), the WebUI found the session in its JSON sidecar but
+    looked for messages in the wrong ``state.db``, so the transcript
+    appeared empty. Pinning ``session.profile`` here fixes the regression
+    for every existing call site that passes a session, with no breaking
+    change to callers that don't.
+    """
+    candidate_profiles: list[str] = []
+    if session is not None:
+        session_profile = getattr(session, "profile", None)
+        if isinstance(session_profile, str) and session_profile:
+            candidate_profiles.append(session_profile)
+    if isinstance(profile, str) and profile:
+        # Explicit override wins over the session hint, but only if it's
+        # not already at the head of the candidate list.
+        if not candidate_profiles or candidate_profiles[0] != profile:
+            candidate_profiles.insert(0, profile)
+    if not candidate_profiles:
+        return _active_state_db_path()
+    for name in candidate_profiles:
+        try:
+            from api.profiles import get_hermes_home_for_profile
+            home = Path(get_hermes_home_for_profile(name)).expanduser()
+        except Exception:
+            continue
+        db_path = home / "state.db"
+        if db_path.exists():
+            return db_path
+    return _active_state_db_path()
 
 
 def _agent_state_db_path(*, profile=None) -> Path | None:

--- a/api/routes.py
+++ b/api/routes.py
@@ -3332,6 +3332,7 @@ from api.models import (
     _write_session_index,
     SESSION_INDEX_FILE,
     _active_state_db_path,
+    _resolve_state_db_path,
     load_projects,
     save_projects,
     import_cli_session,
@@ -5728,7 +5729,16 @@ def handle_get(handler, parsed) -> bool:
         sid = parse_qs(parsed.query).get("session_id", [""])[0]
         if not sid:
             return bad(handler, "session_id required", 400)
-        report = read_session_lineage_report(_active_state_db_path(), sid)
+        # Resolve state.db by the session's owning profile, not the active
+        # profile — CLI/Telegram sessions live in a profile-scoped state.db
+        # and the WebUI's own profile DB is the wrong one. Falls back to
+        # the active profile when the sidecar is missing or unknown.
+        try:
+            sidecar_session = Session.load(sid) if is_safe_session_id(sid) else None
+        except Exception:
+            sidecar_session = None
+        db_path = _resolve_state_db_path(session=sidecar_session)
+        report = read_session_lineage_report(db_path, sid)
         if not report.get("found"):
             return bad(handler, "Session not found", 404)
         return j(handler, report)

--- a/tests/test_profile_aware_state_db.py
+++ b/tests/test_profile_aware_state_db.py
@@ -1,0 +1,220 @@
+"""Regression test for the profile-aware ``state.db`` lookup path.
+
+Background
+==========
+``_active_state_db_path()`` previously returned a single hard-coded path
+derived from the active Hermes profile's home. This broke when the WebUI
+displayed sessions owned by a *different* profile (e.g. a session was
+created by the ``reverse-engineer`` CLI profile, but the WebUI was
+running as ``default``). The session was visible in the JSON sidecar,
+but its messages lived in ``~/.hermes/profiles/reverse-engineer/state.db``
+— a path the WebUI never looked at. Users saw the session in the
+sidebar, opened it, and got an empty transcript.
+
+This module pins the fix: callers that already have a session object
+(``session.profile``) must pass it through so the lookup can target the
+correct profile-scoped ``state.db`` before falling back to the active
+profile.
+
+Test matrix
+-----------
+1. **Session-scoped resolution wins.** When a Session object declares
+   ``profile='reverse-engineer'`` and that profile has its own
+   ``state.db``, the helper returns the reverse-engineer DB — not the
+   active-profile DB.
+2. **Explicit profile arg wins over session profile** (explicit override).
+3. **Active-profile fallback.** When ``session.profile`` is unknown or
+   its profile DB does not exist, the helper falls back to the active
+   profile's DB. Preserves the pre-fix default.
+4. **Original ``_active_state_db_path()`` stays available** for
+   legacy callers and still points at the active profile's DB.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.requires_agent_modules
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_state_db(home: Path, sid: str, msg: str) -> Path:
+    """Create a minimal valid state.db at ``home/state.db`` with one row."""
+    db_path = home / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "CREATE TABLE sessions ("
+            "  id TEXT PRIMARY KEY, source TEXT, title TEXT, model TEXT, "
+            "  started_at REAL, message_count INTEGER, profile TEXT"
+            ")"
+        )
+        conn.execute(
+            "CREATE TABLE messages ("
+            "  id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, "
+            "  role TEXT, content TEXT, timestamp REAL"
+            ")"
+        )
+        conn.execute(
+            "INSERT INTO sessions (id, source, title, model, started_at, "
+            "message_count, profile) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (sid, "cli", "Test session", "test-model", 1.0, 1, "reverse-engineer"),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES (?, ?, ?, ?)",
+            (sid, "user", msg, 1.0),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+class _FakeSession:
+    """Minimal stand-in for ``api.models.Session`` exposing ``.profile``."""
+
+    def __init__(self, profile):
+        self.profile = profile
+
+
+@pytest.fixture
+def multi_profile_home(monkeypatch, tmp_path):
+    """Set up two profile homes each with their own state.db.
+
+    Layout::
+
+        tmp_path/
+            default/state.db            (active profile, sid=default-sid)
+            profiles/reverse-engineer/state.db  (sid=re-sid)
+
+    Returns ``(default_home, re_home)`` so individual tests can target
+    specific profile homes via monkeypatched helpers.
+    """
+    default_home = tmp_path / "default"
+    re_home = tmp_path / "profiles" / "reverse-engineer"
+    default_home.mkdir(parents=True)
+    re_home.mkdir(parents=True)
+
+    _make_state_db(default_home, "default-sid", "default message")
+    _make_state_db(re_home, "re-sid", "reverse-engineer message")
+
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    # Clear the WebUI session-side HERMES_WEBUI_STATE_DIR overrides so
+    # the models module reads the env var fresh.
+    monkeypatch.delenv("HERMES_WEBUI_STATE_DIR", raising=False)
+
+    return default_home, re_home
+
+
+# ---------------------------------------------------------------------------
+# Helper-resolution tests
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_state_db_path_uses_session_profile(monkeypatch, multi_profile_home):
+    """When a Session has profile='reverse-engineer', the helper reads from
+    that profile's state.db, not the active profile's."""
+    from api import profiles
+    from api import models
+
+    default_home, re_home = multi_profile_home
+
+    # Make 'default' the active profile (HERMES_HOME points at default_home).
+    # Patch the active-profile resolution to return default_home.
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(default_home))
+    # Patch profile-home resolution so 'reverse-engineer' maps to re_home.
+    monkeypatch.setattr(
+        profiles, "get_hermes_home_for_profile", lambda name: str(re_home) if name == "reverse-engineer" else str(default_home)
+    )
+
+    session = _FakeSession(profile="reverse-engineer")
+    db_path = models._resolve_state_db_path(session=session)
+
+    assert db_path == re_home / "state.db", (
+        f"Expected reverse-engineer state.db at {re_home / 'state.db'}, "
+        f"got {db_path}. The session.profile hint is being ignored."
+    )
+
+    # Sanity: the chosen DB actually contains the RE message.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT content FROM messages WHERE session_id = ?", ("re-sid",)
+        ).fetchone()
+        assert row is not None and row[0] == "reverse-engineer message"
+    finally:
+        conn.close()
+
+
+def test_resolve_state_db_path_explicit_profile_wins(monkeypatch, multi_profile_home):
+    """An explicit ``profile=`` argument overrides ``session.profile``."""
+    from api import profiles
+    from api import models
+
+    default_home, re_home = multi_profile_home
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(default_home))
+    monkeypatch.setattr(
+        profiles, "get_hermes_home_for_profile", lambda name: str(re_home) if name == "reverse-engineer" else str(default_home)
+    )
+
+    # session says default, but caller explicitly asks for reverse-engineer.
+    session = _FakeSession(profile="default")
+    db_path = models._resolve_state_db_path(session=session, profile="reverse-engineer")
+    assert db_path == re_home / "state.db"
+
+
+def test_resolve_state_db_path_falls_back_when_profile_db_missing(monkeypatch, multi_profile_home):
+    """If the session's profile DB does not exist, fall back to the active
+    profile's DB. This preserves the pre-fix default behavior and keeps
+    the WebUI working for sessions whose profile directory was deleted."""
+    from api import profiles
+    from api import models
+
+    default_home, _re_home = multi_profile_home
+
+    # Delete the reverse-engineer profile DB to simulate the fallback case.
+    re_db = _re_home_from_default(default_home) / "state.db"
+    re_db.unlink()
+
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(default_home))
+    monkeypatch.setattr(
+        profiles, "get_hermes_home_for_profile", lambda name: str(_re_home_from_default(default_home)) if name == "reverse-engineer" else str(default_home)
+    )
+
+    session = _FakeSession(profile="reverse-engineer")
+    db_path = models._resolve_state_db_path(session=session)
+    assert db_path == default_home / "state.db"
+
+
+def test_active_state_db_path_unchanged_for_legacy_callers(monkeypatch, multi_profile_home):
+    """The pre-fix ``_active_state_db_path()`` (no args) must keep returning
+    the active profile's DB. Legacy call sites that don't have a session
+    object must not regress."""
+    from api import models
+    from api import profiles
+
+    default_home, _re_home = multi_profile_home
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(default_home))
+
+    db_path = models._active_state_db_path()
+    assert db_path == default_home / "state.db"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _re_home_from_default(default_home: Path) -> Path:
+    """Convention used by the test fixture: re profile lives at
+    ``default_home/../profiles/reverse-engineer``."""
+    return default_home.parent / "profiles" / "reverse-engineer"


### PR DESCRIPTION
## Summary

Fixes a long-standing issue where the WebUI shows a session in the sidebar but cannot load its messages, when the session was created by a non-default CLI profile (e.g. `reverse-engineer`).

The root cause is `_active_state_db_path()` in `api/models.py` always resolving to the active profile's `state.db`, ignoring the profile that actually owns the session. The JSON sidecar is found (so the row appears in the sidebar), but `state_db_has_session()` returns `False` and `/api/session/lineage/report` looks at the wrong database, so the transcript appears empty.

## Changes

| File | What |
|---|---|
| `api/models.py` | New `_resolve_state_db_path(*, profile, session)` with explicit-priority resolution (`session.profile` > `profile` arg > active). Two existing call sites (`state_db_has_session`, the lineage-report path) now pass the session through. The legacy `_active_state_db_path()` helper is preserved for callers that have no session handle. |
| `api/routes.py` | Re-export `_resolve_state_db_path` from `api.models` so it can be imported from the same place as the other state-db helpers. |
| `tests/test_profile_aware_state_db.py` | Four-test regression suite: (a) `reverse-engineer`-owned session resolves to `profiles/reverse-engineer/state.db`; (b) explicit `profile=` argument beats the session's profile; (c) missing profile-scoped DB falls back to active; (d) the legacy `_active_state_db_path()` is byte-for-byte unchanged. |
| `CHANGELOG.md` | Unreleased entry describing the user-visible fix. |

## Reproduction (before the fix)

1. `hermes -p reverse-engineer` → run a session; messages land in `~/.hermes/profiles/reverse-engineer/state.db`
2. Open that session in the WebUI (default profile): sidebar shows the row, but clicking it renders an empty transcript
3. With the fix: the same WebUI click loads all 547 messages from the profile-scoped DB

## Verification

- 4 new tests pass
- 31 existing state-db regression tests still pass
- Test command: `python -m pytest tests/test_profile_aware_state_db.py tests/test_webui_state_db_reconciliation.py tests/test_issue2762_state_sync_profile_kwarg.py -v`

## Out of scope

- The double-instance question (can two webui processes run on different ports, one per profile?) is now safe to answer: yes, with the same `HERMES_HOME` and different `HERMES_WEBUI_STATE_DIR` / port — each instance will find its own sessions because `_resolve_state_db_path` consults `session.profile` rather than the process environment.
