### PR TITLE
test(gateway-watcher): fix profile-switch tests' auth-state bleed (full-suite order dependency)

### DIFF
--- a/tests/test_gateway_watcher_profile.py
+++ b/tests/test_gateway_watcher_profile.py
@@ -4,6 +4,8 @@ import json
 import threading
 from urllib.parse import urlparse
 
+import pytest
+
 
 class _FakeHandler:
     def __init__(self):
@@ -27,6 +29,27 @@ class _FakeHandler:
 
     def get_json(self):
         return json.loads(self.body.decode("utf-8"))
+
+
+@pytest.fixture(autouse=True)
+def _disable_auth_for_profile_switch(monkeypatch):
+    """Keep these watcher/profile-switch tests hermetic w.r.t. leaked auth state.
+
+    The /api/profile/switch handler signs the active-profile cookie when auth is
+    enabled (helpers.build_profile_cookie -> auth.sign_profile_cookie_value),
+    which raises -> RuntimeError -> HTTP 409 if there's no active session. A
+    sibling test that enables password/passkey auth in the shared in-process
+    state would otherwise make the switch tests here return 409 instead of 200
+    under a full-suite run (they pass in isolation). Forcing auth OFF for this
+    module makes them order-independent — they exercise watcher restart, not
+    auth. Patch every import site so the value is consistent.
+    """
+    for _mod in ("api.auth", "api.helpers", "api.routes"):
+        try:
+            monkeypatch.setattr(f"{_mod}.is_auth_enabled", lambda: False, raising=False)
+        except Exception:
+            pass
+    yield
 
 
 def test_gateway_watcher_pins_explicit_profile_home(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem
`tests/test_gateway_watcher_profile.py::test_profile_switch_restarts_watcher_best_effort` and `test_profile_switch_response_survives_watcher_restart_failure` **pass in isolation but fail in the full suite** with `assert 409 == 200`.

## Root cause — auth-state bleed
When an auth-enabling sibling test leaves `is_auth_enabled()` True in the shared in-process state, the `/api/profile/switch` handler signs the active-profile cookie: `build_profile_cookie` → `api.auth.sign_profile_cookie_value` raises (no active session) → `RuntimeError` → the handler returns **HTTP 409** instead of 200. These tests assert 200 (auth-disabled path) and so fail order-dependently.

## Fix
An autouse fixture in that module forces `api.auth.is_auth_enabled → False` for its tests — they exercise **watcher restart behavior, not auth**, so disabling auth makes them hermetic and order-independent. Test-only; no app/runtime change.

## Verification
Full suite run clean: **9139 passed, 9 skipped, 0 failed**. The two tests now pass both in isolation and in the full suite (run after auth/passkey tests in the same process). No version stamp (test-only).

> Note: this surfaced while diagnosing the local full-suite ConnectionRefused cascade. The cascade itself is a local process-group signal artifact (the session test-server subprocess gets reaped mid-run when other processes share the launching shell's group) — running pytest under `setsid` eliminates it (own process group), which is how these 2 genuine order-dependent failures became visible. The setsid run method is a launcher change only (no CI impact).