### PR TITLE
fix(#4040): allow Tauri IPC host in connect-src

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -53,7 +53,7 @@ def safe_resolve(root: Path, requested: str) -> Path:
 
 
 _CSP_CONNECT_BASE = (
-    "'self' http://127.0.0.1:* http://localhost:* "
+    "'self' http://127.0.0.1:* http://localhost:* http://ipc.localhost "
     "ws://127.0.0.1:* ws://localhost:*"
 )
 _CSP_EXTRA_CONNECT_RE = _re.compile(

--- a/tests/test_issue1909_csp_enforcement.py
+++ b/tests/test_issue1909_csp_enforcement.py
@@ -50,7 +50,7 @@ def test_security_helper_sends_enforcing_csp_with_hardening_directives(monkeypat
     assert "object-src 'none'" in policy
     assert "frame-ancestors 'none'" in policy
     assert "media-src 'self' data: blob:" in policy
-    assert "connect-src 'self' http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:* https://cdn.jsdelivr.net" in policy
+    assert "connect-src 'self' http://127.0.0.1:* http://localhost:* http://ipc.localhost ws://127.0.0.1:* ws://localhost:* https://cdn.jsdelivr.net" in policy
 
 
 def test_enforcing_csp_honors_valid_extra_connect_origins(monkeypatch):
@@ -64,7 +64,7 @@ def test_enforcing_csp_honors_valid_extra_connect_origins(monkeypatch):
     policy = headers["Content-Security-Policy"]
     assert (
         "connect-src 'self' http://127.0.0.1:* http://localhost:* "
-        "ws://127.0.0.1:* ws://localhost:* https://cdn.jsdelivr.net "
+        "http://ipc.localhost ws://127.0.0.1:* ws://localhost:* https://cdn.jsdelivr.net "
         "https://metrics.example.com wss://events.example.com:443; "
     ) in policy
 

--- a/tests/test_issue2901_csp_connect_extra.py
+++ b/tests/test_issue2901_csp_connect_extra.py
@@ -16,7 +16,6 @@ def test_csp_connect_src_default_header_unchanged(monkeypatch):
     )
 
     assert expected in policy
-    assert "http://ipc.localhost" in policy
 
 
 def test_csp_connect_src_includes_valid_extra_origins(monkeypatch):

--- a/tests/test_issue2901_csp_connect_extra.py
+++ b/tests/test_issue2901_csp_connect_extra.py
@@ -9,11 +9,14 @@ def test_csp_connect_src_default_header_unchanged(monkeypatch):
     monkeypatch.delenv("HERMES_WEBUI_CSP_CONNECT_EXTRA", raising=False)
 
     policy = Handler.csp_report_only_policy()
-
-    assert (
+    expected = (
         "connect-src 'self' http://127.0.0.1:* http://localhost:* "
-        "ws://127.0.0.1:* ws://localhost:* https://cdn.jsdelivr.net; "
-    ) in policy
+        "http://ipc.localhost ws://127.0.0.1:* ws://localhost:* "
+        "https://cdn.jsdelivr.net; "
+    )
+
+    assert expected in policy
+    assert "http://ipc.localhost" in policy
 
 
 def test_csp_connect_src_includes_valid_extra_origins(monkeypatch):
@@ -28,7 +31,8 @@ def test_csp_connect_src_includes_valid_extra_origins(monkeypatch):
 
     assert (
         "connect-src 'self' http://127.0.0.1:* http://localhost:* "
-        "ws://127.0.0.1:* ws://localhost:* https://cdn.jsdelivr.net "
+        "http://ipc.localhost ws://127.0.0.1:* ws://localhost:* "
+        "https://cdn.jsdelivr.net "
         "https://metrics.example.com wss://events.example.com:443; "
     ) in policy
 


### PR DESCRIPTION
## Thinking Path- The Tauri desktop app still loads the WebUI under the server's enforced CSP, and current `origin/master` still builds `connect-src` from a baseline that omits `http://ipc.localhost`.- The issue thread and current helper code agree on the smallest live fix, add the built-in Tauri IPC host to `_CSP_CONNECT_BASE` so desktop IPC is allowed without relying on env overrides.- The cheapest honest regression guard is the existing CSP connect-extra test file, which already pins the default header shape and can absorb a focused `ipc.localhost` assertion without widening this target.## What Changed- `api/helpers.py`: add `http://ipc.localhost` to the built-in `connect-src` baseline that feeds both enforced and report-only CSP headers.- `tests/test_issue2901_csp_connect_extra.py`: update the default baseline expectation and add focused coverage for the built-in Tauri IPC host.## Why It MattersDesktop IPC calls stop tripping the default WebUI CSP, which removes the current `ipc.localhost` violation path without reopening broader CSP policy questions. The change stays inside the narrow Tauri desktop slice the issue asked for.## Verification- `pytest tests/test_issue2901_csp_connect_extra.py -v --timeout=60`- Full-suite CI context, not a claimed local run: `pytest tests/ -v --timeout=60`## Risks / Follow-ups- This proposal intentionally does not add the bare `ipc:` scheme, because the current issue thread reproduces `http://ipc.localhost/...` on `origin/master`, not a separate `ipc:` request shape.- This proposal intentionally leaves `/api/csp-report` logging alone, because the report spam should disappear as a consequence of allowing the current bridge host, not from separately suppressing or changing the report handler.## Model UsedGPT-5 via Codex CLI