### PR TITLE
fix(sse): close global sidebar streams on PWA window blur (#4151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Multiple PWA windows no longer saturate the connection pool and cycle "Request timed out" toasts (#4151).** The idle-SSE close added in #3992/#3996 keyed off the Page Visibility API (`visibilitychange` / `document.hidden`), but a PWA *standalone* window does not reliably fire `visibilitychange` when it loses focus to another window of the same app — `document.hidden` only flips on minimize. So two side-by-side PWA windows both stayed `visible`, each held its two global sidebar SSE streams open (session-events + gateway), and 2×3 = 6 connections hit the browser's per-origin HTTP/1.1 limit; subsequent `fetch()` calls (the 30s background polls) queued behind the saturated pool and timed out. The two global sidebar streams now also close on a sustained window `blur` (gated on `document.hasFocus()`, the signal `visibilitychange` misses) and reopen — catching up the session list — on `focus`. The per-session live stream is intentionally left visibility-only so an unfocused-but-visible window still receives live `bg_task_complete` / `server_turn_started` events. (#4151)
+
 ## [v0.51.403] — 2026-06-13 — Release NP (notification click reuses the existing chat tab, #4109)
 
 ### Fixed

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3645,6 +3645,62 @@ function _scheduleSessionEventsRefresh(reason){
   }, 300);
 }
 
+// ── #4151: focus-aware close for the two GLOBAL sidebar SSE streams ──────────
+// Each WebUI window holds up to three persistent SSE connections (session-events
+// + gateway + the per-session stream). #3992/#3996 close them on the Page
+// Visibility API (`visibilitychange` / `document.hidden`) so a hidden tab frees
+// HTTP/1.1 pool slots. But a PWA *standalone* window does NOT reliably fire
+// `visibilitychange` when it merely loses focus to another window of the same
+// app — `document.hidden` only flips on minimize. So two side-by-side PWA windows
+// both stay `visibilityState==='visible'`, each keeps its sidebar streams open,
+// and 2x3 = 6 = the per-origin HTTP/1.1 connection limit; every later fetch()
+// (the 30s polls) queues behind the saturated pool and times out (#4151).
+// `document.hasFocus()` is the signal `visibilitychange` misses — only one window
+// holds focus at a time.
+//
+// Scope: ONLY the two global sidebar streams (session-events + gateway). The
+// per-session live stream (messages.js `startSessionStream`) deliberately stays
+// visibility-only — it carries live `bg_task_complete` toasts and
+// `server_turn_started` live-view that an unfocused-but-VISIBLE window must still
+// receive (the OS-notification path is gated on `document.hidden`, so the in-app
+// toast is the only completion signal a visible-unfocused window gets). Closing
+// it on blur would regress the multi-window live-view UX.
+function _sidebarSseBackgrounded(){
+  if(typeof document === 'undefined') return false;
+  if(document.hidden) return true;
+  if(typeof document.hasFocus === 'function' && !document.hasFocus()) return true;
+  return false;
+}
+
+let _sidebarSseBlurCloseTimer = 0;
+// Debounce the blur-close so a transient blur (native dialog, quick alt-tab and
+// back) doesn't thrash the streams; a sustained blur frees the pool slots.
+const _SIDEBAR_SSE_BLUR_CLOSE_MS = 1000;
+
+function _installSidebarSseFocusHook(){
+  if(typeof window === 'undefined' || typeof document === 'undefined') return;
+  if(document._hermesSidebarSseFocusHook) return;
+  document._hermesSidebarSseFocusHook = true;
+  window.addEventListener('blur', () => {
+    if(_sidebarSseBlurCloseTimer) return;
+    _sidebarSseBlurCloseTimer = setTimeout(() => {
+      _sidebarSseBlurCloseTimer = 0;
+      // Re-check at fire time — focus may have returned during the debounce.
+      if(_sidebarSseBackgrounded()){
+        _closeSessionEventsSSE();
+        stopGatewaySSE();
+      }
+    }, _SIDEBAR_SSE_BLUR_CLOSE_MS);
+  });
+  window.addEventListener('focus', () => {
+    if(_sidebarSseBlurCloseTimer){ clearTimeout(_sidebarSseBlurCloseTimer); _sidebarSseBlurCloseTimer = 0; }
+    // Reopen (both ensure-idempotent) and catch up on anything missed while blurred.
+    ensureSessionEventsSSE();
+    startGatewaySSE();
+    void refreshSessionList('focus');
+  });
+}
+
 function _closeSessionEventsSSE(){
   if(_sessionEventsSSE){
     _sessionEventsSSE.close();
@@ -3664,8 +3720,9 @@ function ensureSessionEventsSSE(){
     });
     document._hermesSessionEventsVisibilityHook = true;
   }
