### PR TITLE
Fix stale thinking dot placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Legacy thinking placeholders no longer pile up as stale three-dot rows.** Empty pre-stream thinking spinners are now removed when the thinking phase finalizes instead of being mistaken for durable Thinking content. (#3869)
+
 ## [v0.51.340] — 2026-06-09 — Release LD (background-task agent wakeup in WebUI) — ⛔ HELD pending independent review
 
 ### Added

--- a/static/ui.js
+++ b/static/ui.js
@@ -10189,7 +10189,7 @@ function finalizeThinkingCard(){
     if(!row) return;
     // If the row is still just a spinner (no thinking content rendered),
     // remove it entirely — it's the initial waiting dots.
-    const hasContent=row.querySelector('.thinking-card') || row.classList.contains('thinking-card-row');
+    const hasContent=!!row.querySelector('.thinking-card');
     if(!hasContent && row.getAttribute('data-thinking-active')==='1'){
       row.remove();
       return;

--- a/tests/test_issue3869_thinking_dots.py
+++ b/tests/test_issue3869_thinking_dots.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text()
+
+
+def _function_body(src: str, name: str) -> str:
+    marker = f"function {name}("
+    start = src.find(marker)
+    assert start != -1, f"{name} not found"
+    brace = src.find("{", start)
+    assert brace != -1, f"{name} body not found"
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[brace + 1 : idx]
+    raise AssertionError(f"{name} body not closed")
+
+
+def test_finalize_removes_dot_only_legacy_thinking_placeholder():
+    """#3869: an empty legacy thinking row is only a spinner, not durable content."""
+    body = _function_body(UI_JS, "finalizeThinkingCard")
+
+    assert "const hasContent=!!row.querySelector('.thinking-card');" in body
+    assert "row.classList.contains('thinking-card-row')" not in body
+    assert "if(!hasContent && row.getAttribute('data-thinking-active')==='1'){" in body
+    assert "row.remove();" in body
+
+
+def test_live_worklog_thinking_cards_are_preserved_on_finalize():
+    """#3869 fix must not remove real Worklog Thinking Cards that contain text."""
+    body = _function_body(UI_JS, "finalizeThinkingCard")
+
+    assert "turn.querySelectorAll('.agent-activity-thinking[data-thinking-active=\"1\"]')" in body
+    assert "active.removeAttribute('data-thinking-active');" in body
+    assert "active.removeAttribute('data-live-thinking');" in body
+    assert "active.remove()" not in body


### PR DESCRIPTION
## Thinking Path

- #3869 reports that empty three-dot thinking placeholders can remain visible after the agent has moved on to tool calls or final content.
- The live-to-final model treats real provider reasoning as a durable Thinking Card, but an empty pre-stream spinner is only a transient placeholder.
- The bug was in the legacy thinking-row finalizer: it treated the row container class itself as durable content, so empty spinners were finalized instead of removed.
- This PR narrows the content check to actual `.thinking-card` content and adds a regression test so dot-only placeholders cannot pile up again.

## What Changed

- Updated `finalizeThinkingCard()` so dot-only legacy thinking rows are removed when finalized.
- Added #3869 regression coverage that distinguishes empty spinner placeholders from real Worklog Thinking Cards.
- Added an Unreleased changelog entry.

## Why It Matters

- Users should only see the three-dot animation while the agent is actively waiting/thinking.
- Once the turn advances to tools or final content, empty spinner rows should disappear instead of stacking as stale visual noise.
- Real Thinking Cards with provider reasoning remain preserved; this does not change the Worklog / Thinking Card model.

## UI Evidence

- Before: #3869 includes the reporter's screenshot showing multiple stale three-dot thinking rows stacked in the message area.
- After / invariant evidence: the new #3869 regression test pins the DOM-finalization behavior that creates the visible fix:
  - dot-only legacy thinking rows have no `.thinking-card` child and are removed when `finalizeThinkingCard()` runs;
  - real Worklog Thinking Cards keep their content and only lose live/active markers.
- CI also ran the repository browser smoke check successfully on this PR.
- I did not restart the user's local 8787/8788 runtime or record a provider-specific video for this narrow one-line DOM finalization fix.

## Contract Routing

Task type: focused UI regression fix.
Touched areas: `static/ui.js`, thinking placeholder finalization, regression tests, changelog.
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/live-to-final-assistant-replies.md`
- `docs/UIUX-GUIDE.md`
- `DESIGN.md`
Scope boundaries: no backend schema changes, no Thinking Card redesign, no new animation style.
Evidence needed before claiming done: syntax checks plus regression coverage for dot-only placeholder removal and real Thinking Card preservation.

## Verification

- `node --check static/ui.js`
- `node --check static/messages.js`
- `git diff --check`
- `uv run --python /opt/homebrew/bin/python3.12 --with pytest pytest tests/test_issue3869_thinking_dots.py tests/test_ui_tool_call_cleanup.py tests/test_issue1298_cancel_and_activity.py tests/test_regressions.py::test_ui_js_can_upgrade_thinking_spinner_into_live_reasoning_card tests/test_regressions.py::test_messages_js_finalizes_thinking_card_before_tool_card -q`
  - Result: `41 passed`
- `python3 scripts/scope_undef_gate.py`
  - Result: skipped locally because `eslint` is not installed on PATH.
- GitHub CI on this PR:
  - `browser-smoke`: passed
  - `lint`: passed
  - test matrix for Python 3.11 / 3.12 / 3.13: passed

## Risks / Follow-ups

- #3869 also mentions richer thinking animation inspiration; this PR intentionally does not redesign the animation.
- A future visual polish PR can revisit the spinner animation itself if maintainers want a richer active-thinking indicator.

Fixes #3869

## Model Used

OpenAI GPT-5 Codex via Codex CLI, with local shell, GitHub CLI, and CodeGraph context.
