### PR TITLE
Stable Assistant Turn Anchors: guard Compact Worklog handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,14 @@
 
 - **Long final answers no longer snap back to the bottom while you are reading them in PWA/mobile mode (#4123).** Same-session background refreshes now treat a preserved scroll snapshot whose viewport is clearly away from the bottom (>250px) as an active reading position and restore it before any follow-to-bottom path runs, re-mark restored mid-answer positions as unpinned so later refreshes keep respecting the reader, and no longer reset the scroll-direction tracker on same-session force refreshes (that reset stays scoped to real session switches). (#4123)
 
+### Changed
+
+- **Stable Assistant Turn Anchors Compact Worklog handoff (#3926).** Settled Compact Worklog rendering can now consume the live anchor registry's `activity_scene_v1` for assistant messages stamped with `_anchor_stream_id`, coalescing tool start/complete events into the existing Worklog tool-card UI and skipping the legacy `S.toolCalls` / `assistantThinking` rebuild only when the scene proves it owns a complete settled tool set for that turn. The handoff still backfills same-turn settled reasoning ahead of tool rows when the live scene lacks it, bypasses the session HTML cache for anchor-stamped turns so session switching re-runs scene reconciliation, and missing registries, mismatched sessions, reasoning-only scenes, incomplete/running tool scenes, non-Compact modes, Transparent Stream, and projection errors all fall back to the existing renderer.
+
+### Fixed
+
+- **Restored settled streams rebuild Worklog tool rows before final render (#3926).** The stream-end/reconnect restore path now clears the active pane busy state before calling `renderMessages()`, so the settled message-level tool metadata fallback can rebuild Compact Worklog tool cards instead of rendering a restored final turn with only Thinking detail.
+
 ## [v0.51.389] — 2026-06-13 — Release NB (surface dirty-install state in update check, #4085)
 
 ### Fixed

--- a/docs/architecture/stable-assistant-turn-anchor-phase0.md
+++ b/docs/architecture/stable-assistant-turn-anchor-phase0.md
@@ -3,8 +3,9 @@
 This inventory implements the first non-visual slice of
 [`stable-assistant-turn-anchors.md`](../rfcs/stable-assistant-turn-anchors.md).
 It documents the current per-turn state layers and the event-shape contract that
-future anchor phases must consume. It does not claim that anchors are wired into
-streaming or rendering yet.
+later anchor phases must consume. Early slices were inert; this file now tracks
+which narrow rendering handoffs have started and which paths still fall back to
+the existing renderer.
 
 ## RFC Phase Progress
 
@@ -41,6 +42,12 @@ streaming or rendering yet.
   Transparent Stream row hooks and feed them through the reconciler to produce a
   concrete matched / mismatched answer. The adapter remains opt-in and is not
   invoked by `renderMessages()` or the live SSE hot path.
+- Slice 9 starts the Compact Worklog renderer handoff: settled assistant
+  messages stamped with `_anchor_stream_id` can read the retained live anchor
+  registry's `activity_scene_v1`, render reasoning/tool rows through the current
+  Worklog DOM helpers, and skip the legacy rebuild for that turn. Transparent
+  Stream, reload-after-registry-expiry, and any missing/mismatched registry still
+  use the existing renderer.
 
 ## State Layers
 
@@ -163,8 +170,10 @@ Transparent Stream receives the same row IDs, order, kinds, roles, text, tool
 IDs, and sanitized payloads with a chronological display hint. This pins the
 shared input shape before either renderer is rewired.
 
-This slice is still inert. No current UI module consumes the activity scene.
-`renderMessages()` and the live streaming hot path were unchanged by Slice 5.
+Slice 5 landed inert: no UI module consumed the activity scene at that point,
+and `renderMessages()` plus the live streaming hot path were unchanged by that
+slice. Later handoffs must be documented separately below when they start
+consuming this projection.
 
 ## Slice 6 Live Shadow Feed
 
@@ -249,6 +258,53 @@ bounded way to ask whether the current renderer output is equivalent to the
 anchor-owned activity scene. A `matched: false` result is expected while current
 renderers intentionally collapse or omit events, such as representing a tool
 start + tool completion as one visible row or omitting terminal status rows.
+
+## Slice 9 Compact Worklog Handoff
+
+`renderMessages()` now has a guarded Compact Worklog handoff for settled
+assistant messages that carry `_anchor_stream_id` from the live stream done
+path. When `window._liveAnchorRegistries` still contains the matching registry
+and the registry belongs to the current session, the renderer projects
+`activity_scene_v1` in `compact_worklog` mode and renders the scene's reasoning
+and tool rows through the existing Worklog helpers (`ensureActivityGroup()`,
+`_appendWorklogStep()`, and `buildToolCard()`).
+
+The handoff preserves the current visual surface. It does not redesign Worklog
+rows, does not fold the final answer into Worklog, and does not touch
+Transparent Stream. Tool start/update/complete activity rows are coalesced by
+tool identity so Compact Worklog continues to show one tool card with the latest
+known state rather than duplicate start and completion cards.
+
+The scene remains the owner for tool rows in this slice. Same-turn
+`assistantThinking` is only used as a de-duped reasoning backfill when the
+retained live scene does not include reasoning text that already exists in the
+settled transcript extraction path, such as reasoning split from a final
+assistant message after `done`. Those fallback reasoning rows are inserted
+before the first tool row so the expanded Compact Worklog still reads as
+reasoning first, then tool activity, instead of moving settled Thinking to the
+bottom.
+
+Anchor-stamped settled turns also bypass the session HTML cache. The cache is a
+DOM snapshot optimization for ordinary session switches; restoring it before the
+worklog rebuild would skip the scene projection and make settled Worklog
+continuity depend on whether a stale DOM snapshot happened to exist. This slice
+therefore re-runs render-time scene reconciliation whenever `_anchor_stream_id`
+is present, while still allowing normal sessions to use the cache.
+
+If the anchor helper is unavailable, the retained live registry has expired, the
+session identity is missing or does not match, the scene has no Compact Worklog
+rows, or the projection/render adapter throws, the current `S.toolCalls` /
+`assistantThinking` settled rebuild path remains the fallback. This keeps Slice
+9 as a renderer handoff, not a second semantic store and not the final
+replay/reload rebuild solution.
+
+The handoff also has a negative ownership guard: an anchor scene may suppress the
+legacy settled rebuild only when it has at least one completed tool row and, when
+message-derived fallback tools exist for the same assistant turn, the scene has
+at least as many tool rows as that fallback set. Reasoning-only scenes,
+incomplete/running tool scenes, and scenes missing message-level tools all fall
+back to the existing renderer so a restored final turn cannot collapse to
+Thinking-only Worklog detail.
 
 ## Source Event Classification
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -3931,6 +3931,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         if(typeof _messageRenderableMessageCount==='function'&&typeof _messageRenderWindowSize!=='undefined'){
           _messageRenderWindowSize=Math.max(typeof _currentMessageRenderWindowSize==='function'?_currentMessageRenderWindowSize():50, _messageRenderableMessageCount());
         }
+        // Restore-path settlement must render as idle. The settled renderer's
+        // message-level tool fallback is gated on !S.busy, so leaving the pane
+        // busy here can rebuild the final turn with Thinking only and no tools.
+        S.busy=false;
         syncTopbar();renderMessages({preserveScroll:true});
       }
       if(_isActiveSession()) _queueDrainSid=activeSid;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1197,6 +1197,7 @@ async function loadSession(sid){
       }else{
         const liveTurn=document.getElementById('liveAssistantTurn');
         const hasCurrentWorklogContent=!!(liveTurn&&liveTurn.querySelector(
+          '.agent-activity-thinking[data-live-thinking="1"],'+
           '.live-worklog[data-live-worklog-shell="1"] .tool-card-row,'+
           '.live-worklog[data-live-worklog-shell="1"] .wl-reason,'+
           '.tool-call-group[data-live-tool-worklog-group="1"] .tool-card-row,'+

--- a/static/ui.js
+++ b/static/ui.js
@@ -8860,6 +8860,199 @@ function _assistantTurnAnchorSettledFinalAnswer(message, content, context){
     return null;
   }
 }
+let _assistantTurnAnchorActivitySceneWarned=false;
+function _assistantTurnAnchorWarnActivitySceneFailure(err){
+  if(_assistantTurnAnchorActivitySceneWarned||typeof console==='undefined'||!console.warn) return;
+  _assistantTurnAnchorActivitySceneWarned=true;
+  console.warn('assistant turn anchor activity-scene projection failed',err);
+}
+function _assistantTurnAnchorActivitySceneForMessage(message, context){
+  try{
+    const api=(typeof window!=='undefined')?window.HermesAssistantTurnAnchors:null;
+    if(!api||typeof api.projectAssistantTurnAnchorActivityScene!=='function') return null;
+    const streamId=String((message&&message._anchor_stream_id)||'').trim();
+    if(!streamId) return null;
+    const registries=(typeof window!=='undefined')?window._liveAnchorRegistries:null;
+    if(!registries||typeof registries.get!=='function') return null;
+    const registry=registries.get(streamId);
+    const anchor=registry&&registry.anchor;
+    if(!anchor) return null;
+    const expectedSession=String((context&&context.session_id)||'').trim();
+    const actualSession=String((anchor.identity&&anchor.identity.session_id)||anchor.session_id||'').trim();
+    if(expectedSession&&(!actualSession||actualSession!==expectedSession)) return null;
+    const scene=api.projectAssistantTurnAnchorActivityScene(registry,{mode:'compact_worklog'});
+    if(!scene||scene.version!=='activity_scene_v1'||scene.mode!=='compact_worklog') return null;
+    return _assistantTurnAnchorCompactWorklogItems(scene).length?scene:null;
+  }catch(err){
+    _assistantTurnAnchorWarnActivitySceneFailure(err);
+    return null;
+  }
+}
+function _assistantTurnAnchorSceneTextValue(value){
+  if(value===undefined||value===null) return '';
+  if(typeof value==='string') return value;
+  try{return JSON.stringify(value,null,2);}catch(_){return String(value);}
+}
+function _assistantTurnAnchorToolKey(row){
+  if(!row) return '';
+  const tool=row.tool&&typeof row.tool==='object'?row.tool:null;
+  return String(
+    row.tool_call_id||
+    (tool&&(tool.id||tool.signature))||
+    row.event_id||
+    row.local_id||
+    row.row_id||
+    ''
+  );
+}
+function _assistantTurnAnchorToolCallFromSceneRow(row, rawIdx){
+  const tool=row&&row.tool&&typeof row.tool==='object'?row.tool:null;
+  if(!tool) return null;
+  const payload=row.payload&&typeof row.payload==='object'?row.payload:{};
+  const tid=String(row.tool_call_id||tool.id||payload.tool_call_id||payload.tool_use_id||payload.call_id||payload.tid||row.row_id||'');
+  const snippet=_assistantTurnAnchorSceneTextValue(tool.snippet||tool.output||payload.output||payload.result||payload.snippet||'');
+  const preview=_assistantTurnAnchorSceneTextValue(tool.preview||payload.preview||payload.summary||row.text||'');
+  const done=tool.done!==undefined&&tool.done!==null
+    ? !!tool.done
+    : (row.kind==='tool_completed'||row.status==='completed'||row.status==='error'||row.status==='failed');
+  const args=tool.args&&typeof tool.args==='object'?tool.args:{};
+  const tc={
+    name:tool.name||payload.name||payload.tool_name||payload.function_name||'tool',
+    tid,
+    id:tid,
+    tool_call_id:tid,
+    args:typeof _toolArgsSnapshot==='function'?_toolArgsSnapshot(args):args,
+    preview,
+    snippet:snippet||preview,
+    done,
+    is_error:!!tool.is_error,
+    assistant_msg_idx:rawIdx,
+  };
+  if(tool.duration!==undefined&&tool.duration!==null) tc.duration=tool.duration;
+  if(tool.started_at!==undefined&&tool.started_at!==null) tc.started_at=tool.started_at;
+  if(row.group&&row.group.activity_burst_id!==undefined&&row.group.activity_burst_id!==null) tc.activityBurstId=row.group.activity_burst_id;
+  if(row.group&&row.group.activity_segment_seq!==undefined&&row.group.activity_segment_seq!==null) tc.activitySegmentSeq=row.group.activity_segment_seq;
+  return tc;
+}
+function _assistantTurnAnchorThinkingDedupeKey(text){
+  const raw=String(text||'').trim();
+  if(!raw) return '';
+  if(typeof _normalizeThinkingEchoCompare==='function') return _normalizeThinkingEchoCompare(raw);
+  return raw.replace(/\s+/g,' ').trim().toLowerCase();
+}
+function _assistantTurnAnchorCompactWorklogItems(scene, rawIdx, opts){
+  const rows=scene&&Array.isArray(scene.activity_rows)?scene.activity_rows:[];
+  const fallbackThinkingEntries=Array.isArray(opts&&opts.fallbackThinkingEntries)?opts.fallbackThinkingEntries:[];
+  const items=[];
+  const toolIndexes=new Map();
+  const thinkingKeys=new Set();
+  const fallbackItems=[];
+  rows.forEach(row=>{
+    if(!row||typeof row!=='object') return;
+    if(row.kind==='reasoning'){
+      const text=row.thinking&&row.thinking.text?row.thinking.text:row.text;
+      const key=_assistantTurnAnchorThinkingDedupeKey(text);
+      if(key){
+        thinkingKeys.add(key);
+        items.push({kind:'reasoning',row,text:String(text)});
+      }
+      return;
+    }
+    if(row.kind==='tool_started'||row.kind==='tool_updated'||row.kind==='tool_completed'){
+      const toolCall=_assistantTurnAnchorToolCallFromSceneRow(row, rawIdx);
+      if(!toolCall) return;
+      const key=_assistantTurnAnchorToolKey(row)||`row:${items.length}`;
+      const item={kind:'tool',row,toolCall};
+      if(toolIndexes.has(key)) items[toolIndexes.get(key)]=item;
+      else{
+        toolIndexes.set(key,items.length);
+        items.push(item);
+      }
+    }
+  });
+  fallbackThinkingEntries.forEach((entry,index)=>{
+    const text=String((entry&&entry.text)||entry||'').trim();
+    const key=_assistantTurnAnchorThinkingDedupeKey(text);
+    if(!key||thinkingKeys.has(key)) return;
+    thinkingKeys.add(key);
+    fallbackItems.push({
+      kind:'reasoning',
+      row:{row_id:(entry&&entry.key)||`fallback-thinking:${index}`},
+      text,
+    });
+  });
+  if(fallbackItems.length){
+    const firstToolIndex=items.findIndex(item=>item&&item.kind==='tool');
+    if(firstToolIndex>=0) items.splice(firstToolIndex,0,...fallbackItems);
+    else items.push(...fallbackItems);
+  }
+  return items;
+}
+function _assistantTurnAnchorSceneOwnsCompactWorklogTurn(items, fallbackToolCount){
+  const toolItems=Array.from(items||[]).filter(item=>item&&item.kind==='tool'&&item.toolCall);
+  if(!toolItems.length) return false;
+  if(toolItems.some(item=>item.toolCall&&item.toolCall.done===false)) return false;
+  const fallbackCount=Math.max(0,Number(fallbackToolCount)||0);
+  if(fallbackCount&&toolItems.length<fallbackCount) return false;
+  return true;
+}
+function _assistantTurnAnchorCompactWorklogPlacementAnchor(anchorTurn, fallbackAnchor){
+  const blocks=_assistantTurnBlocks(anchorTurn);
+  if(!blocks) return fallbackAnchor;
+  return blocks.querySelector('.assistant-segment')||fallbackAnchor;
+}
+function _renderAssistantTurnAnchorCompactWorklogScene(anchorRow, scene, opts){
+  if(!anchorRow||!scene) return false;
+  const anchorTurn=anchorRow.closest('.assistant-turn');
+  if(!anchorTurn) return false;
+  const placementAnchor=_assistantTurnAnchorCompactWorklogPlacementAnchor(anchorTurn, anchorRow);
+  const anchorParent=placementAnchor&&placementAnchor.parentElement;
+  if(!anchorParent) return false;
+  const rawIdx=opts&&opts.raw_idx;
+  const items=Array.isArray(opts&&opts.items)
+    ? opts.items
+    : _assistantTurnAnchorCompactWorklogItems(scene, rawIdx, opts);
+  if(!items.length) return false;
+  const identity=scene.identity||{};
+  const activityKey=`anchor-scene:${identity.session_id||''}:${identity.stream_id||identity.run_id||rawIdx||''}`;
+  const firstGroup=(items.find(item=>item.row&&item.row.group)||{}).row?.group||{};
+  const group=ensureActivityGroup(anchorParent,{
+    collapsed:true,
+    anchor:placementAnchor,
+    beforeAnchor:true,
+    syncAnchorReason:false,
+    activityKey,
+    burstId:firstGroup.activity_burst_id||'',
+    segmentSeq:firstGroup.activity_segment_seq||'',
+    turnDuration:opts&&opts.turnDuration,
+  });
+  const list=_toolWorklogListEl(group);
+  if(!list) return false;
+  list.innerHTML='';
+  const state={seenReasons:new Set(),seenTools:new Set()};
+  for(const item of items){
+    if(item.kind==='reasoning'){
+      const rowId=item.row&&item.row.row_id?item.row.row_id:String(item.text||'').trim();
+      _appendWorklogStep(group, anchorRow, [], item.text, {
+        live:false,
+        includeAnchorReason:false,
+        thinkingKey:`anchor-scene:${rowId}`,
+        thinkingDisclosureKey:`anchor-scene:${rowId}`,
+        seenReasons:state.seenReasons,
+        seenTools:state.seenTools,
+      });
+    }else if(item.kind==='tool'){
+      _appendWorklogStep(group, anchorRow, [item.toolCall], '', {
+        live:false,
+        includeAnchorReason:false,
+        seenReasons:state.seenReasons,
+        seenTools:state.seenTools,
+      });
+    }
+  }
+  _syncToolCallGroupSummary(group);
+  return true;
+}
 function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
   // Terminal stream renders can happen after S.activeStreamId is cleared.
   // In that case, preserveScroll asks the normal pin-state helper to decide:
@@ -8918,6 +9111,7 @@ function renderMessages(options){
   if(sid!==_messageRenderWindowSid) _resetMessageRenderWindow(sid);
   const renderWindowSize=_currentMessageRenderWindowSize();
   let cachedRenderSignature=null;
+  const hasAnchorSceneWorklogCandidate=isCompactWorklogMode()&&Array.isArray(S.messages)&&S.messages.some(m=>m&&m.role==='assistant'&&!m._live&&m._anchor_stream_id);
   const hasTransientTranscriptUi=!!(
     (window._compressionUi&&(!window._compressionUi.sessionId||window._compressionUi.sessionId===sid)) ||
     (window._handoffUi&&(!window._handoffUi.sessionId||window._handoffUi.sessionId===sid))
@@ -8931,7 +9125,10 @@ function renderMessages(options){
   // Also skip cache for transient transcript cards such as /compress and
   // cross-channel handoff summaries; otherwise the cached transcript returns
   // before those cards can be inserted.
-  if(sid&&sid!==_sessionHtmlCacheSid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi){
+  // Anchor-scene Worklog handoff is also a render-time reconciliation: restoring
+  // cached HTML here would skip the scene projection and make session switching
+  // depend on whether the old DOM happened to be cached before settlement.
+  if(sid&&sid!==_sessionHtmlCacheSid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi&&!hasAnchorSceneWorklogCandidate){
     const renderSignature=_messageRenderCacheSignature();
     cachedRenderSignature=renderSignature;
     const cached=_sessionHtmlCache.get(sid);
@@ -9622,7 +9819,8 @@ function renderMessages(options){
     if(derived.length) S.toolCalls=derived;
     if(S._settledLiveToolMetadata) S._settledLiveToolMetadata=null;
   }
-  if(!S.busy || (S.toolCalls&&S.toolCalls.length)){
+  const anchorSceneWorklogAssistantIdxs=new Set();
+  if(!S.busy || (S.toolCalls&&S.toolCalls.length) || hasAnchorSceneWorklogCandidate){
     // Rebuild settled tool/worklog/thinking nodes. The `|| (S.toolCalls.length)`
     // arm is REQUIRED, not just `!S.busy`: when renderMessages re-runs during an
     // active stream (e.g. switching back to an in-progress session, busy=true),
@@ -9668,8 +9866,20 @@ function renderMessages(options){
       }
       return duration;
     };
+    const _assistantThinkingEntriesForTurn=(anchorTurn)=>{
+      const entries=[];
+      if(!anchorTurn) return entries;
+      for(const [thinkingIdx,text] of assistantThinking){
+        const thinkingSeg=assistantSegments.get(thinkingIdx);
+        if(thinkingSeg&&thinkingSeg.closest('.assistant-turn')===anchorTurn&&String(text||'').trim()){
+          entries.push({key:`legacy-thinking:${thinkingIdx}`,text});
+        }
+      }
+      return entries;
+    };
     const durationAssignedTurns = new Set();
     const activityByTurn = new Map();
+    const anchorSceneWorklogTurns = new Set();
     const activityOrder = [];
     const ensureActivityBucket=(key,aIdx,segmentSeq,burstId)=>{
       if(!byActivity.has(key)){
@@ -9725,6 +9935,49 @@ function renderMessages(options){
       return a.aIdx-b.aIdx;
     });
     if(!isTransparentStream()){
+      if(isCompactWorklogMode()){
+        const _legacyToolCountForTurn=(anchorTurn)=>{
+          let count=0;
+          for(const entry of activityOrder){
+            if(!entry||!Array.isArray(entry.cards)||!entry.cards.length) continue;
+            const row=_assistantAnchorForActivity(entry.aIdx,entry.segmentSeq,entry.burstId);
+            if(row&&row.closest('.assistant-turn')===anchorTurn) count+=entry.cards.length;
+          }
+          return count;
+        };
+        for(const aIdx of assistantIdxs){
+          const msg=S.messages[aIdx]||{};
+          if(!msg||msg.role!=='assistant'||msg._live||!msg._anchor_stream_id) continue;
+          const anchorRow=assistantSegments.get(aIdx);
+          if(!anchorRow) continue;
+          const anchorTurn=anchorRow.closest('.assistant-turn');
+          if(!anchorTurn||anchorSceneWorklogTurns.has(anchorTurn)) continue;
+          const scene=_assistantTurnAnchorActivitySceneForMessage(msg,{
+            session_id:sid,
+            raw_idx:aIdx,
+          });
+          if(!scene) continue;
+          const fallbackThinkingEntries=_assistantThinkingEntriesForTurn(anchorTurn);
+          const items=_assistantTurnAnchorCompactWorklogItems(scene, aIdx, {
+            fallbackThinkingEntries,
+          });
+          if(!_assistantTurnAnchorSceneOwnsCompactWorklogTurn(items,_legacyToolCountForTurn(anchorTurn))) continue;
+          const includeTurnDuration=!durationAssignedTurns.has(anchorTurn);
+          const rendered=_renderAssistantTurnAnchorCompactWorklogScene(anchorRow, scene, {
+            raw_idx:aIdx,
+            turnDuration:includeTurnDuration?_turnDurationForAnchor(anchorRow):undefined,
+            fallbackThinkingEntries,
+            items,
+          });
+          if(rendered){
+            anchorSceneWorklogTurns.add(anchorTurn);
+            for(const [turnIdx,turnSeg] of assistantSegments){
+              if(turnSeg&&turnSeg.closest('.assistant-turn')===anchorTurn) anchorSceneWorklogAssistantIdxs.add(turnIdx);
+            }
+            if(includeTurnDuration) durationAssignedTurns.add(anchorTurn);
+          }
+        }
+      }
       for(const entry of activityOrder){
         const {aIdx,segmentSeq,burstId,cards,thinkingIdx,includeAnchorReason}=entry;
         if(aIdx<assistantIdxs[0]) continue;
@@ -9736,6 +9989,7 @@ function renderMessages(options){
         if(!cards.length&&!anchorReasonHtml&&!thinkingText) continue;
         const anchorTurn=anchorRow.closest('.assistant-turn');
         if(!anchorTurn) continue;
+        if(anchorSceneWorklogTurns.has(anchorTurn)) continue;
         let state=activityByTurn.get(anchorTurn);
         if(!state){
           const includeTurnDuration=!durationAssignedTurns.has(anchorTurn);
@@ -9860,7 +10114,7 @@ function renderMessages(options){
       // The Worklog summary owns the "Done in …" duration whenever this
       // assistant message contributes tool or thinking detail to a folded
       // Worklog above the final answer.
-      const compactWorklogForMessage=isCompactWorklogMode()&&(toolCallAssistantIdxs.has(mi)||assistantThinking.has(mi));
+      const compactWorklogForMessage=isCompactWorklogMode()&&(toolCallAssistantIdxs.has(mi)||assistantThinking.has(mi)||anchorSceneWorklogAssistantIdxs.has(mi));
       const durationText=compactWorklogForMessage?'':_formatTurnDuration(msg._turnDuration);
       if(!hasTurnUsage&&!durationText&&!gatewayText&&!failoverText&&!modelWarningText) continue;
       const seg=assistantSegments.get(mi);
@@ -10136,7 +10390,7 @@ function renderMessages(options){
   if(typeof _applyMediaPlaybackPreferences==='function') _applyMediaPlaybackPreferences(inner);
   // Populate session cache so switching back here skips a full rebuild.
   _sessionHtmlCacheSid=sid;
-  if(sid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi){
+  if(sid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi&&!hasAnchorSceneWorklogCandidate){
     const _html=inner.innerHTML;
     // Only cache sessions with <300KB rendered HTML; evict oldest beyond 8 sessions.
     if(_html.length<300_000){

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -168,9 +168,9 @@ def test_load_session_same_sid_noop_does_not_mask_pending_switch_back():
 def test_load_session_preserves_existing_worklog_content_without_destructive_fallback():
     """Switching back to an active stream with live Worklog content should be treated as restored.
 
-    If loadSession() sees .wl-reason or .tool-card-row already in #liveAssistantTurn,
-    the destructive fallback must not call clearLiveToolCards() and rebuild a blank
-    Running shell over the preserved timeline.
+    If loadSession() sees live Thinking, .wl-reason, or .tool-card-row already in
+    #liveAssistantTurn, the destructive fallback must not call clearLiveToolCards()
+    and rebuild a blank Running shell over the preserved timeline.
     """
     body = _function_body(SESSIONS_JS, "loadSession")
     content_pos = body.find("const hasCurrentWorklogContent=")
@@ -179,6 +179,10 @@ def test_load_session_preserves_existing_worklog_content_without_destructive_fal
     assert clear_pos != -1
     between = body[content_pos:clear_pos]
     compact = re.sub(r"\s+", "", between)
+    assert '.agent-activity-thinking[data-live-thinking="1"]' in between, (
+        "Live Thinking Cards must count as existing live Worklog content; otherwise "
+        "switch-back during a Thinking-only phase rebuilds a blank shell."
+    )
     assert "if(hasCurrentWorklogContent)restoredLiveTurn=true" in compact, (
         "Existing live Worklog content must mark the turn restored before the "
         "clearLiveToolCards() fallback runs."

--- a/tests/test_issue3401_deep_review_fixes.py
+++ b/tests/test_issue3401_deep_review_fixes.py
@@ -134,13 +134,18 @@ def test_settled_worklog_rebuild_not_gated_on_idle_only():
     when renderMessages re-ran during an active stream (switch-back to in-progress
     session) — the same content-loss-on-switch class as #3668. (#3401 regression)"""
     body = UI_JS
-    # The rebuild guard must include the `|| (S.toolCalls && S.toolCalls.length)` arm.
-    assert re.search(
-        r"if\(!S\.busy\s*\|\|\s*\(S\.toolCalls\s*&&\s*S\.toolCalls\.length\)\)\{",
+    guard_match = re.search(
+        r"if\((?P<guard>[^\n]+)\)\{\n    // Rebuild settled tool/worklog/thinking nodes",
         body,
-    ), (
+    )
+    assert guard_match, "the settled worklog rebuild guard was not found"
+    guard = re.sub(r"\s+", "", guard_match.group("guard"))
+    # The rebuild guard may gain additional ownership arms, but it must keep the
+    # busy-path `S.toolCalls` arm that fixes the original switch-back regression.
+    assert "!S.busy" in guard, "the settled worklog rebuild must still run while idle"
+    assert re.search(r"(^|\|\|)\(?S\.toolCalls&&S\.toolCalls\.length\)?($|\|\|)", guard), (
         "the settled worklog rebuild must run while busy when tool calls exist "
-        "(if(!S.busy || (S.toolCalls && S.toolCalls.length))), not gate purely on !S.busy"
+        "(the guard must include an OR arm for S.toolCalls&&S.toolCalls.length)"
     )
     # And the bare `if(!S.busy){` immediately before that rebuild's worklog-wipe must be gone.
     assert "if(!S.busy){\n    inner.querySelectorAll('.tool-worklog-group" not in body, (

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -77,7 +77,7 @@ def test_tool_activity_uses_tool_cards_and_run_activity_owns_timer():
 
 
 def test_settled_activity_render_keeps_tools_bound_to_progress_bursts():
-    render_fn = UI_JS.split("if(!S.busy || (S.toolCalls&&S.toolCalls.length)){", 1)[1].split("// Render per-turn duration", 1)[0]
+    render_fn = UI_JS.split("const hasAnchorSceneWorklogCandidate=", 1)[1].split("// Render per-turn duration", 1)[0]
     assert "_assistantAnchorForActivity" in render_fn
     assert "const byActivity = new Map()" in render_fn
     assert "tc.activityBurstId" in render_fn
@@ -217,7 +217,7 @@ assert.strictEqual(merged[0].started_at, 123);
 
 
 def test_settled_activity_render_treats_burst_zero_as_unanchored_activity():
-    render_fn = UI_JS.split("if(!S.busy || (S.toolCalls&&S.toolCalls.length)){", 1)[1].split("// Render per-turn duration", 1)[0]
+    render_fn = UI_JS.split("const hasAnchorSceneWorklogCandidate=", 1)[1].split("// Render per-turn duration", 1)[0]
     assert "String(burstId)!=='0'" in render_fn
     assert "if(aIdx<assistantIdxs[0]) return null;" in render_fn
     assert "normalizeToken(tc.activityBurstId)" in render_fn

--- a/tests/test_stable_assistant_turn_anchor_registry.py
+++ b/tests/test_stable_assistant_turn_anchor_registry.py
@@ -31,6 +31,23 @@ def _event_listener_body(src: str, event_name: str) -> str:
     return src[start:end]
 
 
+def _function_source(src: str, name: str) -> str:
+    marker = f"function {name}("
+    start = src.find(marker)
+    assert start != -1
+    brace = src.find("{", start)
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start:idx + 1]
+    raise AssertionError(f"function {name} did not close")
+
+
 def _registry_snapshot() -> dict:
     assert NODE, "node is required for assistant_turn_anchors.js registry tests"
     script = f"""
@@ -1236,22 +1253,246 @@ def test_registry_instances_do_not_share_owner_state():
     assert isolated["stats"]["applied"] == 0
     assert isolated["anchor"]["activity_events"] == []
 
-def test_slice5_scene_projection_does_not_wire_activity_scene_into_rendering_hot_paths():
+def test_activity_scene_projection_only_reaches_compact_worklog_handoff():
     scene_helper = "projectAssistantTurnAnchorActivityScene"
+    ui_src = _read(UI_JS)
     for helper in [
         "applyAssistantTurnAnchorNormalizedEvent",
         "applyAssistantTurnAnchorSourceEvents",
         "createAssistantTurnAnchorShadowSnapshot",
-        scene_helper,
         "reconcileAssistantTurnAnchorActivityScene",
     ]:
         assert helper not in _read(UI_JS)
         assert helper not in _read(SESSIONS_JS)
         assert helper not in _read(MESSAGES_JS)
     assert "projectAssistantTurnAnchorSettledMessageFinalAnswer" in _read(UI_JS)
-    assert scene_helper not in _read(UI_JS)
+    assert scene_helper in ui_src
+    assert "_assistantTurnAnchorActivitySceneForMessage" in ui_src
+    assert "projectAssistantTurnAnchorActivityScene(registry,{mode:'compact_worklog'})" in ui_src
     assert scene_helper not in _read(SESSIONS_JS)
     assert scene_helper not in _read(MESSAGES_JS)
+
+
+def test_compact_worklog_anchor_scene_handoff_is_guarded_and_fallback_preserving():
+    src = _read(UI_JS)
+    helper = src.split("function _assistantTurnAnchorActivitySceneForMessage", 1)[1].split(
+        "function _assistantTurnAnchorSceneTextValue", 1
+    )[0]
+    render_body = src.split("const hasAnchorSceneWorklogCandidate=", 1)[1].split(
+        "// ── transparent_stream path: individual expandable event rows ──", 1
+    )[0]
+    render_fn = src.split("function renderMessages(options){", 1)[1].split(
+        "function _toolDisplayName", 1
+    )[0]
+    cache_body = src.split("const hasAnchorSceneWorklogCandidate=", 1)[1].split(
+        "const worklogDetailDisclosureState=", 1
+    )[0]
+    cache_store_body = src.split("// Populate session cache so switching back here skips a full rebuild.", 1)[1].split(
+        "function _toolDisplayName", 1
+    )[0]
+
+    assert "window._liveAnchorRegistries" in helper
+    assert "message._anchor_stream_id" in helper
+    assert "message.stream_id" not in helper
+    assert "message._stream_id" not in helper
+    assert "registries.get(streamId)" in helper
+    assert "expectedSession&&(!actualSession||actualSession!==expectedSession)" in helper
+    assert "return _assistantTurnAnchorCompactWorklogItems(scene).length?scene:null" in helper
+
+    assert "m&&m.role==='assistant'&&!m._live&&m._anchor_stream_id" in render_body
+    assert "!hasAnchorSceneWorklogCandidate" in cache_body
+    assert "!hasAnchorSceneWorklogCandidate" in cache_store_body
+    assert render_fn.index("const hasAnchorSceneWorklogCandidate=") < render_fn.index("if(sid&&sid!==_sessionHtmlCacheSid")
+    assert "if(!S.busy || (S.toolCalls&&S.toolCalls.length) || hasAnchorSceneWorklogCandidate){" in render_body
+    assert "if(isCompactWorklogMode()){" in render_body
+    assert "_assistantTurnAnchorActivitySceneForMessage(msg,{" in render_body
+    assert "_renderAssistantTurnAnchorCompactWorklogScene(anchorRow, scene" in render_body
+    assert "_legacyToolCountForTurn(anchorTurn)" in render_body
+    assert "_assistantTurnAnchorSceneOwnsCompactWorklogTurn(items,_legacyToolCountForTurn(anchorTurn))" in render_body
+    assert "anchorSceneWorklogTurns.add(anchorTurn)" in render_body
+    assert "anchorSceneWorklogAssistantIdxs.add(turnIdx)" in render_body
+    assert "if(anchorSceneWorklogTurns.has(anchorTurn)) continue;" in render_body
+
+
+def test_compact_worklog_anchor_scene_session_guard_fails_closed_for_missing_anchor_session():
+    assert NODE, "node is required for ui.js helper tests"
+    src = _read(UI_JS)
+    helper = _function_source(src, "_assistantTurnAnchorActivitySceneForMessage")
+    script = f"""
+const assert = require('assert');
+const projectCalls = [];
+function _assistantTurnAnchorCompactWorklogItems(scene) {{
+  return Array.isArray(scene && scene.activity_rows) ? scene.activity_rows : [];
+}}
+global.window = {{
+  HermesAssistantTurnAnchors: {{
+    projectAssistantTurnAnchorActivityScene(registry, opts) {{
+      projectCalls.push({{registry, opts}});
+      return {{
+        version: 'activity_scene_v1',
+        mode: 'compact_worklog',
+        activity_rows: [{{kind: 'tool_completed', row_id: 'row-1'}}],
+      }};
+    }},
+  }},
+  _liveAnchorRegistries: new Map(),
+}};
+var window = global.window;
+{helper}
+
+const registry = {{anchor: {{identity: {{stream_id: 'stream-1'}}}}}};
+window._liveAnchorRegistries.set('stream-1', registry);
+const message = {{_anchor_stream_id: 'stream-1'}};
+assert.strictEqual(
+  _assistantTurnAnchorActivitySceneForMessage(message, {{session_id: 'sid-current'}}),
+  null
+);
+assert.strictEqual(projectCalls.length, 0);
+
+registry.anchor.identity.session_id = 'sid-other';
+assert.strictEqual(
+  _assistantTurnAnchorActivitySceneForMessage(message, {{session_id: 'sid-current'}}),
+  null
+);
+assert.strictEqual(projectCalls.length, 0);
+
+registry.anchor.identity.session_id = 'sid-current';
+const scene = _assistantTurnAnchorActivitySceneForMessage(message, {{session_id: 'sid-current'}});
+assert.strictEqual(scene && scene.version, 'activity_scene_v1');
+assert.strictEqual(projectCalls.length, 1);
+"""
+    result = subprocess.run([NODE, "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
+def test_compact_worklog_scene_coalesces_tools_and_keeps_final_anchor_visible():
+    src = _read(UI_JS)
+    item_helper = src.split("function _assistantTurnAnchorCompactWorklogItems", 1)[1].split(
+        "function _renderAssistantTurnAnchorCompactWorklogScene", 1
+    )[0]
+    render_helper = src.split("function _renderAssistantTurnAnchorCompactWorklogScene", 1)[1].split(
+        "function _scrollAfterMessageRender", 1
+    )[0]
+    footer_body = src.split("// Render per-turn duration", 1)[1].split(
+        "// Transparent mode per-turn wiring", 1
+    )[0]
+
+    assert "const toolIndexes=new Map()" in item_helper
+    assert "items[toolIndexes.get(key)]=item" in item_helper
+    assert "row.kind==='tool_started'||row.kind==='tool_updated'||row.kind==='tool_completed'" in item_helper
+    assert "row.kind==='reasoning'" in item_helper
+    assert "fallbackThinkingEntries.forEach" in item_helper
+    assert "thinkingKeys.has(key)" in item_helper
+    assert "const fallbackItems=[]" in item_helper
+    assert "const firstToolIndex=items.findIndex(item=>item&&item.kind==='tool')" in item_helper
+    assert "items.splice(firstToolIndex,0,...fallbackItems)" in item_helper
+    assert "function _assistantTurnAnchorSceneOwnsCompactWorklogTurn(items, fallbackToolCount)" in src
+    assert "if(!toolItems.length) return false;" in src
+    assert "toolItems.some(item=>item.toolCall&&item.toolCall.done===false)" in src
+    assert "toolItems.length<fallbackCount" in src
+
+    assert "_assistantTurnAnchorCompactWorklogPlacementAnchor(anchorTurn, anchorRow)" in render_helper
+    assert "beforeAnchor:true" in render_helper
+    assert "syncAnchorReason:false" in render_helper
+    assert "includeAnchorReason:false" in render_helper
+    assert "_appendWorklogStep(group, anchorRow, [item.toolCall], ''" in render_helper
+    assert "Array.isArray(opts&&opts.items)" in render_helper
+    assert "anchorSceneWorklogAssistantIdxs.has(mi)" in footer_body
+    assert "const fallbackThinkingEntries=_assistantThinkingEntriesForTurn(anchorTurn);" in src
+    assert "fallbackThinkingEntries," in src
+    assert "items," in src
+
+
+def test_compact_worklog_scene_item_projection_orders_fallback_reasoning_before_tools_and_guards_ownership():
+    assert NODE, "node is required for ui.js helper tests"
+    src = _read(UI_JS)
+    helpers = "\n".join(
+        _function_source(src, name)
+        for name in [
+            "_assistantTurnAnchorSceneTextValue",
+            "_assistantTurnAnchorToolKey",
+            "_assistantTurnAnchorToolCallFromSceneRow",
+            "_assistantTurnAnchorThinkingDedupeKey",
+            "_assistantTurnAnchorCompactWorklogItems",
+            "_assistantTurnAnchorSceneOwnsCompactWorklogTurn",
+        ]
+    )
+    script = f"""
+const assert = require('assert');
+function _normalizeThinkingEchoCompare(text) {{
+  return String(text || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+}}
+function _toolArgsSnapshot(args) {{ return Object.assign({{}}, args || {{}}); }}
+{helpers}
+
+const scene = {{
+  activity_rows: [
+    {{
+      kind: 'tool_started',
+      row_id: 'run-item:2',
+      tool_call_id: 'tool-1',
+      group: {{activity_burst_id: 2, activity_segment_seq: 4}},
+      tool: {{
+        id: 'tool-1',
+        name: 'terminal',
+        args: {{command: 'rg anchor'}},
+        preview: 'rg anchor',
+        done: false,
+        is_error: false,
+      }},
+    }},
+    {{
+      kind: 'tool_completed',
+      row_id: 'run-item:3',
+      tool_call_id: 'tool-1',
+      group: {{activity_burst_id: 2, activity_segment_seq: 4}},
+      tool: {{
+        id: 'tool-1',
+        name: 'terminal',
+        args: {{command: 'rg anchor'}},
+        snippet: 'done',
+        done: true,
+        is_error: false,
+      }},
+    }},
+  ],
+}};
+
+const items = _assistantTurnAnchorCompactWorklogItems(scene, 7, {{
+  fallbackThinkingEntries: [{{key: 'legacy-thinking:7', text: 'I should inspect the files first.'}}],
+}});
+
+assert.deepStrictEqual(items.map((item) => item.kind), ['reasoning', 'tool']);
+assert.strictEqual(items[0].text, 'I should inspect the files first.');
+assert.strictEqual(items[1].toolCall.done, true);
+assert.strictEqual(items[1].toolCall.snippet, 'done');
+assert.strictEqual(items[1].toolCall.assistant_msg_idx, 7);
+assert.strictEqual(items[1].toolCall.activityBurstId, 2);
+assert.strictEqual(items[1].toolCall.activitySegmentSeq, 4);
+assert.strictEqual(_assistantTurnAnchorSceneOwnsCompactWorklogTurn(items, 1), true);
+assert.strictEqual(_assistantTurnAnchorSceneOwnsCompactWorklogTurn(items, 2), false);
+
+const deduped = _assistantTurnAnchorCompactWorklogItems({{
+  activity_rows: [{{kind: 'reasoning', row_id: 'run-item:1', text: 'Same thought'}}],
+}}, 8, {{
+  fallbackThinkingEntries: [{{key: 'legacy-thinking:8', text: 'Same thought'}}],
+}});
+assert.deepStrictEqual(deduped.map((item) => item.kind), ['reasoning']);
+assert.strictEqual(_assistantTurnAnchorSceneOwnsCompactWorklogTurn(deduped, 0), false);
+
+const runningOnly = _assistantTurnAnchorCompactWorklogItems({{
+  activity_rows: [{{
+    kind: 'tool_started',
+    row_id: 'run-item:4',
+    tool_call_id: 'tool-running',
+    tool: {{id: 'tool-running', name: 'terminal', done: false}},
+  }}],
+}}, 9, {{}});
+assert.strictEqual(runningOnly.length, 1);
+assert.strictEqual(_assistantTurnAnchorSceneOwnsCompactWorklogTurn(runningOnly, 1), false);
+"""
+    result = subprocess.run([NODE, "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
 
 
 def test_slice6_live_shadow_feed_wires_non_token_events_without_renderer_scene_consumption():

--- a/tests/test_stream_end_recovery_gating.py
+++ b/tests/test_stream_end_recovery_gating.py
@@ -114,6 +114,18 @@ def test_restore_settled_session_can_report_active_pending_status():
     assert "return returnStatus?'restored':true;" in fn
 
 
+def test_restore_settled_session_renders_after_clearing_busy_state():
+    fn = _function_body("_restoreSettledSession")
+    clear_idx = fn.find("S.busy=false;")
+    render_idx = fn.find("renderMessages({preserveScroll:true});")
+    assert clear_idx != -1, (
+        "restored settled sessions must clear busy before render so message-level "
+        "tool metadata can rebuild Worklog tool rows"
+    )
+    assert render_idx != -1
+    assert clear_idx < render_idx
+
+
 def test_stream_end_recovery_state_is_cleared_on_done_and_terminal_events():
     assert "_clearStreamEndRecovery();" in _event_block("done")
     assert "_clearStreamEndRecovery();" in _event_block("stream_end")

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -239,7 +239,7 @@ class TestToolCallGroupingStatic:
         restore_fn = _function_body(UI_JS, "_restoreWorklogDetailDisclosureState")
         apply_fn = _function_body(UI_JS, "_setWorklogDetailDisclosureOpen")
         capture_pos = render_fn.index("const worklogDetailDisclosureState=_captureWorklogDetailDisclosureState(inner);")
-        cache_pos = render_fn.index("if(sid&&sid!==_sessionHtmlCacheSid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi)")
+        cache_pos = render_fn.index("if(sid&&sid!==_sessionHtmlCacheSid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi&&!hasAnchorSceneWorklogCandidate)")
         cache_return_pos = render_fn.index("return;", cache_pos)
         wipe_pos = render_fn.index("inner.innerHTML='';")
         restore_pos = render_fn.index("_restoreWorklogDetailDisclosureState(inner, worklogDetailDisclosureState);")


### PR DESCRIPTION
## Stacked Ship Gate

This PR is ready for review, but it should not be merged/released by itself.

Please review this PR as Slice 9, then ship it together with the Slice 10 companion PR: #4177.

- Slice 9 / this PR: guarded Compact Worklog handoff from the retained live anchor registry.
- Slice 10 / #4177: durable Compact Worklog rebuild for hard refresh, session switch, and registry-loss cases.

Reason: landing this PR alone improves the same-page live-to-settled path, but still leaves hard refresh / reload / session switch on the legacy rebuild behavior. That creates an inconsistent user-visible window. Preferred merge plan: review #4172 and #4177 separately, then merge back-to-back. If maintainers prefer one atomic release diff, fold #4177 into this PR before merge.

---

## Thinking Path
- This is part of #3926, under the #3400 live-to-final consistency track.
- The previous anchor slices established the inert anchor owner, activity scene projection, live shadow feed, dual-run reconciliation, and the renderer snapshot adapter. Those slices made `activity_scene_v1` available, but they did not let it own Compact Worklog rendering.
- This slice is the first guarded Compact Worklog handoff: settled assistant messages stamped with `_anchor_stream_id` may render their Worklog rows from the retained anchor activity scene.
- The handoff is intentionally narrow. The anchor scene only owns the settled Compact Worklog when it proves complete tool ownership for that assistant turn; otherwise the existing `S.toolCalls` / `assistantThinking` settled rebuild remains the fallback.
- The next slice should use the durable transcript / replay path to rebuild the same activity ownership after reload or session switch. This PR does not claim durable reload/replay ownership yet.

## What Changed
- Added a Compact Worklog renderer handoff for assistant-turn anchor activity scenes in `renderMessages()`.
- Reuses the existing Worklog row/card helpers instead of adding a new visual component family.
- Bypasses the session HTML cache only for anchor-stamped assistant messages so scene projection can run during settled rendering.
- Added ownership guards so incomplete, running, reasoning-only, or tool-count-incomplete scenes cannot suppress the legacy settled Worklog fallback.
- Hardened the retained-registry session guard to fail closed when an anchor scene lacks session identity or belongs to a different session.
- Fixed restore-path settlement rendering by clearing `S.busy` before the settled render pass, so recovered settled sessions can rebuild message-derived Worklog rows.
- Updated architecture docs and changelog to record the Compact Worklog handoff boundary and the fallback guard.

## Why It Matters
- This is the first user-visible step where the anchor can preserve live-to-final Worklog continuity instead of letting settlement discard and rebuild the activity trace from a weaker source.
- It directly addresses the class of bugs where final settlement can reorder, drop, or temporarily hide Worklog rows while the final answer appears.
- It keeps the rollout reversible: if the anchor scene is not complete enough or does not prove same-session ownership, the old settled rendering path still wins.

## Contract Routing
- Contract owner: Stable Assistant Turn Anchor / live-to-final rendering consistency (#3926, parent #3400).
- Contract document updated: `docs/architecture/stable-assistant-turn-anchor-phase0.md`.
- Intentional contract change: `activity_scene_v1` is no longer fully inert for rendering; it may feed the settled Compact Worklog path only through the guarded handoff added here.
- Out of scope: Transparent Stream ownership, durable reload/replay rebuild, backend RuntimeAdapter migration, and removal of legacy `S.toolCalls` fallback.

## Verification
- `node --check static/ui.js`
- `node --check static/messages.js`
- `node --check static/assistant_turn_anchors.js`
- `git diff --check`
- `python -m pytest tests/test_stable_assistant_turn_anchor_registry.py -q`
- `python -m pytest tests/test_issue3401_deep_review_fixes.py tests/test_stable_assistant_turn_anchor_phase0.py tests/test_live_activity_timeline.py tests/test_ui_tool_call_cleanup.py tests/test_stream_end_recovery_gating.py tests/test_stable_assistant_turn_anchor_normalizer.py tests/test_issue3820_chat_activity_display_mode.py tests/test_issue1690_scroll_completion.py -q`
- Local result: 26 passed + 124 passed.
- GitHub Actions result after the latest push: browser-smoke, lint, and all Python 3.11 / 3.12 / 3.13 test shards passed.

## Risks / Follow-ups
- This PR intentionally relies on the retained live anchor registry for the settled handoff. Reload/session-switch durable rebuild remains the next slice.
- Visual surface is the existing Compact Worklog renderer; no new row/card styling is introduced here. A human 8787 visual pass is still useful before marking the draft ready if reviewers want UI evidence attached.
- Legacy `S.toolCalls` and `assistantThinking` stay in place as fallback until the durable reload/replay slice proves equivalent coverage.

## Model Used
- GPT-5 Codex assisted with implementation, tests, documentation, and PR preparation.

