### PR TITLE
fix(sidebar): preserve GitHub issue numbers in session titles (#4154)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4726,7 +4726,7 @@ function _sessionTitleIsDefaultWebUI(rawTitle){
 
 function _sessionTitleTags(rawTitle){
   if(_sessionTitleIsDefaultWebUI(rawTitle)) return [];
-  return String(rawTitle||'').match(/#[\w-]+/g)||[];
+  return String(rawTitle||'').match(/#(?!\d+\b)[\w-]+/g)||[];
 }
 
 function _activeSessionIdForSidebar(){
@@ -5427,7 +5427,7 @@ function renderSessionListFromCache(){
     if(isActive&&S.session&&S.session._flash)delete S.session._flash;
     const rawTitle=_sessionDisplayTitle(s);
     const tags=_sessionTitleTags(rawTitle);
-    let cleanTitle=tags.length?rawTitle.replace(/#[\w-]+/g,'').trim():rawTitle;
+    let cleanTitle=tags.length?rawTitle.replace(/#(?!\d+\b)[\w-]+/g,'').trim():rawTitle;
     // Guard: system prompt content must never surface as a visible session title
     if(cleanTitle.startsWith('[SYSTEM:')){
       cleanTitle='Session';

--- a/tests/test_issue4154_sidebar_issue_numbers.py
+++ b/tests/test_issue4154_sidebar_issue_numbers.py
@@ -1,0 +1,67 @@
+"""Regression tests for #4154: sidebar strips GitHub issue numbers from titles.
+
+The _sessionTitleTags regex must NOT treat purely numeric #NNNN patterns as
+tags.  Only known attention/session-control tags like #approval, #clarify,
+#attention should be extracted.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+
+
+def _read_sessions_js():
+    return SESSIONS_JS.read_text(encoding="utf-8")
+
+
+def test_sessionTitleTags_function_exists():
+    """The _sessionTitleTags function must be present in sessions.js."""
+    src = _read_sessions_js()
+    assert "function _sessionTitleTags" in src
+
+
+def test_regex_excludes_numeric_issue_numbers():
+    """The regex in _sessionTitleTags must use a negative lookahead to skip
+    purely numeric #NNNN patterns (GitHub issue references)."""
+    src = _read_sessions_js()
+    # The fix replaces /#[\w-]+/g with /#(?!\d+\b)[\w-]+/g
+    assert r"#(?!\d+\b)[\w-]+" in src, (
+        "Expected negative lookahead regex /#(??!\\d+\\b)[\\w-]+/ in _sessionTitleTags"
+    )
+    # The old broad pattern must NOT be the only pattern present
+    # (the negative lookahead variant must exist)
+
+
+def test_old_broad_regex_not_still_present():
+    r"""The old /#[\w-]+/g pattern (without negative lookahead) must not appear
+    in _sessionTitleTags or _renderOneSession tag-stripping code."""
+    src = _read_sessions_js()
+    # Find _sessionTitleTags function body
+    match = re.search(
+        r"function _sessionTitleTags\(rawTitle\)\{(.*?)\n\}",
+        src,
+        re.DOTALL,
+    )
+    assert match, "Could not locate _sessionTitleTags function body"
+    body = match.group(1)
+    # The function body must not contain the old broad regex
+    assert "/#[\\w-]+/g" not in body.replace(" ", ""), (
+        "_sessionTitleTags still uses the old broad /#[\\w-]+/g regex"
+    )
+
+
+def test_regex_applied_in_renderOneSession_too():
+    """The tag-stripping regex in _renderOneSession must also use the
+    negative lookahead so visible titles keep issue numbers."""
+    src = _read_sessions_js()
+    # Find the cleanTitle line
+    assert r"#(?!\d+\b)[\w-]+" in src
+    # Confirm it appears at least twice (once in _sessionTitleTags, once in
+    # _renderOneSession)
+    count = src.count(r"#(?!\d+\b)[\w-]+")
+    assert count >= 2, (
+        f"Expected negative lookahead regex in at least 2 locations "
+        f"(_sessionTitleTags + _renderOneSession), found {count}"
+    )


### PR DESCRIPTION
title: fix(sidebar): preserve GitHub issue numbers in session titles (#4154)

## Thinking Path

- Session titles containing GitHub issue references like #3748 are stripped of the number in the sidebar, showing GH  Bool Fix instead of GH #3748 Bool Fix.
- The root cause is _sessionTitleTags using a broad /#[\w-]+/g regex that treats numeric issue references as session-control tags (like #approval).
- The fix narrows the tag regex to exclude purely numeric #NNNN patterns while preserving the existing attention/session-control tag extraction.

## What Changed

- static/sessions.js: Narrowed _sessionTitleTags regex to skip numeric #NNNN patterns, and aligned the strip regex in _renderOneSession to match.
- 	ests/test_issue4154_sidebar_issue_numbers.py: New focused test verifying the negative lookahead pattern.

## Why It Matters

Session titles with GitHub issue references are common in developer workflows. Stripping them silently loses context and makes it harder to identify sessions in the sidebar.

## Verification

`
pytest tests/test_issue4154_sidebar_issue_numbers.py -v --timeout=60
`

4/4 passed, ESLint clean.

## Risks / Follow-ups

- If session titles contain non-GitHub numeric tags (e.g., #1234 as a real tag), they will no longer be extracted. This is acceptable because session-control tags are always non-numeric.

## Model Used

MiMo-V2.5-Pro via MiMoCode CLI