### PR TITLE
test-infra: hard-isolate test state from production + resilient teardown

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -145,7 +145,7 @@ Environment variables controlling behavior:
 Test isolation environment variables (set by conftest.py):
 
     HERMES_WEBUI_TEST_PORT=...                         Optional pinned test port
-    HERMES_WEBUI_TEST_STATE_DIR=~/.hermes/webui-test-* Optional pinned test state
+    HERMES_WEBUI_TEST_STATE_DIR=/tmp/hermes-webui-tests/* Optional pinned test state (default: OS temp dir; must be outside ~/.hermes)
     HERMES_WEBUI_DEFAULT_WORKSPACE=.../test-workspace  Isolated test workspace
 
 Tests NEVER talk to the production server (port 8787).

--- a/tests/_pytest_port.py
+++ b/tests/_pytest_port.py
@@ -45,7 +45,26 @@ _TEST_STATE_ROOT = pathlib.Path(
 TEST_STATE_DIR = pathlib.Path(os.environ.get(
     'HERMES_WEBUI_TEST_STATE_DIR',
     str(_TEST_STATE_ROOT / _auto_state_dir_name(_REPO_ROOT))
-))
+)).resolve()
+
+# Defense-in-depth: mirror conftest.py's production-proximity guard so a
+# standalone import (without conftest) can't resolve a state dir inside the real
+# ~/.hermes either. Same logic: trip only if under literal ~/.hermes and the temp
+# root isn't itself under production.
+_PROD_HERMES_HOME = (pathlib.Path.home() / '.hermes').resolve()
+_TEMP_ROOT = pathlib.Path(_tempfile.gettempdir()).resolve()
+_temp_root_is_safe = not (
+    _TEMP_ROOT == _PROD_HERMES_HOME or _PROD_HERMES_HOME in _TEMP_ROOT.parents
+)
+_under_temp = _temp_root_is_safe and (
+    TEST_STATE_DIR == _TEMP_ROOT or _TEMP_ROOT in TEST_STATE_DIR.parents
+)
+_under_prod = TEST_STATE_DIR == _PROD_HERMES_HOME or _PROD_HERMES_HOME in TEST_STATE_DIR.parents
+if _under_prod and not _under_temp:
+    raise RuntimeError(
+        f"REFUSING TO RUN: test state dir {TEST_STATE_DIR} is inside the production "
+        f"Hermes home {_PROD_HERMES_HOME}. Tests must never touch production files."
+    )
 
 # Default model injected by conftest — tests that mutate the default model
 # must restore to this value so later tests see a consistent baseline.

--- a/tests/_pytest_port.py
+++ b/tests/_pytest_port.py
@@ -29,16 +29,22 @@ def _auto_state_dir_name(repo_root: pathlib.Path) -> str:
 
 _TESTS_DIR   = pathlib.Path(__file__).parent.resolve()
 _REPO_ROOT   = _TESTS_DIR.parent.resolve()
-_HERMES_HOME = pathlib.Path(os.getenv('HERMES_HOME',
-                             str(pathlib.Path.home() / '.hermes')))
 
 TEST_PORT = int(os.environ.get('HERMES_WEBUI_TEST_PORT',
                                str(_auto_test_port(_REPO_ROOT))))
 BASE = f"http://127.0.0.1:{TEST_PORT}"
 
+# Test state dir: prefer the value conftest.py published to the environment.
+# The standalone fallback anchors under the OS temp dir (NOT ~/.hermes) so test
+# state is never created inside the production Hermes home — matching conftest's
+# hard-isolation default. (See conftest.py TEST_STATE_DIR.)
+import tempfile as _tempfile
+_TEST_STATE_ROOT = pathlib.Path(
+    os.environ.get('HERMES_WEBUI_TEST_STATE_ROOT', _tempfile.gettempdir())
+) / 'hermes-webui-tests'
 TEST_STATE_DIR = pathlib.Path(os.environ.get(
     'HERMES_WEBUI_TEST_STATE_DIR',
-    str(_HERMES_HOME / _auto_state_dir_name(_REPO_ROOT))
+    str(_TEST_STATE_ROOT / _auto_state_dir_name(_REPO_ROOT))
 ))
 
 # Default model injected by conftest — tests that mutate the default model

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,10 +72,36 @@ def _auto_state_dir_name(repo_root) -> str:
 TEST_PORT      = int(os.getenv('HERMES_WEBUI_TEST_PORT',
                                str(_auto_test_port(REPO_ROOT))))
 TEST_BASE      = f"http://127.0.0.1:{TEST_PORT}"
+
+# ── Test state dir: HARD-ISOLATED from production ──────────────────────────
+# Test state must NEVER live inside the real Hermes home (~/.hermes or any
+# HERMES_HOME), or anywhere near production profiles/files/server. Earlier this
+# defaulted to ``HERMES_HOME / webui-test-<hash>`` which wrote test state INTO
+# ~/.hermes/profiles/<...>/ (observed: 144 leaked webui-test-* dirs in the real
+# profile home). We now anchor the default under the OS temp dir, in a dedicated
+# `hermes-webui-tests/` namespace, fully outside any production tree.
+import tempfile as _tempfile
+_TEST_STATE_ROOT = pathlib.Path(
+    os.getenv('HERMES_WEBUI_TEST_STATE_ROOT', _tempfile.gettempdir())
+) / 'hermes-webui-tests'
 TEST_STATE_DIR = pathlib.Path(os.getenv(
     'HERMES_WEBUI_TEST_STATE_DIR',
-    str(HERMES_HOME / _auto_state_dir_name(REPO_ROOT))
-))
+    str(_TEST_STATE_ROOT / _auto_state_dir_name(REPO_ROOT))
+)).resolve()
+
+# Production-proximity guard: refuse to run if the resolved test state dir lands
+# inside the real Hermes home tree. This is a hard stop — a misconfigured
+# HERMES_WEBUI_TEST_STATE_DIR pointing at ~/.hermes would let tests wipe/clobber
+# production profiles, sessions, and credentials on teardown.
+_REAL_HERMES_HOME = pathlib.Path(os.getenv('HERMES_HOME', str(HOME / '.hermes'))).resolve()
+if TEST_STATE_DIR == _REAL_HERMES_HOME or _REAL_HERMES_HOME in TEST_STATE_DIR.parents:
+    raise RuntimeError(
+        f"REFUSING TO RUN: test state dir {TEST_STATE_DIR} is inside the production "
+        f"Hermes home {_REAL_HERMES_HOME}. Tests must never touch production files. "
+        f"Unset HERMES_WEBUI_TEST_STATE_DIR (defaults to a temp dir) or point it "
+        f"outside ~/.hermes."
+    )
+
 TEST_WORKSPACE = TEST_STATE_DIR / 'test-workspace'
 
 # Publish at module level so api.config, _pytest_port.py, and any test module
@@ -685,12 +711,20 @@ def _kill_port_owner(port):
 
 
 def _rmtree_retry(path):
-    """Remove a tree, retrying on Windows after clearing read-only bits."""
+    """Remove a tree, retrying transient races (Linux + Windows).
+
+    The retry loop covers two real failure modes seen in CI/local:
+      * Windows: read-only bits / lingering handles (cleared via onexc/onerror).
+      * Linux: `OSError [Errno 39] Directory not empty` — a background thread or
+        daemon (model-metadata fetcher, session-events watcher, profile writer)
+        creates a file inside the tree WHILE shutil.rmtree is walking it, so the
+        parent rmdir fails even though we just emptied it. A short retry lets the
+        racing writer settle; a final ignore_errors sweep guarantees teardown
+        never fails the test over a pure cleanup race (the dir is abandoned test
+        state, not an assertion target).
+    """
     target = pathlib.Path(path)
     if not target.exists():
-        return
-    if sys.platform != "win32":
-        shutil.rmtree(target)
         return
 
     def _clear_readonly(_func, entry, _exc):
@@ -704,7 +738,7 @@ def _rmtree_retry(path):
         {"onexc": _clear_readonly}
         if "onexc" in inspect.signature(shutil.rmtree).parameters
         else {"onerror": _clear_readonly}
-    )
+    ) if sys.platform == "win32" else {}
 
     attempts = 5
     last_exc = None
@@ -720,13 +754,27 @@ def _rmtree_retry(path):
                 break
             time.sleep(0.3)
 
+    # Final fallback: a concurrent-writer race (Errno 39) shouldn't fail teardown.
+    # Best-effort ignore_errors sweep; if anything remains it's abandoned test
+    # state under HERMES_HOME, not something a test asserts on.
+    shutil.rmtree(target, ignore_errors=True)
+    if not target.exists():
+        return
     leftovers = []
     try:
         leftovers = [child.name for child in list(target.iterdir())[:5]]
     except Exception:
         pass
+    # Don't raise — log-and-continue. Raising here turns a benign cleanup race
+    # into a spurious test ERROR (the behaviour #4283-area tests hit when a
+    # model-metadata background fetch repopulated the profile dir mid-teardown).
+    import warnings as _warnings
     leftover_note = f" leftovers={leftovers}" if leftovers else ""
-    raise RuntimeError(f"Could not remove {target} after {attempts} attempts.{leftover_note}") from last_exc
+    _warnings.warn(
+        f"_rmtree_retry: could not fully remove {target} after {attempts} attempts"
+        f"{leftover_note} (last_exc={last_exc!r}); left for OS temp cleanup.",
+        stacklevel=2,
+    )
 
 
 # ── Session-scoped test server ────────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,15 @@ TEST_STATE_DIR = pathlib.Path(os.getenv(
 # allowed even if it nominally sits below a temp-rooted HERMES_HOME.
 _PROD_HERMES_HOME = (HOME / '.hermes').resolve()
 _TEMP_ROOT = pathlib.Path(_tempfile.gettempdir()).resolve()
-_under_temp = TEST_STATE_DIR == _TEMP_ROOT or _TEMP_ROOT in TEST_STATE_DIR.parents
+# The temp-root exception only holds when the temp root is itself OUTSIDE the
+# production home. If TMPDIR is (mis)configured under ~/.hermes, a "temp" path is
+# still a production path — don't let it suppress the guard.
+_temp_root_is_safe = not (
+    _TEMP_ROOT == _PROD_HERMES_HOME or _PROD_HERMES_HOME in _TEMP_ROOT.parents
+)
+_under_temp = _temp_root_is_safe and (
+    TEST_STATE_DIR == _TEMP_ROOT or _TEMP_ROOT in TEST_STATE_DIR.parents
+)
 _under_prod = TEST_STATE_DIR == _PROD_HERMES_HOME or _PROD_HERMES_HOME in TEST_STATE_DIR.parents
 if _under_prod and not _under_temp:
     raise RuntimeError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,14 +90,22 @@ TEST_STATE_DIR = pathlib.Path(os.getenv(
 )).resolve()
 
 # Production-proximity guard: refuse to run if the resolved test state dir lands
-# inside the real Hermes home tree. This is a hard stop — a misconfigured
-# HERMES_WEBUI_TEST_STATE_DIR pointing at ~/.hermes would let tests wipe/clobber
-# production profiles, sessions, and credentials on teardown.
-_REAL_HERMES_HOME = pathlib.Path(os.getenv('HERMES_HOME', str(HOME / '.hermes'))).resolve()
-if TEST_STATE_DIR == _REAL_HERMES_HOME or _REAL_HERMES_HOME in TEST_STATE_DIR.parents:
+# inside the REAL Hermes home tree — a misconfigured HERMES_WEBUI_TEST_STATE_DIR
+# pointing at ~/.hermes would let tests wipe/clobber production profiles,
+# sessions, and credentials on teardown. We anchor on the literal user-home
+# `~/.hermes` (NOT $HERMES_HOME): HERMES_HOME is frequently overridden to a
+# profile dir or, during a test run, to TEST_STATE_DIR itself — comparing
+# against it would either miss a real production path or false-trip when the
+# test dir legitimately lives in /tmp. A test dir under the OS temp dir is always
+# allowed even if it nominally sits below a temp-rooted HERMES_HOME.
+_PROD_HERMES_HOME = (HOME / '.hermes').resolve()
+_TEMP_ROOT = pathlib.Path(_tempfile.gettempdir()).resolve()
+_under_temp = TEST_STATE_DIR == _TEMP_ROOT or _TEMP_ROOT in TEST_STATE_DIR.parents
+_under_prod = TEST_STATE_DIR == _PROD_HERMES_HOME or _PROD_HERMES_HOME in TEST_STATE_DIR.parents
+if _under_prod and not _under_temp:
     raise RuntimeError(
         f"REFUSING TO RUN: test state dir {TEST_STATE_DIR} is inside the production "
-        f"Hermes home {_REAL_HERMES_HOME}. Tests must never touch production files. "
+        f"Hermes home {_PROD_HERMES_HOME}. Tests must never touch production files. "
         f"Unset HERMES_WEBUI_TEST_STATE_DIR (defaults to a temp dir) or point it "
         f"outside ~/.hermes."
     )

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -48,7 +48,7 @@ def _get_test_state_dir():
     (via os.environ.setdefault) so that tests writing directly to state.db always
     use the same path the test server was started with.  If the env var is not
     set (e.g. when running this file standalone), fall back to the conftest
-    formula: HERMES_HOME/webui-mvp-test.
+    formula via _pytest_port (temp-rooted, never ~/.hermes).
     """
     # Use _pytest_port which applies the same auto-derivation as conftest.py
     from tests._pytest_port import TEST_STATE_DIR as _ptsd

--- a/tests/test_onboarding_existing_config.py
+++ b/tests/test_onboarding_existing_config.py
@@ -290,7 +290,8 @@ def _server_hermes_home() -> pathlib.Path:
     env_path = data.get("system", {}).get("env_path", "")
     if env_path:
         return pathlib.Path(env_path).parent
-    return pathlib.Path(os.environ.get("HERMES_WEBUI_TEST_STATE_DIR", str(pathlib.Path.home() / ".hermes" / "webui-mvp-test")))
+    from tests._pytest_port import TEST_STATE_DIR
+    return pathlib.Path(os.environ.get("HERMES_WEBUI_TEST_STATE_DIR", str(TEST_STATE_DIR)))
 
 
 def _server_reachable() -> bool:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -116,7 +116,8 @@ def test_session_with_tool_calls_in_json_loads_ok(cleanup_test_sessions):
     sid = make_session(cleanup_test_sessions)
 
     # Manually inject tool_calls into the session's JSON file
-    sessions_dir = pathlib.Path(os.environ.get("HERMES_WEBUI_TEST_STATE_DIR", str(pathlib.Path.home() / ".hermes" / "webui-mvp-test"))) / "sessions"
+    from tests._pytest_port import TEST_STATE_DIR
+    sessions_dir = pathlib.Path(os.environ.get("HERMES_WEBUI_TEST_STATE_DIR", str(TEST_STATE_DIR))) / "sessions"
     session_file = sessions_dir / f"{sid}.json"
     if session_file.exists():
         d = json.loads(session_file.read_text())

--- a/tests/test_sprint45.py
+++ b/tests/test_sprint45.py
@@ -14,15 +14,14 @@ import urllib.request
 
 import os
 
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE, TEST_STATE_DIR
 REPO = pathlib.Path(__file__).parent.parent
 # Use HERMES_WEBUI_TEST_STATE_DIR if available (set by conftest for the test process),
-# falling back to the conventional webui-mvp-test path.
+# falling back to the shared isolated TEST_STATE_DIR (temp-rooted, never ~/.hermes).
 def _get_settings_file() -> pathlib.Path:
     """Resolve SETTINGS_FILE at call time (env var set by conftest after module import)."""
     state_dir = pathlib.Path(
-        os.environ.get("HERMES_WEBUI_TEST_STATE_DIR",
-                       str(pathlib.Path.home() / ".hermes" / "webui-mvp-test"))
+        os.environ.get("HERMES_WEBUI_TEST_STATE_DIR", str(TEST_STATE_DIR))
     )
     return state_dir / "settings.json"
 

--- a/tests/test_sprint5.py
+++ b/tests/test_sprint5.py
@@ -225,8 +225,9 @@ def test_file_save_path_traversal_blocked(cleanup_test_sessions):
     assert status in (400, 500)
 
 def test_session_index_created_after_save(cleanup_test_sessions):
-    # Index is created in the TEST state dir, not the production dir
-    test_state_dir = pathlib.Path(os.environ.get("HERMES_WEBUI_TEST_STATE_DIR", str(pathlib.Path.home() / ".hermes" / "webui-mvp-test")))
+    # Index is created in the TEST state dir, not the production dir.
+    # Use the shared isolated TEST_STATE_DIR (temp-rooted, never ~/.hermes).
+    from tests._pytest_port import TEST_STATE_DIR as test_state_dir
     index_path = test_state_dir / "sessions" / "_index.json"
     make_session_tracked(cleanup_test_sessions)
     # Index may not exist yet if cleanup already wiped it -- just check the endpoint works


### PR DESCRIPTION
## test-infra: hard-isolate test state from production + resilient teardown

**Maintainer-directed:** tests, test environments, and staging must never touch production files, folders, profiles, or the production server. This closes a real isolation gap and a teardown flake.

### 1. Test state was being written INTO production
`TEST_STATE_DIR` defaulted to `HERMES_HOME / webui-test-<hash>`, which resolved into the real `~/.hermes/profiles/webui/` — I found **144 leaked `webui-test-*` dirs** sitting in the production profile home. Tests were creating (and rmtree-ing) state directly adjacent to production profiles/sessions/credentials.

**Fix:**
- `TEST_STATE_DIR` now defaults under the OS temp dir: `/tmp/hermes-webui-tests/<hash>`, fully outside any production tree. (`HERMES_WEBUI_TEST_STATE_ROOT` / `HERMES_WEBUI_TEST_STATE_DIR` still override.)
- **Hard-stop guard:** conftest raises `RuntimeError` at import if the resolved test state dir is under the literal `~/.hermes` (and not under the temp root) — so a misconfigured env can never let a teardown wipe production. Verified: trips on a `~/.hermes/...` target, allows the `/tmp` default even when `HERMES_HOME` points at a profile/temp dir.
- `tests/_pytest_port.py` fallback updated to match (was the same `~/.hermes`-rooted default).

### 2. `_rmtree_retry` was not resilient on Linux
It did a bare `shutil.rmtree` on non-Windows (only Windows had retry). A background daemon (model-metadata fetcher / session watcher) writing into the tree during teardown caused `OSError [Errno 39] Directory not empty`, spuriously ERRORing tests (seen near the #4283 context-reconciliation tests). Now: retry loop on all platforms + a final `ignore_errors` sweep + warn-instead-of-raise so a benign cleanup race never fails a test.

### Validation
- Full suite under `setsid`: **9147 passed, 9 skipped, 0 failed**.
- **Zero** `webui-test-*` dirs leaked into `~/.hermes` after the run (was 144).
- Gated Codex + Opus.

Test-infra only — no app/runtime change, no version stamp. CI runs in a clean container with its own state dir, so the temp default + guard are inert there.
