### PR TITLE
fix(#4217): guard /api/file/delete and /api/file/rename against symlink targets

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -14725,6 +14725,8 @@ def _handle_file_delete(handler, body):
         target = safe_resolve(ws_root, body["path"])
         if not target.exists():
             return bad(handler, "File not found", 404)
+        if (ws_root / body["path"]).is_symlink():
+            return bad(handler, "Cannot delete a symlinked entry")
         if target.is_dir():
             if not body.get("recursive"):
                 return bad(handler, "Set recursive=true to delete directories")
@@ -14805,6 +14807,8 @@ def _handle_file_rename(handler, body):
         source = safe_resolve(ws_root, body["path"])
         if not source.exists():
             return bad(handler, "File not found", 404)
+        if (ws_root / body["path"]).is_symlink():
+            return bad(handler, "Cannot rename a symlinked entry")
         new_name = body["new_name"].strip()
         if not new_name or "/" in new_name or "\\" in new_name or ".." in new_name:
             return bad(handler, "Invalid file name")

--- a/tests/test_workspace_symlink_delete_rename.py
+++ b/tests/test_workspace_symlink_delete_rename.py
@@ -1,0 +1,206 @@
+"""Regression tests for #4217 — symlink guards on /api/file/delete and /api/file/rename."""
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import api.routes as routes
+
+
+@pytest.fixture()
+def workspace(tmp_path):
+    """Yield a real temporary workspace directory and clean up after."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    yield ws
+
+
+class _FakeHandler:
+    pass
+
+
+def _patch_routes(ws):
+    """Monkey-patch routes helpers so handlers run without an HTTP server."""
+
+    class _S:
+        workspace = str(ws)
+
+    cap = {}
+    orig_j = routes.j
+    orig_bad = routes.bad
+    orig_get = routes.get_session_for_file_ops
+    routes.j = lambda h, o: (cap.__setitem__("ok", o), True)[1]
+    routes.bad = lambda h, m, c=400: (cap.__setitem__("bad", (m, c)), True)[1]
+    routes.get_session_for_file_ops = lambda sid: _S()
+    return cap, (orig_j, orig_bad, orig_get)
+
+
+def _restore_routes(originals):
+    routes.j, routes.bad, routes.get_session_for_file_ops = originals
+
+
+# ── DELETE symlink guards ────────────────────────────────────────────────
+
+def test_delete_workspace_symlink_to_dir_rejected(workspace):
+    real_dir = workspace / "real_dir"
+    real_dir.mkdir()
+    link = workspace / "link_to_dir"
+    try:
+        os.symlink(str(real_dir), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap, orig = _patch_routes(workspace)
+    try:
+        routes._handle_file_delete(
+            _FakeHandler(),
+            {"session_id": "x", "path": "link_to_dir", "recursive": True},
+        )
+    finally:
+        _restore_routes(orig)
+
+    assert "bad" in cap, f"expected 400, got {cap}"
+    assert cap["bad"][1] == 400
+    assert "Cannot delete a symlinked entry" in cap["bad"][0]
+    assert real_dir.exists(), "real target directory was deleted through the symlink"
+
+
+def test_delete_workspace_symlink_to_file_rejected(workspace):
+    real_file = workspace / "real_file.txt"
+    real_file.write_text("important")
+    link = workspace / "link_to_file.txt"
+    try:
+        os.symlink(str(real_file), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap, orig = _patch_routes(workspace)
+    try:
+        routes._handle_file_delete(
+            _FakeHandler(),
+            {"session_id": "x", "path": "link_to_file.txt"},
+        )
+    finally:
+        _restore_routes(orig)
+
+    assert "bad" in cap, f"expected 400, got {cap}"
+    assert cap["bad"][1] == 400
+    assert "Cannot delete a symlinked entry" in cap["bad"][0]
+    assert real_file.exists(), "real target file was deleted through the symlink"
+
+
+# ── RENAME symlink guards ───────────────────────────────────────────────
+
+def test_rename_workspace_symlink_to_dir_rejected(workspace):
+    real_dir = workspace / "real_dir"
+    real_dir.mkdir()
+    link = workspace / "link_to_dir"
+    try:
+        os.symlink(str(real_dir), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap, orig = _patch_routes(workspace)
+    try:
+        routes._handle_file_rename(
+            _FakeHandler(),
+            {"session_id": "x", "path": "link_to_dir", "new_name": "renamed"},
+        )
+    finally:
+        _restore_routes(orig)
+
+    assert "bad" in cap, f"expected 400, got {cap}"
+    assert cap["bad"][1] == 400
+    assert "Cannot rename a symlinked entry" in cap["bad"][0]
+
+
+def test_rename_workspace_symlink_to_file_rejected(workspace):
+    real_file = workspace / "real_file.txt"
+    real_file.write_text("important")
+    link = workspace / "link_to_file.txt"
+    try:
+        os.symlink(str(real_file), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap, orig = _patch_routes(workspace)
+    try:
+        routes._handle_file_rename(
+            _FakeHandler(),
+            {"session_id": "x", "path": "link_to_file.txt", "new_name": "renamed.txt"},
+        )
+    finally:
+        _restore_routes(orig)
+
+    assert "bad" in cap, f"expected 400, got {cap}"
+    assert cap["bad"][1] == 400
+    assert "Cannot rename a symlinked entry" in cap["bad"][0]
+
+
+# ── Non-symlink operations still work ───────────────────────────────────
+
+def test_delete_real_dir_still_works(workspace):
+    real_dir = workspace / "deleteme"
+    real_dir.mkdir()
+    (real_dir / "child.txt").write_text("x")
+
+    cap, orig = _patch_routes(workspace)
+    try:
+        routes._handle_file_delete(
+            _FakeHandler(),
+            {"session_id": "x", "path": "deleteme", "recursive": True},
+        )
+    finally:
+        _restore_routes(orig)
+
+    assert "ok" in cap, f"expected success, got {cap}"
+    assert cap["ok"]["ok"] is True
+    assert not real_dir.exists()
+
+
+def test_rename_real_file_still_works(workspace):
+    real_file = workspace / "old_name.txt"
+    real_file.write_text("content")
+
+    cap, orig = _patch_routes(workspace)
+    try:
+        routes._handle_file_rename(
+            _FakeHandler(),
+            {"session_id": "x", "path": "old_name.txt", "new_name": "new_name.txt"},
+        )
+    finally:
+        _restore_routes(orig)
+
+    assert "ok" in cap, f"expected success, got {cap}"
+    assert cap["ok"]["ok"] is True
+    assert not real_file.exists()
+    assert (workspace / "new_name.txt").exists()
+
+
+# ── Existing move guard pinned ──────────────────────────────────────────
+
+def test_move_workspace_symlink_still_rejected(workspace):
+    real_file = workspace / "real.txt"
+    real_file.write_text("data")
+    dest = workspace / "dest"
+    dest.mkdir()
+    link = workspace / "link.txt"
+    try:
+        os.symlink(str(real_file), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap, orig = _patch_routes(workspace)
+    try:
+        routes._handle_file_move(
+            _FakeHandler(),
+            {"session_id": "x", "path": "link.txt", "dest_dir": "dest"},
+        )
+    finally:
+        _restore_routes(orig)
+
+    assert "bad" in cap, f"expected 400, got {cap}"
+    assert cap["bad"][1] == 400
+    assert "Cannot move a symlinked entry" in cap["bad"][0]


### PR DESCRIPTION
## Thinking Path

- `/api/file/delete` and `/api/file/rename` call `safe_resolve()`, which follows the final symlink via `.resolve()`; both handlers then operate on the real target, so deleting a workspace symlink deletes the pointed-to directory or file.
- The move handler already has the correct pattern: check `(ws_root / body["path"]).is_symlink()` on the lexically-requested path (lstat, no-follow) before any destructive op, and return a 400.
- Added the same two-line guard to both handlers immediately after the `exists()` 404 check, matching the move handler's wording and placement exactly.

## What Changed

- `api/routes.py`: added `(ws_root / body["path"]).is_symlink()` guard in `_handle_file_delete` (after the 404 check, before the `is_dir()` branch) and in `_handle_file_rename` (after the 404 check, before `new_name` extraction).
- `tests/test_workspace_symlink_delete_rename.py`: new file with 7 regression tests covering symlink-to-dir and symlink-to-file rejection for both handlers, real file/dir ops still working, and the existing move guard pinned.

## Why It Matters

Without the guard, any user who can create a workspace symlink can silently destroy files outside their intended scope by issuing a standard delete or rename API call against the symlink name; the fix brings delete and rename into parity with the already-hardened move handler.

## Verification

```
pytest tests/test_workspace_symlink_delete_rename.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- Broken (dangling) symlinks already 404 today because `target.exists()` returns False; this PR does not change that behavior. Allowing explicit cleanup of broken links is a follow-up if desired.
- The guard uses `is_symlink()` on the lexically-joined path, not the resolved path, so it correctly detects in-workspace symlinks regardless of whether the workspace root itself is a symlink (e.g., macOS `/tmp -> /private/tmp`).

## Model Used

Claude Opus 4.6 via Claude Code CLI