### PR TITLE
Release v0.51.483 — QS (virtual-scroll scroll-jump fixes #4367 + #4368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.483] — 2026-06-18 — Release QS (virtual-scroll height + measurement scroll-jump fixes)
+
+### Fixed
+
+- **Smoother scrolling in the experimental "Virtualize long transcripts" mode — fewer jumps around tool-call rows and during measurement (#4346, via #4367 + #4368).** Two fixes to the (still default-off, opt-in) transcript virtualization: (1) per-role height estimates for not-yet-measured rows (user 120 / assistant 160 / tool_call 400 / default 140) so large tool-call rows aren't under-counted before they're measured, which previously threw off the initial scroll position; and (2) anchor-based scroll compensation during measurement — the view captures an anchor row + scrollTop, renders, then re-pins scrollTop by the anchor's measured delta, plus a short scroll-active guard that defers measurement refresh while you're actively scrolling. Both are additive and only run when "Virtualize long transcripts (experimental)" is enabled. Thanks @rodboev.
+
 ## [v0.51.482] — 2026-06-17 — Release QR (archived cron sessions stay hidden)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -376,7 +376,17 @@ function _statusCardHtml(card){
 const MESSAGE_RENDER_WINDOW_DEFAULT=50;
 const MESSAGE_VIRTUAL_THRESHOLD_ROWS=80;
 const MESSAGE_VIRTUAL_BUFFER_PX=900;
-const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT=140;
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+function _messageVirtualDefaultHeightForRole(role){
+  return MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS[
+    role&&Object.prototype.hasOwnProperty.call(MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS,role)?role:'default'
+  ];
+}
 const MESSAGE_VIRTUAL_MEASUREMENT_MAX_RERENDERS=2;
 let _messageRenderWindowSid=null;
 let _messageRenderWindowSize=MESSAGE_RENDER_WINDOW_DEFAULT;
@@ -384,11 +394,26 @@ let _messageVirtualHeightCache=[];
 let _messageVirtualHeightCacheEntries=[];
 let _messageVirtualHeightCacheLen=0;
 let _messageVirtualHeightCacheSrc=null;
-let _messageVirtualEstimatedRowHeight=MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT;
+let _messageVirtualEstimatedRowHeight=_messageVirtualDefaultHeightForRole('default');
 let _messageVirtualScrollRaf=0;
 let _messageVirtualWindowKey='';
 let _messageVirtualMeasurementCycleKey='';
 let _messageVirtualMeasurementRetryCount=0;
+let _messageVirtualScrollActive=false;
+let _messageVirtualScrollSettleTimer=0;
+let _messageVirtualDeferredMeasurement=null;
+function _markMessageVirtualScrollActive(){
+  _messageVirtualScrollActive=true;
+  clearTimeout(_messageVirtualScrollSettleTimer);
+  _messageVirtualScrollSettleTimer=setTimeout(()=>{
+    _messageVirtualScrollActive=false;
+    if(_messageVirtualDeferredMeasurement){
+      const deferred=_messageVirtualDeferredMeasurement;
+      _messageVirtualDeferredMeasurement=null;
+      _scheduleMessageVirtualMeasurementRefresh(deferred);
+    }
+  },150);
+}
 // Cached visWithIdx array — invalidated when S.messages.length changes.
 let _visWithIdxCache=null;
 let _visWithIdxCacheLen=0;
@@ -403,10 +428,14 @@ function _clearMessageVirtualHeightCache(){
   _messageVirtualHeightCacheEntries=[];
   _messageVirtualHeightCacheLen=0;
   _messageVirtualHeightCacheSrc=null;
-  _messageVirtualEstimatedRowHeight=MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT;
+  _messageVirtualEstimatedRowHeight=_messageVirtualDefaultHeightForRole('default');
   _messageVirtualWindowKey='';
   _messageVirtualMeasurementCycleKey='';
   _messageVirtualMeasurementRetryCount=0;
+  _messageVirtualScrollActive=false;
+  clearTimeout(_messageVirtualScrollSettleTimer);
+  _messageVirtualScrollSettleTimer=0;
+  _messageVirtualDeferredMeasurement=null;
 }
 function _resetMessageRenderWindow(sid){
   _messageRenderWindowSid=sid||null;
@@ -450,15 +479,17 @@ function _getVisibleMessagesWithIdx(){
 function _messageVirtualWindow(opts){
   const total=Math.max(0, Number(opts&&opts.total)||0);
   const threshold=Math.max(1, Number(opts&&opts.threshold)||MESSAGE_VIRTUAL_THRESHOLD_ROWS);
-  const defaultHeight=Math.max(1, Number(opts&&opts.defaultHeight)||MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT);
+  const defaultHeight=Math.max(1, Number(opts&&opts.defaultHeight)||_messageVirtualDefaultHeightForRole('default'));
   const bufferPx=Math.max(0, Number(opts&&opts.bufferPx)||MESSAGE_VIRTUAL_BUFFER_PX);
   const viewportHeight=Math.max(defaultHeight, Number(opts&&opts.viewportHeight)||defaultHeight*6);
   const keepTailCount=Math.max(0, Number(opts&&opts.keepTailCount)||0);
   const tailStart=Math.max(0, total-keepTailCount);
   const heights=Array.isArray(opts&&opts.heights)?opts.heights:[];
+  const roleForIdx=typeof (opts&&opts.roleForIdx)==='function'?opts.roleForIdx:null;
   const rowHeightFor=(idx)=>{
     const cached=Number(heights[idx]);
-    return Number.isFinite(cached)&&cached>0?cached:defaultHeight;
+    if(Number.isFinite(cached)&&cached>0) return cached;
+    return roleForIdx?Math.max(1,_messageVirtualDefaultHeightForRole(roleForIdx(idx))):defaultHeight;
   };
   if(total<=Math.max(threshold, keepTailCount)){
     return {virtualized:false,start:0,end:total,topPad:0,bottomPad:0,total,tailStart};
@@ -524,6 +555,10 @@ function _messageVirtualMeasurementCycleKeyFor(windowMetrics){
   ].join(':');
 }
 function _scheduleMessageVirtualMeasurementRefresh(windowMetrics){
+  if(_messageVirtualScrollActive){
+    _messageVirtualDeferredMeasurement=windowMetrics;
+    return;
+  }
   const cycleKey=_messageVirtualMeasurementCycleKeyFor(windowMetrics);
   if(_messageVirtualMeasurementCycleKey!==cycleKey){
     _messageVirtualMeasurementCycleKey=cycleKey;
@@ -609,6 +644,19 @@ function _syncMessageVirtualHeightCache(visWithIdx){
   _messageVirtualHeightCacheLen=S.messages.length;
   _messageVirtualHeightCacheSrc=S.messages;
 }
+function _messageVirtualRoleForEntry(entry){
+  const m=entry&&entry.m;
+  if(!m) return 'default';
+  if(m.role==='user') return 'user';
+  if(m.role==='assistant'){
+    if((Array.isArray(m.tool_calls)&&m.tool_calls.length>0)||
+       (Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use'))||
+       (Array.isArray(m._partial_tool_calls)&&m._partial_tool_calls.length>0))
+      return 'tool_call';
+    return 'assistant';
+  }
+  return 'default';
+}
 function _currentMessageVirtualWindow(visWithIdx, keepTailCount){
   _syncMessageVirtualHeightCache(visWithIdx);
   const container=$('messages');
@@ -627,6 +675,7 @@ function _currentMessageVirtualWindow(visWithIdx, keepTailCount){
     viewportHeight:container?container.clientHeight:(_messageVirtualEstimatedRowHeight*6),
     heights:_messageVirtualHeightCache,
     defaultHeight:_messageVirtualEstimatedRowHeight,
+    roleForIdx:idx=>_messageVirtualRoleForEntry(visWithIdx[idx]),
     keepTailCount,
   });
 }
@@ -640,7 +689,7 @@ function _messageVirtualPrependedHeightDelta(prependedRenderableCount){
   let total=0;
   for(let i=0;i<limit;i++){
     const cached=Number(_messageVirtualHeightCache[i]);
-    total+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualEstimatedRowHeight;
+    total+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualDefaultHeightForRole(_messageVirtualRoleForEntry(visWithIdx[i]));
   }
   return Math.max(0,Math.round(total));
 }
@@ -658,7 +707,7 @@ function _messageVirtualScrollTopForVisibleIdx(visWithIdx, visibleIdx, container
   let offset=0;
   for(let i=0;i<limit;i++){
     const cached=Number(_messageVirtualHeightCache[i]);
-    offset+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualEstimatedRowHeight;
+    offset+=(Number.isFinite(cached)&&cached>0)?cached:_messageVirtualDefaultHeightForRole(_messageVirtualRoleForEntry(visWithIdx[i]));
   }
   const viewport=container?Math.max(0,Number(container.clientHeight)||0):0;
   return Math.max(0,Math.round(offset-(viewport*0.35)));
@@ -695,6 +744,25 @@ function _restoreMessageViewportAnchor(anchor, rawIdxDelta){
   container.scrollTop+=(rect.top-containerRect.top)-targetTop;
   requestAnimationFrame(()=>{ _programmaticScroll=false; });
   return true;
+}
+function _compensateScrollForMeasurementDelta(renderFn){
+  const container=$('messages');
+  if(!container) return renderFn();
+  const anchorBefore=_captureMessageViewportAnchor();
+  const scrollTopBefore=container.scrollTop;
+  renderFn();
+  if(!anchorBefore) return;
+  const row=container.querySelector(`[data-msg-idx="${anchorBefore.rawIdx}"]`);
+  if(!row) return;
+  const containerRect=container.getBoundingClientRect();
+  const rowRect=row.getBoundingClientRect();
+  const actualOffset=rowRect.top-containerRect.top;
+  const delta=actualOffset-anchorBefore.topOffset;
+  if(Math.abs(delta)<2) return;
+  _programmaticScroll=true;
+  container.scrollTop=scrollTopBefore+delta;
+  _lastScrollTop=container.scrollTop;
+  requestAnimationFrame(()=>{ setTimeout(()=>{ _programmaticScroll=false; },0); });
 }
 function _messageViewportIntersectsRenderedRow(){
   const container=$('messages');
@@ -771,7 +839,7 @@ function _scheduleMessageVirtualizedRender(force){
     const liveWindow=_currentMessageVirtualWindow(liveVisWithIdx,_messageVirtualKeepTailCount());
     const liveKey=_messageVirtualWindowKeyFor(liveWindow);
     if(!force&&liveKey===_messageVirtualWindowKey) return;
-    renderMessages({ preserveScroll:true });
+    _compensateScrollForMeasurementDelta(()=>{ renderMessages({ preserveScroll:true }); });
   });
 }
 
@@ -3535,6 +3603,7 @@ if(typeof window!=='undefined'){
   let _scrollRaf=0;
   el.addEventListener('scroll',()=>{
     if(_programmaticScroll) return; // ignore scrolls we triggered ourselves
+    _markMessageVirtualScrollActive();
     cancelAnimationFrame(_scrollRaf);
     _scrollRaf=requestAnimationFrame(()=>{
       const top=el.scrollTop;

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -189,6 +189,14 @@ console.log(JSON.stringify({
 def test_virtual_prepended_height_delta_uses_prefix_cache_only_when_virtualized():
     js = UI_JS_PATH.read_text(encoding="utf-8")
     source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS = {
+  user: 120,
+  assistant: 160,
+  tool_call: 400,
+  default: 140,
+};
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualRoleForEntry'));
 let virtualized = true;
 let _messageVirtualHeightCache = [0, 220, 180, 120];
 let _messageVirtualEstimatedRowHeight = 140;
@@ -525,13 +533,24 @@ def test_virtualize_transcript_opt_out_forces_full_render_window():
     so the whole transcript renders. When true/undefined it virtualizes as before."""
     js = UI_JS_PATH.read_text(encoding="utf-8")
     source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+function _messageVirtualDefaultHeightForRole(role){
+  return MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS[
+    role&&Object.prototype.hasOwnProperty.call(MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS,role)?role:'default'
+  ];
+}
 const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 80;
-const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT = 140;
 const MESSAGE_VIRTUAL_BUFFER_PX = 900;
 let _messageVirtualHeightCache = [];
 let _messageVirtualEstimatedRowHeight = 140;
 function _syncMessageVirtualHeightCache(){ /* no-op for the test */ }
 function $(id){ return {scrollTop: 5000, clientHeight: 720}; }
+function _messageVirtualRoleForEntry(){ return 'default'; }
 const window = {};
 eval(extractFunc('_messageVirtualWindow'));
 eval(extractFunc('_currentMessageVirtualWindow'));
@@ -573,3 +592,534 @@ def test_virtualize_transcript_gate_present_in_current_window_fn():
         "_currentMessageVirtualWindow"
     )
     assert "virtualized:false" in body, "gate must return a non-virtualized window when opted out"
+
+
+def test_message_virtual_default_height_for_role_returns_correct_heights():
+    """Verify per-role default heights are configured."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+console.log(JSON.stringify({
+  tool_call: _messageVirtualDefaultHeightForRole('tool_call'),
+  user: _messageVirtualDefaultHeightForRole('user'),
+  assistant: _messageVirtualDefaultHeightForRole('assistant'),
+  unknown: _messageVirtualDefaultHeightForRole('unknown'),
+  default: _messageVirtualDefaultHeightForRole('default'),
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["tool_call"] == 400
+    assert metrics["user"] == 120
+    assert metrics["assistant"] == 160
+    assert metrics["unknown"] == 140
+    assert metrics["default"] == 140
+
+
+def test_message_virtual_role_for_entry_classifies_tool_calls():
+    """Verify role classifier detects tool_calls, tool_use content, and _partial_tool_calls."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+eval(extractFunc('_messageVirtualRoleForEntry'));
+console.log(JSON.stringify({
+  userRole: _messageVirtualRoleForEntry({m: {role: 'user'}}),
+  assistantNoTools: _messageVirtualRoleForEntry({m: {role: 'assistant'}}),
+  assistantWithToolCalls: _messageVirtualRoleForEntry({m: {role: 'assistant', tool_calls: [{id: '1'}]}}),
+  assistantWithToolUse: _messageVirtualRoleForEntry({m: {role: 'assistant', content: [{type: 'tool_use', id: '1'}]}}),
+  assistantWithPartialToolCalls: _messageVirtualRoleForEntry({m: {role: 'assistant', _partial_tool_calls: [{id: '1'}]}}),
+  noEntry: _messageVirtualRoleForEntry(null),
+  noMessage: _messageVirtualRoleForEntry({m: null}),
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["userRole"] == "user"
+    assert metrics["assistantNoTools"] == "assistant"
+    assert metrics["assistantWithToolCalls"] == "tool_call"
+    assert metrics["assistantWithToolUse"] == "tool_call"
+    assert metrics["assistantWithPartialToolCalls"] == "tool_call"
+    assert metrics["noEntry"] == "default"
+    assert metrics["noMessage"] == "default"
+
+
+def test_message_virtual_window_with_role_for_idx_uses_role_defaults():
+    """Verify _messageVirtualWindow uses role-specific heights when roleForIdx is provided."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 80;
+const MESSAGE_VIRTUAL_BUFFER_PX = 900;
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualWindow'));
+const visWithIdx = [
+  {m: {role: 'user'}},
+  {m: {role: 'assistant', tool_calls: [{id: '1'}]}},
+  {m: {role: 'assistant'}},
+];
+const metrics = _messageVirtualWindow({
+  total: 3,
+  scrollTop: 0,
+  viewportHeight: 600,
+  heights: [0, 0, 0],
+  defaultHeight: 140,
+  roleForIdx: (idx) => {
+    const entry = visWithIdx[idx];
+    if(!entry || !entry.m) return 'default';
+    if(entry.m.role === 'user') return 'user';
+    if(entry.m.role === 'assistant'){
+      if(Array.isArray(entry.m.tool_calls) && entry.m.tool_calls.length > 0) return 'tool_call';
+      return 'assistant';
+    }
+    return 'default';
+  },
+  bufferPx: 0,
+  threshold: 2,
+  keepTailCount: 0,
+});
+console.log(JSON.stringify({
+  virtualized: metrics.virtualized,
+  start: metrics.start,
+  end: metrics.end,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    # With 3 rows (120 + 400 + 160 = 680px) and viewport 600px, should not virtualize (below threshold)
+    # So this checks that the role-based defaults are being computed
+    assert metrics["end"] - metrics["start"] > 0
+
+
+def test_message_virtual_window_cached_heights_override_role_defaults():
+    """Verify cached heights take precedence over role-specific defaults."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS={
+  user:120,
+  assistant:160,
+  tool_call:400,
+  default:140,
+};
+const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 80;
+const MESSAGE_VIRTUAL_BUFFER_PX = 900;
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualWindow'));
+const visWithIdx = [
+  {m: {role: 'user'}},  // normally 120
+  {m: {role: 'assistant', tool_calls: [{id: '1'}]}},  // normally 400
+];
+// Test case 1: with cached heights 250+300=550px < 600px viewport, no virtualization needed
+const metricsSmall = _messageVirtualWindow({
+  total: 2,
+  scrollTop: 0,
+  viewportHeight: 600,
+  heights: [250, 300],  // Cached heights override roles
+  defaultHeight: 140,
+  roleForIdx: (idx) => {
+    const entry = visWithIdx[idx];
+    if(!entry || !entry.m) return 'default';
+    if(entry.m.role === 'user') return 'user';
+    if(entry.m.role === 'assistant'){
+      if(Array.isArray(entry.m.tool_calls) && entry.m.tool_calls.length > 0) return 'tool_call';
+      return 'assistant';
+    }
+    return 'default';
+  },
+  bufferPx: 0,
+  threshold: 80,
+  keepTailCount: 0,
+});
+// Test case 2: with many rows and cached heights, should use cached heights not role defaults
+const largeList = Array.from({length: 100}, (_, i) => ({m: {role: i % 2 ? 'user' : 'assistant'}}));
+const cachedHeights = Array.from({length: 100}, (_, i) => 200);  // All 200px when cached
+const metricsLarge = _messageVirtualWindow({
+  total: 100,
+  scrollTop: 0,
+  viewportHeight: 600,
+  heights: cachedHeights,
+  defaultHeight: 140,
+  roleForIdx: (idx) => {
+    if(largeList[idx]?.m?.role === 'user') return 'user';
+    return 'assistant';
+  },
+  bufferPx: 0,
+  threshold: 80,
+  keepTailCount: 0,
+});
+console.log(JSON.stringify({
+  smallVirtualized: metricsSmall.virtualized,
+  largeVirtualized: metricsLarge.virtualized,
+  largeHasWindow: metricsLarge.end > metricsLarge.start,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    # With 2 rows below threshold, should not virtualize
+    assert metrics["smallVirtualized"] is False
+    # With 100 rows above threshold, should virtualize and use cached heights
+    assert metrics["largeVirtualized"] is True
+    assert metrics["largeHasWindow"] is True
+
+
+def test_offset_helpers_use_per_role_defaults_for_uncached_rows():
+    """Verify _messageVirtualScrollTopForVisibleIdx and _messageVirtualPrependedHeightDelta
+    use per-role default heights (not the flat 140px estimate) for uncached rows,
+    and that these agree with _messageVirtualWindow's own accounting."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS = {
+  user: 120,
+  assistant: 160,
+  tool_call: 400,
+  default: 140,
+};
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_messageVirtualRoleForEntry'));
+
+// Three entries: user (120), tool_call (400), assistant (160) — all uncached (height=0)
+const visWithIdx = [
+  {rawIdx: 0, m: {role: 'user'}},
+  {rawIdx: 1, m: {role: 'assistant', tool_calls: [{id: 'x'}]}},
+  {rawIdx: 2, m: {role: 'assistant'}},
+];
+
+// --- _messageVirtualScrollTopForVisibleIdx ---
+let _messageVirtualHeightCache = [0, 0, 0];
+let _messageVirtualHeightCacheEntries = [];
+let _messageVirtualHeightCacheLen = 3;
+let _messageVirtualHeightCacheSrc = null;
+let _messageVirtualEstimatedRowHeight = 140;
+let _messageVirtualWindowKey = '';
+let S = {messages: visWithIdx.map(e => e.m)};
+function _messageIsRenderable(){ return true; }
+eval(extractFunc('_messageVirtualHeightEntryMatches'));
+eval(extractFunc('_syncMessageVirtualHeightCache'));
+eval(extractFunc('_messageVirtualScrollTopForVisibleIdx'));
+// scrollTop to visibleIdx=2 must sum heights of idx 0 (120) and idx 1 (400) = 520
+_messageVirtualHeightCacheEntries = visWithIdx;
+_messageVirtualHeightCacheSrc = S.messages;
+const scrollTop = _messageVirtualScrollTopForVisibleIdx(visWithIdx, 2, null);
+
+// --- _messageVirtualPrependedHeightDelta ---
+let virtualized2 = true;
+let _messageVirtualHeightCache2 = [0, 0, 0];
+let _messageVirtualEstimatedRowHeight2 = 140;
+function _getVisibleMessagesWithIdx(){ return visWithIdx; }
+function _messageVirtualKeepTailCount(){ return 0; }
+function _currentMessageVirtualWindow(){ return {virtualized: virtualized2}; }
+// Patch cache var used by _messageVirtualPrependedHeightDelta
+eval(extractFunc('_messageVirtualPrependedHeightDelta').replace(
+  /_messageVirtualHeightCache/g, '_messageVirtualHeightCache2'
+).replace(
+  /_messageVirtualEstimatedRowHeight/g, '_messageVirtualEstimatedRowHeight2'
+));
+// Sum of first 3 uncached entries: user(120) + tool_call(400) + assistant(160) = 680
+const delta = _messageVirtualPrependedHeightDelta(3);
+
+// --- _messageVirtualWindow agreement ---
+const MESSAGE_VIRTUAL_THRESHOLD_ROWS = 2;
+const MESSAGE_VIRTUAL_BUFFER_PX = 0;
+eval(extractFunc('_messageVirtualWindow'));
+const win = _messageVirtualWindow({
+  total: 3,
+  scrollTop: 0,
+  viewportHeight: 600,
+  heights: [0, 0, 0],
+  defaultHeight: 140,
+  roleForIdx: idx => _messageVirtualRoleForEntry(visWithIdx[idx]),
+  bufferPx: 0,
+  threshold: 2,
+  keepTailCount: 0,
+});
+// topPad is sum of rows before win.start; with start=0 it is 0, but
+// the window must have consumed the same per-role heights when computing
+// row positions, so verify the window spans all rows correctly
+const windowCoversAll = win.start === 0 && win.end === 3;
+
+console.log(JSON.stringify({scrollTop, delta, windowCoversAll}));
+"""
+    metrics = json.loads(_run_node(source))
+    # scrollTop to idx=2 = sum of row 0 (120) + row 1 (400) = 520, no viewport offset (null container)
+    assert metrics["scrollTop"] == 520, (
+        f"expected 520 (120+400) but got {metrics['scrollTop']}; "
+        "offset helper must use per-role defaults, not flat 140px"
+    )
+    # prepended delta for 3 uncached rows = 120 + 400 + 160 = 680
+    assert metrics["delta"] == 680, (
+        f"expected 680 (120+400+160) but got {metrics['delta']}; "
+        "prepend helper must use per-role defaults, not flat 140px"
+    )
+    # windowing function must also cover the same three rows
+    assert metrics["windowCoversAll"] is True
+
+
+def test_compensate_scroll_for_measurement_delta_no_anchor_does_not_throw():
+    """When _captureMessageViewportAnchor returns null, the compensation helper
+    should not throw and should not mutate scrollTop."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let renderCalls = [];
+let scrollTopWasMutated = false;
+let scrollTopValue = 100;
+const container = {
+  get scrollTop(){ return scrollTopValue; },
+  set scrollTop(v){ scrollTopWasMutated = true; scrollTopValue = v; },
+  getBoundingClientRect(){ return {top: 0}; },
+  querySelector(){ return null; },
+};
+function $(id){ return id === 'messages' ? container : null; }
+function _captureMessageViewportAnchor(){ return null; }
+let _programmaticScroll = false;
+let _lastScrollTop = 0;
+function _scheduleMessageVirtualizedRender(){ renderCalls.push(true); }
+function requestAnimationFrame(cb){ cb(); }
+eval(extractFunc('_compensateScrollForMeasurementDelta'));
+_compensateScrollForMeasurementDelta(()=>{ _scheduleMessageVirtualizedRender(true); });
+console.log(JSON.stringify({
+  renderCalled: renderCalls.length > 0,
+  scrollTopMutated: scrollTopWasMutated,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["renderCalled"] is True
+    assert metrics["scrollTopMutated"] is False
+
+
+def test_compensate_scroll_for_measurement_delta_shifts_scroll_when_anchor_moves():
+    """When the anchor row shifts position due to measurement changes,
+    scrollTop should be adjusted by the delta."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let scrollTopValue = 200;
+let scrollHistory = [];
+const container = {
+  get scrollTop(){ return scrollTopValue; },
+  set scrollTop(v){ scrollHistory.push(v); scrollTopValue = v; },
+  getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  querySelector(selector){
+    if(selector === '[data-msg-idx="42"]'){
+      // After render, the row moved from relative offset 100 to 150 (50px shift)
+      return {
+        getBoundingClientRect(){ return {top: 100}; }
+      };
+    }
+    return null;
+  },
+};
+function $(id){ return id === 'messages' ? container : null; }
+function _captureMessageViewportAnchor(){
+  // Anchor was at topOffset 100 before the render
+  return {rawIdx: 42, topOffset: 100};
+}
+let _programmaticScroll = false;
+let _lastScrollTop = 0;
+let renderCalls = [];
+function _scheduleMessageVirtualizedRender(){ renderCalls.push(true); }
+function requestAnimationFrame(cb){ cb(); }
+eval(extractFunc('_compensateScrollForMeasurementDelta'));
+_compensateScrollForMeasurementDelta(()=>{ _scheduleMessageVirtualizedRender(true); });
+console.log(JSON.stringify({
+  scrollHistory: scrollHistory,
+  renderCalled: renderCalls.length > 0,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["renderCalled"] is True
+    # actualOffset = 100 - 50 = 50, delta = 50 - 100 = -50 (row moved up 50px)
+    # scrollTop should adjust: 200 + (-50) = 150
+    assert metrics["scrollHistory"] == [150], (
+        "scrollTop should shift by -50px to keep anchor in place"
+    )
+
+
+def test_compensate_scroll_for_measurement_delta_skips_small_delta():
+    """When delta < 2px, no compensation is applied (tolerance)."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let scrollTopValue = 200;
+let scrollHistory = [];
+const container = {
+  get scrollTop(){ return scrollTopValue; },
+  set scrollTop(v){ scrollHistory.push(v); scrollTopValue = v; },
+  getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  querySelector(selector){
+    if(selector === '[data-msg-idx="42"]'){
+      // Row moved by only 1px, within tolerance
+      return {
+        getBoundingClientRect(){ return {top: 251}; }
+      };
+    }
+    return null;
+  },
+};
+function $(id){ return id === 'messages' ? container : null; }
+function _captureMessageViewportAnchor(){
+  return {rawIdx: 42, topOffset: 200};
+}
+let _programmaticScroll = false;
+let _lastScrollTop = 0;
+let renderCalls = [];
+function _scheduleMessageVirtualizedRender(){ renderCalls.push(true); }
+function requestAnimationFrame(cb){ cb(); }
+eval(extractFunc('_compensateScrollForMeasurementDelta'));
+_compensateScrollForMeasurementDelta(()=>{ _scheduleMessageVirtualizedRender(true); });
+console.log(JSON.stringify({
+  scrollHistory: scrollHistory,
+  renderCalled: renderCalls.length > 0,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["renderCalled"] is True
+    assert metrics["scrollHistory"] == [], (
+        "scrollTop should not change for delta < 2px"
+    )
+
+
+def test_compensate_scroll_for_measurement_delta_sets_programmatic_scroll_flag():
+    """_programmaticScroll should be set during compensation and cleared after rAF+setTimeout."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let scrollTopValue = 200;
+let _programmaticScroll = false;
+let _lastScrollTop = 0;
+let scrollSetCount = 0;
+const container = {
+  get scrollTop(){ return scrollTopValue; },
+  set scrollTop(v){
+    scrollSetCount++;
+    scrollTopValue = v;
+  },
+  getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  querySelector(selector){
+    if(selector === '[data-msg-idx="42"]'){
+      return {
+        getBoundingClientRect(){ return {top: 300}; }
+      };
+    }
+    return null;
+  },
+};
+function $(id){ return id === 'messages' ? container : null; }
+function _captureMessageViewportAnchor(){
+  return {rawIdx: 42, topOffset: 200};
+}
+let renderCalls = [];
+function _scheduleMessageVirtualizedRender(){ renderCalls.push(true); }
+let timeoutCbBeingCalled = false;
+function requestAnimationFrame(cb){
+  // This is called with a callback that will eventually clear _programmaticScroll
+  cb();
+}
+function setTimeout(cb, delay){
+  // This is called from within the rAF callback (after scrollTop is set)
+  // The callback should clear _programmaticScroll
+  timeoutCbBeingCalled = true;
+  cb();
+  timeoutCbBeingCalled = false;
+}
+eval(extractFunc('_compensateScrollForMeasurementDelta'));
+_compensateScrollForMeasurementDelta(()=>{ _scheduleMessageVirtualizedRender(true); });
+console.log(JSON.stringify({
+  programmaticScrollWasTrue: _programmaticScroll === true || scrollSetCount > 0,
+  programmaticScrollNowFalse: _programmaticScroll === false,
+  scrollWasSet: scrollSetCount > 0,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    # _programmaticScroll should have been set to true when scrollTop was adjusted
+    assert metrics["scrollWasSet"] is True, (
+        "scrollTop should be set when delta > 2px"
+    )
+    # _programmaticScroll should have been cleared after the setTimeout callback
+    assert metrics["programmaticScrollNowFalse"] is True, (
+        "_programmaticScroll should be false after setTimeout completes"
+    )
+
+
+def test_virtualized_render_uses_compensation_helper():
+    """_scheduleMessageVirtualizedRender must wrap renderMessages with _compensateScrollForMeasurementDelta."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    start = js.index("function _scheduleMessageVirtualizedRender(")
+    end = js.index("\n// ──", start)
+    body = js[start:end]
+
+    assert "_compensateScrollForMeasurementDelta" in body, (
+        "_scheduleMessageVirtualizedRender must call "
+        "_compensateScrollForMeasurementDelta to compensate scroll after measurement-driven rerenders"
+    )
+    assert "renderMessages(" in body, (
+        "the compensation helper should wrap the actual renderMessages call"
+    )
+
+
+def test_scroll_listener_guards_programmatic_scroll_before_marking_active():
+    """The _programmaticScroll guard must appear before _markMessageVirtualScrollActive
+    in the scroll listener so that programmatic scrolls (e.g. from
+    _compensateScrollForMeasurementDelta) do not arm the 150ms settle timer."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    listener_start = js.index("el.addEventListener('scroll',()=>{")
+    listener_end = js.index("});", listener_start)
+    listener_body = js[listener_start:listener_end]
+
+    guard_pos = listener_body.index("if(_programmaticScroll) return;")
+    mark_pos = listener_body.index("_markMessageVirtualScrollActive();")
+    assert guard_pos < mark_pos, (
+        "Scroll listener must check _programmaticScroll before calling "
+        "_markMessageVirtualScrollActive so programmatic scrolls do not arm "
+        "the 150ms settle timer and chain measurement delays"
+    )
+
+
+def test_clear_height_cache_resets_scroll_settle_globals():
+    """_clearMessageVirtualHeightCache must zero out the three scroll-settle globals
+    so that a deferred measurement from a previous session cannot fire against the
+    new session's DOM after a session switch."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    source = _extract_func_script(js) + """
+let timerCleared = false;
+let _messageVirtualScrollActive = true;
+let _messageVirtualScrollSettleTimer = 99;
+let _messageVirtualDeferredMeasurement = {some: 'stale-metrics'};
+let _messageVirtualHeightCache = [100, 200];
+let _messageVirtualHeightCacheEntries = [{rawIdx: 0}];
+let _messageVirtualHeightCacheLen = 2;
+let _messageVirtualHeightCacheSrc = {};
+let _messageVirtualEstimatedRowHeight = 200;
+let _messageVirtualWindowKey = 'old-key';
+let _messageVirtualMeasurementCycleKey = 'old-cycle';
+let _messageVirtualMeasurementRetryCount = 3;
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHT = 140;
+// #4367 introduced per-role default heights; the combined _clearMessageVirtualHeightCache
+// resets the estimate via _messageVirtualDefaultHeightForRole('default'), so the harness
+// must provide the role map + that helper.
+const MESSAGE_VIRTUAL_DEFAULT_ROW_HEIGHTS = {user:120, assistant:160, tool_call:400, default:140};
+function clearTimeout(id){ timerCleared = (id === 99); }
+eval(extractFunc('_messageVirtualDefaultHeightForRole'));
+eval(extractFunc('_clearMessageVirtualHeightCache'));
+_clearMessageVirtualHeightCache();
+console.log(JSON.stringify({
+  scrollActive: _messageVirtualScrollActive,
+  settleTimer: _messageVirtualScrollSettleTimer,
+  deferred: _messageVirtualDeferredMeasurement,
+  timerCleared: timerCleared,
+}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["scrollActive"] is False, (
+        "_clearMessageVirtualHeightCache must reset _messageVirtualScrollActive to false"
+    )
+    assert metrics["settleTimer"] == 0, (
+        "_clearMessageVirtualHeightCache must reset _messageVirtualScrollSettleTimer to 0"
+    )
+    assert metrics["deferred"] is None, (
+        "_clearMessageVirtualHeightCache must clear _messageVirtualDeferredMeasurement to null"
+    )
+    assert metrics["timerCleared"] is True, (
+        "_clearMessageVirtualHeightCache must call clearTimeout on the pending settle timer"
+    )


### PR DESCRIPTION
## Release v0.51.483 — QS (virtual-scroll height + measurement scroll-jump fixes)

Joint release of the #4346 transcript-virtualization scroll-jump cluster. **Contributor (@rodboev) gave the go-ahead** after the deep reviews on #4367 + #4368; shipped together because both touch `static/ui.js` + the same virtualization test file and interact in `_clearMessageVirtualHeightCache`. **Kept default-OFF / experimental** — both fixes only run when "Virtualize long transcripts (experimental)" is enabled (#4343), so blast radius is opt-in users only.

### Included (both @rodboev)
- **#4367** — per-role virtual scroll height estimates (user 120 / assistant 160 / tool_call 400 / default 140) so large tool-call rows aren't under-counted before measurement, which threw off the initial scroll position.
- **#4368** — anchor-based scroll compensation during measurement (capture anchor + scrollTop → render → re-pin scrollTop by the anchor's measured delta; null/<2px guards; programmatic-scroll flag), plus a 150ms scroll-active guard that defers measurement refresh while scrolling, and session-switch cleanup of three scroll-settle globals.

### The combination
Both edit `_clearMessageVirtualHeightCache` → the merged function is the union: #4367's per-role-default estimate reset + #4368's scroll-settle-globals cleanup. The `test_clear_height_cache_resets_scroll_settle_globals` harness was updated to eval `_messageVirtualDefaultHeightForRole` + define the role map (since the combined function calls #4367's helper). Both PRs' test sets retained.

### Gate
- **Codex:** SAFE TO SHIP — merged cache reset correct, default-off virtualization gate verified, scroll-compensation latch cleanup sound; 55 focused virtualization tests pass.
- **Opus:** SAFE TO SHIP — no window-math regression, scroll compensation loop-bounded with no stuck-flag path, and **genuinely inert when the experimental setting is off (render byte-identical to master)**. One optional non-blocking micro-opt noted (not required).
- **Full suite:** 9386 passed, 0 failed. Ruff + ESLint clean. revert-guard: origin/master ancestor of HEAD.

Both PRs were deep-reviewed earlier (reviews posted on each); this is the contributor-approved ship. Attribution preserved via `Co-authored-by`.

Closes #4367, closes #4368.