### PR TITLE
Add assistant turn anchor source normalizer

### DIFF
--- a/docs/architecture/stable-assistant-turn-anchor-phase0.md
+++ b/docs/architecture/stable-assistant-turn-anchor-phase0.md
@@ -22,6 +22,21 @@ The same inventory is encoded in `static/assistant_turn_anchors.js` as
 `HermesAssistantTurnAnchors.stateLayers` so tests can pin the current authority
 order.
 
+## Slice 2 Normalizer Helper
+
+`HermesAssistantTurnAnchors.normalizeAssistantTurnAnchorSourceEvent()` converts a
+single current source event into a normalized anchor event envelope without
+registering it, rendering it, or mutating browser state. It accepts live SSE-like
+events (`type`, `data`, `lastEventId`), replay/journal-like events (`event`,
+`payload`, `event_id`, `seq`), and settled/session payload events such as
+`settled_message`.
+
+`HermesAssistantTurnAnchors.normalizeAssistantTurnAnchorSourceEvents()` applies
+the same helper to a list and dedupes repeated live + replay observations by the
+same event-envelope key. This is still inert: `send()`, `attachLiveStream()`,
+`renderMessages()`, settlement restore, `S.messages`, `INFLIGHT`, and the DOM do
+not consume the helper yet.
+
 ## Source Event Classification
 
 Phase 0 classifies current sources before changing render behavior:

--- a/static/assistant_turn_anchors.js
+++ b/static/assistant_turn_anchors.js
@@ -1,4 +1,4 @@
-// Stable Assistant Turn Anchors Phase 0 scaffold (#3926).
+// Stable Assistant Turn Anchors scaffold (#3926).
 //
 // This file is intentionally inert: it defines the current ownership inventory,
 // event classifications, and small pure helpers, but it does not register
@@ -117,6 +117,126 @@
     return typeof value==='string'?value.trim():'';
   }
 
