### PR TITLE
Release v0.51.328 — Release KR (#3750 LM Studio probe auth + #3800 full compaction summaries)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.328] — 2026-06-08 — Release KR (LM Studio probe auth + full compaction summaries)
+
+### Fixed
+- **Reasoning-effort detection no longer 401s against a keyed LM Studio server.** The reasoning probe now resolves the LM Studio API key (active-model config → `providers.lmstudio` → `LM_API_KEY`/`LMSTUDIO_API_KEY`) instead of probing keyless. (#3750, @rodboev)
+- **Compaction summaries are no longer truncated at 320 characters.** The full compaction summary text is preserved in the summary card (the prior clip also broke a long-summary reference-card match). (#3800, @rodboev)
+
 ## [v0.51.327] — 2026-06-08 — Release KQ (brick wave: session-cache freshness + compression-tail + interrupt race)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -2402,6 +2402,35 @@ def _models_dev_reasoning_efforts(model_id: str, provider_id: str) -> list[str] 
     return None
 
 
+def _get_lmstudio_reasoning_probe_api_key() -> str | None:
+    """Resolve the LM Studio key for reasoning probes with WebUI precedence."""
+    config_data = _load_yaml_config_file(_get_config_path())
+    model_cfg = config_data.get("model") or {}
+    if isinstance(model_cfg, dict):
+        active_provider = str(model_cfg.get("provider") or "").strip().lower()
+        model_key = str(model_cfg.get("api_key") or "").strip()
+        if active_provider == "lmstudio" and model_key:
+            return model_key
+
+    providers_cfg = config_data.get("providers") or {}
+    if isinstance(providers_cfg, dict):
+        lmstudio_cfg = providers_cfg.get("lmstudio") or {}
+        if isinstance(lmstudio_cfg, dict):
+            config_key = str(lmstudio_cfg.get("api_key") or "").strip()
+            if config_key:
+                return config_key
+
+    env_key = str(os.getenv("LM_API_KEY") or "").strip()
+    if env_key:
+        return env_key
+
+    legacy_env_key = str(os.getenv("LMSTUDIO_API_KEY") or "").strip()
+    if legacy_env_key:
+        return legacy_env_key
+
+    return None
+
+
 def resolve_model_reasoning_efforts(
     model_id: str | None = None,
     provider_id: str | None = None,
@@ -2442,7 +2471,11 @@ def resolve_model_reasoning_efforts(
 
         if provider == "lmstudio":
             probe_base = resolved_base_url or _get_provider_base_url(provider)
-            opts = lmstudio_model_reasoning_options(hinted_model, probe_base)
+            opts = lmstudio_model_reasoning_options(
+                hinted_model,
+                probe_base,
+                api_key=_get_lmstudio_reasoning_probe_api_key(),
+            )
             normalized = [str(opt).strip().lower() for opt in opts if str(opt).strip()]
             if not normalized or set(normalized).issubset({"off"}):
                 return []

--- a/api/routes.py
+++ b/api/routes.py
@@ -13724,10 +13724,7 @@ def _handle_session_compress(handler, body):
         txt = raw_text.strip()
         if not txt:
             return None
-        txt = re.sub(r"\s+", " ", txt)
-        if len(txt) > 320:
-            txt = f"{txt[:314]}…"
-        return txt
+        return re.sub(r"\s+", " ", txt)
 
     try:
         require(body, "session_id")

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3256,17 +3256,14 @@ def _is_context_compression_marker(msg):
     return is_context_compression_marker(msg)
 
 
-def _compact_summary_text(raw_text: str | None, limit: int = 320) -> str | None:
+def _compact_summary_text(raw_text: str | None) -> str | None:
     """Normalize a text blob used in compression summary cards."""
     if not isinstance(raw_text, str):
         return None
     txt = raw_text.strip()
     if not txt:
         return None
-    txt = re.sub(r"\s+", " ", txt).strip()
-    if len(txt) > limit:
-        txt = f"{txt[: limit - 6]}…"
-    return txt
+    return re.sub(r"\s+", " ", txt).strip()
 
 
 def _compression_anchor_message_key(message):

--- a/tests/test_issue3750_lmstudio_probe_auth.py
+++ b/tests/test_issue3750_lmstudio_probe_auth.py
@@ -1,0 +1,254 @@
+"""Regression tests for #3750 LM Studio reasoning probes dropping auth."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+import api.config as config
+import api.onboarding as onboarding
+import api.profiles as profiles
+
+
+_API_KEY_ENV_VARS = (
+    "LM_API_KEY",
+    "LMSTUDIO_API_KEY",
+)
+
+
+class _LmStudioProbeServer:
+    def __init__(self):
+        self.requests: list[dict[str, str | None]] = []
+        self._server = HTTPServer(("127.0.0.1", 0), self._handler())
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def base_v1(self) -> str:
+        return f"http://127.0.0.1:{self._server.server_address[1]}/v1"
+
+    def close(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+    def _handler(self):
+        parent = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                auth = self.headers.get("Authorization")
+                parent.requests.append(
+                    {
+                        "path": self.path,
+                        "authorization": auth,
+                    }
+                )
+
+                if self.path == "/api/v1/models":
+                    if auth:
+                        self.send_response(200)
+                        self.send_header("Content-Type", "application/json")
+                        self.end_headers()
+                        self.wfile.write(
+                            json.dumps(
+                                {
+                                    "models": [
+                                        {
+                                            "key": "auth-model",
+                                            "capabilities": {
+                                                "reasoning": {
+                                                    "allowed_options": ["low", "medium", "high"]
+                                                }
+                                            },
+                                        }
+                                    ]
+                                }
+                            ).encode()
+                        )
+                        return
+
+                    self.send_response(401)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error": "unauthorized"}).encode())
+                    return
+
+                if self.path == "/v1/models":
+                    if auth:
+                        self.send_response(200)
+                        self.send_header("Content-Type", "application/json")
+                        self.end_headers()
+                        self.wfile.write(json.dumps({"data": [{"id": "auth-model"}]}).encode())
+                        return
+
+                    self.send_response(401)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(
+                        json.dumps({"error": {"message": "unauthorized"}}).encode()
+                    )
+                    return
+
+                self.send_response(404)
+                self.end_headers()
+
+            def log_message(self, fmt, *args):
+                return None
+
+        return Handler
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(monkeypatch, tmp_path):
+    old_cfg = dict(config.cfg)
+    old_mtime = config._cfg_mtime
+    old_path = config._cfg_path
+    old_fp = config._cfg_fingerprint
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("BROWSER", "echo")
+    for var in _API_KEY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    config.invalidate_models_cache()
+    yield
+    config.cfg.clear()
+    config.cfg.update(old_cfg)
+    config._cfg_mtime = old_mtime
+    config._cfg_path = old_path
+    config._cfg_fingerprint = old_fp
+    config.invalidate_models_cache()
+
+
+@pytest.fixture
+def lmstudio_probe_server():
+    server = _LmStudioProbeServer()
+    try:
+        yield server
+    finally:
+        server.close()
+
+
+def _write_config(tmp_path, monkeypatch, text: str) -> None:
+    cfgfile = tmp_path / "config.yaml"
+    cfgfile.write_text(text, encoding="utf-8")
+    monkeypatch.setattr(config, "_get_config_path", lambda: cfgfile)
+    config.reload_config()
+    config.invalidate_models_cache()
+
+
+def test_reasoning_probe_uses_config_key_before_env_aliases(
+    tmp_path,
+    monkeypatch,
+    lmstudio_probe_server,
+):
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        f"""
+model:
+  provider: lmstudio
+  default: auth-model
+  base_url: {lmstudio_probe_server.base_v1}
+providers:
+  lmstudio:
+    api_key: config-token
+agent:
+  reasoning_effort: medium
+display:
+  show_reasoning: true
+""",
+    )
+    monkeypatch.setenv("LM_API_KEY", "env-token")
+    monkeypatch.setenv("LMSTUDIO_API_KEY", "legacy-token")
+
+    status = config.get_reasoning_status()
+
+    assert status["supports_reasoning_effort"] is True
+    assert status["supported_efforts"] == ["low", "medium", "high"]
+    assert lmstudio_probe_server.requests[0] == {
+        "path": "/api/v1/models",
+        "authorization": "Bearer config-token",
+    }
+
+
+def test_reasoning_probe_honors_active_model_api_key(
+    tmp_path,
+    monkeypatch,
+    lmstudio_probe_server,
+):
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        f"""
+model:
+  provider: lmstudio
+  default: auth-model
+  base_url: {lmstudio_probe_server.base_v1}
+  api_key: model-token
+providers:
+  lmstudio:
+    api_key: provider-token
+agent:
+  reasoning_effort: medium
+display:
+  show_reasoning: true
+""",
+    )
+
+    status = config.get_reasoning_status()
+
+    assert status["supports_reasoning_effort"] is True
+    assert status["supported_efforts"] == ["low", "medium", "high"]
+    assert lmstudio_probe_server.requests[0] == {
+        "path": "/api/v1/models",
+        "authorization": "Bearer model-token",
+    }
+
+
+def test_reasoning_probe_stays_keyless_when_no_key_is_configured(
+    tmp_path,
+    monkeypatch,
+    lmstudio_probe_server,
+):
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        f"""
+model:
+  provider: lmstudio
+  default: auth-model
+  base_url: {lmstudio_probe_server.base_v1}
+agent:
+  reasoning_effort: medium
+display:
+  show_reasoning: true
+""",
+    )
+
+    status = config.get_reasoning_status()
+
+    assert status["supports_reasoning_effort"] is False
+    assert status["supported_efforts"] == []
+    assert lmstudio_probe_server.requests[0] == {
+        "path": "/api/v1/models",
+        "authorization": None,
+    }
+
+
+def test_onboarding_probe_remains_authorized_control(
+    lmstudio_probe_server,
+):
+    result = onboarding.probe_provider_endpoint(
+        "lmstudio",
+        lmstudio_probe_server.base_v1,
+        api_key="control-token",
+    )
+
+    assert result["ok"] is True
+    assert lmstudio_probe_server.requests[0] == {
+        "path": "/v1/models",
+        "authorization": "Bearer control-token",
+    }

--- a/tests/test_issue3800_compaction_summary_length.py
+++ b/tests/test_issue3800_compaction_summary_length.py
@@ -1,0 +1,72 @@
+"""
+Regression coverage for compaction summary normalization (#3800).
+"""
+
+import sys
+import types
+
+from api.routes import _handle_session_compress, get_session
+from api.streaming import _compact_summary_text
+from tests.test_sprint46 import (
+    _FakeAgent,
+    _FakeHandler,
+    _install_fake_compression_runtime,
+    _make_session,
+)
+
+
+def _install_manual_summary(monkeypatch, summary_text):
+    agent_module = types.ModuleType("agent")
+    agent_module.__path__ = []
+    feedback_module = types.ModuleType("agent.manual_compression_feedback")
+    feedback_module.summarize_manual_compression = (
+        lambda original_messages, compressed_messages, before_count, after_count: {
+            "reference_message": summary_text,
+        }
+    )
+    monkeypatch.setitem(sys.modules, "agent", agent_module)
+    monkeypatch.setitem(sys.modules, "agent.manual_compression_feedback", feedback_module)
+
+
+def _run_manual_compaction_summary(monkeypatch, cleanup_test_sessions, summary_text):
+    sid = _make_session()
+    cleanup_test_sessions.append(sid)
+
+    _install_fake_compression_runtime(monkeypatch, _FakeAgent)
+    _install_manual_summary(monkeypatch, summary_text)
+
+    handler = _FakeHandler()
+    _handle_session_compress(handler, {"session_id": sid})
+
+    assert handler.status == 200
+    payload = handler.payload()
+    return payload["session"]["compression_anchor_summary"], get_session(sid)
+
+
+def test_manual_and_streaming_compaction_preserve_long_summaries(
+    monkeypatch, cleanup_test_sessions
+):
+    long_summary = ("Alpha summary line.\n" + "Long detail " * 40 + "tail").strip()
+
+    route_summary, stored_session = _run_manual_compaction_summary(
+        monkeypatch, cleanup_test_sessions, long_summary
+    )
+
+    assert route_summary == _compact_summary_text(long_summary)
+    assert route_summary == stored_session.compression_anchor_summary
+    assert route_summary is not None
+    assert len(route_summary) > 320
+
+
+def test_manual_and_streaming_compaction_normalize_blank_summaries(
+    monkeypatch, cleanup_test_sessions
+):
+    blank_summary = " \n\t  "
+
+    route_summary, stored_session = _run_manual_compaction_summary(
+        monkeypatch, cleanup_test_sessions, blank_summary
+    )
+
+    assert route_summary is None
+    assert route_summary == _compact_summary_text(blank_summary)
+    assert stored_session.compression_anchor_summary is None


### PR DESCRIPTION
## Release v0.51.328 — Release KR (Phase-1 batch: LM Studio probe auth + full compaction summaries)

Two narrow backend bug fixes, both @rodboev, both CI-green-on-fresh-base, deep-reviewed.

### #3837 (#3750) — preserve LM Studio auth on the reasoning probe
The reasoning-effort detection probe ran keyless, so a keyed LM Studio server 401'd it. Now resolves the key (active-model config → `providers.lmstudio` → `LM_API_KEY`/`LMSTUDIO_API_KEY`) and passes it to the probe. Key is only resolved/passed inside the `provider == "lmstudio"` branch (no cross-provider leak).

### #3835 (#3800) — preserve full compaction summaries
Removes the 320-char truncation in `_compact_summary_text` + `_handle_session_compress` so the full summary text is preserved. Opus noted the trailing `…` was also breaking a long-summary reference-card substring match — so this is a net-positive secondary fix too.

### Gate
- Full suite **8277 passed, 0 failed**; targeted tests (6) pass.
- **Codex SAFE TO SHIP**, **Opus SHIP BOTH** — no MUST-FIX. Verified: key precedence + no cross-provider leak; no consumer relied on the 320-char cap.
- Deferred follow-ups (non-blocking): consolidate the duplicate `_compact_summary_text` definitions; optional TypeError-tolerant fallback on the probe kwarg.
- ruff clean. Rebased clean onto fresh master (both were stale; #3837's CI failures were stale-base — green on fresh).

Co-authored-by: rodboev <rodboev@users.noreply.github.com>
