### PR TITLE
Release MW (v0.51.384): no false streaming / activity-timer reset on session switch (#3900)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Session falsely streams after sidebar switch:** `loadSession` now clears `S.busy` and `S.activeStreamId` as soon as session metadata confirms there is no `active_stream_id`, before the async message-load gap. Prevents the previous session's busy flag from making an idle chat show Stop/spinner/thinking.
+- **Activity timer resets when switching back to a streaming chat:** `loadSession` snapshots the live turn DOM before replacing `msgInner`, ensures an `INFLIGHT` bucket exists for the snapshot, and restores that HTML on the `active_stream_id` return path instead of always rebuilding the worklog shell from scratch.
+
 ## [v0.51.346] — 2026-06-09 — Release LJ (PWA notification controls)
 
 ### Added

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -794,6 +794,22 @@ async function loadSession(sid){
     // close streams for the session the user actually landed on (#1060 guard,
     // extended to cover the new pre-switch await).
     if (_loadingSessionId !== sid) return;
+    // Snapshot the live turn before msgInner is replaced. Preserves the activity
+    // timer, partial response, and tool cards so switching back does not rebuild
+    // the stream UI from scratch.
+    if(
+      (S.busy||S.activeStreamId||(INFLIGHT&&INFLIGHT[currentSid]))&&
+      typeof snapshotLiveTurnHtmlForSession==='function'
+    ){
+      if(!INFLIGHT[currentSid]){
+        INFLIGHT[currentSid]={
+          messages:Array.isArray(S.messages)?[...S.messages]:[],
+          uploaded:[],
+          toolCalls:Array.isArray(S.toolCalls)?[...S.toolCalls]:[],
+        };
+      }
+      snapshotLiveTurnHtmlForSession(currentSid);
+    }
   }
   if (currentSid !== sid || forceReload) {
     // #3306: When force-reloading the currently-active session (e.g. external
@@ -935,14 +951,21 @@ async function loadSession(sid){
   if(typeof startSessionStream==='function') startSessionStream(S.session.session_id);
 
   const activeStreamId=S.session.active_stream_id||null;
-  // If the server says the session is idle, discard any browser-side inflight
-  // cache left behind by a crashed/restarted stream. Otherwise the UI can keep
-  // showing a permanent thinking/running state even though active_streams=0.
-  if(!activeStreamId&&INFLIGHT[sid]){
-    delete INFLIGHT[sid];
-    if(typeof clearInflightState==='function') clearInflightState(sid);
+  // If the server says the session is idle, reset browser-side streaming flags
+  // NOW — before the async _ensureMessagesLoaded gap below. Without this,
+  // S.busy can remain true from a still-running stream in the PREVIOUS session
+  // while S.session.session_id has already advanced to the new one.
+  // _isSessionLocallyStreaming() checks (isActive && S.busy), so during the
+  // async window the new session would appear locally-streaming (sidebar spinner,
+  // Stop button, thinking state on an idle chat). Also clears stale INFLIGHT
+  // entries left behind by a crashed/restarted stream.
+  if(!activeStreamId){
     S.activeStreamId=null;
     S.busy=false;
+    if(INFLIGHT[sid]){
+      delete INFLIGHT[sid];
+      if(typeof clearInflightState==='function') clearInflightState(sid);
+    }
   }
 
   function _mergePendingSessionMessage(session,messages){
@@ -1155,10 +1178,15 @@ async function loadSession(sid){
       updateSendBtn();
       setStatus('');
       setComposerStatus('');
-      // syncTopbar();renderMessages();appendThinking();loadDir('.');
       syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
-      if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
-      else appendThinking();
+      let restoredLiveTurn=false;
+      if(typeof restoreLiveTurnHtmlForSession==='function'){
+        restoredLiveTurn=restoreLiveTurnHtmlForSession(sid);
+      }
+      if(!restoredLiveTurn){
+        if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
+        else appendThinking();
+      }
       loadDir('.');
       updateQueueBadge(sid);
       startApprovalPolling(sid);

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -254,7 +254,10 @@ def test_load_session_reattaches_when_inflight_is_in_memory_and_marked_for_reatt
     pins the gate's shape so future refactors don't drop the flag check.
     """
     body = _function_body(SESSIONS_JS, "loadSession")
-    inflight_idx = body.find("if(INFLIGHT[sid]){")
+    # Anchor on the Phase-2 INFLIGHT restore branch (the later occurrence): #3899
+    # added an earlier if(INFLIGHT[sid]){ idle-reset block, so .find() would grab
+    # the wrong one. rfind = the substantive restore branch.
+    inflight_idx = body.rfind("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
     inflight_block = body[inflight_idx : inflight_idx + 4200]
     assert "INFLIGHT[sid].reattach" in inflight_block, (
@@ -283,9 +286,17 @@ def test_load_session_attaches_sse_before_auxiliary_work():
     active_branch = body[body.find("if(activeStreamId){") : body.find("}else{", body.find("if(activeStreamId){"))]
     active_attach = active_branch.find("attachLiveStream(sid, activeStreamId")
     assert active_attach != -1
+    # #3899 inserted restoreLiveTurnHtmlForSession between renderMessages and
+    # appendThinking, and renderMessages now takes a preserveScroll arg — so the
+    # old contiguous "syncTopbar();renderMessages();appendThinking();loadDir('.');"
+    # literal no longer exists. Assert each auxiliary call individually; all must
+    # still run AFTER attachLiveStream (the invariant this test protects).
     for marker in (
         "updateSendBtn();",
-        "syncTopbar();renderMessages();appendThinking();loadDir('.');",
+        "syncTopbar();",
+        "renderMessages(",
+        "appendThinking();",
+        "loadDir('.');",
         "updateQueueBadge(sid);",
         "startApprovalPolling(sid)",
     ):
@@ -1013,7 +1024,9 @@ def test_load_session_discards_cursor_only_inflight_before_reattach():
     guard = "if(activeStreamId&&INFLIGHT[sid]&&!_inflightHasVisibleLiveState(INFLIGHT[sid]))"
     assert guard in compact_load
     guard_pos = compact_load.find(guard)
-    inflight_branch_pos = compact_load.find("if(INFLIGHT[sid]){")
+    # rfind: anchor on the Phase-2 restore branch, not #3899's earlier idle-reset
+    # if(INFLIGHT[sid]){ block (which now precedes the guard).
+    inflight_branch_pos = compact_load.rfind("if(INFLIGHT[sid]){")
     assert 0 <= guard_pos < inflight_branch_pos
 
 

--- a/tests/test_issue3306_loadsession_carry_forward.py
+++ b/tests/test_issue3306_loadsession_carry_forward.py
@@ -26,7 +26,10 @@ SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
 def _load_session_clear_block() -> str:
     """The if(currentSid!==sid||forceReload){...} block in loadSession()."""
     start = SESSIONS_JS.index("async function loadSession(sid)")
-    return SESSIONS_JS[start: start + 4000]
+    # Window widened to 6500: #3899's idle-reset + live-turn-snapshot blocks added
+    # code earlier in loadSession, pushing the carry-forward snapshot past the old
+    # 4000-char window.
+    return SESSIONS_JS[start: start + 6500]
 
 
 def _ensure_messages_loaded_body() -> str:

--- a/tests/test_issue_new_chat_draft_restore.py
+++ b/tests/test_issue_new_chat_draft_restore.py
@@ -76,7 +76,9 @@ def test_pre_switch_draft_flush_rechecks_stale_loading_guard():
     (Codex pre-release CORE catch, #3471)."""
     start = SESSIONS_JS.find("async function loadSession(")
     assert start != -1, "loadSession not found"
-    body = SESSIONS_JS[start:start + 4000]
+    # Window widened to 6500: #3899's idle-reset + live-turn-snapshot blocks pushed
+    # the destructive S.messages clear past the old 4000-char window.
+    body = SESSIONS_JS[start:start + 6500]
     await_idx = body.find("await _saveComposerDraftNow(currentSid")
     guard_idx = body.find("if (_loadingSessionId !== sid) return;", await_idx)
     clear_idx = body.find("S.messages = [];", await_idx)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -426,7 +426,10 @@ def test_loadSession_inflight_restores_live_tool_cards(cleanup_test_sessions):
     """
     src = (REPO_ROOT / "static/sessions.js").read_text()
     # INFLIGHT branch must call appendLiveToolCard
-    inflight_idx = src.find("if(INFLIGHT[sid]){")
+    # Anchor on the Phase-2 INFLIGHT restore branch (the later occurrence); #3899
+    # added an earlier if(INFLIGHT[sid]){ idle-reset block, so .find() would
+    # grab the wrong one. (rfind = the substantive restore branch.)
+    inflight_idx = src.rfind("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
     inflight_block = src[inflight_idx:inflight_idx+4200]
     assert "appendLiveToolCard" in inflight_block,         "loadSession INFLIGHT branch must restore live tool cards via appendLiveToolCard"
@@ -647,7 +650,10 @@ def test_loadSession_inflight_sets_busy_before_renderMessages(cleanup_test_sessi
     session switch.
     """
     src = (REPO_ROOT / "static/sessions.js").read_text()
-    inflight_idx = src.find("if(INFLIGHT[sid]){")
+    # Anchor on the Phase-2 INFLIGHT restore branch (the later occurrence); #3899
+    # added an earlier if(INFLIGHT[sid]){ idle-reset block, so .find() would
+    # grab the wrong one. (rfind = the substantive restore branch.)
+    inflight_idx = src.rfind("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
     inflight_block = src[inflight_idx:inflight_idx+4200]
     busy_pos = inflight_block.find("S.busy=true;")
@@ -662,7 +668,10 @@ def test_loadSession_inflight_sets_busy_before_renderMessages(cleanup_test_sessi
 
 def test_loadSession_inflight_merges_tail_with_persisted_transcript(cleanup_test_sessions):
     src = (REPO_ROOT / "static/sessions.js").read_text()
-    inflight_idx = src.find("if(INFLIGHT[sid]){")
+    # Anchor on the Phase-2 INFLIGHT restore branch (the later occurrence); #3899
+    # added an earlier if(INFLIGHT[sid]){ idle-reset block, so .find() would
+    # grab the wrong one. (rfind = the substantive restore branch.)
+    inflight_idx = src.rfind("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
     inflight_block = src[inflight_idx:inflight_idx+1200]
 
@@ -756,7 +765,10 @@ def test_loadSession_inflight_sets_active_stream_before_replaying_live_tool_card
     counter drops the previously-seen tools after a focus change.
     """
     src = (REPO_ROOT / "static/sessions.js").read_text()
-    inflight_idx = src.find("if(INFLIGHT[sid]){")
+    # Anchor on the Phase-2 INFLIGHT restore branch (the later occurrence); #3899
+    # added an earlier if(INFLIGHT[sid]){ idle-reset block, so .find() would
+    # grab the wrong one. (rfind = the substantive restore branch.)
+    inflight_idx = src.rfind("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
     inflight_block = src[inflight_idx:inflight_idx+4200]
     active_pos = inflight_block.find("S.activeStreamId=activeStreamId;")

--- a/tests/test_session_switch_busy_race.py
+++ b/tests/test_session_switch_busy_race.py
@@ -1,0 +1,79 @@
+"""Regression coverage for session-switch busy-state race and live-turn restore.
+
+Switching from a streaming session to an idle one must clear S.busy before the
+async _ensureMessagesLoaded gap. Otherwise _isSessionLocallyStreaming() treats
+the newly opened session as locally streaming while messages are still loading.
+
+Switching back to a streaming session must restore the snapshotted live turn
+instead of rebuilding thinking/worklog chrome from scratch.
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SESSIONS_SRC = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+UI_SRC = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.find(signature)
+    assert start != -1, f"missing {signature}"
+    brace = src.find("{", start)
+    assert brace != -1, f"missing opening brace for {signature}"
+    depth = 0
+    for i in range(brace, len(src)):
+        ch = src[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[brace + 1 : i]
+    raise AssertionError(f"could not extract function body for {signature}")
+
+
+def test_loadSession_clears_busy_before_async_message_load_when_server_idle():
+    body = _function_body(SESSIONS_SRC, "async function loadSession(")
+
+    idle_reset = body.find("if(!activeStreamId){")
+    assert idle_reset != -1, "loadSession must gate idle cleanup on missing active_stream_id"
+    idle_block = body[idle_reset : idle_reset + 500]
+    assert "S.busy=false" in idle_block, "idle switch must clear S.busy immediately"
+    assert "S.activeStreamId=null" in idle_block, "idle switch must clear S.activeStreamId immediately"
+
+    ensure_load = body.find("await _ensureMessagesLoaded(sid)")
+    assert ensure_load != -1, "loadSession must still lazy-load messages for idle sessions"
+    assert idle_reset < ensure_load, (
+        "S.busy must be cleared before _ensureMessagesLoaded so session-list polling "
+        "during the async gap does not mark the new session as locally streaming"
+    )
+
+
+def test_loadSession_snapshots_live_turn_before_wiping_message_pane():
+    body = _function_body(SESSIONS_SRC, "async function loadSession(")
+
+    snap_pos = body.find("snapshotLiveTurnHtmlForSession(currentSid)")
+    wipe_pos = body.find('_msgInner.innerHTML=\'<div style="display:flex')
+    assert snap_pos != -1, "loadSession must snapshot the outgoing live turn before switching"
+    assert wipe_pos != -1, "loadSession must still show the loading placeholder on switch"
+    assert snap_pos < wipe_pos, "snapshot must run before msgInner is replaced"
+
+
+def test_loadSession_restores_live_turn_on_active_stream_return_path():
+    body = _function_body(SESSIONS_SRC, "async function loadSession(")
+
+    phase2b = body.find("Phase 2b")
+    assert phase2b != -1, "loadSession must keep the idle lazy-load branch"
+    tail = body[phase2b:]
+    active_branch = tail.find("if(activeStreamId){")
+    assert active_branch != -1, "idle-branch active_stream_id path must exist"
+    restore_in_branch = tail.find("restoreLiveTurnHtmlForSession(sid)", active_branch)
+    assert restore_in_branch != -1, (
+        "active_stream_id return path must restore snapshotted live turn HTML"
+    )
+
+
+def test_activity_timer_reads_pending_started_at():
+    body = _function_body(UI_SRC, "function _activityElapsedStartedAt(")
+    assert "pending_started_at" in body
+    assert "data-turn-started-at" in body or "turnStartedAt" in body

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -398,13 +398,19 @@ def test_stale_stream_cleanup_does_not_clobber_concurrent_chat_start(monkeypatch
 
 
 def test_frontend_drops_inflight_cache_when_server_session_is_idle():
-    marker = "If the server says the session is idle, discard any browser-side inflight"
+    # #3900/#3899 generalized this block: on an idle server session it now resets
+    # the streaming flags (S.busy/S.activeStreamId) AND drops the inflight cache,
+    # before the async message-load gap. Anchor on the current comment + assert the
+    # (preserved) cache-drop behavior in the now-nested form.
+    marker = "If the server says the session is idle, reset browser-side streaming flags"
     marker_pos = SESSIONS_SRC.index(marker)
-    window = SESSIONS_SRC[marker_pos:marker_pos + 500]
-    assert "if(!activeStreamId&&INFLIGHT[sid])" in window
+    window = SESSIONS_SRC[marker_pos:marker_pos + 900]
+    assert "if(!activeStreamId){" in window
+    assert "S.busy=false" in window
+    assert "S.activeStreamId=null" in window
+    assert "if(INFLIGHT[sid]){" in window
     assert "delete INFLIGHT[sid]" in window
     assert "clearInflightState" in window
-    assert "S.busy=false" in window
 
 
 def test_service_worker_cache_bumped_for_frontend_fix_delivery():


### PR DESCRIPTION
## Release MW — v0.51.384 — No false streaming / activity-timer reset on session switch (#3900)

Absorbs **#3899** (@Tamaz-sujashvili) — fixes #3900. Two session-switch bugs, both already reviewed sound by the maintainer (the review only asked to re-anchor 2 brittle tests, now done + extended).

### What changed (`static/sessions.js`)
- **Idle session no longer shows streaming chrome after a switch:** `loadSession` clears `S.busy` / `S.activeStreamId` as soon as metadata confirms no `active_stream_id`, *before* the async `_ensureMessagesLoaded` gap, so the previous session's busy flag can't make an idle chat show Stop/spinner/thinking. Also drops any stale INFLIGHT left by a crashed stream.
- **Activity timer/trace survives switching back to a live stream:** snapshots the live-turn DOM before wiping `msgInner` (seeding INFLIGHT if absent) and restores it on the Phase 2a active-stream return path instead of rebuilding the worklog shell.

### Gate (deep — touches the core session-switch path)
- **Codex: SAFE TO SHIP** — idle-reset only fires when server reports no stream; restore composes cleanly with the #4024/#4063/#3920/#4006 restore+scroll machinery (distinct INFLIGHT keys, journal-replay precedence); no stranded recovery tail.
- **Opus: SAFE-TO-SHIP** — both fixes minimally scoped; early idle-cleanup can't strand a concurrent stream's tail; re-anchored tests pin the real invariants.
- **Full suite: 8795 passed**, ESLint clean.

### Test re-anchoring (no production change)
#3899's new idle-reset block added an earlier `if(INFLIGHT[sid]){` and shifted source positions, so **21 brittle source-window/anchor tests** across `test_regressions`, `test_stale_stream_cleanup`, `test_issue3306_loadsession_carry_forward`, `test_issue_new_chat_draft_restore`, `test_inflight_stream_reuse`, and the PR's own `test_session_switch_busy_race` were re-anchored (rfind for the Phase-2 INFLIGHT branch, widened fixed windows, individual-call assertions, updated comment markers). All verified as anchor collisions, not behavior regressions.

Thanks @Tamaz-sujashvili.