### PR TITLE
fix(sidebar): refresh stale zero-message session index rows (#3740)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -2648,6 +2648,14 @@ def _strip_sidebar_internal_flags(sessions: list[dict]) -> None:
         session.pop('_show_pre_compression_snapshot', None)
 
 
+def _looks_like_stale_zero_message_row(session: dict) -> bool:
+    """Return True for indexed rows that likely need sidecar metadata repair."""
+    return bool(
+        int(session.get('message_count') or 0) == 0
+        and int(session.get('user_message_count') or 0) > 0
+    )
+
+
 def _row_may_need_sidecar_metadata_refresh(
     session: dict,
     *,
@@ -2687,7 +2695,22 @@ def _row_may_need_sidecar_metadata_refresh(
             or session.get('_lineage_root_id')
             or session.get('_compression_segment_count')
         )
-        return bool(lineage_shaped and sid and _sidecar_mtime_after_index_timestamp(session))
+        if lineage_shaped and _sidecar_mtime_after_index_timestamp(session):
+            return True
+        if (
+            sid
+            and _looks_like_stale_zero_message_row(session)
+            and _sidecar_mtime_after_index_timestamp(session)
+        ):
+            return True
+        return False
+    if (
+        sid
+        and _looks_like_stale_zero_message_row(session)
+        and str(session.get('session_source') or '').strip().lower() != 'fork'
+        and _sidecar_mtime_after_index_timestamp(session)
+    ):
+        return True
     if session.get('message_count') is None or session.get('last_message_at') is None:
         return True
     return bool(sid and stale_snapshot_ids and sid in stale_snapshot_ids)

--- a/api/models.py
+++ b/api/models.py
@@ -2695,13 +2695,10 @@ def _row_may_need_sidecar_metadata_refresh(
             or session.get('_lineage_root_id')
             or session.get('_compression_segment_count')
         )
-        if lineage_shaped and _sidecar_mtime_after_index_timestamp(session):
-            return True
-        if (
-            sid
-            and _looks_like_stale_zero_message_row(session)
-            and _sidecar_mtime_after_index_timestamp(session)
-        ):
+        needs_mtime_check = lineage_shaped or (
+            sid and _looks_like_stale_zero_message_row(session)
+        )
+        if needs_mtime_check and _sidecar_mtime_after_index_timestamp(session):
             return True
         return False
     if (

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -907,6 +907,46 @@ def test_all_sessions_refreshes_stale_zero_count_row_from_sidecar(monkeypatch):
     assert rows[0]["last_message_at"] == 101.0
 
 
+def test_all_sessions_refreshes_stale_zero_count_snapshot_row_from_sidecar(monkeypatch):
+    """Snapshot rows follow the same stale-zero sidecar refresh path."""
+    session = Session(
+        session_id="stale_zero_snapshot_count",
+        title="Recovered Snapshot Session",
+        messages=[
+            {"role": "user", "content": "first", "timestamp": 100.0},
+            {"role": "assistant", "content": "second", "timestamp": 101.0},
+        ],
+        updated_at=101.0,
+        last_message_at=101.0,
+        pre_compression_snapshot=True,
+    )
+    session.save(touch_updated_at=False)
+    _write_index_file(
+        models.SESSION_INDEX_FILE,
+        [
+            {
+                "session_id": "stale_zero_snapshot_count",
+                "title": "Recovered Snapshot Session",
+                "message_count": 0,
+                "user_message_count": 1,
+                "created_at": 100.0,
+                "updated_at": 1.0,
+                "last_message_at": 1.0,
+                "pinned": False,
+                "archived": False,
+                "pre_compression_snapshot": True,
+            },
+        ],
+    )
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    rows = models.all_sessions()
+
+    assert [row["session_id"] for row in rows] == ["stale_zero_snapshot_count"]
+    assert rows[0]["message_count"] == 2
+    assert rows[0]["last_message_at"] == 101.0
+
+
 def test_all_sessions_skips_refresh_for_real_empty_untitled_drafts(monkeypatch):
     """Keep genuine empty drafts on the cheap path when they have no user turns."""
     draft = Session(

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -869,6 +869,78 @@ def test_all_sessions_refreshes_stale_visible_continuation_metadata(monkeypatch)
     assert rows[0]["last_message_at"] == 103.0
 
 
+def test_all_sessions_refreshes_stale_zero_count_row_from_sidecar(monkeypatch):
+    """A zero-message indexed row can still have real transcript content on disk."""
+    session = Session(
+        session_id="stale_zero_count",
+        title="Recovered Session",
+        messages=[
+            {"role": "user", "content": "first", "timestamp": 100.0},
+            {"role": "assistant", "content": "second", "timestamp": 101.0},
+        ],
+        updated_at=101.0,
+        last_message_at=101.0,
+    )
+    session.save(touch_updated_at=False)
+    _write_index_file(
+        models.SESSION_INDEX_FILE,
+        [
+            {
+                "session_id": "stale_zero_count",
+                "title": "Recovered Session",
+                "message_count": 0,
+                "user_message_count": 1,
+                "created_at": 100.0,
+                "updated_at": 1.0,
+                "last_message_at": 1.0,
+                "pinned": False,
+                "archived": False,
+            },
+        ],
+    )
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    rows = models.all_sessions()
+
+    assert [row["session_id"] for row in rows] == ["stale_zero_count"]
+    assert rows[0]["message_count"] == 2
+    assert rows[0]["last_message_at"] == 101.0
+
+
+def test_all_sessions_skips_refresh_for_real_empty_untitled_drafts(monkeypatch):
+    """Keep genuine empty drafts on the cheap path when they have no user turns."""
+    draft = Session(
+        session_id="untitled_empty_draft",
+        title="Untitled",
+        messages=[],
+        updated_at=100.0,
+        last_message_at=100.0,
+    )
+    draft.save(touch_updated_at=False)
+    _write_index_file(
+        models.SESSION_INDEX_FILE,
+        [
+            {
+                "session_id": "untitled_empty_draft",
+                "title": "Untitled",
+                "message_count": 0,
+                "user_message_count": 0,
+                "created_at": 100.0,
+                "updated_at": 100.0,
+                "last_message_at": 100.0,
+                "pinned": False,
+                "archived": False,
+            },
+        ],
+    )
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    with patch.object(Session, "load_metadata_only", side_effect=AssertionError("empty draft should not refresh sidecar")):
+        rows = models.all_sessions()
+
+    assert rows == []
+
+
 def test_all_sessions_does_not_refresh_plain_branch_fork_from_sidecar(monkeypatch):
     """A plain /branch fork (session_source='fork') must NOT trigger a sidecar refresh.
 


### PR DESCRIPTION

## Thinking Path

- The underlying transcript is already safe on disk, but a stale `message_count: 0` index row can make the sidebar hide a real session and feel like silent data loss.
- The repo already has a sidecar-refresh path for known stale shapes, so the right fix is to widen that gate narrowly instead of reintroducing an expensive per-row sidecar scan on every poll.
- The narrow signal the issue thread validated is `message_count == 0` with `user_message_count > 0`, which repairs genuinely stale rows without touching empty drafts.

## What Changed

- `api/models.py`: widen the stale-row probe only for zero-message rows that already carry evidence of real user turns.
- `tests/test_session_index.py`: add focused coverage for the healed stale row and the cheap-path empty-draft guard.

## Why It Matters

Hidden sessions feel like silent data loss even when the transcript is still on disk. Repairing that stale index shape restores the conversation to the sidebar and keeps discoverability consistent with the actual saved data.

## Verification

- Targeted: `pytest tests/test_session_index.py -v --timeout=60`
  Result: passed with an isolated `HERMES_WEBUI_TEST_STATE_DIR`, `37 passed in 2.11s`.
- Full suite command for reviewer use: `pytest tests/ -v --timeout=60`
  Result: not run locally in this session.

## Risks / Follow-ups

This stays intentionally narrower than a generic stale-index repair pass. If other stale shapes surface later, they should be added with similarly specific gates instead of broad sidecar hydration.

## Model Used

GPT-5 via Codex CLI