### PR TITLE
fix(session): preserve compression child sidecar tails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Compression continuation sessions keep their latest persisted tail.** Opening a WebUI compression child no longer lets a snapshot parent's `truncation_watermark` hide the child's saved continuation messages, and children that already replay their parent snapshot are no longer stitched back through older ancestors.
+
 ## [v0.51.326] — 2026-06-08 — Release KP (mic STT probe + journal cleanup + schema guard + help hover)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -2893,6 +2893,23 @@ def _message_window_for_display(messages, msg_limit=None, msg_before=None, expan
     return window, start_idx
 
 
+def _messages_start_with_visible_prefix(messages, prefix) -> bool:
+    """Return True when ``messages`` already replays ``prefix`` in display order."""
+    messages = list(messages or [])
+    prefix = list(prefix or [])
+    if not prefix:
+        return True
+    if len(messages) < len(prefix):
+        return False
+    try:
+        return all(
+            _session_message_visible_key(messages[idx]) == _session_message_visible_key(prefix_msg)
+            for idx, prefix_msg in enumerate(prefix)
+        )
+    except Exception:
+        return False
+
+
 def _webui_sidecar_lineage_messages_for_display(session, *, max_hops: int = 20) -> list:
     """Return WebUI sidecar messages stitched across compression snapshots.
 
@@ -2904,6 +2921,7 @@ def _webui_sidecar_lineage_messages_for_display(session, *, max_hops: int = 20) 
     """
     segments = []
     current = session
+    session_messages = list(getattr(session, "messages", []) or [])
     seen = {str(getattr(session, "session_id", "") or "")}
     for _ in range(max(0, int(max_hops))):
         parent_id = str(getattr(current, "parent_session_id", "") or "").strip()
@@ -2912,6 +2930,11 @@ def _webui_sidecar_lineage_messages_for_display(session, *, max_hops: int = 20) 
         parent = Session.load(parent_id)
         if not parent or not getattr(parent, "pre_compression_snapshot", False):
             break
+        if not segments and _messages_start_with_visible_prefix(
+            session_messages,
+            getattr(parent, "messages", []) or [],
+        ):
+            return session_messages
         segments.append(parent)
         seen.add(parent_id)
         current = parent
@@ -2929,7 +2952,7 @@ def _webui_sidecar_lineage_messages_for_display(session, *, max_hops: int = 20) 
     return merge_session_messages_append_only(
         merged,
         getattr(session, "messages", []) or [],
-        truncation_watermark=getattr(session, "truncation_watermark", None),
+        truncation_watermark=None,
     )
 
 
