### PR TITLE
Release OF (v0.51.419): settled-stream message-count consistency (#4192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Streaming completion payloads now report a message count that matches the embedded transcript.** Settled `done`/error SSE payloads no longer reuse stale compact metadata when they include the full `messages` array, preventing completion/reconcile code from mistaking a full transcript for a short stale window.
+
 ## [v0.51.418] — 2026-06-14 — Release OE (slash-command autocomplete after non-ASCII prefix + multiple slashes, #3924)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.419] — 2026-06-14 — Release OF (settled-stream message-count consistency, #4192)
+
 ### Fixed
 
-- **Streaming completion payloads now report a message count that matches the embedded transcript.** Settled `done`/error SSE payloads no longer reuse stale compact metadata when they include the full `messages` array, preventing completion/reconcile code from mistaking a full transcript for a short stale window.
+- **Streaming completion payloads now report a message count that matches the embedded transcript.** Settled `done`/error SSE payloads (including the gateway-routed chat `done` event) no longer reuse stale compact metadata when they embed the full `messages` array, so completion/reconcile code can't mistake a complete payload for a short stale window. A shared `_session_payload_with_full_messages()` helper sets `message_count` to the embedded transcript length at all three settled-payload sites. (#4192)
 
 ## [v0.51.418] — 2026-06-14 — Release OE (slash-command autocomplete after non-ASCII prefix + multiple slashes, #3924)
 

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -508,7 +508,8 @@ def _run_gateway_chat_streaming(
             s.model = model
             s.model_provider = model_provider
             s.save()
-        gateway_session_payload = s.compact() | {"messages": s.messages, "tool_calls": []}
+        from api.streaming import _session_payload_with_full_messages
+        gateway_session_payload = _session_payload_with_full_messages(s, tool_calls=[])
         put_gateway_event("done", {"session": redact_session_data(gateway_session_payload), "usage": usage})
         put_gateway_event("stream_end", {"session_id": session_id})
     except urllib.error.HTTPError as exc:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -53,6 +53,25 @@ from api.models import (
 )
 from api.session_ops import mark_session_title_generated, session_has_manual_title
 
+
+def _session_payload_with_full_messages(session, *, tool_calls=None):
+    """Return compact session metadata plus the embedded full transcript.
+
+    ``Session.compact()`` may intentionally use metadata-only counts from an
+    index/sidebar load. A settled SSE payload that embeds ``session.messages``
+    must report the count of that embedded transcript, otherwise completion and
+    reconcile paths can mistake a complete payload for a stale short window.
+    """
+    messages = list(getattr(session, 'messages', None) or [])
+    raw = session.compact() | {
+        'messages': messages,
+        'message_count': len(messages),
+    }
+    if tool_calls is not None:
+        raw['tool_calls'] = tool_calls
+    return raw
+
+
 # Global lock for os.environ writes. Per-session locks (_agent_lock) prevent
 # concurrent runs of the SAME session, but two DIFFERENT sessions can still
 # interleave their os.environ writes. This global lock serializes the env
@@ -7181,7 +7200,7 @@ def _run_agent_streaming(
                         except Exception:
                             pass
                         _error_payload['session'] = redact_session_data(
-                            s.compact() | {'messages': s.messages, 'tool_calls': s.tool_calls}
+                            _session_payload_with_full_messages(s, tool_calls=s.tool_calls)
                         )
                         _error_payload['session_id'] = s.session_id
                         _error_payload['old_session_id'] = _compression_origin_session_id
@@ -7884,7 +7903,7 @@ def _run_agent_streaming(
                         })
             except Exception as _goal_exc:
                 logger.debug("Goal continuation hook failed for session %s: %s", session_id, _goal_exc)
-            raw_session = s.compact() | {'messages': s.messages, 'tool_calls': tool_calls}
+            raw_session = _session_payload_with_full_messages(s, tool_calls=tool_calls)
             _done_payload = {'session': redact_session_data(raw_session), 'usage': usage}
             if _tool_limit_reached:
                 _done_payload['terminal_state'] = 'tool_limit_reached'

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -743,9 +743,9 @@ def test_streaming_persists_reasoning_in_session():
     assert "_rm['reasoning'] = _existing_reasoning" in src, \
         "the no-think-block branch must still persist _reasoning_text into the assistant message"
 
-    # Persistence block must come BEFORE raw_session assignment
+    # Persistence block must come BEFORE the settled raw_session payload is built
     persist_idx = src.index("Persist reasoning trace in the session")
-    raw_session_idx = src.index("raw_session = s.compact()")
+    raw_session_idx = src.index("raw_session = _session_payload_with_full_messages")
     assert persist_idx < raw_session_idx, \
         "Reasoning persistence block must appear before raw_session assignment"
 

--- a/tests/test_streaming_done_payload_message_count.py
+++ b/tests/test_streaming_done_payload_message_count.py
@@ -1,0 +1,53 @@
+"""Regression coverage for settled SSE payload message counts."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from api.streaming import _session_payload_with_full_messages
+
+
+STREAMING_SOURCE = Path("api/streaming.py").read_text(encoding="utf-8")
+
+
+class _FakeSession(SimpleNamespace):
+    def compact(self):
+        return {
+            "session_id": self.session_id,
+            "message_count": 45,
+            "title": "stale compact metadata",
+        }
+
+
+def test_full_message_payload_overrides_stale_compact_message_count():
+    session = _FakeSession(
+        session_id="child-session",
+        messages=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "second"},
+        ],
+    )
+
+    payload = _session_payload_with_full_messages(session, tool_calls=[])
+
+    assert payload["messages"] == session.messages
+    assert payload["message_count"] == len(session.messages)
+    assert payload["message_count"] != session.compact()["message_count"]
+
+
+def test_done_payload_uses_full_message_count_helper():
+    done_idx = STREAMING_SOURCE.index("put('done', _done_payload)")
+    block_start = STREAMING_SOURCE.rfind("raw_session =", 0, done_idx)
+    block = STREAMING_SOURCE[block_start:done_idx]
+
+    assert "_session_payload_with_full_messages(s, tool_calls=tool_calls)" in block
+    assert "s.compact() | {'messages': s.messages" not in block
+
+
+def test_apperror_payload_uses_full_message_count_helper():
+    error_idx = STREAMING_SOURCE.index("put('apperror', _error_payload)")
+    block_start = STREAMING_SOURCE.rfind("_error_payload['session']", 0, error_idx)
+    block = STREAMING_SOURCE[block_start:error_idx]
+
+    assert "_session_payload_with_full_messages(s, tool_calls=s.tool_calls)" in block
+    assert "s.compact() | {'messages': s.messages" not in block

--- a/tests/test_streaming_done_payload_message_count.py
+++ b/tests/test_streaming_done_payload_message_count.py
@@ -51,3 +51,16 @@ def test_apperror_payload_uses_full_message_count_helper():
 
     assert "_session_payload_with_full_messages(s, tool_calls=s.tool_calls)" in block
     assert "s.compact() | {'messages': s.messages" not in block
+
+
+def test_gateway_done_payload_uses_full_message_count_helper():
+    """The gateway-routed chat `done` SSE shares the settled-payload path and
+    must also report a message_count matching the embedded transcript (sibling
+    of the two streaming.py sites)."""
+    gateway_source = Path("api/gateway_chat.py").read_text(encoding="utf-8")
+    done_idx = gateway_source.index('put_gateway_event("done"')
+    block_start = gateway_source.rfind("gateway_session_payload =", 0, done_idx)
+    block = gateway_source[block_start:done_idx]
+
+    assert "_session_payload_with_full_messages(s, tool_calls=[])" in block
+    assert 's.compact() | {"messages": s.messages' not in block


### PR DESCRIPTION
## Release OF — v0.51.419

Single PR — streaming settled-payload consistency fix (deep-gated; rebased + sibling-fix applied).

- **#4192** (ai-ag2026): keep settled stream message counts consistent. Settled `done`/error SSE payloads built `s.compact() | {'messages': s.messages}`, but `compact()` can carry a metadata-only `message_count` (from an index/sidebar load) that mismatches the embedded full transcript — so frontend completion/reconcile could mistake a complete payload for a short stale window. A new `_session_payload_with_full_messages()` helper sets `message_count = len(messages)`.
  - Applied at the streaming `done` (streaming.py:7906) and error (streaming.py:7203) payload sites.
  - **Sibling fix (Codex-flagged, applied on review):** the gateway-routed chat `done` event (gateway_chat.py:511) shares the same settled-payload path and had the same stale-count bug — now also uses the helper (local import; no cycle). Added a regression test covering it.

### Gates
- **Codex regression gate:** the two streaming sites correct; flagged + fixed the gateway sibling; confirmed the 6 routes.py sync-HTTP `compact()|{messages}` sites are out of scope (not the SSE done path).
- **Opus advisor:** net-positive, no MUST-FIX — no under-reporting path (payloads always embed the full transcript), tool_calls preserved at all sites, no import cycle. (Low-priority follow-up: extend the helper to the routes.py HTTP siblings for consistency.)
- **ruff + py_compile:** CLEAN. **Full suite:** 8987 passed, 0 failed.

Co-authored-by: ai-ag2026