+  _installSidebarSseFocusHook();
   if(typeof EventSource==='undefined') return;
-  if(typeof document !== 'undefined' && document.hidden) return;
+  if(_sidebarSseBackgrounded()) return;
   if(_sessionEventsSSE) return;
   try{
     // Same-origin relative URL preserves subpath mounts and normal WebUI cookies.
@@ -3788,8 +3845,10 @@ function startGatewaySSE(){
     });
     document._hermesGatewaySSEVisibilityHook = true;
   }
-  // Don't open when tab is hidden — saves connection pool slots
-  if(typeof document !== 'undefined' && document.hidden) return;
+  _installSidebarSseFocusHook();
+  // Don't open when tab is hidden OR the window has lost focus (PWA blur) —
+  // saves connection pool slots (#4151).
+  if(_sidebarSseBackgrounded()) return;
   try{
     _gatewaySSE = new EventSource('api/sessions/gateway/stream');
     _gatewaySSE.addEventListener('sessions_changed', (ev) => {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3694,9 +3694,16 @@ function _installSidebarSseFocusHook(){
   });
   window.addEventListener('focus', () => {
     if(_sidebarSseBlurCloseTimer){ clearTimeout(_sidebarSseBlurCloseTimer); _sidebarSseBlurCloseTimer = 0; }
-    // Reopen (both ensure-idempotent) and catch up on anything missed while blurred.
+    // Reopen and catch up on anything missed while blurred. ensureSessionEventsSSE()
+    // is idempotent (`if(_sessionEventsSSE) return`), but startGatewaySSE() is NOT — it
+    // begins with an unconditional stopGatewaySSE(). So only reopen the gateway when it
+    // was actually closed; otherwise a transient blur shorter than the debounce (where
+    // the blur-close timer was cleared and the stream was never torn down) would
+    // drop+reconnect the live gateway on every window switch, cancelling its poll
+    // fallback and resetting probe/warning state — the exact thrash the debounce exists
+    // to prevent, in the multi-window scenario this fix targets (#4151).
     ensureSessionEventsSSE();
-    startGatewaySSE();
+    if(!_gatewaySSE) startGatewaySSE();
     void refreshSessionList('focus');
   });
 }

--- a/tests/test_issue4151_pwa_focus_sse.py
+++ b/tests/test_issue4151_pwa_focus_sse.py
@@ -1,0 +1,135 @@
+"""Structural tests for #4151 — PWA two-window connection-pool saturation.
+
+#3992/#3996 close the idle SSE streams on the Page Visibility API
+(`visibilitychange` / `document.hidden`). But a PWA *standalone* window does NOT
+reliably fire `visibilitychange` when it loses focus to another window of the
+same app — `document.hidden` only flips on minimize. So two side-by-side PWA
+windows both stay `visibilityState==='visible'`, each holds its sidebar SSE
+streams open, and 2x3 = 6 = the per-origin HTTP/1.1 connection limit; every
+later fetch() queues behind the saturated pool and times out (#4151).
+
+The fix makes the two GLOBAL sidebar streams (session-events + gateway) also
+close on window `blur` (gated on `document.hasFocus()`, the signal
+`visibilitychange` misses) and reopen on `focus`, via a shared
+`_sidebarSseBackgrounded()` predicate and a debounced `_installSidebarSseFocusHook()`.
+
+CRITICAL SCOPE GUARD (the regression these tests lock): the PER-SESSION live
+stream (`startSessionStream` in messages.js) must stay visibility-only and must
+NOT be torn down on blur — it carries live `bg_task_complete` toasts +
+`server_turn_started` live-view that an unfocused-but-VISIBLE window must still
+receive. So the focus hook lives in sessions.js and only touches
+`_closeSessionEventsSSE()` + `stopGatewaySSE()`.
+
+Source-grep checks (the hooks live in static JS with no server round trip).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def test_backgrounded_predicate_uses_hasfocus_not_only_hidden():
+    """_sidebarSseBackgrounded() must consult document.hasFocus(), not only document.hidden.
+
+    document.hidden alone is exactly what misses the PWA blur case; the predicate
+    has to treat a visible-but-unfocused window as backgrounded.
+    """
+    assert "function _sidebarSseBackgrounded()" in SESSIONS_JS
+    start = SESSIONS_JS.find("function _sidebarSseBackgrounded()")
+    block = SESSIONS_JS[start:start + 320]
+    assert "document.hidden" in block
+    assert "document.hasFocus" in block
+    assert "!document.hasFocus()" in block
+
+
+def test_focus_hook_closes_both_global_sidebar_streams():
+    """The blur path closes the session-events AND gateway streams."""
+    assert "function _installSidebarSseFocusHook()" in SESSIONS_JS
+    start = SESSIONS_JS.find("function _installSidebarSseFocusHook()")
+    block = SESSIONS_JS[start:start + 1100]
+    # Installed once.
+    assert "_hermesSidebarSseFocusHook" in block
+    # Blur listener tears down both global streams.
+    assert "window.addEventListener('blur'" in block
+    assert "_closeSessionEventsSSE()" in block
+    assert "stopGatewaySSE()" in block
+    # Focus listener reopens both and refreshes the list.
+    assert "window.addEventListener('focus'" in block
+    assert "ensureSessionEventsSSE()" in block
+    assert "startGatewaySSE()" in block
+
+
+def test_blur_close_is_debounced_and_rechecks_focus_at_fire_time():
+    """A transient blur must not thrash the streams.
+
+    The blur close is scheduled on a timer and re-checks _sidebarSseBackgrounded()
+    when it fires, so focus returning during the debounce cancels the teardown.
+    """
+    start = SESSIONS_JS.find("function _installSidebarSseFocusHook()")
+    block = SESSIONS_JS[start:start + 1100]
+    assert "_sidebarSseBlurCloseTimer" in block
+    assert "setTimeout(" in block
+    # Re-check guards the actual close so a returned focus is a no-op.
+    assert "if(_sidebarSseBackgrounded()){" in block
+    # Focus listener clears any pending blur-close timer.
+    assert "clearTimeout(_sidebarSseBlurCloseTimer)" in block
+
+
+def test_session_events_open_guard_uses_backgrounded_predicate():
+    """ensureSessionEventsSSE installs the focus hook and gates open on the predicate."""
+    start = SESSIONS_JS.find("function ensureSessionEventsSSE()")
+    assert start != -1
+    block = SESSIONS_JS[start:start + 700]
+    assert "_installSidebarSseFocusHook()" in block
+    # Open guard is the focus-aware predicate, not the old hidden-only check.
+    assert "if(_sidebarSseBackgrounded()) return;" in block
+
+
+def test_gateway_open_guard_uses_backgrounded_predicate():
+    """startGatewaySSE installs the focus hook and gates open on the predicate."""
+    start = SESSIONS_JS.find("function startGatewaySSE()")
+    assert start != -1
+    block = SESSIONS_JS[start:start + 700]
+    assert "_installSidebarSseFocusHook()" in block
+    assert "if(_sidebarSseBackgrounded()) return;" in block
+
+
+def test_per_session_stream_NOT_closed_on_blur():
+    """REGRESSION GUARD: the per-session live stream must stay visibility-only.
+
+    startSessionStream carries live bg_task_complete toasts + server_turn_started
+    live-view that an unfocused-but-visible window must still get. The focus hook
+    must NOT tear it down, so:
+      (a) messages.js must not add a window 'blur' listener that calls stopSessionStream, and
+      (b) the focus hook in sessions.js must not reference stopSessionStream/startSessionStream.
+    """
+    # (a) the per-session stream file must not tear down the stream on blur.
+    #     (A pre-existing composer speech-synthesis blur handler on _msgEl is
+    #     fine — the guard is specifically that no blur path calls
+    #     stopSessionStream.) Scan each blur-listener body in messages.js.
+    import re
+    for m in re.finditer(r"addEventListener\(\s*['\"]blur['\"]", MESSAGES_JS):
+        tail = MESSAGES_JS[m.start():m.start() + 200]
+        assert "stopSessionStream" not in tail, (
+            "a blur listener in messages.js tears down the per-session stream — "
+            "that regresses live bg_task_complete / server_turn_started for an "
+            "unfocused-but-visible window (#4151 scope guard)"
+        )
+    # (b) the sidebar focus hook only manages the two global streams.
+    start = SESSIONS_JS.find("function _installSidebarSseFocusHook()")
+    block = SESSIONS_JS[start:start + 1100]
+    assert "stopSessionStream" not in block
+    assert "startSessionStream" not in block
+
+
+def test_per_session_stream_still_visibility_gated():
+    """Sanity: the per-session stream keeps its existing visibility hook untouched."""
+    assert "_hermesSessionStreamVisibilityHook" in MESSAGES_JS
+    start = MESSAGES_JS.find("function startSessionStream(sid)")
+    block = MESSAGES_JS[start:start + 1700]
+    assert "visibilitychange" in block
+    assert "document.hidden" in block

--- a/tests/test_issue4151_pwa_focus_sse.py
+++ b/tests/test_issue4151_pwa_focus_sse.py
@@ -50,7 +50,7 @@ def test_focus_hook_closes_both_global_sidebar_streams():
     """The blur path closes the session-events AND gateway streams."""
     assert "function _installSidebarSseFocusHook()" in SESSIONS_JS
     start = SESSIONS_JS.find("function _installSidebarSseFocusHook()")
-    block = SESSIONS_JS[start:start + 1100]
+    block = SESSIONS_JS[start:start + 1700]
     # Installed once.
     assert "_hermesSidebarSseFocusHook" in block
     # Blur listener tears down both global streams.
@@ -70,13 +70,41 @@ def test_blur_close_is_debounced_and_rechecks_focus_at_fire_time():
     when it fires, so focus returning during the debounce cancels the teardown.
     """
     start = SESSIONS_JS.find("function _installSidebarSseFocusHook()")
-    block = SESSIONS_JS[start:start + 1100]
+    block = SESSIONS_JS[start:start + 1700]
     assert "_sidebarSseBlurCloseTimer" in block
     assert "setTimeout(" in block
     # Re-check guards the actual close so a returned focus is a no-op.
     assert "if(_sidebarSseBackgrounded()){" in block
     # Focus listener clears any pending blur-close timer.
     assert "clearTimeout(_sidebarSseBlurCloseTimer)" in block
+
+
+def test_focus_reopen_does_not_thrash_the_gateway_stream():
+    """The focus handler must NOT unconditionally restart the gateway stream.
+
+    startGatewaySSE() begins with an unconditional stopGatewaySSE() (it is NOT
+    idempotent, unlike ensureSessionEventsSSE()'s `if(_sessionEventsSSE) return`).
+    On a transient blur shorter than the 1s debounce, the blur-close timer is
+    cleared and the gateway stream is never torn down — so an unconditional
+    startGatewaySSE() on the following focus would drop+reconnect the live gateway,
+    cancel its poll fallback, and reset probe/warning state on every window switch
+    (the exact thrash the debounce exists to prevent, in the multi-window scenario
+    #4151 targets). The reopen must therefore be guarded on the gateway actually
+    being closed. (greptile P1.)
+    """
+    start = SESSIONS_JS.find("function _installSidebarSseFocusHook()")
+    block = SESSIONS_JS[start:start + 1700]
+    focus_idx = block.find("window.addEventListener('focus'")
+    assert focus_idx != -1
+    focus_body = block[focus_idx:]
+    # The gateway reopen is guarded on the stream being closed (mirrors the
+    # session-events idempotency), not called unconditionally.
+    assert "if(!_gatewaySSE) startGatewaySSE()" in focus_body, (
+        "focus handler must guard startGatewaySSE() on `!_gatewaySSE` so a "
+        "transient blur+focus does not drop+reconnect a still-open gateway stream"
+    )
+    # And it must NOT call startGatewaySSE() bare (unguarded) on focus.
+    assert "\n    startGatewaySSE();" not in focus_body
 
 
 def test_session_events_open_guard_uses_backgrounded_predicate():
@@ -121,7 +149,7 @@ def test_per_session_stream_NOT_closed_on_blur():
         )
     # (b) the sidebar focus hook only manages the two global streams.
     start = SESSIONS_JS.find("function _installSidebarSseFocusHook()")
