### PR TITLE
feat(launchd): add plist, install/uninstall/status scripts, and docs for macOS auto-start

### DIFF
--- a/docs/macos-launchd.md
+++ b/docs/macos-launchd.md
@@ -1,0 +1,91 @@
+# hermes-webui macOS launchd 자동 시작
+
+macOS 로그인 시 hermes-webui 서버를 자동으로 시작하려면 `launchd`를 사용합니다.
+
+## launchd vs ctl.sh
+
+`launchd`와 `ctl.sh`는 **둘 중 하나만 활성화**해야 합니다. 같은 포트에서 두 프로세스가 충돌하는 것을 방지하기 위해 `ctl.sh`는 launchd job을 감지하면 시작을 거부합니다.
+
+| 방식 | 시작 방법 | 관리 |
+|------|-----------|------|
+| launchd | 로그인 시 자동 (`RunAtLoad`) + `KeepAlive`로 크래시 복구 | `launchctl` 명령어 |
+| ctl.sh | 수동 `./ctl.sh start` | `./ctl.sh stop/restart/status` |
+
+## 설치
+
+```bash
+# plist를 ~/Library/LaunchAgents/에 설치 (load는 하지 않음)
+./scripts/launchd/install.sh
+
+# 설치 후 수동으로 load (macOS Ventura+):
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.parantoux.hermes-webui.plist
+
+# 또는 구형 macOS:
+launchctl load ~/Library/LaunchAgents/com.parantoux.hermes-webui.plist
+```
+
+## 상태 확인
+
+```bash
+# launchd job 상태 + 서버 health check (한국어 요약)
+./scripts/launchd/status.sh
+
+# ctl.sh로도 확인 가능 (launchd가 관리 중일 때는 PID/cgroup 정보가 다를 수 있음)
+./ctl.sh status
+```
+
+## launchd 사용 중 수동 재시작
+
+```bash
+# launchd job을 강제로 재시작 (프로세스를 kill하고 다시 spawn)
+launchctl kickstart -k gui/$(id -u)/com.parantoux.hermes-webui
+```
+
+`./ctl.sh restart`는 **사용하지 마세요** — launchd가 관리 중일 때 ctl.sh는 충돌을 감지하고 거부합니다.
+
+## launchd에서 ctl.sh로 전환
+
+```bash
+# 1. launchd job 중지 및 등록 해제 (macOS Ventura+):
+launchctl bootout gui/$(id -u)/com.parantoux.hermes-webui
+
+# 또는 구형 macOS:
+launchctl unload ~/Library/LaunchAgents/com.parantoux.hermes-webui.plist
+
+# 2. ctl.sh로 시작:
+./ctl.sh start
+```
+
+## ctl.sh에서 launchd로 전환
+
+```bash
+# 1. ctl.sh로 중지:
+./ctl.sh stop
+
+# 2. launchd job 등록 및 시작:
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.parantoux.hermes-webui.plist
+```
+
+## 제거
+
+```bash
+# plist 파일 제거 + 수동 unload 명령어 안내 (실제 unload는 실행하지 않음)
+./scripts/launchd/uninstall.sh
+```
+
+## 충돌 감지 동작 방식
+
+`ctl.sh`의 `start_cmd()`는 시작 전에 `launchctl print gui/$(id -u)/com.parantoux.hermes-webui`를 조회합니다. 동일 포트(8788)에서 실행 중인 launchd job이 있으면:
+
+```
+[ctl] Refusing to start a second Hermes WebUI while launchd job com.parantoux.hermes-webui is running (PID 12345).
+[ctl] Use launchctl kickstart -k gui/501/com.parantoux.hermes-webui or disable the launchd job before using ctl.sh start.
+```
+
+와 같이 거부 메시지를 출력하고 종료 코드 2로 빠져나갑니다. `HERMES_WEBUI_CTL_ALLOW_LAUNCHD_CONFLICT=1`이 설정된 환경(launchd plist에서 설정됨)에서는 launchd 자신이 이 검사를 건너뛰므로 launchd job 자체는 정상 동작합니다.
+
+## 문제 해결
+
+- **로그 확인**: `tail -f ~/.hermes/webui.log`
+- **launchd job이 안 뜰 때**: `launchctl print gui/$(id -u)/com.parantoux.hermes-webui`로 상태/종료 코드 확인
+- **포트 충돌**: `lsof -iTCP:8788 -sTCP:LISTEN`으로 어떤 프로세스가 포트를 점유 중인지 확인

