### PR TITLE
Release v0.51.457 — gateway watcher non-blocking startup (#4297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.457] — 2026-06-16 — Release PR (gateway watcher can't brick startup)
+
+### Fixed
+
+- **Gateway watcher startup is now non-blocking (#4297).** `start_watcher()` ran synchronously in `main()` during boot, so if `_resolve_watcher_target()` stalled (a locked `state.db`, slow profile/home resolution, or an I/O block) the WebUI would never bind its port — a startup brick. It now starts on a daemon thread with a 5-second join, so the server proceeds to bind even when watcher initialization is slow; the watcher's own poll loop already ran on a separate daemon thread, so real-time SSE liveness is unchanged. Thanks @minidarkmimi.
+
 ### Internal
 
 - **Windows pytest-harness compatibility (#3664).** Hardened the test suite to run on Windows: profile-home fallback paths are path-normalized, strict POSIX file-mode (`0o600`) assertions are gated behind `os.name != "nt"` (Linux still asserts them at full strictness), the conftest cleanup handles Windows process-tree/port teardown and the Py3.12+ `shutil.rmtree` `onexc` shim, and tests that require `fork`/`fcntl` carry `@requires_fork` / `@requires_fcntl` markers (which never skip on Linux). Test-only — no runtime or app behavior change, no Linux CI behavior change. (#4254, #4255, #4256, #4257, #4259, #4263, #4266, #4274)

--- a/server.py
+++ b/server.py
@@ -593,7 +593,18 @@ def main() -> None:
     # Start the gateway session watcher for real-time SSE updates
     try:
         from api.gateway_watcher import start_watcher
-        start_watcher()
+
+        def _start_watcher_safe():
+            try:
+                start_watcher()
+            except Exception as e:
+                print(f'[!!] WARNING: Gateway watcher failed to start: {e}', flush=True)
+
+        t = threading.Thread(target=_start_watcher_safe, daemon=True)
+        t.start()
+        t.join(timeout=5)
+        if t.is_alive():
+            print('[tip] Gateway watcher still initializing (non-blocking)', flush=True)
     except Exception as e:
         print(f'[!!] WARNING: Gateway watcher failed to start: {e}', flush=True)
 


### PR DESCRIPTION
## v0.51.457 — Release PR (gateway watcher can't brick startup)

Single brick-class fix.

### #4297 — gateway watcher non-blocking startup (@minidarkmimi)

`start_watcher()` ran synchronously in `main()` during boot. Its synchronous surface (`_resolve_watcher_target()` → profile/home resolution + `_watcher_lock` acquisition) could block on a locked `state.db`, slow profile resolution, or an I/O stall — and because it ran before the bind/accept loop, the WebUI would **never bind its port**. A startup brick.

Fix: run it on a `daemon=True` thread with a 5-second `join`, so boot proceeds to bind even when watcher init is slow. The watcher's poll loop already runs on its own daemon thread (`api/gateway_watcher.py:235`), so real-time SSE liveness is unchanged.

### Gate
- Full pytest suite: **9186 passed, 9 skipped** (exit 0)
- Codex regression gate: **SAFE TO SHIP**
- Opus advisor: **Ship it** (refined the precise blocking surface; fix sound, error handling preserved)
- Ruff forward gate: clean
- revert-guard: PASS (cut from fresh origin/master)

Attribution: original author @minidarkmimi (Co-authored-by trailer on the fix commit).
