### PR TITLE
fix(sidebar): hide child rows for archived parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Archiving a parent conversation no longer leaves child, delegate, or fork rows stranded in the sidebar (#4293).** The sidebar now checks the active project/session set before rendering orphan child rows, suppresses children whose archived parent is intentionally hidden, and clears stale child-session decorations during each render rebuild.
+
 ## [v0.51.498] — 2026-06-18 — Release RH (profile runtime env no longer clobbers core shell identity)
 
 ### Fixed
@@ -46,7 +50,6 @@
 ### Fixed
 
 - **Reloading a session with a large model context window no longer snaps it back to the 256k fallback (#4248).** The session reload path now resolves context-window metadata with the same base URL / API-key lookup inputs used by streaming saves, and it refuses to overwrite a larger persisted context window with the generic 256k fallback. The reload model-identity check also normalizes slash-qualified model ids (`provider/model`, OpenRouter-style) so a slash-stored model resolving to its bare id is not mistaken for a model change. Thanks @franksong2702.
-
 ## [v0.51.489] — 2026-06-18 — Release QY (outline button no longer collides with the scroll control)
 
 ### Fixed

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4720,12 +4720,25 @@ function _sessionStateTooltip({isStreaming=false,hasUnread=false}={}){
   return '';
 }
 
-function _attachChildSessionsToSidebarRows(collapsedRows, rawSessions){
-  const sessionIdsInList=new Set((rawSessions||[]).map(s=>s&&s.session_id).filter(Boolean));
-  const rawSessionsById=new Map((rawSessions||[]).filter(s=>s&&s.session_id).map(s=>[s.session_id,s]));
+function _attachChildSessionsToSidebarRows(collapsedRows, rawSessions, rawReferenceSessions){
+  const referenceSessions=Array.isArray(rawReferenceSessions)?rawReferenceSessions:(rawSessions||[]);
+  const sessionIdsInList=new Set(referenceSessions.map(s=>s&&s.session_id).filter(Boolean));
+  const rawSessionsById=new Map(referenceSessions.filter(s=>s&&s.session_id).map(s=>[s.session_id,s]));
+  const cleanSidebarRow=(s)=>{
+    const row={...s};
+    // Child-session decoration is render-derived.  Drop stale copies so an
+    // archived child disappears immediately on the next list rebuild instead of
+    // lingering under a copied parent row (#4293).
+    delete row._child_sessions;
+    delete row._child_session_count;
+    delete row._child_session_streaming;
+    delete row._child_session_has_unread;
+    delete row._child_session_attention;
+    return row;
+  };
   const rows=(collapsedRows||[])
     .filter(s=>!_isChildSession(s)&&((s&&s.pinned)||!_isForkWithResolvableParent(s, sessionIdsInList)))
-    .map(s=>({...s}));
+    .map(cleanSidebarRow);
   const isChildStreaming=(childRow)=>typeof _isSessionEffectivelyStreaming==='function'
     ? _isSessionEffectivelyStreaming(childRow)
     : !!(childRow&&(childRow.active_stream_id||childRow.pending_user_message));
@@ -4772,6 +4785,23 @@ function _attachChildSessionsToSidebarRows(collapsedRows, rawSessions){
       if(seg&&seg.session_id) visibleBySegmentSid.set(seg.session_id,{row,seg});
     }
   }
+  const hiddenArchivedChildTree=new Set();
+  const archivedRowsVisible=typeof _showArchived!=='undefined'&&!!_showArchived;
+  const hasHiddenArchivedAncestor=(session)=>{
+    if(!session||!session.session_id||archivedRowsVisible) return false;
+    const seen=new Set();
+    let parentSid=session.parent_session_id;
+    while(parentSid){
+      if(hiddenArchivedChildTree.has(parentSid)) return true;
+      if(seen.has(parentSid)) break;
+      seen.add(parentSid);
+      const rawParent=rawSessionsById.get(parentSid);
+      if(!rawParent) break;
+      if(rawParent.archived) return true;
+      parentSid=rawParent.parent_session_id;
+    }
+    return false;
+  };
   const orphans=[];
   const attachQueue=[...(rawSessions||[])].sort((a,b)=>attachDepthFor(a)-attachDepthFor(b));
   for(const child of attachQueue){
@@ -4791,6 +4821,10 @@ function _attachChildSessionsToSidebarRows(collapsedRows, rawSessions){
     }
     if(!parentRow&&child._parent_lineage_root_id){
       parentRow=visibleByLineageKey.get(child._parent_lineage_root_id)||null;
+    }
+    if(!parentRow&&hasHiddenArchivedAncestor(child)){
+      hiddenArchivedChildTree.add(child.session_id);
+      continue;
     }
     if(parentRow){
       if(!Array.isArray(parentRow._child_sessions)) parentRow._child_sessions=[];
@@ -5128,6 +5162,8 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
   let cliSessionCount=0;
   const webuiProfileFiltered=[];
   const cliProfileFiltered=[];
+  const webuiReferenceRaw=[];
+  const cliReferenceRaw=[];
   const webuiSessionsRaw=[];
   const cliSessionsRaw=[];
   let webuiArchivedCount=0;
@@ -5138,6 +5174,7 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
     if(isCli) cliSessionCount++;
     if(s.default_hidden&&!(_activeProject&&_activeProject!==NO_PROJECT_FILTER&&s.project_id===_activeProject)) continue;
     const profileFiltered=isCli ? cliProfileFiltered : webuiProfileFiltered;
+    const referenceRaw=isCli ? cliReferenceRaw : webuiReferenceRaw;
     const sessionsRaw=isCli ? cliSessionsRaw : webuiSessionsRaw;
     profileFiltered.push(s);
     if(_activeProject===NO_PROJECT_FILTER){
@@ -5145,6 +5182,7 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
     } else if(_activeProject){
       if(s.project_id!==_activeProject) continue;
     }
+    referenceRaw.push(s);
     if(s.archived){
       if(isCli) cliArchivedCount++;
       else webuiArchivedCount++;
@@ -5161,19 +5199,18 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
     profileFiltered: showCliOnly ? cliProfileFiltered : webuiProfileFiltered,
     sessionsRaw: showCliOnly ? cliSessionsRaw : webuiSessionsRaw,
     archivedCount: showCliOnly ? cliArchivedCount : webuiArchivedCount,
+    webuiReferenceRaw,
+    cliReferenceRaw,
     webuiSessionsRaw,
     cliSessionsRaw,
   };
 }
 
-function _renderSidebarRowsFromRawSessions(sessionsRaw){
-  return _attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw);
+function _renderSidebarRowsFromRawSessions(sessionsRaw, referenceSessionsRaw){
+  const referenceRows=Array.isArray(referenceSessionsRaw)?referenceSessionsRaw:sessionsRaw;
+  return _attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw, referenceRows);
 }
 
-function _countRenderedSidebarRowsFromRawSessions(sessionsRaw){
-  // Keep inactive-tab chip counts on the exact same top-level row path as render.
-  return _renderSidebarRowsFromRawSessions(sessionsRaw).length;
-}
 
 function renderSessionListFromCache(){
   // Don't re-render while user is actively renaming a session (would destroy the input)
@@ -5202,16 +5239,19 @@ function renderSessionListFromCache(){
     profileFiltered,
     sessionsRaw,
     archivedCount,
+    webuiReferenceRaw,
+    cliReferenceRaw,
     webuiSessionsRaw,
     cliSessionsRaw,
   }=_partitionSidebarSessionRows(allMatched, activeSidForSidebar);
-  const sessions=_renderSidebarRowsFromRawSessions(sessionsRaw);
+  const referenceRaw=_sessionSourceFilter==='cli'?cliReferenceRaw:webuiReferenceRaw;
+  const sessions=_renderSidebarRowsFromRawSessions(sessionsRaw, referenceRaw);
   const renderedWebuiSessionCount=_sessionSourceFilter==='webui'
     ? sessions.length
-    : _countRenderedSidebarRowsFromRawSessions(webuiSessionsRaw);
+    : _renderSidebarRowsFromRawSessions(webuiSessionsRaw, webuiReferenceRaw).length;
   const renderedCliSessionCount=_sessionSourceFilter==='cli'
     ? sessions.length
-    : _countRenderedSidebarRowsFromRawSessions(cliSessionsRaw);
+    : _renderSidebarRowsFromRawSessions(cliSessionsRaw, cliReferenceRaw).length;
   _syncSidebarExpansionForActiveSession(sessions, activeSidForSidebar);
   const list=$('sessionList');
   const animateRefresh=_sessionListRefreshAnimationPending;

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -421,6 +421,219 @@ console.log(JSON.stringify(rows));
     assert "_child_sessions" not in rows[0]
 
 
+def test_archived_hidden_parent_suppresses_child_and_fork_orphans():
+    """Archived parents should not leave child/delegate clutter behind (#4293)."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+var _showArchived = false;
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+const parent = {{session_id:'parent', title:'Archived parent', archived:true, updated_at:10, last_message_at:10}};
+const child = {{session_id:'child', title:'Child', parent_session_id:'parent', relationship_type:'child_session', updated_at:20, last_message_at:20}};
+const fork = {{session_id:'fork', title:'Fork', session_source:'fork', parent_session_id:'parent', updated_at:30, last_message_at:30}};
+const visibleRows = [child, fork];
+const referenceRows = [parent, child, fork];
+const rows = _attachChildSessionsToSidebarRows(visibleRows, visibleRows, referenceRows);
+console.log(JSON.stringify(rows));
+"""
+    assert json.loads(_run_node(source)) == []
+
+
+def test_archived_hidden_ancestor_suppresses_nested_child_and_fork_orphans():
+    """Nested descendants of an archived hidden parent must not leak as orphans (#4293)."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+var _showArchived = false;
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+const parent = {{session_id:'parent', title:'Archived parent', archived:true, updated_at:10, last_message_at:10}};
+const child = {{session_id:'child', title:'Child', parent_session_id:'parent', relationship_type:'child_session', updated_at:20, last_message_at:20}};
+const grandchild = {{session_id:'grandchild', title:'Grandchild', parent_session_id:'child', relationship_type:'child_session', updated_at:30, last_message_at:30}};
+const fork1 = {{session_id:'fork1', title:'Fork 1', session_source:'fork', parent_session_id:'parent', updated_at:40, last_message_at:40}};
+const fork2 = {{session_id:'fork2', title:'Fork 2', session_source:'fork', parent_session_id:'fork1', updated_at:50, last_message_at:50}};
+const visibleRows = [child, grandchild, fork1, fork2];
+const referenceRows = [parent, child, grandchild, fork1, fork2];
+const rows = _attachChildSessionsToSidebarRows(visibleRows, visibleRows, referenceRows);
+console.log(JSON.stringify(rows));
+"""
+    assert json.loads(_run_node(source)) == []
+
+
+def test_cross_project_archived_parent_does_not_hide_active_project_fork():
+    """Archived parents outside the active project must not suppress an active-project fork (#4293)."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+var _showArchived = false;
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+eval(extractFunc('_renderSidebarRowsFromRawSessions'));
+const otherProjectParent = {{session_id:'parent', title:'Other project parent', archived:true, project_id:'other', updated_at:10, last_message_at:10}};
+const activeProjectFork = {{session_id:'fork', title:'Active project fork', session_source:'fork', parent_session_id:'parent', project_id:'active', updated_at:20, last_message_at:20}};
+const activeProjectRows = [activeProjectFork];
+const activeProjectReferenceRows = [activeProjectFork];
+const crossProjectReferenceRows = [otherProjectParent, activeProjectFork];
+const correctRows = _renderSidebarRowsFromRawSessions(activeProjectRows, activeProjectReferenceRows);
+const wrongRows = _renderSidebarRowsFromRawSessions(activeProjectRows, crossProjectReferenceRows);
+console.log(JSON.stringify({{correctRows, wrongRows}}));
+"""
+    result = json.loads(_run_node(source))
+    assert [row["session_id"] for row in result["correctRows"]] == ["fork"]
+    assert "_orphan_child_session" not in result["correctRows"][0]
+    # This documents why render references must be active-project scoped: a
+    # cross-project archived parent would make the active-project fork vanish.
+    assert result["wrongRows"] == []
+
+
+def test_inactive_source_tab_count_uses_its_own_archived_parent_references():
+    """Inactive source-count renders must not borrow another source's reference rows (#4293)."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+var _showArchived = false;
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+eval(extractFunc('_renderSidebarRowsFromRawSessions'));
+const webuiParent = {{session_id:'webui-parent', title:'Archived WebUI parent', archived:true, updated_at:10, last_message_at:10}};
+const webuiChild = {{session_id:'webui-child', title:'WebUI child', parent_session_id:'webui-parent', relationship_type:'child_session', updated_at:20, last_message_at:20}};
+const cliParent = {{session_id:'cli-parent', title:'Archived CLI parent', archived:true, is_cli_session:true, session_source:'cli', updated_at:30, last_message_at:30}};
+const cliChild = {{session_id:'cli-child', title:'CLI child', parent_session_id:'cli-parent', relationship_type:'child_session', is_cli_session:true, session_source:'cli', updated_at:40, last_message_at:40}};
+const webuiVisibleRows = [webuiChild];
+const cliVisibleRows = [cliChild];
+const webuiReferenceRows = [webuiParent, webuiChild];
+const cliReferenceRows = [cliParent, cliChild];
+const wrongWebuiCount = _renderSidebarRowsFromRawSessions(webuiVisibleRows, cliReferenceRows).length;
+const rightWebuiCount = _renderSidebarRowsFromRawSessions(webuiVisibleRows, webuiReferenceRows).length;
+const wrongCliCount = _renderSidebarRowsFromRawSessions(cliVisibleRows, webuiReferenceRows).length;
+const rightCliCount = _renderSidebarRowsFromRawSessions(cliVisibleRows, cliReferenceRows).length;
+console.log(JSON.stringify({{wrongWebuiCount,rightWebuiCount,wrongCliCount,rightCliCount}}));
+"""
+    counts = json.loads(_run_node(source))
+    assert counts == {
+        "wrongWebuiCount": 1,
+        "rightWebuiCount": 0,
+        "wrongCliCount": 1,
+        "rightCliCount": 0,
+    }
+
+
+def test_child_archive_render_rebuild_drops_stale_decorated_children():
+    """A previous decorated parent copy must not retain an archived child (#4293)."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+const decoratedParent = {{
+  session_id:'parent',
+  title:'Parent',
+  updated_at:10,
+  last_message_at:10,
+  _child_sessions:[{{session_id:'archived-child', title:'Archived child'}}],
+  _child_session_count:1,
+  _child_session_streaming:true,
+  _child_session_has_unread:true,
+  _child_session_attention:{{kind:'approval', count:1}},
+}};
+const rows = _attachChildSessionsToSidebarRows([decoratedParent], [decoratedParent]);
+console.log(JSON.stringify(rows));
+"""
+    rows = json.loads(_run_node(source))
+    assert [row["session_id"] for row in rows] == ["parent"]
+    assert "_child_sessions" not in rows[0]
+    assert "_child_session_count" not in rows[0]
+    assert "_child_session_streaming" not in rows[0]
+    assert "_child_session_has_unread" not in rows[0]
+    assert "_child_session_attention" not in rows[0]
+
+
 def test_fork_child_with_visible_parent_is_nested_once():
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
     source = f"""

--- a/tests/test_sidebar_session_partition.py
+++ b/tests/test_sidebar_session_partition.py
@@ -31,10 +31,10 @@ def test_render_uses_single_pass_partition_helper():
     render_body = _function_block("renderSessionListFromCache")
 
     assert "_partitionSidebarSessionRows(allMatched, activeSidForSidebar)" in render_body
-    assert "_renderSidebarRowsFromRawSessions(sessionsRaw)" in render_body
+    assert "_renderSidebarRowsFromRawSessions(sessionsRaw, referenceRaw)" in render_body
     assert "? sessions.length" in render_body
-    assert ": _countRenderedSidebarRowsFromRawSessions(webuiSessionsRaw);" in render_body
-    assert ": _countRenderedSidebarRowsFromRawSessions(cliSessionsRaw);" in render_body
+    assert ": _renderSidebarRowsFromRawSessions(webuiSessionsRaw, webuiReferenceRaw).length;" in render_body
+    assert ": _renderSidebarRowsFromRawSessions(cliSessionsRaw, cliReferenceRaw).length;" in render_body
     assert "const count=filter==='cli'?renderedCliSessionCount:renderedWebuiSessionCount;" in render_body
     assert "const count=filter==='cli'?cliSessionCount:webuiSessionCount;" not in render_body
     assert "withMessages.filter(" not in render_body
@@ -60,11 +60,14 @@ def test_partition_helper_keeps_raw_source_counts_while_render_owns_visible_coun
 
     assert "webuiSessionCount," not in _partition_block()
     assert "cliSessionCount," in _partition_block()
+    assert "webuiReferenceRaw," in _partition_block()
+    assert "cliReferenceRaw," in _partition_block()
     assert "webuiSessionsRaw," in _partition_block()
     assert "cliSessionsRaw," in _partition_block()
     assert "const renderedWebuiSessionCount=" in render_body
     assert "const renderedCliSessionCount=" in render_body
-    helper_body = _function_block("_countRenderedSidebarRowsFromRawSessions")
-    assert "_renderSidebarRowsFromRawSessions(sessionsRaw).length;" in helper_body
-    assert "function _renderSidebarRowsFromRawSessions(sessionsRaw){" in SESSIONS_JS
-    assert "_attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw)" in SESSIONS_JS
+    assert "_renderSidebarRowsFromRawSessions(webuiSessionsRaw, webuiReferenceRaw).length" in render_body
+    assert "_renderSidebarRowsFromRawSessions(cliSessionsRaw, cliReferenceRaw).length" in render_body
+    assert "function _countRenderedSidebarRowsFromRawSessions" not in SESSIONS_JS
+    assert "function _renderSidebarRowsFromRawSessions(sessionsRaw, referenceSessionsRaw){" in SESSIONS_JS
+    assert "_attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw, referenceRows)" in SESSIONS_JS


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI sidebar rows are filtered for archived state before child/delegate rows are attached.
- That meant archiving a parent could hide the parent while leaving child, delegate, or nested fork rows behind as top-level orphans.
- The fix should be render-path only: do not mutate child sessions on disk, and do not change compression-lineage collapse semantics.
- Child-session decoration is derived during render, so stale copied `_child_sessions` metadata should also be cleared each rebuild.
- Source-tab counts need to use the same reference set as the rendered rows, otherwise hidden archived parents can still inflate inactive tab counts.

## What Changed

- Extended `_attachChildSessionsToSidebarRows()` to accept a full reference row set separate from the currently visible rows.
- Suppressed child/delegate/fork rows whose archived ancestor is hidden and no visible parent row, lineage segment, or lineage root can attach them.
- Cleared render-derived child-session decoration fields when rebuilding sidebar rows so archived children disappear immediately.
- Passed source-specific profile-filtered references for WebUI/CLI source-tab counts.
- Added regression coverage for:
  - direct archived parent hiding child/fork orphans,
  - nested child/fork descendants under an archived hidden ancestor,
  - inactive source-tab counts using their own reference set,
  - stale decorated child rows being cleared after archive,
  - updated partition/render contracts.
- Added an Unreleased changelog entry for #4293.

## Why It Matters

Archiving a conversation should clean up the visible sidebar state. Users should not have to manually chase child, delegate, or fork rows after hiding the parent conversation, and archived hidden subtrees should not continue to affect source-tab counts.

## Verification

- `./scripts/test.sh tests/test_session_lineage_collapse.py tests/test_sidebar_session_partition.py tests/test_465_session_branching.py tests/test_issue4385_cron_archive_reappears.py tests/test_session_import_cli_fallback_model.py tests/test_issue3988_show_cli_sessions_default.py -q`
  - `97 passed`
- `node --check static/sessions.js`
- `git diff --check`
- `python3 scripts/ruff_lint.py --diff origin/master`
  - `ruff_lint: no changed .py files vs origin/master (...) OK.`
- `./scripts/test.sh tests/test_static_js_runtime_lint.py tests/test_ruff_forward_lint.py -q`
  - `4 passed, 1 skipped`
- Full local `./scripts/test.sh`
  - `9323 passed, 103 skipped, 1 xfailed, 2 xpassed, 8 warnings, 16 subtests passed`
  - Local environment had one unrelated remaining failure in `tests/test_tls_support.py::TestTLSEndToEnd::test_tls_startup_failure_fallback_to_http`: the server stdout was flooded by missing optional agent dependencies (`requests`/`websockets`) before the TLS warning string, so the test's 2000-byte stdout read did not include `TLS setup failed`. No touched files participate in TLS startup.
  - A second full-suite failure, `tests/test_v050259_sessiondb_fd_leak.py::test_session_db_close_is_idempotent`, passed on focused rerun.
- Independent agent review of the final diff: PASS, no blockers, no secrets/private paths found.
- Diff secret/private-path scan: no matches in added diff.

## Risks / Follow-ups

- This intentionally does not cascade archive state to child sessions on disk; it only hides orphaned archived-parent subtrees while archived rows are hidden.
- Archived children remain discoverable again when archived conversations are shown.
- Follow-up could add explicit UI/browser screenshots, but this is a sidebar render-state fix covered by runtime-style JS tests.

## Contract Routing

Task type: sidebar/session metadata render-state bug fix.

Touched areas:
- `static/sessions.js`
- `tests/test_session_lineage_collapse.py`
- `tests/test_sidebar_session_partition.py`
- `CHANGELOG.md`

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/UIUX-GUIDE.md`

Scope boundaries:
- No server-side archive cascade.
- No changes to persisted session metadata or compression-lineage contracts.
- No new dependencies or build steps.

Evidence needed before claiming done:
- Runtime-style sidebar tests for archived parent child/fork suppression.
- Existing lineage/fork/cross-surface/sidebar partition tests remain green.

## Model Used

AI-assisted with OpenAI GPT-5.5 through Hermes Agent, including tool-driven local tests and independent subagent review. No local provider secrets or private environment details are required for the change.
