### PR TITLE
Expose built-in personalities in WebUI config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Agent personality defaults now include the CLI built-ins when `agent.personalities` is missing or malformed.** Fresh config data is hydrated with the same 14 built-in personalities used by CLI, while user-defined names continue to override those defaults. A malformed or non-dict `agent.personalities` section now falls back to the built-in set instead of emptying personality selection. Issue #4465.
+
 ## [v0.51.513] — 2026-06-19 — Release RX (credential-pool quota status for all pooled providers)
 
 ### Added

--- a/api/config.py
+++ b/api/config.py
@@ -328,10 +328,43 @@ _DEFAULT_EXPERIMENTAL_CONFIG = {
     # later PR deliberately enables and wires this flag.
     "unified_session_db": False,
 }
+_DEFAULT_AGENT_PERSONALITIES = {
+    # Mirrors the Hermes Agent CLI built-ins so WebUI's config-derived
+    # /personality path is not empty for fresh profiles.
+    "helpful": "You are a helpful, friendly AI assistant.",
+    "concise": "You are a concise assistant. Keep responses brief and to the point.",
+    "technical": "You are a technical expert. Provide detailed, accurate technical information.",
+    "creative": "You are a creative assistant. Think outside the box and offer innovative solutions.",
+    "teacher": "You are a patient teacher. Explain concepts clearly with examples.",
+    "kawaii": "You are a kawaii assistant! Use cute expressions like (◕‿◕), ★, ♪, and ~! Add sparkles and be super enthusiastic about everything! Every response should feel warm and adorable desu~! ヽ(>∀<☆)ノ",
+    "catgirl": "You are Neko-chan, an anime catgirl AI assistant, nya~! Add 'nya' and cat-like expressions to your speech. Use kaomoji like (=^･ω･^=) and ฅ^•ﻌ•^ฅ. Be playful and curious like a cat, nya~!",
+    "pirate": "Arrr! Ye be talkin' to Captain Hermes, the most tech-savvy pirate to sail the digital seas! Speak like a proper buccaneer, use nautical terms, and remember: every problem be just treasure waitin' to be plundered! Yo ho ho!",
+    "shakespeare": "Hark! Thou speakest with an assistant most versed in the bardic arts. I shall respond in the eloquent manner of William Shakespeare, with flowery prose, dramatic flair, and perhaps a soliloquy or two. What light through yonder terminal breaks?",
+    "surfer": "Duuude! You're chatting with the chillest AI on the web, bro! Everything's gonna be totally rad. I'll help you catch the gnarly waves of knowledge while keeping things super chill. Cowabunga!",
+    "noir": "The rain hammered against the terminal like regrets on a guilty conscience. They call me Hermes - I solve problems, find answers, dig up the truth that hides in the shadows of your codebase. In this city of silicon and secrets, everyone's got something to hide. What's your story, pal?",
+    "uwu": "hewwo! i'm your fwiendwy assistant uwu~ i wiww twy my best to hewp you! *nuzzles your code* OwO what's this? wet me take a wook! i pwomise to be vewy hewpful >w<",
+    "philosopher": "Greetings, seeker of wisdom. I am an assistant who contemplates the deeper meaning behind every query. Let us examine not just the 'how' but the 'why' of your questions. Perhaps in solving your problem, we may glimpse a greater truth about existence itself.",
+    "hype": "YOOO LET'S GOOOO!!! I am SO PUMPED to help you today! Every question is AMAZING and we're gonna CRUSH IT together! This is gonna be LEGENDARY! ARE YOU READY?! LET'S DO THIS!",
+}
 
 
 def _apply_config_defaults(config_data: dict) -> None:
     """Populate documented default-only config keys in-place."""
+    agent_cfg = config_data.get("agent")
+    if not isinstance(agent_cfg, dict):
+        agent_cfg = {}
+        config_data["agent"] = agent_cfg
+
+    personalities = agent_cfg.get("personalities")
+    if isinstance(personalities, dict):
+        merged = copy.deepcopy(_DEFAULT_AGENT_PERSONALITIES)
+        merged.update(copy.deepcopy(personalities))
+        agent_cfg["personalities"] = merged
+    else:
+        # Keep behavior aligned with CLI loader defaults: if personalities are
+        # absent or malformed, replace the section entirely with built-ins.
+        agent_cfg["personalities"] = copy.deepcopy(_DEFAULT_AGENT_PERSONALITIES)
+
     experimental = config_data.get("experimental")
     if not isinstance(experimental, dict):
         experimental = {}
