### PR TITLE
Release v0.51.485 — QU (mobile: 44px hamburger + browser edge-swipe #4394)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.485] — 2026-06-18 — Release QU (mobile: bigger hamburger tap target + browser edge-swipe)
+
+### Improved
+
+- **Mobile menu is easier to tap and the edge-swipe-to-open-sidebar gesture now works in the browser, not just the installed PWA (#4394).** The title-bar hamburger button grows from 32×32 to a 44×44 tap target (the iOS minimum) with a slightly larger icon, and the left-edge swipe-to-open-sidebar gesture is widened and now active in a normal mobile browser (previously PWA-standalone only). The gesture stays left-edge-gated, touch-only, requires clear horizontal intent, and ignores interactive elements, so it won't fire on a scroll or a tap. Thanks @kaishi00.
+
 ## [v0.51.484] — 2026-06-18 — Release QT (collapsible paused cron section)
 
 ### Added

--- a/static/boot.js
+++ b/static/boot.js
@@ -266,9 +266,9 @@ function closeMobileSidebar(){
   if(overlay)overlay.classList.remove('visible');
 }
 
-const _PWA_SIDEBAR_SWIPE_EDGE=28;
-const _PWA_SIDEBAR_SWIPE_TRIGGER=72;
-const _PWA_SIDEBAR_SWIPE_MAX_VERTICAL=48;
+const _PWA_SIDEBAR_SWIPE_EDGE=80;
+const _PWA_SIDEBAR_SWIPE_TRIGGER=64;
+const _PWA_SIDEBAR_SWIPE_MAX_VERTICAL=56;
 let _pwaSidebarSwipe=null;
 
 function _isPwaStandalone(){
@@ -298,7 +298,7 @@ function _openMobileSidebarFromGesture(){
 }
 
 function _onPwaSidebarSwipeStart(e){
-  if(!_isPwaStandalone()||_isDesktopWidth())return;
+  if(_isDesktopWidth())return;
   if(e.pointerType==='mouse'||(e.pointerType&&e.pointerType!=='touch'&&e.pointerType!=='pen'))return;
   if(document.querySelector('.sidebar')?.classList.contains('mobile-open'))return;
   const clientX=Number(e.clientX)||0;

--- a/static/index.html
+++ b/static/index.html
@@ -119,7 +119,7 @@
 <body>
 <header class="app-titlebar" role="banner">
   <button class="app-titlebar-hamburger has-tooltip has-tooltip--bottom" id="btnHamburger" onclick="toggleMobileSidebar()" type="button" data-tooltip="Menu" aria-label="Menu">
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
   </button>
   <div class="app-titlebar-inner">
     <span class="app-titlebar-icon" aria-hidden="true">

--- a/static/style.css
+++ b/static/style.css
@@ -989,7 +989,7 @@
   .app-titlebar-title{font-size:12px;font-weight:600;color:var(--text);letter-spacing:-.01em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:60vw;}
   .app-titlebar-sub{font-size:10px;color:var(--muted);background:var(--hover-bg);padding:2px 7px;border-radius:4px;font-family:'SF Mono',ui-monospace,monospace;white-space:nowrap;flex-shrink:0;}
   .app-titlebar-sub[hidden]{display:none;}
-  .app-titlebar-hamburger,.app-titlebar-spacer{display:none;width:32px;height:32px;flex-shrink:0;}
+  .app-titlebar-hamburger,.app-titlebar-spacer{display:none;width:44px;height:44px;flex-shrink:0;}
   .app-titlebar-hamburger{-webkit-app-region:no-drag;align-items:center;justify-content:center;background:none;border:none;color:var(--muted);border-radius:8px;cursor:pointer;padding:0;-webkit-tap-highlight-color:transparent;transition:background-color .15s,color .15s;}
   .app-titlebar-hamburger:hover{background:var(--hover-bg);color:var(--text);}
   .sidebar{width:300px;background:var(--sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;overflow:visible;flex-shrink:0;transition:width .24s cubic-bezier(.22,1,.36,1),opacity .18s ease,transform .24s cubic-bezier(.22,1,.36,1),border-color .24s ease;}


### PR DESCRIPTION
## Release v0.51.485 — QU (mobile: bigger hamburger tap target + browser edge-swipe)

Single small mobile-UX PR — the clean split-out from #4390 that the maintainer asked for (streaming.py + image-paste commits removed). **Deep-reviewed + live browser-tested at 390×844 + screenshot-verified.** Nathan approved shipping as-is (the iOS-Safari-back-swipe overlap is an accepted PWA-primary tradeoff).

### Included
- **#4394** (@kaishi00) — mobile UX: 44px hamburger tap target + browser edge-swipe sidebar.
  - Hamburger button `32×32 → 44×44` (iOS HIG minimum tap target), SVG icon `20 → 24px`.
  - Edge-swipe-to-open-sidebar: edge zone `28 → 80px`, trigger `72 → 64px`, max-vertical `48 → 56px`; drops the `_isPwaStandalone()` gate so the gesture works in a normal mobile browser, not only the installed PWA.

### Verification
- **Live-driven at 390×844:** hamburger renders 44×44 (display:flex on mobile) + tap opens the sidebar; a simulated left-edge swipe opens the sidebar in a non-PWA browser context. Screenshot vision-verified — clean title bar, well-sized hamburger, no glitches.
- Swipe guards all intact: `_isDesktopWidth()`-blocked (desktop inert), touch/pen-only (mouse rejected), `_isInteractiveSwipeTarget` exclusion, horizontal-intent (`dx>=64 && dx>|dy|*1.5`), left-edge-gated, `preventDefault` only after trigger + behind `if(e.cancelable)`. Listener install is a single unconditional boot-time call (no double-install/leak).

### Gate
- **Codex:** SAFE TO SHIP — all guards preserved, single listener install, no regression.
- **Opus:** SAFE TO SHIP — desktop provably inert, no listener leak, preventDefault gated, 44px hamburger preserves title centering. Two cosmetic non-gating nits only.
- **Full suite:** 9393 passed, 0 failed. Ruff + ESLint clean. revert-guard: origin/master ancestor of HEAD.

### Known + accepted tradeoff
In mobile *browser* the 80px left-edge zone overlaps iOS Safari's back-swipe; it degrades gracefully (the installed PWA — the primary mobile target — has no back gesture). Maintainer-approved ship-as-is.

Attribution preserved via `Co-authored-by`.

Closes #4394.