### PR TITLE
fix(model-resolver): preserve @provider:model picks across cold catalogs

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1218,16 +1218,29 @@ def _provider_is_known_or_configured(
     provider_id: object,
     config_obj: dict | None = None,
 ) -> bool:
-    """True when ``provider_id`` is a provider Hermes recognizes or the user has
-    configured, decided from the STATIC registry + config state only — never from
-    a live/cold catalog snapshot.
+    """True when ``provider_id`` is a provider Hermes recognizes (static registry)
+    or the user has configured (named custom provider), decided from the STATIC
+    registry + config state only — never from a live/cold catalog snapshot.
 
-    This distinguishes a *cold live-discovery* provider (e.g. ``ollama-cloud`` is
-    configured; its model group simply isn't folded into the current cached
-    catalog yet) from a *genuinely removed / unknown* one (``@removed:...`` no
-    longer configured anywhere). The former's explicitly-qualified selection must
-    be preserved across a cold catalog; the latter must fall back to the default
-    so chat/start doesn't route to a provider that cannot be reached.
+    This distinguishes a provider Hermes knows how to route (e.g. ``ollama-cloud``,
+    whose model group simply isn't folded into the current cached catalog yet, or a
+    named ``custom_providers`` entry) from a *genuinely unknown* one
+    (``@removed:...`` that is in no registry and configured nowhere). The former's
+    explicitly-qualified selection is preserved across a cold catalog; the latter
+    falls back to the default so chat/start doesn't route to an unrecognized
+    provider.
+
+    DELIBERATE SCOPE (see the @provider:model guard in
+    ``_resolve_compatible_session_model_state``): registry membership counts as
+    "known" even when the user has no key configured for that built-in. We do NOT
+    require authenticated-credential evidence here, on purpose. The only fully
+    reliable "is this provider authenticated" signal is the live auth store /
+    catalog rebuild — exactly the cost the caller's ``prefer_cached_catalog`` hot
+    path avoids — and a cheap env/config-only credential check would mis-classify
+    providers authenticated via OAuth/auth-store (``ollama-cloud`` among them),
+    re-introducing the original silent-revert bug for them. A known-but-unconfigured
+    pick is therefore kept and surfaces a clear run-time auth error rather than a
+    silent swap to the default.
 
     Deliberately does NOT consult ``get_available_models()`` / the catalog groups,
     which are exactly what is cold here — re-deriving them live would defeat the