-    block = SESSIONS_JS[start:start + 1100]
+    block = SESSIONS_JS[start:start + 1700]
     assert "stopSessionStream" not in block
     assert "startSessionStream" not in block
 

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -47,7 +47,10 @@ def test_session_list_external_refresh_uses_sse_invalidation_not_polling():
     assert "ensureSessionEventsSSE();" in SESSIONS_JS
     assert "document._hermesSessionEventsVisibilityHook" in SESSIONS_JS
     ensure_fn = SESSIONS_JS[SESSIONS_JS.find("function ensureSessionEventsSSE()") :]
-    assert ensure_fn.find("document._hermesSessionEventsVisibilityHook") < ensure_fn.find("document.hidden) return")
+    # The visibility hook must be installed before the open-guard early-return.
+    # #4151 replaced the `document.hidden) return` open guard with the focus-aware
+    # `_sidebarSseBackgrounded()) return` predicate (which also covers PWA blur).
+    assert ensure_fn.find("document._hermesSessionEventsVisibilityHook") < ensure_fn.find("_sidebarSseBackgrounded()) return")
     assert "_sessionListExternalRefreshMs" not in SESSIONS_JS
     assert "addEventListener('sessions_changed', (ev) => {" in ensure_fn
     assert "const activeProfile = S.activeProfile || 'default';" in ensure_fn


