### PR TITLE
Project assistant turn anchor activity scene rows

### DIFF
--- a/docs/architecture/stable-assistant-turn-anchor-phase0.md
+++ b/docs/architecture/stable-assistant-turn-anchor-phase0.md
@@ -23,10 +23,13 @@ streaming or rendering yet.
   pinned by tests before visible wiring begins.
 - Slice 4 starts RFC Phase 3 by routing settled assistant final prose through the
   anchor owner before `renderMessages()` renders the final assistant body.
-- The next independently reviewable boundary is activity/render-scene projection
-  for reasoning, tool rows, and transparent-stream/worklog metadata. `S.messages`,
-  `INFLIGHT`, stream-local state, and DOM nodes remain projection/cache layers
-  outside the settled final-prose path.
+- Slice 5 starts RFC Phase 5 by projecting anchor-owned activity events into a
+  renderer-neutral activity scene that Compact Worklog and Transparent Stream
+  can later consume from the same ordered rows.
+- The next independently reviewable boundary is wiring one current renderer to
+  the activity scene. `S.messages`, `INFLIGHT`, stream-local state, and DOM nodes
+  remain projection/cache layers outside the settled final-prose path and the
+  inert activity-scene projection.
 
 ## State Layers
 
@@ -135,6 +138,22 @@ content path.
 This is intentionally narrower than render-scene ownership: live stream tokens,
 replay hydration, worklog rows, transparent-stream rows, tool cards, `INFLIGHT`,
 and DOM continuity are still not consumed by the anchor registry in this slice.
+
+## Slice 5 Activity Scene Projection
+
+`HermesAssistantTurnAnchors.projectAssistantTurnAnchorActivityScene()` projects
+an anchor or registry into `activity_scene_v1`: identity, lifecycle,
+`final_answer`, `final_message_ref`, terminal state, and an ordered
+`activity_rows` list.
+
+The rows are renderer-neutral. Compact Worklog receives display hints such as
+`main_prose`, `collapsed_thinking`, `tool_row`, and `terminal_status_row`.
+Transparent Stream receives the same row IDs, order, kinds, roles, text, tool
+IDs, and sanitized payloads with a chronological display hint. This pins the
+shared input shape before either renderer is rewired.
+
+This slice is still inert. No current UI module consumes the activity scene.
+`renderMessages()` and the live streaming hot path are unchanged by this slice.
 
 ## Source Event Classification
 

--- a/docs/architecture/stable-assistant-turn-anchor-phase0.md
+++ b/docs/architecture/stable-assistant-turn-anchor-phase0.md
@@ -21,9 +21,12 @@ streaming or rendering yet.
   anchor seed excludes renderer presentation state, terminal states are exposed
   as constants with alias normalization, and replay + settlement ordering is
   pinned by tests before visible wiring begins.
-- The next independently reviewable boundary is Phase 3 settlement through the
-  anchor owner. `S.messages`, `INFLIGHT`, stream-local state, and DOM nodes remain
-  projection/cache layers until that wiring lands.
+- Slice 4 starts RFC Phase 3 by routing settled assistant final prose through the
+  anchor owner before `renderMessages()` renders the final assistant body.
+- The next independently reviewable boundary is activity/render-scene projection
+  for reasoning, tool rows, and transparent-stream/worklog metadata. `S.messages`,
+  `INFLIGHT`, stream-local state, and DOM nodes remain projection/cache layers
+  outside the settled final-prose path.
 
 ## State Layers
 
@@ -113,6 +116,25 @@ event identity, lifecycle, final answer reference, and activity events.
 `streamId`, and cached live text/tool state remain recovery or renderer caches
 until the matching field is explicitly moved. The fallback order is journal
 replay first, settled transcript second, `INFLIGHT` only for gaps.
+
+## Slice 4 Settled Final Projection
+
+`HermesAssistantTurnAnchors.projectAssistantTurnAnchorSettledMessageFinalAnswer()`
+projects one settled assistant transcript message through a local anchor
+registry. The settled transcript message reference remains the semantic
+authority (`content.final_message_ref`); `content.final_answer` is a derived
+render snapshot for the existing markdown pipeline.
+
+`renderMessages()` uses that projection only for settled assistant messages
+(`!isUser && !m._live`) and only after preserving the current content-array
+flattening behavior. It then continues through the existing inline-thinking and
+markdown rendering pipeline. If the anchor helper is unavailable or cannot
+produce a final answer, `renderMessages()` falls back to the existing message
+content path.
+
+This is intentionally narrower than render-scene ownership: live stream tokens,
+replay hydration, worklog rows, transparent-stream rows, tool cards, `INFLIGHT`,
+and DOM continuity are still not consumed by the anchor registry in this slice.
 
 ## Source Event Classification
 

--- a/static/assistant_turn_anchors.js
+++ b/static/assistant_turn_anchors.js
@@ -1,9 +1,9 @@
 // Stable Assistant Turn Anchors scaffold (#3926).
 //
-// This file is intentionally inert: it defines the current ownership inventory,
-// event classifications, and small owner helpers, but it does not register
-// anchors globally or change any renderer. Later phases can wire these helpers into
-// send(), attachLiveStream(), replay hydration, and renderMessages().
+// This file defines the current ownership inventory, event classifications, and
+// small owner helpers. It does not register anchors globally. The only renderer
+// wiring in this slice is settled assistant final-answer projection; live
+// streaming, replay hydration, tools, and DOM ownership remain unwired.
 (function(){
   const ROOT=(typeof window!=='undefined')?window:globalThis;
 
@@ -696,6 +696,96 @@
     });
   }
 
