### PR TITLE
Release v0.51.479 — QN (named context blocks in the composer #2543)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.479] — 2026-06-17 — Release QN (named context blocks in the composer)
+
+### Added
+
+- **Selected chat text can now be collected as named context blocks before sending (#2543/#3306).** When you select text in a conversation and use "Reply with selection," instead of immediately dumping it into the composer, it's added as a small named chip ("Context 1", "Context 2", …) in a row above the message box. You can rename a chip (double-click) or remove it (×), stack several from different parts of the conversation, and on send they're flushed into the message as labeled markdown-quoted blocks (`**Name:**` + quoted text). Switching away from a session clears any pending blocks so they don't leak between conversations. Thanks @rodboev.
+
 ## [v0.51.478] — 2026-06-17 — Release QM (read-only LLM Wiki browser in Insights)
 
 ### Added

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -53,6 +53,8 @@ const LOCALES = {
     saved_prompts_saved: 'Prompt saved',
     saved_prompts_delete: 'Delete prompt',
     saved_prompts_empty_input: 'Type a prompt to save first',
+    context_block_name_default: 'Context',
+    context_block_flush_aria: 'Context blocks will be included when you send',
 
     diff_loading: 'Loading diff',
     diff_error: 'Could not load patch file',
@@ -1548,6 +1550,8 @@ const LOCALES = {
     saved_prompts_saved: 'Prompt salvato',
     saved_prompts_delete: 'Elimina prompt',
     saved_prompts_empty_input: 'Digita un prompt da salvare prima',
+    context_block_name_default: 'Contesto',
+    context_block_flush_aria: 'I blocchi di contesto verranno inclusi quando invii',
 
     diff_loading: 'Caricamento diff',
     diff_error: 'Impossibile caricare il file patch',
@@ -3034,6 +3038,8 @@ const LOCALES = {
     saved_prompts_saved: 'プロンプトを保存しました',
     saved_prompts_delete: 'プロンプトを削除',
     saved_prompts_empty_input: '保存するプロンプトを先に入力してください',
+    context_block_name_default: 'コンテキスト',
+    context_block_flush_aria: '送信時にコンテキストブロックが含まれます',
 
     diff_loading: '差分を読み込み中',
     diff_error: 'パッチファイルを読み込めませんでした',
@@ -4522,6 +4528,8 @@ const LOCALES = {
     saved_prompts_saved: 'Подсказка сохранена',
     saved_prompts_delete: 'Удалить подсказку',
     saved_prompts_empty_input: 'Сначала введите подсказку для сохранения',
+    context_block_name_default: 'Контекст',
+    context_block_flush_aria: 'Блоки контекста будут включены при отправке',
 
     diff_loading: 'Загрузка diff',
     diff_error: 'Не удалось загрузить файл патча',
@@ -5940,6 +5948,8 @@ const LOCALES = {
     saved_prompts_saved: 'Indicación guardada',
     saved_prompts_delete: 'Eliminar indicación',
     saved_prompts_empty_input: 'Escribe una indicación para guardar primero',
+    context_block_name_default: 'Contexto',
+    context_block_flush_aria: 'Los bloques de contexto se incluirán al enviar',
 
     diff_loading: 'Cargando diff',
     diff_error: 'No se pudo cargar el archivo de parche',
@@ -7362,6 +7372,8 @@ const LOCALES = {
     saved_prompts_saved: 'Eingabeaufforderung gespeichert',
     saved_prompts_delete: 'Eingabeaufforderung löschen',
     saved_prompts_empty_input: 'Gib zuerst eine Eingabeaufforderung ein',
+    context_block_name_default: 'Kontext',
+    context_block_flush_aria: 'Kontextblöcke werden beim Senden eingefügt',
 
     diff_loading: 'Lade Diff',
     diff_error: 'Patch-Datei konnte nicht geladen werden',
@@ -8788,6 +8800,8 @@ const LOCALES = {
     saved_prompts_saved: '提示已保存',
     saved_prompts_delete: '删除提示',
     saved_prompts_empty_input: '请先输入要保存的提示',
+    context_block_name_default: '上下文',
+    context_block_flush_aria: '发送时将包含上下文块',
 
     diff_loading: '加载 diff',
     diff_error: '无法加载 patch 文件',
@@ -10222,6 +10236,8 @@ const LOCALES = {
     saved_prompts_saved: '提示已儲存',
     saved_prompts_delete: '刪除提示',
     saved_prompts_empty_input: '請先輸入要儲存的提示',
+    context_block_name_default: '上下文',
+    context_block_flush_aria: '傳送時將包含上下文區塊',
 
     diff_loading: '載入 diff',
     diff_error: '無法載入 patch 檔案',
@@ -11697,6 +11713,8 @@ const LOCALES = {
     saved_prompts_saved: 'Prompt salvo',
     saved_prompts_delete: 'Excluir prompt',
     saved_prompts_empty_input: 'Digite um prompt para salvar primeiro',
+    context_block_name_default: 'Contexto',
+    context_block_flush_aria: 'Os blocos de contexto serão incluídos ao enviar',
     you: 'Você',
     thinking: 'Pensando',
     expand_all: 'Expandir tudo',
@@ -12999,6 +13017,8 @@ const LOCALES = {
     saved_prompts_saved: '프롬프트가 저장되었습니다',
     saved_prompts_delete: '프롬프트 삭제',
     saved_prompts_empty_input: '먼저 저장할 프롬프트를 입력하세요',
+    context_block_name_default: '컨텍스트',
+    context_block_flush_aria: '전송 시 컨텍스트 블록이 포함됩니다',
 
     diff_loading: 'diff 불러오는 중',
     diff_error: '패치 파일을 로드할 수 없습니다',
@@ -14484,6 +14504,8 @@ const LOCALES = {
     saved_prompts_saved: 'Invite sauvegardée',
     saved_prompts_delete: 'Supprimer l\'invite',
     saved_prompts_empty_input: 'Tapez d\'abord une invite à sauvegarder',
+    context_block_name_default: 'Contexte',
+    context_block_flush_aria: 'Les blocs de contexte seront inclus lors de l\'envoi',
     diff_loading: 'Chargement des différences',
     diff_error: 'Impossible de charger le fichier de correctif',
     diff_too_large: 'Fichier de correctif trop volumineux pour être affiché en ligne',
@@ -15906,6 +15928,8 @@ const LOCALES = {
     saved_prompts_saved: 'İstem kaydedildi',
     saved_prompts_delete: 'İstemi sil',
     saved_prompts_empty_input: 'Önce kaydedilecek bir istem girin',
+    context_block_name_default: 'Bağlam',
+    context_block_flush_aria: 'Bağlam blokları gönderildiğinde dahil edilecek',
 
     diff_loading: 'Fark yükleniyor',
     diff_error: 'Yama dosyası yüklenemedi',
@@ -17385,6 +17409,8 @@ const LOCALES = {
     saved_prompts_saved: 'Prompt zapisany',
     saved_prompts_delete: 'Usuń prompt',
     saved_prompts_empty_input: 'Najpierw wpisz prompt do zapisania',
+    context_block_name_default: 'Kontekst',
+    context_block_flush_aria: 'Bloki kontekstu zostaną dołączone podczas wysyłania',
 
     diff_loading: 'Ładowanie zmian (diff)',
     diff_error: 'Nie można załadować pliku poprawki',

--- a/static/index.html
+++ b/static/index.html
@@ -564,6 +564,7 @@
       <div class="queue-pill-outer">
         <button id="queuePill" class="queue-pill" aria-label="Show queued messages" type="button"></button>
       </div>
+      <div id="composerSelectionChips" class="composer-selection-chips" hidden aria-live="polite"></div>
       <div class="composer-box" id="composerBox">
         <div class="cmd-dropdown" id="cmdDropdown"></div>
         <div class="drop-hint" id="dropHint">

--- a/static/messages.js
+++ b/static/messages.js
@@ -150,6 +150,8 @@ if(_msgEl) _msgEl.addEventListener('blur', ()=>{ if('speechSynthesis' in window 
 
 let _selectedTextReplyBtn=null;
 let _selectedTextReplyText='';
+let _pendingSelections=[];  // [{id, name, text}] — named context blocks
+let _selectionIdCounter=0;
 let _selectedTextReplyRaf=0;
 const _persistentStateToastSeen=new Set();
 const _thinkPairs=[
@@ -710,6 +712,71 @@ document.addEventListener('click',(e)=>{
     if(btn)btn.setAttribute('aria-expanded','false');
   }
 },{capture:false});
+function _addNamedContextBlock(text){
+  const id='ctx-'+(++_selectionIdCounter);
+  const name=(_selectedTextReplyT('context_block_name_default','Context'))+' '+_selectionIdCounter;
+  _pendingSelections.push({id, name, text});
+  _renderSelectionChips();
+  return id;
+}
+
+function _removeNamedContextBlock(id){
+  _pendingSelections=_pendingSelections.filter(s=>s.id!==id);
+  _renderSelectionChips();
+}
+
+function _clearPendingSelections(){
+  if(!_pendingSelections.length)return false;
+  _pendingSelections=[];
+  _renderSelectionChips();
+  return true;
+}
+if(typeof window!=='undefined') window._clearPendingSelections=_clearPendingSelections;
+
+function _renderSelectionChips(){
+  const wrap=document.getElementById('composerSelectionChips');
+  if(!wrap)return;
+  wrap.innerHTML='';
+  wrap.hidden=!_pendingSelections.length;
+  _pendingSelections.forEach(s=>{
+    const chip=document.createElement('span');
+    chip.className='chip selection-chip';
+    chip.dataset.selectionId=s.id;
+    chip.innerHTML=`<span class="selection-chip-name" title="${esc(s.text)}">${esc(s.name)}</span>`+
+      `<button type="button" class="selection-chip-remove" aria-label="Remove context block" onclick="_removeNamedContextBlock('${s.id}')">&#x2715;</button>`;
+    chip.addEventListener('dblclick',()=>_editSelectionChipName(s.id,chip));
+    wrap.appendChild(chip);
+  });
+}
+
+function _editSelectionChipName(id,chip){
+  const s=_pendingSelections.find(x=>x.id===id);
+  if(!s)return;
+  const nameEl=chip.querySelector('.selection-chip-name');
+  const inp=document.createElement('input');
+  inp.type='text';inp.value=s.name;inp.className='selection-chip-edit';
+  nameEl.replaceWith(inp);
+  inp.focus();inp.select();
+  let done=false;
+  const commit=()=>{ if(done)return; done=true; s.name=inp.value.trim()||s.name; _renderSelectionChips(); };
+  const cancel=()=>{ if(done)return; done=true; _renderSelectionChips(); };
+  inp.addEventListener('blur',commit);
+  inp.addEventListener('keydown',e=>{ if(e.key==='Enter'){e.preventDefault();commit();} if(e.key==='Escape'){cancel();} });
+}
+
+function _flushSelectionBlocksToComposer(){
+  if(!_pendingSelections.length)return;
+  const composer=(typeof $==='function'&&$('msg'))||document.getElementById('msg');
+  if(!composer)return;
+  const blocks=_pendingSelections.map(s=>`**${s.name}:**\n${_formatSelectedTextReplyQuote(s.text)}`).join('\n\n');
+  const current=String(composer.value||'');
+  composer.value=current.trim()?`${current.replace(/\s+$/,'')}\n\n${blocks}\n\n`:`${blocks}\n\n`;
+  _clearPendingSelections();
+  composer.focus();
+  try{ composer.setSelectionRange(composer.value.length, composer.value.length); }catch(_e){}
+  composer.dispatchEvent(new Event('input',{bubbles:true}));
+  if(typeof autoResize==='function') autoResize();
+}
 
 function _selectedTextReplyButton(){
   if(_selectedTextReplyBtn)return _selectedTextReplyBtn;
@@ -726,7 +793,8 @@ function _selectedTextReplyButton(){
   btn.addEventListener('mousedown', e=>e.preventDefault());
   btn.addEventListener('click', e=>{
     e.preventDefault();
-    if(_appendSelectedTextReplyToComposer(_selectedTextReplyText)){
+    if(_selectedTextReplyText){
+      _addNamedContextBlock(_selectedTextReplyText);
       _hideSelectedTextReplyButton();
       const selection=window.getSelection&&window.getSelection();
       if(selection&&selection.removeAllRanges)selection.removeAllRanges();
@@ -872,6 +940,7 @@ function applySessionTitleUpdate(sid, titleText, options={}){
 }
 
 async function send(){
+  _flushSelectionBlocksToComposer();
   // Reject concurrent invocations early — before any await yields control.
   // If a send is already in-flight (e.g. queue drain), re-queue the message
   // instead of silently dropping it.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -668,6 +668,11 @@ async function newSession(flash, options={}){
   }
   _setNewSessionPending(true);
   _newSessionInFlight=(async()=>{
+    // Starting a brand-new chat must not carry named context blocks selected in
+    // the previous conversation (#2543). loadSession() clears these on a sidebar
+    // switch, but the New Chat path replaces S.session here without going through
+    // loadSession(), so clear them explicitly before the session is replaced.
+    if(typeof window._clearPendingSelections==='function') window._clearPendingSelections();
     updateQueueBadge();
     S.toolCalls=[];
     _messagesTruncated=false;
@@ -895,6 +900,7 @@ async function loadSession(sid){
   // restored when the user switches back (#1060). Save to server now so the
   // draft survives page refresh and syncs across clients.
   if (currentSid && currentSid !== sid) {
+    if(typeof window._clearPendingSelections==='function') window._clearPendingSelections();
     await _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
     // The awaited draft save above yields the event loop. If another
     // loadSession() started for a different session while we were waiting

--- a/static/style.css
+++ b/static/style.css
@@ -855,6 +855,13 @@
   :root:not(.dark) .project-chip.active{background:var(--accent-bg);color:var(--accent-text);border-color:var(--accent-bg-strong);}
   :root:not(.dark) .chip{border-color:rgba(0,0,0,.1);background:rgba(0,0,0,.04);}
   :root:not(.dark) .chip.model{color:var(--accent-text);border-color:var(--accent-bg-strong);background:var(--accent-bg);}
+.composer-selection-chips{display:flex;flex-wrap:wrap;gap:6px;padding:6px 12px 0;min-height:0;}
+.composer-selection-chips[hidden]{display:none;}
+.selection-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 6px 2px 8px;border-radius:99px;font-size:11px;cursor:default;border:1px solid var(--border);background:var(--surface-subtle);color:var(--text);}
+.selection-chip-name{max-width:160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.selection-chip-remove{background:none;border:none;padding:0 2px;cursor:pointer;color:var(--muted);font-size:10px;line-height:1;}
+.selection-chip-remove:hover{color:var(--text);}
+.selection-chip-edit{font-size:11px;border:none;outline:1px solid var(--accent);border-radius:3px;padding:0 2px;background:var(--surface);color:var(--text);width:100px;}
   :root:not(.dark) .new-chat-btn{border-color:var(--accent-bg-strong);color:var(--accent-text);}
   :root:not(.dark) .new-chat-btn:hover{background:var(--accent-bg);}
   :root:not(.dark) .sidebar-search input{border-color:rgba(0,0,0,.1);background:rgba(0,0,0,.03);}

--- a/tests/test_issue2543_named_context_session_switch.py
+++ b/tests/test_issue2543_named_context_session_switch.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+MESSAGES_JS = Path("static/messages.js").read_text(encoding="utf-8")
+SESSIONS_JS = Path("static/sessions.js").read_text(encoding="utf-8")
+
+
+def test_named_context_clear_helper_is_exported_for_session_switches():
+    assert "function _clearPendingSelections(){" in MESSAGES_JS
+    assert "window._clearPendingSelections=_clearPendingSelections;" in MESSAGES_JS
+
+
+def test_loadsession_clears_pending_named_context_before_saving_old_draft():
+    start = SESSIONS_JS.index("if (currentSid && currentSid !== sid) {")
+    end = SESSIONS_JS.index("if (currentSid !== sid || forceReload) {", start)
+    block = SESSIONS_JS[start:end]
+
+    clear_idx = block.find("window._clearPendingSelections()")
+    save_idx = block.find("await _saveComposerDraftNow(currentSid")
+
+    assert clear_idx != -1, "loadSession() must clear pending named context blocks on real session switches"
+    assert save_idx != -1, "loadSession() switch block must still persist the old draft before leaving"
+    assert clear_idx < save_idx, "pending named context blocks should disappear before the switch draft save yields"
+
+
+def test_newsession_clears_pending_named_context():
+    """New Chat (newSession) must also clear pending named context blocks — it
+    replaces S.session WITHOUT going through loadSession(), so without an explicit
+    clear, blocks selected in the previous conversation would leak into the new
+    chat and be flushed on the first send (#2543)."""
+    start = SESSIONS_JS.index("async function newSession(")
+    end = SESSIONS_JS.index("updateQueueBadge();", start)
+    head = SESSIONS_JS[start:end]
+    assert "window._clearPendingSelections()" in head, (
+        "newSession() must clear pending named context blocks before replacing S.session"
+    )

--- a/tests/test_issue3306_loadsession_carry_forward.py
+++ b/tests/test_issue3306_loadsession_carry_forward.py
@@ -23,18 +23,25 @@ REPO = Path(__file__).resolve().parents[1]
 SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
 
 
+def _function_body(start_marker: str, end_marker: str) -> str:
+    start = SESSIONS_JS.index(start_marker)
+    end = SESSIONS_JS.index(end_marker, start)
+    return SESSIONS_JS[start:end]
+
+
 def _load_session_clear_block() -> str:
     """The if(currentSid!==sid||forceReload){...} block in loadSession()."""
     start = SESSIONS_JS.index("async function loadSession(sid)")
-    # Window widened to 6500: #3899's idle-reset + live-turn-snapshot blocks added
-    # code earlier in loadSession, pushing the carry-forward snapshot past the old
-    # 4000-char window.
-    return SESSIONS_JS[start: start + 6500]
+    clear_start = SESSIONS_JS.index("if (currentSid !== sid || forceReload) {", start)
+    clear_end = SESSIONS_JS.index("// Phase 1: Load metadata only", clear_start)
+    return SESSIONS_JS[clear_start:clear_end]
 
 
 def _ensure_messages_loaded_body() -> str:
-    start = SESSIONS_JS.index("async function _ensureMessagesLoaded")
-    return SESSIONS_JS[start: start + 3000]
+    return _function_body(
+        "async function _ensureMessagesLoaded(sid) {",
+        "function _messageComparableText",
+    )
 
 
 def test_pending_carry_forward_snapshot_declared_at_module_scope():
@@ -88,13 +95,17 @@ def test_ensure_messages_loaded_consumes_snapshot_then_clears_it():
 
 
 def _load_older_messages_body() -> str:
-    start = SESSIONS_JS.index("async function _loadOlderMessages")
-    return SESSIONS_JS[start: start + 6000]
+    return _function_body(
+        "async function _loadOlderMessages() {",
+        "async function _ensureAllMessagesLoaded",
+    )
 
 
 def _start_gateway_sse_body() -> str:
-    start = SESSIONS_JS.index("function startGatewaySSE")
-    return SESSIONS_JS[start: start + 4000]
+    return _function_body(
+        "function startGatewaySSE(){",
+        "function stopGatewaySSE",
+    )
 
 
 def test_load_older_messages_tail_match_carries_forward():

--- a/tests/test_issue_new_chat_draft_restore.py
+++ b/tests/test_issue_new_chat_draft_restore.py
@@ -18,6 +18,15 @@ def _btn_new_chat_handler() -> str:
     return BOOT_JS[start:end]
 
 
+def _load_session_clear_block() -> str:
+    start = SESSIONS_JS.find("async function loadSession(")
+    clear_start = SESSIONS_JS.find("if (currentSid !== sid || forceReload) {", start)
+    clear_end = SESSIONS_JS.find("// Phase 1: Load metadata only", clear_start)
+    assert start != -1, "loadSession not found"
+    assert clear_start != -1 and clear_end != -1, "loadSession clear block not found"
+    return SESSIONS_JS[start:clear_end]
+
+
 def test_new_session_remembers_regular_empty_session_id():
     start = SESSIONS_JS.find("async function newSession(")
     end = SESSIONS_JS.find("async function loadSession(", start)
@@ -74,11 +83,7 @@ def test_pre_switch_draft_flush_rechecks_stale_loading_guard():
     freshly-loaded C state. The guard is `if (_loadingSessionId !== sid) return;`
     placed AFTER the awaited save and BEFORE the `S.messages = []` clear
     (Codex pre-release CORE catch, #3471)."""
-    start = SESSIONS_JS.find("async function loadSession(")
-    assert start != -1, "loadSession not found"
-    # Window widened to 6500: #3899's idle-reset + live-turn-snapshot blocks pushed
-    # the destructive S.messages clear past the old 4000-char window.
-    body = SESSIONS_JS[start:start + 6500]
+    body = _load_session_clear_block()
     await_idx = body.find("await _saveComposerDraftNow(currentSid")
     guard_idx = body.find("if (_loadingSessionId !== sid) return;", await_idx)
     clear_idx = body.find("S.messages = [];", await_idx)


### PR DESCRIPTION
## Release v0.51.479 — QN (named context blocks in the composer)

Single feature PR from the Priority Review Queue Tier 3. Nathan delegated the go/no-go to me with the instruction to ship only if genuinely confident there's no regression risk — I deep-reviewed, **live-drove every interaction** (headless CDP), and ran the full authoritative gate (Codex + Opus + full suite).

### Included
- **#3567** (@rodboev, closes #2543, refs #3306) — *named context blocks in the composer.* "Reply with selection" now adds selected chat text as a small named chip ("Context N") in a row above the message box instead of dumping it straight into the composer. Chips can be renamed (double-click) or removed (×); multiple stack from different parts of the conversation. On send, pending blocks flush into the message as labeled markdown-quoted blocks (`**Name:**` + quoted text).

### Verified live (headless CDP drive)
- add / render / remove / rename chips all work
- flush produces correct markdown; **empty-flush is a no-op** → `send()` is byte-identical for anyone who never uses the feature (key regression-safety property)
- injected `<img onerror=...>` chip name is escaped, not executed (XSS-safe)
- session switch clears pending blocks (no cross-session leak)

### Gate
- **Codex:** SAFE TO SHIP — but first caught a real **New Chat leak**: `newSession()` replaced `S.session` without clearing pending blocks (only `loadSession()` did), so chips from a previous conversation would carry into a brand-new chat and flush on first send. Fixed with a `_clearPendingSelections()` at the start of `newSession()` + a regression test (toothless-checked RED without the fix); Codex re-confirmed SAFE.
- **Opus:** SAFE TO SHIP — the mid-send flush can't corrupt typed text, can't double-fire, XSS escaped on both fields, legacy selection-reply path intact. (Opus's cross-session analysis covered only `loadSession`; the `newSession` path was Codex's catch — stricter-wins.)
- **Full suite:** 9362 passed, 0 failed. Ruff + ESLint clean. revert-guard: origin/master ancestor of HEAD.

Maintainer change (New Chat clear + test) attributed via `Co-authored-by`.

Closes #2543.