### PR TITLE
fix(#4326): reject embedded null byte in remote workspace candidate

### DIFF
--- a/api/workspace.py
+++ b/api/workspace.py
@@ -163,6 +163,8 @@ def _remote_terminal_workspace_candidate(path: str | Path) -> Path | None:
     raw = _strip_surrounding_quotes(str(path)).strip()
     if not raw:
         return None
+    if '\x00' in raw or '\x00' in cwd:
+        return None
     normalized_raw = _normalize_posix_path(raw)
     normalized_cwd = _normalize_posix_path(cwd)
     if normalized_raw is not None and normalized_cwd is not None:

--- a/tests/test_remote_terminal_workspace.py
+++ b/tests/test_remote_terminal_workspace.py
@@ -90,3 +90,23 @@ def test_var_home_workspaces_stay_allowed_before_system_root_blocklist(monkeypat
     monkeypatch.setattr(workspace, "_workspace_access_error", lambda _candidate: None)
 
     assert validator(str(candidate)) == candidate
+
+
+def test_remote_terminal_workspace_rejects_embedded_nullbyte_in_raw_path(monkeypatch):
+    """Embedded null bytes in remote workspace path should be rejected."""
+    monkeypatch.setattr(api_config, "get_config", lambda: _remote_config())
+
+    # Path with embedded null byte
+    nullbyte_path = f"{REMOTE_CWD}/projects\x00/demo"
+
+    assert workspace._remote_terminal_workspace_candidate(nullbyte_path) is None
+
+
+def test_remote_terminal_workspace_rejects_embedded_nullbyte_in_cwd(monkeypatch):
+    """Embedded null bytes in remote terminal cwd should be rejected."""
+    monkeypatch.setattr(api_config, "get_config", lambda: _remote_config(terminal={"backend": "ssh", "cwd": f"{REMOTE_CWD}\x00/malicious"}))
+
+    # Normal path, but remote cwd contains null byte
+    normal_path = f"{REMOTE_CWD}/projects/demo"
+
+    assert workspace._remote_terminal_workspace_candidate(normal_path) is None


### PR DESCRIPTION
## Thinking Path

- The #4273 workspace trust-boundary hardening shipped in v0.51.463, but both Opus gate passes flagged `_remote_terminal_workspace_candidate` as the one residual: it reads `raw` and `cwd` without rejecting embedded null bytes.
- The rest of the file already fails closed on `\x00` through `_as_posix_path` (line 111) and `_safe_resolve` (line 416), but the remote function's `else` fallback at line 176 bypasses both gates.
- Adding an early null-byte rejection at the top of the function aligns the remote boundary with the local one, matching the `_as_posix_path` pattern.

## What Changed

- `api/workspace.py`: add `\x00` rejection guard at the top of `_remote_terminal_workspace_candidate`, returning `None` before any path parsing when either `raw` or `cwd` contains a null byte
- `tests/test_remote_terminal_workspace.py`: add null-byte remote-candidate regression cases mirroring `tests/test_4273_expanduser_and_nullbyte.py`

## Why It Matters

Closes a residual fail-open on the remote workspace trust boundary so the entire #4273 hardening surface consistently rejects embedded null bytes. Low severity (remote profiles only, no path-traversal escape), but the inconsistency on a security boundary is worth closing for defense-in-depth.

## Verification

```
pytest tests/test_remote_terminal_workspace.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- None expected. The change is additive (new guard + new tests) and matches an established pattern in the same file.

## Upstream

Closes #4326.

## Model Used

Claude Opus 4.6 via Claude Code CLI