+  function _coercePayload(value){
+    if(value==null) return {};
+    if(typeof value==='string'){
+      const raw=value.trim();
+      if(!raw) return {};
+      try{
+        const parsed=JSON.parse(raw);
+        return parsed&&typeof parsed==='object'?parsed:{value:parsed};
+      }catch(_){
+        return {text:value};
+      }
+    }
+    if(typeof value==='object') return value;
+    return {value};
+  }
+
+  function _sanitizePayload(value, depth=0){
+    if(value==null) return value;
+    const type=typeof value;
+    if(type==='string'||type==='number'||type==='boolean') return value;
+    if(type==='bigint') return String(value);
+    if(type!=='object') return undefined;
+    if(depth>=6) return '[MaxDepth]';
+    if(Array.isArray(value)){
+      return value.map((item)=>_sanitizePayload(item,depth+1)).filter((item)=>item!==undefined);
+    }
+    const out={};
+    Object.keys(value).sort().forEach((key)=>{
+      const safe=_sanitizePayload(value[key],depth+1);
+      if(safe!==undefined) out[key]=safe;
+    });
+    return out;
+  }
+
+  function _coerceSeq(value){
+    if(value==null||value==='') return null;
+    const str=String(value);
+    const numeric=Number(str);
+    return Number.isFinite(numeric)?numeric:str;
+  }
+
+  function _eventIdSeq(eventId){
+    const raw=_cleanString(eventId);
+    if(!raw||!raw.includes(':')) return null;
+    return _coerceSeq(raw.slice(raw.lastIndexOf(':')+1));
+  }
+
+  function _eventIdRunId(eventId){
+    const raw=_cleanString(eventId);
+    if(!raw||!raw.includes(':')) return '';
+    return raw.slice(0,raw.lastIndexOf(':'));
+  }
+
+  function _sourceEventType(input, payload){
+    return _cleanString(input&&(
+      input.source_event_type||
+      input.sourceType||
+      input.source_type||
+      input.event_type||
+      input.type||
+      input.event
+    )) || _cleanString(payload&&(payload.source_event_type||payload.type||payload.event));
+  }
+
+  function _sourceEventPayload(input){
+    if(!input||typeof input!=='object') return {};
+    if(Object.prototype.hasOwnProperty.call(input,'payload')) return _coercePayload(input.payload);
+    if(Object.prototype.hasOwnProperty.call(input,'data')) return _coercePayload(input.data);
+    const payload={};
+    const reserved=new Set([
+      'source_event_type',
+      'sourceType',
+      'source_type',
+      'type',
+      'event',
+      'event_id',
+      'lastEventId',
+      'last_event_id',
+      'seq',
+      'session_id',
+      'turn_id',
+      'run_id',
+      'stream_id',
+      'created_at',
+      'timestamp',
+    ]);
+    Object.keys(input).forEach((key)=>{
+      if(!reserved.has(key)) payload[key]=input[key];
+    });
+    return payload;
+  }
+
+  function _statusForSourceEvent(sourceType, kind, payload){
+    const explicit=_cleanString(payload&&(payload.status||payload.state||payload.phase));
+    if(explicit) return explicit;
+    if(kind==='tool_started') return 'running';
+    if(kind==='tool_completed') return payload&&payload.is_error?'error':'completed';
+    if(kind==='terminal_status'){
+      if(sourceType==='done') return 'completed';
+      if(sourceType==='cancel') return 'cancelled';
+      return 'error';
+    }
+    if(kind==='lifecycle_status') return 'running';
+    if(kind==='control_boundary') return 'pending';
+    if(sourceType==='stream_end') return 'transport_closed';
+    return null;
+  }
+
+  function _localIdForSourceEvent(sourceType, context, payload){
+    const explicit=_cleanString(
+      (context&&context.local_id)||
+      (payload&&(payload.local_id||payload.id||payload.tid||payload.tool_call_id||payload.tool_use_id||payload.call_id))
+    );
+    if(explicit) return explicit;
+    const sessionId=_cleanString(context&&context.session_id)||'session';
+    const turnId=_cleanString(context&&context.turn_id)||'turn';
+    const seq=(context&&context.seq!=null&&context.seq!=='')?String(context.seq):'pending';
+    return [sessionId,turnId,sourceType||'event',seq].join(':');
+  }
+
   function assistantTurnAnchorEventDedupeKey(event){
     if(!event||typeof event!=='object') return '';
     const eventId=_cleanString(event.event_id);
@@ -141,6 +261,71 @@
 
   function isAssistantTurnAnchorActivityKind(kind){
     return ACTIVITY_EVENT_KINDS.indexOf(kind)!==-1;
+  }
+
+  function normalizeAssistantTurnAnchorSourceEvent(input, context){
+    const event=(input&&typeof input==='object')?input:{};
+    const ctx=(context&&typeof context==='object')?context:{};
+    const payload=_sanitizePayload(_sourceEventPayload(event))||{};
+    const sourceType=_sourceEventType(event,payload);
+    const meta=classifyAssistantTurnAnchorSourceEvent(sourceType);
+    const classification=meta.classification;
+    if(classification==='excluded'){
+      return Object.freeze({
+        classification,
+        source_event_type:sourceType||'unknown',
+        anchor_event:null,
+        dedupe_key:'',
+      });
+    }
+    const eventId=_cleanString(event.event_id||event.lastEventId||event.last_event_id||payload.event_id);
+    const seq=_coerceSeq(
+      event.seq!==undefined?event.seq:
+        payload.seq!==undefined?payload.seq:
+          ctx.seq!==undefined?ctx.seq:
+            _eventIdSeq(eventId)
+    );
+    const runId=_cleanString(event.run_id||payload.run_id||ctx.run_id)||_eventIdRunId(eventId)||null;
+    const sessionId=_cleanString(event.session_id||payload.session_id||ctx.session_id);
+    const turnId=_cleanString(event.turn_id||payload.turn_id||ctx.turn_id);
+    const streamId=_cleanString(event.stream_id||payload.stream_id||ctx.stream_id)||null;
+    const localId=_localIdForSourceEvent(sourceType, {...ctx,seq}, payload);
+    const anchorEvent={
+      event_id:eventId||null,
+      local_id:localId,
+      session_id:sessionId||null,
+      turn_id:turnId||null,
+      run_id:runId,
+      stream_id:streamId,
+      seq,
+      kind:meta.kind,
+      source_event_type:sourceType,
+      created_at:event.created_at||event.timestamp||payload.created_at||payload.ts||ctx.created_at||null,
+      status:_statusForSourceEvent(sourceType,meta.kind,payload),
+      payload,
+    };
+    const dedupeKey=assistantTurnAnchorEventDedupeKey(anchorEvent);
+    return Object.freeze({
+      classification,
+      source_event_type:sourceType,
+      anchor_event:Object.freeze(anchorEvent),
+      dedupe_key:dedupeKey,
+    });
+  }
+
+  function normalizeAssistantTurnAnchorSourceEvents(events, context){
+    const list=Array.isArray(events)?events:[];
+    const out=[];
+    const seen=new Set();
+    list.forEach((event)=>{
+      const normalized=normalizeAssistantTurnAnchorSourceEvent(event,context);
+      if(!normalized.anchor_event) return;
+      const key=normalized.dedupe_key;
+      if(key&&seen.has(key)) return;
+      if(key) seen.add(key);
+      out.push(normalized);
+    });
+    return out;
   }
 
   function createAssistantTurnAnchorSeed(input){
@@ -186,7 +371,7 @@
   }
 
   ROOT.HermesAssistantTurnAnchors=Object.freeze({
-    version:'phase0',
+    version:'slice2-normalizer',
     activityEventKinds:ACTIVITY_EVENT_KINDS,
     stateLayers:STATE_LAYERS,
     sourceEventClassification:SOURCE_EVENT_CLASSIFICATION,
@@ -194,6 +379,8 @@
     createAssistantTurnAnchorSeed,
     assistantTurnAnchorEventDedupeKey,
     classifyAssistantTurnAnchorSourceEvent,
+    normalizeAssistantTurnAnchorSourceEvent,
+    normalizeAssistantTurnAnchorSourceEvents,
     isAssistantTurnAnchorActivityKind,
   });
 })();

--- a/static/assistant_turn_anchors.js
+++ b/static/assistant_turn_anchors.js
@@ -113,6 +113,33 @@
     'excluded',
   ]);
 
+  const UNSAFE_OBJECT_KEYS=Object.freeze([
+    '__proto__',
+    'constructor',
+    'prototype',
+  ]);
+
+  function _isUnsafeObjectKey(key){
+    return UNSAFE_OBJECT_KEYS.indexOf(key)!==-1;
+  }
+
+  function _hasOwn(value, key){
+    return !!value&&typeof value==='object'&&Object.prototype.hasOwnProperty.call(value,key);
+  }
+
+  function _own(value, key){
+    return _hasOwn(value,key)?value[key]:undefined;
+  }
+
+  function _firstOwn(value, keys){
+    if(!value||typeof value!=='object') return undefined;
+    for(let i=0;i<keys.length;i+=1){
+      const item=_own(value,keys[i]);
+      if(item!==undefined&&item!==null&&item!=='') return item;
+    }
+    return undefined;
+  }
+
   function _cleanString(value){
     return typeof value==='string'?value.trim():'';
   }
