### PR TITLE
fix(memory): reject symlinked memory writes

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -16715,16 +16715,23 @@ def _handle_memory_write(handler, body):
     except ImportError:
         home = Path.home() / ".hermes"
         mem_dir = home / "memories"
-    mem_dir.mkdir(parents=True, exist_ok=True)
     section = body["section"]
     if section == "memory":
+        if mem_dir.is_symlink():
+            return bad(handler, "Cannot write through a symlinked memories directory")
+        mem_dir.mkdir(parents=True, exist_ok=True)
         target = mem_dir / "MEMORY.md"
     elif section == "user":
+        if mem_dir.is_symlink():
+            return bad(handler, "Cannot write through a symlinked memories directory")
+        mem_dir.mkdir(parents=True, exist_ok=True)
         target = mem_dir / "USER.md"
     elif section == "soul":
         target = home / "SOUL.md"
     else:
         return bad(handler, 'section must be "memory", "user", or "soul"')
+    if target.is_symlink():
+        return bad(handler, "Cannot write to a symlinked memory file")
     target.write_text(body["content"], encoding="utf-8")
     return j(handler, {"ok": True, "section": section, "path": str(target)})
 

--- a/tests/test_memory_write_symlink_guard.py
+++ b/tests/test_memory_write_symlink_guard.py
@@ -1,0 +1,85 @@
+import os
+
+import pytest
+
+import api.profiles as profiles
+import api.routes as routes
+
+
+class _FakeHandler:
+    pass
+
+
+def _patch_memory_routes(monkeypatch, home):
+    cap = {}
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: home)
+    monkeypatch.setattr(routes, "j", lambda h, o: (cap.__setitem__("ok", o), True)[1])
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda h, m, c=400: (cap.__setitem__("bad", (m, c)), True)[1],
+    )
+    return cap
+
+
+def test_memory_write_rejects_symlinked_memory_file(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    mem_dir = home / "memories"
+    mem_dir.mkdir(parents=True)
+    outside = tmp_path / "outside-memory.md"
+    outside.write_text("important", encoding="utf-8")
+    link = mem_dir / "MEMORY.md"
+    try:
+        os.symlink(str(outside), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap = _patch_memory_routes(monkeypatch, home)
+    routes._handle_memory_write(
+        _FakeHandler(),
+        {"section": "memory", "content": "changed"},
+    )
+
+    assert "bad" in cap, f"expected 400, got {cap}"
+    assert cap["bad"][1] == 400
+    assert "Cannot write to a symlinked memory file" in cap["bad"][0]
+    assert outside.read_text(encoding="utf-8") == "important"
+
+
+def test_memory_write_rejects_symlinked_memories_directory(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    outside_dir = tmp_path / "outside-memories"
+    outside_dir.mkdir()
+    link = home / "memories"
+    try:
+        os.symlink(str(outside_dir), str(link), target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap = _patch_memory_routes(monkeypatch, home)
+    routes._handle_memory_write(
+        _FakeHandler(),
+        {"section": "user", "content": "changed"},
+    )
+
+    assert "bad" in cap, f"expected 400, got {cap}"
+    assert cap["bad"][1] == 400
+    assert "Cannot write through a symlinked memories directory" in cap["bad"][0]
+    assert not (outside_dir / "USER.md").exists()
+
+
+def test_memory_write_real_file_still_works(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+
+    cap = _patch_memory_routes(monkeypatch, home)
+    routes._handle_memory_write(
+        _FakeHandler(),
+        {"section": "memory", "content": "# Memory\n"},
+    )
+
+    target = home / "memories" / "MEMORY.md"
+    assert "ok" in cap, f"expected success, got {cap}"
+    assert cap["ok"]["ok"] is True
+    assert cap["ok"]["section"] == "memory"
+    assert target.read_text(encoding="utf-8") == "# Memory\n"


### PR DESCRIPTION
## Thinking Path
- I reviewed current open PRs/issues for memory write, MEMORY.md, SOUL.md, and symlink-related work before editing.
- Existing memory issues cover wrong-profile writes and broader memory features, but I did not find a PR guarding the final memory files or `memories/` directory against symlink write-through.
- The narrow fix is to refuse writes when the target persistent memory surface is a symlink.

## What Changed
- Reject `/api/memory/write` for `memory` and `user` sections when the `memories/` directory is itself a symlink.
- Reject writes when the final `MEMORY.md`, `USER.md`, or `SOUL.md` target is a symlink.
- Add regression coverage for a symlinked memory file, a symlinked memories directory, and a normal memory write.

## Why It Matters
- `/api/memory/write` is a persistent profile data write. If a local attacker or previous unsafe state prepares a symlinked memory path, the WebUI can overwrite the linked target.
- Refusing symlinked memory surfaces keeps the endpoint bound to real profile memory files.

## Verification
- `py -3.12 -m py_compile api\routes.py`
- `git diff --check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 HERMES_WEBUI_PYTHON=C:\Users\downl\AppData\Local\Programs\Python\Python312\python.exe HERMES_HOME=%TEMP%\hermes-webui-pr3-home py -3.12 -m pytest tests/test_memory_write_symlink_guard.py -q`
  - Windows local result: 1 passed, 2 skipped. The symlink-specific cases skip because this shell lacks Windows symlink privilege; Linux CI should exercise them.

## Risks / Follow-ups
- This intentionally does not change profile selection or memory redaction behavior.
- Ordinary memory writes continue to create/update real files as before.

## Model Used
- GPT-5 Codex