### PR TITLE
[security] fix(session): scope exports to active profile

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -182,7 +182,10 @@ def _visible_pinned_lineage_ids(session_rows) -> set[str]:
 # (mcp_server.py) can import it without duplicating the visibility model.
 # Re-exported here so existing `_profiles_match(...)` call sites in this
 # module keep resolving without per-call-site refactors.
-from api.profiles import _profiles_match  # noqa: F401, E402  (re-export)
+from api.profiles import (  # noqa: F401, E402  (re-export)
+    _profiles_match,
+    get_active_profile_name,
+)
 
 
 def _all_profiles_query_flag(parsed_url) -> bool:
@@ -9230,9 +9233,8 @@ def _handle_session_export(handler, parsed):
         s = get_session(sid)
     except KeyError:
         return bad(handler, "Session not found", 404)
-    from api.profiles import get_active_profile_name
-
-    if not _profiles_match(getattr(s, "profile", None), get_active_profile_name()):
+    active_profile = get_active_profile_name()
+    if not _profiles_match(getattr(s, "profile", None), active_profile):
         return bad(handler, "Session not found", 404)
     safe = redact_session_data(s.__dict__)
     payload = json.dumps(safe, ensure_ascii=False, indent=2)

--- a/api/routes.py
+++ b/api/routes.py
@@ -9230,6 +9230,10 @@ def _handle_session_export(handler, parsed):
         s = get_session(sid)
     except KeyError:
         return bad(handler, "Session not found", 404)
+    from api.profiles import get_active_profile_name
+
+    if not _profiles_match(getattr(s, "profile", None), get_active_profile_name()):
+        return bad(handler, "Session not found", 404)
     safe = redact_session_data(s.__dict__)
     payload = json.dumps(safe, ensure_ascii=False, indent=2)
     handler.send_response(200)

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -260,7 +260,7 @@ def test_session_export_rejects_session_from_inactive_profile():
     handler = _ExportCaptureHandler()
     parsed = urlparse("/api/session/export?session_id=foreign_export_001")
     with patch("api.routes.get_session", return_value=foreign), \
-         patch("api.profiles.get_active_profile_name", return_value="default"), \
+         patch("api.routes.get_active_profile_name", return_value="default"), \
          patch("api.routes.bad", side_effect=fake_bad):
         routes._handle_session_export(handler, parsed)
 
@@ -282,7 +282,8 @@ def test_session_export_allows_session_from_active_profile():
     handler = _ExportCaptureHandler()
     parsed = urlparse("/api/session/export?session_id=active_export_001")
     with patch("api.routes.get_session", return_value=active), \
