### PR TITLE
Release MO (v0.51.376): Hide Thinking also hides Worklog reasoning (#3903)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 - **New RFC: Stable Assistant Turn Anchors for Live-to-Final rendering.** Defines a frontend presentation/reconciliation model for anchoring one assistant turn across live streaming, settlement, replay/reload/recovery, Compact Worklog, Transparent Stream, terminal states, artifacts, and side effects. (#3926)
 
+### Fixed
+
+- **Hide Thinking now also hides Worklog reasoning rows without hiding tool activity.** The `show_thinking=false` path now suppresses `.wl-reason` entries that come from reasoning text and prunes already-rendered rows when Thinking is toggled off, while preserving tool cards and ordinary Worklog anchor/progress rows. (#3903)
+
 ## [v0.51.358] — 2026-06-11 — Release LV (first-run password bootstrap hardening)
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.376] — 2026-06-13 — Release MO (Hide Thinking also hides Worklog reasoning, #3903)
+
+### Fixed
+
+- **Hiding Thinking now also hides Worklog reasoning rows, without hiding tool activity (#3903).** When reasoning/thinking display is turned off, the Worklog reasoning rows (`.wl-reason`) are now suppressed on both the live streaming path and the settled/reloaded render path, and any already-rendered reasoning rows are pruned when Thinking is toggled off — while tool cards and ordinary Worklog anchor/progress rows are preserved. (Previously the gate sat on an unused helper, so reasoning rows kept rendering even with Thinking off.) (#3903)
+
 ## [v0.51.375] — 2026-06-13 — Release MN (Transparent Stream activity display, #3820)
 
 ### Added
@@ -120,10 +126,6 @@
 
 - **Internal Stable Assistant Turn Anchors Phase 0 scaffold.** The browser now ships an inert `HermesAssistantTurnAnchors` helper surface plus a documented state-layer inventory for #3926, pinning current live/replay/settled source classifications and event dedupe precedence without changing visible chat rendering.
 - **New RFC: Stable Assistant Turn Anchors for Live-to-Final rendering.** Defines a frontend presentation/reconciliation model for anchoring one assistant turn across live streaming, settlement, replay/reload/recovery, Compact Worklog, Transparent Stream, terminal states, artifacts, and side effects. (#3926)
-
-### Fixed
-
-- **Hide Thinking now also hides Worklog reasoning rows without hiding tool activity.** The `show_thinking=false` path now suppresses `.wl-reason` entries that come from reasoning text and prunes already-rendered rows when Thinking is toggled off, while preserving tool cards and ordinary Worklog anchor/progress rows. (#3903)
 
 ## [v0.51.358] — 2026-06-11 — Release LV (first-run password bootstrap hardening)
 

--- a/static/commands.js
+++ b/static/commands.js
@@ -1362,6 +1362,7 @@ function cmdReasoning(args){
     const on=(arg==='show'||arg==='on');
     // Update the UI render gate immediately for responsiveness.
     window._showThinking=on;
+    if(!on&&typeof removeThinking==='function') removeThinking();
     if(typeof renderMessages==='function') renderMessages();
     // Persist via /api/reasoning → config.yaml display.show_reasoning
     // (CLI reads the same key).  Also mirror into WebUI settings.json

--- a/static/ui.js
+++ b/static/ui.js
@@ -6649,6 +6649,7 @@ function _renderWorklogReasonInto(row, text){
   row.innerHTML=html;
 }
 function _worklogReasonNodeFromText(text, attrs){
+  if(window._showThinking===false) return null;
   const html=_worklogReasonHtmlFromText(text);
   if(!html) return null;
   const row=document.createElement('div');
@@ -10633,9 +10634,10 @@ function removeThinking(){
   const turn=$('liveAssistantTurn');
   const blocks=_assistantTurnBlocks(turn);
   if(blocks) blocks.querySelectorAll('.agent-activity-thinking').forEach(el=>el.remove());
-  if(blocks) blocks.querySelectorAll('.tool-call-group[data-agent-activity-group="1"]').forEach(group=>{
+  if(blocks) blocks.querySelectorAll('.wl-reason[data-worklog-reason-source="reasoning"]').forEach(el=>el.remove());
+  if(blocks) blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-call-group[data-agent-activity-group="1"]').forEach(group=>{
     _syncToolCallGroupSummary(group);
-    if(!group.querySelector('.tool-card-row,.agent-activity-thinking')){
+    if(!group.querySelector('.tool-card-row,.agent-activity-thinking,.wl-reason')){
       if(typeof _clearActivityElapsedTimer==='function') _clearActivityElapsedTimer();
       group.remove();
     }

--- a/static/ui.js
+++ b/static/ui.js
@@ -7275,10 +7275,19 @@ function _syncWorklogReasonFromAnchor(group, anchor, displayTextOverride){
   const list=_toolWorklogListEl(group);
   if(!group||!list) return;
   const anchorKey=_worklogReasonAnchorKey(anchor);
+  const selector=anchorKey?`:scope > .wl-reason[data-worklog-anchor-key="${CSS.escape(anchorKey)}"]`:':scope > .wl-reason[data-worklog-anchor-reason="1"]';
+  // When reasoning/thinking display is turned off (#3903), do not render Worklog
+  // reasoning rows on the live OR settled path — remove any existing one and bail
+  // before building. (The gate must live here, in the actual render path, not in
+  // the unused _worklogReasonNodeFromText helper.)
+  if(window._showThinking===false){
+    const existing=list.querySelector(selector);
+    if(existing) existing.remove();
+    return;
+  }
   const html=arguments.length>2
     ? _worklogReasonHtmlFromAnchor(anchor, displayTextOverride)
     : _worklogReasonHtmlFromAnchor(anchor);
-  const selector=anchorKey?`:scope > .wl-reason[data-worklog-anchor-key="${CSS.escape(anchorKey)}"]`:':scope > .wl-reason[data-worklog-anchor-reason="1"]';
   let reason=list.querySelector(selector);
   if(!html){
     if(reason) reason.remove();
@@ -7344,6 +7353,8 @@ function _migrateLegacyLiveActivityGroupsToWorklog(blocks, worklog){
 }
 function _appendWorklogReason(list, anchor){
   if(!list) return null;
+  // Reasoning display off (#3903): never append a Worklog reasoning row.
+  if(window._showThinking===false) return null;
   const html=_worklogReasonHtmlFromAnchor(anchor);
   if(!html) return null;
   const reason=document.createElement('div');
@@ -9288,7 +9299,7 @@ function renderMessages(options){
     // regression vs master; same content-loss-on-switch class as #3668). The
     // `:not([data-live-thinking="1"])` / live-card guards below keep the active
     // turn's own live nodes from being double-built.
-    inner.querySelectorAll('.tool-worklog-group:not([data-compression-card]),.tool-call-group:not([data-compression-card]),.tool-card-row:not([data-compression-card]),.agent-activity-thinking:not([data-live-thinking="1"]):not([data-event-type="thinking"]),.wl-reason[data-worklog-reason-source="reasoning"]').forEach(el=>el.remove());
+    inner.querySelectorAll('.tool-worklog-group:not([data-compression-card]),.tool-call-group:not([data-compression-card]),.tool-card-row:not([data-compression-card]),.agent-activity-thinking:not([data-live-thinking="1"]):not([data-event-type="thinking"]),.wl-reason[data-worklog-anchor-reason="1"],.wl-reason[data-worklog-reason-source="reasoning"]').forEach(el=>el.remove());
     const byActivity = new Map();
     const assistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);
     const _assistantAnchorForActivity=(aIdx,segmentSeq,burstId)=>{
@@ -11478,7 +11489,7 @@ function removeThinking(){
   const turn=$('liveAssistantTurn');
   const blocks=_assistantTurnBlocks(turn);
   if(blocks) blocks.querySelectorAll('.agent-activity-thinking').forEach(el=>el.remove());
-  if(blocks) blocks.querySelectorAll('.wl-reason[data-worklog-reason-source="reasoning"]').forEach(el=>el.remove());
+  if(blocks) blocks.querySelectorAll('.wl-reason[data-worklog-anchor-reason="1"],.wl-reason[data-worklog-reason-source="reasoning"]').forEach(el=>el.remove());
   if(blocks) blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-call-group[data-agent-activity-group="1"]').forEach(group=>{
     _syncToolCallGroupSummary(group);
     if(!group.querySelector('.tool-card-row,.agent-activity-thinking,.wl-reason')){

--- a/tests/test_reasoning_show_hide.py
+++ b/tests/test_reasoning_show_hide.py
@@ -20,6 +20,23 @@ def read(rel):
     return (REPO / rel).read_text(encoding='utf-8')
 
 
+def function_body(src, name):
+    start = src.find(f"function {name}")
+    assert start != -1, f"{name} not found"
+    brace = src.find("{", start)
+    assert brace != -1, f"{name} body not found"
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[brace + 1:idx]
+    raise AssertionError(f"{name} body did not close")
+
+
 # ── api/config.py ─────────────────────────────────────────────────────────────
 
 class TestShowThinkingConfig:
@@ -79,6 +96,36 @@ class TestUiJsThinkingGate:
                     f"thinking card insertion must be gated: {line.strip()}"
                 )
                 break
+
+    def test_worklog_reasoning_rows_are_gated_by_show_thinking(self):
+        src = read('static/ui.js')
+        node_fn = function_body(src, "_worklogReasonNodeFromText")
+        assert 'window._showThinking===false' in node_fn and 'return null' in node_fn, (
+            "reasoning-source Worklog rows must not be created when thinking is hidden"
+        )
+
+    def test_show_thinking_gate_does_not_hide_worklog_anchor_text(self):
+        src = read('static/ui.js')
+        html_fn = function_body(src, "_worklogReasonHtmlFromText")
+        assert 'window._showThinking' not in html_fn, (
+            "the low-level Worklog text renderer is also used for anchor/progress text; "
+            "only reasoning-source rows should be gated"
+        )
+
+    def test_remove_thinking_prunes_reasoning_rows_but_preserves_tool_or_anchor_rows(self):
+        src = read('static/ui.js')
+        fn = function_body(src, "removeThinking")
+        assert '.wl-reason[data-worklog-reason-source="reasoning"]' in fn, (
+            "removeThinking must sweep already-rendered reasoning Worklog rows"
+        )
+        assert '.tool-card-row,.agent-activity-thinking,.wl-reason' in fn, (
+            "empty-group cleanup must preserve groups that still contain tool cards "
+            "or non-reasoning Worklog anchor rows"
+        )
+        assert '.live-worklog[data-live-worklog-shell="1"]' in fn, (
+            "live Worklog shells must be considered for cleanup after their reasoning "
+            "rows are removed"
+        )
 
 
 # ── static/messages.js ────────────────────────────────────────────────────────
@@ -157,6 +204,9 @@ class TestReasoningCommand:
         )
         assert 'renderMessages' in fn, (
             "show/hide branch must call renderMessages()"
+        )
+        assert "typeof removeThinking==='function'" in fn and "removeThinking()" in fn, (
+            "hide/off must prune already-rendered live Thinking and Worklog reasoning rows"
         )
         # Persistence: POST to /api/reasoning (CLI-shared config.yaml) AND
         # /api/settings (boot.js mirror).

--- a/tests/test_reasoning_show_hide.py
+++ b/tests/test_reasoning_show_hide.py
@@ -99,9 +99,17 @@ class TestUiJsThinkingGate:
 
     def test_worklog_reasoning_rows_are_gated_by_show_thinking(self):
         src = read('static/ui.js')
-        node_fn = function_body(src, "_worklogReasonNodeFromText")
-        assert 'window._showThinking===false' in node_fn and 'return null' in node_fn, (
-            "reasoning-source Worklog rows must not be created when thinking is hidden"
+        # The gate must sit in the ACTUAL render paths that build Worklog reasoning
+        # rows — _syncWorklogReasonFromAnchor (live + settled) and _appendWorklogReason
+        # (settled rebuild) — not in the unused _worklogReasonNodeFromText helper.
+        sync_fn = function_body(src, "_syncWorklogReasonFromAnchor")
+        assert 'window._showThinking===false' in sync_fn and 'return' in sync_fn, (
+            "_syncWorklogReasonFromAnchor must bail (and remove any existing row) "
+            "when thinking display is off"
+        )
+        append_fn = function_body(src, "_appendWorklogReason")
+        assert 'window._showThinking===false' in append_fn and 'return null' in append_fn, (
+            "_appendWorklogReason must not build a reasoning row when thinking is hidden"
         )
 
     def test_show_thinking_gate_does_not_hide_worklog_anchor_text(self):
@@ -115,8 +123,12 @@ class TestUiJsThinkingGate:
     def test_remove_thinking_prunes_reasoning_rows_but_preserves_tool_or_anchor_rows(self):
         src = read('static/ui.js')
         fn = function_body(src, "removeThinking")
-        assert '.wl-reason[data-worklog-reason-source="reasoning"]' in fn, (
-            "removeThinking must sweep already-rendered reasoning Worklog rows"
+        # The live/settled reasoning rows are tagged data-worklog-anchor-reason="1"
+        # (by _syncWorklogReasonFromAnchor / _appendWorklogReason); the sweep MUST
+        # target that attribute, not only the legacy data-worklog-reason-source.
+        assert '.wl-reason[data-worklog-anchor-reason="1"]' in fn, (
+            "removeThinking must sweep the actually-rendered reasoning Worklog rows "
+            '(data-worklog-anchor-reason="1")'
         )
         assert '.tool-card-row,.agent-activity-thinking,.wl-reason' in fn, (
             "empty-group cleanup must preserve groups that still contain tool cards "


### PR DESCRIPTION
## Release MO — v0.51.376 — Hide Thinking also hides Worklog reasoning (#3903)

Absorbs **#3971** (@franksong2702) — when reasoning/Thinking display is turned off, Worklog reasoning rows are now actually hidden, without hiding tool activity. Closes #3903.

### What changed
- `_syncWorklogReasonFromAnchor` (live + settled) removes any existing `.wl-reason` row and bails when `_showThinking===false`.
- `_appendWorklogReason` (settled rebuild) returns null when reasoning display is off.
- `removeThinking` + the settled-rebuild cleanup sweep both the real `data-worklog-anchor-reason="1"` rows and the legacy `data-worklog-reason-source="reasoning"`.
- Tests re-anchored to assert against the real render functions.

### Trifecta gate — note the catch
The contributor's branch as-staged placed the `_showThinking===false` gate on `_worklogReasonNodeFromText`, which has **zero callers** — so live/settled reasoning rows (built by `_syncWorklogReasonFromAnchor`/`_appendWorklogReason`) were never hidden, and `removeThinking` swept an attribute the real rows don't carry. The string-match tests passed against the dead function (green-suite blind spot). **Opus caught it; Codex + the full suite passed it.** Fixed by moving the gate to the real render paths.

- **Opus: SAFE-TO-SHIP** (after the fix — verified both paths suppress reasoning, no regression when on, no over-removal of tool/anchor rows).
- **Codex: SAFE TO SHIP** (re-gated on the fixed diff).
- **Full suite: 8765 passed**, 31 targeted tests, ESLint clean.

Thanks @franksong2702 — the live-path fix #3903 needed, now landing correctly.