### PR TITLE
fix(sidebar): prime idx_messages_session before CLI-session scan (#3887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sidebar no longer stalls for seconds on a state.db that is missing the agent's message index.** The CLI-session scan orders candidate sessions by a correlated `MAX(timestamp)` subquery over `messages`, which collapses to a full per-session table scan when `idx_messages_session ON messages(session_id, timestamp)` is absent — stalling `/api/sessions` for several seconds on every refresh (the 5s cache TTL never settles, so repeated "Slow WebUI request still running" warnings appear). A normally-migrated hermes-agent state.db has this index, but a db that lost its migrations (older hermes-agent, or a hand-rebuilt/reimported db) does not. WebUI now primes the index with `CREATE INDEX IF NOT EXISTS` before the scan — a no-op when it already exists, and a ~20ms self-heal otherwise (measured 13.3s → 0.009s on a no-index 8k-session db). Best-effort: degrades silently on a read-only db, a locked db, or a minimal schema without a `timestamp` column. (#3887)
+
 ## [v0.51.341] — 2026-06-09 — Release LE (stale thinking-dot placeholder fix)
 
 ### Fixed

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -462,6 +462,28 @@ def read_importable_agent_session_rows(
         use_messages_join = messages_has_session_id
         count_col = 'id' if 'id' in message_cols else 'session_id'
 
+        # Defensive index prime (#3887). The candidate-ordering query below sorts
+        # sessions by a correlated ``MAX(mx.timestamp)`` subquery over ``messages``.
+        # That is fast only when the agent's standard
+        # ``idx_messages_session ON messages(session_id, timestamp)`` index exists.
+        # A normally-migrated hermes-agent state.db has it, but a db that lost its
+        # migrations (older hermes-agent, or a hand-rebuilt/reimported db) does
+        # not — and the subquery then degrades to a full ``messages`` scan per
+        # candidate session, stalling ``/api/sessions`` for seconds on every
+        # refresh (the 5s-TTL cache never settles). Priming the index is a no-op
+        # (~free) when it already exists, and self-heals an affected db in
+        # milliseconds. Best-effort: degrade silently on a read-only db or any
+        # error so the listing never fails because of the prime.
+        if messages_has_session_id and messages_has_timestamp:
+            try:
+                cur.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_messages_session "
+                    "ON messages(session_id, timestamp)"
+                )
+                conn.commit()
+            except sqlite3.Error:
+                pass  # read-only db / locked / older schema — degrade gracefully
+
         if use_messages_join:
             actual_count_expr = f"COUNT(m.{count_col})"
             if 'role' in message_cols:

--- a/tests/test_issue3887_index_prime.py
+++ b/tests/test_issue3887_index_prime.py
@@ -18,6 +18,8 @@ import os
 import sqlite3
 import stat
 
+import pytest
+
 import api.agent_sessions as agent_sessions
 
 
@@ -158,6 +160,13 @@ def test_prime_skipped_without_timestamp_column(tmp_path):
 def test_prime_degrades_on_readonly_db(tmp_path):
     """A read-only db (can't create the index) must not raise — the listing
     still returns, just without the perf benefit."""
+    # Root bypasses POSIX permission bits, so chmod 0444 doesn't make the file
+    # read-only for root and the prime would succeed — validating the wrong path
+    # and giving false confidence on root-run CI (greptile). Skip under root; the
+    # production handler's `except sqlite3.Error: pass` covers read-only/locked/
+    # corrupted/older-schema regardless, and the other cases pin that contract.
+    if hasattr(os, "getuid") and os.getuid() == 0:
+        pytest.skip("chmod-based read-only test is a no-op under root")
     db = tmp_path / "state.db"
     _full_schema_db(db)
     os.chmod(db, stat.S_IREAD)

--- a/tests/test_issue3887_index_prime.py
+++ b/tests/test_issue3887_index_prime.py
@@ -1,0 +1,171 @@
+"""Regression tests for #3887 — defensive index prime for the sidebar scan.
+
+The sidebar's CLI-session scan (``read_importable_agent_session_rows``) orders
+candidate sessions by a correlated ``MAX(mx.timestamp)`` subquery over the
+``messages`` table. That is fast only when the agent's standard
+``idx_messages_session ON messages(session_id, timestamp)`` index exists. A
+state.db that lost its migrations (older hermes-agent, or a hand-rebuilt /
+reimported db) has no such index and the scan degrades to a full ``messages``
+scan per candidate session — stalling ``/api/sessions`` for seconds on every
+refresh.
+
+These tests assert the intent (the index is primed when missing so the listing
+self-heals) and the cross-cell isolation (the prime is a no-op when the index
+already exists, is skipped when the schema lacks the columns, and degrades
+silently on a read-only db without ever failing the listing).
+"""
+import os
+import sqlite3
+import stat
+
+import api.agent_sessions as agent_sessions
+
+
+def _full_schema_db(path):
+    """A state.db with the columns the scan reads, but NO messages index."""
+    conn = sqlite3.connect(str(path))
+    cur = conn.cursor()
+    cur.execute(
+        """CREATE TABLE sessions(
+            id TEXT PRIMARY KEY, title TEXT, model TEXT, message_count INTEGER,
+            started_at REAL, source TEXT, session_source TEXT,
+            parent_session_id TEXT, ended_at REAL, end_reason TEXT,
+            user_id TEXT, chat_id TEXT, chat_type TEXT, thread_id TEXT,
+            session_key TEXT, origin_chat_id TEXT, origin_user_id TEXT,
+            platform TEXT)"""
+    )
+    cur.execute(
+        """CREATE TABLE messages(
+            id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, role TEXT,
+            content TEXT, timestamp REAL)"""
+    )
+    for i in range(3):
+        sid = f"sess{i}"
+        cur.execute(
+            "INSERT INTO sessions(id, title, model, message_count, started_at, "
+            "source, session_source) VALUES (?,?,?,?,?,?,?)",
+            (sid, f"Session {i}", "m", 2, 1000.0 + i, "cli", "cli"),
+        )
+        cur.execute(
+            "INSERT INTO messages(session_id, role, content, timestamp) "
+            "VALUES (?,?,?,?)",
+            (sid, "user", "hi", 1001.0 + i),
+        )
+        cur.execute(
+            "INSERT INTO messages(session_id, role, content, timestamp) "
+            "VALUES (?,?,?,?)",
+            (sid, "assistant", "yo", 1002.0 + i),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _messages_indexes(path):
+    conn = sqlite3.connect(str(path))
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND tbl_name='messages'"
+        ).fetchall()
+    finally:
+        conn.close()
+    return {r[0] for r in rows}
+
+
+def test_prime_creates_missing_index(tmp_path):
+    """A db missing idx_messages_session gets it primed on the first scan."""
+    db = tmp_path / "state.db"
+    _full_schema_db(db)
+    assert "idx_messages_session" not in _messages_indexes(db)
+
+    rows = agent_sessions.read_importable_agent_session_rows(
+        db, limit=20, exclude_sources=None
+    )
+
+    # Listing still returns the sessions ...
+    assert {r["id"] for r in rows} == {"sess0", "sess1", "sess2"}
+    # ... and the index now exists on (session_id, timestamp).
+    assert "idx_messages_session" in _messages_indexes(db)
+    conn = sqlite3.connect(str(db))
+    try:
+        sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='idx_messages_session'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert "session_id" in sql and "timestamp" in sql
+
+
+def test_prime_is_noop_when_index_exists(tmp_path):
+    """When the agent already created the index, the prime must not duplicate
+    or error — the existing index is reused untouched."""
+    db = tmp_path / "state.db"
+    _full_schema_db(db)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "CREATE INDEX idx_messages_session ON messages(session_id, timestamp)"
+    )
+    conn.commit()
+    conn.close()
+    before = _messages_indexes(db)
+
+    rows = agent_sessions.read_importable_agent_session_rows(
+        db, limit=20, exclude_sources=None
+    )
+
+    assert {r["id"] for r in rows} == {"sess0", "sess1", "sess2"}
+    # Index set is unchanged — no duplicate, no error.
+    assert _messages_indexes(db) == before
+    assert "idx_messages_session" in _messages_indexes(db)
+
+
+def test_prime_skipped_without_timestamp_column(tmp_path):
+    """A minimal messages schema (no timestamp column) must not attempt the
+    index and must not crash the listing."""
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db))
+    cur = conn.cursor()
+    cur.execute(
+        """CREATE TABLE sessions(
+            id TEXT PRIMARY KEY, title TEXT, model TEXT, message_count INTEGER,
+            started_at REAL, source TEXT)"""
+    )
+    cur.execute(
+        "CREATE TABLE messages(id INTEGER PRIMARY KEY, session_id TEXT, "
+        "role TEXT, content TEXT)"
+    )
+    cur.execute(
+        "INSERT INTO sessions(id, title, model, message_count, started_at, "
+        "source) VALUES ('s1','T','m',1,1000.0,'cli')"
+    )
+    cur.execute(
+        "INSERT INTO messages(id, session_id, role, content) "
+        "VALUES (1,'s1','user','hi')"
+    )
+    conn.commit()
+    conn.close()
+
+    rows = agent_sessions.read_importable_agent_session_rows(
+        db, limit=20, exclude_sources=None
+    )
+
+    # Listing degrades gracefully via the denormalized counts (still surfaces).
+    assert {r["id"] for r in rows} == {"s1"}
+    # The timestamp-less schema must NOT have an index primed on it.
+    assert "idx_messages_session" not in _messages_indexes(db)
+
+
+def test_prime_degrades_on_readonly_db(tmp_path):
+    """A read-only db (can't create the index) must not raise — the listing
+    still returns, just without the perf benefit."""
+    db = tmp_path / "state.db"
+    _full_schema_db(db)
+    os.chmod(db, stat.S_IREAD)
+    try:
+        rows = agent_sessions.read_importable_agent_session_rows(
+            db, limit=20, exclude_sources=None
+        )
+        assert {r["id"] for r in rows} == {"sess0", "sess1", "sess2"}
+    finally:
+        # Restore write so tmp_path cleanup can remove it.
+        os.chmod(db, stat.S_IWRITE | stat.S_IREAD)


