### PR TITLE
Release MQ (v0.51.378): scroll auto-follow toggle + don't-yank-while-reading (#4006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 
 ## [Unreleased]
 
+## [v0.51.378] — 2026-06-13 — Release MQ (don't yank the viewport while reading; auto-follow toggle, #4006)
+
+### Fixed
+
+- **Streaming no longer snaps you to the bottom when you've scrolled up to read (#4006).** Two pin-hysteresis bugs are fixed: `_scrollAfterMessageRender` now honors `_messageUserUnpinned` (so a forced follow can't override a deliberate scroll-up after the 250px near-bottom counter re-pins), and `_finishDone`'s completion scroll is gated on an actual near-bottom check instead of firing unconditionally. (#4006)
+
+### Added
+
+- **Auto-follow toggle (Settings → Appearance).** A new "Auto-follow new content" setting controls whether the transcript follows new output to the bottom while streaming. It defaults **on** — a Codex/Claude-Code-style sticky bottom: you stay pinned to the latest output until you scroll up, at which point you're left where you are. Turn it off to always manage the scroll position yourself. (#4006)
+
 ## [v0.51.377] — 2026-06-13 — Release MP (Firefox post-stream scroll jitter, #3920)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -5746,6 +5746,7 @@ _SETTINGS_DEFAULTS = {
     "font_size": "default",  # small | default | large | xlarge
     "session_jump_buttons": False,  # show Start/End transcript jump pills
     "session_endless_scroll": False,  # auto-load older transcript pages while scrolling upward
+    "auto_scroll_follow": False,  # auto-scroll to bottom during streaming; false = user controls scroll
     "worklog_details_expanded_default": False,  # opt-in: expand Worklog details by default; default remains folded
     "pinned_sessions_limit": 3,  # maximum active pinned sessions shown in the sidebar
     "inflight_state_max_sessions": 8,  # max active-stream recovery snapshots kept in browser localStorage
@@ -5932,6 +5933,7 @@ _SETTINGS_BOOL_KEYS = {
     "api_redact_enabled",
     "session_jump_buttons",
     "session_endless_scroll",
+    "auto_scroll_follow",
     "worklog_details_expanded_default",
 }
 # Language codes are validated as short alphanumeric BCP-47-like tags (e.g. 'en', 'zh', 'fr')

--- a/static/boot.js
+++ b/static/boot.js
@@ -1815,6 +1815,7 @@ function applyBotName(){
     };
     window._busyInputMode=(s.busy_input_mode||'queue');
     window._sessionEndlessScrollEnabled=!!s.session_endless_scroll;
