### PR TITLE
fix(models): preserve colon-suffixed model IDs in normalization (#3959)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3158,8 +3158,9 @@ def _configured_model_badges_from_static_catalog(
     def _norm_static_model_id(model_id: str) -> str:
         s = str(model_id or "").strip().lower()
         if s.startswith("@") and ":" in s:
-            parts = s.split(":")
-            s = parts[-1] or s
+            colon_idx = s.index(":", 1)
+            candidate = s[colon_idx + 1:]
+            s = candidate or s
         if "://" not in s and "/" in s:
             stripped = s.split("/", 1)[1]
             s = stripped or s
@@ -4384,8 +4385,11 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
             # Defensive: if the last segment is empty (trailing colon, malformed
             # config), keep the original to avoid collapsing distinct IDs to ''.
             if s.startswith("@") and ":" in s:
-                parts = s.split(":")
-                s = parts[-1] or s
+                # Strip @provider: prefix, preserving remaining hierarchy including
+                # colon-suffixed model IDs like provider/model:free (#3959).
+                colon_idx = s.index(":", 1)
+                candidate = s[colon_idx + 1:]
+                s = candidate or s
             # Skip slash-based stripping for URI-scheme IDs (e.g.
             # gpt://folder/model/latest) whose slashes are path separators,
             # not provider delimiters (#3429).

--- a/api/config.py
+++ b/api/config.py
@@ -3157,13 +3157,23 @@ def _configured_model_badges_from_static_catalog(
 
     def _norm_static_model_id(model_id: str) -> str:
         s = str(model_id or "").strip().lower()
+        stripped_at_provider = False
         if s.startswith("@") and ":" in s:
             colon_idx = s.index(":", 1)
             candidate = s[colon_idx + 1:]
+            stripped_at_provider = bool(candidate)
             s = candidate or s
-        if "://" not in s and "/" in s:
-            stripped = s.split("/", 1)[1]
-            s = stripped or s
+        if "://" not in s:
+            if (
+                not stripped_at_provider
+                and "/" in s
+                and ":" in s
+                and s.index(":") < s.index("/")
+            ):
+                s = s[s.index("/") + 1 :] or s
+            if "/" in s:
+                stripped = s.split("/", 1)[1]
+                s = stripped or s
         return s.replace("-", ".")
 
     norm_lookup: dict[str, list[str]] = {}
@@ -4381,6 +4391,7 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
 
         def _norm_model_id(model_id: str) -> str:
             s = str(model_id or "").strip().lower()
+            stripped_at_provider = False
             # Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> GLM-5).
             # Defensive: if the last segment is empty (trailing colon, malformed
             # config), keep the original to avoid collapsing distinct IDs to ''.
@@ -4389,11 +4400,19 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
                 # colon-suffixed model IDs like provider/model:free (#3959).
                 colon_idx = s.index(":", 1)
                 candidate = s[colon_idx + 1:]
+                stripped_at_provider = bool(candidate)
                 s = candidate or s
             # Skip slash-based stripping for URI-scheme IDs (e.g.
             # gpt://folder/model/latest) whose slashes are path separators,
             # not provider delimiters (#3429).
             if "://" not in s:
+                if (
+                    not stripped_at_provider
+                    and "/" in s
+                    and ":" in s
+                    and s.index(":") < s.index("/")
+                ):
+                    s = s[s.index("/") + 1 :] or s
                 # Strip only the first slash-segment (provider prefix), preserving
                 # any remaining vendor hierarchy.  Using parts[-1] here previously
                 # discarded ALL segments except the last, collapsing distinct

--- a/static/ui.js
+++ b/static/ui.js
@@ -1658,10 +1658,10 @@ function _selectedModelOption(){
 
 function _normalizeConfiguredModelKey(modelId){
   let s=String(modelId||'').trim().toLowerCase();
-  // Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> GLM-5).
+  // Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> jingdong:GLM-5).
   // Defensive: trailing-colon / trailing-slash falls back to the original key
   // so malformed configs don't collapse distinct ids to '' (matches backend _norm_model_id).
-  if(s.startsWith('@')&&s.includes(':')){const last=s.split(':').pop();s=last||s;}
+  if(s.startsWith('@')&&s.includes(':')){const ci=s.indexOf(':',1);const cand=s.slice(ci+1);s=cand||s;}
   // Skip slash-based stripping for URI-scheme IDs (e.g. gpt://folder/model)
   // whose slashes are path separators, not provider delimiters (#3429).
   const _hasScheme=/^[a-z][a-z0-9+.-]*:\/\//i.test(s);

--- a/static/ui.js
+++ b/static/ui.js
@@ -1658,10 +1658,11 @@ function _selectedModelOption(){
 
 function _normalizeConfiguredModelKey(modelId){
   let s=String(modelId||'').trim().toLowerCase();
+  let strippedAtProvider=false;
   // Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> jingdong:GLM-5).
   // Defensive: trailing-colon / trailing-slash falls back to the original key
   // so malformed configs don't collapse distinct ids to '' (matches backend _norm_model_id).
-  if(s.startsWith('@')&&s.includes(':')){const ci=s.indexOf(':',1);const cand=s.slice(ci+1);s=cand||s;}
+  if(s.startsWith('@')&&s.includes(':')){const ci=s.indexOf(':',1);const cand=s.slice(ci+1);strippedAtProvider=!!cand;s=cand||s;}
   // Skip slash-based stripping for URI-scheme IDs (e.g. gpt://folder/model)
   // whose slashes are path separators, not provider delimiters (#3429).
   const _hasScheme=/^[a-z][a-z0-9+.-]*:\/\//i.test(s);
@@ -1671,7 +1672,7 @@ function _normalizeConfiguredModelKey(modelId){
     // key variants like 'custom:llm-proxy/opencode_go/deepseek-v4-pro' and the
     // bare 'opencode_go/deepseek-v4-pro' produce different normalized keys and
     // aren't deduped in the configured section (#3360).
-    if(s.includes('/')&&s.indexOf(':')!==-1&&s.indexOf(':')<s.indexOf('/')){
+    if(!strippedAtProvider&&s.includes('/')&&s.indexOf(':')!==-1&&s.indexOf(':')<s.indexOf('/')){
       s=s.slice(s.indexOf('/')+1)||s;
     }
     // Strip only the first slash-segment (provider prefix), preserving any

--- a/tests/test_issue3360_multi_slash_model_collision.py
+++ b/tests/test_issue3360_multi_slash_model_collision.py
@@ -228,7 +228,7 @@ class TestNormalizeConfiguredModelKeyMultiSlash:
 
     def test_at_provider_prefix_still_stripped(self, norm_driver):
         keys = _norm_keys(norm_driver, ["@custom:jingdong:GLM-5"])
-        assert keys["@custom:jingdong:GLM-5"] == "glm.5"
+        assert keys["@custom:jingdong:GLM-5"] == "jingdong:glm.5"
 
     def test_trailing_slash_fallback(self, norm_driver):
         """A trailing slash (malformed) must not collapse to empty."""

--- a/tests/test_issue3959_model_suffix_dedup.py
+++ b/tests/test_issue3959_model_suffix_dedup.py
@@ -1,0 +1,132 @@
+"""Regression tests for #3959 — Model selector shows duplicate entries for
+colon-suffixed model IDs (e.g. :free, :thinking, :discounted).
+
+The normalizer was using parts[-1] (last colon segment) which collapsed all
+:free models to the same key 'free'.  Fix: strip only the @provider: prefix
+(first colon after @), preserving the rest including colon-suffixed suffixes.
+"""
+import shutil
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+CONFIG_PY = (REPO_ROOT / "api" / "config.py").read_text(encoding="utf-8")
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+NODE = shutil.which("node")
+
+
+def _exec_norm():
+    """Re-execute the _norm_model_id closure body via a synthetic def."""
+    start_marker = "def _norm_model_id(model_id: str) -> str:"
+    end_marker = "def _build_configured_model_badges"
+    s = CONFIG_PY.find(start_marker)
+    e = CONFIG_PY.find(end_marker, s)
+    assert s != -1 and e != -1
+    body = CONFIG_PY[s:e]
+    lines = body.splitlines()
+    indent = None
+    for ln in lines:
+        if ln.strip():
+            indent = len(ln) - len(ln.lstrip())
+            break
+    dedented = "\n".join(ln[indent:] if len(ln) >= indent else ln for ln in lines)
+    ns = {}
+    exec(dedented, ns)
+    return ns["_norm_model_id"]
+
+
+def test_colon_suffix_model_preserves_suffix():
+    """@custom:llm-proxy:kilo/nvidia/nemotron-3-ultra-550b-a55b:free must
+    NOT collapse to just 'free'."""
+    norm = _exec_norm()
+    result = norm("@custom:llm-proxy:kilo/nvidia/nemotron-3-ultra-550b-a55b:free")
+    assert "free" in result, f"Expected 'free' in result, got {result!r}"
+    assert result != "free", f"Suffix-only collapse is the bug: {result!r}"
+
+
+def test_free_vs_thinking_produce_different_keys():
+    """:free and :thinking variants of the same model must normalize to
+    different keys to avoid duplicate selector entries."""
+    norm = _exec_norm()
+    base = "@custom:llm-proxy:kilo/nvidia/nemotron-3-ultra-550b-a55b"
+    key_free = norm(f"{base}:free")
+    key_thinking = norm(f"{base}:thinking")
+    assert key_free != key_thinking, (
+        f":free and :thinking collapsed to same key: "
+        f"free={key_free!r}, thinking={key_thinking!r}"
+    )
+
+
+def test_plain_model_id_still_normalizes():
+    """Simple model IDs without @ prefix must still normalize correctly."""
+    norm = _exec_norm()
+    assert norm("gpt-4") == "gpt.4"
+    assert norm("") == ""
+    assert norm(None) == ""
+
+
+def test_provider_prefix_only_model():
+    """@custom:vendor:model (no colon suffix) still strips prefix."""
+    norm = _exec_norm()
+    result = norm("@custom:jingdong:GLM-5")
+    assert result == "jingdong:glm.5"
+
+
+def test_ui_js_uses_indexof_not_split_pop():
+    """Frontend must use indexOf(':',1)+slice, not split(':').pop()."""
+    assert "indexOf(':',1)" in UI_JS
+    assert "s.split(':').pop()" not in UI_JS, (
+        "ui.js still uses the buggy split(':').pop() pattern"
+    )
+
+
+@pytest.mark.skipif(NODE is None, reason="node not in PATH")
+def test_backend_frontend_parity_complex_aggregator_proxy():
+    """Python and JS normalizers must agree on the inputs our fix affects.
+
+    Note: complex multi-colon+slash IDs like @custom:llm-proxy:kilo/nvidia/model:free
+    have a pre-existing parity gap (JS strips colon-before-slash segments, Python doesn't).
+    This test verifies parity for the simpler @provider:model and @provider:vendor:model
+    forms where our fix changes behavior.
+    """
+    py_norm = _exec_norm()
+    import re
+    js_match = re.search(
+        r"function _normalizeConfiguredModelKey\([^)]*\)\{(.+?)\n\}",
+        UI_JS,
+        re.DOTALL,
+    )
+    assert js_match, "Could not find _normalizeConfiguredModelKey in ui.js"
+    js_body = js_match.group(1)
+    js_fn = f"""
+    function _normalizeConfiguredModelKey(modelId){{{js_body}}}
+    """
+    import subprocess, json, tempfile, os
+    test_ids = [
+        "@custom:jingdong:GLM-5",
+        "openai/gpt-5.5",
+        "gpt-4",
+        "@custom:vendor:model-name",
+    ]
+    js_code = js_fn + "\n" + f"console.log(JSON.stringify({json.dumps(test_ids)}.map(id => [id, _normalizeConfiguredModelKey(id)])))"
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
+        f.write(js_code)
+        tmp = f.name
+    try:
+        result = subprocess.run(
+            ["node", tmp], capture_output=True, text=True, timeout=10
+        )
+        assert result.returncode == 0, f"JS execution failed: {result.stderr}"
+        js_pairs = json.loads(result.stdout.strip())
+        js_map = dict(js_pairs)
+    finally:
+        os.unlink(tmp)
+    for model_id in test_ids:
+        py_result = py_norm(model_id)
+        js_result = js_map[model_id]
+        assert py_result == js_result, (
+            f"Parity mismatch for {model_id!r}: "
+            f"Python={py_result!r}, JS={js_result!r}"
+        )

--- a/tests/test_issue3959_model_suffix_dedup.py
+++ b/tests/test_issue3959_model_suffix_dedup.py
@@ -17,10 +17,7 @@ UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 NODE = shutil.which("node")
 
 
-def _exec_norm():
-    """Re-execute the _norm_model_id closure body via a synthetic def."""
-    start_marker = "def _norm_model_id(model_id: str) -> str:"
-    end_marker = "def _build_configured_model_badges"
+def _exec_nested_fn(start_marker: str, end_marker: str, fn_name: str):
     s = CONFIG_PY.find(start_marker)
     e = CONFIG_PY.find(end_marker, s)
     assert s != -1 and e != -1
@@ -34,7 +31,25 @@ def _exec_norm():
     dedented = "\n".join(ln[indent:] if len(ln) >= indent else ln for ln in lines)
     ns = {}
     exec(dedented, ns)
-    return ns["_norm_model_id"]
+    return ns[fn_name]
+
+
+def _exec_norm():
+    """Re-execute the _norm_model_id closure body via a synthetic def."""
+    return _exec_nested_fn(
+        "def _norm_model_id(model_id: str) -> str:",
+        "def _build_configured_model_badges",
+        "_norm_model_id",
+    )
+
+
+def _exec_static_norm():
+    """Re-execute the _norm_static_model_id helper via a synthetic def."""
+    return _exec_nested_fn(
+        "def _norm_static_model_id(model_id: str) -> str:",
+        "norm_lookup: dict[str, list[str]] = {}",
+        "_norm_static_model_id",
+    )
 
 
 def test_colon_suffix_model_preserves_suffix():
@@ -80,18 +95,23 @@ def test_ui_js_uses_indexof_not_split_pop():
     assert "s.split(':').pop()" not in UI_JS, (
         "ui.js still uses the buggy split(':').pop() pattern"
     )
+    assert "strippedAtProvider=!!cand" in UI_JS
+
+
+def test_colon_before_slash_prefix_matches_backend_paths():
+    """The non-@ colon-before-slash strip must match both backend helpers."""
+    norm = _exec_norm()
+    static_norm = _exec_static_norm()
+    model_id = "custom:llm-proxy/opencode_go/deepseek-v4-pro"
+    assert norm(model_id) == "deepseek.v4.pro"
+    assert static_norm(model_id) == "deepseek.v4.pro"
 
 
 @pytest.mark.skipif(NODE is None, reason="node not in PATH")
 def test_backend_frontend_parity_complex_aggregator_proxy():
-    """Python and JS normalizers must agree on the inputs our fix affects.
-
-    Note: complex multi-colon+slash IDs like @custom:llm-proxy:kilo/nvidia/model:free
-    have a pre-existing parity gap (JS strips colon-before-slash segments, Python doesn't).
-    This test verifies parity for the simpler @provider:model and @provider:vendor:model
-    forms where our fix changes behavior.
-    """
+    """Python and JS normalizers must stay byte-for-byte aligned."""
     py_norm = _exec_norm()
+    static_norm = _exec_static_norm()
     import re
     js_match = re.search(
         r"function _normalizeConfiguredModelKey\([^)]*\)\{(.+?)\n\}",
@@ -106,9 +126,11 @@ def test_backend_frontend_parity_complex_aggregator_proxy():
     import subprocess, json, tempfile, os
     test_ids = [
         "@custom:jingdong:GLM-5",
-        "openai/gpt-5.5",
-        "gpt-4",
-        "@custom:vendor:model-name",
+        "@custom:llm-proxy:kilo/nvidia/nemotron-3-ultra-550b-a55b:free",
+        "@custom:proxy:nvidia/model:free",
+        "@custom:host:8080:model",
+        "openrouter/deepseek:free",
+        "custom:llm-proxy/opencode_go/deepseek-v4-pro",
     ]
     js_code = js_fn + "\n" + f"console.log(JSON.stringify({json.dumps(test_ids)}.map(id => [id, _normalizeConfiguredModelKey(id)])))"
     with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
@@ -125,8 +147,9 @@ def test_backend_frontend_parity_complex_aggregator_proxy():
         os.unlink(tmp)
     for model_id in test_ids:
         py_result = py_norm(model_id)
+        static_result = static_norm(model_id)
         js_result = js_map[model_id]
-        assert py_result == js_result, (
+        assert py_result == static_result == js_result, (
             f"Parity mismatch for {model_id!r}: "
-            f"Python={py_result!r}, JS={js_result!r}"
+            f"Python={py_result!r}, static={static_result!r}, JS={js_result!r}"
         )

--- a/tests/test_norm_model_id_trailing_empty_guard.py
+++ b/tests/test_norm_model_id_trailing_empty_guard.py
@@ -48,9 +48,9 @@ def test_norm_model_id_trailing_colon_keeps_original():
 
 
 def test_norm_model_id_clean_multi_segment_strips_correctly():
-    """Clean @custom:vendor:model still strips to last segment (the new fix's purpose)."""
+    """Clean @custom:vendor:model strips @custom: prefix, preserving hierarchy."""
     norm = _exec_norm()
-    assert norm("@custom:jingdong:GLM-5") == "glm.5"
+    assert norm("@custom:jingdong:GLM-5") == "jingdong:glm.5"
 
 
 def test_norm_model_id_trailing_slash_keeps_original():
@@ -71,11 +71,10 @@ def test_norm_model_id_simple_inputs_unchanged():
 
 def test_ui_js_mirror_has_trailing_empty_guard():
     """Frontend _normalizeConfiguredModelKey must mirror the backend guard."""
-    # The colon branch still uses `const last=s.split(':').pop();s=last||s;`
-    assert "s.split(':').pop()" in UI_JS, "ui.js no longer uses split-pop pattern for colon branch"
-    # Look for the `||s` fallback on the colon branch
+    # The colon branch now uses indexOf(':',1)+slice to strip only @provider: prefix
+    assert "indexOf(':',1)" in UI_JS, "ui.js no longer uses indexOf-slice pattern for colon branch"
     snippet = UI_JS[UI_JS.find("function _normalizeConfiguredModelKey"):UI_JS.find("function _normalizeConfiguredModelKey") + 1800]
-    assert "last||s" in snippet, "ui.js missing trailing-empty guard `||s` fallback on colon branch"
+    assert "cand||s" in snippet, "ui.js missing trailing-empty guard `||s` fallback on colon branch"
     # The slash branch now uses replace(/^[^/]+\//, '') instead of split('/').pop()
     # to preserve multi-slash vendor hierarchy (#3360).  Verify the new pattern
     # and its trailing-empty guard (the `||s` suffix).


### PR DESCRIPTION
## Thinking Path

- The configured-model picker needs one stable normalization path across the backend badge map and the frontend dedup logic.
- The original fix correctly stopped collapsing colon-suffixed IDs like `:free` and `:thinking` down to the last colon segment.
- The follow-up maintainer review found one remaining parity gap: `static/ui.js` still handled colon-before-slash prefixes differently from the two Python normalizers.
- This update keeps the accepted `@provider:` prefix handling, gates the JS colon-before-slash strip after an `@...:` peel, and mirrors that same colon-before-slash path into both Python normalizers.
- The result is that configured-model dedup, backend badges, and custom-provider suffix handling all normalize the same IDs byte-for-byte.

## What Changed

- `api/config.py`: added the `stripped_at_provider` guard in both `_norm_model_id()` and `_norm_static_model_id()`, and mirrored the JS colon-before-slash strip into both backend paths before the existing slash-prefix strip.
- `static/ui.js`: tracked `strippedAtProvider` inside `_normalizeConfiguredModelKey()` so `@...:`-peeled IDs skip the extra colon-before-slash trim while non-`@` proxy-prefixed IDs keep the existing dedup behavior.
- `tests/test_issue3959_model_suffix_dedup.py`: added coverage for the backend static helper, the non-`@` colon-before-slash case, and the maintainer's parity-table examples so all three normalizers stay aligned.

## Why It Matters

Without this parity fix, the configured-model picker and the backend badge map can normalize the same custom-provider ID differently, which leaves duplicate or mislabeled selector entries even after the original `:free`/`:thinking` collapse fix.

## Verification

- `pytest tests/test_issue3959_model_suffix_dedup.py -v --timeout=60`
- `pytest tests/test_norm_model_id_trailing_empty_guard.py -v --timeout=60`
- `pytest tests/test_issue3429_uri_scheme_model_ids.py -v --timeout=60`
- `pytest tests/test_issue3360_multi_slash_model_collision.py -v --timeout=60`
- `npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs static/ui.js`

## Risks / Follow-ups

- The change is intentionally scoped to configured-model normalization. It does not change provider resolution or the broader custom-provider routing logic outside these three normalizers.

## Model Used

GPT-5.4 via MiMoCode CLI
