### PR TITLE
Fix final answer scroll during session refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Long final answers no longer snap back to the bottom while you are reading them after a same-session refresh (#4123).** Same-session background refreshes now preserve a reader's current transcript position whenever the viewport is clearly away from the bottom, and they no longer clear the sticky scroll-unpin state before rebuilding the transcript. PWA/mobile remains the easiest reproduction surface, but the fix applies to the shared browser transcript refresh path. (#4123)
+
 ## [v0.51.389] — 2026-06-13 — Release NB (surface dirty-install state in update check, #4085)
 
 ### Fixed

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1038,10 +1038,13 @@ async function loadSession(sid){
   if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
   S.session._modelResolutionDeferred=true;
   S.lastUsage={...(data.session.last_usage||{})};
-  // Reset scroll-direction tracker on session switch so the new chat's
-  // first scroll doesn't compare against the previous chat's scrollTop
+  // Reset scroll-direction tracker only on real session switches so the new
+  // chat's first scroll doesn't compare against the previous chat's scrollTop
   // and false-trigger an unpin (#1731 follow-up — Opus stage-302 SHOULD-FIX).
-  if (typeof window !== 'undefined' && typeof window._resetScrollDirectionTracker === 'function') {
+  // Same-session force refreshes reuse the current transcript viewport; clearing
+  // the sticky-unpin state here makes preserveScroll treat a reader mid-answer
+  // as pinned and snap them back to the bottom on the next render.
+  if (currentSid !== sid && typeof window !== 'undefined' && typeof window._resetScrollDirectionTracker === 'function') {
     try { window._resetScrollDirectionTracker(); } catch (_) {}
   }
   if(typeof _applyPendingSessionModelForSession==='function') _applyPendingSessionModelForSession(sid);

--- a/static/ui.js
+++ b/static/ui.js
@@ -8718,6 +8718,16 @@ function _restoreMessageScrollSnapshot(snapshot){
   el.scrollTop=Math.max(0,Math.min(Number(snapshot.top)||0,maxTop));
   // Sync _lastScrollTop after programmatic restore so sticky-unpin does not false-trigger (#1731).
   _lastScrollTop=el.scrollTop;
+  const bottomDistance=el.scrollHeight-el.scrollTop-el.clientHeight;
+  if(bottomDistance>250){
+    _messageUserUnpinned=true;
+    _scrollPinned=false;
+    _nearBottomCount=0;
+  }else if(bottomDistance<=120){
+    _messageUserUnpinned=false;
+    _scrollPinned=true;
+    _nearBottomCount=2;
+  }
   requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
 }
 function _restoreMessageScrollSnapshotSameFrame(snapshot){
@@ -8773,6 +8783,11 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
   // pinned users stay at bottom; users who manually scrolled up get their
   // pre-render scrollTop restored after the DOM replacement.
   if(preserveScroll){
+    const readerAwayFromBottom=!!(
+      scrollSnapshot &&
+      Number.isFinite(Number(scrollSnapshot.bottom)) &&
+      Number(scrollSnapshot.bottom)>250
+    );
     // Keep master's follow heuristic for pinned / still-near-bottom users:
     // _followMessagesAfterDomReplace() does a FORCED scrollToBottom() (synchronous
     // bottom write + forced settle), so the final settled response can't leave a
@@ -8781,7 +8796,7 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
     // new-message cue. (Using scrollIfPinned() here instead would skip the forced
     // write unless distance>500 and let the DOM-rebuild scroll event cancel the
     // delayed settles — Codex CORE catch on #3631.)
-    if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;
+    if(!readerAwayFromBottom && !_messageUserUnpinned && _followMessagesAfterDomReplace()) return;
     _restoreMessageScrollSnapshot(scrollSnapshot);
     _maybeShowNewMessageScrollCue(scrollSnapshot);
     return;

--- a/tests/test_issue3479_ios_stream_scroll_jump.py
+++ b/tests/test_issue3479_ios_stream_scroll_jump.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
 
 
@@ -76,6 +77,36 @@ def test_same_frame_snapshot_preserves_bottom_distance_and_unpinned_state():
     assert "_scrollPinned=false" in restore
     assert "renderMessages({...(options||{}),preserveScroll:true});" in wrapper
     assert "_restoreMessageScrollSnapshotSameFrame(scrollSnapshot);" in wrapper
+
+
+def test_preserve_scroll_restores_reader_away_from_bottom_before_following():
+    body = _function_body(UI_JS, "_scrollAfterMessageRender")
+    compact = _compact(body)
+
+    reader_idx = compact.index("constreaderAwayFromBottom=")
+    follow_idx = compact.index("if(!readerAwayFromBottom&&!_messageUserUnpinned&&_followMessagesAfterDomReplace())return;")
+    restore_idx = compact.index("_restoreMessageScrollSnapshot(scrollSnapshot);")
+
+    assert "Number(scrollSnapshot.bottom)>250" in compact
+    assert reader_idx < follow_idx < restore_idx
+
+
+def test_scroll_snapshot_restore_reinstates_unpinned_state_when_reader_is_mid_answer():
+    restore = _function_body(UI_JS, "_restoreMessageScrollSnapshot")
+    compact = _compact(restore)
+
+    assert "constbottomDistance=el.scrollHeight-el.scrollTop-el.clientHeight;" in compact
+    assert "if(bottomDistance>250)" in compact
+    assert "_messageUserUnpinned=true" in compact
+    assert "_scrollPinned=false" in compact
+
+
+def test_same_session_force_refresh_does_not_reset_scroll_direction_tracker():
+    body = _function_body(SESSIONS_JS, "loadSession")
+    compact = _compact(body)
+
+    assert "constcurrentSid=S.session?S.session.session_id:null;" in compact
+    assert "if(currentSid!==sid&&typeofwindow!=='undefined'&&typeofwindow._resetScrollDirectionTracker==='function')" in compact
 
 
 def test_clarify_card_is_height_clamped_and_scrollable_on_mobile_viewports():


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI long-running sessions often produce very long settled Final Answers.
- Reading position is part of the transcript presentation state; session refreshes should not override it.
- The active-session refresh path force-reloads the same session and rebuilds the transcript with `preserveScroll`.
- `preserveScroll` still allowed follow-to-bottom when sticky-unpin state had been cleared, and same-session force reload did clear that state.
- PWA/mobile makes this easier to reproduce because touch scrolling and app resume/reconnect events exercise the refresh path more often, but the root cause is browser-wide transcript refresh scroll state.
- This PR makes the actual scroll snapshot authoritative when the reader is clearly away from the bottom, while preserving the existing pinned/near-bottom behavior.

## What Changed

- Treat a preserved scroll snapshot with `bottom > 250px` as an active reader position and restore it before any follow-to-bottom path can run.
- Re-mark restored mid-answer positions as unpinned so later refreshes and streaming follow logic continue to respect the reader.
- Stop resetting the scroll-direction tracker during same-session force refreshes; keep that reset scoped to real session switches.
- Added regression coverage for the away-from-bottom preserve path and the same-session force-refresh guard.
- Updated `CHANGELOG.md` for #4123.

## Why It Matters

A user reading a long Final Answer should not be pulled back to the bottom by background metadata refreshes. PWA/mobile users are most likely to notice the bug, but the fix is intentionally scoped to the shared browser transcript refresh path. It keeps auto-follow behavior for users who are actually pinned to the tail, while preserving reader position once the viewport is clearly away from the bottom.

## Verification

- `node --check static/ui.js`
- `node --check static/sessions.js`
- `.venv/bin/python -m pytest tests/test_issue3479_ios_stream_scroll_jump.py tests/test_issue677.py tests/test_session_jump_buttons.py tests/test_issue734_message_windowing.py -q` (`26 passed`)
- Node/VM smoke: simulated a mid-answer `preserveScroll` render and verified no bottom-follow call, preserved `scrollTop`, and restored `_messageUserUnpinned=true`.

UI evidence: no visual layout or styling changed. This is a transcript scroll-state behavior fix; before/after evidence is covered by the regression tests and DOM smoke above.

## Contract Routing

Task type: UI behavior / transcript refresh state fix.
Touched areas: `static/ui.js`, `static/sessions.js`, scroll snapshot preservation, same-session force refresh.
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/UIUX-GUIDE.md`
- `DESIGN.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
- `docs/rfcs/live-to-final-assistant-replies.md`
Scope boundaries: no visual redesign, no streaming protocol change, no session metadata schema change, no PWA-specific forked behavior.
Evidence needed before claiming done: regression tests proving same-session refresh preserves reader position and does not clear sticky-unpin state.

State layer changed: browser live UI scene/cache and transcript presentation state. Durable transcript, model context, SSE/replay, and sidebar metadata are unchanged.

## Risks / Follow-ups

- The threshold uses the existing 250px scroll-pin distance. If reviewers want a different product threshold for “reader is away from bottom,” that can be tuned independently.
- I did not restart the user's 8787 runtime. Validation was static/DOM-level and pytest-based.

## Model Used

AI-assisted by OpenAI GPT-5 Codex in the local Codex CLI environment. Notable tool use: repo inspection, static regression tests, Node syntax checks, and a Node/VM DOM smoke simulation.

Refs #4123