### PR TITLE
fix(#4059): pass custom provider keys to context probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Custom provider context-length probes now include the provider API key during session hydration and streaming fallbacks (#4059).** Static session loads and fallback usage/session-save paths now reuse the matched custom provider credentials when querying `/v1/models`, so authenticated custom endpoints do not fall back to the default 256K window and clobber a larger persisted context length / compression threshold.
+
 ## [v0.51.369] — 2026-06-12 — Release MH (WebUI streaming honors runtime target model/base_url)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -2276,7 +2276,7 @@ def _model_matches_configured_default(
 
 
 class _ContextLengthLookupInputs:
-    __slots__ = ("config_context_length", "custom_providers", "base_url", "provider")
+    __slots__ = ("config_context_length", "custom_providers", "base_url", "provider", "api_key")
 
     def __init__(
         self,
@@ -2285,11 +2285,13 @@ class _ContextLengthLookupInputs:
         custom_providers: list | None = None,
         base_url: str = "",
         provider: str = "",
+        api_key: str = "",
     ) -> None:
         self.config_context_length = config_context_length
         self.custom_providers = custom_providers
         self.base_url = base_url
         self.provider = provider
+        self.api_key = api_key
 
 
 def _positive_context_length(value) -> int | None:
@@ -2379,6 +2381,38 @@ def _providers_match_for_context(config_key: object, requested_provider: str) ->
     )
 
 