+  function _contextValue(context, keys){
+    return _firstOwn(context&&typeof context==='object'?context:{},keys);
+  }
+
+  function _messageValue(message, keys){
+    return _firstOwn(message&&typeof message==='object'?message:{},keys);
+  }
+
+  function _rawIndexMessageRef(context){
+    const rawIdx=_contextValue(context,['raw_idx','rawIdx']);
+    if(rawIdx===undefined||rawIdx===null||rawIdx==='') return '';
+    return 'raw_idx:'+String(rawIdx);
+  }
+
+  function projectAssistantTurnAnchorSettledMessageFinalAnswer(input, context){
+    const message=(input&&typeof input==='object')?input:{};
+    const ctx=(context&&typeof context==='object')?context:{};
+    const sessionId=_cleanString(_contextValue(ctx,['session_id','sessionId']))
+      ||_cleanString(_messageValue(message,['session_id','sessionId']));
+    if(!sessionId){
+      return Object.freeze({applied:false,reason:'missing_session',final_answer:'',final_message_ref:null,registry:null});
+    }
+    const role=_cleanString(_messageValue(message,['role']))||'assistant';
+    if(role&&role!=='assistant'){
+      return Object.freeze({applied:false,reason:'non_assistant',final_answer:'',final_message_ref:null,registry:null});
+    }
+    const runId=_cleanString(_contextValue(ctx,['run_id','runId']))
+      ||_cleanString(_messageValue(message,['run_id','runId','_run_id','runtime_run_id']));
+    const streamId=_cleanString(_contextValue(ctx,['stream_id','streamId']))
+      ||_cleanString(_messageValue(message,['stream_id','streamId','_stream_id']));
+    const messageRef=_firstTextValue(
+      _messageValue(message,['message_id','id','local_id']),
+      _contextValue(ctx,['message_id','messageId','local_id','localId'])
+    )||_rawIndexMessageRef(ctx);
+    const turnId=_cleanString(_contextValue(ctx,['turn_id','turnId']))
+      ||_cleanString(_messageValue(message,['turn_id','turnId']))
+      ||[
+        'settled',
+        sessionId,
+        runId||streamId||messageRef||'assistant',
+      ].join(':');
+    const registry=createAssistantTurnAnchorRegistry({
+      session_id:sessionId,
+      turn_id:turnId,
+      run_id:runId||null,
+      stream_id:streamId||null,
+      local_id:messageRef||null,
+      source_message_refs:messageRef?[messageRef]:[],
+    });
+    const payload={
+      role:'assistant',
+      id:messageRef||null,
+      content:_hasOwn(ctx,'content')?_own(ctx,'content'):_own(message,'content'),
+    };
+    const usage=_own(message,'usage');
+    const turnUsage=_own(message,'_turnUsage');
+    if(usage&&typeof usage==='object') payload.usage=usage;
+    if(turnUsage&&typeof turnUsage==='object') payload._turnUsage=turnUsage;
+    const result=applyAssistantTurnAnchorSourceEvent(registry,{
+      source_type:'settled_message',
+      payload,
+      local_id:messageRef||null,
+    },{
+      session_id:sessionId,
+      turn_id:turnId,
+      run_id:runId||null,
+      stream_id:streamId||null,
+    });
+    if(!result.applied){
+      return Object.freeze({
+        applied:false,
+        reason:result.reason||null,
+        final_answer:'',
+        final_message_ref:null,
+        registry,
+      });
+    }
+    const rawFinalAnswer=registry.anchor&&registry.anchor.content&&registry.anchor.content.final_answer;
+    const rawFinalMessageRef=registry.anchor&&registry.anchor.content&&registry.anchor.content.final_message_ref;
+    const finalAnswer=typeof rawFinalAnswer==='string'?rawFinalAnswer:'';
+    const finalMessageRef=typeof rawFinalMessageRef==='string'?rawFinalMessageRef:null;
+    return Object.freeze({
+      applied:!!result.applied,
+      reason:result.reason||null,
+      final_answer:finalAnswer,
+      final_message_ref:finalMessageRef,
+      registry,
+    });
+  }
+
   function createAssistantTurnAnchorSeed(input){
     const opts=(input&&typeof input==='object')?input:{};
     const sessionId=_cleanString(opts.session_id);
@@ -755,7 +845,7 @@
   }
 
   ROOT.HermesAssistantTurnAnchors=Object.freeze({
-    version:'slice3-registry-shadow',
+    version:'slice4-final-projection',
     activityEventKinds:ACTIVITY_EVENT_KINDS,
     stateLayers:STATE_LAYERS,
     sourceEventClassification:SOURCE_EVENT_CLASSIFICATION,
@@ -772,6 +862,7 @@
     applyAssistantTurnAnchorSourceEvent,
     applyAssistantTurnAnchorSourceEvents,
     createAssistantTurnAnchorShadowSnapshot,
+    projectAssistantTurnAnchorSettledMessageFinalAnswer,
     isAssistantTurnAnchorActivityKind,
   });
 })();

--- a/static/assistant_turn_anchors.js
+++ b/static/assistant_turn_anchors.js
@@ -786,6 +786,262 @@
     });
   }
 
