### PR TITLE
fix(models): preserve colon-suffixed model IDs in normalization (#3959, ships #4196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.421] — 2026-06-14 — Release OH (preserve colon-suffixed model IDs in normalization, #3959)
+
+### Fixed
+
+- **Model-ID normalization no longer drops a variant suffix like `:free` or `:thinking`, and configured-model dedup keys now match between the backend and the picker.** A model id such as `deepseek-r1:free` keeps its `:free` variant instead of collapsing to the base model, and `@custom:vendor:model` ids now strip only the `@provider:` prefix while preserving the vendor hierarchy (e.g. `@custom:jingdong:GLM-5` → `jingdong:glm.5`), so distinct vendors no longer collide. The same normalization rules are applied consistently across both backend normalizers and the `static/ui.js` configured-model mirror so badge dedup and the model picker agree byte-for-byte. (#3959)
+
 ## [v0.51.420] — 2026-06-14 — Release OG (LM Studio reasoning-probe auth, #3750/#3837)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -3351,8 +3351,9 @@ def _configured_model_badges_from_static_catalog(
     def _norm_static_model_id(model_id: str) -> str:
         s = str(model_id or "").strip().lower()
         if s.startswith("@") and ":" in s:
-            parts = s.split(":")
-            s = parts[-1] or s
+            colon_idx = s.index(":", 1)
+            candidate = s[colon_idx + 1:]
+            s = candidate or s
         if "://" not in s and "/" in s:
             stripped = s.split("/", 1)[1]
             s = stripped or s
@@ -4577,8 +4578,11 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
             # Defensive: if the last segment is empty (trailing colon, malformed
             # config), keep the original to avoid collapsing distinct IDs to ''.
             if s.startswith("@") and ":" in s:
-                parts = s.split(":")
-                s = parts[-1] or s
+                # Strip @provider: prefix, preserving remaining hierarchy including
+                # colon-suffixed model IDs like provider/model:free (#3959).
+                colon_idx = s.index(":", 1)
+                candidate = s[colon_idx + 1:]
+                s = candidate or s
             # Skip slash-based stripping for URI-scheme IDs (e.g.
             # gpt://folder/model/latest) whose slashes are path separators,
             # not provider delimiters (#3429).

--- a/api/config.py
+++ b/api/config.py
@@ -3350,13 +3350,23 @@ def _configured_model_badges_from_static_catalog(
 
     def _norm_static_model_id(model_id: str) -> str:
         s = str(model_id or "").strip().lower()
+        stripped_at_provider = False
         if s.startswith("@") and ":" in s:
             colon_idx = s.index(":", 1)
             candidate = s[colon_idx + 1:]
+            stripped_at_provider = bool(candidate)
             s = candidate or s
-        if "://" not in s and "/" in s:
-            stripped = s.split("/", 1)[1]
-            s = stripped or s
+        if "://" not in s:
+            if (
+                not stripped_at_provider
+                and "/" in s
+                and ":" in s
+                and s.index(":") < s.index("/")
+            ):
+                s = s[s.index("/") + 1 :] or s
+            if "/" in s:
+                stripped = s.split("/", 1)[1]
+                s = stripped or s
         return s.replace("-", ".")
 
     norm_lookup: dict[str, list[str]] = {}
@@ -4574,6 +4584,7 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
 
         def _norm_model_id(model_id: str) -> str:
             s = str(model_id or "").strip().lower()
+            stripped_at_provider = False
             # Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> GLM-5).
             # Defensive: if the last segment is empty (trailing colon, malformed
             # config), keep the original to avoid collapsing distinct IDs to ''.
@@ -4582,11 +4593,19 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
                 # colon-suffixed model IDs like provider/model:free (#3959).
                 colon_idx = s.index(":", 1)
                 candidate = s[colon_idx + 1:]
+                stripped_at_provider = bool(candidate)
                 s = candidate or s
             # Skip slash-based stripping for URI-scheme IDs (e.g.
             # gpt://folder/model/latest) whose slashes are path separators,
             # not provider delimiters (#3429).
             if "://" not in s:
+                if (
+                    not stripped_at_provider
+                    and "/" in s
+                    and ":" in s
+                    and s.index(":") < s.index("/")
+                ):
+                    s = s[s.index("/") + 1 :] or s
                 # Strip only the first slash-segment (provider prefix), preserving
                 # any remaining vendor hierarchy.  Using parts[-1] here previously
                 # discarded ALL segments except the last, collapsing distinct

--- a/static/ui.js
+++ b/static/ui.js
@@ -1658,10 +1658,10 @@ function _selectedModelOption(){
 
 function _normalizeConfiguredModelKey(modelId){
   let s=String(modelId||'').trim().toLowerCase();
-  // Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> GLM-5).
+  // Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> jingdong:GLM-5).
   // Defensive: trailing-colon / trailing-slash falls back to the original key
   // so malformed configs don't collapse distinct ids to '' (matches backend _norm_model_id).
-  if(s.startsWith('@')&&s.includes(':')){const last=s.split(':').pop();s=last||s;}
+  if(s.startsWith('@')&&s.includes(':')){const ci=s.indexOf(':',1);const cand=s.slice(ci+1);s=cand||s;}
   // Skip slash-based stripping for URI-scheme IDs (e.g. gpt://folder/model)
   // whose slashes are path separators, not provider delimiters (#3429).
   const _hasScheme=/^[a-z][a-z0-9+.-]*:\/\//i.test(s);

--- a/static/ui.js
+++ b/static/ui.js
@@ -1658,10 +1658,11 @@ function _selectedModelOption(){
 
 function _normalizeConfiguredModelKey(modelId){
   let s=String(modelId||'').trim().toLowerCase();
+  let strippedAtProvider=false;
   // Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> jingdong:GLM-5).
   // Defensive: trailing-colon / trailing-slash falls back to the original key
   // so malformed configs don't collapse distinct ids to '' (matches backend _norm_model_id).
-  if(s.startsWith('@')&&s.includes(':')){const ci=s.indexOf(':',1);const cand=s.slice(ci+1);s=cand||s;}
+  if(s.startsWith('@')&&s.includes(':')){const ci=s.indexOf(':',1);const cand=s.slice(ci+1);strippedAtProvider=!!cand;s=cand||s;}
   // Skip slash-based stripping for URI-scheme IDs (e.g. gpt://folder/model)
   // whose slashes are path separators, not provider delimiters (#3429).
   const _hasScheme=/^[a-z][a-z0-9+.-]*:\/\//i.test(s);
@@ -1671,7 +1672,7 @@ function _normalizeConfiguredModelKey(modelId){
     // key variants like 'custom:llm-proxy/opencode_go/deepseek-v4-pro' and the
     // bare 'opencode_go/deepseek-v4-pro' produce different normalized keys and
     // aren't deduped in the configured section (#3360).
-    if(s.includes('/')&&s.indexOf(':')!==-1&&s.indexOf(':')<s.indexOf('/')){
+    if(!strippedAtProvider&&s.includes('/')&&s.indexOf(':')!==-1&&s.indexOf(':')<s.indexOf('/')){
       s=s.slice(s.indexOf('/')+1)||s;
     }
     // Strip only the first slash-segment (provider prefix), preserving any

--- a/tests/test_issue3360_multi_slash_model_collision.py
+++ b/tests/test_issue3360_multi_slash_model_collision.py
@@ -228,7 +228,7 @@ class TestNormalizeConfiguredModelKeyMultiSlash:
 
     def test_at_provider_prefix_still_stripped(self, norm_driver):
         keys = _norm_keys(norm_driver, ["@custom:jingdong:GLM-5"])
-        assert keys["@custom:jingdong:GLM-5"] == "glm.5"
+        assert keys["@custom:jingdong:GLM-5"] == "jingdong:glm.5"
 
     def test_trailing_slash_fallback(self, norm_driver):
         """A trailing slash (malformed) must not collapse to empty."""

--- a/tests/test_issue3959_model_suffix_dedup.py
+++ b/tests/test_issue3959_model_suffix_dedup.py
@@ -1,0 +1,132 @@
+"""Regression tests for #3959 — Model selector shows duplicate entries for
+colon-suffixed model IDs (e.g. :free, :thinking, :discounted).
+
+The normalizer was using parts[-1] (last colon segment) which collapsed all
+:free models to the same key 'free'.  Fix: strip only the @provider: prefix
+(first colon after @), preserving the rest including colon-suffixed suffixes.
+"""
+import shutil
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+CONFIG_PY = (REPO_ROOT / "api" / "config.py").read_text(encoding="utf-8")
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+NODE = shutil.which("node")
+
+
+def _exec_norm():
+    """Re-execute the _norm_model_id closure body via a synthetic def."""
+    start_marker = "def _norm_model_id(model_id: str) -> str:"
+    end_marker = "def _build_configured_model_badges"
+    s = CONFIG_PY.find(start_marker)
+    e = CONFIG_PY.find(end_marker, s)
+    assert s != -1 and e != -1
+    body = CONFIG_PY[s:e]
+    lines = body.splitlines()
+    indent = None
+    for ln in lines:
+        if ln.strip():
+            indent = len(ln) - len(ln.lstrip())
+            break
+    dedented = "\n".join(ln[indent:] if len(ln) >= indent else ln for ln in lines)
+    ns = {}
+    exec(dedented, ns)
+    return ns["_norm_model_id"]
+
+
+def test_colon_suffix_model_preserves_suffix():
+    """@custom:llm-proxy:kilo/nvidia/nemotron-3-ultra-550b-a55b:free must
+    NOT collapse to just 'free'."""
+    norm = _exec_norm()
+    result = norm("@custom:llm-proxy:kilo/nvidia/nemotron-3-ultra-550b-a55b:free")
+    assert "free" in result, f"Expected 'free' in result, got {result!r}"
+    assert result != "free", f"Suffix-only collapse is the bug: {result!r}"
+
+
+def test_free_vs_thinking_produce_different_keys():
+    """:free and :thinking variants of the same model must normalize to
+    different keys to avoid duplicate selector entries."""
+    norm = _exec_norm()
+    base = "@custom:llm-proxy:kilo/nvidia/nemotron-3-ultra-550b-a55b"
+    key_free = norm(f"{base}:free")
+    key_thinking = norm(f"{base}:thinking")
+    assert key_free != key_thinking, (
+        f":free and :thinking collapsed to same key: "
+        f"free={key_free!r}, thinking={key_thinking!r}"
+    )
+
+
+def test_plain_model_id_still_normalizes():
+    """Simple model IDs without @ prefix must still normalize correctly."""
+    norm = _exec_norm()
+    assert norm("gpt-4") == "gpt.4"
+    assert norm("") == ""
+    assert norm(None) == ""
+
+
+def test_provider_prefix_only_model():
+    """@custom:vendor:model (no colon suffix) still strips prefix."""
+    norm = _exec_norm()
+    result = norm("@custom:jingdong:GLM-5")
+    assert result == "jingdong:glm.5"
+
+
+def test_ui_js_uses_indexof_not_split_pop():
+    """Frontend must use indexOf(':',1)+slice, not split(':').pop()."""
+    assert "indexOf(':',1)" in UI_JS
+    assert "s.split(':').pop()" not in UI_JS, (
+        "ui.js still uses the buggy split(':').pop() pattern"
+    )
+
+
+@pytest.mark.skipif(NODE is None, reason="node not in PATH")
+def test_backend_frontend_parity_complex_aggregator_proxy():
+    """Python and JS normalizers must agree on the inputs our fix affects.
+
+    Note: complex multi-colon+slash IDs like @custom:llm-proxy:kilo/nvidia/model:free
+    have a pre-existing parity gap (JS strips colon-before-slash segments, Python doesn't).
+    This test verifies parity for the simpler @provider:model and @provider:vendor:model
+    forms where our fix changes behavior.
+    """
+    py_norm = _exec_norm()
+    import re
+    js_match = re.search(
+        r"function _normalizeConfiguredModelKey\([^)]*\)\{(.+?)\n\}",
+        UI_JS,
+        re.DOTALL,
+    )
+    assert js_match, "Could not find _normalizeConfiguredModelKey in ui.js"
+    js_body = js_match.group(1)
+    js_fn = f"""
+    function _normalizeConfiguredModelKey(modelId){{{js_body}}}
+    """
+    import subprocess, json, tempfile, os
+    test_ids = [
+        "@custom:jingdong:GLM-5",
+        "openai/gpt-5.5",
+        "gpt-4",
+        "@custom:vendor:model-name",
+    ]
+    js_code = js_fn + "\n" + f"console.log(JSON.stringify({json.dumps(test_ids)}.map(id => [id, _normalizeConfiguredModelKey(id)])))"
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
+        f.write(js_code)
+        tmp = f.name
+    try:
+        result = subprocess.run(
+            ["node", tmp], capture_output=True, text=True, timeout=10
+        )
+        assert result.returncode == 0, f"JS execution failed: {result.stderr}"
+        js_pairs = json.loads(result.stdout.strip())
+        js_map = dict(js_pairs)
+    finally:
+        os.unlink(tmp)
+    for model_id in test_ids:
+        py_result = py_norm(model_id)
+        js_result = js_map[model_id]
+        assert py_result == js_result, (
+            f"Parity mismatch for {model_id!r}: "
+            f"Python={py_result!r}, JS={js_result!r}"
+        )

--- a/tests/test_issue3959_model_suffix_dedup.py
+++ b/tests/test_issue3959_model_suffix_dedup.py
@@ -17,10 +17,7 @@ UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 NODE = shutil.which("node")
 
 
-def _exec_norm():
-    """Re-execute the _norm_model_id closure body via a synthetic def."""
-    start_marker = "def _norm_model_id(model_id: str) -> str:"
-    end_marker = "def _build_configured_model_badges"
+def _exec_nested_fn(start_marker: str, end_marker: str, fn_name: str):
     s = CONFIG_PY.find(start_marker)
     e = CONFIG_PY.find(end_marker, s)
     assert s != -1 and e != -1
@@ -34,7 +31,25 @@ def _exec_norm():
     dedented = "\n".join(ln[indent:] if len(ln) >= indent else ln for ln in lines)
     ns = {}
     exec(dedented, ns)
-    return ns["_norm_model_id"]
+    return ns[fn_name]
+
+
+def _exec_norm():
+    """Re-execute the _norm_model_id closure body via a synthetic def."""
+    return _exec_nested_fn(
+        "def _norm_model_id(model_id: str) -> str:",
+        "def _build_configured_model_badges",
+        "_norm_model_id",
+    )
+
+
+def _exec_static_norm():
+    """Re-execute the _norm_static_model_id helper via a synthetic def."""
+    return _exec_nested_fn(
+        "def _norm_static_model_id(model_id: str) -> str:",
+        "norm_lookup: dict[str, list[str]] = {}",
+        "_norm_static_model_id",
+    )
 
 
 def test_colon_suffix_model_preserves_suffix():
@@ -80,18 +95,23 @@ def test_ui_js_uses_indexof_not_split_pop():
     assert "s.split(':').pop()" not in UI_JS, (
         "ui.js still uses the buggy split(':').pop() pattern"
     )
+    assert "strippedAtProvider=!!cand" in UI_JS
+
+
+def test_colon_before_slash_prefix_matches_backend_paths():
+    """The non-@ colon-before-slash strip must match both backend helpers."""
+    norm = _exec_norm()
+    static_norm = _exec_static_norm()
+    model_id = "custom:llm-proxy/opencode_go/deepseek-v4-pro"
+    assert norm(model_id) == "deepseek.v4.pro"
+    assert static_norm(model_id) == "deepseek.v4.pro"
 
 
 @pytest.mark.skipif(NODE is None, reason="node not in PATH")
 def test_backend_frontend_parity_complex_aggregator_proxy():
-    """Python and JS normalizers must agree on the inputs our fix affects.
-
-    Note: complex multi-colon+slash IDs like @custom:llm-proxy:kilo/nvidia/model:free
-    have a pre-existing parity gap (JS strips colon-before-slash segments, Python doesn't).
-    This test verifies parity for the simpler @provider:model and @provider:vendor:model
-    forms where our fix changes behavior.
-    """
+    """Python and JS normalizers must stay byte-for-byte aligned."""
     py_norm = _exec_norm()
+    static_norm = _exec_static_norm()
     import re
     js_match = re.search(
         r"function _normalizeConfiguredModelKey\([^)]*\)\{(.+?)\n\}",
@@ -106,9 +126,11 @@ def test_backend_frontend_parity_complex_aggregator_proxy():
     import subprocess, json, tempfile, os
     test_ids = [
         "@custom:jingdong:GLM-5",
-        "openai/gpt-5.5",
-        "gpt-4",
-        "@custom:vendor:model-name",
+        "@custom:llm-proxy:kilo/nvidia/nemotron-3-ultra-550b-a55b:free",
+        "@custom:proxy:nvidia/model:free",
+        "@custom:host:8080:model",
+        "openrouter/deepseek:free",
+        "custom:llm-proxy/opencode_go/deepseek-v4-pro",
     ]
     js_code = js_fn + "\n" + f"console.log(JSON.stringify({json.dumps(test_ids)}.map(id => [id, _normalizeConfiguredModelKey(id)])))"
     with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
@@ -125,8 +147,9 @@ def test_backend_frontend_parity_complex_aggregator_proxy():
         os.unlink(tmp)
     for model_id in test_ids:
         py_result = py_norm(model_id)
+        static_result = static_norm(model_id)
         js_result = js_map[model_id]
-        assert py_result == js_result, (
+        assert py_result == static_result == js_result, (
             f"Parity mismatch for {model_id!r}: "
-            f"Python={py_result!r}, JS={js_result!r}"
+            f"Python={py_result!r}, static={static_result!r}, JS={js_result!r}"
         )

--- a/tests/test_norm_model_id_trailing_empty_guard.py
+++ b/tests/test_norm_model_id_trailing_empty_guard.py
@@ -48,9 +48,9 @@ def test_norm_model_id_trailing_colon_keeps_original():
 
 
 def test_norm_model_id_clean_multi_segment_strips_correctly():
-    """Clean @custom:vendor:model still strips to last segment (the new fix's purpose)."""
+    """Clean @custom:vendor:model strips @custom: prefix, preserving hierarchy."""
     norm = _exec_norm()
-    assert norm("@custom:jingdong:GLM-5") == "glm.5"
+    assert norm("@custom:jingdong:GLM-5") == "jingdong:glm.5"
 
 
 def test_norm_model_id_trailing_slash_keeps_original():
@@ -71,11 +71,10 @@ def test_norm_model_id_simple_inputs_unchanged():
 
 def test_ui_js_mirror_has_trailing_empty_guard():
     """Frontend _normalizeConfiguredModelKey must mirror the backend guard."""
-    # The colon branch still uses `const last=s.split(':').pop();s=last||s;`
-    assert "s.split(':').pop()" in UI_JS, "ui.js no longer uses split-pop pattern for colon branch"
-    # Look for the `||s` fallback on the colon branch
+    # The colon branch now uses indexOf(':',1)+slice to strip only @provider: prefix
+    assert "indexOf(':',1)" in UI_JS, "ui.js no longer uses indexOf-slice pattern for colon branch"
     snippet = UI_JS[UI_JS.find("function _normalizeConfiguredModelKey"):UI_JS.find("function _normalizeConfiguredModelKey") + 1800]
-    assert "last||s" in snippet, "ui.js missing trailing-empty guard `||s` fallback on colon branch"
+    assert "cand||s" in snippet, "ui.js missing trailing-empty guard `||s` fallback on colon branch"
     # The slash branch now uses replace(/^[^/]+\//, '') instead of split('/').pop()
     # to preserve multi-slash vendor hierarchy (#3360).  Verify the new pattern
     # and its trailing-empty guard (the `||s` suffix).


### PR DESCRIPTION
## Release of #4196 (preserve colon-suffixed model IDs, #3959)

This is the maintainer ship-pass of @rodboev's #4196, rebased onto current master.
Closes #3959. Supersedes the #4196 branch (parity-converged head `cb32c727`).

### What it fixes (#3959)
Model-ID normalization was collapsing variant suffixes (`:free`, `:thinking`) into
the base model. Now:
- Variant suffixes after a colon are preserved (`deepseek-r1:free` keeps `:free`).
- `@custom:vendor:model` strips only the `@provider:` prefix and preserves the
  vendor hierarchy: `@custom:jingdong:GLM-5` → `jingdong:glm.5` (was `glm.5`), so
  distinct vendors no longer collide. This is an intentional, maintainer-approved
  contract change (vendor disambiguation).
- A `stripped_at_provider` / `strippedAtProvider` flag gates the colon-before-slash
  strip so all three normalizers agree byte-for-byte: `_norm_static_model_id`,
  inline `_norm_model_id`, and `static/ui.js`'s `_normalizeConfiguredModelKey`.

### Review / gate
- Two prior bounces (collision finding, then a Python↔JS parity gap) — both
  CONVERGED on the current head: the maintainer parity table runs byte-identical
  across all 9 cases, 21/21 affected tests pass.
- Codex final gate: **SAFE TO SHIP** (3 normalizers agree byte-for-byte; badge
  matching intact; send-time routing unaffected).
- ruff + ESLint forward gates: clean. Full local suite: pass (the local
  process-group cascade is a known box artifact; CI 3-shard is authoritative + green).

Co-authored-by: Rod Boev <rod.boev@gmail.com>
