### PR TITLE
fix(#3863): reattach live stream after mobile app-switch offline recovery

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -124,6 +124,16 @@ async function _recoverFromOfflineSoftly(){
     if(S.session && typeof refreshSession==='function'){
       await refreshSession();
     }
+    // After refreshSession() sets S.activeStreamId, reattach if a stream is live.
+    // The server buffers events while no subscriber is attached (#2307/#3863).
+    const sid=S.session&&S.session.session_id;
+    const streamId=S.session&&S.session.active_stream_id;
+    if(sid&&streamId&&typeof attachLiveStream==='function'){
+      try{
+        const status=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
+        if(status&&status.active) attachLiveStream(sid,streamId,S.session.pending_attachments||[],{reconnecting:true});
+      }catch(_){/* stream status check failed — leave session refreshed but don't reattach */}
+    }
     return true;
   }catch(_){
     // Soft reattach failed (server mid-restart, session gone, etc.) — fall

--- a/static/ui.js
+++ b/static/ui.js
@@ -129,10 +129,13 @@ async function _recoverFromOfflineSoftly(){
     const sid=S.session&&S.session.session_id;
     const streamId=S.session&&S.session.active_stream_id;
     if(sid&&streamId&&typeof attachLiveStream==='function'){
+      let status=null;
       try{
-        const status=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
-        if(status&&status.active) attachLiveStream(sid,streamId,S.session.pending_attachments||[],{reconnecting:true});
+        status=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
       }catch(_){/* stream status check failed — leave session refreshed but don't reattach */}
+      // Outside the probe's catch so an attachLiveStream throw reaches the
+      // outer fallback (hard reload) instead of being silently swallowed.
+      if(status&&status.active) attachLiveStream(sid,streamId,S.session.pending_attachments||[],{reconnecting:true});
     }
     return true;
   }catch(_){


### PR DESCRIPTION

## Thinking Path

- On Android, backgrounding the PWA during an active stream triggers fetch/SSE errors that fire the offline banner (Path B) rather than the `visibilitychange` handler (Path A).
- `_recoverFromOfflineSoftly()` already calls `refreshSession()`, which fetches the session and sets `S.activeStreamId` from `data.session.active_stream_id` — so the stream ID is known after recovery.
- The gap is that `_recoverFromOfflineSoftly()` never calls `attachLiveStream()` afterward; the server is still running the stream and buffering events (#2307), but no subscriber ever reconnects.
- Fix: after `refreshSession()`, read `S.session.active_stream_id`, verify via `/api/chat/stream/status` (same endpoint used at ui.js:6084), and call `attachLiveStream()` with `{reconnecting:true}` if active.

## What Changed

- `static/ui.js`: after the `await refreshSession()` call in `_recoverFromOfflineSoftly()`, added a stream-status check and conditional `attachLiveStream()` call when `S.session.active_stream_id` is set and the server confirms the stream is still active.

## Why It Matters

Android users who background the app mid-stream no longer lose the live assistant response — on resume the stream reattaches and the in-progress message completes normally.

## Verification

```
$env:PYTHONUTF8 = '1'
..\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_sessions.py -v --timeout=60
..\hermes-agent\venv\Scripts\python.exe -m pytest tests/ -v --timeout=60
```

Manual: on an Android device (or emulated), start a long-running response, background the app until the offline banner triggers, then foreground — the live stream should resume and the assistant bubble should complete.

## Risks / Follow-ups

- The status check adds one extra round-trip on every soft offline recovery, even when no stream is active; the `if(sid&&streamId)` guard keeps it no-op for normal recovery.
- Path A (`visibilitychange`) already handles reattach correctly; this only closes the Path B gap.

## Model Used

Claude Opus 4.6 via Claude Code CLI

