### PR TITLE
[security] fix(settings): gate first password setup to local clients

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1849,10 +1849,11 @@ def _onboarding_request_is_local(handler) -> bool:
     return bool(addr.is_loopback or addr.is_private)
 
 
-def _onboarding_gate_allows(handler) -> bool:
+def _onboarding_gate_allows(handler, auth_enabled: bool | None = None) -> bool:
     from api.auth import is_auth_enabled
 
-    if is_auth_enabled() or _truthy_env("HERMES_WEBUI_ONBOARDING_OPEN"):
+    auth_enabled = is_auth_enabled() if auth_enabled is None else auth_enabled
+    if auth_enabled or _truthy_env("HERMES_WEBUI_ONBOARDING_OPEN"):
         return True
     return _onboarding_request_is_local(handler)
 
@@ -8329,7 +8330,7 @@ def handle_post(handler, parsed) -> bool:
         # onboarding setup: local/private networks only, unless the operator
         # explicitly opts into remote bootstrap with HERMES_WEBUI_ONBOARDING_OPEN.
         if requested_password and not auth_enabled_before:
-            if not _onboarding_gate_allows(handler):
+            if not _onboarding_gate_allows(handler, auth_enabled_before):
                 return bad(
                     handler,
                     "First password setup is only available from local networks when auth is not enabled. "

--- a/api/routes.py
+++ b/api/routes.py
@@ -8322,6 +8322,21 @@ def handle_post(handler, parsed) -> bool:
                     "Unset the env var and restart the server before changing the password here.",
                     409,
                 )
+
+        # First password creation decides who owns a previously passwordless
+        # WebUI. While auth is disabled, the generic /api/settings route is also
+        # unauthenticated, so gate bootstrap password setup the same way as
+        # onboarding setup: local/private networks only, unless the operator
+        # explicitly opts into remote bootstrap with HERMES_WEBUI_ONBOARDING_OPEN.
+        if requested_password and not auth_enabled_before:
+            if not _onboarding_gate_allows(handler):
+                return bad(
+                    handler,
+                    "First password setup is only available from local networks when auth is not enabled. "
+                    "To bootstrap this on a remote server, set HERMES_WEBUI_ONBOARDING_OPEN=1.",
+                    403,
+                )
+
         if requested_passwordless:
             from api.auth import _passkey_feature_flag_enabled
             from api.passkeys import registered_credentials

--- a/tests/test_security_review_fixes.py
+++ b/tests/test_security_review_fixes.py
@@ -18,6 +18,7 @@ class _Handler:
         self.headers = _Headers(headers or {})
         self.rfile = io.BytesIO(body)
         self.wfile = io.BytesIO()
+        self.request = None
         self.status = None
         self.sent_headers = []
 
@@ -221,3 +222,72 @@ def test_onboarding_complete_allowed_when_auth_enabled(monkeypatch):
     h = _Handler(client_ip="8.8.8.8", body=b"{}", headers={"Content-Length": "2"})
     routes.handle_post(h, SimpleNamespace(path="/api/onboarding/complete", query=""))
     assert h.status == 200
