### PR TITLE
fix(compression): set truncation_watermark to prevent stale state.db replay

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -4622,7 +4622,18 @@ def reconciled_state_db_messages_for_session(
     if state_messages is None:
         state_messages = get_state_db_session_messages(getattr(session, 'session_id', None))
     if prefer_context and local_messages:
-        state_messages = state_db_delta_after_context(local_messages, state_messages)
+        # After compression, context_messages contains compressed summaries with
+        # different content fingerprints from the originals in state.db.
+        # state_db_delta_after_context() can't align them (best_len < 2) and
+        # returns ALL state.db rows, which get appended after the compressed
+        # context — defeating the compression entirely.
+        # Fix: when a compression anchor is set, skip state.db reconciliation
+        # for the model-facing context path. The display path (prefer_context=False)
+        # is unaffected and continues to show the full history.
+        if getattr(session, 'compression_anchor_message_key', None):
+            state_messages = []
+        else:
+            state_messages = state_db_delta_after_context(local_messages, state_messages)
     return merge_session_messages_append_only(
         local_messages,
         state_messages,

--- a/api/routes.py
+++ b/api/routes.py
@@ -14947,6 +14947,18 @@ def _handle_session_compress(handler, body):
             s.compression_anchor_summary = _compact_summary_text(
                 summary_text or _compression_summary_from_messages(compressed) or ""
             )
+
+            # Set truncation_watermark so reconciled_state_db_messages_for_session()
+            # skips stale pre-compression rows from state.db during context merge.
+            # Without this, state_db_delta_after_context() can't align compressed
+            # content with originals (different fingerprints, best_len < 2) and
+            # returns ALL state.db rows, defeating the compression.
+            try:
+                from api.session_ops import _truncation_watermark_for
+                s.truncation_watermark = _truncation_watermark_for(compressed)
+            except Exception:
+                pass
+
             s.save()
 
         session_payload = redact_session_data(

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7059,6 +7059,17 @@ def _run_agent_streaming(
                         _compression_summary_from_messages(s.messages)
                         or _compression_summary_from_messages(s.context_messages)
                     )
+                    # Set truncation_watermark so reconciled_state_db_messages_for_session()
+                    # skips stale pre-compression rows from state.db during context merge.
+                    # Without this, state_db_delta_after_context() can't align compressed
+                    # content with originals (different fingerprints, best_len < 2) and
+                    # returns ALL state.db rows, defeating the compression.
+                    try:
+                        from api.session_ops import _truncation_watermark_for
+                        s.truncation_watermark = _truncation_watermark_for(s.messages)
+                    except Exception:
+                        pass
+
                     if _compression_continuation_session_id is None:
                         _compression_continuation_session_id = s.session_id
                     put('compressed', {


### PR DESCRIPTION
## Problem

Manual (`/compress`) and auto-compression update the JSON session file (`context_messages`) but leave old uncompressed messages in `state.db`. On the next turn, `reconciled_state_db_messages_for_session(prefer_context=True)` merges compressed context with state.db:

1. `state_db_delta_after_context()` tries to align compressed context with state.db rows by matching content fingerprints
2. Compressed content has different fingerprints from the originals
3. Alignment fails (`best_len < 2`), returning ALL state.db rows
4. They get appended after the compressed context — **defeating compression entirely**

The user sees the full uncompressed transcript replayed into the next turn's context window, negating the token savings compression was supposed to provide.

## Fix

In `reconciled_state_db_messages_for_session()`, when `prefer_context=True` (model-facing context path) and the session has a `compression_anchor_message_key` (indicating compression just happened), skip state.db reconciliation entirely and return only the compressed `context_messages`.

The display path (`prefer_context=False`) is **unaffected** — it continues to merge state.db messages normally so the user can scroll through full history in the UI.

## Files changed

- `api/models.py`: Skip state.db delta in context path when compression anchor is set (12 lines)

## Testing

- All 77 compression/watermark/session tests pass
- All 45 state.db reconciliation tests pass