### PR TITLE
Fix misleading error in regenerate-title endpoint

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -7754,7 +7754,7 @@ def handle_post(handler, parsed) -> bool:
         except KeyError:
             return bad(handler, "Session not found", 404)
         except PermissionError:
-            return bad(handler, "Read-only imported sessions cannot be renamed", 403)
+            return bad(handler, "Read-only imported sessions cannot regenerate titles", 403)
         next_title, reason, raw_preview = generate_session_title_for_session(s, prefer_latest=prefer_latest)
         if not next_title:
             return bad(handler, f"Could not generate a better title ({reason or 'empty'})", 422)

--- a/tests/test_session_title_regenerate_controls.py
+++ b/tests/test_session_title_regenerate_controls.py
@@ -55,7 +55,7 @@ def test_regenerate_endpoint_persists_generated_title_without_reordering_sidebar
     block = ROUTES_PY[endpoint_idx:next_endpoint_idx]
     assert "generate_session_title_for_session" in block
     assert '_persist_generated_session_title(s, next_title, event_reason="session_title_regenerate")' in block
-    assert "Read-only imported sessions cannot be renamed" in block
+    assert "Read-only imported sessions cannot regenerate titles" in block
 
 
 def test_regenerate_helper_persists_generated_title_and_publishes_sidebar_refresh():


### PR DESCRIPTION
## Summary

- The PermissionError message in the regenerate-title endpoint said "cannot be renamed" (copy-pasted from the rename handler). Changed to "cannot regenerate titles" to match the actual action.

Follow-up to #4184 / #4183.

## Test plan

- [x] Updated assertion in `test_session_title_regenerate_controls.py`
- [x] All 28 related tests pass