### PR TITLE
Release v0.51.508 — RS (/model command works under reverse-proxy subpath, #4448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.508] — 2026-06-19 — Release RS (the /model command works under a reverse-proxy subpath)
+
+### Fixed
+
+- **The `/model` slash command now works when the WebUI is served under a subpath (#3368 follow-up).** Its two API calls (`/api/models` and `/api/session/update`) used root-absolute paths that broke behind a reverse proxy mounting the app under a subpath; they now resolve relative to `document.baseURI`, matching how the rest of the app builds API URLs. Thanks @tomtong2015.
+
 ## [v0.51.507] — 2026-06-19 — Release RR (jump-to-question button stays usable on mobile)
 
 ### Fixed

--- a/static/commands.js
+++ b/static/commands.js
@@ -547,7 +547,7 @@ async function cmdModel(args){
   // CLI resolves against the full catalog, so /model must too. (#3368)
   let modelsData=null;
   try {
-    const resp=await fetch('/api/models');
+    const resp=await fetch(new URL('api/models',document.baseURI||location.href).href);
     if(resp.ok){
       modelsData=await resp.json();
       const aliases=modelsData.aliases||{};
@@ -587,7 +587,7 @@ async function cmdModel(args){
     if(!match && !versionedNoSnap && S&&S.session&&S.session.session_id){
       const provider=q.slice(0,q.indexOf('/'));
       try{
-        const resp=await fetch('/api/session/update',{
+        const resp=await fetch(new URL('api/session/update',document.baseURI||location.href).href,{
           method:'POST',
           headers:{'Content-Type':'application/json'},
           body:JSON.stringify({


### PR DESCRIPTION
Ships **#4448** (tomtong2015). The `/model` command's two API calls used root-absolute paths (`/api/models`, `/api/session/update`) that break behind a reverse proxy mounting the WebUI under a subpath. Now they resolve via `new URL('api/...', document.baseURI||location.href)` — the established app convention (boot.js, messages.js:8 helper).

- **Codex:** SAFE TO SHIP (relative resolution correct at root + subpath; POST method/headers/body intact; consistent with the rest of the app).
- **Full suite:** 9532 passed.
- 0 bare `/api` fetches remain in commands.js.

Co-authored-by: tomtong2015 <tomtong2015@users.noreply.github.com>

Closes #4448