### PR TITLE
[security][DRAFT] Scope session-by-id endpoints to active profile (absorbs #3982 + #3991)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -5789,6 +5789,8 @@ def handle_get(handler, parsed) -> bool:
             s = get_session(sid, metadata_only=True)
         except KeyError:
             return bad(handler, "Session not found", status=404)
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+            return bad(handler, "Session not found", status=404)
         try:
             from api.worktrees import worktree_status_for_session
 
@@ -6199,7 +6201,10 @@ def handle_get(handler, parsed) -> bool:
             return bad(handler, "Missing session_id")
         try:
             from api.session_ops import session_status
-            _clear_stale_stream_state(get_session(sid, metadata_only=True))
+            _status_meta = get_session(sid, metadata_only=True)
+            if not _session_visible_to_active_profile(getattr(_status_meta, "profile", None), handler):
+                return bad(handler, "Session not found", 404)
+            _clear_stale_stream_state(_status_meta)
             return j(handler, session_status(sid))
         except KeyError:
             return bad(handler, "Session not found", 404)
@@ -6216,6 +6221,9 @@ def handle_get(handler, parsed) -> bool:
             return bad(handler, "Missing session_id")
         try:
             from api.session_ops import session_usage
+            _usage_meta = get_session(sid, metadata_only=True)
+            if not _session_visible_to_active_profile(getattr(_usage_meta, "profile", None), handler):
+                return bad(handler, "Session not found", 404)
             return j(handler, session_usage(sid))
         except KeyError:
             return bad(handler, "Session not found", 404)
@@ -7478,6 +7486,8 @@ def handle_post(handler, parsed) -> bool:
             s = _ensure_full_session_before_mutation(body["session_id"], s)
         except KeyError:
             return bad(handler, "Session not found", 404)
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+            return bad(handler, "Session not found", 404)
         with _get_session_agent_lock(body["session_id"]):
             from api.session_ops import apply_session_title_rename
             apply_session_title_rename(s, body["title"])
@@ -7535,6 +7545,8 @@ def handle_post(handler, parsed) -> bool:
             s = _ensure_full_session_before_mutation(sid, s)
         except KeyError:
             return bad(handler, "Session not found", 404)
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+            return bad(handler, "Session not found", 404)
         # Resolve personality from config.yaml agent.personalities section
         # (matches hermes-agent CLI behavior)
         prompt = ""
@@ -7588,6 +7600,8 @@ def handle_post(handler, parsed) -> bool:
         try:
             s = get_session(sid)
         except KeyError:
+            return bad(handler, "Session not found", 404)
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
             return bad(handler, "Session not found", 404)
         with _get_session_agent_lock(sid):
             s.enabled_toolsets = toolsets
@@ -7725,6 +7739,8 @@ def handle_post(handler, parsed) -> bool:
         try:
             s = get_session(sid, metadata_only=True)
         except KeyError:
+            return bad(handler, "Session not found", status=404)
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
             return bad(handler, "Session not found", status=404)
         force = bool(body.get("force", False))
         try:
@@ -8534,6 +8550,8 @@ def handle_post(handler, parsed) -> bool:
             s = _ensure_full_session_before_mutation(body["session_id"], s)
         except KeyError:
             return bad(handler, "Session not found", 404)
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+            return bad(handler, "Session not found", 404)
         pin_requested = bool(body.get("pinned", True))
         # TOCTOU guard (Opus stage-389): the count check and the pin write
         # must happen under the same lock, otherwise two parallel pin
@@ -8679,6 +8697,8 @@ def handle_post(handler, parsed) -> bool:
         try:
             s = get_session(body["session_id"])
         except KeyError:
+            return bad(handler, "Session not found", 404)
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
             return bad(handler, "Session not found", 404)
         # #1614: refuse moves into a project owned by another profile.
         target_pid = body.get("project_id") or None
@@ -9751,13 +9771,15 @@ def _handle_sse_stream(handler, parsed):
     return True
 
 
-def _terminal_session_lookup(body_or_query):
+def _terminal_session_lookup(body_or_query, handler=None):
     sid = str(body_or_query.get("session_id", "")).strip()
     if not sid:
         raise ValueError("session_id required")
     try:
         s = get_session(sid)
     except KeyError:
+        raise KeyError("Session not found")
+    if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
         raise KeyError("Session not found")
     return sid, s
 
@@ -9775,7 +9797,7 @@ def _terminal_remote_backend_enabled() -> bool:
 
 def _handle_terminal_start(handler, body):
     try:
-        sid, session = _terminal_session_lookup(body)
+        sid, session = _terminal_session_lookup(body, handler)
         if _terminal_remote_backend_enabled():
             return j(
                 handler,
@@ -10395,7 +10417,7 @@ def _message_content_text(content) -> str:
     return str(content or "")
 
 
-def _session_media_token_allows_image_path(sid: str, target: Path, image_mimes: set[str]) -> bool:
+def _session_media_token_allows_image_path(sid: str, target: Path, image_mimes: set[str], handler=None) -> bool:
     """Allow exact MEDIA:image paths already present in the requested session."""
     sid = str(sid or "").strip()
     if not sid:
@@ -10410,6 +10432,11 @@ def _session_media_token_allows_image_path(sid: str, target: Path, image_mimes: 
     try:
         session = get_session(sid)
     except Exception:
+        return False
+
+    # Active-profile boundary: don't authorize a media path from another
+    # profile's session transcript.
+    if not _session_visible_to_active_profile(getattr(session, "profile", None), handler):
         return False
 
     for message in getattr(session, "messages", []) or []:
@@ -10528,6 +10555,7 @@ def _handle_media(handler, parsed):
         qs.get("session_id", [""])[0],
         target,
         _INLINE_IMAGE_TYPES,
+        handler,
     )
 
     # ── #3234: hard-deny Hermes's own state + secret/config files ────────────
@@ -11994,6 +12022,8 @@ def _handle_background(handler, body):
         s = get_session(body["session_id"])
     except KeyError:
         return bad(handler, "Session not found", 404)
+    if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+        return bad(handler, "Session not found", 404)
     prompt = str(body["prompt"]).strip()
     if not prompt:
         return bad(handler, "prompt is required")
@@ -12736,6 +12766,12 @@ def _handle_goal_command(handler, body):
         )
         if not has_persisted_turns:
             s.profile = requested_profile
+
+    # Active-profile boundary (after the empty-placeholder retag): a caller scoped
+    # to one profile must not read/control goal state or start a turn for another
+    # profile's session.
+    if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+        return bad(handler, "Session not found", 404)
 
     current_stream_id = getattr(s, "active_stream_id", None)
     stream_running = False
@@ -14977,6 +15013,12 @@ def _handle_conversation_rounds(handler, body):
     sid = str(body.get("session_id") or "").strip()
     if not sid:
         return bad(handler, "session_id is required")
+
+    # Active-profile boundary: resolve the CLI session's profile and reject before
+    # counting rounds over a foreign-profile transcript.
+    _rounds_meta = _lookup_cli_session_metadata(sid)
+    if not _session_visible_to_active_profile((_rounds_meta or {}).get("profile") or None, handler):
+        return bad(handler, "Session not found", 404)
 
     since = body.get("since")
     if since is not None:

--- a/api/routes.py
+++ b/api/routes.py
@@ -227,6 +227,21 @@ def _session_visible_to_active_profile(session_profile, handler=None) -> bool:
     return _profiles_match(session_profile, active_profile)
 
 
+def _visible_session_for_file_ops(sid, handler):
+    """get_session_for_file_ops + active-profile boundary.
+
+    Workspace/file routes resolve a session by id then operate on its workspace
+    tree. They must enforce the same active-profile boundary as /api/sessions.
+    Raises KeyError when the session is not visible to the active profile so the
+    callers' existing ``except KeyError -> 404`` path returns a uniform 404
+    (mirroring the not-found response, never disclosing existence).
+    """
+    s = get_session_for_file_ops(sid)
+    if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+        raise KeyError(sid)
+    return s
+
+
 def _active_skills_dir() -> Path:
     """Return the skills directory for the request's active Hermes profile.
 
@@ -9438,6 +9453,8 @@ def _handle_list_dir(handler, parsed):
         return bad(handler, "session_id is required")
     try:
         s = get_session(sid)
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+            return bad(handler, "Session not found", 404)
         workspace = s.workspace
     except KeyError:
         # Fallback for CLI sessions not loaded in WebUI memory
@@ -9448,6 +9465,8 @@ def _handle_list_dir(handler, parsed):
                     cli_meta = cs
                     break
             if not cli_meta:
+                return bad(handler, "Session not found", 404)
+            if not _session_visible_to_active_profile(cli_meta.get("profile") or None, handler):
                 return bad(handler, "Session not found", 404)
             workspace = cli_meta.get("workspace", "")
         except Exception:
@@ -10822,7 +10841,7 @@ def _handle_folder_download(handler, parsed):
     if not sid:
         return bad(handler, "session_id is required")
     try:
-        s = get_session_for_file_ops(sid)
+        s = _visible_session_for_file_ops(sid, handler)
     except KeyError:
         return bad(handler, "Session not found", 404)
 
@@ -10908,7 +10927,7 @@ def _handle_file_raw(handler, parsed):
     if not sid:
         return bad(handler, "session_id is required")
     try:
-        s = get_session_for_file_ops(sid)
+        s = _visible_session_for_file_ops(sid, handler)
     except KeyError:
         return bad(handler, "Session not found", 404)
     rel = qs.get("path", [""])[0]
@@ -10948,7 +10967,7 @@ def _handle_file_read(handler, parsed):
     if not sid:
         return bad(handler, "session_id is required")
     try:
-        s = get_session_for_file_ops(sid)
+        s = _visible_session_for_file_ops(sid, handler)
     except KeyError:
         return bad(handler, "Session not found", 404)
     rel = qs.get("path", [""])[0]
@@ -13324,10 +13343,14 @@ def _git_session(handler, session_id: str):
         bad(handler, "session_id required")
         return None
     try:
-        return get_session(session_id)
+        session = get_session(session_id)
     except KeyError:
         bad(handler, "Session not found", 404)
         return None
+    if not _session_visible_to_active_profile(getattr(session, "profile", None), handler):
+        bad(handler, "Session not found", 404)
+        return None
+    return session
 
 
 def _git_session_workspace(handler, session_id: str):
@@ -13619,7 +13642,9 @@ def _handle_git_commit_message(handler, body):
 
     try:
         require(body, "session_id")
-        session = get_session(body["session_id"])
+        session = _git_session(handler, body["session_id"])
+        if session is None:
+            return True
         workspace = Path(session.workspace)
 
         prompt = staged_commit_message_prompt(workspace)
@@ -13650,7 +13675,9 @@ def _handle_git_commit_message_selected(handler, body):
     try:
         require(body, "session_id")
         paths = _git_paths_from_body(body)
-        session = get_session(body["session_id"])
+        session = _git_session(handler, body["session_id"])
+        if session is None:
+            return True
         workspace = Path(session.workspace)
 
         prompt = selected_commit_message_prompt(workspace, paths)
@@ -13807,7 +13834,7 @@ def _handle_file_delete(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session_for_file_ops(body["session_id"])
+        s = _visible_session_for_file_ops(body["session_id"], handler)
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -13832,7 +13859,7 @@ def _handle_file_save(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session_for_file_ops(body["session_id"])
+        s = _visible_session_for_file_ops(body["session_id"], handler)
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -13859,7 +13886,7 @@ def _handle_file_create(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session_for_file_ops(body["session_id"])
+        s = _visible_session_for_file_ops(body["session_id"], handler)
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -13886,7 +13913,7 @@ def _handle_file_rename(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session_for_file_ops(body["session_id"])
+        s = _visible_session_for_file_ops(body["session_id"], handler)
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -13916,7 +13943,7 @@ def _handle_file_move(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session_for_file_ops(body["session_id"])
+        s = _visible_session_for_file_ops(body["session_id"], handler)
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -14011,7 +14038,7 @@ def _handle_create_dir(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session_for_file_ops(body["session_id"])
+        s = _visible_session_for_file_ops(body["session_id"], handler)
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -14033,7 +14060,7 @@ def _handle_file_reveal(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session_for_file_ops(body["session_id"])
+        s = _visible_session_for_file_ops(body["session_id"], handler)
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -14094,7 +14121,7 @@ def _handle_file_path(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session_for_file_ops(body["session_id"])
+        s = _visible_session_for_file_ops(body["session_id"], handler)
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:
@@ -14124,7 +14151,7 @@ def _handle_file_open_vscode(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        s = get_session_for_file_ops(body["session_id"])
+        s = _visible_session_for_file_ops(body["session_id"], handler)
     except KeyError:
         return bad(handler, "Session not found", 404)
     try:

--- a/api/routes.py
+++ b/api/routes.py
@@ -7484,6 +7484,8 @@ def handle_post(handler, parsed) -> bool:
             s = _ensure_full_session_before_mutation(sid, s)
         except KeyError:
             return bad(handler, "Session not found", 404)
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+            return bad(handler, "Session not found", 404)
         if getattr(s, "read_only", False) or getattr(s, "is_imported", False):
             return bad(handler, "Read-only imported sessions cannot be renamed", 403)
         next_title, reason, raw_preview = generate_session_title_for_session(s, prefer_latest=prefer_latest)
@@ -7590,6 +7592,8 @@ def handle_post(handler, parsed) -> bool:
                 s = get_session(sid)
             except KeyError:
                 return bad(handler, "Session not found", 404)
+            if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+                return bad(handler, "Session not found", 404)
             draft = getattr(s, "composer_draft", {}) or {}
             return j(handler, {"draft": draft})
         # POST
@@ -7617,6 +7621,8 @@ def handle_post(handler, parsed) -> bool:
         try:
             s = get_session(sid)
         except KeyError:
+            return bad(handler, "Session not found", 404)
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
             return bad(handler, "Session not found", 404)
         unchanged = False
         with _get_session_agent_lock(sid):
@@ -8587,9 +8593,13 @@ def handle_post(handler, parsed) -> bool:
                     raise KeyError(sid)
                 with LOCK:
                     SESSIONS[sid] = s
+            if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+                return bad(handler, "Session not found", 404)
         except KeyError:
             cli_meta = _lookup_cli_session_metadata(sid)
             if not cli_meta:
+                return bad(handler, "Session not found", 404)
+            if not _session_visible_to_active_profile(cli_meta.get("profile") or None, handler):
                 return bad(handler, "Session not found", 404)
             if cli_meta.get("read_only"):
                 return bad(handler, "Read-only imported sessions cannot be archived from WebUI", 400)
@@ -11907,6 +11917,8 @@ def _handle_btw(handler, body):
         s = get_session(body["session_id"])
     except KeyError:
         return bad(handler, "Session not found", 404)
+    if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+        return bad(handler, "Session not found", 404)
     question = str(body["question"]).strip()
     if not question:
         return bad(handler, "question is required")
@@ -12855,6 +12867,11 @@ def _handle_chat_start(handler, body, diag=None):
                 # currently-selected profile instead of the stale one stamped at
                 # creation time.
                 s.profile = requested_profile
+        # Active-profile boundary: after the empty-placeholder retag, a caller
+        # scoped to one profile must not be able to start a turn on (and thus
+        # read/append to) another profile's session by id.
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+            return bad(handler, "Session not found", 404)
         diag.stage("normalize_message") if diag else None
         msg = str(body.get("message", "")).strip()
         if not msg:
@@ -12962,7 +12979,12 @@ def _normalize_chat_attachments(raw_attachments):
 
 def _handle_chat_sync(handler, body):
     """Fallback synchronous chat endpoint (POST /api/chat). Not used by frontend."""
-    s = get_session(body["session_id"])
+    try:
+        s = get_session(body["session_id"])
+    except KeyError:
+        return bad(handler, "Session not found", 404)
+    if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+        return bad(handler, "Session not found", 404)
     msg = str(body.get("message", "")).strip()
     if not msg:
         return j(handler, {"error": "empty message"}, status=400)

--- a/api/routes.py
+++ b/api/routes.py
@@ -7727,6 +7727,11 @@ def handle_post(handler, parsed) -> bool:
         except Exception:
             logger.debug("Failed to resolve profile for deleted session %s", sid, exc_info=True)
             event_profile = None
+        # Active-profile boundary: a caller scoped to one profile must not be able
+        # to delete another profile's session (sidecar, journals, attachments, CLI
+        # rows). Resolve+check the profile before any destructive work below.
+        if not _session_visible_to_active_profile(event_profile, handler):
+            return bad(handler, "Session not found", status=404)
         # Delete from WebUI session store
         with LOCK:
             SESSIONS.pop(sid, None)
@@ -7799,6 +7804,8 @@ def handle_post(handler, parsed) -> bool:
         try:
             s = get_session(body["session_id"])
         except KeyError:
+            return bad(handler, "Session not found", 404)
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
             return bad(handler, "Session not found", 404)
         sid = body["session_id"]
         with _get_session_agent_lock(sid):
@@ -7888,6 +7895,8 @@ def handle_post(handler, parsed) -> bool:
         try:
             source = get_session(body["session_id"])
         except KeyError:
+            return bad(handler, "Session not found", 404)
+        if not _session_visible_to_active_profile(getattr(source, "profile", None), handler):
             return bad(handler, "Session not found", 404)
 
         keep_count = body.get("keep_count")
@@ -7993,6 +8002,9 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, str(e))
         try:
             from api.session_ops import retry_last
+            _meta = get_session(body["session_id"], metadata_only=True)
+            if not _session_visible_to_active_profile(getattr(_meta, "profile", None), handler):
+                return bad(handler, "Session not found", 404)
             result = retry_last(body["session_id"])
             return j(handler, {"ok": True, **result})
         except KeyError:
@@ -8007,6 +8019,9 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, str(e))
         try:
             from api.session_ops import undo_last
+            _meta = get_session(body["session_id"], metadata_only=True)
+            if not _session_visible_to_active_profile(getattr(_meta, "profile", None), handler):
+                return bad(handler, "Session not found", 404)
             result = undo_last(body["session_id"])
             return j(handler, {"ok": True, **result})
         except KeyError:
@@ -14525,6 +14540,8 @@ def _handle_session_compress_start(handler, body):
         s = get_session(sid)
     except KeyError:
         return bad(handler, "Session not found", 404)
+    if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+        return bad(handler, "Session not found", 404)
     if getattr(s, "active_stream_id", None):
         return bad(handler, "Session is still streaming; wait for the current turn to finish.", 409)
 
@@ -14661,6 +14678,9 @@ def _handle_session_compress(handler, body):
     try:
         s = get_session(sid)
     except KeyError:
+        return bad(handler, "Session not found", 404)
+
+    if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
         return bad(handler, "Session not found", 404)
 
     if getattr(s, "active_stream_id", None):
@@ -15130,6 +15150,14 @@ def _handle_handoff_summary(handler, body):
     sid = str(body.get("session_id") or "").strip()
     if not sid:
         return bad(handler, "session_id is required")
+
+    # Active-profile boundary: resolve the CLI session's profile and reject before
+    # counting rounds, reading the transcript, summarizing, or persisting a marker,
+    # so a caller scoped to one profile can't derive a summary from another
+    # profile's CLI transcript.
+    _handoff_meta = _lookup_cli_session_metadata(sid)
+    if not _session_visible_to_active_profile((_handoff_meta or {}).get("profile") or None, handler):
+        return bad(handler, "Session not found", 404)
 
     since = body.get("since")
     if since is not None:
@@ -15832,6 +15860,14 @@ def _handle_session_import_cli(handler, body):
                 "imported": False,
             },
         )
+
+    # Active-profile boundary: resolve the CLI session's profile and reject before
+    # reading the transcript, deriving a title, returning a read-only payload, or
+    # importing it — a caller scoped to one profile must not import/return another
+    # profile's CLI transcript.
+    _import_meta = _lookup_cli_session_metadata(sid)
+    if not _session_visible_to_active_profile((_import_meta or {}).get("profile") or None, handler):
+        return bad(handler, "Session not found", 404)
 
     # Fetch messages from CLI store
     msgs = get_cli_session_messages(sid)

--- a/api/routes.py
+++ b/api/routes.py
@@ -182,7 +182,10 @@ def _visible_pinned_lineage_ids(session_rows) -> set[str]:
 # (mcp_server.py) can import it without duplicating the visibility model.
 # Re-exported here so existing `_profiles_match(...)` call sites in this
 # module keep resolving without per-call-site refactors.
-from api.profiles import _profiles_match  # noqa: F401, E402  (re-export)
+from api.profiles import (  # noqa: F401, E402  (re-export)
+    _profiles_match,
+    get_active_profile_name as _get_active_profile_name,
+)
 
 
 def _all_profiles_query_flag(parsed_url) -> bool:
@@ -5802,11 +5805,7 @@ def handle_get(handler, parsed) -> bool:
             _t1 = _time.monotonic()
             s = get_session(sid, metadata_only=(not load_messages))
             _session_profile = getattr(s, 'profile', None) or None
-            try:
-                from api.profiles import get_active_profile_name
-                _active_profile = get_active_profile_name()
-            except Exception:
-                _active_profile = "default"
+            _active_profile = _get_active_profile_name()
             if not _profiles_match(_session_profile, _active_profile):
                 return bad(handler, "Session not found", 404)
             original_stream_id = getattr(s, "active_stream_id", None)
@@ -6105,6 +6104,10 @@ def handle_get(handler, parsed) -> bool:
             if _was_webui_session:
                 return bad(handler, "Session not found", 404)
             cli_meta = _lookup_cli_session_metadata(sid)
+            _session_profile = (cli_meta or {}).get("profile") or None
+            _active_profile = _get_active_profile_name()
+            if not _profiles_match(_session_profile, _active_profile):
+                return bad(handler, "Session not found", 404)
             msgs = get_cli_session_messages(sid)
             if msgs:
                 sess = {

--- a/api/routes.py
+++ b/api/routes.py
@@ -182,7 +182,10 @@ def _visible_pinned_lineage_ids(session_rows) -> set[str]:
 # (mcp_server.py) can import it without duplicating the visibility model.
 # Re-exported here so existing `_profiles_match(...)` call sites in this
 # module keep resolving without per-call-site refactors.
-from api.profiles import _profiles_match  # noqa: F401, E402  (re-export)
+from api.profiles import (  # noqa: F401, E402  (re-export)
+    _profiles_match,
+    get_active_profile_name,
+)
 
 
 def _all_profiles_query_flag(parsed_url) -> bool:
@@ -9230,9 +9233,8 @@ def _handle_session_export(handler, parsed):
         s = get_session(sid)
     except KeyError:
         return bad(handler, "Session not found", 404)
-    from api.profiles import get_active_profile_name
-
-    if not _profiles_match(getattr(s, "profile", None), get_active_profile_name()):
+    active_profile = get_active_profile_name()
+    if not _profiles_match(getattr(s, "profile", None), active_profile):
         return bad(handler, "Session not found", 404)
     safe = redact_session_data(s.__dict__)
     payload = json.dumps(safe, ensure_ascii=False, indent=2)

--- a/api/routes.py
+++ b/api/routes.py
@@ -5801,6 +5801,14 @@ def handle_get(handler, parsed) -> bool:
         try:
             _t1 = _time.monotonic()
             s = get_session(sid, metadata_only=(not load_messages))
+            _session_profile = getattr(s, 'profile', None) or None
+            try:
+                from api.profiles import get_active_profile_name
+                _active_profile = get_active_profile_name()
+            except Exception:
+                _active_profile = "default"
+            if not _profiles_match(_session_profile, _active_profile):
+                return bad(handler, "Session not found", 404)
             original_stream_id = getattr(s, "active_stream_id", None)
             _clear_stale_stream_state(s)
             cli_meta = _lookup_cli_session_metadata(sid) if _session_requires_cli_metadata_lookup(s) else {}
@@ -5808,7 +5816,6 @@ def handle_get(handler, parsed) -> bool:
             cli_messages = []
             state_db_messages = []
             metadata_summary = None
-            _session_profile = getattr(s, 'profile', None) or None
             if is_messaging_session:
                 cli_messages = get_cli_session_messages(sid)
             elif load_messages:

--- a/api/routes.py
+++ b/api/routes.py
@@ -199,6 +199,27 @@ def _all_profiles_query_flag(parsed_url) -> bool:
     return raw in ('1', 'true', 'yes', 'on')
 
 
+def _session_visible_to_active_profile(session_profile, handler=None) -> bool:
+    """Return whether a detail-load session belongs to the active profile.
+
+    Apply the /api/sessions profile boundary when the request has an explicit
+    profile scope (cookie/TLS). Direct unit-callers without request profile
+    context keep the historical metadata-load behavior.
+    """
+    active_profile = _get_active_profile_name()
+    explicit_scope = active_profile not in (None, "", "default")
+    try:
+        cookie = handler.headers.get("Cookie", "") if handler is not None else ""
+        explicit_scope = explicit_scope or "hermes_profile=" in str(cookie)
+    except Exception:
+        pass
+    if not explicit_scope:
+        return True
+    if not isinstance(session_profile, str):
+        session_profile = None
+    return _profiles_match(session_profile, active_profile)
+
+
 def _active_skills_dir() -> Path:
     """Return the skills directory for the request's active Hermes profile.
 
@@ -5805,13 +5826,7 @@ def handle_get(handler, parsed) -> bool:
             _t1 = _time.monotonic()
             s = get_session(sid, metadata_only=(not load_messages))
             _session_profile = getattr(s, 'profile', None) or None
-            _active_profile = _get_active_profile_name()
-            if (
-                load_messages
-                and isinstance(_session_profile, str)
-                and _session_profile.strip()
-                and not _profiles_match(_session_profile, _active_profile)
-            ):
+            if not _session_visible_to_active_profile(_session_profile, handler):
                 return bad(handler, "Session not found", 404)
             original_stream_id = getattr(s, "active_stream_id", None)
             _clear_stale_stream_state(s)
@@ -6110,8 +6125,7 @@ def handle_get(handler, parsed) -> bool:
                 return bad(handler, "Session not found", 404)
             cli_meta = _lookup_cli_session_metadata(sid)
             _session_profile = (cli_meta or {}).get("profile") or None
-            _active_profile = _get_active_profile_name()
-            if not _profiles_match(_session_profile, _active_profile):
+            if not _session_visible_to_active_profile(_session_profile, handler):
                 return bad(handler, "Session not found", 404)
             msgs = get_cli_session_messages(sid)
             if msgs:

--- a/api/routes.py
+++ b/api/routes.py
@@ -210,8 +210,16 @@ def _session_visible_to_active_profile(session_profile, handler=None) -> bool:
     /api/sessions, even when the request has no hermes_profile cookie and the
     process-level active profile is the default/root profile. Direct unit-callers
     without a request handler keep the historical metadata-load behavior.
+
+    Internal callers that re-dispatch a handler under an already-validated and
+    profile-scoped context (e.g. the manual-compression worker, which guards the
+    external /compress/start entry point and then applies the session's own
+    profile env before re-invoking _handle_session_compress) may set
+    ``handler._hermes_internal_trusted = True`` to bypass the re-check.
     """
     if handler is None:
+        return True
+    if getattr(handler, "_hermes_internal_trusted", False):
         return True
     active_profile = _get_active_profile_name()
     if not isinstance(session_profile, str):
@@ -14422,6 +14430,11 @@ class _ManualCompressionMemoryHandler:
         self.wfile = io.BytesIO()
         self.status = None
         self.sent_headers = {}
+        # The external /compress/start route already enforced the active-profile
+        # boundary, and the worker applies the session's own profile env before
+        # re-invoking _handle_session_compress. Mark this synthetic handler trusted
+        # so the in-handler guard doesn't re-reject under the worker's scoped env.
+        self._hermes_internal_trusted = True
 
     def send_response(self, status):
         self.status = status

--- a/api/routes.py
+++ b/api/routes.py
@@ -202,19 +202,14 @@ def _all_profiles_query_flag(parsed_url) -> bool:
 def _session_visible_to_active_profile(session_profile, handler=None) -> bool:
     """Return whether a detail-load session belongs to the active profile.
 
-    Apply the /api/sessions profile boundary when the request has an explicit
-    profile scope (cookie/TLS). Direct unit-callers without request profile
-    context keep the historical metadata-load behavior.
+    Real request handlers must enforce the same profile boundary as
+    /api/sessions, even when the request has no hermes_profile cookie and the
+    process-level active profile is the default/root profile. Direct unit-callers
+    without a request handler keep the historical metadata-load behavior.
     """
-    active_profile = _get_active_profile_name()
-    explicit_scope = active_profile not in (None, "", "default")
-    try:
-        cookie = handler.headers.get("Cookie", "") if handler is not None else ""
-        explicit_scope = explicit_scope or "hermes_profile=" in str(cookie)
-    except Exception:
-        pass
-    if not explicit_scope:
+    if handler is None:
         return True
+    active_profile = _get_active_profile_name()
     if not isinstance(session_profile, str):
         session_profile = None
     return _profiles_match(session_profile, active_profile)

--- a/api/routes.py
+++ b/api/routes.py
@@ -9230,6 +9230,10 @@ def _handle_session_export(handler, parsed):
         s = get_session(sid)
     except KeyError:
         return bad(handler, "Session not found", 404)
+    from api.profiles import get_active_profile_name
+
+    if not _profiles_match(getattr(s, "profile", None), get_active_profile_name()):
+        return bad(handler, "Session not found", 404)
     safe = redact_session_data(s.__dict__)
     payload = json.dumps(safe, ensure_ascii=False, indent=2)
     handler.send_response(200)

--- a/api/routes.py
+++ b/api/routes.py
@@ -7243,7 +7243,12 @@ def handle_post(handler, parsed) -> bool:
                 # 404, not 400 — missing resource, not a malformed request.
                 return bad(handler, "Session not found", status=404)
 
-            # Deep-copy mutable lists so the duplicate is *actually* independent.
+            # Same active-profile boundary as /api/session: a foreign-profile
+            # session must not be duplicated (which would otherwise copy and
+            # return its transcript to a caller scoped to a different profile).
+            if not _session_visible_to_active_profile(getattr(session, "profile", None), handler):
+                return bad(handler, "Session not found", status=404)
+
             # `Session.__init__` does `self.messages = messages or []` — plain
             # assignment, no copy. Without deepcopy, both sessions share the same
             # list object in memory; appending to one mutates the other.
@@ -7639,6 +7644,8 @@ def handle_post(handler, parsed) -> bool:
             s = get_session(body["session_id"])
         except KeyError:
             return bad(handler, "Session not found", 404)
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
+            return bad(handler, "Session not found", 404)
         old_ws = getattr(s, "workspace", "")
         old_model = getattr(s, "model", None)
         old_provider = getattr(s, "model_provider", None)
@@ -7821,6 +7828,8 @@ def handle_post(handler, parsed) -> bool:
         try:
             s = get_session(body["session_id"])
         except KeyError:
+            return bad(handler, "Session not found", 404)
+        if not _session_visible_to_active_profile(getattr(s, "profile", None), handler):
             return bad(handler, "Session not found", 404)
         # Validate keep_count before it reaches the destructive `messages[:keep]`
         # slice. A non-numeric value would raise ValueError and surface as a
@@ -15769,6 +15778,10 @@ def _handle_session_import_cli(handler, body):
     # Check if already imported — refresh messages from CLI store if new ones arrived
     existing = Session.load(sid)
     if existing:
+        # Same active-profile boundary as /api/session: don't refresh or return a
+        # foreign-profile sidecar's transcript to a caller scoped elsewhere.
+        if not _session_visible_to_active_profile(getattr(existing, "profile", None), handler):
+            return bad(handler, "Session not found", 404)
         fresh_msgs = get_cli_session_messages(sid)
         changed = False
         cli_meta = None

--- a/api/routes.py
+++ b/api/routes.py
@@ -5806,7 +5806,12 @@ def handle_get(handler, parsed) -> bool:
             s = get_session(sid, metadata_only=(not load_messages))
             _session_profile = getattr(s, 'profile', None) or None
             _active_profile = _get_active_profile_name()
-            if not _profiles_match(_session_profile, _active_profile):
+            if (
+                load_messages
+                and isinstance(_session_profile, str)
+                and _session_profile.strip()
+                and not _profiles_match(_session_profile, _active_profile)
+            ):
                 return bad(handler, "Session not found", 404)
             original_stream_id = getattr(s, "active_stream_id", None)
             _clear_stale_stream_state(s)

--- a/api/upload.py
+++ b/api/upload.py
@@ -168,6 +168,9 @@ def handle_upload(handler):
             s = get_session(session_id)
         except KeyError:
             return j(handler, {'error': 'Session not found'}, status=404)
+        from api.routes import _session_visible_to_active_profile
+        if not _session_visible_to_active_profile(getattr(s, 'profile', None), handler):
+            return j(handler, {'error': 'Session not found'}, status=404)
         safe_name = _sanitize_upload_name(filename)
         dest = _upload_destination(session_id, safe_name)
         dest.write_bytes(file_bytes)
@@ -343,6 +346,9 @@ def handle_upload_extract(handler):
         try:
             s = get_session(session_id)
         except KeyError:
+            return j(handler, {'error': 'Session not found'}, status=404)
+        from api.routes import _session_visible_to_active_profile
+        if not _session_visible_to_active_profile(getattr(s, 'profile', None), handler):
             return j(handler, {'error': 'Session not found'}, status=404)
         session_dir = _session_attachment_dir(session_id)
         session_dir.mkdir(parents=True, exist_ok=True)
@@ -547,6 +553,9 @@ def handle_workspace_upload(handler):
         try:
             session = get_session(session_id)
         except KeyError:
+            return j(handler, {'error': 'Session not found'}, status=404)
+        from api.routes import _session_visible_to_active_profile
+        if not _session_visible_to_active_profile(getattr(session, 'profile', None), handler):
             return j(handler, {'error': 'Session not found'}, status=404)
 
         # Resolve workspace root from session

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -575,6 +575,211 @@ def test_session_import_cli_rejects_existing_sidecar_from_inactive_profile():
     assert "json" not in captured, "foreign-profile CLI sidecar must not be refreshed/returned"
 
 
+# ── Destructive + derive paths must also honor active profile (LX class sweep) ──
+#
+# delete / clear / branch / retry / undo / compress / handoff-summary / fresh
+# import_cli all loaded a session by id without the active-profile boundary, so a
+# caller scoped to one profile could DESTROY (delete/clear/truncate/retry/undo) or
+# derive-from (branch/compress/handoff/import) another profile's transcript by id.
+
+
+def _post_capture():
+    captured = {}
+
+    def fake_bad(_handler, message, status=400, **_kwargs):
+        captured["bad"] = {"message": message, "status": status}
+        return captured["bad"]
+
+    def fake_j(_handler, data, status=200, **_kwargs):
+        captured["json"] = {"data": data, "status": status}
+        return captured["json"]
+
+    return captured, fake_bad, fake_j
+
+
+def test_session_delete_rejects_session_from_inactive_profile():
+    """POST /api/session/delete must not delete a foreign-profile session."""
+    import api.routes as routes
+
+    captured, fake_bad, fake_j = _post_capture()
+    foreign = SimpleNamespace(profile="other")
+    parsed = urlparse("/api/session/delete")
+    body = {"session_id": "foreign_del_001"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes._check_csrf", return_value=True), \
+         patch("api.routes.read_body", return_value=body), \
+         patch("api.routes.is_safe_session_id", return_value=True), \
+         patch("api.routes._lookup_cli_session_metadata", return_value={}), \
+         patch("api.routes._is_messaging_session_id", return_value=False), \
+         patch("api.routes._worktree_retained_payload_for_session_id", return_value={}), \
+         patch("api.routes.get_session", return_value=foreign), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_post(SimpleNamespace(headers={}), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "foreign-profile session must not be deleted"
+
+
+def test_session_clear_rejects_session_from_inactive_profile():
+    """POST /api/session/clear must not wipe a foreign-profile transcript."""
+    import api.routes as routes
+
+    captured, fake_bad, fake_j = _post_capture()
+    foreign = SimpleNamespace(profile="other", messages=[{"role": "user", "content": "x"}], tool_calls=[])
+    parsed = urlparse("/api/session/clear")
+    body = {"session_id": "foreign_clr_001"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes._check_csrf", return_value=True), \
+         patch("api.routes.read_body", return_value=body), \
+         patch("api.routes.get_session", return_value=foreign), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_post(SimpleNamespace(headers={}), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert foreign.messages == [{"role": "user", "content": "x"}], "transcript must not be wiped"
+    assert "json" not in captured
+
+
+def test_session_branch_rejects_session_from_inactive_profile():
+    """POST /api/session/branch must not fork a foreign-profile transcript."""
+    import api.routes as routes
+
+    captured, fake_bad, fake_j = _post_capture()
+    foreign = SimpleNamespace(profile="other", messages=[{"role": "user", "content": "x"}], title="F")
+    parsed = urlparse("/api/session/branch")
+    body = {"session_id": "foreign_br_001"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes._check_csrf", return_value=True), \
+         patch("api.routes.read_body", return_value=body), \
+         patch("api.routes.get_session", return_value=foreign), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_post(SimpleNamespace(headers={}), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "foreign-profile session must not be forked/returned"
+
+
+def test_session_retry_rejects_session_from_inactive_profile():
+    """POST /api/session/retry must not truncate/return a foreign-profile transcript."""
+    import api.routes as routes
+    import api.session_ops as session_ops
+
+    captured, fake_bad, fake_j = _post_capture()
+    meta = SimpleNamespace(profile="other")
+    parsed = urlparse("/api/session/retry")
+    body = {"session_id": "foreign_rt_001"}
+    called = {"retry": False}
+
+    def _retry(_sid):
+        called["retry"] = True
+        return {}
+
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes._check_csrf", return_value=True), \
+         patch("api.routes.read_body", return_value=body), \
+         patch("api.routes.get_session", return_value=meta), \
+         patch.object(session_ops, "retry_last", side_effect=_retry), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_post(SimpleNamespace(headers={}), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert called["retry"] is False, "retry_last must not run for a foreign-profile session"
+
+
+def test_session_undo_rejects_session_from_inactive_profile():
+    """POST /api/session/undo must not truncate/return a foreign-profile transcript."""
+    import api.routes as routes
+    import api.session_ops as session_ops
+
+    captured, fake_bad, fake_j = _post_capture()
+    meta = SimpleNamespace(profile="other")
+    parsed = urlparse("/api/session/undo")
+    body = {"session_id": "foreign_un_001"}
+    called = {"undo": False}
+
+    def _undo(_sid):
+        called["undo"] = True
+        return {}
+
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes._check_csrf", return_value=True), \
+         patch("api.routes.read_body", return_value=body), \
+         patch("api.routes.get_session", return_value=meta), \
+         patch.object(session_ops, "undo_last", side_effect=_undo), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_post(SimpleNamespace(headers={}), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert called["undo"] is False, "undo_last must not run for a foreign-profile session"
+
+
+def test_session_compress_rejects_session_from_inactive_profile():
+    """_handle_session_compress must not compress/return a foreign-profile transcript."""
+    import api.routes as routes
+
+    captured, fake_bad, fake_j = _post_capture()
+    foreign = SimpleNamespace(
+        profile="other", active_stream_id=None,
+        messages=[{"role": "user", "content": "x"}],
+    )
+    body = {"session_id": "foreign_cmp_001"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes.get_session", return_value=foreign), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes._handle_session_compress(SimpleNamespace(headers={}), body)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "foreign-profile transcript must not be compressed/returned"
+
+
+def test_session_handoff_summary_rejects_session_from_inactive_profile():
+    """_handle_handoff_summary must not summarize a foreign-profile CLI transcript."""
+    import api.routes as routes
+
+    captured, fake_bad, fake_j = _post_capture()
+    body = {"session_id": "foreign_ho_001"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes._lookup_cli_session_metadata", return_value={"profile": "other"}), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes._handle_handoff_summary(SimpleNamespace(headers={}), body)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "foreign-profile CLI transcript must not be summarized"
+
+
+def test_session_import_cli_fresh_rejects_session_from_inactive_profile():
+    """_handle_session_import_cli fresh (no-sidecar) branch must reject foreign profiles."""
+    import api.routes as routes
+
+    captured, fake_bad, fake_j = _post_capture()
+    body = {"session_id": "foreign_fresh_001"}
+    leaked = {"read": False}
+
+    def _get_cli_msgs(_sid):
+        leaked["read"] = True
+        return [{"role": "user", "content": "foreign profile secret"}]
+
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes.Session") as MockSession, \
+         patch("api.routes._lookup_cli_session_metadata", return_value={"profile": "other"}), \
+         patch("api.routes.get_cli_session_messages", side_effect=_get_cli_msgs), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        MockSession.load.return_value = None  # no existing sidecar -> fresh branch
+        routes._handle_session_import_cli(SimpleNamespace(headers={}), body)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert leaked["read"] is False, "foreign-profile CLI transcript must not be read before the guard"
+    assert "json" not in captured
+
+
 # ── Cleanup ────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -14,6 +14,8 @@ all_profiles=1 opt-in path. End-to-end HTTP-level tests live separately under
 tests/test_sessions_endpoint.py if/when added.
 """
 
+from types import SimpleNamespace
+from unittest.mock import patch
 from urllib.parse import urlparse
 
 import pytest
@@ -207,6 +209,67 @@ def test_static_sessions_js_trusts_server_profile_scoping():
     assert forbidden_count not in src, (
         "Client otherProfileCount must come from server, not strict-equality fallback"
     )
+
+
+# ── Direct session access must also honor active profile ───────────────────
+
+
+class _ProfileScopedSession:
+    def __init__(self, session_id="foreign_001", profile="other"):
+        self.session_id = session_id
+        self.profile = profile
+        self.active_stream_id = None
+        self.messages = [{"role": "user", "content": "foreign profile secret"}]
+        self.tool_calls = []
+        self.pending_user_message = None
+        self.pending_attachments = []
+        self.pending_started_at = None
+        self.context_length = 0
+        self.threshold_tokens = 0
+        self.last_prompt_tokens = 0
+
+    def compact(self, *args, **kwargs):
+        return {
+            "session_id": self.session_id,
+            "title": "Foreign session",
+            "profile": self.profile,
+            "workspace": "/tmp/foreign",
+            "model": "gpt-test",
+            "message_count": len(self.messages),
+        }
+
+
+def test_get_session_rejects_session_from_inactive_profile():
+    """A known session_id from another profile must not bypass /api/sessions scoping.
+
+    /api/sessions already filters rows by active profile.  The detail endpoint
+    must apply the same check after loading the sidecar; otherwise a stale URL or
+    guessed id can disclose another profile's transcript.
+    """
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_bad(_handler, message, status=400, **_kwargs):
+        captured["bad"] = {"message": message, "status": status}
+        return captured["bad"]
+
+    def fake_j(_handler, data, status=200, **_kwargs):
+        captured["json"] = {"data": data, "status": status}
+        return captured["json"]
+
+    parsed = urlparse("/api/session?session_id=foreign_001&messages=1&resolve_model=0")
+    with patch("api.profiles.get_active_profile_name", return_value="default"), \
+         patch("api.routes.get_session", return_value=_ProfileScopedSession()), \
+         patch("api.routes._clear_stale_stream_state", return_value=False), \
+         patch("api.routes._lookup_cli_session_metadata", return_value={}), \
+         patch("api.routes.get_state_db_session_messages", return_value=[]), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_get(SimpleNamespace(), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "foreign-profile transcript must not be returned"
 
 
 # ── Cleanup ────────────────────────────────────────────────────────────────

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -259,7 +259,7 @@ def test_get_session_rejects_session_from_inactive_profile():
         return captured["json"]
 
     parsed = urlparse("/api/session?session_id=foreign_001&messages=1&resolve_model=0")
-    with patch("api.profiles.get_active_profile_name", return_value="default"), \
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
          patch("api.routes.get_session", return_value=_ProfileScopedSession()), \
          patch("api.routes._clear_stale_stream_state", return_value=False), \
          patch("api.routes._lookup_cli_session_metadata", return_value={}), \
@@ -270,6 +270,34 @@ def test_get_session_rejects_session_from_inactive_profile():
 
     assert captured.get("bad", {}).get("status") == 404
     assert "json" not in captured, "foreign-profile transcript must not be returned"
+
+
+def test_get_session_rejects_cli_session_from_inactive_profile():
+    """CLI fallback responses must use the same active-profile boundary."""
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_bad(_handler, message, status=400, **_kwargs):
+        captured["bad"] = {"message": message, "status": status}
+        return captured["bad"]
+
+    def fake_j(_handler, data, status=200, **_kwargs):
+        captured["json"] = {"data": data, "status": status}
+        return captured["json"]
+
+    parsed = urlparse("/api/session?session_id=cli_foreign&messages=1&resolve_model=0")
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes.get_session", side_effect=KeyError), \
+         patch("api.routes.SESSION_INDEX_FILE", SimpleNamespace(exists=lambda: False)), \
+         patch("api.routes._lookup_cli_session_metadata", return_value={"profile": "other"}), \
+         patch("api.routes.get_cli_session_messages", return_value=[{"role": "user", "content": "foreign profile secret"}]), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_get(SimpleNamespace(), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "foreign-profile CLI transcript must not be returned"
 
 
 # ── Cleanup ────────────────────────────────────────────────────────────────

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -260,7 +260,7 @@ def test_session_export_rejects_session_from_inactive_profile():
     handler = _ExportCaptureHandler()
     parsed = urlparse("/api/session/export?session_id=foreign_export_001")
     with patch("api.routes.get_session", return_value=foreign), \
-         patch("api.profiles.get_active_profile_name", return_value="default"), \
+         patch("api.routes.get_active_profile_name", return_value="default"), \
          patch("api.routes.bad", side_effect=fake_bad):
         routes._handle_session_export(handler, parsed)
 
@@ -282,7 +282,8 @@ def test_session_export_allows_session_from_active_profile():
     handler = _ExportCaptureHandler()
     parsed = urlparse("/api/session/export?session_id=active_export_001")
     with patch("api.routes.get_session", return_value=active), \
-         patch("api.profiles.get_active_profile_name", return_value="default"):
+         patch("api.routes.get_active_profile_name", return_value="default"), \
+         patch("api.routes.redact_session_data", side_effect=lambda data: data):
         routes._handle_session_export(handler, parsed)
 
     assert handler.status == 200

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -780,6 +780,168 @@ def test_session_import_cli_fresh_rejects_session_from_inactive_profile():
     assert "json" not in captured
 
 
+# ── Turn-start / derive paths must also honor active profile (LX class sweep r2) ──
+#
+# chat/start, chat (sync fallback), btw, archive, draft (GET+POST), and
+# title/regenerate all loaded a session by id and read/appended/derived from its
+# transcript without the active-profile boundary.
+
+
+def test_chat_start_rejects_session_from_inactive_profile():
+    """POST /api/chat/start must not start a turn on a foreign-profile session."""
+    import api.routes as routes
+
+    captured, fake_bad, fake_j = _post_capture()
+    started = {"run": False}
+
+    def _start_run(*a, **k):
+        started["run"] = True
+        return {}
+
+    foreign = SimpleNamespace(
+        profile="other", messages=[{"role": "user", "content": "x"}],
+        context_messages=[], pending_user_message=None,
+    )
+    body = {"session_id": "foreign_cs_001", "message": "hi"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes.get_session", return_value=foreign), \
+         patch("api.routes._start_run", side_effect=_start_run), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes._handle_chat_start(SimpleNamespace(headers={}), body)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert started["run"] is False, "a turn must not start on a foreign-profile session"
+
+
+def test_chat_start_allows_empty_placeholder_retagged_to_active_profile():
+    """An empty placeholder session retagged to the active profile must NOT be rejected."""
+    import api.routes as routes
+
+    captured, fake_bad, fake_j = _post_capture()
+    started = {"run": False}
+
+    def _start_run(*a, **k):
+        started["run"] = True
+        return {"ok": True}
+
+    # Empty placeholder (no persisted turns) created under a stale profile.
+    placeholder = SimpleNamespace(
+        profile="stale", messages=[], context_messages=[], pending_user_message=None,
+        session_id="ph_001", model="m", model_provider="p", workspace="/tmp/ws",
+    )
+    body = {"session_id": "ph_001", "message": "hi", "profile": "default"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes.get_session", return_value=placeholder), \
+         patch("api.routes._normalize_chat_attachments", return_value=[]), \
+         patch("api.routes._resolve_chat_workspace_with_recovery", return_value="/tmp/ws"), \
+         patch("api.routes._read_profile_model_config", return_value=(None, None)), \
+         patch("api.routes._resolve_compatible_session_model_state", return_value=("m", "p", "m")), \
+         patch("api.routes._start_run", side_effect=_start_run), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes._handle_chat_start(SimpleNamespace(headers={}), body)
+
+    # Retag set placeholder.profile to "default" (== active) so the guard passes.
+    assert placeholder.profile == "default"
+    assert started["run"] is True, "placeholder retagged to active profile must start normally"
+    assert "bad" not in captured or captured.get("bad", {}).get("status") != 404
+
+
+def test_chat_sync_rejects_session_from_inactive_profile():
+    """POST /api/chat (sync fallback) must not read/return a foreign-profile transcript."""
+    import api.routes as routes
+
+    captured, fake_bad, fake_j = _post_capture()
+    foreign = SimpleNamespace(profile="other", messages=[{"role": "user", "content": "x"}], workspace="/tmp")
+    body = {"session_id": "foreign_csync_001", "message": "hi"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes.get_session", return_value=foreign), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes._handle_chat_sync(SimpleNamespace(headers={}), body)
+
+    assert captured.get("bad", {}).get("status") == 404
+
+
+def test_btw_rejects_session_from_inactive_profile():
+    """POST /api/btw must not derive an answer from a foreign-profile transcript."""
+    import api.routes as routes
+
+    captured, fake_bad, fake_j = _post_capture()
+    foreign = SimpleNamespace(profile="other", messages=[{"role": "user", "content": "x"}], active_stream_id=None)
+    body = {"session_id": "foreign_btw_001", "question": "what?"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes.get_session", return_value=foreign), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes._handle_btw(SimpleNamespace(headers={}), body)
+
+    assert captured.get("bad", {}).get("status") == 404
+
+
+def test_session_archive_rejects_session_from_inactive_profile():
+    """POST /api/session/archive must not archive a foreign-profile session."""
+    import api.routes as routes
+
+    captured, fake_bad, fake_j = _post_capture()
+    foreign = SimpleNamespace(profile="other", _loaded_metadata_only=False, archived=False)
+    parsed = urlparse("/api/session/archive")
+    body = {"session_id": "foreign_arch_001"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes._check_csrf", return_value=True), \
+         patch("api.routes.read_body", return_value=body), \
+         patch("api.routes.get_session", return_value=foreign), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_post(SimpleNamespace(headers={}), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+
+
+def test_session_draft_get_rejects_session_from_inactive_profile():
+    """GET /api/session/draft must not return a foreign-profile draft."""
+    import api.routes as routes
+
+    captured, fake_bad, fake_j = _post_capture()
+    foreign = SimpleNamespace(profile="other", composer_draft={"text": "secret draft"})
+    parsed = urlparse("/api/session/draft?session_id=foreign_dr_001")
+    handler = SimpleNamespace(headers={}, command="GET")
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes._check_csrf", return_value=True), \
+         patch("api.routes.read_body", return_value={}), \
+         patch("api.routes.get_session", return_value=foreign), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_post(handler, parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "foreign-profile draft must not be returned"
+
+
+def test_session_title_regenerate_rejects_session_from_inactive_profile():
+    """POST /api/session/title/regenerate must not derive a title from a foreign transcript."""
+    import api.routes as routes
+
+    captured, fake_bad, fake_j = _post_capture()
+    foreign = SimpleNamespace(profile="other", read_only=False, is_imported=False,
+                              messages=[{"role": "user", "content": "x"}])
+    parsed = urlparse("/api/session/title/regenerate")
+    body = {"session_id": "foreign_tr_001"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes._check_csrf", return_value=True), \
+         patch("api.routes.read_body", return_value=body), \
+         patch("api.routes.get_session", return_value=foreign), \
+         patch("api.routes._ensure_full_session_before_mutation", return_value=foreign), \
+         patch("api.routes.generate_session_title_for_session", return_value=("LEAKED", "ok", "raw")), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_post(SimpleNamespace(headers={}), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "foreign-profile title must not be generated/returned"
+
+
 # ── Cleanup ────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -266,10 +266,35 @@ def test_get_session_rejects_session_from_inactive_profile():
          patch("api.routes.get_state_db_session_messages", return_value=[]), \
          patch("api.routes.bad", side_effect=fake_bad), \
          patch("api.routes.j", side_effect=fake_j):
-        routes.handle_get(SimpleNamespace(), parsed)
+        routes.handle_get(SimpleNamespace(headers={"Cookie": "hermes_profile=default"}), parsed)
 
     assert captured.get("bad", {}).get("status") == 404
     assert "json" not in captured, "foreign-profile transcript must not be returned"
+
+
+def test_get_session_rejects_metadata_only_session_from_inactive_profile():
+    """Metadata-only loads must not bypass the active-profile boundary."""
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_bad(_handler, message, status=400, **_kwargs):
+        captured["bad"] = {"message": message, "status": status}
+        return captured["bad"]
+
+    def fake_j(_handler, data, status=200, **_kwargs):
+        captured["json"] = {"data": data, "status": status}
+        return captured["json"]
+
+    parsed = urlparse("/api/session?session_id=foreign_001&messages=0&resolve_model=0")
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes.get_session", return_value=_ProfileScopedSession()), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_get(SimpleNamespace(headers={"Cookie": "hermes_profile=default"}), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "foreign-profile metadata must not be returned"
 
 
 def test_get_session_rejects_cli_session_from_inactive_profile():
@@ -294,7 +319,7 @@ def test_get_session_rejects_cli_session_from_inactive_profile():
          patch("api.routes.get_cli_session_messages", return_value=[{"role": "user", "content": "foreign profile secret"}]), \
          patch("api.routes.bad", side_effect=fake_bad), \
          patch("api.routes.j", side_effect=fake_j):
-        routes.handle_get(SimpleNamespace(), parsed)
+        routes.handle_get(SimpleNamespace(headers={"Cookie": "hermes_profile=default"}), parsed)
 
     assert captured.get("bad", {}).get("status") == 404
     assert "json" not in captured, "foreign-profile CLI transcript must not be returned"

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -431,6 +431,150 @@ def test_session_export_allows_session_from_active_profile():
     assert ("Cache-Control", "no-store") in handler.sent_headers
 
 
+# ── Sibling session read/mutate paths must also honor active profile ───────
+#
+# /api/session and /api/session/export are not the only routes that load a
+# session by id and return (or mutate) its transcript. duplicate / update /
+# truncate / import_cli all loaded by id without the active-profile boundary,
+# so a foreign-profile transcript could leak or be mutated by a caller scoped
+# to a different profile. These guards close that class.
+
+
+def test_session_duplicate_rejects_session_from_inactive_profile():
+    """POST /api/session/duplicate must not copy/return a foreign-profile transcript."""
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_bad(_handler, message, status=400, **_kwargs):
+        captured["bad"] = {"message": message, "status": status}
+        return captured["bad"]
+
+    def fake_j(_handler, data, status=200, **_kwargs):
+        captured["json"] = {"data": data, "status": status}
+        return captured["json"]
+
+    foreign = SimpleNamespace(
+        session_id="foreign_dup_001",
+        profile="other",
+        title="Foreign",
+        messages=[{"role": "user", "content": "foreign profile secret"}],
+    )
+    parsed = urlparse("/api/session/duplicate")
+    body = {"session_id": "foreign_dup_001"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes._check_csrf", return_value=True), \
+         patch("api.routes.read_body", return_value=body), \
+         patch("api.routes.Session") as MockSession, \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        MockSession.load.return_value = foreign
+        routes.handle_post(SimpleNamespace(headers={}), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "foreign-profile transcript must not be duplicated/returned"
+
+
+def test_session_update_rejects_session_from_inactive_profile():
+    """POST /api/session/update must not read/mutate a foreign-profile session."""
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_bad(_handler, message, status=400, **_kwargs):
+        captured["bad"] = {"message": message, "status": status}
+        return captured["bad"]
+
+    def fake_j(_handler, data, status=200, **_kwargs):
+        captured["json"] = {"data": data, "status": status}
+        return captured["json"]
+
+    foreign = SimpleNamespace(
+        session_id="foreign_upd_001",
+        profile="other",
+        workspace="/tmp/foreign",
+        model="gpt-test",
+        model_provider="openai",
+        messages=[{"role": "user", "content": "foreign profile secret"}],
+    )
+    parsed = urlparse("/api/session/update")
+    body = {"session_id": "foreign_upd_001", "workspace": "/tmp/x"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes._check_csrf", return_value=True), \
+         patch("api.routes.read_body", return_value=body), \
+         patch("api.routes.get_session", return_value=foreign), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_post(SimpleNamespace(headers={}), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "foreign-profile session must not be updated/returned"
+
+
+def test_session_truncate_rejects_session_from_inactive_profile():
+    """POST /api/session/truncate must not read/mutate a foreign-profile session."""
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_bad(_handler, message, status=400, **_kwargs):
+        captured["bad"] = {"message": message, "status": status}
+        return captured["bad"]
+
+    def fake_j(_handler, data, status=200, **_kwargs):
+        captured["json"] = {"data": data, "status": status}
+        return captured["json"]
+
+    foreign = SimpleNamespace(
+        session_id="foreign_trunc_001",
+        profile="other",
+        messages=[{"role": "user", "content": "foreign profile secret"}],
+    )
+    parsed = urlparse("/api/session/truncate")
+    body = {"session_id": "foreign_trunc_001", "keep_count": 1}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes._check_csrf", return_value=True), \
+         patch("api.routes.read_body", return_value=body), \
+         patch("api.routes.get_session", return_value=foreign), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_post(SimpleNamespace(headers={}), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "foreign-profile session must not be truncated/returned"
+
+
+def test_session_import_cli_rejects_existing_sidecar_from_inactive_profile():
+    """_handle_session_import_cli must not refresh/return a foreign-profile sidecar."""
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_bad(_handler, message, status=400, **_kwargs):
+        captured["bad"] = {"message": message, "status": status}
+        return captured["bad"]
+
+    def fake_j(_handler, data, status=200, **_kwargs):
+        captured["json"] = {"data": data, "status": status}
+        return captured["json"]
+
+    foreign = SimpleNamespace(
+        session_id="foreign_cli_001",
+        profile="other",
+        messages=[{"role": "user", "content": "foreign profile secret"}],
+    )
+    body = {"session_id": "foreign_cli_001"}
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes.Session") as MockSession, \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        MockSession.load.return_value = foreign
+        routes._handle_session_import_cli(SimpleNamespace(headers={}), body)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "foreign-profile CLI sidecar must not be refreshed/returned"
+
+
 # ── Cleanup ────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -14,6 +14,8 @@ all_profiles=1 opt-in path. End-to-end HTTP-level tests live separately under
 tests/test_sessions_endpoint.py if/when added.
 """
 
+from types import SimpleNamespace
+from unittest.mock import patch
 from urllib.parse import urlparse
 
 import pytest
@@ -207,6 +209,86 @@ def test_static_sessions_js_trusts_server_profile_scoping():
     assert forbidden_count not in src, (
         "Client otherProfileCount must come from server, not strict-equality fallback"
     )
+
+
+# ── Direct session export must also honor active profile ───────────────────
+
+
+class _ExportCaptureHandler:
+    def __init__(self):
+        self.headers = {}
+        self.status = None
+        self.sent_headers = []
+        self.ended = False
+        self.wfile = SimpleNamespace(write=self._write)
+        self.body = b""
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.sent_headers.append((name, value))
+
+    def end_headers(self):
+        self.ended = True
+
+    def _write(self, data):
+        self.body += data
+
+
+def test_session_export_rejects_session_from_inactive_profile():
+    """A known session_id from another profile must not bypass /api/sessions scoping.
+
+    /api/sessions hides foreign-profile rows by default, but the export endpoint
+    loaded directly by id and serialized the sidecar. It must apply the same
+    active-profile check before writing the JSON attachment.
+    """
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_bad(_handler, message, status=400, **_kwargs):
+        captured["bad"] = {"message": message, "status": status}
+        return captured["bad"]
+
+    foreign = SimpleNamespace(
+        session_id="foreign_export_001",
+        profile="other",
+        messages=[{"role": "user", "content": "foreign profile secret"}],
+    )
+
+    handler = _ExportCaptureHandler()
+    parsed = urlparse("/api/session/export?session_id=foreign_export_001")
+    with patch("api.routes.get_session", return_value=foreign), \
+         patch("api.profiles.get_active_profile_name", return_value="default"), \
+         patch("api.routes.bad", side_effect=fake_bad):
+        routes._handle_session_export(handler, parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert handler.status is None
+    assert handler.body == b""
+
+
+def test_session_export_allows_session_from_active_profile():
+    """Same-profile exports still stream the redacted JSON attachment."""
+    import api.routes as routes
+
+    active = SimpleNamespace(
+        session_id="active_export_001",
+        profile="default",
+        messages=[{"role": "user", "content": "same profile content"}],
+    )
+
+    handler = _ExportCaptureHandler()
+    parsed = urlparse("/api/session/export?session_id=active_export_001")
+    with patch("api.routes.get_session", return_value=active), \
+         patch("api.profiles.get_active_profile_name", return_value="default"):
+        routes._handle_session_export(handler, parsed)
+
+    assert handler.status == 200
+    assert handler.ended is True
+    assert b"same profile content" in handler.body
+    assert ("Cache-Control", "no-store") in handler.sent_headers
 
 
 # ── Cleanup ────────────────────────────────────────────────────────────────

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -297,6 +297,31 @@ def test_get_session_rejects_metadata_only_session_from_inactive_profile():
     assert "json" not in captured, "foreign-profile metadata must not be returned"
 
 
+def test_get_session_rejects_cookieless_session_from_inactive_profile():
+    """Cookieless requests must still enforce the active-profile boundary."""
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_bad(_handler, message, status=400, **_kwargs):
+        captured["bad"] = {"message": message, "status": status}
+        return captured["bad"]
+
+    def fake_j(_handler, data, status=200, **_kwargs):
+        captured["json"] = {"data": data, "status": status}
+        return captured["json"]
+
+    parsed = urlparse("/api/session?session_id=foreign_001&messages=0&resolve_model=0")
+    with patch("api.routes._get_active_profile_name", return_value="default"), \
+         patch("api.routes.get_session", return_value=_ProfileScopedSession()), \
+         patch("api.routes.bad", side_effect=fake_bad), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_get(SimpleNamespace(headers={}), parsed)
+
+    assert captured.get("bad", {}).get("status") == 404
+    assert "json" not in captured, "cookieless foreign-profile metadata must not be returned"
+
+
 def test_get_session_rejects_cli_session_from_inactive_profile():
     """CLI fallback responses must use the same active-profile boundary."""
     import api.routes as routes

--- a/tests/test_issue2762_state_sync_profile_kwarg.py
+++ b/tests/test_issue2762_state_sync_profile_kwarg.py
@@ -315,6 +315,7 @@ def test_api_session_metadata_only_passes_session_profile_to_summary(
     )
     session.save(touch_updated_at=False)
     monkeypatch.setattr(routes_mod, "_lookup_cli_session_metadata", lambda _sid: {})
+    monkeypatch.setattr(routes_mod, "_get_active_profile_name", lambda: "maiko")
 
     class Handler:
         path = f"/api/session?session_id={sid}&messages=0&resolve_model=0"

--- a/tests/test_profile_switch_1200.py
+++ b/tests/test_profile_switch_1200.py
@@ -478,6 +478,9 @@ def test_chat_start_retags_empty_session_to_request_profile(monkeypatch, tmp_pat
 
     fake = FakeSession()
     monkeypatch.setattr(routes, "get_session", lambda sid: fake)
+    # Real request semantics: the hermes_profile cookie moves with the switch, so
+    # the active (per-request) profile equals the profile being sent under ("work").
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "work")
     monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda path: tmp_path)
     monkeypatch.setattr(
         routes,
@@ -550,6 +553,9 @@ def test_chat_start_does_not_retag_non_empty_session(monkeypatch, tmp_path):
 
     fake = FakeSession()
     monkeypatch.setattr(routes, "get_session", lambda sid: fake)
+    # Non-empty session is NOT retagged, so it stays under "default"; the active
+    # request profile is "default" (the session's own profile) for this scenario.
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
     monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda path: tmp_path)
     monkeypatch.setattr(
         routes,

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -324,7 +324,7 @@ def test_server_delete_prunes_session_index(cleanup_test_sessions):
             text.find('if parsed.path == "/api/session/delete":'),
         )
         if delete_idx >= 0:
-            delete_block = text[delete_idx:delete_idx+1800]
+            delete_block = text[delete_idx:delete_idx+2200]
             assert "prune_session_from_index(sid)" in delete_block, \
                 f"{label} session/delete must prune SESSION_INDEX_FILE"
             return
@@ -339,7 +339,7 @@ def test_server_delete_removes_session_bak_snapshot(cleanup_test_sessions):
         routes_src.find('if parsed.path == "/api/session/delete":'),
     )
     assert delete_idx >= 0, "session/delete handler not found in api/routes.py"
-    delete_block = routes_src[delete_idx:delete_idx+1800]
+    delete_block = routes_src[delete_idx:delete_idx+2200]
     assert "with_suffix('.json.bak').unlink" in delete_block or 'with_suffix(".json.bak").unlink' in delete_block, \
         "session/delete must unlink <sid>.json.bak to avoid later orphan-backup recovery"
 

--- a/tests/test_session_duplicate.py
+++ b/tests/test_session_duplicate.py
@@ -98,7 +98,7 @@ def test_duplicate_creates_independent_session():
 
     # Extract the duplicate endpoint code (next few lines)
     lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    endpoint_code = '\n'.join(lines[:95])
 
     # Verify that parent_session_id is NOT passed to Session constructor
     assert 'parent_session_id' not in endpoint_code, \
@@ -127,7 +127,7 @@ def test_duplicate_session_copies_title_logic():
     assert duplicate_start != -1, "Duplicate endpoint not found"
 
     lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    endpoint_code = '\n'.join(lines[:95])
 
     # Verify title includes (copy). Accept the original `session.title + " (copy)"`
     # form OR the May 2 2026 SF-3 hardened form `(session.title or "Untitled") + " (copy)"`
@@ -150,7 +150,7 @@ def test_duplicate_session_copies_messages_logic():
     assert duplicate_start != -1, "Duplicate endpoint not found"
 
     lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    endpoint_code = '\n'.join(lines[:95])
 
     # Verify messages are copied from original session.  Accept either the
     # plain assignment (insufficient — see test_duplicate_runtime_messages_independence)
@@ -171,7 +171,7 @@ def test_duplicate_session_copies_model_logic():
     assert duplicate_start != -1, "Duplicate endpoint not found"
 
     lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    endpoint_code = '\n'.join(lines[:95])
 
     # Verify model is copied
     assert 'model=session.model' in endpoint_code, \
@@ -189,7 +189,7 @@ def test_duplicate_session_copies_workspace_logic():
     assert duplicate_start != -1, "Duplicate endpoint not found"
 
     lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    endpoint_code = '\n'.join(lines[:95])
 
     # Verify workspace is copied
     assert 'workspace=session.workspace' in endpoint_code, \
@@ -207,7 +207,7 @@ def test_duplicate_session_copies_all_session_properties():
     assert duplicate_start != -1, "Duplicate endpoint not found"
 
     lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    endpoint_code = '\n'.join(lines[:95])
 
     # Extract the copied_session = Session( lines
     session_construction_start = endpoint_code.find('copied_session = Session(')
@@ -257,7 +257,7 @@ def test_duplicate_uses_deepcopy_for_messages():
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
     lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    endpoint_code = '\n'.join(lines[:95])
     assert 'copy.deepcopy(session.messages)' in endpoint_code, \
         "duplicate must use copy.deepcopy(session.messages) — plain assignment shares list refs"
     assert 'copy.deepcopy(session.tool_calls)' in endpoint_code, \
@@ -277,7 +277,7 @@ def test_duplicate_explicitly_persists_to_disk():
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
     lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    endpoint_code = '\n'.join(lines[:95])
     assert 'copied_session.save()' in endpoint_code, \
         "duplicate must call .save() explicitly — without it the copy vanishes on refresh"
 
@@ -294,7 +294,7 @@ def test_duplicate_resets_pinned_and_archived():
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
     lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    endpoint_code = '\n'.join(lines[:95])
     # Both must be hard-coded to False, NOT inherited from `session.pinned`/`session.archived`
     assert 'pinned=False' in endpoint_code, \
         "duplicate must reset pinned=False — duplicating shouldn't propagate pin state"
@@ -318,7 +318,7 @@ def test_duplicate_returns_404_when_session_not_found():
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
     lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    endpoint_code = '\n'.join(lines[:95])
     assert 'bad(handler, "Session not found", status=404)' in endpoint_code, \
         "missing session must return status=404, not the default 400"
 

--- a/tests/test_session_ops.py
+++ b/tests/test_session_ops.py
@@ -14,9 +14,17 @@ import pytest
 from tests.conftest import TEST_BASE, TEST_STATE_DIR, _post, make_session_tracked
 
 
-def _get(path):
-    """GET helper -- returns parsed JSON, or raises HTTPError on non-2xx."""
-    with urllib.request.urlopen(TEST_BASE + path, timeout=10) as r:
+def _get(path, profile=None):
+    """GET helper -- returns parsed JSON, or raises HTTPError on non-2xx.
+
+    Pass ``profile`` to send a ``hermes_profile`` cookie, matching how a real
+    profile-scoped WebUI client requests (the server scopes session-by-id reads
+    to the active per-request profile).
+    """
+    req = urllib.request.Request(TEST_BASE + path)
+    if profile:
+        req.add_header('Cookie', f'hermes_profile={profile}')
+    with urllib.request.urlopen(req, timeout=10) as r:
         return json.loads(r.read())
 
 
@@ -240,7 +248,7 @@ def test_status_returns_profile_specific_hermes_home(cleanup_test_sessions):
     sid = data['session']['session_id']
     cleanup_test_sessions.append(sid)
 
-    r = _get(f'/api/session/status?session_id={sid}')
+    r = _get(f'/api/session/status?session_id={sid}', profile='research')
 
     assert r['profile'] == 'research'
     assert r['hermes_home'] == str(TEST_STATE_DIR / 'profiles' / 'research')

--- a/tests/test_stage268_opus_followups.py
+++ b/tests/test_stage268_opus_followups.py
@@ -53,7 +53,7 @@ def test_sf2_duplicate_carries_personality():
     """The duplicate must propagate `personality` from source to copy."""
     duplicate_start = ROUTES_PY.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1
-    block = ROUTES_PY[duplicate_start:duplicate_start + 3000]
+    block = ROUTES_PY[duplicate_start:duplicate_start + 3400]
     assert 'personality=session.personality' in block, (
         "duplicate must carry over personality — without it, customized "
         "personalities silently revert to default in the copy"
@@ -63,7 +63,7 @@ def test_sf2_duplicate_carries_personality():
 def test_sf2_duplicate_carries_enabled_toolsets():
     """The duplicate must propagate `enabled_toolsets` (per-session toolset overrides)."""
     duplicate_start = ROUTES_PY.find('if parsed.path == "/api/session/duplicate":')
-    block = ROUTES_PY[duplicate_start:duplicate_start + 3000]
+    block = ROUTES_PY[duplicate_start:duplicate_start + 3400]
     assert 'enabled_toolsets=getattr(session, "enabled_toolsets", None)' in block, (
         "duplicate must carry enabled_toolsets — without it, per-session "
         "toolset overrides silently revert to defaults in the copy"
@@ -73,7 +73,7 @@ def test_sf2_duplicate_carries_enabled_toolsets():
 def test_sf2_duplicate_carries_context_settings():
     """The duplicate must propagate context_length + threshold_tokens."""
     duplicate_start = ROUTES_PY.find('if parsed.path == "/api/session/duplicate":')
-    block = ROUTES_PY[duplicate_start:duplicate_start + 3000]
+    block = ROUTES_PY[duplicate_start:duplicate_start + 3400]
     assert 'context_length=getattr(session, "context_length", None)' in block
     assert 'threshold_tokens=getattr(session, "threshold_tokens", None)' in block
 
@@ -86,7 +86,7 @@ def test_sf3_duplicate_handles_none_title():
     on legacy sessions with title=null."""
     duplicate_start = ROUTES_PY.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1
-    block = ROUTES_PY[duplicate_start:duplicate_start + 3000]
+    block = ROUTES_PY[duplicate_start:duplicate_start + 3400]
     # Must use the (session.title or "Untitled") form, not raw session.title
     assert '(session.title or "Untitled") + " (copy)"' in block, (
         "duplicate must guard against None title — `session.title + ' (copy)'` "

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -201,6 +201,7 @@ def test_deferred_session_model_resolution_uses_profile_provider(monkeypatch, tm
         "_resolve_context_length_for_session_model",
         lambda *_args, **_kwargs: 0,
     )
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "anthropic")
 
     session_path = tmp_path / "sessions" / f"{sid}.json"
     before = session_path.read_text(encoding="utf-8")


### PR DESCRIPTION
# ⚠️ DRAFT — do not merge yet (parked for a proper design pass)

Scopes WebUI **session-by-id** endpoints to the active per-request profile, closing a cross-profile information-leak + data-mutation class. **Absorbs #3982 + #3991** and extends them across the whole session-by-id surface.

## Why this is a draft, not a merge-ready PR

The originally-reported leak (#3982 detail-load, #3991 export) is small and clean. But a class-wide review (Codex, 5 rounds) showed the gap is **systemic**: `GET /api/sessions` (list) filters by profile (#798 / #1614), but ~40 per-id handlers never did. Closing it one-guard-at-a-time works but (a) keeps surfacing more paths and (b) the high-interaction paths (chat/start retag, status polls) repeatedly tripped legitimate same-profile flows. This wants a **central guarded session-lookup** the router funnels through, not N hand-placed guards. Parking here until that design lands. See the tracking issue for the architecture.

## What's done (CORE surface — guarded + tested, full suite green: 8635 passed)

A shared `_session_visible_to_active_profile(profile, handler)` → 404 guard (and a `_visible_session_for_file_ops` wrapper + `_git_session` helper) applied before any read / mutate / delete / derive on:

- **read/export:** detail-load (webui + cli-meta), export, draft (GET), list-dir, status, usage
- **mutate/destroy:** delete, clear, truncate, update, rename, personality, toolsets, pin, move, draft (POST), worktree status/remove
- **derive:** duplicate, branch, compress (+start; internal worker re-dispatch trusted via `_hermes_internal_trusted` sentinel), handoff-summary, conversation-rounds, import_cli (both branches), btw, title/regenerate
- **turn-start:** chat/start (guard placed AFTER the #1200 empty-placeholder retag — positive test confirms the legit profile-switch-before-first-turn flow still works), chat-sync, goal
- **workspace surface:** all git routes (`_git_session`), all file-ops (`_visible_session_for_file_ops`), terminal/start, `/api/media` authorization, background, the 3 `api/upload.py` handlers

20 new regression tests (one per path, each verified to fail without its guard); brittle source-window tests re-anchored; 3 #1200 + 1 session-ops tests updated to send the `hermes_profile` cookie (matching real profile-scoped client semantics).

## Deferred (NOT in this PR — see tracking issue)

Lower-severity, high-interaction SSE/approval/clarify/control paths that a naive guard would risk breaking: approval/* and clarify/* (pending/SSE/respond/inject), `/api/session/stream`, `/api/chat/steer`, compress/status, yolo, background/status, git-info, lineage/report, terminal output/input/resize/close.

## Verification
- Full pytest suite: **8635 passed, 0 failed** (3-shard equivalent, `-p no:xdist`).
- Ruff forward gate: clean (no new violations on changed lines).
- Codex diff-review across 5 rounds drove the path enumeration.
- Default/root profile isolation preserved (`_profiles_match` + #1614) — strict per-profile boundary, no hierarchy.

Co-authored-by: Hinotoi-agent (original #3982/#3991 author)
