### PR TITLE
test(#3664): normalize the profile-home fallback path expectation

### DIFF
--- a/tests/test_session_sidecar_repair.py
+++ b/tests/test_session_sidecar_repair.py
@@ -440,7 +440,7 @@ class TestGetProfileHome:
         monkeypatch.setitem(sys.modules, "api.profiles", None)
         monkeypatch.setenv("HERMES_HOME", "/custom/hermes")
         result = _get_profile_home(None)
-        assert str(result) == "/custom/hermes"
+        assert result == Path(os.environ["HERMES_HOME"]).expanduser()
 
     def test_expands_tilde_in_hermes_home(self, monkeypatch):
         """If HERMES_HOME contains ~, it gets expanded."""


### PR DESCRIPTION
## Thinking Path

- The current `_get_profile_home()` fallback already returns a host-native `Path`, so the remaining Windows failure in [#3664](https://github.com/nesquena/hermes-webui/issues/3664) is not a code bug, it is a stale test contract.
- `test_uses_hermes_home_env_var` hardcodes `/custom/hermes` and compares that literal slash string to the function output, even though the function is intentionally a `Path`-based filesystem helper.
- The smallest useful slice is to normalize that one expectation to the actual host-path contract and leave the rest of the file alone.

## Contract Routing

- Contributor test harness only: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `README.md`, and `TESTING.md` cover the path semantics this regression test should reflect.

## What Changed

- `tests/test_session_sidecar_repair.py`: updated `test_uses_hermes_home_env_var` to compare the fallback result against the expanded host-native path instead of a literal POSIX string.

## Why It Matters

This removes a false Windows failure without changing product behavior. The test now matches the actual path contract the helper already implements.

## Verification

```text
pytest tests/test_session_sidecar_repair.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- This PR should stay narrow. If a later Windows run finds additional slash-vs-backslash failures, triage them one by one instead of broad speculative path churn.

Refs #3664

Attribution: this slice follows the failure-class breakdown already documented in [#3664](https://github.com/nesquena/hermes-webui/issues/3664) and the maintainer's request there to land one Windows failure class per PR.

## Model Used

GPT-5.4 via MiMoCode
