### PR TITLE
Release v0.51.331 — Release KU (dismissible error toasts, #3844)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.331] — 2026-06-08 — Release KU (dismissible error toasts)
+
+### Fixed
+- **Error toasts can now be dismissed immediately.** Error toasts default to a 20-second timeout and can sit over workspace controls; they now render an explicit **Dismiss** button (alongside the existing Copy button), and non-error toasts dismiss on click. Both clear the auto-dismiss timer and hide the toast right away. (#3844, @claw-io, fixes #3842)
+
 ## [v0.51.330] — 2026-06-08 — Release KT (api docstring backfill)
 
 ### Changed

--- a/static/style.css
+++ b/static/style.css
@@ -1208,8 +1208,8 @@
   .toast.success{background:color-mix(in srgb,var(--success) 14%,var(--surface));border-color:color-mix(in srgb,var(--success) 45%,var(--surface));color:var(--success);}
   .toast.error{background:color-mix(in srgb,var(--error) 14%,var(--surface));border-color:color-mix(in srgb,var(--error) 45%,var(--surface));color:var(--error);}
   .toast-message{min-width:0;overflow-wrap:anywhere;white-space:pre-wrap;}
-  .toast-copy{border:1px solid currentColor;background:transparent;color:inherit;border-radius:8px;padding:4px 8px;font:inherit;font-size:12px;font-weight:700;cursor:pointer;opacity:.85;}
-  .toast-copy:hover,.toast-copy:focus-visible{opacity:1;background:color-mix(in srgb,currentColor 10%,transparent);outline:none;}
+  .toast-copy,.toast-dismiss{border:1px solid currentColor;background:transparent;color:inherit;border-radius:8px;padding:4px 8px;font:inherit;font-size:12px;font-weight:700;cursor:pointer;opacity:.85;}
+  .toast-copy:hover,.toast-copy:focus-visible,.toast-dismiss:hover,.toast-dismiss:focus-visible{opacity:1;background:color-mix(in srgb,currentColor 10%,transparent);outline:none;}
   .toast.warning{background:color-mix(in srgb,var(--warning) 14%,var(--surface));border-color:color-mix(in srgb,var(--warning) 45%,var(--surface));color:var(--warning);}
   .onboarding-overlay{position:fixed;inset:0;z-index:1050;background:rgba(7,12,19,.78);backdrop-filter:blur(8px);display:none;align-items:center;justify-content:center;padding:24px;}
   .onboarding-card{width:min(980px,100%);max-height:min(760px,94vh);overflow:auto;border:1px solid var(--accent-bg-strong);border-radius:24px;background:linear-gradient(180deg,rgba(20,30,44,.98),rgba(11,17,27,.98));box-shadow:0 24px 80px rgba(0,0,0,.45);}

--- a/static/ui.js
+++ b/static/ui.js
@@ -4311,6 +4311,12 @@ const TOAST_DEFAULT_MS=2800;
 const TOAST_ERROR_DEFAULT_MS=20000;
 function clearToastDismissTimer(el){if(!el)return;clearTimeout(el._t);el._t=null;}
 function setToastDismissTimer(el,duration){if(!el)return;clearToastDismissTimer(el);el._t=setTimeout(()=>{el.classList.remove('show');},duration);}
+function dismissToast(btnOrEl){
+  const el=btnOrEl&&btnOrEl.closest?btnOrEl.closest('#toast'):(btnOrEl&&btnOrEl.id==='toast'?btnOrEl:null);
+  if(!el)return;
+  clearToastDismissTimer(el);
+  el.classList.remove('show');
+}
 function copyToastText(btn){
   const el=btn&&btn.closest?btn.closest('#toast'):null;
   const text=el?(el.dataset.toastMessage||el.textContent||''):'';
@@ -4324,12 +4330,13 @@ function showToast(msg,ms,type){
   const duration=(ms==null)?(t==='error'?TOAST_ERROR_DEFAULT_MS:TOAST_DEFAULT_MS):ms;
   el.className='toast show '+t;
   el.dataset.toastMessage=s;
-  if(t==='error') el.innerHTML=`<span class="toast-message">${esc(s)}</span><button class="toast-copy" type="button" data-toast-copy="1" onclick="copyToastText(this);event.stopPropagation()">Copy</button>`;
+  if(t==='error') el.innerHTML=`<span class="toast-message">${esc(s)}</span><button class="toast-copy" type="button" data-toast-copy="1" onclick="copyToastText(this);event.stopPropagation()">Copy</button><button class="toast-dismiss" type="button" aria-label="Dismiss error toast" data-toast-dismiss="1" onclick="dismissToast(this);event.stopPropagation()">Dismiss</button>`;
   else el.textContent=s;
   el.onmouseenter=()=>clearToastDismissTimer(el);
   el.onmouseleave=()=>setToastDismissTimer(el,duration);
   el.onfocusin=()=>clearToastDismissTimer(el);
   el.onfocusout=()=>setToastDismissTimer(el,duration);
+  el.onclick=t==='error'?null:()=>dismissToast(el);
   setToastDismissTimer(el,duration);
 }
 

--- a/tests/test_issue3842_dismissible_error_toast.py
+++ b/tests/test_issue3842_dismissible_error_toast.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+def test_error_toast_renders_explicit_dismiss_button():
+    ui = read("static/ui.js")
+
+    assert 'class="toast-dismiss"' in ui, (
+        "Error toasts must render an explicit dismiss button so users can clear "
+        "blocking toasts immediately instead of waiting for the timeout (#3842)."
+    )
+    assert 'data-toast-dismiss="1"' in ui, (
+        "Dismiss button should expose a stable hook for future DOM/runtime tests."
+    )
+    assert "dismissToast(this)" in ui, (
+        "Error toast dismiss control must call a dedicated dismiss helper."
+    )
+
+
+def test_error_toast_dismiss_helper_clears_show_state_and_timer():
+    ui = read("static/ui.js")
+
+    assert "function dismissToast(btnOrEl)" in ui, "Dismiss helper missing from static/ui.js"
+    assert "clearToastDismissTimer(el);" in ui, (
+        "Dismiss helper must clear the auto-dismiss timer before hiding the toast."
+    )
+    assert "el.classList.remove('show');" in ui, (
+        "Dismiss helper must hide the toast immediately by removing the show class."
+    )
+
+
+def test_toast_styles_define_dismiss_button_layout():
+    style = read("static/style.css")
+
+    assert ".toast-dismiss" in style, (
+        "Toast stylesheet must define the dismiss button so it matches the existing "
+        "copy-button affordance without adding layout regressions."
+    )
+    assert ".toast-dismiss:hover,.toast-dismiss:focus-visible" in style, (
+        "Dismiss button should have explicit hover/focus-visible styling for keyboard "
+        "and pointer accessibility."
+    )


### PR DESCRIPTION
## Release v0.51.331 — Release KU (dismissible error toasts)

Absorbs **#3844** (@claw-io) — fixes **#3842**.

### What ships
- **Error toasts can now be dismissed immediately.** Error toasts default to a 20s timeout (`TOAST_ERROR_DEFAULT_MS`) and can sit over workspace controls with no early-dismiss affordance. They now render an explicit **Dismiss** button alongside the existing Copy button, and non-error toasts dismiss on click. A new top-level `dismissToast()` helper clears the auto-dismiss timer and hides the toast right away.

### Scope
Frontend-only: `static/ui.js` (+`dismissToast`, error-toast button, info-toast click-to-dismiss), `static/style.css` (`.toast-dismiss` reuses the `.toast-copy` affordance), plus a structural test.

### Gate
- Full suite **8278 passed**, 9 skipped, 3 xpassed (4:26)
- `node -c` ✓ · no merge markers ✓ · ESLint runtime gate **CLEAN** · scope-undef gate **CLEAN** (no inline-onclick ReferenceError class) · ruff forward gate **CLEAN**
- Opus advisory: **SHIP-safe as-is** — preserves all toast lifecycle behavior (timer, hover-pause, focus-pause, Copy), no XSS surface, `aria-label` present
- Greptile P2 flag (dead-branch fallback in `dismissToast`) evaluated → harmless defensive guard, not a blocker
- revert-guard: PR parent == current master tip, zero divergence (false-positive on `?` count; verified two-dot == three-dot diff)

Co-authored-by: claw-io <claw-io@users.noreply.github.com>
