### PR TITLE
fix(#3983): re-arm browser voice mode when speechSynthesis drops onend

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -853,7 +853,44 @@ window._micPendingSend=window._micPendingSend||false;
   // a different session's last assistant reply if the user navigated away
   // between send and stream completion. (Opus pre-release advisor.)
   let _voiceModeThinkingSid=null;
+  let _browserTtsKeepAlive=null;
+  let _browserTtsWatchdog=null;
   const SILENCE_MS=1800; // auto-send after 1.8s silence
+
+  function _clearBrowserTtsRecovery(){
+    if(_browserTtsKeepAlive){
+      clearInterval(_browserTtsKeepAlive);
+      _browserTtsKeepAlive=null;
+    }
+    if(_browserTtsWatchdog){
+      clearTimeout(_browserTtsWatchdog);
+      _browserTtsWatchdog=null;
+    }
+  }
+
+  function _armBrowserTtsRecovery(clean, rate){
+    _clearBrowserTtsRecovery();
+    const safeRate=(Number.isFinite(rate)&&rate>0)?rate:1;
+    // Chromium can drop utter.onend on later turns, so force a recovery path.
+    const watchdogMs=Math.max(4000,Math.round((String(clean||'').length/(12*safeRate))*1000)+10000);
+    _browserTtsWatchdog=setTimeout(()=>{
+      if(!_voiceModeActive||_voiceModeState!=='speaking') return;
+      try{ speechSynthesis.cancel(); }catch(_){}
+      _clearBrowserTtsRecovery();
+      _startListening();
+    },watchdogMs);
+    _browserTtsKeepAlive=setInterval(()=>{
+      if(!_voiceModeActive||_voiceModeState!=='speaking'){
+        _clearBrowserTtsRecovery();
+        return;
+      }
+      if(!speechSynthesis.speaking) return;
+      try{
+        speechSynthesis.pause();
+        speechSynthesis.resume();
+      }catch(_){}
+    },10000);
+  }
 
   function _setState(state){
     _voiceModeState=state;
@@ -867,6 +904,7 @@ window._micPendingSend=window._micPendingSend||false;
 
   function _startListening(){
     if(!_voiceModeActive) return;
+    _clearBrowserTtsRecovery();
     _setState('listening');
 
     _recognition=new SpeechRecognition();
@@ -1057,14 +1095,22 @@ window._micPendingSend=window._micPendingSend||false;
     if(!isNaN(savedPitch)) utter.pitch=Math.min(2,Math.max(0,savedPitch));
 
     utter.onend=()=>{
+      _clearBrowserTtsRecovery();
       // After speaking, go back to listening
       if(_voiceModeActive) setTimeout(()=>_startListening(),500);
     };
     utter.onerror=()=>{
+      _clearBrowserTtsRecovery();
       if(_voiceModeActive) setTimeout(()=>_startListening(),1000);
     };
 
-    speechSynthesis.speak(utter);
+    _armBrowserTtsRecovery(clean, utter.rate);
+    try{
+      speechSynthesis.speak(utter);
+    }catch(_){
+      _clearBrowserTtsRecovery();
+      if(_voiceModeActive) setTimeout(()=>_startListening(),1000);
+    }
   }
 
   // Hook into response completion — observe when the agent finishes
@@ -1125,6 +1171,7 @@ window._micPendingSend=window._micPendingSend||false;
     _setButtonTooltip(modeBtn, t('voice_mode_toggle'));
     bar.style.display='none';
     clearTimeout(_silenceTimer);
+    _clearBrowserTtsRecovery();
     try{ if(_recognition) _recognition.abort(); }catch(_){}
     _recognition=null;
     if(typeof stopTTS==='function') stopTTS();

--- a/static/boot.js
+++ b/static/boot.js
@@ -1101,7 +1101,7 @@ window._micPendingSend=window._micPendingSend||false;
       _browserTtsSuppressNextErrorRearm=false;
       _clearBrowserTtsRecovery();
       // After speaking, go back to listening
-      if(_voiceModeActive) setTimeout(()=>_startListening(),500);
+      if(_voiceModeActive&&_voiceModeState==='speaking') setTimeout(()=>_startListening(),500);
     };
     utter.onerror=()=>{
       _clearBrowserTtsRecovery();

--- a/static/boot.js
+++ b/static/boot.js
@@ -855,6 +855,7 @@ window._micPendingSend=window._micPendingSend||false;
   let _voiceModeThinkingSid=null;
   let _browserTtsKeepAlive=null;
   let _browserTtsWatchdog=null;
+  let _browserTtsSuppressNextErrorRearm=false;
   const SILENCE_MS=1800; // auto-send after 1.8s silence
 
   function _clearBrowserTtsRecovery(){
@@ -870,11 +871,13 @@ window._micPendingSend=window._micPendingSend||false;
 
   function _armBrowserTtsRecovery(clean, rate){
     _clearBrowserTtsRecovery();
+    _browserTtsSuppressNextErrorRearm=false;
     const safeRate=(Number.isFinite(rate)&&rate>0)?rate:1;
     // Chromium can drop utter.onend on later turns, so force a recovery path.
     const watchdogMs=Math.max(4000,Math.round((String(clean||'').length/(12*safeRate))*1000)+10000);
     _browserTtsWatchdog=setTimeout(()=>{
       if(!_voiceModeActive||_voiceModeState!=='speaking') return;
+      _browserTtsSuppressNextErrorRearm=true;
       try{ speechSynthesis.cancel(); }catch(_){}
       _clearBrowserTtsRecovery();
       _startListening();
@@ -1095,12 +1098,17 @@ window._micPendingSend=window._micPendingSend||false;
     if(!isNaN(savedPitch)) utter.pitch=Math.min(2,Math.max(0,savedPitch));
 
     utter.onend=()=>{
+      _browserTtsSuppressNextErrorRearm=false;
       _clearBrowserTtsRecovery();
       // After speaking, go back to listening
       if(_voiceModeActive) setTimeout(()=>_startListening(),500);
     };
     utter.onerror=()=>{
       _clearBrowserTtsRecovery();
+      if(_browserTtsSuppressNextErrorRearm){
+        _browserTtsSuppressNextErrorRearm=false;
+        return;
+      }
       if(_voiceModeActive) setTimeout(()=>_startListening(),1000);
     };
 
@@ -1167,6 +1175,7 @@ window._micPendingSend=window._micPendingSend||false;
     _voiceModeActive=false;
     _voiceModeState='idle';
     _voiceModeThinkingSid=null;
+    _browserTtsSuppressNextErrorRearm=false;
     modeBtn.classList.remove('active');
     _setButtonTooltip(modeBtn, t('voice_mode_toggle'));
     bar.style.display='none';

--- a/tests/test_issue3983_browser_tts_watchdog.py
+++ b/tests/test_issue3983_browser_tts_watchdog.py
@@ -40,6 +40,7 @@ def test_browser_tts_callbacks_and_deactivate_clear_recovery_handles():
         "Both browser TTS completion callbacks must clear watchdog/keep-alive handles."
     )
     assert "_browserTtsSuppressNextErrorRearm=false;" in speak_body
+    assert "_voiceModeActive&&_voiceModeState==='speaking'" in speak_body
     assert "if(_browserTtsSuppressNextErrorRearm){" in speak_body
     assert "_armBrowserTtsRecovery(clean, utter.rate);" in speak_body
 

--- a/tests/test_issue3983_browser_tts_watchdog.py
+++ b/tests/test_issue3983_browser_tts_watchdog.py
@@ -58,9 +58,13 @@ def test_browser_tts_callbacks_and_deactivate_clear_recovery_handles():
 
 def test_edge_audio_branch_stays_separate():
     src = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    edge_idx = src.find("if(engine===\"edge\"){")
-    assert edge_idx != -1
-    edge_body = src[edge_idx : edge_idx + 1300]
+    edge_match = re.search(
+        r'if\(engine==="edge"\)\{(.*?)\n\s+return;\n\s+\}',
+        src,
+        re.DOTALL,
+    )
+    assert edge_match, "Edge audio branch must exist"
+    edge_body = edge_match.group(1)
     assert "const audio = new Audio(url);" in edge_body
     assert "audio.onended = () => {" in edge_body
     assert "_armBrowserTtsRecovery" not in edge_body, (

--- a/tests/test_issue3983_browser_tts_watchdog.py
+++ b/tests/test_issue3983_browser_tts_watchdog.py
@@ -5,6 +5,24 @@ import re
 REPO = Path(__file__).resolve().parents[1]
 
 
+def _extract_function(src: str, name: str) -> str:
+    anchor = f"function {name}("
+    start = src.find(anchor)
+    assert start != -1, f"{name}() must exist"
+    body_start = src.find("{", start)
+    assert body_start != -1, f"{name}() must have a body"
+    depth = 1
+    idx = body_start + 1
+    while depth and idx < len(src):
+        if src[idx] == "{":
+            depth += 1
+        elif src[idx] == "}":
+            depth -= 1
+        idx += 1
+    assert depth == 0, f"{name}() body must balance braces"
+    return src[start:idx]
+
+
 def test_boot_js_declares_browser_tts_recovery_helpers():
     src = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
     assert "let _browserTtsKeepAlive=null;" in src
@@ -16,9 +34,7 @@ def test_boot_js_declares_browser_tts_recovery_helpers():
 
 def test_browser_tts_watchdog_rearms_listening_if_onend_drops():
     src = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    arm_idx = src.find("function _armBrowserTtsRecovery(clean, rate){")
-    assert arm_idx != -1
-    arm_body = src[arm_idx : arm_idx + 1400]
+    arm_body = _extract_function(src, "_armBrowserTtsRecovery")
     assert "_browserTtsWatchdog=setTimeout" in arm_body
     assert "_voiceModeState!=='speaking'" in arm_body
     assert "_browserTtsSuppressNextErrorRearm=true;" in arm_body
@@ -31,9 +47,8 @@ def test_browser_tts_watchdog_rearms_listening_if_onend_drops():
 
 def test_browser_tts_callbacks_and_deactivate_clear_recovery_handles():
     src = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    speak_idx = src.find("const utter=new SpeechSynthesisUtterance(clean);")
-    assert speak_idx != -1
-    speak_body = src[speak_idx : speak_idx + 1200]
+    speak_body = _extract_function(src, "_speakResponse")
+    assert "const utter=new SpeechSynthesisUtterance(clean);" in speak_body
     assert "utter.onend=()=>{" in speak_body
     assert "utter.onerror=()=>{" in speak_body
     assert speak_body.count("_clearBrowserTtsRecovery();") >= 2, (
@@ -44,13 +59,7 @@ def test_browser_tts_callbacks_and_deactivate_clear_recovery_handles():
     assert "if(_browserTtsSuppressNextErrorRearm){" in speak_body
     assert "_armBrowserTtsRecovery(clean, utter.rate);" in speak_body
 
-    deactivate_match = re.search(
-        r"function _deactivate\(\)\{(.*?)\n  \}",
-        src,
-        re.DOTALL,
-    )
-    assert deactivate_match, "_deactivate() must exist"
-    deactivate_body = deactivate_match.group(1)
+    deactivate_body = _extract_function(src, "_deactivate")
     assert "_clearBrowserTtsRecovery();" in deactivate_body, (
         "_deactivate() must clear browser TTS watchdog/keep-alive handles."
     )

--- a/tests/test_issue3983_browser_tts_watchdog.py
+++ b/tests/test_issue3983_browser_tts_watchdog.py
@@ -9,6 +9,7 @@ def test_boot_js_declares_browser_tts_recovery_helpers():
     src = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
     assert "let _browserTtsKeepAlive=null;" in src
     assert "let _browserTtsWatchdog=null;" in src
+    assert "let _browserTtsSuppressNextErrorRearm=false;" in src
     assert "function _clearBrowserTtsRecovery()" in src
     assert "function _armBrowserTtsRecovery(clean, rate)" in src
 
@@ -20,6 +21,7 @@ def test_browser_tts_watchdog_rearms_listening_if_onend_drops():
     arm_body = src[arm_idx : arm_idx + 1400]
     assert "_browserTtsWatchdog=setTimeout" in arm_body
     assert "_voiceModeState!=='speaking'" in arm_body
+    assert "_browserTtsSuppressNextErrorRearm=true;" in arm_body
     assert "speechSynthesis.cancel()" in arm_body
     assert "_startListening();" in arm_body
     assert "_browserTtsKeepAlive=setInterval" in arm_body
@@ -37,6 +39,8 @@ def test_browser_tts_callbacks_and_deactivate_clear_recovery_handles():
     assert speak_body.count("_clearBrowserTtsRecovery();") >= 2, (
         "Both browser TTS completion callbacks must clear watchdog/keep-alive handles."
     )
+    assert "_browserTtsSuppressNextErrorRearm=false;" in speak_body
+    assert "if(_browserTtsSuppressNextErrorRearm){" in speak_body
     assert "_armBrowserTtsRecovery(clean, utter.rate);" in speak_body
 
     deactivate_match = re.search(
@@ -49,6 +53,7 @@ def test_browser_tts_callbacks_and_deactivate_clear_recovery_handles():
     assert "_clearBrowserTtsRecovery();" in deactivate_body, (
         "_deactivate() must clear browser TTS watchdog/keep-alive handles."
     )
+    assert "_browserTtsSuppressNextErrorRearm=false;" in deactivate_body
 
 
 def test_edge_audio_branch_stays_separate():

--- a/tests/test_issue3983_browser_tts_watchdog.py
+++ b/tests/test_issue3983_browser_tts_watchdog.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import re
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def test_boot_js_declares_browser_tts_recovery_helpers():
+    src = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    assert "let _browserTtsKeepAlive=null;" in src
+    assert "let _browserTtsWatchdog=null;" in src
+    assert "function _clearBrowserTtsRecovery()" in src
+    assert "function _armBrowserTtsRecovery(clean, rate)" in src
+
+
+def test_browser_tts_watchdog_rearms_listening_if_onend_drops():
+    src = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    arm_idx = src.find("function _armBrowserTtsRecovery(clean, rate){")
+    assert arm_idx != -1
+    arm_body = src[arm_idx : arm_idx + 1400]
+    assert "_browserTtsWatchdog=setTimeout" in arm_body
+    assert "_voiceModeState!=='speaking'" in arm_body
+    assert "speechSynthesis.cancel()" in arm_body
+    assert "_startListening();" in arm_body
+    assert "_browserTtsKeepAlive=setInterval" in arm_body
+    assert "speechSynthesis.pause();" in arm_body
+    assert "speechSynthesis.resume();" in arm_body
+
+
+def test_browser_tts_callbacks_and_deactivate_clear_recovery_handles():
+    src = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    speak_idx = src.find("const utter=new SpeechSynthesisUtterance(clean);")
+    assert speak_idx != -1
+    speak_body = src[speak_idx : speak_idx + 1200]
+    assert "utter.onend=()=>{" in speak_body
+    assert "utter.onerror=()=>{" in speak_body
+    assert speak_body.count("_clearBrowserTtsRecovery();") >= 2, (
+        "Both browser TTS completion callbacks must clear watchdog/keep-alive handles."
+    )
+    assert "_armBrowserTtsRecovery(clean, utter.rate);" in speak_body
+
+    deactivate_match = re.search(
+        r"function _deactivate\(\)\{(.*?)\n  \}",
+        src,
+        re.DOTALL,
+    )
+    assert deactivate_match, "_deactivate() must exist"
+    deactivate_body = deactivate_match.group(1)
+    assert "_clearBrowserTtsRecovery();" in deactivate_body, (
+        "_deactivate() must clear browser TTS watchdog/keep-alive handles."
+    )
+
+
+def test_edge_audio_branch_stays_separate():
+    src = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    edge_idx = src.find("if(engine===\"edge\"){")
+    assert edge_idx != -1
+    edge_body = src[edge_idx : edge_idx + 1300]
+    assert "const audio = new Audio(url);" in edge_body
+    assert "audio.onended = () => {" in edge_body
+    assert "_armBrowserTtsRecovery" not in edge_body, (
+        "The browser speechSynthesis workaround must not be injected into the Edge audio branch."
+    )


### PR DESCRIPTION

## Thinking Path

- The broken path is not voice mode in general; it is the browser `speechSynthesis` branch that depends on an event Chromium is known to drop.
- The Edge `Audio` branch already has a stable `onended` signal, so the fix should stay localized to the browser utterance path plus shared cleanup.
- A watchdog is the non-negotiable part because it guarantees the conversation does not dead-end; a pause/resume keep-alive is useful only as a best-effort assist.

## What Changed

- `static/boot.js`: add browser-TTS recovery handles, clear them on completion and deactivation, and force a return to listening if Chromium drops `utter.onend`.
- `tests/test_issue3983_browser_tts_watchdog.py`: add focused source-level regression coverage for the watchdog, cleanup, and branch scoping.

## Why It Matters

Hands-free voice mode can now survive repeated browser-engine replies instead of getting stranded in `speaking` after turn one. Keeping the workaround isolated to the browser branch also avoids risking regressions in the working Edge `Audio` path.

## Verification

```cmd
cmd /c npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs static/boot.js
pytest tests/test_issue3983_browser_tts_watchdog.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- The pause/resume keep-alive can be flaky across Chromium versions, so the watchdog should be the code path that guarantees recovery.
- Manual browser verification still matters because no local unit test can prove a real `speechSynthesis` engine fires or drops `onend`.
- This intentionally does not alter the `/api/tts` Edge engine path, because that branch is not the one failing here.

## Model Used

GPT 5.5 via Codex CLI
