### PR TITLE
Release v0.51.488 — QW (rescue state.db user prompts before newer sidecar tail #4216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.488] — 2026-06-18 — Release QW (rescue state.db user prompts that fall before a newer sidecar tail)
+
+### Fixed
+
+- **A user prompt stored only in Hermes `state.db` is no longer dropped when it falls chronologically before a newer sidecar message tail (#4216).** `merge_session_messages_append_only` previously appended state.db-only user prompts after the sidecar tail (or skipped them), so a prompt that belongs earlier in the conversation could be lost or mis-ordered on load. The merge now inserts such a state.db user message at its correct chronological position (with a role-aware tie-break for equal timestamps), preserving the real conversation order. Thanks @dso2ng.
+
 ## [v0.51.487] — 2026-06-18 — Release QX (multi-container Docker: make staged hermes-agent source writable)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -4585,6 +4585,89 @@ def state_db_delta_after_context(sidecar_context: list, state_messages: list) ->
     return state_messages[best_len:]
 
 
+def _insert_state_message_chronologically(messages: list, msg: dict) -> bool:
+    """Insert a state.db-only row before newer sidecar rows when safe.
+
+    Returns False when the only chronological slot would resurrect an old state
+    row before the sidecar/context begins. This keeps no-watermark compression
+    display paths from reintroducing rows that were already compacted out.
+    """
+    timestamp = _message_timestamp_as_float(msg)
+    if timestamp is None:
+        messages.append(msg)
+        return True
+    idx = 0
+    while idx < len(messages):
+        existing = messages[idx]
+        existing_timestamp = _message_timestamp_as_float(existing)
+        should_insert = existing_timestamp is not None and (
+            existing_timestamp > timestamp
+            or (
+                existing_timestamp == timestamp
+                and msg.get("role") == "user"
+                and existing.get("role") == "assistant"
+            )
+        )
+        if not should_insert:
+            idx += 1
+            continue
+        if idx == 0 and existing_timestamp is not None and existing_timestamp > timestamp:
+            # With no surviving sidecar/context row before this slot, a real
+            # interruption rescue is indistinguishable from a compacted-out old
+            # prompt; prefer avoiding no-watermark resurrection in that shape.
+            return False
+        # Advance the insertion point past two kinds of slots that must not be
+        # split, applied to a fixpoint so they compose in any order at an
+        # equal-timestamp collision:
+        #   (a) an assistant(tool_calls) -> tool result block — inserting inside
+        #       it would split the tool call from its result (provider 400 /
+        #       corrupt tool context);
+        #   (b) a slot whose left neighbour shares this message's role at the
+        #       same timestamp — inserting there would re-order an already-matched
+        #       same-role turn (e.g. user, <inserted user>, assistant). The agent
+        #       core merges adjacent users before send, so (b) is benign in
+        #       practice, but advancing keeps the merged transcript correctly
+        #       ordered and alternation-clean regardless.
+        # Looping to a fixpoint guarantees the same-role guard can't strand the
+        # insert back inside a tool-pair (and vice versa).
+        while True:
+            advanced = False
+            # (a) Skip past a complete assistant(tool_calls) -> tool result
+            # block. Advance over ALL contiguous tool rows that belong to the
+            # preceding assistant's tool_calls, not just the first — a multi-tool
+            # turn has several adjacent tool results, and inserting between any of
+            # them splits the block (assistant, tool, <insert>, tool).
+            if (
+                idx < len(messages)
+                and messages[idx].get("role") == "tool"
+                and idx > 0
+                and messages[idx - 1].get("role") == "assistant"
+                and messages[idx - 1].get("tool_calls")
+            ):
+                while idx < len(messages) and messages[idx].get("role") == "tool":
+                    idx += 1
+                    advanced = True
+            # (b) Skip past an equal-timestamp run whose left neighbour shares
+            # this message's role — inserting there would re-order an
+            # already-matched same-role turn (user, <inserted user>, assistant).
+            # The agent core merges adjacent users before send, so this is benign
+            # in practice, but advancing keeps the merged transcript ordered.
+            while (
+                idx < len(messages)
+                and idx > 0
+                and messages[idx - 1].get("role") == msg.get("role")
+                and _message_timestamp_as_float(messages[idx]) == timestamp
+            ):
+                idx += 1
+                advanced = True
+            if not advanced:
+                break
+        messages.insert(idx, msg)
+        return True
+    messages.append(msg)
+    return True
+
+
 def merge_session_messages_append_only(
     sidecar_messages: list,
     state_messages: list,
@@ -4778,6 +4861,13 @@ def merge_session_messages_append_only(
                 else:
                     continue
             else:
+                if msg.get("role") == "user" and _session_message_content_key(msg) not in seen_content_keys:
+                    if _insert_state_message_chronologically(merged_messages, msg):
+                        seen_message_keys.add(key)
+                        seen_dedup_keys.add(dedup_key)
+                        seen_content_keys.add(_session_message_content_key(msg))
+                        seen_visible_keys.add(visible_key)
+                    continue
                 continue
         seen_message_keys.add(key)
         seen_dedup_keys.add(dedup_key)

--- a/tests/test_session_lost_response_regression.py
+++ b/tests/test_session_lost_response_regression.py
@@ -228,6 +228,184 @@ def test_state_db_full_replay_does_not_append_after_sidecar_tail():
     assert merged[-1]["content"] == "opened browser preview"
 
 
+def test_state_db_only_user_prompt_before_sidecar_tail_is_reinserted_chronologically():
+    """A missing state.db-only user prompt must not be hidden by a newer sidecar tail.
+
+    Interruption/restart recovery can persist a newer assistant/error tail in
+    the WebUI sidecar while the user prompt that triggered it only exists in
+    state.db. The append-only reconciliation should preserve that state-backed
+    user turn and place it before the newer sidecar tail instead of treating
+    every state row older than the sidecar tail as replay.
+    """
+    sidecar_messages = [
+        {"role": "user", "content": "old user", "timestamp": 100.0},
+        {"role": "assistant", "content": "old assistant", "timestamp": 101.0},
+        {"role": "assistant", "content": "newer recovery tail", "timestamp": 103.0},
+    ]
+    state_messages = [
+        {"role": "user", "content": "old user", "timestamp": 100.0},
+        {"role": "assistant", "content": "old assistant", "timestamp": 101.0},
+        {"role": "user", "content": "missing prompt", "timestamp": 102.0},
+    ]
+
+    merged = merge_session_messages_append_only(sidecar_messages, state_messages)
+
+    assert [m["content"] for m in merged] == [
+        "old user",
+        "old assistant",
+        "missing prompt",
+        "newer recovery tail",
+    ]
+
+
+def test_state_db_only_user_prompt_equal_timestamp_stays_before_assistant_tail():
+    """Same-timestamp rescued user prompts must not render after the answer."""
+    sidecar_messages = [
+        {"role": "assistant", "content": "answer", "timestamp": 100.0},
+    ]
+    state_messages = [
+        {"role": "user", "content": "the question", "timestamp": 100.0},
+    ]
+
+    merged = merge_session_messages_append_only(sidecar_messages, state_messages)
+
+    assert [m["content"] for m in merged] == ["the question", "answer"]
+
+
+def test_state_db_rescue_same_second_multiturn_keeps_order_no_user_assistant_inversion():
+    """Regression (#4216): when an EARLIER user/assistant turn, a recovery tail,
+    and the rescued state-only prompt all share one timestamp, the rescue must
+    NOT insert the prompt before the earlier assistant (which would produce
+    user, user, assistant — re-ordering the already-answered turn). The rescued
+    prompt belongs after the earlier turn, before the recovery tail."""
+    sidecar_messages = [
+        {"role": "user", "content": "old user", "timestamp": 100.0},
+        {"role": "assistant", "content": "old assistant", "timestamp": 100.0},
+        {"role": "user", "content": "recovery tail", "timestamp": 100.0},
+    ]
+    state_messages = [
+        {"role": "user", "content": "missing prompt", "timestamp": 100.0},
+    ]
+
+    merged = merge_session_messages_append_only(sidecar_messages, state_messages)
+    contents = [m["content"] for m in merged]
+
+    # The rescued prompt lands after the answered turn, not before its assistant.
+    assert contents == ["old user", "old assistant", "missing prompt", "recovery tail"], contents
+    # No user message is inverted ahead of an assistant that already answered it:
+    # 'old assistant' must come before BOTH later user turns.
+    assert contents.index("old assistant") < contents.index("missing prompt")
+    assert contents.index("old assistant") < contents.index("recovery tail")
+
+
+def test_state_db_only_user_prompt_does_not_split_tool_call_and_result_pair():
+    """Chronological rescue must preserve assistant tool_call/tool result adjacency."""
+    sidecar_messages = [
+        {
+            "role": "assistant",
+            "content": "I will inspect it",
+            "timestamp": 100.0,
+            "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "read_file"}}],
+        },
+        {"role": "tool", "content": "tool result", "timestamp": 101.0, "tool_call_id": "call_1"},
+        {"role": "assistant", "content": "final answer", "timestamp": 103.0},
+    ]
+    state_messages = [
+        {"role": "user", "content": "missing prompt", "timestamp": 100.5},
+    ]
+
+    merged = merge_session_messages_append_only(sidecar_messages, state_messages)
+
+    assert [m["content"] for m in merged] == [
+        "I will inspect it",
+        "tool result",
+        "missing prompt",
+        "final answer",
+    ]
+
+
+def test_state_db_rescue_equal_timestamp_does_not_split_tool_call_result_pair():
+    """Regression (#4216): when the rescued prompt and an assistant(tool_calls)
+    -> tool result block share one timestamp, the rescue must NOT land between
+    the tool call and its result (which would corrupt tool context / 400). It
+    belongs after the complete tool pair."""
+    sidecar_messages = [
+        {"role": "user", "content": "u", "timestamp": 100.0},
+        {
+            "role": "assistant",
+            "content": "call",
+            "timestamp": 100.0,
+            "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "f"}}],
+        },
+        {"role": "tool", "content": "res", "timestamp": 100.0, "tool_call_id": "c1"},
+        {"role": "user", "content": "recovery tail", "timestamp": 100.0},
+    ]
+    state_messages = [
+        {"role": "user", "content": "missing", "timestamp": 100.0},
+    ]
+
+    merged = merge_session_messages_append_only(sidecar_messages, state_messages)
+    contents = [m["content"] for m in merged]
+
+    assert contents == ["u", "call", "res", "missing", "recovery tail"], contents
+    # The assistant tool_call is immediately followed by its tool result.
+    roles = [m["role"] for m in merged]
+    ai = roles.index("assistant")
+    assert roles[ai + 1] == "tool", f"tool pair split: {roles}"
+
+
+def test_state_db_rescue_equal_timestamp_does_not_split_multi_tool_result_block():
+    """Regression (#4216): a multi-tool assistant turn (2+ tool_calls -> 2+
+    adjacent tool results) sharing the rescue timestamp must not have the
+    rescued prompt land between the tool results — the whole contiguous tool
+    block stays intact and the prompt lands after it."""
+    sidecar_messages = [
+        {"role": "user", "content": "u", "timestamp": 100.0},
+        {
+            "role": "assistant",
+            "content": "call",
+            "timestamp": 100.0,
+            "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "f"}},
+                {"id": "c2", "type": "function", "function": {"name": "g"}},
+            ],
+        },
+        {"role": "tool", "content": "r1", "timestamp": 100.0, "tool_call_id": "c1"},
+        {"role": "tool", "content": "r2", "timestamp": 100.0, "tool_call_id": "c2"},
+        {"role": "user", "content": "recovery", "timestamp": 100.0},
+    ]
+    state_messages = [
+        {"role": "user", "content": "missing", "timestamp": 100.0},
+    ]
+
+    merged = merge_session_messages_append_only(sidecar_messages, state_messages)
+    roles = [m["role"] for m in merged]
+    contents = [m["content"] for m in merged]
+
+    assert contents == ["u", "call", "r1", "r2", "missing", "recovery"], contents
+    # Both tool results stay contiguous immediately after the assistant.
+    ai = roles.index("assistant")
+    assert roles[ai + 1] == "tool" and roles[ai + 2] == "tool", f"multi-tool block split: {roles}"
+
+
+def test_state_db_only_user_prompt_before_sidecar_start_is_not_resurrected_without_watermark():
+    """No-watermark context/compression reads must not revive old pre-sidecar users."""
+    sidecar_messages = [
+        {"role": "assistant", "content": "compacted summary", "timestamp": 200.0},
+        {"role": "assistant", "content": "current answer", "timestamp": 201.0},
+    ]
+    state_messages = [
+        {"role": "user", "content": "compressed-out old prompt", "timestamp": 100.0},
+    ]
+
+    merged = merge_session_messages_append_only(sidecar_messages, state_messages)
+
+    assert [m["content"] for m in merged] == [
+        "compacted summary",
+        "current answer",
+    ]
+
+
 def test_state_db_middle_segment_replay_does_not_append_after_sidecar_tail():
     """A replayed state.db segment from the middle must not be appended after the tail."""
     sidecar_messages = [


### PR DESCRIPTION
## Release v0.51.488 — QW (rescue state.db user prompts that fall before a newer sidecar tail)

Single fix-class PR on `merge_session_messages_append_only` (the most display- and model-facing function in the repo). Full authoritative gate green after a thorough multi-round hardening of the equal-timestamp edge cases.

### Included
- **#4216** (@dso2ng, fixes #4216) — *insert state.db-only user prompts chronologically.* A user prompt that exists only in Hermes `state.db` (no sidecar copy) and falls chronologically before a newer sidecar message tail was being appended after the tail (or skipped) — losing or mis-ordering it on load. The merge now inserts it at its correct chronological position via `_insert_state_message_chronologically`. Append-only invariant + `seen_content_keys` dedup preserved.

### Maintainer hardening on absorb (3 equal-timestamp edge cases the gate surfaced)
The insertion-point advance is now a **fixpoint loop** that composes two skips in any order so none can strand the insert into a bad slot:
- **(a) block-aware tool skip** — advances past the *entire* contiguous `tool` result block of a preceding `assistant(tool_calls)`, so a multi-tool turn (2+ tool results) can't be split (`assistant, tool, <insert>, tool`).
- **(b) same-role guard** — never inserts at a slot whose left neighbour shares the message's role at the same timestamp, so an already-answered earlier turn can't be re-ordered into `user, <inserted user>, assistant`.

3 new equal-timestamp regression tests (same-second multiturn, single tool-pair, multi-tool block), all toothless-checked (RED without the fix).

### Gate
- **Codex:** the chronological insert path is monotonic; targeted reconciliation suite 71 passed. (The one transient "BRICK" flag was a stale-base phantom — #4398's docker chmod merged to master after this stage was cut; resolved by rebase. #4216 does not touch `docker_init.bash`.)
- **Opus:** SHIP IT — append-only/alternation safe, dedup intact, prompt-cache no-op on healthy sessions, strictly better than master (which dropped the prompt outright); not O(n²) in any realistic path.
- **Full suite:** 9401 passed, 0 failed. Ruff clean. revert-guard: origin/master ancestor of HEAD.

Attribution preserved via `Co-authored-by`.

Closes #4216.