### PR TITLE
fix(#4277): restore virtualized transcript viewport anchors

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -9442,8 +9442,11 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
 function _maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualWindow){
   if(!preserveScroll||!virtualWindow||!virtualWindow.virtualized||!!(options&&options._virtualFallback)) return false;
   if(_messageViewportIntersectsRenderedRow()) return false;
+  if(_sessionHtmlCacheSid&&S.session&&S.session.session_id===_sessionHtmlCacheSid){
+    _sessionHtmlCache.delete(_sessionHtmlCacheSid);
+  }
   _messageVirtualWindowKey='';
-  renderMessages({...(options||{}),preserveScroll:true,_virtualFallback:true});
+  renderMessages({preserveScroll:true,_virtualFallback:true});
   return true;
 }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -687,6 +687,17 @@ function _restoreMessageViewportAnchor(anchor, rawIdxDelta){
   requestAnimationFrame(()=>{ _programmaticScroll=false; });
   return true;
 }
+function _messageViewportIntersectsRenderedRow(){
+  const container=$('messages');
+  if(!container) return true;
+  const containerRect=container.getBoundingClientRect();
+  const rows=Array.from(container.querySelectorAll('[data-msg-idx]'));
+  for(const row of rows){
+    const rect=row.getBoundingClientRect();
+    if(rect.bottom>containerRect.top+1&&rect.top<containerRect.bottom-1) return true;
+  }
+  return false;
+}
 function _measureMessageVirtualRow(inner, entry){
   if(!inner||!entry) return 0;
   const primary=inner.querySelector(`[data-msg-idx="${entry.rawIdx}"]`);
@@ -9304,6 +9315,7 @@ function _captureMessageScrollSnapshot(){
   if(!el) return null;
   const bottom=Math.max(0,el.scrollHeight-el.scrollTop-el.clientHeight);
   return {
+    anchor:(typeof _captureMessageViewportAnchor==='function')?_captureMessageViewportAnchor():null,
     top:el.scrollTop,
     bottom,
     scrollHeight:el.scrollHeight,
@@ -9315,8 +9327,13 @@ function _restoreMessageScrollSnapshot(snapshot){
   const el=$('messages');
   if(!el||!snapshot) return;
   const maxTop=Math.max(0,el.scrollHeight-el.clientHeight);
-  _programmaticScroll=true;
-  el.scrollTop=Math.max(0,Math.min(Number(snapshot.top)||0,maxTop));
+  const restoredViaAnchor=(snapshot.anchor&&typeof _restoreMessageViewportAnchor==='function')
+    ? _restoreMessageViewportAnchor(snapshot.anchor,0)
+    : false;
+  if(!restoredViaAnchor){
+    _programmaticScroll=true;
+    el.scrollTop=Math.max(0,Math.min(Number(snapshot.top)||0,maxTop));
+  }
   // Sync _lastScrollTop after programmatic restore so sticky-unpin does not false-trigger (#1731).
   _lastScrollTop=el.scrollTop;
   const bottomDistance=el.scrollHeight-el.scrollTop-el.clientHeight;
@@ -9329,7 +9346,9 @@ function _restoreMessageScrollSnapshot(snapshot){
     _scrollPinned=true;
     _nearBottomCount=2;
   }
-  requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+  if(!restoredViaAnchor){
+    requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+  }
 }
 function _restoreMessageScrollSnapshotSameFrame(snapshot){
   const el=$('messages');
@@ -9420,8 +9439,17 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
   scrollToBottom();
 }
 
+function _maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualWindow){
+  if(!preserveScroll||!virtualWindow||!virtualWindow.virtualized||!!(options&&options._virtualFallback)) return false;
+  if(_messageViewportIntersectsRenderedRow()) return false;
+  _messageVirtualWindowKey='';
+  renderMessages({...(options||{}),preserveScroll:true,_virtualFallback:true});
+  return true;
+}
+
 function renderMessages(options){
   const preserveScroll=!!(options&&options.preserveScroll);
+  const virtualFallback=!!(options&&options._virtualFallback);
   // Capture the pre-wipe scroll position when preserving OR when Auto-follow is
   // off and the user has scrolled up — both need to restore the reader's position
   // after the DOM rebuild rather than snap to the bottom. (Codex #4006 r3.)
@@ -9443,7 +9471,9 @@ function renderMessages(options){
   const preservedCompressionTaskMessages=_latestPreservedCompressionTaskListMessages(S.messages);
   const visWithIdx=_getVisibleMessagesWithIdx();
   $('emptyState').style.display=(visWithIdx.length||preservedCompressionTaskMessages.length)?'none':'';
-  const virtualWindow=_currentMessageVirtualWindow(visWithIdx,_messageVirtualKeepTailCount());
+  const virtualWindow=virtualFallback
+    ? {virtualized:false,start:0,end:visWithIdx.length,topPad:0,bottomPad:0,total:visWithIdx.length,tailStart:visWithIdx.length}
+    : _currentMessageVirtualWindow(visWithIdx,_messageVirtualKeepTailCount());
   const renderWindowKey=_messageVirtualWindowKeyFor(virtualWindow);
   const windowStart=virtualWindow.start;
   const windowEnd=virtualWindow.end;
@@ -9479,6 +9509,7 @@ function renderMessages(options){
       _wireMessageWindowLoadEarlierButton();
       if(typeof _applySessionNavigationPrefs==='function') _applySessionNavigationPrefs();
       _scrollAfterMessageRender(preserveScroll, scrollSnapshot);
+      if(_maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualWindow)) return;
       _updateMessageVirtualMeasurements(renderVisWithIdx, renderVisibleIdxs, virtualWindow);
       requestAnimationFrame(()=>postProcessRenderedMessages(inner));
       if(typeof _initMediaPlaybackObserver==='function') _initMediaPlaybackObserver();
@@ -10636,6 +10667,7 @@ function renderMessages(options){
   // scrollIfPinned() respects _scrollPinned, so it's a no-op if user scrolled up.
   if(typeof _syncLiveRunStatusAfterRender==='function') _syncLiveRunStatusAfterRender();
   _scrollAfterMessageRender(preserveScroll, scrollSnapshot);
+  if(_maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualWindow)) return;
   // Apply syntax highlighting after DOM is built
   requestAnimationFrame(()=>postProcessRenderedMessages(inner));
   // Refresh todo panel if it's currently open

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -362,3 +362,44 @@ def test_tool_rows_do_not_carry_message_measurement_hook():
 
     assert "row.dataset.msgIdx" not in build_body
     assert "querySelectorAll(`[data-msg-idx=" not in js
+
+
+def test_viewport_intersection_helper_detects_visible_rendered_rows_only():
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let rows = [];
+const container = {
+  getBoundingClientRect(){ return {top: 100, bottom: 300}; },
+  querySelectorAll(selector){
+    if(selector === '[data-msg-idx]') return rows;
+    return [];
+  },
+};
+function $(id){ return id === 'messages' ? container : null; }
+eval(extractFunc('_messageViewportIntersectsRenderedRow'));
+rows = [
+  { getBoundingClientRect(){ return {top: 10, bottom: 90}; } },
+  { getBoundingClientRect(){ return {top: 320, bottom: 360}; } },
+];
+const blank = _messageViewportIntersectsRenderedRow();
+rows = [
+  { getBoundingClientRect(){ return {top: 120, bottom: 180}; } },
+];
+const visible = _messageViewportIntersectsRenderedRow();
+console.log(JSON.stringify({blank, visible}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["blank"] is False
+    assert metrics["visible"] is True
+
+
+def test_render_messages_has_one_shot_virtual_blank_viewport_fallback():
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    render_start = js.index("function renderMessages(options)")
+    render_end = js.index("function _toolDisplayName", render_start)
+    render_body = js[render_start:render_end]
+
+    assert "const virtualFallback=!!(options&&options._virtualFallback);" in render_body
+    assert "const virtualWindow=virtualFallback" in render_body
+    assert "if(_maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualWindow)) return;" in render_body
+    assert "renderMessages({...(options||{}),preserveScroll:true,_virtualFallback:true});" in js

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -402,4 +402,28 @@ def test_render_messages_has_one_shot_virtual_blank_viewport_fallback():
     assert "const virtualFallback=!!(options&&options._virtualFallback);" in render_body
     assert "const virtualWindow=virtualFallback" in render_body
     assert "if(_maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualWindow)) return;" in render_body
-    assert "renderMessages({...(options||{}),preserveScroll:true,_virtualFallback:true});" in js
+    assert "if(_sessionHtmlCacheSid&&S.session&&S.session.session_id===_sessionHtmlCacheSid){" in js
+    assert "_sessionHtmlCache.delete(_sessionHtmlCacheSid);" in js
+    assert "renderMessages({preserveScroll:true,_virtualFallback:true});" in js
+
+
+def test_virtual_blank_viewport_recovery_evicts_stale_cache_before_fallback():
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let deletes = [];
+let renderCalls = [];
+const _sessionHtmlCache = {
+  delete(sid){ deletes.push(sid); }
+};
+let _sessionHtmlCacheSid = 'sid-123';
+const S = { session: { session_id: 'sid-123' } };
+function _messageViewportIntersectsRenderedRow(){ return false; }
+function renderMessages(options){ renderCalls.push(options); }
+eval(extractFunc('_maybeRecoverVirtualizedBlankViewport'));
+const recovered = _maybeRecoverVirtualizedBlankViewport({preserveScroll:false, someFlag:true}, true, {virtualized:true});
+console.log(JSON.stringify({recovered, deletes, renderCalls}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["recovered"] is True
+    assert metrics["deletes"] == ["sid-123"]
+    assert metrics["renderCalls"] == [{"preserveScroll": True, "_virtualFallback": True}]

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -106,6 +106,7 @@ def test_preserve_scroll_restores_unpinned_viewport_after_dom_rebuild():
     render = _function_body(UI_JS, "function renderMessages")
     after_render = _function_body(UI_JS, "function _scrollAfterMessageRender")
     follow = _function_body(UI_JS, "function _followMessagesAfterDomReplace")
+    capture = _function_body(UI_JS, "function _captureMessageScrollSnapshot")
     restore = _function_body(UI_JS, "function _restoreMessageScrollSnapshot")
 
     snapshot_idx = render.index("const scrollSnapshot=(preserveScroll||(!_autoScrollFollow&&_messageUserUnpinned))?_captureMessageScrollSnapshot():null")
@@ -120,5 +121,8 @@ def test_preserve_scroll_restores_unpinned_viewport_after_dom_rebuild():
     assert "_restoreMessageScrollSnapshot(scrollSnapshot);\n    _maybeShowNewMessageScrollCue(scrollSnapshot);" in after_render
     assert "_shouldFollowMessagesOnDomReplace()" in follow
     assert "scrollToBottom();" in follow
+    assert "anchor:(typeof _captureMessageViewportAnchor==='function')?_captureMessageViewportAnchor():null" in capture
+    assert "_restoreMessageViewportAnchor(snapshot.anchor,0)" in restore
+    assert "if(!restoredViaAnchor){" in restore
     assert "el.scrollTop=Math.max(0,Math.min(Number(snapshot.top)||0,maxTop))" in restore
     assert "_programmaticScroll=true" in restore


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI's long-transcript virtualization is supposed to be an invisible performance optimization, not a new scroll-state failure mode.
- The regression is in viewport restoration, not in message ordering: preserve-scroll restores raw pixels across a DOM rebuild whose spacer geometry is still estimate-driven.
- The safest fix is to anchor preserve-scroll to a real rendered row, then keep a one-shot fallback when a virtualized rerender still lands the reader inside spacer-only space.

## What Changed

- `static/ui.js`: taught preserve-scroll snapshots to carry a semantic viewport anchor, evicts the session HTML cache before blank-viewport recovery, and uses a clean non-virtualized fallback render when the viewport still intersects no rendered message row.
- `tests/test_issue500_message_list_virtualization.py`: added a runtime regression for the blank-viewport recovery path so it proves the stale cache entry is deleted before fallback render runs.
- `tests/test_tars_scroll_reset_regressions.py`: extended the preserve-scroll assertions to pin the new anchor-first restore path.
- Attribution: the implementation follows the maintainer's semantic-anchor plus visible-row-guard direction from [issue #4277](https://github.com/nesquena/hermes-webui/issues/4277#issuecomment-4713480723).

## Why It Matters

This keeps long transcripts readable after replies land: the user stays anchored to real transcript content instead of getting dropped into a blank spacer band until another UI action forces a rerender. It also keeps the fix scoped to viewport preservation rather than turning transcript virtualization into a broader renderer rewrite.

## Verification

```text
D:\Repos\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_issue500_message_list_virtualization.py -v --timeout=60
D:\Repos\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_tars_scroll_reset_regressions.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- The fallback render is intentionally one-shot and preserve-scroll-only so normal transcript virtualization behavior stays unchanged outside the broken case.
- This does not re-scope the assistant-turn anchor RFC into a new transcript owner; it reuses the existing viewport-anchor helpers strictly for scroll restoration.

## Model Used

GPT 5.4 via MiMoCode

## Upstream

Closes #4277.
