### PR TITLE
Release PH (v0.51.447): toolset selector shows active-profile defaults (#3100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 - **Windows pytest-harness compatibility (#3664).** Hardened the test suite to run on Windows: profile-home fallback paths are path-normalized, strict POSIX file-mode (`0o600`) assertions are gated behind `os.name != "nt"` (Linux still asserts them at full strictness), the conftest cleanup handles Windows process-tree/port teardown and the Py3.12+ `shutil.rmtree` `onexc` shim, and tests that require `fork`/`fcntl` carry `@requires_fork` / `@requires_fcntl` markers (which never skip on Linux). Test-only — no runtime or app behavior change, no Linux CI behavior change. (#4254, #4255, #4256, #4257, #4259, #4263, #4266, #4274)
 
+## [v0.51.447] — 2026-06-15 — Release PH (toolset selector shows the active profile's defaults)
+
+### Added
+
+- **The composer toolset selector now surfaces the active profile's toolset defaults.** When a conversation has no per-session toolset override it shows "profile defaults" (the toolsets the active profile enables) rather than a generic label, and the dropdown lists the configured MCP servers with their current state plus Apply / "Use profile defaults" controls. Picking toolsets is scoped to the current session only (it never mutates the profile or global config); when no MCP toolsets are configured it falls back cleanly to the global view. The selector appears only when the composer footer has room (wide desktop) and is hidden on narrow desktop and mobile so the footer never crowds. (#3100)
+
 ## [v0.51.446] — 2026-06-15 — Release PG (model picker "show all" for large provider catalogs)
 
 ### Added

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -358,14 +358,19 @@ const LOCALES = {
     usage_personality_none:'none',
     // Session toolsets (#493)
     session_toolsets:'Session Toolsets',
-    session_toolsets_desc:'Restrict available tools for this session (blank = use global config)',
-    session_toolsets_global:'Global (default)',
-    session_toolsets_custom:'Custom',
+    session_toolsets_desc:'Use active profile defaults or choose a custom toolset list for this session',
+    session_toolsets_global:'Active profile defaults',
+    session_toolsets_profile_defaults:'Active profile defaults',
+    session_toolsets_custom:'Custom override',
+    session_toolsets_use_profile_defaults:'Use active profile defaults',
+    session_toolsets_configured_servers:'Configured MCP servers',
+    session_toolsets_loading_servers:'Loading configured servers...',
+    session_toolsets_no_configured_servers:'No configured MCP servers',
     session_toolsets_placeholder:'tool1, tool2, …',
     session_toolsets_apply:'Apply',
-    session_toolsets_clear:'Clear (use global)',
+    session_toolsets_clear:'Use defaults',
     session_toolsets_applied:'Toolsets updated',
-    session_toolsets_cleared:'Toolsets cleared — using global config',
+    session_toolsets_cleared:'Using active profile defaults',
     session_toolsets_failed:'Failed to update toolsets: ',
   untitled:'Untitled',
     no_personalities: 'No personalities found (add them to ~/.hermes/personalities/)',
@@ -1837,14 +1842,19 @@ const LOCALES = {
     usage_personality_none:'nessuna',
     // Session toolsets (#493)
     session_toolsets:'Strumenti Sessione',
-    session_toolsets_desc:'Limita gli strumenti disponibili per questa sessione (vuoto = usa config globale)',
-    session_toolsets_global:'Globale (predefinito)',
-    session_toolsets_custom:'Personalizzato',
+    session_toolsets_desc:'Usa i valori predefiniti del profilo attivo o scegli un elenco di strumenti personalizzato per questa sessione',
+    session_toolsets_global:'Valori predefiniti del profilo attivo',
+    session_toolsets_profile_defaults:'Valori predefiniti del profilo attivo',
+    session_toolsets_custom:'Sostituzione personalizzata',
+    session_toolsets_use_profile_defaults:'Usa valori predefiniti del profilo attivo',
+    session_toolsets_configured_servers:'Server MCP configurati',
+    session_toolsets_loading_servers:'Caricamento server configurati...',
+    session_toolsets_no_configured_servers:'Nessun server MCP configurato',
     session_toolsets_placeholder:'strumento1, strumento2, …',
     session_toolsets_apply:'Applica',
-    session_toolsets_clear:'Pulisci (usa globale)',
+    session_toolsets_clear:'Usa predefiniti',
     session_toolsets_applied:'Strumenti aggiornati',
-    session_toolsets_cleared:'Strumenti azzerati — uso config globale',
+    session_toolsets_cleared:'Uso i valori predefiniti del profilo attivo',
     session_toolsets_failed:'Aggiornamento strumenti fallito: ',
   untitled:'Senza titolo',
     no_personalities: 'Nessuna personalità trovata (aggiungile in ~/.hermes/personalities/)',
@@ -3307,14 +3317,19 @@ const LOCALES = {
     usage_personality_none:'なし',
     // Session toolsets (#493)
     session_toolsets:'セッションツールセット',
-    session_toolsets_desc:'このセッションで利用可能なツールを制限 (空欄=グローバル設定を使用)',
-    session_toolsets_global:'グローバル (デフォルト)',
-    session_toolsets_custom:'カスタム',
+    session_toolsets_desc:'アクティブなプロファイルのデフォルトを使うか、このセッション用のカスタムツールセットを選択します',
+    session_toolsets_global:'アクティブプロファイルのデフォルト',
+    session_toolsets_profile_defaults:'アクティブプロファイルのデフォルト',
+    session_toolsets_custom:'カスタム上書き',
+    session_toolsets_use_profile_defaults:'アクティブプロファイルのデフォルトを使用',
+    session_toolsets_configured_servers:'設定済みMCPサーバー',
+    session_toolsets_loading_servers:'設定済みサーバーを読み込み中...',
+    session_toolsets_no_configured_servers:'設定済みMCPサーバーはありません',
     session_toolsets_placeholder:'tool1, tool2, …',
     session_toolsets_apply:'適用',
-    session_toolsets_clear:'クリア (グローバルを使用)',
+    session_toolsets_clear:'デフォルトを使用',
     session_toolsets_applied:'ツールセットを更新しました',
-    session_toolsets_cleared:'ツールセットをクリアしました — グローバル設定を使用',
+    session_toolsets_cleared:'アクティブプロファイルのデフォルトを使用しています',
     session_toolsets_failed:'ツールセット更新失敗: ',
   untitled:'無題',
     no_personalities: 'パーソナリティが見つかりません (~/.hermes/personalities/ に追加してください)',
@@ -4694,14 +4709,19 @@ const LOCALES = {
     model_search_placeholder: 'Поиск моделей…',
     model_scope_advisory: 'Применяется к этой беседе со следующего сообщения.',
     session_toolsets: 'Session Toolsets', // TODO: translate
-    session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
-    session_toolsets_global: 'Global (default)', // TODO: translate
-    session_toolsets_custom: 'Custom', // TODO: translate
+    session_toolsets_desc: 'Use active profile defaults or choose a custom toolset list for this session', // TODO: translate
+    session_toolsets_global: 'Active profile defaults', // TODO: translate
+    session_toolsets_profile_defaults: 'Active profile defaults', // TODO: translate
+    session_toolsets_custom: 'Custom override', // TODO: translate
+    session_toolsets_use_profile_defaults: 'Use active profile defaults', // TODO: translate
+    session_toolsets_configured_servers: 'Configured MCP servers', // TODO: translate
+    session_toolsets_loading_servers: 'Loading configured servers...', // TODO: translate
+    session_toolsets_no_configured_servers: 'No configured MCP servers', // TODO: translate
     session_toolsets_placeholder: 'tool1, tool2, \u2026', // TODO: translate
     session_toolsets_apply: 'Apply', // TODO: translate
-    session_toolsets_clear: 'Clear (use global)', // TODO: translate
+    session_toolsets_clear: 'Use defaults', // TODO: translate
     session_toolsets_applied: 'Toolsets updated', // TODO: translate
-    session_toolsets_cleared: 'Toolsets cleared — using global config', // TODO: translate
+    session_toolsets_cleared: 'Using active profile defaults', // TODO: translate
     session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
     model_scope_toast: 'Применяется к этой беседе со следующего сообщения.',
     reference_only_label: 'Только справка',
@@ -6008,14 +6028,19 @@ const LOCALES = {
     workspace_worktree_failed: 'Error al crear worktree: ',
     session_worktree_badge: 'Worktree',
     session_toolsets: 'Session Toolsets', // TODO: translate
-    session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
-    session_toolsets_global: 'Global (default)', // TODO: translate
-    session_toolsets_custom: 'Custom', // TODO: translate
+    session_toolsets_desc: 'Use active profile defaults or choose a custom toolset list for this session', // TODO: translate
+    session_toolsets_global: 'Active profile defaults', // TODO: translate
+    session_toolsets_profile_defaults: 'Active profile defaults', // TODO: translate
+    session_toolsets_custom: 'Custom override', // TODO: translate
+    session_toolsets_use_profile_defaults: 'Use active profile defaults', // TODO: translate
+    session_toolsets_configured_servers: 'Configured MCP servers', // TODO: translate
+    session_toolsets_loading_servers: 'Loading configured servers...', // TODO: translate
+    session_toolsets_no_configured_servers: 'No configured MCP servers', // TODO: translate
     session_toolsets_placeholder: 'tool1, tool2, \u2026', // TODO: translate
     session_toolsets_apply: 'Apply', // TODO: translate
-    session_toolsets_clear: 'Clear (use global)', // TODO: translate
+    session_toolsets_clear: 'Use defaults', // TODO: translate
     session_toolsets_applied: 'Toolsets updated', // TODO: translate
-    session_toolsets_cleared: 'Toolsets cleared — using global config', // TODO: translate
+    session_toolsets_cleared: 'Using active profile defaults', // TODO: translate
     session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
     model_scope_advisory: 'Se aplica a esta conversación desde tu próximo mensaje.',
     model_scope_toast: 'Se aplica a esta conversación desde tu próximo mensaje.',
@@ -8236,14 +8261,19 @@ const LOCALES = {
     workspace_worktree_failed: 'Worktree-Erstellung fehlgeschlagen: ',
     session_worktree_badge: 'Worktree',
     session_toolsets: 'Session Toolsets', // TODO: translate
-    session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
-    session_toolsets_global: 'Global (default)', // TODO: translate
-    session_toolsets_custom: 'Custom', // TODO: translate
+    session_toolsets_desc: 'Use active profile defaults or choose a custom toolset list for this session', // TODO: translate
+    session_toolsets_global: 'Active profile defaults', // TODO: translate
+    session_toolsets_profile_defaults: 'Active profile defaults', // TODO: translate
+    session_toolsets_custom: 'Custom override', // TODO: translate
+    session_toolsets_use_profile_defaults: 'Use active profile defaults', // TODO: translate
+    session_toolsets_configured_servers: 'Configured MCP servers', // TODO: translate
+    session_toolsets_loading_servers: 'Loading configured servers...', // TODO: translate
+    session_toolsets_no_configured_servers: 'No configured MCP servers', // TODO: translate
     session_toolsets_placeholder: 'tool1, tool2, \u2026', // TODO: translate
     session_toolsets_apply: 'Apply', // TODO: translate
-    session_toolsets_clear: 'Clear (use global)', // TODO: translate
+    session_toolsets_clear: 'Use defaults', // TODO: translate
     session_toolsets_applied: 'Toolsets updated', // TODO: translate
-    session_toolsets_cleared: 'Toolsets cleared — using global config', // TODO: translate
+    session_toolsets_cleared: 'Using active profile defaults', // TODO: translate
     session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
     session_time_unknown: 'Unbekannt',
     session_time_minutes_ago: (n) => `Vor ${n} Minuten`,
@@ -8824,14 +8854,19 @@ const LOCALES = {
     workspace_worktree_failed: 'Worktree 创建失败：',
     session_worktree_badge: 'Worktree',
     session_toolsets: 'Session 工具集',
-    session_toolsets_desc: '限制此会话可用工具（留空 = 使用全局配置）',
-    session_toolsets_global: '全局（默认）',
-    session_toolsets_custom: '自定义',
+    session_toolsets_desc: '使用当前配置档默认工具，或为此会话选择自定义工具集',
+    session_toolsets_global: '当前配置档默认',
+    session_toolsets_profile_defaults: '当前配置档默认',
+    session_toolsets_custom: '自定义覆盖',
+    session_toolsets_use_profile_defaults: '使用当前配置档默认',
+    session_toolsets_configured_servers: '已配置 MCP 服务器',
+    session_toolsets_loading_servers: '正在加载已配置服务器...',
+    session_toolsets_no_configured_servers: '没有已配置的 MCP 服务器',
     session_toolsets_placeholder: 'tool1, tool2, …', // 保持英文——这是占位符示例
     session_toolsets_apply: '应用',
-    session_toolsets_clear: '清除（使用全局）',
+    session_toolsets_clear: '使用默认',
     session_toolsets_applied: '工具集已更新',
-    session_toolsets_cleared: '工具集已清除 — 使用全局配置',
+    session_toolsets_cleared: '正在使用当前配置档默认',
     session_toolsets_failed: '更新工具集失败：',
     model_scope_advisory: '从下一条消息起应用于当前对话。',
     model_scope_toast: '从下一条消息起应用于当前对话。',
@@ -10414,14 +10449,19 @@ const LOCALES = {
     usage_personality_none: '無',
     // Session toolsets (#493)
     session_toolsets: '對話工具集',
-    session_toolsets_desc: '限制此對話可用的工具（留空即使用全域設定）',
-    session_toolsets_global: '全域（預設）',
-    session_toolsets_custom: '自訂',
+    session_toolsets_desc: '使用目前設定檔預設工具，或為此對話選擇自訂工具集',
+    session_toolsets_global: '目前設定檔預設',
+    session_toolsets_profile_defaults: '目前設定檔預設',
+    session_toolsets_custom: '自訂覆寫',
+    session_toolsets_use_profile_defaults: '使用目前設定檔預設',
+    session_toolsets_configured_servers: '已設定 MCP 伺服器',
+    session_toolsets_loading_servers: '正在載入已設定伺服器...',
+    session_toolsets_no_configured_servers: '沒有已設定的 MCP 伺服器',
     session_toolsets_placeholder: 'tool1, tool2, …',
     session_toolsets_apply: '套用',
-    session_toolsets_clear: '清除（使用全域）',
+    session_toolsets_clear: '使用預設',
     session_toolsets_applied: '工具集已更新',
-    session_toolsets_cleared: '工具集已清除，改用全域設定',
+    session_toolsets_cleared: '正在使用目前設定檔預設',
     session_toolsets_failed: '更新工具集失敗：',
     untitled: '未命名',
     no_personalities: '找不到角色（可新增至 ~/.hermes/personalities/）',
@@ -11630,14 +11670,19 @@ const LOCALES = {
     model_show_all_models: 'Mostrar todos os {0} modelos',
     model_search_placeholder: 'Buscar modelos…',
     session_toolsets: 'Session Toolsets', // TODO: translate
-    session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
-    session_toolsets_global: 'Global (default)', // TODO: translate
-    session_toolsets_custom: 'Custom', // TODO: translate
+    session_toolsets_desc: 'Use active profile defaults or choose a custom toolset list for this session', // TODO: translate
+    session_toolsets_global: 'Active profile defaults', // TODO: translate
+    session_toolsets_profile_defaults: 'Active profile defaults', // TODO: translate
+    session_toolsets_custom: 'Custom override', // TODO: translate
+    session_toolsets_use_profile_defaults: 'Use active profile defaults', // TODO: translate
+    session_toolsets_configured_servers: 'Configured MCP servers', // TODO: translate
+    session_toolsets_loading_servers: 'Loading configured servers...', // TODO: translate
+    session_toolsets_no_configured_servers: 'No configured MCP servers', // TODO: translate
     session_toolsets_placeholder: 'tool1, tool2, \u2026', // TODO: translate
     session_toolsets_apply: 'Apply', // TODO: translate
-    session_toolsets_clear: 'Clear (use global)', // TODO: translate
+    session_toolsets_clear: 'Use defaults', // TODO: translate
     session_toolsets_applied: 'Toolsets updated', // TODO: translate
-    session_toolsets_cleared: 'Toolsets cleared — using global config', // TODO: translate
+    session_toolsets_cleared: 'Using active profile defaults', // TODO: translate
     session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
     model_search_no_results: 'Nenhum modelo encontrado',
     model_group_configured: 'Configurados',
@@ -12978,14 +13023,19 @@ const LOCALES = {
     model_show_all_models: '{0}개 모델 모두 보기',
     model_search_placeholder: 'Search models…',
     session_toolsets: 'Session Toolsets', // TODO: translate
-    session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
-    session_toolsets_global: 'Global (default)', // TODO: translate
-    session_toolsets_custom: 'Custom', // TODO: translate
+    session_toolsets_desc: 'Use active profile defaults or choose a custom toolset list for this session', // TODO: translate
+    session_toolsets_global: 'Active profile defaults', // TODO: translate
+    session_toolsets_profile_defaults: 'Active profile defaults', // TODO: translate
+    session_toolsets_custom: 'Custom override', // TODO: translate
+    session_toolsets_use_profile_defaults: 'Use active profile defaults', // TODO: translate
+    session_toolsets_configured_servers: 'Configured MCP servers', // TODO: translate
+    session_toolsets_loading_servers: 'Loading configured servers...', // TODO: translate
+    session_toolsets_no_configured_servers: 'No configured MCP servers', // TODO: translate
     session_toolsets_placeholder: 'tool1, tool2, \u2026', // TODO: translate
     session_toolsets_apply: 'Apply', // TODO: translate
-    session_toolsets_clear: 'Clear (use global)', // TODO: translate
+    session_toolsets_clear: 'Use defaults', // TODO: translate
     session_toolsets_applied: 'Toolsets updated', // TODO: translate
-    session_toolsets_cleared: 'Toolsets cleared — using global config', // TODO: translate
+    session_toolsets_cleared: 'Using active profile defaults', // TODO: translate
     session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
     model_search_no_results: 'No models found',
     model_group_configured: '구성됨',
@@ -14546,14 +14596,19 @@ const LOCALES = {
     status_unknown: 'Inconnu',
     usage_personality_none: 'aucun',
     session_toolsets: 'Ensembles d\'outils de session',
-    session_toolsets_desc: 'Restreindre les outils disponibles pour cette session (vide = utiliser la configuration globale)',
-    session_toolsets_global: 'Global (par défaut)',
-    session_toolsets_custom: 'Coutume',
+    session_toolsets_desc: 'Utiliser les valeurs par défaut du profil actif ou choisir une liste personnalisée pour cette session',
+    session_toolsets_global: 'Valeurs par défaut du profil actif',
+    session_toolsets_profile_defaults: 'Valeurs par défaut du profil actif',
+    session_toolsets_custom: 'Remplacement personnalisé',
+    session_toolsets_use_profile_defaults: 'Utiliser les valeurs par défaut du profil actif',
+    session_toolsets_configured_servers: 'Serveurs MCP configurés',
+    session_toolsets_loading_servers: 'Chargement des serveurs configurés...',
+    session_toolsets_no_configured_servers: 'Aucun serveur MCP configuré',
     session_toolsets_placeholder: 'outil1, outil2, …',
     session_toolsets_apply: 'Appliquer',
-    session_toolsets_clear: 'Effacer (utiliser global)',
+    session_toolsets_clear: 'Utiliser les valeurs par défaut',
     session_toolsets_applied: 'Ensembles d\'outils mis à jour',
-    session_toolsets_cleared: 'Ensembles d\'outils effacés - à l\'aide de la configuration globale',
+    session_toolsets_cleared: 'Utilisation des valeurs par défaut du profil actif',
     session_toolsets_failed: 'Échec de la mise à jour des ensembles d\'outils :',
     no_personalities: 'Aucune personnalité trouvée (ajoutez-les à ~/.hermes/personalities/)',
     available_personalities: 'Personnalités disponibles :',
@@ -15857,14 +15912,19 @@ const LOCALES = {
     model_show_all_models: '{0} modelin tümünü göster',
     model_search_placeholder: 'Modelleri ara\u2026',
     session_toolsets: 'Oturum araç setleri',
-    session_toolsets_desc: 'Bu oturum için kullanılabilir araçları kısıtlayın (boş = genel yapılandırma)',
-    session_toolsets_global: 'Genel (varsayılan)',
-    session_toolsets_custom: 'Özel',
+    session_toolsets_desc: 'Etkin profil varsayılanlarını kullanın veya bu oturum için özel araç seti listesi seçin',
+    session_toolsets_global: 'Etkin profil varsayılanları',
+    session_toolsets_profile_defaults: 'Etkin profil varsayılanları',
+    session_toolsets_custom: 'Özel geçersiz kılma',
+    session_toolsets_use_profile_defaults: 'Etkin profil varsayılanlarını kullan',
+    session_toolsets_configured_servers: 'Yapılandırılmış MCP sunucuları',
+    session_toolsets_loading_servers: 'Yapılandırılmış sunucular yükleniyor...',
+    session_toolsets_no_configured_servers: 'Yapılandırılmış MCP sunucusu yok',
     session_toolsets_placeholder: 'araç1, araç2, \u2026',
     session_toolsets_apply: 'Uygula',
-    session_toolsets_clear: 'Temizle (geneli kullan)',
+    session_toolsets_clear: 'Varsayılanları kullan',
     session_toolsets_applied: 'Araç setleri güncellendi',
-    session_toolsets_cleared: 'Araç setleri temizlendi — genel yapılandırma kullanılıyor',
+    session_toolsets_cleared: 'Etkin profil varsayılanları kullanılıyor',
     session_toolsets_failed: 'Araç setleri güncellenemedi: ',
     model_search_no_results: 'Hiçbir model bulunamadı',
     model_group_configured: 'Yapılandırılmış',
@@ -17441,6 +17501,11 @@ const LOCALES = {
     forked_from: 'Rozgałęzione z',
     subagent_children: 'Sesje subagentów',
     model_show_all_models: 'Pokaż wszystkie {0} modele',
+    session_toolsets_profile_defaults: 'Domyślne ustawienia aktywnego profilu',
+    session_toolsets_use_profile_defaults: 'Użyj domyślnych ustawień aktywnego profilu',
+    session_toolsets_configured_servers: 'Skonfigurowane serwery MCP',
+    session_toolsets_loading_servers: 'Ładowanie skonfigurowanych serwerów...',
+    session_toolsets_no_configured_servers: 'Brak skonfigurowanych serwerów MCP',
     insights_model_health_title: 'Porównanie kondycji modeli',
     insights_model_health_provider: 'Dostawca',
     insights_model_health_replacement: 'Przewodnik zastąpienia',

--- a/static/panels.js
+++ b/static/panels.js
@@ -8672,10 +8672,16 @@ function toggleMcpServer(name, enabled){
     method:'PATCH',
     body:JSON.stringify({enabled:enabled}),
   }).then(r=>{
-    if(r&&r.ok) showToast(t(enabled?'mcp_enabled_toast':'mcp_disabled_toast',name));
+    if(r&&r.ok){
+      _refreshMcpToolsetsCatalog();
+      showToast(t(enabled?'mcp_enabled_toast':'mcp_disabled_toast',name));
+    }
     else showToast(t('mcp_toggle_failed'),'error');
     loadMcpServers();
   }).catch(()=>{showToast(t('mcp_toggle_failed'),'error');loadMcpServers();});
+}
+function _refreshMcpToolsetsCatalog(payload){
+  if(typeof window.invalidateToolsetsCatalog==='function') window.invalidateToolsetsCatalog(payload);
 }
 function loadMcpServers(){
   const list=$('mcpServerList');
@@ -8683,6 +8689,7 @@ function loadMcpServers(){
   list.innerHTML=`<div style="color:var(--muted);font-size:12px;padding:6px 0">${esc(t('loading'))}</div>`;
   api('/api/mcp/servers').then(r=>{
     if(!r||!Array.isArray(r.servers)) return;
+    _refreshMcpToolsetsCatalog(r);
     if(!r.servers.length){
       list.innerHTML=`<div class="mcp-empty-state" style="color:var(--muted);font-size:12px;padding:6px 0">${esc(t('mcp_no_servers'))}</div>`;
       return;

--- a/static/ui.js
+++ b/static/ui.js
@@ -2742,7 +2742,8 @@ document.addEventListener('click',function(e){
 });
 
 // ── Session toolsets chip (#493) ───────────────────────────────────────────
-let _currentSessionToolsets = null; // null = global, array = custom list
+let _currentSessionToolsets = null; // null = active profile defaults, array = custom list
+let _toolsetsCatalog = null;
 
 function _applyToolsetsChip(toolsets) {
   _currentSessionToolsets = toolsets;
@@ -2764,9 +2765,9 @@ function _applyToolsetsChip(toolsets) {
     chip.classList.add('has-custom');
     chip.title = t('session_toolsets') + ': ' + toolsets.join(', ');
   } else {
-    label.textContent = t('session_toolsets_global');
+    label.textContent = t('session_toolsets_profile_defaults');
     chip.classList.remove('has-custom');
-    chip.title = t('session_toolsets');
+    chip.title = t('session_toolsets') + ': ' + t('session_toolsets_profile_defaults');
   }
 }
 
@@ -2782,6 +2783,115 @@ function syncToolsetsChip() {
   _syncToolsetsChip();
 }
 
+function _normalizeToolsetsCatalog(payload) {
+  const servers = payload && Array.isArray(payload.servers) ? payload.servers : [];
+  const seen = new Set();
+  const names = [];
+  servers.forEach(function(server) {
+    const name = String((server && server.name) || '').trim();
+    if (!name || seen.has(name)) return;
+    seen.add(name);
+    names.push(name);
+  });
+  return names;
+}
+
+function _loadToolsetsCatalog() {
+  if (Array.isArray(_toolsetsCatalog)) return Promise.resolve(_toolsetsCatalog);
+  return api('/api/mcp/servers')
+    .then(function(payload) {
+      _toolsetsCatalog = _normalizeToolsetsCatalog(payload);
+      return _toolsetsCatalog;
+    })
+    .catch(function() {
+      _toolsetsCatalog = false;
+      return [];
+    });
+}
+
+function invalidateToolsetsCatalog(payload) {
+  _toolsetsCatalog = payload && Array.isArray(payload.servers) ? _normalizeToolsetsCatalog(payload) : null;
+}
+if (typeof window !== 'undefined') window.invalidateToolsetsCatalog = invalidateToolsetsCatalog;
+
+function _toolsetsInputList(input) {
+  if (!input) return [];
+  return input.value.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+function _ensureToolsetsPresetSection() {
+  const dd = $('composerToolsetsDropdown');
+  if (!dd) return null;
+  let section = $('toolsetsPresetSections');
+  if (section) return section;
+  section = document.createElement('div');
+  section.id = 'toolsetsPresetSections';
+  section.className = 'toolsets-preset-sections';
+  const inputRow = dd.querySelector('.toolsets-dropdown-input-row');
+  if (inputRow) dd.insertBefore(section, inputRow);
+  else dd.appendChild(section);
+  return section;
+}
+
+function _appendToolsetsLabel(section, text) {
+  const label = document.createElement('div');
+  label.className = 'toolsets-dropdown-desc';
+  label.textContent = text;
+  section.appendChild(label);
+}
+
+function _renderToolsetsPresetSections(opts) {
+  const state = opts && opts.state;
+  const input = opts && opts.input;
+  const section = _ensureToolsetsPresetSection();
+  if (!section || !state || !input) return;
+  const selected = _toolsetsInputList(input);
+  const selectedSet = new Set(selected);
+  const hasCustom = selected.length > 0;
+  state.textContent = hasCustom
+    ? '🔧 ' + selected.join(', ')
+    : '👤 ' + t('session_toolsets_profile_defaults');
+
+  section.innerHTML = '';
+  const defaultsBtn = document.createElement('button');
+  defaultsBtn.type = 'button';
+  defaultsBtn.id = 'toolsetsProfileDefaultsBtn';
+  defaultsBtn.className = 'toolsets-action-btn toolsets-clear-btn';
+  defaultsBtn.textContent = t('session_toolsets_use_profile_defaults');
+  section.appendChild(defaultsBtn);
+
+  _appendToolsetsLabel(section, t('session_toolsets_configured_servers'));
+  if (_toolsetsCatalog === null) {
+    _appendToolsetsLabel(section, t('session_toolsets_loading_servers'));
+    return;
+  }
+  if (_toolsetsCatalog === false) {
+    _appendToolsetsLabel(section, t('mcp_load_failed'));
+    return;
+  }
+  if (!Array.isArray(_toolsetsCatalog) || !_toolsetsCatalog.length) {
+    _appendToolsetsLabel(section, t('session_toolsets_no_configured_servers'));
+    return;
+  }
+  _toolsetsCatalog.forEach(function(name) {
+    const row = document.createElement('label');
+    row.className = 'toolsets-server-option';
+    row.style.display = 'flex';
+    row.style.alignItems = 'center';
+    row.style.gap = '6px';
+    row.style.margin = '4px 0';
+    row.style.fontSize = '12px';
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.className = 'toolsets-server-checkbox';
+    checkbox.value = name;
+    checkbox.checked = selectedSet.has(name);
+    row.appendChild(checkbox);
+    row.appendChild(document.createTextNode(name));
+    section.appendChild(row);
+  });
+}
+
 function _populateToolsetsDropdown() {
   const desc = $('toolsetsDropdownDesc');
   const state = $('toolsetsDropdownState');
@@ -2795,14 +2905,14 @@ function _populateToolsetsDropdown() {
   input.placeholder = t('session_toolsets_placeholder');
   // Escape key handler for toolsets input
   input.onkeydown = function(e) { if(e.key === 'Escape') closeToolsetsDropdown(); };
+  input.oninput = function() { _renderToolsetsPresetSections({ state, input }); };
   const hasCustom = Array.isArray(_currentSessionToolsets) && _currentSessionToolsets.length > 0;
   if (hasCustom) {
-    state.textContent = '🔧 ' + _currentSessionToolsets.join(', ');
     input.value = _currentSessionToolsets.join(', ');
   } else {
-    state.textContent = '🌍 ' + t('session_toolsets_global');
     input.value = '';
   }
+  _renderToolsetsPresetSections({ state, input });
 }
 
 function _positionToolsetsDropdown() {
@@ -2838,6 +2948,14 @@ function toggleToolsetsDropdown() {
   if (typeof closeReasoningDropdown === 'function') closeReasoningDropdown();
   _syncToolsetsChip();
   _populateToolsetsDropdown();
+  _loadToolsetsCatalog().then(function() {
+    const stillOpen = dd && dd.classList.contains('open');
+    if (stillOpen) {
+      const state = $('toolsetsDropdownState');
+      const input = $('toolsetsInput');
+      _renderToolsetsPresetSections({ state, input });
+    }
+  });
   dd.classList.add('open');
   _positionToolsetsDropdown();
   chip.classList.add('active');
@@ -2883,6 +3001,12 @@ document.addEventListener('click', function(e) {
     !e.target.closest('#composerToolsetsChip') &&
     !e.target.closest('#composerToolsetsDropdown')
   ) closeToolsetsDropdown();
+  // Active profile defaults button
+  if (e.target.closest('#toolsetsProfileDefaultsBtn')) {
+    _applySessionToolsets(null);
+    closeToolsetsDropdown();
+    return;
+  }
   // Apply button
   if (e.target.closest('#toolsetsApplyBtn')) {
     const input = $('toolsetsInput');
@@ -2905,6 +3029,21 @@ document.addEventListener('click', function(e) {
     _applySessionToolsets(null);
     closeToolsetsDropdown();
   }
+});
+
+document.addEventListener('change', function(e) {
+  if (!e.target.closest('#toolsetsPresetSections')) return;
+  if (!e.target.classList.contains('toolsets-server-checkbox')) return;
+  const input = $('toolsetsInput');
+  const state = $('toolsetsDropdownState');
+  if (!input) return;
+  const checked = Array.from(document.querySelectorAll('#toolsetsPresetSections .toolsets-server-checkbox:checked'))
+    .map(el => String(el.value || '').trim())
+    .filter(Boolean);
+  const catalogSet = new Set(Array.isArray(_toolsetsCatalog) ? _toolsetsCatalog : []);
+  const manual = _toolsetsInputList(input).filter(name => !catalogSet.has(name));
+  input.value = checked.concat(manual).join(', ');
+  _renderToolsetsPresetSections({ state, input });
 });
 
 // Position toolsets dropdown on resize, OR close it if the chip is no longer

--- a/tests/test_issue3100_profile_toolsets_affordance.py
+++ b/tests/test_issue3100_profile_toolsets_affordance.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+PANELS_JS = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
+I18N_JS = (REPO / "static" / "i18n.js").read_text(encoding="utf-8")
+INDEX_HTML = (REPO / "static" / "index.html").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.index(signature)
+    brace = src.index("{", start)
+    depth = 0
+    for i in range(brace, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise AssertionError(f"function body not found: {signature}")
+
+
+def test_toolsets_dropdown_fetches_configured_mcp_server_names():
+    load = _function_body(UI_JS, "function _loadToolsetsCatalog")
+    normalize = _function_body(UI_JS, "function _normalizeToolsetsCatalog")
+    toggle = _function_body(UI_JS, "function toggleToolsetsDropdown")
+
+    assert "api('/api/mcp/servers')" in load
+    assert "payload.servers" in normalize
+    assert "server.name" in normalize
+    assert "_toolsetsCatalog = false;" in load
+    assert "return [];" in load
+    assert "_loadToolsetsCatalog().then(function()" in toggle
+
+
+def test_async_catalog_refresh_preserves_manual_toolset_input():
+    toggle = _function_body(UI_JS, "function toggleToolsetsDropdown")
+
+    assert "const state = $('toolsetsDropdownState');" in toggle
+    assert "const input = $('toolsetsInput');" in toggle
+    assert "_renderToolsetsPresetSections({ state, input });" in toggle
+
+
+def test_null_state_is_labeled_as_active_profile_defaults():
+    apply_chip = _function_body(UI_JS, "function _applyToolsetsChip")
+    render_sections = _function_body(UI_JS, "function _renderToolsetsPresetSections")
+
+    assert "null = active profile defaults" in UI_JS
+    assert "session_toolsets_profile_defaults" in apply_chip
+    assert "session_toolsets_global" not in apply_chip
+    assert "session_toolsets_profile_defaults" in render_sections
+    assert "Global (default)" not in I18N_JS
+
+
+def test_profile_default_action_saves_null_override():
+    click_start = UI_JS.index("document.addEventListener('click', function(e)")
+    clear_start = UI_JS.index("if (e.target.closest('#toolsetsClearBtn'))")
+    click_block = UI_JS[click_start : UI_JS.index("});", clear_start) + 3]
+
+    assert "toolsetsProfileDefaultsBtn" in UI_JS
+    assert "session_toolsets_use_profile_defaults" in UI_JS
+    assert "if (e.target.closest('#toolsetsProfileDefaultsBtn'))" in click_block
+    assert "_applySessionToolsets(null);" in click_block
+    assert "static/index.html" not in UI_JS
+    assert "toolsetsProfileDefaultsBtn" not in INDEX_HTML
+
+
+def test_custom_checkbox_and_manual_selection_reuse_existing_apply_path():
+    render_sections = _function_body(UI_JS, "function _renderToolsetsPresetSections")
+    change_start = UI_JS.index("document.addEventListener('change', function(e)")
+    change_block = UI_JS[change_start : UI_JS.index("});", change_start) + 3]
+    click_start = UI_JS.index("document.addEventListener('click', function(e)")
+    apply_block = UI_JS[click_start : UI_JS.index("// Clear button", click_start)]
+
+    assert "toolsets-server-checkbox" in render_sections
+    assert "checkbox.value = name" in render_sections
+    assert "input.value = checked.concat(manual).join(', ')" in change_block
+    assert "const toolsets = raw.split(',').map(s => s.trim()).filter(Boolean);" in apply_block
+    assert "_applySessionToolsets(toolsets);" in apply_block
+
+
+def test_toolsets_affordance_i18n_keys_exist_in_locale_blocks():
+    keys = [
+        "session_toolsets_profile_defaults",
+        "session_toolsets_use_profile_defaults",
+        "session_toolsets_configured_servers",
+        "session_toolsets_loading_servers",
+        "session_toolsets_no_configured_servers",
+    ]
+    for key in keys:
+        assert I18N_JS.count(f"{key}:") >= 8, f"missing locale entries for {key}"
+    assert "session_toolsets_custom:'Custom override'" in I18N_JS
+    assert "session_toolsets_desc:'Use active profile defaults or choose a custom toolset list for this session'" in I18N_JS
+
+
+def test_toolsets_dropdown_distinguishes_failed_catalog_loads_from_loading():
+    render_sections = _function_body(UI_JS, "function _renderToolsetsPresetSections")
+
+    assert "_toolsetsCatalog === null" in render_sections
+    assert "_toolsetsCatalog === false" in render_sections
+    assert "session_toolsets_loading_servers" in render_sections
+    assert "mcp_load_failed" in render_sections
+
+
+def test_mcp_server_panel_refreshes_cached_toolsets_catalog():
+    invalidate = _function_body(UI_JS, "function invalidateToolsetsCatalog")
+    load_servers = _function_body(PANELS_JS, "function loadMcpServers")
+    toggle_server = _function_body(PANELS_JS, "function toggleMcpServer")
+
+    assert "_toolsetsCatalog = payload && Array.isArray(payload.servers)" in invalidate
+    assert "_normalizeToolsetsCatalog(payload)" in invalidate
+    assert ": null" in invalidate
+    assert "window.invalidateToolsetsCatalog = invalidateToolsetsCatalog" in UI_JS
+    assert "_refreshMcpToolsetsCatalog(r);" in load_servers
+    assert "_refreshMcpToolsetsCatalog();" in toggle_server


### PR DESCRIPTION
## Release PH — v0.51.447

Ships **#3632** (rodboev) — the composer toolset selector now surfaces the active profile's toolset defaults (#3100). You approved the concept + the responsive-footer behavior; self-rebased onto v0.51.446 and gated fresh (Codex SAFE + Opus SHIP + full suite).

### What it does
When a conversation has no per-session toolset override, the selector shows "profile defaults" (the toolsets the active profile enables) instead of a generic label, and the dropdown lists configured MCP servers with their current state + Apply / "Use profile defaults" controls. Picking toolsets is scoped to the **current session only** (never mutates the profile or global config). With no MCP toolsets configured it falls back cleanly to the global view.

### Responsive footer (verified live at 3 widths)
The selector is driven by an existing `@container composer-footer (min-width:1100px)` query, so it appears only when the footer has room and is hidden otherwise:
- Wide desktop (footer ≥1100px) → shown
- Narrow desktop (~1000px, sidebar+workspace open) → hidden
- Mobile (390px) → hidden

No footer crowding at any width.

### Gate results
- **Codex SAFE:** per-session save posts only `session_id` to `/api/session/toolsets` (mutates `Session.enabled_toolsets`, streaming resolves profile defaults first); catalog rendering uses `textContent`/`createTextNode` (XSS-safe); catalog load caches + handles empty/failure; no global-name collision.
- **Opus SHIP:** all 5 concerns clean — scoped write, XSS-safe, graceful degradation with no crash/refetch-storm, footer controls intact, i18n complete across 13/13 locales.
- **Full suite:** 8 `test_issue3100` toolset tests + onboarding pass in isolation; wider failures are this box's process-group cascade artifact (CI authoritative).

Closes #3100.

Co-authored-by: rodboev