@@ -145,8 +172,9 @@
     }
     const proto=Object.getPrototypeOf(value);
     if(proto!==null&&Object.prototype.toString.call(value)!=='[object Object]') return '[Object]';
-    const out={};
+    const out=Object.create(null);
     Object.keys(value).sort().forEach((key)=>{
+      if(_isUnsafeObjectKey(key)) return;
       const safe=_sanitizePayload(value[key],depth+1);
       if(safe!==undefined) out[key]=safe;
     });
@@ -173,21 +201,21 @@
   }
 
   function _sourceEventType(input, payload){
-    return _cleanString(input&&(
-      input.source_event_type||
-      input.sourceType||
-      input.source_type||
-      input.event_type||
-      input.type||
-      input.event
-    )) || _cleanString(payload&&(payload.source_event_type||payload.type||payload.event));
+    return _cleanString(_firstOwn(input,[
+      'source_event_type',
+      'sourceType',
+      'source_type',
+      'event_type',
+      'type',
+      'event',
+    ])) || _cleanString(_firstOwn(payload,['source_event_type','type','event']));
   }
 
   function _sourceEventPayload(input){
     if(!input||typeof input!=='object') return {};
-    if(Object.prototype.hasOwnProperty.call(input,'payload')) return _coercePayload(input.payload);
-    if(Object.prototype.hasOwnProperty.call(input,'data')) return _coercePayload(input.data);
-    const payload={};
+    if(_hasOwn(input,'payload')) return _coercePayload(_own(input,'payload'));
+    if(_hasOwn(input,'data')) return _coercePayload(_own(input,'data'));
+    const payload=Object.create(null);
     const reserved=new Set([
       'source_event_type',
       'sourceType',
@@ -207,6 +235,7 @@
       'timestamp',
     ]);
     Object.keys(input).forEach((key)=>{
+      if(_isUnsafeObjectKey(key)) return;
       if(!reserved.has(key)) payload[key]=input[key];
     });
     return payload;
@@ -230,26 +259,28 @@
 
   function _localIdForSourceEvent(sourceType, context, payload){
     const explicit=_cleanString(
-      (context&&context.local_id)||
-      (payload&&(payload.local_id||payload.id||payload.tid||payload.tool_call_id||payload.tool_use_id||payload.call_id))
+      _own(context,'local_id')||
+      _firstOwn(payload,['local_id','id','tid','tool_call_id','tool_use_id','call_id'])
     );
     if(explicit) return explicit;
-    const sessionId=_cleanString(context&&context.session_id)||'session';
-    const turnId=_cleanString(context&&context.turn_id)||'turn';
-    const seq=(context&&context.seq!=null&&context.seq!=='')?String(context.seq):'pending';
+    const sessionId=_cleanString(_own(context,'session_id'))||'session';
+    const turnId=_cleanString(_own(context,'turn_id'))||'turn';
+    const ctxSeq=_own(context,'seq');
+    const seq=(ctxSeq!=null&&ctxSeq!=='')?String(ctxSeq):'pending';
     return [sessionId,turnId,sourceType||'event',seq].join(':');
   }
 
   function assistantTurnAnchorEventDedupeKey(event){
     if(!event||typeof event!=='object') return '';
-    const eventId=_cleanString(event.event_id);
-    if(eventId) return 'event_id:'+eventId;
-    const runId=_cleanString(event.run_id);
-    const seq=(event.seq!=null&&event.seq!=='')?String(event.seq):'';
-    if(runId&&seq) return 'run_seq:'+runId+':'+seq;
-    const sid=_cleanString(event.session_id);
-    const localId=_cleanString(event.local_id);
-    if(sid&&localId) return 'local:'+sid+':'+localId;
+    const eventId=_cleanString(_own(event,'event_id'));
+    if(eventId) return 'event_id:'+JSON.stringify(eventId);
+    const runId=_cleanString(_own(event,'run_id'));
+    const eventSeq=_own(event,'seq');
+    const seq=(eventSeq!=null&&eventSeq!=='')?String(eventSeq):'';
+    if(runId&&seq) return 'run_seq:'+JSON.stringify([runId,seq]);
+    const sid=_cleanString(_own(event,'session_id'));
+    const localId=_cleanString(_own(event,'local_id'));
+    if(sid&&localId) return 'local:'+JSON.stringify([sid,localId]);
     return '';
   }
 
@@ -291,17 +322,19 @@
         dedupe_key:'',
       });
     }
-    const eventId=_cleanString(event.event_id||event.lastEventId||event.last_event_id||rawPayload.event_id);
+    const eventId=_cleanString(_firstOwn(event,['event_id','lastEventId','last_event_id'])||_payloadEventId);
+    const eventSeq=_own(event,'seq');
+    const ctxSeq=_own(ctx,'seq');
     const seq=_coerceSeq(
-      event.seq!==undefined?event.seq:
-        rawPayload.seq!==undefined?rawPayload.seq:
-          ctx.seq!==undefined?ctx.seq:
+      eventSeq!==undefined?eventSeq:
+        _payloadSeq!==undefined?_payloadSeq:
+          ctxSeq!==undefined?ctxSeq:
             _eventIdSeq(eventId)
     );
