### PR TITLE
Release LY — v0.51.360 — close idle SSE on hidden tabs (#3996, fixes #3992)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.360] — 2026-06-11 — Release LY (close idle SSE on hidden tabs)
+
+### Fixed
+
+- **Idle background tabs no longer exhaust the browser's connection pool and cause "Request timed out" toasts (#3992).** Each WebUI window opened three persistent SSE connections (session-events, gateway stream, per-session stream); with two windows open that reached the browser's six-connection per-origin HTTP/1.1 limit, so any subsequent request queued behind the saturated pool and timed out. The gateway and per-session streams now follow the same Page Visibility pattern the session-events stream already used: they close while the tab is hidden (freeing pool slots) and reopen when it becomes visible again. The per-session stream correctly reattaches on re-show — including for a session that was loaded or restored while the tab was already hidden — so live `bg_task_complete` / `server_turn_started` events are not missed. (#3996)
+
 ## [v0.51.359] — 2026-06-11 — Release LW (assistant turn anchor phase 0 scaffold)
 
 ### Added

--- a/static/messages.js
+++ b/static/messages.js
@@ -4202,6 +4202,9 @@ function stopApprovalPolling() {
 let _sessionEventSource = null;
 let _sessionStreamSessionId = null;
 let _sessionStreamReconnectTimer = null;
+// Holds the session id across a hidden-tab close so the visibility handler can
+// reopen the per-session SSE on re-show (stopSessionStream nulls _sessionStreamSessionId).
+let _sessionStreamHiddenSid = null;
 
 function startSessionStream(sid) {
   if (!sid) return;
@@ -4210,13 +4213,19 @@ function startSessionStream(sid) {
   if (_sessionStreamSessionId === sid && _sessionEventSource) return;
   stopSessionStream();
   _sessionStreamSessionId = sid;
-  // Visibility hook (install once) — mirror ensureSessionEventsSSE() pattern
+  // Visibility hook (install once) — mirror ensureSessionEventsSSE() pattern.
+  // Capture the active session id into a dedicated var BEFORE closing, because
+  // stopSessionStream() nulls _sessionStreamSessionId — so the reopen path can't
+  // rely on it (that was the bug: the stream never reopened on tab re-show).
   if (typeof document !== 'undefined' && !document._hermesSessionStreamVisibilityHook) {
     document.addEventListener('visibilitychange', () => {
       if (document.hidden) {
+        _sessionStreamHiddenSid = _sessionStreamSessionId;
         stopSessionStream();
-      } else if (_sessionStreamSessionId) {
-        void startSessionStream(_sessionStreamSessionId);
+      } else if (_sessionStreamHiddenSid) {
+        const resumeSid = _sessionStreamHiddenSid;
+        _sessionStreamHiddenSid = null;
+        void startSessionStream(resumeSid);
       }
     });
     document._hermesSessionStreamVisibilityHook = true;

--- a/static/messages.js
+++ b/static/messages.js
@@ -4230,8 +4230,13 @@ function startSessionStream(sid) {
     });
     document._hermesSessionStreamVisibilityHook = true;
   }
-  // Don't open when tab is hidden — saves connection pool slots
-  if (typeof document !== 'undefined' && document.hidden) return;
+  // Don't open when tab is hidden — saves connection pool slots. Preserve the
+  // pending session id so the visibility handler reopens it on re-show (a session
+  // loaded/restored while the tab is already hidden must still reattach).
+  if (typeof document !== 'undefined' && document.hidden) {
+    _sessionStreamHiddenSid = sid;
+    return;
+  }
   try {
     const es = new EventSource(_apiUrl('api/session/stream?session_id=' + encodeURIComponent(sid)));
     _sessionEventSource = es;

--- a/static/messages.js
+++ b/static/messages.js
@@ -4210,6 +4210,19 @@ function startSessionStream(sid) {
   if (_sessionStreamSessionId === sid && _sessionEventSource) return;
   stopSessionStream();
   _sessionStreamSessionId = sid;
+  // Visibility hook (install once) — mirror ensureSessionEventsSSE() pattern
+  if (typeof document !== 'undefined' && !document._hermesSessionStreamVisibilityHook) {
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        stopSessionStream();
+      } else if (_sessionStreamSessionId) {
+        void startSessionStream(_sessionStreamSessionId);
+      }
+    });
+    document._hermesSessionStreamVisibilityHook = true;
+  }
+  // Don't open when tab is hidden — saves connection pool slots
+  if (typeof document !== 'undefined' && document.hidden) return;
   try {
     const es = new EventSource(_apiUrl('api/session/stream?session_id=' + encodeURIComponent(sid)));
     _sessionEventSource = es;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3704,6 +3704,19 @@ async function probeGatewaySSEStatus(){
 function startGatewaySSE(){
   stopGatewaySSE();
   if(!window._showCliSessions) return;
+  // Visibility hook (install once) — mirror ensureSessionEventsSSE() pattern
+  if(typeof document !== 'undefined' && !document._hermesGatewaySSEVisibilityHook){
+    document.addEventListener('visibilitychange', () => {
+      if(document.hidden){
+        stopGatewaySSE();
+      }else{
+        void startGatewaySSE();
+      }
+    });
+    document._hermesGatewaySSEVisibilityHook = true;
+  }
+  // Don't open when tab is hidden — saves connection pool slots
+  if(typeof document !== 'undefined' && document.hidden) return;
   try{
     _gatewaySSE = new EventSource('api/sessions/gateway/stream');
     _gatewaySSE.addEventListener('sessions_changed', (ev) => {

--- a/tests/test_issue3996_sse_visibility.py
+++ b/tests/test_issue3996_sse_visibility.py
@@ -45,7 +45,7 @@ def test_session_stream_has_visibility_hook():
     assert "visibilitychange" in block
     assert "document.hidden" in block
     # Must skip opening a new EventSource while the tab is hidden.
-    assert "if (typeof document !== 'undefined' && document.hidden) return;" in block
+    assert "if (typeof document !== 'undefined' && document.hidden) {" in block
 
 
 def test_session_stream_reopens_from_dedicated_var_not_nulled_id():
@@ -82,3 +82,26 @@ def test_stop_session_stream_still_nulls_session_id():
     assert stop_idx != -1
     block = MESSAGES_JS[stop_idx:stop_idx + 400]
     assert "_sessionStreamSessionId = null" in block
+
+
+def test_session_stream_hidden_open_preserves_id_for_reopen():
+    """A session opened while the tab is ALREADY hidden must still reopen on re-show.
+
+    Codex CORE: startSessionStream(sid) sets _sessionStreamSessionId and then
+    returns early when document.hidden. If it doesn't also record the id in the
+    dedicated holder, the visibility handler (which reopens only from the holder)
+    never reattaches — silently dropping bg_task_complete / server_turn_started
+    for a session loaded in a background tab. The hidden-skip path must set
+    _sessionStreamHiddenSid = sid before returning.
+    """
+    start_idx = MESSAGES_JS.find("function startSessionStream(sid)")
+    block = MESSAGES_JS[start_idx:start_idx + 1700]
+    # Find the hidden-tab early-return skip path (distinct from the in-hook
+    # `if (document.hidden)` branch) and assert it preserves the id.
+    hidden_idx = block.find("!== 'undefined' && document.hidden) {")
+    assert hidden_idx != -1, "expected a braced hidden-tab skip block (not a bare return)"
+    hidden_block = block[hidden_idx:hidden_idx + 160]
+    assert "_sessionStreamHiddenSid = sid" in hidden_block, (
+        "hidden-tab skip must record the pending session id for reopen on re-show"
+    )
+

--- a/tests/test_issue3996_sse_visibility.py
+++ b/tests/test_issue3996_sse_visibility.py
@@ -1,0 +1,84 @@
+"""Structural tests for #3996 — close idle SSE on hidden tabs to free the
+HTTP/1.1 connection pool (#3992), plus the reopen-on-re-show correctness fix.
+
+Two idle persistent SSE connections per window (gateway stream + per-session
+stream) plus the always-present session-events stream meant 2 windows x 3 = 6 =
+the browser's per-origin HTTP/1.1 connection limit, so any subsequent fetch()
+queued behind a saturated pool and timed out. #3996 adds Page Visibility API
+hooks that close those streams while the tab is hidden and reopen them on
+re-show, mirroring the existing ensureSessionEventsSSE() pattern.
+
+These are source-grep checks (the hooks live in static JS with no server round
+trip). The key regression guard is that the *per-session* stream actually
+reopens on re-show: stopSessionStream() nulls _sessionStreamSessionId, so the
+reopen path must NOT depend on that variable (it captures the id into a
+dedicated _sessionStreamHiddenSid before closing).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def test_gateway_sse_has_visibility_hook():
+    """startGatewaySSE installs a visibilitychange hook that closes on hide."""
+    assert "_hermesGatewaySSEVisibilityHook" in SESSIONS_JS
+    # Closes on hide, and skips opening while hidden to save pool slots.
+    assert "stopGatewaySSE()" in SESSIONS_JS
+    start_idx = SESSIONS_JS.find("function startGatewaySSE()")
+    assert start_idx != -1
+    block = SESSIONS_JS[start_idx:start_idx + 1200]
+    assert "visibilitychange" in block
+    assert "document.hidden" in block
+
+
+def test_session_stream_has_visibility_hook():
+    """startSessionStream installs a visibilitychange hook."""
+    assert "_hermesSessionStreamVisibilityHook" in MESSAGES_JS
+    start_idx = MESSAGES_JS.find("function startSessionStream(sid)")
+    assert start_idx != -1
+    block = MESSAGES_JS[start_idx:start_idx + 1600]
+    assert "visibilitychange" in block
+    assert "document.hidden" in block
+    # Must skip opening a new EventSource while the tab is hidden.
+    assert "if (typeof document !== 'undefined' && document.hidden) return;" in block
+
+
+def test_session_stream_reopens_from_dedicated_var_not_nulled_id():
+    """Regression: the per-session SSE must reopen on re-show.
+
+    stopSessionStream() sets _sessionStreamSessionId = null, so the visibility
+    reopen path must capture the id into a dedicated holder BEFORE closing and
+    reopen from that — otherwise the stream closes on hide and never comes back.
+    """
+    # Dedicated holder declared at module scope.
+    assert "_sessionStreamHiddenSid" in MESSAGES_JS, (
+        "expected a dedicated holder var for the hidden-tab session id"
+    )
+
+    start_idx = MESSAGES_JS.find("function startSessionStream(sid)")
+    block = MESSAGES_JS[start_idx:start_idx + 1600]
+
+    # On hide: capture the id, then stop.
+    assert "_sessionStreamHiddenSid = _sessionStreamSessionId" in block
+    # On re-show: reopen from the captured holder, NOT from the nulled id.
+    assert "else if (_sessionStreamHiddenSid)" in block
+    assert "void startSessionStream(resumeSid)" in block or \
+           "startSessionStream(_sessionStreamHiddenSid)" in block
+
+    # Guard against the buggy form that reopens off the (already-nulled) id.
+    assert "else if (_sessionStreamSessionId) {\n        void startSessionStream(_sessionStreamSessionId)" not in block, (
+        "reopen must not depend on _sessionStreamSessionId — stopSessionStream() nulls it"
+    )
+
+
+def test_stop_session_stream_still_nulls_session_id():
+    """Confirms the precondition the reopen fix defends against."""
+    stop_idx = MESSAGES_JS.find("function stopSessionStream()")
+    assert stop_idx != -1
+    block = MESSAGES_JS[stop_idx:stop_idx + 400]
+    assert "_sessionStreamSessionId = null" in block


### PR DESCRIPTION
# Release LY — v0.51.360 — close idle SSE on hidden tabs (#3996, fixes #3992)

Single-PR release absorbing **#3996** (ddiall).

## Problem (#3992)
Each WebUI window opens **three** persistent SSE connections (session-events, gateway stream, per-session stream). Two idle windows on the same origin = 6 = the browser's per-origin HTTP/1.1 connection limit, so any subsequent `fetch()` (polling, clicks) queued behind the saturated pool and timed out at 30s with "Request timed out. Please try again." toasts.

## Fix
Add Page Visibility API hooks to the two streams that lacked them (`startGatewaySSE` in `sessions.js`, `startSessionStream` in `messages.js`), mirroring the proven `ensureSessionEventsSSE()` pattern already in `sessions.js`: close the stream on `document.hidden` (freeing pool slots), skip opening while hidden, reopen on re-show.

## Two reopen bugs found + fixed during review (beyond the contributor's original)
1. **Reopen depended on a nulled var.** The per-session hook reopened from `_sessionStreamSessionId`, but `stopSessionStream()` nulls it → the per-session SSE closed on hide and never reopened (regressing live-stream reattach). Fixed by capturing the id into a dedicated module-scope `_sessionStreamHiddenSid` before closing.
2. **(Codex CORE) Background-tab open lost the id.** If `startSessionStream(sid)` runs while the tab is already hidden (session loaded/restored in a background tab), it returned at the hidden-skip without recording the holder → never reopened on re-show, silently dropping `bg_task_complete` / `server_turn_started`. Fixed by setting `_sessionStreamHiddenSid = sid` on the hidden-skip return.

## Verification
- **Full suite: 8615 passed, 0 failed** (`-p no:xdist`).
- 5 new structural regression tests (`tests/test_issue3996_sse_visibility.py`): hooks present on both streams, reopen-from-holder, hidden-open preserves id, stop still nulls id.
- node -c clean, ESLint runtime gate clean, ruff forward gate clean.
- **Codex** (diff-vs-master): one CORE finding (background-tab reopen) — applied verbatim.
- **Opus**: "release #3996 as staged" — close/reopen lifecycle correct, listener install once-guarded, double-open structurally impossible, reconnect timer cannot race the visibility reopen. Two observations explicitly non-blocking (hidden-tab toast loss is invisible anyway; theoretical self-correcting stale-sid on cross-window delete).

Listener accumulation guarded via `document._hermesSessionStreamVisibilityHook` / `_hermesGatewaySSEVisibilityHook` (installed once).

Co-authored-by: ddiall
