### PR TITLE
fix(#4354): unstuck running indicator when SSE dies during provider retry

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -381,7 +381,7 @@ function _isServerIdleSessionRow(s) {
 
 function _reconcileActiveSessionIdleStateFromList(serverRows) {
   if (!S || !S.session || !S.session.session_id) return false;
-  if (typeof _sendInProgress !== 'undefined' && _sendInProgress) return false;
+  // #4354: Removed _sendInProgress guard — server is_streaming=false is authoritative.
   if (!Array.isArray(serverRows)) return false;
   const sid=S.session.session_id;
   const serverRow=serverRows.find(s=>s&&s.session_id===sid);
@@ -435,9 +435,7 @@ function _purgeStaleInflightEntries() {
     }
   }
   for (const sid of Object.keys(INFLIGHT)) {
-    if (typeof _sendInProgress !== 'undefined' && _sendInProgress && sid === _sendInProgressSid) {
-      continue;
-    }
+    // #4354: Removed _sendInProgressSid skip — purge stale INFLIGHT even during hung sends.
     if (!sessionsById.has(sid)) {
       // Session is absent from _allSessions — it was deleted / archived /
       // filtered and can never stream again, so drop the entry.
@@ -1189,7 +1187,7 @@ async function loadSession(sid){
     }
     // Refresh todos from cold-load or persisted INFLIGHT before painting.
     if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
-    S.busy=true;
+    S.busy=!!activeStreamId;  // #4354: Only assert busy if server confirms active stream.
     // appendLiveToolCard() is guarded by S.activeStreamId; restore it before
     // replaying persisted live tools so the compact Activity count survives
     // switching away from and back to an active chat (#1715).

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -656,14 +656,14 @@ def test_loadSession_inflight_sets_busy_before_renderMessages(cleanup_test_sessi
     inflight_idx = src.rfind("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
     inflight_block = src[inflight_idx:inflight_idx+4200]
-    busy_pos = inflight_block.find("S.busy=true;")
+    busy_pos = inflight_block.find("S.busy=")
     # #3326 added an optional {preserveScroll} arg to the INFLIGHT-branch render
     # call, so match the call form rather than the bare `renderMessages();`.
     render_pos = inflight_block.find("renderMessages(")
-    assert busy_pos >= 0, "loadSession INFLIGHT branch must set S.busy=true"
+    assert busy_pos >= 0, "loadSession INFLIGHT branch must set S.busy"
     assert render_pos >= 0, "loadSession INFLIGHT branch must call renderMessages()"
     assert busy_pos < render_pos, \
-        "loadSession must set S.busy=true before renderMessages() to avoid duplicate tool cards"
+        "loadSession must set S.busy before renderMessages() to avoid duplicate tool cards"
 
 
 def test_loadSession_inflight_merges_tail_with_persisted_transcript(cleanup_test_sessions):


### PR DESCRIPTION
## Summary

The "Conversation is running" indicator and ticking timer can remain stuck after the agent run has fully completed server-side, when the SSE connection dies before the `apperror` event is delivered. Three independent gaps in the busy-state machine conspire to make this state unrecoverable without a page refresh.

Fixes #4354

## Root cause (from issue)

1. No client-side watchdog: `attachLiveStream` opens EventSource but has no idle timer to detect silence
2. `_reconcileActiveSessionIdleStateFromList` gated on `_sendInProgress === false` — but `_sendInProgress` stays stuck true when the send flow SSE dies before the `finally` block runs
3. INFLIGHT reattach unconditionally sets `S.busy = true` from local cache, ignoring server truth

## Changes (3 targeted edits in `static/sessions.js`)

| Location | Before | After | Effect |
|----------|--------|-------|--------|
| `_reconcileActiveSessionIdleStateFromList` L384 | `if (_sendInProgress) return false;` | Comment (guard removed) | Server `is_streaming=false` now overrides stuck client state |
| `_purgeStaleInflightEntries` L438-440 | Skip if `_sendInProgress && sid === _sendInProgressSid` | Comment (skip removed) | Stale INFLIGHT entries purged even during hung sends |
| `loadSession` INFLIGHT reattach L1192 | `S.busy = true;` | `S.busy = !!activeStreamId;` | Only assert busy if server confirms active stream |

## Combined effect

When a provider hangs for 30+ min, retries exhaust, and SSE dies before `apperror` is delivered:
1. The periodic `/api/sessions` poll returns `is_streaming: false`
2. `_reconcileActiveSessionIdleStateFromList` now clears `S.busy`, `S.activeStreamId`, and `INFLIGHT[sid]` (previously bailed at `_sendInProgress` guard)
3. `_purgeStaleInflightEntries` now removes the stale INFLIGHT entry (previously skipped it)
4. If user navigates away and back, `loadSession` only asserts busy if `activeStreamId` is truthy

No page refresh needed — the stuck spinner clears on the next session list poll (~15s).

## Risk assessment

- **Minimal**: 3 insertions, 5 deletions, purely in busy-state reconciliation paths
- **`_sendInProgress` guard removal**: the worst case is clearing busy state during a genuinely in-progress send. The periodic poll runs every ~15s, and the server would not report `is_streaming=false` while the stream is active. If a false positive somehow occurs, the user just sees a brief busy→idle→busy transition on the next token event.
- **`!!activeStreamId`**: activeStreamId comes from the server session object (`s.active_stream_id`), which is the source of truth.