### PR TITLE
Release v0.51.465 — reject embedded null byte in remote workspace candidate (#4326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.465] — 2026-06-16 — Release PZ (workspace null-byte hardening)
+
+### Fixed
+
+- **Remote workspace paths containing an embedded null byte are now rejected (#4326).** Completes the #4273/#3664 remote-workspace trust-boundary hardening (v0.51.463): `_remote_terminal_workspace_candidate` now fails closed on a `\x00` in either the candidate path or `terminal.cwd`, before normalization. Previously a null-byte path skipped the POSIX-normalize branch, `_safe_resolve` swallowed the `ValueError` and returned the raw null `Path`, and the string-level containment check wrongly succeeded — accepting the path. Matches the fail-closed null-byte handling already applied at `_as_posix_path` / `_safe_resolve`. Thanks @rodboev.
+
 ## [v0.51.464] — 2026-06-16 — Release PY (scannable model picker)
 
 ### Added

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -163,6 +163,8 @@ def _remote_terminal_workspace_candidate(path: str | Path) -> Path | None:
     raw = _strip_surrounding_quotes(str(path)).strip()
     if not raw:
         return None
+    if '\x00' in raw or '\x00' in cwd:
+        return None
     normalized_raw = _normalize_posix_path(raw)
     normalized_cwd = _normalize_posix_path(cwd)
     if normalized_raw is not None and normalized_cwd is not None:

--- a/tests/test_remote_terminal_workspace.py
+++ b/tests/test_remote_terminal_workspace.py
@@ -90,3 +90,23 @@ def test_var_home_workspaces_stay_allowed_before_system_root_blocklist(monkeypat
     monkeypatch.setattr(workspace, "_workspace_access_error", lambda _candidate: None)
 
     assert validator(str(candidate)) == candidate
+
+
+def test_remote_terminal_workspace_rejects_embedded_nullbyte_in_raw_path(monkeypatch):
+    """Embedded null bytes in remote workspace path should be rejected."""
+    monkeypatch.setattr(api_config, "get_config", lambda: _remote_config())
+
+    # Path with embedded null byte
+    nullbyte_path = f"{REMOTE_CWD}/projects\x00/demo"
+
+    assert workspace._remote_terminal_workspace_candidate(nullbyte_path) is None
+
+
+def test_remote_terminal_workspace_rejects_embedded_nullbyte_in_cwd(monkeypatch):
+    """Embedded null bytes in remote terminal cwd should be rejected."""
+    monkeypatch.setattr(api_config, "get_config", lambda: _remote_config(terminal={"backend": "ssh", "cwd": f"{REMOTE_CWD}\x00/malicious"}))
+
+    # Normal path, but remote cwd contains null byte
+    normal_path = f"{REMOTE_CWD}/projects/demo"
+
+    assert workspace._remote_terminal_workspace_candidate(normal_path) is None


### PR DESCRIPTION
Ships @rodboev's #4327 (closes #4326), rebased onto current master (v0.51.464) and stamped v0.51.465.

Completes the #4273/#3664 remote-workspace trust-boundary hardening: `_remote_terminal_workspace_candidate` now fails closed on an embedded null byte in either the candidate path or `terminal.cwd`. rodboev's fix commit is preserved (authorship intact); this is the same code reviewed clean in #4327.

**Gate (rebased onto v0.51.464):** full suite 9253 passed · Codex SAFE TO SHIP · Opus SAFE TO SHIP (fix logic unchanged from the #4327 review). CI green expected.

Supersedes #4327 (same commit, rebased) — closing #4327 as integrated on merge with credit to @rodboev.