### PR TITLE
feat: add session action menu shortcuts

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2727,6 +2727,7 @@ function _showBatchProjectPicker(){
 function closeSessionActionMenu(){
   if(_sessionActionMenu){
     _sessionActionMenu.remove();
+    document.removeEventListener('keydown', _handleSessionActionMenuKeydown);
     _sessionActionMenu = null;
   }
   if(_sessionActionAnchor){
@@ -2774,10 +2775,15 @@ function _positionSessionActionMenu(anchorEl){
   _sessionActionMenu.style.top=top+'px';
 }
 
-function _buildSessionAction(label, meta, icon, onSelect, extraClass=''){
+function _buildSessionAction(label, meta, icon, onSelect, extraClass='', options=null){
   const opt=document.createElement('button');
   opt.type='button';
   opt.className='ws-opt session-action-opt'+(extraClass?` ${extraClass}`:'');
+  const shortcutKey=options&&options.shortcutKey?String(options.shortcutKey).slice(0,1):'';
+  if(shortcutKey){
+    opt.setAttribute('data-shortcut-key', shortcutKey.toLowerCase());
+    opt.setAttribute('aria-keyshortcuts', shortcutKey.toUpperCase());
+  }
   // Compact context-menu shape (#3223 redesign, Nathan 2026-06-01): show only
   // icon + label, matching VS Code / browser / ChatGPT conversation menus. The
   // descriptive `meta` is preserved as a hover tooltip (title=) so the
@@ -2790,6 +2796,7 @@ function _buildSessionAction(label, meta, icon, onSelect, extraClass=''){
       + `<span class="session-action-copy">`
         + `<span class="ws-opt-name">${esc(label)}</span>`
       + `</span>`
+      + (shortcutKey?`<span class="session-action-shortcut" aria-hidden="true">${esc(shortcutKey.toUpperCase())}</span>`:'')
     + `</span>`;
   opt.onclick=async(e)=>{
     e.preventDefault();
@@ -2797,6 +2804,29 @@ function _buildSessionAction(label, meta, icon, onSelect, extraClass=''){
     await onSelect();
   };
   return opt;
+}
+
+function _isSessionActionShortcutEditableTarget(target){
+  if(!target) return false;
+  const tag=(target.tagName||'').toLowerCase();
+  if(tag==='input'||tag==='textarea'||tag==='select') return true;
+  if(target.isContentEditable) return true;
+  const contentEditable=target.getAttribute&&target.getAttribute('contenteditable');
+  return contentEditable==='' || contentEditable==='true';
+}
+
+function _handleSessionActionMenuKeydown(e){
+  if(!_sessionActionMenu) return;
+  if(!e||!e.key||e.metaKey||e.ctrlKey||e.altKey) return;
+  const contentEditableTarget=e.target&&e.target.isContentEditable;
+  if(contentEditableTarget||_isSessionActionShortcutEditableTarget(e.target)) return;
+  const key=String(e.key).toLowerCase();
+  if(key.length!==1) return;
+  const target=_sessionActionMenu.querySelector('.session-action-opt[data-shortcut-key="'+key+'"]');
+  if(!target||target.disabled) return;
+  e.preventDefault();
+  e.stopPropagation();
+  target.click();
 }
 
 function _sessionMarkdownLabel(session){
@@ -2851,6 +2881,8 @@ function _mountSessionActionMenu(menu, session, anchorEl){
   _sessionActionMenu = menu;
   _sessionActionAnchor = anchorEl;
   _sessionActionSessionId = session.session_id;
+  document.removeEventListener('keydown', _handleSessionActionMenuKeydown);
+  document.addEventListener('keydown', _handleSessionActionMenuKeydown);
   if(anchorEl.classList&&anchorEl.classList.contains('session-actions-trigger')) anchorEl.classList.add('active');
   const row=anchorEl.closest('.session-item');
   if(row) row.classList.add('menu-open');
@@ -2866,7 +2898,9 @@ function _appendSessionCopyLinkAction(menu, session){
     async()=>{
       closeSessionActionMenu();
       await _copySessionLink(session);
-    }
+    },
+    '',
+    {shortcutKey:'C'}
   ));
 }
 
@@ -2885,7 +2919,9 @@ function _appendSessionDuplicateAction(menu, session){
           showToast(t('session_duplicated'));
         }
       }catch(err){showToast(t('session_duplicate_failed')+err.message);}
-    }
+    },
+    '',
+    {shortcutKey:'D'}
   ));
 }
 
