### PR TITLE
[security] fix(oauth): reuse pending onboarding flows

### DIFF
--- a/api/oauth.py
+++ b/api/oauth.py
@@ -59,6 +59,41 @@ _OAUTH_FLOWS_LOCK = threading.Lock()
 _ANTHROPIC_ENV_KEYS = ("ANTHROPIC_TOKEN", "ANTHROPIC_API_KEY")
 
 
+def _pending_oauth_flow_for_locked(provider: str, hermes_home: Path) -> tuple[str, dict[str, Any]] | None:
+    """Return an existing live onboarding OAuth flow for the provider/profile.
+
+    Onboarding OAuth starts are unauthenticated while first-run auth is disabled.
+    Keep them single-flight per provider/profile so repeated start requests reuse
+    the existing worker instead of accumulating pending flows and daemon threads.
+
+    The caller must hold _OAUTH_FLOWS_LOCK so the check can be paired atomically
+    with flow insertion on start paths.
+    """
+    canonical_provider = _normalize_onboarding_oauth_provider(provider)
+    canonical_home = str(Path(hermes_home))
+    now = time.time()
+    for flow_id, flow in _OAUTH_FLOWS.items():
+        if flow.get("provider") != canonical_provider:
+            continue
+        if str(flow.get("hermes_home") or "") != canonical_home:
+            continue
+        if flow.get("status") != "pending":
+            continue
+        if float(flow.get("expires_at") or 0) <= now:
+            flow["status"] = "expired"
+            flow["updated_at"] = now
+            _drop_sensitive_flow_fields(flow)
+            continue
+        return flow_id, dict(flow)
+    return None
+
+
+def _pending_oauth_flow_for(provider: str, hermes_home: Path) -> tuple[str, dict[str, Any]] | None:
+    """Return an existing live onboarding OAuth flow for the provider/profile, if any."""
+    with _OAUTH_FLOWS_LOCK:
+        return _pending_oauth_flow_for_locked(provider, hermes_home)
+
+
 def _clear_process_anthropic_env_values() -> None:
     """Clear Anthropic process env fallbacks under the streaming env lock."""
     from api.streaming import _ENV_LOCK
@@ -687,6 +722,10 @@ def _start_anthropic_flow(hermes_home: Path) -> dict[str, Any]:
         "updated_at": time.time(),
     }
     with _OAUTH_FLOWS_LOCK:
+        existing = _pending_oauth_flow_for_locked("anthropic", hermes_home)
+        if existing is not None:
+            flow_id, flow = existing
+            return _public_start_payload(flow_id, flow)
         _OAUTH_FLOWS[flow_id] = flow
     _spawn_anthropic_credential_worker(flow_id)
     return _public_start_payload(flow_id, flow)
@@ -714,32 +753,37 @@ def start_onboarding_oauth_flow(body: dict[str, Any] | None) -> dict[str, Any]:
 
     # Codex flow
     hermes_home = _get_active_hermes_home()
-    try:
-        device = _request_codex_user_code()
-    except Exception as exc:
-        raise RuntimeError(f"Failed to start Codex OAuth: {exc}") from exc
-
-    user_code = str(device.get("user_code") or "").strip()
-    device_auth_id = str(device.get("device_auth_id") or "").strip()
-    if not user_code or not device_auth_id:
-        raise RuntimeError("Device code response missing required fields")
-
-    interval = max(3, int(device.get("interval") or 5))
-    expires_in = int(device.get("expires_in") or CODEX_FLOW_MAX_WAIT_SECONDS)
-    expires_at = time.time() + min(max(expires_in, 60), CODEX_FLOW_MAX_WAIT_SECONDS)
-    flow_id = uuid.uuid4().hex
-    flow = {
-        "provider": "openai-codex",
-        "status": "pending",
-        "device_auth_id": device_auth_id,
-        "user_code": user_code,
-        "expires_at": expires_at,
-        "poll_interval_seconds": interval,
-        "hermes_home": str(hermes_home),
-        "created_at": time.time(),
-        "updated_at": time.time(),
-    }
     with _OAUTH_FLOWS_LOCK:
