### PR TITLE
fix(composer): coalesce composer auto-resize reflows (#4042)

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -1288,6 +1288,7 @@ $('modelSelect').onchange=async()=>{
   }
 };
 $('msg').addEventListener('input',()=>{
+  updateSendBtn();
   scheduleComposerAutoResize();
   // Persist composer draft to server (debounced in _saveComposerDraft).
   const sid = S && S.session && S.session.session_id;

--- a/static/boot.js
+++ b/static/boot.js
@@ -1288,8 +1288,7 @@ $('modelSelect').onchange=async()=>{
   }
 };
 $('msg').addEventListener('input',()=>{
-  autoResize();
-  updateSendBtn();
+  scheduleComposerAutoResize();
   // Persist composer draft to server (debounced in _saveComposerDraft).
   const sid = S && S.session && S.session.session_id;
   if (sid && typeof _saveComposerDraft === 'function') {

--- a/static/messages.js
+++ b/static/messages.js
@@ -3868,7 +3868,17 @@ function transcript(){
   return lines.join('\n');
 }
 
+let _composerAutoResizeRaf=0;
 function autoResize(){const el=$('msg');el.style.height='auto';el.style.height=Math.min(el.scrollHeight,200)+'px';updateSendBtn();}
+function scheduleComposerAutoResize(){
+  updateSendBtn();
+  if(typeof requestAnimationFrame!=='function'){autoResize();return;}
+  if(_composerAutoResizeRaf) return;
+  _composerAutoResizeRaf=requestAnimationFrame(()=>{
+    _composerAutoResizeRaf=0;
+    autoResize();
+  });
+}
 
 
 // ── YOLO mode state ──

--- a/static/messages.js
+++ b/static/messages.js
@@ -3869,9 +3869,17 @@ function transcript(){
 }
 
 let _composerAutoResizeRaf=0;
-function autoResize(){const el=$('msg');el.style.height='auto';el.style.height=Math.min(el.scrollHeight,200)+'px';updateSendBtn();}
-function scheduleComposerAutoResize(){
+function autoResize(){
+  if(_composerAutoResizeRaf && typeof cancelAnimationFrame==='function'){
+    cancelAnimationFrame(_composerAutoResizeRaf);
+    _composerAutoResizeRaf=0;
+  }
+  const el=$('msg');
+  el.style.height='auto';
+  el.style.height=Math.min(el.scrollHeight,200)+'px';
   updateSendBtn();
+}
+function scheduleComposerAutoResize(){
   if(typeof requestAnimationFrame!=='function'){autoResize();return;}
   if(_composerAutoResizeRaf) return;
   _composerAutoResizeRaf=requestAnimationFrame(()=>{

--- a/tests/test_issue4042_typing_lag_autoresize.py
+++ b/tests/test_issue4042_typing_lag_autoresize.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+
+
+def test_composer_autoresize_is_single_flight_per_frame():
+    assert "let _composerAutoResizeRaf=0;" in MESSAGES_JS
+    assert "function scheduleComposerAutoResize()" in MESSAGES_JS
+    assert "if(typeof requestAnimationFrame!=='function'){autoResize();return;}" in MESSAGES_JS
+    assert "if(_composerAutoResizeRaf) return;" in MESSAGES_JS
+    assert "_composerAutoResizeRaf=requestAnimationFrame(()=>{" in MESSAGES_JS
+    assert "_composerAutoResizeRaf=0;" in MESSAGES_JS
+    assert "autoResize();" in MESSAGES_JS
+
+
+def test_composer_input_listener_uses_scheduler_instead_of_direct_reflow():
+    start = BOOT_JS.index("$('msg').addEventListener('input',()=>{")
+    end = BOOT_JS.index("// Persist composer draft to server", start)
+    listener = BOOT_JS[start:end]
+
+    assert "scheduleComposerAutoResize();" in listener
+    assert "autoResize();" not in listener
+    assert "updateSendBtn();" not in listener

--- a/tests/test_issue4042_typing_lag_autoresize.py
+++ b/tests/test_issue4042_typing_lag_autoresize.py
@@ -12,6 +12,7 @@ def test_composer_autoresize_is_single_flight_per_frame():
     assert "if(typeof requestAnimationFrame!=='function'){autoResize();return;}" in MESSAGES_JS
     assert "if(_composerAutoResizeRaf) return;" in MESSAGES_JS
     assert "_composerAutoResizeRaf=requestAnimationFrame(()=>{" in MESSAGES_JS
+    assert "cancelAnimationFrame(_composerAutoResizeRaf);" in MESSAGES_JS
     assert "_composerAutoResizeRaf=0;" in MESSAGES_JS
     assert "autoResize();" in MESSAGES_JS
 
@@ -23,4 +24,4 @@ def test_composer_input_listener_uses_scheduler_instead_of_direct_reflow():
 
     assert "scheduleComposerAutoResize();" in listener
     assert "autoResize();" not in listener
-    assert "updateSendBtn();" not in listener
+    assert "updateSendBtn();" in listener


### PR DESCRIPTION
## Thinking Path

- Current `origin/master` still expands the message render window after completed turns and some jump or refresh paths, so long sessions can leave the full transcript DOM materialized.
- The typing regression comes from the composer path, not from `renderMessages()` itself: `static/boot.js` fires `autoResize()` on every keystroke, and `autoResize()` forces a synchronous layout by reading `scrollHeight`.
- Open PR `#3714` already covers the broader transcript virtualization surface in `static/ui.js`, so this fix stays narrow and removes the per-keystroke hot path without taking on that overlapping design.

## What Changed

- `static/messages.js`: add a single-flight composer auto-resize scheduler that coalesces repeated input events into one `autoResize()` per animation frame while keeping direct `autoResize()` calls synchronous for programmatic composer updates.
- `static/boot.js`: route the composer `input` listener through the scheduled helper and remove any duplicate send-button work that is no longer needed.
- `tests/test_issue4042_typing_lag_autoresize.py`: add focused regression coverage for the scheduling contract and the new input-listener wiring.

## Why It Matters

This removes the main-thread reflow tax from each keystroke in long conversations without changing the broader transcript-windowing behavior on current master. Users get responsive typing back while the wider virtualization work can continue independently.

## Verification

- `pytest tests/test_issue4042_typing_lag_autoresize.py -v --timeout=60`
- `pytest tests/test_issue734_message_windowing.py -v --timeout=60`
- Manual: not run locally; load a long session, complete one turn so the transcript is fully expanded, then type in the composer and confirm input stays responsive while the textarea still grows and shrinks correctly

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- This narrows the keystroke hot path, but it does not re-window the transcript after a turn completes; if `#3714` or a later follow-up lands, that broader DOM and memory improvement can still proceed independently.

## Model Used

GPT-5 via Codex CLI

