### PR TITLE
feat(#4159): jump to matched message + flash on session-search content hit

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -10143,10 +10143,14 @@ def _handle_sessions_search(handler, parsed):
             try:
                 sess = get_session(s["session_id"])
                 msgs = sess.messages[:depth] if depth else sess.messages
-                for m in msgs:
+                for raw_idx, m in enumerate(msgs):
                     c = _session_search_message_text(m)
                     if q in str(c).lower():
-                        item = dict(s, match_type="content")
+                        # #4159: surface the matched message index so the frontend
+                        # can jump to it (msg-user-<rawIdx>). The renderer stamps
+                        # rows with the same raw index it gets from sess.messages,
+                        # so this enumerate lines up with the DOM ids.
+                        item = dict(s, match_type="content", match_message_idx=raw_idx)
                         preview = _session_search_preview(c, q)
                         if preview:
                             item["match_preview"] = _redact_text(preview)

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -6283,6 +6283,15 @@ function renderSessionListFromCache(){
         try{
           if(($('sessionSearch').value||'').trim()) _hideSearchPreviewsAfterSelect=true;
           await loadSession(s.session_id);renderSessionListFromCache();
+          // #4159: if the user clicked a content-search hit, scroll the
+          // newly-loaded transcript to the matched message and flash it.
+          // _jumpToMessage handles the out-of-render-window case (it refetches
+          // the full session with msg_limit=9999) and the in-window case
+          // (smooth scrollIntoView + flash).
+          if(s.match_type==='content' && Number.isInteger(s.match_message_idx) && typeof _jumpToMessage==='function'){
+            const _jumpIdx=s.match_message_idx;
+            window.setTimeout(()=>{ try{ _jumpToMessage(_jumpIdx); }catch(_e){} }, 0);
+          }
           if(typeof closeMobileSidebar==='function')closeMobileSidebar();
         }finally{
           el.classList.remove('loading');

--- a/tests/test_issue4159_search_match_message_idx.py
+++ b/tests/test_issue4159_search_match_message_idx.py
@@ -1,0 +1,101 @@
+"""Backend regression for #4159: content-search results must surface the
+matched message index so the frontend can jump straight to the hit.
+
+The content scan in ``_handle_sessions_search`` already locates the exact
+message that contains the query (it iterates ``sess.messages`` and ``break``s
+on the first hit). Until now the loop index was discarded; this test pins the
+new ``match_message_idx`` field on content-typed results, indexed against the
+same raw ``sess.messages`` array the renderer stamps onto each row as
+``data-msg-idx`` / ``msg-user-<rawIdx>``.
+
+Title matches must NOT carry ``match_message_idx`` (there's no message-level
+hit to jump to).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+
+def _run_search(query, *, session_messages, sessions_meta=None):
+    import api.routes as routes
+
+    meta = sessions_meta or [
+        {"session_id": "s1", "title": "Untitled", "profile": "default"}
+    ]
+    session = SimpleNamespace(session_id="s1", messages=session_messages)
+    captured = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        captured["payload"] = payload
+
+    with patch("api.routes.all_sessions", return_value=list(meta)), patch(
+        "api.routes.get_session", return_value=session
+    ), patch("api.profiles.get_active_profile_name", return_value="default"), patch(
+        "api.routes.j", side_effect=fake_j
+    ):
+        routes._handle_sessions_search(SimpleNamespace(), urlparse(query))
+    return captured
+
+
+def test_content_match_includes_message_index():
+    """A content hit must carry match_message_idx pointing at the raw index
+    inside sess.messages (so msg-user-<rawIdx> resolves on the client)."""
+    msgs = [
+        {"role": "user", "content": "first message"},
+        {"role": "assistant", "content": "second message — no hit"},
+        {"role": "user", "content": "NEEDLE in the third message"},
+        {"role": "assistant", "content": "fourth message"},
+    ]
+    captured = _run_search(
+        "/api/sessions/search?q=needle&content=1&depth=10",
+        session_messages=msgs,
+    )
+    assert captured["status"] == 200
+    results = captured["payload"]["sessions"]
+    assert len(results) == 1
+    hit = results[0]
+    assert hit["match_type"] == "content"
+    assert hit["match_message_idx"] == 2, (
+        "match_message_idx must be the raw enumerate index into sess.messages "
+        "(0-based); the renderer stamps the same index onto msg-user-<rawIdx>"
+    )
+
+
+def test_content_match_returns_first_hit_index_not_last():
+    """The scan break()s on the first hit (preserving existing behavior); the
+    returned idx must reflect that first hit, not a later occurrence."""
+    msgs = [
+        {"role": "user", "content": "alpha NEEDLE first"},
+        {"role": "user", "content": "beta NEEDLE second"},
+    ]
+    captured = _run_search(
+        "/api/sessions/search?q=needle&content=1&depth=10",
+        session_messages=msgs,
+    )
+    assert captured["payload"]["sessions"][0]["match_message_idx"] == 0
+
+
+def test_title_match_does_not_include_message_index():
+    """Title matches short-circuit before the content scan, so they must not
+    grow a match_message_idx field (nothing to jump to)."""
+    meta = [{"session_id": "s1", "title": "needle in the title", "profile": "default"}]
+    captured = _run_search(
+        "/api/sessions/search?q=needle&content=1",
+        session_messages=[{"role": "user", "content": "no hit here"}],
+        sessions_meta=meta,
+    )
+    hit = captured["payload"]["sessions"][0]
+    assert hit["match_type"] == "title"
+    assert "match_message_idx" not in hit
+
+
+def test_no_match_returns_empty_results():
+    captured = _run_search(
+        "/api/sessions/search?q=needle&content=1",
+        session_messages=[{"role": "user", "content": "no hit here"}],
+    )
+    assert captured["payload"]["count"] == 0


### PR DESCRIPTION
Closes #4159.

Implements the design the maintainer outlined in the issue thread — capture the matched-message index on the server, reuse the existing `_jumpToMessage` helper on click.

### Backend (`api/routes.py`)
`_handle_sessions_search` already locates the exact matching message during the content scan (it `break`s on the first hit) — until now the loop index was discarded. This adds `match_message_idx` on content-type results, captured from `enumerate(msgs)`. Title matches do **not** grow the field (nothing to jump to). The index is into `sess.messages`, which is the same array the renderer enumerates to stamp `msg-user-<rawIdx>` ids on user rows and `data-msg-idx` on assistant segments, so the DOM lookup on the client resolves.

### Frontend (`static/sessions.js`)
After `loadSession()` in the sidebar-row click handler, if the session carries `match_type==='content'` and an integer `match_message_idx`, call `_jumpToMessage(idx)` on the next tick.

Reuses `outline.js:94 _jumpToMessage` unchanged — it already handles both the in-window case (smooth `scrollIntoView` + `_flashRow`) and the out-of-window case (re-fetch `/api/session?...&messages=1&msg_limit=9999`, expand the render window, then retry). The dispatch is purely additive: a missing idx falls back to opening the session at the latest message, exactly as today, so this is backward compatible with older servers.

### Tests
`tests/test_issue4159_search_match_message_idx.py` (4 tests) pins:
- content match surfaces `match_message_idx` at the right raw enumerate index;
- the first-hit index is returned (preserves the existing `break()` semantics);
- title matches do **not** include the field;
- no-match case returns empty results, unchanged.

Full search test suite still green: 28 passed across `test_issue4159_*`, `test_sessions_search_depth_validation`, `test_sessions_search_profile_scope`, `test_session_search_bfcache_822`, `test_sidebar_search_highlights`.