### PR TITLE
fix(#4395): make staged hermes-agent source writable after rsync/cp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+- **Multi-container WebUI no longer dies on `uv pip install hermes-agent` with `could not create 'hermes_agent.egg-info': Permission denied` (#4395).** The staging block in `docker_init.bash` now `chmod -R u+w "$_stage_src"` after the rsync/cp copy. Without it, `rsync -a` / `cp -a` preserved the source tree's mode bits from the `:ro` `hermes-agent-src` mount (mode 555), leaving the staged `/tmp/hermes-agent-build` itself read-only even though hermeswebui owned it; setuptools then could not create `<pkg>.egg-info/` during PEP 517 `egg_info` and the container crashed at startup under `set -e`. Affects every multi-container deploy (`docker-compose.two-container.yml`, `docker-compose.three-container.yml`).
+
 ## [v0.51.484] — 2026-06-18 — Release QT (collapsible paused cron section)
 
 ### Added

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -438,6 +438,13 @@ else
     # and `--reflink=auto` makes the copy near-free on overlay2/btrfs where
     # supported. We rebuild on every container start (the agent source can
     # change across volume re-init); cost is one rsync of ~10MB of Python source.
+    #
+    # NB: `rsync -a` / `cp -a` preserve the source tree's mode bits, so a `:ro`
+    # source mounted mode 555 leaves the staged copy also mode 555. setuptools
+    # then can't create `hermes_agent.egg-info/` next to the package — it dies
+    # with "Permission denied" even though `_stage_src` itself was created
+    # writable by hermeswebui. Re-add owner-write on the staged tree after the
+    # copy so the build dir is genuinely writable, not just owned by us.
     _stage_src="/tmp/hermes-agent-build"
     rm -rf "$_stage_src"
     mkdir -p "$_stage_src"
@@ -455,6 +462,8 @@ else
       rm -rf "$_stage_src"/*.egg-info "$_stage_src"/build "$_stage_src"/dist 2>/dev/null || true
       find "$_stage_src" -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
     fi
+    chmod -R u+w "$_stage_src" \
+      || error_exit "Failed to make staged hermes-agent source writable (rsync/cp preserved :ro mount perms)"
     uv pip install "$_stage_src[all]" --trusted-host pypi.org --trusted-host files.pythonhosted.org \
       || error_exit "Failed to install hermes-agent's requirements"
     rm -rf "$_stage_src"

--- a/tests/test_docker_docs_and_readonly.py
+++ b/tests/test_docker_docs_and_readonly.py
@@ -19,6 +19,7 @@ Pins three invariants:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -250,5 +251,54 @@ def test_docker_init_excludes_egg_info_during_staging():
     )
     assert "--exclude='__pycache__'" in stage_block, (
         "rsync staging must --exclude='__pycache__' to keep the copy minimal."
+    )
+
+
+def test_docker_init_makes_staged_dir_writable_after_ro_mount_copy():
+    """Regression test for the docker-init "could not create hermes_agent.egg-info:
+    Permission denied" failure on :ro multi-container mounts.
+
+    `rsync -a` / `cp -a` preserve the source tree's mode bits, so a hermes-agent
+    source mounted mode 555 leaves the staged copy also mode 555 even though the
+    staging dir itself was created writable by hermeswebui. setuptools then can't
+    create `<pkg>.egg-info/` next to the package and dies with "Permission denied"
+    during `uv pip install`. The fix is a `chmod -R u+w` on the staged tree AFTER
+    both copy paths and BEFORE the install. This test pins that ordering and the
+    `u+w` form (so the staged tree isn't accidentally made world-writable).
+    """
+    src = (REPO / "docker_init.bash").read_text(encoding="utf-8")
+
+    stage_idx = src.index("_stage_src=")
+    install_idx = src.index("uv pip install", stage_idx)
+    stage_block = src[stage_idx:install_idx]
+
+    # The fix MUST add owner-write to the staged tree after the rsync/cp copy.
+    # A naked `chmod` call that strips 0555 (or equivalent) would also work,
+    # but `u+w` is the minimal-permission form and matches the rest of the
+    # docker-init.bash style (never widen perms beyond what the operator needs).
+    assert re.search(r"chmod\s+-R\s+u\+w\s+\"?\\?\$?_stage_src\"?", stage_block), (
+        "docker_init.bash staging block must `chmod -R u+w \"$_stage_src\"` "
+        "after the rsync/cp copy. Without it, a :ro hermes-agent mount leaves "
+        "the staged tree mode 555 and `uv pip install` fails with "
+        "'could not create hermes_agent.egg-info: Permission denied' under "
+        "PEP 517 build isolation."
+    )
+
+    # The chmod must live in the SHARED tail (after `fi`), not inside either
+    # branch — otherwise dropping back to cp -a (when rsync is missing) would
+    # silently re-introduce the bug.
+    assert "chmod -R u+w \"$_stage_src\"" in stage_block, (
+        "the post-staging chmod must use the exact `chmod -R u+w \"$_stage_src\"` "
+        "form so the substring-check pattern below matches both code paths."
+    )
+
+    # Both copy branches (rsync and cp -a) close with `fi`; the chmod must
+    # come AFTER the closing `fi` so it covers whichever path was taken.
+    fi_idx = stage_block.rindex("\n    fi\n")
+    chmod_idx = stage_block.index("chmod -R u+w")
+    assert chmod_idx > fi_idx, (
+        "chmod must live AFTER the rsync/cp if/else closes — putting it "
+        "inside one branch means the other copy path skips it and the "
+        ":ro mount perm leak returns."
     )
 


### PR DESCRIPTION
## Summary

Multi-container WebUI deploys (`docker-compose.two-container.yml`, `docker-compose.three-container.yml`) die at startup with:

```
error: could not create 'hermes_agent.egg-info': Permission denied
```

`docker_init.bash` correctly stages the `:ro` `hermes-agent-src` source into `/tmp/hermes-agent-build` to avoid EROFS (added in `70f371c8`), but `rsync -a` / `cp -a` preserve the source tree's mode bits. A source mounted mode 555 leaves the staged copy also mode 555, and setuptools' PEP 517 `egg_info` then cannot create `<pkg>.egg-info/` next to the package — even though hermeswebui owns the dir.

Fix: `chmod -R u+w "$_stage_src"` after both copy paths and before `uv pip install`. Minimal-permission form (`u+w`, not `a+w`) so the staged tree isn't accidentally world-writable.

Closes #4395.

## Changes

| File | Change |
|---|---|
| `docker_init.bash` | +8 (chmod + 7-line `NB:` comment explaining the perm-inheritance trap) |
| `tests/test_docker_docs_and_readonly.py` | +50 (`import re` + `test_docker_init_makes_staged_dir_writable_after_ro_mount_copy`) |
| `CHANGELOG.md` | +2 (one bullet under `[Unreleased]`) |

Total: 3 files, 61 insertions, 0 deletions.

## Why staging-as-tmpfs alone isn't enough

The original staging commit (`70f371c8`) assumed a freshly-`mkdir`'d tmp dir would be writable. It would be — if nothing came after to overwrite the mode. Both `rsync -a` and `cp -a` include `-p` (preserve permissions), so the staging dir's mode 700 from `mkdir -p` gets clobbered to whatever the source's mode is. The fix preserves the original staging invariant — *writable* tmpfs copy — by re-adding owner-write after the copy.

## Why the existing PR #2490 smoke gate didn't catch this

The smoke job mounts the `hermes-agent-src` fixture read-write, so the staging path never exercises mode-555 inheritance. The `error_exit` log signature is identical to the EROFS case the gate does catch, but the fixture won't trigger it. The new regression test (source-level, not runtime) is the durable defence for this class.

## Verification

| Gate | Result |
|---|---|
| `bash -n docker_init.bash` | clean |
| `pytest tests/test_docker_docs_and_readonly.py -v` | **12 passed** (11 existing + 1 new) |
| Host-level reproduction (read-only source → `cp -a` → mode 555 → setuptools `Permission denied`) | confirmed before fix |
| Same reproduction with `chmod -R u+w` after `cp -a` | install succeeds (`Built hermes-agent`) |
| Negative test (revert the chmod line) | the new test fails with a clear error message naming the missing `chmod -R u+w "$_stage_src"` invariant |

## Risk

- One-line change in a bash script. No new code path, no dependency changes, no API surface change.
- The `chmod -R u+w` widens perms to owner-write, which is what the staging block's invariant already required. No privilege expansion.
- Affects only the WebUI's install path. The agent service is unchanged.

## Out of scope (noted, not addressed)

A long-term fix would be to refactor the staging block into a named function in a sourced helper file so it can be exercised by an integration test that creates an actual `:ro` tmpfs mount and asserts the resulting staged dir is writable — source-level invariants only catch what they're written to catch. Worth a follow-up; not a release gate for this fix.