### PR TITLE
[security] fix(auth): bind active profile cookie to session

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -467,6 +467,47 @@ def _session_token_from_cookie_value(cookie_value: str) -> str | None:
     return token or None
 
 
+def sign_profile_cookie_value(profile_name: str, session_cookie_value: str | None) -> str:
+    """Return a profile cookie value authenticated for one WebUI session.
+
+    The active-profile cookie is client-controlled, so when auth is enabled it
+    must not be trusted as a bare profile name. Binding the selected profile to
+    the HttpOnly session token prevents a client from forging
+    ``hermes_profile=<other-profile>`` and bypassing profile visibility guards.
+    """
+    if not session_cookie_value or not verify_session(session_cookie_value):
+        raise ValueError("active auth session is required to sign profile cookie")
+    token = _session_token_from_cookie_value(session_cookie_value)
+    if not token:
+        raise ValueError("active auth session is required to sign profile cookie")
+    sig = hmac.new(
+        _signing_key(),
+        f"profile:{token}:{profile_name}".encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{profile_name}.{sig}"
+
+
+def verify_profile_cookie_value(cookie_value: str, session_cookie_value: str | None) -> str | None:
+    """Verify a session-bound profile cookie and return its profile name."""
+    if not cookie_value or '.' not in cookie_value:
+        return None
+    if not session_cookie_value or not verify_session(session_cookie_value):
+        return None
+    profile_name, sig = cookie_value.rsplit('.', 1)
+    token = _session_token_from_cookie_value(session_cookie_value)
+    if not profile_name or not token or not sig:
+        return None
+    expected = hmac.new(
+        _signing_key(),
+        f"profile:{token}:{profile_name}".encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    if hmac.compare_digest(str(sig), expected):
+        return profile_name
+    return None
+
+
 def csrf_token_for_session(cookie_value: str) -> str | None:
     """Return the CSRF token bound to an authenticated WebUI session.
 

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -503,7 +503,14 @@ def get_profile_cookie_name() -> str:
 
 
 def get_profile_cookie(handler) -> str | None:
-    """Extract the active-profile cookie value from the request, or None."""
+    """Extract and authenticate the active-profile cookie value.
+
+    When WebUI auth is enabled, the profile cookie is treated as an
+    authorization input for profile-scoped routes. Require it to be signed for
+    the current auth session so clients cannot forge ``hermes_profile`` to
+    impersonate another profile. In no-auth deployments, keep the historical
+    plain profile-name cookie behavior.
+    """
     cookie_header = handler.headers.get('Cookie', '')
     if not cookie_header:
         return None
@@ -515,16 +522,30 @@ def get_profile_cookie(handler) -> str | None:
         return None
     cookie_name = get_profile_cookie_name()
     morsel = cookie.get(cookie_name)
-    if morsel and morsel.value:
-        # Validate against profile-name pattern before trusting
-        from api.profiles import _PROFILE_ID_RE
-        val = morsel.value
-        if val == 'default' or _PROFILE_ID_RE.fullmatch(val):
-            return val
-    return None
+    if not (morsel and morsel.value):
+        return None
+
+    from api.profiles import _PROFILE_ID_RE
+
+    def _valid_profile_name(val: str) -> bool:
+        return val == 'default' or bool(_PROFILE_ID_RE.fullmatch(val))
+
+    raw_val = morsel.value
+    try:
+        from api.auth import is_auth_enabled, parse_cookie, verify_profile_cookie_value
+        if is_auth_enabled():
+            val = verify_profile_cookie_value(raw_val, parse_cookie(handler))
+            return val if val and _valid_profile_name(val) else None
+    except Exception:
+        logger.warning("Failed to verify active profile cookie", exc_info=True)
+        return None
+
+    # No-auth mode: the cookie is a per-browser UI preference, not an authz
+    # boundary, so retain the legacy plain profile-name format.
+    return raw_val if _valid_profile_name(raw_val) else None
 
 
-def build_profile_cookie(name: str) -> str:
+def build_profile_cookie(name: str, handler=None) -> str:
     """Build a Set-Cookie header value for the active-profile cookie.
 
     Always persist the selected profile in the cookie, including 'default'.
@@ -539,7 +560,16 @@ def build_profile_cookie(name: str) -> str:
     import http.cookies as _hc
     cookie = _hc.SimpleCookie()
     cookie_name = get_profile_cookie_name()
-    cookie[cookie_name] = name
+    value = name
+    if handler is not None:
+        try:
+            from api.auth import is_auth_enabled, parse_cookie, sign_profile_cookie_value
+            if is_auth_enabled():
+                value = sign_profile_cookie_value(name, parse_cookie(handler))
+        except Exception as exc:
+            logger.warning("Failed to sign active profile cookie", exc_info=True)
+            raise RuntimeError("could not sign active profile cookie") from exc
+    cookie[cookie_name] = value
     cookie[cookie_name]['path'] = '/'
     cookie[cookie_name]['httponly'] = True
     cookie[cookie_name]['samesite'] = 'Lax'

--- a/api/routes.py
+++ b/api/routes.py
@@ -8320,7 +8320,7 @@ def handle_post(handler, parsed) -> bool:
             from api.config import invalidate_models_cache
             invalidate_models_cache()
             return j(handler, result, extra_headers={
-                'Set-Cookie': build_profile_cookie(name),
+                'Set-Cookie': build_profile_cookie(name, handler),
             })
         except (ValueError, FileNotFoundError) as e:
             return bad(handler, _sanitize_error(e), 404)

--- a/tests/test_issue803.py
+++ b/tests/test_issue803.py
@@ -45,21 +45,108 @@ class TestProfileCookieHelpers:
         handler.headers.get = lambda k, d='': ''
         assert get_profile_cookie(handler) is None
 
-    def test_get_profile_cookie_extracts_valid_name(self):
+    def test_get_profile_cookie_extracts_valid_name(self, monkeypatch):
         from api.helpers import get_profile_cookie
+        monkeypatch.setattr('api.auth.is_auth_enabled', lambda: False)
         handler = MagicMock()
         handler.headers.get = lambda k, d='': 'hermes_profile=alice' if k == 'Cookie' else d
         assert get_profile_cookie(handler) == 'alice'
 
-    def test_get_profile_cookie_accepts_default(self):
+    def test_get_profile_cookie_requires_session_bound_signature_when_auth_enabled(self, monkeypatch):
+        from api.auth import sign_profile_cookie_value
         from api.helpers import get_profile_cookie
+
+        session_cookie = 'session-token.session-sig'
+        monkeypatch.setattr('api.auth.is_auth_enabled', lambda: True)
+        monkeypatch.setattr('api.auth.verify_session', lambda cookie: cookie == session_cookie)
+        signed_profile = sign_profile_cookie_value('alice', session_cookie)
+
+        handler = MagicMock()
+        handler.headers.get = lambda k, d='': (
+            f'hermes_session={session_cookie}; hermes_profile={signed_profile}' if k == 'Cookie' else d
+        )
+        assert get_profile_cookie(handler) == 'alice'
+
+    def test_get_profile_cookie_rejects_unsigned_profile_when_auth_enabled(self, monkeypatch):
+        from api.helpers import get_profile_cookie
+
+        monkeypatch.setattr('api.auth.is_auth_enabled', lambda: True)
+        handler = MagicMock()
+        handler.headers.get = lambda k, d='': (
+            'hermes_session=session-token.session-sig; hermes_profile=alice' if k == 'Cookie' else d
+        )
+        assert get_profile_cookie(handler) is None
+
+    def test_get_profile_cookie_rejects_profile_signed_for_another_session(self, monkeypatch):
+        from api.auth import sign_profile_cookie_value
+        from api.helpers import get_profile_cookie
+
+        other_session = 'other-token.other-sig'
+        current_session = 'session-token.session-sig'
+        monkeypatch.setattr('api.auth.verify_session', lambda cookie: cookie in {other_session, current_session})
+        signed_profile = sign_profile_cookie_value('alice', other_session)
+        monkeypatch.setattr('api.auth.is_auth_enabled', lambda: True)
+        handler = MagicMock()
+        handler.headers.get = lambda k, d='': (
+            f'hermes_session={current_session}; hermes_profile={signed_profile}' if k == 'Cookie' else d
+        )
+        assert get_profile_cookie(handler) is None
+
+    def test_build_profile_cookie_binds_to_auth_session_when_auth_enabled(self, monkeypatch):
+        from api.auth import verify_profile_cookie_value
+        from api.helpers import build_profile_cookie
+
+        session_cookie = 'session-token.session-sig'
+        monkeypatch.setattr('api.auth.is_auth_enabled', lambda: True)
+        monkeypatch.setattr('api.auth.verify_session', lambda cookie: cookie == session_cookie)
+        handler = MagicMock()
+        handler.headers.get = lambda k, d='': f'hermes_session={session_cookie}' if k == 'Cookie' else d
+
+        cookie = build_profile_cookie('alice', handler)
+        value = cookie.split('hermes_profile=', 1)[1].split(';', 1)[0]
+        assert value != 'alice'
+        assert verify_profile_cookie_value(value, session_cookie) == 'alice'
+
+    def test_sign_profile_cookie_requires_active_session(self, monkeypatch):
+        from api.auth import sign_profile_cookie_value
+
+        monkeypatch.setattr('api.auth.verify_session', lambda cookie: False)
+        with pytest.raises(ValueError):
+            sign_profile_cookie_value('alice', 'expired-token.session-sig')
+
+    def test_verify_profile_cookie_rejects_expired_session(self, monkeypatch):
+        from api.auth import sign_profile_cookie_value, verify_profile_cookie_value
+
+        session_cookie = 'session-token.session-sig'
+        monkeypatch.setattr('api.auth.verify_session', lambda cookie: True)
+        signed_profile = sign_profile_cookie_value('alice', session_cookie)
+
+        monkeypatch.setattr('api.auth.verify_session', lambda cookie: False)
+        assert verify_profile_cookie_value(signed_profile, session_cookie) is None
+
+    def test_build_profile_cookie_fails_closed_when_auth_session_missing(self, monkeypatch, caplog):
+        from api.helpers import build_profile_cookie
+
+        monkeypatch.setattr('api.auth.is_auth_enabled', lambda: True)
+        monkeypatch.setattr('api.auth.verify_session', lambda cookie: False)
+        handler = MagicMock()
+        handler.headers.get = lambda k, d='': ''
+
+        with pytest.raises(RuntimeError):
+            build_profile_cookie('alice', handler)
+        assert 'Failed to sign active profile cookie' in caplog.text
+
+    def test_get_profile_cookie_accepts_default(self, monkeypatch):
+        from api.helpers import get_profile_cookie
+        monkeypatch.setattr('api.auth.is_auth_enabled', lambda: False)
         handler = MagicMock()
         handler.headers.get = lambda k, d='': 'hermes_profile=default' if k == 'Cookie' else d
         assert get_profile_cookie(handler) == 'default'
 
-    def test_get_profile_cookie_rejects_injection(self):
+    def test_get_profile_cookie_rejects_injection(self, monkeypatch):
         """Cookie value must pass _PROFILE_ID_RE fullmatch — rejects traversal/injection."""
         from api.helpers import get_profile_cookie
+        monkeypatch.setattr('api.auth.is_auth_enabled', lambda: False)
         for bad in ('../etc', 'a/b', 'name;DROP', 'WithCaps', 'has space', '.hidden'):
             handler = MagicMock()
             handler.headers.get = lambda k, d='', v=bad: f'hermes_profile={v}' if k == 'Cookie' else d
@@ -85,6 +172,7 @@ class TestProfileCookieHelpers:
         from api.helpers import build_profile_cookie, get_profile_cookie
 
         monkeypatch.setenv('WEBUI_PROFILE_COOKIE_NAME', 'hermes_profile_social')
+        monkeypatch.setattr('api.auth.is_auth_enabled', lambda: False)
 
         s = build_profile_cookie('writer')
         assert 'hermes_profile_social=writer' in s
@@ -100,6 +188,7 @@ class TestProfileCookieHelpers:
         from api.helpers import get_profile_cookie
 
         monkeypatch.setenv('WEBUI_PROFILE_COOKIE_NAME', 'hermes_profile_main')
+        monkeypatch.setattr('api.auth.is_auth_enabled', lambda: False)
 
         handler = MagicMock()
         handler.headers.get = lambda k, d='': 'hermes_profile=social_profile' if k == 'Cookie' else d


### PR DESCRIPTION
## Thinking Path

- PR #3999 scopes session-by-id behavior to the active profile.
- That guard is only effective if the active profile is derived from trusted state.
- The current request profile was still accepted from a bare `hermes_profile` cookie value.
- This PR keeps the active-profile UX cookie, but authenticates it against the current WebUI auth session before it can influence profile-scoped authorization.
- The result is a narrow defense-in-depth fix for profile isolation without adding frontend infrastructure or changing the no-auth local preference behavior.

## Summary

This PR hardens the active-profile trust boundary used by the profile-scoped session guards added in #3999.

- Binds `hermes_profile` to the current `hermes_session` when WebUI auth is enabled.
- Rejects unsigned or cross-session profile cookies before they can set request-local profile state.
- Keeps the legacy plain profile-name cookie behavior for no-auth deployments, where the cookie is only a per-browser UI preference.
- Adds regression coverage for forged, valid, and wrong-session profile cookie values.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Client-controlled active profile cookie can influence profile-scoped authorization | An authenticated client could forge `hermes_profile=<target-profile>` and make guarded session/file operations evaluate under another profile | High if profiles isolate users, tenants, workspaces, sessions, secrets, or API-key-backed state; Medium/hardening if profiles are only a local trusted-user convenience |

## Before this PR

- The server accepted the active profile from the `hermes_profile` request cookie.
- `get_profile_cookie()` validated the value syntactically, but did not authenticate it or bind it to the logged-in WebUI session.
- Profile visibility guards could therefore rely on an attacker-selectable active profile.
- Tests covered plain cookie parsing, but not forged authenticated-session profile selection.

## After this PR

- Auth-enabled deployments require the profile cookie value to be signed for the current `hermes_session` token.
- Unsigned profile cookies are ignored when auth is enabled.
- Profile cookies signed for another session are ignored when auth is enabled.
- `/api/profile/switch` emits the session-bound profile cookie format when auth is enabled.
- No-auth deployments keep the existing plain cookie behavior for local UI preference compatibility.

## Why this matters

Profiles are used as a security-sensitive boundary by the new session visibility checks. If the server trusts a raw browser cookie as the authorization input for that boundary, any authenticated client can choose the profile that the guard evaluates against.

That weakens the intended isolation added by #3999: the guard may be present and called correctly, but it can still be evaluated under attacker-supplied profile state.

## How this differs from related issue/PR

This is related to #3999, but it is not the same issue as “session-by-id endpoints missing active-profile guards.”

- #3999 adds or centralizes the active-profile checks on session-by-id paths.
- This PR hardens the trust source used by those checks.
- The failure mode here is not a missing guard call site; it is that a correctly called guard can be bypassed when its active-profile input comes from an unauthenticated, client-controlled cookie.
- Both layers matter: endpoints need the guard, and the guard needs trusted profile state.

## Attack flow

```text
Authenticated WebUI client
    -> sends a valid auth session cookie
        -> forges Cookie: hermes_profile=<target-profile>
            -> request-local active profile is set from the forged value
                -> profile-scoped session/file guard evaluates under attacker-selected profile
                    -> cross-profile session/file access may be allowed
```

## Affected code

| Issue | Files |
|-------|-------|
| Client-controlled active profile cookie can influence authorization | `server.py`, `api/helpers.py`, `api/routes.py`, `api/auth.py` |

## Root cause

Issue: client-controlled active profile cookie can influence profile-scoped authorization

- `server.py` sets request-local profile state from `get_profile_cookie(handler)` before route handling.
- `get_profile_cookie()` previously accepted any syntactically valid profile name from the `hermes_profile` cookie.
- `api/routes.py` profile visibility checks compare target session metadata against the request-local active profile.
- That made a UI preference cookie part of an authorization decision without authenticating it against the active WebUI session.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Client-controlled active profile cookie can influence profile-scoped authorization | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N` |

Rationale:

- The attacker must already be authenticated to WebUI.
- The exploit is network-reachable in WebUI deployments and does not require user interaction.
- If profiles isolate sensitive sessions, files, API-backed state, or workspace data, the impact is cross-profile confidentiality and integrity loss.
- If a deployment treats all profiles as the same fully trusted local user, the practical severity is lower and this becomes defense-in-depth hardening.

## Safe reproduction steps

1. Enable WebUI auth and create or use two profiles, for example `alice` and `bob`.
2. Create or identify a session/file operation that should only be visible while `bob` is the active authorized profile.
3. Authenticate as a WebUI client with a valid `hermes_session`.
4. On vulnerable code, send the guarded request with a forged plain profile cookie:

   ```http
   Cookie: hermes_session=<valid-session>; hermes_profile=bob
   ```

5. Observe that the active-profile guard can evaluate the request under `bob` because the cookie value is accepted as request-local profile state.
6. With this PR, the same unsigned `hermes_profile=bob` value is ignored when auth is enabled, and a value signed for a different session is also ignored.

## Expected vulnerable behavior

- A bare client-controlled `hermes_profile` value should never determine the profile used for authorization.
- Pre-patch auth-enabled requests could still supply a plain profile name in the cookie.
- The safe proof signal is that unsigned and cross-session profile cookies now return `None` from `get_profile_cookie()` when auth is enabled.

## Changes in this PR

- Adds `sign_profile_cookie_value()` and `verify_profile_cookie_value()` helpers in `api/auth.py`.
- Binds the profile cookie signature to the raw authenticated session token.
- Updates `get_profile_cookie()` to require a valid session-bound signature when auth is enabled.
- Preserves existing plain profile cookie parsing for no-auth deployments.
- Updates `build_profile_cookie()` and `/api/profile/switch` so profile switches emit the session-bound cookie in auth-enabled deployments.
- Adds regression tests for valid, unsigned, and wrong-session profile cookies.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Auth helpers | `api/auth.py` | Added session-bound signing and verification helpers for profile cookie values |
| Cookie parsing | `api/helpers.py` | Authenticates `hermes_profile` before returning it when auth is enabled; preserves no-auth legacy behavior |
| Profile switch route | `api/routes.py` | Passes the handler into `build_profile_cookie()` so the Set-Cookie value can be bound to the current session |
| Regression tests | `tests/test_issue803.py` | Covers valid signed profile cookie, unsigned forgery rejection, wrong-session rejection, and emitted signed cookie behavior |

## Maintainer impact

- The patch is intentionally narrow and limited to active-profile cookie trust.
- It does not add new dependencies, frontend build steps, or new storage services.
- No-auth deployments keep the existing plain profile-name cookie behavior.
- Auth-enabled deployments may require users to switch profiles again once after the patch if their browser only has the old unsigned profile cookie.
- The implementation keeps the existing `HttpOnly`, `SameSite=Lax`, path-scoped cookie shape.

## Fix rationale

The active profile can influence which profile-scoped sessions and files are visible. In auth-enabled deployments, that makes it authorization-relevant state. Binding the profile cookie to the authenticated WebUI session keeps the UI preference mechanism while preventing clients from supplying arbitrary profile names across sessions.

The fix is narrow because it changes only the cookie trust boundary and the profile-switch Set-Cookie path. The regression tests lock the security behavior at the helper boundary where request profile state is derived.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Syntax check for touched server modules.
- [x] Focused profile/session regression suite.
- [x] `git diff --check`.
- [ ] Full `pytest tests/ -v --timeout=60` was not run locally; this PR ran the focused profile/session tests that cover the changed code paths.

Executed with:

- `python3 -m py_compile api/auth.py api/helpers.py api/routes.py`
- `python3 -m pytest tests/test_issue803.py tests/test_session_ops.py tests/test_issue1611_session_profile_filtering.py tests/test_profile_switch_ux.py tests/test_profile_switch_1200.py -q`
- `git diff --check`

Result:

- `101 passed, 1 warning`

## Risks / Follow-ups

- Existing auth-enabled browser sessions with an old unsigned `hermes_profile` cookie may fall back to the default/requested server profile until the user switches profiles again.
- This PR does not attempt to redesign profile authorization or add per-user profile ACLs; it only prevents the active-profile guard from trusting an unauthenticated cookie value.
- If profiles are intended to be a stronger multi-user boundary, a follow-up could explicitly bind allowed profile IDs to server-side user/session state.

## Contract Routing

This is a security-sensitive behavior fix in the server/profile-cookie path. It does not intentionally change a documented public contract, RFC, UI flow, or product-semantics document. Evidence used: focused helper and session/profile tests listed in the test plan.

## Model Used

AI-assisted implementation and PR drafting via Hermes Agent using OpenAI GPT-5.5. The final code changes were validated locally with the commands listed above.

## Disclosure notes

- This PR is bounded to the active-profile cookie trust source used by profile-scoped session/file authorization.
- It does not claim unauthenticated reachability; the attacker condition is an already authenticated WebUI client.
- It does not include production testing or real secrets.
- No unrelated files were changed.
