### PR TITLE
fix: clarify post-create workspace prompt (#3856)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **The post-create-folder workspace prompt now offers `No` instead of `Cancel` for the negative action.** The folder has already been created when the follow-up dialog asks whether to add it as a workspace/space, so `No` more clearly answers the question and avoids implying that folder creation itself will be undone. (#3856, @b3nw)
+
 ## [v0.51.337] — 2026-06-09 — Release LA (model-picker keyboard nav + mobile new-chat)
 
 ### Added

--- a/static/ui.js
+++ b/static/ui.js
@@ -11125,6 +11125,7 @@ async function promptNewFolder(){
         title:t('folder_add_as_space_title'),
         message:t('folder_add_as_space_msg'),
         confirmLabel:t('folder_add_as_space_btn'),
+        cancelLabel:t('status_no'),
         focusCancel:true
       });
       if(addAsSpace){

--- a/tests/test_issue1786_workspace_heading_actions.py
+++ b/tests/test_issue1786_workspace_heading_actions.py
@@ -41,3 +41,11 @@ def test_workspace_heading_affordance_requires_workspace():
     guard_idx = UI_JS.find("if(!(S.session&&S.session.workspace)) return;", context_idx)
     prevent_idx = UI_JS.find("e.preventDefault()", context_idx)
     assert context_idx < guard_idx < prevent_idx
+
+
+def test_new_folder_add_as_workspace_prompt_uses_no_for_cancel_label():
+    """The post-create-folder workspace prompt should offer an explicit 'No' option."""
+    assert "title:t('folder_add_as_space_title')" in UI_JS
+    assert "message:t('folder_add_as_space_msg')" in UI_JS
+    assert "confirmLabel:t('folder_add_as_space_btn')" in UI_JS
+    assert "cancelLabel:t('status_no')" in UI_JS


### PR DESCRIPTION
## Thinking Path
- Reproduced the code path for folder creation in the workspace panel and traced the follow-up prompt in `static/ui.js`.
- Confirmed the folder is already created before the second dialog appears, so the existing `Cancel` label can incorrectly imply that folder creation itself will be undone.
- Chose the smallest safe UX fix: keep the existing prompt flow and change only the negative action label to `No` via `cancelLabel:t('status_no')`.
- Added a focused regression test matching the existing static-source test style in the workspace heading test file.

Closes #3856 

## What Changed
- Updated the post-folder-create "add this folder as a workspace/space" dialog to label the negative action as `No` instead of relying on the default `Cancel` button text.
- Added regression coverage asserting that the dialog now passes `cancelLabel:t('status_no')`.

## Why It Matters
- The folder has already been created when this dialog appears.
- `Cancel` can suggest that the folder creation itself will be cancelled, which is misleading.
- `No` more clearly answers the actual question being asked: whether to add the newly created folder as a workspace/space.

## Verification
- `uv run --with pytest python -m pytest tests/test_issue1786_workspace_heading_actions.py -q -o addopts=''`
  - Result: `4 passed in 1.52s`
- Diff vs `upstream/master` is limited to:
  - `static/ui.js`
  - `tests/test_issue1786_workspace_heading_actions.py`

## Risks / Follow-ups
- This change intentionally stays narrow and does not address broader localization cleanup for `status_yes` / `status_no` across all locale bundles.
- If maintainers want stricter wording symmetry later, they may prefer dedicated dialog yes/no keys or a different confirm label pairing.

## Model Used
- Provider: custom llm-proxy, hermes-agent + hermes-webui prompting
- Model: codex/gpt-5.4, antigravity/gemini-flash-3.5-high
- Breakdown:
  - implemented the UI label change and regression test
  - ran a read-only agy review for additional scrutiny
  - verified the targeted pytest coverage locally with `uv run --with pytest`
