### PR TITLE
fix(kanban): close the per-request DB connection in _conn()

### DIFF
--- a/api/kanban_bridge.py
+++ b/api/kanban_bridge.py
@@ -79,9 +79,24 @@ def _normalise_board_or_raise(raw):
 
 
 def _conn(board=None):
-    """Initialize the kanban DB for the given board slug and return a context-managed sqlite connection."""
+    """Initialize the kanban DB for the given board slug and return a context manager
+    that yields a sqlite connection and CLOSES it on exit.
+
+    Must be ``kb.connect_closing`` — a raw ``kb.connect()`` connection used as
+    ``with _conn(...) as conn:`` only gets sqlite3's transaction-scope context
+    manager, which never closes the file descriptor. In this long-lived server
+    that leaks one FD per request and pins stale WAL snapshots (FDs to deleted
+    ``-wal``/``-shm`` files), which starves SQLite checkpoints on the shared
+    kanban DB and aggravates probe⇄checkpoint contention for every process.
+    """
     kb = _kb()
     kb.init_db(board=board)
+    closing = getattr(kb, "connect_closing", None)
+    if closing is not None:
+        return closing(board=board)
+    # Older kanban_db builds (and lightweight test doubles) without
+    # connect_closing: fall back to the raw connection; sqlite3's own
+    # context manager at least scopes the transaction.
     return kb.connect(board=board)
 
 


### PR DESCRIPTION
## Problem

`api/kanban_bridge.py::_conn()` returns a raw `kb.connect()` connection, and every call site uses it as `with _conn(...) as conn:`. But sqlite3's connection context manager only scopes the **transaction** — it never closes the file descriptor.

In this long-lived server that means **one leaked FD per kanban API request**. Observed in production (WSL2 host, hermes-agent kanban board under dispatcher load):

- the webui process accumulating multiple handles to `kanban.db`, plus FDs to **deleted** `-wal`/`-shm` files;
- those stale handles pin old WAL snapshots, which starves SQLite checkpoints on the shared board DB and aggravates probe/checkpoint contention for **every other process** using the board (gateway watchers, CLI workers);
- eventually the same failure class as hermes-agent#33159 (`[Errno 24] Too many open files`).

## Fix

Use `kb.connect_closing()` — added to hermes-agent for exactly this incident class (#33159) — with a `getattr` fallback to the raw connection for older `kanban_db` builds and lightweight test doubles (the suite's `FakeKanbanDB` keeps working unchanged).

## Verification

- `tests/test_kanban_bridge.py` + `tests/test_issue1823_kanban_not_found.py`: 52/52 pass.
- Live check after deploy: 6 consecutive `/api/kanban/board` requests → **0** kanban FDs held by the webui process (previously 4+ including deleted-file handles).



🤖 Generated with [Claude Code](https://claude.com/claude-code)