-    const runId=_cleanString(event.run_id||rawPayload.run_id||ctx.run_id)||_eventIdRunId(eventId)||null;
-    const sessionId=_cleanString(event.session_id||rawPayload.session_id||ctx.session_id);
-    const turnId=_cleanString(event.turn_id||rawPayload.turn_id||ctx.turn_id);
-    const streamId=_cleanString(event.stream_id||rawPayload.stream_id||ctx.stream_id)||null;
+    const runId=_cleanString(_own(event,'run_id')||_payloadRunId||_own(ctx,'run_id'))||_eventIdRunId(eventId)||null;
+    const sessionId=_cleanString(_own(event,'session_id')||_payloadSessionId||_own(ctx,'session_id'));
+    const turnId=_cleanString(_own(event,'turn_id')||_payloadTurnId||_own(ctx,'turn_id'));
+    const streamId=_cleanString(_own(event,'stream_id')||_payloadStreamId||_own(ctx,'stream_id'))||null;
     const localId=_localIdForSourceEvent(sourceType, {...ctx,seq}, payload);
     const anchorEvent={
       event_id:eventId||null,
@@ -313,7 +346,7 @@
       seq,
       kind:meta.kind,
       source_event_type:sourceType,
-      created_at:event.created_at||event.timestamp||payload.created_at||payload.ts||ctx.created_at||null,
+      created_at:_own(event,'created_at')||_own(event,'timestamp')||_own(payload,'created_at')||_own(payload,'ts')||_own(ctx,'created_at')||null,
       status:_statusForSourceEvent(sourceType,meta.kind,payload),
       payload,
     };

--- a/static/assistant_turn_anchors.js
+++ b/static/assistant_turn_anchors.js
@@ -143,6 +143,8 @@
     if(Array.isArray(value)){
       return value.map((item)=>_sanitizePayload(item,depth+1)).filter((item)=>item!==undefined);
     }
+    const proto=Object.getPrototypeOf(value);
+    if(proto!==null&&Object.prototype.toString.call(value)!=='[object Object]') return '[Object]';
     const out={};
     Object.keys(value).sort().forEach((key)=>{
       const safe=_sanitizePayload(value[key],depth+1);
@@ -190,6 +192,7 @@
       'source_event_type',
       'sourceType',
       'source_type',
+      'event_type',
       'type',
       'event',
       'event_id',
@@ -266,7 +269,17 @@
   function normalizeAssistantTurnAnchorSourceEvent(input, context){
     const event=(input&&typeof input==='object')?input:{};
     const ctx=(context&&typeof context==='object')?context:{};
-    const payload=_sanitizePayload(_sourceEventPayload(event))||{};
+    const sanitizedPayload=_sanitizePayload(_sourceEventPayload(event));
+    const rawPayload=(sanitizedPayload&&typeof sanitizedPayload==='object'&&!Array.isArray(sanitizedPayload))?sanitizedPayload:{};
+    const {
+      session_id:_payloadSessionId,
+      turn_id:_payloadTurnId,
+      run_id:_payloadRunId,
+      stream_id:_payloadStreamId,
+      event_id:_payloadEventId,
+      seq:_payloadSeq,
+      ...payload
+    }=rawPayload;
     const sourceType=_sourceEventType(event,payload);
     const meta=classifyAssistantTurnAnchorSourceEvent(sourceType);
     const classification=meta.classification;
@@ -278,17 +291,17 @@
         dedupe_key:'',
       });
     }
-    const eventId=_cleanString(event.event_id||event.lastEventId||event.last_event_id||payload.event_id);
+    const eventId=_cleanString(event.event_id||event.lastEventId||event.last_event_id||rawPayload.event_id);
     const seq=_coerceSeq(
       event.seq!==undefined?event.seq:
-        payload.seq!==undefined?payload.seq:
+        rawPayload.seq!==undefined?rawPayload.seq:
           ctx.seq!==undefined?ctx.seq:
             _eventIdSeq(eventId)
     );
