### PR TITLE
[security] fix(models): scope live model provider keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Security
+
+- **Live model discovery no longer forwards a top-level provider API key to a different provider's `/models` endpoint.** The OpenAI-compatible fallback now only uses `model.api_key` when the requested live-model provider matches the active model provider; cross-provider requests fall back to provider-scoped credentials or the static catalog instead.
+
 ## [v0.51.513] — 2026-06-19 — Release RX (credential-pool quota status for all pooled providers)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -13204,11 +13204,19 @@ def _handle_live_models(handler, parsed):
                     import urllib.request
                     _providers_cfg = cfg.get("providers", {})
                     _prov = _providers_cfg.get(provider, {}) if isinstance(_providers_cfg, dict) else {}
-                    # Only use provider-scoped key — never fall back to a top-level
-                    # api_key which may belong to a different provider.
+                    # Only use a provider-scoped key.  A top-level model.api_key
+                    # is safe here only when it belongs to the requested provider;
+                    # otherwise /api/models/live?provider=<other> could forward
+                    # the active provider's credential to the wrong third party.
                     _key = _prov.get("api_key") if isinstance(_prov, dict) else None
                     if not _key:
-                        _key = cfg.get("model", {}).get("api_key")
+                        _model_cfg = cfg.get("model", {})
+                        if isinstance(_model_cfg, dict):
+                            _active_provider = _resolve_provider_alias(
+                                (_model_cfg.get("provider") or "").strip().lower()
+                            )
+                            if _active_provider == provider:
+                                _key = _model_cfg.get("api_key")
                     if _key:
                         _req = urllib.request.Request(
                             f"{_ep}/models",

--- a/api/routes.py
+++ b/api/routes.py
@@ -13124,7 +13124,8 @@ def _handle_live_models(handler, parsed):
                 # Fallback: try credential pool for base_url + api_key
                 if (not _base_url or not _api_key) and provider.startswith("custom:"):
                     try:
-                        from api.config import _has_explicit_pool_credentials, _resolve_provider_alias
+                        from api.config import _has_explicit_pool_credentials
+
                         if _has_explicit_pool_credentials(provider):
                             from agent.credential_pool import load_pool as _lpool
                             _resolved = _resolve_provider_alias(provider)

--- a/tests/test_byok_model_dropdown.py
+++ b/tests/test_byok_model_dropdown.py
@@ -247,7 +247,6 @@ class TestLiveModelsCustomProviderFallback:
             return True
         monkeypatch.setattr(r, "j", fake_j)
 
-        from urllib.parse import urlparse
         parsed = mock.MagicMock()
         parsed.query = "provider=custom"
 
@@ -372,6 +371,140 @@ class TestLiveModelsCustomProviderFallback:
             }
         ]
         assert [m["id"] for m in resp["models"]] == ["right-live-model"]
+
+    def test_standard_provider_live_fetch_does_not_reuse_active_provider_key(self, monkeypatch):
+        """A requested provider must not receive another provider's top-level key."""
+        import urllib.request
+
+        requests = []
+
+        def fake_urlopen(req, timeout=None):
+            requests.append(
+                {
+                    "url": req.full_url,
+                    "authorization": req.headers.get("Authorization"),
+                    "timeout": timeout,
+                }
+            )
+            raise AssertionError("unexpected cross-provider live fetch")
+
+        cfg = {
+            "model": {
+                "provider": "openai",
+                "api_key": "active-provider-canary",
+            },
+            "providers": {"mistralai": {}},
+        }
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+        resp = self._call_live_models(monkeypatch, cfg, "mistralai")
+
+        assert requests == []
+        assert resp["provider"] == "mistralai"
+        assert resp["models"], "static fallback models should still be returned"
+
+    def test_standard_provider_live_fetch_can_use_matching_top_level_key(self, monkeypatch):
+        """The active provider's top-level key remains valid for that same provider."""
+        import json
+        import urllib.request
+
+        requests = []
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps({"data": [{"id": "mistral-live-model"}]}).encode("utf-8")
+
+        def fake_urlopen(req, timeout=None):
+            requests.append(
+                {
+                    "url": req.full_url,
+                    "authorization": req.headers.get("Authorization"),
+                    "timeout": timeout,
+                }
+            )
+            return Response()
+
+        cfg = {
+            "model": {
+                "provider": "mistralai",
+                "api_key": "active-provider-canary",
+            },
+            "providers": {"mistralai": {}},
+        }
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+        resp = self._call_live_models(monkeypatch, cfg, "mistralai")
+
+        assert requests == [
+            {
+                "url": "https://api.mistral.ai/v1/models",
+                "authorization": "Bearer active-provider-canary",
+                "timeout": 8,
+            }
+        ]
+        assert resp["provider"] == "mistralai"
+
+    def test_standard_provider_live_fetch_allows_matching_active_provider_alias(self, monkeypatch):
+        """Alias-equivalent active providers should still count as the same provider."""
+        import json
+        import urllib.request
+
+        requests = []
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps({"data": [{"id": "zai-live-model"}]}).encode("utf-8")
+
+        def fake_urlopen(req, timeout=None):
+            requests.append(
+                {
+                    "url": req.full_url,
+                    "authorization": req.headers.get("Authorization"),
+                    "timeout": timeout,
+                }
+            )
+            return Response()
+
+        cfg = {
+            "model": {
+                "provider": "z.ai",
+                "api_key": "active-provider-canary",
+            },
+            "providers": {"zai": {}},
+        }
+        import api.config as c
+        import api.routes as r
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(c, "get_config", lambda: cfg)
+        monkeypatch.setattr(r, "j", lambda _handler, payload, **_kw: payload)
+        self._install_provider_model_ids(monkeypatch, lambda _p: [])
+
+        parsed = mock.MagicMock()
+        parsed.query = "provider=zai"
+        r._clear_live_models_cache()
+        resp = r._handle_live_models(object(), parsed)
+
+        assert requests == [
+            {
+                "url": "https://api.z.ai/v1/models",
+                "authorization": "Bearer active-provider-canary",
+                "timeout": 8,
+            }
+        ]
+        assert resp["provider"] == "zai"
 
 
 # ── Regression: known-good providers still work ───────────────────────────────


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI enriches the model picker by asking `/api/models/live?provider=<provider>` for provider-specific live model catalogs.
- The OpenAI-compatible fallback is allowed to call fixed provider `/models` endpoints, but each request must use only credentials that belong to that requested provider.
- The existing fallback had a provider-scoped key lookup, then fell back to the active top-level `model.api_key` even when the requested provider was different.
- This PR keeps same-provider top-level key compatibility while preventing cross-provider credential forwarding.
- The change is intentionally narrow: one credential-selection guard, regression coverage for both blocked and allowed cases, and a changelog note.

