### PR TITLE
Fix imported lineage sidebar discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Session sidebar discoverability now preserves multi-row imported/CLI lineages when a fuller pre-compression snapshot exists.** The sidebar may still expose the fuller snapshot, but it no longer suppresses multiple messageful non-snapshot rows from the same imported/CLI lineage as if they were a single inactive continuation. (#498, #3418)
+
 ## [v0.51.424] — 2026-06-15 — Release OK (visible-message tail pagination, #4069)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -2702,6 +2702,13 @@ def _prefer_fuller_snapshots_for_sidebar(sessions: list[dict]) -> list[dict]:
         if newest_visible_ts > snapshot_ts:
             continue
 
+        messageful_visible = [
+            session for session in visible
+            if _sidebar_message_count(session) > 0
+        ]
+        if len(messageful_visible) > 1:
+            continue
+
         continuation_ids_to_hide.update(
             str(session.get('session_id'))
             for session in visible

--- a/tests/test_session_discoverability_invariants.py
+++ b/tests/test_session_discoverability_invariants.py
@@ -60,3 +60,54 @@ def test_intentional_background_sessions_are_not_rescued_into_sidebar():
     )
 
     assert result == []
+
+
+def _lineage_row(session_id, *, root="lineage", count=1, ts=1.0, snapshot=False, source="cli"):
+    return {
+        "session_id": session_id,
+        "title": session_id,
+        "source_tag": source,
+        "session_source": source,
+        "_lineage_root_id": root,
+        "message_count": count,
+        "user_message_count": 1 if count else 0,
+        "last_message_at": ts,
+        "updated_at": ts,
+        "pre_compression_snapshot": snapshot,
+    }
+
+
+def test_fuller_snapshot_does_not_hide_multirow_imported_cli_lineage():
+    """Multiple messageful imported/CLI rows in one lineage are user-facing segments."""
+    from api.models import _prefer_fuller_snapshots_for_sidebar
+
+    rows = [
+        _lineage_row("imported-a", count=3, ts=100.0),
+        _lineage_row("imported-b", count=4, ts=200.0),
+        _lineage_row("snapshot", count=20, ts=300.0, snapshot=True),
+    ]
+
+    result = _prefer_fuller_snapshots_for_sidebar(rows)
+
+    assert [row["session_id"] for row in result] == [
+        "imported-a",
+        "imported-b",
+        "snapshot",
+    ]
+    snapshot = next(row for row in result if row["session_id"] == "snapshot")
+    assert snapshot["_show_pre_compression_snapshot"] is True
+
+
+def test_fuller_snapshot_still_replaces_single_inactive_continuation():
+    """The existing single-continuation cleanup stays intact."""
+    from api.models import _prefer_fuller_snapshots_for_sidebar
+
+    rows = [
+        _lineage_row("continuation", count=3, ts=100.0, source="webui"),
+        _lineage_row("snapshot", count=20, ts=300.0, snapshot=True, source="webui"),
+    ]
+
+    result = _prefer_fuller_snapshots_for_sidebar(rows)
+
+    assert [row["session_id"] for row in result] == ["snapshot"]
+    assert result[0]["_show_pre_compression_snapshot"] is True


### PR DESCRIPTION
## Summary
- Preserve multiple messageful imported/CLI non-snapshot rows that share a lineage with a fuller pre-compression snapshot.
- Still expose the fuller snapshot when it has the larger transcript.
- Keep the existing single inactive-continuation replacement behavior intact.

## Related issues
- Related to #498 unified/session-storage discoverability context.
- Related to #3418 sidebar source/filtering UX context.
- Adjacent to #3988 CLI session discoverability defaults, but this PR is specifically about backend lineage suppression.

## What this does not do
- Does not rewrite unified storage.
- Does not change CLI/TUI source classification; #4213 covers TUI-origin sidebar classification separately.
- Does not delete, migrate, or rewrite existing sessions.
- Does not include any private transcript/session content.

## Test plan
- `python -m pytest -q tests/test_session_discoverability_invariants.py::test_fuller_snapshot_does_not_hide_multirow_imported_cli_lineage` (RED before fix)
- `python -m pytest -q tests/test_session_discoverability_invariants.py tests/test_session_index.py tests/test_session_sidebar_cache.py tests/test_issue3238_orphaned_cli_sidecar_prune.py tests/test_issue3586_cli_session_source_label.py`
- `git diff --check`
- non-ASCII added-line guard -> `non_ascii_added_lines=0`