+        existing = _pending_oauth_flow_for_locked("openai-codex", hermes_home)
+        if existing is not None:
+            flow_id, flow = existing
+            return _public_start_payload(flow_id, flow)
+
+        try:
+            device = _request_codex_user_code()
+        except Exception as exc:
+            raise RuntimeError(f"Failed to start Codex OAuth: {exc}") from exc
+
+        user_code = str(device.get("user_code") or "").strip()
+        device_auth_id = str(device.get("device_auth_id") or "").strip()
+        if not user_code or not device_auth_id:
+            raise RuntimeError("Device code response missing required fields")
+
+        interval = max(3, int(device.get("interval") or 5))
+        expires_in = int(device.get("expires_in") or CODEX_FLOW_MAX_WAIT_SECONDS)
+        expires_at = time.time() + min(max(expires_in, 60), CODEX_FLOW_MAX_WAIT_SECONDS)
+        flow_id = uuid.uuid4().hex
+        flow = {
+            "provider": "openai-codex",
+            "status": "pending",
+            "device_auth_id": device_auth_id,
+            "user_code": user_code,
+            "expires_at": expires_at,
+            "poll_interval_seconds": interval,
+            "hermes_home": str(hermes_home),
+            "created_at": time.time(),
+            "updated_at": time.time(),
+        }
         _OAUTH_FLOWS[flow_id] = flow
     _spawn_codex_oauth_worker(flow_id)
     return _public_start_payload(flow_id, flow)

--- a/api/oauth.py
+++ b/api/oauth.py
@@ -56,7 +56,25 @@ ANTHROPIC_PUBLIC_LINK_ERROR = "Claude Code credential linking failed. Check serv
 
 _OAUTH_FLOWS: dict[str, dict[str, Any]] = {}
 _OAUTH_FLOWS_LOCK = threading.Lock()
+_OAUTH_START_LOCKS: dict[tuple[str, str], threading.Lock] = {}
+_OAUTH_START_LOCKS_LOCK = threading.Lock()
 _ANTHROPIC_ENV_KEYS = ("ANTHROPIC_TOKEN", "ANTHROPIC_API_KEY")
+
+
+def _oauth_start_key(provider: str, hermes_home: Path) -> tuple[str, str]:
+    """Return the canonical single-flight key for onboarding OAuth starts."""
+    return (_normalize_onboarding_oauth_provider(provider), str(Path(hermes_home)))
+
+
+def _oauth_start_lock(provider: str, hermes_home: Path) -> threading.Lock:
+    """Return the per provider/profile lock that serializes OAuth flow creation."""
+    key = _oauth_start_key(provider, hermes_home)
+    with _OAUTH_START_LOCKS_LOCK:
+        lock = _OAUTH_START_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _OAUTH_START_LOCKS[key] = lock
+        return lock
 
 
 def _pending_oauth_flow_for_locked(provider: str, hermes_home: Path) -> tuple[str, dict[str, Any]] | None:
@@ -753,11 +771,16 @@ def start_onboarding_oauth_flow(body: dict[str, Any] | None) -> dict[str, Any]:
 
     # Codex flow
     hermes_home = _get_active_hermes_home()
-    with _OAUTH_FLOWS_LOCK:
-        existing = _pending_oauth_flow_for_locked("openai-codex", hermes_home)
-        if existing is not None:
-            flow_id, flow = existing
-            return _public_start_payload(flow_id, flow)
+    # Serialize check -> device-code request -> flow insertion -> worker spawn
+    # for this provider/profile. The global flow lock is still held only for
+    # short in-memory checks/inserts, so unrelated polling/status/cleanup paths
+    # are not blocked by the slow provider request.
+    with _oauth_start_lock("openai-codex", hermes_home):
+        with _OAUTH_FLOWS_LOCK:
+            existing = _pending_oauth_flow_for_locked("openai-codex", hermes_home)
+            if existing is not None:
+                flow_id, flow = existing
+                return _public_start_payload(flow_id, flow)
 
         try:
             device = _request_codex_user_code()
@@ -784,9 +807,15 @@ def start_onboarding_oauth_flow(body: dict[str, Any] | None) -> dict[str, Any]:
             "created_at": time.time(),
             "updated_at": time.time(),
         }
