### PR TITLE
fix: seed _PROVIDER_MODELS from hermes_cli at startup to prevent stale model catalogs

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -918,6 +918,7 @@ _FALLBACK_MODELS = [
     {"provider": "MiniMax",   "id": "minimax/MiniMax-M2.7",             "label": "MiniMax M2.7"},
     {"provider": "MiniMax",   "id": "minimax/MiniMax-M2.7-highspeed",   "label": "MiniMax M2.7 Highspeed"},
     # Z.AI / GLM
+    {"provider": "Z.AI",      "id": "zai/glm-5.2",                      "label": "GLM-5.2"},
     {"provider": "Z.AI",      "id": "zai/glm-5.1",                      "label": "GLM-5.1"},
     {"provider": "Z.AI",      "id": "zai/glm-5",                        "label": "GLM-5"},
     {"provider": "Z.AI",      "id": "zai/glm-5-turbo",                  "label": "GLM-5 Turbo"},
@@ -1427,6 +1428,7 @@ _PROVIDER_MODELS = {
         {"id": "@nous:google/gemini-3.1-pro-preview", "label": "Gemini 3.1 Pro Preview (via Nous)"},
     ],
     "zai": [
+        {"id": "glm-5.2", "label": "GLM-5.2"},
         {"id": "glm-5.1", "label": "GLM-5.1"},
         {"id": "glm-5", "label": "GLM-5"},
         {"id": "glm-5-turbo", "label": "GLM-5 Turbo"},
@@ -1577,6 +1579,62 @@ _PROVIDER_MODELS = {
         {"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",  "label": "Global Anthropic Claude Haiku 4.5"},
     ],
 }
+
+
+def _seed_provider_models_from_core() -> None:
+    """Merge models from hermes_cli.models._PROVIDER_MODELS into the WebUI catalog.
+
+    The core's _PROVIDER_MODELS is the authoritative curated list of agent-capable
+    models per provider.  The WebUI's static dict above is a display-oriented copy
+    (with {id, label} entries) that can go stale when new models are added to the
+    core without a matching WebUI update.  This function bridges the gap by
+    injecting any missing model IDs from the core at startup.
+
+    Safe to call multiple times; only missing entries are added.  Silently no-ops
+    if hermes_cli is not importable (standalone WebUI deployments).
+    """
+    try:
+        from hermes_cli.models import _PROVIDER_MODELS as _core_pm
+    except Exception:
+        return
+
+    for provider_id, core_models in _core_pm.items():
+        if not isinstance(core_models, list):
+            continue
+        webui_list = _PROVIDER_MODELS.get(provider_id)
+        if webui_list is None:
+            # Provider exists in core but not in WebUI — seed the full list.
+            _PROVIDER_MODELS[provider_id] = [
+                {"id": mid, "label": _get_label_for_model(mid, [])}
+                for mid in core_models
+                if isinstance(mid, str) and mid.strip()
+            ]
+            continue
+        if not isinstance(webui_list, list):
+            continue
+        # Provider exists in both — inject missing model IDs.
+        existing_ids = {
+            (m.get("id") if isinstance(m, dict) else str(m)).replace("-", ".").lower()
+            for m in webui_list
+            if isinstance(m, dict) and m.get("id")
+        }
+        for mid in core_models:
+            if not isinstance(mid, str) or not mid.strip():
+                continue
+            normed = mid.strip().replace("-", ".").lower()
+            if normed not in existing_ids:
+                webui_list.append({
+                    "id": mid.strip(),
+                    "label": _get_label_for_model(mid.strip(), []),
+                })
+
+
+# Run once at import time so every consumer (resolve_model_provider, the model
+# picker, session creation) sees the merged catalog immediately.
+try:
+    _seed_provider_models_from_core()
+except Exception:
+    pass  # Defensive: never block module load over a seeding failure
 
 
 _AMBIENT_GH_CLI_MARKERS = frozenset({"gh_cli", "gh auth token"})

--- a/api/config.py
+++ b/api/config.py
@@ -4949,19 +4949,6 @@ def _get_label_for_model(model_id: str, existing_groups: list) -> str:
     )
 
 
-# Run the seeder once at import time, AFTER _get_label_for_model is defined.
-# Must be placed here (not at the top of the module near the seeder's def)
-# because the seeder calls _get_label_for_model, which is defined just above.
-# Moving the call earlier causes a NameError that the bare except silently
-# swallows — exactly when the seeder has real work to do (#4413).
-try:
-    _seed_provider_models_from_core()
-except ImportError:
-    pass  # hermes_cli not available (standalone deployment)
-except Exception:
-    logger.warning("provider-model seeder failed", exc_info=True)
-
-
 def _read_live_provider_model_ids(provider_id: str) -> list[str]:
     """Return live model IDs from Hermes CLI for a provider, or [] on failure.
 
@@ -7524,3 +7511,16 @@ try:
     init_profile_state()
 except ImportError:
     pass  # hermes_cli not available -- default profile only
+
+
+# Run the provider-model seeder once at import time. Must be at the END of the
+# module because _seed_provider_models_from_core() calls _get_label_for_model,
+# which is defined ~3000 lines above. Placing the invocation earlier (e.g. right
+# after the seeder's def) caused a NameError that the bare except silently
+# swallowed — exactly when the seeder had real work to do (#4413).
+try:
+    _seed_provider_models_from_core()
+except ImportError:
+    pass  # hermes_cli not available (standalone deployment)
+except Exception:
+    logger.warning("provider-model seeder failed", exc_info=True)

--- a/api/config.py
+++ b/api/config.py
@@ -1592,16 +1592,43 @@ def _seed_provider_models_from_core() -> None:
 
     Safe to call multiple times; only missing entries are added.  Silently no-ops
     if hermes_cli is not importable (standalone WebUI deployments).
+
+    Must be called AFTER ``_get_label_for_model`` is defined (module-level
+    invocation is at the bottom of this module, not here).
     """
     try:
         from hermes_cli.models import _PROVIDER_MODELS as _core_pm
