### PR TITLE
fix(sidebar): mark cron sessions unread when new runs land (#3460)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -273,7 +273,7 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
                            {select_message_count}
                     FROM sessions s
                     WHERE LOWER(COALESCE(s.source, '')) = 'cron'
-                    ORDER BY COALESCE(s.started_at, 0) DESC, s.id DESC
+                    ORDER BY COALESCE(s.started_at, 0) DESC, s.id DESC  -- newest start, not last activity
                 """
             else:
                 query = f"""
@@ -315,20 +315,6 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
     except sqlite3.Error:
         return {jid: {"session_id": "", "message_count": None} for jid in normalized}
 
-
-def _latest_cron_session_ids_for_jobs(job_ids) -> dict[str, str]:
-    return {
-        jid: info.get("session_id", "")
-        for jid, info in _latest_cron_session_info_for_jobs(job_ids).items()
-    }
-
-
-def _latest_cron_session_id_for_job(job_id: str) -> str:
-    """Return the newest persisted cron session id for ``job_id``."""
-    normalized = str(job_id or "").strip()
-    if not normalized:
-        return ""
-    return _latest_cron_session_ids_for_jobs([normalized]).get(normalized, "")
 
 
 def _session_field(session, field, default=None):
@@ -12674,7 +12660,7 @@ def _handle_cron_recent(handler, parsed):
                     }
                 )
         latest_session_info = _latest_cron_session_info_for_jobs(
-            [job.get("id", "") for job in jobs]
+            [c["job_id"] for c in completions]
         )
         for completion in completions:
             info = latest_session_info.get(str(completion.get("job_id", "") or ""), {})

--- a/api/routes.py
+++ b/api/routes.py
@@ -234,14 +234,32 @@ _CLIENT_EVENT_ALLOWED_FIELDS = {
 }
 
 
-def _latest_cron_session_id_for_job(job_id: str) -> str:
-    """Return the newest persisted cron session id for ``job_id``."""
-    normalized = str(job_id or "").strip()
+def _normalize_cron_job_ids(job_ids) -> list[str]:
+    seen = set()
+    normalized = []
+    for job_id in job_ids or []:
+        jid = str(job_id or "").strip()
+        if not jid or jid in seen:
+            continue
+        seen.add(jid)
+        normalized.append(jid)
+    return normalized
+
+
+def _cron_session_like_pattern(job_id: str) -> str:
+    escaped = str(job_id or "")
+    escaped = escaped.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"cron_{escaped}_%"
+
+
+def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str | None]]:
+    """Return newest persisted cron session info keyed by cron job id."""
+    normalized = _normalize_cron_job_ids(job_ids)
     if not normalized:
-        return ""
+        return {}
     db_path = _active_state_db_path()
     if not db_path or not Path(db_path).exists():
-        return ""
+        return {jid: {"session_id": "", "message_count": None} for jid in normalized}
     try:
         with closing(sqlite3.connect(str(db_path))) as conn:
             conn.row_factory = sqlite3.Row
@@ -249,23 +267,72 @@ def _latest_cron_session_id_for_job(job_id: str) -> str:
             cur.execute("PRAGMA table_info(sessions)")
             session_cols = {row[1] for row in cur.fetchall()}
             if "id" not in session_cols or "source" not in session_cols:
