### PR TITLE
fix(mobile): constrain Worklog summary overflow on narrow viewports (#4064)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2834,8 +2834,9 @@ body.resizing .sidebar{transition:none!important;}
   margin:4px 0 14px;
 }
 .tool-worklog-summary{
-  width:auto;
   display:inline-flex;
+  max-width:100%;
+  min-width:0;
   align-items:center;
   gap:9px;
   padding:5px 8px;
@@ -2856,6 +2857,8 @@ body.resizing .sidebar{transition:none!important;}
   font-weight:500;
   line-height:var(--message-body-line-height);
   letter-spacing:0;
+  flex:1 1 auto;
+  min-width:0;
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;

--- a/tests/test_issue4064_worklog_mobile_overflow.py
+++ b/tests/test_issue4064_worklog_mobile_overflow.py
@@ -1,0 +1,44 @@
+"""Regression guard for worklog summary overflow on narrow mobile viewports."""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _rule(selector: str) -> str:
+    start = STYLE_CSS.find(selector)
+    assert start >= 0, f"{selector} selector not found in style.css"
+    end = STYLE_CSS.find("}", start)
+    assert end >= 0, f"{selector} rule did not close"
+    return STYLE_CSS[start:end]
+
+
+def test_worklog_summary_no_longer_uses_auto_width_inline_flex():
+    """The summary button must be width-bounded inside the chat column."""
+    rule = _rule(".tool-worklog-summary{")
+    assert "width:auto" not in rule, (
+        "The worklog summary must not force width:auto; that lets long one-line "
+        "labels widen narrow mobile viewports."
+    )
+    assert "display:inline-flex" in rule, "The summary should keep its inline-flex layout."
+    assert "max-width:100%" in rule, (
+        "The worklog summary must cap itself to the available message width."
+    )
+    assert "min-width:0" in rule, (
+        "The worklog summary must allow its inner label to shrink inside the chat column."
+    )
+
+
+def test_worklog_summary_label_can_shrink_with_ellipsis():
+    """The long summary label must be the shrinkable flex child."""
+    rule = _rule(".tool-worklog-summary .tool-worklog-label{")
+    assert "white-space:nowrap" in rule, "The summary copy should stay single-line."
+    assert "text-overflow:ellipsis" in rule, "The summary copy should still ellipsize."
+    assert "flex:1 1 auto" in rule, (
+        "The summary label must be a shrinkable flex child so it truncates before widening the viewport."
+    )
+    assert "min-width:0" in rule, (
+        "The summary label must opt out of the default flex min-width:auto clamp."
+    )

--- a/tests/test_issue4064_worklog_mobile_overflow.py
+++ b/tests/test_issue4064_worklog_mobile_overflow.py
@@ -10,9 +10,18 @@ STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 def _rule(selector: str) -> str:
     start = STYLE_CSS.find(selector)
     assert start >= 0, f"{selector} selector not found in style.css"
-    end = STYLE_CSS.find("}", start)
-    assert end >= 0, f"{selector} rule did not close"
-    return STYLE_CSS[start:end]
+    open_brace = STYLE_CSS.find("{", start + len(selector) - 1)
+    assert open_brace >= 0, f"{selector} rule did not open"
+    depth = 0
+    for idx in range(open_brace, len(STYLE_CSS)):
+        ch = STYLE_CSS[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return STYLE_CSS[start:idx]
+    raise AssertionError(f"{selector} rule did not close")
 
 
 def test_worklog_summary_no_longer_uses_auto_width_inline_flex():


### PR DESCRIPTION

## Thinking Path

- The reported Android sideways-pan bug maps to a specific layout contract, not to the broader Activity/Worklog UX debate.
- Current Worklog summaries use long one-line text, but their dedicated CSS overrides the normal full-width group-header layout with an auto-width inline-flex shell.
- The safest fix is to keep the existing UI semantics and only re-bound the summary layout so long labels shrink inside the chat column instead of widening it.

## What Changed

- `static/style.css`: make the Worklog summary row width-bounded and mobile-safe while preserving the current visual treatment.
- `tests/test_issue4064_worklog_mobile_overflow.py`: add a focused regression for the overflow-prone Worklog summary contract.

## Why It Matters

Mobile users can scroll the transcript normally again without the Worklog summary pulling the page sideways, and the compact Worklog UI stays readable instead of destabilizing the chat layout.

## Verification

```powershell
pytest tests/test_issue4064_worklog_mobile_overflow.py -v --timeout=60
npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs static/ui.js static/style.css
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- This should stay a narrow layout fix, not a redesign of Activity/Worklog presentation or disclosure behavior.
- If the open Transparent Stream work lands first and materially changes the Worklog shell, this patch may need a mechanical rebase onto the new markup.

## Model Used

Claude Opus 4.6 via Claude Code CLI
