### PR TITLE
fix: make error toasts dismissible #3842

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Error toasts can now be dismissed immediately.** Error toasts already stayed visible longer and exposed a Copy button, but they could still block nearby workspace controls until the timeout expired. They now include an explicit Dismiss button, and non-error toasts can also be cleared with a click on the toast body. Adds regression coverage for the dismiss helper, dismiss-button markup hook, and shared toast-button styling. (#3842)
+
 ## [v0.51.330] — 2026-06-08 — Release KT (api docstring backfill)
 
 ### Changed

--- a/static/style.css
+++ b/static/style.css
@@ -1208,8 +1208,8 @@
   .toast.success{background:color-mix(in srgb,var(--success) 14%,var(--surface));border-color:color-mix(in srgb,var(--success) 45%,var(--surface));color:var(--success);}
   .toast.error{background:color-mix(in srgb,var(--error) 14%,var(--surface));border-color:color-mix(in srgb,var(--error) 45%,var(--surface));color:var(--error);}
   .toast-message{min-width:0;overflow-wrap:anywhere;white-space:pre-wrap;}
-  .toast-copy{border:1px solid currentColor;background:transparent;color:inherit;border-radius:8px;padding:4px 8px;font:inherit;font-size:12px;font-weight:700;cursor:pointer;opacity:.85;}
-  .toast-copy:hover,.toast-copy:focus-visible{opacity:1;background:color-mix(in srgb,currentColor 10%,transparent);outline:none;}
+  .toast-copy,.toast-dismiss{border:1px solid currentColor;background:transparent;color:inherit;border-radius:8px;padding:4px 8px;font:inherit;font-size:12px;font-weight:700;cursor:pointer;opacity:.85;}
+  .toast-copy:hover,.toast-copy:focus-visible,.toast-dismiss:hover,.toast-dismiss:focus-visible{opacity:1;background:color-mix(in srgb,currentColor 10%,transparent);outline:none;}
   .toast.warning{background:color-mix(in srgb,var(--warning) 14%,var(--surface));border-color:color-mix(in srgb,var(--warning) 45%,var(--surface));color:var(--warning);}
   .onboarding-overlay{position:fixed;inset:0;z-index:1050;background:rgba(7,12,19,.78);backdrop-filter:blur(8px);display:none;align-items:center;justify-content:center;padding:24px;}
   .onboarding-card{width:min(980px,100%);max-height:min(760px,94vh);overflow:auto;border:1px solid var(--accent-bg-strong);border-radius:24px;background:linear-gradient(180deg,rgba(20,30,44,.98),rgba(11,17,27,.98));box-shadow:0 24px 80px rgba(0,0,0,.45);}

--- a/static/ui.js
+++ b/static/ui.js
@@ -4311,6 +4311,12 @@ const TOAST_DEFAULT_MS=2800;
 const TOAST_ERROR_DEFAULT_MS=20000;
 function clearToastDismissTimer(el){if(!el)return;clearTimeout(el._t);el._t=null;}
 function setToastDismissTimer(el,duration){if(!el)return;clearToastDismissTimer(el);el._t=setTimeout(()=>{el.classList.remove('show');},duration);}
+function dismissToast(btnOrEl){
+  const el=btnOrEl&&btnOrEl.closest?btnOrEl.closest('#toast'):(btnOrEl&&btnOrEl.id==='toast'?btnOrEl:null);
+  if(!el)return;
+  clearToastDismissTimer(el);
+  el.classList.remove('show');
+}
 function copyToastText(btn){
   const el=btn&&btn.closest?btn.closest('#toast'):null;
   const text=el?(el.dataset.toastMessage||el.textContent||''):'';
@@ -4324,12 +4330,13 @@ function showToast(msg,ms,type){
   const duration=(ms==null)?(t==='error'?TOAST_ERROR_DEFAULT_MS:TOAST_DEFAULT_MS):ms;
   el.className='toast show '+t;
   el.dataset.toastMessage=s;
-  if(t==='error') el.innerHTML=`<span class="toast-message">${esc(s)}</span><button class="toast-copy" type="button" data-toast-copy="1" onclick="copyToastText(this);event.stopPropagation()">Copy</button>`;
+  if(t==='error') el.innerHTML=`<span class="toast-message">${esc(s)}</span><button class="toast-copy" type="button" data-toast-copy="1" onclick="copyToastText(this);event.stopPropagation()">Copy</button><button class="toast-dismiss" type="button" aria-label="Dismiss error toast" data-toast-dismiss="1" onclick="dismissToast(this);event.stopPropagation()">Dismiss</button>`;
   else el.textContent=s;
   el.onmouseenter=()=>clearToastDismissTimer(el);
   el.onmouseleave=()=>setToastDismissTimer(el,duration);
   el.onfocusin=()=>clearToastDismissTimer(el);
   el.onfocusout=()=>setToastDismissTimer(el,duration);
+  el.onclick=t==='error'?null:()=>dismissToast(el);
   setToastDismissTimer(el,duration);
 }
 

--- a/tests/test_issue3842_dismissible_error_toast.py
+++ b/tests/test_issue3842_dismissible_error_toast.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+def test_error_toast_renders_explicit_dismiss_button():
+    ui = read("static/ui.js")
+
+    assert 'class="toast-dismiss"' in ui, (
+        "Error toasts must render an explicit dismiss button so users can clear "
+        "blocking toasts immediately instead of waiting for the timeout (#3842)."
+    )
+    assert 'data-toast-dismiss="1"' in ui, (
+        "Dismiss button should expose a stable hook for future DOM/runtime tests."
+    )
+    assert "dismissToast(this)" in ui, (
+        "Error toast dismiss control must call a dedicated dismiss helper."
+    )
+
+
+def test_error_toast_dismiss_helper_clears_show_state_and_timer():
+    ui = read("static/ui.js")
+
+    assert "function dismissToast(btnOrEl)" in ui, "Dismiss helper missing from static/ui.js"
+    assert "clearToastDismissTimer(el);" in ui, (
+        "Dismiss helper must clear the auto-dismiss timer before hiding the toast."
+    )
+    assert "el.classList.remove('show');" in ui, (
+        "Dismiss helper must hide the toast immediately by removing the show class."
+    )
+
+
+def test_toast_styles_define_dismiss_button_layout():
+    style = read("static/style.css")
+
+    assert ".toast-dismiss" in style, (
+        "Toast stylesheet must define the dismiss button so it matches the existing "
+        "copy-button affordance without adding layout regressions."
+    )
+    assert ".toast-dismiss:hover,.toast-dismiss:focus-visible" in style, (
+        "Dismiss button should have explicit hover/focus-visible styling for keyboard "
+        "and pointer accessibility."
+    )


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI aims for near-CLI parity in a browser, which includes keeping transient status UI informative without letting it interfere with core controls.
- Error toasts are intentionally more prominent and longer-lived than ordinary success/info toasts, but the current implementation gives them no user-controlled dismissal path.
- The toast host is a single fixed element in the top-right of the viewport, so when an error happens near workspace interactions it can overlap controls until the timeout expires.
- This PR fixes that narrow UX gap without redesigning the toast system: error toasts get an explicit dismiss affordance, and non-error toasts can be cleared with a direct click.
- The result is that users can immediately clear a blocking toast and continue using workspace/session controls without waiting for the timer.

Closes #3842.

## What Changed
- Added a dedicated `dismissToast()` helper in `static/ui.js`.
- Updated `showToast()` so error toasts render a `Dismiss` button alongside the existing `Copy` button.
- Wired non-error toasts so clicking the toast body dismisses them immediately.
- Reused the existing toast button styling pattern for the new dismiss control in `static/style.css`.
- Added regression coverage in `tests/test_issue3842_dismissible_error_toast.py`.
- Added an Unreleased changelog entry for the user-visible behavior change.

## Why It Matters
Users currently have to wait for an error toast timeout even when the toast is covering nearby controls. This is especially awkward around workspace interactions, where the top-right fixed toast can obstruct controls the user wants to use immediately after the error. A small explicit dismiss control removes that friction without reducing the visibility of errors.

## Verification
Automated:
- `uv run --with pytest pytest tests/test_issue3842_dismissible_error_toast.py -q`
- `uv run --with pytest pytest tests/test_model_scope_copy.py -q`
- `uv run --with pytest pytest tests/test_static_js_runtime_lint.py -q` *(skipped locally because the optional runtime-lint toolchain is not installed in this environment)*

Manual / code-level evidence:
- Confirmed the pre-fix implementation used a single global `<div id="toast">` fixed at `top: 24px; right: 24px;`.
- Confirmed pre-fix `showToast()` rendered error toasts with only a `Copy` button and no dismiss affordance.
- Confirmed the new implementation clears the timer before hiding the toast, so manual dismiss does not leave a stale timeout path behind.

## Risks / Follow-ups
- This is intentionally narrow and does not change toast placement or move to a stacked-toast system.
- The non-error click-to-dismiss behavior is small but user-visible; if maintainers prefer to scope the change strictly to error toasts, that can be reduced easily.
- A future follow-up could add a browser-driven DOM/runtime test for interactive toast dismissal if broader toast behavior changes continue.

## Model Used
- Provider: custom `llm-proxy - codex` (Hermes Agent + Hermes WebUI),
  `antigravity-cli`
- Model: `codex/gpt-5.4`,
  `antigravity_cl/gemini-3.5-flash-high`
- Breakdown:
  - implemented the toast-dismiss UX change and regression test in Hermes
    WebUI
  - ran an agy read-only review and fixed the hidden-toast pointer-events
    regression it found
  - verified with targeted pytest runs, including the pre-existing toast
    regression test, before force-pushing the updated branch
