### PR TITLE
fix(#3895): honor runtime target model and base_url in WebUI streaming

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -255,7 +255,7 @@ def _runtime_preferred_base_url(
         or ""
     ).strip().lower()
     if provider_id.startswith("custom:"):
-        return configured_base_url
+        return configured_base_url or runtime_base_url
     return runtime_base_url
 
 
@@ -5901,6 +5901,7 @@ def _run_agent_streaming(
             resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(
                 model_with_provider_context(model, provider_context)
             )
+            configured_base_url = resolved_base_url
 
             # Resolve API key via Hermes runtime provider (matches gateway behaviour).
             # Pass the resolved provider so non-default providers get their own credentials.
@@ -5917,7 +5918,7 @@ def _run_agent_streaming(
                 if not resolved_provider:
                     resolved_provider = _rt.get("provider")
                 resolved_base_url = _runtime_preferred_base_url(
-                    _rt, resolved_provider, resolved_base_url
+                    _rt, resolved_provider, configured_base_url
                 )
             except Exception as _e:
                 print(f"[webui] WARNING: resolve_runtime_provider failed: {_e}", flush=True)
@@ -6797,7 +6798,7 @@ def _run_agent_streaming(
                             if not resolved_provider:
                                 resolved_provider = _heal_rt.get('provider')
                             resolved_base_url = _runtime_preferred_base_url(
-                                _heal_rt, resolved_provider, resolved_base_url
+                                _heal_rt, resolved_provider, configured_base_url
                             )
                             resolved_provider, resolved_api_key, resolved_base_url = _resolve_custom_provider_runtime_overrides(
                                 resolved_provider, resolved_api_key, resolved_base_url
@@ -7751,7 +7752,7 @@ def _run_agent_streaming(
                     if not resolved_provider:
                         resolved_provider = _heal_rt.get('provider')
                     resolved_base_url = _runtime_preferred_base_url(
-                        _heal_rt, resolved_provider, resolved_base_url
+                        _heal_rt, resolved_provider, configured_base_url
                     )
                     resolved_provider, resolved_api_key, resolved_base_url = _resolve_custom_provider_runtime_overrides(
                         resolved_provider, resolved_api_key, resolved_base_url

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4614,7 +4614,7 @@ def _replace_session_db_in_kwargs(agent_kwargs, state_db_path):
 
 
 def _attempt_credential_self_heal(
-    provider_id, session_id, _agent_lock_ref,
+    provider_id, session_id, _agent_lock_ref, *, target_model=None,
 ):
     """Try to silently refresh credentials after a 401/auth error (#1401).
 
@@ -4662,6 +4662,7 @@ def _attempt_credential_self_heal(
         _new_rt = resolve_runtime_provider_with_anthropic_env_lock(
             resolve_runtime_provider,
             requested=provider_id,
+            target_model=target_model,
         )
 
         logger.info(
@@ -6789,6 +6790,7 @@ def _run_agent_streaming(
                         _heal_result = None
                         _heal_rt = _attempt_credential_self_heal(
                             resolved_provider or '', session_id, _agent_lock,
+                            target_model=resolved_model,
                         )
                         if _heal_rt is not None:
                             logger.info('[webui] self-heal: retrying stream after credential refresh')
@@ -7742,6 +7744,7 @@ def _run_agent_streaming(
                 # ── Credential self-heal on 401 (#1401) ──
                 _heal_rt = _attempt_credential_self_heal(
                     resolved_provider or '', session_id, _agent_lock,
+                    target_model=resolved_model,
                 )
                 if _heal_rt is not None:
                     logger.info('[webui] self-heal (except path): retrying stream after credential refresh')

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -237,6 +237,28 @@ def _resolve_custom_provider_runtime_overrides(
     return resolved_provider, resolved_api_key, resolved_base_url
 
 
+def _runtime_preferred_base_url(
+    runtime_provider: dict | None,
+    resolved_provider: str | None,
+    configured_base_url: str | None,
+) -> str | None:
+    """Prefer runtime-normalized URLs except for named custom endpoints."""
+    runtime_base_url = None
+    if isinstance(runtime_provider, dict):
+        runtime_base_url = runtime_provider.get("base_url")
+    if not runtime_base_url:
+        return configured_base_url
+
+    provider_id = str(
+        resolved_provider
+        or (runtime_provider or {}).get("provider")
+        or ""
+    ).strip().lower()
+    if provider_id.startswith("custom:"):
+        return configured_base_url
+    return runtime_base_url
+
+
 def _is_fallback_lifecycle_message(kind: str, message: str) -> bool:
     """Return True if an agent lifecycle status should surface as a fallback warning."""
     k = str(kind or '').strip().lower()
@@ -5889,12 +5911,14 @@ def _run_agent_streaming(
                 _rt = resolve_runtime_provider_with_anthropic_env_lock(
                     resolve_runtime_provider,
                     requested=resolved_provider,
+                    target_model=resolved_model,
                 )
                 resolved_api_key = _rt.get("api_key")
                 if not resolved_provider:
                     resolved_provider = _rt.get("provider")
-                if not resolved_base_url:
-                    resolved_base_url = _rt.get("base_url")
+                resolved_base_url = _runtime_preferred_base_url(
+                    _rt, resolved_provider, resolved_base_url
+                )
             except Exception as _e:
                 print(f"[webui] WARNING: resolve_runtime_provider failed: {_e}", flush=True)
 
@@ -6772,8 +6796,9 @@ def _run_agent_streaming(
                             resolved_api_key = _heal_rt.get('api_key')
                             if not resolved_provider:
                                 resolved_provider = _heal_rt.get('provider')
-                            if not resolved_base_url:
-                                resolved_base_url = _heal_rt.get('base_url')
+                            resolved_base_url = _runtime_preferred_base_url(
+                                _heal_rt, resolved_provider, resolved_base_url
+                            )
                             resolved_provider, resolved_api_key, resolved_base_url = _resolve_custom_provider_runtime_overrides(
                                 resolved_provider, resolved_api_key, resolved_base_url
                             )
@@ -7725,8 +7750,9 @@ def _run_agent_streaming(
                     resolved_api_key = _heal_rt.get('api_key')
                     if not resolved_provider:
                         resolved_provider = _heal_rt.get('provider')
-                    if not resolved_base_url:
-                        resolved_base_url = _heal_rt.get('base_url')
+                    resolved_base_url = _runtime_preferred_base_url(
+                        _heal_rt, resolved_provider, resolved_base_url
+                    )
                     resolved_provider, resolved_api_key, resolved_base_url = _resolve_custom_provider_runtime_overrides(
                         resolved_provider, resolved_api_key, resolved_base_url
                     )

--- a/tests/test_issue3895_opencode_go_model_picker.py
+++ b/tests/test_issue3895_opencode_go_model_picker.py
@@ -2,7 +2,6 @@
 
 import pathlib
 import queue
-import re
 import sys
 import threading
 import types
@@ -169,8 +168,8 @@ def test_streaming_passes_target_model_and_prefers_runtime_base_url(monkeypatch)
     monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", fake_runtime_module)
     monkeypatch.setitem(sys.modules, "hermes_state", fake_hermes_state)
 
-    streaming.STREAMS[fake_stream_id] = fake_queue
     try:
+        streaming.STREAMS[fake_stream_id] = fake_queue
         streaming._run_agent_streaming(
             session_id=fake_session.session_id,
             msg_text="hello from picker",
@@ -191,30 +190,24 @@ def test_streaming_passes_target_model_and_prefers_runtime_base_url(monkeypatch)
     assert captured["init_kwargs"]["api_key"] == "rt-key"
 
 
-def test_streaming_reuses_runtime_base_url_helper_in_self_heal_paths():
-    source = (pathlib.Path(__file__).parent.parent / "api" / "streaming.py").read_text(
-        encoding="utf-8"
+def test_runtime_provider_lock_wrapper_forwards_target_model():
+    calls = {}
+
+    def fake_resolver(**kwargs):
+        calls["kwargs"] = kwargs
+        return {"provider": kwargs.get("requested"), "base_url": None, "api_key": None}
+
+    result = api.oauth.resolve_runtime_provider_with_anthropic_env_lock(
+        fake_resolver,
+        requested="opencode-go",
+        target_model="glm-5.1",
     )
-    assert re.search(
-        r"resolved_base_url\s*=\s*_runtime_preferred_base_url\(\s*_rt,\s*resolved_provider,\s*configured_base_url\s*\)",
-        source,
-    )
-    assert len(
-        re.findall(
-            r"resolved_base_url\s*=\s*_runtime_preferred_base_url\(\s*_heal_rt,\s*resolved_provider,\s*configured_base_url\s*\)",
-            source,
-        )
-    ) == 2
-    assert len(
-        re.findall(
-            r"_attempt_credential_self_heal\(\s*resolved_provider\s+or\s+['\"]{2},\s*session_id,\s*_agent_lock,\s*target_model=resolved_model,\s*\)",
-            source,
-        )
-    ) == 2
-    assert re.search(
-        r"resolve_runtime_provider_with_anthropic_env_lock\(\s*resolve_runtime_provider,\s*requested=provider_id,\s*target_model=target_model,\s*\)",
-        source,
-    )
+
+    assert result["provider"] == "opencode-go"
+    assert calls["kwargs"] == {
+        "requested": "opencode-go",
+        "target_model": "glm-5.1",
+    }
 
 
 def test_attempt_credential_self_heal_passes_target_model(monkeypatch):

--- a/tests/test_issue3895_opencode_go_model_picker.py
+++ b/tests/test_issue3895_opencode_go_model_picker.py
@@ -1,0 +1,184 @@
+"""Regression tests for OpenCode-Go model-picker runtime routing (#3895)."""
+
+import pathlib
+import queue
+import sys
+import types
+from unittest import mock
+
+import api.oauth
+import api.streaming as streaming
+
+
+def test_runtime_preferred_base_url_uses_runtime_value_for_pooled_provider():
+    assert streaming._runtime_preferred_base_url(
+        {"provider": "opencode-go", "base_url": "https://opencode.example.com/api"},
+        "opencode-go",
+        "https://opencode.example.com/api/v1",
+    ) == "https://opencode.example.com/api"
+
+
+def test_runtime_preferred_base_url_keeps_custom_config_base_url():
+    assert streaming._runtime_preferred_base_url(
+        {"provider": "custom:opencode-proxy", "base_url": "https://runtime.example.com"},
+        "custom:opencode-proxy",
+        "https://config.example.com/v1",
+    ) == "https://config.example.com/v1"
+
+
+def test_streaming_passes_target_model_and_prefers_runtime_base_url(monkeypatch):
+    captured = {}
+
+    class FakeSession:
+        def __init__(self):
+            self.session_id = "sess-3895"
+            self.title = "OpenCode test"
+            self.workspace = "/tmp"
+            self.model = "glm-5.1"
+            self.messages = []
+            self.personality = None
+            self.input_tokens = 0
+            self.output_tokens = 0
+            self.estimated_cost = None
+            self.tool_calls = []
+            self.active_stream_id = None
+            self.pending_user_message = None
+            self.pending_attachments = []
+            self.pending_started_at = None
+
+        def save(self, touch_updated_at=True):
+            self._saved = touch_updated_at
+
+        def compact(self):
+            return {
+                "session_id": self.session_id,
+                "title": self.title,
+                "workspace": self.workspace,
+                "model": self.model,
+                "created_at": 0,
+                "updated_at": 0,
+                "pinned": False,
+                "archived": False,
+                "project_id": None,
+                "profile": None,
+                "input_tokens": self.input_tokens,
+                "output_tokens": self.output_tokens,
+                "estimated_cost": self.estimated_cost,
+                "personality": self.personality,
+            }
+
+    class CapturingAgent:
+        def __init__(
+            self,
+            model=None,
+            provider=None,
+            base_url=None,
+            api_key=None,
+            platform=None,
+            quiet_mode=False,
+            enabled_toolsets=None,
+            fallback_model=None,
+            session_id=None,
+            session_db=None,
+            stream_delta_callback=None,
+            reasoning_callback=None,
+            tool_progress_callback=None,
+            clarify_callback=None,
+            **kwargs,
+        ):
+            captured["init_kwargs"] = {
+                "model": model,
+                "provider": provider,
+                "base_url": base_url,
+                "api_key": api_key,
+                "session_id": session_id,
+                "session_db": session_db,
+            }
+            self.session_id = session_id
+            self.context_compressor = None
+            self.session_prompt_tokens = 0
+            self.session_completion_tokens = 0
+            self.session_estimated_cost_usd = None
+            self.reasoning_config = None
+            self.ephemeral_system_prompt = None
+            self._last_error = None
+
+        def run_conversation(self, **kwargs):
+            captured["run_kwargs"] = kwargs
+            return {
+                "messages": [
+                    {"role": "user", "content": kwargs["persist_user_message"]},
+                    {"role": "assistant", "content": "ok"},
+                ]
+            }
+
+        def interrupt(self, _message):
+            captured["interrupted"] = _message
+
+    fake_session = FakeSession()
+    fake_stream_id = "stream-3895"
+    fake_session.active_stream_id = fake_stream_id
+    fake_queue = queue.Queue()
+    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
+    resolve_runtime_provider = mock.Mock(
+        return_value={
+            "provider": "opencode-go",
+            "base_url": "https://opencode.example.com/api",
+            "api_key": "rt-key",
+        }
+    )
+    fake_runtime_module.resolve_runtime_provider = resolve_runtime_provider
+    fake_hermes_cli = types.ModuleType("hermes_cli")
+    fake_hermes_cli.runtime_provider = fake_runtime_module
+    fake_hermes_state = types.ModuleType("hermes_state")
+    fake_hermes_state.SessionDB = mock.Mock(return_value=object())
+
+    def fake_runtime_lock(resolver, **kwargs):
+        return resolver(**kwargs)
+
+    monkeypatch.setattr(
+        api.oauth,
+        "resolve_runtime_provider_with_anthropic_env_lock",
+        fake_runtime_lock,
+    )
+    monkeypatch.setattr(streaming, "get_session", lambda _session_id: fake_session)
+    monkeypatch.setattr(streaming, "_get_ai_agent", lambda: CapturingAgent)
+    monkeypatch.setattr(
+        streaming,
+        "resolve_model_provider",
+        lambda *_args, **_kwargs: (
+            "glm-5.1",
+            "opencode-go",
+            "https://opencode.example.com/api/v1",
+        ),
+    )
+    monkeypatch.setattr("api.config.get_config", lambda: {})
+    monkeypatch.setattr("api.config._resolve_cli_toolsets", lambda *_args, **_kwargs: [])
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", fake_runtime_module)
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_hermes_state)
+
+    streaming.STREAMS[fake_stream_id] = fake_queue
+    streaming._run_agent_streaming(
+        session_id=fake_session.session_id,
+        msg_text="hello from picker",
+        model="glm-5.1",
+        workspace="/tmp",
+        stream_id=fake_stream_id,
+    )
+
+    resolve_runtime_provider.assert_called_once_with(
+        requested="opencode-go",
+        target_model="glm-5.1",
+    )
+    assert captured["init_kwargs"]["provider"] == "opencode-go"
+    assert captured["init_kwargs"]["base_url"] == "https://opencode.example.com/api"
+    assert captured["init_kwargs"]["api_key"] == "rt-key"
+
+
+def test_streaming_reuses_runtime_base_url_helper_in_self_heal_paths():
+    source = (pathlib.Path(__file__).parent.parent / "api" / "streaming.py").read_text(
+        encoding="utf-8"
+    )
+    assert source.count("_runtime_preferred_base_url(") == 4
+

--- a/tests/test_issue3895_opencode_go_model_picker.py
+++ b/tests/test_issue3895_opencode_go_model_picker.py
@@ -26,6 +26,14 @@ def test_runtime_preferred_base_url_keeps_custom_config_base_url():
     ) == "https://config.example.com/v1"
 
 
+def test_runtime_preferred_base_url_uses_runtime_for_custom_provider_without_config():
+    assert streaming._runtime_preferred_base_url(
+        {"provider": "custom:opencode-proxy", "base_url": "https://runtime.example.com"},
+        "custom:opencode-proxy",
+        None,
+    ) == "https://runtime.example.com"
+
+
 def test_streaming_passes_target_model_and_prefers_runtime_base_url(monkeypatch):
     captured = {}
 
@@ -159,13 +167,16 @@ def test_streaming_passes_target_model_and_prefers_runtime_base_url(monkeypatch)
     monkeypatch.setitem(sys.modules, "hermes_state", fake_hermes_state)
 
     streaming.STREAMS[fake_stream_id] = fake_queue
-    streaming._run_agent_streaming(
-        session_id=fake_session.session_id,
-        msg_text="hello from picker",
-        model="glm-5.1",
-        workspace="/tmp",
-        stream_id=fake_stream_id,
-    )
+    try:
+        streaming._run_agent_streaming(
+            session_id=fake_session.session_id,
+            msg_text="hello from picker",
+            model="glm-5.1",
+            workspace="/tmp",
+            stream_id=fake_stream_id,
+        )
+    finally:
+        streaming.STREAMS.pop(fake_stream_id, None)
 
     resolve_runtime_provider.assert_called_once_with(
         requested="opencode-go",
@@ -180,5 +191,6 @@ def test_streaming_reuses_runtime_base_url_helper_in_self_heal_paths():
     source = (pathlib.Path(__file__).parent.parent / "api" / "streaming.py").read_text(
         encoding="utf-8"
     )
-    assert source.count("_runtime_preferred_base_url(") == 4
-
+    assert "resolved_base_url = _runtime_preferred_base_url(\n                    _rt, resolved_provider, configured_base_url\n                )" in source
+    assert "resolved_base_url = _runtime_preferred_base_url(\n                                _heal_rt, resolved_provider, configured_base_url\n                            )" in source
+    assert "resolved_base_url = _runtime_preferred_base_url(\n                        _heal_rt, resolved_provider, configured_base_url\n                    )" in source

--- a/tests/test_issue3895_opencode_go_model_picker.py
+++ b/tests/test_issue3895_opencode_go_model_picker.py
@@ -2,6 +2,7 @@
 
 import pathlib
 import queue
+import re
 import sys
 import types
 from unittest import mock
@@ -191,6 +192,23 @@ def test_streaming_reuses_runtime_base_url_helper_in_self_heal_paths():
     source = (pathlib.Path(__file__).parent.parent / "api" / "streaming.py").read_text(
         encoding="utf-8"
     )
-    assert "resolved_base_url = _runtime_preferred_base_url(\n                    _rt, resolved_provider, configured_base_url\n                )" in source
-    assert "resolved_base_url = _runtime_preferred_base_url(\n                                _heal_rt, resolved_provider, configured_base_url\n                            )" in source
-    assert "resolved_base_url = _runtime_preferred_base_url(\n                        _heal_rt, resolved_provider, configured_base_url\n                    )" in source
+    assert re.search(
+        r"resolved_base_url\s*=\s*_runtime_preferred_base_url\(\s*_rt,\s*resolved_provider,\s*configured_base_url\s*\)",
+        source,
+    )
+    assert len(
+        re.findall(
+            r"resolved_base_url\s*=\s*_runtime_preferred_base_url\(\s*_heal_rt,\s*resolved_provider,\s*configured_base_url\s*\)",
+            source,
+        )
+    ) == 2
+    assert len(
+        re.findall(
+            r"_attempt_credential_self_heal\(\s*resolved_provider\s+or\s+['\"]{2},\s*session_id,\s*_agent_lock,\s*target_model=resolved_model,\s*\)",
+            source,
+        )
+    ) == 2
+    assert re.search(
+        r"resolve_runtime_provider_with_anthropic_env_lock\(\s*resolve_runtime_provider,\s*requested=provider_id,\s*target_model=target_model,\s*\)",
+        source,
+    )

--- a/tests/test_issue3895_opencode_go_model_picker.py
+++ b/tests/test_issue3895_opencode_go_model_picker.py
@@ -1,6 +1,5 @@
 """Regression tests for OpenCode-Go model-picker runtime routing (#3895)."""
 
-import pathlib
 import queue
 import sys
 import threading

--- a/tests/test_issue3895_opencode_go_model_picker.py
+++ b/tests/test_issue3895_opencode_go_model_picker.py
@@ -4,9 +4,11 @@ import pathlib
 import queue
 import re
 import sys
+import threading
 import types
 from unittest import mock
 
+import api.config
 import api.oauth
 import api.streaming as streaming
 
@@ -178,6 +180,7 @@ def test_streaming_passes_target_model_and_prefers_runtime_base_url(monkeypatch)
         )
     finally:
         streaming.STREAMS.pop(fake_stream_id, None)
+        streaming.AGENT_INSTANCES.pop(fake_stream_id, None)
 
     resolve_runtime_provider.assert_called_once_with(
         requested="opencode-go",
@@ -212,3 +215,64 @@ def test_streaming_reuses_runtime_base_url_helper_in_self_heal_paths():
         r"resolve_runtime_provider_with_anthropic_env_lock\(\s*resolve_runtime_provider,\s*requested=provider_id,\s*target_model=target_model,\s*\)",
         source,
     )
+
+
+def test_attempt_credential_self_heal_passes_target_model(monkeypatch):
+    calls = {}
+    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
+
+    def fake_resolve_runtime_provider(**kwargs):
+        calls["resolver_kwargs"] = kwargs
+        return {
+            "provider": kwargs.get("requested"),
+            "base_url": "https://opencode.example.com/api",
+            "api_key": "rt-key",
+        }
+
+    fake_runtime_module.resolve_runtime_provider = fake_resolve_runtime_provider
+
+    def fake_runtime_lock(resolver, **kwargs):
+        calls["lock_kwargs"] = kwargs
+        return resolver(**kwargs)
+
+    closed = []
+    monkeypatch.setattr(api.oauth, "read_auth_json", lambda: {"providers": {"opencode-go": {}}})
+    monkeypatch.setattr(
+        api.oauth,
+        "resolve_runtime_provider_with_anthropic_env_lock",
+        fake_runtime_lock,
+    )
+    monkeypatch.setattr(
+        api.config,
+        "SESSION_AGENT_CACHE",
+        {"sess-3895": object()},
+    )
+    monkeypatch.setattr(api.config, "SESSION_AGENT_CACHE_LOCK", threading.Lock())
+    monkeypatch.setattr(api.config, "invalidate_credential_pool_cache", lambda provider_id: calls.setdefault("invalidated", []).append(provider_id))
+    monkeypatch.setattr(
+        streaming,
+        "_close_cached_agent_entry_at_session_boundary",
+        lambda session_id, entry: closed.append((session_id, entry)),
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", fake_runtime_module)
+
+    result = streaming._attempt_credential_self_heal(
+        "opencode-go",
+        "sess-3895",
+        None,
+        target_model="glm-5.1",
+    )
+
+    assert result["base_url"] == "https://opencode.example.com/api"
+    assert calls["lock_kwargs"] == {
+        "requested": "opencode-go",
+        "target_model": "glm-5.1",
+    }
+    assert calls["resolver_kwargs"] == {
+        "requested": "opencode-go",
+        "target_model": "glm-5.1",
+    }
+    assert calls["invalidated"] == ["opencode-go"]
+    assert len(closed) == 1
+    assert closed[0][0] == "sess-3895"
+    assert api.config.SESSION_AGENT_CACHE == {}


### PR DESCRIPTION

## Thinking Path

- The agent-side contract already supports this flow correctly; WebUI streaming is the one remaining resolver call that omits `target_model`, so it can derive OpenCode api-mode from the wrong model.
- Fixing only the missing kwarg is not enough, because the raw config `base_url` still shadows the runtime-normalized value whenever it is already truthy.
- The clean version is to treat the runtime provider as authoritative for pooled-provider base-url normalization, while preserving config ownership for `custom:*` endpoints.

## What Changed

- `api/streaming.py`: pass `target_model=resolved_model` into the runtime resolver, centralize the `base_url` precedence rule, and carry the original configured fallback through both self-heal retry paths.
- `tests/test_issue3895_opencode_go_model_picker.py`: add focused regression coverage for the missing kwarg, pooled-vs-custom `base_url` precedence, credential self-heal runtime resolution, and the real lock-wrapper pass-through contract.

## Why It Matters

Picker-selected OpenCode-Go models stop inheriting the stale default model's routing semantics, so WebUI can hit the same runtime-normalized endpoint shape that already works in the TUI. The fix also avoids baking an OpenCode-only allowlist into base-url precedence, which makes the behavior safer for future pooled providers.

## Verification

```cmd
pytest tests/test_issue3895_opencode_go_model_picker.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- `custom:*` endpoint ownership must remain with config; the new precedence rule should not let pooled-runtime normalization override named custom providers.
- If upstream runtime-provider metadata changes how pooled sources are identified, the precedence helper may need a narrow follow-up.

## Model Used

GPT 5.5 via Codex CLI
