### PR TITLE
Release PM (v0.51.452): reject symlinked memory-file writes (#4242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 - **Windows pytest-harness compatibility (#3664).** Hardened the test suite to run on Windows: profile-home fallback paths are path-normalized, strict POSIX file-mode (`0o600`) assertions are gated behind `os.name != "nt"` (Linux still asserts them at full strictness), the conftest cleanup handles Windows process-tree/port teardown and the Py3.12+ `shutil.rmtree` `onexc` shim, and tests that require `fork`/`fcntl` carry `@requires_fork` / `@requires_fcntl` markers (which never skip on Linux). Test-only — no runtime or app behavior change, no Linux CI behavior change. (#4254, #4255, #4256, #4257, #4259, #4263, #4266, #4274)
 
+## [v0.51.452] — 2026-06-16 — Release PM (reject symlinked memory-file writes)
+
+### Security
+
+- **Memory writes refuse a symlinked target file.** Writing memory (`MEMORY.md` / `USER.md` / `SOUL.md`) now rejects the write if the target path is a symlink, so a symlink planted at the memory path — e.g. via a restored or imported workspace — can no longer redirect a memory write to clobber an arbitrary file outside the memories directory. This extends the symlink-rejection hardening already shipped for skills and plugins (#4217 / #4234 / #4240). A symlinked parent `memories/` directory is intentionally still allowed (symlinking the whole directory is a legitimate setup); only the concrete target file is guarded. (#4242)
+
 ## [v0.51.451] — 2026-06-16 — Release PL (show named-profile external sessions in the all-profiles list)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -16942,6 +16942,13 @@ def _handle_memory_write(handler, body):
         target = home / "SOUL.md"
     else:
         return bad(handler, 'section must be "memory", "user", or "soul"')
+    # Refuse to write through a symlinked target file: a symlink planted at the
+    # memory path (e.g. via a restored/imported workspace) would otherwise let a
+    # memory write clobber an arbitrary file outside the memories directory. This
+    # mirrors the symlink-rejection hardening already shipped for skills/plugins
+    # (#4217/#4234/#4240).
+    if target.is_symlink():
+        return bad(handler, "Cannot write to a symlinked memory file")
     target.write_text(body["content"], encoding="utf-8")
     return j(handler, {"ok": True, "section": section, "path": str(target)})
 

--- a/tests/test_memory_write_symlink_guard.py
+++ b/tests/test_memory_write_symlink_guard.py
@@ -1,0 +1,100 @@
+"""Regression test for the memory-write symlinked-target guard (#4242).
+
+`_handle_memory_write` refuses to write through a symlinked target file so a
+symlink planted at MEMORY.md / USER.md / SOUL.md (e.g. via a restored or imported
+workspace) cannot redirect a memory write to clobber an arbitrary file. This
+mirrors the symlink-rejection hardening shipped for skills/plugins
+(#4217/#4234/#4240).
+
+Per maintainer decision, a symlinked *parent memories directory* is deliberately
+NOT rejected here (symlinking the whole .hermes/memories dir is a legitimate
+setup); only the concrete target file is guarded.
+"""
+
+import os
+
+import pytest
+
+import api.profiles as profiles
+import api.routes as routes
+
+
+class _FakeHandler:
+    pass
+
+
+def _patch_memory_routes(monkeypatch, home):
+    cap = {}
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: home)
+    monkeypatch.setattr(routes, "j", lambda h, o: (cap.__setitem__("ok", o), True)[1])
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda h, m, c=400: (cap.__setitem__("bad", (m, c)), True)[1],
+    )
+    return cap
+
+
+def test_memory_write_rejects_symlinked_memory_file(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    mem_dir = home / "memories"
+    mem_dir.mkdir(parents=True)
+    outside = tmp_path / "outside-memory.md"
+    outside.write_text("important", encoding="utf-8")
+    link = mem_dir / "MEMORY.md"
+    try:
+        os.symlink(str(outside), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap = _patch_memory_routes(monkeypatch, home)
+    routes._handle_memory_write(
+        _FakeHandler(),
+        {"section": "memory", "content": "changed"},
+    )
+
+    assert "bad" in cap, f"expected 400, got {cap}"
+    assert cap["bad"][1] == 400
+    assert "Cannot write to a symlinked memory file" in cap["bad"][0]
+    # The symlink target outside the memories dir must be untouched.
+    assert outside.read_text(encoding="utf-8") == "important"
+
+
+def test_memory_write_allows_symlinked_memories_directory(tmp_path, monkeypatch):
+    """A symlinked parent memories directory is allowed (deliberate decision) as
+    long as the concrete target file itself is not a symlink."""
+    home = tmp_path / "home"
+    home.mkdir()
+    real_dir = tmp_path / "real-memories"
+    real_dir.mkdir()
+    link = home / "memories"
+    try:
+        os.symlink(str(real_dir), str(link), target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not support symlinks")
+
+    cap = _patch_memory_routes(monkeypatch, home)
+    routes._handle_memory_write(
+        _FakeHandler(),
+        {"section": "user", "content": "# User\n"},
+    )
+
+    assert "ok" in cap, f"expected success, got {cap}"
+    assert cap["ok"]["ok"] is True
+    assert (real_dir / "USER.md").read_text(encoding="utf-8") == "# User\n"
+
+
+def test_memory_write_real_file_still_works(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+
+    cap = _patch_memory_routes(monkeypatch, home)
+    routes._handle_memory_write(
+        _FakeHandler(),
+        {"section": "memory", "content": "# Memory\n"},
+    )
+
+    target = home / "memories" / "MEMORY.md"
+    assert "ok" in cap, f"expected success, got {cap}"
+    assert cap["ok"]["ok"] is True
+    assert cap["ok"]["section"] == "memory"
+    assert target.read_text(encoding="utf-8") == "# Memory\n"


### PR DESCRIPTION
## Release PM — v0.51.452

Ships **#4242** (zapabob) — security hardening: memory writes refuse a symlinked target file.

### What it does
`_handle_memory_write` (the WebUI memory editor's only write path for `MEMORY.md` / `USER.md` / `SOUL.md`) now rejects the write when the target path is a symlink. A symlink planted at the memory path — e.g. via a restored or imported workspace — can no longer redirect a memory write to clobber an arbitrary file outside the memories directory. This extends the symlink-rejection hardening already shipped for skills and plugins (#4217 / #4234 / #4240), using the same `lstat`-based no-follow `is_symlink()` check as the rest of that class (so dangling symlinks are also caught).

### Deliberate scope (maintainer decision)
The original PR additionally rejected a symlinked **parent** `memories/` directory. That part was intentionally dropped — symlinking the whole `.hermes/memories` directory is a legitimate setup, and the fixed filenames mean a symlinked parent can at most *create* one of three known files in the link-target dir, not clobber an arbitrary existing file. Only the concrete target file is guarded. A regression test pins that the symlinked-parent case is allowed while a symlinked target file is rejected.

### Gate (Codex + Opus + full suite)
- **Codex: SAFE TO SHIP** — guard correctly placed (after target resolution, before write), all three sections covered, no regression. (TOCTOU window noted as defense-in-depth only, consistent with the shipped sibling guards; not a blocker on the single-user authenticated surface.)
- **Opus: safe to ship** — confirmed this is the complete WebUI write surface, dangling-symlink handling correct, dropped parent-dir reject correct, both residual gaps accepted/by-design.
- **Full suite: 9169 passed, 0 failed.** ruff clean.

3 regression tests: symlinked target rejected (external file untouched), symlinked parent dir allowed, real file still written.

Co-authored-by: zapabob
