### PR TITLE
Report read-only memory writes as 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Memory writes now return actionable 403 errors for read-only `SOUL.md`, `MEMORY.md`, or `USER.md` targets (#4480).** The memory editor no longer turns permission failures into an opaque 500; the response names the target file so users can fix ownership or permissions on the shared volume.
+
 ## [v0.51.513] — 2026-06-19 — Release RX (credential-pool quota status for all pooled providers)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -17711,7 +17711,10 @@ def _handle_memory_write(handler, body):
     # (#4217/#4234/#4240).
     if target.is_symlink():
         return bad(handler, "Cannot write to a symlinked memory file")
-    target.write_text(body["content"], encoding="utf-8")
+    try:
+        target.write_text(body["content"], encoding="utf-8")
+    except PermissionError:
+        return bad(handler, f"{target.name} is not writable: {target}", 403)
     return j(handler, {"ok": True, "section": section, "path": str(target)})
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -5,6 +5,7 @@ Extracted from server.py (Sprint 11) so server.py is a thin shell.
 
 import html as _html
 import copy
+import errno
 import io
 import gzip
 import json
@@ -17713,7 +17714,9 @@ def _handle_memory_write(handler, body):
         return bad(handler, "Cannot write to a symlinked memory file")
     try:
         target.write_text(body["content"], encoding="utf-8")
-    except PermissionError:
+    except OSError as exc:
+        if not isinstance(exc, PermissionError) and getattr(exc, "errno", None) != errno.EROFS:
+            raise
         mode_hint = ""
         try:
             mode_hint = f" (mode {target.stat().st_mode & 0o777:o})"

--- a/api/routes.py
+++ b/api/routes.py
@@ -17714,7 +17714,19 @@ def _handle_memory_write(handler, body):
     try:
         target.write_text(body["content"], encoding="utf-8")
     except PermissionError:
-        return bad(handler, f"{target.name} is not writable: {target}", 403)
+        mode_hint = ""
+        try:
+            mode_hint = f" (mode {target.stat().st_mode & 0o777:o})"
+        except OSError:
+            pass
+        return bad(
+            handler,
+            (
+                f"{target.name} is not writable{mode_hint}: {target}. "
+                "Run chmod 644 on the file or fix ownership on the shared volume."
+            ),
+            403,
+        )
     return j(handler, {"ok": True, "section": section, "path": str(target)})
 
 

--- a/tests/test_memory_write_symlink_guard.py
+++ b/tests/test_memory_write_symlink_guard.py
@@ -12,6 +12,7 @@ setup); only the concrete target file is guarded.
 """
 
 import os
+import errno
 from pathlib import Path
 
 import pytest
@@ -86,6 +87,33 @@ def test_memory_write_read_only_soul_returns_403(tmp_path, monkeypatch):
     assert cap["bad"][1] == 403
     assert "SOUL.md" in cap["bad"][0]
     assert "writable" in cap["bad"][0].lower()
+    assert "chmod 644" in cap["bad"][0]
+
+
+def test_memory_write_read_only_filesystem_returns_403(tmp_path, monkeypatch):
+    """Docker read-only volume writes can raise EROFS instead of PermissionError."""
+    home = tmp_path / "home"
+    home.mkdir()
+    target = home / "SOUL.md"
+    target.write_text("original", encoding="utf-8")
+    original_write_text = Path.write_text
+
+    def fake_write_text(self, *args, **kwargs):
+        if self == target:
+            raise OSError(errno.EROFS, "read-only file system")
+        return original_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fake_write_text)
+
+    cap = _patch_memory_routes(monkeypatch, home)
+    routes._handle_memory_write(
+        _FakeHandler(),
+        {"section": "soul", "content": "# Soul\n"},
+    )
+
+    assert "bad" in cap, f"expected 403, got {cap}"
+    assert cap["bad"][1] == 403
+    assert "SOUL.md" in cap["bad"][0]
     assert "chmod 644" in cap["bad"][0]
 
 

--- a/tests/test_memory_write_symlink_guard.py
+++ b/tests/test_memory_write_symlink_guard.py
@@ -65,10 +65,12 @@ def test_memory_write_read_only_soul_returns_403(tmp_path, monkeypatch):
     """A read-only SOUL.md write must return an actionable 403, not bubble as 500."""
     home = tmp_path / "home"
     home.mkdir()
+    target = home / "SOUL.md"
+    target.write_text("original", encoding="utf-8")
     original_write_text = Path.write_text
 
     def fake_write_text(self, *args, **kwargs):
-        if self.name == "SOUL.md":
+        if self == target:
             raise PermissionError("read-only test file")
         return original_write_text(self, *args, **kwargs)
 
@@ -84,6 +86,7 @@ def test_memory_write_read_only_soul_returns_403(tmp_path, monkeypatch):
     assert cap["bad"][1] == 403
     assert "SOUL.md" in cap["bad"][0]
     assert "writable" in cap["bad"][0].lower()
+    assert "chmod 644" in cap["bad"][0]
 
 
 def test_memory_write_allows_symlinked_memories_directory(tmp_path, monkeypatch):

--- a/tests/test_memory_write_symlink_guard.py
+++ b/tests/test_memory_write_symlink_guard.py
@@ -12,6 +12,7 @@ setup); only the concrete target file is guarded.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -58,6 +59,31 @@ def test_memory_write_rejects_symlinked_memory_file(tmp_path, monkeypatch):
     assert "Cannot write to a symlinked memory file" in cap["bad"][0]
     # The symlink target outside the memories dir must be untouched.
     assert outside.read_text(encoding="utf-8") == "important"
+
+
+def test_memory_write_read_only_soul_returns_403(tmp_path, monkeypatch):
+    """A read-only SOUL.md write must return an actionable 403, not bubble as 500."""
+    home = tmp_path / "home"
+    home.mkdir()
+    original_write_text = Path.write_text
+
+    def fake_write_text(self, *args, **kwargs):
+        if self.name == "SOUL.md":
+            raise PermissionError("read-only test file")
+        return original_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fake_write_text)
+
+    cap = _patch_memory_routes(monkeypatch, home)
+    routes._handle_memory_write(
+        _FakeHandler(),
+        {"section": "soul", "content": "# Soul\n"},
+    )
+
+    assert "bad" in cap, f"expected 403, got {cap}"
+    assert cap["bad"][1] == 403
+    assert "SOUL.md" in cap["bad"][0]
+    assert "writable" in cap["bad"][0].lower()
 
 
 def test_memory_write_allows_symlinked_memories_directory(tmp_path, monkeypatch):


### PR DESCRIPTION
## Thinking Path

- The memory editor should fail with actionable permissions guidance, not an opaque server error.
- #4480 reports a read-only `SOUL.md` in a two-container setup, which currently makes `/api/memory/write` bubble `PermissionError` as a generic 500.
- The WebUI can fix its half by converting filesystem write permission failures into a clear 403 while leaving the agent-side source of the read-only file as a separate concern.

## What Changed

- Wrap memory target writes in `api/routes.py` with `PermissionError` handling.
- Return a 403 response that names the non-writable target file instead of letting the exception become a 500.
- Keep the existing symlink-target guard unchanged.
- Add regression coverage for read-only `SOUL.md` writes.
- Update `CHANGELOG.md`.

## Why It Matters

Users get a clear permissions/ownership problem they can fix instead of having to inspect container logs to understand why saving `SOUL.md` failed.

Refs #4480.

## Verification

- `./scripts/test.sh tests/test_memory_write_symlink_guard.py::test_memory_write_read_only_soul_returns_403 tests/test_memory_write_symlink_guard.py`
- `git diff --check`
- `.venv/bin/python scripts/ruff_lint.py --diff origin/master`

## Risks / Follow-ups

- This does not change the agent-side distribution or seeding behavior that may create a read-only `SOUL.md`; it only makes the WebUI failure mode explicit and actionable.
- The response includes the local target path, consistent with the existing successful memory-write response shape.

## Model Used

OpenAI GPT-5 Codex as coordinator, with a bounded `gpt-5.3-codex-spark` sub-agent attempted for implementation. The coordinator owned the acceptance test, corrected the worker worktree mistake, applied the final patch, reviewed the diff, and ran verification.
