### PR TITLE
Release v0.51.341 — Release LE (stale thinking-dot placeholder fix #3869/#3876)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 
 ## [Unreleased]
 
-## [v0.51.340] — 2026-06-09 — Release LD (background-task agent wakeup in WebUI) — ⛔ HELD pending independent review
+## [v0.51.341] — 2026-06-09 — Release LE (stale thinking-dot placeholder fix)
+
+### Fixed
+
+- **Legacy thinking placeholders no longer pile up as stale three-dot rows.** Empty pre-stream thinking spinners are now removed when the thinking phase finalizes instead of being mistaken for durable Thinking content. The live-to-final redesign (#3401) made the `thinking-card-row` wrapper class unconditional, which broke `finalizeThinkingCard()`'s dots-only detection (it treated the wrapper class itself as a "has content" signal); the check is now narrowed to the actual `.thinking-card` element so dots-only spinners are removed on finalize while real Worklog Thinking Cards are preserved. (#3869, #3876)
+
+## [v0.51.340] — 2026-06-09 — Release LD (background-task agent wakeup in WebUI)
 
 ### Added
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -10189,7 +10189,7 @@ function finalizeThinkingCard(){
     if(!row) return;
     // If the row is still just a spinner (no thinking content rendered),
     // remove it entirely — it's the initial waiting dots.
-    const hasContent=row.querySelector('.thinking-card') || row.classList.contains('thinking-card-row');
+    const hasContent=!!row.querySelector('.thinking-card');
     if(!hasContent && row.getAttribute('data-thinking-active')==='1'){
       row.remove();
       return;

--- a/tests/test_issue3869_thinking_dots.py
+++ b/tests/test_issue3869_thinking_dots.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text()
+
+
+def _function_body(src: str, name: str) -> str:
+    marker = f"function {name}("
+    start = src.find(marker)
+    assert start != -1, f"{name} not found"
+    brace = src.find("{", start)
+    assert brace != -1, f"{name} body not found"
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[brace + 1 : idx]
+    raise AssertionError(f"{name} body not closed")
+
+
+def test_finalize_removes_dot_only_legacy_thinking_placeholder():
+    """#3869: an empty legacy thinking row is only a spinner, not durable content."""
+    body = _function_body(UI_JS, "finalizeThinkingCard")
+
+    assert "const hasContent=!!row.querySelector('.thinking-card');" in body
+    assert "row.classList.contains('thinking-card-row')" not in body
+    assert "if(!hasContent && row.getAttribute('data-thinking-active')==='1'){" in body
+    assert "row.remove();" in body
+
+
+def test_live_worklog_thinking_cards_are_preserved_on_finalize():
+    """#3869 fix must not remove real Worklog Thinking Cards that contain text."""
+    body = _function_body(UI_JS, "finalizeThinkingCard")
+
+    assert "turn.querySelectorAll('.agent-activity-thinking[data-thinking-active=\"1\"]')" in body
+    assert "active.removeAttribute('data-thinking-active');" in body
+    assert "active.removeAttribute('data-live-thinking');" in body
+    assert "active.remove()" not in body


### PR DESCRIPTION
## Release v0.51.341 — Release LE (stale thinking-dot placeholder fix)

Brick-prepass release. Absorbs contributor PR #3876 (@franksong2702) which fixes the confirmed #3401 regression #3869.

### Fixed

- **Legacy thinking placeholders no longer pile up as stale three-dot rows (#3869, #3876).** Empty pre-stream thinking spinners are now removed when the thinking phase finalizes instead of being mistaken for durable Thinking content.

### Root cause

The live-to-final redesign (#3401, v0.51.294) made the `thinking-card-row` wrapper class **unconditional** on every thinking row, including the dots-only spinner. But `finalizeThinkingCard()` used that same class as its "has real content" signal:

```js
const hasContent = row.querySelector('.thinking-card') || row.classList.contains('thinking-card-row');
```

Since the wrapper now always carries `thinking-card-row`, `hasContent` was always truthy, so the dots-only-removal branch went dead and empty spinners stacked across turns. Narrowed to the actual content element:

```js
const hasContent = !!row.querySelector('.thinking-card');
```

Real Worklog Thinking Cards (which contain a `.thinking-card`) are preserved; dots-only spinners are removed on finalize.

### Files

- `static/ui.js` — 1-line change in `finalizeThinkingCard()`
- `tests/test_issue3869_thinking_dots.py` — NEW regression test (asserts the narrowed check + that real thinking cards are not removed)
- `CHANGELOG.md` — release entry

### Gate

- Full suite: **8470 passed, 9 skipped, 3 xpassed, 0 failures** (`pytest -p no:xdist`)
- Codex advisor: **SAFE TO SHIP** — confirmed scoped to the legacy path; verified no other production code treats `thinking-card-row` as a content signal (the remaining use at ui.js:5189 is a positional insertion anchor)
- Opus advisor: **correct, complete, ship-safe** — Worklog branch structurally untouched, no regression risk to the live-to-final render family
- node -c clean, regression test green, rebase fidelity verified identical to PR head

Closes #3869.

Co-authored-by: franksong2702 <franksong2702@users.noreply.github.com>