@@ -486,6 +519,29 @@ def get_config_for_profile_home(profile_home: "Path | str | None") -> dict:
     return _load_yaml_config_file(target / "config.yaml")
 
 
+def _config_for_yaml_save(config_data: dict) -> dict:
+    """Return a YAML-safe config copy without runtime-only expanded defaults."""
+    if not isinstance(config_data, dict):
+        return {}
+    data = copy.deepcopy(config_data)
+    agent_cfg = data.get("agent")
+    if isinstance(agent_cfg, dict):
+        personalities = agent_cfg.get("personalities")
+        if isinstance(personalities, dict):
+            custom_personalities = {
+                name: value
+                for name, value in personalities.items()
+                if _DEFAULT_AGENT_PERSONALITIES.get(name) != value
+            }
+            if custom_personalities:
+                agent_cfg["personalities"] = custom_personalities
+            else:
+                agent_cfg.pop("personalities", None)
+        if not agent_cfg:
+            data.pop("agent", None)
+    return data
+
+
 def _save_yaml_config_file(config_path: Path, config_data: dict) -> None:
     try:
         import yaml as _yaml
@@ -494,7 +550,7 @@ def _save_yaml_config_file(config_path: Path, config_data: dict) -> None:
 
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(
-        _yaml.safe_dump(config_data, sort_keys=False, allow_unicode=True),
+        _yaml.safe_dump(_config_for_yaml_save(config_data), sort_keys=False, allow_unicode=True),
         encoding="utf-8",
     )
 

--- a/tests/test_issue4465_builtin_personalities.py
+++ b/tests/test_issue4465_builtin_personalities.py
@@ -1,0 +1,106 @@
+"""Regression coverage for #4465 built-in personality visibility.
+
+Hermes Agent CLI ships built-in personalities from its CLI config loader. WebUI
+should expose the same defaults through config-derived personality paths so a
+fresh profile is not empty.
+"""
+
+from api import config
+
+
+BUILTIN_NAMES = {
+    "helpful",
+    "concise",
+    "technical",
+    "creative",
+    "teacher",
+    "kawaii",
+    "catgirl",
+    "pirate",
+    "shakespeare",
+    "surfer",
+    "noir",
+    "uwu",
+    "philosopher",
+    "hype",
+}
+
+
+def test_config_defaults_seed_agent_builtin_personalities_for_fresh_profile():
+    cfg = {}
+
+    config._apply_config_defaults(cfg)
+
+    personalities = cfg["agent"]["personalities"]
+    assert set(personalities) == BUILTIN_NAMES
+    assert personalities["helpful"] == "You are a helpful, friendly AI assistant."
+    assert "desu~!" in personalities["kawaii"]
+    assert "William Shakespeare" in personalities["shakespeare"]
+    assert personalities["hype"].startswith("YOOO LET'S GOOOO!!!")
+
+
+def test_config_defaults_preserve_custom_personality_overrides():
+    cfg = {
+        "agent": {
+            "personalities": {
+                "helpful": "Custom helpful prompt.",
+                "local": {
+                    "description": "Local voice",
+                    "prompt": "Use the local team voice.",
+                },
+            }
+        }
+    }
+
+    config._apply_config_defaults(cfg)
+
+    personalities = cfg["agent"]["personalities"]
+    assert personalities["helpful"] == "Custom helpful prompt."
+    assert personalities["local"]["prompt"] == "Use the local team voice."
+    assert "kawaii" in personalities
+    assert "shakespeare" in personalities
+
+
+def test_config_defaults_replace_non_dict_personality_section_with_builtins():
+    cfg = {"agent": {"personalities": []}}
+
+    config._apply_config_defaults(cfg)
+
+    assert set(cfg["agent"]["personalities"]) == BUILTIN_NAMES
+
+
+def test_config_save_strips_generated_builtin_personalities(tmp_path):
+    cfg = {}
+    config._apply_config_defaults(cfg)
+    cfg["webui"] = {"theme": "dark"}
+
+    path = tmp_path / "config.yaml"
+    config._save_yaml_config_file(path, cfg)
+
+    text = path.read_text(encoding="utf-8")
+    assert "webui:" in text
+    assert "theme: dark" in text
+    assert "personalities:" not in text
+    assert "helpful:" not in text
+
+
+def test_config_save_preserves_custom_personality_overrides(tmp_path):
+    cfg = {
+        "agent": {
+            "personality": "local",
+            "personalities": {
+                "helpful": "Custom helpful prompt.",
+                "local": "Use the local team voice.",
+            },
+        }
+    }
+    config._apply_config_defaults(cfg)
+
+    path = tmp_path / "config.yaml"
+    config._save_yaml_config_file(path, cfg)
+
+    text = path.read_text(encoding="utf-8")
+    assert "personalities:" in text
+    assert "helpful: Custom helpful prompt." in text
+    assert "local: Use the local team voice." in text
+    assert "kawaii:" not in text

