### PR TITLE
Add AI/ML API onboarding preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **AI/ML API is now available as an onboarding provider preset.** Users can configure it with `AIMLAPI_API_KEY`, use the OpenAI-compatible `https://api.aimlapi.com/v1` endpoint, and pick from a curated starter catalog of chat-capable models. (#4243)
+
 ### Internal
 
 - **Windows pytest-harness compatibility (#3664).** Hardened the test suite to run on Windows: profile-home fallback paths are path-normalized, strict POSIX file-mode (`0o600`) assertions are gated behind `os.name != "nt"` (Linux still asserts them at full strictness), the conftest cleanup handles Windows process-tree/port teardown and the Py3.12+ `shutil.rmtree` `onexc` shim, and tests that require `fork`/`fcntl` carry `@requires_fork` / `@requires_fcntl` markers (which never skip on Linux). Test-only — no runtime or app behavior change, no Linux CI behavior change. (#4254, #4255, #4256, #4257, #4259, #4263, #4266, #4274)

--- a/api/config.py
+++ b/api/config.py
@@ -1285,6 +1285,7 @@ _PROVIDER_MODELS = {
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
         {"id": "gpt-5.4",      "label": "GPT-5.4"},
     ],
+    # Curated chat-capable AIML API subset for the initial offline picker.
     "aimlapi": [
         {"id": "gpt-4o-mini", "label": "GPT-4o mini"},
         {"id": "gpt-4o", "label": "GPT-4o"},

--- a/api/config.py
+++ b/api/config.py
@@ -873,6 +873,7 @@ _PROVIDER_DISPLAY = {
     "openrouter": "OpenRouter",
     "anthropic": "Anthropic",
     "openai": "OpenAI",
+    "aimlapi": "AI/ML API",
     "openai-api": "OpenAI API",
     "openai-codex": "OpenAI Codex",
     "xai-oauth": "xAI Grok OAuth",
@@ -1283,6 +1284,26 @@ _PROVIDER_MODELS = {
         {"id": "gpt-5.5-mini", "label": "GPT-5.5 Mini"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
         {"id": "gpt-5.4",      "label": "GPT-5.4"},
+    ],
+    "aimlapi": [
+        {"id": "gpt-4o-mini", "label": "GPT-4o mini"},
+        {"id": "gpt-4o", "label": "GPT-4o"},
+        {"id": "gpt-5-chat", "label": "GPT-5 Chat"},
+        {"id": "gpt-5", "label": "GPT-5"},
+        {"id": "gpt-5-mini", "label": "GPT-5 mini"},
+        {"id": "gpt-5-nano", "label": "GPT-5 nano"},
+        {"id": "gpt-5.1-chat-latest", "label": "GPT-5.1 Chat latest"},
+        {"id": "gpt-5.2-chat-latest", "label": "GPT-5.2 Chat latest"},
+        {"id": "claude-sonnet-4-5-20250929", "label": "Claude Sonnet 4.5"},
+        {"id": "claude-sonnet-4-6", "label": "Claude Sonnet 4.6"},
+        {"id": "gemini-3-flash-preview", "label": "Gemini 3 Flash Preview"},
+        {"id": "gemini-2.5-pro", "label": "Gemini 2.5 Pro"},
+        {"id": "deepseek-chat", "label": "DeepSeek Chat"},
+        {"id": "deepseek-reasoner", "label": "DeepSeek Reasoner"},
+        {"id": "x-ai/grok-4-07-09", "label": "Grok 4"},
+        {"id": "qwen3.5-flash", "label": "Qwen3.5 Flash"},
+        {"id": "qwen3-coder-480b-a35b-instruct", "label": "Qwen3 Coder"},
+        {"id": "meta-llama/Llama-3.3-70B-Instruct-Turbo", "label": "Llama 3.3 70B Instruct Turbo"},
     ],
     "openai-api": [
         {"id": "gpt-5.5",      "label": "GPT-5.5"},
@@ -2175,7 +2196,7 @@ def resolve_model_provider(model_id: str) -> tuple:
         # fired in the prefix==config_provider case, causing HTTP 404 from the
         # portal which requires the full provider/model id (#2177; sibling of
         # #854 / #894 for Nous, where this guard was originally added).
-        _PORTAL_PROVIDERS = {"nous", "opencode-zen", "opencode-go", "nvidia"}
+        _PORTAL_PROVIDERS = {"nous", "opencode-zen", "opencode-go", "nvidia", "aimlapi"}
         if config_provider in _PORTAL_PROVIDERS:
             return model_id, config_provider, config_base_url
         # If prefix matches config provider exactly, strip it and use that provider directly.
@@ -5048,6 +5069,7 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
             for k in (
                 "ANTHROPIC_API_KEY",
                 "OPENAI_API_KEY",
+                "AIMLAPI_API_KEY",
                 "OPENROUTER_API_KEY",
                 "GOOGLE_API_KEY",
                 "GEMINI_API_KEY",
@@ -5082,6 +5104,8 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
                 # picker without a manual config.yaml edit. Users without Codex OAuth will see
                 # picker entries but hit auth errors at inference time (#1189 known limitation).
                 detected_providers.add("openai-codex")
+            if all_env.get("AIMLAPI_API_KEY"):
+                detected_providers.add("aimlapi")
             if all_env.get("OPENROUTER_API_KEY"):
                 detected_providers.add("openrouter")
             if all_env.get("GOOGLE_API_KEY"):

--- a/api/onboarding.py
+++ b/api/onboarding.py
@@ -65,6 +65,15 @@ _SUPPORTED_PROVIDER_SETUPS = {
         "models": list(_PROVIDER_MODELS.get("openai", [])),
         "category": "easy_start",
     },
+    "aimlapi": {
+        "label": "AI/ML API",
+        "env_var": "AIMLAPI_API_KEY",
+        "default_model": "gpt-5-chat",
+        "default_base_url": "https://api.aimlapi.com/v1",
+        "requires_base_url": False,
+        "models": list(_PROVIDER_MODELS.get("aimlapi", [])),
+        "category": "easy_start",
+    },
     # ── Open / self-hosted ─────────────────────────────────────────────
     "ollama": {
         "label": "Ollama",

--- a/api/providers.py
+++ b/api/providers.py
@@ -688,6 +688,7 @@ _PROVIDER_ENV_VAR: dict[str, str] = {
     "openrouter": "OPENROUTER_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
     "openai": "OPENAI_API_KEY",
+    "aimlapi": "AIMLAPI_API_KEY",
     "google": "GOOGLE_API_KEY",
     "gemini": "GEMINI_API_KEY",
     "zai": "GLM_API_KEY",

--- a/api/routes.py
+++ b/api/routes.py
@@ -1293,6 +1293,7 @@ _PROVIDER_ALIASES = {
 # returns [] for a provider (#871).  Kept at module level so the dict is
 # built once, not reconstructed per request.
 _OPENAI_COMPAT_ENDPOINTS = {
+    "aimlapi": "https://api.aimlapi.com/v1",
     "zai": "https://api.z.ai/v1",
     "minimax": "https://api.minimax.chat/v1",
     "mistralai": "https://api.mistral.ai/v1",

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -263,6 +263,26 @@ def _resolve_custom_provider_runtime_overrides(
     return resolved_provider, resolved_api_key, resolved_base_url
 
 
+def _resolve_aimlapi_api_key(profile_home: str | Path | None = None) -> str | None:
+    api_key = os.getenv("AIMLAPI_API_KEY", "").strip()
+    if api_key:
+        return api_key
+    if not profile_home:
+        return None
+    try:
+        env_path = Path(profile_home) / ".env"
+        for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            if key.strip() == "AIMLAPI_API_KEY":
+                return value.strip().strip('"').strip("'") or None
+    except OSError:
+        return None
+    return None
+
+
 def _same_base_url_endpoint(url_a: str, url_b: str) -> bool:
     """True if two base URLs point at the same scheme+host+port endpoint.
 
@@ -6178,6 +6198,8 @@ def _run_agent_streaming(
             resolved_provider, resolved_api_key, resolved_base_url = _resolve_custom_provider_runtime_overrides(
                 resolved_provider, resolved_api_key, resolved_base_url
             )
+            if resolved_provider == "aimlapi" and not resolved_api_key:
+                resolved_api_key = _resolve_aimlapi_api_key(_profile_home)
 
             # Read per-profile config at call time (not module-level snapshot).
             # The streaming worker is a detached thread that does NOT inherit the

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -276,7 +276,7 @@ def _resolve_aimlapi_api_key(profile_home: str | Path | None = None) -> str | No
                     if key.strip() == "AIMLAPI_API_KEY":
                         return value.strip().strip('"').strip("'") or None
         except Exception:
-            return None
+            pass
     api_key = os.getenv("AIMLAPI_API_KEY", "").strip()
     if api_key:
         return api_key

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -264,22 +264,22 @@ def _resolve_custom_provider_runtime_overrides(
 
 
 def _resolve_aimlapi_api_key(profile_home: str | Path | None = None) -> str | None:
+    if profile_home:
+        try:
+            env_path = Path(profile_home) / ".env"
+            if env_path.is_file():
+                for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+                    line = raw_line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, value = line.split("=", 1)
+                    if key.strip() == "AIMLAPI_API_KEY":
+                        return value.strip().strip('"').strip("'") or None
+        except Exception:
+            return None
     api_key = os.getenv("AIMLAPI_API_KEY", "").strip()
     if api_key:
         return api_key
-    if not profile_home:
-        return None
-    try:
-        env_path = Path(profile_home) / ".env"
-        for raw_line in env_path.read_text(encoding="utf-8").splitlines():
-            line = raw_line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, value = line.split("=", 1)
-            if key.strip() == "AIMLAPI_API_KEY":
-                return value.strip().strip('"').strip("'") or None
-    except OSError:
-        return None
     return None
 
 

--- a/tests/test_custom_providers_in_panel.py
+++ b/tests/test_custom_providers_in_panel.py
@@ -318,3 +318,58 @@ class TestDeepSeekV4Models:
         assert ds.get("default_base_url") == "https://api.deepseek.com", (
             f"Base URL should be bare domain, got: {ds.get('default_base_url')}"
         )
+
+    def test_aimlapi_onboarding_preset_uses_curated_model_catalog(self):
+        """AI/ML API should be a named OpenAI-compatible preset with curated chat models."""
+        from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+
+        meta = _SUPPORTED_PROVIDER_SETUPS.get("aimlapi", {})
+        assert meta.get("label") == "AI/ML API"
+        assert meta.get("env_var") == "AIMLAPI_API_KEY"
+        assert meta.get("default_model") == "gpt-5-chat"
+        assert meta.get("default_base_url") == "https://api.aimlapi.com/v1"
+        assert meta.get("requires_base_url") is False
+        models = meta.get("models") or []
+        model_ids = {m.get("id") for m in models}
+        assert "gpt-5-chat" in model_ids
+        assert "gpt-4o-mini" in model_ids
+        assert "claude-sonnet-4-5-20250929" in model_ids
+        assert "gemini-3-flash-preview" in model_ids
+        assert meta.get("category") == "easy_start"
+
+    def test_aimlapi_is_registered_as_builtin_provider(self):
+        """AI/ML API must be available beyond onboarding in the shared provider catalog."""
+        from api.config import _PROVIDER_DISPLAY, _PROVIDER_MODELS
+
+        assert _PROVIDER_DISPLAY.get("aimlapi") == "AI/ML API"
+        ids = {m.get("id") for m in _PROVIDER_MODELS.get("aimlapi", [])}
+        assert "gpt-5-chat" in ids
+        assert "x-ai/grok-4-07-09" in ids
+
+    def test_aimlapi_provider_card_is_configurable(self, monkeypatch, tmp_path):
+        """Settings providers must let users manage the AIML API key."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("AIMLAPI_API_KEY", "aiml-test-key-12345678")
+
+        old_cfg, old_mtime = TestCustomProvidersInGetProviders()._setup_cfg(
+            custom_providers=[],
+            active_provider="aimlapi",
+        )
+
+        from api.providers import get_providers
+        try:
+            result = get_providers()
+            aimlapi = next(p for p in result["providers"] if p["id"] == "aimlapi")
+            assert aimlapi["display_name"] == "AI/ML API"
+            assert aimlapi["has_key"] is True
+            assert aimlapi["configurable"] is True
+            assert "gpt-5-chat" in {m["id"] for m in aimlapi["models"]}
+        finally:
+            TestCustomProvidersInGetProviders()._restore_cfg(old_cfg, old_mtime)
+
+    def test_aimlapi_has_live_models_endpoint_fallback(self):
+        """Live model enrichment should know AIML API's OpenAI-compatible root."""
+        from api.routes import _OPENAI_COMPAT_ENDPOINTS
+
+        assert _OPENAI_COMPAT_ENDPOINTS.get("aimlapi") == "https://api.aimlapi.com/v1"

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -69,6 +69,19 @@ def test_openai_prefix_stripped_for_direct_api():
     assert provider == 'openai'
 
 
+def test_aimlapi_namespaced_models_stay_on_aimlapi_endpoint():
+    """AIML API curated namespaced models are routed through its OpenAI-compatible base URL."""
+    model, provider, base_url = _resolve_with_config(
+        'x-ai/grok-4-07-09',
+        provider='aimlapi',
+        base_url='https://api.aimlapi.com/v1',
+        default='x-ai/grok-4-07-09',
+    )
+    assert model == 'x-ai/grok-4-07-09'
+    assert provider == 'aimlapi'
+    assert base_url == 'https://api.aimlapi.com/v1'
+
+
 # ── Cross-provider routing ───────────────────────────────────────────────
 
 def test_cross_provider_routes_through_openrouter():

--- a/tests/test_provider_sort_order.py
+++ b/tests/test_provider_sort_order.py
@@ -197,6 +197,25 @@ class TestModelPickerSortOrder:
         )
         _teardown_config()
 
+    def test_aimlapi_active_provider_group_uses_builtin_catalog(self, tmp_path, monkeypatch):
+        """AIML API should appear in /api/models as a first-class active provider."""
+        _setup_config(tmp_path, monkeypatch,
+            "model:\n"
+            "  provider: aimlapi\n"
+            "  default: gpt-5-chat\n"
+        )
+
+        result = config.get_available_models()
+        group_ids = [g.get("provider_id") for g in result.get("groups", [])]
+        aimlapi = next(g for g in result["groups"] if g.get("provider_id") == "aimlapi")
+        model_ids = {m.get("id") for m in aimlapi.get("models", [])}
+
+        assert group_ids[0] == "aimlapi"
+        assert aimlapi["provider"] == "AI/ML API"
+        assert "gpt-5-chat" in model_ids
+        assert "x-ai/grok-4-07-09" in model_ids
+        _teardown_config()
+
     def test_custom_groups_before_configured(self, tmp_path, monkeypatch):
         """custom:* groups sort before providers that merely have keys."""
         _setup_config(tmp_path, monkeypatch,

--- a/tests/test_sprint39.py
+++ b/tests/test_sprint39.py
@@ -177,7 +177,7 @@ class TestApplyOnboardingKeySync(unittest.TestCase):
 
             mod.apply_onboarding_setup({
                 "provider": "aimlapi",
-                "model": "openai/gpt-4o-mini",
+                "model": "gpt-5-chat",
                 "api_key": "aiml-test-key",
             })
 
@@ -185,7 +185,7 @@ class TestApplyOnboardingKeySync(unittest.TestCase):
         self.assertEqual(write_env_mock.call_args.args[1], {"AIMLAPI_API_KEY": "aiml-test-key"})
         saved_cfg = save_yaml_mock.call_args.args[1]
         self.assertEqual(saved_cfg["model"]["provider"], "aimlapi")
-        self.assertEqual(saved_cfg["model"]["default"], "openai/gpt-4o-mini")
+        self.assertEqual(saved_cfg["model"]["default"], "gpt-5-chat")
         self.assertEqual(saved_cfg["model"]["base_url"], "https://api.aimlapi.com/v1")
         self.assertEqual(os.environ.get("AIMLAPI_API_KEY"), "aiml-test-key")
         os.environ.pop("AIMLAPI_API_KEY", None)
@@ -264,6 +264,19 @@ class TestApplyOnboardingSkipGuard(unittest.TestCase):
             })
 
         save_yaml_mock.assert_called_once()
+
+
+def test_aimlapi_runtime_key_fallback_reads_profile_env(tmp_path, monkeypatch):
+    """AIML API should still run when hermes-agent lacks a native aimlapi registry."""
+    monkeypatch.delenv("AIMLAPI_API_KEY", raising=False)
+    (tmp_path / ".env").write_text(
+        "AIMLAPI_API_KEY=aiml-profile-key\n",
+        encoding="utf-8",
+    )
+
+    from api.streaming import _resolve_aimlapi_api_key
+
+    assert _resolve_aimlapi_api_key(tmp_path) == "aiml-profile-key"
 
 
 if __name__ == "__main__":

--- a/tests/test_sprint39.py
+++ b/tests/test_sprint39.py
@@ -293,13 +293,13 @@ def test_aimlapi_runtime_key_prefers_profile_env(tmp_path, monkeypatch):
 
 
 def test_aimlapi_runtime_key_ignores_malformed_profile_env(tmp_path, monkeypatch):
-    """Malformed profile env files should not bubble out of the streaming path."""
+    """Malformed profile env files should not block the process env fallback."""
     monkeypatch.setenv("AIMLAPI_API_KEY", "aiml-process-key")
     (tmp_path / ".env").write_bytes(b"\xff\xfe\x00")
 
     from api.streaming import _resolve_aimlapi_api_key
 
-    assert _resolve_aimlapi_api_key(tmp_path) is None
+    assert _resolve_aimlapi_api_key(tmp_path) == "aiml-process-key"
 
 
 def test_aimlapi_runtime_key_uses_process_env_without_profile_env(tmp_path, monkeypatch):

--- a/tests/test_sprint39.py
+++ b/tests/test_sprint39.py
@@ -155,6 +155,41 @@ class TestApplyOnboardingKeySync(unittest.TestCase):
                          "OPENAI_API_KEY must be set directly on os.environ after apply")
         os.environ.pop("OPENAI_API_KEY", None)
 
+    def test_aimlapi_setup_writes_aimlapi_env_and_base_url(self):
+        """AIML API onboarding must wire its own env var and OpenAI-compatible base URL."""
+        import pathlib
+
+        os.environ.pop("AIMLAPI_API_KEY", None)
+
+        mock_cfg = {"model": {}}
+        save_yaml_mock = unittest.mock.MagicMock()
+        write_env_mock = unittest.mock.MagicMock()
+
+        with patch("api.onboarding._load_yaml_config", return_value=mock_cfg), \
+             patch("api.onboarding._save_yaml_config", save_yaml_mock), \
+             patch("api.onboarding._write_env_file", write_env_mock), \
+             patch("api.onboarding.reload_config"), \
+             patch("api.onboarding.get_onboarding_status", return_value={"completed": True}), \
+             patch("api.onboarding._get_config_path", return_value=pathlib.Path("/tmp/fake.yaml")), \
+             patch("api.onboarding._load_env_file", return_value={}), \
+             patch("api.onboarding._provider_api_key_present", return_value=False), \
+             patch("api.onboarding._get_active_hermes_home", return_value=pathlib.Path("/tmp")):
+
+            mod.apply_onboarding_setup({
+                "provider": "aimlapi",
+                "model": "openai/gpt-4o-mini",
+                "api_key": "aiml-test-key",
+            })
+
+        write_env_mock.assert_called_once()
+        self.assertEqual(write_env_mock.call_args.args[1], {"AIMLAPI_API_KEY": "aiml-test-key"})
+        saved_cfg = save_yaml_mock.call_args.args[1]
+        self.assertEqual(saved_cfg["model"]["provider"], "aimlapi")
+        self.assertEqual(saved_cfg["model"]["default"], "openai/gpt-4o-mini")
+        self.assertEqual(saved_cfg["model"]["base_url"], "https://api.aimlapi.com/v1")
+        self.assertEqual(os.environ.get("AIMLAPI_API_KEY"), "aiml-test-key")
+        os.environ.pop("AIMLAPI_API_KEY", None)
+
     def test_no_key_provided_does_not_set_environ(self):
         """If no api_key is given (key already present), os.environ is not clobbered."""
         import pathlib

--- a/tests/test_sprint39.py
+++ b/tests/test_sprint39.py
@@ -279,5 +279,37 @@ def test_aimlapi_runtime_key_fallback_reads_profile_env(tmp_path, monkeypatch):
     assert _resolve_aimlapi_api_key(tmp_path) == "aiml-profile-key"
 
 
+def test_aimlapi_runtime_key_prefers_profile_env(tmp_path, monkeypatch):
+    """The active profile key must win over a process env mirror from another profile."""
+    monkeypatch.setenv("AIMLAPI_API_KEY", "aiml-process-key")
+    (tmp_path / ".env").write_text(
+        "AIMLAPI_API_KEY=aiml-profile-key\n",
+        encoding="utf-8",
+    )
+
+    from api.streaming import _resolve_aimlapi_api_key
+
+    assert _resolve_aimlapi_api_key(tmp_path) == "aiml-profile-key"
+
+
+def test_aimlapi_runtime_key_ignores_malformed_profile_env(tmp_path, monkeypatch):
+    """Malformed profile env files should not bubble out of the streaming path."""
+    monkeypatch.setenv("AIMLAPI_API_KEY", "aiml-process-key")
+    (tmp_path / ".env").write_bytes(b"\xff\xfe\x00")
+
+    from api.streaming import _resolve_aimlapi_api_key
+
+    assert _resolve_aimlapi_api_key(tmp_path) is None
+
+
+def test_aimlapi_runtime_key_uses_process_env_without_profile_env(tmp_path, monkeypatch):
+    """Process env remains the fallback when the active profile has no .env file."""
+    monkeypatch.setenv("AIMLAPI_API_KEY", "aiml-process-key")
+
+    from api.streaming import _resolve_aimlapi_api_key
+
+    assert _resolve_aimlapi_api_key(tmp_path) == "aiml-process-key"
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
- Add AIML API as a named onboarding provider preset.
- Use AIMLAPI_API_KEY and https://api.aimlapi.com/v1 as the OpenAI-compatible base URL.
- Keep the preset model list empty and use the existing /models probe flow for live model discovery.

Tests:
- python -m pytest tests\test_custom_providers_in_panel.py tests\test_sprint39.py
- npm run lint:runtime
- python -m ruff check api\onboarding.py tests\test_sprint39.py
- python scripts\ruff_lint.py --diff origin/master

Closes #4045