### PR TITLE
start.sh: detect already-running server and inform the user accordingly

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -62,4 +62,62 @@ if [[ -z "${PYTHON}" ]]; then
   fi
 fi
 
+# Pre-flight: detect an already-running server before launching bootstrap.py.
+#
+# bootstrap.py's detached (non-foreground) path spawns server.py, then probes
+# /health and reports success once *anything* answers. If a server is already
+# bound to this host:port, the freshly spawned child fails to bind and dies,
+# but the EXISTING (often orphaned) server answers the /health probe — so
+# bootstrap.py prints "ready" and exits 0 without having started anything. The
+# user just keeps re-confirming the old instance on every run.
+#
+# To avoid that, probe /health here first. If a server is already up, tell the
+# user plainly that nothing was (re)started and how to restart, then exit 0.
+# ctl.sh already refuses to double-start via PID/state tracking; this brings
+# the detached start.sh path to parity using a health probe (start.sh keeps no
+# PID file of its own).
+#
+# Resolve host/port the same way bootstrap.py does: HERMES_WEBUI_HOST /
+# HERMES_WEBUI_PORT (possibly just sourced from .env above), else the
+# bootstrap.py defaults of 127.0.0.1 / 8787. A 0.0.0.0 / :: bind is probed via
+# loopback, matching server.py's _abort_if_already_serving.
+_hermes_host="${HERMES_WEBUI_HOST:-127.0.0.1}"
+_hermes_port="${HERMES_WEBUI_PORT:-8787}"
+case "${_hermes_host}" in
+  0.0.0.0|""|::|"[::]") _hermes_probe_host="127.0.0.1" ;;
+  *) _hermes_probe_host="${_hermes_host}" ;;
+esac
+_hermes_health_url="http://${_hermes_probe_host}:${_hermes_port}/health"
+
+# Best-effort probe. If neither curl nor wget is present we skip the check and
+# fall through to the normal launch (unchanged behavior). Short 2s timeout so a
+# normal cold start is not delayed.
+_hermes_already_up=""
+if command -v curl >/dev/null 2>&1; then
+  _hermes_already_up="$(curl -fsS --max-time 2 "${_hermes_health_url}" 2>/dev/null || true)"
+elif command -v wget >/dev/null 2>&1; then
+  _hermes_already_up="$(wget -qO- --timeout=2 --tries=1 "${_hermes_health_url}" 2>/dev/null || true)"
+fi
+
+if [[ -n "${_hermes_already_up}" ]]; then
+  cat >&2 <<EOF
+[==] Hermes WebUI is already running at http://${_hermes_probe_host}:${_hermes_port}
+     The server was NOT started again (start.sh does not double-start).
+
+     If you need to restart the server, do the following:
+
+     Preferred — use the daemon controller:
+       ./ctl.sh restart
+
+     Otherwise, stop the running server and start it again manually:
+       1. Find the process listening on port ${_hermes_port}:
+            lsof -iTCP:${_hermes_port} -sTCP:LISTEN      # macOS / Linux
+       2. Stop it (use -9 only if it ignores a normal stop):
+            kill <PID>
+       3. Start it again:
+            ./start.sh
+EOF
+  exit 0
+fi
+
 exec "${PYTHON}" "${REPO_ROOT}/bootstrap.py" --no-browser "$@"


### PR DESCRIPTION
When the server is running and user runs start.sh, currently the script pretends it starts the server

Instead, this change makes the script inform the user that the server is already running, that it hasn't started a new instance. It also tells the user how to restart the server if that's what their intention was.