### PR TITLE
Release OL: empty-pending session-save guard (#4205) + cron-reply fix (#3975)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## [Unreleased]
 
+## [v0.51.425] — 2026-06-15 — Release OL (data-integrity batch: empty-pending guard #4205 + cron-reply fix #3975)
+
+### Fixed
+
+- **A session save can no longer wipe an in-flight conversation to empty.** `Session.save()` now guards against overwriting a session that has on-disk messages with an empty message list while a turn is still in flight (an active stream or a pending user message), preventing a rare data-loss window where a transient empty save clobbered the real transcript. New/legitimately-empty sessions and cancel paths are unaffected. (#4205)
+- **Replying to cron (and other foreign-origin) sessions now works instead of redirecting to the start page.** The chat-send handler now materializes a missing WebUI sidecar from state.db via the shared `_get_or_materialize_session` helper (the same path four sibling handlers already use) and returns a clean 403 on a genuine read-only/messaging-session write, so replies to cron-run sessions send correctly. (#3975)
+
 ## [v0.51.424] — 2026-06-15 — Release OK (visible-message tail pagination, #4069)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -787,6 +787,20 @@ class Session:
                 except (json.JSONDecodeError, ValueError):
                     existing_msg_count = -1  # corrupt → always back up
                 incoming_msg_count = len(self.messages or [])
+                if (
+                    existing_msg_count > 0
+                    and incoming_msg_count == 0
+                    and (self.active_stream_id or self.pending_user_message)
+                ):
+                    logger.warning(
+                        "refusing to overwrite session %s messages with empty active/pending snapshot "
+                        "(existing=%s, incoming=%s, stream=%s)",
+                        self.session_id,
+                        existing_msg_count,
+                        incoming_msg_count,
+                        self.active_stream_id,
+                    )
+                    return
                 if existing_msg_count > incoming_msg_count:
                     bak_path = self.path.with_suffix('.json.bak')
                     # SHOULD-FIX #2 (Opus): atomic write via tmp+replace,

--- a/api/routes.py
+++ b/api/routes.py
@@ -13760,9 +13760,11 @@ def _handle_chat_start(handler, body, diag=None):
             return bad(handler, str(e))
         diag.stage("get_session") if diag else None
         try:
-            s = get_session(body["session_id"])
+            s = _get_or_materialize_session(body["session_id"])
         except KeyError:
             return bad(handler, "Session not found", 404)
+        except PermissionError:
+            return bad(handler, "Read-only imported sessions cannot be continued from WebUI", 403)
         diag.stage("validate_profile") if diag else None
         requested_profile = str(body.get("profile") or "").strip()
         if requested_profile:

--- a/tests/test_issue3975_cron_reply_materialization.py
+++ b/tests/test_issue3975_cron_reply_materialization.py
@@ -1,0 +1,85 @@
+"""Regression coverage for replying to cron-origin sessions (#3975)."""
+
+import io
+import json
+from types import SimpleNamespace
+
+import api.routes as routes
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.status = None
+        self.headers = {}
+        self.response_headers = []
+        self.wfile = io.BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.response_headers.append((key, value))
+
+    def end_headers(self):
+        self.response_headers.append(("__end__", ""))
+
+
+def _json_body(handler):
+    return json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+def test_chat_start_materializes_cron_session_before_reply(monkeypatch, tmp_path):
+    """Cron sessions shown from state.db must be replyable, not treated as stale."""
+    sid = "cron_job123_20260615_101544"
+    materialized = SimpleNamespace(
+        session_id=sid,
+        title="Daily cron output",
+        workspace=str(tmp_path),
+        model="gpt-5.4",
+        model_provider=None,
+        profile="default",
+        messages=[{"role": "user", "content": "cron prompt"}],
+        context_messages=[],
+        pending_user_message=None,
+    )
+    captured = {}
+
+    def fail_get_session(_sid):
+        raise KeyError(_sid)
+
+    def materialize(_sid):
+        captured["materialize_sid"] = _sid
+        return materialized
+
+    def start_run(session, **kwargs):
+        captured["session"] = session
+        captured["kwargs"] = kwargs
+        return {"stream_id": "stream-3975", "session_id": session.session_id}
+
+    monkeypatch.setattr(routes, "get_session", fail_get_session)
+    monkeypatch.setattr(routes, "_get_or_materialize_session", materialize)
+    monkeypatch.setattr(routes, "_resolve_chat_workspace_with_recovery", lambda _s, _w: str(tmp_path))
+    monkeypatch.setattr(routes, "_read_profile_model_config", lambda _s, _provider: (None, None))
+    monkeypatch.setattr(
+        routes,
+        "_resolve_compatible_session_model_state",
+        lambda *_args, **_kwargs: ("gpt-5.4", None, "gpt-5.4"),
+    )
+    monkeypatch.setattr(routes, "_start_run", start_run)
+
+    handler = _FakeHandler()
+    routes._handle_chat_start(
+        handler,
+        {
+            "session_id": sid,
+            "message": "follow up on the cron output",
+            "workspace": str(tmp_path),
+            "profile": "default",
+        },
+    )
+
+    assert handler.status == 200
+    assert _json_body(handler)["stream_id"] == "stream-3975"
+    assert captured["materialize_sid"] == sid
+    assert captured["session"] is materialized
+    assert captured["kwargs"]["route"] == "/api/chat/start"

--- a/tests/test_session_save_empty_pending_guard.py
+++ b/tests/test_session_save_empty_pending_guard.py
@@ -1,0 +1,44 @@
+"""Regression coverage for empty active/pending session save writebacks."""
+
+import json
+
+import api.config as config
+import api.models as models
+from api.models import Session
+
+
+def test_empty_active_pending_save_cannot_overwrite_existing_messages(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(config, "SESSION_INDEX_FILE", index_file, raising=False)
+    models.SESSIONS.clear()
+
+    sid = "pending_overwrite_guard"
+    existing = Session(
+        session_id=sid,
+        messages=[
+            {"role": "user", "content": "prompt"},
+            {"role": "assistant", "content": "answer"},
+        ],
+    )
+    existing.save()
+
+    stale = Session(
+        session_id=sid,
+        messages=[],
+        active_stream_id="stale-stream",
+        pending_user_message="prompt",
+        pending_started_at=123.0,
+    )
+    stale.save()
+
+    persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+    assert [m["content"] for m in persisted["messages"]] == ["prompt", "answer"]
+    assert persisted["message_count"] == 2
+
+    index = json.loads(index_file.read_text(encoding="utf-8"))
+    indexed = next(row for row in index if row["session_id"] == sid)
+    assert indexed["message_count"] == 2


### PR DESCRIPTION
## Release OL — data-integrity batch (#4205 + #3975)

Two independent clean fix-class PRs, batched into one low-risk release. Both
warm-up-reviewed CLEAN, then passed the full canonical gate (Codex SAFE + Opus
SAFE net-positive + full suite 9027 passed, ruff clean).

### #4205 (@ai-ag2026) — block empty active pending session overwrite
`Session.save()` now early-returns (skipping the file write + index update) when
the session has on-disk messages but the incoming list is empty AND a turn is
still in flight (`active_stream_id` or `pending_user_message`). Closes a rare
data-loss window where a transient empty save clobbered the real transcript.
Verified: no false-positive on new/legitimately-empty/cancelled sessions, no
write-path bypass (all save call sites route through the guard). New test
fails-on-master / passes-on-PR.

### #3975 (@TomBanksAU, via #4211) — fix replies to cron sessions
The chat-send handler now materializes a missing WebUI sidecar from state.db via
the shared `_get_or_materialize_session` helper (the path 4 sibling handlers
already use) and returns a clean 403 on a genuine read-only/messaging write. Root
-cause fix for "replying to a cron-run session redirects to the start page."
Security boundary intact — cron is writable, messaging sources stay 403-gated; no
foreign-write fork introduced. Handles all foreign-origin replies (cron + CLI/TUI).

Note: #4211 is the preferred minimal fix for #3975 over the larger CONFLICTING
#4153 (which can be closed/superseded — flagged separately).

Co-authored-by: ai-ag2026 <ai-ag2026@users.noreply.github.com>
Co-authored-by: TomBanksAU <246584738+TomBanksAU@users.noreply.github.com>
