### PR TITLE
Release PI (v0.51.448): fix blank transcript viewport regression (#4277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 - **Windows pytest-harness compatibility (#3664).** Hardened the test suite to run on Windows: profile-home fallback paths are path-normalized, strict POSIX file-mode (`0o600`) assertions are gated behind `os.name != "nt"` (Linux still asserts them at full strictness), the conftest cleanup handles Windows process-tree/port teardown and the Py3.12+ `shutil.rmtree` `onexc` shim, and tests that require `fork`/`fcntl` carry `@requires_fork` / `@requires_fcntl` markers (which never skip on Linux). Test-only — no runtime or app behavior change, no Linux CI behavior change. (#4254, #4255, #4256, #4257, #4259, #4263, #4266, #4274)
 
+## [v0.51.448] — 2026-06-16 — Release PI (fix blank transcript viewport regression)
+
+### Fixed
+
+- **The chat transcript no longer renders blank after a reply in long conversations.** A regression from the message-list virtualization (v0.51.423, #3714) could leave the transcript viewport empty after an assistant reply settled — the data was still there, but you had to click "Newest Message" to force it back, and scrolling up could blank it again. The viewport now captures and restores a row anchor across re-renders (instead of only a raw scroll offset), and detects the blank state to force a one-time re-render recovery. (#4277)
+
 ## [v0.51.447] — 2026-06-15 — Release PH (toolset selector shows the active profile's defaults)
 
 ### Added

--- a/static/ui.js
+++ b/static/ui.js
@@ -687,6 +687,17 @@ function _restoreMessageViewportAnchor(anchor, rawIdxDelta){
   requestAnimationFrame(()=>{ _programmaticScroll=false; });
   return true;
 }
+function _messageViewportIntersectsRenderedRow(){
+  const container=$('messages');
+  if(!container) return true;
+  const containerRect=container.getBoundingClientRect();
+  const rows=Array.from(container.querySelectorAll('[data-msg-idx]'));
+  for(const row of rows){
+    const rect=row.getBoundingClientRect();
+    if(rect.bottom>containerRect.top+1&&rect.top<containerRect.bottom-1) return true;
+  }
+  return false;
+}
 function _measureMessageVirtualRow(inner, entry){
   if(!inner||!entry) return 0;
   const primary=inner.querySelector(`[data-msg-idx="${entry.rawIdx}"]`);
@@ -9443,6 +9454,7 @@ function _captureMessageScrollSnapshot(){
   if(!el) return null;
   const bottom=Math.max(0,el.scrollHeight-el.scrollTop-el.clientHeight);
   return {
+    anchor:(typeof _captureMessageViewportAnchor==='function')?_captureMessageViewportAnchor():null,
     top:el.scrollTop,
     bottom,
     scrollHeight:el.scrollHeight,
@@ -9454,8 +9466,13 @@ function _restoreMessageScrollSnapshot(snapshot){
   const el=$('messages');
   if(!el||!snapshot) return;
   const maxTop=Math.max(0,el.scrollHeight-el.clientHeight);
-  _programmaticScroll=true;
-  el.scrollTop=Math.max(0,Math.min(Number(snapshot.top)||0,maxTop));
+  const restoredViaAnchor=(snapshot.anchor&&typeof _restoreMessageViewportAnchor==='function')
+    ? _restoreMessageViewportAnchor(snapshot.anchor,0)
+    : false;
+  if(!restoredViaAnchor){
+    _programmaticScroll=true;
+    el.scrollTop=Math.max(0,Math.min(Number(snapshot.top)||0,maxTop));
+  }
   // Sync _lastScrollTop after programmatic restore so sticky-unpin does not false-trigger (#1731).
   _lastScrollTop=el.scrollTop;
   const bottomDistance=el.scrollHeight-el.scrollTop-el.clientHeight;
@@ -9468,7 +9485,9 @@ function _restoreMessageScrollSnapshot(snapshot){
     _scrollPinned=true;
     _nearBottomCount=2;
   }
-  requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+  if(!restoredViaAnchor){
+    requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+  }
 }
 function _restoreMessageScrollSnapshotSameFrame(snapshot){
   const el=$('messages');
@@ -9559,8 +9578,20 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
   scrollToBottom();
 }
 
+function _maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualWindow){
+  if(!preserveScroll||!virtualWindow||!virtualWindow.virtualized||!!(options&&options._virtualFallback)) return false;
+  if(_messageViewportIntersectsRenderedRow()) return false;
+  if(_sessionHtmlCacheSid&&S.session&&S.session.session_id===_sessionHtmlCacheSid){
+    _sessionHtmlCache.delete(_sessionHtmlCacheSid);
+  }
+  _messageVirtualWindowKey='';
+  renderMessages({preserveScroll:true,_virtualFallback:true});
+  return true;
+}
+
 function renderMessages(options){
   const preserveScroll=!!(options&&options.preserveScroll);
+  const virtualFallback=!!(options&&options._virtualFallback);
   // Capture the pre-wipe scroll position when preserving OR when Auto-follow is
   // off and the user has scrolled up — both need to restore the reader's position
   // after the DOM rebuild rather than snap to the bottom. (Codex #4006 r3.)
@@ -9582,7 +9613,9 @@ function renderMessages(options){
   const preservedCompressionTaskMessages=_latestPreservedCompressionTaskListMessages(S.messages);
   const visWithIdx=_getVisibleMessagesWithIdx();
   $('emptyState').style.display=(visWithIdx.length||preservedCompressionTaskMessages.length)?'none':'';
-  const virtualWindow=_currentMessageVirtualWindow(visWithIdx,_messageVirtualKeepTailCount());
+  const virtualWindow=virtualFallback
+    ? {virtualized:false,start:0,end:visWithIdx.length,topPad:0,bottomPad:0,total:visWithIdx.length,tailStart:visWithIdx.length}
+    : _currentMessageVirtualWindow(visWithIdx,_messageVirtualKeepTailCount());
   const renderWindowKey=_messageVirtualWindowKeyFor(virtualWindow);
   const windowStart=virtualWindow.start;
   const windowEnd=virtualWindow.end;
@@ -9618,6 +9651,7 @@ function renderMessages(options){
       _wireMessageWindowLoadEarlierButton();
       if(typeof _applySessionNavigationPrefs==='function') _applySessionNavigationPrefs();
       _scrollAfterMessageRender(preserveScroll, scrollSnapshot);
+      if(_maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualWindow)) return;
       _updateMessageVirtualMeasurements(renderVisWithIdx, renderVisibleIdxs, virtualWindow);
       requestAnimationFrame(()=>postProcessRenderedMessages(inner));
       if(typeof _initMediaPlaybackObserver==='function') _initMediaPlaybackObserver();
@@ -10775,6 +10809,7 @@ function renderMessages(options){
   // scrollIfPinned() respects _scrollPinned, so it's a no-op if user scrolled up.
   if(typeof _syncLiveRunStatusAfterRender==='function') _syncLiveRunStatusAfterRender();
   _scrollAfterMessageRender(preserveScroll, scrollSnapshot);
+  if(_maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualWindow)) return;
   // Apply syntax highlighting after DOM is built
   requestAnimationFrame(()=>postProcessRenderedMessages(inner));
   // Refresh todo panel if it's currently open

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -362,3 +362,68 @@ def test_tool_rows_do_not_carry_message_measurement_hook():
 
     assert "row.dataset.msgIdx" not in build_body
     assert "querySelectorAll(`[data-msg-idx=" not in js
+
+
+def test_viewport_intersection_helper_detects_visible_rendered_rows_only():
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let rows = [];
+const container = {
+  getBoundingClientRect(){ return {top: 100, bottom: 300}; },
+  querySelectorAll(selector){
+    if(selector === '[data-msg-idx]') return rows;
+    return [];
+  },
+};
+function $(id){ return id === 'messages' ? container : null; }
+eval(extractFunc('_messageViewportIntersectsRenderedRow'));
+rows = [
+  { getBoundingClientRect(){ return {top: 10, bottom: 90}; } },
+  { getBoundingClientRect(){ return {top: 320, bottom: 360}; } },
+];
+const blank = _messageViewportIntersectsRenderedRow();
+rows = [
+  { getBoundingClientRect(){ return {top: 120, bottom: 180}; } },
+];
+const visible = _messageViewportIntersectsRenderedRow();
+console.log(JSON.stringify({blank, visible}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["blank"] is False
+    assert metrics["visible"] is True
+
+
+def test_render_messages_has_one_shot_virtual_blank_viewport_fallback():
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    render_start = js.index("function renderMessages(options)")
+    render_end = js.index("function _toolDisplayName", render_start)
+    render_body = js[render_start:render_end]
+
+    assert "const virtualFallback=!!(options&&options._virtualFallback);" in render_body
+    assert "const virtualWindow=virtualFallback" in render_body
+    assert "if(_maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualWindow)) return;" in render_body
+    assert "if(_sessionHtmlCacheSid&&S.session&&S.session.session_id===_sessionHtmlCacheSid){" in js
+    assert "_sessionHtmlCache.delete(_sessionHtmlCacheSid);" in js
+    assert "renderMessages({preserveScroll:true,_virtualFallback:true});" in js
+
+
+def test_virtual_blank_viewport_recovery_evicts_stale_cache_before_fallback():
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let deletes = [];
+let renderCalls = [];
+const _sessionHtmlCache = {
+  delete(sid){ deletes.push(sid); }
+};
+let _sessionHtmlCacheSid = 'sid-123';
+const S = { session: { session_id: 'sid-123' } };
+function _messageViewportIntersectsRenderedRow(){ return false; }
+function renderMessages(options){ renderCalls.push(options); }
+eval(extractFunc('_maybeRecoverVirtualizedBlankViewport'));
+const recovered = _maybeRecoverVirtualizedBlankViewport({preserveScroll:false, someFlag:true}, true, {virtualized:true});
+console.log(JSON.stringify({recovered, deletes, renderCalls}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["recovered"] is True
+    assert metrics["deletes"] == ["sid-123"]
+    assert metrics["renderCalls"] == [{"preserveScroll": True, "_virtualFallback": True}]

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -106,6 +106,7 @@ def test_preserve_scroll_restores_unpinned_viewport_after_dom_rebuild():
     render = _function_body(UI_JS, "function renderMessages")
     after_render = _function_body(UI_JS, "function _scrollAfterMessageRender")
     follow = _function_body(UI_JS, "function _followMessagesAfterDomReplace")
+    capture = _function_body(UI_JS, "function _captureMessageScrollSnapshot")
     restore = _function_body(UI_JS, "function _restoreMessageScrollSnapshot")
 
     snapshot_idx = render.index("const scrollSnapshot=(preserveScroll||(!_autoScrollFollow&&_messageUserUnpinned))?_captureMessageScrollSnapshot():null")
@@ -120,5 +121,8 @@ def test_preserve_scroll_restores_unpinned_viewport_after_dom_rebuild():
     assert "_restoreMessageScrollSnapshot(scrollSnapshot);\n    _maybeShowNewMessageScrollCue(scrollSnapshot);" in after_render
     assert "_shouldFollowMessagesOnDomReplace()" in follow
     assert "scrollToBottom();" in follow
+    assert "anchor:(typeof _captureMessageViewportAnchor==='function')?_captureMessageViewportAnchor():null" in capture
+    assert "_restoreMessageViewportAnchor(snapshot.anchor,0)" in restore
+    assert "if(!restoredViaAnchor){" in restore
     assert "el.scrollTop=Math.max(0,Math.min(Number(snapshot.top)||0,maxTop))" in restore
     assert "_programmaticScroll=true" in restore


### PR DESCRIPTION
## Release PI — v0.51.448

Ships **#4281** (rodboev) — fixes #4277, a blank-transcript-viewport regression from the message-list virtualization (#3714, v0.51.423). Self-rebased onto v0.51.447 and gated fresh (Codex + Opus + virtualization suite).

### The regression
In long/tool-heavy chats the transcript viewport could render BLANK after an assistant reply settled — data still present, but you had to click "Newest Message" to force it back, and scrolling up could blank it again. (santastabber filed #4277 today; rodboev turned the fix around within the hour.)

### The fix
- Capture/restore a viewport row-anchor across re-renders (instead of only a raw `scrollTop`), so a virtualized re-render lands on a still-rendered row.
- `_messageViewportIntersectsRenderedRow()` detects the blank state.
- `_maybeRecoverVirtualizedBlankViewport()` — when virtualized + preserveScroll + viewport blank, drops the session HTML cache and forces a one-time re-render recovery (two independent anti-recursion guards).

### Gate results
- **Codex SAFE:** non-virtualized scroll-restore path unregressed, recovery can't infinite-loop, cache eviction strictly current-sid scoped, no #3714 windowing/newest-jump/streaming regression, `_programmaticScroll` always clears.
- **Opus net-positive-and-safe:** same five axes verified; only caveats are a full-render perf cost that occurs *only* in the bug state (acceptable) and this CHANGELOG entry (added).
- **Tests:** 20 virtualization + scroll-reset-regression tests pass; the PR adds coverage to both files.

Closes #4277.

Co-authored-by: rodboev
