### PR TITLE
feat(ux): enlarge rendered Mermaid diagrams in chat (#4075)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 # Hermes Web UI -- Changelog
 
 ## [Unreleased]
+### Added
+
+- **Rendered Mermaid diagrams can now be enlarged in chat (#4075).** Clicking a Mermaid diagram opens it in the existing fullscreen lightbox so larger graphs are readable without leaving the conversation. (#4075)
 
 ## [v0.51.386] — 2026-06-13 — Release MY (voice mode survives a dropped speechSynthesis onend, #3983)
 

--- a/static/style.css
+++ b/static/style.css
@@ -1729,6 +1729,7 @@
   .img-lightbox{position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,.82);display:flex;align-items:center;justify-content:center;cursor:zoom-out;animation:lb-in .15s ease;}
   @keyframes lb-in{from{opacity:0}to{opacity:1}}
   .img-lightbox img{max-width:90vw;max-height:90vh;object-fit:contain;border-radius:8px;box-shadow:0 8px 48px rgba(0,0,0,.6);cursor:default;}
+  .img-lightbox .mermaid-lightbox-svg{max-width:90vw;max-height:90vh;width:auto;height:auto;display:block;background:#fff;box-shadow:0 8px 48px rgba(0,0,0,.6);cursor:default;}
   .img-lightbox-close{position:absolute;top:16px;right:20px;width:36px;height:36px;border:none;border-radius:50%;background:rgba(255,255,255,.12);color:#fff;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background .15s;}
   .img-lightbox-close:hover{background:rgba(255,255,255,.22);}
   .img-lightbox-nav{position:absolute;top:50%;transform:translateY(-50%);width:44px;height:44px;border:none;border-radius:50%;background:rgba(255,255,255,.12);color:#fff;font-size:28px;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background .15s,opacity .15s;z-index:1;opacity:.6;}
@@ -4531,7 +4532,7 @@ main.main > #mainPlugin{display:none;}
 /* ── Mermaid diagrams ── */
 .mermaid-block{background:var(--code-bg);border-radius:8px;padding:16px;margin:8px 0;overflow-x:auto;}
 .mermaid-rendered{background:transparent;padding:8px 0;}
-.mermaid-rendered svg{max-width:100%;height:auto;}
+.mermaid-rendered svg{max-width:100%;height:auto;cursor:zoom-in;}
 
 /* ── Session projects ── */
 .session-source-tabs{display:flex;gap:4px;padding:4px 10px 8px;flex-shrink:0;}

--- a/static/style.css
+++ b/static/style.css
@@ -1729,7 +1729,7 @@
   .img-lightbox{position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,.82);display:flex;align-items:center;justify-content:center;cursor:zoom-out;animation:lb-in .15s ease;}
   @keyframes lb-in{from{opacity:0}to{opacity:1}}
   .img-lightbox img{max-width:90vw;max-height:90vh;object-fit:contain;border-radius:8px;box-shadow:0 8px 48px rgba(0,0,0,.6);cursor:default;}
-  .img-lightbox .mermaid-lightbox-svg{max-width:90vw;max-height:90vh;width:auto;height:auto;display:block;background:#fff;box-shadow:0 8px 48px rgba(0,0,0,.6);cursor:default;}
+  .img-lightbox .mermaid-lightbox-svg{max-width:90vw;max-height:90vh;width:auto;height:auto;display:block;background:var(--code-bg);box-shadow:0 8px 48px rgba(0,0,0,.6);cursor:default;}
   .img-lightbox-close{position:absolute;top:16px;right:20px;width:36px;height:36px;border:none;border-radius:50%;background:rgba(255,255,255,.12);color:#fff;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background .15s;}
   .img-lightbox-close:hover{background:rgba(255,255,255,.22);}
   .img-lightbox-nav{position:absolute;top:50%;transform:translateY(-50%);width:44px;height:44px;border:none;border-radius:50%;background:rgba(255,255,255,.12);color:#fff;font-size:28px;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background .15s,opacity .15s;z-index:1;opacity:.6;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -706,6 +706,15 @@ function _openMermaidLightbox(svgEl) {
         }
       });
     });
+    clone.querySelectorAll('style').forEach(styleEl => {
+      let styleText = styleEl.textContent || '';
+      idMap.forEach((nextId, originalId) => {
+        const escapedId = originalId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        styleText = styleText.replace(new RegExp(`url\\(#${escapedId}\\)`, 'g'), `url(#${nextId})`);
+        styleText = styleText.replace(new RegExp(`(^|[^\\w-])#${escapedId}(?=$|[^\\w-])`, 'g'), (match, prefix) => `${prefix}#${nextId}`);
+      });
+      styleEl.textContent = styleText;
+    });
   }
   clone.classList.add('mermaid-lightbox-svg');
   clone.removeAttribute('width');

