### PR TITLE
fix(file): reject symlink saves

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -14824,6 +14824,8 @@ def _handle_file_save(handler, body):
     try:
         ws_root = Path(s.workspace)
         target = safe_resolve(ws_root, body["path"])
+        if (ws_root / body["path"]).is_symlink():
+            return bad(handler, "Cannot save to a symlinked entry")
         if not target.exists():
             return bad(handler, "File not found", 404)
         if target.is_dir():

--- a/tests/test_workspace_symlink_delete_rename.py
+++ b/tests/test_workspace_symlink_delete_rename.py
@@ -138,6 +138,51 @@ def test_rename_workspace_symlink_to_file_rejected(workspace):
 
 # ── Non-symlink operations still work ───────────────────────────────────
 
+def test_save_workspace_symlink_to_file_rejected(workspace):
+    real_file = workspace / "real_file.txt"
+    real_file.write_text("important")
+    link = workspace / "link_to_file.txt"
+    try:
+        os.symlink(str(real_file), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap, orig = _patch_routes(workspace)
+    try:
+        routes._handle_file_save(
+            _FakeHandler(),
+            {"session_id": "x", "path": "link_to_file.txt", "content": "changed"},
+        )
+    finally:
+        _restore_routes(orig)
+
+    assert "bad" in cap, f"expected 400, got {cap}"
+    assert cap["bad"][1] == 400
+    assert "Cannot save to a symlinked entry" in cap["bad"][0]
+    assert real_file.read_text() == "important"
+
+
+def test_save_dangling_symlink_rejected_not_404(workspace):
+    link = workspace / "dangling_save"
+    try:
+        os.symlink(str(workspace / "gone_target"), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap, orig = _patch_routes(workspace)
+    try:
+        routes._handle_file_save(
+            _FakeHandler(),
+            {"session_id": "x", "path": "dangling_save", "content": "changed"},
+        )
+    finally:
+        _restore_routes(orig)
+
+    assert "bad" in cap, f"expected 400, got {cap}"
+    assert cap["bad"][1] == 400
+    assert "Cannot save to a symlinked entry" in cap["bad"][0]
+
+
 def test_delete_real_dir_still_works(workspace):
     real_dir = workspace / "deleteme"
     real_dir.mkdir()
@@ -177,6 +222,25 @@ def test_rename_real_file_still_works(workspace):
 
 
 # ── Existing move guard pinned ──────────────────────────────────────────
+
+def test_save_real_file_still_works(workspace):
+    real_file = workspace / "save_me.txt"
+    real_file.write_text("old")
+
+    cap, orig = _patch_routes(workspace)
+    try:
+        routes._handle_file_save(
+            _FakeHandler(),
+            {"session_id": "x", "path": "save_me.txt", "content": "new"},
+        )
+    finally:
+        _restore_routes(orig)
+
+    assert "ok" in cap, f"expected success, got {cap}"
+    assert cap["ok"]["ok"] is True
+    assert cap["ok"]["size"] == len("new")
+    assert real_file.read_text() == "new"
+
 
 def test_move_workspace_symlink_still_rejected(workspace):
     real_file = workspace / "real.txt"


### PR DESCRIPTION
## Thinking Path
- Issue #4234 identifies `/api/file/save` as the remaining sibling of the symlink delete/rename/move guard from #4217.
- I checked the current open security/path/symlink PR and issue set before editing. I found no open PR covering this exact save path.
- The narrow fix is to reject the lexically requested workspace entry when it is a symlink before the save path writes through the resolved target.

## What Changed
- Reject `/api/file/save` requests whose requested workspace path is a symlinked entry.
- Add regression coverage for saving through a symlink, dangling symlink ordering, and ordinary real-file saves.

## Why It Matters
- `safe_resolve()` follows the final symlink. Without this guard, saving `link.txt` can overwrite the linked in-workspace target instead of rejecting the symlink entry consistently with delete, rename, and move.
- The guard keeps the file mutation contract uniform across workspace write operations.

## Verification
- `py -3.12 -m py_compile api\routes.py`
- `git diff --check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 HERMES_WEBUI_PYTHON=C:\Users\downl\AppData\Local\Programs\Python\Python312\python.exe HERMES_HOME=%TEMP%\hermes-webui-pr1-home py -3.12 -m pytest tests/test_workspace_symlink_delete_rename.py -q`
  - Windows local result: 3 passed, 9 skipped. The symlink-specific cases skip because this shell lacks Windows symlink privilege; Linux CI should exercise them.

## Risks / Follow-ups
- This intentionally does not change read/raw behavior or broader workspace symlink policy.
- It preserves existing behavior for ordinary file saves.

## Model Used
- GPT-5 Codex