### PR TITLE
fix(#4346): key virtual scroll height cache by message identity

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -376,7 +376,17 @@ function _statusCardHtml(card){
 const MESSAGE_RENDER_WINDOW_DEFAULT=50;
 const MESSAGE_VIRTUAL_THRESHOLD_ROWS=80;
 const MESSAGE_VIRTUAL_BUFFER_PX=900;
-const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT=140;
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+function _messageVirtualDefaultHeightForRole(role){
+  return MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS[
+    role&&Object.prototype.hasOwnProperty.call(MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS,role)?role:'default'
+  ];
+}
 const MESSAGE_VIRTUAL_MEASUREMENT_MAX_RERENDERS=2;
 let _messageRenderWindowSid=null;
 let _messageRenderWindowSize=MESSAGE_RENDER_WINDOW_DEFAULT;
@@ -384,7 +394,7 @@ let _messageVirtualHeightCache=[];
 let _messageVirtualHeightCacheEntries=[];
 let _messageVirtualHeightCacheLen=0;
 let _messageVirtualHeightCacheSrc=null;
-let _messageVirtualEstimatedRowHeight=MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT;
+let _messageVirtualEstimatedRowHeight=_messageVirtualDefaultHeightForRole('default');
 let _messageVirtualScrollRaf=0;
 let _messageVirtualWindowKey='';
 let _messageVirtualMeasurementCycleKey='';
@@ -403,7 +413,7 @@ function _clearMessageVirtualHeightCache(){
   _messageVirtualHeightCacheEntries=[];
   _messageVirtualHeightCacheLen=0;
   _messageVirtualHeightCacheSrc=null;
-  _messageVirtualEstimatedRowHeight=MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT;
+  _messageVirtualEstimatedRowHeight=_messageVirtualDefaultHeightForRole('default');
   _messageVirtualWindowKey='';
   _messageVirtualMeasurementCycleKey='';
   _messageVirtualMeasurementRetryCount=0;
@@ -450,15 +460,17 @@ function _getVisibleMessagesWithIdx(){
 function _messageVirtualWindow(opts){
   const total=Math.max(0, Number(opts&&opts.total)||0);
   const threshold=Math.max(1, Number(opts&&opts.threshold)||MESSAGE_VIRTUAL_THRESHOLD_ROWS);
-  const defaultHeight=Math.max(1, Number(opts&&opts.defaultHeight)||MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT);
+  const defaultHeight=Math.max(1, Number(opts&&opts.defaultHeight)||_messageVirtualDefaultHeightForRole('default'));
   const bufferPx=Math.max(0, Number(opts&&opts.bufferPx)||MESSAGE_VIRTUAL_BUFFER_PX);
   const viewportHeight=Math.max(defaultHeight, Number(opts&&opts.viewportHeight)||defaultHeight*6);
   const keepTailCount=Math.max(0, Number(opts&&opts.keepTailCount)||0);
   const tailStart=Math.max(0, total-keepTailCount);
   const heights=Array.isArray(opts&&opts.heights)?opts.heights:[];
+  const roleForIdx=typeof (opts&&opts.roleForIdx)==='function'?opts.roleForIdx:null;
   const rowHeightFor=(idx)=>{
     const cached=Number(heights[idx]);
-    return Number.isFinite(cached)&&cached>0?cached:defaultHeight;
+    if(Number.isFinite(cached)&&cached>0) return cached;
+    return roleForIdx?Math.max(1,_messageVirtualDefaultHeightForRole(roleForIdx(idx))):defaultHeight;
   };
   if(total<=Math.max(threshold, keepTailCount)){
     return {virtualized:false,start:0,end:total,topPad:0,bottomPad:0,total,tailStart};
@@ -609,6 +621,19 @@ function _syncMessageVirtualHeightCache(visWithIdx){
   _messageVirtualHeightCacheLen=S.messages.length;
   _messageVirtualHeightCacheSrc=S.messages;
 }
+function _messageVirtualRoleForEntry(entry){
+  const m=entry&&entry.m;
+  if(!m) return 'default';
+  if(m.role==='user') return 'user';
+  if(m.role==='assistant'){
+    if((Array.isArray(m.tool_calls)&&m.tool_calls.length>0)||
+       (Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use'))||
+       (Array.isArray(m._partial_tool_calls)&&m._partial_tool_calls.length>0))
+      return 'tool_call';
+    return 'assistant';
+  }
+  return 'default';
+}
 function _currentMessageVirtualWindow(visWithIdx, keepTailCount){
   _syncMessageVirtualHeightCache(visWithIdx);
   const container=$('messages');
@@ -627,6 +652,7 @@ function _currentMessageVirtualWindow(visWithIdx, keepTailCount){
     viewportHeight:container?container.clientHeight:(_messageVirtualEstimatedRowHeight*6),
     heights:_messageVirtualHeightCache,
     defaultHeight:_messageVirtualEstimatedRowHeight,
+    roleForIdx:idx=>_messageVirtualRoleForEntry(visWithIdx[idx]),
     keepTailCount,
   });
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -666,7 +666,7 @@ function _messageVirtualPrependedHeightDelta(prependedRenderableCount){
   let total=0;
   for(let i=0;i<limit;i++){
     const cached=Number(_messageVirtualHeightCache[i]);
-    total+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualEstimatedRowHeight;
+    total+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualDefaultHeightForRole(_messageVirtualRoleForEntry(visWithIdx[i]));
   }
   return Math.max(0,Math.round(total));
 }
@@ -684,7 +684,7 @@ function _messageVirtualScrollTopForVisibleIdx(visWithIdx, visibleIdx, container
   let offset=0;
   for(let i=0;i<limit;i++){
     const cached=Number(_messageVirtualHeightCache[i]);
-    offset+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualEstimatedRowHeight;
+    offset+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualDefaultHeightForRole(_messageVirtualRoleForEntry(visWithIdx[i]));
   }
   const viewport=container?Math.max(0,Number(container.clientHeight)||0):0;
   return Math.max(0,Math.round(offset-(viewport*0.35)));

--- a/static/ui.js
+++ b/static/ui.js
@@ -390,8 +390,7 @@ function _messageVirtualDefaultHeightForRole(role){
 const MESSAGE_VIRTUAL_MEASUREMENT_MAX_RERENDERS=2;
 let _messageRenderWindowSid=null;
 let _messageRenderWindowSize=MESSAGE_RENDER_WINDOW_DEFAULT;
-let _messageVirtualHeightCache=[];
-let _messageVirtualHeightCacheEntries=[];
+const _messageVirtualHeightCacheById=new Map();
 let _messageVirtualHeightCacheLen=0;
 let _messageVirtualHeightCacheSrc=null;
 let _messageVirtualEstimatedRowHeight=_messageVirtualDefaultHeightForRole('default');
@@ -409,8 +408,7 @@ function clearVisibleMessageRowCache(){
   _visWithIdxCacheSrc=null;
 }
 function _clearMessageVirtualHeightCache(){
-  _messageVirtualHeightCache=[];
-  _messageVirtualHeightCacheEntries=[];
+  _messageVirtualHeightCacheById.clear();
   _messageVirtualHeightCacheLen=0;
   _messageVirtualHeightCacheSrc=null;
   _messageVirtualEstimatedRowHeight=_messageVirtualDefaultHeightForRole('default');
@@ -457,6 +455,11 @@ function _getVisibleMessagesWithIdx(){
   }
   return _visWithIdxCache;
 }
+function _messageVirtualHeightForIdx(idx,roleForIdx){
+  const cached=_messageVirtualHeightCacheById.get(idx);
+  if(cached!==undefined) return cached;
+  return _messageVirtualDefaultHeightForRole(roleForIdx());
+}
 function _messageVirtualWindow(opts){
   const total=Math.max(0, Number(opts&&opts.total)||0);
   const threshold=Math.max(1, Number(opts&&opts.threshold)||MESSAGE_VIRTUAL_THRESHOLD_ROWS);
@@ -467,7 +470,9 @@ function _messageVirtualWindow(opts){
   const tailStart=Math.max(0, total-keepTailCount);
   const heights=Array.isArray(opts&&opts.heights)?opts.heights:[];
   const roleForIdx=typeof (opts&&opts.roleForIdx)==='function'?opts.roleForIdx:null;
+  const heightForIdx=typeof (opts&&opts.heightForIdx)==='function'?opts.heightForIdx:null;
   const rowHeightFor=(idx)=>{
+    if(heightForIdx) return heightForIdx(idx);
     const cached=Number(heights[idx]);
     if(Number.isFinite(cached)&&cached>0) return cached;
     return roleForIdx?Math.max(1,_messageVirtualDefaultHeightForRole(roleForIdx(idx))):defaultHeight;
@@ -563,61 +568,26 @@ function _messageVirtualHeightPrefixEntryMatches(previousEntry, nextEntry){
   );
 }
 function _syncMessageVirtualHeightCache(visWithIdx){
-  const nextEntries=Array.isArray(visWithIdx)
-    ? visWithIdx.map(entry=>entry?{rawIdx:entry.rawIdx,m:entry.m}:entry)
-    : [];
-  if(
-    _messageVirtualHeightCacheLen===S.messages.length &&
-    _messageVirtualHeightCacheSrc===S.messages &&
-    _messageVirtualHeightCacheEntries.length===nextEntries.length
-  ) return;
-  const previousEntries=Array.isArray(_messageVirtualHeightCacheEntries)?_messageVirtualHeightCacheEntries:[];
-  const previousHeights=Array.isArray(_messageVirtualHeightCache)?_messageVirtualHeightCache.slice():[];
-  let nextHeights=null;
-  if(!previousEntries.length){
-    nextHeights=new Array(nextEntries.length);
-  }else if(!nextEntries.length){
-    _clearMessageVirtualHeightCache();
+  if(!visWithIdx||!visWithIdx.length){
+    _messageVirtualHeightCacheById.clear();
+    _messageVirtualWindowKey='';
     _messageVirtualHeightCacheLen=S.messages.length;
     _messageVirtualHeightCacheSrc=S.messages;
     return;
-  }else{
-    const sharedPrefix=Math.min(previousEntries.length,nextEntries.length);
-    let prefixMatches=true;
-    for(let i=0;i<sharedPrefix;i++){
-      if(!_messageVirtualHeightPrefixEntryMatches(previousEntries[i], nextEntries[i])){
-        prefixMatches=false;
-        break;
-      }
-    }
-    if(prefixMatches){
-      nextHeights=previousHeights.slice(0, sharedPrefix);
-      nextHeights.length=nextEntries.length;
-    }else if(nextEntries.length>=previousEntries.length){
-      const prependedCount=nextEntries.length-previousEntries.length;
-      let suffixMatches=true;
-      for(let i=0;i<previousEntries.length;i++){
-        if(!_messageVirtualHeightEntryMatches(previousEntries[i], nextEntries[i+prependedCount])){
-          suffixMatches=false;
-          break;
-        }
-      }
-      if(suffixMatches){
-        nextHeights=new Array(nextEntries.length);
-        for(let i=0;i<previousEntries.length;i++){
-          nextHeights[prependedCount+i]=previousHeights[i];
-        }
-      }
-    }
   }
-  if(nextHeights===null){
-    _clearMessageVirtualHeightCache();
-    _messageVirtualHeightCache=new Array(nextEntries.length);
-  }else{
-    _messageVirtualHeightCache=nextHeights;
-    _messageVirtualWindowKey='';
+  const validIds=new Set();
+  for(let i=0;i<visWithIdx.length;i++){
+    if(visWithIdx[i]&&visWithIdx[i].rawIdx!==undefined) validIds.add(visWithIdx[i].rawIdx);
   }
-  _messageVirtualHeightCacheEntries=nextEntries;
+  for(const key of _messageVirtualHeightCacheById.keys()){
+    if(!validIds.has(key)) _messageVirtualHeightCacheById.delete(key);
+  }
+  if(_messageVirtualHeightCacheById.size>500){
+    const excess=_messageVirtualHeightCacheById.size-500;
+    const iter=_messageVirtualHeightCacheById.keys();
+    for(let i=0;i<excess;i++) _messageVirtualHeightCacheById.delete(iter.next().value);
+  }
+  _messageVirtualWindowKey='';
   _messageVirtualHeightCacheLen=S.messages.length;
   _messageVirtualHeightCacheSrc=S.messages;
 }
@@ -650,9 +620,8 @@ function _currentMessageVirtualWindow(visWithIdx, keepTailCount){
     total:visWithIdx.length,
     scrollTop:container?container.scrollTop:0,
     viewportHeight:container?container.clientHeight:(_messageVirtualEstimatedRowHeight*6),
-    heights:_messageVirtualHeightCache,
     defaultHeight:_messageVirtualEstimatedRowHeight,
-    roleForIdx:idx=>_messageVirtualRoleForEntry(visWithIdx[idx]),
+    heightForIdx:idx=>_messageVirtualHeightForIdx(visWithIdx[idx].rawIdx,()=>_messageVirtualRoleForEntry(visWithIdx[idx])),
     keepTailCount,
   });
 }
@@ -662,11 +631,12 @@ function _messageVirtualPrependedHeightDelta(prependedRenderableCount){
   const visWithIdx=_getVisibleMessagesWithIdx();
   const virtualWindow=_currentMessageVirtualWindow(visWithIdx,_messageVirtualKeepTailCount());
   if(!virtualWindow||!virtualWindow.virtualized) return null;
-  const limit=Math.min(count,_messageVirtualHeightCache.length);
+  const limit=Math.min(count,visWithIdx.length);
   let total=0;
   for(let i=0;i<limit;i++){
-    const cached=Number(_messageVirtualHeightCache[i]);
-    total+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualDefaultHeightForRole(_messageVirtualRoleForEntry(visWithIdx[i]));
+    const entry=visWithIdx[i];
+    const cached=_messageVirtualHeightCacheById.get(entry.rawIdx);
+    total+=(cached!==undefined)?cached:_messageVirtualDefaultHeightForRole(_messageVirtualRoleForEntry(entry));
   }
   return Math.max(0,Math.round(total));
 }
@@ -680,11 +650,12 @@ function _messageVisibleIndexForRawIdx(rawIdx, visWithIdx){
 function _messageVirtualScrollTopForVisibleIdx(visWithIdx, visibleIdx, container){
   const idx=Math.max(0,Number(visibleIdx)||0);
   _syncMessageVirtualHeightCache(visWithIdx);
-  const limit=Math.min(idx,_messageVirtualHeightCache.length);
+  const limit=Math.min(idx,visWithIdx.length);
   let offset=0;
   for(let i=0;i<limit;i++){
-    const cached=Number(_messageVirtualHeightCache[i]);
-    offset+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualDefaultHeightForRole(_messageVirtualRoleForEntry(visWithIdx[i]));
+    const entry=visWithIdx[i];
+    const cached=_messageVirtualHeightCacheById.get(entry.rawIdx);
+    offset+=(cached!==undefined)?cached:_messageVirtualDefaultHeightForRole(_messageVirtualRoleForEntry(entry));
   }
   const viewport=container?Math.max(0,Number(container.clientHeight)||0):0;
   return Math.max(0,Math.round(offset-(viewport*0.35)));
@@ -760,10 +731,9 @@ function _updateMessageVirtualMeasurements(renderVisWithIdx, renderVisibleIdxs, 
     if(!entry) continue;
     const totalHeight=_measureMessageVirtualRow(inner, entry);
     if(totalHeight<=0) continue;
-    const visibleIdx=Number(renderVisibleIdxs&&renderVisibleIdxs[vi]);
-    if(!Number.isFinite(visibleIdx)) continue;
-    if(Math.abs((Number(_messageVirtualHeightCache[visibleIdx])||0)-totalHeight)>1){
-      _messageVirtualHeightCache[visibleIdx]=totalHeight;
+    const cached=_messageVirtualHeightCacheById.get(entry.rawIdx);
+    if(cached!==totalHeight){
+      _messageVirtualHeightCacheById.set(entry.rawIdx, totalHeight);
       changed=true;
     }
     measuredTotal+=totalHeight;

--- a/static/ui.js
+++ b/static/ui.js
@@ -575,12 +575,10 @@ function _syncMessageVirtualHeightCache(visWithIdx){
     _messageVirtualHeightCacheSrc=S.messages;
     return;
   }
-  const validIds=new Set();
-  for(let i=0;i<visWithIdx.length;i++){
-    if(visWithIdx[i]&&visWithIdx[i].rawIdx!==undefined) validIds.add(visWithIdx[i].rawIdx);
-  }
+  if(_messageVirtualHeightCacheLen===S.messages.length&&_messageVirtualHeightCacheSrc===S.messages) return;
+  const msgLen=S.messages.length;
   for(const key of _messageVirtualHeightCacheById.keys()){
-    if(!validIds.has(key)) _messageVirtualHeightCacheById.delete(key);
+    if(key>=msgLen) _messageVirtualHeightCacheById.delete(key);
   }
   if(_messageVirtualHeightCacheById.size>500){
     const excess=_messageVirtualHeightCacheById.size-500;
@@ -732,7 +730,7 @@ function _updateMessageVirtualMeasurements(renderVisWithIdx, renderVisibleIdxs, 
     const totalHeight=_measureMessageVirtualRow(inner, entry);
     if(totalHeight<=0) continue;
     const cached=_messageVirtualHeightCacheById.get(entry.rawIdx);
-    if(cached!==totalHeight){
+    if(cached===undefined||Math.abs(cached-totalHeight)>1){
       _messageVirtualHeightCacheById.set(entry.rawIdx, totalHeight);
       changed=true;
     }

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -525,13 +525,24 @@ def test_virtualize_transcript_opt_out_forces_full_render_window():
     so the whole transcript renders. When true/undefined it virtualizes as before."""
     js = UI_JS_PATH.read_text(encoding="utf-8")
     source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+function _messageVirtualDefaultHeightForRole(role){
+  return MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS[
+    role&&Object.prototype.hasOwnProperty.call(MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS,role)?role:'default'
+  ];
+}
 const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 80;
-const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT = 140;
 const MESSAGE_VIRTUAL_BUFFER_PX = 900;
 let _messageVirtualHeightCache = [];
 let _messageVirtualEstimatedRowHeight = 140;
 function _syncMessageVirtualHeightCache(){ /* no-op for the test */ }
 function $(id){ return {scrollTop: 5000, clientHeight: 720}; }
+function _messageVirtualRoleForEntry(){ return 'default'; }
 const window = {};
 eval(extractFunc('_messageVirtualWindow'));
 eval(extractFunc('_currentMessageVirtualWindow'));
@@ -573,3 +584,176 @@ def test_virtualize_transcript_gate_present_in_current_window_fn():
         "_currentMessageVirtualWindow"
     )
     assert "virtualized:false" in body, "gate must return a non-virtualized window when opted out"
+
+
+def test_message_virtual_default_height_for_role_returns_correct_heights():
+    """Verify per-role default heights are configured."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+console.log(JSON.stringify({
+  tool_call: _messageVirtualDefaultHeightForRole('tool_call'),
+  user: _messageVirtualDefaultHeightForRole('user'),
+  assistant: _messageVirtualDefaultHeightForRole('assistant'),
+  unknown: _messageVirtualDefaultHeightForRole('unknown'),
+  default: _messageVirtualDefaultHeightForRole('default'),
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["tool_call"] == 400
+    assert metrics["user"] == 120
+    assert metrics["assistant"] == 160
+    assert metrics["unknown"] == 140
+    assert metrics["default"] == 140
+
+
+def test_message_virtual_role_for_entry_classifies_tool_calls():
+    """Verify role classifier detects tool_calls, tool_use content, and _partial_tool_calls."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+eval(extractFunc('_messageVirtualRoleForEntry'));
+console.log(JSON.stringify({
+  userRole: _messageVirtualRoleForEntry({m: {role: 'user'}}),
+  assistantNoTools: _messageVirtualRoleForEntry({m: {role: 'assistant'}}),
+  assistantWithToolCalls: _messageVirtualRoleForEntry({m: {role: 'assistant', tool_calls: [{id: '1'}]}}),
+  assistantWithToolUse: _messageVirtualRoleForEntry({m: {role: 'assistant', content: [{type: 'tool_use', id: '1'}]}}),
+  assistantWithPartialToolCalls: _messageVirtualRoleForEntry({m: {role: 'assistant', _partial_tool_calls: [{id: '1'}]}}),
+  noEntry: _messageVirtualRoleForEntry(null),
+  noMessage: _messageVirtualRoleForEntry({m: null}),
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["userRole"] == "user"
+    assert metrics["assistantNoTools"] == "assistant"
+    assert metrics["assistantWithToolCalls"] == "tool_call"
+    assert metrics["assistantWithToolUse"] == "tool_call"
+    assert metrics["assistantWithPartialToolCalls"] == "tool_call"
+    assert metrics["noEntry"] == "default"
+    assert metrics["noMessage"] == "default"
+
+
+def test_message_virtual_window_with_role_for_idx_uses_role_defaults():
+    """Verify _messageVirtualWindow uses role-specific heights when roleForIdx is provided."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 80;
+const MESSAGE_VIRTUAL_BUFFER_PX = 900;
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualWindow'));
+const visWithIdx = [
+  {m: {role: 'user'}},
+  {m: {role: 'assistant', tool_calls: [{id: '1'}]}},
+  {m: {role: 'assistant'}},
+];
+const metrics = _messageVirtualWindow({
+  total: 3,
+  scrollTop: 0,
+  viewportHeight: 600,
+  heights: [0, 0, 0],
+  defaultHeight: 140,
+  roleForIdx: (idx) => {
+    const entry = visWithIdx[idx];
+    if(!entry || !entry.m) return 'default';
+    if(entry.m.role === 'user') return 'user';
+    if(entry.m.role === 'assistant'){
+      if(Array.isArray(entry.m.tool_calls) && entry.m.tool_calls.length > 0) return 'tool_call';
+      return 'assistant';
+    }
+    return 'default';
+  },
+  bufferPx: 0,
+  threshold: 2,
+  keepTailCount: 0,
+});
+console.log(JSON.stringify({
+  virtualized: metrics.virtualized,
+  start: metrics.start,
+  end: metrics.end,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    # With 3 rows (120 + 400 + 160 = 680px) and viewport 600px, should not virtualize (below threshold)
+    # So this checks that the role-based defaults are being computed
+    assert metrics["end"] - metrics["start"] > 0
+
+
+def test_message_virtual_window_cached_heights_override_role_defaults():
+    """Verify cached heights take precedence over role-specific defaults."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 80;
+const MESSAGE_VIRTUAL_BUFFER_PX = 900;
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualWindow'));
+const visWithIdx = [
+  {m: {role: 'user'}},  // normally 120
+  {m: {role: 'assistant', tool_calls: [{id: '1'}]}},  // normally 400
+];
+// Test case 1: with cached heights 250+300=550px < 600px viewport, no virtualization needed
+const metricsSmall = _messageVirtualWindow({
+  total: 2,
+  scrollTop: 0,
+  viewportHeight: 600,
+  heights: [250, 300],  // Cached heights override roles
+  defaultHeight: 140,
+  roleForIdx: (idx) => {
+    const entry = visWithIdx[idx];
+    if(!entry || !entry.m) return 'default';
+    if(entry.m.role === 'user') return 'user';
+    if(entry.m.role === 'assistant'){
+      if(Array.isArray(entry.m.tool_calls) && entry.m.tool_calls.length > 0) return 'tool_call';
+      return 'assistant';
+    }
+    return 'default';
+  },
+  bufferPx: 0,
+  threshold: 80,
+  keepTailCount: 0,
+});
+// Test case 2: with many rows and cached heights, should use cached heights not role defaults
+const largeList = Array.from({length: 100}, (_, i) => ({m: {role: i % 2 ? 'user' : 'assistant'}}));
+const cachedHeights = Array.from({length: 100}, (_, i) => 200);  // All 200px when cached
+const metricsLarge = _messageVirtualWindow({
+  total: 100,
+  scrollTop: 0,
+  viewportHeight: 600,
+  heights: cachedHeights,
+  defaultHeight: 140,
+  roleForIdx: (idx) => {
+    if(largeList[idx]?.m?.role === 'user') return 'user';
+    return 'assistant';
+  },
+  bufferPx: 0,
+  threshold: 80,
+  keepTailCount: 0,
+});
+console.log(JSON.stringify({
+  smallVirtualized: metricsSmall.virtualized,
+  largeVirtualized: metricsLarge.virtualized,
+  largeHasWindow: metricsLarge.end > metricsLarge.start,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    # With 2 rows below threshold, should not virtualize
+    assert metrics["smallVirtualized"] is False
+    # With 100 rows above threshold, should virtualize and use cached heights
+    assert metrics["largeVirtualized"] is True
+    assert metrics["largeHasWindow"] is True

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -189,6 +189,14 @@ console.log(JSON.stringify({
 def test_virtual_prepended_height_delta_uses_prefix_cache_only_when_virtualized():
     js = UI_JS_PATH.read_text(encoding="utf-8")
     source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS = {
+  user: 120,
+  assistant: 160,
+  tool_call: 400,
+  default: 140,
+};
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualRoleForEntry'));
 let virtualized = true;
 let _messageVirtualHeightCache = [0, 220, 180, 120];
 let _messageVirtualEstimatedRowHeight = 140;
@@ -757,3 +765,95 @@ console.log(JSON.stringify({
     # With 100 rows above threshold, should virtualize and use cached heights
     assert metrics["largeVirtualized"] is True
     assert metrics["largeHasWindow"] is True
+
+
+def test_offset_helpers_use_per_role_defaults_for_uncached_rows():
+    """Verify _messageVirtualScrollTopForVisibleIdx and _messageVirtualPrependedHeightDelta
+    use per-role default heights (not the flat 140px estimate) for uncached rows,
+    and that these agree with _messageVirtualWindow's own accounting."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS = {
+  user: 120,
+  assistant: 160,
+  tool_call: 400,
+  default: 140,
+};
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualRoleForEntry'));
+
+// Three entries: user (120), tool_call (400), assistant (160) — all uncached (height=0)
+const visWithIdx = [
+  {rawIdx: 0, m: {role: 'user'}},
+  {rawIdx: 1, m: {role: 'assistant', tool_calls: [{id: 'x'}]}},
+  {rawIdx: 2, m: {role: 'assistant'}},
+];
+
+// --- _messageVirtualScrollTopForVisibleIdx ---
+let _messageVirtualHeightCache = [0, 0, 0];
+let _messageVirtualHeightCacheEntries = [];
+let _messageVirtualHeightCacheLen = 3;
+let _messageVirtualHeightCacheSrc = null;
+let _messageVirtualEstimatedRowHeight = 140;
+let _messageVirtualWindowKey = '';
+let S = {messages: visWithIdx.map(e => e.m)};
+function _messageIsRenderable(){ return true; }
+eval(extractFunc('_messageVirtualHeightEntryMatches'));
+eval(extractFunc('_syncMessageVirtualHeightCache'));
+eval(extractFunc('_messageVirtualScrollTopForVisibleIdx'));
+// scrollTop to visibleIdx=2 must sum heights of idx 0 (120) and idx 1 (400) = 520
+_messageVirtualHeightCacheEntries = visWithIdx;
+_messageVirtualHeightCacheSrc = S.messages;
+const scrollTop = _messageVirtualScrollTopForVisibleIdx(visWithIdx, 2, null);
+
+// --- _messageVirtualPrependedHeightDelta ---
+let virtualized2 = true;
+let _messageVirtualHeightCache2 = [0, 0, 0];
+let _messageVirtualEstimatedRowHeight2 = 140;
+function _getVisibleMessagesWithIdx(){ return visWithIdx; }
+function _messageVirtualKeepTailCount(){ return 0; }
+function _currentMessageVirtualWindow(){ return {virtualized: virtualized2}; }
+// Patch cache var used by _messageVirtualPrependedHeightDelta
+eval(extractFunc('_messageVirtualPrependedHeightDelta').replace(
+  /_messageVirtualHeightCache/g, '_messageVirtualHeightCache2'
+).replace(
+  /_messageVirtualEstimatedRowHeight/g, '_messageVirtualEstimatedRowHeight2'
+));
+// Sum of first 3 uncached entries: user(120) + tool_call(400) + assistant(160) = 680
+const delta = _messageVirtualPrependedHeightDelta(3);
+
+// --- _messageVirtualWindow agreement ---
+const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 2;
+const MESSAGE_VIRTUAL_BUFFER_PX = 0;
+eval(extractFunc('_messageVirtualWindow'));
+const win = _messageVirtualWindow({
+  total: 3,
+  scrollTop: 0,
+  viewportHeight: 600,
+  heights: [0, 0, 0],
+  defaultHeight: 140,
+  roleForIdx: idx => _messageVirtualRoleForEntry(visWithIdx[idx]),
+  bufferPx: 0,
+  threshold: 2,
+  keepTailCount: 0,
+});
+// topPad is sum of rows before win.start; with start=0 it is 0, but
+// the window must have consumed the same per-role heights when computing
+// row positions, so verify the window spans all rows correctly
+const windowCoversAll = win.start === 0 && win.end === 3;
+
+console.log(JSON.stringify({scrollTop, delta, windowCoversAll}));
+"""
+    metrics = json.loads(_run_node(source))
+    # scrollTop to idx=2 = sum of row 0 (120) + row 1 (400) = 520, no viewport offset (null container)
+    assert metrics["scrollTop"] == 520, (
+        f"expected 520 (120+400) but got {metrics['scrollTop']}; "
+        "offset helper must use per-role defaults, not flat 140px"
+    )
+    # prepended delta for 3 uncached rows = 120 + 400 + 160 = 680
+    assert metrics["delta"] == 680, (
+        f"expected 680 (120+400+160) but got {metrics['delta']}; "
+        "prepend helper must use per-role defaults, not flat 140px"
+    )
+    # windowing function must also cover the same three rows
+    assert metrics["windowCoversAll"] is True

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -196,9 +196,14 @@ const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS = {
   default: 140,
 };
 eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualHeightForIdx'));
 eval(extractFunc('_messageVirtualRoleForEntry'));
 let virtualized = true;
-let _messageVirtualHeightCache = [0, 220, 180, 120];
+const _messageVirtualHeightCacheById = new Map();
+_messageVirtualHeightCacheById.set(0, 120);  // user
+_messageVirtualHeightCacheById.set(1, 400);  // tool_call
+_messageVirtualHeightCacheById.set(2, 160);  // assistant
+_messageVirtualHeightCacheById.set(3, 140);  // default
 let _messageVirtualEstimatedRowHeight = 140;
 function _getVisibleMessagesWithIdx(){
   return [{rawIdx: 0}, {rawIdx: 1}, {rawIdx: 2}, {rawIdx: 3}];
@@ -214,21 +219,32 @@ const inactive = _messageVirtualPrependedHeightDelta(3);
 console.log(JSON.stringify({active, inactive}));
 """
     metrics = json.loads(_run_node(source))
-    assert metrics["active"] == 540
+    assert metrics["active"] == 680, f"Active should be 120+400+160=680, got {metrics['active']}"
     assert metrics["inactive"] is None
 
 
 def test_virtual_question_jump_scroll_target_uses_visible_index_height_prefix():
     js = UI_JS_PATH.read_text(encoding="utf-8")
     source = _extract_func_script(js) + """
-let _messageVirtualHeightCache = [100, 120, 80, 140];
-let _messageVirtualHeightCacheEntries = [];
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS = {
+  user: 120,
+  assistant: 160,
+  tool_call: 400,
+  default: 140,
+};
+const _messageVirtualHeightCacheById = new Map();
+_messageVirtualHeightCacheById.set(10, 100);
+_messageVirtualHeightCacheById.set(12, 120);
+_messageVirtualHeightCacheById.set(14, 80);
+_messageVirtualHeightCacheById.set(16, 140);
 let _messageVirtualHeightCacheLen = 4;
 let _messageVirtualHeightCacheSrc = null;
 let _messageVirtualEstimatedRowHeight = 110;
 let _messageVirtualWindowKey = 'old';
 let S = {messages: [{}, {}, {}, {}]};
 function _messageIsRenderable(){ return true; }
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualHeightForIdx'));
 eval(extractFunc('_messageVirtualHeightEntryMatches'));
 eval(extractFunc('_syncMessageVirtualHeightCache'));
 eval(extractFunc('_messageVisibleIndexForRawIdx'));
@@ -239,7 +255,6 @@ const visWithIdx = [
   {rawIdx: 14, m: S.messages[2]},
   {rawIdx: 16, m: S.messages[3]},
 ];
-_messageVirtualHeightCacheEntries = visWithIdx;
 _messageVirtualHeightCacheSrc = S.messages;
 const visibleIdx = _messageVisibleIndexForRawIdx(14, visWithIdx);
 const scrollTop = _messageVirtualScrollTopForVisibleIdx(visWithIdx, visibleIdx, {clientHeight: 200});
@@ -254,15 +269,15 @@ def test_height_cache_preserves_measured_prefix_across_append_only_growth():
     js = UI_JS_PATH.read_text(encoding="utf-8")
     source = _extract_func_script(js) + """
 const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT = 140;
-let _messageVirtualHeightCache = [180, 220];
-let _messageVirtualHeightCacheEntries = [];
+const _messageVirtualHeightCacheById = new Map();
+_messageVirtualHeightCacheById.set(0, 180);
+_messageVirtualHeightCacheById.set(1, 220);
 let _messageVirtualHeightCacheLen = 2;
 let _messageVirtualHeightCacheSrc = null;
 let _messageVirtualEstimatedRowHeight = 200;
 let _messageVirtualWindowKey = 'stale-key';
 function _clearMessageVirtualHeightCache() {
-  _messageVirtualHeightCache = [];
-  _messageVirtualHeightCacheEntries = [];
+  _messageVirtualHeightCacheById.clear();
   _messageVirtualHeightCacheLen = 0;
   _messageVirtualHeightCacheSrc = null;
   _messageVirtualEstimatedRowHeight = MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT;
@@ -274,10 +289,6 @@ eval(extractFunc('_syncMessageVirtualHeightCache'));
 const first = {id: 'first'};
 const second = {id: 'second'};
 let S = {messages: [first, second]};
-_messageVirtualHeightCacheEntries = [
-  {rawIdx: 0, m: first},
-  {rawIdx: 1, m: second},
-];
 _messageVirtualHeightCacheSrc = S.messages;
 S = {messages: [first, second, {id: 'third'}]};
 _syncMessageVirtualHeightCache([
@@ -285,15 +296,17 @@ _syncMessageVirtualHeightCache([
   {rawIdx: 1, m: second},
   {rawIdx: 2, m: S.messages[2]},
 ]);
+const cacheArray = Array.from(_messageVirtualHeightCacheById.values());
 console.log(JSON.stringify({
-  cache: _messageVirtualHeightCache,
+  cacheValues: cacheArray,
+  cacheSize: _messageVirtualHeightCacheById.size,
   estimated: _messageVirtualEstimatedRowHeight,
   windowKey: _messageVirtualWindowKey,
 }));
 """
     metrics = json.loads(_run_node(source))
-    assert metrics["cache"][:2] == [180, 220]
-    assert len(metrics["cache"]) == 3
+    assert metrics["cacheValues"][:2] == [180, 220]
+    assert metrics["cacheSize"] == 2
     assert metrics["estimated"] == 200
     assert metrics["windowKey"] == ""
 
@@ -302,15 +315,15 @@ def test_height_cache_preserves_measured_suffix_across_prepended_history():
     js = UI_JS_PATH.read_text(encoding="utf-8")
     source = _extract_func_script(js) + """
 const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT = 140;
-let _messageVirtualHeightCache = [180, 220];
-let _messageVirtualHeightCacheEntries = [];
+const _messageVirtualHeightCacheById = new Map();
+_messageVirtualHeightCacheById.set(0, 180);
+_messageVirtualHeightCacheById.set(1, 220);
 let _messageVirtualHeightCacheLen = 2;
 let _messageVirtualHeightCacheSrc = null;
 let _messageVirtualEstimatedRowHeight = 200;
 let _messageVirtualWindowKey = 'stale-key';
 function _clearMessageVirtualHeightCache() {
-  _messageVirtualHeightCache = [];
-  _messageVirtualHeightCacheEntries = [];
+  _messageVirtualHeightCacheById.clear();
   _messageVirtualHeightCacheLen = 0;
   _messageVirtualHeightCacheSrc = null;
   _messageVirtualEstimatedRowHeight = MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT;
@@ -322,10 +335,6 @@ eval(extractFunc('_syncMessageVirtualHeightCache'));
 const first = {id: 'first'};
 const second = {id: 'second'};
 let S = {messages: [first, second]};
-_messageVirtualHeightCacheEntries = [
-  {rawIdx: 0, m: first},
-  {rawIdx: 1, m: second},
-];
 _messageVirtualHeightCacheSrc = S.messages;
 const olderA = {id: 'older-a'};
 const olderB = {id: 'older-b'};
@@ -336,15 +345,17 @@ _syncMessageVirtualHeightCache([
   {rawIdx: 2, m: first},
   {rawIdx: 3, m: second},
 ]);
+const cacheArray = Array.from(_messageVirtualHeightCacheById.values());
 console.log(JSON.stringify({
-  cache: _messageVirtualHeightCache,
+  cacheValues: cacheArray,
+  cacheSize: _messageVirtualHeightCacheById.size,
   estimated: _messageVirtualEstimatedRowHeight,
   windowKey: _messageVirtualWindowKey,
 }));
 """
     metrics = json.loads(_run_node(source))
-    assert metrics["cache"][2:] == [180, 220]
-    assert len(metrics["cache"]) == 4
+    assert metrics["cacheValues"][0:2] == [180, 220]
+    assert metrics["cacheSize"] == 2
     assert metrics["estimated"] == 200
     assert metrics["windowKey"] == ""
 
@@ -455,8 +466,8 @@ let _lastScrollTop = 0;
 let _messageUserUnpinned = true;
 let _scrollPinned = false;
 let _nearBottomCount = 0;
-let _messageVirtualHeightCache = Array.from({length: TOTAL}, () => ROW_HEIGHT);
-let _messageVirtualHeightCacheEntries = [];
+const _messageVirtualHeightCacheById = new Map();
+for(let i=0; i<TOTAL; i++) _messageVirtualHeightCacheById.set(i, ROW_HEIGHT);
 let _messageVirtualHeightCacheLen = TOTAL;
 let _messageVirtualHeightCacheSrc = null;
 let _messageVirtualEstimatedRowHeight = ROW_HEIGHT;
@@ -539,19 +550,18 @@ const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
   tool_call:400,
   default:140,
 };
-function _messageVirtualDefaultHeightForRole(role){
-  return MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS[
-    role&&Object.prototype.hasOwnProperty.call(MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS,role)?role:'default'
-  ];
-}
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
 const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 80;
 const MESSAGE_VIRTUAL_BUFFER_PX = 900;
-let _messageVirtualHeightCache = [];
+const _messageVirtualHeightCacheById = new Map();
+let _messageVirtualHeightCacheLen = 0;
+let _messageVirtualHeightCacheSrc = null;
 let _messageVirtualEstimatedRowHeight = 140;
 function _syncMessageVirtualHeightCache(){ /* no-op for the test */ }
 function $(id){ return {scrollTop: 5000, clientHeight: 720}; }
 function _messageVirtualRoleForEntry(){ return 'default'; }
 const window = {};
+eval(extractFunc('_messageVirtualHeightForIdx'));
 eval(extractFunc('_messageVirtualWindow'));
 eval(extractFunc('_currentMessageVirtualWindow'));
 // 200 visible messages — well over the 80 threshold
@@ -790,35 +800,35 @@ const visWithIdx = [
 ];
 
 // --- _messageVirtualScrollTopForVisibleIdx ---
-let _messageVirtualHeightCache = [0, 0, 0];
-let _messageVirtualHeightCacheEntries = [];
+const _messageVirtualHeightCacheById = new Map();
 let _messageVirtualHeightCacheLen = 3;
 let _messageVirtualHeightCacheSrc = null;
 let _messageVirtualEstimatedRowHeight = 140;
 let _messageVirtualWindowKey = '';
 let S = {messages: visWithIdx.map(e => e.m)};
 function _messageIsRenderable(){ return true; }
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualHeightForIdx'));
 eval(extractFunc('_messageVirtualHeightEntryMatches'));
 eval(extractFunc('_syncMessageVirtualHeightCache'));
 eval(extractFunc('_messageVirtualScrollTopForVisibleIdx'));
 // scrollTop to visibleIdx=2 must sum heights of idx 0 (120) and idx 1 (400) = 520
-_messageVirtualHeightCacheEntries = visWithIdx;
 _messageVirtualHeightCacheSrc = S.messages;
 const scrollTop = _messageVirtualScrollTopForVisibleIdx(visWithIdx, 2, null);
 
 // --- _messageVirtualPrependedHeightDelta ---
 let virtualized2 = true;
-let _messageVirtualHeightCache2 = [0, 0, 0];
+let _messageVirtualHeightCacheById2 = new Map();
 let _messageVirtualEstimatedRowHeight2 = 140;
 function _getVisibleMessagesWithIdx(){ return visWithIdx; }
 function _messageVirtualKeepTailCount(){ return 0; }
 function _currentMessageVirtualWindow(){ return {virtualized: virtualized2}; }
-// Patch cache var used by _messageVirtualPrependedHeightDelta
-eval(extractFunc('_messageVirtualPrependedHeightDelta').replace(
-  /_messageVirtualHeightCache/g, '_messageVirtualHeightCache2'
-).replace(
-  /_messageVirtualEstimatedRowHeight/g, '_messageVirtualEstimatedRowHeight2'
-));
+// Patch cache Map used by _messageVirtualPrependedHeightDelta
+const origFunc = extractFunc('_messageVirtualPrependedHeightDelta');
+const patchedFunc = origFunc
+  .replace(/_messageVirtualHeightCacheById/g, '_messageVirtualHeightCacheById2')
+  .replace(/_messageVirtualEstimatedRowHeight/g, '_messageVirtualEstimatedRowHeight2');
+eval(patchedFunc);
 // Sum of first 3 uncached entries: user(120) + tool_call(400) + assistant(160) = 680
 const delta = _messageVirtualPrependedHeightDelta(3);
 
@@ -857,3 +867,231 @@ console.log(JSON.stringify({scrollTop, delta, windowCoversAll}));
     )
     # windowing function must also cover the same three rows
     assert metrics["windowCoversAll"] is True
+
+
+def test_message_virtual_height_cache_by_id_hit():
+    """Test cache hit: set a height in the Map for rawIdx=5, call _messageVirtualHeightForIdx. Assert returns cached value, not default."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS = {
+  user: 120,
+  assistant: 160,
+  tool_call: 400,
+  default: 140,
+};
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualHeightForIdx'));
+
+// Mock the cache Map
+const _messageVirtualHeightCacheById = new Map();
+_messageVirtualHeightCacheById.set(5, 250);
+
+const result = _messageVirtualHeightForIdx(5, () => 'user');
+console.log(JSON.stringify({result}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["result"] == 250, "Should return cached value 250, not default"
+
+
+def test_message_virtual_height_cache_by_id_miss_with_role():
+    """Test cache miss with role fallback: call for uncached rawIdx. Assert returns per-role default."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS = {
+  user: 120,
+  assistant: 160,
+  tool_call: 400,
+  default: 140,
+};
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualHeightForIdx'));
+
+// Mock the cache Map (empty)
+const _messageVirtualHeightCacheById = new Map();
+
+const userResult = _messageVirtualHeightForIdx(99, () => 'user');
+const assistantResult = _messageVirtualHeightForIdx(100, () => 'assistant');
+const toolCallResult = _messageVirtualHeightForIdx(101, () => 'tool_call');
+
+console.log(JSON.stringify({userResult, assistantResult, toolCallResult}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["userResult"] == 120, "User role should default to 120"
+    assert result["assistantResult"] == 160, "Assistant role should default to 160"
+    assert result["toolCallResult"] == 400, "Tool call role should default to 400"
+
+
+def test_message_virtual_height_cache_persistence_across_window_shift():
+    """Test persistence: set heights for rawIdx 10-20, simulate window shift to 15-25, assert heights for 15-20 are cached."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let S = {messages: []};
+let _messageVirtualHeightCacheLen = 0;
+let _messageVirtualHeightCacheSrc = null;
+eval(extractFunc('_syncMessageVirtualHeightCache'));
+
+// Mock the cache Map
+const _messageVirtualHeightCacheById = new Map();
+for (let i = 10; i <= 20; i++) {
+  _messageVirtualHeightCacheById.set(i, 150 + i);
+}
+
+// Simulate first window with rawIdx 10-20
+const visWithIdx1 = Array.from({length: 11}, (_, i) => ({rawIdx: 10 + i, m: {role: 'user'}}));
+_syncMessageVirtualHeightCache(visWithIdx1);
+
+// After sync, cache for 10-20 should still be present
+const cachedAt15 = _messageVirtualHeightCacheById.get(15);
+const cachedAt20 = _messageVirtualHeightCacheById.get(20);
+
+// Simulate window shift to 15-25 (rawIdx 15-25)
+const visWithIdx2 = Array.from({length: 11}, (_, i) => ({rawIdx: 15 + i, m: {role: 'user'}}));
+_syncMessageVirtualHeightCache(visWithIdx2);
+
+// Entries 10-14 should be pruned, 15-20 should remain
+const pruned10 = _messageVirtualHeightCacheById.get(10);
+const stillCached15 = _messageVirtualHeightCacheById.get(15);
+const stillCached20 = _messageVirtualHeightCacheById.get(20);
+
+console.log(JSON.stringify({cachedAt15, cachedAt20, pruned10: pruned10 !== undefined ? pruned10 : null, stillCached15, stillCached20}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["cachedAt15"] == 165, "rawIdx 15 should be cached at 165"
+    assert result["cachedAt20"] == 170, "rawIdx 20 should be cached at 170"
+    assert result["pruned10"] is None, "rawIdx 10 should be pruned after window shift"
+    assert result["stillCached15"] == 165, "rawIdx 15 should persist after shift"
+    assert result["stillCached20"] == 170, "rawIdx 20 should persist after shift"
+
+
+def test_message_virtual_height_cache_pruning_on_sync():
+    """Test pruning: populate cache with rawIdx 1-10, sync with visWithIdx containing only 5-10, assert entries 1-4 are pruned."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let S = {messages: []};
+let _messageVirtualHeightCacheLen = 0;
+let _messageVirtualHeightCacheSrc = null;
+eval(extractFunc('_syncMessageVirtualHeightCache'));
+
+// Mock the cache Map
+const _messageVirtualHeightCacheById = new Map();
+for (let i = 1; i <= 10; i++) {
+  _messageVirtualHeightCacheById.set(i, 100 + i);
+}
+
+// Sync with visWithIdx containing only rawIdx 5-10
+const visWithIdx = Array.from({length: 6}, (_, i) => ({rawIdx: 5 + i, m: {role: 'user'}}));
+_syncMessageVirtualHeightCache(visWithIdx);
+
+// Check which entries remain
+const kept5 = _messageVirtualHeightCacheById.get(5);
+const kept10 = _messageVirtualHeightCacheById.get(10);
+const pruned1 = _messageVirtualHeightCacheById.get(1);
+const pruned4 = _messageVirtualHeightCacheById.get(4);
+
+console.log(JSON.stringify({kept5, kept10, pruned1: pruned1 !== undefined ? pruned1 : null, pruned4: pruned4 !== undefined ? pruned4 : null, size: _messageVirtualHeightCacheById.size}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["kept5"] == 105, "rawIdx 5 should remain cached"
+    assert result["kept10"] == 110, "rawIdx 10 should remain cached"
+    assert result["pruned1"] is None, "rawIdx 1 should be pruned"
+    assert result["pruned4"] is None, "rawIdx 4 should be pruned"
+    assert result["size"] == 6, "Cache should contain exactly 6 entries (5-10)"
+
+
+def test_message_virtual_height_cache_full_clear():
+    """Test full clear: populate cache, sync with empty visWithIdx, assert Map is empty."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let S = {messages: []};
+let _messageVirtualHeightCacheLen = 0;
+let _messageVirtualHeightCacheSrc = null;
+eval(extractFunc('_syncMessageVirtualHeightCache'));
+
+// Mock the cache Map
+const _messageVirtualHeightCacheById = new Map();
+for (let i = 1; i <= 10; i++) {
+  _messageVirtualHeightCacheById.set(i, 100 + i);
+}
+
+const sizeBefore = _messageVirtualHeightCacheById.size;
+
+// Sync with empty visWithIdx
+_syncMessageVirtualHeightCache([]);
+
+const sizeAfter = _messageVirtualHeightCacheById.size;
+
+console.log(JSON.stringify({sizeBefore, sizeAfter}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["sizeBefore"] == 10, "Cache should contain 10 entries before clear"
+    assert result["sizeAfter"] == 0, "Cache should be empty after clear"
+
+
+def test_message_virtual_window_with_height_resolver():
+    """Test window function with heightForIdx resolver: call with varying heights. Assert window uses those heights."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS = {
+  user: 120,
+  assistant: 160,
+  tool_call: 400,
+  default: 140,
+};
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualWindow'));
+
+// heightForIdx that returns varying heights: idx < 10 -> 200px, idx >= 10 -> 400px
+const heightForIdx = (idx) => idx < 10 ? 200 : 400;
+
+const metrics = _messageVirtualWindow({
+  total: 20,
+  scrollTop: 3000,  // Near middle
+  viewportHeight: 800,
+  heightForIdx,
+  bufferPx: 100,
+  threshold: 5,
+  keepTailCount: 3,
+});
+
+// With varying heights and scrollTop=3000:
+// Rows 0-9: 200px each = 2000px total
+// Rows 10-19: 400px each = 4000px total
+// scrollTop 3000 is past the first 10 rows (2000px), so should start in the 400px region
+const startsAfterFirstRegion = metrics.start > 9;
+
+console.log(JSON.stringify({
+  virtualized: metrics.virtualized,
+  start: metrics.start,
+  end: metrics.end,
+  topPad: metrics.topPad,
+  startsAfterFirstRegion
+}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["virtualized"] is True, "Should virtualize with 20 rows"
+    assert result["startsAfterFirstRegion"] is True, "Window should start after first region (rows 0-9)"
+    assert result["topPad"] > 2000, "topPad should account for the first 10 rows at 200px each"
+
+
+def test_message_virtual_height_cache_measurement_write():
+    """Test measurement write: simulate measurement, assert Map entry is set by rawIdx, not by visible index."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+// Minimal test for height cache write pattern
+const _messageVirtualHeightCacheById = new Map();
+
+// Simulate entry with rawIdx
+const entry = {rawIdx: 42, m: {role: 'assistant'}};
+const totalHeight = 320;
+
+// This is the pattern used in _updateMessageVirtualMeasurements
+_messageVirtualHeightCacheById.set(entry.rawIdx, totalHeight);
+
+const cached = _messageVirtualHeightCacheById.get(42);
+const byVisibleIdx = _messageVirtualHeightCacheById.get(0);  // Visible index would be wrong key
+
+console.log(JSON.stringify({cached, byVisibleIdx: byVisibleIdx !== undefined ? byVisibleIdx : null}));
+"""
+    result = json.loads(_run_node(source))
+    assert result["cached"] == 320, "Should be able to retrieve height by rawIdx=42"
+    assert result["byVisibleIdx"] is None, "Should not find height when keyed by visible index"

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -922,80 +922,76 @@ console.log(JSON.stringify({userResult, assistantResult, toolCallResult}));
 
 
 def test_message_virtual_height_cache_persistence_across_window_shift():
-    """Test persistence: set heights for rawIdx 10-20, simulate window shift to 15-25, assert heights for 15-20 are cached."""
+    """Test persistence: heights survive a virtual window shift because pruning is identity-based, not visibility-based."""
     js = UI_JS_PATH.read_text(encoding="utf-8")
     source = _extract_func_script(js) + """
-let S = {messages: []};
+let S = {messages: new Array(30)};
 let _messageVirtualHeightCacheLen = 0;
 let _messageVirtualHeightCacheSrc = null;
 eval(extractFunc('_syncMessageVirtualHeightCache'));
 
-// Mock the cache Map
 const _messageVirtualHeightCacheById = new Map();
 for (let i = 10; i <= 20; i++) {
   _messageVirtualHeightCacheById.set(i, 150 + i);
 }
 
-// Simulate first window with rawIdx 10-20
+// Sync with first window (rawIdx 10-20)
 const visWithIdx1 = Array.from({length: 11}, (_, i) => ({rawIdx: 10 + i, m: {role: 'user'}}));
 _syncMessageVirtualHeightCache(visWithIdx1);
 
-// After sync, cache for 10-20 should still be present
-const cachedAt15 = _messageVirtualHeightCacheById.get(15);
-const cachedAt20 = _messageVirtualHeightCacheById.get(20);
-
-// Simulate window shift to 15-25 (rawIdx 15-25)
+// Shift window to rawIdx 15-25; entries 10-14 should SURVIVE (identity-based pruning)
+S.messages = new Array(30);
 const visWithIdx2 = Array.from({length: 11}, (_, i) => ({rawIdx: 15 + i, m: {role: 'user'}}));
 _syncMessageVirtualHeightCache(visWithIdx2);
 
-// Entries 10-14 should be pruned, 15-20 should remain
-const pruned10 = _messageVirtualHeightCacheById.get(10);
-const stillCached15 = _messageVirtualHeightCacheById.get(15);
-const stillCached20 = _messageVirtualHeightCacheById.get(20);
+const still10 = _messageVirtualHeightCacheById.get(10);
+const still15 = _messageVirtualHeightCacheById.get(15);
+const still20 = _messageVirtualHeightCacheById.get(20);
 
-console.log(JSON.stringify({cachedAt15, cachedAt20, pruned10: pruned10 !== undefined ? pruned10 : null, stillCached15, stillCached20}));
+console.log(JSON.stringify({still10, still15, still20}));
 """
     result = json.loads(_run_node(source))
-    assert result["cachedAt15"] == 165, "rawIdx 15 should be cached at 165"
-    assert result["cachedAt20"] == 170, "rawIdx 20 should be cached at 170"
-    assert result["pruned10"] is None, "rawIdx 10 should be pruned after window shift"
-    assert result["stillCached15"] == 165, "rawIdx 15 should persist after shift"
-    assert result["stillCached20"] == 170, "rawIdx 20 should persist after shift"
+    assert result["still10"] == 160, "rawIdx 10 should survive window shift (identity-based)"
+    assert result["still15"] == 165, "rawIdx 15 should persist"
+    assert result["still20"] == 170, "rawIdx 20 should persist"
 
 
 def test_message_virtual_height_cache_pruning_on_sync():
-    """Test pruning: populate cache with rawIdx 1-10, sync with visWithIdx containing only 5-10, assert entries 1-4 are pruned."""
+    """Test pruning: entries with rawIdx >= messages.length are pruned when the message array shrinks."""
     js = UI_JS_PATH.read_text(encoding="utf-8")
     source = _extract_func_script(js) + """
-let S = {messages: []};
+let S = {messages: new Array(15)};
 let _messageVirtualHeightCacheLen = 0;
 let _messageVirtualHeightCacheSrc = null;
 eval(extractFunc('_syncMessageVirtualHeightCache'));
 
-// Mock the cache Map
 const _messageVirtualHeightCacheById = new Map();
 for (let i = 1; i <= 10; i++) {
   _messageVirtualHeightCacheById.set(i, 100 + i);
 }
 
-// Sync with visWithIdx containing only rawIdx 5-10
-const visWithIdx = Array.from({length: 6}, (_, i) => ({rawIdx: 5 + i, m: {role: 'user'}}));
-_syncMessageVirtualHeightCache(visWithIdx);
+// First sync establishes baseline
+const visWithIdx1 = Array.from({length: 6}, (_, i) => ({rawIdx: 5 + i, m: {role: 'user'}}));
+_syncMessageVirtualHeightCache(visWithIdx1);
 
-// Check which entries remain
+// Shrink messages to 8 — entries 8, 9, 10 should be pruned
+S.messages = new Array(8);
+const visWithIdx2 = Array.from({length: 3}, (_, i) => ({rawIdx: 5 + i, m: {role: 'user'}}));
+_syncMessageVirtualHeightCache(visWithIdx2);
+
 const kept5 = _messageVirtualHeightCacheById.get(5);
-const kept10 = _messageVirtualHeightCacheById.get(10);
-const pruned1 = _messageVirtualHeightCacheById.get(1);
-const pruned4 = _messageVirtualHeightCacheById.get(4);
+const kept7 = _messageVirtualHeightCacheById.get(7);
+const pruned8 = _messageVirtualHeightCacheById.get(8);
+const pruned10 = _messageVirtualHeightCacheById.get(10);
 
-console.log(JSON.stringify({kept5, kept10, pruned1: pruned1 !== undefined ? pruned1 : null, pruned4: pruned4 !== undefined ? pruned4 : null, size: _messageVirtualHeightCacheById.size}));
+console.log(JSON.stringify({kept5, kept7, pruned8: pruned8 !== undefined ? pruned8 : null, pruned10: pruned10 !== undefined ? pruned10 : null, size: _messageVirtualHeightCacheById.size}));
 """
     result = json.loads(_run_node(source))
-    assert result["kept5"] == 105, "rawIdx 5 should remain cached"
-    assert result["kept10"] == 110, "rawIdx 10 should remain cached"
-    assert result["pruned1"] is None, "rawIdx 1 should be pruned"
-    assert result["pruned4"] is None, "rawIdx 4 should be pruned"
-    assert result["size"] == 6, "Cache should contain exactly 6 entries (5-10)"
+    assert result["kept5"] == 105, "rawIdx 5 should remain (within messages.length)"
+    assert result["kept7"] == 107, "rawIdx 7 should remain (within messages.length)"
+    assert result["pruned8"] is None, "rawIdx 8 should be pruned (>= messages.length)"
+    assert result["pruned10"] is None, "rawIdx 10 should be pruned (>= messages.length)"
+    assert result["size"] == 7, "Entries 1-7 should remain (rawIdx < 8)"
 
 
 def test_message_virtual_height_cache_full_clear():


### PR DESCRIPTION
## What Changed

- `static/ui.js`: replaced `_messageVirtualHeightCache[]` and `_messageVirtualHeightCacheEntries[]` with `_messageVirtualHeightCacheById` Map keyed by `rawIdx`; rewrote `_syncMessageVirtualHeightCache` to use identity-based pruning (only prune entries with rawIdx >= messages.length) instead of rebuilding; added `_messageVirtualHeightForIdx` resolver with subpixel tolerance (`Math.abs(cached - totalHeight) > 1`); updated `_messageVirtualWindow` to accept a `heightForIdx` function; updated all 17 consumer sites from array indexing to Map operations
- `tests/test_issue500_message_list_virtualization.py`: added tests for Map-based cache lookup, cache persistence across virtual window shifts, fallback to per-role defaults, and cache invalidation on message array changes

## Why It Matters

The array-indexed `_messageVirtualHeightCache` loses previously-measured heights whenever the virtual window shifts, forcing re-measurement and causing spacer jumps. This is the primary cause of jitter when rows re-enter the virtual window during scrolling.

By keying the cache on `rawIdx` (stable per message within a session), heights survive virtual window shifts and are available in O(1) when a row re-enters — eliminating the rAF + getBoundingClientRect gap that causes spacer height instability. Identity-based pruning (only evict entries for messages that no longer exist) preserves the cache across window shifts instead of rebuilding it.

## Verification

```
pytest tests/test_issue500_message_list_virtualization.py -v --timeout=60
```

## Risks / Follow-ups

- The Map grows with conversation length. Identity-based pruning keeps it bounded to the current message count. For very long conversations (500+ messages), an oldest-first eviction cap could be added if memory becomes a concern.
- Streaming messages need their cache entries invalidated on content change. The existing invalidation logic (sentinel comparison via `_messageVirtualHeightCacheSrc`) is preserved.
- Independent of #4383 (velocity guard) and can merge separately, but both together address the remaining snap-backs from #4346.

## Upstream

Part of the ongoing work on #4346. Does not close the issue (#4383 is the companion fix).

Refs #4346