### PR TITLE
fix: keep settled stream message counts consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Streaming completion payloads now report a message count that matches the embedded transcript.** Settled `done`/error SSE payloads no longer reuse stale compact metadata when they include the full `messages` array, preventing completion/reconcile code from mistaking a full transcript for a short stale window.
+
 ## [v0.51.415] — 2026-06-14 — Release OB (keep complete sidebar metadata on the index fastpath, #4166)
 
 ### Fixed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -53,6 +53,25 @@ from api.models import (
 )
 from api.session_ops import mark_session_title_generated, session_has_manual_title
 
+
+def _session_payload_with_full_messages(session, *, tool_calls=None):
+    """Return compact session metadata plus the embedded full transcript.
+
+    ``Session.compact()`` may intentionally use metadata-only counts from an
+    index/sidebar load. A settled SSE payload that embeds ``session.messages``
+    must report the count of that embedded transcript, otherwise completion and
+    reconcile paths can mistake a complete payload for a stale short window.
+    """
+    messages = list(getattr(session, 'messages', None) or [])
+    raw = session.compact() | {
+        'messages': messages,
+        'message_count': len(messages),
+    }
+    if tool_calls is not None:
+        raw['tool_calls'] = tool_calls
+    return raw
+
+
 # Global lock for os.environ writes. Per-session locks (_agent_lock) prevent
 # concurrent runs of the SAME session, but two DIFFERENT sessions can still
 # interleave their os.environ writes. This global lock serializes the env
@@ -7181,7 +7200,7 @@ def _run_agent_streaming(
                         except Exception:
                             pass
                         _error_payload['session'] = redact_session_data(
-                            s.compact() | {'messages': s.messages, 'tool_calls': s.tool_calls}
+                            _session_payload_with_full_messages(s, tool_calls=s.tool_calls)
                         )
                         _error_payload['session_id'] = s.session_id
                         _error_payload['old_session_id'] = _compression_origin_session_id
@@ -7884,7 +7903,7 @@ def _run_agent_streaming(
                         })
             except Exception as _goal_exc:
                 logger.debug("Goal continuation hook failed for session %s: %s", session_id, _goal_exc)
-            raw_session = s.compact() | {'messages': s.messages, 'tool_calls': tool_calls}
+            raw_session = _session_payload_with_full_messages(s, tool_calls=tool_calls)
             _done_payload = {'session': redact_session_data(raw_session), 'usage': usage}
             if _tool_limit_reached:
                 _done_payload['terminal_state'] = 'tool_limit_reached'

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -743,9 +743,9 @@ def test_streaming_persists_reasoning_in_session():
     assert "_rm['reasoning'] = _existing_reasoning" in src, \
         "the no-think-block branch must still persist _reasoning_text into the assistant message"
 
-    # Persistence block must come BEFORE raw_session assignment
+    # Persistence block must come BEFORE the settled raw_session payload is built
     persist_idx = src.index("Persist reasoning trace in the session")
-    raw_session_idx = src.index("raw_session = s.compact()")
+    raw_session_idx = src.index("raw_session = _session_payload_with_full_messages")
     assert persist_idx < raw_session_idx, \
         "Reasoning persistence block must appear before raw_session assignment"
 

