### PR TITLE
Release PB (v0.51.441): honest notification-permission controls (#4118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 
 ## [Unreleased]
 
-## [v0.51.440] — 2026-06-15 — Release PA (advanced per-model options + auxiliary model routing)
+## [v0.51.441] — 2026-06-15 — Release PB (honest notification-permission controls)
+
+### Fixed
+
+- **Notification permission controls now reflect the real browser state (#4118).** The "Enable notifications" button in Settings was a silent no-op once permission had already been granted or denied — it gave no feedback and didn't show the current state. It now reflects the live `Notification.permission` value: the button is disabled with an explanatory tooltip/aria-label when permission is already granted, surfaces the denied/unsupported states honestly, and the granted branch confirms with a toast instead of doing nothing.
 
 ### Added
 

--- a/static/index.html
+++ b/static/index.html
@@ -1159,7 +1159,9 @@
               </label>
               <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_notifications">Show a system notification when a response completes while the app is in the background.</div>
               <div style="display:flex;gap:8px;align-items:center;margin-top:8px;flex-wrap:wrap">
-                <button type="button" class="sm-btn" onclick="requestNotificationPermission()" style="padding:5px 10px;font-size:12px" data-i18n="notifications_enable_btn">Enable notifications</button>
+                <span id="notificationPermissionButtonWrap" style="display:inline-flex">
+                  <button type="button" class="sm-btn" id="notificationPermissionButton" onclick="requestNotificationPermission()" style="padding:5px 10px;font-size:12px" data-i18n="notifications_enable_btn">Enable notifications</button>
+                </span>
                 <button type="button" class="sm-btn" onclick="sendBrowserNotification('Hermes test','Notifications are ready.',{force:true});" style="padding:5px 10px;font-size:12px" data-i18n="notifications_test_btn">Send test</button>
                 <span id="notificationPermissionStatus" style="font-size:11px;color:var(--muted)"></span>
               </div>

--- a/static/messages.js
+++ b/static/messages.js
@@ -5234,11 +5234,17 @@ function _showPwaNotification(title,body,options={}){
 function requestNotificationPermission(){
   if(!('Notification' in window)){
     if(typeof showToast==='function') showToast(t('notifications_unsupported'),3000,'error');
+    if(typeof updateNotificationPermissionStatus==='function') updateNotificationPermissionStatus();
     return Promise.resolve('unsupported');
   }
-  if(Notification.permission==='granted') return Promise.resolve('granted');
+  if(Notification.permission==='granted'){
+    if(typeof updateNotificationPermissionStatus==='function') updateNotificationPermissionStatus();
+    if(typeof showToast==='function') showToast(t('notifications_enabled_toast'),3000);
+    return Promise.resolve('granted');
+  }
   if(Notification.permission==='denied'){
     if(typeof showToast==='function') showToast(t('notifications_denied'),3500,'error');
+    if(typeof updateNotificationPermissionStatus==='function') updateNotificationPermissionStatus();
     return Promise.resolve('denied');
   }
   return Notification.requestPermission().then(p=>{

--- a/static/panels.js
+++ b/static/panels.js
@@ -8984,8 +8984,30 @@ async function _restoreCheckpoint(workspace,checkpoint,message){
 
 function updateNotificationPermissionStatus(){
   const el=$('notificationPermissionStatus');
+  const btn=$('notificationPermissionButton');
+  const btnWrap=$('notificationPermissionButtonWrap');
   if(!el) return;
-  if(!('Notification' in window)){el.textContent=t('notifications_unsupported');return;}
+  if(!('Notification' in window)){
+    const unsupported=t('notifications_unsupported');
+    el.textContent=unsupported;
+    if(btn){
+      btn.disabled=true;
+      btn.title='';
+      btn.setAttribute('aria-label', unsupported);
+      btn.setAttribute('aria-disabled','true');
+    }
+    if(btnWrap) btnWrap.title=unsupported;
+    return;
+  }
   const perm=Notification.permission||'default';
-  el.textContent=t('notifications_permission_status', perm);
+  const label=t('notifications_permission_status', perm);
+  el.textContent=label;
+  if(btn){
+    const granted=perm==='granted';
+    btn.disabled=granted;
+    btn.title=granted?'':label;
+    btn.setAttribute('aria-label', label);
+    btn.setAttribute('aria-disabled', granted?'true':'false');
+  }
+  if(btnWrap) btnWrap.title=label;
 }

--- a/tests/test_pwa_notification_controls.py
+++ b/tests/test_pwa_notification_controls.py
@@ -47,11 +47,36 @@ def test_service_worker_handles_notification_clicks_without_hijacking_other_sess
 
 def test_settings_expose_permission_and_test_controls():
     assert "notificationPermissionStatus" in INDEX_HTML
+    assert 'id="notificationPermissionButtonWrap"' in INDEX_HTML
+    assert 'id="notificationPermissionButton"' in INDEX_HTML
     assert "requestNotificationPermission()" in INDEX_HTML
     assert "sendBrowserNotification('Hermes test'" in INDEX_HTML
     assert "{force:true}" in INDEX_HTML
     assert "function updateNotificationPermissionStatus" in PANELS_JS
+    assert "const btn=$('notificationPermissionButton');" in PANELS_JS
+    assert "const btnWrap=$('notificationPermissionButtonWrap');" in PANELS_JS
+    assert "btn.disabled=granted;" in PANELS_JS
+    assert "btn.title=granted?'':label;" in PANELS_JS
+    assert "if(btnWrap) btnWrap.title=label;" in PANELS_JS
     assert "notifications_permission_status" in PANELS_JS
+    assert "btn.setAttribute('aria-label', label);" in PANELS_JS
+    assert "btn.setAttribute('aria-disabled', granted?'true':'false');" in PANELS_JS
+    assert "btn.setAttribute('aria-disabled','true');" in PANELS_JS
+
+
+def test_granted_permission_branch_is_not_silent():
+    fn = MESSAGES_JS[
+        MESSAGES_JS.index("function requestNotificationPermission(){") :
+        MESSAGES_JS.index("function sendBrowserNotification(", MESSAGES_JS.index("function requestNotificationPermission(){"))
+    ]
+    assert "if(Notification.permission==='granted'){" in fn
+    granted_branch = fn[
+        fn.index("if(Notification.permission==='granted'){") :
+        fn.index("if(Notification.permission==='denied'){")
+    ]
+    assert "updateNotificationPermissionStatus()" in granted_branch
+    assert "showToast(t('notifications_enabled_toast'),3000)" in granted_branch
+    assert "return Promise.resolve('granted');" in granted_branch
 
 
 def test_notification_i18n_and_changelog_entries_exist():
@@ -66,3 +91,8 @@ def test_notification_i18n_and_changelog_entries_exist():
         assert key in I18N_JS
     assert "PWA notifications now use the service worker" in CHANGELOG
     assert "#3196" in CHANGELOG
+    entry = next(
+        line for line in CHANGELOG.splitlines()
+        if "Notification permission controls now reflect the real browser state" in line
+    )
+    assert entry.count("#4118") == 1


### PR DESCRIPTION
## Release PB — v0.51.441

Ships **#4133** (rodboev) — honest notification-permission controls (#4118). Self-rebased onto v0.51.440, scope-split, and gated fresh (Codex + Opus + full suite). Functionally confirmed live.

### What it does
The Settings "Enable notifications" button was a silent no-op once permission was already granted/denied. It now reflects the live `Notification.permission`:
- **granted** → button disabled (`aria-disabled=true`) with status "Permission: granted"
- **denied / default** → button stays actionable with honest labels
- **unsupported** → honest unsupported state
- the granted branch confirms with a toast instead of doing nothing

### Scope-split (applied on the way in)
The PR head bundled an unrelated commit (`fix(sessions): invalidate sidebar cache on WAL updates` — `api/routes.py` + `test_session_sidebar_cache.py`). I extracted **only** the notification feature for this release (`static/messages.js`, `static/panels.js`, `static/index.html`, `tests/test_pwa_notification_controls.py`); the notification feature doesn't touch `routes.py`, so the split is clean. The sidebar-cache-WAL fix is a separate good change worth splitting into its own PR. Also fixed the duplicate-`#4118` CHANGELOG entry it was originally bounced for.

### Verified
- **Live functional test:** permission=`default` → button enabled; simulated `granted` → button disabled + `aria-disabled=true` + "Permission: granted" status. The silent no-op is gone.
- **Codex SAFE** + **Opus SHIP:** all 4 states handled, PWA send path untouched, init-wiring confirmed (`updateNotificationPermissionStatus()` on settings open), scope-split clean (no routes.py diff remains).
- **Full suite:** notification tests green (6 + focus-tab tests); wider failures are this box's process-group cascade artifact (CI authoritative).

Closes #4118.

Co-authored-by: rodboev
