### PR TITLE
[security] fix(rollback): contain checkpoint restore writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Rollback restore now refuses workspace symlink escapes.** Restoring a checkpoint writes through the workspace-anchored file helpers instead of pathname-based copies, so a symlink planted inside the workspace cannot redirect restored content outside the workspace.
+
 ## [v0.51.488] — 2026-06-18 — Release QW (rescue state.db user prompts that fall before a newer sidecar tail)
 
 ### Fixed

--- a/api/rollback.py
+++ b/api/rollback.py
@@ -7,13 +7,12 @@ created by the Hermes agent's CheckpointManager.  Checkpoints live at
 """
 
 import hashlib
-import json
 import logging
 import os
 import re
 import shutil
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -237,7 +236,7 @@ def get_checkpoint_diff(workspace: str, checkpoint: str) -> dict[str, Any]:
             # File exists in checkpoint but not in workspace (deleted)
             files_changed.append({"file": rel_path, "status": "deleted"})
             diff_lines.append(f"--- a/{rel_path}")
-            diff_lines.append(f"+++ /dev/null")
+            diff_lines.append("+++ /dev/null")
             diff_lines.append("@@ -1,{lines} +0,0 @@".format(lines=len(ckpt_content.splitlines())))
             for line in ckpt_content.splitlines():
                 diff_lines.append(f"-{line}")
@@ -263,6 +262,31 @@ def get_checkpoint_diff(workspace: str, checkpoint: str) -> dict[str, Any]:
     }
 
 
+def _restore_checkpoint_file(workspace_root: Path, ckpt_file: Path, rel_path: str) -> None:
+    """Restore one checkpoint file without following workspace symlinks outward."""
+    from api.workspace import open_anchored_create_fd, open_anchored_write_fd, safe_resolve_ws
+
+    target = safe_resolve_ws(workspace_root, rel_path)
+    if target.exists():
+        fd = open_anchored_write_fd(workspace_root, target)
+    else:
+        fd = open_anchored_create_fd(workspace_root, target)
+
+    src_stat = ckpt_file.stat()
+    with os.fdopen(fd, "wb") as out:
+        with ckpt_file.open("rb") as src:
+            shutil.copyfileobj(src, out)
+        out.flush()
+        try:
+            os.fchmod(out.fileno(), src_stat.st_mode & 0o777)
+        except (AttributeError, OSError):
+            logger.debug("Failed to apply restored mode to %s", target, exc_info=True)
+        try:
+            os.utime(out.fileno(), ns=(src_stat.st_atime_ns, src_stat.st_mtime_ns))
+        except OSError:
+            logger.debug("Failed to apply restored timestamp to %s", target, exc_info=True)
+
+
 def restore_checkpoint(workspace: str, checkpoint: str) -> dict[str, Any]:
     """Restore a checkpoint by copying files back to the workspace.
 
