### PR TITLE
fix(#4373): mark process wakeups as synthetic

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -440,6 +440,7 @@ def _clear_gateway_pending_state(session: Any, stream_id: str) -> None:
     session.pending_user_message = None
     session.pending_attachments = None
     session.pending_started_at = None
+    session.pending_user_source = None
     session.save()
 
 
@@ -713,6 +714,9 @@ def _run_gateway_chat_streaming(
             # role/content ordering instead of turn order.
             assistant_ts = now + 0.000001
             user_msg = {"role": "user", "content": str(msg_text or ""), "timestamp": now}
+            pending_source = getattr(s, "pending_user_source", None) or "webui"
+            if pending_source != "webui":
+                user_msg["_source"] = pending_source
             if attachments:
                 user_msg["attachments"] = list(attachments)
             assistant_msg = {"role": "assistant", "content": assistant_text, "timestamp": assistant_ts}
@@ -744,6 +748,7 @@ def _run_gateway_chat_streaming(
                     previous_context,
                     s.context_messages,
                     str(msg_text or ""),
+                    source=pending_source,
                 )
             except Exception:
                 logger.debug("Failed to merge gateway display transcript", exc_info=True)
@@ -760,6 +765,7 @@ def _run_gateway_chat_streaming(
             s.pending_user_message = None
             s.pending_attachments = None
             s.pending_started_at = None
+            s.pending_user_source = None
             s.workspace = str(workspace)
             s.model = model
             s.model_provider = model_provider

--- a/api/models.py
+++ b/api/models.py
@@ -1896,6 +1896,7 @@ def _apply_core_sync_or_error_marker(
             session.pending_user_message = None
             session.pending_attachments = []
             session.pending_started_at = None
+            session.pending_user_source = None
             session.save(touch_updated_at=touch_updated_at)
             logger.info(
                 "Session %s: cleared stale pending state for completed stream %s without error marker",
@@ -1922,6 +1923,7 @@ def _apply_core_sync_or_error_marker(
         session.pending_user_message = None
         session.pending_attachments = []
         session.pending_started_at = None
+        session.pending_user_source = None
         session.messages.append(
             _build_recovery_marker_with_retry_hook(
                 recovered_output=recovered_output,
@@ -1976,6 +1978,7 @@ def _apply_core_sync_or_error_marker(
             session.pending_user_message = None
             session.pending_attachments = []
             session.pending_started_at = None
+            session.pending_user_source = None
             if recovered_output:
                 session.messages.append(
                     _interrupted_recovery_marker(
@@ -2023,6 +2026,7 @@ def _apply_core_sync_or_error_marker(
     session.pending_user_message = None
     session.pending_attachments = []
     session.pending_started_at = None
+    session.pending_user_source = None
     session.messages.append(
         _build_recovery_marker_with_retry_hook(
             recovered_output=recovered_output,

--- a/api/models.py
+++ b/api/models.py
@@ -416,6 +416,9 @@ def _append_recovered_pending_turn(session, *, timestamp: int | None = None) -> 
         'timestamp': recovered_ts,
         '_recovered': True,
     }
+    pending_source = getattr(session, 'pending_user_source', None)
+    if pending_source and pending_source != 'webui':
+        recovered['_source'] = pending_source
     if session.pending_attachments:
         recovered['attachments'] = list(session.pending_attachments)
     session.messages.append(recovered)
@@ -621,6 +624,7 @@ class Session:
                  pending_user_message: str=None,
                  pending_attachments=None,
                  pending_started_at=None,
+                 pending_user_source: str=None,
                  context_messages=None,
                  compression_anchor_visible_idx=None,
                  compression_anchor_message_key=None,
@@ -668,6 +672,7 @@ class Session:
         self.pending_user_message = pending_user_message
         self.pending_attachments = pending_attachments or []
         self.pending_started_at = pending_started_at
+        self.pending_user_source = pending_user_source
         self.context_messages = context_messages if isinstance(context_messages, list) else []
         self.compression_anchor_visible_idx = compression_anchor_visible_idx
         self.compression_anchor_message_key = compression_anchor_message_key
@@ -743,7 +748,7 @@ class Session:
             'input_tokens', 'output_tokens', 'estimated_cost',
             'cache_read_tokens', 'cache_write_tokens',
             'personality', 'active_stream_id',
-            'pending_user_message', 'pending_attachments', 'pending_started_at',
+            'pending_user_message', 'pending_attachments', 'pending_started_at', 'pending_user_source',
             'compression_anchor_visible_idx', 'compression_anchor_message_key',
             'compression_anchor_summary', 'pre_compression_snapshot',
             'context_engine', 'compression_anchor_engine', 'compression_anchor_mode',

--- a/api/routes.py
+++ b/api/routes.py
@@ -13908,7 +13908,7 @@ def _handle_background(handler, body):
     return j(handler, {"task_id": task_id, "stream_id": stream_id, "session_id": bg.session_id})
 
 
-def _checkpoint_user_message_for_eager_session_save(s, msg: str, attachments, started_at: float | None) -> None:
+def _checkpoint_user_message_for_eager_session_save(s, msg: str, attachments, started_at: float | None, source: str = "webui") -> None:
     """Materialize the current user turn for eager first-turn persistence.
 
     The streaming thread still receives ``pending_user_message`` so existing
@@ -13926,6 +13926,8 @@ def _checkpoint_user_message_for_eager_session_save(s, msg: str, attachments, st
             if latest_text == msg_text:
                 return
     user_msg = {"role": "user", "content": msg}
+    if source and source != "webui":
+        user_msg["_source"] = source
     if isinstance(started_at, (int, float)) and started_at > 0:
         user_msg["timestamp"] = int(started_at)
     if attachments:
@@ -13963,6 +13965,7 @@ def _prepare_chat_start_session_for_stream(
     model_provider,
     stream_id: str,
     started_at: float | None = None,
+    source: str = "webui",
 ):
     """Persist chat-start state according to webui.session_save_mode.
 
@@ -13980,6 +13983,7 @@ def _prepare_chat_start_session_for_stream(
     s.pending_user_message = msg
     s.pending_attachments = attachments
     s.pending_started_at = started_at if started_at is not None else time.time()
+    s.pending_user_source = source
     current_title = getattr(s, "title", None)
     if _is_default_or_empty_session_title(current_title):
         provisional_title = _provisional_title_from_prompt(msg, current_title or "Untitled")
@@ -13991,6 +13995,7 @@ def _prepare_chat_start_session_for_stream(
             msg,
             attachments,
             s.pending_started_at,
+            source=source,
         )
     s.save()
 
@@ -14097,6 +14102,7 @@ def _start_chat_stream_for_session(
     normalized_model: bool = False,
     diag=None,
     goal_related: bool = False,
+    source: str = "webui",
 ):
     """Persist pending state, register an SSE channel, and start an agent turn."""
     attachments = attachments or []
@@ -14167,6 +14173,7 @@ def _start_chat_stream_for_session(
                     model=model,
                     model_provider=model_provider,
                     stream_id=stream_id,
+                    source=source,
                 )
                 break
         if needs_stale_cleanup:
@@ -14343,6 +14350,7 @@ def _start_run(
                 model_provider=request.provider or model_provider,
                 normalized_model=normalized_model,
                 diag=diag,
+                source=request.source or source,
             )
 
         def _legacy_adapter_factory():
@@ -14381,6 +14389,7 @@ def _start_run(
         model_provider=model_provider,
         normalized_model=normalized_model,
         diag=diag,
+        source=source,
     )
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -15008,6 +15008,7 @@ def _handle_chat_sync(handler, body):
             _previous_context_messages,
             _restore_display_reasoning_metadata(_previous_messages, _result_messages),
             msg,
+            source=getattr(s, "pending_user_source", None) or "webui",
         )
         # Only auto-generate title when still default; preserves user renames
         if s.title == "Untitled":

--- a/api/routes.py
+++ b/api/routes.py
@@ -2224,6 +2224,8 @@ def _clear_stale_stream_state(session) -> bool:
                     original_stub.pending_attachments = []
                 if hasattr(original_stub, "pending_started_at"):
                     original_stub.pending_started_at = None
+                if hasattr(original_stub, "pending_user_source"):
+                    original_stub.pending_user_source = None
             except Exception:
                 pass
             return False
@@ -2263,6 +2265,8 @@ def _clear_stale_stream_state(session) -> bool:
                             original_stub.pending_attachments = []
                         if hasattr(original_stub, "pending_started_at"):
                             original_stub.pending_started_at = None
+                        if hasattr(original_stub, "pending_user_source"):
+                            original_stub.pending_user_source = None
                     except Exception:
                         pass
                 return True
@@ -2276,6 +2280,8 @@ def _clear_stale_stream_state(session) -> bool:
             session.pending_attachments = []
         if hasattr(session, "pending_started_at"):
             session.pending_started_at = None
+        if hasattr(session, "pending_user_source"):
+            session.pending_user_source = None
         try:
             # Runtime cleanup is not user activity; do not bubble old sessions
             # to the top of the sidebar just because a stale stream flag was
@@ -2297,6 +2303,8 @@ def _clear_stale_stream_state(session) -> bool:
                 original_stub.pending_attachments = []
             if hasattr(original_stub, "pending_started_at"):
                 original_stub.pending_started_at = None
+            if hasattr(original_stub, "pending_user_source"):
+                original_stub.pending_user_source = None
         except Exception:
             pass
     return True
@@ -7713,6 +7721,7 @@ def handle_get(handler, parsed) -> bool:
                 "pending_user_message": getattr(s, "pending_user_message", None),
                 "pending_attachments": getattr(s, "pending_attachments", []) if load_messages else [],
                 "pending_started_at": getattr(s, "pending_started_at", None),
+                "pending_user_source": getattr(s, "pending_user_source", None),
                 "context_length": _persisted_cl,
                 "threshold_tokens": _threshold_tokens,
                 "last_prompt_tokens": getattr(s, "last_prompt_tokens", 0) or 0,
@@ -16800,6 +16809,7 @@ def _handle_session_compress(handler, body):
             s.pending_user_message = None
             s.pending_attachments = []
             s.pending_started_at = None
+            s.pending_user_source = None
             visible_after = visible_messages_for_anchor(compressed, auto_compression=False)
             s.compression_anchor_visible_idx = max(0, len(visible_after) - 1) if visible_after else None
             s.compression_anchor_message_key = _anchor_message_key(visible_after[-1]) if visible_after else None

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1174,6 +1174,7 @@ def _persist_cancelled_turn(session, *, message: str = 'Task cancelled.') -> Non
     session.pending_user_message = None
     session.pending_attachments = []
     session.pending_started_at = None
+    session.pending_user_source = None
     if not _session_has_cancel_marker(session):
         agent_name = _preferred_agent_display_name_for_session(session)
         session.messages.append({
@@ -1192,6 +1193,7 @@ def _cleanup_ephemeral_cancelled_turn(session) -> None:
     session.pending_user_message = None
     session.pending_attachments = []
     session.pending_started_at = None
+    session.pending_user_source = None
     try:
         import pathlib
         pathlib.Path(session.path).unlink(missing_ok=True)
@@ -3265,10 +3267,12 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
             saved_pending_user_message = getattr(s, 'pending_user_message', None)
             saved_pending_attachments = list(getattr(s, 'pending_attachments', []) or [])
             saved_pending_started_at = getattr(s, 'pending_started_at', None)
+            saved_pending_user_source = getattr(s, 'pending_user_source', None)
             s.active_stream_id = None
             s.pending_user_message = None
             s.pending_attachments = []
             s.pending_started_at = None
+            s.pending_user_source = None
             try:
                 # skip_index=False so the snapshot appears in _index.json with
                 # the pre_compression_snapshot marker. The sidebar projection
@@ -3287,6 +3291,7 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
                 s.pending_user_message = saved_pending_user_message
                 s.pending_attachments = saved_pending_attachments
                 s.pending_started_at = saved_pending_started_at
+                s.pending_user_source = saved_pending_user_source
             return
         # Existing file is already at least as complete as memory; stamp only
         # the snapshot marker so index/sidebar projection can hide it without
@@ -4366,7 +4371,7 @@ def _retire_truncation_watermark_after_commit(session) -> None:
         session.truncation_watermark = None
 
 
-def _merge_display_messages_after_agent_result(previous_display, previous_context, result_messages, msg_text):
+def _merge_display_messages_after_agent_result(previous_display, previous_context, result_messages, msg_text, source: str = "webui"):
     """Keep UI transcript durable while allowing model context to compact.
 
     If Hermes Agent returns a normal append-only history, append that delta to
@@ -4565,6 +4570,8 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
         # exchange and then clear the pending prompt. Materialize the current
         # turn at the transcript boundary before the assistant/tool response.
         current_user_msg = {'role': 'user', 'content': msg_text}
+        if source and source != 'webui':
+            current_user_msg['_source'] = source
         insert_at = 0
         while insert_at < len(candidates) and _is_context_compression_marker(candidates[insert_at]):
             insert_at += 1
@@ -4608,6 +4615,8 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
         ):
             display_msg = copy.deepcopy(msg)
             display_msg['content'] = msg_text
+            if source and source != 'webui':
+                display_msg['_source'] = source
         merged.append(copy.deepcopy(display_msg))
         if key is not None:
             seen.add(key)
@@ -7186,6 +7195,7 @@ def _run_agent_streaming(
                     _previous_context_messages,
                     _restore_display_reasoning_metadata(_previous_messages, _result_messages),
                     msg_text,
+                    source=getattr(s, 'pending_user_source', None) or 'webui',
                 )
                 _retire_truncation_watermark_after_commit(s)  # #3831
                 # Strip XML tool-call blocks from assistant message content.
@@ -7478,6 +7488,7 @@ def _run_agent_streaming(
                                     _previous_context_messages,
                                     _restore_reasoning_metadata(_previous_messages, _result_messages),
                                     msg_text,
+                                    source=getattr(s, 'pending_user_source', None) or 'webui',
                                 )
                                 _retire_truncation_watermark_after_commit(s)  # #3831
                                 # Skip the error block — jump directly to the
@@ -7533,6 +7544,7 @@ def _run_agent_streaming(
                         s.pending_user_message = None
                         s.pending_attachments = []
                         s.pending_started_at = None
+                        s.pending_user_source = None
                         try:
                             _snapshot_and_append_partial_on_error(s, stream_id)
                         except Exception:
@@ -7713,6 +7725,7 @@ def _run_agent_streaming(
                 s.pending_user_message = None
                 s.pending_attachments = []
                 s.pending_started_at = None
+                s.pending_user_source = None
                 # Tag the matching user message with attachment filenames for display on reload
                 # Only tag a user message whose content relates to this turn's text
                 # (msg_text is the full message including the [Attached files: ...] suffix)
@@ -8458,6 +8471,7 @@ def _run_agent_streaming(
                                     _previous_context_messages,
                                     _restore_reasoning_metadata(_previous_messages, _result_messages),
                                     msg_text,
+                                    source=getattr(s, 'pending_user_source', None) or 'webui',
                                 )
                                 _retire_truncation_watermark_after_commit(s)  # #3831
                                 s.save()
@@ -8508,6 +8522,7 @@ def _run_agent_streaming(
                 s.pending_user_message = None
                 s.pending_attachments = []
                 s.pending_started_at = None
+                s.pending_user_source = None
                 try:
                     _snapshot_and_append_partial_on_error(s, stream_id)
                 except Exception:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5008,6 +5008,9 @@ def _materialize_pending_user_turn_before_error(session) -> bool:
         'timestamp': recovered_ts,
         '_recovered': True,
     }
+    pending_source = getattr(session, 'pending_user_source', None)
+    if pending_source and pending_source != 'webui':
+        recovered['_source'] = pending_source
     pending_attachments = getattr(session, 'pending_attachments', None)
     if pending_attachments:
         recovered['attachments'] = list(pending_attachments)
@@ -8960,6 +8963,7 @@ def cancel_stream(stream_id: str) -> bool:
                 # the cleanup.
                 try:
                     _pending_user = getattr(_cs, 'pending_user_message', None)
+                    _pending_source = getattr(_cs, 'pending_user_source', None)
                     _pending_atts_raw = getattr(_cs, 'pending_attachments', None)
                     _pending_atts = list(_pending_atts_raw) if isinstance(_pending_atts_raw, (list, tuple)) else []
                     _pending_started = getattr(_cs, 'pending_started_at', None) or 0
@@ -8985,11 +8989,16 @@ def cancel_stream(stream_id: str) -> bool:
                                 if _pending_user == _last_content or _pending_user in _last_content:
                                     _already_persisted = True
                         if not _already_persisted:
+                            _recovered_ts = int(time.time())
+                            if isinstance(_pending_started, (int, float)) and _pending_started > 0:
+                                _recovered_ts = int(_pending_started)
                             _user_turn: dict = {
                                 'role': 'user',
                                 'content': _pending_user,
-                                'timestamp': int(time.time()),
+                                'timestamp': _recovered_ts,
                             }
+                            if _pending_source and _pending_source != 'webui':
+                                _user_turn['_source'] = _pending_source
                             if _pending_atts:
                                 _user_turn['attachments'] = _pending_atts
                             _msgs_for_recovery.append(_user_turn)
@@ -9002,6 +9011,7 @@ def cancel_stream(stream_id: str) -> bool:
                 _cs.pending_user_message = None
                 _cs.pending_attachments = []
                 _cs.pending_started_at = None
+                _cs.pending_user_source = None
                 # Persist any partial assistant text that was streamed before cancel (#893).
                 # Preserving partial content means the user sees what the agent had
                 # produced rather than losing it entirely.  The marker is _partial=True

--- a/static/ui.js
+++ b/static/ui.js
@@ -453,6 +453,7 @@ function _cancelMessageVirtualizedRender(){
 }
 function _messageIsRenderable(m){
   if(!m||!m.role||m.role==='tool') return false;
+  if(m._source === 'process_wakeup') return false;
   if(_isContextCompactionMessage(m)||_isPreservedCompressionTaskListMessage(m)) return false;
   if(_isRecoveryControlMessage(m)) return false;
   const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
@@ -7285,6 +7286,7 @@ function getPendingSessionMessage(session, messagesOverride=null){
     attachments:attachments.length?attachments:undefined,
     _ts:session?.pending_started_at||Date.now()/1000,
     _pending:true,
+    _source:session?.pending_user_source||undefined,
   };
 }
 async function checkInflightOnBoot(sid) {

--- a/tests/test_process_wakeup_synthetic.py
+++ b/tests/test_process_wakeup_synthetic.py
@@ -3,6 +3,7 @@
 import time
 from api.models import Session, _append_recovered_pending_turn
 from api.routes import _checkpoint_user_message_for_eager_session_save
+from api.streaming import _merge_display_messages_after_agent_result
 
 
 def test_append_recovered_pending_turn_stamps_process_wakeup_source():
@@ -116,3 +117,48 @@ def test_session_pending_user_source_persisted():
     # Reconstruct from dict
     s2 = Session(**s_dict)
     assert s2.pending_user_source == "process_wakeup"
+
+
+def test_merge_display_materializes_missing_process_wakeup_user_turn():
+    merged = _merge_display_messages_after_agent_result(
+        [],
+        [],
+        [{"role": "assistant", "content": "done"}],
+        "[IMPORTANT: Wakeup prompt]",
+        source="process_wakeup",
+    )
+
+    assert merged[0]["role"] == "user"
+    assert merged[0]["content"] == "[IMPORTANT: Wakeup prompt]"
+    assert merged[0]["_source"] == "process_wakeup"
+    assert merged[1]["role"] == "assistant"
+
+
+def test_merge_display_stamps_process_wakeup_source_on_echoed_user_turn():
+    merged = _merge_display_messages_after_agent_result(
+        [],
+        [],
+        [
+            {"role": "user", "content": "[IMPORTANT: Wakeup prompt]"},
+            {"role": "assistant", "content": "done"},
+        ],
+        "[IMPORTANT: Wakeup prompt]",
+        source="process_wakeup",
+    )
+
+    assert merged[0]["role"] == "user"
+    assert merged[0]["_source"] == "process_wakeup"
+    assert merged[1]["role"] == "assistant"
+
+
+def test_merge_display_leaves_webui_user_turn_unmarked():
+    merged = _merge_display_messages_after_agent_result(
+        [],
+        [],
+        [{"role": "assistant", "content": "done"}],
+        "Normal user message",
+        source="webui",
+    )
+
+    assert merged[0]["role"] == "user"
+    assert "_source" not in merged[0]

--- a/tests/test_process_wakeup_synthetic.py
+++ b/tests/test_process_wakeup_synthetic.py
@@ -1,0 +1,118 @@
+"""Test coverage for source field threading on process-wakeup synthetic turns."""
+
+import time
+from api.models import Session, _append_recovered_pending_turn
+from api.routes import _checkpoint_user_message_for_eager_session_save
+
+
+def test_append_recovered_pending_turn_stamps_process_wakeup_source():
+    """Verify _append_recovered_pending_turn stamps _source when pending_user_source is process_wakeup."""
+    s = Session(
+        session_id="test-session-1",
+        pending_user_message="[IMPORTANT: Process completed]",
+        pending_user_source="process_wakeup",
+    )
+    recovered = _append_recovered_pending_turn(s)
+    assert recovered is not None
+    assert recovered["role"] == "user"
+    assert recovered["content"] == "[IMPORTANT: Process completed]"
+    assert recovered["_source"] == "process_wakeup"
+    assert recovered["_recovered"] is True
+
+
+def test_append_recovered_pending_turn_skips_webui_source():
+    """Verify _append_recovered_pending_turn does NOT stamp _source when source is webui (default)."""
+    s = Session(
+        session_id="test-session-2",
+        pending_user_message="Normal user message",
+        pending_user_source="webui",
+    )
+    recovered = _append_recovered_pending_turn(s)
+    assert recovered is not None
+    assert recovered["role"] == "user"
+    assert recovered["content"] == "Normal user message"
+    assert "_source" not in recovered
+    assert recovered["_recovered"] is True
+
+
+def test_append_recovered_pending_turn_defaults_to_no_source():
+    """Verify _append_recovered_pending_turn does NOT stamp _source when pending_user_source is None."""
+    s = Session(
+        session_id="test-session-3",
+        pending_user_message="Another user message",
+        pending_user_source=None,
+    )
+    recovered = _append_recovered_pending_turn(s)
+    assert recovered is not None
+    assert recovered["role"] == "user"
+    assert "_source" not in recovered
+
+
+def test_checkpoint_user_message_stamps_process_wakeup_source():
+    """Verify eager-path checkpoint stamps _source on message dict when source is process_wakeup."""
+    s = Session(session_id="test-session-4")
+    s.messages = []
+    _checkpoint_user_message_for_eager_session_save(
+        s,
+        msg="[IMPORTANT: Wakeup prompt]",
+        attachments=[],
+        started_at=time.time(),
+        source="process_wakeup",
+    )
+    assert len(s.messages) == 1
+    user_msg = s.messages[0]
+    assert user_msg["role"] == "user"
+    assert user_msg["content"] == "[IMPORTANT: Wakeup prompt]"
+    assert user_msg["_source"] == "process_wakeup"
+
+
+def test_checkpoint_user_message_skips_webui_source():
+    """Verify eager-path checkpoint does NOT stamp _source when source is webui (default)."""
+    s = Session(session_id="test-session-5")
+    s.messages = []
+    _checkpoint_user_message_for_eager_session_save(
+        s,
+        msg="Normal user message",
+        attachments=[],
+        started_at=time.time(),
+        source="webui",
+    )
+    assert len(s.messages) == 1
+    user_msg = s.messages[0]
+    assert user_msg["role"] == "user"
+    assert user_msg["content"] == "Normal user message"
+    assert "_source" not in user_msg
+
+
+def test_checkpoint_user_message_defaults_to_no_source():
+    """Verify eager-path checkpoint does NOT stamp _source when source is omitted (defaults to webui)."""
+    s = Session(session_id="test-session-6")
+    s.messages = []
+    _checkpoint_user_message_for_eager_session_save(
+        s,
+        msg="Another user message",
+        attachments=[],
+        started_at=time.time(),
+    )
+    assert len(s.messages) == 1
+    user_msg = s.messages[0]
+    assert user_msg["role"] == "user"
+    assert user_msg["content"] == "Another user message"
+    assert "_source" not in user_msg
+
+
+def test_session_pending_user_source_persisted():
+    """Verify pending_user_source survives serialization and deserialization."""
+    s = Session(
+        session_id="test-session-7",
+        pending_user_message="Test message",
+        pending_user_source="process_wakeup",
+    )
+    s_dict = {k: getattr(s, k, None) for k in [
+        'session_id', 'pending_user_message', 'pending_user_source'
+    ]}
+    assert s_dict["pending_user_source"] == "process_wakeup"
+
+    # Reconstruct from dict
+    s2 = Session(**s_dict)
+    assert s2.pending_user_source == "process_wakeup"

--- a/tests/test_process_wakeup_synthetic.py
+++ b/tests/test_process_wakeup_synthetic.py
@@ -1,9 +1,11 @@
 """Test coverage for source field threading on process-wakeup synthetic turns."""
 
 import time
-from api.models import Session, _append_recovered_pending_turn
+from pathlib import Path
+
+from api.models import Session, _append_recovered_pending_turn, _apply_core_sync_or_error_marker
 from api.routes import _checkpoint_user_message_for_eager_session_save
-from api.streaming import _merge_display_messages_after_agent_result
+from api.streaming import _materialize_pending_user_turn_before_error, _merge_display_messages_after_agent_result
 
 
 def test_append_recovered_pending_turn_stamps_process_wakeup_source():
@@ -162,3 +164,29 @@ def test_merge_display_leaves_webui_user_turn_unmarked():
 
     assert merged[0]["role"] == "user"
     assert "_source" not in merged[0]
+
+
+def test_materialize_pending_user_turn_before_error_stamps_process_wakeup_source():
+    s = Session(
+        session_id="test-session-8",
+        pending_user_message="[IMPORTANT: Wakeup prompt]",
+        pending_user_source="process_wakeup",
+    )
+    s.messages = []
+
+    assert _materialize_pending_user_turn_before_error(s) is True
+    assert s.messages[0]["_source"] == "process_wakeup"
+
+
+def test_apply_core_sync_or_error_marker_clears_pending_user_source(tmp_path):
+    s = Session(
+        session_id="test-session-9",
+        pending_user_message="[IMPORTANT: Wakeup prompt]",
+        pending_user_source="process_wakeup",
+    )
+    s.messages = [{"role": "assistant", "content": "done"}]
+    s.pending_started_at = time.time()
+    s.save = lambda *args, **kwargs: None
+
+    assert _apply_core_sync_or_error_marker(s, Path(tmp_path / "missing-core.json")) is True
+    assert s.pending_user_source is None

--- a/tests/test_sprint51.py
+++ b/tests/test_sprint51.py
@@ -86,6 +86,8 @@ class TestCancelStreamEagerRelease:
         mock_session.pending_user_message = "hello"
         mock_session.pending_attachments = ["file.txt"]
         mock_session.pending_started_at = 1234567890.0
+        mock_session.pending_user_source = "process_wakeup"
+        mock_session.messages = []
 
         STREAMS[stream_id] = queue.Queue()
         CANCEL_FLAGS[stream_id] = threading.Event()
@@ -102,6 +104,14 @@ class TestCancelStreamEagerRelease:
             "cancel_stream() should clear session.pending_attachments"
         assert mock_session.pending_started_at is None, \
             "cancel_stream() should clear session.pending_started_at"
+        assert mock_session.pending_user_source is None, \
+            "cancel_stream() should clear session.pending_user_source"
+        assert any(
+            isinstance(msg, dict)
+            and msg.get("role") == "user"
+            and msg.get("_source") == "process_wakeup"
+            for msg in mock_session.messages
+        ), "cancel_stream() should preserve process_wakeup source on recovered user turns"
         mock_session.save.assert_called_once()
 
     def test_cancel_without_agent_still_pops_streams(self):


### PR DESCRIPTION
## Thinking Path

- The branch already preserved `pending_user_source` through chat start and hid the live pending stub, but the settled transcript merge still rebuilt the current user turn without `_source`.
- That meant the fix held only during the pending window. As soon as the turn completed, the synthetic wakeup prompt was materialized as an ordinary user row and became visible again on reload.
- The right follow-up is to thread the same source through the final merge helper, reuse it on the gateway-backed settle path, and clear `pending_user_source` anywhere pending turn state is torn down.

## What Changed

- `api/streaming.py`: `_merge_display_messages_after_agent_result()` now accepts `source`, stamps `_source` on inserted or normalized current-user rows when the source is synthetic, and all settled merge call sites now pass `pending_user_source`; pending teardown paths also clear `pending_user_source` alongside the other pending fields.
- `api/gateway_chat.py`: gateway-backed completion now stamps the settled `user_msg` with the pending source, passes that source through the same merge helper, and clears `pending_user_source` when pending gateway state is torn down.
- `api/routes.py`: the direct transcript merge path also threads `pending_user_source` so every visible-merge surface uses the same settled-turn contract.
- `tests/test_process_wakeup_synthetic.py`: added settled-path regressions for both the inserted-user-turn and echoed-user-turn cases, plus the normal `webui` control case.

## Why It Matters

Process wakeup prompts now stay hidden after the turn settles, not just while the turn is pending. The same source distinction also survives the gateway-backed completion path, so synthetic wakeups do not reappear as normal user bubbles after reload.

## Verification

- `pytest tests/test_process_wakeup_synthetic.py tests/test_wakeup_model_resolve_hang.py -v --timeout=60`

## Risks / Follow-ups

- The wakeup prompt still exists in stored transcript data with `_source="process_wakeup"`; this is intentional because the agent needs the prompt and the UI now has the metadata to suppress it.
- Any future transcript-finalization path that bypasses `_merge_display_messages_after_agent_result()` will need to thread source explicitly too; the current settled merge call sites are covered in this PR.

## Upstream

Closes #4373.

## Model Used

GPT-5 via Codex CLI
