### PR TITLE
Fix TUI session sidebar discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **TUI-origin Hermes Agent sessions now stay discoverable in the CLI/agent sidebar view.** State-db rows with `source='tui'` are normalized as CLI-like rows, legacy browser payloads also treat raw `tui` as CLI-like for destructive-action gating, and TUI continuation chains display the latest tip title instead of an older parent title. (#3986, #3988, #3418)
+
 ## [v0.51.422] — 2026-06-14 — Release OI (optional Todos tab in workspace panel, #3564)
 
 ### Added

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -31,6 +31,7 @@ SOURCE_LABELS = {
     'slack': 'Slack',
     'telegram': 'Telegram',
     'tool': 'Tool',
+    'tui': 'TUI',
     'webui': 'WebUI',
     'weixin': 'Weixin',
 }
@@ -47,7 +48,7 @@ def normalize_agent_session_source(raw_source: str | None) -> dict:
 
     if raw == 'webui':
         session_source = 'webui'
-    elif raw == 'cli':
+    elif raw in {'cli', 'tui'}:
         session_source = 'cli'
     elif raw in MESSAGING_SOURCES:
         session_source = 'messaging'
@@ -176,7 +177,12 @@ def is_cli_session_row(row: dict) -> bool:
         return False
     if source == "cli":
         return True
-    if source_tag == "cli" or raw_source == "cli" or source_name == "cli" or source_label == "cli":
+    if (
+        source_tag in {"cli", "tui"}
+        or raw_source in {"cli", "tui"}
+        or source_name in {"cli", "tui"}
+        or source_label in {"cli", "tui"}
+    ):
         return True
 
     # Legacy imported CLI rows may only be marked as CLI in sidebar metadata.
@@ -201,6 +207,14 @@ def is_cli_session_row_visible(row: dict) -> bool:
     message_count = _as_positive_int(row.get("actual_message_count") or row.get("message_count"))
     if message_count <= 0:
         return False
+
+    if "tui" in {
+        _normalize_source_name(row.get("source")),
+        _normalize_source_name(row.get("source_tag")),
+        _normalize_source_name(row.get("raw_source")),
+        _normalize_source_name(row.get("source_label")),
+    }:
+        return True
 
     if _has_cli_lineage(row):
         return True
@@ -375,10 +389,20 @@ def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
         ):
             if key in tip:
                 merged[key] = tip[key]
-        if not merged.get('title'):
-            merged['title'] = tip.get('title')
-        if not merged.get('source'):
-            merged['source'] = tip.get('source')
+        if str(tip.get('source') or '').strip().lower() == 'tui':
+            # TUI continuation rows are user-visible session segments (#6, #17,
+            # ...), not opaque compression snapshots. Keep navigation pointed at
+            # the latest tip and show that tip's title so the newest conversation
+            # can be found by its visible TUI name.
+            if tip.get('title'):
+                merged['title'] = tip.get('title')
+            if tip.get('source'):
+                merged['source'] = tip.get('source')
+        else:
+            if not merged.get('title'):
+                merged['title'] = tip.get('title')
+            if not merged.get('source'):
+                merged['source'] = tip.get('source')
         merged['_lineage_root_id'] = row['id']
         merged['_lineage_tip_id'] = tip['id']
         merged['_compression_segment_count'] = segment_count

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1418,7 +1418,7 @@ function _isCliSession(session) {
     || session.source_label
     || ''
   ).toLowerCase();
-  if (raw === 'cli') return true;
+  if (raw === 'cli' || raw === 'tui') return true;
   // If messaging-like, don't classify as legacy CLI even when is_cli_session is true.
   if (_isMessagingSession(session)) return false;
   return session.is_cli_session === true;

--- a/tests/test_1466_sidebar_cancel_clarify.py
+++ b/tests/test_1466_sidebar_cancel_clarify.py
@@ -71,6 +71,7 @@ class TestSidebarCancelAction:
         assert "session.source" in body
         assert "session.source_label" in body
         assert "if (_isMessagingSession(session)) return false;" in body
+        assert "raw === 'tui'" in body
         assert "return session.is_cli_session === true;" in body
 
     def test_cli_sessions_hide_duplicate_and_delete_in_action_menu(self):

--- a/tests/test_issue2351_cli_session_source_filter.py
+++ b/tests/test_issue2351_cli_session_source_filter.py
@@ -125,3 +125,74 @@ def test_real_cli_sidebar_cli_flag_is_preserved_before_frontend_response():
     )
 
     assert normalized["is_cli_session"] is True