-    const runId=_cleanString(event.run_id||payload.run_id||ctx.run_id)||_eventIdRunId(eventId)||null;
-    const sessionId=_cleanString(event.session_id||payload.session_id||ctx.session_id);
-    const turnId=_cleanString(event.turn_id||payload.turn_id||ctx.turn_id);
-    const streamId=_cleanString(event.stream_id||payload.stream_id||ctx.stream_id)||null;
+    const runId=_cleanString(event.run_id||rawPayload.run_id||ctx.run_id)||_eventIdRunId(eventId)||null;
+    const sessionId=_cleanString(event.session_id||rawPayload.session_id||ctx.session_id);
+    const turnId=_cleanString(event.turn_id||rawPayload.turn_id||ctx.turn_id);
+    const streamId=_cleanString(event.stream_id||rawPayload.stream_id||ctx.stream_id)||null;
     const localId=_localIdForSourceEvent(sourceType, {...ctx,seq}, payload);
     const anchorEvent={
       event_id:eventId||null,

--- a/tests/test_stable_assistant_turn_anchor_normalizer.py
+++ b/tests/test_stable_assistant_turn_anchor_normalizer.py
@@ -1,0 +1,194 @@
+"""Slice 2 normalizer tests for Stable Assistant Turn Anchors (#3926)."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+ANCHORS_JS = REPO / "static" / "assistant_turn_anchors.js"
+MESSAGES_JS = REPO / "static" / "messages.js"
+UI_JS = REPO / "static" / "ui.js"
+SESSIONS_JS = REPO / "static" / "sessions.js"
+NODE = shutil.which("node")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _normalizer_snapshot() -> dict:
+    assert NODE, "node is required for assistant_turn_anchors.js normalizer tests"
+    script = f"""
+const fs = require('fs');
+const vm = require('vm');
+const src = fs.readFileSync({json.dumps(str(ANCHORS_JS))}, 'utf8');
+const sandbox = {{window:{{}}}};
+vm.createContext(sandbox);
+vm.runInContext(src, sandbox, {{filename:'assistant_turn_anchors.js'}});
+const api = sandbox.window.HermesAssistantTurnAnchors;
+const context = {{
+  session_id:'sid-1',
+  turn_id:'turn-1',
+  run_id:'run-1',
+  stream_id:'stream-1',
+}};
+const liveToken = api.normalizeAssistantTurnAnchorSourceEvent({{
+  type:'token',
+  data:JSON.stringify({{text:'hello', session_id:'sid-1'}}),
+  lastEventId:'run-1:7',
+}}, context);
+const replayToken = api.normalizeAssistantTurnAnchorSourceEvent({{
+  event:'token',
+  payload:{{text:'hello', session_id:'sid-1'}},
+  event_id:'run-1:7',
+  seq:7,
+}}, context);
+const settled = api.normalizeAssistantTurnAnchorSourceEvent({{
+  source_type:'settled_message',
+  payload:{{
+    role:'assistant',
+    content:'final',
+    reasoning:'trace',
+    _turnUsage:{{input_tokens:3, output_tokens:5}},
+  }},
+}}, context);
+const artifact = api.normalizeAssistantTurnAnchorSourceEvent({{
+  source_type:'artifact_reference',
+  payload:{{path:'result.txt', kind:'workspace_file'}},
+  event_id:'run-1:8',
+}}, context);
+const sideEffect = api.normalizeAssistantTurnAnchorSourceEvent({{
+  type:'state_saved',
+  payload:{{kind:'memory', name:'saved-state'}},
+  event_id:'run-1:9',
+}}, context);
+const transport = api.normalizeAssistantTurnAnchorSourceEvent({{
+  type:'stream_end',
+  data:'{{"session_id":"sid-1"}}',
+  event_id:'run-1:10',
+}}, context);
+const unknown = api.normalizeAssistantTurnAnchorSourceEvent({{
+  type:'unknown_future_event',
+  payload:{{text:'ignored'}},
+}}, context);
+const deduped = api.normalizeAssistantTurnAnchorSourceEvents([
+  {{type:'token', data:'{{"text":"live"}}', lastEventId:'run-1:11'}},
+  {{event:'token', payload:{{text:'replay'}}, event_id:'run-1:11', seq:11}},
+  {{event:'reasoning', payload:{{text:'thinking'}}, event_id:'run-1:12', seq:12}},
+], context);
+const invalidPayload = api.normalizeAssistantTurnAnchorSourceEvent({{
+  type:'token',
+  data:'plain text chunk',
+  event_id:'run-1:13',
+}}, context);
+const directParsedPayload = api.normalizeAssistantTurnAnchorSourceEvent({{
+  source_type:'token',
+  text:'direct parsed payload',
+  event_id:'run-1:14',
+  seq:14,
+}}, context);
+console.log(JSON.stringify({{
+  version: api.version,
+  liveToken,
+  replayToken,
+  settled,
+  artifact,
+  sideEffect,
+  transport,
+  unknown,
+  deduped,
+  invalidPayload,
+  directParsedPayload,
+}}));
+"""
+    result = subprocess.run([NODE, "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_normalizer_maps_live_and_replay_to_same_anchor_event_identity():
+    data = _normalizer_snapshot()
+    live = data["liveToken"]
+    replay = data["replayToken"]
+
+    assert data["version"] == "slice2-normalizer"
+    assert live["classification"] == "activity"
+    assert live["dedupe_key"] == "event_id:run-1:7"
+    assert replay["dedupe_key"] == live["dedupe_key"]
+    assert live["anchor_event"]["kind"] == "process_prose"
+    assert live["anchor_event"]["source_event_type"] == "token"
+    assert live["anchor_event"]["session_id"] == "sid-1"
+    assert live["anchor_event"]["turn_id"] == "turn-1"
+    assert live["anchor_event"]["run_id"] == "run-1"
+    assert live["anchor_event"]["stream_id"] == "stream-1"
+    assert live["anchor_event"]["seq"] == 7
+    assert live["anchor_event"]["payload"] == {"session_id": "sid-1", "text": "hello"}
+
+
+def test_normalizer_keeps_artifact_side_effect_metadata_and_transport_distinct():
+    data = _normalizer_snapshot()
+
+    settled = data["settled"]
+    assert settled["classification"] == "metadata"
+    assert settled["anchor_event"]["kind"] is None
+    assert settled["anchor_event"]["source_event_type"] == "settled_message"
+    assert settled["anchor_event"]["payload"]["role"] == "assistant"
+    assert settled["anchor_event"]["payload"]["_turnUsage"] == {"input_tokens": 3, "output_tokens": 5}
+
+    artifact = data["artifact"]
+    assert artifact["classification"] == "artifact"
+    assert artifact["anchor_event"]["kind"] == "artifact_reference"
+    assert artifact["anchor_event"]["payload"] == {"kind": "workspace_file", "path": "result.txt"}
+
+    side_effect = data["sideEffect"]
+    assert side_effect["classification"] == "side_effect"
+    assert side_effect["anchor_event"]["kind"] is None
+    assert side_effect["anchor_event"]["payload"] == {"kind": "memory", "name": "saved-state"}
+
+    transport = data["transport"]
+    assert transport["classification"] == "transport"
+    assert transport["anchor_event"]["kind"] is None
+    assert transport["anchor_event"]["status"] == "transport_closed"
+
+
+def test_normalizer_excludes_unknown_sources_and_sanitizes_non_json_data():
+    data = _normalizer_snapshot()
+
+    assert data["unknown"] == {
+        "classification": "excluded",
+        "source_event_type": "unknown_future_event",
+        "anchor_event": None,
+        "dedupe_key": "",
+    }
+    assert data["invalidPayload"]["anchor_event"]["payload"] == {"text": "plain text chunk"}
+    assert data["invalidPayload"]["dedupe_key"] == "event_id:run-1:13"
+    assert data["directParsedPayload"]["anchor_event"]["payload"] == {"text": "direct parsed payload"}
+    assert data["directParsedPayload"]["anchor_event"]["seq"] == 14
+
+
+def test_batch_normalizer_dedupes_live_plus_replay_by_event_envelope():
+    data = _normalizer_snapshot()
+    deduped = data["deduped"]
+
+    assert [item["dedupe_key"] for item in deduped] == [
+        "event_id:run-1:11",
+        "event_id:run-1:12",
+    ]
+    assert [item["anchor_event"]["kind"] for item in deduped] == [
+        "process_prose",
+        "reasoning",
+    ]
+    assert deduped[0]["anchor_event"]["payload"] == {"text": "live"}
+
+
+def test_slice2_normalizer_is_still_unwired_from_rendering_hot_paths():
+    helper_names = [
+        "normalizeAssistantTurnAnchorSourceEvent",
+        "normalizeAssistantTurnAnchorSourceEvents",
+    ]
+    for helper in helper_names:
+        assert helper not in _read(UI_JS)
+        assert helper not in _read(SESSIONS_JS)
+        assert helper not in _read(MESSAGES_JS)

--- a/tests/test_stable_assistant_turn_anchor_normalizer.py
+++ b/tests/test_stable_assistant_turn_anchor_normalizer.py
@@ -113,6 +113,39 @@ const promotedIdentityPayload = api.normalizeAssistantTurnAnchorSourceEvent({{
   }},
   event_id:'run-1:17',
 }}, context);
+const pollutionPayload = JSON.parse('{{"text":"clean","__proto__":{{"session_id":"polluted-session","run_id":"polluted-run"}},"constructor":{{"bad":true}},"prototype":{{"bad":true}}}}');
+const pollutionAttempt = api.normalizeAssistantTurnAnchorSourceEvent({{
+  type:'token',
+  payload:pollutionPayload,
+  event_id:'run-1:18',
+}}, context);
+const inheritedEvent = Object.create({{
+  event_id:'evil:1',
+  session_id:'evil-session',
+  run_id:'evil-run',
+  stream_id:'evil-stream',
+  seq:666,
+  created_at:'evil-time',
+}});
+inheritedEvent.type = 'token';
+inheritedEvent.payload = {{text:'own event only'}};
+const inheritedEnvelopeIdentity = api.normalizeAssistantTurnAnchorSourceEvent(inheritedEvent, context);
+const inheritedContext = Object.create({{
+  session_id:'evil-context-session',
+  turn_id:'evil-context-turn',
+  run_id:'evil-context-run',
+  stream_id:'evil-context-stream',
+  seq:777,
+  created_at:'evil-context-time',
+}});
+const inheritedContextIdentity = api.normalizeAssistantTurnAnchorSourceEvent({{
+  type:'token',
+  payload:{{text:'own context only'}},
+}}, inheritedContext);
+const runSeqCollisionA = api.assistantTurnAnchorEventDedupeKey({{run_id:'a:b', seq:'c'}});
+const runSeqCollisionB = api.assistantTurnAnchorEventDedupeKey({{run_id:'a', seq:'b:c'}});
+const localCollisionA = api.assistantTurnAnchorEventDedupeKey({{session_id:'a:b', local_id:'c'}});
+const localCollisionB = api.assistantTurnAnchorEventDedupeKey({{session_id:'a', local_id:'b:c'}});
 console.log(JSON.stringify({{
   version: api.version,
   liveToken,
@@ -128,6 +161,13 @@ console.log(JSON.stringify({{
   eventTypePayload,
   nonPlainPayload,
   promotedIdentityPayload,
+  pollutionAttempt,
+  inheritedEnvelopeIdentity,
+  inheritedContextIdentity,
+  runSeqCollisionA,
+  runSeqCollisionB,
+  localCollisionA,
+  localCollisionB,
 }}));
 """
     result = subprocess.run([NODE, "-e", script], text=True, capture_output=True, check=False)
@@ -142,7 +182,7 @@ def test_normalizer_maps_live_and_replay_to_same_anchor_event_identity():
 
     assert data["version"] == "slice2-normalizer"
     assert live["classification"] == "activity"
-    assert live["dedupe_key"] == "event_id:run-1:7"
+    assert live["dedupe_key"] == 'event_id:"run-1:7"'
     assert replay["dedupe_key"] == live["dedupe_key"]
     assert live["anchor_event"]["kind"] == "process_prose"
     assert live["anchor_event"]["source_event_type"] == "token"
@@ -190,7 +230,7 @@ def test_normalizer_excludes_unknown_sources_and_sanitizes_non_json_data():
         "dedupe_key": "",
     }
     assert data["invalidPayload"]["anchor_event"]["payload"] == {"text": "plain text chunk"}
