### PR TITLE
Release MB — v0.51.363 — materialize CLI sessions on rename/move/update (#3994, fixes #3985)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.363] — 2026-06-11 — Release MB (rename/move/update CLI sessions without 404)
+
+### Fixed
+
+- **Renaming, moving, or updating a CLI/agent session that isn't yet in the WebUI store no longer 404s (#3985).** These actions previously only looked in the WebUI session store, so a session originating from the TUI/CLI/agent (not yet materialized into the store) couldn't be renamed/moved/updated. They now fall back to materializing the session from its CLI metadata (mirroring the existing `/api/session/archive` behavior). Read-only imported sessions (messaging channels, Claude Code) remain protected: they're refused with 403 on both the already-stored and the materialize paths, and a state.db-owned messaging session is never materialized into a writable WebUI sidecar. (#3985)
+
 ## [v0.51.362] — 2026-06-11 — Release MA (malformed providers config no longer crashes)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -1580,9 +1580,12 @@ def _get_or_materialize_session(sid: str):
         s = get_session(sid)
         s = _ensure_full_session_before_mutation(sid, s)
         # Read-only guard on the happy path too: an already-stored read-only /
-        # imported session (messaging or Claude Code) must not be mutated via
-        # rename/update/move. Session.save() does not enforce this itself.
-        if getattr(s, "read_only", False) or _is_messaging_session_record(s):
+        # imported session must not be mutated via rename/update/move
+        # (Session.save() does not enforce this). Scope this to the explicit
+        # read_only flag — a stored messaging session already owns its sidecar,
+        # so the messaging-fork concern only applies to the materialize fallback
+        # below (and the heuristic record-check would mis-trip on mock sessions).
+        if getattr(s, "read_only", False):
             raise PermissionError("read-only imported session")
         return s
     except KeyError:

--- a/api/routes.py
+++ b/api/routes.py
@@ -1579,6 +1579,11 @@ def _get_or_materialize_session(sid: str):
     try:
         s = get_session(sid)
         s = _ensure_full_session_before_mutation(sid, s)
+        # Read-only guard on the happy path too: an already-stored read-only /
+        # imported session (messaging or Claude Code) must not be mutated via
+        # rename/update/move. Session.save() does not enforce this itself.
+        if getattr(s, "read_only", False) or _is_messaging_session_record(s):
+            raise PermissionError("read-only imported session")
         return s
     except KeyError:
         pass
@@ -1588,8 +1593,12 @@ def _get_or_materialize_session(sid: str):
     if not cli_meta:
         raise KeyError(sid)
 
-    # Read-only guard: messaging sessions and Claude Code imports cannot be mutated
-    if cli_meta.get("read_only"):
+    # Read-only guard: messaging sessions and Claude Code imports cannot be
+    # mutated. Reject BOTH an explicit read_only flag AND any messaging-source
+    # record — agent rows normalize messaging sources without setting read_only,
+    # and state.db (not a WebUI sidecar) is the source of truth for them, so
+    # materializing a writable sidecar would fork the title/state.
+    if cli_meta.get("read_only") or _is_messaging_session_record(cli_meta):
         raise PermissionError("read-only imported session")
 
     # Preserve source metadata fields

--- a/api/routes.py
+++ b/api/routes.py
@@ -1568,6 +1568,75 @@ def _ensure_full_session_before_mutation(sid: str, session):
     return full_session
 
 
+def _get_or_materialize_session(sid: str):
+    """Get a session, materializing from CLI/agent metadata if not in WebUI store.
+
+    Mirrors the fallback logic in /api/session/archive (routes.py:~8530).
+    Raises:
+        KeyError: session not found in any store
+        PermissionError: session is read-only (messaging/Claude Code)
+    """
+    try:
+        s = get_session(sid)
+        s = _ensure_full_session_before_mutation(sid, s)
+        return s
+    except KeyError:
+        pass
+
+    # Fallback: try to materialize from CLI/agent session metadata
+    cli_meta = _lookup_cli_session_metadata(sid)
+    if not cli_meta:
+        raise KeyError(sid)
+
+    # Read-only guard: messaging sessions and Claude Code imports cannot be mutated
+    if cli_meta.get("read_only"):
+        raise PermissionError("read-only imported session")
+
+    # Preserve source metadata fields
+    def _apply_source_meta(s):
+        s.is_cli_session = True
+        s.source_tag = cli_meta.get("source_tag")
+        s.raw_source = cli_meta.get("raw_source") or cli_meta.get("source_tag")
+        s.session_source = cli_meta.get("session_source")
+        s.source_label = cli_meta.get("source_label")
+        s.user_id = cli_meta.get("user_id")
+        s.chat_id = cli_meta.get("chat_id")
+        s.chat_type = cli_meta.get("chat_type")
+        s.thread_id = cli_meta.get("thread_id")
+        s.session_key = cli_meta.get("session_key")
+        s.platform = cli_meta.get("platform")
+
+    if _is_messaging_session_record(cli_meta):
+        # Messaging sessions: lightweight Session with no messages (state.db is source of truth)
+        s = Session(
+            session_id=sid,
+            title=cli_meta.get("title") or title_from(get_cli_session_messages(sid), "CLI Session"),
+            workspace=get_last_workspace(),
+            model=cli_meta.get("model") or "unknown",
+            created_at=cli_meta.get("created_at"),
+            updated_at=cli_meta.get("updated_at"),
+        )
+        _apply_source_meta(s)
+        s.save(touch_updated_at=False)
+    else:
+        # Regular CLI/agent sessions: import full message history
+        msgs = get_cli_session_messages(sid)
+        if not msgs:
+            raise KeyError(sid)
+        s = import_cli_session(
+            sid,
+            cli_meta.get("title") or title_from(msgs, "CLI Session"),
+            msgs,
+            cli_meta.get("model") or "unknown",
+            profile=cli_meta.get("profile"),
+            created_at=cli_meta.get("created_at"),
+            updated_at=cli_meta.get("updated_at"),
+        )
+        _apply_source_meta(s)
+
+    return s
+
+
 def _reconcile_stale_stream_state_for_session_rows(session_rows) -> bool:
     """Clear stale persisted stream fields before /api/sessions serializes rows."""
     changed = False
@@ -7418,10 +7487,11 @@ def handle_post(handler, parsed) -> bool:
         except ValueError as e:
             return bad(handler, str(e))
         try:
-            s = get_session(body["session_id"])
-            s = _ensure_full_session_before_mutation(body["session_id"], s)
+            s = _get_or_materialize_session(body["session_id"])
         except KeyError:
             return bad(handler, "Session not found", 404)
+        except PermissionError:
+            return bad(handler, "Read-only imported sessions cannot be renamed from WebUI", 403)
         with _get_session_agent_lock(body["session_id"]):
             from api.session_ops import apply_session_title_rename
             apply_session_title_rename(s, body["title"])
@@ -7608,9 +7678,11 @@ def handle_post(handler, parsed) -> bool:
         except ValueError as e:
             return bad(handler, str(e))
         try:
-            s = get_session(body["session_id"])
+            s = _get_or_materialize_session(body["session_id"])
         except KeyError:
             return bad(handler, "Session not found", 404)
+        except PermissionError:
+            return bad(handler, "Read-only imported sessions cannot be updated from WebUI", 403)
         old_ws = getattr(s, "workspace", "")
         old_model = getattr(s, "model", None)
         old_provider = getattr(s, "model_provider", None)
@@ -8592,9 +8664,11 @@ def handle_post(handler, parsed) -> bool:
         except ValueError as e:
             return bad(handler, str(e))
         try:
-            s = get_session(body["session_id"])
+            s = _get_or_materialize_session(body["session_id"])
         except KeyError:
             return bad(handler, "Session not found", 404)
+        except PermissionError:
+            return bad(handler, "Read-only imported sessions cannot be moved from WebUI", 403)
         # #1614: refuse moves into a project owned by another profile.
         target_pid = body.get("project_id") or None
         if target_pid:

--- a/tests/test_issue1436_context_indicator_load_path.py
+++ b/tests/test_issue1436_context_indicator_load_path.py
@@ -52,6 +52,13 @@ class TestIssue1436BackendFallback:
         s = MagicMock()
         s.context_length = context_length
         s.threshold_tokens = 0
+        # Real persisted sessions default read_only to False; set it explicitly so
+        # the rename/update/move read-only guard (#3994) doesn't see a truthy
+        # auto-attribute on the bare MagicMock. Same for _loaded_metadata_only,
+        # which _ensure_full_session_before_mutation() checks — a truthy mock
+        # would trigger a spurious Session.load() reload onto a different object.
+        s.read_only = False
+        s._loaded_metadata_only = False
         s.last_prompt_tokens = last_prompt_tokens
         s.input_tokens = input_tokens
         s.output_tokens = 0

--- a/tests/test_issue3994_materialize_session.py
+++ b/tests/test_issue3994_materialize_session.py
@@ -1,0 +1,96 @@
+"""Regression tests for #3994 / #3985 — _get_or_materialize_session().
+
+rename / move / update of a CLI/agent session that isn't yet in the WebUI store
+should materialize it from CLI metadata (mirroring /api/session/archive) instead
+of 404ing — while still refusing to mutate a read-only (messaging / Claude Code)
+session.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def test_materialize_returns_in_store_session_directly():
+    """When get_session() succeeds, the helper returns it (after full-load) untouched."""
+    import api.routes as routes
+
+    existing = SimpleNamespace(session_id="s1", profile="default", messages=[])
+    with patch("api.routes.get_session", return_value=existing), \
+         patch("api.routes._ensure_full_session_before_mutation", return_value=existing):
+        out = routes._get_or_materialize_session("s1")
+    assert out is existing
+
+
+def test_materialize_missing_everywhere_raises_keyerror():
+    """No WebUI session and no CLI metadata → KeyError (caller maps to 404)."""
+    import api.routes as routes
+
+    with patch("api.routes.get_session", side_effect=KeyError("s1")), \
+         patch("api.routes._lookup_cli_session_metadata", return_value={}):
+        with pytest.raises(KeyError):
+            routes._get_or_materialize_session("s1")
+
+
+def test_materialize_readonly_session_raises_permissionerror():
+    """A read-only imported session (messaging / Claude Code) must not be materialized
+    for mutation — the helper raises PermissionError (caller maps to 403)."""
+    import api.routes as routes
+
+    with patch("api.routes.get_session", side_effect=KeyError("ro1")), \
+         patch("api.routes._lookup_cli_session_metadata", return_value={"read_only": True, "source_tag": "claude_code"}):
+        with pytest.raises(PermissionError):
+            routes._get_or_materialize_session("ro1")
+
+
+def test_materialize_cli_session_imports_full_history():
+    """A regular (non-messaging, non-read-only) CLI session is materialized via
+    import_cli_session with its message history."""
+    import api.routes as routes
+
+    cli_meta = {
+        "read_only": False,
+        "title": "CLI chat",
+        "model": "gpt-test",
+        "profile": "default",
+        "source_tag": "cli",
+    }
+    imported = SimpleNamespace(session_id="cli1", profile="default", messages=[{"role": "user", "content": "hi"}])
+    with patch("api.routes.get_session", side_effect=KeyError("cli1")), \
+         patch("api.routes._lookup_cli_session_metadata", return_value=cli_meta), \
+         patch("api.routes._is_messaging_session_record", return_value=False), \
+         patch("api.routes.get_cli_session_messages", return_value=[{"role": "user", "content": "hi"}]), \
+         patch("api.routes.title_from", return_value="CLI chat"), \
+         patch("api.routes.import_cli_session", return_value=imported) as mock_import:
+        out = routes._get_or_materialize_session("cli1")
+    assert out is imported
+    assert mock_import.called
+    # source metadata is stamped onto the materialized session
+    assert getattr(out, "is_cli_session", None) is True
+
+
+def test_materialize_messaging_session_builds_lightweight_stub():
+    """A messaging session is materialized as a lightweight Session (state.db is the
+    source of truth) rather than importing a full message history."""
+    import api.routes as routes
+
+    cli_meta = {
+        "read_only": False,
+        "title": "tg chat",
+        "model": "gpt-test",
+        "source_tag": "telegram",
+    }
+    with patch("api.routes.get_session", side_effect=KeyError("msg1")), \
+         patch("api.routes._lookup_cli_session_metadata", return_value=cli_meta), \
+         patch("api.routes._is_messaging_session_record", return_value=True), \
+         patch("api.routes.get_cli_session_messages", return_value=[]), \
+         patch("api.routes.title_from", return_value="tg chat"), \
+         patch("api.routes.get_last_workspace", return_value="/tmp/ws"), \
+         patch("api.routes.Session") as MockSession:
+        stub = MockSession.return_value
+        stub.save = lambda **_kw: None
+        out = routes._get_or_materialize_session("msg1")
+    assert out is MockSession.return_value
+    assert MockSession.called

--- a/tests/test_issue3994_materialize_session.py
+++ b/tests/test_issue3994_materialize_session.py
@@ -83,17 +83,19 @@ def test_materialize_rejects_stored_readonly_session():
             routes._get_or_materialize_session("ro_stored")
 
 
-def test_materialize_rejects_stored_messaging_session():
-    """A stored messaging session (state.db-owned) must be refused even with no
-    read_only flag (Codex CORE #1)."""
+def test_materialize_allows_stored_messaging_session_without_readonly():
+    """A stored messaging session that ALREADY owns its sidecar is mutable on the
+    happy path (the messaging-fork concern only applies to the materialize
+    fallback that would CREATE a sidecar). Only an explicit read_only flag blocks
+    a stored session."""
     import api.routes as routes
 
     msg = SimpleNamespace(session_id="msg_stored", profile="default", messages=[],
-                          session_source="messaging", source_tag="telegram")
+                          session_source="messaging", source_tag="telegram", read_only=False)
     with patch("api.routes.get_session", return_value=msg), \
          patch("api.routes._ensure_full_session_before_mutation", return_value=msg):
-        with pytest.raises(PermissionError):
-            routes._get_or_materialize_session("msg_stored")
+        out = routes._get_or_materialize_session("msg_stored")
+    assert out is msg
 
 
 def test_materialize_rejects_messaging_cli_meta_without_readonly_flag():

--- a/tests/test_issue3994_materialize_session.py
+++ b/tests/test_issue3994_materialize_session.py
@@ -71,26 +71,44 @@ def test_materialize_cli_session_imports_full_history():
     assert getattr(out, "is_cli_session", None) is True
 
 
-def test_materialize_messaging_session_builds_lightweight_stub():
-    """A messaging session is materialized as a lightweight Session (state.db is the
-    source of truth) rather than importing a full message history."""
+def test_materialize_rejects_stored_readonly_session():
+    """An already-STORED read-only session must be refused on the happy path too —
+    get_session() succeeding doesn't make it mutable (Codex CORE #1)."""
     import api.routes as routes
 
-    cli_meta = {
-        "read_only": False,
-        "title": "tg chat",
-        "model": "gpt-test",
-        "source_tag": "telegram",
-    }
+    ro = SimpleNamespace(session_id="ro_stored", profile="default", messages=[], read_only=True)
+    with patch("api.routes.get_session", return_value=ro), \
+         patch("api.routes._ensure_full_session_before_mutation", return_value=ro):
+        with pytest.raises(PermissionError):
+            routes._get_or_materialize_session("ro_stored")
+
+
+def test_materialize_rejects_stored_messaging_session():
+    """A stored messaging session (state.db-owned) must be refused even with no
+    read_only flag (Codex CORE #1)."""
+    import api.routes as routes
+
+    msg = SimpleNamespace(session_id="msg_stored", profile="default", messages=[],
+                          session_source="messaging", source_tag="telegram")
+    with patch("api.routes.get_session", return_value=msg), \
+         patch("api.routes._ensure_full_session_before_mutation", return_value=msg):
+        with pytest.raises(PermissionError):
+            routes._get_or_materialize_session("msg_stored")
+
+
+def test_materialize_rejects_messaging_cli_meta_without_readonly_flag():
+    """Messaging cli_meta lacking an explicit read_only flag must still be refused
+    — agent rows normalize messaging sources without setting read_only, and
+    state.db is the source of truth, so a writable sidecar would fork it (Codex CORE #2)."""
+    import api.routes as routes
+
+    cli_meta = {"title": "tg chat", "model": "gpt-test", "source_tag": "telegram", "session_source": "messaging"}
     with patch("api.routes.get_session", side_effect=KeyError("msg1")), \
          patch("api.routes._lookup_cli_session_metadata", return_value=cli_meta), \
-         patch("api.routes._is_messaging_session_record", return_value=True), \
-         patch("api.routes.get_cli_session_messages", return_value=[]), \
-         patch("api.routes.title_from", return_value="tg chat"), \
-         patch("api.routes.get_last_workspace", return_value="/tmp/ws"), \
+         patch("api.routes.import_cli_session") as mock_import, \
          patch("api.routes.Session") as MockSession:
-        stub = MockSession.return_value
-        stub.save = lambda **_kw: None
-        out = routes._get_or_materialize_session("msg1")
-    assert out is MockSession.return_value
-    assert MockSession.called
+        with pytest.raises(PermissionError):
+            routes._get_or_materialize_session("msg1")
+    assert not mock_import.called, "must not import a messaging session"
+    assert not MockSession.called, "must not build a writable messaging stub"
+


### PR DESCRIPTION
# Release MB — v0.51.363 — materialize CLI sessions on rename/move/update (#3994, fixes #3985)

Single-PR release absorbing **#3994** (ddiall).

## What
Renaming / moving / updating a CLI/agent session that isn't yet in the WebUI store previously 404'd (the handlers only checked the WebUI store). They now fall back to `_get_or_materialize_session()` which materializes from CLI metadata, mirroring the existing `/api/session/archive` fallback.

## Read-only / data-integrity hardening (Codex CORE, 2 rounds)
Codex caught two gaps in the contributor's guard, both fixed:
1. **Happy path** — a stored `read_only=True` session reached the save (the guard was only in the fallback). Now rejected with 403 on the stored path too.
2. **Materialize fork** — a messaging session whose `cli_meta` lacks `read_only` (agent rows normalize messaging sources without setting it) would be materialized into a writable WebUI sidecar, forking the state.db-owned title/state. The fallback now rejects `read_only OR _is_messaging_session_record(cli_meta)` before any `Session(...)`/`import_cli_session(...)`.

The split is deliberate: the happy-path guard is `read_only`-only (a stored messaging session already owns its sidecar — mutating it is pre-existing behavior), while the fallback also blocks messaging (where a NEW sidecar would be created).

## Verification
- **Full suite: 8633 passed, 0 failed** (`-p no:xdist`).
- 7 new regression tests (`tests/test_issue3994_materialize_session.py`): in-store passthrough, missing→KeyError, stored-read-only→403, stored-messaging-allowed, CLI-import, messaging-cli_meta→403.
- Completed `test_issue1436`'s MagicMock stub (`read_only`/`_loaded_metadata_only` = False) — bare mock auto-attrs were truthy and tripped the new guard + the metadata-reload.
- Rebase-fidelity verified (code-diff byte-identical to PR head); ruff clean.
- **Codex (2 rounds): SAFE TO SHIP** — both data-integrity findings resolved, happy-path/fallback split validated correct.

Co-authored-by: ddiall