### PR DESCRIPTION
## Summary

Fixes #4151 — two side-by-side PWA windows saturate the browser's per-origin HTTP/1.1 connection pool, causing **"Request timed out"** toasts to cycle every ~30s.

Reported by @ddiall with a thorough, accurate root-cause analysis.

## Root cause (confirmed against `master`)

Each WebUI window opens up to **three** persistent SSE connections:
- session-events (`api/sessions/events`)
- gateway (`api/sessions/gateway/stream`, when CLI sessions are shown)
- per-session (`api/session/stream`)

The idle-SSE close added in #3992/#3996 keys off the **Page Visibility API** (`visibilitychange` / `document.hidden`) so a hidden tab frees connection-pool slots. But a **PWA standalone window does not reliably fire `visibilitychange` when it loses focus to another window of the same app** — `document.hidden` only flips on *minimize*. So two side-by-side PWA windows both stay `visibilityState === 'visible'`, each keeps its streams open, and **2 × 3 = 6** connections hit the per-origin HTTP/1.1 limit. Every subsequent `fetch()` (the 30s background polls — active-session refresh, agent health, gateway fallback) queues behind the saturated pool and times out → the cycling toast. Minimizing one window flips its `document.hidden`, frees 3 slots, and the toasts stop — exactly the reporter's steps 5–6.

