### PR TITLE
fix(session): refresh cached sessions that lag disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Session reloads use the newer sidecar when the in-memory cache lags disk.** `/api/session` no longer serves an older LRU object after another session object has already persisted additional turns for the same session id.
+
 ## [v0.51.326] — 2026-06-08 — Release KP (mic STT probe + journal cleanup + schema guard + help hover)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -2191,6 +2191,33 @@ def _cache_has_stale_unsaved_user_tail(cached, disk_session) -> bool:
     return _message_content_text(cached_tail) == _message_content_text(previous_disk_user)
 
 
+def _cached_session_lags_disk(cached) -> bool:
+    """Return True when a cached full session is older than its sidecar.
+
+    Active/reconnect paths can update the persisted sidecar through another
+    Session object while the LRU cache still holds an older object for the same
+    id. Serving the cache then makes recent assistant results disappear from
+    GET /api/session even though disk and _index.json are correct. Compare only
+    cheap metadata here; full reload happens only if disk is strictly ahead.
+    """
+    if cached is None:
+        return False
+    sid = getattr(cached, 'session_id', None)
+    if not sid:
+        return False
+    try:
+        disk_meta = Session.load_metadata_only(sid)
+    except Exception:
+        return False
+    if disk_meta is None:
+        return False
+    cached_count = len(getattr(cached, 'messages', None) or [])
+    disk_count = _parse_nonnegative_int(getattr(disk_meta, '_metadata_message_count', None))
+    if disk_count is None:
+        disk_count = _lookup_index_message_count(sid)
+    return bool(disk_count is not None and disk_count > cached_count)
+
+
 def get_session(sid, metadata_only=False):
     """Load a session, optionally with metadata only (skipping the messages array).
 
@@ -2220,6 +2247,18 @@ def get_session(sid, metadata_only=False):
                     SESSIONS.pop(sid, None)
             cached = None
     if cached is not None:
+        if not metadata_only and _cached_session_lags_disk(cached):
+            try:
+                disk_session = Session.load(sid)
+                with LOCK:
+                    SESSIONS[sid] = disk_session
+                    SESSIONS.move_to_end(sid)
+                cached = disk_session
+            except Exception:
+                logger.debug(
+                    "cached session disk-freshness check failed for session %s",
+                    sid, exc_info=True,
+                )
         if not metadata_only and _inactive_cache_tail_needs_disk_check(cached):
             try:
                 disk_session = Session.load(sid)

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -566,6 +566,49 @@ def test_api_session_reload_drops_stale_cached_user_tail_after_saved_assistant(m
     assert handler.response_json["session"]["message_count"] == 2
 
 
+def test_get_session_reloads_when_cached_session_lags_disk(monkeypatch, tmp_path):
+    import api.models as models
+
+    sid = "webui_reconcile_cache_lags_disk"
+    old_messages = [
+        {"role": "user", "content": "old user", "timestamp": 1000.0},
+        {"role": "assistant", "content": "old assistant", "timestamp": 1001.0},
+    ]
+    _install_test_session(monkeypatch, tmp_path, sid, old_messages)
+
+    cached = models.Session.load(sid)
+    assert cached is not None
+    cached.active_stream_id = "stream-cache-lags-disk"
+    cached.pending_user_message = "next prompt"
+    models.SESSIONS[sid] = cached
+
+    newer = models.Session(
+        session_id=sid,
+        title="Reconcile",
+        workspace=str(tmp_path),
+        model="test-model",
+        messages=old_messages + [
+            {"role": "user", "content": "new user", "timestamp": 1002.0},
+            {"role": "assistant", "content": "new final answer", "timestamp": 1003.0},
+        ],
+        created_at=1000.0,
+        updated_at=1003.0,
+        active_stream_id="stream-cache-lags-disk",
+        pending_user_message="next prompt",
+    )
+    newer.save(touch_updated_at=False)
+
+    loaded = models.get_session(sid)
+
+    assert [m["content"] for m in loaded.messages] == [
+        "old user",
+        "old assistant",
+        "new user",
+        "new final answer",
+    ]
+    assert models.SESSIONS[sid] is loaded
+
+
 def test_metadata_fast_path_uses_summary_without_full_merge_for_restamped_replays(monkeypatch, tmp_path):
     """Metadata-only /api/session must not full-read and merge transcripts.
 


### PR DESCRIPTION
## Thinking Path

A local WebUI transcript incident had two separate failure layers. The compression lineage display bug is handled separately in #3828. This PR handles the independent cache-hit path: `get_session()` can return an older object from the in-process `SESSIONS` LRU even after another `Session` object has persisted additional turns for the same session id.

The sidecar and `_index.json` can be correct, but `/api/session` still serves the stale cached object until process restart or cache eviction.

## What Changed

- Add a cheap cache-hit freshness check for full `get_session()` loads.
- Compare the cached message count with sidecar metadata / index message count.
- If disk is strictly ahead, reload the full session from disk and replace the LRU entry.
- Add regression coverage for a cached session lagging a newer saved sidecar.
- Add a release-note-ready changelog entry.

## Why It Matters

The visible transcript should use durable sidecar state once it has advanced. Serving a stale LRU object makes recent assistant results look missing even though the session file on disk already contains them.

## Contract Routing

Task type: narrow session cache freshness correctness fix.

Touched areas:
- `api.models.get_session()` cache-hit path
- WebUI session sidecar metadata / index message-count freshness
- `/api/session` visible transcript source selection through `get_session()`

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`

State layer changed: in-memory session cache reconciliation against durable sidecar metadata. Durable sidecars and state.db are not rewritten.

Invariant: if disk is strictly ahead of the cached full session for the same id, `/api/session` must not keep serving the older cached transcript.

## Upstream Landscape

- #3814 optimizes repeated `_index.json` reads during `/api/sessions` metadata refresh; it does not refresh stale full-session LRU entries on `get_session()` cache hits.
- #3815 optimizes startup recovery candidate selection; it does not touch `get_session()` cache freshness.
- #3828 addresses compression lineage display stitching; this PR intentionally keeps cache freshness separate.

## Verification

- `python -m py_compile api/models.py`
- `python -m pytest tests/test_webui_state_db_reconciliation.py -q -o 'addopts='` → `18 passed`
- `git diff --check`
- Added-line secret-ish scan → `added_marker_hits=0`

## Risks / Follow-ups

- The freshness check only reloads when disk metadata reports a strictly larger message count than the cached object. Equal or older disk state keeps the existing cache behavior.
- If #3814 lands first, this should remain conceptually compatible; it may only need a trivial rebase around nearby metadata helper code.

## Model Used

OpenAI GPT-5.5 via Hermes Agent / Codex tool workflow.
