### PR TITLE
fix(sessions): invalidate sidebar cache on WAL updates

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1463,7 +1463,10 @@ def _session_list_cache_source_stamp(key: tuple) -> tuple[tuple[int, int], tuple
         state_db_path = Path(_active_state_db_path())
     except Exception:
         state_db_path = None
-    state_db_wal_path = state_db_path.with_name(f"{state_db_path.name}-wal") if state_db_path is not None else None
+    try:
+        state_db_wal_path = state_db_path.with_name(f"{state_db_path.name}-wal") if state_db_path is not None else None
+    except Exception:
+        state_db_wal_path = None
     try:
         gateway_metadata_path = _gateway_session_metadata_path()
     except Exception:
@@ -1472,12 +1475,16 @@ def _session_list_cache_source_stamp(key: tuple) -> tuple[tuple[int, int], tuple
         session_index_path = SESSION_DIR / "_index.json"
     except Exception:
         session_index_path = None
+    try:
+        settings_file = SETTINGS_FILE
+    except Exception:
+        settings_file = None
     return (
         _session_list_cache_path_stamp(state_db_path),
         _session_list_cache_path_stamp(state_db_wal_path),
         _session_list_cache_path_stamp(gateway_metadata_path),
         _session_list_cache_path_stamp(session_index_path),
-        _session_list_cache_path_stamp(SETTINGS_FILE),
+        _session_list_cache_path_stamp(settings_file),
     )
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1455,14 +1455,15 @@ def _session_list_cache_path_stamp(path: Path | None) -> tuple[int, int]:
         return (0, 0)
 
 
-def _session_list_cache_source_stamp(key: tuple) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int]]:
+def _session_list_cache_source_stamp(key: tuple) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int]]:
     _cache_profile, _cache_all_profiles, cache_show_cli_sessions, *_rest = key
     if not cache_show_cli_sessions:
-        return ((0, 0), (0, 0), (0, 0))
+        return ((0, 0), (0, 0), (0, 0), (0, 0), (0, 0))
     try:
         state_db_path = Path(_active_state_db_path())
     except Exception:
         state_db_path = None
+    state_db_wal_path = state_db_path.with_name(f"{state_db_path.name}-wal") if state_db_path is not None else None
     try:
         gateway_metadata_path = _gateway_session_metadata_path()
     except Exception:
@@ -1473,8 +1474,10 @@ def _session_list_cache_source_stamp(key: tuple) -> tuple[tuple[int, int], tuple
         session_index_path = None
     return (
         _session_list_cache_path_stamp(state_db_path),
+        _session_list_cache_path_stamp(state_db_wal_path),
         _session_list_cache_path_stamp(gateway_metadata_path),
         _session_list_cache_path_stamp(session_index_path),
+        _session_list_cache_path_stamp(SETTINGS_FILE),
     )
 
 
@@ -1847,6 +1850,7 @@ from api.config import (
     CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS,
     load_settings,
     save_settings,
+    SETTINGS_FILE,
     set_hermes_default_model,
     model_with_provider_context,
     get_reasoning_status,

--- a/tests/test_session_sidebar_cache.py
+++ b/tests/test_session_sidebar_cache.py
@@ -292,6 +292,70 @@ def test_session_list_cache_rebuild_retries_after_invalidation():
     assert calls == ["build", "build"]
 
 
+def test_session_list_cache_source_stamp_tracks_state_db_wal(tmp_path, monkeypatch):
+    state_db = tmp_path / "state.db"
+    state_db.write_text("db", encoding="utf-8")
+    state_db_wal = tmp_path / "state.db-wal"
+    state_db_wal.write_text("wal-1", encoding="utf-8")
+    gateway = tmp_path / "gateway-sessions.json"
+    gateway.write_text("{}", encoding="utf-8")
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    (session_dir / "_index.json").write_text("{}", encoding="utf-8")
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: str(state_db))
+    monkeypatch.setattr(routes, "_gateway_session_metadata_path", lambda: gateway)
+    monkeypatch.setattr(routes, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(routes, "SETTINGS_FILE", settings_file)
+
+    key = routes._session_list_cache_key(
+        active_profile="default",
+        all_profiles=False,
+        show_cli_sessions=True,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+
+    before = routes._session_list_cache_source_stamp(key)
+    state_db_wal.write_text("wal-2-more", encoding="utf-8")
+    after = routes._session_list_cache_source_stamp(key)
+
+    assert after != before
+
+
+def test_session_list_cache_source_stamp_tracks_settings_file(tmp_path, monkeypatch):
+    state_db = tmp_path / "state.db"
+    state_db.write_text("db", encoding="utf-8")
+    gateway = tmp_path / "gateway-sessions.json"
+    gateway.write_text("{}", encoding="utf-8")
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    (session_dir / "_index.json").write_text("{}", encoding="utf-8")
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text('{"show_cli_sessions": false}', encoding="utf-8")
+
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: str(state_db))
+    monkeypatch.setattr(routes, "_gateway_session_metadata_path", lambda: gateway)
+    monkeypatch.setattr(routes, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(routes, "SETTINGS_FILE", settings_file)
+
+    key = routes._session_list_cache_key(
+        active_profile="default",
+        all_profiles=False,
+        show_cli_sessions=True,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+
+    before = routes._session_list_cache_source_stamp(key)
+    settings_file.write_text('{"show_cli_sessions": true}', encoding="utf-8")
+    after = routes._session_list_cache_source_stamp(key)
+
+    assert after != before
+
+
 def test_session_list_payload_to_response_overlays_live_stream_runtime(monkeypatch):
     payload = {
         "sessions": [


### PR DESCRIPTION
Split from #4133 at maintainer request after the notification-permission fix shipped on its own in #4265.

## Thinking Path
- #4133 bundled a notification-permission UX fix with a separate sidebar-cache invalidation change.
- The maintainer shipped the notification fix independently and asked for the WAL/settings cache invalidation to be reopened as its own PR.
- The session sidebar cache currently stamps the main state DB, gateway metadata, and session index, but WAL-only writes and settings-file updates can leave cached session rows stale until some other stamp changes.

## What Changed
- `api/routes.py`: extend `_session_list_cache_source_stamp()` to include both `state.db-wal` and `SETTINGS_FILE` whenever CLI sessions are part of the cache key.
- `tests/test_session_sidebar_cache.py`: add focused regression tests that prove WAL-file writes and settings-file writes each invalidate the source stamp.

## Why It Matters
This keeps sidebar session rows fresh when SQLite only touches the WAL file or when settings changes alter session visibility. Without those extra stamps, users can keep seeing stale session state behind a warm cache.

## Verification
- `D:\Repos\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_session_sidebar_cache.py tests/test_request_diagnostics_cache.py tests/test_gateway_sync.py -v --timeout=60`
- CI/reviewer context: `pytest tests/ -v --timeout=60`

## Risks / Follow-ups
This only broadens the cache invalidation inputs; it does not change cache lifetime, rebuild logic, or the `/api/sessions` response shape.

## Model Used (AI disclosure)
GPT-5.4 via MiMoCode