### PR TITLE
fix: extend timeout for full history session loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Full-history session loads now use an extended client timeout.** Actions that intentionally fetch the entire transcript (fork/export/start-jump helpers) can legitimately take longer than the default API timeout on very large sessions; the WebUI now gives that path up to 120 seconds instead of showing a premature "Request timed out" toast while the backend is still working.
+
 ## [v0.51.395] — 2026-06-13 — Release NH (push source filters into agent session scans, #3930)
 
 ### Fixed

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2470,7 +2470,7 @@ async function _ensureAllMessagesLoaded() {
   _loadingOlder = true;
   try {
     const sid = S.session.session_id;
-    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`);
+    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`, {timeoutMs:120000});
     // Guard: api() may have redirected (401) and returned undefined.
     if (!data || !data.session) return;
     // Session may have been switched while we awaited. Bail rather than

--- a/tests/test_issue2184_fork_from_here_absolute_index.py
+++ b/tests/test_issue2184_fork_from_here_absolute_index.py
@@ -160,6 +160,20 @@ def test_ensure_all_resets_oldest_idx_to_zero():
     )
 
 
+def test_ensure_all_messages_uses_extended_timeout_for_full_history_load():
+    """Full-history loads for fork/export/start-jump can legitimately exceed the API default timeout."""
+    body = _function_body(SESSIONS_JS, "_ensureAllMessagesLoaded")
+    full_history_call = re.search(
+        r"api\((?P<url>`[^`]*messages=1&resolve_model=0[^`]*`)\s*,\s*\{(?P<opts>[^}]*)\}\s*\)",
+        body,
+        re.S,
+    )
+    assert full_history_call, "_ensureAllMessagesLoaded must pass options to the full-history api() call"
+    timeout_match = re.search(r"timeoutMs\s*:\s*(\d+)", full_history_call.group("opts"))
+    assert timeout_match, "Full-history api() call must specify timeoutMs"
+    assert int(timeout_match.group(1)) >= 120000
+
+
 # ---------------------------------------------------------------------------
 # Short-session / full-transcript behaviour preserved
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path
The normal session open path is now tail-windowed, but a few deliberate full-history actions still fetch the entire transcript. On very large sessions that can legitimately exceed the shared 30s API timeout even when the backend is still working.

## What Changed
- Pass `{ timeoutMs: 120000 }` to `_ensureAllMessagesLoaded()`'s full-history `/api/session?messages=1` request.
- Add a regression test so the long-history path keeps the extended timeout.
- Add a changelog entry.

## Why It Matters
Large sessions should not show a premature "Request timed out" toast for actions that intentionally require full transcript hydration, such as fork/export/start-jump helpers.

## Verification
- `python3 -m pytest tests/test_issue2184_fork_from_here_absolute_index.py -q` → `10 passed`
- `python3 -m py_compile tests/test_issue2184_fork_from_here_absolute_index.py`
- `node --check static/sessions.js`
- `git diff --check`
- Added-line static risk scan → `0`

## Contract Routing

Task type: session-load timeout mitigation / frontend API behavior
Touched areas:
- `static/sessions.js`
- `tests/test_issue2184_fork_from_here_absolute_index.py`
- `CHANGELOG.md`
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
Scope boundaries:
- Does not make full-history hydration faster.
- Does not change the initial tail-window load path.
- Only extends the timeout for the deliberate full-history helper path.
Evidence needed before claiming done:
- Focused static regression test and JS syntax check.

## Risks / Follow-ups
This is a mitigation, not a replacement for backend performance improvements. The full-history path can still be slow on very large transcripts; this just avoids a premature client-side timeout.

## Model Used
AI-assisted by TARS / OpenAI GPT-5.5 via Hermes Agent.