### PR TITLE
Recognize command STT providers in voice capability probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Voice transcription capability checks now recognize Hermes named command STT providers.** WebUI's `/api/transcribe/capability` now treats explicit `stt.provider` values that resolve through Hermes Agent's `stt.providers.<name>: type: command` registry as available, so browser voice recordings can use custom command-backed providers instead of falling back to browser speech recognition or raw audio uploads.
+
 ### Internal
 
 - **Windows pytest-harness compatibility (#3664).** Hardened the test suite to run on Windows: profile-home fallback paths are path-normalized, strict POSIX file-mode (`0o600`) assertions are gated behind `os.name != "nt"` (Linux still asserts them at full strictness), the conftest cleanup handles Windows process-tree/port teardown and the Py3.12+ `shutil.rmtree` `onexc` shim, and tests that require `fork`/`fcntl` carry `@requires_fork` / `@requires_fcntl` markers (which never skip on Linux). Test-only — no runtime or app behavior change, no Linux CI behavior change. (#4254, #4255, #4256, #4257, #4259, #4263, #4266, #4274)

--- a/api/upload.py
+++ b/api/upload.py
@@ -457,6 +457,13 @@ def _stt_provider_capability_from_module(stt):
             # non-WAV input through ffmpeg before invoking the command.
             return has_local_command() and has_browser_audio_converter()
 
+        def command_provider_available(provider):
+            resolver = getattr(stt, "_resolve_command_stt_provider_config", None)
+            try:
+                return callable(resolver) and resolver(provider, cfg_dict) is not None
+            except Exception:
+                return False
+
         def resolve_provider(provider):
             if provider == "local":
                 if bool(getattr(stt, "_HAS_FASTER_WHISPER", False)):
@@ -485,6 +492,8 @@ def _stt_provider_capability_from_module(stt):
                     return "none"
             if provider == "elevenlabs":
                 return "elevenlabs" if bool(env("ELEVENLABS_API_KEY")) else "none"
+            if command_provider_available(provider):
+                return provider
             return "none"
 
         explicit = "provider" in cfg_dict

--- a/tests/test_voice_transcribe_endpoint.py
+++ b/tests/test_voice_transcribe_endpoint.py
@@ -156,3 +156,31 @@ def test_handle_transcribe_capability_reports_actual_local_command_fallback(monk
 
     assert available is True
     assert provider == "local_command"
+
+
+def test_handle_transcribe_capability_reports_named_command_provider(monkeypatch):
+    stt_config = {
+        "provider": "elevenlabs-gemini",
+        "providers": {
+            "elevenlabs-gemini": {
+                "type": "command",
+                "command": "/home/user/.hermes/scripts/hermes-elevenlabs-stt.sh {input}",
+            }
+        },
+    }
+    fake_mod = types.ModuleType("tools.transcription_tools")
+    fake_mod.__dict__.update(
+        {
+            "_load_stt_config": lambda: stt_config,
+            "is_stt_enabled": lambda cfg=None: True,
+            "_HAS_FASTER_WHISPER": False,
+            "_HAS_OPENAI": False,
+            "_HAS_MISTRAL": False,
+            "_resolve_command_stt_provider_config": lambda provider, cfg: cfg["providers"].get(provider),
+        }
+    )
+
+    available, provider = _stt_provider_capability_from_module(fake_mod)
+
+    assert available is True
+    assert provider == "elevenlabs-gemini"


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI aims to reuse the user's existing Hermes Agent setup rather than maintain separate provider logic.
- Hermes Agent now supports explicit named STT providers through `stt.providers.<name>: type: command`.
- WebUI's passive `/api/transcribe/capability` probe still only recognized built-in STT providers, so explicit command-backed providers were reported unavailable even though `transcribe_audio()` could handle them.
- The fix is to delegate that provider recognition to Hermes Agent's resolver when it is available, without invoking transcription or lazy installs during the probe.

## What Changed

- Added command-provider recognition to `_stt_provider_capability_from_module()` via Hermes Agent's `_resolve_command_stt_provider_config()` helper.
- Added a regression test for an explicit named command provider such as `stt.provider: elevenlabs-gemini`.
- Added an Unreleased changelog note.

## Why It Matters

Browser voice recordings can now use custom command-backed Hermes STT providers instead of being incorrectly treated as unavailable and falling back to browser speech recognition or raw audio upload flows.

## Verification

- `./scripts/test.sh tests/test_voice_transcribe_endpoint.py -q` → `8 passed`
- `git diff --check` → clean
- `ruff check api/upload.py tests/test_voice_transcribe_endpoint.py` was attempted; it reports pre-existing unused imports/variables in `api/upload.py` unrelated to this change, so I left them untouched to keep the PR focused.

## Risks / Follow-ups

- This is a passive capability probe only. It does not execute command providers and does not change the actual transcription path.
- If a future Hermes Agent release renames `_resolve_command_stt_provider_config()`, WebUI will fall back to the previous behavior for named command providers until it is updated.

## Contract Routing

Task type: backend capability-probe bug fix
Touched areas:
- `api/upload.py`
- `tests/test_voice_transcribe_endpoint.py`
- `CHANGELOG.md`
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
Scope boundaries:
- No UI flow, streaming, session-state, or security contract changes.
Evidence needed before claiming done:
- Focused endpoint regression test passes.

## Model Used

OpenAI GPT-5.5 via Hermes Agent, with file/terminal tool use.