@@ -3342,6 +3365,7 @@ from api.models import (
     merge_session_messages_append_only,
     _active_stream_ids,
     _session_message_merge_key,
+    _session_message_visible_key,
     _is_empty_partial_activity_message,
     _hide_from_default_sidebar,
     prune_session_from_index,

--- a/tests/test_session_lineage_full_transcript.py
+++ b/tests/test_session_lineage_full_transcript.py
@@ -274,3 +274,85 @@ def test_webui_fork_session_does_not_stitch_non_snapshot_parent(monkeypatch):
     assert [m["content"] for m in routes._webui_sidecar_lineage_messages_for_display(child)] == [
         "fork child only",
     ]
+
+
+def test_webui_lineage_display_keeps_child_tail_after_snapshot_watermark(monkeypatch):
+    """A child sidecar watermark must not delete the child's persisted continuation tail."""
+    parent = SimpleNamespace(
+        session_id="parent-watermark",
+        parent_session_id=None,
+        pre_compression_snapshot=True,
+        truncation_watermark=None,
+        messages=[
+            {"role": "user", "content": "parent user", "timestamp": 1000.0},
+            {"role": "assistant", "content": "parent assistant", "timestamp": 1001.0},
+        ],
+    )
+    child = SimpleNamespace(
+        session_id="child-watermark",
+        parent_session_id="parent-watermark",
+        pre_compression_snapshot=False,
+        truncation_watermark=1001.0,
+        messages=[
+            {"role": "user", "content": "child user", "timestamp": 1002.0},
+            {"role": "assistant", "content": "child assistant final", "timestamp": 1003.0},
+        ],
+    )
+    monkeypatch.setattr(routes.Session, "load", lambda sid: parent if sid == "parent-watermark" else None)
+
+    contents = [m["content"] for m in routes._webui_sidecar_lineage_messages_for_display(child)]
+
+    assert contents == [
+        "parent user",
+        "parent assistant",
+        "child user",
+        "child assistant final",
+    ]
+
+
+def test_webui_lineage_display_does_not_restitch_ancestor_when_child_replays_parent(monkeypatch):
+    """If the child sidecar already starts with its direct parent snapshot, use it as-is."""
+    grandparent = SimpleNamespace(
+        session_id="grandparent-replayed",
+        parent_session_id=None,
+        pre_compression_snapshot=True,
+        truncation_watermark=None,
+        messages=[
+            {"role": "user", "content": "grandparent user", "timestamp": 1000.0},
+            {"role": "assistant", "content": "grandparent assistant", "timestamp": 1001.0},
+        ],
+    )
+    parent = SimpleNamespace(
+        session_id="parent-replayed",
+        parent_session_id="grandparent-replayed",
+        pre_compression_snapshot=True,
+        truncation_watermark=1001.0,
+        messages=grandparent.messages + [
+            {"role": "user", "content": "parent user", "timestamp": 1002.0},
+            {"role": "assistant", "content": "parent assistant", "timestamp": 1003.0},
+        ],
+    )
+    child = SimpleNamespace(
+        session_id="child-replayed",
+        parent_session_id="parent-replayed",
+        pre_compression_snapshot=False,
+        truncation_watermark=1001.0,
+        messages=parent.messages + [
+            {"role": "user", "content": "followup user", "timestamp": 1004.0},
+            {"role": "assistant", "content": "latest final answer", "timestamp": 1005.0},
+        ],
+    )
+    by_id = {"parent-replayed": parent, "grandparent-replayed": grandparent}
+    monkeypatch.setattr(routes.Session, "load", lambda sid: by_id.get(sid))
+
+    contents = [m["content"] for m in routes._webui_sidecar_lineage_messages_for_display(child)]
+
+    assert contents == [
+        "grandparent user",
+        "grandparent assistant",
+        "parent user",
+        "parent assistant",
+        "followup user",
+        "latest final answer",
+    ]
+    assert contents[-1] == "latest final answer"


### PR DESCRIPTION
## Thinking Path

A local WebUI session showed the latest assistant tail disappearing after compression lineage stitching. The durable child sidecar still contained the tail; the display merge was dropping it while stitching `pre_compression_snapshot` parents.

This follows up #3770 / #3776. That release correctly stitched snapshot parents into WebUI continuation display, but it also applied the continuation child's own `truncation_watermark` while appending the child's already-persisted sidecar messages.

## What Changed

- Do not apply the child session's `truncation_watermark` when appending the child sidecar during WebUI compression lineage display stitching.
- Add a small visible-prefix guard: if a child sidecar already starts with its direct parent snapshot, use that child transcript as-is instead of walking older ancestors and restitching them again.
- Add regression coverage for:
  - child continuation messages above the snapshot watermark staying visible;
  - a child sidecar that already replays its parent snapshot not being restitched through older ancestors.
- Add a release-note-ready changelog entry.

## Why It Matters

`truncation_watermark` is a sidecar-vs-state.db stale replay guard. It should not delete messages that are already persisted inside the child sidecar being displayed. Applying it in this display stitch path can make `/api/session` appear to end at an older compression snapshot even though the latest child messages are present on disk.

## Contract Routing

Task type: narrow session display / compression lineage correctness fix.

Touched areas:
- `GET /api/session` display transcript coordinate space
- WebUI compression continuation sidecar stitching
- `truncation_watermark` interaction with already-persisted sidecar messages

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
- `docs/rfcs/canonical-session-resolution.md`

State layer changed: visible transcript display merge. Durable sidecar contents are not rewritten.

Invariant: opening a compression continuation must preserve one chronological visible transcript and must not hide persisted child turns while stitching archived snapshot parents.

## Verification

- `python -m py_compile api/routes.py`
- `python -m pytest tests/test_session_lineage_full_transcript.py tests/test_issue2914_truncation_watermark.py -q -o 'addopts='` → `19 passed`
- `git diff --check`
- Added-line secret-ish scan → `added_marker_hits=0`

## Risks / Follow-ups

- This intentionally leaves the existing `truncation_watermark` behavior intact for sidecar-vs-state.db replay filtering; the change only removes it from the already-persisted child sidecar append in the compression lineage display helper.
- Related but separate session discoverability work remains tracked in #3799.
- A separate cache-freshness hardening may be worth a follow-up PR, but is intentionally not included here.

## Model Used

OpenAI GPT-5.5 via Hermes Agent / Codex tool workflow.
