### PR TITLE
docs(README): correct server stop instructions for start.sh (#4303)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ For self-hosted VM or homelab installs, `ctl.sh` wraps the common daemon lifecyc
 >
 > | Launch method | How to stop |
 > |---|---|
-> | `python3 bootstrap.py` or `./start.sh` | **Ctrl-C** in the terminal (both run in the foreground) |
+> | `python3 bootstrap.py` | **Ctrl-C** in the terminal (runs in the foreground) |
 > | `./ctl.sh start` | `./ctl.sh stop` (sends SIGTERM, waits, then SIGKILL) |
-> | Detached `bootstrap.py` (no `--foreground`) | Find the PID via `lsof -i :8787` (or `ss -tlnp`) and `kill` it |
+> | Detached `bootstrap.py` (no `--foreground`) or `./start.sh` | Find the PID via `lsof -i :8787` (or `ss -tlnp`) and `kill` it |
 >
 > `./ctl.sh stop` cannot stop a server launched by `bootstrap.py` or `start.sh` directly — it only manages processes it started itself.
 


### PR DESCRIPTION
Pulls in #4303 (tomas-forgac) — corrects the README's server-stop table. `./start.sh` exec's `bootstrap.py` *without* `--foreground` (start.sh:65), which double-forks into a detached daemon, so it belongs in the 'find PID via `lsof -i :8787` + kill' row, not the Ctrl-C foreground row. Verified against start.sh + bootstrap.py behavior. Docs-only (README), no version stamp per the docs-only rule.

Co-authored-by: tomas-forgac

Closes #4303.