### PR TITLE
Hydrate built-in personalities for profile config reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Built-in personalities are now hydrated for non-default profiles without writing profile config defaults (#4513).** Profile-specific runtime reads now merge the documented built-in personalities with per-profile customizations from `config.yaml` on each worker read, matching ambient `get_config()` shape and preserving non-default profile isolation.
+
 ## [v0.51.527] — 2026-06-19 — Release SL (completion notifications survive a backgrounded tab)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -509,6 +509,8 @@ def get_config_for_profile_home(profile_home: "Path | str | None") -> dict:
         target = Path(profile_home).expanduser()
     except Exception:
         return get_config()
+    if not target.exists():
+        return {}
     # If the ambient resolver already points at this profile home, defer to
     # get_config() so in-memory overrides (monkeypatched cfg) are honored.
     try:
@@ -516,7 +518,12 @@ def get_config_for_profile_home(profile_home: "Path | str | None") -> dict:
             return get_config()
     except Exception:
         pass
-    return _load_yaml_config_file(target / "config.yaml")
+    # Read the profile file directly and apply documented defaults locally so the
+    # returned dict matches ambient get_config() shape (including built-in
+    # personalities) without mutating any global cache state.
+    profile_cfg = _load_yaml_config_file(target / "config.yaml")
+    _apply_config_defaults(profile_cfg)
+    return profile_cfg
 
 
 def _config_for_yaml_save(config_data: dict) -> dict:

--- a/tests/test_issue4465_builtin_personalities.py
+++ b/tests/test_issue4465_builtin_personalities.py
@@ -69,6 +69,42 @@ def test_config_defaults_replace_non_dict_personality_section_with_builtins():
     assert set(cfg["agent"]["personalities"]) == BUILTIN_NAMES
 
 
+def test_profile_home_config_read_hydrates_builtin_personalities_without_writing(tmp_path):
+    profile_home = tmp_path / "profiles" / "research"
+    profile_home.mkdir(parents=True)
+
+    cfg = config.get_config_for_profile_home(profile_home)
+
+    personalities = cfg["agent"]["personalities"]
+    assert set(personalities) == BUILTIN_NAMES
+    assert personalities["helpful"] == "You are a helpful, friendly AI assistant."
+    assert not (profile_home / "config.yaml").exists()
+
+
+def test_profile_home_config_read_merges_custom_personalities(tmp_path):
+    profile_home = tmp_path / "profiles" / "research"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        "\n".join(
+            [
+                "agent:",
+                "  personalities:",
+                "    helpful: Custom helpful prompt.",
+                "    analyst:",
+                "      system_prompt: Use careful evidence.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = config.get_config_for_profile_home(profile_home)
+
+    personalities = cfg["agent"]["personalities"]
+    assert set(BUILTIN_NAMES).issubset(personalities)
+    assert personalities["helpful"] == "Custom helpful prompt."
+    assert personalities["analyst"]["system_prompt"] == "Use careful evidence."
+
+
 def test_config_save_strips_generated_builtin_personalities(tmp_path):
     cfg = {}
     config._apply_config_defaults(cfg)


### PR DESCRIPTION
## Thinking Path

- #4494 made WebUI expose Hermes Agent's built-in personalities through the ambient config loader.
- #4513 showed that non-default profile runtime reads still bypassed those defaults through `get_config_for_profile_home()`.
- That helper intentionally avoids global cache mutation for #3294 profile isolation, so the fix needs to apply documented defaults to the returned local dict only.
- This keeps runtime shape consistent across profiles without writing generated defaults into profile `config.yaml`.

## What Changed

- Apply `_apply_config_defaults()` to the local dict returned by non-ambient `get_config_for_profile_home()` reads.
- Preserve the existing ambient-profile path through `get_config()` so in-memory overrides still work.
- Preserve the existing missing-profile-directory behavior by returning `{}` for non-existent profile homes.
- Added regression coverage for fresh non-default profile homes and custom personality overrides.

## Why It Matters

Fresh non-default profiles now see the same built-in personalities as the default profile, while custom profile personalities still override built-ins and no generated defaults are written to disk.

## Verification

- Baseline: the new #4513 tests failed on `origin/master`.
- `./scripts/test.sh tests/test_issue4465_builtin_personalities.py tests/test_sprint28.py tests/test_default_personality.py tests/test_issue3294_profile_toolset_scoping.py` (`24 passed`)
- `.venv/bin/python -m py_compile api/config.py tests/test_issue4465_builtin_personalities.py`
- `.venv/bin/ruff check tests/test_issue4465_builtin_personalities.py`
- `git diff --check`

## Risks / Follow-ups

- Non-existent profile homes still return `{}` to preserve the #3294 profile-isolation contract.
- Existing profile directories with no `config.yaml` now return documented defaults in-memory; no file is created or written.

Fixes #4513

## Model Used

AI-assisted with OpenAI GPT-5 Codex as coordinator and `gpt-5.3-codex-spark` as worker. The coordinator wrote the failing acceptance tests, reviewed the worker diff, ran local verification, and prepared this PR.
