### PR TITLE
Release NY (v0.51.412): gateway reasoning previews (#4148) + regenerate-title for CLI/TUI sessions (#4184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## [Unreleased]
 
+## [v0.51.412] — 2026-06-14 — Release NY (gateway reasoning previews + regenerate-title for CLI/TUI sessions, #4146/#4183)
+
+### Fixed
+
+- **Gateway-routed chat now surfaces reasoning/thinking previews in the WebUI (#4146).** When chat is routed through a running Hermes Gateway, reasoning fragments streamed by reasoning-capable models (`delta.reasoning_content`) now appear as a thinking preview, matching the non-gateway streaming path. Only string reasoning fragments are forwarded (structured payloads are never stringified into the browser), inter-delta whitespace is preserved, and the accumulated reasoning is persisted onto the saved assistant message so it survives a transcript reload. (#4146)
+- **Regenerating a title now works for CLI/TUI sessions that exist only in `state.db` (#4183).** The `/api/session/title/regenerate` endpoint previously used a sidecar-only lookup, so CLI/TUI sessions without a materialized sidecar JSON returned "Session not found". It now materializes a writable sidecar from `state.db` (the same pattern rename and archive use) and returns a clear 403 for read-only imported sessions. (#4183)
+
 ## [v0.51.411] — 2026-06-14 — Release NX (offline recovery verifies unreliable browser offline reports via /health probe, #4170)
 
 ### Fixed

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -145,13 +145,11 @@ def _gateway_stream_usage(payload: dict) -> dict:
 def _gateway_reasoning_delta(payload: dict) -> str:
     if not isinstance(payload, dict):
         return ""
-    return str(
-        payload.get("text")
-        or payload.get("preview")
-        or payload.get("delta")
-        or payload.get("content")
-        or ""
-    ).strip()
+    for key in ("text", "preview", "delta", "content"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
 
 
 def _gateway_tool_progress_event(payload: dict) -> tuple[str, dict] | None:
@@ -375,7 +373,7 @@ def _run_gateway_chat_streaming(
                         if event_name == "reasoning":
                             reason_delta = event_payload.get("text")
                             if reason_delta and stream_id in STREAM_REASONING_TEXT:
-                                STREAM_REASONING_TEXT[stream_id] += str(reason_delta)
+                                STREAM_REASONING_TEXT[stream_id] += reason_delta
                         elif stream_id in STREAM_LIVE_TOOL_CALLS:
                             if event_name == "tool":
                                 STREAM_LIVE_TOOL_CALLS[stream_id].append({
@@ -439,6 +437,9 @@ def _run_gateway_chat_streaming(
             if attachments:
                 user_msg["attachments"] = list(attachments)
             assistant_msg = {"role": "assistant", "content": assistant_text, "timestamp": assistant_ts}
+            saved_reasoning = STREAM_REASONING_TEXT.get(stream_id, "")
+            if saved_reasoning:
+                assistant_msg["reasoning"] = saved_reasoning
             previous_context = list(getattr(s, "context_messages", None) or getattr(s, "messages", None) or [])
             s.context_messages = previous_context + [user_msg, assistant_msg]
             try:

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -147,7 +147,14 @@ def _gateway_tool_progress_event(payload: dict) -> tuple[str, dict] | None:
     if not isinstance(payload, dict):
         return None
     name = str(payload.get("tool") or payload.get("name") or payload.get("function_name") or "").strip()
-    if not name or name.startswith("_"):
+    if not name:
+        return None
+    if name == "_thinking":
+        reason_delta = str(payload.get("preview") or payload.get("delta") or "").strip()
+        if not reason_delta:
+            return None
+        return "reasoning", {"text": reason_delta}
+    if name.startswith("_"):
         return None
     status = str(payload.get("status") or "running").strip().lower()
     tid = payload.get("toolCallId") or payload.get("tool_call_id") or payload.get("id")
@@ -353,7 +360,11 @@ def _run_gateway_chat_streaming(
                     translated = _gateway_tool_progress_event(payload)
                     if translated:
                         event_name, event_payload = translated
-                        if stream_id in STREAM_LIVE_TOOL_CALLS:
+                        if event_name == "reasoning":
+                            reason_delta = event_payload.get("text")
+                            if reason_delta and stream_id in STREAM_REASONING_TEXT:
+                                STREAM_REASONING_TEXT[stream_id] += str(reason_delta)
+                        elif stream_id in STREAM_LIVE_TOOL_CALLS:
                             if event_name == "tool":
                                 STREAM_LIVE_TOOL_CALLS[stream_id].append({
                                     "name": event_payload.get("name"),
@@ -372,7 +383,23 @@ def _run_gateway_chat_streaming(
                                         shared_tc["is_error"] = bool(event_payload.get("is_error"))
                                         break
                         put_gateway_event(event_name, event_payload)
-                        update_active_run(stream_id, phase="gateway-tool", latest_tool=event_payload.get("name"))
+                        if event_name != "reasoning":
+                            update_active_run(stream_id, phase="gateway-tool", latest_tool=event_payload.get("name"))
+                    sse_event = "message"
+                    continue
+                if sse_event == "reasoning.available":
+                    reason_delta = (
+                        payload.get("text")
+                        or payload.get("preview")
+                        or payload.get("delta")
+                        or payload.get("content")
+                        or ""
+                    )
+                    reason_delta = str(reason_delta).strip()
+                    if reason_delta:
+                        if stream_id in STREAM_REASONING_TEXT:
+                            STREAM_REASONING_TEXT[stream_id] += reason_delta
+                        put_gateway_event("reasoning", {"text": reason_delta})
                     sse_event = "message"
                     continue
                 last_payload = payload

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -142,6 +142,18 @@ def _gateway_stream_usage(payload: dict) -> dict:
     }
 
 
+def _gateway_reasoning_delta(payload: dict) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    return str(
+        payload.get("text")
+        or payload.get("preview")
+        or payload.get("delta")
+        or payload.get("content")
+        or ""
+    ).strip()
+
+
 def _gateway_tool_progress_event(payload: dict) -> tuple[str, dict] | None:
     """Translate Hermes Gateway tool-progress SSE payloads to WebUI events."""
     if not isinstance(payload, dict):
@@ -150,7 +162,7 @@ def _gateway_tool_progress_event(payload: dict) -> tuple[str, dict] | None:
     if not name:
         return None
     if name == "_thinking":
-        reason_delta = str(payload.get("preview") or payload.get("delta") or "").strip()
+        reason_delta = _gateway_reasoning_delta(payload)
         if not reason_delta:
             return None
         return "reasoning", {"text": reason_delta}
@@ -388,14 +400,7 @@ def _run_gateway_chat_streaming(
                     sse_event = "message"
                     continue
                 if sse_event == "reasoning.available":
-                    reason_delta = (
-                        payload.get("text")
-                        or payload.get("preview")
-                        or payload.get("delta")
-                        or payload.get("content")
-                        or ""
-                    )
-                    reason_delta = str(reason_delta).strip()
+                    reason_delta = _gateway_reasoning_delta(payload)
                     if reason_delta:
                         if stream_id in STREAM_REASONING_TEXT:
                             STREAM_REASONING_TEXT[stream_id] += reason_delta

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -131,6 +131,24 @@ def _gateway_sse_delta(payload: dict) -> str:
         return ""
 
 
+def _gateway_sse_reasoning_delta(payload: dict) -> str:
+    """Extract reasoning text from OpenAI-compatible streaming chunks."""
+    try:
+        choices = payload.get("choices") or []
+        if not choices:
+            return ""
+        choice = choices[0] or {}
+        delta = choice.get("delta") or {}
+        reasoning = delta.get("reasoning_content")
+        if isinstance(reasoning, str) and reasoning.strip():
+            return reasoning
+        message = choice.get("message") or {}
+        reasoning = message.get("reasoning_content")
+        return reasoning if isinstance(reasoning, str) and reasoning.strip() else ""
+    except Exception:
+        return ""
+
+
 def _gateway_stream_usage(payload: dict) -> dict:
     usage = payload.get("usage") if isinstance(payload, dict) else None
     if not isinstance(usage, dict):
@@ -406,6 +424,11 @@ def _run_gateway_chat_streaming(
                     sse_event = "message"
                     continue
                 last_payload = payload
+                reasoning_delta = _gateway_sse_reasoning_delta(payload)
+                if reasoning_delta:
+                    if stream_id in STREAM_REASONING_TEXT:
+                        STREAM_REASONING_TEXT[stream_id] += reasoning_delta
+                    put_gateway_event("reasoning", {"text": reasoning_delta})
                 delta = _gateway_sse_delta(payload)
                 if delta:
                     final_text += delta

--- a/api/routes.py
+++ b/api/routes.py
@@ -7750,11 +7750,10 @@ def handle_post(handler, parsed) -> bool:
         sid = body["session_id"]
         prefer_latest = bool(body.get("prefer_latest", False))
         try:
-            s = get_session(sid)
-            s = _ensure_full_session_before_mutation(sid, s)
+            s = _get_or_materialize_session(sid)
         except KeyError:
             return bad(handler, "Session not found", 404)
-        if getattr(s, "read_only", False):
+        except PermissionError:
             return bad(handler, "Read-only imported sessions cannot be renamed", 403)
         next_title, reason, raw_preview = generate_session_title_for_session(s, prefer_latest=prefer_latest)
         if not next_title:

--- a/tests/test_issue3987_imported_session_titles.py
+++ b/tests/test_issue3987_imported_session_titles.py
@@ -213,8 +213,8 @@ def test_regenerate_endpoint_only_blocks_read_only_imported_sessions():
     endpoint_idx = ROUTES_PY.index('"/api/session/title/regenerate"')
     next_endpoint_idx = ROUTES_PY.index('"/api/personality/set"', endpoint_idx)
     block = ROUTES_PY[endpoint_idx:next_endpoint_idx]
-    assert 'if getattr(s, "read_only", False):' in block
-    assert 'getattr(s, "is_imported", False)' not in block
+    assert "_get_or_materialize_session(sid)" in block
+    assert "except PermissionError:" in block
 
 
 def test_sessions_ui_keeps_regenerate_action_for_writable_imports():

--- a/tests/test_issue4183_regenerate_materialize.py
+++ b/tests/test_issue4183_regenerate_materialize.py
@@ -1,0 +1,35 @@
+"""Issue #4183: regenerate-title must materialize CLI/TUI sessions from state.db.
+
+The /api/session/title/regenerate endpoint must use _get_or_materialize_session
+so sessions that only exist in state.db (no sidecar JSON) can have their titles
+regenerated instead of returning "Session not found".
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTES_PY = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+
+
+def test_regenerate_endpoint_uses_materialize_fallback():
+    start = ROUTES_PY.index('"/api/session/title/regenerate"')
+    end = ROUTES_PY.index('"/api/personality/set"', start)
+    block = ROUTES_PY[start:end]
+    assert "_get_or_materialize_session(sid)" in block, (
+        "regenerate handler must use _get_or_materialize_session to find "
+        "sessions that only exist in state.db (CLI/TUI sessions)"
+    )
+    assert "get_session(sid)" not in block, (
+        "regenerate handler must not use bare get_session — it misses "
+        "CLI/TUI sessions that lack a sidecar JSON file"
+    )
+
+
+def test_regenerate_endpoint_catches_permission_error():
+    start = ROUTES_PY.index('"/api/session/title/regenerate"')
+    end = ROUTES_PY.index('"/api/personality/set"', start)
+    block = ROUTES_PY[start:end]
+    assert "except PermissionError:" in block, (
+        "regenerate handler must catch PermissionError from "
+        "_get_or_materialize_session for read-only imported sessions"
+    )

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -138,6 +138,14 @@ def test_gateway_tool_progress_event_translates_gateway_lifecycle_payloads():
             "text": "Thinking...",
         },
     )
+    assert _gateway_tool_progress_event(
+        {"tool": "_thinking", "status": "running", "text": "Thinking from text..."}
+    ) == (
+        "reasoning",
+        {
+            "text": "Thinking from text...",
+        },
+    )
     assert _gateway_tool_progress_event({"tool": "_thinking", "status": "running"}) is None
 
 
@@ -242,6 +250,8 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
             yield b'event: hermes.tool.progress\n'
             yield b'data: {"tool":"terminal","label":"terminal: pytest","toolCallId":"call-1","status":"running"}\n\n'
             yield b'data: {"choices":[{"delta":{"content":"hel"}}]}\n\n'
+            yield b'event: hermes.tool.progress\n'
+            yield b'data: {"tool":"_thinking","text":"Thinking from tool progress"}\n\n'
             yield b'event: reasoning.available\n'
             yield b'data: {"text":"Reasoning preview", "preview":"Reasoning preview"}\n\n'
             yield b'event: hermes.tool.progress\n'
@@ -334,6 +344,7 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
         "is_error": False,
         "tid": "call-1",
     }) in event_pairs
+    assert ("reasoning", {"text": "Thinking from tool progress"}) in event_pairs
     assert ("reasoning", {"text": "Reasoning preview"}) in event_pairs
     assert ("tool_complete", {
         "event_type": "tool.completed",

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -13,6 +13,7 @@ from api.config import STREAMS, create_stream_channel
 from api.models import new_session
 from api.gateway_chat import (
     _gateway_http_error_event,
+    _gateway_reasoning_delta,
     _gateway_sse_delta,
     _gateway_stream_usage,
     _gateway_tool_progress_event,
@@ -147,6 +148,13 @@ def test_gateway_tool_progress_event_translates_gateway_lifecycle_payloads():
         },
     )
     assert _gateway_tool_progress_event({"tool": "_thinking", "status": "running"}) is None
+
+
+def test_gateway_reasoning_delta_keeps_string_deltas_and_ignores_structured_payloads():
+    assert _gateway_reasoning_delta({"text": " Let me"}) == " Let me"
+    assert _gateway_reasoning_delta({"text": "   ", "preview": " think"}) == " think"
+    assert _gateway_reasoning_delta({"content": {"text": "safe", "debug": {"note": "x"}}}) == ""
+    assert _gateway_reasoning_delta({"text": ["safe"], "preview": " more"}) == " more"
 
 
 def test_gateway_http_401_reports_gateway_auth_not_provider_key():
@@ -355,6 +363,68 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
         "tid": "call-1",
     }) in event_pairs
     assert all(len(item) == 3 and item[2] for item in events)
+
+
+def test_gateway_chat_worker_preserves_reasoning_delta_whitespace_and_persists_reasoning(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield b'data: {"choices":[{"delta":{"content":"hel"}}]}\n\n'
+            yield b'event: hermes.tool.progress\n'
+            yield b'data: {"tool":"_thinking","text":"Let me"}\n\n'
+            yield b'event: reasoning.available\n'
+            yield b'data: {"text":" think", "preview":"should not win"}\n\n'
+            yield b'event: reasoning.available\n'
+            yield b'data: {"content":{"text":"safe","debug":{"note":"x"}}}\n\n'
+            yield b'event: reasoning.available\n'
+            yield b'data: {"preview":" more"}\n\n'
+            yield b'data: {"choices":[{"delta":{"content":"lo"}}]}\n\n'
+            yield b'data: [DONE]\n\n'
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", lambda req, timeout=0: FakeResponse())
+
+    s = new_session()
+    stream_id = "stream-gateway-reasoning-persist-test"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.pending_started_at = 123
+    s.save()
+    channel = create_stream_channel()
+    subscriber = channel.subscribe()
+    STREAMS[stream_id] = channel
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+    )
+
+    saved = models.get_session(s.session_id)
+    assert saved.messages[-1]["content"] == "hello"
+    assert saved.messages[-1]["reasoning"] == "Let me think more"
+    reasoning_events = []
+    while not subscriber.empty():
+        item = subscriber.get_nowait()
+        if item[0] == "reasoning":
+            reasoning_events.append(item[1]["text"])
+    assert reasoning_events == ["Let me", " think", " more"]
+    assert not any("debug" in text for text in reasoning_events)
 
 
 def test_gateway_chat_worker_normalizes_prefill_slice_before_system_prefix(tmp_path, monkeypatch):

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -15,6 +15,7 @@ from api.gateway_chat import (
     _gateway_http_error_event,
     _gateway_reasoning_delta,
     _gateway_sse_delta,
+    _gateway_sse_reasoning_delta,
     _gateway_stream_usage,
     _gateway_tool_progress_event,
     gateway_chat_config_status,
@@ -155,6 +156,12 @@ def test_gateway_reasoning_delta_keeps_string_deltas_and_ignores_structured_payl
     assert _gateway_reasoning_delta({"text": "   ", "preview": " think"}) == " think"
     assert _gateway_reasoning_delta({"content": {"text": "safe", "debug": {"note": "x"}}}) == ""
     assert _gateway_reasoning_delta({"text": ["safe"], "preview": " more"}) == " more"
+
+
+def test_gateway_sse_reasoning_delta_extracts_reasoning_content_chunks():
+    assert _gateway_sse_reasoning_delta({"choices": [{"delta": {"reasoning_content": "Let me"}}]}) == "Let me"
+    assert _gateway_sse_reasoning_delta({"choices": [{"message": {"reasoning_content": "Done thinking"}}]}) == "Done thinking"
+    assert _gateway_sse_reasoning_delta({"choices": [{"delta": {"reasoning_content": "   "}}]}) == ""
 
 
 def test_gateway_http_401_reports_gateway_auth_not_provider_key():
@@ -425,6 +432,59 @@ def test_gateway_chat_worker_preserves_reasoning_delta_whitespace_and_persists_r
             reasoning_events.append(item[1]["text"])
     assert reasoning_events == ["Let me", " think", " more"]
     assert not any("debug" in text for text in reasoning_events)
+
+
+def test_gateway_chat_worker_reads_reasoning_content_deltas_from_chat_completions(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield b'data: {"choices":[{"delta":{"reasoning_content":"Let me ","content":"hel"}}]}\n\n'
+            yield b'data: {"choices":[{"delta":{"reasoning_content":"think","content":"lo"}}]}\n\n'
+            yield b'data: [DONE]\n\n'
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", lambda req, timeout=0: FakeResponse())
+
+    s = new_session()
+    stream_id = "stream-gateway-reasoning-content-test"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.pending_started_at = 123
+    s.save()
+    channel = create_stream_channel()
+    subscriber = channel.subscribe()
+    STREAMS[stream_id] = channel
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+    )
+
+    saved = models.get_session(s.session_id)
+    assert saved.messages[-1]["content"] == "hello"
+    assert saved.messages[-1]["reasoning"] == "Let me think"
+    reasoning_events = []
+    while not subscriber.empty():
+        item = subscriber.get_nowait()
+        if item[0] == "reasoning":
+            reasoning_events.append(item[1]["text"])
+    assert reasoning_events == ["Let me ", "think"]
 
 
 def test_gateway_chat_worker_normalizes_prefill_slice_before_system_prefix(tmp_path, monkeypatch):

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -130,6 +130,14 @@ def test_gateway_tool_progress_event_translates_gateway_lifecycle_payloads():
             "tid": "call-1",
         },
     )
+    assert _gateway_tool_progress_event(
+        {"tool": "_thinking", "status": "running", "preview": "Thinking..."}
+    ) == (
+        "reasoning",
+        {
+            "text": "Thinking...",
+        },
+    )
     assert _gateway_tool_progress_event({"tool": "_thinking", "status": "running"}) is None
 
 
@@ -234,6 +242,8 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
             yield b'event: hermes.tool.progress\n'
             yield b'data: {"tool":"terminal","label":"terminal: pytest","toolCallId":"call-1","status":"running"}\n\n'
             yield b'data: {"choices":[{"delta":{"content":"hel"}}]}\n\n'
+            yield b'event: reasoning.available\n'
+            yield b'data: {"text":"Reasoning preview", "preview":"Reasoning preview"}\n\n'
             yield b'event: hermes.tool.progress\n'
             yield b'data: {"tool":"terminal","toolCallId":"call-1","status":"completed"}\n\n'
             yield b'data: {"choices":[{"delta":{"content":"lo"}}],"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n'
@@ -324,6 +334,7 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
         "is_error": False,
         "tid": "call-1",
     }) in event_pairs
+    assert ("reasoning", {"text": "Reasoning preview"}) in event_pairs
     assert ("tool_complete", {
         "event_type": "tool.completed",
         "name": "terminal",


### PR DESCRIPTION
## Release NY — v0.51.412

Two clean re-gated contributor fixes (each independently Codex-gated SAFE; risk-separated from the approval-lifecycle fix shipping solo as NZ).

### Included
- **#4148** (rodboev): surface gateway reasoning previews in WebUI (#4146). Reasoning fragments streamed by reasoning-capable models over a gateway route now show as a thinking preview. Re-gated after a 3-finding bounce: only string fragments forwarded (no `str()` of structured payloads), inter-delta whitespace preserved, reasoning persisted on the saved message so it survives reload. Degrades gracefully where the agent side doesn't yet emit `delta.reasoning_content`.
- **#4184** (rodboev): regenerate-title now works for CLI/TUI sessions that exist only in `state.db` (#4183). `/api/session/title/regenerate` now uses `_get_or_materialize_session` (the canonical mutation pattern used by rename/archive) instead of a sidecar-only lookup, fixing the "Session not found" error; read-only imported sessions still return 403.

### Gates
- **Codex regression gate:** SAFE on each PR independently.
- **Opus advisor:** net-positive, no MUST-FIX.
- **py_compile, ruff forward gate:** CLEAN.
- **Full suite:** 8945 passed, 0 failed.

Co-authored-by: rodboev
