### PR TITLE
fix(#4346): suppress virtual-scroll measurement refreshes during fast upward scroll

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -696,6 +696,25 @@ function _restoreMessageViewportAnchor(anchor, rawIdxDelta){
   requestAnimationFrame(()=>{ _programmaticScroll=false; });
   return true;
 }
+function _compensateScrollForMeasurementDelta(renderFn){
+  const container=$('messages');
+  if(!container) return renderFn();
+  const anchorBefore=_captureMessageViewportAnchor();
+  const scrollTopBefore=container.scrollTop;
+  renderFn();
+  if(!anchorBefore) return;
+  const row=container.querySelector(`[data-msg-idx="${anchorBefore.rawIdx}"]`);
+  if(!row) return;
+  const containerRect=container.getBoundingClientRect();
+  const rowRect=row.getBoundingClientRect();
+  const actualOffset=rowRect.top-containerRect.top;
+  const delta=actualOffset-anchorBefore.topOffset;
+  if(Math.abs(delta)<2) return;
+  _programmaticScroll=true;
+  container.scrollTop=scrollTopBefore+delta;
+  _lastScrollTop=container.scrollTop;
+  requestAnimationFrame(()=>{ setTimeout(()=>{ _programmaticScroll=false; },0); });
+}
 function _messageViewportIntersectsRenderedRow(){
   const container=$('messages');
   if(!container) return true;
@@ -771,7 +790,7 @@ function _scheduleMessageVirtualizedRender(force){
     const liveWindow=_currentMessageVirtualWindow(liveVisWithIdx,_messageVirtualKeepTailCount());
     const liveKey=_messageVirtualWindowKeyFor(liveWindow);
     if(!force&&liveKey===_messageVirtualWindowKey) return;
-    renderMessages({ preserveScroll:true });
+    _compensateScrollForMeasurementDelta(()=>{ renderMessages({ preserveScroll:true }); });
   });
 }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -376,7 +376,17 @@ function _statusCardHtml(card){
 const MESSAGE_RENDER_WINDOW_DEFAULT=50;
 const MESSAGE_VIRTUAL_THRESHOLD_ROWS=80;
 const MESSAGE_VIRTUAL_BUFFER_PX=900;
-const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT=140;
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+function _messageVirtualDefaultHeightForRole(role){
+  return MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS[
+    role&&Object.prototype.hasOwnProperty.call(MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS,role)?role:'default'
+  ];
+}
 const MESSAGE_VIRTUAL_MEASUREMENT_MAX_RERENDERS=2;
 let _messageRenderWindowSid=null;
 let _messageRenderWindowSize=MESSAGE_RENDER_WINDOW_DEFAULT;
@@ -384,7 +394,7 @@ let _messageVirtualHeightCache=[];
 let _messageVirtualHeightCacheEntries=[];
 let _messageVirtualHeightCacheLen=0;
 let _messageVirtualHeightCacheSrc=null;
-let _messageVirtualEstimatedRowHeight=MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT;
+let _messageVirtualEstimatedRowHeight=_messageVirtualDefaultHeightForRole('default');
 let _messageVirtualScrollRaf=0;
 let _messageVirtualWindowKey='';
 let _messageVirtualMeasurementCycleKey='';
@@ -403,7 +413,7 @@ function _clearMessageVirtualHeightCache(){
   _messageVirtualHeightCacheEntries=[];
   _messageVirtualHeightCacheLen=0;
   _messageVirtualHeightCacheSrc=null;
-  _messageVirtualEstimatedRowHeight=MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT;
+  _messageVirtualEstimatedRowHeight=_messageVirtualDefaultHeightForRole('default');
   _messageVirtualWindowKey='';
   _messageVirtualMeasurementCycleKey='';
   _messageVirtualMeasurementRetryCount=0;
@@ -450,15 +460,17 @@ function _getVisibleMessagesWithIdx(){
 function _messageVirtualWindow(opts){
   const total=Math.max(0, Number(opts&&opts.total)||0);
   const threshold=Math.max(1, Number(opts&&opts.threshold)||MESSAGE_VIRTUAL_THRESHOLD_ROWS);
-  const defaultHeight=Math.max(1, Number(opts&&opts.defaultHeight)||MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT);
+  const defaultHeight=Math.max(1, Number(opts&&opts.defaultHeight)||_messageVirtualDefaultHeightForRole('default'));
   const bufferPx=Math.max(0, Number(opts&&opts.bufferPx)||MESSAGE_VIRTUAL_BUFFER_PX);
   const viewportHeight=Math.max(defaultHeight, Number(opts&&opts.viewportHeight)||defaultHeight*6);
   const keepTailCount=Math.max(0, Number(opts&&opts.keepTailCount)||0);
   const tailStart=Math.max(0, total-keepTailCount);
   const heights=Array.isArray(opts&&opts.heights)?opts.heights:[];
+  const roleForIdx=typeof (opts&&opts.roleForIdx)==='function'?opts.roleForIdx:null;
   const rowHeightFor=(idx)=>{
     const cached=Number(heights[idx]);
-    return Number.isFinite(cached)&&cached>0?cached:defaultHeight;
+    if(Number.isFinite(cached)&&cached>0) return cached;
+    return roleForIdx?Math.max(1,_messageVirtualDefaultHeightForRole(roleForIdx(idx))):defaultHeight;
   };
   if(total<=Math.max(threshold, keepTailCount)){
     return {virtualized:false,start:0,end:total,topPad:0,bottomPad:0,total,tailStart};
@@ -609,6 +621,19 @@ function _syncMessageVirtualHeightCache(visWithIdx){
   _messageVirtualHeightCacheLen=S.messages.length;
   _messageVirtualHeightCacheSrc=S.messages;
 }
+function _messageVirtualRoleForEntry(entry){
+  const m=entry&&entry.m;
+  if(!m) return 'default';
+  if(m.role==='user') return 'user';
+  if(m.role==='assistant'){
+    if((Array.isArray(m.tool_calls)&&m.tool_calls.length>0)||
+       (Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use'))||
+       (Array.isArray(m._partial_tool_calls)&&m._partial_tool_calls.length>0))
+      return 'tool_call';
+    return 'assistant';
+  }
+  return 'default';
+}
 function _currentMessageVirtualWindow(visWithIdx, keepTailCount){
   _syncMessageVirtualHeightCache(visWithIdx);
   const container=$('messages');
@@ -627,6 +652,7 @@ function _currentMessageVirtualWindow(visWithIdx, keepTailCount){
     viewportHeight:container?container.clientHeight:(_messageVirtualEstimatedRowHeight*6),
     heights:_messageVirtualHeightCache,
     defaultHeight:_messageVirtualEstimatedRowHeight,
+    roleForIdx:idx=>_messageVirtualRoleForEntry(visWithIdx[idx]),
     keepTailCount,
   });
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -402,11 +402,55 @@ let _messageVirtualMeasurementRetryCount=0;
 let _messageVirtualScrollActive=false;
 let _messageVirtualScrollSettleTimer=0;
 let _messageVirtualDeferredMeasurement=null;
+let _messageVirtualScrollVelocity=0;
+let _messageVirtualScrollVelocityTs=0;
+let _messageVirtualScrollVelocityLastTop=null;
+let _messageVirtualVelocityGuardActive=false;
+let _messageVirtualVelocityDecayTimer=0;
+let _messageVirtualDeferredMeasurementPayload=null;
+const MESSAGE_VIRTUAL_VELOCITY_THRESHOLD=-1.5;
+const MESSAGE_VIRTUAL_VELOCITY_DECAY_MS=80;
+function _updateMessageScrollVelocity(scrollTop,timestamp){
+  if(_messageVirtualScrollVelocityLastTop===null){
+    _messageVirtualScrollVelocityLastTop=scrollTop;
+    _messageVirtualScrollVelocityTs=timestamp;
+    return;
+  }
+  const dt=timestamp-_messageVirtualScrollVelocityTs;
+  if(dt<1) return;
+  const raw=(scrollTop-_messageVirtualScrollVelocityLastTop)/dt;
+  const alpha=0.4;
+  _messageVirtualScrollVelocity=alpha*raw+(1-alpha)*_messageVirtualScrollVelocity;
+  _messageVirtualScrollVelocityLastTop=scrollTop;
+  _messageVirtualScrollVelocityTs=timestamp;
+  const wasActive=_messageVirtualVelocityGuardActive;
+  _messageVirtualVelocityGuardActive=_messageVirtualScrollVelocity<MESSAGE_VIRTUAL_VELOCITY_THRESHOLD;
+  if(wasActive&&!_messageVirtualVelocityGuardActive){
+    _flushDeferredMeasurementPayload();
+  }
+}
+function _flushDeferredMeasurementPayload(){
+  if(!_messageVirtualDeferredMeasurementPayload) return;
+  const payload=_messageVirtualDeferredMeasurementPayload;
+  _messageVirtualDeferredMeasurementPayload=null;
+  _scheduleMessageVirtualMeasurementRefresh(payload);
+}
 function _markMessageVirtualScrollActive(){
   _messageVirtualScrollActive=true;
   clearTimeout(_messageVirtualScrollSettleTimer);
+  clearTimeout(_messageVirtualVelocityDecayTimer);
+  _messageVirtualVelocityDecayTimer=setTimeout(()=>{
+    if(_messageVirtualVelocityGuardActive){
+      _messageVirtualVelocityGuardActive=false;
+      _flushDeferredMeasurementPayload();
+    }
+  },MESSAGE_VIRTUAL_VELOCITY_DECAY_MS);
   _messageVirtualScrollSettleTimer=setTimeout(()=>{
     _messageVirtualScrollActive=false;
+    _messageVirtualScrollVelocity=0;
+    _messageVirtualScrollVelocityLastTop=null;
+    _messageVirtualVelocityGuardActive=false;
+    _flushDeferredMeasurementPayload();
     if(_messageVirtualDeferredMeasurement){
       const deferred=_messageVirtualDeferredMeasurement;
       _messageVirtualDeferredMeasurement=null;
@@ -433,9 +477,15 @@ function _clearMessageVirtualHeightCache(){
   _messageVirtualMeasurementCycleKey='';
   _messageVirtualMeasurementRetryCount=0;
   _messageVirtualScrollActive=false;
+  clearTimeout(_messageVirtualVelocityDecayTimer);
+  _messageVirtualVelocityDecayTimer=0;
   clearTimeout(_messageVirtualScrollSettleTimer);
   _messageVirtualScrollSettleTimer=0;
   _messageVirtualDeferredMeasurement=null;
+  _messageVirtualScrollVelocity=0;
+  _messageVirtualScrollVelocityLastTop=null;
+  _messageVirtualVelocityGuardActive=false;
+  _messageVirtualDeferredMeasurementPayload=null;
 }
 function _resetMessageRenderWindow(sid){
   _messageRenderWindowSid=sid||null;
@@ -555,6 +605,10 @@ function _messageVirtualMeasurementCycleKeyFor(windowMetrics){
   ].join(':');
 }
 function _scheduleMessageVirtualMeasurementRefresh(windowMetrics){
+  if(_messageVirtualVelocityGuardActive){
+    _messageVirtualDeferredMeasurementPayload=windowMetrics||_messageVirtualDeferredMeasurementPayload;
+    return;
+  }
   if(_messageVirtualScrollActive){
     _messageVirtualDeferredMeasurement=windowMetrics;
     return;
@@ -3592,6 +3646,7 @@ if(typeof window!=='undefined'){
     _markMessageVirtualScrollActive();
     cancelAnimationFrame(_scrollRaf);
     _scrollRaf=requestAnimationFrame(()=>{
+      _updateMessageScrollVelocity(el.scrollTop,performance.now());
       const top=el.scrollTop;
       const nearBottom=el.scrollHeight-top-el.clientHeight<250;
       const movedUp=_lastScrollTop!==null&&top<_lastScrollTop-2;

--- a/static/ui.js
+++ b/static/ui.js
@@ -666,7 +666,7 @@ function _messageVirtualPrependedHeightDelta(prependedRenderableCount){
   let total=0;
   for(let i=0;i<limit;i++){
     const cached=Number(_messageVirtualHeightCache[i]);
-    total+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualEstimatedRowHeight;
+    total+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualDefaultHeightForRole(_messageVirtualRoleForEntry(visWithIdx[i]));
   }
   return Math.max(0,Math.round(total));
 }
@@ -684,7 +684,7 @@ function _messageVirtualScrollTopForVisibleIdx(visWithIdx, visibleIdx, container
   let offset=0;
   for(let i=0;i<limit;i++){
     const cached=Number(_messageVirtualHeightCache[i]);
-    offset+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualEstimatedRowHeight;
+    offset+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualDefaultHeightForRole(_messageVirtualRoleForEntry(visWithIdx[i]));
   }
   const viewport=container?Math.max(0,Number(container.clientHeight)||0):0;
   return Math.max(0,Math.round(offset-(viewport*0.35)));

--- a/static/ui.js
+++ b/static/ui.js
@@ -389,6 +389,21 @@ let _messageVirtualScrollRaf=0;
 let _messageVirtualWindowKey='';
 let _messageVirtualMeasurementCycleKey='';
 let _messageVirtualMeasurementRetryCount=0;
+let _messageVirtualScrollActive=false;
+let _messageVirtualScrollSettleTimer=0;
+let _messageVirtualDeferredMeasurement=null;
+function _markMessageVirtualScrollActive(){
+  _messageVirtualScrollActive=true;
+  clearTimeout(_messageVirtualScrollSettleTimer);
+  _messageVirtualScrollSettleTimer=setTimeout(()=>{
+    _messageVirtualScrollActive=false;
+    if(_messageVirtualDeferredMeasurement){
+      const deferred=_messageVirtualDeferredMeasurement;
+      _messageVirtualDeferredMeasurement=null;
+      _scheduleMessageVirtualMeasurementRefresh(deferred);
+    }
+  },150);
+}
 // Cached visWithIdx array — invalidated when S.messages.length changes.
 let _visWithIdxCache=null;
 let _visWithIdxCacheLen=0;
@@ -524,6 +539,10 @@ function _messageVirtualMeasurementCycleKeyFor(windowMetrics){
   ].join(':');
 }
 function _scheduleMessageVirtualMeasurementRefresh(windowMetrics){
+  if(_messageVirtualScrollActive){
+    _messageVirtualDeferredMeasurement=windowMetrics;
+    return;
+  }
   const cycleKey=_messageVirtualMeasurementCycleKeyFor(windowMetrics);
   if(_messageVirtualMeasurementCycleKey!==cycleKey){
     _messageVirtualMeasurementCycleKey=cycleKey;
@@ -3539,6 +3558,7 @@ if(typeof window!=='undefined'){
   if(!el) return;
   let _scrollRaf=0;
   el.addEventListener('scroll',()=>{
+    _markMessageVirtualScrollActive();
     if(_programmaticScroll) return; // ignore scrolls we triggered ourselves
     cancelAnimationFrame(_scrollRaf);
     _scrollRaf=requestAnimationFrame(()=>{

--- a/static/ui.js
+++ b/static/ui.js
@@ -422,6 +422,10 @@ function _clearMessageVirtualHeightCache(){
   _messageVirtualWindowKey='';
   _messageVirtualMeasurementCycleKey='';
   _messageVirtualMeasurementRetryCount=0;
+  _messageVirtualScrollActive=false;
+  clearTimeout(_messageVirtualScrollSettleTimer);
+  _messageVirtualScrollSettleTimer=0;
+  _messageVirtualDeferredMeasurement=null;
 }
 function _resetMessageRenderWindow(sid){
   _messageRenderWindowSid=sid||null;
@@ -3558,8 +3562,8 @@ if(typeof window!=='undefined'){
   if(!el) return;
   let _scrollRaf=0;
   el.addEventListener('scroll',()=>{
-    _markMessageVirtualScrollActive();
     if(_programmaticScroll) return; // ignore scrolls we triggered ourselves
+    _markMessageVirtualScrollActive();
     cancelAnimationFrame(_scrollRaf);
     _scrollRaf=requestAnimationFrame(()=>{
       const top=el.scrollTop;

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -829,8 +829,14 @@ let _messageVirtualEstimatedRowHeight = 200;
 let _messageVirtualWindowKey = 'old-key';
 let _messageVirtualMeasurementCycleKey = 'old-cycle';
 let _messageVirtualMeasurementRetryCount = 3;
+let _messageVirtualScrollVelocity = 0;
+let _messageVirtualScrollVelocityLastTop = null;
+let _messageVirtualVelocityGuardActive = false;
+let _messageVirtualVelocityDecayTimer = 0;
+let _messageVirtualDeferredMeasurementPayload = null;
 const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT = 140;
 function clearTimeout(id){ timerCleared = (id === 99); }
+function _messageVirtualDefaultHeightForRole() { return 140; }
 eval(extractFunc('_clearMessageVirtualHeightCache'));
 _clearMessageVirtualHeightCache();
 console.log(JSON.stringify({
@@ -853,7 +859,8 @@ console.log(JSON.stringify({
     assert metrics["timerCleared"] is True, (
         "_clearMessageVirtualHeightCache must call clearTimeout on the pending settle timer"
     )
-=======
+
+
 def test_message_virtual_default_height_for_role_returns_correct_heights():
     """Verify per-role default heights are configured."""
     js = UI_JS_PATH.read_text(encoding="utf-8")
@@ -1117,4 +1124,220 @@ console.log(JSON.stringify({scrollTop, delta, windowCoversAll}));
     )
     # windowing function must also cover the same three rows
     assert metrics["windowCoversAll"] is True
->>>>>>> fork/pr/per-role-virtual-heights
+
+
+def test_velocity_ema_computation_fast_upward_scroll():
+    """EMA velocity tracker should compute negative velocity from fast upward scroll samples."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+eval(extractFunc('_updateMessageScrollVelocity'));
+let _messageVirtualScrollVelocity = 0;
+let _messageVirtualScrollVelocityTs = 0;
+let _messageVirtualScrollVelocityLastTop = null;
+let _messageVirtualVelocityGuardActive = false;
+const MESSAGE_VIRTUAL_VELOCITY_THRESHOLD = -1.5;
+const MESSAGE_VIRTUAL_VELOCITY_DECAY_MS = 80;
+let _messageVirtualDeferredMeasurementPayload = null;
+function _flushDeferredMeasurementPayload() {}
+// Simulate fast upward scroll: scrollTop decreases ~400px in 16ms intervals
+const samples = [
+  [5000, 1000],
+  [4600, 1016],
+  [4200, 1032],
+  [3800, 1048],
+];
+samples.forEach(([scrollTop, ts]) => {
+  _updateMessageScrollVelocity(scrollTop, ts);
+});
+console.log(JSON.stringify({velocity: _messageVirtualScrollVelocity, guardActive: _messageVirtualVelocityGuardActive}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["velocity"] < -1.5, (
+        f"velocity {result['velocity']} should be < -1.5 for fast upward scroll"
+    )
+
+
+def test_velocity_guard_activation():
+    """Guard should activate when velocity exceeds threshold."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+eval(extractFunc('_updateMessageScrollVelocity'));
+let _messageVirtualScrollVelocity = 0;
+let _messageVirtualScrollVelocityTs = 0;
+let _messageVirtualScrollVelocityLastTop = null;
+let _messageVirtualVelocityGuardActive = false;
+const MESSAGE_VIRTUAL_VELOCITY_THRESHOLD = -1.5;
+const MESSAGE_VIRTUAL_VELOCITY_DECAY_MS = 80;
+let _messageVirtualDeferredMeasurementPayload = null;
+function _flushDeferredMeasurementPayload() {}
+const samples = [
+  [5000, 1000],
+  [4600, 1016],
+  [4200, 1032],
+  [3800, 1048],
+];
+samples.forEach(([scrollTop, ts]) => {
+  _updateMessageScrollVelocity(scrollTop, ts);
+});
+console.log(JSON.stringify({guardActive: _messageVirtualVelocityGuardActive}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["guardActive"] is True, "guard should activate on fast upward scroll"
+
+
+def test_velocity_guard_not_activated_on_slow_scroll():
+    """Guard should stay inactive on slow scroll."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+eval(extractFunc('_updateMessageScrollVelocity'));
+let _messageVirtualScrollVelocity = 0;
+let _messageVirtualScrollVelocityTs = 0;
+let _messageVirtualScrollVelocityLastTop = null;
+let _messageVirtualVelocityGuardActive = false;
+const MESSAGE_VIRTUAL_VELOCITY_THRESHOLD = -1.5;
+const MESSAGE_VIRTUAL_VELOCITY_DECAY_MS = 80;
+let _messageVirtualDeferredMeasurementPayload = null;
+function _flushDeferredMeasurementPayload() {}
+const samples = [
+  [5000, 1000],
+  [4950, 1100],
+  [4900, 1200],
+  [4850, 1300],
+];
+samples.forEach(([scrollTop, ts]) => {
+  _updateMessageScrollVelocity(scrollTop, ts);
+});
+console.log(JSON.stringify({guardActive: _messageVirtualVelocityGuardActive}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["guardActive"] is False, "guard should not activate on slow scroll"
+
+
+def test_velocity_guard_not_activated_on_downward_scroll():
+    """Guard should stay inactive on downward scroll."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+eval(extractFunc('_updateMessageScrollVelocity'));
+let _messageVirtualScrollVelocity = 0;
+let _messageVirtualScrollVelocityTs = 0;
+let _messageVirtualScrollVelocityLastTop = null;
+let _messageVirtualVelocityGuardActive = false;
+const MESSAGE_VIRTUAL_VELOCITY_THRESHOLD = -1.5;
+const MESSAGE_VIRTUAL_VELOCITY_DECAY_MS = 80;
+let _messageVirtualDeferredMeasurementPayload = null;
+function _flushDeferredMeasurementPayload() {}
+const samples = [
+  [5000, 1000],
+  [5400, 1016],
+  [5800, 1032],
+  [6200, 1048],
+];
+samples.forEach(([scrollTop, ts]) => {
+  _updateMessageScrollVelocity(scrollTop, ts);
+});
+console.log(JSON.stringify({guardActive: _messageVirtualVelocityGuardActive}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["guardActive"] is False, "guard should not activate on downward scroll"
+
+
+def test_measurement_suppression_when_guard_active():
+    """Measurement refresh should be suppressed and deferred when guard is active."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+eval(extractFunc('_scheduleMessageVirtualMeasurementRefresh'));
+let _messageVirtualVelocityGuardActive = true;
+let _messageVirtualDeferredMeasurementPayload = null;
+let _messageVirtualScrollActive = false;
+let _messageVirtualMeasurementCycleKey = '';
+let _messageVirtualMeasurementRetryCount = 0;
+const MESSAGE_VIRTUAL_MEASUREMENT_MAX_RERENDERS = 5;
+let refreshTriggered = false;
+function requestAnimationFrame(fn) { refreshTriggered = true; }
+function _scheduleMessageVirtualizedRender() {}
+function _messageVirtualMeasurementCycleKeyFor() { return 'key'; }
+const windowMetrics = {virtualized: true};
+_scheduleMessageVirtualMeasurementRefresh(windowMetrics);
+console.log(JSON.stringify({refreshTriggered: refreshTriggered, hasDeferredPayload: _messageVirtualDeferredMeasurementPayload !== null}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["refreshTriggered"] is False, "refresh should not be triggered when guard is active"
+    assert result["hasDeferredPayload"] is True, "payload should be deferred when guard is active"
+
+
+def test_deferred_payload_flush_when_guard_deactivates():
+    """Deferred payload should be flushed when guard deactivates."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+eval(extractFunc('_scheduleMessageVirtualMeasurementRefresh'));
+eval(extractFunc('_flushDeferredMeasurementPayload'));
+let _messageVirtualVelocityGuardActive = false;
+let _messageVirtualDeferredMeasurementPayload = {virtualized: true};
+let _messageVirtualScrollActive = false;
+let _messageVirtualMeasurementCycleKey = '';
+let _messageVirtualMeasurementRetryCount = 0;
+const MESSAGE_VIRTUAL_MEASUREMENT_MAX_RERENDERS = 5;
+let refreshPayloads = [];
+function requestAnimationFrame(fn) { fn(); }
+function _scheduleMessageVirtualizedRender() { refreshPayloads.push(_messageVirtualDeferredMeasurementPayload); }
+function _messageVirtualMeasurementCycleKeyFor() { return 'key'; }
+_flushDeferredMeasurementPayload();
+console.log(JSON.stringify({payloadFlushed: refreshPayloads.length > 0, payloadNull: _messageVirtualDeferredMeasurementPayload === null}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["payloadFlushed"] is True, "deferred payload should be flushed"
+    assert result["payloadNull"] is True, "deferred payload should be null after flush"
+
+
+def test_scroll_listener_ordering_programmatic_before_mark_active():
+    """_programmaticScroll guard must appear before _markMessageVirtualScrollActive() in scroll listener."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    start = js.index("addEventListener('scroll'")
+    section = js[start:start + 2000]
+    programmatic_pos = section.find("_programmaticScroll")
+    mark_active_pos = section.find("_markMessageVirtualScrollActive")
+    assert programmatic_pos >= 0, "_programmaticScroll guard must exist in scroll listener"
+    assert mark_active_pos >= 0, "_markMessageVirtualScrollActive must exist in scroll listener"
+    assert programmatic_pos < mark_active_pos, (
+        "_programmaticScroll guard must appear before _markMessageVirtualScrollActive"
+    )
+
+
+def test_reset_velocity_state_on_clear_cache():
+    """_clearMessageVirtualHeightCache must reset all velocity guard state."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+eval(extractFunc('_clearMessageVirtualHeightCache'));
+let _messageVirtualHeightCache = [1, 2, 3];
+let _messageVirtualHeightCacheEntries = [1, 2];
+let _messageVirtualHeightCacheLen = 2;
+let _messageVirtualHeightCacheSrc = {};
+let _messageVirtualEstimatedRowHeight = 200;
+let _messageVirtualWindowKey = 'key';
+let _messageVirtualMeasurementCycleKey = 'cycle';
+let _messageVirtualMeasurementRetryCount = 5;
+let _messageVirtualScrollActive = true;
+let _messageVirtualScrollSettleTimer = 123;
+let _messageVirtualDeferredMeasurement = {test: true};
+let _messageVirtualScrollVelocity = -2.5;
+let _messageVirtualScrollVelocityLastTop = 5000;
+let _messageVirtualVelocityGuardActive = true;
+let _messageVirtualVelocityDecayTimer = 456;
+let _messageVirtualDeferredMeasurementPayload = {payload: true};
+function clearTimeout(id) {}
+function _messageVirtualDefaultHeightForRole() { return 140; }
+_clearMessageVirtualHeightCache();
+console.log(JSON.stringify({
+  velocityZero: _messageVirtualScrollVelocity === 0,
+  lastTopNull: _messageVirtualScrollVelocityLastTop === null,
+  guardInactive: _messageVirtualVelocityGuardActive === false,
+  decayTimerZero: _messageVirtualVelocityDecayTimer === 0,
+  payloadNull: _messageVirtualDeferredMeasurementPayload === null
+}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["velocityZero"] is True, "velocity should be reset to 0"
+    assert result["lastTopNull"] is True, "velocity last top should be reset to null"
+    assert result["guardInactive"] is True, "velocity guard should be reset to false"
+    assert result["decayTimerZero"] is True, "decay timer should be reset to 0"
+    assert result["payloadNull"] is True, "deferred payload should be reset to null"

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -525,13 +525,24 @@ def test_virtualize_transcript_opt_out_forces_full_render_window():
     so the whole transcript renders. When true/undefined it virtualizes as before."""
     js = UI_JS_PATH.read_text(encoding="utf-8")
     source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+function _messageVirtualDefaultHeightForRole(role){
+  return MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS[
+    role&&Object.prototype.hasOwnProperty.call(MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS,role)?role:'default'
+  ];
+}
 const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 80;
-const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT = 140;
 const MESSAGE_VIRTUAL_BUFFER_PX = 900;
 let _messageVirtualHeightCache = [];
 let _messageVirtualEstimatedRowHeight = 140;
 function _syncMessageVirtualHeightCache(){ /* no-op for the test */ }
 function $(id){ return {scrollTop: 5000, clientHeight: 720}; }
+function _messageVirtualRoleForEntry(){ return 'default'; }
 const window = {};
 eval(extractFunc('_messageVirtualWindow'));
 eval(extractFunc('_currentMessageVirtualWindow'));
@@ -573,3 +584,176 @@ def test_virtualize_transcript_gate_present_in_current_window_fn():
         "_currentMessageVirtualWindow"
     )
     assert "virtualized:false" in body, "gate must return a non-virtualized window when opted out"
+
+
+def test_message_virtual_default_height_for_role_returns_correct_heights():
+    """Verify per-role default heights are configured."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+console.log(JSON.stringify({
+  tool_call: _messageVirtualDefaultHeightForRole('tool_call'),
+  user: _messageVirtualDefaultHeightForRole('user'),
+  assistant: _messageVirtualDefaultHeightForRole('assistant'),
+  unknown: _messageVirtualDefaultHeightForRole('unknown'),
+  default: _messageVirtualDefaultHeightForRole('default'),
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["tool_call"] == 400
+    assert metrics["user"] == 120
+    assert metrics["assistant"] == 160
+    assert metrics["unknown"] == 140
+    assert metrics["default"] == 140
+
+
+def test_message_virtual_role_for_entry_classifies_tool_calls():
+    """Verify role classifier detects tool_calls, tool_use content, and _partial_tool_calls."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+eval(extractFunc('_messageVirtualRoleForEntry'));
+console.log(JSON.stringify({
+  userRole: _messageVirtualRoleForEntry({m: {role: 'user'}}),
+  assistantNoTools: _messageVirtualRoleForEntry({m: {role: 'assistant'}}),
+  assistantWithToolCalls: _messageVirtualRoleForEntry({m: {role: 'assistant', tool_calls: [{id: '1'}]}}),
+  assistantWithToolUse: _messageVirtualRoleForEntry({m: {role: 'assistant', content: [{type: 'tool_use', id: '1'}]}}),
+  assistantWithPartialToolCalls: _messageVirtualRoleForEntry({m: {role: 'assistant', _partial_tool_calls: [{id: '1'}]}}),
+  noEntry: _messageVirtualRoleForEntry(null),
+  noMessage: _messageVirtualRoleForEntry({m: null}),
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["userRole"] == "user"
+    assert metrics["assistantNoTools"] == "assistant"
+    assert metrics["assistantWithToolCalls"] == "tool_call"
+    assert metrics["assistantWithToolUse"] == "tool_call"
+    assert metrics["assistantWithPartialToolCalls"] == "tool_call"
+    assert metrics["noEntry"] == "default"
+    assert metrics["noMessage"] == "default"
+
+
+def test_message_virtual_window_with_role_for_idx_uses_role_defaults():
+    """Verify _messageVirtualWindow uses role-specific heights when roleForIdx is provided."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 80;
+const MESSAGE_VIRTUAL_BUFFER_PX = 900;
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualWindow'));
+const visWithIdx = [
+  {m: {role: 'user'}},
+  {m: {role: 'assistant', tool_calls: [{id: '1'}]}},
+  {m: {role: 'assistant'}},
+];
+const metrics = _messageVirtualWindow({
+  total: 3,
+  scrollTop: 0,
+  viewportHeight: 600,
+  heights: [0, 0, 0],
+  defaultHeight: 140,
+  roleForIdx: (idx) => {
+    const entry = visWithIdx[idx];
+    if(!entry || !entry.m) return 'default';
+    if(entry.m.role === 'user') return 'user';
+    if(entry.m.role === 'assistant'){
+      if(Array.isArray(entry.m.tool_calls) && entry.m.tool_calls.length > 0) return 'tool_call';
+      return 'assistant';
+    }
+    return 'default';
+  },
+  bufferPx: 0,
+  threshold: 2,
+  keepTailCount: 0,
+});
+console.log(JSON.stringify({
+  virtualized: metrics.virtualized,
+  start: metrics.start,
+  end: metrics.end,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    # With 3 rows (120 + 400 + 160 = 680px) and viewport 600px, should not virtualize (below threshold)
+    # So this checks that the role-based defaults are being computed
+    assert metrics["end"] - metrics["start"] > 0
+
+
+def test_message_virtual_window_cached_heights_override_role_defaults():
+    """Verify cached heights take precedence over role-specific defaults."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 80;
+const MESSAGE_VIRTUAL_BUFFER_PX = 900;
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualWindow'));
+const visWithIdx = [
+  {m: {role: 'user'}},  // normally 120
+  {m: {role: 'assistant', tool_calls: [{id: '1'}]}},  // normally 400
+];
+// Test case 1: with cached heights 250+300=550px < 600px viewport, no virtualization needed
+const metricsSmall = _messageVirtualWindow({
+  total: 2,
+  scrollTop: 0,
+  viewportHeight: 600,
+  heights: [250, 300],  // Cached heights override roles
+  defaultHeight: 140,
+  roleForIdx: (idx) => {
+    const entry = visWithIdx[idx];
+    if(!entry || !entry.m) return 'default';
+    if(entry.m.role === 'user') return 'user';
+    if(entry.m.role === 'assistant'){
+      if(Array.isArray(entry.m.tool_calls) && entry.m.tool_calls.length > 0) return 'tool_call';
+      return 'assistant';
+    }
+    return 'default';
+  },
+  bufferPx: 0,
+  threshold: 80,
+  keepTailCount: 0,
+});
+// Test case 2: with many rows and cached heights, should use cached heights not role defaults
+const largeList = Array.from({length: 100}, (_, i) => ({m: {role: i % 2 ? 'user' : 'assistant'}}));
+const cachedHeights = Array.from({length: 100}, (_, i) => 200);  // All 200px when cached
+const metricsLarge = _messageVirtualWindow({
+  total: 100,
+  scrollTop: 0,
+  viewportHeight: 600,
+  heights: cachedHeights,
+  defaultHeight: 140,
+  roleForIdx: (idx) => {
+    if(largeList[idx]?.m?.role === 'user') return 'user';
+    return 'assistant';
+  },
+  bufferPx: 0,
+  threshold: 80,
+  keepTailCount: 0,
+});
+console.log(JSON.stringify({
+  smallVirtualized: metricsSmall.virtualized,
+  largeVirtualized: metricsLarge.virtualized,
+  largeHasWindow: metricsLarge.end > metricsLarge.start,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    # With 2 rows below threshold, should not virtualize
+    assert metrics["smallVirtualized"] is False
+    # With 100 rows above threshold, should virtualize and use cached heights
+    assert metrics["largeVirtualized"] is True
+    assert metrics["largeHasWindow"] is True

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -772,3 +772,65 @@ def test_virtualized_render_uses_compensation_helper():
     assert "renderMessages(" in body, (
         "the compensation helper should wrap the actual renderMessages call"
     )
+
+
+def test_scroll_listener_guards_programmatic_scroll_before_marking_active():
+    """The _programmaticScroll guard must appear before _markMessageVirtualScrollActive
+    in the scroll listener so that programmatic scrolls (e.g. from
+    _compensateScrollForMeasurementDelta) do not arm the 150ms settle timer."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    listener_start = js.index("el.addEventListener('scroll',()=>{")
+    listener_end = js.index("});", listener_start)
+    listener_body = js[listener_start:listener_end]
+
+    guard_pos = listener_body.index("if(_programmaticScroll) return;")
+    mark_pos = listener_body.index("_markMessageVirtualScrollActive();")
+    assert guard_pos < mark_pos, (
+        "Scroll listener must check _programmaticScroll before calling "
+        "_markMessageVirtualScrollActive so programmatic scrolls do not arm "
+        "the 150ms settle timer and chain measurement delays"
+    )
+
+
+def test_clear_height_cache_resets_scroll_settle_globals():
+    """_clearMessageVirtualHeightCache must zero out the three scroll-settle globals
+    so that a deferred measurement from a previous session cannot fire against the
+    new session's DOM after a session switch."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let timerCleared = false;
+let _messageVirtualScrollActive = true;
+let _messageVirtualScrollSettleTimer = 99;
+let _messageVirtualDeferredMeasurement = {some: 'stale-metrics'};
+let _messageVirtualHeightCache = [100, 200];
+let _messageVirtualHeightCacheEntries = [{rawIdx: 0}];
+let _messageVirtualHeightCacheLen = 2;
+let _messageVirtualHeightCacheSrc = {};
+let _messageVirtualEstimatedRowHeight = 200;
+let _messageVirtualWindowKey = 'old-key';
+let _messageVirtualMeasurementCycleKey = 'old-cycle';
+let _messageVirtualMeasurementRetryCount = 3;
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT = 140;
+function clearTimeout(id){ timerCleared = (id === 99); }
+eval(extractFunc('_clearMessageVirtualHeightCache'));
+_clearMessageVirtualHeightCache();
+console.log(JSON.stringify({
+  scrollActive: _messageVirtualScrollActive,
+  settleTimer: _messageVirtualScrollSettleTimer,
+  deferred: _messageVirtualDeferredMeasurement,
+  timerCleared: timerCleared,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["scrollActive"] is False, (
+        "_clearMessageVirtualHeightCache must reset _messageVirtualScrollActive to false"
+    )
+    assert metrics["settleTimer"] == 0, (
+        "_clearMessageVirtualHeightCache must reset _messageVirtualScrollSettleTimer to 0"
+    )
+    assert metrics["deferred"] is None, (
+        "_clearMessageVirtualHeightCache must clear _messageVirtualDeferredMeasurement to null"
+    )
+    assert metrics["timerCleared"] is True, (
+        "_clearMessageVirtualHeightCache must call clearTimeout on the pending settle timer"
+    )

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -573,3 +573,202 @@ def test_virtualize_transcript_gate_present_in_current_window_fn():
         "_currentMessageVirtualWindow"
     )
     assert "virtualized:false" in body, "gate must return a non-virtualized window when opted out"
+
+
+def test_compensate_scroll_for_measurement_delta_no_anchor_does_not_throw():
+    """When _captureMessageViewportAnchor returns null, the compensation helper
+    should not throw and should not mutate scrollTop."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let renderCalls = [];
+let scrollTopWasMutated = false;
+let scrollTopValue = 100;
+const container = {
+  get scrollTop(){ return scrollTopValue; },
+  set scrollTop(v){ scrollTopWasMutated = true; scrollTopValue = v; },
+  getBoundingClientRect(){ return {top: 0}; },
+  querySelector(){ return null; },
+};
+function $(id){ return id === 'messages' ? container : null; }
+function _captureMessageViewportAnchor(){ return null; }
+let _programmaticScroll = false;
+let _lastScrollTop = 0;
+function _scheduleMessageVirtualizedRender(){ renderCalls.push(true); }
+function requestAnimationFrame(cb){ cb(); }
+eval(extractFunc('_compensateScrollForMeasurementDelta'));
+_compensateScrollForMeasurementDelta(()=>{ _scheduleMessageVirtualizedRender(true); });
+console.log(JSON.stringify({
+  renderCalled: renderCalls.length > 0,
+  scrollTopMutated: scrollTopWasMutated,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["renderCalled"] is True
+    assert metrics["scrollTopMutated"] is False
+
+
+def test_compensate_scroll_for_measurement_delta_shifts_scroll_when_anchor_moves():
+    """When the anchor row shifts position due to measurement changes,
+    scrollTop should be adjusted by the delta."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let scrollTopValue = 200;
+let scrollHistory = [];
+const container = {
+  get scrollTop(){ return scrollTopValue; },
+  set scrollTop(v){ scrollHistory.push(v); scrollTopValue = v; },
+  getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  querySelector(selector){
+    if(selector === '[data-msg-idx="42"]'){
+      // After render, the row moved from relative offset 100 to 150 (50px shift)
+      return {
+        getBoundingClientRect(){ return {top: 100}; }
+      };
+    }
+    return null;
+  },
+};
+function $(id){ return id === 'messages' ? container : null; }
+function _captureMessageViewportAnchor(){
+  // Anchor was at topOffset 100 before the render
+  return {rawIdx: 42, topOffset: 100};
+}
+let _programmaticScroll = false;
+let _lastScrollTop = 0;
+let renderCalls = [];
+function _scheduleMessageVirtualizedRender(){ renderCalls.push(true); }
+function requestAnimationFrame(cb){ cb(); }
+eval(extractFunc('_compensateScrollForMeasurementDelta'));
+_compensateScrollForMeasurementDelta(()=>{ _scheduleMessageVirtualizedRender(true); });
+console.log(JSON.stringify({
+  scrollHistory: scrollHistory,
+  renderCalled: renderCalls.length > 0,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["renderCalled"] is True
+    # actualOffset = 100 - 50 = 50, delta = 50 - 100 = -50 (row moved up 50px)
+    # scrollTop should adjust: 200 + (-50) = 150
+    assert metrics["scrollHistory"] == [150], (
+        "scrollTop should shift by -50px to keep anchor in place"
+    )
+
+
+def test_compensate_scroll_for_measurement_delta_skips_small_delta():
+    """When delta < 2px, no compensation is applied (tolerance)."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let scrollTopValue = 200;
+let scrollHistory = [];
+const container = {
+  get scrollTop(){ return scrollTopValue; },
+  set scrollTop(v){ scrollHistory.push(v); scrollTopValue = v; },
+  getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  querySelector(selector){
+    if(selector === '[data-msg-idx="42"]'){
+      // Row moved by only 1px, within tolerance
+      return {
+        getBoundingClientRect(){ return {top: 251}; }
+      };
+    }
+    return null;
+  },
+};
+function $(id){ return id === 'messages' ? container : null; }
+function _captureMessageViewportAnchor(){
+  return {rawIdx: 42, topOffset: 200};
+}
+let _programmaticScroll = false;
+let _lastScrollTop = 0;
+let renderCalls = [];
+function _scheduleMessageVirtualizedRender(){ renderCalls.push(true); }
+function requestAnimationFrame(cb){ cb(); }
+eval(extractFunc('_compensateScrollForMeasurementDelta'));
+_compensateScrollForMeasurementDelta(()=>{ _scheduleMessageVirtualizedRender(true); });
+console.log(JSON.stringify({
+  scrollHistory: scrollHistory,
+  renderCalled: renderCalls.length > 0,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["renderCalled"] is True
+    assert metrics["scrollHistory"] == [], (
+        "scrollTop should not change for delta < 2px"
+    )
+
+
+def test_compensate_scroll_for_measurement_delta_sets_programmatic_scroll_flag():
+    """_programmaticScroll should be set during compensation and cleared after rAF+setTimeout."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let scrollTopValue = 200;
+let _programmaticScroll = false;
+let _lastScrollTop = 0;
+let scrollSetCount = 0;
+const container = {
+  get scrollTop(){ return scrollTopValue; },
+  set scrollTop(v){
+    scrollSetCount++;
+    scrollTopValue = v;
+  },
+  getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  querySelector(selector){
+    if(selector === '[data-msg-idx="42"]'){
+      return {
+        getBoundingClientRect(){ return {top: 300}; }
+      };
+    }
+    return null;
+  },
+};
+function $(id){ return id === 'messages' ? container : null; }
+function _captureMessageViewportAnchor(){
+  return {rawIdx: 42, topOffset: 200};
+}
+let renderCalls = [];
+function _scheduleMessageVirtualizedRender(){ renderCalls.push(true); }
+let timeoutCbBeingCalled = false;
+function requestAnimationFrame(cb){
+  // This is called with a callback that will eventually clear _programmaticScroll
+  cb();
+}
+function setTimeout(cb, delay){
+  // This is called from within the rAF callback (after scrollTop is set)
+  // The callback should clear _programmaticScroll
+  timeoutCbBeingCalled = true;
+  cb();
+  timeoutCbBeingCalled = false;
+}
+eval(extractFunc('_compensateScrollForMeasurementDelta'));
+_compensateScrollForMeasurementDelta(()=>{ _scheduleMessageVirtualizedRender(true); });
+console.log(JSON.stringify({
+  programmaticScrollWasTrue: _programmaticScroll === true || scrollSetCount > 0,
+  programmaticScrollNowFalse: _programmaticScroll === false,
+  scrollWasSet: scrollSetCount > 0,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    # _programmaticScroll should have been set to true when scrollTop was adjusted
+    assert metrics["scrollWasSet"] is True, (
+        "scrollTop should be set when delta > 2px"
+    )
+    # _programmaticScroll should have been cleared after the setTimeout callback
+    assert metrics["programmaticScrollNowFalse"] is True, (
+        "_programmaticScroll should be false after setTimeout completes"
+    )
+
+
+def test_virtualized_render_uses_compensation_helper():
+    """_scheduleMessageVirtualizedRender must wrap renderMessages with _compensateScrollForMeasurementDelta."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    start = js.index("function _scheduleMessageVirtualizedRender(")
+    end = js.index("\n// ──", start)
+    body = js[start:end]
+
+    assert "_compensateScrollForMeasurementDelta" in body, (
+        "_scheduleMessageVirtualizedRender must call "
+        "_compensateScrollForMeasurementDelta to compensate scroll after measurement-driven rerenders"
+    )
+    assert "renderMessages(" in body, (
+        "the compensation helper should wrap the actual renderMessages call"
+    )

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -189,6 +189,14 @@ console.log(JSON.stringify({
 def test_virtual_prepended_height_delta_uses_prefix_cache_only_when_virtualized():
     js = UI_JS_PATH.read_text(encoding="utf-8")
     source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS = {
+  user: 120,
+  assistant: 160,
+  tool_call: 400,
+  default: 140,
+};
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualRoleForEntry'));
 let virtualized = true;
 let _messageVirtualHeightCache = [0, 220, 180, 120];
 let _messageVirtualEstimatedRowHeight = 140;
@@ -757,3 +765,95 @@ console.log(JSON.stringify({
     # With 100 rows above threshold, should virtualize and use cached heights
     assert metrics["largeVirtualized"] is True
     assert metrics["largeHasWindow"] is True
+
+
+def test_offset_helpers_use_per_role_defaults_for_uncached_rows():
+    """Verify _messageVirtualScrollTopForVisibleIdx and _messageVirtualPrependedHeightDelta
+    use per-role default heights (not the flat 140px estimate) for uncached rows,
+    and that these agree with _messageVirtualWindow's own accounting."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS = {
+  user: 120,
+  assistant: 160,
+  tool_call: 400,
+  default: 140,
+};
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualRoleForEntry'));
+
+// Three entries: user (120), tool_call (400), assistant (160) — all uncached (height=0)
+const visWithIdx = [
+  {rawIdx: 0, m: {role: 'user'}},
+  {rawIdx: 1, m: {role: 'assistant', tool_calls: [{id: 'x'}]}},
+  {rawIdx: 2, m: {role: 'assistant'}},
+];
+
+// --- _messageVirtualScrollTopForVisibleIdx ---
+let _messageVirtualHeightCache = [0, 0, 0];
+let _messageVirtualHeightCacheEntries = [];
+let _messageVirtualHeightCacheLen = 3;
+let _messageVirtualHeightCacheSrc = null;
+let _messageVirtualEstimatedRowHeight = 140;
+let _messageVirtualWindowKey = '';
+let S = {messages: visWithIdx.map(e => e.m)};
+function _messageIsRenderable(){ return true; }
+eval(extractFunc('_messageVirtualHeightEntryMatches'));
+eval(extractFunc('_syncMessageVirtualHeightCache'));
+eval(extractFunc('_messageVirtualScrollTopForVisibleIdx'));
+// scrollTop to visibleIdx=2 must sum heights of idx 0 (120) and idx 1 (400) = 520
+_messageVirtualHeightCacheEntries = visWithIdx;
+_messageVirtualHeightCacheSrc = S.messages;
+const scrollTop = _messageVirtualScrollTopForVisibleIdx(visWithIdx, 2, null);
+
+// --- _messageVirtualPrependedHeightDelta ---
+let virtualized2 = true;
+let _messageVirtualHeightCache2 = [0, 0, 0];
+let _messageVirtualEstimatedRowHeight2 = 140;
+function _getVisibleMessagesWithIdx(){ return visWithIdx; }
+function _messageVirtualKeepTailCount(){ return 0; }
+function _currentMessageVirtualWindow(){ return {virtualized: virtualized2}; }
+// Patch cache var used by _messageVirtualPrependedHeightDelta
+eval(extractFunc('_messageVirtualPrependedHeightDelta').replace(
+  /_messageVirtualHeightCache/g, '_messageVirtualHeightCache2'
+).replace(
+  /_messageVirtualEstimatedRowHeight/g, '_messageVirtualEstimatedRowHeight2'
+));
+// Sum of first 3 uncached entries: user(120) + tool_call(400) + assistant(160) = 680
+const delta = _messageVirtualPrependedHeightDelta(3);
+
+// --- _messageVirtualWindow agreement ---
+const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 2;
+const MESSAGE_VIRTUAL_BUFFER_PX = 0;
+eval(extractFunc('_messageVirtualWindow'));
+const win = _messageVirtualWindow({
+  total: 3,
+  scrollTop: 0,
+  viewportHeight: 600,
+  heights: [0, 0, 0],
+  defaultHeight: 140,
+  roleForIdx: idx => _messageVirtualRoleForEntry(visWithIdx[idx]),
+  bufferPx: 0,
+  threshold: 2,
+  keepTailCount: 0,
+});
+// topPad is sum of rows before win.start; with start=0 it is 0, but
+// the window must have consumed the same per-role heights when computing
+// row positions, so verify the window spans all rows correctly
+const windowCoversAll = win.start === 0 && win.end === 3;
+
+console.log(JSON.stringify({scrollTop, delta, windowCoversAll}));
+"""
+    metrics = json.loads(_run_node(source))
+    # scrollTop to idx=2 = sum of row 0 (120) + row 1 (400) = 520, no viewport offset (null container)
+    assert metrics["scrollTop"] == 520, (
+        f"expected 520 (120+400) but got {metrics['scrollTop']}; "
+        "offset helper must use per-role defaults, not flat 140px"
+    )
+    # prepended delta for 3 uncached rows = 120 + 400 + 160 = 680
+    assert metrics["delta"] == 680, (
+        f"expected 680 (120+400+160) but got {metrics['delta']}; "
+        "prepend helper must use per-role defaults, not flat 140px"
+    )
+    # windowing function must also cover the same three rows
+    assert metrics["windowCoversAll"] is True

--- a/tests/test_issue677.py
+++ b/tests/test_issue677.py
@@ -132,7 +132,7 @@ class TestScrollPinningFix:
         assert scroll_listener_start != -1, "scroll event listener not found"
         # After #1360 fix, the nearBottom + btn logic lives inside an rAF
         # callback — extend search window to cover the full listener block.
-        listener_block = UI_JS[scroll_listener_start:scroll_listener_start + 1400]
+        listener_block = UI_JS[scroll_listener_start:scroll_listener_start + 1600]
         assert "_syncScrollToBottomCue(showBottomButton" in listener_block, (
             "Scroll listener must show/hide scrollToBottomBtn based on _scrollPinned (#677)"
         )


### PR DESCRIPTION
## What Changed

- `static/ui.js`: added velocity tracking (`_updateMessageScrollVelocity`) with EMA smoothing (alpha=0.4, threshold -1.5 px/ms), extended `_markMessageVirtualScrollActive` with an 80ms velocity decay timer, suppressed `_scheduleMessageVirtualMeasurementRefresh` during fast upward scroll to retain a single deferred measurement payload, and flushed it once through the existing anchor-compensated path when velocity settles
- `static/ui.js`: kept `_programmaticScroll` guard ahead of `_markMessageVirtualScrollActive` in the scroll listener so programmatic scrolls (anchor restoration, jump-to-start, bottom-follow, snapshot restores) do not arm the velocity guard
- `tests/test_issue500_message_list_virtualization.py`: added tests for velocity computation, guard activation/deactivation, measurement suppression during fast scroll, deferred flush on velocity settle, and scroll-listener ordering for programmatic scroll

## Why It Matters

The shipped PRs #4367 and #4368 reduced catastrophic snap-backs from 200K px to ~4K px, but ~13 single-frame stutters remain per scroll session because measurement-driven rerenders fire during fast upward scroll, producing visible pushback. Users cannot read content at fast-scroll speeds, so suppressing corrections until the scroll pauses eliminates the stutter without visible inaccuracy.

The fix tracks scroll velocity via an EMA, suppresses measurement refreshes during fast upward scroll, and flushes the deferred measurement through the existing anchor-compensated path when velocity drops or the 150ms settle timer fires.

## Verification

```
pytest tests/test_issue500_message_list_virtualization.py -v --timeout=60
```

Full-suite CI context (not a required local check): `pytest tests/ -v --timeout=60`

## Risks / Follow-ups

- The velocity threshold (-1.5 px/ms) may need tuning on different devices or input methods (trackpad vs mouse wheel vs touch). The constant can be adjusted in the source if needed.
- Suppression retains only the latest deferred measurement and flushes it once when the guard settles, so real size changes are never hidden permanently.
- Independent of #4384 (height cache by identity) and can merge separately.

## Upstream

Part of the ongoing work on #4346. Does not close the issue (#4384 is the companion fix).

Refs #4346