### PR TITLE
fix: /api/profiles UnboundLocalError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- Profiles now load correctly from `/api/profiles` after the recent active-profile route refactor, instead of returning a server-side `UnboundLocalError` and showing `Failed to load profiles` in the WebUI.
-
 ## [v0.51.528] — 2026-06-20 — Release SM (isolated HERMES_HOME single-profile mode)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Profiles now load correctly from `/api/profiles` after the recent active-profile route refactor, instead of returning a server-side `UnboundLocalError` and showing `Failed to load profiles` in the WebUI.
+
 ## [v0.51.528] — 2026-06-20 — Release SM (isolated HERMES_HOME single-profile mode)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -8595,7 +8595,10 @@ def handle_get(handler, parsed) -> bool:
 
     # ── Profile API (GET) ──
     if parsed.path == "/api/profiles":
-        from api.profiles import list_profiles_api
+        from api.profiles import (
+            get_active_profile_name,
+            list_profiles_api,
+        )
 
         return j(
             handler,

--- a/tests/test_profiles_route_endpoint.py
+++ b/tests/test_profiles_route_endpoint.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+
+def test_profiles_route_returns_active_profile(monkeypatch):
+    import api.profiles as profiles
+    import api.routes as routes
+
+    expected_profiles = [{"name": "default", "is_default": True}]
+
+    monkeypatch.setattr(profiles, "list_profiles_api", lambda: expected_profiles)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(routes, "_is_isolated_profile_mode", lambda: False)
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda _handler, payload, status=200: {"status": status, "payload": payload},
+    )
+
+    response = routes.handle_get(SimpleNamespace(), urlparse("/api/profiles"))
+
+    assert response == {
+        "status": 200,
+        "payload": {
+            "profiles": expected_profiles,
+            "active": "default",
+            "single_profile_mode": False,
+        },
+    }


### PR DESCRIPTION
## Thinking Path
- The WebUI profile picker loads through `/api/profiles`.
- That route branch locally imported `list_profiles_api()`, but `handle_get()` also has a later `/api/profile/active` branch that locally imports `get_active_profile_name()`.
- Because Python scopes imports as local assignments for the whole function, `/api/profiles` could call `get_active_profile_name()` before that local binding existed and raise `UnboundLocalError`.
- This PR binds the active-profile helper in the `/api/profiles` branch itself and adds a route-level regression test.

## What Changed
- Import `get_active_profile_name` alongside `list_profiles_api` inside the `/api/profiles` route branch.
- Add a regression test that exercises `handle_get('/api/profiles')` and asserts the `profiles`, `active`, and `single_profile_mode` response fields.
- Leave `CHANGELOG.md` untouched per repo release-process convention.

## Why It Matters
This prevents `/api/profiles` from returning a server-side `UnboundLocalError` after the active-profile route refactor. Users see the profile list load normally instead of a `Failed to load profiles` error in the WebUI.

## Verification
- `/tmp/hermes-webui-pr-venv/bin/python -m pytest tests/test_profiles_route_endpoint.py -q --timeout=60` -> `1 passed`
- `/tmp/hermes-webui-pr-venv/bin/python -m pytest tests/test_profiles_route_endpoint.py tests/test_issue2698_isolated_hermes_home.py tests/test_issue1700_parallel_profile_switch.py tests/test_issue803.py -q --timeout=60` -> `62 passed`
- `/tmp/hermes-webui-pr-venv/bin/python -m py_compile api/routes.py api/profiles.py` -> passed
- `/tmp/hermes-webui-pr-venv/bin/python -m pytest tests/ -v --timeout=60` -> `9586 passed, 104 skipped, 1 xfailed, 2 xpassed, 3 failed`; the failures are outside this change: OpenRouter catalog budget fallback in `test_free_tier_cap_prevents_picker_drowning`, TLS stdout assertion displaced by local missing-agent dependency warnings in `test_tls_startup_failure_fallback_to_http`, and a `SessionDB` import failure that passed when rerun in isolation.
- `/tmp/hermes-webui-pr-venv/bin/python -m pytest tests/test_v050259_sessiondb_fd_leak.py::test_session_db_close_is_idempotent -q --timeout=60` -> `1 passed`
- `git diff --cached --check` -> passed before each commit

## Risks / Follow-ups
Low risk. The fix only binds a helper already used by the `/api/profiles` response path and does not change the response shape.

## Model Used
OpenAI GPT-5.5(high) via Codex, with local shell-based repository inspection, TDD regression testing, and GitHub CLI for PR publication.
