### PR TITLE
fix(#3988): default show_cli_sessions to true

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -6505,7 +6505,7 @@ _SETTINGS_DEFAULTS = {
     "hide_empty_state_suggestions": False,  # hide the default new-chat suggestion buttons
     "show_tps": False,  # show tokens-per-second chip in assistant message headers
     "fade_text_effect": False,  # animate newly streamed words with a lightweight fade-in effect
-    "show_cli_sessions": False,  # merge CLI sessions from state.db into the sidebar
+    "show_cli_sessions": True,  # merge CLI sessions (TUI/Telegram/Discord/Hermes One/etc.) into the sidebar by default (#3988)
     "show_cron_sessions": False,  # surface cron sessions in the sidebar (subordinate to show_cli_sessions)
     "show_previous_messaging_sessions": False,  # show older Telegram/Discord/etc. reset segments
     "sync_to_insights": False,  # mirror WebUI token usage to state.db for /insights

--- a/static/boot.js
+++ b/static/boot.js
@@ -1848,7 +1848,7 @@ function applyBotName(){
     applyEmptyStateSuggestionPref();
     window._showTps=!!s.show_tps;
     window._fadeTextEffect=!!s.fade_text_effect;
-    window._showCliSessions=!!s.show_cli_sessions;
+    window._showCliSessions=s.show_cli_sessions!==false;
     window._showPreviousMessagingSessions=!!s.show_previous_messaging_sessions;
     window._soundEnabled=!!s.sound_enabled;
     window._notificationsEnabled=!!s.notifications_enabled;

--- a/static/panels.js
+++ b/static/panels.js
@@ -6773,7 +6773,7 @@ async function loadSettingsPanel(){
     const apiRedactCb=$('settingsApiRedact');
     if(apiRedactCb){apiRedactCb.checked=settings.api_redact_enabled!==false;apiRedactCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
     const showCliCb=$('settingsShowCliSessions');
-    if(showCliCb){showCliCb.checked=!!settings.show_cli_sessions;showCliCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
+    if(showCliCb){showCliCb.checked=settings.show_cli_sessions!==false;showCliCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
     const showCronCb=$('settingsShowCronSessions');
     if(showCronCb){
       showCronCb.checked=!!settings.show_cron_sessions;

--- a/tests/test_issue3988_show_cli_sessions_default.py
+++ b/tests/test_issue3988_show_cli_sessions_default.py
@@ -1,0 +1,63 @@
+"""Pin the show_cli_sessions setting's default + hydration consistency (#3988).
+
+show_cli_sessions defaults to True so that sessions from the TUI, Telegram,
+Discord, CLI, and the Hermes One desktop app appear in the WebUI sidebar
+without users having to discover the toggle in Settings (which was the source
+of the surprise described in #3988).
+
+This test pins the True default in every place the setting is read so a
+future edit can't silently flip it back, or — worse — default it ON in
+config.py while hydrating it OFF in the browser (the classic default-mismatch
+bug from #4006, where an existing user with no saved value sees the feature
+as disabled).
+"""
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _read(rel):
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_show_cli_sessions_default_is_true_in_config():
+    src = _read("api/config.py")
+    assert re.search(r'["\']show_cli_sessions["\']\s*:\s*True', src), (
+        "show_cli_sessions must default to True in _SETTINGS_DEFAULTS — "
+        "CLI/TUI/messaging sessions visible by default (#3988)"
+    )
+
+
+def test_show_cli_sessions_in_bool_keys():
+    src = _read("api/config.py")
+    m = re.search(r"_SETTINGS_BOOL_KEYS\s*=\s*\{([^}]+)\}", src, re.DOTALL)
+    assert m, "_SETTINGS_BOOL_KEYS not found"
+    assert "show_cli_sessions" in m.group(1), (
+        "show_cli_sessions must be in _SETTINGS_BOOL_KEYS so it round-trips as a bool"
+    )
+
+
+def test_boot_hydration_defaults_true_when_setting_absent():
+    """boot.js must hydrate _showCliSessions as True when the saved settings
+    omit the key — `!!s.show_cli_sessions` would wrongly default it OFF for
+    every existing user, contradicting the config.py default."""
+    src = _read("static/boot.js")
+    # Default-true read (=== false), not the truthy-coerce form.
+    assert "window._showCliSessions=s.show_cli_sessions!==false" in src, (
+        "boot.js must default _showCliSessions True when the saved value is absent"
+    )
+    assert "window._showCliSessions=!!s.show_cli_sessions" not in src, (
+        "boot.js must not use !!s.show_cli_sessions — that defaults the True "
+        "setting OFF for users with no saved value"
+    )
+
+
+def test_settings_checkbox_renders_checked_by_default():
+    """The Settings checkbox must render checked when the setting is absent,
+    matching the True default (panels.js settings-load)."""
+    src = _read("static/panels.js")
+    assert "showCliCb.checked=settings.show_cli_sessions!==false" in src, (
+        "the show-CLI-sessions checkbox must default checked (=== false), not "
+        "!!settings.show_cli_sessions which would render it unchecked by default"
+    )


### PR DESCRIPTION
Closes #3988.

Flips the `show_cli_sessions` default from `False` to `True` so that sessions from the TUI, Telegram, Discord, CLI, and the Hermes One desktop app appear in the WebUI sidebar without users having to discover the toggle in Settings.

Three load-bearing spots had to change in lockstep, because the issue body's "one-line change" runs into the same default-mismatch trap as #4006: an existing user with no saved value would still see the feature OFF in the browser even after the config default flips.

- `api/config.py` — `_SETTINGS_DEFAULTS['show_cli_sessions'] = True`
- `static/boot.js` — hydrate as `s.show_cli_sessions !== false` instead of `!!s.show_cli_sessions` so an absent saved value defaults True
- `static/panels.js` — Settings checkbox renders checked when the setting is absent, matching the new default

`tests/test_issue3988_show_cli_sessions_default.py` pins all three spots, modeled directly on `tests/test_issue4006_auto_scroll_follow_default.py` since the failure mode is identical.

Verified `pytest tests/test_gateway_sync.py tests/test_session_sidebar_cache.py` (65 tests, all pass) — those exercise the toggle through explicit True/False POSTs, so only the absent-value default actually changes here. Larger filter redesigns in #3418 / #3403 / #3122 still land cleanly on a True default per the issue body.