### PR TITLE
fix: preserve session document title during bot-name refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Desktop tab titles keep the active session name when profile/settings boot paths refresh the assistant name (#4086).** `applyBotName()` now leaves `document.title` alone while a chat session is active, so `syncTopbar()` remains the owner of the per-session `"<session> — <assistant>"` title and desktop tabs no longer collapse to the same fallback name.
+
 ## [v0.51.382] — 2026-06-13 — Release MU (Stable Assistant Turn Anchors: activity-scene projection, inert, #4093)
 
 ### Added

--- a/static/boot.js
+++ b/static/boot.js
@@ -1761,7 +1761,7 @@ function applyBotName(){
   // The saved assistant name applies to the default profile only.
   // Non-default profiles use their own profile names.
   const name=assistantDisplayName();
-  document.title=name;
+  if(!S.session) document.title=name;
   const sidebarH1=document.querySelector('.sidebar-header h1');
   if(sidebarH1) sidebarH1.textContent=name;
   const logo=document.querySelector('.sidebar-header .logo');

--- a/tests/test_issue4086_document_title_owner.py
+++ b/tests/test_issue4086_document_title_owner.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOT_JS = ROOT / "static" / "boot.js"
+UI_JS = ROOT / "static" / "ui.js"
+
+
+def _extract_function(src: str, signature: str) -> str:
+    start = src.find(signature)
+    assert start != -1, f"{signature} not found"
+    depth = 0
+    for idx in range(start, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : idx + 1]
+    raise AssertionError(f"{signature} body did not terminate")
+
+
+def test_apply_bot_name_does_not_overwrite_active_session_document_title():
+    """Session titles belong to syncTopbar() while a chat session is active."""
+    src = BOOT_JS.read_text()
+    body = _extract_function(src, "function applyBotName(){")
+
+    assert "if(!S.session) document.title=name;" in body
+    assert "document.title=name;" not in body.replace(
+        "if(!S.session) document.title=name;",
+        "",
+    )
+
+
+def test_sync_topbar_remains_session_document_title_owner():
+    src = UI_JS.read_text()
+    body = _extract_function(src, "function syncTopbar(){")
+
+    assert "document.title=sessionTitle+' \\u2014 '+assistantDisplayName();" in body


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI uses `document.title` as the source for desktop/native tab names.
- `syncTopbar()` already stamps active chat sessions as `<session title> — <assistant name>`.
- `applyBotName()` can run later from profile/settings boot paths and was unconditionally resetting `document.title` to the bare assistant/profile name.
- That made distinct active-session tabs collapse back to the same desktop fallback title.
- This PR keeps `applyBotName()` from touching `document.title` while a session is active, leaving active-session title ownership with `syncTopbar()`.

## What Changed

- Guarded the `applyBotName()` `document.title` assignment with `!S.session`.
- Added a focused #4086 regression test for the document-title ownership invariant.
- Added an Unreleased changelog entry.

## Why It Matters

Desktop tabs keep their per-session names after profile/settings boot paths refresh the assistant name, instead of being clobbered to the same bare/fallback title.

## Verification

- `HERMES_WEBUI_PYTHON="$PWD/../.venvs/hermes-webui/bin/python" ../.venvs/hermes-webui/bin/python -m pytest tests/test_issue4086_document_title_owner.py -q` -> `2 passed`
- `HERMES_WEBUI_PYTHON="$PWD/../.venvs/hermes-webui/bin/python" ../.venvs/hermes-webui/bin/python -m pytest tests/test_issue3635_profile_chip_active.py tests/test_sprint40_ui_polish.py -q` -> `18 passed`
- `node --check static/boot.js`
- `git diff --check`

## Risks / Follow-ups

- This is intentionally narrow and does not attempt to change non-chat panel title behavior from #4039.
- No screenshots included because there is no layout or visible in-page UI change; the affected surface is the browser/native tab title and is covered by the regression test.

## Model Used

OpenAI GPT-5 Codex in Codex desktop, using local `gh`/`git`, pytest, and Node syntax checks.

Closes #4086
