### PR TITLE
fix(#4358): compact quota chip to prevent truncation on narrow composer

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1934,7 +1934,7 @@
   .composer-model-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
   .composer-model-icon,.composer-model-chevron{display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;}
   .composer-model-select{position:absolute!important;left:-9999px!important;width:1px!important;height:1px!important;opacity:0!important;pointer-events:none!important;}
-  .provider-quota-chip{display:inline-flex;align-items:center;gap:6px;height:34px;max-width:150px;padding:7px 10px;border:1px solid var(--border2);border-radius:999px;background:rgba(34,197,94,.10);color:var(--text);font-size:11px;font-weight:650;line-height:1;white-space:nowrap;cursor:pointer;transition:background .12s,border-color .12s,color .12s;}
+  .provider-quota-chip{display:inline-flex;align-items:center;gap:4px;height:30px;max-width:120px;padding:5px 8px;border:1px solid var(--border2);border-radius:999px;background:rgba(34,197,94,.10);color:var(--text);font-size:11px;font-weight:650;line-height:1;white-space:nowrap;cursor:pointer;transition:background .12s,border-color .12s,color .12s;}
   .provider-quota-chip[hidden]{display:none!important;}
   .provider-quota-chip:hover{background:rgba(34,197,94,.16);border-color:rgba(34,197,94,.35);}
   .provider-quota-chip-dot{width:6px;height:6px;border-radius:999px;background:#22c55e;box-shadow:0 0 0 3px rgba(34,197,94,.12);flex:0 0 auto;}
@@ -2284,6 +2284,7 @@
     .composer-divider{display:none;}
     .ctx-indicator-wrap{display:none!important;}
     .ctx-indicator-wrap{display:none!important;}
+    .provider-quota-chip{display:none!important;}
   }
 
   @container composer-footer (max-width: 520px){


### PR DESCRIPTION
## Summary

The provider quota chip in the composer footer was cut off on narrow screens due to excessive sizing (`max-width:150px`, `padding:7px 10px`, `height:34px`, `gap:6px`).

Fixes #4358

## Changes

```css
.provider-quota-chip {
-  gap: 6px; height: 34px; max-width: 150px; padding: 7px 10px;
+  gap: 4px; height: 30px; max-width: 120px; padding: 5px 8px;
}
```

Also hides the chip inside the `@container composer-footer (max-width: 700px)` query where it competes with model picker, reasoning, and media buttons for space.

The `.provider-quota-chip-label` already has `text-overflow:ellipsis` so long labels truncate cleanly with "..." instead of being hard-clipped.

## Verification

- Verified no conflicting CSS rules among the 7 existing `.provider-quota-chip` references
- Chip text gracefully truncates with ellipsis on overflow
- Green dot (`.provider-quota-chip-dot`, flex-shrink: 0) remains visible