### PR TITLE
Release v0.51.527 — completion notifications survive a backgrounded tab (#4416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.527] — 2026-06-19 — Release SL (completion notifications survive a backgrounded tab)
+
+### Fixed
+
+- **Desktop notifications no longer get silently dropped when the agent finishes while you're on another tab (#4416).** Chromium throttles a background tab's SSE, so the stream's `done` event is delivered late — after you return to the tab, when `document.hidden` already reads `false` — and the response-complete notification was suppressed by the live visibility check. The WebUI now tracks whether the tab was hidden at *any* point during a stream and notifies on that basis, so a turn you stepped away from still notifies on completion. A turn you watched the whole time stays silent (matching how Slack/Discord/Gmail/Claude behave), and the user's notifications-enabled setting is still honored.
+
 ## [v0.51.526] — 2026-06-19 — Release SK (the "Running" indicator clears when the server is idle)
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -1426,18 +1426,30 @@ const LIVE_STREAMS={};
 // #4416: track whether the tab was hidden at ANY point during a live stream, so
 // the response-complete notification fires for a backgrounded tab even when
 // Chromium throttles the background-tab SSE and delivers the `done` event LATE
-// (after the user returns, when document.hidden already reads false). Keyed by
-// session id; set at stream attach, OR'd true whenever the tab goes hidden,
-// read + cleared at done. One idempotent visibilitychange listener (never
-// leaks) flips the bit on all active entries.
+// (after the user returns, when document.hidden already reads false). Each entry
+// is STREAM-OWNED ({streamId, wasHidden}) so a stale entry left by a non-`done`
+// terminal path (apperror/cancel/stream-error/reconnect-no-active) can never be
+// mis-attributed to a later stream for the same session id — a reconnect only
+// keeps the prior state when the streamId matches. One idempotent
+// visibilitychange listener (never leaks) flips wasHidden on all active entries.
 const _STREAM_WAS_HIDDEN={};
 let _streamHiddenTrackerBound=false;
 function _bindStreamHiddenTracker(){
   if(_streamHiddenTrackerBound||typeof document==='undefined'||typeof document.addEventListener!=='function') return;
   _streamHiddenTrackerBound=true;
   document.addEventListener('visibilitychange',()=>{
-    if(document.hidden){ for(const k in _STREAM_WAS_HIDDEN) _STREAM_WAS_HIDDEN[k]=true; }
+    if(document.hidden){ for(const k in _STREAM_WAS_HIDDEN){ const e=_STREAM_WAS_HIDDEN[k]; if(e) e.wasHidden=true; } }
   });
+}
+function _clearStreamHidden(sid, streamId){
+  // Clear only when we own the current stream's entry (or unconditionally when
+  // streamId is omitted). Prevents a terminal path for an old stream from wiping
+  // a newer stream's tracker.
+  if(!sid) return;
+  const e=_STREAM_WAS_HIDDEN[sid];
+  if(!e) return;
+  if(streamId&&e.streamId&&e.streamId!==streamId) return;
+  delete _STREAM_WAS_HIDDEN[sid];
 }
 
 function closeLiveStream(sessionId, streamId, source){
@@ -1506,11 +1518,17 @@ function closeOtherLiveStreams(activeSid){
 function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!activeSid||!streamId) return;
   const reconnecting=!!options.reconnecting;
-  // #4416: start (or, on reconnect, keep) tracking whether the tab was hidden
-  // during this stream so the done-notification fires for a backgrounded tab.
+  // #4416: start (or, on reconnect for the SAME stream, keep) tracking whether
+  // the tab was hidden during this stream so the done-notification fires for a
+  // backgrounded tab. A reconnect with a different streamId re-seeds (the old
+  // entry belonged to a prior stream).
   _bindStreamHiddenTracker();
-  if(!reconnecting||!(activeSid in _STREAM_WAS_HIDDEN)){
-    _STREAM_WAS_HIDDEN[activeSid]=(typeof document!=='undefined'&&!!document.hidden);
+  {
+    const _prev=_STREAM_WAS_HIDDEN[activeSid];
+    const _keep=reconnecting&&_prev&&_prev.streamId===streamId;
+    if(!_keep){
+      _STREAM_WAS_HIDDEN[activeSid]={streamId,wasHidden:(typeof document!=='undefined'&&!!document.hidden)};
+    }
   }
   if(!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[...uploaded],toolCalls:[]};
   else {
@@ -1779,6 +1797,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _smdEndParser();
     if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
     _clearOwnerInflightState();
+    _clearStreamHidden(activeSid, streamId);  // #4416: terminal path, drop hidden tracker
     _flushReasoningToAnchor();
     _scheduleAnchorRegistryCleanup();
     _clearApprovalForOwner();
@@ -3560,8 +3579,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         // delivers late — after the user returns and document.hidden is false).
         // If the user watched the whole stream, _wasEverHidden stays false and
         // the notification is suppressed (matches Slack/Discord/Gmail/Claude).
-        const _wasEverHidden=!!_STREAM_WAS_HIDDEN[activeSid];
-        delete _STREAM_WAS_HIDDEN[activeSid];
+        const _hiddenEntry=_STREAM_WAS_HIDDEN[activeSid];
+        const _wasEverHidden=!!(_hiddenEntry&&_hiddenEntry.wasHidden);
+        _clearStreamHidden(activeSid, streamId);
         sendBrowserNotification('Response complete',assistantText?assistantText.slice(0,100):'Task finished',{forceHidden:_wasEverHidden,sid:activeSid});
       };
       if(_shouldUseStreamFade()&&assistantBody){
@@ -3727,6 +3747,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // This is distinct from the SSE network 'error' event below.
       try{if(source&&source.readyState!==2)source.close();}catch(_){ }
       _clearOwnerInflightState();
+      _clearStreamHidden(activeSid, streamId);  // #4416: terminal path, drop hidden tracker
       _clearApprovalForOwner();
       _clearClarifyForOwner('terminal');
       let d={};
@@ -3899,6 +3920,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
       try{if(source&&source.readyState!==2)source.close();}catch(_){ }
       _clearOwnerInflightState();
+      _clearStreamHidden(activeSid, streamId);  // #4416: terminal path, drop hidden tracker
       _clearApprovalForOwner();
       _clearClarifyForOwner('cancelled');
       let _cancelData={};

--- a/static/messages.js
+++ b/static/messages.js
@@ -1423,6 +1423,23 @@ async function send(){
 
 const LIVE_STREAMS={};
 
+// #4416: track whether the tab was hidden at ANY point during a live stream, so
+// the response-complete notification fires for a backgrounded tab even when
+// Chromium throttles the background-tab SSE and delivers the `done` event LATE
+// (after the user returns, when document.hidden already reads false). Keyed by
+// session id; set at stream attach, OR'd true whenever the tab goes hidden,
+// read + cleared at done. One idempotent visibilitychange listener (never
+// leaks) flips the bit on all active entries.
+const _STREAM_WAS_HIDDEN={};
+let _streamHiddenTrackerBound=false;
+function _bindStreamHiddenTracker(){
+  if(_streamHiddenTrackerBound||typeof document==='undefined'||typeof document.addEventListener!=='function') return;
+  _streamHiddenTrackerBound=true;
+  document.addEventListener('visibilitychange',()=>{
+    if(document.hidden){ for(const k in _STREAM_WAS_HIDDEN) _STREAM_WAS_HIDDEN[k]=true; }
+  });
+}
+
 function closeLiveStream(sessionId, streamId, source){
   const live=LIVE_STREAMS[sessionId];
   if(!live) return;
@@ -1489,6 +1506,12 @@ function closeOtherLiveStreams(activeSid){
 function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!activeSid||!streamId) return;
   const reconnecting=!!options.reconnecting;
+  // #4416: start (or, on reconnect, keep) tracking whether the tab was hidden
+  // during this stream so the done-notification fires for a backgrounded tab.
+  _bindStreamHiddenTracker();
+  if(!reconnecting||!(activeSid in _STREAM_WAS_HIDDEN)){
+    _STREAM_WAS_HIDDEN[activeSid]=(typeof document!=='undefined'&&!!document.hidden);
+  }
   if(!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[...uploaded],toolCalls:[]};
   else {
     if(uploaded.length) INFLIGHT[activeSid].uploaded=[...uploaded];
@@ -3532,7 +3555,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         renderSessionList();
         _setActivePaneIdleIfOwner();
         playNotificationSound();
-        sendBrowserNotification('Response complete',assistantText?assistantText.slice(0,100):'Task finished',{sid:activeSid});
+        // #4416: notify if the tab was hidden at ANY point during this stream
+        // (not just at done-receive time, which a throttled background-tab SSE
+        // delivers late — after the user returns and document.hidden is false).
+        // If the user watched the whole stream, _wasEverHidden stays false and
+        // the notification is suppressed (matches Slack/Discord/Gmail/Claude).
+        const _wasEverHidden=!!_STREAM_WAS_HIDDEN[activeSid];
+        delete _STREAM_WAS_HIDDEN[activeSid];
+        sendBrowserNotification('Response complete',assistantText?assistantText.slice(0,100):'Task finished',{forceHidden:_wasEverHidden,sid:activeSid});
       };
       if(_shouldUseStreamFade()&&assistantBody){
         _cancelAnimationFramePendingStreamRender();
@@ -5351,7 +5381,15 @@ function requestNotificationPermission(){
 }
 function sendBrowserNotification(title,body,options={}){
   const force=!!(options&&options.force);
-  if(!force&&(!window._notificationsEnabled||!document.hidden)) return;
+  // #4416: `forceHidden` means the caller already determined the tab was hidden
+  // during the relevant window (e.g. a stream that ran while backgrounded), so
+  // the live `document.hidden` visibility gate — which a late, throttled SSE
+  // makes unreliable — should be treated as satisfied. The user's
+  // notifications-enabled SETTING is still honored (unlike `force`, which is the
+  // explicit "Send test" override); only the visibility gate is bypassed.
+  const forceHidden=!!(options&&options.forceHidden);
+  if(!force&&!window._notificationsEnabled) return;
+  if(!force&&!forceHidden&&!document.hidden) return;
   if(!('Notification' in window)) return;
   if(Notification.permission==='granted'){
     _showPwaNotification(title,body,options).catch(()=>{try{new Notification(title||assistantDisplayName(),_notificationOptions(body,options));}catch(_err){}});

--- a/tests/test_pwa_notification_controls.py
+++ b/tests/test_pwa_notification_controls.py
@@ -40,8 +40,13 @@ def test_completion_notification_fires_when_tab_was_hidden_during_stream():
     # The per-stream hidden tracker exists and is wired at attach + done.
     assert "_STREAM_WAS_HIDDEN" in MESSAGES_JS
     assert "function _bindStreamHiddenTracker" in MESSAGES_JS
-    assert "const _wasEverHidden=!!_STREAM_WAS_HIDDEN[activeSid];" in MESSAGES_JS
-    assert "delete _STREAM_WAS_HIDDEN[activeSid];" in MESSAGES_JS
+    # Entries are stream-owned ({streamId, wasHidden}) so a stale entry from a
+    # non-`done` terminal path can't be mis-attributed to a later same-sid stream.
+    assert "const _wasEverHidden=!!(_hiddenEntry&&_hiddenEntry.wasHidden);" in MESSAGES_JS
+    assert "function _clearStreamHidden" in MESSAGES_JS
+    # Cleared on the non-done terminal paths too (belt-and-suspenders alongside
+    # the streamId-ownership guard).
+    assert MESSAGES_JS.count("_clearStreamHidden(activeSid, streamId)") >= 4
     # sendBrowserNotification honors forceHidden but still respects the
     # notifications-enabled setting (forceHidden is NOT the test-button force).
     assert "const forceHidden=!!(options&&options.forceHidden);" in MESSAGES_JS

--- a/tests/test_pwa_notification_controls.py
+++ b/tests/test_pwa_notification_controls.py
@@ -25,9 +25,28 @@ def test_notification_payload_uses_completion_session_when_provided():
     assert "_sessionUrlForSid(sid)" in MESSAGES_JS
     assert "data:{url}" in MESSAGES_JS
     assert "tag:sid?`hermes-${sid}`" in MESSAGES_JS
-    assert "sendBrowserNotification('Response complete',assistantText?assistantText.slice(0,100):'Task finished',{sid:activeSid})" in MESSAGES_JS
+    assert "sendBrowserNotification('Response complete',assistantText?assistantText.slice(0,100):'Task finished',{forceHidden:_wasEverHidden,sid:activeSid})" in MESSAGES_JS
     assert "sendBrowserNotification('Approval required',d.description||'Tool approval needed',{sid:activeSid})" in MESSAGES_JS
     assert "sendBrowserNotification('Clarification needed',d.question||'Tool clarification needed',{sid:activeSid})" in MESSAGES_JS
+
+
+def test_completion_notification_fires_when_tab_was_hidden_during_stream():
+    """#4416: a throttled background-tab SSE delivers `done` late (after the user
+    returns, document.hidden=false), which silently dropped the completion
+    notification. The done handler now passes forceHidden based on whether the
+    tab was hidden at ANY point during the stream, and sendBrowserNotification
+    bypasses ONLY the live visibility gate (not the user's enabled setting) on
+    forceHidden — so a backgrounded stream notifies, a watched one stays silent."""
+    # The per-stream hidden tracker exists and is wired at attach + done.
+    assert "_STREAM_WAS_HIDDEN" in MESSAGES_JS
+    assert "function _bindStreamHiddenTracker" in MESSAGES_JS
+    assert "const _wasEverHidden=!!_STREAM_WAS_HIDDEN[activeSid];" in MESSAGES_JS
+    assert "delete _STREAM_WAS_HIDDEN[activeSid];" in MESSAGES_JS
+    # sendBrowserNotification honors forceHidden but still respects the
+    # notifications-enabled setting (forceHidden is NOT the test-button force).
+    assert "const forceHidden=!!(options&&options.forceHidden);" in MESSAGES_JS
+    assert "if(!force&&!window._notificationsEnabled) return;" in MESSAGES_JS
+    assert "if(!force&&!forceHidden&&!document.hidden) return;" in MESSAGES_JS
 
 
 def test_service_worker_handles_notification_clicks_without_hijacking_other_sessions():


### PR DESCRIPTION
## Release v0.51.527 — Release SL

Fixes #4416. Agent-authored on master, building on @bergeouss's #4421 direction (co-authored); supersedes #4421.

### Fixed
- **Desktop notifications no longer get silently dropped when the agent finishes while you're on another tab (#4416).** Chromium throttles a background tab's SSE, so the stream's `done` event arrives late — after you return, when `document.hidden` already reads `false` — and the response-complete notification was suppressed by the live visibility check. The WebUI now tracks whether the tab was hidden at *any* point during a stream and notifies on that basis, so a turn you stepped away from notifies on completion; a turn you watched the whole time stays silent (matching Slack/Discord/Gmail/Claude), and the user's notifications-enabled setting is still honored.

### Why this over #4421
#4421 fixed the same issue by firing the completion notification **unconditionally** (`forceHidden:true`), which also fires when the tab was never backgrounded — noise that no major app produces. This fix targets the root cause: per-stream `_STREAM_WAS_HIDDEN` (stream-owned `{streamId, wasHidden}`, seeded at attach, OR'd by one idempotent `visibilitychange` listener, read+cleared at done, and cleared on the apperror/cancel/stream-error terminal paths). `forceHidden` bypasses only the live `document.hidden` gate, never the user's enabled setting.

### Gate
- Codex: SAFE TO SHIP (stream-owned entries can't be mis-attributed across reconnects; listener bound once / no leak; notifications-enabled setting honored; approval/clarify unchanged). First pass flagged stale-entry-on-non-done-terminal-paths → fixed (stream-ownership + terminal-path clears) → re-gate SAFE.
- Opus: SAFE — ship (targets the root cause vs #4421's unconditional fire; reconnect-keeps-state correct; guard split keeps the setting authoritative).
- Full pytest suite: 9651 passed, 0 failed.

Closes #4416. Co-authored-by @bergeouss (#4421 direction).
