### PR TITLE
test(#3664): relax strict POSIX mode assertions on Windows

### DIFF
--- a/tests/test_auth_session_persistence.py
+++ b/tests/test_auth_session_persistence.py
@@ -79,7 +79,7 @@ class TestSessionPersistence(unittest.TestCase):
         self.assertIn("valid_token", auth._sessions)
 
     def test_sessions_file_permissions(self) -> None:
-        """Sessions file must be owner-read-only (0600)."""
+        """Sessions file must stay strict on POSIX and still be created on Windows."""
         auth.create_session()
         # Check the path auth actually writes to (auth._SESSIONS_FILE is computed
         # from api.config.STATE_DIR at import time). Asserting against a local

--- a/tests/test_auth_session_persistence.py
+++ b/tests/test_auth_session_persistence.py
@@ -87,6 +87,9 @@ class TestSessionPersistence(unittest.TestCase):
         # this module may import before api.config.STATE_DIR resolves to _TEST_STATE.
         sessions_file = auth._SESSIONS_FILE
         self.assertTrue(sessions_file.exists(), ".sessions.json was not created")
+        if os.name == "nt":
+            self.assertTrue(sessions_file.is_file(), ".sessions.json was not written as a file")
+            return
         mode = oct(sessions_file.stat().st_mode & 0o777)
         self.assertEqual(mode, oct(0o600),
                          f".sessions.json permissions {mode} — expected 0o600")

--- a/tests/test_issue1910_login_attempt_persistence.py
+++ b/tests/test_issue1910_login_attempt_persistence.py
@@ -1,4 +1,5 @@
 import json
+import os
 import stat
 import time
 
@@ -15,7 +16,9 @@ def test_login_attempts_persist_failed_attempts(tmp_path, monkeypatch):
     data = json.loads(attempts_file.read_text(encoding="utf-8"))
     assert "203.0.113.10" in data
     assert len(data["203.0.113.10"]) == 1
-    assert stat.S_IMODE(attempts_file.stat().st_mode) == 0o600
+    assert attempts_file.exists()
+    if os.name != "nt":
+        assert stat.S_IMODE(attempts_file.stat().st_mode) == 0o600
 
 
 def test_login_attempts_load_prunes_expired_entries(tmp_path, monkeypatch):

--- a/tests/test_security_redaction.py
+++ b/tests/test_security_redaction.py
@@ -500,6 +500,8 @@ def test_fix_credential_permissions_corrects_loose_files(tmp_path, monkeypatch):
     if os.name != "nt":
         assert stat.S_IMODE(env_file.stat().st_mode) == 0o600, ".env not fixed to 600"
         assert stat.S_IMODE(google_file.stat().st_mode) == 0o600, "google_token.json not fixed to 600"
+    # Windows CI cannot assert a POSIX mode-bit repair here; keeping the files
+    # present after the repair pass is the strongest portable contract for now.
 
 
 def test_fix_credential_permissions_skips_correct_files(tmp_path, monkeypatch):

--- a/tests/test_security_redaction.py
+++ b/tests/test_security_redaction.py
@@ -496,10 +496,10 @@ def test_fix_credential_permissions_corrects_loose_files(tmp_path, monkeypatch):
 
     import stat
     assert env_file.exists(), ".env missing after permission repair"
-    assert google_file.exists(), "aux sidecar missing after permission repair"
+    assert google_file.exists(), "google_token.json missing after permission repair"
     if os.name != "nt":
         assert stat.S_IMODE(env_file.stat().st_mode) == 0o600, ".env not fixed to 600"
-        assert stat.S_IMODE(google_file.stat().st_mode) == 0o600, "aux sidecar not fixed to 600"
+        assert stat.S_IMODE(google_file.stat().st_mode) == 0o600, "google_token.json not fixed to 600"
 
 
 def test_fix_credential_permissions_skips_correct_files(tmp_path, monkeypatch):

--- a/tests/test_security_redaction.py
+++ b/tests/test_security_redaction.py
@@ -495,12 +495,17 @@ def test_fix_credential_permissions_corrects_loose_files(tmp_path, monkeypatch):
     fix_credential_permissions()
 
     import stat
-    assert stat.S_IMODE(env_file.stat().st_mode) == 0o600, ".env not fixed to 600"
-    assert stat.S_IMODE(google_file.stat().st_mode) == 0o600, "google_token.json not fixed to 600"
+    assert env_file.exists(), ".env missing after permission repair"
+    assert google_file.exists(), "aux sidecar missing after permission repair"
+    if os.name != "nt":
+        assert stat.S_IMODE(env_file.stat().st_mode) == 0o600, ".env not fixed to 600"
+        assert stat.S_IMODE(google_file.stat().st_mode) == 0o600, "aux sidecar not fixed to 600"
 
 
 def test_fix_credential_permissions_skips_correct_files(tmp_path, monkeypatch):
     """fix_credential_permissions() does not alter already-strict files."""
+    import os
+
     env_file = tmp_path / ".env"
     env_file.write_text("SECRET=abc")
     env_file.chmod(0o600)
@@ -511,4 +516,6 @@ def test_fix_credential_permissions_skips_correct_files(tmp_path, monkeypatch):
     fix_credential_permissions()
 
     import stat
-    assert stat.S_IMODE(env_file.stat().st_mode) == 0o600
+    assert env_file.exists(), ".env missing after strict-permission check"
+    if os.name != "nt":
+        assert stat.S_IMODE(env_file.stat().st_mode) == 0o600

--- a/tests/test_v050257_opus_followups.py
+++ b/tests/test_v050257_opus_followups.py
@@ -64,6 +64,9 @@ def test_oauth_write_auth_json_uses_chmod_0600_before_rename(monkeypatch, tmp_pa
         os.umask(old_umask)
 
     assert fake_path.exists(), "auth.json was not written"
+    if os.name == "nt":
+        assert fake_path.is_file(), "auth.json was not written as a file"
+        return
     mode = stat.S_IMODE(fake_path.stat().st_mode)
     # The file must be chmod 0600 — owner read/write only.
     assert mode == 0o600, (


### PR DESCRIPTION
## Thinking Path

- The Windows umbrella in [#3664](https://github.com/nesquena/hermes-webui/issues/3664) includes a real class of false failures where runtime tests assert exact POSIX `0o600` bits on hosts that do not expose that as a stable filesystem contract.
- The underlying security intent is still important, and current product code still calls `chmod` in the sensitive write paths. The suite already has source-level pins for that intent.
- This slice keeps the exact runtime mode checks on POSIX but narrows the Windows expectation to a successful write/repair plus file existence, which is the strongest portable runtime contract available here.

## Contract Routing

- Contributor test harness only: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `README.md`, and `TESTING.md` define the security-sensitive test contract this PR is clarifying.

## What Changed

- `tests/test_auth_session_persistence.py`: split the `.sessions.json` assertion into exact POSIX mode checks vs Windows-safe existence/write checks.
- `tests/test_issue1910_login_attempt_persistence.py`: applied the same POSIX-vs-Windows expectation split to login-attempt persistence.
- `tests/test_security_redaction.py`: kept the runtime startup repair coverage while avoiding exact POSIX mode assertions on Windows.
- `tests/test_v050257_opus_followups.py`: kept the source-level chmod pin unchanged and narrowed only the runtime `auth.json` mode assertion on Windows.

## Why It Matters

This keeps the security intent covered without turning every Windows run into noise from a filesystem contract the host does not actually provide. POSIX still keeps the strict mode-bit assertions.

## Verification

```text
pytest tests/test_auth_session_persistence.py tests/test_issue1910_login_attempt_persistence.py tests/test_security_redaction.py tests/test_v050257_opus_followups.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- This PR must not weaken POSIX coverage. Exact `0o600` runtime assertions stay in place there.
- If maintainers want stronger Windows secrecy checks later, that should be a follow-up that inspects ACLs explicitly rather than pretending POSIX mode bits are portable.

Refs #3664

Attribution: this slice follows the failure-class breakdown already documented in [#3664](https://github.com/nesquena/hermes-webui/issues/3664) and the maintainer's request there to land one Windows failure class per PR.

## Model Used

GPT-5.4 via MiMoCode
