### PR TITLE
docs(onboarding): document AIML API custom-provider setup (#4045)

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -93,11 +93,16 @@ The setup step groups providers by how much information they usually need.
 | Group | Examples | What you usually enter |
 |---|---|---|
 | Easy start | OpenRouter, Anthropic, OpenAI | API key and model. |
-| Open / self-hosted | Ollama, LM Studio, custom OpenAI-compatible | Base URL, model, optional API key. |
+| Open / self-hosted | Ollama, LM Studio, custom OpenAI-compatible, AIML API | Base URL, model, optional API key. |
 | Specialized | Gemini, DeepSeek, Xiaomi MiMo, Z.AI / GLM, NVIDIA NIM, Mistral, xAI | Provider API key and default model. |
 
 For API-key providers, the wizard writes the key to the active Hermes `.env`
 file and writes the default model/provider to `config.yaml`.
+
+For local providers, the API key field can be blank when the server is keyless.
+Most LM Studio, Ollama, vLLM, llama-server, and TabbyAPI installs run this way.
+Use **Test connection** to verify the Base URL and populate the model list
+before continuing.
 
 AIML API uses the existing custom OpenAI-compatible setup path, not a
 first-class built-in Hermes provider id. Configure it under the
@@ -107,11 +112,6 @@ at `AIMLAPI_API_KEY` if you want the custom provider to read its key from the
 environment. Create or manage keys at `https://aimlapi.com/app/keys`. Model
 discovery comes from the live `/v1/models` response for that endpoint, not from
 a static WebUI-maintained model list.
-
-For local providers, the API key field can be blank when the server is keyless.
-Most LM Studio, Ollama, vLLM, llama-server, and TabbyAPI installs run this way.
-Use **Test connection** to verify the Base URL and populate the model list
-before continuing.
 
 Advanced provider flows such as Nous Portal and GitHub Copilot are still
 terminal-first. OpenAI Codex and Anthropic Claude Code OAuth can be started in

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -99,6 +99,15 @@ The setup step groups providers by how much information they usually need.
 For API-key providers, the wizard writes the key to the active Hermes `.env`
 file and writes the default model/provider to `config.yaml`.
 
+AIML API uses the existing custom OpenAI-compatible setup path, not a
+first-class built-in Hermes provider id. Configure it under the
+custom-provider flow with Base URL `https://api.aimlapi.com/v1`, then use
+either the normal custom-provider API key field or a config entry that points
+at `AIMLAPI_API_KEY` if you want the custom provider to read its key from the
+environment. Create or manage keys at `https://aimlapi.com/app/keys`. Model
+discovery comes from the live `/v1/models` response for that endpoint, not from
+a static WebUI-maintained model list.
+
 For local providers, the API key field can be blank when the server is keyless.
 Most LM Studio, Ollama, vLLM, llama-server, and TabbyAPI installs run this way.
 Use **Test connection** to verify the Base URL and populate the model list


### PR DESCRIPTION

## Thinking Path

- Hermes WebUI already supports AIML API through the generic custom OpenAI-compatible path, but the onboarding docs do not say that explicitly.
- The runtime does not currently expose `aimlapi` as a first-class provider id, so a built-in Settings card would advertise a route the backend cannot actually resolve.
- The safe reviewable slice is to document the exact custom-provider setup path, including the fixed Base URL, the optional `AIMLAPI_API_KEY` env-backed config pattern, and the live `/v1/models` discovery behavior.

## What Changed

- `docs/onboarding.md`: document AIML API as a custom OpenAI-compatible provider, including Base URL `https://api.aimlapi.com/v1`, key-management URL `https://aimlapi.com/app/keys`, the optional env-backed `AIMLAPI_API_KEY` pattern, and the fact that model discovery comes from live `/v1/models`.

## Why It Matters

This gives AIML API users a concrete setup path that matches what Hermes can actually route today. It also avoids creating a misleading built-in provider surface before the upstream runtime grows a real `aimlapi` provider id.

## Verification

No targeted local test applies to this docs-only change.

## Risks / Follow-ups

- This does not add a first-class `aimlapi` runtime provider id. If upstream wants that later, it should land in Hermes Agent first and then be reflected in WebUI.
- The change is documentation-only, so users still configure AIML API through the existing custom-provider UI/path.

## Model Used

GPT 5.5 via Codex CLI