+
+
+def test_first_password_setup_is_gated_against_public_clients(monkeypatch):
+    """Unauthenticated first-password setup is bootstrap-sensitive.
+
+    While auth is disabled, POST /api/settings normally passes the auth/CSRF
+    checks. A public client must not be able to win first-run ownership by
+    setting `_set_password`; it should be gated like onboarding setup and should
+    not write settings.
+    """
+    from api import routes
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: False)
+    monkeypatch.setattr("api.auth.parse_cookie", lambda handler: "")
+    monkeypatch.setattr("api.auth.verify_session", lambda cookie: False)
+    monkeypatch.delenv("HERMES_WEBUI_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_ONBOARDING_OPEN", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", raising=False)
+
+    saved = {"called": False}
+    monkeypatch.setattr(
+        routes,
+        "save_settings",
+        lambda body: saved.__setitem__("called", True) or dict(body),
+    )
+
+    body = b'{"_set_password":"attacker-password"}'
+    handler = _Handler(
+        client_ip="8.8.8.8",
+        body=body,
+        headers={"Content-Length": str(len(body))},
+    )
+    routes.handle_post(handler, SimpleNamespace(path="/api/settings", query=""))
+
+    assert handler.status == 403
+    assert saved["called"] is False
+
+
+def test_first_password_setup_allows_genuine_loopback_client(monkeypatch):
+    """A same-host first-run setup flow still works without setting the bypass env."""
+    from api import routes
+
+    auth_state = {"enabled": False}
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: auth_state["enabled"])
+    monkeypatch.setattr("api.auth.parse_cookie", lambda handler: "")
+    monkeypatch.setattr("api.auth.verify_session", lambda cookie: False)
+    monkeypatch.setattr("api.auth.create_session", lambda: "new-session")
+    monkeypatch.delenv("HERMES_WEBUI_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_ONBOARDING_OPEN", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", raising=False)
+
+    def fake_save_settings(body):
+        auth_state["enabled"] = True
+        return {"theme": "dark", "password_hash": "redacted"}
+
+    monkeypatch.setattr(routes, "save_settings", fake_save_settings)
+
+    body = b'{"_set_password":"local-owner-password"}'
+    handler = _Handler(
+        client_ip="127.0.0.1",
+        body=body,
+        headers={"Content-Length": str(len(body))},
+    )
+    routes.handle_post(handler, SimpleNamespace(path="/api/settings", query=""))
+
+    assert handler.status == 200
+    assert any(key.lower() == "set-cookie" for key, _ in handler.sent_headers)

--- a/tests/test_security_review_fixes.py
+++ b/tests/test_security_review_fixes.py
@@ -291,3 +291,65 @@ def test_first_password_setup_allows_genuine_loopback_client(monkeypatch):
 
     assert handler.status == 200
     assert any(key.lower() == "set-cookie" for key, _ in handler.sent_headers)
+
+
+def test_first_password_setup_uses_initial_auth_state_for_gate(monkeypatch):
+    """A public bootstrap request cannot pass just because auth flips mid-request."""
+    from api import routes
+
+    auth_checks = iter([False, True])
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: next(auth_checks))
+    monkeypatch.setattr("api.auth.parse_cookie", lambda handler: "")
+    monkeypatch.setattr("api.auth.verify_session", lambda cookie: False)
+    monkeypatch.delenv("HERMES_WEBUI_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_ONBOARDING_OPEN", raising=False)
+
+    saved = {"called": False}
+    monkeypatch.setattr(
+        routes,
+        "save_settings",
+        lambda body: saved.__setitem__("called", True) or dict(body),
+    )
+
+    body = b'{"_set_password":"attacker-password"}'
+    handler = _Handler(
+        client_ip="8.8.8.8",
+        body=body,
+        headers={"Content-Length": str(len(body))},
+    )
+    routes.handle_post(handler, SimpleNamespace(path="/api/settings", query=""))
+
+    assert handler.status == 403
+    assert saved["called"] is False
+
+
+def test_first_password_setup_allows_public_client_with_open_onboarding(monkeypatch):
+    """The documented operator opt-in permits remote first-run bootstrap."""
+    from api import routes
+
+    auth_state = {"enabled": False}
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: auth_state["enabled"])
+    monkeypatch.setattr("api.auth.parse_cookie", lambda handler: "")
+    monkeypatch.setattr("api.auth.verify_session", lambda cookie: False)
+    monkeypatch.setattr("api.auth.create_session", lambda: "new-session")
+    monkeypatch.delenv("HERMES_WEBUI_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_ONBOARDING_OPEN", "1")
+
+    def fake_save_settings(body):
+        auth_state["enabled"] = True
+        return {"theme": "dark", "password_hash": "redacted"}
+
+    monkeypatch.setattr(routes, "save_settings", fake_save_settings)
+
+    body = b'{"_set_password":"remote-owner-password"}'
+    handler = _Handler(
+        client_ip="8.8.8.8",
+        body=body,
+        headers={"Content-Length": str(len(body))},
+    )
+    routes.handle_post(handler, SimpleNamespace(path="/api/settings", query=""))
+
+    assert handler.status == 200
+    assert any(key.lower() == "set-cookie" for key, _ in handler.sent_headers)


### PR DESCRIPTION
## Summary

This PR hardens the first-run password bootstrap boundary for `POST /api/settings`.

When Hermes WebUI starts without auth enabled, the settings route is intentionally reachable without an existing session for local setup. Setting `_set_password` is different from ordinary settings edits, though: it creates the first WebUI password, persists the auth state, and issues a session to the requester. This PR gates that first-password bootstrap action with the existing onboarding locality check.

- Blocks non-local unauthenticated clients from winning first-run ownership by posting `_set_password`.
- Preserves normal authenticated password changes after auth is enabled.
- Preserves same-host/local/private bootstrap behavior for first-run setup.
- Preserves the explicit operator opt-in path with `HERMES_WEBUI_ONBOARDING_OPEN=1`.
- Adds regression tests for rejected public bootstrap and allowed loopback bootstrap.