@@ -2970,7 +3006,9 @@ function _openSessionActionMenu(session, anchorEl){
         } else if(typeof showToast==='function'){
           showToast(t('session_rename_failed_no_row')||'Could not start rename — row not found.', 3000, 'error');
         }
-      }
+      },
+      '',
+      {shortcutKey:'R'}
     ));
   }
   menu.appendChild(_buildSessionAction(
@@ -2990,7 +3028,8 @@ function _openSessionActionMenu(session, anchorEl){
         await renderSessionList();
       }
     },
-    session.pinned?'is-active':''
+    session.pinned?'is-active':'',
+    {shortcutKey:'P'}
   ));
   menu.appendChild(_buildSessionAction(
     t('session_move_project'),
@@ -2999,7 +3038,9 @@ function _openSessionActionMenu(session, anchorEl){
     async()=>{
       closeSessionActionMenu();
       _showProjectPicker(session, anchorEl);
-    }
+    },
+    '',
+    {shortcutKey:'M'}
   ));
   menu.appendChild(_buildSessionAction(
     session.archived?t('session_restore'):t('session_archive'),
@@ -3008,7 +3049,9 @@ function _openSessionActionMenu(session, anchorEl){
     async()=>{
       closeSessionActionMenu();
       await _archiveSession(session,!session.archived);
-    }
+    },
+    '',
+    {shortcutKey:'A'}
   ));
   if(isExternalSession && !session.archived){
     menu.appendChild(_buildSessionAction(
@@ -3025,7 +3068,9 @@ function _openSessionActionMenu(session, anchorEl){
           void renderSessionList();
           showToast(t('session_hidden'));
         }catch(err){showToast(t('session_archive_failed')+err.message);}
-      }
+      },
+      '',
+      {shortcutKey:'H'}
     ));
   }
   if(!isExternalSession){
@@ -3040,7 +3085,9 @@ function _openSessionActionMenu(session, anchorEl){
         closeSessionActionMenu();
         await cancelSessionStream(session);
         showToast(t('stream_stopped'));
-      }
+      },
+      '',
+      {shortcutKey:'S'}
     ));
   }
   // Title regeneration matches the backend guard (api/routes.py rejects
@@ -3073,7 +3120,9 @@ function _openSessionActionMenu(session, anchorEl){
           setStatus(msg);
           if(typeof showToast==='function') showToast(msg,3000,'error');
         }
