### PR TITLE
fix(approval): restore pending fallback reliability (#4107)

### DIFF
--- a/api/route_approvals.py
+++ b/api/route_approvals.py
@@ -111,7 +111,7 @@ def _gateway_mirror_entry_token(entry) -> str:
     if not token:
         token = uuid.uuid4().hex
         try:
-            setattr(entry, "_webui_gateway_mirror_token", token)
+            entry._webui_gateway_mirror_token = token
         except Exception:
             token = f"{id(entry)}:{uuid.uuid4().hex}"
     return str(token)

--- a/api/route_approvals.py
+++ b/api/route_approvals.py
@@ -106,15 +106,20 @@ def _approval_sse_notify(session_id: str, head: dict | None, total: int) -> None
 
 
 def _gateway_mirror_entry_token(entry) -> str:
-    """Return a stable token for the current process lifetime of a gateway head."""
-    token = getattr(entry, "_webui_gateway_mirror_token", None)
-    if not token:
-        token = uuid.uuid4().hex
-        try:
-            entry._webui_gateway_mirror_token = token
-        except Exception:
-            token = f"{id(entry)}:{uuid.uuid4().hex}"
-    return str(token)
+    """Return a stable token for the current process lifetime of a gateway head.
+
+    Stamps a `_webui_mirror_token` key into the entry's `.data` dict so
+    slotted objects like `_ApprovalEntry` work without attribute mutation
+    and the token survives CPython `id()` reuse after GC.
+    """
+    data = getattr(entry, "data", None)
+    if isinstance(data, dict):
+        token = data.get("_webui_mirror_token")
+        if not token:
+            token = uuid.uuid4().hex
+            data["_webui_mirror_token"] = token
+        return token
+    return uuid.uuid4().hex
 
 
 def _is_gateway_mirror_entry(entry: dict | None) -> bool:
@@ -138,6 +143,7 @@ def reconcile_gateway_pending_mirror_locked(session_key: str) -> tuple[dict | No
     changed = False
     queue_list = list(_normalize_pending_queue_locked(session_key))
     live_gateway_queue = _gateway_queues.get(session_key) or []
+
     live_head_entry = live_gateway_queue[0] if live_gateway_queue else None
     live_head_data = getattr(live_head_entry, "data", None) or {}
     live_token = _gateway_mirror_entry_token(live_head_entry) if live_head_entry and live_head_data else None

--- a/api/route_approvals.py
+++ b/api/route_approvals.py
@@ -44,6 +44,8 @@ except ImportError:
 
 # ── Approval SSE subscribers (long-connection push) ──────────────────────────
 _approval_sse_subscribers: dict[str, list[queue.Queue]] = {}
+_GATEWAY_MIRROR_FLAG = "_gateway_mirror"
+_GATEWAY_MIRROR_TOKEN = "_gateway_mirror_token"
 
 
 def _approval_sse_subscribe(session_id: str) -> queue.Queue:
@@ -103,6 +105,87 @@ def _approval_sse_notify(session_id: str, head: dict | None, total: int) -> None
         _approval_sse_notify_locked(session_id, head, total)
 
 
+def _gateway_mirror_entry_token(entry) -> str:
+    """Return a stable token for the current process lifetime of a gateway head."""
+    token = getattr(entry, "_webui_gateway_mirror_token", None)
+    if not token:
+        token = uuid.uuid4().hex
+        try:
+            setattr(entry, "_webui_gateway_mirror_token", token)
+        except Exception:
+            token = f"{id(entry)}:{uuid.uuid4().hex}"
+    return str(token)
+
+
+def _is_gateway_mirror_entry(entry: dict | None) -> bool:
+    return isinstance(entry, dict) and bool(entry.get(_GATEWAY_MIRROR_FLAG))
+
+
+def _normalize_pending_queue_locked(session_key: str) -> list[dict]:
+    """Return the session's polling queue as a mutable list under `_lock`."""
+    queue_list = _pending.setdefault(session_key, [])
+    if not isinstance(queue_list, list):
+        _pending[session_key] = [queue_list]
+        queue_list = _pending[session_key]
+    return queue_list
+
+
+def reconcile_gateway_pending_mirror_locked(session_key: str) -> tuple[dict | None, int, bool]:
+    """Purge stale gateway mirrors and ensure at most one live head mirror exists.
+
+    CALLER MUST HOLD `_lock`.
+    """
+    changed = False
+    queue_list = list(_normalize_pending_queue_locked(session_key))
+    live_gateway_queue = _gateway_queues.get(session_key) or []
+    live_head_entry = live_gateway_queue[0] if live_gateway_queue else None
+    live_head_data = getattr(live_head_entry, "data", None) or {}
+    live_token = _gateway_mirror_entry_token(live_head_entry) if live_head_entry and live_head_data else None
+
+    rebuilt: list[dict] = []
+    live_mirror_present = False
+    for entry in queue_list:
+        if not _is_gateway_mirror_entry(entry):
+            rebuilt.append(entry)
+            continue
+        if live_token and entry.get(_GATEWAY_MIRROR_TOKEN) == live_token and not live_mirror_present:
+            rebuilt.append(entry)
+            live_mirror_present = True
+            continue
+        changed = True
+
+    if live_token and not live_mirror_present:
+        mirror_entry = dict(live_head_data)
+        mirror_entry.setdefault("approval_id", uuid.uuid4().hex)
+        mirror_entry[_GATEWAY_MIRROR_FLAG] = True
+        mirror_entry[_GATEWAY_MIRROR_TOKEN] = live_token
+        rebuilt.append(mirror_entry)
+        live_mirror_present = True
+        changed = True
+
+    if rebuilt:
+        if rebuilt != queue_list:
+            _pending[session_key] = rebuilt
+            changed = True
+    else:
+        if session_key in _pending:
+            _pending.pop(session_key, None)
+            changed = True
+
+    head = rebuilt[0] if rebuilt else None
+    total = len(rebuilt)
+    return head, total, changed
+
+
+def submit_gateway_pending_mirror(session_key: str, approval: dict) -> None:
+    """Mirror the live gateway head into WebUI polling state under a typed tag."""
+    del approval  # mirror from the live gateway head under `_lock`, not from callback input
+    with _lock:
+        head, total, _changed = reconcile_gateway_pending_mirror_locked(session_key)
+        _approval_sse_notify_locked(session_key, head, total)
+    publish_session_list_changed("attention_pending")
+
+
 def submit_pending(session_key: str, approval: dict) -> None:
     """Append a pending approval to the per-session queue.
 
@@ -116,11 +199,7 @@ def submit_pending(session_key: str, approval: dict) -> None:
     entry = dict(approval)
     entry.setdefault("approval_id", uuid.uuid4().hex)
     with _lock:
-        queue_list = _pending.setdefault(session_key, [])
-        # Replace a legacy non-list value if the agent version uses the old pattern.
-        if not isinstance(queue_list, list):
-            _pending[session_key] = [queue_list]
-            queue_list = _pending[session_key]
+        queue_list = _normalize_pending_queue_locked(session_key)
         queue_list.append(entry)
         total = len(queue_list)
         head = queue_list[0]  # /api/approval/pending always returns head

--- a/api/route_approvals.py
+++ b/api/route_approvals.py
@@ -46,6 +46,7 @@ except ImportError:
 _approval_sse_subscribers: dict[str, list[queue.Queue]] = {}
 _GATEWAY_MIRROR_FLAG = "_gateway_mirror"
 _GATEWAY_MIRROR_TOKEN = "_gateway_mirror_token"
+_GATEWAY_ENTRY_DATA_TOKEN_KEY = "_webui_mirror_token"
 
 
 def _approval_sse_subscribe(session_id: str) -> queue.Queue:
@@ -108,16 +109,16 @@ def _approval_sse_notify(session_id: str, head: dict | None, total: int) -> None
 def _gateway_mirror_entry_token(entry) -> str:
     """Return a stable token for the current process lifetime of a gateway head.
 
-    Stamps a `_webui_mirror_token` key into the entry's `.data` dict so
+    Stamps a token key into the entry's `.data` dict so
     slotted objects like `_ApprovalEntry` work without attribute mutation
     and the token survives CPython `id()` reuse after GC.
     """
     data = getattr(entry, "data", None)
     if isinstance(data, dict):
-        token = data.get("_webui_mirror_token")
+        token = data.get(_GATEWAY_ENTRY_DATA_TOKEN_KEY)
         if not token:
             token = uuid.uuid4().hex
-            data["_webui_mirror_token"] = token
+            data[_GATEWAY_ENTRY_DATA_TOKEN_KEY] = token
         return token
     return uuid.uuid4().hex
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -14455,17 +14455,13 @@ def _resolve_approval_legacy(sid: str, approval_id: str, choice: str) -> bool:
             if not approval_id or queue.get("approval_id") == approval_id:
                 pending = _pending.pop(sid, None)
                 found_target = pending is not None
-        # When no _pending entry found, peek into _gateway_queues for
-        # pattern_keys so session-level approval still works. The gateway
-        # path is the primary mechanism during active streaming; _pending
-        # is only used for UI polling/SSE notification.
-        # NOTE: Gateway queue entries don't carry approval_id, so when
-        # approval_id is given and _pending is empty, we assume the gateway
-        # entry at the head of the queue corresponds. This is safe because
-        # tagged gateway mirrors were reconciled against the live queue head
-        # under this same lock above, so a stale WebUI-only mirror cannot be
-        # popped ahead of whichever gateway entry is actually live now.
-        if not pending:
+        # When no _pending entry found AND no explicit approval_id was
+        # given, peek into _gateway_queues for pattern_keys so legacy
+        # no-id clients still work. When approval_id IS given but not
+        # found, the caller sent a stale/duplicate id — do NOT fall
+        # through to the gateway queue, or a stale click on approval A
+        # would resolve the unrelated live approval B.
+        if not pending and not approval_id:
             gw_queue = _gateway_queues.get(sid)
             if gw_queue and len(gw_queue) > 0:
                 gw_entry = gw_queue[0]

--- a/api/routes.py
+++ b/api/routes.py
@@ -11115,6 +11115,8 @@ def _handle_approval_pending(handler, parsed):
                 if raw:
                     p = raw
                     total = len(gw_queue)
+                else:
+                    logger.warning("Gateway queue entry for %s has no .data attribute", sid)
     if p:
         return j(handler, {"pending": dict(p), "pending_count": total})
     return j(handler, {"pending": None, "pending_count": 0})

--- a/api/routes.py
+++ b/api/routes.py
@@ -11108,6 +11108,13 @@ def _handle_approval_pending(handler, parsed):
         else:
             p = None
             total = 0
+        if p is None:
+            gw_queue = _gateway_queues.get(sid) or []
+            if gw_queue:
+                raw = getattr(gw_queue[0], "data", None) or {}
+                if raw:
+                    p = raw
+                    total = len(gw_queue)
     if p:
         return j(handler, {"pending": dict(p), "pending_count": total})
     return j(handler, {"pending": None, "pending_count": 0})

--- a/api/routes.py
+++ b/api/routes.py
@@ -3973,6 +3973,8 @@ from api.route_approvals import (  # noqa: F401 — re-exports for backward comp
     _approval_sse_unsubscribe,
     _approval_sse_notify_locked,
     _approval_sse_notify,
+    reconcile_gateway_pending_mirror_locked,
+    submit_gateway_pending_mirror,
     submit_pending,
 )
 
@@ -11097,6 +11099,7 @@ def _handle_file_read(handler, parsed):
 def _handle_approval_pending(handler, parsed):
     sid = parse_qs(parsed.query).get("session_id", [""])[0]
     with _lock:
+        _head, _total, _changed = reconcile_gateway_pending_mirror_locked(sid)
         queue = _pending.get(sid)
         # Support both the new list format and a legacy single-dict value.
         if isinstance(queue, list):
@@ -11144,6 +11147,7 @@ def _handle_approval_sse_stream(handler, parsed):
     initial_count = 0
     with _lock:
         _approval_sse_subscribers.setdefault(sid, []).append(q)
+        reconcile_gateway_pending_mirror_locked(sid)
         q_list = _pending.get(sid)
         if isinstance(q_list, list):
             initial_pending = dict(q_list[0]) if q_list else None
@@ -14426,6 +14430,7 @@ def _resolve_approval_legacy(sid: str, approval_id: str, choice: str) -> bool:
     found_target = False
     gateway_keys = []
     with _lock:
+        reconcile_gateway_pending_mirror_locked(sid)
         queue = _pending.get(sid)
         if isinstance(queue, list):
             if approval_id:
@@ -14457,9 +14462,9 @@ def _resolve_approval_legacy(sid: str, approval_id: str, choice: str) -> bool:
         # NOTE: Gateway queue entries don't carry approval_id, so when
         # approval_id is given and _pending is empty, we assume the gateway
         # entry at the head of the queue corresponds. This is safe because
-        # gateway entries are consumed synchronously with _pending entries
-        # under the same lock — there is no interleaving where a stale
-        # approval_id could match a different gateway entry.
+        # tagged gateway mirrors were reconciled against the live queue head
+        # under this same lock above, so a stale WebUI-only mirror cannot be
+        # popped ahead of whichever gateway entry is actually live now.
         if not pending:
             gw_queue = _gateway_queues.get(sid)
             if gw_queue and len(gw_queue) > 0:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5555,11 +5555,20 @@ def _run_agent_streaming(
         _approval_registered = False
         _unreg_notify = None
         try:
+            try:
+                from api.route_approvals import submit_pending as _submit_pending_for_polling
+            except ImportError:
+                _submit_pending_for_polling = None
             from tools.approval import (
                 register_gateway_notify as _reg_notify,
                 unregister_gateway_notify as _unreg_notify,
             )
             def _approval_notify_cb(approval_data):
+                if _submit_pending_for_polling is not None:
+                    try:
+                        _submit_pending_for_polling(session_id, approval_data)
+                    except Exception:
+                        logger.warning("Failed to mirror approval into WebUI polling state", exc_info=True)
                 put('approval', approval_data)
             _reg_notify(session_id, _approval_notify_cb)
             _approval_registered = True
@@ -5857,10 +5866,22 @@ def _run_agent_streaming(
                     # Fallback: poll for pending approval in case notify_cb wasn't
                     # registered (e.g. older approval module without gateway support).
                     try:
-                        from tools.approval import has_pending as _has_pending, _pending, _lock
-                        if _has_pending(session_id):
-                            with _lock:
-                                p = dict(_pending.get(session_id, {}))
+                        from api.route_approvals import _gateway_queues as _approval_gateway_queues, _lock as _approval_lock, _pending as _approval_pending
+                        from tools.approval import has_blocking_approval as _has_blocking_approval
+                        if _has_blocking_approval(session_id):
+                            p = None
+                            with _approval_lock:
+                                queue = _approval_pending.get(session_id)
+                                if isinstance(queue, list):
+                                    p = dict(queue[0]) if queue else None
+                                elif queue:
+                                    p = dict(queue)
+                                if p is None:
+                                    gw_queue = _approval_gateway_queues.get(session_id) or []
+                                    if gw_queue:
+                                        raw = getattr(gw_queue[0], 'data', None) or {}
+                                        if raw:
+                                            p = dict(raw)
                             if p:
                                 put('approval', p)
                     except ImportError:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5882,6 +5882,8 @@ def _run_agent_streaming(
                                         raw = getattr(gw_queue[0], 'data', None) or {}
                                         if raw:
                                             p = dict(raw)
+                                        else:
+                                            logger.warning("Gateway queue entry for %s has no .data attribute", session_id)
                             if p:
                                 put('approval', p)
                     except ImportError:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5554,11 +5554,22 @@ def _run_agent_streaming(
         # the chat stuck in "Thinking…" forever.
         _approval_registered = False
         _unreg_notify = None
+        _cleanup_gateway_pending_mirror = None
         try:
             try:
-                from api.route_approvals import submit_pending as _submit_pending_for_polling
+                from api.route_approvals import (
+                    submit_gateway_pending_mirror as _submit_pending_for_polling,
+                    reconcile_gateway_pending_mirror_locked as _reconcile_gateway_pending_mirror_locked,
+                    _approval_sse_notify_locked as _approval_sse_notify_locked,
+                    _lock as _approval_lock,
+                )
+                def _cleanup_gateway_pending_mirror():
+                    with _approval_lock:
+                        head, total, _changed = _reconcile_gateway_pending_mirror_locked(session_id)
+                        _approval_sse_notify_locked(session_id, head, total)
             except ImportError:
                 _submit_pending_for_polling = None
+                _cleanup_gateway_pending_mirror = None
             from tools.approval import (
                 register_gateway_notify as _reg_notify,
                 unregister_gateway_notify as _unreg_notify,
@@ -5866,11 +5877,17 @@ def _run_agent_streaming(
                     # Fallback: poll for pending approval in case notify_cb wasn't
                     # registered (e.g. older approval module without gateway support).
                     try:
-                        from api.route_approvals import _gateway_queues as _approval_gateway_queues, _lock as _approval_lock, _pending as _approval_pending
+                        from api.route_approvals import (
+                            _gateway_queues as _approval_gateway_queues,
+                            _lock as _approval_lock,
+                            _pending as _approval_pending,
+                            reconcile_gateway_pending_mirror_locked as _reconcile_gateway_pending_mirror_locked,
+                        )
                         from tools.approval import has_blocking_approval as _has_blocking_approval
                         if _has_blocking_approval(session_id):
                             p = None
                             with _approval_lock:
+                                _reconcile_gateway_pending_mirror_locked(session_id)
                                 queue = _approval_pending.get(session_id)
                                 if isinstance(queue, list):
                                     p = dict(queue[0]) if queue else None
@@ -7848,6 +7865,11 @@ def _run_agent_streaming(
                     _unreg_notify(session_id)
                 except Exception:
                     logger.debug("Failed to unregister approval callback")
+            if _cleanup_gateway_pending_mirror is not None:
+                try:
+                    _cleanup_gateway_pending_mirror()
+                except Exception:
+                    logger.debug("Failed to reconcile gateway approval mirror")
             if _clarify_registered and _unreg_clarify_notify is not None:
                 try:
                     _unreg_clarify_notify(session_id)

--- a/tests/test_approval_sse.py
+++ b/tests/test_approval_sse.py
@@ -428,7 +428,6 @@ class TestSSENotifyFromSubmitPending:
     def test_gateway_mirror_reconcile_tags_live_head_and_purges_stale_copy(self):
         """Gateway mirrors must track the live head and disappear when the queue does."""
         from api import routes as r
-        from tools.approval import _ApprovalEntry
 
         sid = f"sse-gateway-mirror-{uuid.uuid4().hex[:8]}"
         approval = {
@@ -437,11 +436,16 @@ class TestSSENotifyFromSubmitPending:
             "pattern_keys": ["recursive delete"],
             "description": "recursive delete",
         }
+
+        class _GatewayEntry:
+            def __init__(self, data):
+                self.data = data
+
         q = r._approval_sse_subscribe(sid)
         try:
             with r._lock:
                 r._pending.pop(sid, None)
-                r._gateway_queues[sid] = [_ApprovalEntry(approval)]
+                r._gateway_queues[sid] = [_GatewayEntry(approval)]
             r.submit_gateway_pending_mirror(sid, approval)
 
             mirrored = q.get(timeout=1)

--- a/tests/test_approval_sse.py
+++ b/tests/test_approval_sse.py
@@ -105,6 +105,19 @@ class TestSSEStaticAnalysis:
              "from inside the `with _lock:` block — not the unlocked _approval_sse_notify wrapper, "
              "and head must be queue_list[0] (the head, not the just-appended entry).")
 
+    def test_streaming_notify_callback_mirrors_pending_before_sse_push(self):
+        """Gateway notify callback must repopulate polling state before relying on SSE."""
+        stream_start = ROUTES_SRC.find("def _handle_sse_stream(")
+        assert stream_start != -1, "_handle_sse_stream must exist"
+        streaming_src = (REPO_ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
+        cb_start = streaming_src.find("def _approval_notify_cb(approval_data):")
+        cb_end = streaming_src.find("_reg_notify(session_id, _approval_notify_cb)", cb_start)
+        cb_body = streaming_src[cb_start:cb_end]
+        assert "_submit_pending_for_polling(session_id, approval_data)" in cb_body, \
+            "_approval_notify_cb must mirror approval data into polling state before SSE"
+        assert "put('approval', approval_data)" in cb_body, \
+            "_approval_notify_cb must still emit the approval SSE event"
+
     def test_unsubscribe_in_finally(self):
         """SSE handler must unsubscribe in a finally block."""
         # Find the finally block that calls _approval_sse_unsubscribe

--- a/tests/test_approval_sse.py
+++ b/tests/test_approval_sse.py
@@ -425,6 +425,48 @@ class TestSSENotifyFromSubmitPending:
         finally:
             r._approval_sse_unsubscribe(sid, q)
 
+    def test_gateway_mirror_reconcile_tags_live_head_and_purges_stale_copy(self):
+        """Gateway mirrors must track the live head and disappear when the queue does."""
+        from api import routes as r
+        from tools.approval import _ApprovalEntry
+
+        sid = f"sse-gateway-mirror-{uuid.uuid4().hex[:8]}"
+        approval = {
+            "command": "rm -rf /tmp/test",
+            "pattern_key": "recursive delete",
+            "pattern_keys": ["recursive delete"],
+            "description": "recursive delete",
+        }
+        q = r._approval_sse_subscribe(sid)
+        try:
+            with r._lock:
+                r._pending.pop(sid, None)
+                r._gateway_queues[sid] = [_ApprovalEntry(approval)]
+            r.submit_gateway_pending_mirror(sid, approval)
+
+            mirrored = q.get(timeout=1)
+            assert mirrored["pending"]["command"] == approval["command"]
+            assert mirrored["pending"]["_gateway_mirror"] is True
+            assert mirrored["pending_count"] == 1
+
+            with r._lock:
+                assert r._pending[sid][0]["_gateway_mirror"] is True
+                r._gateway_queues.pop(sid, None)
+                head, total, changed = r.reconcile_gateway_pending_mirror_locked(sid)
+                r._approval_sse_notify_locked(sid, head, total)
+            assert changed is True
+
+            cleared = q.get(timeout=1)
+            assert cleared["pending"] is None
+            assert cleared["pending_count"] == 0
+            with r._lock:
+                assert sid not in r._pending
+        finally:
+            with r._lock:
+                r._pending.pop(sid, None)
+                r._gateway_queues.pop(sid, None)
+            r._approval_sse_unsubscribe(sid, q)
+
 
 class TestSSEConcurrency:
     """Test thread safety of SSE subscribe/unsubscribe/notify."""

--- a/tests/test_approval_unblock.py
+++ b/tests/test_approval_unblock.py
@@ -11,6 +11,7 @@ import uuid
 import urllib.request
 import urllib.error
 import urllib.parse
+from pathlib import Path
 
 import pytest
 
@@ -42,6 +43,10 @@ pytestmark = pytest.mark.skipif(
 )
 
 from tests._pytest_port import BASE
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STREAMING_SRC = (REPO_ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
 
 
 def get(path):
@@ -215,6 +220,22 @@ class TestApprovalModuleExports:
         assert hasattr(ap, "_ApprovalEntry"), \
             "tools.approval must export _ApprovalEntry"
 
+    def test_streaming_fallback_uses_blocking_approval_contract(self):
+        assert "has_blocking_approval as _has_blocking_approval" in STREAMING_SRC, \
+            "streaming fallback must use has_blocking_approval from tools.approval"
+        assert "has_pending as _has_pending" not in STREAMING_SRC, \
+            "streaming fallback must not import removed has_pending"
+
+    def test_notify_callback_mirrors_polling_state_before_sse(self):
+        cb_start = STREAMING_SRC.find("def _approval_notify_cb(approval_data):")
+        assert cb_start != -1, "_approval_notify_cb must exist"
+        cb_end = STREAMING_SRC.find("_reg_notify(session_id, _approval_notify_cb)", cb_start)
+        cb_body = STREAMING_SRC[cb_start:cb_end]
+        assert "_submit_pending_for_polling(session_id, approval_data)" in cb_body, \
+            "approval notify callback must mirror approval data into polling state"
+        assert "put('approval', approval_data)" in cb_body, \
+            "approval notify callback must still push the SSE event"
+
 
 # ── HTTP regression tests (test server, port 8788) ───────────────────────────
 
@@ -286,3 +307,37 @@ class TestApprovalHTTPEndpoints:
 
         data = get(f"/api/approval/pending?session_id={urllib.parse.quote(sid)}")
         assert data["pending"] is None
+
+    def test_pending_route_falls_back_to_gateway_queue(self, monkeypatch):
+        """GET /api/approval/pending must surface gateway-only approvals when _pending is empty."""
+        from api import routes as r
+
+        sid = f"http-gateway-fallback-{uuid.uuid4().hex[:8]}"
+        payload = {
+            "command": "rm -rf /tmp/gateway-only",
+            "pattern_key": "recursive delete",
+            "pattern_keys": ["recursive delete"],
+            "description": "recursive delete",
+        }
+        captured = {}
+
+        def fake_j(handler, data, status=200, extra_headers=None):
+            captured["payload"] = data
+            captured["status"] = status
+            return data
+
+        monkeypatch.setattr(r, "j", fake_j)
+        with _lock:
+            r._pending.pop(sid, None)
+            r._gateway_queues[sid] = [_ApprovalEntry(payload)]
+
+        try:
+            parsed = urllib.parse.urlparse(f"/api/approval/pending?session_id={urllib.parse.quote(sid)}")
+            r._handle_approval_pending(object(), parsed)
+            assert captured["status"] == 200
+            assert captured["payload"]["pending"]["command"] == payload["command"]
+            assert captured["payload"]["pending_count"] == 1
+        finally:
+            with _lock:
+                r._pending.pop(sid, None)
+                r._gateway_queues.pop(sid, None)

--- a/tests/test_approval_unblock.py
+++ b/tests/test_approval_unblock.py
@@ -341,3 +341,61 @@ class TestApprovalHTTPEndpoints:
             with _lock:
                 r._pending.pop(sid, None)
                 r._gateway_queues.pop(sid, None)
+
+    def test_stale_gateway_mirror_does_not_mask_next_live_approval(self, monkeypatch):
+        """A stale mirrored gateway approval must not outlive its live queue head."""
+        from api import routes as r
+        from api import route_approvals as ra
+
+        sid = f"http-gateway-stale-{uuid.uuid4().hex[:8]}"
+        approval_a = {
+            "command": "rm -rf /tmp/stale-a",
+            "pattern_key": "recursive delete",
+            "pattern_keys": ["recursive delete"],
+            "description": "recursive delete",
+        }
+        approval_b = {
+            "command": "rm -rf /tmp/live-b",
+            "pattern_key": "recursive delete",
+            "pattern_keys": ["recursive delete"],
+            "description": "recursive delete",
+        }
+        captured = {}
+
+        def fake_j(handler, data, status=200, extra_headers=None):
+            captured["payload"] = data
+            captured["status"] = status
+            return data
+
+        monkeypatch.setattr(r, "j", fake_j)
+        with _lock:
+            r._pending.pop(sid, None)
+            r._gateway_queues.pop(sid, None)
+            r._gateway_queues[sid] = [_ApprovalEntry(approval_a)]
+        try:
+            ra.submit_gateway_pending_mirror(sid, approval_a)
+            with _lock:
+                r._gateway_queues.pop(sid, None)
+                r._gateway_queues[sid] = [_ApprovalEntry(approval_b)]
+            ra.submit_gateway_pending_mirror(sid, approval_b)
+
+            parsed = urllib.parse.urlparse(f"/api/approval/pending?session_id={urllib.parse.quote(sid)}")
+            r._handle_approval_pending(object(), parsed)
+            assert captured["status"] == 200
+            assert captured["payload"]["pending"]["command"] == approval_b["command"]
+            assert captured["payload"]["pending_count"] == 1
+
+            with _lock:
+                queue = r._pending.get(sid)
+                assert isinstance(queue, list)
+                assert len(queue) == 1
+                assert queue[0]["command"] == approval_b["command"]
+
+            assert r._resolve_approval_legacy(sid, "", "once") is True
+            with _lock:
+                assert sid not in r._pending
+                assert sid not in r._gateway_queues
+        finally:
+            with _lock:
+                r._pending.pop(sid, None)
+                r._gateway_queues.pop(sid, None)

--- a/tests/test_approval_unblock.py
+++ b/tests/test_approval_unblock.py
@@ -399,3 +399,83 @@ class TestApprovalHTTPEndpoints:
             with _lock:
                 r._pending.pop(sid, None)
                 r._gateway_queues.pop(sid, None)
+
+    def test_gateway_mirror_token_stable_across_reconciles(self, monkeypatch):
+        """Two reconciles of the same _ApprovalEntry must keep the same approval_id."""
+        from api import routes as r
+        from api import route_approvals as ra
+
+        sid = f"http-token-stable-{uuid.uuid4().hex[:8]}"
+        approval = {
+            "command": "rm -rf /tmp/token-test",
+            "pattern_key": "recursive delete",
+            "pattern_keys": ["recursive delete"],
+            "description": "recursive delete",
+        }
+
+        entry = _ApprovalEntry(approval)
+        with _lock:
+            r._pending.pop(sid, None)
+            r._gateway_queues[sid] = [entry]
+        try:
+            with _lock:
+                head1, total1, _ = ra.reconcile_gateway_pending_mirror_locked(sid)
+            aid1 = head1["approval_id"]
+            token1 = head1[ra._GATEWAY_MIRROR_TOKEN]
+
+            with _lock:
+                head2, total2, _ = ra.reconcile_gateway_pending_mirror_locked(sid)
+            aid2 = head2["approval_id"]
+            token2 = head2[ra._GATEWAY_MIRROR_TOKEN]
+
+            assert token1 == token2, "token must be stable across reconciles"
+            assert aid1 == aid2, "approval_id must be stable across reconciles"
+        finally:
+            with _lock:
+                r._pending.pop(sid, None)
+                r._gateway_queues.pop(sid, None)
+                pass  # no external token state to clean
+
+    def test_stale_explicit_approval_id_does_not_resolve_live_gateway_head(self, monkeypatch):
+        """A stale explicit approval_id must not resolve the next live gateway head."""
+        from api import routes as r
+        from api import route_approvals as ra
+
+        sid = f"http-stale-id-{uuid.uuid4().hex[:8]}"
+        approval_a = {
+            "command": "rm -rf /tmp/stale-a",
+            "pattern_key": "recursive delete",
+            "pattern_keys": ["recursive delete"],
+            "description": "recursive delete",
+        }
+        approval_b = {
+            "command": "rm -rf /tmp/live-b",
+            "pattern_key": "recursive delete",
+            "pattern_keys": ["recursive delete"],
+            "description": "recursive delete",
+        }
+
+        entry_a = _ApprovalEntry(approval_a)
+        with _lock:
+            r._pending.pop(sid, None)
+            r._gateway_queues[sid] = [entry_a]
+        try:
+            ra.submit_gateway_pending_mirror(sid, approval_a)
+            with _lock:
+                mirror_aid_a = r._pending[sid][0]["approval_id"]
+
+            with _lock:
+                r._gateway_queues.pop(sid, None)
+            entry_b = _ApprovalEntry(approval_b)
+            with _lock:
+                r._gateway_queues[sid] = [entry_b]
+            ra.submit_gateway_pending_mirror(sid, approval_b)
+
+            resolved = r._resolve_approval_legacy(sid, mirror_aid_a, "once")
+            assert resolved is False, "stale approval_id must not resolve live B"
+            assert not entry_b.event.is_set(), "live B must not be unblocked by stale A"
+        finally:
+            with _lock:
+                r._pending.pop(sid, None)
+                r._gateway_queues.pop(sid, None)
+                pass  # no external token state to clean

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -134,17 +134,16 @@ def test_session_with_tool_calls_in_json_loads_ok(cleanup_test_sessions):
     cleanup_test_sessions.clear()
 
 
-# ── R4: has_pending not imported in streaming.py (Sprint 10 split regression) ─
+# ── R4: approval check not imported in streaming.py (Sprint 10 split regression) ─
 
 def test_streaming_py_imports_has_pending(cleanup_test_sessions):
-    """R4: api/streaming.py must import or define has_pending.
+    """R4: api/streaming.py must import an approval-check function.
     When missing, the approval check mid-stream caused NameError.
     """
     src = (REPO_ROOT / "api/streaming.py").read_text()
-    assert "has_pending" in src, "has_pending not found in api/streaming.py"
-    # Verify it's imported (not just used)
-    assert "import" in src and "has_pending" in src, \
-        "has_pending must be imported in api/streaming.py"
+    assert "has_blocking_approval" in src, "has_blocking_approval not found in api/streaming.py"
+    assert "import" in src and "has_blocking_approval" in src, \
+        "has_blocking_approval must be imported in api/streaming.py"
 
 
 def test_aiagent_imported_in_streaming(cleanup_test_sessions):


### PR DESCRIPTION
title: fix(approval): restore pending fallback reliability (#4107)

## Thinking Path

- The first rework reconnected approval delivery, but it also introduced a new lifecycle obligation: once gateway approvals are mirrored into the WebUI polling queue, that mirror has to be cleaned up whenever the gateway head disappears.
- The maintainer's follow-up review isolates the remaining failure mode, a stale mirrored `_pending` head surviving after unregister, timeout, or another gateway turnover, which can make the next live approval resolve against the wrong polling entry.
- The second review found two further defects in the reconcile mechanism itself: the mirror token couldn't persist on slotted `_ApprovalEntry` objects (churning `approval_id` on every poll), and a stale explicit `approval_id` could fall through to resolve an unrelated live gateway head.

## What Changed

- `api/route_approvals.py`: tag gateway-backed `_pending` mirrors, add a reconcile helper that compares them with the live `_gateway_queues` head under the shared lock, and expose a typed mirror helper for the streaming callback. Mirror tokens are now stamped into the entry's mutable `.data` dict instead of relying on attribute mutation or `id()`-keyed external state, so they survive CPython `id()` reuse after GC and work with slotted objects.
- `api/streaming.py`: route gateway approval mirroring through the typed helper, reconcile mirrored polling state before degraded fallback emits, and purge stale mirrors after gateway unregister cleanup.
- `api/routes.py`: reconcile gateway-backed mirrors before `/api/approval/pending`, approval SSE initial snapshots, and `_resolve_approval_legacy()`, so stale mirrors cannot be returned or popped ahead of the live gateway head. When an explicit `approval_id` is provided but not found after reconcile, the resolve path now returns false instead of falling through to `_gateway_queues`, preventing a stale click on approval A from resolving the unrelated live approval B.
- `tests/test_approval_unblock.py`, `tests/test_approval_sse.py`: add the stale-A/live-B regression, mirror-tagging coverage, purge coverage for the gateway lifecycle paths, token stability across reconciles, and stale explicit `approval_id` guard.

## Why It Matters

When a gateway approval is cancelled, times out, or is replaced by a new live approval, the WebUI should never keep serving the old approval card or resolve the wrong command. This keeps the approval fallback reliable even after the first delivery fix.

## Verification

```text
pytest tests/test_approval_unblock.py tests/test_approval_sse.py tests/test_regressions.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- This keeps the current approval transport model; it does not redesign how approval payloads are shared between the WebUI wrapper and the agent runtime.
- The mirror-reconcile path now depends on the gateway queue head remaining the source of truth; if the bundled agent approval contract changes shape again, the mirror token and head-reconcile helpers must stay aligned.

## Model Used

GPT 5 via Codex CLI