### PR TITLE
feat(topbar): badge pending prompts in document title (#4121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Desktop wrappers can now detect approval/clarify attention from the document title without stealing chat-title ownership (#4121).** Active chat tabs prepend a `● ` marker only while the current session has a pending approval or clarification prompt, and the badge clears cleanly on prompt dismissal or session switch while `syncTopbar()` keeps owning the underlying `"<session> — <assistant>"` title format. (#4121)
+
 ## [v0.51.392] — 2026-06-13 — Release NE (align WebUI reasoning efforts to the agent's accepted set, drop "max")
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -4126,6 +4126,14 @@ function _approvalPromptBelongsToActiveSession(sid) {
   return !!(sid && _promptActiveSessionId() === sid);
 }
 
+function activeSessionHasPendingPromptAttention() {
+  const sid = _promptActiveSessionId();
+  return !!(sid && (
+    _approvalPendingBySession.has(sid) ||
+    _clarifyPendingBySession.has(sid)
+  ));
+}
+
 function _rememberApprovalPending(pending, pendingCount) {
   if (!pending) return null;
   const sid = pending._session_id || _promptActiveSessionId();
@@ -4137,6 +4145,7 @@ function _rememberApprovalPending(pending, pendingCount) {
 
 function _clearApprovalPendingForSession(sid) {
   if (sid) _approvalPendingBySession.delete(sid);
+  if (typeof syncTopbar === 'function') syncTopbar();
 }
 
 function _hideApprovalCardIfOwner(sid, force=false) {
@@ -4204,6 +4213,7 @@ function showApprovalCard(pending, pendingCount) {
   if (onceBtn && document.activeElement !== $('msg')) {
     setTimeout(() => onceBtn.focus({preventScroll: true}), 50);
   }
+  if (typeof syncTopbar === 'function') syncTopbar();
 }
 
 function _syncApprovalCollapseButton(card) {
@@ -4591,6 +4601,7 @@ function _rememberClarifyPending(pending) {
 
 function _clearClarifyPendingForSession(sid) {
   if (sid) _clarifyPendingBySession.delete(sid);
+  if (typeof syncTopbar === 'function') syncTopbar();
 }
 
 function _hideClarifyCardIfOwner(sid, force=false, reason="dismissed") {
@@ -4614,6 +4625,7 @@ function showClarifyForSession(sid, pending) {
 function _renderPendingPromptsForActiveSession() {
   _renderPendingApprovalForActiveSession();
   _renderPendingClarifyForActiveSession();
+  if (typeof syncTopbar === 'function') syncTopbar();
 }
 
 function _ensureClarifyCardDom() {
@@ -4966,6 +4978,7 @@ function showClarifyCard(pending) {
   if (input && !sameClarify && document.activeElement !== $('msg')) {
     input.focus({preventScroll: true});
   }
+  if (typeof syncTopbar === 'function') syncTopbar();
 }
 
 async function respondClarify(response) {

--- a/static/messages.js
+++ b/static/messages.js
@@ -4144,8 +4144,10 @@ function _rememberApprovalPending(pending, pendingCount) {
 }
 
 function _clearApprovalPendingForSession(sid) {
-  if (sid) _approvalPendingBySession.delete(sid);
-  if (typeof syncTopbar === 'function') syncTopbar();
+  if (sid) {
+    _approvalPendingBySession.delete(sid);
+    if (typeof syncTopbar === 'function') syncTopbar();
+  }
 }
 
 function _hideApprovalCardIfOwner(sid, force=false) {
@@ -4600,8 +4602,10 @@ function _rememberClarifyPending(pending) {
 }
 
 function _clearClarifyPendingForSession(sid) {
-  if (sid) _clarifyPendingBySession.delete(sid);
-  if (typeof syncTopbar === 'function') syncTopbar();
+  if (sid) {
+    _clarifyPendingBySession.delete(sid);
+    if (typeof syncTopbar === 'function') syncTopbar();
+  }
 }
 
 function _hideClarifyCardIfOwner(sid, force=false, reason="dismissed") {
@@ -4623,8 +4627,14 @@ function showClarifyForSession(sid, pending) {
 }
 
 function _renderPendingPromptsForActiveSession() {
+  const sid = _promptActiveSessionId();
   _renderPendingApprovalForActiveSession();
   _renderPendingClarifyForActiveSession();
+  if (
+    sid &&
+    typeof activeSessionHasPendingPromptAttention === 'function' &&
+    activeSessionHasPendingPromptAttention()
+  ) return;
   if (typeof syncTopbar === 'function') syncTopbar();
 }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -6274,8 +6274,10 @@ function syncTopbar(){
   }
   const sessionTitle=S.session.title||t('untitled');
   const _topbarTitle=$('topbarTitle');if(_topbarTitle)_topbarTitle.textContent=sessionTitle;
-  const pendingPrefix=(typeof activeSessionHasPendingPromptAttention==='function'&&activeSessionHasPendingPromptAttention())?'● ':'';
-  document.title=pendingPrefix+sessionTitle+' \u2014 '+assistantDisplayName();
+  document.title=sessionTitle+' \u2014 '+assistantDisplayName();
+  if(typeof activeSessionHasPendingPromptAttention==='function'&&activeSessionHasPendingPromptAttention()){
+    document.title='● '+document.title;
+  }
   const _topbarMeta=$('topbarMeta');
   if(_topbarMeta){
     let sourceLabel=(S.session&&(S.session.source_label||S.session.source_tag||S.session.raw_source))||'';

--- a/static/ui.js
+++ b/static/ui.js
@@ -6274,7 +6274,8 @@ function syncTopbar(){
   }
   const sessionTitle=S.session.title||t('untitled');
   const _topbarTitle=$('topbarTitle');if(_topbarTitle)_topbarTitle.textContent=sessionTitle;
-  document.title=sessionTitle+' \u2014 '+assistantDisplayName();
+  const pendingPrefix=(typeof activeSessionHasPendingPromptAttention==='function'&&activeSessionHasPendingPromptAttention())?'● ':'';
+  document.title=pendingPrefix+sessionTitle+' \u2014 '+assistantDisplayName();
   const _topbarMeta=$('topbarMeta');
   if(_topbarMeta){
     let sourceLabel=(S.session&&(S.session.source_label||S.session.source_tag||S.session.raw_source))||'';

--- a/tests/test_1694_prompt_ownership.py
+++ b/tests/test_1694_prompt_ownership.py
@@ -62,8 +62,10 @@ def test_approval_card_render_is_gated_to_active_session_and_cached():
     body = _function_body(MESSAGES_JS, "showApprovalCard")
     assert "_rememberApprovalPending(" in body
     assert "_approvalPromptBelongsToActiveSession(sid)" in body
+    assert "syncTopbar()" in body
     assert "return;" in body
     assert "let _approvalPendingBySession" in MESSAGES_JS
+    assert "function activeSessionHasPendingPromptAttention()" in MESSAGES_JS
     assert "function _renderPendingPromptsForActiveSession()" in MESSAGES_JS
 
 
@@ -71,6 +73,7 @@ def test_clarify_card_render_is_gated_to_active_session_and_cached():
     body = _function_body(MESSAGES_JS, "showClarifyCard")
     assert "_rememberClarifyPending(" in body
     assert "_clarifyPromptBelongsToActiveSession(sid)" in body
+    assert "syncTopbar()" in body
     assert "return;" in body
     assert "let _clarifyPendingBySession" in MESSAGES_JS
     assert "function _renderPendingPromptsForActiveSession()" in MESSAGES_JS
@@ -100,7 +103,13 @@ def test_load_session_rerenders_cached_prompt_for_new_active_session():
 def test_prompt_rerender_hides_previous_session_cards_without_clearing_cache():
     approval_body = _function_body(MESSAGES_JS, "_renderPendingApprovalForActiveSession")
     clarify_body = _function_body(MESSAGES_JS, "_renderPendingClarifyForActiveSession")
+    rerender_body = _function_body(MESSAGES_JS, "_renderPendingPromptsForActiveSession")
+    clear_approval_body = _function_body(MESSAGES_JS, "_clearApprovalPendingForSession")
+    clear_clarify_body = _function_body(MESSAGES_JS, "_clearClarifyPendingForSession")
     assert "_approvalSessionId && _approvalSessionId !== sid" in approval_body
     assert "hideApprovalCard(true)" in approval_body
     assert "_clarifySessionId && _clarifySessionId !== sid" in clarify_body
     assert "hideClarifyCard(true, 'session')" in clarify_body
+    assert "syncTopbar()" in rerender_body
+    assert "syncTopbar()" in clear_approval_body
+    assert "syncTopbar()" in clear_clarify_body

--- a/tests/test_1694_prompt_ownership.py
+++ b/tests/test_1694_prompt_ownership.py
@@ -111,5 +111,8 @@ def test_prompt_rerender_hides_previous_session_cards_without_clearing_cache():
     assert "_clarifySessionId && _clarifySessionId !== sid" in clarify_body
     assert "hideClarifyCard(true, 'session')" in clarify_body
     assert "syncTopbar()" in rerender_body
+    assert "activeSessionHasPendingPromptAttention()" in rerender_body
+    assert "if (sid) {" in clear_approval_body
     assert "syncTopbar()" in clear_approval_body
+    assert "if (sid) {" in clear_clarify_body
     assert "syncTopbar()" in clear_clarify_body

--- a/tests/test_topbar_lazy_message_count.py
+++ b/tests/test_topbar_lazy_message_count.py
@@ -24,9 +24,9 @@ def test_sync_topbar_does_not_count_only_loaded_tail_messages():
     assert "const metaText=_topbarMessageMetaText();" in block
     assert "t('n_messages',vis.length)" not in block
     assert "S.messages.filter(m=>m&&m.role&&m.role!=='tool')" not in block
-    assert "const pendingPrefix=(typeof activeSessionHasPendingPromptAttention==='function'&&activeSessionHasPendingPromptAttention())?'● ':'';" in block
-    assert "document.title=pendingPrefix+sessionTitle+' \\u2014 '+assistantDisplayName();" in block
-    assert "document.title=sessionTitle+' \\u2014 '+assistantDisplayName();" not in block
+    assert "document.title=sessionTitle+' \\u2014 '+assistantDisplayName();" in block
+    assert "document.title='● '+document.title;" in block
+    assert "const pendingPrefix=(typeof activeSessionHasPendingPromptAttention==='function'&&activeSessionHasPendingPromptAttention())?'● ':'';" not in block
 
     sessions_js = (ROOT / "static" / "sessions.js").read_text()
     fn = sessions_js[

--- a/tests/test_topbar_lazy_message_count.py
+++ b/tests/test_topbar_lazy_message_count.py
@@ -24,6 +24,9 @@ def test_sync_topbar_does_not_count_only_loaded_tail_messages():
     assert "const metaText=_topbarMessageMetaText();" in block
     assert "t('n_messages',vis.length)" not in block
     assert "S.messages.filter(m=>m&&m.role&&m.role!=='tool')" not in block
+    assert "const pendingPrefix=(typeof activeSessionHasPendingPromptAttention==='function'&&activeSessionHasPendingPromptAttention())?'● ':'';" in block
+    assert "document.title=pendingPrefix+sessionTitle+' \\u2014 '+assistantDisplayName();" in block
+    assert "document.title=sessionTitle+' \\u2014 '+assistantDisplayName();" not in block
 
     sessions_js = (ROOT / "static" / "sessions.js").read_text()
     fn = sessions_js[


### PR DESCRIPTION
## Thinking Path

- The current client already tracks pending approval and clarify prompts per session in `static/messages.js`, and the sidebar already exposes session-local attention; the missing piece is only a shell-visible signal for the active document.
- The desktop wrapper already mirrors `document.title`, via the existing topbar sync flow, so the smallest contract is to reuse that path rather than add a new bridge or IPC channel.
- This stays page-side and active-session-only, which matches the existing prompt-ownership model and keeps the shell-facing change small, deterministic, and easy to revert or extend later.

## What Changed

- `static/ui.js`: prepend a `● ` marker in the active-session document title when the current session has a pending approval or clarify.
- `static/messages.js`: expose a small active-session pending-state helper and trigger `syncTopbar()` on prompt-state transitions that affect the current title badge.
- `tests/test_topbar_lazy_message_count.py`: update the title-path assertions so the topbar flow remains centralized while allowing the prompt marker.
- `tests/test_1694_prompt_ownership.py`: lock the prompt-state title sync on approval and clarify ownership paths.

## Why It Matters

Background tabs can already hold blocked approval or clarify prompts, but the shell currently has no durable signal to badge them. Reusing the title mirror gives the desktop wrapper an immediate, low-cost contract without changing the existing prompt ownership or adding a second state channel.

## Verification

```text
pytest tests/test_topbar_lazy_message_count.py -v --timeout=60
pytest tests/test_1694_prompt_ownership.py -v --timeout=60
pytest tests/test_issue3668_prompt_card_reshow_on_switch.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- The title marker is intentionally lossy, it communicates pending attention, not prompt kind or count. The companion shell work can decide how much to infer from the prefix alone.
- This PR should not broaden into sidebar, session-schema, or IPC changes; if the desktop shell later needs structured payloads, that should be a separate follow-up from this title-marker contract.

## Model Used

GPT-5.5 via Codex CLI
