### PR TITLE
fix(autocomplete): CJK prefix, multi-slash, selection, multi-skill loading

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf

--- a/static/boot.js
+++ b/static/boot.js
@@ -1296,7 +1296,8 @@ $('msg').addEventListener('input',()=>{
     _saveComposerDraft(sid, $('msg').value, S.pendingFiles ? [...S.pendingFiles] : []);
   }
   const text=$('msg').value;
-  if(text.startsWith('/')&&text.indexOf('\n')===-1){
+  const slashIdx=text.indexOf('/');
+  if(slashIdx>=0&&text.indexOf('\n')===-1){
     if(typeof getSlashAutocompleteMatches==='function'){
       getSlashAutocompleteMatches(text).then(matches=>{
         if(($('msg').value||'')!==text) return;

--- a/static/boot.js
+++ b/static/boot.js
@@ -1304,7 +1304,7 @@ $('msg').addEventListener('input',()=>{
         if(matches.length)showCmdDropdown(matches); else hideCmdDropdown();
       });
     }else{
-      const prefix=text.slice(1);
+      const prefix=text.slice(slashIdx+1);
       const matches=getMatchingCommands(prefix);
       if(matches.length)showCmdDropdown(matches); else hideCmdDropdown();
     }

--- a/static/commands.js
+++ b/static/commands.js
@@ -263,16 +263,30 @@ async function _runAgentCommandTransport(text,_meta){
   return String(data&&data.output||'(no output)');
 }
 
+let _currentAutocompleteBeforeSlash='';
+let _currentAutocompletePrefix='';
+
 function _parseSlashAutocomplete(text){
-  if(!text.startsWith('/')||text.indexOf('\n')!==-1) return null;
-  const raw=text.slice(1);
+  if(text.indexOf('\n')!==-1) return null;
+  const firstSlash=text.indexOf('/');
+  if(firstSlash<0) return null;
+  const beforeSlash=text.slice(0,firstSlash);
+  const raw=text.slice(firstSlash+1);
   const hasSpace=/\s/.test(raw);
   const parts=raw.split(/\s+/);
   const cmdName=(parts[0]||'').toLowerCase();
   const command=COMMANDS.find(c=>c.name===cmdName);
   const subArgSource=(command&&command.subArgs)?command:SLASH_SUBARG_SOURCES[cmdName];
   if(!hasSpace||!subArgSource){
-    return {kind:'commands', query:raw};
+    if(hasSpace&&!subArgSource){
+      const lastSlash=raw.lastIndexOf('/');
+      if(lastSlash>=0){
+        const betweenPrefix=raw.slice(0,lastSlash);
+        const afterLastSlash=raw.slice(lastSlash+1);
+        return {kind:'commands', query:afterLastSlash, beforeSlash:beforeSlash, prefix:betweenPrefix};
+      }
+    }
+    return {kind:'commands', query:raw, beforeSlash:beforeSlash, prefix:''};
   }
   const argText=raw.slice(cmdName.length).replace(/^\s+/,'');
   return {kind:'subargs', command:{name:cmdName, desc:subArgSource.desc, subArgs:subArgSource.subArgs}, query:argText.toLowerCase(), rawQuery:argText};
@@ -1515,7 +1529,7 @@ async function loadSkillCommands(force=false){
 function refreshSlashCommandDropdown(){
   const ta=$('msg');if(!ta)return;
   const text=ta.value||'';
-  if(!text.startsWith('/')||text.indexOf('\n')!==-1){hideCmdDropdown();return;}
+  if(text.indexOf('/')<0||text.indexOf('\n')!==-1){hideCmdDropdown();return;}
   getSlashAutocompleteMatches(text).then(matches=>{
     if(($('msg').value||'')!==text) return;
     if(matches.length)showCmdDropdown(matches);else hideCmdDropdown();
@@ -1578,11 +1592,19 @@ function showCmdDropdown(matches){
         return;
       }
       const nextValue=isSubArg?('/'+c.parent+' '+c.value):('/'+c.name+(c.arg?' ':''));
-      $('msg').value=nextValue;
+      const _b=_currentAutocompleteBeforeSlash||'';
+      const _p=_currentAutocompletePrefix||'';
+      const _trail=c.arg?' ':'';
+      if(_b||_p){
+        $('msg').value=_b+'/'+(_p?_p+'/':'')+c.name+_trail;
+      }else{
+        $('msg').value=nextValue;
+      }
       $('msg').focus();
       if(!isSubArg&&c.source!=='skill'&&nextValue.endsWith(' ')&&typeof getSlashAutocompleteMatches==='function'){
-        getSlashAutocompleteMatches(nextValue).then(matches=>{
-          if(($('msg').value||'')!==nextValue) return;
+        const _fullValue=$('msg').value;
+        getSlashAutocompleteMatches(_fullValue).then(matches=>{
+          if(($('msg').value||'')!==_fullValue) return;
           if(matches.length) showCmdDropdown(matches);
           else hideCmdDropdown();
         });

--- a/static/commands.js
+++ b/static/commands.js
@@ -297,7 +297,9 @@ function _parseSlashAutocomplete(text){
 
 async function getSlashAutocompleteMatches(text){
   const parsed=_parseSlashAutocomplete(text);
-  if(!parsed) return [];
+  if(!parsed){_currentAutocompleteBeforeSlash='';_currentAutocompletePrefix='';return [];}
+  _currentAutocompleteBeforeSlash=parsed.beforeSlash||'';
+  _currentAutocompletePrefix=parsed.prefix||'';
   if(parsed.kind==='commands') return getMatchingCommands(parsed.query);
   const options=await _getSlashSubArgOptions(parsed.command.subArgs);
   return options

--- a/static/commands.js
+++ b/static/commands.js
@@ -292,7 +292,7 @@ function _parseSlashAutocomplete(text){
     return {kind:'commands', query:raw, beforeSlash:beforeSlash, prefix:''};
   }
   const argText=raw.slice(cmdName.length).replace(/^\s+/,'');
-  return {kind:'subargs', command:{name:cmdName, desc:subArgSource.desc, subArgs:subArgSource.subArgs}, query:argText.toLowerCase(), rawQuery:argText};
+  return {kind:'subargs', command:{name:cmdName, desc:subArgSource.desc, subArgs:subArgSource.subArgs}, query:argText.toLowerCase(), rawQuery:argText, beforeSlash:beforeSlash, prefix:''};
 }
 
 async function getSlashAutocompleteMatches(text){
@@ -1601,7 +1601,9 @@ function showCmdDropdown(matches){
       const _p=_currentAutocompletePrefix||'';
       const _trail=c.arg?' ':'';
       if(_b||_p){
-        $('msg').value=_b+'/'+(_p?_p+'/':'')+c.name+_trail;
+        $('msg').value=isSubArg
+          ?_b+'/'+c.parent+' '+c.value
+          :_b+'/'+(_p?_p+'/':'')+c.name+_trail;
       }else{
         $('msg').value=nextValue;
       }

--- a/static/commands.js
+++ b/static/commands.js
@@ -273,19 +273,22 @@ function _parseSlashAutocomplete(text){
   const beforeSlash=text.slice(0,firstSlash);
   const raw=text.slice(firstSlash+1);
   const hasSpace=/\s/.test(raw);
+  // Multi-slash check runs before subArgs branch so that inputs like
+  // "/think /karpathy" are handled as a second slash-command lookup
+  // even when the first command (e.g. "think") has a subArgSource.
+  if(hasSpace){
+    const lastSlash=raw.lastIndexOf('/');
+    if(lastSlash>=0){
+      const betweenPrefix=raw.slice(0,lastSlash);
+      const afterLastSlash=raw.slice(lastSlash+1);
+      return {kind:'commands', query:afterLastSlash, beforeSlash:beforeSlash, prefix:betweenPrefix};
+    }
+  }
   const parts=raw.split(/\s+/);
   const cmdName=(parts[0]||'').toLowerCase();
   const command=COMMANDS.find(c=>c.name===cmdName);
   const subArgSource=(command&&command.subArgs)?command:SLASH_SUBARG_SOURCES[cmdName];
   if(!hasSpace||!subArgSource){
-    if(hasSpace&&!subArgSource){
-      const lastSlash=raw.lastIndexOf('/');
-      if(lastSlash>=0){
-        const betweenPrefix=raw.slice(0,lastSlash);
-        const afterLastSlash=raw.slice(lastSlash+1);
-        return {kind:'commands', query:afterLastSlash, beforeSlash:beforeSlash, prefix:betweenPrefix};
-      }
-    }
     return {kind:'commands', query:raw, beforeSlash:beforeSlash, prefix:''};
   }
   const argText=raw.slice(cmdName.length).replace(/^\s+/,'');

--- a/static/messages.js
+++ b/static/messages.js
@@ -1081,7 +1081,7 @@ async function send(){
       if(_afterMatch==='/') continue;
       const _raw=_m[1].toLowerCase();
       let _match=_skillCommandCache.find(s=>s.name===_raw);
-      if(!_match)_match=_skillCommandCache.find(s=>s.name.startsWith(_raw));
+      if(!_match&&_raw.length>=2)_match=_skillCommandCache.find(s=>s.name.startsWith(_raw));
       if(_match&&_match.source==='skill'&&!_seenSkills.has(_match.name)){
         _seenSkills.add(_match.name);
       }

--- a/static/messages.js
+++ b/static/messages.js
@@ -1072,6 +1072,26 @@ async function send(){
   }
   if(!msgText){setComposerStatus('Nothing to send');return;}
 
+  if(typeof _skillCommandCache!=='undefined'&&_skillCommandCache.length){
+    const _skillPattern=/\/([a-z][a-z0-9-]{1,63})\b/gi;
+    const _seenSkills=new Set();
+    let _m;
+    while((_m=_skillPattern.exec(text))!==null){
+      const _afterMatch=text[_m.index+_m[0].length];
+      if(_afterMatch==='/') continue;
+      const _raw=_m[1].toLowerCase();
+      let _match=_skillCommandCache.find(s=>s.name===_raw);
+      if(!_match)_match=_skillCommandCache.find(s=>s.name.startsWith(_raw));
+      if(_match&&_match.source==='skill'&&!_seenSkills.has(_match.name)){
+        _seenSkills.add(_match.name);
+      }
+    }
+    if(_seenSkills.size){
+      const _skillList=[..._seenSkills].join(', ');
+      msgText=`[MANDATORY: Before any other action, load these skills with skill_view(name) — do NOT skip: ${_skillList}]\n\n${msgText}`;
+    }
+  }
+
   $('msg').value='';autoResize();
   // Clear persisted composer draft since message was sent.
   if (activeSid && typeof _clearComposerDraft === 'function') _clearComposerDraft(activeSid);

--- a/tests/test_3965_autocomplete_cjk_selection.py
+++ b/tests/test_3965_autocomplete_cjk_selection.py
@@ -1,0 +1,127 @@
+"""Regression tests for PR #3965: autocomplete CJK prefix + selection preservation.
+
+Covers:
+- _parseSlashAutocomplete carries beforeSlash on all return paths (commands + subargs)
+- getSlashAutocompleteMatches assigns module-level state vars (P1-1 fix)
+- onmousedown has prefix-preserving reassembly for both command and subarg items
+- Multi-slash check fires before subArgs branch (P1-2 fix)
+- boot.js uses indexOf('/') not startsWith('/') (CJK fix)
+- boot.js fallback uses slashIdx+1 not hardcoded 1
+- subarg return path carries beforeSlash/prefix (Follow-up 2 fix)
+- onmousedown isSubArg branch uses c.parent+c.value not c.name (Follow-up 2 fix)
+"""
+from pathlib import Path
+import re
+
+COMMANDS_JS = (Path(__file__).parent.parent / "static" / "commands.js").read_text(encoding="utf-8")
+BOOT_JS = (Path(__file__).parent.parent / "static" / "boot.js").read_text(encoding="utf-8")
+
+
+def _function_block(src, name):
+    marker = re.search(rf"(^|\n)(?:async\s+)?function\s+{re.escape(name)}\(", src)
+    assert marker is not None, f"{name}() not found"
+    start = marker.start()
+    next_marker = re.search(r"\n(?:function\s+\w+\(|async\s+function\s+\w+\()", src[start + 1:])
+    end = start + 1 + next_marker.start() if next_marker else len(src)
+    return src[start:end]
+
+
+# ── P1-1 fix: state vars must be wired ─────────────────────────────────────
+
+def test_get_slash_autocomplete_matches_assigns_state_vars():
+    block = _function_block(COMMANDS_JS, "getSlashAutocompleteMatches")
+    assert "_currentAutocompleteBeforeSlash=" in block, (
+        "getSlashAutocompleteMatches must assign _currentAutocompleteBeforeSlash "
+        "so onmousedown can read a populated value"
+    )
+    assert "_currentAutocompletePrefix=" in block, (
+        "getSlashAutocompleteMatches must assign _currentAutocompletePrefix"
+    )
+
+
+def test_onmousedown_has_prefix_preserving_branch():
+    block = _function_block(COMMANDS_JS, "showCmdDropdown")
+    assert "_currentAutocompleteBeforeSlash" in block, (
+        "showCmdDropdown/onmousedown must read _currentAutocompleteBeforeSlash"
+    )
+    assert "_b+'/'" in block, (
+        "onmousedown must have prefix-preserving reassembly: _b + '/' + ..."
+    )
+
+
+# ── P1-2 fix: multi-slash before subArgs branch ────────────────────────────
+
+def test_multi_slash_check_before_subargs_branch():
+    block = _function_block(COMMANDS_JS, "_parseSlashAutocomplete")
+    # Use code-level identifiers (not comment text) to compare positions
+    last_slash_pos = block.find("const lastSlash=raw.lastIndexOf")
+    subarg_source_pos = block.find("const subArgSource=")
+    assert last_slash_pos >= 0, "const lastSlash=raw.lastIndexOf not found in _parseSlashAutocomplete"
+    assert subarg_source_pos >= 0, "const subArgSource= not found in _parseSlashAutocomplete"
+    assert last_slash_pos < subarg_source_pos, (
+        "Multi-slash lastIndexOf('/') check must appear before subArgSource= assignment "
+        "so inputs like /think /karpathy are handled correctly"
+    )
+
+
+# ── Commands return paths carry beforeSlash ────────────────────────────────
+
+def test_parse_slash_autocomplete_carries_beforeSlash_on_commands_paths():
+    block = _function_block(COMMANDS_JS, "_parseSlashAutocomplete")
+    # Count how many return statements include beforeSlash
+    returns_with_beforeslash = re.findall(r"return\s*\{[^}]*beforeSlash\s*:", block)
+    assert len(returns_with_beforeslash) >= 2, (
+        "_parseSlashAutocomplete must carry beforeSlash on at least 2 return paths "
+        "(multi-slash and single-slash commands paths)"
+    )
+
+
+# ── Follow-up 2: subargs return carries beforeSlash/prefix ────────────────
+
+def test_subargs_return_carries_beforeSlash():
+    block = _function_block(COMMANDS_JS, "_parseSlashAutocomplete")
+    # Use DOTALL to match the full multi-property return object
+    subargs_return = re.search(r"return\s*\{kind:'subargs'.*?;", block, re.DOTALL)
+    assert subargs_return is not None, "kind:'subargs' return not found"
+    subargs_return_text = subargs_return.group(0)
+    assert "beforeSlash" in subargs_return_text, (
+        "subargs return must include beforeSlash so CJK prefix is preserved "
+        "when user selects a sub-argument (e.g. /think budget)"
+    )
+    assert "prefix" in subargs_return_text, (
+        "subargs return must include prefix"
+    )
+
+
+def test_onmousedown_subarg_branch_uses_parent_and_value():
+    block = _function_block(COMMANDS_JS, "showCmdDropdown")
+    # The isSubArg branch inside if(_b||_p) must use c.parent and c.value, not just c.name
+    assert "c.parent" in block, (
+        "onmousedown must reference c.parent for subarg reconstruction"
+    )
+    # The prefix-preserving branch must handle isSubArg with c.parent+' '+c.value
+    assert "isSubArg" in block and "c.parent" in block and "c.value" in block, (
+        "onmousedown prefix-preserving branch must handle isSubArg using "
+        "c.parent + ' ' + c.value (not just c.name)"
+    )
+
+
+# ── boot.js CJK + fallback offset fixes ───────────────────────────────────
+
+def test_boot_js_uses_slashIdx_not_startsWith():
+    input_handler_pos = BOOT_JS.find("addEventListener('input'")
+    assert input_handler_pos >= 0, "input event listener not found in boot.js"
+    handler_section = BOOT_JS[input_handler_pos:input_handler_pos + 600]
+    assert "startsWith('/')" not in handler_section, (
+        "boot.js input handler must not use startsWith('/') — breaks CJK prefix"
+    )
+    assert "slashIdx=text.indexOf('/')" in BOOT_JS, (
+        "boot.js must use slashIdx=text.indexOf('/')"
+    )
+
+
+def test_boot_js_fallback_uses_slashIdx_offset():
+    assert "text.slice(slashIdx+1)" in BOOT_JS, (
+        "boot.js fallback branch must use text.slice(slashIdx+1) not text.slice(1) "
+        "— when slashIdx>0 the old offset 1 strips leading non-slash characters"
+    )


### PR DESCRIPTION
## Summary

This PR fixes four autocomplete bugs that degrade the slash-command UX, especially for users with CJK text in the composer or multiple skill commands in a single message.

The previous submission was blocked by two accidental regressions (CRLF line endings + ~62 missing functions from an old Docker container image). This revision rebases cleanly onto `origin/master` (`85d0e52`) and cherry-picks only the four intended hunks. Diff is 51 insertions / 8 deletions across 3 files; a `.gitattributes` entry enforces LF going forward.

---

## Bugs Fixed

### Bug 1 — Multi-slash dropdown disappears after first command

**Symptom:** Typing `/superpowers /kar` — the dropdown shows for the first slash, then vanishes when you continue after the space.

**Root cause:** `_parseSlashAutocomplete` used the entire `raw` string (e.g. `superpowers /kar`) as the query, which matched nothing.

**Fix (`commands.js`):** When the input contains a space but no subarg source, scan for a trailing `/` and use only the text after it as the query. Also tracks `beforeSlash` and `prefix` so multi-slash context is preserved.

---

### Bug 2 — Agent unreliably loads skills from slash commands

**Symptom:** User sends `/superpowers /karpathy-guidelines` — agent loads one or neither skill, or ignores them entirely.

**Root cause:** No frontend mechanism to signal the agent which skills to preload. The agent guesses.

**Fix (`messages.js`):** On `send()`, the input text is scanned for `/skillname` tokens. Each token that resolves to a cached skill entry (`source === 'skill'`) is collected. If any are found, a `[MANDATORY: … load these skills with skill_view(name)]` directive is prepended to `msgText` before the API call.

**On the `startsWith` prefix fallback (reviewer's correctness note):**

I tested this in production and the UX tradeoff is intentional:

- **Test group A:** Type `/sup` → dropdown shows → input becomes `/superpowers`. Then immediately type `/kar` (no space between) → no dropdown fires for `/kar`. ✅ No spurious `/api/sup`-style false positive here.
- **Test group B:** Type `/sup` → select `superpowers` from dropdown → then type a **space** + `/kar` → dropdown fires correctly for `/kar`. ✅ Multi-skill flow works.

The `startsWith` fallback exists specifically for Test B's second slash: after selecting the first skill the user types a prefix of the second. At that point `onmousedown` has written the full first-skill name, so `send()` sees `/superpowers /kar`; exact-match on `kar` finds nothing — only `startsWith` catches `karpathy-guidelines`.

A pure exact-match would silently drop skill preloading for any user who types a prefix rather than a full skill name — which is the common case (skill names are long, muscle memory is fast).

The goal is first-class parity with Claude Code / Codex slash-command UX: users should never need to memorise exact skill names, copy-paste them, or type the full name just to trigger a preload.

**The URL false-positive concern is addressed by a one-line guard:**
```js
const _afterMatch = text[_m.index + _m[0].length];
if (_afterMatch === '/') continue;  // URL path segment — skip
```
`/api/supplyInfo` → captures `api`, but `_afterMatch` is `/` → skipped. No injection occurs.

---

### Bug 3 — Selecting from dropdown replaces the entire input

**Symptom:** `/superpowers issue 1323, /kar` → select `karpathy-guidelines` from dropdown → input becomes `/karpathy-guidelines`. Everything before is lost.

**Root cause:** `onmousedown` did an unconditional `$('msg').value = '/' + c.name`.

**Fix (`commands.js`):** Uses `_currentAutocompleteBeforeSlash` and `_currentAutocompletePrefix` state tracked by `_parseSlashAutocomplete`. When these are set, the new value is assembled as `beforeSlash + '/' + [prefix+'/'] + name` instead of replacing the whole input.

---

### Bug 4 — CJK or any text before `/` blocks autocomplete entirely

**Symptom:** `如果我说 /supe` or `请你使用 /s` → no dropdown appears.

**Root cause:** `boot.js` and `commands.js` both checked `text.startsWith('/')`. Any non-slash prefix killed the feature.

**Fix:**
- `boot.js`: `startsWith('/')` → `indexOf('/')` + `>= 0` check
- `commands.js` `_parseSlashAutocomplete`: same — find first `/` anywhere, split `beforeSlash` / `raw` at that index
- `commands.js` `refreshSlashCommandDropdown`: guard updated to match

---

## Files Changed

| File | Change |
|------|--------|
| `static/boot.js` | 2 lines: `startsWith('/') → indexOf('/')` |
| `static/commands.js` | `_parseSlashAutocomplete` rewrite, `_currentAutocompleteBeforeSlash/Prefix` state, `onmousedown` input preservation, `refreshSlashCommandDropdown` guard |
| `static/messages.js` | `send()` skill scan + MANDATORY preload injection with URL-path guard |
| `.gitattributes` | `*.js text eol=lf` — prevents CRLF recurrence on Windows |

Total diff: **51 insertions, 8 deletions** (vs ~6990 in the previous submission).

---

## Verification

```bash
# Syntax
node -c static/boot.js && node -c static/commands.js && node -c static/messages.js

# Line endings — all must print LF
python -c "
for f in ['static/boot.js','static/commands.js','static/messages.js']:
    d=open(f,'rb').read(); print(f,'CRLF' if b'\\r\\n' in d else 'LF')
"

# Functions that must not have been removed
grep -c 'enhanceMarkdownTables' static/messages.js          # ≥1
grep -c '_extractInlineThinkingFromContent' static/messages.js  # ≥1
grep -c '_probeServerSttCapability' static/boot.js          # ≥1
grep -c "name:'use'" static/commands.js                     # ≥1
```