+
+
+def test_tui_state_db_rows_are_cli_sidebar_rows():
+    """Hermes TUI state.db rows belong in the CLI/agent sidebar bucket.
+
+    TUI sessions are projected from state.db with raw/source_tag='tui'. If they
+    stay session_source='other' and is_cli_session=false, the two-tab sidebar
+    partition can make active TUI continuations disappear from both the WebUI
+    and CLI views.
+    """
+    from api.agent_sessions import is_cli_session_row, normalize_agent_session_source
+    from api.routes import _normalize_sidebar_source_flags
+
+    normalized_source = normalize_agent_session_source("tui")
+    assert normalized_source["session_source"] == "cli"
+    assert normalized_source["source_label"] == "TUI"
+
+    tui_row = {
+        "session_id": "tui-tip",
+        "title": "Podcast work #17",
+        "source_tag": "tui",
+        "raw_source": "tui",
+        "session_source": "other",
+        "source_label": "Tui",
+        "message_count": 281,
+    }
+
+    assert is_cli_session_row(tui_row) is True
+    assert _normalize_sidebar_source_flags(tui_row)["is_cli_session"] is True
+
+
+def test_tui_continuation_projection_uses_latest_tip_title():
+    """TUI continuation rows should surface under the latest segment title."""
+    from api.agent_sessions import _project_agent_session_rows
+
+    rows = [
+        {
+            "id": "tui_parent",
+            "source": "tui",
+            "title": "Podcast work #6",
+            "started_at": 100.0,
+            "last_activity": 150.0,
+            "message_count": 10,
+            "actual_message_count": 10,
+            "actual_user_message_count": 5,
+            "parent_session_id": None,
+            "ended_at": 199.0,
+            "end_reason": "cli_close",
+        },
+        {
+            "id": "tui_tip",
+            "source": "tui",
+            "title": "Podcast work #17",
+            "started_at": 200.0,
+            "last_activity": 250.0,
+            "message_count": 8,
+            "actual_message_count": 8,
+            "actual_user_message_count": 4,
+            "parent_session_id": "tui_parent",
+            "ended_at": None,
+            "end_reason": None,
+        },
+    ]
+
+    projected = _project_agent_session_rows(rows)
+
+    assert len(projected) == 1
+    assert projected[0]["id"] == "tui_tip"
+    assert projected[0]["title"] == "Podcast work #17"
+    assert projected[0]["_lineage_root_id"] == "tui_parent"
+    assert projected[0]["_lineage_tip_id"] == "tui_tip"


### PR DESCRIPTION
## Summary
- normalize Hermes Agent `source='tui'` rows as CLI-like sidebar rows with a `TUI` label
- keep non-empty TUI rows visible even when their title is the generic `TUI Session`
- display the latest TUI continuation tip title in collapsed sidebar rows instead of an older parent title
- treat legacy browser payloads with raw `tui` source as CLI-like for external-session action gating

## Problem
WebUI projects Hermes Agent `state.db` sessions into the sidebar. Sessions created or continued from TUI/Desktop-like surfaces can arrive with `source='tui'` and parent/child continuation metadata. Before this change those rows could be treated as `other` rather than CLI/agent sessions, hidden by generic CLI-title visibility rules, or displayed with an older parent title after continuation collapse. The result is that an active TUI conversation can appear to disappear from the WebUI sidebar even though the session is still present in `state.db`.

## Fix
This keeps the existing storage/projection model, but hardens the source contract for TUI-origin rows:

- `normalize_agent_session_source('tui')` returns `session_source='cli'`, `raw_source='tui'`, `source_label='TUI'`
- `is_cli_session_row()` recognizes `tui` in raw/source/source_label fields
- `is_cli_session_row_visible()` preserves non-empty TUI rows instead of applying the generic untitled-CLI threshold
- collapsed TUI continuation rows keep navigation pointed at the latest tip and use that tip's visible title
- `_isCliSession()` recognizes legacy raw `tui` browser payloads

## What this does not do
- does not migrate WebUI JSON sidecars to `state.db`
- does not implement bidirectional title sync
- does not change Desktop/TUI runtime behavior
- does not change the default sidebar source filter setting
- does not delete, archive, or rewrite existing session data

## Related issues
Related to #3986, #3988, and #3418. This is a narrow discoverability/projection hardening slice; #498 and #1925 remain the broader storage/runtime direction.

## Tests
- `python -m pytest -q tests/test_issue2351_cli_session_source_filter.py tests/test_1466_sidebar_cancel_clarify.py tests/test_issue3586_cli_session_source_label.py tests/test_issue3930_source_filter_pushdown.py tests/test_gateway_sync.py::test_compression_projection_handles_deep_lineage_iteratively tests/test_gateway_sync.py::test_compression_chain_with_empty_latest_tip_falls_back_to_latest_importable_segment`
- `git diff --check`
