### PR TITLE
fix: focus the existing chat tab when a notification is clicked instead of opening a new tab

### DIFF
--- a/static/sw.js
+++ b/static/sw.js
@@ -182,6 +182,9 @@ self.addEventListener('notificationclick', (event) => {
   const samePath = (clientUrl) => {
     try { return new URL(clientUrl).pathname === targetPath; } catch (_e) { return false; }
   };
+  const sameOrigin = (clientUrl) => {
+    try { return new URL(clientUrl).origin === self.location.origin; } catch (_e) { return false; }
+  };
   event.waitUntil(
     self.clients.matchAll({type: 'window', includeUncontrolled: true}).then((clientList) => {
       // Match on pathname, not the full href: _sessionUrlForSid copies the
@@ -190,13 +193,17 @@ self.addEventListener('notificationclick', (event) => {
       // duplicate window.
       const targetClient = clientList.find((client) => samePath(client.url) && 'focus' in client);
       if (targetClient) return targetClient.focus();
-      if (self.clients.openWindow) return self.clients.openWindow(targetUrl);
-      const focusableClient = clientList.find((client) => 'focus' in client);
+
+      const openNotificationWindow = () => (
+        self.clients.openWindow ? self.clients.openWindow(targetUrl) : undefined
+      );
+      const focusableClient = clientList.find((client) => sameOrigin(client.url) && 'focus' in client && 'navigate' in client);
       if (focusableClient && 'navigate' in focusableClient) {
         return focusableClient.navigate(targetUrl)
           .then((client) => (client && 'focus' in client ? client.focus() : focusableClient.focus()))
           .catch(() => focusableClient.focus());
       }
+      return openNotificationWindow();
     })
   );
 });

--- a/tests/test_4109_notification_focus_existing_tab.py
+++ b/tests/test_4109_notification_focus_existing_tab.py
@@ -1,0 +1,83 @@
+"""Regression coverage for notification clicks reusing an open WebUI tab (#4109)."""
+
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SW_SRC = (ROOT / "static" / "sw.js").read_text(encoding="utf-8")
+MESSAGES_SRC = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+ROUTES_SRC = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def test_server():
+    """This module only reads static source; it does not need the HTTP fixture."""
+
+
+def _notification_click_handler() -> str:
+    start = SW_SRC.index("self.addEventListener('notificationclick'")
+    return SW_SRC[start:]
+
+
+def test_notification_click_keeps_exact_path_focus_fast_path():
+    handler = _notification_click_handler()
+
+    target_idx = handler.index("const targetClient = clientList.find")
+    exact_focus_idx = handler.index("if (targetClient) return targetClient.focus();")
+    reusable_idx = handler.index("const focusableClient = clientList.find")
+
+    assert "samePath(client.url)" in handler
+    assert "new URL(clientUrl).pathname === targetPath" in handler
+    assert target_idx < exact_focus_idx < reusable_idx
+
+
+def test_notification_click_navigates_reusable_client_before_opening_window():
+    handler = _notification_click_handler()
+
+    reusable_idx = handler.index("const focusableClient = clientList.find")
+    navigate_idx = handler.index("focusableClient.navigate(targetUrl)")
+    open_fallback_idx = handler.index("return openNotificationWindow();")
+
+    assert "sameOrigin(client.url) && 'focus' in client && 'navigate' in client" in handler
+    assert reusable_idx < navigate_idx < open_fallback_idx
+    assert "if (self.clients.openWindow) return self.clients.openWindow(targetUrl)" not in handler
+
+
+def test_notification_click_focuses_after_navigation_or_navigation_failure():
+    handler = _notification_click_handler()
+
+    assert (
+        ".then((client) => (client && 'focus' in client ? "
+        "client.focus() : focusableClient.focus()))"
+    ) in handler
+    assert ".catch(() => focusableClient.focus())" in handler
+
+
+def test_notification_click_open_window_remains_no_reusable_client_fallback():
+    handler = _notification_click_handler()
+
+    assert "const openNotificationWindow = () => (" in handler
+    assert "self.clients.openWindow ? self.clients.openWindow(targetUrl) : undefined" in handler
+    assert handler.index("return openNotificationWindow();") > handler.index(
+        "focusableClient.navigate(targetUrl)"
+    )
+
+
+def test_test_notification_without_sid_still_targets_current_page_for_reuse():
+    assert "const url=sid?`${location.origin}${_sessionUrlForSid(sid)}`:location.href;" in MESSAGES_SRC
+    assert "sendBrowserNotification('Hermes test','Notifications are ready.',{force:true});" in (
+        ROOT / "static" / "index.html"
+    ).read_text(encoding="utf-8")
+
+
+def test_service_worker_update_delivery_keeps_versioned_no_store_route():
+    assert "const CACHE_NAME = 'hermes-shell-__WEBUI_VERSION__';" in SW_SRC
+    assert "self.skipWaiting();" in SW_SRC
+    assert "self.clients.claim();" in SW_SRC
+
+    route_idx = ROUTES_SRC.index('"/sw.js"')
+    route_block = ROUTES_SRC[route_idx : route_idx + 1200]
+    assert 'replace(\n                "__WEBUI_VERSION__", version_token\n            )' in route_block
+    assert 'handler.send_header("Cache-Control", "no-store")' in route_block


### PR DESCRIPTION
## Summary

Focus the existing chat tab when a notification is clicked instead of opening a new tab

## Why this matters

Clicking a completion (or "Send test") browser notification opens a brand-new browser tab/window instead of focusing the already-open chat tab. Reproduced on Firefox, the PWA, and confirmed by a second reporter in Discord. The maintainer traced it end to end: the `notificationclick` handler in `static/sw.js` does try to focus an existing client, but only when that client's pathname is an exact match for the notification target (`/session/<sid>`). On any pathname divergence (the tab is on `/`, on a different session, or the completion fired for the active session while the visible path differed) the handler immediately calls `clients.openWindow(targetUrl)`, spawning a duplicate. The `navigate`-an-existing-client fallback below that line is dead code because `clients.openWindow` is defined on every modern browser, so control never reaches it.

## Changes

In the `notificationclick` handler (`static/sw.js` ~177-202), reorder the fallback so an already-open same-origin app client is reused before ever calling `openWindow`. Keep the existing exact-path focus as the fast path; then, before `openWindow`, find any focusable client that also supports `navigate`, call `client.navigate(targetUrl)`, then focus the resulting (or original) client, with a `.catch` that still focuses on navigate failure. Only call `self.clients.openWindow(targetUrl)` when no reusable client exists. This single change fixes the completion-notification case, the Send-test case, and the PWA case because all three flow through the same `showNotification` -> `notificationclick` path. Bump the service-worker cache version token (`CACHE_NAME = 'hermes-shell-__WEBUI_VERSION__'`, sw.js:10 — the version is substituted at serve time, so confirm the `/sw.js` route still forces the new worker to take over) so clients pick up the new worker.

## Testing

- Happy path: a chat tab is open on `/session/<sid>`; the completion notification for that session is clicked -> the existing tab is focused, no new tab.
- Pathname divergence: the open tab is sitting on `/` or on a different session when the notification is clicked -> the existing tab is navigated to the target session and focused, no new tab.
- Send-test button with no `sid`: clicking the test notification when the active tab is not on the exact session path -> reuses/navigates the existing tab rather than opening a new one.
- No app window open at all -> `openWindow` is still called and a new tab opens (genuine fallback preserved).
- Cache-version regression: confirm the cache name token changed so the updated worker is installed rather than the stale one serving the old handler.

Fixes #4109

AI was used for assistance.
