### PR TITLE
refactor(profiles): align profile cookie env var with HERMES_WEBUI_* naming

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -495,11 +495,36 @@ def read_body(handler) -> dict:
 # ── Profile cookie helpers (issue #798) ─────────────────────────────────────
 
 PROFILE_COOKIE_NAME = 'hermes_profile'
+_PROFILE_COOKIE_ENV = 'HERMES_WEBUI_PROFILE_COOKIE_NAME'
+_LEGACY_PROFILE_COOKIE_ENV = 'WEBUI_PROFILE_COOKIE_NAME'
+_legacy_profile_cookie_warned = False
 
 
 def get_profile_cookie_name() -> str:
-    """Return the cookie name used to persist the active WebUI profile."""
-    return os.getenv('WEBUI_PROFILE_COOKIE_NAME', PROFILE_COOKIE_NAME)
+    """Return the cookie name used to persist the active WebUI profile.
+
+    Honours ``HERMES_WEBUI_PROFILE_COOKIE_NAME`` so multiple WebUI instances
+    sharing a hostname (different ports) can use distinct profile-cookie names
+    instead of trampling each other; browsers scope cookies by host, not
+    host+port (RFC 6265). The original ``WEBUI_PROFILE_COOKIE_NAME`` is still
+    honoured as a deprecated fallback (warned once per process, since this is
+    called on every request).
+    """
+    name = os.getenv(_PROFILE_COOKIE_ENV, '').strip()
+    if name:
+        return name
+    legacy = os.getenv(_LEGACY_PROFILE_COOKIE_ENV, '').strip()
+    if legacy:
+        global _legacy_profile_cookie_warned
+        if not _legacy_profile_cookie_warned:
+            logger.warning(
+                '%s is deprecated; use %s instead.',
+                _LEGACY_PROFILE_COOKIE_ENV,
+                _PROFILE_COOKIE_ENV,
+            )
+            _legacy_profile_cookie_warned = True
+        return legacy
+    return PROFILE_COOKIE_NAME
 
 
 def get_profile_cookie(handler) -> str | None:

