### PR TITLE
feat(providers): register Tencent Cloud (TokenHub) in WebUI catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 
+- **Tencent Cloud (TokenHub) provider support in Settings and the model picker.** The Hermes agent already ships a `tencent-tokenhub` provider (OpenAI-compatible gateway at `https://tokenhub.tencentmaas.com/v1`), but the WebUI had no catalog entry for it, so it never appeared in Settings → Providers or the model dropdown. This registers it under the WebUI catalog key `tencent` ("Tencent Cloud"): a curated model list (DeepSeek / GLM / Kimi / MiniMax families), aliases mapping the agent's `tencent-tokenhub` slug (and `tencent-cloud` / `hunyuan` variants) onto `tencent`, env-var detection that accepts the WebUI-friendly `TENCENT_API_KEY` or the agent's canonical `TOKENHUB_API_KEY`, and an onboarding wizard entry. Removing the key now also clears aliased env vars so the provider card doesn't linger as "configured".
 - **New RFC: Stable Assistant Turn Anchors for Live-to-Final rendering.** Defines a frontend presentation/reconciliation model for anchoring one assistant turn across live streaming, settlement, replay/reload/recovery, Compact Worklog, Transparent Stream, terminal states, artifacts, and side effects. (#3926)
 
 ## [v0.51.358] — 2026-06-11 — Release LV (first-run password bootstrap hardening)

--- a/api/config.py
+++ b/api/config.py
@@ -896,6 +896,7 @@ _PROVIDER_DISPLAY = {
     "nvidia": "NVIDIA NIM",
     "xiaomi": "Xiaomi",
     "bedrock": "AWS Bedrock",
+    "tencent": "Tencent Cloud",
 }
 
 # Provider alias → canonical slug.  Users configure providers using the
@@ -954,6 +955,14 @@ _PROVIDER_ALIASES = {
     # lets the agent's auxiliary client take the ``no-key-required``
     # OpenAI-compat path. See #1384.
     "local": "custom",
+    # Tencent Cloud TokenHub. The Hermes agent registers this provider under
+    # the slug ``tencent-tokenhub``; map it (and the user-facing variants) onto
+    # the WebUI catalog key ``tencent`` so the picker and Settings card resolve.
+    "tencent-tokenhub": "tencent",
+    "tencent-cloud": "tencent",
+    "tencentcloud": "tencent",
+    "hunyuan": "tencent",
+    "tencent-hunyuan": "tencent",
 }
 
 
@@ -1467,6 +1476,22 @@ _PROVIDER_MODELS = {
         {"id": "global.anthropic.claude-opus-4-5-20251101-v1:0",   "label": "GLOBAL Anthropic Claude Opus 4.5"},
         {"id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0", "label": "Global Claude Sonnet 4.5"},
         {"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",  "label": "Global Anthropic Claude Haiku 4.5"},
+    ],
+    # Tencent Cloud TokenHub — OpenAI-compatible gateway exposing Hunyuan plus
+    # proxied third-party models (DeepSeek / GLM / Kimi / MiniMax). The Hermes
+    # agent's live catalog for this provider is sparse, so this static list is
+    # the practical fallback the picker shows.
+    "tencent": [
+        {"id": "deepseek-v4-flash",  "label": "DeepSeek V4 Flash"},
+        {"id": "deepseek-v4-pro",    "label": "DeepSeek V4 Pro"},
+        {"id": "deepseek-v3.2",      "label": "DeepSeek V3.2"},
+        {"id": "glm-5",             "label": "GLM-5"},
+        {"id": "glm-5-turbo",       "label": "GLM-5 Turbo"},
+        {"id": "glm-5.1",           "label": "GLM-5.1"},
+        {"id": "kimi-k2.6",         "label": "Kimi K2.6"},
+        {"id": "kimi-k2.5",         "label": "Kimi K2.5"},
+        {"id": "minimax-m2.5",      "label": "MiniMax M2.5"},
+        {"id": "minimax-m2.7",      "label": "MiniMax M2.7"},
     ],
 }
 
@@ -4110,6 +4135,8 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
                 "MINIMAX_CN_API_KEY",
                 "XAI_API_KEY",
                 "MISTRAL_API_KEY",
+                "TENCENT_API_KEY",
+                "TOKENHUB_API_KEY",
                 "AWS_ACCESS_KEY_ID",
                 "AWS_SECRET_ACCESS_KEY",
             ):
@@ -4148,6 +4175,10 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
                 detected_providers.add("deepseek")
             if all_env.get("XIAOMI_API_KEY"):
                 detected_providers.add("xiaomi")
