### PR TITLE
fix(sessions): guard external refresh poll to skip non-external sessions (#3916)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3650,6 +3650,7 @@ async function refreshActiveSessionIfExternallyUpdated(reason){
   if(_activeSessionExternalRefreshInFlight) return;
   if(!S.session || !S.session.session_id) return;
   if(S.busy || S.activeStreamId) return;
+  if(!_isExternalSession(S.session)) return;
   // Cooldown: don't force-reload immediately after streaming ends — the
   // "done" event already delivered the final messages. Reloading here would
   // clear S.toolCalls and lose Activity.

--- a/tests/test_issue3916_external_refresh_poll.py
+++ b/tests/test_issue3916_external_refresh_poll.py
@@ -1,0 +1,24 @@
+import re
+from pathlib import Path
+
+SESSIONS_JS = Path(__file__).resolve().parent.parent / "static" / "sessions.js"
+
+
+def test_refreshActiveSessionIfExternallyUpdated_exists():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    assert "async function refreshActiveSessionIfExternallyUpdated" in src
+
+
+def test_isExternalSession_guard_present():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    m = re.search(
+        r"async function refreshActiveSessionIfExternallyUpdated\b.*?^}",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert m, "refreshActiveSessionIfExternallyUpdated function not found"
+    body = m.group(0)
+    assert re.search(r"if\s*\(\s*!\s*_isExternalSession\s*\(", body), (
+        "refreshActiveSessionIfExternallyUpdated must have an early-return "
+        "guard: if(!_isExternalSession(...))"
+    )


### PR DESCRIPTION
title: fix(sessions): guard external refresh poll to skip non-external sessions (#3916)

## Thinking Path

- The 30-second external refresh poll fires for all sessions, including pure WebUI sessions, causing unnecessary full chat re-renders when message counts diverge.
- The _isExternalSession function already exists and is used in multiple places to distinguish CLI/Telegram/Discord sessions from WebUI-originated ones.
- Adding a single guard line to 
efreshActiveSessionIfExternallyUpdated eliminates the unnecessary polling for WebUI sessions.

## What Changed

- static/sessions.js: Added _isExternalSession guard to 
efreshActiveSessionIfExternallyUpdated.
- 	ests/test_issue3916_external_refresh_poll.py: New focused test verifying the guard.

## Why It Matters

Wasteful 30-second polling for non-external sessions causes unnecessary API calls and potential full chat re-renders, degrading performance for all WebUI users.

## Verification

`
pytest tests/test_issue3916_external_refresh_poll.py -v --timeout=60
`

2/2 passed, ESLint clean.

## Risks / Follow-ups

- None. The change is a single early-return guard using an existing utility function.

## Model Used

MiMo-V2.5-Pro via MiMoCode CLI