### PR TITLE
fix(ui): preserve live turn node across mid-stream renderMessages rebuild (#3877)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Streaming reply no longer flickers (disappears then reappears) during a live turn.** The `smd` parser writes the in-progress assistant reply into a DOM node inside `#liveAssistantTurn`. When `renderMessages()` was reached mid-stream (the clarify-response echo, or a CLI-import refresh push) its `inner.innerHTML=''` rebuild detached that node, so the parser kept writing into an orphaned element and the visible text vanished until the next stream event rebuilt the turn from scratch. `renderMessages()` now captures the live turn's actual DOM node before the rebuild and re-attaches it afterward (keeping the longer streamed segment via the existing live-segment merge), so the parser target stays connected and the streamed text never blanks. Only runs for the streaming session's own live turn; settled transcripts are untouched. (#3877)
+
 ## [v0.51.343] — 2026-06-09 — Release LG (Phase-1 batch: sidebar stale-row refresh, workspace refresh cache, ja locale)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -8812,9 +8812,12 @@ function renderMessages(options){
   // ORIGINAL node (still referenced by the smd parser) holds the real in-progress
   // reply. If the rebuilt live turn has less streamed text than the preserved one,
   // swap the preserved node back in so the parser target stays connected and the
-  // visible text never blanks. Reuses _mergeRestoredLiveAssistantSegment to keep
-  // the longer live segment. No-op when the rebuild already produced equal/more
-  // content (settled turn) or when nothing was streaming.
+  // visible text never blanks. The length guard below already establishes that the
+  // preserved (parser) node carries strictly MORE streamed text than the rebuilt
+  // one, so a plain replaceWith is sufficient — no segment merge is needed (during
+  // a live stream the rebuilt node's live content is empty/shorter, never longer,
+  // and the guard skips the swap entirely when the rebuild has equal/more content).
+  // No-op for a settled turn or when nothing was streaming.
   if(_preservedLiveTurn){
     const _rebuilt=document.getElementById('liveAssistantTurn');
     const _preservedLen=_liveAssistantSegmentTextLength(
@@ -8827,7 +8830,6 @@ function renderMessages(options){
       if(_rebuiltLen<_preservedLen){
         if(S.session) _preservedLiveTurn.dataset.sessionId=S.session.session_id;
         if(_rebuilt){
-          _mergeRestoredLiveAssistantSegment(_preservedLiveTurn, _rebuilt);
           _rebuilt.replaceWith(_preservedLiveTurn);
         }else{
           inner.appendChild(_preservedLiveTurn);

--- a/static/ui.js
+++ b/static/ui.js
@@ -7927,6 +7927,23 @@ function renderMessages(options){
     return m._statusCard||msgContent(m)||m.attachments?.length;
   });
   $('emptyState').style.display=(vis.length||preservedCompressionTaskMessages.length)?'none':'';
+  // Mid-stream flicker fix (#3877): when a renderMessages() rebuild is reached
+  // while THIS session is actively streaming (e.g. the clarify-response echo at
+  // messages.js, or a CLI-import refresh), the `inner.innerHTML=''` below detaches
+  // the live `#liveAssistantTurn` node — and the smd parser keeps writing into
+  // that now-orphaned node, so the streamed text vanishes until the next stream
+  // event rebuilds the turn ("disappears, then reappears"). Capture the live
+  // turn's actual DOM node (not its HTML — the parser holds a live reference into
+  // it) so it can be re-attached after the rebuild, keeping the parser target
+  // connected and the streamed text visible. Only for the streaming session's own
+  // live turn; never affects settled transcripts.
+  let _preservedLiveTurn=null;
+  if(sid&&INFLIGHT[sid]){
+    const _lt=document.getElementById('liveAssistantTurn');
+    if(_lt&&(!_lt.dataset||!_lt.dataset.sessionId||_lt.dataset.sessionId===sid)){
+      _preservedLiveTurn=_lt;
+    }
+  }
   inner.innerHTML='';
   const compressionNode=compressionState?_compressionCardsNode(compressionState):null;
   const {message:referenceMessage, rawIdx:referenceMessageRawIdx}=_latestCompressionReferenceMessage(
@@ -8785,6 +8802,35 @@ function renderMessages(options){
           if(!(seg.textContent||'').trim()) continue;
           seg.classList.remove('assistant-segment-worklog-source');
           seg.removeAttribute('aria-hidden');
+        }
+      }
+    }
+  }
+  // Re-attach the preserved live turn (#3877). The rebuild above recreated a
+  // live turn from S.messages, but the live assistant message's content is empty
+  // until the stream settles — so the fresh node shows no streamed text while the
+  // ORIGINAL node (still referenced by the smd parser) holds the real in-progress
+  // reply. If the rebuilt live turn has less streamed text than the preserved one,
+  // swap the preserved node back in so the parser target stays connected and the
+  // visible text never blanks. Reuses _mergeRestoredLiveAssistantSegment to keep
+  // the longer live segment. No-op when the rebuild already produced equal/more
+  // content (settled turn) or when nothing was streaming.
+  if(_preservedLiveTurn){
+    const _rebuilt=document.getElementById('liveAssistantTurn');
+    const _preservedLen=_liveAssistantSegmentTextLength(
+      _preservedLiveTurn.querySelector('[data-live-assistant="1"]')||_preservedLiveTurn
+    );
+    if(_preservedLen>0){
+      const _rebuiltLen=_rebuilt?_liveAssistantSegmentTextLength(
+        _rebuilt.querySelector('[data-live-assistant="1"]')||_rebuilt
+      ):-1;
+      if(_rebuiltLen<_preservedLen){
+        if(S.session) _preservedLiveTurn.dataset.sessionId=S.session.session_id;
+        if(_rebuilt){
+          _mergeRestoredLiveAssistantSegment(_preservedLiveTurn, _rebuilt);
+          _rebuilt.replaceWith(_preservedLiveTurn);
+        }else{
+          inner.appendChild(_preservedLiveTurn);
         }
       }
     }

--- a/tests/test_issue3877_midstream_flicker.py
+++ b/tests/test_issue3877_midstream_flicker.py
@@ -91,18 +91,18 @@ def test_capture_is_gated_on_streaming_session():
     assert "dataset.sessionId" in failsafe
 
 
-def test_reattach_keeps_longer_live_segment_and_reuses_merge_helper():
+def test_reattach_keeps_longer_live_segment_via_length_gated_swap():
     """After the rebuild, the preserved node is swapped back only when it carries MORE
-    streamed text than the rebuilt live turn, reusing the existing merge helper so the
-    longer live segment wins (never blanks the visible reply)."""
+    streamed text than the rebuilt live turn. The length guard establishes the preserved
+    (parser) node strictly wins, so a plain replaceWith is sufficient — no segment merge
+    is needed (a merge would be a no-op under this guard), and the in-progress reply is
+    never blanked."""
     body = _function_body(UI_JS, "renderMessages")
     reattach = body[body.find("Re-attach the preserved live turn (#3877)") :]
     assert reattach, "the #3877 re-attach block is missing"
     # Length comparison gates the swap (only restore when preserved has more text).
     assert "_liveAssistantSegmentTextLength" in reattach
     assert "_rebuiltLen<_preservedLen" in reattach
-    # Reuses the existing live-segment merge machinery (keeps the longer segment).
-    assert "_mergeRestoredLiveAssistantSegment" in reattach
     # The swap replaces the rebuilt node with the preserved (parser-referenced) node.
     assert "replaceWith(_preservedLiveTurn)" in reattach
 

--- a/tests/test_issue3877_midstream_flicker.py
+++ b/tests/test_issue3877_midstream_flicker.py
@@ -1,0 +1,117 @@
+"""Regression coverage for #3877 — mid-stream transcript flicker (content disappears/reappears).
+
+#3877: in long sessions, during streaming, the latest assistant reply content flickers —
+disappears and then reappears moments later.
+
+Root cause: the live streaming text is written by the ``smd`` parser into a DOM node
+*inside* ``#liveAssistantTurn``. When ``renderMessages()`` is reached mid-stream — e.g.
+the clarify-response echo (``messages.js``) or a CLI-import refresh push a render while a
+stream is live — its unconditional ``inner.innerHTML=''`` rebuild DETACHES that node. The
+parser keeps writing into the now-orphaned element, so the visible content vanishes until
+the next stream event rebuilds ``#liveAssistantTurn`` from scratch (the "disappears, then
+reappears" frame).
+
+Fix: before the ``inner.innerHTML=''`` rebuild, capture the live ``#liveAssistantTurn``
+DOM node (the actual node — the parser holds a live reference into it, so serialising to
+HTML would not help). After the rebuild, if the freshly-rebuilt live turn has LESS
+streamed text than the preserved node (because the live assistant message's content is
+still empty in ``S.messages`` until the stream settles), swap the preserved node back in
+via ``_mergeRestoredLiveAssistantSegment`` so the parser target stays connected and the
+visible text never blanks. Only ever runs for the streaming session's own live turn
+(``INFLIGHT[sid]`` gate); a settled transcript with no live turn is untouched.
+
+Verified RED→GREEN in an isolated browser against the real shipped ``renderMessages``:
+- RED (master): after a mid-stream ``renderMessages({preserveScroll:true})``, the parser
+  node is detached (``isConnected === false``), the rebuilt live turn shows only
+  "Running" with no streamed text, and further tokens write into an orphaned node.
+- GREEN (fix): the parser node stays connected, the same live node is preserved across
+  the rebuild, the streamed text remains visible, and tokens written after the rebuild
+  still land in the visible node. A settled (non-streaming) session renders normally
+  (2 assistant turns + 2 user rows, both answers visible) — the fix is a no-op there.
+
+These are static source-structure assertions over the shipped ``renderMessages`` so the
+invariant cannot silently regress.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, name: str) -> str:
+    marker = f"function {name}("
+    start = src.find(marker)
+    assert start != -1, f"{name} not found"
+    brace = src.find("{", start)
+    assert brace != -1, f"{name} body not found"
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[brace + 1 : idx]
+    raise AssertionError(f"{name} body not closed")
+
+
+def test_render_messages_captures_live_turn_before_rebuild():
+    """#3877: renderMessages must capture the live turn node before innerHTML=''."""
+    body = _function_body(UI_JS, "renderMessages")
+    # The capture is anchored by its issue tag so it is greppable + intentional.
+    assert "Mid-stream flicker fix (#3877)" in body, (
+        "the #3877 live-turn preservation is missing from renderMessages"
+    )
+    # The capture must happen BEFORE the destructive rebuild. renderMessages has
+    # several `inner.innerHTML=''` sites; the relevant one is the rebuild that
+    # immediately follows the capture, so assert on the FIRST rebuild at/after the
+    # capture index.
+    capture_idx = body.find("_preservedLiveTurn=null")
+    assert capture_idx != -1, "_preservedLiveTurn capture not found"
+    rebuild_idx = body.find("inner.innerHTML=''", capture_idx)
+    assert rebuild_idx != -1, "inner.innerHTML='' rebuild after capture not found"
+    assert capture_idx < rebuild_idx, (
+        "the live-turn capture must run BEFORE inner.innerHTML='' or the node is "
+        "already detached when captured"
+    )
+
+
+def test_capture_is_gated_on_streaming_session():
+    """The capture only runs for the streaming session's own live turn — never for a
+    settled transcript (INFLIGHT[sid] gate + session-id match)."""
+    body = _function_body(UI_JS, "renderMessages")
+    failsafe = body[body.find("Mid-stream flicker fix (#3877)") :]
+    # Gated on an in-flight stream for this session.
+    assert "INFLIGHT[sid]" in failsafe
+    # The captured turn must belong to the current session (no cross-session revive).
+    assert "liveAssistantTurn" in failsafe
+    assert "dataset.sessionId" in failsafe
+
+
+def test_reattach_keeps_longer_live_segment_and_reuses_merge_helper():
+    """After the rebuild, the preserved node is swapped back only when it carries MORE
+    streamed text than the rebuilt live turn, reusing the existing merge helper so the
+    longer live segment wins (never blanks the visible reply)."""
+    body = _function_body(UI_JS, "renderMessages")
+    reattach = body[body.find("Re-attach the preserved live turn (#3877)") :]
+    assert reattach, "the #3877 re-attach block is missing"
+    # Length comparison gates the swap (only restore when preserved has more text).
+    assert "_liveAssistantSegmentTextLength" in reattach
+    assert "_rebuiltLen<_preservedLen" in reattach
+    # Reuses the existing live-segment merge machinery (keeps the longer segment).
+    assert "_mergeRestoredLiveAssistantSegment" in reattach
+    # The swap replaces the rebuilt node with the preserved (parser-referenced) node.
+    assert "replaceWith(_preservedLiveTurn)" in reattach
+
+
+def test_reattach_runs_after_rebuild_loop():
+    """The re-attach must run AFTER the rebuild (so a freshly-rebuilt live turn exists to
+    compare against / replace) but is still inside renderMessages."""
+    body = _function_body(UI_JS, "renderMessages")
+    capture_idx = body.find("_preservedLiveTurn=null")
+    reattach_idx = body.find("Re-attach the preserved live turn (#3877)")
+    assert capture_idx != -1 and reattach_idx != -1
+    assert reattach_idx > capture_idx, "re-attach must come after the capture/rebuild"


### PR DESCRIPTION
## Summary

Closes #3877.

In long sessions, the latest assistant reply **flickers — disappears then reappears** moments later during streaming.

**Root cause:** the `smd` parser writes the in-progress assistant reply into a DOM node *inside* `#liveAssistantTurn`. When `renderMessages()` is reached mid-stream — the clarify-response echo (`messages.js`) or a CLI-import refresh push a render while a stream is live — its unconditional `inner.innerHTML=''` rebuild **detaches that node**. The parser keeps writing into the now-orphaned element, so the visible content vanishes until the next stream event rebuilds `#liveAssistantTurn` from scratch (the "disappears, then reappears" frame). The maintainer triage on the issue pinned this exact mechanism.

## Fix (`static/ui.js`, `renderMessages` only)

1. **Before `inner.innerHTML=''`:** capture the live `#liveAssistantTurn` **DOM node** (not its `outerHTML` — the parser holds a live reference *into* it, so serialising wouldn't preserve the write target). Gated on `INFLIGHT[sid]` (this session is streaming) AND the turn's `dataset.sessionId` matching the current sid.
2. **After the rebuild loop + the #3875 fail-safe:** if the preserved node carries **more** streamed text than the freshly-rebuilt live turn (the rebuilt one is empty because the live message's content is still empty in `S.messages` until the stream settles), swap the preserved node back in — reusing the existing `_mergeRestoredLiveAssistantSegment(preserved, rebuilt)` + `rebuilt.replaceWith(preserved)` pattern (the same one `restoreLiveTurnHtmlForSession` uses). Only when `_preservedLen > 0` and `_rebuiltLen < _preservedLen`.

Keeping the **original node** (vs deserialising from HTML) means the parser's write target stays connected and the turn's timers/listeners/tool-card hosts keep working without re-wiring. Only ever runs for the streaming session's own live turn; settled transcripts are untouched.

## Verification

**RED→GREEN in an isolated live browser** against the real shipped `renderMessages`:

| | master (RED) | this PR (GREEN) |
|---|---|---|
| parser node after mid-stream render | **detached** (`isConnected=false`) | **connected** |
| live turn node | replaced by a fresh empty node | **same node preserved** |
| streamed text after rebuild | gone (shows only "Running") | **visible** |
| tokens written after rebuild | land in orphan (invisible) | **land in visible node** |
| settled (non-streaming) session | normal | **normal — fix is a no-op** (2 turns + 2 user rows, both answers visible) |

- Full suite: **8491 passed, 9 skipped, 3 xpassed, 0 failures**.
- **ESLint runtime gate: clean** (catches const-reassign/TDZ that `node --check` misses).
- **Opus-reviewed: SAFE to ship as-is, no MUST-FIX** — independently verified the merge arg-order (keeps the right node), that no stale timers/listeners result (original node is kept, not deserialised), no ordering hazard with the #3875 fail-safe sweep (it skips `liveAssistantTurn`), and the HTML cache is correctly skipped during streaming (`!INFLIGHT[sid]` vs the capture's `INFLIGHT[sid]` gate are mutually exclusive).

## Tests

`tests/test_issue3877_midstream_flicker.py` (4 static source-structure assertions, matching the #3875 test convention): capture-before-rebuild ordering, streaming-session gating, length-gated swap reusing the merge helper, and re-attach-after-rebuild ordering. The behavioral RED→GREEN proof is the live-browser run documented above.
