### PR TITLE
fix(approval): keep approval polling alive across busy dips (#4041)

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -4172,10 +4172,12 @@ function _startApprovalFallbackPoll(sid) {
     try {
       const data = await api("/api/approval/pending?session_id=" + encodeURIComponent(sid),{timeoutToast:false});
       if (data.pending) { showApprovalForSession(sid, data.pending, data.pending_count||1); }
-      else if (!_approvalPollingSessionMissingOrMismatched(sid) && !S.busy) {
+      else if (!_approvalPollingSessionMissingOrMismatched(sid)) {
         _clearApprovalPendingForSession(sid);
         _hideApprovalCardIfOwner(sid);
-        stopApprovalPollingForSession(sid);
+        if (!S.busy) {
+          stopApprovalPollingForSession(sid);
+        }
       }
     } catch(e) { /* ignore poll errors */ }
     finally { _approvalFallbackPollInFlight = false; }

--- a/static/messages.js
+++ b/static/messages.js
@@ -3994,6 +3994,10 @@ function _hideApprovalCardIfOwner(sid, force=false) {
   if (!sid || _approvalSessionId === sid) hideApprovalCard(force);
 }
 
+function _approvalPollingSessionMissingOrMismatched(sid) {
+  return !sid || !S.session || S.session.session_id !== sid;
+}
+
 function _renderPendingApprovalForActiveSession() {
   const sid = _promptActiveSessionId();
   if (!sid) return;
@@ -4160,7 +4164,7 @@ function _startApprovalFallbackPoll(sid) {
   // shows its card instantly (the removed SSE 'initial' event used to do this);
   // then poll on the 1500ms cadence. (#3913 SHOULD-FIX)
   const _tick = async () => {
-    if (!S.busy || !S.session || S.session.session_id !== sid) {
+    if (_approvalPollingSessionMissingOrMismatched(sid)) {
       stopApprovalPolling(); _hideApprovalCardIfOwner(sid, true); return;
     }
     if (_approvalFallbackPollInFlight) return;
@@ -4168,7 +4172,11 @@ function _startApprovalFallbackPoll(sid) {
     try {
       const data = await api("/api/approval/pending?session_id=" + encodeURIComponent(sid),{timeoutToast:false});
       if (data.pending) { showApprovalForSession(sid, data.pending, data.pending_count||1); }
-      else { _clearApprovalPendingForSession(sid); _hideApprovalCardIfOwner(sid); }
+      else if (!_approvalPollingSessionMissingOrMismatched(sid) && !S.busy) {
+        _clearApprovalPendingForSession(sid);
+        _hideApprovalCardIfOwner(sid);
+        stopApprovalPollingForSession(sid);
+      }
     } catch(e) { /* ignore poll errors */ }
     finally { _approvalFallbackPollInFlight = false; }
   };

--- a/tests/test_issue4041_approval_poll_busy_dip.py
+++ b/tests/test_issue4041_approval_poll_busy_dip.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+
+
+def _body_from_brace(src: str, brace: int, label: str) -> str:
+    assert brace >= 0, f"body opening brace not found for: {label}"
+    depth = 1
+    i = brace + 1
+    while i < len(src) and depth:
+        ch = src[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"body did not close for: {label}"
+    return src[brace + 1 : i - 1]
+
+
+def _function_body(name: str) -> str:
+    marker = f"function {name}("
+    start = MESSAGES_JS.find(marker)
+    assert start >= 0, f"function not found: {name}"
+    signature_end = MESSAGES_JS.find(")", start)
+    assert signature_end >= 0, f"function signature not found: {name}"
+    brace = MESSAGES_JS.find("{", signature_end)
+    return _body_from_brace(MESSAGES_JS, brace, name)
+
+
+def test_busy_dips_no_longer_force_stop_approval_polling():
+    body = _function_body("_startApprovalFallbackPoll")
+
+    assert "_approvalPollingSessionMissingOrMismatched(sid)" in body
+    assert "!S.busy || !S.session || S.session.session_id !== sid" not in body
+
+
+def test_empty_pending_only_stops_after_confirmed_idle():
+    fallback_body = _function_body("_startApprovalFallbackPoll")
+
+    assert "else if (!_approvalPollingSessionMissingOrMismatched(sid) && !S.busy)" in fallback_body
+    assert "_clearApprovalPendingForSession(sid);" in fallback_body
+    assert "_hideApprovalCardIfOwner(sid);" in fallback_body
+    assert "stopApprovalPollingForSession(sid);" in fallback_body
+    assert "stopApprovalPolling(); _hideApprovalCardIfOwner(sid, true); return;" in fallback_body

--- a/tests/test_issue4041_approval_poll_busy_dip.py
+++ b/tests/test_issue4041_approval_poll_busy_dip.py
@@ -36,11 +36,13 @@ def test_busy_dips_no_longer_force_stop_approval_polling():
     assert "!S.busy || !S.session || S.session.session_id !== sid" not in body
 
 
-def test_empty_pending_only_stops_after_confirmed_idle():
+def test_empty_pending_clears_card_and_only_stops_after_confirmed_idle():
     fallback_body = _function_body("_startApprovalFallbackPoll")
 
-    assert "else if (!_approvalPollingSessionMissingOrMismatched(sid) && !S.busy)" in fallback_body
+    assert "else if (!_approvalPollingSessionMissingOrMismatched(sid)) {" in fallback_body
     assert "_clearApprovalPendingForSession(sid);" in fallback_body
     assert "_hideApprovalCardIfOwner(sid);" in fallback_body
+    assert "if (!S.busy) {" in fallback_body
     assert "stopApprovalPollingForSession(sid);" in fallback_body
+    assert "else if (!_approvalPollingSessionMissingOrMismatched(sid) && !S.busy)" not in fallback_body
     assert "stopApprovalPolling(); _hideApprovalCardIfOwner(sid, true); return;" in fallback_body


### PR DESCRIPTION
## Thinking Path

- Current `origin/master` still uses the HTTP approval poll introduced in `#3913`, and the issue is not stale: the fallback tick still tears itself down on any transient `S.busy=false`.
- The current teardown is worse than a simple hide, because it force-hides past the 30 second visibility guard from `#225` and clears the poll timer before the server has confirmed the approval is actually gone.
- The narrow fix is to keep polling alive across busy dips, stop only on true session mismatch or confirmed idle plus empty pending state, and lock that lifecycle with a focused regression the current suite does not cover.

## What Changed

- `static/messages.js`: narrow the approval poll hard-stop to true session loss or mismatch, and move ordinary cleanup to the confirmed empty-pending plus idle branch so the existing no-force visibility guard still applies.
- `tests/test_issue4041_approval_poll_busy_dip.py`: add focused regression coverage for the approval poll busy-dip lifecycle.

## Why It Matters

Pending approvals are load-bearing control prompts; if the poll tears down early, the session looks stuck and the user cannot continue without reloading the page. This fix keeps the prompt alive through reconnect churn while preserving the current owner-scoped and visibility-guard behavior.

## Verification

- `pytest tests/test_issue4041_approval_poll_busy_dip.py -v --timeout=60`
- `pytest tests/test_1694_prompt_ownership.py -v --timeout=60`
- Manual: start a session waiting on approval, force a transient reconnect or stream reattach, and confirm the approval card remains available until the approval is answered or the server confirms there is no pending approval

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- This target only fixes approval polling. If clarify polling shows the same reconnect lifecycle bug under separate evidence, mirror the same pattern in a follow-up instead of widening this PR preemptively.

## Model Used

GPT-5.5 via Codex CLI

