### PR TITLE
fix(transparent-stream): keep live prose chronological, don't fold into top Worklog rail (#4096)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Transparent Stream: assistant prose no longer bunches at the top of a live multi-round turn (#4096).** During a streaming turn that alternates prose with tool calls (narrate → tools → narrate → tools …), every round's prose visually stacked at the top of the turn while all tool/thinking rows clustered below it; the transcript only re-interleaved correctly once the turn settled. Root cause: `_syncLiveWorklogReasonsForAnchor()` runs on every live segment render and unconditionally built the top-anchored Worklog rail — mirroring each round's prose into a `wl-reason` row there and hiding the real, chronologically-placed inline `assistant-segment` (`assistant-segment-worklog-source` → `display:none`). That prose-folding is the **Compact Worklog** presentation (#3401) and must not run in **Transparent Stream** mode, where prose is meant to stay as visible inline segments interleaved with tool rows. The helper is now gated on `isCompactWorklogMode()`, so Transparent Stream keeps prose in chronological position live (matching the already-correct settled render), while Compact Worklog folding is unchanged. (#4096)
+
+
 ## [v0.51.404] — 2026-06-14 — Release NQ (PWA multi-window connection-pool saturation fix, #4151)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -7631,6 +7631,17 @@ function _appendWorklogStep(group, anchor, cards, thinkingText, opts){
   }
 }
 function _syncLiveWorklogReasonsForAnchor(anchor, displayTextOverride){
+  // Worklog reason-mirroring (folding intermediate prose into a top Worklog rail
+  // and hiding the inline `assistant-segment` via `assistant-segment-worklog-source`
+  // → display:none) is the Compact Worklog presentation (#3401). In Transparent
+  // Stream mode prose must stay as visible, chronologically-placed inline segments
+  // interleaved with tool rows — so do NOT build the worklog rail or hide the
+  // inline segment here. Without this gate every round's prose mirror piles into
+  // the single top rail while tool rows append at the bottom, so all prose bunches
+  // above all tools during a live multi-round turn (#4096); it only self-heals when
+  // the turn settles and renderMessages() rebuilds with the compact-only
+  // `messageBelongsInWorklog` gate (which is already isCompactWorklogMode()-only).
+  if(typeof isCompactWorklogMode==='function' && !isCompactWorklogMode()) return;
   if(!anchor||!anchor.matches||!anchor.matches('[data-live-assistant="1"]')) return;
   const blocks=anchor.parentElement;
   if(!blocks) return;
@@ -7759,6 +7770,13 @@ function ensureActivityGroup(inner, opts){
 function normalizeLiveActivityGroupPlacement(turn){
   const blocks=_assistantTurnBlocks(turn);
   if(!blocks) return;
+  // Compact Worklog only: this reorders `.tool-call-group`/`.tool-worklog-group`
+  // containers, which exist solely on the Compact Worklog live path. Transparent
+  // Stream renders tool rows as flat `.transparent-event-row`s and never builds
+  // these group containers (see appendLiveToolCard's transparent branch), and the
+  // worklog prose-rail is gated off in transparent mode (#4096), so the selector
+  // below matches nothing and this is a no-op there. Kept implicit (empty match)
+  // rather than an early return so reconnect/restore behavior is unchanged.
   const groups=Array.from(
     blocks.querySelectorAll('.tool-worklog-group[data-live-tool-worklog-group="1"],.tool-call-group[data-live-tool-worklog-group="1"],.tool-call-group[data-live-tool-call-group="1"]')
   );

--- a/tests/test_issue3820_chat_activity_display_mode.py
+++ b/tests/test_issue3820_chat_activity_display_mode.py
@@ -639,3 +639,55 @@ def test_transparent_entrance_animation_is_live_turn_only():
     """The entrance animation must be scoped to the live turn so it doesn't
     replay across the whole transcript on every renderMessages. (Trifecta V9.)"""
     assert "#liveAssistantTurn .transparent-event-row{animation:transparent-event-enter" in STYLE_CSS
+
+
+def test_live_worklog_reason_mirror_is_gated_to_compact_mode():
+    """#4096: during a live multi-round turn in Transparent Stream mode, all
+    assistant prose visually bunched at the top while every tool row clustered
+    below, self-healing only when the turn settled.
+
+    Root cause: _syncLiveWorklogReasonsForAnchor() runs on every live segment
+    render (from _flushPendingSegmentRender + the RAF _doRender in messages.js).
+    It builds the top-anchored `live-worklog` rail, mirrors each round's prose
+    into a `wl-reason` row there, AND tags the real chronological inline
+    `assistant-segment` as `assistant-segment-worklog-source` (-> display:none,
+    style.css). That worklog-folding is the Compact Worklog presentation (#3401)
+    and must NOT run in Transparent Stream mode, where prose stays as visible,
+    chronologically-placed inline segments interleaved with tool rows.
+
+    The fix gates the whole function on isCompactWorklogMode(). Assert the guard
+    is the FIRST statement in the function body (before it touches
+    ensureLiveWorklogContainer / _syncWorklogReasonFromAnchor) so it actually
+    short-circuits in transparent mode rather than running the rail-build first.
+    """
+    start = UI_JS.index("function _syncLiveWorklogReasonsForAnchor(anchor, displayTextOverride){")
+    end = UI_JS.index("\nfunction ", start + 1)
+    body = UI_JS[start:end]
+
+    # The compact-mode gate exists and short-circuits non-compact (transparent) mode.
+    guard = "if(typeof isCompactWorklogMode==='function' && !isCompactWorklogMode()) return;"
+    assert guard in body, "missing transparent-mode gate on _syncLiveWorklogReasonsForAnchor"
+
+    # The guard must come BEFORE the rail is built / prose is mirrored, otherwise
+    # it would not actually prevent the bunching.
+    guard_idx = body.index(guard)
+    assert guard_idx < body.index("ensureLiveWorklogContainer("), (
+        "compact-mode gate must precede ensureLiveWorklogContainer() so transparent "
+        "mode never builds the top worklog rail"
+    )
+    assert guard_idx < body.index("_syncWorklogReasonFromAnchor("), (
+        "compact-mode gate must precede _syncWorklogReasonFromAnchor() so transparent "
+        "mode never hides the inline assistant-segment or appends a wl-reason mirror"
+    )
+
+    # Both live-render call sites still invoke the (now-gated) helper — the gate
+    # lives in the helper, not at the call sites, so live rendering is unchanged
+    # in compact mode.
+    MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+    assert MESSAGES_JS.count("_syncLiveWorklogReasonsForAnchor(assistantRow") >= 2
+
+    # The settled-render worklog-folding gate is also compact-only (regression
+    # guard against the symmetric settled-path bug).
+    render_message_start = UI_JS.index("const messageBelongsInWorklog=")
+    render_message_end = UI_JS.index("if(messageBelongsInWorklog)", render_message_start)
+    assert "isCompactWorklogMode()" in UI_JS[render_message_start:render_message_end]


### PR DESCRIPTION
## What

Fixes **#4096** — in **Transparent Stream** mode, during a live multi-round turn (narrate → tools → narrate → tools …) all of the agent's prose visually bunched at the **top** of the turn while every tool/thinking row clustered **below** it. The transcript only re-interleaved correctly once the turn **settled**.

https://github.com/nesquena/hermes-webui/issues/4096

## Root cause

`_syncLiveWorklogReasonsForAnchor()` (`static/ui.js`) runs on **every** live segment render — from `_flushPendingSegmentRender()` and the RAF `_doRender()` in `static/messages.js`. It unconditionally:

1. built/located the top-anchored `live-worklog` rail (`ensureLiveWorklogContainer`),
2. mirrored each round's prose into a `.wl-reason` row in that rail, and
3. tagged the **real, chronologically-placed** inline `assistant-segment` as `assistant-segment-worklog-source` → `display:none !important` (`static/style.css`).

So the *visible* prose was the `.wl-reason` mirrors piled into the single top rail, while the chronological inline copies were hidden. As rounds progressed, every round's prose joined the top cluster and tool rows appended at the bottom → bunching. This is the **Compact Worklog** presentation (#3401) and should **not** run in Transparent Stream mode, where prose is meant to stay as visible inline segments interleaved with tool rows.

It self-healed on settle because the settled-render fold gate (`messageBelongsInWorklog`, `ui.js`) is already `isCompactWorklogMode()`-only — so only the **live** path was wrong.

## The fix

Gate `_syncLiveWorklogReasonsForAnchor()` on `isCompactWorklogMode()` (first statement, before it builds the rail / hides the segment). One predicate; in compact mode it's a no-op and the function runs exactly as before. Also adds a clarifying comment in `normalizeLiveActivityGroupPlacement()` documenting why it's already a no-op in transparent mode (per advisor note).

## How it was verified

Reproduced **live on production** with the reporter's exact prompt, then built a **reliable isolated repro** (mock LLM + an on-screen *visual-position* probe that classifies rows by `getBoundingClientRect().top` over only visible nodes — the previous row-classifier counted the `display:none` inline copies and missed the bug).

| | master | this branch |
|---|---|---|
| Peak live visible order | `wlTEXT × 4 → TOOL × 12` | `TEXT · tools · TEXT · tools · TEXT · tools · TEXT` |
| `textAfterFirstTool` | **0** ❌ | **3** ✅ |
| `allTextAboveAllTools` | **true** ❌ | **false** ✅ |

- **Compact Worklog**: re-verified it still folds prose into the rail (`wlReason=4, liveWorklog=1, hiddenSrc=4, visibleSeg=0`) — no regression.
- **Full pytest suite**: 8881 passed, 9 skipped, 3 xpassed, 0 failed.
- **ESLint runtime gate**: clean.
- Adds `test_live_worklog_reason_mirror_is_gated_to_compact_mode` — asserts the gate is the first statement (precedes the rail-build), red/green validated (fails on master, passes here).

## Relationship to #4114

#4114 targets the same issue but operates on the **settled** transparent branch (relocating `assistant-segment` nodes), which doesn't address the **live** path — and the segments it would move are the hidden `display:none` copies, so it's effectively a no-op for the reported live bunching. This PR fixes the actual live root cause; #4114 can be closed as superseded.

## Files
- `static/ui.js` — gate `_syncLiveWorklogReasonsForAnchor` on `isCompactWorklogMode()` + clarifying comment
- `tests/test_issue3820_chat_activity_display_mode.py` — regression test
- `CHANGELOG.md` — `[Unreleased]` entry
