### PR TITLE
fix(scroll): prevent stuck-scroll on long sessions with dense tool blocks

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -752,7 +752,7 @@ function _compensateScrollForMeasurementDelta(renderFn){
   const scrollTopBefore=container.scrollTop;
   renderFn();
   if(!anchorBefore) return;
-  if(scrollTopBefore<=0){
+  if(scrollTopBefore<1){
     const spacer=container.querySelector('[data-virtual-spacer="before"]');
     if(!spacer||parseFloat(spacer.style.height||'0')<=0) return;
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -752,6 +752,10 @@ function _compensateScrollForMeasurementDelta(renderFn){
   const scrollTopBefore=container.scrollTop;
   renderFn();
   if(!anchorBefore) return;
+  if(scrollTopBefore<=0){
+    const spacer=container.querySelector('[data-virtual-spacer="before"]');
+    if(!spacer||parseFloat(spacer.style.height||'0')<=0) return;
+  }
   const row=container.querySelector(`[data-msg-idx="${anchorBefore.rawIdx}"]`);
   if(!row) return;
   const containerRect=container.getBoundingClientRect();


### PR DESCRIPTION
## Problem

When scrolling up through a long virtualized transcript containing dense tool-call blocks (30+ consecutive tool calls), the scroll can get permanently stuck, preventing the user from reaching earlier messages. Disabling virtualization works around it.

Reported in Discord: sessions with 400+ messages are smooth until hitting a large tool block, then scroll gets stuck.

## Root cause

`_compensateScrollForMeasurementDelta` captures a viewport anchor before rendering, then adjusts `scrollTop` after to keep the anchor in place. When estimated heights are significantly larger than measured heights (common with tool_call rows at 400px default vs ~150px actual), a feedback loop forms at the scroll ceiling:

1. User scrolls up, `scrollTop` reaches 0
2. Virtual window recomputes with `start=0`, removing the top spacer
3. Anchor compensation calculates a positive delta (anchor moved down because spacer was removed) and pushes `scrollTop` back up
4. The positive `scrollTop` triggers the next render to re-add the top spacer
5. Repeat from step 1, the user can never scroll past this point

## Fix

When `scrollTopBefore` is already at the ceiling (≤ 0) and the render produced no top spacer (the virtual window correctly starts at row 0), skip anchor compensation entirely. The user is at the top of the transcript and should stay there.

```js
if(scrollTopBefore<=0){
  const spacer=container.querySelector('[data-virtual-spacer="before"]');
  if(!spacer||parseFloat(spacer.style.height||'0')<=0) return;
}
```

## Testing

Tested via CDP with a synthetic 535-message session (335 renderable rows, 5 dense tool blocks of 35-45 calls each):

- **Before fix**: scroll gets stuck at `firstRow=239`, `scrollTop=0`, `topPad=23562px` around step 45
- **After fix**: scroll reaches `firstRow=0` at step 64 with zero stuck events