### PR TITLE
fix(#4325): use semantic viewport anchoring for stream-end scroll restore

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -9708,6 +9708,7 @@ function renderMessages(options){
   const worklogDetailDisclosureState=_captureWorklogDetailDisclosureState(inner);
   _programmaticScroll=true;
   inner.innerHTML='';
+  _programmaticScroll=false;
   const compressionNode=compressionState?_compressionCardsNode(compressionState):null;
   const {message:referenceMessage, rawIdx:referenceMessageRawIdx}=_latestCompressionReferenceMessage(
     S.messages,

--- a/static/ui.js
+++ b/static/ui.js
@@ -9492,9 +9492,26 @@ function _restoreMessageScrollSnapshot(snapshot){
 function _restoreMessageScrollSnapshotSameFrame(snapshot){
   const el=$('messages');
   if(!el||!snapshot) return;
-  const restoredViaAnchor=(snapshot.anchor&&typeof _restoreMessageViewportAnchor==='function')
+  let restoredViaAnchor=(snapshot.anchor&&typeof _restoreMessageViewportAnchor==='function')
     ? _restoreMessageViewportAnchor(snapshot.anchor,0)
     : false;
+  if(!restoredViaAnchor&&snapshot.anchor&&snapshot.anchor.rawIdx!=null&&
+     !el.querySelector(`[data-msg-idx="${snapshot.anchor.rawIdx}"]`)&&
+     typeof _getVisibleMessagesWithIdx==='function'&&
+     typeof _messageVisibleIndexForRawIdx==='function'&&
+     typeof _messageVirtualScrollTopForVisibleIdx==='function'){
+    const visWithIdx=_getVisibleMessagesWithIdx();
+    const visIdx=_messageVisibleIndexForRawIdx(snapshot.anchor.rawIdx,visWithIdx);
+    if(visIdx>=0){
+      _programmaticScroll=true;
+      el.scrollTop=_messageVirtualScrollTopForVisibleIdx(visWithIdx,visIdx,el);
+      _messageVirtualWindowKey='';
+      renderMessages({preserveScroll:true});
+      restoredViaAnchor=(typeof _restoreMessageViewportAnchor==='function')
+        ? _restoreMessageViewportAnchor(snapshot.anchor,0)
+        : false;
+    }
+  }
   if(!restoredViaAnchor){
     const maxTop=Math.max(0,el.scrollHeight-el.clientHeight);
     const bottom=Number(snapshot.bottom);

--- a/static/ui.js
+++ b/static/ui.js
@@ -9492,13 +9492,18 @@ function _restoreMessageScrollSnapshot(snapshot){
 function _restoreMessageScrollSnapshotSameFrame(snapshot){
   const el=$('messages');
   if(!el||!snapshot) return;
-  const maxTop=Math.max(0,el.scrollHeight-el.clientHeight);
-  const bottom=Number(snapshot.bottom);
-  const target=(snapshot.pinned===true&&Number.isFinite(bottom))
-    ? maxTop-Math.max(0,bottom)
-    : Number(snapshot.top)||0;
-  _programmaticScroll=true;
-  el.scrollTop=Math.max(0,Math.min(target,maxTop));
+  const restoredViaAnchor=(snapshot.anchor&&typeof _restoreMessageViewportAnchor==='function')
+    ? _restoreMessageViewportAnchor(snapshot.anchor,0)
+    : false;
+  if(!restoredViaAnchor){
+    const maxTop=Math.max(0,el.scrollHeight-el.clientHeight);
+    const bottom=Number(snapshot.bottom);
+    const target=(snapshot.pinned===true&&Number.isFinite(bottom))
+      ? maxTop-Math.max(0,bottom)
+      : Number(snapshot.top)||0;
+    _programmaticScroll=true;
+    el.scrollTop=Math.max(0,Math.min(target,maxTop));
+  }
   _lastScrollTop=el.scrollTop;
   if(snapshot.pinned===true){
     _messageUserUnpinned=false;
@@ -9509,7 +9514,9 @@ function _restoreMessageScrollSnapshotSameFrame(snapshot){
     _scrollPinned=false;
     _nearBottomCount=0;
   }
-  requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+  if(!restoredViaAnchor){
+    requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+  }
 }
 function _renderMessagesWithScrollSnapshot(options){
   const scrollSnapshot=_captureMessageScrollSnapshot();
@@ -9699,6 +9706,7 @@ function renderMessages(options){
     S.session && typeof S.session.compression_anchor_summary==='string'
   ) ? S.session.compression_anchor_summary.trim() : '';
   const worklogDetailDisclosureState=_captureWorklogDetailDisclosureState(inner);
+  _programmaticScroll=true;
   inner.innerHTML='';
   const compressionNode=compressionState?_compressionCardsNode(compressionState):null;
   const {message:referenceMessage, rawIdx:referenceMessageRawIdx}=_latestCompressionReferenceMessage(

--- a/static/ui.js
+++ b/static/ui.js
@@ -9706,9 +9706,7 @@ function renderMessages(options){
     S.session && typeof S.session.compression_anchor_summary==='string'
   ) ? S.session.compression_anchor_summary.trim() : '';
   const worklogDetailDisclosureState=_captureWorklogDetailDisclosureState(inner);
-  _programmaticScroll=true;
   inner.innerHTML='';
-  _programmaticScroll=false;
   const compressionNode=compressionState?_compressionCardsNode(compressionState):null;
   const {message:referenceMessage, rawIdx:referenceMessageRawIdx}=_latestCompressionReferenceMessage(
     S.messages,

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -427,3 +427,93 @@ console.log(JSON.stringify({recovered, deletes, renderCalls}));
     assert metrics["recovered"] is True
     assert metrics["deletes"] == ["sid-123"]
     assert metrics["renderCalls"] == [{"preserveScroll": True, "_virtualFallback": True}]
+
+
+def test_same_frame_restore_nudges_virtual_window_when_anchor_row_is_missing():
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + r"""
+const ROW_HEIGHT = 120;
+const TOTAL = 60;
+
+// Rows 10-59 are mounted (tail window); rows 0-9 are virtualized out.
+// Anchor points to rawIdx=5, which is in the virtualized zone.
+let mountedStart = 10;
+let scrollTopValue = 0;
+let renderCalls = [];
+let scrollTopHistory = [];
+let _messageVirtualWindowKey = 'stale-key';
+let _programmaticScroll = false;
+let _lastScrollTop = 0;
+let _messageUserUnpinned = true;
+let _scrollPinned = false;
+let _nearBottomCount = 0;
+let _messageVirtualHeightCache = Array.from({length: TOTAL}, () => ROW_HEIGHT);
+let _messageVirtualHeightCacheEntries = [];
+let _messageVirtualHeightCacheLen = TOTAL;
+let _messageVirtualHeightCacheSrc = null;
+let _messageVirtualEstimatedRowHeight = ROW_HEIGHT;
+
+function _clearMessageVirtualHeightCache(){}
+function _syncMessageVirtualHeightCache(){}
+
+const container = {
+  get scrollTop(){ return scrollTopValue; },
+  set scrollTop(v){ scrollTopHistory.push(v); scrollTopValue = v; },
+  get scrollHeight(){ return TOTAL * ROW_HEIGHT; },
+  get clientHeight(){ return 600; },
+  getBoundingClientRect(){ return {top: 0, bottom: 600}; },
+  querySelector(selector){
+    const m = selector && selector.match(/\[data-msg-idx="(\d+)"\]/);
+    if(!m) return null;
+    const idx = Number(m[1]);
+    if(idx < mountedStart || idx >= TOTAL) return null;
+    const top = (idx - mountedStart) * ROW_HEIGHT;
+    return { getBoundingClientRect(){ return {top, bottom: top + ROW_HEIGHT}; } };
+  },
+};
+function $(id){ return id === 'messages' ? container : null; }
+
+function _getVisibleMessagesWithIdx(){
+  return Array.from({length: TOTAL}, (_, i) => ({rawIdx: i}));
+}
+
+function renderMessages(opts){
+  renderCalls.push(JSON.parse(JSON.stringify(opts)));
+  mountedStart = 0;
+}
+
+function _restoreMessageViewportAnchor(anchor, delta){
+  const idx = Number(anchor.rawIdx) + Number(delta||0);
+  const row = container.querySelector(`[data-msg-idx="${idx}"]`);
+  if(!row) return false;
+  _programmaticScroll = true;
+  return true;
+}
+
+eval(extractFunc('_messageVisibleIndexForRawIdx'));
+eval(extractFunc('_messageVirtualScrollTopForVisibleIdx'));
+eval(extractFunc('_restoreMessageScrollSnapshotSameFrame'));
+
+const snapshot = {
+  anchor: {rawIdx: 5, topOffset: 50},
+  top: 100,
+  bottom: 6600,
+  scrollHeight: 7200,
+  pinned: false,
+  userUnpinned: true,
+};
+_restoreMessageScrollSnapshotSameFrame(snapshot);
+console.log(JSON.stringify({renderCalls, scrollTopHistory}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert len(metrics["renderCalls"]) == 1, (
+        "_restoreMessageScrollSnapshotSameFrame must call renderMessages to mount the virtualized-out anchor row"
+    )
+    assert metrics["renderCalls"][0].get("preserveScroll") is True, (
+        "re-render must use preserveScroll:true to avoid scrolling to bottom"
+    )
+    assert len(metrics["scrollTopHistory"]) >= 1, (
+        "scrollTop must be adjusted before re-render to place anchor row in the virtual window"
+    )
+    # rawIdx=5, visIdx=5: offset=5*120=600, viewport=600, scrollTop=round(600-600*0.35)=390
+    assert metrics["scrollTopHistory"][0] == 390


### PR DESCRIPTION
## Thinking Path

- The transcript virtualization shipped in v0.51.440 (#500/#4214) introduced a render-window mechanism that starts at 50 messages and expands to all messages on stream completion. When `_finishDone()` expands the window and calls `renderMessages({preserveScroll:true})`, previously-hidden earlier messages are prepended to the DOM, changing `scrollHeight` dramatically.
- The current scroll restore functions (`_restoreMessageScrollSnapshot`, `_restoreMessageScrollSnapshotSameFrame`) use pixel-based `scrollTop` values that become invalid when the DOM height changes underneath them. The infrastructure for semantic message anchoring already exists (`_captureMessageViewportAnchor` / `_restoreMessageViewportAnchor`) and was wired into the blank-viewport recovery path in #4281, but was never used by the primary scroll-after-render path.
- Wiring anchor-based restore as the first-choice strategy in both `_scrollAfterMessageRender` and `_restoreMessageScrollSnapshotSameFrame` makes the viewport survive DOM height changes from render-window expansion, while falling back to pixel-based restore when the anchor row is no longer rendered.

## What Changed

- `static/ui.js`: `_scrollAfterMessageRender` now tries `_restoreMessageViewportAnchor(snapshot.anchor)` before falling back to pixel-based `_restoreMessageScrollSnapshot`
- `static/ui.js`: `_restoreMessageScrollSnapshotSameFrame` tries anchor-based restore first, falls back to pixel-based bottom-distance calculation
- `static/ui.js`: `_restoreMessageScrollSnapshot` tries anchor-based restore first, falls back to the existing pixel-based path

## Why It Matters

Users in sessions with 50+ messages see a freeze, scroll jump to early messages, and sometimes need a manual page reload when a streaming response completes. The regression makes longer conversations unusable after each response finishes.

## Verification

```
pytest tests/test_issue500_message_list_virtualization.py tests/test_tars_scroll_reset_regressions.py tests/test_smooth_text_fade.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- PR [#4110](https://github.com/nesquena/hermes-webui/pull/4110) takes a complementary approach (scrollHeight delta compensation in the pixel restore path). Both fixes are independently valid; if #4110 also merges, the delta compensation serves as an extra safety net for edge cases where the anchor row is not in the DOM.
- Issue [#4295](https://github.com/nesquena/hermes-webui/issues/4295) describes mid-stream viewport jumps, a distinct symptom requiring separate investigation of the streaming rAF scroll paths.

## Upstream

Closes #4325.

## Model Used

Claude Opus 4.6 via Claude Code CLI

