### PR TITLE
test(#3664): normalize background title skill path assertion

### DIFF
--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -7,6 +7,7 @@ Covers:
   - _aux_title_timeout rejects zero, negative, and non-numeric values
 """
 import os
+from pathlib import Path
 import sys
 import types
 import unittest
@@ -785,7 +786,7 @@ class TestBackgroundTitleProfileRouting(unittest.TestCase):
 
         self.assertEqual(captured.get('hermes_home'), 'profile-home')
         self.assertEqual(str(captured.get('skill_module_home')), 'profile-home')
-        self.assertEqual(str(captured.get('skill_module_dir')), 'profile-home/skills')
+        self.assertEqual(Path(str(captured.get('skill_module_dir'))), Path('profile-home') / 'skills')
         self.assertEqual(captured.get('restored_hermes_home'), 'default-home')
         self.assertEqual(getattr(fake_skill_module, 'HERMES_HOME'), 'default-home')
         self.assertEqual(getattr(fake_skill_module, 'SKILLS_DIR'), 'default-home/skills')


### PR DESCRIPTION
Refs #3664.

This keeps the follow-up test-only and fixes one remaining Windows-hosted local-path assertion in the background title routing coverage.

`profile_env_for_background_worker()` patches `SKILLS_DIR` to a native local path, so the test should compare it as a host filesystem path instead of expecting a slash-normalized string.

Validation:
- `D:\Repos\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_title_aux_routing.py -q`