-                return ""
-            order_expr = "COALESCE(s.started_at, 0) DESC, s.id DESC" if "started_at" in session_cols else "s.id DESC"
-            cur.execute(
-                f"""
-                SELECT s.id
-                FROM sessions s
-                WHERE LOWER(COALESCE(s.source, '')) = 'cron'
-                  AND s.id LIKE ?
-                ORDER BY {order_expr}
-                LIMIT 1
-                """,
-                (f"cron_{normalized}_%",),
+                return {jid: {"session_id": "", "message_count": None} for jid in normalized}
+            case_clauses = " ".join(["WHEN s.id LIKE ? ESCAPE '\\' THEN ?"] * len(normalized))
+            where_clauses = " OR ".join(["s.id LIKE ? ESCAPE '\\'"] * len(normalized))
+            select_message_count = (
+                "COALESCE(s.message_count, NULL) AS message_count"
+                if "message_count" in session_cols
+                else "NULL AS message_count"
             )
-            row = cur.fetchone()
-            return str(row["id"]) if row and row["id"] else ""
+            params = []
+            for jid in normalized:
+                params.extend((_cron_session_like_pattern(jid), jid))
+            for jid in normalized:
+                params.append(_cron_session_like_pattern(jid))
+            if "started_at" in session_cols:
+                query = f"""
+                    SELECT s.id,
+                           {select_message_count},
+                           CASE {case_clauses} ELSE '' END AS job_id
+                    FROM sessions s
+                    WHERE LOWER(COALESCE(s.source, '')) = 'cron'
+                      AND ({where_clauses})
+                    ORDER BY COALESCE(s.started_at, 0) DESC, s.id DESC
+                """
+            else:
+                query = f"""
+                    SELECT s.id,
+                           {select_message_count},
+                           CASE {case_clauses} ELSE '' END AS job_id
+                    FROM sessions s
+                    WHERE LOWER(COALESCE(s.source, '')) = 'cron'
+                      AND ({where_clauses})
+                    ORDER BY s.id DESC
+                """
+            cur.execute(query, params)
+            results = {
+                jid: {"session_id": "", "message_count": None} for jid in normalized
+            }
+            for row in cur.fetchall():
+                jid = str(row["job_id"] or "")
+                if jid and not results[jid]["session_id"]:
+                    results[jid] = {
+                        "session_id": str(row["id"] or ""),
+                        "message_count": (
+                            int(row["message_count"])
+                            if row["message_count"] is not None
+                            else None
+                        ),
+                    }
+            return results
     except sqlite3.Error:
+        return {jid: {"session_id": "", "message_count": None} for jid in normalized}
+
+
+def _latest_cron_session_ids_for_jobs(job_ids) -> dict[str, str]:
+    return {
+        jid: info.get("session_id", "")
+        for jid, info in _latest_cron_session_info_for_jobs(job_ids).items()
+    }
+
+
+def _latest_cron_session_id_for_job(job_id: str) -> str:
+    """Return the newest persisted cron session id for ``job_id``."""
+    normalized = str(job_id or "").strip()
+    if not normalized:
         return ""
+    return _latest_cron_session_ids_for_jobs([normalized]).get(normalized, "")
 
 
 def _session_field(session, field, default=None):
@@ -12604,13 +12671,20 @@ def _handle_cron_recent(handler, parsed):
                 completions.append(
                     {
                         "job_id": job_id,
-                        "session_id": _latest_cron_session_id_for_job(job_id),
                         "name": job.get("name", "Unknown"),
                         "status": job.get("last_status", "unknown"),
                         "completed_at": ts,
                         "toast_notifications": job.get("toast_notifications") is not False,
                     }
                 )
+        latest_session_info = _latest_cron_session_info_for_jobs(
+            [c.get("job_id", "") for c in completions]
+        )
+        for completion in completions:
+            info = latest_session_info.get(str(completion.get("job_id", "") or ""), {})
+            completion["session_id"] = str(info.get("session_id", "") or "")
+            if info.get("message_count") is not None:
+                completion["message_count"] = int(info["message_count"])
         return j(handler, {"completions": completions, "since": since})
     except ImportError:
         return j(handler, {"completions": [], "since": since})

--- a/api/routes.py
+++ b/api/routes.py
@@ -234,6 +234,40 @@ _CLIENT_EVENT_ALLOWED_FIELDS = {
 }
 
 
+def _latest_cron_session_id_for_job(job_id: str) -> str:
+    """Return the newest persisted cron session id for ``job_id``."""
+    normalized = str(job_id or "").strip()
+    if not normalized:
+        return ""
+    db_path = _active_state_db_path()
+    if not db_path or not Path(db_path).exists():
+        return ""
+    try:
+        with closing(sqlite3.connect(str(db_path))) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("PRAGMA table_info(sessions)")
+            session_cols = {row[1] for row in cur.fetchall()}
+            if "id" not in session_cols or "source" not in session_cols:
+                return ""
+            order_expr = "COALESCE(s.started_at, 0) DESC, s.id DESC" if "started_at" in session_cols else "s.id DESC"
+            cur.execute(
+                f"""
+                SELECT s.id
+                FROM sessions s
+                WHERE LOWER(COALESCE(s.source, '')) = 'cron'
+                  AND s.id LIKE ?
+                ORDER BY {order_expr}
+                LIMIT 1
+                """,
+                (f"cron_{normalized}_%",),
+            )
+            row = cur.fetchone()
+            return str(row["id"]) if row and row["id"] else ""
+    except sqlite3.Error:
+        return ""
+
+
 def _session_field(session, field, default=None):
     if isinstance(session, dict):
         return session.get(field, default)
@@ -12553,6 +12587,7 @@ def _handle_cron_recent(handler, parsed):
         jobs = list_jobs(include_disabled=True)
         completions = []
         for job in jobs:
+            job_id = str(job.get("id", "") or "")
             last_run = job.get("last_run_at")
             if not last_run:
                 continue
@@ -12568,7 +12603,8 @@ def _handle_cron_recent(handler, parsed):
             if ts > since:
                 completions.append(
                     {
-                        "job_id": job.get("id", ""),
+                        "job_id": job_id,
+                        "session_id": _latest_cron_session_id_for_job(job_id),
                         "name": job.get("name", "Unknown"),
                         "status": job.get("last_status", "unknown"),
                         "completed_at": ts,

--- a/api/routes.py
+++ b/api/routes.py
@@ -263,7 +263,7 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
             if "id" not in session_cols or "source" not in session_cols:
                 return {jid: {"session_id": "", "message_count": None} for jid in normalized}
             select_message_count = (
-                "COALESCE(s.message_count, NULL) AS message_count"
+                "s.message_count AS message_count"
                 if "message_count" in session_cols
                 else "NULL AS message_count"
             )

--- a/api/routes.py
+++ b/api/routes.py
@@ -246,12 +246,6 @@ def _normalize_cron_job_ids(job_ids) -> list[str]:
     return normalized
 
 
-def _cron_session_like_pattern(job_id: str) -> str:
-    escaped = str(job_id or "")
-    escaped = escaped.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-    return f"cron_{escaped}_%"
-
-
 def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str | None]]:
     """Return newest persisted cron session info keyed by cron job id."""
     normalized = _normalize_cron_job_ids(job_ids)
@@ -268,53 +262,53 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
             session_cols = {row[1] for row in cur.fetchall()}
             if "id" not in session_cols or "source" not in session_cols:
                 return {jid: {"session_id": "", "message_count": None} for jid in normalized}
-            case_clauses = " ".join(["WHEN s.id LIKE ? ESCAPE '\\' THEN ?"] * len(normalized))
-            where_clauses = " OR ".join(["s.id LIKE ? ESCAPE '\\'"] * len(normalized))
             select_message_count = (
                 "COALESCE(s.message_count, NULL) AS message_count"
                 if "message_count" in session_cols
                 else "NULL AS message_count"
             )
-            params = []
-            for jid in normalized:
-                params.extend((_cron_session_like_pattern(jid), jid))
-            for jid in normalized:
-                params.append(_cron_session_like_pattern(jid))
             if "started_at" in session_cols:
                 query = f"""
                     SELECT s.id,
-                           {select_message_count},
-                           CASE {case_clauses} ELSE '' END AS job_id
+                           {select_message_count}
                     FROM sessions s
                     WHERE LOWER(COALESCE(s.source, '')) = 'cron'
-                      AND ({where_clauses})
                     ORDER BY COALESCE(s.started_at, 0) DESC, s.id DESC
                 """
             else:
                 query = f"""
                     SELECT s.id,
-                           {select_message_count},
-                           CASE {case_clauses} ELSE '' END AS job_id
+                           {select_message_count}
                     FROM sessions s
                     WHERE LOWER(COALESCE(s.source, '')) = 'cron'
-                      AND ({where_clauses})
                     ORDER BY s.id DESC
                 """
-            cur.execute(query, params)
+            cur.execute(query)
             results = {
                 jid: {"session_id": "", "message_count": None} for jid in normalized
             }
+            prefixes = {jid: f"cron_{jid}_" for jid in normalized}
             for row in cur.fetchall():
-                jid = str(row["job_id"] or "")
-                if jid and not results[jid]["session_id"]:
+                sid = str(row["id"] or "")
+                if not sid:
+                    continue
+                matches = [
+                    jid
+                    for jid in normalized
+                    if not results[jid]["session_id"] and sid.startswith(prefixes[jid])
+                ]
+                if matches:
+                    jid = max(matches, key=len)
                     results[jid] = {
-                        "session_id": str(row["id"] or ""),
+                        "session_id": sid,
                         "message_count": (
                             int(row["message_count"])
                             if row["message_count"] is not None
                             else None
                         ),
                     }
+                if all(info["session_id"] for info in results.values()):
+                    break
             return results
     except sqlite3.Error:
         return {jid: {"session_id": "", "message_count": None} for jid in normalized}

--- a/api/routes.py
+++ b/api/routes.py
@@ -246,14 +246,19 @@ def _normalize_cron_job_ids(job_ids) -> list[str]:
     return normalized
 
 
-def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str | None]]:
-    """Return newest persisted cron session info keyed by cron job id."""
+def _latest_cron_session_info_for_jobs(
+    job_ids, completed_job_ids=None
+) -> dict[str, dict[str, int | str | None]]:
+    """Return newest persisted cron session info keyed by completed cron job id."""
     normalized = _normalize_cron_job_ids(job_ids)
-    if not normalized:
+    requested = _normalize_cron_job_ids(completed_job_ids if completed_job_ids is not None else job_ids)
+    if not requested:
         return {}
+    if not normalized:
+        return {jid: {"session_id": "", "message_count": None} for jid in requested}
     db_path = _active_state_db_path()
     if not db_path or not Path(db_path).exists():
-        return {jid: {"session_id": "", "message_count": None} for jid in normalized}
+        return {jid: {"session_id": "", "message_count": None} for jid in requested}
     try:
         with closing(sqlite3.connect(str(db_path))) as conn:
             conn.row_factory = sqlite3.Row
@@ -261,7 +266,7 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
             cur.execute("PRAGMA table_info(sessions)")
             session_cols = {row[1] for row in cur.fetchall()}
             if "id" not in session_cols or "source" not in session_cols:
