### PR TITLE
feat: credential pool fallback for custom providers + collapsible mod…

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -5245,13 +5245,27 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
                     _named_custom_groups[_slug] = (_cp_name, [])
 
                 _cp_base_url = str(_cp.get("base_url") or "").strip()
-                if _slug and _cp_base_url:
-                    _cp_api_key = str(_cp.get("api_key") or "").strip()
-                    if not _cp_api_key:
-                        _cp_key_env = str(_cp.get("key_env") or "").strip()
-                        if _cp_key_env:
-                            _cp_api_key = str(os.getenv(_cp_key_env) or "").strip()
+                _cp_api_key = str(_cp.get("api_key") or "").strip()
+                if not _cp_api_key:
+                    _cp_key_env = str(_cp.get("key_env") or "").strip()
+                    if _cp_key_env:
+                        _cp_api_key = str(os.getenv(_cp_key_env) or "").strip()
+                # Fallback: check credential pool for both api_key and base_url
+                if (not _cp_api_key or not _cp_base_url) and _slug:
+                    try:
+                        from agent.credential_pool import load_pool
+                        _pool = load_pool(_slug)
+                        if _pool and _pool.has_credentials():
+                            _entry = _pool.select()
+                            if _entry:
+                                if not _cp_api_key:
+                                    _cp_api_key = _entry.runtime_api_key
+                                if not _cp_base_url:
+                                    _cp_base_url = str(getattr(_entry, "base_url", "") or "").strip()
+                    except Exception:
+                        pass
 
+                if _slug and _cp_base_url:
                     # Check if user has configured models in config.yaml —
                     # configured models take priority over live /v1/models
                     # discovery (same as hermes-agent model_switch.py Section 4

--- a/api/providers.py
+++ b/api/providers.py
@@ -983,6 +983,13 @@ def _provider_has_key(provider_id: str) -> bool:
         env_value = os.getenv(env_var)
         if _provider_value_counts_as_api_key(provider_id, env_value):
             return True
+        try:
+           from agent.credential_pool import load_pool
+           pool = load_pool(provider_id)   # provider_id == "custom:bothub" for custom
+           if pool and pool.has_credentials():
+               return True
+        except Exception:
+           pass
         # Fall back to legacy env-var aliases (e.g. lmstudio's pre-#1500
         # LMSTUDIO_API_KEY name) so existing users don't lose detection
         # after an env-var rename.  See _PROVIDER_ENV_VAR_ALIASES.
@@ -991,7 +998,7 @@ def _provider_has_key(provider_id: str) -> bool:
                 return True
             if _provider_value_counts_as_api_key(provider_id, os.getenv(alias)):
                 return True
-
+    
     cfg = get_config()
     # Check model.api_key — only match if this provider is the active one.
     # Previously this checked globally, causing all providers to show
@@ -1068,6 +1075,18 @@ def _get_provider_api_key(provider_id: str) -> str | None:
                     return os.getenv(cp_key[2:-1], "").strip() or None
                 if _provider_value_counts_as_api_key(provider_id, cp_key):
                     return cp_key
+    # Fallback: try credential pool (e.g. bothub key stored via auth.json)
+    try:
+        from agent.credential_pool import load_pool
+        pool = load_pool(provider_id)
+        if pool and pool.has_credentials():
+            entry = pool.peek()
+            if entry:
+                key = getattr(entry, "access_token", "") or getattr(entry, "runtime_api_key", "")
+                if key:
+                    return key
+    except Exception:
+        pass
     return None
 
 
@@ -2343,6 +2362,15 @@ def get_providers() -> dict[str, Any]:
             if cp_api_key.startswith("${") and cp_api_key.endswith("}"):
                 env_var = cp_api_key[2:-1]
                 cp_has_key = bool(os.getenv(env_var, "").strip())
