### PR TITLE
fix(commands): inject forced skill content for /use (#4044)

### DIFF
--- a/static/commands.js
+++ b/static/commands.js
@@ -949,8 +949,11 @@ async function cmdUse(args){
       }
       return;
     }
+    const detail = await api(`/api/skills/content?name=${encodeURIComponent(match.name)}`);
+    const skillContent = detail&&typeof detail.content==='string' ? detail.content.trim() : '';
+    if(!skillContent) throw new Error(`Skill \`${match.name}\` has no readable content.`);
     const directive = `[USER OVERRIDE] You MUST consult skill '${match.name}' via skill_view before responding to the next message.`;
-    resolve(directive);
+    resolve({name:match.name,directive,content:skillContent});
     if(isCurrentSession()){
       S.messages.push({role:'assistant', content:`Next turn: skill \`${match.name}\` will be forced.`});
       renderMessages();

--- a/static/commands.js
+++ b/static/commands.js
@@ -952,7 +952,7 @@ async function cmdUse(args){
     const detail = await api(`/api/skills/content?name=${encodeURIComponent(match.name)}`);
     const skillContent = detail&&typeof detail.content==='string' ? detail.content.trim() : '';
     if(!skillContent) throw new Error(`Skill \`${match.name}\` has no readable content.`);
-    const directive = `[USER OVERRIDE] You MUST consult skill '${match.name}' via skill_view before responding to the next message.`;
+    const directive = `[USER OVERRIDE] You MUST follow the skill '${match.name}' content provided below before responding to the next message.`;
     resolve({name:match.name,directive,content:skillContent});
     if(isCurrentSession()){
       S.messages.push({role:'assistant', content:`Next turn: skill \`${match.name}\` will be forced.`});

--- a/static/messages.js
+++ b/static/messages.js
@@ -1063,10 +1063,22 @@ async function send(){
   if(_forcedSkillDirectivePending){
     const _pending=_forcedSkillDirectivePending;
     if(!_pending.sessionId||_pending.sessionId===activeSid){
-      const _directive = await _pending.promise;
+      const _directivePayload = await _pending.promise;
       if(_forcedSkillDirectivePending===_pending)_forcedSkillDirectivePending = null;
-      if(typeof _directive==='string'&&_directive){
-        msgText=`${_directive}\n\n${msgText||''}`.trim();
+      if(_directivePayload){
+        const _directive = typeof _directivePayload==='string'
+          ? _directivePayload
+          : String(_directivePayload.directive||'').trim();
+        const _forcedSkillName = typeof _directivePayload==='string'
+          ? ''
+          : String(_directivePayload.name||'').trim();
+        const _forcedSkillContent = typeof _directivePayload==='string'
+          ? ''
+          : String(_directivePayload.content||'').trim();
+        const _forcedSkillBlock = _forcedSkillName&&_forcedSkillContent
+          ? `[FORCED SKILL CONTEXT: ${_forcedSkillName}]\n${_forcedSkillContent}\n[/FORCED SKILL CONTEXT]`
+          : '';
+        msgText=`${_directive}${_forcedSkillBlock?`\n\n${_forcedSkillBlock}`:''}\n\n${msgText||''}`.trim();
       }
     }
   }

--- a/tests/test_issue2977_use_command.py
+++ b/tests/test_issue2977_use_command.py
@@ -77,7 +77,8 @@ def test_directive_injection_before_empty_guard():
 def test_directive_text_uses_match_name():
     src = read("static/commands.js")
     assert "match.name" in src, "directive must use match.name (canonical casing), not raw user input"
-    assert "[USER OVERRIDE] You MUST consult skill '" in src, "directive text must match the specified format"
+    assert "[USER OVERRIDE] You MUST follow the skill '" in src, "directive text must match the specified format"
+    assert "content provided below" in src, "directive must reference the injected skill content"
 
 
 def test_use_fetches_canonical_skill_content():

--- a/tests/test_issue2977_use_command.py
+++ b/tests/test_issue2977_use_command.py
@@ -34,6 +34,8 @@ def test_forced_skill_directive_set_in_cmdUse():
     src = read("static/commands.js")
     assert "pending.promise = new Promise" in src, "cmdUse must create a pending Promise"
     assert "_forcedSkillDirectivePending = pending;" in src, "cmdUse must publish the pending directive before awaiting"
+    assert "resolve({name:match.name,directive,content:skillContent});" in src, \
+        "cmdUse must resolve the pending payload with skill name, directive, and fetched content"
 
 
 def test_use_entry_has_noEcho():
@@ -59,7 +61,7 @@ def test_directive_consumed_at_injection_site():
     finally_part = src.split("finally")[1] if "finally" in src else ""
     assert "_forcedSkillDirectivePending = null;" not in finally_part, \
         "_forcedSkillDirectivePending must NOT be cleared in the finally block"
-    assert "const _directive = await _pending.promise;" in src, \
+    assert "const _directivePayload = await _pending.promise;" in src, \
         "consume site must await the pending promise"
     assert "_forcedSkillDirectivePending = null;" in src, \
         "_forcedSkillDirectivePending must be cleared somewhere in messages.js"
@@ -76,6 +78,14 @@ def test_directive_text_uses_match_name():
     src = read("static/commands.js")
     assert "match.name" in src, "directive must use match.name (canonical casing), not raw user input"
     assert "[USER OVERRIDE] You MUST consult skill '" in src, "directive text must match the specified format"
+
+
+def test_use_fetches_canonical_skill_content():
+    src = read("static/commands.js")
+    assert "api(`/api/skills/content?name=${encodeURIComponent(match.name)}`)" in src, \
+        "cmdUse must fetch the canonical skill content after resolving the canonical skill name"
+    assert "typeof detail.content==='string' ? detail.content.trim() : ''" in src, \
+        "cmdUse must reject missing or non-string skill content"
 
 
 def test_pending_promise_set_synchronously():
@@ -114,3 +124,5 @@ def test_directive_only_consumed_by_matching_session():
         "send() must only consume /use directives issued for the active session"
     assert "if(_forcedSkillDirectivePending===_pending)_forcedSkillDirectivePending = null;" in src, \
         "send() must not clear a newer pending directive created while awaiting"
+    assert "[FORCED SKILL CONTEXT: ${_forcedSkillName}]" in src, \
+        "send() must prepend deterministic forced-skill content before the user message"


### PR DESCRIPTION

## Thinking Path

- The shipped `/use` flow already has the right race-safe plumbing, namely a session-scoped pending promise consumed at the next real send; what it lacks is enforceable payload data.
- The repo already exposes `/api/skills/content`, so the smallest deterministic fix is to fetch the selected skill body and carry it through that existing pending path.
- Open PRs already touch adjacent `/use` autocomplete and `send()` logic, so this patch should stay tightly scoped to `cmdUse()` and the `_forcedSkillDirectivePending` consume block.

## What Changed

- `static/commands.js`: keep `/use` registration and session-ownership guards, but resolve the pending override with canonical skill content fetched from `/api/skills/content`.
- `static/messages.js`: inject the forced skill body into the next-turn context through the existing pending-directive consume site, preserving the current race guards.
- `tests/test_issue2977_use_command.py`: extend the existing `/use` regression file so it guards content fetching, deterministic payload shape, and the preserved consume-site ordering.

## Why It Matters

The current UX says `/use` forces a skill, but today it only asks the model politely. Injecting the selected skill body through the existing one-turn override path makes the promise real without expanding `/use` into a broader product redesign.

## Verification

```text
pytest tests/test_issue2977_use_command.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- Open PR #4010 and open PR #3965 both touch adjacent slash-command files, so a rebase may be needed if either lands first.
- This target intentionally stops at the minimal enforceable slice; it does not add post-turn notices, multi-turn skill attachment, or `/use` UX redesign.

## Model Used

GPT 5.5 via Codex CLI