### PR TITLE
Release v0.51.496 — RF (compact provider quota chip on narrow composer, #4419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.496] — 2026-06-18 — Release RF (compact provider quota chip on narrow composer)
+
+### Fixed
+
+- **The provider quota chip no longer gets truncated on a narrow composer (#4358).** The chip is now more compact (smaller height, padding, and gap, `max-width` 120px) and is hidden entirely on a very narrow composer where it would otherwise be clipped, matching how the context indicator already behaves at that width. Thanks @bergeouss.
+
 ## [v0.51.495] — 2026-06-18 — Release RE (suppress ERR_ABORTED console noise on SSE close)
 
 ### Fixed

--- a/static/style.css
+++ b/static/style.css
@@ -1934,7 +1934,7 @@
   .composer-model-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
   .composer-model-icon,.composer-model-chevron{display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;}
   .composer-model-select{position:absolute!important;left:-9999px!important;width:1px!important;height:1px!important;opacity:0!important;pointer-events:none!important;}
-  .provider-quota-chip{display:inline-flex;align-items:center;gap:6px;height:34px;max-width:150px;padding:7px 10px;border:1px solid var(--border2);border-radius:999px;background:rgba(34,197,94,.10);color:var(--text);font-size:11px;font-weight:650;line-height:1;white-space:nowrap;cursor:pointer;transition:background .12s,border-color .12s,color .12s;}
+  .provider-quota-chip{display:inline-flex;align-items:center;gap:4px;height:30px;max-width:120px;padding:5px 8px;border:1px solid var(--border2);border-radius:999px;background:rgba(34,197,94,.10);color:var(--text);font-size:11px;font-weight:650;line-height:1;white-space:nowrap;cursor:pointer;transition:background .12s,border-color .12s,color .12s;}
   .provider-quota-chip[hidden]{display:none!important;}
   .provider-quota-chip:hover{background:rgba(34,197,94,.16);border-color:rgba(34,197,94,.35);}
   .provider-quota-chip-dot{width:6px;height:6px;border-radius:999px;background:#22c55e;box-shadow:0 0 0 3px rgba(34,197,94,.12);flex:0 0 auto;}
@@ -2284,6 +2284,7 @@
     .composer-divider{display:none;}
     .ctx-indicator-wrap{display:none!important;}
     .ctx-indicator-wrap{display:none!important;}
+    .provider-quota-chip{display:none!important;}
   }
 
   @container composer-footer (max-width: 520px){


### PR DESCRIPTION
## Release v0.51.496 — Release RF (compact provider quota chip on narrow composer)

Ships **#4419** (bergeouss) — fix #4358 quota-chip truncation.

### The change (CSS-only, +2/-1 in static/style.css)
- `.provider-quota-chip` is more compact: height 34→30px, max-width 150→120px, gap 6→4, padding 7/10→5/8.
- Adds `.provider-quota-chip{display:none!important}` inside the `@container composer-footer (max-width: 700px)` narrow-composer query, so the chip hides at the width where it would otherwise be clipped — matching how `.ctx-indicator-wrap` already behaves there.

### Gate
- **Codex regression gate:** SAFE TO SHIP (confirmed the `display:none` is scoped inside the narrow-composer container query, not always-on; no selector collision).
- **Browser smoke gate:** CLEAN — /, /#settings, /#sessions loaded with zero console errors.
- **Full pytest suite:** 9444 passed, 0 failed.
- Pure CSS; no JS/backend/security surface.

Co-authored-by: bergeouss <bergeouss@users.noreply.github.com>

Closes #4419
Closes #4358
