### PR TITLE
fix(#4003): open clicked lineage segments without sid rewrite

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -5284,7 +5284,7 @@ function renderSessionListFromCache(){
             try{await api('/api/session/import_cli',{method:'POST',body:JSON.stringify({session_id:seg.session_id})});}
             catch(_e){ /* read-only fallback */ }
           }
-          await loadSession(seg.session_id);
+          await loadSession(seg.session_id, {skipLineageResolve:true});
           renderSessionListFromCache();
         };
         lineageList.appendChild(row);
@@ -5311,7 +5311,7 @@ function renderSessionListFromCache(){
             try{await api('/api/session/import_cli',{method:'POST',body:JSON.stringify({session_id:child.session_id})});}
             catch(_e){ /* read-only fallback */ }
           }
-          await loadSession(child.session_id);
+          await loadSession(child.session_id, {skipLineageResolve:true});
           renderSessionListFromCache();
         };
         childList.appendChild(row);

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -481,7 +481,9 @@ def test_lineage_segment_expansion_static_contract():
     assert "className='session-lineage-segment'" in js
     assert "const segTitle=_sessionDisplayTitle(seg)||t('session_lineage_segment_untitled');" in js
     assert "row.title=t('session_lineage_segment_open');" in js
-    assert "await loadSession(seg.session_id);" in js
+    assert "await loadSession(seg.session_id, {skipLineageResolve:true});" in js
+    assert "await loadSession(child.session_id, {skipLineageResolve:true});" in js
+    assert "if(!opts.skipLineageResolve && typeof _resolveSessionIdFromSidebarLineage==='function'){" in js
     assert ".session-lineage-count.expandable{" in css
     assert ".session-lineage-count.expandable:hover" in css
     assert ".session-lineage-segments{" in css


### PR DESCRIPTION

## Thinking Path

- The bug is not in the sidebar toggle itself, it is in the explicit row-open path: expanded lineage and child rows call `loadSession()` as if they were stale collapsed ids.
- `loadSession()` already has the exact escape hatch this path needs, `{skipLineageResolve:true}`, and `origin/master` uses it elsewhere for exact-session restore.
- The narrow fix is to adopt that opt-out only on the explicit expanded-member buttons, leaving collapsed-row repair and the separate streaming-refresh bug in #4005 untouched.

## What Changed

- `static/sessions.js`: pass `{skipLineageResolve:true}` when the user clicks an expanded lineage segment or expanded child-session row, while preserving the existing external-session import gate.
- `tests/test_session_lineage_collapse.py`: add source-level regression coverage that the expanded-member buttons use the opt-out and that `loadSession()` still defaults to resolver-on.

## Why It Matters

Users can finally open the exact fork or child session they clicked instead of being snapped back to the active lineage representative. The diff stays small and isolated, which matters because the same sidebar surface already has separate refresh work in #4005 and an unrelated open renderer PR in #3601.

## Verification

```cmd
cmd /c npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs static/sessions.js
pytest tests/test_session_lineage_collapse.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- This intentionally does not change `_resolveSessionIdFromSidebarLineage()` ranking or collapsed-row behavior; those paths still need the default resolver.
- Issue #4005 tracks the separate refresh/cache collapse symptom on the same sidebar lineage surface and should stay a separate PR.
- Open PR #3601 touches nearby renderer code, so this fix should avoid opportunistic refactors to keep rebase risk low.
- Adversarial review noted similar exact-navigation call sites in session links and background-error navigation. They are outside the reported expanded lineage/child row click path and should be handled as a follow-up if maintainers want the resolver opt-out generalized.

## Model Used

GPT 5.5 via Codex CLI