-                return {jid: {"session_id": "", "message_count": None} for jid in normalized}
+                return {jid: {"session_id": "", "message_count": None} for jid in requested}
             select_message_count = (
                 "s.message_count AS message_count"
                 if "message_count" in session_cols
@@ -285,8 +290,9 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
                 """
             cur.execute(query)
             results = {
-                jid: {"session_id": "", "message_count": None} for jid in normalized
+                jid: {"session_id": "", "message_count": None} for jid in requested
             }
+            requested_ids = set(requested)
             prefixes = {jid: f"cron_{jid}_" for jid in normalized}
             for row in cur.fetchall():
                 sid = str(row["id"] or "")
@@ -299,7 +305,7 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
                 ]
                 if matches:
                     jid = max(matches, key=len)
-                    if results[jid]["session_id"]:
+                    if jid not in requested_ids or results[jid]["session_id"]:
                         continue
                     results[jid] = {
                         "session_id": sid,
@@ -313,7 +319,7 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
                     break
             return results
     except sqlite3.Error:
-        return {jid: {"session_id": "", "message_count": None} for jid in normalized}
+        return {jid: {"session_id": "", "message_count": None} for jid in requested}
 
 
 
@@ -12660,7 +12666,8 @@ def _handle_cron_recent(handler, parsed):
                     }
                 )
         latest_session_info = _latest_cron_session_info_for_jobs(
-            [c["job_id"] for c in completions]
+            [job.get("id", "") for job in jobs],
+            [c["job_id"] for c in completions],
         )
         for completion in completions:
             info = latest_session_info.get(str(completion.get("job_id", "") or ""), {})

--- a/api/routes.py
+++ b/api/routes.py
@@ -157,10 +157,12 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
                 matches = [
                     jid
                     for jid in normalized
-                    if not results[jid]["session_id"] and sid.startswith(prefixes[jid])
+                    if sid.startswith(prefixes[jid])
                 ]
                 if matches:
                     jid = max(matches, key=len)
+                    if results[jid]["session_id"]:
+                        continue
                     results[jid] = {
                         "session_id": sid,
                         "message_count": (
@@ -11851,7 +11853,7 @@ def _handle_cron_recent(handler, parsed):
                     }
                 )
         latest_session_info = _latest_cron_session_info_for_jobs(
-            [c.get("job_id", "") for c in completions]
+            [job.get("id", "") for job in jobs]
         )
         for completion in completions:
             info = latest_session_info.get(str(completion.get("job_id", "") or ""), {})

--- a/api/routes.py
+++ b/api/routes.py
@@ -96,14 +96,32 @@ _CLIENT_EVENT_ALLOWED_FIELDS = {
 }
 
 
-def _latest_cron_session_id_for_job(job_id: str) -> str:
-    """Return the newest persisted cron session id for ``job_id``."""
-    normalized = str(job_id or "").strip()
+def _normalize_cron_job_ids(job_ids) -> list[str]:
+    seen = set()
+    normalized = []
+    for job_id in job_ids or []:
+        jid = str(job_id or "").strip()
+        if not jid or jid in seen:
+            continue
+        seen.add(jid)
+        normalized.append(jid)
+    return normalized
+
+
+def _cron_session_like_pattern(job_id: str) -> str:
+    escaped = str(job_id or "")
+    escaped = escaped.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"cron_{escaped}_%"
+
+
+def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str | None]]:
+    """Return newest persisted cron session info keyed by cron job id."""
+    normalized = _normalize_cron_job_ids(job_ids)
     if not normalized:
-        return ""
+        return {}
     db_path = _active_state_db_path()
     if not db_path or not Path(db_path).exists():
-        return ""
+        return {jid: {"session_id": "", "message_count": None} for jid in normalized}
     try:
         with closing(sqlite3.connect(str(db_path))) as conn:
             conn.row_factory = sqlite3.Row
@@ -111,23 +129,72 @@ def _latest_cron_session_id_for_job(job_id: str) -> str:
             cur.execute("PRAGMA table_info(sessions)")
             session_cols = {row[1] for row in cur.fetchall()}
             if "id" not in session_cols or "source" not in session_cols:
-                return ""
-            order_expr = "COALESCE(s.started_at, 0) DESC, s.id DESC" if "started_at" in session_cols else "s.id DESC"
-            cur.execute(
-                f"""
-                SELECT s.id
-                FROM sessions s
-                WHERE LOWER(COALESCE(s.source, '')) = 'cron'
-                  AND s.id LIKE ?
-                ORDER BY {order_expr}
-                LIMIT 1
-                """,
-                (f"cron_{normalized}_%",),
+                return {jid: {"session_id": "", "message_count": None} for jid in normalized}
+            case_clauses = " ".join(["WHEN s.id LIKE ? ESCAPE '\\' THEN ?"] * len(normalized))
+            where_clauses = " OR ".join(["s.id LIKE ? ESCAPE '\\'"] * len(normalized))
+            select_message_count = (
+                "COALESCE(s.message_count, NULL) AS message_count"
+                if "message_count" in session_cols
+                else "NULL AS message_count"
             )
-            row = cur.fetchone()
-            return str(row["id"]) if row and row["id"] else ""
+            params = []
+            for jid in normalized:
+                params.extend((_cron_session_like_pattern(jid), jid))
+            for jid in normalized:
+                params.append(_cron_session_like_pattern(jid))
+            if "started_at" in session_cols:
+                query = f"""
+                    SELECT s.id,
+                           {select_message_count},
+                           CASE {case_clauses} ELSE '' END AS job_id
+                    FROM sessions s
+                    WHERE LOWER(COALESCE(s.source, '')) = 'cron'
+                      AND ({where_clauses})
+                    ORDER BY COALESCE(s.started_at, 0) DESC, s.id DESC
+                """
+            else:
+                query = f"""
+                    SELECT s.id,
+                           {select_message_count},
+                           CASE {case_clauses} ELSE '' END AS job_id
+                    FROM sessions s
+                    WHERE LOWER(COALESCE(s.source, '')) = 'cron'
+                      AND ({where_clauses})
+                    ORDER BY s.id DESC
+                """
+            cur.execute(query, params)
+            results = {
+                jid: {"session_id": "", "message_count": None} for jid in normalized
+            }
+            for row in cur.fetchall():
+                jid = str(row["job_id"] or "")
+                if jid and not results[jid]["session_id"]:
+                    results[jid] = {
+                        "session_id": str(row["id"] or ""),
+                        "message_count": (
+                            int(row["message_count"])
+                            if row["message_count"] is not None
+                            else None
+                        ),
+                    }
+            return results
     except sqlite3.Error:
+        return {jid: {"session_id": "", "message_count": None} for jid in normalized}
+
+
+def _latest_cron_session_ids_for_jobs(job_ids) -> dict[str, str]:
+    return {
+        jid: info.get("session_id", "")
+        for jid, info in _latest_cron_session_info_for_jobs(job_ids).items()
+    }
+
+
+def _latest_cron_session_id_for_job(job_id: str) -> str:
+    """Return the newest persisted cron session id for ``job_id``."""
+    normalized = str(job_id or "").strip()
+    if not normalized:
         return ""
+    return _latest_cron_session_ids_for_jobs([normalized]).get(normalized, "")
 
 
 def _session_field(session, field, default=None):
@@ -11783,13 +11850,20 @@ def _handle_cron_recent(handler, parsed):
                 completions.append(
                     {
                         "job_id": job_id,
-                        "session_id": _latest_cron_session_id_for_job(job_id),
                         "name": job.get("name", "Unknown"),
                         "status": job.get("last_status", "unknown"),
                         "completed_at": ts,
                         "toast_notifications": job.get("toast_notifications") is not False,
                     }
                 )
+        latest_session_info = _latest_cron_session_info_for_jobs(
+            [c.get("job_id", "") for c in completions]
+        )
+        for completion in completions:
+            info = latest_session_info.get(str(completion.get("job_id", "") or ""), {})
+            completion["session_id"] = str(info.get("session_id", "") or "")
+            if info.get("message_count") is not None:
+                completion["message_count"] = int(info["message_count"])
         return j(handler, {"completions": completions, "since": since})
     except ImportError:
         return j(handler, {"completions": [], "since": since})

--- a/api/routes.py
+++ b/api/routes.py
@@ -295,10 +295,12 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
                 matches = [
                     jid
                     for jid in normalized
-                    if not results[jid]["session_id"] and sid.startswith(prefixes[jid])
+                    if sid.startswith(prefixes[jid])
                 ]
                 if matches:
                     jid = max(matches, key=len)
+                    if results[jid]["session_id"]:
+                        continue
                     results[jid] = {
                         "session_id": sid,
                         "message_count": (
@@ -12672,7 +12674,7 @@ def _handle_cron_recent(handler, parsed):
                     }
                 )
         latest_session_info = _latest_cron_session_info_for_jobs(
-            [c.get("job_id", "") for c in completions]
+            [job.get("id", "") for job in jobs]
         )
         for completion in completions:
             info = latest_session_info.get(str(completion.get("job_id", "") or ""), {})

--- a/api/routes.py
+++ b/api/routes.py
@@ -96,6 +96,40 @@ _CLIENT_EVENT_ALLOWED_FIELDS = {
 }
 
 
+def _latest_cron_session_id_for_job(job_id: str) -> str:
+    """Return the newest persisted cron session id for ``job_id``."""
+    normalized = str(job_id or "").strip()
+    if not normalized:
+        return ""
+    db_path = _active_state_db_path()
+    if not db_path or not Path(db_path).exists():
+        return ""
+    try:
+        with closing(sqlite3.connect(str(db_path))) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("PRAGMA table_info(sessions)")
+            session_cols = {row[1] for row in cur.fetchall()}
+            if "id" not in session_cols or "source" not in session_cols:
+                return ""
+            order_expr = "COALESCE(s.started_at, 0) DESC, s.id DESC" if "started_at" in session_cols else "s.id DESC"
+            cur.execute(
+                f"""
+                SELECT s.id
+                FROM sessions s
+                WHERE LOWER(COALESCE(s.source, '')) = 'cron'
+                  AND s.id LIKE ?
+                ORDER BY {order_expr}
+                LIMIT 1
+                """,
+                (f"cron_{normalized}_%",),
+            )
+            row = cur.fetchone()
+            return str(row["id"]) if row and row["id"] else ""
+    except sqlite3.Error:
+        return ""
+
+
 def _session_field(session, field, default=None):
     if isinstance(session, dict):
         return session.get(field, default)
@@ -11732,6 +11766,7 @@ def _handle_cron_recent(handler, parsed):
         jobs = list_jobs(include_disabled=True)
         completions = []
         for job in jobs:
+            job_id = str(job.get("id", "") or "")
             last_run = job.get("last_run_at")
             if not last_run:
                 continue
@@ -11747,7 +11782,8 @@ def _handle_cron_recent(handler, parsed):
             if ts > since:
                 completions.append(
                     {
-                        "job_id": job.get("id", ""),
+                        "job_id": job_id,
+                        "session_id": _latest_cron_session_id_for_job(job_id),
                         "name": job.get("name", "Unknown"),
                         "status": job.get("last_status", "unknown"),
                         "completed_at": ts,

--- a/api/routes.py
+++ b/api/routes.py
@@ -135,7 +135,7 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
                            {select_message_count}
                     FROM sessions s
                     WHERE LOWER(COALESCE(s.source, '')) = 'cron'
-                    ORDER BY COALESCE(s.started_at, 0) DESC, s.id DESC
+                    ORDER BY COALESCE(s.started_at, 0) DESC, s.id DESC  -- newest start, not last activity
                 """
             else:
                 query = f"""
@@ -177,20 +177,6 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
     except sqlite3.Error:
         return {jid: {"session_id": "", "message_count": None} for jid in normalized}
 
-
-def _latest_cron_session_ids_for_jobs(job_ids) -> dict[str, str]:
-    return {
-        jid: info.get("session_id", "")
-        for jid, info in _latest_cron_session_info_for_jobs(job_ids).items()
-    }
-
-
-def _latest_cron_session_id_for_job(job_id: str) -> str:
-    """Return the newest persisted cron session id for ``job_id``."""
-    normalized = str(job_id or "").strip()
-    if not normalized:
-        return ""
-    return _latest_cron_session_ids_for_jobs([normalized]).get(normalized, "")
 
 
 def _session_field(session, field, default=None):
@@ -11853,7 +11839,7 @@ def _handle_cron_recent(handler, parsed):
                     }
                 )
         latest_session_info = _latest_cron_session_info_for_jobs(
-            [job.get("id", "") for job in jobs]
+            [c["job_id"] for c in completions]
         )
         for completion in completions:
             info = latest_session_info.get(str(completion.get("job_id", "") or ""), {})

--- a/api/routes.py
+++ b/api/routes.py
@@ -108,12 +108,6 @@ def _normalize_cron_job_ids(job_ids) -> list[str]:
     return normalized
 
 
-def _cron_session_like_pattern(job_id: str) -> str:
-    escaped = str(job_id or "")
-    escaped = escaped.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-    return f"cron_{escaped}_%"
-
-
 def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str | None]]:
     """Return newest persisted cron session info keyed by cron job id."""
     normalized = _normalize_cron_job_ids(job_ids)
@@ -130,53 +124,53 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
             session_cols = {row[1] for row in cur.fetchall()}
             if "id" not in session_cols or "source" not in session_cols:
                 return {jid: {"session_id": "", "message_count": None} for jid in normalized}
-            case_clauses = " ".join(["WHEN s.id LIKE ? ESCAPE '\\' THEN ?"] * len(normalized))
-            where_clauses = " OR ".join(["s.id LIKE ? ESCAPE '\\'"] * len(normalized))
             select_message_count = (
                 "COALESCE(s.message_count, NULL) AS message_count"
                 if "message_count" in session_cols
                 else "NULL AS message_count"
             )
-            params = []
-            for jid in normalized:
-                params.extend((_cron_session_like_pattern(jid), jid))
-            for jid in normalized:
-                params.append(_cron_session_like_pattern(jid))
             if "started_at" in session_cols:
                 query = f"""
                     SELECT s.id,
-                           {select_message_count},
-                           CASE {case_clauses} ELSE '' END AS job_id
+                           {select_message_count}
                     FROM sessions s
                     WHERE LOWER(COALESCE(s.source, '')) = 'cron'
-                      AND ({where_clauses})
                     ORDER BY COALESCE(s.started_at, 0) DESC, s.id DESC
                 """
             else:
                 query = f"""
                     SELECT s.id,
-                           {select_message_count},
-                           CASE {case_clauses} ELSE '' END AS job_id
+                           {select_message_count}
                     FROM sessions s
                     WHERE LOWER(COALESCE(s.source, '')) = 'cron'
-                      AND ({where_clauses})
                     ORDER BY s.id DESC
                 """
-            cur.execute(query, params)
+            cur.execute(query)
             results = {
                 jid: {"session_id": "", "message_count": None} for jid in normalized
             }
+            prefixes = {jid: f"cron_{jid}_" for jid in normalized}
             for row in cur.fetchall():
-                jid = str(row["job_id"] or "")
-                if jid and not results[jid]["session_id"]:
+                sid = str(row["id"] or "")
+                if not sid:
+                    continue
+                matches = [
+                    jid
+                    for jid in normalized
+                    if not results[jid]["session_id"] and sid.startswith(prefixes[jid])
+                ]
+                if matches:
+                    jid = max(matches, key=len)
                     results[jid] = {
-                        "session_id": str(row["id"] or ""),
+                        "session_id": sid,
                         "message_count": (
                             int(row["message_count"])
                             if row["message_count"] is not None
                             else None
                         ),
                     }
+                if all(info["session_id"] for info in results.values()):
+                    break
             return results
     except sqlite3.Error:
         return {jid: {"session_id": "", "message_count": None} for jid in normalized}

--- a/api/routes.py
+++ b/api/routes.py
@@ -125,7 +125,7 @@ def _latest_cron_session_info_for_jobs(job_ids) -> dict[str, dict[str, int | str
             if "id" not in session_cols or "source" not in session_cols:
                 return {jid: {"session_id": "", "message_count": None} for jid in normalized}
             select_message_count = (
-                "COALESCE(s.message_count, NULL) AS message_count"
+                "s.message_count AS message_count"
                 if "message_count" in session_cols
                 else "NULL AS message_count"
             )

--- a/static/panels.js
+++ b/static/panels.js
@@ -8361,6 +8361,9 @@ function startCronPolling(){
           }
           _cronPollSince=Math.max(_cronPollSince,c.completed_at);
           if(c.job_id) _cronNewJobIds.add(String(c.job_id));
+          if(c.session_id && typeof _markSessionCompletionUnreadIfBackground === 'function'){
+            _markSessionCompletionUnreadIfBackground(c.session_id);
+          }
         }
         // _cronUnreadCount is derived from _cronNewJobIds.size in updateCronBadge.
         updateCronBadge();

--- a/static/panels.js
+++ b/static/panels.js
@@ -8362,7 +8362,7 @@ function startCronPolling(){
           _cronPollSince=Math.max(_cronPollSince,c.completed_at);
           if(c.job_id) _cronNewJobIds.add(String(c.job_id));
           if(c.session_id && typeof _markSessionCompletionUnreadIfBackground === 'function'){
-            _markSessionCompletionUnreadIfBackground(c.session_id);
+            _markSessionCompletionUnreadIfBackground(c.session_id, c.message_count);
           }
         }
         // _cronUnreadCount is derived from _cronNewJobIds.size in updateCronBadge.

--- a/static/panels.js
+++ b/static/panels.js
@@ -8236,7 +8236,7 @@ function startCronPolling(){
           _cronPollSince=Math.max(_cronPollSince,c.completed_at);
           if(c.job_id) _cronNewJobIds.add(String(c.job_id));
           if(c.session_id && typeof _markSessionCompletionUnreadIfBackground === 'function'){
-            _markSessionCompletionUnreadIfBackground(c.session_id);
+            _markSessionCompletionUnreadIfBackground(c.session_id, c.message_count);
           }
         }
         // _cronUnreadCount is derived from _cronNewJobIds.size in updateCronBadge.

--- a/static/panels.js
+++ b/static/panels.js
@@ -8235,6 +8235,9 @@ function startCronPolling(){
           }
           _cronPollSince=Math.max(_cronPollSince,c.completed_at);
           if(c.job_id) _cronNewJobIds.add(String(c.job_id));
+          if(c.session_id && typeof _markSessionCompletionUnreadIfBackground === 'function'){
+            _markSessionCompletionUnreadIfBackground(c.session_id);
+          }
         }
         // _cronUnreadCount is derived from _cronNewJobIds.size in updateCronBadge.
         updateCronBadge();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -255,6 +255,25 @@ function _markSessionCompletionUnread(sid, messageCount = 0) {
   _saveSessionCompletionUnread();
 }
 
+function _markSessionCompletionUnreadIfBackground(sid, messageCount = null) {
+  if (!sid) return false;
+  let count = Number.isFinite(messageCount) ? Number(messageCount) : NaN;
+  if (!Number.isFinite(count)) {
+    const snapshot = _sessionListSnapshotById.get(sid)
+      || (_allSessions || []).find(s => s && s.session_id === sid)
+      || null;
+    count = Number(snapshot && snapshot.message_count) || 0;
+  }
+  if (_isSessionActivelyViewedForList(sid)) {
+    _setSessionViewedCount(sid, count);
+    if (typeof renderSessionListFromCache === 'function') renderSessionListFromCache();
+    return false;
+  }
+  _markSessionCompletionUnread(sid, count);
+  if (typeof renderSessionListFromCache === 'function') renderSessionListFromCache();
+  return true;
+}
+
 function _clearSessionCompletionUnread(sid) {
   if (!sid) return;
   const unread = _getSessionCompletionUnread();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -273,6 +273,7 @@ function _markSessionCompletionUnreadIfBackground(sid, messageCount = null) {
   if (typeof renderSessionListFromCache === 'function') renderSessionListFromCache();
   return true;
 }
+if (typeof window !== 'undefined') window._markSessionCompletionUnreadIfBackground = _markSessionCompletionUnreadIfBackground;
 
 function _clearSessionCompletionUnread(sid) {
   if (!sid) return;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -273,7 +273,6 @@ function _markSessionCompletionUnreadIfBackground(sid, messageCount = null) {
   if (typeof renderSessionListFromCache === 'function') renderSessionListFromCache();
   return true;
 }
-if (typeof window !== 'undefined') window._markSessionCompletionUnreadIfBackground = _markSessionCompletionUnreadIfBackground;
 
 function _clearSessionCompletionUnread(sid) {
   if (!sid) return;

--- a/tests/test_cron_toast_notifications.py
+++ b/tests/test_cron_toast_notifications.py
@@ -87,6 +87,7 @@ def test_cron_recent_marks_muted_jobs_without_requesting_toast(monkeypatch):
             "toast_notifications": False,
         },
     ]
+    monkeypatch.setattr(routes, "_latest_cron_session_id_for_job", lambda job_id: f"cron_{job_id}_latest")
     monkeypatch.setitem(sys.modules, "cron", cron_pkg)
     monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
 
@@ -97,7 +98,9 @@ def test_cron_recent_marks_muted_jobs_without_requesting_toast(monkeypatch):
     assert handler.status == 200
     by_id = {item["job_id"]: item for item in body["completions"]}
     assert by_id["loud"]["toast_notifications"] is True
+    assert by_id["loud"]["session_id"] == "cron_loud_latest"
     assert by_id["muted"]["toast_notifications"] is False
+    assert by_id["muted"]["session_id"] == "cron_muted_latest"
 
 
 def test_cron_create_persists_muted_toast_setting_after_create(monkeypatch):
@@ -149,6 +152,8 @@ def test_cron_polling_suppresses_toasts_but_keeps_unread_badges():
     assert "c.toast_notifications !== false" in body
     assert "showToast(t('cron_completion_status'" in body
     assert "if(c.job_id) _cronNewJobIds.add(String(c.job_id));" in body
+    assert "if(c.session_id && typeof _markSessionCompletionUnreadIfBackground === 'function')" in body
+    assert "_markSessionCompletionUnreadIfBackground(c.session_id);" in body
 
 
 def test_cron_toast_i18n_keys_exist():

--- a/tests/test_cron_toast_notifications.py
+++ b/tests/test_cron_toast_notifications.py
@@ -87,7 +87,17 @@ def test_cron_recent_marks_muted_jobs_without_requesting_toast(monkeypatch):
             "toast_notifications": False,
         },
     ]
-    monkeypatch.setattr(routes, "_latest_cron_session_id_for_job", lambda job_id: f"cron_{job_id}_latest")
+    monkeypatch.setattr(
+        routes,
+        "_latest_cron_session_info_for_jobs",
+        lambda job_ids: {
+            str(job_id): {
+                "session_id": f"cron_{job_id}_latest",
+                "message_count": 3 if str(job_id) == "loud" else 5,
+            }
+            for job_id in job_ids
+        },
+    )
     monkeypatch.setitem(sys.modules, "cron", cron_pkg)
     monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
 
@@ -99,8 +109,10 @@ def test_cron_recent_marks_muted_jobs_without_requesting_toast(monkeypatch):
     by_id = {item["job_id"]: item for item in body["completions"]}
     assert by_id["loud"]["toast_notifications"] is True
     assert by_id["loud"]["session_id"] == "cron_loud_latest"
+    assert by_id["loud"]["message_count"] == 3
     assert by_id["muted"]["toast_notifications"] is False
     assert by_id["muted"]["session_id"] == "cron_muted_latest"
+    assert by_id["muted"]["message_count"] == 5
 
 
 def test_cron_create_persists_muted_toast_setting_after_create(monkeypatch):
@@ -152,8 +164,6 @@ def test_cron_polling_suppresses_toasts_but_keeps_unread_badges():
     assert "c.toast_notifications !== false" in body
     assert "showToast(t('cron_completion_status'" in body
     assert "if(c.job_id) _cronNewJobIds.add(String(c.job_id));" in body
-    assert "if(c.session_id && typeof _markSessionCompletionUnreadIfBackground === 'function')" in body
-    assert "_markSessionCompletionUnreadIfBackground(c.session_id);" in body
 
 
 def test_cron_toast_i18n_keys_exist():

--- a/tests/test_cron_toast_notifications.py
+++ b/tests/test_cron_toast_notifications.py
@@ -90,12 +90,12 @@ def test_cron_recent_marks_muted_jobs_without_requesting_toast(monkeypatch):
     monkeypatch.setattr(
         routes,
         "_latest_cron_session_info_for_jobs",
-        lambda job_ids: {
+        lambda job_ids, completed_job_ids=None: {
             str(job_id): {
                 "session_id": f"cron_{job_id}_latest",
                 "message_count": 3 if str(job_id) == "loud" else 5,
             }
-            for job_id in job_ids
+            for job_id in (completed_job_ids or job_ids)
         },
     )
     monkeypatch.setitem(sys.modules, "cron", cron_pkg)

--- a/tests/test_issue3460_cron_session_unread.py
+++ b/tests/test_issue3460_cron_session_unread.py
@@ -201,6 +201,63 @@ def test_cron_recent_escapes_like_wildcards_in_job_id(monkeypatch, tmp_path):
     assert body["completions"][0]["message_count"] == 11
 
 
+def test_cron_recent_does_not_cross_match_shared_job_prefixes(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                started_at REAL,
+                message_count INTEGER
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source, started_at, message_count) VALUES (?, ?, ?, ?)",
+            ("cron_backup_20260610_090000", "cron", 100.0, 4),
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source, started_at, message_count) VALUES (?, ?, ?, ?)",
+            ("cron_backup_full_20260610_100000", "cron", 200.0, 8),
+        )
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    cron_jobs = types.ModuleType("cron.jobs")
+    cron_jobs.list_jobs = lambda include_disabled=True: [
+        {
+            "id": "backup",
+            "name": "Backup",
+            "last_run_at": 150,
+            "last_status": "success",
+        },
+        {
+            "id": "backup_full",
+            "name": "Backup Full",
+            "last_run_at": 250,
+            "last_status": "success",
+        },
+    ]
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: db_path)
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+
+    handler = _JSONHandler()
+    routes._handle_cron_recent(handler, SimpleNamespace(query="since=0"))
+
+    body = _payload(handler)
+    assert handler.status == 200
+    by_id = {item["job_id"]: item for item in body["completions"]}
+    assert by_id["backup"]["session_id"] == "cron_backup_20260610_090000"
+    assert by_id["backup"]["message_count"] == 4
+    assert by_id["backup_full"]["session_id"] == "cron_backup_full_20260610_100000"
+    assert by_id["backup_full"]["message_count"] == 8
+
+
 def test_sessions_helper_marks_background_completion_with_existing_snapshot():
     script = f"""
 const fs = require('fs');

--- a/tests/test_issue3460_cron_session_unread.py
+++ b/tests/test_issue3460_cron_session_unread.py
@@ -4,16 +4,23 @@ from __future__ import annotations
 
 import io
 import json
+import shutil
 import sqlite3
+import subprocess
 import sys
 import types
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 
 REPO = Path(__file__).resolve().parents[1]
-SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
-PANELS_JS = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
+SESSIONS_JS_PATH = REPO / "static" / "sessions.js"
+PANELS_JS_PATH = REPO / "static" / "panels.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
 
 
 class _JSONHandler:
@@ -35,6 +42,18 @@ class _JSONHandler:
 
 def _payload(handler):
     return json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+def _run_node(script: str) -> dict:
+    assert NODE is not None
+    result = subprocess.run(
+        [NODE, "-e", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return json.loads(result.stdout)
 
 
 def test_cron_recent_returns_latest_session_id_for_job(monkeypatch, tmp_path):
@@ -86,27 +105,251 @@ def test_cron_recent_returns_latest_session_id_for_job(monkeypatch, tmp_path):
     assert handler.status == 200
     assert body["completions"][0]["job_id"] == "job3460"
     assert body["completions"][0]["session_id"] == "cron_job3460_20260610_070000"
+    assert body["completions"][0].get("message_count") is None
 
 
-def test_sessions_helper_marks_background_completion_with_existing_unread_marker():
-    assert "function _markSessionCompletionUnreadIfBackground(" in SESSIONS_JS
-    helper_start = SESSIONS_JS.find("function _markSessionCompletionUnreadIfBackground(")
-    helper_end = SESSIONS_JS.find("function _clearSessionCompletionUnread(", helper_start)
-    assert helper_start != -1 and helper_end != -1
-    helper_block = SESSIONS_JS[helper_start:helper_end]
+def test_cron_recent_falls_back_to_id_order_when_started_at_missing(monkeypatch, tmp_path):
+    import api.routes as routes
 
-    assert "_isSessionActivelyViewedForList(sid)" in helper_block
-    assert "_setSessionViewedCount(sid, count);" in helper_block
-    assert "_markSessionCompletionUnread(sid, count);" in helper_block
-    assert "renderSessionListFromCache()" in helper_block
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source) VALUES (?, ?)",
+            ("cron_job3460_20260610_060000", "cron"),
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source) VALUES (?, ?)",
+            ("cron_job3460_20260610_070000", "cron"),
+        )
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    cron_jobs = types.ModuleType("cron.jobs")
+    cron_jobs.list_jobs = lambda include_disabled=True: [
+        {
+            "id": "job3460",
+            "name": "Morning Briefing",
+            "last_run_at": 250,
+            "last_status": "success",
+        }
+    ]
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: db_path)
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+
+    handler = _JSONHandler()
+    routes._handle_cron_recent(handler, SimpleNamespace(query="since=0"))
+
+    body = _payload(handler)
+    assert handler.status == 200
+    assert body["completions"][0]["session_id"] == "cron_job3460_20260610_070000"
 
 
-def test_cron_polling_bridges_recent_completion_to_sidebar_unread_helper():
-    start = PANELS_JS.find("function startCronPolling()")
-    end = PANELS_JS.find("function updateCronBadge()", start)
-    assert start != -1 and end != -1
-    body = PANELS_JS[start:end]
+def test_cron_recent_escapes_like_wildcards_in_job_id(monkeypatch, tmp_path):
+    import api.routes as routes
 
