### PR TITLE
fix(#3968): autocomplete skill names for /use

### DIFF
--- a/static/commands.js
+++ b/static/commands.js
@@ -100,6 +100,8 @@ let _slashModelCache=null;
 let _slashModelCachePromise=null;
 let _slashPersonalityCache=null;
 let _slashPersonalityCachePromise=null;
+let _slashSkillCache=null;
+let _slashSkillCachePromise=null;
 let _agentCommandCache=null;
 let _agentCommandCachePromise=null;
 
@@ -117,6 +119,7 @@ function _invalidateSlashModelCache(){
 // define a window global — see tests/test_cli_only_slash_commands.py.
 if(typeof window!=='undefined'){
   window._invalidateSlashModelCache=_invalidateSlashModelCache;
+  window.invalidateSlashSkillCaches=invalidateSlashSkillCaches;
 }
 
 function _normalizeSlashSubArg(value){
@@ -198,10 +201,43 @@ async function _loadSlashPersonalitySubArgs(force=false){
   return _slashPersonalityCachePromise;
 }
 
+async function _loadSlashSkillSubArgs(force=false){
+  if(_slashSkillCache&&!force) return _slashSkillCache;
+  if(_slashSkillCachePromise&&!force) return _slashSkillCachePromise;
+  _slashSkillCachePromise=(async()=>{
+    try{
+      const data=await api('/api/skills');
+      const values=[];
+      for(const skill of (data&&data.skills)||[]){
+        const name=_normalizeSlashSubArg(skill&&skill.name);
+        if(name) values.push(name);
+      }
+      const deduped=Array.from(new Set(values)).sort((a,b)=>a.localeCompare(b));
+      _slashSkillCache=deduped;
+      return deduped;
+    }catch(_){
+      _slashSkillCache=null;
+      return [];
+    }finally{
+      _slashSkillCachePromise=null;
+    }
+  })();
+  return _slashSkillCachePromise;
+}
+
+function invalidateSlashSkillCaches(){
+  _slashSkillCache=null;
+  _slashSkillCachePromise=null;
+  _skillCommandCache=[];
+  _skillCommandCacheReady=false;
+  _skillCommandLoadPromise=null;
+}
+
 function _getSlashSubArgOptions(spec){
   if(Array.isArray(spec)) return Promise.resolve(spec.slice());
   if(spec==='models') return _loadSlashModelSubArgs();
   if(spec==='personalities') return _loadSlashPersonalitySubArgs();
+  if(spec==='skills') return _loadSlashSkillSubArgs();
   return Promise.resolve([]);
 }
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -3860,6 +3860,7 @@ async function toggleSkill(name, currentlyEnabled) {
         const skill = _skillsData.find(s => s.name === name);
         if (skill) skill.disabled = !newEnabled;
       }
+      if(typeof window!=='undefined'&&typeof window.invalidateSlashSkillCaches==='function') window.invalidateSlashSkillCaches();
       renderSkills(_skillsData || []);
     } else {
       setStatus((result && result.error) || t('skill_toggle_failed'));
@@ -4114,6 +4115,7 @@ async function saveSkillForm() {
     showToast(_editingSkillName ? t('skill_updated') : t('skill_created'));
     _skillsData = null;
     _cronSkillsCache = null;
+    if(typeof window!=='undefined'&&typeof window.invalidateSlashSkillCaches==='function') window.invalidateSlashSkillCaches();
     _editingSkillName = null;
     _skillPreFormDetail = null;
     await loadSkills();
@@ -4153,6 +4155,7 @@ async function deleteCurrentSkill() {
     _skillPreFormDetail = null;
     _skillsData = null;
     _cronSkillsCache = null;
+    if(typeof window!=='undefined'&&typeof window.invalidateSlashSkillCaches==='function') window.invalidateSlashSkillCaches();
     _skillMode = 'empty';
     const body = $('skillDetailBody');
     const empty = $('skillDetailEmpty');

--- a/tests/test_sprint47.py
+++ b/tests/test_sprint47.py
@@ -13,13 +13,43 @@ import pathlib
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 COMMANDS_JS = (REPO_ROOT / "static" / "commands.js").read_text(encoding="utf-8")
 BOOT_JS = (REPO_ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _function_body(source, name):
+    marker = f"function {name}("
+    start = source.find(marker)
+    assert start != -1, f"{name} function not found"
+    next_function = source.find("\nfunction ", start + len(marker))
+    next_async_function = source.find("\nasync function ", start + len(marker))
+    ends = [pos for pos in (next_function, next_async_function) if pos != -1]
+    end = min(ends) if ends else len(source)
+    return source[start:end]
 
 
 def test_skill_commands_are_loaded_from_api_skills_for_autocomplete():
     assert "loadSkillCommands" in COMMANDS_JS
     assert "api('/api/skills')" in COMMANDS_JS
     assert "source:'skill'" in COMMANDS_JS
+
+
+def test_use_command_declares_skills_subargs():
+    assert "{name:'use'" in COMMANDS_JS
+    assert "subArgs:'skills'" in COMMANDS_JS
+
+
+def test_skills_subargs_route_through_dedicated_loader():
+    assert "async function _loadSlashSkillSubArgs(force=false)" in COMMANDS_JS
+    assert "if(spec==='skills') return _loadSlashSkillSubArgs();" in COMMANDS_JS
+    assert "if(spec==='skills') return loadSkillCommands();" not in COMMANDS_JS
+
+
+def test_skill_mutations_invalidate_slash_skill_caches():
+    assert "function invalidateSlashSkillCaches()" in COMMANDS_JS
+    assert "window.invalidateSlashSkillCaches=invalidateSlashSkillCaches;" in COMMANDS_JS
+    for function_name in ("saveSkillForm", "deleteCurrentSkill", "toggleSkill"):
+        assert "window.invalidateSlashSkillCaches()" in _function_body(PANELS_JS, function_name)
 
 
 def test_builtin_commands_take_precedence_over_skill_slug_collisions():


### PR DESCRIPTION

## Thinking Path

- `/use` is already declared as a sub-argument command in `static/commands.js:20`, so the missing UX is not an API gap; it is a routing hole between `subArgs:'skills'` and `_getSlashSubArgOptions()` at `static/commands.js:201-205`.
- The repo already loads `/api/skills` for top-level `/skill-name` autocomplete via `loadSkillCommands()`, but `/use` needs a plain list of subarg strings, not full command objects with badges and collision metadata.
- Keep this PR frontend-only and narrowly scoped to the missing `skills` branch so it does not overlap the separate caret-aware autocomplete work already under review in PR `#3965` for issue `#3924`.

## What Changed

- `static/commands.js`: add a cached `/api/skills` subarg loader, then route `spec==='skills'` through it inside `_getSlashSubArgOptions()`.
- `static/panels.js`: invalidate the slash skill caches after successful skill save, delete, or toggle actions so `/use` suggestions update without a page reload.
- `tests/test_sprint47.py`: pin the `/use` + `skills` wiring and the mutation invalidation hook so future slash-autocomplete refactors cannot silently drop this subarg source again.

## Why It Matters

Typing `/use <prefix>` will finally behave like `/model` and `/personality`, so users can discover available skills instead of memorizing exact names. Keeping the patch narrow also avoids entangling this fix with the separate multi-slash and CJK-prefix tokenizer changes already being reviewed upstream.

## Verification

- `pytest tests/test_sprint47.py -v --timeout=60`
- `cmd /c npm run lint:runtime`

Local note: `tests/test_static_js_runtime_lint.py` was also run after installing local ESLint, but its Windows subprocess wrapper tried to execute `node_modules\.bin\eslint` directly and failed with `WinError 193`. The direct runtime lint command above passed.

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- This intentionally does not change caret-aware slash parsing, insertion semantics, or send-time multi-skill loading; those belong to issue `#3924` and open PR `#3965`.
- If `/api/skills` ever starts returning aliases distinct from canonical names, the new subarg loader should mirror that contract explicitly instead of assuming the current `name` field is the desired `/use` token.

## Model Used

GPT 5.5 via Codex CLI
