### PR TITLE
[security] fix(auth): require auth for passkey enrollment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Passkey first-run bootstrap now matches the existing local-only onboarding gate.** With `HERMES_WEBUI_PASSKEY=1`, passwordless instances can enroll the first passkey only from loopback/private onboarding contexts (or with `HERMES_WEBUI_ONBOARDING_OPEN=1`), while remote/tunnel callers still receive `Authentication required` instead of being able to claim the first credential.
+
 ## [v0.51.409] — 2026-06-14 — Release NV (provider-gate title-gen reasoning extra_body, #4161/#2083)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -7331,17 +7331,19 @@ def handle_get(handler, parsed) -> bool:
 # ── POST auth helpers
 
 def _require_passkey_registration_auth(handler) -> tuple[bool, str, int]:
-    """Require an existing authenticated WebUI session before adding passkeys.
+    """Require auth, or the existing local-only first-run bootstrap gate.
 
-    Registering the first passkey is an auth-factor enrollment action, not a
-    login bootstrap.  In passkey-only first-run states (feature flag enabled, no
-    password hash, and zero credentials) there is no current factor to prove, so
-    unauthenticated registration must fail instead of silently creating the
-    first credential for whoever can reach the endpoint.
+    Registering additional passkeys is an auth-factor enrollment action and
+    requires a valid WebUI session.  The first passkey can still bootstrap a
+    passkey-only instance, but only through the same local/private-network
+    onboarding gate used for first password setup.
     """
     from api.auth import is_auth_enabled, parse_cookie, verify_session
 
-    if not is_auth_enabled():
+    auth_enabled = is_auth_enabled()
+    if not auth_enabled:
+        if _onboarding_gate_allows(handler, auth_enabled):
+            return True, "", 200
         return False, "Authentication required", 401
     cookie_val = parse_cookie(handler)
     if not cookie_val or not verify_session(cookie_val):

--- a/api/routes.py
+++ b/api/routes.py
@@ -7328,7 +7328,7 @@ def handle_get(handler, parsed) -> bool:
     return False  # 404
 
 
-# ── GET route helpers
+# ── POST auth helpers
 
 def _require_passkey_registration_auth(handler) -> tuple[bool, str, int]:
     """Require an existing authenticated WebUI session before adding passkeys.
@@ -7342,7 +7342,7 @@ def _require_passkey_registration_auth(handler) -> tuple[bool, str, int]:
     from api.auth import is_auth_enabled, parse_cookie, verify_session
 
     if not is_auth_enabled():
-        return False, "Authenticate with a password before registering a passkey.", 401
+        return False, "Authentication required", 401
     cookie_val = parse_cookie(handler)
     if not cookie_val or not verify_session(cookie_val):
         return False, "Authentication required", 401

--- a/api/routes.py
+++ b/api/routes.py
@@ -7330,6 +7330,23 @@ def handle_get(handler, parsed) -> bool:
 
 # ── GET route helpers
 
+def _require_passkey_registration_auth(handler) -> tuple[bool, str, int]:
+    """Require an existing authenticated WebUI session before adding passkeys.
+
+    Registering the first passkey is an auth-factor enrollment action, not a
+    login bootstrap.  In passkey-only first-run states (feature flag enabled, no
+    password hash, and zero credentials) there is no current factor to prove, so
+    unauthenticated registration must fail instead of silently creating the
+    first credential for whoever can reach the endpoint.
+    """
+    from api.auth import is_auth_enabled, parse_cookie, verify_session
+
+    if not is_auth_enabled():
+        return False, "Authenticate with a password before registering a passkey.", 401
+    cookie_val = parse_cookie(handler)
+    if not cookie_val or not verify_session(cookie_val):
+        return False, "Authentication required", 401
+    return True, "", 200
 
 def handle_post(handler, parsed) -> bool:
     """Handle all POST routes. Returns True if handled, False for 404."""
@@ -9302,6 +9319,9 @@ def handle_post(handler, parsed) -> bool:
 
         if not _passkey_feature_flag_enabled():
             return j(handler, {"error": "Passkey support is disabled."}, status=404)