## Summary

This PR hardens live model discovery so a top-level provider API key is never forwarded to a different provider's `/models` endpoint.

- Prevents `/api/models/live?provider=<other>` from reusing the active provider's `model.api_key` when the requested provider has no provider-scoped key.
- Preserves the existing same-provider behavior, including alias-equivalent active providers such as `z.ai` resolving to `zai`.
- Adds regression tests for the blocked cross-provider case and the allowed same-provider cases.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Cross-provider live-model credential forwarding | A caller who can reach the live model endpoint could cause WebUI to send the active provider's top-level API key to a different fixed third-party provider endpoint during model discovery. | Medium |

## Before this PR

- `_handle_live_models()` first looked for `providers[requested_provider].api_key`.
- If that provider-scoped key was absent, it fell back to `model.api_key` unconditionally.
- A request such as `/api/models/live?provider=mistralai` could therefore send an active OpenAI top-level key in an Authorization bearer header to Mistral's `/models` endpoint.
- There was no regression test proving that cross-provider requests without provider-scoped credentials avoid live fetches with the active provider's key.

## After this PR

- The OpenAI-compatible fallback still prefers `providers[requested_provider].api_key`.
- A top-level `model.api_key` is used only when the active model provider resolves to the same canonical provider as the requested live-model provider.
- Cross-provider requests without a matching provider-scoped credential fall back to the static catalog rather than making a credentialed live fetch.
- Tests now cover:
  - cross-provider request does not call `urlopen`,
  - same-provider request can still use the top-level key,
  - alias-equivalent active provider names still work.

## Why It Matters

Provider API keys should not cross provider trust boundaries. Model discovery is a convenience feature, but it still attaches bearer credentials to outbound requests. If a key configured for one provider is sent to another provider's endpoint, the secret is disclosed to the wrong third party and may appear in upstream logs, telemetry, or error handling outside the user's intended provider relationship.

## How this differs from related issue/PR

- #892 added the OpenAI-compatible live `/models` fallback for standard providers.
- #2126 / #2135 fixed custom-provider model and endpoint scoping so named custom providers do not leak sibling custom-provider models or mix custom endpoint/key pairs.
- #4413 currently adjusts endpoint selection for stale provider catalogs and configured base URLs.

This PR addresses a distinct remaining standard-provider credential boundary: the fallback for fixed OpenAI-compatible providers must not use `model.api_key` unless the active model provider and requested live-model provider are the same after alias normalization.

## Attack flow

```text
Authenticated WebUI caller requests /api/models/live?provider=mistralai
    -> Mistral has no provider-scoped key in config
        -> fallback reuses active top-level model.api_key from another provider
            -> urllib sends Authorization: Bearer <active-provider-key> to https://api.mistral.ai/v1/models
                -> provider credential is disclosed to the wrong third-party endpoint
```

## Affected code

| Issue | Files |
|-------|-------|
| Cross-provider live-model credential forwarding | `api/routes.py`, `tests/test_byok_model_dropdown.py`, `CHANGELOG.md` |

## Root cause

Cross-provider live-model credential forwarding:

