### PR TITLE
fix(#4346): suppress footer jitter during virtual scroll measurement re-renders

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2639,6 +2639,8 @@
 /* ── Message action buttons (copy, edit, retry) ── */
 .msg-actions{display:flex;align-items:center;gap:2px;opacity:0;transition:opacity .15s;margin-left:auto;}
 .msg-row:hover .msg-actions{opacity:1;}
+.vscroll-measuring .msg-foot,
+.vscroll-measuring .msg-actions{transition:none !important;}
 .msg-action-btn{background:none;border:none;color:var(--muted);cursor:pointer;font-size:13px;padding:2px 5px;border-radius:5px;transition:color .12s,background .12s;line-height:1;}
 .msg-action-btn:hover{color:var(--accent-text);background:var(--accent-bg);}
 .selected-text-reply-btn{position:fixed;z-index:1200;display:inline-flex;align-items:center;gap:6px;padding:7px 11px;border:2px solid var(--accent);border-radius:999px;background:var(--bg);color:var(--text);box-shadow:0 8px 24px rgba(0,0,0,.26),0 0 0 1px var(--surface);font-size:12px;font-weight:700;line-height:1;cursor:pointer;opacity:0;pointer-events:none;transform:translateY(4px);transition:opacity .12s ease,transform .12s ease,background .12s ease,border-color .12s ease;user-select:none;}

--- a/static/style.css
+++ b/static/style.css
@@ -2639,6 +2639,7 @@
 /* ── Message action buttons (copy, edit, retry) ── */
 .msg-actions{display:flex;align-items:center;gap:2px;opacity:0;transition:opacity .15s;margin-left:auto;}
 .msg-row:hover .msg-actions{opacity:1;}
+/* Keep !important so this beats equal-specificity .msg-foot-with-usage fades during measurement rerenders. */
 .vscroll-measuring .msg-foot,
 .vscroll-measuring .msg-actions,
 .vscroll-measuring .msg-time{transition:none !important;}

--- a/static/style.css
+++ b/static/style.css
@@ -2640,7 +2640,8 @@
 .msg-actions{display:flex;align-items:center;gap:2px;opacity:0;transition:opacity .15s;margin-left:auto;}
 .msg-row:hover .msg-actions{opacity:1;}
 .vscroll-measuring .msg-foot,
-.vscroll-measuring .msg-actions{transition:none !important;}
+.vscroll-measuring .msg-actions,
+.vscroll-measuring .msg-time{transition:none !important;}
 .msg-action-btn{background:none;border:none;color:var(--muted);cursor:pointer;font-size:13px;padding:2px 5px;border-radius:5px;transition:color .12s,background .12s;line-height:1;}
 .msg-action-btn:hover{color:var(--accent-text);background:var(--accent-bg);}
 .selected-text-reply-btn{position:fixed;z-index:1200;display:inline-flex;align-items:center;gap:6px;padding:7px 11px;border:2px solid var(--accent);border-radius:999px;background:var(--bg);color:var(--text);box-shadow:0 8px 24px rgba(0,0,0,.26),0 0 0 1px var(--surface);font-size:12px;font-weight:700;line-height:1;cursor:pointer;opacity:0;pointer-events:none;transform:translateY(4px);transition:opacity .12s ease,transform .12s ease,background .12s ease,border-color .12s ease;user-select:none;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -751,7 +751,8 @@ function _compensateScrollForMeasurementDelta(renderFn){
   if(!container) return renderFn();
   const anchorBefore=_captureMessageViewportAnchor();
   const scrollTopBefore=container.scrollTop;
-  renderFn();
+  container.classList.add('vscroll-measuring');
+  try{ renderFn(); }finally{ container.classList.remove('vscroll-measuring'); }
   if(!anchorBefore) return;
   if(scrollTopBefore<1){
     const spacer=container.querySelector('[data-virtual-spacer="before"]');

--- a/tests/test_issue4346_vscroll_footer_jitter.py
+++ b/tests/test_issue4346_vscroll_footer_jitter.py
@@ -12,18 +12,14 @@ def test_css_vscroll_measuring_guard():
     """style.css suppresses opacity transitions on .msg-foot and .msg-actions
     while .vscroll-measuring is present on the scroll container."""
     assert 'vscroll-measuring' in CSS
-    assert re.search(
-        r'\.vscroll-measuring\s+\.msg-foot.*transition\s*:\s*none\s*!important',
-        CSS, re.DOTALL
-    ), "missing transition:none !important for .vscroll-measuring .msg-foot"
-    assert re.search(
-        r'\.vscroll-measuring\s+\.msg-actions.*transition\s*:\s*none\s*!important',
-        CSS, re.DOTALL
-    ), "missing transition:none !important for .vscroll-measuring .msg-actions"
-    assert re.search(
-        r'\.vscroll-measuring\s+\.msg-time.*transition\s*:\s*none\s*!important',
-        CSS, re.DOTALL
-    ), "missing transition:none !important for .vscroll-measuring .msg-time"
+    guard_match = re.search(
+        r'(?m)^\.vscroll-measuring\s+\.msg-foot,\n'
+        r'^\.vscroll-measuring\s+\.msg-actions,\n'
+        r'^\.vscroll-measuring\s+\.msg-time\{transition:none !important;\}$',
+        CSS,
+    )
+    assert guard_match, \
+        "missing contiguous .vscroll-measuring transition:none !important guard block"
 
 
 def test_js_compensate_adds_vscroll_measuring():

--- a/tests/test_issue4346_vscroll_footer_jitter.py
+++ b/tests/test_issue4346_vscroll_footer_jitter.py
@@ -1,0 +1,50 @@
+"""Static source assertions for issue #4346 virtual-scroll footer jitter fix."""
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).parent.parent
+
+CSS = (ROOT / 'static' / 'style.css').read_text(encoding='utf-8')
+JS  = (ROOT / 'static' / 'ui.js').read_text(encoding='utf-8')
+
+
+def test_css_vscroll_measuring_guard():
+    """style.css suppresses opacity transitions on .msg-foot and .msg-actions
+    while .vscroll-measuring is present on the scroll container."""
+    assert 'vscroll-measuring' in CSS
+    assert re.search(
+        r'\.vscroll-measuring\s+\.msg-foot.*transition\s*:\s*none\s*!important',
+        CSS, re.DOTALL
+    ), "missing transition:none !important for .vscroll-measuring .msg-foot"
+    assert re.search(
+        r'\.vscroll-measuring\s+\.msg-actions.*transition\s*:\s*none\s*!important',
+        CSS, re.DOTALL
+    ), "missing transition:none !important for .vscroll-measuring .msg-actions"
+
+
+def test_js_compensate_adds_vscroll_measuring():
+    """_compensateScrollForMeasurementDelta adds and removes the vscroll-measuring
+    class around the render callback."""
+    fn_match = re.search(
+        r'function _compensateScrollForMeasurementDelta\(renderFn\)\{(.+?)^(?=function )',
+        JS, re.DOTALL | re.MULTILINE
+    )
+    assert fn_match, "_compensateScrollForMeasurementDelta not found"
+    body = fn_match.group(1)
+    assert "classList.add('vscroll-measuring')" in body
+    assert "classList.remove('vscroll-measuring')" in body
+
+
+def test_js_try_finally_guards_class_removal():
+    """The classList.remove is in a finally block so the class is always cleared."""
+    fn_match = re.search(
+        r'function _compensateScrollForMeasurementDelta\(renderFn\)\{(.+?)^(?=function )',
+        JS, re.DOTALL | re.MULTILINE
+    )
+    assert fn_match
+    body = fn_match.group(1)
+    add_pos = body.find("classList.add('vscroll-measuring')")
+    try_pos = body.find('try{', add_pos) if add_pos != -1 else -1
+    finally_pos = body.find('finally{', try_pos) if try_pos != -1 else -1
+    remove_pos = body.find("classList.remove('vscroll-measuring')", finally_pos) if finally_pos != -1 else -1
+    assert remove_pos != -1, "classList.remove must be inside a finally block after classList.add"

--- a/tests/test_issue4346_vscroll_footer_jitter.py
+++ b/tests/test_issue4346_vscroll_footer_jitter.py
@@ -20,6 +20,10 @@ def test_css_vscroll_measuring_guard():
         r'\.vscroll-measuring\s+\.msg-actions.*transition\s*:\s*none\s*!important',
         CSS, re.DOTALL
     ), "missing transition:none !important for .vscroll-measuring .msg-actions"
+    assert re.search(
+        r'\.vscroll-measuring\s+\.msg-time.*transition\s*:\s*none\s*!important',
+        CSS, re.DOTALL
+    ), "missing transition:none !important for .vscroll-measuring .msg-time"
 
 
 def test_js_compensate_adds_vscroll_measuring():
@@ -36,15 +40,18 @@ def test_js_compensate_adds_vscroll_measuring():
 
 
 def test_js_try_finally_guards_class_removal():
-    """The classList.remove is in a finally block so the class is always cleared."""
+    """The classList.remove is inside the finally{} block, not after it."""
     fn_match = re.search(
         r'function _compensateScrollForMeasurementDelta\(renderFn\)\{(.+?)^(?=function )',
         JS, re.DOTALL | re.MULTILINE
     )
     assert fn_match
     body = fn_match.group(1)
-    add_pos = body.find("classList.add('vscroll-measuring')")
-    try_pos = body.find('try{', add_pos) if add_pos != -1 else -1
-    finally_pos = body.find('finally{', try_pos) if try_pos != -1 else -1
-    remove_pos = body.find("classList.remove('vscroll-measuring')", finally_pos) if finally_pos != -1 else -1
-    assert remove_pos != -1, "classList.remove must be inside a finally block after classList.add"
+    finally_match = re.search(
+        r'finally\{([^}]*)\}',
+        body
+    )
+    assert finally_match, "no finally block found in _compensateScrollForMeasurementDelta"
+    finally_body = finally_match.group(1)
+    assert "classList.remove('vscroll-measuring')" in finally_body, \
+        "classList.remove must be inside the finally{} block, not after it"

--- a/tests/test_issue4346_vscroll_footer_jitter.py
+++ b/tests/test_issue4346_vscroll_footer_jitter.py
@@ -47,11 +47,11 @@ def test_js_try_finally_guards_class_removal():
     )
     assert fn_match
     body = fn_match.group(1)
-    finally_match = re.search(
-        r'finally\{([^}]*)\}',
-        body
-    )
-    assert finally_match, "no finally block found in _compensateScrollForMeasurementDelta"
-    finally_body = finally_match.group(1)
-    assert "classList.remove('vscroll-measuring')" in finally_body, \
-        "classList.remove must be inside the finally{} block, not after it"
+    try_idx = body.find('try{')
+    finally_idx = body.find('finally{')
+    remove_idx = body.find("classList.remove('vscroll-measuring')")
+    assert try_idx != -1, "no try block found in _compensateScrollForMeasurementDelta"
+    assert finally_idx != -1, "no finally block found in _compensateScrollForMeasurementDelta"
+    assert remove_idx != -1, "missing classList.remove('vscroll-measuring')"
+    assert try_idx < finally_idx < remove_idx, \
+        "classList.remove must remain in the finally{} cleanup path"

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -872,6 +872,7 @@ const container = {
   set scrollTop(v){ scrollTopWasMutated = true; scrollTopValue = v; },
   getBoundingClientRect(){ return {top: 0}; },
   querySelector(){ return null; },
+  classList: { add(){}, remove(){} },
 };
 function $(id){ return id === 'messages' ? container : null; }
 function _captureMessageViewportAnchor(){ return null; }
@@ -902,6 +903,7 @@ const container = {
   get scrollTop(){ return scrollTopValue; },
   set scrollTop(v){ scrollHistory.push(v); scrollTopValue = v; },
   getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  classList: { add(){}, remove(){} },
   querySelector(selector){
     if(selector === '[data-msg-idx="42"]'){
       // After render, the row moved from relative offset 100 to 150 (50px shift)
@@ -948,6 +950,7 @@ const container = {
   get scrollTop(){ return scrollTopValue; },
   set scrollTop(v){ scrollHistory.push(v); scrollTopValue = v; },
   getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  classList: { add(){}, remove(){} },
   querySelector(selector){
     if(selector === '[data-msg-idx="42"]'){
       // Row moved by only 1px, within tolerance
@@ -996,6 +999,7 @@ const container = {
     scrollTopValue = v;
   },
   getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  classList: { add(){}, remove(){} },
   querySelector(selector){
     if(selector === '[data-msg-idx="42"]'){
       return {


### PR DESCRIPTION
## Thinking Path

Timestamps and action icons flash during scrolling because `_compensateScrollForMeasurementDelta` calls `renderFn()` up to three times per scroll event (initial + 2 measurement retries), and each call wipes `inner.innerHTML=''` and rebuilds the whole visible DOM, repeatedly resetting the `opacity:0; transition:opacity .15s` from scratch.

## What Changed

- `static/style.css`: `.vscroll-measuring` guard rule disables transitions on `.msg-foot`, `.msg-actions`, `.msg-time` during measurement. Uses `!important` so it beats equal-specificity `.msg-foot-with-usage` fades regardless of cascade position.
- `static/ui.js`: `_compensateScrollForMeasurementDelta` wraps `renderFn()` with the measuring class toggle in a `try/finally` so a throwing `renderFn()` can't strand the container in `.vscroll-measuring`.
- `tests/test_issue4346_vscroll_footer_jitter.py`: source-level assertions for CSS guard (contiguous, line-anchored block match), class toggling, `try/finally` guarantee.
- `tests/test_issue500_message_list_virtualization.py`: non-regression guard for the existing virtual-scroll test suite.

## Why It Matters

Per-row timestamps and action icons no longer flash during transcript scrolling.

## Verification

```text
pytest tests/test_issue4346_vscroll_footer_jitter.py tests/test_issue500_message_list_virtualization.py -v --timeout=60
```

## Risks / Follow-ups

- The `!important` qualifier on the guard rule is scoped to the measurement class and does not affect normal hover/focus behavior.
- DOM node recycling (the deeper fix for measurement-path layout churn) is proposed separately in #4478.

## Upstream

Refs #4346.

## Model Used

Claude Opus 4.6 via Claude Code CLI

<!-- DO NOT EXPAND SCOPE — recycling belongs in #4478 -->