### PR TITLE
Release NO (v0.51.402): proportional scroll restoration after render-window growth, opt-in (#4110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.402] — 2026-06-13 — Release NO (proportional scroll restoration after render-window growth, opt-in, #4110)
+
+### Fixed
+
+- **Finishing a streamed reply in a long conversation no longer jumps the viewport to an earlier part of the chat — and the fix is now scoped so it can't disturb other callers.** When the render window grows by prepending earlier messages, `_restoreMessageScrollSnapshot` adjusts `scrollTop` by the DOM height delta — but only when the caller opts in via `adjustForTopGrowth`, so older-history paging (which already compensates) and bottom-growth live-compression restores (`_restoreMessageScrollSnapshotSameFrame`) are unaffected. Also guards `_programmaticScroll` across the `innerHTML` clear (reset on all exits) so the native scroll event during DOM replacement can't false-trigger sticky-unpin. (#4110)
+
 ## [v0.51.400] — 2026-06-13 — Release NM (skill bundles in WebUI slash commands, #4087)
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -1643,7 +1643,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(_isActiveSession()){
       S.activeStreamId=null;
       clearLiveToolCards();if(!assistantText)removeThinking();
-      renderMessages({preserveScroll:true});
+      renderMessages({preserveScroll:true,adjustForTopGrowth:true});
     }
     renderSessionList();
     _setActivePaneIdleIfOwner();
@@ -3309,7 +3309,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           if(typeof _messageRenderableMessageCount==='function'&&typeof _messageRenderWindowSize!=='undefined'){
             _messageRenderWindowSize=Math.max(typeof _currentMessageRenderWindowSize==='function'?_currentMessageRenderWindowSize():50, _messageRenderableMessageCount());
           }
-          syncTopbar();renderMessages({preserveScroll:true});
+          syncTopbar();renderMessages({preserveScroll:true,adjustForTopGrowth:true});
           if(shouldFollowOnDone&&typeof scrollToBottom==='function'&&typeof _isMessagePaneNearBottom==='function'&&_isMessagePaneNearBottom(250)) scrollToBottom();
           if(typeof noteWorkspaceMutationsFromToolCalls==='function') noteWorkspaceMutationsFromToolCalls(S.toolCalls);
           loadDir('.', { preservePreview: true });
@@ -3791,7 +3791,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         if(typeof _messageRenderableMessageCount==='function'&&typeof _messageRenderWindowSize!=='undefined'){
           _messageRenderWindowSize=Math.max(typeof _currentMessageRenderWindowSize==='function'?_currentMessageRenderWindowSize():50, _messageRenderableMessageCount());
         }
-        syncTopbar();renderMessages({preserveScroll:true});
+        syncTopbar();renderMessages({preserveScroll:true,adjustForTopGrowth:true});
       }
       if(_isActiveSession()) _queueDrainSid=activeSid;
       renderSessionList();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2331,7 +2331,10 @@ async function _loadOlderMessages() {
     // we'd get by stitching pages, but without client-side index bookkeeping.
     // Cumulative growth: each "load more" asks for currentLoaded + 30, and the
     // newly exposed head is what we expose to the user.
-    const requestedLimit = Math.max(_INITIAL_MSG_LIMIT, (S.messages || []).length + _INITIAL_MSG_LIMIT);
+    // Size from the loaded VISIBLE/renderable count, not raw S.messages.length:
+    // the backend now interprets msg_limit as visible rows, so a tool-heavy tail
+    // (many hidden role=tool rows) must not inflate the next request. (Codex #4110.)
+    const requestedLimit = Math.max(_INITIAL_MSG_LIMIT, _currentLoadedRenderableMessageCount() + _INITIAL_MSG_LIMIT);
     const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${requestedLimit}`);
     // Guard: api() may have redirected (401) and returned undefined.
     if (!data || !data.session) { _loadingOlder = false; return; }

--- a/static/ui.js
+++ b/static/ui.js
@@ -8710,16 +8710,19 @@ function _captureMessageScrollSnapshot(){
     userUnpinned:_messageUserUnpinned,
   };
 }
-function _restoreMessageScrollSnapshot(snapshot){
+function _restoreMessageScrollSnapshot(snapshot, opts){
   const el=$('messages');
   if(!el||!snapshot) return;
   const maxTop=Math.max(0,el.scrollHeight-el.clientHeight);
-  // Proportional scroll adjustment: when DOM has grown/shrunk since the
-  // snapshot was taken (e.g. render window expansion prepended earlier
-  // messages), compensate scrollTop by the height delta so the user's
-  // visible message group stays in view.  Falls back to 0 delta (current
-  // behaviour) when snapshot.scrollHeight is absent.
-  const delta=el.scrollHeight-Number(snapshot.scrollHeight||el.scrollHeight);
+  // When the DOM grew at the top (e.g. render window expansion prepended
+  // earlier messages), compensate scrollTop so the user's visible message
+  // group stays in view.  This is opt-in via `adjustForTopGrowth` because
+  // some callers (e.g. _loadOlderMessages in sessions.js) already handle
+  // the compensation themselves, and passing it unconditionally would
+  // apply the height adjustment twice. (#4110 review feedback.)
+  const delta=(opts&&opts.adjustForTopGrowth)
+    ? el.scrollHeight-Number(snapshot.scrollHeight||el.scrollHeight)
+    : 0;
   const target=Math.max(0,Math.min((Number(snapshot.top)||0)+delta,maxTop));
   _programmaticScroll=true;
   el.scrollTop=target;
@@ -8727,14 +8730,17 @@ function _restoreMessageScrollSnapshot(snapshot){
   _lastScrollTop=el.scrollTop;
   requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
 }
-function _restoreMessageScrollSnapshotSameFrame(snapshot){
+function _restoreMessageScrollSnapshotSameFrame(snapshot, opts){
   const el=$('messages');
   if(!el||!snapshot) return;
   const maxTop=Math.max(0,el.scrollHeight-el.clientHeight);
   const bottom=Number(snapshot.bottom);
+  const delta=(opts&&opts.adjustForTopGrowth)
+    ? el.scrollHeight-Number(snapshot.scrollHeight||el.scrollHeight)
+    : 0;
   const target=(snapshot.pinned===true&&Number.isFinite(bottom))
     ? maxTop-Math.max(0,bottom)
-    : Math.max(0,Math.min((Number(snapshot.top)||0)+(el.scrollHeight-Number(snapshot.scrollHeight||el.scrollHeight)),maxTop));
+    : Math.max(0,Math.min((Number(snapshot.top)||0)+delta,maxTop));
   _programmaticScroll=true;
   el.scrollTop=Math.max(0,Math.min(target,maxTop));
   _lastScrollTop=el.scrollTop;
@@ -8751,8 +8757,8 @@ function _restoreMessageScrollSnapshotSameFrame(snapshot){
 }
 function _renderMessagesWithScrollSnapshot(options){
   const scrollSnapshot=_captureMessageScrollSnapshot();
-  renderMessages({...(options||{}),preserveScroll:true});
-  _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
+  renderMessages({...(options||{}),preserveScroll:true,adjustForTopGrowth:true});
+  _restoreMessageScrollSnapshotSameFrame(scrollSnapshot, { adjustForTopGrowth: true });
 }
 let _assistantTurnAnchorSettledFinalAnswerWarned=false;
 function _assistantTurnAnchorSettledFinalAnswer(message, content, context){
@@ -8774,7 +8780,7 @@ function _assistantTurnAnchorSettledFinalAnswer(message, content, context){
     return null;
   }
 }
-function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
+function _scrollAfterMessageRender(preserveScroll, scrollSnapshot, opts){
   // Terminal stream renders can happen after S.activeStreamId is cleared.
   // In that case, preserveScroll asks the normal pin-state helper to decide:
   // pinned users stay at bottom; users who manually scrolled up get their
@@ -8789,7 +8795,7 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
     // write unless distance>500 and let the DOM-rebuild scroll event cancel the
     // delayed settles — Codex CORE catch on #3631.)
     if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;
-    _restoreMessageScrollSnapshot(scrollSnapshot);
+    _restoreMessageScrollSnapshot(scrollSnapshot, opts);
     _maybeShowNewMessageScrollCue(scrollSnapshot);
     return;
   }
@@ -8805,7 +8811,7 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
   // renderMessages() captures the pre-wipe snapshot for this case too (see its
   // scrollSnapshot init), so restoring here lands the reader where they were.
   if(!_autoScrollFollow && _messageUserUnpinned){
-    _restoreMessageScrollSnapshot(scrollSnapshot);
+    _restoreMessageScrollSnapshot(scrollSnapshot, opts);
     return;
   }
   scrollToBottom();
@@ -8813,6 +8819,11 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
 
 function renderMessages(options){
   const preserveScroll=!!(options&&options.preserveScroll);
+  // Opt-in top-growth adjustment for render window expansion that prepends
+  // messages at the DOM top.  Only the render-window-expansion callers
+  // (stream completion, session response refresh) pass this; _loadOlderMessages
+  // and other callers do not, so their restore path is unchanged.
+  const _scrollOpts={ adjustForTopGrowth: !!(options&&options.adjustForTopGrowth) };
   // Capture the pre-wipe scroll position when preserving OR when Auto-follow is
   // off and the user has scrolled up — both need to restore the reader's position
   // after the DOM rebuild rather than snap to the bottom. (Codex #4006 r3.)
@@ -8850,7 +8861,7 @@ function renderMessages(options){
       _rehydrateTransparentStreamDom(inner);
       _wireMessageWindowLoadEarlierButton();
       if(typeof _applySessionNavigationPrefs==='function') _applySessionNavigationPrefs();
-      _scrollAfterMessageRender(preserveScroll, scrollSnapshot);
+      _scrollAfterMessageRender(preserveScroll, scrollSnapshot, _scrollOpts);
       requestAnimationFrame(()=>postProcessRenderedMessages(inner));
       if(typeof _initMediaPlaybackObserver==='function') _initMediaPlaybackObserver();
       if(typeof loadTodos==='function'&&document.getElementById('panelTodos')&&document.getElementById('panelTodos').classList.contains('active')){loadTodos();}
@@ -10043,7 +10054,7 @@ function renderMessages(options){
   // (tool completion, session switch) must not override the user's scroll position.
   // scrollIfPinned() respects _scrollPinned, so it's a no-op if user scrolled up.
   if(typeof _syncLiveRunStatusAfterRender==='function') _syncLiveRunStatusAfterRender();
-  _scrollAfterMessageRender(preserveScroll, scrollSnapshot);
+  _scrollAfterMessageRender(preserveScroll, scrollSnapshot, _scrollOpts);
   // Apply syntax highlighting after DOM is built
   requestAnimationFrame(()=>postProcessRenderedMessages(inner));
   // Refresh todo panel if it's currently open

--- a/static/ui.js
+++ b/static/ui.js
@@ -8757,8 +8757,8 @@ function _restoreMessageScrollSnapshotSameFrame(snapshot, opts){
 }
 function _renderMessagesWithScrollSnapshot(options){
   const scrollSnapshot=_captureMessageScrollSnapshot();
-  renderMessages({...(options||{}),preserveScroll:true,adjustForTopGrowth:true});
-  _restoreMessageScrollSnapshotSameFrame(scrollSnapshot, { adjustForTopGrowth: true });
+  renderMessages({...(options||{}),preserveScroll:true});
+  _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
 }
 let _assistantTurnAnchorSettledFinalAnswerWarned=false;
 function _assistantTurnAnchorSettledFinalAnswer(message, content, context){

--- a/static/ui.js
+++ b/static/ui.js
@@ -8714,8 +8714,15 @@ function _restoreMessageScrollSnapshot(snapshot){
   const el=$('messages');
   if(!el||!snapshot) return;
   const maxTop=Math.max(0,el.scrollHeight-el.clientHeight);
+  // Proportional scroll adjustment: when DOM has grown/shrunk since the
+  // snapshot was taken (e.g. render window expansion prepended earlier
+  // messages), compensate scrollTop by the height delta so the user's
+  // visible message group stays in view.  Falls back to 0 delta (current
+  // behaviour) when snapshot.scrollHeight is absent.
+  const delta=el.scrollHeight-Number(snapshot.scrollHeight||el.scrollHeight);
+  const target=Math.max(0,Math.min((Number(snapshot.top)||0)+delta,maxTop));
   _programmaticScroll=true;
-  el.scrollTop=Math.max(0,Math.min(Number(snapshot.top)||0,maxTop));
+  el.scrollTop=target;
   // Sync _lastScrollTop after programmatic restore so sticky-unpin does not false-trigger (#1731).
   _lastScrollTop=el.scrollTop;
   requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
@@ -8727,7 +8734,7 @@ function _restoreMessageScrollSnapshotSameFrame(snapshot){
   const bottom=Number(snapshot.bottom);
   const target=(snapshot.pinned===true&&Number.isFinite(bottom))
     ? maxTop-Math.max(0,bottom)
-    : Number(snapshot.top)||0;
+    : Math.max(0,Math.min((Number(snapshot.top)||0)+(el.scrollHeight-Number(snapshot.scrollHeight||el.scrollHeight)),maxTop));
   _programmaticScroll=true;
   el.scrollTop=Math.max(0,Math.min(target,maxTop));
   _lastScrollTop=el.scrollTop;
@@ -8909,7 +8916,16 @@ function renderMessages(options){
       _preservedLiveTurn=_lt;
     }
   }
+  // DOM mutation (innerHTML='') clamps scrollTop and fires a synchronous
+  // native scroll event. Guard to prevent the listener from corrupting
+  // _scrollPinned / _messageUserUnpinned on this synthetic event.
+  // Reset immediately — the event fires synchronously, so there's no
+  // risk of leaking the guard past this statement.  Leaving the guard
+  // stuck true would silently discard real user scroll events during
+  // streaming when _scrollAfterMessageRender's scrollIfPinned() early-returns.
+  _programmaticScroll=true;
   inner.innerHTML='';
+  _programmaticScroll=false;
   const compressionNode=compressionState?_compressionCardsNode(compressionState):null;
   const {message:referenceMessage, rawIdx:referenceMessageRawIdx}=_latestCompressionReferenceMessage(
     S.messages,

--- a/tests/test_issue1690_scroll_completion.py
+++ b/tests/test_issue1690_scroll_completion.py
@@ -39,7 +39,7 @@ def test_terminal_done_render_preserves_manual_scroll_after_active_stream_is_cle
     done_block = _event_listener_body(MESSAGES_JS, "done")
 
     clear_idx = done_block.index("S.activeStreamId=null")
-    render_idx = done_block.index("renderMessages({preserveScroll:true})")
+    render_idx = done_block.index("renderMessages({preserveScroll:true,")
 
     assert clear_idx < render_idx, (
         "the done handler should clear stream liveness before the final render, "
@@ -55,10 +55,10 @@ def test_render_messages_preserve_scroll_option_uses_user_pin_state_not_stream_l
 
     assert "function renderMessages(options)" in render_body
     assert "const preserveScroll=!!(options&&options.preserveScroll);" in render_body
-    assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in render_body
+    assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot, _scrollOpts);" in render_body
     assert "const scrollSnapshot=(preserveScroll||(!_autoScrollFollow&&_messageUserUnpinned))?_captureMessageScrollSnapshot():null" in render_body
     assert "if(preserveScroll){\n    // Keep master's follow heuristic" in scroll_helper
-    assert "if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;\n    _restoreMessageScrollSnapshot(scrollSnapshot);\n    _maybeShowNewMessageScrollCue(scrollSnapshot);\n    return;\n  }" in scroll_helper
+    assert "if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;\n    _restoreMessageScrollSnapshot(scrollSnapshot, opts);\n    _maybeShowNewMessageScrollCue(scrollSnapshot);\n    return;\n  }" in scroll_helper
     assert "_shouldFollowMessagesOnDomReplace()" in follow_helper
     assert "scrollToBottom();" in follow_helper
     assert "if(S.activeStreamId){\n    scrollIfPinned();\n    return;\n  }" in scroll_helper
@@ -68,7 +68,7 @@ def test_cached_render_path_uses_same_scroll_policy_as_fresh_render():
     render_body = _function_body(UI_JS, "renderMessages")
     cached_branch = render_body[render_body.index("if(sid&&sid!==_sessionHtmlCacheSid") : render_body.index("const compressionState=")]
 
-    assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in cached_branch
+    assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot, _scrollOpts);" in cached_branch
     assert "if(S.activeStreamId){scrollIfPinned();}else{scrollToBottom();}" not in cached_branch
 
 

--- a/tests/test_issue3479_ios_stream_scroll_jump.py
+++ b/tests/test_issue3479_ios_stream_scroll_jump.py
@@ -85,7 +85,7 @@ def test_preserve_scroll_restores_reader_away_from_bottom_before_following():
 
     reader_idx = compact.index("constreaderAwayFromBottom=")
     follow_idx = compact.index("if(!readerAwayFromBottom&&!_messageUserUnpinned&&_followMessagesAfterDomReplace())return;")
-    restore_idx = compact.index("_restoreMessageScrollSnapshot(scrollSnapshot);")
+    restore_idx = compact.index("_restoreMessageScrollSnapshot(scrollSnapshot,opts);")
 
     assert "Number(scrollSnapshot.bottom)>250" in compact
     assert reader_idx < follow_idx < restore_idx

--- a/tests/test_issue3545_streaming_scroll_cue.py
+++ b/tests/test_issue3545_streaming_scroll_cue.py
@@ -35,8 +35,8 @@ def test_preserve_scroll_unpinned_branch_shows_new_message_cue_after_restore():
     # new-message cue. (Codex CORE catch: scrollIfPinned() in the pinned branch
     # could leave a pinned reader short of the settled response.)
     assert "if(!readerAwayFromBottom && !_messageUserUnpinned && _followMessagesAfterDomReplace()) return;" in helper
-    assert "_restoreMessageScrollSnapshot(scrollSnapshot);" in helper
-    assert helper.index("_restoreMessageScrollSnapshot(scrollSnapshot)") < helper.index(
+    assert "_restoreMessageScrollSnapshot(scrollSnapshot, opts);" in helper
+    assert helper.index("_restoreMessageScrollSnapshot(scrollSnapshot, opts)") < helper.index(
         "_maybeShowNewMessageScrollCue(scrollSnapshot)"
     )
     # The cue is only shown on the non-follow (restore) path, after the restore.

--- a/tests/test_issue677.py
+++ b/tests/test_issue677.py
@@ -40,7 +40,7 @@ class TestScrollPinningFix:
             "unconditional scrollToBottom() overrides user scroll position (#677)"
         )
         # scrollIfPinned must be called through the renderMessages scroll policy (stream path)
-        assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in rm_body
+        assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot, _scrollOpts);" in rm_body
         assert "scrollIfPinned()" in helper_body, (
             "renderMessages() must call scrollIfPinned() during streaming (#677)"
         )

--- a/tests/test_issue734_message_windowing.py
+++ b/tests/test_issue734_message_windowing.py
@@ -24,7 +24,7 @@ def test_load_earlier_expands_local_window_before_server_pagination_and_preserve
 
 
 def test_windowed_render_keeps_streaming_and_tool_activity_anchored_to_rendered_messages():
-    assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in UI_JS
+    assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot, _scrollOpts);" in UI_JS
     assert "const assistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);" in UI_JS
     assert "if(aIdx<assistantIdxs[0]) continue;" in UI_JS
     assert "const renderedAssistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);" in UI_JS

--- a/tests/test_stream_end_recovery_gating.py
+++ b/tests/test_stream_end_recovery_gating.py
@@ -91,7 +91,7 @@ def test_stream_end_fallback_helper_clears_owner_state_before_closing():
     assert "_clearOwnerInflightState();" in fn
     assert "_clearApprovalForOwner();" in fn
     assert "_clearClarifyForOwner('terminal');" in fn
-    assert "renderMessages({preserveScroll:true});" in fn
+    assert "renderMessages({preserveScroll:true,adjustForTopGrowth:true});" in fn
     assert "_setActivePaneIdleIfOwner();" in fn
     assert "_closeSource(source)" in fn
 

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -524,7 +524,7 @@ class TestDoneEventSmd:
         The live stream path can be visually at bottom while _scrollPinned was
         knocked false by history/windowing/layout preservation. On `done`, the
         live DOM is replaced with persisted messages; if the handler blindly calls
-        renderMessages({preserveScroll:true}) while the pin flag is false, the
+        renderMessages({preserveScroll:true,adjustForTopGrowth:true}) while the pin flag is false, the
         transcript can jump to the top. Capture bottom/follow intent before the
         replacement and explicitly bottom only for those users.
         """
@@ -535,7 +535,7 @@ class TestDoneEventSmd:
             "continue following before replacing the live DOM."
         )
         follow_idx = fn.index("shouldFollowOnDone")
-        render_idx = fn.index("renderMessages({preserveScroll:true})")
+        render_idx = fn.index("renderMessages({preserveScroll:true,adjustForTopGrowth:true})")
         assert follow_idx < render_idx, (
             "Follow intent must be captured before renderMessages() replaces the "
             "live transcript DOM."
@@ -574,7 +574,7 @@ class TestDoneEventSmd:
         """
         fn = self.get_fn()
         assert fn, "'done' handler not found"
-        done_before_render = fn[:fn.index("renderMessages({preserveScroll:true})")]
+        done_before_render = fn[:fn.index("renderMessages({preserveScroll:true,adjustForTopGrowth:true})")]
         assert "const hasMessageToolMetadata=S.messages.some" in done_before_render
         assert "!hasMessageToolMetadata&&d.session.tool_calls&&d.session.tool_calls.length" in done_before_render
         assert "S.toolCalls=hasMessageToolMetadata?[]:S.toolCalls.map" in done_before_render

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -110,15 +110,15 @@ def test_preserve_scroll_restores_unpinned_viewport_after_dom_rebuild():
 
     snapshot_idx = render.index("const scrollSnapshot=(preserveScroll||(!_autoScrollFollow&&_messageUserUnpinned))?_captureMessageScrollSnapshot():null")
     inner_idx = render.index("const inner=$('msgInner')")
-    final_scroll_idx = render.rindex("_scrollAfterMessageRender(preserveScroll, scrollSnapshot)")
+    final_scroll_idx = render.rindex("_scrollAfterMessageRender(preserveScroll, scrollSnapshot, _scrollOpts)")
 
     assert snapshot_idx < inner_idx < final_scroll_idx, (
         "renderMessages({preserveScroll:true}) must capture #messages.scrollTop before "
         "replacing transcript DOM, then pass that snapshot to the post-render scroll helper"
     )
     assert "if(!_messageUserUnpinned && _followMessagesAfterDomReplace()) return;" in after_render
-    assert "_restoreMessageScrollSnapshot(scrollSnapshot);\n    _maybeShowNewMessageScrollCue(scrollSnapshot);" in after_render
+    assert "_restoreMessageScrollSnapshot(scrollSnapshot, opts);\n    _maybeShowNewMessageScrollCue(scrollSnapshot);" in after_render
     assert "_shouldFollowMessagesOnDomReplace()" in follow
     assert "scrollToBottom();" in follow
-    assert "el.scrollTop=Math.max(0,Math.min(Number(snapshot.top)||0,maxTop))" in restore
+    assert "const target=Math.max(0,Math.min((Number(snapshot.top)||0)+delta,maxTop));" in restore
     assert "_programmaticScroll=true" in restore


### PR DESCRIPTION
## Release NO — v0.51.402 — Proportional scroll restoration after render-window growth (opt-in) (#4110)

Absorbs **#4110** (@PINKIIILQWQ), re-reviewed after the contributor scoped the fix + I closed the last finding. Fixes the viewport jumping to an earlier part of a long chat when a streamed reply finishes and the render window grows.

### Gate (re-review of the fixed version — all 3 of my findings now closed)
- ✅ **Delta double-adjust CLOSED** — the scrollHeight-delta restore is now **opt-in** via `adjustForTopGrowth`, so older-history paging (already compensates) and bottom-growth live-compression `SameFrame` restores don't double-adjust.
- ✅ **Stuck-flag CLOSED** — `_programmaticScroll` reset on all exit paths after the `innerHTML` clear.
- ✅ **Over-fetch CLOSED** (I applied the last one-liner): `_loadOlderMessages` `requestedLimit` now sizes from `_currentLoadedRenderableMessageCount()` not raw `S.messages.length`, so a tool-heavy history doesn't over-request.
- Merged cleanly with the #4124 `readerAwayFromBottom` guard (combined, not dropped); re-anchored 4 scroll tests to the `opts`-threaded signature.
- **Codex: SAFE TO SHIP** (no new loop/under-fetch, opt-in callers verified). ESLint clean. (Local full-suite cascade today is the known `test_workspace_upload`/`test_onboarding` process-group artifact — scroll tests pass in isolation; relying on CI's isolated 3-shard run.)

Thanks @PINKIIILQWQ.