--- a/tests/test_issue803.py
+++ b/tests/test_issue803.py
@@ -13,6 +13,7 @@ Covers:
   4. switch_profile(process_wide=False) does NOT mutate process globals
   5. Concurrent requests on different threads see independent profiles
 """
+import logging
 import os
 import threading
 from pathlib import Path
@@ -228,6 +229,60 @@ class TestProfileCookieHelpers:
         handler = MagicMock()
         handler.headers.get = lambda k, d='': 'hermes_profile=social_profile' if k == 'Cookie' else d
         assert get_profile_cookie(handler) is None
+
+
+# ── 1b. Profile cookie name resolution (env > legacy env > default) ───────────
+
+class TestProfileCookieNameResolution:
+
+    def test_default_when_unset(self, monkeypatch):
+        from api.helpers import PROFILE_COOKIE_NAME, get_profile_cookie_name
+        monkeypatch.delenv('HERMES_WEBUI_PROFILE_COOKIE_NAME', raising=False)
+        monkeypatch.delenv('WEBUI_PROFILE_COOKIE_NAME', raising=False)
+        assert get_profile_cookie_name() == PROFILE_COOKIE_NAME
+
+    def test_canonical_env_overrides_default(self, monkeypatch):
+        from api.helpers import get_profile_cookie_name
+        monkeypatch.delenv('WEBUI_PROFILE_COOKIE_NAME', raising=False)
+        monkeypatch.setenv('HERMES_WEBUI_PROFILE_COOKIE_NAME', 'hermes_profile_alt')
+        assert get_profile_cookie_name() == 'hermes_profile_alt'
+
+    def test_legacy_env_still_honoured(self, monkeypatch):
+        from api.helpers import get_profile_cookie_name
+        monkeypatch.delenv('HERMES_WEBUI_PROFILE_COOKIE_NAME', raising=False)
+        monkeypatch.setenv('WEBUI_PROFILE_COOKIE_NAME', 'hermes_profile_legacy')
+        assert get_profile_cookie_name() == 'hermes_profile_legacy'
+
+    def test_canonical_takes_precedence_over_legacy(self, monkeypatch):
+        from api.helpers import get_profile_cookie_name
+        monkeypatch.setenv('HERMES_WEBUI_PROFILE_COOKIE_NAME', 'canonical')
+        monkeypatch.setenv('WEBUI_PROFILE_COOKIE_NAME', 'legacy')
+        assert get_profile_cookie_name() == 'canonical'
+
+    def test_blank_canonical_falls_back_to_legacy(self, monkeypatch):
+        from api.helpers import get_profile_cookie_name
+        monkeypatch.setenv('HERMES_WEBUI_PROFILE_COOKIE_NAME', '   ')
+        monkeypatch.setenv('WEBUI_PROFILE_COOKIE_NAME', 'hermes_profile_legacy')
+        assert get_profile_cookie_name() == 'hermes_profile_legacy'
+
+    def test_blank_envs_fall_back_to_default(self, monkeypatch):
+        from api.helpers import PROFILE_COOKIE_NAME, get_profile_cookie_name
+        monkeypatch.setenv('HERMES_WEBUI_PROFILE_COOKIE_NAME', '   ')
+        monkeypatch.setenv('WEBUI_PROFILE_COOKIE_NAME', '')
+        assert get_profile_cookie_name() == PROFILE_COOKIE_NAME
+
+    def test_legacy_deprecation_warns_only_once(self, monkeypatch, caplog):
+        # get_profile_cookie_name() runs on every request, so the deprecation
+        # warning for the legacy env var must be emitted once per process.
+        import api.helpers as helpers
+        monkeypatch.delenv('HERMES_WEBUI_PROFILE_COOKIE_NAME', raising=False)
+        monkeypatch.setenv('WEBUI_PROFILE_COOKIE_NAME', 'hermes_profile_legacy')
+        monkeypatch.setattr(helpers, '_legacy_profile_cookie_warned', False)
+        with caplog.at_level(logging.WARNING, logger='api.helpers'):
+            for _ in range(3):
+                assert helpers.get_profile_cookie_name() == 'hermes_profile_legacy'
+        warned = [r for r in caplog.records if 'deprecated' in r.getMessage()]
+        assert len(warned) == 1
 
 
 # ── 2. Thread-local request context ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Brings the profile-cookie env var in line with the `HERMES_WEBUI_` prefix used by every other WebUI setting, by adding `HERMES_WEBUI_PROFILE_COOKIE_NAME`.
- Keeps `WEBUI_PROFILE_COOKIE_NAME` working as a deprecated alias (logged once when used). Deployments setting it keep working unchanged; the profile cookie has been configurable via that var since #1756.
- Blank or whitespace-only values are now treated as unset and fall back to the default `hermes_profile`. This is the only behavior difference (see Implementation).

## Why
Every other WebUI setting uses the `HERMES_WEBUI_` prefix (`HERMES_WEBUI_HOST`, `HERMES_WEBUI_PORT`, `HERMES_WEBUI_SESSION_TTL`, `HERMES_WEBUI_COOKIE_NAME`, ...). The profile cookie was the lone exception at `WEBUI_PROFILE_COOKIE_NAME` (added in #1756), which is easy to misremember and inconsistent to document.

The profile cookie has been configurable since #1756; #3981 later added the *session* cookie's knob as `HERMES_WEBUI_COOKIE_NAME` with the shared prefix. This PR only brings the older profile env name in line with that convention. It changes naming, not behavior. The functional rationale (multiple WebUI instances on the same host but different ports, where browsers scope cookies by host not host+port per RFC 6265) is unchanged and documented in the `get_profile_cookie_name` docstring.

## Implementation
- `get_profile_cookie_name()` resolves `HERMES_WEBUI_PROFILE_COOKIE_NAME` > `WEBUI_PROFILE_COOKIE_NAME` (deprecated) > default `hermes_profile`.
- Blank/whitespace values are treated as unset, matching `_resolve_cookie_name()` in `api/auth.py`.
- Using the legacy name logs a one-line deprecation warning naming the replacement; behaviour is otherwise unchanged.

## Testing
- `pytest tests/test_issue803.py -v` (profile cookie + new resolution tests) passes.
- Ran the wider `pytest tests/` suite locally; unrelated failures are environment-only (`test_passkey_auth.py` needs `cryptography`; `test_workspace_git.py` needs a git fixture environment).