@@ -274,6 +298,7 @@ def restore_checkpoint(workspace: str, checkpoint: str) -> dict[str, Any]:
         files_restored: list of restored file paths
     """
     resolved = _resolve_workspace(workspace)
+    workspace_root = Path(resolved)
     checkpoint = _validate_checkpoint_id(checkpoint)
     ws_hash = _workspace_hash(resolved)
     ckpt_dir = _checkpoint_root() / ws_hash / checkpoint
@@ -297,16 +322,14 @@ def restore_checkpoint(workspace: str, checkpoint: str) -> dict[str, Any]:
 
     for rel_path in ckpt_files:
         ckpt_file = ckpt_dir / rel_path
-        ws_file = Path(resolved) / rel_path
 
         if not ckpt_file.is_file():
             continue
 
         try:
-            ws_file.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(str(ckpt_file), str(ws_file))
+            _restore_checkpoint_file(workspace_root, ckpt_file, rel_path)
             restored.append(rel_path)
-        except OSError as e:
+        except (OSError, ValueError) as e:
             errors.append({"file": rel_path, "error": str(e)})
             logger.warning("Failed to restore %s: %s", rel_path, e)
 

--- a/tests/test_rollback_restore_symlink_containment.py
+++ b/tests/test_rollback_restore_symlink_containment.py
@@ -1,0 +1,83 @@
+import subprocess
+
+from api import rollback
+
+
+def _init_checkpoint_repo(path, files):
+    path.mkdir(parents=True)
+    subprocess.run(["git", "-C", str(path), "init", "-q"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Test"], check=True)
+    for rel_path, content in files.items():
+        target = path / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    subprocess.run(["git", "-C", str(path), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-q", "-m", "checkpoint"], check=True)
+
+
+def test_restore_checkpoint_refuses_symlink_escape(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    outside_target = outside / "target.txt"
+    outside_target.write_text("ORIGINAL")
+    (workspace / "victim.txt").symlink_to(outside_target)
+
+    checkpoint_root = tmp_path / "checkpoints"
+    checkpoint_id = "checkpoint-1"
+    ckpt_dir = checkpoint_root / rollback._workspace_hash(str(workspace.resolve())) / checkpoint_id
+    _init_checkpoint_repo(ckpt_dir, {"victim.txt": "CHECKPOINT_MARKER"})
+
+    monkeypatch.setattr(rollback, "_resolve_workspace", lambda workspace_arg: str(workspace.resolve()))
+    monkeypatch.setattr(rollback, "_checkpoint_root", lambda: checkpoint_root)
+
+    result = rollback.restore_checkpoint(str(workspace), checkpoint_id)
+
+    assert result["ok"] is True
+    assert result["files_restored"] == []
+    assert result["files_restored_count"] == 0
+    assert result["errors"]
+    assert result["errors"][0]["file"] == "victim.txt"
+    assert outside_target.read_text() == "ORIGINAL"
+
+
+def test_restore_checkpoint_restores_regular_file(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "nested").mkdir()
+    (workspace / "nested" / "file.txt").write_text("OLD")
+
+    checkpoint_root = tmp_path / "checkpoints"
+    checkpoint_id = "checkpoint-2"
+    ckpt_dir = checkpoint_root / rollback._workspace_hash(str(workspace.resolve())) / checkpoint_id
+    _init_checkpoint_repo(ckpt_dir, {"nested/file.txt": "NEW"})
+
+    monkeypatch.setattr(rollback, "_resolve_workspace", lambda workspace_arg: str(workspace.resolve()))
+    monkeypatch.setattr(rollback, "_checkpoint_root", lambda: checkpoint_root)
+
+    result = rollback.restore_checkpoint(str(workspace), checkpoint_id)
+
+    assert result["ok"] is True
+    assert result["files_restored"] == ["nested/file.txt"]
+    assert (workspace / "nested" / "file.txt").read_text() == "NEW"
+
+
+def test_restore_checkpoint_creates_missing_regular_file(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    checkpoint_root = tmp_path / "checkpoints"
+    checkpoint_id = "checkpoint-3"
+    ckpt_dir = checkpoint_root / rollback._workspace_hash(str(workspace.resolve())) / checkpoint_id
+    _init_checkpoint_repo(ckpt_dir, {"nested/new-file.txt": "NEW"})
+
+    monkeypatch.setattr(rollback, "_resolve_workspace", lambda workspace_arg: str(workspace.resolve()))
+    monkeypatch.setattr(rollback, "_checkpoint_root", lambda: checkpoint_root)
+
+    result = rollback.restore_checkpoint(str(workspace), checkpoint_id)
+
+    assert result["ok"] is True
+    assert result["files_restored"] == ["nested/new-file.txt"]
+    assert (workspace / "nested" / "new-file.txt").read_text() == "NEW"


### PR DESCRIPTION
## Summary

This PR hardens rollback checkpoint restore writes so restored checkpoint files cannot be redirected outside the selected workspace by symlinks planted inside that workspace.

- Confirms the rollback restore path previously used pathname-based `shutil.copy2()` writes.
- Routes restore writes through the existing workspace-anchored file helpers instead.
- Adds regression coverage for an escaping symlink target and a normal restore path.
- Adds a release-note-ready changelog entry for the behavior change.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Rollback restore follows workspace symlinks | A workspace symlink can redirect restored checkpoint content to a host path outside the workspace during checkpoint restore. | Medium |

## Before this PR

- `restore_checkpoint()` joined each checkpoint path under the workspace and called `shutil.copy2()` on that pathname.
- If the workspace entry was a symlink, the restore followed it and overwrote the symlink target.
- The workspace file API already had symlink-aware anchored helpers, but rollback restore did not use them.
- There was no regression test proving checkpoint restore could not write outside the workspace through a symlink.

## After this PR

- Each restored checkpoint file is resolved through `safe_resolve_ws()` before writing.
- Existing files are opened with `open_anchored_write_fd()` and new files with `open_anchored_create_fd()`.
- Escaping symlink targets are reported as per-file restore errors instead of being overwritten.
- Regression tests cover both the rejected symlink escape and the normal restore behavior.

## Why this matters

Rollback restore is a high-trust workspace mutation path: it takes files from a checkpoint and writes them back into a configured workspace. A malicious or compromised workspace can contain symlinks. If restore follows those symlinks, restoring a checkpoint can mutate files outside the workspace boundary, bypassing the containment guarantees used by the normal workspace file APIs.

## How this differs from related issue/PR

Hermes WebUI already has workspace file API hardening around symlinks and anchored filesystem operations. This PR applies the same containment principle to the separate rollback checkpoint restore path. The vulnerable sink is `api/rollback.py::restore_checkpoint()`, not the ordinary file editor/upload/delete routes.

## Attack flow

```text
attacker controls or influences workspace contents
    -> attacker plants workspace/victim.txt as a symlink to an outside host path
        -> authenticated user restores a checkpoint containing victim.txt
            -> rollback restore follows the symlink during pathname copy
                -> checkpoint content overwrites the outside host path
```

## Affected code

| Issue | Files |
|-------|-------|
| Rollback restore follows workspace symlinks | `api/rollback.py`, `tests/test_rollback_restore_symlink_containment.py` |

## Root cause

Issue: rollback restore follows workspace symlinks

- The restore code built `Path(resolved) / rel_path` and copied to it with `shutil.copy2()`.
- Pathname writes follow symlinks by default, including symlinks whose target is outside the workspace.
- Rollback restore did not share the anchored workspace write helpers used by the rest of the workspace file API.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Rollback restore follows workspace symlinks | 5.0 Medium | `CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:N/I:H/A:N` |

Rationale:

- The attacker needs an admitted local workspace-content position and the restore action requires user interaction.
- The impact is bounded to integrity of host files reachable by the server process when a workspace symlink redirects the restore write.

## Safe reproduction steps

1. Create a temporary workspace and a temporary outside directory.
2. Place a symlink inside the workspace, for example `workspace/victim.txt -> outside/target.txt`.
3. Create a checkpoint repository containing a tracked `victim.txt` file with marker content.
4. Call the real `api.rollback.restore_checkpoint()` function for that workspace and checkpoint.
5. On vulnerable code, observe that the outside target receives the checkpoint marker content.
6. With this PR, observe that restore returns a per-file error and the outside target remains unchanged.

## Expected vulnerable behavior

- The workspace entry remains a symlink.
- The outside target is overwritten with checkpoint content.
- The restore result reports `victim.txt` as restored even though the write escaped the workspace boundary.

## Changes in this PR

- Adds `_restore_checkpoint_file()` to centralize the restore write operation.
- Resolves each checkpoint relative path with `safe_resolve_ws()` before opening it for write.
- Uses `open_anchored_write_fd()` for existing targets and `open_anchored_create_fd()` for new targets.
- Preserves restored file content and best-effort mode/timestamp metadata without returning to symlink-following pathname copies.
- Adds regression tests for rejecting escaping symlink restores and preserving normal restore behavior.
- Adds a changelog entry under `Unreleased`.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Security fix | `api/rollback.py` | Replaces pathname-based restore copies with workspace-anchored writes. |
| Tests | `tests/test_rollback_restore_symlink_containment.py` | Adds symlink-escape and normal-restore regression coverage. |
| Changelog | `CHANGELOG.md` | Notes the rollback restore containment fix. |

## Maintainer impact

- This patch is intentionally limited to rollback checkpoint restore writes.
- It does not change checkpoint listing, diffing, upload handling, or the general workspace file API.
- A workspace symlink that resolves outside the workspace now causes that individual checkpoint file to be skipped with an error instead of being followed.
- Normal checkpoint restore of regular workspace files continues to work.

## Fix rationale

- The workspace boundary should be enforced at the final file-write sink, not only at higher-level route validation.
- The repository already has anchored helpers for this trust boundary, so reusing them keeps rollback restore aligned with existing workspace file API behavior.
- The tests exercise both sides of the intended invariant: escaping symlink writes are blocked, while ordinary restores still succeed.

## Type of change

- [x] Security fix
- [x] Tests
- [x] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Confirmed the new symlink-escape regression test fails on the vulnerable implementation before the fix.
- [x] `./scripts/test.sh tests/test_rollback_restore_symlink_containment.py -q`
- [x] `./scripts/test.sh tests/test_workspace_symlink_containment.py tests/test_routes_file_api_toctou.py tests/test_rollback_restore_symlink_containment.py -q`
- [x] `.venv/bin/ruff check api/rollback.py tests/test_rollback_restore_symlink_containment.py && git diff --check`
- [x] Docker/container focused regression with `python:3.11-slim`, installed Git and test dependencies, then ran `PYTHONPATH=/work pytest tests/test_rollback_restore_symlink_containment.py -q`

Observed results:

```text
2 passed in 0.91s
18 passed, 1 skipped in 2.05s
All checks passed!
2 passed in 0.71s  # Docker/container focused regression
```

## Disclosure notes

- This PR is bounded to rollback checkpoint restore symlink containment.
- It does not claim unauthenticated reachability; the attacker condition is control or influence over workspace contents plus a user-triggered restore.
- No production systems, secrets, or destructive payloads were used in validation.
- No unrelated files are intentionally changed beyond the focused code, tests, and changelog entry.
