### PR TITLE
fix(#4001): preserve inline code inside markdown link labels

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -3530,6 +3530,21 @@ function renderMd(raw){
   // Inline backtick spans: restore <code> tags produced in the stash callback above.
   // Must happen BEFORE bold/italic so **`code`** → <strong><code>code</code></strong>.
   s=s.replace(/\x00F(\d+)\x00/g,(_,i)=>fence_stash[+i]);
+  const SAFE_LABEL_INLINE=/^<\/?(strong|em|del|code)([\s>]|$)/i;
+  function _markdownLabelHtml(label){
+    const _label_stash=[];
+    const tokenized=String(label||'').replace(/<\/?[a-z][^>]*>/gi,tag=>{
+      if(!SAFE_LABEL_INLINE.test(tag)) return tag;
+      _label_stash.push(tag);
+      return `\x00H${_label_stash.length-1}\x00`;
+    });
+    return esc(tokenized).replace(/\x00H(\d+)\x00/g,(_,i)=>_label_stash[+i]);
+  }
+  function _markdownAnchor(label,rawUrl){
+    const href=_markdownHref(rawUrl);
+    const internal=/^session:\/\//i.test(String(rawUrl||'')) || _isInternalSessionHref(href);
+    return `<a${internal?' class="session-link"':''} href="${href}"${internal?'':' target="_blank" rel="noopener"'}>${_markdownLabelHtml(label)}</a>`;
+  }
   // inlineMd: process bold/italic/code/links within a single line of text.
   // Used inside list items and blockquotes where the text may already contain
   // HTML from the pre-pass → bold pipeline, so we cannot call esc() directly.
@@ -3756,21 +3771,6 @@ function renderMd(raw){
     }catch(_){
       return false;
     }
-  }
-  const SAFE_LABEL_INLINE=/^<\/?(strong|em|del|code)([\s>]|$)/i;
-  function _markdownLabelHtml(label){
-    const _label_stash=[];
-    const tokenized=String(label||'').replace(/<\/?[a-z][^>]*>/gi,tag=>{
-      if(!SAFE_LABEL_INLINE.test(tag)) return tag;
-      _label_stash.push(tag);
-      return `\x00H${_label_stash.length-1}\x00`;
-    });
-    return esc(tokenized).replace(/\x00H(\d+)\x00/g,(_,i)=>_label_stash[+i]);
-  }
-  function _markdownAnchor(label,rawUrl){
-    const href=_markdownHref(rawUrl);
-    const internal=/^session:\/\//i.test(String(rawUrl||'')) || _isInternalSessionHref(href);
-    return `<a${internal?' class="session-link"':''} href="${href}"${internal?'':' target="_blank" rel="noopener"'}>${_markdownLabelHtml(label)}</a>`;
   }
   function _isSafeUrl(v, img){
     const raw=_safeAttrValue(v);

--- a/static/ui.js
+++ b/static/ui.js
@@ -3530,21 +3530,6 @@ function renderMd(raw){
   // Inline backtick spans: restore <code> tags produced in the stash callback above.
   // Must happen BEFORE bold/italic so **`code`** → <strong><code>code</code></strong>.
   s=s.replace(/\x00F(\d+)\x00/g,(_,i)=>fence_stash[+i]);
-  const SAFE_LABEL_INLINE=/^<\/?(strong|em|del|code)([\s>]|$)/i;
-  function _markdownLabelHtml(label){
-    const _label_stash=[];
-    const tokenized=String(label||'').replace(/<\/?[a-z][^>]*>/gi,tag=>{
-      if(!SAFE_LABEL_INLINE.test(tag)) return tag;
-      _label_stash.push(tag);
-      return `\x00H${_label_stash.length-1}\x00`;
-    });
-    return esc(tokenized).replace(/\x00H(\d+)\x00/g,(_,i)=>_label_stash[+i]);
-  }
-  function _markdownAnchor(label,rawUrl){
-    const href=_markdownHref(rawUrl);
-    const internal=/^session:\/\//i.test(String(rawUrl||'')) || _isInternalSessionHref(href);
-    return `<a${internal?' class="session-link"':''} href="${href}"${internal?'':' target="_blank" rel="noopener"'}>${_markdownLabelHtml(label)}</a>`;
-  }
   // inlineMd: process bold/italic/code/links within a single line of text.
   // Used inside list items and blockquotes where the text may already contain
   // HTML from the pre-pass → bold pipeline, so we cannot call esc() directly.
@@ -3771,6 +3756,23 @@ function renderMd(raw){
     }catch(_){
       return false;
     }
+  }
+  function _isSafeLabelInline(tag){
+    return /^<\/?(strong|em|del|code)([\s>]|$)/i.test(tag);
+  }
+  function _markdownLabelHtml(label){
+    const _label_stash=[];
+    const tokenized=String(label||'').replace(/<\/?[a-z][^>]*>/gi,tag=>{
+      if(!_isSafeLabelInline(tag)) return tag;
+      _label_stash.push(tag);
+      return `\x00H${_label_stash.length-1}\x00`;
+    });
+    return esc(tokenized).replace(/\x00H(\d+)\x00/g,(_,i)=>_label_stash[+i]);
+  }
+  function _markdownAnchor(label,rawUrl){
+    const href=_markdownHref(rawUrl);
+    const internal=/^session:\/\//i.test(String(rawUrl||'')) || _isInternalSessionHref(href);
+    return `<a${internal?' class="session-link"':''} href="${href}"${internal?'':' target="_blank" rel="noopener"'}>${_markdownLabelHtml(label)}</a>`;
   }
   function _isSafeUrl(v, img){
     const raw=_safeAttrValue(v);

--- a/static/ui.js
+++ b/static/ui.js
@@ -3757,10 +3757,20 @@ function renderMd(raw){
       return false;
     }
   }
+  const SAFE_LABEL_INLINE=/^<\/?(strong|em|del|code)([\s>]|$)/i;
+  function _markdownLabelHtml(label){
+    const _label_stash=[];
+    const tokenized=String(label||'').replace(/<\/?[a-z][^>]*>/gi,tag=>{
+      if(!SAFE_LABEL_INLINE.test(tag)) return tag;
+      _label_stash.push(tag);
+      return `\x00H${_label_stash.length-1}\x00`;
+    });
+    return esc(tokenized).replace(/\x00H(\d+)\x00/g,(_,i)=>_label_stash[+i]);
+  }
   function _markdownAnchor(label,rawUrl){
     const href=_markdownHref(rawUrl);
     const internal=/^session:\/\//i.test(String(rawUrl||'')) || _isInternalSessionHref(href);
-    return `<a${internal?' class="session-link"':''} href="${href}"${internal?'':' target="_blank" rel="noopener"'}>${esc(label)}</a>`;
+    return `<a${internal?' class="session-link"':''} href="${href}"${internal?'':' target="_blank" rel="noopener"'}>${_markdownLabelHtml(label)}</a>`;
   }
   function _isSafeUrl(v, img){
     const raw=_safeAttrValue(v);

--- a/tests/test_issue4001_inline_code_link_label.py
+++ b/tests/test_issue4001_inline_code_link_label.py
@@ -1,0 +1,22 @@
+from tests.test_renderer_js_behaviour import _render, driver_path  # noqa: F401
+
+
+def test_inline_code_inside_link_label_renders_as_code(driver_path):
+    out = _render(driver_path, "[`8c64957`](https://github.com/x/y)")
+    assert '<a href="https://github.com/x/y"' in out
+    assert "<code>8c64957</code>" in out
+    assert "&lt;code&gt;" not in out
+
+
+def test_list_item_link_label_keeps_inline_code(driver_path):
+    out = _render(driver_path, "- [`8c64957`](https://github.com/x/y)")
+    assert "<li>" in out
+    assert "<code>8c64957</code>" in out
+    assert "&lt;code&gt;" not in out
+
+
+def test_unknown_raw_html_inside_link_label_is_escaped_once(driver_path):
+    out = _render(driver_path, "[<script>alert(1)</script>](https://github.com/x/y)")
+    assert "<script>" not in out
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in out
+    assert "&amp;lt;script" not in out

--- a/tests/test_issue4001_inline_code_link_label.py
+++ b/tests/test_issue4001_inline_code_link_label.py
@@ -1,4 +1,6 @@
-from tests.test_renderer_js_behaviour import _render, driver_path  # noqa: F401
+pytest_plugins = ("tests.test_renderer_js_behaviour",)
+
+from tests.test_renderer_js_behaviour import _render
 
 
 def test_inline_code_inside_link_label_renders_as_code(driver_path):


### PR DESCRIPTION

## Thinking Path

- The renderer already has stash patterns for inline HTML it produced itself; the link-label path is the remaining place that treats safe renderer output as raw text.
- `_markdownAnchor()` is the single choke point for both relevant link passes, so a tight fix there covers chat, list items, and cron/task output together.
- The important tradeoff is preserving renderer-built inline tags without relaxing the sanitizer for arbitrary raw HTML.

## What Changed

- `static/ui.js`: teach `_markdownAnchor()` to preserve allowlisted renderer-produced inline tags inside link labels instead of escaping them back to literal text.
- `tests/test_issue4001_inline_code_link_label.py`: add real-renderer regression coverage for inline-code link labels and a guard that unknown raw HTML still gets escaped.

## Why It Matters

Commit links, file references, and task output can show inline code inside link text the way users wrote it, instead of leaking raw `<code>` tags into the UI. Keeping the fix inside the shared anchor helper also avoids duplicating special cases across multiple markdown passes.

## Verification

```cmd
cmd /c npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs static/ui.js
pytest tests/test_issue4001_inline_code_link_label.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- The allowlist must stay narrow; preserving all HTML in labels would be the wrong tradeoff.
- This intentionally does not touch the settings-page `<code>` symptom, because that is a separate `applyLocaleToDOM` / i18n issue in #4002.
- Because target 112 also edits `static/ui.js`, keep this PR tightly scoped so a rebase stays mechanical.

## Model Used

GPT 5.5 via Codex CLI
