### PR TITLE
fix(streaming): age-gate stale background-process completions (#4029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stale background-process completion notifications no longer contaminate later turns (#4029).** The WebUI completion-notification drain filtered queued completions only by session ownership, with no age gate — so a `notify_on_complete` background task that finished long ago (or whose completion sat in the queue while the session was idle) had its `[IMPORTANT: ...]` notification prepended to whatever the user typed next, making the agent respond to a stale task and visibly re-delivering already-seen completion notifications. The agent now stamps each completion event with `completed_at` when it is enqueued (`tools/process_registry.py`), and the WebUI drain (`_drain_webui_process_notifications`) drops — silently consumes, without requeueing — any completion older than a configurable cap (default 6h, `HERMES_WEBUI_STALE_COMPLETION_MAX_AGE_SECONDS`, set `0` to disable). Events without a `completed_at` (older agent builds) are never dropped, preserving backward-compatible behavior. The existing session-ownership and consumed-state filters are unchanged, so completions for other tabs still remain queued for their owners. (#4029)
+
 ### Internal
 
 - **Windows pytest-harness compatibility (#3664).** Hardened the test suite to run on Windows: profile-home fallback paths are path-normalized, strict POSIX file-mode (`0o600`) assertions are gated behind `os.name != "nt"` (Linux still asserts them at full strictness), the conftest cleanup handles Windows process-tree/port teardown and the Py3.12+ `shutil.rmtree` `onexc` shim, and tests that require `fork`/`fcntl` carry `@requires_fork` / `@requires_fcntl` markers (which never skip on Linux). Test-only — no runtime or app behavior change, no Linux CI behavior change. (#4254, #4255, #4256, #4257, #4259, #4263, #4266, #4274)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1536,6 +1536,31 @@ def _bind_turn_session_identity(session_id: str):
         _reset_turn_session_identity(tokens)
 
 
+def _stale_completion_max_age_seconds() -> float:
+    """Max age (seconds) a background-process completion may sit in the queue
+    before the WebUI drain treats it as stale and drops it instead of
+    prepending it to the user's next turn.
+
+    Completions older than this are silently consumed (not requeued) so a
+    notification that finally fires long after the user moved on cannot
+    contaminate an unrelated later turn. See nesquena/hermes-webui#4029.
+
+    Configurable via HERMES_WEBUI_STALE_COMPLETION_MAX_AGE_SECONDS. A value of
+    0 (or negative) disables age-gating and restores the legacy drain-all
+    behavior. Defaults to 6 hours.
+    """
+    raw = os.environ.get("HERMES_WEBUI_STALE_COMPLETION_MAX_AGE_SECONDS")
+    if raw is not None:
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid HERMES_WEBUI_STALE_COMPLETION_MAX_AGE_SECONDS=%r; using default",
+                raw,
+            )
+    return 6 * 60 * 60  # 6 hours
+
+
 def _format_process_notification(evt: dict) -> str:
     """Format a completed background process notification for agent input."""
     if not isinstance(evt, dict):
@@ -1606,6 +1631,26 @@ def _drain_webui_process_notifications(session_id: str) -> list[str]:
         if getattr(proc, 'session_key', None) != session_id:
             skipped_events.append(evt)
             continue
+
+        # Age-gate stale completions: a completion that fires long after the
+        # user moved on must not be prepended to an unrelated later turn
+        # (nesquena/hermes-webui#4029). Drop (consume, do not requeue) any
+        # completion whose enqueue time is older than the configured cap.
+        # Events without a 'completed_at' (older agent builds) are never
+        # dropped here, preserving backward-compatible behavior.
+        max_age = _stale_completion_max_age_seconds()
+        if max_age > 0 and isinstance(evt, dict):
+            completed_at = evt.get('completed_at')
+            if isinstance(completed_at, (int, float)) and completed_at > 0:
+                age = time.time() - completed_at
+                if age > max_age:
+                    logger.info(
+                        "Dropping stale background-process completion for "
+                        "session %s (age %.0fs > cap %.0fs)",
+                        evt_sid, age, max_age,
+                    )
+                    _mark_process_completion_consumed(process_registry, evt_sid)
+                    continue
 
         notification = _format_process_notification(evt)
         if notification:

--- a/tests/test_issue4029_stale_completion_age_gate.py
+++ b/tests/test_issue4029_stale_completion_age_gate.py
@@ -1,0 +1,126 @@
+"""Behavioral tests for issue #4029 stale-completion age gate.
+
+These exercise the real `_drain_webui_process_notifications` against a fake
+process_registry, proving that:
+  - a completion older than the cap is dropped (consumed, not requeued),
+  - a fresh completion is still delivered,
+  - events without `completed_at` are never dropped (backward compat),
+  - the env override (incl. disable via 0) is honored.
+"""
+import importlib
+import queue
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+
+def _install_fake_registry(monkeypatch, events):
+    """Build a fake `tools.process_registry` module whose `process_registry`
+    exposes the surface `_drain_webui_process_notifications` touches."""
+    q = queue.Queue()
+    for e in events:
+        q.put(e)
+
+    class _FakeProc:
+        def __init__(self, session_key):
+            self.session_key = session_key
+
+    class _FakeRegistry:
+        def __init__(self):
+            self.completion_queue = q
+            self._lock = threading.RLock()
+            self._completion_consumed = set()
+            # map session_id -> session_key so ownership check passes
+            self._owner = {}
+
+        def is_completion_consumed(self, sid):
+            return sid in self._completion_consumed
+
+        def get(self, sid):
+            key = self._owner.get(sid)
+            return _FakeProc(key) if key is not None else None
+
+    reg = _FakeRegistry()
+    mod = types.ModuleType("tools.process_registry")
+    mod.process_registry = reg
+    # ensure parent package exists
+    if "tools" not in sys.modules:
+        pkg = types.ModuleType("tools")
+        pkg.__path__ = []
+        monkeypatch.setitem(sys.modules, "tools", pkg)
+    monkeypatch.setitem(sys.modules, "tools.process_registry", mod)
+    return reg
+
+
+def _make_event(sid, completed_at, session_key="websess-1"):
+    return {
+        "type": "completion",
+        "session_id": sid,
+        "session_key": session_key,
+        "command": f"cmd-{sid}",
+        "exit_code": 0,
+        "output": f"out-{sid}",
+        **({"completed_at": completed_at} if completed_at is not None else {}),
+    }
+
+
+@pytest.fixture
+def streaming():
+    return importlib.import_module("api.streaming")
+
+
+def test_stale_completion_is_dropped_and_fresh_is_delivered(streaming, monkeypatch):
+    now = time.time()
+    fresh = _make_event("fresh", now - 60)          # 1 min old -> keep
+    stale = _make_event("stale", now - 7 * 3600)    # 7 h old -> drop (cap 6h)
+    reg = _install_fake_registry(monkeypatch, [stale, fresh])
+    reg._owner["fresh"] = "websess-1"
+    reg._owner["stale"] = "websess-1"
+    # default cap = 6h
+    monkeypatch.delenv("HERMES_WEBUI_STALE_COMPLETION_MAX_AGE_SECONDS", raising=False)
+
+    out = streaming._drain_webui_process_notifications("websess-1")
+
+    joined = "\n".join(out)
+    assert "fresh" in joined, "fresh completion should be delivered"
+    assert "stale" not in joined, "stale completion must be dropped"
+    # stale was consumed (won't come back), fresh consumed after delivery
+    assert "stale" in reg._completion_consumed
+    assert "fresh" in reg._completion_consumed
+    # nothing belonging to this session is left requeued
+    assert reg.completion_queue.empty()
+
+
+def test_event_without_completed_at_is_never_dropped(streaming, monkeypatch):
+    now = time.time()
+    legacy = _make_event("legacy", None)  # no completed_at -> backward compat keep
+    reg = _install_fake_registry(monkeypatch, [legacy])
+    reg._owner["legacy"] = "websess-1"
+    monkeypatch.delenv("HERMES_WEBUI_STALE_COMPLETION_MAX_AGE_SECONDS", raising=False)
+
+    out = streaming._drain_webui_process_notifications("websess-1")
+
+    assert any("legacy" in n for n in out), "legacy event (no timestamp) must be delivered"
+
+
+def test_env_zero_disables_age_gate(streaming, monkeypatch):
+    now = time.time()
+    ancient = _make_event("ancient", now - 10 * 24 * 3600)  # 10 days old
+    reg = _install_fake_registry(monkeypatch, [ancient])
+    reg._owner["ancient"] = "websess-1"
+    monkeypatch.setenv("HERMES_WEBUI_STALE_COMPLETION_MAX_AGE_SECONDS", "0")
+
+    out = streaming._drain_webui_process_notifications("websess-1")
+
+    assert any("ancient" in n for n in out), "age gate disabled -> even ancient delivered"
+
+
+def test_helper_reads_env_override(streaming, monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_STALE_COMPLETION_MAX_AGE_SECONDS", "120")
+    assert streaming._stale_completion_max_age_seconds() == 120.0
+    monkeypatch.setenv("HERMES_WEBUI_STALE_COMPLETION_MAX_AGE_SECONDS", "not-a-number")
+    # invalid -> falls back to default 6h
+    assert streaming._stale_completion_max_age_seconds() == 6 * 60 * 60

--- a/tests/test_notify_on_complete_webui.py
+++ b/tests/test_notify_on_complete_webui.py
@@ -28,3 +28,20 @@ def test_webui_sets_gateway_session_platform_for_background_watchers():
     assert "os.environ['HERMES_SESSION_PLATFORM'] = 'webui'" in src
     assert "old_session_platform = os.environ.get('HERMES_SESSION_PLATFORM')" in src
     assert "os.environ.pop('HERMES_SESSION_PLATFORM', None)" in src
+
+
+def test_webui_age_gates_stale_background_completion_events():
+    """Issue #4029: drain must drop completions older than the configured cap
+    so stale notifications can't be prepended to an unrelated later turn."""
+    src = Path("api/streaming.py").read_text(encoding="utf-8")
+
+    # The age-gate helper + its env override exist.
+    assert "def _stale_completion_max_age_seconds()" in src
+    assert "HERMES_WEBUI_STALE_COMPLETION_MAX_AGE_SECONDS" in src
+    # The drain reads completed_at and drops over-age events without requeueing.
+    assert "completed_at = evt.get('completed_at')" in src
+    assert "age = time.time() - completed_at" in src
+    assert "if age > max_age:" in src
+    # Over-age events are consumed (marked), not requeued, so they vanish.
+    assert "_mark_process_completion_consumed(process_registry, evt_sid)" in src
+


### PR DESCRIPTION
## Summary

Fixes #4029 — stale background-process completion notifications being prepended to a later, unrelated user turn.

When a `notify_on_complete` background task's completion fired long after the user moved on (or sat in the queue while the session was idle), `_drain_webui_process_notifications` concatenated its `[IMPORTANT: ... completed]` notification ahead of whatever the user typed next. The agent then responded to the **old** task, and the user saw already-delivered completion notifications re-appear on every subsequent message.

Root cause (confirmed by the maintainer in #4029): the drain filters the process-wide `completion_queue` **only by session ownership and consumed-state — there is no age gate**, and the completion event carried no timestamp to gate on.

## Approach

Implements the maintainer's recommended **Option B (absolute completion-age cap)**, which needs the timestamp added at the source:

1. **Agent side** (`tools/process_registry.py`, separate repo): stamp each completion event with `completed_at = time.time()` when it is enqueued. *This is the missing primitive — without it the WebUI can't tell a 5-minute-old completion from a 5-day-old one.*
2. **WebUI side** (this PR): in `_drain_webui_process_notifications`, drop (silently consume, **do not requeue**) any completion whose `completed_at` is older than a configurable cap. Existing session-ownership + consumed-state filters are unchanged.

## Cross-repo note

The `completed_at` field is produced by the **hermes-agent** repo (`tools/process_registry.py`). This WebUI change is **safe to land independently**: events without `completed_at` (older agent builds) are never dropped, so the drain keeps its current behavior until the agent side ships the timestamp. I've made the matching agent-side change locally and can open that PR against the agent repo too — flagging here so the layering is explicit (a WebUI-only patch can't age-gate correctly on its own, per the maintainer's note).

## Config

- `HERMES_WEBUI_STALE_COMPLETION_MAX_AGE_SECONDS` — cap in seconds. Default **6h** (maintainer-suggested). Set `0` (or negative) to disable age-gating and restore legacy drain-all behavior. Invalid values log a warning and fall back to the default.

## Tests

`tests/test_issue4029_stale_completion_age_gate.py` exercises the **real** drain against a fake `process_registry`:
- stale completion (7h, cap 6h) is dropped + consumed; fresh completion (1 min) is delivered
- event without `completed_at` (legacy agent) is never dropped — backward compat
- env override `0` disables the gate (even a 10-day-old completion is delivered)
- helper honors the env override and falls back to default on invalid input

Plus a source-assertion guard added to `tests/test_notify_on_complete_webui.py`.

All 8 tests pass (`pytest tests/test_issue4029_stale_completion_age_gate.py tests/test_notify_on_complete_webui.py`).

CHANGELOG updated under `[Unreleased] / Fixed`.