+  function _anchorFromProjectionInput(input){
+    if(!input||typeof input!=='object') return null;
+    if(input.anchor&&typeof input.anchor==='object') return input.anchor;
+    if(input.identity&&typeof input.identity==='object') return input;
+    return null;
+  }
+
+  function _activityRowId(event, index){
+    const eventId=_cleanString(_own(event,'event_id'));
+    if(eventId) return eventId;
+    const runId=_cleanString(_own(event,'run_id'));
+    const seq=_own(event,'seq');
+    if(runId&&seq!==undefined&&seq!==null&&seq!=='') return [runId,String(seq)].join(':');
+    const localId=_cleanString(_own(event,'local_id'));
+    if(localId){
+      const sourceType=_cleanString(_own(event,'source_event_type'))||_cleanString(_own(event,'kind'))||'event';
+      return [localId,sourceType,String(index)].join(':');
+    }
+    return 'activity:'+String(index);
+  }
+
+  function _activityRowText(event){
+    const payload=_own(event,'payload')||{};
+    return _firstTextValue(
+      _own(payload,'text'),
+      _own(payload,'content'),
+      _own(payload,'message'),
+      _own(payload,'summary'),
+      _own(payload,'result'),
+      _own(payload,'output')
+    );
+  }
+
+  function _isToolActivityKind(kind){
+    return kind==='tool_started'||kind==='tool_updated'||kind==='tool_completed';
+  }
+
+  function _activityRowToolId(event, kind){
+    if(!_isToolActivityKind(kind)) return null;
+    const payload=_own(event,'payload')||{};
+    return _firstTextValue(
+      _own(payload,'tool_call_id'),
+      _own(payload,'tool_use_id'),
+      _own(payload,'call_id'),
+      _own(payload,'tid'),
+      _own(payload,'id')
+    )||null;
+  }
+
+  function _activityPayloadFirst(payload, keys){
+    return _firstOwn(payload||{},keys);
+  }
+
+  function _activityRowToolDone(kind, status, payload){
+    if(payload&&typeof _own(payload,'done')==='boolean') return _own(payload,'done');
+    if(kind==='tool_completed') return true;
+    if(kind==='tool_started'||kind==='tool_updated') return false;
+    if(status==='completed'||status==='error'||status==='failed') return true;
+    if(status==='running'||status==='pending') return false;
+    return null;
+  }
+
+  function _activityRowToolIsError(status, payload){
+    if(payload&&typeof _own(payload,'is_error')==='boolean') return _own(payload,'is_error');
+    const raw=_cleanString(status).toLowerCase();
+    if(raw==='error'||raw==='failed'||raw==='failure') return true;
+    return false;
+  }
+
+  function _activityRowGroup(event, payload, index){
+    const activitySegmentSeq=_activityPayloadFirst(payload,['activitySegmentSeq','activity_segment_seq','segmentSeq','segment_seq']);
+    const activityBurstId=_activityPayloadFirst(payload,['activityBurstId','activity_burst_id','burstId','burst_id']);
+    const assistantMsgIdx=_activityPayloadFirst(payload,['assistant_msg_idx','assistantMessageIndex','assistant_msg_index']);
+    const cleanSegment=activitySegmentSeq!==undefined&&activitySegmentSeq!==null&&String(activitySegmentSeq)!==''
+      ? activitySegmentSeq
+      : null;
+    const cleanBurst=activityBurstId!==undefined&&activityBurstId!==null&&String(activityBurstId)!==''
+      ? activityBurstId
+      : null;
+    const cleanAssistant=assistantMsgIdx!==undefined&&assistantMsgIdx!==null&&String(assistantMsgIdx)!==''
+      ? assistantMsgIdx
+      : null;
+    const fallbackSeq=_own(event,'seq');
+    const fallbackKey=fallbackSeq!==undefined&&fallbackSeq!==null&&fallbackSeq!==''?`event:${String(fallbackSeq)}`:`activity:${String(index)}`;
+    const groupKey=cleanSegment!==null
+      ? `segment:${String(cleanSegment)}`
+      : cleanBurst!==null
+        ? `burst:${String(cleanBurst)}`
+        : cleanAssistant!==null
+          ? `assistant:${String(cleanAssistant)}`
+          : fallbackKey;
+    return Object.freeze({
+      group_key:groupKey,
+      activity_burst_id:cleanBurst,
+      activity_segment_seq:cleanSegment,
+      assistant_msg_idx:cleanAssistant,
+    });
+  }
+
+  function _activityRowThinking(event, kind, text){
+    if(kind!=='reasoning') return null;
+    const payload=_own(event,'payload')||{};
+    const thinkingText=_firstTextValue(
+      _own(payload,'thinking'),
+      _own(payload,'reasoning'),
+      _own(payload,'text'),
+      text
+    );
+    const preview=thinkingText?String(thinkingText).replace(/\s+/g,' ').trim():'';
+    return Object.freeze({
+      text:thinkingText||'',
+      preview:preview.length>180?`${preview.slice(0,177)}...`:preview,
+      dedupe_key:preview?`thinking:${preview.toLowerCase()}`:'',
+    });
+  }
+
+  function _activityRowTool(event, kind, status, text, toolCallId){
+    if(!_isToolActivityKind(kind)) return null;
+    const payload=_own(event,'payload')||{};
+    const toolName=_cleanString(
+      _activityPayloadFirst(payload,['name','tool_name','function_name'])||
+      (_own(payload,'function')&&_own(_own(payload,'function'),'name'))
+    )||'tool';
+    const args=_activityPayloadFirst(payload,['args','arguments','input','params']);
+    const preview=_firstTextValue(
+      _own(payload,'preview'),
+      _own(payload,'summary'),
+      text
+    );
+    const snippet=_firstTextValue(
+      _own(payload,'snippet'),
+      _own(payload,'result'),
+      _own(payload,'output')
+    );
+    const done=_activityRowToolDone(kind,status,payload);
+    const isError=_activityRowToolIsError(status,payload);
+    const signatureParts=[
+      toolName,
+      toolCallId||'',
+      JSON.stringify(_sanitizePayload(args||{})),
+    ];
+    return Object.freeze({
+      id:toolCallId,
+      name:toolName,
+      args:_sanitizePayload(args||{}),
+      preview:preview||'',
+      snippet:snippet||'',
+      result:_sanitizePayload(_own(payload,'result'))??null,
+      output:_sanitizePayload(_own(payload,'output'))??null,
+      done,
+      is_error:isError,
+      duration:_activityPayloadFirst(payload,['duration','duration_seconds','elapsed'])??null,
+      started_at:_activityPayloadFirst(payload,['started_at','startedAt'])??null,
+      signature:signatureParts.join('|'),
+    });
+  }
+
+  function _activityRowRole(kind){
+    if(kind==='process_prose') return 'prose';
+    if(kind==='reasoning') return 'thinking';
+    if(_isToolActivityKind(kind)) return 'tool';
+    if(kind==='lifecycle_status') return 'lifecycle';
+    if(kind==='control_boundary') return 'control';
+    if(kind==='terminal_status') return 'terminal';
+    return 'activity';
+  }
+
+  function _activityRowDisplayHint(kind, mode){
+    if(mode==='transparent_stream') return 'chronological_activity';
+    if(kind==='process_prose') return 'main_prose';
+    if(kind==='reasoning') return 'collapsed_thinking';
+    if(_isToolActivityKind(kind)) return 'tool_row';
+    if(kind==='lifecycle_status') return 'quiet_lifecycle_row';
+    if(kind==='control_boundary') return 'control_boundary_row';
+    if(kind==='terminal_status') return 'terminal_status_row';
+    return 'activity_row';
+  }
+
+  function _activityRowDisplayHints(kind){
+    return Object.freeze({
+      compact_worklog:_activityRowDisplayHint(kind,'compact_worklog'),
+      transparent_stream:_activityRowDisplayHint(kind,'transparent_stream'),
+    });
+  }
+
+  function _activitySceneRow(event, index, mode){
+    const payload=_own(event,'payload');
+    const kind=_cleanString(_own(event,'kind'))||'activity';
+    const status=_cleanString(_own(event,'status'))||null;
+    const text=_activityRowText(event);
+    const toolCallId=_activityRowToolId(event,kind);
+    const sanitizedPayload=_sanitizePayload(payload);
+    return Object.freeze({
+      row_id:_activityRowId(event,index),
+      order_index:index,
+      kind,
+      role:_activityRowRole(kind),
+      display_hint:_activityRowDisplayHint(kind,mode),
+      display_hints:_activityRowDisplayHints(kind),
+      source_event_type:_cleanString(_own(event,'source_event_type'))||null,
+      event_id:_cleanString(_own(event,'event_id'))||null,
+      local_id:_cleanString(_own(event,'local_id'))||null,
+      run_id:_cleanString(_own(event,'run_id'))||null,
+      stream_id:_cleanString(_own(event,'stream_id'))||null,
+      seq:_own(event,'seq')??null,
+      status,
+      created_at:_own(event,'created_at')??null,
+      identity:Object.freeze({
+        event_id:_cleanString(_own(event,'event_id'))||null,
+        local_id:_cleanString(_own(event,'local_id'))||null,
+        run_id:_cleanString(_own(event,'run_id'))||null,
+        stream_id:_cleanString(_own(event,'stream_id'))||null,
+        seq:_own(event,'seq')??null,
+      }),
+      group:_activityRowGroup(event,payload||{},index),
+      text,
+      thinking:_activityRowThinking(event,kind,text),
+      tool_call_id:toolCallId,
+      tool:_activityRowTool(event,kind,status,text,toolCallId),
+      payload:sanitizedPayload,
+    });
+  }
+
+  function projectAssistantTurnAnchorActivityScene(input, options){
+    const anchor=_anchorFromProjectionInput(input);
+    const opts=(options&&typeof options==='object')?options:{};
+    const requestedMode=_cleanString(_own(opts,'mode'));
+    const mode=requestedMode==='transparent_stream'?'transparent_stream':'compact_worklog';
+    if(!anchor){
+      return Object.freeze({
+        version:'activity_scene_v1',
+        mode,
+        identity:Object.freeze({source_message_refs:Object.freeze([])}),
+        lifecycle:Object.freeze({}),
+        final_answer:'',
+        final_message_ref:null,
+        terminal_state:null,
+        activity_rows:Object.freeze([]),
+      });
+    }
+    const rows=(Array.isArray(anchor.activity_events)?anchor.activity_events:[])
+      .map((event,index)=>_activitySceneRow(event,index,mode));
+    const lifecycle=_copyObject(anchor.lifecycle);
+    const content=anchor.content&&typeof anchor.content==='object'?anchor.content:{};
+    return Object.freeze({
+      version:'activity_scene_v1',
+      mode,
+      identity:_frozenIdentityCopy(anchor.identity||{}),
+      lifecycle:Object.freeze(lifecycle),
+      final_answer:typeof content.final_answer==='string'?content.final_answer:'',
+      final_message_ref:typeof content.final_message_ref==='string'?content.final_message_ref:null,
+      terminal_state:_cleanString(_own(lifecycle,'terminal_state'))||null,
+      activity_rows:Object.freeze(rows),
+    });
+  }
+
   function createAssistantTurnAnchorSeed(input){
     const opts=(input&&typeof input==='object')?input:{};
     const sessionId=_cleanString(opts.session_id);
@@ -845,7 +1101,7 @@
   }
 
   ROOT.HermesAssistantTurnAnchors=Object.freeze({
-    version:'slice4-final-projection',
+    version:'slice5-activity-scene',
     activityEventKinds:ACTIVITY_EVENT_KINDS,
     stateLayers:STATE_LAYERS,
     sourceEventClassification:SOURCE_EVENT_CLASSIFICATION,
@@ -863,6 +1119,7 @@
     applyAssistantTurnAnchorSourceEvents,
     createAssistantTurnAnchorShadowSnapshot,
     projectAssistantTurnAnchorSettledMessageFinalAnswer,
+    projectAssistantTurnAnchorActivityScene,
     isAssistantTurnAnchorActivityKind,
   });
 })();

