### PR TITLE
fix(#4283): stop recovered turns from replaying into later context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Recovered interrupted turns no longer replay the interrupted prompt into later context rebuilds.** After a gateway restart or tool-iteration abort, the recovered user turn still stays visible once, but state-db/context reconciliation now treats the recovered turn as already represented only when it is the actual aligned prefix row. That keeps later turns from inheriting the old interrupted prompt repeatedly. (#4283)
+
 ### Internal
 
 - **Windows pytest-harness compatibility (#3664).** Hardened the test suite to run on Windows: profile-home fallback paths are path-normalized, strict POSIX file-mode (`0o600`) assertions are gated behind `os.name != "nt"` (Linux still asserts them at full strictness), the conftest cleanup handles Windows process-tree/port teardown and the Py3.12+ `shutil.rmtree` `onexc` shim, and tests that require `fork`/`fcntl` carry `@requires_fork` / `@requires_fcntl` markers (which never skip on Linux). Test-only — no runtime or app behavior change, no Linux CI behavior change. (#4254, #4255, #4256, #4257, #4259, #4263, #4266, #4274)

--- a/api/models.py
+++ b/api/models.py
@@ -4448,18 +4448,18 @@ def state_db_delta_after_context(sidecar_context: list, state_messages: list) ->
 
     # Recovered interrupted turns are special: the visible interruption marker
     # is synthetic, so the recovered user turn should still count as a mirrored
-    # prefix even when it is the only durable row that matches the state DB.
-    allow_single_row_prefix = any(
-        isinstance(msg, dict)
-        and msg.get('_recovered')
-        and str(msg.get('role') or '') == 'user'
-        for msg in sidecar_context
+    # prefix when it is the actual aligned prefix row.
+    allow_single_row_prefix = bool(
+        isinstance(sidecar_context[0], dict)
+        and sidecar_context[0].get('_recovered')
+        and str(sidecar_context[0].get('role') or '') == 'user'
     )
 
     sidecar_keys = [_session_message_content_key(m) for m in sidecar_context]
     state_keys = [_session_message_content_key(m) for m in state_messages]
     max_offset = min(len(sidecar_keys), len(state_keys))
     best_len = 0
+    best_offset = 0
     for offset in range(max_offset):
         length = 0
         while (
@@ -4470,12 +4470,13 @@ def state_db_delta_after_context(sidecar_context: list, state_messages: list) ->
             length += 1
         if length > best_len:
             best_len = length
+            best_offset = offset
 
     # Require at least two mirrored rows. A single repeated short user message
     # is not enough evidence that state.db starts with a mirrored context
     # segment, but small recovered contexts often contain only a compact summary
     # and one follow-up row; those should still use the delta path.
-    if best_len < (1 if allow_single_row_prefix else 2):
+    if best_len < (1 if allow_single_row_prefix and best_offset == 0 else 2):
         return state_messages
 
     # Drop only rows that can be aligned with the remaining sidecar context in

--- a/api/models.py
+++ b/api/models.py
@@ -4446,6 +4446,16 @@ def state_db_delta_after_context(sidecar_context: list, state_messages: list) ->
     if not sidecar_context or not state_messages:
         return state_messages
 
+    # Recovered interrupted turns are special: the visible interruption marker
+    # is synthetic, so the recovered user turn should still count as a mirrored
+    # prefix even when it is the only durable row that matches the state DB.
+    allow_single_row_prefix = any(
+        isinstance(msg, dict)
+        and msg.get('_recovered')
+        and str(msg.get('role') or '') == 'user'
+        for msg in sidecar_context
+    )
+
     sidecar_keys = [_session_message_content_key(m) for m in sidecar_context]
     state_keys = [_session_message_content_key(m) for m in state_messages]
     max_offset = min(len(sidecar_keys), len(state_keys))
@@ -4465,7 +4475,7 @@ def state_db_delta_after_context(sidecar_context: list, state_messages: list) ->
     # is not enough evidence that state.db starts with a mirrored context
     # segment, but small recovered contexts often contain only a compact summary
     # and one follow-up row; those should still use the delta path.
-    if best_len < 2:
+    if best_len < (1 if allow_single_row_prefix else 2):
         return state_messages
 
     # Drop only rows that can be aligned with the remaining sidecar context in

--- a/tests/test_webui_state_db_context_reconciliation.py
+++ b/tests/test_webui_state_db_context_reconciliation.py
@@ -132,6 +132,41 @@ def test_next_webui_turn_context_includes_state_db_external_messages(monkeypatch
     ]
 
 
+def test_state_db_delta_after_context_allows_recovered_turn_prefix():
+    from api.models import state_db_delta_after_context
+
+    sidecar_context = [
+        {
+            "role": "user",
+            "content": "alright gateway restarted, lets give it a live test...",
+            "_recovered": True,
+        },
+        {
+            "role": "assistant",
+            "content": (
+                "**Response interrupted.**\n\n"
+                "The live response stream stopped before this turn finished. "
+                "The user message above was preserved, but no agent output was recovered."
+            ),
+            "_error": True,
+            "type": "interrupted",
+        },
+    ]
+    state_messages = [
+        {
+            "role": "user",
+            "content": "alright gateway restarted, lets give it a live test...",
+            "timestamp": 1.0,
+        },
+        {"role": "assistant", "content": "old assistant", "timestamp": 2.0},
+        {"role": "user", "content": "new prompt", "timestamp": 3.0},
+    ]
+
+    delta = state_db_delta_after_context(sidecar_context, state_messages)
+
+    assert [m.get("content") for m in delta] == ["old assistant", "new prompt"]
+
+
 def test_webui_streaming_normalizes_trailing_prefill_user_before_current_turn(monkeypatch, tmp_path):
     import api.config as config
     import api.models as models

--- a/tests/test_webui_state_db_context_reconciliation.py
+++ b/tests/test_webui_state_db_context_reconciliation.py
@@ -167,6 +167,23 @@ def test_state_db_delta_after_context_allows_recovered_turn_prefix():
     assert [m.get("content") for m in delta] == ["old assistant", "new prompt"]
 
 
+def test_state_db_delta_after_context_does_not_promote_unrelated_prefix_as_recovered():
+    from api.models import state_db_delta_after_context
+
+    sidecar_context = [
+        {"role": "user", "content": "hi", "_recovered": True},
+        {"role": "user", "content": "hello"},
+    ]
+    state_messages = [
+        {"role": "user", "content": "hello", "timestamp": 1.0},
+        {"role": "assistant", "content": "response", "timestamp": 2.0},
+    ]
+
+    delta = state_db_delta_after_context(sidecar_context, state_messages)
+
+    assert [m.get("content") for m in delta] == ["hello", "response"]
+
+
 def test_webui_streaming_normalizes_trailing_prefill_user_before_current_turn(monkeypatch, tmp_path):
     import api.config as config
     import api.models as models


### PR DESCRIPTION

## Summary
A recovered interrupted turn still confuses `state_db_delta_after_context()`, so the next turn can replay the old prompt as if it were fresh context. This target narrows the delta alignment for recovered turns and keeps the recovered prompt visible once without re-prepending it on every later turn.

Closes #4283.

## What Changed
- `api/models.py`: adjust the state-db/context reconciliation so a recovered turn can anchor a one-row prefix instead of falling back to replaying the whole state transcript.
- `tests/test_webui_state_db_context_reconciliation.py`: add a regression that reproduces the recovered-turn shape and proves the later delta no longer includes the old prompt again.
- `CHANGELOG.md`: add an Unreleased fixed-note for the user-visible recovery behavior change.

## Why It Matters
After a gateway restart or tool-iteration abort, the resumed conversation should not keep carrying the interrupted prompt into every future turn. That replay contaminates the model context, wastes tokens, and makes the resumed session behave as if the earlier prompt was re-sent by the user.

## Verification
- Focused pytest on the new context-reconciliation regression.
- Focused pytest on the recovered-turn regression and the unrelated-prefix guard.
- Existing related coverage remains in `tests/test_session_sidecar_repair.py` and `tests/test_webui_state_db_context_reconciliation.py`.

## Risks / Follow-ups
- The exception needs to stay narrow so ordinary sessions still require the existing multi-row prefix match.
- If the regression shows a second recovery shape, fold it into the same helper rather than adding another ad hoc filter.

## Model Used
GPT-5 via Codex CLI
