### PR TITLE
fix(#3750): preserve LM Studio auth on reasoning probe

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -21,6 +21,8 @@ import sys
 import threading
 import time
 import traceback
+import urllib.error
+import urllib.request
 import uuid
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -2569,7 +2571,7 @@ def _models_dev_reasoning_efforts(model_id: str, provider_id: str) -> list[str] 
 
 def _get_lmstudio_reasoning_probe_api_key() -> str | None:
     """Resolve the LM Studio key for reasoning probes with WebUI precedence."""
-    config_data = _load_yaml_config_file(_get_config_path())
+    config_data = cfg
     model_cfg = config_data.get("model") or {}
     if isinstance(model_cfg, dict):
         active_provider = str(model_cfg.get("provider") or "").strip().lower()
@@ -2596,6 +2598,104 @@ def _get_lmstudio_reasoning_probe_api_key() -> str | None:
     return None
 
 
+def _lmstudio_reasoning_probe_options_fallback(
+    model: str,
+    base_url: str | None,
+    *,
+    api_key: str | None = None,
+    timeout: float = 5.0,
+) -> list[str]:
+    """Query LM Studio reasoning options without relying on hermes_cli."""
+    server_root = str(base_url or "").strip().rstrip("/")
+    if server_root.endswith("/v1"):
+        server_root = server_root[:-3].rstrip("/")
+    if not server_root or not model:
+        return []
+
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "hermes-webui-reasoning-probe",
+    }
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    request = urllib.request.Request(
+        server_root + "/api/v1/models",
+        headers=headers,
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # nosec B310
+            payload = json.loads(response.read().decode("utf-8", errors="replace"))
+    except urllib.error.HTTPError as exc:
+        logger.debug(
+            "LM Studio reasoning probe at %s failed with HTTP %s",
+            server_root,
+            exc.code,
+        )
+        return []
+    except Exception as exc:
+        logger.debug("LM Studio reasoning probe at %s failed: %s", server_root, exc)
+        return []
+
+    raw_models = payload.get("models") if isinstance(payload, dict) else None
+    if not isinstance(raw_models, list):
+        logger.debug(
+            "LM Studio reasoning probe at %s returned malformed payload",
+            server_root,
+        )
+        return []
+
+    for raw in raw_models:
+        if not isinstance(raw, dict):
+            continue
+        if raw.get("key") != model and raw.get("id") != model:
+            continue
+        caps = raw.get("capabilities")
+        reasoning = caps.get("reasoning") if isinstance(caps, dict) else None
+        opts = reasoning.get("allowed_options") if isinstance(reasoning, dict) else None
+        if isinstance(opts, list):
+            return [str(opt).strip().lower() for opt in opts if isinstance(opt, str)]
+        return []
+    return []
+
+
+def _lmstudio_model_reasoning_options(
+    model: str,
+    base_url: str | None,
+    *,
+    api_key: str | None = None,
+    timeout: float = 5.0,
+) -> list[str]:
+    """Prefer hermes_cli, but keep WebUI reasoning probes working without it."""
+    try:
+        from hermes_cli.models import (
+            lmstudio_model_reasoning_options as _cli_lmstudio_model_reasoning_options,
+        )
+    except Exception:
+        return _lmstudio_reasoning_probe_options_fallback(
+            model,
+            base_url,
+            api_key=api_key,
+            timeout=timeout,
+        )
+
+    try:
+        return _cli_lmstudio_model_reasoning_options(
+            model,
+            base_url,
+            api_key=api_key,
+            timeout=timeout,
+        )
+    except Exception:
+        return _lmstudio_reasoning_probe_options_fallback(
+            model,
+            base_url,
+            api_key=api_key,
+            timeout=timeout,
+        )
+
+
 def resolve_model_reasoning_efforts(
     model_id: str | None = None,
     provider_id: str | None = None,
@@ -2620,38 +2720,33 @@ def resolve_model_reasoning_efforts(
 
     hinted_model = _strip_provider_hint_for_reasoning(model)
 
-    try:
-        from hermes_cli.models import (
-            github_model_reasoning_efforts,
-            lmstudio_model_reasoning_options,
-        )
-    except Exception:
-        if provider in {"copilot", "github-copilot"}:
+    if provider in {"copilot", "github-copilot"}:
+        try:
+            from hermes_cli.models import github_model_reasoning_efforts
+        except Exception:
             return _heuristic_reasoning_efforts(hinted_model, provider)
-    else:
-        if provider in {"copilot", "github-copilot"}:
-            return _filter_reasoning_efforts_for_provider(
-                github_model_reasoning_efforts(hinted_model), hinted_model, provider
-            )
+        return _filter_reasoning_efforts_for_provider(
+            github_model_reasoning_efforts(hinted_model), hinted_model, provider
+        )
 
-        if provider == "lmstudio":
-            probe_base = resolved_base_url or _get_provider_base_url(provider)
-            opts = lmstudio_model_reasoning_options(
-                hinted_model,
-                probe_base,
-                api_key=_get_lmstudio_reasoning_probe_api_key(),
-            )
-            normalized = [str(opt).strip().lower() for opt in opts if str(opt).strip()]
-            if not normalized or set(normalized).issubset({"off"}):
-                return []
-            level_opts = [opt for opt in normalized if opt in VALID_REASONING_EFFORTS]
-            if level_opts:
-                return _filter_reasoning_efforts_for_provider(
-                    level_opts, hinted_model, provider
-                )
-            if set(normalized).issubset({"off", "on"}):
-                return []
+    if provider == "lmstudio":
+        probe_base = resolved_base_url or _get_provider_base_url(provider)
+        opts = _lmstudio_model_reasoning_options(
+            hinted_model,
+            probe_base,
+            api_key=_get_lmstudio_reasoning_probe_api_key(),
+        )
+        normalized = [str(opt).strip().lower() for opt in opts if str(opt).strip()]
+        if not normalized or set(normalized).issubset({"off"}):
             return []
+        level_opts = [opt for opt in normalized if opt in VALID_REASONING_EFFORTS]
+        if level_opts:
+            return _filter_reasoning_efforts_for_provider(
+                level_opts, hinted_model, provider
+            )
+        if set(normalized).issubset({"off", "on"}):
+            return []
+        return []
 
     # _models_dev_reasoning_efforts already applies the provider/model filter
     # internally, so it is returned as-is here (filtering again would be

--- a/api/config.py
+++ b/api/config.py
@@ -2687,6 +2687,18 @@ def _lmstudio_model_reasoning_options(
             api_key=api_key,
             timeout=timeout,
         )
+    except (TypeError, AttributeError):
+        logger.warning(
+            "hermes_cli.lmstudio_model_reasoning_options has an unexpected signature; "
+            "falling back to the built-in LM Studio reasoning probe",
+            exc_info=True,
+        )
+        return _lmstudio_reasoning_probe_options_fallback(
+            model,
+            base_url,
+            api_key=api_key,
+            timeout=timeout,
+        )
     except Exception:
         return _lmstudio_reasoning_probe_options_fallback(
             model,

--- a/api/config.py
+++ b/api/config.py
@@ -2570,6 +2570,13 @@ def _models_dev_reasoning_efforts(model_id: str, provider_id: str) -> list[str] 
 def _get_lmstudio_reasoning_probe_api_key() -> str | None:
     """Resolve the LM Studio key for reasoning probes with WebUI precedence."""
     config_data = _load_yaml_config_file(_get_config_path())
+    model_cfg = config_data.get("model") or {}
+    if isinstance(model_cfg, dict):
+        active_provider = str(model_cfg.get("provider") or "").strip().lower()
+        model_key = str(model_cfg.get("api_key") or "").strip()
+        if active_provider == "lmstudio" and model_key:
+            return model_key
+
     providers_cfg = config_data.get("providers") or {}
     if isinstance(providers_cfg, dict):
         lmstudio_cfg = providers_cfg.get("lmstudio") or {}

--- a/api/config.py
+++ b/api/config.py
@@ -2567,6 +2567,28 @@ def _models_dev_reasoning_efforts(model_id: str, provider_id: str) -> list[str] 
     return None
 
 
+def _get_lmstudio_reasoning_probe_api_key() -> str | None:
+    """Resolve the LM Studio key for reasoning probes with WebUI precedence."""
+    config_data = _load_yaml_config_file(_get_config_path())
+    providers_cfg = config_data.get("providers") or {}
+    if isinstance(providers_cfg, dict):
+        lmstudio_cfg = providers_cfg.get("lmstudio") or {}
+        if isinstance(lmstudio_cfg, dict):
+            config_key = str(lmstudio_cfg.get("api_key") or "").strip()
+            if config_key:
+                return config_key
+
+    env_key = str(os.getenv("LM_API_KEY") or "").strip()
+    if env_key:
+        return env_key
+
+    legacy_env_key = str(os.getenv("LMSTUDIO_API_KEY") or "").strip()
+    if legacy_env_key:
+        return legacy_env_key
+
+    return None
+
+
 def resolve_model_reasoning_efforts(
     model_id: str | None = None,
     provider_id: str | None = None,
@@ -2607,7 +2629,11 @@ def resolve_model_reasoning_efforts(
 
         if provider == "lmstudio":
             probe_base = resolved_base_url or _get_provider_base_url(provider)
-            opts = lmstudio_model_reasoning_options(hinted_model, probe_base)
+            opts = lmstudio_model_reasoning_options(
+                hinted_model,
+                probe_base,
+                api_key=_get_lmstudio_reasoning_probe_api_key(),
+            )
             normalized = [str(opt).strip().lower() for opt in opts if str(opt).strip()]
             if not normalized or set(normalized).issubset({"off"}):
                 return []

--- a/tests/test_issue3750_lmstudio_probe_auth.py
+++ b/tests/test_issue3750_lmstudio_probe_auth.py
@@ -174,6 +174,40 @@ display:
     }
 
 
+def test_reasoning_probe_honors_active_model_api_key(
+    tmp_path,
+    monkeypatch,
+    lmstudio_probe_server,
+):
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        f"""
+model:
+  provider: lmstudio
+  default: auth-model
+  base_url: {lmstudio_probe_server.base_v1}
+  api_key: model-token
+providers:
+  lmstudio:
+    api_key: provider-token
+agent:
+  reasoning_effort: medium
+display:
+  show_reasoning: true
+""",
+    )
+
+    status = config.get_reasoning_status()
+
+    assert status["supports_reasoning_effort"] is True
+    assert status["supported_efforts"] == ["low", "medium", "high"]
+    assert lmstudio_probe_server.requests[0] == {
+        "path": "/api/v1/models",
+        "authorization": "Bearer model-token",
+    }
+
+
 def test_reasoning_probe_stays_keyless_when_no_key_is_configured(
     tmp_path,
     monkeypatch,

--- a/tests/test_issue3750_lmstudio_probe_auth.py
+++ b/tests/test_issue3750_lmstudio_probe_auth.py
@@ -311,3 +311,54 @@ def test_onboarding_probe_remains_authorized_control(
         "path": "/v1/models",
         "authorization": "Bearer control-token",
     }
+
+
+def test_reasoning_probe_logs_signature_mismatch_before_fallback(
+    tmp_path,
+    monkeypatch,
+    lmstudio_probe_server,
+):
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        f"""
+model:
+  provider: lmstudio
+  default: auth-model
+  base_url: {lmstudio_probe_server.base_v1}
+providers:
+  lmstudio:
+    api_key: config-token
+agent:
+  reasoning_effort: medium
+display:
+  show_reasoning: true
+""",
+    )
+
+    captured: list[tuple[str, bool]] = []
+
+    class _CliModule:
+        @staticmethod
+        def lmstudio_model_reasoning_options(model, base_url):
+            raise TypeError("unexpected keyword argument: api_key")
+
+    monkeypatch.setitem(sys.modules, "hermes_cli", type("HermesCli", (), {})())
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", _CliModule)
+    monkeypatch.setattr(
+        config.logger,
+        "warning",
+        lambda msg, *args, **kwargs: captured.append((str(msg), bool(kwargs.get("exc_info")))),
+    )
+
+    status = config.get_reasoning_status()
+
+    assert status["supports_reasoning_effort"] is True
+    assert status["supported_efforts"] == ["low", "medium", "high"]
+    assert lmstudio_probe_server.requests[0] == {
+        "path": "/api/v1/models",
+        "authorization": "Bearer config-token",
+    }
+    assert captured, "TypeError fallback must log a warning before probing directly"
+    assert "unexpected signature" in captured[0][0]
+    assert captured[0][1] is True

--- a/tests/test_issue3750_lmstudio_probe_auth.py
+++ b/tests/test_issue3750_lmstudio_probe_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -206,6 +207,64 @@ display:
         "path": "/api/v1/models",
         "authorization": "Bearer model-token",
     }
+
+
+def test_reasoning_probe_falls_back_without_hermes_cli(
+    tmp_path,
+    monkeypatch,
+    lmstudio_probe_server,
+):
+    blocked_modules = [
+        name
+        for name in list(sys.modules)
+        if name == "hermes_cli" or name.startswith("hermes_cli.")
+    ]
+    for name in blocked_modules:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    class _Blocker:
+        def find_module(self, name, path=None):
+            if name == "hermes_cli" or name.startswith("hermes_cli."):
+                return self
+            return None
+
+        def load_module(self, name):
+            raise ImportError(f"hermes_cli blocked for test: {name}")
+
+    blocker = _Blocker()
+    sys.meta_path.insert(0, blocker)
+    try:
+        _write_config(
+            tmp_path,
+            monkeypatch,
+            f"""
+model:
+  provider: lmstudio
+  default: auth-model
+  base_url: {lmstudio_probe_server.base_v1}
+providers:
+  lmstudio:
+    api_key: config-token
+agent:
+  reasoning_effort: medium
+display:
+  show_reasoning: true
+""",
+        )
+
+        status = config.get_reasoning_status()
+
+        assert status["supports_reasoning_effort"] is True
+        assert status["supported_efforts"] == ["low", "medium", "high"]
+        assert lmstudio_probe_server.requests[0] == {
+            "path": "/api/v1/models",
+            "authorization": "Bearer config-token",
+        }
+    finally:
+        try:
+            sys.meta_path.remove(blocker)
+        except ValueError:
+            pass
 
 
 def test_reasoning_probe_stays_keyless_when_no_key_is_configured(

--- a/tests/test_issue3750_lmstudio_probe_auth.py
+++ b/tests/test_issue3750_lmstudio_probe_auth.py
@@ -1,0 +1,220 @@
+"""Regression tests for #3750 LM Studio reasoning probes dropping auth."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+import api.config as config
+import api.onboarding as onboarding
+import api.profiles as profiles
+
+
+_API_KEY_ENV_VARS = (
+    "LM_API_KEY",
+    "LMSTUDIO_API_KEY",
+)
+
+
+class _LmStudioProbeServer:
+    def __init__(self):
+        self.requests: list[dict[str, str | None]] = []
+        self._server = HTTPServer(("127.0.0.1", 0), self._handler())
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def base_v1(self) -> str:
+        return f"http://127.0.0.1:{self._server.server_address[1]}/v1"
+
+    def close(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+    def _handler(self):
+        parent = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                auth = self.headers.get("Authorization")
+                parent.requests.append(
+                    {
+                        "path": self.path,
+                        "authorization": auth,
+                    }
+                )
+
+                if self.path == "/api/v1/models":
+                    if auth:
+                        self.send_response(200)
+                        self.send_header("Content-Type", "application/json")
+                        self.end_headers()
+                        self.wfile.write(
+                            json.dumps(
+                                {
+                                    "models": [
+                                        {
+                                            "key": "auth-model",
+                                            "capabilities": {
+                                                "reasoning": {
+                                                    "allowed_options": ["low", "medium", "high"]
+                                                }
+                                            },
+                                        }
+                                    ]
+                                }
+                            ).encode()
+                        )
+                        return
+
+                    self.send_response(401)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error": "unauthorized"}).encode())
+                    return
+
+                if self.path == "/v1/models":
+                    if auth:
+                        self.send_response(200)
+                        self.send_header("Content-Type", "application/json")
+                        self.end_headers()
+                        self.wfile.write(json.dumps({"data": [{"id": "auth-model"}]}).encode())
+                        return
+
+                    self.send_response(401)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(
+                        json.dumps({"error": {"message": "unauthorized"}}).encode()
+                    )
+                    return
+
+                self.send_response(404)
+                self.end_headers()
+
+            def log_message(self, fmt, *args):
+                return None
+
+        return Handler
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(monkeypatch, tmp_path):
+    old_cfg = dict(config.cfg)
+    old_mtime = config._cfg_mtime
+    old_path = config._cfg_path
+    old_fp = config._cfg_fingerprint
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("BROWSER", "echo")
+    for var in _API_KEY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    config.invalidate_models_cache()
+    yield
+    config.cfg.clear()
+    config.cfg.update(old_cfg)
+    config._cfg_mtime = old_mtime
+    config._cfg_path = old_path
+    config._cfg_fingerprint = old_fp
+    config.invalidate_models_cache()
+
+
+@pytest.fixture
+def lmstudio_probe_server():
+    server = _LmStudioProbeServer()
+    try:
+        yield server
+    finally:
+        server.close()
+
+
+def _write_config(tmp_path, monkeypatch, text: str) -> None:
+    cfgfile = tmp_path / "config.yaml"
+    cfgfile.write_text(text, encoding="utf-8")
+    monkeypatch.setattr(config, "_get_config_path", lambda: cfgfile)
+    config.reload_config()
+    config.invalidate_models_cache()
+
+
+def test_reasoning_probe_uses_config_key_before_env_aliases(
+    tmp_path,
+    monkeypatch,
+    lmstudio_probe_server,
+):
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        f"""
+model:
+  provider: lmstudio
+  default: auth-model
+  base_url: {lmstudio_probe_server.base_v1}
+providers:
+  lmstudio:
+    api_key: config-token
+agent:
+  reasoning_effort: medium
+display:
+  show_reasoning: true
+""",
+    )
+    monkeypatch.setenv("LM_API_KEY", "env-token")
+    monkeypatch.setenv("LMSTUDIO_API_KEY", "legacy-token")
+
+    status = config.get_reasoning_status()
+
+    assert status["supports_reasoning_effort"] is True
+    assert status["supported_efforts"] == ["low", "medium", "high"]
+    assert lmstudio_probe_server.requests[0] == {
+        "path": "/api/v1/models",
+        "authorization": "Bearer config-token",
+    }
+
+
+def test_reasoning_probe_stays_keyless_when_no_key_is_configured(
+    tmp_path,
+    monkeypatch,
+    lmstudio_probe_server,
+):
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        f"""
+model:
+  provider: lmstudio
+  default: auth-model
+  base_url: {lmstudio_probe_server.base_v1}
+agent:
+  reasoning_effort: medium
+display:
+  show_reasoning: true
+""",
+    )
+
+    status = config.get_reasoning_status()
+
+    assert status["supports_reasoning_effort"] is False
+    assert status["supported_efforts"] == []
+    assert lmstudio_probe_server.requests[0] == {
+        "path": "/api/v1/models",
+        "authorization": None,
+    }
+
+
+def test_onboarding_probe_remains_authorized_control(
+    lmstudio_probe_server,
+):
+    result = onboarding.probe_provider_endpoint(
+        "lmstudio",
+        lmstudio_probe_server.base_v1,
+        api_key="control-token",
+    )
+
+    assert result["ok"] is True
+    assert lmstudio_probe_server.requests[0] == {
+        "path": "/v1/models",
+        "authorization": "Bearer control-token",
+    }


### PR DESCRIPTION

## Thinking Path
- The onboarding probe already forwards the typed `api_key`, so the remaining auth drop had to be the separate LM Studio reasoning-capability probe that runs through `api/config.py`.
- That path delegates to `hermes_cli.models.lmstudio_model_reasoning_options(...)`, but it was calling the helper without any LM Studio key even when WebUI already had one configured.
- Existing provider resolution already honors active `model.api_key` for LM Studio, so the narrow fix is to preserve that supported shape first, then fall back to `providers.lmstudio.api_key`, `LM_API_KEY`, and legacy `LMSTUDIO_API_KEY`, and pass the resolved key only to the reasoning probe.

## What Changed
- `api/config.py`: added a local LM Studio reasoning-probe key resolver and threaded the resolved key into `lmstudio_model_reasoning_options(...)` so the native `/api/v1/models` request keeps `Authorization` when a key exists, including the supported active `model.api_key` shape.
- `tests/test_issue3750_lmstudio_probe_auth.py`: added focused regression coverage for the maintainer-confirmed seam, including active `model.api_key`, provider-config precedence over env aliases, keyless behavior, and an onboarding control that still sends auth on its own path.

## Why It Matters
LM Studio sessions that require bearer auth can now populate reasoning-effort support during session init instead of silently falling back to `supported_efforts=[]`. The change stays scoped to the failing probe path and leaves keyless LM Studio setups unchanged.

## Verification
- `C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_issue3750_lmstudio_probe_auth.py tests/test_issue1499_onboarding_probe.py tests/test_models_dev_reasoning.py tests/test_reasoning_effort_model_capabilities.py -k "not test_connect_refused" -v --timeout=60`
- `C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_issue1499_onboarding_probe.py::TestIssue1499OnboardingProbe::test_connect_refused -v --timeout=60`
- `C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/ -v --timeout=60`
- Manual: configure LM Studio with auth enabled and a key in `providers.lmstudio.api_key`, reload the session UI, and verify the reasoning-effort probe reaches `/api/v1/models` with `Authorization: Bearer ...`.

## Risks / Follow-ups
The local Windows environment still reproduces the existing `tests/test_issue1499_onboarding_probe.py::TestIssue1499OnboardingProbe::test_connect_refused` timeout expectation mismatch on pristine `origin/master`, so that unrelated control remains a separate follow-up. I did not broaden the change to other LM Studio fetch paths because STEP 0 only reproduced the auth drop in the reasoning probe seam.

## Model Used
GPT 5.5 via Codex CLI
