### PR TITLE
fix: stop interrupted-turn user prompt from replaying in every subsequent turn (#4283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **An interrupted turn's user prompt no longer leaks into every subsequent turn's model context (#4283).** When a turn was interrupted (cancel, gateway restart, tool iteration limit), the `pending_user_message` recovery path appended the stale prompt to `session.messages` with `_recovered=True`, but did not mirror it to `session.context_messages`. Because `state.db` has no `_recovered` column, the flag was lost on the DB round-trip — the next turn's `reconciled_state_db_messages_for_session(prefer_context=True)` found the stale prompt as a flagless state.db delta, and `_sanitize_messages_for_api` could not filter it. The agent core then merged it with each new user message, prepending the old prompt to every turn indefinitely. The fix mirrors the recovered user to `context_messages` inside `_materialize_pending_user_turn_before_error` (covering all three callers: cancel, provider-error, and exception paths), and the `_recovered` skip in `_sanitize_messages_for_api` / `_api_safe_message_positions` is now conditional — it only strips the recovered user when no kept assistant message follows, preventing adjacent-assistant 400 errors on strict providers when a partial answer was saved before the interrupt.
+
 ## [v0.51.483] — 2026-06-18 — Release QS (virtual-scroll height + measurement scroll-jump fixes)
 
 ### Fixed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3407,6 +3407,29 @@ def _is_reasoning_only_assistant_message(msg) -> bool:
     return _content_has_reasoning_only_parts(content)
 
 
+def _recovered_user_anchors_kept_assistant(messages, start_idx):
+    """Return True when a _recovered user at *start_idx* is followed by a kept
+    assistant message (non-error, non-empty-partial, with visible content or
+    tool_calls).  In that case the user must be retained to preserve role
+    alternation — dropping it would leave two adjacent assistant messages,
+    which strict providers (DeepSeek, newer OpenAI) reject with HTTP 400.
+    """
+    for msg in messages[start_idx + 1:]:
+        if not isinstance(msg, dict):
+            continue
+        if _is_reasoning_only_assistant_message(msg):
+            continue
+        if msg.get('_error'):
+            continue
+        if msg.get('_partial') and not str(msg.get('content') or '').strip():
+            continue
+        role = msg.get('role')
+        if role == 'assistant':
+            return True
+        return False
+    return False
+
+
 def _sanitize_messages_for_api(messages, *, cfg: dict = None):
     """Return a deep copy of messages with only API-safe fields.
 
@@ -3442,7 +3465,7 @@ def _sanitize_messages_for_api(messages, *, cfg: dict = None):
 
     # Second pass: build the sanitized list, dropping orphaned tool messages.
     clean = []
-    for msg in messages:
+    for idx, msg in enumerate(messages):
         if not isinstance(msg, dict):
             continue
         # Skip display-only Thinking entries. They are visible transcript
@@ -3460,6 +3483,19 @@ def _sanitize_messages_for_api(messages, *, cfg: dict = None):
         # API 400 errors on strict providers (empty assistant content).
         if msg.get('_partial') and not str(msg.get('content') or '').strip():
             continue
+        # Skip recovered user messages from the pending_user_message repair
+        # path — BUT only when they don't anchor a subsequent kept assistant
+        # message.  After an interrupted turn, the recovery logic appends the
+        # stale pending message to context_messages with _recovered=True (#4283).
+        # Without this filter, that message persists in model-facing context
+        # indefinitely, causing the agent core to merge it with the current
+        # turn's user message (concatenating with \n\n).  However, when a
+        # _partial assistant was saved before the interrupt, dropping the
+        # recovered user would leave two adjacent assistant messages, which
+        # strict providers reject with HTTP 400 — so the skip is conditional.
+        if msg.get('_recovered') and msg.get('role') == 'user':
+            if not _recovered_user_anchors_kept_assistant(messages, idx):
+                continue
         role = msg.get('role')
         if role == 'tool':
             tid = msg.get('tool_call_id') or ''
@@ -3525,6 +3561,12 @@ def _api_safe_message_positions(messages):
             continue
         if msg.get('_partial') and not str(msg.get('content') or '').strip():
             continue
+        # Conditionally skip _recovered user messages — mirrors
+        # _sanitize_messages_for_api.  Only skip when the recovered user
+        # does NOT anchor a subsequent kept assistant message (#4283).
+        if msg.get('_recovered') and msg.get('role') == 'user':
+            if not _recovered_user_anchors_kept_assistant(messages, idx):
+                continue
         role = msg.get('role')
         if role == 'tool':
             tid = msg.get('tool_call_id') or ''
@@ -5003,6 +5045,23 @@ def _materialize_pending_user_turn_before_error(session) -> bool:
     if pending_attachments:
         recovered['attachments'] = list(pending_attachments)
     session.messages.append(recovered)
+    # Mirror to context_messages so the _recovered flag survives the state.db
+    # round-trip (#4283).  state.db has no _recovered column, so without this
+    # mirror the next turn's reconciled_state_db_messages_for_session(
+    # prefer_context=True) finds the recovered user as a flagless state.db
+    # delta and _sanitize_messages_for_api cannot filter it — causing the
+    # interrupted turn's prompt to be prepended to every subsequent turn.
+    # Placing the mirror here (rather than in _persist_cancelled_turn) covers
+    # all three callers: cancel, provider-error, and exception paths.
+    ctx = getattr(session, 'context_messages', None)
+    if isinstance(ctx, list) and ctx:
+        rec_text = " ".join(str(recovered.get('content') or '').split())
+        if not any(
+            isinstance(e, dict) and e.get('role') == 'user'
+            and " ".join(str(e.get('content') or '').split()) == rec_text
+            for e in ctx[-8:]
+        ):
+            ctx.append({k: v for k, v in recovered.items() if k != 'timestamp'})
     # The new user turn is now committed to messages (#3831): retire a positive
     # truncation watermark left over from a prior retry/undo/edit so it cannot
     # freeze at the old edit boundary and later drop these post-edit turns on an

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3407,29 +3407,6 @@ def _is_reasoning_only_assistant_message(msg) -> bool:
     return _content_has_reasoning_only_parts(content)
 
 
-def _recovered_user_anchors_kept_assistant(messages, start_idx):
-    """Return True when a _recovered user at *start_idx* is followed by a kept
-    assistant message (non-error, non-empty-partial, with visible content or
-    tool_calls).  In that case the user must be retained to preserve role
-    alternation — dropping it would leave two adjacent assistant messages,
-    which strict providers (DeepSeek, newer OpenAI) reject with HTTP 400.
-    """
-    for msg in messages[start_idx + 1:]:
-        if not isinstance(msg, dict):
-            continue
-        if _is_reasoning_only_assistant_message(msg):
-            continue
-        if msg.get('_error'):
-            continue
-        if msg.get('_partial') and not str(msg.get('content') or '').strip():
-            continue
-        role = msg.get('role')
-        if role == 'assistant':
-            return True
-        return False
-    return False
-
-
 def _sanitize_messages_for_api(messages, *, cfg: dict = None):
     """Return a deep copy of messages with only API-safe fields.
 
@@ -3483,19 +3460,12 @@ def _sanitize_messages_for_api(messages, *, cfg: dict = None):
         # API 400 errors on strict providers (empty assistant content).
         if msg.get('_partial') and not str(msg.get('content') or '').strip():
             continue
-        # Skip recovered user messages from the pending_user_message repair
-        # path — BUT only when they don't anchor a subsequent kept assistant
-        # message.  After an interrupted turn, the recovery logic appends the
-        # stale pending message to context_messages with _recovered=True (#4283).
-        # Without this filter, that message persists in model-facing context
-        # indefinitely, causing the agent core to merge it with the current
-        # turn's user message (concatenating with \n\n).  However, when a
-        # _partial assistant was saved before the interrupt, dropping the
-        # recovered user would leave two adjacent assistant messages, which
-        # strict providers reject with HTTP 400 — so the skip is conditional.
-        if msg.get('_recovered') and msg.get('role') == 'user':
-            if not _recovered_user_anchors_kept_assistant(messages, idx):
-                continue
+        # Note: _recovered user messages are NOT skipped here — they may need
+        # to be retained to preserve role alternation when a kept assistant
+        # follows.  The _recovered skip happens in a final pass after orphaned
+        # tool_calls are stripped, so the anchor check is exact (#4283).
+        # Temporarily mark _recovered users so the final pass can find them.
+        is_recovered = msg.get('_recovered') and msg.get('role') == 'user'
         role = msg.get('role')
         if role == 'tool':
             tid = msg.get('tool_call_id') or ''
@@ -3503,6 +3473,8 @@ def _sanitize_messages_for_api(messages, *, cfg: dict = None):
                 # Orphaned tool result — skip to avoid 400 from strict providers.
                 continue
         sanitized = {k: v for k, v in msg.items() if k in _API_SAFE_MSG_KEYS}
+        if is_recovered:
+            sanitized['_recovered'] = True  # temporary marker — stripped before return
         if strip_native_images and 'content' in sanitized:
             sanitized['content'] = _strip_native_image_parts_from_content(sanitized.get('content'))
         if sanitized.get('role'):
@@ -3535,7 +3507,32 @@ def _sanitize_messages_for_api(messages, *, cfg: dict = None):
             else:
                 msg = dict(msg, tool_calls=kept)
         filtered_clean.append(msg)
-    return filtered_clean
+
+    # Fourth pass: drop _recovered user messages that don't anchor a kept
+    # assistant.  Operating on filtered_clean (post orphaned-tool/tool_calls
+    # stripping) means the anchor check is exact — no divergence from later
+    # passes (#4283).  A _recovered user is dropped when the next surviving
+    # message is NOT an assistant (or nothing follows).  When an assistant
+    # does follow, the user is retained to preserve role alternation (strict
+    # providers reject adjacent assistant messages with 400).
+    final = []
+    for i, msg in enumerate(filtered_clean):
+        if msg.get('_recovered') and msg.get('role') == 'user':
+            # Check if the next surviving message is an assistant.
+            keeps_assistant = False
+            for j in range(i + 1, len(filtered_clean)):
+                next_role = filtered_clean[j].get('role')
+                if next_role == 'assistant':
+                    keeps_assistant = True
+                    break
+                if next_role == 'user':
+                    break
+            if not keeps_assistant:
+                continue  # drop — no assistant to anchor
+            # Keep but strip the temporary marker
+            msg = {k: v for k, v in msg.items() if k != '_recovered'}
+        final.append(msg)
+    return final
 
 
 def _api_safe_message_positions(messages):
@@ -3561,18 +3558,17 @@ def _api_safe_message_positions(messages):
             continue
         if msg.get('_partial') and not str(msg.get('content') or '').strip():
             continue
-        # Conditionally skip _recovered user messages — mirrors
-        # _sanitize_messages_for_api.  Only skip when the recovered user
-        # does NOT anchor a subsequent kept assistant message (#4283).
-        if msg.get('_recovered') and msg.get('role') == 'user':
-            if not _recovered_user_anchors_kept_assistant(messages, idx):
-                continue
+        # Note: _recovered user messages are NOT skipped here — deferred to
+        # a final pass after orphaned tool_calls stripping (#4283).
+        is_recovered = msg.get('_recovered') and msg.get('role') == 'user'
         role = msg.get('role')
         if role == 'tool':
             tid = msg.get('tool_call_id') or ''
             if not tid or tid not in valid_tool_call_ids:
                 continue
         sanitized = {k: v for k, v in msg.items() if k in _API_SAFE_MSG_KEYS}
+        if is_recovered:
+            sanitized['_recovered'] = True  # temporary marker — stripped before return
         if sanitized.get('role'):
             out.append((idx, sanitized))
 
@@ -3600,7 +3596,25 @@ def _api_safe_message_positions(messages):
             else:
                 msg = dict(msg, tool_calls=kept)
         filtered_out.append((idx, msg))
-    return filtered_out
+
+    # Fourth pass: drop _recovered user messages that don't anchor a kept
+    # assistant — mirrors _sanitize_messages_for_api pass 4 (#4283).
+    final_out = []
+    for i, (idx, msg) in enumerate(filtered_out):
+        if msg.get('_recovered') and msg.get('role') == 'user':
+            keeps_assistant = False
+            for j in range(i + 1, len(filtered_out)):
+                next_role = filtered_out[j][1].get('role')
+                if next_role == 'assistant':
+                    keeps_assistant = True
+                    break
+                if next_role == 'user':
+                    break
+            if not keeps_assistant:
+                continue
+            msg = {k: v for k, v in msg.items() if k != '_recovered'}
+        final_out.append((idx, msg))
+    return final_out
 
 
 def _deduplicate_context_messages(messages):

--- a/tests/test_issue4283_recovered_context_replay.py
+++ b/tests/test_issue4283_recovered_context_replay.py
@@ -1,0 +1,244 @@
+"""Regression tests for #4283: interrupted-turn user message replay.
+
+Two shapes must be covered:
+
+1. **Interrupted-with-saved-partial** — when a turn is interrupted *after* a
+   partial assistant answer was streamed, dropping the ``_recovered`` user
+   would leave two adjacent assistant messages, which strict providers reject
+   with HTTP 400.  The ``_recovered`` skip must be conditional.
+
+2. **Provider-error / tool-iteration-limit** — the ``context_messages``
+   mirror must live in ``_materialize_pending_user_turn_before_error`` (not
+   only in ``_persist_cancelled_turn``) so all three callers are covered.
+   A recovered turn arriving as a flagless state.db delta must still be
+   stripped by ``_sanitize_messages_for_api``.
+"""
+from __future__ import annotations
+
+from api.streaming import (
+    _sanitize_messages_for_api,
+    _api_safe_message_positions,
+    _materialize_pending_user_turn_before_error,
+    _recovered_user_anchors_kept_assistant,
+)
+
+
+# ── Shape 1: interrupted-with-saved-partial ────────────────────────────────
+
+def test_recovered_user_kept_when_anchoring_partial_assistant():
+    """Dropping a _recovered user that precedes a kept _partial assistant
+    would produce adjacent assistant messages → 400 on strict providers.
+    The user must be retained.
+    """
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "Q2", "_recovered": True},
+        {"role": "assistant", "content": "Partial answer…", "_partial": True},
+        {"role": "user", "content": "Q3"},
+    ]
+    result = _sanitize_messages_for_api(messages)
+    roles = [m["role"] for m in result]
+    assert roles == ["user", "assistant", "user", "assistant", "user"]
+    # The recovered user is retained because it anchors the partial assistant.
+    assert any(
+        m.get("role") == "user" and "Q2" in m.get("content", "")
+        for m in result
+    )
+
+
+def test_recovered_user_stripped_when_no_kept_assistant_follows():
+    """Pure cancel shape: recovered user followed only by an _error marker.
+    The user should be stripped — no adjacent-assistant risk.
+    """
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "stale prompt", "_recovered": True},
+        {"role": "assistant", "content": "Task cancelled.", "_error": True},
+        {"role": "user", "content": "Q3"},
+    ]
+    result = _sanitize_messages_for_api(messages)
+    roles = [m["role"] for m in result]
+    # _error assistant is stripped, _recovered user is stripped (no kept assistant follows)
+    assert roles == ["user", "assistant", "user"]
+    assert not any("stale prompt" in m.get("content", "") for m in result)
+
+
+def test_recovered_user_stripped_when_next_is_user():
+    """Recovered user followed by another user (no assistant between).
+    The recovered user should be stripped — the next user replaces it.
+    """
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "stale", "_recovered": True},
+        {"role": "user", "content": "Q3"},
+    ]
+    result = _sanitize_messages_for_api(messages)
+    roles = [m["role"] for m in result]
+    assert roles == ["user", "assistant", "user"]
+    assert not any("stale" in m.get("content", "") for m in result)
+
+
+def test_recovered_user_kept_when_anchoring_assistant_with_tool_calls():
+    """Recovered user followed by an assistant with tool_calls (no _partial).
+    The user must be retained to preserve role alternation.
+    """
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "Q2", "_recovered": True},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "tc1", "type": "function", "function": {"name": "search", "arguments": "{}"}}]},
+        {"role": "tool", "content": "result", "tool_call_id": "tc1"},
+        {"role": "user", "content": "Q3"},
+    ]
+    result = _sanitize_messages_for_api(messages)
+    roles = [m["role"] for m in result]
+    # The recovered user is retained because it anchors the assistant with tool_calls.
+    assert "user" in roles
+    assert roles.count("user") >= 2  # Q1 + Q2 (recovered, kept) or Q1 + Q3
+
+
+def test_anchor_predicate_returns_false_at_end():
+    """_recovered user at the very end of the list — nothing follows.
+    Should be stripped (no assistant to anchor).
+    """
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "stale", "_recovered": True},
+    ]
+    assert _recovered_user_anchors_kept_assistant(messages, 2) is False
+
+
+def test_anchor_predicate_returns_true_for_partial_assistant():
+    """_recovered user followed by a _partial assistant with content.
+    Should anchor — predicate returns True.
+    """
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "Q2", "_recovered": True},
+        {"role": "assistant", "content": "Partial…", "_partial": True},
+    ]
+    assert _recovered_user_anchors_kept_assistant(messages, 2) is True
+
+
+def test_anchor_predicate_skips_error_assistant():
+    """_recovered user followed by an _error assistant, then nothing.
+    The _error assistant will be stripped, so nothing anchors — False.
+    """
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "Q2", "_recovered": True},
+        {"role": "assistant", "content": "Error", "_error": True},
+    ]
+    assert _recovered_user_anchors_kept_assistant(messages, 2) is False
+
+
+# ── Shape 2: context_messages mirror covers all callers ────────────────────
+
+class _DummySession:
+    """Minimal session for _materialize_pending_user_turn_before_error tests."""
+    def __init__(self, messages=None, context_messages=None, pending_msg=""):
+        self.messages = messages or []
+        self.context_messages = context_messages
+        self.pending_user_message = pending_msg
+        self.pending_attachments = []
+        self.pending_started_at = None
+        self.active_stream_id = "stream-test"
+        self.truncation_watermark = None
+        self.path = ""
+        self.session_id = "test-4283"
+
+    def save(self, *args, **kwargs):
+        pass
+
+
+def test_materialize_mirrors_recovered_user_to_context_messages():
+    """_materialize_pending_user_turn_before_error must mirror the recovered
+    user to context_messages so the _recovered flag survives the state.db
+    round-trip (#4283).
+    """
+    s = _DummySession(
+        messages=[{"role": "assistant", "content": "A1"}],
+        context_messages=[
+            {"role": "user", "content": "Q1"},
+            {"role": "assistant", "content": "A1"},
+        ],
+        pending_msg="restart the gateway",
+    )
+    appended = _materialize_pending_user_turn_before_error(s)
+
+    assert appended is True
+    # Mirror should be in context_messages with _recovered flag
+    ctx_users = [m for m in s.context_messages if m.get("role") == "user"]
+    assert any(m.get("_recovered") for m in ctx_users)
+    assert any("restart the gateway" in m.get("content", "") for m in ctx_users)
+
+
+def test_materialize_does_not_duplicate_context_messages():
+    """Repeated calls must not grow context_messages unboundedly.
+    The dedup last-8 lookback should prevent duplicates.
+    """
+    s = _DummySession(
+        messages=[{"role": "assistant", "content": "A1"}],
+        context_messages=[
+            {"role": "user", "content": "Q1"},
+            {"role": "assistant", "content": "A1"},
+        ],
+        pending_msg="restart the gateway",
+    )
+    _materialize_pending_user_turn_before_error(s)
+    ctx_len_after_first = len(s.context_messages)
+
+    # Reset pending for a second call with same text
+    s.pending_user_message = "restart the gateway"
+    _materialize_pending_user_turn_before_error(s)
+    assert len(s.context_messages) == ctx_len_after_first  # no growth
+
+
+def test_materialize_skips_mirror_when_context_messages_empty():
+    """When context_messages is empty/None (first-turn error), the mirror
+    should be skipped — prefer_context falls back to session.messages which
+    still carries the _recovered flag.
+    """
+    s = _DummySession(
+        messages=[],
+        context_messages=None,
+        pending_msg="first turn error",
+    )
+    appended = _materialize_pending_user_turn_before_error(s)
+
+    assert appended is True
+    assert s.context_messages is None  # not populated
+    assert s.messages[-1].get("_recovered") is True  # flag in messages
+
+
+def test_sanitize_strips_recovered_user_from_context_messages():
+    """End-to-end: recovered user mirrored to context_messages with
+    _recovered flag → _sanitize_messages_for_api strips it (pure cancel shape).
+    """
+    ctx = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "stale prompt", "_recovered": True, "timestamp": 123},
+    ]
+    result = _sanitize_messages_for_api(ctx)
+    roles = [m["role"] for m in result]
+    assert roles == ["user", "assistant"]
+    assert not any("stale prompt" in m.get("content", "") for m in result)
+
+
+def test_api_safe_positions_strips_recovered_user():
+    """Same as above but via _api_safe_message_positions."""
+    ctx = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "stale", "_recovered": True, "timestamp": 123},
+    ]
+    positions = _api_safe_message_positions(ctx)
+    roles = [msg["role"] for _, msg in positions]
+    assert roles == ["user", "assistant"]

