### PR TITLE
Release OB (v0.51.415): keep complete sidebar metadata on index fastpath (#4166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.415] — 2026-06-14 — Release OB (keep complete sidebar metadata on the index fastpath, #4166)
+
+### Fixed
+
+- **The session sidebar no longer re-reads every session's sidecar file on each `/api/sessions` poll.** A complete `_index.json` row (one that carries `message_count`, `user_message_count`, and `last_message_at`) now stays on the index fastpath even when the sidecar file's mtime is newer than the row's logical timestamp — a pattern that is common after compression and previously turned each sidebar poll into hundreds of per-sidecar JSON prefix scans. The mtime "rescue" reload is kept for incomplete, legacy, and stale-zero-message rows whose counters can't be trusted, so sidebar correctness is unchanged while the steady-state poll cost drops. (#4166)
+
 ## [v0.51.414] — 2026-06-14 — Release OA (fix misleading regenerate-title error message, #4186)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -2770,13 +2770,26 @@ def _row_may_need_sidecar_metadata_refresh(
         # so only true continuations are eligible.
         if str(session.get('session_source') or '').strip().lower() == 'fork':
             return False
+        if session.get('message_count') is None or session.get('last_message_at') is None:
+            return True
+        # Lineage fields are enriched from state.db in a batched pass later in
+        # all_sessions(). A complete indexed lineage row must not be reloaded
+        # from its sidecar merely because the filesystem mtime is newer than the
+        # logical message timestamp; that pattern is common after compression
+        # and turns each /api/sessions poll into hundreds of JSON prefix scans.
+        # Keep the mtime repair path only for rows whose counters are known bad
+        # or incomplete enough that the index cannot be trusted.
         lineage_shaped = bool(
             session.get('parent_session_id')
             or session.get('_lineage_root_id')
             or session.get('_compression_segment_count')
         )
-        needs_mtime_check = lineage_shaped or (
-            sid and _looks_like_stale_zero_message_row(session)
+        needs_mtime_check = bool(
+            sid
+            and (
+                _looks_like_stale_zero_message_row(session)
+                or (lineage_shaped and session.get('user_message_count') is None)
+            )
         )
         if needs_mtime_check and _sidecar_mtime_after_index_timestamp(session):
             return True
@@ -2842,6 +2855,17 @@ def _stale_snapshot_metadata_refresh_ids(sessions: list[dict]) -> set[str]:
             if not sid:
                 continue
             if _sidebar_message_count(snapshot) > best_visible_count:
+                continue
+            # Modern index rows already carry enough sidebar summary data to
+            # decide snapshot visibility. Only legacy/incomplete rows need the
+            # sidecar mtime rescue; otherwise every historical snapshot whose
+            # file mtime is newer than its logical timestamp is re-read on every
+            # sidebar poll.
+            if (
+                snapshot.get('user_message_count') is not None
+                and snapshot.get('message_count') is not None
+                and snapshot.get('last_message_at') is not None
+            ):
                 continue
             if _sidecar_mtime_after_index_timestamp(snapshot):
                 refresh_ids.add(sid)

--- a/api/models.py
+++ b/api/models.py
@@ -2860,10 +2860,12 @@ def _stale_snapshot_metadata_refresh_ids(sessions: list[dict]) -> set[str]:
             # decide snapshot visibility. Only legacy/incomplete rows need the
             # sidecar mtime rescue; otherwise every historical snapshot whose
             # file mtime is newer than its logical timestamp is re-read on every
-            # sidebar poll.
+            # sidebar poll. Treat stale-zero-message rows as incomplete even
+            # when user_message_count/last_message_at are present; their sidecar
+            # may hold the real count that makes the snapshot visible.
             if (
                 snapshot.get('user_message_count') is not None
-                and snapshot.get('message_count') is not None
+                and int(snapshot.get('message_count') or 0) > 0
                 and snapshot.get('last_message_at') is not None
             ):
                 continue

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -547,6 +547,39 @@ def test_fuller_pre_compression_snapshot_replaces_shorter_visible_segment(monkey
     assert rows[0]["pre_compression_snapshot"] is True
 
 
+def test_complete_snapshot_refresh_ids_do_not_follow_mtime_when_sidebar_metadata_is_complete(monkeypatch):
+    """Complete snapshot metadata should stay on the index fastpath.
+
+    The stale-snapshot rescue path is for incomplete legacy rows. Modern index
+    rows include user_message_count plus last_message_at; refreshing every such
+    snapshot whose sidecar mtime is newer creates O(history) sidecar fan-out.
+    """
+    rows = [
+        {
+            "session_id": "snapshot_complete",
+            "title": "Complete Snapshot",
+            "message_count": 4,
+            "user_message_count": 2,
+            "updated_at": 100.0,
+            "last_message_at": 100.0,
+            "pre_compression_snapshot": True,
+            "parent_session_id": "root_sid",
+        },
+        {
+            "session_id": "visible_child",
+            "title": "Visible Child",
+            "message_count": 4,
+            "user_message_count": 2,
+            "updated_at": 120.0,
+            "last_message_at": 120.0,
+            "parent_session_id": "snapshot_complete",
+        },
+    ]
+    monkeypatch.setattr(models, "_sidecar_mtime_after_index_timestamp", lambda _row: True)
+
+    assert models._stale_snapshot_metadata_refresh_ids(rows) == set()
+
+
 def test_stale_index_fuller_pre_compression_snapshot_uses_sidecar_metadata(monkeypatch):
     """A stale index must not hide the fuller pre-compression sidecar.
 
@@ -888,6 +921,82 @@ def test_all_sessions_does_not_refresh_fresh_lineage_rows_from_sidecars(monkeypa
 
     assert rows[0]["session_id"] == "lineage_sid"
     assert rows[0]["message_count"] == 7
+
+
+def test_complete_lineage_refresh_gate_ignores_mtime_when_sidebar_metadata_is_complete(monkeypatch):
+    """Filesystem mtime alone must not force sidecar refresh for complete lineage rows."""
+    row = {
+        "session_id": "complete_lineage_gate",
+        "title": "Complete Lineage Gate",
+        "message_count": 8,
+        "user_message_count": 4,
+        "updated_at": 200.0,
+        "last_message_at": 200.0,
+        "parent_session_id": "snapshot_parent",
+        "_lineage_root_id": "snapshot_parent",
+        "_compression_segment_count": 2,
+    }
+    monkeypatch.setattr(models, "_sidecar_mtime_after_index_timestamp", lambda _row: True)
+
+    assert models._row_may_need_sidecar_metadata_refresh(row) is False
+
+
+def test_all_sessions_does_not_refresh_complete_lineage_rows_with_newer_sidecar_mtime(monkeypatch):
+    """Complete indexed lineage rows should not fan out into sidecar reads per poll.
+
+    Real WebUI histories can have hundreds of compression-linked rows whose
+    sidecar file mtime is newer than the logical last_message_at. When the index
+    already has complete sidebar counters/timestamps, state.db lineage
+    enrichment owns the lineage fields; /api/sessions must not re-hydrate every
+    sidecar just because its filesystem mtime is newer.
+    """
+    session = Session(
+        session_id="complete_lineage_child",
+        title="Complete Lineage Child",
+        messages=[
+            {"role": "user", "content": "a", "timestamp": 100.0},
+            {"role": "assistant", "content": "b", "timestamp": 101.0},
+            {"role": "user", "content": "c", "timestamp": 102.0},
+            {"role": "assistant", "content": "d", "timestamp": 103.0},
+        ],
+        parent_session_id="snapshot_parent",
+        updated_at=103.0,
+        last_message_at=103.0,
+    )
+    session.save(touch_updated_at=False)
+    _write_index_file(
+        models.SESSION_INDEX_FILE,
+        [
+            {
+                "session_id": "complete_lineage_child",
+                "title": "Complete Lineage Child",
+                "message_count": 4,
+                "user_message_count": 2,
+                "created_at": 100.0,
+                "updated_at": 103.0,
+                "last_message_at": 103.0,
+                "pinned": False,
+                "archived": False,
+                "parent_session_id": "snapshot_parent",
+                "_lineage_root_id": "snapshot_parent",
+                "_compression_segment_count": 2,
+            }
+        ],
+    )
+    # Ensure the filesystem mtime still looks newer than the logical timestamp,
+    # which is the production fan-out trigger we are guarding against.
+    assert models._sidecar_mtime_after_index_timestamp({
+        "session_id": "complete_lineage_child",
+        "last_message_at": 103.0,
+        "updated_at": 103.0,
+    })
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    with patch.object(Session, "load_metadata_only", side_effect=AssertionError("complete lineage rows must stay on the index fastpath")):
+        rows = models.all_sessions()
+
+    assert rows[0]["session_id"] == "complete_lineage_child"
+    assert rows[0]["message_count"] == 4
 
 
 def test_all_sessions_refreshes_stale_visible_continuation_metadata(monkeypatch):

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -580,6 +580,34 @@ def test_complete_snapshot_refresh_ids_do_not_follow_mtime_when_sidebar_metadata
     assert models._stale_snapshot_metadata_refresh_ids(rows) == set()
 
 
+def test_stale_zero_message_snapshot_refresh_ids_follow_mtime(monkeypatch):
+    """A snapshot with message_count=0 but user messages is not complete metadata."""
+    rows = [
+        {
+            "session_id": "snapshot_stale_zero",
+            "title": "Stale Zero Snapshot",
+            "message_count": 0,
+            "user_message_count": 2,
+            "updated_at": 100.0,
+            "last_message_at": 100.0,
+            "pre_compression_snapshot": True,
+            "parent_session_id": "root_sid",
+        },
+        {
+            "session_id": "visible_child",
+            "title": "Visible Child",
+            "message_count": 1,
+            "user_message_count": 1,
+            "updated_at": 120.0,
+            "last_message_at": 120.0,
+            "parent_session_id": "snapshot_stale_zero",
+        },
+    ]
+    monkeypatch.setattr(models, "_sidecar_mtime_after_index_timestamp", lambda _row: True)
+
+    assert models._stale_snapshot_metadata_refresh_ids(rows) == {"snapshot_stale_zero"}
+
+
 def test_stale_index_fuller_pre_compression_snapshot_uses_sidecar_metadata(monkeypatch):
     """A stale index must not hide the fuller pre-compression sidecar.
 


### PR DESCRIPTION
## Release OB — v0.51.415

Single PR — clean backend perf fix (deep-gated).

- **#4166** (ai-ag2026): keep complete sidebar metadata on the `_index.json` fastpath. A complete index row (carrying `message_count` + `user_message_count` + `last_message_at`) now stays on the fastpath even when the sidecar file mtime is newer than the row's logical timestamp — a post-compression pattern that previously turned every `/api/sessions` poll into hundreds of per-sidecar JSON prefix scans. The mtime "rescue" reload is preserved for incomplete/legacy/stale-zero rows, so sidebar correctness is unchanged.

### Gates
- **Codex regression gate:** SAFE TO SHIP — verified incomplete/stale-zero/legacy rows still get the mtime rescue; only complete rows skip it; the sole stale-row case needs an anomalous out-of-band write (not a normal flow).
- **Opus advisor:** net-positive, no MUST-FIX ("Ship it"). One cosmetic non-blocking edge noted (a rare `skip_index=True` self-heal can leave a count digit briefly high; self-corrects next save — follow-up, not a blocker).
- **ruff + py_compile:** CLEAN. **Full suite:** 8957 passed, 0 failed.

Co-authored-by: ai-ag2026
