### PR TITLE
test(#3664): stabilize Windows-hosted path regressions

### DIFF
--- a/tests/test_1764_context_menu_essentials.py
+++ b/tests/test_1764_context_menu_essentials.py
@@ -274,8 +274,7 @@ class TestFilePathEndpointBehaviour:
         body, status = _post("/api/file/path", {"session_id": sid, "path": "."})
         assert status == 200, body
         assert body.get("ok") is True
-        # Path should be absolute (starts with /).
-        assert body.get("path", "").startswith("/"), body
+        assert Path(body.get("path", "")).is_absolute(), body
 
     def test_does_not_404_on_missing_file(self):
         """Copy-path on a stale-but-recently-deleted file must still

--- a/tests/test_issue1955_worktree_sessions.py
+++ b/tests/test_issue1955_worktree_sessions.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 import time
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -15,6 +16,7 @@ def _isolate_sessions(tmp_path, monkeypatch):
     session_dir.mkdir()
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setenv("GIT_CEILING_DIRECTORIES", str(tmp_path.parent.resolve()))
     SESSIONS.clear()
     yield session_dir
     SESSIONS.clear()
@@ -32,7 +34,7 @@ def test_worktree_metadata_round_trips_through_session_file(_isolate_sessions):
     s.save()
 
     raw = json.loads(s.path.read_text(encoding="utf-8"))
-    assert raw["worktree_path"].endswith(".worktrees/hermes-1234")
+    assert Path(raw["worktree_path"]).as_posix().endswith(".worktrees/hermes-1234")
     assert raw["worktree_branch"] == "hermes/hermes-1234"
     assert raw["worktree_repo_root"].endswith("repo")
     assert raw["worktree_created_at"] == 123.5
@@ -133,7 +135,7 @@ def test_create_worktree_for_workspace_calls_agent_setup_with_repo_root(tmp_path
     info = worktrees.create_worktree_for_workspace(nested)
 
     assert seen["repo_root"] == str(repo.resolve())
-    assert info["path"].endswith(".worktrees/hermes-test")
+    assert Path(info["path"]).as_posix().endswith(".worktrees/hermes-test")
     assert info["branch"] == "hermes/hermes-test"
     assert info["repo_root"] == str(repo.resolve())
     assert info["created_at"] >= now

--- a/tests/test_issue4164_bound_non_git_project_context_walk.py
+++ b/tests/test_issue4164_bound_non_git_project_context_walk.py
@@ -24,10 +24,31 @@ def _ctx(workspace):
     return routes._read_active_project_context(pathlib.Path(workspace))
 
 
-def test_non_git_workspace_does_not_walk_above_workspace(tmp_path):
+def _scoped_git_root(scope_root: pathlib.Path):
+    scope_root = scope_root.resolve()
+
+    def _inner(start: pathlib.Path) -> pathlib.Path | None:
+        current = start.resolve()
+        for parent in [current, *current.parents]:
+            try:
+                parent.relative_to(scope_root)
+            except ValueError:
+                break
+            if (parent / ".git").exists():
+                return parent
+            if parent == scope_root:
+                break
+        return None
+
+    return _inner
+
+
+def test_non_git_workspace_does_not_walk_above_workspace(tmp_path, monkeypatch):
     """Sentinel HERMES.md placed *above* the workspace in a non-git tree must
     not be surfaced — the pre-fix walk would have loaded it because stop_at
     was None and the loop ran to filesystem root."""
+    monkeypatch.setattr(routes, "_project_context_git_root", _scoped_git_root(tmp_path))
+
     above = tmp_path / "outside"
     above.mkdir()
     (above / "HERMES.md").write_text("LEAKED FROM OUTSIDE", encoding="utf-8")
@@ -47,9 +68,11 @@ def test_non_git_workspace_does_not_walk_above_workspace(tmp_path):
     )
 
 
-def test_non_git_workspace_still_reads_in_workspace_context(tmp_path):
+def test_non_git_workspace_still_reads_in_workspace_context(tmp_path, monkeypatch):
     """The bound must only block *parents* — files inside the workspace itself
     must still load exactly as before."""
+    monkeypatch.setattr(routes, "_project_context_git_root", _scoped_git_root(tmp_path))
+
     workspace = tmp_path / "no-git-here"
     workspace.mkdir()
     (workspace / "AGENTS.md").write_text("# In-workspace rules", encoding="utf-8")
@@ -61,11 +84,13 @@ def test_non_git_workspace_still_reads_in_workspace_context(tmp_path):
     assert data["name"] == "AGENTS.md"
 
 
-def test_git_workspace_walk_to_git_root_is_unchanged(tmp_path):
+def test_git_workspace_walk_to_git_root_is_unchanged(tmp_path, monkeypatch):
     """Git workspaces must keep walking up to the git root — the bound only
     activates when git_root is None. This duplicates the pre-existing
     ``test_project_context_walks_hermes_md_to_git_root_but_not_agents_md``
     intent specifically against the #4164 patch site."""
+    monkeypatch.setattr(routes, "_project_context_git_root", _scoped_git_root(tmp_path))
+
     root = tmp_path / "repo"
     nested = root / "src" / "deep" / "pkg"
     nested.mkdir(parents=True)
@@ -78,11 +103,13 @@ def test_git_workspace_walk_to_git_root_is_unchanged(tmp_path):
     assert data["path"].endswith("HERMES.md")
 
 
-def test_non_git_workspace_bound_is_workspace_not_first_parent(tmp_path):
+def test_non_git_workspace_bound_is_workspace_not_first_parent(tmp_path, monkeypatch):
     """Edge case: if the workspace itself contains a HERMES.md AND a parent
     also contains one, the workspace copy must win and the parent copy must
     NOT leak in via the candidate list (i.e. the bound triggers immediately,
     not after one extra parent step)."""
+    monkeypatch.setattr(routes, "_project_context_git_root", _scoped_git_root(tmp_path))
+
     parent = tmp_path / "container"
     parent.mkdir()
     (parent / "HERMES.md").write_text("PARENT COPY", encoding="utf-8")

--- a/tests/test_issue609.py
+++ b/tests/test_issue609.py
@@ -61,10 +61,13 @@ def test_path_outside_boot_default_and_home_is_rejected(monkeypatch, tmp_path):
 
     boot_default = tmp_path / "data" / "workspace"
     boot_default.mkdir(parents=True)
+    home = tmp_path / "home"
+    home.mkdir()
     outside = tmp_path / "other_mount" / "secret"
     outside.mkdir(parents=True)
 
     monkeypatch.setattr(ws_mod, "_BOOT_DEFAULT_WORKSPACE", str(boot_default))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
 
     with pytest.raises(ValueError, match="outside the user home"):
         resolve_trusted_workspace(str(outside))
@@ -95,10 +98,13 @@ def test_path_traversal_via_dotdot_does_not_escape_boot_default(monkeypatch, tmp
 
     boot_default = tmp_path / "data" / "workspace"
     boot_default.mkdir(parents=True)
+    home = tmp_path / "home"
+    home.mkdir()
     sibling = tmp_path / "data" / "private"
     sibling.mkdir(parents=True)
 
     monkeypatch.setattr(ws_mod, "_BOOT_DEFAULT_WORKSPACE", str(boot_default))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
 
     # `boot_default/../private` resolves to `tmp_path/data/private`, which is
     # NOT a child of boot_default and not under home — must reject.

--- a/tests/test_sprint3.py
+++ b/tests/test_sprint3.py
@@ -1,7 +1,11 @@
 """Sprint 3 tests: cron API, skills API, memory API, input validation."""
-import json, uuid, urllib.request, urllib.error
+import json, pathlib, shutil, tempfile, uuid, urllib.request, urllib.error
 
 from tests._pytest_port import BASE
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+OUTSIDE_TRUSTED_ROOT = REPO_ROOT / ".tmp-outside-trusted"
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
@@ -15,6 +19,11 @@ def post(path, body=None):
             return json.loads(r.read()), r.status
     except urllib.error.HTTPError as e:
         return json.loads(e.read()), e.code
+
+
+def make_outside_trusted_dir(prefix):
+    OUTSIDE_TRUSTED_ROOT.mkdir(exist_ok=True)
+    return pathlib.Path(tempfile.mkdtemp(prefix=f"{prefix}-", dir=OUTSIDE_TRUSTED_ROOT))
 
 def make_session_tracked(created_list, ws=None):
     """Create a session and register it with the cleanup fixture."""
@@ -208,21 +217,25 @@ def test_session_update_unknown_id_returns_404():
 def test_session_update_rejects_workspace_outside_trusted_root(tmp_path):
     d, _ = post("/api/session/new", {})
     sid = d["session"]["session_id"]
-    outside = tmp_path / "outside"
-    outside.mkdir(parents=True, exist_ok=True)
-    result, status = post("/api/session/update", {"session_id": sid, "workspace": str(outside)})
-    assert status == 400
-    assert "outside" in result.get("error", "").lower()
+    outside = make_outside_trusted_dir("outside")
+    try:
+        result, status = post("/api/session/update", {"session_id": sid, "workspace": str(outside)})
+        assert status == 400
+        assert "outside" in result.get("error", "").lower()
+    finally:
+        shutil.rmtree(outside, ignore_errors=True)
 
 
 def test_chat_start_rejects_workspace_outside_trusted_root(tmp_path):
     d, _ = post("/api/session/new", {})
     sid = d["session"]["session_id"]
-    outside = tmp_path / "outside-chat"
-    outside.mkdir(parents=True, exist_ok=True)
-    result, status = post("/api/chat/start", {"session_id": sid, "message": "hello", "workspace": str(outside)})
-    assert status == 400
-    assert "outside" in result.get("error", "").lower()
+    outside = make_outside_trusted_dir("outside-chat")
+    try:
+        result, status = post("/api/chat/start", {"session_id": sid, "message": "hello", "workspace": str(outside)})
+        assert status == 400
+        assert "outside" in result.get("error", "").lower()
+    finally:
+        shutil.rmtree(outside, ignore_errors=True)
 
 
 def test_workspace_add_allows_external_valid_paths(tmp_path):
@@ -251,19 +264,23 @@ def test_legacy_chat_rejects_workspace_outside_trusted_root(tmp_path):
     """Legacy /api/chat must use the same trusted workspace validation as /api/chat/start."""
     d, _ = post("/api/session/new", {})
     sid = d["session"]["session_id"]
-    outside = tmp_path / "outside-legacy-chat"
-    outside.mkdir(parents=True, exist_ok=True)
-    result, status = post("/api/chat", {"session_id": sid, "message": "hello", "workspace": str(outside)})
-    assert status == 400
-    assert "outside" in result.get("error", "").lower()
+    outside = make_outside_trusted_dir("outside-legacy-chat")
+    try:
+        result, status = post("/api/chat", {"session_id": sid, "message": "hello", "workspace": str(outside)})
+        assert status == 400
+        assert "outside" in result.get("error", "").lower()
+    finally:
+        shutil.rmtree(outside, ignore_errors=True)
 
 
 def test_session_new_rejects_workspace_outside_trusted_root(tmp_path):
-    outside = tmp_path / "outside-new"
-    outside.mkdir(parents=True, exist_ok=True)
-    result, status = post("/api/session/new", {"workspace": str(outside)})
-    assert status == 400
-    assert "outside" in result.get("error", "").lower()
+    outside = make_outside_trusted_dir("outside-new")
+    try:
+        result, status = post("/api/session/new", {"workspace": str(outside)})
+        assert status == 400
+        assert "outside" in result.get("error", "").lower()
+    finally:
+        shutil.rmtree(outside, ignore_errors=True)
 
 
 def test_session_search_returns_matches(cleanup_test_sessions):

--- a/tests/test_sprint3.py
+++ b/tests/test_sprint3.py
@@ -1,11 +1,10 @@
 """Sprint 3 tests: cron API, skills API, memory API, input validation."""
-import json, pathlib, shutil, tempfile, uuid, urllib.request, urllib.error
+import json, pathlib, shutil, tempfile, urllib.request, urllib.error
 
 from tests._pytest_port import BASE
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
-OUTSIDE_TRUSTED_ROOT = REPO_ROOT / ".tmp-outside-trusted"
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
@@ -22,8 +21,12 @@ def post(path, body=None):
 
 
 def make_outside_trusted_dir(prefix):
-    OUTSIDE_TRUSTED_ROOT.mkdir(exist_ok=True)
-    return pathlib.Path(tempfile.mkdtemp(prefix=f"{prefix}-", dir=OUTSIDE_TRUSTED_ROOT))
+    home_root = pathlib.Path.home().resolve()
+    temp_root = pathlib.Path(tempfile.gettempdir()).resolve()
+    base_root = temp_root if temp_root != home_root and home_root not in (temp_root, *temp_root.parents) else REPO_ROOT
+    outside_root = base_root / ".tmp-outside-trusted"
+    outside_root.mkdir(exist_ok=True)
+    return pathlib.Path(tempfile.mkdtemp(prefix=f"{prefix}-", dir=outside_root))
 
 def make_session_tracked(created_list, ws=None):
     """Create a session and register it with the cleanup fixture."""


### PR DESCRIPTION
## Summary
- normalize Windows-hosted path assertions so regression tests check absolute/trailing path semantics instead of hardcoded POSIX separators
- keep the non-git and worktree regressions scoped to their temp trees instead of leaking ambient home-repo discovery into the tests
- move the live server trust-boundary checks onto paths that are actually outside the test server's home/default workspace on this Windows host

## Testing
- D:\Repos\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_issue609.py tests/test_issue1955_worktree_sessions.py tests/test_issue4164_bound_non_git_project_context_walk.py tests/test_1764_context_menu_essentials.py::TestFilePathEndpointBehaviour::test_returns_absolute_path_for_relative_input tests/test_sprint3.py -q