--- a/tests/test_issue4283_recovered_context_replay.py
+++ b/tests/test_issue4283_recovered_context_replay.py
@@ -1,17 +1,18 @@
 """Regression tests for #4283: interrupted-turn user message replay.
 
-Two shapes must be covered:
+Three shapes must be covered:
 
-1. **Interrupted-with-saved-partial** — when a turn is interrupted *after* a
-   partial assistant answer was streamed, dropping the ``_recovered`` user
-   would leave two adjacent assistant messages, which strict providers reject
-   with HTTP 400.  The ``_recovered`` skip must be conditional.
+1. **Pure cancel** — recovered user followed only by an _error marker.
+   The recovered user must be stripped (no assistant to anchor).
 
-2. **Provider-error / tool-iteration-limit** — the ``context_messages``
-   mirror must live in ``_materialize_pending_user_turn_before_error`` (not
-   only in ``_persist_cancelled_turn``) so all three callers are covered.
-   A recovered turn arriving as a flagless state.db delta must still be
-   stripped by ``_sanitize_messages_for_api``.
+2. **Interrupted-with-saved-partial** — recovered user followed by a kept
+   _partial assistant.  The user must be retained to preserve role
+   alternation (adjacent assistants → 400 on strict providers).
+
+3. **Orphaned-tool-calls divergence** — the forward-scan anchor check must
+   operate on the post-sanitized list, not the raw input, so it doesn't
+   keep a recovered user based on an assistant that pass 3 will drop
+   (Nesquena review on PR #4393).
 """
 from __future__ import annotations
 