+            # Fallback: check credential pool (key added via hermes auth add)
+            if not cp_has_key:
+                try:
+                    from agent.credential_pool import load_pool
+                    pool = load_pool(cp_id)
+                    if pool and pool.has_credentials():
+                        cp_has_key = True
+                except Exception:
+                    pass
             providers.append({
                 "id": cp_id,
                 "display_name": cp_name,

--- a/api/routes.py
+++ b/api/routes.py
@@ -12221,6 +12221,27 @@ def _handle_live_models(handler, parsed):
                     _model_cfg = cfg.get("model", {})
                     _base_url = _model_cfg.get("base_url")
                     _api_key = _model_cfg.get("api_key")
+                # Fallback: try credential pool for base_url + api_key
+                if (not _base_url or not _api_key) and provider.startswith("custom:"):
+                    try:
+                        import sys as _lmsys
+                        import os as _lmos
+                        _lm_agent_dir = _lmos.path.join(_lmos.path.dirname(_lmos.path.dirname(_lmos.path.abspath(__file__))),
+                                                       "..", "..", ".hermes", "hermes-agent")
+                        _lm_agent_dir = _lmos.path.normpath(_lm_agent_dir)
+                        if _lm_agent_dir not in _lmsys.path:
+                            _lmsys.path.insert(0, _lm_agent_dir)
+                        from agent.credential_pool import load_pool as _lpool
+                        _lm_pool = _lpool(provider)
+                        if _lm_pool and _lm_pool.has_credentials():
+                            _lm_entry = _lm_pool.select()
+                            if _lm_entry:
+                                if not _api_key:
+                                    _api_key = _lm_entry.runtime_api_key
+                                if not _base_url:
+                                    _base_url = str(getattr(_lm_entry, "base_url", "") or "").strip()
+                    except Exception:
+                        pass
                 if _base_url and _api_key:
                     try:
                         import urllib.request

--- a/static/style.css
+++ b/static/style.css
@@ -2503,7 +2503,7 @@
 .model-dropdown{display:none;position:absolute;bottom:calc(100% + 4px);left:0;min-width:280px;max-width:min(420px,calc(100vw - 32px));background:var(--surface);border:1px solid var(--border2);border-radius:10px;box-shadow:0 -4px 24px rgba(0,0,0,.4);z-index:200;overflow:hidden;max-height:320px;overflow-y:auto;}
 .model-dropdown.open{display:block;}
 .model-scope-note{position:sticky;top:0;z-index:2;padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text);font-size:11px;font-weight:650;line-height:1.4;background:color-mix(in srgb,var(--surface) 82%,var(--accent-bg));box-shadow:0 1px 0 rgba(0,0,0,.12);}
-.model-group{padding:8px 14px 4px;font-size:10px;font-weight:700;letter-spacing:.04em;color:var(--muted);text-transform:uppercase;border-top:1px solid var(--border2);margin-top:2px;}
+.model-group{padding:8px 14px 4px;font-size:10px;font-weight:700;letter-spacing:.04em;color:var(--muted);text-transform:uppercase;border-top:1px solid var(--border2);margin-top:2px;cursor:pointer;user-select:none;}.model-group::before{content:"▶";display:inline-block;margin-right:6px;font-size:8px;transition:transform .15s ease;}.model-group.open::before{content:"▼";}.model-group-body{overflow:hidden;transition:opacity .1s ease;}
 .model-opt{padding:10px 14px;cursor:pointer;transition:background .12s;display:flex;flex-direction:column;gap:3px;align-items:flex-start;}
 .model-opt:hover{background:rgba(255,255,255,.07);}
 .model-opt.is-highlighted{background:rgba(255,255,255,.1);outline:1px solid var(--border2);outline-offset:-1px;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -2185,9 +2185,14 @@ function renderModelDropdown(){
     }
     return 500;
   };
+  // Collapsible group state — persists across _filterModels calls
+  const _groupOpenState={};
   // Filter function (defined AFTER _searchRow and _cust* are created)
   const _filterModels=(term)=>{
     term=term.trim().toLowerCase();
+    const hasSearch=!!term;
+    // On a fresh search, expand all groups (#collapse)
+    if(hasSearch) for(const k in _groupOpenState) _groupOpenState[k]=true;
     const found=new Set();
     for(const m of _modelData){
       const name=m.name.toLowerCase();
@@ -2285,6 +2290,7 @@ function renderModelDropdown(){
       hint.textContent=entry.modelsEndpointError.message||'Models endpoint could not be reached for this provider.';
       dd.appendChild(hint);
     };
+    _groupWrappers={};
     for(const m of _modelData){
       if(configuredIds.has(m.value)||!matches(m)) continue;
       if(m.group&&m.group!==_lastGroup){
@@ -2294,17 +2300,39 @@ function renderModelDropdown(){
         heading.textContent=count>1?`${m.group} (${count})`:m.group;
         dd.appendChild(heading);
         _renderProviderEndpointHint(m.group);
+        const wrapper=document.createElement('div');
+        wrapper.className='model-group-body';
+        wrapper.dataset.group=m.group;
+        if(Object.keys(_groupOpenState).length>0) _groupOpenState[m.group]=false;
+        else _groupOpenState[m.group]=true;
+        if(!_groupOpenState[m.group]) wrapper.style.display='none';
+        else heading.classList.add('open');
+        dd.appendChild(wrapper);
+        _groupWrappers[m.group]=wrapper;
+        heading.style.cursor='pointer';
+        heading.addEventListener('click',(e)=>{
+          e.stopPropagation();
+          const w=dd.querySelector(`.model-group-body[data-group="${CSS.escape(m.group)}"]`);
+          if(!w) return;
+          const closed=w.style.display==='none';
+          w.style.display=closed?'':'none';
+          _groupOpenState[m.group]=closed;
+          heading.classList.toggle('open',closed);
+        });
         _lastGroup=m.group;
       }
       if(m.endpointErrorOnly) continue;
       const row=document.createElement('div');
       row.className='model-opt'+(m.value===sel.value?' active':'');
       const badgeHtml=m.badge?`<span class="model-opt-badge model-opt-badge--${esc(m.badge.role||'configured')}">${esc(m.badge.label||'Configured')}</span>`:'';
-      // Inline provider chip on every row that has a group (#1425)
       const providerChip=m.group?`<span class="model-opt-provider">${esc(m.group)}</span>`:'';
       row.innerHTML=`<div class="model-opt-top"><span class="model-opt-name">${esc(m.name)}</span>${badgeHtml}${providerChip}</div><span class="model-opt-id">${esc(m.id)}</span>`;
       row.onclick=()=>selectModelFromDropdown(m.value,m.providerId||(m.badge&&m.badge.provider)||null);
-      dd.appendChild(row);
+      if(m.group&&_groupWrappers[m.group]){
+        _groupWrappers[m.group].appendChild(row);
+      }else{
+        dd.appendChild(row);
+      }
     }
     // Show "No results" if filtered and nothing matched
     if(term&&found.size===0){


### PR DESCRIPTION
## Credential pool fallback for custom providers + Collapsible model groups in dropdown

### Problem

When using `hermes auth add` to register a custom provider (e.g., Bothub, OpenRouter, Polza), the WebUI shows the provider as **"Not configured"** and refuses to display its models — even though valid credentials exist in the credential pool (`auth.json`). This happens because the backend (`config.py`, `providers.py`, `routes.py`) only checks `config.yaml` and `.env` for `base_url` and `api_key`, completely ignoring the credential pool.

Additionally, the model selection dropdown becomes unusable when there are many providers — groups are plain text headers with no way to collapse them.

### Changes

#### 1. Backend: Credential pool fallback (4 commits squashed)

- **`api/config.py` — `get_available_models()`**  
  Before querying a custom provider's `/v1/models` endpoint, try the credential pool as a fallback for both `base_url` and `api_key`. If neither is in `config.yaml` but they exist in `auth.json` — use those.

- **`api/providers.py` — `_provider_has_key()`**  
  Check credential pool when determining whether a provider has a configured API key. Without this, `get_providers()` returns the provider as "no key" and models aren't rendered even when the key is available.

- **`api/providers.py` — `get_provider_api_key()`**  
  Same fallback when extracting the actual API key for downstream use (e.g., proxied requests).

- **`api/providers.py` — `get_providers()`**  
  Set `cp_has_key = True` if credentials exist in the pool for this custom provider, even when the env-var check fails.

- **`api/routes.py` — `_handle_live_models()`**  
  When fetching `/v1/models` for a custom provider, fall back to credential pool for `base_url` + `api_key` if they're missing from config. Without this, live-model discovery silently returns zero models.

**Dependency:** `htpx` must be available in WebUI's venv — `agent.credential_pool` imports it. Without it, all try/except blocks silently pass and the pool is never consulted.

#### 2. Frontend: Collapsible provider groups

- **`static/style.css`**  
  Added `::before` pseudo-element (▶/▼ indicators), `.open` class toggle, and `.model-group-body` wrapper styles. Only the `model-group` rule was modified (1 line change).

- **`static/ui.js`** — `renderModelDropdown()`  
  - Introduced `_groupOpenState` — persists collapse state across re-renders.  
  - Each group heading now creates a `.model-group-body` wrapper for its models.  
  - Heading click toggles the wrapper (show/hide) and flips ▶ to ▼ via `.open` class.  
  - **Search expands all groups** — when the user types a search term, every group opens automatically so search results aren't hidden inside collapsed sections.  
  - Default state: first group open, all others collapsed — keeps the dropdown compact on first load.

### Before / After

| Before | After |
|--------|-------|
| Provider not shown if key is only in credential pool | Works — pool is used as fallback |
| `/v1/models` returns 0 models if `base_url` not in config | Works — base_url from pool |
| Model list is one flat scroll (5+ providers = unusable) | Groups are collapsible, show/hide on click |
| Search looks through invisible models in collapsed groups | Search auto-expands everything |

### How to test

1. Add a custom provider via `hermes auth add bothub <key>` (omit `base_url` and `api_key` from `config.yaml`).
2. Restart the WebUI server and hard-reload the browser (`Ctrl+Shift+R`).
3. Open the model dropdown — the provider should appear **without** a "Not configured" badge.
4. Click the group header — it should collapse/expand.
5. Type in the search field — all groups should expand automatically.
6. Select a model — it should work end-to-end.