--- a/static/ui.js
+++ b/static/ui.js
@@ -8747,6 +8747,26 @@ function _renderMessagesWithScrollSnapshot(options){
   renderMessages({...(options||{}),preserveScroll:true});
   _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
 }
+let _assistantTurnAnchorSettledFinalAnswerWarned=false;
+function _assistantTurnAnchorSettledFinalAnswer(message, content, context){
+  try{
+    const api=(typeof window!=='undefined')?window.HermesAssistantTurnAnchors:null;
+    if(!api||typeof api.projectAssistantTurnAnchorSettledMessageFinalAnswer!=='function') return null;
+    const result=api.projectAssistantTurnAnchorSettledMessageFinalAnswer(message,{
+      session_id:context&&context.session_id,
+      raw_idx:context&&context.raw_idx,
+      content,
+    });
+    const finalAnswer=result&&typeof result.final_answer==='string'?result.final_answer:'';
+    return finalAnswer?finalAnswer:null;
+  }catch(err){
+    if(!_assistantTurnAnchorSettledFinalAnswerWarned&&typeof console!=='undefined'&&console.warn){
+      _assistantTurnAnchorSettledFinalAnswerWarned=true;
+      console.warn('assistant turn anchor settled-final projection failed',err);
+    }
+    return null;
+  }
+}
 function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
   // Terminal stream renders can happen after S.activeStreamId is cleared.
   // In that case, preserveScroll asks the normal pin-state helper to decide:
