### PR TITLE
fix(#766): dashboard aesthetic refinements — team column, bold names, alert border (#766)

### DIFF
--- a/static/i18n.js
+++ b/static/i18n.js
@@ -858,6 +858,7 @@ const LOCALES = {
     insights_model_tokens: 'Tokens',
     insights_model_cost: 'Cost',
     insights_model_share: 'Share',
+    insights_model_team: 'Team',
     insights_no_usage_data: 'No usage data yet',
     insights_footer: 'Showing data from the last {days} days',
     insights_skill_usage_title: 'Skill Usage',
@@ -2275,6 +2276,7 @@ const LOCALES = {
     insights_model_tokens: 'Token',
     insights_model_cost: 'Costo',
     insights_model_share: 'Quota',
+    insights_model_team: 'Team',
     insights_no_usage_data: 'Nessun dato di utilizzo',
     insights_footer: 'Dati mostrati dagli ultimi {days} giorni',
     insights_skill_usage_title: 'Utilizzo Skill',
@@ -3693,6 +3695,7 @@ const LOCALES = {
     insights_model_tokens: 'トークン',
     insights_model_cost: 'コスト',
     insights_model_share: 'シェア',
+    insights_model_team: 'チーム',
     insights_no_usage_data: '使用データはまだありません',
     insights_footer: '直近 {days} 日間のデータを表示',
     insights_skill_usage_title: 'スキル使用状況',
@@ -5579,6 +5582,7 @@ const LOCALES = {
     insights_model_tokens: 'Tokens',
     insights_model_cost: 'Cost',
     insights_model_share: 'Share',
+    insights_model_team: 'Team',
     insights_no_usage_data: 'No usage data yet',
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
     insights_skill_usage_title: 'Skill Usage',  // TODO: translate
@@ -6916,6 +6920,7 @@ const LOCALES = {
     insights_model_tokens: 'Tokens',
     insights_model_cost: 'Cost',
     insights_model_share: 'Share',
+    insights_model_team: 'Equipo',
     insights_no_usage_data: 'No usage data yet',
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
     insights_skill_usage_title: 'Skill Usage',  // TODO: translate
@@ -8269,6 +8274,7 @@ const LOCALES = {
     insights_model_tokens: 'Tokens',
     insights_model_cost: 'Cost',
     insights_model_share: 'Share',
+    insights_model_team: 'Team',
     insights_no_usage_data: 'No usage data yet',
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
     insights_skill_usage_title: 'Skill Usage',  // TODO: translate
@@ -9615,6 +9621,7 @@ const LOCALES = {
     insights_model_tokens: '令牌',
     insights_model_cost: '费用',
     insights_model_share: '占比',
+    insights_model_team: '团队',
     insights_no_usage_data: '暂无使用数据',
     insights_footer: '显示最近 {days} 天的数据',
     insights_skill_usage_title: '技能使用统计',
@@ -10507,6 +10514,7 @@ const LOCALES = {
     insights_model_tokens: 'Token',
     insights_model_cost: '成本',
     insights_model_share: '占比',
+    insights_model_team: '團隊',
     insights_no_usage_data: '尚無用量資料',
     insights_footer: '顯示最近 {days} 天的資料',
     insights_skill_usage_title: '技能使用情況',
@@ -13662,6 +13670,7 @@ const LOCALES = {
     insights_model_tokens: '토큰',
     insights_model_cost: '비용',
     insights_model_share: '비율',
+    insights_model_team: '팀',
     insights_no_usage_data: '아직 사용 데이터가 없습니다',
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
     insights_skill_usage_title: 'Skill Usage',  // TODO: translate
@@ -14423,6 +14432,7 @@ const LOCALES = {
     insights_model_tokens: 'Jetons',
     insights_model_cost: 'Coût',
     insights_model_share: 'Partager',
+    insights_model_team: 'Équipe',
     insights_no_usage_data: 'Aucune donnée d\'utilisation pour l\'instant',
     insights_footer: 'Affichage des données des {days} derniers jours',
     insights_skill_usage_title: 'Utilisation des Skills',
@@ -16423,6 +16433,7 @@ const LOCALES = {
     insights_model_tokens: 'Jetonlar',
     insights_model_cost: 'Maliyet',
     insights_model_share: 'Paylaşmak',
+    insights_model_team: 'Takım',
     insights_no_usage_data: 'Henüz kullanım verisi yok',
     insights_footer: 'Son {days} günün verileri gösteriliyor',
     insights_skill_usage_title: 'Skill Usage',  // TODO: translate
@@ -17301,6 +17312,7 @@ const LOCALES = {
     insights_model_tokens: 'Tokeny',
     insights_model_cost: 'Koszt',
     insights_model_share: 'Udział',
+    insights_model_team: 'Zespół',
     insights_no_usage_data: 'Brak danych o zużyciu',
     insights_footer: 'Wyświetlanie danych z ostatnich {days} dni',
     insights_skill_usage_title: 'Użycie umiejętności',

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -848,6 +848,7 @@ const LOCALES = {
     insights_model_tokens: 'Tokens',
     insights_model_cost: 'Cost',
     insights_model_share: 'Share',
+    insights_model_team: 'Team',
     insights_no_usage_data: 'No usage data yet',
     insights_footer: 'Showing data from the last {days} days',
     insights_skill_usage_title: 'Skill Usage',
@@ -2253,6 +2254,7 @@ const LOCALES = {
     insights_model_tokens: 'Token',
     insights_model_cost: 'Costo',
     insights_model_share: 'Quota',
+    insights_model_team: 'Team',
     insights_no_usage_data: 'Nessun dato di utilizzo',
     insights_footer: 'Dati mostrati dagli ultimi {days} giorni',
     insights_skill_usage_title: 'Utilizzo Skill',
@@ -3659,6 +3661,7 @@ const LOCALES = {
     insights_model_tokens: 'トークン',
     insights_model_cost: 'コスト',
     insights_model_share: 'シェア',
+    insights_model_team: 'チーム',
     insights_no_usage_data: '使用データはまだありません',
     insights_footer: '直近 {days} 日間のデータを表示',
     insights_skill_usage_title: 'スキル使用状況',
@@ -5531,6 +5534,7 @@ const LOCALES = {
     insights_model_tokens: 'Tokens',
     insights_model_cost: 'Cost',
     insights_model_share: 'Share',
+    insights_model_team: 'Team',
     insights_no_usage_data: 'No usage data yet',
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
     insights_skill_usage_title: 'Skill Usage',  // TODO: translate
@@ -6856,6 +6860,7 @@ const LOCALES = {
     insights_model_tokens: 'Tokens',
     insights_model_cost: 'Cost',
     insights_model_share: 'Share',
+    insights_model_team: 'Equipo',
     insights_no_usage_data: 'No usage data yet',
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
     insights_skill_usage_title: 'Skill Usage',  // TODO: translate
@@ -8197,6 +8202,7 @@ const LOCALES = {
     insights_model_tokens: 'Tokens',
     insights_model_cost: 'Cost',
     insights_model_share: 'Share',
+    insights_model_team: 'Team',
     insights_no_usage_data: 'No usage data yet',
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
     insights_skill_usage_title: 'Skill Usage',  // TODO: translate
@@ -9531,6 +9537,7 @@ const LOCALES = {
     insights_model_tokens: '令牌',
     insights_model_cost: '费用',
     insights_model_share: '占比',
+    insights_model_team: '团队',
     insights_no_usage_data: '暂无使用数据',
     insights_footer: '显示最近 {days} 天的数据',
     insights_skill_usage_title: '技能使用统计',
@@ -10413,6 +10420,7 @@ const LOCALES = {
     insights_model_tokens: 'Token',
     insights_model_cost: '成本',
     insights_model_share: '占比',
+    insights_model_team: '團隊',
     insights_no_usage_data: '尚無用量資料',
     insights_footer: '顯示最近 {days} 天的資料',
     insights_skill_usage_title: '技能使用情況',
@@ -13542,6 +13550,7 @@ const LOCALES = {
     insights_model_tokens: '토큰',
     insights_model_cost: '비용',
     insights_model_share: '비율',
+    insights_model_team: '팀',
     insights_no_usage_data: '아직 사용 데이터가 없습니다',
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
     insights_skill_usage_title: 'Skill Usage',  // TODO: translate
@@ -14293,6 +14302,7 @@ const LOCALES = {
     insights_model_tokens: 'Jetons',
     insights_model_cost: 'Coût',
     insights_model_share: 'Partager',
+    insights_model_team: 'Équipe',
     insights_no_usage_data: 'Aucune donnée d\'utilisation pour l\'instant',
     insights_footer: 'Affichage des données des {days} derniers jours',
     insights_skill_usage_title: 'Utilisation des Skills',
@@ -16279,6 +16289,7 @@ const LOCALES = {
     insights_model_tokens: 'Jetonlar',
     insights_model_cost: 'Maliyet',
     insights_model_share: 'Paylaşmak',
+    insights_model_team: 'Takım',
     insights_no_usage_data: 'Henüz kullanım verisi yok',
     insights_footer: 'Son {days} günün verileri gösteriliyor',
     insights_skill_usage_title: 'Skill Usage',  // TODO: translate
@@ -17149,6 +17160,7 @@ const LOCALES = {
     insights_model_tokens: 'Tokeny',
     insights_model_cost: 'Koszt',
     insights_model_share: 'Udział',
+    insights_model_team: 'Zespół',
     insights_no_usage_data: 'Brak danych o zużyciu',
     insights_footer: 'Wyświetlanie danych z ostatnich {days} dni',
     insights_skill_usage_title: 'Użycie umiejętności',

--- a/static/panels.js
+++ b/static/panels.js
@@ -3674,11 +3674,12 @@ function _renderInsights(d, box, wikiStatus, skillUsage) {
   // Models table
   let modelsHtml = '';
   if (d.models && d.models.length) {
-    modelsHtml = `<div class="insights-card"><div class="insights-card-title">${esc(t('insights_models'))}</div><div class="insights-table insights-model-table"><div class="insights-table-head"><span>${esc(t('insights_model_name'))}</span><span>${esc(t('insights_model_sessions'))}</span><span>${esc(t('insights_model_tokens'))}</span><span>${esc(t('insights_model_cost'))}</span><span>${esc(t('insights_model_share'))}</span></div>` +
+    modelsHtml = `<div class="insights-card"><div class="insights-card-title">${esc(t('insights_models'))}</div><div class="insights-table insights-model-table"><div class="insights-table-head"><span>${esc(t('insights_model_name'))}</span><span>${esc(t('insights_model_team','Team'))}</span><span>${esc(t('insights_model_sessions'))}</span><span>${esc(t('insights_model_tokens'))}</span><span>${esc(t('insights_model_cost'))}</span><span>${esc(t('insights_model_share'))}</span></div>` +
       d.models.map(m => {
         const share = Number(m.cost_share || m.token_share || m.session_share || 0);
         const title = `${m.model} · ${fmtTokens(m.input_tokens)} ${t('insights_input_tokens')} · ${fmtTokens(m.output_tokens)} ${t('insights_output_tokens')}`;
-        return `<div class="insights-table-row"><span class="insights-model-name" title="${esc(m.model)}">${esc(m.model)}</span><span>${fmtNum(m.sessions)}</span><span class="insights-model-tokens" title="${esc(title)}">${fmtTokens(m.total_tokens || 0)}</span><span class="insights-model-cost">${fmtCost(m.cost)}</span><span>${share}%</span></div>`;
+        const team = esc(m.profile || m.team || '—');
+        return `<div class="insights-table-row"><span class="insights-model-name" title="${esc(m.model)}">${esc(m.model)}</span><span class="insights-model-team" title="${team}">${team}</span><span>${fmtNum(m.sessions)}</span><span class="insights-model-tokens" title="${esc(title)}">${fmtTokens(m.total_tokens || 0)}</span><span class="insights-model-cost">${fmtCost(m.cost)}</span><span>${share}%</span></div>`;
       }).join('') +
       `</div></div>`;
   } else {

--- a/static/panels.js
+++ b/static/panels.js
@@ -3674,12 +3674,11 @@ function _renderInsights(d, box, wikiStatus, skillUsage) {
   // Models table
   let modelsHtml = '';
   if (d.models && d.models.length) {
-    modelsHtml = `<div class="insights-card"><div class="insights-card-title">${esc(t('insights_models'))}</div><div class="insights-table insights-model-table"><div class="insights-table-head"><span>${esc(t('insights_model_name'))}</span><span>${esc(t('insights_model_team'))}</span><span>${esc(t('insights_model_sessions'))}</span><span>${esc(t('insights_model_tokens'))}</span><span>${esc(t('insights_model_cost'))}</span><span>${esc(t('insights_model_share'))}</span></div>` +
+    modelsHtml = `<div class="insights-card"><div class="insights-card-title">${esc(t('insights_models'))}</div><div class="insights-table insights-model-table"><div class="insights-table-head"><span>${esc(t('insights_model_name'))}</span><span>${esc(t('insights_model_sessions'))}</span><span>${esc(t('insights_model_tokens'))}</span><span>${esc(t('insights_model_cost'))}</span><span>${esc(t('insights_model_share'))}</span></div>` +
       d.models.map(m => {
         const share = Number(m.cost_share || m.token_share || m.session_share || 0);
         const title = `${m.model} · ${fmtTokens(m.input_tokens)} ${t('insights_input_tokens')} · ${fmtTokens(m.output_tokens)} ${t('insights_output_tokens')}`;
-        const team = esc(m.profile || m.team || '—');
-        return `<div class="insights-table-row"><span class="insights-model-name" title="${esc(m.model)}">${esc(m.model)}</span><span class="insights-model-team" title="${team}">${team}</span><span>${fmtNum(m.sessions)}</span><span class="insights-model-tokens" title="${esc(title)}">${fmtTokens(m.total_tokens || 0)}</span><span class="insights-model-cost">${fmtCost(m.cost)}</span><span>${share}%</span></div>`;
+        return `<div class="insights-table-row"><span class="insights-model-name" title="${esc(m.model)}">${esc(m.model)}</span><span>${fmtNum(m.sessions)}</span><span class="insights-model-tokens" title="${esc(title)}">${fmtTokens(m.total_tokens || 0)}</span><span class="insights-model-cost">${fmtCost(m.cost)}</span><span>${share}%</span></div>`;
       }).join('') +
       `</div></div>`;
   } else {

--- a/static/panels.js
+++ b/static/panels.js
@@ -3674,7 +3674,7 @@ function _renderInsights(d, box, wikiStatus, skillUsage) {
   // Models table
   let modelsHtml = '';
   if (d.models && d.models.length) {
-    modelsHtml = `<div class="insights-card"><div class="insights-card-title">${esc(t('insights_models'))}</div><div class="insights-table insights-model-table"><div class="insights-table-head"><span>${esc(t('insights_model_name'))}</span><span>${esc(t('insights_model_team','Team'))}</span><span>${esc(t('insights_model_sessions'))}</span><span>${esc(t('insights_model_tokens'))}</span><span>${esc(t('insights_model_cost'))}</span><span>${esc(t('insights_model_share'))}</span></div>` +
+    modelsHtml = `<div class="insights-card"><div class="insights-card-title">${esc(t('insights_models'))}</div><div class="insights-table insights-model-table"><div class="insights-table-head"><span>${esc(t('insights_model_name'))}</span><span>${esc(t('insights_model_team'))}</span><span>${esc(t('insights_model_sessions'))}</span><span>${esc(t('insights_model_tokens'))}</span><span>${esc(t('insights_model_cost'))}</span><span>${esc(t('insights_model_share'))}</span></div>` +
       d.models.map(m => {
         const share = Number(m.cost_share || m.token_share || m.session_share || 0);
         const title = `${m.model} · ${fmtTokens(m.input_tokens)} ${t('insights_input_tokens')} · ${fmtTokens(m.output_tokens)} ${t('insights_output_tokens')}`;

--- a/static/panels.js
+++ b/static/panels.js
@@ -3669,7 +3669,7 @@ function _renderInsights(d, box, wikiStatus, skillUsage) {
   // Models table
   let modelsHtml = '';
   if (d.models && d.models.length) {
-    modelsHtml = `<div class="insights-card"><div class="insights-card-title">${esc(t('insights_models'))}</div><div class="insights-table insights-model-table"><div class="insights-table-head"><span>${esc(t('insights_model_name'))}</span><span>${esc(t('insights_model_team','Team'))}</span><span>${esc(t('insights_model_sessions'))}</span><span>${esc(t('insights_model_tokens'))}</span><span>${esc(t('insights_model_cost'))}</span><span>${esc(t('insights_model_share'))}</span></div>` +
+    modelsHtml = `<div class="insights-card"><div class="insights-card-title">${esc(t('insights_models'))}</div><div class="insights-table insights-model-table"><div class="insights-table-head"><span>${esc(t('insights_model_name'))}</span><span>${esc(t('insights_model_team'))}</span><span>${esc(t('insights_model_sessions'))}</span><span>${esc(t('insights_model_tokens'))}</span><span>${esc(t('insights_model_cost'))}</span><span>${esc(t('insights_model_share'))}</span></div>` +
       d.models.map(m => {
         const share = Number(m.cost_share || m.token_share || m.session_share || 0);
         const title = `${m.model} · ${fmtTokens(m.input_tokens)} ${t('insights_input_tokens')} · ${fmtTokens(m.output_tokens)} ${t('insights_output_tokens')}`;

--- a/static/panels.js
+++ b/static/panels.js
@@ -3669,11 +3669,12 @@ function _renderInsights(d, box, wikiStatus, skillUsage) {
   // Models table
   let modelsHtml = '';
   if (d.models && d.models.length) {
-    modelsHtml = `<div class="insights-card"><div class="insights-card-title">${esc(t('insights_models'))}</div><div class="insights-table insights-model-table"><div class="insights-table-head"><span>${esc(t('insights_model_name'))}</span><span>${esc(t('insights_model_sessions'))}</span><span>${esc(t('insights_model_tokens'))}</span><span>${esc(t('insights_model_cost'))}</span><span>${esc(t('insights_model_share'))}</span></div>` +
+    modelsHtml = `<div class="insights-card"><div class="insights-card-title">${esc(t('insights_models'))}</div><div class="insights-table insights-model-table"><div class="insights-table-head"><span>${esc(t('insights_model_name'))}</span><span>${esc(t('insights_model_team','Team'))}</span><span>${esc(t('insights_model_sessions'))}</span><span>${esc(t('insights_model_tokens'))}</span><span>${esc(t('insights_model_cost'))}</span><span>${esc(t('insights_model_share'))}</span></div>` +
       d.models.map(m => {
         const share = Number(m.cost_share || m.token_share || m.session_share || 0);
         const title = `${m.model} · ${fmtTokens(m.input_tokens)} ${t('insights_input_tokens')} · ${fmtTokens(m.output_tokens)} ${t('insights_output_tokens')}`;
-        return `<div class="insights-table-row"><span class="insights-model-name" title="${esc(m.model)}">${esc(m.model)}</span><span>${fmtNum(m.sessions)}</span><span class="insights-model-tokens" title="${esc(title)}">${fmtTokens(m.total_tokens || 0)}</span><span class="insights-model-cost">${fmtCost(m.cost)}</span><span>${share}%</span></div>`;
+        const team = esc(m.profile || m.team || '—');
+        return `<div class="insights-table-row"><span class="insights-model-name" title="${esc(m.model)}">${esc(m.model)}</span><span class="insights-model-team" title="${team}">${team}</span><span>${fmtNum(m.sessions)}</span><span class="insights-model-tokens" title="${esc(title)}">${fmtTokens(m.total_tokens || 0)}</span><span class="insights-model-cost">${fmtCost(m.cost)}</span><span>${share}%</span></div>`;
       }).join('') +
       `</div></div>`;
   } else {

--- a/static/style.css
+++ b/static/style.css
@@ -1297,7 +1297,7 @@
   .offline-action{flex-shrink:0;padding:7px 13px;border-radius:9px;border:1px solid var(--accent-bg-strong);background:var(--accent-bg);color:var(--accent-text);font-size:12px;font-weight:700;cursor:pointer;}
   .offline-action:hover{background:var(--accent-bg-strong);}
   .offline-action[disabled]{cursor:wait;opacity:.65;}
-  .agent-health-banner{position:sticky;bottom:0;z-index:4;display:none;align-items:center;justify-content:space-between;gap:12px;margin:10px auto 0;max-width:var(--msg-max);width:calc(100% - 40px);padding:12px 16px;border:1px solid color-mix(in srgb,var(--error) 55%,var(--surface));border-radius:12px;background:color-mix(in srgb,var(--error) 14%,var(--surface));color:var(--text);box-shadow:0 10px 32px rgba(0,0,0,.16);}
+  .agent-health-banner{position:sticky;bottom:0;z-index:4;display:none;align-items:center;justify-content:space-between;gap:12px;margin:10px auto 0;max-width:var(--msg-max);width:calc(100% - 40px);padding:12px 16px;border:2px solid color-mix(in srgb,var(--error) 65%,var(--surface));border-radius:12px;background:color-mix(in srgb,var(--error) 14%,var(--surface));color:var(--text);box-shadow:0 10px 32px rgba(0,0,0,.16);}
   .agent-health-banner.visible{display:flex;}
   .agent-health-copy{display:flex;flex-direction:column;gap:3px;min-width:0;font-size:13px;line-height:1.35;}
   .agent-health-copy strong{color:var(--error);font-size:13px;}
@@ -2533,7 +2533,7 @@
 .ws-opt.active{background:var(--accent-bg);}
 .ws-opt-name{display:block;font-size:13px;color:var(--text);font-weight:500;line-height:1.25;white-space:normal;overflow:hidden;text-overflow:ellipsis;}
 .ws-opt-path{display:block;font-size:10px;color:var(--muted);line-height:1.3;overflow:hidden;text-overflow:ellipsis;white-space:normal;opacity:.72;word-break:break-word;}
-.ws-divider{height:1px;background:var(--border);margin:4px 0;}
+.ws-divider{height:1px;background:var(--border2,var(--border));margin:5px 0;}
 .ws-manage{color:var(--muted);font-size:12px;}
 .ws-opt-action{display:flex;flex-direction:row;align-items:center;gap:8px;}
 .ws-search-row{display:flex;align-items:center;gap:6px;padding:8px 10px 10px;}
@@ -2573,7 +2573,7 @@
 .profile-opt-badge{display:inline-block;width:7px;height:7px;border-radius:50%;margin-right:5px;vertical-align:middle;}
 .profile-opt-badge.running{background:#4caf50;box-shadow:0 0 4px rgba(76,175,80,.5);}
 .profile-opt-badge.stopped{background:rgba(255,255,255,.2);}
-.profile-card{padding:8px 10px;margin-bottom:2px;border:1px solid transparent;border-radius:8px;cursor:pointer;color:var(--muted);transition:background .15s,border-color .15s,color .15s;}
+.profile-card{padding:10px 12px;margin-bottom:4px;border:1px solid transparent;border-radius:8px;cursor:pointer;color:var(--muted);transition:background .15s,border-color .15s,color .15s;}
 .profile-card:hover{background:var(--surface);color:var(--text);}
 .profile-card.active{background:var(--accent-bg);border-color:var(--accent-bg-strong);color:var(--accent-text);}
 .profile-card-header{display:flex;align-items:center;justify-content:space-between;gap:8px;}
@@ -5081,8 +5081,8 @@ main.main > .main-view:not([id="mainChat"]):not([id="mainSettings"]) .main-view-
 .detail-badge.running{background:rgba(59,130,246,.12);color:rgba(96,165,250,.95);border-color:rgba(96,165,250,.3);}
 .detail-badge.running::before{content:'';display:inline-block;width:10px;height:10px;border:2px solid rgba(96,165,250,.4);border-top-color:rgba(96,165,250,.95);border-radius:50%;margin-right:6px;vertical-align:middle;animation:cron-spinner .6s linear infinite;}
 @keyframes cron-spinner{to{transform:rotate(360deg);}}
-.detail-alert{border:1px solid rgba(245,158,11,.35);background:rgba(245,158,11,.1);border-radius:8px;padding:12px 14px;margin-bottom:16px;color:var(--text);}
-.detail-alert-title{font-size:12px;font-weight:700;color:rgba(245,158,11,.98);text-transform:uppercase;letter-spacing:0;margin-bottom:6px;}
+.detail-alert{border:2px solid rgba(245,158,11,.45);background:rgba(245,158,11,.1);border-radius:8px;padding:12px 14px;margin-bottom:16px;color:var(--text);}
+.detail-alert-title{font-size:12px;font-weight:700;color:var(--error,#e05);text-transform:uppercase;letter-spacing:0;margin-bottom:6px;}
 .detail-alert p{margin:0 0 8px;font-size:13px;line-height:1.45;color:var(--text);}
 .detail-alert p:last-child{margin-bottom:0;}
 .detail-alert-actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:10px;}
@@ -5281,9 +5281,10 @@ main.main.showing-insights > #mainInsights{display:flex;overflow-y:auto;}
 .insights-table{width:100%;font-size:12px;}
 .insights-table-head{display:grid;grid-template-columns:1fr 80px;padding:4px 0;border-bottom:1px solid var(--border);font-weight:600;color:var(--muted);font-size:11px;}
 .insights-table-row{display:grid;grid-template-columns:1fr 80px;padding:6px 0;border-bottom:1px solid var(--border,.05);}
-.insights-model-table .insights-table-head,.insights-model-table .insights-table-row{grid-template-columns:minmax(90px,1.5fr) 64px 76px 74px 52px;gap:8px;align-items:center;}
-.insights-model-cost,.insights-model-tokens{font-variant-numeric:tabular-nums;}
-.insights-model-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.insights-model-table .insights-table-head,.insights-model-table .insights-table-row{grid-template-columns:minmax(90px,1.5fr) minmax(60px,1fr) 64px 70px 68px 48px;gap:8px;align-items:center;}
+.insights-model-cost,.insights-model-tokens{font-variant-numeric:tabular-nums;font-weight:700;color:var(--text);}
+.insights-model-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:700;color:var(--text);}
+.insights-model-team{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--muted);font-size:11px;}
 .insights-empty{font-size:12px;color:var(--muted);padding:12px 0;}
 .insights-daily-token-chart{height:180px;display:grid;grid-auto-flow:column;grid-auto-columns:minmax(0,1fr);gap:4px;align-items:end;padding:6px 0 2px;border-bottom:1px solid var(--border);overflow:hidden;max-width:100%;}
 .insights-daily-bar{min-width:0;height:100%;display:flex;flex-direction:column;justify-content:flex-end;gap:4px;}

--- a/static/style.css
+++ b/static/style.css
@@ -5281,10 +5281,9 @@ main.main.showing-insights > #mainInsights{display:flex;overflow-y:auto;}
 .insights-table{width:100%;font-size:12px;}
 .insights-table-head{display:grid;grid-template-columns:1fr 80px;padding:4px 0;border-bottom:1px solid var(--border);font-weight:600;color:var(--muted);font-size:11px;}
 .insights-table-row{display:grid;grid-template-columns:1fr 80px;padding:6px 0;border-bottom:1px solid var(--border,.05);}
-.insights-model-table .insights-table-head,.insights-model-table .insights-table-row{grid-template-columns:minmax(90px,1.5fr) minmax(60px,1fr) 64px 70px 68px 48px;gap:8px;align-items:center;}
+.insights-model-table .insights-table-head,.insights-model-table .insights-table-row{grid-template-columns:minmax(90px,1.5fr) 64px 70px 68px 48px;gap:8px;align-items:center;}
 .insights-model-cost,.insights-model-tokens{font-variant-numeric:tabular-nums;font-weight:700;color:var(--text);}
 .insights-model-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:700;color:var(--text);}
-.insights-model-team{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--muted);font-size:11px;}
 .insights-empty{font-size:12px;color:var(--muted);padding:12px 0;}
 .insights-daily-token-chart{height:180px;display:grid;grid-auto-flow:column;grid-auto-columns:minmax(0,1fr);gap:4px;align-items:end;padding:6px 0 2px;border-bottom:1px solid var(--border);overflow:hidden;max-width:100%;}
 .insights-daily-bar{min-width:0;height:100%;display:flex;flex-direction:column;justify-content:flex-end;gap:4px;}

--- a/static/style.css
+++ b/static/style.css
@@ -4493,7 +4493,7 @@ main.main > #mainPlugin{display:none;}
 .cron-agent-badge{flex-shrink:0;font-size:12px;line-height:1;}
 .cron-script-badge{flex-shrink:0;font-size:12px;line-height:1;opacity:.92;}
 .cron-script-job-banner{margin-bottom:12px;}
-.cron-script-job-banner .detail-alert-title{font-weight:600;}
+.cron-script-job-banner .detail-alert-title{font-weight:600;color:rgba(245,158,11,.98);}
 .detail-script{background:var(--sidebar);border:1px solid var(--border);border-radius:8px;padding:10px 12px;font-size:12px;white-space:pre-wrap;line-height:1.55;color:var(--text);font-family:'SF Mono',ui-monospace,monospace;word-break:break-word;}
 .detail-hint{font-size:11px;color:var(--muted);line-height:1.5;}
 .cron-script-card .detail-hint,.cron-script-card-hint{margin-top:8px;}

--- a/static/style.css
+++ b/static/style.css
@@ -4095,7 +4095,7 @@ main.main > #mainPlugin{display:none;}
 .cron-agent-badge{flex-shrink:0;font-size:12px;line-height:1;}
 .cron-script-badge{flex-shrink:0;font-size:12px;line-height:1;opacity:.92;}
 .cron-script-job-banner{margin-bottom:12px;}
-.cron-script-job-banner .detail-alert-title{font-weight:600;}
+.cron-script-job-banner .detail-alert-title{font-weight:600;color:rgba(245,158,11,.98);}
 .detail-script{background:var(--sidebar);border:1px solid var(--border);border-radius:8px;padding:10px 12px;font-size:12px;white-space:pre-wrap;line-height:1.55;color:var(--text);font-family:'SF Mono',ui-monospace,monospace;word-break:break-word;}
 .detail-hint{font-size:11px;color:var(--muted);line-height:1.5;}
 .cron-script-card .detail-hint,.cron-script-card-hint{margin-top:8px;}

--- a/static/style.css
+++ b/static/style.css
@@ -1285,7 +1285,7 @@
   .offline-action{flex-shrink:0;padding:7px 13px;border-radius:9px;border:1px solid var(--accent-bg-strong);background:var(--accent-bg);color:var(--accent-text);font-size:12px;font-weight:700;cursor:pointer;}
   .offline-action:hover{background:var(--accent-bg-strong);}
   .offline-action[disabled]{cursor:wait;opacity:.65;}
-  .agent-health-banner{position:sticky;bottom:0;z-index:4;display:none;align-items:center;justify-content:space-between;gap:12px;margin:10px auto 0;max-width:var(--msg-max);width:calc(100% - 40px);padding:12px 16px;border:1px solid color-mix(in srgb,var(--error) 55%,var(--surface));border-radius:12px;background:color-mix(in srgb,var(--error) 14%,var(--surface));color:var(--text);box-shadow:0 10px 32px rgba(0,0,0,.16);}
+  .agent-health-banner{position:sticky;bottom:0;z-index:4;display:none;align-items:center;justify-content:space-between;gap:12px;margin:10px auto 0;max-width:var(--msg-max);width:calc(100% - 40px);padding:12px 16px;border:2px solid color-mix(in srgb,var(--error) 65%,var(--surface));border-radius:12px;background:color-mix(in srgb,var(--error) 14%,var(--surface));color:var(--text);box-shadow:0 10px 32px rgba(0,0,0,.16);}
   .agent-health-banner.visible{display:flex;}
   .agent-health-copy{display:flex;flex-direction:column;gap:3px;min-width:0;font-size:13px;line-height:1.35;}
   .agent-health-copy strong{color:var(--error);font-size:13px;}
@@ -2520,7 +2520,7 @@
 .ws-opt.active{background:var(--accent-bg);}
 .ws-opt-name{display:block;font-size:13px;color:var(--text);font-weight:500;line-height:1.25;white-space:normal;overflow:hidden;text-overflow:ellipsis;}
 .ws-opt-path{display:block;font-size:10px;color:var(--muted);line-height:1.3;overflow:hidden;text-overflow:ellipsis;white-space:normal;opacity:.72;word-break:break-word;}
-.ws-divider{height:1px;background:var(--border);margin:4px 0;}
+.ws-divider{height:1px;background:var(--border2,var(--border));margin:5px 0;}
 .ws-manage{color:var(--muted);font-size:12px;}
 .ws-opt-action{display:flex;flex-direction:row;align-items:center;gap:8px;}
 .ws-search-row{display:flex;align-items:center;gap:6px;padding:8px 10px 10px;}
@@ -2560,7 +2560,7 @@
 .profile-opt-badge{display:inline-block;width:7px;height:7px;border-radius:50%;margin-right:5px;vertical-align:middle;}
 .profile-opt-badge.running{background:#4caf50;box-shadow:0 0 4px rgba(76,175,80,.5);}
 .profile-opt-badge.stopped{background:rgba(255,255,255,.2);}
-.profile-card{padding:8px 10px;margin-bottom:2px;border:1px solid transparent;border-radius:8px;cursor:pointer;color:var(--muted);transition:background .15s,border-color .15s,color .15s;}
+.profile-card{padding:10px 12px;margin-bottom:4px;border:1px solid transparent;border-radius:8px;cursor:pointer;color:var(--muted);transition:background .15s,border-color .15s,color .15s;}
 .profile-card:hover{background:var(--surface);color:var(--text);}
 .profile-card.active{background:var(--accent-bg);border-color:var(--accent-bg-strong);color:var(--accent-text);}
 .profile-card-header{display:flex;align-items:center;justify-content:space-between;gap:8px;}
@@ -4666,8 +4666,8 @@ main.main > .main-view:not([id="mainChat"]):not([id="mainSettings"]) .main-view-
 .detail-badge.running{background:rgba(59,130,246,.12);color:rgba(96,165,250,.95);border-color:rgba(96,165,250,.3);}
 .detail-badge.running::before{content:'';display:inline-block;width:10px;height:10px;border:2px solid rgba(96,165,250,.4);border-top-color:rgba(96,165,250,.95);border-radius:50%;margin-right:6px;vertical-align:middle;animation:cron-spinner .6s linear infinite;}
 @keyframes cron-spinner{to{transform:rotate(360deg);}}
-.detail-alert{border:1px solid rgba(245,158,11,.35);background:rgba(245,158,11,.1);border-radius:8px;padding:12px 14px;margin-bottom:16px;color:var(--text);}
-.detail-alert-title{font-size:12px;font-weight:700;color:rgba(245,158,11,.98);text-transform:uppercase;letter-spacing:0;margin-bottom:6px;}
+.detail-alert{border:2px solid rgba(245,158,11,.45);background:rgba(245,158,11,.1);border-radius:8px;padding:12px 14px;margin-bottom:16px;color:var(--text);}
+.detail-alert-title{font-size:12px;font-weight:700;color:var(--error,#e05);text-transform:uppercase;letter-spacing:0;margin-bottom:6px;}
 .detail-alert p{margin:0 0 8px;font-size:13px;line-height:1.45;color:var(--text);}
 .detail-alert p:last-child{margin-bottom:0;}
 .detail-alert-actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:10px;}
@@ -4864,9 +4864,10 @@ main.main.showing-insights > #mainInsights{display:flex;overflow-y:auto;}
 .insights-table{width:100%;font-size:12px;}
 .insights-table-head{display:grid;grid-template-columns:1fr 80px;padding:4px 0;border-bottom:1px solid var(--border);font-weight:600;color:var(--muted);font-size:11px;}
 .insights-table-row{display:grid;grid-template-columns:1fr 80px;padding:6px 0;border-bottom:1px solid var(--border,.05);}
-.insights-model-table .insights-table-head,.insights-model-table .insights-table-row{grid-template-columns:minmax(90px,1.5fr) 64px 76px 74px 52px;gap:8px;align-items:center;}
-.insights-model-cost,.insights-model-tokens{font-variant-numeric:tabular-nums;}
-.insights-model-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.insights-model-table .insights-table-head,.insights-model-table .insights-table-row{grid-template-columns:minmax(90px,1.5fr) minmax(60px,1fr) 64px 70px 68px 48px;gap:8px;align-items:center;}
+.insights-model-cost,.insights-model-tokens{font-variant-numeric:tabular-nums;font-weight:700;color:var(--text);}
+.insights-model-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:700;color:var(--text);}
+.insights-model-team{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--muted);font-size:11px;}
 .insights-empty{font-size:12px;color:var(--muted);padding:12px 0;}
 .insights-daily-token-chart{height:180px;display:grid;grid-auto-flow:column;grid-auto-columns:minmax(0,1fr);gap:4px;align-items:end;padding:6px 0 2px;border-bottom:1px solid var(--border);overflow:hidden;max-width:100%;}
 .insights-daily-bar{min-width:0;height:100%;display:flex;flex-direction:column;justify-content:flex-end;gap:4px;}

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -149,6 +149,8 @@ def test_insights_frontend_renders_daily_token_chart_and_model_usage_table():
     assert "insights_model_tokens" in PANELS_JS
     assert "insights_model_cost" in PANELS_JS
     assert "insights_model_share" in PANELS_JS
+    assert "insights_model_team" not in PANELS_JS
+    assert "m.profile || m.team" not in PANELS_JS
     assert "insights_no_usage_data" in PANELS_JS
 
 
@@ -162,6 +164,7 @@ def test_insights_frontend_has_daily_chart_styles_and_range_switching_hooks():
     assert ".insights-daily-token-chart" in STYLE_CSS
     assert ".insights-daily-bar-output" in STYLE_CSS
     assert ".insights-model-cost" in STYLE_CSS
+    assert ".insights-model-team" not in STYLE_CSS
 
 
 def _make_daily_rows(n):


### PR DESCRIPTION
## Thinking Path

- The styling polish is useful on its own, but the new Team column only shipped placeholder `—` values because the Insights payload never provided backing profile data.
- Maintainer review narrowed the safe slice back to purely visual refinements on the existing model-usage table.
- This keeps the readability wins while avoiding a structurally empty column in a production Insights surface.

## What Changed

- `static/panels.js`: removes the Team column and restores the existing five-column model usage table.
- `static/style.css`: keeps the bold model-name and cost styling plus the alert-border/title polish, while dropping the Team-column layout helper.
- `tests/test_insights.py`: updates the focused static regression to assert the Team column is no longer rendered.

## Why It Matters

The dashboard keeps the clearer typography and stronger alert treatment without shipping a column that can never show real data.

## Verification

- Focused local pytest via the repo's headless runner: `tests/test_insights.py`
- Runtime ESLint: `npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"`
- Full suite not run locally; CI covers the full matrix.

## Risks / Follow-ups

This does not add per-profile model attribution to Insights. If that data becomes available later, it can return in a separate backend-backed change.

## Model Used

GPT-5.4 via MiMoCode