--- a/tests/test_streaming_done_payload_message_count.py
+++ b/tests/test_streaming_done_payload_message_count.py
@@ -1,0 +1,53 @@
+"""Regression coverage for settled SSE payload message counts."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from api.streaming import _session_payload_with_full_messages
+
+
+STREAMING_SOURCE = Path("api/streaming.py").read_text(encoding="utf-8")
+
+
+class _FakeSession(SimpleNamespace):
+    def compact(self):
+        return {
+            "session_id": self.session_id,
+            "message_count": 45,
+            "title": "stale compact metadata",
+        }
+
+
+def test_full_message_payload_overrides_stale_compact_message_count():
+    session = _FakeSession(
+        session_id="child-session",
+        messages=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "second"},
+        ],
+    )
+
+    payload = _session_payload_with_full_messages(session, tool_calls=[])
+
+    assert payload["messages"] == session.messages
+    assert payload["message_count"] == len(session.messages)
+    assert payload["message_count"] != session.compact()["message_count"]
+
+
+def test_done_payload_uses_full_message_count_helper():
+    done_idx = STREAMING_SOURCE.index("put('done', _done_payload)")
+    block_start = STREAMING_SOURCE.rfind("raw_session =", 0, done_idx)
+    block = STREAMING_SOURCE[block_start:done_idx]
+
+    assert "_session_payload_with_full_messages(s, tool_calls=tool_calls)" in block
+    assert "s.compact() | {'messages': s.messages" not in block
+
+
+def test_apperror_payload_uses_full_message_count_helper():
+    error_idx = STREAMING_SOURCE.index("put('apperror', _error_payload)")
+    block_start = STREAMING_SOURCE.rfind("_error_payload['session']", 0, error_idx)
+    block = STREAMING_SOURCE[block_start:error_idx]
+
+    assert "_session_payload_with_full_messages(s, tool_calls=s.tool_calls)" in block
+    assert "s.compact() | {'messages': s.messages" not in block


### PR DESCRIPTION
## Thinking Path

A local WebUI incident showed the browser replacing a correct live transcript after stream completion. The old local runtime had two contributing problems: an unsafe state.db tail fastpath and a settled `done` payload whose embedded full transcript had stale compact metadata (`len(messages)=453`, `message_count=45`). Current `origin/master` already loads/merges sidecar truth for `/api/session?messages=1`, so this PR fixes the remaining upstream inconsistency in settled SSE payloads.

## What Changed

- Added `_session_payload_with_full_messages()` in `api/streaming.py`.
- Normal `done` payloads now embed full messages with `message_count = len(messages)`.
- Settled `apperror` payloads use the same helper so they cannot leak stale compact counts either.
- Added regression coverage for the helper and both callsites.
- Updated the existing Sprint 42 source-order test to look for the new settled payload marker instead of the old `raw_session = s.compact()` assignment.
- Added a changelog entry.

## Why It Matters

`Session.compact()` can legitimately carry metadata-only counts from index/sidebar loads. That metadata is fine for compact rows, but it is wrong for SSE payloads that also include the full `messages` array. Completion/reconcile code relies on these counts for viewed-state and message-window decisions, so a stale count can make a complete settled transcript look like a short stale window.

This keeps the payload internally consistent: if the server sends full messages, the reported count matches those messages.

## Verification

Local:

- `git diff --check`
- `python3 -m pytest tests/test_streaming_done_payload_message_count.py tests/test_run_journal_routes.py tests/test_1694_terminal_cleanup_ownership.py -q` → 26 passed
- `python3 -m pytest tests/test_sprint42.py::test_streaming_persists_reasoning_in_session tests/test_streaming_done_payload_message_count.py -q` → 4 passed
- `python3 -m pytest tests/test_run_journal_routes.py tests/test_1694_terminal_cleanup_ownership.py -q` → 23 passed
- `python3 -m py_compile api/streaming.py api/routes.py`
- Added-line risk scan over commit range → 0 findings
- Independent reviewer pass requested callsite coverage; added tests now assert both `done` and `apperror` callsites use the helper.

CI note:

- Initial CI after rebase exposed a stale source assertion in `tests/test_sprint42.py` looking for `raw_session = s.compact()`. This PR now updates that assertion to the new helper call and re-pushed.

## Risks / Follow-ups

- Low risk: the helper preserves existing compact metadata and tool-call fields, only overriding `message_count` when a full message array is embedded.
- This PR does not change `/api/session` route behavior. Current `master` already avoids the older unsafe state.db-tail-only path by merging sidecar lineage and state.db for message loads.

## Contract Routing

Task type: runtime/session consistency bugfix  
Touched areas: streaming settled SSE payloads, session metadata consistency  
Relevant docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, runtime/session consistency contracts  
Evidence: regression test plus adjacent stream/session route tests listed above

## Model Used

OpenAI GPT-5.5 via Hermes Agent, with local terminal/file tooling and an independent reviewer subagent.