-        _OAUTH_FLOWS[flow_id] = flow
-    _spawn_codex_oauth_worker(flow_id)
-    return _public_start_payload(flow_id, flow)
+        with _OAUTH_FLOWS_LOCK:
+            existing = _pending_oauth_flow_for_locked("openai-codex", hermes_home)
+            if existing is not None:
+                flow_id, flow = existing
+                return _public_start_payload(flow_id, flow)
+            _OAUTH_FLOWS[flow_id] = flow
+
+        _spawn_codex_oauth_worker(flow_id)
+        return _public_start_payload(flow_id, flow)
 
 
 def poll_onboarding_oauth_flow(flow_id: str) -> dict[str, Any]:

--- a/tests/test_onboarding_oauth_single_flight.py
+++ b/tests/test_onboarding_oauth_single_flight.py
@@ -9,11 +9,15 @@ import api.oauth as oauth
 def setup_function():
     with oauth._OAUTH_FLOWS_LOCK:
         oauth._OAUTH_FLOWS.clear()
+    with oauth._OAUTH_START_LOCKS_LOCK:
+        oauth._OAUTH_START_LOCKS.clear()
 
 
 def teardown_function():
     with oauth._OAUTH_FLOWS_LOCK:
         oauth._OAUTH_FLOWS.clear()
+    with oauth._OAUTH_START_LOCKS_LOCK:
+        oauth._OAUTH_START_LOCKS.clear()
 
 
 def _run_two_concurrent(fn):
@@ -98,6 +102,29 @@ def test_codex_onboarding_oauth_start_reuses_pending_flow_before_requesting_code
     with oauth._OAUTH_FLOWS_LOCK:
         pending = [flow for flow in oauth._OAUTH_FLOWS.values() if flow.get("status") == "pending"]
     assert len(pending) == 1
+
+
+def test_codex_onboarding_oauth_start_does_not_hold_lock_while_requesting_code(monkeypatch, tmp_path):
+    """The slow Codex device-code request must not block unrelated flow operations."""
+    lock_available_during_request = []
+    hermes_home = tmp_path / "hermes-home"
+
+    monkeypatch.setattr(oauth, "_get_active_hermes_home", lambda: Path(hermes_home))
+    monkeypatch.setattr(oauth, "_spawn_codex_oauth_worker", lambda flow_id: None)
+
+    def fake_request_code():
+        acquired = oauth._OAUTH_FLOWS_LOCK.acquire(blocking=False)
+        lock_available_during_request.append(acquired)
+        if acquired:
+            oauth._OAUTH_FLOWS_LOCK.release()
+        return {"user_code": "ABCD-EFGH", "device_auth_id": "device-1", "interval": 5, "expires_in": 900}
+
+    monkeypatch.setattr(oauth, "_request_codex_user_code", fake_request_code)
+
+    result = oauth.start_onboarding_oauth_flow({"provider": "openai-codex"})
+
+    assert result["status"] == "pending"
+    assert lock_available_during_request == [True]
 
 
 def test_codex_onboarding_oauth_start_single_flight_is_thread_safe(monkeypatch, tmp_path):

