### PR TITLE
fix(commands): hide CLI-only slash collisions from autocomplete (#3969)

### DIFF
--- a/static/commands.js
+++ b/static/commands.js
@@ -65,6 +65,7 @@ function getMatchingCommands(prefix){
   const q=prefix.toLowerCase();
   const matches=COMMANDS.filter(c=>c.name.startsWith(q)).map(c=>({...c,source:'builtin'}));
   const seen=new Set(matches.map(c=>c.name));
+  const reserved=_getReservedSlashCommandSlugs();
   for(const [name, spec] of Object.entries(SLASH_SUBARG_SOURCES)){
     if(!name.startsWith(q)||seen.has(name))continue;
     matches.push({
@@ -76,7 +77,7 @@ function getMatchingCommands(prefix){
     seen.add(name);
   }
   for(const skill of _skillCommandCache){
-    if(!skill.name.startsWith(q)||seen.has(skill.name))continue;
+    if(!skill.name.startsWith(q)||seen.has(skill.name)||reserved.has(skill.name))continue;
     matches.push(skill);
     seen.add(skill.name);
   }
@@ -1490,11 +1491,23 @@ function _skillCommandSlug(name){
   if(!raw)return'';
   return raw.replace(/[\s_]+/g,'-').replace(/[^a-z0-9-]/g,'').replace(/-{2,}/g,'-').replace(/^-+|-+$/g,'');
 }
+function _getReservedSlashCommandSlugs(){
+  const reserved=new Set(COMMANDS.map(c=>String(c&&c.name||'').trim().toLowerCase()).filter(Boolean));
+  for(const cmd of (_agentCommandCache||[])){
+    if(!(cmd&&cmd.cli_only)) continue;
+    const names=[cmd.name].concat(Array.isArray(cmd&&cmd.aliases)?cmd.aliases:[]);
+    for(const name of names){
+      const slug=_skillCommandSlug(name);
+      if(slug) reserved.add(slug);
+    }
+  }
+  return reserved;
+}
 function _buildSkillCommandEntry(skill){
   const skillName=String(skill&&skill.name||'').trim();
   const slug=_skillCommandSlug(skillName);
   if(!slug)return null;
-  if(COMMANDS.some(c=>c.name===slug)) return null;
+  if(_getReservedSlashCommandSlugs().has(slug)) return null;
   return{name:slug,desc:String(skill&&skill.description||'').trim()||t('slash_skill_desc'),source:'skill',skillName};
 }
 async function loadSkillCommands(force=false){

--- a/tests/test_cli_only_slash_commands.py
+++ b/tests/test_cli_only_slash_commands.py
@@ -3,6 +3,7 @@
 import json
 from pathlib import Path
 import subprocess
+import tempfile
 import textwrap
 from types import SimpleNamespace
 
@@ -90,13 +91,19 @@ def _run_commands_js(script_body: str) -> dict:
           localStorage: {{ getItem(){{return null;}}, setItem(){{}}, removeItem(){{}} }},
           t: (key) => key,
           api: async (path) => {{
-            if (path !== '/api/commands') throw new Error('unexpected api path: ' + path);
-            return {{
+            if (path === '/api/commands') return {{
               commands: [
                 {{
                   name: 'browser',
                   description: 'Attach browser tools',
                   aliases: ['browse'],
+                  cli_only: true,
+                  gateway_only: false
+                }},
+                {{
+                  name: 'handoff',
+                  description: 'Hand work to another agent',
+                  aliases: ['delegate_work'],
                   cli_only: true,
                   gateway_only: false
                 }},
@@ -116,6 +123,23 @@ def _run_commands_js(script_body: str) -> dict:
                 }}
               ]
             }};
+            if (path === '/api/skills') return {{
+              skills: [
+                {{
+                  name: 'handoff',
+                  description: 'Skill shortcut that should stay reachable via /use'
+                }},
+                {{
+                  name: 'delegate work',
+                  description: 'Alias collision should also be hidden from slash autocomplete'
+                }},
+                {{
+                  name: 'incident review',
+                  description: 'Non-colliding skills should still autocomplete'
+                }}
+              ]
+            }};
+            throw new Error('unexpected api path: ' + path);
           }}
         }};
         vm.createContext(ctx);
@@ -129,7 +153,13 @@ def _run_commands_js(script_body: str) -> dict:
         }});
         """
     )
-    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    with tempfile.NamedTemporaryFile("w", suffix=".js", encoding="utf-8", delete=False) as handle:
+        handle.write(script)
+        script_path = Path(handle.name)
+    try:
+        proc = subprocess.run(["node", str(script_path)], check=True, capture_output=True, text=True)
+    finally:
+        script_path.unlink(missing_ok=True)
     return json.loads(proc.stdout)
 
 
@@ -169,6 +199,33 @@ def test_cli_only_response_helper_uses_canonical_command_name():
     assert "`/browser` is a Hermes CLI-only command" in result["response"]
     assert "Attach browser tools" in result["response"]
     assert "configured server-side" in result["response"]
+
+
+def test_cli_only_slugs_reserve_skill_autocomplete_namespace():
+    result = _run_commands_js(
+        """
+        await loadAgentCommandMetadata(true);
+        await loadSkillCommands(true);
+        const handoff = await getSlashAutocompleteMatches('/handoff');
+        const delegate = await getSlashAutocompleteMatches('/delegate');
+        const incident = await getSlashAutocompleteMatches('/incident');
+        const skills = await getSlashAutocompleteMatches('/skills');
+        const use = await getSlashAutocompleteMatches('/use');
+        return {
+          handoff_names: handoff.map(item => item.name),
+          delegate_names: delegate.map(item => item.name),
+          incident_names: incident.map(item => item.name),
+          skills_names: skills.map(item => item.name),
+          use_names: use.map(item => item.name)
+        };
+        """
+    )
+
+    assert result["handoff_names"] == []
+    assert result["delegate_names"] == []
+    assert result["incident_names"] == ["incident-review"]
+    assert "skills" in result["skills_names"]
+    assert "use" in result["use_names"]
 
 
 def test_send_intercepts_cli_only_commands_before_agent_round_trip():

--- a/tests/test_sprint47.py
+++ b/tests/test_sprint47.py
@@ -23,10 +23,9 @@ def test_skill_commands_are_loaded_from_api_skills_for_autocomplete():
 
 
 def test_builtin_commands_take_precedence_over_skill_slug_collisions():
-    # In the combined implementation, REGISTRY (agent registry + WEBUI_ONLY) wins over skills
-    assert ("if(COMMANDS.some(c=>c.name===slug)) return null;" in COMMANDS_JS or
-            "if(REGISTRY.some(c=>c.name===slug)) return null;" in COMMANDS_JS), \
-        "Built-in commands must block skill slug collisions"
+    assert "_getReservedSlashCommandSlugs" in COMMANDS_JS
+    assert "if(_getReservedSlashCommandSlugs().has(slug)) return null;" in COMMANDS_JS
+    assert "if(!skill.name.startsWith(q)||seen.has(skill.name)||reserved.has(skill.name))continue;" in COMMANDS_JS
 
 
 def test_typing_slash_primes_async_skill_command_loading():


### PR DESCRIPTION

## Thinking Path

- The issue is a current UI dead-end, not a broad command-migration project: the dropdown advertises `/handoff`, but submission resolves to a CLI-only refusal.
- The narrowest safe fix is to reserve CLI-only command slugs during autocomplete so skill-backed entries cannot claim names that the runtime already treats as non-WebUI commands.
- The slice should keep the underlying handoff skill intentionally reachable through `/skills` and `/use`, while removing the misleading slash shortcut until a fuller migration or rename happens.

## What Changed

- `static/commands.js`: add shared slug-reservation logic so CLI-only agent commands and aliases block skill-backed autocomplete collisions.
- `tests/test_cli_only_slash_commands.py`: add a focused `/handoff`-style regression over the existing CLI-only metadata harness.
- `tests/test_sprint47.py`: expand the skill-autocomplete collision guard beyond built-in `COMMANDS` to include agent metadata reservations.

## Why It Matters

Users stop hitting a self-contradictory UI where the dropdown promises a skill entry that the runtime then refuses to run. The fix is intentionally small and local, which keeps this first slice mergeable without deciding the larger CLI-command migration question.

## Verification

```text
npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs static/commands.js
pytest tests/test_cli_only_slash_commands.py -v --timeout=60
pytest tests/test_sprint47.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- This slice hides the dead-end entry; it does not migrate CLI-only commands into WebUI or rename the underlying handoff skill.
- If the maintainer later prefers disambiguation over hiding, that should be a follow-up on top of the same reserved-slug groundwork.

## Model Used

GPT 5.5 via Codex CLI
