### PR TITLE
settings: align Worklog defaults with live-to-final model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Settings now treats Worklog details as folded by default.** The Appearance toggle is now worded as an opt-in to open Worklog details automatically, while the default remains folded; changing the control now immediately opens or folds Thinking cards, Tool cards, and multi-tool Worklog groups. The deprecated **Compact tool activity** renderer switch is no longer shown in Preferences, and existing installs stay on the Worklog renderer even if they previously saved the legacy setting as disabled.
+
 ## [v0.51.340] — 2026-06-09 — Release LD (background-task agent wakeup in WebUI) — ⛔ HELD pending independent review
 
 ### Added
@@ -38,7 +41,6 @@
 ### Added
 - **Keyboard navigation in the model picker.** With the model dropdown open, ↑/↓ move a highlight through the filtered models (wrapping at the ends) and Enter selects the highlighted one; Escape closes. The highlight reuses the existing hover styling and is invisible until you use the keyboard. (#2952, #2791, @Sanjays2402)
 - **A "New chat" button in the mobile titlebar.** On narrow screens the app titlebar now shows a `+` button to start a new conversation without opening the sidebar; it shares the existing reload-button styling and mirrors the new-chat in-flight/disabled state. (#3531, @franksong2702)
-
 ## [v0.51.336] — 2026-06-08 — Release KZ (fix inline-thinking streaming perf regression)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -5488,7 +5488,7 @@ _SETTINGS_DEFAULTS = {
     "font_size": "default",  # small | default | large | xlarge
     "session_jump_buttons": False,  # show Start/End transcript jump pills
     "session_endless_scroll": False,  # auto-load older transcript pages while scrolling upward
-    "activity_feed_expanded_default": False,  # expand Activity disclosures by default for new turns
+    "worklog_details_expanded_default": False,  # opt-in: expand Worklog details by default; default remains folded
     "pinned_sessions_limit": 3,  # maximum active pinned sessions shown in the sidebar
     "inflight_state_max_sessions": 8,  # max active-stream recovery snapshots kept in browser localStorage
     "inflight_state_max_messages": 24,  # max recent messages kept per recovery snapshot
@@ -5505,7 +5505,7 @@ _SETTINGS_DEFAULTS = {
     "rtl": False,  # right-to-left chat layout (chat messages + composer only)
     "notifications_enabled": False,  # browser notification when tab is in background
     "show_thinking": True,  # show/hide thinking/reasoning blocks in chat view
-    "simplified_tool_calling": True,  # render tools/thinking as compact inline timeline activity
+    "simplified_tool_calling": True,  # legacy compatibility; Worklog renderer remains enabled
     "terminal_auto_expand_on_output": False,  # auto-expand terminal panel when output arrives while collapsed
     "api_redact_enabled": True,  # redact sensitive data (API keys, secrets) from API responses
     "dashboard_plugins": {},  # plugin_name -> bool, opt-in per plugin (default off per PF-10b)
@@ -5514,7 +5514,13 @@ _SETTINGS_DEFAULTS = {
     "busy_input_mode": "queue",  # behavior when sending while agent is running: queue | interrupt | steer
     "password_hash": None,  # PBKDF2-HMAC-SHA256 hash; None = auth disabled
 }
-_SETTINGS_LEGACY_DROP_KEYS = {"assistant_language", "bubble_layout", "default_model"}
+_SETTINGS_LEGACY_DROP_KEYS = {
+    "assistant_language",
+    "bubble_layout",
+    "default_model",
+    "activity_feed_expanded_default",
+    "simplified_tool_calling",
+}
 _SETTINGS_THEME_VALUES = {"light", "dark", "system"}
 _SETTINGS_SKIN_VALUES = {
     "default",
@@ -5595,6 +5601,13 @@ def load_settings() -> dict:
         try:
             stored = json.loads(SETTINGS_FILE.read_text(encoding="utf-8"))
             if isinstance(stored, dict):
+                if (
+                    "worklog_details_expanded_default" not in stored
+                    and "activity_feed_expanded_default" in stored
+                ):
+                    settings["worklog_details_expanded_default"] = bool(
+                        stored.get("activity_feed_expanded_default")
+                    )
                 settings.update(
                     {
                         k: v
@@ -5621,6 +5634,7 @@ def load_settings() -> dict:
 _SETTINGS_ALLOWED_KEYS = set(_SETTINGS_DEFAULTS.keys()) - {
     "password_hash",
     "default_model",
+    "simplified_tool_calling",
 }
 _SETTINGS_ENUM_VALUES = {
     "send_key": {"enter", "ctrl+enter"},
@@ -5655,12 +5669,11 @@ _SETTINGS_BOOL_KEYS = {
     "rtl",
     "notifications_enabled",
     "show_thinking",
-    "simplified_tool_calling",
     "terminal_auto_expand_on_output",
     "api_redact_enabled",
     "session_jump_buttons",
     "session_endless_scroll",
-    "activity_feed_expanded_default",
+    "worklog_details_expanded_default",
 }
 # Language codes are validated as short alphanumeric BCP-47-like tags (e.g. 'en', 'zh', 'fr')
 _SETTINGS_LANG_RE = __import__("re").compile(r"^[a-zA-Z]{2,10}(-[a-zA-Z0-9]{2,8})?$")
@@ -5669,6 +5682,15 @@ _SETTINGS_LANG_RE = __import__("re").compile(r"^[a-zA-Z]{2,10}(-[a-zA-Z0-9]{2,8}
 def save_settings(settings: dict) -> dict:
     """Save settings to disk. Returns the merged settings. Ignores unknown keys."""
     current = load_settings()
+    if (
+        "worklog_details_expanded_default" not in settings
+        and "activity_feed_expanded_default" in settings
+    ):
+        settings["worklog_details_expanded_default"] = settings.get(
+            "activity_feed_expanded_default"
+        )
+    settings.pop("activity_feed_expanded_default", None)
+    settings.pop("simplified_tool_calling", None)
     pending_theme = current.get("theme")
     pending_skin = current.get("skin")
     theme_was_explicit = False

--- a/static/boot.js
+++ b/static/boot.js
@@ -1794,9 +1794,13 @@ function applyBotName(){
     if(s.default_workspace) S._profileDefaultWorkspace=s.default_workspace;
     window._whatsNewSummaryEnabled=!!s.whats_new_summary_enabled;
     window._showThinking=s.show_thinking!==false;
-    window._simplifiedToolCalling=s.simplified_tool_calling!==false;
+    window._simplifiedToolCalling=true;
     window._terminalAutoExpandOnOutput=!!s.terminal_auto_expand_on_output;
-    window._activityFeedExpandedDefault=!!s.activity_feed_expanded_default;
+    window._worklogDetailsExpandedByDefault=!!(
+      Object.prototype.hasOwnProperty.call(s,'worklog_details_expanded_default')
+        ? s.worklog_details_expanded_default
+        : s.activity_feed_expanded_default
+    );
     window._sidebarDensity=(s.sidebar_density==='detailed'?'detailed':'compact');
     window._pinnedSessionsLimit=parseInt(s.pinned_sessions_limit||3,10)||3;
     window._inflightStateLimits={

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -558,8 +558,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Load older messages while scrolling up',
 
     settings_desc_session_endless_scroll: 'When enabled, older messages load automatically as you scroll upward. When disabled, use the older-messages button.',
-    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
-    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
+    settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
+    settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Sidebar tabs',
     settings_desc_tab_visibility: 'Choose which tabs appear in the sidebar and rail. Drag chips to reorder them. Chat and Settings are always visible.',
@@ -1953,8 +1953,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Carica messaggi precedenti scorrendo in alto',
 
     settings_desc_session_endless_scroll: 'Se abilitato, i messaggi precedenti si caricano automaticamente scorrendo in alto. Se disabilitato, usa il pulsante messaggi precedenti.',
-    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
-    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
+    settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
+    settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Schede della barra laterale',
     settings_desc_tab_visibility: 'Scegli quali schede mostrare nella barra laterale e nel rail. Chat e Impostazioni sono sempre visibili.',
@@ -3340,8 +3340,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: '上スクロールで古いメッセージを読み込む',
 
     settings_desc_session_endless_scroll: '有効にすると、上にスクロールしたとき古いメッセージを自動で読み込みます。無効の場合は古いメッセージボタンを使います。',
-    settings_label_activity_feed_expanded_default: 'アクティビティフィードをデフォルトで展開',
-    settings_desc_activity_feed_expanded_default: '新しいアクティビティの詳細を自動的に展開し、ツールやモデルの進捗をクリックなしで確認できます。ターンごとの手動折りたたみ/展開は優先されます。',
+    settings_label_worklog_details_expanded_default: 'Worklog の詳細を自動的に開く',
+    settings_desc_worklog_details_expanded_default: '有効にすると、新しい Worklog の詳細が展開された状態で始まり、ツール、Thinking、進捗カードをクリックなしで確認できます。無効の場合、Worklog の詳細はデフォルトで折りたたまれます。ターンごとの手動折りたたみ/展開は優先されます。',
 
     settings_label_tab_visibility: 'サイドバータブ',
     settings_desc_tab_visibility: 'サイドバーとレールに表示するタブを選択します。チャットと設定は常に表示されます。',
@@ -5335,8 +5335,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Загружать старые сообщения при прокрутке вверх',
 
     settings_desc_session_endless_scroll: 'Если включено, старые сообщения загружаются автоматически при прокрутке вверх. Если выключено, используйте кнопку загрузки старых сообщений.',
-    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
-    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
+    settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
+    settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Вкладки боковой панели',
     settings_desc_tab_visibility: 'Выберите, какие вкладки отображаются на боковой панели и в рейле. Чат и настройки всегда видны.',
@@ -6647,8 +6647,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Cargar mensajes antiguos al desplazarse hacia arriba',
 
     settings_desc_session_endless_scroll: 'Si está activado, los mensajes antiguos se cargan automáticamente al desplazarte hacia arriba. Si está desactivado, usa el botón de mensajes antiguos.',
-    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
-    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
+    settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
+    settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Pestañas de la barra lateral',
     settings_desc_tab_visibility: 'Elige qué pestañas aparecen en la barra lateral y el rail. Chat y Configuración siempre están visibles.',
@@ -7662,8 +7662,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Ältere Nachrichten beim Hochscrollen laden',
 
     settings_desc_session_endless_scroll: 'Wenn aktiviert, werden ältere Nachrichten beim Hochscrollen automatisch geladen. Wenn deaktiviert, nutzt du den Button für ältere Nachrichten.',
-    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
-    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
+    settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
+    settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Seitenleiste-Tabs',
     settings_desc_tab_visibility: 'Wähle, welche Tabs in der Seitenleiste und im Rail angezeigt werden. Ziehe die Chips, um die Reihenfolge zu ändern. Chat und Einstellungen sind immer sichtbar.',
@@ -9306,8 +9306,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: '向上滚动时加载更早的消息',
 
     settings_desc_session_endless_scroll: '启用后，向上滚动时会自动加载更早的消息。禁用时请使用加载更早消息按钮。',
-    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
-    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
+    settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
+    settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: '侧边栏标签',
     settings_desc_tab_visibility: '选择在侧边栏和导航栏中显示哪些标签。聊天和设置始终可见。',
@@ -10024,8 +10024,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: '向上捲動時載入較早訊息',
 
     settings_desc_session_endless_scroll: '啟用後，向上捲動時會自動載入較早訊息。停用時請使用載入較早訊息按鈕。',
-    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
-    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
+    settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
+    settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: '側邊欄標籤',
     settings_desc_tab_visibility: '選擇在側邊欄和導覽列中顯示哪些標籤。聊天和設定始終可見。',
@@ -11301,8 +11301,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Carregar mensagens antigas ao rolar para cima',
 
     settings_desc_session_endless_scroll: 'Quando ativado, mensagens antigas carregam automaticamente ao rolar para cima. Quando desativado, use o botão de mensagens antigas.',
-    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
-    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
+    settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
+    settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Abas da barra lateral',
     settings_desc_tab_visibility: 'Escolha quais abas aparecem na barra lateral e no rail. Chat e Configurações estão sempre visíveis.',
@@ -12589,8 +12589,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: '위로 스크롤할 때 이전 메시지 불러오기',
 
     settings_desc_session_endless_scroll: '활성화하면 위로 스크롤할 때 이전 메시지를 자동으로 불러옵니다. 비활성화하면 이전 메시지 버튼을 사용합니다.',
-    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
-    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
+    settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
+    settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: '사이드바 탭',
     settings_desc_tab_visibility: '사이드바와 레일에 표시할 탭을 선택하세요. 채팅과 설정은 항상 표시됩니다.',
@@ -13894,8 +13894,8 @@ const LOCALES = {
     settings_desc_terminal_auto_expand: 'Développer automatiquement le panneau de terminal réduit lorsqu\'une commande en cours d\'exécution émet une nouvelle sortie.',
     settings_label_session_endless_scroll: 'Charger les anciens messages en faisant défiler vers le haut',
     settings_desc_session_endless_scroll: 'Lorsqu\'ils sont activés, les anciens messages se chargent automatiquement lorsque vous faites défiler vers le haut. Lorsqu\'il est désactivé, utilisez le bouton des messages plus anciens.',
-    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
-    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
+    settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
+    settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Onglets de la barre latérale',
     settings_desc_tab_visibility: 'Choisissez quels onglets apparaissent dans la barre latérale et le rail. Chat et Paramètres sont toujours visibles.',
@@ -15300,8 +15300,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Yukarı kaydırırken eski mesajları yükle',
 
     settings_desc_session_endless_scroll: 'Etkinleştirildiğinde, yukarı doğru kaydırdığınızda eski mesajlar otomatik olarak yüklenir. Devre dışı bırakıldığında eski mesajlar düğmesini kullanın.',
-    settings_label_activity_feed_expanded_default: 'Expand activity feed by default',
-    settings_desc_activity_feed_expanded_default: 'Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.',
+    settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
+    settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 
     settings_label_tab_visibility: 'Kenar çubuğu sekmeleri',
     settings_desc_tab_visibility: 'Kenar çubuğunda ve rayda hangi sekmelerin görüneceğini seçin. Sohbet ve Ayarlar her zaman görünür durumdadır.',
@@ -16698,8 +16698,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Ładuj starsze wiadomości podczas przewijania w górę',
 
     settings_desc_session_endless_scroll: 'Gdy ta opcja jest włączona, starsze wiadomości ładują się automatycznie przy przewijaniu w górę. Gdy jest wyłączona, użyj przycisku wczytywania starszych wiadomości.',
-    settings_label_activity_feed_expanded_default: 'Rozwiń kanał aktywności domyślnie',
-    settings_desc_activity_feed_expanded_default: 'Rozwijaj nowe szczegóły Aktywności automatycznie, aby postęp narzędzi i modeli był widoczny bez dodatkowego kliknięcia. Ręczne decyzje o zwinięciu/rozwinięciu w danej turze mają pierwszeństwo.',
+    settings_label_worklog_details_expanded_default: 'Otwieraj szczegóły Worklog automatycznie',
+    settings_desc_worklog_details_expanded_default: 'Gdy ta opcja jest włączona, nowe szczegóły Worklog zaczynają rozwinięte, dzięki czemu karty narzędzi, Thinking i postępu są widoczne bez dodatkowego kliknięcia. Gdy jest wyłączona, szczegóły Worklog pozostają domyślnie zwinięte. Ręczne decyzje o zwinięciu/rozwinięciu w danej turze mają pierwszeństwo.',
 
     settings_label_tab_visibility: 'Karty paska bocznego',
     settings_desc_tab_visibility: 'Wybierz, które karty pojawiają się na pasku bocznym i szynie. Przeciągnij elementy, aby zmienić ich kolejność. Czat i Ustawienia są zawsze widoczne.',

--- a/static/index.html
+++ b/static/index.html
@@ -1006,10 +1006,10 @@
             </div>
             <div class="settings-field" style="margin-top:8px">
               <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
-                <input type="checkbox" id="settingsActivityFeedExpandedDefault" style="width:15px;height:15px;accent-color:var(--accent)">
-                <span data-i18n="settings_label_activity_feed_expanded_default">Expand activity feed by default</span>
+                <input type="checkbox" id="settingsWorklogDetailsExpandedDefault" style="width:15px;height:15px;accent-color:var(--accent)">
+                <span data-i18n="settings_label_worklog_details_expanded_default">Open Worklog details automatically</span>
               </label>
-              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_activity_feed_expanded_default">Open new Activity disclosures automatically so tool and model progress is visible without an extra click. Per-turn manual collapse/expand choices still win.</div>
+              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_worklog_details_expanded_default">When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.</div>
             </div>
             <div class="settings-field">
               <label id="tabVisibilityLabel" data-i18n="settings_label_tab_visibility">Sidebar tabs</label>
@@ -1154,13 +1154,6 @@
                 <span data-i18n="settings_label_fade_text_effect">Fade text effect</span>
               </label>
               <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_fade_text_effect">Fade newly streamed words in while the assistant is responding. Similar to OpenWebUI; off by default for maximum performance.</div>
-            </div>
-            <div class="settings-field">
-              <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
-                <input type="checkbox" id="settingsSimplifiedToolCalling" style="width:15px;height:15px;accent-color:var(--accent)">
-                <span>Compact tool activity</span>
-              </label>
-              <div style="font-size:11px;color:var(--muted);margin-top:4px">Show thinking and tool calls as compact inline activity while preserving the agent timeline.</div>
             </div>
             <div class="settings-field">
               <label style="display:flex;align-items:center;gap:8px;cursor:pointer">

--- a/static/panels.js
+++ b/static/panels.js
@@ -6097,13 +6097,15 @@ function _applyTtsEnabled(enabled){
 }
 
 function _appearancePayloadFromUi(){
+  const worklogDetailsExpanded=!!($('settingsWorklogDetailsExpandedDefault')||{}).checked;
   return {
     theme: ($('settingsTheme')||{}).value || localStorage.getItem('hermes-theme') || 'dark',
     skin: ($('settingsSkin')||{}).value || localStorage.getItem('hermes-skin') || 'default',
     font_size: ($('settingsFontSize')||{}).value || localStorage.getItem('hermes-font-size') || 'default',
     session_jump_buttons: !!($('settingsSessionJumpButtons')||{}).checked,
     session_endless_scroll: !!($('settingsSessionEndlessScroll')||{}).checked,
-    activity_feed_expanded_default: !!($('settingsActivityFeedExpandedDefault')||{}).checked,
+    worklog_details_expanded_default: worklogDetailsExpanded,
+    activity_feed_expanded_default: worklogDetailsExpanded,
     hidden_tabs: _getHiddenTabs(),
     tab_order: _getTabOrder(),
   };
@@ -6158,8 +6160,15 @@ async function _autosaveAppearanceSettings(payload){
       if(typeof _applySessionNavigationPrefs==='function') _applySessionNavigationPrefs();
     }
     window._sessionEndlessScrollEnabled=!!(saved&&saved.session_endless_scroll);
-    if(saved&&Object.prototype.hasOwnProperty.call(saved,'activity_feed_expanded_default')){
-      window._activityFeedExpandedDefault=!!saved.activity_feed_expanded_default;
+    if(saved&&payload&&Object.prototype.hasOwnProperty.call(payload,'worklog_details_expanded_default')&&(
+      Object.prototype.hasOwnProperty.call(saved,'worklog_details_expanded_default') ||
+      Object.prototype.hasOwnProperty.call(saved,'activity_feed_expanded_default')
+    )){
+      window._worklogDetailsExpandedByDefault=!!(
+        Object.prototype.hasOwnProperty.call(saved,'worklog_details_expanded_default')
+          ? saved.worklog_details_expanded_default
+          : saved.activity_feed_expanded_default
+      );
     }
     _setAppearanceAutosaveStatus('saved');
   }catch(e){
@@ -6192,8 +6201,6 @@ function _preferencesPayloadFromUi(){
   if(showTpsCb) payload.show_tps=showTpsCb.checked;
   const fadeTextCb=$('settingsFadeTextEffect');
   if(fadeTextCb) payload.fade_text_effect=fadeTextCb.checked;
-  const simplifiedToolCb=$('settingsSimplifiedToolCalling');
-  if(simplifiedToolCb) payload.simplified_tool_calling=simplifiedToolCb.checked;
   const terminalAutoExpandCb=$('settingsTerminalAutoExpand');
   if(terminalAutoExpandCb) payload.terminal_auto_expand_on_output=terminalAutoExpandCb.checked;
   const apiRedactCb=$('settingsApiRedact');
@@ -6270,11 +6277,6 @@ function _schedulePreferencesAutosave(){
 async function _autosavePreferencesSettings(payload){
   try{
     const saved=await api('/api/settings',{method:'POST',body:JSON.stringify(payload)});
-    if(payload&&payload.simplified_tool_calling!==undefined){
-      window._simplifiedToolCalling=(saved&&saved.simplified_tool_calling!==false);
-      if(typeof clearMessageRenderCache==='function') clearMessageRenderCache();
-      if(typeof renderMessages==='function') renderMessages();
-    }
     if(payload&&payload.terminal_auto_expand_on_output!==undefined){
       window._terminalAutoExpandOnOutput=!!(saved&&saved.terminal_auto_expand_on_output);
     }
@@ -6385,12 +6387,16 @@ async function loadSettingsPanel(){
         _scheduleAppearanceAutosave();
       };
     }
-    const activityExpandedCb=$('settingsActivityFeedExpandedDefault');
-    if(activityExpandedCb){
-      activityExpandedCb.checked=!!settings.activity_feed_expanded_default;
-      window._activityFeedExpandedDefault=activityExpandedCb.checked;
-      activityExpandedCb.onchange=function(){
-        window._activityFeedExpandedDefault=this.checked;
+    const worklogDetailsExpandedCb=$('settingsWorklogDetailsExpandedDefault');
+    if(worklogDetailsExpandedCb){
+      const worklogDetailsExpanded=Object.prototype.hasOwnProperty.call(settings,'worklog_details_expanded_default')
+        ? settings.worklog_details_expanded_default
+        : settings.activity_feed_expanded_default;
+      worklogDetailsExpandedCb.checked=!!worklogDetailsExpanded;
+      window._worklogDetailsExpandedByDefault=worklogDetailsExpandedCb.checked;
+      worklogDetailsExpandedCb.onchange=function(){
+        window._worklogDetailsExpandedByDefault=this.checked;
+        if(typeof _applyWorklogDetailsExpandedDefault==='function') _applyWorklogDetailsExpandedDefault();
         _scheduleAppearanceAutosave();
       };
     }
@@ -6517,8 +6523,6 @@ async function loadSettingsPanel(){
     }
     const fadeTextCb=$('settingsFadeTextEffect');
     if(fadeTextCb){fadeTextCb.checked=!!settings.fade_text_effect;window._fadeTextEffect=fadeTextCb.checked;fadeTextCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
-    const simplifiedToolCb=$('settingsSimplifiedToolCalling');
-    if(simplifiedToolCb){simplifiedToolCb.checked=settings.simplified_tool_calling!==false;simplifiedToolCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
     const terminalAutoExpandCb=$('settingsTerminalAutoExpand');
     if(terminalAutoExpandCb){terminalAutoExpandCb.checked=!!settings.terminal_auto_expand_on_output;window._terminalAutoExpandOnOutput=terminalAutoExpandCb.checked;terminalAutoExpandCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
     const apiRedactCb=$('settingsApiRedact');
@@ -7629,7 +7633,7 @@ function _applySavedSettingsUi(saved, body, opts){
   window._notificationsEnabled=body.notifications_enabled;
   window._whatsNewSummaryEnabled=!!body.whats_new_summary_enabled;
   window._showThinking=body.show_thinking!==false;
-  window._simplifiedToolCalling=body.simplified_tool_calling!==false;
+  window._simplifiedToolCalling=true;
   window._terminalAutoExpandOnOutput=!!body.terminal_auto_expand_on_output;
   window._sessionJumpButtonsEnabled=!!body.session_jump_buttons;
   if(typeof _applySessionNavigationPrefs==='function') _applySessionNavigationPrefs();
@@ -7971,7 +7975,6 @@ async function saveSettings(andClose){
   body.show_quota_chip=showQuotaChip===true;
   body.show_tps=showTps;
   body.fade_text_effect=fadeTextEffect;
-  body.simplified_tool_calling=!!($('settingsSimplifiedToolCalling')||{}).checked;
   body.terminal_auto_expand_on_output=!!($('settingsTerminalAutoExpand')||{}).checked;
   body.api_redact_enabled=!!($('settingsApiRedact')||{}).checked;
   body.show_cli_sessions=showCliSessions;

--- a/static/ui.js
+++ b/static/ui.js
@@ -10179,7 +10179,7 @@ function renderKatexBlocks(container,options){
 
 function _thinkingMarkup(text=''){
   const clean=_sanitizeThinkingDisplayText(text);
-  const openClass=_worklogDetailsExpandedDefault()||!isSimplifiedToolCalling()?' open':'';
+  const openClass=_worklogDetailsExpandedDefault()?' open':'';
   return (clean&&String(clean).trim())
     ? `<div class="thinking-card${openClass}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body"><pre>${esc(String(clean).trim())}</pre></div></div>`
     : `<div class="thinking"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div>`;

--- a/static/ui.js
+++ b/static/ui.js
@@ -6410,10 +6410,30 @@ function _worklogReasoningTextFromMessage(m, rawIdx, toolCallAssistantIdxs, visi
   const visibleTexts=Array.isArray(turnVisibleContents)?turnVisibleContents:[];
   return _stripVisibleAssistantEchoFromThinking(thinkingText, visibleContent, turnFinalVisibleContent, ...visibleTexts);
 }
+function _worklogDetailsExpandedDefault(){
+  return window._worklogDetailsExpandedByDefault===true;
+}
+function _applyWorklogDetailsExpandedDefault(root){
+  const scope=root&&root.querySelectorAll?root:document;
+  const open=_worklogDetailsExpandedDefault();
+  scope.querySelectorAll('.thinking-card').forEach(card=>{
+    card.classList.toggle('open', open);
+  });
+  scope.querySelectorAll('.tool-card').forEach(card=>{
+    if(card.querySelector('.tool-card-detail')) card.classList.toggle('open', open);
+  });
+  scope.querySelectorAll('.tool-group[data-tool-worklog-tool-group="1"],.tool-worklog-tool-group').forEach(group=>{
+    group.classList.toggle('open', open);
+    group.classList.toggle('tool-worklog-tool-group-collapsed', !open);
+    const summary=group.querySelector('.tool-group-head,.tool-worklog-tool-group-head');
+    if(summary) summary.setAttribute('aria-expanded', String(open));
+  });
+}
 function _thinkingCardHtml(text, open){
   const clean=_sanitizeThinkingDisplayText(text);
   const copyBtn=`<button class="thinking-copy-btn" onclick="event.stopPropagation();_copyThinkingText(this)" title="${t('copy')}" aria-label="${t('copy')}">${li('copy',12)}</button>`;
-  const classes=`thinking-card${open?' open':''}`;
+  const shouldOpen=!!open||_worklogDetailsExpandedDefault();
+  const classes=`thinking-card${shouldOpen?' open':''}`;
   return `<div class="${classes}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-btn-row">${copyBtn}<span class="thinking-card-toggle">${li('chevron-right',12)}</span></span></div><div class="thinking-card-body"><pre>${esc(clean)}</pre></div></div>`;
 }
 function isSimplifiedToolCalling(){
@@ -6769,7 +6789,7 @@ function ensureActivityGroup(inner, opts){
   if(!group){
     group=document.createElement('div');
     let collapsed=opts.collapsed!==false;
-    if(window._activityFeedExpandedDefault===true) collapsed=false;
+    if(window._worklogDetailsExpandedByDefault===true) collapsed=false;
     const savedState=_readActivityDisclosureState(activityKey);
     // Restore the user's explicit expand intent when recreating the live
     // activity group within the same turn (#1298), then let persisted chat/turn
@@ -8987,7 +9007,7 @@ function _syncToolRowsContainer(tools, isLiveWorklog){
     return;
   }
   const hasRunning=rows.some(row=>row&&row.dataset&&row.dataset.toolDone==='false');
-  const shouldOpen=false;
+  const shouldOpen=_worklogDetailsExpandedDefault();
   const group=document.createElement('div');
   group.className='tool-group'+(shouldOpen?' open':' tool-worklog-tool-group-collapsed');
   group.setAttribute('data-tool-worklog-tool-group','1');
@@ -9120,7 +9140,8 @@ function buildToolCard(tc){
   const runIndicator=tc.done===false?'<span class="tool-card-running-dot"></span>':'';
   const isSubagent=tc.name==='subagent_progress';
   const isDelegation=tc.name==='delegate_task';
-  const cardClass='tool-card'+(tc.done===false?' tool-card-running':'')+(isSubagent?' tool-card-subagent':'');
+  const openClass=hasDetail&&_worklogDetailsExpandedDefault()?' open':'';
+  const cardClass='tool-card'+(tc.done===false?' tool-card-running':'')+(isSubagent?' tool-card-subagent':'')+openClass;
   // Clean up legacy subagent prefixes since the Lucide icon already shows it
   let displayName=_toolDisplayName(tc);
   let previewText=_toolCardPreviewText(tc, displaySnippet);
@@ -10158,7 +10179,7 @@ function renderKatexBlocks(container,options){
 
 function _thinkingMarkup(text=''){
   const clean=_sanitizeThinkingDisplayText(text);
-  const openClass=isSimplifiedToolCalling()?'':' open';
+  const openClass=_worklogDetailsExpandedDefault()||!isSimplifiedToolCalling()?' open':'';
   return (clean&&String(clean).trim())
     ? `<div class="thinking-card${openClass}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body"><pre>${esc(String(clean).trim())}</pre></div></div>`
     : `<div class="thinking"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div>`;

--- a/tests/test_1003_preferences_autosave.py
+++ b/tests/test_1003_preferences_autosave.py
@@ -3,7 +3,7 @@
 Mirrors the structure of test_1003_appearance_autosave.py to verify the
 preferences-panel autosave pattern is wired correctly:
 
-- All 15 preference fields use _schedulePreferencesAutosave (not _markSettingsDirty)
+- All 14 preference fields use _schedulePreferencesAutosave (not _markSettingsDirty)
 - Password field MUST still call _markSettingsDirty (security: never autosave)
 - _preferencesPayloadFromUi covers all 14 fields
 - _setPreferencesAutosaveStatus uses the shared i18n keys
@@ -39,7 +39,6 @@ PREFERENCE_FIELDS_AUTOSAVE = [
     ("settingsLanguage", "language"),
     ("settingsShowTokenUsage", "show_token_usage"),
     ("settingsShowTps", "show_tps"),
-    ("settingsSimplifiedToolCalling", "simplified_tool_calling"),
     ("settingsShowCliSessions", "show_cli_sessions"),
     ("settingsShowPreviousMessagingSessions", "show_previous_messaging_sessions"),
     ("settingsSyncInsights", "sync_to_insights"),
@@ -54,8 +53,8 @@ PREFERENCE_FIELDS_AUTOSAVE = [
 ]
 
 
-def test_all_15_preference_fields_have_autosave_payload_entries():
-    """_preferencesPayloadFromUi must include all 15 preference fields."""
+def test_all_14_preference_fields_have_autosave_payload_entries():
+    """_preferencesPayloadFromUi must include all 14 preference fields."""
     block = _function_block(PANELS_JS, "_preferencesPayloadFromUi")
     for dom_id, field in PREFERENCE_FIELDS_AUTOSAVE:
         assert f"$('{dom_id}')" in block, \

--- a/tests/test_issue1824_cli_patch_diff_rendering.py
+++ b/tests/test_issue1824_cli_patch_diff_rendering.py
@@ -116,6 +116,7 @@ def test_rendered_apply_patch_tool_card_html_contains_diff_lines():
         # #3336: buildToolCard now wraps diff snippets via these helpers.
         "_snippetLooksLikeDiff",
         "_colorDiffLines",
+        "_worklogDetailsExpandedDefault",
         # #3544: buildToolCard stamps durable memory/skill-save flags via these.
         "_tcAction",
         "_isMemorySave",
@@ -129,6 +130,7 @@ def test_rendered_apply_patch_tool_card_html_contains_diff_lines():
         function li(){{return '';}}
         function toolIcon(){{return '';}}
         function _toolDisplayName(tc){{return tc.name||'tool';}}
+        const window={{_worklogDetailsExpandedByDefault:false}};
         // #3544: const Sets the _isMemorySave/_isSkillUpdate predicates close over
         // (extracted helpers reference these module-level constants).
         const _MEMORY_SAVE_ACTIONS=new Set(['add','replace']);

--- a/tests/test_issue3595_activity_default_expanded.py
+++ b/tests/test_issue3595_activity_default_expanded.py
@@ -1,35 +1,139 @@
-"""Pin the full behavioral contract for the Activity expanded-default setting."""
+"""Pin the full behavioral contract for the Worklog expanded-default setting."""
+import json
 import pathlib
 import re
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 
 
+def _function_body(src, name):
+    marker = f"function {name}"
+    start = src.index(marker)
+    brace = src.index("{", start)
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[brace + 1:idx]
+    raise AssertionError(f"function {name} body not found")
+
+
 def test_setting_in_defaults():
     src = (ROOT / "api" / "config.py").read_text(encoding="utf-8")
-    assert '"activity_feed_expanded_default"' in src or "'activity_feed_expanded_default'" in src, \
-        "activity_feed_expanded_default must exist in _SETTINGS_DEFAULTS"
+    assert '"worklog_details_expanded_default"' in src or "'worklog_details_expanded_default'" in src, \
+        "worklog_details_expanded_default must exist in _SETTINGS_DEFAULTS"
     # Verify default is False
-    assert re.search(r'["\']activity_feed_expanded_default["\']:\s*False', src), \
-        "activity_feed_expanded_default default must be False (collapsed)"
+    assert re.search(r'["\']worklog_details_expanded_default["\']:\s*False', src), \
+        "worklog_details_expanded_default default must be False (collapsed)"
 
 
 def test_setting_in_bool_keys():
     src = (ROOT / "api" / "config.py").read_text(encoding="utf-8")
-    assert re.search(r'_SETTINGS_BOOL_KEYS\b.*?activity_feed_expanded_default', src, re.DOTALL), \
-        "activity_feed_expanded_default must appear inside _SETTINGS_BOOL_KEYS (not just anywhere in config.py)"
+    assert re.search(r'_SETTINGS_BOOL_KEYS\b.*?worklog_details_expanded_default', src, re.DOTALL), \
+        "worklog_details_expanded_default must appear inside _SETTINGS_BOOL_KEYS (not just anywhere in config.py)"
+
+
+def test_legacy_activity_feed_setting_migrates_without_remaining_primary_semantics():
+    src = (ROOT / "api" / "config.py").read_text(encoding="utf-8")
+    assert '"activity_feed_expanded_default"' in src, \
+        "config.py should still accept the legacy key as a migration alias"
+    assert re.search(r'_SETTINGS_LEGACY_DROP_KEYS\b.*?activity_feed_expanded_default', src, re.DOTALL), \
+        "The legacy Activity Feed key should be dropped from primary settings after migration"
+    assert 'settings["worklog_details_expanded_default"] = bool(' in src, \
+        "load_settings should migrate legacy Activity Feed values into the Worklog details key"
+    assert 'settings.pop("activity_feed_expanded_default", None)' in src, \
+        "save_settings should not persist the legacy Activity Feed key"
+
+
+def test_legacy_activity_feed_setting_migrates_on_load_and_save(monkeypatch, tmp_path):
+    from api import config
+
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(
+        json.dumps({"activity_feed_expanded_default": True}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "SETTINGS_FILE", settings_file)
+
+    loaded = config.load_settings()
+    assert loaded["worklog_details_expanded_default"] is True
+    assert "activity_feed_expanded_default" not in loaded
+
+    saved = config.save_settings({"activity_feed_expanded_default": False})
+    assert saved["worklog_details_expanded_default"] is False
+    on_disk = json.loads(settings_file.read_text(encoding="utf-8"))
+    assert on_disk["worklog_details_expanded_default"] is False
+    assert "activity_feed_expanded_default" not in on_disk
 
 
 def test_boot_initializes_window_flag():
     src = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
-    assert "activityFeedExpandedDefault" in src, \
-        "boot.js must initialize window._activityFeedExpandedDefault from settings"
+    assert "worklog_details_expanded_default" in src, \
+        "boot.js must initialize window._worklogDetailsExpandedByDefault from settings"
+    assert "s.activity_feed_expanded_default" in src, \
+        "boot.js should tolerate old servers that still return the legacy key"
 
 
 def test_ensure_activity_group_checks_flag():
     src = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
-    assert "_activityFeedExpandedDefault" in src, \
-        "ensureActivityGroup must check window._activityFeedExpandedDefault"
+    assert "_worklogDetailsExpandedByDefault" in src, \
+        "ensureActivityGroup must check window._worklogDetailsExpandedByDefault"
+
+
+def test_setting_controls_worklog_item_details_not_only_outer_group():
+    src = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+    assert "function _worklogDetailsExpandedDefault()" in src, \
+        "Worklog detail cards should share a single expanded-default helper"
+
+    thinking_fn = _function_body(src, "_thinkingCardHtml")
+    assert "_worklogDetailsExpandedDefault()" in thinking_fn, \
+        "Thinking cards should respect the Worklog details default"
+
+    legacy_thinking_fn = _function_body(src, "_thinkingMarkup")
+    assert "_worklogDetailsExpandedDefault()" in legacy_thinking_fn, \
+        "Thinking update fallback markup should not overwrite the Worklog details default"
+
+    tool_fn = _function_body(src, "buildToolCard")
+    assert "_worklogDetailsExpandedDefault()" in tool_fn and "openClass" in tool_fn, \
+        "Tool cards should respect the Worklog details default when they have detail content"
+
+    grouped_tools_fn = _function_body(src, "_syncToolRowsContainer")
+    assert "const shouldOpen=_worklogDetailsExpandedDefault()" in grouped_tools_fn, \
+        "Multi-tool Worklog groups should respect the Worklog details default"
+
+
+def test_setting_toggle_applies_to_existing_worklog_details():
+    ui_src = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+    helper = _function_body(ui_src, "_applyWorklogDetailsExpandedDefault")
+    assert "scope.querySelectorAll('.thinking-card')" in helper, \
+        "Toggling the setting should update existing Thinking cards"
+    assert "scope.querySelectorAll('.tool-card')" in helper and ".tool-card-detail" in helper, \
+        "Toggling the setting should update existing Tool cards that have details"
+    assert "data-tool-worklog-tool-group" in helper and "aria-expanded" in helper, \
+        "Toggling the setting should update existing multi-tool Worklog groups"
+
+    panels_src = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+    onchange_block = re.search(
+        r"worklogDetailsExpandedCb\.onchange=function\(\)\{(?P<body>.*?)\n\s*\};",
+        panels_src,
+        re.DOTALL,
+    )
+    assert onchange_block, "Worklog detail checkbox should have an onchange handler"
+    assert "_applyWorklogDetailsExpandedDefault()" in onchange_block.group("body"), \
+        "Changing the Worklog detail setting should apply the new default immediately"
+
+
+def test_appearance_autosave_does_not_reapply_worklog_details_over_manual_state():
+    panels_src = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+    autosave_fn = _function_body(panels_src, "_autosaveAppearanceSettings")
+    assert "_worklogDetailsExpandedByDefault" in autosave_fn, \
+        "Autosave should still reconcile the stored Worklog default flag"
+    assert "_applyWorklogDetailsExpandedDefault()" not in autosave_fn, \
+        "Autosave responses must not overwrite per-turn manual Worklog expand/collapse choices"
 
 
 def test_per_turn_override():
@@ -46,19 +150,25 @@ def test_collapse_class_applied():
 
 def test_settings_checkbox_exists():
     src = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
-    assert "settings_label_activity_feed_expanded_default" in src, \
-        "index.html must have a settings checkbox with data-i18n for activity_feed_expanded_default"
+    assert "settings_label_worklog_details_expanded_default" in src, \
+        "index.html must have a settings checkbox with data-i18n for worklog_details_expanded_default"
+    assert "Open Worklog details automatically" in src, \
+        "The setting copy should describe Worklog details, not the old Activity Feed wording"
+    assert "Worklog details stay folded by default" in src, \
+        "The setting copy must make the off/default state folded"
 
 
 def test_panels_wiring():
     src = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
-    assert "activity_feed_expanded_default" in src, \
-        "panels.js must read/write the activity_feed_expanded_default setting"
+    assert "worklog_details_expanded_default" in src, \
+        "panels.js must read/write the worklog_details_expanded_default setting"
+    assert "activity_feed_expanded_default: worklogDetailsExpanded" in src, \
+        "panels.js should include a legacy POST alias so old servers can persist the setting during rolling updates"
 
 
 def test_i18n_keys():
     src = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
-    assert "settings_label_activity_feed_expanded_default" in src, \
+    assert "settings_label_worklog_details_expanded_default" in src, \
         "i18n.js must have the label key for the setting"
-    assert "settings_desc_activity_feed_expanded_default" in src, \
+    assert "settings_desc_worklog_details_expanded_default" in src, \
         "i18n.js must have the description key for the setting"

--- a/tests/test_issue3595_activity_default_expanded.py
+++ b/tests/test_issue3595_activity_default_expanded.py
@@ -96,6 +96,8 @@ def test_setting_controls_worklog_item_details_not_only_outer_group():
     legacy_thinking_fn = _function_body(src, "_thinkingMarkup")
     assert "_worklogDetailsExpandedDefault()" in legacy_thinking_fn, \
         "Thinking update fallback markup should not overwrite the Worklog details default"
+    assert "!isSimplifiedToolCalling()" not in legacy_thinking_fn, \
+        "The deprecated compact-tool toggle should not keep dead branches in Thinking markup"
 
     tool_fn = _function_body(src, "buildToolCard")
     assert "_worklogDetailsExpandedDefault()" in tool_fn and "openClass" in tool_fn, \

--- a/tests/test_simplified_tool_calling_setting.py
+++ b/tests/test_simplified_tool_calling_setting.py
@@ -1,10 +1,9 @@
-"""Regression tests for the Simplified tool calling setting."""
+"""Regression tests for the deprecated Simplified tool calling setting."""
 
-import importlib
 import json
 
 
-def test_simplified_tool_calling_defaults_enabled_and_round_trips(monkeypatch, tmp_path):
+def test_simplified_tool_calling_defaults_enabled_but_legacy_false_is_ignored(monkeypatch, tmp_path):
     import api.config as config
 
     settings_path = tmp_path / "settings.json"
@@ -14,16 +13,21 @@ def test_simplified_tool_calling_defaults_enabled_and_round_trips(monkeypatch, t
     assert loaded["simplified_tool_calling"] is True
 
     saved = config.save_settings({"simplified_tool_calling": False})
-    assert saved["simplified_tool_calling"] is False
-    assert json.loads(settings_path.read_text(encoding="utf-8"))["simplified_tool_calling"] is False
-
-    saved = config.save_settings({"simplified_tool_calling": True})
     assert saved["simplified_tool_calling"] is True
+    assert json.loads(settings_path.read_text(encoding="utf-8"))["simplified_tool_calling"] is True
+
+    settings_path.write_text(
+        json.dumps({"simplified_tool_calling": False}),
+        encoding="utf-8",
+    )
+    loaded = config.load_settings()
+    assert loaded["simplified_tool_calling"] is True
 
 
-def test_simplified_tool_calling_is_a_valid_boolean_setting():
+def test_simplified_tool_calling_is_legacy_compatibility_not_user_setting():
     import api.config as config
 
     assert "simplified_tool_calling" in config._SETTINGS_DEFAULTS
-    assert "simplified_tool_calling" in config._SETTINGS_BOOL_KEYS
-    assert "simplified_tool_calling" in config._SETTINGS_ALLOWED_KEYS
+    assert "simplified_tool_calling" in config._SETTINGS_LEGACY_DROP_KEYS
+    assert "simplified_tool_calling" not in config._SETTINGS_BOOL_KEYS
+    assert "simplified_tool_calling" not in config._SETTINGS_ALLOWED_KEYS

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -153,29 +153,24 @@ def _run_thinking_echo_helper(*args: str) -> str:
 
 
 class TestToolCallGroupingStatic:
-    def test_simplified_tool_calling_setting_is_wired_through_frontend(self):
-        assert "settingsSimplifiedToolCalling" in (REPO / "static" / "index.html").read_text(encoding="utf-8"), (
-            "Settings should expose a Compact tool activity checkbox."
-        )
-        assert "window._simplifiedToolCalling" in (REPO / "static" / "boot.js").read_text(encoding="utf-8"), (
-            "Boot should hydrate simplified_tool_calling into a runtime flag."
+    def test_simplified_tool_calling_setting_is_hidden_from_frontend(self):
+        assert "settingsSimplifiedToolCalling" not in (REPO / "static" / "index.html").read_text(encoding="utf-8"), (
+            "Settings should no longer expose the deprecated Compact tool activity checkbox."
         )
         panels = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
-        assert "settingsSimplifiedToolCalling" in panels and "simplified_tool_calling" in panels, (
-            "Settings panel should load and save the simplified_tool_calling setting."
+        assert "settingsSimplifiedToolCalling" not in panels, (
+            "Settings panel should not load or save the deprecated simplified_tool_calling setting."
         )
 
-    def test_simplified_tool_calling_autosave_hot_applies_renderer_mode(self):
+    def test_simplified_tool_calling_renderer_is_forced_to_worklog_mode(self):
+        boot = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+        assert "window._simplifiedToolCalling=true" in boot, (
+            "Boot should keep the Compact Worklog renderer enabled regardless of legacy saved values."
+        )
         panels = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
         fn = _function_body(panels, "_autosavePreferencesSettings")
-        assert "window._simplifiedToolCalling" in fn, (
-            "Autosaving Compact tool activity should update the live renderer flag immediately."
-        )
-        assert "clearMessageRenderCache()" in fn, (
-            "Autosaving Compact tool activity should invalidate cached transcript HTML."
-        )
-        assert "renderMessages()" in fn, (
-            "Autosaving Compact tool activity should rebuild the visible transcript without a refresh."
+        assert "simplified_tool_calling" not in fn and "window._simplifiedToolCalling" not in fn, (
+            "Preferences autosave should no longer hot-apply the deprecated renderer switch."
         )
 
     def test_render_messages_gates_settled_activity_grouping(self):


### PR DESCRIPTION
## Summary

- rename the old Activity expanded-default setting surface to Worklog details and keep the default folded
- hide/deprecate the old `Compact tool activity` preference so it no longer implies a legacy transparent stream mode
- keep the Worklog renderer enabled even when older installs saved `simplified_tool_calling=false`
- make the Worklog details toggle apply immediately only when that toggle changes, without unrelated Appearance autosaves overriding per-turn manual expand/collapse choices

## Scope

Refs #3400 and #3820.

This does **not** implement Transparent Stream and does not add a `Compact Worklog / Transparent Stream` selector. That remains the separate #3820 implementation track. This PR only aligns existing settings with the current Compact Worklog default model.

## Verification

- `node --check static/boot.js static/panels.js static/ui.js static/i18n.js`
- `python3 -m py_compile api/config.py tests/test_1003_preferences_autosave.py tests/test_issue3595_activity_default_expanded.py tests/test_simplified_tool_calling_setting.py tests/test_ui_tool_call_cleanup.py`
- `pytest tests/test_ui_tool_call_cleanup.py tests/test_issue3595_activity_default_expanded.py tests/test_simplified_tool_calling_setting.py tests/test_1003_preferences_autosave.py tests/test_issue1824_cli_patch_diff_rendering.py`
- `pytest tests/ -v --timeout=60 --shard-id=0 --num-shards=3`
- `git diff --check`
- `python3 scripts/scope_undef_gate.py` attempted locally, skipped because `eslint` is not installed on PATH; GitHub CI `lint` passed the scope/undefined-reference gate