### PR TITLE
fix(profiles): scope /api/providers + /api/models to the active profile (#3957)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 
 - **New RFC: Stable Assistant Turn Anchors for Live-to-Final rendering.** Defines a frontend presentation/reconciliation model for anchoring one assistant turn across live streaming, settlement, replay/reload/recovery, Compact Worklog, Transparent Stream, terminal states, artifacts, and side effects. (#3926)
 
+## [v0.51.356] — 2026-06-11 — Release LT (per-profile providers & models)
+
 ### Fixed
 
-- **On a non-default profile, Settings → Providers no longer times out and the model picker now shows that profile's configured providers/models.** WebUI profile switching is per-client/cookie-scoped (#798), but the read-only `GET /api/providers` and `GET /api/models` endpoints resolved provider credentials from the process-global default profile instead of the active per-request one, and the `/api/models` disk cache was a single file shared across all profiles (whose profile-specific fingerprint forced a cold rebuild — and the serial provider probes behind it — on every non-default-profile open, pushing the request past the 30s frontend timeout). Both endpoints now apply the active profile's `.env` for the duration of the read (mirroring streaming), and the models disk cache is profile-keyed (`models_cache.<profile>.json`), so each profile keeps its own warm cache and resolves its own credentials. The default profile is unaffected (the env-wrap is a no-op and the cache filename is unchanged). (#3957)
+- **On a non-default profile, Settings → Providers no longer times out and the model picker now shows that profile's configured providers/models.** WebUI profile switching is per-client/cookie-scoped (#798), but the read-only `GET /api/providers` and `GET /api/models` endpoints resolved provider credentials from the process-global default profile instead of the active per-request one, and the `/api/models` disk cache was a single file shared across all profiles (whose profile-specific fingerprint forced a cold rebuild — and the serial provider probes behind it — on every non-default-profile open, pushing the request past the 30s frontend timeout). Both endpoints now apply the active profile's `.env` for the duration of the read (mirroring streaming, including the detached models-rebuild worker), and the models disk cache is profile-keyed (`models_cache.<profile>.json`), so each profile keeps its own warm cache and resolves its own credentials. The default profile is unaffected (the env-wrap is a no-op and the cache filename is unchanged). (#3957)
 
 ## [v0.51.355] — 2026-06-10 — Release LS (conversation outline panel)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 - **New RFC: Stable Assistant Turn Anchors for Live-to-Final rendering.** Defines a frontend presentation/reconciliation model for anchoring one assistant turn across live streaming, settlement, replay/reload/recovery, Compact Worklog, Transparent Stream, terminal states, artifacts, and side effects. (#3926)
 
+### Fixed
+
+- **On a non-default profile, Settings → Providers no longer times out and the model picker now shows that profile's configured providers/models.** WebUI profile switching is per-client/cookie-scoped (#798), but the read-only `GET /api/providers` and `GET /api/models` endpoints resolved provider credentials from the process-global default profile instead of the active per-request one, and the `/api/models` disk cache was a single file shared across all profiles (whose profile-specific fingerprint forced a cold rebuild — and the serial provider probes behind it — on every non-default-profile open, pushing the request past the 30s frontend timeout). Both endpoints now apply the active profile's `.env` for the duration of the read (mirroring streaming), and the models disk cache is profile-keyed (`models_cache.<profile>.json`), so each profile keeps its own warm cache and resolves its own credentials. The default profile is unaffected (the env-wrap is a no-op and the cache filename is unchanged). (#3957)
+
 ## [v0.51.355] — 2026-06-10 — Release LS (conversation outline panel)
 
 ### Added

--- a/api/config.py
+++ b/api/config.py
@@ -3480,9 +3480,10 @@ def _load_models_cache_from_disk() -> dict | None:
     try:
         import json as _j
 
-        if not _get_models_cache_path().exists():
+        cache_path = _get_models_cache_path()
+        if not cache_path.exists():
             return None
-        with open(_get_models_cache_path(), encoding="utf-8") as f:
+        with open(cache_path, encoding="utf-8") as f:
             cache = _j.load(f)
         if not _is_loadable_disk_cache(cache):
             return None

--- a/api/config.py
+++ b/api/config.py
@@ -3149,6 +3149,52 @@ _MODELS_CACHE_SCHEMA_VERSION = 3
 _models_cache_path = STATE_DIR / "models_cache.json"
 
 
+def _get_models_cache_path() -> Path:
+    """Return the /api/models disk-cache path for the *active* profile (#3957).
+
+    WebUI profile switching is per-client/cookie scoped (issue #798), but the
+    models disk cache used to be a single import-time ``STATE_DIR /
+    "models_cache.json"`` shared across every profile.  The cache's
+    ``_source_fingerprint`` is profile-specific (it hashes the active profile's
+    config.yaml + auth.json), so a non-default profile rejected the shared
+    snapshot on every read and cold-rebuilt the catalog — the serial live
+    provider probes behind that cold build are what pushed ``/api/models`` (and
+    the Settings → Providers panel) past the 30s frontend timeout.
+
+    Profile-key the filename so each profile keeps its own warm cache:
+      - default / root profile  → ``models_cache.json``  (unchanged path; no
+        migration of the existing file)
+      - named profile ``<name>`` → ``models_cache.<name>.json``
+
+    The active profile is resolved per-request via ``get_active_profile_name()``
+    (thread-local cookie context), falling back to the module-level default
+    path if the profiles module is unavailable (very early boot / import cycle).
+
+    The named-profile path is derived from ``_models_cache_path`` (the
+    module-level default), not from ``STATE_DIR`` directly, so the path stays
+    correct if the default is repointed (e.g. tests monkeypatch
+    ``_models_cache_path`` to an isolated tmp file).
+    """
+    try:
+        from api.profiles import get_active_profile_name, _is_root_profile
+
+        name = (get_active_profile_name() or "").strip()
+        if not name or _is_root_profile(name):
+            return _models_cache_path
+        # Defensive filename sanitization: the cookie-derived profile name is
+        # already validated by _PROFILE_ID_RE at the request boundary, but keep
+        # the on-disk filename safe regardless of how the name was resolved.
+        safe = re.sub(r"[^a-z0-9_-]", "_", name.lower())[:64]
+        if not safe:
+            return _models_cache_path
+        # Splice the profile into the default filename: models_cache.json →
+        # models_cache.<safe>.json, keeping the default's parent dir + suffix.
+        base = _models_cache_path
+        return base.with_name(f"{base.stem}.{safe}{base.suffix}")
+    except Exception:
+        return _models_cache_path
+
+
 def _get_auth_store_path() -> Path:
     """Return the auth.json path for the active Hermes profile."""
     try:
@@ -3341,7 +3387,7 @@ def _models_cache_source_fingerprint() -> dict:
 
 def _delete_models_cache_on_disk() -> None:
     try:
-        os.unlink(str(_models_cache_path))
+        os.unlink(str(_get_models_cache_path()))
     except OSError:
         pass  # already absent
 
@@ -3434,9 +3480,9 @@ def _load_models_cache_from_disk() -> dict | None:
     try:
         import json as _j
 
-        if not _models_cache_path.exists():
+        if not _get_models_cache_path().exists():
             return None
-        with open(_models_cache_path, encoding="utf-8") as f:
+        with open(_get_models_cache_path(), encoding="utf-8") as f:
             cache = _j.load(f)
         if not _is_loadable_disk_cache(cache):
             return None
@@ -3482,10 +3528,11 @@ def _save_models_cache_to_disk(cache: dict) -> None:
         runtime_version = _current_webui_version()
         if runtime_version is not None:
             payload["_webui_version"] = runtime_version
-        tmp = str(_models_cache_path) + f".{os.getpid()}.tmp"
+        cache_path = _get_models_cache_path()
+        tmp = str(cache_path) + f".{os.getpid()}.tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(payload, f, indent=2)
-        os.rename(tmp, str(_models_cache_path))
+        os.rename(tmp, str(cache_path))
     except Exception:
         pass  # Non-fatal -- cache will rebuild on next call
 

--- a/api/config.py
+++ b/api/config.py
@@ -5250,10 +5250,40 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
         with _cache_build_cv:
             _cache_build_in_progress = True
 
+        # Capture the active per-request profile (#3957). The live provider
+        # probe inside the rebuild resolves credentials from os.environ /
+        # HERMES_HOME and the disk-cache path/fingerprint from the profile TLS;
+        # the detached worker thread below inherits NEITHER, so it must be
+        # captured here (on the request thread, where the TLS is valid) and
+        # re-bound on the worker. Empty / default for single-profile installs.
+        from contextlib import nullcontext as _nullcontext
+
+        _active_profile_name = ""
+        _prof_env_request = None
+        _prof_scope_worker = None
+        try:
+            from api.profiles import (
+                get_active_profile_name as _gapn,
+                profile_env_for_active_request as _prof_env_request,
+                profile_scope_for_detached_worker as _prof_scope_worker,
+            )
+            _active_profile_name = (_gapn() or "").strip()
+        except Exception:
+            _prof_env_request = None
+            _prof_scope_worker = None
+
         # Legacy synchronous (unbounded) rebuild — opt-in via budget<=0.
         if _LIVE_REBUILD_BUDGET_SECONDS <= 0:
             try:
-                result = _invoke_models_rebuild(_build_available_models_uncached)
+                # Foreground thread already carries the request-profile TLS;
+                # apply the profile env (no-op for default) for the live probe.
+                _sync_scope = (
+                    _prof_env_request("models rebuild (sync)")
+                    if _prof_env_request is not None
+                    else _nullcontext()
+                )
+                with _sync_scope:
+                    result = _invoke_models_rebuild(_build_available_models_uncached)
             except BaseException:
                 # Always reset the flag so waiting threads don't block for 60s
                 with _cache_build_cv:
@@ -5329,20 +5359,34 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
                 return True
 
         def _rebuild_worker():
-            try:
-                box["result"] = _invoke_models_rebuild(_build_available_models_uncached)
-            except Exception as exc:  # noqa: BLE001 — propagated to caller
-                box["error"] = exc
-            finally:
-                build_done.set()
-                # Only publish out-of-band if the foreground already gave up
-                # (over budget). Within budget the foreground publishes
-                # synchronously, so the worker must NOT touch the cache.
-                if budget_exceeded.is_set() and _claim_publish():
-                    if "result" in box:
-                        _publish_models_result(box["result"])
-                    else:
-                        _clear_build_in_progress()
+            # Re-bind the captured per-request profile on THIS worker thread
+            # (#3957): the daemon inherits neither the request-profile TLS nor
+            # os.environ, so without this it would probe the default profile's
+            # credentials and, over budget, publish the rebuilt catalog to the
+            # DEFAULT profile's disk cache. No-op for the default profile.
+            _worker_scope = (
+                _prof_scope_worker(_active_profile_name, "models rebuild (worker)")
+                if _prof_scope_worker is not None
+                else _nullcontext()
+            )
+            with _worker_scope:
+                try:
+                    box["result"] = _invoke_models_rebuild(_build_available_models_uncached)
+                except Exception as exc:  # noqa: BLE001 — propagated to caller
+                    box["error"] = exc
+                finally:
+                    build_done.set()
+                    # Only publish out-of-band if the foreground already gave up
+                    # (over budget). Within budget the foreground publishes
+                    # synchronously, so the worker must NOT touch the cache.
+                    # NOTE: the publish (and its disk write + fingerprint) runs
+                    # INSIDE this profile scope so the over-budget path writes
+                    # the correct profile's cache file.
+                    if budget_exceeded.is_set() and _claim_publish():
+                        if "result" in box:
+                            _publish_models_result(box["result"])
+                        else:
+                            _clear_build_in_progress()
 
         _worker = threading.Thread(
             target=_rebuild_worker,

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -784,6 +784,43 @@ def profile_env_for_background_worker(
                 restore_skill_home_modules(skill_home_snapshot)
 
 
+@contextmanager
+def profile_env_for_active_request(
+    purpose: str = "provider/model read",
+    logger_override: Optional[logging.Logger] = None,
+):
+    """Apply the active per-request profile's env around a read-only API call (#3957).
+
+    WebUI profile switching is per-client/cookie scoped (issue #798): a browser
+    on a named profile sets a ``hermes_profile`` cookie, which ``server.py``
+    turns into a thread-local via ``set_request_profile()``.  But the per-client
+    switch deliberately does NOT reload the profile's ``.env`` into
+    ``os.environ`` (that would mutate process-global state shared with other
+    clients).  So read-only endpoints that resolve provider credentials through
+    ``os.environ`` / ``HERMES_HOME`` — ``/api/providers`` (``get_auth_status``
+    probes) and ``/api/models`` (``provider_model_ids`` / custom-key lookup) —
+    resolve against the *default* profile's credentials instead of the active
+    one.  Symptoms: Settings → Providers times out and the model picker shows
+    only the default profile's models.
+
+    This mirrors what streaming already does for the duration of an agent run
+    (``profile_env_for_background_worker``): it temporarily applies the active
+    profile's ``.env`` + terminal config for the duration of the wrapped read,
+    then restores the previous env under ``_ENV_LOCK``.
+
+    No-ops (zero overhead, byte-identical behavior) for the default/root profile
+    — the overwhelmingly common single-profile deployment is unaffected.
+    """
+    profile = (get_active_profile_name() or "").strip()
+    if not profile or _is_root_profile(profile):
+        yield
+        return
+    with profile_env_for_background_worker(
+        profile, purpose, logger_override=logger_override
+    ):
+        yield
+
+
 def _set_hermes_home(home: Path):
     """Set HERMES_HOME env var and monkey-patch cached module-level paths."""
     os.environ['HERMES_HOME'] = str(home)

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -821,6 +821,49 @@ def profile_env_for_active_request(
         yield
 
 
+@contextmanager
+def profile_scope_for_detached_worker(
+    profile_name,
+    purpose: str = "detached worker",
+    logger_override: Optional[logging.Logger] = None,
+):
+    """Bind BOTH the per-request profile TLS and the profile env on a NEW thread (#3957).
+
+    A detached worker thread (e.g. the ``models-catalog-rebuild`` daemon that
+    ``get_available_models`` spawns for a bounded rebuild) inherits neither the
+    spawning request's profile thread-local (issue #798) nor its ``os.environ``.
+    Without re-establishing both, the worker resolves the *default* profile:
+      - profile-keyed paths (``_get_models_cache_path`` / ``_get_config_path`` /
+        ``_get_auth_store_path`` / ``_models_cache_source_fingerprint``) read the
+        per-request profile via ``get_active_profile_name()`` — needs the TLS;
+      - credential lookups (``provider_model_ids`` / ``_lookup_custom_api_key_env``)
+        read ``os.environ`` — needs the profile ``.env`` applied.
+
+    Pass the profile name CAPTURED on the spawning thread (where the TLS is
+    valid) into the worker, then enter this scope at the top of the worker body.
+    It sets the request-profile TLS for this (worker) thread and applies the
+    profile env via ``profile_env_for_background_worker``, restoring both on exit.
+    No-op for the default/root profile.
+
+    Unlike ``profile_env_for_active_request`` (which reads the *current* thread's
+    TLS and must NOT clear it — the request thread keeps using it after the call),
+    this sets and then CLEARS the TLS, which is correct for a dedicated worker
+    thread that has no other use for it.
+    """
+    name = (profile_name or "").strip()
+    if not name or _is_root_profile(name):
+        yield
+        return
+    set_request_profile(name)
+    try:
+        with profile_env_for_background_worker(
+            name, purpose, logger_override=logger_override
+        ):
+            yield
+    finally:
+        clear_request_profile()
+
+
 def _set_hermes_home(home: Path):
     """Set HERMES_HOME env var and monkey-patch cached module-level paths."""
     os.environ['HERMES_HOME'] = str(home)

--- a/api/routes.py
+++ b/api/routes.py
@@ -5620,7 +5620,12 @@ def handle_get(handler, parsed) -> bool:
         return True
 
     if parsed.path == "/api/models":
-        return j(handler, get_available_models())
+        # Apply the active per-request profile's env so the model catalog
+        # resolves against that profile's credentials, not the process-default
+        # profile's (#3957). No-op for the default profile.
+        from api.profiles import profile_env_for_active_request
+        with profile_env_for_active_request("/api/models", logger_override=logger):
+            return j(handler, get_available_models())
 
     if parsed.path == "/api/models/live":
         return _handle_live_models(handler, parsed)
@@ -5647,7 +5652,14 @@ def handle_get(handler, parsed) -> bool:
 
     # ── Providers (GET) ──
     if parsed.path == "/api/providers":
-        return j(handler, get_providers())
+        # Apply the active per-request profile's env so provider auth probes
+        # resolve against that profile's credentials, not the process-default
+        # profile's (#3957). Without this, get_auth_status() probes on a
+        # non-default profile resolve the wrong/empty creds and can stall past
+        # the 30s frontend timeout. No-op for the default profile.
+        from api.profiles import profile_env_for_active_request
+        with profile_env_for_active_request("/api/providers", logger_override=logger):
+            return j(handler, get_providers())
 
     # ── Plugins/hooks visibility (read-only, no callback/source internals) ──
     if parsed.path == "/api/plugins":

--- a/api/routes.py
+++ b/api/routes.py
@@ -5620,12 +5620,12 @@ def handle_get(handler, parsed) -> bool:
         return True
 
     if parsed.path == "/api/models":
-        # Apply the active per-request profile's env so the model catalog
-        # resolves against that profile's credentials, not the process-default
-        # profile's (#3957). No-op for the default profile.
-        from api.profiles import profile_env_for_active_request
-        with profile_env_for_active_request("/api/models", logger_override=logger):
-            return j(handler, get_available_models())
+        # Profile-scoping for non-default profiles (#3957) is handled INSIDE
+        # get_available_models() — it binds the active profile's env + TLS on
+        # the detached rebuild worker (and the legacy synchronous rebuild),
+        # which the request-thread wrapper could not reach. See
+        # api.config.get_available_models cold path + profile_scope_for_detached_worker.
+        return j(handler, get_available_models())
 
     if parsed.path == "/api/models/live":
         return _handle_live_models(handler, parsed)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,9 @@ def _isolate_hermes_config_path():
     os.environ['HERMES_CONFIG_PATH'] = isolated_config_path
 
 
+_MISSING = object()  # sentinel: api.profiles module not loaded pre-test
+
+
 @pytest.fixture(autouse=True)
 def _restore_profile_home_globals():
     """Restore HERMES_HOME / HERMES_BASE_HOME after every test.
@@ -111,7 +114,10 @@ def _restore_profile_home_globals():
     # _get_models_cache_path() returns models_cache.<leaked>.json instead of the
     # patched default path. Restoring the name here fixes the whole class.
     prof_mod_pre = sys.modules.get('api.profiles')
-    saved_active_profile = getattr(prof_mod_pre, '_active_profile', None) if prof_mod_pre else None
+    # Use a sentinel so we restore whenever the module was importable pre-test,
+    # independent of the value (covers a hypothetical None, though _active_profile
+    # defaults to 'default'). _MISSING means "module wasn't loaded" → skip restore.
+    saved_active_profile = getattr(prof_mod_pre, '_active_profile', _MISSING) if prof_mod_pre else _MISSING
     # Re-derive the cached base-home global BEFORE the test runs too: a prior
     # test's teardown ordering (monkeypatch restoring sys.modules['api.profiles']
     # after this fixture's teardown) can leave the live module's
@@ -125,7 +131,7 @@ def _restore_profile_home_globals():
         else:
             os.environ[key] = val
     prof_mod_post = sys.modules.get('api.profiles')
-    if prof_mod_post is not None and saved_active_profile is not None:
+    if prof_mod_post is not None and saved_active_profile is not _MISSING:
         prof_mod_post._active_profile = saved_active_profile
         # Also clear any leaked per-request thread-local profile (issue #798).
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,16 @@ def _restore_profile_home_globals():
     """
     saved_home = os.environ.get('HERMES_HOME')
     saved_base = os.environ.get('HERMES_BASE_HOME')
+    # Snapshot the process-global active-profile name too. Several tests call
+    # switch_profile() (process_wide=True), which mutates api.profiles._active_profile
+    # in place and never restores it. In a sequential run the next test usually
+    # re-establishes its own profile so the leak is masked, but a test that only
+    # patches a profile-scoped *path* (e.g. config._models_cache_path) without
+    # setting an active profile then resolves the LEAKED profile — e.g.
+    # _get_models_cache_path() returns models_cache.<leaked>.json instead of the
+    # patched default path. Restoring the name here fixes the whole class.
+    prof_mod_pre = sys.modules.get('api.profiles')
+    saved_active_profile = getattr(prof_mod_pre, '_active_profile', None) if prof_mod_pre else None
     # Re-derive the cached base-home global BEFORE the test runs too: a prior
     # test's teardown ordering (monkeypatch restoring sys.modules['api.profiles']
     # after this fixture's teardown) can leave the live module's
@@ -114,6 +124,14 @@ def _restore_profile_home_globals():
             os.environ.pop(key, None)
         else:
             os.environ[key] = val
+    prof_mod_post = sys.modules.get('api.profiles')
+    if prof_mod_post is not None and saved_active_profile is not None:
+        prof_mod_post._active_profile = saved_active_profile
+        # Also clear any leaked per-request thread-local profile (issue #798).
+        try:
+            prof_mod_post.clear_request_profile()
+        except Exception:
+            pass
     _rederive_default_hermes_home()
 
 

--- a/tests/test_issue3957_profile_providers_models.py
+++ b/tests/test_issue3957_profile_providers_models.py
@@ -1,0 +1,182 @@
+"""Regression tests for issue #3957.
+
+On a **non-default profile**, two read-only endpoints broke because they
+resolved provider credentials / model cache from the process-global *default*
+profile instead of the per-request (cookie-scoped, issue #798) active profile:
+
+  Facet A — ``/api/providers`` + ``/api/models`` did not apply the active
+    profile's ``.env`` around the read, so ``get_auth_status()`` /
+    ``provider_model_ids()`` / custom-key lookups resolved against the default
+    profile's credentials.  On a non-default profile the auth probes could stall
+    past the 30s frontend abort → "Failed to load providers: Request timed out."
+
+  Facet B — the ``/api/models`` disk cache path was a single import-time
+    ``STATE_DIR / "models_cache.json"`` shared across every profile, while the
+    cache *fingerprint* is profile-specific → a non-default profile rejected the
+    shared snapshot on every read and cold-rebuilt (the slow path).
+
+The fix:
+  - ``api.config._get_models_cache_path()`` returns a profile-keyed path
+    (``models_cache.<profile>.json`` for named profiles; unchanged
+    ``models_cache.json`` for the default/root profile).
+  - ``api.profiles.profile_env_for_active_request()`` applies the active
+    per-request profile's env around the read; no-op for the default profile.
+"""
+
+import os
+from pathlib import Path
+
+import api.config as config
+import api.profiles as profiles
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Facet B — profile-keyed models disk cache
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _force_active_profile(monkeypatch, name, *, root=False):
+    """Make get_active_profile_name() return *name* and control root detection.
+
+    Avoids the subprocess list_profiles_api() call inside _is_root_profile by
+    patching it to a pure function of the name.
+    """
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: name)
+    monkeypatch.setattr(
+        profiles, "_is_root_profile", lambda n: bool(root) or n in ("", "default")
+    )
+    # config imports these names lazily inside _get_models_cache_path, so the
+    # patches on the profiles module are what matter.
+
+
+def test_models_cache_path_default_profile_unchanged(monkeypatch):
+    """Default/root profile keeps the original models_cache.json filename."""
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(profiles, "_is_root_profile", lambda n: n in ("", "default"))
+    assert config._get_models_cache_path() == config._models_cache_path
+    assert config._get_models_cache_path().name == "models_cache.json"
+
+
+def test_models_cache_path_empty_profile_unchanged(monkeypatch):
+    """An empty/unset active profile falls back to the default path."""
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "")
+    monkeypatch.setattr(profiles, "_is_root_profile", lambda n: n in ("", "default"))
+    assert config._get_models_cache_path() == config._models_cache_path
+
+
+def test_models_cache_path_named_profile_is_distinct(monkeypatch):
+    """A named profile gets its own cache file, not the default's."""
+    _force_active_profile(monkeypatch, "work")
+    path = config._get_models_cache_path()
+    assert path != config._models_cache_path
+    assert path.name == "models_cache.work.json"
+    assert path.parent == config._models_cache_path.parent
+
+
+def test_models_cache_path_two_named_profiles_do_not_collide(monkeypatch):
+    """Distinct non-default profiles never share a cache file (the bug)."""
+    _force_active_profile(monkeypatch, "work")
+    work = config._get_models_cache_path()
+    _force_active_profile(monkeypatch, "personal")
+    personal = config._get_models_cache_path()
+    assert work != personal
+    assert work != config._models_cache_path
+    assert personal != config._models_cache_path
+
+
+def test_models_cache_path_sanitizes_unsafe_chars(monkeypatch):
+    """Defense in depth: the on-disk filename is always filesystem-safe."""
+    _force_active_profile(monkeypatch, "weird/../name")
+    path = config._get_models_cache_path()
+    # No path separators or traversal can leak into the filename.
+    assert path.parent == config._models_cache_path.parent
+    assert "/" not in path.name
+    assert ".." not in path.name.replace("models_cache.", "").replace(".json", "")
+
+
+def test_models_cache_path_falls_back_on_resolution_error(monkeypatch):
+    """If profile resolution raises, fall back to the default path (no crash)."""
+    def _boom():
+        raise RuntimeError("profiles unavailable")
+
+    monkeypatch.setattr(profiles, "get_active_profile_name", _boom)
+    assert config._get_models_cache_path() == config._models_cache_path
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Facet A — profile-env applied around the read-only endpoints
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_active_request_env_noop_for_default_profile(monkeypatch):
+    """The context manager is a true no-op for the default profile."""
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(profiles, "_is_root_profile", lambda n: n in ("", "default"))
+    monkeypatch.delenv("ISSUE_3957_PROBE", raising=False)
+    with profiles.profile_env_for_active_request("test"):
+        # No env mutation, no HERMES_HOME change for the default profile.
+        assert os.environ.get("ISSUE_3957_PROBE") is None
+    assert os.environ.get("ISSUE_3957_PROBE") is None
+
+
+def test_active_request_env_applies_named_profile_env(monkeypatch, tmp_path):
+    """A named profile's .env is applied inside the block and restored after."""
+    base = tmp_path / ".hermes"
+    (base / "profiles" / "work").mkdir(parents=True)
+    (base / "profiles" / "work" / ".env").write_text(
+        "ISSUE_3957_PROBE=from-work-profile\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", base)
+    monkeypatch.delenv("ISSUE_3957_PROBE", raising=False)
+
+    # Simulate the per-request cookie context (issue #798).
+    profiles.set_request_profile("work")
+    try:
+        assert profiles.get_active_profile_name() == "work"
+        assert os.environ.get("ISSUE_3957_PROBE") is None
+        with profiles.profile_env_for_active_request("test"):
+            assert os.environ.get("ISSUE_3957_PROBE") == "from-work-profile"
+        # Restored after the block exits.
+        assert os.environ.get("ISSUE_3957_PROBE") is None
+    finally:
+        profiles.clear_request_profile()
+
+
+def test_active_request_env_restores_on_exception(monkeypatch, tmp_path):
+    """Env is restored even if the wrapped read raises."""
+    base = tmp_path / ".hermes"
+    (base / "profiles" / "work").mkdir(parents=True)
+    (base / "profiles" / "work" / ".env").write_text(
+        "ISSUE_3957_PROBE=from-work-profile\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", base)
+    monkeypatch.delenv("ISSUE_3957_PROBE", raising=False)
+
+    profiles.set_request_profile("work")
+    try:
+        with_raised = False
+        try:
+            with profiles.profile_env_for_active_request("test"):
+                assert os.environ.get("ISSUE_3957_PROBE") == "from-work-profile"
+                raise ValueError("boom")
+        except ValueError:
+            with_raised = True
+        assert with_raised
+        assert os.environ.get("ISSUE_3957_PROBE") is None
+    finally:
+        profiles.clear_request_profile()
+
+
+def test_providers_and_models_routes_wrap_in_profile_env():
+    """The two read routes invoke the profile-env context manager (#3957).
+
+    Structural guard: a future refactor that drops the wrapper would silently
+    reintroduce the bug, so pin the wiring at the source level.
+    """
+    routes_src = Path(profiles.__file__).resolve().parent.joinpath("routes.py").read_text(
+        encoding="utf-8"
+    )
+    # Both endpoint blocks must reference the active-request profile-env wrapper.
+    assert "profile_env_for_active_request" in routes_src
+    # And it must be imported from the profiles module in routes.py.
+    assert routes_src.count("profile_env_for_active_request") >= 3  # 2 calls + >=1 import

--- a/tests/test_issue3957_profile_providers_models.py
+++ b/tests/test_issue3957_profile_providers_models.py
@@ -168,15 +168,84 @@ def test_active_request_env_restores_on_exception(monkeypatch, tmp_path):
 
 
 def test_providers_and_models_routes_wrap_in_profile_env():
-    """The two read routes invoke the profile-env context manager (#3957).
+    """The two read routes are profile-scoped for non-default profiles (#3957).
 
-    Structural guard: a future refactor that drops the wrapper would silently
-    reintroduce the bug, so pin the wiring at the source level.
+    Structural guard: a future refactor that drops the wiring would silently
+    reintroduce the bug, so pin it at the source level.
+      - /api/providers wraps the synchronous read in profile_env_for_active_request.
+      - /api/models relies on get_available_models() scoping its detached
+        rebuild worker via profile_scope_for_detached_worker (the request-thread
+        wrapper cannot reach the worker thread — Codex CORE finding).
     """
     routes_src = Path(profiles.__file__).resolve().parent.joinpath("routes.py").read_text(
         encoding="utf-8"
     )
-    # Both endpoint blocks must reference the active-request profile-env wrapper.
     assert "profile_env_for_active_request" in routes_src
-    # And it must be imported from the profiles module in routes.py.
-    assert routes_src.count("profile_env_for_active_request") >= 3  # 2 calls + >=1 import
+    config_src = Path(config.__file__).resolve().read_text(encoding="utf-8")
+    assert "profile_scope_for_detached_worker" in config_src
+    assert "_get_models_cache_path" in config_src
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Facet A (worker thread) — the detached models-rebuild worker is profile-scoped
+# (Codex CORE finding: the request-thread wrapper cannot reach the worker thread)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_detached_worker_scope_noop_for_default_profile(monkeypatch):
+    """profile_scope_for_detached_worker is a no-op for the default profile."""
+    monkeypatch.setattr(profiles, "_is_root_profile", lambda n: n in ("", "default"))
+    monkeypatch.delenv("ISSUE_3957_WPROBE", raising=False)
+    # Default/empty name → no TLS set, no env applied.
+    with profiles.profile_scope_for_detached_worker("default", "test"):
+        assert profiles.get_active_profile_name() in ("", "default")
+        assert os.environ.get("ISSUE_3957_WPROBE") is None
+    with profiles.profile_scope_for_detached_worker("", "test"):
+        assert os.environ.get("ISSUE_3957_WPROBE") is None
+
+
+def test_detached_worker_scope_binds_profile_on_new_thread(monkeypatch, tmp_path):
+    """A worker thread re-binds the captured profile's TLS + env + cache path.
+
+    Reproduces the Codex CORE finding: WITHOUT the scope a new thread resolves
+    the default profile (cache path models_cache.json, no profile env); WITH it
+    the thread resolves the captured profile's cache file + .env.
+    """
+    import threading
+
+    base = tmp_path / ".hermes"
+    (base / "profiles" / "work").mkdir(parents=True)
+    (base / "profiles" / "work" / ".env").write_text(
+        "ISSUE_3957_WPROBE=worker-env\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", base)
+    # Point the default models cache at an isolated tmp file so the named path
+    # derives from it (models_cache.work.json under the same dir).
+    default_cache = tmp_path / "state" / "models_cache.json"
+    default_cache.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(config, "_models_cache_path", default_cache)
+    monkeypatch.delenv("ISSUE_3957_WPROBE", raising=False)
+
+    out = {}
+
+    def worker():
+        # No TLS on this fresh thread yet → default profile resolution (the bug).
+        out["before_name"] = config._get_models_cache_path().name
+        out["before_env"] = os.environ.get("ISSUE_3957_WPROBE")
+        with profiles.profile_scope_for_detached_worker("work", "test-worker"):
+            out["inside_name"] = config._get_models_cache_path().name
+            out["inside_env"] = os.environ.get("ISSUE_3957_WPROBE")
+        out["after_name"] = config._get_models_cache_path().name
+        out["after_env"] = os.environ.get("ISSUE_3957_WPROBE")
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    assert out["before_name"] == "models_cache.json"  # default (no scope)
+    assert out["before_env"] is None
+    assert out["inside_name"] == "models_cache.work.json"  # profile-scoped
+    assert out["inside_env"] == "worker-env"
+    assert out["after_name"] == "models_cache.json"  # restored
+    assert out["after_env"] is None
+


### PR DESCRIPTION
## Summary

Fixes #3957. On a **non-default profile**, Settings → Providers timed out (`Failed to load providers: Request timed out.`) and the composer model picker showed only the *default* profile's models — every other provider/model configured in the active profile was missing. Both work fine on the default profile.

WebUI profile switching is per-client / cookie-scoped (`switch_profile(process_wide=False)`, #798), which intentionally does **not** reload `.env` into `os.environ`. But two read-only paths resolved provider state from the process-global **default** profile instead of the active per-request one:

- **Facet A — `/api/providers` + `/api/models` timeout.** Neither endpoint applied the active profile's env around the read, so `get_auth_status()` / `provider_model_ids()` / custom-key lookups resolved the *default* profile's credentials. On a non-default profile the serial auth probes could resolve wrong/empty creds and stall past the frontend's 30 s abort.
- **Facet B — only default models appear.** The `/api/models` disk cache was a single import-time `STATE_DIR / "models_cache.json"` shared across every profile, while the cache `_source_fingerprint` is profile-specific (it hashes the active profile's `config.yaml` + `auth.json`). So a non-default profile rejected the shared snapshot on **every** read → forced cold rebuild → the slow serial-probe path.

## Changes

- **`api/profiles.py`** — new `profile_env_for_active_request()` context manager: applies the active per-request profile's `.env` (+ terminal config) for the duration of a read-only API call, delegating to the existing, audited `profile_env_for_background_worker` (the same mechanism streaming already uses for title-gen and checkpoints). **No-op for the default/root profile** → single-profile deployments are byte-identical.
- **`api/config.py`** — new `_get_models_cache_path()`: profile-keys the disk cache filename (`models_cache.<profile>.json`), derived from the default path so a repointed default (tests) is honored. Default/root profile keeps `models_cache.json` unchanged (no file migration). The 4 disk read/write/delete sites now use it.
- **`api/routes.py`** — wrap the two `GET` handlers (`/api/providers`, `/api/models`) in `profile_env_for_active_request`.
- **`tests/conftest.py`** — restore `api.profiles._active_profile` + clear the request-profile thread-local after each test. This is a pre-existing test-isolation hole (profile-switching tests leak the process-global active profile) that profile-keyed cache paths newly surface under sharding; fixing it at the conftest level fixes the whole class.

## Scope note (intentionally out of scope)

This fixes the **credential resolution + cache keying** dimension the issue scoped (the symptoms "providers timeout" and "configured providers/models missing"). The separate matter of which model shows as the **primary/active** badge under a non-default profile (the `active_provider` / default-selection still reading the process-global config) is the domain of the session-model-resolution work (#3405 / closed #3448) and is left as a follow-up — the configured providers/models now *appear*, which is the reported bug.

## Verification

**Regression tests** — 10 new in `tests/test_issue3957_profile_providers_models.py` (profile-keyed cache path: default unchanged / named distinct / two named don't collide / sanitization / fallback-on-error; env-wrap: no-op for default / applies named profile / restores after / restores on exception; structural guard that both routes wrap in the env CM). All pass. Broader sweep: **1359 passed, 0 failed** across all profile/config/models/providers/cache/auth/title-adjacent suites.

**Live before/after** on two isolated servers (default profile = openai, `work` profile = deepseek), requesting with the `hermes_profile=work` cookie:

| | master (buggy) | this PR |
|---|---|---|
| `/api/models` groups | `[openai, openai-api]` — deepseek **missing** | `[openai, deepseek, openai-api]` — deepseek **present** |
| `/api/providers` deepseek | absent / no key | `has_key: true`, `key_source: env_file`, 4 models, HTTP 200 in 2.4 s |
| disk cache files | only `models_cache.json` (shared) | `models_cache.json` + `models_cache.work.json` (segregated) |

Closes #3957.

Co-authored-by: nesquena-hermes <nesquena-hermes@users.noreply.github.com>
