### PR TITLE
fix: block empty active pending session overwrite

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -787,6 +787,20 @@ class Session:
                 except (json.JSONDecodeError, ValueError):
                     existing_msg_count = -1  # corrupt → always back up
                 incoming_msg_count = len(self.messages or [])
+                if (
+                    existing_msg_count > 0
+                    and incoming_msg_count == 0
+                    and (self.active_stream_id or self.pending_user_message)
+                ):
+                    logger.warning(
+                        "refusing to overwrite session %s messages with empty active/pending snapshot "
+                        "(existing=%s, incoming=%s, stream=%s)",
+                        self.session_id,
+                        existing_msg_count,
+                        incoming_msg_count,
+                        self.active_stream_id,
+                    )
+                    return
                 if existing_msg_count > incoming_msg_count:
                     bak_path = self.path.with_suffix('.json.bak')
                     # SHOULD-FIX #2 (Opus): atomic write via tmp+replace,

--- a/tests/test_session_save_empty_pending_guard.py
+++ b/tests/test_session_save_empty_pending_guard.py
@@ -1,0 +1,44 @@
+"""Regression coverage for empty active/pending session save writebacks."""
+
+import json
+
+import api.config as config
+import api.models as models
+from api.models import Session
+
+
+def test_empty_active_pending_save_cannot_overwrite_existing_messages(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(config, "SESSION_INDEX_FILE", index_file, raising=False)
+    models.SESSIONS.clear()
+
+    sid = "pending_overwrite_guard"
+    existing = Session(
+        session_id=sid,
+        messages=[
+            {"role": "user", "content": "prompt"},
+            {"role": "assistant", "content": "answer"},
+        ],
+    )
+    existing.save()
+
+    stale = Session(
+        session_id=sid,
+        messages=[],
+        active_stream_id="stale-stream",
+        pending_user_message="prompt",
+        pending_started_at=123.0,
+    )
+    stale.save()
+
+    persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+    assert [m["content"] for m in persisted["messages"]] == ["prompt", "answer"]
+    assert persisted["message_count"] == 2
+
+    index = json.loads(index_file.read_text(encoding="utf-8"))
+    indexed = next(row for row in index if row["session_id"] == sid)
+    assert indexed["message_count"] == 2


### PR DESCRIPTION
## Summary

Prevents a stale active/pending WebUI session snapshot with `messages=[]` from overwriting an existing messageful session sidecar and refreshing the session index to a shorter/empty transcript.

This is the sibling failure class observed after the settled-stream message-count fix from #4192: a completed/recovered transcript can exist on disk, but an older active pending `Session` object can later save `messages=[]` over it. The existing `.json.bak` safeguard preserves a copy, but the primary sidecar and `_index.json` still degrade, so the browser can continue to show missing/empty transcript state.

## Contract Routing

Task type: runtime/session durability bug fix

Touched areas:
- `api/models.py` session sidecar persistence
- regression coverage for active/pending save invariants

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`

State layers affected:
- durable WebUI session sidecar
- sidebar/session index metadata
- pending turn runtime metadata

Invariant: runtime maintenance or a stale active/pending object must not make a messageful transcript shorter by writing `messages=[]` over it.

## Tests

```bash
python3 -m pytest tests/test_session_save_empty_pending_guard.py tests/test_stale_stream_writeback.py -q
# 9 passed in 2.39s

python3 -m py_compile api/models.py
```

Live productive checkout smoke also passed with the streaming sibling tests:

```bash
python3 -m pytest tests/test_session_save_empty_pending_guard.py tests/test_stale_stream_writeback.py tests/test_sprint42.py::test_streaming_persists_reasoning_in_session tests/test_streaming_done_payload_message_count.py -q
# 13 passed in 2.66s

python3 -m py_compile api/models.py api/streaming.py
```