--- a/scripts/launchd/com.parantoux.hermes-webui.plist
+++ b/scripts/launchd/com.parantoux.hermes-webui.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.parantoux.hermes-webui</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/jinwoo/hermes-webui/bootstrap.py</string>
+        <string>--no-browser</string>
+        <string>--foreground</string>
+        <string>--host</string>
+        <string>127.0.0.1</string>
+        <string>8788</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/jinwoo/.hermes/webui.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/jinwoo/.hermes/webui.log</string>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/jinwoo/hermes-webui</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>/Users/jinwoo/.hermes</string>
+        <key>HERMES_WEBUI_HOST</key>
+        <string>127.0.0.1</string>
+        <key>HERMES_WEBUI_PORT</key>
+        <string>8788</string>
+        <key>HERMES_WEBUI_STATE_DIR</key>
+        <string>/Users/jinwoo/.hermes/webui</string>
+        <key>HERMES_WEBUI_LOG_FILE</key>
+        <string>/Users/jinwoo/.hermes/webui.log</string>
+        <key>HERMES_WEBUI_PID_FILE</key>
+        <string>/Users/jinwoo/.hermes/webui.pid</string>
+        <key>HERMES_WEBUI_PRESERVE_ENV</key>
+        <string>1</string>
+        <key>HERMES_WEBUI_CTL_ALLOW_LAUNCHD_CONFLICT</key>
+        <string>1</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# install.sh — Install the hermes-webui launchd plist into ~/Library/LaunchAgents/
+#
+# What it does:
+#   1. Backs up any existing identically-named plist to ~/.hermes/backups/launchd-YYYYMMDD-HHMMSS/
+#   2. Copies the plist to ~/Library/LaunchAgents/com.parantoux.hermes-webui.plist
+#   3. Prints the manual command to load the job — does NOT execute launchctl bootstrap/load
+#
+# Usage: ./scripts/launchd/install.sh
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST_SRC="${REPO_ROOT}/scripts/launchd/com.parantoux.hermes-webui.plist"
+PLIST_DST="${HOME}/Library/LaunchAgents/com.parantoux.hermes-webui.plist"
+BACKUP_BASE="${HOME}/.hermes/backups"
+TIMESTAMP="$(date '+%Y%m%d-%H%M%S')"
+BACKUP_DIR="${BACKUP_BASE}/launchd-${TIMESTAMP}"
+
+echo "=== hermes-webui launchd installer ==="
+echo ""
+
+# --- Validate source plist exists ---
+if [[ ! -f "${PLIST_SRC}" ]]; then
+    echo "[install] ERROR: plist not found at ${PLIST_SRC}" >&2
+    exit 1
+fi
+
+# --- Backup existing plist if present ---
+if [[ -f "${PLIST_DST}" ]]; then
+    echo "[install] Existing plist found at ${PLIST_DST}"
+    mkdir -p "${BACKUP_DIR}"
+    cp "${PLIST_DST}" "${BACKUP_DIR}/"
+    echo "[install]   → backed up to ${BACKUP_DIR}/"
+else
+    echo "[install] No existing plist to back up."
+fi
+
+# --- Copy plist to LaunchAgents ---
+mkdir -p "$(dirname "${PLIST_DST}")"
+cp "${PLIST_SRC}" "${PLIST_DST}"
+echo "[install] Plist installed to ${PLIST_DST}"
+
+echo ""
+
+# --- Print manual activation instructions ---
+echo "=== Manual activation (run these yourself when ready) ==="
+echo ""
+echo "  # Load and start the launchd job:"
+echo "  launchctl bootstrap gui/\$(id -u) ${PLIST_DST}"
+echo ""
+echo "  # Or, on older macOS (pre-Ventura):"
+echo "  launchctl load ${PLIST_DST}"
+echo ""
+echo "  # Verify it's running:"
+echo "  launchctl print gui/\$(id -u)/com.parantoux.hermes-webui"
+echo "  curl http://127.0.0.1:8788/health"
+echo ""
+echo "  # To uninstall later, run:"
+echo "  ${REPO_ROOT}/scripts/launchd/uninstall.sh"

