### PR TITLE
feat(#3845): add J/K keyboard shortcuts for previous/next session navigation

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -6169,3 +6169,22 @@ async function _confirmDeleteProject(proj){
 document.addEventListener('keydown',(e)=>{
   if(e.key==='Escape'&&_sessionSelectMode) exitSessionSelectMode();
 });
+
+// Keyboard session navigation — J/K bindings
+function navigateSession(dir){
+  const rows=[...document.querySelectorAll('.session-item[data-sid]')];
+  const sids=rows.map(r=>r.dataset.sid);
+  const cur=S.session&&S.session.session_id;
+  const i=sids.indexOf(cur);
+  if(i<0||!sids.length)return;
+  const next=sids[Math.min(Math.max(i+dir,0),sids.length-1)];
+  if(next&&next!==cur) loadSession(next);
+}
+
+document.addEventListener('keydown',(e)=>{
+  if(e.key!=='j'&&e.key!=='k') return;
+  if(e.ctrlKey||e.metaKey||e.altKey) return;
+  if(typeof _isInteractiveSwipeTarget==='function'&&_isInteractiveSwipeTarget(e.target)) return;
+  e.preventDefault();
+  navigateSession(e.key==='j'?1:-1);
+});

--- a/tests/test_3845_keyboard_session_nav.py
+++ b/tests/test_3845_keyboard_session_nav.py
@@ -1,0 +1,99 @@
+"""Regression check for #3845 — keyboard session navigation with J/K bindings.
+
+The session list supports keyboard navigation using J (next) and K (previous)
+to move focus through sessions without mouse interaction. Verified at the source
+level so this stays fast.
+"""
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def test_navigateSession_function_exists():
+    """navigateSession function is defined and exported to global scope."""
+    assert "function navigateSession(dir)" in SESSIONS_JS
+
+
+def test_navigateSession_calls_loadSession():
+    """navigateSession calls loadSession(next) when switching sessions."""
+    # Extract the navigateSession function definition
+    start = SESSIONS_JS.index("function navigateSession(dir)")
+    end = SESSIONS_JS.index("}", start) + 1
+    func_body = SESSIONS_JS[start:end]
+    assert "loadSession(next)" in func_body
+
+
+def test_navigateSession_queries_session_items():
+    """navigateSession queries .session-item[data-sid] elements."""
+    start = SESSIONS_JS.index("function navigateSession(dir)")
+    end = SESSIONS_JS.index("}", start) + 1
+    func_body = SESSIONS_JS[start:end]
+    assert ".session-item[data-sid]" in func_body
+
+
+def test_j_k_keydown_listener_exists():
+    """J/K keyboard listener is registered on document."""
+    # Find the keyboard listener that checks for j and k keys
+    assert "if(e.key!=='j'&&e.key!=='k')" in SESSIONS_JS
+
+
+def test_j_k_listener_appears_after_navigateSession():
+    """J/K listener appears after navigateSession function definition."""
+    nav_start = SESSIONS_JS.index("function navigateSession(dir)")
+    jk_start = SESSIONS_JS.index("if(e.key!=='j'&&e.key!=='k')", nav_start)
+    assert jk_start > nav_start
+
+
+def test_j_k_listener_prevents_default():
+    """e.preventDefault() is called before navigateSession in J/K listener."""
+    jk_start = SESSIONS_JS.index("if(e.key!=='j'&&e.key!=='k')")
+    # Extract the J/K listener code block
+    jk_block_end = SESSIONS_JS.index("});", jk_start)
+    jk_block = SESSIONS_JS[jk_start:jk_block_end]
+
+    assert "e.preventDefault()" in jk_block
+    # Verify preventDefault comes before navigateSession call
+    prevent_idx = jk_block.index("e.preventDefault()")
+    nav_idx = jk_block.index("navigateSession")
+    assert prevent_idx < nav_idx
+
+
+def test_j_k_listener_checks_modifiers():
+    """J/K listener ignores when Ctrl, Meta, or Alt modifiers are active."""
+    jk_start = SESSIONS_JS.index("if(e.key!=='j'&&e.key!=='k')")
+    jk_block_end = SESSIONS_JS.index("});", jk_start)
+    jk_block = SESSIONS_JS[jk_start:jk_block_end]
+
+    assert "e.ctrlKey" in jk_block
+    assert "e.metaKey" in jk_block
+    assert "e.altKey" in jk_block
+
+
+def test_j_k_listener_checks_interactive_swipe_target():
+    """J/K listener checks _isInteractiveSwipeTarget to avoid input fields."""
+    jk_start = SESSIONS_JS.index("if(e.key!=='j'&&e.key!=='k')")
+    jk_block_end = SESSIONS_JS.index("});", jk_start)
+    jk_block = SESSIONS_JS[jk_start:jk_block_end]
+
+    assert "_isInteractiveSwipeTarget" in jk_block
+    assert "typeof _isInteractiveSwipeTarget===" in jk_block
+
+
+def test_j_navigates_forward():
+    """Pressing J calls navigateSession with dir=1 (forward)."""
+    jk_start = SESSIONS_JS.index("if(e.key!=='j'&&e.key!=='k')")
+    jk_block_end = SESSIONS_JS.index("});", jk_start)
+    jk_block = SESSIONS_JS[jk_start:jk_block_end]
+
+    assert "navigateSession(e.key==='j'?1:-1)" in jk_block
+
+
+def test_k_navigates_backward():
+    """Pressing K calls navigateSession with dir=-1 (backward)."""
+    jk_start = SESSIONS_JS.index("if(e.key!=='j'&&e.key!=='k')")
+    jk_block_end = SESSIONS_JS.index("});", jk_start)
+    jk_block = SESSIONS_JS[jk_start:jk_block_end]
+
+    # The ternary "e.key==='j'?1:-1" encodes both J and K behavior
+    assert "navigateSession(e.key==='j'?1:-1)" in jk_block


### PR DESCRIPTION
## Thinking Path

- Users asked for fast session switching without reaching for the mouse; the maintainer confirmed the feature and recommended starting with keyboard bindings as the lower-risk slice 1.
- `loadSession(sid)` at `sessions.js:754` is already the canonical session-switch path; DOM order from `.session-item[data-sid]` gives the navigation sequence without coupling to any internal sort state.
- Reusing `_isInteractiveSwipeTarget` from `boot.js:282` as the input-guard keeps the guard logic in one place and covers all the same interactive surfaces already protected by the swipe gesture.

## What Changed

- `static/sessions.js`: added `navigateSession(dir)` function and a `document.addEventListener('keydown',...)` listener that fires J (next) / K (prev) when focus is outside interactive elements.

## Why It Matters

Keyboard-centric users can now move between sessions without touching the mouse; J and K are the standard vim-style navigation keys already familiar to power users of similar tools.

## Verification

```
$env:PYTHONUTF8 = '1'
..\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_3845_keyboard_session_nav.py -v --timeout=60
..\hermes-agent\venv\Scripts\python.exe -m pytest tests/ -v --timeout=60
npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"
```

## Risks / Follow-ups

- `.sidebar` is included in `_isInteractiveSwipeTarget`'s exclusion list, so J/K do not fire when focus is inside the sidebar panel; if users want to navigate from the sidebar too, the guard can be narrowed in a follow-up.
- Slice 2 (chat-area swipe gesture + visual affordance) is a separate PR per the maintainer's recommendation.

## Model Used

Claude Opus 4.6 via Claude Code CLI
