### PR TITLE
fix(server): make request logging non-fatal so a closed stdout can't abort a response (#4188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.431] — 2026-06-15 — Release OR (make request logging non-fatal)
+
+### Fixed
+
+- **A closed or redirected stdout/stderr stream can no longer abort an HTTP response before it's sent.** Request/access logging and request-error logging now route through a small guarded print helper, so if agent or tool code redirects or closes the process-wide output streams in another thread, the log write is swallowed instead of raising mid-response. Real handler errors are unaffected — the error message and traceback are still built and still surface a 500; only the log I/O is guarded, and `KeyboardInterrupt`/`SystemExit` still propagate. (#4188)
+
 ## [v0.51.430] — 2026-06-15 — Release OQ (session-list-changed events carry the changed session id)
 
 ### Changed

--- a/server.py
+++ b/server.py
@@ -273,6 +273,17 @@ class Handler(BaseHTTPRequestHandler):
 
     def log_message(self, fmt, *args): pass  # suppress default Apache-style log
 
+    @staticmethod
+    def _safe_webui_print(message: str) -> None:
+        """Emit a request log line without letting logging break responses."""
+        try:
+            print(message, flush=True)
+        except Exception:
+            # Agent/tool code can redirect or close process-wide stdout/stderr
+            # in another thread. HTTP response handling must not depend on
+            # those global streams remaining writable.
+            pass
+
     def log_request(self, code: str='-', size: str='-') -> None:
         """Structured JSON logs for each request."""
         import json as _json
@@ -299,7 +310,7 @@ class Handler(BaseHTTPRequestHandler):
         if forwarded_for:
             record_data['forwarded_for'] = forwarded_for
         record = _json.dumps(record_data)
-        print(f'[webui] {record}', flush=True)
+        self._safe_webui_print(f'[webui] {record}')
 
     def do_GET(self) -> None:
         self._req_t0 = time.time()
@@ -319,7 +330,7 @@ class Handler(BaseHTTPRequestHandler):
             # reconnect races; do not convert it into a misleading server 500.
             return
         except Exception:
-            print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc(), flush=True)
+            self._safe_webui_print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc())
             try:
                 j(self, {'error': 'Internal server error'}, status=500)
             except _CLIENT_DISCONNECT_ERRORS:
@@ -328,7 +339,7 @@ class Handler(BaseHTTPRequestHandler):
             except Exception:
                 # Unexpected failure while sending the error response itself.
                 # Log it so we know something is wrong with our error handler.
-                traceback.print_exc()
+                self._safe_webui_print(traceback.format_exc())
         finally:
             clear_request_profile()
 
@@ -358,7 +369,7 @@ class Handler(BaseHTTPRequestHandler):
             # reconnect races; do not convert it into a misleading server 500.
             return
         except Exception:
-            print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc(), flush=True)
+            self._safe_webui_print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc())
             try:
                 j(self, {'error': 'Internal server error'}, status=500)
             except _CLIENT_DISCONNECT_ERRORS:
@@ -367,7 +378,7 @@ class Handler(BaseHTTPRequestHandler):
             except Exception:
                 # Unexpected failure while sending the error response itself.
                 # Log it so we know something is wrong with our error handler.
-                traceback.print_exc()
+                self._safe_webui_print(traceback.format_exc())
         finally:
             clear_request_profile()
 

--- a/tests/test_broken_pipe_cascade.py
+++ b/tests/test_broken_pipe_cascade.py
@@ -10,6 +10,7 @@ The fix:
 - helpers._safe_write() catches _CLIENT_DISCONNECT_ERRORS (including ssl.SSLError)
 - server.py exception handlers wrap their 500-response j() calls in try/except
 """
+import io
 import ssl
 import unittest
 from unittest.mock import MagicMock
@@ -255,6 +256,52 @@ class TestServerDisconnectHandling(unittest.TestCase):
             _server_mod.check_auth = orig_check_auth
 
         handler.send_response.assert_not_called()
+
+    def test_log_request_ignores_closed_stdout(self):
+        """A poisoned stdout stream must not break send_response()."""
+        from server import Handler
+        handler = Handler.__new__(Handler)
+        handler.command = "GET"
+        handler.path = "/health"
+        handler._req_t0 = 0.0
+        handler.headers = {}
+        handler.client_address = ("127.0.0.1", 12345)
+
+        closed_stdout = io.StringIO()
+        closed_stdout.close()
+        original_stdout = sys.stdout
+        sys.stdout = closed_stdout
+        try:
+            Handler.log_request(handler, 200)
+        finally:
+            sys.stdout = original_stdout
+
+    def test_do_get_sends_500_when_stdout_closed(self):
+        """Route errors should still produce a 500 if stdout was closed."""
+        from server import Handler
+        handler = self._make_handler(route_raises=ValueError("real bug"))
+
+        def _fake_handle_get(self, parsed):
+            raise self._route_raises
+
+        import server as _server_mod
+        orig_handle_get = _server_mod.handle_get
+        orig_check_auth = _server_mod.check_auth
+        _server_mod.handle_get = _fake_handle_get
+        _server_mod.check_auth = lambda h, p: True
+
+        closed_stdout = io.StringIO()
+        closed_stdout.close()
+        original_stdout = sys.stdout
+        sys.stdout = closed_stdout
+        try:
+            Handler.do_GET(handler)
+        finally:
+            sys.stdout = original_stdout
+            _server_mod.handle_get = orig_handle_get
+            _server_mod.check_auth = orig_check_auth
+
+        handler.send_response.assert_called_once_with(500)
 
     def test_do_get_sends_500_on_real_error(self):
         from server import Handler


### PR DESCRIPTION
## Release OR (#4188 — make request logging non-fatal)

Maintainer ship-pass of @mintymac's #4188, rebased onto current master.

### What it fixes
A closed or redirected process-wide stdout/stderr stream (e.g. agent or tool code redirecting output in another thread) could raise inside `Handler.log_request()` / request-error logging and abort an HTTP response before its headers were sent. Logging now routes through a small guarded helper `_safe_webui_print` (a single `print(..., flush=True)` wrapped in `try/except Exception: pass`), so the log write is swallowed instead of breaking the response.

Real handler errors are unaffected: the error message and `traceback.format_exc()` are built *before* the guarded print, so they still surface a 500 through the surrounding handler. `except Exception` (not `BaseException`) means `KeyboardInterrupt` / `SystemExit` still propagate, and the success-path `[webui] {...}` JSON access line is byte-identical.

### Review / gate (full canonical gate)
- **Codex: SAFE TO SHIP** · **Opus: SAFE TO SHIP** — both verified empirically: only log I/O is swallowed (handler errors still 500), Ctrl+C/shutdown still propagate, success log unchanged, and the 2 new tests genuinely fail on master (`ValueError: I/O operation on closed file` at the exact replaced `print()`) and pass on the PR.
- **Full suite: 9060 passed, 0 failed**; ruff clean.

Co-authored-by: mintymac <mintymac@users.noreply.github.com>
