### PR TITLE
fix(scroll): guard scroll pin hysteresis + add auto_scroll_follow setting

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -5746,6 +5746,7 @@ _SETTINGS_DEFAULTS = {
     "font_size": "default",  # small | default | large | xlarge
     "session_jump_buttons": False,  # show Start/End transcript jump pills
     "session_endless_scroll": False,  # auto-load older transcript pages while scrolling upward
+    "auto_scroll_follow": False,  # auto-scroll to bottom during streaming; false = user controls scroll
     "worklog_details_expanded_default": False,  # opt-in: expand Worklog details by default; default remains folded
     "pinned_sessions_limit": 3,  # maximum active pinned sessions shown in the sidebar
     "inflight_state_max_sessions": 8,  # max active-stream recovery snapshots kept in browser localStorage
@@ -5932,6 +5933,7 @@ _SETTINGS_BOOL_KEYS = {
     "api_redact_enabled",
     "session_jump_buttons",
     "session_endless_scroll",
+    "auto_scroll_follow",
     "worklog_details_expanded_default",
 }
 # Language codes are validated as short alphanumeric BCP-47-like tags (e.g. 'en', 'zh', 'fr')

--- a/static/boot.js
+++ b/static/boot.js
@@ -1815,6 +1815,7 @@ function applyBotName(){
     };
     window._busyInputMode=(s.busy_input_mode||'queue');
     window._sessionEndlessScrollEnabled=!!s.session_endless_scroll;
+    window._autoScrollFollow=!!s.auto_scroll_follow;
     window._botName=s.bot_name||'Hermes';
     if(s.default_model_provider) window._activeProvider=s.default_model_provider;
     if(s.default_model){
@@ -1909,6 +1910,7 @@ function applyBotName(){
     window._pinnedSessionsLimit=3;
     window._busyInputMode='queue';
     window._sessionEndlessScrollEnabled=false;
+    window._autoScrollFollow=false;
     window._botName='Hermes';
     _bootSettings={check_for_updates:false};
     if(typeof setLocale==='function'){

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -558,6 +558,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Load older messages while scrolling up',
 
     settings_desc_session_endless_scroll: 'When enabled, older messages load automatically as you scroll upward. When disabled, use the older-messages button.',
+    settings_label_auto_scroll_follow: 'Auto-follow new content',
+    settings_desc_auto_scroll_follow: 'When enabled, the view scrolls to the bottom as new tokens stream in. When disabled, you control the scroll position manually.',
     settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
     settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 
@@ -9402,6 +9404,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: '向上滚动时加载更早的消息',
 
     settings_desc_session_endless_scroll: '启用后，向上滚动时会自动加载更早的消息。禁用时请使用加载更早消息按钮。',
+    settings_label_auto_scroll_follow: '自动跟随新内容',
+    settings_desc_auto_scroll_follow: '启用后，流式输出时页面会自动滚动到底部。禁用后，你可以自由控制滚动位置，阅读答案不会被拽到底部。',
     settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
     settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 

--- a/static/index.html
+++ b/static/index.html
@@ -1006,6 +1006,13 @@
             </div>
             <div class="settings-field" style="margin-top:8px">
               <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+                <input type="checkbox" id="settingsAutoScrollFollow" style="width:15px;height:15px;accent-color:var(--accent)">
+                <span data-i18n="settings_label_auto_scroll_follow">Auto-follow new content</span>
+              </label>
+              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_auto_scroll_follow">When enabled, the view scrolls to the bottom as new tokens stream in. When disabled, you control the scroll position manually.</div>
+            </div>
+            <div class="settings-field" style="margin-top:8px">
+              <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
                 <input type="checkbox" id="settingsWorklogDetailsExpandedDefault" style="width:15px;height:15px;accent-color:var(--accent)">
                 <span data-i18n="settings_label_worklog_details_expanded_default">Open Worklog details automatically</span>
               </label>

--- a/static/messages.js
+++ b/static/messages.js
@@ -3299,7 +3299,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             _messageRenderWindowSize=Math.max(typeof _currentMessageRenderWindowSize==='function'?_currentMessageRenderWindowSize():50, _messageRenderableMessageCount());
           }
           syncTopbar();renderMessages({preserveScroll:true});
-          if(shouldFollowOnDone&&typeof scrollToBottom==='function') scrollToBottom();
+          if(shouldFollowOnDone&&typeof scrollToBottom==='function'&&typeof _isMessagePaneNearBottom==='function'&&_isMessagePaneNearBottom(250)) scrollToBottom();
           if(typeof noteWorkspaceMutationsFromToolCalls==='function') noteWorkspaceMutationsFromToolCalls(S.toolCalls);
           loadDir('.', { preservePreview: true });
           // TTS auto-read: speak the last assistant response if enabled (#499)

--- a/static/panels.js
+++ b/static/panels.js
@@ -6210,6 +6210,7 @@ function _appearancePayloadFromUi(){
     font_size: ($('settingsFontSize')||{}).value || localStorage.getItem('hermes-font-size') || 'default',
     session_jump_buttons: !!($('settingsSessionJumpButtons')||{}).checked,
     session_endless_scroll: !!($('settingsSessionEndlessScroll')||{}).checked,
+    auto_scroll_follow: !!($('settingsAutoScrollFollow')||{}).checked,
     worklog_details_expanded_default: worklogDetailsExpanded,
     activity_feed_expanded_default: worklogDetailsExpanded,
     hidden_tabs: _getHiddenTabs(),
@@ -6266,6 +6267,7 @@ async function _autosaveAppearanceSettings(payload){
       if(typeof _applySessionNavigationPrefs==='function') _applySessionNavigationPrefs();
     }
     window._sessionEndlessScrollEnabled=!!(saved&&saved.session_endless_scroll);
+    window._autoScrollFollow=!!(saved&&saved.auto_scroll_follow);
     if(saved&&payload&&Object.prototype.hasOwnProperty.call(payload,'worklog_details_expanded_default')&&(
       Object.prototype.hasOwnProperty.call(saved,'worklog_details_expanded_default') ||
       Object.prototype.hasOwnProperty.call(saved,'activity_feed_expanded_default')
@@ -6497,6 +6499,15 @@ async function loadSettingsPanel(){
       window._sessionEndlessScrollEnabled=endlessScrollCb.checked;
       endlessScrollCb.onchange=function(){
         window._sessionEndlessScrollEnabled=this.checked;
+        _scheduleAppearanceAutosave();
+      };
+    }
+    const autoScrollFollowCb=$('settingsAutoScrollFollow');
+    if(autoScrollFollowCb){
+      autoScrollFollowCb.checked=!!settings.auto_scroll_follow;
+      window._autoScrollFollow=autoScrollFollowCb.checked;
+      autoScrollFollowCb.onchange=function(){
+        window._autoScrollFollow=this.checked;
         _scheduleAppearanceAutosave();
       };
     }
@@ -7769,6 +7780,7 @@ function _applySavedSettingsUi(saved, body, opts){
   window._sidebarDensity=sidebarDensity==='detailed'?'detailed':'compact';
   window._busyInputMode=body.busy_input_mode||'queue';
   window._sessionEndlessScrollEnabled=!!body.session_endless_scroll;
+  window._autoScrollFollow=!!body.auto_scroll_follow;
   window._botName=body.bot_name||'Hermes';
   if(typeof applyBotName==='function') applyBotName();
   if(typeof setLocale==='function') setLocale(language);
@@ -8100,6 +8112,7 @@ async function saveSettings(andClose){
   body.font_size=fontSize;
   body.session_jump_buttons=!!($('settingsSessionJumpButtons')||{}).checked;
   body.session_endless_scroll=!!($('settingsSessionEndlessScroll')||{}).checked;
+  body.auto_scroll_follow=!!($('settingsAutoScrollFollow')||{}).checked;
   body.language=language;
   body.show_token_usage=showTokenUsage;
   body.show_quota_chip=showQuotaChip===true;

--- a/static/ui.js
+++ b/static/ui.js
@@ -3087,7 +3087,7 @@ function _shouldFollowMessagesOnDomReplace(){
   // following only for users who are still pinned or effectively at the tail.
   // A broad near-bottom window causes long answers/mobile readers who scroll up
   // a little to read mid-stream to get snapped back to the bottom on completion.
-  return !_messageUserUnpinned && (_scrollPinned || _isMessagePaneNearBottom(120));
+  return _autoScrollFollow && !_messageUserUnpinned && (_scrollPinned || _isMessagePaneNearBottom(120));
 }
 function _followMessagesAfterDomReplace(){
   if(_shouldFollowMessagesOnDomReplace()){
@@ -3119,6 +3119,7 @@ function _settleMessageScrollToBottom(force){
   });
 }
 function scrollIfPinned(){
+  if(!_autoScrollFollow) return;
   if(_messageUserUnpinned) return;
   if(!_scrollPinned) return;
   if(_recentNonMessageScrollIntent()) return;
@@ -7967,7 +7968,7 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
     // new-message cue. (Using scrollIfPinned() here instead would skip the forced
     // write unless distance>500 and let the DOM-rebuild scroll event cancel the
     // delayed settles — Codex CORE catch on #3631.)
-    if(_followMessagesAfterDomReplace()) return;
+    if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;
     _restoreMessageScrollSnapshot(scrollSnapshot);
     _maybeShowNewMessageScrollCue(scrollSnapshot);
     return;

--- a/tests/test_issue1690_scroll_completion.py
+++ b/tests/test_issue1690_scroll_completion.py
@@ -58,7 +58,7 @@ def test_render_messages_preserve_scroll_option_uses_user_pin_state_not_stream_l
     assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in render_body
     assert "const scrollSnapshot=preserveScroll?_captureMessageScrollSnapshot():null" in render_body
     assert "if(preserveScroll){\n    // Keep master's follow heuristic" in scroll_helper
-    assert "if(_followMessagesAfterDomReplace()) return;\n    _restoreMessageScrollSnapshot(scrollSnapshot);\n    _maybeShowNewMessageScrollCue(scrollSnapshot);\n    return;\n  }" in scroll_helper
+    assert "if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;\n    _restoreMessageScrollSnapshot(scrollSnapshot);\n    _maybeShowNewMessageScrollCue(scrollSnapshot);\n    return;\n  }" in scroll_helper
     assert "_shouldFollowMessagesOnDomReplace()" in follow_helper
     assert "scrollToBottom();" in follow_helper
     assert "if(S.activeStreamId){\n    scrollIfPinned();\n    return;\n  }" in scroll_helper

--- a/tests/test_issue3545_streaming_scroll_cue.py
+++ b/tests/test_issue3545_streaming_scroll_cue.py
@@ -34,7 +34,7 @@ def test_preserve_scroll_unpinned_branch_shows_new_message_cue_after_restore():
     # only the genuinely-scrolled-up cohort restores their viewport + gets the
     # new-message cue. (Codex CORE catch: scrollIfPinned() in the pinned branch
     # could leave a pinned reader short of the settled response.)
-    assert "if(_followMessagesAfterDomReplace()) return;" in helper
+    assert "if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;" in helper
     assert "_restoreMessageScrollSnapshot(scrollSnapshot);" in helper
     assert helper.index("_restoreMessageScrollSnapshot(scrollSnapshot)") < helper.index(
         "_maybeShowNewMessageScrollCue(scrollSnapshot)"

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -103,7 +103,7 @@ def test_preserve_scroll_restores_unpinned_viewport_after_dom_rebuild():
         "renderMessages({preserveScroll:true}) must capture #messages.scrollTop before "
         "replacing transcript DOM, then pass that snapshot to the post-render scroll helper"
     )
-    assert "if(_followMessagesAfterDomReplace()) return;" in after_render
+    assert "if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;" in after_render
     assert "_restoreMessageScrollSnapshot(scrollSnapshot);\n    _maybeShowNewMessageScrollCue(scrollSnapshot);" in after_render
     assert "_shouldFollowMessagesOnDomReplace()" in follow
     assert "scrollToBottom();" in follow


### PR DESCRIPTION
## Problem

After streaming completes, the viewport snaps to the bottom even when the user has scrolled up to read the answer. Two root causes:

1. **`_scrollAfterMessageRender` pin hysteresis** — When `preserveScroll=true` and `_scrollPinned=true` (re-set by the 250px near-bottom hysteresis counter), `_followMessagesAfterDomReplace()` forces `scrollToBottom()`, overriding the user's position. The `_messageUserUnpinned` flag is not checked.

2. **`_finishDone` unconditional `scrollToBottom()`** — The explicit `scrollToBottom()` fires when `shouldFollowOnDone` is true, but that flag uses a 120px near-bottom check. Users reading even slightly above that threshold get snapped to the bottom.

## Changes

### Bug fixes (2 lines)

**`static/ui.js` L7970** — Added `!_messageUserUnpinned` guard:
```diff
-if(_followMessagesAfterDomReplace()) return;
+if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;
```
When the user explicitly scrolled up, skip forced follow and restore their scroll snapshot instead.

**`static/messages.js` L3302** — Added `_isMessagePaneNearBottom(250)` gate:
```diff
-if(shouldFollowOnDone&&typeof scrollToBottom==='function') scrollToBottom();
+if(shouldFollowOnDone&&typeof scrollToBottom==='function'&&typeof _isMessagePaneNearBottom==='function'&&_isMessagePaneNearBottom(250)) scrollToBottom();
```
Only call explicit `scrollToBottom()` if the user is within 250px of the bottom.

### New setting: `auto_scroll_follow` (7-file pattern)

A new `auto_scroll_follow` boolean setting (default: **off**) that gates `scrollIfPinned()` and `_shouldFollowMessagesOnDomReplace()`. When disabled, the viewport never auto-scrolls during streaming — the user controls scroll position manually and uses the ↓ button to jump to bottom.

| File | Change |
|------|--------|
| `api/config.py` | `_SETTINGS_DEFAULTS` + `_SETTINGS_BOOL_KEYS` |
| `static/boot.js` | Both init paths (normal + error fallback) |
| `static/ui.js` | `scrollIfPinned()` early return + `_shouldFollowMessagesOnDomReplace()` guard |
| `static/index.html` | Checkbox in appearance settings section |
| `static/i18n.js` | English + Chinese (zh-CN) translations |
| `static/panels.js` | Payload, autosave init, populate, full save |

### Tests

Updated 3 test files to match the new `_scrollAfterMessageRender` guard. All 116 scroll-related tests pass.

## Testing

- Verified on macOS Safari: scroll up during streaming → no snap-back on completion
- Setting toggle works: off = manual scroll, on = legacy auto-follow
- Scroll-to-bottom (↓) button still works regardless of setting
