### PR TITLE
Release: collapsible model-picker provider groups + phantom-providers fix (#4279, #4324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+## [v0.51.464] — 2026-06-16 — Release PY (scannable model picker)
+
 ### Added
 
 - **Model picker provider groups are now collapsible and open scannable (#4279).** Provider groups in the model picker start collapsed except the group that owns your currently-selected model, so a picker with many providers/models opens as a tidy list of provider headings rather than one long flat scroll. Searching auto-expands matching groups (and searches hidden overflow models); clearing the search restores the collapsed-except-selected view. The "Show all N models" affordance is restyled as a distinct "+ Show all N models" expander (muted italic, indented, not mistakable for a selectable model) and now reveals the overflow in place — the group stays open and the view scrolls to the newly-revealed models instead of resetting to the top. The redundant per-row provider chip is suppressed for rows already under their own provider heading (kept only for hoisted/search rows). Builds on @akrhin's collapsible-groups work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Model picker provider groups are now collapsible and open scannable (#4279).** Provider groups in the model picker start collapsed except the group that owns your currently-selected model, so a picker with many providers/models opens as a tidy list of provider headings rather than one long flat scroll. Searching auto-expands matching groups (and searches hidden overflow models); clearing the search restores the collapsed-except-selected view. The "Show all N models" affordance is restyled as a distinct "+ Show all N models" expander (muted italic, indented, not mistakable for a selectable model) and now reveals the overflow in place — the group stays open and the view scrolls to the newly-revealed models instead of resetting to the top. The redundant per-row provider chip is suppressed for rows already under their own provider heading (kept only for hoisted/search rows). Builds on @akrhin's collapsible-groups work.
+
+### Fixed
+
+- **Non-model credential-pool keys no longer appear as phantom providers in the model picker (#4324).** A regression from #4247: the credential-pool detection loop added *every* `auth.json` → `credential_pool` key to the detected providers without checking it names a model provider. The Photon iMessage plugin writes three such keys (`photon`, `photon_project`, `photon_user`) that are messaging-platform credentials, not LLM API keys — so the picker showed three bogus "providers" (`photon`, `photon project`, `photon user`) each listing the full auto-detected model catalog. Pool detection is now gated on a new `_is_known_model_provider()` check (a `custom:*` slug, a static `_PROVIDER_DISPLAY`/`_PROVIDER_MODELS` entry, or a registered model-provider plugin) on both the `load_pool` and raw-dict fallback paths, and the group-builder's generic fallback no longer paints an unrecognized id with the global catalog. Real pool-keyed providers (`copilot`, aliased `google`→`gemini`) still surface. Reported by Nic; fix by @nesquena-hermes and independently by @rodboev (#4329/#4330).
+
 ## [v0.51.463] — 2026-06-16 — Release PX (tighter remote workspace boundaries)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -1012,7 +1012,11 @@ def _is_known_model_provider(provider_id: str) -> bool:
         if _is_plugin_model_provider(pid):
             return True
     except Exception:
-        logger.debug("plugin model-provider check failed for %s", pid)
+        # A transient failure here (import/IO hiccup in the plugin registry) makes
+        # a real plugin-backed provider briefly look unknown and drop from the
+        # picker until the next successful check. Surface at warning so it's
+        # visible in default production logs rather than silently swallowed.
+        logger.warning("plugin model-provider check failed for %s", pid, exc_info=True)
     return False
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -981,6 +981,41 @@ def _resolve_provider_alias(name: str) -> str:
     return _PROVIDER_ALIASES.get(raw, name)
 
 
+def _is_known_model_provider(provider_id: str) -> bool:
+    """True when *provider_id* names a model provider WebUI can render.
+
+    The credential pool (``auth.json`` → ``credential_pool``) stores keys for
+    BOTH model providers (whose API keys belong in the model picker) and
+    non-model platform plugins.  The Photon iMessage plugin, for example,
+    writes ``photon`` / ``photon_project`` / ``photon_user`` pool entries that
+    are messaging-platform credentials, not LLM API keys.  Only the former
+    should surface as provider groups.
+
+    Without this gate, #4247's pool-detection loop added *every* pool key to
+    ``detected_providers``; unknown ids then fell through to the global
+    auto-detected catalog and each phantom provider was painted with the full
+    model list (#4324).  ``provider_id`` is expected to be the canonical slug
+    (post ``_resolve_provider_alias``); the lookup is case-insensitive.
+
+    A provider is "known" when it is a configured custom-provider slug
+    (``custom:*``), appears in WebUI's static ``_PROVIDER_DISPLAY`` /
+    ``_PROVIDER_MODELS`` tables, or is a registered model-provider plugin.
+    """
+    pid = (provider_id or "").strip().lower()
+    if not pid:
+        return False
+    if pid.startswith("custom:"):
+        return True
+    if pid in _PROVIDER_DISPLAY or pid in _PROVIDER_MODELS:
+        return True
+    try:
+        if _is_plugin_model_provider(pid):
+            return True
+    except Exception:
+        logger.debug("plugin model-provider check failed for %s", pid)
+    return False
+
+
 def _custom_provider_slug_from_name(name: object) -> str:
     raw = str(name or "").strip().lower()
     if not raw:
@@ -5029,7 +5064,7 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
                                     str(getattr(e, "key_source", "") or ""),
                                 )
                             ]
-                            if _explicit:
+                            if _explicit and _is_known_model_provider(_canonical_pid):
                                 detected_providers.add(_canonical_pid)
                         except Exception:
                             logger.debug("credential_pool.load_pool(%s) failed", _pid)
@@ -5047,7 +5082,9 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
                             for _entry in _entries
                         )
                         if _has_explicit_cred:
-                            detected_providers.add(_resolve_provider_alias(str(_pid)))
+                            _canonical_pid = _resolve_provider_alias(str(_pid))
+                            if _is_known_model_provider(_canonical_pid):
+                                detected_providers.add(_canonical_pid)
         except Exception:
             logger.debug("Failed to inspect credential_pool from auth store")
 
@@ -6034,7 +6071,7 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
                     detected_models = auto_detected_models_by_provider.get(pid)
                     if detected_models:
                         models_for_group = copy.deepcopy(detected_models)
