### PR TITLE
fix(config): reasoning toggle for nested Gemini custom provider routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Custom provider model ids with nested Gemini gateway routes (e.g. `vertex/gemini-…`, `gemini_cli/gemini-…`) now expose the reasoning effort selector when the underlying model supports thinking.** Extends the heuristic fallback used for bare and dot-separated custom names; embedding and image-only Gemini routes stay excluded. OpenRouter-style `x-ai/…` ids continue to use the existing slash-prefix list.
+
 ## [v0.51.406] — 2026-06-14 — Release NS (project-context file in the Memory tab, #3866)
 
 ### Added

--- a/api/config.py
+++ b/api/config.py
@@ -2482,6 +2482,37 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
     return False
 
 
+def _nested_route_reasoning_denied(model: str) -> bool:
+    """Hard deny for nested Gemini gateway routes that must never show a reasoning toggle."""
+    lower = str(model or "").strip().lower()
+    if not lower:
+        return False
+    for prefix in ("vertex/gemini-", "gemini_cli/gemini-"):
+        if lower.startswith(prefix):
+            tail = lower[len(prefix) :]
+            if tail.startswith("embedding") or "image" in tail or "imagine" in tail:
+                return True
+    return False
+
+
+def _nested_gateway_route_reasoning(model: str) -> bool:
+    """Recognize nested ``vertex/gemini-`` and ``gemini_cli/gemini-`` routes on custom providers.
+
+    The slash-prefix heuristic list includes ``google/gemini-2`` but not gateway-prefixed
+    Gemini ids, so capable models behind custom aggregators stayed hidden.
+    """
+    lower = str(model or "").strip().lower()
+    if not lower:
+        return False
+    for prefix in ("vertex/gemini-", "gemini_cli/gemini-"):
+        if lower.startswith(prefix):
+            tail = lower[len(prefix) :]
+            if tail.startswith("embedding") or "image" in tail or "imagine" in tail:
+                return False
+            return True
+    return False
+
+
 def _filter_reasoning_efforts_for_provider(
     efforts: list[str],
     model_id: str,
@@ -2534,6 +2565,8 @@ def _heuristic_reasoning_efforts(model_id: str, provider_id: str) -> list[str]:
         "xiaomi/",
     )
     if any(model.startswith(prefix) for prefix in prefixes):
+        return list(VALID_REASONING_EFFORTS)
+    if _nested_gateway_route_reasoning(model):
         return list(VALID_REASONING_EFFORTS)
     # Named custom providers often rewrite model ids with dots, underscores, or
     # extra vendor namespaces. Normalize those shapes before applying family-level
@@ -2601,6 +2634,9 @@ def resolve_model_reasoning_efforts(
         return []
 
     hinted_model = _strip_provider_hint_for_reasoning(model)
+
+    if _nested_route_reasoning_denied(hinted_model):
+        return []
 
     try:
         from hermes_cli.models import (

--- a/tests/test_custom_provider_bare_model_reasoning.py
+++ b/tests/test_custom_provider_bare_model_reasoning.py
@@ -248,3 +248,38 @@ def test_deepseek_non_reasoning_variants_excluded(model_id):
     )
 
 
+# ── custom provider nested Gemini routes (vertex/, gemini_cli/) ───────────────
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "vertex/gemini-3.1-pro-preview",
+        "vertex/gemini-3-pro-preview",
+        "gemini_cli/gemini-3-pro-preview",
+    ],
+)
+def test_custom_nested_gemini_routes_expose_reasoning(model_id):
+    efforts = cfg.resolve_model_reasoning_efforts(
+        model_id,
+        provider_id="custom:newapi",
+    )
+    assert set(efforts) >= {"low", "medium", "high"}, (
+        f"{model_id} via custom:newapi should expose reasoning efforts"
+    )
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "vertex/gemini-embedding-001",
+        "vertex/gemini-3-pro-image-preview",
+    ],
+)
+def test_custom_nested_gemini_routes_exclude_non_reasoning(model_id):
+    assert cfg.resolve_model_reasoning_efforts(
+        model_id,
+        provider_id="custom:newapi",
+    ) == [], f"{model_id} must not expose reasoning efforts"
+
+


### PR DESCRIPTION
# fix: reasoning toggle for custom provider nested Gemini routes (vertex/, gemini_cli/)

**Related context:** Follow-up to closed [PR #3431](https://github.com/nesquena/hermes-webui/pull/3431) (always-show reasoning chip). Direction in [this comment](https://github.com/nesquena/hermes-webui/pull/3431#issuecomment-4697219994): keep the selector **only when the model actually supports reasoning** — improve `resolve_model_reasoning_efforts` detection for custom providers and aggregator-shaped ids, not a default-off chip on every model. This PR is scoped to that detection fix for nested Gemini routes (`vertex/`, `gemini_cli/`).

## Thinking Path

- Custom OpenAI-compatible aggregators often list Gemini as nested routes (`vertex/gemini-…`, `gemini_cli/gemini-…`) rather than OpenRouter-style `google/gemini-*`.
- The WebUI shows the reasoning/thinking effort chip only when `resolve_model_reasoning_efforts()` returns a non-empty list; PR #3379 fixed bare and dot-separated ids but not these Gemini route prefixes. That aligns with the #3431 maintainer feedback: fix false negatives in capability detection, not universal chip visibility.
- Named `custom:*` providers often lack authoritative `models_dev` capability mapping, so the heuristic fallback in `api/config.py` must recognize these gateway shapes.
- Embedding and image-preview Gemini routes under the same prefixes must stay hidden; an early deny in `resolve_model_reasoning_efforts` covers registry false positives.

## What Changed

- **`api/config.py`**
  - Added `_nested_gateway_route_reasoning()` for `vertex/gemini-` and `gemini_cli/gemini-`, wired into `_heuristic_reasoning_efforts()`.
  - Added `_nested_route_reasoning_denied()` and an early return in `resolve_model_reasoning_efforts()` for embedding / image / imagine Gemini routes.
- **`tests/test_custom_provider_bare_model_reasoning.py`**
  - Parametrized positive/negative cases for `vertex/` and `gemini_cli/` via `custom:newapi`.

## Why It Matters

Users on custom gateways lose the reasoning effort control for capable Gemini models when the catalog uses `vertex/` or `gemini_cli/` prefixes. This restores the toggle without affecting embeddings or image-only routes.

## Verification

- Targeted checks: `vertex/gemini-3.1-pro-preview`, `gemini_cli/gemini-3-pro-preview` → non-empty efforts; `vertex/gemini-embedding-001`, `vertex/gemini-3-pro-image-preview` → `[]`.
- Manual UAT on a named custom provider profile (nested Gemini route ids) — passed.
- Recommended before merge: `pytest tests/test_custom_provider_bare_model_reasoning.py -v --timeout=60` and `python3 scripts/ruff_lint.py --diff upstream/master` (CI runs full matrix).

## Risks / Follow-ups

- Other nested Gemini gateway prefixes may need the same pattern if catalogs diverge further.
- `google/gemini-3*` on custom providers still depends on existing `google/gemini-2` prefix rules unless ids use `vertex/` / `gemini_cli/`.
- No UI/CSS change.

## Model Used

- **Implementation & PR text:** xAI `grok-composer-2.5-fast` (Hermes WebUI developer session).
- **Read-only code review:** Google Antigravity CLI, model `gemini-3.5-flash-high`