### PR TITLE
Fix mobile PWA reflow and avoid redundant session refresh

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -98,6 +98,23 @@ function _isCompactWorkspaceViewport(){
   return window.matchMedia('(max-width: 900px)').matches;
 }
 
+function _isPhoneWidthViewport(){
+  return window.matchMedia('(max-width: 640px)').matches;
+}
+
+function _forceMobileViewportReflow(){
+  if(!_isPhoneWidthViewport()) return;
+  const layout=document.querySelector('.layout');
+  if(!layout) return;
+  document.documentElement.classList.add('viewport-reflow');
+  void layout.offsetWidth;
+  requestAnimationFrame(()=>{
+    document.documentElement.classList.remove('viewport-reflow');
+    try{ syncWorkspacePanelState(); }catch(_){ }
+    try{ if(typeof _syncSidebarAria==='function') _syncSidebarAria(); }catch(_){ }
+  });
+}
+
 function _syncWorkspacePanelInlineWidth(){
   const {panel}= _workspacePanelEls();
   if(!panel) return;
@@ -1500,7 +1517,21 @@ function applyEmptyStateSuggestionPref(){
 window.addEventListener('resize',()=>{
   _syncWorkspacePanelInlineWidth();
   syncWorkspacePanelState();
+  _forceMobileViewportReflow();
 });
+
+if(window.visualViewport){
+  let _mobileViewportReflowTimer=0;
+  const _scheduleMobileViewportReflow=()=>{
+    if(_mobileViewportReflowTimer) clearTimeout(_mobileViewportReflowTimer);
+    _mobileViewportReflowTimer=setTimeout(()=>{
+      _mobileViewportReflowTimer=0;
+      _forceMobileViewportReflow();
+    },60);
+  };
+  window.visualViewport.addEventListener('resize', _scheduleMobileViewportReflow);
+  window.visualViewport.addEventListener('scroll', _scheduleMobileViewportReflow);
+}
 
 // Boot: restore last session or start fresh
 // ── Resizable panels ──────────────────────────────────────────────────────

--- a/static/boot.js
+++ b/static/boot.js
@@ -1517,7 +1517,7 @@ function applyEmptyStateSuggestionPref(){
 window.addEventListener('resize',()=>{
   _syncWorkspacePanelInlineWidth();
   syncWorkspacePanelState();
-  _forceMobileViewportReflow();
+  if(!window.visualViewport) _forceMobileViewportReflow();
 });
 
 if(window.visualViewport){

--- a/static/boot.js
+++ b/static/boot.js
@@ -98,6 +98,23 @@ function _isCompactWorkspaceViewport(){
   return window.matchMedia('(max-width: 900px)').matches;
 }
 
+function _isPhoneWidthViewport(){
+  return window.matchMedia('(max-width: 640px)').matches;
+}
+
+function _forceMobileViewportReflow(){
+  if(!_isPhoneWidthViewport()) return;
+  const layout=document.querySelector('.layout');
+  if(!layout) return;
+  document.documentElement.classList.add('viewport-reflow');
+  void layout.offsetWidth;
+  requestAnimationFrame(()=>{
+    document.documentElement.classList.remove('viewport-reflow');
+    try{ syncWorkspacePanelState(); }catch(_){ }
+    try{ if(typeof _syncSidebarAria==='function') _syncSidebarAria(); }catch(_){ }
+  });
+}
+
 function _syncWorkspacePanelInlineWidth(){
   const {panel}= _workspacePanelEls();
   if(!panel) return;
@@ -1557,7 +1574,21 @@ function applyEmptyStateSuggestionPref(){
 window.addEventListener('resize',()=>{
   _syncWorkspacePanelInlineWidth();
   syncWorkspacePanelState();
+  if(!window.visualViewport) _forceMobileViewportReflow();
 });
+
+if(window.visualViewport){
+  let _mobileViewportReflowTimer=0;
+  const _scheduleMobileViewportReflow=()=>{
+    if(_mobileViewportReflowTimer) clearTimeout(_mobileViewportReflowTimer);
+    _mobileViewportReflowTimer=setTimeout(()=>{
+      _mobileViewportReflowTimer=0;
+      _forceMobileViewportReflow();
+    },60);
+  };
+  window.visualViewport.addEventListener('resize', _scheduleMobileViewportReflow);
+  window.visualViewport.addEventListener('scroll', _scheduleMobileViewportReflow);
+}
 
 // Boot: restore last session or start fresh
 // ── Resizable panels ──────────────────────────────────────────────────────

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -389,6 +389,15 @@ function _scheduleActiveSessionIdleReload(sid) {
     if(!S||!S.session||S.session.session_id !== sid) return;
     if(S.busy || S.activeStreamId) return;
     try{
+      // Avoid an unconditional same-session force reload the moment streaming
+      // settles. On mobile PWA this produces a visible end-of-turn flash and can
+      // briefly restore the pane with stale layout geometry. Reuse the lighter
+      // external-refresh gate so we only reload when the authoritative session
+      // on disk is actually newer than the just-finished in-memory turn.
+      if(typeof refreshActiveSessionIfExternallyUpdated==='function'){
+        await refreshActiveSessionIfExternallyUpdated('idle-reconcile');
+        return;
+      }
       await loadSession(sid, {force:true, externalRefreshReason:'idle-reconcile'});
     }catch(_){}
   },0);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -387,18 +387,18 @@ function _scheduleActiveSessionIdleReload(sid) {
   if(!sid) return;
   setTimeout(async () => {
     if(!S||!S.session||S.session.session_id !== sid) return;
-    if(S.busy || S.activeStreamId) return;
+    if(S.busy || S.activeStreamId) return 'skipped';
     try{
       // Avoid an unconditional same-session force reload the moment streaming
       // settles. On mobile PWA this produces a visible end-of-turn flash and can
       // briefly restore the pane with stale layout geometry. Reuse the lighter
-      // external-refresh gate so we only reload when the authoritative session
-      // on disk is actually newer than the just-finished in-memory turn.
-      if(typeof refreshActiveSessionIfExternallyUpdated==='function'){
-        await refreshActiveSessionIfExternallyUpdated('idle-reconcile');
-        return;
+      // metadata check, but bypass the post-stream cooldown because this path
+      // runs specifically to reconcile the just-finished turn against server
+      // truth. Fall back to a forced load only when that lighter probe fails.
+      const outcome=await refreshActiveSessionIfExternallyUpdated('idle-reconcile',{ignoreStreamJustFinished:true});
+      if(outcome==='failed'){
+        await loadSession(sid, {force:true, externalRefreshReason:'idle-reconcile'});
       }
-      await loadSession(sid, {force:true, externalRefreshReason:'idle-reconcile'});
     }catch(_){}
   },0);
 }
@@ -3505,32 +3505,35 @@ function ensureSessionTimeRefreshPoll(){
   }, _sessionTimeRefreshMs);
 }
 
-async function refreshActiveSessionIfExternallyUpdated(reason){
-  if(_activeSessionExternalRefreshInFlight) return;
-  if(!S.session || !S.session.session_id) return;
-  if(S.busy || S.activeStreamId) return;
+async function refreshActiveSessionIfExternallyUpdated(reason, opts={}){
+  if(_activeSessionExternalRefreshInFlight) return 'skipped';
+  if(!S.session || !S.session.session_id) return 'skipped';
+  if(S.busy || S.activeStreamId) return 'skipped';
   // Cooldown: don't force-reload immediately after streaming ends — the
   // "done" event already delivered the final messages. Reloading here would
   // clear S.toolCalls and lose Activity.
-  if(typeof window !== 'undefined' && window._streamJustFinished) return;
-  if(typeof document !== 'undefined' && document.hidden) return;
+  if(!opts.ignoreStreamJustFinished&&typeof window !== 'undefined' && window._streamJustFinished) return 'skipped';
+  if(typeof document !== 'undefined' && document.hidden) return 'skipped';
   const sid = S.session.session_id;
   const localCount = Number(S.session.message_count || (Array.isArray(S.messages)?S.messages.length:0) || 0);
   const localLast = Number(S.session.last_message_at || S.session.updated_at || 0);
   _activeSessionExternalRefreshInFlight = true;
   try{
     const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`,{timeoutToast:false});
-    if(!data || !data.session) return;
-    if(!S.session || S.session.session_id !== sid) return;
+    if(!data || !data.session) return 'unchanged';
+    if(!S.session || S.session.session_id !== sid) return 'skipped';
     if(S.busy || S.activeStreamId) return;
     const remoteCount = Number(data.session.message_count || 0);
     const remoteLast = Number(data.session.last_message_at || data.session.updated_at || 0);
     if(remoteCount > localCount || remoteLast > localLast){
       await loadSession(sid, {force:true, externalRefreshReason:reason||'poll'});
       if(typeof renderSessionList==='function') void renderSessionList();
+      return 'reloaded';
     }
+    return 'unchanged';
   }catch(e){
     // Ignore transient refresh failures; the next poll/focus event will retry.
+    return 'failed';
   }finally{
     _activeSessionExternalRefreshInFlight = false;
   }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -389,10 +389,22 @@ function _scheduleActiveSessionIdleReload(sid) {
     if(!S||!S.session||S.session.session_id !== sid) return;
     if(S.busy || S.activeStreamId) return;
     try{
-      await loadSession(sid, {force:true, externalRefreshReason:'idle-reconcile'});
+      // Avoid an unconditional same-session force reload the moment streaming
+      // settles. On mobile PWA this produces a visible end-of-turn flash and can
+      // briefly restore the pane with stale layout geometry. Use a lightweight
+      // metadata probe for the just-finished active turn, but preserve the
+      // original forced reload as a fallback when that probe fails.
+      const outcome = await _probeActiveSessionServerFreshness('idle-reconcile', {
+        allowNative: true,
+        ignoreStreamJustFinished: true,
+      });
+      if(outcome === 'failed'){
+        await loadSession(sid, {force:true, externalRefreshReason:'idle-reconcile'});
+      }
     }catch(_){}
   },0);
 }
+
 
 function _purgeStaleInflightEntries() {
   // Clean up INFLIGHT entries for sessions the server confirms are NOT
@@ -3664,37 +3676,47 @@ function ensureSessionTimeRefreshPoll(){
   }, _sessionTimeRefreshMs);
 }
 
-async function refreshActiveSessionIfExternallyUpdated(reason){
-  if(_activeSessionExternalRefreshInFlight) return;
-  if(!S.session || !S.session.session_id) return;
-  if(S.busy || S.activeStreamId) return;
-  if(!_isExternalSession(S.session)) return;
-  // Cooldown: don't force-reload immediately after streaming ends — the
+async function _probeActiveSessionServerFreshness(reason, opts={}){
+  if(_activeSessionExternalRefreshInFlight) return 'skipped';
+  if(!S.session || !S.session.session_id) return 'skipped';
+  if(S.busy || S.activeStreamId) return 'skipped';
+  if(!opts.allowNative && !_isExternalSession(S.session)) return 'skipped';
+  // Cooldown: don't force-reload immediately after streaming ends - the
   // "done" event already delivered the final messages. Reloading here would
-  // clear S.toolCalls and lose Activity.
-  if(typeof window !== 'undefined' && window._streamJustFinished) return;
-  if(typeof document !== 'undefined' && document.hidden) return;
+  // clear S.toolCalls and lose Activity. The idle-reconcile path may bypass
+  // this guard because it only runs for the just-finished active turn and
+  // first probes server metadata before falling back to the original reload.
+  if(!opts.ignoreStreamJustFinished && typeof window !== 'undefined' && window._streamJustFinished) return 'skipped';
+  if(typeof document !== 'undefined' && document.hidden) return 'skipped';
   const sid = S.session.session_id;
   const localCount = Number(S.session.message_count || (Array.isArray(S.messages)?S.messages.length:0) || 0);
   const localLast = Number(S.session.last_message_at || S.session.updated_at || 0);
   _activeSessionExternalRefreshInFlight = true;
   try{
     const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`,{timeoutToast:false});
-    if(!data || !data.session) return;
-    if(!S.session || S.session.session_id !== sid) return;
-    if(S.busy || S.activeStreamId) return;
+    if(!data || !data.session) return 'unchanged';
+    if(!S.session || S.session.session_id !== sid) return 'skipped';
+    if(S.busy || S.activeStreamId) return 'skipped';
     const remoteCount = Number(data.session.message_count || 0);
     const remoteLast = Number(data.session.last_message_at || data.session.updated_at || 0);
     if(remoteCount > localCount || remoteLast > localLast){
       await loadSession(sid, {force:true, externalRefreshReason:reason||'poll'});
       if(typeof renderSessionList==='function') void renderSessionList();
+      return 'reloaded';
     }
+    return 'unchanged';
   }catch(e){
     // Ignore transient refresh failures; the next poll/focus event will retry.
+    return 'failed';
   }finally{
     _activeSessionExternalRefreshInFlight = false;
   }
 }
+
+async function refreshActiveSessionIfExternallyUpdated(reason){
+  return _probeActiveSessionServerFreshness(reason);
+}
+
 
 function ensureActiveSessionExternalRefreshPoll(){
   if(_activeSessionExternalRefreshTimer) return;

--- a/static/style.css
+++ b/static/style.css
@@ -961,8 +961,7 @@
   }
   html{background:var(--sidebar);}
   body{background:var(--bg);color:var(--text);height:100vh;height:100dvh;overflow:hidden;display:flex;flex-direction:column;}
-  .layout{display:flex;width:100%;flex:1 1 auto;min-height:0;overflow-x:hidden;}
-  html.viewport-reflow .layout{transform:translateZ(0);}
+  .layout{display:flex;width:100%;flex:1 1 auto;min-height:0;}
   .app-titlebar{display:flex;align-items:center;justify-content:center;height:38px;flex-shrink:0;background:var(--sidebar);border-bottom:1px solid var(--border);padding:0 12px;padding-top:var(--app-titlebar-safe-top);padding-left:max(12px,env(safe-area-inset-left,0));padding-right:max(12px,env(safe-area-inset-right,0));box-sizing:content-box;font-size:12px;color:var(--muted);user-select:none;-webkit-app-region:drag;position:relative;z-index:20;}
   .app-titlebar-inner{display:flex;align-items:center;gap:8px;min-width:0;max-width:100%;justify-content:center;}
   .system-health-panel.insights-card{display:flex;flex-direction:column;gap:12px;color:var(--muted);}
@@ -2313,6 +2312,8 @@
   }
 
   @media(max-width:640px){
+    html.viewport-reflow .layout{transform:translateZ(0);}
+    .layout{overflow-x:hidden;}
     /* Viewport-phone rules handle app chrome and touch sizing; they intentionally
        overlap the container compact rules for actual phones. */
     /* ── Sidebar: slide-in overlay instead of hidden ── */

--- a/static/style.css
+++ b/static/style.css
@@ -2325,6 +2325,8 @@
   }
 
   @media(max-width:640px){
+    html.viewport-reflow .layout{transform:translateZ(0);}
+    .layout{overflow-x:hidden;}
     /* Viewport-phone rules handle app chrome and touch sizing; they intentionally
        overlap the container compact rules for actual phones. */
     /* ── Sidebar: slide-in overlay instead of hidden ── */
@@ -2359,17 +2361,17 @@
     .rightpanel .panel-header{row-gap:8px;}
     .rightpanel .panel-actions{align-items:center;gap:8px;}
     /* Topbar adjustments */
-    .topbar{padding:8px 12px;gap:8px;}
+    .topbar{padding:8px 12px;gap:8px;padding-left:max(12px,env(safe-area-inset-left,0));padding-right:max(12px,env(safe-area-inset-right,0));}
     .topbar-title{font-size:14px;}
     .topbar-meta{display:none;}
     .topbar-chips{flex-wrap:nowrap;gap:4px;overflow-x:auto;-webkit-overflow-scrolling:touch;}
     .topbar-chips .chip,.topbar-chips .ws-chip,.topbar-chips button{font-size:11px!important;padding:4px 8px!important;white-space:nowrap;}
     .settings-main{padding:18px 16px;}
     .hermes-action-grid{grid-template-columns:1fr;}
-    .messages-inner{padding:12px 10px 20px;}
+    .messages-inner{padding:12px 10px 20px;padding-left:max(10px,env(safe-area-inset-left,0));padding-right:max(10px,env(safe-area-inset-right,0));}
     .msg-body{padding-left:0;max-width:100%;}
     .msg-role{font-size:12px;}
-    .composer-wrap{padding:8px 10px 12px!important;}
+    .composer-wrap{padding:8px 10px 12px!important;padding-left:max(10px,env(safe-area-inset-left,0))!important;padding-right:max(10px,env(safe-area-inset-right,0))!important;}
     .composer-box{border-radius:12px;}
     .composer-box textarea{min-height:40px;}
     .composer-footer{padding:6px 8px 8px!important;gap:6px;flex-wrap:nowrap;align-items:center;}

--- a/static/style.css
+++ b/static/style.css
@@ -961,7 +961,8 @@
   }
   html{background:var(--sidebar);}
   body{background:var(--bg);color:var(--text);height:100vh;height:100dvh;overflow:hidden;display:flex;flex-direction:column;}
-  .layout{display:flex;width:100%;flex:1 1 auto;min-height:0;}
+  .layout{display:flex;width:100%;flex:1 1 auto;min-height:0;overflow-x:hidden;}
+  html.viewport-reflow .layout{transform:translateZ(0);}
   .app-titlebar{display:flex;align-items:center;justify-content:center;height:38px;flex-shrink:0;background:var(--sidebar);border-bottom:1px solid var(--border);padding:0 12px;padding-top:var(--app-titlebar-safe-top);padding-left:max(12px,env(safe-area-inset-left,0));padding-right:max(12px,env(safe-area-inset-right,0));box-sizing:content-box;font-size:12px;color:var(--muted);user-select:none;-webkit-app-region:drag;position:relative;z-index:20;}
   .app-titlebar-inner{display:flex;align-items:center;gap:8px;min-width:0;max-width:100%;justify-content:center;}
   .system-health-panel.insights-card{display:flex;flex-direction:column;gap:12px;color:var(--muted);}
@@ -2346,17 +2347,17 @@
     .rightpanel .panel-header{row-gap:8px;}
     .rightpanel .panel-actions{align-items:center;gap:8px;}
     /* Topbar adjustments */
-    .topbar{padding:8px 12px;gap:8px;}
+    .topbar{padding:8px 12px;gap:8px;padding-left:max(12px,env(safe-area-inset-left,0));padding-right:max(12px,env(safe-area-inset-right,0));}
     .topbar-title{font-size:14px;}
     .topbar-meta{display:none;}
     .topbar-chips{flex-wrap:nowrap;gap:4px;overflow-x:auto;-webkit-overflow-scrolling:touch;}
     .topbar-chips .chip,.topbar-chips .ws-chip,.topbar-chips button{font-size:11px!important;padding:4px 8px!important;white-space:nowrap;}
     .settings-main{padding:18px 16px;}
     .hermes-action-grid{grid-template-columns:1fr;}
-    .messages-inner{padding:12px 10px 20px;}
+    .messages-inner{padding:12px 10px 20px;padding-left:max(10px,env(safe-area-inset-left,0));padding-right:max(10px,env(safe-area-inset-right,0));}
     .msg-body{padding-left:0;max-width:100%;}
     .msg-role{font-size:12px;}
-    .composer-wrap{padding:8px 10px 12px!important;}
+    .composer-wrap{padding:8px 10px 12px!important;padding-left:max(10px,env(safe-area-inset-left,0))!important;padding-right:max(10px,env(safe-area-inset-right,0))!important;}
     .composer-box{border-radius:12px;}
     .composer-box textarea{min-height:40px;}
     .composer-footer{padding:6px 8px 8px!important;gap:6px;flex-wrap:nowrap;align-items:center;}


### PR DESCRIPTION
## Summary
- avoid an unnecessary same-session force reload when idle reconciliation runs after a stream settles
- add a small mobile viewport reflow guard for PWA visualViewport changes
- tighten mobile safe-area and horizontal overflow protection in the main layout

## Why
On mobile PWA installs, the active conversation could visibly flash at end-of-turn when idle reconciliation immediately force-reloaded the same session. In the same environment, viewport/compositor changes could also leave the layout slightly clipped on the left until a manual scroll or repaint corrected it.

## Changes
- in static/sessions.js, prefer efreshActiveSessionIfExternallyUpdated('idle-reconcile') before falling back to a same-session force reload
- in static/boot.js, add a mobile-only viewport reflow helper and trigger it on window resize and isualViewport resize/scroll changes
- in static/style.css, add horizontal overflow protection on .layout and apply mobile safe-area-aware padding to the topbar, messages container, and composer shell

## Notes
- this PR intentionally does not change static/manifest.json
- the local manifest orientation adjustment was useful for device-specific testing but is left out here because it is a product-policy choice rather than a general bug fix