## Thinking Path

- Hermes WebUI supports a local-first, passwordless startup mode.
- In that mode, `/api/settings` is reachable before a session exists.
- Most settings are ordinary preferences, but `_set_password` establishes WebUI ownership.
- The safest narrow fix is to treat first-password creation like onboarding setup: local/private by default, explicit remote opt-in when an operator wants it.
- This keeps setup simple without allowing an accidentally reachable fresh instance to become first-client-wins.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Unauthenticated first-run password takeover through `POST /api/settings` | A reachable no-password instance can let the first non-local requester set the WebUI password, receive a session, and lock out the intended operator until state is manually reset. | Medium, deployment-dependent |

## Before this PR

- When auth was disabled, `check_auth()` allowed `POST /api/settings` without a session.
- The settings handler accepted `_set_password` in that unauthenticated state.
- Saving the setting could turn auth on and immediately issue a session cookie to the same requester.
- The first-password path did not reuse the locality gate already used by onboarding setup.
- There was no regression test proving public/non-local bootstrap was denied before writing settings.

## After this PR

- Existing authenticated password changes keep using the normal settings flow.
- First password setup is denied for non-local clients while auth is disabled.
- First password setup from genuine loopback/local/private clients remains allowed.
- Operators who intentionally need remote bootstrap can opt in with `HERMES_WEBUI_ONBOARDING_OPEN=1`.
- Regression tests cover both the blocked public path and the preserved loopback setup path.

## Explicit operator choice

Default behavior:

```text
HERMES_WEBUI_ONBOARDING_OPEN unset or false
```

- First-run password setup is available from local/private clients only.
- Public/non-local unauthenticated `_set_password` requests receive `403` before settings are saved.

Explicit remote bootstrap behavior:

```text
HERMES_WEBUI_ONBOARDING_OPEN=1
```

- The operator explicitly permits remote first-run bootstrap, matching the existing onboarding bypass semantics.
- This is useful for intentionally remote setup, but it requires a conscious deployment choice instead of being the default behavior.

## Why this matters

The first password is an ownership boundary. If a fresh no-password WebUI is reachable over a LAN, tunnel, reverse proxy, container bind, or accidental public bind, the first remote client that reaches `/api/settings` should not be able to become the owner simply by posting `_set_password`.

The patch keeps the intended local-first setup path, but makes remote bootstrap an explicit operator decision.

## How this differs from related issue/PR

This is related to the same general auth/settings area as prior hardening around password changes and auth state transitions, but it fixes a different boundary:

- existing-auth flows protect changes after a password already exists;
- this PR protects the bootstrap moment before any password exists;
- the vulnerable condition is not “change someone else’s existing password,” but “be the first requester to set the initial password on a reachable no-password instance.”

Both paths matter because first-run setup establishes the initial trust root for later authenticated behavior.

## Attack flow

```text
Fresh Hermes WebUI starts with no password configured
    -> instance is reachable by a non-local client
        -> auth is disabled, so POST /api/settings is accepted without a session
            -> request includes _set_password
                -> password hash is persisted and a session is issued to the requester
                    -> intended operator can be locked out until state is reset
```

## Affected code

| Issue | Files |
|-------|-------|
| First-run password bootstrap not locality-gated | `api/routes.py`, `tests/test_security_review_fixes.py` |

## Root cause

Unauthenticated first-run password takeover through `POST /api/settings`:

- `POST /api/settings` intentionally remains reachable while auth is disabled.
- `_set_password` is ownership-establishing, but it previously shared the same unauthenticated path as ordinary settings while no password existed.
- The handler did not apply the existing onboarding locality gate before persisting the first password and issuing a session.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Unauthenticated first-run password takeover through `POST /api/settings` | 6.3 Medium | `AV:A/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L` |

Rationale:

- The score assumes a reachable same-network/local-deployment exposure, which fits the local-first deployment model and the patch’s local/private gate.
- Impact is bounded to deployments that start without auth configured and are reachable before the intended operator completes setup.
- If an operator exposes a no-password fresh instance directly over a public network, the effective attack surface is broader than the adjacent-network assumption above.

## Safe reproduction steps

### 1. Public/non-local first-password setup before the patch

