### PR TITLE
test-infra: per-process test port for true parallel-run safety (fixes the local ConnectionRefused cascade)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,8 +81,10 @@ def _auto_test_port(repo_root) -> int:
             except OSError:
                 continue
         # Avoid the production WebUI port (8787) on the off chance the OS hands
-        # it out, and stay clear of privileged ranges.
-        if port and port != 8787 and port >= 1024:
+        # it out, and stay clear of privileged ranges. Also cap below 64535 so
+        # tests that derive offset ports (test_server_port_exclusivity adds up to
+        # +905 to TEST_PORT) can't overflow past 65535.
+        if port and port != 8787 and 1024 <= port <= 64535:
             return port
     # Fallback to the legacy repo-hash port if the OS won't hand us one.
     import hashlib
@@ -103,6 +105,13 @@ def _auto_state_dir_name(repo_root, port=None) -> str:
     h = hashlib.md5(str(repo_root).encode()).hexdigest()[:8]
     return f"webui-test-{h}-{port}" if port else f"webui-test-{h}"
 
+# Whether the test port was explicitly pinned (vs auto-allocated). An auto port
+# is a fresh free OS port unique to this process, so it never needs the
+# _kill_port_owner() reap at setup — and reaping it would be DANGEROUS: fuser -k
+# on an ephemeral-range port can match a *client* socket (or the other concurrent
+# run's pytest) that merely has that local port, killing the wrong process. Only
+# pinned ports (which may have a genuinely stale prior server) get the reap.
+TEST_PORT_PINNED = bool(os.getenv('HERMES_WEBUI_TEST_PORT'))
 TEST_PORT      = int(os.getenv('HERMES_WEBUI_TEST_PORT',
                                str(_auto_test_port(REPO_ROOT))))
 TEST_BASE      = f"http://127.0.0.1:{TEST_PORT}"
@@ -838,9 +847,14 @@ def test_server():
     # Kill any leftover process on the test port before starting.
     # Stale servers from QA harness runs or prior test sessions cause
     # conftest to think the server is already up, producing false failures.
-    _kill_port_owner(TEST_PORT)
-    import time as _time
-    _time.sleep(0.5)  # brief pause to let the port release
+    # ONLY for a pinned port: an auto-allocated free port is unique to this
+    # process and was just confirmed free, so there's nothing stale to reap —
+    # and fuser -k on an ephemeral-range port could kill an unrelated client
+    # socket or a concurrent run's process (see TEST_PORT_PINNED note).
+    if TEST_PORT_PINNED:
+        _kill_port_owner(TEST_PORT)
+        import time as _time
+        _time.sleep(0.5)  # brief pause to let the port release
 
     # Clean slate
     if TEST_STATE_DIR.exists():
@@ -985,7 +999,8 @@ def test_server():
         except Exception:
             pass
         if _attempt < boot_attempts:
-            _kill_port_owner(TEST_PORT)
+            if TEST_PORT_PINNED:
+                _kill_port_owner(TEST_PORT)
             time.sleep(1.0)
     else:
         pytest.fail(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,17 +57,51 @@ HERMES_HOME = pathlib.Path(os.getenv('HERMES_HOME', str(HOME / '.hermes')))
 # Override with HERMES_WEBUI_TEST_PORT / HERMES_WEBUI_TEST_STATE_DIR to pin.
 
 def _auto_test_port(repo_root) -> int:
-    """Map repo path to a unique port in 20000-29999 (10k range = near-zero collisions).
-    Far from system port ranges and Linux ephemeral ports (32768+).
-    Override with HERMES_WEBUI_TEST_PORT to use a specific port."""
+    """Pick a port for the session test server.
+
+    PARALLEL-SAFE: when ``HERMES_WEBUI_TEST_PORT`` is not pinned, grab a free
+    OS-assigned ephemeral port (bind to :0, read it back, release) so that
+    MULTIPLE concurrent pytest runs from the SAME worktree never collide on one
+    port. The old behaviour hashed the repo path to a fixed port in 20000-29999,
+    which meant a Codex/Opus gate running ``./scripts/test.sh`` from this worktree
+    (to verify a change) spun a server on the SAME port as a developer's
+    concurrently-running suite — and the fixture's ``_kill_port_owner(TEST_PORT)``
+    at setup then reaped the other run's server mid-suite, cascading every
+    HTTP-dependent test with ConnectionRefused. A per-process free port removes
+    the shared resource entirely, so gates + local suite + CI shards can all run
+    at once. Pin with ``HERMES_WEBUI_TEST_PORT`` for a reproducible/fixed port.
+    """
+    import socket
+    for _ in range(10):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                s.bind(("127.0.0.1", 0))
+                port = s.getsockname()[1]
+            except OSError:
+                continue
+        # Avoid the production WebUI port (8787) on the off chance the OS hands
+        # it out, and stay clear of privileged ranges.
+        if port and port != 8787 and port >= 1024:
+            return port
+    # Fallback to the legacy repo-hash port if the OS won't hand us one.
     import hashlib
     h = int(hashlib.md5(str(repo_root).encode()).hexdigest(), 16)
     return 20000 + (h % 10000)
 
-def _auto_state_dir_name(repo_root) -> str:
+def _auto_state_dir_name(repo_root, port=None) -> str:
+    """Per-(repo, port) state dir name.
+
+    Including the port makes the state dir unique PER pytest PROCESS (the port is
+    now a free per-process port, see _auto_test_port), so two concurrent runs
+    from the same worktree — e.g. a developer's suite + a Codex/Opus gate's
+    ./scripts/test.sh — get DISTINCT state dirs and never clobber each other's
+    sessions/db or race on teardown rmtree. Falls back to repo-hash-only when no
+    port is supplied (legacy callers).
+    """
     import hashlib
     h = hashlib.md5(str(repo_root).encode()).hexdigest()[:8]
-    return f"webui-test-{h}"
+    return f"webui-test-{h}-{port}" if port else f"webui-test-{h}"
 
 TEST_PORT      = int(os.getenv('HERMES_WEBUI_TEST_PORT',
                                str(_auto_test_port(REPO_ROOT))))
@@ -86,7 +120,7 @@ _TEST_STATE_ROOT = pathlib.Path(
 ) / 'hermes-webui-tests'
 TEST_STATE_DIR = pathlib.Path(os.getenv(
     'HERMES_WEBUI_TEST_STATE_DIR',
-    str(_TEST_STATE_ROOT / _auto_state_dir_name(REPO_ROOT))
+    str(_TEST_STATE_ROOT / _auto_state_dir_name(REPO_ROOT, TEST_PORT))
 )).resolve()
 
 # Production-proximity guard: refuse to run if the resolved test state dir lands


### PR DESCRIPTION
## test-infra: per-process test port + port-keyed state dir (true parallel safety)

### Root cause of the cascade-under-concurrency
The session test-server port was `md5(repo_path) % 10000` — **deterministic per worktree**. Two concurrent pytest runs from the SAME worktree (a developer's suite + a Codex/Opus gate running `./scripts/test.sh` to verify a change) bound the SAME port, and the `test_server` fixture's `_kill_port_owner(TEST_PORT)` at setup reaped the OTHER run's server mid-suite → every HTTP-dependent test cascaded with ConnectionRefused (the ~500-failure cascade we kept hitting locally).

### Fix
- `_auto_test_port`: when `HERMES_WEBUI_TEST_PORT` isn't pinned, grab a **free OS-assigned ephemeral port per process** (bind `127.0.0.1:0`, read back, release), capped ≤64535 so offset-deriving tests can't overflow 65535.
- State dir name is **keyed on that port** (`webui-test-<repohash>-<port>`), so concurrent runs share no port / state dir / db.
- **Don't `_kill_port_owner` an auto (unpinned) port** — `fuser -k` on an ephemeral-range port could match a client socket or a concurrent run's process; auto ports are freshly confirmed-free so there's nothing to reap. Only pinned ports get the reap.
- conftest publishes both port + state dir to env at module import, so `_pytest_port.py` and the server subprocess read the same resolved values.

### Validation
**Two FULL suites run concurrently from the same worktree, alongside a Codex gate doing its own verification — all three clean:** both suites 9150 passed / 0 failed, **0 ConnectionRefused**, **0 dirs leaked into `~/.hermes`**. Builds on the temp-dir hard-isolation (#4289).

This is the parallel-safe world: Codex + Opus gates + local suite(s) can all run at once without colliding.

### Gates
Codex SAFE TO SHIP (its 2 CORE findings — fuser-kills-client-socket + offset-port overflow — fixed). Opus net-positive and safe. Test-infra only — no app/runtime change, no version stamp. CI shards are separate jobs/processes, so each gets its own free port (unaffected).