--- a/tests/test_sprint28.py
+++ b/tests/test_sprint28.py
@@ -71,14 +71,16 @@ def _cleanup_session(sid):
 # ── GET /api/personalities ────────────────────────────────────────────────────
 
 def test_personalities_empty_when_none_exist():
-    """GET /api/personalities returns empty list when no personalities exist."""
+    """GET /api/personalities returns built-in personalities when no files exist."""
     p_dir = _personalities_dir()
     for child in list(p_dir.iterdir()):
         if child.is_dir() and not child.is_symlink():
             shutil.rmtree(child)
     d, status = get("/api/personalities")
     assert status == 200
-    assert d.get("personalities") == []
+    personalities = d.get("personalities") or []
+    assert len(personalities) == 14
+    assert {"name": "helpful", "description": "You are a helpful, friendly AI assistant."} in personalities
 
 
 def test_personalities_lists_from_config():


### PR DESCRIPTION
## Thinking Path

- #4465 asks to expose Hermes Agent personalities in WebUI.
- The existing WebUI `/personality` backend and slash-command flow already work, but WebUI only reads `agent.personalities` literally from `config.yaml`.
- Hermes Agent CLI ships 14 built-in personalities through its CLI config defaults, so a fresh WebUI profile can incorrectly look like it has no personalities.
- This PR fixes the narrow source-of-truth mismatch first: WebUI hydrates the same built-in names/prompts at config-default time while preserving user overrides.
- I intentionally leave the profile-dropdown/settings-toggle UI as follow-up scope.

## What Changed

- Added a WebUI-local `_DEFAULT_AGENT_PERSONALITIES` map mirroring the current Hermes Agent CLI built-ins.
- Updated `_apply_config_defaults(...)` so missing or malformed `agent.personalities` gets the built-ins.
- Preserved user-defined personalities and let custom names override built-in names.
- Added `_config_for_yaml_save(...)` so generated built-ins are not written back into `config.yaml`; only user custom/overridden personalities persist.
- Updated the existing Sprint 28 personality expectation from empty fresh config to built-in defaults.
- Added focused regression tests for fresh defaults, malformed config fallback, custom override preservation, and YAML writeback hygiene.
- Updated `CHANGELOG.md`.

## Why It Matters

Fresh WebUI profiles should not show `/personality` as empty when Hermes Agent CLI already has built-in personalities available. This gives WebUI parity for the existing slash-command path without adding new UI surface or persisting generated defaults into user config files.

## Verification

- `./scripts/test.sh tests/test_issue4465_builtin_personalities.py tests/test_sprint28.py tests/test_issue798.py` -> 29 passed
- `git diff --check`
- `.venv/bin/python -m py_compile api/config.py tests/test_issue4465_builtin_personalities.py tests/test_sprint28.py`
- `.venv/bin/ruff check tests/test_issue4465_builtin_personalities.py`

Note: full-file Ruff on `api/config.py` still reports pre-existing unused/redefined imports unrelated to this diff, so I did not expand this PR into broad lint cleanup.

## Risks / Follow-ups

- This keeps a local WebUI copy of the current CLI built-ins. If Hermes Agent changes the built-in list later, WebUI will need a follow-up sync or a shared source.
- This does not add the requested profile-dropdown personality picker or the optional settings toggle. Those should remain follow-up UI slices after the backend source is non-empty.
- The PR references #4465 rather than closing it because the broader UI request remains open.

## Model Used

AI-assisted with OpenAI GPT-5 Codex as coordinator and `gpt-5.3-codex-spark` worker sub-agent. Coordinator wrote the failing acceptance test, reviewed the worker diff, corrected the built-in prompt copy to match Hermes Agent CLI, added YAML writeback hygiene coverage, and performed final verification.

Refs #4465