--- a/scripts/launchd/status.sh
+++ b/scripts/launchd/status.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# status.sh — Show the status of the hermes-webui launchd job
+#
+# Runs launchctl print (read-only — no side effects) and curl health check.
+#
+# Usage: ./scripts/launchd/status.sh
+
+LABEL="com.parantoux.hermes-webui"
+UID_NOW="$(id -u)"
+SERVICE="gui/${UID_NOW}/${LABEL}"
+
+echo "=== hermes-webui launchd 상태 ==="
+echo ""
+
+# --- launchctl print ---
+if ! launchd_out="$(launchctl print "${SERVICE}" 2>/dev/null)"; then
+    echo "launchd 작업을 찾을 수 없습니다 (${SERVICE})"
+    echo ""
+    echo "plist가 설치되어 있고 load 되었는지 확인:"
+    echo "  install:  ./scripts/launchd/install.sh"
+    echo "  load:     launchctl bootstrap gui/\$(id -u) ~/Library/LaunchAgents/${LABEL}.plist"
+else
+    # Parse key fields
+    pid="$(printf '%s\n' "${launchd_out}" | awk '/^[[:space:]]*pid = / {print $3; exit}')"
+    state="$(printf '%s\n' "${launchd_out}" | awk '/^[[:space:]]*state = / {print $3; exit}')"
+    last_exit="$(printf '%s\n' "${launchd_out}" | awk '/^[[:space:]]*last exit code = / {print $5; exit}')"
+
+    echo "● launchd 작업: ${SERVICE}"
+    echo "  상태(state): ${state:-unknown}"
+    if [[ -n "${pid}" && "${pid}" =~ ^[0-9]+$ ]]; then
+        echo "  PID:         ${pid}"
+        if uptime="$(ps -p "${pid}" -o etime= 2>/dev/null | sed 's/^ *//')"; then
+            echo "  가동 시간:   ${uptime}"
+        fi
+    fi
+    if [[ -n "${last_exit}" ]]; then
+        echo "  마지막 종료 코드: ${last_exit}"
+    fi
+
+    # Full print output for debugging
+    echo ""
+    echo "--- launchctl print 전체 출력 ---"
+    printf '%s\n' "${launchd_out}"
+fi
+
+echo ""
+
+# --- Health check ---
+HEALTH_URL="http://127.0.0.1:8788/health"
+echo "--- 서버 health check (${HEALTH_URL}) ---"
+if command -v curl >/dev/null 2>&1; then
+    if result="$(curl -fsS --max-time 3 "${HEALTH_URL}" 2>/dev/null)"; then
+        echo "● 서버 응답: OK"
+        if command -v python3 >/dev/null 2>&1; then
+            printf '%s' "${result}" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    sessions = data.get("sessions", data.get("session_count", "?"))
+    active = data.get("active_streams", "?")
+    status = data.get("status", "ok")
+    print(f"  세션: {sessions}, 활성 스트림: {active}")
+    print(f"  상태: {status}")
+except Exception:
+    print("  (JSON 파싱 실패 — 원시 응답 보존)")
+    print(sys.stdin.read())
+' 2>/dev/null || true
+        fi
+    else
+        echo "● 서버 응답 없음 — 서버가 실행 중이 아닐 수 있습니다"
+    fi
+else
+    echo "  curl이 설치되어 있지 않아 health check를 건너뜁니다"
+fi
+
+echo ""
+echo "--- 수동 조작 ---"
+echo "  재시작:  launchctl kickstart -k ${SERVICE}"
+echo "  중지:    launchctl bootout ${SERVICE}"
+echo "  ctl.sh:  ./ctl.sh status"

