### PR TITLE
docs(#3794): clarify how to stop each launch method in Quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ For self-hosted VM or homelab installs, `ctl.sh` wraps the common daemon lifecyc
 
 `ctl.sh start` runs the bootstrap in foreground/no-browser mode behind the daemon wrapper, writes logs to `~/.hermes/webui.log`, and respects `.env` plus inline overrides such as `HERMES_WEBUI_HOST=0.0.0.0 ./ctl.sh start`.
 
+> **Stopping the server.** Each launch method has its own stop path because only `ctl.sh start` writes a PID file (`~/.hermes/webui.pid`):
+>
+> | Launch method | How to stop |
+> |---|---|
+> | `python3 bootstrap.py` or `./start.sh` | **Ctrl-C** in the terminal (both run in the foreground) |
+> | `./ctl.sh start` | `./ctl.sh stop` (sends SIGTERM, waits, then SIGKILL) |
+> | Detached `bootstrap.py` (no `--foreground`) | Kill the PID shown in the bootstrap output, or find it via `lsof -i :8787` |
+>
+> `./ctl.sh stop` cannot stop a server launched by `bootstrap.py` or `start.sh` directly — it only manages processes it started itself.
+
 ### Advanced: dynamic recall prefill & Gateway-backed chat
 
 Two optional, self-hosted-deployment features — attaching dynamic **session-recall prefill** to browser turns (Joplin/Obsidian/Notion/llm-wiki routers), and routing browser chat through a running **Hermes Gateway** — are documented in [`docs/advanced-chat-setup.md`](docs/advanced-chat-setup.md). Most users need neither.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ For self-hosted VM or homelab installs, `ctl.sh` wraps the common daemon lifecyc
 > |---|---|
 > | `python3 bootstrap.py` or `./start.sh` | **Ctrl-C** in the terminal (both run in the foreground) |
 > | `./ctl.sh start` | `./ctl.sh stop` (sends SIGTERM, waits, then SIGKILL) |
-> | Detached `bootstrap.py` (no `--foreground`) | Kill the PID shown in the bootstrap output, or find it via `lsof -i :8787` |
+> | Detached `bootstrap.py` (no `--foreground`) | Find the PID via `lsof -i :8787` (or `ss -tlnp`) and `kill` it |
 >
 > `./ctl.sh stop` cannot stop a server launched by `bootstrap.py` or `start.sh` directly — it only manages processes it started itself.
 


### PR DESCRIPTION
## Thinking Path

- The Quick start documents three launch paths (bootstrap.py, start.sh, ctl.sh start) but only ctl.sh has a documented stop command, and users don't realize it only works for ctl.sh-launched servers because it relies on a PID file that other launchers don't write.
- The maintainer's bot already diagnosed this in the issue comments with the full ctl.sh lifecycle analysis.
- Fix: add a concise "Stopping the server" blockquote with a three-row table mapping each launcher to its stop method, placed between the ctl.sh paragraph and the Advanced section.

## What Changed

- README.md: added a "Stopping the server" blockquote table after the ctl.sh prose paragraph, covering bootstrap.py/start.sh (Ctrl-C), ctl.sh start (ctl.sh stop), and detached bootstrap (PID kill)

## Why It Matters

Users who start via ootstrap.py or start.sh and then try ./ctl.sh stop get a false "stopped" message while the server keeps running, leading to port conflicts and confusion on restart.

## Verification

- pytest tests/test_docker_docs_and_readonly.py -v --timeout=60
- Manual: README.md renders without formatting issues, table aligns properly

## Risks / Follow-ups

- The detached ootstrap.py path (no --foreground, no supervisor) is a legacy code path; a follow-up could deprecate it in favor of ctl.sh start for all daemon use cases

## Model Used

Claude Opus 4.6 via Claude Code CLI