--- a/static/ui.js
+++ b/static/ui.js
@@ -675,6 +675,31 @@ function _openImgLightbox(imgEl) {
   }
   _openImgLightboxWithNav(src, alt, allImages, startIndex);
 }
+function _openMermaidLightbox(svgEl) {
+  if(!svgEl) return;
+  const lb = document.createElement('div');
+  lb.className = 'img-lightbox';
+  lb.setAttribute('role', 'dialog');
+  lb.setAttribute('aria-label', 'Mermaid diagram');
+  const clone = svgEl.cloneNode(true);
+  clone.classList.add('mermaid-lightbox-svg');
+  clone.removeAttribute('width');
+  clone.removeAttribute('height');
+  clone.onclick = e => e.stopPropagation();
+  const cls = document.createElement('button');
+  cls.className = 'img-lightbox-close';
+  cls.setAttribute('aria-label', 'Close');
+  cls.textContent = '×';
+  cls.onclick = () => _closeImgLightbox(lb);
+  lb.appendChild(clone);
+  lb.appendChild(cls);
+  lb.onclick = () => _closeImgLightbox(lb);
+  lb._keyHandler = e => {
+    if(e.key==='Escape') _closeImgLightbox(lb);
+  };
+  document.body.appendChild(lb);
+  document.addEventListener('keydown', lb._keyHandler);
+}
 function _openImgLightboxWithNav(src, alt, images, index) {
   const lb = document.createElement('div');
   lb.className = 'img-lightbox';
@@ -772,6 +797,8 @@ document.addEventListener('click', e => {
   // Message-attached images (already wired since v0.50.x).
   let img = e.target.closest('.msg-media-img');
   if(img){ _openImgLightbox(img); return; }
+  const mermaidSvg = e.target.closest('.mermaid-rendered svg');
+  if(mermaidSvg){ _openMermaidLightbox(mermaidSvg); return; }
   // Composer attach-tray image thumbnails — click any pasted/dropped image
   // chip to lightbox-zoom it before sending. Excludes audio/video chips,
   // which keep their inline media controls. SVG thumbnails (.attach-thumb--svg)

--- a/static/ui.js
+++ b/static/ui.js
@@ -680,8 +680,33 @@ function _openMermaidLightbox(svgEl) {
   const lb = document.createElement('div');
   lb.className = 'img-lightbox';
   lb.setAttribute('role', 'dialog');
+  lb.setAttribute('aria-modal', 'true');
   lb.setAttribute('aria-label', 'Mermaid diagram');
   const clone = svgEl.cloneNode(true);
+  const idMap = new Map();
+  const idPrefix = 'mermaid-lightbox-'+Math.random().toString(36).slice(2,10)+'-';
+  const idNodes = [clone, ...clone.querySelectorAll('[id]')].filter(el => el.id);
+  idNodes.forEach(el => {
+    const nextId = idPrefix + el.id;
+    idMap.set(el.id, nextId);
+    el.id = nextId;
+  });
+  if(idMap.size){
+    const refAttrs = ['href','xlink:href','fill','stroke','filter','clip-path','mask','marker-start','marker-mid','marker-end','aria-labelledby','aria-describedby'];
+    [clone, ...clone.querySelectorAll('*')].forEach(el => {
+      refAttrs.forEach(attr => {
+        const value = el.getAttribute(attr);
+        if(!value) return;
+        let nextValue = value.replace(/url\(#([^)]+)\)/g, (match, refId) => idMap.has(refId) ? `url(#${idMap.get(refId)})` : match);
+        if(nextValue.startsWith('#') && idMap.has(nextValue.slice(1))){
+          nextValue = '#'+idMap.get(nextValue.slice(1));
+        }
+        if(nextValue !== value){
+          el.setAttribute(attr, nextValue);
+        }
+      });
+    });
+  }
   clone.classList.add('mermaid-lightbox-svg');
   clone.removeAttribute('width');
   clone.removeAttribute('height');
@@ -704,6 +729,7 @@ function _openImgLightboxWithNav(src, alt, images, index) {
   const lb = document.createElement('div');
   lb.className = 'img-lightbox';
   lb.setAttribute('role', 'dialog');
+  lb.setAttribute('aria-modal', 'true');
   lb.setAttribute('aria-label', alt || 'Image');
   const img = document.createElement('img');
   img.src = src;

--- a/tests/test_issue4075_mermaid_lightbox.py
+++ b/tests/test_issue4075_mermaid_lightbox.py
@@ -36,6 +36,12 @@ class TestMermaidLightboxHelper:
         assert "const idPrefix = 'mermaid-lightbox-'" in src
         assert "replace(/url\\(#([^)]+)\\)/g" in src
 
+    def test_mermaid_lightbox_rewrites_embedded_style_selectors(self):
+        src = _ui_js()
+        assert "clone.querySelectorAll('style').forEach(styleEl => {" in src
+        assert "styleText = styleText.replace(new RegExp(`url\\\\(#${escapedId}\\\\)`" in src
+        assert "styleText = styleText.replace(new RegExp(`(^|[^\\\\w-])#${escapedId}(?=$|[^\\\\w-])`" in src
+
 
 class TestDocumentClickDelegate:
     def test_delegate_routes_rendered_mermaid_svgs_before_attach_thumb(self):

--- a/tests/test_issue4075_mermaid_lightbox.py
+++ b/tests/test_issue4075_mermaid_lightbox.py
@@ -73,6 +73,7 @@ class TestMermaidLightboxCss:
         src = _style_css()
         rule = ".img-lightbox .mermaid-lightbox-svg{max-width:90vw;max-height:90vh;"
         assert rule in src
+        assert "background:var(--code-bg);" in src
 
 
 class TestLightboxAria:

--- a/tests/test_issue4075_mermaid_lightbox.py
+++ b/tests/test_issue4075_mermaid_lightbox.py
@@ -1,0 +1,62 @@
+"""Static regression coverage for Mermaid diagram lightbox wiring."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+UI = ROOT / "static" / "ui.js"
+STYLE = ROOT / "static" / "style.css"
+
+
+def _ui_js() -> str:
+    return UI.read_text(encoding="utf-8")
+
+
+def _style_css() -> str:
+    return STYLE.read_text(encoding="utf-8")
+
+
+class TestMermaidLightboxHelper:
+    def test_mermaid_lightbox_has_dedicated_helper(self):
+        src = _ui_js()
+        assert "function _openMermaidLightbox(svgEl) {" in src
+        assert "const clone = svgEl.cloneNode(true);" in src
+        assert "clone.classList.add('mermaid-lightbox-svg');" in src
+
+    def test_mermaid_lightbox_reuses_existing_modal_chrome(self):
+        src = _ui_js()
+        assert "lb.className = 'img-lightbox';" in src
+        assert "cls.className = 'img-lightbox-close';" in src
+        assert "cls.onclick = () => _closeImgLightbox(lb);" in src
+
+
+class TestDocumentClickDelegate:
+    def test_delegate_routes_rendered_mermaid_svgs_before_attach_thumb(self):
+        src = _ui_js()
+        mermaid_branch = (
+            "  const mermaidSvg = e.target.closest('.mermaid-rendered svg');\n"
+            "  if(mermaidSvg){ _openMermaidLightbox(mermaidSvg); return; }\n"
+        )
+        attach_branch = (
+            "  img = e.target.closest('.attach-thumb');\n"
+            "  if(img && img.tagName === 'IMG'){\n"
+        )
+        assert mermaid_branch in src
+        assert attach_branch in src
+        assert src.index(mermaid_branch) < src.index(attach_branch)
+
+    def test_delegate_still_handles_message_images(self):
+        src = _ui_js()
+        msg_branch = "let img = e.target.closest('.msg-media-img');\n  if(img){ _openImgLightbox(img); return; }"
+        assert msg_branch in src
+
+
+class TestMermaidLightboxCss:
+    def test_rendered_mermaid_svg_advertises_zoom(self):
+        src = _style_css()
+        assert ".mermaid-rendered svg{max-width:100%;height:auto;cursor:zoom-in;}" in src
+
+    def test_lightbox_svg_uses_modal_viewport_limits(self):
+        src = _style_css()
+        rule = ".img-lightbox .mermaid-lightbox-svg{max-width:90vw;max-height:90vh;"
+        assert rule in src

--- a/tests/test_issue4075_mermaid_lightbox.py
+++ b/tests/test_issue4075_mermaid_lightbox.py
@@ -1,6 +1,7 @@
 """Static regression coverage for Mermaid diagram lightbox wiring."""
 
 from pathlib import Path
+import re
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -19,15 +20,21 @@ def _style_css() -> str:
 class TestMermaidLightboxHelper:
     def test_mermaid_lightbox_has_dedicated_helper(self):
         src = _ui_js()
-        assert "function _openMermaidLightbox(svgEl) {" in src
-        assert "const clone = svgEl.cloneNode(true);" in src
-        assert "clone.classList.add('mermaid-lightbox-svg');" in src
+        assert re.search(r"function\s+_openMermaidLightbox\(svgEl\)\s*\{", src)
+        assert "svgEl.cloneNode(true)" in src
+        assert "mermaid-lightbox-svg" in src
 
     def test_mermaid_lightbox_reuses_existing_modal_chrome(self):
         src = _ui_js()
-        assert "lb.className = 'img-lightbox';" in src
-        assert "cls.className = 'img-lightbox-close';" in src
-        assert "cls.onclick = () => _closeImgLightbox(lb);" in src
+        assert "img-lightbox" in src
+        assert "img-lightbox-close" in src
+        assert "_closeImgLightbox(lb)" in src
+
+    def test_mermaid_lightbox_rewrites_cloned_svg_ids(self):
+        src = _ui_js()
+        assert "const idMap = new Map();" in src
+        assert "const idPrefix = 'mermaid-lightbox-'" in src
+        assert "replace(/url\\(#([^)]+)\\)/g" in src
 
 
 class TestDocumentClickDelegate:
@@ -60,3 +67,9 @@ class TestMermaidLightboxCss:
         src = _style_css()
         rule = ".img-lightbox .mermaid-lightbox-svg{max-width:90vw;max-height:90vh;"
         assert rule in src
+
+
+class TestLightboxAria:
+    def test_lightboxes_set_aria_modal(self):
+        src = _ui_js()
+        assert src.count("setAttribute('aria-modal', 'true')") >= 2


### PR DESCRIPTION

## Thinking Path

- Mermaid already renders into inline SVG in chat, but those nodes never enter the existing `.msg-media-img` lightbox delegate, so large diagrams stay trapped at column width.
- Users already know the fullscreen image lightbox, so the narrowest fix is to reuse that affordance for rendered Mermaid output instead of introducing a new in-place pan/zoom system.
- Keep the change local to the post-render Mermaid path, the document click delegate, and a small CSS/test update so it does not overlap broader renderer work.

## What Changed

- `static/ui.js`: add a Mermaid-specific lightbox path and delegated click handling for rendered diagram SVGs, rewriting cloned SVG IDs plus embedded style/url references so Mermaid theming survives inside the existing overlay.
- `static/style.css`: add zoom affordance and fullscreen sizing rules for Mermaid SVGs shown in the existing overlay.
- `tests/test_issue4075_mermaid_lightbox.py`: pin the Mermaid lightbox helper, cloned-style rewrite, delegated click branch, and CSS contract with focused static assertions.
- `CHANGELOG.md`: note the new Mermaid diagram enlarge interaction for release notes.

## Why It Matters

Large Mermaid diagrams become readable without leaving the chat flow or screenshotting the output. Reusing the existing lightbox keeps the UX consistent with how Hermes already handles attached images.

## Verification

`pytest tests/test_issue4075_mermaid_lightbox.py -v --timeout=60`

`npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"`

Manual: open a chat message with a rendered Mermaid diagram, click the diagram, and confirm it opens fullscreen and closes cleanly.

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- This adds enlarge-to-fit behavior only; in-place pan/zoom can remain a later follow-up if users want more than fullscreen readability.

## Model Used

GPT 5.5 via Codex CLI