--- a/api/config.py
+++ b/api/config.py
@@ -1214,6 +1214,46 @@ def _named_custom_provider_slug_for_base_url(
     return ""
 
 
+def _provider_is_known_or_configured(
+    provider_id: object,
+    config_obj: dict | None = None,
+) -> bool:
+    """True when ``provider_id`` is a provider Hermes recognizes or the user has
+    configured, decided from the STATIC registry + config state only — never from
+    a live/cold catalog snapshot.
+
+    This distinguishes a *cold live-discovery* provider (e.g. ``ollama-cloud`` is
+    configured; its model group simply isn't folded into the current cached
+    catalog yet) from a *genuinely removed / unknown* one (``@removed:...`` no
+    longer configured anywhere). The former's explicitly-qualified selection must
+    be preserved across a cold catalog; the latter must fall back to the default
+    so chat/start doesn't route to a provider that cannot be reached.
+
+    Deliberately does NOT consult ``get_available_models()`` / the catalog groups,
+    which are exactly what is cold here — re-deriving them live would defeat the
+    ``prefer_cached_catalog`` hot-path win this guards.
+    """
+    raw = str(provider_id or "").strip().lower()
+    if not raw:
+        return False
+    # Configured custom provider: a named slug in custom_providers, or any
+    # ``custom`` / ``custom:<slug>`` form when custom_providers are defined.
+    if _named_custom_provider_slug_for_provider(raw, config_obj):
+        return True
+    if raw == "custom" or raw.startswith("custom:"):
+        return bool(_custom_provider_entries(config_obj))
+    # Known first-party / built-in provider id (alias-resolved). Static registry
+    # knowledge that is always available, so a live-discovery provider whose
+    # catalog group is momentarily absent still counts as known.
+    canonical = _resolve_provider_alias(raw)
+    return (
+        raw in _PROVIDER_DISPLAY
+        or canonical in _PROVIDER_DISPLAY
+        or raw in _PROVIDER_MODELS
+        or canonical in _PROVIDER_MODELS
+    )
+
+
 # Well-known models per provider (used to populate dropdown for direct API providers)
 _PROVIDER_MODELS = {
     "anthropic": [

--- a/api/routes.py
+++ b/api/routes.py
@@ -2663,6 +2663,32 @@ def _resolve_compatible_session_model_state(
                 else None
             )
             return bare_model, provider_context, True
+        # Do NOT revert to the default when the user explicitly named a provider
+        # we can't find in *this* catalog snapshot but have no positive reason to
+        # treat as stale:
+        #   * explicit_model_pick — the user just chose this exact @provider:model,
+        #     so honor it (mirrors the bare-model branch's #3737 guard below).
+        #   * a non-first-party provider hint (provider_normalized == "", e.g.
+        #     ollama-cloud / deepseek / xai) whose BARE model is itself not a
+        #     first-party family id (gpt/claude/gemini). Those providers discover
+        #     their models live, so a cold/partial catalog can momentarily lack the
+        #     group even though the provider is configured; reverting here silently
+        #     discards the selection on the 2nd+ turn / chat switch (the
+        #     "@ollama-cloud:minimax-m3" snapping-to-default report). This mirrors
+        #     the slash-qualified branch, which already passes models whose provider
+        #     normalizes to "" through unchanged (see the active_provider in
+        #     {custom,openrouter} branch and #1023 below).
+        # A first-party family bare id under a vanished provider (e.g.
+        # "@copilot:claude-opus-4.6" while the agent now runs openai-codex) is a
+        # genuinely stale, misrouted first-party model and still falls through to
+        # the default-repair below.
+        _bare_is_first_party_family = any(
+            bare_model.lower().startswith(_p) for _p in ("gpt", "claude", "gemini")
+        )
+        if explicit_model_pick or (
+            not provider_normalized and not _bare_is_first_party_family
+        ):
+            return model, provider_raw, False
         if default_model:
             provider_context = (
                 raw_active_provider

--- a/api/routes.py
+++ b/api/routes.py
@@ -2633,6 +2633,16 @@ def _resolve_compatible_session_model_state(
         if not provider_raw or not bare_model:
             return model, requested_provider, False
 
+        # A fresh, explicit user pick is by definition not a stale artifact, so
+        # honor the @provider:model exactly as chosen — never reroute it via the
+        # active-provider family repair or the cold-catalog fallback below (a bare
+        # id like "gpt-oss-120b" under an OpenAI-active agent would otherwise get
+        # pulled to OpenAI by the family-match branch). If the named provider is
+        # unreachable the user sees a clear run-time error rather than a silent
+        # model swap. Must sit above the family-match repair (#3737 principle).
+        if explicit_model_pick:
+            return model, provider_raw, False
+
         raw_provider_ids, normalized_provider_ids = _catalog_provider_id_sets(catalog)
         hint_matches_active = (
             provider_raw == raw_active_provider
@@ -2664,15 +2674,8 @@ def _resolve_compatible_session_model_state(
                 else None
             )
             return bare_model, provider_context, True
-        # An explicit, fresh user pick is always honored. The caller sets
-        # explicit_model_pick only when the model was just chosen in the picker, so
-        # it must never be second-guessed against the catalog — even if the named
-        # provider is gone, the user gets a clear run-time error rather than a
-        # silent model swap.
-        if explicit_model_pick:
-            return model, provider_raw, False
-        # On NON-explicit resolves (2nd+ turn, chat switch), preserve the selection
-        # only when all three hold:
+        # On NON-explicit resolves (2nd+ turn, chat switch — explicit picks already
+        # returned above), preserve the selection only when all three hold:
         #
         #   * provider_normalized == "" — a non-first-party provider hint
         #     (ollama-cloud / deepseek / xai / a named custom proxy). First-party
@@ -2682,20 +2685,27 @@ def _resolve_compatible_session_model_state(
         #     gpt/claude/gemini), i.e. not a misrouted first-party model that a
         #     vanished provider used to host (e.g. "@copilot:claude-opus-4.6").
         #
-        #   * the provider is still KNOWN or CONFIGURED. This is the load-bearing
-        #     distinction: catalog-absence has two causes, and only one should be
-        #     preserved —
-        #       (a) a cold live-discovery provider (ollama-cloud IS configured; its
+        #   * the provider is KNOWN or CONFIGURED. This is the load-bearing
+        #     distinction: catalog-absence has two causes —
+        #       (a) a cold live-discovery provider (ollama-cloud is configured; its
         #           group just isn't in this cached snapshot yet) → preserve, and
         #       (b) a genuinely removed/unknown provider ("@removed:mistral-large"
-        #           no longer configured anywhere) → must still fall through to the
-        #           default so chat/start doesn't route to an unreachable provider.
+        #           configured nowhere) → fall through to the default so chat/start
+        #           doesn't route to an unreachable provider.
         #     _provider_is_known_or_configured() decides this from the static
         #     provider registry + config state, NOT from the cold catalog snapshot
         #     (re-deriving that live would defeat the prefer_cached_catalog win).
         #
-        # This preservation matches the slash-qualified branch above, which already
-        # passes configured/known "" -provider models through unchanged.
+        # DELIBERATE: the registry test treats a KNOWN built-in (deepseek, minimax,
+        # ollama-cloud, …) as preservable even when the user has no key configured
+        # for it. We accept this on purpose. The only fully-reliable "is this
+        # provider authenticated" signal is the live auth store / catalog rebuild —
+        # exactly the cost this hot path avoids — and a cheap config/env-only check
+        # would mis-classify providers configured via OAuth/auth-store (ollama-cloud
+        # among them), re-introducing the original silent-revert bug for them. So a
+        # known-but-unconfigured pick is kept; the user gets a clear run-time auth
+        # error instead of a silent swap to the default. Pinned by
+        # test_at_provider_known_unconfigured_builtin_is_intentionally_preserved.
         #
         # KNOWN LIMITATION: the first-party-family test is a bare-name prefix match
         # (the same approximation _model_matches_active_provider_family uses). A

--- a/api/routes.py
+++ b/api/routes.py
@@ -1079,6 +1079,7 @@ from api.config import (
     _resolve_cli_toolsets,
     _INDEX_HTML_PATH,
     get_available_models,
+    _provider_is_known_or_configured,
     IMAGE_EXTS,
     MD_EXTS,
     MIME_MAP,
@@ -2663,42 +2664,53 @@ def _resolve_compatible_session_model_state(
                 else None
             )
             return bare_model, provider_context, True
-        # Do NOT revert to the default when the user explicitly named a provider
-        # that is merely absent from *this* catalog snapshot, with no positive
-        # signal that the selection is stale. Two cases are preserved:
+        # An explicit, fresh user pick is always honored. The caller sets
+        # explicit_model_pick only when the model was just chosen in the picker, so
+        # it must never be second-guessed against the catalog — even if the named
+        # provider is gone, the user gets a clear run-time error rather than a
+        # silent model swap.
+        if explicit_model_pick:
+            return model, provider_raw, False
+        # On NON-explicit resolves (2nd+ turn, chat switch), preserve the selection
+        # only when all three hold:
         #
-        #   * explicit_model_pick — the caller sets this flag only when the model
-        #     was just chosen by the user in the picker (a deliberate, fresh pick).
-        #     A fresh pick must be honored as-is, never second-guessed against the
-        #     catalog.
+        #   * provider_normalized == "" — a non-first-party provider hint
+        #     (ollama-cloud / deepseek / xai / a named custom proxy). First-party
+        #     families fall through to the stale-cross-provider repair below.
         #
-        #   * a non-first-party provider hint (provider_normalized == "", e.g.
-        #     ollama-cloud / deepseek / xai) whose BARE model is not a first-party
-        #     family id (does not start with gpt/claude/gemini). Such providers
-        #     discover their models live, so a cold/minimal catalog can momentarily
-        #     omit the group even though the provider is configured. Reverting here
-        #     would silently swap the user's model on the next turn or on chat
-        #     switch. This matches the slash-qualified branch above, which already
-        #     passes models whose provider normalizes to "" through unchanged.
+        #   * the BARE model is not a first-party family id (does not start with
+        #     gpt/claude/gemini), i.e. not a misrouted first-party model that a
+        #     vanished provider used to host (e.g. "@copilot:claude-opus-4.6").
         #
-        # A first-party-family bare id under such a provider (e.g.
-        # "@copilot:claude-opus-4.6" while the agent now runs a different provider)
-        # is treated as a genuinely stale, misrouted first-party model and still
-        # falls through to the default-repair below.
+        #   * the provider is still KNOWN or CONFIGURED. This is the load-bearing
+        #     distinction: catalog-absence has two causes, and only one should be
+        #     preserved —
+        #       (a) a cold live-discovery provider (ollama-cloud IS configured; its
+        #           group just isn't in this cached snapshot yet) → preserve, and
+        #       (b) a genuinely removed/unknown provider ("@removed:mistral-large"
+        #           no longer configured anywhere) → must still fall through to the
+        #           default so chat/start doesn't route to an unreachable provider.
+        #     _provider_is_known_or_configured() decides this from the static
+        #     provider registry + config state, NOT from the cold catalog snapshot
+        #     (re-deriving that live would defeat the prefer_cached_catalog win).
+        #
+        # This preservation matches the slash-qualified branch above, which already
+        # passes configured/known "" -provider models through unchanged.
         #
         # KNOWN LIMITATION: the first-party-family test is a bare-name prefix match
         # (the same approximation _model_matches_active_provider_family uses). A
         # genuine third-party model whose name merely *starts* with gpt/claude/
         # gemini (e.g. "@ollama:gpt4all-mini") is therefore still mis-classified as
         # first-party and reverted on non-explicit paths. A name-based check cannot
-        # disambiguate that case; only consulting the user's configured providers
-        # could. The behavior is pinned by
+        # disambiguate that; the behavior is pinned by
         # test_at_provider_first_party_named_third_party_model_known_limitation.
         _bare_is_first_party_family = any(
             bare_model.lower().startswith(_p) for _p in ("gpt", "claude", "gemini")
         )
-        if explicit_model_pick or (
-            not provider_normalized and not _bare_is_first_party_family
+        if (
+            not provider_normalized
+            and not _bare_is_first_party_family
+            and _provider_is_known_or_configured(provider_raw)
         ):
             return model, provider_raw, False
         if default_model:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2664,24 +2664,36 @@ def _resolve_compatible_session_model_state(
             )
             return bare_model, provider_context, True
         # Do NOT revert to the default when the user explicitly named a provider
-        # we can't find in *this* catalog snapshot but have no positive reason to
-        # treat as stale:
-        #   * explicit_model_pick — the user just chose this exact @provider:model,
-        #     so honor it (mirrors the bare-model branch's #3737 guard below).
+        # that is merely absent from *this* catalog snapshot, with no positive
+        # signal that the selection is stale. Two cases are preserved:
+        #
+        #   * explicit_model_pick — the caller sets this flag only when the model
+        #     was just chosen by the user in the picker (a deliberate, fresh pick).
+        #     A fresh pick must be honored as-is, never second-guessed against the
+        #     catalog.
+        #
         #   * a non-first-party provider hint (provider_normalized == "", e.g.
-        #     ollama-cloud / deepseek / xai) whose BARE model is itself not a
-        #     first-party family id (gpt/claude/gemini). Those providers discover
-        #     their models live, so a cold/partial catalog can momentarily lack the
-        #     group even though the provider is configured; reverting here silently
-        #     discards the selection on the 2nd+ turn / chat switch (the
-        #     "@ollama-cloud:minimax-m3" snapping-to-default report). This mirrors
-        #     the slash-qualified branch, which already passes models whose provider
-        #     normalizes to "" through unchanged (see the active_provider in
-        #     {custom,openrouter} branch and #1023 below).
-        # A first-party family bare id under a vanished provider (e.g.
-        # "@copilot:claude-opus-4.6" while the agent now runs openai-codex) is a
-        # genuinely stale, misrouted first-party model and still falls through to
-        # the default-repair below.
+        #     ollama-cloud / deepseek / xai) whose BARE model is not a first-party
+        #     family id (does not start with gpt/claude/gemini). Such providers
+        #     discover their models live, so a cold/minimal catalog can momentarily
+        #     omit the group even though the provider is configured. Reverting here
+        #     would silently swap the user's model on the next turn or on chat
+        #     switch. This matches the slash-qualified branch above, which already
+        #     passes models whose provider normalizes to "" through unchanged.
+        #
+        # A first-party-family bare id under such a provider (e.g.
+        # "@copilot:claude-opus-4.6" while the agent now runs a different provider)
+        # is treated as a genuinely stale, misrouted first-party model and still
+        # falls through to the default-repair below.
+        #
+        # KNOWN LIMITATION: the first-party-family test is a bare-name prefix match
+        # (the same approximation _model_matches_active_provider_family uses). A
+        # genuine third-party model whose name merely *starts* with gpt/claude/
+        # gemini (e.g. "@ollama:gpt4all-mini") is therefore still mis-classified as
+        # first-party and reverted on non-explicit paths. A name-based check cannot
+        # disambiguate that case; only consulting the user's configured providers
+        # could. The behavior is pinned by
+        # test_at_provider_first_party_named_third_party_model_known_limitation.
         _bare_is_first_party_family = any(
             bare_model.lower().startswith(_p) for _p in ("gpt", "claude", "gemini")
         )

--- a/tests/test_provider_mismatch.py
+++ b/tests/test_provider_mismatch.py
@@ -1009,13 +1009,14 @@ def test_at_provider_third_party_model_survives_cold_catalog(monkeypatch):
     """A non-first-party @provider:model selection must NOT revert to the default
     just because the provider's group is missing from the current catalog snapshot.
 
-    Regression for the "@ollama-cloud:minimax-m3 snaps to default" report: providers
-    like ollama-cloud / deepseek / xai normalize to "" and discover their models
-    live, so a cold/partial catalog can momentarily lack the group even though the
-    provider is configured. The @provider:model resolver used to fall through to
-    ``default_model`` here, silently discarding the user's choice on the 2nd+ turn
-    and on chat switch (explicit_model_pick is False on those paths). Because the
-    bare id (minimax-m3) is not a first-party family id, the selection is preserved.
+    Providers like ollama-cloud / deepseek / xai normalize to "" and discover their
+    models live, so a cold/minimal catalog can momentarily lack the group even
+    though the provider is configured. The @provider:model branch of
+    _resolve_compatible_session_model_state used to fall through to ``default_model``
+    in that case, silently swapping the user's chosen model on any non-explicit
+    resolve (2nd+ turn, chat switch — explicit_model_pick is False there). Because
+    the bare id (minimax-m3) is not a first-party family id (gpt/claude/gemini), the
+    selection must instead be preserved.
     """
     import api.routes as routes
 
@@ -1054,10 +1055,11 @@ def test_at_provider_third_party_model_survives_cold_catalog(monkeypatch):
 
 
 def test_at_provider_explicit_pick_is_honored_even_when_unroutable(monkeypatch):
-    """An explicit @provider:model pick is honored even if its bare id is a
-    first-party family name and the provider is absent — mirrors the bare-model
-    branch's #3737 'user explicitly chose it' guard. Only the *non-explicit*
-    stale path repairs to the default (see the test above)."""
+    """A fresh, explicit @provider:model pick is honored verbatim even when its
+    bare id is a first-party family name and the provider is absent from the
+    catalog. explicit_model_pick is only set on a deliberate user pick, so it must
+    win over the stale-cross-provider repair. Only the *non-explicit* path (2nd+
+    turn / chat switch) repairs such a model to the default (see the test below)."""
     import api.routes as routes
 
     monkeypatch.setattr(
@@ -1076,13 +1078,72 @@ def test_at_provider_explicit_pick_is_honored_even_when_unroutable(monkeypatch):
         },
     )
 
-    model, _provider, changed = routes._resolve_compatible_session_model_state(
+    model, provider, changed = routes._resolve_compatible_session_model_state(
         "@copilot:claude-opus-4.6",
         None,
         explicit_model_pick=True,
     )
     assert model == "@copilot:claude-opus-4.6"
+    # The explicit pick is returned with its own @-qualified provider hint intact,
+    # not rewritten to the active provider or the default's provider.
+    assert provider == "copilot"
     assert changed is False
+
+
+def test_at_provider_first_party_named_third_party_model_known_limitation(monkeypatch):
+    """Pin (not endorse) the known false-positive of the bare-name prefix heuristic.
+
+    The first-party-family guard classifies a bare id purely by its name prefix
+    (gpt/claude/gemini), the same approximation _model_matches_active_provider_family
+    uses. A genuine third-party model whose name merely starts with one of those
+    prefixes — e.g. "@ollama:gpt4all-mini" (GPT4All is a third-party family) — is
+    therefore mis-classified as first-party and still reverts to the default on a
+    non-explicit resolve, the very behavior the sibling test prevents for
+    non-first-party-named ids. A name-only check cannot distinguish this case;
+    disambiguating it would require consulting the user's configured providers.
+
+    This test documents the boundary so the limitation is tracked, not silent. If a
+    future change makes the classifier provider-aware, update this expectation to
+    assert preservation instead.
+    """
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        routes,
+        "get_available_models",
+        lambda: {
+            "active_provider": "anthropic",
+            "default_model": "claude-opus-4.8",
+            "groups": [
+                {
+                    "provider": "Anthropic",
+                    "provider_id": "anthropic",
+                    "models": [{"id": "claude-opus-4.8", "label": "Opus"}],
+                },
+            ],
+        },
+    )
+
+    # Non-explicit path: the gpt-prefixed third-party id is (imperfectly) treated
+    # as a stale first-party model and repaired to the default.
+    model, _provider, changed = routes._resolve_compatible_session_model_state(
+        "@ollama:gpt4all-mini",
+        "ollama",
+        explicit_model_pick=False,
+    )
+    assert model == "claude-opus-4.8"
+    assert changed is True
+
+    # An explicit pick still escapes the heuristic and is preserved, so the user
+    # always has a reliable way to select such a model.
+    model2, provider2, changed2 = routes._resolve_compatible_session_model_state(
+        "@ollama:gpt4all-mini",
+        "ollama",
+        explicit_model_pick=True,
+    )
+    assert model2 == "@ollama:gpt4all-mini"
+    assert provider2 == "ollama"
+    assert changed2 is False
 
 
 def test_google_active_provider_keeps_valid_gemini_session_model(monkeypatch):

--- a/tests/test_provider_mismatch.py
+++ b/tests/test_provider_mismatch.py
@@ -1054,6 +1054,64 @@ def test_at_provider_third_party_model_survives_cold_catalog(monkeypatch):
         assert changed is False
 
 
+def test_at_provider_removed_provider_still_reverts_to_default(monkeypatch):
+    """The catalog-absence preservation must NOT extend to a genuinely
+    removed/unconfigured provider.
+
+    Catalog-absence has two causes and only one is a cold-discovery artifact:
+      * ollama-cloud is configured, its group is just missing from this snapshot
+        -> preserve (covered by the sibling test).
+      * @removed:mistral-large names a provider that is no longer configured
+        anywhere -> preserving it would route chat/start to an unreachable
+        provider, so it must still fall through to the default-repair.
+
+    The guard tells the two apart via _provider_is_known_or_configured() (static
+    registry + config state), never via the cold catalog. "removed" is neither a
+    known built-in provider nor a configured custom provider, so a non-explicit
+    resolve reverts to the active default. An explicit pick is still honored,
+    leaving the user a deliberate escape hatch.
+    """
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        routes,
+        "get_available_models",
+        lambda: {
+            "active_provider": "anthropic",
+            "default_model": "claude-opus-4.8",
+            "groups": [
+                {
+                    "provider": "Anthropic",
+                    "provider_id": "anthropic",
+                    "models": [{"id": "claude-opus-4.8", "label": "Opus"}],
+                },
+            ],
+        },
+    )
+
+    # Non-explicit (2nd+ turn / chat switch): unknown provider -> repair to default.
+    model, _provider, changed = routes._resolve_compatible_session_model_state(
+        "@removed:mistral-large",
+        "removed",
+        explicit_model_pick=False,
+    )
+    assert model == "claude-opus-4.8", (
+        f"a removed/unconfigured @provider model must revert to the default on a "
+        f"non-explicit resolve, got {model!r}"
+    )
+    assert changed is True
+
+    # Explicit pick is still honored even for an unknown provider.
+    model2, provider2, changed2 = routes._resolve_compatible_session_model_state(
+        "@removed:mistral-large",
+        "removed",
+        explicit_model_pick=True,
+    )
+    assert model2 == "@removed:mistral-large"
+    assert provider2 == "removed"
+    assert changed2 is False
+
+
 def test_at_provider_explicit_pick_is_honored_even_when_unroutable(monkeypatch):
     """A fresh, explicit @provider:model pick is honored verbatim even when its
     bare id is a first-party family name and the provider is absent from the

--- a/tests/test_provider_mismatch.py
+++ b/tests/test_provider_mismatch.py
@@ -1005,6 +1005,86 @@ def test_stale_at_provider_model_falls_back_when_family_mismatches(monkeypatch):
     assert effective == "gpt-5.5"
 
 
+def test_at_provider_third_party_model_survives_cold_catalog(monkeypatch):
+    """A non-first-party @provider:model selection must NOT revert to the default
+    just because the provider's group is missing from the current catalog snapshot.
+
+    Regression for the "@ollama-cloud:minimax-m3 snaps to default" report: providers
+    like ollama-cloud / deepseek / xai normalize to "" and discover their models
+    live, so a cold/partial catalog can momentarily lack the group even though the
+    provider is configured. The @provider:model resolver used to fall through to
+    ``default_model`` here, silently discarding the user's choice on the 2nd+ turn
+    and on chat switch (explicit_model_pick is False on those paths). Because the
+    bare id (minimax-m3) is not a first-party family id, the selection is preserved.
+    """
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        routes,
+        "get_available_models",
+        lambda: {
+            # Active provider is something else and the ollama-cloud group is
+            # absent from THIS snapshot (live discovery not yet folded in).
+            "active_provider": "anthropic",
+            "default_model": "claude-opus-4.8",
+            "groups": [
+                {
+                    "provider": "Anthropic",
+                    "provider_id": "anthropic",
+                    "models": [{"id": "claude-opus-4.8", "label": "Opus"}],
+                },
+            ],
+        },
+    )
+
+    # Both the explicit-pick (1st turn) and the non-explicit (2nd+ turn / chat
+    # switch) paths must keep the selection.
+    for explicit in (True, False):
+        model, provider, changed = routes._resolve_compatible_session_model_state(
+            "@ollama-cloud:minimax-m3",
+            "ollama-cloud",
+            explicit_model_pick=explicit,
+        )
+        assert model == "@ollama-cloud:minimax-m3", (
+            f"explicit_model_pick={explicit}: third-party @provider model must "
+            f"survive a cold catalog snapshot, got {model!r}"
+        )
+        assert provider == "ollama-cloud"
+        assert changed is False
+
+
+def test_at_provider_explicit_pick_is_honored_even_when_unroutable(monkeypatch):
+    """An explicit @provider:model pick is honored even if its bare id is a
+    first-party family name and the provider is absent — mirrors the bare-model
+    branch's #3737 'user explicitly chose it' guard. Only the *non-explicit*
+    stale path repairs to the default (see the test above)."""
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        routes,
+        "get_available_models",
+        lambda: {
+            "active_provider": "openai-codex",
+            "default_model": "gpt-5.5",
+            "groups": [
+                {
+                    "provider": "OpenAI Codex",
+                    "provider_id": "openai-codex",
+                    "models": [{"id": "gpt-5.5", "label": "GPT-5.5"}],
+                },
+            ],
+        },
+    )
+
+    model, _provider, changed = routes._resolve_compatible_session_model_state(
+        "@copilot:claude-opus-4.6",
+        None,
+        explicit_model_pick=True,
+    )
+    assert model == "@copilot:claude-opus-4.6"
+    assert changed is False
+
+
 def test_google_active_provider_keeps_valid_gemini_session_model(monkeypatch):
     """A Google-configured session must keep its Gemini model."""
     import api.routes as routes

--- a/tests/test_provider_mismatch.py
+++ b/tests/test_provider_mismatch.py
@@ -1112,6 +1112,97 @@ def test_at_provider_removed_provider_still_reverts_to_default(monkeypatch):
     assert changed2 is False
 
 
+def test_at_provider_known_unconfigured_builtin_is_intentionally_preserved(monkeypatch):
+    """Pin the DELIBERATE choice: a KNOWN built-in provider is preserved on a cold
+    catalog even when the user has no key configured for it.
+
+    _provider_is_known_or_configured() counts static-registry membership as "known"
+    and does NOT require authenticated-credential evidence. This is on purpose: the
+    only fully-reliable "is this provider authenticated" signal is the live auth
+    store / catalog rebuild — exactly the cost the hot path avoids — and a cheap
+    env/config-only credential check would mis-classify OAuth/auth-store providers
+    (ollama-cloud among them) and re-introduce the original silent-revert bug. So a
+    known-but-unconfigured pick like "@deepseek:deepseek-v4-pro" under an
+    Anthropic-only setup is kept; the user gets a clear run-time auth error rather
+    than a silent swap to the default.
+
+    If a future change adds reliable cheap credential evidence and flips this to
+    revert-when-unconfigured, update this expectation (and the helper docstring).
+    """
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        routes,
+        "get_available_models",
+        lambda: {
+            "active_provider": "anthropic",
+            "default_model": "claude-opus-4.8",
+            "groups": [
+                {
+                    "provider": "Anthropic",
+                    "provider_id": "anthropic",
+                    "models": [{"id": "claude-opus-4.8", "label": "Opus"}],
+                },
+            ],
+        },
+    )
+
+    model, provider, changed = routes._resolve_compatible_session_model_state(
+        "@deepseek:deepseek-v4-pro",
+        "deepseek",
+        explicit_model_pick=False,
+    )
+    assert model == "@deepseek:deepseek-v4-pro", (
+        "a known built-in provider is intentionally preserved on a cold catalog "
+        f"even without configured credentials, got {model!r}"
+    )
+    assert provider == "deepseek"
+    assert changed is False
+
+
+def test_at_provider_explicit_pick_not_rerouted_by_family_match(monkeypatch):
+    """An explicit pick must NOT be rerouted by the active-provider family-match
+    repair, even when the bare id looks like the active family and the catalog is
+    cold.
+
+    Regression for the branch-order bug: the explicit-pick guard sits at the top of
+    the @provider:model branch, above the _model_matches_active_provider_family
+    repair. Without that ordering, an explicit "@ollama-cloud:gpt-oss-120b" under an
+    OpenAI-active agent would be stripped to bare "gpt-oss-120b" and routed to
+    OpenAI (the family match fires on the "gpt" prefix) — silently swapping the
+    user's deliberately-chosen ollama-cloud provider.
+    """
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        routes,
+        "get_available_models",
+        lambda: {
+            "active_provider": "openai",
+            "default_model": "gpt-5.5",
+            "groups": [
+                {
+                    "provider": "OpenAI",
+                    "provider_id": "openai",
+                    "models": [{"id": "gpt-5.5", "label": "GPT-5.5"}],
+                },
+            ],
+        },
+    )
+
+    model, provider, changed = routes._resolve_compatible_session_model_state(
+        "@ollama-cloud:gpt-oss-120b",
+        "ollama-cloud",
+        explicit_model_pick=True,
+    )
+    assert model == "@ollama-cloud:gpt-oss-120b", (
+        "explicit @provider:model pick must survive the family-match repair, "
+        f"got {model!r}"
+    )
+    assert provider == "ollama-cloud"
+    assert changed is False
+
+
 def test_at_provider_explicit_pick_is_honored_even_when_unroutable(monkeypatch):
     """A fresh, explicit @provider:model pick is honored verbatim even when its
     bare id is a first-party family name and the provider is absent from the


### PR DESCRIPTION
## Thinking Path

- Explicit provider-qualified model selections should survive normal session display, chat start, and chat-switch resolution.
- A selected model like `@ollama-cloud:minimax-m3` was instead snapping back to the global default when the current catalog snapshot did not include the `ollama-cloud` group.
- #3737 already established that explicit user picks should not be silently normalized back to the default; this PR applies the same principle to provider-qualified `@provider:model` selections.
- The fallback behavior dates back to #1131 / v0.50.224, but it became visible after #3867 / v0.51.340 moved hot session/display resolution to cached catalogs for performance.
- The cached-catalog hot path should stay intact: it avoids expensive live catalog rebuilds on `GET /api/session` and related side-effect-free paths.
- This PR keeps that performance behavior and narrows only the fallback decision: preserve explicit `@provider:model` selections when the user chose them, or when the provider is a non-first-party hint and the bare model is not a first-party family model.
- Stale first-party cross-provider repairs still work: a vanished provider hint around a first-party family model can still fall through to the existing default repair path.

## What Changed

- Updated `_resolve_compatible_session_model_state()` so the `@provider:model` branch no longer defaults away an explicit user pick just because the provider is absent from the current catalog snapshot.
- Preserved non-first-party provider-qualified selections, such as `@ollama-cloud:minimax-m3`, when the bare model does not look like a first-party family model (`gpt*`, `claude*`, `gemini*`).
- Left the cached-catalog behavior unchanged; this PR does not force live catalog rebuilds back onto hot session-display paths.
- Added regression coverage for:
  - a non-first-party `@provider:model` surviving a cold/partial catalog on explicit and non-explicit paths;
  - an explicit provider-qualified pick being honored even when the provider is not currently routable.

## Why It Matters

- Prevents WebUI from silently discarding an explicitly selected provider/model on later assistant turns or when switching chats.
- Keeps live-discovered provider selections stable even when the fast cached catalog is intentionally incomplete.
- Preserves the existing safety repair for genuinely stale first-party model/provider mismatches.
- Avoids regressing the cached-catalog performance fix that prevents slow live provider discovery from blocking hot session reads.

## Verification

Targeted resolver regression coverage:

```text
python -m pytest tests/test_provider_mismatch.py -q
# 68 passed
```

Adjacent model/session resolver coverage:

```text
python -m pytest \
  tests/test_provider_mismatch.py \
  tests/test_issue1855_resolve_model_provider_fast_path.py \
  tests/test_session_display_resolver_no_live_rebuild.py \
  tests/test_wakeup_model_resolve_hang.py \
  tests/test_chat_start_provider_fallback.py \
  tests/test_issue2518_active_provider_fallback.py \
  tests/test_issue3405_profile_provider_resolution.py -q
# 144 passed
```

Hygiene checks:

```text
git diff --check origin/master...HEAD
python -m compileall -q api/routes.py
# passed
```

## Risks / Follow-ups

- If a user removes a non-first-party provider from config entirely, an old `@provider:model` session can now remain selected and fail at runtime instead of being silently replaced by the default. That is intentional here: the cached catalog cannot reliably distinguish “provider removed” from “provider configured but not present in this snapshot,” and preserving the explicit selection is less surprising than silently changing it.
- A more precise follow-up could consult configured provider IDs from config, not the live catalog, before preserving missing non-first-party providers. That is intentionally left out to keep this fix narrow.

## Model Used

- Anthropic / Claude Opus 4.8 for implementation.
- OpenAI / GPT-5.5 for review, verification, and PR description drafting.