+    window._autoScrollFollow=!!s.auto_scroll_follow;
     window._botName=s.bot_name||'Hermes';
     if(s.default_model_provider) window._activeProvider=s.default_model_provider;
     if(s.default_model){
@@ -1909,6 +1910,7 @@ function applyBotName(){
     window._pinnedSessionsLimit=3;
     window._busyInputMode='queue';
     window._sessionEndlessScrollEnabled=false;
+    window._autoScrollFollow=false;
     window._botName='Hermes';
     _bootSettings={check_for_updates:false};
     if(typeof setLocale==='function'){

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -1978,6 +1978,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Carica messaggi precedenti scorrendo in alto',
 
     settings_desc_session_endless_scroll: 'Se abilitato, i messaggi precedenti si caricano automaticamente scorrendo in alto. Se disabilitato, usa il pulsante messaggi precedenti.',
+    settings_label_auto_scroll_follow: 'Segui automaticamente i nuovi contenuti',
+    settings_desc_auto_scroll_follow: 'Se abilitato, la vista scorre verso il basso man mano che arrivano nuovi token. Se disabilitato, controlli tu la posizione di scorrimento.',
     settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
     settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
     settings_label_chat_activity_display_mode: 'Activity display',
@@ -3387,6 +3389,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: '上スクロールで古いメッセージを読み込む',
 
     settings_desc_session_endless_scroll: '有効にすると、上にスクロールしたとき古いメッセージを自動で読み込みます。無効の場合は古いメッセージボタンを使います。',
+    settings_label_auto_scroll_follow: '新しい内容を自動で追従',
+    settings_desc_auto_scroll_follow: '有効にすると、ストリーミング中に画面が自動で一番下までスクロールします。無効にすると、スクロール位置を自分で操作できます。',
     settings_label_worklog_details_expanded_default: 'Worklog の詳細を自動的に開く',
     settings_desc_worklog_details_expanded_default: '有効にすると、新しい Worklog の詳細が展開された状態で始まり、ツール、Thinking、進捗カードをクリックなしで確認できます。無効の場合、Worklog の詳細はデフォルトで折りたたまれます。ターンごとの手動折りたたみ/展開は優先されます。',
     settings_label_chat_activity_display_mode: 'Activity display',
@@ -5417,6 +5421,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Загружать старые сообщения при прокрутке вверх',
 
     settings_desc_session_endless_scroll: 'Если включено, старые сообщения загружаются автоматически при прокрутке вверх. Если выключено, используйте кнопку загрузки старых сообщений.',
+    settings_label_auto_scroll_follow: 'Автопрокрутка к новому содержимому',
+    settings_desc_auto_scroll_follow: 'Если включено, область прокручивается вниз по мере поступления новых токенов. Если выключено, вы сами управляете прокруткой.',
     settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
     settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
     settings_label_chat_activity_display_mode: 'Activity display',
@@ -6751,6 +6757,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Cargar mensajes antiguos al desplazarse hacia arriba',
 
     settings_desc_session_endless_scroll: 'Si está activado, los mensajes antiguos se cargan automáticamente al desplazarte hacia arriba. Si está desactivado, usa el botón de mensajes antiguos.',
+    settings_label_auto_scroll_follow: 'Seguir automáticamente el contenido nuevo',
+    settings_desc_auto_scroll_follow: 'Si está activado, la vista se desplaza hacia abajo a medida que llegan nuevos tokens. Si está desactivado, controlas tú la posición de desplazamiento.',
     settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
     settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
     settings_label_chat_activity_display_mode: 'Activity display',
@@ -7785,6 +7793,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Ältere Nachrichten beim Hochscrollen laden',
 
     settings_desc_session_endless_scroll: 'Wenn aktiviert, werden ältere Nachrichten beim Hochscrollen automatisch geladen. Wenn deaktiviert, nutzt du den Button für ältere Nachrichten.',
+    settings_label_auto_scroll_follow: 'Neuen Inhalten automatisch folgen',
+    settings_desc_auto_scroll_follow: 'Wenn aktiviert, scrollt die Ansicht nach unten, während neue Tokens eintreffen. Wenn deaktiviert, steuerst du die Scrollposition selbst.',
     settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
     settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
     settings_label_chat_activity_display_mode: 'Activity display',
@@ -10183,6 +10193,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: '向上捲動時載入較早訊息',
 
     settings_desc_session_endless_scroll: '啟用後，向上捲動時會自動載入較早訊息。停用時請使用載入較早訊息按鈕。',
+    settings_label_auto_scroll_follow: '自動跟隨新內容',
+    settings_desc_auto_scroll_follow: '啟用後，串流輸出時畫面會自動捲動到底部。停用後，你可以自由控制捲動位置。',
     settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
     settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
     settings_label_chat_activity_display_mode: 'Activity display',
@@ -11482,6 +11494,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Carregar mensagens antigas ao rolar para cima',
 
     settings_desc_session_endless_scroll: 'Quando ativado, mensagens antigas carregam automaticamente ao rolar para cima. Quando desativado, use o botão de mensagens antigas.',
+    settings_label_auto_scroll_follow: 'Acompanhar automaticamente o novo conteúdo',
+    settings_desc_auto_scroll_follow: 'Quando ativado, a visualização rola para baixo conforme novos tokens chegam. Quando desativado, você controla a posição de rolagem.',
     settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
     settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
     settings_label_chat_activity_display_mode: 'Activity display',
@@ -12792,6 +12806,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: '위로 스크롤할 때 이전 메시지 불러오기',
 
     settings_desc_session_endless_scroll: '활성화하면 위로 스크롤할 때 이전 메시지를 자동으로 불러옵니다. 비활성화하면 이전 메시지 버튼을 사용합니다.',
+    settings_label_auto_scroll_follow: '새 내용 자동 따라가기',
+    settings_desc_auto_scroll_follow: '활성화하면 토큰이 스트리밍되는 동안 화면이 자동으로 맨 아래로 스크롤됩니다. 비활성화하면 스크롤 위치를 직접 제어합니다.',
     settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
     settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
     settings_label_chat_activity_display_mode: 'Activity display',
@@ -14119,6 +14135,8 @@ const LOCALES = {
     settings_desc_terminal_auto_expand: 'Développer automatiquement le panneau de terminal réduit lorsqu\'une commande en cours d\'exécution émet une nouvelle sortie.',
     settings_label_session_endless_scroll: 'Charger les anciens messages en faisant défiler vers le haut',
     settings_desc_session_endless_scroll: 'Lorsqu\'ils sont activés, les anciens messages se chargent automatiquement lorsque vous faites défiler vers le haut. Lorsqu\'il est désactivé, utilisez le bouton des messages plus anciens.',
+    settings_label_auto_scroll_follow: 'Suivre automatiquement le nouveau contenu',
+    settings_desc_auto_scroll_follow: 'Lorsque cette option est activée, la vue défile vers le bas à mesure que de nouveaux jetons arrivent. Lorsqu\'elle est désactivée, vous contrôlez la position de défilement.',
     settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
     settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
     settings_label_chat_activity_display_mode: 'Activity display',
@@ -15547,6 +15565,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Yukarı kaydırırken eski mesajları yükle',
 
     settings_desc_session_endless_scroll: 'Etkinleştirildiğinde, yukarı doğru kaydırdığınızda eski mesajlar otomatik olarak yüklenir. Devre dışı bırakıldığında eski mesajlar düğmesini kullanın.',
+    settings_label_auto_scroll_follow: 'Yeni içeriği otomatik takip et',
+    settings_desc_auto_scroll_follow: 'Etkinleştirildiğinde, yeni belirteçler akarken görünüm en alta kaydırılır. Devre dışı bırakıldığında kaydırma konumunu kendiniz kontrol edersiniz.',
     settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
     settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
     settings_label_chat_activity_display_mode: 'Activity display',
@@ -16967,6 +16987,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Ładuj starsze wiadomości podczas przewijania w górę',
 
     settings_desc_session_endless_scroll: 'Gdy ta opcja jest włączona, starsze wiadomości ładują się automatycznie przy przewijaniu w górę. Gdy jest wyłączona, użyj przycisku wczytywania starszych wiadomości.',
+    settings_label_auto_scroll_follow: 'Automatycznie podążaj za nową treścią',
+    settings_desc_auto_scroll_follow: 'Gdy włączone, widok przewija się na dół w miarę napływania nowych tokenów. Gdy wyłączone, sam kontrolujesz pozycję przewijania.',
     settings_label_worklog_details_expanded_default: 'Otwieraj szczegóły Worklog automatycznie',
     settings_desc_worklog_details_expanded_default: 'Gdy ta opcja jest włączona, nowe szczegóły Worklog zaczynają rozwinięte, dzięki czemu karty narzędzi, Thinking i postępu są widoczne bez dodatkowego kliknięcia. Gdy jest wyłączona, szczegóły Worklog pozostają domyślnie zwinięte. Ręczne decyzje o zwinięciu/rozwinięciu w danej turze mają pierwszeństwo.',
     settings_label_chat_activity_display_mode: 'Activity display',

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -558,6 +558,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Load older messages while scrolling up',
 
     settings_desc_session_endless_scroll: 'When enabled, older messages load automatically as you scroll upward. When disabled, use the older-messages button.',
+    settings_label_auto_scroll_follow: 'Auto-follow new content',
+    settings_desc_auto_scroll_follow: 'When enabled, the view scrolls to the bottom as new tokens stream in. When disabled, you control the scroll position manually.',
     settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
     settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 
@@ -9402,6 +9404,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: '向上滚动时加载更早的消息',
 
     settings_desc_session_endless_scroll: '启用后，向上滚动时会自动加载更早的消息。禁用时请使用加载更早消息按钮。',
+    settings_label_auto_scroll_follow: '自动跟随新内容',
+    settings_desc_auto_scroll_follow: '启用后，流式输出时页面会自动滚动到底部。禁用后，你可以自由控制滚动位置，阅读答案不会被拽到底部。',
     settings_label_worklog_details_expanded_default: 'Open Worklog details automatically',
     settings_desc_worklog_details_expanded_default: 'When enabled, new Worklog details start expanded so tool, thinking, and progress cards are visible without an extra click. When off, Worklog details stay folded by default; per-turn manual collapse/expand choices still win.',
 

--- a/static/index.html
+++ b/static/index.html
@@ -1006,6 +1006,13 @@
             </div>
             <div class="settings-field" style="margin-top:8px">
               <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+                <input type="checkbox" id="settingsAutoScrollFollow" style="width:15px;height:15px;accent-color:var(--accent)">
+                <span data-i18n="settings_label_auto_scroll_follow">Auto-follow new content</span>
+              </label>
+              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_auto_scroll_follow">When enabled, the view scrolls to the bottom as new tokens stream in. When disabled, you control the scroll position manually.</div>
+            </div>
+            <div class="settings-field" style="margin-top:8px">
+              <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
                 <input type="checkbox" id="settingsWorklogDetailsExpandedDefault" style="width:15px;height:15px;accent-color:var(--accent)">
                 <span data-i18n="settings_label_worklog_details_expanded_default">Open Worklog details automatically</span>
               </label>

--- a/static/messages.js
+++ b/static/messages.js
@@ -3299,7 +3299,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             _messageRenderWindowSize=Math.max(typeof _currentMessageRenderWindowSize==='function'?_currentMessageRenderWindowSize():50, _messageRenderableMessageCount());
           }
           syncTopbar();renderMessages({preserveScroll:true});
-          if(shouldFollowOnDone&&typeof scrollToBottom==='function') scrollToBottom();
+          if(shouldFollowOnDone&&typeof scrollToBottom==='function'&&typeof _isMessagePaneNearBottom==='function'&&_isMessagePaneNearBottom(250)) scrollToBottom();
           if(typeof noteWorkspaceMutationsFromToolCalls==='function') noteWorkspaceMutationsFromToolCalls(S.toolCalls);
           loadDir('.', { preservePreview: true });
           // TTS auto-read: speak the last assistant response if enabled (#499)

--- a/static/panels.js
+++ b/static/panels.js
@@ -6210,6 +6210,7 @@ function _appearancePayloadFromUi(){
     font_size: ($('settingsFontSize')||{}).value || localStorage.getItem('hermes-font-size') || 'default',
     session_jump_buttons: !!($('settingsSessionJumpButtons')||{}).checked,
     session_endless_scroll: !!($('settingsSessionEndlessScroll')||{}).checked,
+    auto_scroll_follow: !!($('settingsAutoScrollFollow')||{}).checked,
     worklog_details_expanded_default: worklogDetailsExpanded,
     activity_feed_expanded_default: worklogDetailsExpanded,
     hidden_tabs: _getHiddenTabs(),
@@ -6266,6 +6267,7 @@ async function _autosaveAppearanceSettings(payload){
       if(typeof _applySessionNavigationPrefs==='function') _applySessionNavigationPrefs();
     }
     window._sessionEndlessScrollEnabled=!!(saved&&saved.session_endless_scroll);
+    window._autoScrollFollow=!!(saved&&saved.auto_scroll_follow);
     if(saved&&payload&&Object.prototype.hasOwnProperty.call(payload,'worklog_details_expanded_default')&&(
       Object.prototype.hasOwnProperty.call(saved,'worklog_details_expanded_default') ||
       Object.prototype.hasOwnProperty.call(saved,'activity_feed_expanded_default')
@@ -6497,6 +6499,15 @@ async function loadSettingsPanel(){
       window._sessionEndlessScrollEnabled=endlessScrollCb.checked;
       endlessScrollCb.onchange=function(){
         window._sessionEndlessScrollEnabled=this.checked;
+        _scheduleAppearanceAutosave();
+      };
+    }
+    const autoScrollFollowCb=$('settingsAutoScrollFollow');
+    if(autoScrollFollowCb){
+      autoScrollFollowCb.checked=!!settings.auto_scroll_follow;
+      window._autoScrollFollow=autoScrollFollowCb.checked;
+      autoScrollFollowCb.onchange=function(){
+        window._autoScrollFollow=this.checked;
         _scheduleAppearanceAutosave();
       };
     }
@@ -7769,6 +7780,7 @@ function _applySavedSettingsUi(saved, body, opts){
   window._sidebarDensity=sidebarDensity==='detailed'?'detailed':'compact';
   window._busyInputMode=body.busy_input_mode||'queue';
   window._sessionEndlessScrollEnabled=!!body.session_endless_scroll;
+  window._autoScrollFollow=!!body.auto_scroll_follow;
   window._botName=body.bot_name||'Hermes';
   if(typeof applyBotName==='function') applyBotName();
   if(typeof setLocale==='function') setLocale(language);
@@ -8100,6 +8112,7 @@ async function saveSettings(andClose){
   body.font_size=fontSize;
   body.session_jump_buttons=!!($('settingsSessionJumpButtons')||{}).checked;
   body.session_endless_scroll=!!($('settingsSessionEndlessScroll')||{}).checked;
+  body.auto_scroll_follow=!!($('settingsAutoScrollFollow')||{}).checked;
   body.language=language;
   body.show_token_usage=showTokenUsage;
   body.show_quota_chip=showQuotaChip===true;

--- a/static/panels.js
+++ b/static/panels.js
@@ -6306,7 +6306,7 @@ async function _autosaveAppearanceSettings(payload){
       if(typeof _applySessionNavigationPrefs==='function') _applySessionNavigationPrefs();
     }
     window._sessionEndlessScrollEnabled=!!(saved&&saved.session_endless_scroll);
-    window._autoScrollFollow=!!(saved&&saved.auto_scroll_follow);
+    window._autoScrollFollow=!saved||saved.auto_scroll_follow!==false;
     if(saved&&payload&&Object.prototype.hasOwnProperty.call(payload,'worklog_details_expanded_default')&&(
       Object.prototype.hasOwnProperty.call(saved,'worklog_details_expanded_default') ||
       Object.prototype.hasOwnProperty.call(saved,'activity_feed_expanded_default')
@@ -7834,7 +7834,7 @@ function _applySavedSettingsUi(saved, body, opts){
   window._sidebarDensity=sidebarDensity==='detailed'?'detailed':'compact';
   window._busyInputMode=body.busy_input_mode||'queue';
   window._sessionEndlessScrollEnabled=!!body.session_endless_scroll;
-  window._autoScrollFollow=!!body.auto_scroll_follow;
+  window._autoScrollFollow=body.auto_scroll_follow!==false;
   window._botName=body.bot_name||'Hermes';
   if(typeof applyBotName==='function') applyBotName();
   if(typeof setLocale==='function') setLocale(language);

--- a/static/ui.js
+++ b/static/ui.js
@@ -3150,7 +3150,7 @@ function _settleMessageScrollToBottom(force){
   // active one that may now be in the global _settleRO. (Codex review #3.)
   const ro=new ResizeObserver(()=>{
     if(token!==_bottomSettleToken){ ro.disconnect(); if(_settleRO===ro) _settleRO=null; return; }
-    if(!_scrollPinned||_messageUserUnpinned||_recentNonMessageScrollIntent()){
+    if(!_autoScrollFollow||!_scrollPinned||_messageUserUnpinned||_recentNonMessageScrollIntent()){
       ro.disconnect(); if(_settleRO===ro) _settleRO=null;
       _programmaticScroll=false;
       return;
@@ -3183,7 +3183,7 @@ function _settleMessageScrollToBottom(force){
   _settleFinalTimer=setTimeout(()=>{
     if(token!==_bottomSettleToken) return;
     ro.disconnect(); if(_settleRO===ro) _settleRO=null;
-    if(!_scrollPinned||_messageUserUnpinned||_recentNonMessageScrollIntent()){ _programmaticScroll=false; return; }
+    if(!_autoScrollFollow||!_scrollPinned||_messageUserUnpinned||_recentNonMessageScrollIntent()){ _programmaticScroll=false; return; }
     _settleFinalScroll(token);
   },2000);
 }
@@ -8648,6 +8648,15 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
   }
   if(S.activeStreamId){
     scrollIfPinned();
+    return;
+  }
+  // Auto-follow OFF + the user has scrolled up: don't yank them to the bottom on
+  // an automatic (non-preserve) re-render. This also covers the send() race where
+  // renderMessages() runs before S.activeStreamId is set, so a stream-start
+  // wouldn't otherwise be caught by the scrollIfPinned() branch above. A fresh
+  // session load (not unpinned) still lands at the bottom as expected. (Codex #4006.)
+  if(!_autoScrollFollow && _messageUserUnpinned){
+    _restoreMessageScrollSnapshot(scrollSnapshot);
     return;
   }
   scrollToBottom();

--- a/static/ui.js
+++ b/static/ui.js
@@ -3087,7 +3087,7 @@ function _shouldFollowMessagesOnDomReplace(){
   // following only for users who are still pinned or effectively at the tail.
   // A broad near-bottom window causes long answers/mobile readers who scroll up
   // a little to read mid-stream to get snapped back to the bottom on completion.
-  return !_messageUserUnpinned && (_scrollPinned || _isMessagePaneNearBottom(120));
+  return _autoScrollFollow && !_messageUserUnpinned && (_scrollPinned || _isMessagePaneNearBottom(120));
 }
 function _followMessagesAfterDomReplace(){
   if(_shouldFollowMessagesOnDomReplace()){
@@ -3119,6 +3119,7 @@ function _settleMessageScrollToBottom(force){
   });
 }
 function scrollIfPinned(){
+  if(!_autoScrollFollow) return;
   if(_messageUserUnpinned) return;
   if(!_scrollPinned) return;
   if(_recentNonMessageScrollIntent()) return;
@@ -7967,7 +7968,7 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
     // new-message cue. (Using scrollIfPinned() here instead would skip the forced
     // write unless distance>500 and let the DOM-rebuild scroll event cancel the
     // delayed settles — Codex CORE catch on #3631.)
-    if(_followMessagesAfterDomReplace()) return;
+    if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;
     _restoreMessageScrollSnapshot(scrollSnapshot);
     _maybeShowNewMessageScrollCue(scrollSnapshot);
     return;

--- a/static/ui.js
+++ b/static/ui.js
@@ -3112,8 +3112,11 @@ function _followMessagesAfterDomReplace(){
   }
   return false;
 }
-function _settleMessageScrollToBottom(force){
-  // Markdown post-processing (Prism, tables, Mermaid/KaTeX/PDF placeholders)
+function _settleMessageScrollToBottom(force, explicit){
+  // `explicit` = a user-invoked scroll-to-bottom (End button / scrollToBottom()).
+  // When explicit, late-layout settling runs even if Auto-follow is OFF — the
+  // setting only suppresses AUTOMATIC streaming follow, not a deliberate jump
+  // to the bottom. (Codex #4006 r3.)
   // can grow the transcript after the first scroll write. Re-apply the bottom
   // position when content settles so late layout does not leave the viewport
   // above the real end. User scroll increments _bottomSettleToken and cancels.
@@ -3150,7 +3153,7 @@ function _settleMessageScrollToBottom(force){
   // active one that may now be in the global _settleRO. (Codex review #3.)
   const ro=new ResizeObserver(()=>{
     if(token!==_bottomSettleToken){ ro.disconnect(); if(_settleRO===ro) _settleRO=null; return; }
-    if(!_autoScrollFollow||!_scrollPinned||_messageUserUnpinned||_recentNonMessageScrollIntent()){
+    if((!_autoScrollFollow&&!explicit)||!_scrollPinned||_messageUserUnpinned||_recentNonMessageScrollIntent()){
       ro.disconnect(); if(_settleRO===ro) _settleRO=null;
       _programmaticScroll=false;
       return;
@@ -3183,7 +3186,7 @@ function _settleMessageScrollToBottom(force){
   _settleFinalTimer=setTimeout(()=>{
     if(token!==_bottomSettleToken) return;
     ro.disconnect(); if(_settleRO===ro) _settleRO=null;
-    if(!_autoScrollFollow||!_scrollPinned||_messageUserUnpinned||_recentNonMessageScrollIntent()){ _programmaticScroll=false; return; }
+    if((!_autoScrollFollow&&!explicit)||!_scrollPinned||_messageUserUnpinned||_recentNonMessageScrollIntent()){ _programmaticScroll=false; return; }
     _settleFinalScroll(token);
   },2000);
 }
@@ -3219,7 +3222,7 @@ function scrollToBottom(){
   // was skipping the observer and causing Firefox paint jumps when
   // renderMessages({preserveScroll:true}) + scrollToBottom() fired back-to-back.
   _setMessageScrollToBottom();
-  _settleMessageScrollToBottom(false);
+  _settleMessageScrollToBottom(false, true);
   _syncScrollToBottomCue(false,{newMessage:false});
   if(typeof _updateSessionStartJumpButton==='function') _updateSessionStartJumpButton();
 }
@@ -8655,6 +8658,8 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
   // renderMessages() runs before S.activeStreamId is set, so a stream-start
   // wouldn't otherwise be caught by the scrollIfPinned() branch above. A fresh
   // session load (not unpinned) still lands at the bottom as expected. (Codex #4006.)
+  // renderMessages() captures the pre-wipe snapshot for this case too (see its
+  // scrollSnapshot init), so restoring here lands the reader where they were.
   if(!_autoScrollFollow && _messageUserUnpinned){
     _restoreMessageScrollSnapshot(scrollSnapshot);
     return;
@@ -8664,7 +8669,10 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
 
 function renderMessages(options){
   const preserveScroll=!!(options&&options.preserveScroll);
-  const scrollSnapshot=preserveScroll?_captureMessageScrollSnapshot():null;
+  // Capture the pre-wipe scroll position when preserving OR when Auto-follow is
+  // off and the user has scrolled up — both need to restore the reader's position
+  // after the DOM rebuild rather than snap to the bottom. (Codex #4006 r3.)
+  const scrollSnapshot=(preserveScroll||(!_autoScrollFollow&&_messageUserUnpinned))?_captureMessageScrollSnapshot():null;
   const inner=$('msgInner');
   const sid=S.session?S.session.session_id:null;
   const msgCount=S.messages.length;

--- a/tests/test_issue1690_scroll_completion.py
+++ b/tests/test_issue1690_scroll_completion.py
@@ -58,7 +58,7 @@ def test_render_messages_preserve_scroll_option_uses_user_pin_state_not_stream_l
     assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in render_body
     assert "const scrollSnapshot=preserveScroll?_captureMessageScrollSnapshot():null" in render_body
     assert "if(preserveScroll){\n    // Keep master's follow heuristic" in scroll_helper
-    assert "if(_followMessagesAfterDomReplace()) return;\n    _restoreMessageScrollSnapshot(scrollSnapshot);\n    _maybeShowNewMessageScrollCue(scrollSnapshot);\n    return;\n  }" in scroll_helper
+    assert "if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;\n    _restoreMessageScrollSnapshot(scrollSnapshot);\n    _maybeShowNewMessageScrollCue(scrollSnapshot);\n    return;\n  }" in scroll_helper
     assert "_shouldFollowMessagesOnDomReplace()" in follow_helper
     assert "scrollToBottom();" in follow_helper
     assert "if(S.activeStreamId){\n    scrollIfPinned();\n    return;\n  }" in scroll_helper

--- a/tests/test_issue1690_scroll_completion.py
+++ b/tests/test_issue1690_scroll_completion.py
@@ -56,7 +56,7 @@ def test_render_messages_preserve_scroll_option_uses_user_pin_state_not_stream_l
     assert "function renderMessages(options)" in render_body
     assert "const preserveScroll=!!(options&&options.preserveScroll);" in render_body
     assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in render_body
-    assert "const scrollSnapshot=preserveScroll?_captureMessageScrollSnapshot():null" in render_body
+    assert "const scrollSnapshot=(preserveScroll||(!_autoScrollFollow&&_messageUserUnpinned))?_captureMessageScrollSnapshot():null" in render_body
     assert "if(preserveScroll){\n    // Keep master's follow heuristic" in scroll_helper
     assert "if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;\n    _restoreMessageScrollSnapshot(scrollSnapshot);\n    _maybeShowNewMessageScrollCue(scrollSnapshot);\n    return;\n  }" in scroll_helper
     assert "_shouldFollowMessagesOnDomReplace()" in follow_helper

--- a/tests/test_issue3545_streaming_scroll_cue.py
+++ b/tests/test_issue3545_streaming_scroll_cue.py
@@ -34,7 +34,7 @@ def test_preserve_scroll_unpinned_branch_shows_new_message_cue_after_restore():
     # only the genuinely-scrolled-up cohort restores their viewport + gets the
     # new-message cue. (Codex CORE catch: scrollIfPinned() in the pinned branch
     # could leave a pinned reader short of the settled response.)
-    assert "if(_followMessagesAfterDomReplace()) return;" in helper
+    assert "if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;" in helper
     assert "_restoreMessageScrollSnapshot(scrollSnapshot);" in helper
     assert helper.index("_restoreMessageScrollSnapshot(scrollSnapshot)") < helper.index(
         "_maybeShowNewMessageScrollCue(scrollSnapshot)"

--- a/tests/test_issue4006_auto_scroll_follow_default.py
+++ b/tests/test_issue4006_auto_scroll_follow_default.py
@@ -1,0 +1,74 @@
+"""Pin the auto_scroll_follow setting's default + hydration consistency (#4006).
+
+The viewport-follow default is `True` (Codex/Claude-Code-style sticky bottom:
+follow new output to the bottom while streaming, but a deliberate scroll-up
+unpins and is respected). This pins the default in every place it is read so a
+future edit can't silently flip it or, worse, default it ON in config.py while
+hydrating it OFF in the browser (the classic default-mismatch bug, where an
+existing user with no saved value sees the feature as disabled).
+"""
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _read(rel):
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_auto_scroll_follow_default_is_true_in_config():
+    src = _read("api/config.py")
+    assert re.search(r'["\']auto_scroll_follow["\']\s*:\s*True', src), (
+        "auto_scroll_follow must default to True in _SETTINGS_DEFAULTS "
+        "(sticky-bottom follow; scroll-up unpins)"
+    )
+
+
+def test_auto_scroll_follow_in_bool_keys():
+    src = _read("api/config.py")
+    m = re.search(r"_SETTINGS_BOOL_KEYS\s*=\s*\{([^}]+)\}", src, re.DOTALL)
+    assert m, "_SETTINGS_BOOL_KEYS not found"
+    assert "auto_scroll_follow" in m.group(1), (
+        "auto_scroll_follow must be in _SETTINGS_BOOL_KEYS so it round-trips as a bool"
+    )
+
+
+def test_boot_hydration_defaults_true_when_setting_absent():
+    """boot.js must hydrate _autoScrollFollow as True when the saved settings
+    omit the key — `!!s.auto_scroll_follow` would wrongly default it OFF for
+    every existing user, contradicting the config.py default."""
+    src = _read("static/boot.js")
+    # Settings path: default-true read (=== false), not the truthy-coerce form.
+    assert "window._autoScrollFollow=s.auto_scroll_follow!==false" in src, (
+        "boot.js settings path must default _autoScrollFollow True when absent"
+    )
+    assert "window._autoScrollFollow=!!s.auto_scroll_follow" not in src, (
+        "boot.js must not use !!s.auto_scroll_follow — that defaults the True "
+        "setting OFF for users with no saved value"
+    )
+    # Fallback (no-settings) path must also default true.
+    assert "window._autoScrollFollow=true" in src, (
+        "boot.js fallback path must default _autoScrollFollow to true"
+    )
+
+
+def test_settings_checkbox_renders_checked_by_default():
+    """The Appearance checkbox must render checked when the setting is absent,
+    matching the True default (panels.js settings-load)."""
+    src = _read("static/panels.js")
+    assert "autoScrollFollowCb.checked=settings.auto_scroll_follow!==false" in src, (
+        "the auto-follow checkbox must default checked (=== false), not "
+        "!!settings.auto_scroll_follow which would render it unchecked by default"
+    )
+
+
+def test_follow_gate_references_auto_scroll_follow_and_unpin():
+    """The DOM-replace follow gate must consult both _autoScrollFollow (the
+    setting) and _messageUserUnpinned (the user's scroll-up), so the opt-out and
+    the read-while-streaming behaviors both hold."""
+    src = _read("static/ui.js")
+    assert "_shouldFollowMessagesOnDomReplace" in src
+    assert "_autoScrollFollow" in src and "_messageUserUnpinned" in src, (
+        "the follow gate must reference both _autoScrollFollow and _messageUserUnpinned"
+    )

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -103,7 +103,7 @@ def test_preserve_scroll_restores_unpinned_viewport_after_dom_rebuild():
         "renderMessages({preserveScroll:true}) must capture #messages.scrollTop before "
         "replacing transcript DOM, then pass that snapshot to the post-render scroll helper"
     )
-    assert "if(_followMessagesAfterDomReplace()) return;" in after_render
+    assert "if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;" in after_render
     assert "_restoreMessageScrollSnapshot(scrollSnapshot);\n    _maybeShowNewMessageScrollCue(scrollSnapshot);" in after_render
     assert "_shouldFollowMessagesOnDomReplace()" in follow
     assert "scrollToBottom();" in follow

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -55,9 +55,10 @@ def test_scroll_to_bottom_settles_across_late_markdown_layout_growth():
         "not the fixed #messages scroll container"
     )
     assert "2000" in settle, "a 2s fallback must cover fully-static content that never resizes"
-    # scrollToBottom uses force=false so the observer actually runs (the old
-    # force=true skipped it and caused Firefox paint jumps).
-    assert "_settleMessageScrollToBottom(false)" in scroll
+    # scrollToBottom uses force=false so the observer runs, and explicit=true so the
+    # settle still runs even when Auto-follow is off (explicit user jump). The
+    # automatic scrollIfPinned() path passes no explicit flag (stays auto-gated).
+    assert "_settleMessageScrollToBottom(false, true)" in scroll
     assert "_settleMessageScrollToBottom(false)" in pinned
     assert "!_scrollPinned" in settle
     assert "const token=++_bottomSettleToken" in settle
@@ -68,7 +69,7 @@ def test_scroll_to_bottom_writes_scroll_position_immediately_before_delayed_sett
     scroll = _function_body(UI_JS, "function scrollToBottom")
 
     immediate_idx = scroll.index("_setMessageScrollToBottom();")
-    settle_idx = scroll.index("_settleMessageScrollToBottom(false)")
+    settle_idx = scroll.index("_settleMessageScrollToBottom(false, true)")
 
     assert immediate_idx < settle_idx, (
         "scrollToBottom() must write scrollTop synchronously before scheduling the "
@@ -107,7 +108,7 @@ def test_preserve_scroll_restores_unpinned_viewport_after_dom_rebuild():
     follow = _function_body(UI_JS, "function _followMessagesAfterDomReplace")
     restore = _function_body(UI_JS, "function _restoreMessageScrollSnapshot")
 
-    snapshot_idx = render.index("const scrollSnapshot=preserveScroll?_captureMessageScrollSnapshot():null")
+    snapshot_idx = render.index("const scrollSnapshot=(preserveScroll||(!_autoScrollFollow&&_messageUserUnpinned))?_captureMessageScrollSnapshot():null")
     inner_idx = render.index("const inner=$('msgInner')")
     final_scroll_idx = render.rindex("_scrollAfterMessageRender(preserveScroll, scrollSnapshot)")
 


### PR DESCRIPTION
## Release MQ — v0.51.378 — Don't yank the viewport while reading; auto-follow toggle (#4006)

Absorbs **#4006** (@Pythonming2020) — two pin-hysteresis scroll bug fixes + a new opt-out **Auto-follow** setting, with the maintainer-review + trifecta fixes layered on top.

### What changed
- **Bug fixes:** `_scrollAfterMessageRender` honors `_messageUserUnpinned` (a forced follow can't override a deliberate scroll-up after the 250px re-pin counter); `_finishDone`'s completion scroll is gated on an actual near-bottom check instead of firing unconditionally.
- **New "Auto-follow new content" setting** (Settings → Appearance), **default ON** — Codex/Claude-Code-style sticky bottom: stay pinned to the latest output until you scroll up, then you're left where you are. Turn it off to always manage scroll yourself.

### Decisions + gate fixes applied
- **Default = ON** (maintainer decision; the PR shipped it OFF) — Codex/Claude-Code parity.
- **Fixed a default-hydration mismatch** (boot.js both paths, panels.js checkbox + 2 more hydration sites) — `!!` would have shown the True default as OFF for existing users; now `!==false` everywhere a settings object is read.
- **(Codex, 3 rounds) Gated the #3920 ResizeObserver settle + 2s fallback + non-preserve render path on `_autoScrollFollow`** so Auto-follow OFF genuinely suppresses streaming auto-scroll — while an `explicit` flag keeps the End-button `scrollToBottom()` settling late layout, and `renderMessages` captures a pre-wipe snapshot for the off+unpinned path so a reader's position is restored (not a null no-op).
- Added `test_issue4006_auto_scroll_follow_default.py` (pins True default across config/boot/panels), re-anchored 4 scroll regression tests, and added the i18n label/desc to all 13 locales (was en+zh only).

### Gates
- **Codex: SAFE TO SHIP** (after 3 rounds — RO gating, explicit-settle, snapshot capture all verified).
- **Opus: SAFE-TO-SHIP** (4 mechanisms coherent: ON = master-equivalent, OFF never yanks a reader, explicit jumps + fresh loads preserved).
- **Full suite: 8770 passed**, ESLint clean.

Thanks @Pythonming2020 — good scroll-UX instinct; this lands the toggle + the never-yank guarantee.