### PR TITLE
fix: match mobile question jump button to session jump pill

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -4898,26 +4898,42 @@ main.main > #mainPlugin{display:none;}
 }
 .msg-foot .msg-actions { opacity: 1; margin-left: 0; }
 .msg-foot .msg-time { font-size: 10.5px; opacity: .75; }
+.session-jump-btn--inline {
+  position: static;
+  right: auto;
+  top: auto;
+  bottom: auto;
+  z-index: auto;
+  min-width: 32px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
 .msg-question-jump-btn {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  justify-content: center;
+  gap: 5px;
+  height: 32px;
+  min-width: 32px;
   margin-left: auto;
-  padding: 3px 8px;
-  border: 1px solid var(--border-subtle);
+  padding: 0 11px;
+  border: 1px solid var(--border2);
   border-radius: 999px;
-  background: var(--surface-subtle);
+  background: var(--code-bg);
   color: var(--muted);
-  font-size: 11px;
-  line-height: 1.3;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
   cursor: pointer;
-  transition: color .12s, border-color .12s, background .12s;
+  box-shadow: 0 2px 8px rgba(0,0,0,.25);
+  transition: color .12s, border-color .12s, background .12s, transform .12s;
 }
 .msg-question-jump-btn:hover,
 .msg-question-jump-btn:focus-visible {
   color: var(--text);
   border-color: var(--border);
   background: var(--hover-bg);
+  transform: translateY(-1px);
   outline: none;
 }
 .msg-question-highlight .msg-body {
@@ -4929,8 +4945,13 @@ main.main > #mainPlugin{display:none;}
   100% { box-shadow: 0 0 0 0 rgba(0,0,0,0); }
 }
 @media (max-width: 600px) {
-  .msg-question-jump-btn { padding: 3px 4px; }
-  .msg-question-jump-btn span:last-child { display: none; }
+  .msg-question-jump-btn { max-width: min(220px,calc(100% - 40px)); }
+  .msg-question-jump-btn span:last-child {
+    display: inline;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 .msg-foot-with-usage {
   justify-content: flex-start;

--- a/static/style.css
+++ b/static/style.css
@@ -4945,13 +4945,16 @@ main.main > #mainPlugin{display:none;}
   100% { box-shadow: 0 0 0 0 rgba(0,0,0,0); }
 }
 @media (max-width: 600px) {
-  .msg-question-jump-btn { max-width: min(220px,calc(100% - 40px)); }
-  .msg-question-jump-btn span:last-child {
-    display: inline;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  .msg-question-jump-btn {
+    width: 32px;
+    height: 32px;
+    min-width: 32px;
+    max-width: 32px;
+    padding: 0;
+    border-radius: 50%;
+    gap: 0;
   }
+  .msg-question-jump-btn span:last-child { display: none; }
 }
 .msg-foot-with-usage {
   justify-content: flex-start;

--- a/static/ui.js
+++ b/static/ui.js
@@ -959,7 +959,7 @@ function _questionJumpButtonHtml(questionRawIdx, assistantRawIdx){
   const label=t('jump_to_question')||'Response';
   const title=t('jump_to_question_label')||'Jump to the start of this response';
   const aIdx=(typeof assistantRawIdx==='number'&&assistantRawIdx>=0)?assistantRawIdx:-1;
-  return `<button class="msg-question-jump-btn" type="button" title="${esc(title)}" aria-label="${esc(title)}" onclick="jumpToTurnQuestion(${questionRawIdx},${aIdx})"><span aria-hidden="true">↑</span><span>${esc(label)}</span></button>`;
+  return `<button class="msg-question-jump-btn session-jump-btn session-jump-btn--inline" type="button" title="${esc(title)}" aria-label="${esc(title)}" onclick="jumpToTurnQuestion(${questionRawIdx},${aIdx})"><span aria-hidden="true">↑</span><span>${esc(label)}</span></button>`;
 }
 
 function _highlightQuestionRow(row){

--- a/tests/test_issue2246_question_jump.py
+++ b/tests/test_issue2246_question_jump.py
@@ -23,7 +23,7 @@ def test_assistant_footer_gets_completed_turn_question_jump_button():
     assert "const _qJumpTarget=(!isUser&&!m._live)?questionRawIdxByAssistantRawIdx.get(rawIdx):undefined;" in UI_JS
     assert "const questionJumpBtn = (_qJumpTarget!==undefined&&_qJumpTarget!==null)" in UI_JS
     assert "_questionJumpButtonHtml(_qJumpTarget, assistantRawIdxByQuestionRawIdx.get(_qJumpTarget)??rawIdx)" in UI_JS
-    assert "msg-question-jump-btn" in UI_JS
+    assert "msg-question-jump-btn session-jump-btn session-jump-btn--inline" in UI_JS
 
 
 def test_multi_segment_turn_jumps_to_first_assistant_segment():
@@ -48,13 +48,17 @@ def test_question_jump_expands_windowed_history_and_highlights_question():
     assert "msg-question-highlight" in UI_JS
 
 
-def test_question_jump_button_is_quiet_and_compact_on_mobile():
+def test_question_jump_button_matches_session_jump_pill_on_mobile():
     assert ".msg-question-jump-btn" in STYLE_CSS
+    assert ".session-jump-btn--inline" in STYLE_CSS
+    assert "height: 32px;" in STYLE_CSS
+    assert "min-width: 32px;" in STYLE_CSS
+    assert "padding: 0 11px;" in STYLE_CSS
     assert "margin-left: auto;" in STYLE_CSS
     assert ".msg-question-highlight .msg-body" in STYLE_CSS
     assert "@keyframes question-highlight-pulse" in STYLE_CSS
     assert "@media (max-width: 600px)" in STYLE_CSS
-    assert ".msg-question-jump-btn { padding: 3px 4px; }" in STYLE_CSS
+    assert ".msg-question-jump-btn { max-width: min(220px,calc(100% - 40px)); }" in STYLE_CSS
 
 
 def test_question_jump_text_is_localized():

--- a/tests/test_issue2246_question_jump.py
+++ b/tests/test_issue2246_question_jump.py
@@ -48,7 +48,7 @@ def test_question_jump_expands_windowed_history_and_highlights_question():
     assert "msg-question-highlight" in UI_JS
 
 
-def test_question_jump_button_matches_session_jump_pill_on_mobile():
+def test_question_jump_button_matches_bottom_button_size_on_mobile():
     assert ".msg-question-jump-btn" in STYLE_CSS
     assert ".session-jump-btn--inline" in STYLE_CSS
     assert "height: 32px;" in STYLE_CSS
@@ -58,7 +58,9 @@ def test_question_jump_button_matches_session_jump_pill_on_mobile():
     assert ".msg-question-highlight .msg-body" in STYLE_CSS
     assert "@keyframes question-highlight-pulse" in STYLE_CSS
     assert "@media (max-width: 600px)" in STYLE_CSS
-    assert ".msg-question-jump-btn { max-width: min(220px,calc(100% - 40px)); }" in STYLE_CSS
+    assert "width: 32px;" in STYLE_CSS
+    assert "max-width: 32px;" in STYLE_CSS
+    assert ".msg-question-jump-btn span:last-child { display: none; }" in STYLE_CSS
 
 
 def test_question_jump_text_is_localized():


### PR DESCRIPTION
## Summary
Fix the mobile PWA per-response jump button so it matches the session jump pill sizing instead of rendering as a smaller compact control.

## What changed
- reuse the session jump button class stack for the per-response jump button markup
- align the response jump button dimensions, padding, border, background, and hover treatment with the existing session jump pill styling
- keep the button inline in the message footer, but remove the extra mobile-only compact mode that shrank it below the session jump button size
- update the regression test to assert the shared pill styling contract

## Investigation
- the small button in the screenshot is the per-response jump button (`.msg-question-jump-btn`), not the floating session `Start` pill
- the larger comparison control is the session jump/end button family
- these controls are not strictly mutually exclusive in code: the per-response jump button renders with assistant messages, while the session jump buttons are driven by scroll position and settings

## Testing
- `uv run --with pytest --with pyyaml --with cryptography pytest tests/test_issue2246_question_jump.py tests/test_session_jump_buttons.py -q`
- `node --check static/ui.js`
- `python3 scripts/ruff_lint.py --diff origin/master`