-    assert "_cronNewJobIds.add(String(c.job_id))" in body
-    assert "if(c.session_id && typeof _markSessionCompletionUnreadIfBackground === 'function')" in body
-    assert "_markSessionCompletionUnreadIfBackground(c.session_id);" in body
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                started_at REAL,
+                message_count INTEGER
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source, started_at, message_count) VALUES (?, ?, ?, ?)",
+            ("cron_job_3460%_20260610_090000", "cron", 300.0, 11),
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source, started_at, message_count) VALUES (?, ?, ?, ?)",
+            ("cron_jobA3460x_20260610_100000", "cron", 400.0, 99),
+        )
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    cron_jobs = types.ModuleType("cron.jobs")
+    cron_jobs.list_jobs = lambda include_disabled=True: [
+        {
+            "id": "job_3460%",
+            "name": "Wildcard Job",
+            "last_run_at": 500,
+            "last_status": "success",
+        }
+    ]
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: db_path)
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+
+    handler = _JSONHandler()
+    routes._handle_cron_recent(handler, SimpleNamespace(query="since=0"))
+
+    body = _payload(handler)
+    assert handler.status == 200
+    assert body["completions"][0]["session_id"] == "cron_job_3460%_20260610_090000"
+    assert body["completions"][0]["message_count"] == 11
+
+
+def test_sessions_helper_marks_background_completion_with_existing_snapshot():
+    script = f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(SESSIONS_JS_PATH))}, 'utf8');
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+let _sessionListSnapshotById = new Map([['cron_1', {{message_count: 7}}]]);
+let _allSessions = [];
+let viewed = [];
+let unread = [];
+let renders = 0;
+function _isSessionActivelyViewedForList() {{ return false; }}
+function _setSessionViewedCount(sid, count) {{ viewed.push([sid, count]); }}
+function _markSessionCompletionUnread(sid, count) {{ unread.push([sid, count]); }}
+function renderSessionListFromCache() {{ renders += 1; }}
+global.window = {{}};
+    eval(extractFunc('_markSessionCompletionUnreadIfBackground'));
+    window._markSessionCompletionUnreadIfBackground = _markSessionCompletionUnreadIfBackground;
+const result = _markSessionCompletionUnreadIfBackground('cron_1');
+console.log(JSON.stringify({{result, viewed, unread, renders, exported: typeof window._markSessionCompletionUnreadIfBackground === 'function'}}));
+"""
+    payload = _run_node(script)
+
+    assert payload == {
+        "result": True,
+        "viewed": [],
+        "unread": [["cron_1", 7]],
+        "renders": 1,
+        "exported": True,
+    }
+
+
+def test_sessions_helper_marks_actively_viewed_completion_as_read():
+    script = f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(SESSIONS_JS_PATH))}, 'utf8');
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+let _sessionListSnapshotById = new Map();
+let _allSessions = [{{session_id: 'cron_2', message_count: 9}}];
+let viewed = [];
+let unread = [];
+let renders = 0;
+function _isSessionActivelyViewedForList(sid) {{ return sid === 'cron_2'; }}
+function _setSessionViewedCount(sid, count) {{ viewed.push([sid, count]); }}
+function _markSessionCompletionUnread(sid, count) {{ unread.push([sid, count]); }}
+function renderSessionListFromCache() {{ renders += 1; }}
+global.window = {{}};
+eval(extractFunc('_markSessionCompletionUnreadIfBackground'));
+const result = _markSessionCompletionUnreadIfBackground('cron_2');
+console.log(JSON.stringify({{result, viewed, unread, renders}}));
+"""
+    payload = _run_node(script)
+
+    assert payload == {
+        "result": False,
+        "viewed": [["cron_2", 9]],
+        "unread": [],
+        "renders": 1,
+    }
+
+
+def test_cron_polling_marks_sidebar_unread_without_needing_toast():
+    script = f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(PANELS_JS_PATH))}, 'utf8');
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+let _cronPollSince = 10;
+let _cronPollTimer = null;
+let _cronUnreadCount = 0;
+const _cronNewJobIds = new Set();
+const markCalls = [];
+const toastCalls = [];
+let badgeUpdates = 0;
+global.document = {{ hidden: false }};
+global.setInterval = (fn, _ms) => {{ global.__tick = fn; return 1; }};
+async function api(_url) {{
+  return {{
+    completions: [{{
+      job_id: 'job3460',
+      session_id: 'cron_job3460_20260610_070000',
+      message_count: 12,
+      name: 'Morning Briefing',
+      status: 'success',
+      completed_at: 25,
+      toast_notifications: false
+    }}]
+  }};
+}}
+function showToast(...args) {{ toastCalls.push(args); }}
+function t(...args) {{ return args.join('|'); }}
+function updateCronBadge() {{ badgeUpdates += 1; }}
+function _markSessionCompletionUnreadIfBackground(sid, count) {{ markCalls.push([sid, count]); }}
+eval(extractFunc('startCronPolling'));
+(async() => {{
+  startCronPolling();
+  await global.__tick();
+  console.log(JSON.stringify({{
+    since: _cronPollSince,
+    unreadJobs: Array.from(_cronNewJobIds),
+    markCalls,
+    toastCalls,
+    badgeUpdates
+  }}));
+}})().catch(err => {{
+  console.error(err);
+  process.exit(1);
+}});
+"""
+    payload = _run_node(script)
+
+    assert payload == {
+        "since": 25,
+        "unreadJobs": ["job3460"],
+        "markCalls": [["cron_job3460_20260610_070000", 12]],
+        "toastCalls": [],
+        "badgeUpdates": 1,
+    }

--- a/tests/test_issue3460_cron_session_unread.py
+++ b/tests/test_issue3460_cron_session_unread.py
@@ -319,6 +319,71 @@ def test_cron_recent_does_not_steal_older_long_prefix_history_for_short_job(
     assert body["completions"][0]["message_count"] == 4
 
 
+def test_cron_recent_does_not_cross_match_newer_long_prefix_session_when_only_short_job_completed(
+    monkeypatch, tmp_path
+):
+    import api.routes as routes
+
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                started_at REAL,
+                message_count INTEGER
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source, started_at, message_count) VALUES (?, ?, ?, ?)",
+            ("cron_backup_full_20260610_110000", "cron", 300.0, 12),
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source, started_at, message_count) VALUES (?, ?, ?, ?)",
+            ("cron_backup_20260610_090000", "cron", 100.0, 4),
+        )
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    cron_jobs = types.ModuleType("cron.jobs")
+    cron_jobs.list_jobs = lambda include_disabled=True: [
+        {
+            "id": "backup",
+            "name": "Backup",
+            "last_run_at": 250,
+            "last_status": "success",
+        },
+        {
+            "id": "backup_full",
+            "name": "Backup Full",
+            "last_run_at": 150,
+            "last_status": "success",
+        },
+    ]
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: db_path)
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+
+    handler = _JSONHandler()
+    routes._handle_cron_recent(handler, SimpleNamespace(query="since=200"))
+
+    body = _payload(handler)
+    assert handler.status == 200
+    assert body["completions"] == [
+        {
+            "job_id": "backup",
+            "name": "Backup",
+            "status": "success",
+            "completed_at": 250.0,
+            "toast_notifications": True,
+            "session_id": "cron_backup_20260610_090000",
+            "message_count": 4,
+        }
+    ]
+
+
 def test_sessions_helper_marks_background_completion_with_existing_snapshot():
     script = f"""
 const fs = require('fs');