+            # Tencent Cloud TokenHub accepts either the WebUI-friendly
+            # TENCENT_API_KEY or the agent's canonical TOKENHUB_API_KEY.
+            if all_env.get("TENCENT_API_KEY") or all_env.get("TOKENHUB_API_KEY"):
+                detected_providers.add("tencent")
             if all_env.get("XAI_API_KEY"):
                 detected_providers.add("x-ai")
             if all_env.get("MISTRAL_API_KEY"):

--- a/api/onboarding.py
+++ b/api/onboarding.py
@@ -187,6 +187,17 @@ _SUPPORTED_PROVIDER_SETUPS = {
         "models": list(_PROVIDER_MODELS.get("xai", []) or _PROVIDER_MODELS.get("x-ai", [])),
         "category": "specialized",
     },
+    "tencent": {
+        "label": "Tencent Cloud (TokenHub)",
+        # WebUI-friendly primary name; the agent runtime also accepts
+        # TOKENHUB_API_KEY (see _PROVIDER_ENV_VAR_ALIASES in api/providers.py).
+        "env_var": "TENCENT_API_KEY",
+        "default_model": "deepseek-v4-flash",
+        "default_base_url": "https://tokenhub.tencentmaas.com/v1",
+        "requires_base_url": False,
+        "models": list(_PROVIDER_MODELS.get("tencent", [])),
+        "category": "specialized",
+    },
 }
 
 _PROVIDER_CATEGORIES = [

--- a/api/providers.py
+++ b/api/providers.py
@@ -717,6 +717,7 @@ _PROVIDER_ENV_VAR: dict[str, str] = {
     # flip to "no key" after upgrading.
     "lmstudio": "LM_API_KEY",
     "nvidia": "NVIDIA_API_KEY",
+    "tencent": "TENCENT_API_KEY",
 }
 
 # Read-only legacy env-var aliases.  When `_provider_has_key(pid)` looks up its
@@ -735,6 +736,10 @@ _PROVIDER_ENV_VAR_ALIASES: dict[str, tuple[str, ...]] = {
     # show the groups as configured while chat fails the no-key path.
     "opencode-zen": ("OPENCODE_API_KEY",),
     "opencode-go": ("OPENCODE_API_KEY",),
+    # Tencent Cloud TokenHub — the Hermes agent runtime reads TOKENHUB_API_KEY
+    # (canonical). The WebUI exposes the friendlier TENCENT_API_KEY as the
+    # primary name, so read both for detection and runtime key lookup.
+    "tencent": ("TOKENHUB_API_KEY",),
 }
 
 # Providers that use OAuth or token flows — their credentials are managed
@@ -2397,6 +2402,11 @@ def remove_provider_key(provider_id: str) -> dict[str, Any]:
     (``providers.<id>.api_key`` or top-level ``model.api_key`` when this
     provider is the active one).
 
+    Also clears any aliased env vars registered in
+    ``_PROVIDER_ENV_VAR_ALIASES`` (e.g. a provider whose runtime key name
+    differs from the WebUI-facing one) so detection does not resurrect the
+    provider card after removal.
+
     Returns a status dict with the operation result.
     """
     result = set_provider_key(provider_id, None)
@@ -2406,6 +2416,16 @@ def remove_provider_key(provider_id: str) -> dict[str, Any]:
     # Clean those up so _provider_has_key() returns False after removal.
     if result.get("ok"):
         _clean_provider_key_from_config(provider_id)
+
+        # Also clear alias env vars so the provider doesn't reappear as
+        # "configured" via the alias detection path.
+        aliases = _PROVIDER_ENV_VAR_ALIASES.get(provider_id, ())
+        if aliases:
+            env_path = _get_hermes_home() / ".env"
+            try:
+                _write_env_file(env_path, {alias: None for alias in aliases})
+            except Exception:
+                logger.debug("Failed to remove alias env vars for %s", provider_id)
 
     return result
 

--- a/tests/test_tencent_provider.py
+++ b/tests/test_tencent_provider.py
@@ -1,0 +1,130 @@
+"""Tests for Tencent Cloud (TokenHub) provider registration.
+
+Validates that the 'tencent' provider is correctly registered across all
+configuration surfaces: display name, aliases, models, env var, onboarding,
+and Nous vendor priority.
+
+The Hermes agent registers this provider as ``tencent-tokenhub`` and reads
+``TOKENHUB_API_KEY``; the WebUI exposes it under the catalog key ``tencent``
+with the friendlier ``TENCENT_API_KEY`` primary name, mapping the two via
+``_PROVIDER_ALIASES`` and ``_PROVIDER_ENV_VAR_ALIASES``.
+"""
+
+import api.config as config
+from api.config import (
+    _PROVIDER_ALIASES,
+    _PROVIDER_DISPLAY,
+    _PROVIDER_MODELS,
+    _NOUS_VENDOR_PRIORITY,
+)
+from api.providers import _PROVIDER_ENV_VAR, _PROVIDER_ENV_VAR_ALIASES
+from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+
+
+class TestTencentProviderDisplay:
+    def test_tencent_in_provider_display(self):
+        assert _PROVIDER_DISPLAY["tencent"] == "Tencent Cloud"
+
+
+class TestTencentProviderEnvVar:
+    def test_tencent_env_var_mapping(self):
+        assert _PROVIDER_ENV_VAR["tencent"] == "TENCENT_API_KEY"
+
+    def test_tencent_tokenhub_alias_env_var(self):
+        # The agent runtime reads TOKENHUB_API_KEY; WebUI must read it too.
+        assert "TOKENHUB_API_KEY" in _PROVIDER_ENV_VAR_ALIASES["tencent"]
+
+
+class TestTencentProviderAliases:
+    def test_tencent_tokenhub_alias(self):
+        # The agent's canonical slug must resolve to the WebUI catalog key.
+        assert _PROVIDER_ALIASES["tencent-tokenhub"] == "tencent"
+
+    def test_tencent_cloud_alias(self):
+        assert _PROVIDER_ALIASES["tencent-cloud"] == "tencent"
+
+    def test_tencentcloud_alias(self):
+        assert _PROVIDER_ALIASES["tencentcloud"] == "tencent"
+
+    def test_hunyuan_alias(self):
+        assert _PROVIDER_ALIASES["hunyuan"] == "tencent"
+
+    def test_tencent_hunyuan_alias(self):
+        assert _PROVIDER_ALIASES["tencent-hunyuan"] == "tencent"
+
+    def test_alias_resolution_via_function(self):
+        # _resolve_provider_alias merges the agent's alias table on top of the
+        # WebUI's local one when hermes_cli is importable. Either way, every
+        # tencent variant must resolve to a tencent-prefixed slug.
+        for alias in (
+            "tencent-tokenhub",
+            "tencent-cloud",
+            "tencentcloud",
+            "hunyuan",
+            "tencent-hunyuan",
+        ):
+            resolved = config._resolve_provider_alias(alias)
+            assert "tencent" in resolved, (
+                f"Alias '{alias}' resolved to '{resolved}', expected a "
+                f"tencent-prefixed slug"
+            )
+
+
+class TestTencentProviderModels:
+    def test_tencent_models_exist(self):
+        assert "tencent" in _PROVIDER_MODELS
+
+    def test_tencent_models_count(self):
+        assert len(_PROVIDER_MODELS["tencent"]) == 10
+
+    def test_tencent_models_order(self):
+        ids = [m["id"] for m in _PROVIDER_MODELS["tencent"]]
+        expected = [
+            "deepseek-v4-flash",
+            "deepseek-v4-pro",
+            "deepseek-v3.2",
+            "glm-5",
+            "glm-5-turbo",
+            "glm-5.1",
+            "kimi-k2.6",
+            "kimi-k2.5",
+            "minimax-m2.5",
+            "minimax-m2.7",
+        ]
+        assert ids == expected
+
+    def test_tencent_models_have_labels(self):
+        for model in _PROVIDER_MODELS["tencent"]:
+            assert "id" in model
+            assert "label" in model
+            assert model["label"].strip()
+
+
+class TestTencentOnboarding:
+    def test_tencent_in_onboarding(self):
+        assert "tencent" in _SUPPORTED_PROVIDER_SETUPS
+
+    def test_tencent_base_url(self):
+        setup = _SUPPORTED_PROVIDER_SETUPS["tencent"]
+        assert setup["default_base_url"] == "https://tokenhub.tencentmaas.com/v1"
+
+    def test_tencent_default_model(self):
+        setup = _SUPPORTED_PROVIDER_SETUPS["tencent"]
+        assert setup["default_model"] == "deepseek-v4-flash"
+
+    def test_tencent_env_var(self):
+        setup = _SUPPORTED_PROVIDER_SETUPS["tencent"]
+        assert setup["env_var"] == "TENCENT_API_KEY"
+
+    def test_tencent_category(self):
+        setup = _SUPPORTED_PROVIDER_SETUPS["tencent"]
+        assert setup["category"] == "specialized"
+
+    def test_tencent_models_populated(self):
+        setup = _SUPPORTED_PROVIDER_SETUPS["tencent"]
+        assert len(setup["models"]) == 10
+
+
+class TestTencentNousVendorPriority:
+    def test_tencent_in_nous_vendor_priority(self):
+        assert "tencent" in _NOUS_VENDOR_PRIORITY


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI aims for near 1:1 parity with the Hermes CLI/agent in the browser, including which providers you can pick.
- The Hermes agent already registers a `tencent-tokenhub` provider — an OpenAI-compatible gateway at `https://tokenhub.tencentmaas.com/v1` that fronts Hunyuan plus proxied DeepSeek / GLM / Kimi / MiniMax models — and authenticates it with `TOKENHUB_API_KEY`.
- But the WebUI has no catalog entry for it, so even with a valid key the provider never shows up in Settings → Providers or the model picker. The only Tencent surface today is the `tencent/hy3-preview:free` entry under OpenRouter, which is unrelated to TokenHub.
- This PR registers the provider in the WebUI catalog under the key `tencent`, mapping the agent's `tencent-tokenhub` slug onto it so detection, the picker, and the Settings card all resolve.

## What Changed

- **`api/config.py`**
  - `_PROVIDER_DISPLAY`: add `tencent` → "Tencent Cloud".
  - `_PROVIDER_ALIASES`: map the agent slug `tencent-tokenhub` (and user-facing variants `tencent-cloud`, `tencentcloud`, `hunyuan`, `tencent-hunyuan`) onto `tencent`.
  - `_PROVIDER_MODELS`: add a curated DeepSeek / GLM / Kimi / MiniMax list. The agent's live catalog for this provider is sparse, so this static list is the practical fallback the picker shows (same pattern as other direct-API providers).
  - `get_available_models()`: env-var fallback detection accepts either the WebUI-friendly `TENCENT_API_KEY` or the agent's canonical `TOKENHUB_API_KEY`.
- **`api/providers.py`**
  - `_PROVIDER_ENV_VAR`: add `tencent` → `TENCENT_API_KEY`.
  - `_PROVIDER_ENV_VAR_ALIASES`: add `tencent` → `TOKENHUB_API_KEY` so detection and runtime key lookup work under either name.
  - `remove_provider_key()`: also clear aliased env vars on removal, so the provider card doesn't linger as "configured" via the alias path. (Also benefits existing aliased providers like `lmstudio` / `opencode-*`.)
- **`api/onboarding.py`**
  - `_SUPPORTED_PROVIDER_SETUPS`: add a `tencent` wizard entry (label "Tencent Cloud (TokenHub)", default model `deepseek-v4-flash`, default base URL `https://tokenhub.tencentmaas.com/v1`, category `specialized`).
- **`tests/test_tencent_provider.py`**: 20 tests covering display name, aliases (incl. `tencent-tokenhub` → `tencent`), model list contents/order, env var + alias mapping, onboarding entry, and Nous vendor priority.
- **`CHANGELOG.md`**: `[Unreleased]` → Added entry.

No new dependencies, no build step, no frontend changes (the picker and Settings card render from the catalog data automatically).

## Why It Matters

Users with a Tencent Cloud TokenHub subscription can now configure it from Settings → Providers (or onboarding) and pick its models in the chat composer, instead of hand-editing `config.yaml`. It closes a parity gap where the agent supported the provider but the WebUI couldn't surface it.

## Verification

- `pytest tests/test_tencent_provider.py -v` → 20 passed.
- `pytest tests/test_issue603_provider_categories.py tests/test_issue2025_xiaomi_env_key.py` → 36 passed (no regression in neighboring provider-registration tests).
- Manually confirmed via `hermes_cli.auth.get_auth_status('tencent-tokenhub')` that the provider reports `configured: True` / `logged_in: True` when `TOKENHUB_API_KEY` is set, and that the alias resolves `tencent-tokenhub` → `tencent`.

## Risks / Follow-ups

- The static model list will drift as TokenHub adds/removes models; it's intentionally a fallback, and live discovery via the agent still takes precedence when it returns results.
- Base URL (`https://tokenhub.tencentmaas.com/v1`) is the Guangzhou-region endpoint; an international endpoint also exists. Left configurable via the standard `base_url` mechanism rather than hardcoding multiple regions.

## Model Used

AI-assisted. Provider: Anthropic (via Kiro). Model: Claude (Opus-class). The human contributor reviewed the design, verified behavior against a live TokenHub key, and approved the final diff.
