### PR TITLE
Hide Worklog reasoning when Thinking is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@
 - **Internal Stable Assistant Turn Anchors Phase 0 scaffold.** The browser now ships an inert `HermesAssistantTurnAnchors` helper surface plus a documented state-layer inventory for #3926, pinning current live/replay/settled source classifications and event dedupe precedence without changing visible chat rendering.
 - **New RFC: Stable Assistant Turn Anchors for Live-to-Final rendering.** Defines a frontend presentation/reconciliation model for anchoring one assistant turn across live streaming, settlement, replay/reload/recovery, Compact Worklog, Transparent Stream, terminal states, artifacts, and side effects. (#3926)
 
+### Fixed
+
+- **Hide Thinking now also hides Worklog reasoning rows without hiding tool activity.** The `show_thinking=false` path now suppresses `.wl-reason` entries that come from reasoning text and prunes already-rendered rows when Thinking is toggled off, while preserving tool cards and ordinary Worklog anchor/progress rows. (#3903)
+
 ## [v0.51.358] — 2026-06-11 — Release LV (first-run password bootstrap hardening)
 
 ### Security

--- a/static/commands.js
+++ b/static/commands.js
@@ -1362,6 +1362,7 @@ function cmdReasoning(args){
     const on=(arg==='show'||arg==='on');
     // Update the UI render gate immediately for responsiveness.
     window._showThinking=on;
+    if(!on&&typeof removeThinking==='function') removeThinking();
     if(typeof renderMessages==='function') renderMessages();
     // Persist via /api/reasoning → config.yaml display.show_reasoning
     // (CLI reads the same key).  Also mirror into WebUI settings.json

--- a/static/ui.js
+++ b/static/ui.js
@@ -6655,7 +6655,6 @@ function _renderWorklogReasonInto(row, text){
   row.innerHTML=html;
 }
 function _worklogReasonNodeFromText(text, attrs){
-  if(window._showThinking===false) return null;
   const html=_worklogReasonHtmlFromText(text);
   if(!html) return null;
   const row=document.createElement('div');
@@ -6689,11 +6688,19 @@ function _syncWorklogReasonFromAnchor(group, anchor, displayTextOverride){
   const list=_toolWorklogListEl(group);
   if(!group||!list) return;
   const anchorKey=_worklogReasonAnchorKey(anchor);
+  const selector=anchorKey?`:scope > .wl-reason[data-worklog-anchor-key="${CSS.escape(anchorKey)}"]`:':scope > .wl-reason[data-worklog-anchor-reason="1"]';
+  let reason=list.querySelector(selector);
+  if(window._showThinking===false){
+    if(reason) reason.remove();
+    if(anchor){
+      anchor.classList.add('assistant-segment-worklog-source');
+      anchor.setAttribute('aria-hidden','true');
+    }
+    return;
+  }
   const html=arguments.length>2
     ? _worklogReasonHtmlFromAnchor(anchor, displayTextOverride)
     : _worklogReasonHtmlFromAnchor(anchor);
-  const selector=anchorKey?`:scope > .wl-reason[data-worklog-anchor-key="${CSS.escape(anchorKey)}"]`:':scope > .wl-reason[data-worklog-anchor-reason="1"]';
-  let reason=list.querySelector(selector);
   if(!html){
     if(reason) reason.remove();
     return;
@@ -6758,6 +6765,13 @@ function _migrateLegacyLiveActivityGroupsToWorklog(blocks, worklog){
 }
 function _appendWorklogReason(list, anchor){
   if(!list) return null;
+  if(window._showThinking===false){
+    if(anchor){
+      anchor.classList.add('assistant-segment-worklog-source');
+      anchor.setAttribute('aria-hidden','true');
+    }
+    return null;
+  }
   const html=_worklogReasonHtmlFromAnchor(anchor);
   if(!html) return null;
   const reason=document.createElement('div');
@@ -10640,7 +10654,7 @@ function removeThinking(){
   const turn=$('liveAssistantTurn');
   const blocks=_assistantTurnBlocks(turn);
   if(blocks) blocks.querySelectorAll('.agent-activity-thinking').forEach(el=>el.remove());
-  if(blocks) blocks.querySelectorAll('.wl-reason[data-worklog-reason-source="reasoning"]').forEach(el=>el.remove());
+  if(blocks) blocks.querySelectorAll('.wl-reason[data-worklog-anchor-reason="1"]').forEach(el=>el.remove());
   if(blocks) blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-call-group[data-agent-activity-group="1"]').forEach(group=>{
     _syncToolCallGroupSummary(group);
     if(!group.querySelector('.tool-card-row,.agent-activity-thinking,.wl-reason')){

--- a/static/ui.js
+++ b/static/ui.js
@@ -6655,6 +6655,7 @@ function _renderWorklogReasonInto(row, text){
   row.innerHTML=html;
 }
 function _worklogReasonNodeFromText(text, attrs){
+  if(window._showThinking===false) return null;
   const html=_worklogReasonHtmlFromText(text);
   if(!html) return null;
   const row=document.createElement('div');
@@ -10639,9 +10640,10 @@ function removeThinking(){
   const turn=$('liveAssistantTurn');
   const blocks=_assistantTurnBlocks(turn);
   if(blocks) blocks.querySelectorAll('.agent-activity-thinking').forEach(el=>el.remove());
-  if(blocks) blocks.querySelectorAll('.tool-call-group[data-agent-activity-group="1"]').forEach(group=>{
+  if(blocks) blocks.querySelectorAll('.wl-reason[data-worklog-reason-source="reasoning"]').forEach(el=>el.remove());
+  if(blocks) blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-call-group[data-agent-activity-group="1"]').forEach(group=>{
     _syncToolCallGroupSummary(group);
-    if(!group.querySelector('.tool-card-row,.agent-activity-thinking')){
+    if(!group.querySelector('.tool-card-row,.agent-activity-thinking,.wl-reason')){
       if(typeof _clearActivityElapsedTimer==='function') _clearActivityElapsedTimer();
       group.remove();
     }

--- a/tests/test_reasoning_show_hide.py
+++ b/tests/test_reasoning_show_hide.py
@@ -20,6 +20,23 @@ def read(rel):
     return (REPO / rel).read_text(encoding='utf-8')
 
 
+def function_body(src, name):
+    start = src.find(f"function {name}")
+    assert start != -1, f"{name} not found"
+    brace = src.find("{", start)
+    assert brace != -1, f"{name} body not found"
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[brace + 1:idx]
+    raise AssertionError(f"{name} body did not close")
+
+
 # ── api/config.py ─────────────────────────────────────────────────────────────
 
 class TestShowThinkingConfig:
@@ -79,6 +96,36 @@ class TestUiJsThinkingGate:
                     f"thinking card insertion must be gated: {line.strip()}"
                 )
                 break
+
+    def test_worklog_reasoning_rows_are_gated_by_show_thinking(self):
+        src = read('static/ui.js')
+        node_fn = function_body(src, "_worklogReasonNodeFromText")
+        assert 'window._showThinking===false' in node_fn and 'return null' in node_fn, (
+            "reasoning-source Worklog rows must not be created when thinking is hidden"
+        )
+
+    def test_show_thinking_gate_does_not_hide_worklog_anchor_text(self):
+        src = read('static/ui.js')
+        html_fn = function_body(src, "_worklogReasonHtmlFromText")
+        assert 'window._showThinking' not in html_fn, (
+            "the low-level Worklog text renderer is also used for anchor/progress text; "
+            "only reasoning-source rows should be gated"
+        )
+
+    def test_remove_thinking_prunes_reasoning_rows_but_preserves_tool_or_anchor_rows(self):
+        src = read('static/ui.js')
+        fn = function_body(src, "removeThinking")
+        assert '.wl-reason[data-worklog-reason-source="reasoning"]' in fn, (
+            "removeThinking must sweep already-rendered reasoning Worklog rows"
+        )
+        assert '.tool-card-row,.agent-activity-thinking,.wl-reason' in fn, (
+            "empty-group cleanup must preserve groups that still contain tool cards "
+            "or non-reasoning Worklog anchor rows"
+        )
+        assert '.live-worklog[data-live-worklog-shell="1"]' in fn, (
+            "live Worklog shells must be considered for cleanup after their reasoning "
+            "rows are removed"
+        )
 
 
 # ── static/messages.js ────────────────────────────────────────────────────────
@@ -157,6 +204,9 @@ class TestReasoningCommand:
         )
         assert 'renderMessages' in fn, (
             "show/hide branch must call renderMessages()"
+        )
+        assert "typeof removeThinking==='function'" in fn and "removeThinking()" in fn, (
+            "hide/off must prune already-rendered live Thinking and Worklog reasoning rows"
         )
         # Persistence: POST to /api/reasoning (CLI-shared config.yaml) AND
         # /api/settings (boot.js mirror).

--- a/tests/test_reasoning_show_hide.py
+++ b/tests/test_reasoning_show_hide.py
@@ -4,6 +4,7 @@ Covers:
   - show_thinking in _SETTINGS_DEFAULTS and _SETTINGS_BOOL_KEYS (api/config.py)
   - window._showThinking initialised in boot.js (settings and fallback paths)
   - window._showThinking guard in ui.js renderMessages thinking card
+  - window._showThinking guards in live Worklog reasoning creators
   - _renderLiveThinking guard in messages.js
   - cmdReasoning function present in commands.js with show/hide/effort handling
   - /reasoning in COMMANDS array (not just SLASH_SUBARG_SOURCES)
@@ -12,6 +13,8 @@ Covers:
 
 import pathlib
 import re
+import shutil
+import subprocess
 
 REPO = pathlib.Path(__file__).parent.parent
 
@@ -97,11 +100,37 @@ class TestUiJsThinkingGate:
                 )
                 break
 
-    def test_worklog_reasoning_rows_are_gated_by_show_thinking(self):
+    def test_live_worklog_reasoning_creators_are_gated_by_show_thinking(self):
         src = read('static/ui.js')
-        node_fn = function_body(src, "_worklogReasonNodeFromText")
-        assert 'window._showThinking===false' in node_fn and 'return null' in node_fn, (
-            "reasoning-source Worklog rows must not be created when thinking is hidden"
+        sync_fn = function_body(src, "_syncWorklogReasonFromAnchor")
+        append_fn = function_body(src, "_appendWorklogReason")
+        assert 'window._showThinking===false' in sync_fn, (
+            "_syncWorklogReasonFromAnchor must honor Hide Thinking for live Worklog rows"
+        )
+        assert 'if(reason) reason.remove()' in sync_fn, (
+            "_syncWorklogReasonFromAnchor must prune an existing live anchor reason row "
+            "when Thinking is hidden"
+        )
+        sync_guard_idx = sync_fn.index('window._showThinking===false')
+        assert sync_guard_idx < sync_fn.index('_worklogReasonHtmlFromAnchor'), (
+            "_syncWorklogReasonFromAnchor must return before rendering anchor text when "
+            "Thinking is hidden"
+        )
+        assert sync_guard_idx < sync_fn.index('document.createElement'), (
+            "_syncWorklogReasonFromAnchor must return before creating a .wl-reason row "
+            "when Thinking is hidden"
+        )
+        assert 'window._showThinking===false' in append_fn and 'return null' in append_fn, (
+            "_appendWorklogReason must skip row creation when Thinking is hidden"
+        )
+        append_guard_idx = append_fn.index('window._showThinking===false')
+        assert append_guard_idx < append_fn.index('_worklogReasonHtmlFromAnchor'), (
+            "_appendWorklogReason must return before rendering anchor text when Thinking "
+            "is hidden"
+        )
+        assert append_guard_idx < append_fn.index('document.createElement'), (
+            "_appendWorklogReason must return before creating a .wl-reason row when "
+            "Thinking is hidden"
         )
 
     def test_show_thinking_gate_does_not_hide_worklog_anchor_text(self):
@@ -115,8 +144,12 @@ class TestUiJsThinkingGate:
     def test_remove_thinking_prunes_reasoning_rows_but_preserves_tool_or_anchor_rows(self):
         src = read('static/ui.js')
         fn = function_body(src, "removeThinking")
-        assert '.wl-reason[data-worklog-reason-source="reasoning"]' in fn, (
-            "removeThinking must sweep already-rendered reasoning Worklog rows"
+        assert '.wl-reason[data-worklog-anchor-reason="1"]' in fn, (
+            "removeThinking must sweep already-rendered live anchor reasoning Worklog rows"
+        )
+        assert '.wl-reason[data-worklog-reason-source="reasoning"]' not in fn, (
+            "removeThinking must target the live anchor reason marker, not the obsolete "
+            "reasoning-source marker"
         )
         assert '.tool-card-row,.agent-activity-thinking,.wl-reason' in fn, (
             "empty-group cleanup must preserve groups that still contain tool cards "
@@ -126,6 +159,89 @@ class TestUiJsThinkingGate:
             "live Worklog shells must be considered for cleanup after their reasoning "
             "rows are removed"
         )
+
+    def test_remove_thinking_removes_live_anchor_reason_dom_but_keeps_tool_rows(self):
+        node = shutil.which("node")
+        if node is None:
+            raise AssertionError("node is required for DOM-ish removeThinking regression test")
+        remove_thinking_src = "function removeThinking(){" + function_body(read('static/ui.js'), "removeThinking") + "}"
+        script = f"""
+class El {{
+  constructor(tag, attrs={{}}, children=[]) {{
+    this.tagName=tag.toUpperCase();
+    this.children=[];
+    this.parentElement=null;
+    this.attributes={{}};
+    this.id=attrs.id||'';
+    this.className=attrs.className||attrs.class||'';
+    for(const [k,v] of Object.entries(attrs.attrs||{{}})) this.setAttribute(k,v);
+    for(const child of children) this.appendChild(child);
+  }}
+  appendChild(child) {{ child.parentElement=this; this.children.push(child); return child; }}
+  getAttribute(name) {{ return Object.prototype.hasOwnProperty.call(this.attributes,name)?this.attributes[name]:null; }}
+  setAttribute(name,value) {{ this.attributes[name]=String(value); }}
+  removeAttribute(name) {{ delete this.attributes[name]; }}
+  remove() {{
+    if(!this.parentElement) return;
+    this.parentElement.children=this.parentElement.children.filter(child=>child!==this);
+    this.parentElement=null;
+  }}
+  get classList() {{
+    const self=this;
+    return {{
+      contains(cls) {{ return self.className.split(/\\s+/).filter(Boolean).includes(cls); }},
+      add(cls) {{ if(!this.contains(cls)) self.className=(self.className?self.className+' ':'')+cls; }},
+      remove(cls) {{ self.className=self.className.split(/\\s+/).filter(Boolean).filter(c=>c!==cls).join(' '); }},
+    }};
+  }}
+  querySelector(selector) {{ return this.querySelectorAll(selector)[0]||null; }}
+  querySelectorAll(selector) {{
+    const selectors=selector.split(',').map(s=>s.trim()).filter(Boolean);
+    const out=[];
+    const visit=(node)=>{{
+      for(const child of node.children){{
+        if(selectors.some(sel=>matches(child,sel))) out.push(child);
+        visit(child);
+      }}
+    }};
+    visit(this);
+    return out;
+  }}
+}}
+function matches(el, selector) {{
+  selector=selector.replace(/^:scope\\s*>\\s*/,'').trim();
+  const classes=[...selector.matchAll(/\\.([A-Za-z0-9_-]+)/g)].map(m=>m[1]);
+  if(classes.some(cls=>!el.classList.contains(cls))) return false;
+  const attrs=[...selector.matchAll(/\\[([A-Za-z0-9_-]+)(?:="([^"]*)")?\\]/g)];
+  for(const attr of attrs){{
+    const actual=el.getAttribute(attr[1]);
+    if(actual===null) return false;
+    if(attr[2]!==undefined&&actual!==attr[2]) return false;
+  }}
+  return classes.length>0||attrs.length>0;
+}}
+const anchorReason=new El('div', {{class:'wl-reason', attrs:{{'data-worklog-anchor-reason':'1'}}}});
+const toolRow=new El('div', {{class:'tool-card-row'}}, [new El('div', {{class:'tool-card'}})]);
+const worklogList=new El('div', {{class:'tool-worklog-list'}}, [anchorReason, toolRow]);
+const worklog=new El('div', {{class:'live-worklog', attrs:{{'data-live-worklog-shell':'1'}}}}, [worklogList]);
+const blocks=new El('div', {{class:'assistant-turn-blocks'}}, [worklog]);
+const turn=new El('div', {{id:'liveAssistantTurn'}}, [blocks]);
+global.window={{_simplifiedToolCalling:true,_showThinking:false}};
+global.$=(id)=>id==='liveAssistantTurn'?turn:null;
+global.isSimplifiedToolCalling=()=>window._simplifiedToolCalling!==false;
+global._assistantTurnBlocks=(node)=>node?node.querySelector('.assistant-turn-blocks'):null;
+global._syncToolCallGroupSummary=()=>{{}};
+global._clearActivityElapsedTimer=()=>{{ throw new Error('tool-bearing group should not be removed'); }};
+{remove_thinking_src}
+removeThinking();
+const remainingAnchorReasons=blocks.querySelectorAll('.wl-reason[data-worklog-anchor-reason="1"]').length;
+const remainingTools=blocks.querySelectorAll('.tool-card-row').length;
+const worklogStillAttached=worklog.parentElement===blocks;
+if(remainingAnchorReasons!==0||remainingTools!==1||!worklogStillAttached){{
+  throw new Error(JSON.stringify({{remainingAnchorReasons,remainingTools,worklogStillAttached}}));
+}}
+"""
+        subprocess.run([node, "-e", script], check=True, capture_output=True, text=True)
 
 
 # ── static/messages.js ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Thinking Path

- `show_thinking=false` should hide reasoning content regardless of which renderer path produced it.
- The inline Thinking card path already respected `_showThinking`, but Worklog reasoning rows used a separate `.wl-reason` path that did not.
- Tool activity is execution observability, not private reasoning, so the fix must not hide tool cards or ordinary Worklog anchor/progress rows.
- The immediate fix is to gate reasoning-source Worklog row creation and prune already-rendered live rows when `/reasoning hide` is used.

## Contract Routing

Task type: UI / live-to-final behavior bugfix.
Touched areas: `static/ui.js`, `static/commands.js`, `tests/test_reasoning_show_hide.py`, `CHANGELOG.md`.
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/UIUX-GUIDE.md`
- `DESIGN.md`
- `docs/rfcs/live-to-final-assistant-replies.md`
Scope boundaries: fixes the Hide Thinking vs Worklog reasoning inconsistency from #3903; does not change tool-card visibility, Transparent Stream, or markdown hard-break behavior.
Evidence needed before claiming done: JS syntax check, targeted reasoning/worklog regression tests, runtime JS lint, and scope-undef guard.

## What Changed

- Suppressed creation of `.wl-reason[data-worklog-reason-source="reasoning"]` when `window._showThinking === false`.
- Extended `removeThinking()` to remove existing reasoning-source Worklog rows while preserving tool cards and non-reasoning Worklog rows.
- Made `/reasoning hide|off` call `removeThinking()` immediately so live DOM is pruned without waiting for a later rebuild.
- Added regression coverage for the reasoning-row gate and the preservation boundary around tool/anchor rows.
- Added an Unreleased changelog note for #3903.

## Why It Matters

Hide Thinking previously hid inline Thinking cards but left Worklog reasoning rows visible, so the same reasoning content leaked through a different renderer path. This keeps the setting semantically consistent without reducing tool-call observability.

Refs #3903.

## Verification

- `node --check static/ui.js && node --check static/commands.js`
- `.venv/bin/python -m pytest tests/test_reasoning_show_hide.py tests/test_ui_tool_call_cleanup.py tests/test_live_activity_timeline.py -q` (`83 passed`)
- `.venv/bin/python scripts/ruff_lint.py --diff origin/master`
- `npm exec --yes --package eslint@10.4.0 -- eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"`
- `scope_undef_gate.py` with a temporary ESLint install (`CLEAN`)
- `git diff --check`

## Risks / Follow-ups

- This intentionally does not hide tool rows. A final-answer-only or hide-tool-activity mode is separate product work.
- This intentionally does not change the single-newline-to-`<br>` markdown behavior called out in #3903.
- No screenshots included because this is a renderer-state consistency fix with regression tests rather than a visual layout redesign.

## Model Used

AI-assisted using OpenAI GPT-5 Codex in Codex desktop, with local shell, GitHub CLI, and repository test/lint tooling.