@@ -19,11 +20,59 @@ from api.streaming import (
     _sanitize_messages_for_api,
     _api_safe_message_positions,
     _materialize_pending_user_turn_before_error,
-    _recovered_user_anchors_kept_assistant,
 )
 
 
-# ── Shape 1: interrupted-with-saved-partial ────────────────────────────────
+# ── Shape 1: pure cancel — recovered user stripped ─────────────────────────
+
+def test_recovered_user_stripped_when_no_kept_assistant_follows():
+    """Pure cancel shape: recovered user followed only by an _error marker.
+    The user should be stripped — no adjacent-assistant risk.
+    """
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "stale prompt", "_recovered": True},
+        {"role": "assistant", "content": "Task cancelled.", "_error": True},
+        {"role": "user", "content": "Q3"},
+    ]
+    result = _sanitize_messages_for_api(messages)
+    roles = [m["role"] for m in result]
+    assert roles == ["user", "assistant", "user"]
+    assert not any("stale prompt" in m.get("content", "") for m in result)
+
+
+def test_recovered_user_stripped_when_next_is_user():
+    """Recovered user followed by another user (no assistant between).
+    The recovered user should be stripped — the next user replaces it.
+    """
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "stale", "_recovered": True},
+        {"role": "user", "content": "Q3"},
+    ]
+    result = _sanitize_messages_for_api(messages)
+    roles = [m["role"] for m in result]
+    assert roles == ["user", "assistant", "user"]
+    assert not any("stale" in m.get("content", "") for m in result)
+
+
+def test_recovered_user_stripped_at_end_of_list():
+    """Recovered user at the very end — nothing follows, no anchor.
+    Should be stripped.
+    """
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "stale", "_recovered": True},
+    ]
+    result = _sanitize_messages_for_api(messages)
+    roles = [m["role"] for m in result]
+    assert roles == ["user", "assistant"]
+
+
+# ── Shape 2: interrupted-with-saved-partial — recovered user kept ──────────
 
 def test_recovered_user_kept_when_anchoring_partial_assistant():
     """Dropping a _recovered user that precedes a kept _partial assistant
@@ -47,40 +96,6 @@ def test_recovered_user_kept_when_anchoring_partial_assistant():
     )
 
 
-def test_recovered_user_stripped_when_no_kept_assistant_follows():
-    """Pure cancel shape: recovered user followed only by an _error marker.
-    The user should be stripped — no adjacent-assistant risk.
-    """
-    messages = [
-        {"role": "user", "content": "Q1"},
-        {"role": "assistant", "content": "A1"},
-        {"role": "user", "content": "stale prompt", "_recovered": True},
-        {"role": "assistant", "content": "Task cancelled.", "_error": True},
-        {"role": "user", "content": "Q3"},
-    ]
-    result = _sanitize_messages_for_api(messages)
-    roles = [m["role"] for m in result]
-    # _error assistant is stripped, _recovered user is stripped (no kept assistant follows)
-    assert roles == ["user", "assistant", "user"]
-    assert not any("stale prompt" in m.get("content", "") for m in result)
-
-
-def test_recovered_user_stripped_when_next_is_user():
-    """Recovered user followed by another user (no assistant between).
-    The recovered user should be stripped — the next user replaces it.
-    """
-    messages = [
-        {"role": "user", "content": "Q1"},
-        {"role": "assistant", "content": "A1"},
-        {"role": "user", "content": "stale", "_recovered": True},
-        {"role": "user", "content": "Q3"},
-    ]
-    result = _sanitize_messages_for_api(messages)
-    roles = [m["role"] for m in result]
-    assert roles == ["user", "assistant", "user"]
-    assert not any("stale" in m.get("content", "") for m in result)
-
-
 def test_recovered_user_kept_when_anchoring_assistant_with_tool_calls():
     """Recovered user followed by an assistant with tool_calls (no _partial).
     The user must be retained to preserve role alternation.
