### PR TITLE
paths: default WebUI state to $HERMES_HOME/webui; allow HERMES_WEBUI_…

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Full list of environment variables:
 | `HERMES_WEBUI_PORT` | `8787` | Port |
 | `HERMES_WEBUI_STATE_DIR` | `$HERMES_HOME/webui` (Windows default `%LOCALAPPDATA%\hermes\webui`, POSIX default `~/.hermes/webui`) | Where sessions and state are stored |
 | `HERMES_WEBUI_DEFAULT_WORKSPACE` | `~/workspace` | Default workspace |
+| `HERMES_WEBUI_SERVER_CWD` | *(unset)* | Working directory for the server process. Defaults to the agent dir; point it at a writable workspace when the agent dir is read-only (e.g. container images) so relative file writes from `execute_code` land somewhere writable |
 | `HERMES_WEBUI_DEFAULT_MODEL` | *(provider default)* | Optional model override; leave unset to use the active Hermes provider default |
 | `HERMES_WEBUI_PASSWORD` | *(unset)* | Set to enable password authentication |
 | `HERMES_WEBUI_CSP_CONNECT_EXTRA` | *(unset)* | Optional space-separated `http(s)://` or `ws(s)://` origins to append to the report-only CSP `connect-src` directive for reverse-proxy or tunnel deployments |

--- a/api/config.py
+++ b/api/config.py
@@ -71,8 +71,12 @@ TLS_ENABLED = TLS_CERT is not None and TLS_KEY is not None
 # ── State directory (env-overridable, never inside repo) ──────────────────────
 _DEFAULT_HERMES_HOME = _platform_default_hermes_home()
 
+# WebUI state defaults to $HERMES_HOME/webui (the README-documented default) so it
+# sits alongside the agent's home when HERMES_HOME is set; HERMES_WEBUI_STATE_DIR
+# still overrides, and the platform default applies when neither is set.
+_DEFAULT_STATE_HOME = Path(os.getenv("HERMES_HOME") or _DEFAULT_HERMES_HOME).expanduser()
 STATE_DIR = (
-    Path(os.getenv("HERMES_WEBUI_STATE_DIR", str(_DEFAULT_HERMES_HOME / "webui")))
+    Path(os.getenv("HERMES_WEBUI_STATE_DIR", str(_DEFAULT_STATE_HOME / "webui")))
     .expanduser()
     .resolve()
 )

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -494,7 +494,8 @@ def main() -> int:
 
     python_exe = ensure_python_has_webui_deps(discover_launcher_python(agent_dir), agent_dir)
     state_dir = Path(
-        os.getenv("HERMES_WEBUI_STATE_DIR", str(Path.home() / ".hermes" / "webui"))
+        os.getenv("HERMES_WEBUI_STATE_DIR")
+        or Path(os.getenv("HERMES_HOME") or (Path.home() / ".hermes")) / "webui"
     ).expanduser()
     state_dir.mkdir(parents=True, exist_ok=True)
 
@@ -505,7 +506,13 @@ def main() -> int:
     if agent_dir:
         os.environ["HERMES_WEBUI_AGENT_DIR"] = str(agent_dir)
 
-    server_cwd = str(agent_dir or REPO_ROOT)
+    # The agent is a CLI tool that runs fine from any directory; default to the
+    # agent dir but allow an explicit override. In containerized deployments the
+    # agent dir is read-only, and execute_code's project-mode cwd falls back to
+    # os.getcwd() when a turn hasn't set TERMINAL_CWD yet — landing relative file
+    # writes (plt.savefig("x.png")) in a read-only dir. Point the server cwd at a
+    # writable workspace so that fallback is always writable.
+    server_cwd = os.environ.get("HERMES_WEBUI_SERVER_CWD", "").strip() or str(agent_dir or REPO_ROOT)
     server_path = str(REPO_ROOT / "server.py")
     # Scheme the server will advertise (HTTPS when TLS cert+key are configured).
     scheme = "https" if _tls_probe_enabled() else "http"


### PR DESCRIPTION
…SERVER_CWD

Two related path-resolution fixes for containerized / non-default-home deploys:

- State directory: bootstrap's state_dir and config's STATE_DIR fell back to the platform default even when HERMES_HOME was set, so WebUI state could land in a different home than the agent's. Default both to $HERMES_HOME/webui (the README-documented default) when HERMES_HOME is set; HERMES_WEBUI_STATE_DIR still overrides, and the platform default applies when neither is set. Scoped to STATE_DIR only — _DEFAULT_HERMES_HOME (auth.json/.env/skills resolution) is left unchanged.

- Server cwd: bootstrap hard-chdir'd into the agent dir, which is read-only in container images. execute_code's project-mode cwd falls back to os.getcwd() when a turn hasn't set TERMINAL_CWD yet, landing relative file writes (plt.savefig("x.png")) in that read-only dir. Honor HERMES_WEBUI_SERVER_CWD so a deployment can point the server cwd at a writable workspace.

Both default to the previous behavior when the env vars are unset.