### PR TITLE
fix: make gateway watcher startup non-blocking with timeout

### DIFF
--- a/server.py
+++ b/server.py
@@ -592,8 +592,13 @@ def main() -> None:
 
     # Start the gateway session watcher for real-time SSE updates
     try:
+        import threading, signal
         from api.gateway_watcher import start_watcher
-        start_watcher()
+        t = threading.Thread(target=start_watcher, daemon=True)
+        t.start()
+        t.join(timeout=5)
+        if t.is_alive():
+            print('[tip] Gateway watcher still initializing (non-blocking)', flush=True)
     except Exception as e:
         print(f'[!!] WARNING: Gateway watcher failed to start: {e}', flush=True)
 

--- a/server.py
+++ b/server.py
@@ -592,9 +592,15 @@ def main() -> None:
 
     # Start the gateway session watcher for real-time SSE updates
     try:
-        import threading, signal
         from api.gateway_watcher import start_watcher
-        t = threading.Thread(target=start_watcher, daemon=True)
+
+        def _start_watcher_safe():
+            try:
+                start_watcher()
+            except Exception as e:
+                print(f'[!!] WARNING: Gateway watcher failed to start: {e}', flush=True)
+
+        t = threading.Thread(target=_start_watcher_safe, daemon=True)
         t.start()
         t.join(timeout=5)
         if t.is_alive():


### PR DESCRIPTION
## Problem

The gateway watcher's `start_watcher()` call in `server.py` runs synchronously in the main thread during WebUI startup. If `_resolve_watcher_target()` hangs (e.g., `state.db` locked, profile resolution slow, or any I/O block), the entire WebUI never starts — the server never binds its port and no requests are accepted.

## Fix

Wrap `start_watcher()` in a daemon thread with a 5-second join timeout:

```python
import threading
t = threading.Thread(target=start_watcher, daemon=True)
t.start()
t.join(timeout=5)
if t.is_alive():
    print('[tip] Gateway watcher still initializing (non-blocking)', flush=True)
```

- The watcher initializes in the background without blocking the server
- If it takes >5s, a tip is printed but startup continues
- Daemon thread is cleaned up on shutdown
- No functional change — the watcher still starts and works normally

## Testing

Tested on macOS with Hermes Agent running. WebUI starts immediately even when the watcher's profile resolution is slow. The watcher initializes in the background and begins polling `state.db` normally.