--- a/tests/test_issue3460_cron_session_unread.py
+++ b/tests/test_issue3460_cron_session_unread.py
@@ -1,0 +1,112 @@
+"""Regression coverage for #3460 cron session unread badges."""
+
+from __future__ import annotations
+
+import io
+import json
+import sqlite3
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO = Path(__file__).resolve().parents[1]
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+PANELS_JS = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
+
+
+class _JSONHandler:
+    def __init__(self):
+        self.status = None
+        self.headers = {}
+        self.response_headers = []
+        self.wfile = io.BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.response_headers.append((key, value))
+
+    def end_headers(self):
+        pass
+
+
+def _payload(handler):
+    return json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+def test_cron_recent_returns_latest_session_id_for_job(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                started_at REAL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source, started_at) VALUES (?, ?, ?)",
+            ("cron_job3460_20260610_060000", "cron", 100.0),
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source, started_at) VALUES (?, ?, ?)",
+            ("cron_job3460_20260610_070000", "cron", 200.0),
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source, started_at) VALUES (?, ?, ?)",
+            ("telegram_job3460_20260610_080000", "telegram", 300.0),
+        )
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    cron_jobs = types.ModuleType("cron.jobs")
+    cron_jobs.list_jobs = lambda include_disabled=True: [
+        {
+            "id": "job3460",
+            "name": "Morning Briefing",
+            "last_run_at": 250,
+            "last_status": "success",
+        }
+    ]
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: db_path)
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+
+    handler = _JSONHandler()
+    routes._handle_cron_recent(handler, SimpleNamespace(query="since=0"))
+
+    body = _payload(handler)
+    assert handler.status == 200
+    assert body["completions"][0]["job_id"] == "job3460"
+    assert body["completions"][0]["session_id"] == "cron_job3460_20260610_070000"
+
+
+def test_sessions_helper_marks_background_completion_with_existing_unread_marker():
+    assert "function _markSessionCompletionUnreadIfBackground(" in SESSIONS_JS
+    helper_start = SESSIONS_JS.find("function _markSessionCompletionUnreadIfBackground(")
+    helper_end = SESSIONS_JS.find("function _clearSessionCompletionUnread(", helper_start)
+    assert helper_start != -1 and helper_end != -1
+    helper_block = SESSIONS_JS[helper_start:helper_end]
+
+    assert "_isSessionActivelyViewedForList(sid)" in helper_block
+    assert "_setSessionViewedCount(sid, count);" in helper_block
+    assert "_markSessionCompletionUnread(sid, count);" in helper_block
+    assert "renderSessionListFromCache()" in helper_block
+
+
+def test_cron_polling_bridges_recent_completion_to_sidebar_unread_helper():
+    start = PANELS_JS.find("function startCronPolling()")
+    end = PANELS_JS.find("function updateCronBadge()", start)
+    assert start != -1 and end != -1
+    body = PANELS_JS[start:end]
+
+    assert "_cronNewJobIds.add(String(c.job_id))" in body
+    assert "if(c.session_id && typeof _markSessionCompletionUnreadIfBackground === 'function')" in body
+    assert "_markSessionCompletionUnreadIfBackground(c.session_id);" in body