-      }
+      },
+      '',
+      {shortcutKey:'G'}
     ));
   }
   if(!isExternalSession){

--- a/static/style.css
+++ b/static/style.css
@@ -1138,7 +1138,9 @@
   .session-action-opt .ws-opt-action{display:flex;flex-direction:row;align-items:center;gap:10px;width:100%;padding:8px 14px;}
   .session-action-opt .ws-opt-icon{color:var(--muted);transition:color .12s,opacity .12s;flex-shrink:0;display:flex;align-items:center;width:16px;}
   .session-action-opt:hover .ws-opt-icon{color:var(--text);opacity:1;}
-  .session-action-copy{display:flex;flex-direction:column;gap:2px;min-width:0;}
+  .session-action-copy{display:flex;flex-direction:column;gap:2px;min-width:0;flex:1;}
+  .session-action-shortcut{margin-left:auto;min-width:18px;height:18px;padding:0 5px;border:1px solid var(--border2);border-radius:5px;background:var(--code-bg);color:var(--muted);font-size:10px;font-weight:700;line-height:16px;text-align:center;letter-spacing:.02em;box-shadow:inset 0 -1px 0 rgba(255,255,255,.04);}
+  .session-action-opt:hover .session-action-shortcut{color:var(--text);border-color:var(--accent-bg-strong);}
   .session-action-meta{font-size:11px;color:var(--muted);line-height:1.3;white-space:normal;opacity:.72;}
   .session-action-opt.is-active{background:var(--accent-bg);}
   .session-action-opt.is-disabled{opacity:.55;cursor:not-allowed;}

--- a/tests/test_session_action_shortcuts.py
+++ b/tests/test_session_action_shortcuts.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _function_block(name: str) -> str:
+    marker = f"function {name}"
+    start = SESSIONS_JS.find(marker)
+    assert start >= 0, f"{name} not found"
+    brace = SESSIONS_JS.find("{", start)
+    assert brace > start, f"{name} body not found"
+    depth = 1
+    i = brace + 1
+    while depth and i < len(SESSIONS_JS):
+        if SESSIONS_JS[i] == "{":
+            depth += 1
+        elif SESSIONS_JS[i] == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{name} body did not close"
+    return SESSIONS_JS[start:i]
+
+
+def test_session_action_builder_exposes_visible_shortcut_badges():
+    builder = _function_block("_buildSessionAction")
+    assert "shortcutKey" in builder
+    assert "data-shortcut-key" in builder
+    assert "aria-keyshortcuts" in builder
+    assert "session-action-shortcut" in builder
+    assert "esc(shortcutKey.toUpperCase())" in builder
+
+
+def test_common_session_actions_define_non_destructive_shortcuts():
+    assert "shortcutKey:'C'" in SESSIONS_JS
+    assert "shortcutKey:'R'" in SESSIONS_JS
+    assert "shortcutKey:'P'" in SESSIONS_JS
+    assert "shortcutKey:'M'" in SESSIONS_JS
+    assert "shortcutKey:'A'" in SESSIONS_JS
+    assert "shortcutKey:'D'" in SESSIONS_JS
+    assert "shortcutKey:'G'" in SESSIONS_JS
+    assert "shortcutKey:'H'" in SESSIONS_JS
+    assert "shortcutKey:'X'" not in SESSIONS_JS
+
+
+def test_open_action_menu_registers_menu_scoped_keydown_handler():
+    assert "function _handleSessionActionMenuKeydown" in SESSIONS_JS
+    handler = _function_block("_handleSessionActionMenuKeydown")
+    assert "_sessionActionMenu" in handler
+    assert "metaKey" in handler and "ctrlKey" in handler and "altKey" in handler
+    assert "contentEditable" in handler
+    assert ".session-action-opt[data-shortcut-key=\"" in handler
+    assert "target.click()" in handler
+    assert "document.addEventListener('keydown', _handleSessionActionMenuKeydown);" in SESSIONS_JS
+    assert "document.removeEventListener('keydown', _handleSessionActionMenuKeydown);" in SESSIONS_JS
+
+
+def test_shortcut_badges_are_styled_as_keycaps():
+    assert ".session-action-shortcut" in STYLE_CSS
+    assert "font-size:10px" in STYLE_CSS
+    assert "border:1px solid var(--border2)" in STYLE_CSS


### PR DESCRIPTION
## Summary
- Adds visible keycap badges to the conversation three-dot action menu.
- Adds menu-scoped keyboard shortcuts for common non-destructive actions: C copy link, R rename, P pin/unpin, M move, A archive/restore, D duplicate, G regenerate title, H hide external, S stop response.
- Keeps destructive Delete/worktree removal without shortcuts.
- Ignores shortcuts while typing in inputs, textareas, selects, or contenteditable elements, and ignores modified key combos.

## Test Plan
- [x] `/Users/ops/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_session_action_shortcuts.py -q`
- [x] `/Users/ops/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_session_action_shortcuts.py tests/test_session_copy_link_action.py tests/test_session_duplicate_edit.py tests/test_session_title_regenerate_controls.py tests/test_session_touch_actions.py tests/test_session_batch_select.py tests/test_inflight_purge_missing_sessions.py tests/test_window_function_collision.py -q`
- [x] `node --check static/sessions.js`