### PR TITLE
fix(streaming): block interrupt successor while prior run unwinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Interrupt-and-send no longer starts a successor run while the cancelled run is still unwinding.** `cancel_stream()` still clears `active_stream_id` eagerly so Stop remains responsive, but `/api/chat/start` now also checks `ACTIVE_RUNS` by `session_id` before creating a new stream. This closes the window where busy-composer `interrupt` could show a queued user turn in WebUI while a still-active predecessor worker shared the session agent and prevented the successor turn from reaching the durable Agent message chain. (#3808)
+
 ## [v0.51.326] — 2026-06-08 — Release KP (mic STT probe + journal cleanup + schema guard + help hover)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -11439,6 +11439,31 @@ def _active_stream_blocks_chat_start(session, stream_id: str | None) -> bool:
     return False
 
 
+def _active_run_stream_for_session(session_id: str | None) -> str | None:
+    """Return a live worker stream for this session even if sidecar stream id is clear.
+
+    cancel_stream() intentionally clears ``session.active_stream_id`` before the
+    worker thread fully exits so Stop remains responsive. During that unwind
+    window ACTIVE_RUNS is the worker-lifecycle truth; a successor chat/start for
+    the same session must wait or it can reuse the cached agent while the old
+    interrupt is still landing (#3808).
+    """
+    sid = str(session_id or "").strip()
+    if not sid:
+        return None
+    try:
+        from api import config as _live_config
+        with _live_config.ACTIVE_RUNS_LOCK:
+            for run_stream_id, raw in (_live_config.ACTIVE_RUNS or {}).items():
+                stream_id = str((raw or {}).get("stream_id") or run_stream_id or "").strip()
+                run_sid = str((raw or {}).get("session_id") or "").strip()
+                if run_sid == sid and stream_id:
+                    return stream_id
+    except Exception:
+        return None
+    return None
+
+
 def _start_chat_stream_for_session(
     s,
     *,
@@ -11492,6 +11517,14 @@ def _start_chat_stream_for_session(
                     }
                 needs_stale_cleanup = True
             else:
+                blocking_run_stream_id = _active_run_stream_for_session(s.session_id)
+                if blocking_run_stream_id:
+                    diag.stage("response_write") if diag else None
+                    return {
+                        "error": "session already has an active stream",
+                        "active_stream_id": blocking_run_stream_id,
+                        "_status": 409,
+                    }
                 needs_stale_cleanup = False
                 stream_id = uuid.uuid4().hex
                 diag.stage("save_pending_state") if diag else None

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -155,6 +155,129 @@ def test_chat_start_rechecks_active_stream_under_session_lock(monkeypatch, tmp_p
         routes.STREAMS.pop(existing_stream_id, None)
 
 
+def test_chat_start_blocks_same_session_active_run_after_cancel_clears_stream_id(monkeypatch, tmp_path):
+    """Regression for #3808: cancel clears active_stream_id before worker exit.
+
+    interrupt-and-send queues a successor message, then calls cancel_stream().
+    cancel_stream() intentionally clears session.active_stream_id so Stop remains
+    responsive, but the old worker remains in ACTIVE_RUNS until its finally block
+    unregisters it. chat/start must still block by session_id during that window.
+    """
+    config.STREAMS.clear()
+    config.ACTIVE_RUNS.clear()
+    config.SESSION_AGENT_LOCKS.clear()
+
+    class ChatStartSession:
+        session_id = "interrupt-send-session"
+
+        def __init__(self):
+            self.active_stream_id = None
+            self.pending_user_message = None
+            self.pending_attachments = []
+            self.pending_started_at = None
+            self.messages = []
+            self.title = "Interrupt Send"
+            self.worktree_path = None
+            self.workspace = None
+            self.model = None
+            self.model_provider = None
+
+        def save(self, *args, **kwargs):
+            return None
+
+    session = ChatStartSession()
+    old_stream_id = "old-cancelling-stream"
+    config.register_active_run(old_stream_id, session_id=session.session_id, phase="cancelling")
+
+    class NoopThread:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def start(self):
+            return None
+
+    monkeypatch.setattr(routes.uuid, "uuid4", lambda: type("FakeUuid", (), {"hex": "new-stream"})())
+    monkeypatch.setattr(routes, "set_last_workspace", lambda workspace: None)
+    monkeypatch.setattr(routes, "create_stream_channel", lambda: queue.Queue())
+    monkeypatch.setattr(routes.threading, "Thread", NoopThread)
+
+    try:
+        response = routes._start_chat_stream_for_session(
+            session,
+            msg="successor prompt",
+            attachments=[],
+            workspace=str(tmp_path),
+            model="test-model",
+            model_provider=None,
+        )
+
+        assert response["_status"] == 409
+        assert response["active_stream_id"] == old_stream_id
+        assert session.active_stream_id is None
+        assert session.pending_user_message is None
+        assert "new-stream" not in routes.STREAMS
+    finally:
+        config.unregister_active_run(old_stream_id)
+
+
+def test_chat_start_allows_same_session_after_active_run_unregisters(monkeypatch, tmp_path):
+    """The #3808 guard must release once the old worker unregisters ACTIVE_RUNS."""
+    config.STREAMS.clear()
+    config.ACTIVE_RUNS.clear()
+    config.SESSION_AGENT_LOCKS.clear()
+
+    class ChatStartSession:
+        session_id = "interrupt-send-session-released"
+
+        def __init__(self):
+            self.active_stream_id = None
+            self.pending_user_message = None
+            self.pending_attachments = []
+            self.pending_started_at = None
+            self.messages = []
+            self.title = "Interrupt Send"
+            self.worktree_path = None
+            self.workspace = None
+            self.model = None
+            self.model_provider = None
+
+        def save(self, *args, **kwargs):
+            return None
+
+    session = ChatStartSession()
+
+    class NoopThread:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def start(self):
+            return None
+
+    monkeypatch.setattr(routes.uuid, "uuid4", lambda: type("FakeUuid", (), {"hex": "new-stream"})())
+    monkeypatch.setattr(routes, "set_last_workspace", lambda workspace: None)
+    monkeypatch.setattr(routes, "create_stream_channel", lambda: queue.Queue())
+    monkeypatch.setattr(routes.threading, "Thread", NoopThread)
+
+    response = routes._start_chat_stream_for_session(
+        session,
+        msg="successor prompt",
+        attachments=[],
+        workspace=str(tmp_path),
+        model="test-model",
+        model_provider=None,
+    )
+
+    try:
+        assert "error" not in response
+        assert response["stream_id"] == "new-stream"
+        assert session.active_stream_id == "new-stream"
+        assert session.pending_user_message == "successor prompt"
+    finally:
+        routes.STREAMS.pop("new-stream", None)
+
+
 def test_stale_stream_cleanup_does_not_clobber_concurrent_chat_start(monkeypatch):
     """Regression for #1533: stale cleanup must not erase a new stream id.
 


### PR DESCRIPTION
## Thinking Path
- #3808's redacted report and the maintainer comment point to the same race: `cancel_stream()` clears `active_stream_id` before the worker leaves `ACTIVE_RUNS`.
- `/api/chat/start` only checked `ACTIVE_RUNS` through the sidecar `active_stream_id` path, so interrupt-and-send could start a successor while the cancelled worker still owned the cached agent.
- The fix keeps Stop responsive and moves the missing same-session worker guard to chat/start.

## What Changed
- Added `_active_run_stream_for_session()` to detect same-session active workers from `ACTIVE_RUNS` even after `active_stream_id` is clear.
- Block `/api/chat/start` with the existing active-stream 409 shape while such a worker is present.
- Added regressions for the blocked unwind window and the release-after-unregister case.
- Added a changelog entry.

## Why It Matters
- Prevents WebUI from showing a queued user turn while the agent durable chain never receives it.
- Preserves Stop responsiveness and existing frontend requeue behavior.

## Contract Routing
Task type: runtime/session ownership bugfix.

Touched areas: `api/routes.py`, `tests/test_stale_stream_cleanup.py`, `CHANGELOG.md`.

Relevant public docs:
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
- `docs/rfcs/turn-journal.md`

Scope boundaries:
- Does not change `cancel_stream()` eager release.
- Does not redefine Queue/Steer/Interrupt semantics or update #3061.
- Does not expose local session ids or original user text.

Evidence needed before claiming done:
- regression for `ACTIVE_RUNS` same-session block after cancel clears `active_stream_id`
- adjacent cancel/stream ownership tests

## Verification
- `.venv/bin/pytest tests/test_stale_stream_cleanup.py tests/test_stale_stream_writeback.py tests/test_session_lost_response_regression.py tests/test_issue1361_cancel_data_loss.py tests/test_1062_busy_input_modes.py tests/test_cancel_stream_owner_guard.py -q`
- `python3 -m py_compile api/routes.py api/streaming.py`
- `git diff --check`

## Risks / Follow-ups
- No live browser interrupt-and-send repro was run against real 8787 state.
- If a truly stale `ACTIVE_RUNS` entry ever survives without a worker finally, chat/start will keep using the existing active-stream conflict path until runtime health or stale-run repair handles it.
- The broader Queue/Steer/Stop-and-send product contract remains in #3058/#3061.

## Model Used
OpenAI GPT-5 Codex, with local shell and GitHub CLI.

Fixes #3808
