### PR TITLE
fix(sessions): refresh active WebUI sessions on session events

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3650,7 +3650,12 @@ async function refreshActiveSessionIfExternallyUpdated(reason){
   if(_activeSessionExternalRefreshInFlight) return;
   if(!S.session || !S.session.session_id) return;
   if(S.busy || S.activeStreamId) return;
-  if(!_isExternalSession(S.session)) return;
+  // #3916: the 30s timer is only a fallback for imported/external sessions.
+  // WebUI-native sessions should not keep probing forever when the sidebar SSE
+  // is healthy, but they still must reconcile when an actual sessions_changed
+  // event, focus, or visibility recovery says another client/process mutated
+  // the active transcript (#4205 follow-up shape).
+  if((reason||'poll')==='poll' && !_isExternalSession(S.session)) return;
   // Cooldown: don't force-reload immediately after streaming ends — the
   // "done" event already delivered the final messages. Reloading here would
   // clear S.toolCalls and lose Activity.
@@ -3719,7 +3724,7 @@ function _scheduleSessionEventsRefresh(reason){
   if(_sessionEventsRefreshTimer) return;
   _sessionEventsRefreshTimer = setTimeout(() => {
     _sessionEventsRefreshTimer = 0;
-    void refreshSessionList(reason||'event');
+    void refreshSessionList(reason||'event', {refreshActive:true});
   }, 300);
 }
 

--- a/tests/test_issue3916_external_refresh_poll.py
+++ b/tests/test_issue3916_external_refresh_poll.py
@@ -4,21 +4,34 @@ from pathlib import Path
 SESSIONS_JS = Path(__file__).resolve().parent.parent / "static" / "sessions.js"
 
 
+def _function_body(src: str, name: str) -> str:
+    m = re.search(
+        rf"(?:async\s+)?function\s+{re.escape(name)}\b.*?^}}",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert m, f"{name} function not found"
+    return m.group(0)
+
+
 def test_refreshActiveSessionIfExternallyUpdated_exists():
     src = SESSIONS_JS.read_text(encoding="utf-8")
     assert "async function refreshActiveSessionIfExternallyUpdated" in src
 
 
-def test_isExternalSession_guard_present():
+def test_poll_path_skips_non_external_sessions():
     src = SESSIONS_JS.read_text(encoding="utf-8")
-    m = re.search(
-        r"async function refreshActiveSessionIfExternallyUpdated\b.*?^}",
-        src,
-        re.DOTALL | re.MULTILINE,
+    body = _function_body(src, "refreshActiveSessionIfExternallyUpdated")
+    assert re.search(
+        r"if\s*\(\s*\(\s*reason\s*\|\|\s*['\"]poll['\"]\s*\)\s*===\s*['\"]poll['\"]\s*&&\s*!\s*_isExternalSession\s*\(",
+        body,
+    ), (
+        "the 30s poll fallback should early-return for WebUI-native sessions, "
+        "but non-poll refresh triggers must still be allowed"
     )
-    assert m, "refreshActiveSessionIfExternallyUpdated function not found"
-    body = m.group(0)
-    assert re.search(r"if\s*\(\s*!\s*_isExternalSession\s*\(", body), (
-        "refreshActiveSessionIfExternallyUpdated must have an early-return "
-        "guard: if(!_isExternalSession(...))"
-    )
+
+
+def test_session_events_refresh_active_session():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    body = _function_body(src, "_scheduleSessionEventsRefresh")
+    assert "refreshSessionList(reason||'event', {refreshActive:true})" in body


### PR DESCRIPTION
## Summary

Fixes the refresh gap introduced by the #3916/#4195 external-refresh guard: the 30-second poll should still skip WebUI-native sessions, but real `sessions_changed` events must be allowed to reconcile the active WebUI transcript when another client/process updates it.

Root cause: `refreshActiveSessionIfExternallyUpdated()` returned early for every non-external session, and `_scheduleSessionEventsRefresh()` only refreshed the sidebar list. So a WebUI-native active session could receive a sidebar/session event, update the list, and still leave the currently-open transcript stale.

## Changes

- Keep the #3916 behavior for the periodic `poll` path only.
- Allow non-poll triggers (`event`, focus/visibility recovery callers) to run the existing count/timestamp divergence check for WebUI-native sessions.
- Make the session-events debounce call `refreshSessionList(..., {refreshActive:true})` so a `sessions_changed` event can refresh the currently-open transcript.
- Update the #3916 regression test to lock this narrower contract instead of the over-broad source guard.

## Tests

```bash
python3 -m pytest tests/test_issue3916_external_refresh_poll.py tests/test_issue4154_sidebar_issue_numbers.py -q
# 7 passed, 1 warning

node --check static/sessions.js

git diff --check

python3 -m pytest tests/test_stale_stream_cleanup.py tests/test_streaming_done_payload_message_count.py -q
# 15 passed, 1 warning

python3 -m pytest tests/test_gateway_sync.py::test_empty_active_gateway_session_does_not_hide_messaging_history -q
# 1 passed, 1 warning
```

## Notes

This is separate from the data-durability guard proposed in #4205. That PR may still be useful to prevent a stale empty pending object from degrading the sidecar, but the reason the active browser view is not refreshing is the client-side event path above.
