### PR TITLE
fix(file): reject symlinked entries in /api/file/save (#4234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.433] — 2026-06-15 — Release OT (reject symlinked entries in /api/file/save, #4234)
+
+### Fixed
+
+- **Saving to a workspace symlink no longer writes through to the symlink's target.** `/api/file/save` resolved the final symlink before writing, so saving to a workspace symlink `link.txt → real.txt` overwrote `real.txt` instead of the link. It now rejects a symlinked path with a 400 (checked before the existence probe, so dangling symlinks are caught too) — completing the symlink hardening from #4217 (delete/rename/move) for the write path. `safe_resolve` already blocked out-of-workspace targets, so this closes the in-workspace overwrite-through-symlink case. (#4234)
+
 ## [v0.51.432] — 2026-06-15 — Release OS (TUI sessions discoverable in the sidebar)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -14824,6 +14824,8 @@ def _handle_file_save(handler, body):
     try:
         ws_root = Path(s.workspace)
         target = safe_resolve(ws_root, body["path"])
+        if (ws_root / body["path"]).is_symlink():
+            return bad(handler, "Cannot save to a symlinked entry")
         if not target.exists():
             return bad(handler, "File not found", 404)
         if target.is_dir():

--- a/tests/test_workspace_symlink_delete_rename.py
+++ b/tests/test_workspace_symlink_delete_rename.py
@@ -138,6 +138,51 @@ def test_rename_workspace_symlink_to_file_rejected(workspace):
 
 # ── Non-symlink operations still work ───────────────────────────────────
 
+def test_save_workspace_symlink_to_file_rejected(workspace):
+    real_file = workspace / "real_file.txt"
+    real_file.write_text("important")
+    link = workspace / "link_to_file.txt"
+    try:
+        os.symlink(str(real_file), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap, orig = _patch_routes(workspace)
+    try:
+        routes._handle_file_save(
+            _FakeHandler(),
+            {"session_id": "x", "path": "link_to_file.txt", "content": "changed"},
+        )
+    finally:
+        _restore_routes(orig)
+
+    assert "bad" in cap, f"expected 400, got {cap}"
+    assert cap["bad"][1] == 400
+    assert "Cannot save to a symlinked entry" in cap["bad"][0]
+    assert real_file.read_text() == "important"
+
+
+def test_save_dangling_symlink_rejected_not_404(workspace):
+    link = workspace / "dangling_save"
+    try:
+        os.symlink(str(workspace / "gone_target"), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap, orig = _patch_routes(workspace)
+    try:
+        routes._handle_file_save(
+            _FakeHandler(),
+            {"session_id": "x", "path": "dangling_save", "content": "changed"},
+        )
+    finally:
+        _restore_routes(orig)
+
+    assert "bad" in cap, f"expected 400, got {cap}"
+    assert cap["bad"][1] == 400
+    assert "Cannot save to a symlinked entry" in cap["bad"][0]
+
+
 def test_delete_real_dir_still_works(workspace):
     real_dir = workspace / "deleteme"
     real_dir.mkdir()
@@ -177,6 +222,25 @@ def test_rename_real_file_still_works(workspace):
 
 
 # ── Existing move guard pinned ──────────────────────────────────────────
+
+def test_save_real_file_still_works(workspace):
+    real_file = workspace / "save_me.txt"
+    real_file.write_text("old")
+
+    cap, orig = _patch_routes(workspace)
+    try:
+        routes._handle_file_save(
+            _FakeHandler(),
+            {"session_id": "x", "path": "save_me.txt", "content": "new"},
+        )
+    finally:
+        _restore_routes(orig)
+
+    assert "ok" in cap, f"expected success, got {cap}"
+    assert cap["ok"]["ok"] is True
+    assert cap["ok"]["size"] == len("new")
+    assert real_file.read_text() == "new"
+
 
 def test_move_workspace_symlink_still_rejected(workspace):
     real_file = workspace / "real.txt"


### PR DESCRIPTION
## Release OT (#4239 — reject symlinked entries in /api/file/save, closes #4234)

Maintainer ship-pass of @zapabob's #4239, which implements the fix I filed as #4234 (the `_handle_file_save` sibling of the #4217 symlink guard).

### What it fixes
`/api/file/save` resolved the final symlink before writing, so saving to a workspace symlink `link.txt → real.txt` overwrote `real.txt` instead of the link. It now rejects a symlinked path with a 400, checked **before** the existence probe (so a dangling symlink is rejected, not misclassified as 404). This completes the symlink hardening from #4217 (delete/rename/move) for the write path. `safe_resolve` already blocked out-of-workspace targets, so this closes the remaining in-workspace overwrite-through-symlink case.

```python
target = safe_resolve(ws_root, body["path"])
if (ws_root / body["path"]).is_symlink():
    return bad(handler, "Cannot save to a symlinked entry")
if not target.exists():
    return bad(handler, "File not found", 404)
```

### Review / gate (full canonical gate)
- **Codex: SAFE TO SHIP** · **Opus: SAFE TO SHIP** — both confirmed the guard is additive-only (purely rejects, real-file-save behavior unchanged), the no-follow `is_symlink()` catches live and dangling links with correct before-`exists()` ordering, `safe_resolve` out-of-workspace containment is intact, and a save to a real file inside a symlinked workspace root still works (guard is on the leaf, not the root).
- **Full suite: 9065 passed, 0 failed**; ruff clean. +64 lines of regression tests.

Closes #4234.

Co-authored-by: zapabob <zapabob@users.noreply.github.com>