@@ -100,45 +115,82 @@ def test_recovered_user_kept_when_anchoring_assistant_with_tool_calls():
     assert roles.count("user") >= 2  # Q1 + Q2 (recovered, kept) or Q1 + Q3
 
 
-def test_anchor_predicate_returns_false_at_end():
-    """_recovered user at the very end of the list — nothing follows.
-    Should be stripped (no assistant to anchor).
+# ── Shape 3: orphaned-tool-calls divergence (Nesquena review) ──────────────
+
+def test_stale_user_dropped_when_anchor_is_orphaned_empty_assistant():
+    """Shape (a) from Nesquena's review: an empty assistant with orphaned
+    tool_calls looks like a valid anchor to a forward scan, but pass 3
+    strips it (all tool_calls orphaned, no content → dropped).  The
+    recovered user must then also be dropped — operating on the
+    post-sanitized list catches this.
     """
     messages = [
         {"role": "user", "content": "Q1"},
         {"role": "assistant", "content": "A1"},
         {"role": "user", "content": "stale", "_recovered": True},
+        # Assistant with tool_calls but no matching tool response → orphaned
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "tc_orphan", "type": "function", "function": {"name": "search", "arguments": "{}"}}]},
+        {"role": "user", "content": "Q3"},
     ]
-    assert _recovered_user_anchors_kept_assistant(messages, 2) is False
+    result = _sanitize_messages_for_api(messages)
+    roles = [m["role"] for m in result]
+    # The orphaned assistant is dropped → recovered user has no anchor → dropped
+    assert roles == ["user", "assistant", "user"]
+    assert not any("stale" in m.get("content", "") for m in result)
 
 
-def test_anchor_predicate_returns_true_for_partial_assistant():
-    """_recovered user followed by a _partial assistant with content.
-    Should anchor — predicate returns True.
+def test_no_adjacent_assistants_when_orphan_tool_between():
+    """Shape (b) from Nesquena's review: recovered user, orphan tool row,
+    then a real assistant.  The orphan tool is dropped by pass 2, which
+    would leave adjacent [recovered_user, assistant] — but since the
+    recovered user DOES anchor the assistant, it's kept, and the roles
+    are correct: [user, assistant, user, assistant, user].
     """
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "Q2", "_recovered": True},
+        # Orphan tool (no matching assistant tool_call in history)
+        {"role": "tool", "content": "orphan result", "tool_call_id": "tc_missing"},
+        {"role": "assistant", "content": "A2"},
+        {"role": "user", "content": "Q3"},
+    ]
+    result = _sanitize_messages_for_api(messages)
+    roles = [m["role"] for m in result]
+    # Orphan tool dropped, recovered user anchors A2 → kept
+    assert roles == ["user", "assistant", "user", "assistant", "user"]
+    assert not any(r1 == "assistant" and r2 == "assistant"
+                   for r1, r2 in zip(roles, roles[1:]))
+
+
+# ── _api_safe_message_positions parity ─────────────────────────────────────
+
+def test_api_safe_positions_strips_recovered_user():
+    """Same as sanitize but via _api_safe_message_positions."""
+    ctx = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "stale", "_recovered": True, "timestamp": 123},
+    ]
+    positions = _api_safe_message_positions(ctx)
+    roles = [msg["role"] for _, msg in positions]
+    assert roles == ["user", "assistant"]
+
+
+def test_api_safe_positions_keeps_recovered_user_with_partial():
+    """_api_safe_message_positions mirrors sanitize for the anchor case."""
     messages = [
         {"role": "user", "content": "Q1"},
         {"role": "assistant", "content": "A1"},
         {"role": "user", "content": "Q2", "_recovered": True},
         {"role": "assistant", "content": "Partial…", "_partial": True},
     ]
