### PR TITLE
Fix regenerate-title for CLI/TUI sessions that lack sidecar files

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -7750,11 +7750,10 @@ def handle_post(handler, parsed) -> bool:
         sid = body["session_id"]
         prefer_latest = bool(body.get("prefer_latest", False))
         try:
-            s = get_session(sid)
-            s = _ensure_full_session_before_mutation(sid, s)
+            s = _get_or_materialize_session(sid)
         except KeyError:
             return bad(handler, "Session not found", 404)
-        if getattr(s, "read_only", False):
+        except PermissionError:
             return bad(handler, "Read-only imported sessions cannot be renamed", 403)
         next_title, reason, raw_preview = generate_session_title_for_session(s, prefer_latest=prefer_latest)
         if not next_title:

--- a/tests/test_issue3987_imported_session_titles.py
+++ b/tests/test_issue3987_imported_session_titles.py
@@ -213,8 +213,8 @@ def test_regenerate_endpoint_only_blocks_read_only_imported_sessions():
     endpoint_idx = ROUTES_PY.index('"/api/session/title/regenerate"')
     next_endpoint_idx = ROUTES_PY.index('"/api/personality/set"', endpoint_idx)
     block = ROUTES_PY[endpoint_idx:next_endpoint_idx]
-    assert 'if getattr(s, "read_only", False):' in block
-    assert 'getattr(s, "is_imported", False)' not in block
+    assert "_get_or_materialize_session(sid)" in block
+    assert "except PermissionError:" in block
 
 
 def test_sessions_ui_keeps_regenerate_action_for_writable_imports():

--- a/tests/test_issue4183_regenerate_materialize.py
+++ b/tests/test_issue4183_regenerate_materialize.py
@@ -1,0 +1,35 @@
+"""Issue #4183: regenerate-title must materialize CLI/TUI sessions from state.db.
+
+The /api/session/title/regenerate endpoint must use _get_or_materialize_session
+so sessions that only exist in state.db (no sidecar JSON) can have their titles
+regenerated instead of returning "Session not found".
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTES_PY = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+
+
+def test_regenerate_endpoint_uses_materialize_fallback():
+    start = ROUTES_PY.index('"/api/session/title/regenerate"')
+    end = ROUTES_PY.index('"/api/personality/set"', start)
+    block = ROUTES_PY[start:end]
+    assert "_get_or_materialize_session(sid)" in block, (
+        "regenerate handler must use _get_or_materialize_session to find "
+        "sessions that only exist in state.db (CLI/TUI sessions)"
+    )
+    assert "get_session(sid)" not in block, (
+        "regenerate handler must not use bare get_session — it misses "
+        "CLI/TUI sessions that lack a sidecar JSON file"
+    )
+
+
+def test_regenerate_endpoint_catches_permission_error():
+    start = ROUTES_PY.index('"/api/session/title/regenerate"')
+    end = ROUTES_PY.index('"/api/personality/set"', start)
+    block = ROUTES_PY[start:end]
+    assert "except PermissionError:" in block, (
+        "regenerate handler must catch PermissionError from "
+        "_get_or_materialize_session for read-only imported sessions"
+    )


### PR DESCRIPTION
## Summary

- The `/api/session/title/regenerate` endpoint used `get_session(sid)` which only finds sessions with materialized sidecar JSON files. CLI/TUI sessions that exist only in `state.db` (with null titles and no sidecar) raised `KeyError`, returning "Session not found".
- Replaced with `_get_or_materialize_session(sid)` which falls back to materializing a writable sidecar from `state.db`, matching the pattern used by rename, archive, and other mutation endpoints.
- Added `PermissionError` catch for read-only imported sessions, consistent with sibling handlers.

Closes #4183

## Test plan

- [x] New test `test_issue4183_regenerate_materialize.py` asserts the handler uses `_get_or_materialize_session` and catches `PermissionError`
- [x] Existing `test_session_title_regenerate_controls.py` suite (7 tests) still passes
- [x] `test_issue3225_rename_sync.py` still passes