-    assert data["invalidPayload"]["dedupe_key"] == "event_id:run-1:13"
+    assert data["invalidPayload"]["dedupe_key"] == 'event_id:"run-1:13"'
     assert data["directParsedPayload"]["anchor_event"]["payload"] == {"text": "direct parsed payload"}
     assert data["directParsedPayload"]["anchor_event"]["seq"] == 14
 
@@ -217,6 +257,35 @@ def test_normalizer_strips_discriminators_and_promoted_identity_fields_from_payl
     }
 
 
+def test_normalizer_rejects_pollution_keys_and_inherited_identity_fields():
+    data = _normalizer_snapshot()
+
+    pollution = data["pollutionAttempt"]
+    assert pollution["dedupe_key"] == 'event_id:"run-1:18"'
+    assert pollution["anchor_event"]["session_id"] == "sid-1"
+    assert pollution["anchor_event"]["run_id"] == "run-1"
+    assert pollution["anchor_event"]["payload"] == {"text": "clean"}
+
+    inherited_event = data["inheritedEnvelopeIdentity"]["anchor_event"]
+    assert inherited_event["event_id"] is None
+    assert inherited_event["session_id"] == "sid-1"
+    assert inherited_event["run_id"] == "run-1"
+    assert inherited_event["stream_id"] == "stream-1"
+    assert inherited_event["seq"] is None
+    assert inherited_event["created_at"] is None
+    assert inherited_event["payload"] == {"text": "own event only"}
+
+    inherited_context = data["inheritedContextIdentity"]["anchor_event"]
+    assert inherited_context["event_id"] is None
+    assert inherited_context["session_id"] is None
+    assert inherited_context["turn_id"] is None
+    assert inherited_context["run_id"] is None
+    assert inherited_context["stream_id"] is None
+    assert inherited_context["seq"] is None
+    assert inherited_context["created_at"] is None
+    assert inherited_context["payload"] == {"text": "own context only"}
+
+
 def test_normalizer_marks_non_plain_payload_objects_explicitly():
     data = _normalizer_snapshot()
 