--- a/tests/test_issue3460_cron_session_unread.py
+++ b/tests/test_issue3460_cron_session_unread.py
@@ -258,6 +258,67 @@ def test_cron_recent_does_not_cross_match_shared_job_prefixes(monkeypatch, tmp_p
     assert by_id["backup_full"]["message_count"] == 8
 
 
+def test_cron_recent_does_not_steal_older_long_prefix_history_for_short_job(
+    monkeypatch, tmp_path
+):
+    import api.routes as routes
+
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                started_at REAL,
+                message_count INTEGER
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source, started_at, message_count) VALUES (?, ?, ?, ?)",
+            ("cron_backup_full_20260610_110000", "cron", 300.0, 12),
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source, started_at, message_count) VALUES (?, ?, ?, ?)",
+            ("cron_backup_full_20260610_100000", "cron", 200.0, 8),
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, source, started_at, message_count) VALUES (?, ?, ?, ?)",
+            ("cron_backup_20260610_090000", "cron", 100.0, 4),
+        )
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    cron_jobs = types.ModuleType("cron.jobs")
+    cron_jobs.list_jobs = lambda include_disabled=True: [
+        {
+            "id": "backup",
+            "name": "Backup",
+            "last_run_at": 150,
+            "last_status": "success",
+        },
+        {
+            "id": "backup_full",
+            "name": "Backup Full",
+            "last_run_at": 50,
+            "last_status": "success",
+        },
+    ]
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: db_path)
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+
+    handler = _JSONHandler()
+    routes._handle_cron_recent(handler, SimpleNamespace(query="since=0"))
+
+    body = _payload(handler)
+    assert handler.status == 200
+    assert body["completions"][0]["job_id"] == "backup"
+    assert body["completions"][0]["session_id"] == "cron_backup_20260610_090000"
+    assert body["completions"][0]["message_count"] == 4
+
+
 def test_sessions_helper_marks_background_completion_with_existing_snapshot():
     script = f"""
 const fs = require('fs');

--- a/tests/test_issue3460_cron_session_unread.py
+++ b/tests/test_issue3460_cron_session_unread.py
@@ -286,9 +286,8 @@ function _markSessionCompletionUnread(sid, count) {{ unread.push([sid, count]); 
 function renderSessionListFromCache() {{ renders += 1; }}
 global.window = {{}};
     eval(extractFunc('_markSessionCompletionUnreadIfBackground'));
-    window._markSessionCompletionUnreadIfBackground = _markSessionCompletionUnreadIfBackground;
-const result = _markSessionCompletionUnreadIfBackground('cron_1');
-console.log(JSON.stringify({{result, viewed, unread, renders, exported: typeof window._markSessionCompletionUnreadIfBackground === 'function'}}));
+    const result = _markSessionCompletionUnreadIfBackground('cron_1');
+    console.log(JSON.stringify({{result, viewed, unread, renders}}));
 """
     payload = _run_node(script)
 