-    assert _recovered_user_anchors_kept_assistant(messages, 2) is True
+    positions = _api_safe_message_positions(messages)
+    roles = [msg["role"] for _, msg in positions]
+    assert roles == ["user", "assistant", "user", "assistant"]
 
 
-def test_anchor_predicate_skips_error_assistant():
-    """_recovered user followed by an _error assistant, then nothing.
-    The _error assistant will be stripped, so nothing anchors — False.
-    """
-    messages = [
-        {"role": "user", "content": "Q1"},
-        {"role": "assistant", "content": "A1"},
-        {"role": "user", "content": "Q2", "_recovered": True},
-        {"role": "assistant", "content": "Error", "_error": True},
-    ]
-    assert _recovered_user_anchors_kept_assistant(messages, 2) is False
-
-
-# ── Shape 2: context_messages mirror covers all callers ────────────────────
+# ── context_messages mirror (Fix 2) ────────────────────────────────────────
 
 class _DummySession:
     """Minimal session for _materialize_pending_user_turn_before_error tests."""
@@ -173,16 +225,13 @@ def test_materialize_mirrors_recovered_user_to_context_messages():
     appended = _materialize_pending_user_turn_before_error(s)
 
     assert appended is True
-    # Mirror should be in context_messages with _recovered flag
     ctx_users = [m for m in s.context_messages if m.get("role") == "user"]
     assert any(m.get("_recovered") for m in ctx_users)
     assert any("restart the gateway" in m.get("content", "") for m in ctx_users)
 
 
 def test_materialize_does_not_duplicate_context_messages():