@@ -9076,6 +9096,13 @@ function renderMessages(options){
     let thinkingText='';
     if(Array.isArray(content)){
       content=content.filter(p=>p&&p.type==='text').map(p=>p.text||p.content||'').join('\n');
+    }
+    if(m.role==='assistant'&&!m._live&&typeof content==='string'){
+      const anchorFinal=_assistantTurnAnchorSettledFinalAnswer(m, content, {
+        session_id:sid,
+        raw_idx:rawIdx,
+      });
+      if(anchorFinal!==null) content=anchorFinal;
     }
     if(typeof content==='string'){
       if(typeof window!=='undefined'&&typeof window._extractInlineThinkingFromContentForRender==='function'){

--- a/tests/test_stable_assistant_turn_anchor_normalizer.py
+++ b/tests/test_stable_assistant_turn_anchor_normalizer.py
@@ -182,7 +182,7 @@ def test_normalizer_maps_live_and_replay_to_same_anchor_event_identity():
     live = data["liveToken"]
     replay = data["replayToken"]
 
-    assert data["version"] == "slice4-final-projection"
+    assert data["version"] == "slice5-activity-scene"
     assert live["classification"] == "activity"
     assert live["dedupe_key"] == 'event_id:"run-1:7"'
     assert replay["dedupe_key"] == live["dedupe_key"]

--- a/tests/test_stable_assistant_turn_anchor_normalizer.py
+++ b/tests/test_stable_assistant_turn_anchor_normalizer.py
@@ -182,7 +182,7 @@ def test_normalizer_maps_live_and_replay_to_same_anchor_event_identity():
     live = data["liveToken"]
     replay = data["replayToken"]
 
-    assert data["version"] == "slice3-registry-shadow"
+    assert data["version"] == "slice4-final-projection"
     assert live["classification"] == "activity"
     assert live["dedupe_key"] == 'event_id:"run-1:7"'
     assert replay["dedupe_key"] == live["dedupe_key"]

--- a/tests/test_stable_assistant_turn_anchor_phase0.py
+++ b/tests/test_stable_assistant_turn_anchor_phase0.py
@@ -88,8 +88,11 @@ def test_phase0_scaffold_is_loaded_before_current_rendering_modules():
     messages_pos = html.index('static/messages.js?v=__WEBUI_VERSION__')
 
     assert anchor_pos < ui_pos < sessions_pos < messages_pos
+    ui_src = _read(UI_JS)
     assert "'./static/assistant_turn_anchors.js' + VQ" in _read(SW_JS)
-    assert "HermesAssistantTurnAnchors" not in _read(UI_JS)
+    assert "projectAssistantTurnAnchorSettledMessageFinalAnswer" in ui_src
+    assert "createAssistantTurnAnchorRegistry" not in ui_src
+    assert "applyAssistantTurnAnchorSourceEvent" not in ui_src
     assert "HermesAssistantTurnAnchors" not in _read(SESSIONS_JS)
     assert "HermesAssistantTurnAnchors" not in _read(MESSAGES_JS)
 

--- a/tests/test_stable_assistant_turn_anchor_registry.py
+++ b/tests/test_stable_assistant_turn_anchor_registry.py
@@ -112,6 +112,59 @@ console.log(JSON.stringify({{
     return json.loads(result.stdout)
 
 
+def _final_projection_snapshot() -> dict:
+    assert NODE, "node is required for assistant_turn_anchors.js registry tests"
+    script = f"""
+const fs = require('fs');
+const vm = require('vm');
+const src = fs.readFileSync({json.dumps(str(ANCHORS_JS))}, 'utf8');
+const sandbox = {{window:{{}}}};
+vm.createContext(sandbox);
+vm.runInContext(src, sandbox, {{filename:'assistant_turn_anchors.js'}});
+const api = sandbox.window.HermesAssistantTurnAnchors;
+const projected = api.projectAssistantTurnAnchorSettledMessageFinalAnswer({{
+  role:'assistant',
+  id:'message-final',
+  content:'raw content should be replaced by render-preserved content',
+  _turnUsage:{{input_tokens:8, output_tokens:13}},
+}}, {{
+  session_id:'sid-project',
+  raw_idx:7,
+  content:'line one\\nline two',
+}});
+const projectedByRawIdx = api.projectAssistantTurnAnchorSettledMessageFinalAnswer({{
+  role:'assistant',
+  content:'message without id',
+}}, {{
+  session_id:'sid-project',
+  raw_idx:11,
+  content:'raw index final',
+}});
+const missingSession = api.projectAssistantTurnAnchorSettledMessageFinalAnswer({{
+  role:'assistant',
+  id:'message-missing-session',
+  content:'final',
+}}, {{}});
+const nonAssistant = api.projectAssistantTurnAnchorSettledMessageFinalAnswer({{
+  role:'user',
+  id:'message-user',
+  content:'user text',
+}}, {{
+  session_id:'sid-project',
+}});
+console.log(JSON.stringify({{
+  version:api.version,
+  projected,
+  projectedByRawIdx,
+  missingSession,
+  nonAssistant,
+}}));
+"""
+    result = subprocess.run([NODE, "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
 def _hardening_snapshot() -> dict:
     assert NODE, "node is required for assistant_turn_anchors.js registry tests"
     script = f"""
@@ -289,7 +342,7 @@ def test_registry_owns_one_anchor_and_dedupes_live_plus_replay_events():
     registry = data["registry"]
     anchor = registry["anchor"]
 
-    assert data["version"] == "slice3-registry-shadow"
+    assert data["version"] == "slice4-final-projection"
     assert [item["reason"] for item in data["results"][:2]] == [None, "duplicate"]
     assert registry["event_index"]["dedupe_keys"][:2] == [
         'event_id:"run-1:1"',
@@ -389,7 +442,7 @@ def test_registry_does_not_destructively_dedupe_seqless_local_tool_lifecycle():
     registry = data["toolRegistry"]
     anchor = registry["anchor"]
 
-    assert data["version"] == "slice3-registry-shadow"
+    assert data["version"] == "slice4-final-projection"
     assert data["toolResults"] == [
         {"applied": True, "reason": None},
         {"applied": True, "reason": None},
@@ -439,7 +492,7 @@ def test_shadow_snapshot_feeds_current_source_families_into_one_registry_owner()
     registry = data["registry"]
     anchor = registry["anchor"]
 
-    assert data["version"] == "slice3-registry-shadow"
+    assert data["version"] == "slice4-final-projection"
     assert data["results"]["live"] == [{"applied": True, "reason": None}]
     assert data["results"]["replay"] == [
         {"applied": False, "reason": "duplicate"},
@@ -463,6 +516,70 @@ def test_shadow_snapshot_feeds_current_source_families_into_one_registry_owner()
     assert anchor["content"]["final_answer"] == "shadow final"
 
 
+def test_final_projection_routes_settled_assistant_message_through_anchor_owner():
+    data = _final_projection_snapshot()
+    projected = data["projected"]
+    registry = projected["registry"]
+    anchor = registry["anchor"]
+
+    assert data["version"] == "slice4-final-projection"
+    assert projected["applied"] is True
+    assert projected["reason"] is None
+    assert projected["final_message_ref"] == "message-final"
+    assert projected["final_answer"] == "line one\nline two"
+    assert registry["stats"]["applied"] == 1
+    assert anchor["identity"]["session_id"] == "sid-project"
+    assert anchor["content"]["final_answer"] == "line one\nline two"
+    assert anchor["content"]["final_message_ref"] == "message-final"
+    assert anchor["usage"] == {"input_tokens": 8, "output_tokens": 13}
+    assert [event["source_event_type"] for event in anchor["metadata_events"]] == [
+        "settled_message",
+    ]
+    assert data["projectedByRawIdx"]["final_message_ref"] == "raw_idx:11"
+    assert data["projectedByRawIdx"]["registry"]["anchor"]["identity"][
+        "source_message_refs"
+    ] == ["raw_idx:11"]
+    anchor_src = _read(ANCHORS_JS)
+    assert "if(!result.applied)" in anchor_src
+
+
+def test_final_projection_is_scoped_to_settled_assistant_messages():
+    data = _final_projection_snapshot()
+
+    assert data["missingSession"] == {
+        "applied": False,
+        "reason": "missing_session",
+        "final_answer": "",
+        "final_message_ref": None,
+        "registry": None,
+    }
+    assert data["nonAssistant"] == {
+        "applied": False,
+        "reason": "non_assistant",
+        "final_answer": "",
+        "final_message_ref": None,
+        "registry": None,
+    }
+
+
+def test_render_messages_uses_anchor_projection_only_for_settled_final_prose():
+    src = _read(UI_JS)
+    start = src.index("function renderMessages")
+    end = src.index("function _toolDisplayName", start)
+    render_body = src[start:end]
+
+    flatten_idx = render_body.index("content=content.filter(p=>p&&p.type==='text')")
+    projection_idx = render_body.index("_assistantTurnAnchorSettledFinalAnswer(m, content")
+    thinking_idx = render_body.index("_extractInlineThinkingFromContentForRender(content")
+
+    assert flatten_idx < projection_idx < thinking_idx
+    assert "if(m.role==='assistant'&&!m._live&&typeof content==='string'){" in render_body
+    assert "createAssistantTurnAnchorRegistry" not in render_body
+    assert "applyAssistantTurnAnchorSourceEvent" not in render_body
+    assert "_assistantTurnAnchorSettledFinalAnswerWarned" in src
+    assert "console.warn('assistant turn anchor settled-final projection failed',err)" in src
+
+
 def test_registry_instances_do_not_share_owner_state():
     data = _registry_snapshot()
     isolated = data["isolated"]
@@ -473,7 +590,7 @@ def test_registry_instances_do_not_share_owner_state():
     assert isolated["anchor"]["activity_events"] == []
 
 
-def test_slice3_registry_is_still_unwired_from_rendering_hot_paths():
+def test_slice4_projection_does_not_wire_registry_into_rendering_hot_paths():
     helper_names = [
         "createAssistantTurnAnchorRegistry",
         "applyAssistantTurnAnchorNormalizedEvent",
@@ -485,3 +602,4 @@ def test_slice3_registry_is_still_unwired_from_rendering_hot_paths():
         assert helper not in _read(UI_JS)
         assert helper not in _read(SESSIONS_JS)
         assert helper not in _read(MESSAGES_JS)
+    assert "projectAssistantTurnAnchorSettledMessageFinalAnswer" in _read(UI_JS)

--- a/tests/test_stable_assistant_turn_anchor_registry.py
+++ b/tests/test_stable_assistant_turn_anchor_registry.py
@@ -111,6 +111,97 @@ console.log(JSON.stringify({{
     assert result.returncode == 0, result.stderr
     return json.loads(result.stdout)
 
+def _activity_scene_snapshot() -> dict:
+    assert NODE, "node is required for assistant_turn_anchors.js registry tests"
+    script = f"""
+const fs = require('fs');
+const vm = require('vm');
+const src = fs.readFileSync({json.dumps(str(ANCHORS_JS))}, 'utf8');
+const sandbox = {{window:{{}}}};
+vm.createContext(sandbox);
+vm.runInContext(src, sandbox, {{filename:'assistant_turn_anchors.js'}});
+const api = sandbox.window.HermesAssistantTurnAnchors;
+const registry = api.createAssistantTurnAnchorRegistry({{
+  session_id:'sid-scene',
+  turn_id:'turn-scene',
+}});
+api.applyAssistantTurnAnchorSourceEvents(registry, [
+  {{event:'token', payload:{{text:'progress'}}, event_id:'run-scene:1', seq:1}},
+  {{event:'reasoning', payload:{{text:'private thinking'}}, event_id:'run-scene:2', seq:2}},
+  {{event:'tool', payload:{{
+    tool_call_id:'tool-1',
+    name:'terminal',
+    args:{{command:'rg anchor static'}},
+    preview:'rg anchor static',
+    activityBurstId:7,
+    activitySegmentSeq:3,
+    assistant_msg_idx:12,
+    started_at:1781200000
+  }}, event_id:'run-scene:3', seq:3}},
+  {{event:'tool_update', payload:{{
+    tool_call_id:'tool-1',
+    name:'terminal',
+    text:'running',
+    preview:'searching workspace',
+    activityBurstId:7,
+    activitySegmentSeq:3,
+    assistant_msg_idx:12
+  }}, event_id:'run-scene:4', seq:4}},
+  {{event:'tool_complete', payload:{{
+    tool_call_id:'tool-1',
+    name:'terminal',
+    result:'done',
+    output:'done',
+    snippet:'done',
+    is_error:false,
+    duration:1.25,
+    activityBurstId:7,
+    activitySegmentSeq:3,
+    assistant_msg_idx:12
+  }}, event_id:'run-scene:5', seq:5}},
+  {{event:'done', payload:{{}}, event_id:'run-scene:6', seq:6}},
+  {{source_type:'settled_message', payload:{{role:'assistant', id:'message-scene', content:'final answer'}}}},
+], {{run_id:'run-scene', stream_id:'stream-scene'}});
+const compact = api.projectAssistantTurnAnchorActivityScene(registry, {{mode:'compact_worklog'}});
+const transparent = api.projectAssistantTurnAnchorActivityScene(registry.anchor, {{mode:'transparent_stream'}});
+const empty = api.projectAssistantTurnAnchorActivityScene(null, {{mode:'transparent_stream'}});
+const seqlessRegistry = api.createAssistantTurnAnchorRegistry({{
+  session_id:'sid-seqless',
+  turn_id:'turn-seqless',
+}});
+api.applyAssistantTurnAnchorSourceEvents(seqlessRegistry, [
+  {{event:'tool', payload:{{tool_call_id:'tool-same', name:'terminal'}}}},
+  {{event:'tool_update', payload:{{tool_call_id:'tool-same', text:'running'}}}},
+  {{event:'tool_complete', payload:{{tool_call_id:'tool-same', result:'done'}}}},
+]);
+const seqless = api.projectAssistantTurnAnchorActivityScene(seqlessRegistry, {{mode:'compact_worklog'}});
+const zeroRegistry = api.createAssistantTurnAnchorRegistry({{
+  session_id:'sid-zero',
+  turn_id:'turn-zero',
+}});
+api.applyAssistantTurnAnchorSourceEvents(zeroRegistry, [
+  {{event:'tool', payload:{{
+    tool_call_id:'tool-zero',
+    name:'terminal',
+    activityBurstId:0,
+    activitySegmentSeq:0,
+    assistant_msg_idx:0
+  }}, event_id:'run-zero:0', seq:0}},
+]);
+const zero = api.projectAssistantTurnAnchorActivityScene(zeroRegistry, {{mode:'compact_worklog'}});
+console.log(JSON.stringify({{
+  version:api.version,
+  compact,
+  transparent,
+  empty,
+  seqless,
+  zero,
+}}));
+"""
+    result = subprocess.run([NODE, "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
 
 def _final_projection_snapshot() -> dict:
     assert NODE, "node is required for assistant_turn_anchors.js registry tests"
@@ -342,7 +433,7 @@ def test_registry_owns_one_anchor_and_dedupes_live_plus_replay_events():
     registry = data["registry"]
     anchor = registry["anchor"]
 
-    assert data["version"] == "slice4-final-projection"
+    assert data["version"] == "slice5-activity-scene"
     assert [item["reason"] for item in data["results"][:2]] == [None, "duplicate"]
     assert registry["event_index"]["dedupe_keys"][:2] == [
         'event_id:"run-1:1"',
@@ -442,7 +533,7 @@ def test_registry_does_not_destructively_dedupe_seqless_local_tool_lifecycle():
     registry = data["toolRegistry"]
     anchor = registry["anchor"]
 
-    assert data["version"] == "slice4-final-projection"
+    assert data["version"] == "slice5-activity-scene"
     assert data["toolResults"] == [
         {"applied": True, "reason": None},
         {"applied": True, "reason": None},
@@ -492,7 +583,7 @@ def test_shadow_snapshot_feeds_current_source_families_into_one_registry_owner()
     registry = data["registry"]
     anchor = registry["anchor"]
 
-    assert data["version"] == "slice4-final-projection"
+    assert data["version"] == "slice5-activity-scene"
     assert data["results"]["live"] == [{"applied": True, "reason": None}]
     assert data["results"]["replay"] == [
         {"applied": False, "reason": "duplicate"},
@@ -515,6 +606,131 @@ def test_shadow_snapshot_feeds_current_source_families_into_one_registry_owner()
     ]
     assert anchor["content"]["final_answer"] == "shadow final"
 
+def test_activity_scene_projects_current_activity_events_for_both_render_modes():
+    data = _activity_scene_snapshot()
+    compact = data["compact"]
+    transparent = data["transparent"]
+
+    assert data["version"] == "slice5-activity-scene"
+    assert compact["version"] == "activity_scene_v1"
+    assert transparent["version"] == "activity_scene_v1"
+    assert compact["mode"] == "compact_worklog"
+    assert transparent["mode"] == "transparent_stream"
+    assert compact["final_answer"] == "final answer"
+    assert transparent["final_answer"] == "final answer"
+    assert compact["terminal_state"] == "completed"
+    assert transparent["terminal_state"] == "completed"
+
+    compact_rows = compact["activity_rows"]
+    transparent_rows = transparent["activity_rows"]
+    assert [row["row_id"] for row in compact_rows] == [
+        "run-scene:1",
+        "run-scene:2",
+        "run-scene:3",
+        "run-scene:4",
+        "run-scene:5",
+        "run-scene:6",
+    ]
+    assert [row["row_id"] for row in transparent_rows] == [
+        row["row_id"] for row in compact_rows
+    ]
+    assert [row["kind"] for row in compact_rows] == [
+        "process_prose",
+        "reasoning",
+        "tool_started",
+        "tool_updated",
+        "tool_completed",
+        "terminal_status",
+    ]
+    assert [row["role"] for row in compact_rows] == [
+        "prose",
+        "thinking",
+        "tool",
+        "tool",
+        "tool",
+        "terminal",
+    ]
+    assert [row["display_hint"] for row in compact_rows] == [
+        "main_prose",
+        "collapsed_thinking",
+        "tool_row",
+        "tool_row",
+        "tool_row",
+        "terminal_status_row",
+    ]
+    assert all(row["display_hint"] == "chronological_activity" for row in transparent_rows)
+    assert compact_rows[0]["text"] == "progress"
+    assert compact_rows[0]["tool_call_id"] is None
+    assert compact_rows[2]["tool_call_id"] == "tool-1"
+    assert compact_rows[4]["text"] == "done"
+    assert compact_rows[1]["thinking"] == {
+        "text": "private thinking",
+        "preview": "private thinking",
+        "dedupe_key": "thinking:private thinking",
+    }
+    assert compact_rows[2]["group"] == {
+        "group_key": "segment:3",
+        "activity_burst_id": 7,
+        "activity_segment_seq": 3,
+        "assistant_msg_idx": 12,
+    }
+    assert compact_rows[2]["tool"] == {
+        "id": "tool-1",
+        "name": "terminal",
+        "args": {"command": "rg anchor static"},
+        "preview": "rg anchor static",
+        "snippet": "",
+        "result": None,
+        "output": None,
+        "done": False,
+        "is_error": False,
+        "duration": None,
+        "started_at": 1781200000,
+        "signature": 'terminal|tool-1|{"command":"rg anchor static"}',
+    }
+    assert compact_rows[4]["tool"]["done"] is True
+    assert compact_rows[4]["tool"]["is_error"] is False
+    assert compact_rows[4]["tool"]["duration"] == 1.25
+    assert compact_rows[4]["tool"]["snippet"] == "done"
+    assert compact_rows[4]["display_hints"] == {
+        "compact_worklog": "tool_row",
+        "transparent_stream": "chronological_activity",
+    }
+    seqless_ids = [row["row_id"] for row in data["seqless"]["activity_rows"]]
+    assert len(seqless_ids) == len(set(seqless_ids))
+    assert seqless_ids == [
+        "tool-same:tool:0",
+        "tool-same:tool_update:1",
+        "tool-same:tool_complete:2",
+    ]
+    assert data["zero"]["activity_rows"][0]["group"] == {
+        "group_key": "segment:0",
+        "activity_burst_id": 0,
+        "activity_segment_seq": 0,
+        "assistant_msg_idx": 0,
+    }
+
+
+def test_activity_scene_is_renderer_neutral_and_empty_safe():
+    data = _activity_scene_snapshot()
+    compact = data["compact"]
+    empty = data["empty"]
+
+    assert "final answer" not in [row["text"] for row in compact["activity_rows"]]
+    assert compact["identity"]["session_id"] == "sid-scene"
+    assert compact["identity"]["run_id"] == "run-scene"
+    assert compact["identity"]["stream_id"] == "stream-scene"
+    assert empty == {
+        "version": "activity_scene_v1",
+        "mode": "transparent_stream",
+        "identity": {"source_message_refs": []},
+        "lifecycle": {},
+        "final_answer": "",
+        "final_message_ref": None,
+        "terminal_state": None,
+        "activity_rows": [],
+    }
+
 
 def test_final_projection_routes_settled_assistant_message_through_anchor_owner():
     data = _final_projection_snapshot()
@@ -522,7 +738,7 @@ def test_final_projection_routes_settled_assistant_message_through_anchor_owner(
     registry = projected["registry"]
     anchor = registry["anchor"]
 
-    assert data["version"] == "slice4-final-projection"
+    assert data["version"] == "slice5-activity-scene"
     assert projected["applied"] is True
     assert projected["reason"] is None
     assert projected["final_message_ref"] == "message-final"
@@ -589,8 +805,7 @@ def test_registry_instances_do_not_share_owner_state():
     assert isolated["stats"]["applied"] == 0
     assert isolated["anchor"]["activity_events"] == []
 
-
-def test_slice4_projection_does_not_wire_registry_into_rendering_hot_paths():
+def test_slice5_scene_projection_does_not_wire_activity_scene_into_rendering_hot_paths():
     helper_names = [
         "createAssistantTurnAnchorRegistry",
         "applyAssistantTurnAnchorNormalizedEvent",
@@ -603,3 +818,6 @@ def test_slice4_projection_does_not_wire_registry_into_rendering_hot_paths():
         assert helper not in _read(SESSIONS_JS)
         assert helper not in _read(MESSAGES_JS)
     assert "projectAssistantTurnAnchorSettledMessageFinalAnswer" in _read(UI_JS)
+    assert "projectAssistantTurnAnchorActivityScene" not in _read(UI_JS)
+    assert "projectAssistantTurnAnchorActivityScene" not in _read(SESSIONS_JS)
+    assert "projectAssistantTurnAnchorActivityScene" not in _read(MESSAGES_JS)


### PR DESCRIPTION
## Thinking Path

- #4092 starts RFC Phase 3 by routing settled assistant final prose through the anchor owner.
- This PR is the next stacked slice: it builds on #4092 and adds the renderer-neutral activity scene projection without wiring any current renderer to it.
- The goal is to give Compact Worklog and Transparent Stream one shared ordered row model before either renderer consumes it.
- The projection includes enough data for later renderer work: event identity, row order, grouping, reasoning preview, tool metadata, status, payload, display hints, final answer snapshot, and final message reference.

## Contract Routing

Task type: Stable Assistant Turn Anchors implementation slice, stacked on #4092.

Touched areas:
- `static/assistant_turn_anchors.js`
- anchor phase architecture docs
- anchor normalizer / registry tests

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/stable-assistant-turn-anchors.md`
- `docs/architecture/stable-assistant-turn-anchor-phase0.md`

Scope boundaries:
- Depends on #4092 / Slice 4.
- Does not wire `projectAssistantTurnAnchorActivityScene()` into `ui.js`, `sessions.js`, or `messages.js`.
- Does not change live SSE, replay hydration, `INFLIGHT`, Compact Worklog rendering, Transparent Stream rendering, or DOM ownership.
- Does not reintroduce `presentation_state` into the anchor seed.

Evidence needed before claiming done:
- Anchor tests pass with Slice 4 + Slice 5 stacked.
- Activity scene row IDs are stable and unique, including seqless local tool lifecycle rows.
- Hot-path tests prove the scene projection is not consumed by current renderers yet.

## What Changed

- Added `projectAssistantTurnAnchorActivityScene()` to project an anchor or registry into `activity_scene_v1`.
- Added renderer-neutral activity rows with stable `row_id`, order, event identity, grouping, role, display hints, text, reasoning metadata, tool metadata, status, timestamps, and sanitized payloads.
- Preserved `final_message_ref` and `final_answer` in the scene header while keeping the final answer out of activity rows.
- Added tests for Compact Worklog and Transparent Stream modes using the same row IDs and ordered activity data.
- Added a uniqueness test for seqless local tool lifecycle rows so future renderers do not inherit duplicate row keys.

## Why It Matters

This is the data-model slice that lets the later renderer work stop inventing separate Compact Worklog and Transparent Stream inputs. It keeps the current UI inert while proving that the anchor can already project the common scene shape those renderers need.

## Verification

- `git diff --check`
- `node --check static/assistant_turn_anchors.js`
- `node --check static/ui.js`
- `pytest tests/test_stable_assistant_turn_anchor_phase0.py tests/test_stable_assistant_turn_anchor_normalizer.py tests/test_stable_assistant_turn_anchor_registry.py -q`
  - `32 passed`

## Risks / Follow-ups

- This PR is stacked on #4092. Until #4092 merges, GitHub may show the Slice 4 commit in the full PR diff; the Slice 5-specific diff is the second commit on this branch.
- The activity scene carries renderer-facing display hints, but it remains inert and is not yet consumed by Compact Worklog or Transparent Stream.
- The next slice should wire one renderer to this scene projection and keep the other renderer unchanged until its own review boundary.
- No browser runtime was restarted for this PR.

## Model Used

OpenAI GPT-5 Codex via Codex CLI. AI assisted with code changes, local review, conflict resolution, and verification commands.