### PR TITLE
fix(compression): preserve full compaction summaries (#3800)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -13646,10 +13646,7 @@ def _handle_session_compress(handler, body):
         txt = raw_text.strip()
         if not txt:
             return None
-        txt = re.sub(r"\s+", " ", txt)
-        if len(txt) > 320:
-            txt = f"{txt[:314]}…"
-        return txt
+        return re.sub(r"\s+", " ", txt)
 
     try:
         require(body, "session_id")

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3256,17 +3256,14 @@ def _is_context_compression_marker(msg):
     return is_context_compression_marker(msg)
 
 
-def _compact_summary_text(raw_text: str | None, limit: int = 320) -> str | None:
+def _compact_summary_text(raw_text: str | None) -> str | None:
     """Normalize a text blob used in compression summary cards."""
     if not isinstance(raw_text, str):
         return None
     txt = raw_text.strip()
     if not txt:
         return None
-    txt = re.sub(r"\s+", " ", txt).strip()
-    if len(txt) > limit:
-        txt = f"{txt[: limit - 6]}…"
-    return txt
+    return re.sub(r"\s+", " ", txt).strip()
 
 
 def _compression_anchor_message_key(message):

--- a/tests/test_issue3800_compaction_summary_length.py
+++ b/tests/test_issue3800_compaction_summary_length.py
@@ -1,0 +1,72 @@
+"""
+Regression coverage for compaction summary normalization (#3800).
+"""
+
+import sys
+import types
+
+from api.routes import _handle_session_compress, get_session
+from api.streaming import _compact_summary_text
+from tests.test_sprint46 import (
+    _FakeAgent,
+    _FakeHandler,
+    _install_fake_compression_runtime,
+    _make_session,
+)
+
+
+def _install_manual_summary(monkeypatch, summary_text):
+    agent_module = types.ModuleType("agent")
+    agent_module.__path__ = []
+    feedback_module = types.ModuleType("agent.manual_compression_feedback")
+    feedback_module.summarize_manual_compression = (
+        lambda original_messages, compressed_messages, before_count, after_count: {
+            "reference_message": summary_text,
+        }
+    )
+    monkeypatch.setitem(sys.modules, "agent", agent_module)
+    monkeypatch.setitem(sys.modules, "agent.manual_compression_feedback", feedback_module)
+
+
+def _run_manual_compaction_summary(monkeypatch, cleanup_test_sessions, summary_text):
+    sid = _make_session()
+    cleanup_test_sessions.append(sid)
+
+    _install_fake_compression_runtime(monkeypatch, _FakeAgent)
+    _install_manual_summary(monkeypatch, summary_text)
+
+    handler = _FakeHandler()
+    _handle_session_compress(handler, {"session_id": sid})
+
+    assert handler.status == 200
+    payload = handler.payload()
+    return payload["session"]["compression_anchor_summary"], get_session(sid)
+
+
+def test_manual_and_streaming_compaction_preserve_long_summaries(
+    monkeypatch, cleanup_test_sessions
+):
+    long_summary = ("Alpha summary line.\n" + "Long detail " * 40 + "tail").strip()
+
+    route_summary, stored_session = _run_manual_compaction_summary(
+        monkeypatch, cleanup_test_sessions, long_summary
+    )
+
+    assert route_summary == _compact_summary_text(long_summary)
+    assert route_summary == stored_session.compression_anchor_summary
+    assert route_summary is not None
+    assert len(route_summary) > 320
+
+
+def test_manual_and_streaming_compaction_normalize_blank_summaries(
+    monkeypatch, cleanup_test_sessions
+):
+    blank_summary = " \n\t  "
+
+    route_summary, stored_session = _run_manual_compaction_summary(
+        monkeypatch, cleanup_test_sessions, blank_summary
+    )
+
+    assert route_summary is None
+    assert route_summary == _compact_summary_text(blank_summary)
+    assert stored_session.compression_anchor_summary is None


### PR DESCRIPTION

## Thinking Path

- The issue is source-confirmed twice: both the route-side and streaming-side compaction helpers slice summaries to 320 characters before they ever reach persisted session state.
- Because the same fallback field is written from two code paths, the safe fix is to keep their normalization behavior aligned instead of removing the cap in only one place.
- The change can stay narrow because the bug is in summary post-processing, not in the compaction request flow itself.

## What Changed

- `api/routes.py`: removed the 320-character truncation while keeping the helper's empty-summary normalization.
- `api/streaming.py`: matched the route-side summary handling so streaming compaction no longer persists a shortened fallback.
- `tests/test_issue3800_compaction_summary_length.py`: added regression coverage for long summaries and whitespace-only inputs across both paths.

## Why It Matters

Users keep the meaningful part of a compaction summary instead of only the first 320 characters, which makes the fallback context far more useful on reload or after persistence. Keeping both paths aligned also prevents route-vs-streaming drift from reintroducing the truncation later.

## Verification

```text
pytest tests/test_issue3800_compaction_summary_length.py tests/test_sprint46.py tests/test_issue2028_compression_anchor_helpers.py -v --timeout=60
pytest tests/ -v --timeout=60
```

## Risks / Follow-ups

- This keeps the existing summary field contract and only removes the arbitrary truncation, so any future summary-size guard should live in one shared helper rather than diverging again.

## Model Used

GPT-5.5 via Codex CLI
