### PR TITLE
Release v0.51.460 — recognize command STT providers in voice probe (#4312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.460] — 2026-06-16 — Release PU (custom voice providers recognized)
+
+### Fixed
+
+- **Command (custom) speech-to-text providers are now recognized by the voice capability probe (#4312).** When `stt.provider` pointed at a Hermes command-type STT provider, the WebUI's `/api/transcribe/capability` probe only knew the built-in providers, so it reported voice input as unavailable and the browser fell back unnecessarily. The probe now delegates command-provider recognition to the agent's own resolver (`_resolve_command_stt_provider_config`) as the single source of truth, consulted after the built-in chain. Thanks @LLMinem.
+
 ## [v0.51.459] — 2026-06-16 — Release PT (your message stays your message)
 
 ### Fixed

--- a/api/upload.py
+++ b/api/upload.py
@@ -457,6 +457,13 @@ def _stt_provider_capability_from_module(stt):
             # non-WAV input through ffmpeg before invoking the command.
             return has_local_command() and has_browser_audio_converter()
 
+        def command_provider_available(provider):
+            resolver = getattr(stt, "_resolve_command_stt_provider_config", None)
+            try:
+                return callable(resolver) and resolver(provider, cfg_dict) is not None
+            except Exception:
+                return False
+
         def resolve_provider(provider):
             if provider == "local":
                 if bool(getattr(stt, "_HAS_FASTER_WHISPER", False)):
@@ -485,6 +492,8 @@ def _stt_provider_capability_from_module(stt):
                     return "none"
             if provider == "elevenlabs":
                 return "elevenlabs" if bool(env("ELEVENLABS_API_KEY")) else "none"
+            if command_provider_available(provider):
+                return provider
             return "none"
 
         explicit = "provider" in cfg_dict
@@ -494,6 +503,12 @@ def _stt_provider_capability_from_module(stt):
             return provider != "none", provider if provider != "none" else configured
 
         for candidate in ("local", "local_command", "groq", "openai", "mistral", "xai", "elevenlabs"):
+            # Command (custom) STT providers are intentionally omitted from this
+            # auto-detect tuple to mirror the agent's _get_provider() (transcription_tools.py),
+            # which only auto-selects local > groq > openai and never auto-picks a command
+            # provider. A command-backed STT activates only via an explicit stt.provider.
+            # Do NOT add command providers here without matching the agent, or the WebUI
+            # probe will diverge from what the agent actually resolves.
             provider = resolve_provider(candidate)
             if provider != "none":
                 return True, provider

--- a/tests/test_voice_transcribe_endpoint.py
+++ b/tests/test_voice_transcribe_endpoint.py
@@ -156,3 +156,31 @@ def test_handle_transcribe_capability_reports_actual_local_command_fallback(monk
 
     assert available is True
     assert provider == "local_command"
+
+
+def test_handle_transcribe_capability_reports_named_command_provider(monkeypatch):
+    stt_config = {
+        "provider": "elevenlabs-gemini",
+        "providers": {
+            "elevenlabs-gemini": {
+                "type": "command",
+                "command": "/home/user/.hermes/scripts/hermes-elevenlabs-stt.sh {input}",
+            }
+        },
+    }
+    fake_mod = types.ModuleType("tools.transcription_tools")
+    fake_mod.__dict__.update(
+        {
+            "_load_stt_config": lambda: stt_config,
+            "is_stt_enabled": lambda cfg=None: True,
+            "_HAS_FASTER_WHISPER": False,
+            "_HAS_OPENAI": False,
+            "_HAS_MISTRAL": False,
+            "_resolve_command_stt_provider_config": lambda provider, cfg: cfg["providers"].get(provider),
+        }
+    )
+
+    available, provider = _stt_provider_capability_from_module(fake_mod)
+
+    assert available is True
+    assert provider == "elevenlabs-gemini"


### PR DESCRIPTION
# Release gate brief — stage-4312 (v0.51.460)

Single small fix-class PR. Warm-up dossier already rated CLEAN ship-ready (fail-on-master/pass-on-PR proven, Layer1 threat-scan clean, Layer3 sandbox green). This is the authoritative ship gate.

## #4312 — recognize command STT providers in voice capability probe (LLMinem)
File: `api/upload.py` (`_stt_provider_capability_from_module`, +9), `tests/test_voice_transcribe_endpoint.py` (+28). Plus a maintainer-added clarifying comment.

### The bug
`/api/transcribe/capability`'s `resolve_provider()` only knew built-in STT providers (local/groq/openai/mistral/xai/elevenlabs). An explicit `stt.provider: <command-type-provider>` was reported unavailable → browser fell back unnecessarily (no voice input).

### The fix
- New `command_provider_available(provider)`: `getattr(stt, "_resolve_command_stt_provider_config", None)`, `callable(...) and resolver(provider, cfg_dict) is not None`, wrapped in `try/except → False`. Matches the existing defensive helper style (`has_local_command`, `has_browser_audio_converter`).
- Consulted as the FINAL fallthrough in `resolve_provider()`, after the built-in elif chain. The agent rejects built-in names internally (`transcription_tools.py:322`, returns None for built-ins + "none"), so ordering can't shadow a native provider.
- Maintainer added a clarifying comment that command providers are intentionally omitted from the explicit-absent auto-detect tuple, to mirror the agent's `_get_provider()` precedence (which only auto-selects local>groq>openai).

### Cross-repo contract (verified)
`_resolve_command_stt_provider_config(provider, stt_config)` exists at `~/.hermes/hermes-agent/tools/transcription_tools.py:322`; arg order matches the call site. `callable(resolver)` guard means older agents without the helper fall back gracefully.

## Verification questions
1. Is the new branch purely a PASSIVE config probe (no transcription, no install, no network)? Confirm it can't trigger any side effect.
2. Ordering: command check placed AFTER all built-in early-returns — can a user's `stt.providers.openai.command` shadow the real OpenAI handler? (Agent rejects built-in names, so it shouldn't.)
3. `try/except Exception → False` — correct graceful-degradation if the agent helper is absent/renamed?
4. Does the new test actually exercise the real call path (not a mock that masks the branch)?

Focused read; do NOT write extensive repro harnesses.