+def _custom_provider_api_key_for_context(entry: dict, provider: str) -> str:
+    """Resolve the API key for a matched ``custom_providers`` entry.
+
+    Static session hydration/update routes already have a per-profile config
+    snapshot. Resolve from the matched entry instead of re-reading global config,
+    while preserving the same literal, ``${ENV_VAR}``, ``key_env``, and
+    sanitized-env shapes used by streaming/provider resolution.
+    """
+    raw_api_key = entry.get("api_key")
+    if raw_api_key is not None:
+        api_key_text = str(raw_api_key).strip()
+        if api_key_text.startswith("${") and api_key_text.endswith("}") and len(api_key_text) > 3:
+            resolved = os.getenv(api_key_text[2:-1], "").strip()
+            if resolved:
+                return resolved
+        elif api_key_text:
+            return api_key_text
+
+    key_env = str(entry.get("key_env") or "").strip()
+    if key_env:
+        resolved = os.getenv(key_env, "").strip()
+        if resolved:
+            return resolved
+
+    try:
+        from api.config import _lookup_custom_api_key_env
+
+        return _lookup_custom_api_key_env(provider) or ""
+    except Exception:
+        return ""
+
+
 def _context_length_lookup_inputs_for_model(
     model: str | None,
     provider: str | None = None,
@@ -2438,6 +2472,7 @@ def _context_length_lookup_inputs_for_model(
             break
 
     custom_context_length = None
+    effective_api_key = ""
     if custom_providers:
         target_base = effective_base_url.rstrip("/")
         model_candidates = set(_model_lookup_candidates(bare_model or model_for_lookup))
@@ -2467,6 +2502,7 @@ def _context_length_lookup_inputs_for_model(
                 effective_provider = entry_slug
             if not effective_base_url and entry_base:
                 effective_base_url = entry_base
+            effective_api_key = _custom_provider_api_key_for_context(entry, effective_provider or entry_slug)
             custom_context_length = _models_config_context_length(models_cfg, bare_model or model_for_lookup)
             break
 
@@ -2489,6 +2525,7 @@ def _context_length_lookup_inputs_for_model(
         custom_providers=custom_providers,
         base_url=effective_base_url,
         provider=effective_provider,
+        api_key=effective_api_key,
     )
 
 
@@ -3002,6 +3039,7 @@ def _resolve_context_length_for_session_model(
             return _get_cl(
                 model_for_lookup,
                 _ctx_lookup.base_url,
+                api_key=_ctx_lookup.api_key,
                 config_context_length=_ctx_lookup.config_context_length,
                 provider=_ctx_lookup.provider or provider or "",
                 custom_providers=_ctx_lookup.custom_providers,

--- a/api/routes.py
+++ b/api/routes.py
@@ -2393,9 +2393,15 @@ def _custom_provider_api_key_for_context(entry: dict, provider: str) -> str:
     if raw_api_key is not None:
         api_key_text = str(raw_api_key).strip()
         if api_key_text.startswith("${") and api_key_text.endswith("}") and len(api_key_text) > 3:
-            resolved = os.getenv(api_key_text[2:-1], "").strip()
+            env_name = api_key_text[2:-1]
+            resolved = os.getenv(env_name, "").strip()
             if resolved:
                 return resolved
+            logger.debug(
+                "Custom provider %s api_key references %s, but the environment variable is unset or empty",
+                provider,
+                api_key_text,
+            )
         elif api_key_text:
             return api_key_text
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7294,11 +7294,13 @@ def _run_agent_streaming(
                         )
                         _cfg_ctx_len = _ctx_lookup.config_context_length
                         _cfg_custom_providers = _ctx_lookup.custom_providers
+                        _cfg_api_key = _ctx_lookup.api_key or getattr(agent, 'api_key', '') or resolved_api_key or ''
                         _cfg_base_url = _ctx_lookup.base_url or _cfg_base_url
                         _cfg_provider = _ctx_lookup.provider or resolved_provider or ''
                         _resolved_cl = get_model_context_length(
                             getattr(agent, 'model', resolved_model or '') or '',
                             _cfg_base_url,
+                            api_key=_cfg_api_key,
                             config_context_length=_cfg_ctx_len,
                             provider=_cfg_provider,
                             custom_providers=_cfg_custom_providers,
@@ -7552,12 +7554,14 @@ def _run_agent_streaming(
                     )
                     _cfg_ctx_len = _ctx_lookup.config_context_length
                     _cfg_custom_providers = _ctx_lookup.custom_providers
+                    _cfg_api_key = _ctx_lookup.api_key or getattr(agent, 'api_key', '') or resolved_api_key or ''
                     _cfg_base_url = _ctx_lookup.base_url
                     _cfg_provider = _ctx_lookup.provider or resolved_provider or ''
                     try:
                         _fb_cl = _get_cl(
                             getattr(agent, 'model', resolved_model or '') or '',
                             _cfg_base_url,
+                            api_key=_cfg_api_key,
                             config_context_length=_cfg_ctx_len,
                             provider=_cfg_provider,
                             custom_providers=_cfg_custom_providers,

--- a/tests/test_issue1896_context_length_fallback_args.py
+++ b/tests/test_issue1896_context_length_fallback_args.py
@@ -233,3 +233,133 @@ def test_routes_session_load_fallback_passes_config_overrides():
         "session-load fallback must catch TypeError to support older "
         "hermes-agent builds without the new kwargs."
     )
+
+
+def test_context_lookup_returns_custom_provider_api_key_from_entry():
+    """#4059: static session hydration must carry custom-provider API keys.
+
+    A named ``custom_providers`` entry can require auth for its ``/v1/models``
+    endpoint. The route-side lookup helper already identifies the matching
+    provider/base/model; it must also return that entry's API key so
+    ``get_model_context_length`` does not probe anonymously and fall back to
+    256K.
+    """
+    from api.routes import _context_length_lookup_inputs_for_model
+
+    lookup = _context_length_lookup_inputs_for_model(
+        "custom-model-id",
+        "custom:llm-proxy",
+        cfg={
+            "custom_providers": [
+                {
+                    "name": "llm-proxy",
+                    "base_url": "https://llm.example.test/v1",
+                    "api_key": "sk-test-entry",
+                    "model": "custom-model-id",
+                }
+            ]
+        },
+    )
+
+    assert lookup.provider == "custom:llm-proxy"
+    assert lookup.base_url == "https://llm.example.test/v1"
+    assert lookup.api_key == "sk-test-entry"
+
+
+def test_context_lookup_resolves_custom_provider_api_key_env_template(monkeypatch):
+    """#4059: ``${ENV_VAR}`` custom-provider keys resolve before metadata probes."""
+    from api.routes import _context_length_lookup_inputs_for_model
+
+    monkeypatch.setenv("ISSUE_4059_CONTEXT_KEY", "env-template-key")
+
+    lookup = _context_length_lookup_inputs_for_model(
+        "custom-model-id",
+        "custom:llm-proxy",
+        cfg={
+            "custom_providers": [
+                {
+                    "name": "llm-proxy",
+                    "base_url": "https://llm.example.test/v1",
+                    "api_key": "${ISSUE_4059_CONTEXT_KEY}",
+                    "model": "custom-model-id",
+                }
+            ]
+        },
+    )
+
+    assert lookup.api_key == "env-template-key"
+
+
+def test_context_lookup_resolves_custom_provider_key_env(monkeypatch):
+    """#4059: ``key_env`` custom-provider keys resolve before metadata probes."""
+    from api.routes import _context_length_lookup_inputs_for_model
+
+    monkeypatch.setenv("ISSUE_4059_KEY_ENV", "key-env-value")
+
+    lookup = _context_length_lookup_inputs_for_model(
+        "custom-model-id",
+        "custom:llm-proxy",
+        cfg={
+            "custom_providers": [
+                {
+                    "name": "llm-proxy",
+                    "base_url": "https://llm.example.test/v1",
+                    "key_env": "ISSUE_4059_KEY_ENV",
+                    "model": "custom-model-id",
+                }
+            ]
+        },
+    )
+
+    assert lookup.api_key == "key-env-value"
+
+
+def test_routes_session_model_resolver_passes_custom_provider_api_key(monkeypatch):
+    """#4059: ``_resolve_context_length_for_session_model`` passes api_key.
+
+    This is the session-load/static-update path that was clobbering persisted
+    500K context metadata back to the unauthenticated 256K fallback.
+    """
+    from api import config as cfg_mod
+    from api import routes
+    import agent.model_metadata as metadata
+
+    seen = {}
+
+    monkeypatch.setattr(
+        cfg_mod,
+        "get_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "llm-proxy",
+                    "base_url": "https://llm.example.test/v1",
+                    "api_key": "sk-test-route",
+                    "model": "custom-model-id",
+                }
+            ]
+        },
+    )
+
+    def fake_get_model_context_length(model, base_url, **kwargs):
+        seen.update(model=model, base_url=base_url, kwargs=kwargs)
+        return 500_000 if kwargs.get("api_key") == "sk-test-route" else 256_000
+
+    monkeypatch.setattr(metadata, "get_model_context_length", fake_get_model_context_length)
+
+    assert routes._resolve_context_length_for_session_model(
+        "custom-model-id",
+        "custom:llm-proxy",
+    ) == 500_000
+    assert seen["kwargs"]["api_key"] == "sk-test-route"
+
+
+def test_streaming_context_length_fallbacks_pass_api_key():
+    """#4059: both streaming fallback probes must pass the resolved api_key."""
+    blocks = _both_callsites()
+    for i, block in enumerate(blocks):
+        assert "api_key=" in block, (
+            f"Callsite #{i+1} is missing api_key=. Authenticated custom "
+            f"provider /v1/models probes then fail and fall back to 256K. "
+            f"See #4059.\n\nBlock:\n{block}"
+        )

--- a/tests/test_issue1896_context_length_fallback_args.py
+++ b/tests/test_issue1896_context_length_fallback_args.py
@@ -292,6 +292,41 @@ def test_context_lookup_resolves_custom_provider_api_key_env_template(monkeypatc
     assert lookup.api_key == "env-template-key"
 
 
+def test_context_lookup_logs_unresolved_custom_provider_api_key_env_template(monkeypatch, caplog):
+    """#4059: unresolved ``${ENV_VAR}`` keys get a DEBUG diagnostic.
+
+    Behavior stays permissive: after logging the unresolved template, the helper
+    still falls through to ``key_env`` and sanitized provider env lookup.
+    """
+    import logging
+
+    from api.routes import _context_length_lookup_inputs_for_model
+
+    monkeypatch.delenv("ISSUE_4059_MISSING_CONTEXT_KEY", raising=False)
+    monkeypatch.setenv("ISSUE_4059_KEY_ENV_AFTER_TEMPLATE", "key-env-fallback")
+    caplog.set_level(logging.DEBUG, logger="api.routes")
+
+    lookup = _context_length_lookup_inputs_for_model(
+        "custom-model-id",
+        "custom:llm-proxy",
+        cfg={
+            "custom_providers": [
+                {
+                    "name": "llm-proxy",
+                    "base_url": "https://llm.example.test/v1",
+                    "api_key": "${ISSUE_4059_MISSING_CONTEXT_KEY}",
+                    "key_env": "ISSUE_4059_KEY_ENV_AFTER_TEMPLATE",
+                    "model": "custom-model-id",
+                }
+            ]
+        },
+    )
+
+    assert lookup.api_key == "key-env-fallback"
+    assert "${ISSUE_4059_MISSING_CONTEXT_KEY}" in caplog.text
+    assert "unset or empty" in caplog.text
+
+
 def test_context_lookup_resolves_custom_provider_key_env(monkeypatch):
     """#4059: ``key_env`` custom-provider keys resolve before metadata probes."""
     from api.routes import _context_length_lookup_inputs_for_model

--- a/tests/test_issue1896_context_length_fallback_args.py
+++ b/tests/test_issue1896_context_length_fallback_args.py
@@ -21,6 +21,8 @@ config-override args again.
 """
 
 from pathlib import Path
+import sys
+import types
 
 
 REPO = Path(__file__).resolve().parent.parent
@@ -322,7 +324,17 @@ def test_routes_session_model_resolver_passes_custom_provider_api_key(monkeypatc
     """
     from api import config as cfg_mod
     from api import routes
-    import agent.model_metadata as metadata
+
+    # Some unrelated route tests install ``sys.modules["agent"]`` as a plain
+    # module stub at collection time. Make this regression test own a package-
+    # shaped temporary ``agent.model_metadata`` import target so the production
+    # helper's local import is order-independent.
+    fake_agent = types.ModuleType("agent")
+    fake_agent.__path__ = []
+    metadata = types.ModuleType("agent.model_metadata")
+    fake_agent.model_metadata = metadata  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "agent", fake_agent)
+    monkeypatch.setitem(sys.modules, "agent.model_metadata", metadata)
 
     seen = {}
 
@@ -345,7 +357,7 @@ def test_routes_session_model_resolver_passes_custom_provider_api_key(monkeypatc
         seen.update(model=model, base_url=base_url, kwargs=kwargs)
         return 500_000 if kwargs.get("api_key") == "sk-test-route" else 256_000
 
-    monkeypatch.setattr(metadata, "get_model_context_length", fake_get_model_context_length)
+    monkeypatch.setattr(metadata, "get_model_context_length", fake_get_model_context_length, raising=False)
 
     assert routes._resolve_context_length_for_session_model(
         "custom-model-id",

--- a/tests/test_issue3256_context_length_default_only_guard.py
+++ b/tests/test_issue3256_context_length_default_only_guard.py
@@ -20,8 +20,9 @@ def _install_fake_get_model_context_length(monkeypatch, recorder):
     """Install a fake get_model_context_length into a stand-in agent.model_metadata."""
     mod = types.ModuleType("agent.model_metadata")
 
-    def _fake(model, base_url="", config_context_length=None, provider="", custom_providers=None):
+    def _fake(model, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
         recorder["model"] = model
+        recorder["api_key"] = api_key
         recorder["config_context_length"] = config_context_length
         # Pretend the real per-model metadata window is 1,000,000 unless the
         # caller forced a config cap, in which case honor the cap (mirrors the


### PR DESCRIPTION
# fix(#4059): pass custom provider keys to context probes

Closes #4059

## Thinking Path

- Hermes WebUI relies on model context metadata during session hydration, session updates, and streaming completion so the browser and persisted session state agree with the agent runtime.
- Custom provider `/v1/models` endpoints may require authentication to return their true context windows.
- The streaming runtime can have the correct API key, but static session hydration and fallback metadata probes were resolving the matching custom provider without carrying its key.
- Anonymous metadata probes can fall back to the default 256K context window, overwriting larger persisted context lengths and rescaling compression thresholds downward.
- This PR threads the matched custom-provider key through the existing route and streaming fallback context-length resolver paths while preserving legacy `hermes-agent` compatibility.

## What Changed

- **`api/routes.py`**
  - Added `api_key` to `_ContextLengthLookupInputs`.
  - Added `_custom_provider_api_key_for_context()` to resolve the matched custom provider credential from the active config snapshot.
  - Supports literal `api_key`, `${ENV_VAR}` expansion, `key_env`, and the existing sanitized custom-provider environment fallback.
  - Passes the resolved `api_key` into `_resolve_context_length_for_session_model()` calls to `get_model_context_length()`.

- **`api/streaming.py`**
  - Passes the resolved API key into both streaming fallback context-length probes.
  - Falls back to the live agent/resolved API key if the config lookup did not produce one.

- **Tests**
  - Added #4059 coverage for literal custom-provider keys, `${ENV_VAR}` keys, `key_env` keys, route resolver pass-through, and streaming fallback callsites.
  - Updated the existing #3256 fake metadata resolver to accept the modern `api_key` keyword so it continues exercising the non-legacy path.

- **`CHANGELOG.md`**
  - Added an Unreleased fix entry for #4059.

## Why It Matters

Authenticated custom providers can report context windows larger than the generic 256K fallback. Without the API key on static and fallback metadata probes, a page load or session update can replace a correctly persisted context window with the fallback value and incorrectly shrink the compression threshold. Keeping the credential with the matched provider metadata prevents premature compaction and keeps session hydration aligned with the runtime model configuration.

## Contract Routing

Task type: Runtime/session metadata bug fix.

Touched areas:
- Session hydration context-length reconstruction in `api/routes.py`.
- Streaming completion/fallback usage metadata in `api/streaming.py`.
- Persisted session `context_length` / `threshold_tokens` invariants.

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`

State layer / invariant:
- Model context metadata and session metadata should preserve the authenticated provider-reported context window across hydration and stream fallback paths.
- Static hydration should not clobber a larger persisted context window by doing an anonymous metadata probe that falls back to 256K.

Evidence:
- Added focused regression tests for route lookup/pass-through and streaming fallback callsites.
- Re-ran adjacent context-provider regression tests covering custom provider overrides and default-only context caps.

## Verification

```bash
uv run --with pytest --with pyyaml --with requests pytest \
  tests/test_issue1896_context_length_fallback_args.py \
  tests/test_issue3717_context_length_provider_overrides.py \
  tests/test_issue3256_context_length_default_only_guard.py \
  tests/test_issue3718_live_models_custom_probe.py \
  -q
```

Result:

```text
40 passed in 2.13s
```

```bash
python3 scripts/ruff_lint.py --diff upstream/master
```

Result:

```text
ruff_lint: no changed .py files vs upstream/master (df6cfd0a1546). OK.
```

```bash
git diff --check upstream/master
```

Result: clean.

Additional review:
- agy read-only code review completed with no blocking findings.
- The suggested `${ENV_VAR}` and `key_env` regression tests were added before the final verification run.

## Risks / Follow-ups

- The fix intentionally reuses the matched custom-provider config snapshot instead of re-reading global config, so profile-scoped static hydration stays aligned with the active profile.
- API keys remain server-side and are only passed to metadata probing; they are not persisted to session metadata or exposed to the browser.
- Legacy `hermes-agent` builds that do not accept the `api_key` keyword still fall back through the existing `TypeError` legacy call path.
- Full live-provider validation depends on an authenticated custom provider endpoint, so this PR covers the behavior with focused unit tests and callsite guards rather than a networked integration test.

## Model Used

- Provider: hermes-webui, hermes-agent, antigravity-cli
- Model: codex/gpt-5.5 (agents), google/gemini-3.5-flash-high (cli code review)
- Notable tool use:
  - Hermes file/terminal tools for implementation and verification.
  - agy read-only review for independent patch review.
  - GitHub CLI for issue/branch/compare checks.

