### PR TITLE
[security] fix(session): scope imported sessions to active profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Security
+
+- **Imported sessions are now stamped with the active Hermes profile instead of being saved as root/default-owned.** This keeps JSON imports performed from a named profile inside that profile boundary, so default-profile export and file APIs cannot later treat the imported session as their own.
+
 ## [v0.51.513] — 2026-06-19 — Release RX (credential-pool quota status for all pooled providers)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -18012,6 +18012,7 @@ def _handle_session_import(handler, body):
         model=model,
         messages=messages,
         tool_calls=body.get("tool_calls", []),
+        profile=get_active_profile_name(),
     )
     s.pinned = body.get("pinned", False)
     with LOCK:

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -526,16 +526,18 @@ def test_session_import_default_profile_remains_default_owned():
         captured["json"] = {"data": data, "status": status}
         return captured["json"]
 
+    sessions = OrderedDict()
     with patch("api.routes.get_active_profile_name", return_value="default"), \
          patch("api.routes.resolve_trusted_workspace", return_value=Path("/tmp/default-workspace")), \
          patch("api.routes.Session", side_effect=lambda **kwargs: _ImportedSessionStub(**kwargs)), \
-         patch.object(routes, "SESSIONS", OrderedDict()), \
+         patch.object(routes, "SESSIONS", sessions), \
          patch("api.routes.publish_session_list_changed"), \
          patch("api.routes.j", side_effect=fake_j):
         routes._handle_session_import(SimpleNamespace(headers={}), body)
 
     session = captured["json"]["data"]["session"]
     assert session["profile"] == "default"
+    assert sessions["imported_profile_001"].profile == "default"
 
 
 def _profile_state_db_path(profile: str | None = None) -> Path:

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -18,6 +18,7 @@ import json
 import os
 import sqlite3
 import time
+from collections import OrderedDict
 from types import SimpleNamespace
 from unittest.mock import patch
 import urllib.request
@@ -450,6 +451,91 @@ def test_session_export_allows_session_from_active_profile():
     assert handler.ended is True
     assert b"same profile content" in handler.body
     assert ("Cache-Control", "no-store") in handler.sent_headers
+
+
+# ── Imported sessions must be stamped with the active profile ───────────────
+
+
+class _ImportedSessionStub:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.session_id = kwargs.get("session_id") or "imported_profile_001"
+        self.profile = kwargs.get("profile")
+        self.messages = kwargs.get("messages") or []
+        self.pinned = False
+
+    def save(self):
+        self.saved = True
+
+    def compact(self):
+        return {
+            "session_id": self.session_id,
+            "profile": self.profile,
+            "workspace": getattr(self, "workspace", None),
+            "message_count": len(self.messages),
+        }
+
+
+def test_session_import_stamps_active_profile():
+    """JSON imports must not create root/default-owned rows from named profiles.
+
+    The import route validates the workspace under the request's active profile.
+    If the new Session is then saved with profile=None, default/root requests can
+    later export the transcript or use the session id to read files from that
+    named-profile workspace. Pin the import-time ownership stamp directly.
+    """
+    import api.routes as routes
+
+    captured = {}
+    body = {
+        "title": "Named profile import",
+        "workspace": "/tmp/named-profile-workspace",
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "named profile secret"}],
+    }
+
+    def fake_j(_handler, data, status=200, **_kwargs):
+        captured["json"] = {"data": data, "status": status}
+        return captured["json"]
+
+    sessions = OrderedDict()
+    with patch("api.routes.get_active_profile_name", return_value="poc"), \
+         patch("api.routes.resolve_trusted_workspace", return_value=Path("/tmp/named-profile-workspace")), \
+         patch("api.routes.Session", side_effect=lambda **kwargs: _ImportedSessionStub(**kwargs)), \
+         patch.object(routes, "SESSIONS", sessions), \
+         patch("api.routes.publish_session_list_changed"), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes._handle_session_import(SimpleNamespace(headers={}), body)
+
+    session = captured["json"]["data"]["session"]
+    assert captured["json"]["status"] == 200
+    assert session["profile"] == "poc"
+    assert sessions["imported_profile_001"].profile == "poc"
+
+
+def test_session_import_default_profile_remains_default_owned():
+    """Root/default imports keep the legacy default ownership semantics."""
+    import api.routes as routes
+
+    captured = {}
+    body = {
+        "messages": [{"role": "user", "content": "default profile content"}],
+    }
+
+    def fake_j(_handler, data, status=200, **_kwargs):
+        captured["json"] = {"data": data, "status": status}
+        return captured["json"]
+
+    with patch("api.routes.get_active_profile_name", return_value="default"), \
+         patch("api.routes.resolve_trusted_workspace", return_value=Path("/tmp/default-workspace")), \
+         patch("api.routes.Session", side_effect=lambda **kwargs: _ImportedSessionStub(**kwargs)), \
+         patch.object(routes, "SESSIONS", OrderedDict()), \
+         patch("api.routes.publish_session_list_changed"), \
+         patch("api.routes.j", side_effect=fake_j):
+        routes._handle_session_import(SimpleNamespace(headers={}), body)
+
+    session = captured["json"]["data"]["session"]
+    assert session["profile"] == "default"
 
 
 def _profile_state_db_path(profile: str | None = None) -> Path:


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI profiles are used to keep sessions, workspaces, credentials, and sidecar state scoped to the active profile.
- `/api/session/import` already validates the imported workspace through the active request/profile context.
- The route then created the new `Session` without an explicit `profile`, leaving the sidecar row as `profile: null`.
- Existing profile matching treats missing profile values as the root/default profile for legacy compatibility.
- This PR stamps imported sessions with the active profile at creation time so named-profile imports remain owned by that named profile.

