### PR TITLE
Fix disabled provider plugin badge state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- **Disabled provider-category plugins now show the disabled badge in Settings (#4496).** The Plugins panel previously rendered any `provider` / `exclusive` plugin with the green provider badge before checking whether the plugin was disabled, making disabled provider plugins look active. The badge now reflects the actual enabled state: disabled provider plugins use the same grey disabled badge as other disabled plugins.
 - **Desktop notifications no longer get silently dropped when the agent finishes while you're on another tab (#4416).** Chromium throttles a background tab's SSE, so the stream's `done` event is delivered late — after you return to the tab, when `document.hidden` already reads `false` — and the response-complete notification was suppressed by the live visibility check. The WebUI now tracks whether the tab was hidden at *any* point during a stream and notifies on that basis, so a turn you stepped away from still notifies on completion. A turn you watched the whole time stays silent (matching how Slack/Discord/Gmail/Claude behave), and the user's notifications-enabled setting is still honored.
 
 ## [v0.51.526] — 2026-06-19 — Release SK (the "Running" indicator clears when the server is idle)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 ### Fixed
 
-- **Disabled provider-category plugins now show the disabled badge in Settings (#4496).** The Plugins panel previously rendered any `provider` / `exclusive` plugin with the green provider badge before checking whether the plugin was disabled, making disabled provider plugins look active. The badge now reflects the actual enabled state: disabled provider plugins use the same grey disabled badge as other disabled plugins.
 - **Desktop notifications no longer get silently dropped when the agent finishes while you're on another tab (#4416).** Chromium throttles a background tab's SSE, so the stream's `done` event is delivered late — after you return to the tab, when `document.hidden` already reads `false` — and the response-complete notification was suppressed by the live visibility check. The WebUI now tracks whether the tab was hidden at *any* point during a stream and notifies on that basis, so a turn you stepped away from still notifies on completion. A turn you watched the whole time stays silent (matching how Slack/Discord/Gmail/Claude behave), and the user's notifications-enabled setting is still honored.
 
 ## [v0.51.526] — 2026-06-19 — Release SK (the "Running" indicator clears when the server is idle)

--- a/api/routes.py
+++ b/api/routes.py
@@ -7109,10 +7109,12 @@ def _plugin_visibility_payload(manager=None) -> dict:
     category's ``<category>.provider`` config, not through ``plugins.enabled``.
     Their ``loaded.enabled`` stays False by design and they register hooks
     outside the four visibility hooks below. The payload surfaces ``kind``
-    and ``activation`` plus ``is_active_provider`` so the panel can render the
-    selected provider distinctly instead of mislabeling it as "Disabled" with no
-    hooks (issue #2659), while still showing unselected exclusive providers as
-    disabled.
+    and ``activation`` plus ``is_active_provider`` when the plugin key carries a
+    category prefix so the panel can render the selected provider distinctly
+    instead of mislabeling it as "Disabled" with no hooks (issue #2659), while
+    still showing unselected exclusive providers as disabled. Flat-key exclusive
+    plugins omit the new field so older activation-based badge semantics remain
+    intact when the category cannot be inferred.
     """
     manager = manager or _get_plugin_manager_for_visibility()
     manager.discover_and_load(force=False)
@@ -7143,17 +7145,22 @@ def _plugin_visibility_payload(manager=None) -> dict:
             activation = "provider"
         else:
             activation = "enabled" if enabled_flag else "disabled"
-        is_active_provider = (
-            (kind == "exclusive" and bool(selected_provider) and plugin_slug == selected_provider)
-            or (kind == "model-provider" and enabled_flag)
-        )
+        include_active_provider = True
+        if kind == "exclusive":
+            if category:
+                is_active_provider = bool(selected_provider) and plugin_slug == selected_provider
+            else:
+                include_active_provider = False
+                is_active_provider = False
+        else:
+            is_active_provider = kind == "model-provider" and enabled_flag
         registered = []
         for hook in list(getattr(manifest, "provides_hooks", []) or []) + list(getattr(loaded, "hooks_registered", []) or []):
             hook_name = str(hook or "").strip()
             if hook_name in _PLUGIN_VISIBILITY_HOOK_SET and hook_name not in registered:
                 registered.append(hook_name)
         registered.sort(key=_PLUGIN_VISIBILITY_HOOKS.index)
-        plugins.append({
+        plugin_payload = {
             "name": name,
             "key": plugin_key or name,
             "version": version,
@@ -7163,9 +7170,11 @@ def _plugin_visibility_payload(manager=None) -> dict:
             "enabled": enabled_flag,
             "kind": kind,
             "activation": activation,
-            "is_active_provider": bool(is_active_provider),
             "hooks": registered,
-        })
+        }
+        if include_active_provider:
+            plugin_payload["is_active_provider"] = bool(is_active_provider)
+        plugins.append(plugin_payload)
 
     return {
         "plugins": plugins,

--- a/api/routes.py
+++ b/api/routes.py
@@ -7065,6 +7065,31 @@ def _clean_plugin_visibility_text(value, *, limit=240) -> str:
     return text
 
 
+def _plugin_visibility_category_from_key(key: str) -> str:
+    """Return the config category prefix for nested plugin keys."""
+    raw = str(key or "").strip().replace("\\", "/")
+    if "/" not in raw:
+        return ""
+    category = raw.split("/", 1)[0].strip()
+    return category if category and category not in {".", ".."} else ""
+
+
+def _plugin_visibility_selected_provider(category: str) -> str:
+    """Read ``<category>.provider`` without surfacing config errors."""
+    if not category:
+        return ""
+    try:
+        from api.config import get_config as _get_cfg
+
+        cfg = _get_cfg() or {}
+    except Exception:
+        return ""
+    category_cfg = cfg.get(category, {}) if isinstance(cfg, dict) else {}
+    if not isinstance(category_cfg, dict):
+        return ""
+    return str(category_cfg.get("provider") or "").strip().lower()
+
+
 def _plugin_visibility_payload(manager=None) -> dict:
     """Build a sanitized plugin/hook visibility payload for Settings.
 
@@ -7078,8 +7103,10 @@ def _plugin_visibility_payload(manager=None) -> dict:
     category's ``<category>.provider`` config, not through ``plugins.enabled``.
     Their ``loaded.enabled`` stays False by design and they register hooks
     outside the four visibility hooks below. The payload surfaces ``kind``
-    and ``activation`` so the panel can render them distinctly instead of
-    mislabeling them as "Disabled" with no hooks (issue #2659).
+    and ``activation`` plus ``is_active_provider`` so the panel can render the
+    selected provider distinctly instead of mislabeling it as "Disabled" with no
+    hooks (issue #2659), while still showing unselected exclusive providers as
+    disabled.
     """
     manager = manager or _get_plugin_manager_for_visibility()
     manager.discover_and_load(force=False)
@@ -7101,12 +7128,19 @@ def _plugin_visibility_payload(manager=None) -> dict:
         description = _clean_plugin_visibility_text(getattr(manifest, "description", ""), limit=280)
         kind = _clean_plugin_visibility_text(getattr(manifest, "kind", "") or "standalone", limit=40)
         enabled_flag = bool(getattr(loaded, "enabled", False))
+        category = _plugin_visibility_category_from_key(plugin_key)
+        selected_provider = _plugin_visibility_selected_provider(category)
+        plugin_slug = plugin_key.rsplit("/", 1)[-1].strip().lower()
         if kind == "exclusive":
             activation = "exclusive"
         elif kind == "model-provider" and enabled_flag:
             activation = "provider"
         else:
             activation = "enabled" if enabled_flag else "disabled"
+        is_active_provider = (
+            (kind == "exclusive" and bool(selected_provider) and plugin_slug == selected_provider)
+            or (kind == "model-provider" and enabled_flag)
+        )
         registered = []
         for hook in list(getattr(manifest, "provides_hooks", []) or []) + list(getattr(loaded, "hooks_registered", []) or []):
             hook_name = str(hook or "").strip()
@@ -7123,6 +7157,7 @@ def _plugin_visibility_payload(manager=None) -> dict:
             "enabled": enabled_flag,
             "kind": kind,
             "activation": activation,
+            "is_active_provider": bool(is_active_provider),
             "hooks": registered,
         })
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -7546,9 +7546,10 @@ const enabled=plugin&&plugin.enabled!==false;
          </label>
        </div>`
     : '');
+  const isProviderActive = isProvider && enabled && activation !== 'disabled';
   let badgeText;
   let badgeClass;
-  if(isProvider){
+  if(isProviderActive){
     badgeText=t('plugins_active_provider');
     badgeClass='plugin-card-badge-provider';
   }else if(activation==='enabled'){

--- a/static/panels.js
+++ b/static/panels.js
@@ -7546,7 +7546,9 @@ const enabled=plugin&&plugin.enabled!==false;
          </label>
        </div>`
     : '');
-  const isProviderActive = isProvider && enabled && activation !== 'disabled';
+  const isProviderActive = plugin&&typeof plugin.is_active_provider==='boolean'
+    ? plugin.is_active_provider
+    : isProvider;
   let badgeText;
   let badgeClass;
   if(isProviderActive){

--- a/tests/test_issue4496_plugin_badge_state.py
+++ b/tests/test_issue4496_plugin_badge_state.py
@@ -1,0 +1,79 @@
+"""Regression coverage for #4496 plugin provider badge state."""
+
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_disabled_provider_plugin_renders_disabled_badge(tmp_path):
+    script = tmp_path / "check_plugin_badge.js"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            const fs = require('fs');
+            const assert = require('assert');
+            const src = fs.readFileSync({json.dumps(str(REPO_ROOT / "static" / "panels.js"))}, 'utf8');
+
+            function extractFunction(name) {{
+              const marker = 'function ' + name;
+              const start = src.indexOf(marker);
+              if (start < 0) throw new Error('missing function ' + name);
+              const brace = src.indexOf('{{', start);
+              let depth = 1;
+              let i = brace + 1;
+              while (depth && i < src.length) {{
+                if (src[i] === '{{') depth += 1;
+                else if (src[i] === '}}') depth -= 1;
+                i += 1;
+              }}
+              return src.slice(start, i);
+            }}
+
+            global.t = (key) => key;
+            global.esc = (value) => String(value ?? '');
+            global.document = {{
+              createElement() {{
+                return {{
+                  className: '',
+                  dataset: {{}},
+                  _html: '',
+                  set innerHTML(value) {{ this._html = String(value); }},
+                  get innerHTML() {{ return this._html; }},
+                  querySelector() {{ return null; }},
+                }};
+              }},
+            }};
+
+            eval(extractFunction('_buildPluginCard'));
+
+            const disabled = _buildPluginCard({{
+              key: 'memory',
+              name: 'Memory',
+              activation: 'provider',
+              enabled: false,
+              hooks: [],
+            }}).innerHTML;
+            assert(disabled.includes('plugin-card-badge-disabled'), disabled);
+            assert(!disabled.includes('plugin-card-badge-provider'), disabled);
+            assert(disabled.includes('plugins_disabled'), disabled);
+
+            const enabled = _buildPluginCard({{
+              key: 'memory',
+              name: 'Memory',
+              activation: 'provider',
+              enabled: true,
+              hooks: [],
+            }}).innerHTML;
+            assert(enabled.includes('plugin-card-badge-provider'), enabled);
+            assert(!enabled.includes('plugin-card-badge-disabled'), enabled);
+            assert(enabled.includes('plugins_active_provider'), enabled);
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    subprocess.run(["node", str(script)], check=True, cwd=REPO_ROOT)

--- a/tests/test_issue4496_plugin_badge_state.py
+++ b/tests/test_issue4496_plugin_badge_state.py
@@ -62,6 +62,17 @@ def test_provider_badge_uses_active_provider_payload_state(tmp_path):
             assert(!activeExclusive.includes('plugin-card-badge-disabled'), activeExclusive);
             assert(activeExclusive.includes('plugins_active_provider'), activeExclusive);
 
+            const legacyFlatKeyExclusive = _buildPluginCard({{
+              key: 'noema',
+              name: 'Noema',
+              activation: 'exclusive',
+              enabled: false,
+              hooks: [],
+            }}).innerHTML;
+            assert(legacyFlatKeyExclusive.includes('plugin-card-badge-provider'), legacyFlatKeyExclusive);
+            assert(!legacyFlatKeyExclusive.includes('plugin-card-badge-disabled'), legacyFlatKeyExclusive);
+            assert(legacyFlatKeyExclusive.includes('plugins_active_provider'), legacyFlatKeyExclusive);
+
             const inactiveExclusive = _buildPluginCard({{
               key: 'memory',
               name: 'Memory',

--- a/tests/test_issue4496_plugin_badge_state.py
+++ b/tests/test_issue4496_plugin_badge_state.py
@@ -9,7 +9,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_disabled_provider_plugin_renders_disabled_badge(tmp_path):
+def test_provider_badge_uses_active_provider_payload_state(tmp_path):
     script = tmp_path / "check_plugin_badge.js"
     script.write_text(
         textwrap.dedent(
@@ -50,27 +50,41 @@ def test_disabled_provider_plugin_renders_disabled_badge(tmp_path):
 
             eval(extractFunction('_buildPluginCard'));
 
-            const disabled = _buildPluginCard({{
+            const activeExclusive = _buildPluginCard({{
               key: 'memory',
               name: 'Memory',
-              activation: 'provider',
+              activation: 'exclusive',
+              is_active_provider: true,
               enabled: false,
               hooks: [],
             }}).innerHTML;
-            assert(disabled.includes('plugin-card-badge-disabled'), disabled);
-            assert(!disabled.includes('plugin-card-badge-provider'), disabled);
-            assert(disabled.includes('plugins_disabled'), disabled);
+            assert(activeExclusive.includes('plugin-card-badge-provider'), activeExclusive);
+            assert(!activeExclusive.includes('plugin-card-badge-disabled'), activeExclusive);
+            assert(activeExclusive.includes('plugins_active_provider'), activeExclusive);
 
-            const enabled = _buildPluginCard({{
+            const inactiveExclusive = _buildPluginCard({{
               key: 'memory',
               name: 'Memory',
+              activation: 'exclusive',
+              is_active_provider: false,
+              enabled: false,
+              hooks: [],
+            }}).innerHTML;
+            assert(inactiveExclusive.includes('plugin-card-badge-disabled'), inactiveExclusive);
+            assert(!inactiveExclusive.includes('plugin-card-badge-provider'), inactiveExclusive);
+            assert(inactiveExclusive.includes('plugins_disabled'), inactiveExclusive);
+
+            const activeModelProvider = _buildPluginCard({{
+              key: 'openrouter',
+              name: 'OpenRouter',
               activation: 'provider',
+              is_active_provider: true,
               enabled: true,
               hooks: [],
             }}).innerHTML;
-            assert(enabled.includes('plugin-card-badge-provider'), enabled);
-            assert(!enabled.includes('plugin-card-badge-disabled'), enabled);
-            assert(enabled.includes('plugins_active_provider'), enabled);
+            assert(activeModelProvider.includes('plugin-card-badge-provider'), activeModelProvider);
+            assert(!activeModelProvider.includes('plugin-card-badge-disabled'), activeModelProvider);
+            assert(activeModelProvider.includes('plugins_active_provider'), activeModelProvider);
             """
         ),
         encoding="utf-8",

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -198,6 +198,30 @@ class TestPluginsApi:
         assert plugin["enabled"] is False
         assert plugin["is_active_provider"] is False
 
+    def test_api_plugins_omits_active_provider_for_flat_key_exclusive_plugins(self):
+        manager = _FakePluginManager({
+            "noema": _FakeLoadedPlugin(
+                _FakeManifest(
+                    name="noema",
+                    key="noema",
+                    version="0.1.0",
+                    description="Flat-key memory provider",
+                    kind="exclusive",
+                ),
+                enabled=False,
+                hooks_registered=[],
+            )
+        })
+
+        with patch("api.config.get_config", return_value={"memory": {"provider": "noema"}}):
+            payload = self._capture_plugins_response(manager)
+
+        plugin = payload["plugins"][0]
+        assert plugin["kind"] == "exclusive"
+        assert plugin["activation"] == "exclusive"
+        assert plugin["enabled"] is False
+        assert "is_active_provider" not in plugin
+
     def test_api_plugins_marks_active_model_provider(self):
         # model-provider plugins that loaded successfully (loaded.enabled True)
         # get the "provider" activation badge so the panel can distinguish

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -90,6 +90,7 @@ class TestPluginsApi:
             "enabled": True,
             "kind": "standalone",
             "activation": "enabled",
+            "is_active_provider": False,
             "hooks": ["pre_tool_call", "post_tool_call"],
         }]
         serialized = repr(payload)
@@ -147,7 +148,7 @@ class TestPluginsApi:
             "noema": _FakeLoadedPlugin(
                 _FakeManifest(
                     name="noema",
-                    key="noema",
+                    key="memory/noema",
                     version="0.1.0",
                     description="Structured memory backed by a Noema Cortex",
                     kind="exclusive",
@@ -158,11 +159,13 @@ class TestPluginsApi:
             )
         })
 
-        payload = self._capture_plugins_response(manager)
+        with patch("api.config.get_config", return_value={"memory": {"provider": "noema"}}):
+            payload = self._capture_plugins_response(manager)
 
         plugin = payload["plugins"][0]
         assert plugin["kind"] == "exclusive"
         assert plugin["activation"] == "exclusive"
+        assert plugin["is_active_provider"] is True
         # `enabled` stays False for back-compat with older WebUI clients that
         # key off it directly; new clients must read `activation`.
         assert plugin["enabled"] is False
@@ -170,6 +173,30 @@ class TestPluginsApi:
         # The raw error string is intentionally NOT surfaced — it can contain
         # filesystem paths or other internals on other plugin kinds.
         assert "exclusive plugin" not in repr(payload)
+
+    def test_api_plugins_marks_unselected_exclusive_plugins_inactive(self):
+        manager = _FakePluginManager({
+            "honcho": _FakeLoadedPlugin(
+                _FakeManifest(
+                    name="honcho",
+                    key="memory/honcho",
+                    version="1.0.0",
+                    description="Honcho memory provider",
+                    kind="exclusive",
+                ),
+                enabled=False,
+                hooks_registered=[],
+            )
+        })
+
+        with patch("api.config.get_config", return_value={"memory": {"provider": "noema"}}):
+            payload = self._capture_plugins_response(manager)
+
+        plugin = payload["plugins"][0]
+        assert plugin["kind"] == "exclusive"
+        assert plugin["activation"] == "exclusive"
+        assert plugin["enabled"] is False
+        assert plugin["is_active_provider"] is False
 
     def test_api_plugins_marks_active_model_provider(self):
         # model-provider plugins that loaded successfully (loaded.enabled True)
@@ -194,6 +221,7 @@ class TestPluginsApi:
         plugin = payload["plugins"][0]
         assert plugin["kind"] == "model-provider"
         assert plugin["activation"] == "provider"
+        assert plugin["is_active_provider"] is True
         assert plugin["enabled"] is True
 
 


### PR DESCRIPTION
## Thinking Path

- The Plugins settings panel should show which plugin is actually the active provider for provider-style categories.
- #4496 identified that provider-category badge state needed an explicit active-provider signal, not inference from a generic enabled flag.
- Maintainer review caught that active exclusive providers intentionally carry `activation: "exclusive"` and `enabled: false` under the #2659 contract.
- This update preserves that active-exclusive path and makes inactive exclusive providers render as disabled.

## What Changed

- Added an explicit `is_active_provider` boolean to the `/api/plugins` payload.
- For `kind: "exclusive"` plugins, `is_active_provider` is derived from the plugin key category and the matching `<category>.provider` config value.
- For active `kind: "model-provider"` plugins, `is_active_provider` remains true when the backend already reports the plugin as enabled.
- Updated `_buildPluginCard()` to prefer `is_active_provider` for the green provider badge, with a fallback to existing `activation` semantics for older payloads.
- Removed the direct `CHANGELOG.md` edit after review feedback.
- Added regression coverage for active exclusive, inactive exclusive, and active model-provider badge rendering.

## Why It Matters

Settings no longer marks inactive exclusive provider plugins as active, while active exclusive providers such as memory providers still keep the green provider badge even though their legacy `enabled` flag is false by design.

## Verification

- Baseline: the updated #4496/#2659 regression tests failed against the previous PR head.
- `./scripts/test.sh tests/test_issue4496_plugin_badge_state.py tests/test_plugins_panel.py` (`34 passed`)
- `node --check static/panels.js`
- `.venv/bin/python -m py_compile api/routes.py tests/test_issue4496_plugin_badge_state.py tests/test_plugins_panel.py`
- `.venv/bin/python scripts/ruff_lint.py --diff origin/master --strict`
- `git diff --check`

## Risks / Follow-ups

- This changes the `/api/plugins` payload by adding a backwards-compatible field; existing `enabled`, `kind`, and `activation` fields are preserved.
- Older clients without `is_active_provider` still fall back to the existing `activation` behavior.
- No manual screenshot was captured in this run; the regression tests check the rendered badge markup directly.

Fixes #4496

## Model Used

AI-assisted with OpenAI GPT-5 Codex as coordinator. A `gpt-5.3-codex-spark` worker was briefly assigned for the review follow-up but was closed before producing usable changes; the coordinator implemented and verified the final follow-up patch.
