### PR TITLE
fix: drain queued WebUI turns server-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1824,7 +1824,6 @@
 ### Added
 
 - **Vietnamese (Tiếng Việt) is now a selectable UI language.** Adds a full `vi` locale to the language picker, including the login page. Thanks @thanhtantran. (#4241)
-
 ## [v0.51.620] — 2026-06-24 — Release WA (fix /api/sessions CPU spike + slowness during streaming)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1824,6 +1824,7 @@
 ### Added
 
 - **Vietnamese (Tiếng Việt) is now a selectable UI language.** Adds a full `vi` locale to the language picker, including the login page. Thanks @thanhtantran. (#4241)
+
 ## [v0.51.620] — 2026-06-24 — Release WA (fix /api/sessions CPU spike + slowness during streaming)
 
 ### Fixed

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -499,6 +499,8 @@ def _run_gateway_runs_api_streaming(
     *, put_gateway_event, cancel_event,
     attachments=None, cfg=None, session=None,
     active_provider: str = "",
+    queue_item_id: str | None = None,
+    queue_attempt_id: str | None = None,
 ):
     """Submit via POST /v1/runs and relay SSE events including approval."""
     try:
@@ -569,6 +571,19 @@ def _run_gateway_runs_api_streaming(
             headers=headers,
             method="POST",
         )
+        admission_id = ""
+        if queue_item_id:
+            from api.session_queue import mark_external_admission
+
+            admission_id = uuid.uuid4().hex
+            if not mark_external_admission(
+                session_id,
+                queue_item_id,
+                stream_id,
+                admission_id,
+                attempt_id=queue_attempt_id,
+            ):
+                raise RuntimeError("queued item lost external admission ownership")
         update_active_run(stream_id, phase="gateway-request")
         with urllib.request.urlopen(req, timeout=30) as resp:
             run_data = json.loads(resp.read(65536))
@@ -580,6 +595,19 @@ def _run_gateway_runs_api_streaming(
         raise
 
     usage: dict = {}
+    if queue_item_id:
+        from api.session_queue import mark_external_run
+
+        if not mark_external_run(
+            session_id,
+            queue_item_id,
+            stream_id,
+            run_id,
+            admission_id=admission_id,
+            attempt_id=queue_attempt_id,
+        ):
+            stop_gateway_run(run_id)
+            raise RuntimeError("queued item lost external run ownership")
     _publish_gateway_run_id(stream_id, run_id)
 
     url_events = f"{base_url.rstrip('/')}/v1/runs/{run_id}/events"
@@ -834,6 +862,8 @@ def _run_gateway_chat_streaming(
     *,
     model_provider=None,
     goal_related=False,
+    queue_item_id: str | None = None,
+    queue_attempt_id: str | None = None,
 ):
     """Bridge a WebUI chat turn through Hermes Gateway's API server.
 
@@ -992,6 +1022,8 @@ def _run_gateway_chat_streaming(
                     cfg=cfg,
                     session=s,
                     active_provider=(model_provider or ""),
+                    queue_item_id=queue_item_id,
+                    queue_attempt_id=queue_attempt_id,
                 )
             except Exception as exc:
                 error_payload = _settle_gateway_terminal_error(

--- a/api/models.py
+++ b/api/models.py
@@ -1205,6 +1205,8 @@ class Session:
                  pending_attachments=None,
                  pending_started_at=None,
                  pending_user_source: str=None,
+                 pending_queue_item_id: str | None=None,
+                 pending_queue_client_id: str | None=None,
                  context_messages=None,
                  compression_anchor_visible_idx=None,
                  compression_anchor_message_key=None,
@@ -1289,6 +1291,8 @@ class Session:
         self.pending_attachments = pending_attachments or []
         self.pending_started_at = pending_started_at
         self.pending_user_source = pending_user_source
+        self.pending_queue_item_id = pending_queue_item_id
+        self.pending_queue_client_id = pending_queue_client_id
         self.context_messages = context_messages if isinstance(context_messages, list) else []
         self.compression_anchor_visible_idx = compression_anchor_visible_idx
         self.compression_anchor_message_key = compression_anchor_message_key
@@ -1385,6 +1389,13 @@ class Session:
             )
         if touch_updated_at:
             self.updated_at = time.time()
+        # Queue correlation is meaningful only while this session owns a
+        # pending turn. Clearing it at the persistence boundary prevents stale
+        # queue ids from making startup recovery treat an unsubmitted item as
+        # already started.
+        if not self.active_stream_id and not self.pending_user_message:
+            self.pending_queue_item_id = None
+            self.pending_queue_client_id = None
         # Write metadata fields first so load_metadata_only() can read them
         # without parsing the full messages array (which may be 400KB+).
         # Fields are listed in the order they should appear in the JSON file.
@@ -1395,6 +1406,7 @@ class Session:
             'cache_read_tokens', 'cache_write_tokens',
             'personality', 'active_stream_id',
             'pending_user_message', 'pending_attachments', 'pending_started_at', 'pending_user_source',
+            'pending_queue_item_id', 'pending_queue_client_id',
             'compression_anchor_visible_idx', 'compression_anchor_message_key',
             'compression_anchor_summary', 'pre_compression_snapshot',
             'context_engine', 'compression_anchor_engine', 'compression_anchor_mode',

--- a/api/routes.py
+++ b/api/routes.py
@@ -13702,9 +13702,11 @@ def handle_get(handler, parsed) -> bool:
         query = parse_qs(parsed.query)
         sid = query.get("session_id", [""])[0]
         try:
-            get_session(sid)
-        except KeyError:
-            return bad(handler, "Session not found", 404)
+            _resolve_session_queue_owner(sid)
+        except (KeyError, OSError, sqlite3.Error):
+            # Queue reads fail closed without turning an unavailable lineage into
+            # a browser-level sync error during startup or historical replay.
+            return j(handler, {"session_id": sid, "items": [], "available": False})
         from api.session_queue import QueueStorageError, list_queue
         try:
             items = list_queue(sid)
@@ -22243,6 +22245,61 @@ def start_session_turn(
             "server_turn_started fan-out failed for session %s", session_id, exc_info=True
         )
     return resp
+
+
+def _resolve_session_queue_owner(session_id: str):
+    """Authorize queue reads for the canonical writable conversation tip."""
+    sid = str(session_id or "").strip()
+    report = read_session_lineage_report(_active_state_db_path(), sid)
+    if (
+        not report.get("found")
+        or report.get("manual_review")
+        or str(report.get("tip_session_id") or "") != sid
+    ):
+        raise KeyError(sid)
+
+    db_path = _active_state_db_path()
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    with sqlite3.connect(uri, uri=True) as conn:
+        columns = {
+            str(row[1]) for row in conn.execute("PRAGMA table_info(sessions)")
+        }
+        selected = [
+            column if column in columns else f"NULL AS {column}"
+            for column in ("source", "session_source", "model_config")
+        ]
+        row = conn.execute(
+            f"SELECT {', '.join(selected)} FROM sessions WHERE id = ?",
+            (sid,),
+        ).fetchone()
+    if row is None:
+        raise KeyError(sid)
+    source, session_source, raw_config = row
+    allowed_sources = {"", "webui", "local", "cli", "tui", "desktop", "agent"}
+    if str(source or "").strip().lower() not in allowed_sources:
+        raise KeyError(sid)
+    if str(session_source or "").strip().lower() not in allowed_sources:
+        raise KeyError(sid)
+    try:
+        config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+    except (TypeError, ValueError) as exc:
+        raise KeyError(sid) from exc
+    if config not in (None, {}) and not isinstance(config, dict):
+        raise KeyError(sid)
+    if isinstance(config, dict) and (
+        config.get("_branched_from") is not None
+        or config.get("_delegate_from") is not None
+    ):
+        raise KeyError(sid)
+    try:
+        session = get_session(sid)
+    except KeyError:
+        if int(report.get("total_segments") or 0) < 2:
+            raise
+        return sid
+    if getattr(session, "read_only", False):
+        raise KeyError(sid)
+    return session
 
 
 def _handle_session_queue_enqueue(handler, body):

--- a/api/routes.py
+++ b/api/routes.py
@@ -21564,6 +21564,7 @@ def _start_chat_stream_for_session(
     external_runtime_owned: bool | None = None,
     queue_item_id: str | None = None,
     queue_client_id: str | None = None,
+    queue_attempt_id: str | None = None,
 ):
     """Persist pending state, register an SSE channel, and start an agent turn."""
     if external_runtime_owned is None:
@@ -21704,13 +21705,28 @@ def _start_chat_stream_for_session(
     if backend_is_gateway:
         from api.gateway_chat import _mark_gateway_run_starting
         _mark_gateway_run_starting(stream_id)
+        if queue_item_id:
+            worker_kwargs["queue_item_id"] = queue_item_id
+            worker_kwargs["queue_attempt_id"] = queue_attempt_id
     thr = threading.Thread(
         target=worker_target,
         args=(s.session_id, msg, model, workspace, stream_id, attachments),
         kwargs=worker_kwargs,
         daemon=True,
     )
+    queue_dispatch_conflict = False
     try:
+        if queue_item_id:
+            from api.session_queue import mark_dispatched
+
+            if not mark_dispatched(
+                s.session_id,
+                str(queue_item_id),
+                stream_id,
+                attempt_id=queue_attempt_id,
+            ):
+                queue_dispatch_conflict = True
+                raise RuntimeError("queued item lost dispatch ownership")
         thr.start()
     except Exception:
         if backend_is_gateway:
@@ -21743,6 +21759,8 @@ def _start_chat_stream_for_session(
                     s.save(touch_updated_at=False)
                 except Exception:
                     logger.exception("Failed to persist worker start failure cleanup for %s", s.session_id)
+        if queue_dispatch_conflict:
+            return {"error": "queued item lost dispatch ownership", "_status": 409}
         return {"error": "failed to start agent worker", "_status": 500}
     response = {
         "stream_id": stream_id,
@@ -21826,6 +21844,7 @@ def _start_run(
     gateway_chat_enabled: bool | None = None,
     queue_item_id: str | None = None,
     queue_client_id: str | None = None,
+    queue_attempt_id: str | None = None,
 ):
     """Shared start-run helper for /api/chat/start and start_session_turn.
 
@@ -21869,6 +21888,7 @@ def _start_run(
                 external_runtime_owned=gateway_chat_enabled,
                 queue_item_id=queue_item_id,
                 queue_client_id=queue_client_id,
+                queue_attempt_id=queue_attempt_id,
             )
 
         def _legacy_adapter_factory():
@@ -21895,6 +21915,7 @@ def _start_run(
                         "route": route,
                         **({"queue_item_id": str(queue_item_id)} if queue_item_id else {}),
                         **({"queue_client_id": str(queue_client_id)} if queue_client_id else {}),
+                        **({"queue_attempt_id": str(queue_attempt_id)} if queue_attempt_id else {}),
                     },
                 )
             )
@@ -21916,6 +21937,7 @@ def _start_run(
         external_runtime_owned=gateway_chat_enabled,
         queue_item_id=queue_item_id,
         queue_client_id=queue_client_id,
+        queue_attempt_id=queue_attempt_id,
     )
 
 
@@ -21980,6 +22002,7 @@ def start_session_turn(
     requested_provider=None,
     queue_item_id: str | None = None,
     queue_client_id: str | None = None,
+    queue_attempt_id: str | None = None,
 ):
     """Start a server-side agent turn for ``session_id`` with ``message``.
 
@@ -22178,6 +22201,7 @@ def start_session_turn(
         route="start_session_turn",
         queue_item_id=queue_item_id,
         queue_client_id=queue_client_id,
+        queue_attempt_id=queue_attempt_id,
     )
 
     # ── Defect B: live-view of server-initiated turns ──────────────────────

--- a/api/routes.py
+++ b/api/routes.py
@@ -22173,12 +22173,13 @@ def _handle_session_queue_enqueue(handler, body):
         get_session(sid)
     except KeyError:
         return bad(handler, "Session not found", 404)
-    from api.session_queue import enqueue, list_queue
+    from api.session_queue import drain_for_session, enqueue, list_queue
 
     try:
         item = enqueue(sid, body)
     except ValueError as e:
         return bad(handler, str(e), 400)
+    drain_for_session(sid)
     return j(handler, {"ok": True, "session_id": sid, "item": item, "items": list_queue(sid)})
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -13698,6 +13698,16 @@ def handle_get(handler, parsed) -> bool:
     if parsed.path == "/api/clarify/stream":
         return _handle_clarify_sse_stream(handler, parsed)
 
+    if parsed.path == "/api/session/queue":
+        query = parse_qs(parsed.query)
+        sid = query.get("session_id", [""])[0]
+        try:
+            get_session(sid)
+        except KeyError:
+            return bad(handler, "Session not found", 404)
+        from api.session_queue import list_queue
+        return j(handler, {"ok": True, "session_id": sid, "items": list_queue(sid)})
+
     if parsed.path == "/api/session/stream":
         return _handle_session_sse_stream(handler, parsed)
 
@@ -15622,6 +15632,15 @@ def handle_post(handler, parsed) -> bool:
 
     if parsed.path == "/api/bg-task-complete-ack":
         return _handle_bg_task_complete_ack(handler, body)
+
+    if parsed.path == "/api/session/queue":
+        return _handle_session_queue_enqueue(handler, body)
+
+    if parsed.path == "/api/session/queue/update":
+        return _handle_session_queue_update(handler, body)
+
+    if parsed.path == "/api/session/queue/delete":
+        return _handle_session_queue_delete(handler, body)
 
     if parsed.path == "/api/chat/start":
         return _handle_chat_start(handler, body, diag=diag)
@@ -21901,6 +21920,10 @@ def start_session_turn(
     message: str,
     *,
     source: str = "process_wakeup",
+    attachments=None,
+    requested_model=None,
+    requested_provider=None,
+    queue_item_id: str | None = None,
 ):
     """Start a server-side agent turn for ``session_id`` with ``message``.
 
@@ -21952,8 +21975,13 @@ def start_session_turn(
     except ValueError as e:
         return {"error": str(e), "_status": 400}
 
-    requested_model = s.model
-    requested_provider = getattr(s, "model_provider", None)
+    requested_model = requested_model if requested_model not in (None, "") else s.model
+    requested_provider = (
+        requested_provider
+        if requested_provider not in (None, "")
+        else getattr(s, "model_provider", None)
+    )
+    turn_attachments = attachments or []
     # Server-initiated wakeup (Option Z): resolve persisted model via the
     # standard helper in cache-only mode so wakeups never trigger a cold
     # catalog rebuild. Thread the session's PROFILE model defaults through too
@@ -22085,7 +22113,7 @@ def start_session_turn(
     resp = _start_run(
         s,
         msg=msg,
-        attachments=[],
+        attachments=turn_attachments,
         workspace=workspace,
         model=model,
         model_provider=model_provider,
@@ -22124,6 +22152,7 @@ def start_session_turn(
                         "stream_id": str(stream_id),
                         "pending_started_at": (resp or {}).get("pending_started_at"),
                         "source": source,
+                        **({"queue_item_id": str(queue_item_id)} if queue_item_id else {}),
                     },
                 )
     except Exception:
@@ -22131,6 +22160,65 @@ def start_session_turn(
             "server_turn_started fan-out failed for session %s", session_id, exc_info=True
         )
     return resp
+
+
+def _handle_session_queue_enqueue(handler, body):
+    """Acknowledge a backend-owned queued follow-up turn for a session."""
+    try:
+        require(body, "session_id")
+    except ValueError as e:
+        return bad(handler, str(e))
+    sid = str(body.get("session_id") or "").strip()
+    try:
+        get_session(sid)
+    except KeyError:
+        return bad(handler, "Session not found", 404)
+    from api.session_queue import enqueue, list_queue
+
+    try:
+        item = enqueue(sid, body)
+    except ValueError as e:
+        return bad(handler, str(e), 400)
+    return j(handler, {"ok": True, "session_id": sid, "item": item, "items": list_queue(sid)})
+
+
+def _handle_session_queue_update(handler, body):
+    try:
+        require(body, "session_id")
+        require(body, "id")
+    except ValueError as e:
+        return bad(handler, str(e))
+    sid = str(body.get("session_id") or "").strip()
+    try:
+        get_session(sid)
+    except KeyError:
+        return bad(handler, "Session not found", 404)
+    from api.session_queue import list_queue, update_item
+
+    item = update_item(sid, str(body.get("id") or ""), body)
+    if item is None:
+        return bad(handler, "Queued item not found", 404)
+    return j(handler, {"ok": True, "session_id": sid, "item": item, "items": list_queue(sid)})
+
+
+def _handle_session_queue_delete(handler, body):
+    try:
+        require(body, "session_id")
+        require(body, "id")
+    except ValueError as e:
+        return bad(handler, str(e))
+    sid = str(body.get("session_id") or "").strip()
+    try:
+        get_session(sid)
+    except KeyError:
+        return bad(handler, "Session not found", 404)
+    from api.session_queue import delete_item, list_queue
+
+    deleted = delete_item(sid, str(body.get("id") or ""))
+    if not deleted:
+        return bad(handler, "Queued item not found", 404)
+    return j(handler, {"ok": True, "session_id": sid, "deleted": True, "items": list_queue(sid)})
+
 
 
 def _handle_bg_task_complete_ack(handler, body):

--- a/api/routes.py
+++ b/api/routes.py
@@ -22277,6 +22277,13 @@ def _handle_session_queue_enqueue(handler, body):
     return j(handler, {"ok": True, "session_id": sid, "item": item, "items": list_queue(sid)})
 
 
+def _drain_session_queue_after_mutation(session_id: str):
+    """Resume an idle FIFO when a successful mutation exposes a queued head."""
+    from api.session_queue import drain_for_session
+
+    drain_for_session(session_id)
+
+
 def _handle_session_queue_update(handler, body):
     try:
         require(body, "session_id")
@@ -22298,7 +22305,10 @@ def _handle_session_queue_update(handler, body):
         return bad(handler, str(e), 409)
     if item is None:
         return bad(handler, "Queued item not found", 404)
-    return j(handler, {"ok": True, "session_id": sid, "item": item, "items": list_queue(sid)})
+    _drain_session_queue_after_mutation(sid)
+    items = list_queue(sid)
+    current = next((entry for entry in items if entry.get("id") == item.get("id")), item)
+    return j(handler, {"ok": True, "session_id": sid, "item": current, "items": items})
 
 
 def _handle_session_queue_delete(handler, body):
@@ -22322,6 +22332,7 @@ def _handle_session_queue_delete(handler, body):
         return bad(handler, str(e), 409)
     if not deleted:
         return bad(handler, "Queued item not found", 404)
+    _drain_session_queue_after_mutation(sid)
     return j(handler, {"ok": True, "session_id": sid, "deleted": True, "items": list_queue(sid)})
 
 
@@ -22348,21 +22359,23 @@ def _handle_session_queue_order_mutation(handler, body, *, operation: str):
         QueueItemConflictError,
         QueueStorageError,
         combine_items,
+        list_queue,
         reorder_items,
     )
 
     try:
         if operation == "combine":
-            items = combine_items(sid, body.get("ordered_ids") or [])
+            combine_items(sid, body.get("ordered_ids") or [])
         else:
-            items = reorder_items(sid, body.get("ordered_ids") or [])
+            reorder_items(sid, body.get("ordered_ids") or [])
     except ValueError as e:
         return bad(handler, str(e), 400)
     except QueueItemConflictError as e:
         return bad(handler, str(e), 409)
     except QueueStorageError as e:
         return bad(handler, str(e), 503)
-    return j(handler, {"ok": True, "session_id": sid, "items": items})
+    _drain_session_queue_after_mutation(sid)
+    return j(handler, {"ok": True, "session_id": sid, "items": list_queue(sid)})
 
 
 def _handle_session_queue_clear(handler, body):

--- a/api/routes.py
+++ b/api/routes.py
@@ -13705,8 +13705,12 @@ def handle_get(handler, parsed) -> bool:
             get_session(sid)
         except KeyError:
             return bad(handler, "Session not found", 404)
-        from api.session_queue import list_queue
-        return j(handler, {"ok": True, "session_id": sid, "items": list_queue(sid)})
+        from api.session_queue import QueueStorageError, list_queue
+        try:
+            items = list_queue(sid)
+        except QueueStorageError as exc:
+            return bad(handler, str(exc), 503)
+        return j(handler, {"ok": True, "session_id": sid, "items": items})
 
     if parsed.path == "/api/session/stream":
         return _handle_session_sse_stream(handler, parsed)
@@ -15641,6 +15645,15 @@ def handle_post(handler, parsed) -> bool:
 
     if parsed.path == "/api/session/queue/delete":
         return _handle_session_queue_delete(handler, body)
+
+    if parsed.path == "/api/session/queue/reorder":
+        return _handle_session_queue_reorder(handler, body)
+
+    if parsed.path == "/api/session/queue/combine":
+        return _handle_session_queue_combine(handler, body)
+
+    if parsed.path == "/api/session/queue/clear":
+        return _handle_session_queue_clear(handler, body)
 
     if parsed.path == "/api/chat/start":
         return _handle_chat_start(handler, body, diag=diag)
@@ -21331,6 +21344,8 @@ def _prepare_chat_start_session_for_stream(
     stream_id: str,
     started_at: float | None = None,
     source: str = "webui",
+    queue_item_id: str | None = None,
+    queue_client_id: str | None = None,
 ):
     """Persist chat-start state according to webui.session_save_mode.
 
@@ -21351,6 +21366,8 @@ def _prepare_chat_start_session_for_stream(
     s.pending_attachments = attachments
     s.pending_started_at = started_at if started_at is not None else time.time()
     s.pending_user_source = source
+    s.pending_queue_item_id = str(queue_item_id or "").strip() or None
+    s.pending_queue_client_id = str(queue_client_id or "").strip() or None
     current_title = getattr(s, "title", None)
     if _is_default_or_empty_session_title(current_title):
         provisional_title = _provisional_title_from_prompt(msg, current_title or "Untitled")
@@ -21545,6 +21562,8 @@ def _start_chat_stream_for_session(
     source: str = "webui",
     moa_config=None,
     external_runtime_owned: bool | None = None,
+    queue_item_id: str | None = None,
+    queue_client_id: str | None = None,
 ):
     """Persist pending state, register an SSE channel, and start an agent turn."""
     if external_runtime_owned is None:
@@ -21625,6 +21644,8 @@ def _start_chat_stream_for_session(
                     model_provider=model_provider,
                     stream_id=stream_id,
                     source=source,
+                    queue_item_id=queue_item_id,
+                    queue_client_id=queue_client_id,
                 )
                 break
         if needs_stale_cleanup:
@@ -21659,6 +21680,8 @@ def _start_chat_stream_for_session(
                 "model": model,
                 "model_provider": model_provider,
                 "created_at": s.pending_started_at,
+                **({"queue_item_id": str(queue_item_id)} if queue_item_id else {}),
+                **({"queue_client_id": str(queue_client_id)} if queue_client_id else {}),
             },
         )
     except Exception:
@@ -21698,7 +21721,29 @@ def _start_chat_stream_for_session(
                 _clear_gateway_run_starting(stream_id)
             except Exception:
                 logger.debug("Failed to record gateway run-start failure for stream %s", stream_id, exc_info=True)
-        raise
+        with STREAMS_LOCK:
+            STREAMS.pop(stream_id, None)
+        unregister_stream_owner(stream_id)
+        try:
+            from api.config import clear_session_writeback_owner_if_owned
+
+            clear_session_writeback_owner_if_owned(s.session_id, stream_id)
+        except Exception:
+            logger.debug("Failed to clear writeback owner after worker start failure", exc_info=True)
+        with session_lock:
+            if getattr(s, "active_stream_id", None) == stream_id:
+                s.active_stream_id = None
+                s.pending_user_message = None
+                s.pending_attachments = []
+                s.pending_started_at = None
+                s.pending_user_source = None
+                s.pending_queue_item_id = None
+                s.pending_queue_client_id = None
+                try:
+                    s.save(touch_updated_at=False)
+                except Exception:
+                    logger.exception("Failed to persist worker start failure cleanup for %s", s.session_id)
+        return {"error": "failed to start agent worker", "_status": 500}
     response = {
         "stream_id": stream_id,
         "session_id": s.session_id,
@@ -21779,6 +21824,8 @@ def _start_run(
     diag=None,
     moa_config=None,
     gateway_chat_enabled: bool | None = None,
+    queue_item_id: str | None = None,
+    queue_client_id: str | None = None,
 ):
     """Shared start-run helper for /api/chat/start and start_session_turn.
 
@@ -21820,6 +21867,8 @@ def _start_run(
                 source=request.source or source,
                 moa_config=moa_config,
                 external_runtime_owned=gateway_chat_enabled,
+                queue_item_id=queue_item_id,
+                queue_client_id=queue_client_id,
             )
 
         def _legacy_adapter_factory():
@@ -21842,7 +21891,11 @@ def _start_run(
                     provider=model_provider,
                     model=model,
                     source=source,
-                    metadata={"route": route},
+                    metadata={
+                        "route": route,
+                        **({"queue_item_id": str(queue_item_id)} if queue_item_id else {}),
+                        **({"queue_client_id": str(queue_client_id)} if queue_client_id else {}),
+                    },
                 )
             )
         except NotImplementedError as exc:
@@ -21861,6 +21914,8 @@ def _start_run(
         source=source,
         moa_config=moa_config,
         external_runtime_owned=gateway_chat_enabled,
+        queue_item_id=queue_item_id,
+        queue_client_id=queue_client_id,
     )
 
 
@@ -21924,6 +21979,7 @@ def start_session_turn(
     requested_model=None,
     requested_provider=None,
     queue_item_id: str | None = None,
+    queue_client_id: str | None = None,
 ):
     """Start a server-side agent turn for ``session_id`` with ``message``.
 
@@ -22120,6 +22176,8 @@ def start_session_turn(
         normalized_model=normalized_model,
         source=turn_source,
         route="start_session_turn",
+        queue_item_id=queue_item_id,
+        queue_client_id=queue_client_id,
     )
 
     # ── Defect B: live-view of server-initiated turns ──────────────────────
@@ -22153,6 +22211,7 @@ def start_session_turn(
                         "pending_started_at": (resp or {}).get("pending_started_at"),
                         "source": source,
                         **({"queue_item_id": str(queue_item_id)} if queue_item_id else {}),
+                        **({"queue_client_id": str(queue_client_id)} if queue_client_id else {}),
                     },
                 )
     except Exception:
@@ -22173,10 +22232,21 @@ def _handle_session_queue_enqueue(handler, body):
         get_session(sid)
     except KeyError:
         return bad(handler, "Session not found", 404)
-    from api.session_queue import drain_for_session, enqueue, list_queue
+    from api.session_queue import (
+        QueueCapacityError,
+        QueueItemConflictError,
+        QueueStorageError,
+        drain_for_session,
+        enqueue,
+        list_queue,
+    )
 
     try:
         item = enqueue(sid, body)
+    except QueueStorageError as e:
+        return bad(handler, str(e), 503)
+    except (QueueCapacityError, QueueItemConflictError) as e:
+        return bad(handler, str(e), 409)
     except ValueError as e:
         return bad(handler, str(e), 400)
     drain_for_session(sid)
@@ -22194,9 +22264,14 @@ def _handle_session_queue_update(handler, body):
         get_session(sid)
     except KeyError:
         return bad(handler, "Session not found", 404)
-    from api.session_queue import list_queue, update_item
+    from api.session_queue import QueueItemConflictError, QueueStorageError, list_queue, update_item
 
-    item = update_item(sid, str(body.get("id") or ""), body)
+    try:
+        item = update_item(sid, str(body.get("id") or ""), body)
+    except QueueStorageError as e:
+        return bad(handler, str(e), 503)
+    except QueueItemConflictError as e:
+        return bad(handler, str(e), 409)
     if item is None:
         return bad(handler, "Queued item not found", 404)
     return j(handler, {"ok": True, "session_id": sid, "item": item, "items": list_queue(sid)})
@@ -22213,12 +22288,78 @@ def _handle_session_queue_delete(handler, body):
         get_session(sid)
     except KeyError:
         return bad(handler, "Session not found", 404)
-    from api.session_queue import delete_item, list_queue
+    from api.session_queue import QueueItemConflictError, QueueStorageError, delete_item, list_queue
 
-    deleted = delete_item(sid, str(body.get("id") or ""))
+    try:
+        deleted = delete_item(sid, str(body.get("id") or ""))
+    except QueueStorageError as e:
+        return bad(handler, str(e), 503)
+    except QueueItemConflictError as e:
+        return bad(handler, str(e), 409)
     if not deleted:
         return bad(handler, "Queued item not found", 404)
     return j(handler, {"ok": True, "session_id": sid, "deleted": True, "items": list_queue(sid)})
+
+
+def _handle_session_queue_reorder(handler, body):
+    return _handle_session_queue_order_mutation(handler, body, operation="reorder")
+
+
+def _handle_session_queue_combine(handler, body):
+    return _handle_session_queue_order_mutation(handler, body, operation="combine")
+
+
+def _handle_session_queue_order_mutation(handler, body, *, operation: str):
+    try:
+        require(body, "session_id")
+        require(body, "ordered_ids")
+    except ValueError as e:
+        return bad(handler, str(e))
+    sid = str(body.get("session_id") or "").strip()
+    try:
+        get_session(sid)
+    except KeyError:
+        return bad(handler, "Session not found", 404)
+    from api.session_queue import (
+        QueueItemConflictError,
+        QueueStorageError,
+        combine_items,
+        reorder_items,
+    )
+
+    try:
+        if operation == "combine":
+            items = combine_items(sid, body.get("ordered_ids") or [])
+        else:
+            items = reorder_items(sid, body.get("ordered_ids") or [])
+    except ValueError as e:
+        return bad(handler, str(e), 400)
+    except QueueItemConflictError as e:
+        return bad(handler, str(e), 409)
+    except QueueStorageError as e:
+        return bad(handler, str(e), 503)
+    return j(handler, {"ok": True, "session_id": sid, "items": items})
+
+
+def _handle_session_queue_clear(handler, body):
+    try:
+        require(body, "session_id")
+    except ValueError as e:
+        return bad(handler, str(e))
+    sid = str(body.get("session_id") or "").strip()
+    try:
+        get_session(sid)
+    except KeyError:
+        return bad(handler, "Session not found", 404)
+    from api.session_queue import QueueItemConflictError, QueueStorageError, clear_queue
+
+    try:
+        deleted = clear_queue(sid)
+    except QueueItemConflictError as e:
+        return bad(handler, str(e), 409)
+    except QueueStorageError as e:
+        return bad(handler, str(e), 503)
+    return j(handler, {"ok": True, "session_id": sid, "deleted": deleted, "items": []})
 
 
 

--- a/api/session_queue.py
+++ b/api/session_queue.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 
 _LOCK = threading.RLock()
 _SAFE_SESSION_ID_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+_MAX_QUEUE_ITEMS = 50
+_MAX_START_RETRIES = 3
 
 
 def _queue_dir() -> Path:
@@ -109,17 +111,29 @@ def _normalize_attachments(raw: Any) -> list[dict[str, Any]]:
     return out
 
 
+def _normalize_model_provider(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 def _public_item(item: dict[str, Any]) -> dict[str, Any]:
-    return {
+    out = {
         "id": str(item.get("id") or ""),
         "session_id": str(item.get("session_id") or ""),
         "text": str(item.get("text") or ""),
         "attachments": list(item.get("attachments") or []),
         "model": str(item.get("model") or ""),
-        "model_provider": item.get("model_provider"),
+        "model_provider": _normalize_model_provider(item.get("model_provider")),
         "profile": str(item.get("profile") or ""),
         "created_at": float(item.get("created_at") or 0.0),
     }
+    if item.get("blocked"):
+        out["blocked"] = True
+    if item.get("error"):
+        out["error"] = str(item.get("error") or "")
+    return out
 
 
 def list_queue(session_id: str) -> list[dict[str, Any]]:
@@ -131,7 +145,7 @@ def enqueue(session_id: str, payload: dict[str, Any]) -> dict[str, Any]:
     text = str(payload.get("text") or payload.get("message") or "").strip()
     if not session_id:
         raise ValueError("session_id is required")
-    if not text and not payload.get("attachments") and not payload.get("files"):
+    if not text:
         raise ValueError("text is required")
     item = {
         "id": uuid.uuid4().hex,
@@ -139,12 +153,14 @@ def enqueue(session_id: str, payload: dict[str, Any]) -> dict[str, Any]:
         "text": text,
         "attachments": _normalize_attachments(payload.get("attachments") or payload.get("files") or []),
         "model": str(payload.get("model") or ""),
-        "model_provider": payload.get("model_provider"),
+        "model_provider": _normalize_model_provider(payload.get("model_provider")),
         "profile": str(payload.get("profile") or ""),
         "created_at": time.time(),
     }
     with _LOCK:
         items = _read_items_unlocked(session_id)
+        if len(items) >= _MAX_QUEUE_ITEMS:
+            items = items[-(_MAX_QUEUE_ITEMS - 1) :]
         items.append(item)
         _write_items_unlocked(session_id, items)
     return _public_item(item)
@@ -165,7 +181,11 @@ def update_item(session_id: str, item_id: str, patch: dict[str, Any]) -> dict[st
             if "model" in patch:
                 item["model"] = str(patch.get("model") or "")
             if "model_provider" in patch:
-                item["model_provider"] = patch.get("model_provider")
+                item["model_provider"] = _normalize_model_provider(patch.get("model_provider"))
+            if any(key in patch for key in ("text", "model", "model_provider")):
+                item.pop("blocked", None)
+                item.pop("error", None)
+                item.pop("retry_count", None)
             _write_items_unlocked(session_id, items)
             return _public_item(item)
     return None
@@ -190,7 +210,10 @@ def claim_next(session_id: str) -> dict[str, Any] | None:
         items = _read_items_unlocked(session_id)
         if not items:
             return None
-        item = items.pop(0)
+        idx = next((i for i, existing in enumerate(items) if not existing.get("blocked")), -1)
+        if idx < 0:
+            return None
+        item = items.pop(idx)
         _write_items_unlocked(session_id, items)
         return dict(item)
 
@@ -254,14 +277,21 @@ def drain_for_session(session_id: str) -> int:
             if status == 409:
                 requeue_front(session_id, item)
             elif status >= 400:
+                retry_count = int(item.get("retry_count") or 0) + 1
+                item["retry_count"] = retry_count
+                item["error"] = str((resp or {}).get("error") or f"start_failed_{status}")
+                if status < 500 and retry_count >= _MAX_START_RETRIES:
+                    item["blocked"] = True
                 # Keep user intent instead of dropping it on transient or
-                # configuration errors; the browser can still show/edit/delete
-                # it after reconnect.
+                # configuration errors; blocked items remain editable/deletable
+                # but claim_next will not churn on them every teardown.
                 requeue_front(session_id, item)
                 logger.warning(
-                    "queued follow-up failed for session %s: status=%s err=%r",
+                    "queued follow-up failed for session %s: status=%s retries=%s blocked=%s err=%r",
                     session_id,
                     status,
+                    retry_count,
+                    bool(item.get("blocked")),
                     (resp or {}).get("error"),
                 )
             else:

--- a/api/session_queue.py
+++ b/api/session_queue.py
@@ -1,0 +1,283 @@
+"""Backend-owned queued follow-up turns for WebUI sessions.
+
+The browser may optimistically render queue chips, but once this module
+acknowledges an item the backend owns dispatch.  The invariant is:
+
+    acknowledged queued follow-ups drain into their original session after the
+    active run settles, even if no browser tab is connected.
+
+Storage is deliberately small and local: one JSON file per session under the
+WebUI session directory.  This keeps the first implementation profile/state-dir
+local without introducing a database migration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_LOCK = threading.RLock()
+_SAFE_SESSION_ID_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _queue_dir() -> Path:
+    from api.config import SESSION_DIR
+
+    path = Path(SESSION_DIR) / "_session_queue"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _queue_path(session_id: str) -> Path:
+    safe = _SAFE_SESSION_ID_RE.sub("_", str(session_id or "").strip())
+    if not safe:
+        safe = "unknown"
+    return _queue_dir() / f"{safe}.json"
+
+
+def _read_items_unlocked(session_id: str) -> list[dict[str, Any]]:
+    path = _queue_path(session_id)
+    try:
+        raw = path.read_text(encoding="utf-8")
+        parsed = json.loads(raw)
+    except FileNotFoundError:
+        return []
+    except Exception:
+        logger.warning("Failed to read session queue for %s", session_id, exc_info=True)
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [dict(item) for item in parsed if isinstance(item, dict)]
+
+
+def _write_items_unlocked(session_id: str, items: list[dict[str, Any]]) -> None:
+    path = _queue_path(session_id)
+    if not items:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        return
+    payload = json.dumps(items, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, path)
+    finally:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+
+
+def _normalize_attachments(raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for item in raw[:20]:
+        if isinstance(item, dict):
+            att: dict[str, Any] = {}
+            for key in ("name", "filename", "path", "mime"):
+                value = item.get(key)
+                if value not in (None, ""):
+                    att[key] = str(value)
+            size = item.get("size")
+            if isinstance(size, int):
+                att["size"] = size
+            is_image = item.get("is_image")
+            if isinstance(is_image, bool):
+                att["is_image"] = is_image
+            if att:
+                out.append(att)
+        else:
+            value = str(item or "").strip()
+            if value:
+                out.append({"name": value})
+    return out
+
+
+def _public_item(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": str(item.get("id") or ""),
+        "session_id": str(item.get("session_id") or ""),
+        "text": str(item.get("text") or ""),
+        "attachments": list(item.get("attachments") or []),
+        "model": str(item.get("model") or ""),
+        "model_provider": item.get("model_provider"),
+        "profile": str(item.get("profile") or ""),
+        "created_at": float(item.get("created_at") or 0.0),
+    }
+
+
+def list_queue(session_id: str) -> list[dict[str, Any]]:
+    with _LOCK:
+        return [_public_item(item) for item in _read_items_unlocked(session_id)]
+
+
+def enqueue(session_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+    text = str(payload.get("text") or payload.get("message") or "").strip()
+    if not session_id:
+        raise ValueError("session_id is required")
+    if not text and not payload.get("attachments") and not payload.get("files"):
+        raise ValueError("text is required")
+    item = {
+        "id": uuid.uuid4().hex,
+        "session_id": str(session_id),
+        "text": text,
+        "attachments": _normalize_attachments(payload.get("attachments") or payload.get("files") or []),
+        "model": str(payload.get("model") or ""),
+        "model_provider": payload.get("model_provider"),
+        "profile": str(payload.get("profile") or ""),
+        "created_at": time.time(),
+    }
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        items.append(item)
+        _write_items_unlocked(session_id, items)
+    return _public_item(item)
+
+
+def update_item(session_id: str, item_id: str, patch: dict[str, Any]) -> dict[str, Any] | None:
+    if not session_id or not item_id:
+        return None
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        for item in items:
+            if str(item.get("id") or "") != str(item_id):
+                continue
+            if "text" in patch:
+                text = str(patch.get("text") or "").strip()
+                if text:
+                    item["text"] = text
+            if "model" in patch:
+                item["model"] = str(patch.get("model") or "")
+            if "model_provider" in patch:
+                item["model_provider"] = patch.get("model_provider")
+            _write_items_unlocked(session_id, items)
+            return _public_item(item)
+    return None
+
+
+def delete_item(session_id: str, item_id: str) -> bool:
+    if not session_id or not item_id:
+        return False
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        kept = [item for item in items if str(item.get("id") or "") != str(item_id)]
+        if len(kept) == len(items):
+            return False
+        _write_items_unlocked(session_id, kept)
+        return True
+
+
+def claim_next(session_id: str) -> dict[str, Any] | None:
+    if not session_id:
+        return None
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        if not items:
+            return None
+        item = items.pop(0)
+        _write_items_unlocked(session_id, items)
+        return dict(item)
+
+
+def requeue_front(session_id: str, item: dict[str, Any]) -> None:
+    if not session_id or not item:
+        return
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        # Preserve exact-once-ish behavior: do not duplicate an item id already
+        # requeued by a racing 409 handler.
+        item_id = str(item.get("id") or "")
+        if item_id and any(str(existing.get("id") or "") == item_id for existing in items):
+            return
+        items.insert(0, dict(item))
+        _write_items_unlocked(session_id, items)
+
+
+def _session_has_active_turn(session_id: str) -> bool:
+    try:
+        from api import config as _cfg
+
+        with _cfg.ACTIVE_RUNS_LOCK:
+            for _stream_id, meta in (_cfg.ACTIVE_RUNS or {}).items():
+                if isinstance(meta, dict) and meta.get("session_id") == session_id:
+                    return True
+    except Exception:
+        logger.debug("ACTIVE_RUNS queue active-turn check failed", exc_info=True)
+    return False
+
+
+def drain_for_session(session_id: str) -> int:
+    """Start at most one queued follow-up turn for an idle session.
+
+    Called from the streaming teardown hook after ``unregister_active_run``.
+    It claims one item atomically, starts it on a daemon thread, and requeues the
+    item if the existing chat-start guard reports a 409 race.
+    """
+    if not session_id:
+        return 0
+    if _session_has_active_turn(session_id):
+        return 0
+    item = claim_next(session_id)
+    if not item:
+        return 0
+
+    def _runner() -> None:
+        try:
+            from api.routes import start_session_turn
+
+            resp = start_session_turn(
+                session_id,
+                str(item.get("text") or ""),
+                source="queued_followup",
+                attachments=list(item.get("attachments") or []),
+                requested_model=str(item.get("model") or "") or None,
+                requested_provider=item.get("model_provider"),
+                queue_item_id=str(item.get("id") or "") or None,
+            )
+            status = int((resp or {}).get("_status", 200) or 200)
+            if status == 409:
+                requeue_front(session_id, item)
+            elif status >= 400:
+                # Keep user intent instead of dropping it on transient or
+                # configuration errors; the browser can still show/edit/delete
+                # it after reconnect.
+                requeue_front(session_id, item)
+                logger.warning(
+                    "queued follow-up failed for session %s: status=%s err=%r",
+                    session_id,
+                    status,
+                    (resp or {}).get("error"),
+                )
+            else:
+                logger.info(
+                    "queued follow-up turn started for session %s item=%s stream_id=%s",
+                    session_id,
+                    item.get("id"),
+                    (resp or {}).get("stream_id"),
+                )
+        except Exception:
+            requeue_front(session_id, item)
+            logger.warning("queued follow-up turn raised for session %s", session_id, exc_info=True)
+
+    threading.Thread(
+        target=_runner,
+        name=f"hermes-webui-queued-followup-{str(session_id)[:8]}",
+        daemon=True,
+    ).start()
+    return 1

--- a/api/session_queue.py
+++ b/api/session_queue.py
@@ -30,6 +30,32 @@ _LOCK = threading.RLock()
 _SAFE_SESSION_ID_RE = re.compile(r"[^A-Za-z0-9_.-]+")
 _MAX_QUEUE_ITEMS = 50
 _MAX_START_RETRIES = 3
+_MAX_RECEIPTS = 256
+_RETRY_DELAY_SECONDS = 0.25
+_DRAINING_SESSIONS: set[str] = set()
+
+
+class QueueStorageError(RuntimeError):
+    """The persisted queue cannot be trusted and must not be overwritten."""
+
+
+class QueueCapacityError(ValueError):
+    """The session queue is full; acknowledged items are never evicted."""
+
+
+class QueueItemConflictError(RuntimeError):
+    """A queue mutation lost ownership because the item already started."""
+
+
+def _emit_queue_changed(session_id: str) -> None:
+    try:
+        from api.background_process import get_session_channel
+
+        channel = get_session_channel(session_id)
+        if channel is not None:
+            channel.emit("session_queue_changed", {"session_id": session_id})
+    except Exception:
+        logger.debug("Failed to emit queue change for %s", session_id, exc_info=True)
 
 
 def _queue_dir() -> Path:
@@ -41,10 +67,19 @@ def _queue_dir() -> Path:
 
 
 def _queue_path(session_id: str) -> Path:
-    safe = _SAFE_SESSION_ID_RE.sub("_", str(session_id or "").strip())
-    if not safe:
-        safe = "unknown"
-    return _queue_dir() / f"{safe}.json"
+    from api.models import is_safe_session_id
+
+    normalized = str(session_id or "").strip()
+    if not is_safe_session_id(normalized):
+        raise ValueError("session_id is not path-safe")
+    return _queue_dir() / f"{normalized}.json"
+
+
+def _receipt_path(session_id: str) -> Path:
+    queue_path = _queue_path(session_id)
+    receipt_dir = queue_path.parent / "receipts"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    return receipt_dir / queue_path.name
 
 
 def _read_items_unlocked(session_id: str) -> list[dict[str, Any]]:
@@ -54,12 +89,58 @@ def _read_items_unlocked(session_id: str) -> list[dict[str, Any]]:
         parsed = json.loads(raw)
     except FileNotFoundError:
         return []
-    except Exception:
-        logger.warning("Failed to read session queue for %s", session_id, exc_info=True)
-        return []
+    except Exception as exc:
+        logger.error("Corrupt session queue for %s; refusing mutation", session_id, exc_info=True)
+        raise QueueStorageError(f"failed to read corrupt session queue for {session_id}") from exc
     if not isinstance(parsed, list):
+        raise QueueStorageError(f"corrupt session queue for {session_id}: expected a list")
+    items: list[dict[str, Any]] = []
+    for raw_item in parsed:
+        if not isinstance(raw_item, dict):
+            raise QueueStorageError(f"corrupt session queue for {session_id}: invalid item")
+        item = dict(raw_item)
+        item_id = str(item.get("id") or "").strip()
+        if not item_id:
+            raise QueueStorageError(f"corrupt session queue for {session_id}: item id missing")
+        item["id"] = item_id
+        if str(item.get("session_id") or "") != str(session_id):
+            raise QueueStorageError(f"queue owner does not match requested session {session_id}")
+        item.setdefault("client_queue_id", f"legacy:{item_id}")
+        if item.get("blocked") and not item.get("state"):
+            item["state"] = "blocked"
+        item.setdefault("state", "queued")
+        items.append(item)
+    return items
+
+
+def _read_receipts_unlocked(session_id: str) -> list[dict[str, Any]]:
+    path = _receipt_path(session_id)
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
         return []
-    return [dict(item) for item in parsed if isinstance(item, dict)]
+    except Exception as exc:
+        raise QueueStorageError(f"failed to read corrupt queue receipts for {session_id}") from exc
+    if not isinstance(parsed, list):
+        raise QueueStorageError(f"corrupt queue receipts for {session_id}: expected a list")
+    receipts = []
+    for receipt in parsed:
+        if not isinstance(receipt, dict) or str(receipt.get("session_id") or "") != session_id:
+            raise QueueStorageError(f"corrupt queue receipt owner for {session_id}")
+        receipts.append(dict(receipt))
+    return receipts
+
+
+def _fsync_parent(path: Path) -> None:
+    """Make a replace/unlink durable across a process or host crash."""
+    try:
+        fd = os.open(path.parent, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
 
 
 def _write_items_unlocked(session_id: str, items: list[dict[str, Any]]) -> None:
@@ -69,6 +150,8 @@ def _write_items_unlocked(session_id: str, items: list[dict[str, Any]]) -> None:
             path.unlink()
         except FileNotFoundError:
             pass
+        else:
+            _fsync_parent(path)
         return
     payload = json.dumps(items, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
     fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
@@ -78,11 +161,45 @@ def _write_items_unlocked(session_id: str, items: list[dict[str, Any]]) -> None:
             fh.flush()
             os.fsync(fh.fileno())
         os.replace(tmp_name, path)
+        _fsync_parent(path)
     finally:
         try:
             os.unlink(tmp_name)
         except FileNotFoundError:
             pass
+
+
+def _write_receipts_unlocked(session_id: str, receipts: list[dict[str, Any]]) -> None:
+    path = _receipt_path(session_id)
+    payload = json.dumps(receipts[-_MAX_RECEIPTS:], ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, path)
+        _fsync_parent(path)
+    finally:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+
+
+def _record_completed_unlocked(session_id: str, completed_items: list[dict[str, Any]]) -> None:
+    if not completed_items:
+        return
+    receipts = _read_receipts_unlocked(session_id)
+    by_client_id = {str(receipt.get("client_queue_id") or ""): receipt for receipt in receipts}
+    for item in completed_items:
+        client_queue_id = str(item.get("client_queue_id") or "")
+        receipt = _public_item(item)
+        receipt["state"] = "completed"
+        receipt["completed_at"] = time.time()
+        by_client_id[client_queue_id] = receipt
+    ordered = sorted(by_client_id.values(), key=lambda value: float(value.get("completed_at") or 0.0))
+    _write_receipts_unlocked(session_id, ordered[-_MAX_RECEIPTS:])
 
 
 def _normalize_attachments(raw: Any) -> list[dict[str, Any]]:
@@ -121,6 +238,7 @@ def _normalize_model_provider(value: Any) -> str | None:
 def _public_item(item: dict[str, Any]) -> dict[str, Any]:
     out = {
         "id": str(item.get("id") or ""),
+        "client_queue_id": str(item.get("client_queue_id") or ""),
         "session_id": str(item.get("session_id") or ""),
         "text": str(item.get("text") or ""),
         "attachments": list(item.get("attachments") or []),
@@ -128,12 +246,29 @@ def _public_item(item: dict[str, Any]) -> dict[str, Any]:
         "model_provider": _normalize_model_provider(item.get("model_provider")),
         "profile": str(item.get("profile") or ""),
         "created_at": float(item.get("created_at") or 0.0),
+        "state": str(item.get("state") or "queued"),
     }
+    if item.get("stream_id"):
+        out["stream_id"] = str(item.get("stream_id") or "")
     if item.get("blocked"):
         out["blocked"] = True
     if item.get("error"):
         out["error"] = str(item.get("error") or "")
+    if item.get("retry_count") is not None:
+        out["retry_count"] = int(item.get("retry_count") or 0)
     return out
+
+
+def _same_intent(item: dict[str, Any], payload: dict[str, Any], text: str) -> bool:
+    return (
+        str(item.get("text") or "") == text
+        and list(item.get("attachments") or [])
+        == _normalize_attachments(payload.get("attachments") or payload.get("files") or [])
+        and str(item.get("model") or "") == str(payload.get("model") or "")
+        and _normalize_model_provider(item.get("model_provider"))
+        == _normalize_model_provider(payload.get("model_provider"))
+        and str(item.get("profile") or "") == str(payload.get("profile") or "")
+    )
 
 
 def list_queue(session_id: str) -> list[dict[str, Any]]:
@@ -147,22 +282,40 @@ def enqueue(session_id: str, payload: dict[str, Any]) -> dict[str, Any]:
         raise ValueError("session_id is required")
     if not text:
         raise ValueError("text is required")
-    item = {
-        "id": uuid.uuid4().hex,
-        "session_id": str(session_id),
-        "text": text,
-        "attachments": _normalize_attachments(payload.get("attachments") or payload.get("files") or []),
-        "model": str(payload.get("model") or ""),
-        "model_provider": _normalize_model_provider(payload.get("model_provider")),
-        "profile": str(payload.get("profile") or ""),
-        "created_at": time.time(),
-    }
+    client_queue_id = str(payload.get("client_queue_id") or "").strip()
+    if not client_queue_id:
+        raise ValueError("client_queue_id is required")
     with _LOCK:
         items = _read_items_unlocked(session_id)
+        for existing in items:
+            if str(existing.get("client_queue_id") or "") != client_queue_id:
+                continue
+            if not _same_intent(existing, payload, text):
+                raise QueueItemConflictError("client_queue_id already owns a different queued item")
+            return _public_item(existing)
+        for receipt in _read_receipts_unlocked(session_id):
+            if str(receipt.get("client_queue_id") or "") != client_queue_id:
+                continue
+            if not _same_intent(receipt, payload, text):
+                raise QueueItemConflictError("client_queue_id already owns a different completed item")
+            return _public_item(receipt)
         if len(items) >= _MAX_QUEUE_ITEMS:
-            items = items[-(_MAX_QUEUE_ITEMS - 1) :]
+            raise QueueCapacityError(f"session queue is at capacity ({_MAX_QUEUE_ITEMS})")
+        item = {
+            "id": uuid.uuid4().hex,
+            "client_queue_id": client_queue_id,
+            "session_id": str(session_id),
+            "text": text,
+            "attachments": _normalize_attachments(payload.get("attachments") or payload.get("files") or []),
+            "model": str(payload.get("model") or ""),
+            "model_provider": _normalize_model_provider(payload.get("model_provider")),
+            "profile": str(payload.get("profile") or ""),
+            "created_at": time.time(),
+            "state": "queued",
+        }
         items.append(item)
         _write_items_unlocked(session_id, items)
+        _emit_queue_changed(session_id)
     return _public_item(item)
 
 
@@ -174,6 +327,8 @@ def update_item(session_id: str, item_id: str, patch: dict[str, Any]) -> dict[st
         for item in items:
             if str(item.get("id") or "") != str(item_id):
                 continue
+            if str(item.get("state") or "queued") not in ("queued", "blocked"):
+                raise QueueItemConflictError("queued item already started")
             if "text" in patch:
                 text = str(patch.get("text") or "").strip()
                 if text:
@@ -186,7 +341,9 @@ def update_item(session_id: str, item_id: str, patch: dict[str, Any]) -> dict[st
                 item.pop("blocked", None)
                 item.pop("error", None)
                 item.pop("retry_count", None)
+                item["state"] = "queued"
             _write_items_unlocked(session_id, items)
+            _emit_queue_changed(session_id)
             return _public_item(item)
     return None
 
@@ -196,11 +353,77 @@ def delete_item(session_id: str, item_id: str) -> bool:
         return False
     with _LOCK:
         items = _read_items_unlocked(session_id)
-        kept = [item for item in items if str(item.get("id") or "") != str(item_id)]
-        if len(kept) == len(items):
+        target = next((item for item in items if str(item.get("id") or "") == str(item_id)), None)
+        if target is None:
             return False
+        if str(target.get("state") or "queued") not in ("queued", "blocked"):
+            raise QueueItemConflictError("queued item already started")
+        kept = [item for item in items if str(item.get("id") or "") != str(item_id)]
         _write_items_unlocked(session_id, kept)
+        _emit_queue_changed(session_id)
         return True
+
+
+def _require_mutable_items(items: list[dict[str, Any]]) -> None:
+    if any(str(item.get("state") or "queued") not in ("queued", "blocked") for item in items):
+        raise QueueItemConflictError("queued item is already starting or started")
+
+
+def reorder_items(session_id: str, ordered_ids: list[str]) -> list[dict[str, Any]]:
+    """Persist an exact authoritative FIFO order in one locked write."""
+    normalized = [str(item_id or "").strip() for item_id in ordered_ids]
+    if not session_id or not normalized or any(not item_id for item_id in normalized):
+        raise ValueError("session_id and ordered_ids are required")
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("ordered_ids must be unique")
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        _require_mutable_items(items)
+        by_id = {str(item.get("id") or ""): item for item in items}
+        if set(normalized) != set(by_id):
+            raise QueueItemConflictError("ordered_ids no longer match the authoritative queue")
+        reordered = [by_id[item_id] for item_id in normalized]
+        _write_items_unlocked(session_id, reordered)
+        _emit_queue_changed(session_id)
+        return [_public_item(item) for item in reordered]
+
+
+def combine_items(session_id: str, ordered_ids: list[str]) -> list[dict[str, Any]]:
+    """Combine selected FIFO items without exposing a delete/create gap."""
+    normalized = [str(item_id or "").strip() for item_id in ordered_ids]
+    if not session_id or len(normalized) < 2 or len(set(normalized)) != len(normalized):
+        raise ValueError("at least two unique ordered_ids are required")
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        _require_mutable_items(items)
+        by_id = {str(item.get("id") or ""): item for item in items}
+        if any(item_id not in by_id for item_id in normalized):
+            raise QueueItemConflictError("combined items no longer match the authoritative queue")
+        selected = [by_id[item_id] for item_id in normalized]
+        first = selected[0]
+        first["text"] = "\n\n".join(str(item.get("text") or "").strip() for item in selected).strip()
+        attachments: list[dict[str, Any]] = []
+        for item in selected:
+            attachments.extend(_normalize_attachments(item.get("attachments") or []))
+        first["attachments"] = attachments
+        selected_ids = set(normalized)
+        insertion_index = min(index for index, item in enumerate(items) if str(item.get("id") or "") in selected_ids)
+        combined = [item for item in items if str(item.get("id") or "") not in selected_ids]
+        combined.insert(insertion_index, first)
+        _write_items_unlocked(session_id, combined)
+        _emit_queue_changed(session_id)
+        return [_public_item(item) for item in combined]
+
+
+def clear_queue(session_id: str) -> int:
+    if not session_id:
+        return 0
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        _require_mutable_items(items)
+        _write_items_unlocked(session_id, [])
+        _emit_queue_changed(session_id)
+        return len(items)
 
 
 def claim_next(session_id: str) -> dict[str, Any] | None:
@@ -210,11 +433,13 @@ def claim_next(session_id: str) -> dict[str, Any] | None:
         items = _read_items_unlocked(session_id)
         if not items:
             return None
-        idx = next((i for i, existing in enumerate(items) if not existing.get("blocked")), -1)
-        if idx < 0:
+        item = items[0]
+        if str(item.get("state") or "queued") != "queued":
             return None
-        item = items.pop(idx)
+        item["state"] = "starting"
+        item["starting_at"] = time.time()
         _write_items_unlocked(session_id, items)
+        _emit_queue_changed(session_id)
         return dict(item)
 
 
@@ -226,10 +451,98 @@ def requeue_front(session_id: str, item: dict[str, Any]) -> None:
         # Preserve exact-once-ish behavior: do not duplicate an item id already
         # requeued by a racing 409 handler.
         item_id = str(item.get("id") or "")
-        if item_id and any(str(existing.get("id") or "") == item_id for existing in items):
-            return
-        items.insert(0, dict(item))
+        for idx, existing in enumerate(items):
+            if item_id and str(existing.get("id") or "") == item_id:
+                restored = dict(existing)
+                restored.update(item)
+                restored["state"] = "blocked" if restored.get("blocked") else "queued"
+                restored.pop("starting_at", None)
+                restored.pop("stream_id", None)
+                items[idx] = restored
+                _write_items_unlocked(session_id, items)
+                _emit_queue_changed(session_id)
+                return
+        restored = dict(item)
+        restored["state"] = "blocked" if restored.get("blocked") else "queued"
+        restored.pop("starting_at", None)
+        restored.pop("stream_id", None)
+        items.insert(0, restored)
         _write_items_unlocked(session_id, items)
+        _emit_queue_changed(session_id)
+
+
+def _finish_attempt(session_id: str, item_id: str, response: dict[str, Any]) -> None:
+    status = int((response or {}).get("_status", 200) or 200)
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        item = next((entry for entry in items if str(entry.get("id") or "") == item_id), None)
+        if item is None:
+            return
+        item.pop("starting_at", None)
+        if status == 409:
+            item["state"] = "queued"
+        elif status >= 400:
+            retry_count = int(item.get("retry_count") or 0) + 1
+            item["retry_count"] = retry_count
+            item["error"] = str((response or {}).get("error") or f"start_failed_{status}")
+            if retry_count >= _MAX_START_RETRIES:
+                item["blocked"] = True
+                item["state"] = "blocked"
+            else:
+                item["state"] = "queued"
+        else:
+            stream_id = str((response or {}).get("stream_id") or "").strip()
+            if not stream_id:
+                item["state"] = "queued"
+                item["error"] = "start response did not include a stream id"
+            elif not _stream_is_still_active(session_id, stream_id):
+                # The worker can finish between returning its start response
+                # and this durable transition. Teardown cannot retire a
+                # `starting` item, so retire it here while holding the same
+                # queue lock; otherwise a completed turn leaves a tombstone.
+                _record_completed_unlocked(session_id, [item])
+                items.remove(item)
+            else:
+                item["state"] = "started"
+                item["stream_id"] = stream_id
+                item["started_at"] = time.time()
+                item.pop("blocked", None)
+                item.pop("error", None)
+        _write_items_unlocked(session_id, items)
+        _emit_queue_changed(session_id)
+
+
+def complete_started(session_id: str, stream_id: str) -> bool:
+    """Retire the queue tombstone after the correlated turn tears down."""
+    if not session_id or not stream_id:
+        return False
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        completed = [
+            item
+            for item in items
+            if (
+                str(item.get("state") or "") == "started"
+                and str(item.get("stream_id") or "") == str(stream_id)
+            )
+        ]
+        kept = [
+            item
+            for item in items
+            if not (
+                str(item.get("state") or "") == "started"
+                and str(item.get("stream_id") or "") == str(stream_id)
+            )
+        ]
+        if len(kept) == len(items):
+            return False
+        # Persist the idempotency receipt before removing the queue owner. If
+        # the process dies between these writes, recovery sees the remaining
+        # started item and retires it without allowing a duplicate enqueue.
+        _record_completed_unlocked(session_id, completed)
+        _write_items_unlocked(session_id, kept)
+        _emit_queue_changed(session_id)
+        return True
 
 
 def _session_has_active_turn(session_id: str) -> bool:
@@ -245,6 +558,45 @@ def _session_has_active_turn(session_id: str) -> bool:
     return False
 
 
+def _stream_is_still_active(session_id: str, stream_id: str) -> bool:
+    try:
+        from api import config
+
+        with config.ACTIVE_RUNS_LOCK:
+            for active_stream_id, active in config.ACTIVE_RUNS.items():
+                if str(active_stream_id) == stream_id and str((active or {}).get("session_id") or "") == session_id:
+                    return True
+    except Exception:
+        logger.debug("Could not inspect active runs for queue completion", exc_info=True)
+    try:
+        from api.routes import STREAMS, get_session
+
+        if stream_id in STREAMS:
+            return True
+        return str(getattr(get_session(session_id), "active_stream_id", None) or "") == stream_id
+    except Exception:
+        return False
+
+
+def _stream_has_live_runtime(session_id: str, stream_id: str) -> bool:
+    """Return true only for process-live ownership, not a persisted session id."""
+    try:
+        from api import config
+
+        with config.ACTIVE_RUNS_LOCK:
+            active = config.ACTIVE_RUNS.get(stream_id)
+            if isinstance(active, dict) and str(active.get("session_id") or "") == session_id:
+                return True
+    except Exception:
+        logger.debug("Could not inspect active runs during queue recovery", exc_info=True)
+    try:
+        from api.routes import STREAMS
+
+        return stream_id in STREAMS
+    except Exception:
+        return False
+
+
 def drain_for_session(session_id: str) -> int:
     """Start at most one queued follow-up turn for an idle session.
 
@@ -254,13 +606,16 @@ def drain_for_session(session_id: str) -> int:
     """
     if not session_id:
         return 0
-    if _session_has_active_turn(session_id):
-        return 0
-    item = claim_next(session_id)
-    if not item:
-        return 0
+    with _LOCK:
+        if session_id in _DRAINING_SESSIONS or _session_has_active_turn(session_id):
+            return 0
+        item = claim_next(session_id)
+        if not item:
+            return 0
+        _DRAINING_SESSIONS.add(session_id)
 
     def _runner() -> None:
+        retry_needed = False
         try:
             from api.routes import start_session_turn
 
@@ -272,26 +627,18 @@ def drain_for_session(session_id: str) -> int:
                 requested_model=str(item.get("model") or "") or None,
                 requested_provider=item.get("model_provider"),
                 queue_item_id=str(item.get("id") or "") or None,
+                queue_client_id=str(item.get("client_queue_id") or "") or None,
             )
             status = int((resp or {}).get("_status", 200) or 200)
-            if status == 409:
-                requeue_front(session_id, item)
-            elif status >= 400:
-                retry_count = int(item.get("retry_count") or 0) + 1
-                item["retry_count"] = retry_count
-                item["error"] = str((resp or {}).get("error") or f"start_failed_{status}")
-                if status < 500 and retry_count >= _MAX_START_RETRIES:
-                    item["blocked"] = True
-                # Keep user intent instead of dropping it on transient or
-                # configuration errors; blocked items remain editable/deletable
-                # but claim_next will not churn on them every teardown.
-                requeue_front(session_id, item)
+            _finish_attempt(session_id, str(item.get("id") or ""), resp or {})
+            if status >= 400:
+                retry_needed = status != 409
                 logger.warning(
                     "queued follow-up failed for session %s: status=%s retries=%s blocked=%s err=%r",
                     session_id,
                     status,
-                    retry_count,
-                    bool(item.get("blocked")),
+                    int(item.get("retry_count") or 0) + 1,
+                    int(item.get("retry_count") or 0) + 1 >= _MAX_START_RETRIES,
                     (resp or {}).get("error"),
                 )
             else:
@@ -301,13 +648,113 @@ def drain_for_session(session_id: str) -> int:
                     item.get("id"),
                     (resp or {}).get("stream_id"),
                 )
-        except Exception:
-            requeue_front(session_id, item)
+        except Exception as exc:
+            _finish_attempt(
+                session_id,
+                str(item.get("id") or ""),
+                {"_status": 500, "error": str(exc) or type(exc).__name__},
+            )
+            retry_needed = True
             logger.warning("queued follow-up turn raised for session %s", session_id, exc_info=True)
+        finally:
+            with _LOCK:
+                _DRAINING_SESSIONS.discard(session_id)
+        if retry_needed:
+            with _LOCK:
+                queued = _read_items_unlocked(session_id)
+                retry_needed = bool(
+                    queued
+                    and str(queued[0].get("id") or "") == str(item.get("id") or "")
+                    and str(queued[0].get("state") or "") == "queued"
+                )
+            if retry_needed:
+                timer = threading.Timer(_RETRY_DELAY_SECONDS, drain_for_session, args=(session_id,))
+                timer.daemon = True
+                timer.start()
 
-    threading.Thread(
+    thread = threading.Thread(
         target=_runner,
         name=f"hermes-webui-queued-followup-{str(session_id)[:8]}",
         daemon=True,
-    ).start()
+    )
+    try:
+        thread.start()
+    except Exception:
+        with _LOCK:
+            _DRAINING_SESSIONS.discard(session_id)
+        requeue_front(session_id, item)
+        logger.warning("failed to start queued follow-up runner for %s", session_id, exc_info=True)
+        return 0
     return 1
+
+
+def recover_all_queues(*, schedule: bool = True) -> dict[str, int]:
+    """Repair crash-interrupted ownership transitions and resume queued FIFO heads."""
+    result = {"sessions": 0, "requeued": 0, "started": 0, "retired": 0, "errors": 0}
+    to_schedule: list[str] = []
+    queue_dir = _queue_dir()
+    if not queue_dir.exists():
+        return result
+    from api.routes import get_session
+
+    for path in sorted(queue_dir.glob("*.json")):
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(raw, list) or not raw:
+                continue
+            session_id = str(raw[0].get("session_id") or "").strip()
+            if not session_id:
+                raise QueueStorageError(f"queue file {path.name} has no session owner")
+            session = get_session(session_id)
+            active_stream_id = str(getattr(session, "active_stream_id", None) or "").strip()
+            pending_item_id = str(getattr(session, "pending_queue_item_id", None) or "").strip()
+            active_stream_is_live = bool(
+                active_stream_id and _stream_has_live_runtime(session_id, active_stream_id)
+            )
+            with _LOCK:
+                items = _read_items_unlocked(session_id)
+                repaired: list[dict[str, Any]] = []
+                changed = False
+                for item in items:
+                    state = str(item.get("state") or "queued")
+                    item_id = str(item.get("id") or "")
+                    correlated = bool(
+                        pending_item_id
+                        and pending_item_id == item_id
+                        and active_stream_is_live
+                    )
+                    if state == "starting":
+                        changed = True
+                        item.pop("starting_at", None)
+                        if correlated:
+                            item["state"] = "started"
+                            if active_stream_id:
+                                item["stream_id"] = active_stream_id
+                            result["started"] += 1
+                        else:
+                            item["state"] = "queued"
+                            item.pop("stream_id", None)
+                            result["requeued"] += 1
+                    elif state == "started":
+                        if correlated:
+                            if active_stream_id and item.get("stream_id") != active_stream_id:
+                                item["stream_id"] = active_stream_id
+                                changed = True
+                            result["started"] += 1
+                        else:
+                            changed = True
+                            _record_completed_unlocked(session_id, [item])
+                            result["retired"] += 1
+                            continue
+                    repaired.append(item)
+                if changed:
+                    _write_items_unlocked(session_id, repaired)
+                result["sessions"] += 1
+                if schedule and repaired and str(repaired[0].get("state") or "queued") == "queued":
+                    to_schedule.append(session_id)
+        except Exception:
+            result["errors"] += 1
+            logger.exception("Failed to recover persisted session queue %s", path)
+    for session_id in to_schedule:
+        drain_for_session(session_id)
+    return result

--- a/api/session_queue.py
+++ b/api/session_queue.py
@@ -202,6 +202,93 @@ def _record_completed_unlocked(session_id: str, completed_items: list[dict[str, 
     _write_receipts_unlocked(session_id, ordered[-_MAX_RECEIPTS:])
 
 
+def mark_dispatched(
+    session_id: str,
+    item_id: str,
+    stream_id: str,
+    *,
+    attempt_id: str | None = None,
+) -> bool:
+    """Durably bind a claimed FIFO item to the exact stream before it runs."""
+    if not session_id or not item_id or not stream_id:
+        return False
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        item = next((entry for entry in items if str(entry.get("id") or "") == str(item_id)), None)
+        if (
+            item is None
+            or str(item.get("state") or "queued") != "starting"
+            or (attempt_id and str(item.get("attempt_id") or "") != str(attempt_id))
+        ):
+            return False
+        item["stream_id"] = str(stream_id)
+        item["dispatched_at"] = time.time()
+        _write_items_unlocked(session_id, items)
+        _emit_queue_changed(session_id)
+        return True
+
+
+def mark_external_admission(
+    session_id: str,
+    item_id: str,
+    stream_id: str,
+    admission_id: str,
+    *,
+    attempt_id: str | None = None,
+) -> bool:
+    """Persist a fail-closed Gateway admission marker before the POST begins."""
+    if not session_id or not item_id or not stream_id or not admission_id:
+        return False
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        item = next((entry for entry in items if str(entry.get("id") or "") == str(item_id)), None)
+        if (
+            item is None
+            or str(item.get("state") or "queued") not in ("starting", "started")
+            or str(item.get("stream_id") or "") != str(stream_id)
+            or (attempt_id and str(item.get("attempt_id") or "") != str(attempt_id))
+        ):
+            return False
+        item["external_admission_id"] = str(admission_id)
+        item["external_admission_started_at"] = time.time()
+        _write_items_unlocked(session_id, items)
+        _emit_queue_changed(session_id)
+        return True
+
+
+def mark_external_run(
+    session_id: str,
+    item_id: str,
+    stream_id: str,
+    run_id: str,
+    *,
+    admission_id: str | None = None,
+    attempt_id: str | None = None,
+) -> bool:
+    """Bind an accepted Gateway run to its exact durable queue owner."""
+    if not session_id or not item_id or not stream_id or not run_id:
+        return False
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        item = next((entry for entry in items if str(entry.get("id") or "") == str(item_id)), None)
+        if (
+            item is None
+            or str(item.get("state") or "queued") not in ("starting", "started")
+            or str(item.get("stream_id") or "") != str(stream_id)
+            or (attempt_id and str(item.get("attempt_id") or "") != str(attempt_id))
+            or (
+                admission_id
+                and str(item.get("external_admission_id") or "") != str(admission_id)
+            )
+        ):
+            return False
+        item["external_run_id"] = str(run_id)
+        item["external_run_bound_at"] = time.time()
+        _write_items_unlocked(session_id, items)
+        _emit_queue_changed(session_id)
+        return True
+
+
 def _normalize_attachments(raw: Any) -> list[dict[str, Any]]:
     if not isinstance(raw, list):
         return []
@@ -437,6 +524,7 @@ def claim_next(session_id: str) -> dict[str, Any] | None:
         if str(item.get("state") or "queued") != "queued":
             return None
         item["state"] = "starting"
+        item["attempt_id"] = uuid.uuid4().hex
         item["starting_at"] = time.time()
         _write_items_unlocked(session_id, items)
         _emit_queue_changed(session_id)
@@ -456,31 +544,58 @@ def requeue_front(session_id: str, item: dict[str, Any]) -> None:
                 restored = dict(existing)
                 restored.update(item)
                 restored["state"] = "blocked" if restored.get("blocked") else "queued"
+                restored.pop("attempt_id", None)
                 restored.pop("starting_at", None)
                 restored.pop("stream_id", None)
+                restored.pop("dispatched_at", None)
+                restored.pop("external_run_id", None)
+                restored.pop("external_run_bound_at", None)
+                restored.pop("external_admission_id", None)
+                restored.pop("external_admission_started_at", None)
                 items[idx] = restored
                 _write_items_unlocked(session_id, items)
                 _emit_queue_changed(session_id)
                 return
         restored = dict(item)
         restored["state"] = "blocked" if restored.get("blocked") else "queued"
+        restored.pop("attempt_id", None)
         restored.pop("starting_at", None)
         restored.pop("stream_id", None)
+        restored.pop("dispatched_at", None)
+        restored.pop("external_run_id", None)
+        restored.pop("external_run_bound_at", None)
+        restored.pop("external_admission_id", None)
+        restored.pop("external_admission_started_at", None)
         items.insert(0, restored)
         _write_items_unlocked(session_id, items)
         _emit_queue_changed(session_id)
 
 
-def _finish_attempt(session_id: str, item_id: str, response: dict[str, Any]) -> None:
+def _finish_attempt(
+    session_id: str,
+    item_id: str,
+    response: dict[str, Any],
+    *,
+    attempt_id: str | None = None,
+) -> None:
     status = int((response or {}).get("_status", 200) or 200)
     with _LOCK:
         items = _read_items_unlocked(session_id)
         item = next((entry for entry in items if str(entry.get("id") or "") == item_id), None)
         if item is None:
             return
+        if attempt_id and str(item.get("attempt_id") or "") != str(attempt_id):
+            return
         item.pop("starting_at", None)
         if status == 409:
             item["state"] = "queued"
+            item.pop("attempt_id", None)
+            item.pop("stream_id", None)
+            item.pop("dispatched_at", None)
+            item.pop("external_run_id", None)
+            item.pop("external_run_bound_at", None)
+            item.pop("external_admission_id", None)
+            item.pop("external_admission_started_at", None)
         elif status >= 400:
             retry_count = int(item.get("retry_count") or 0) + 1
             item["retry_count"] = retry_count
@@ -490,18 +605,25 @@ def _finish_attempt(session_id: str, item_id: str, response: dict[str, Any]) -> 
                 item["state"] = "blocked"
             else:
                 item["state"] = "queued"
+            item.pop("attempt_id", None)
+            item.pop("stream_id", None)
+            item.pop("dispatched_at", None)
+            item.pop("external_run_id", None)
+            item.pop("external_run_bound_at", None)
+            item.pop("external_admission_id", None)
+            item.pop("external_admission_started_at", None)
         else:
             stream_id = str((response or {}).get("stream_id") or "").strip()
             if not stream_id:
                 item["state"] = "queued"
                 item["error"] = "start response did not include a stream id"
-            elif not _stream_is_still_active(session_id, stream_id):
-                # The worker can finish between returning its start response
-                # and this durable transition. Teardown cannot retire a
-                # `starting` item, so retire it here while holding the same
-                # queue lock; otherwise a completed turn leaves a tombstone.
-                _record_completed_unlocked(session_id, [item])
-                items.remove(item)
+                item.pop("attempt_id", None)
+                item.pop("stream_id", None)
+                item.pop("dispatched_at", None)
+                item.pop("external_run_id", None)
+                item.pop("external_run_bound_at", None)
+                item.pop("external_admission_id", None)
+                item.pop("external_admission_started_at", None)
             else:
                 item["state"] = "started"
                 item["stream_id"] = stream_id
@@ -522,7 +644,7 @@ def complete_started(session_id: str, stream_id: str) -> bool:
             item
             for item in items
             if (
-                str(item.get("state") or "") == "started"
+                str(item.get("state") or "") in ("starting", "started")
                 and str(item.get("stream_id") or "") == str(stream_id)
             )
         ]
@@ -530,7 +652,7 @@ def complete_started(session_id: str, stream_id: str) -> bool:
             item
             for item in items
             if not (
-                str(item.get("state") or "") == "started"
+                str(item.get("state") or "") in ("starting", "started")
                 and str(item.get("stream_id") or "") == str(stream_id)
             )
         ]
@@ -558,26 +680,6 @@ def _session_has_active_turn(session_id: str) -> bool:
     return False
 
 
-def _stream_is_still_active(session_id: str, stream_id: str) -> bool:
-    try:
-        from api import config
-
-        with config.ACTIVE_RUNS_LOCK:
-            for active_stream_id, active in config.ACTIVE_RUNS.items():
-                if str(active_stream_id) == stream_id and str((active or {}).get("session_id") or "") == session_id:
-                    return True
-    except Exception:
-        logger.debug("Could not inspect active runs for queue completion", exc_info=True)
-    try:
-        from api.routes import STREAMS, get_session
-
-        if stream_id in STREAMS:
-            return True
-        return str(getattr(get_session(session_id), "active_stream_id", None) or "") == stream_id
-    except Exception:
-        return False
-
-
 def _stream_has_live_runtime(session_id: str, stream_id: str) -> bool:
     """Return true only for process-live ownership, not a persisted session id."""
     try:
@@ -595,6 +697,19 @@ def _stream_has_live_runtime(session_id: str, stream_id: str) -> bool:
         return stream_id in STREAMS
     except Exception:
         return False
+
+
+def _external_run_status(run_id: str) -> str | None:
+    """Return the authoritative Gateway status, or unknown on any lookup failure."""
+    if not run_id:
+        return None
+    try:
+        from api.gateway_chat import gateway_run_status
+
+        return gateway_run_status(run_id)
+    except Exception:
+        logger.warning("could not reconcile Gateway run %s", run_id, exc_info=True)
+        return None
 
 
 def drain_for_session(session_id: str) -> int:
@@ -628,9 +743,15 @@ def drain_for_session(session_id: str) -> int:
                 requested_provider=item.get("model_provider"),
                 queue_item_id=str(item.get("id") or "") or None,
                 queue_client_id=str(item.get("client_queue_id") or "") or None,
+                queue_attempt_id=str(item.get("attempt_id") or "") or None,
             )
             status = int((resp or {}).get("_status", 200) or 200)
-            _finish_attempt(session_id, str(item.get("id") or ""), resp or {})
+            _finish_attempt(
+                session_id,
+                str(item.get("id") or ""),
+                resp or {},
+                attempt_id=str(item.get("attempt_id") or "") or None,
+            )
             if status >= 400:
                 retry_needed = status != 409
                 logger.warning(
@@ -653,6 +774,7 @@ def drain_for_session(session_id: str) -> int:
                 session_id,
                 str(item.get("id") or ""),
                 {"_status": 500, "error": str(exc) or type(exc).__name__},
+                attempt_id=str(item.get("attempt_id") or "") or None,
             )
             retry_needed = True
             logger.warning("queued follow-up turn raised for session %s", session_id, exc_info=True)
@@ -705,6 +827,15 @@ def recover_all_queues(*, schedule: bool = True) -> dict[str, int]:
             session_id = str(raw[0].get("session_id") or "").strip()
             if not session_id:
                 raise QueueStorageError(f"queue file {path.name} has no session owner")
+            external_statuses = {
+                run_id: _external_run_status(run_id)
+                for run_id in {
+                    str(entry.get("external_run_id") or "").strip()
+                    for entry in raw
+                    if isinstance(entry, dict)
+                }
+                if run_id
+            }
             session = get_session(session_id)
             active_stream_id = str(getattr(session, "active_stream_id", None) or "").strip()
             pending_item_id = str(getattr(session, "pending_queue_item_id", None) or "").strip()
@@ -718,15 +849,50 @@ def recover_all_queues(*, schedule: bool = True) -> dict[str, int]:
                 for item in items:
                     state = str(item.get("state") or "queued")
                     item_id = str(item.get("id") or "")
-                    correlated = bool(
+                    item_stream_id = str(item.get("stream_id") or "").strip()
+                    external_run_id = str(item.get("external_run_id") or "").strip()
+                    external_admission_id = str(
+                        item.get("external_admission_id") or ""
+                    ).strip()
+                    if external_run_id:
+                        remote_status = external_statuses.get(external_run_id)
+                        if remote_status in {
+                            "cancelled",
+                            "completed",
+                            "error",
+                            "failed",
+                            "stopped",
+                        }:
+                            changed = True
+                            _record_completed_unlocked(session_id, [item])
+                            result["retired"] += 1
+                            continue
+                        if state != "started":
+                            item["state"] = "started"
+                            item.pop("starting_at", None)
+                            changed = True
+                        result["started"] += 1
+                        repaired.append(item)
+                        continue
+                    if external_admission_id:
+                        if state != "started":
+                            item["state"] = "started"
+                            item.pop("starting_at", None)
+                            changed = True
+                        result["started"] += 1
+                        repaired.append(item)
+                        continue
+                    pending_correlated = bool(
                         pending_item_id
                         and pending_item_id == item_id
-                        and active_stream_is_live
+                        and active_stream_id
+                        and (not item_stream_id or item_stream_id == active_stream_id)
                     )
+                    runtime_correlated = pending_correlated and active_stream_is_live
                     if state == "starting":
                         changed = True
                         item.pop("starting_at", None)
-                        if correlated:
+                        if runtime_correlated:
                             item["state"] = "started"
                             if active_stream_id:
                                 item["stream_id"] = active_stream_id
@@ -734,9 +900,14 @@ def recover_all_queues(*, schedule: bool = True) -> dict[str, int]:
                         else:
                             item["state"] = "queued"
                             item.pop("stream_id", None)
+                            item.pop("dispatched_at", None)
+                            item.pop("external_run_id", None)
+                            item.pop("external_run_bound_at", None)
+                            item.pop("external_admission_id", None)
+                            item.pop("external_admission_started_at", None)
                             result["requeued"] += 1
                     elif state == "started":
-                        if correlated:
+                        if runtime_correlated:
                             if active_stream_id and item.get("stream_id") != active_stream_id:
                                 item["stream_id"] = active_stream_id
                                 changed = True

--- a/api/startup.py
+++ b/api/startup.py
@@ -126,3 +126,15 @@ def auto_install_agent_deps() -> bool:
     except Exception as e:
         print(f'[!!] Auto-install error: {e}', flush=True)
         return False
+
+
+def recover_session_queues() -> None:
+    """Repair persisted queue ownership before the HTTP server accepts work."""
+    try:
+        from api.session_queue import recover_all_queues
+
+        result = recover_all_queues(schedule=True)
+        if result.get("sessions") or result.get("errors"):
+            print(f'[ok] Session queue recovery: {result}', flush=True)
+    except Exception as e:
+        print(f'[!!] WARNING: Session queue recovery failed: {e}', flush=True)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -11911,6 +11911,22 @@ def _run_agent_streaming(
                 exc_info=True,
             )
 
+        # Backend-owned queued follow-ups are session intent, not browser UI
+        # state. Once /api/session/queue acknowledges an item, this teardown
+        # hook starts the next queued turn after the active run settles even if
+        # every WebUI tab is disconnected. The queue drain has the same active
+        # run guard and 409 requeue behavior as process wakeups.
+        try:
+            from api.session_queue import drain_for_session
+
+            drain_for_session(session_id)
+        except Exception:
+            logger.debug(
+                "turn-teardown queued-followup drain failed for session %s",
+                session_id,
+                exc_info=True,
+            )
+
 # ============================================================
 # SECTION: HTTP Request Handler
 # do_GET: read-only API endpoints + SSE stream + static HTML

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -11917,8 +11917,9 @@ def _run_agent_streaming(
         # every WebUI tab is disconnected. The queue drain has the same active
         # run guard and 409 requeue behavior as process wakeups.
         try:
-            from api.session_queue import drain_for_session
+            from api.session_queue import complete_started, drain_for_session
 
+            complete_started(session_id, stream_id)
             drain_for_session(session_id)
         except Exception:
             logger.debug(

--- a/docs/rfcs/webui-pending-intent-controls.md
+++ b/docs/rfcs/webui-pending-intent-controls.md
@@ -277,6 +277,20 @@ Queue requirements:
 - drains only into its original session
 - respects Edit/Delete after recovery
 - protects zero-message sessions that still contain draft or queued intent
+- backend persistence is authoritative once enqueue is acknowledged; browser
+  storage is only a recovery cache for an acknowledgement still in flight
+- every enqueue carries a stable `client_queue_id`, and retrying that key is
+  idempotent rather than creating a second queue owner
+- queue order and edit/delete/reorder/combine/clear mutations are committed by
+  the backend before WebUI changes the visible authoritative state
+- dispatch follows durable `queued -> starting -> started` transitions;
+  exhausted start retries become visible `blocked` items
+- only one dispatcher may claim the FIFO head for a session at a time
+- the durable item is retired only after the correlated stream has settled;
+  startup recovery repairs a crash-interrupted `starting` transition and does
+  not resubmit an item already correlated to a live stream
+- corrupt or unwritable queue storage fails closed; capacity never evicts an
+  older acknowledged intent
 
 Steer requirements:
 

--- a/server.py
+++ b/server.py
@@ -109,7 +109,7 @@ from api.helpers import (
 )
 from api.profiles import set_request_profile, clear_request_profile
 from api.routes import handle_delete, handle_get, handle_patch, handle_post, handle_put, apply_cors_preflight_headers
-from api.startup import auto_install_agent_deps, fix_credential_permissions
+from api.startup import auto_install_agent_deps, fix_credential_permissions, recover_session_queues
 from api.updates import WEBUI_VERSION
 from api.crash_visibility import install_crash_visibility
 
@@ -670,16 +670,7 @@ def main() -> None:
 
     _abort_if_already_serving(HOST, PORT)
     httpd = QuietHTTPServer((HOST, PORT), Handler)
-
-    try:
-        from api.session_queue import recover_all_queues
-
-        queue_recovery = recover_all_queues(schedule=True)
-        if queue_recovery.get("sessions") or queue_recovery.get("errors"):
-            print(f'[ok] Session queue recovery: {queue_recovery}', flush=True)
-    except Exception as e:
-        print(f'[!!] WARNING: Session queue recovery failed: {e}', flush=True)
-
+    recover_session_queues()
     from api.config import TLS_ENABLED, TLS_CERT, TLS_KEY
     scheme = 'https' if TLS_ENABLED else 'http'
     if TLS_ENABLED:

--- a/server.py
+++ b/server.py
@@ -671,6 +671,15 @@ def main() -> None:
     _abort_if_already_serving(HOST, PORT)
     httpd = QuietHTTPServer((HOST, PORT), Handler)
 
+    try:
+        from api.session_queue import recover_all_queues
+
+        queue_recovery = recover_all_queues(schedule=True)
+        if queue_recovery.get("sessions") or queue_recovery.get("errors"):
+            print(f'[ok] Session queue recovery: {queue_recovery}', flush=True)
+    except Exception as e:
+        print(f'[!!] WARNING: Session queue recovery failed: {e}', flush=True)
+
     from api.config import TLS_ENABLED, TLS_CERT, TLS_KEY
     scheme = 'https' if TLS_ENABLED else 'http'
     if TLS_ENABLED:

--- a/static/messages.js
+++ b/static/messages.js
@@ -8031,6 +8031,17 @@ function startSessionStream(sid) {
         }
       } catch (_) {}
     });
+    es.addEventListener('session_queue_changed', e => {
+      try {
+        const d = JSON.parse(e.data || '{}');
+        if ((d.session_id || sid) !== sid) return;
+        if (typeof syncBackendSessionQueue === 'function') {
+          void syncBackendSessionQueue(sid).catch(err => {
+            if (typeof showToast === 'function') showToast('Could not refresh queued messages: '+(err&&err.message||err), null, 'error');
+          });
+        }
+      } catch (_) {}
+    });
     // ── Defect B: live-view of server-initiated (Option Z) turns ──────────
     // The drain thread starts the wakeup turn server-side and the server
     // fans a `server_turn_started` {stream_id} frame onto this per-session
@@ -8046,7 +8057,7 @@ function startSessionStream(sid) {
         const streamId = String(d.stream_id || '');
         if (!streamId || evSid !== sid) return;
         if (d.queue_item_id && typeof _removeServerQueuedEntry === 'function') {
-          _removeServerQueuedEntry(sid, String(d.queue_item_id));
+          _removeServerQueuedEntry(sid, String(d.queue_item_id), String(d.queue_client_id || ''));
         }
         // `recovered` marks an on-subscribe replay from the server: the tab
         // (re)connected to /api/session/stream AFTER the original

--- a/static/messages.js
+++ b/static/messages.js
@@ -8045,6 +8045,9 @@ function startSessionStream(sid) {
         const evSid = d.session_id || sid;
         const streamId = String(d.stream_id || '');
         if (!streamId || evSid !== sid) return;
+        if (d.queue_item_id && typeof _removeServerQueuedEntry === 'function') {
+          _removeServerQueuedEntry(sid, String(d.queue_item_id));
+        }
         // `recovered` marks an on-subscribe replay from the server: the tab
         // (re)connected to /api/session/stream AFTER the original
         // fire-and-forget server_turn_started had already been broadcast, so

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1551,6 +1551,7 @@ async function newSession(flash, options={}){
       });
     }
     updateQueueBadge(S.session.session_id);
+    if(typeof syncBackendSessionQueue==='function') syncBackendSessionQueue(S.session.session_id);
     syncTopbar();renderMessages();
     if(typeof _announceNewSessionWorkspace==='function') _announceNewSessionWorkspace(S.session);
     // Keep new-chat first paint instant. The workspace tree / git badge can

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2038,6 +2038,7 @@ async function loadSession(sid){
   try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
   _setActiveSessionUrl(S.session.session_id);
   if(typeof startSessionStream==='function') startSessionStream(S.session.session_id);
+  if(typeof syncBackendSessionQueue==='function') syncBackendSessionQueue(S.session.session_id);
 
 
   // _mergePendingSessionMessage is the global identity-aware helper shared by

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2038,7 +2038,12 @@ async function loadSession(sid){
   try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
   _setActiveSessionUrl(S.session.session_id);
   if(typeof startSessionStream==='function') startSessionStream(S.session.session_id);
-  if(typeof syncBackendSessionQueue==='function') syncBackendSessionQueue(S.session.session_id);
+  if(typeof syncBackendSessionQueue==='function'){
+    try{await syncBackendSessionQueue(S.session.session_id);}
+    catch(err){
+      if(typeof showToast==='function')showToast('Could not reconcile queued messages: '+(err&&err.message||err),null,'error');
+    }
+  }
 
 
   // _mergePendingSessionMessage is the global identity-aware helper shared by
@@ -2235,31 +2240,6 @@ async function loadSession(sid){
     }
     // Stale? A newer loadSession() call has already started (#1060).
     if (!_isCurrentLoad()) return;
-
-    // Restore any queued message that survived page refresh or tab restore.
-    if(typeof queueSessionMessage==='function'){
-      try{
-        const _entries=typeof _readPersistedSessionQueue==='function'
-          ? _readPersistedSessionQueue(sid)
-          : [];
-        if(Array.isArray(_entries)&&_entries.length){
-          const _lastMsg=S.messages.slice().reverse()
-            .find(m=>m&&m.role==='assistant');
-          const _lastAsst=_lastMsg?(_lastMsg.timestamp||_lastMsg._ts||0)*1000:0;
-          const _fresh=_entries.filter(e=>!e._queued_at||e._queued_at>_lastAsst);
-          if(_fresh.length){
-            const _first=_fresh[0];
-            const _msg=$&&$('msg');
-            if(_msg&&_first.text&&!_msg.value){
-              _msg.value=_first.text||'';
-              if(typeof autoResize==='function') autoResize();
-              if(typeof showToast==='function') showToast((_fresh.length>1?`${_fresh.length} queued messages restored (showing first)`:'Queued message restored')+' — review and send when ready');
-            }
-          }
-          if(typeof _clearPersistedSessionQueue==='function') _clearPersistedSessionQueue(sid);
-        }
-      }catch(_){if(typeof _clearPersistedSessionQueue==='function') _clearPersistedSessionQueue(sid);}
-    }
 
     // Reconstruct tool calls from message metadata, or fall back to session-level summary.
     // (hasMessageToolMetadata already computed inside _ensureMessagesLoaded; S.toolCalls set there.)

--- a/static/style.css
+++ b/static/style.css
@@ -2030,6 +2030,7 @@
   .queue-card-header-actions{display:flex;align-items:center;gap:4px;margin-left:auto;}
   .queue-card-btn{display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:6px;border:1px solid var(--border);background:none;color:var(--muted);font-size:11px;font-weight:500;cursor:pointer;transition:background .12s,color .12s;white-space:nowrap;}
   .queue-card-btn:hover{background:var(--hover-bg);color:var(--text);}
+  .queue-card-btn:disabled,.queue-card-icon-btn:disabled{cursor:not-allowed;opacity:.35;pointer-events:none;}
   .queue-card-icon-btn{display:inline-flex;align-items:center;padding:3px;border-radius:5px;border:none;background:none;color:var(--muted);cursor:pointer;opacity:.5;transition:opacity .12s,background .12s;}
   .queue-card-icon-btn:hover{opacity:1;background:var(--hover-bg);}
   .queue-card-row{display:flex;align-items:center;gap:8px;padding:8px 14px;border-bottom:1px solid var(--border);cursor:grab;}
@@ -2040,6 +2041,8 @@
   .queue-card-text:focus{white-space:pre-wrap;overflow:auto;text-overflow:clip;}
   .queue-card-badges{display:flex;align-items:center;gap:5px;flex-shrink:0;font-size:10px;color:var(--muted);opacity:.6;}
   .queue-card-file-badge{display:flex;align-items:center;gap:2px;}
+  .queue-card-state{display:inline-flex;align-items:center;padding:2px 5px;border-radius:999px;background:var(--hover-bg);white-space:nowrap;}
+  .queue-card-state-blocked,.queue-card-state-error{color:var(--error,#d85c5c);background:color-mix(in srgb,var(--error,#d85c5c) 12%,transparent);opacity:1;}
   .approval-btn-icon{font-size:13px;line-height:1;}
   .approval-btn-label{line-height:1;}
   .approval-kbd{display:inline-flex;align-items:center;justify-content:center;padding:1px 5px;border-radius:4px;font-size:10px;font-family:inherit;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.15);color:var(--muted);line-height:1.4;margin-left:2px;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -353,9 +353,10 @@ function syncBackendSessionQueue(sid){
         const id=String(item&&item.id||'');
         if(!id||q.some(e=>e&&e._server_queue_id===id))return;
         const itemText=String(item.text||'');
-        const pendingIdx=q.findIndex(e=>e&&e._server_pending&&!e._server_queue_id&&String(e.text||e.message||e.content||'')===itemText);
+        const itemMatchText=itemText.trim();
+        const pendingIdx=q.findIndex(e=>e&&e._server_pending&&!e._server_queue_id&&String(e.text||e.message||e.content||'').trim()===itemMatchText);
         if(pendingIdx>=0){
-          q[pendingIdx]={...q[pendingIdx],_server_pending:false,_server_owned:true,_server_queue_id:id};
+          q[pendingIdx]={...q[pendingIdx],text:itemText,_server_pending:false,_server_owned:true,_server_queue_id:id};
           changed=true;
           return;
         }
@@ -373,6 +374,12 @@ function syncBackendSessionQueue(sid){
         });
         changed=true;
       });
+      for(let i=0;i<q.length;i++){
+        if(q[i]&&q[i]._server_pending&&!q[i]._server_queue_id){
+          q[i]={...q[i],_server_pending:false,_server_error:'queue_ack_recovered'};
+          changed=true;
+        }
+      }
       if(changed){_persistSessionQueueStorage(sid,q);delete _queueRenderKeys[sid];updateQueueBadge(sid);}
     }).catch(()=>{});
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -266,6 +266,13 @@ function _findQueuedEntryByClientId(sid, clientId){
   const idx=q.findIndex(e=>e&&e._client_queue_id===clientId);
   return {q,idx,entry:idx>=0?q[idx]:null};
 }
+function _deleteBackendQueuedItem(sid, serverId){
+  if(!sid||!serverId||typeof fetch!=='function')return;
+  fetch(new URL('api/session/queue/delete',document.baseURI||location.href).href,{
+    method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({session_id:sid,id:serverId}),
+  }).catch(()=>{});
+}
 function _backendAcknowledgeQueuedMessage(sid, entry){
   if(!sid||!entry||entry._server_owned||entry._server_pending)return;
   if(_queuedEntryHasBrowserOnlyFiles(entry))return;
@@ -287,7 +294,10 @@ function _backendAcknowledgeQueuedMessage(sid, entry){
   }).then(r=>r.json().then(data=>({ok:r.ok,data})).catch(()=>({ok:r.ok,data:{}})))
     .then(({ok,data})=>{
       const found=_findQueuedEntryByClientId(sid,entry._client_queue_id);
-      if(found.idx<0)return;
+      if(found.idx<0){
+        if(ok&&data&&data.item&&data.item.id)_deleteBackendQueuedItem(sid,data.item.id);
+        return;
+      }
       if(ok&&data&&data.item&&data.item.id){
         found.q[found.idx]={...found.entry,_server_pending:false,_server_owned:true,_server_queue_id:data.item.id};
       }else{
@@ -341,7 +351,12 @@ function syncBackendSessionQueue(sid){
     .then(r=>r.ok?r.json():null)
     .then(data=>{
       if(!data||!Array.isArray(data.items))return;
-      const q=_getSessionQueue(sid,true);
+      let q=_getSessionQueue(sid,false);
+      if(!q.length){
+        const persisted=_readPersistedSessionQueue(sid);
+        if(persisted.length){SESSION_QUEUES[sid]=persisted;q=persisted;}
+      }
+      if(!q.length)q=_getSessionQueue(sid,true);
       const serverIds=new Set(data.items.map(item=>String(item&&item.id||'')).filter(Boolean));
       let changed=false;
       for(let i=q.length-1;i>=0;i--){
@@ -356,7 +371,7 @@ function syncBackendSessionQueue(sid){
         const itemMatchText=itemText.trim();
         const pendingIdx=q.findIndex(e=>e&&e._server_pending&&!e._server_queue_id&&String(e.text||e.message||e.content||'').trim()===itemMatchText);
         if(pendingIdx>=0){
-          q[pendingIdx]={...q[pendingIdx],text:itemText,_server_pending:false,_server_owned:true,_server_queue_id:id};
+          q[pendingIdx]={...q[pendingIdx],text:itemText,_server_pending:false,_server_owned:true,_server_queue_id:id,_server_error:item.error||'',_server_blocked:!!item.blocked};
           changed=true;
           return;
         }
@@ -371,6 +386,8 @@ function syncBackendSessionQueue(sid){
           _server_owned:true,
           _server_pending:false,
           _server_queue_id:id,
+          _server_error:item.error||'',
+          _server_blocked:!!item.blocked,
         });
         changed=true;
       });

--- a/static/ui.js
+++ b/static/ui.js
@@ -251,15 +251,78 @@ function queueSessionMessage(sid, payload){
   if(!sid||!payload) return 0;
   const q=_getSessionQueue(sid,true);
   // Stamp created_at so the restore path can detect stale entries (agent already responded)
-  const entry={...payload, _queued_at: Date.now()};
+  const entry={...payload, _queued_at: Date.now(), _client_queue_id: (Date.now().toString(36)+'-'+Math.random().toString(36).slice(2))};
   q.push(entry);
   _persistSessionQueueStorage(sid,q);
+  _backendAcknowledgeQueuedMessage(sid, entry);
   return q.length;
+}
+function _queuedEntryHasBrowserOnlyFiles(entry){
+  const files=entry&&Array.isArray(entry.files)?entry.files:[];
+  return files.some(f=>f&&typeof File!=='undefined'&&f instanceof File);
+}
+function _findQueuedEntryByClientId(sid, clientId){
+  const q=_getSessionQueue(sid,false);
+  const idx=q.findIndex(e=>e&&e._client_queue_id===clientId);
+  return {q,idx,entry:idx>=0?q[idx]:null};
+}
+function _backendAcknowledgeQueuedMessage(sid, entry){
+  if(!sid||!entry||entry._server_owned||entry._server_pending)return;
+  if(_queuedEntryHasBrowserOnlyFiles(entry))return;
+  const text=String(entry.text||entry.message||entry.content||'').trim();
+  if(!text)return;
+  entry._server_pending=true;
+  _persistSessionQueueStorage(sid,_getSessionQueue(sid,false));
+  const body={
+    session_id:sid,
+    text,
+    attachments:Array.isArray(entry.attachments)?entry.attachments:[],
+    model:entry.model||'',
+    model_provider:entry.model_provider||null,
+    profile:entry.profile||S.activeProfile||'default',
+  };
+  fetch(new URL('api/session/queue',document.baseURI||location.href).href,{
+    method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify(body),
+  }).then(r=>r.json().then(data=>({ok:r.ok,data})).catch(()=>({ok:r.ok,data:{}})))
+    .then(({ok,data})=>{
+      const found=_findQueuedEntryByClientId(sid,entry._client_queue_id);
+      if(found.idx<0)return;
+      if(ok&&data&&data.item&&data.item.id){
+        found.q[found.idx]={...found.entry,_server_pending:false,_server_owned:true,_server_queue_id:data.item.id};
+      }else{
+        found.q[found.idx]={...found.entry,_server_pending:false,_server_error:(data&&data.error)||'queue_ack_failed'};
+      }
+      _persistSessionQueueStorage(sid,found.q);
+      delete _queueRenderKeys[sid];
+      updateQueueBadge(sid);
+    }).catch(()=>{
+      const found=_findQueuedEntryByClientId(sid,entry._client_queue_id);
+      if(found.idx<0)return;
+      found.q[found.idx]={...found.entry,_server_pending:false,_server_error:'queue_ack_failed'};
+      _persistSessionQueueStorage(sid,found.q);
+      delete _queueRenderKeys[sid];
+      updateQueueBadge(sid);
+    });
+}
+function _removeServerQueuedEntry(sid, serverId){
+  if(!sid||!serverId)return false;
+  const q=_getSessionQueue(sid,false);
+  const idx=q.findIndex(e=>e&&e._server_queue_id===serverId);
+  if(idx<0)return false;
+  q.splice(idx,1);
+  if(!q.length){delete SESSION_QUEUES[sid];_clearPersistedSessionQueue(sid);}
+  else _persistSessionQueueStorage(sid,q);
+  delete _queueRenderKeys[sid];
+  updateQueueBadge(sid);
+  return true;
 }
 function shiftQueuedSessionMessage(sid){
   const q=_getSessionQueue(sid,false);
   if(!q.length) return null;
-  const next=q.shift();
+  const idx=q.findIndex(e=>!(e&&(_serverEntryOwnedOrPending(e))));
+  if(idx<0)return null;
+  const next=q.splice(idx,1)[0];
   if(!q.length){
     delete SESSION_QUEUES[sid];
     _clearPersistedSessionQueue(sid);
@@ -268,8 +331,50 @@ function shiftQueuedSessionMessage(sid){
   }
   return next;
 }
+function _serverEntryOwnedOrPending(entry){return !!(entry&&(entry._server_owned||entry._server_pending));}
 function getQueuedSessionCount(sid){
   return _getSessionQueue(sid,false).length;
+}
+function syncBackendSessionQueue(sid){
+  if(!sid||typeof fetch!=='function')return;
+  fetch(new URL('api/session/queue?session_id='+encodeURIComponent(sid),document.baseURI||location.href).href,{credentials:'include'})
+    .then(r=>r.ok?r.json():null)
+    .then(data=>{
+      if(!data||!Array.isArray(data.items))return;
+      const q=_getSessionQueue(sid,true);
+      const serverIds=new Set(data.items.map(item=>String(item&&item.id||'')).filter(Boolean));
+      let changed=false;
+      for(let i=q.length-1;i>=0;i--){
+        if(q[i]&&q[i]._server_owned&&q[i]._server_queue_id&&!serverIds.has(String(q[i]._server_queue_id))){
+          q.splice(i,1);changed=true;
+        }
+      }
+      data.items.forEach(item=>{
+        const id=String(item&&item.id||'');
+        if(!id||q.some(e=>e&&e._server_queue_id===id))return;
+        const itemText=String(item.text||'');
+        const pendingIdx=q.findIndex(e=>e&&e._server_pending&&!e._server_queue_id&&String(e.text||e.message||e.content||'')===itemText);
+        if(pendingIdx>=0){
+          q[pendingIdx]={...q[pendingIdx],_server_pending:false,_server_owned:true,_server_queue_id:id};
+          changed=true;
+          return;
+        }
+        q.push({
+          text:itemText,
+          files:[],
+          attachments:Array.isArray(item.attachments)?item.attachments:[],
+          model:item.model||'',
+          model_provider:item.model_provider||null,
+          profile:item.profile||S.activeProfile||'default',
+          _queued_at:Math.round((Number(item.created_at)||Date.now()/1000)*1000),
+          _server_owned:true,
+          _server_pending:false,
+          _server_queue_id:id,
+        });
+        changed=true;
+      });
+      if(changed){_persistSessionQueueStorage(sid,q);delete _queueRenderKeys[sid];updateQueueBadge(sid);}
+    }).catch(()=>{});
 }
 function _compressionSessionLock(){
   return window._compressionLockSid||null;
@@ -8105,15 +8210,30 @@ function _renderQueueChips(sid){
       if(hasFiles){
         if(typeof showToast==='function') showToast('Attachments on queued items will be removed',2600,'warning');
       }
+      const snapshot=[..._getSessionQueue(sid,false)];
+      if(snapshot.some(e=>e&&e._server_owned)){
+        if(typeof showToast==='function') showToast('Already-synced queued messages cannot be merged yet',2600,'warning');
+        return;
+      }
       // Merge from current live queue (no delay — snapshot + defer caused data-loss races)
-      _doMerge([..._getSessionQueue(sid,false)]);
+      _doMerge(snapshot);
     };
     const clearBtn=document.createElement('button');
     clearBtn.className='queue-card-icon-btn';
     clearBtn.title='Clear all queued messages';
     clearBtn.setAttribute('aria-label','Clear all queued messages');
     clearBtn.innerHTML=li('x',13);
-    clearBtn.onclick=()=>{q.length=0;_saveAndRefresh();};
+    clearBtn.onclick=()=>{
+      q.forEach(entry=>{
+        if(entry&&entry._server_owned&&entry._server_queue_id){
+          fetch(new URL('api/session/queue/delete',document.baseURI||location.href).href,{
+            method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+            body:JSON.stringify({session_id:sid,id:entry._server_queue_id}),
+          }).catch(()=>{});
+        }
+      });
+      q.length=0;_saveAndRefresh();
+    };
     actions.appendChild(mergeBtn);
     actions.appendChild(clearBtn);
     // Hide button — collapses flyout entirely; queue pill re-shows it
@@ -8179,6 +8299,12 @@ function _renderQueueChips(sid){
         if(idx!==-1){
           liveQ[idx]={...liveQ[idx],text:newText};
           _persistSessionQueueStorage(sid,liveQ);
+          if(liveQ[idx]._server_owned&&liveQ[idx]._server_queue_id){
+            fetch(new URL('api/session/queue/update',document.baseURI||location.href).href,{
+              method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+              body:JSON.stringify({session_id:sid,id:liveQ[idx]._server_queue_id,text:newText}),
+            }).catch(()=>{});
+          }
           delete _queueRenderKeys[sid];
           updateQueueBadge(sid);
         }
@@ -8216,7 +8342,16 @@ function _renderQueueChips(sid){
     delBtn.onclick=()=>{
       const liveQ=_getSessionQueue(sid,false);
       const idx=_entryTs!=null?liveQ.findIndex(e=>e&&e._queued_at===_entryTs):i;
-      if(idx!==-1) liveQ.splice(idx,1);
+      if(idx!==-1){
+        const removed=liveQ[idx];
+        liveQ.splice(idx,1);
+        if(removed&&removed._server_owned&&removed._server_queue_id){
+          fetch(new URL('api/session/queue/delete',document.baseURI||location.href).href,{
+            method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+            body:JSON.stringify({session_id:sid,id:removed._server_queue_id}),
+          }).catch(()=>{});
+        }
+      }
       if(!liveQ.length){delete SESSION_QUEUES[sid];_clearPersistedSessionQueue(sid);}
       else{SESSION_QUEUES[sid]=[...liveQ];_persistSessionQueueStorage(sid,liveQ);}
       delete _queueRenderKeys[sid];

--- a/static/ui.js
+++ b/static/ui.js
@@ -267,15 +267,24 @@ function _findQueuedEntryByClientId(sid, clientId){
   return {q,idx,entry:idx>=0?q[idx]:null};
 }
 function _deleteBackendQueuedItem(sid, serverId){
-  if(!sid||!serverId||typeof fetch!=='function')return;
-  fetch(new URL('api/session/queue/delete',document.baseURI||location.href).href,{
+  if(!sid||!serverId||typeof fetch!=='function')return Promise.resolve(false);
+  return fetch(new URL('api/session/queue/delete',document.baseURI||location.href).href,{
     method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
     body:JSON.stringify({session_id:sid,id:serverId}),
-  }).catch(()=>{});
+  }).then(async r=>{
+    if(r.ok)return true;
+    let data={};try{data=await r.json();}catch(_){}
+    throw new Error(data.error||'queue_delete_failed');
+  });
 }
-function _backendAcknowledgeQueuedMessage(sid, entry){
+async function _backendAcknowledgeQueuedMessage(sid, entry, attempt=0){
   if(!sid||!entry||entry._server_owned||entry._server_pending)return;
-  if(_queuedEntryHasBrowserOnlyFiles(entry))return;
+  if(_queuedEntryHasBrowserOnlyFiles(entry)){
+    entry._server_error='Attachments could not be queued durably; remove this item and resend';
+    _persistSessionQueueStorage(sid,_getSessionQueue(sid,false));
+    delete _queueRenderKeys[sid];updateQueueBadge(sid);
+    return;
+  }
   const text=String(entry.text||entry.message||entry.content||'').trim();
   if(!text)return;
   entry._server_pending=true;
@@ -287,38 +296,48 @@ function _backendAcknowledgeQueuedMessage(sid, entry){
     model:entry.model||'',
     model_provider:entry.model_provider||null,
     profile:entry.profile||S.activeProfile||'default',
+    client_queue_id:entry._client_queue_id,
   };
-  fetch(new URL('api/session/queue',document.baseURI||location.href).href,{
-    method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
-    body:JSON.stringify(body),
-  }).then(r=>r.json().then(data=>({ok:r.ok,data})).catch(()=>({ok:r.ok,data:{}})))
-    .then(({ok,data})=>{
+  try{
+    const r=await fetch(new URL('api/session/queue',document.baseURI||location.href).href,{
+      method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify(body),
+    });
+    let data={};try{data=await r.json();}catch(_){}
+    const ok=r.ok;
       const found=_findQueuedEntryByClientId(sid,entry._client_queue_id);
       if(found.idx<0){
-        if(ok&&data&&data.item&&data.item.id)_deleteBackendQueuedItem(sid,data.item.id);
+        if(ok&&data&&data.item&&data.item.id)await _deleteBackendQueuedItem(sid,data.item.id).catch(()=>{});
         return;
       }
       if(ok&&data&&data.item&&data.item.id){
-        found.q[found.idx]={...found.entry,_server_pending:false,_server_owned:true,_server_queue_id:data.item.id};
+        found.q[found.idx]={...found.entry,_server_pending:false,_server_owned:true,
+          _server_queue_id:data.item.id,_server_state:data.item.state||'queued',_server_error:data.item.error||''};
       }else{
         found.q[found.idx]={...found.entry,_server_pending:false,_server_error:(data&&data.error)||'queue_ack_failed'};
       }
       _persistSessionQueueStorage(sid,found.q);
       delete _queueRenderKeys[sid];
       updateQueueBadge(sid);
-    }).catch(()=>{
+  }catch(_){
+      await syncBackendSessionQueue(sid).catch(()=>{});
       const found=_findQueuedEntryByClientId(sid,entry._client_queue_id);
       if(found.idx<0)return;
-      found.q[found.idx]={...found.entry,_server_pending:false,_server_error:'queue_ack_failed'};
+      if(found.entry&&found.entry._server_owned)return;
+      found.q[found.idx]={...found.entry,_server_pending:false,_server_error:'queue_ack_failed',_server_ack_attempts:attempt+1};
       _persistSessionQueueStorage(sid,found.q);
       delete _queueRenderKeys[sid];
       updateQueueBadge(sid);
-    });
+      if(attempt<2)setTimeout(()=>_backendAcknowledgeQueuedMessage(sid,found.q[found.idx],attempt+1),250*(attempt+1));
+  }
 }
-function _removeServerQueuedEntry(sid, serverId){
-  if(!sid||!serverId)return false;
+function _removeServerQueuedEntry(sid, serverId, clientId=''){
+  if(!sid||(!serverId&&!clientId))return false;
   const q=_getSessionQueue(sid,false);
-  const idx=q.findIndex(e=>e&&e._server_queue_id===serverId);
+  const idx=q.findIndex(e=>e&&(
+    (serverId&&e._server_queue_id===serverId)||
+    (clientId&&e._client_queue_id===clientId)
+  ));
   if(idx<0)return false;
   q.splice(idx,1);
   if(!q.length){delete SESSION_QUEUES[sid];_clearPersistedSessionQueue(sid);}
@@ -341,64 +360,79 @@ function shiftQueuedSessionMessage(sid){
   }
   return next;
 }
-function _serverEntryOwnedOrPending(entry){return !!(entry&&(entry._server_owned||entry._server_pending));}
+function _serverEntryOwnedOrPending(entry){
+  // Every entry minted by queueSessionMessage is awaiting or has acquired
+  // backend ownership. Never fall back to the legacy browser-side drain on an
+  // ambiguous acknowledgement or mutation failure.
+  return !!(entry&&(entry._client_queue_id||entry._server_owned||entry._server_pending));
+}
 function getQueuedSessionCount(sid){
   return _getSessionQueue(sid,false).length;
 }
-function syncBackendSessionQueue(sid){
-  if(!sid||typeof fetch!=='function')return;
-  fetch(new URL('api/session/queue?session_id='+encodeURIComponent(sid),document.baseURI||location.href).href,{credentials:'include'})
-    .then(r=>r.ok?r.json():null)
-    .then(data=>{
-      if(!data||!Array.isArray(data.items))return;
-      let q=_getSessionQueue(sid,false);
-      if(!q.length){
-        const persisted=_readPersistedSessionQueue(sid);
-        if(persisted.length){SESSION_QUEUES[sid]=persisted;q=persisted;}
-      }
-      if(!q.length)q=_getSessionQueue(sid,true);
-      const serverIds=new Set(data.items.map(item=>String(item&&item.id||'')).filter(Boolean));
-      let changed=false;
-      for(let i=q.length-1;i>=0;i--){
-        if(q[i]&&q[i]._server_owned&&q[i]._server_queue_id&&!serverIds.has(String(q[i]._server_queue_id))){
-          q.splice(i,1);changed=true;
-        }
-      }
-      data.items.forEach(item=>{
-        const id=String(item&&item.id||'');
-        if(!id||q.some(e=>e&&e._server_queue_id===id))return;
-        const itemText=String(item.text||'');
-        const itemMatchText=itemText.trim();
-        const pendingIdx=q.findIndex(e=>e&&e._server_pending&&!e._server_queue_id&&String(e.text||e.message||e.content||'').trim()===itemMatchText);
-        if(pendingIdx>=0){
-          q[pendingIdx]={...q[pendingIdx],text:itemText,_server_pending:false,_server_owned:true,_server_queue_id:id,_server_error:item.error||'',_server_blocked:!!item.blocked};
-          changed=true;
-          return;
-        }
-        q.push({
-          text:itemText,
-          files:[],
-          attachments:Array.isArray(item.attachments)?item.attachments:[],
-          model:item.model||'',
-          model_provider:item.model_provider||null,
-          profile:item.profile||S.activeProfile||'default',
-          _queued_at:Math.round((Number(item.created_at)||Date.now()/1000)*1000),
-          _server_owned:true,
-          _server_pending:false,
-          _server_queue_id:id,
-          _server_error:item.error||'',
-          _server_blocked:!!item.blocked,
-        });
-        changed=true;
-      });
-      for(let i=0;i<q.length;i++){
-        if(q[i]&&q[i]._server_pending&&!q[i]._server_queue_id){
-          q[i]={...q[i],_server_pending:false,_server_error:'queue_ack_recovered'};
-          changed=true;
-        }
-      }
-      if(changed){_persistSessionQueueStorage(sid,q);delete _queueRenderKeys[sid];updateQueueBadge(sid);}
-    }).catch(()=>{});
+async function syncBackendSessionQueue(sid){
+  if(!sid||typeof fetch!=='function')return [];
+  const generations=syncBackendSessionQueue._generations||(syncBackendSessionQueue._generations={});
+  const generation=(generations[sid]||0)+1;
+  generations[sid]=generation;
+  const r=await fetch(new URL('api/session/queue?session_id='+encodeURIComponent(sid),document.baseURI||location.href).href,{credentials:'include'});
+  if(!r.ok)throw new Error('queue_sync_failed');
+  const data=await r.json();
+  if(!data||!Array.isArray(data.items))throw new Error('queue_sync_invalid');
+  if(generations[sid]!==generation)return _getSessionQueue(sid,false);
+  let local=_getSessionQueue(sid,false);
+  if(!local.length){
+    const persisted=_readPersistedSessionQueue(sid);
+    if(persisted.length){SESSION_QUEUES[sid]=persisted;local=persisted;}
+  }
+  const byServerId=new Map();
+  const byClientId=new Map();
+  local.forEach(entry=>{
+    if(entry&&entry._server_queue_id)byServerId.set(String(entry._server_queue_id),entry);
+    if(entry&&entry._client_queue_id)byClientId.set(String(entry._client_queue_id),entry);
+  });
+  const authoritative=[];
+  const consumed=new Set();
+  for(const item of data.items){
+    const id=String(item&&item.id||'');
+    if(!id)continue;
+    const clientId=String(item&&item.client_queue_id||'');
+    let prior=(clientId&&byClientId.get(clientId))||byServerId.get(id)||null;
+    // Compatibility for queue files created before client ids existed. New
+    // acknowledgements always reconcile by stable client_queue_id.
+    if(!prior&&!clientId){
+      prior=local.find(entry=>entry&&entry._server_pending&&!consumed.has(entry)&&
+        String(entry.text||entry.message||entry.content||'').trim()===String(item.text||'').trim())||null;
+    }
+    if(prior)consumed.add(prior);
+    if(String(item.state||'queued')==='started')continue;
+    authoritative.push({
+      ...(prior||{}),
+      text:String(item.text||''),
+      files:[],
+      attachments:Array.isArray(item.attachments)?item.attachments:[],
+      model:item.model||'',
+      model_provider:item.model_provider||null,
+      profile:item.profile||S.activeProfile||'default',
+      _queued_at:Math.round((Number(item.created_at)||Date.now()/1000)*1000),
+      _client_queue_id:clientId||(prior&&prior._client_queue_id)||'',
+      _server_owned:true,
+      _server_pending:false,
+      _server_queue_id:id,
+      _server_state:item.state||'queued',
+      _server_error:item.error||'',
+      _server_blocked:item.state==='blocked'||!!item.blocked,
+    });
+  }
+  // Preserve only browser-owned entries whose acknowledgement has not yet
+  // been authoritatively observed. Server-owned order comes exclusively from
+  // the backend response.
+  const browserOwned=local.filter(entry=>entry&&!entry._server_owned&&!consumed.has(entry));
+  const reconciled=authoritative.concat(browserOwned);
+  if(reconciled.length){SESSION_QUEUES[sid]=reconciled;_persistSessionQueueStorage(sid,reconciled);}
+  else{delete SESSION_QUEUES[sid];_clearPersistedSessionQueue(sid);}
+  delete _queueRenderKeys[sid];
+  updateQueueBadge(sid);
+  return reconciled;
 }
 function _compressionSessionLock(){
   return window._compressionLockSid||null;
@@ -8157,6 +8191,17 @@ function _clearQueueCardDisplay(sid){
   _updateQueuePill(sid,0);
 }
 
+async function _postBackendQueueMutation(sid, operation, payload={}){
+  const r=await fetch(new URL('api/session/queue/'+operation,document.baseURI||location.href).href,{
+    method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({session_id:sid,...payload}),
+  });
+  let data={};try{data=await r.json();}catch(_){}
+  if(!r.ok)throw new Error(data.error||('queue_'+operation+'_failed'));
+  await syncBackendSessionQueue(sid);
+  return data;
+}
+
 function _renderQueueChips(sid){
   const card=document.getElementById('queueCard');
   const inner=document.getElementById('queueChips');
@@ -8215,11 +8260,23 @@ function _renderQueueChips(sid){
     const actions=document.createElement('span');
     actions.className='queue-card-header-actions';
     const hasFiles=q.some(e=>e&&Array.isArray(e.files)&&e.files.length>0);
+    const allServerMutable=q.every(e=>e&&e._server_owned&&e._server_queue_id&&
+      (!e._server_state||e._server_state==='queued'||e._server_state==='blocked'));
     const mergeBtn=document.createElement('button');
     mergeBtn.className='queue-card-btn';
     mergeBtn.title='Combine all into one message'+(hasFiles?' — attachments will be removed':'');
     mergeBtn.innerHTML=li('layers',12)+'Combine';
-    mergeBtn.onclick=()=>{
+    mergeBtn.disabled=!allServerMutable&&q.some(e=>e&&e._server_owned);
+    mergeBtn.onclick=async()=>{
+      if(allServerMutable){
+        try{
+          await _postBackendQueueMutation(sid,'combine',{ordered_ids:q.map(e=>e._server_queue_id)});
+        }catch(err){
+          if(typeof showToast==='function')showToast('Could not combine queued messages: '+(err&&err.message||err),null,'error');
+          await syncBackendSessionQueue(sid).catch(()=>{});
+        }
+        return;
+      }
       const _doMerge=(snapshot)=>{
         const combined=snapshot.map(e=>e&&(e.text||e.message||e.content||'')).filter(Boolean).join('\n\n');
         const liveQ=_getSessionQueue(sid,false);
@@ -8235,10 +8292,7 @@ function _renderQueueChips(sid){
         if(typeof showToast==='function') showToast('Attachments on queued items will be removed',2600,'warning');
       }
       const snapshot=[..._getSessionQueue(sid,false)];
-      if(snapshot.some(e=>e&&e._server_owned)){
-        if(typeof showToast==='function') showToast('Already-synced queued messages cannot be merged yet',2600,'warning');
-        return;
-      }
+
       // Merge from current live queue (no delay — snapshot + defer caused data-loss races)
       _doMerge(snapshot);
     };
@@ -8247,15 +8301,16 @@ function _renderQueueChips(sid){
     clearBtn.title='Clear all queued messages';
     clearBtn.setAttribute('aria-label','Clear all queued messages');
     clearBtn.innerHTML=li('x',13);
-    clearBtn.onclick=()=>{
-      q.forEach(entry=>{
-        if(entry&&entry._server_owned&&entry._server_queue_id){
-          fetch(new URL('api/session/queue/delete',document.baseURI||location.href).href,{
-            method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
-            body:JSON.stringify({session_id:sid,id:entry._server_queue_id}),
-          }).catch(()=>{});
+    clearBtn.disabled=!allServerMutable&&q.some(e=>e&&e._server_owned);
+    clearBtn.onclick=async()=>{
+      if(allServerMutable){
+        try{await _postBackendQueueMutation(sid,'clear');}
+        catch(err){
+          if(typeof showToast==='function')showToast('Could not clear queued messages: '+(err&&err.message||err),null,'error');
+          await syncBackendSessionQueue(sid).catch(()=>{});
         }
-      });
+        return;
+      }
       q.length=0;_saveAndRefresh();
     };
     actions.appendChild(mergeBtn);
@@ -8283,20 +8338,33 @@ function _renderQueueChips(sid){
     const _entryTs=entry&&entry._queued_at;
     const entryText=entry&&(entry.text||entry.message||entry.content||'');
     const _files=entry&&Array.isArray(entry.files)?entry.files.filter(Boolean):[];
+    const _serverState=entry&&entry._server_state||'';
+    const _entryMutable=!_serverState||_serverState==='queued'||_serverState==='blocked';
     const row=document.createElement('div');
     row.className='queue-card-row';
     row.setAttribute('role','listitem');
-    row.setAttribute('draggable','true');
+    row.setAttribute('draggable',_entryMutable?'true':'false');
     row.ondragstart=(e)=>{if(_entryTs==null) return;_dragTs=_entryTs;row.style.opacity='.4';e.dataTransfer.effectAllowed='move';};
     row.ondragend=()=>{row.style.opacity='';};
     row.ondragover=(e)=>{e.preventDefault();row.style.background='var(--hover-bg)';};
     row.ondragleave=()=>{row.style.background='';};
-    row.ondrop=(e)=>{
+    row.ondrop=async(e)=>{
       e.preventDefault();row.style.background='';
       if(_dragTs!=null&&_dragTs!==_entryTs){
         const fromIdx=q.findIndex(e=>e&&e._queued_at===_dragTs);
-        if(fromIdx!==-1&&fromIdx!==i){const moved=q.splice(fromIdx,1)[0];q.splice(i,0,moved);}
-        _dragTs=null;_saveAndRefresh();
+        if(fromIdx!==-1&&fromIdx!==i){
+          const planned=[...q];const moved=planned.splice(fromIdx,1)[0];planned.splice(i,0,moved);
+          const backendOwned=planned.every(item=>item&&item._server_owned&&item._server_queue_id&&
+            (!item._server_state||item._server_state==='queued'||item._server_state==='blocked'));
+          if(backendOwned){
+            try{await _postBackendQueueMutation(sid,'reorder',{ordered_ids:planned.map(item=>item._server_queue_id)});}
+            catch(err){
+              if(typeof showToast==='function')showToast('Could not reorder queued messages: '+(err&&err.message||err),null,'error');
+              await syncBackendSessionQueue(sid).catch(()=>{});
+            }
+          }else{q.length=0;q.push(...planned);_saveAndRefresh();}
+        }
+        _dragTs=null;
       }
     };
     // Drag handle
@@ -8307,13 +8375,13 @@ function _renderQueueChips(sid){
     // Inline-editable text
     const msgSpan=document.createElement('span');
     msgSpan.className='queue-card-text';
-    msgSpan.setAttribute('contenteditable','true');
+    msgSpan.setAttribute('contenteditable',_entryMutable?'true':'false');
     msgSpan.setAttribute('role','textbox');
     msgSpan.setAttribute('aria-label','Queued message — edit in place');
     msgSpan.textContent=entryText||(_files.length?'':'—');
     msgSpan.setAttribute('draggable','false');
     msgSpan.onfocus=()=>{msgSpan.style.overflow='auto';msgSpan.style.whiteSpace='pre-wrap';msgSpan.style.textOverflow='clip';};
-    msgSpan.onblur=()=>{
+    msgSpan.onblur=async()=>{
       msgSpan.style.overflow='';msgSpan.style.whiteSpace='';msgSpan.style.textOverflow='';
       const newText=msgSpan.textContent.trim();
       if(newText===''&&!_files.length){ msgSpan.textContent=entryText||'—'; return; }
@@ -8321,13 +8389,16 @@ function _renderQueueChips(sid){
         const liveQ=_getSessionQueue(sid,false);
         const idx=_entryTs!=null?liveQ.findIndex(e=>e&&e._queued_at===_entryTs):i;
         if(idx!==-1){
-          liveQ[idx]={...liveQ[idx],text:newText};
-          _persistSessionQueueStorage(sid,liveQ);
           if(liveQ[idx]._server_owned&&liveQ[idx]._server_queue_id){
-            fetch(new URL('api/session/queue/update',document.baseURI||location.href).href,{
-              method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
-              body:JSON.stringify({session_id:sid,id:liveQ[idx]._server_queue_id,text:newText}),
-            }).catch(()=>{});
+            try{await _postBackendQueueMutation(sid,'update',{id:liveQ[idx]._server_queue_id,text:newText});}
+            catch(err){
+              msgSpan.textContent=entryText||'—';
+              if(typeof showToast==='function')showToast('Could not edit queued message: '+(err&&err.message||err),null,'error');
+              await syncBackendSessionQueue(sid).catch(()=>{});
+            }
+          }else{
+            liveQ[idx]={...liveQ[idx],text:newText};
+            _persistSessionQueueStorage(sid,liveQ);
           }
           delete _queueRenderKeys[sid];
           updateQueueBadge(sid);
@@ -8338,6 +8409,19 @@ function _renderQueueChips(sid){
     // Compact badges (files, model, profile)
     const badges=document.createElement('span');
     badges.className='queue-card-badges';
+    if(_serverState&&_serverState!=='queued'){
+      const stateBadge=document.createElement('span');
+      stateBadge.className='queue-card-state queue-card-state-'+_serverState;
+      stateBadge.textContent=_serverState==='starting'?'Starting…':(_serverState==='blocked'?'Needs attention':'Queued');
+      stateBadge.title=entry._server_error||('Queue state: '+_serverState);
+      badges.appendChild(stateBadge);
+    }else if(entry&&entry._server_error){
+      const stateBadge=document.createElement('span');
+      stateBadge.className='queue-card-state queue-card-state-error';
+      stateBadge.textContent='Sync failed';
+      stateBadge.title=entry._server_error;
+      badges.appendChild(stateBadge);
+    }
     if(_files.length>0){
       const fb=document.createElement('span');
       fb.className='queue-card-file-badge';
@@ -8362,19 +8446,22 @@ function _renderQueueChips(sid){
     delBtn.setAttribute('aria-label',typeof t==='function'?t('queued_cancel'):'Remove queued message');
     delBtn.setAttribute('draggable','false');
     delBtn.title='Remove from queue';
+    delBtn.disabled=!_entryMutable;
     delBtn.innerHTML=li('x',13);
-    delBtn.onclick=()=>{
+    delBtn.onclick=async()=>{
       const liveQ=_getSessionQueue(sid,false);
       const idx=_entryTs!=null?liveQ.findIndex(e=>e&&e._queued_at===_entryTs):i;
       if(idx!==-1){
         const removed=liveQ[idx];
-        liveQ.splice(idx,1);
         if(removed&&removed._server_owned&&removed._server_queue_id){
-          fetch(new URL('api/session/queue/delete',document.baseURI||location.href).href,{
-            method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
-            body:JSON.stringify({session_id:sid,id:removed._server_queue_id}),
-          }).catch(()=>{});
+          try{await _deleteBackendQueuedItem(sid,removed._server_queue_id);await syncBackendSessionQueue(sid);}
+          catch(err){
+            if(typeof showToast==='function')showToast('Could not remove queued message: '+(err&&err.message||err),null,'error');
+            await syncBackendSessionQueue(sid).catch(()=>{});
+          }
+          return;
         }
+        liveQ.splice(idx,1);
       }
       if(!liveQ.length){delete SESSION_QUEUES[sid];_clearPersistedSessionQueue(sid);}
       else{SESSION_QUEUES[sid]=[...liveQ];_persistSessionQueueStorage(sid,liveQ);}

--- a/static/ui.js
+++ b/static/ui.js
@@ -266,6 +266,20 @@ function _findQueuedEntryByClientId(sid, clientId){
   const idx=q.findIndex(e=>e&&e._client_queue_id===clientId);
   return {q,idx,entry:idx>=0?q[idx]:null};
 }
+function _findQueuedEntryIndex(queue, target){
+  if(!Array.isArray(queue)||!target)return -1;
+  const serverId=String(target._server_queue_id||'');
+  if(serverId){
+    const index=queue.findIndex(entry=>entry&&String(entry._server_queue_id||'')===serverId);
+    if(index>=0)return index;
+  }
+  const clientId=String(target._client_queue_id||'');
+  if(clientId){
+    const index=queue.findIndex(entry=>entry&&String(entry._client_queue_id||'')===clientId);
+    if(index>=0)return index;
+  }
+  return queue.indexOf(target);
+}
 function _deleteBackendQueuedItem(sid, serverId){
   if(!sid||!serverId||typeof fetch!=='function')return Promise.resolve(false);
   return fetch(new URL('api/session/queue/delete',document.baseURI||location.href).href,{
@@ -8207,7 +8221,11 @@ function _renderQueueChips(sid){
   const inner=document.getElementById('queueChips');
   if(!card||!inner) return;
   const q=_getSessionQueue(sid,false);
-  const key=q.map(e=>{const t=e&&(e.text||e.message||e.content||'');return(e&&e._queued_at||0)+':'+t.length+':'+t.slice(0,20);}).join('|');
+  const key=q.map((e,index)=>{
+    const t=e&&(e.text||e.message||e.content||'');
+    const identity=e&&(e._server_queue_id||e._client_queue_id)||('local-'+index+'-'+(e&&e._queued_at||0));
+    return identity+':'+(e&&e._server_state||'')+':'+t.length+':'+t.slice(0,20);
+  }).join('|');
   if(key===(_queueRenderKeys[sid]||'')&&key!='') return;
   // Skip re-render if user is actively editing inside the queue panel
   if(inner.contains(document.activeElement)&&document.activeElement!==inner) return;
@@ -8333,9 +8351,8 @@ function _renderQueueChips(sid){
     inner.appendChild(header);
   }
 
-  let _dragTs=null;  // use _queued_at timestamp — survives re-renders, not an index
+  let _dragEntry=null;
   q.forEach((entry,i)=>{
-    const _entryTs=entry&&entry._queued_at;
     const entryText=entry&&(entry.text||entry.message||entry.content||'');
     const _files=entry&&Array.isArray(entry.files)?entry.files.filter(Boolean):[];
     const _serverState=entry&&entry._server_state||'';
@@ -8343,17 +8360,20 @@ function _renderQueueChips(sid){
     const row=document.createElement('div');
     row.className='queue-card-row';
     row.setAttribute('role','listitem');
+    row.setAttribute('data-queue-item-id',String(entry&&entry._server_queue_id||entry&&entry._client_queue_id||''));
     row.setAttribute('draggable',_entryMutable?'true':'false');
-    row.ondragstart=(e)=>{if(_entryTs==null) return;_dragTs=_entryTs;row.style.opacity='.4';e.dataTransfer.effectAllowed='move';};
+    row.ondragstart=(e)=>{_dragEntry=entry;row.style.opacity='.4';e.dataTransfer.effectAllowed='move';};
     row.ondragend=()=>{row.style.opacity='';};
     row.ondragover=(e)=>{e.preventDefault();row.style.background='var(--hover-bg)';};
     row.ondragleave=()=>{row.style.background='';};
     row.ondrop=async(e)=>{
       e.preventDefault();row.style.background='';
-      if(_dragTs!=null&&_dragTs!==_entryTs){
-        const fromIdx=q.findIndex(e=>e&&e._queued_at===_dragTs);
-        if(fromIdx!==-1&&fromIdx!==i){
-          const planned=[...q];const moved=planned.splice(fromIdx,1)[0];planned.splice(i,0,moved);
+      if(_dragEntry&&_findQueuedEntryIndex(_getSessionQueue(sid,false),_dragEntry)!==_findQueuedEntryIndex(_getSessionQueue(sid,false),entry)){
+        const liveQ=_getSessionQueue(sid,false);
+        const fromIdx=_findQueuedEntryIndex(liveQ,_dragEntry);
+        const toIdx=_findQueuedEntryIndex(liveQ,entry);
+        if(fromIdx!==-1&&toIdx!==-1&&fromIdx!==toIdx){
+          const planned=[...liveQ];const moved=planned.splice(fromIdx,1)[0];planned.splice(toIdx,0,moved);
           const backendOwned=planned.every(item=>item&&item._server_owned&&item._server_queue_id&&
             (!item._server_state||item._server_state==='queued'||item._server_state==='blocked'));
           if(backendOwned){
@@ -8362,9 +8382,9 @@ function _renderQueueChips(sid){
               if(typeof showToast==='function')showToast('Could not reorder queued messages: '+(err&&err.message||err),null,'error');
               await syncBackendSessionQueue(sid).catch(()=>{});
             }
-          }else{q.length=0;q.push(...planned);_saveAndRefresh();}
+          }else{liveQ.length=0;liveQ.push(...planned);_saveAndRefresh();}
         }
-        _dragTs=null;
+        _dragEntry=null;
       }
     };
     // Drag handle
@@ -8387,7 +8407,7 @@ function _renderQueueChips(sid){
       if(newText===''&&!_files.length){ msgSpan.textContent=entryText||'—'; return; }
       if(newText!==entryText){
         const liveQ=_getSessionQueue(sid,false);
-        const idx=_entryTs!=null?liveQ.findIndex(e=>e&&e._queued_at===_entryTs):i;
+        const idx=_findQueuedEntryIndex(liveQ,entry);
         if(idx!==-1){
           if(liveQ[idx]._server_owned&&liveQ[idx]._server_queue_id){
             try{await _postBackendQueueMutation(sid,'update',{id:liveQ[idx]._server_queue_id,text:newText});}
@@ -8449,8 +8469,9 @@ function _renderQueueChips(sid){
     delBtn.disabled=!_entryMutable;
     delBtn.innerHTML=li('x',13);
     delBtn.onclick=async()=>{
+      delBtn.blur();
       const liveQ=_getSessionQueue(sid,false);
-      const idx=_entryTs!=null?liveQ.findIndex(e=>e&&e._queued_at===_entryTs):i;
+      const idx=_findQueuedEntryIndex(liveQ,entry);
       if(idx!==-1){
         const removed=liveQ[idx];
         if(removed&&removed._server_owned&&removed._server_queue_id){

--- a/static/ui.js
+++ b/static/ui.js
@@ -208,6 +208,8 @@ function _getSessionQueue(sid, create=false){
   if(!SESSION_QUEUES[sid]&&create) SESSION_QUEUES[sid]=[];
   return SESSION_QUEUES[sid]||[];
 }
+const _QUEUE_ACK_IN_FLIGHT=new Set();
+function _queueAckKey(sid,clientId){return String(sid||'')+'\n'+String(clientId||'');}
 function _queueStorageKey(sid){
   return 'hermes-queue-'+sid;
 }
@@ -291,8 +293,12 @@ function _deleteBackendQueuedItem(sid, serverId){
     throw new Error(data.error||'queue_delete_failed');
   });
 }
-async function _backendAcknowledgeQueuedMessage(sid, entry, attempt=0){
-  if(!sid||!entry||entry._server_owned||entry._server_pending)return;
+async function _backendAcknowledgeQueuedMessage(sid, entry, attempt=0, recoverPending=false){
+  if(!sid||!entry||entry._server_owned||(entry._server_pending&&!recoverPending))return;
+  const clientId=String(entry._client_queue_id||'');
+  if(!clientId)return;
+  const ackKey=_queueAckKey(sid,clientId);
+  if(_QUEUE_ACK_IN_FLIGHT.has(ackKey))return;
   if(_queuedEntryHasBrowserOnlyFiles(entry)){
     entry._server_error='Attachments could not be queued durably; remove this item and resend';
     _persistSessionQueueStorage(sid,_getSessionQueue(sid,false));
@@ -301,6 +307,7 @@ async function _backendAcknowledgeQueuedMessage(sid, entry, attempt=0){
   }
   const text=String(entry.text||entry.message||entry.content||'').trim();
   if(!text)return;
+  _QUEUE_ACK_IN_FLIGHT.add(ackKey);
   entry._server_pending=true;
   _persistSessionQueueStorage(sid,_getSessionQueue(sid,false));
   const body={
@@ -310,7 +317,7 @@ async function _backendAcknowledgeQueuedMessage(sid, entry, attempt=0){
     model:entry.model||'',
     model_provider:entry.model_provider||null,
     profile:entry.profile||S.activeProfile||'default',
-    client_queue_id:entry._client_queue_id,
+    client_queue_id:clientId,
   };
   try{
     const r=await fetch(new URL('api/session/queue',document.baseURI||location.href).href,{
@@ -319,30 +326,33 @@ async function _backendAcknowledgeQueuedMessage(sid, entry, attempt=0){
     });
     let data={};try{data=await r.json();}catch(_){}
     const ok=r.ok;
-      const found=_findQueuedEntryByClientId(sid,entry._client_queue_id);
-      if(found.idx<0){
-        if(ok&&data&&data.item&&data.item.id)await _deleteBackendQueuedItem(sid,data.item.id).catch(()=>{});
-        return;
-      }
-      if(ok&&data&&data.item&&data.item.id){
-        found.q[found.idx]={...found.entry,_server_pending:false,_server_owned:true,
-          _server_queue_id:data.item.id,_server_state:data.item.state||'queued',_server_error:data.item.error||''};
-      }else{
-        found.q[found.idx]={...found.entry,_server_pending:false,_server_error:(data&&data.error)||'queue_ack_failed'};
-      }
-      _persistSessionQueueStorage(sid,found.q);
-      delete _queueRenderKeys[sid];
-      updateQueueBadge(sid);
+    const found=_findQueuedEntryByClientId(sid,clientId);
+    if(found.idx<0){
+      if(ok&&data&&data.item&&data.item.id)await _deleteBackendQueuedItem(sid,data.item.id).catch(()=>{});
+      return;
+    }
+    if(ok&&data&&data.item&&data.item.id){
+      found.q[found.idx]={...found.entry,_server_pending:false,_server_owned:true,
+        _server_queue_id:data.item.id,_server_state:data.item.state||'queued',_server_error:data.item.error||'',_server_ack_attempts:0};
+    }else{
+      found.q[found.idx]={...found.entry,_server_pending:false,
+        _server_error:(data&&data.error)||'queue_ack_failed',_server_ack_attempts:attempt+1};
+    }
+    _persistSessionQueueStorage(sid,found.q);
+    delete _queueRenderKeys[sid];
+    updateQueueBadge(sid);
   }catch(_){
-      await syncBackendSessionQueue(sid).catch(()=>{});
-      const found=_findQueuedEntryByClientId(sid,entry._client_queue_id);
-      if(found.idx<0)return;
-      if(found.entry&&found.entry._server_owned)return;
-      found.q[found.idx]={...found.entry,_server_pending:false,_server_error:'queue_ack_failed',_server_ack_attempts:attempt+1};
-      _persistSessionQueueStorage(sid,found.q);
-      delete _queueRenderKeys[sid];
-      updateQueueBadge(sid);
-      if(attempt<2)setTimeout(()=>_backendAcknowledgeQueuedMessage(sid,found.q[found.idx],attempt+1),250*(attempt+1));
+    await syncBackendSessionQueue(sid).catch(()=>{});
+    const found=_findQueuedEntryByClientId(sid,clientId);
+    if(found.idx<0)return;
+    if(found.entry&&found.entry._server_owned)return;
+    found.q[found.idx]={...found.entry,_server_pending:false,_server_error:'queue_ack_failed',_server_ack_attempts:attempt+1};
+    _persistSessionQueueStorage(sid,found.q);
+    delete _queueRenderKeys[sid];
+    updateQueueBadge(sid);
+    if(attempt<2)setTimeout(()=>_backendAcknowledgeQueuedMessage(sid,found.q[found.idx],attempt+1),250*(attempt+1));
+  }finally{
+    _QUEUE_ACK_IN_FLIGHT.delete(ackKey);
   }
 }
 function _removeServerQueuedEntry(sid, serverId, clientId=''){
@@ -446,7 +456,21 @@ async function syncBackendSessionQueue(sid){
   else{delete SESSION_QUEUES[sid];_clearPersistedSessionQueue(sid);}
   delete _queueRenderKeys[sid];
   updateQueueBadge(sid);
-  return reconciled;
+  const recoveries=browserOwned.filter(entry=>{
+    const clientId=String(entry&&entry._client_queue_id||'');
+    const attempts=Number(entry&&entry._server_ack_attempts)||0;
+    return clientId&&attempts<3&&!_QUEUE_ACK_IN_FLIGHT.has(_queueAckKey(sid,clientId));
+  }).map(entry=>{
+    entry._server_pending=false;
+    return _backendAcknowledgeQueuedMessage(
+      sid,entry,Number(entry._server_ack_attempts)||0,true
+    );
+  });
+  if(recoveries.length){
+    _persistSessionQueueStorage(sid,reconciled);
+    await Promise.all(recoveries);
+  }
+  return _getSessionQueue(sid,false);
 }
 function _compressionSessionLock(){
   return window._compressionLockSid||null;

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -1775,16 +1775,16 @@ def test_start_chat_stream_clears_gateway_run_state_when_thread_start_fails(monk
     monkeypatch.setattr(routes, "threading", SimpleNamespace(Thread=_BoomThread))
 
     with patch("api.turn_journal.append_turn_journal_event", return_value={}):
-        with pytest.raises(RuntimeError, match="thread start failed"):
-            routes._start_chat_stream_for_session(
-                session,
-                msg="hi",
-                attachments=[],
-                workspace="/tmp",
-                model="test-model",
-                external_runtime_owned=True,
-            )
+        response = routes._start_chat_stream_for_session(
+            session,
+            msg="hi",
+            attachments=[],
+            workspace="/tmp",
+            model="test-model",
+            external_runtime_owned=True,
+        )
 
+    assert response == {"error": "failed to start agent worker", "_status": 500}
     assert gateway_chat.gateway_run_id_pending(recorded["stream_id"]) is False
     assert recorded["stream_id"] not in getattr(gateway_chat, "_STREAM_RUN_LIFECYCLE", {})
 

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -389,16 +389,36 @@ def test_gateway_approval_event_translation():
     assert _gateway_runs_approval_event({}) is None
 
 
-def test_gateway_runs_api_streaming_parses_real_run_events():
+def test_gateway_runs_api_streaming_parses_real_run_events(monkeypatch):
     """The runs-API bridge must parse the real gateway event payloads."""
     from api.config import STREAM_PARTIAL_TEXT, STREAM_REASONING_TEXT
     from api.gateway_chat import _STREAM_RUN_IDS, _run_gateway_runs_api_streaming
 
     events = []
     requests = []
+    external_admissions = []
+    external_marks = []
     stream_id = "sid-real-runs"
     STREAM_PARTIAL_TEXT[stream_id] = ""
     STREAM_REASONING_TEXT[stream_id] = ""
+    from api import session_queue
+
+    monkeypatch.setattr(
+        session_queue,
+        "mark_external_admission",
+        lambda session_id, item_id, local_stream_id, admission_id, **kwargs: external_admissions.append(
+            (session_id, item_id, local_stream_id, admission_id, kwargs, len(requests))
+        )
+        or True,
+    )
+    monkeypatch.setattr(
+        session_queue,
+        "mark_external_run",
+        lambda session_id, item_id, local_stream_id, run_id, **kwargs: external_marks.append(
+            (session_id, item_id, local_stream_id, run_id, kwargs)
+        )
+        or True,
+    )
 
     class _JsonResponse:
         def __init__(self, payload):
@@ -456,6 +476,8 @@ def test_gateway_runs_api_streaming_parses_real_run_events():
                     {"role": "assistant", "content": "earlier reply"},
                 ],
                 body_extras={"provider": "anthropic"},
+                queue_item_id="queue-item-1",
+                queue_attempt_id="attempt-1",
                 put_gateway_event=lambda event, data: events.append((event, data)),
                 cancel_event=threading.Event(),
             )
@@ -474,6 +496,21 @@ def test_gateway_runs_api_streaming_parses_real_run_events():
     assert run_body["provider"] == "anthropic"
     assert run_body["session_id"] == "sess1"
     assert "messages" not in run_body
+    assert len(external_admissions) == 1
+    admission = external_admissions[0]
+    assert admission[:3] == ("sess1", "queue-item-1", stream_id)
+    assert admission[3]
+    assert admission[4] == {"attempt_id": "attempt-1"}
+    assert admission[5] == 0, "external admission must be durable before the POST"
+    assert external_marks == [
+        (
+            "sess1",
+            "queue-item-1",
+            stream_id,
+            "run-abc",
+            {"admission_id": admission[3], "attempt_id": "attempt-1"},
+        )
+    ]
 
     assert final_text == "Hello"
     assert usage["input_tokens"] == 3
@@ -485,6 +522,48 @@ def test_gateway_runs_api_streaming_parses_real_run_events():
     assert events[2] == ("token", {"text": "Hello"})
     import api.route_approvals as approvals
     assert approvals.gateway_pending_mirror("sess1", run_id="run-abc") is None
+
+
+def test_gateway_runs_api_stops_remote_run_when_queue_binding_is_lost(monkeypatch):
+    from api import gateway_chat, session_queue
+
+    stopped = []
+
+    class _JsonResponse:
+        def read(self, _limit=None):
+            return b'{"run_id":"run-orphan"}'
+
+        def __iter__(self):
+            return iter(())
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+    monkeypatch.setattr(session_queue, "mark_external_admission", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(session_queue, "mark_external_run", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(gateway_chat, "stop_gateway_run", lambda run_id: stopped.append(run_id) or True)
+
+    with patch("urllib.request.urlopen", return_value=_JsonResponse()):
+        with pytest.raises(RuntimeError, match="lost external run ownership"):
+            gateway_chat._run_gateway_runs_api_streaming(
+                session_id="sess-orphan",
+                msg_text="hi",
+                model="test-model",
+                workspace="/tmp",
+                stream_id="stream-orphan",
+                base_url="http://gw:8642",
+                api_key="secret",
+                prefill_messages=[],
+                body_extras={},
+                queue_item_id="queue-orphan",
+                put_gateway_event=lambda *_args: None,
+                cancel_event=threading.Event(),
+            )
+
+    assert stopped == ["run-orphan"]
 
 
 def test_live_empty_ingress_id_stays_fifo_under_capability_v1():

--- a/tests/test_issue660.py
+++ b/tests/test_issue660.py
@@ -54,11 +54,11 @@ class TestQueuePersistence:
 
 
 class TestQueueRestore:
-    """Queue is restored from the shared storage helper on idle session load."""
+    """Persisted optimistic state is reconciled with backend queue authority."""
 
     def test_restore_reads_shared_helper(self):
-        """sessions.js must use the shared helper so localStorage fallback is reachable."""
-        assert "_readPersistedSessionQueue(sid)" in sess_src
+        """Session load must invoke the authoritative backend reconciliation helper."""
+        assert "syncBackendSessionQueue(S.session.session_id)" in sess_src
 
     def test_read_helper_falls_back_to_local_storage(self):
         """The helper must fall back to localStorage and re-mirror sessionStorage."""
@@ -73,25 +73,35 @@ class TestQueueRestore:
         assert "sessionStorage.setItem(key,JSON.stringify(localValue))" in body
 
     def test_restore_uses_timestamp_guard(self):
-        """Stale entries (created before last assistant response) must be dropped."""
-        assert '_queued_at' in sess_src
-        assert '_lastAsst' in sess_src
+        """Reconciliation hydrates the persisted ACK-in-flight cache before matching IDs."""
+        start = ui_src.find("async function syncBackendSessionQueue(sid)")
+        end = ui_src.find("function _compressionSessionLock()", start)
+        assert start != -1 and end != -1
+        body = ui_src[start:end]
+        assert "const persisted=_readPersistedSessionQueue(sid)" in body
+        assert "byClientId" in body
 
     def test_restore_shows_toast(self):
-        """User must see a toast notification when a queue is restored."""
-        assert 'queued message' in sess_src.lower() and 'restored' in sess_src.lower()
+        """A failed authoritative reconciliation must remain visible to the user."""
+        assert "Could not reconcile queued messages" in sess_src
 
     def test_restore_puts_text_in_composer(self):
-        """First queued message goes into the composer input, not auto-sent."""
-        assert "_msg.value=_first.text" in sess_src
+        """Recovered queue intent remains a queue chip and is never duplicated as a draft."""
+        assert "_msg.value=_first.text" not in sess_src
+        assert "syncBackendSessionQueue(S.session.session_id)" in sess_src
 
     def test_restore_clears_stale_storage(self):
-        """On timestamp mismatch, stale queue state is removed from both storage layers."""
-        assert "_clearPersistedSessionQueue(sid)" in sess_src
+        """An empty authoritative snapshot clears the optimistic recovery cache."""
+        start = ui_src.find("async function syncBackendSessionQueue(sid)")
+        end = ui_src.find("function _compressionSessionLock()", start)
+        body = ui_src[start:end]
+        assert "_clearPersistedSessionQueue(sid)" in body
 
     def test_restore_wrapped_in_try_catch(self):
-        """Storage access must be wrapped in try/catch (private browsing may block it)."""
-        assert "catch(_){if(typeof _clearPersistedSessionQueue==='function') _clearPersistedSessionQueue(sid);}" in sess_src
+        """Session load contains reconciliation failure without discarding the cache."""
+        sync_pos = sess_src.find("await syncBackendSessionQueue(S.session.session_id)")
+        catch_pos = sess_src.find("catch(err){", sync_pos)
+        assert sync_pos != -1 and catch_pos > sync_pos
 
     def test_delete_session_clears_persisted_queue_after_success(self):
         """Deleting a session must clear localStorage-backed queue state after the API succeeds."""
@@ -106,10 +116,11 @@ class TestQueueRestore:
         assert success_pos < clear_pos, "queue cleanup should run only after delete success"
 
     def test_active_session_not_restored_as_draft(self):
-        """When agent is active (INFLIGHT), queue restore must NOT run."""
-        # The restore block must be inside the else branch (idle path), not the INFLIGHT branch
-        inflight_pos = sess_src.find("if(INFLIGHT[sid]){")
-        restore_pos = sess_src.find("_readPersistedSessionQueue(sid)")
-        else_pos = sess_src.find("}else{", inflight_pos)
-        assert restore_pos > else_pos, \
-            "Queue restore must be inside the else (idle) branch, not the INFLIGHT branch"
+        """Active sessions reconcile queue chips without restoring intent into Composer."""
+        load_start = sess_src.find("async function loadSession(")
+        load_end = sess_src.find("// ── Handoff hint logic", load_start)
+        load_body = sess_src[load_start:load_end]
+        active_stream_pos = load_body.find("let activeStreamId=S.session.active_stream_id")
+        sync_pos = load_body.find("syncBackendSessionQueue(S.session.session_id)")
+        assert active_stream_pos != -1 and sync_pos > active_stream_pos
+        assert "_msg.value=_first.text" not in load_body

--- a/tests/test_session_queue.py
+++ b/tests/test_session_queue.py
@@ -230,6 +230,19 @@ if(calls[1].body.id !== 'srv-ghost' || calls[1].body.session_id !== sid){
     )
 
 
+def test_existing_session_load_syncs_backend_queue():
+    src = (pathlib.Path(__file__).parent.parent / "static" / "sessions.js").read_text(
+        encoding="utf-8"
+    )
+    load_start = src.index("async function loadSession(")
+    load_body = src[load_start : src.index("// ── Handoff hint logic", load_start)]
+    assign_pos = load_body.index("S.session=data.session")
+    stream_pos = load_body.index("startSessionStream(S.session.session_id)")
+    sync_pos = load_body.index("syncBackendSessionQueue(S.session.session_id)")
+    active_stream_pos = load_body.index("let activeStreamId=S.session.active_stream_id")
+    assert assign_pos < active_stream_pos < stream_pos < sync_pos
+
+
 def test_drain_for_session_starts_one_backend_owned_turn(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
     monkeypatch.setattr(config, "ACTIVE_RUNS", {})

--- a/tests/test_session_queue.py
+++ b/tests/test_session_queue.py
@@ -1,0 +1,106 @@
+import sys
+import time
+import types
+
+from api import config
+from api import session_queue
+
+
+def _wait_until(predicate, timeout=2.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return bool(predicate())
+
+
+def _install_fake_routes(monkeypatch, start_session_turn):
+    fake_routes = types.SimpleNamespace(start_session_turn=start_session_turn)
+    monkeypatch.setitem(sys.modules, "api.routes", fake_routes)
+
+
+def _is_empty_queue_dir(path):
+    qdir = path / "_session_queue"
+    return not qdir.exists() or not any(qdir.iterdir())
+
+
+def test_enqueue_persists_and_lists_session_queue(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+
+    item = session_queue.enqueue(
+        "sid-1",
+        {"text": "next please", "model": "m1", "model_provider": "p1", "profile": "default"},
+    )
+
+    assert item["id"]
+    assert item["text"] == "next please"
+    assert session_queue.list_queue("sid-1") == [item]
+
+
+def test_drain_for_session_starts_one_backend_owned_turn(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+
+    item = session_queue.enqueue(
+        "sid-drain",
+        {"text": "queued followup", "model": "m-drain", "model_provider": "p-drain"},
+    )
+    calls = []
+
+    def fake_start_session_turn(session_id, message, **kwargs):
+        calls.append((session_id, message, kwargs))
+        return {"stream_id": "stream-1", "_status": 200}
+
+    _install_fake_routes(monkeypatch, fake_start_session_turn)
+
+    assert session_queue.drain_for_session("sid-drain") == 1
+    assert _wait_until(lambda: calls)
+    assert calls == [
+        (
+            "sid-drain",
+            "queued followup",
+            {
+                "source": "queued_followup",
+                "attachments": [],
+                "requested_model": "m-drain",
+                "requested_provider": "p-drain",
+                "queue_item_id": item["id"],
+            },
+        )
+    ]
+    assert session_queue.list_queue("sid-drain") == []
+    assert _is_empty_queue_dir(tmp_path)
+
+
+def test_drain_requeues_item_when_start_races_active_turn(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+
+    item = session_queue.enqueue("sid-race", {"text": "still needed"})
+
+    def fake_start_session_turn(session_id, message, **kwargs):
+        return {"error": "session already has an active stream", "_status": 409}
+
+    _install_fake_routes(monkeypatch, fake_start_session_turn)
+
+    assert session_queue.drain_for_session("sid-race") == 1
+    assert _wait_until(lambda: session_queue.list_queue("sid-race"))
+    queued = session_queue.list_queue("sid-race")
+    assert len(queued) == 1
+    assert queued[0]["id"] == item["id"]
+    assert queued[0]["text"] == "still needed"
+
+
+def test_drain_does_not_claim_while_session_has_active_run(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(
+        config,
+        "ACTIVE_RUNS",
+        {"stream-active": {"session_id": "sid-active"}},
+    )
+
+    item = session_queue.enqueue("sid-active", {"text": "later"})
+
+    assert session_queue.drain_for_session("sid-active") == 0
+    assert session_queue.list_queue("sid-active")[0]["id"] == item["id"]

--- a/tests/test_session_queue.py
+++ b/tests/test_session_queue.py
@@ -107,6 +107,32 @@ def test_enqueue_persists_and_lists_session_queue(monkeypatch, tmp_path):
     assert session_queue.list_queue("sid-1") == [item]
 
 
+def test_enqueue_requires_text_even_with_attachments(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+
+    try:
+        session_queue.enqueue("sid-empty", {"attachments": [{"name": "file.txt"}]})
+    except ValueError as exc:
+        assert str(exc) == "text is required"
+    else:  # pragma: no cover - defensive clarity for the regression
+        raise AssertionError("attachments-only backend queue item should be rejected")
+
+
+def test_enqueue_coerces_provider_and_caps_queue(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(session_queue, "_MAX_QUEUE_ITEMS", 3)
+
+    for idx in range(5):
+        session_queue.enqueue(
+            "sid-cap",
+            {"text": f"item {idx}", "model_provider": {"provider": idx}},
+        )
+
+    queued = session_queue.list_queue("sid-cap")
+    assert [item["text"] for item in queued] == ["item 2", "item 3", "item 4"]
+    assert queued[-1]["model_provider"] == "{'provider': 4}"
+
+
 def test_enqueue_handler_attempts_idle_drain(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
     monkeypatch.setattr(routes, "get_session", lambda sid: {"id": sid})
@@ -155,6 +181,50 @@ if(q[1]._server_pending || q[1]._server_owned || q[1]._server_queue_id){
 const shifted = shiftQueuedSessionMessage(sid);
 if(!shifted || shifted.text !== 'orphan after tab close'){
   throw new Error('reset orphan should be browser-drainable: '+JSON.stringify(shifted));
+}
+"""
+    )
+
+
+def test_frontend_sync_hydrates_persisted_queue_before_reconcile():
+    _run_queue_sync_node_script(
+        r"""
+const sid = 'sid-hydrate';
+sessionStorage.setItem('hermes-queue-'+sid, JSON.stringify([
+  {text: ' persisted pending ', _server_pending: true, _client_queue_id: 'persisted-1'},
+]));
+fetch = async () => ({ok: true, json: async () => ({items: [
+  {id: 'srv-hydrated', text: 'persisted pending', attachments: [], created_at: 1700000000},
+]})});
+syncBackendSessionQueue(sid);
+await new Promise(resolve => setTimeout(resolve, 0));
+const q = SESSION_QUEUES[sid];
+if(!q || q.length !== 1 || q[0]._server_queue_id !== 'srv-hydrated' || q[0]._server_pending){
+  throw new Error('persisted pending entry was not hydrated and reconciled: '+JSON.stringify(q));
+}
+"""
+    )
+
+
+def test_frontend_ack_deletes_backend_item_when_local_chip_was_removed():
+    _run_queue_sync_node_script(
+        r"""
+const sid = 'sid-ghost';
+const entry = {text: 'ghost followup', _client_queue_id: 'local-ghost'};
+const calls = [];
+fetch = async (url, opts) => {
+  calls.push({url: String(url), body: opts && opts.body ? JSON.parse(opts.body) : null});
+  if(String(url).includes('/delete')) return {ok: true, json: async () => ({ok: true})};
+  return {ok: true, json: async () => ({item: {id: 'srv-ghost'}})};
+};
+_backendAcknowledgeQueuedMessage(sid, entry);
+await new Promise(resolve => setTimeout(resolve, 0));
+await new Promise(resolve => setTimeout(resolve, 0));
+if(calls.length !== 2 || !String(calls[1].url).includes('api/session/queue/delete')){
+  throw new Error('expected cleanup delete after missing local chip: '+JSON.stringify(calls));
+}
+if(calls[1].body.id !== 'srv-ghost' || calls[1].body.session_id !== sid){
+  throw new Error('delete payload mismatch: '+JSON.stringify(calls[1]));
 }
 """
     )
@@ -212,6 +282,32 @@ def test_drain_requeues_item_when_start_races_active_turn(monkeypatch, tmp_path)
     assert len(queued) == 1
     assert queued[0]["id"] == item["id"]
     assert queued[0]["text"] == "still needed"
+
+
+def test_permanent_start_errors_stop_churning_after_retry_limit(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+    monkeypatch.setattr(session_queue, "_MAX_START_RETRIES", 2)
+
+    item = session_queue.enqueue("sid-bad", {"text": "bad model"})
+    calls = []
+
+    def fake_start_session_turn(session_id, message, **kwargs):
+        calls.append((session_id, message, kwargs))
+        return {"error": "invalid model", "_status": 400}
+
+    _install_fake_routes(monkeypatch, fake_start_session_turn)
+
+    assert session_queue.drain_for_session("sid-bad") == 1
+    assert _wait_until(lambda: session_queue.list_queue("sid-bad") and len(calls) == 1)
+    assert session_queue.drain_for_session("sid-bad") == 1
+    assert _wait_until(lambda: session_queue.list_queue("sid-bad")[0].get("blocked") is True)
+    queued = session_queue.list_queue("sid-bad")
+    assert queued[0]["id"] == item["id"]
+    assert queued[0]["blocked"] is True
+    assert queued[0]["error"] == "invalid model"
+    assert session_queue.drain_for_session("sid-bad") == 0
+    assert len(calls) == 2
 
 
 def test_drain_does_not_claim_while_session_has_active_run(monkeypatch, tmp_path):

--- a/tests/test_session_queue.py
+++ b/tests/test_session_queue.py
@@ -1,8 +1,13 @@
+import io
+import json
+import pathlib
+import subprocess
 import sys
 import time
 import types
 
 from api import config
+from api import routes
 from api import session_queue
 
 
@@ -25,6 +30,70 @@ def _is_empty_queue_dir(path):
     return not qdir.exists() or not any(qdir.iterdir())
 
 
+class _FakeHandler:
+    def __init__(self):
+        self.status = None
+        self.headers = {}
+        self.wfile = io.BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def json_body(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+def _run_queue_sync_node_script(script_body):
+    ui_src = (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text(
+        encoding="utf-8"
+    )
+    start = ui_src.index("function _getSessionQueue")
+    end = ui_src.index("function _compressionSessionLock", start)
+    queue_src = ui_src[start:end]
+    script = f"""
+const vm = require('vm');
+const storage = {{}};
+const store = {{
+  getItem: (key) => Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null,
+  setItem: (key, value) => {{ storage[key] = String(value); }},
+  removeItem: (key) => {{ delete storage[key]; }},
+}};
+const ctx = {{
+  SESSION_QUEUES: {{}},
+  S: {{activeProfile: 'default'}},
+  _queueRenderKeys: {{}},
+  sessionStorage: store,
+  localStorage: store,
+  document: {{baseURI: 'http://example.test/session/sid/'}},
+  location: {{href: 'http://example.test/session/sid/', pathname: '/session/sid/', search: ''}},
+  fetch: null,
+  updateQueueBadge: () => {{}},
+  File: function File(){{}},
+  URL,
+  setTimeout,
+  clearTimeout,
+}};
+ctx.window = ctx;
+vm.createContext(ctx);
+vm.runInContext({json.dumps(queue_src)}, ctx, {{filename: 'ui-queue.js'}});
+(async () => {{
+  await vm.runInContext(`(async () => {{
+{script_body}
+  }})()`, ctx, {{filename: 'ui-queue-test.js'}});
+}})().catch(err => {{
+  console.error(err && err.stack || err);
+  process.exit(1);
+}});
+"""
+    subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+
 def test_enqueue_persists_and_lists_session_queue(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
 
@@ -36,6 +105,59 @@ def test_enqueue_persists_and_lists_session_queue(monkeypatch, tmp_path):
     assert item["id"]
     assert item["text"] == "next please"
     assert session_queue.list_queue("sid-1") == [item]
+
+
+def test_enqueue_handler_attempts_idle_drain(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(routes, "get_session", lambda sid: {"id": sid})
+    drained = []
+
+    def fake_drain_for_session(sid):
+        drained.append(sid)
+        return 1
+
+    monkeypatch.setattr(session_queue, "drain_for_session", fake_drain_for_session)
+
+    handler = _FakeHandler()
+    routes._handle_session_queue_enqueue(
+        handler,
+        {"session_id": "sid-idle", "text": "queued while idle", "profile": "default"},
+    )
+
+    assert handler.status == 200
+    assert drained == ["sid-idle"]
+    body = handler.json_body()
+    assert body["ok"] is True
+    assert body["item"]["text"] == "queued while idle"
+
+
+def test_frontend_sync_recovers_stale_pending_and_matches_trimmed_text():
+    _run_queue_sync_node_script(
+        r"""
+const sid = 'sid-sync';
+SESSION_QUEUES[sid] = [
+  {text: '  hello from pending  ', _server_pending: true, _client_queue_id: 'local-1'},
+  {text: 'orphan after tab close', _server_pending: true, _client_queue_id: 'local-2'},
+];
+fetch = async () => ({ok: true, json: async () => ({items: [
+  {id: 'srv-1', text: 'hello from pending', attachments: [], model: 'm1', model_provider: 'p1', profile: 'default', created_at: 1700000000},
+]})});
+syncBackendSessionQueue(sid);
+await new Promise(resolve => setTimeout(resolve, 0));
+const q = SESSION_QUEUES[sid];
+if(q.length !== 2) throw new Error('expected no duplicate server chip, got '+q.length);
+if(q[0]._server_queue_id !== 'srv-1' || !q[0]._server_owned || q[0]._server_pending){
+  throw new Error('trimmed pending entry was not promoted: '+JSON.stringify(q[0]));
+}
+if(q[1]._server_pending || q[1]._server_owned || q[1]._server_queue_id){
+  throw new Error('orphan pending entry was not reset: '+JSON.stringify(q[1]));
+}
+const shifted = shiftQueuedSessionMessage(sid);
+if(!shifted || shifted.text !== 'orphan after tab close'){
+  throw new Error('reset orphan should be browser-drainable: '+JSON.stringify(shifted));
+}
+"""
+    )
 
 
 def test_drain_for_session_starts_one_backend_owned_turn(monkeypatch, tmp_path):

--- a/tests/test_session_queue.py
+++ b/tests/test_session_queue.py
@@ -238,7 +238,64 @@ def test_enqueue_handler_attempts_idle_drain(monkeypatch, tmp_path):
     assert body["item"]["text"] == "queued while idle"
 
 
-def test_frontend_sync_preserves_uncertain_ack_and_matches_legacy_server_item():
+@pytest.mark.parametrize("operation", ["update", "delete", "reorder", "combine"])
+def test_successful_queue_mutation_restarts_exposed_idle_head(monkeypatch, tmp_path, operation):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(routes, "get_session", lambda sid: {"id": sid})
+    sid = f"sid-mutation-{operation}"
+    first = session_queue.enqueue(sid, {"text": "blocked", "client_queue_id": "client-blocked"})
+    second = session_queue.enqueue(sid, {"text": "next", "client_queue_id": "client-next"})
+    with session_queue._LOCK:
+        items = session_queue._read_items_unlocked(sid)
+        items[0]["state"] = "blocked"
+        items[0]["blocked"] = True
+        items[0]["error"] = "start failed"
+        session_queue._write_items_unlocked(sid, items)
+
+    drained = []
+    monkeypatch.setattr(session_queue, "drain_for_session", lambda value: drained.append(value) or 1)
+    handler = _FakeHandler()
+    if operation == "update":
+        routes._handle_session_queue_update(handler, {"session_id": sid, "id": first["id"], "text": "fixed"})
+    elif operation == "delete":
+        routes._handle_session_queue_delete(handler, {"session_id": sid, "id": first["id"]})
+    elif operation == "reorder":
+        routes._handle_session_queue_reorder(
+            handler, {"session_id": sid, "ordered_ids": [second["id"], first["id"]]}
+        )
+    else:
+        routes._handle_session_queue_combine(
+            handler, {"session_id": sid, "ordered_ids": [second["id"], first["id"]]}
+        )
+
+    assert handler.status == 200
+    assert drained == [sid]
+    assert session_queue.list_queue(sid)[0]["state"] == "queued"
+
+
+def test_mutation_drain_respects_active_session_guard(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(routes, "get_session", lambda sid: {"id": sid})
+    sid = "sid-mutation-active"
+    item = session_queue.enqueue(sid, {"text": "blocked", "client_queue_id": "client-active"})
+    with session_queue._LOCK:
+        items = session_queue._read_items_unlocked(sid)
+        items[0]["state"] = "blocked"
+        items[0]["blocked"] = True
+        session_queue._write_items_unlocked(sid, items)
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {"stream-active": {"session_id": sid}})
+
+    handler = _FakeHandler()
+    routes._handle_session_queue_update(
+        handler, {"session_id": sid, "id": item["id"], "text": "fixed while busy"}
+    )
+
+    assert handler.status == 200
+    queued = session_queue.list_queue(sid)
+    assert [(entry["id"], entry["state"]) for entry in queued] == [(item["id"], "queued")]
+
+
+def test_frontend_sync_retries_unmatched_ack_and_matches_legacy_server_item():
     _run_queue_sync_node_script(
         r"""
 const sid = 'sid-sync';
@@ -246,23 +303,27 @@ SESSION_QUEUES[sid] = [
   {text: '  hello from pending  ', _server_pending: true, _client_queue_id: 'local-1'},
   {text: 'orphan after tab close', _server_pending: true, _client_queue_id: 'local-2'},
 ];
-fetch = async () => ({ok: true, json: async () => ({items: [
-  {id: 'srv-1', text: 'hello from pending', attachments: [], model: 'm1', model_provider: 'p1', profile: 'default', created_at: 1700000000},
-]})});
-syncBackendSessionQueue(sid);
-await new Promise(resolve => setTimeout(resolve, 0));
+let reposts=0;
+fetch = async (_url, opts) => {
+  if(opts&&opts.method==='POST'){
+    reposts++;
+    const body=JSON.parse(opts.body);
+    return {ok:true,json:async()=>({item:{id:'srv-2',client_queue_id:body.client_queue_id,state:'queued'}})};
+  }
+  return {ok: true, json: async () => ({items: [
+    {id: 'srv-1', text: 'hello from pending', attachments: [], model: 'm1', model_provider: 'p1', profile: 'default', created_at: 1700000000},
+  ]})};
+};
+await syncBackendSessionQueue(sid);
 const q = SESSION_QUEUES[sid];
 if(q.length !== 2) throw new Error('expected no duplicate server chip, got '+q.length);
 if(q[0]._server_queue_id !== 'srv-1' || !q[0]._server_owned || q[0]._server_pending){
   throw new Error('trimmed pending entry was not promoted: '+JSON.stringify(q[0]));
 }
-if(!q[1]._server_pending || q[1]._server_owned || q[1]._server_queue_id){
-  throw new Error('uncertain acknowledgement was not preserved: '+JSON.stringify(q[1]));
+if(q[1]._server_queue_id !== 'srv-2' || !q[1]._server_owned || q[1]._server_pending){
+  throw new Error('unmatched acknowledgement was not recovered: '+JSON.stringify(q[1]));
 }
-const shifted = shiftQueuedSessionMessage(sid);
-if(shifted){
-  throw new Error('uncertain acknowledgement must not become browser-drainable: '+JSON.stringify(shifted));
-}
+if(reposts!==1)throw new Error('expected one idempotent recovery POST, got '+reposts);
 """
     )
 
@@ -347,6 +408,45 @@ const q=_getSessionQueue(sid,false);
 if(q.length!==1||q[0]._server_queue_id!=='server-race'){
   throw new Error('stale GET erased newer authority: '+JSON.stringify(q));
 }
+"""
+    )
+
+
+def test_frontend_reload_reposts_complete_intent_once_and_converges_to_server_owner():
+    _run_queue_sync_node_script(
+        r"""
+const sid='sid-reload-repost';
+sessionStorage.setItem('hermes-queue-'+sid,JSON.stringify([{
+  text:' recover me ',attachments:[{name:'note.txt',path:'/tmp/note.txt'}],
+  model:'model-a',model_provider:'provider-a',profile:'profile-a',
+  _server_pending:true,_client_queue_id:'client-reload'
+}]));
+let gets=0;
+let posts=0;
+let postedBody=null;
+fetch=async(url,opts)=>{
+  if(opts&&opts.method==='POST'){
+    posts++;
+    postedBody=JSON.parse(opts.body);
+    return {ok:true,json:async()=>({item:{
+      id:'server-reload',client_queue_id:'client-reload',state:'queued'
+    }})};
+  }
+  gets++;
+  return {ok:true,json:async()=>({items:[]})};
+};
+await Promise.all([syncBackendSessionQueue(sid),syncBackendSessionQueue(sid)]);
+const q=_getSessionQueue(sid,false);
+if(gets!==2||posts!==1)throw new Error('recovery was not single-flight: '+JSON.stringify({gets,posts}));
+if(!postedBody||postedBody.client_queue_id!=='client-reload'||postedBody.text!=='recover me'||
+   postedBody.model!=='model-a'||postedBody.model_provider!=='provider-a'||
+   postedBody.profile!=='profile-a'||postedBody.attachments[0].path!=='/tmp/note.txt'){
+  throw new Error('recovery POST lost canonical intent: '+JSON.stringify(postedBody));
+}
+if(q.length!==1||q[0]._server_queue_id!=='server-reload'||!q[0]._server_owned||q[0]._server_pending){
+  throw new Error('recovery did not converge to server owner: '+JSON.stringify(q));
+}
+if(shiftQueuedSessionMessage(sid)!==null)throw new Error('recovered owner became browser-drainable');
 """
     )
 

--- a/tests/test_session_queue.py
+++ b/tests/test_session_queue.py
@@ -351,6 +351,27 @@ if(q.length!==1||q[0]._server_queue_id!=='server-race'){
     )
 
 
+def test_frontend_queue_mutations_resolve_stable_item_identity():
+    _run_queue_sync_node_script(
+        r"""
+const first={text:'same',_queued_at:1700000000000,_server_queue_id:'server-first',_client_queue_id:'client-first'};
+const second={text:'same',_queued_at:1700000000000,_server_queue_id:'server-second',_client_queue_id:'client-second'};
+const q=[first,second];
+const rerenderedSecond={...second};
+if(_findQueuedEntryIndex(q,rerenderedSecond)!==1){
+  throw new Error('server identity did not select the second duplicate');
+}
+const optimistic=[
+  {text:'same',_queued_at:1700000000000,_client_queue_id:'client-first'},
+  {text:'same',_queued_at:1700000000000,_client_queue_id:'client-second'},
+];
+if(_findQueuedEntryIndex(optimistic,{...optimistic[1]})!==1){
+  throw new Error('client identity did not select the second duplicate');
+}
+"""
+    )
+
+
 def test_frontend_ack_deletes_backend_item_when_local_chip_was_removed():
     _run_queue_sync_node_script(
         r"""
@@ -412,20 +433,20 @@ def test_drain_for_session_starts_one_backend_owned_turn(monkeypatch, tmp_path):
 
     assert session_queue.drain_for_session("sid-drain") == 1
     assert _wait_until(lambda: calls)
-    assert calls == [
-        (
-            "sid-drain",
-            "queued followup",
-            {
-                "source": "queued_followup",
-                "attachments": [],
-                "requested_model": "m-drain",
-                "requested_provider": "p-drain",
-                "queue_item_id": item["id"],
-                "queue_client_id": "client-drain",
-            },
-        )
-    ]
+    assert len(calls) == 1
+    call_session_id, call_message, call_kwargs = calls[0]
+    assert call_session_id == "sid-drain"
+    assert call_message == "queued followup"
+    assert call_kwargs == {
+        "source": "queued_followup",
+        "attachments": [],
+        "requested_model": "m-drain",
+        "requested_provider": "p-drain",
+        "queue_item_id": item["id"],
+        "queue_client_id": "client-drain",
+        "queue_attempt_id": call_kwargs["queue_attempt_id"],
+    }
+    assert call_kwargs["queue_attempt_id"]
     queued = session_queue.list_queue("sid-drain")
     assert len(queued) == 1
     assert queued[0]["id"] == item["id"]
@@ -444,11 +465,265 @@ def test_turn_that_finishes_before_started_transition_does_not_leave_tombstone(m
     )
 
     def fake_start_session_turn(session_id, message, **kwargs):
+        assert session_queue.mark_dispatched(
+            session_id, kwargs["queue_item_id"], "stream-fast"
+        ) is True
+        assert session_queue.complete_started(session_id, "stream-fast") is True
         return {"stream_id": "stream-fast", "session_id": session_id, "_status": 200}
 
     _install_fake_routes(monkeypatch, fake_start_session_turn)
     assert session_queue.drain_for_session("sid-fast") == 1
     assert _wait_until(lambda: not session_queue.list_queue("sid-fast"))
+
+
+def test_remote_start_without_process_local_registry_remains_started_until_terminal(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+    item = session_queue.enqueue(
+        "sid-remote", {"text": "remote run", "client_queue_id": "client-remote"}
+    )
+
+    def fake_start_session_turn(session_id, message, **kwargs):
+        assert session_queue.mark_dispatched(
+            session_id, kwargs["queue_item_id"], "remote-run-1"
+        ) is True
+        assert session_queue.mark_external_run(
+            session_id,
+            kwargs["queue_item_id"],
+            "remote-run-1",
+            "gateway-run-1",
+        ) is True
+        return {"stream_id": "remote-run-1", "session_id": session_id, "_status": 200}
+
+    _install_fake_routes(monkeypatch, fake_start_session_turn)
+    assert session_queue.drain_for_session("sid-remote") == 1
+    assert _wait_until(
+        lambda: session_queue.list_queue("sid-remote")
+        and session_queue.list_queue("sid-remote")[0].get("state") == "started"
+    )
+    queued = session_queue.list_queue("sid-remote")
+    assert [(entry["id"], entry["stream_id"]) for entry in queued] == [
+        (item["id"], "remote-run-1")
+    ]
+
+
+def test_recovery_does_not_infer_started_remote_completion_from_local_absence(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    item = session_queue.enqueue(
+        "sid-remote-recover",
+        {"text": "remote pending", "client_queue_id": "client-remote-recover"},
+    )
+    session_queue.claim_next("sid-remote-recover")
+    assert session_queue.mark_dispatched(
+        "sid-remote-recover", item["id"], "remote-run-recover"
+    ) is True
+    assert session_queue.mark_external_run(
+        "sid-remote-recover",
+        item["id"],
+        "remote-run-recover",
+        "gateway-run-recover",
+    ) is True
+    session_queue._finish_attempt(
+        "sid-remote-recover", item["id"], {"stream_id": "remote-run-recover"}
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda _sid: types.SimpleNamespace(
+            active_stream_id="remote-run-recover",
+            pending_queue_item_id=item["id"],
+        ),
+    )
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+    monkeypatch.setattr(routes, "STREAMS", {})
+
+    result = session_queue.recover_all_queues(schedule=False)
+
+    assert result["retired"] == 0
+    queued = session_queue.list_queue("sid-remote-recover")
+    assert [(entry["id"], entry["state"]) for entry in queued] == [
+        (item["id"], "started")
+    ]
+
+
+def test_recovery_preserves_dispatched_remote_owner_before_start_response(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    item = session_queue.enqueue(
+        "sid-remote-dispatched",
+        {"text": "remote dispatched", "client_queue_id": "client-remote-dispatched"},
+    )
+    session_queue.claim_next("sid-remote-dispatched")
+    assert session_queue.mark_dispatched(
+        "sid-remote-dispatched", item["id"], "remote-run-dispatched"
+    ) is True
+    assert session_queue.mark_external_run(
+        "sid-remote-dispatched",
+        item["id"],
+        "remote-run-dispatched",
+        "gateway-run-dispatched",
+    ) is True
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda _sid: types.SimpleNamespace(
+            active_stream_id="remote-run-dispatched",
+            pending_queue_item_id=item["id"],
+        ),
+    )
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+    monkeypatch.setattr(routes, "STREAMS", {})
+
+    result = session_queue.recover_all_queues(schedule=False)
+
+    assert result["started"] == 1
+    queued = session_queue.list_queue("sid-remote-dispatched")
+    assert [(entry["id"], entry["state"]) for entry in queued] == [
+        (item["id"], "started")
+    ]
+
+
+def test_recovery_preserves_unknown_remote_admission_without_duplicate(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    item = session_queue.enqueue(
+        "sid-remote-admission",
+        {"text": "remote admission", "client_queue_id": "client-remote-admission"},
+    )
+    claimed = session_queue.claim_next("sid-remote-admission")
+    assert claimed is not None
+    assert session_queue.mark_dispatched(
+        "sid-remote-admission",
+        item["id"],
+        "remote-admission-stream",
+        attempt_id=claimed["attempt_id"],
+    ) is True
+    session_queue._finish_attempt(
+        "sid-remote-admission",
+        item["id"],
+        {"stream_id": "remote-admission-stream"},
+        attempt_id=claimed["attempt_id"],
+    )
+    assert session_queue.mark_external_admission(
+        "sid-remote-admission",
+        item["id"],
+        "remote-admission-stream",
+        "admission-1",
+        attempt_id=claimed["attempt_id"],
+    ) is True
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda _sid: types.SimpleNamespace(
+            active_stream_id=None,
+            pending_queue_item_id=None,
+        ),
+    )
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+
+    result = session_queue.recover_all_queues(schedule=False)
+
+    assert result["started"] == 1
+    assert session_queue.list_queue("sid-remote-admission")[0]["state"] == "started"
+
+
+@pytest.mark.parametrize(
+    ("remote_status", "expected_started", "expected_retired"),
+    [("running", 1, 0), (None, 1, 0), ("completed", 0, 1)],
+)
+def test_recovery_reconciles_exact_remote_run_status_without_session_correlation(
+    monkeypatch,
+    tmp_path,
+    remote_status,
+    expected_started,
+    expected_retired,
+):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    item = session_queue.enqueue(
+        "sid-remote-status",
+        {"text": "remote status", "client_queue_id": "client-remote-status"},
+    )
+    claimed = session_queue.claim_next("sid-remote-status")
+    assert claimed is not None
+    assert session_queue.mark_dispatched(
+        "sid-remote-status",
+        item["id"],
+        "remote-status-stream",
+        attempt_id=claimed["attempt_id"],
+    ) is True
+    session_queue._finish_attempt(
+        "sid-remote-status",
+        item["id"],
+        {"stream_id": "remote-status-stream"},
+        attempt_id=claimed["attempt_id"],
+    )
+    assert session_queue.mark_external_admission(
+        "sid-remote-status",
+        item["id"],
+        "remote-status-stream",
+        "admission-status",
+        attempt_id=claimed["attempt_id"],
+    ) is True
+    assert session_queue.mark_external_run(
+        "sid-remote-status",
+        item["id"],
+        "remote-status-stream",
+        "gateway-run-status",
+        admission_id="admission-status",
+        attempt_id=claimed["attempt_id"],
+    ) is True
+    monkeypatch.setattr(session_queue, "_external_run_status", lambda _run_id: remote_status)
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda _sid: types.SimpleNamespace(
+            active_stream_id=None,
+            pending_queue_item_id=None,
+        ),
+    )
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+
+    result = session_queue.recover_all_queues(schedule=False)
+
+    assert result["started"] == expected_started
+    assert result["retired"] == expected_retired
+    if expected_retired:
+        assert session_queue.list_queue("sid-remote-status") == []
+        replay = session_queue.enqueue(
+            "sid-remote-status",
+            {"text": "remote status", "client_queue_id": "client-remote-status"},
+        )
+        assert replay["state"] == "completed"
+    else:
+        assert session_queue.list_queue("sid-remote-status")[0]["state"] == "started"
+
+
+def test_recovery_retires_started_local_owner_without_live_runtime(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    item = session_queue.enqueue(
+        "sid-local-recover",
+        {"text": "local interrupted", "client_queue_id": "client-local-recover"},
+    )
+    session_queue.claim_next("sid-local-recover")
+    assert session_queue.mark_dispatched(
+        "sid-local-recover", item["id"], "local-run-recover"
+    ) is True
+    session_queue._finish_attempt(
+        "sid-local-recover", item["id"], {"stream_id": "local-run-recover"}
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda _sid: types.SimpleNamespace(
+            active_stream_id="local-run-recover",
+            pending_queue_item_id=item["id"],
+        ),
+    )
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+    monkeypatch.setattr(routes, "STREAMS", {})
+
+    result = session_queue.recover_all_queues(schedule=False)
+
+    assert result["retired"] == 1
+    assert session_queue.list_queue("sid-local-recover") == []
 
 
 def test_thread_start_failure_restores_starting_item(monkeypatch, tmp_path):
@@ -676,6 +951,36 @@ def test_raised_start_error_retries_automatically_then_blocks(monkeypatch, tmp_p
     )
     assert len(calls) == 2
     assert session_queue.list_queue("sid-raised")[0]["retry_count"] == 2
+
+
+def test_stale_attempt_settlement_cannot_requeue_a_successor_dispatch(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    item = session_queue.enqueue(
+        "sid-attempt-fence",
+        {"text": "once", "client_queue_id": "client-attempt-fence"},
+    )
+
+    first = session_queue.claim_next("sid-attempt-fence")
+    assert first is not None
+    first_attempt_id = first["attempt_id"]
+    session_queue.requeue_front("sid-attempt-fence", first)
+
+    successor = session_queue.claim_next("sid-attempt-fence")
+    assert successor is not None
+    assert successor["attempt_id"] != first_attempt_id
+
+    session_queue._finish_attempt(
+        "sid-attempt-fence",
+        item["id"],
+        {"_status": 500, "error": "stale failure"},
+        attempt_id=first_attempt_id,
+    )
+
+    with session_queue._LOCK:
+        current = session_queue._read_items_unlocked("sid-attempt-fence")[0]
+    assert current["state"] == "starting"
+    assert current["attempt_id"] == successor["attempt_id"]
+    assert current.get("last_error") != "stale failure"
 
 
 def test_drain_does_not_claim_while_session_has_active_run(monkeypatch, tmp_path):

--- a/tests/test_session_queue.py
+++ b/tests/test_session_queue.py
@@ -3,8 +3,11 @@ import json
 import pathlib
 import subprocess
 import sys
+import threading
 import time
 import types
+
+import pytest
 
 from api import config
 from api import routes
@@ -27,7 +30,7 @@ def _install_fake_routes(monkeypatch, start_session_turn):
 
 def _is_empty_queue_dir(path):
     qdir = path / "_session_queue"
-    return not qdir.exists() or not any(qdir.iterdir())
+    return not qdir.exists() or not any(qdir.glob("*.json"))
 
 
 class _FakeHandler:
@@ -99,12 +102,61 @@ def test_enqueue_persists_and_lists_session_queue(monkeypatch, tmp_path):
 
     item = session_queue.enqueue(
         "sid-1",
-        {"text": "next please", "model": "m1", "model_provider": "p1", "profile": "default"},
+        {
+            "text": "next please",
+            "model": "m1",
+            "model_provider": "p1",
+            "profile": "default",
+            "client_queue_id": "client-next",
+        },
     )
 
     assert item["id"]
     assert item["text"] == "next please"
+    assert item["client_queue_id"] == "client-next"
+    assert item["state"] == "queued"
     assert session_queue.list_queue("sid-1") == [item]
+
+
+def test_enqueue_is_idempotent_by_client_queue_id(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    payload = {"text": "only once", "client_queue_id": "stable-client-id"}
+
+    first = session_queue.enqueue("sid-idempotent", payload)
+    second = session_queue.enqueue("sid-idempotent", payload)
+
+    assert second == first
+    assert session_queue.list_queue("sid-idempotent") == [first]
+
+
+def test_completed_item_keeps_bounded_durable_idempotency_receipt(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    payload = {"text": "run exactly once", "client_queue_id": "client-completed"}
+    first = session_queue.enqueue("sid-receipt", payload)
+    session_queue.claim_next("sid-receipt")
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {"stream-receipt": {"session_id": "sid-receipt"}})
+    session_queue._finish_attempt("sid-receipt", first["id"], {"stream_id": "stream-receipt"})
+    assert session_queue.complete_started("sid-receipt", "stream-receipt") is True
+
+    replay = session_queue.enqueue("sid-receipt", payload)
+
+    assert replay["id"] == first["id"]
+    assert replay["state"] == "completed"
+    assert session_queue.list_queue("sid-receipt") == []
+
+
+def test_queue_rejects_unsafe_or_mismatched_session_identity(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    with pytest.raises(ValueError, match="session_id"):
+        session_queue.enqueue("a/b", {"text": "one", "client_queue_id": "client-one"})
+
+    session_queue.enqueue("safe-one", {"text": "owned", "client_queue_id": "client-owned"})
+    path = session_queue._queue_path("safe-one")
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw[0]["session_id"] = "safe-two"
+    path.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(Exception, match="owner|session"):
+        session_queue.list_queue("safe-one")
 
 
 def test_enqueue_requires_text_even_with_attachments(monkeypatch, tmp_path):
@@ -118,19 +170,43 @@ def test_enqueue_requires_text_even_with_attachments(monkeypatch, tmp_path):
         raise AssertionError("attachments-only backend queue item should be rejected")
 
 
-def test_enqueue_coerces_provider_and_caps_queue(monkeypatch, tmp_path):
+def test_enqueue_rejects_capacity_without_evicting_acknowledged_items(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
     monkeypatch.setattr(session_queue, "_MAX_QUEUE_ITEMS", 3)
 
-    for idx in range(5):
+    for idx in range(3):
         session_queue.enqueue(
             "sid-cap",
-            {"text": f"item {idx}", "model_provider": {"provider": idx}},
+            {
+                "text": f"item {idx}",
+                "model_provider": {"provider": idx},
+                "client_queue_id": f"client-{idx}",
+            },
+        )
+
+    with pytest.raises(Exception, match="capacity|full"):
+        session_queue.enqueue(
+            "sid-cap",
+            {"text": "rejected item", "client_queue_id": "client-rejected"},
         )
 
     queued = session_queue.list_queue("sid-cap")
-    assert [item["text"] for item in queued] == ["item 2", "item 3", "item 4"]
-    assert queued[-1]["model_provider"] == "{'provider': 4}"
+    assert [item["text"] for item in queued] == ["item 0", "item 1", "item 2"]
+    assert queued[-1]["model_provider"] == "{'provider': 2}"
+
+
+def test_corrupt_queue_fails_closed_and_is_not_overwritten(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    queue_path = session_queue._queue_path("sid-corrupt")
+    queue_path.write_text('{"owed": "turn"', encoding="utf-8")
+
+    with pytest.raises(Exception, match="corrupt|read"):
+        session_queue.enqueue(
+            "sid-corrupt",
+            {"text": "new item", "client_queue_id": "client-new"},
+        )
+
+    assert queue_path.read_text(encoding="utf-8") == '{"owed": "turn"'
 
 
 def test_enqueue_handler_attempts_idle_drain(monkeypatch, tmp_path):
@@ -147,7 +223,12 @@ def test_enqueue_handler_attempts_idle_drain(monkeypatch, tmp_path):
     handler = _FakeHandler()
     routes._handle_session_queue_enqueue(
         handler,
-        {"session_id": "sid-idle", "text": "queued while idle", "profile": "default"},
+        {
+            "session_id": "sid-idle",
+            "text": "queued while idle",
+            "profile": "default",
+            "client_queue_id": "client-idle",
+        },
     )
 
     assert handler.status == 200
@@ -157,7 +238,7 @@ def test_enqueue_handler_attempts_idle_drain(monkeypatch, tmp_path):
     assert body["item"]["text"] == "queued while idle"
 
 
-def test_frontend_sync_recovers_stale_pending_and_matches_trimmed_text():
+def test_frontend_sync_preserves_uncertain_ack_and_matches_legacy_server_item():
     _run_queue_sync_node_script(
         r"""
 const sid = 'sid-sync';
@@ -175,12 +256,12 @@ if(q.length !== 2) throw new Error('expected no duplicate server chip, got '+q.l
 if(q[0]._server_queue_id !== 'srv-1' || !q[0]._server_owned || q[0]._server_pending){
   throw new Error('trimmed pending entry was not promoted: '+JSON.stringify(q[0]));
 }
-if(q[1]._server_pending || q[1]._server_owned || q[1]._server_queue_id){
-  throw new Error('orphan pending entry was not reset: '+JSON.stringify(q[1]));
+if(!q[1]._server_pending || q[1]._server_owned || q[1]._server_queue_id){
+  throw new Error('uncertain acknowledgement was not preserved: '+JSON.stringify(q[1]));
 }
 const shifted = shiftQueuedSessionMessage(sid);
-if(!shifted || shifted.text !== 'orphan after tab close'){
-  throw new Error('reset orphan should be browser-drainable: '+JSON.stringify(shifted));
+if(shifted){
+  throw new Error('uncertain acknowledgement must not become browser-drainable: '+JSON.stringify(shifted));
 }
 """
     )
@@ -201,6 +282,70 @@ await new Promise(resolve => setTimeout(resolve, 0));
 const q = SESSION_QUEUES[sid];
 if(!q || q.length !== 1 || q[0]._server_queue_id !== 'srv-hydrated' || q[0]._server_pending){
   throw new Error('persisted pending entry was not hydrated and reconciled: '+JSON.stringify(q));
+}
+"""
+    )
+
+
+def test_frontend_sync_is_awaitable_and_reconciles_by_stable_client_id():
+    _run_queue_sync_node_script(
+        r"""
+const sid = 'sid-stable-client';
+SESSION_QUEUES[sid] = [
+  {text: 'local text changed before lost ACK', _server_pending: true, _client_queue_id: 'stable-1'},
+];
+fetch = async () => {
+  await new Promise(resolve => setTimeout(resolve, 10));
+  return {ok: true, json: async () => ({items: [
+    {id: 'srv-stable', client_queue_id: 'stable-1', state: 'queued', text: 'server authoritative text', attachments: [], created_at: 1700000000},
+  ]})};
+};
+await syncBackendSessionQueue(sid);
+const q = SESSION_QUEUES[sid];
+if(q.length !== 1) throw new Error('stable client id created duplicate: '+JSON.stringify(q));
+if(q[0]._server_queue_id !== 'srv-stable' || q[0].text !== 'server authoritative text'){
+  throw new Error('stable client id was not authoritatively reconciled: '+JSON.stringify(q));
+}
+"""
+    )
+
+
+def test_frontend_early_start_event_removes_by_client_id_before_ack_lands():
+    _run_queue_sync_node_script(
+        r"""
+const sid = 'sid-early-start';
+SESSION_QUEUES[sid] = [
+  {text: 'already starting', _server_pending: true, _client_queue_id: 'stable-early'},
+];
+const removed = _removeServerQueuedEntry(sid, 'srv-not-stamped-yet', 'stable-early');
+if(!removed) throw new Error('early start event did not remove pending client owner');
+if(_getSessionQueue(sid, false).length !== 0) throw new Error('early start chip remained');
+"""
+    )
+
+
+def test_frontend_ignores_stale_overlapping_queue_sync_response():
+    _run_queue_sync_node_script(
+        r"""
+const sid='sid-sync-race';
+SESSION_QUEUES[sid]=[{text:'queued',_server_pending:true,_client_queue_id:'client-race'}];
+let resolveFirst;
+const first=new Promise(resolve=>{resolveFirst=resolve;});
+let call=0;
+fetch=async()=>{
+  call++;
+  if(call===1){await first;return {ok:true,json:async()=>({items:[]})};}
+  return {ok:true,json:async()=>({items:[
+    {id:'server-race',client_queue_id:'client-race',state:'queued',text:'queued',attachments:[],created_at:1700000000},
+  ]})};
+};
+const oldSync=syncBackendSessionQueue(sid);
+await syncBackendSessionQueue(sid);
+resolveFirst();
+await oldSync;
+const q=_getSessionQueue(sid,false);
+if(q.length!==1||q[0]._server_queue_id!=='server-race'){
+  throw new Error('stale GET erased newer authority: '+JSON.stringify(q));
 }
 """
     )
@@ -249,12 +394,18 @@ def test_drain_for_session_starts_one_backend_owned_turn(monkeypatch, tmp_path):
 
     item = session_queue.enqueue(
         "sid-drain",
-        {"text": "queued followup", "model": "m-drain", "model_provider": "p-drain"},
+        {
+            "text": "queued followup",
+            "model": "m-drain",
+            "model_provider": "p-drain",
+            "client_queue_id": "client-drain",
+        },
     )
     calls = []
 
     def fake_start_session_turn(session_id, message, **kwargs):
         calls.append((session_id, message, kwargs))
+        config.ACTIVE_RUNS["stream-1"] = {"session_id": session_id}
         return {"stream_id": "stream-1", "_status": 200}
 
     _install_fake_routes(monkeypatch, fake_start_session_turn)
@@ -271,18 +422,190 @@ def test_drain_for_session_starts_one_backend_owned_turn(monkeypatch, tmp_path):
                 "requested_model": "m-drain",
                 "requested_provider": "p-drain",
                 "queue_item_id": item["id"],
+                "queue_client_id": "client-drain",
             },
         )
     ]
+    queued = session_queue.list_queue("sid-drain")
+    assert len(queued) == 1
+    assert queued[0]["id"] == item["id"]
+    assert queued[0]["state"] == "started"
+    assert queued[0]["stream_id"] == "stream-1"
+    assert session_queue.complete_started("sid-drain", "stream-1") is True
     assert session_queue.list_queue("sid-drain") == []
     assert _is_empty_queue_dir(tmp_path)
+
+
+def test_turn_that_finishes_before_started_transition_does_not_leave_tombstone(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+    session_queue.enqueue(
+        "sid-fast", {"text": "fast", "client_queue_id": "client-fast"}
+    )
+
+    def fake_start_session_turn(session_id, message, **kwargs):
+        return {"stream_id": "stream-fast", "session_id": session_id, "_status": 200}
+
+    _install_fake_routes(monkeypatch, fake_start_session_turn)
+    assert session_queue.drain_for_session("sid-fast") == 1
+    assert _wait_until(lambda: not session_queue.list_queue("sid-fast"))
+
+
+def test_thread_start_failure_restores_starting_item(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+    item = session_queue.enqueue(
+        "sid-thread-fail",
+        {"text": "must survive", "client_queue_id": "client-thread-fail"},
+    )
+    monkeypatch.setattr(threading.Thread, "start", lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    assert session_queue.drain_for_session("sid-thread-fail") == 0
+    queued = session_queue.list_queue("sid-thread-fail")
+    assert [(entry["id"], entry["state"]) for entry in queued] == [(item["id"], "queued")]
+
+
+def test_concurrent_drains_serialize_one_fifo_owner(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+    first = session_queue.enqueue(
+        "sid-fifo", {"text": "first", "client_queue_id": "client-first"}
+    )
+    session_queue.enqueue(
+        "sid-fifo", {"text": "second", "client_queue_id": "client-second"}
+    )
+    entered = threading.Event()
+    release = threading.Event()
+    calls = []
+
+    def fake_start_session_turn(session_id, message, **kwargs):
+        calls.append((message, kwargs["queue_item_id"]))
+        entered.set()
+        assert release.wait(2)
+        config.ACTIVE_RUNS["stream-fifo"] = {"session_id": session_id}
+        return {"stream_id": "stream-fifo", "_status": 200}
+
+    _install_fake_routes(monkeypatch, fake_start_session_turn)
+
+    assert session_queue.drain_for_session("sid-fifo") == 1
+    assert entered.wait(1)
+    assert session_queue.drain_for_session("sid-fifo") == 0
+    release.set()
+    assert _wait_until(
+        lambda: session_queue.list_queue("sid-fifo")[0].get("state") == "started"
+    )
+    assert calls == [("first", first["id"])]
+    assert [entry["text"] for entry in session_queue.list_queue("sid-fifo")] == [
+        "first",
+        "second",
+    ]
+
+
+def test_starting_items_reject_edit_delete_and_reorder(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    first = session_queue.enqueue(
+        "sid-authoritative", {"text": "first", "client_queue_id": "client-first"}
+    )
+    second = session_queue.enqueue(
+        "sid-authoritative", {"text": "second", "client_queue_id": "client-second"}
+    )
+    claimed = session_queue.claim_next("sid-authoritative")
+    assert claimed and claimed["id"] == first["id"]
+
+    with pytest.raises(Exception, match="started|starting"):
+        session_queue.update_item("sid-authoritative", first["id"], {"text": "wrong"})
+    with pytest.raises(Exception, match="started|starting"):
+        session_queue.delete_item("sid-authoritative", first["id"])
+    with pytest.raises(Exception, match="started|starting"):
+        session_queue.reorder_items("sid-authoritative", [second["id"], first["id"]])
+
+    assert [item["text"] for item in session_queue.list_queue("sid-authoritative")] == [
+        "first",
+        "second",
+    ]
+
+
+def test_backend_reorder_combine_and_clear_are_atomic(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    first = session_queue.enqueue(
+        "sid-mutate", {"text": "first", "client_queue_id": "client-first"}
+    )
+    second = session_queue.enqueue(
+        "sid-mutate", {"text": "second", "client_queue_id": "client-second"}
+    )
+
+    reordered = session_queue.reorder_items("sid-mutate", [second["id"], first["id"]])
+    assert [item["id"] for item in reordered] == [second["id"], first["id"]]
+    combined = session_queue.combine_items("sid-mutate", [second["id"], first["id"]])
+    assert len(combined) == 1
+    assert combined[0]["id"] == second["id"]
+    assert combined[0]["text"] == "second\n\nfirst"
+    assert session_queue.clear_queue("sid-mutate") == 1
+    assert session_queue.list_queue("sid-mutate") == []
+
+
+def test_startup_recovery_requeues_unsubmitted_starting_item(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    item = session_queue.enqueue(
+        "sid-recover", {"text": "survive restart", "client_queue_id": "client-recover"}
+    )
+    assert session_queue.claim_next("sid-recover")["state"] == "starting"
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda _sid: types.SimpleNamespace(
+            active_stream_id="stale-stream",
+            pending_user_message="survive restart",
+            pending_queue_item_id=item["id"],
+        ),
+    )
+
+    result = session_queue.recover_all_queues(schedule=False)
+
+    assert result["requeued"] == 1
+    queued = session_queue.list_queue("sid-recover")
+    assert queued[0]["id"] == item["id"]
+    assert queued[0]["state"] == "queued"
+
+
+def test_startup_recovery_keeps_correlated_started_owner_and_schedules_fifo(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    item = session_queue.enqueue(
+        "sid-correlated", {"text": "already submitted", "client_queue_id": "client-correlated"}
+    )
+    session_queue.claim_next("sid-correlated")
+    monkeypatch.setattr(
+        config,
+        "ACTIVE_RUNS",
+        {"stream-correlated": {"session_id": "sid-correlated"}},
+    )
+    session_queue._finish_attempt("sid-correlated", item["id"], {"stream_id": "stream-correlated"})
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda _sid: types.SimpleNamespace(
+            active_stream_id="stream-correlated",
+            pending_user_message="already submitted",
+            pending_queue_item_id=item["id"],
+        ),
+    )
+    scheduled = []
+    monkeypatch.setattr(session_queue, "drain_for_session", lambda sid: scheduled.append(sid) or 0)
+
+    result = session_queue.recover_all_queues(schedule=True)
+
+    assert result["started"] == 1
+    assert session_queue.list_queue("sid-correlated")[0]["state"] == "started"
+    assert scheduled == []
 
 
 def test_drain_requeues_item_when_start_races_active_turn(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
     monkeypatch.setattr(config, "ACTIVE_RUNS", {})
 
-    item = session_queue.enqueue("sid-race", {"text": "still needed"})
+    item = session_queue.enqueue(
+        "sid-race", {"text": "still needed", "client_queue_id": "client-race"}
+    )
 
     def fake_start_session_turn(session_id, message, **kwargs):
         return {"error": "session already has an active stream", "_status": 409}
@@ -297,30 +620,62 @@ def test_drain_requeues_item_when_start_races_active_turn(monkeypatch, tmp_path)
     assert queued[0]["text"] == "still needed"
 
 
-def test_permanent_start_errors_stop_churning_after_retry_limit(monkeypatch, tmp_path):
+@pytest.mark.parametrize("status", [400, 500])
+def test_start_errors_stop_churning_after_retry_limit(monkeypatch, tmp_path, status):
     monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
     monkeypatch.setattr(config, "ACTIVE_RUNS", {})
     monkeypatch.setattr(session_queue, "_MAX_START_RETRIES", 2)
 
-    item = session_queue.enqueue("sid-bad", {"text": "bad model"})
+    item = session_queue.enqueue(
+        "sid-bad", {"text": "bad model", "client_queue_id": "client-bad"}
+    )
     calls = []
 
     def fake_start_session_turn(session_id, message, **kwargs):
         calls.append((session_id, message, kwargs))
-        return {"error": "invalid model", "_status": 400}
+        return {"error": "start failed", "_status": status}
 
     _install_fake_routes(monkeypatch, fake_start_session_turn)
 
     assert session_queue.drain_for_session("sid-bad") == 1
-    assert _wait_until(lambda: session_queue.list_queue("sid-bad") and len(calls) == 1)
+    assert _wait_until(
+        lambda: session_queue.list_queue("sid-bad")
+        and session_queue.list_queue("sid-bad")[0].get("state") == "queued"
+        and len(calls) == 1
+        and "sid-bad" not in session_queue._DRAINING_SESSIONS
+    )
     assert session_queue.drain_for_session("sid-bad") == 1
     assert _wait_until(lambda: session_queue.list_queue("sid-bad")[0].get("blocked") is True)
     queued = session_queue.list_queue("sid-bad")
     assert queued[0]["id"] == item["id"]
     assert queued[0]["blocked"] is True
-    assert queued[0]["error"] == "invalid model"
+    assert queued[0]["error"] == "start failed"
     assert session_queue.drain_for_session("sid-bad") == 0
     assert len(calls) == 2
+
+
+def test_raised_start_error_retries_automatically_then_blocks(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+    monkeypatch.setattr(session_queue, "_MAX_START_RETRIES", 2)
+    monkeypatch.setattr(session_queue, "_RETRY_DELAY_SECONDS", 0.01)
+    session_queue.enqueue(
+        "sid-raised", {"text": "keep retrying", "client_queue_id": "client-raised"}
+    )
+    calls = []
+
+    def fake_start_session_turn(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise RuntimeError("worker unavailable")
+
+    _install_fake_routes(monkeypatch, fake_start_session_turn)
+    assert session_queue.drain_for_session("sid-raised") == 1
+    assert _wait_until(
+        lambda: session_queue.list_queue("sid-raised")
+        and session_queue.list_queue("sid-raised")[0].get("state") == "blocked"
+    )
+    assert len(calls) == 2
+    assert session_queue.list_queue("sid-raised")[0]["retry_count"] == 2
 
 
 def test_drain_does_not_claim_while_session_has_active_run(monkeypatch, tmp_path):
@@ -331,7 +686,9 @@ def test_drain_does_not_claim_while_session_has_active_run(monkeypatch, tmp_path
         {"stream-active": {"session_id": "sid-active"}},
     )
 
-    item = session_queue.enqueue("sid-active", {"text": "later"})
+    item = session_queue.enqueue(
+        "sid-active", {"text": "later", "client_queue_id": "client-active"}
+    )
 
     assert session_queue.drain_for_session("sid-active") == 0
     assert session_queue.list_queue("sid-active")[0]["id"] == item["id"]

--- a/tests/test_session_queue.py
+++ b/tests/test_session_queue.py
@@ -1,6 +1,7 @@
 import io
 import json
 import pathlib
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -95,6 +96,194 @@ vm.runInContext({json.dumps(queue_src)}, ctx, {{filename: 'ui-queue.js'}});
 }});
 """
     subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+
+def _queue_owner_state_db(path, *, model_config="{}", source="webui", session_source=None):
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                session_source TEXT,
+                model_config TEXT
+            )"""
+        )
+        conn.execute(
+            "INSERT INTO sessions VALUES (?, ?, ?, ?)",
+            ("tip", source, session_source, model_config),
+        )
+
+
+def test_queue_owner_allows_state_db_only_canonical_tip(monkeypatch, tmp_path):
+    db_path = tmp_path / "state.db"
+    _queue_owner_state_db(db_path)
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: db_path)
+    monkeypatch.setattr(
+        routes,
+        "read_session_lineage_report",
+        lambda _path, _sid: {
+            "found": True,
+            "manual_review": False,
+            "tip_session_id": "tip",
+            "total_segments": 3,
+        },
+    )
+    monkeypatch.setattr(routes, "get_session", lambda _sid: (_ for _ in ()).throw(KeyError()))
+
+    assert routes._resolve_session_queue_owner("tip") == "tip"
+
+
+@pytest.mark.parametrize(
+    ("model_config", "source", "session_source"),
+    [
+        ('{"_delegate_from": "parent"}', "webui", None),
+        ('{"_branched_from": "parent"}', "webui", None),
+        ("{malformed", "webui", None),
+        ("{}", "subagent", None),
+        ("{}", "unknown-plugin", None),
+        ("{}", "webui", "fork"),
+    ],
+)
+def test_queue_owner_rejects_branch_delegate_and_malformed_identity(
+    monkeypatch, tmp_path, model_config, source, session_source
+):
+    db_path = tmp_path / "state.db"
+    _queue_owner_state_db(
+        db_path,
+        model_config=model_config,
+        source=source,
+        session_source=session_source,
+    )
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: db_path)
+    monkeypatch.setattr(
+        routes,
+        "read_session_lineage_report",
+        lambda _path, _sid: {
+            "found": True,
+            "manual_review": False,
+            "tip_session_id": "tip",
+            "total_segments": 3,
+        },
+    )
+
+    with pytest.raises(KeyError):
+        routes._resolve_session_queue_owner("tip")
+
+
+def test_queue_owner_rejects_stale_or_ambiguous_lineage(monkeypatch, tmp_path):
+    db_path = tmp_path / "state.db"
+    _queue_owner_state_db(db_path)
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: db_path)
+    monkeypatch.setattr(
+        routes,
+        "read_session_lineage_report",
+        lambda _path, _sid: {
+            "found": True,
+            "manual_review": True,
+            "tip_session_id": "new-tip",
+            "total_segments": 3,
+        },
+    )
+
+    with pytest.raises(KeyError):
+        routes._resolve_session_queue_owner("tip")
+
+
+def test_queue_owner_rejects_unavailable_lineage_state(monkeypatch):
+    monkeypatch.setattr(
+        routes,
+        "read_session_lineage_report",
+        lambda _path, _sid: {"found": False},
+    )
+    monkeypatch.setattr(routes, "get_session", lambda _sid: types.SimpleNamespace())
+
+    with pytest.raises(KeyError):
+        routes._resolve_session_queue_owner("tip")
+
+
+def test_queue_owner_rejects_read_only_sidecar(monkeypatch, tmp_path):
+    db_path = tmp_path / "state.db"
+    _queue_owner_state_db(db_path)
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: db_path)
+    monkeypatch.setattr(
+        routes,
+        "read_session_lineage_report",
+        lambda _path, _sid: {
+            "found": True,
+            "manual_review": False,
+            "tip_session_id": "tip",
+            "total_segments": 1,
+        },
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda _sid: types.SimpleNamespace(read_only=True),
+    )
+
+    with pytest.raises(KeyError):
+        routes._resolve_session_queue_owner("tip")
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [KeyError(), sqlite3.OperationalError("unable to open database file")],
+)
+def test_queue_get_returns_empty_unavailable_payload_when_lineage_is_not_authorized(
+    monkeypatch,
+    failure,
+):
+    monkeypatch.setattr(
+        routes,
+        "_resolve_session_queue_owner",
+        lambda _sid: (_ for _ in ()).throw(failure),
+    )
+    handler = _FakeHandler()
+
+    routes.handle_get(
+        handler,
+        types.SimpleNamespace(path="/api/session/queue", query="session_id=tip"),
+    )
+    assert handler.status == 200
+    assert handler.json_body() == {
+        "session_id": "tip",
+        "items": [],
+        "available": False,
+    }
+
+
+def test_queue_get_fails_closed_when_state_db_disappears_after_lineage_report(
+    monkeypatch,
+    tmp_path,
+):
+    db_path = tmp_path / "state.db"
+    missing_path = tmp_path / "missing-state.db"
+    _queue_owner_state_db(db_path)
+    paths = iter((db_path, missing_path))
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: next(paths))
+    monkeypatch.setattr(
+        routes,
+        "read_session_lineage_report",
+        lambda _path, _sid: {
+            "found": True,
+            "manual_review": False,
+            "tip_session_id": "tip",
+            "total_segments": 3,
+        },
+    )
+    handler = _FakeHandler()
+
+    routes.handle_get(
+        handler,
+        types.SimpleNamespace(path="/api/session/queue", query="session_id=tip"),
+    )
+
+    assert handler.status == 200
+    assert handler.json_body() == {
+        "session_id": "tip",
+        "items": [],
+        "available": False,
+    }
 
 
 def test_enqueue_persists_and_lists_session_queue(monkeypatch, tmp_path):

--- a/tests/test_session_queue_durable_start.py
+++ b/tests/test_session_queue_durable_start.py
@@ -2,7 +2,9 @@ from types import SimpleNamespace
 from unittest.mock import patch
 import json
 
-from api import config, gateway_chat, routes
+import pytest
+
+from api import config, gateway_chat, routes, session_queue
 from api.models import Session
 
 
@@ -22,9 +24,19 @@ def test_save_clears_queue_correlation_when_no_pending_turn(monkeypatch, tmp_pat
     assert persisted["pending_queue_client_id"] is None
 
 
-def test_worker_thread_start_failure_clears_durable_pending_owner(monkeypatch):
+@pytest.mark.parametrize(
+    ("dispatch_accepted", "expected_response"),
+    [
+        (True, {"error": "failed to start agent worker", "_status": 500}),
+        (False, {"error": "queued item lost dispatch ownership", "_status": 409}),
+    ],
+)
+def test_queue_dispatch_failure_clears_durable_pending_owner(
+    monkeypatch, dispatch_accepted, expected_response
+):
     recorded = {}
     released_owners = []
+    dispatches = []
     session = SimpleNamespace(
         session_id="sess-queue-start-fail",
         active_stream_id=None,
@@ -50,6 +62,7 @@ def test_worker_thread_start_failure_clears_durable_pending_owner(monkeypatch):
             pass
 
         def start(self):
+            assert dispatch_accepted
             raise RuntimeError("thread start failed")
 
     def fake_prepare(session_obj, *, stream_id, **_kwargs):
@@ -69,6 +82,14 @@ def test_worker_thread_start_failure_clears_durable_pending_owner(monkeypatch):
     monkeypatch.setattr(routes, "unregister_stream_owner", lambda stream_id: released_owners.append(stream_id))
     monkeypatch.setattr(config, "clear_session_writeback_owner_if_owned", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(routes, "set_last_workspace", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        session_queue,
+        "mark_dispatched",
+        lambda sid, item_id, stream_id, **kwargs: dispatches.append(
+            (sid, item_id, stream_id, kwargs)
+        )
+        or dispatch_accepted,
+    )
     monkeypatch.setattr(routes, "threading", SimpleNamespace(Thread=_BoomThread))
 
     with patch("api.turn_journal.append_turn_journal_event", return_value={}):
@@ -80,9 +101,20 @@ def test_worker_thread_start_failure_clears_durable_pending_owner(monkeypatch):
             model="test-model",
             source="queued_followup",
             external_runtime_owned=True,
+            queue_item_id="queue-item-1",
+            queue_client_id="queue-client-1",
+            queue_attempt_id="queue-attempt-1",
         )
 
-    assert response == {"error": "failed to start agent worker", "_status": 500}
+    assert response == expected_response
+    assert dispatches == [
+        (
+            session.session_id,
+            "queue-item-1",
+            recorded["stream_id"],
+            {"attempt_id": "queue-attempt-1"},
+        )
+    ]
     assert session.active_stream_id is None
     assert session.pending_user_message is None
     assert session.pending_started_at is None

--- a/tests/test_session_queue_durable_start.py
+++ b/tests/test_session_queue_durable_start.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+import json
+
+from api import config, gateway_chat, routes
+from api.models import Session
+
+
+def test_save_clears_queue_correlation_when_no_pending_turn(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr("api.models.SESSION_DIR", tmp_path)
+    session = Session(
+        session_id="safe-correlation",
+        pending_queue_item_id="stale-item",
+        pending_queue_client_id="stale-client",
+    )
+
+    session.save(skip_index=True)
+
+    persisted = json.loads((tmp_path / "safe-correlation.json").read_text(encoding="utf-8"))
+    assert persisted["pending_queue_item_id"] is None
+    assert persisted["pending_queue_client_id"] is None
+
+
+def test_worker_thread_start_failure_clears_durable_pending_owner(monkeypatch):
+    recorded = {}
+    released_owners = []
+    session = SimpleNamespace(
+        session_id="sess-queue-start-fail",
+        active_stream_id=None,
+        pending_user_message=None,
+        pending_attachments=[],
+        pending_started_at=None,
+        pending_user_source=None,
+        title="title",
+        profile=None,
+        process_wakeup_pause={},
+        save=lambda **_kwargs: None,
+    )
+
+    class _NoopLock:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *args):
+            return False
+
+    class _BoomThread:
+        def __init__(self, *, target=None, args=None, kwargs=None, daemon=None):
+            pass
+
+        def start(self):
+            raise RuntimeError("thread start failed")
+
+    def fake_prepare(session_obj, *, stream_id, **_kwargs):
+        recorded["stream_id"] = stream_id
+        session_obj.active_stream_id = stream_id
+        session_obj.pending_user_message = "queued prompt"
+        session_obj.pending_started_at = 123.0
+        session_obj.pending_user_source = "queued_followup"
+
+    monkeypatch.setattr(routes, "_agent_runtime_barrier_response", lambda **_kwargs: None)
+    monkeypatch.setattr(routes, "_active_run_stream_for_session", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(routes, "_get_session_agent_lock", lambda *_args, **_kwargs: _NoopLock())
+    monkeypatch.setattr(routes, "_is_hidden_empty_session", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(routes, "_prepare_chat_start_session_for_stream", fake_prepare)
+    monkeypatch.setattr(routes, "create_stream_channel", lambda: SimpleNamespace())
+    monkeypatch.setattr(routes, "register_stream_owner", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(routes, "unregister_stream_owner", lambda stream_id: released_owners.append(stream_id))
+    monkeypatch.setattr(config, "clear_session_writeback_owner_if_owned", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(routes, "set_last_workspace", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(routes, "threading", SimpleNamespace(Thread=_BoomThread))
+
+    with patch("api.turn_journal.append_turn_journal_event", return_value={}):
+        response = routes._start_chat_stream_for_session(
+            session,
+            msg="queued prompt",
+            attachments=[],
+            workspace="/tmp",
+            model="test-model",
+            source="queued_followup",
+            external_runtime_owned=True,
+        )
+
+    assert response == {"error": "failed to start agent worker", "_status": 500}
+    assert session.active_stream_id is None
+    assert session.pending_user_message is None
+    assert session.pending_started_at is None
+    assert released_owners == [recorded["stream_id"]]
+    assert recorded["stream_id"] not in routes.STREAMS
+    assert gateway_chat.gateway_run_id_pending(recorded["stream_id"]) is False


### PR DESCRIPTION
## Thinking Path
- Browser queue acknowledgements create durable user intent; after acknowledgement the backend, not the tab, must own dispatch.
- The prior live-row implementation removed or inferred ownership across crash and concurrency windows.
- The queue therefore models one backend-authoritative FIFO with durable item identity, bounded retry, dispatch fencing, completion receipts, and fail-closed storage/recovery.
- Frontend state is an optimistic projection reconciled by stable server/client IDs, stale-response fencing, and idempotent recovery of ACK-in-flight rows after reload.

## What Changed
- Persist per-session queue items through `queued -> starting -> started -> completed`, with a unique attempt fence and exact stream correlation.
- Serialize per-session drains so concurrent teardown/enqueue paths cannot claim past the FIFO head.
- Reject capacity overflow instead of evicting acknowledged intent.
- Reject corrupt or cross-session queue/receipt storage instead of treating it as empty and overwriting it.
- Require a stable `client_queue_id`; bind retries to the complete execution-affecting intent and retain bounded durable completion receipts after live-row retirement.
- Retry returned and raised start failures through the same bounded budget, surfacing exhausted items as `blocked`.
- Persist queue item/client correlation through turn start and clear it at terminal serialization/teardown chokepoints.
- Fence Gateway-backed dispatch before worker start, persist external admission before POST, bind accepted remote run IDs to the exact queue attempt, and reconcile only authoritative remote terminal states.
- Reconcile browser queue snapshots with request epochs and mutate duplicate-looking rows by stable item identity rather than timestamp/text/index.
- On reload, re-submit an unmatched browser recovery row with its original `client_queue_id` and complete intent; a page-local single-flight fence prevents overlapping syncs from duplicating the POST, while persisted attempt counts bound retries.
- After update, delete, reorder, or combine successfully exposes a queued FIFO head, invoke the same serialized `drain_for_session` chokepoint and return the post-drain authoritative queue state.

## Why It Matters
An acknowledged follow-up can no longer be silently evicted, overwritten after corruption, double-owned after a lost acknowledgement, claimed out of FIFO order, mutated through the wrong duplicate-looking chip, or left inert after reload or a successful mutation. Crash/reload and out-of-process Gateway paths fail closed instead of inferring completion from missing process-local state.

## RED Gate / Review Follow-up
The revision-1 review identified eight material failure classes. Regression coverage pins each one:
1. claim/start crash loss: durable `starting` + stream dispatch binding and fast-completion tests;
2. concurrent FIFO drains: serialized drain/concurrency tests;
3. silent cap eviction: explicit capacity rejection test;
4. corrupt JSON overwrite: fail-closed corruption tests;
5. lost-ACK duplicate ownership: stable-key live and completed-receipt replay tests;
6. reload/composer duplication and stale GETs: acknowledgement cleanup and out-of-order sync tests;
7. wrong-item frontend mutation: duplicate timestamp/text stable-identity tests;
8. silent start errors / split ownership: returned+raised retry-budget, terminal correlation cleanup, stale-attempt fence, and remote admission/run lifecycle tests.

Revision 3 answers the two canonical liveness findings at `7fcc3547`:
1. The reload regression first retained an unmatched `_server_pending` row without any POST. The new Node behavioral tests now require one idempotent recovery POST with the original complete intent, prove two overlapping syncs still issue only one POST, and require convergence to the server queue ID.
2. The route-level mutation regression first observed successful blocked-head update/delete/reorder/combine responses with zero drain calls. The new parametrized behavioral test requires every successful operation that exposes a queued head to enter the serialized drain chokepoint; an active-session test proves the existing guard still prevents a second dispatch.

Earlier TDD evidence for the remote-admission crash window: the focused test first failed with `_run_gateway_runs_api_streaming() got an unexpected keyword argument 'queue_attempt_id'`; after wiring the durable pre-POST admission and attempt fence it passed.

## Verification
- RED at `7fcc3547`: `./scripts/test.sh tests/test_session_queue.py -q` -> **6 failed, 38 passed**, with all six failures matching the two reviewer findings.
- GREEN at `d68cffef`: `./scripts/test.sh tests/test_session_queue.py -q` -> **44 passed**.
- Queue/Gateway plus CI-neighbor reproduction: `./scripts/test.sh tests/test_gateway_approval_runs_api.py tests/test_issue660.py tests/test_session_queue.py tests/test_session_queue_durable_start.py tests/test_sprint10.py -q` -> **160 passed, 3 skipped**.
- Full local suite: **14,316 passed, 104 skipped, 1 xfailed, 2 xpassed, 34 subtests passed**; one unrelated macOS setgid-permission assertion failed. The exact same isolated node fails at the reviewed `7fcc3547` baseline (`test_atomic_write_preserves_existing_permissions`: expected `02664`, APFS returned `0664`).
- `npm run lint:runtime` -> **passed**.
- `node --check static/ui.js` -> **passed**.
- Python compile for changed Python files -> **passed**.
- `python scripts/ruff_lint.py --diff HEAD^` -> **0 findings on added/modified lines**.
- `git diff --check HEAD^..HEAD` -> **passed**.
- Local branch, fork remote, and PR head readback -> `d68cffefbfc19e1a81770ac67e8b4ba9de33c06e`.

## Contract Routing
Task type: runtime durability and recovery fix.

Touched areas: session-owned pending queue, chat start/teardown, Gateway remote-run correlation, browser reconciliation.

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-pending-intent-controls.md`
- `docs/rfcs/turn-journal.md`

State invariant: backend persistence becomes authoritative once enqueue is acknowledged; only the exact fenced attempt may dispatch/settle; durable completion evidence precedes live-row retirement; ambiguous browser recovery can only re-enter through the idempotent backend enqueue key.

## Risks / Follow-ups
- Unknown Gateway status and a crash after external admission but before accepted run-ID binding remain fail-closed as a visible retained started owner; WebUI does not risk duplicate remote execution by guessing that local absence means completion.
- Revision 3 changes queue liveness/reconciliation behavior but adds no visual control or layout, so there is no new before/after visual delta.
- The disjoint queued-row Steer feature remains outside this dependency PR and should be restacked only after this queue authority revision is accepted.

## Model Used
OpenAI `gpt-5.6-sol` via Hermes Agent CLI, with strict TDD, repository tests, Git, and GitHub CLI verification.
