### PR TITLE
test(#3664): mark Windows-incompatible test capabilities explicitly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,6 +255,8 @@ requires_agent_modules = pytest.mark.skipif(
 def pytest_configure(config):
     config.addinivalue_line("markers", "requires_agent: skip when hermes-agent dir is not found")
     config.addinivalue_line("markers", "requires_agent_modules: skip when hermes-agent Python modules are not importable")
+    config.addinivalue_line("markers", "requires_fcntl: skip when fcntl-backed file-descriptor operations are unavailable")
+    config.addinivalue_line("markers", "requires_fork: skip when the platform lacks multiprocessing fork support")
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ PATH DISCOVERY:
     4. System python3 as a last resort
 """
 import json
+import multiprocessing
 import os
 import pathlib
 import shutil
@@ -31,6 +32,16 @@ if not (3, 11) <= sys.version_info[:2] <= (3, 13):
         "instead of an unsupported system python.",
         returncode=3,
     )
+
+WINDOWS = sys.platform == "win32"
+requires_fcntl = pytest.mark.skipif(
+    WINDOWS,
+    reason="requires fcntl-backed nonblocking pipe reads",
+)
+requires_fork = pytest.mark.skipif(
+    "fork" not in multiprocessing.get_all_start_methods(),
+    reason="requires multiprocessing fork",
+)
 
 # ── Repo root discovery ────────────────────────────────────────────────────
 # conftest.py lives at <repo>/tests/conftest.py

--- a/tests/test_issue1574_cron_profile_lock.py
+++ b/tests/test_issue1574_cron_profile_lock.py
@@ -5,6 +5,9 @@ import threading
 import types
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent))
+from conftest import requires_fork
+
 
 def _install_fake_cron(monkeypatch, run_job, events):
     cron_pkg = types.ModuleType("cron")
@@ -193,6 +196,7 @@ def _run_lock_probe_with_context(context_name, target, result_queue):
     return process.exitcode, acquired
 
 
+@requires_fork
 def test_spawn_context_does_not_inherit_parent_thread_locks(tmp_path):
     """Spawn starts a fresh interpreter where fork would clone a held lock."""
     helper_dir = tmp_path / "spawn_helper"
@@ -244,6 +248,7 @@ def test_spawn_context_does_not_inherit_parent_thread_locks(tmp_path):
     assert spawn_acquired is True
 
 
+@requires_fork
 def test_manual_cron_subprocess_drains_large_result_before_join(tmp_path):
     """A >100 KB result must not deadlock the parent before it can persist output."""
     if _real_hermes_agent_editable_install_present():
@@ -349,6 +354,7 @@ def test_manual_cron_run_does_not_hold_profile_lock_for_job_duration(tmp_path, m
     assert routes._is_cron_running("job1574") == (False, 0.0)
 
 
+@requires_fork
 def test_cron_job_subprocess_executes_under_selected_profile_home(tmp_path, monkeypatch):
     if _real_hermes_agent_editable_install_present():
         import pytest as _pytest

--- a/tests/test_tls_support.py
+++ b/tests/test_tls_support.py
@@ -16,6 +16,9 @@ import unittest
 from contextlib import suppress
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent))
+from conftest import requires_fcntl
+
 ROOT = Path(__file__).parent.parent
 
 
@@ -190,6 +193,7 @@ class TestTLSEndToEnd(unittest.TestCase):
         self.assertEqual(data.get("status"), "ok")
         conn.close()
 
+    @requires_fcntl
     def test_tls_startup_failure_fallback_to_http(self):
         """Bad cert paths should print a warning and start HTTP anyway."""
         port = _find_free_port()


### PR DESCRIPTION
## Thinking Path

- The Windows umbrella in [#3664](https://github.com/nesquena/hermes-webui/issues/3664) should keep real regressions visible, but a few current failures are just capability mismatches: `fcntl`-based pipe reads and test harnesses that unconditionally require `fork`.
- Those tests should not silently pass, and they should not take the whole module down on Windows either; the right contract is an explicit skip with a reason naming the missing capability.
- This slice adds shared capability markers and applies them only to the currently unavoidable cells, leaving the spawn-safe coverage intact.

## Contract Routing

- Contributor test harness only: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `README.md`, and `TESTING.md` define the local test semantics this PR makes explicit.

## What Changed

- `tests/conftest.py`: added shared `requires_fork` and `requires_fcntl` markers with capability-specific skip reasons.
- `tests/test_tls_support.py`: marked the one `fcntl`-dependent TLS fallback warning test as capability-bound.
- `tests/test_issue1574_cron_profile_lock.py`: marked only the fork-dependent harness tests, leaving spawn-safe cron/profile coverage unchanged.

## Why It Matters

Explicit capability skips make a native Windows run more trustworthy: reviewers can tell the difference between a real regression and a test that simply requires a host primitive Windows does not provide.

## Verification

```text
pytest tests/test_tls_support.py tests/test_issue1574_cron_profile_lock.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- Over-skipping would hide real Windows regressions, so this PR must stay limited to the currently unavoidable `fcntl` and outer-harness `fork` cells.
- A later follow-up can replace the TLS warning read path with a portable helper and remove that skip entirely.

Refs #3664

Attribution: this slice follows the failure-class breakdown already documented in [#3664](https://github.com/nesquena/hermes-webui/issues/3664) and the maintainer's request there to land one Windows failure class per PR.

## Model Used

GPT-5.4 via MiMoCode
