### PR TITLE
frontend: subpath-safe fetch() in /model command

### DIFF
--- a/static/commands.js
+++ b/static/commands.js
@@ -547,7 +547,7 @@ async function cmdModel(args){
   // CLI resolves against the full catalog, so /model must too. (#3368)
   let modelsData=null;
   try {
-    const resp=await fetch('/api/models');
+    const resp=await fetch(new URL('api/models',document.baseURI||location.href).href);
     if(resp.ok){
       modelsData=await resp.json();
       const aliases=modelsData.aliases||{};
@@ -587,7 +587,7 @@ async function cmdModel(args){
     if(!match && !versionedNoSnap && S&&S.session&&S.session.session_id){
       const provider=q.slice(0,q.indexOf('/'));
       try{
-        const resp=await fetch('/api/session/update',{
+        const resp=await fetch(new URL('api/session/update',document.baseURI||location.href).href,{
           method:'POST',
           headers:{'Content-Type':'application/json'},
           body:JSON.stringify({


### PR DESCRIPTION
cmdModel() had the only two root-absolute fetch('/api/...') calls left in the frontend. Under a reverse proxy that mounts the app at a subpath (e.g. jupyter-server-proxy at /proxy/<port>/), a root-absolute path escapes the mount and 404s, so /model can't load the catalog or update the session. Resolve both against document.baseURI (falling back to location.href) like every other fetch in the frontend already does.