### PR TITLE
Release v0.51.487 — QX (multi-container Docker: staged source writable #4395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.487] — 2026-06-18 — Release QX (multi-container Docker: make staged hermes-agent source writable)
+
+### Fixed
+
+- **Multi-container Docker deploys no longer die at startup with `could not create 'hermes_agent.egg-info': Permission denied` (#4395).** `docker_init.bash` stages the read-only `hermes-agent-src` mount into `/tmp/hermes-agent-build` to avoid EROFS, but `rsync -a` / `cp -a` preserve the source's mode bits — a source mounted mode 555 left the staged copy 555 too, so setuptools couldn't create `egg-info` next to the package. The staged tree is now `chmod -R u+w`'d after the copy (with a clear error if that fails), so the build dir is genuinely writable. Thanks @enihcam.
+
 ## [v0.51.486] — 2026-06-18 — Release QV (archived cron runs stay hidden on state.db re-projection)
 
 ### Fixed

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -438,6 +438,13 @@ else
     # and `--reflink=auto` makes the copy near-free on overlay2/btrfs where
     # supported. We rebuild on every container start (the agent source can
     # change across volume re-init); cost is one rsync of ~10MB of Python source.
+    #
+    # NB: `rsync -a` / `cp -a` preserve the source tree's mode bits, so a `:ro`
+    # source mounted mode 555 leaves the staged copy also mode 555. setuptools
+    # then can't create `hermes_agent.egg-info/` next to the package — it dies
+    # with "Permission denied" even though `_stage_src` itself was created
+    # writable by hermeswebui. Re-add owner-write on the staged tree after the
+    # copy so the build dir is genuinely writable, not just owned by us.
     _stage_src="/tmp/hermes-agent-build"
     rm -rf "$_stage_src"
     mkdir -p "$_stage_src"
@@ -455,6 +462,8 @@ else
       rm -rf "$_stage_src"/*.egg-info "$_stage_src"/build "$_stage_src"/dist 2>/dev/null || true
       find "$_stage_src" -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
     fi
+    chmod -R u+w "$_stage_src" \
+      || error_exit "Failed to make staged hermes-agent source writable (rsync/cp preserved :ro mount perms)"
     uv pip install "$_stage_src[all]" --trusted-host pypi.org --trusted-host files.pythonhosted.org \
       || error_exit "Failed to install hermes-agent's requirements"
     rm -rf "$_stage_src"

--- a/tests/test_docker_docs_and_readonly.py
+++ b/tests/test_docker_docs_and_readonly.py
@@ -19,6 +19,7 @@ Pins three invariants:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -250,5 +251,54 @@ def test_docker_init_excludes_egg_info_during_staging():
     )
     assert "--exclude='__pycache__'" in stage_block, (
         "rsync staging must --exclude='__pycache__' to keep the copy minimal."
+    )
+
+
+def test_docker_init_makes_staged_dir_writable_after_ro_mount_copy():
+    """Regression test for the docker-init "could not create hermes_agent.egg-info:
+    Permission denied" failure on :ro multi-container mounts.
+
+    `rsync -a` / `cp -a` preserve the source tree's mode bits, so a hermes-agent
+    source mounted mode 555 leaves the staged copy also mode 555 even though the
+    staging dir itself was created writable by hermeswebui. setuptools then can't
+    create `<pkg>.egg-info/` next to the package and dies with "Permission denied"
+    during `uv pip install`. The fix is a `chmod -R u+w` on the staged tree AFTER
+    both copy paths and BEFORE the install. This test pins that ordering and the
+    `u+w` form (so the staged tree isn't accidentally made world-writable).
+    """
+    src = (REPO / "docker_init.bash").read_text(encoding="utf-8")
+
+    stage_idx = src.index("_stage_src=")
+    install_idx = src.index("uv pip install", stage_idx)
+    stage_block = src[stage_idx:install_idx]
+
+    # The fix MUST add owner-write to the staged tree after the rsync/cp copy.
+    # A naked `chmod` call that strips 0555 (or equivalent) would also work,
+    # but `u+w` is the minimal-permission form and matches the rest of the
+    # docker-init.bash style (never widen perms beyond what the operator needs).
+    assert re.search(r"chmod\s+-R\s+u\+w\s+\"?\\?\$?_stage_src\"?", stage_block), (
+        "docker_init.bash staging block must `chmod -R u+w \"$_stage_src\"` "
+        "after the rsync/cp copy. Without it, a :ro hermes-agent mount leaves "
+        "the staged tree mode 555 and `uv pip install` fails with "
+        "'could not create hermes_agent.egg-info: Permission denied' under "
+        "PEP 517 build isolation."
+    )
+
+    # The chmod must live in the SHARED tail (after `fi`), not inside either
+    # branch — otherwise dropping back to cp -a (when rsync is missing) would
+    # silently re-introduce the bug.
+    assert "chmod -R u+w \"$_stage_src\"" in stage_block, (
+        "the post-staging chmod must use the exact `chmod -R u+w \"$_stage_src\"` "
+        "form so the substring-check pattern below matches both code paths."
+    )
+
+    # Both copy branches (rsync and cp -a) close with `fi`; the chmod must
+    # come AFTER the closing `fi` so it covers whichever path was taken.
+    fi_idx = stage_block.rindex("\n    fi\n")
+    chmod_idx = stage_block.index("chmod -R u+w")
+    assert chmod_idx > fi_idx, (
+        "chmod must live AFTER the rsync/cp if/else closes — putting it "
+        "inside one branch means the other copy path skips it and the "
+        ":ro mount perm leak returns."
     )
 


### PR DESCRIPTION
## Release v0.51.487 — QX (multi-container Docker: make staged hermes-agent source writable)

Single fix-class deploy/infra PR. Full authoritative gate green.

### Included
- **#4398** (@enihcam, fixes #4395) — *make staged hermes-agent source writable after rsync/cp in `docker_init.bash`.* Multi-container deploys died at startup with `could not create 'hermes_agent.egg-info': Permission denied`: `docker_init.bash` stages the read-only `hermes-agent-src` mount into `/tmp/hermes-agent-build` to avoid EROFS, but `rsync -a` / `cp -a` preserve mode bits — a source mounted mode 555 left the staged copy 555, so setuptools couldn't write egg-info. The staged tree is now `chmod -R u+w`'d after the copy (fail-closed via `error_exit`).

### Gate
- **Codex:** SAFE TO SHIP — `chmod -R u+w` after both copy paths + cleanup, before install; owner-write only; staged-source path only; `bash -n` + docker test pass.
- **Opus:** SAFE TO SHIP ("No bugs found") — minimal/correct/fail-closed, runtime-user-owned throwaway `/tmp` tree, no symlink-escape, single-container + fast-restart paths unaffected.
- **Full suite:** 9395 passed, 0 failed. Ruff clean. revert-guard: origin/master ancestor of HEAD.

+50-line regression test pinning the `u+w` form, after-`fi` placement, and before-install ordering. Attribution preserved via `Co-authored-by`.

Closes #4395.