### PR TITLE
Release v0.51.530 — fix /api/profiles 500 (UnboundLocalError regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.530] — 2026-06-20 — Release SO (fix /api/profiles 500)
+
+### Fixed
+
+- **`GET /api/profiles` no longer returns a 500 (UnboundLocalError).** A later branch in the request handler imports `get_active_profile_name` as a function-local, which made the name local across the whole handler; the `/api/profiles` branch referenced it before that import ran, so every call to the profiles list endpoint raised `UnboundLocalError`. The branch now imports the name it uses directly. Regression introduced in v0.51.528 and surfaced once the redundant local import was removed there; this restores the profiles list/dropdown. Thanks @TomBanksAU.
+
 ## [v0.51.529] — 2026-06-20 — Release SN (per-response jump button matches the session jump pill)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -8595,7 +8595,10 @@ def handle_get(handler, parsed) -> bool:
 
     # ── Profile API (GET) ──
     if parsed.path == "/api/profiles":
-        from api.profiles import list_profiles_api
+        from api.profiles import (
+            get_active_profile_name,
+            list_profiles_api,
+        )
 
         return j(
             handler,

--- a/tests/test_profiles_route_endpoint.py
+++ b/tests/test_profiles_route_endpoint.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+
+def test_profiles_route_returns_active_profile(monkeypatch):
+    import api.profiles as profiles
+    import api.routes as routes
+
+    expected_profiles = [{"name": "default", "is_default": True}]
+
+    monkeypatch.setattr(profiles, "list_profiles_api", lambda: expected_profiles)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(routes, "_is_isolated_profile_mode", lambda: False)
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda _handler, payload, status=200: {"status": status, "payload": payload},
+    )
+
+    response = routes.handle_get(SimpleNamespace(), urlparse("/api/profiles"))
+
+    assert response == {
+        "status": 200,
+        "payload": {
+            "profiles": expected_profiles,
+            "active": "default",
+            "single_profile_mode": False,
+        },
+    }


### PR DESCRIPTION
## Release v0.51.530 — Release SO

Ships #4522 (fixes a live regression introduced in v0.51.528 / #4454).

### Fixed
- **`GET /api/profiles` no longer returns a 500 (UnboundLocalError).** A later branch in the request handler (`/api/profile/active`) imports `get_active_profile_name` as a function-local, which — by Python scoping — makes the name local across the *entire* `handle_get`. The `/api/profiles` branch referenced it before that import ran, so every call to the profiles list endpoint raised `UnboundLocalError`. The branch now imports the name it uses directly. Confirmed empirically (prod returned HTTP 500 with `cannot access local variable 'get_active_profile_name'` in the log). Restores the profiles list/dropdown. Thanks @TomBanksAU.

### Context
Introduced in v0.51.528 (#4454) when a redundant local import was removed from the `/api/profiles` branch, exposing the function-scope trap from the sibling `/api/profile/active` branch. The full suite stayed green because no test exercised `GET /api/profiles` directly — #4522 adds that regression test.

### Gate
- Codex: SAFE TO SHIP (audited every `api.profiles` function-local import in `handle_get`; `/api/profiles` was the only use-before-local-import path; all others import-then-use within their own branch).
- Opus: SAFE — ship (same audit independently; `_is_isolated_profile_mode` is module-only, resolves cleanly).
- Full pytest suite: 9684 passed, 0 failed (includes the new `test_profiles_route_endpoint.py`).

Original PR: #4522 by @TomBanksAU.
