### PR TITLE
Release v0.51.514 — RY (no footer jitter during virtual-scroll measurement, #4474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.514] — 2026-06-19 — Release RY (no footer jitter during virtual-scroll measurement)
+
+### Fixed
+
+- **Message footers no longer flicker while scrolling through a long virtualized transcript (#4346).** During the virtual-window measurement re-render (the compensation pass added in v0.51.511), the scroll container now carries a transient `vscroll-measuring` class that suppresses CSS transitions on the message footer, actions, and timestamp (applied in a `try/finally` so it is always cleared), and stable user-row DOM nodes are recycled across the measurement pass instead of rebuilt. This stops the `.msg-actions` opacity fade from re-triggering on rows re-rendered under the cursor. Thanks @rodboev.
+
 ## [v0.51.513] — 2026-06-19 — Release RX (credential-pool quota status for all pooled providers)
 
 ### Added

--- a/static/style.css
+++ b/static/style.css
@@ -2639,6 +2639,9 @@
 /* ── Message action buttons (copy, edit, retry) ── */
 .msg-actions{display:flex;align-items:center;gap:2px;opacity:0;transition:opacity .15s;margin-left:auto;}
 .msg-row:hover .msg-actions{opacity:1;}
+.vscroll-measuring .msg-foot,
+.vscroll-measuring .msg-actions,
+.vscroll-measuring .msg-time{transition:none !important;}
 .msg-action-btn{background:none;border:none;color:var(--muted);cursor:pointer;font-size:13px;padding:2px 5px;border-radius:5px;transition:color .12s,background .12s;line-height:1;}
 .msg-action-btn:hover{color:var(--accent-text);background:var(--accent-bg);}
 .selected-text-reply-btn{position:fixed;z-index:1200;display:inline-flex;align-items:center;gap:6px;padding:7px 11px;border:2px solid var(--accent);border-radius:999px;background:var(--bg);color:var(--text);box-shadow:0 8px 24px rgba(0,0,0,.26),0 0 0 1px var(--surface);font-size:12px;font-weight:700;line-height:1;cursor:pointer;opacity:0;pointer-events:none;transform:translateY(4px);transition:opacity .12s ease,transform .12s ease,background .12s ease,border-color .12s ease;user-select:none;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -402,6 +402,8 @@ let _messageVirtualMeasurementRetryCount=0;
 let _messageVirtualScrollActive=false;
 let _messageVirtualScrollSettleTimer=0;
 let _messageVirtualDeferredMeasurement=null;
+let _msgNodeRecycleEnabled=false;
+const _recycleStash=new Map();
 function _markMessageVirtualScrollActive(){
   _messageVirtualScrollActive=true;
   clearTimeout(_messageVirtualScrollSettleTimer);
@@ -751,7 +753,8 @@ function _compensateScrollForMeasurementDelta(renderFn){
   if(!container) return renderFn();
   const anchorBefore=_captureMessageViewportAnchor();
   const scrollTopBefore=container.scrollTop;
-  renderFn();
+  container.classList.add('vscroll-measuring');
+  try{ renderFn(); }finally{ container.classList.remove('vscroll-measuring'); }
   if(!anchorBefore) return;
   if(scrollTopBefore<1){
     const spacer=container.querySelector('[data-virtual-spacer="before"]');
@@ -844,7 +847,9 @@ function _scheduleMessageVirtualizedRender(force){
     const liveWindow=_currentMessageVirtualWindow(liveVisWithIdx,_messageVirtualKeepTailCount());
     const liveKey=_messageVirtualWindowKeyFor(liveWindow);
     if(!force&&liveKey===_messageVirtualWindowKey) return;
-    _compensateScrollForMeasurementDelta(()=>{ renderMessages({ preserveScroll:true }); });
+    _msgNodeRecycleEnabled=true;
+    try{ _compensateScrollForMeasurementDelta(()=>{ renderMessages({ preserveScroll:true }); }); }
+    finally{ _msgNodeRecycleEnabled=false; }
   });
 }
 
@@ -10129,6 +10134,14 @@ function renderMessages(options){
     S.session && typeof S.session.compression_anchor_summary==='string'
   ) ? S.session.compression_anchor_summary.trim() : '';
   const worklogDetailDisclosureState=_captureWorklogDetailDisclosureState(inner);
+  _recycleStash.clear();
+  if(_msgNodeRecycleEnabled){
+    for(const child of Array.from(inner.children)){
+      if(!child.dataset||!child.dataset.msgIdx) continue;
+      if(child.id==='liveAssistantTurn'||child.querySelector&&child.querySelector('#liveAssistantTurn')) continue;
+      _recycleStash.set(Number(child.dataset.msgIdx), child);
+    }
+  }
   inner.innerHTML='';
   const compressionNode=compressionState?_compressionCardsNode(compressionState):null;
   const {message:referenceMessage, rawIdx:referenceMessageRawIdx}=_latestCompressionReferenceMessage(
@@ -10396,20 +10409,36 @@ function renderMessages(options){
 
     if(isUser){
       currentAssistantTurn=null;
-      const row=document.createElement('div');
-      row.className='msg-row';
-      row.id=_userMessageDomId(rawIdx);
-      row.dataset.msgIdx=rawIdx;
-      row.dataset.role='user';
-      row.dataset.rawText=String(displayContent).trim();
-      row.innerHTML=`${filesHtml}<div class="msg-body">${bodyHtml}</div>${footHtml}`;
+      let row=_msgNodeRecycleEnabled?_recycleStash.get(rawIdx):null;
+      if(row){
+        const newRawText=String(displayContent).trim();
+        if(row.dataset.rawText!==newRawText){
+          row.dataset.rawText=newRawText;
+          row.innerHTML=`${filesHtml}<div class="msg-body">${bodyHtml}</div>${footHtml}`;
+        }
+      }else{
+        row=document.createElement('div');
+        row.className='msg-row';
+        row.id=_userMessageDomId(rawIdx);
+        row.dataset.msgIdx=rawIdx;
+        row.dataset.role='user';
+        row.dataset.rawText=String(displayContent).trim();
+        row.innerHTML=`${filesHtml}<div class="msg-body">${bodyHtml}</div>${footHtml}`;
+      }
       inner.appendChild(row);
       userRows.set(rawIdx, row);
       continue;
     }
 
     if(!currentAssistantTurn){
-      currentAssistantTurn=_createAssistantTurn(tsTitle, isTpsDisplayEnabled()?_formatTurnTps(m._turnTps):'');
+      const recycled=_msgNodeRecycleEnabled?_recycleStash.get(rawIdx):null;
+      if(recycled){
+        const blocks=_assistantTurnBlocks(recycled);
+        if(blocks) blocks.innerHTML='';
+        currentAssistantTurn=recycled;
+      }else{
+        currentAssistantTurn=_createAssistantTurn(tsTitle, isTpsDisplayEnabled()?_formatTurnTps(m._turnTps):'');
+      }
       inner.appendChild(currentAssistantTurn);
     }
     const seg=document.createElement('div');
@@ -11260,6 +11289,7 @@ function renderMessages(options){
     }
   }
   _updateMessageVirtualMeasurements(renderVisWithIdx, renderVisibleIdxs, virtualWindow);
+  _recycleStash.clear();
 }
 
 function _toolDisplayName(tc){

--- a/tests/test_issue4346_vscroll_footer_jitter.py
+++ b/tests/test_issue4346_vscroll_footer_jitter.py
@@ -1,0 +1,109 @@
+"""Static source assertions for issue #4346 virtual-scroll footer jitter fix."""
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).parent.parent
+
+CSS = (ROOT / 'static' / 'style.css').read_text(encoding='utf-8')
+JS  = (ROOT / 'static' / 'ui.js').read_text(encoding='utf-8')
+
+
+def test_css_vscroll_measuring_guard():
+    """style.css suppresses opacity transitions on .msg-foot and .msg-actions
+    while .vscroll-measuring is present on the scroll container."""
+    assert 'vscroll-measuring' in CSS
+    assert re.search(
+        r'\.vscroll-measuring\s+\.msg-foot.*transition\s*:\s*none\s*!important',
+        CSS, re.DOTALL
+    ), "missing transition:none !important for .vscroll-measuring .msg-foot"
+    assert re.search(
+        r'\.vscroll-measuring\s+\.msg-actions.*transition\s*:\s*none\s*!important',
+        CSS, re.DOTALL
+    ), "missing transition:none !important for .vscroll-measuring .msg-actions"
+    assert re.search(
+        r'\.vscroll-measuring\s+\.msg-time.*transition\s*:\s*none\s*!important',
+        CSS, re.DOTALL
+    ), "missing transition:none !important for .vscroll-measuring .msg-time"
+
+
+def test_js_compensate_adds_vscroll_measuring():
+    """_compensateScrollForMeasurementDelta adds and removes the vscroll-measuring
+    class around the render callback."""
+    fn_match = re.search(
+        r'function _compensateScrollForMeasurementDelta\(renderFn\)\{(.+?)^(?=function )',
+        JS, re.DOTALL | re.MULTILINE
+    )
+    assert fn_match, "_compensateScrollForMeasurementDelta not found"
+    body = fn_match.group(1)
+    assert "classList.add('vscroll-measuring')" in body
+    assert "classList.remove('vscroll-measuring')" in body
+
+
+def test_js_try_finally_guards_class_removal():
+    """The classList.remove is inside the finally{} block, not after it."""
+    fn_match = re.search(
+        r'function _compensateScrollForMeasurementDelta\(renderFn\)\{(.+?)^(?=function )',
+        JS, re.DOTALL | re.MULTILINE
+    )
+    assert fn_match
+    body = fn_match.group(1)
+    try_idx = body.find('try{')
+    finally_idx = body.find('finally{')
+    remove_idx = body.find("classList.remove('vscroll-measuring')")
+    assert try_idx != -1, "no try block found in _compensateScrollForMeasurementDelta"
+    assert finally_idx != -1, "no finally block found in _compensateScrollForMeasurementDelta"
+    assert remove_idx != -1, "missing classList.remove('vscroll-measuring')"
+    assert try_idx < finally_idx < remove_idx, \
+        "classList.remove must remain in the finally{} cleanup path"
+
+
+def test_js_recycle_flag_exists():
+    """ui.js declares the _msgNodeRecycleEnabled flag."""
+    assert '_msgNodeRecycleEnabled' in JS
+
+
+def test_js_recycle_stash_exists():
+    """ui.js declares the _recycleStash Map."""
+    assert '_recycleStash' in JS
+
+
+def test_js_recycle_flag_set_in_virtual_render():
+    """_scheduleMessageVirtualizedRender sets _msgNodeRecycleEnabled=true
+    before the compensate call and clears it in finally."""
+    fn_match = re.search(
+        r'function _scheduleMessageVirtualizedRender\(force\)\{(.+?)^(?=function )',
+        JS, re.DOTALL | re.MULTILINE
+    )
+    assert fn_match, "_scheduleMessageVirtualizedRender not found"
+    body = fn_match.group(1)
+    assert '_msgNodeRecycleEnabled=true' in body
+    finally_match = re.search(r'finally\{([^}]*)\}', body)
+    assert finally_match, "no finally block in _scheduleMessageVirtualizedRender"
+    assert '_msgNodeRecycleEnabled=false' in finally_match.group(1)
+
+
+def test_js_stash_populated_before_wipe():
+    """The recycleStash population loop appears before innerHTML='' in renderMessages."""
+    fn_match = re.search(
+        r'function renderMessages\(options\)\{(.+?)^(?=function )',
+        JS, re.DOTALL | re.MULTILINE
+    )
+    assert fn_match, "renderMessages not found"
+    body = fn_match.group(1)
+    stash_pos = body.find('_recycleStash.set(')
+    wipe_pos = body.find("inner.innerHTML='';")
+    assert stash_pos != -1, "_recycleStash.set not found in renderMessages"
+    assert wipe_pos != -1, "innerHTML wipe not found in renderMessages"
+    assert stash_pos < wipe_pos, "_recycleStash.set must appear before innerHTML=''"
+
+
+def test_js_user_row_checks_stash():
+    """The user-row creation block checks _recycleStash before createElement."""
+    fn_match = re.search(
+        r'function renderMessages\(options\)\{(.+?)^(?=function )',
+        JS, re.DOTALL | re.MULTILINE
+    )
+    assert fn_match, "renderMessages not found"
+    body = fn_match.group(1)
+    assert '_recycleStash.get(rawIdx)' in body, \
+        "user row block must check _recycleStash.get(rawIdx)"

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -872,6 +872,7 @@ const container = {
   set scrollTop(v){ scrollTopWasMutated = true; scrollTopValue = v; },
   getBoundingClientRect(){ return {top: 0}; },
   querySelector(){ return null; },
+  classList: { add(){}, remove(){} },
 };
 function $(id){ return id === 'messages' ? container : null; }
 function _captureMessageViewportAnchor(){ return null; }
@@ -902,6 +903,7 @@ const container = {
   get scrollTop(){ return scrollTopValue; },
   set scrollTop(v){ scrollHistory.push(v); scrollTopValue = v; },
   getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  classList: { add(){}, remove(){} },
   querySelector(selector){
     if(selector === '[data-msg-idx="42"]'){
       // After render, the row moved from relative offset 100 to 150 (50px shift)
@@ -948,6 +950,7 @@ const container = {
   get scrollTop(){ return scrollTopValue; },
   set scrollTop(v){ scrollHistory.push(v); scrollTopValue = v; },
   getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  classList: { add(){}, remove(){} },
   querySelector(selector){
     if(selector === '[data-msg-idx="42"]'){
       // Row moved by only 1px, within tolerance
@@ -996,6 +999,7 @@ const container = {
     scrollTopValue = v;
   },
   getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  classList: { add(){}, remove(){} },
   querySelector(selector){
     if(selector === '[data-msg-idx="42"]'){
       return {


### PR DESCRIPTION
Ships **#4474** (rodboev) — fixes #4346 (footer jitter during virtualized-transcript scrolling), in the message-virtualization series (pairs with #4468/v0.51.511).

### What it does
1. During the virtual-window measurement re-render, the scroll container gets a transient `vscroll-measuring` class that suppresses CSS transitions on `.msg-foot`/`.msg-actions`/`.msg-time` (applied in `try/finally` so it's always cleared) — stops the `.msg-actions` opacity fade re-triggering on rows re-rendered under the cursor.
2. Recycles stable user-row DOM nodes across the measurement pass instead of rebuilding them.

### Gate (fresh, after the author's later DOM-recycling commit `eab4b7d4`)
- **Codex SAFE TO SHIP** + **Opus SAFE TO SHIP** — recycling is gated to the virtualized measurement rAF, reset in `finally` (no flag leak into normal renders), live assistant turns excluded from the stash, stash cleared at render start+end, heights match a fresh render, no listener accumulation (inline `onclick`, not `addEventListener`).
- **Full suite:** 9600 passed.
- Author + maintainer go-ahead given (virtualization-series sign-off).

### Non-blocking follow-ups (noted by the gate, for a later PR)
- The assistant-turn recycling branch is currently inert (`dataset.msgIdx` isn't set on the turn container) — either wire it or remove the dead branch.
- The user-row reuse guard is positional+text, not message-identity — an id check would close a narrow stale-content edge that isn't reachable by the designed flow.

Co-authored-by: rodboev <rodboev@users.noreply.github.com>

Closes #4474