@@ -297,7 +296,6 @@ console.log(JSON.stringify({{result, viewed, unread, renders, exported: typeof w
         "viewed": [],
         "unread": [["cron_1", 7]],
         "renders": 1,
-        "exported": True,
     }
 
 


### PR DESCRIPTION
## Summary

This keeps the shipped `show_cron_sessions` sidebar path from #3514, and adds the missing attention state on that existing path instead of introducing a separate Scheduled tab.

When `/api/crons/recent` reports a completed cron job, the WebUI now resolves the newest persisted `cron_<job_id>_*` session for that job and marks that sidebar row unread if the user is not actively viewing it. If the row is already open and focused, it is marked read immediately instead.

## What changed

- batch-resolve the newest persisted cron session per completed job in `api/routes.py`
- include the resolved `session_id`, and when available `message_count`, in `/api/crons/recent`
- choose the longest exact `cron_<job_id>_` prefix match so shared job prefixes do not cross-assign unread badges
- forward cron completions from `startCronPolling()` into the existing session completion unread helper
- add backend and Node-backed frontend regression coverage for session resolution, wildcard-safe job IDs, shared-prefix matching, active-view suppression, and muted-toast polling behavior

## Why

`show_cron_sessions` already surfaces cron chats in the main sidebar, but fresh cron output still had no strong per-session attention signal there. This follow-up keeps the maintainer-approved information architecture and adds unread dots on the actual affected session rows.

## Verification

```powershell
npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"
pytest tests/test_cron_toast_notifications.py tests/test_issue3460_cron_session_unread.py tests/test_issue2841_show_cron_sessions_toggle.py tests/test_issue856_background_completion_unread.py tests/test_window_function_collision.py -q
```
