### PR TITLE
docs(changelog): correct v0.51.530 attribution to @MinhoJJang (#4522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Fixed
 
-- **`GET /api/profiles` no longer returns a 500 (UnboundLocalError).** A later branch in the request handler imports `get_active_profile_name` as a function-local, which made the name local across the whole handler; the `/api/profiles` branch referenced it before that import ran, so every call to the profiles list endpoint raised `UnboundLocalError`. The branch now imports the name it uses directly. Regression introduced in v0.51.528 and surfaced once the redundant local import was removed there; this restores the profiles list/dropdown. Thanks @TomBanksAU.
+- **`GET /api/profiles` no longer returns a 500 (UnboundLocalError).** A later branch in the request handler imports `get_active_profile_name` as a function-local, which made the name local across the whole handler; the `/api/profiles` branch referenced it before that import ran, so every call to the profiles list endpoint raised `UnboundLocalError`. The branch now imports the name it uses directly. Regression introduced in v0.51.528 and surfaced once the redundant local import was removed there; this restores the profiles list/dropdown. Thanks @MinhoJJang.
 
 ## [v0.51.529] — 2026-06-20 — Release SN (per-response jump button matches the session jump pill)
 


### PR DESCRIPTION
## What

Corrects the contributor attribution on the **v0.51.530** CHANGELOG entry (the `GET /api/profiles` 500 / `UnboundLocalError` fix).

That fix shipped from PR #4522, which was authored by **@MinhoJJang** — but the CHANGELOG credited **@TomBanksAU**.

## Why it happened

#4518 (TomBanksAU's jump-button fix → v0.51.529) and #4522 (MinhoJJang's fix → v0.51.530) shipped back-to-back. TomBanksAU's handle was fresh from the previous release entry and got carried forward onto the v0.51.530 credit instead of being re-derived from the PR author.

## Scope

One-line change. Only the v0.51.530 entry is touched — the three legitimate @TomBanksAU credits elsewhere in the CHANGELOG (v0.51.529 #2246, #4397, #4385, #3525) are unchanged.

The PR #4522 thank-you comment and the GitHub release notes for v0.51.530 are being corrected separately.