--- a/tests/test_onboarding_oauth_single_flight.py
+++ b/tests/test_onboarding_oauth_single_flight.py
@@ -1,0 +1,129 @@
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import threading
+import time
+
+import api.oauth as oauth
+
+
+def setup_function():
+    with oauth._OAUTH_FLOWS_LOCK:
+        oauth._OAUTH_FLOWS.clear()
+
+
+def teardown_function():
+    with oauth._OAUTH_FLOWS_LOCK:
+        oauth._OAUTH_FLOWS.clear()
+
+
+def _run_two_concurrent(fn):
+    ready = threading.Barrier(2)
+
+    def wrapped():
+        ready.wait(timeout=5)
+        return fn()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(wrapped), executor.submit(wrapped)]
+        return [future.result(timeout=5) for future in futures]
+
+
+def test_anthropic_onboarding_oauth_start_reuses_pending_flow(monkeypatch, tmp_path):
+    """Repeated unauthenticated starts must not spawn unbounded pending workers."""
+    spawned = []
+    hermes_home = tmp_path / "hermes-home"
+
+    monkeypatch.setattr(oauth, "_read_claude_code_credentials", lambda: None)
+    monkeypatch.setattr(oauth, "_spawn_anthropic_credential_worker", lambda flow_id: spawned.append(flow_id))
+
+    first = oauth._start_anthropic_flow(hermes_home)
+    second = oauth._start_anthropic_flow(hermes_home)
+
+    assert first["status"] == "pending"
+    assert second["status"] == "pending"
+    assert second["flow_id"] == first["flow_id"]
+    assert spawned == [first["flow_id"]]
+    with oauth._OAUTH_FLOWS_LOCK:
+        pending = [flow for flow in oauth._OAUTH_FLOWS.values() if flow.get("status") == "pending"]
+    assert len(pending) == 1
+
+
+def test_anthropic_onboarding_oauth_start_single_flight_is_thread_safe(monkeypatch, tmp_path):
+    """Concurrent unauthenticated Anthropic starts must reserve one pending worker atomically."""
+    spawned = []
+    hermes_home = tmp_path / "hermes-home"
+    credential_reads = threading.Barrier(2)
+
+    def no_credentials():
+        credential_reads.wait(timeout=5)
+        return None
+
+    monkeypatch.setattr(oauth, "_read_claude_code_credentials", no_credentials)
+    monkeypatch.setattr(oauth, "_spawn_anthropic_credential_worker", lambda flow_id: spawned.append(flow_id))
+
+    first, second = _run_two_concurrent(lambda: oauth._start_anthropic_flow(hermes_home))
+
+    assert first["status"] == "pending"
+    assert second["status"] == "pending"
+    assert second["flow_id"] == first["flow_id"]
+    assert spawned == [first["flow_id"]]
+    with oauth._OAUTH_FLOWS_LOCK:
+        pending = [flow for flow in oauth._OAUTH_FLOWS.values() if flow.get("status") == "pending"]
+    assert len(pending) == 1
+
+
+def test_codex_onboarding_oauth_start_reuses_pending_flow_before_requesting_code(monkeypatch, tmp_path):
+    """A second Codex start should reuse the live flow before creating a new device code or worker."""
+    spawned = []
+    requested = []
+    hermes_home = tmp_path / "hermes-home"
+
+    monkeypatch.setattr(oauth, "_get_active_hermes_home", lambda: Path(hermes_home))
+
+    def fake_request_code():
+        requested.append(True)
+        return {"user_code": "ABCD-EFGH", "device_auth_id": "device-1", "interval": 5, "expires_in": 900}
+
+    monkeypatch.setattr(oauth, "_request_codex_user_code", fake_request_code)
+    monkeypatch.setattr(oauth, "_spawn_codex_oauth_worker", lambda flow_id: spawned.append(flow_id))
+
+    first = oauth.start_onboarding_oauth_flow({"provider": "openai-codex"})
+    second = oauth.start_onboarding_oauth_flow({"provider": "openai-codex"})
+
+    assert first["status"] == "pending"
+    assert second["flow_id"] == first["flow_id"]
+    assert second["user_code"] == "ABCD-EFGH"
+    assert requested == [True]
+    assert spawned == [first["flow_id"]]
+    with oauth._OAUTH_FLOWS_LOCK:
+        pending = [flow for flow in oauth._OAUTH_FLOWS.values() if flow.get("status") == "pending"]
+    assert len(pending) == 1
+
+
+def test_codex_onboarding_oauth_start_single_flight_is_thread_safe(monkeypatch, tmp_path):
+    """Concurrent Codex starts must request one device code and spawn one worker."""
+    spawned = []
+    requested = []
+    hermes_home = tmp_path / "hermes-home"
+
+    monkeypatch.setattr(oauth, "_get_active_hermes_home", lambda: Path(hermes_home))
+
+    def fake_request_code():
+        requested.append(True)
+        time.sleep(0.05)
+        return {"user_code": "ABCD-EFGH", "device_auth_id": "device-1", "interval": 5, "expires_in": 900}
+
+    monkeypatch.setattr(oauth, "_request_codex_user_code", fake_request_code)
+    monkeypatch.setattr(oauth, "_spawn_codex_oauth_worker", lambda flow_id: spawned.append(flow_id))
+
+    first, second = _run_two_concurrent(lambda: oauth.start_onboarding_oauth_flow({"provider": "openai-codex"}))
+
+    assert first["status"] == "pending"
+    assert second["status"] == "pending"
+    assert second["flow_id"] == first["flow_id"]
+    assert second["user_code"] == "ABCD-EFGH"
+    assert requested == [True]
+    assert spawned == [first["flow_id"]]
+    with oauth._OAUTH_FLOWS_LOCK:
+        pending = [flow for flow in oauth._OAUTH_FLOWS.values() if flow.get("status") == "pending"]
+    assert len(pending) == 1


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI exposes onboarding helpers before password/session authentication is configured.
- `POST /api/onboarding/oauth/start` starts background provider polling so the UI can detect completed CLI OAuth setup.
- Repeated unauthenticated start requests for the same provider/profile should not spawn unbounded duplicate pending flows.
- This PR makes onboarding OAuth start single-flight for a provider/profile and adds regression tests for both Anthropic and OpenAI Codex onboarding flows.
- The result is the same frontend contract for normal users, while repeated starts reuse the active pending flow instead of creating more workers.

