### PR TITLE
Release NI (v0.51.396): longer timeout for full-history session loads (#4139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Full-history session loads now use an extended client timeout.** Actions that intentionally fetch the entire transcript (fork/export/start-jump helpers) can legitimately take longer than the default API timeout on very large sessions; the WebUI now gives that path up to 120 seconds instead of showing a premature "Request timed out" toast while the backend is still working.
+
 ## [v0.51.395] — 2026-06-13 — Release NH (push source filters into agent session scans, #3930)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.396] — 2026-06-13 — Release NI (longer timeout for full-history session loads, #4139)
+
 ### Fixed
 
-- **Full-history session loads now use an extended client timeout.** Actions that intentionally fetch the entire transcript (fork/export/start-jump helpers) can legitimately take longer than the default API timeout on very large sessions; the WebUI now gives that path up to 120 seconds instead of showing a premature "Request timed out" toast while the backend is still working.
+- **Full-history session loads now use an extended client timeout.** Actions that intentionally fetch the entire transcript (fork/export/start-jump helpers) can legitimately take longer than the default API timeout on very large sessions; the WebUI now gives that path up to 120 seconds instead of showing a premature "Request timed out" toast while the backend is still working. (#4139)
 
 ## [v0.51.395] — 2026-06-13 — Release NH (push source filters into agent session scans, #3930)
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2470,7 +2470,7 @@ async function _ensureAllMessagesLoaded() {
   _loadingOlder = true;
   try {
     const sid = S.session.session_id;
-    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`);
+    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`, {timeoutMs:120000});
     // Guard: api() may have redirected (401) and returned undefined.
     if (!data || !data.session) return;
     // Session may have been switched while we awaited. Bail rather than

--- a/tests/test_issue2184_fork_from_here_absolute_index.py
+++ b/tests/test_issue2184_fork_from_here_absolute_index.py
@@ -160,6 +160,20 @@ def test_ensure_all_resets_oldest_idx_to_zero():
     )
 
 
+def test_ensure_all_messages_uses_extended_timeout_for_full_history_load():
+    """Full-history loads for fork/export/start-jump can legitimately exceed the API default timeout."""
+    body = _function_body(SESSIONS_JS, "_ensureAllMessagesLoaded")
+    full_history_call = re.search(
+        r"api\((?P<url>`[^`]*messages=1&resolve_model=0[^`]*`)\s*,\s*\{(?P<opts>[^}]*)\}\s*\)",
+        body,
+        re.S,
+    )
+    assert full_history_call, "_ensureAllMessagesLoaded must pass options to the full-history api() call"
+    timeout_match = re.search(r"timeoutMs\s*:\s*(\d+)", full_history_call.group("opts"))
+    assert timeout_match, "Full-history api() call must specify timeoutMs"
+    assert int(timeout_match.group(1)) >= 120000
+
+
 # ---------------------------------------------------------------------------
 # Short-session / full-transcript behaviour preserved
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Release NI — v0.51.396 — Longer timeout for full-history session loads (#4139)

Absorbs **#4139** (@ai-ag2026). The full-history fetch (`_ensureAllMessagesLoaded()` — start-jump, outline expansion, fork-from-message) now passes `timeoutMs:120000` so a very large transcript isn't aborted by the default 30s `api()` timeout. The fast windowed session load keeps the normal timeout; a genuinely-hung request still aborts (at 120s).

- **Codex: SAFE TO SHIP** — `api()` honors `opts.timeoutMs` (other callers already use 60s/120s); change is scoped to the full-history reveal paths only.
- **Full suite: 8827 passed**, ESLint clean.

Thanks @ai-ag2026.