-         patch("api.profiles.get_active_profile_name", return_value="default"):
+         patch("api.routes.get_active_profile_name", return_value="default"), \
+         patch("api.routes.redact_session_data", side_effect=lambda data: data):
         routes._handle_session_export(handler, parsed)
 
     assert handler.status == 200

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -14,6 +14,8 @@ all_profiles=1 opt-in path. End-to-end HTTP-level tests live separately under
 tests/test_sessions_endpoint.py if/when added.
 """
 
+from types import SimpleNamespace
+from unittest.mock import patch
 from urllib.parse import urlparse
 
 import pytest
@@ -207,6 +209,86 @@ def test_static_sessions_js_trusts_server_profile_scoping():
     assert forbidden_count not in src, (
         "Client otherProfileCount must come from server, not strict-equality fallback"
     )
+
+
+# ── Direct session export must also honor active profile ───────────────────
+
+
+class _ExportCaptureHandler:
+    def __init__(self):
+        self.headers = {}
+        self.status = None
+        self.sent_headers = []
+        self.ended = False
+        self.wfile = SimpleNamespace(write=self._write)
+        self.body = b""
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.sent_headers.append((name, value))
+
+    def end_headers(self):
+        self.ended = True
+
+    def _write(self, data):
+        self.body += data
+
+
+def test_session_export_rejects_session_from_inactive_profile():
+    """A known session_id from another profile must not bypass /api/sessions scoping.
+
+    /api/sessions hides foreign-profile rows by default, but the export endpoint
+    loaded directly by id and serialized the sidecar. It must apply the same
+    active-profile check before writing the JSON attachment.
+    """
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_bad(_handler, message, status=400, **_kwargs):
+        captured["bad"] = {"message": message, "status": status}
+        return captured["bad"]
+
+    foreign = SimpleNamespace(
+        session_id="foreign_export_001",
+        profile="other",
+        messages=[{"role": "user", "content": "foreign profile secret"}],
+    )
+
+    handler = _ExportCaptureHandler()
+    parsed = urlparse("/api/session/export?session_id=foreign_export_001")
+    with patch("api.routes.get_session", return_value=foreign), \
+         patch("api.profiles.get_active_profile_name", return_value="default"), \
+         patch("api.routes.bad", side_effect=fake_bad):
+        routes._handle_session_export(handler, parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert handler.status is None
+    assert handler.body == b""
+
+
+def test_session_export_allows_session_from_active_profile():
+    """Same-profile exports still stream the redacted JSON attachment."""
+    import api.routes as routes
+
+    active = SimpleNamespace(
+        session_id="active_export_001",
+        profile="default",
+        messages=[{"role": "user", "content": "same profile content"}],
+    )
+
+    handler = _ExportCaptureHandler()
+    parsed = urlparse("/api/session/export?session_id=active_export_001")
+    with patch("api.routes.get_session", return_value=active), \
+         patch("api.profiles.get_active_profile_name", return_value="default"):
+        routes._handle_session_export(handler, parsed)
+
+    assert handler.status == 200
+    assert handler.ended is True
+    assert b"same profile content" in handler.body
+    assert ("Cache-Control", "no-store") in handler.sent_headers
 
 
 # ── Cleanup ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR hardens direct session export so it follows the same active-profile boundary as the session list API.

- Fixes a direct `GET /api/session/export?session_id=...` path that could serialize a known cross-profile session id.
- Applies the existing `_profiles_match(...)` profile comparison before writing the JSON attachment.
- Returns the same `404` shape used for missing sessions so the export path does not disclose foreign-profile session existence.
- Adds regression coverage for both rejected cross-profile exports and allowed same-profile exports.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Direct session export bypassed active-profile scoping | A user with access to one Hermes profile could export another profile's session JSON if they knew or recovered the session id | Medium |

## Before this PR
- `/api/sessions` scoped the visible session list to the active profile.
- `/api/session/export` accepted a raw `session_id`, loaded the session, redacted it, and streamed it as JSON without checking the active profile.
- Regression coverage covered profile scoping for list behavior, but not the direct export endpoint.

## After this PR
- `/api/session/export` resolves the active Hermes profile and checks the target session with `_profiles_match(...)` before serialization.
- Explicitly cross-profile exports return `404` before headers or JSON content are written.
- Same-profile exports continue to stream the existing redacted JSON attachment.
- Tests now cover both the rejection and allowed-export paths.

## Why this matters
The UI list already treats profile boundaries as meaningful, but a direct export endpoint should not be a weaker bypass around that boundary. Session exports can include conversation content and metadata, so a known or stale session id from another profile should not be enough to retrieve that profile's transcript JSON.

## How this differs from related issue/PR
This is a sibling boundary to the existing `/api/sessions` profile-scoping work. The list endpoint can hide foreign-profile rows while a direct-by-id export endpoint still needs its own authorization check because it does not depend on list visibility.

## Attack flow
```text
user is active in profile A
    -> sends GET /api/session/export?session_id=<profile-B-session>
        -> endpoint loads by id without checking active profile
            -> redacted JSON export is streamed
                -> profile-B session transcript/metadata is exposed to profile A
```

## Affected code

| Issue | Files |
|-------|-------|
| Direct session export bypassed active-profile scoping | `api/routes.py`, `tests/test_issue1611_session_profile_filtering.py` |

## Root cause
Issue 1: Direct session export bypassed active-profile scoping
- The export handler loaded sessions directly by id and immediately serialized the sidecar through `redact_session_data(...)`.
- The active-profile comparison used elsewhere was not applied to this direct export path.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Direct session export bypassed active-profile scoping | 6.5 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` |

Rationale:
- The impact is bounded to confidentiality of sessions stored by the same WebUI deployment, but the endpoint is network-reachable and requires only a valid session id plus normal access to the WebUI.

## Safe reproduction steps
1. Create or stub a session record tagged to profile `other`.
2. Run the WebUI/API with active profile `default`.
3. Request `GET /api/session/export?session_id=<other-profile-session-id>`.
4. On the vulnerable path, observe that the response streams the exported JSON attachment instead of denying the cross-profile session.

## Expected vulnerable behavior
- A direct export request for a foreign-profile session should never serialize the session body.
- The pre-patch handler did not check the active profile before export serialization.
- The safe proof signal is the absence of a `404` and the presence of the foreign-profile JSON attachment.

## Changes in this PR
- Adds an active-profile lookup inside `_handle_session_export(...)`.
- Reuses `_profiles_match(...)` to preserve existing default/root-profile alias semantics.
- Returns `404` for foreign-profile sessions before the export response is started.
- Adds focused regression tests for cross-profile denial and same-profile export compatibility.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| API hardening | `api/routes.py` | Profile-checks the loaded session before export serialization |
| Tests | `tests/test_issue1611_session_profile_filtering.py` | Adds direct export regression coverage |

## Maintainer impact
- Narrow API-only change to the direct session export handler.
- Existing same-profile export behavior, redaction, filename, and cache headers are preserved.
- The patch reuses existing profile comparison semantics instead of introducing a second profile-matching model.
- No frontend, CLI, storage format, or unrelated route changes are included.

## Fix rationale
- The export endpoint is the correct place to enforce this because it is the direct-by-id read boundary.
- Returning `404` matches the existing missing-session behavior and avoids confirming whether a foreign-profile session id exists.
- Tests exercise both denial and compatibility so future refactors cannot silently re-open the direct export path.

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] `pytest tests/test_issue1611_session_profile_filtering.py -q`
- [x] `pytest tests/test_issue1611_session_profile_filtering.py tests/test_session_tail_payload.py tests/test_session_metadata_cli_lookup.py -q`

Executed with:
- `pytest tests/test_issue1611_session_profile_filtering.py -q`
- `pytest tests/test_issue1611_session_profile_filtering.py tests/test_session_tail_payload.py tests/test_session_metadata_cli_lookup.py -q`

## Disclosure notes
- Claims are limited to the local code path and regression coverage described above.
- No production systems were tested.
- No unrelated files were changed.