+        ok, error, status = _require_passkey_registration_auth(handler)
+        if not ok:
+            return j(handler, {"error": error}, status=status)
         try:
             return j(handler, {"ok": True, "publicKey": registration_options(handler)})
         except PasskeyRateLimitError as e:
@@ -9315,6 +9335,9 @@ def handle_post(handler, parsed) -> bool:
 
         if not _passkey_feature_flag_enabled():
             return j(handler, {"error": "Passkey support is disabled."}, status=404)
+        ok, error, status = _require_passkey_registration_auth(handler)
+        if not ok:
+            return j(handler, {"error": error}, status=status)
         try:
             result = finish_registration(body, handler)
             result["credentials"] = registered_credentials()

--- a/tests/test_passkey_auth.py
+++ b/tests/test_passkey_auth.py
@@ -240,7 +240,7 @@ def test_first_passkey_registration_options_requires_existing_auth(monkeypatch, 
     routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/register/options"))
 
     assert handler.status == 401
-    assert "Authenticate" in json.loads(handler.wfile.getvalue())["error"]
+    assert json.loads(handler.wfile.getvalue())["error"] == "Authentication required"
 
 
 def test_first_passkey_registration_requires_existing_auth(monkeypatch, tmp_path):
@@ -256,7 +256,41 @@ def test_first_passkey_registration_requires_existing_auth(monkeypatch, tmp_path
     routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/register"))
 
     assert handler.status == 401
-    assert "Authenticate" in json.loads(handler.wfile.getvalue())["error"]
+    assert json.loads(handler.wfile.getvalue())["error"] == "Authentication required"
+
+
+def test_passkey_registration_requires_valid_session_when_auth_is_enabled(monkeypatch):
+    import api.auth as auth
+    import api.passkeys as passkeys
+    import api.routes as routes
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(auth, "_passkey_feature_flag_enabled", lambda: True)
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+    monkeypatch.setattr(auth, "parse_cookie", lambda handler: None)
+    monkeypatch.setattr(
+        auth,
+        "verify_session",
+        lambda cookie: (_ for _ in ()).throw(AssertionError("verify_session should not be called without a cookie")),
+    )
+    monkeypatch.setattr(
+        passkeys,
+        "registration_options",
+        lambda handler: (_ for _ in ()).throw(AssertionError("registration_options should not be reached")),
+    )
+    monkeypatch.setattr(
+        passkeys,
+        "finish_registration",
+        lambda body, handler: (_ for _ in ()).throw(AssertionError("finish_registration should not be reached")),
+    )
+
+    for path in ("/api/auth/passkey/register/options", "/api/auth/passkey/register"):
+        handler = RouteFakeHandler()
+        routes.handle_post(handler, SimpleNamespace(path=path))
+
+        assert handler.status == 401
+        assert json.loads(handler.wfile.getvalue())["error"] == "Authentication required"
+
 
 def test_auth_status_reports_passkey_availability_source_contract():
     src = open("api/routes.py", encoding="utf-8").read()

--- a/tests/test_passkey_auth.py
+++ b/tests/test_passkey_auth.py
@@ -172,7 +172,7 @@ class RouteFakeHandler:
         self.wfile = io.BytesIO()
         self.status = None
         self.sent_headers = []
-        self.client_address = ("127.0.0.1", 12345)
+        self.client_address: tuple[str, int] = ("127.0.0.1", 12345)
 
     def send_response(self, status):
         self.status = status
@@ -227,7 +227,7 @@ def test_passkey_register_options_handles_base_passkey_errors(monkeypatch):
     assert handler.status == 400
     assert json.loads(handler.wfile.getvalue())["error"] == "plain passkey error"
 
-def test_first_passkey_registration_options_requires_existing_auth(monkeypatch, tmp_path):
+def test_first_passkey_registration_options_rejects_remote_bootstrap(monkeypatch, tmp_path):
     import api.auth as auth
     import api.routes as routes
 
@@ -237,13 +237,14 @@ def test_first_passkey_registration_options_requires_existing_auth(monkeypatch, 
     monkeypatch.setattr(auth, "get_password_hash", lambda: None)
 
     handler = RouteFakeHandler()
+    handler.client_address = ("8.8.8.8", 12345)
     routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/register/options"))
 
     assert handler.status == 401
     assert json.loads(handler.wfile.getvalue())["error"] == "Authentication required"
 
 
-def test_first_passkey_registration_requires_existing_auth(monkeypatch, tmp_path):
+def test_first_passkey_registration_rejects_remote_bootstrap(monkeypatch, tmp_path):
     import api.auth as auth
     import api.routes as routes
 
@@ -253,10 +254,48 @@ def test_first_passkey_registration_requires_existing_auth(monkeypatch, tmp_path
     monkeypatch.setattr(auth, "get_password_hash", lambda: None)
 
     handler = RouteFakeHandler()
+    handler.client_address = ("8.8.8.8", 12345)
     routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/register"))
 
     assert handler.status == 401
     assert json.loads(handler.wfile.getvalue())["error"] == "Authentication required"
+
+
+def test_first_passkey_registration_options_allows_local_bootstrap(monkeypatch, tmp_path):
+    import api.auth as auth
+    import api.passkeys as passkeys
+    import api.routes as routes
+
+    _set_paths(monkeypatch, tmp_path)
+    monkeypatch.setenv("HERMES_WEBUI_PASSKEY", "1")
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(auth, "get_password_hash", lambda: None)
+    monkeypatch.setattr(passkeys, "registration_options", lambda handler: {"challenge": "local-bootstrap"})
+
+    handler = RouteFakeHandler()
+    routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/register/options"))
+
+    assert handler.status == 200
+    assert json.loads(handler.wfile.getvalue())["publicKey"] == {"challenge": "local-bootstrap"}
+
+
+def test_first_passkey_registration_allows_local_bootstrap(monkeypatch, tmp_path):
+    import api.auth as auth
+    import api.passkeys as passkeys
+    import api.routes as routes
+
+    _set_paths(monkeypatch, tmp_path)
+    monkeypatch.setenv("HERMES_WEBUI_PASSKEY", "1")
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(auth, "get_password_hash", lambda: None)
+    monkeypatch.setattr(passkeys, "finish_registration", lambda body, handler: {"ok": True})
+    monkeypatch.setattr(passkeys, "registered_credentials", lambda: [{"id": "local-bootstrap"}])
+
+    handler = RouteFakeHandler()
+    routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/register"))
+
+    assert handler.status == 200
+    assert json.loads(handler.wfile.getvalue()) == {"ok": True, "credentials": [{"id": "local-bootstrap"}]}
 
 
 def test_passkey_registration_requires_valid_session_when_auth_is_enabled(monkeypatch):

--- a/tests/test_passkey_auth.py
+++ b/tests/test_passkey_auth.py
@@ -212,6 +212,9 @@ def test_passkey_register_options_handles_base_passkey_errors(monkeypatch):
 
     monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
     monkeypatch.setattr(auth, "_passkey_feature_flag_enabled", lambda: True)
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+    monkeypatch.setattr(auth, "parse_cookie", lambda handler: "session")
+    monkeypatch.setattr(auth, "verify_session", lambda cookie: True)
 
     def raise_passkey_error(_handler):
         raise passkeys.PasskeyError("plain passkey error")
@@ -224,6 +227,36 @@ def test_passkey_register_options_handles_base_passkey_errors(monkeypatch):
     assert handler.status == 400
     assert json.loads(handler.wfile.getvalue())["error"] == "plain passkey error"
 
+def test_first_passkey_registration_options_requires_existing_auth(monkeypatch, tmp_path):
+    import api.auth as auth
+    import api.routes as routes
+
+    _set_paths(monkeypatch, tmp_path)
+    monkeypatch.setenv("HERMES_WEBUI_PASSKEY", "1")
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(auth, "get_password_hash", lambda: None)
+
+    handler = RouteFakeHandler()
+    routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/register/options"))
+
+    assert handler.status == 401
+    assert "Authenticate" in json.loads(handler.wfile.getvalue())["error"]
+
+
+def test_first_passkey_registration_requires_existing_auth(monkeypatch, tmp_path):
+    import api.auth as auth
+    import api.routes as routes
+
+    _set_paths(monkeypatch, tmp_path)
+    monkeypatch.setenv("HERMES_WEBUI_PASSKEY", "1")
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(auth, "get_password_hash", lambda: None)
+
+    handler = RouteFakeHandler()
+    routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/register"))
+
+    assert handler.status == 401
+    assert "Authenticate" in json.loads(handler.wfile.getvalue())["error"]
 
 def test_auth_status_reports_passkey_availability_source_contract():
     src = open("api/routes.py", encoding="utf-8").read()


### PR DESCRIPTION
## Summary

- Hardens passkey first-run enrollment so a remote unauthenticated caller cannot claim the first credential on a `HERMES_WEBUI_PASSKEY=1` instance.
- Aligns first-passkey bootstrap with the existing first-password onboarding gate: loopback/private onboarding requests, or an explicit `HERMES_WEBUI_ONBOARDING_OPEN=1` operator opt-in, may bootstrap the first passkey; remote/tunnel callers are rejected.
- Keeps additional passkey enrollment as an authenticated account-management action once auth is enabled.
- Adds regression coverage for both passkey registration endpoints across remote rejection, local bootstrap, and enabled-auth/no-session paths.
- Adds an Unreleased changelog entry for the operator-visible first-run behavior.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Unauthenticated remote first passkey enrollment in passwordless first-run state | A caller who can reach a not-yet-owned WebUI instance before the legitimate operator could register the first passkey and become the credential owner. | High, deployment-dependent |

## Before this PR

- With `HERMES_WEBUI_PASSKEY=1`, no password hash, and zero registered passkeys, the passkey registration endpoints were reachable without an authenticated WebUI session or onboarding locality check.
- A remote/tunnel-exposed unauthenticated caller could request WebAuthn registration options for an arbitrary username.
- The same unauthenticated caller could submit a registration response to the passkey registration completion endpoint.
- The first passkey enrollment path acted as an ambient bootstrap mechanism instead of requiring either an existing authenticated session or the same onboarding trust boundary already used for first password setup.
- The passwordless zero-passkey state did not have regression coverage for remote rejection or local first-run bootstrap behavior.

## After this PR

- `POST /api/auth/passkey/register/options` and `POST /api/auth/passkey/register` now share a registration guard.
- When auth is already enabled, passkey registration requires a valid WebUI session before issuing registration options or saving a credential.
- When auth is not enabled yet, first-passkey bootstrap is allowed only through `_onboarding_gate_allows`, matching the first-password setup policy:
  - loopback/private onboarding requests are allowed;
  - `HERMES_WEBUI_ONBOARDING_OPEN=1` remains the explicit remote-bootstrap opt-in;
  - other remote callers receive `Authentication required`.
- Regression tests lock the zero-password-hash, zero-passkey behavior for both endpoints:
  - remote bootstrap is rejected;
  - local bootstrap reaches the registration handlers;
  - enabled-auth requests without a session do not reach the WebAuthn handlers.
- `CHANGELOG.md` documents the operator-visible passkey first-run behavior.

## Why this matters

The first passkey is an ownership primitive. In a passwordless first-run configuration, letting any reachable unauthenticated caller register that credential makes ownership depend on network timing rather than a deliberate operator-approved bootstrap boundary.

This matters most for self-hosted or tunnel-exposed WebUI deployments where a setup window is reachable before the legitimate operator finishes onboarding. The updated guard closes that remote claim path while preserving the local-first bootstrap behavior the project already uses for first password setup.

## Affected code

- `api/routes.py`
  - Adds `_require_passkey_registration_auth` for the two passkey registration routes.
  - Uses `_onboarding_gate_allows` only for the auth-disabled first-run case.
  - Keeps the existing session-cookie requirement for all auth-enabled passkey enrollment.
- `tests/test_passkey_auth.py`
  - Adds/updates focused route-level regressions for passkey registration authorization.
- `CHANGELOG.md`
  - Adds an Unreleased note for passkey first-run bootstrap behavior.

## Root cause

`is_auth_enabled()` returns `False` in the exact passwordless first-run state: passkey support is enabled, no password hash exists, and there are zero registered credentials. The existing passkey registration routes were therefore reachable as unauthenticated bootstrap endpoints without applying the local/private onboarding gate used by first password setup.

That left first credential ownership to whichever caller could reach the registration endpoint first.

## CVSS assessment

| Metric | Value |
|--------|-------|
| Attack Vector | Adjacent/Network-adjacent (`AV:A`) |
| Attack Complexity | Low (`AC:L`) |
| Privileges Required | None (`PR:N`) |
| User Interaction | None (`UI:N`) |
| Scope | Unchanged (`S:U`) |
| Confidentiality | High (`C:H`) |
| Integrity | High (`I:H`) |
| Availability | None (`A:N`) |
| Suggested vector | `CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N` |

Rationale:

- The impact is high for confidentiality and integrity because successful first credential registration gives the attacker account-control capability for the WebUI instance.
- Availability impact is not the primary issue.
- Attack reachability depends on deployment exposure. The vector uses adjacent/network-adjacent reachability as a conservative default for local-first WebUI setups; internet-exposed deployments would increase practical risk.

## Safe reproduction steps

### 1. Remote unauthenticated registration options are rejected

1. Configure a test state with `HERMES_WEBUI_PASSKEY=1`, no password hash, and zero registered passkeys.
2. Send an unauthenticated remote `POST /api/auth/passkey/register/options` request with a candidate username.
3. Observe that the request is rejected instead of returning WebAuthn registration options.

### 2. Remote unauthenticated registration completion is rejected

1. Configure a test state with `HERMES_WEBUI_PASSKEY=1`, no password hash, and zero registered passkeys.
2. Send an unauthenticated remote `POST /api/auth/passkey/register` request with a registration payload.
3. Observe that the request is rejected instead of attempting to save the first credential.

### 3. Local first-run bootstrap still works

1. Configure the same first-run state.
2. Send the same passkey registration requests from a loopback/private onboarding context.
3. Observe that the requests pass the guard and reach the WebAuthn registration handlers.

## Expected vulnerable behavior

Before this PR, the zero-password-hash/zero-passkey state allowed passkey registration handlers to run without an authenticated WebUI session and without the onboarding locality gate, so a reachable remote caller could claim the first passkey.

## Fix in this PR

- Adds a shared passkey registration authorization helper.
- In auth-enabled states, the helper requires a valid parsed session cookie.
- In auth-disabled first-run states, the helper defers to the existing `_onboarding_gate_allows` local/private-network policy used for first password setup.
- Reuses the same neutral `Authentication required` error for refused registration attempts.
- Adds focused regressions for remote refusal, local bootstrap allowance, and auth-enabled/no-session refusal.

## Suggested fix rationale

Passkey registration after ownership is established should remain an authenticated account-management action. First passkey creation is different: it can establish ownership for a passkey-only instance, so it needs an explicit bootstrap boundary.

This PR reuses the project’s existing bootstrap boundary instead of inventing a separate passkey-only token flow. That keeps policy consistent with first password setup while still blocking the documented remote/tunnel claim path.

## Type of change

- [x] Security fix
- [x] Tests
- [x] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_passkey_auth.py -q`
  - Result: `17 passed in 2.21s`
- [x] `.venv/bin/python scripts/ruff_lint.py --diff`
  - Result: `ruff_lint: no new violations on added/modified lines. OK.`
- [x] `git diff --check`
  - Result: passed

Executed with:

- `.venv/bin/python -m pytest tests/test_passkey_auth.py -q`
- `.venv/bin/python scripts/ruff_lint.py --diff`
- `git diff --check`

## Disclosure notes

- This PR is bounded to passkey enrollment authorization in the first-run/passwordless zero-passkey state.
- It reuses the existing first-run onboarding gate rather than adding a new bootstrap-token mechanism.
- It does not change WebAuthn challenge generation or credential verification semantics beyond gating when the registration handlers may be reached.
- No unrelated files are changed.
