### PR TITLE
fix: prevent cross-provider model selection from silently reverting to default

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -1511,14 +1511,28 @@ function _reconcileModelDropdownSelection(sel,data,previousState,opts){
   // rebuild should preserve the loaded session model or the user's current
   // in-page selection when it still exists in the refreshed catalog.
   const shouldApplyBootDefault=!!(opts&&opts.preferProfileDefaultOnFreshBoot);
+
+  // Helper: try _applyModelToDropdown first; if the model is missing from the
+  // current catalog (cross-provider selection after a partial rebuild), inject
+  // it as a custom option via _ensureModelOptionInDropdown instead of returning
+  // null and letting the browser silently snap to the first <option> (#XXXX).
+  const _applyOrEnsure = function(modelId, providerId) {
+    const applied = _applyModelToDropdown(modelId, sel, providerId);
+    if (applied) return applied;
+    if (typeof _ensureModelOptionInDropdown === 'function') {
+      return _ensureModelOptionInDropdown(modelId, sel, providerId);
+    }
+    return null;
+  };
+
   if(shouldApplyBootDefault && data&&data.default_model && !(activeSession&&activeSession.model)){
-    return _applyModelToDropdown(data.default_model,sel,data.active_provider||null);
+    return _applyOrEnsure(data.default_model, data.active_provider||null);
   }
   if(activeSession&&activeSession.model){
-    return _applyModelToDropdown(activeSession.model,sel,activeSession.model_provider||null);
+    return _applyOrEnsure(activeSession.model, activeSession.model_provider||null);
   }
   if(previousState&&previousState.model){
-    return _applyModelToDropdown(previousState.model,sel,previousState.model_provider||null);
+    return _applyOrEnsure(previousState.model, previousState.model_provider||null);
   }
   return null;
 }


### PR DESCRIPTION
## Summary

Fixes a bug where selecting a model from a non-default provider (e.g. `@ed-vivo-local:gemma4:12b`) silently reverts to the default model (`deepseek-v4-pro:cloud`) when the model dropdown is rebuilt.

## Root Cause

When `populateModelDropdown()` or `_fetchLiveModels()` rebuilds the `<select>`, `_reconcileModelDropdownSelection()` calls `_applyModelToDropdown()` to restore the user's selection. If the cross-provider model is missing from the refreshed catalog (e.g. the rebuild timed out at 4s and served a fallback without the non-default provider's group), `_applyModelToDropdown()` returns `null`. The browser then auto-selects the **first `<option>`** in the dropdown — which is always the default model.

Models on the **active provider** (e.g. `kimi-k2.7-code` on `ollama-cloud`) survive because they're always present in the catalog, even in the fallback.

## Fix

`_reconcileModelDropdownSelection()` now uses a new `_applyOrEnsure` helper that falls back to `_ensureModelOptionInDropdown()` when `_applyModelToDropdown()` returns `null`. This injects the missing model as a custom `<option>` instead of returning `null` and letting the browser snap to the first entry.

## Test Plan

- [ ] Select a cross-provider model (e.g. `@ed-vivo-local:gemma4:12b`) in the WebUI
- [ ] Trigger a model dropdown rebuild (switch panels, refresh providers, or wait for live-model fetch)
- [ ] Verify the selection stays on the chosen model, not the default

## Changes

- `static/ui.js`: `_reconcileModelDropdownSelection` — 17 insertions, 3 deletions