### PR TITLE
Release MD — v0.51.365 — lineage-segment open + reasoning chip fixes (#4009, #4015)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## [Unreleased]
 
+## [v0.51.365] — 2026-06-11 — Release MD (lineage-segment open + reasoning chip fixes)
+
+### Fixed
+
+- **Clicking an expanded session-lineage segment now opens that exact session instead of resolving back to the collapsed parent (#4003).** The explicit lineage-segment and child-row click handlers now skip the collapsed-id lineage resolution (which is only meant for stale collapsed rows), so the session you click is the session that loads.
+- **The reasoning-effort chip no longer disappears after you pick an effort (#3958).** Selecting an effort posted to `/api/reasoning`, which re-resolved the supported efforts for the config-default model rather than the active session's model — so a session whose model differs from the default lost its chip until a refresh. The effort POST now carries the active session's model/provider context, matching the GET path, so the chip stays correct. (#3958)
+
 ## [v0.51.364] — 2026-06-11 — Release MC (self-heal stuck session loads)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -2756,7 +2756,13 @@ def set_reasoning_display(show: bool) -> dict:
     return get_reasoning_status()
 
 
-def set_reasoning_effort(effort: str) -> dict:
+def set_reasoning_effort(
+    effort: str,
+    *,
+    model_id: str | None = None,
+    provider_id: str | None = None,
+    base_url: str | None = None,
+) -> dict:
     """Persist ``agent.reasoning_effort`` to the active profile's config.yaml.
 
     Mirrors CLI ``/reasoning <level>``: same key, same valid values
@@ -2781,7 +2787,11 @@ def set_reasoning_effort(effort: str) -> dict:
         config_data["agent"] = agent_cfg
         _save_yaml_config_file(config_path, config_data)
     reload_config()
-    return get_reasoning_status()
+    return get_reasoning_status(
+        model_id=model_id,
+        provider_id=provider_id,
+        base_url=base_url,
+    )
 
 
 def set_hermes_default_model(model_id: str) -> dict:

--- a/api/routes.py
+++ b/api/routes.py
@@ -7446,7 +7446,18 @@ def handle_post(handler, parsed) -> bool:
                     return j(handler, set_reasoning_display(False))
                 return bad(handler, f"display must be show|hide|on|off (got '{display}')")
             if effort is not None:
-                return j(handler, set_reasoning_effort(effort))
+                model_id = str(body.get("model") or "").strip() or None
+                provider_id = str(body.get("provider") or "").strip() or None
+                base_url = str(body.get("base_url") or "").strip() or None
+                return j(
+                    handler,
+                    set_reasoning_effort(
+                        effort,
+                        model_id=model_id,
+                        provider_id=provider_id,
+                        base_url=base_url,
+                    ),
+                )
             return bad(handler, "reasoning: must supply 'display' or 'effort'")
         except ValueError as e:
             return bad(handler, str(e))

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -5284,7 +5284,7 @@ function renderSessionListFromCache(){
             try{await api('/api/session/import_cli',{method:'POST',body:JSON.stringify({session_id:seg.session_id})});}
             catch(_e){ /* read-only fallback */ }
           }
-          await loadSession(seg.session_id);
+          await loadSession(seg.session_id, {skipLineageResolve:true});
           renderSessionListFromCache();
         };
         lineageList.appendChild(row);
@@ -5311,7 +5311,7 @@ function renderSessionListFromCache(){
             try{await api('/api/session/import_cli',{method:'POST',body:JSON.stringify({session_id:child.session_id})});}
             catch(_e){ /* read-only fallback */ }
           }
-          await loadSession(child.session_id);
+          await loadSession(child.session_id, {skipLineageResolve:true});
           renderSessionListFromCache();
         };
         childList.appendChild(row);

--- a/static/ui.js
+++ b/static/ui.js
@@ -2004,16 +2004,21 @@ function _formatReasoningEffortLabel(effort){
   return effort;
 }
 
-function _reasoningEffortQuery(){
+function _reasoningEffortContext(){
   const sel=$('modelSelect');
   const model=(S&&S.session&&S.session.model)||(sel&&sel.value)||'';
   let provider=(S&&S.session&&S.session.model_provider)||'';
   if(!provider&&sel&&model&&typeof _modelStateForSelect==='function'){
     provider=_modelStateForSelect(sel, model).model_provider||'';
   }
-  const params=new URLSearchParams();
-  if(model) params.set('model', model);
-  if(provider) params.set('provider', provider);
+  const ctx={};
+  if(model) ctx.model=model;
+  if(provider) ctx.provider=provider;
+  return ctx;
+}
+
+function _reasoningEffortQuery(){
+  const params=new URLSearchParams(_reasoningEffortContext());
   const qs=params.toString();
   return qs?('?'+qs):'';
 }
@@ -2146,7 +2151,8 @@ document.addEventListener('click',function(e){
     const opt=e.target.closest('.reasoning-option');
     const effort=opt&&opt.dataset.effort;
     if(effort){
-      api('/api/reasoning',{method:'POST',body:JSON.stringify({effort:effort})})
+      const payload=Object.assign({effort:effort},_reasoningEffortContext());
+      api('/api/reasoning',{method:'POST',body:JSON.stringify(payload)})
         .then(function(st){
           _applyReasoningChip((st&&st.reasoning_effort)||effort, st||{});
           showToast('🧠 Reasoning effort set to '+((st&&st.reasoning_effort)||effort));

--- a/tests/test_issue3958_reasoning_post_session_context.py
+++ b/tests/test_issue3958_reasoning_post_session_context.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+import re
+
+import api.config as cfg
+import yaml
+
+
+def read(path):
+    return Path(path).read_text(encoding="utf-8")
+
+
+def test_set_reasoning_effort_returns_status_for_explicit_model(tmp_path, monkeypatch):
+    cfgfile = tmp_path / "config.yaml"
+    cfgfile.write_text(
+        yaml.safe_dump(
+            {
+                "model": {"default": "gpt-4o", "provider": "openai"},
+                "agent": {"reasoning_effort": ""},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: cfgfile)
+    monkeypatch.setattr(cfg, "reload_config", lambda: None)
+
+    seen = {}
+
+    def fake_resolve(model_id, provider_id=None, base_url=None):
+        seen["args"] = (model_id, provider_id, base_url)
+        if model_id == "claude-opus-4-7":
+            return ["minimal", "low", "medium", "high", "xhigh", "max"]
+        return []
+
+    monkeypatch.setattr(cfg, "resolve_model_reasoning_efforts", fake_resolve)
+
+    status = cfg.set_reasoning_effort(
+        "high",
+        model_id="claude-opus-4-7",
+        provider_id="anthropic",
+    )
+
+    assert seen["args"] == ("claude-opus-4-7", "anthropic", None)
+    assert status["reasoning_effort"] == "high"
+    assert status["supported_efforts"] == [
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    ]
+
+
+def test_ui_posts_reasoning_context_with_effort():
+    src = read("static/ui.js")
+    assert "function _reasoningEffortContext()" in src
+    assert "new URLSearchParams(_reasoningEffortContext())" in src
+    assert "Object.assign({effort:effort},_reasoningEffortContext())" in src
+
+
+def test_reasoning_post_route_threads_model_context():
+    src = read("api/routes.py")
+    match = re.search(
+        r"if parsed\.path == \"/api/reasoning\":(.*?)return bad\(handler, \"reasoning: must supply 'display' or 'effort'\"\)",
+        src,
+        re.DOTALL,
+    )
+    assert match, "The /api/reasoning POST route block must exist"
+    body = match.group(1)
+    assert 'body.get("model")' in body
+    assert 'body.get("provider")' in body
+    assert 'set_reasoning_effort(' in body
+    assert "model_id=model_id" in body
+    assert "provider_id=provider_id" in body

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -481,7 +481,9 @@ def test_lineage_segment_expansion_static_contract():
     assert "className='session-lineage-segment'" in js
     assert "const segTitle=_sessionDisplayTitle(seg)||t('session_lineage_segment_untitled');" in js
     assert "row.title=t('session_lineage_segment_open');" in js
-    assert "await loadSession(seg.session_id);" in js
+    assert "await loadSession(seg.session_id, {skipLineageResolve:true});" in js
+    assert "await loadSession(child.session_id, {skipLineageResolve:true});" in js
+    assert "if(!opts.skipLineageResolve && typeof _resolveSessionIdFromSidebarLineage==='function'){" in js
     assert ".session-lineage-count.expandable{" in css
     assert ".session-lineage-count.expandable:hover" in css
     assert ".session-lineage-segments{" in css


### PR DESCRIPTION
# Release MD — v0.51.365 — lineage-segment open + reasoning chip fixes (#4009, #4015)

Two fix-only PRs (rodboev), batched.

## #4009 (fixes #4003) — lineage segment opens the wrong session
Clicking an expanded lineage segment / child row re-resolved the id through the collapsed-row lineage resolver and opened the parent instead. The explicit click handlers now pass `loadSession(id, {skipLineageResolve:true})` (an existing escape hatch), so the clicked session is the one that loads. `static/sessions.js` +4/-2.

## #4015 (fixes #3958) — reasoning-effort chip disappears after selection
Picking an effort POSTed to `/api/reasoning`, and `get_reasoning_status` re-resolved `supported_efforts` for the **config-default** model rather than the active session's model — so on a session whose model differs from the default, the chip vanished until F5. `set_reasoning_effort(effort, *, model_id, provider_id, base_url)` now threads the active session's model context (routes.py reads `model`/`provider`/`base_url` from the POST body), matching the GET path. `ui.js` refactors `_reasoningEffortQuery` into a shared `_reasoningEffortContext` used for the POST body. config.py + routes.py + ui.js + test.

## Verification
- **Full suite: 8640 passed, 0 failed** (`-p no:xdist`); 25 targeted tests (lineage-collapse + the new #3958 post-context test) pass.
- node -c (ui.js, sessions.js), ESLint runtime gate, ruff gate all clean.
- Rebase-fidelity verified: combined code-diff byte-identical to both PR heads for every shared file.
- **Codex: SAFE TO SHIP** — both fixes correct, no skip-resolve mis-open, model-context threading sound (empty model/provider degrades to prior behavior, not a regression), no interaction between the two.

Co-authored-by: rodboev