@@ -231,14 +300,25 @@ def test_batch_normalizer_dedupes_live_plus_replay_by_event_envelope():
     deduped = data["deduped"]
 
     assert [item["dedupe_key"] for item in deduped] == [
-        "event_id:run-1:11",
-        "event_id:run-1:12",
+        'event_id:"run-1:11"',
+        'event_id:"run-1:12"',
     ]
     assert [item["anchor_event"]["kind"] for item in deduped] == [
         "process_prose",
         "reasoning",
     ]
     assert deduped[0]["anchor_event"]["payload"] == {"text": "live"}
+
+
+def test_structured_fallback_dedupe_keys_do_not_collide_on_delimiters():
+    data = _normalizer_snapshot()
+
+    assert data["runSeqCollisionA"] == 'run_seq:["a:b","c"]'
+    assert data["runSeqCollisionB"] == 'run_seq:["a","b:c"]'
+    assert data["runSeqCollisionA"] != data["runSeqCollisionB"]
+    assert data["localCollisionA"] == 'local:["a:b","c"]'
+    assert data["localCollisionB"] == 'local:["a","b:c"]'
+    assert data["localCollisionA"] != data["localCollisionB"]
 
 
 def test_slice2_normalizer_is_still_unwired_from_rendering_hot_paths():

--- a/tests/test_stable_assistant_turn_anchor_normalizer.py
+++ b/tests/test_stable_assistant_turn_anchor_normalizer.py
@@ -89,6 +89,30 @@ const directParsedPayload = api.normalizeAssistantTurnAnchorSourceEvent({{
   event_id:'run-1:14',
   seq:14,
 }}, context);