### PR DESCRIPTION
## Summary

Closes #3887.

On large installs, the WebUI sidebar (`/api/sessions`) stalls for several seconds per refresh when the agent's `state.db` is **missing the `idx_messages_session` index** on `messages(session_id, timestamp)`. The CLI-session scan in `read_importable_agent_session_rows()` orders candidate sessions by a correlated `MAX(timestamp)` subquery over `messages`, which degrades to a full `messages` scan per candidate session without that index. The stall exceeds the 5s session-cache TTL, so every refresh re-runs the uncached scan and the user sees repeating "Slow WebUI request still running" warnings — the sidebar never settles.

A normally-migrated hermes-agent state.db has this index. It's missing only on a db that lost its migrations — an older hermes-agent that predates the index, or a hand-rebuilt/reimported db (the reporter on #3831 was reimporting into a fresh state.db).

## Root cause

`api/agent_sessions.py` `read_importable_agent_session_rows()`:

```sql
ORDER BY COALESCE(
  (SELECT MAX(mx.timestamp) FROM messages mx WHERE mx.session_id = s.id),
  s.started_at
) DESC, s.started_at DESC
```

Fast only when `messages(session_id, timestamp)` is indexed.

## Fix

Prime the index with `CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp)` right after the existing column-detection block, gated on the `messages` table actually having `session_id` + `timestamp` columns. It's a no-op when the index already exists (the common case → zero cost for normally-migrated installs) and a ~20ms self-heal otherwise. Wrapped in `try/except sqlite3.Error` so a read-only/locked db or older schema degrades silently — the listing never fails because of the prime.

