### PR TITLE
fix(scroll): render virtual window during programmatic scrolls

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -3657,6 +3657,7 @@ if(typeof window!=='undefined'){
   if(!el) return;
   let _scrollRaf=0;
   el.addEventListener('scroll',()=>{
+    _scheduleMessageVirtualizedRender();
     if(_programmaticScroll) return; // ignore scrolls we triggered ourselves
     _markMessageVirtualScrollActive();
     cancelAnimationFrame(_scrollRaf);
@@ -3693,7 +3694,6 @@ if(typeof window!=='undefined'){
       const showBottomButton=!_scrollPinned && el.scrollHeight-top-el.clientHeight>80;
       _syncScrollToBottomCue(showBottomButton,{newMessage:_newMessageCueVisible});
       if(typeof _updateSessionStartJumpButton==='function') _updateSessionStartJumpButton();
-      _scheduleMessageVirtualizedRender();
       // Prefetch older messages before the reader hits the hard top. Prepending
       // then preserving scrollTop is seamless only if there is runway left for
       // the user's continued upward wheel/touch movement.


### PR DESCRIPTION
## Summary

Fixes the scroll-down blank reported on Discord after #4434 landed:

> so the getting stuck seems fixed, will test a few more large sessions, but I do notice when scrolling back down (after scrolling up a bunch), it starts not displaying text on the way down

### Reproduction

Injected a 400+ message session with dense tool blocks (35–45 consecutive tool calls each) via CDP, enabled virtualization, scrolled to the top, then scrolled back down. Instrumented `_messageVirtualWindow` and the DOM to compare the computed virtual window against the actual spacer/row state on each scroll step.

The virtual window computes correctly (start and topPad advance as scrollTop increases), but the DOM never updates — the spacer height and firstRow stay frozen:

```
step 0:  scrollTop=300   computed topPad=0     actual spacer=3760  firstRow=27
step 9:  scrollTop=3280  computed topPad=2080  actual spacer=3760  firstRow=27
step 18: scrollTop=5700  computed topPad=4761  actual spacer=3760  firstRow=27
```

Further instrumentation revealed `_programmaticScroll` is stuck at `true` after the scroll-up phase settles. The scroll handler's `if(_programmaticScroll) return` guard (line 3660) silently drops every scroll event, so `_scheduleMessageVirtualizedRender()` never fires and the DOM freezes.

The flag gets stuck because `_compensateScrollForMeasurementDelta` sets `_programmaticScroll=true` and clears it via `rAF→setTimeout`. During rapid measurement refresh cycles at the scroll ceiling (measurement → re-render → measurement, capped at `MESSAGE_VIRTUAL_MEASUREMENT_MAX_RERENDERS=2`), each cycle sets the flag before the previous cleanup fires. The last cleanup races with the next measurement rAF, leaving the flag permanently set.

### Fix

Moves `_scheduleMessageVirtualizedRender()` before the `_programmaticScroll` guard in the scroll event handler. The virtual window always updates regardless of scroll origin. The guard still protects pin/unpin state tracking (its intended purpose) — only the render scheduling moves above it.

## Test plan

- [x] Scroll up through 400+ message session with dense tool blocks → reach top
- [x] Scroll back down → text renders at every scroll position (zero blank viewports, down from 13)
- [x] Verified across real CLI sessions (96–256 messages, up to 92 tool blocks)
- [x] `test_issue500_message_list_virtualization.py` — 29/29 pass