-                    elif auto_detected_models:
+                    elif auto_detected_models and (pid == "custom" or _is_known_model_provider(pid)):
                         # Don't fall back to the global auto_detected_models
                         # list for the bare "custom" PID when the active
                         # provider is something concrete (e.g. ai-gateway,
@@ -6047,6 +6084,17 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
                         else:
                             models_for_group = copy.deepcopy(auto_detected_models)
                     else:
+                        # An unrecognized provider id with no catalog of its
+                        # own must NOT be painted with the global
+                        # auto_detected_models list. Otherwise a non-model
+                        # credential_pool key (the Photon plugin's
+                        # photon/photon_project/photon_user entries, #4324) or
+                        # any future unknown id renders as a phantom provider
+                        # carrying the active endpoint's entire model catalog.
+                        # Such ids are dropped upstream by
+                        # _is_known_model_provider() in the pool-detection
+                        # loop; this omission is belt-and-braces matching the
+                        # #1572/#7372 "omit rather than misattribute" posture.
                         models_for_group = []
                     if models_for_group:
                         # Per-group deep copy so subsequent mutation by

--- a/static/style.css
+++ b/static/style.css
@@ -2503,7 +2503,7 @@
 .model-dropdown{display:none;position:absolute;bottom:calc(100% + 4px);left:0;min-width:280px;max-width:min(420px,calc(100vw - 32px));background:var(--surface);border:1px solid var(--border2);border-radius:10px;box-shadow:0 -4px 24px rgba(0,0,0,.4);z-index:200;overflow:hidden;max-height:320px;overflow-y:auto;}
 .model-dropdown.open{display:block;}
 .model-scope-note{position:sticky;top:0;z-index:2;padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text);font-size:11px;font-weight:650;line-height:1.4;background:color-mix(in srgb,var(--surface) 82%,var(--accent-bg));box-shadow:0 1px 0 rgba(0,0,0,.12);}
-.model-group{padding:8px 14px 4px;font-size:10px;font-weight:700;letter-spacing:.04em;color:var(--muted);text-transform:uppercase;border-top:1px solid var(--border2);margin-top:2px;}
+.model-group{padding:8px 14px 4px;font-size:10px;font-weight:700;letter-spacing:.04em;color:var(--muted);text-transform:uppercase;border-top:1px solid var(--border2);margin-top:2px;}.model-group.collapsible{cursor:pointer;user-select:none}.model-group.collapsible:before{content:'\25b6';display:inline-block;font-size:8px;margin-right:5px;transition:transform .15s ease}.model-group.collapsible.open:before{transform:rotate(90deg)}.model-group-body:empty{display:none}
 .model-opt{padding:10px 14px;cursor:pointer;transition:background .12s;display:flex;flex-direction:column;gap:3px;align-items:flex-start;}
 .model-opt:hover{background:rgba(255,255,255,.07);}
 .model-opt.is-highlighted{background:rgba(255,255,255,.1);outline:1px solid var(--border2);outline-offset:-1px;}
@@ -2517,6 +2517,18 @@
 .model-opt-id{display:block;font-size:10px;color:var(--muted);line-height:1.3;opacity:.72;word-break:break-word;}
 .model-provider-hint{margin:2px 14px 6px;padding:7px 9px;border:1px solid var(--border2);border-radius:7px;background:color-mix(in srgb,var(--surface) 90%,var(--warning));color:var(--muted);font-size:11px;line-height:1.35;}
 .model-opt-provider{display:inline-flex;align-items:center;padding:1px 6px;border-radius:4px;font-size:9px;font-weight:600;letter-spacing:.03em;color:var(--muted);background:rgba(255,255,255,.05);border:1px solid var(--border2);margin-left:auto;white-space:nowrap;flex-shrink:0;}
