### PR TITLE
ci: add Trivy scan, coverage gate, and branch protection docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,25 @@ jobs:
           build-args: HERMES_VERSION=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # ─── Docker image security scan (trivy) ──────────────────────────────
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}
+          format: 'table'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          timeout: '10m'
+        if: steps.meta.outputs.version != ''
+
+      - name: Run Trivy on Dockerfile (config scan)
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: .
+          scanners: 'misconfig'
+          format: 'table'
+          exit-code: '0'
+          severity: 'HIGH,MEDIUM'
+          timeout: '5m'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install "pyyaml>=6.0" pytest pytest-timeout pytest-asyncio pytest-shard
+          pip install pytest-cov coverage
           # ruff is installed so tests/test_ruff_forward_lint.py runs its E9/F821
           # tree-clean assertions in-suite (mirrors how eslint is available for
           # tests/test_static_js_runtime_lint.py). If install fails the test
@@ -106,4 +107,4 @@ jobs:
           pip install mcp || echo "mcp install failed — test_mcp_server.py will importorskip"
 
       - name: Run tests (shard ${{ matrix.shard }} of 3)
-        run: pytest tests/ -v --timeout=60 --shard-id=${{ matrix.shard }} --num-shards=3
+        run: pytest tests/ -v --timeout=60 --shard-id=${{ matrix.shard }} --num-shards=3 --cov=. --cov-report=xml --cov-fail-under=80

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,3 +203,23 @@ Want the smoothest review?
 - [SPRINTS.md](SPRINTS.md)
 
 Questions are best raised early, before a large change is finished.
+
+## Branch Protection
+
+The `master` branch is protected to enforce quality gates. Required checks:
+
+| Check | Workflow / Job | Purpose |
+|-------|---------------|---------|
+| `Tests / lint` | `.github/workflows/tests.yml` | Ruff Python lint + ESLint JS runtime guards |
+| `Tests / test` | `.github/workflows/tests.yml` | Full test suite (3 Python versions × 3 shards) |
+| `Browser smoke` | `.github/workflows/browser-smoke.yml` | Headless browser page-load smoke tests |
+| `Dependency Audit` | `.github/workflows/dep-audit.yml` | pip-audit + npm audit + semgrep |
+| `Security Scan` | `.github/workflows/security-scan.yml` | gitleaks + bandit + safety + ruff format |
+| `Lint configs` | `.github/workflows/lint-configs.yml` | yamllint + hadolint |
+| `Post-merge feature checks` | `.github/workflows/feature-checks.yml` | Live server feature validation |
+
+Review requirements:
+- **CODEOWNERS** auto-assigns reviewers for sensitive paths (see `.github/CODEOWNERS`)
+- All required status checks must pass before merging
+- At least one approving review is required (unless exempt by CODEOWNERS)
+


### PR DESCRIPTION
## Summary

- Add Trivy Docker image vulnerability scanner to `release.yml` (blocks on CRITICAL/HIGH)
- Add Trivy filesystem/misconfig scan to `release.yml`
- Add `pytest-cov` to test pipeline and enforce 80% coverage threshold
- Document branch protection requirements and required status checks in `CONTRIBUTING.md`

## Test plan

- [ ] Verify Trivy scan step runs on next release tag
- [ ] Verify test suite fails if coverage drops below 80%
- [ ] Confirm `CONTRIBUTING.md` branch protection table is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)