### PR TITLE
[codex] Make request logging nonfatal

### DIFF
--- a/server.py
+++ b/server.py
@@ -299,6 +299,17 @@ class Handler(BaseHTTPRequestHandler):
 
     def log_message(self, fmt, *args): pass  # suppress default Apache-style log
 
+    @staticmethod
+    def _safe_webui_print(message: str) -> None:
+        """Emit a request log line without letting logging break responses."""
+        try:
+            print(message, flush=True)
+        except Exception:
+            # Agent/tool code can redirect or close process-wide stdout/stderr
+            # in another thread. HTTP response handling must not depend on
+            # those global streams remaining writable.
+            pass
+
     def log_request(self, code: str='-', size: str='-') -> None:
         """Structured JSON logs for each request."""
         import json as _json
@@ -325,7 +336,7 @@ class Handler(BaseHTTPRequestHandler):
         if forwarded_for:
             record_data['forwarded_for'] = forwarded_for
         record = _json.dumps(record_data)
-        print(f'[webui] {record}', flush=True)
+        self._safe_webui_print(f'[webui] {record}')
 
     def do_GET(self) -> None:
         self._req_t0 = time.time()
@@ -345,7 +356,7 @@ class Handler(BaseHTTPRequestHandler):
             # reconnect races; do not convert it into a misleading server 500.
             return
         except Exception:
-            print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc(), flush=True)
+            self._safe_webui_print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc())
             try:
                 j(self, {'error': 'Internal server error'}, status=500)
             except _CLIENT_DISCONNECT_ERRORS:
@@ -354,7 +365,7 @@ class Handler(BaseHTTPRequestHandler):
             except Exception:
                 # Unexpected failure while sending the error response itself.
                 # Log it so we know something is wrong with our error handler.
-                traceback.print_exc()
+                self._safe_webui_print(traceback.format_exc())
         finally:
             clear_request_profile()
 
@@ -384,7 +395,7 @@ class Handler(BaseHTTPRequestHandler):
             # reconnect races; do not convert it into a misleading server 500.
             return
         except Exception:
-            print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc(), flush=True)
+            self._safe_webui_print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc())
             try:
                 j(self, {'error': 'Internal server error'}, status=500)
             except _CLIENT_DISCONNECT_ERRORS:
@@ -393,7 +404,7 @@ class Handler(BaseHTTPRequestHandler):
             except Exception:
                 # Unexpected failure while sending the error response itself.
                 # Log it so we know something is wrong with our error handler.
-                traceback.print_exc()
+                self._safe_webui_print(traceback.format_exc())
         finally:
             clear_request_profile()
 

--- a/tests/test_broken_pipe_cascade.py
+++ b/tests/test_broken_pipe_cascade.py
@@ -10,6 +10,7 @@ The fix:
 - helpers._safe_write() catches _CLIENT_DISCONNECT_ERRORS (including ssl.SSLError)
 - server.py exception handlers wrap their 500-response j() calls in try/except
 """
+import io
 import ssl
 import unittest
 from unittest.mock import MagicMock
@@ -255,6 +256,52 @@ class TestServerDisconnectHandling(unittest.TestCase):
             _server_mod.check_auth = orig_check_auth
 
         handler.send_response.assert_not_called()
+
+    def test_log_request_ignores_closed_stdout(self):
+        """A poisoned stdout stream must not break send_response()."""
+        from server import Handler
+        handler = Handler.__new__(Handler)
+        handler.command = "GET"
+        handler.path = "/health"
+        handler._req_t0 = 0.0
+        handler.headers = {}
+        handler.client_address = ("127.0.0.1", 12345)
+
+        closed_stdout = io.StringIO()
+        closed_stdout.close()
+        original_stdout = sys.stdout
+        sys.stdout = closed_stdout
+        try:
+            Handler.log_request(handler, 200)
+        finally:
+            sys.stdout = original_stdout
+
+    def test_do_get_sends_500_when_stdout_closed(self):
+        """Route errors should still produce a 500 if stdout was closed."""
+        from server import Handler
+        handler = self._make_handler(route_raises=ValueError("real bug"))
+
+        def _fake_handle_get(self, parsed):
+            raise self._route_raises
+
+        import server as _server_mod
+        orig_handle_get = _server_mod.handle_get
+        orig_check_auth = _server_mod.check_auth
+        _server_mod.handle_get = _fake_handle_get
+        _server_mod.check_auth = lambda h, p: True
+
+        closed_stdout = io.StringIO()
+        closed_stdout.close()
+        original_stdout = sys.stdout
+        sys.stdout = closed_stdout
+        try:
+            Handler.do_GET(handler)
+        finally:
+            sys.stdout = original_stdout
+            _server_mod.handle_get = orig_handle_get
+            _server_mod.check_auth = orig_check_auth
+
+        handler.send_response.assert_called_once_with(500)
 
     def test_do_get_sends_500_on_real_error(self):
         from server import Handler


### PR DESCRIPTION
## Summary

Make request/access logging non-fatal during HTTP response handling. `Handler.log_request()` and request error logging now route through a small guarded print helper so a closed or redirected process-wide stdout/stderr stream cannot abort a response before headers are sent.

## Root Cause

In a threaded WebUI process, agent/tool code can temporarily redirect global `sys.stdout`/`sys.stderr`. If another thread restores one of those globals to a stream that has since been closed, `print(..., flush=True)` raises `ValueError: I/O operation on closed file`. `BaseHTTPRequestHandler.send_response()` calls `log_request()` before writing response headers, so a poisoned stdout can turn otherwise healthy endpoints, including `/health`, into empty TCP replies.

## Impact

This hardens the WebUI against a failure mode observed in production where `/health` accepted connections but returned an empty reply, causing Docker to mark the container unhealthy. Normal request handling no longer depends on stdout/stderr remaining writable.

## Validation

- `python -m pytest tests/test_broken_pipe_cascade.py`
- `python3 scripts/ruff_lint.py --diff origin/master`

Note: direct whole-file ruff over `server.py` still reports pre-existing findings outside this change; the repo's diff-scoped gate reports no new violations.
