### PR TITLE
fix(markdown): preserve list markers around LaTeX blocks (#3830)

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -3509,38 +3509,84 @@ function renderMd(raw){
   s=s.replace(/^---+$/gm,'<hr>');
   // (Blockquotes are handled by the pre-pass at the top of renderMd, before
   // fence_stash. The per-line passes below never see > prefixes.)
-  // B8: improved list handling supporting up to 2 levels of indentation
-  s=s.replace(/((?:^(?:  )?[-*+] .+\n?)+)/gm,block=>{
-    const lines=block.trimEnd().split('\n');
-    let html='<ul>';
-    for(const l of lines){
-      const indent=/^ {2,}/.test(l);
-      const text=l.replace(/^ {0,4}[-*+] /,'');
-      let _ih;
-      if(/^\[x\] /i.test(text)) _ih='<span class="task-done">✅</span> '+inlineMd(text.slice(4));
-      else if(/^\[ \] /.test(text)) _ih='<span class="task-todo">☐</span> '+inlineMd(text.slice(4));
-      else _ih=inlineMd(text);
-      if(indent) html+=`<li style="margin-left:16px">${_ih}</li>`;
-      else html+=`<li>${_ih}</li>`;
+  function _renderListBlock(lines, ordered){
+    const marker=ordered?'\\d+\\. ':'[-*+] ';
+    let html=ordered?'<ol>':'<ul>';
+    let item=null;
+    const flush=()=>{
+      if(!item) return;
+      const body=item.parts.join('\n').trim();
+      let inner;
+      if(!ordered && /^\[x\] /i.test(body)) inner='<span class="task-done">✅</span> '+inlineMd(body.slice(4));
+      else if(!ordered && /^\[ \] /.test(body)) inner='<span class="task-todo">☐</span> '+inlineMd(body.slice(4));
+      else inner=inlineMd(body);
+      const valueAttr=item.value!==null?` value="${item.value}"`:'';
+      const styleAttr=item.indent?` style="margin-left:16px"`:'';
+      html+=`<li${valueAttr}${styleAttr}>${inner}</li>`;
+      item=null;
+    };
+    for(const raw of lines){
+      const line=String(raw||'');
+      const nested=line.match(new RegExp(`^ {2,}(${marker})(.*)$`));
+      if(nested){
+        flush();
+        item={indent:true,value:ordered?parseInt(nested[1],10):null,parts:[nested[2]]};
+        continue;
+      }
+      const top=line.match(new RegExp(`^(?:  )?(${marker})(.*)$`));
+      if(top){
+        flush();
+        item={indent:false,value:ordered?parseInt(top[1],10):null,parts:[top[2]]};
+        continue;
+      }
+      if(!item) continue;
+      if(!line.trim()) continue;
+      item.parts.push(line.replace(/^ {2,}/,'').trim());
     }
-    return html+'</ul>';
-  });
-  // Ordered lists: use value= on each <li> so the correct number is preserved
-  // even when blank lines between items cause the paragraph splitter to place
-  // each item in its own <ol> container — without value= every <ol> restarts
-  // at 1, producing "1. 1. 1." instead of "1. 2. 3." (#886).
-  s=s.replace(/((?:^(?:  )?\d+\. .+\n?)+)/gm,block=>{
-    const lines=block.trimEnd().split('\n');
-    let html='<ol>';
-    for(const l of lines){
-      const numMatch=l.match(/^\s*(\d+)\. /);
-      const num=numMatch?parseInt(numMatch[1],10):null;
-      const text=l.replace(/^ {0,4}\d+\. /,'');
-      const valAttr=num!==null?` value="${num}"`:'';
-      html+=`<li${valAttr}>${inlineMd(text)}</li>`;
+    flush();
+    return html+(ordered?'</ol>':'</ul>');
+  }
+  function _renderLists(src, ordered){
+    const lines=src.split('\n');
+    const out=[];
+    const topRe=ordered?/^(?:  )?\d+\. /:/^(?:  )?[-*+] /;
+    const nestedRe=ordered?/^ {2,}\d+\. /:/^ {2,}[-*+] /;
+    const contRe=/^ {2,}\S/;
+    let i=0;
+    while(i<lines.length){
+      if(!topRe.test(lines[i])){
+        out.push(lines[i]);
+        i++;
+        continue;
+      }
+      const block=[lines[i]];
+      i++;
+      while(i<lines.length){
+        const line=lines[i];
+        if(topRe.test(line)||nestedRe.test(line)||contRe.test(line)){
+          block.push(line);
+          i++;
+          continue;
+        }
+        if(!line.trim()){
+          const next=lines[i+1]||'';
+          if(topRe.test(next)||nestedRe.test(next)||contRe.test(next)){
+            i++;
+            continue;
+          }
+        }
+        break;
+      }
+      out.push(_renderListBlock(block,ordered));
     }
-    return html+'</ol>';
-  });
+    return out.join('\n');
+  }
+  // Preserve continuation lines, nested indentation, and LaTeX placeholder lines
+  // inside list items without changing the wider markdown pipeline.
+  s=_renderLists(s,false);
+  // Ordered lists: keep continuation lines attached to their item and preserve
+  // explicit numbering via value= even when blank lines split the markdown.
+  s=_renderLists(s,true);
   // Tables: | col | col | header row followed by | --- | --- | separator then data rows
   // NOTE: table pass runs BEFORE outer link pass so [label](url) in table cells
   // is handled by inlineMd() only — prevents double-linking.

--- a/static/ui.js
+++ b/static/ui.js
@@ -3516,10 +3516,11 @@ function renderMd(raw){
     const flush=()=>{
       if(!item) return;
       const body=item.parts.join('\n').trim();
+      const text=body;
       let inner;
-      if(!ordered && /^\[x\] /i.test(body)) inner='<span class="task-done">✅</span> '+inlineMd(body.slice(4));
-      else if(!ordered && /^\[ \] /.test(body)) inner='<span class="task-todo">☐</span> '+inlineMd(body.slice(4));
-      else inner=inlineMd(body);
+      if(!ordered && /^\[x\] /i.test(text)) inner='<span class="task-done">✅</span> '+inlineMd(text.slice(4));
+      else if(!ordered && /^\[ \] /.test(text)) inner='<span class="task-todo">☐</span> '+inlineMd(text.slice(4));
+      else inner=inlineMd(text);
       const valueAttr=item.value!==null?` value="${item.value}"`:'';
       const styleAttr=item.indent?` style="margin-left:16px"`:'';
       html+=`<li${valueAttr}${styleAttr}>${inner}</li>`;

--- a/static/ui.js
+++ b/static/ui.js
@@ -3541,7 +3541,6 @@ function renderMd(raw){
         continue;
       }
       if(!item) continue;
-      if(!line.trim()) continue;
       item.parts.push(line.replace(/^ {2,}/,'').trim());
     }
     flush();
@@ -3585,8 +3584,10 @@ function renderMd(raw){
   // Preserve continuation lines, nested indentation, and LaTeX placeholder lines
   // inside list items without changing the wider markdown pipeline.
   s=_renderLists(s,false);
-  // Ordered lists: keep continuation lines attached to their item and preserve
-  // explicit numbering via value= even when blank lines split the markdown.
+  // Ordered-list parsing intentionally runs on the post-unordered string; the
+  // unordered pass emits <ul> HTML that cannot satisfy the ordered-item regex.
+  // Keep continuation lines attached to their item and preserve explicit
+  // numbering via value= even when blank lines split the markdown.
   s=_renderLists(s,true);
   // Tables: | col | col | header row followed by | --- | --- | separator then data rows
   // NOTE: table pass runs BEFORE outer link pass so [label](url) in table cells

--- a/tests/test_886_ordered_list_numbering.py
+++ b/tests/test_886_ordered_list_numbering.py
@@ -20,15 +20,22 @@ def get_ui_js():
 
 
 class TestOrderedListNumbering:
+    def _ordered_list_block(self, src: str) -> str:
+        start = src.find("function _renderListBlock(lines, ordered){")
+        assert start != -1, "_renderListBlock helper not found in ui.js"
+        end = src.find("function _renderLists(src, ordered){", start)
+        assert end != -1, "_renderLists helper not found after _renderListBlock"
+        return src[start:end]
+
+    def _ordered_list_dispatch_block(self, src: str) -> str:
+        start = src.find("s=_renderLists(s,true);")
+        assert start != -1, "ordered-list dispatch not found in ui.js"
+        return src[max(0, start - 260):start + 80]
 
     def test_li_value_attr_present_in_ordered_list_block(self):
         """The ordered-list renderer must emit value= on each <li>."""
         src = get_ui_js()
-        # Locate the ordered-list replace block
-        ol_idx = src.find('s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm')
-        assert ol_idx != -1, "Ordered-list replace block not found in ui.js"
-        # Extract a window large enough to cover the whole closure (~400 chars)
-        ol_block = src[ol_idx:ol_idx + 500]
+        ol_block = self._ordered_list_block(src)
         assert 'value=' in ol_block, (
             "Ordered-list block must emit value= attribute on <li> elements to "
             "preserve numbering when items are separated by blank lines (#886)"
@@ -37,56 +44,42 @@ class TestOrderedListNumbering:
     def test_li_value_uses_parsed_number(self):
         """The value= must be derived from parseInt of the captured digit, not hardcoded."""
         src = get_ui_js()
-        ol_idx = src.find('s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm')
-        assert ol_idx != -1, "Ordered-list replace block not found in ui.js"
-        ol_block = src[ol_idx:ol_idx + 500]
+        ol_block = self._ordered_list_block(src)
         assert 'parseInt' in ol_block, (
             "Ordered-list block should use parseInt() to parse the list number (#886)"
         )
 
     def test_numMatch_variable_present(self):
-        """The numMatch variable (or equivalent digit capture) must exist in the OL block."""
+        """The ordered-list branch must still capture digits from the markdown marker."""
         src = get_ui_js()
-        ol_idx = src.find('s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm')
-        assert ol_idx != -1, "Ordered-list replace block not found in ui.js"
-        ol_block = src[ol_idx:ol_idx + 500]
-        # Either numMatch or a similar digit-capture variable
-        assert 'numMatch' in ol_block or re.search(r'match\(/.*\\d', ol_block), (
-            "Ordered-list block should capture the list item number with a regex match (#886)"
+        ol_block = self._ordered_list_block(src)
+        assert "const marker=ordered?'\\\\d+\\\\. ':'[-*+] ';" in ol_block, (
+            "Ordered-list block should keep a digit marker pattern for numbered items (#886)"
         )
 
     def test_valAttr_or_value_template_present(self):
         """The <li> template must include the value attribute conditionally or unconditionally."""
         src = get_ui_js()
-        ol_idx = src.find('s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm')
-        assert ol_idx != -1, "Ordered-list replace block not found in ui.js"
-        ol_block = src[ol_idx:ol_idx + 500]
-        # Either a valAttr variable or an inline value= in the template
-        has_val_attr = 'valAttr' in ol_block
+        ol_block = self._ordered_list_block(src)
+        has_value_attr = 'valueAttr' in ol_block
         has_inline_value = re.search(r'<li.*value=', ol_block)
-        assert has_val_attr or has_inline_value, (
-            "Ordered-list block must have value= on <li> (via valAttr var or inline) (#886)"
+        assert has_value_attr or has_inline_value, (
+            "Ordered-list block must have value= on <li> (via valueAttr var or inline) (#886)"
         )
 
     def test_ordered_list_comment_references_issue(self):
         """A comment near the OL fix should reference the issue (#886) or the symptom."""
         src = get_ui_js()
-        ol_idx = src.find('s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm')
-        assert ol_idx != -1, "Ordered-list replace block not found in ui.js"
-        # Look at the 300 chars BEFORE the replace line for an explanatory comment
-        context = src[max(0, ol_idx - 300):ol_idx]
+        context = self._ordered_list_dispatch_block(src)
         has_comment = '#886' in context or '1. 1. 1.' in context or 'blank lines' in context.lower()
         assert has_comment, (
             "Expected a comment near the OL fix explaining the blank-line issue (#886)"
         )
 
     def test_list_without_blank_lines_unaffected(self):
-        """A compact list (no blank lines) should still produce one <ol> with sequential items."""
+        """A compact list should still flow through the ordered-list helper."""
         src = get_ui_js()
-        # Structural check: the regex still captures multi-line blocks (\\n? allows groups)
-        ol_idx = src.find('s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm')
-        assert ol_idx != -1, "Ordered-list replace block not found"
-        # The \\n? quantifier that allows grouping must still be present
-        assert '\\n?' in src[ol_idx:ol_idx + 80], (
-            "The \\\\n? in the ordered-list regex was removed — compact lists may break"
+        ol_block = self._ordered_list_dispatch_block(src)
+        assert "s=_renderLists(s,true);" in ol_block, (
+            "Ordered-list rendering should still route through the shared helper"
         )

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -290,6 +290,44 @@ class TestCommonLLMShapes:
         assert "\n " not in out.replace("</blockquote>", "")
 
 
+class TestMarkdownListsWithLatex:
+    """Drive the real renderer through the list path that shares the KaTeX placeholders."""
+
+    def test_plain_lists_still_render_markers(self, driver_path):
+        out = _render(driver_path, "- one\n- two\n\n1. alpha\n2. beta")
+        assert "<ul><li>one</li><li>two</li></ul>" in out
+        assert '<ol><li value="1">alpha</li><li value="2">beta</li></ol>' in out
+
+    def test_continuation_line_stays_inside_same_list_item(self, driver_path):
+        out = _render(driver_path, "- first line\n  second line\n- next item")
+        assert "<ul>" in out
+        assert "<li>first line\nsecond line</li>" in out, out
+        assert "<li>next item</li>" in out
+
+    def test_nested_indentation_stays_in_list(self, driver_path):
+        out = _render(driver_path, "- parent\n  - child")
+        assert "<ul>" in out
+        assert "<li>parent</li>" in out
+        assert '<li style="margin-left:16px">child</li>' in out
+
+    def test_display_math_line_stays_inside_list_item(self, driver_path):
+        src = "- intro\n\n  $$x^2$$\n\n  continuation"
+        out = _render(driver_path, src)
+        assert "<ul>" in out and "</ul>" in out
+        assert "<p>continuation</p>" not in out, out
+        assert "<div class=\"katex-block\" data-katex=\"display\">x^2</div>" in out
+        assert "<li>intro\n<div class=\"katex-block\" data-katex=\"display\">x^2</div>\ncontinuation</li>" in out, out
+
+    def test_mixed_markdown_and_latex_ordered_list_preserves_all_items(self, driver_path):
+        src = "1. **First** with $x$\n2. $$y$$\n3. tail"
+        out = _render(driver_path, src)
+        assert "<ol>" in out and "</ol>" in out
+        assert "<strong>First</strong>" in out
+        assert "<span class=\"katex-inline\" data-katex=\"inline\">x</span>" in out
+        assert "<div class=\"katex-block\" data-katex=\"display\">y</div>" in out
+        assert '<li value="3">tail</li>' in out
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Block-level constructs INSIDE blockquotes — the six bugs documented in
 # blockquote-rendering-bugs.md. Each test feeds the exact input from the


### PR DESCRIPTION

## Thinking Path

- The visible bug shows up around LaTeX, but the underlying failure is that the renderer's one-line list matching drops continuation lines, nested indentation, and math placeholder lines out of the current list item.
- Fixing that at the markdown list parsing layer is safer than patching the symptom in CSS, because the broken structure is already emitted before styling runs.
- The implementation therefore keeps the change narrow to the list parser while covering plain lists, nested lists, and KaTeX placeholder lines through focused renderer regressions.

## What Changed

- `static/ui.js`: replace the fragile one-line list handling with a narrow helper-based pass that keeps continuation lines, nested indentation, blank-line-separated numbered items, and KaTeX placeholder lines attached to the correct list item.
- `tests/test_renderer_js_behaviour.py`: cover mixed Markdown + LaTeX list rendering through the real renderer path.
- `tests/test_886_ordered_list_numbering.py`: update the ordered-list coverage to match the new parser shape and keep numbering regressions pinned.

## Why It Matters

Long teaching or explanatory replies often mix numbered steps with equations. Preserving the list structure keeps those replies readable instead of flattening them into hard-to-scan prose.

## Verification

- Targeted: `pytest tests/test_*markdown* tests/test_renderer_js_behaviour.py -v --timeout=60`
  Result: passed, `144 passed`.
- Focused regression: `pytest tests/test_886_ordered_list_numbering.py -v --timeout=60`
  Result: passed, `6 passed`.
- Runtime lint: `npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"`
  Result: passed.
- Syntax check: `node --check static/ui.js`
  Result: passed.
- Full suite command for reviewer use: `pytest tests/ -v --timeout=60`
  Result: not run locally in this session.

## Risks / Follow-ups

This intentionally leaves CSS alone because the failing path was structural, not stylistic. If a skin-specific list-style override still exists elsewhere, that should be addressed separately from this parser fix.

## Model Used

GPT-5 via Codex CLI