### PR TITLE
fix(sessions): preserve archived cron state.db projections

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -3877,6 +3877,22 @@ def _all_profiles_cli_contexts() -> tuple[list[tuple[Path, Path, str | None]], t
     return contexts, tuple(cache_entries)
 
 
+def _state_projection_sidecar_metadata(sid: str) -> dict:
+    """Return UI-owned metadata for a state.db-projected sidebar row."""
+    metadata = {"title": None, "archived": False}
+    try:
+        webui_meta = Session.load_metadata_only(sid)
+    except Exception:
+        return metadata
+    if not webui_meta:
+        return metadata
+    title = getattr(webui_meta, 'title', None)
+    if title:
+        metadata["title"] = title
+    metadata["archived"] = bool(getattr(webui_meta, 'archived', False))
+    return metadata
+
+
 def _load_cli_sessions_uncached(
     hermes_home: Path,
     db_path: Path,
@@ -3944,15 +3960,14 @@ def _load_cli_sessions_uncached(
                 except Exception:
                     pass  # degrade gracefully
         # If a WebUI JSON file exists for this session (e.g. previously
-        # imported or renamed in the sidebar), prefer its title over the
-        # state.db title.  This fixes rename-not-persisting for CLI sessions
-        # after compression chain extension (#1486).
-        try:
-            _webui_meta = Session.load_metadata_only(sid)
-            if _webui_meta and getattr(_webui_meta, 'title', None):
-                _title = _webui_meta.title
-        except Exception:
-            pass
+        # imported or renamed in the sidebar), prefer its UI-owned metadata over
+        # the state.db projection. This keeps archived cron/tool/API runs hidden
+        # even when all_sessions() omits the hidden sidecar and the state row is
+        # re-injected from Hermes state.db (#4397).
+        _sidecar_meta = _state_projection_sidecar_metadata(sid)
+        if _sidecar_meta.get('title'):
+            _title = _sidecar_meta['title']
+        _archived = bool(_sidecar_meta.get('archived'))
         _display_title = _title or f'{_source.title()} Session'
         cli_sessions.append({
             'session_id': sid,
@@ -3963,7 +3978,7 @@ def _load_cli_sessions_uncached(
             'created_at': row['started_at'],
             'updated_at': raw_ts,
             'pinned': False,
-            'archived': False,
+            'archived': _archived,
             'project_id': _cron_pid() if is_cron_session(sid, _source) else None,
             'profile': profile,
             'source_tag': _source,
@@ -4033,12 +4048,10 @@ def _load_cli_sessions_uncached(
                                         break
                         except Exception:
                             pass
-                try:
-                    _webui_meta = Session.load_metadata_only(sid)
-                    if _webui_meta and getattr(_webui_meta, 'title', None):
-                        _title = _webui_meta.title
-                except Exception:
-                    pass
+                _sidecar_meta = _state_projection_sidecar_metadata(sid)
+                if _sidecar_meta.get('title'):
+                    _title = _sidecar_meta['title']
+                _archived = bool(_sidecar_meta.get('archived'))
                 _display_title = _title or 'Cron Session'
                 cli_sessions.append({
                     'session_id': sid,
@@ -4049,7 +4062,7 @@ def _load_cli_sessions_uncached(
                     'created_at': row['started_at'],
                     'updated_at': raw_ts,
                     'pinned': False,
-                    'archived': False,
+                    'archived': _archived,
                     'project_id': _cron_pid(),
                     'profile': profile_value,
                     'source_tag': 'cron',

--- a/tests/test_issue4385_cron_archive_reappears.py
+++ b/tests/test_issue4385_cron_archive_reappears.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from unittest.mock import patch
 
 
@@ -77,6 +78,59 @@ def test_materializing_cron_session_preserves_non_cli_identity(monkeypatch):
     assert session.session_source == "cron"
     assert session.source_tag == "cron"
     assert session.is_cli_session is False
+
+
+def test_cron_state_projection_preserves_archived_sidecar(monkeypatch, tmp_path):
+    """A hidden archived sidecar must still mark the state.db cron projection archived."""
+    import api.models as models
+
+    sid = "cron_job123_20260618"
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                model TEXT,
+                message_count INTEGER,
+                started_at REAL,
+                source TEXT,
+                session_source TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO sessions (
+                id, title, model, message_count, started_at, source, session_source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (sid, "Cron Session", "test-model", 1, 20, "cron", "cron"),
+        )
+
+    class ArchivedSidecar:
+        title = "Cron Session"
+        archived = True
+
+    monkeypatch.setattr(
+        models.Session,
+        "load_metadata_only",
+        staticmethod(lambda candidate: ArchivedSidecar() if candidate == sid else None),
+    )
+    monkeypatch.setattr(models, "ensure_cron_project", lambda: "cron-project")
+
+    rows = models._load_cli_sessions_uncached(
+        tmp_path,
+        db_path,
+        "default",
+        source_filter="cron",
+        include_claude_code=False,
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["session_id"] == sid
+    assert rows[0]["archived"] is True
 
 
 def test_archived_cron_sidecar_suppresses_raw_unarchived_cron_row(monkeypatch):


### PR DESCRIPTION
## Summary
Fixes archived cron runs reappearing in the Sessions panel after refresh when the run is re-projected from Hermes `state.db`.

This is a follow-up to closed issue #4385 and merged PR #4388. That fix covered stale cron sidecars being treated as CLI rows. This follow-up covers the remaining path where `all_sessions()` omits the hidden archived sidecar, then `get_cli_sessions()` re-adds the same cron run from `state.db` with `archived: false`.

## What changed
- Preserves UI-owned sidecar metadata when projecting state.db sessions into sidebar rows.
- Carries the archived flag from the WebUI sidecar for matching cron/tool/API projections.
- Adds a regression test for a hidden archived cron sidecar plus a state.db cron row.

## Testing
- `uv run --with pytest --with pyyaml --with cryptography pytest tests/test_issue4385_cron_archive_reappears.py -q`
- `uv run --with pytest --with pyyaml --with cryptography pytest tests/test_issue4385_cron_archive_reappears.py tests/test_issue3585_cron_session_overflow.py tests/test_gateway_sync.py -q`
- Verified against local reproduced data: affected cron session IDs now resolve as `archived=True` in `_build_session_list_cache_payload(...)`.

Closes #4397
Follow-up to #4385
Follow-up to #4388
