### PR TITLE
Fix replies to cron sessions

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -13658,9 +13658,11 @@ def _handle_chat_start(handler, body, diag=None):
             return bad(handler, str(e))
         diag.stage("get_session") if diag else None
         try:
-            s = get_session(body["session_id"])
+            s = _get_or_materialize_session(body["session_id"])
         except KeyError:
             return bad(handler, "Session not found", 404)
+        except PermissionError:
+            return bad(handler, "Read-only imported sessions cannot be continued from WebUI", 403)
         diag.stage("validate_profile") if diag else None
         requested_profile = str(body.get("profile") or "").strip()
         if requested_profile:

--- a/tests/test_issue3975_cron_reply_materialization.py
+++ b/tests/test_issue3975_cron_reply_materialization.py
@@ -1,0 +1,85 @@
+"""Regression coverage for replying to cron-origin sessions (#3975)."""
+
+import io
+import json
+from types import SimpleNamespace
+
+import api.routes as routes
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.status = None
+        self.headers = {}
+        self.response_headers = []
+        self.wfile = io.BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.response_headers.append((key, value))
+
+    def end_headers(self):
+        self.response_headers.append(("__end__", ""))
+
+
+def _json_body(handler):
+    return json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+def test_chat_start_materializes_cron_session_before_reply(monkeypatch, tmp_path):
+    """Cron sessions shown from state.db must be replyable, not treated as stale."""
+    sid = "cron_job123_20260615_101544"
+    materialized = SimpleNamespace(
+        session_id=sid,
+        title="Daily cron output",
+        workspace=str(tmp_path),
+        model="gpt-5.4",
+        model_provider=None,
+        profile="default",
+        messages=[{"role": "user", "content": "cron prompt"}],
+        context_messages=[],
+        pending_user_message=None,
+    )
+    captured = {}
+
+    def fail_get_session(_sid):
+        raise KeyError(_sid)
+
+    def materialize(_sid):
+        captured["materialize_sid"] = _sid
+        return materialized
+
+    def start_run(session, **kwargs):
+        captured["session"] = session
+        captured["kwargs"] = kwargs
+        return {"stream_id": "stream-3975", "session_id": session.session_id}
+
+    monkeypatch.setattr(routes, "get_session", fail_get_session)
+    monkeypatch.setattr(routes, "_get_or_materialize_session", materialize)
+    monkeypatch.setattr(routes, "_resolve_chat_workspace_with_recovery", lambda _s, _w: str(tmp_path))
+    monkeypatch.setattr(routes, "_read_profile_model_config", lambda _s, _provider: (None, None))
+    monkeypatch.setattr(
+        routes,
+        "_resolve_compatible_session_model_state",
+        lambda *_args, **_kwargs: ("gpt-5.4", None, "gpt-5.4"),
+    )
+    monkeypatch.setattr(routes, "_start_run", start_run)
+
+    handler = _FakeHandler()
+    routes._handle_chat_start(
+        handler,
+        {
+            "session_id": sid,
+            "message": "follow up on the cron output",
+            "workspace": str(tmp_path),
+            "profile": "default",
+        },
+    )
+
+    assert handler.status == 200
+    assert _json_body(handler)["stream_id"] == "stream-3975"
+    assert captured["materialize_sid"] == sid
+    assert captured["session"] is materialized
+    assert captured["kwargs"]["route"] == "/api/chat/start"


### PR DESCRIPTION
## Summary
Fixes replies from cron job sessions shown in the WebUI. Those sessions could be opened from state.db, but chat start treated them as missing and the frontend reset to the start page.

## What changed
- Route `/api/chat/start` now uses the existing materializing session resolver.
- Read-only imported sessions return 403 instead of being handled like deleted sessions.
- Added regression coverage for replying to a materializable cron session.

## Testing
- `uv run --with pytest --with pyyaml --with cryptography pytest -q tests/test_issue3975_cron_reply_materialization.py tests/test_issue3994_materialize_session.py tests/test_issue3585_cron_session_overflow.py`
- `uv run --with ruff python scripts/ruff_lint.py --diff origin/master`
- `python3 -m py_compile api/routes.py tests/test_issue3975_cron_reply_materialization.py`

Closes #3975
