### PR TITLE
fix(visibility): close gateway/session SSE on hidden tabs to prevent connection pool exhaustion (#3992)

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -4210,6 +4210,19 @@ function startSessionStream(sid) {
   if (_sessionStreamSessionId === sid && _sessionEventSource) return;
   stopSessionStream();
   _sessionStreamSessionId = sid;
+  // Visibility hook (install once) — mirror ensureSessionEventsSSE() pattern
+  if (typeof document !== 'undefined' && !document._hermesSessionStreamVisibilityHook) {
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        stopSessionStream();
+      } else if (_sessionStreamSessionId) {
+        void startSessionStream(_sessionStreamSessionId);
+      }
+    });
+    document._hermesSessionStreamVisibilityHook = true;
+  }
+  // Don't open when tab is hidden — saves connection pool slots
+  if (typeof document !== 'undefined' && document.hidden) return;
   try {
     const es = new EventSource(_apiUrl('api/session/stream?session_id=' + encodeURIComponent(sid)));
     _sessionEventSource = es;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3704,6 +3704,19 @@ async function probeGatewaySSEStatus(){
 function startGatewaySSE(){
   stopGatewaySSE();
   if(!window._showCliSessions) return;
+  // Visibility hook (install once) — mirror ensureSessionEventsSSE() pattern
+  if(typeof document !== 'undefined' && !document._hermesGatewaySSEVisibilityHook){
+    document.addEventListener('visibilitychange', () => {
+      if(document.hidden){
+        stopGatewaySSE();
+      }else{
+        void startGatewaySSE();
+      }
+    });
+    document._hermesGatewaySSEVisibilityHook = true;
+  }
+  // Don't open when tab is hidden — saves connection pool slots
+  if(typeof document !== 'undefined' && document.hidden) return;
   try{
     _gatewaySSE = new EventSource('api/sessions/gateway/stream');
     _gatewaySSE.addEventListener('sessions_changed', (ev) => {


### PR DESCRIPTION
## Summary

Fixes **#3992** — Two PWA/browser windows idle on same origin exhaust HTTP/1.1 connection pool (6 streams → 6 limit), causing "Request timed out. Please try again." toasts on any subsequent action.

## Root Cause

Each WebUI window opens **3 persistent SSE connections** even when idle:

| Connection | Opened by | Visibility handling |
|------------|-----------|-------------------|
| `api/sessions/events` | `ensureSessionEventsSSE()` | ✅ Yes (lines 3582–3593) |
| `api/sessions/gateway/stream` | `startGatewaySSE()` | ❌ **No** (before this fix) |
| `api/session/stream?session_id=<sid>` | `startSessionStream()` | ❌ **No** (before this fix) |

With 2 windows × 3 connections = 6 = browser's HTTP/1.1 limit. Any `fetch()` (polling, user clicks) queues behind saturated pool and times out at 30s.

## Solution

Add Page Visibility API hooks to both remaining SSE entry points, mirroring the existing `ensureSessionEventsSSE()` pattern (sessions.js:3582–3593):

1. **`startGatewaySSE()`** (sessions.js:3704): Install visibility hook once, close SSE on `document.hidden`, reopen on `visible`, skip open when hidden.

2. **`startSessionStream()`** (messages.js:4206): Same pattern.

## Changes

- `static/sessions.js`: +13 lines (visibility hook + guard)
- `static/messages.js`: +13 lines (visibility hook + guard)

## Testing

- ✅ ESLint runtime guard passes (`npm run lint:runtime`)
- ✅ Browser smoke test passes (zero console errors on `/`, `/#settings`, `/#sessions`)
- ✅ Static JS analysis tests pass (`test_session_events.py`, `test_session_events_http_integration.py`, `test_gateway_sse_reconnect_dedupe.py`)
- ✅ Session channel tests pass (`test_session_channel_option_x.py`)
- ✅ Issue #3746 regression tests pass (`test_issue3746_session_move_delete_timeout.py`)
- ✅ 2135 tests pass (1 pre-existing unrelated failure in `test_issue1499_onboarding_probe.py`)
- ✅ Node syntax check passes

## Manual Verification

1. Open WebUI in two browser tabs/windows
2. Wait for SSE connections to establish (visible in DevTools Network tab)
3. Hide first tab (switch to second) → gateway + session SSE close in first tab
4. Return to first tab → SSE reconnect automatically
5. Perform action in first tab → no timeout toast

## Related

- Fixes **#3992** (multi-window idle timeout toasts)
- Complements **#3748** fix (v0.51.348) which addressed active-streaming connection pool exhaustion by converting approval/clarify to polling
- Same pattern as `ensureSessionEventsSSE()` (sessions.js:3582–3593) which has worked correctly since inception