### PR TITLE
feat(kanban): faithful dashboard layout + task detail in workspace panel

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1468,11 +1468,13 @@
       <button class="workspace-panel-tab active" id="workspaceFilesTab" type="button" onclick="switchWorkspacePanelTab('files')" role="tab" aria-selected="true">Files</button>
       <button class="workspace-panel-tab" id="workspaceArtifactsTab" type="button" onclick="switchWorkspacePanelTab('artifacts')" role="tab" aria-selected="false">Artifacts <span id="workspaceArtifactsCount" class="workspace-artifacts-count">0</span></button>
       <button class="workspace-panel-tab" id="workspaceTodosTab" type="button" onclick="switchWorkspacePanelTab('todos')" role="tab" aria-selected="false" hidden data-i18n="tab_todos">Todos</button>
+      <button class="workspace-panel-tab" id="workspaceKanbanTaskTab" type="button" onclick="switchWorkspacePanelTab('kanban-task')" role="tab" aria-selected="false" hidden>Task</button>
     </div>
     <div class="breadcrumb-bar" id="breadcrumbBar" style="display:none"></div>
     <div class="file-tree" id="fileTree"></div>
     <div class="workspace-artifacts" id="workspaceArtifacts" hidden></div>
     <div class="workspace-todos" id="workspaceTodosPanel" hidden style="flex:1;overflow-y:auto;padding:8px 12px"></div>
+    <div class="workspace-kanban-task" id="workspaceKanbanTask" hidden style="flex:1;overflow-y:auto;padding:12px"></div>
     <div id="wsEmptyState" style="display:none;flex:1;align-items:center;justify-content:center;padding:24px 16px;text-align:center;color:var(--muted);font-size:12px;line-height:1.6"></div>
     <div class="preview-area" id="previewArea">
       <div class="preview-path" id="previewPath">