-    except Exception:
+    except ImportError:
         return
+
+    # Build a canonical-id → WebUI-key lookup so that providers whose canonical
+    # form differs between core and WebUI (e.g. core uses "xai" but WebUI
+    # indexes by "x-ai") merge into the existing entry instead of creating a
+    # duplicate (#4413).
+    _webui_key_by_canonical: dict[str, str] = {}
+    for _wk in _PROVIDER_MODELS:
+        try:
+            _canon = _resolve_provider_alias(_wk)
+        except Exception:
+            _canon = _wk
+        if _canon not in _webui_key_by_canonical:
+            _webui_key_by_canonical[_canon] = _wk
 
     for provider_id, core_models in _core_pm.items():
         if not isinstance(core_models, list):
             continue
+
+        # Resolve the core's provider_id to the WebUI's key for this provider.
+        webui_key = provider_id
         webui_list = _PROVIDER_MODELS.get(provider_id)
+        if webui_list is None:
+            try:
+                _canon_pid = _resolve_provider_alias(provider_id)
+            except Exception:
+                _canon_pid = provider_id
+            webui_key = _webui_key_by_canonical.get(_canon_pid, provider_id)
+            webui_list = _PROVIDER_MODELS.get(webui_key)
+
         if webui_list is None:
             # Provider exists in core but not in WebUI — seed the full list.
             _PROVIDER_MODELS[provider_id] = [
@@ -1627,14 +1654,6 @@ def _seed_provider_models_from_core() -> None:
                     "id": mid.strip(),
                     "label": _get_label_for_model(mid.strip(), []),
                 })
-
-
-# Run once at import time so every consumer (resolve_model_provider, the model
-# picker, session creation) sees the merged catalog immediately.
-try:
-    _seed_provider_models_from_core()
-except Exception:
-    pass  # Defensive: never block module load over a seeding failure
 
 
 _AMBIENT_GH_CLI_MARKERS = frozenset({"gh_cli", "gh auth token"})
@@ -4928,6 +4947,19 @@ def _get_label_for_model(model_id: str, existing_groups: list) -> str:
         w.upper() if (len(w) <= 3 and w.replace(".", "").isalnum() and not w.isdigit()) else w.capitalize()
         for w in bare.replace("_", "-").split("-")
     )
+
+
+# Run the seeder once at import time, AFTER _get_label_for_model is defined.
+# Must be placed here (not at the top of the module near the seeder's def)
+# because the seeder calls _get_label_for_model, which is defined just above.
+# Moving the call earlier causes a NameError that the bare except silently
+# swallows — exactly when the seeder has real work to do (#4413).
+try:
+    _seed_provider_models_from_core()
+except ImportError:
+    pass  # hermes_cli not available (standalone deployment)
+except Exception:
+    logger.warning("provider-model seeder failed", exc_info=True)
 
 
 def _read_live_provider_model_ids(provider_id: str) -> list[str]:

