### PR TITLE
Add mobile interaction polish

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -146,6 +146,26 @@ async function _recoverFromOfflineSoftly(){
   }
 }
 function _isAbortError(e){return !!(e&&(e.name==='AbortError'||e.code===20));}
+function _prefersReducedMotion(){
+  try{
+    return !!(window.matchMedia&&window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+  }catch(_){
+    return false;
+  }
+}
+function _triggerHaptic(ms){
+  if(_prefersReducedMotion()) return false;
+  const duration=Number(ms)||0;
+  if(duration<=0) return false;
+  const desktopBridge=(typeof window!=='undefined')?window.__HERMES_DESKTOP__:null;
+  if(desktopBridge&&typeof desktopBridge.haptic==='function'){
+    try{desktopBridge.haptic({duration});return true;}
+    catch(_){}
+  }
+  if(typeof navigator==='undefined'||typeof navigator.vibrate!=='function') return false;
+  try{return navigator.vibrate(duration)!==false;}
+  catch(_){return false;}
+}
 function _patchOfflineFetch(){
   if(_offlineFetchPatched||typeof window.fetch!=='function')return;
   _offlineFetchPatched=true;
@@ -2487,6 +2507,7 @@ let _lastScrollTop=null;
 let _lastNonMessageScrollIntentMs=-Infinity;
 let _messageUserUnpinned=false;
 let _bottomSettleToken=0;
+let _smoothScrollToken=0;
 let _settleRAF=0;
 let _settleRO=null;
 let _settleTimer=0;
@@ -2583,6 +2604,7 @@ function _resetScrollDirectionTracker(){
   _scrollPinned=true;
   _nearBottomCount=0;
   _touchStartY=null;
+  _syncCompletedTodoSeenSet([]);
 }
 function _resetStreamScrollFollow(){
   _clearNewMessageScrollCue();
@@ -3124,10 +3146,39 @@ document.addEventListener('DOMContentLoaded',function(){
   tooltip.addEventListener('click',function(e){e.stopPropagation();});
 });
 
-function _setMessageScrollToBottom(){
+function _releaseProgrammaticScroll(){
+  requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+}
+function _setMessageScrollToBottom(options){
   const el=$('messages');
   if(!el) return;
+  const smooth=!!(options&&options.smooth)&&!_prefersReducedMotion()&&typeof el.scrollTo==='function';
   _programmaticScroll=true;
+  if(smooth){
+    const token=++_smoothScrollToken;
+    try{
+      el.scrollTo({top:el.scrollHeight,behavior:'smooth'});
+    }catch(_){
+      _smoothScrollToken++;
+      el.scrollTop=el.scrollHeight;
+      _lastScrollTop=el.scrollTop;
+      _nearBottomCount=2;
+      _scrollPinned=true;
+      _releaseProgrammaticScroll();
+      return;
+    }
+    _nearBottomCount=2;
+    _scrollPinned=true;
+    // Keep the programmatic latch through the browser's smooth-scroll frames so
+    // the scroll listener does not misread them as user intent. A later settle
+    // pass still writes the final exact bottom position after layout growth.
+    setTimeout(()=>{
+      if(token!==_smoothScrollToken) return;
+      _lastScrollTop=el.scrollTop;
+      _releaseProgrammaticScroll();
+    },360);
+    return;
+  }
   el.scrollTop=el.scrollHeight;
   _lastScrollTop=el.scrollTop;
   _nearBottomCount=2;
@@ -3140,14 +3191,14 @@ function _setMessageScrollToBottom(){
     // is the authoritative "user scrolled away" signal, so DON'T snap them back
     // or re-pin if so; only release the programmatic-scroll latch.
     if(_messageUserUnpinned || !_scrollPinned || _recentNonMessageScrollIntent()){
-      requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+      _releaseProgrammaticScroll();
       return;
     }
     el.scrollTop=el.scrollHeight;
     _lastScrollTop=el.scrollTop;
     _nearBottomCount=2;
     _scrollPinned=true;
-    requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+    _releaseProgrammaticScroll();
   });
 }
 function _isMessagePaneNearBottom(threshold=250){
@@ -3174,11 +3225,12 @@ function _followMessagesAfterDomReplace(){
   }
   return false;
 }
-function _settleMessageScrollToBottom(force, explicit){
+function _settleMessageScrollToBottom(force, explicit, options){
   // `explicit` = a user-invoked scroll-to-bottom (End button / scrollToBottom()).
   // When explicit, late-layout settling runs even if Auto-follow is OFF — the
   // setting only suppresses AUTOMATIC streaming follow, not a deliberate jump
   // to the bottom. (Codex #4006 r3.)
+  // Markdown post-processing (Prism, tables, Mermaid/KaTeX/PDF placeholders)
   // can grow the transcript after the first scroll write. Re-apply the bottom
   // position when content settles so late layout does not leave the viewport
   // above the real end. User scroll increments _bottomSettleToken and cancels.
@@ -3192,13 +3244,16 @@ function _settleMessageScrollToBottom(force, explicit){
   // scrollTop once via rAF (batches multiple resize callbacks per frame into
   // a single write). After 300ms of no resize events, the observer disconnects.
   const token=++_bottomSettleToken;
+  const afterSmooth=!!(options&&options.afterSmooth);
   cancelAnimationFrame(_settleRAF);
   if(_settleRO){ _settleRO.disconnect(); _settleRO=null; }
   clearTimeout(_settleTimer);
   clearTimeout(_settleFinalTimer);
 
-  // Sync write anchors the viewport immediately.
-  _setMessageScrollToBottom();
+  // Sync write anchors the viewport immediately unless an explicit smooth jump
+  // already started. Skipping it for smooth preserves the animation while the
+  // observer/fallback below still handles late layout growth.
+  if(!afterSmooth) _setMessageScrollToBottom();
 
   if(force) return;
 
@@ -3278,13 +3333,10 @@ function scrollToBottom(){
   _clearNewMessageScrollCue();
   _scrollPinned=true;
   _messageUserUnpinned=false;
-  // Write scrollTop once synchronously to anchor the viewport, then let
-  // ResizeObserver settle handle any late layout growth (Prism, KaTeX,
-  // Mermaid, images).  Using force=false so the observer runs — force=true
-  // was skipping the observer and causing Firefox paint jumps when
-  // renderMessages({preserveScroll:true}) + scrollToBottom() fired back-to-back.
-  _setMessageScrollToBottom();
-  _settleMessageScrollToBottom(false, true);
+  // Start explicit bottom jumps with smooth scrolling where supported, then let
+  // ResizeObserver settle any late layout growth without smoothing streaming.
+  _setMessageScrollToBottom({smooth:true});
+  _settleMessageScrollToBottom(false, true, {afterSmooth:true});
   _syncScrollToBottomCue(false,{newMessage:false});
   if(typeof _updateSessionStartJumpButton==='function') _updateSessionStartJumpButton();
 }
@@ -5305,6 +5357,7 @@ function clearInflightState(sid){
 // any other innerHTML path in this file.
 let _todosLastRenderedHash=null;
 let _todosRenderRafId=0;
+let _todosCompletedIdsSeen=new Set();
 
 function _todosHash(items){
   if(!Array.isArray(items)) return '';
@@ -5328,17 +5381,53 @@ function _todosPanelIsActive(){
   return !!(panel&&panel.classList&&panel.classList.contains('active'));
 }
 
+function _todoIdentity(item){
+  if(!item||typeof item!=='object') return '';
+  return String(item.id||item.content||'').trim();
+}
+
+function _todoIsCompleted(item){
+  return !!(item&&item.status==='completed');
+}
+
+function _syncCompletedTodoSeenSet(todos){
+  _todosCompletedIdsSeen=new Set();
+  if(!Array.isArray(todos)) return;
+  todos.forEach(item=>{
+    const id=_todoIdentity(item);
+    if(id&&_todoIsCompleted(item)) _todosCompletedIdsSeen.add(id);
+  });
+}
+
+function _checkAndFireTodoHaptic(todos){
+  if(!Array.isArray(todos)) return;
+  let newlyCompleted=false;
+  todos.forEach(item=>{
+    const id=_todoIdentity(item);
+    if(!id) return;
+    if(_todoIsCompleted(item)){
+      if(!_todosCompletedIdsSeen.has(id)) newlyCompleted=true;
+      _todosCompletedIdsSeen.add(id);
+    }else{
+      _todosCompletedIdsSeen.delete(id);
+    }
+  });
+  if(newlyCompleted) _triggerHaptic(30);
+}
+
 function scheduleTodosRefresh(){
   // Idempotent: many `todo_state` events fire on each tool result, but
   // only the latest snapshot needs to paint.  RAF lets us coalesce
   // without timer drift.
   if(_todosRenderRafId) return;
   if(typeof requestAnimationFrame!=='function'){
+    _checkAndFireTodoHaptic(S.todos);
     if(typeof loadTodos==='function') loadTodos();
     return;
   }
   _todosRenderRafId=requestAnimationFrame(()=>{
     _todosRenderRafId=0;
+    _checkAndFireTodoHaptic(S.todos);
     if(!_todosPanelIsActive()) return;
     if(typeof loadTodos==='function') loadTodos();
   });
@@ -5427,6 +5516,7 @@ function _hydrateTodosFromSession(session){
     S.todos=[];
     S.todoStateMeta=null;
   }
+  _syncCompletedTodoSeenSet(S.todos);
   _resetTodosRenderCache();
 }
 

--- a/tests/test_interaction_polish_static.py
+++ b/tests/test_interaction_polish_static.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.index(signature)
+    brace = src.index("{", start)
+    depth = 0
+    for i in range(brace, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise AssertionError(f"function body not found: {signature}")
+
+
+def test_reduced_motion_and_haptic_helpers_are_progressive_enhancement():
+    reduced = _function_body(UI_JS, "function _prefersReducedMotion")
+    haptic = _function_body(UI_JS, "function _triggerHaptic")
+
+    assert "matchMedia('(prefers-reduced-motion: reduce)')" in reduced
+    assert "try{" in reduced and "catch(_)" in reduced
+    assert "_prefersReducedMotion()" in haptic
+    assert "typeof navigator==='undefined'" in haptic
+    assert "typeof navigator.vibrate!=='function'" in haptic
+    assert "window.__HERMES_DESKTOP__" in haptic
+    assert "desktopBridge.haptic({duration})" in haptic
+    assert "navigator.vibrate(duration)" in haptic
+    assert "return false" in haptic
+
+
+def test_smooth_bottom_scroll_is_explicit_reduced_motion_safe_and_latched():
+    set_bottom = _function_body(UI_JS, "function _setMessageScrollToBottom")
+    scroll = _function_body(UI_JS, "function scrollToBottom")
+    pinned = _function_body(UI_JS, "function scrollIfPinned")
+    settle = _function_body(UI_JS, "function _settleMessageScrollToBottom")
+
+    assert "function _setMessageScrollToBottom(options)" in set_bottom
+    assert "options&&options.smooth" in set_bottom
+    assert "!_prefersReducedMotion()" in set_bottom
+    assert "typeof el.scrollTo==='function'" in set_bottom
+    assert "_programmaticScroll=true" in set_bottom
+    assert "el.scrollTo({top:el.scrollHeight,behavior:'smooth'})" in set_bottom
+    assert "let _smoothScrollToken=0;" in UI_JS
+    assert "const token=++_smoothScrollToken" in set_bottom
+    assert "try{" in set_bottom
+    assert "catch(_)" in set_bottom
+    assert "_smoothScrollToken++" in set_bottom
+    assert "el.scrollTop=el.scrollHeight" in set_bottom
+    assert "if(token!==_smoothScrollToken) return;" in set_bottom
+    assert "_releaseProgrammaticScroll()" in set_bottom
+    assert "setTimeout(()=>" in set_bottom
+    assert "},360)" in set_bottom
+
+    assert "_setMessageScrollToBottom({smooth:true})" in scroll
+    assert "_settleMessageScrollToBottom(false, true, {afterSmooth:true})" in scroll
+    assert "options&&options.afterSmooth" in settle
+    assert "if(!afterSmooth) _setMessageScrollToBottom();" in settle
+    assert "_setMessageScrollToBottom({smooth:true})" not in pinned
+    assert "_settleMessageScrollToBottom(false)" in pinned
+    assert "new ResizeObserver" in settle
+    assert "getElementById('msgInner')" in settle
+    assert "2000" in settle
+    assert "if(!afterSmooth) _setMessageScrollToBottom();" in settle
+
+
+def test_todo_completion_haptics_are_batched_and_not_panel_dependent():
+    schedule = _function_body(UI_JS, "function scheduleTodosRefresh")
+    check = _function_body(UI_JS, "function _checkAndFireTodoHaptic")
+    completed = _function_body(UI_JS, "function _todoIsCompleted")
+    sync_seen = _function_body(UI_JS, "function _syncCompletedTodoSeenSet")
+    hydrate = _function_body(UI_JS, "function _hydrateTodosFromSession")
+    reset_scroll = _function_body(UI_JS, "function _resetScrollDirectionTracker")
+
+    assert "let _todosCompletedIdsSeen=new Set();" in UI_JS
+    assert "item.status==='completed'" in completed
+    assert "_triggerHaptic(30)" in check
+    assert "newlyCompleted" in check
+    assert "_todosCompletedIdsSeen.add(id)" in check
+    assert "_todosCompletedIdsSeen.delete(id)" in check
+
+    raf_haptic_idx = schedule.index("_checkAndFireTodoHaptic(S.todos);")
+    panel_idx = schedule.index("if(!_todosPanelIsActive()) return;")
+    assert raf_haptic_idx < panel_idx
+    assert schedule.count("_checkAndFireTodoHaptic(S.todos);") == 2
+
+    assert "_syncCompletedTodoSeenSet(S.todos);" in hydrate
+    assert hydrate.index("_syncCompletedTodoSeenSet(S.todos);") > hydrate.index("S.todos=[]")
+    assert "_todosCompletedIdsSeen=new Set();" in sync_seen
+    assert "_syncCompletedTodoSeenSet([]);" in reset_scroll

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -55,10 +55,12 @@ def test_scroll_to_bottom_settles_across_late_markdown_layout_growth():
         "not the fixed #messages scroll container"
     )
     assert "2000" in settle, "a 2s fallback must cover fully-static content that never resizes"
-    # scrollToBottom uses force=false so the observer runs, and explicit=true so the
-    # settle still runs even when Auto-follow is off (explicit user jump). The
-    # automatic scrollIfPinned() path passes no explicit flag (stays auto-gated).
-    assert "_settleMessageScrollToBottom(false, true)" in scroll
+    assert "options&&options.afterSmooth" in settle
+    assert "if(!afterSmooth) _setMessageScrollToBottom();" in settle
+    # scrollToBottom uses force=false so the observer runs, explicit=true so the
+    # settle still runs when Auto-follow is off, and afterSmooth=true so the
+    # initial smooth jump is not overwritten by an immediate instant scroll.
+    assert "_settleMessageScrollToBottom(false, true, {afterSmooth:true})" in scroll
     assert "_settleMessageScrollToBottom(false)" in pinned
     assert "!_scrollPinned" in settle
     assert "const token=++_bottomSettleToken" in settle
@@ -68,13 +70,13 @@ def test_scroll_to_bottom_settles_across_late_markdown_layout_growth():
 def test_scroll_to_bottom_writes_scroll_position_immediately_before_delayed_settle():
     scroll = _function_body(UI_JS, "function scrollToBottom")
 
-    immediate_idx = scroll.index("_setMessageScrollToBottom();")
-    settle_idx = scroll.index("_settleMessageScrollToBottom(false, true)")
+    immediate_idx = scroll.index("_setMessageScrollToBottom({smooth:true});")
+    settle_idx = scroll.index("_settleMessageScrollToBottom(false, true, {afterSmooth:true})")
 
     assert immediate_idx < settle_idx, (
-        "scrollToBottom() must write scrollTop synchronously before scheduling the "
-        "ResizeObserver settle; otherwise a DOM-rebuild scroll event can cancel the "
-        "delayed settle and strand the viewport at the top"
+        "scrollToBottom() must start the explicit smooth bottom action before scheduling "
+        "the ResizeObserver settle; otherwise the settle can overwrite the animation or "
+        "a DOM rebuild can strand the viewport at the top"
     )
 
 


### PR DESCRIPTION
## Summary
- add reduced-motion-safe smooth scroll for explicit bottom jumps
- add progressive task-completion haptics via web vibration and optional desktop bridge
- preserve upstream ResizeObserver scroll settling and instant streaming follow

## Verification
- npm run lint:runtime
- node --check static/ui.js && node --check static/panels.js
- /Users/zaynkhan/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_tars_scroll_reset_regressions.py tests/test_todo_state.py tests/test_todo_state_emission.py tests/test_todo_panel_cold_load_static.py tests/test_todo_live_frontend_static.py tests/test_interaction_polish_static.py -v --timeout=60
- tests/browser_smoke.py attempted locally; skipped because Playwright is not installed in this environment

## AI Usage
Implemented with Hermes Agent/Codex workflow, including scoped independent review and local regression gates.