## Fix

Make the **two global sidebar streams** (session-events + gateway) also close on a sustained window **`blur`** — gated on `document.hasFocus()`, the signal `visibilitychange` misses — and reopen (catching up the session list) on **`focus`**. Implemented as:
- a shared `_sidebarSseBackgrounded()` predicate (`document.hidden` **or** `!document.hasFocus()`),
- a debounced `_installSidebarSseFocusHook()` (1s debounce so a transient blur — a native dialog, a quick alt-tab-and-back — doesn't thrash the streams; re-checks focus at fire time),
- the two open-guards switched from `document.hidden` to `_sidebarSseBackgrounded()`.

Connection math after the fix (only one window holds focus at a time): `3 (focused) + 1 × (N−1)` → **N=2 → 4** connections (under the cap, with headroom), N=3 → 5, N=4 → 6.

## Deliberate scope decision — per-session stream stays visibility-only

The reporter's suggested strategy also applied the focus guard to `startSessionStream` (the per-session live stream). **I intentionally left that one visibility-only**, because it carries live `bg_task_complete` toasts and `server_turn_started` live-view that an **unfocused-but-visible** window must still receive. The bg-completion toast path is explicitly designed to fire when the session is visible-but-unfocused (`_isSessionActivelyViewed` gates the toast on `hasFocus()`), and the OS-notification fallback is gated on `document.hidden` (false when merely unfocused). Closing the per-session stream on blur would silently kill the only live completion signal a side-by-side PWA window gets — a regression for the exact multi-window persona this issue is about. Two global sidebar streams are enough to resolve the saturation; the per-session stream is left alone. The regression test locks this scope (`test_per_session_stream_NOT_closed_on_blur`).

## Testing

- New structural regression test `tests/test_issue4151_pwa_focus_sse.py` (7 tests), RED on `master` / GREEN with the fix. Includes the scope guard that the per-session stream is **not** torn down on blur.
- Updated `test_webui_external_refresh_frontend.py` open-guard assertion to track the new `_sidebarSseBackgrounded()` predicate (the `document.hidden) return` guard string changed).
- `node -c static/sessions.js` clean; ESLint runtime gate clean.
- Full suite: **8873 passed, 9 skipped, 3 xpassed, 0 failed**.

## Note on the reported workaround

The issue's cited workaround `HERMES_WEBUI_UPDATE_CHECK_INTERVAL=0` isn't a real env var, and the update check is fire-and-forget *once per tab session* (not a recurring 30s fetch). The recurring timeouts come from the 30s background polls queueing behind the saturated pool, not the update check — so this fix addresses the actual mechanism.

Closes #4151

## Known tradeoff (by design)

While a window is visible-but-unfocused, its sidebar won't live-update and the gateway-driven external/CLI active-session conversation refresh pauses. Both catch up on `focus` (gateway reopen + `refreshSessionList('focus')`), consistent with the existing hidden-tab behavior. This is the intended cost of freeing the pool slots.

---

### Review gates
- **Codex** (diff vs `origin/master`): **SAFE TO SHIP** — no regression risk; independently confirmed the per-session stream is correctly left visibility-only (OS notifications are suppressed while visible, so the per-session in-app path is the only completion signal a visible-unfocused window gets).
- **Opus**: **Approve** — "correct, minimal, well-scoped"; flagged the visibility-only scope decision as the key judgment and the right one.
- Full suite: 8873 passed / 0 failed. ESLint runtime gate clean.
