### PR TITLE
test: fix recurring gateway_sync StopIteration flake (show_cli_sessions isolation)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1066,6 +1066,11 @@ def cleanup_test_sessions():
     Yields a list for tests to register created session IDs.
     Deletes all registered sessions after each test.
     Resets last_workspace to the test workspace to prevent state bleed.
+    Resets show_cli_sessions to its default (off) so a test that toggles it
+    on can't leak that setting into a sibling test under shard ordering — the
+    root cause behind the intermittent gateway_sync StopIteration flake, where a
+    session was occasionally absent from /api/sessions because show_cli_sessions
+    was left in an unexpected state by a prior test in the same shard.
     """
     created: list[str] = []
     yield created
@@ -1084,6 +1089,13 @@ def cleanup_test_sessions():
     try:
         last_ws_file = TEST_STATE_DIR / "last_workspace.txt"
         last_ws_file.write_text(str(TEST_WORKSPACE), encoding='utf-8')
+    except Exception:
+        pass
+
+    # Reset the CLI-session visibility setting to its default so it never bleeds
+    # across tests (33 gateway_sync tests flip it on; only ~30 reset it).
+    try:
+        _post(TEST_BASE, "/api/settings", {"show_cli_sessions": False})
     except Exception:
         pass
 

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -693,7 +693,8 @@ def test_default_title_cli_compression_chain_is_kept_by_lineage():
 
         assert 'cli_default_compress_tip_001' in ids
         assert 'cli_default_compress_root_001' not in ids
-        tip = next(s for s in data.get('sessions', []) if s.get('session_id') == 'cli_default_compress_tip_001')
+        tip = next((s for s in data.get('sessions', []) if s.get('session_id') == 'cli_default_compress_tip_001'), None)
+        assert tip is not None, "compression tip session missing from /api/sessions (test-isolation? check show_cli_sessions + session presence)"
         assert tip.get('_compression_segment_count') == 2
         assert tip.get('_lineage_root_id') == 'cli_default_compress_root_001'
     finally:
@@ -779,7 +780,8 @@ def test_agent_session_limit_applies_after_compression_projection():
         assert chain_ids[-1] in ids
         assert standalone_id in ids
         assert not any(sid in ids for sid in chain_ids[:-1])
-        chain = next(row for row in rows if row.get('id') == chain_ids[-1])
+        chain = next((row for row in rows if row.get('id') == chain_ids[-1]), None)
+        assert chain is not None, "limit-chain tip row missing from projected rows (test-isolation?)"
         assert chain.get('title') == 'Limit Chain #1'
         assert chain.get('_lineage_root_id') == chain_ids[0]
         assert chain.get('_compression_segment_count') == len(chain_ids)
@@ -879,7 +881,8 @@ def test_compression_chain_bubbles_to_top_by_tip_activity():
             f"not the tip's recent value."
         )
 
-        tip_row = next(r for r in rows if r['id'] == 'bubble_tip_001')
+        tip_row = next((r for r in rows if r['id'] == 'bubble_tip_001'), None)
+        assert tip_row is not None, "bubble tip row missing from projected rows (test-isolation?)"
         assert abs(tip_row['last_activity'] - tip_latest_msg) < 0.01, (
             f"Projected tip's last_activity must equal the tip's most recent "
             f"message timestamp ({tip_latest_msg}), not the root's "
@@ -1341,7 +1344,8 @@ def test_sessions_response_backfills_imported_messaging_source_metadata(cleanup_
 
         data, status = get('/api/sessions')
         assert status == 200
-        session = next(item for item in data.get('sessions', []) if item.get('session_id') == sid)
+        session = next((item for item in data.get('sessions', []) if item.get('session_id') == sid), None)
+        assert session is not None, f"{sid} missing from /api/sessions — show_cli_sessions not applied or session hidden (test-isolation)"
         assert session.get('source_tag') == 'weixin'
         assert session.get('raw_source') == 'weixin'
         assert session.get('session_source') == 'messaging'
@@ -2093,7 +2097,8 @@ def test_sessions_prefers_state_db_metadata_for_messaging_overlap(cleanup_test_s
         post('/api/settings', {'show_cli_sessions': True})
         data, status = get('/api/sessions')
         assert status == 200, data
-        session = next(item for item in data.get('sessions', []) if item.get('session_id') == sid)
+        session = next((item for item in data.get('sessions', []) if item.get('session_id') == sid), None)
+        assert session is not None, f"{sid} missing from /api/sessions (test-isolation)"
         assert session.get('message_count') == len(rows)
         expected_updated = max(ts for _, _, ts in rows)
         assert abs(float(session.get('updated_at') or 0) - expected_updated) < 1.0


### PR DESCRIPTION
## Fix the recurring `test_gateway_sync` StopIteration flake (test-isolation)

`test_sessions_response_backfills_imported_messaging_source_metadata` has flaked multiple times on sharded CI (`test (3.12, 2)` and `(3.13, 2)`) with `StopIteration`, while passing in isolation, in the full sequential suite, and (usually) in a single sharded re-run. It's been cleared by `gh run rerun --failed` several times. This fixes the root cause so it stops costing reruns.

### Two compounding causes, both fixed

**1. Root cause — `show_cli_sessions` setting leaks across shard-ordered tests.**
33 `test_gateway_sync` tests flip `show_cli_sessions=True`, but only ~30 reset it, and `cleanup_test_sessions` (conftest) never reset it. Under `pytest-shard` ordering a test could run with the setting in an unexpected state, so its CLI/messaging session was occasionally absent from `/api/sessions`. `cleanup_test_sessions` now resets `show_cli_sessions` to its default (off) after every test, the same way it already resets `last_workspace` — so the setting can't bleed between tests regardless of which test forgets to reset it.

**2. Symptom — bare `next(generator)` raised an opaque `StopIteration`.**
The 5 bare `next(...)` call sites over `/api/sessions` results (no default) raised `StopIteration` when the session was absent — which surfaces as a mysterious flake rather than a diagnosable failure. They now use `next(..., None)` + an explicit assertion naming the missing session, so any future isolation regression fails clearly instead of masquerading as a flake.

### Verification
- Full sequential suite: **9386 passed**, 0 failed.
- CI-shape sharded run (`--num-shards=3`, all 3 shards): shard 0 = 3072, shard 1 = 3153, shard 2 = 3162 (the flake's shard) — **all green**.
- No production code change — `tests/` + the conftest fixture only.

Resolves the A3 flake tracked in the maintainer flake registry.