--- a/static/index.html
+++ b/static/index.html
@@ -19,6 +19,7 @@
 <link rel="apple-touch-icon" sizes="512x512" href="static/apple-touch-icon.png">
 <script>(function(){try{var themes={light:1,dark:1,system:1},skins={default:1,ares:1,mono:1,graphite:1,slate:1,poseidon:1,sisyphus:1,charizard:1,sienna:1,catppuccin:1,hepburn:1,nous:1,'geist-contrast':1,neon:1,zeus:1,'verdigris':1},legacy={slate:['dark','slate'],solarized:['dark','poseidon'],monokai:['dark','sisyphus'],nord:['dark','slate'],oled:['dark','default']},t=(localStorage.getItem('hermes-theme')||'dark').toLowerCase(),s=(localStorage.getItem('hermes-skin')||'').toLowerCase(),m=legacy[t],theme=m?m[0]:(themes[t]?t:'dark'),skin=skins[s]?s:(m?m[1]:'default');localStorage.setItem('hermes-theme',theme);localStorage.setItem('hermes-skin',skin);if(theme==='system')theme=window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light';if(theme==='dark')document.documentElement.classList.add('dark');if(skin!=='default')document.documentElement.dataset.skin=skin;}catch(e){document.documentElement.classList.add('dark');}})()</script>
 <script>(function(){try{var fs=localStorage.getItem('hermes-font-size');if(fs&&fs!=='default')document.documentElement.dataset.fontSize=fs;}catch(e){}})()</script>
+<script>(function(){try{var kl=localStorage.getItem('hermes-kanban-layout');if(kl)document.documentElement.dataset.kanbanLayout=kl;}catch(e){}})()</script>
 <!-- theme-color: surfaces the active app chrome color to native status bars (Safari status bar, PWA, native WKWebView wrappers). Updated dynamically by boot.js when theme/skin changes. The light/dark default values match style.css :root --sidebar / :root.dark --sidebar. -->
 <meta name="theme-color" content="#FAF7F0" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#141425" media="(prefers-color-scheme: dark)">
@@ -1085,6 +1086,14 @@
             <div class="settings-field">
               <label for="settingsLanguage" data-i18n="settings_label_language">Language</label>
               <select id="settingsLanguage" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px"></select>
+            </div>
+            <div class="settings-field">
+              <label for="settingsKanbanLayout" data-i18n="settings_label_kanban_layout">Kanban Layout</label>
+              <select id="settingsKanbanLayout" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px">
+                <option value="webui" data-i18n="settings_kanban_layout_webui">WebUI (default)</option>
+                <option value="dashboard" data-i18n="settings_kanban_layout_dashboard">Dashboard (compact)</option>
+              </select>
+              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_kanban_layout">Choose the kanban board layout. "Dashboard" uses a compact board style similar to the Hermes dashboard plugin.</div>
             </div>
             <div class="settings-field">
               <label style="display:flex;align-items:center;gap:8px;cursor:pointer">

--- a/static/panels.js
+++ b/static/panels.js
@@ -2213,8 +2213,24 @@ function closeKanbanTaskDetail(){
     preview.style.display = 'none';
     preview.innerHTML = '';
   }
+  if (document.documentElement.dataset.kanbanLayout === 'dashboard') {
+    _kanbanHideWorkspaceTaskDetail();
+  }
   const board = $('kanbanBoard');
   if (board) board.querySelectorAll('.kanban-card').forEach(card => card.classList.remove('selected'));
+}
+
+function _kanbanHideWorkspaceTaskDetail(){
+  const kanbanTaskTab = $('workspaceKanbanTaskTab');
+  const kanbanTask = $('workspaceKanbanTask');
+  if (kanbanTaskTab) kanbanTaskTab.hidden = true;
+  if (kanbanTask) {
+    kanbanTask.innerHTML = '';
+    kanbanTask.hidden = true;
+  }
+  if (document.documentElement.dataset.workspacePanel === 'open' && typeof switchWorkspacePanelTab === 'function') {
+    switchWorkspacePanelTab('files');
+  }
 }
 
 function _kanbanFormatTimestamp(value){
@@ -2795,7 +2811,7 @@ async function addKanbanComment(taskId){
   } catch(e) { showToast(t('kanban_unavailable') + ': ' + (e.message || e), 'error'); }
 }
 
-function _kanbanRenderTaskDetail(data){
+function _kanbanRenderTaskDetail(data, mode='preview'){
   const task = data.task || {};
   const log = data.log || {};
   const title = _kanbanTaskTitle(task);
@@ -2805,16 +2821,14 @@ function _kanbanRenderTaskDetail(data){
   const events = data.events || [];
   const links = data.links || {};
   const runs = data.runs || [];
-  // Note: 'running' is intentionally absent — entering 'running' is the
-  // dispatcher/claim_task path's responsibility, not a user UI write. The
-  // bridge rejects PATCH status='running' with HTTP 400 to match the agent
-  // dashboard plugin's contract. UI users want to claim/promote a ready task
-  // via the dispatcher Nudge button, not flip it to running by hand.
   const statusButtons = ['triage', 'todo', 'ready', 'blocked', 'done', 'archived'].map(status =>
     `<button class="btn secondary" onclick="updateKanbanTask('${esc(task.id)}',{status:'${status}'})">${esc(_kanbanColumnLabel(status))}</button>`
   ).join('') + `<button class="btn secondary" onclick="blockKanbanTask('${esc(task.id)}')">${esc(t('kanban_block'))}</button><button class="btn secondary" onclick="unblockKanbanTask('${esc(task.id)}')">${esc(t('kanban_unblock'))}</button>`;
+  const closeAction = mode === 'workspace'
+    ? `<button class="btn secondary kanban-back-btn" onclick="closeKanbanTaskDetail()">${esc(t('kanban_close') || 'Close')}</button>`
+    : `<button class="btn secondary kanban-back-btn" onclick="closeKanbanTaskDetail()">${esc(t('kanban_back_to_board'))}</button>`;
   return `<div class="kanban-task-preview-header">
-      <button class="btn secondary kanban-back-btn" onclick="closeKanbanTaskDetail()">${esc(t('kanban_back_to_board'))}</button>
+      ${closeAction}
       <div class="kanban-task-preview-title">${esc(title)}</div>
       <button class="btn secondary kanban-edit-btn" onclick="openKanbanEdit('${esc(task.id)}')" data-i18n="kanban_edit_task" title="${esc(t('kanban_edit_task') || 'Edit task')}">${esc(t('kanban_edit_task') || 'Edit task')}</button>
     </div>
@@ -2847,10 +2861,23 @@ async function loadKanbanTask(taskId){
       board.querySelectorAll('.kanban-card').forEach(card => card.classList.remove('selected'));
       Array.from(board.querySelectorAll('.kanban-card')).find(card => card.dataset.kanbanTaskId === taskId)?.classList.add('selected');
     }
-    const preview = $('kanbanTaskPreview');
-    if (preview) {
-      preview.style.display = '';
-      preview.innerHTML = _kanbanRenderTaskDetail(data);
+    const isDashboard = document.documentElement.dataset.kanbanLayout === 'dashboard';
+    if (isDashboard) {
+      const wsTask = $('workspaceKanbanTask');
+      const wsTaskTab = $('workspaceKanbanTaskTab');
+      if (wsTask && wsTaskTab) {
+        wsTask.innerHTML = `<div class="kanban-task-preview">${_kanbanRenderTaskDetail(data, 'workspace')}</div>`;
+        wsTask.hidden = false;
+        wsTaskTab.hidden = false;
+        if (typeof toggleWorkspacePanel === 'function') toggleWorkspacePanel(true);
+        if (typeof switchWorkspacePanelTab === 'function') switchWorkspacePanelTab('kanban-task');
+      }
+    } else {
+      const preview = $('kanbanTaskPreview');
+      if (preview) {
+        preview.style.display = '';
+        preview.innerHTML = _kanbanRenderTaskDetail(data, 'preview');
+      }
     }
     showToast(`${t('kanban_task')}: ${title}`);
   } catch(e) { showToast(t('kanban_unavailable') + ': ' + (e.message || e), 'error'); }
@@ -6720,6 +6747,7 @@ async function loadSettingsPanel(){
         const layout=this.value;
         localStorage.setItem('hermes-kanban-layout',layout);
         document.documentElement.dataset.kanbanLayout=layout;
+        if(typeof closeKanbanTaskDetail==='function') closeKanbanTaskDetail();
         if(typeof _kanbanRenderBoard==='function' && _kanbanBoard) _kanbanRenderBoard();
       },{once:false});
     }

--- a/static/panels.js
+++ b/static/panels.js
@@ -1834,7 +1834,8 @@ function _kanbanRenderBoard(){
     board.innerHTML = _kanbanEmptyBoardHtml();
     return;
   }
-  board.innerHTML = _kanbanLanesByProfile ? _kanbanRenderProfileLanes(columns) : columns.map(_kanbanRenderColumn).join('');
+  const isDashboard = document.documentElement.dataset.kanbanLayout === 'dashboard';
+  board.innerHTML = (!isDashboard && _kanbanLanesByProfile) ? _kanbanRenderProfileLanes(columns) : columns.map(_kanbanRenderColumn).join('');
 }
 
 function _kanbanCard(task, status){
@@ -1846,12 +1847,20 @@ function _kanbanCard(task, status){
   const stale = _kanbanCardStalenessClass(task);
   const body = _kanbanTaskBody(task);
   const assignee = task.assignee ? `<span class="kanban-card-assignee">@${esc(task.assignee)}</span>` : `<span class="kanban-card-unassigned">${esc(t('kanban_unassigned'))}</span>`;
-  return `<article class="kanban-card ${esc(stale)}" data-kanban-task-id="${esc(task.id)}" draggable="true" ondragstart="dragKanbanTask(event, '${esc(task.id)}')" ondragend="finishKanbanDrag(event)" onclick="return openKanbanCard(event, '${esc(task.id)}')" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();loadKanbanTask('${esc(task.id)}')}">
-    <div class="kanban-card-topline"><span class="kanban-card-id">${esc(task.id || '')}</span>${priority ? `<span class="kanban-badge priority">P${priority}</span>` : ''}${task.tenant ? `<span class="kanban-badge tenant">${esc(task.tenant)}</span>` : ''}</div>
+  const progress = task.progress || task.link_counts;
+  const isDashboard = document.documentElement.dataset.kanbanLayout === 'dashboard';
+  const progressHtml = (isDashboard && progress && progress.done !== undefined && progress.total !== undefined)
+    ? `<span class="kanban-progress${progress.done === progress.total ? ' kanban-progress--full' : ''}" title="${progress.done} of ${progress.total} child tasks done">${progress.done}/${progress.total}</span>`
+    : '';
+  const inner = `
+    <div class="kanban-card-topline"><span class="kanban-card-id">${esc(task.id || '')}</span>${progressHtml}${priority ? `<span class="kanban-badge priority">P${priority}</span>` : ''}${task.tenant ? `<span class="kanban-badge tenant">${esc(task.tenant)}</span>` : ''}</div>
     <div class="kanban-card-title">${esc(_kanbanTaskTitle(task))}</div>
     ${body ? `<div class="kanban-card-body">${_kanbanRenderMarkdown(body)}</div>` : ''}
-    <div class="kanban-card-meta">${assignee}${comments ? `<span class="kanban-card-metric">💬 ${comments}</span>` : ''}${linkTotal ? `<span class="kanban-card-metric">↔ ${linkTotal}</span>` : ''}${age ? `<span class="kanban-card-age">${esc(age)}</span>` : ''}</div>
-    ${_kanbanCardQuickActions(task)}
+    <div class="kanban-card-row kanban-card-meta">${assignee}${comments ? `<span class="kanban-card-metric">💬 ${comments}</span>` : ''}${linkTotal ? `<span class="kanban-card-metric">↔ ${linkTotal}</span>` : ''}${age ? `<span class="kanban-card-age">${esc(age)}</span>` : ''}</div>
+    ${_kanbanCardQuickActions(task)}`;
+  const content = isDashboard ? `<div class="kanban-card-content">${inner}</div>` : inner;
+  return `<article class="kanban-card ${esc(stale)}" data-kanban-task-id="${esc(task.id)}" draggable="true" ondragstart="dragKanbanTask(event, '${esc(task.id)}')" ondragend="finishKanbanDrag(event)" onclick="return openKanbanCard(event, '${esc(task.id)}')" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();loadKanbanTask('${esc(task.id)}')}">
+    ${content}
   </article>`;
 }
 
@@ -6699,6 +6708,19 @@ async function loadSettingsPanel(){
       langSel.addEventListener('change',function(){
         if(typeof setLocale==='function'){setLocale(this.value);if(typeof applyLocaleToDOM==='function')applyLocaleToDOM();}
         _schedulePreferencesAutosave();
+      },{once:false});
+    }
+    // Kanban layout preference (UI-only, stored in localStorage)
+    const kanbanLayoutSel=$('settingsKanbanLayout');
+    if(kanbanLayoutSel){
+      const savedLayout=localStorage.getItem('hermes-kanban-layout')||'webui';
+      kanbanLayoutSel.value=savedLayout;
+      document.documentElement.dataset.kanbanLayout=savedLayout;
+      kanbanLayoutSel.addEventListener('change',function(){
+        const layout=this.value;
+        localStorage.setItem('hermes-kanban-layout',layout);
+        document.documentElement.dataset.kanbanLayout=layout;
+        if(typeof _kanbanRenderBoard==='function' && _kanbanBoard) _kanbanRenderBoard();
       },{once:false});
     }
     const showUsageCb=$('settingsShowTokenUsage');

--- a/static/style.css
+++ b/static/style.css
@@ -5119,6 +5119,13 @@ main.main > .main-view:not([id="mainChat"]):not([id="mainSettings"]) .main-view-
 .rightpanel[data-active-tab="files"] .workspace-artifacts{display:none!important;}
 .rightpanel[data-active-tab="todos"] .breadcrumb-bar,.rightpanel[data-active-tab="todos"] .file-tree,.rightpanel[data-active-tab="todos"] #wsEmptyState,.rightpanel[data-active-tab="todos"] .workspace-artifacts{display:none!important;}
 .rightpanel:not([data-active-tab="todos"]) .workspace-todos{display:none!important;}
+.rightpanel[data-active-tab="kanban-task"] .breadcrumb-bar,
+.rightpanel[data-active-tab="kanban-task"] .file-tree,
+.rightpanel[data-active-tab="kanban-task"] #wsEmptyState,
+.rightpanel[data-active-tab="kanban-task"] .workspace-artifacts,
+.rightpanel[data-active-tab="kanban-task"] .workspace-todos{display:none!important;}
+.rightpanel:not([data-active-tab="kanban-task"]) .workspace-kanban-task{display:none!important;}
+.workspace-kanban-task .kanban-task-preview{height:100%;overflow-y:auto;}
 .cron-run-usage-strip{display:inline-flex;align-items:center;gap:4px;margin-left:8px;color:var(--text-secondary);font-size:11px;opacity:.72;white-space:nowrap;}
 .cron-run-usage-footer{display:flex;margin:8px 0 0 0;padding-top:8px;border-top:1px solid var(--border-subtle);}
 .cron-item.active,.ws-row.active,.profile-card.active{background:var(--accent-bg);}

--- a/static/style.css
+++ b/static/style.css
@@ -5845,3 +5845,305 @@ html[data-conversation-outline="enabled"] #outlineToggleBtn:not([hidden]){displa
 @media(max-width:900px){
   #outlineToggleBtn,#outlinePanelWrapper{display:none!important;}
 }
+
+/* ═══ Kanban Dashboard Layout ═══ */
+/* Faithful reproduction of Hermes dashboard plugin kanban style */
+
+/* Status dots */
+html[data-kanban-layout="dashboard"] .kanban-column-head::before {
+  content: '';
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: var(--muted);
+  margin-right: 0.4rem;
+  flex-shrink: 0;
+}
+html[data-kanban-layout="dashboard"] .kanban-column[data-status="triage"] .kanban-column-head::before { background: #b47dd6; }
+html[data-kanban-layout="dashboard"] .kanban-column[data-status="todo"] .kanban-column-head::before { background: var(--muted); }
+html[data-kanban-layout="dashboard"] .kanban-column[data-status="ready"] .kanban-column-head::before { background: #d4b348; }
+html[data-kanban-layout="dashboard"] .kanban-column[data-status="running"] .kanban-column-head::before { background: #3fb97d; }
+html[data-kanban-layout="dashboard"] .kanban-column[data-status="blocked"] .kanban-column-head::before { background: var(--danger, #d14a4a); }
+html[data-kanban-layout="dashboard"] .kanban-column[data-status="done"] .kanban-column-head::before { background: #4a8cd1; }
+html[data-kanban-layout="dashboard"] .kanban-column[data-status="archived"] .kanban-column-head::before { background: var(--border); }
+
+/* Board layout */
+html[data-kanban-layout="dashboard"] .kanban-board {
+  gap: 0.75rem;
+  align-items: start;
+}
+
+/* Column */
+html[data-kanban-layout="dashboard"] .kanban-column {
+  flex: 0 0 280px;
+  min-width: 280px;
+  max-width: 280px;
+  min-height: 200px;
+  max-height: calc(100vh - 220px);
+  padding: 0.5rem;
+  border-radius: var(--radius-md, 8px);
+  background: color-mix(in srgb, var(--panel) 85%, transparent);
+  transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+html[data-kanban-layout="dashboard"] .kanban-column.drop-target {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 8%, var(--panel));
+}
+
+/* Column header */
+html[data-kanban-layout="dashboard"] .kanban-column-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0.25rem 0.35rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text);
+  border-bottom: none;
+}
+
+html[data-kanban-layout="dashboard"] .kanban-count {
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+  margin-left: auto;
+}
+
+/* Column body */
+html[data-kanban-layout="dashboard"] .kanban-column-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.5rem 0.25rem;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+/* Empty state */
+html[data-kanban-layout="dashboard"] .kanban-empty {
+  padding: 1.5rem 0.5rem;
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--muted);
+  border: 1px dashed color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: var(--radius-sm, 6px);
+}
+
+/* Card */
+html[data-kanban-layout="dashboard"] .kanban-card {
+  cursor: grab;
+  transition: transform 100ms ease, box-shadow 100ms ease, border-color 100ms ease;
+  padding: 0;
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+
+html[data-kanban-layout="dashboard"] .kanban-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 1px 0 0 var(--accent) inset, 0 0 0 1px var(--accent) inset;
+}
+
+html[data-kanban-layout="dashboard"] .kanban-card:active {
+  cursor: grabbing;
+  transform: scale(0.995);
+}
+
+html[data-kanban-layout="dashboard"] .kanban-card.selected {
+  border-color: var(--accent);
+  box-shadow: 0 1px 0 0 var(--accent) inset, 0 0 0 1px var(--accent) inset;
+}
+
+/* Card content wrapper */
+html[data-kanban-layout="dashboard"] .kanban-card-content {
+  padding: 0.5rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+/* Card row (flex container for inline elements) */
+html[data-kanban-layout="dashboard"] .kanban-card-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+/* Card ID */
+html[data-kanban-layout="dashboard"] .kanban-card-id {
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.65rem;
+  color: var(--muted);
+  letter-spacing: 0.03em;
+}
+
+/* Card title */
+html[data-kanban-layout="dashboard"] .kanban-card-title {
+  font-size: 0.85rem;
+  font-weight: 500;
+  line-height: 1.3;
+  color: var(--text);
+  word-break: break-word;
+  margin: 0;
+}
+
+/* Card meta */
+html[data-kanban-layout="dashboard"] .kanban-card-meta {
+  font-size: 0.7rem;
+  color: var(--muted);
+  gap: 0.55rem;
+  margin-top: 0.2rem;
+}
+
+/* Priority badge */
+html[data-kanban-layout="dashboard"] .kanban-badge.priority {
+  font-size: 0.6rem;
+  padding: 0.05rem 0.3rem;
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--text);
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+/* Tenant badge */
+html[data-kanban-layout="dashboard"] .kanban-badge.tenant {
+  font-size: 0.6rem;
+  padding: 0.05rem 0.3rem;
+  border-radius: 4px;
+}
+
+/* Assignee */
+html[data-kanban-layout="dashboard"] .kanban-card-assignee {
+  font-weight: 500;
+  color: color-mix(in srgb, var(--text) 80%, var(--muted));
+}
+
+html[data-kanban-layout="dashboard"] .kanban-card-unassigned {
+  font-style: italic;
+  opacity: 0.75;
+}
+
+/* Age indicator */
+html[data-kanban-layout="dashboard"] .kanban-card-age {
+  margin-left: auto;
+}
+
+/* Staleness indicators */
+html[data-kanban-layout="dashboard"] .kanban-card-stale-amber {
+  border-color: #d4b348;
+}
+html[data-kanban-layout="dashboard"] .kanban-card-stale-amber:hover {
+  box-shadow: 0 1px 0 0 #d4b348 inset, 0 0 0 1px #d4b348 inset;
+}
+
+html[data-kanban-layout="dashboard"] .kanban-card-stale-red {
+  border-color: var(--danger, #d14a4a);
+}
+html[data-kanban-layout="dashboard"] .kanban-card-stale-red:hover {
+  box-shadow: 0 1px 0 0 var(--danger, #d14a4a) inset, 0 0 0 1px var(--danger, #d14a4a) inset;
+}
+
+/* Progress pill */
+html[data-kanban-layout="dashboard"] .kanban-progress {
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.62rem;
+  padding: 0.05rem 0.35rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+html[data-kanban-layout="dashboard"] .kanban-progress--full {
+  background: color-mix(in srgb, #3fb97d 22%, transparent);
+  border-color: color-mix(in srgb, #3fb97d 45%, transparent);
+  color: var(--text);
+}
+
+/* Card actions */
+html[data-kanban-layout="dashboard"] .kanban-card-actions {
+  display: flex;
+  gap: 4px;
+  margin-top: 0.4rem;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  flex-wrap: wrap;
+}
+
+html[data-kanban-layout="dashboard"] .kanban-card:hover .kanban-card-actions {
+  opacity: 0.85;
+}
+
+html[data-kanban-layout="dashboard"] .kanban-card-action {
+  font-size: 0.65rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 100ms ease;
+}
+
+html[data-kanban-layout="dashboard"] .kanban-card-action:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+html[data-kanban-layout="dashboard"] .kanban-card-action.danger:hover {
+  border-color: var(--danger, #d14a4a);
+  color: var(--danger, #d14a4a);
+}
+
+/* Profile lanes (sub-grouping) */
+html[data-kanban-layout="dashboard"] .kanban-profile-lane {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.25rem 0 0.35rem;
+  border-top: 1px dashed color-mix(in srgb, var(--border) 70%, transparent);
+  margin-bottom: 0.5rem;
+}
+
+html[data-kanban-layout="dashboard"] .kanban-profile-lane:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+html[data-kanban-layout="dashboard"] .kanban-profile-lane-head {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+  padding: 0 0.1rem;
+  font-weight: 600;
+  font-family: var(--mono, ui-monospace, monospace);
+}
+
+html[data-kanban-layout="dashboard"] .kanban-board-in-lane {
+  min-height: 0;
+  overflow-x: auto;
+}
+
+/* Hide card-body markdown preview in dashboard mode for compactness */
+html[data-kanban-layout="dashboard"] .kanban-card-body {
+  display: none;
+}
+
+/* Card topline (ID + badges row) */
+html[data-kanban-layout="dashboard"] .kanban-card-topline {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.2rem;
+}

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -145,11 +145,12 @@ if(typeof document !== 'undefined'){
 }
 
 function switchWorkspacePanelTab(tab){
-  _workspacePanelActiveTab = tab === 'artifacts' ? 'artifacts' : tab === 'todos' ? 'todos' : 'files';
+  _workspacePanelActiveTab = tab === 'artifacts' ? 'artifacts' : tab === 'todos' ? 'todos' : tab === 'kanban-task' ? 'kanban-task' : 'files';
   _setWorkspacePanelTabDataset();
   const filesTab = $('workspaceFilesTab');
   const artifactsTab = $('workspaceArtifactsTab');
   const todosTab = $('workspaceTodosTab');
+  const kanbanTaskTab = $('workspaceKanbanTaskTab');
   if(filesTab){
     filesTab.classList.toggle('active', _workspacePanelActiveTab === 'files');
     filesTab.setAttribute('aria-selected', _workspacePanelActiveTab === 'files' ? 'true' : 'false');
@@ -162,10 +163,18 @@ function switchWorkspacePanelTab(tab){
     todosTab.classList.toggle('active', _workspacePanelActiveTab === 'todos');
     todosTab.setAttribute('aria-selected', _workspacePanelActiveTab === 'todos' ? 'true' : 'false');
   }
+  if(kanbanTaskTab){
+    kanbanTaskTab.classList.toggle('active', _workspacePanelActiveTab === 'kanban-task');
+    kanbanTaskTab.setAttribute('aria-selected', _workspacePanelActiveTab === 'kanban-task' ? 'true' : 'false');
+  }
   const artifacts = $('workspaceArtifacts');
   if(artifacts) artifacts.hidden = _workspacePanelActiveTab !== 'artifacts';
   const todosPanel = $('workspaceTodosPanel');
   if(todosPanel) todosPanel.hidden = _workspacePanelActiveTab !== 'todos';
+  const fileTree = $('fileTree');
+  if(fileTree) fileTree.hidden = _workspacePanelActiveTab !== 'files';
+  const kanbanTask = $('workspaceKanbanTask');
+  if(kanbanTask) kanbanTask.hidden = _workspacePanelActiveTab !== 'kanban-task';
   if(_workspacePanelActiveTab === 'artifacts') renderSessionArtifacts();
   if(_workspacePanelActiveTab === 'todos') _loadWorkspacePanelTodos();
 }


### PR DESCRIPTION
## Summary

Adds a **Dashboard** kanban layout option that faithfully reproduces the Hermes agent dashboard plugin's visual style, plus moves task detail view into the right-side workspace panel when in dashboard mode.

## Changes

### Phase 1 — Dashboard layout reproduction
- **`static/style.css`**: Full dashboard-style CSS — status dots (lilac/amber/green/red/blue), compact 280px cards, assignee badges, progress pills, hover actions, staleness indicators, hidden markdown preview.
- **`static/panels.js`** (`_kanbanCard`): Conditionally renders dashboard-style card HTML when layout is "dashboard" (monospace ID, priority badge, progress pill, assignee badge).
- **`static/panels.js`** (`_kanbanRenderBoard`): In dashboard mode, renders a single row of columns — no profile lane subdivision.
- **`static/index.html`**: Adds `settingsKanbanLayout` select to Preferences panel with early-init script to prevent FOUC.

### Phase 2 — Task detail in workspace panel
- **`static/index.html`**: Adds hidden "Task" tab + `workspaceKanbanTask` container to the workspace panel.
- **`static/workspace.js`** (`switchWorkspacePanelTab`): Supports `'kanban-task'` tab — shows/hides file tree and kanban task container.
- **`static/panels.js`** (`loadKanbanTask`): In dashboard mode, opens the workspace panel and shows task detail in the new "Task" tab instead of the preview above the board.
- **`static/panels.js`** (`_kanbanRenderTaskDetail`): Accepts `mode` param (`'preview'` | `'workspace'`) — shows "Close" button in workspace mode vs "Back to board" in preview mode.
- **`static/panels.js`** (`closeKanbanTaskDetail`): Cleans up workspace task tab and reverts to Files tab in dashboard mode.
- **`static/style.css`**: CSS rules to hide File/Artifacts/Todos tabs content when kanban-task tab is active, proper scrolling.

## How to test
1. Open Web UI → Settings → change **Kanban Layout** to "Dashboard".
2. Verify columns render as a single compact row (no profile lanes).
3. Click any task card → detail should open in the right-side workspace panel under a "Task" tab.
4. Click "Close" → task tab hides, workspace reverts to Files tab.
5. Switch layout back to "WebUI" → task detail closes, layout reverts to default.
6. In WebUI mode, clicking a task still shows the preview above the board (unchanged).