### PR TITLE
Release OA (v0.51.414): fix misleading regenerate-title error message (#4186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.414] — 2026-06-14 — Release OA (fix misleading regenerate-title error message, #4186)
+
+### Fixed
+
+- **The read-only error for the regenerate-title action now reads correctly.** Attempting to regenerate a title on a read-only imported session returned "Read-only imported sessions cannot be renamed" (copy-pasted from the rename handler); it now says "cannot regenerate titles" to match the actual action. (#4186)
+
 ## [v0.51.413] — 2026-06-14 — Release NZ (restore approval pending-fallback reliability, #4107)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -7754,7 +7754,7 @@ def handle_post(handler, parsed) -> bool:
         except KeyError:
             return bad(handler, "Session not found", 404)
         except PermissionError:
-            return bad(handler, "Read-only imported sessions cannot be renamed", 403)
+            return bad(handler, "Read-only imported sessions cannot regenerate titles", 403)
         next_title, reason, raw_preview = generate_session_title_for_session(s, prefer_latest=prefer_latest)
         if not next_title:
             return bad(handler, f"Could not generate a better title ({reason or 'empty'})", 422)

--- a/tests/test_session_title_regenerate_controls.py
+++ b/tests/test_session_title_regenerate_controls.py
@@ -55,7 +55,7 @@ def test_regenerate_endpoint_persists_generated_title_without_reordering_sidebar
     block = ROUTES_PY[endpoint_idx:next_endpoint_idx]
     assert "generate_session_title_for_session" in block
     assert '_persist_generated_session_title(s, next_title, event_reason="session_title_regenerate")' in block
-    assert "Read-only imported sessions cannot be renamed" in block
+    assert "Read-only imported sessions cannot regenerate titles" in block
 
 
 def test_regenerate_helper_persists_generated_title_and_publishes_sidebar_refresh():


### PR DESCRIPTION
## Release OA — v0.51.414

Pure copy fix (no logic change).

- **#4186** (rodboev): the regenerate-title endpoint's read-only `PermissionError` message said "cannot be renamed" (copy-pasted from the rename handler) — now reads "cannot regenerate titles". Follow-up to #4184. +2/-2 (one string + its test assertion).

Gates: py_compile + ruff CLEAN; targeted regenerate-title tests pass. Full suite via CI.

Co-authored-by: rodboev