1. Start Hermes WebUI with no `HERMES_WEBUI_PASSWORD` and a fresh settings state.
2. From a non-local client, send a `POST /api/settings` request containing `_set_password`.
3. Observe that the server accepts the request, persists a password hash, and allows login/session flow for that password.

### 2. Behavior after this PR

1. Simulate a non-local client posting `_set_password` while auth is disabled.
2. Observe `403` and confirm `save_settings()` is not called.
3. Simulate a genuine loopback client posting `_set_password` while auth is disabled.
4. Observe success and session cookie issuance, preserving local setup.

## Expected vulnerable behavior

On vulnerable code, a non-local unauthenticated requester could set the initial WebUI password through `/api/settings` before the intended operator did. The safe proof signal is that a password hash is written and the requester can receive/use a session for the newly configured password.

## Changes in this PR

- Adds a first-password guard in the `/api/settings` POST handler when auth was previously disabled.
- Reuses `_onboarding_gate_allows(handler)` for consistent local/private, trusted-forwarded-header, and explicit-bypass behavior.
- Returns `403` before saving settings when public/non-local first-password bootstrap is not allowed.
- Adds regression coverage for rejected public bootstrap before `save_settings()` runs.
- Adds regression coverage proving loopback first-password setup still succeeds and receives a session cookie.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| API hardening | `api/routes.py` | Gates `_set_password` while auth is disabled through the existing onboarding locality check. |
| Regression tests | `tests/test_security_review_fixes.py` | Adds public rejection and loopback success tests for first-password bootstrap. |

## Maintainer impact

- Scope is limited to the first-password branch of `POST /api/settings`.
- Existing authenticated settings/password changes are not changed.
- Same-host setup remains available without extra flags.
- Intentional remote bootstrap remains available through the existing `HERMES_WEBUI_ONBOARDING_OPEN=1` operator opt-in.
- No frontend, storage format, CLI, or dependency changes are introduced.

## Fix rationale

First password creation should be treated as bootstrap-sensitive, not as an ordinary unauthenticated setting. Reusing the existing onboarding gate keeps the implementation narrow and consistent with the project’s current local/private setup semantics.

The regression tests lock in the two important security properties:

- non-local unauthenticated bootstrap is rejected before persistence;
- local bootstrap remains functional for the normal first-run workflow.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Contract Routing

- Touched contract family: auth/settings first-run behavior.
- Evidence used: existing onboarding locality helper, `/api/settings` password-setting path, focused regression tests, and existing password-env-var/onboarding-network tests.
- Contract impact: first-password setup from non-local clients is now denied by default while auth is disabled; local/private setup and explicit remote opt-in remain supported.

## Test plan

- [x] Focused security regression tests for settings/auth hardening.
- [x] Combined password settings regression tests.
- [x] Existing onboarding network tests.
- [x] Whitespace diff check.
- [x] GitHub CI matrix and browser smoke checks on the PR.

Executed with:

```text
python3 -m pytest tests/test_security_review_fixes.py -q
14 passed, 1 warning in 2.52s

python3 -m pytest tests/test_security_review_fixes.py tests/test_1560_password_env_var_no_op.py -q
27 passed, 1 warning in 2.16s

python3 -m pytest tests/test_onboarding_network.py -q
18 passed, 1 warning in 2.04s

git diff --check
# no output
```

Current PR CI status observed after opening:

```text
browser-smoke: success
lint: success
test (3.11, 0): success
test (3.11, 1): success
test (3.11, 2): success
test (3.12, 0): success
test (3.12, 1): success
test (3.12, 2): success
test (3.13, 0): success
test (3.13, 1): success
test (3.13, 2): success
```

## Risks / Follow-ups

- The change intentionally blocks non-local first-password setup by default. Operators who rely on remote first-run setup should use `HERMES_WEBUI_ONBOARDING_OPEN=1` during bootstrap.
- This PR does not change the broader passwordless mode after an operator intentionally leaves auth disabled.
- This PR does not add a new bootstrap token mechanism; it uses the project’s existing onboarding locality/opt-in behavior for a narrow fix.

## Model Used

AI-assisted implementation and PR drafting: OpenAI `gpt-5.5` through the Hermes Agent environment, with local git/pytest/GitHub CLI tool use for validation and PR updates.

## Disclosure notes

- This PR is bounded to first-run password bootstrap through `POST /api/settings`.
- It does not claim compromise of instances that already have auth enabled.
- It does not claim exposure when the WebUI is only reachable by the intended same-host operator.
- No production systems were tested.
- No unrelated files were changed.
