### PR TITLE
fix(skills): reject symlinked skill saves

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -16600,6 +16600,8 @@ def _handle_skill_save(handler, body):
         return bad(handler, "Invalid skill path")
     skill_dir.mkdir(parents=True, exist_ok=True)
     skill_file = skill_dir / "SKILL.md"
+    if skill_file.is_symlink():
+        return bad(handler, "Cannot save to a symlinked skill file")
     skill_file.write_text(body["content"], encoding="utf-8")
     return j(handler, {"ok": True, "name": skill_name, "path": str(skill_file)})
 

--- a/tests/test_skill_save_symlink_guard.py
+++ b/tests/test_skill_save_symlink_guard.py
@@ -1,0 +1,60 @@
+import os
+
+import pytest
+
+import api.routes as routes
+
+
+class _FakeHandler:
+    pass
+
+
+def _patch_skill_routes(monkeypatch, skills_dir):
+    cap = {}
+    monkeypatch.setattr(routes, "_active_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr(routes, "j", lambda h, o: (cap.__setitem__("ok", o), True)[1])
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda h, m, c=400: (cap.__setitem__("bad", (m, c)), True)[1],
+    )
+    return cap
+
+
+def test_skill_save_rejects_symlinked_skill_file(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "demo"
+    skill_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.md"
+    outside.write_text("important", encoding="utf-8")
+    link = skill_dir / "SKILL.md"
+    try:
+        os.symlink(str(outside), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap = _patch_skill_routes(monkeypatch, skills_dir)
+    routes._handle_skill_save(
+        _FakeHandler(),
+        {"name": "demo", "content": "changed"},
+    )
+
+    assert "bad" in cap, f"expected 400, got {cap}"
+    assert cap["bad"][1] == 400
+    assert "Cannot save to a symlinked skill file" in cap["bad"][0]
+    assert outside.read_text(encoding="utf-8") == "important"
+
+
+def test_skill_save_real_file_still_works(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+
+    cap = _patch_skill_routes(monkeypatch, skills_dir)
+    routes._handle_skill_save(
+        _FakeHandler(),
+        {"name": "Demo Skill", "content": "# Demo\n"},
+    )
+
+    skill_file = skills_dir / "demo-skill" / "SKILL.md"
+    assert "ok" in cap, f"expected success, got {cap}"
+    assert cap["ok"]["ok"] is True
+    assert skill_file.read_text(encoding="utf-8") == "# Demo\n"


### PR DESCRIPTION
## Thinking Path
- I reviewed the open PR/issue set for skill save/path/symlink/SKILL.md work before editing.
- Existing skill PRs are feature/UI oriented or profile management work; I did not find a PR that guards the `/api/skills/save` final `SKILL.md` write against symlinked files.
- The narrow risk is write-through when an existing `SKILL.md` inside the active skills directory is a symlink.

## What Changed
- Reject `/api/skills/save` when the target `SKILL.md` is a symlinked file.
- Add focused regression coverage for a symlinked `SKILL.md` and a normal skill save.

## Why It Matters
- The handler validates the resolved skill directory, then writes `SKILL.md` directly. If that final file is a symlink, saving a skill can overwrite the linked target.
- This keeps profile skill editing bounded to an actual skill file rather than following an attacker-prepared link.

## Verification
- `py -3.12 -m py_compile api\routes.py`
- `git diff --check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 HERMES_WEBUI_PYTHON=C:\Users\downl\AppData\Local\Programs\Python\Python312\python.exe HERMES_HOME=%TEMP%\hermes-webui-pr2-home py -3.12 -m pytest tests/test_skill_save_symlink_guard.py -q`
  - Windows local result: 1 passed, 1 skipped. The symlink-specific case skips because this shell lacks Windows symlink privilege; Linux CI should exercise it.

## Risks / Follow-ups
- This does not alter skill name/category validation or external skill discovery.
- Ordinary skill creation and update remain unchanged.

## Model Used
- GPT-5 Codex