### PR TITLE
Release PC (v0.51.442): [security] require auth for passkey enrollment (#4171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 
 ## [Unreleased]
 
-## [v0.51.441] — 2026-06-15 — Release PB (honest notification-permission controls)
+## [v0.51.442] — 2026-06-15 — Release PC (require auth for passkey enrollment)
+
+### Security
+
+- **First passkey enrollment is now gated like first-password onboarding.** On a `HERMES_WEBUI_PASSKEY=1` instance with auth not yet configured, a remote unauthenticated caller could register the *first* passkey credential and claim the account before the legitimate operator. The passkey registration endpoints now apply the same onboarding gate as first-password setup: only loopback/private-network requests (or an explicit `HERMES_WEBUI_ONBOARDING_OPEN=1` operator opt-in) can bootstrap the first passkey, and remote/tunnel callers are rejected. The locality check uses the raw socket address (forwarded headers are ignored unless `HERMES_WEBUI_TRUST_FORWARDED_FOR=1`), so it can't be spoofed via `X-Forwarded-For`/`Host`. Once auth is enabled, additional enrollment requires a valid authenticated session. The passkey *login* path is unchanged. (#4171)
 
 ### Fixed
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -7916,8 +7916,27 @@ def handle_get(handler, parsed) -> bool:
     return False  # 404
 
 
-# ── GET route helpers
+# ── POST auth helpers
 
+def _require_passkey_registration_auth(handler) -> tuple[bool, str, int]:
+    """Require auth, or the existing local-only first-run bootstrap gate.
+
+    Registering additional passkeys is an auth-factor enrollment action and
+    requires a valid WebUI session.  The first passkey can still bootstrap a
+    passkey-only instance, but only through the same local/private-network
+    onboarding gate used for first password setup.
+    """
+    from api.auth import is_auth_enabled, parse_cookie, verify_session
+
+    auth_enabled = is_auth_enabled()
+    if not auth_enabled:
+        if _onboarding_gate_allows(handler, auth_enabled):
+            return True, "", 200
+        return False, "Authentication required", 401
+    cookie_val = parse_cookie(handler)
+    if not cookie_val or not verify_session(cookie_val):
+        return False, "Authentication required", 401
+    return True, "", 200
 
 def handle_post(handler, parsed) -> bool:
     """Handle all POST routes. Returns True if handled, False for 404."""
@@ -9919,6 +9938,9 @@ def handle_post(handler, parsed) -> bool:
 
         if not _passkey_feature_flag_enabled():
             return j(handler, {"error": "Passkey support is disabled."}, status=404)
+        ok, error, status = _require_passkey_registration_auth(handler)
+        if not ok:
+            return j(handler, {"error": error}, status=status)
         try:
             return j(handler, {"ok": True, "publicKey": registration_options(handler)})
         except PasskeyRateLimitError as e:
@@ -9932,6 +9954,9 @@ def handle_post(handler, parsed) -> bool:
 
         if not _passkey_feature_flag_enabled():
             return j(handler, {"error": "Passkey support is disabled."}, status=404)
+        ok, error, status = _require_passkey_registration_auth(handler)
+        if not ok:
+            return j(handler, {"error": error}, status=status)
         try:
             result = finish_registration(body, handler)
             result["credentials"] = registered_credentials()

--- a/tests/test_passkey_auth.py
+++ b/tests/test_passkey_auth.py
@@ -172,7 +172,7 @@ class RouteFakeHandler:
         self.wfile = io.BytesIO()
         self.status = None
         self.sent_headers = []
-        self.client_address = ("127.0.0.1", 12345)
+        self.client_address: tuple[str, int] = ("127.0.0.1", 12345)
 
     def send_response(self, status):
         self.status = status
@@ -212,6 +212,9 @@ def test_passkey_register_options_handles_base_passkey_errors(monkeypatch):
 
     monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
     monkeypatch.setattr(auth, "_passkey_feature_flag_enabled", lambda: True)
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+    monkeypatch.setattr(auth, "parse_cookie", lambda handler: "session")
+    monkeypatch.setattr(auth, "verify_session", lambda cookie: True)
 
     def raise_passkey_error(_handler):
         raise passkeys.PasskeyError("plain passkey error")
@@ -223,6 +226,109 @@ def test_passkey_register_options_handles_base_passkey_errors(monkeypatch):
 
     assert handler.status == 400
     assert json.loads(handler.wfile.getvalue())["error"] == "plain passkey error"
+
+def test_first_passkey_registration_options_rejects_remote_bootstrap(monkeypatch, tmp_path):
+    import api.auth as auth
+    import api.routes as routes
+
+    _set_paths(monkeypatch, tmp_path)
+    monkeypatch.setenv("HERMES_WEBUI_PASSKEY", "1")
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(auth, "get_password_hash", lambda: None)
+
+    handler = RouteFakeHandler()
+    handler.client_address = ("8.8.8.8", 12345)
+    routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/register/options"))
+
+    assert handler.status == 401
+    assert json.loads(handler.wfile.getvalue())["error"] == "Authentication required"
+
+
+def test_first_passkey_registration_rejects_remote_bootstrap(monkeypatch, tmp_path):
+    import api.auth as auth
+    import api.routes as routes
+
+    _set_paths(monkeypatch, tmp_path)
+    monkeypatch.setenv("HERMES_WEBUI_PASSKEY", "1")
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(auth, "get_password_hash", lambda: None)
+
+    handler = RouteFakeHandler()
+    handler.client_address = ("8.8.8.8", 12345)
+    routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/register"))
+
+    assert handler.status == 401
+    assert json.loads(handler.wfile.getvalue())["error"] == "Authentication required"
+
+
+def test_first_passkey_registration_options_allows_local_bootstrap(monkeypatch, tmp_path):
+    import api.auth as auth
+    import api.passkeys as passkeys
+    import api.routes as routes
+
+    _set_paths(monkeypatch, tmp_path)
+    monkeypatch.setenv("HERMES_WEBUI_PASSKEY", "1")
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(auth, "get_password_hash", lambda: None)
+    monkeypatch.setattr(passkeys, "registration_options", lambda handler: {"challenge": "local-bootstrap"})
+
+    handler = RouteFakeHandler()
+    routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/register/options"))
+
+    assert handler.status == 200
+    assert json.loads(handler.wfile.getvalue())["publicKey"] == {"challenge": "local-bootstrap"}
+
+
+def test_first_passkey_registration_allows_local_bootstrap(monkeypatch, tmp_path):
+    import api.auth as auth
+    import api.passkeys as passkeys
+    import api.routes as routes
+
+    _set_paths(monkeypatch, tmp_path)
+    monkeypatch.setenv("HERMES_WEBUI_PASSKEY", "1")
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(auth, "get_password_hash", lambda: None)
+    monkeypatch.setattr(passkeys, "finish_registration", lambda body, handler: {"ok": True})
+    monkeypatch.setattr(passkeys, "registered_credentials", lambda: [{"id": "local-bootstrap"}])
+
+    handler = RouteFakeHandler()
+    routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/register"))
+
+    assert handler.status == 200
+    assert json.loads(handler.wfile.getvalue()) == {"ok": True, "credentials": [{"id": "local-bootstrap"}]}
+
+
+def test_passkey_registration_requires_valid_session_when_auth_is_enabled(monkeypatch):
+    import api.auth as auth
+    import api.passkeys as passkeys
+    import api.routes as routes
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(auth, "_passkey_feature_flag_enabled", lambda: True)
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+    monkeypatch.setattr(auth, "parse_cookie", lambda handler: None)
+    monkeypatch.setattr(
+        auth,
+        "verify_session",
+        lambda cookie: (_ for _ in ()).throw(AssertionError("verify_session should not be called without a cookie")),
+    )
+    monkeypatch.setattr(
+        passkeys,
+        "registration_options",
+        lambda handler: (_ for _ in ()).throw(AssertionError("registration_options should not be reached")),
+    )
+    monkeypatch.setattr(
+        passkeys,
+        "finish_registration",
+        lambda body, handler: (_ for _ in ()).throw(AssertionError("finish_registration should not be reached")),
+    )
+
+    for path in ("/api/auth/passkey/register/options", "/api/auth/passkey/register"):
+        handler = RouteFakeHandler()
+        routes.handle_post(handler, SimpleNamespace(path=path))
+
+        assert handler.status == 401
+        assert json.loads(handler.wfile.getvalue())["error"] == "Authentication required"
 
 
 def test_auth_status_reports_passkey_availability_source_contract():


### PR DESCRIPTION
## Release PC — v0.51.442

Ships **#4171** (Hinotoi-agent) — `[security]` require auth for passkey enrollment. Nathan-approved security posture; self-rebased onto v0.51.441 and gated fresh (Codex + Opus + full suite).

### Threat closed
On a `HERMES_WEBUI_PASSKEY=1` instance with auth not yet configured, a remote unauthenticated caller could register the **first** passkey credential and claim the account before the legitimate operator — a pre-auth account-takeover on an exposed/tunnelled instance.

### Fix
Gates first-passkey bootstrap exactly like first-password onboarding:
- loopback/private-network requests (or explicit `HERMES_WEBUI_ONBOARDING_OPEN=1`) may bootstrap the first passkey;
- remote/tunnel callers are rejected;
- the locality check uses the **raw socket address** — forwarded headers are ignored unless `HERMES_WEBUI_TRUST_FORWARDED_FOR=1`, so it can't be spoofed via `X-Forwarded-For`/`Host`;
- once auth is enabled, additional enrollment requires a valid authenticated session (real `verify_session()`, not env-presence);
- the passkey **login** path is unchanged.

### Gate results
- **Codex SAFE:** local first-run still works, remote unauth rejected, real session verify, no header-spoof bypass, login untouched.
- **Opus SHIP:** confirmed socket-based locality (loopback-only when untrusted forwarded headers present), HMAC+expiry session check, gate parity with the password flow, no login regression.
- **Full suite:** 17 passkey tests + auth/profile tests green; wider failures are this box's process-group cascade artifact (CI authoritative).

Scope: `api/routes.py` + `tests/test_passkey_auth.py`. Closes #4171.

Co-authored-by: Hinotoi-agent
