### PR TITLE
fix(#3988): default show_cli_sessions to true

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -6505,7 +6505,7 @@ _SETTINGS_DEFAULTS = {
     "hide_empty_state_suggestions": False,  # hide the default new-chat suggestion buttons
     "show_tps": False,  # show tokens-per-second chip in assistant message headers
     "fade_text_effect": False,  # animate newly streamed words with a lightweight fade-in effect
-    "show_cli_sessions": False,  # merge CLI sessions from state.db into the sidebar
+    "show_cli_sessions": True,  # merge CLI sessions from state.db into the sidebar
     "show_cron_sessions": False,  # surface cron sessions in the sidebar (subordinate to show_cli_sessions)
     "show_previous_messaging_sessions": False,  # show older Telegram/Discord/etc. reset segments
     "sync_to_insights": False,  # mirror WebUI token usage to state.db for /insights

--- a/api/config.py
+++ b/api/config.py
@@ -5734,7 +5734,7 @@ _SETTINGS_DEFAULTS = {
     "hide_empty_state_suggestions": False,  # hide the default new-chat suggestion buttons
     "show_tps": False,  # show tokens-per-second chip in assistant message headers
     "fade_text_effect": False,  # animate newly streamed words with a lightweight fade-in effect
-    "show_cli_sessions": False,  # merge CLI sessions from state.db into the sidebar
+    "show_cli_sessions": True,  # merge CLI sessions from state.db into the sidebar
     "show_cron_sessions": False,  # surface cron sessions in the sidebar (subordinate to show_cli_sessions)
     "show_previous_messaging_sessions": False,  # show older Telegram/Discord/etc. reset segments
     "sync_to_insights": False,  # mirror WebUI token usage to state.db for /insights

--- a/static/boot.js
+++ b/static/boot.js
@@ -1959,7 +1959,7 @@ function applyBotName(){
     applyEmptyStateSuggestionPref();
     window._showTps=false;
     window._fadeTextEffect=false;
-    window._showCliSessions=false;
+    window._showCliSessions=true;
     window._soundEnabled=false;
     window._notificationsEnabled=false;
     window._whatsNewSummaryEnabled=false;

--- a/static/boot.js
+++ b/static/boot.js
@@ -1897,7 +1897,7 @@ function applyBotName(){
     applyEmptyStateSuggestionPref();
     window._showTps=false;
     window._fadeTextEffect=false;
-    window._showCliSessions=false;
+    window._showCliSessions=true;
     window._soundEnabled=false;
     window._notificationsEnabled=false;
     window._whatsNewSummaryEnabled=false;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3916,6 +3916,11 @@ async function probeGatewaySSEStatus(){
       return;
     }
     if(resp.status === 503 || data.watcher_running === false){
+      const hasGatewaySessions = (Array.isArray(_allSessions)?_allSessions:[]).some(_isGatewaySessionForSnapshot);
+      if(!hasGatewaySessions){
+        stopGatewayPollFallback();
+        return;
+      }
       startGatewayPollFallback(data.fallback_poll_ms || _gatewayFallbackPollMs);
       renderSessionList({deferWhileInteracting:true});
       if(!_gatewaySSEWarningShown && typeof showToast === 'function'){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3683,6 +3683,11 @@ async function probeGatewaySSEStatus(){
       return;
     }
     if(resp.status === 503 || data.watcher_running === false){
+      const hasGatewaySessions = (Array.isArray(_allSessions)?_allSessions:[]).some(_isGatewaySessionForSnapshot);
+      if(!hasGatewaySessions){
+        stopGatewayPollFallback();
+        return;
+      }
       startGatewayPollFallback(data.fallback_poll_ms || _gatewayFallbackPollMs);
       renderSessionList({deferWhileInteracting:true});
       if(!_gatewaySSEWarningShown && typeof showToast === 'function'){

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -60,6 +60,11 @@ def _get_state_db_path():
     return _get_test_state_dir() / 'state.db'
 
 
+def _get_settings_file_path():
+    """Return path to the test settings.json."""
+    return _get_test_state_dir() / 'settings.json'
+
+
 def _ensure_state_db():
     """Create state.db with sessions and messages tables if it doesn't exist.
     Returns a connection. Does NOT delete existing data (safe for parallel tests).
@@ -278,6 +283,70 @@ def test_webui_state_db_session_without_sidecar_appears_when_agent_sessions_enab
         except Exception:
             pass
         post('/api/settings', {'show_cli_sessions': False})
+
+
+def test_webui_state_db_session_without_sidecar_appears_when_show_cli_sessions_unset():
+    """Default settings should surface CLI-backed state.db rows without requiring an opt-in toggle."""
+    conn = _ensure_state_db()
+    sid = 'cli_state_default_on_001'
+    settings_path = _get_settings_file_path()
+    original_settings = None
+    try:
+        if settings_path.exists():
+            original_settings = settings_path.read_text(encoding='utf-8')
+            persisted = json.loads(original_settings or '{}')
+            if not isinstance(persisted, dict):
+                persisted = {}
+        # API writes deep-merge into the current settings, so removing the key
+        # from the persisted file is the only way to exercise the clean-default path.
+        else:
+            persisted = {}
+        persisted.pop('show_cli_sessions', None)
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps(persisted, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+
+        _insert_agent_session_row(
+            conn,
+            session_id=sid,
+            source='cli',
+            title='Default-On CLI Session',
+            model='openai/gpt-5',
+            messages=2,
+        )
+
+        settings_data, settings_status = get('/api/settings')
+        assert settings_status == 200, settings_data
+        assert settings_data.get('show_cli_sessions') is True
+
+        data, status = get('/api/sessions')
+        assert status == 200
+        recovered = [s for s in data.get('sessions', []) if s.get('session_id') == sid]
+        assert len(recovered) == 1, (
+            "Unset show_cli_sessions should fall back to the clean default and "
+            "surface CLI-backed state.db sessions."
+        )
+        assert recovered[0].get('source_tag') == 'cli'
+        assert recovered[0].get('is_cli_session') is True
+    finally:
+        try:
+            _remove_test_sessions(conn, sid)
+            conn.close()
+        except Exception:
+            pass
+        if original_settings is None:
+            settings_path.unlink(missing_ok=True)
+        else:
+            settings_path.write_text(original_settings, encoding='utf-8')
+
+
+def test_show_cli_sessions_default_on_boot_and_gateway_probe_fallbacks_stay_aligned():
+    boot_src = (REPO_ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+    sessions_src = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+    assert "window._showCliSessions=true;" in boot_src
+    assert "const hasGatewaySessions = (Array.isArray(_allSessions)?_allSessions:[]).some(_isGatewaySessionForSnapshot);" in sessions_src
+    assert "if(!hasGatewaySessions){" in sessions_src
+    assert "stopGatewayPollFallback();" in sessions_src
 
 
 def test_gateway_sessions_without_messages_are_hidden_from_sidebar():


### PR DESCRIPTION

## Thinking Path

- The sidebar already knows how to merge non-WebUI sessions, but the clean-install default keeps that path off until the user discovers a Settings checkbox.
- The route already caps visible CLI rows, so flipping the default no longer reintroduces the earlier full-scan concern.
- The boot fallback and gateway-probe path also need to agree with that new default, otherwise a transient settings load failure or a gateway-less install can silently hide CLI sessions again or show a confusing warning loop.

## What Changed

- `api/config.py`: change the default `show_cli_sessions` setting from `false` to `true`.
- `static/boot.js`: align the settings-load fallback with the new `show_cli_sessions=true` default.
- `static/sessions.js`: skip the gateway-unavailable fallback poll and toast when the sidebar has no imported CLI or messaging sessions yet.
- `tests/test_gateway_sync.py`: add regression coverage for the clean-default settings path and the boot/probe source contracts, while preserving the explicit-off case.

## Why It Matters

Users who split time across WebUI, TUI, CLI, Telegram, or desktop surfaces will see the same conversations by default instead of looking at an empty or incomplete sidebar on first use.

## Verification

- `pytest tests/test_gateway_sync.py -v --timeout=60 -k "test_gateway_sessions_appear_when_enabled or test_webui_state_db_session_without_sidecar_appears_when_agent_sessions_enabled or test_webui_state_db_session_without_sidecar_appears_when_show_cli_sessions_unset or test_show_cli_sessions_default_on_boot_and_gateway_probe_fallbacks_stay_aligned or test_gateway_sessions_excluded_when_disabled"`, passed locally via the Windows headless runner, 5 selected tests.
- `npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs static/boot.js static/sessions.js`, passed locally.

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- Users who prefer the old cleaner sidebar can still turn the setting off; this PR only changes the default for unset configs.
- The gateway watcher still does not auto-start on gateway-less installs; this change only avoids the confusing warning loop when no imported sessions exist yet.
- If the multi-select origin filter in PR [#3566](https://github.com/nesquena/hermes-webui/pull/3566) lands later, it can absorb this default without changing the underlying setting migration story.

## Model Used

GPT-5 via Codex CLI
