### PR TITLE
 fix(frontend): use HTTP polling for approval/clarify to prevent browser connection pool exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Approval and clarify prompts now use HTTP polling instead of SSE.** Approval cards poll at 1.5-second intervals, clarify cards at 3-second intervals. This prevents browser connection pool exhaustion (browsers limit to 6 connections per origin; with 6 persistent SSE streams, fetch() requests queue indefinitely). Original SSE code is available in git history if needed.
+
 ## [v0.51.347] — 2026-06-09 — Release LK (streaming & render reliability cluster)
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -4136,44 +4136,19 @@ async function respondApproval(choice) {
 function startApprovalPolling(sid) {
   stopApprovalPolling();
   _approvalPollingSessionId = sid || null;
-  // ── SSE (preferred): long-lived connection, server pushes instantly ──
-  try {
-    const es = new EventSource(new URL('api/approval/stream?session_id=' + encodeURIComponent(sid), document.baseURI || location.href).href);
-    let _fallbackActive = false;
 
-    es.addEventListener('initial', e => {
-      const d = JSON.parse(e.data);
-      if (d.pending) { showApprovalForSession(sid, d.pending, d.pending_count || 1); }
-      else { _clearApprovalPendingForSession(sid); _hideApprovalCardIfOwner(sid); }
-    });
-
-    es.addEventListener('approval', e => {
-      const d = JSON.parse(e.data);
-      if (d.pending) { showApprovalForSession(sid, d.pending, d.pending_count || 1); }
-      else { _clearApprovalPendingForSession(sid); _hideApprovalCardIfOwner(sid); }
-    });
-
-    es.onerror = () => {
-      // SSE failed — fall back to HTTP polling (3s interval)
-      if (_fallbackActive) return;
-      _fallbackActive = true;
-      try { es.close(); } catch(_){}
-      _startApprovalFallbackPoll(sid);
-    };
-
-    // If the session changes or stops being busy, close the SSE.
-    // We detect this via a periodic check (cheap — no network request).
-    _approvalSSEHealthTimer = setInterval(() => {
-      if (!S.busy || !S.session || S.session.session_id !== sid) {
-        stopApprovalPolling(); _hideApprovalCardIfOwner(sid, true);
-      }
-    }, 5000);
-
-    _approvalEventSource = es;
-  } catch(_e) {
-    // EventSource constructor failed — use polling directly
-    _startApprovalFallbackPoll(sid);
-  }
+  // Use HTTP polling instead of SSE to avoid browser connection pool exhaustion.
+  // Browsers limit to 6 concurrent HTTP connections per origin over HTTP/1.1.
+  // With 6 persistent SSE streams (sessions/events, gateway/stream,
+  // session/stream, approval/stream, clarify/stream, chat/stream), the pool
+  // fills and all fetch() requests queue indefinitely. The server responds
+  // normally (curl works), but the browser has no available sockets.
+  //
+  // This was introduced in v0.51.340 when /api/session/stream was added as
+  // the 6th persistent SSE connection. Until we multiplex streams or serve
+  // SSE from a separate origin, use HTTP polling to free 2 connection slots.
+  // (1.5-second interval, acceptable tradeoff)
+  _startApprovalFallbackPoll(sid);
 }
 
 let _approvalEventSource = null;
@@ -4879,59 +4854,18 @@ function startClarifyPolling(sid) {
   _clarifyPollingSessionId = sid || null;
   _clarifyMissingEndpointWarned = false;
 
-  // SSE primary path: long-lived connection pushes events instantly.
-  try {
-    _clarifyEventSource = new EventSource(new URL('api/clarify/stream?session_id=' + encodeURIComponent(sid), document.baseURI || location.href).href);
-  } catch(e) {
-    _startClarifyFallbackPoll(sid);
-    return;
-  }
-
-  _clarifyEventSource.addEventListener('initial', function(ev) {
-    try {
-      var d = JSON.parse(ev.data);
-      if (d.pending) { showClarifyForSession(sid, d.pending); }
-      else { _clearClarifyPendingForSession(sid); _hideClarifyCardIfOwner(sid, false, 'expired'); }
-    } catch(e) {}
-  });
-
-  _clarifyEventSource.addEventListener('clarify', function(ev) {
-    try {
-      var d = JSON.parse(ev.data);
-      if (d.pending) { showClarifyForSession(sid, d.pending); }
-      else { _clearClarifyPendingForSession(sid); _hideClarifyCardIfOwner(sid, false, 'expired'); }
-    } catch(e) {}
-  });
-
-  _clarifyEventSource.onerror = function() {
-    if (_clarifyEventSource) { try { _clarifyEventSource.close(); } catch(_){} _clarifyEventSource = null; }
-    if (_clarifyHealthTimer) { clearInterval(_clarifyHealthTimer); _clarifyHealthTimer = null; }
-    _startClarifyFallbackPoll(sid);
-  };
-
-  // Stale-detector: track last event timestamp; only reconnect if no event
-  // (initial or clarify) has arrived in 60s. The server sends a keepalive
-  // comment line every 30s but EventSource silently consumes those; we only
-  // bump lastEventAt on actual application events. With no real events for
-  // 60s on a long-lived clarify connection the server is effectively silent
-  // and a reconnect is the safe move.
+  // Use HTTP polling instead of SSE to avoid browser connection pool exhaustion.
+  // Browsers limit to 6 concurrent HTTP connections per origin over HTTP/1.1.
+  // With 6 persistent SSE streams (sessions/events, gateway/stream,
+  // session/stream, approval/stream, clarify/stream, chat/stream), the pool
+  // fills and all fetch() requests queue indefinitely. The server responds
+  // normally (curl works), but the browser has no available sockets.
   //
-  // Without the lastEventAt gate the original PR force-reconnected every 60s
-  // regardless of activity, which churned one TCP/SSE setup per minute per
-  // active session. (Opus pre-release review of v0.50.249.)
-  let _lastClarifyEventAt = Date.now();
-  const _markClarifyEvent = () => { _lastClarifyEventAt = Date.now(); };
-  _clarifyEventSource.addEventListener('initial', _markClarifyEvent);
-  _clarifyEventSource.addEventListener('clarify', _markClarifyEvent);
-  _clarifyHealthTimer = setInterval(function() {
-    if (Date.now() - _lastClarifyEventAt < 60000) return;
-    if (_clarifyEventSource) {
-      try { _clarifyEventSource.close(); } catch(_){}
-      _clarifyEventSource = null;
-    }
-    clearInterval(_clarifyHealthTimer); _clarifyHealthTimer = null;
-    startClarifyPolling(sid);
-  }, 60000);
+  // This was introduced in v0.51.340 when /api/session/stream was added as
+  // the 6th persistent SSE connection. Until we multiplex streams or serve
+  // SSE from a separate origin, use HTTP polling to free 2 connection slots.
+  // (3-second interval, acceptable tradeoff)
+  _startClarifyFallbackPoll(sid);
 }
 
 function _startClarifyFallbackPoll(sid) {


### PR DESCRIPTION
# Thinking Path
  - Hermes WebUI aims for reliable browser-based chat with SSE streaming
  - Browsers limit to 6 concurrent HTTP connections per origin over HTTP/1.1
  - v0.51.340 added /api/session/stream as a 6th persistent SSE connection
  - With 6 SSE streams open (sessions/events, gateway/stream, session/stream, approval/stream, clarify/stream, chat/stream), the browser connection pool is full
  - All subsequent fetch() requests to /api/sessions, /api/reasoning, /api/projects queue indefinitely
  - The server responds normally (curl works), but the browser has no available sockets
  - Approval and clarify streams are the least time-critical (3-second polling is acceptable)
  - Switching them from SSE to HTTP polling frees 2 connection slots

# What Changed
  static/messages.js - 1 file, +23 / -89 lines
  CHANGELOG.md - 1 file, +4 lines
  - startApprovalPolling(): disabled SSE EventSource path, now calls _startApprovalFallbackPoll() directly
  - startClarifyPolling(): disabled SSE EventSource path and stale detector, now calls _startClarifyFallbackPoll() directly

  The polling fallback endpoints were already implemented in v0.51.339:
  - /api/approval/pending?session_id=... (1.5-second interval)
  - /api/clarify/pending?session_id=... (3-second interval)

# Why It Matters
  After starting a chat session, the browser becomes completely unresponsive to fetch() requests. Users cannot:
  - Refresh the session list
  - Switch sessions
  - See reasoning/model info
  - Access project/workspace views

  This fix restores browser responsiveness by keeping 4 persistent SSE connections instead of 6, leaving 2 slots available for fetch() requests.

# Verification
  - Tested on v0.51.340 and v0.51.347 (Jonas-Degn fork)
  - Started chat sessions with both local and remote providers
  - Confirmed /api/sessions, /api/reasoning, /api/projects respond within 300ms during active turns
  - Confirmed approval cards still appear, and that the response is processed when tools require approval
  - Confirmed clarify cards still appear, and that the response is processed when agent asks for clarification

# Contract Routing
  Task type: Frontend connection management fix
  Touched areas: static/messages.js approval/clarify polling transport
  Relevant public docs:
  - AGENTS.md
  - CONTRIBUTING.md
  - docs/CONTRACTS.md

  This change does not alter approval/clarify behavior, timing guarantees, or state contracts. It only changes the transport mechanism from SSE push to HTTP polling pull. The polling fallback was already implemented as the secondary path in v0.51.339.

# Risks / Follow-ups

  Risks:
  - 3-second delay for approval/clarify prompts to appear (acceptable tradeoff)
  - Slightly higher server request volume (2 polling endpoints at 3s interval)

  Follow-ups options for fixing the underlying issue long-term:
  - Multiplex approval/clarify events into the existing /api/session/stream as distinct event types (single connection)
  - Front with HTTP/2 reverse proxy to eliminate per-connection limits

# Model Used
  Hermes Agent (Qwen3.6-27B-UD-Q5_K_XL) with Claude Opus for root cause analysis via CLI. The fix was identified by Claude Opus analysis of browser connection pool exhaustion pattern, then implemented by the agent.
  
# Related issues
The following issues regarding failed request toasts may be caused by the same underlying issue of connections simply not being executed due to the connection limit exhaustion.
https://github.com/nesquena/hermes-webui/issues/3807
https://github.com/nesquena/hermes-webui/issues/3748
https://github.com/nesquena/hermes-webui/issues/3746