## What Changed

- Pass `profile=get_active_profile_name()` when `POST /api/session/import` constructs the imported `Session`.
- Add regression coverage that:
  - a named-profile import is saved with that named profile;
  - a default-profile import remains default-owned for compatibility.
- Add an Unreleased security changelog entry.

## Security issues covered

| Issue | Impact | Severity |
| --- | --- | --- |
| Imported sessions from a named profile were saved as root/default-owned | A default-profile request could later treat the imported session as its own, including export and session-backed workspace file access | High |

## Before this PR

- The import route validated the supplied workspace under the request's active profile.
- The new `Session` was created without `profile=...`.
- The imported sidecar row had `profile: null`.
- `profile: null` is treated as default/root for legacy rows, so the default profile could later match that imported session.

## After this PR

- The imported session is stamped with the active request profile during creation.
- Named-profile imports stay named-profile-owned.
- Default-profile imports keep the expected default ownership behavior.

## Why It Matters

Hermes WebUI session ids are used by direct session and file APIs. If an imported session created from a named profile is silently saved as default-owned, the profile boundary is weakened: the default profile can export that imported transcript or use the session id as a handle to the imported session's workspace.

This is especially sensitive because profiles commonly separate workspaces, provider credentials, and local project context. The fix keeps the ownership decision at the same point where the route already validates the imported workspace.

## How this differs from related profile/session hardening

This is related to the profile/session scoping family addressed by prior session detail/export hardening, but the failure mode is different:

- Prior fixes scoped direct reads of already-owned sessions.
- This PR fixes an import-time ownership stamping bug that caused a newly imported named-profile session to be created as root/default-owned.
- The route-specific fix is intentionally narrow: it changes the owner assigned at session creation instead of adding another downstream exception to export or file routes.

## Attack flow

1. A request scoped to a named profile imports a JSON session with a workspace valid for that named profile.
2. The import route validates that workspace successfully under the named profile.
3. The route creates the new session without `profile=...`.
4. The saved row has `profile: null`.
5. Later default-profile requests match the row as root/default and can use the imported session id with direct session/export/file APIs.

## Affected code

| Area | File | Change |
| --- | --- | --- |
| Session import | `api/routes.py` | Stamp imported sessions with `get_active_profile_name()` |
| Regression tests | `tests/test_issue1611_session_profile_filtering.py` | Cover named-profile and default-profile import ownership |
| Release notes | `CHANGELOG.md` | Add Unreleased security note |

## Root cause

`_handle_session_import` enforced profile-aware workspace validation, but did not carry the active profile into the new `Session` object. Because legacy rows with no profile are intentionally treated as default/root, the missing creation-time profile became a cross-profile ownership confusion.

## CVSS assessment

- CVSS v3.1: 7.5 High
- Vector: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N`
- Rationale: an authenticated/browser-scoped WebUI actor in one profile can cause imported session data and session-backed workspace files to become readable through another profile boundary. The main impact is confidentiality; the patch is scoped to ownership stamping and does not claim a broader write primitive.

## Safe reproduction steps

On vulnerable code, using isolated test state:

1. Create or select a named profile.
2. Add a workspace under that named profile.
3. Import a JSON session through `POST /api/session/import` while scoped to the named profile.
4. Observe the imported session sidecar/response has no named profile ownership.
5. Switch to the default profile and request the imported session by id through export or session-backed file read APIs.

## Expected vulnerable behavior

On vulnerable code, the imported session is saved as `profile: null`, and default-profile requests can treat it as default-owned.

## Fix rationale

The import route already knows the correct trust boundary: the active profile used for workspace validation. Stamping the new `Session` with that same active profile keeps ownership consistent at creation time and avoids relying on downstream routes to infer intent from legacy-compatible `None` profile values.

## Verification

Host-local:

```bash
./scripts/test.sh tests/test_issue1611_session_profile_filtering.py -q
# 21 passed

./.venv/bin/ruff check tests/test_issue1611_session_profile_filtering.py
# All checks passed

./.venv/bin/python -m py_compile api/routes.py tests/test_issue1611_session_profile_filtering.py
# passed

git diff --check
# passed
```

Docker/container:

```bash
docker run --rm -v "$PWD":/src:ro python:3.11-slim bash -lc '
  set -euo pipefail
  apt-get update >/dev/null
  apt-get install -y git >/dev/null
  cp -a /src /work
  cd /work
  ./scripts/test.sh tests/test_issue1611_session_profile_filtering.py -q
  ./.venv/bin/ruff check tests/test_issue1611_session_profile_filtering.py
  ./.venv/bin/python -m py_compile api/routes.py tests/test_issue1611_session_profile_filtering.py
  git diff --check
'
# 21 passed; ruff passed; py_compile passed; diff check passed
```

## Risks / Follow-ups

- Existing legacy sessions with no profile continue to behave as default/root rows; this PR does not migrate historical data.
- The change is limited to JSON session imports and does not alter CLI/session-list aggregation behavior.
- This is not a UI change, so no screenshots are included.

## Contract Routing

Task type: security-sensitive session ownership fix.

Touched areas:
- `api/routes.py` session import path
- `tests/test_issue1611_session_profile_filtering.py`
- `CHANGELOG.md`

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`

Scope boundaries:
- No intentional contract-document change.
- No UI/UX change.
- Legacy `profile: null` compatibility remains unchanged for existing rows.

Evidence needed before claiming done:
- Focused profile/session tests.
- Syntax/lint checks for touched code.
- Docker/container validation.

## Model Used

AI-assisted using OpenAI GPT-5.5 through Hermes Agent. Notable tool use: local git/GitHub CLI, focused pytest validation, ruff on touched tests, Python syntax compilation, and Docker container validation.