This is a WebUI-side resilience guard; the canonical index belongs in hermes-agent's migrations, but the WebUI shouldn't be unusable for 5s/refresh when the index is recoverable in milliseconds.

## Empirical verification (run against the real master function)

Synthetic 8k-session / 20k-message db with **no** `idx_messages_session`:

| condition | `read_importable_agent_session_rows()` |
|---|---|
| master (no index) | **13.3 s** |
| this PR, 1st call (builds index) | **0.03 s** |
| this PR, 2nd call (index present) | **0.009 s** |

The earlier 21k-session benchmark on #3887 measured 58.9s → 0.015s. Two real local state.db files **with** the agent index already run the query in 0.02–0.57s (confirming size isn't the driver — the missing index is).

## Tests

`tests/test_issue3887_index_prime.py` (4 cases, all green):
- **creates missing index** — a db without it gets it primed on the first scan, sessions still listed, index lands on `(session_id, timestamp)`.
- **no-op when index exists** — the agent-created index is reused untouched (no duplicate, no error).
- **skipped without timestamp column** — a minimal `messages` schema doesn't get an index attempted and the listing degrades gracefully via the denormalized counts.
- **degrades on read-only db** — a read-only db can't create the index but the listing still returns without raising.

Full suite: **8474 passed, 9 skipped, 3 xpassed, 0 failures**. `ruff check` clean, `py_compile` clean.
