### PR TITLE
test(#3664): harden Windows pytest harness cleanup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -601,6 +601,114 @@ def _server_boot_diagnostic(headline, log_path):
     return "\n".join(parts)
 
 
+def _kill_process_tree(pid):
+    """Best-effort kill for a known fixture-owned or port-owning PID."""
+    if not pid or pid <= 0:
+        return
+    try:
+        if sys.platform == "win32":
+            subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+                **({"creationflags": subprocess.CREATE_NO_WINDOW}),
+            )
+            return
+        import signal
+
+        os.kill(pid, signal.SIGKILL)
+    except Exception:
+        pass
+
+
+def _kill_port_owner(port):
+    """Best-effort free of TEST_PORT, using a Windows-native owner lookup."""
+    try:
+        if sys.platform != "win32":
+            subprocess.run(["fuser", "-k", f"{port}/tcp"], capture_output=True, timeout=5)
+            return
+
+        creationflags = {"creationflags": subprocess.CREATE_NO_WINDOW}
+        ps_cmd = (
+            "$port = " + str(port) + "; "
+            "$conn = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue | "
+            "Where-Object { $_.LocalAddress -in @('127.0.0.1', '::1', '0.0.0.0', '::', '::ffff:127.0.0.1') } | "
+            "Select-Object -First 1 -ExpandProperty OwningProcess; "
+            "if ($conn) { $conn }"
+        )
+        proc = subprocess.run(
+            ["powershell", "-NoProfile", "-NonInteractive", "-Command", ps_cmd],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            **creationflags,
+        )
+        pid_text = proc.stdout.strip()
+        if not pid_text:
+            proc = subprocess.run(
+                ["netstat", "-ano", "-p", "tcp"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                **creationflags,
+            )
+            port_suffixes = (f":{port}", f"[::]:{port}", f"127.0.0.1:{port}", f"[::1]:{port}")
+            for line in proc.stdout.splitlines():
+                parts = line.split()
+                if len(parts) < 5 or parts[0].upper() != "TCP":
+                    continue
+                local_addr = parts[1]
+                state = parts[3].upper()
+                owner_pid = parts[4]
+                if state == "LISTENING" and any(local_addr.endswith(suffix) for suffix in port_suffixes):
+                    pid_text = owner_pid
+                    break
+        if pid_text:
+            _kill_process_tree(int(pid_text))
+    except Exception:
+        pass
+
+
+def _rmtree_retry(path):
+    """Remove a tree, retrying on Windows after clearing read-only bits."""
+    target = pathlib.Path(path)
+    if not target.exists():
+        return
+    if sys.platform != "win32":
+        shutil.rmtree(target)
+        return
+
+    def _clear_readonly(_func, entry, _excinfo):
+        try:
+            os.chmod(entry, 0o666)
+            _func(entry)
+        except Exception:
+            raise
+
+    attempts = 5
+    last_exc = None
+    for attempt in range(1, attempts + 1):
+        try:
+            shutil.rmtree(target, onerror=_clear_readonly)
+            return
+        except FileNotFoundError:
+            return
+        except Exception as exc:
+            last_exc = exc
+            if attempt == attempts:
+                break
+            time.sleep(0.3)
+
+    leftovers = []
+    try:
+        leftovers = [child.name for child in list(target.iterdir())[:5]]
+    except Exception:
+        pass
+    leftover_note = f" leftovers={leftovers}" if leftovers else ""
+    raise RuntimeError(f"Could not remove {target} after {attempts} attempts.{leftover_note}") from last_exc
+
+
 # ── Session-scoped test server ────────────────────────────────────────────────
 
 @pytest.fixture(scope="session", autouse=True)
@@ -612,18 +720,13 @@ def test_server():
     # Kill any leftover process on the test port before starting.
     # Stale servers from QA harness runs or prior test sessions cause
     # conftest to think the server is already up, producing false failures.
-    try:
-        import subprocess as _sp
-        _sp.run(['fuser', '-k', f'{TEST_PORT}/tcp'],
-                capture_output=True, timeout=5)
-    except Exception:
-        pass
+    _kill_port_owner(TEST_PORT)
     import time as _time
     _time.sleep(0.5)  # brief pause to let the port release
 
     # Clean slate
     if TEST_STATE_DIR.exists():
-        shutil.rmtree(TEST_STATE_DIR)
+        _rmtree_retry(TEST_STATE_DIR)
     TEST_STATE_DIR.mkdir(parents=True)
     TEST_WORKSPACE.mkdir(parents=True)
 
@@ -759,16 +862,12 @@ def test_server():
         last_reason = reason
         # Tear down the failed attempt and free the port before retrying.
         try:
-            proc.kill()
+            _kill_process_tree(proc.pid)
             proc.wait(timeout=5)
         except Exception:
             pass
         if _attempt < boot_attempts:
-            try:
-                import subprocess as _sp2
-                _sp2.run(['fuser', '-k', f'{TEST_PORT}/tcp'], capture_output=True, timeout=5)
-            except Exception:
-                pass
+            _kill_port_owner(TEST_PORT)
             time.sleep(1.0)
     else:
         pytest.fail(
@@ -787,12 +886,9 @@ def test_server():
     try:
         proc.wait(timeout=5)
     except subprocess.TimeoutExpired:
-        proc.kill()
+        _kill_process_tree(proc.pid)
 
-    try:
-        shutil.rmtree(TEST_STATE_DIR)
-    except Exception:
-        pass
+    _rmtree_retry(TEST_STATE_DIR)
 
 
 # ── Test base URL ─────────────────────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ PATH DISCOVERY:
     4. System python3 as a last resort
 """
 import json
+import inspect
 import os
 import pathlib
 import shutil
@@ -679,18 +680,24 @@ def _rmtree_retry(path):
         shutil.rmtree(target)
         return
 
-    def _clear_readonly(_func, entry, _excinfo):
+    def _clear_readonly(_func, entry, _exc):
         try:
             os.chmod(entry, 0o666)
             _func(entry)
         except Exception:
             raise
 
+    rmtree_kwargs = (
+        {"onexc": _clear_readonly}
+        if "onexc" in inspect.signature(shutil.rmtree).parameters
+        else {"onerror": _clear_readonly}
+    )
+
     attempts = 5
     last_exc = None
     for attempt in range(1, attempts + 1):
         try:
-            shutil.rmtree(target, onerror=_clear_readonly)
+            shutil.rmtree(target, **rmtree_kwargs)
             return
         except FileNotFoundError:
             return


### PR DESCRIPTION
## Thinking Path

- The Windows failures in [#3664](https://github.com/nesquena/hermes-webui/issues/3664) are not all product bugs; some are harness failures where one bad run leaves the next rerun with a locked state dir or stale port owner.
- `tests/conftest.py` already captures boot logs and retries once, but it still frees the port with `fuser` and deletes the state dir with a plain `shutil.rmtree()`, which is the wrong contract on native Windows.
- The smallest useful slice is to harden only the harness cleanup layer so later focused Windows reruns fail on real regressions instead of stale fixture state.

## Contract Routing

- Contributor test harness only: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `README.md`, and `TESTING.md` describe the local verification contract this PR is tightening.

## What Changed

- `tests/conftest.py`: replaced the fixture's POSIX-only `fuser` cleanup and plain `shutil.rmtree()` calls with Windows-aware port-owner, process-tree, and retrying state-dir cleanup helpers.

## Why It Matters

Windows contributors need a local pytest rerun to reflect the code they just changed, not residue from the previous failed run. Hardening the fixture cleanup removes a false-failure class without changing product behavior.

## Verification

```text
pytest tests/test_windows_native_support.py tests/test_ctl_script.py -q --timeout=60
pytest tests/conftest.py --collect-only -q
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- The cleanup helpers must stay tightly scoped to the fixture's own PID and `TEST_PORT`; broad process killing would be worse than the current failure mode.
- This does not close the umbrella issue. It only clears the stale-process and locked-state failure class.

Refs #3664

Attribution: this slice follows the failure-class breakdown already documented in [#3664](https://github.com/nesquena/hermes-webui/issues/3664) and the maintainer's request there to land one Windows failure class per PR.

## Model Used

GPT-5.4 via MiMoCode
