### PR TITLE
Release MK (v0.51.372): markdown link-label inline code + /use skill autocomplete + mobile Worklog overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 ## [Unreleased]
 
+## [v0.51.372] — 2026-06-12 — Release MK (markdown link-label inline code, /use skill autocomplete, mobile Worklog overflow)
+
+### Fixed
+
+- **Inline code (and bold/italic/strikethrough) inside a markdown link label now renders correctly (#4001).** A link like `` [`abc123`](https://…) `` previously showed the literal `` `abc123` `` backticks (or escaped `&lt;code&gt;`) instead of a code span. The renderer now preserves `code`/`strong`/`em`/`del` formatting inside link labels while still escaping everything else and running the result through the existing tag/attribute sanitizer. (#4001)
+- **`/use` now autocompletes installed skill names (#3968).** Typing `/use ` offers the available skills, matching how `/model` and `/personality` already autocomplete their arguments. The suggestion list refreshes when skills are enabled, disabled, saved, or deleted. (#3968)
+- **The Worklog summary no longer causes sideways panning on narrow mobile viewports (#4064).** A long single-line Worklog label could widen the chat column past the screen on Android; the summary row is now bounded to the available width and truncates with an ellipsis instead. (#4064)
+
 ## [v0.51.371] — 2026-06-12 — Release MJ (low-risk batch: approval polling, composer/titlebar polish, slash-command parity, skill categories, French TTS)
 
 ### Fixed

--- a/static/commands.js
+++ b/static/commands.js
@@ -100,6 +100,8 @@ let _slashModelCache=null;
 let _slashModelCachePromise=null;
 let _slashPersonalityCache=null;
 let _slashPersonalityCachePromise=null;
+let _slashSkillCache=null;
+let _slashSkillCachePromise=null;
 let _agentCommandCache=null;
 let _agentCommandCachePromise=null;
 
@@ -117,6 +119,7 @@ function _invalidateSlashModelCache(){
 // define a window global — see tests/test_cli_only_slash_commands.py.
 if(typeof window!=='undefined'){
   window._invalidateSlashModelCache=_invalidateSlashModelCache;
+  window.invalidateSlashSkillCaches=invalidateSlashSkillCaches;
 }
 
 function _normalizeSlashSubArg(value){
@@ -198,10 +201,43 @@ async function _loadSlashPersonalitySubArgs(force=false){
   return _slashPersonalityCachePromise;
 }
 
+async function _loadSlashSkillSubArgs(force=false){
+  if(_slashSkillCache&&!force) return _slashSkillCache;
+  if(_slashSkillCachePromise&&!force) return _slashSkillCachePromise;
+  _slashSkillCachePromise=(async()=>{
+    try{
+      const data=await api('/api/skills');
+      const values=[];
+      for(const skill of (data&&data.skills)||[]){
+        const name=_normalizeSlashSubArg(skill&&skill.name);
+        if(name) values.push(name);
+      }
+      const deduped=Array.from(new Set(values)).sort((a,b)=>a.localeCompare(b));
+      _slashSkillCache=deduped;
+      return deduped;
+    }catch(_){
+      _slashSkillCache=null;
+      return [];
+    }finally{
+      _slashSkillCachePromise=null;
+    }
+  })();
+  return _slashSkillCachePromise;
+}
+
+function invalidateSlashSkillCaches(){
+  _slashSkillCache=null;
+  _slashSkillCachePromise=null;
+  _skillCommandCache=[];
+  _skillCommandCacheReady=false;
+  _skillCommandLoadPromise=null;
+}
+
 function _getSlashSubArgOptions(spec){
   if(Array.isArray(spec)) return Promise.resolve(spec.slice());
   if(spec==='models') return _loadSlashModelSubArgs();
   if(spec==='personalities') return _loadSlashPersonalitySubArgs();
+  if(spec==='skills') return _loadSlashSkillSubArgs();
   return Promise.resolve([]);
 }
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -3860,6 +3860,7 @@ async function toggleSkill(name, currentlyEnabled) {
         const skill = _skillsData.find(s => s.name === name);
         if (skill) skill.disabled = !newEnabled;
       }
+      if(typeof window!=='undefined'&&typeof window.invalidateSlashSkillCaches==='function') window.invalidateSlashSkillCaches();
       renderSkills(_skillsData || []);
     } else {
       setStatus((result && result.error) || t('skill_toggle_failed'));
@@ -4114,6 +4115,7 @@ async function saveSkillForm() {
     showToast(_editingSkillName ? t('skill_updated') : t('skill_created'));
     _skillsData = null;
     _cronSkillsCache = null;
+    if(typeof window!=='undefined'&&typeof window.invalidateSlashSkillCaches==='function') window.invalidateSlashSkillCaches();
     _editingSkillName = null;
     _skillPreFormDetail = null;
     await loadSkills();
@@ -4153,6 +4155,7 @@ async function deleteCurrentSkill() {
     _skillPreFormDetail = null;
     _skillsData = null;
     _cronSkillsCache = null;
+    if(typeof window!=='undefined'&&typeof window.invalidateSlashSkillCaches==='function') window.invalidateSlashSkillCaches();
     _skillMode = 'empty';
     const body = $('skillDetailBody');
     const empty = $('skillDetailEmpty');

--- a/static/style.css
+++ b/static/style.css
@@ -2834,8 +2834,9 @@ body.resizing .sidebar{transition:none!important;}
   margin:4px 0 14px;
 }
 .tool-worklog-summary{
-  width:auto;
   display:inline-flex;
+  max-width:100%;
+  min-width:0;
   align-items:center;
   gap:9px;
   padding:5px 8px;
@@ -2856,6 +2857,8 @@ body.resizing .sidebar{transition:none!important;}
   font-weight:500;
   line-height:var(--message-body-line-height);
   letter-spacing:0;
+  flex:1 1 auto;
+  min-width:0;
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;

--- a/static/ui.js
+++ b/static/ui.js
@@ -3530,6 +3530,21 @@ function renderMd(raw){
   // Inline backtick spans: restore <code> tags produced in the stash callback above.
   // Must happen BEFORE bold/italic so **`code`** → <strong><code>code</code></strong>.
   s=s.replace(/\x00F(\d+)\x00/g,(_,i)=>fence_stash[+i]);
+  const SAFE_LABEL_INLINE=/^<\/?(strong|em|del|code)([\s>]|$)/i;
+  function _markdownLabelHtml(label){
+    const _label_stash=[];
+    const tokenized=String(label||'').replace(/<\/?[a-z][^>]*>/gi,tag=>{
+      if(!SAFE_LABEL_INLINE.test(tag)) return tag;
+      _label_stash.push(tag);
+      return `\x00H${_label_stash.length-1}\x00`;
+    });
+    return esc(tokenized).replace(/\x00H(\d+)\x00/g,(_,i)=>_label_stash[+i]);
+  }
+  function _markdownAnchor(label,rawUrl){
+    const href=_markdownHref(rawUrl);
+    const internal=/^session:\/\//i.test(String(rawUrl||'')) || _isInternalSessionHref(href);
+    return `<a${internal?' class="session-link"':''} href="${href}"${internal?'':' target="_blank" rel="noopener"'}>${_markdownLabelHtml(label)}</a>`;
+  }
   // inlineMd: process bold/italic/code/links within a single line of text.
   // Used inside list items and blockquotes where the text may already contain
   // HTML from the pre-pass → bold pipeline, so we cannot call esc() directly.
@@ -3756,21 +3771,6 @@ function renderMd(raw){
     }catch(_){
       return false;
     }
-  }
-  const SAFE_LABEL_INLINE=/^<\/?(strong|em|del|code)([\s>]|$)/i;
-  function _markdownLabelHtml(label){
-    const _label_stash=[];
-    const tokenized=String(label||'').replace(/<\/?[a-z][^>]*>/gi,tag=>{
-      if(!SAFE_LABEL_INLINE.test(tag)) return tag;
-      _label_stash.push(tag);
-      return `\x00H${_label_stash.length-1}\x00`;
-    });
-    return esc(tokenized).replace(/\x00H(\d+)\x00/g,(_,i)=>_label_stash[+i]);
-  }
-  function _markdownAnchor(label,rawUrl){
-    const href=_markdownHref(rawUrl);
-    const internal=/^session:\/\//i.test(String(rawUrl||'')) || _isInternalSessionHref(href);
-    return `<a${internal?' class="session-link"':''} href="${href}"${internal?'':' target="_blank" rel="noopener"'}>${_markdownLabelHtml(label)}</a>`;
   }
   function _isSafeUrl(v, img){
     const raw=_safeAttrValue(v);

--- a/static/ui.js
+++ b/static/ui.js
@@ -3530,21 +3530,6 @@ function renderMd(raw){
   // Inline backtick spans: restore <code> tags produced in the stash callback above.
   // Must happen BEFORE bold/italic so **`code`** → <strong><code>code</code></strong>.
   s=s.replace(/\x00F(\d+)\x00/g,(_,i)=>fence_stash[+i]);
-  const SAFE_LABEL_INLINE=/^<\/?(strong|em|del|code)([\s>]|$)/i;
-  function _markdownLabelHtml(label){
-    const _label_stash=[];
-    const tokenized=String(label||'').replace(/<\/?[a-z][^>]*>/gi,tag=>{
-      if(!SAFE_LABEL_INLINE.test(tag)) return tag;
-      _label_stash.push(tag);
-      return `\x00H${_label_stash.length-1}\x00`;
-    });
-    return esc(tokenized).replace(/\x00H(\d+)\x00/g,(_,i)=>_label_stash[+i]);
-  }
-  function _markdownAnchor(label,rawUrl){
-    const href=_markdownHref(rawUrl);
-    const internal=/^session:\/\//i.test(String(rawUrl||'')) || _isInternalSessionHref(href);
-    return `<a${internal?' class="session-link"':''} href="${href}"${internal?'':' target="_blank" rel="noopener"'}>${_markdownLabelHtml(label)}</a>`;
-  }
   // inlineMd: process bold/italic/code/links within a single line of text.
   // Used inside list items and blockquotes where the text may already contain
   // HTML from the pre-pass → bold pipeline, so we cannot call esc() directly.
@@ -3771,6 +3756,23 @@ function renderMd(raw){
     }catch(_){
       return false;
     }
+  }
+  function _isSafeLabelInline(tag){
+    return /^<\/?(strong|em|del|code)([\s>]|$)/i.test(tag);
+  }
+  function _markdownLabelHtml(label){
+    const _label_stash=[];
+    const tokenized=String(label||'').replace(/<\/?[a-z][^>]*>/gi,tag=>{
+      if(!_isSafeLabelInline(tag)) return tag;
+      _label_stash.push(tag);
+      return `\x00H${_label_stash.length-1}\x00`;
+    });
+    return esc(tokenized).replace(/\x00H(\d+)\x00/g,(_,i)=>_label_stash[+i]);
+  }
+  function _markdownAnchor(label,rawUrl){
+    const href=_markdownHref(rawUrl);
+    const internal=/^session:\/\//i.test(String(rawUrl||'')) || _isInternalSessionHref(href);
+    return `<a${internal?' class="session-link"':''} href="${href}"${internal?'':' target="_blank" rel="noopener"'}>${_markdownLabelHtml(label)}</a>`;
   }
   function _isSafeUrl(v, img){
     const raw=_safeAttrValue(v);

--- a/static/ui.js
+++ b/static/ui.js
@@ -3757,10 +3757,20 @@ function renderMd(raw){
       return false;
     }
   }
+  const SAFE_LABEL_INLINE=/^<\/?(strong|em|del|code)([\s>]|$)/i;
+  function _markdownLabelHtml(label){
+    const _label_stash=[];
+    const tokenized=String(label||'').replace(/<\/?[a-z][^>]*>/gi,tag=>{
+      if(!SAFE_LABEL_INLINE.test(tag)) return tag;
+      _label_stash.push(tag);
+      return `\x00H${_label_stash.length-1}\x00`;
+    });
+    return esc(tokenized).replace(/\x00H(\d+)\x00/g,(_,i)=>_label_stash[+i]);
+  }
   function _markdownAnchor(label,rawUrl){
     const href=_markdownHref(rawUrl);
     const internal=/^session:\/\//i.test(String(rawUrl||'')) || _isInternalSessionHref(href);
-    return `<a${internal?' class="session-link"':''} href="${href}"${internal?'':' target="_blank" rel="noopener"'}>${esc(label)}</a>`;
+    return `<a${internal?' class="session-link"':''} href="${href}"${internal?'':' target="_blank" rel="noopener"'}>${_markdownLabelHtml(label)}</a>`;
   }
   function _isSafeUrl(v, img){
     const raw=_safeAttrValue(v);

--- a/tests/test_issue4001_inline_code_link_label.py
+++ b/tests/test_issue4001_inline_code_link_label.py
@@ -1,0 +1,22 @@
+from tests.test_renderer_js_behaviour import _render, driver_path  # noqa: F401
+
+
+def test_inline_code_inside_link_label_renders_as_code(driver_path):
+    out = _render(driver_path, "[`8c64957`](https://github.com/x/y)")
+    assert '<a href="https://github.com/x/y"' in out
+    assert "<code>8c64957</code>" in out
+    assert "&lt;code&gt;" not in out
+
+
+def test_list_item_link_label_keeps_inline_code(driver_path):
+    out = _render(driver_path, "- [`8c64957`](https://github.com/x/y)")
+    assert "<li>" in out
+    assert "<code>8c64957</code>" in out
+    assert "&lt;code&gt;" not in out
+
+
+def test_unknown_raw_html_inside_link_label_is_escaped_once(driver_path):
+    out = _render(driver_path, "[<script>alert(1)</script>](https://github.com/x/y)")
+    assert "<script>" not in out
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in out
+    assert "&amp;lt;script" not in out

--- a/tests/test_issue4001_inline_code_link_label.py
+++ b/tests/test_issue4001_inline_code_link_label.py
@@ -1,4 +1,6 @@
-from tests.test_renderer_js_behaviour import _render, driver_path  # noqa: F401
+pytest_plugins = ("tests.test_renderer_js_behaviour",)
+
+from tests.test_renderer_js_behaviour import _render
 
 
 def test_inline_code_inside_link_label_renders_as_code(driver_path):

--- a/tests/test_issue4064_worklog_mobile_overflow.py
+++ b/tests/test_issue4064_worklog_mobile_overflow.py
@@ -1,0 +1,44 @@
+"""Regression guard for worklog summary overflow on narrow mobile viewports."""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _rule(selector: str) -> str:
+    start = STYLE_CSS.find(selector)
+    assert start >= 0, f"{selector} selector not found in style.css"
+    end = STYLE_CSS.find("}", start)
+    assert end >= 0, f"{selector} rule did not close"
+    return STYLE_CSS[start:end]
+
+
+def test_worklog_summary_no_longer_uses_auto_width_inline_flex():
+    """The summary button must be width-bounded inside the chat column."""
+    rule = _rule(".tool-worklog-summary{")
+    assert "width:auto" not in rule, (
+        "The worklog summary must not force width:auto; that lets long one-line "
+        "labels widen narrow mobile viewports."
+    )
+    assert "display:inline-flex" in rule, "The summary should keep its inline-flex layout."
+    assert "max-width:100%" in rule, (
+        "The worklog summary must cap itself to the available message width."
+    )
+    assert "min-width:0" in rule, (
+        "The worklog summary must allow its inner label to shrink inside the chat column."
+    )
+
+
+def test_worklog_summary_label_can_shrink_with_ellipsis():
+    """The long summary label must be the shrinkable flex child."""
+    rule = _rule(".tool-worklog-summary .tool-worklog-label{")
+    assert "white-space:nowrap" in rule, "The summary copy should stay single-line."
+    assert "text-overflow:ellipsis" in rule, "The summary copy should still ellipsize."
+    assert "flex:1 1 auto" in rule, (
+        "The summary label must be a shrinkable flex child so it truncates before widening the viewport."
+    )
+    assert "min-width:0" in rule, (
+        "The summary label must opt out of the default flex min-width:auto clamp."
+    )

--- a/tests/test_issue4064_worklog_mobile_overflow.py
+++ b/tests/test_issue4064_worklog_mobile_overflow.py
@@ -10,9 +10,18 @@ STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 def _rule(selector: str) -> str:
     start = STYLE_CSS.find(selector)
     assert start >= 0, f"{selector} selector not found in style.css"
-    end = STYLE_CSS.find("}", start)
-    assert end >= 0, f"{selector} rule did not close"
-    return STYLE_CSS[start:end]
+    open_brace = STYLE_CSS.find("{", start + len(selector) - 1)
+    assert open_brace >= 0, f"{selector} rule did not open"
+    depth = 0
+    for idx in range(open_brace, len(STYLE_CSS)):
+        ch = STYLE_CSS[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return STYLE_CSS[start:idx]
+    raise AssertionError(f"{selector} rule did not close")
 
 
 def test_worklog_summary_no_longer_uses_auto_width_inline_flex():

--- a/tests/test_sprint47.py
+++ b/tests/test_sprint47.py
@@ -13,13 +13,43 @@ import pathlib
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 COMMANDS_JS = (REPO_ROOT / "static" / "commands.js").read_text(encoding="utf-8")
 BOOT_JS = (REPO_ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _function_body(source, name):
+    marker = f"function {name}("
+    start = source.find(marker)
+    assert start != -1, f"{name} function not found"
+    next_function = source.find("\nfunction ", start + len(marker))
+    next_async_function = source.find("\nasync function ", start + len(marker))
+    ends = [pos for pos in (next_function, next_async_function) if pos != -1]
+    end = min(ends) if ends else len(source)
+    return source[start:end]
 
 
 def test_skill_commands_are_loaded_from_api_skills_for_autocomplete():
     assert "loadSkillCommands" in COMMANDS_JS
     assert "api('/api/skills')" in COMMANDS_JS
     assert "source:'skill'" in COMMANDS_JS
+
+
+def test_use_command_declares_skills_subargs():
+    assert "{name:'use'" in COMMANDS_JS
+    assert "subArgs:'skills'" in COMMANDS_JS
+
+
+def test_skills_subargs_route_through_dedicated_loader():
+    assert "async function _loadSlashSkillSubArgs(force=false)" in COMMANDS_JS
+    assert "if(spec==='skills') return _loadSlashSkillSubArgs();" in COMMANDS_JS
+    assert "if(spec==='skills') return loadSkillCommands();" not in COMMANDS_JS
+
+
+def test_skill_mutations_invalidate_slash_skill_caches():
+    assert "function invalidateSlashSkillCaches()" in COMMANDS_JS
+    assert "window.invalidateSlashSkillCaches=invalidateSlashSkillCaches;" in COMMANDS_JS
+    for function_name in ("saveSkillForm", "deleteCurrentSkill", "toggleSkill"):
+        assert "window.invalidateSlashSkillCaches()" in _function_body(PANELS_JS, function_name)
 
 
 def test_builtin_commands_take_precedence_over_skill_slug_collisions():


### PR DESCRIPTION
## Release MK — v0.51.372

Phase-2 round 1. Three small, independent-surface contributor fixes (all rodboev). Sequential `--no-ff` merges onto fresh master, zero conflicts.

### PRs
| PR | Fix |
|---|---|
| #4017 | preserve inline code/bold/italic/strike inside markdown link labels in renderMd (#4001) |
| #4010 | `/use` autocompletes installed skill names (#3968) |
| #4066 | mobile Worklog summary no longer causes sideways panning (#4064) |

### Review gates (all green)
- **Codex** (diff vs origin/master): **SAFE TO SHIP** — verified #4017's `\x00H<n>\x00` stash namespace is NOT used by existing render stashes, restored label tags still pass the renderMd allowlist sanitizer (ui.js:3852) so attributes/schemes are stripped; #4010 escapes dropdown values + cache invalidators wired; #4066 pure CSS, no core-flow dependency.
- **Opus advisor**: **SAFE-TO-SHIP** — ran 21 XSS payloads through the sanitizer (all 4 safe tags, entity-encoding, token-spoofing, quoted-`>` attribute splitting, every block context); confirmed #4017 cannot leak unescaped HTML or let a dangerous attribute survive. Only note: a cosmetic `undefined` from raw-NUL token-spoofing (requires typing literal NUL bytes, resolves to a safe tag) — not a blocker.
- **Full suite** (single-thread): **8709 passed**, 9 skipped, 3 xpassed, 0 failed.
- ESLint runtime gate: clean. Ruff: clean. node -c: all 3 JS OK. Targeted tests 12/12 (incl renderMd inline-code + `<script>` escape-once).

### Files
`static/ui.js`, `static/commands.js`, `static/panels.js`, `static/style.css` + 3 test files.

Closes #4001, #3968, #4064.