+/* "Show N more" group expander — deliberately distinct from a real model row:
+   no model-id line, indented, muted italic label + a subtle + affordance, so it
+   reads as an action that expands the list rather than a selectable model. */
+.model-opt-more{display:flex;align-items:center;gap:7px;padding:7px 14px 9px 26px;cursor:pointer;font-size:11.5px;font-style:italic;color:var(--muted);letter-spacing:.01em;transition:color .12s,background .12s;user-select:none;}
+.model-opt-more:hover,.model-opt-more:focus-visible{color:var(--accent-text,var(--accent));background:rgba(255,255,255,.04);outline:none;}
+.model-opt-more.is-highlighted{color:var(--accent-text,var(--accent));background:rgba(255,255,255,.06);}
+.model-opt-more-chevron{flex-shrink:0;width:13px;height:13px;position:relative;opacity:.7;}
+.model-opt-more-chevron::before,.model-opt-more-chevron::after{content:'';position:absolute;background:currentColor;border-radius:1px;}
+.model-opt-more-chevron::before{left:6px;top:2px;width:1.5px;height:9px;}
+.model-opt-more-chevron::after{left:2px;top:5.75px;width:9px;height:1.5px;}
+.model-opt-more:hover .model-opt-more-chevron,.model-opt-more:focus-visible .model-opt-more-chevron{opacity:1;}
+.model-opt-more-label{line-height:1.2;}
 .model-custom-sep{padding-top:4px;border-top:1px solid var(--border);margin-top:4px;}
 .model-custom-row{display:flex;align-items:center;gap:6px;padding:6px 10px 8px;}
 .model-custom-input{flex:1;background:var(--code-bg);border:1px solid var(--border2);border-radius:6px;color:var(--text);padding:5px 8px;font-size:12px;outline:none;font-family:inherit;min-width:0;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -2547,9 +2547,9 @@ function renderModelDropdown(){
         const wrapper=document.createElement('div');
         wrapper.className='model-group-body';
         wrapper.dataset.group=groupKey;
-        // A group carrying a provider endpoint-error hint (#4253) must stay
-        // visible by default — otherwise the "models endpoint unreachable"
-        // warning is hidden inside a collapsed body and the user never sees it.
+        // A group carrying a provider endpoint-error hint must stay visible by
+        // default — otherwise the "models endpoint unreachable" warning is hidden
+        // inside a collapsed body and the user never sees it. (#2540 surface)
         const _hasEndpointError=!!(meta&&(meta.modelsEndpointError||meta.endpointErrorOnly));
         if(hasSearch) _groupOpenState[groupKey]=true;
         else if(_forceOpenGroups.has(groupKey)) _groupOpenState[groupKey]=true;
@@ -2560,7 +2560,9 @@ function renderModelDropdown(){
         heading.classList.add('collapsible');
         dd.appendChild(wrapper);
         _groupWrappers[groupKey]=wrapper;
-        // Render endpoint error hint inside the collapsible group (#4253)
+        // Render the provider endpoint-error hint inside the collapsible group
+        // so it collapses/expands with it (the group is force-opened above when
+        // an error is present, so the hint stays visible by default).
         _renderProviderEndpointHint(meta,wrapper);
         heading.addEventListener('click',(e)=>{
           e.stopPropagation();

--- a/static/ui.js
+++ b/static/ui.js
@@ -2174,6 +2174,17 @@ function renderModelDropdown(){
   const dd=$('composerModelDropdown');
   const sel=$('modelSelect');
   if(!dd||!sel) return;
+  // Group(s) that must render OPEN even though they aren't the selected group —
+  // set when the user expands a group's overflow via "Show more" so a later full
+  // re-render doesn't re-collapse it (_groupOpenState is rebuilt per render, so
+  // this cross-render intent persists on a global). Resolved as a function-local
+  // so renderModelDropdown stays self-contained when eval'd in isolation (the
+  // #3691 node test driver evals the function body without module scope).
+  const _forceOpenGroups=(()=>{
+    const _g=(typeof window!=='undefined')?window:(typeof globalThis!=='undefined'?globalThis:{});
+    if(!_g.__modelGroupForceOpen) _g.__modelGroupForceOpen=new Set();
+    return _g.__modelGroupForceOpen;
+  })();
   const _modelData=[];
   const _groupMeta=new Map();
   const _groupOrder=[];
@@ -2286,32 +2297,145 @@ function renderModelDropdown(){
     }
     return 500;
   };
-  const _renderProviderEndpointHint=(entry)=>{
+  const _renderProviderEndpointHint=(entry,parent)=>{
     if(!entry||!entry.label||!entry.modelsEndpointError) return;
     const hint=document.createElement('div');
     hint.className='model-provider-hint';
     hint.textContent=entry.modelsEndpointError.message||'Models endpoint could not be reached for this provider.';
-    dd.appendChild(hint);
+    (parent||dd).appendChild(hint);
+  };
+  // Build a single model-option row (mirrors the main render loop's row markup),
+  // used both by the main render and by the in-place overflow reveal below.
+  const _buildModelRow=(m,sel,withProviderChip)=>{
+    const row=document.createElement('div');
+    row.className='model-opt'+(m.value===sel.value?' active':'');
+    const badgeHtml=m.badge?`<span class="model-opt-badge model-opt-badge--${esc(m.badge.role||'configured')}">${esc(m.badge.label||'Configured')}</span>`:'';
+    const _plainGroup=m.group?String(m.group).replace(/\s*\(\d+\s+of\s+\d+\)\s*$/,''):'';
+    const providerChip=(_plainGroup&&withProviderChip)?`<span class="model-opt-provider">${esc(_plainGroup)}</span>`:'';
+    row.innerHTML=`<div class="model-opt-top"><span class="model-opt-name">${esc(m.name)}</span>${badgeHtml}${providerChip}</div><span class="model-opt-id">${esc(m.id)}</span>`;
+    row.onclick=()=>selectModelFromDropdown(m.value,m.providerId||(m.badge&&m.badge.provider)||null);
+    return row;
   };
   const _expandOverflowGroup=(groupMetaEntry)=>{
     if(!groupMetaEntry||!groupMetaEntry.optgroup) return;
-    const currentTerm=_si.value;
-    const extraModels=_readModelOverflowData(groupMetaEntry.optgroup);
-    if(!_appendOverflowOptionsToGroup(groupMetaEntry.optgroup,extraModels)) return;
-    renderModelDropdown();
-    const nextSearch=dd.querySelector('.model-search-input');
-    if(!nextSearch) return;
-    nextSearch.value=currentTerm;
-    if(nextSearch._listeners&&typeof nextSearch._listeners.input==='function'){
-      nextSearch._listeners.input();
+    const og=groupMetaEntry.optgroup;
+    const groupKey=groupMetaEntry.key;
+    const extraModels=_readModelOverflowData(og);
+    // Nothing to reveal — no overflow tail advertised.
+    if(!extraModels.length) return;
+    // Append the overflow models to the source <select> so the dropdown's state
+    // stays the source of truth (search, re-render, selection all see them).
+    // NOTE: guard on extraModels.length (above), NOT on the append return value —
+    // _appendOverflowOptionsToGroup returns the count of NEWLY-created <option>s
+    // and returns 0 (while still clearing dataset.extraModels) when every overflow
+    // model already existed as an option. Bailing on a 0 return would leave those
+    // already-present-but-hidden rows unrevealed and the expander dead (#bug3).
+    _appendOverflowOptionsToGroup(og,extraModels);
+    // Full re-render fallback — the proven path. Used when the in-place reveal
+    // can't run (minimal/headless DOM without CSS.escape/rAF/insertBefore, or any
+    // unexpected failure). Produces the same end state: overflow appended,
+    // expander gone, search term reapplied.
+    const _fullReRender=()=>{
+      const _term=(_si&&_si.value)||'';
+      renderModelDropdown();
+      const ns=dd.querySelector('.model-search-input');
+      if(ns){ ns.value=_term; (ns._listeners&&ns._listeners.input)?ns._listeners.input():ns.dispatchEvent(new Event('input')); }
+    };
+    // IN-PLACE reveal: build the newly-revealed rows and insert them directly into
+    // the existing group wrapper (before the "Show more" expander), then remove
+    // the expander. No full re-render — so the group stays open, every other
+    // group keeps its collapsed/open state, and the scroll position is preserved.
+    // The user lands on the first new row. Falls back to a full re-render if the
+    // runtime lacks the DOM APIs this needs.
+    const _canInPlace = typeof CSS!=='undefined' && CSS && typeof CSS.escape==='function'
+      && typeof dd.querySelector==='function';
+    if(!_canInPlace){ _fullReRender(); return; }
+    let wrap, moreEl;
+    try{
+      wrap=dd.querySelector(`.model-group-body[data-group="${CSS.escape(groupKey)}"]`);
+      moreEl=wrap?wrap.querySelector('.model-opt-more'):null;
+    }catch(_){ _fullReRender(); return; }
+    if(!wrap||!moreEl||typeof wrap.insertBefore!=='function'){
+      _fullReRender();
       return;
     }
-    if(typeof nextSearch.dispatchEvent==='function'){
-      nextSearch.dispatchEvent(new Event('input'));
+    try{
+      const _plainLabel=String(groupMetaEntry.label||'').replace(/\s*\(\d+\s+of\s+\d+\)\s*$/,'');
+      const _alreadyShown=new Set(Array.from(wrap.querySelectorAll('.model-opt .model-opt-id')).map(el=>el.textContent));
+      let firstNewRow=null;
+      for(const m of extraModels){
+        if(!m||!m.id) continue;
+        if(_alreadyShown.has(esc(m.id))) continue;
+        const row=_buildModelRow({value:m.id,name:m.label||m.id,id:m.id,group:_plainLabel,groupKey,providerId:(og.dataset&&og.dataset.provider)||''},$('modelSelect'),false);
+        wrap.insertBefore(row,moreEl);
+        if(!firstNewRow) firstNewRow=row;
+      }
+      // Sync the in-memory model data so a later _filterModels() re-render (e.g.
+      // after a search is typed and cleared) keeps the group fully expanded
+      // instead of snapping back to the capped view + a fresh "Show more". The
+      // overflow rows were just appended to the live <select>, so flip their
+      // _modelData entries to no-longer-hidden and zero the group's hidden count.
+      for(const _md of _modelData){
+        if(_md && _md.groupKey===groupKey && _md.hiddenByDefault){
+          _md.hiddenByDefault=false;
+        }
+      }
+      if(groupMetaEntry && typeof groupMetaEntry.hiddenCount==='number'){
+        groupMetaEntry.hiddenCount=0;
+      }
+      // The group is now fully expanded — drop the "Show more" expander, and bump
+      // the heading count to the full total. Also force the group OPEN (the user
+      // just asked to see more of it) regardless of any prior collapsed state.
+      moreEl.remove();
+      wrap.style.display='';
+      _forceOpenGroups.add(groupKey);
+      const heading=wrap.previousElementSibling;
+      if(heading&&heading.classList&&heading.classList.contains('model-group')){
+        const _total=wrap.querySelectorAll('.model-opt').length;
+        heading.textContent=_total>1?`${_plainLabel} (${_total})`:_plainLabel;
+        heading.classList.add('collapsible','open');
+      }
+      // Scroll so the first newly-revealed row sits near the top of the dropdown
+      // viewport — the user asked to "land on the new models" after Show more,
+      // not be reset to the top of the list and not have it jump unpredictably.
+      if(firstNewRow && typeof firstNewRow.offsetTop==='number' && typeof requestAnimationFrame==='function'){
+        const _targetTop=Math.max(0,firstNewRow.offsetTop-48);
+        const _doScroll=()=>{ try{ dd.scrollTop=_targetTop; }catch(_){} };
+        _doScroll();                                   // immediate
+        requestAnimationFrame(()=>{ _doScroll(); requestAnimationFrame(_doScroll); });
+        if(typeof setTimeout==='function') setTimeout(_doScroll,80); // after any refocus settles
+      }
+    }catch(_err){
+      // Any unexpected DOM failure — fall back to the proven full re-render so
+      // the overflow still gets revealed.
+      _fullReRender();
     }
   };
+  // Collapsible group state — persists across _filterModels calls
+  const _groupOpenState={};
+  let _prevHasSearch=false;  // tracks search->empty transition to reset open-state
+  let _groupWrappers={};
+  // The group that owns the currently-selected model. Groups start COLLAPSED by
+  // default (#4279); the selected provider's group is the one exception so the
+  // user always sees their active model without expanding anything. (#4279 + UX)
+  const _selectedGroupKey=(()=>{
+    const _selVal=String((sel&&sel.value)||'');
+    if(!_selVal) return null;
+    const _hit=_modelData.find(m=>m&&!m.endpointErrorOnly&&String(m.value||'')===_selVal);
+    return _hit?_hit.groupKey:null;
+  })();
   const _filterModels=(term)=>{
     term=term.trim().toLowerCase();
+    const hasSearch=!!term;
+    // On a fresh search, expand all groups so every match is visible (#collapse).
+    if(hasSearch) for(const k in _groupOpenState) _groupOpenState[k]=true;
+    // When a search is CLEARED (search -> empty), reset the per-group open state
+    // so the collapsed-except-selected default re-applies — otherwise every group
+    // the search auto-expanded would stay open, defeating the collapse UX. Groups
+    // the user explicitly expanded via "Show more" (_forceOpenGroups) and the
+    // selected group remain open through the defaulting logic below.
+    else if(_prevHasSearch){ for(const k in _groupOpenState) delete _groupOpenState[k]; }
+    _prevHasSearch=hasSearch;
     const found=new Set();
     for(const m of _modelData){
       const name=m.name.toLowerCase();
@@ -2420,7 +2544,37 @@ function renderModelDropdown(){
         const _plainLabel=String(meta.label||'').replace(/\s*\(\d+\s+of\s+\d+\)\s*$/,'');
         heading.textContent=count>1?`${_plainLabel} (${count})`:meta.label;
         dd.appendChild(heading);
-        _renderProviderEndpointHint(meta);
+        const wrapper=document.createElement('div');
+        wrapper.className='model-group-body';
+        wrapper.dataset.group=groupKey;
+        // A group carrying a provider endpoint-error hint (#4253) must stay
+        // visible by default — otherwise the "models endpoint unreachable"
+        // warning is hidden inside a collapsed body and the user never sees it.
+        const _hasEndpointError=!!(meta&&(meta.modelsEndpointError||meta.endpointErrorOnly));
+        if(hasSearch) _groupOpenState[groupKey]=true;
+        else if(_forceOpenGroups.has(groupKey)) _groupOpenState[groupKey]=true;
+        else if(_hasEndpointError) _groupOpenState[groupKey]=true;
+        else if(!(groupKey in _groupOpenState)) _groupOpenState[groupKey]=(groupKey===_selectedGroupKey);
+        if(!_groupOpenState[groupKey]) wrapper.style.display='none';
+        else heading.classList.add('open');
+        heading.classList.add('collapsible');
+        dd.appendChild(wrapper);
+        _groupWrappers[groupKey]=wrapper;
+        // Render endpoint error hint inside the collapsible group (#4253)
+        _renderProviderEndpointHint(meta,wrapper);
+        heading.addEventListener('click',(e)=>{
+          e.stopPropagation();
+          const w=dd.querySelector(`.model-group-body[data-group="${CSS.escape(groupKey)}"]`);
+          if(!w) return;
+          const closed=w.style.display==='none';
+          w.style.display=closed?'':'none';
+          _groupOpenState[groupKey]=closed;
+          // Keep the cross-render force-open intent in sync with manual toggles:
+          // collapsing a previously overflow-expanded group should let it
+          // re-collapse on the next render too.
+          if(closed) _forceOpenGroups.add(groupKey); else _forceOpenGroups.delete(groupKey);
+          heading.classList.toggle('open',closed);
+        });
       }
       for(const m of groupRows){
         const row=document.createElement('div');
@@ -2431,27 +2585,46 @@ function renderModelDropdown(){
         // the count is stamped redundantly on every row and reads as nonsense after
         // "Show all" expands the group (e.g. row 30 still showing "(15 of 30)"). (#3691)
         const _plainGroup=m.group?String(m.group).replace(/\s*\(\d+\s+of\s+\d+\)\s*$/,''):'';
-        const providerChip=_plainGroup?`<span class="model-opt-provider">${esc(_plainGroup)}</span>`:'';
+        // Only show the per-row provider chip when the row is NOT already under its
+        // own provider heading — i.e. it's a flat/hoisted row appended straight to
+        // the dropdown (no group wrapper). Repeating the provider name on every row
+        // beneath its own "PROVIDER" heading is pure visual noise. The chip still
+        // orients hoisted/configured rows and search results that render flat.
+        const _underOwnHeading=shouldRenderHeading&&!!(m.groupKey&&_groupWrappers[m.groupKey]);
+        const providerChip=(_plainGroup&&!_underOwnHeading)?`<span class="model-opt-provider">${esc(_plainGroup)}</span>`:'';
         row.innerHTML=`<div class="model-opt-top"><span class="model-opt-name">${esc(m.name)}</span>${badgeHtml}${providerChip}</div><span class="model-opt-id">${esc(m.id)}</span>`;
         row.onclick=()=>selectModelFromDropdown(m.value,m.providerId||(m.badge&&m.badge.provider)||null);
-        dd.appendChild(row);
+        if(m.groupKey&&_groupWrappers[m.groupKey]){
+          _groupWrappers[m.groupKey].appendChild(row);
+        }else{
+          dd.appendChild(row);
+        }
       }
       if(!term&&hiddenCount){
         const showAll=document.createElement('div');
-        showAll.className='model-opt model-opt-show-all';
+        showAll.className='model-opt-more';
         showAll.tabIndex=0;
-        showAll.innerHTML=`<div class="model-opt-top"><span class="model-opt-name">${esc(t('model_show_all_models',hiddenCount)||`Show all ${hiddenCount} models`)}</span></div>`;
+        showAll.setAttribute('role','button');
+        const _moreLabel=esc(t('model_show_all_models',hiddenCount)||`Show ${hiddenCount} more`);
+        showAll.innerHTML=`<span class="model-opt-more-chevron" aria-hidden="true"></span><span class="model-opt-more-label">${_moreLabel}</span>`;
+        const _doExpand=()=>{
+          // The reveal itself (in-place row insert + open + scroll-to-new) is
+          // handled by _expandOverflowGroup; just trigger it.
+          _expandOverflowGroup(meta);
+        };
         showAll.onclick=(e)=>{
           if(e&&typeof e.stopPropagation==='function') e.stopPropagation();
-          _expandOverflowGroup(meta);
+          _doExpand();
         };
         showAll.addEventListener('keydown',e=>{
           if(e.key==='Enter'||e.key===' '){
             e.preventDefault();
-            _expandOverflowGroup(meta);
+            _doExpand();
           }
         });
-        dd.appendChild(showAll);
+        // Keep the expander inside the collapsible group so it hides/shows with it.
+        if(_groupWrappers[groupKey]) _groupWrappers[groupKey].appendChild(showAll);
+        else dd.appendChild(showAll);
       }
     }
     if(term&&found.size===0){
@@ -2467,7 +2640,7 @@ function renderModelDropdown(){
   };
   _si.addEventListener('input',()=>_filterModels(_si.value));
   // Keyboard navigation through filtered model rows (#2791).
-  const _visibleModelRows=()=>Array.from(dd.querySelectorAll('.model-opt'));
+  const _visibleModelRows=()=>Array.from(dd.querySelectorAll('.model-opt,.model-opt-more')).filter(el=>!el.closest('.model-group-body')||el.closest('.model-group-body').style.display!=='none');
   const _activeRowIndex=(rows)=>rows.findIndex(r=>r.classList.contains('is-highlighted'));
   const _highlightRow=(rows,idx)=>{
     for(const r of rows) r.classList.remove('is-highlighted');

--- a/tests/test_issue3691_model_picker_show_all.py
+++ b/tests/test_issue3691_model_picker_show_all.py
@@ -307,11 +307,33 @@ function makeSelect(groups, selectedValue) {
 }
 
 function snapshot(dd) {
-  return dd.children.map(node => ({
-    className: node.className,
-    textContent: node.textContent,
-    html: node._innerHTML || '',
-  }));
+  // Recurse into collapsible group bodies (#4279): rows + the show-all expander
+  // now live inside `.model-group-body` wrappers rather than as direct children
+  // of the dropdown, so a flat children map would miss them.
+  const out = [];
+  const walk = (node) => {
+    for (const child of (node.children || [])) {
+      out.push({
+        className: child.className,
+        textContent: child.textContent,
+        html: child._innerHTML || '',
+      });
+      if (child.children && child.children.length) walk(child);
+    }
+  };
+  walk(dd);
+  return out;
+}
+
+// Find a node anywhere in the dropdown subtree whose innerHTML matches.
+function findInTree(dd, pred) {
+  const stack = [...(dd.children || [])];
+  while (stack.length) {
+    const n = stack.shift();
+    if (pred(n)) return n;
+    if (n.children && n.children.length) stack.push(...n.children);
+  }
+  return null;
 }
 
 const payload = JSON.parse(process.argv[3]);
@@ -353,7 +375,9 @@ for (const name of [
 
 renderModelDropdown();
 const initial = snapshot(dropdown);
-const initialShowAllRow = dropdown.children.find(node => String(node._innerHTML || '').includes('Show all'));
+// The show-all expander now lives inside a `.model-group-body` wrapper (#4279),
+// so search the whole subtree rather than only direct children.
+const initialShowAllRow = findInTree(dropdown, node => String(node._innerHTML || '').includes('Show all'));
 const searchInput = dropdown.children[1].querySelector('.model-search-input');
 searchInput.value = payload.searchTerm;
 searchInput._listeners.input();
@@ -470,14 +494,20 @@ def test_runtime_picker_preserves_backend_decorated_nous_heading_without_double_
     assert "Nous (2 of 4)" in heading_text, (
         "The picker should preserve the backend-crafted Nous heading verbatim when overflow exists."
     )
-    # Regression (#3691 row-chip leak): the per-row provider chip must show the PLAIN
-    # provider label, never the "(N of M)" overflow count — otherwise the count is
-    # repeated on every row and reads as nonsense after "Show all" expands the group.
+    # Regression (#3691 row-chip leak): the per-row provider chip must NEVER carry
+    # the "(N of M)" overflow count. As of the collapsible-groups UX pass, the
+    # per-row provider chip is also suppressed entirely when a row sits under its
+    # own provider heading (the heading already names the provider, so repeating it
+    # on every row is pure noise) — the chip is kept only for hoisted/search rows.
     assert "(2 of 4)" not in row_html, (
         "The per-row provider chip must not carry the overflow count; it belongs on the heading only."
     )
-    assert 'class="model-opt-provider">Nous<' in row_html, (
-        "Each row's provider chip should render the plain provider label (e.g. 'Nous')."
+    assert 'class="model-opt-provider">Nous (2 of 4)<' not in row_html, (
+        "A row chip must never show the decorated overflow label."
+    )
+    # Under its own provider heading, rows carry NO redundant provider chip.
+    assert 'class="model-opt-provider"' not in row_html, (
+        "Rows under their own provider heading should not repeat the provider chip (de-noise UX)."
     )
     # After expand, the heading must not double-count ("Nous (2 of 4) (4)") — it should
     # strip the backend decoration and show the plain rendered-row count. (#3691)

--- a/tests/test_issue4324_photon_phantom_providers.py
+++ b/tests/test_issue4324_photon_phantom_providers.py
@@ -1,0 +1,307 @@
+"""Regression tests for issue #4324.
+
+The Photon iMessage plugin writes three keys into ``auth.json`` →
+``credential_pool``: ``photon``, ``photon_project`` and ``photon_user``.
+These are messaging-platform credentials, NOT model providers.
+
+Regression from #4247: the credential-pool provider-detection loop in
+``api/config.py::_build_available_models_uncached`` added *every* non-ambient
+pool key to ``detected_providers`` without checking that the key actually
+names a model provider.  Unknown ids (``photon``, ``photon-project``,
+``photon-user``) then fell through to the generic ``else`` branch of the
+group builder, which copied the global ``auto_detected_models`` catalog (the
+reporter's 251 base-url-probed models) into each phantom group — so the model
+picker showed three bogus "providers" each listing the full catalog.
+
+The fix gates pool detection behind ``_is_known_model_provider()`` (both the
+``load_pool`` and the raw-dict ``ImportError`` branches) and, defensively,
+stops the ``else`` branch from painting an unknown id with the global catalog.
+
+These tests mock at the WebUI boundary (stub ``hermes_cli`` + a fake
+``load_pool`` + a fake ``urlopen`` for the base-url probe) and never import
+the bundled ``agent`` package, which is not installed in CI.
+"""
+
+import json
+import sys
+import types
+
+import api.config as config
+import api.profiles as profiles
+
+
+def _install_fake_hermes_cli(monkeypatch, *, with_load_pool: bool = False, pool_data: dict | None = None):
+    """Stub hermes_cli so detection is deterministic and offline.
+
+    list_available_providers() returns [] so the ONLY way a provider can be
+    detected is via the credential_pool path under test (mirrors the
+    test_credential_pool_providers.py helper).
+    """
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models.list_available_providers = lambda: []
+    fake_models.provider_model_ids = lambda pid: []
+
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda _pid: {}
+
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+
+    # Remove the real agent.credential_pool. When with_load_pool is False this
+    # forces the ImportError raw-dict fallback path; when True we install a
+    # fake load_pool so the primary path is exercised.
+    monkeypatch.delitem(sys.modules, "agent.credential_pool", raising=False)
+    monkeypatch.delitem(sys.modules, "agent", raising=False)
+
+    if with_load_pool:
+        _pool_data = pool_data or {}
+
+        class _FakeEntry:
+            def __init__(self, d):
+                self.source = d.get("source", "manual")
+                self.label = d.get("label", "")
+                self.key_source = d.get("key_source", "")
+                self.id = d.get("id", "")
+                self.runtime_api_key = (d.get("runtime_api_key") or d.get("access_token") or "")
+                self.access_token = (d.get("access_token") or "")
+                self.base_url = d.get("base_url", "")
+
+        class _FakePool:
+            def __init__(self, entries_list):
+                self._entries = entries_list
+
+            def entries(self):
+                return self._entries
+
+            def select(self):
+                return self._entries[0] if self._entries else None
+
+        def _fake_load_pool(pid):
+            raw = _pool_data.get(pid, [])
+            return _FakePool([_FakeEntry(e) for e in raw])
+
+        fake_cp = types.ModuleType("agent.credential_pool")
+        fake_cp.load_pool = _fake_load_pool
+        monkeypatch.setitem(sys.modules, "agent.credential_pool", fake_cp)
+
+
+def _install_fake_base_url_probe(monkeypatch, model_ids):
+    """Make the /v1/models base-url probe return *model_ids*.
+
+    This is what populates the global ``auto_detected_models`` catalog — the
+    list the phantom-provider bug copied into every unknown group.
+    """
+    payload = {"data": [{"id": mid, "name": mid} for mid in model_ids]}
+
+    class _Resp:
+        def read(self):
+            return json.dumps(payload).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda req, timeout=10: _Resp())
+    # Avoid the SSRF private-IP guard rejecting the probe host.
+    monkeypatch.setattr("socket.getaddrinfo", lambda *a, **k: [])
+
+
+def _call_get_available_models(monkeypatch, tmp_path, auth_payload, *,
+                               with_load_pool=False, base_url=None, probe_models=None):
+    _install_fake_hermes_cli(
+        monkeypatch,
+        with_load_pool=with_load_pool,
+        pool_data=auth_payload.get("credential_pool", {}),
+    )
+    if base_url is not None:
+        _install_fake_base_url_probe(monkeypatch, probe_models or [])
+
+    (tmp_path / "auth.json").write_text(json.dumps(auth_payload), encoding="utf-8")
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+    for var in ("OPENAI_API_KEY", "HERMES_API_KEY", "HERMES_OPENAI_API_KEY",
+                "LOCAL_API_KEY", "OPENROUTER_API_KEY", "API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+    old_cfg = dict(config.cfg)
+    old_mtime = config._cfg_mtime
+    config.cfg.clear()
+    if base_url is not None:
+        config.cfg["model"] = {"base_url": base_url, "api_key": "sk-test"}
+    else:
+        config.cfg["model"] = {}
+    try:
+        config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+    except Exception:
+        config._cfg_mtime = 0.0
+
+    config.invalidate_models_cache()
+    try:
+        return config.get_available_models()
+    finally:
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+        config._cfg_mtime = old_mtime
+        config.invalidate_models_cache()
+
+
+def _group_names(result):
+    return [g["provider"] for g in result.get("groups", [])]
+
+
+_PHOTON_POOL = {
+    "photon": [
+        {"id": "ph1", "label": "photon-device", "source": "manual", "auth_type": "api_key"}
+    ],
+    "photon_project": [
+        {"id": "ph2", "label": "photon-project", "source": "manual", "auth_type": "api_key"}
+    ],
+    "photon_user": [
+        {"id": "ph3", "label": "photon-user", "source": "manual", "auth_type": "api_key"}
+    ],
+}
+
+
+def _photon_auth_payload(extra_pool=None):
+    pool = dict(_PHOTON_POOL)
+    if extra_pool:
+        pool.update(extra_pool)
+    return {
+        "version": 1,
+        "providers": {},
+        "active_provider": "openai-codex",
+        "credential_pool": pool,
+    }
+
+
+# ── load_pool path (primary) ─────────────────────────────────────────────────
+
+
+def test_photon_pool_keys_do_not_appear_load_pool(monkeypatch, tmp_path):
+    """The three Photon pool keys must NOT render as provider groups."""
+    result = _call_get_available_models(
+        monkeypatch, tmp_path, _photon_auth_payload(), with_load_pool=True,
+    )
+    names = [n.lower() for n in _group_names(result)]
+    assert not any("photon" in n for n in names), (
+        f"Photon messaging credentials must not appear as model providers; got {_group_names(result)}"
+    )
+
+
+def test_photon_pool_keys_hidden_even_with_base_url_catalog(monkeypatch, tmp_path):
+    """Reproduces the reporter's exact symptom: a base-url probe populates the
+    global catalog, and pre-fix each photon* group was painted with all of it.
+
+    Post-fix: no photon group exists at all, regardless of the catalog size.
+    """
+    catalog = [f"model-{i}" for i in range(40)]  # stand-in for the 251 models
+    result = _call_get_available_models(
+        monkeypatch, tmp_path, _photon_auth_payload(),
+        with_load_pool=True, base_url="http://my-llm.local:11434/v1", probe_models=catalog,
+    )
+    groups = {g["provider"]: g["models"] for g in result.get("groups", [])}
+    assert not any("photon" in n.lower() for n in groups), (
+        f"No photon* group should exist; got {list(groups)}"
+    )
+    # And none of the catalog models leaked into a phantom photon group:
+    for name, models in groups.items():
+        if "photon" in name.lower():
+            raise AssertionError(f"phantom photon group {name!r} carries {len(models)} models")
+
+
+def test_real_provider_still_detected_alongside_photon(monkeypatch, tmp_path):
+    """The #4247 intent is preserved: a real model provider whose key lives in
+    the pool (copilot) is still detected even when photon* keys are present.
+    """
+    extra = {
+        "copilot": [
+            {"id": "cp1", "label": "explicit-copilot", "source": "manual",
+             "auth_type": "api_key", "base_url": "https://api.githubcopilot.com"}
+        ]
+    }
+    result = _call_get_available_models(
+        monkeypatch, tmp_path, _photon_auth_payload(extra), with_load_pool=True,
+    )
+    names = _group_names(result)
+    assert "GitHub Copilot" in names, f"Real pool provider must still appear; got {names}"
+    assert not any("photon" in n.lower() for n in names), (
+        f"Photon keys must still be filtered out; got {names}"
+    )
+
+
+# ── ImportError raw-dict fallback path ───────────────────────────────────────
+
+
+def test_photon_pool_keys_do_not_appear_importerror_path(monkeypatch, tmp_path):
+    """Same guard must hold on the raw-dict fallback (agent.credential_pool absent)."""
+    result = _call_get_available_models(
+        monkeypatch, tmp_path, _photon_auth_payload(), with_load_pool=False,
+    )
+    names = [n.lower() for n in _group_names(result)]
+    assert not any("photon" in n for n in names), (
+        f"Photon keys must be filtered on the ImportError path too; got {_group_names(result)}"
+    )
+
+
+def test_real_provider_still_detected_importerror_path(monkeypatch, tmp_path):
+    extra = {
+        "copilot": [
+            {"id": "cp1", "label": "explicit-copilot", "source": "manual",
+             "auth_type": "api_key", "base_url": "https://api.githubcopilot.com"}
+        ]
+    }
+    result = _call_get_available_models(
+        monkeypatch, tmp_path, _photon_auth_payload(extra), with_load_pool=False,
+    )
+    names = _group_names(result)
+    assert "GitHub Copilot" in names, f"Real pool provider must still appear; got {names}"
+    assert not any("photon" in n.lower() for n in names), (
+        f"Photon keys must still be filtered out; got {names}"
+    )
+
+
+def test_aliased_pool_key_still_detected_alongside_photon(monkeypatch, tmp_path):
+    """#4247 intent (aliased pool keys) is preserved end-to-end.
+
+    A pool key of ``google`` resolves to canonical ``gemini`` (in
+    _PROVIDER_MODELS, not _PROVIDER_DISPLAY) and must still surface as the
+    Gemini group even when non-model photon* keys are filtered out. Drives a
+    real pool key through detection rather than asserting on the helper alone.
+    """
+    extra = {
+        "google": [
+            {"id": "gp1", "label": "explicit-gemini", "source": "manual",
+             "auth_type": "api_key", "base_url": "https://generativelanguage.googleapis.com"}
+        ]
+    }
+    result = _call_get_available_models(
+        monkeypatch, tmp_path, _photon_auth_payload(extra), with_load_pool=True,
+    )
+    names = _group_names(result)
+    assert "Gemini" in names, f"Aliased google→gemini pool key must surface as Gemini; got {names}"
+    assert not any("photon" in n.lower() for n in names), (
+        f"Photon keys must still be filtered out; got {names}"
+    )
+
+
+# ── helper unit coverage ─────────────────────────────────────────────────────
+
+
+def test_is_known_model_provider_rejects_photon():
+    assert config._is_known_model_provider("photon") is False
+    assert config._is_known_model_provider("photon-project") is False
+    assert config._is_known_model_provider("photon-user") is False
+    assert config._is_known_model_provider("") is False
+
+
+def test_is_known_model_provider_accepts_static_and_custom():
+    assert config._is_known_model_provider("copilot") is True
+    assert config._is_known_model_provider("anthropic") is True
+    assert config._is_known_model_provider("gemini") is True
+    assert config._is_known_model_provider("custom:my-endpoint") is True


### PR DESCRIPTION
## What this is

A release bundle of two coherent model-picker changes, staged for independent review before tagging.

### 1. Collapsible provider groups (feature) — extends #4279
- Provider groups start **collapsed except the group that owns the selected model**, so the picker opens scannable instead of as a long flat list.
- **Search** auto-expands matching groups (and searches hidden overflow models); **clearing** the search restores the collapsed-except-selected view.
- **"Show more"** restyled as a distinct `+ Show all N models` expander (muted italic, indented, no model-id line) that reveals the overflow **in place** — the group stays open, other groups keep their state, and the view scrolls to the newly-revealed models instead of resetting to the top. Falls back to a full re-render in minimal/headless DOM.
- Endpoint-error groups (#4253) stay open by default so the warning is visible; the expanded group persists across a search round-trip.
- The redundant per-row provider chip is suppressed for rows already under their own provider heading (kept for hoisted/search rows).
- Co-authored with @akrhin (collapsible-groups foundation).

### 2. Phantom-providers fix (#4324) — regression from #4247
After the **Photon** iMessage plugin is set up, the picker showed three phantom providers (`photon`, `photon project`, `photon user`) each listing the full auto-detected catalog. The #4247 credential-pool detection loop added every `auth.json` → `credential_pool` key without checking it names a model provider. Now gated on `_is_known_model_provider()` (a `custom:*` slug, a static `_PROVIDER_DISPLAY`/`_PROVIDER_MODELS` entry, or a registered model-provider plugin) on both detection paths, and the group-builder no longer paints an unknown id with the global catalog.

This integrates the stronger of two **independent same-fix PRs**: #4330's implementation + 8-case WebUI-boundary test, chosen over #4329's 2-case version. Both @rodboev (#4329) and the maintainer agent (#4330) found and fixed the same regression — co-authored with @rodboev. Reported by Nic.

## Verification

- **Full pytest suite: 9251 passed, 0 failed.**
- **Codex advisor: SAFE TO SHIP** (80 targeted model-picker/credential-pool/endpoint-error tests + `node --check`).
- **Opus advisor: SAFE TO SHIP** — reviewed twice; flagged three bugs in the first pass (search-clear lost expansion; endpoint-error hint hidden in collapsed group; dead show-more when overflow options already exist), **all three fixed and re-verified** in the second pass.
- **Browser E2E (agent-browser CDP, desktop 1440 + mobile 390):** collapse/expand/collapse, search auto-expand + overflow-search + clear-reset + no-results, load-more in-place + stay-open + scroll-to-new, endpoint-error visibility — all green. Zero console errors across the full interaction flow.
- ESLint runtime gate + browser-smoke: clean.

## Follow-up
- #4331 — add CI coverage for the in-place reveal path (the #3691 node driver currently exercises only the full-re-render fallback). Logic is browser-verified; tracked rather than rushed into this branch.

## Review notes
- `static/ui.js` carries the feature; `api/config.py` carries the #4324 gate; the two are independent.
- The in-place reveal's cross-render "stay open" intent persists on a lazy `globalThis.__modelGroupForceOpen` Set, kept in sync by the heading-toggle handler (add on open, delete on manual collapse).

Staged for an independent review pass — not yet tagged.