### PR TITLE
fix: stack conversation outline FAB above scroll control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Conversation outline FAB no longer overlaps the scroll-to-bottom control (#4381).** The outline toggle now shares the chat message-shell positioning context with the existing scroll controls and stacks above the bottom-right scroll button, so composer height changes no longer place the two circular controls on top of each other.
+
 ## [v0.51.485] — 2026-06-18 — Release QU (mobile: bigger hamburger tap target + browser edge-swipe)
 
 ### Improved

--- a/static/index.html
+++ b/static/index.html
@@ -411,6 +411,11 @@
     <div class="messages-shell">
       <button id="jumpToSessionStartBtn" class="session-jump-btn session-jump-btn--start" aria-label="Jump to beginning of session" data-i18n-aria-label="session_jump_start_label" data-i18n-title="session_jump_start_label" onclick="jumpToSessionStart()" style="display:none"><span aria-hidden="true">↑</span><span data-i18n="session_jump_start">Start</span></button>
       <button id="scrollToBottomBtn" class="scroll-to-bottom-btn" style="display:none" onclick="scrollToBottom()" aria-label="Scroll to bottom" data-i18n-aria-label="session_jump_end_label" data-i18n-title="session_jump_end_label"><span aria-hidden="true">↓</span><span class="session-jump-btn__text" data-i18n="session_jump_end">End</span></button>
+      <button id="outlineToggleBtn" type="button" hidden
+        onclick="toggleOutlinePanel()"
+        title="Conversation outline"
+        aria-label="Toggle conversation outline"
+        aria-controls="outlinePanelWrapper">&#9776;</button>
     <div class="messages" id="messages">
       <div class="empty-state" id="emptyState">
         <div class="empty-logo"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="80" height="80" aria-label="Hermes caduceus">
@@ -1645,12 +1650,6 @@
     </div>
   </div>
 </div>
-<!-- Conversation Outline Panel (#2124): floating jump-to-question panel -->
-<button id="outlineToggleBtn" type="button" hidden
-  onclick="toggleOutlinePanel()"
-  title="Conversation outline"
-  aria-label="Toggle conversation outline"
-  aria-controls="outlinePanelWrapper">&#9776;</button>
 <div id="outlinePanelWrapper" hidden
   role="navigation" aria-label="Conversation outline">
   <div class="outline-header">

--- a/static/style.css
+++ b/static/style.css
@@ -5864,7 +5864,7 @@ main.main.showing-logs > #mainLogs{display:flex;}
 
 /* ── Conversation Outline Panel (#2124) ─────────────────────────────────── */
 #outlineToggleBtn{
-  position:fixed;bottom:120px;right:calc(var(--outline-workspace-offset, 0px) + 20px);z-index:9999;
+  position:absolute;bottom:60px;right:20px;z-index:12;
   width:38px;height:38px;border-radius:50%;
   background:var(--surface);border:1px solid var(--border2);
   color:var(--text);cursor:pointer;

--- a/tests/test_issue2124_outline_panel.py
+++ b/tests/test_issue2124_outline_panel.py
@@ -17,6 +17,18 @@ CONFIG_PY   = (ROOT / "api" / "config.py").read_text(encoding="utf-8")
 LOCALE_COUNT = 12
 
 
+def _css_rule_body(selector):
+    rule = re.search(re.escape(selector) + r"\{(?P<body>[^}]*)\}", STYLE_CSS, re.S)
+    assert rule
+    return rule.group("body")
+
+
+def _css_px(rule_body, property_name):
+    match = re.search(rf"{re.escape(property_name)}:(?P<value>\d+)px", rule_body)
+    assert match
+    return int(match.group("value"))
+
+
 def test_outline_panel_html_and_i18n_contract():
     """The panel shell, script tag, and locale keys must be present."""
     assert 'src="static/outline.js?v=__WEBUI_VERSION__"' in INDEX_HTML
@@ -115,3 +127,24 @@ def test_outline_wrapper_hidden_attr_actually_hides():
     the panel (the close button / auto-close set wrapper.hidden=true). An explicit
     #outlinePanelWrapper[hidden]{display:none} rule restores the expected behavior."""
     assert "#outlinePanelWrapper[hidden]{display:none;}" in STYLE_CSS
+
+
+def test_outline_fab_stacks_with_scroll_controls():
+    """The outline FAB shares the messages-shell positioning context with the
+    scroll controls, so composer height changes cannot make the controls overlap
+    in the bottom-right corner. (#4381)"""
+    shell_start = INDEX_HTML.index('<div class="messages-shell">')
+    messages_start = INDEX_HTML.index('<div class="messages" id="messages">', shell_start)
+    shell_controls = INDEX_HTML[shell_start:messages_start]
+    assert 'id="outlineToggleBtn"' in shell_controls
+    assert shell_controls.index('id="scrollToBottomBtn"') < shell_controls.index('id="outlineToggleBtn"')
+
+    outline_css = _css_rule_body("#outlineToggleBtn")
+    scroll_css = _css_rule_body(".scroll-to-bottom-btn")
+    assert "position:absolute" in outline_css
+    assert "position:fixed" not in outline_css
+    assert _css_px(outline_css, "right") == _css_px(scroll_css, "right")
+
+    outline_gap = _css_px(outline_css, "bottom")
+    scroll_top = _css_px(scroll_css, "bottom") + _css_px(scroll_css, "height")
+    assert outline_gap > scroll_top


### PR DESCRIPTION
## Thinking Path
- The conversation outline toggle and the scroll-to-bottom control both occupy the chat bottom-right control area.
- The scroll control is positioned inside `.messages-shell`, while the outline FAB was fixed to the viewport.
- At normal composer heights those two coordinate systems placed the controls on top of each other.
- This fix makes the outline FAB share the chat message-shell positioning context and stack above the scroll control.

## What Changed
- Moved `#outlineToggleBtn` into `.messages-shell` beside the existing scroll controls.
- Changed the outline FAB from viewport-fixed positioning to message-shell absolute positioning.
- Kept the outline panel itself fixed with the existing workspace-panel offset.
- Added a regression test for #4381.
- Added a changelog entry.

## Why It Matters
The scroll-to-bottom button remains reachable when conversation outline is enabled, including when composer height changes.

## Verification
- `./scripts/test.sh -s -q tests/test_issue2124_outline_panel.py tests/test_session_jump_buttons.py`
- `node --check static/outline.js static/ui.js static/panels.js`
- `.venv/bin/python scripts/ruff_lint.py --diff upstream/master`
- `git diff --check`
- `.venv/bin/python tests/browser_smoke.py`

Manual/browser geometry smoke:
- Dark and light mode harness
- Normal and taller composer heights
- Confirmed zero overlap between the outline FAB and scroll-to-bottom control

## Risks / Follow-ups
- The outline panel remains fixed-positioned intentionally so it keeps the existing workspace-panel offset behavior.
- This PR only addresses the FAB collision described in #4381.

Closes #4381