## Summary

This PR hardens the unauthenticated onboarding OAuth start boundary.

- Fixes a Medium availability issue where repeated onboarding OAuth start requests could create many pending OAuth flows and worker threads.
- Reuses an existing live pending flow for the same provider and Hermes home instead of starting duplicate work.
- Covers both `anthropic` and `openai-codex` onboarding providers with regression tests.
- Keeps the existing successful response shape so the current UI flow does not need a frontend change.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Unauthenticated onboarding OAuth start allowed duplicate pending flows and worker-thread creation | A client that can reach the WebUI onboarding endpoint could repeatedly start equivalent pending OAuth flows, causing linear background worker/thread growth and local resource pressure. | Medium |

## Before this PR

- Each unauthenticated `POST /api/onboarding/oauth/start` request for a provider with no completed credentials created a new in-memory flow.
- Anthropic onboarding spawned a new credential polling worker for every duplicate start request.
- OpenAI Codex onboarding could request a new device code and spawn a new polling worker for duplicate starts.
- Existing tests did not assert that repeated starts are bounded or single-flight.

## After this PR

- `start_onboarding_oauth_flow()` now checks for a live pending flow for the same provider and Hermes home before starting provider-specific work.
- Duplicate Anthropic and OpenAI Codex starts return the existing pending flow response instead of creating another flow or worker.
- Regression tests lock in the single-flight behavior for both supported onboarding OAuth providers.

## Why this matters

The onboarding OAuth endpoint is intentionally reachable before a normal authenticated session exists. That makes admission control and bounded background work important: an unauthenticated client that can reach the local/Docker WebUI should not be able to create unbounded equivalent OAuth workers by replaying the same start request.

## How this differs from related issue/PR

This is separate from prior first-run settings/password hardening such as #3964. That issue covered who may set the initial password. This PR covers a different unauthenticated onboarding code path: duplicate OAuth start requests that create pending flows and background polling workers before normal auth is configured.

## Attack flow

```text
client reaches the onboarding WebUI HTTP endpoint
    -> repeatedly POSTs /api/onboarding/oauth/start for the same provider
        -> no live-flow admission check exists before starting provider work
            -> duplicate pending flows and polling workers are created
                -> local process threads/background work grow with request count
```

## Affected code

| Issue | Files |
|-------|-------|
| Duplicate onboarding OAuth pending flows and workers | `api/oauth.py`, `tests/test_onboarding_oauth_single_flight.py` |

## Root cause

Issue: unauthenticated onboarding OAuth start allowed duplicate pending flows and worker-thread creation.

