### PR TITLE
Release v0.51.511 — RV (virtual transcript renders during programmatic scrolls, #4468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.511] — 2026-06-19 — Release RV (virtual transcript renders during programmatic scrolls)
+
+### Fixed
+
+- **Scrolling back down through a long virtualized transcript no longer leaves blank gaps (#4346 family; regression from #4434/v0.51.500).** The message virtual-window render was scheduled behind the scroll handler's `_programmaticScroll` guard, so when the measurement-compensation path adjusted `scrollTop` and briefly left that flag set, scroll events were dropped and the DOM froze (spacer + first row stuck while the computed window advanced). The virtual-window render now always fires on scroll; the guard still suppresses the pin/cue/prefetch bookkeeping that genuinely shouldn't react to programmatic scrolls. Thanks @rodboev.
+
 ## [v0.51.510] — 2026-06-19 — Release RU (Kanban task workspace + dependency controls)
 
 ### Added

--- a/static/ui.js
+++ b/static/ui.js
@@ -3657,6 +3657,7 @@ if(typeof window!=='undefined'){
   if(!el) return;
   let _scrollRaf=0;
   el.addEventListener('scroll',()=>{
+    _scheduleMessageVirtualizedRender();
     if(_programmaticScroll) return; // ignore scrolls we triggered ourselves
     _markMessageVirtualScrollActive();
     cancelAnimationFrame(_scrollRaf);
@@ -3693,7 +3694,6 @@ if(typeof window!=='undefined'){
       const showBottomButton=!_scrollPinned && el.scrollHeight-top-el.clientHeight>80;
       _syncScrollToBottomCue(showBottomButton,{newMessage:_newMessageCueVisible});
       if(typeof _updateSessionStartJumpButton==='function') _updateSessionStartJumpButton();
-      _scheduleMessageVirtualizedRender();
       // Prefetch older messages before the reader hits the hard top. Prepending
       // then preserving scrollTop is seamless only if there is runway left for
       // the user's continued upward wheel/touch movement.


### PR DESCRIPTION
Ships **#4468** (rodboev) — fixes a virtualization regression from #4434 (v0.51.500): scrolling back down through a long transcript left blank gaps because the virtual-window render was scheduled behind the `_programmaticScroll` guard (which the measurement-compensation path briefly leaves set).

The +1/-1 change moves `_scheduleMessageVirtualizedRender()` ahead of the guard so the window always re-renders on scroll; the guard still suppresses pin/cue/prefetch bookkeeping that shouldn't react to programmatic scrolls.

### Author sign-off
@rodboev gave explicit "Good to merge" and a reasoned defense: the stuck flag is transient (measurement loop capped at 2 rerenders, clears always fire), so this is the actual fix, not a mask — the guard is correct for the bookkeeping still behind it.

### Gate (on the identical diff)
- **Codex SAFE TO SHIP** + **Opus SAFE TO SHIP** — verified the window-key self-guard breaks any render→scroll→render cycle, the reorder is inert, no #4434 regression.
- **Browser-smoke:** clean. **Full suite:** 9539 passed (re-running on current master to confirm post-#4453).
- Held for author go-ahead per the message-virtualization-series review convention; now given.

Co-authored-by: rodboev <rodboev@users.noreply.github.com>

Closes #4468