### PR TITLE
Release v0.51.500 — RJ (fix stuck-scroll on long sessions with dense tool blocks, #4434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.500] — 2026-06-18 — Release RJ (fix stuck-scroll on long sessions with dense tool blocks)
+
+### Fixed
+
+- **Scrolling up through a long virtualized transcript with dense tool-call blocks no longer gets stuck (#4346 family).** `_compensateScrollForMeasurementDelta` captures a viewport anchor before a re-render and adjusts `scrollTop` to keep it in place, but when estimated row heights run much larger than measured ones (tool-call rows default to ~400px vs ~150px actual), the correction could form a feedback loop that trapped the user near the top of a 400+ message session. The compensation now short-circuits when the user is already at the scroll ceiling (`scrollTop < 1`) with no preceding virtual spacer, breaking the loop. Thanks @rodboev.
+
 ## [v0.51.498] — 2026-06-18 — Release RH (profile runtime env no longer clobbers core shell identity)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -752,7 +752,7 @@ function _compensateScrollForMeasurementDelta(renderFn){
   const scrollTopBefore=container.scrollTop;
   renderFn();
   if(!anchorBefore) return;
-  if(scrollTopBefore<=0){
+  if(scrollTopBefore<1){
     const spacer=container.querySelector('[data-virtual-spacer="before"]');
     if(!spacer||parseFloat(spacer.style.height||'0')<=0) return;
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -752,6 +752,10 @@ function _compensateScrollForMeasurementDelta(renderFn){
   const scrollTopBefore=container.scrollTop;
   renderFn();
   if(!anchorBefore) return;
+  if(scrollTopBefore<=0){
+    const spacer=container.querySelector('[data-virtual-spacer="before"]');
+    if(!spacer||parseFloat(spacer.style.height||'0')<=0) return;
+  }
   const row=container.querySelector(`[data-msg-idx="${anchorBefore.rawIdx}"]`);
   if(!row) return;
   const containerRect=container.getBoundingClientRect();


### PR DESCRIPTION
## Release v0.51.500 — Release RJ (fix stuck-scroll on long sessions with dense tool blocks)

Ships **#4434** (rodboev, T1) — fixes a virtualized-transcript scroll trap reported in Discord.

### The bug (#4346 family)
On a 400+ message session, scrolling up was smooth until hitting a dense tool-call block (30+
consecutive tool calls), then scroll got permanently stuck — disabling virtualization worked
around it. `_compensateScrollForMeasurementDelta` captures a viewport anchor before a re-render
and adjusts `scrollTop` after to keep it in place; when estimated heights run much larger than
measured (tool_call rows default ~400px vs ~150px actual), the correction forms a feedback loop.

### The fix (+4 lines, `static/ui.js`)
Short-circuit the compensation when the user is already at the scroll ceiling (`scrollTop < 1`)
**and** there's no positive-height leading virtual spacer (`data-virtual-spacer="before"`, i.e.
`topPad` = nothing virtualized above the view). That's exactly the genuine-ceiling case where the
loop forms, and breaking it there is safe; the normal (scrolled, or content-above) compensation
path is byte-for-byte unchanged.

### Gate
- **Codex regression gate:** SAFE TO SHIP.
- **Opus advisor:** SAFE TO SHIP — verified the `data-virtual-spacer="before"` selector is real
  (emitted at ui.js:10107 with `topPad`), the skip is correctly gated (only fires when there's
  genuinely nothing above the view — content-above with `topPad>0` still compensates), the normal
  path is untouched, and the sub-pixel `<1` band is safe (only matters combined with `topPad<=0`).
- **Browser smoke gate:** CLEAN — /, /#settings, /#sessions, zero console errors.
- **Full pytest suite:** 9452 passed, 0 failed.
- Front-end only; scroll-timing surface, reviewed carefully per the virtualization-PR rule.

Co-authored-by: rodboev <rodboev@users.noreply.github.com>

Closes #4434
