### PR TITLE
fix(composer): attach image AND paste text when clipboard carries both

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -1531,16 +1531,15 @@ document.addEventListener('keydown',async e=>{
 });
 $('msg').addEventListener('paste',e=>{
   const items=Array.from(e.clipboardData?.items||[]);
-  // When the clipboard carries BOTH text and an image (common from Notes,
-  // Word, browsers, Slack — the OS attaches a rendered preview alongside
-  // the plain text), prefer the text and let the browser paste normally.
-  // Only intercept when the clipboard is image-only (true screenshot paste).
-  // Tighten the image filter to kind==='file' so string items advertising an
-  // image MIME (e.g. text/html with an embedded data URI) are not misclassified.
-  const hasText=items.some(i=>i.kind==='string'&&(i.type==='text/plain'||i.type==='text/html'));
+  // Extract image items (kind==='file' filter avoids misclassifying text/html
+  // with embedded data URIs as images).
   const imageItems=items.filter(i=>i.kind==='file'&&i.type.startsWith('image/'));
-  if(!imageItems.length||hasText)return;
-  e.preventDefault();
+  if(!imageItems.length)return;
+  // If text is also present (common when copying images from browsers, Notes,
+  // Slack, etc.), let the browser paste the text normally AND attach the image.
+  // Only preventDefault when the clipboard is image-only (true screenshot paste).
+  const hasText=items.some(i=>i.kind==='string'&&(i.type==='text/plain'||i.type==='text/html'));
+  if(!hasText)e.preventDefault();
   const pasteTs=Date.now();
   const files=imageItems.map((i,idx)=>{
     const blob=i.getAsFile();

--- a/tests/test_1620_paste_text_with_image.py
+++ b/tests/test_1620_paste_text_with_image.py
@@ -67,15 +67,44 @@ class TestPasteHandlerTextWithImage:
             body,
         ), "imageItems filter must use kind === 'file' && type.startsWith('image/')"
 
-    def test_handler_skips_attach_when_text_present(self):
-        """The early-return guard must short-circuit when text is in the clipboard,
-        so the browser's default text-paste runs and no image is attached."""
+    def test_handler_skips_preventDefault_when_text_present(self):
+        """When text is in the clipboard alongside an image, preventDefault() must
+        NOT be called so the browser's native text-paste runs. The handler should
+        still attach the image via addFiles(). The #1620 intent (don't swallow text)
+        is preserved by gating preventDefault on !hasText instead of bailing entirely.
+        Additionally, text-only clipboards (no image items) must early-return before
+        reaching the attach path."""
         body = _paste_handler_body()
-        # Guard shape: if(!imageItems.length || hasText) return;
+        # Text-only early-out: if no image items, return before any attach logic.
         assert re.search(
-            r"if\s*\(\s*!\s*imageItems\.length\s*\|\|\s*hasText\s*\)\s*return\s*;",
+            r"if\s*\(\s*!\s*imageItems\.length\s*\)\s*return\s*;",
             body,
-        ), "guard must early-return when there are no image files OR text is present"
+        ), "handler must early-return when there are no image files (text-only paste)"
+        # preventDefault must be gated on !hasText so text+image pastes let the
+        # browser insert text natively.
+        assert re.search(
+            r"if\s*\(\s*!\s*hasText\s*\)\s*e\.preventDefault\s*\(\s*\)\s*;",
+            body,
+        ), "preventDefault must be gated on !hasText (only intercept image-only paste)"
+
+    def test_handler_attaches_image_when_both_text_and_image_present(self):
+        """When the clipboard carries both text and image items (e.g. browser
+        Copy Image), addFiles() must still be reached so the image is attached.
+        The image attach path must NOT be guarded by hasText."""
+        body = _paste_handler_body()
+        # addFiles must appear AFTER the preventDefault gate, reachable regardless
+        # of whether text is present.
+        prevent_idx = body.find("preventDefault")
+        addfiles_idx = body.find("addFiles(files)")
+        assert addfiles_idx > prevent_idx, (
+            "addFiles(files) must come after the preventDefault gate and be "
+            "reachable even when hasText is true"
+        )
+        # No guard that bails before addFiles when hasText is true.
+        assert not re.search(
+            r"hasText\s*\)\s*return\s*;",
+            body,
+        ), "handler must NOT early-return on hasText before addFiles (regression for #1620 fix)"
 
     def test_handler_still_intercepts_pure_screenshot_paste(self):
         """Pure-screenshot paste (image-only clipboard) must still call preventDefault()


### PR DESCRIPTION
## Summary

When the clipboard carries both text and an image — which happens almost every time you copy an image from a browser (right-click → Copy Image), Notes, Slack, or Word — the paste handler silently dropped the image and only pasted the text.

This was a regression introduced by the fix for #1620. The original bug was that Cmd+V always attached an image even when the user intended to paste text. The fix made it so that **any** clipboard containing text would skip image attachment entirely. But since almost every "copy image" action on the web also places a `text/html` or `text/plain` representation on the clipboard, the practical effect was that image paste from web sources **never worked**.

## Behavior matrix

| Clipboard contents | Before this PR | After this PR |
|---|---|---|
| Text only | ✅ Text pastes normally | ✅ Unchanged |
| Image only (screenshot) | ✅ Image attached | ✅ Unchanged |
| **Both text + image** | ❌ Text pastes, **image silently dropped** | ✅ Text pastes normally **AND** image attached |

## Changes

**`static/boot.js`** — paste event handler (~12 lines changed):

1. Extract `imageItems` first, before checking for text
2. If no image items, return early (pure text paste — browser handles it)
3. If image items exist **and** text is also present, do **not** call `preventDefault()` — let the browser insert the text naturally, then call `addFiles()` with the image(s)
4. If image items exist but **no** text (true screenshot paste), call `preventDefault()` and attach — unchanged behavior

## Test plan

- [ ] Copy an image from a web page (right-click → Copy Image), paste into composer → both text and image thumbnail should appear
- [ ] Take a screenshot to clipboard, paste into composer → image thumbnail should appear, no text
- [ ] Copy plain text from a text editor, paste into composer → text should appear normally, no image attached
- [ ] Copy text from Notes/Word/Slack (carries both text + rendered preview), paste → text should paste, **no** image should attach (these sources add a rendered preview that the user didn't intend to send as an image)

> **Note on the last case:** Sources like Notes and Word put a rendered HTML preview alongside the text, which is technically "both text and image." With this PR, that preview would get attached as an image. If maintainers prefer the conservative approach (attach image only when there's no text), the alternative is to check whether the text payload is a URL (browser "copy image" behavior) vs. actual content. Happy to adjust based on preference.

Closes #1620