### PR TITLE
fix: prevent Settings panel from auto-reopening when user is on Chat panel

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -6066,15 +6066,13 @@ function _toggleTabVisibilityChip(panel){
 }
 
 function switchSettingsSection(name){
-  // If the main content is not showing settings, switch back first
+  // If the main content is not showing settings, just remember the section
+  // without force-switching the panel. The section will be applied when the
+  // user next opens settings via switchPanel(). (#appearance-auto-reopen)
   if (_currentPanel !== 'settings') {
-    _currentPanel = 'settings';
-    var mainEl = document.querySelector('main.main');
-    if (mainEl) {
-      ['settings','skills','memory','tasks','kanban','workspaces','profiles','insights','logs','plugin'].forEach(function(p) {
-        mainEl.classList.toggle('showing-' + p, p === 'settings');
-      });
-    }
+    _currentSettingsSection = name;
+    _settingsSection = name;
+    return;
   }
   let section=(name==='appearance'||name==='preferences'||name==='providers'||name==='plugins'||name==='system'||name==='help')?name:'conversation';
   // Deep-linking to the Plugins pane when the tab is hidden (no plugins


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI uses a panel-based navigation model (Chat, Settings, Tasks, etc.)
- The Settings panel has sub-sections (Conversation, Appearance, Preferences, etc.)
- `switchSettingsSection()` manages which sub-section is visible
- The function had a dangerous fallback: when `_currentPanel !== 'settings'`, it **directly mutated** `_currentPanel` to `'settings'` and showed the settings DOM, bypassing `switchPanel()`'s normal flow
- `_currentSettingsSection` is never reset when leaving the Settings panel — so if you last viewed Appearance, it stays `'appearance'`
- Any code path calling `switchSettingsSection('appearance')` while on Chat would force-switch back to the Settings panel
- This race condition is especially visible on iPad/touch: `loadSettingsPanel()` is async; if the user switches away during the `await api('/api/settings')` call, the completion callback at line 6828 calls `switchSettingsSection(_settingsSection)`, which triggers the force-switch
- This PR fixes `switchSettingsSection()` to only **remember** the section when the user is not on the Settings panel, so it applies naturally on the next Settings open

## What Changed

- **`static/panels.js`**: `switchSettingsSection()` — when `_currentPanel !== 'settings'`, now stores the section name in both `_currentSettingsSection` and `_settingsSection` and returns early, instead of forcing `_currentPanel = 'settings'` and mutating the DOM directly

## Why It Matters

Users on iPad (and occasionally Desktop) would see the Settings panel auto-reopen — often on the Appearance tab — while they were actively chatting. This is a disruptive UX bug that breaks the user's flow and cannot be explained by user action.

The root cause was a race condition: `switchSettingsSection()` was designed as a "switch back if needed" helper but bypassed the proper panel-switching pipeline, making it possible for any async callback to hijack the active panel.

## Verification

### Code-level
- `switchSettingsSection()` no longer mutates `_currentPanel` or DOM when not in Settings
- `_currentSettingsSection` and `_settingsSection` are preserved so the correct tab shows on next Settings open
- `switchPanel('settings')` at line 265 still calls `switchSettingsSection(_currentSettingsSection)` normally

### Manual test plan
1. Open Settings → click Appearance tab
2. Switch back to Chat via rail/sidebar
3. Verify Chat panel stays active — Settings should NOT reappear
4. Open Settings again → verify Appearance tab is shown (section was remembered)
5. Repeat on desktop and iPad/mobile layouts

### Race condition reproduction
1. Open Settings (triggers async `loadSettingsPanel()`)
2. While settings are loading, click Chat
3. Verify Chat stays active after settings finish loading

## Risks / Follow-ups

- **Risk**: Code that intentionally called `switchSettingsSection()` while on a non-settings panel expecting the force-switch behavior. This is not a documented contract and is likely never intentional.
- **Follow-up**: Audit all callers of `switchSettingsSection()` to confirm none relied on the force-switch behavior.

## Model Used

- Provider: volcengine-coding-plan
- Model: deepseek-v4-flash
- Notable tool use: `search_files`, `read_file` for codebase navigation; `patch` for the fix; `terminal` for git operations