--- a/scripts/launchd/uninstall.sh
+++ b/scripts/launchd/uninstall.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# uninstall.sh — Remove the hermes-webui launchd plist from ~/Library/LaunchAgents/
+#
+# What it does:
+#   1. Prints the manual unload commands — does NOT execute launchctl bootout/unload
+#   2. Removes the plist file from ~/Library/LaunchAgents/
+#
+# Usage: ./scripts/launchd/uninstall.sh
+
+PLIST_DST="${HOME}/Library/LaunchAgents/com.parantoux.hermes-webui.plist"
+LABEL="com.parantoux.hermes-webui"
+UID_NOW="$(id -u)"
+
+echo "=== hermes-webui launchd uninstaller ==="
+echo ""
+
+if [[ ! -f "${PLIST_DST}" ]]; then
+    echo "[uninstall] No plist found at ${PLIST_DST} — nothing to remove."
+    exit 0
+fi
+
+# --- Print manual unload instructions ---
+echo "[uninstall] Before removing the file, stop the launchd job manually:"
+echo ""
+echo "  # Stop and unregister the job (macOS Ventura+):"
+echo "  launchctl bootout gui/${UID_NOW}/${LABEL}"
+echo ""
+echo "  # Or, on older macOS (pre-Ventura):"
+echo "  launchctl unload ${PLIST_DST}"
+echo ""
+echo "  # Verify it's gone:"
+echo "  launchctl print gui/${UID_NOW}/${LABEL}"
+echo ""
+
+# --- Remove the plist file ---
+rm -f "${PLIST_DST}"
+echo "[uninstall] Removed ${PLIST_DST}"
+echo "[uninstall] Done. The job has been unregistered from the filesystem."
+echo "[uninstall] If the job was still loaded, run the manual unload command above."


### PR DESCRIPTION
# feat(launchd): add plist, install/uninstall/status scripts, and docs for macOS auto-start

## Summary

Adds a macOS `launchd` KeepAlive job so that `hermes-webui` can start automatically at login, while keeping the existing `./ctl.sh` manual path intact and conflict-aware.

## What changed

- `scripts/launchd/com.parantoux.hermes-webui.plist`
  - Label: `com.parantoux.hermes-webui`
  - Runs `bootstrap.py --no-browser --foreground --host 127.0.0.1 8788`
  - `RunAtLoad` + `KeepAlive` for login-time auto start and crash recovery
  - Environment variables required by `ctl.sh` / `bootstrap.py`, including `HERMES_WEBUI_CTL_ALLOW_LAUNCHD_CONFLICT=1` so the launchd job itself is not rejected by `ctl.sh`'s conflict check
  - No secrets/API keys in the plist
- `scripts/launchd/install.sh`
  - Backs up any existing plist to `~/.hermes/backups/launchd-YYYYMMDD-HHMMSS/`
  - Copies the plist to `~/Library/LaunchAgents/`
  - Prints manual `launchctl bootstrap` / `launchctl load` commands; does **not** execute them
- `scripts/launchd/uninstall.sh`
  - Prints manual `launchctl bootout` / `launchctl unload` commands; does **not** execute them
  - Removes the plist file from `~/Library/LaunchAgents/`
- `scripts/launchd/status.sh`
  - Read-only status via `launchctl print ...`
  - Korean summary plus `curl http://127.0.0.1:8788/health` check
- `docs/macos-launchd.md`
  - How to switch between `launchd` and `./ctl.sh`
  - Manual activation / kickstart / bootout instructions
  - Notes that `ctl.sh` refuses to start when the launchd job is running on the same port

## Verification

- `install.sh` contains no `launchctl bootstrap` / `load` execution lines
- `uninstall.sh` contains no `launchctl bootout` / `unload` execution
- `ctl.sh` launchd conflict logic is unchanged (`git diff` empty for `ctl.sh`)
- Plist contains no API key / secret / token / password values
- All three helper scripts have execute permissions
- `install.sh` dry-run prints correct manual activation instructions
- `http://127.0.0.1:8788/health` responds with `status: ok`

## Activation notice

**This PR only writes files. The actual launchd job is NOT loaded automatically.**  
After review/merge, load it manually with:

```bash
launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.parantoux.hermes-webui.plist
# or on older macOS:
launchctl load ~/Library/LaunchAgents/com.parantoux.hermes-webui.plist
```

## Related work

- hermes-desktop README update (server-first connection guide) is being prepared in a separate PR.
- Ticket: `/Users/jinwoo/development/agent-room/docs/ticket/2026-06-14-hermes-webui-autostart.md`

## Merge policy

Merge by 진우형 / 민철형 / 지훈형 / 현수형 only.
