### PR TITLE
fix(skills): categorize flat external skill dirs (#4053)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -227,6 +227,7 @@ def _skill_path_within(base_dir: Path, candidate: Path) -> bool:
 
 
 def _skill_category_from_path(skill_md: Path, skills_dirs: list[Path]) -> str | None:
+    local_skills_dir = skills_dirs[0] if skills_dirs else None
     for skills_dir in skills_dirs:
         try:
             rel_path = skill_md.relative_to(skills_dir)
@@ -235,6 +236,8 @@ def _skill_category_from_path(skill_md: Path, skills_dirs: list[Path]) -> str | 
         parts = rel_path.parts
         if len(parts) >= 3:
             return parts[0]
+        if len(parts) >= 2 and local_skills_dir is not None and skills_dir != local_skills_dir:
+            return skills_dir.name
         return None
     return None
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -227,6 +227,11 @@ def _skill_path_within(base_dir: Path, candidate: Path) -> bool:
 
 
 def _skill_category_from_path(skill_md: Path, skills_dirs: list[Path]) -> str | None:
+    """Return the UI category for a discovered skill path.
+
+    ``skills_dirs[0]`` must be the active local skills root so flat local skills
+    stay uncategorized while flat external roots can use their directory name.
+    """
     local_skills_dir = skills_dirs[0] if skills_dirs else None
     for skills_dir in skills_dirs:
         try:

--- a/tests/test_issue4053_external_skill_categories.py
+++ b/tests/test_issue4053_external_skill_categories.py
@@ -1,0 +1,41 @@
+import pathlib
+
+from tests.conftest import requires_agent_modules
+
+pytestmark = requires_agent_modules
+
+
+def _write_skill(root: pathlib.Path, *parts: str) -> pathlib.Path:
+    skill_dir = root.joinpath(*parts)
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: test-skill\ndescription: test description\n---\n",
+        encoding="utf-8",
+    )
+    return skill_md
+
+
+def test_external_skill_categories_keep_local_flat_and_label_external_roots(tmp_path):
+    from api import routes
+
+    local_root = tmp_path / "skills"
+    external_flat_root = tmp_path / "partner-skills"
+    external_nested_root = tmp_path / "external-catalog"
+
+    local_skill = _write_skill(local_root, "local-flat-skill")
+    flat_external_skill = _write_skill(external_flat_root, "external-flat-skill")
+    nested_external_skill = _write_skill(
+        external_nested_root,
+        "ops",
+        "external-nested-skill",
+    )
+
+    search_dirs = [local_root, external_flat_root, external_nested_root]
+
+    assert routes._skill_category_from_path(local_skill, search_dirs) is None
+    assert (
+        routes._skill_category_from_path(flat_external_skill, search_dirs)
+        == external_flat_root.name
+    )
+    assert routes._skill_category_from_path(nested_external_skill, search_dirs) == "ops"


### PR DESCRIPTION

## Thinking Path

- The issue is not missing discovery, it is missing categorization after discovery: the backend already scans `skills.external_dirs`, but flat external roots still produce `category: None`.
- The UI already groups by `category` and only falls back to `(general)` when the backend gives it nothing, so the right fix lives in the route/helper layer rather than the Skills tab renderer.
- Keeping the change to category derivation for flat external roots preserves existing local-skill behavior and avoids inventing a broader path-label taxonomy.

## What Changed

- `api/routes.py`: derive a stable category for flat external skill roots while preserving current local-root behavior
- `tests/test_issue4053_external_skill_categories.py`: add regression coverage for local-root, flat external-root, and nested external-root cases

## Why It Matters

Users who configure multiple external skill directories can actually tell where those skills came from in the Skills tab, instead of seeing everything flattened into `(general)`. That makes large external skill sets easier to browse without changing how local skills already behave.

## Verification

```powershell
$env:BROWSER='echo'; $env:PYTHONUTF8='1'
$out = [System.IO.Path]::GetTempFileName()
$err = [System.IO.Path]::GetTempFileName()
$ec  = [System.IO.Path]::GetTempFileName()
Start-Process -FilePath conhost -WindowStyle Hidden -Wait -ArgumentList (
  '--headless', 'cmd', '/v:on', '/c',
  'D:\Repos\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_issue4053_external_skill_categories.py tests/test_issue1880_profile_scoped_skills.py -v --timeout=60 >"' + $out + '" 2>"' + $err + '" & echo !errorlevel!>"' + $ec + '"'
)
Get-Content $out; Get-Content $err
$code = [int](Get-Content $ec)
Remove-Item $out,$err,$ec
exit $code
```

- Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`

## Risks / Follow-ups

- This uses the external root basename as the flat-root category label. If upstream later wants richer path labeling or user-configurable aliases, that should be handled as a separate feature.

## Model Used

GPT-5 via Codex CLI
