### PR TITLE
fix: prevent mobile worklog summary overflow

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2834,15 +2834,18 @@ body.resizing .sidebar{transition:none!important;}
   margin:4px 0 14px;
 }
 .tool-worklog-summary{
-  display:inline-flex;
+  width:100%;
   max-width:100%;
   min-width:0;
+  box-sizing:border-box;
+  display:flex;
   align-items:center;
   gap:9px;
   padding:5px 8px;
   border-radius:8px;
   margin:0 0 0 -8px;
   border:0;
+  overflow:hidden;
   color:var(--muted);
   font-size:var(--message-body-font-size);
   font-weight:500;
@@ -2851,14 +2854,14 @@ body.resizing .sidebar{transition:none!important;}
 }
 .as-dot{width:7px;height:7px;border-radius:50%;background:var(--muted);opacity:.45;flex-shrink:0;}
 .tool-worklog-summary .tool-worklog-label{
+  flex:1 1 auto;
+  min-width:0;
   color:var(--muted);
   font-family:inherit;
   font-size:var(--message-body-font-size);
   font-weight:500;
   line-height:var(--message-body-line-height);
   letter-spacing:0;
-  flex:1 1 auto;
-  min-width:0;
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
@@ -3041,6 +3044,7 @@ body.resizing .sidebar{transition:none!important;}
 .tool-worklog-tool-group,
 .tool-group{
   max-width:560px;
+  min-width:0;
   margin:0;
   padding:0;
   background:transparent;
@@ -3049,12 +3053,16 @@ body.resizing .sidebar{transition:none!important;}
 .tool-worklog-tool-group-head,
 .tool-group-head{
   width:100%;
+  max-width:100%;
+  min-width:0;
+  box-sizing:border-box;
   display:flex;
   align-items:center;
   gap:7px;
   padding:3px 8px;
   margin-left:-8px;
   border:0;
+  overflow:hidden;
   background:transparent;
   color:var(--muted);
   cursor:pointer;
@@ -3068,7 +3076,7 @@ body.resizing .sidebar{transition:none!important;}
 .tool-worklog-tool-group-head:hover,
 .tool-group-head:hover{background:var(--hover-bg);color:var(--muted);opacity:.86;}
 .tool-worklog-tool-group-label,
-.tg-sum{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.tg-sum{flex:1 1 auto;display:block;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .tool-worklog-tool-group-running,
 .tg-run{display:none;color:var(--accent-text);font-family:'SF Mono',ui-monospace,monospace;font-size:12px;font-weight:600;line-height:1.4;white-space:nowrap;}
 .tool-worklog-tool-group-body,

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -703,6 +703,47 @@ def test_messages_touch_scrolling_hints_present():
         ".messages must contain vertical overscroll so the transcript keeps the gesture"
 
 
+def test_worklog_summary_headers_stay_width_bounded():
+    """Worklog summary/header rows must be shrinkable so mobile transcripts cannot pan sideways.
+
+    Regression for #4064: a long summary such as "Ran 9 commands, read 14 files, searched
+    workspace ..." must be clipped inside the available width instead of widening the transcript.
+    """
+    summary = _declarations(_rule_body(CSS, ".tool-worklog-summary"))
+    assert summary.get("width") == "100%", \
+        "worklog summary rows must size to the available transcript width"
+    assert summary.get("max-width") == "100%", \
+        "worklog summary rows must never exceed the transcript width"
+    assert summary.get("min-width") == "0", \
+        "worklog summary rows must allow flex shrink instead of preserving content width"
+    assert summary.get("box-sizing") == "border-box", \
+        "worklog summary width must include padding so it stays viewport-safe on phones"
+    assert summary.get("overflow") == "hidden", \
+        "worklog summary rows must clip their own contents rather than widen the transcript"
+
+    summary_label = _declarations(_rule_body(CSS, ".tool-worklog-summary .tool-worklog-label"))
+    assert summary_label.get("flex") == "1 1 auto", \
+        "worklog summary labels must take the remaining row width and shrink on phones"
+    assert summary_label.get("min-width") == "0", \
+        "worklog summary labels need min-width:0 for ellipsis inside flex rows"
+
+    grouped_head = _declarations(_rule_body(CSS, ".tool-group-head"))
+    assert grouped_head.get("max-width") == "100%", \
+        "grouped worklog headers must stay inside the transcript width"
+    assert grouped_head.get("min-width") == "0", \
+        "grouped worklog headers must allow their label to shrink"
+    assert grouped_head.get("box-sizing") == "border-box", \
+        "grouped worklog header width must include padding on narrow screens"
+    assert grouped_head.get("overflow") == "hidden", \
+        "grouped worklog headers must clip long summaries instead of enabling sideways pan"
+
+    grouped_label = _declarations(_rule_body(CSS, ".tg-sum"))
+    assert grouped_label.get("flex") == "1 1 auto", \
+        "grouped worklog summary labels must own the remaining width and ellipsize"
+    assert grouped_label.get("min-width") == "0", \
+        "grouped worklog summary labels need min-width:0 to prevent viewport overflow"
+
+
 def test_100dvh_viewport_height():
     """Layout must use 100dvh (dynamic viewport height) for correct mobile sizing.
 


### PR DESCRIPTION
## Thinking Path
- Reproduced the problem from issue evidence: on mobile/Android widths, long compact Worklog summary rows can contribute to horizontal overflow and sideways transcript pan.
- Inspected the live/settled Worklog summary CSS and found width/shrink constraints were incomplete for both the live summary row and grouped Worklog headers.
- Chose a minimal CSS fix plus a static regression test, keeping the current Worklog UI model intact.

## What Changed
- Made `.tool-worklog-summary` width-bounded (`width/max-width: 100%`, `min-width: 0`, `box-sizing: border-box`, `overflow: hidden`) so it cannot widen the transcript beyond the available width.
- Made `.tool-worklog-summary .tool-worklog-label` shrinkable inside flex rows (`flex: 1 1 auto`, `min-width: 0`) so ellipsis can actually engage on narrow widths.
- Applied the same width/shrink protection to grouped Worklog headers (`.tool-group`, `.tool-group-head`, `.tg-sum`) so the grouped summary path cannot trigger the same overflow class.
- Added a mobile regression test in `tests/test_mobile_layout.py` covering the width-bounding contract for both the live summary row and grouped Worklog headers.

## Why It Matters
This prevents a long compact Worklog summary like `Ran 9 commands, read 14 files, searched workspace ...` from pushing the mobile chat surface wider than the viewport. On Android, that sideways overflow can make vertical transcript scrolling feel unstable because the transcript can then be dragged/panned to the right.

Fixes #4064.

## Verification
### Passed
- Static regression assertion added and executed directly:
  - `test_worklog_summary_headers_stay_width_bounded()` → PASS
- CSS presence/shape verified after patch:
  - width-bounding and shrink rules present in `static/style.css`
- Additional coding-agent review via `ccodex` concluded the current fix is sufficient and no further changes were needed.

### Environment-limited / not green in this local run
- `pytest tests/test_mobile_layout.py -q`
- `pytest tests/test_live_activity_timeline.py -q`

These were blocked by the current local test-server environment rather than this patch itself. The failing setup path timed out bringing up the isolated WebUI test server and reported unrelated environment issues such as:
- `Failed to load plugin 'nous': No module named 'hermes_cli.dashboard_auth'`
- `Could not import tool module tools.browser_dialog_tool: No module named 'websockets'`
- local test server healthcheck timing out under TLS startup

## Before / After Evidence
Issue evidence (same screenshots that motivated this patch):
- Long Worklog summary row on mobile:
  - https://gist.githubusercontent.com/MTGVim/3d75c3fc0901936657c6c93e8d6b59eb/raw/Screenshot_20260613_014229_Chrome.jpg
- Transcript visibly shifted sideways after horizontal pan / overflow:
  - https://gist.githubusercontent.com/MTGVim/3d75c3fc0901936657c6c93e8d6b59eb/raw/Screenshot_20260613_014638_Chrome.jpg

## Risks / Follow-ups
- This PR intentionally limits scope to width/shrink behavior for Worklog summary/header rows. It does not redesign the Worklog/Activity UX.
- A broader end-to-end/mobile visual verification pass is still desirable once the local test environment is healthy again.

## Model Used
- Main implementation/editing: Hermes Agent (OpenAI Codex transport in WebUI session)
- Additional review: `ccodex` via `ccs codex --dangerously-skip-permissions`
- Claude Code path was attempted initially but unavailable due local CLI auth state.

## AI Usage Disclosure
- Provider: OpenAI Codex transport via Hermes + CLIProxy-backed `ccodex`
- Model/Tooling: Hermes WebUI coding session with file/terminal tools; additional one-shot `ccodex` review
