### PR TITLE
Release v0.51.466 — refresh active WebUI transcript on session events (#4208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.466] — 2026-06-16 — Release QA (active transcript reconciles on session events)
+
+### Fixed
+
+- **An open WebUI transcript now reconciles when another client/process updates it (#4205 follow-up).** The #3916/#4195 external-refresh guard made the 30-second poll correctly skip WebUI-native sessions — but it also made `refreshActiveSessionIfExternallyUpdated()` return early for *every* non-external session, so a real `sessions_changed` event would update the sidebar list while leaving the currently-open transcript stale. The early-return is now scoped to the periodic `poll` path only; `event`/focus/visibility triggers run the existing count/timestamp divergence check (guarded by the in-flight/busy/streaming locks, so no refresh loop), and `_scheduleSessionEventsRefresh` reconciles the active transcript, not just the sidebar.
+
 ## [v0.51.465] — 2026-06-16 — Release PZ (workspace null-byte hardening)
 
 ### Fixed

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3764,7 +3764,12 @@ async function refreshActiveSessionIfExternallyUpdated(reason){
   if(_activeSessionExternalRefreshInFlight) return;
   if(!S.session || !S.session.session_id) return;
   if(S.busy || S.activeStreamId) return;
-  if(!_isExternalSession(S.session)) return;
+  // #3916: the 30s timer is only a fallback for imported/external sessions.
+  // WebUI-native sessions should not keep probing forever when the sidebar SSE
+  // is healthy, but they still must reconcile when an actual sessions_changed
+  // event, focus, or visibility recovery says another client/process mutated
+  // the active transcript (#4205 follow-up shape).
+  if((reason||'poll')==='poll' && !_isExternalSession(S.session)) return;
   // Cooldown: don't force-reload immediately after streaming ends — the
   // "done" event already delivered the final messages. Reloading here would
   // clear S.toolCalls and lose Activity.
@@ -3833,7 +3838,7 @@ function _scheduleSessionEventsRefresh(reason){
   if(_sessionEventsRefreshTimer) return;
   _sessionEventsRefreshTimer = setTimeout(() => {
     _sessionEventsRefreshTimer = 0;
-    void refreshSessionList(reason||'event');
+    void refreshSessionList(reason||'event', {refreshActive:true});
   }, 300);
 }
 

--- a/tests/test_issue3916_external_refresh_poll.py
+++ b/tests/test_issue3916_external_refresh_poll.py
@@ -4,21 +4,34 @@ from pathlib import Path
 SESSIONS_JS = Path(__file__).resolve().parent.parent / "static" / "sessions.js"
 
 
+def _function_body(src: str, name: str) -> str:
+    m = re.search(
+        rf"(?:async\s+)?function\s+{re.escape(name)}\b.*?^}}",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert m, f"{name} function not found"
+    return m.group(0)
+
+
 def test_refreshActiveSessionIfExternallyUpdated_exists():
     src = SESSIONS_JS.read_text(encoding="utf-8")
     assert "async function refreshActiveSessionIfExternallyUpdated" in src
 
 
-def test_isExternalSession_guard_present():
+def test_poll_path_skips_non_external_sessions():
     src = SESSIONS_JS.read_text(encoding="utf-8")
-    m = re.search(
-        r"async function refreshActiveSessionIfExternallyUpdated\b.*?^}",
-        src,
-        re.DOTALL | re.MULTILINE,
+    body = _function_body(src, "refreshActiveSessionIfExternallyUpdated")
+    assert re.search(
+        r"if\s*\(\s*\(\s*reason\s*\|\|\s*['\"]poll['\"]\s*\)\s*===\s*['\"]poll['\"]\s*&&\s*!\s*_isExternalSession\s*\(",
+        body,
+    ), (
+        "the 30s poll fallback should early-return for WebUI-native sessions, "
+        "but non-poll refresh triggers must still be allowed"
     )
-    assert m, "refreshActiveSessionIfExternallyUpdated function not found"
-    body = m.group(0)
-    assert re.search(r"if\s*\(\s*!\s*_isExternalSession\s*\(", body), (
-        "refreshActiveSessionIfExternallyUpdated must have an early-return "
-        "guard: if(!_isExternalSession(...))"
-    )
+
+
+def test_session_events_refresh_active_session():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    body = _function_body(src, "_scheduleSessionEventsRefresh")
+    assert "refreshSessionList(reason||'event', {refreshActive:true})" in body


### PR DESCRIPTION
Ships #4208 (agent-authored), rebased onto current master (v0.51.465) and stamped v0.51.466. Nathan-approved to ship.

An open WebUI transcript now reconciles when another client/process updates it: the #3916 poll-skip is scoped to the periodic poll path only, while sessions_changed/focus/visibility triggers run the existing divergence check and reconcile the active transcript (not just the sidebar).

**Gate (rebased onto v0.51.465):** full suite 9254 passed · Codex SAFE TO SHIP · Opus SAFE TO SHIP (no event-storm — client refreshes are pure reads, server broadcasts only on mutations; divergence check no-ops when in sync; streaming/cooldown/in-flight guards intact).

#4208 commit preserved (authorship intact); closing #4208 as integrated on merge.