--- a/api/config.py
+++ b/api/config.py
@@ -1582,13 +1582,18 @@ _PROVIDER_MODELS = {
 
 
 def _seed_provider_models_from_core() -> None:
-    """Merge models from hermes_cli.models._PROVIDER_MODELS into the WebUI catalog.
+    """Enrich existing provider model lists with missing IDs from hermes_cli.
 
     The core's _PROVIDER_MODELS is the authoritative curated list of agent-capable
     models per provider.  The WebUI's static dict above is a display-oriented copy
     (with {id, label} entries) that can go stale when new models are added to the
     core without a matching WebUI update.  This function bridges the gap by
-    injecting any missing model IDs from the core at startup.
+    injecting any missing model IDs from the core into **existing** WebUI provider
+    entries.
+
+    Constrains seeding to providers already in the WebUI catalog — does NOT add
+    brand-new providers.  Adding new vendors is a maintainer curation decision.
+    Respects per-provider ID conventions (e.g. nous uses @nous:-prefixed IDs).
 
     Safe to call multiple times; only missing entries are added.  Silently no-ops
     if hermes_cli is not importable (standalone WebUI deployments).
@@ -1630,28 +1635,42 @@ def _seed_provider_models_from_core() -> None:
             webui_list = _PROVIDER_MODELS.get(webui_key)
 
         if webui_list is None:
-            # Provider exists in core but not in WebUI — seed the full list.
-            _PROVIDER_MODELS[provider_id] = [
-                {"id": mid, "label": _get_label_for_model(mid, [])}
-                for mid in core_models
-                if isinstance(mid, str) and mid.strip()
-            ]
+            # Provider exists in core but not in the WebUI catalog.
+            # Do NOT seed — adding new vendors is a maintainer curation
+            # decision, not something the seeder should do implicitly (#4413).
             continue
         if not isinstance(webui_list, list):
             continue
         # Provider exists in both — inject missing model IDs.
-        existing_ids = {
-            (m.get("id") if isinstance(m, dict) else str(m)).replace("-", ".").lower()
+        # Detect per-provider ID prefix convention (e.g. nous uses @nous:).
+        # The merge must respect each provider's existing ID format rather
+        # than injecting the core's raw IDs (#4413).
+        _existing_ids_raw: list[str] = [
+            (m.get("id") if isinstance(m, dict) else str(m)) or ""
             for m in webui_list
             if isinstance(m, dict) and m.get("id")
+        ]
+        _prefix = ""
+        if _existing_ids_raw and all(i.startswith("@") and ":" in i for i in _existing_ids_raw):
+            _prefix = _existing_ids_raw[0].split(":", 1)[0] + ":"
+
+        def _strip_prefix(mid: str, prefix: str = _prefix) -> str:
+            if prefix and mid.startswith(prefix):
+                return mid[len(prefix):]
+            return mid
+
+        existing_ids = {
+            _strip_prefix(mid).replace("-", ".").lower()
+            for mid in _existing_ids_raw
         }
         for mid in core_models:
             if not isinstance(mid, str) or not mid.strip():
                 continue
             normed = mid.strip().replace("-", ".").lower()
             if normed not in existing_ids:
+                inject_id = (_prefix + mid.strip()) if _prefix else mid.strip()
                 webui_list.append({
-                    "id": mid.strip(),
+                    "id": inject_id,
                     "label": _get_label_for_model(mid.strip(), []),
                 })
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1503,7 +1503,7 @@ _PROVIDER_ALIASES = {
 # returns [] for a provider (#871).  Kept at module level so the dict is
 # built once, not reconstructed per request.
 _OPENAI_COMPAT_ENDPOINTS = {
-    "zai": "https://api.z.ai/v1",
+    "zai": "https://api.z.ai/api/paas/v4",
     "minimax": "https://api.minimax.chat/v1",
     "mistralai": "https://api.mistral.ai/v1",
     "xai": "https://api.x.ai/v1",
@@ -13396,7 +13396,7 @@ def _handle_live_models(handler, parsed):
     - openai-codex: Codex OAuth endpoint + local ~/.codex/ cache fallback
     - Nous: live fetch from inference-api.nousresearch.com/v1/models
     - DeepSeek, kimi-coding, opencode-zen/go, custom: generic OpenAI-compat /v1/models
-    - ZAI, MiniMax, Google/Gemini: fall back to static list (non-standard endpoints)
+    - ZAI, MiniMax, xAI, Google/Gemini: OpenAI-compat /models (via configured base_url or _OPENAI_COMPAT_ENDPOINTS)
     - All others: static _PROVIDER_MODELS fallback
 
     The agent already maintains all provider-specific auth and endpoint logic
@@ -13613,7 +13613,36 @@ def _handle_live_models(handler, parsed):
         #  (b) the frontend shows the static list immediately and enriches in
         #      the background via _fetchLiveModels(), so the user never waits.
         if not ids:
-            _ep = _OPENAI_COMPAT_ENDPOINTS.get(provider)
+            import urllib.request
+            _providers_cfg = cfg.get("providers", {})
+            _prov = _providers_cfg.get(provider, {}) if isinstance(_providers_cfg, dict) else {}
+
+            # Prefer the provider's configured base_url over the hardcoded
+            # _OPENAI_COMPAT_ENDPOINTS table.  The configured URL reflects the
+            # actual plan/endpoint the user subscribed to (e.g. ZAI's coding
+            # plan uses /api/coding/paas/v4 while PAYG uses /api/paas/v4),
+            # whereas the hardcoded table may point to a non-existent path
+            # and silently 404 (#4413).
+            _ep = None
+            if isinstance(_prov, dict):
+                _ep = (_prov.get("base_url") or "").strip().rstrip("/")
+            if not _ep:
+                # Check custom_providers for a matching name (normalised).
+                for _cp in (cfg.get("custom_providers") or []):
+                    if isinstance(_cp, dict):
+                        _cp_name = (_cp.get("name") or "").strip().lower().replace(".", "")
+                        if _cp_name == provider:
+                            _ep = (_cp.get("base_url") or "").strip().rstrip("/")
+                            break
+            if not _ep:
+                # Check top-level model config if provider matches.
+                _mc = cfg.get("model", {})
+                if isinstance(_mc, dict) and (_mc.get("provider") or "").strip().lower() == provider:
+                    _ep = (_mc.get("base_url") or "").strip().rstrip("/")
+            # Fall back to hardcoded endpoint table.
+            if not _ep:
+                _ep = _OPENAI_COMPAT_ENDPOINTS.get(provider)
+
             if _ep:
                 try:
                     import urllib.request
@@ -13640,7 +13669,7 @@ def _handle_live_models(handler, parsed):
                         with urllib.request.urlopen(_req, timeout=8) as _resp:
                             _body = json.loads(_resp.read())
                         ids = [m.get("id", "") for m in _body.get("data", []) if m.get("id")]
-                        logger.debug("Live-fetched %d models from %s /v1/models", len(ids), provider)
+                        logger.debug("Live-fetched %d models from %s /models", len(ids), provider)
                 except Exception as _fetch_err:
                     logger.debug("Live fetch from %s failed: %s", provider, _fetch_err)
                     # Fall through to static list below

--- a/api/routes.py
+++ b/api/routes.py
@@ -1503,7 +1503,7 @@ _PROVIDER_ALIASES = {
 # returns [] for a provider (#871).  Kept at module level so the dict is
 # built once, not reconstructed per request.
 _OPENAI_COMPAT_ENDPOINTS = {
-    "zai": "https://api.z.ai/api/paas/v4",
+    "zai": "https://api.z.ai/v1",
     "minimax": "https://api.minimax.chat/v1",
     "mistralai": "https://api.mistral.ai/v1",
     "xai": "https://api.x.ai/v1",
@@ -13396,7 +13396,7 @@ def _handle_live_models(handler, parsed):
     - openai-codex: Codex OAuth endpoint + local ~/.codex/ cache fallback
     - Nous: live fetch from inference-api.nousresearch.com/v1/models
     - DeepSeek, kimi-coding, opencode-zen/go, custom: generic OpenAI-compat /v1/models
-    - ZAI, MiniMax, xAI, Google/Gemini: OpenAI-compat /models (via configured base_url or _OPENAI_COMPAT_ENDPOINTS)
+    - ZAI, MiniMax, Google/Gemini: fall back to static list (non-standard endpoints)
     - All others: static _PROVIDER_MODELS fallback
 
     The agent already maintains all provider-specific auth and endpoint logic
@@ -13613,36 +13613,7 @@ def _handle_live_models(handler, parsed):
         #  (b) the frontend shows the static list immediately and enriches in
         #      the background via _fetchLiveModels(), so the user never waits.
         if not ids:
-            import urllib.request
-            _providers_cfg = cfg.get("providers", {})
-            _prov = _providers_cfg.get(provider, {}) if isinstance(_providers_cfg, dict) else {}
-
-            # Prefer the provider's configured base_url over the hardcoded
-            # _OPENAI_COMPAT_ENDPOINTS table.  The configured URL reflects the
-            # actual plan/endpoint the user subscribed to (e.g. ZAI's coding
-            # plan uses /api/coding/paas/v4 while PAYG uses /api/paas/v4),
-            # whereas the hardcoded table may point to a non-existent path
-            # and silently 404 (#4413).
-            _ep = None
-            if isinstance(_prov, dict):
-                _ep = (_prov.get("base_url") or "").strip().rstrip("/")
-            if not _ep:
-                # Check custom_providers for a matching name (normalised).
-                for _cp in (cfg.get("custom_providers") or []):
-                    if isinstance(_cp, dict):
-                        _cp_name = (_cp.get("name") or "").strip().lower().replace(".", "")
-                        if _cp_name == provider:
-                            _ep = (_cp.get("base_url") or "").strip().rstrip("/")
-                            break
-            if not _ep:
-                # Check top-level model config if provider matches.
-                _mc = cfg.get("model", {})
-                if isinstance(_mc, dict) and (_mc.get("provider") or "").strip().lower() == provider:
-                    _ep = (_mc.get("base_url") or "").strip().rstrip("/")
-            # Fall back to hardcoded endpoint table.
-            if not _ep:
-                _ep = _OPENAI_COMPAT_ENDPOINTS.get(provider)
-
+            _ep = _OPENAI_COMPAT_ENDPOINTS.get(provider)
             if _ep:
                 try:
                     import urllib.request
@@ -13669,7 +13640,7 @@ def _handle_live_models(handler, parsed):
                         with urllib.request.urlopen(_req, timeout=8) as _resp:
                             _body = json.loads(_resp.read())
                         ids = [m.get("id", "") for m in _body.get("data", []) if m.get("id")]
-                        logger.debug("Live-fetched %d models from %s /models", len(ids), provider)
+                        logger.debug("Live-fetched %d models from %s /v1/models", len(ids), provider)
                 except Exception as _fetch_err:
                     logger.debug("Live fetch from %s failed: %s", provider, _fetch_err)
                     # Fall through to static list below

--- a/tests/test_4413_seed_provider_models.py
+++ b/tests/test_4413_seed_provider_models.py
@@ -142,15 +142,19 @@ class TestAliasedProviderMerge:
             "provider alias was not resolved before .get()"
         )
 
-    def test_unknown_provider_seeds_new_entry(self, restore_providers):
-        """A provider in core but not in WebUI at all should be seeded."""
+    def test_unknown_provider_not_seeded(self, restore_providers):
+        """A provider in core but not in WebUI must NOT be seeded.
+
+        Adding new vendors is a maintainer curation decision, not something
+        the seeder should do implicitly (#4413 review)."""
         fake_pm = {"totally-new-provider": ["model-alpha"]}
         with _patch_core_pm(fake_pm):
             _seed_provider_models_from_core()
 
-        assert "totally-new-provider" in _PROVIDER_MODELS
-        ids = [m["id"] for m in _PROVIDER_MODELS["totally-new-provider"]]
-        assert "model-alpha" in ids
+        assert "totally-new-provider" not in _PROVIDER_MODELS, (
+            "Seeder must not inject brand-new providers — only enrich existing ones. "
+            "Adding vendors is a maintainer curation decision (#4413)."
+        )
 
 
 # ── Test 3: exception narrowing ─────────────────────────────────────────────
@@ -174,32 +178,3 @@ class TestExceptionNarrowing:
                     _seed_provider_models_from_core()
 
 
-# ── Test 4: live models endpoint uses configured base_url ────────────────────
-
-class TestLiveModelsBaseUrlPreference:
-    """The live models probe should prefer the configured base_url over the
-    hardcoded _OPENAI_COMPAT_ENDPOINTS table (#4413)."""
-
-    def test_openai_compat_endpoints_zai_url_is_valid(self):
-        """The hardcoded ZAI fallback URL must not be the old broken /v1 path."""
-        # Read source directly to avoid importing routes.py (heavy deps).
-        routes_src = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
-        # Extract the zai line from _OPENAI_COMPAT_ENDPOINTS
-        import re
-        m = re.search(r'"zai":\s*"(https?://[^"]+)"', routes_src)
-        assert m, "Could not find 'zai' entry in _OPENAI_COMPAT_ENDPOINTS"
-        zai_url = m.group(1)
-        # Must NOT end with /v1 (the old broken endpoint that 404s)
-        assert not zai_url.rstrip("/").endswith("/v1"), (
-            f"ZAI endpoint still uses the broken /v1 suffix: {zai_url}"
-        )
-        assert "api.z.ai" in zai_url
-
-    def test_live_models_code_prefers_base_url(self):
-        """Verify the live-fetch code in routes.py checks configured base_url
-        before falling back to _OPENAI_COMPAT_ENDPOINTS."""
-        routes_src = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
-        # The new code must reference providers config base_url
-        assert "base_url" in routes_src, "routes.py lost base_url reference"
-        # Must still have the fallback table
-        assert "_OPENAI_COMPAT_ENDPOINTS" in routes_src

--- a/tests/test_4413_seed_provider_models.py
+++ b/tests/test_4413_seed_provider_models.py
@@ -1,0 +1,206 @@
+"""Regression tests for #4413 — provider-model seeder from hermes_cli.
+
+Covers three defects identified in PR review:
+
+1.  **NameError at import time** — the seeder called ``_get_label_for_model``
+    before it was defined, so the bare ``except Exception: pass`` swallowed the
+    error exactly when the seeder had real work to do.
+
+2.  **Provider alias mismatch** — the core uses canonical IDs (``xai``) while
+    the WebUI indexes by display IDs (``x-ai``).  Without alias resolution the
+    seeder created a duplicate provider entry instead of merging.
+
+3.  **Live models endpoint** — ``_OPENAI_COMPAT_ENDPOINTS`` had the wrong ZAI
+    URL (``/v1`` instead of ``/api/paas/v4``), and the live probe didn't prefer
+    the provider's configured ``base_url``.
+"""
+import pathlib
+import sys
+import unittest.mock as mock
+
+import pytest
+
+REPO = pathlib.Path(__file__).parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO.parent / ".hermes" / "hermes-agent"))
+
+from api.config import (
+    _PROVIDER_MODELS,
+    _seed_provider_models_from_core,
+    _get_label_for_model,
+    _resolve_provider_alias,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _deepcopy_providers():
+    """Snapshot _PROVIDER_MODELS so tests can mutate freely and restore after."""
+    return {k: list(v) for k, v in _PROVIDER_MODELS.items()}
+
+
+@pytest.fixture
+def restore_providers():
+    """Restore _PROVIDER_MODELS to its pre-test state."""
+    snapshot = _deepcopy_providers()
+    yield
+    _PROVIDER_MODELS.clear()
+    _PROVIDER_MODELS.update(snapshot)
+
+
+def _patch_core_pm(fake_pm: dict):
+    """Patch ``hermes_cli.models._PROVIDER_MODELS`` with *fake_pm*."""
+    # Build a fake hermes_cli.models module with just _PROVIDER_MODELS.
+    fake_module = mock.MagicMock()
+    fake_module._PROVIDER_MODELS = fake_pm
+    return mock.patch.dict(sys.modules, {"hermes_cli.models": fake_module})
+
+
+# ── Test 1: seeder actually adds missing models (catches NameError) ──────────
+
+class TestSeederAddsMissingModels:
+    """The seeder must add models that exist in core but not in WebUI.
+
+    Before the fix, ``_get_label_for_model`` wasn't bound at call time, so the
+    seeder raised ``NameError`` and the bare ``except Exception: pass`` swallowed
+    it.  This test would have caught that bug.
+    """
+
+    def test_missing_model_is_added(self, restore_providers):
+        """A model in core but not in WebUI should appear after seeding."""
+        fake_pm = {"zai": ["glm-9.99-experimental"]}
+        with _patch_core_pm(fake_pm):
+            _seed_provider_models_from_core()
+
+        zai_ids = [m["id"] for m in _PROVIDER_MODELS.get("zai", [])]
+        assert "glm-9.99-experimental" in zai_ids, (
+            "Seeder did not add glm-9.99-experimental — likely a NameError "
+            "on _get_label_for_model at call time"
+        )
+
+    def test_added_model_has_label(self, restore_providers):
+        """Seeded entries must have a human-readable label, not just an ID."""
+        fake_pm = {"zai": ["glm-9.99-experimental"]}
+        with _patch_core_pm(fake_pm):
+            _seed_provider_models_from_core()
+
+        zai_entries = {m["id"]: m for m in _PROVIDER_MODELS.get("zai", [])}
+        assert "glm-9.99-experimental" in zai_entries
+        label = zai_entries["glm-9.99-experimental"]["label"]
+        assert isinstance(label, str) and label.strip(), (
+            f"Label for seeded model is empty/missing: {label!r}"
+        )
+
+    def test_existing_model_not_duplicated(self, restore_providers):
+        """A model that already exists should not be added a second time."""
+        fake_pm = {"zai": ["glm-5.2"]}
+        with _patch_core_pm(fake_pm):
+            _seed_provider_models_from_core()
+
+        zai_ids = [m["id"] for m in _PROVIDER_MODELS.get("zai", [])]
+        assert zai_ids.count("glm-5.2") == 1, (
+            f"glm-5.2 appears {zai_ids.count('glm-5.2')} times — should be 1"
+        )
+
+    def test_no_op_without_hermes_cli(self, restore_providers):
+        """Seeder must be a no-op (not raise) when hermes_cli is unavailable."""
+        with mock.patch.dict(sys.modules, {"hermes_cli.models": None}):
+            # Should silently return without error
+            _seed_provider_models_from_core()
+
+
+# ── Test 2: aliased provider merges instead of duplicating ───────────────────
+
+class TestAliasedProviderMerge:
+    """Providers whose canonical ID differs between core and WebUI must merge.
+
+    The core uses ``"xai"`` while the WebUI indexes by ``"x-ai"``.  Without
+    alias resolution the seeder creates a duplicate ``"xai"`` entry.
+    """
+
+    def test_xai_merges_into_x_hyphen_ai(self, restore_providers):
+        """Core's 'xai' should merge into WebUI's 'x-ai', not create 'xai'."""
+        # Verify the alias exists in the first place
+        assert _resolve_provider_alias("x-ai") == "xai", (
+            "Expected _resolve_provider_alias('x-ai') == 'xai'"
+        )
+
+        fake_pm = {"xai": ["grok-99-test"]}
+        with _patch_core_pm(fake_pm):
+            _seed_provider_models_from_core()
+
+        # The new model should be under "x-ai" (WebUI's key)
+        x_hyphen_ai_ids = [m["id"] for m in _PROVIDER_MODELS.get("x-ai", [])]
+        assert "grok-99-test" in x_hyphen_ai_ids, (
+            "grok-99-test was not added to 'x-ai' — alias resolution failed"
+        )
+
+        # No duplicate "xai" key should have been created
+        assert "xai" not in _PROVIDER_MODELS or all(
+            m["id"] != "grok-99-test" for m in _PROVIDER_MODELS.get("xai", [])
+        ), (
+            "A duplicate 'xai' key was created with grok-99-test — "
+            "provider alias was not resolved before .get()"
+        )
+
+    def test_unknown_provider_seeds_new_entry(self, restore_providers):
+        """A provider in core but not in WebUI at all should be seeded."""
+        fake_pm = {"totally-new-provider": ["model-alpha"]}
+        with _patch_core_pm(fake_pm):
+            _seed_provider_models_from_core()
+
+        assert "totally-new-provider" in _PROVIDER_MODELS
+        ids = [m["id"] for m in _PROVIDER_MODELS["totally-new-provider"]]
+        assert "model-alpha" in ids
+
+
+# ── Test 3: exception narrowing ─────────────────────────────────────────────
+
+class TestExceptionNarrowing:
+    """The seeder's hermes_cli import should only catch ImportError, not all
+    exceptions (which would hide real bugs like the NameError)."""
+
+    def test_does_not_swallow_runtime_errors(self, restore_providers):
+        """If _get_label_for_model raises, the error should propagate (not be
+        silently swallowed by a bare except)."""
+        fake_pm = {"zai": ["boom-model"]}
+        with _patch_core_pm(fake_pm):
+            with mock.patch(
+                "api.config._get_label_for_model",
+                side_effect=RuntimeError("deliberate failure"),
+            ):
+                # The seeder itself should NOT catch RuntimeError — it only
+                # catches ImportError for the optional hermes_cli import.
+                with pytest.raises(RuntimeError, match="deliberate failure"):
+                    _seed_provider_models_from_core()
+
+
+# ── Test 4: live models endpoint uses configured base_url ────────────────────
+
+class TestLiveModelsBaseUrlPreference:
+    """The live models probe should prefer the configured base_url over the
+    hardcoded _OPENAI_COMPAT_ENDPOINTS table (#4413)."""
+
+    def test_openai_compat_endpoints_zai_url_is_valid(self):
+        """The hardcoded ZAI fallback URL must not be the old broken /v1 path."""
+        # Read source directly to avoid importing routes.py (heavy deps).
+        routes_src = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
+        # Extract the zai line from _OPENAI_COMPAT_ENDPOINTS
+        import re
+        m = re.search(r'"zai":\s*"(https?://[^"]+)"', routes_src)
+        assert m, "Could not find 'zai' entry in _OPENAI_COMPAT_ENDPOINTS"
+        zai_url = m.group(1)
+        # Must NOT end with /v1 (the old broken endpoint that 404s)
+        assert not zai_url.rstrip("/").endswith("/v1"), (
+            f"ZAI endpoint still uses the broken /v1 suffix: {zai_url}"
+        )
+        assert "api.z.ai" in zai_url
+
+    def test_live_models_code_prefers_base_url(self):
+        """Verify the live-fetch code in routes.py checks configured base_url
+        before falling back to _OPENAI_COMPAT_ENDPOINTS."""
+        routes_src = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
+        # The new code must reference providers config base_url
+        assert "base_url" in routes_src, "routes.py lost base_url reference"
+        # Must still have the fallback table
+        assert "_OPENAI_COMPAT_ENDPOINTS" in routes_src

--- a/tests/test_4413_seed_provider_models.py
+++ b/tests/test_4413_seed_provider_models.py
@@ -27,7 +27,6 @@ sys.path.insert(0, str(REPO.parent / ".hermes" / "hermes-agent"))
 from api.config import (
     _PROVIDER_MODELS,
     _seed_provider_models_from_core,
-    _get_label_for_model,
     _resolve_provider_alias,
 )
 

--- a/tests/test_issue1538_nous_live_catalog.py
+++ b/tests/test_issue1538_nous_live_catalog.py
@@ -243,10 +243,23 @@ class TestNousStaticFallback:
                 "branch should fall back to the curated static list."
             )
             models = nous_groups[0]["models"]
-            assert len(models) == 4, (
-                f"Static fallback should expose exactly the four curated entries "
-                f"in _PROVIDER_MODELS['nous']. Got {len(models)}: "
-                f"{[m['id'] for m in models]}"
+            # The seeder enriches nous with models from hermes_cli at import
+            # time, so the list may have more than the 4 curated entries.
+            # Assert the original curated IDs are present as a subset, and
+            # every ID still carries the @nous: prefix invariant.
+            _curated_ids = {
+                "@nous:anthropic/claude-opus-4.6",
+                "@nous:anthropic/claude-sonnet-4.6",
+                "@nous:openai/gpt-5.4-mini",
+                "@nous:google/gemini-3.1-pro-preview",
+            }
+            _actual_ids = {m["id"] for m in models}
+            assert _curated_ids.issubset(_actual_ids), (
+                f"Curated nous entries missing. Got: {sorted(_actual_ids)}"
+            )
+            assert len(models) >= 4, (
+                f"Static fallback should expose at least the four curated "
+                f"entries. Got {len(models)}: {sorted(_actual_ids)}"
             )
             for m in models:
                 assert m["id"].startswith("@nous:"), m["id"]

--- a/tests/test_issue1567_nous_picker_capacity_and_symmetry.py
+++ b/tests/test_issue1567_nous_picker_capacity_and_symmetry.py
@@ -446,9 +446,14 @@ class TestNousLiveFetchEmpty:
 
     def test_hermes_cli_unavailable_falls_back_to_static_4(self, monkeypatch, tmp_path):
         """When hermes_cli is unavailable (raises) — distinct from returning [] —
-        we DO fall back to the static 4-entry list so the picker isn't empty
-        in that degraded environment. This preserves pre-#1538 behavior for
-        test envs without hermes_cli."""
+        we DO fall back to the static list so the picker isn't empty in that
+        degraded environment. This preserves pre-#1538 behavior for test envs
+        without hermes_cli.
+
+        Note: _seed_provider_models_from_core() may have enriched the static
+        list at import time if hermes_cli was available then, so we assert the
+        original 4 curated entries are present (subset) rather than an exact
+        count (#4413)."""
         _scrub_provider_env(monkeypatch)
         _install_fake_hermes_cli(
             monkeypatch,
@@ -466,9 +471,19 @@ class TestNousLiveFetchEmpty:
                 "the curated static fallback so the picker isn't empty in "
                 "test envs that lack the agent package."
             )
-            assert len(nous_groups[0]["models"]) == 4, (
-                "Static fallback should expose the curated 4-entry list "
-                "from _PROVIDER_MODELS['nous']."
+            # The original curated 4 entries must all be present.
+            nous_ids = {m["id"] for m in nous_groups[0]["models"]}
+            _curated_nous_ids = {
+                m["id"] for m in config._PROVIDER_MODELS.get("nous", [])
+                if m["id"].startswith("@nous:")
+            }
+            assert _curated_nous_ids.issubset(nous_ids), (
+                f"Static fallback is missing curated @nous: entries. "
+                f"Expected subset {_curated_nous_ids}, got {nous_ids}"
+            )
+            assert len(nous_groups[0]["models"]) >= 4, (
+                "Static fallback should expose at least the curated 4-entry "
+                "list from _PROVIDER_MODELS['nous']."
             )
         finally:
             restore()

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -205,10 +205,13 @@ def test_minimax_cn_detected_from_os_environ(monkeypatch, tmp_path):
 
     assert 'minimax-cn' in groups, f"minimax-cn group missing: {groups.keys()}"
     assert groups['minimax-cn']['provider'] == 'MiniMax (China)'
-    assert {m['id'] for m in groups['minimax-cn']['models']} == {
-        'MiniMax-M3',
-        'MiniMax-M2.7',
-    }
+    # _seed_provider_models_from_core() may have enriched the static list at
+    # import time, so assert the curated entries are a subset rather than an
+    # exact match (#4413).
+    cn_ids = {m['id'] for m in groups['minimax-cn']['models']}
+    assert {'MiniMax-M3', 'MiniMax-M2.7'}.issubset(cn_ids), (
+        f"Expected curated MiniMax-CN models in {cn_ids}"
+    )
     assert 'minimax' not in groups, (
         "MINIMAX_CN_API_KEY must not be collapsed into the global minimax provider"
     )

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -146,10 +146,10 @@ def test_minimax_cn_provider_models_match_hermes_agent_catalog():
     """minimax-cn must have its own static catalog so an empty config provider still shows models."""
     models = config._PROVIDER_MODELS.get('minimax-cn', [])
     ids = [m['id'] for m in models]
-    assert ids == [
-        'MiniMax-M3',
-        'MiniMax-M2.7',
-    ]
+    # _seed_provider_models_from_core() may have enriched the static list at
+    # import time, so assert the curated entries are a subset rather than an
+    # exact match (#4413).
+    assert {'MiniMax-M3', 'MiniMax-M2.7'}.issubset(set(ids)), ids
     assert config._PROVIDER_DISPLAY.get('minimax-cn') == 'MiniMax (China)'
 
 


### PR DESCRIPTION
## Problem

The WebUI maintains its own static `_PROVIDER_MODELS` dict (with `{id, label}` entries for display) as a parallel copy of the core's `hermes_cli.models._PROVIDER_MODELS`. When new models are added to the core without a matching WebUI update, the WebUI's copy goes stale.

This caused a real production issue: `glm-5.2` was added to the core's zai catalog but never propagated to the WebUI's hardcoded `_PROVIDER_MODELS["zai"]` list. When a new session was created with `glm-5.2`, `resolve_model_provider()` couldn't match it to the zai provider (line 2015: `config_provider in _PROVIDER_MODELS` → `glm-5.2` not in the zai list). The resolution logic fell through to `opencode-go` (which also serves GLM models), producing a `@opencode-go:glm-5.2` session that burned through the wrong provider's quota.

## Root Cause

`resolve_model_provider()` uses the hardcoded `_PROVIDER_MODELS` dict in 3 sites:
1. **Line 2015**: `_skip_custom_providers` guard — checks if the model belongs to the configured provider
2. **Line 2082**: `@provider:model` format validation — checks if the provider hint is a known provider
3. **Line 2182/2200**: Slash-prefix routing — checks if a prefix is a known provider namespace

All 3 sites reference the hardcoded dict, not the dynamic `hermes_cli.models.provider_model_ids()` that the model picker display already uses.

## Fix

**Immediate**: Add `glm-5.2` to both `_FALLBACK_MODELS` and `_PROVIDER_MODELS` hardcoded lists.

**Durable**: Add `_seed_provider_models_from_core()` — a function that merges any missing model IDs from `hermes_cli.models._PROVIDER_MODELS` into the WebUI's dict at startup. This runs once at module load time, is idempotent, and silently no-ops if `hermes_cli` is not importable (standalone deployments).

## Testing

- Ran all `resolve_model_provider` tests: 60 passed
- Verified `resolve_model_provider("glm-5.2")` now correctly returns `provider=custom:zai`
- Verified `_PROVIDER_MODELS["zai"]` includes `glm-5.2` after seeding

## Why not just hit the provider's `/v1/models` endpoint?

Not all providers expose a model list endpoint, those that do return ALL models (including non-agentic TTS/embedding models), it adds network latency on startup, and it fails when the provider is down. The core's curated `_PROVIDER_MODELS` is the authoritative, hand-picked list of agent-capable models — seeding from it is the right approach.