### PR TITLE
fix(titlebar): sync document.title on panel switches (#4039)

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -72,6 +72,10 @@ function syncAppTitlebar() {
   if (_renamingAppTitlebar) return;
 
   titleEl.textContent = mainText;
+  if (panel !== 'chat') {
+    const bot = typeof assistantDisplayName === 'function' ? assistantDisplayName() : '';
+    document.title = bot ? mainText + ' \u2014 ' + bot : mainText;
+  }
   if (subEl) {
     if (subText) {
       subEl.textContent = subText;
@@ -272,7 +276,8 @@ async function switchPanel(name, opts = {}) {
     if (overlay) overlay.classList.add('visible');
   }
   _resyncChatSidebarAfterPanelSwitch();
-  syncAppTitlebar();
+  if (nextPanel === 'chat' && typeof syncTopbar === 'function') syncTopbar();
+  else syncAppTitlebar();
   return true;
 }
 

--- a/tests/test_issue4039_panel_document_title.py
+++ b/tests/test_issue4039_panel_document_title.py
@@ -1,0 +1,31 @@
+"""Regression coverage for panel-driven document.title ownership (#4039)."""
+
+from __future__ import annotations
+
+
+def _src(name: str) -> str:
+    with open(f"static/{name}", encoding="utf-8") as f:
+        return f.read()
+
+
+def test_sync_app_titlebar_stamps_non_chat_document_title():
+    src = _src("panels.js")
+
+    assert "if (panel !== 'chat') {" in src
+    assert "const bot = typeof assistantDisplayName === 'function' ? assistantDisplayName() : '';" in src
+    assert "document.title = bot ? mainText + ' \\u2014 ' + bot : mainText;" in src
+
+
+def test_switch_panel_restores_chat_title_via_sync_topbar():
+    src = _src("panels.js")
+
+    assert "if (nextPanel === 'chat' && typeof syncTopbar === 'function') syncTopbar();" in src
+    assert "else syncAppTitlebar();" in src
+
+
+def test_chat_title_format_stays_owned_by_sync_topbar():
+    panels_src = _src("panels.js")
+    ui_src = _src("ui.js")
+
+    assert "document.title=sessionTitle+' \\u2014 '+assistantDisplayName();" in ui_src
+    assert "document.title=sessionTitle+' \\u2014 '+assistantDisplayName();" not in panels_src


### PR DESCRIPTION
## Thinking Path

- The stale desktop window title is not a missing translation problem, it is an ownership gap between `switchPanel()` and `syncTopbar()`.
- `syncTopbar()` already owns the chat-title format, so the fix should preserve that contract and add only the missing non-chat panel `document.title` updates.
- An open app-titlebar PR already touches the same file, so the safest patch is a small, local change near `syncAppTitlebar()` and the `switchPanel()` tail.

## What Changed

- `static/panels.js`: update `syncAppTitlebar()` so non-chat panels stamp `document.title`, and make chat panel returns re-run `syncTopbar()` to restore the session title immediately.
- `tests/test_issue4039_panel_document_title.py`: add focused source-level regression coverage for the non-chat `document.title` stamp and the chat-return handoff back to `syncTopbar()`.

## Why It Matters

In the desktop shell, `document.title` is the actual native window title, so stale chat text on Kanban or Settings is user-visible, not cosmetic. This patch keeps panel names and chat titles in sync without moving the chat-title contract away from `syncTopbar()`.

## Verification

```text
pytest tests/test_issue4039_panel_document_title.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- Open PR #3177 also edits `static/panels.js`, so a rebase may be needed if it lands first. Keeping this patch local to `syncAppTitlebar()` and the `switchPanel()` tail should keep that manageable.
- This target is intentionally limited to `document.title` ownership; it does not redesign the titlebar DOM, profile switcher, or desktop shell integration.

## Model Used

GPT-5 via Codex CLI

