### PR TITLE
perf: reuse prefix duplicate match during message merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Long sidecar/state.db replay-prefix merges no longer rescan every sidecar message after each prefix match.** The merge now reuses the visible key found by the ordered prefix check, avoiding an O(n²) duplicate-lookup path for long sessions whose state.db mirror differs only by small suffix/formatting changes.
+
 ## [v0.51.434] — 2026-06-15 — Release OU (reject symlinked skill files on save)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -4546,6 +4546,7 @@ def merge_session_messages_append_only(
         sidecar_visible_sequence.append(visible_key)
         merged_messages.append(msg)
     sidecar_visible_lookup = _build_visible_duplicate_lookup(sidecar_visible_keys)
+    prefix_visible_lookup_cache = {}
     state_replay_idx = 0
     skipped_state_visible_counts = {}
     for msg in state_messages:
@@ -4553,22 +4554,31 @@ def merge_session_messages_append_only(
         key = _session_message_merge_key(msg)
         visible_key = _session_message_visible_key(msg)
         replays_sidecar_prefix = False
+        matched_prefix_visible_key = None
         if state_replay_idx < len(sidecar_visible_sequence):
             expected_visible_key = sidecar_visible_sequence[state_replay_idx]
-            if visible_key == expected_visible_key or _has_visible_duplicate(
-                visible_key, {expected_visible_key}
-            ):
+            if visible_key == expected_visible_key:
                 replays_sidecar_prefix = True
+                matched_prefix_visible_key = expected_visible_key
                 state_replay_idx += 1
+            else:
+                expected_visible_keys = {expected_visible_key}
+                expected_visible_lookup = prefix_visible_lookup_cache.get(expected_visible_key)
+                if expected_visible_lookup is None:
+                    expected_visible_lookup = _build_visible_duplicate_lookup(expected_visible_keys)
+                    prefix_visible_lookup_cache[expected_visible_key] = expected_visible_lookup
+                matched_prefix_visible_key = _matching_visible_duplicate(
+                    visible_key,
+                    expected_visible_keys,
+                    expected_visible_lookup,
+                )
+                if matched_prefix_visible_key is not None:
+                    replays_sidecar_prefix = True
+                    state_replay_idx += 1
         if replays_sidecar_prefix:
-            matched_visible_key = _matching_visible_duplicate(
-                visible_key,
-                sidecar_visible_keys,
-                sidecar_visible_lookup,
-            )
-            if matched_visible_key is not None:
-                skipped_state_visible_counts[matched_visible_key] = (
-                    skipped_state_visible_counts.get(matched_visible_key, 0) + 1
+            if matched_prefix_visible_key is not None:
+                skipped_state_visible_counts[matched_prefix_visible_key] = (
+                    skipped_state_visible_counts.get(matched_prefix_visible_key, 0) + 1
                 )
             # Record dedup key so later duplicates of this replayed message
             # are caught by the dedup guard (#3346).

--- a/tests/test_merge_prefix_duplicate_fastpath.py
+++ b/tests/test_merge_prefix_duplicate_fastpath.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from api import models
+from api.models import merge_session_messages_append_only
+
+
+def test_prefix_replay_reuses_expected_visible_key_without_global_lookup(monkeypatch):
+    """Replay-prefix matches must not rescan every sidecar visible key.
+
+    The prefix check already knows the only sidecar key that can match the
+    current replay row.  Calling _matching_visible_duplicate() again with the
+    full sidecar key set turns repeated sidecar prefixes into an O(n²) hot path
+    for long sessions with fuzzy-but-ordered state.db mirrors.
+    """
+    original = models._matching_visible_duplicate
+    broad_lookup_calls = []
+
+    def counted_matching_visible_duplicate(visible_key, visible_keys, lookup=None):
+        if len(visible_keys) > 1:
+            broad_lookup_calls.append((visible_key, len(visible_keys)))
+        return original(visible_key, visible_keys, lookup)
+
+    monkeypatch.setattr(models, "_matching_visible_duplicate", counted_matching_visible_duplicate)
+
+    sidecar = [
+        {"role": "assistant", "content": f"payload {i} abc def ghi", "timestamp": i}
+        for i in range(64)
+    ]
+    # Same ordered prefix, but with extra suffix text so the fuzzy prefix path is
+    # exercised instead of exact visible-key equality.
+    state = [
+        {"role": "assistant", "content": f"payload {i} abc def ghi extra", "timestamp": 1000 + i}
+        for i in range(64)
+    ]
+
+    result = merge_session_messages_append_only(sidecar, state)
+
+    assert len(result) == len(sidecar)
+    assert broad_lookup_calls == []
+
+
+def test_prefix_replay_counts_matched_sidecar_key_for_later_duplicate_skips():
+    """A fuzzy prefix replay must debit the matched sidecar key's duplicate budget."""
+    sidecar = [
+        {"role": "assistant", "content": "Repeated visible payload", "timestamp": 1},
+        {"role": "assistant", "content": "Repeated visible payload", "timestamp": 2},
+    ]
+    state = [
+        # Fuzzy replay of the first sidecar row: should skip and count against
+        # the matched sidecar visible key, not the state's longer visible key.
+        {"role": "assistant", "content": "Repeated visible payload plus suffix", "timestamp": 10},
+        # Same visible key as the sidecar duplicate.  Because the sidecar has two
+        # visible copies and only one prefix replay was skipped so far, this row
+        # must also be skipped rather than appended as a false delta.
+        {"role": "assistant", "content": "Repeated visible payload", "timestamp": 11},
+    ]
+
+    result = merge_session_messages_append_only(sidecar, state)
+
+    assert result == sidecar


### PR DESCRIPTION
## Thinking Path
`merge_session_messages_append_only()` already checks whether a state.db row replays the next expected sidecar-visible message. When that ordered prefix check matched fuzzily, the code immediately performed a second duplicate lookup against the entire sidecar visible-key set just to update skipped counts. On long replay prefixes this becomes an O(n²) hot path.

## What Changed
- Reuse the visible key found by the ordered prefix check instead of rescanning all sidecar visible keys for the same state row.
- Preserve the existing global duplicate lookup for non-prefix rows.
- Add a regression test that makes fuzzy ordered-prefix replay rows fail if they invoke broad sidecar duplicate lookup.
- Add an Unreleased changelog note.

## Why It Matters
Long sidecar/state.db reconciliation can happen during full session loads, recovery, and fallback paths. Avoiding the redundant global lookup keeps the merge linear for ordered replay prefixes while leaving the existing dedupe/truncation/tool-call semantics intact.

Local synthetic timing probe:
- Before: 3,000 sidecar rows + 3,000 fuzzy ordered state replay rows → ~4,595ms, ~22.9M function calls.
- After: same probe → ~106ms, ~321k function calls.

## Contract Routing
Task type: runtime/session reconciliation performance fix.
Touched areas:
- `api/models.py` `merge_session_messages_append_only()`
- session sidecar/state.db reconciliation
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
Scope boundaries:
- Does not change full transcript inputs, truncation watermark rules, message-id dedupe, tool-call keying, or non-prefix duplicate detection.
- Only avoids repeating an already-known prefix duplicate lookup.

## Verification
- `python3 -m pytest tests/test_merge_prefix_duplicate_fastpath.py tests/test_merge_key_tool_calls.py tests/test_webui_state_db_reconciliation.py tests/test_session_lineage_full_transcript.py -q` → `38 passed in 2.53s`
- `python3 -m py_compile api/models.py tests/test_merge_prefix_duplicate_fastpath.py`
- `git diff --check`
- Added-line static risk scan → `static scan findings: 0`
- Synthetic timing probe: `4594.6ms` before vs `105.7ms` after for 3k/3k fuzzy ordered replay rows.

## Risks / Follow-ups
- The patch intentionally keeps broad duplicate lookup for non-prefix rows; only the already matched ordered-prefix row reuses its known expected key.
- Follow-up work could benchmark real large fallback/full-history loads after #4137 lands, because #4137 removes the worst initial-tail path before this merge path is reached.

## Model Used
OpenAI GPT-5.5 via Hermes Agent WebUI, with terminal/file tooling and local pytest/timing probes.
