### PR TITLE
Fix queue and draft restore durability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Queued follow-up messages and draft-only sessions are more durable across refresh and tab restore.** Session queues now mirror to both `sessionStorage` and `localStorage`, restore through one shared helper, clear stale queue state from both storage layers, and keep zero-message sessions when they still own unsent composer draft text or files. (#3108)
+
 ## [v0.51.347] — 2026-06-09 — Release LK (streaming & render reliability cluster)
 
 ### Fixed

--- a/static/boot.js
+++ b/static/boot.js
@@ -2044,7 +2044,13 @@ function applyBotName(){
         S.session.active_stream_id ||
         S.session.pending_user_message
       );
-      if(S.session && (S.session.message_count||0) === 0 && !_restoredInFlight){
+      const _restoredDraft = (S.session && S.session.composer_draft) || {};
+      const _restoredDraftText = String(_restoredDraft.text||'').trim();
+      const _restoredDraftFiles = Array.isArray(_restoredDraft.files)
+        ? _restoredDraft.files.filter(Boolean)
+        : [];
+      const _restoredHasDraft = !!(_restoredDraftText || _restoredDraftFiles.length);
+      if(S.session && (S.session.message_count||0) === 0 && !_restoredInFlight && !_restoredHasDraft){
         S.session=null; S.messages=[];
         S._bootReady=true;
         // Restore panel pref before syncing so the workspace panel stays visible

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1110,34 +1110,29 @@ async function loadSession(sid){
     // Stale? A newer loadSession() call has already started (#1060).
     if (_loadingSessionId !== sid) return;
 
-    // Restore any queued message that survived page refresh via sessionStorage.
+    // Restore any queued message that survived page refresh or tab restore.
     if(typeof queueSessionMessage==='function'){
       try{
-        const _storedQ=sessionStorage.getItem('hermes-queue-'+sid);
-        if(_storedQ){
-          const _entries=JSON.parse(_storedQ);
-          if(Array.isArray(_entries)&&_entries.length){
-            const _lastMsg=S.messages.slice().reverse()
-              .find(m=>m&&m.role==='assistant');
-            const _lastAsst=_lastMsg?(_lastMsg.timestamp||_lastMsg._ts||0)*1000:0;
-            const _fresh=_entries.filter(e=>!e._queued_at||e._queued_at>_lastAsst);
-            if(_fresh.length){
-              const _first=_fresh[0];
-              const _msg=$&&$('msg');
-              if(_msg&&_first.text&&!_msg.value){
-                _msg.value=_first.text||'';
-                if(typeof autoResize==='function') autoResize();
-                if(typeof showToast==='function') showToast((_fresh.length>1?`${_fresh.length} queued messages restored (showing first)`:'Queued message restored')+' — review and send when ready');
-              }
-              sessionStorage.removeItem('hermes-queue-'+sid);
-            } else {
-              sessionStorage.removeItem('hermes-queue-'+sid);
+        const _entries=typeof _readPersistedSessionQueue==='function'
+          ? _readPersistedSessionQueue(sid)
+          : [];
+        if(Array.isArray(_entries)&&_entries.length){
+          const _lastMsg=S.messages.slice().reverse()
+            .find(m=>m&&m.role==='assistant');
+          const _lastAsst=_lastMsg?(_lastMsg.timestamp||_lastMsg._ts||0)*1000:0;
+          const _fresh=_entries.filter(e=>!e._queued_at||e._queued_at>_lastAsst);
+          if(_fresh.length){
+            const _first=_fresh[0];
+            const _msg=$&&$('msg');
+            if(_msg&&_first.text&&!_msg.value){
+              _msg.value=_first.text||'';
+              if(typeof autoResize==='function') autoResize();
+              if(typeof showToast==='function') showToast((_fresh.length>1?`${_fresh.length} queued messages restored (showing first)`:'Queued message restored')+' — review and send when ready');
             }
-          } else {
-            sessionStorage.removeItem('hermes-queue-'+sid);
           }
+          if(typeof _clearPersistedSessionQueue==='function') _clearPersistedSessionQueue(sid);
         }
-      }catch(_){sessionStorage.removeItem('hermes-queue-'+sid);}
+      }catch(_){if(typeof _clearPersistedSessionQueue==='function') _clearPersistedSessionQueue(sid);}
     }
 
     // Reconstruct tool calls from message metadata, or fall back to session-level summary.
@@ -5840,6 +5835,7 @@ async function deleteSession(sid, beforeDelete=null){
     return false;
   }
   const response=deleteResult&&deleteResult.response;
+  if(typeof _clearPersistedSessionQueue==='function') _clearPersistedSessionQueue(sid);
   if(!optimisticRendered){
     _pendingSessionReflowPositions=reflowPositions;
     _optimisticallyRemoveSessionFromList(sid);

--- a/static/ui.js
+++ b/static/ui.js
@@ -163,14 +163,52 @@ function _getSessionQueue(sid, create=false){
   if(!SESSION_QUEUES[sid]&&create) SESSION_QUEUES[sid]=[];
   return SESSION_QUEUES[sid]||[];
 }
+function _queueStorageKey(sid){
+  return 'hermes-queue-'+sid;
+}
+function _clearPersistedSessionQueue(sid){
+  if(!sid) return;
+  const key=_queueStorageKey(sid);
+  try{sessionStorage.removeItem(key);}catch(_){}
+  try{localStorage.removeItem(key);}catch(_){}
+}
+function _persistSessionQueueStorage(sid, queue){
+  if(!sid) return;
+  const q=Array.isArray(queue)?queue:[];
+  if(!q.length){_clearPersistedSessionQueue(sid);return;}
+  const key=_queueStorageKey(sid);
+  let payload='[]';
+  try{payload=JSON.stringify(q);}catch(_){return;}
+  try{sessionStorage.setItem(key,payload);}catch(_){}
+  try{localStorage.setItem(key,payload);}catch(_){}
+}
+function _readPersistedSessionQueue(sid){
+  if(!sid) return [];
+  const key=_queueStorageKey(sid);
+  const read=(store)=>{
+    try{
+      const raw=store&&store.getItem?store.getItem(key):null;
+      if(!raw) return null;
+      const parsed=JSON.parse(raw);
+      return Array.isArray(parsed)?parsed:null;
+    }catch(_){return null;}
+  };
+  const sessionValue=read(sessionStorage);
+  if(sessionValue&&sessionValue.length) return sessionValue;
+  const localValue=read(localStorage);
+  if(localValue&&localValue.length){
+    try{sessionStorage.setItem(key,JSON.stringify(localValue));}catch(_){}
+    return localValue;
+  }
+  return [];
+}
 function queueSessionMessage(sid, payload){
   if(!sid||!payload) return 0;
   const q=_getSessionQueue(sid,true);
   // Stamp created_at so the restore path can detect stale entries (agent already responded)
   const entry={...payload, _queued_at: Date.now()};
   q.push(entry);
-  // Persist to sessionStorage so the queue survives page refresh
-  try{ sessionStorage.setItem('hermes-queue-'+sid, JSON.stringify(q)); }catch(_){}
+  _persistSessionQueueStorage(sid,q);
   return q.length;
 }
 function shiftQueuedSessionMessage(sid){
@@ -179,9 +217,9 @@ function shiftQueuedSessionMessage(sid){
   const next=q.shift();
   if(!q.length){
     delete SESSION_QUEUES[sid];
-    try{ sessionStorage.removeItem('hermes-queue-'+sid); }catch(_){}
+    _clearPersistedSessionQueue(sid);
   } else {
-    try{ sessionStorage.setItem('hermes-queue-'+sid, JSON.stringify(q)); }catch(_){}
+    _persistSessionQueueStorage(sid,q);
   }
   return next;
 }
@@ -4204,8 +4242,8 @@ function _renderQueueChips(sid){
 
   function _saveAndRefresh(){
     const liveQ=_getSessionQueue(sid,false);
-    if(!liveQ.length){delete SESSION_QUEUES[sid];try{sessionStorage.removeItem('hermes-queue-'+sid);}catch(_){}}
-    else{SESSION_QUEUES[sid]=[...liveQ];try{sessionStorage.setItem('hermes-queue-'+sid,JSON.stringify(liveQ));}catch(_){}}
+    if(!liveQ.length){delete SESSION_QUEUES[sid];_clearPersistedSessionQueue(sid);}
+    else{SESSION_QUEUES[sid]=[...liveQ];_persistSessionQueueStorage(sid,liveQ);}
     delete _queueRenderKeys[sid];
     updateQueueBadge(sid);
   }
@@ -4232,7 +4270,7 @@ function _renderQueueChips(sid){
         const firstFiles=(snapshot.find(e=>e&&Array.isArray(e.files)&&e.files.length)||{files:[]}).files;
         liveQ.length=0;liveQ.push({text:combined,files:firstFiles,model:first.model||'',model_provider:first.model_provider||null,_queued_at:Date.now()});
         SESSION_QUEUES[sid]=liveQ;
-        try{sessionStorage.setItem('hermes-queue-'+sid,JSON.stringify(liveQ));}catch(_){}
+        _persistSessionQueueStorage(sid,liveQ);
         delete _queueRenderKeys[sid];
         updateQueueBadge(sid);
       };
@@ -4312,7 +4350,7 @@ function _renderQueueChips(sid){
         const idx=_entryTs!=null?liveQ.findIndex(e=>e&&e._queued_at===_entryTs):i;
         if(idx!==-1){
           liveQ[idx]={...liveQ[idx],text:newText};
-          try{sessionStorage.setItem('hermes-queue-'+sid,JSON.stringify(liveQ));}catch(_){}
+          _persistSessionQueueStorage(sid,liveQ);
           delete _queueRenderKeys[sid];
           updateQueueBadge(sid);
         }
@@ -4351,8 +4389,8 @@ function _renderQueueChips(sid){
       const liveQ=_getSessionQueue(sid,false);
       const idx=_entryTs!=null?liveQ.findIndex(e=>e&&e._queued_at===_entryTs):i;
       if(idx!==-1) liveQ.splice(idx,1);
-      if(!liveQ.length){delete SESSION_QUEUES[sid];try{sessionStorage.removeItem('hermes-queue-'+sid);}catch(_){}}
-      else{SESSION_QUEUES[sid]=[...liveQ];try{sessionStorage.setItem('hermes-queue-'+sid,JSON.stringify(liveQ));}catch(_){}}
+      if(!liveQ.length){delete SESSION_QUEUES[sid];_clearPersistedSessionQueue(sid);}
+      else{SESSION_QUEUES[sid]=[...liveQ];_persistSessionQueueStorage(sid,liveQ);}
       delete _queueRenderKeys[sid];
       updateQueueBadge(sid);
     };

--- a/tests/test_issue660.py
+++ b/tests/test_issue660.py
@@ -1,8 +1,9 @@
 """
-Tests for #660: session queue persistence across page refresh.
+Tests for session queue persistence across page refresh and tab restore.
 
-The queue is stored to sessionStorage when entries are added/removed,
-and restored from sessionStorage on session load when the agent is idle.
+#660 introduced sessionStorage persistence. #3108 hardens it by mirroring queue
+state to localStorage and restoring from the durable copy when sessionStorage is
+missing after browser tab/process restore.
 """
 import pathlib
 
@@ -14,35 +15,62 @@ sess_src = SESSIONS_JS.read_text(encoding='utf-8')
 
 
 class TestQueuePersistence:
-    """queueSessionMessage persists to sessionStorage."""
+    """queueSessionMessage persists through the shared dual-storage helper."""
 
-    def test_queue_writes_to_session_storage(self):
-        """queueSessionMessage must write to sessionStorage after enqueueing."""
-        assert "sessionStorage.setItem('hermes-queue-'+sid" in ui_src
+    def test_queue_storage_helpers_exist(self):
+        """Queue persistence must be centralized so write/delete paths stay symmetric."""
+        assert "function _queueStorageKey(sid)" in ui_src
+        assert "function _persistSessionQueueStorage(sid, queue)" in ui_src
+        assert "function _readPersistedSessionQueue(sid)" in ui_src
+        assert "function _clearPersistedSessionQueue(sid)" in ui_src
+
+    def test_queue_writes_to_session_and_local_storage(self):
+        """queueSessionMessage must mirror queue state to sessionStorage and localStorage."""
+        helper_start = ui_src.find("function _persistSessionQueueStorage(sid, queue)")
+        helper_end = ui_src.find("function _readPersistedSessionQueue(sid)", helper_start)
+        assert helper_start != -1 and helper_end != -1, "_persistSessionQueueStorage helper not found"
+        helper = ui_src[helper_start:helper_end]
+        assert "sessionStorage.setItem(key,payload)" in helper
+        assert "localStorage.setItem(key,payload)" in helper
 
     def test_queue_stamps_queued_at_timestamp(self):
         """Each queue entry must have a _queued_at timestamp for stale-entry detection."""
         assert '_queued_at' in ui_src
 
-    def test_shift_removes_from_session_storage(self):
-        """shiftQueuedSessionMessage must remove/update sessionStorage on dequeue."""
-        assert "sessionStorage.removeItem('hermes-queue-'+sid)" in ui_src
+    def test_shift_uses_shared_persist_and_clear_helpers(self):
+        """shiftQueuedSessionMessage must update/remove both storage layers through helpers."""
+        start = ui_src.find("function shiftQueuedSessionMessage(sid)")
+        end = ui_src.find("function getQueuedSessionCount(sid)", start)
+        assert start != -1 and end != -1, "shiftQueuedSessionMessage block not found"
+        body = ui_src[start:end]
+        assert "_clearPersistedSessionQueue(sid)" in body
+        assert "_persistSessionQueueStorage(sid,q)" in body
 
-    def test_shift_updates_session_storage_when_items_remain(self):
-        """When queue still has items after shift, sessionStorage is updated (not removed)."""
-        # After shift: if queue still has items, update storage with remaining
-        assert "sessionStorage.setItem('hermes-queue-'+sid, JSON.stringify(q))" in ui_src
-        # Counts: should appear in both add and update paths (2 occurrences minimum)
-        count = ui_src.count("sessionStorage.setItem('hermes-queue-'+sid")
-        assert count >= 2, f"Expected >=2 sessionStorage.setItem calls, found {count}"
+    def test_queue_card_edit_paths_use_shared_helpers(self):
+        """Queue edit/combine/delete paths must not leave localStorage stale."""
+        assert "_saveAndRefresh()" in ui_src
+        assert "_persistSessionQueueStorage(sid,liveQ)" in ui_src
+        assert "_clearPersistedSessionQueue(sid)" in ui_src
 
 
 class TestQueueRestore:
-    """Queue is restored from sessionStorage on session load when agent is idle."""
+    """Queue is restored from the shared storage helper on idle session load."""
 
-    def test_restore_reads_session_storage(self):
-        """sessions.js must read from sessionStorage in the idle-session load path."""
-        assert "sessionStorage.getItem('hermes-queue-'+sid)" in sess_src
+    def test_restore_reads_shared_helper(self):
+        """sessions.js must use the shared helper so localStorage fallback is reachable."""
+        assert "_readPersistedSessionQueue(sid)" in sess_src
+
+    def test_read_helper_falls_back_to_local_storage(self):
+        """The helper must fall back to localStorage and re-mirror sessionStorage."""
+        start = ui_src.find("function _readPersistedSessionQueue(sid)")
+        end = ui_src.find("function queueSessionMessage(sid", start)
+        assert start != -1 and end != -1, "_readPersistedSessionQueue block not found"
+        body = ui_src[start:end]
+        assert "const sessionValue=read(sessionStorage)" in body
+        assert "if(sessionValue&&sessionValue.length) return sessionValue;" in body
+        assert "const localValue=read(localStorage)" in body
+        assert "if(localValue&&localValue.length)" in body
+        assert "sessionStorage.setItem(key,JSON.stringify(localValue))" in body
 
     def test_restore_uses_timestamp_guard(self):
         """Stale entries (created before last assistant response) must be dropped."""
@@ -58,19 +86,30 @@ class TestQueueRestore:
         assert "_msg.value=_first.text" in sess_src
 
     def test_restore_clears_stale_storage(self):
-        """On timestamp mismatch, stale sessionStorage entry is removed."""
-        assert "sessionStorage.removeItem('hermes-queue-'+sid)" in sess_src
+        """On timestamp mismatch, stale queue state is removed from both storage layers."""
+        assert "_clearPersistedSessionQueue(sid)" in sess_src
 
     def test_restore_wrapped_in_try_catch(self):
-        """sessionStorage access must be wrapped in try/catch (private browsing may block it)."""
-        # The restore block must have a catch that clears the bad key
-        assert "catch(_){sessionStorage.removeItem" in sess_src
+        """Storage access must be wrapped in try/catch (private browsing may block it)."""
+        assert "catch(_){if(typeof _clearPersistedSessionQueue==='function') _clearPersistedSessionQueue(sid);}" in sess_src
+
+    def test_delete_session_clears_persisted_queue_after_success(self):
+        """Deleting a session must clear localStorage-backed queue state after the API succeeds."""
+        start = sess_src.find("async function deleteSession(sid, beforeDelete=null)")
+        end = sess_src.find("// ── Project helpers", start)
+        assert start != -1 and end != -1, "deleteSession block not found"
+        body = sess_src[start:end]
+        clear_pos = body.find("if(typeof _clearPersistedSessionQueue==='function') _clearPersistedSessionQueue(sid);")
+        error_pos = body.find("if(deleteResult&&deleteResult.error){")
+        success_pos = body.find("const response=deleteResult&&deleteResult.response;")
+        assert error_pos != -1 and success_pos != -1 and clear_pos != -1
+        assert success_pos < clear_pos, "queue cleanup should run only after delete success"
 
     def test_active_session_not_restored_as_draft(self):
         """When agent is active (INFLIGHT), queue restore must NOT run."""
         # The restore block must be inside the else branch (idle path), not the INFLIGHT branch
         inflight_pos = sess_src.find("if(INFLIGHT[sid]){")
-        restore_pos = sess_src.find("sessionStorage.getItem('hermes-queue-'")
+        restore_pos = sess_src.find("_readPersistedSessionQueue(sid)")
         else_pos = sess_src.find("}else{", inflight_pos)
         assert restore_pos > else_pos, \
             "Queue restore must be inside the else (idle) branch, not the INFLIGHT branch"

--- a/tests/test_issue_new_chat_draft_restore.py
+++ b/tests/test_issue_new_chat_draft_restore.py
@@ -110,3 +110,19 @@ def test_clear_composer_draft_forgets_same_new_chat_candidate():
     assert "_clearRememberedNewChatDraftSession(sid);" in body, (
         "sending a draft must stop New Chat from restoring that now-cleared candidate"
     )
+
+
+def test_boot_restore_preserves_zero_message_session_with_composer_draft():
+    """A hard refresh should not discard a zero-message session that owns unsent draft text/files."""
+    marker = "const _restoredInFlight = S.session && ("
+    start = BOOT_JS.find(marker)
+    end = BOOT_JS.find("// Restore the panel from localStorage", start)
+    assert start != -1 and end != -1, "boot restored-session cleanup block not found"
+    body = BOOT_JS[start:end]
+    assert "const _restoredDraft = (S.session && S.session.composer_draft) || {};" in body
+    assert "const _restoredDraftText = String(_restoredDraft.text||'').trim();" in body
+    assert "const _restoredDraftFiles = Array.isArray(_restoredDraft.files)" in body
+    assert "const _restoredHasDraft = !!(_restoredDraftText || _restoredDraftFiles.length);" in body
+    assert "&& !_restoredInFlight && !_restoredHasDraft" in body, (
+        "zero-message restored sessions should only be dropped when they have no draft"
+    )


### PR DESCRIPTION
## Thinking Path

- #3108 identifies two user-visible durability gaps: queued follow-up messages can disappear when browser tab/session storage is lost, and zero-message sessions with unsent composer drafts can be discarded on boot restore.
- The current implementation only persisted queue state to `sessionStorage` and restored only from that same storage layer, so tab/process restore paths with fresh `sessionStorage` still lost the pending intent.
- The fix belongs in the WebUI-owned pending-intent presentation/recovery layer, not in runtime steer/applied semantics or Stop-and-send UI.
- This PR keeps the old behavior shape but makes the queue persistence symmetric: write, restore, and clear go through shared helpers that mirror `sessionStorage` and `localStorage`.
- It also preserves restored zero-message sessions when they still own unsent composer draft text or files.

## What Changed

- Added shared queue storage helpers in `static/ui.js`:
  - `_queueStorageKey()`
  - `_persistSessionQueueStorage()`
  - `_readPersistedSessionQueue()`
  - `_clearPersistedSessionQueue()`
- Mirrored queued-message persistence to both `sessionStorage` and `localStorage`.
- Updated dequeue, queue-card edit/combine/delete, and stale-queue cleanup paths to use the same helpers so the two storage layers do not diverge.
- Updated idle-session restore in `static/sessions.js` to read through the shared helper, including localStorage fallback when sessionStorage is missing.
- Updated boot restore in `static/boot.js` so a zero-message restored session is only treated as ephemeral when it has no in-flight state and no composer draft text/files.
- Updated regression coverage in `tests/test_issue660.py` and `tests/test_issue_new_chat_draft_restore.py`.
- Added a release-note entry under `CHANGELOG.md`.

## Why It Matters

Queued follow-up messages are user intent. They should not be lost just because a browser process recycles or tab restore recreates `sessionStorage`.

Draft-only sessions are also real user work. A session with zero visible messages but non-empty composer draft state should not be discarded as an empty scratch session on refresh.

## Contract Routing

Task type: pending-intent recovery / session durability bugfix.

Touched areas:
- `static/ui.js`
- `static/sessions.js`
- `static/boot.js`
- queue/draft regression tests

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-pending-intent-controls.md`

Scope boundaries:
- Does not implement Stop-and-send UI.
- Does not change Steer delivered/applied semantics.
- Does not add a server-side queue scheduler.
- Does not alter runtime adapter behavior.

## Verification

- `node --check static/ui.js && node --check static/sessions.js && node --check static/boot.js`
- `python3 -m pytest tests/test_issue660.py tests/test_issue_new_chat_draft_restore.py tests/test_1062_busy_input_modes.py -q`
  - `48 passed`
- `git diff --check`

Also ran:

- `python3 scripts/scope_undef_gate.py`
  - skipped locally because `eslint` is not installed on PATH.

Notes:

- A broader `tests/test_regressions.py` run under system Python 3.9 hit existing Python-version incompatibility in `api/config.py` (`Path | None` requires Python 3.10+). I did not continue environment setup in this PR; the targeted queue/draft tests and JS checks above passed.

## Risks / Follow-ups

- This keeps queue persistence browser-backed. It is stronger than sessionStorage-only, but it is not a server-side durable queue.
- If future pending-intent work needs cross-device recovery, that should be a separate server/session-sidecar design.
- This PR intentionally does not address #3859 composer affordance ambiguity or #2555 Steer applied traceability.

Fixes #3108.

## Model Used

OpenAI GPT-5 Codex, with local shell/codegraph tooling for repo inspection, editing, and verification. AI assisted with the implementation and PR preparation.