+const eventTypePayload = api.normalizeAssistantTurnAnchorSourceEvent({{
+  event_type:'tool',
+  event_id:'run-1:15',
+  tool_call_id:'tool-1',
+  someField:'x',
+}}, context);
+const nonPlainPayload = api.normalizeAssistantTurnAnchorSourceEvent({{
+  type:'token',
+  payload:{{text:'date payload', meta:new Date('2026-06-11T00:00:00Z')}},
+  event_id:'run-1:16',
+}}, context);
+const promotedIdentityPayload = api.normalizeAssistantTurnAnchorSourceEvent({{
+  type:'token',
+  payload:{{
+    text:'identity fields should be promoted only',
+    session_id:'payload-session',
+    turn_id:'payload-turn',
+    run_id:'payload-run',
+    stream_id:'payload-stream',
+    event_id:'payload-event',
+    seq:99,
+  }},
+  event_id:'run-1:17',
+}}, context);
 console.log(JSON.stringify({{
   version: api.version,
   liveToken,
@@ -101,6 +125,9 @@ console.log(JSON.stringify({{
   deduped,
   invalidPayload,
   directParsedPayload,
+  eventTypePayload,
+  nonPlainPayload,
+  promotedIdentityPayload,
 }}));
 """
     result = subprocess.run([NODE, "-e", script], text=True, capture_output=True, check=False)
@@ -124,7 +151,7 @@ def test_normalizer_maps_live_and_replay_to_same_anchor_event_identity():
     assert live["anchor_event"]["run_id"] == "run-1"
     assert live["anchor_event"]["stream_id"] == "stream-1"
     assert live["anchor_event"]["seq"] == 7
-    assert live["anchor_event"]["payload"] == {"session_id": "sid-1", "text": "hello"}
+    assert live["anchor_event"]["payload"] == {"text": "hello"}
 
 
 def test_normalizer_keeps_artifact_side_effect_metadata_and_transport_distinct():
@@ -166,6 +193,37 @@ def test_normalizer_excludes_unknown_sources_and_sanitizes_non_json_data():
     assert data["invalidPayload"]["dedupe_key"] == "event_id:run-1:13"
     assert data["directParsedPayload"]["anchor_event"]["payload"] == {"text": "direct parsed payload"}
     assert data["directParsedPayload"]["anchor_event"]["seq"] == 14
+
+
+def test_normalizer_strips_discriminators_and_promoted_identity_fields_from_payload():
+    data = _normalizer_snapshot()
+
+    event_type_payload = data["eventTypePayload"]
+    assert event_type_payload["anchor_event"]["source_event_type"] == "tool"
+    assert event_type_payload["anchor_event"]["payload"] == {
+        "someField": "x",
+        "tool_call_id": "tool-1",
+    }
+
+    promoted = data["promotedIdentityPayload"]
+    assert promoted["anchor_event"]["event_id"] == "run-1:17"
+    assert promoted["anchor_event"]["session_id"] == "payload-session"
+    assert promoted["anchor_event"]["turn_id"] == "payload-turn"
+    assert promoted["anchor_event"]["run_id"] == "payload-run"
+    assert promoted["anchor_event"]["stream_id"] == "payload-stream"
+    assert promoted["anchor_event"]["seq"] == 99
+    assert promoted["anchor_event"]["payload"] == {
+        "text": "identity fields should be promoted only"
+    }
+
+
+def test_normalizer_marks_non_plain_payload_objects_explicitly():
+    data = _normalizer_snapshot()
+
+    assert data["nonPlainPayload"]["anchor_event"]["payload"] == {
+        "meta": "[Object]",
+        "text": "date payload",
+    }
 
 
 def test_batch_normalizer_dedupes_live_plus_replay_by_event_envelope():

--- a/tests/test_stable_assistant_turn_anchor_phase0.py
+++ b/tests/test_stable_assistant_turn_anchor_phase0.py
@@ -144,12 +144,12 @@ def test_phase0_classifies_all_current_live_to_final_sources():
 
 def test_phase0_dedupe_prefers_event_envelope_not_visible_text_or_timestamps():
     data = _anchor_api_snapshot()
-    assert data["eventIdKey"] == "event_id:run-1:2"
-    assert data["runSeqKey"] == "run_seq:run-1:2"
-    assert data["localKey"] == "local:sid-1:local-1"
-    assert data["zeroSeqKey"] == "run_seq:run-1:0"
-    assert data["nanSeqKey"] == "run_seq:run-1:NaN"
-    assert data["emptySeqKey"] == "local:sid-1:local-1"
+    assert data["eventIdKey"] == 'event_id:"run-1:2"'
+    assert data["runSeqKey"] == 'run_seq:["run-1","2"]'
+    assert data["localKey"] == 'local:["sid-1","local-1"]'
+    assert data["zeroSeqKey"] == 'run_seq:["run-1","0"]'
+    assert data["nanSeqKey"] == 'run_seq:["run-1","NaN"]'
+    assert data["emptySeqKey"] == 'local:["sid-1","local-1"]'
     assert data["emptyKey"] == ""
 
     helper_src = _read(ANCHORS_JS).split("function assistantTurnAnchorEventDedupeKey", 1)[1]


### PR DESCRIPTION
## Summary

- Add inert assistant-turn source normalizer helpers to `HermesAssistantTurnAnchors`.
- Normalize live SSE-like events, replay/journal events, and settled/session payload events into one anchor event shape.
- Deduplicate repeated live + replay observations by Event Envelope identity (`event_id`, then `run_id + seq`, then browser local fallback).
- Document the Slice 2 helper contract and add focused normalizer tests.

## Lineage and tracking

- Related tracking: #3400 and #3926.
- #3400 is the parent Live-to-Final / Long-Running Session umbrella.
- #3926 is the Stable Assistant Turn Anchors rollout tracker and remains open after this PR.
- #3927 merged the Stable Assistant Turn Anchors RFC.
- #3962 was the Phase 0 scaffold PR. It is closed-unmerged because the same Phase 0 scaffold shipped through release PR #3977 / v0.51.359.
- This PR is the next inert implementation slice after #3962/#3977: it adds the source-event normalizer that later anchor registry, replay, settlement, Compact Worklog, and Transparent Stream slices can consume.

## Scope

- This is Slice 2 normalizer work only.
- It builds on the Phase 0 scaffold shipped through #3977 / v0.51.359.
- Inert by design: this PR does not wire anchors into `send()`, `attachLiveStream()`, `renderMessages()`, `S.messages`, `INFLIGHT`, or the DOM.
- Compact Worklog, Transparent Stream, settlement, replay/reload reconstruction, renderer ownership, artifacts, side effects, and usage/terminal metadata remain follow-up slices.

## Not included

- Does not close #3926.
- Does not implement the Transparent Stream UI work tracked by #3820.
- Does not address #3971 / #3903 Hide Thinking vs Worklog reasoning visibility.
- Does not address #3823 / #3821 tool-limit terminal-state behavior.
- Does not address #3899 / #3900 session-switch false streaming / live-turn restore behavior.

## Verification

- `node --check static/assistant_turn_anchors.js`
- `python -m pytest tests/test_stable_assistant_turn_anchor_normalizer.py tests/test_stable_assistant_turn_anchor_phase0.py -v --timeout=60`