- Direct cause: `_handle_live_models()` fell back from `providers[provider].api_key` to `cfg["model"]["api_key"]` without checking whether the top-level key belonged to the requested provider.
- Boundary failure: the requested provider controls the outbound endpoint, while the top-level key belongs to the active model provider; those are separate credential scopes unless their provider IDs match after alias normalization.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Cross-provider live-model credential forwarding | 4.3 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N` |

Rationale:

- The impact is bounded to confidentiality of a configured provider credential.
- The attacker must be able to reach the WebUI API in a configured deployment.
- The endpoint targets fixed provider model-list URLs rather than arbitrary attacker-controlled hosts, so this is credential disclosure to the wrong third-party provider, not arbitrary SSRF.

## Safe reproduction steps

1. Configure an active top-level provider key, for example:

   ```yaml
   model:
     provider: openai
     api_key: active-provider-canary
   providers:
     mistralai: {}
   ```

2. Stub or intercept `urllib.request.urlopen` so no real network call is made.
3. Call `_handle_live_models()` through the `/api/models/live?provider=mistralai` path with `provider_model_ids()` returning `[]`.
4. On vulnerable code, the stub sees a request to `https://api.mistral.ai/v1/models` with `Authorization: Bearer active-provider-canary`.
5. With this PR, the cross-provider request does not call `urlopen` and the response falls back to the static Mistral catalog.

## Expected vulnerable behavior

- A request for provider `mistralai` could use a top-level key configured for provider `openai`.
- The proof signal is the captured outbound request carrying `Authorization: Bearer active-provider-canary` to Mistral's `/models` endpoint.
- No real secret or production endpoint is required to reproduce the issue; the regression uses a canary value and a monkeypatched `urlopen`.

## What Changed

- Restrict fallback use of top-level `model.api_key` to cases where the active model provider resolves to the requested live-model provider.
- Preserve provider-scoped key behavior for `providers[provider].api_key`.
- Preserve same-provider top-level key behavior, including alias-equivalent provider names.
- Add regression tests for blocked cross-provider forwarding and allowed same-provider live fetches.
- Add a release-note-ready changelog entry under `Unreleased`.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Security fix | `api/routes.py` | Adds the active-provider equality check before top-level `model.api_key` can be used for live model discovery. |
| Regression tests | `tests/test_byok_model_dropdown.py` | Adds blocked cross-provider and allowed same-provider/alias-equivalent live fetch coverage. |
| Changelog | `CHANGELOG.md` | Documents the security-sensitive behavior change. |

## Maintainer impact

- No new dependencies, build steps, or frontend changes.
- Provider-scoped credentials continue to work as before.
- Top-level keys continue to work for the active provider itself.
- Cross-provider model discovery without a provider-scoped key now falls back to the static model list instead of making a credentialed request.

## Fix rationale

The live model endpoint's outbound provider is selected by the request parameter, so credential selection must be scoped to that same provider. Comparing the active top-level provider after alias normalization keeps legitimate same-provider compatibility while preventing accidental cross-provider disclosure.

## Type of change

- [x] Security fix
- [x] Tests
- [x] Documentation update
- [ ] Refactor with no behavior change

## Verification

Docker/container validation:

- [x] `docker run --rm -v <repo-copy>:/src:ro python:3.11-slim bash -lc 'apt-get update >/dev/null && apt-get install -y git >/dev/null && cp -a /src /work && cd /work && ./scripts/test.sh tests/test_byok_model_dropdown.py -q && ./.venv/bin/ruff check tests/test_byok_model_dropdown.py && git diff --check'`
  - Result: `23 passed`; ruff passed for the touched test file; `git diff --check` passed.

Host-local supplemental validation:

- [x] `./scripts/test.sh tests/test_byok_model_dropdown.py -q`
  - Result: `23 passed`.
- [x] `./.venv/bin/ruff check tests/test_byok_model_dropdown.py`
  - Result: passed.
- [x] `git diff --check`
  - Result: passed.

Notes:

- `./.venv/bin/ruff check api/routes.py tests/test_byok_model_dropdown.py` reports pre-existing lint findings in the large legacy `api/routes.py` file unrelated to this patch. The touched test file passes ruff cleanly.

## Risks / Follow-ups

- This may reduce live enrichment for a provider that only has an unrelated top-level key configured. That is intentional: provider-specific live fetches should use provider-specific credentials.
- If maintainers want a broader credential helper, it should return a key only after proving the credential belongs to the requested provider.
- This PR does not change custom-provider credential pool behavior; it only scopes the standard OpenAI-compatible fallback's top-level key use.

## Disclosure notes

- This report is bounded to the standard-provider live model discovery fallback.
- The finding does not claim arbitrary-host SSRF or unauthenticated reachability.
- No real provider credentials were used; tests use canary strings and a monkeypatched request function.
- No unrelated files were changed.

## Model Used

AI-assisted contribution using OpenAI `gpt-5.5` through Hermes Agent, with repository-local tests, Docker validation, and GitHub CLI workflow support.
