### PR TITLE
Release v0.51.492 — RB (large context window preserved on session reload, #4248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Reloading a session with a large model context window no longer snaps it back to the 256k fallback (#4248).** The session reload path now resolves context-window metadata with the same base URL / API-key lookup inputs used by streaming saves, and it refuses to overwrite a larger persisted context window with the generic 256k fallback.
+
 ## [v0.51.489] — 2026-06-18 — Release QY (outline button no longer collides with the scroll control)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.492] — 2026-06-18 — Release RB (large context window preserved on session reload)
+
 ### Fixed
 
-- **Reloading a session with a large model context window no longer snaps it back to the 256k fallback (#4248).** The session reload path now resolves context-window metadata with the same base URL / API-key lookup inputs used by streaming saves, and it refuses to overwrite a larger persisted context window with the generic 256k fallback.
+- **Reloading a session with a large model context window no longer snaps it back to the 256k fallback (#4248).** The session reload path now resolves context-window metadata with the same base URL / API-key lookup inputs used by streaming saves, and it refuses to overwrite a larger persisted context window with the generic 256k fallback. The reload model-identity check also normalizes slash-qualified model ids (`provider/model`, OpenRouter-style) so a slash-stored model resolving to its bare id is not mistaken for a model change. Thanks @franksong2702.
 
 ## [v0.51.489] — 2026-06-18 — Release QY (outline button no longer collides with the scroll control)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -3413,11 +3413,60 @@ def _custom_provider_api_key_for_context(entry: dict, provider: str) -> str:
         return ""
 
 
+def _context_length_config_api_key_for_provider(
+    provider: str | None,
+    cfg: dict | None,
+) -> str:
+    """Return a config/env API key usable for context-window metadata lookup."""
+    cfg = cfg if isinstance(cfg, dict) else {}
+    provider = _canonical_context_provider(provider)
+
+    def _resolve_key(raw_api_key, raw_key_env=None) -> str:
+        api_key_text = str(raw_api_key or "").strip()
+        if (
+            api_key_text.startswith("${")
+            and api_key_text.endswith("}")
+            and len(api_key_text) > 3
+        ):
+            resolved = os.getenv(api_key_text[2:-1], "").strip()
+            if resolved:
+                return resolved
+        elif api_key_text:
+            return api_key_text
+        key_env = str(raw_key_env or "").strip()
+        if key_env:
+            resolved = os.getenv(key_env, "").strip()
+            if resolved:
+                return resolved
+        return ""
+
+    providers_cfg = cfg.get("providers", {})
+    if isinstance(providers_cfg, dict):
+        for provider_key, provider_cfg in providers_cfg.items():
+            if not isinstance(provider_cfg, dict):
+                continue
+            if not _providers_match_for_context(provider_key, provider):
+                continue
+            api_key = _resolve_key(provider_cfg.get("api_key"), provider_cfg.get("key_env"))
+            if api_key:
+                return api_key
+
+    model_cfg = cfg.get("model", {})
+    if isinstance(model_cfg, dict):
+        model_provider = _canonical_context_provider(model_cfg.get("provider"))
+        if not provider or _providers_match_for_context(model_provider, provider):
+            api_key = _resolve_key(model_cfg.get("api_key"), model_cfg.get("key_env"))
+            if api_key:
+                return api_key
+    return ""
+
+
 def _context_length_lookup_inputs_for_model(
     model: str | None,
     provider: str | None = None,
     *,
     base_url: str | None = None,
+    api_key: str | None = None,
     cfg: dict | None = None,
 ) -> _ContextLengthLookupInputs:
     """Return the effective metadata resolver inputs for a WebUI model.
@@ -3472,7 +3521,7 @@ def _context_length_lookup_inputs_for_model(
             break
 
     custom_context_length = None
-    effective_api_key = ""
+    effective_api_key = str(api_key or "").strip()
     if custom_providers:
         target_base = effective_base_url.rstrip("/")
         model_candidates = set(_model_lookup_candidates(bare_model or model_for_lookup))
@@ -3502,7 +3551,8 @@ def _context_length_lookup_inputs_for_model(
                 effective_provider = entry_slug
             if not effective_base_url and entry_base:
                 effective_base_url = entry_base
-            effective_api_key = _custom_provider_api_key_for_context(entry, effective_provider or entry_slug)
+            if not effective_api_key:
+                effective_api_key = _custom_provider_api_key_for_context(entry, effective_provider or entry_slug)
             custom_context_length = _models_config_context_length(models_cfg, bare_model or model_for_lookup)
             break
 
@@ -3519,6 +3569,9 @@ def _context_length_lookup_inputs_for_model(
             )
         ):
             global_context_length = _positive_context_length(raw_cfg_ctx)
+
+    if not effective_api_key:
+        effective_api_key = _context_length_config_api_key_for_provider(effective_provider, cfg)
 
     return _ContextLengthLookupInputs(
         config_context_length=provider_context_length or custom_context_length or global_context_length,
@@ -4016,6 +4069,9 @@ def _resolve_effective_session_model_provider_for_display(session) -> str | None
 def _resolve_context_length_for_session_model(
     model: str | None,
     provider: str | None = None,
+    *,
+    base_url: str | None = None,
+    api_key: str | None = None,
 ) -> int:
     """Best-effort current context window for a session model.
 
@@ -4034,6 +4090,8 @@ def _resolve_context_length_for_session_model(
         _ctx_lookup = _context_length_lookup_inputs_for_model(
             model_for_lookup,
             provider,
+            base_url=base_url,
+            api_key=api_key,
             cfg=_cfg_for_cl if isinstance(_cfg_for_cl, dict) else {},
         )
         try:
@@ -4050,6 +4108,67 @@ def _resolve_context_length_for_session_model(
             return _get_cl(model_for_lookup, _ctx_lookup.base_url) or 0
     except Exception:
         return 0
+
+
+def _session_context_length_lookup_state(
+    model: str | None,
+    provider: str | None,
+) -> tuple[str, str, str, str]:
+    """Return model/provider/base_url/api_key inputs for session context lookup.
+
+    This stays config-based and side-effect-free for GET /api/session. It avoids
+    a live provider catalog rebuild while still aligning the reload path with
+    the base URL / custom-provider key shape used by streaming saves. (#4248)
+    """
+    model_for_lookup = str(model or "").strip()
+    provider_for_lookup = str(provider or "").strip()
+    base_url_for_lookup = ""
+    api_key_for_lookup = ""
+    if not model_for_lookup:
+        return "", provider_for_lookup, "", ""
+    try:
+        from api.config import resolve_custom_provider_connection, resolve_model_provider
+
+        model_for_resolution = model_with_provider_context(model_for_lookup, provider_for_lookup or None)
+        resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(model_for_resolution)
+        model_for_lookup = str(resolved_model or model_for_lookup).strip()
+        provider_for_lookup = str(resolved_provider or provider_for_lookup or "").strip()
+        base_url_for_lookup = str(resolved_base_url or "").strip()
+        if provider_for_lookup.startswith("custom:"):
+            custom_key, custom_base = resolve_custom_provider_connection(provider_for_lookup)
+            api_key_for_lookup = str(custom_key or "").strip()
+            if not base_url_for_lookup:
+                base_url_for_lookup = str(custom_base or "").strip()
+    except Exception:
+        logger.debug("session context-length lookup state resolution failed", exc_info=True)
+    return model_for_lookup, provider_for_lookup, base_url_for_lookup, api_key_for_lookup
+
+
+def _should_accept_session_context_length_refresh(persisted: int, resolved: int) -> bool:
+    if not resolved:
+        return False
+    if not persisted:
+        return True
+    # #4248: an anonymous reload resolver can still fall through to the agent
+    # metadata default fallback. Do not let that lower-confidence 256k value
+    # clobber a larger context window persisted by the streaming path.
+    return not (resolved == 256_000 and persisted > resolved)
+
+
+def _rescale_threshold_tokens_for_context_window(
+    threshold: int,
+    old_window: int,
+    new_window: int,
+) -> int:
+    try:
+        threshold = int(threshold or 0)
+        old_window = int(old_window or 0)
+        new_window = int(new_window or 0)
+    except (TypeError, ValueError):
+        return 0
+    if threshold <= 0 or old_window <= 0 or new_window <= 0:
+        return 0
+    return max(1, int(threshold * new_window / old_window))
 
 
 def _session_model_state_from_request(
@@ -7465,16 +7584,31 @@ def handle_get(handler, parsed) -> bool:
                 _model_for_lookup = (
                     effective_model or getattr(s, "model", "") or ""
                 ).strip()
-                _fb_cl = _resolve_context_length_for_session_model(
+                (
+                    _model_for_lookup,
+                    _provider_for_lookup,
+                    _base_url_for_lookup,
+                    _api_key_for_lookup,
+                ) = _session_context_length_lookup_state(
                     _model_for_lookup,
                     effective_provider or getattr(s, "model_provider", None) or "",
                 )
-                if _fb_cl:
+                _fb_cl = _resolve_context_length_for_session_model(
+                    _model_for_lookup,
+                    _provider_for_lookup,
+                    base_url=_base_url_for_lookup,
+                    api_key=_api_key_for_lookup,
+                )
+                if _should_accept_session_context_length_refresh(_persisted_cl, _fb_cl):
                     if _persisted_cl and _fb_cl != _persisted_cl:
                         # The old threshold belongs to the old window. Hiding it
-                        # is less misleading than rendering a stale compression
-                        # threshold against a freshly resolved context length.
-                        _threshold_tokens = 0
+                        # is less useful than keeping the same compression ratio
+                        # against the freshly resolved context length.
+                        _threshold_tokens = _rescale_threshold_tokens_for_context_window(
+                            _threshold_tokens,
+                            _persisted_cl,
+                            _fb_cl,
+                        )
                     _persisted_cl = _fb_cl
             _session_tool_calls = getattr(s, "tool_calls", []) if load_messages else []
             # Always include session-level tool_calls so the browser can merge

--- a/api/routes.py
+++ b/api/routes.py
@@ -4127,32 +4127,67 @@ def _session_context_length_lookup_state(
     if not model_for_lookup:
         return "", provider_for_lookup, "", ""
     try:
-        from api.config import resolve_custom_provider_connection, resolve_model_provider
+        from api.config import resolve_model_provider
 
         model_for_resolution = model_with_provider_context(model_for_lookup, provider_for_lookup or None)
         resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(model_for_resolution)
         model_for_lookup = str(resolved_model or model_for_lookup).strip()
         provider_for_lookup = str(resolved_provider or provider_for_lookup or "").strip()
         base_url_for_lookup = str(resolved_base_url or "").strip()
-        if provider_for_lookup.startswith("custom:"):
+    except Exception:
+        logger.debug("session context-length lookup state resolution failed", exc_info=True)
+    if provider_for_lookup.startswith("custom:"):
+        try:
+            from api.config import resolve_custom_provider_connection
+
             custom_key, custom_base = resolve_custom_provider_connection(provider_for_lookup)
             api_key_for_lookup = str(custom_key or "").strip()
             if not base_url_for_lookup:
                 base_url_for_lookup = str(custom_base or "").strip()
-    except Exception:
-        logger.debug("session context-length lookup state resolution failed", exc_info=True)
+        except Exception:
+            logger.debug("custom provider context-length connection resolution failed", exc_info=True)
     return model_for_lookup, provider_for_lookup, base_url_for_lookup, api_key_for_lookup
 
 
-def _should_accept_session_context_length_refresh(persisted: int, resolved: int) -> bool:
+def _session_model_identity_matches(
+    stored_model: str | None,
+    stored_provider: str | None,
+    resolved_model: str | None,
+    resolved_provider: str | None,
+) -> bool:
+    stored = str(stored_model or "").strip()
+    resolved = str(resolved_model or "").strip()
+    if not stored or not resolved:
+        return False
+    stored_bare, stored_explicit_provider = _split_provider_qualified_model(stored)
+    resolved_bare, resolved_explicit_provider = _split_provider_qualified_model(resolved)
+    stored_provider_norm = _canonical_context_provider(stored_explicit_provider or stored_provider)
+    resolved_provider_norm = _canonical_context_provider(resolved_explicit_provider or resolved_provider)
+    if stored == resolved and stored_provider_norm == resolved_provider_norm:
+        return True
+    if stored_bare != resolved_bare:
+        return False
+    if stored_provider_norm and resolved_provider_norm:
+        return stored_provider_norm == resolved_provider_norm
+    return True
+
+
+def _should_accept_session_context_length_refresh(
+    persisted: int,
+    resolved: int,
+    *,
+    model_changed: bool = False,
+) -> bool:
     if not resolved:
         return False
     if not persisted:
         return True
     # #4248: an anonymous reload resolver can still fall through to the agent
     # metadata default fallback. Do not let that lower-confidence 256k value
-    # clobber a larger context window persisted by the streaming path.
-    return not (resolved == 256_000 and persisted > resolved)
+    # clobber a larger context window persisted by the streaming path. If the
+    # effective model changed, though, a 256k result may be the real new model
+    # window and should replace the old snapshot.
+    return model_changed or not (resolved == 256_000 and persisted > resolved)
 
 
 def _rescale_threshold_tokens_for_context_window(
@@ -7581,8 +7616,10 @@ def handle_get(handler, parsed) -> bool:
             _persisted_cl = getattr(s, "context_length", 0) or 0
             _threshold_tokens = getattr(s, "threshold_tokens", 0) or 0
             if (not _persisted_cl) or resolve_model:
+                _stored_model_for_lookup = getattr(s, "model", "") or ""
+                _stored_provider_for_lookup = getattr(s, "model_provider", None) or ""
                 _model_for_lookup = (
-                    effective_model or getattr(s, "model", "") or ""
+                    effective_model or _stored_model_for_lookup
                 ).strip()
                 (
                     _model_for_lookup,
@@ -7599,7 +7636,17 @@ def handle_get(handler, parsed) -> bool:
                     base_url=_base_url_for_lookup,
                     api_key=_api_key_for_lookup,
                 )
-                if _should_accept_session_context_length_refresh(_persisted_cl, _fb_cl):
+                _model_changed_for_context = not _session_model_identity_matches(
+                    _stored_model_for_lookup,
+                    _stored_provider_for_lookup,
+                    _model_for_lookup,
+                    _provider_for_lookup,
+                )
+                if _should_accept_session_context_length_refresh(
+                    _persisted_cl,
+                    _fb_cl,
+                    model_changed=_model_changed_for_context,
+                ):
                     if _persisted_cl and _fb_cl != _persisted_cl:
                         # The old threshold belongs to the old window. Hiding it
                         # is less useful than keeping the same compression ratio

--- a/api/routes.py
+++ b/api/routes.py
@@ -4159,8 +4159,25 @@ def _session_model_identity_matches(
     resolved = str(resolved_model or "").strip()
     if not stored or not resolved:
         return False
-    stored_bare, stored_explicit_provider = _split_provider_qualified_model(stored)
-    resolved_bare, resolved_explicit_provider = _split_provider_qualified_model(resolved)
+
+    def _split_model_identity(value: str) -> tuple[str, str | None]:
+        # Handle BOTH provider-qualified shapes so a slash-prefixed session model
+        # (e.g. ``deepseek/deepseek-v4-1m``, OpenRouter-style) compares equal to its
+        # resolved bare id. ``_split_provider_qualified_model`` only handles the
+        # ``@provider:model`` form; without the slash case a reload of a
+        # slash-stored model is wrongly treated as a model change, bypassing the
+        # #4248 256k-clobber guard (Codex regression gate, v0.51.x).
+        bare, prov = _split_provider_qualified_model(value)
+        if prov is None and "/" in value:
+            prefix, rest = value.split("/", 1)
+            prefix = prefix.strip()
+            rest = rest.strip()
+            if prefix and rest:
+                return rest, prefix
+        return bare, prov
+
+    stored_bare, stored_explicit_provider = _split_model_identity(stored)
+    resolved_bare, resolved_explicit_provider = _split_model_identity(resolved)
     stored_provider_norm = _canonical_context_provider(stored_explicit_provider or stored_provider)
     resolved_provider_norm = _canonical_context_provider(resolved_explicit_provider or resolved_provider)
     if stored == resolved and stored_provider_norm == resolved_provider_norm:

--- a/tests/test_issue1896_context_length_fallback_args.py
+++ b/tests/test_issue1896_context_length_fallback_args.py
@@ -209,14 +209,18 @@ def test_routes_session_load_fallback_passes_config_overrides():
     # The route block may delegate the resolver details to a helper, but the
     # session-load path must still call the helper and that helper must preserve
     # the same kwargs as the streaming.py fix.
-    block_end = ROUTES_PY.find("if _fb_cl:", idx)
-    assert block_end != -1, "_fb_cl assignment not found after fallback comment"
+    block_end = ROUTES_PY.find("_session_tool_calls =", idx)
+    assert block_end != -1, "session-load fallback block end not found after fallback comment"
     block = ROUTES_PY[idx:block_end]
     helper_start = ROUTES_PY.find("def _resolve_context_length_for_session_model")
     assert helper_start != -1, "context-length resolver helper not found"
     helper_end = ROUTES_PY.find("\ndef ", helper_start + 1)
     helper = ROUTES_PY[helper_start:helper_end if helper_end != -1 else len(ROUTES_PY)]
     assert "_resolve_context_length_for_session_model" in block
+    assert "_should_accept_session_context_length_refresh" in block, (
+        "session-load fallback must gate lower-confidence recomputes before "
+        "replacing persisted context metadata. See #4248."
+    )
     # Same kwargs as the streaming.py fix.
     assert "config_context_length=" in helper, (
         "session-load fallback in api/routes.py must pass config_context_length= "

--- a/tests/test_issue3256_context_length_default_only_guard.py
+++ b/tests/test_issue3256_context_length_default_only_guard.py
@@ -302,6 +302,89 @@ def test_session_reload_preserves_large_persisted_window_when_recompute_hits_256
     )
 
 
+def test_session_reload_accepts_real_256k_when_effective_model_changes(monkeypatch):
+    """#4248 follow-up: the 256k fallback guard must not block a real model switch."""
+    import api.config as config
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_j(_handler, data, status=200):
+        captured["data"] = data
+        captured["status"] = status
+        return True
+
+    rec = {}
+    _install_fake_get_model_context_length(monkeypatch, rec, default_context=256_000)
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda *a, **k: {
+            "model": {
+                "provider": "deepseek",
+                "base_url": "https://runtime-base.invalid/v1",
+                "api_key": "reload-key",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        config,
+        "resolve_model_provider",
+        lambda _model: ("deepseek-v4-256k", "deepseek", "https://runtime-base.invalid/v1"),
+    )
+
+    s = _stub_route_session(model="deepseek-v4-1m")
+    handler = MagicMock()
+    parsed = urlparse("/api/session?session_id=test-4248&messages=1")
+
+    with patch("api.routes.get_session", return_value=s), \
+         patch("api.routes.j", side_effect=fake_j), \
+         patch("api.routes._resolve_effective_session_model_for_display", return_value="deepseek-v4-256k"), \
+         patch("api.routes._resolve_effective_session_model_provider_for_display", return_value="deepseek"), \
+         patch("api.routes._session_visible_to_active_profile", return_value=True), \
+         patch("api.routes._clear_stale_stream_state", return_value=None), \
+         patch("api.routes._session_requires_cli_metadata_lookup", return_value=False), \
+         patch("api.routes._is_messaging_session_record", return_value=False), \
+         patch("api.routes.get_state_db_session_messages", return_value=[]), \
+         patch("api.routes._webui_sidecar_lineage_messages_for_display", return_value=[]), \
+         patch("api.routes.merge_session_messages_append_only", return_value=[]), \
+         patch("api.routes._merged_webui_lineage_messages_for_display", return_value=[]), \
+         patch("api.routes._active_stream_ids", return_value=set()):
+        assert routes.handle_get(handler, parsed) is True
+
+    body = captured["data"]["session"]
+    assert captured["status"] == 200
+    assert rec["model"] == "deepseek-v4-256k"
+    assert body["context_length"] == 256_000, (
+        "a genuine effective-model change to a 256k model must replace the "
+        "old 1M snapshot rather than being treated as an anonymous fallback"
+    )
+    assert body["threshold_tokens"] == 128_000
+
+
+def test_session_context_lookup_keeps_base_url_when_custom_helper_is_missing(monkeypatch):
+    """#4248 follow-up: non-custom base URL resolution must not depend on custom helper imports."""
+    import api.config as config
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        config,
+        "resolve_model_provider",
+        lambda _model: ("deepseek-v4-1m", "deepseek", "https://runtime-base.invalid/v1"),
+    )
+    monkeypatch.delattr(config, "resolve_custom_provider_connection", raising=False)
+
+    model, provider, base_url, api_key = routes._session_context_length_lookup_state(
+        "deepseek-v4-1m",
+        "deepseek",
+    )
+
+    assert model == "deepseek-v4-1m"
+    assert provider == "deepseek"
+    assert base_url == "https://runtime-base.invalid/v1"
+    assert api_key == ""
+
+
 # --- #3263 dual-gate MUST-FIX invariants (Codex regression gate, v0.51.192) ---
 # These pin the two consistency fixes applied after the gate found that the
 # default-only guard dropped the stale cap but didn't (a) recompute a persisted

--- a/tests/test_issue3256_context_length_default_only_guard.py
+++ b/tests/test_issue3256_context_length_default_only_guard.py
@@ -302,6 +302,93 @@ def test_session_reload_preserves_large_persisted_window_when_recompute_hits_256
     )
 
 
+def test_session_reload_preserves_large_window_for_slash_qualified_model(monkeypatch):
+    """#4248 follow-up (Codex regression gate): a slash-qualified stored model
+    (``deepseek/deepseek-v4-1m``, OpenRouter-style) that resolves to its bare id
+    must NOT be treated as a model change, or the 256k fallback bypasses the
+    accept-guard and clobbers the persisted 1M window.
+    """
+    import api.config as config
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_j(_handler, data, status=200):
+        captured["data"] = data
+        captured["status"] = status
+        return True
+
+    rec = {}
+    _install_fake_get_model_context_length(monkeypatch, rec, default_context=256_000)
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda *a, **k: {
+            "model": {
+                "provider": "deepseek",
+                "base_url": "https://config-base.invalid/v1",
+                "api_key": "reload-key",
+            }
+        },
+    )
+    # Resolver returns the BARE model id (slash prefix stripped) — exactly the
+    # shape that made `_session_model_identity_matches` report a false change.
+    monkeypatch.setattr(
+        config,
+        "resolve_model_provider",
+        lambda _model: ("deepseek-v4-1m", "deepseek", "https://runtime-base.invalid/v1"),
+    )
+
+    s = _stub_route_session(model="deepseek/deepseek-v4-1m")
+    handler = MagicMock()
+    parsed = urlparse("/api/session?session_id=test-4248-slash&messages=1")
+
+    with patch("api.routes.get_session", return_value=s), \
+         patch("api.routes.j", side_effect=fake_j), \
+         patch("api.routes._resolve_effective_session_model_for_display", return_value="deepseek/deepseek-v4-1m"), \
+         patch("api.routes._resolve_effective_session_model_provider_for_display", return_value="deepseek"), \
+         patch("api.routes._session_visible_to_active_profile", return_value=True), \
+         patch("api.routes._clear_stale_stream_state", return_value=None), \
+         patch("api.routes._session_requires_cli_metadata_lookup", return_value=False), \
+         patch("api.routes._is_messaging_session_record", return_value=False), \
+         patch("api.routes.get_state_db_session_messages", return_value=[]), \
+         patch("api.routes._webui_sidecar_lineage_messages_for_display", return_value=[]), \
+         patch("api.routes.merge_session_messages_append_only", return_value=[]), \
+         patch("api.routes._merged_webui_lineage_messages_for_display", return_value=[]), \
+         patch("api.routes._active_stream_ids", return_value=set()):
+        assert routes.handle_get(handler, parsed) is True
+
+    body = captured["data"]["session"]
+    assert captured["status"] == 200
+    assert body["context_length"] == 1_000_000, (
+        "a slash-qualified stored model resolving to its bare id is the SAME "
+        "model, so the 256k fallback must not clobber the persisted 1M window"
+    )
+    assert body["threshold_tokens"] == 500_000
+
+
+def test_session_model_identity_matches_slash_qualified_form():
+    """Unit: the identity check treats provider/model and bare-model as equal."""
+    import api.routes as routes
+
+    # slash-qualified stored vs bare resolved, same provider → same model
+    assert routes._session_model_identity_matches(
+        "deepseek/deepseek-v4-1m", "deepseek", "deepseek-v4-1m", "deepseek"
+    ) is True
+    # @provider:model form still resolves (no regression)
+    assert routes._session_model_identity_matches(
+        "@deepseek:deepseek-v4-1m", "deepseek", "deepseek-v4-1m", "deepseek"
+    ) is True
+    # different provider on the slash prefix → NOT the same model
+    assert routes._session_model_identity_matches(
+        "deepseek/deepseek-v4-1m", "deepseek", "deepseek-v4-1m", "openai"
+    ) is False
+    # genuinely different bare model → not a match
+    assert routes._session_model_identity_matches(
+        "deepseek/deepseek-v4-1m", "deepseek", "gpt-4o", "openai"
+    ) is False
+
+
 def test_session_reload_accepts_real_256k_when_effective_model_changes(monkeypatch):
     """#4248 follow-up: the 256k fallback guard must not block a real model switch."""
     import api.config as config

--- a/tests/test_issue3256_context_length_default_only_guard.py
+++ b/tests/test_issue3256_context_length_default_only_guard.py
@@ -14,22 +14,27 @@ the real agent metadata catalog.
 import sys
 import types
 from pathlib import Path as _Path
+from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 
-def _install_fake_get_model_context_length(monkeypatch, recorder):
+def _install_fake_get_model_context_length(monkeypatch, recorder, *, default_context=1_000_000):
     """Install a fake get_model_context_length into a stand-in agent.model_metadata."""
     mod = types.ModuleType("agent.model_metadata")
 
     def _fake(model, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
         recorder["model"] = model
+        recorder["base_url"] = base_url
         recorder["api_key"] = api_key
+        recorder["provider"] = provider
+        recorder["custom_providers"] = custom_providers
         recorder["config_context_length"] = config_context_length
         # Pretend the real per-model metadata window is 1,000,000 unless the
         # caller forced a config cap, in which case honor the cap (mirrors the
         # real helper's contract).
         if config_context_length:
             return int(config_context_length)
-        return 1_000_000
+        return default_context
 
     mod.get_model_context_length = _fake
     # Ensure a parent `agent` package exists so `from agent.model_metadata import ...` resolves.
@@ -163,6 +168,138 @@ def test_prefixed_default_still_receives_cap(monkeypatch):
         "provider-prefixed default model must still receive its configured cap"
     )
     assert result == 232000
+
+
+def test_resolver_uses_explicit_reload_base_url_and_api_key(monkeypatch):
+    """#4248: reload must query metadata with the same endpoint/key shape as streaming."""
+    import api.config as config
+
+    rec = {}
+    _install_fake_get_model_context_length(monkeypatch, rec)
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda *a, **k: {
+            "model": {
+                "provider": "deepseek",
+                "base_url": "https://config-base.invalid/v1",
+                "api_key": "config-key",
+            }
+        },
+    )
+
+    result = _resolver()(
+        "deepseek-v4-1m",
+        "deepseek",
+        base_url="https://runtime-base.invalid/v1",
+        api_key="runtime-key",
+    )
+
+    assert result == 1_000_000
+    assert rec["base_url"] == "https://runtime-base.invalid/v1"
+    assert rec["api_key"] == "runtime-key"
+    assert rec["provider"] == "deepseek"
+
+
+def _stub_route_session(*, context_length=1_000_000, threshold_tokens=500_000, model="deepseek-v4-1m"):
+    s = MagicMock()
+    s.session_id = "test-4248"
+    s.title = "test-session"
+    s.workspace = "/tmp"
+    s.model = model
+    s.model_provider = "deepseek"
+    s.profile = None
+    s.messages = []
+    s.tool_calls = []
+    s.active_stream_id = None
+    s.pending_user_message = None
+    s.pending_attachments = []
+    s.pending_started_at = None
+    s.context_length = context_length
+    s.threshold_tokens = threshold_tokens
+    s.last_prompt_tokens = 100_000
+    s.input_tokens = 100_000
+    s.output_tokens = 0
+    s.read_only = False
+    s._loaded_metadata_only = False
+    s.compact.return_value = {
+        "session_id": s.session_id,
+        "title": s.title,
+        "workspace": s.workspace,
+        "model": model,
+        "model_provider": "deepseek",
+        "message_count": 0,
+        "input_tokens": s.input_tokens,
+        "output_tokens": 0,
+        "context_length": context_length,
+        "threshold_tokens": threshold_tokens,
+        "last_prompt_tokens": s.last_prompt_tokens,
+    }
+    return s
+
+
+def test_session_reload_preserves_large_persisted_window_when_recompute_hits_256k_fallback(monkeypatch):
+    """#4248: full session reload must not snap a persisted 1M window back to 256k."""
+    import api.config as config
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_j(_handler, data, status=200):
+        captured["data"] = data
+        captured["status"] = status
+        return True
+
+    rec = {}
+    _install_fake_get_model_context_length(monkeypatch, rec, default_context=256_000)
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda *a, **k: {
+            "model": {
+                "provider": "deepseek",
+                "base_url": "https://config-base.invalid/v1",
+                "api_key": "reload-key",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        config,
+        "resolve_model_provider",
+        lambda _model: ("deepseek-v4-1m", "deepseek", "https://runtime-base.invalid/v1"),
+    )
+
+    s = _stub_route_session()
+    handler = MagicMock()
+    parsed = urlparse("/api/session?session_id=test-4248&messages=1")
+
+    with patch("api.routes.get_session", return_value=s), \
+         patch("api.routes.j", side_effect=fake_j), \
+         patch("api.routes._resolve_effective_session_model_for_display", return_value="deepseek-v4-1m"), \
+         patch("api.routes._resolve_effective_session_model_provider_for_display", return_value="deepseek"), \
+         patch("api.routes._session_visible_to_active_profile", return_value=True), \
+         patch("api.routes._clear_stale_stream_state", return_value=None), \
+         patch("api.routes._session_requires_cli_metadata_lookup", return_value=False), \
+         patch("api.routes._is_messaging_session_record", return_value=False), \
+         patch("api.routes.get_state_db_session_messages", return_value=[]), \
+         patch("api.routes._webui_sidecar_lineage_messages_for_display", return_value=[]), \
+         patch("api.routes.merge_session_messages_append_only", return_value=[]), \
+         patch("api.routes._merged_webui_lineage_messages_for_display", return_value=[]), \
+         patch("api.routes._active_stream_ids", return_value=set()):
+        assert routes.handle_get(handler, parsed) is True
+
+    body = captured["data"]["session"]
+    assert captured["status"] == 200
+    assert rec["base_url"] == "https://runtime-base.invalid/v1"
+    assert rec["api_key"] == "reload-key"
+    assert body["context_length"] == 1_000_000, (
+        "reload must keep the persisted 1M window instead of clobbering it "
+        "with the anonymous 256k fallback"
+    )
+    assert body["threshold_tokens"] == 500_000, (
+        "the existing threshold belongs to the preserved 1M window and must not "
+        "be cleared when the 256k recompute is rejected"
+    )
 
 
 # --- #3263 dual-gate MUST-FIX invariants (Codex regression gate, v0.51.192) ---


### PR DESCRIPTION
## Release v0.51.492 — Release RB (large context window preserved on session reload)

Ships **#4248 fix** (PR #4418 by @franksong2702) — preserve large model context window on session reload.

### The bug (#4248)
`GET /api/session` ran the context-length resolver **anonymously** (no base_url / api_key) on
reload, so a session on a large-context model (e.g. a 1M window) snapped back to the generic
256k fallback. Result: wrong context indicator + premature auto-compression after a reload.

### The fix (#4418)
- `_session_context_length_lookup_state` — aligns reload base_url/api_key with the streaming
  save path (config-dict + env reads only; no network/catalog rebuild; fail-safe).
- `_should_accept_session_context_length_refresh` — refuses a `resolved==256k` value clobbering
  a larger persisted window UNLESS the effective model genuinely changed.
- `_rescale_threshold_tokens_for_context_window` — preserves the compression ratio (master
  zeroed it).
- `_context_length_config_api_key_for_provider` — resolves the config/env API key.

### Release-gate fix (this stage, on top of #4418)
The Codex regression gate found that `_session_model_identity_matches` normalized only the
`@provider:model` form, **not** `provider/model` (slash). A session stored as
`deepseek/deepseek-v4-1m` resolving to bare `deepseek-v4-1m` was treated as a model change →
the 256k fallback bypassed the accept-guard for slash-qualified ids (the same #4248 bug surviving
on OpenRouter-style ids). Fixed by mirroring the slash-aware split already used by
`_model_matches_configured_default`, plus a route-level regression test + a unit test for the
slash shape (both verified RED on pre-fix code, GREEN with the fix).

### Gate
- **Codex regression gate:** SAFE TO SHIP (re-run after the slash fix — finding resolved).
- **Opus advisor:** SAFE TO SHIP.
- **Full pytest suite:** 9419 passed, 0 failed.
- Pure-backend change (`api/routes.py` + tests); no UI/security/concept surface.
- `browser-smoke` CI on #4418 was an infra timeout (10m exceeded) on a pure-backend PR, not a PR-caused failure.

Co-authored-by: franksong2702 <franksong2702@users.noreply.github.com>

Closes #4248
