### PR TITLE
fix(gateway): surface reasoning previews in WebUI (#4146)

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -145,13 +145,11 @@ def _gateway_stream_usage(payload: dict) -> dict:
 def _gateway_reasoning_delta(payload: dict) -> str:
     if not isinstance(payload, dict):
         return ""
-    return str(
-        payload.get("text")
-        or payload.get("preview")
-        or payload.get("delta")
-        or payload.get("content")
-        or ""
-    ).strip()
+    for key in ("text", "preview", "delta", "content"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
 
 
 def _gateway_tool_progress_event(payload: dict) -> tuple[str, dict] | None:
@@ -375,7 +373,7 @@ def _run_gateway_chat_streaming(
                         if event_name == "reasoning":
                             reason_delta = event_payload.get("text")
                             if reason_delta and stream_id in STREAM_REASONING_TEXT:
-                                STREAM_REASONING_TEXT[stream_id] += str(reason_delta)
+                                STREAM_REASONING_TEXT[stream_id] += reason_delta
                         elif stream_id in STREAM_LIVE_TOOL_CALLS:
                             if event_name == "tool":
                                 STREAM_LIVE_TOOL_CALLS[stream_id].append({
@@ -439,6 +437,9 @@ def _run_gateway_chat_streaming(
             if attachments:
                 user_msg["attachments"] = list(attachments)
             assistant_msg = {"role": "assistant", "content": assistant_text, "timestamp": assistant_ts}
+            saved_reasoning = STREAM_REASONING_TEXT.get(stream_id, "")
+            if saved_reasoning:
+                assistant_msg["reasoning"] = saved_reasoning
             previous_context = list(getattr(s, "context_messages", None) or getattr(s, "messages", None) or [])
             s.context_messages = previous_context + [user_msg, assistant_msg]
             try:

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -147,7 +147,14 @@ def _gateway_tool_progress_event(payload: dict) -> tuple[str, dict] | None:
     if not isinstance(payload, dict):
         return None
     name = str(payload.get("tool") or payload.get("name") or payload.get("function_name") or "").strip()
-    if not name or name.startswith("_"):
+    if not name:
+        return None
+    if name == "_thinking":
+        reason_delta = str(payload.get("preview") or payload.get("delta") or "").strip()
+        if not reason_delta:
+            return None
+        return "reasoning", {"text": reason_delta}
+    if name.startswith("_"):
         return None
     status = str(payload.get("status") or "running").strip().lower()
     tid = payload.get("toolCallId") or payload.get("tool_call_id") or payload.get("id")
@@ -353,7 +360,11 @@ def _run_gateway_chat_streaming(
                     translated = _gateway_tool_progress_event(payload)
                     if translated:
                         event_name, event_payload = translated
-                        if stream_id in STREAM_LIVE_TOOL_CALLS:
+                        if event_name == "reasoning":
+                            reason_delta = event_payload.get("text")
+                            if reason_delta and stream_id in STREAM_REASONING_TEXT:
+                                STREAM_REASONING_TEXT[stream_id] += str(reason_delta)
+                        elif stream_id in STREAM_LIVE_TOOL_CALLS:
                             if event_name == "tool":
                                 STREAM_LIVE_TOOL_CALLS[stream_id].append({
                                     "name": event_payload.get("name"),
@@ -372,7 +383,23 @@ def _run_gateway_chat_streaming(
                                         shared_tc["is_error"] = bool(event_payload.get("is_error"))
                                         break
                         put_gateway_event(event_name, event_payload)
-                        update_active_run(stream_id, phase="gateway-tool", latest_tool=event_payload.get("name"))
+                        if event_name != "reasoning":
+                            update_active_run(stream_id, phase="gateway-tool", latest_tool=event_payload.get("name"))
+                    sse_event = "message"
+                    continue
+                if sse_event == "reasoning.available":
+                    reason_delta = (
+                        payload.get("text")
+                        or payload.get("preview")
+                        or payload.get("delta")
+                        or payload.get("content")
+                        or ""
+                    )
+                    reason_delta = str(reason_delta).strip()
+                    if reason_delta:
+                        if stream_id in STREAM_REASONING_TEXT:
+                            STREAM_REASONING_TEXT[stream_id] += reason_delta
+                        put_gateway_event("reasoning", {"text": reason_delta})
                     sse_event = "message"
                     continue
                 last_payload = payload

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -142,6 +142,18 @@ def _gateway_stream_usage(payload: dict) -> dict:
     }
 
 
+def _gateway_reasoning_delta(payload: dict) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    return str(
+        payload.get("text")
+        or payload.get("preview")
+        or payload.get("delta")
+        or payload.get("content")
+        or ""
+    ).strip()
+
+
 def _gateway_tool_progress_event(payload: dict) -> tuple[str, dict] | None:
     """Translate Hermes Gateway tool-progress SSE payloads to WebUI events."""
     if not isinstance(payload, dict):
@@ -150,7 +162,7 @@ def _gateway_tool_progress_event(payload: dict) -> tuple[str, dict] | None:
     if not name:
         return None
     if name == "_thinking":
-        reason_delta = str(payload.get("preview") or payload.get("delta") or "").strip()
+        reason_delta = _gateway_reasoning_delta(payload)
         if not reason_delta:
             return None
         return "reasoning", {"text": reason_delta}
@@ -388,14 +400,7 @@ def _run_gateway_chat_streaming(
                     sse_event = "message"
                     continue
                 if sse_event == "reasoning.available":
-                    reason_delta = (
-                        payload.get("text")
-                        or payload.get("preview")
-                        or payload.get("delta")
-                        or payload.get("content")
-                        or ""
-                    )
-                    reason_delta = str(reason_delta).strip()
+                    reason_delta = _gateway_reasoning_delta(payload)
                     if reason_delta:
                         if stream_id in STREAM_REASONING_TEXT:
                             STREAM_REASONING_TEXT[stream_id] += reason_delta

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -131,6 +131,24 @@ def _gateway_sse_delta(payload: dict) -> str:
         return ""
 
 
+def _gateway_sse_reasoning_delta(payload: dict) -> str:
+    """Extract reasoning text from OpenAI-compatible streaming chunks."""
+    try:
+        choices = payload.get("choices") or []
+        if not choices:
+            return ""
+        choice = choices[0] or {}
+        delta = choice.get("delta") or {}
+        reasoning = delta.get("reasoning_content")
+        if isinstance(reasoning, str) and reasoning.strip():
+            return reasoning
+        message = choice.get("message") or {}
+        reasoning = message.get("reasoning_content")
+        return reasoning if isinstance(reasoning, str) and reasoning.strip() else ""
+    except Exception:
+        return ""
+
+
 def _gateway_stream_usage(payload: dict) -> dict:
     usage = payload.get("usage") if isinstance(payload, dict) else None
     if not isinstance(usage, dict):
@@ -406,6 +424,11 @@ def _run_gateway_chat_streaming(
                     sse_event = "message"
                     continue
                 last_payload = payload
+                reasoning_delta = _gateway_sse_reasoning_delta(payload)
+                if reasoning_delta:
+                    if stream_id in STREAM_REASONING_TEXT:
+                        STREAM_REASONING_TEXT[stream_id] += reasoning_delta
+                    put_gateway_event("reasoning", {"text": reasoning_delta})
                 delta = _gateway_sse_delta(payload)
                 if delta:
                     final_text += delta

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -138,6 +138,14 @@ def test_gateway_tool_progress_event_translates_gateway_lifecycle_payloads():
             "text": "Thinking...",
         },
     )
+    assert _gateway_tool_progress_event(
+        {"tool": "_thinking", "status": "running", "text": "Thinking from text..."}
+    ) == (
+        "reasoning",
+        {
+            "text": "Thinking from text...",
+        },
+    )
     assert _gateway_tool_progress_event({"tool": "_thinking", "status": "running"}) is None
 
 
@@ -242,6 +250,8 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
             yield b'event: hermes.tool.progress\n'
             yield b'data: {"tool":"terminal","label":"terminal: pytest","toolCallId":"call-1","status":"running"}\n\n'
             yield b'data: {"choices":[{"delta":{"content":"hel"}}]}\n\n'
+            yield b'event: hermes.tool.progress\n'
+            yield b'data: {"tool":"_thinking","text":"Thinking from tool progress"}\n\n'
             yield b'event: reasoning.available\n'
             yield b'data: {"text":"Reasoning preview", "preview":"Reasoning preview"}\n\n'
             yield b'event: hermes.tool.progress\n'
@@ -334,6 +344,7 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
         "is_error": False,
         "tid": "call-1",
     }) in event_pairs
+    assert ("reasoning", {"text": "Thinking from tool progress"}) in event_pairs
     assert ("reasoning", {"text": "Reasoning preview"}) in event_pairs
     assert ("tool_complete", {
         "event_type": "tool.completed",

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -13,6 +13,7 @@ from api.config import STREAMS, create_stream_channel
 from api.models import new_session
 from api.gateway_chat import (
     _gateway_http_error_event,
+    _gateway_reasoning_delta,
     _gateway_sse_delta,
     _gateway_stream_usage,
     _gateway_tool_progress_event,
@@ -147,6 +148,13 @@ def test_gateway_tool_progress_event_translates_gateway_lifecycle_payloads():
         },
     )
     assert _gateway_tool_progress_event({"tool": "_thinking", "status": "running"}) is None
+
+
+def test_gateway_reasoning_delta_keeps_string_deltas_and_ignores_structured_payloads():
+    assert _gateway_reasoning_delta({"text": " Let me"}) == " Let me"
+    assert _gateway_reasoning_delta({"text": "   ", "preview": " think"}) == " think"
+    assert _gateway_reasoning_delta({"content": {"text": "safe", "debug": {"note": "x"}}}) == ""
+    assert _gateway_reasoning_delta({"text": ["safe"], "preview": " more"}) == " more"
 
 
 def test_gateway_http_401_reports_gateway_auth_not_provider_key():
@@ -355,6 +363,68 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
         "tid": "call-1",
     }) in event_pairs
     assert all(len(item) == 3 and item[2] for item in events)
+
+
+def test_gateway_chat_worker_preserves_reasoning_delta_whitespace_and_persists_reasoning(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield b'data: {"choices":[{"delta":{"content":"hel"}}]}\n\n'
+            yield b'event: hermes.tool.progress\n'
+            yield b'data: {"tool":"_thinking","text":"Let me"}\n\n'
+            yield b'event: reasoning.available\n'
+            yield b'data: {"text":" think", "preview":"should not win"}\n\n'
+            yield b'event: reasoning.available\n'
+            yield b'data: {"content":{"text":"safe","debug":{"note":"x"}}}\n\n'
+            yield b'event: reasoning.available\n'
+            yield b'data: {"preview":" more"}\n\n'
+            yield b'data: {"choices":[{"delta":{"content":"lo"}}]}\n\n'
+            yield b'data: [DONE]\n\n'
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", lambda req, timeout=0: FakeResponse())
+
+    s = new_session()
+    stream_id = "stream-gateway-reasoning-persist-test"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.pending_started_at = 123
+    s.save()
+    channel = create_stream_channel()
+    subscriber = channel.subscribe()
+    STREAMS[stream_id] = channel
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+    )
+
+    saved = models.get_session(s.session_id)
+    assert saved.messages[-1]["content"] == "hello"
+    assert saved.messages[-1]["reasoning"] == "Let me think more"
+    reasoning_events = []
+    while not subscriber.empty():
+        item = subscriber.get_nowait()
+        if item[0] == "reasoning":
+            reasoning_events.append(item[1]["text"])
+    assert reasoning_events == ["Let me", " think", " more"]
+    assert not any("debug" in text for text in reasoning_events)
 
 
 def test_gateway_chat_worker_normalizes_prefill_slice_before_system_prefix(tmp_path, monkeypatch):

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -15,6 +15,7 @@ from api.gateway_chat import (
     _gateway_http_error_event,
     _gateway_reasoning_delta,
     _gateway_sse_delta,
+    _gateway_sse_reasoning_delta,
     _gateway_stream_usage,
     _gateway_tool_progress_event,
     gateway_chat_config_status,
@@ -155,6 +156,12 @@ def test_gateway_reasoning_delta_keeps_string_deltas_and_ignores_structured_payl
     assert _gateway_reasoning_delta({"text": "   ", "preview": " think"}) == " think"
     assert _gateway_reasoning_delta({"content": {"text": "safe", "debug": {"note": "x"}}}) == ""
     assert _gateway_reasoning_delta({"text": ["safe"], "preview": " more"}) == " more"
+
+
+def test_gateway_sse_reasoning_delta_extracts_reasoning_content_chunks():
+    assert _gateway_sse_reasoning_delta({"choices": [{"delta": {"reasoning_content": "Let me"}}]}) == "Let me"
+    assert _gateway_sse_reasoning_delta({"choices": [{"message": {"reasoning_content": "Done thinking"}}]}) == "Done thinking"
+    assert _gateway_sse_reasoning_delta({"choices": [{"delta": {"reasoning_content": "   "}}]}) == ""
 
 
 def test_gateway_http_401_reports_gateway_auth_not_provider_key():
@@ -425,6 +432,59 @@ def test_gateway_chat_worker_preserves_reasoning_delta_whitespace_and_persists_r
             reasoning_events.append(item[1]["text"])
     assert reasoning_events == ["Let me", " think", " more"]
     assert not any("debug" in text for text in reasoning_events)
+
+
+def test_gateway_chat_worker_reads_reasoning_content_deltas_from_chat_completions(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield b'data: {"choices":[{"delta":{"reasoning_content":"Let me ","content":"hel"}}]}\n\n'
+            yield b'data: {"choices":[{"delta":{"reasoning_content":"think","content":"lo"}}]}\n\n'
+            yield b'data: [DONE]\n\n'
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", lambda req, timeout=0: FakeResponse())
+
+    s = new_session()
+    stream_id = "stream-gateway-reasoning-content-test"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.pending_started_at = 123
+    s.save()
+    channel = create_stream_channel()
+    subscriber = channel.subscribe()
+    STREAMS[stream_id] = channel
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+    )
+
+    saved = models.get_session(s.session_id)
+    assert saved.messages[-1]["content"] == "hello"
+    assert saved.messages[-1]["reasoning"] == "Let me think"
+    reasoning_events = []
+    while not subscriber.empty():
+        item = subscriber.get_nowait()
+        if item[0] == "reasoning":
+            reasoning_events.append(item[1]["text"])
+    assert reasoning_events == ["Let me ", "think"]
 
 
 def test_gateway_chat_worker_normalizes_prefill_slice_before_system_prefix(tmp_path, monkeypatch):

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -130,6 +130,14 @@ def test_gateway_tool_progress_event_translates_gateway_lifecycle_payloads():
             "tid": "call-1",
         },
     )
+    assert _gateway_tool_progress_event(
+        {"tool": "_thinking", "status": "running", "preview": "Thinking..."}
+    ) == (
+        "reasoning",
+        {
+            "text": "Thinking...",
+        },
+    )
     assert _gateway_tool_progress_event({"tool": "_thinking", "status": "running"}) is None
 
 
@@ -234,6 +242,8 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
             yield b'event: hermes.tool.progress\n'
             yield b'data: {"tool":"terminal","label":"terminal: pytest","toolCallId":"call-1","status":"running"}\n\n'
             yield b'data: {"choices":[{"delta":{"content":"hel"}}]}\n\n'
+            yield b'event: reasoning.available\n'
+            yield b'data: {"text":"Reasoning preview", "preview":"Reasoning preview"}\n\n'
             yield b'event: hermes.tool.progress\n'
             yield b'data: {"tool":"terminal","toolCallId":"call-1","status":"completed"}\n\n'
             yield b'data: {"choices":[{"delta":{"content":"lo"}}],"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n'
@@ -324,6 +334,7 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
         "is_error": False,
         "tid": "call-1",
     }) in event_pairs
+    assert ("reasoning", {"text": "Reasoning preview"}) in event_pairs
     assert ("tool_complete", {
         "event_type": "tool.completed",
         "name": "terminal",


### PR DESCRIPTION
title: fix(gateway): surface reasoning previews in WebUI (#4146)

## Thinking Path

- Gateway-backed WebUI chat already preserves token deltas and tool lifecycle events, so the remaining parity gap is the separate reasoning stream rather than core assistant output.
- The API server can surface gateway reasoning in three compatible shapes: `_thinking` tool-progress payloads, direct `reasoning.available` SSE events, and OpenAI-style `choices[].delta.reasoning_content` chunks on `/v1/chat/completions`.
- The narrow fix is to preserve string reasoning fragments exactly as streamed, translate all three shapes into the existing WebUI `reasoning` event contract, and persist the accumulated preview onto the saved assistant turn so reload matches the live Thinking card.

## What Changed

- `api/gateway_chat.py`: accept only string reasoning fragments from `text`, `preview`, `delta`, and `content`, keeping the emitted `reasoning` payload unchanged instead of stringifying structured values or trimming inter-fragment whitespace.
- `api/gateway_chat.py`: read OpenAI-style `choices[].delta.reasoning_content` chunks from `/v1/chat/completions` and mirror them into the same `reasoning` event path used by `_thinking` and `reasoning.available`.
- `api/gateway_chat.py`: persist the accumulated gateway reasoning text into `assistant_msg["reasoning"]` before `s.save()`, matching the local runtime's reload-visible transcript behavior.
- `tests/test_webui_gateway_chat_backend.py`: add helper and worker-stream regressions that reject structured payloads, prove 2+ reasoning deltas accumulate without trimming, cover the `delta.reasoning_content` wire shape from `hermes-agent#39006`, and assert the saved assistant turn keeps the preview text after reload.

## Why It Matters

Gateway users regain the same live reasoning preview behavior they already get on the local runtime path, whether the gateway emits custom reasoning events or OpenAI-style `reasoning_content` chunks, and the preview now survives reload instead of disappearing once the gateway-backed turn is saved.

## Verification

`pytest tests/test_webui_gateway_chat_backend.py -v --timeout=60`

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- This keeps the gateway bridge on string reasoning fragments only; structured reasoning payloads remain intentionally ignored rather than stringified into the browser preview.
- If the agent-side gateway lands a different future reasoning field than `_thinking`, `reasoning.available`, or `delta.reasoning_content`, this bridge would still need another small parser arm for that new wire shape.
- This only restores reasoning preview forwarding for the current gateway chat bridge; broader `run.*` lifecycle parity can stay a later slice if the WebUI needs richer structured run-state rendering.

## Model Used

GPT 5 via Codex CLI