- The OAuth flow registry tracked flow IDs after creation, but start did not first check whether an equivalent pending flow already existed for the provider/profile.
- Provider-specific work, including worker creation, happened for every duplicate start request.
- Cleanup only removed expired or terminal flows; it did not bound live duplicate pending work.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Duplicate onboarding OAuth pending flows and workers | 5.3 Medium | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L` |

Rationale:

- The impact is availability/resource pressure in the WebUI process, not code execution or data disclosure.
- The endpoint is HTTP-reachable in local/Docker deployments and can be unauthenticated during onboarding/no-password states.
- Scope remains unchanged and the demonstrated effect is bounded to low availability impact.

## Safe reproduction steps

### Vulnerable behavior before this PR

1. Start a no-password Hermes WebUI instance in an isolated Docker/home directory.
2. Send repeated requests such as:

   ```bash
   curl -sS -X POST http://127.0.0.1:8787/api/onboarding/oauth/start \
     -H 'Content-Type: application/json' \
     --data '{"provider":"anthropic"}'
   ```

3. Repeat the request many times and observe each response returning a distinct pending `flow_id`.
4. Inspect the WebUI process thread count and observe thread growth proportional to the number of duplicate pending Anthropic starts.

### Expected fixed behavior after this PR

1. Start the patched WebUI instance in the same isolated Docker/home setup.
2. Send the same repeated request sequence.
3. Observe that duplicate requests return the same pending `flow_id` for the provider/profile and do not create a new worker for each replay.

## Expected vulnerable behavior

- A replayed start request for the same provider/profile should not start equivalent new background work while a live pending flow already exists.
- Pre-patch behavior allowed repeated requests to create distinct pending flows and worker threads.
- In local Docker validation, 25 duplicate Anthropic starts produced 25 pending flows and grew the WebUI process from 3 to 28 threads.

## Changes in this PR

- Adds `_find_pending_oauth_flow()` to locate a non-expired pending OAuth flow for the same provider and Hermes home.
- Checks that helper before starting Anthropic credential polling.
- Checks that helper before requesting an OpenAI Codex device code or spawning its polling worker.
- Adds regression tests proving duplicate Anthropic and OpenAI Codex starts reuse one pending flow and start provider-specific work only once.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Security fix | `api/oauth.py` | Adds provider/profile pending-flow lookup and reuses live pending onboarding OAuth flows. |
| Tests | `tests/test_onboarding_oauth_single_flight.py` | Adds Anthropic and OpenAI Codex single-flight regression coverage. |

## Maintainer impact

- Scope is limited to onboarding OAuth start behavior.
- No new dependencies, frontend build step, storage schema, or UI changes are introduced.
- Normal first start behavior is preserved.
- Duplicate starts keep the existing `ok: true`, `status: pending`, and `flow_id` response shape, but now return the active flow instead of creating another one.

## Fix rationale

- The narrowest durable boundary is at OAuth flow admission: before provider-specific requests or worker creation.
- Reusing the active pending flow preserves the current client contract and avoids introducing new frontend error handling for normal retry/double-click cases.
- Matching by provider and Hermes home prevents one profile's pending onboarding flow from being reused for another profile.
- The tests assert both the public return behavior and that provider-specific work is only started once.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Verification

Targeted tests:

- [x] `python3.11 -m pytest tests/test_onboarding_oauth_single_flight.py tests/test_issue1362_codex_oauth_onboarding.py`
- [x] `python3.11 -m pytest tests/test_issue1499_keyless_onboarding.py tests/test_issue1499_onboarding_probe.py tests/test_onboarding_mvp.py`
- [x] `python3.11 -m pytest tests/test_issue1202_oauth_provider_status.py`
- [x] `python3.11 -m compileall -q api/oauth.py tests/test_onboarding_oauth_single_flight.py`

Docker validation:

- [x] Built patched image with `docker build -t hermes-webui-oauth-fix:c77c8312 --build-arg HERMES_VERSION=c77c8312 .`
- [x] Ran patched WebUI with isolated throwaway `HERMES_HOME` and workspace mounts.
- [x] Sent 25 unauthenticated `POST /api/onboarding/oauth/start` requests with `{"provider":"anthropic"}`.
- [x] Observed 25 responses, 1 unique `flow_id`, and server process thread count `3 -> 4` instead of pre-patch `3 -> 28`.

Full suite:

- [ ] `python3.11 -m pytest tests/ -v --timeout=60`

Full suite result in this checkout: 8,585 passed, 22 skipped, 3 xpassed, 16 subtests passed, 2 failed. The failing tests were `tests/test_issue3623_profile_visibility.py::test_profile_yaml_visible_false_is_exposed_as_hidden` and `tests/test_profile_skills_stats.py::test_get_profile_skills_stats`; they are profile/skills visibility assertions and do not touch the onboarding OAuth path changed here.

## Risks / Follow-ups

- Returning the existing pending flow means two browser tabs in the same profile/provider share the same onboarding attempt, which matches the intended single local onboarding flow and avoids duplicate background work.
- This PR does not add a broader global rate limiter for all unauthenticated onboarding endpoints; it only bounds duplicate OAuth starts for the same provider/profile.
- If maintainers prefer explicit admission errors, this could be changed to return `409` or `429`, but that would require frontend handling changes.

## Disclosure notes

- This PR keeps claims limited to the local/Docker WebUI onboarding endpoint and the observed pending-flow/worker-thread behavior.
- No production system was tested.
- No real OAuth credentials, tokens, API keys, passwords, or hashes are included.
- No unrelated files were changed.