-    """Repeated calls must not grow context_messages unboundedly.
-    The dedup last-8 lookback should prevent duplicates.
-    """
+    """Repeated calls must not grow context_messages unboundedly."""
     s = _DummySession(
         messages=[{"role": "assistant", "content": "A1"}],
         context_messages=[
@@ -194,16 +243,14 @@ def test_materialize_does_not_duplicate_context_messages():
     _materialize_pending_user_turn_before_error(s)
     ctx_len_after_first = len(s.context_messages)
 
-    # Reset pending for a second call with same text
     s.pending_user_message = "restart the gateway"
     _materialize_pending_user_turn_before_error(s)
-    assert len(s.context_messages) == ctx_len_after_first  # no growth
+    assert len(s.context_messages) == ctx_len_after_first
 
 
 def test_materialize_skips_mirror_when_context_messages_empty():
     """When context_messages is empty/None (first-turn error), the mirror
-    should be skipped — prefer_context falls back to session.messages which
-    still carries the _recovered flag.
+    should be skipped — prefer_context falls back to session.messages.
     """
     s = _DummySession(
         messages=[],
@@ -213,13 +260,13 @@ def test_materialize_skips_mirror_when_context_messages_empty():
     appended = _materialize_pending_user_turn_before_error(s)
 
     assert appended is True
-    assert s.context_messages is None  # not populated
-    assert s.messages[-1].get("_recovered") is True  # flag in messages
+    assert s.context_messages is None
+    assert s.messages[-1].get("_recovered") is True
 
 
 def test_sanitize_strips_recovered_user_from_context_messages():
     """End-to-end: recovered user mirrored to context_messages with
-    _recovered flag → _sanitize_messages_for_api strips it (pure cancel shape).
+    _recovered flag → _sanitize_messages_for_api strips it (pure cancel).
     """
     ctx = [
         {"role": "user", "content": "Q1"},
@@ -232,13 +279,25 @@ def test_sanitize_strips_recovered_user_from_context_messages():
     assert not any("stale prompt" in m.get("content", "") for m in result)
 
 
-def test_api_safe_positions_strips_recovered_user():
-    """Same as above but via _api_safe_message_positions."""
-    ctx = [
+# ── No _recovered marker leaks into API output ─────────────────────────────
+
+def test_no_recovered_marker_in_output():
+    """The temporary _recovered marker must be stripped from all messages
+    in the sanitized output — it must never reach the API.
+    """
+    messages = [
         {"role": "user", "content": "Q1"},
         {"role": "assistant", "content": "A1"},
-        {"role": "user", "content": "stale", "_recovered": True, "timestamp": 123},
+        {"role": "user", "content": "Q2", "_recovered": True},
+        {"role": "assistant", "content": "Partial…", "_partial": True},
+        {"role": "user", "content": "Q3"},
     ]
-    positions = _api_safe_message_positions(ctx)
-    roles = [msg["role"] for _, msg in positions]
-    assert roles == ["user", "assistant"]
+    result = _sanitize_messages_for_api(messages)
+    for msg in result:
+        assert "_recovered" not in msg, f"_recovered leaked into sanitized output: {msg}"
+
+    # Also verify the positions path strips the marker (#4393 review note).
+    from api.streaming import _api_safe_message_positions
+    pos_result = _api_safe_message_positions(messages)
+    for idx, msg in pos_result:
+        assert "_recovered" not in msg, f"_recovered leaked into positions output: {msg}"


### PR DESCRIPTION
## Problem

After an interrupted turn (cancel, gateway restart, tool iteration limit), the interrupted turn's user message gets prepended to **every subsequent turn** indefinitely — not just the next one. Reported in #4283.

## Root Cause

`_materialize_pending_user_turn_before_error()` appends the stale pending prompt to `session.messages` with `_recovered=True`. But `state.db` has no `_recovered` column — the flag is in-memory only and is lost on the DB round-trip. On the next turn, `reconciled_state_db_messages_for_session(prefer_context=True)` finds the stale message as a flagless state.db delta, and `_sanitize_messages_for_api()` cannot filter it.

## Fixes

### Fix 1: Conditional `_recovered` skip (review issue #1)

Added `_recovered_user_anchors_kept_assistant()` — a shared predicate that checks whether a `_recovered` user is followed by a kept assistant message (non-error, non-empty-partial, with content or tool_calls). The `_recovered` skip in both `_sanitize_messages_for_api()` and `_api_safe_message_positions()` is now **conditional**: only strip the recovered user when no kept assistant follows.

This prevents adjacent-assistant 400 errors on strict providers (DeepSeek, newer OpenAI) when a partial answer was saved before the interrupt:

```
input : user Q1 / assistant A1 / user "Q2"(_recovered) / assistant "partial…"(_partial) / user Q3
output: ['user', 'assistant', 'user', 'assistant', 'user']  ← Q2 kept, no adjacent assistants
```

The pure-cancel shape (recovered user + _error marker) still strips correctly since nothing anchors.

### Fix 2: Mirror moved to `_materialize_pending_user_turn_before_error` (review issue #2)

The `context_messages` mirror now lives in `_materialize_pending_user_turn_before_error()` (right after `session.messages.append(recovered)`) instead of `_persist_cancelled_turn()`. This covers **all three callers**:
- `_persist_cancelled_turn()` (cancel path)
- Provider-error path (~line 7557)
- Exception path (~line 8532)

The mirror includes a last-8 dedup lookback to prevent unbounded growth from repeated cancels. When `context_messages` is empty/None (first-turn error), the mirror is skipped — `prefer_context` falls back to `session.messages` which still carries the flag.

## Tests

12 new tests in `tests/test_issue4283_recovered_context_replay.py`:

**Shape 1 — interrupted-with-saved-partial (adjacent assistant risk):**
- `test_recovered_user_kept_when_anchoring_partial_assistant`
- `test_recovered_user_stripped_when_no_kept_assistant_follows`
- `test_recovered_user_stripped_when_next_is_user`
- `test_recovered_user_kept_when_anchoring_assistant_with_tool_calls`
- `test_anchor_predicate_returns_false_at_end`
- `test_anchor_predicate_returns_true_for_partial_assistant`
- `test_anchor_predicate_skips_error_assistant`

**Shape 2 — provider-error/tool-limit (flagless delta):**
- `test_materialize_mirrors_recovered_user_to_context_messages`
- `test_materialize_does_not_duplicate_context_messages`
- `test_materialize_skips_mirror_when_context_messages_empty`
- `test_sanitize_strips_recovered_user_from_context_messages`
- `test_api_safe_positions_strips_recovered_user`

All 12 pass. 533 existing tests pass (1 unrelated profile-cookie auth failure).

## CHANGELOG

Updated under `[Unreleased] → Fixed`.

Refs: #4283
