### PR TITLE
Release v0.51.533 — restart gateway from the agent-health alert (#3285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.533] — 2026-06-20 — Release SR (restart the gateway from the agent-health alert)
+
+### Added
+
+- **Restart the messaging gateway directly from the WebUI when its heartbeat fails (#3285).** When the agent-health alert appears (the gateway heartbeat stopped), it now offers a "Restart Service" button alongside Dismiss. It calls a new authenticated `POST /api/health/restart` that runs `hermes gateway restart` (graceful drain of in-flight runs) for the active profile's `HERMES_HOME`. The endpoint is guarded by a non-blocking lock (concurrent restarts get a 429), returns quickly when the restart completes fast, and otherwise lets the drain finish in the background with a timeout; the client suppresses health-polling for 15s afterward so the alert doesn't flicker during the restart. Thanks @Chukwuebuka-2003.
+
 ## [v0.51.532] — 2026-06-20 — Release SQ (built-in personalities on non-default profiles)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -432,6 +432,7 @@ from api.profiles import (  # noqa: F401, E402  (re-export)
     _is_isolated_profile_mode,
     get_active_profile_name,
     get_active_profile_name as _get_active_profile_name,
+    get_active_hermes_home,
 )
 
 
@@ -7307,6 +7308,122 @@ def _handle_shutdown(handler) -> bool:
     return True
 
 
+_RESTART_LOCK = threading.Lock()
+
+
+def _handle_health_restart(handler) -> bool:
+    """Restart the Hermes messaging gateway service."""
+    # Acquire the lock to prevent concurrent restart invocations
+    if not _RESTART_LOCK.acquire(blocking=False):
+        logger.warning("Gateway restart already in progress, rejecting concurrent request.")
+        return j(
+            handler,
+            {"ok": False, "error": "Restart already in progress. Please wait a moment and try again."},
+            status=429
+        )
+
+    lock_released = False
+    try:
+        # 1. Resolve HERMES_HOME for the active profile
+        active_home = get_active_hermes_home()
+
+        # 2. Build the environment dictionary with the correct HERMES_HOME
+        env = os.environ.copy()
+        env["HERMES_HOME"] = str(active_home)
+
+        # 3. Resolve the path to the hermes CLI binary
+        hermes_cmd = shutil.which("hermes")
+        if not hermes_cmd:
+            sys_exe = Path(sys.executable)
+            sibling = sys_exe.parent / "hermes"
+            if sibling.exists():
+                hermes_cmd = str(sibling)
+            else:
+                hermes_cmd = "hermes"
+
+        # 4. Run the restart command
+        logger.info("Restarting gateway service via CLI command: %s gateway restart (HERMES_HOME=%s)", hermes_cmd, active_home)
+        
+        proc = subprocess.Popen(
+            [hermes_cmd, "gateway", "restart"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env
+        )
+        try:
+            # Wait up to 2.0 seconds for the restart command to complete quickly
+            stdout, stderr = proc.communicate(timeout=2.0)
+            # Since it finished quickly, we can release the lock now
+            _RESTART_LOCK.release()
+            lock_released = True
+
+            if proc.returncode == 0:
+                logger.info("Gateway service restarted successfully: %s", stdout)
+                return j(handler, {"ok": True, "message": "Gateway service restarted successfully"})
+            else:
+                logger.error("Gateway service restart failed with code %d: %s", proc.returncode, stderr)
+                return j(
+                    handler,
+                    {"ok": False, "error": f"Restart failed: {stderr.strip() or stdout.strip()}"},
+                    status=500
+                )
+        except subprocess.TimeoutExpired:
+            # If the process doesn't finish within 2 seconds, it is likely draining
+            # in-flight agent runs. We let it continue running in the background.
+            logger.info("Gateway restart is taking longer than 2.0s (likely draining in-flight runs). Letting it run in the background.")
+
+            # Start background threads to consume the stdout/stderr streams to prevent
+            # the child process from blocking on pipe buffer limits when printing logs.
+            import threading
+
+            def consume_stream(stream):
+                try:
+                    while stream.read(4096):
+                        pass
+                except Exception:
+                    pass
+
+            def wait_and_release():
+                try:
+                    proc.wait(timeout=240.0)
+                except subprocess.TimeoutExpired:
+                    logger.error("Gateway restart process timed out after 240.0s. Terminating process.")
+                    try:
+                        proc.terminate()
+                        try:
+                            proc.wait(timeout=5.0)
+                        except subprocess.TimeoutExpired:
+                            proc.kill()
+                            try:
+                                proc.wait(timeout=5.0)
+                            except subprocess.TimeoutExpired:
+                                logger.error("Gateway restart process refused to die even after SIGKILL.")
+                    except Exception as e:
+                        logger.exception("Failed to terminate timed out gateway restart process: %s", e)
+                finally:
+                    try:
+                        _RESTART_LOCK.release()
+                    except RuntimeError:
+                        # Already released or similar
+                        pass
+
+            threading.Thread(target=consume_stream, args=(proc.stdout,), daemon=True).start()
+            threading.Thread(target=consume_stream, args=(proc.stderr,), daemon=True).start()
+            # This thread will release the lock when the child process exits
+            threading.Thread(target=wait_and_release, daemon=True).start()
+            
+            # Lock will be released by wait_and_release thread
+            lock_released = True
+
+            return j(handler, {"ok": True, "message": "Gateway service restart initiated (in progress)"})
+    except Exception as exc:
+        if not lock_released:
+            _RESTART_LOCK.release()
+        logger.exception("Failed to run gateway restart command")
+        return j(handler, {"ok": False, "error": f"Internal error running restart: {type(exc).__name__}: {exc}"}, status=500)
+
+
 def _serve_manifest(handler) -> bool:
     """Serve static/manifest.json with the correct PWA Content-Type.
 
@@ -8934,6 +9051,9 @@ def handle_post(handler, parsed) -> bool:
 
     if parsed.path == "/api/shutdown":
         return _handle_shutdown(handler)
+
+    if parsed.path == "/api/health/restart":
+        return _handle_health_restart(handler)
 
     if parsed.path == "/api/upload":
         return handle_upload(handler)

--- a/static/index.html
+++ b/static/index.html
@@ -469,7 +469,10 @@
         <strong id="agentHealthTitle">Hermes agent is not responding</strong>
         <span id="agentHealthDetails">The gateway heartbeat failed. Messages may not be delivered until it comes back.</span>
       </div>
-      <button class="agent-health-dismiss" id="agentHealthDismiss" type="button" onclick="dismissAgentHealthAlert()" aria-label="Dismiss Hermes agent heartbeat alert">Dismiss</button>
+      <div class="agent-health-actions">
+        <button class="agent-health-restart" id="btnRestartGateway" type="button" onclick="restartGatewayService()">Restart Service</button>
+        <button class="agent-health-dismiss" id="agentHealthDismiss" type="button" onclick="dismissAgentHealthAlert()" aria-label="Dismiss Hermes agent heartbeat alert">Dismiss</button>
+      </div>
     </div>
     <div class="composer-wrap" id="composerWrap">
       <div class="composer-flyout">

--- a/static/style.css
+++ b/static/style.css
@@ -1311,6 +1311,10 @@
   .agent-health-copy span{color:var(--muted);}
   .agent-health-dismiss{flex-shrink:0;padding:6px 12px;border-radius:8px;border:1px solid color-mix(in srgb,var(--error) 45%,var(--surface));background:color-mix(in srgb,var(--error) 10%,var(--surface));color:var(--error);font-size:12px;font-weight:600;cursor:pointer;}
   .agent-health-dismiss:hover{background:color-mix(in srgb,var(--error) 18%,var(--surface));}
+  .agent-health-actions{display:flex;gap:8px;flex-shrink:0;}
+  .agent-health-restart{flex-shrink:0;padding:6px 12px;border-radius:8px;border:1px solid color-mix(in srgb,var(--accent) 55%,var(--surface));background:color-mix(in srgb,var(--accent) 15%,var(--surface));color:var(--accent);font-size:12px;font-weight:600;cursor:pointer;transition:background-color .15s;}
+  .agent-health-restart:hover{background:color-mix(in srgb,var(--accent) 25%,var(--surface));}
+  .agent-health-restart:disabled{opacity:0.5;cursor:not-allowed;}
   /* ── Update banner ── */
   .update-banner{display:none;background:var(--surface);border:1px solid var(--accent);border-radius:10px;padding:10px 16px;margin:10px auto;max-width:780px;width:calc(100% - 24px);box-sizing:border-box;font-size:13px;color:var(--accent-text);align-items:flex-start;justify-content:space-between;gap:12px;flex-wrap:wrap;overflow-wrap:anywhere;}
   .update-banner.visible{display:flex;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -6713,6 +6713,7 @@ const AGENT_HEALTH_INTERVAL_MS=30000;
 const AGENT_HEALTH_DISMISSED_KEY='agent-health-dismissed';
 let _agentHealthTimer=null;
 let _agentHealthLastState='unknown';
+let _lastGatewayRestartTime=0;
 function _agentHealthDismissed(){
   try{return localStorage.getItem(AGENT_HEALTH_DISMISSED_KEY)==='1';}
   catch(_){return false;}
@@ -6743,8 +6744,35 @@ function dismissAgentHealthAlert(){
   _setAgentHealthDismissed(true);
   _hideAgentHealthAlert();
 }
+async function restartGatewayService(){
+  const btn = $('btnRestartGateway');
+  const dismissBtn = $('agentHealthDismiss');
+  if(!btn) return;
+  btn.disabled = true;
+  if(dismissBtn) dismissBtn.disabled = true;
+  const originalText = btn.textContent;
+  btn.textContent = 'Restarting...';
+  try {
+    const res = await api('/api/health/restart', {method: 'POST'});
+    if(res && res.ok){
+      showToast('Gateway service restarted successfully');
+      _hideAgentHealthAlert();
+      _lastGatewayRestartTime = Date.now();
+      setTimeout(pollAgentHealth, 15000);
+    } else {
+      showToast(res && res.error || 'Failed to restart gateway service');
+    }
+  } catch(e) {
+    showToast('Failed to restart gateway service: ' + e.message);
+  } finally {
+    btn.disabled = false;
+    if(dismissBtn) dismissBtn.disabled = false;
+    btn.textContent = originalText;
+  }
+}
 async function pollAgentHealth(){
   if(document.visibilityState !== 'visible') return;
+  if(Date.now() - _lastGatewayRestartTime < 15000) return;
   try{
     const payload=await api('/api/health/agent',{timeoutToast:false});
     if(payload.alive === true){

--- a/tests/test_health_restart.py
+++ b/tests/test_health_restart.py
@@ -1,0 +1,232 @@
+import io
+import subprocess
+import types
+from api import routes
+
+
+class MockPopen:
+    def __init__(self, args, stdout=None, stderr=None, text=True, env=None):
+        self.args = args
+        self.env = env
+        self.returncode = 0
+        self.stdout = io.StringIO("✓ Service restarted")
+        self.stderr = io.StringIO("")
+        self._should_timeout = False
+        self._should_raise = False
+        self._wait_should_timeout = False
+        self.terminated = False
+        self.killed = False
+
+    def communicate(self, timeout=None):
+        if self._should_raise:
+            raise OSError("Subprocess execution failed")
+        if self._should_timeout:
+            raise subprocess.TimeoutExpired(self.args, timeout)
+        return self.stdout.getvalue(), self.stderr.getvalue()
+
+    def wait(self, timeout=None):
+        if self._wait_should_timeout:
+            raise subprocess.TimeoutExpired(self.args, timeout)
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+
+
+def test_handle_health_restart_success(monkeypatch):
+    import threading
+    routes._RESTART_LOCK = threading.Lock()
+    # Mock profiles home path
+    monkeypatch.setattr("api.routes.get_active_hermes_home", lambda: "/mock/hermes/home")
+
+    # Mock shutil.which to find hermes CLI
+    monkeypatch.setattr("shutil.which", lambda cmd: "/mock/bin/hermes" if cmd == "hermes" else None)
+
+    called_args = []
+    called_env = {}
+
+    def mock_popen(args, stdout=None, stderr=None, text=True, env=None):
+        called_args.append(args)
+        called_env.update(env or {})
+        return MockPopen(args, stdout, stderr, text, env)
+
+    monkeypatch.setattr(subprocess, "Popen", mock_popen)
+
+    # Mock response helper j
+    responses = []
+    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
+
+    handler = types.SimpleNamespace()
+
+    # Call _handle_health_restart
+    result = routes._handle_health_restart(handler)
+
+    assert result is True
+    assert called_args == [["/mock/bin/hermes", "gateway", "restart"]]
+    assert called_env.get("HERMES_HOME") == "/mock/hermes/home"
+    assert responses == [({"ok": True, "message": "Gateway service restarted successfully"}, 200)]
+
+
+def test_handle_health_restart_failure(monkeypatch):
+    import threading
+    routes._RESTART_LOCK = threading.Lock()
+    # Mock profiles home path
+    monkeypatch.setattr("api.routes.get_active_hermes_home", lambda: "/mock/hermes/home")
+    monkeypatch.setattr("shutil.which", lambda cmd: "/mock/bin/hermes" if cmd == "hermes" else None)
+
+    # Mock subprocess.Popen failure
+    def mock_popen(args, stdout=None, stderr=None, text=True, env=None):
+        mp = MockPopen(args, stdout, stderr, text, env)
+        mp.returncode = 1
+        mp.stdout = io.StringIO("")
+        mp.stderr = io.StringIO("Error: something went wrong")
+        return mp
+
+    monkeypatch.setattr(subprocess, "Popen", mock_popen)
+
+    responses = []
+    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
+
+    handler = types.SimpleNamespace()
+    result = routes._handle_health_restart(handler)
+
+    assert result is True
+    assert responses == [({"ok": False, "error": "Restart failed: Error: something went wrong"}, 500)]
+
+
+def test_handle_health_restart_exception(monkeypatch):
+    import threading
+    routes._RESTART_LOCK = threading.Lock()
+    # Mock profiles home path
+    monkeypatch.setattr("api.routes.get_active_hermes_home", lambda: "/mock/hermes/home")
+    monkeypatch.setattr("shutil.which", lambda cmd: "/mock/bin/hermes" if cmd == "hermes" else None)
+
+    # Mock Popen raising OSError immediately on start
+    def mock_popen(args, **kwargs):
+        raise OSError("Subprocess execution failed")
+
+    monkeypatch.setattr(subprocess, "Popen", mock_popen)
+
+    responses = []
+    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
+
+    handler = types.SimpleNamespace()
+    result = routes._handle_health_restart(handler)
+
+    assert result is True
+    assert responses[0][0]["ok"] is False
+    assert "Internal error running restart" in responses[0][0]["error"]
+    assert responses[0][1] == 500
+
+
+def test_handle_health_restart_timeout(monkeypatch):
+    import threading
+    routes._RESTART_LOCK = threading.Lock()
+    # Mock profiles home path
+    monkeypatch.setattr("api.routes.get_active_hermes_home", lambda: "/mock/hermes/home")
+    monkeypatch.setattr("shutil.which", lambda cmd: "/mock/bin/hermes" if cmd == "hermes" else None)
+
+    # Mock Popen raising TimeoutExpired on communicate
+    def mock_popen(args, stdout=None, stderr=None, text=True, env=None):
+        mp = MockPopen(args, stdout, stderr, text, env)
+        mp._should_timeout = True
+        return mp
+
+    monkeypatch.setattr(subprocess, "Popen", mock_popen)
+
+    responses = []
+    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
+
+    handler = types.SimpleNamespace()
+    result = routes._handle_health_restart(handler)
+
+    assert result is True
+    assert responses == [({"ok": True, "message": "Gateway service restart initiated (in progress)"}, 200)]
+
+
+def test_handle_health_restart_concurrency(monkeypatch):
+    import threading
+    import time
+    routes._RESTART_LOCK = threading.Lock()
+    
+    # Mock profiles home path
+    monkeypatch.setattr("api.routes.get_active_hermes_home", lambda: "/mock/hermes/home")
+    monkeypatch.setattr("shutil.which", lambda cmd: "/mock/bin/hermes" if cmd == "hermes" else None)
+
+    # Mock Popen that blocks on communicate
+    barrier = threading.Barrier(2)
+
+    class BlockingMockPopen(MockPopen):
+        def communicate(self, timeout=None):
+            barrier.wait()  # synchronize with test thread
+            time.sleep(0.5)  # hold the lock briefly
+            return self.stdout.getvalue(), self.stderr.getvalue()
+
+    def mock_popen(args, stdout=None, stderr=None, text=True, env=None):
+        return BlockingMockPopen(args, stdout, stderr, text, env)
+
+    monkeypatch.setattr(subprocess, "Popen", mock_popen)
+
+    responses = []
+    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
+
+    handler1 = types.SimpleNamespace()
+    handler2 = types.SimpleNamespace()
+
+    # Run first restart in a separate thread (it will block on communicate)
+    t1 = threading.Thread(target=routes._handle_health_restart, args=(handler1,))
+    t1.start()
+
+    # Wait until the first thread starts Popen and blocks on communicate
+    barrier.wait()
+
+    # Attempt a second restart concurrently; it should fail immediately with 429
+    result2 = routes._handle_health_restart(handler2)
+
+    t1.join()
+
+    assert result2 is True
+    # The second response must be a 429 Conflict / Too Many Requests
+    assert responses[0][0]["ok"] is False
+    assert "Restart already in progress" in responses[0][0]["error"]
+    assert responses[0][1] == 429
+
+
+def test_handle_health_restart_wait_timeout(monkeypatch):
+    import threading
+    import time
+    routes._RESTART_LOCK = threading.Lock()
+    monkeypatch.setattr("api.routes.get_active_hermes_home", lambda: "/mock/hermes/home")
+    monkeypatch.setattr("shutil.which", lambda cmd: "/mock/bin/hermes" if cmd == "hermes" else None)
+
+    mock_instances = []
+    def mock_popen(args, stdout=None, stderr=None, text=True, env=None):
+        mp = MockPopen(args, stdout, stderr, text, env)
+        mp._should_timeout = True
+        mp._wait_should_timeout = True
+        mock_instances.append(mp)
+        return mp
+
+    monkeypatch.setattr(subprocess, "Popen", mock_popen)
+
+    responses = []
+    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
+
+    handler = types.SimpleNamespace()
+    assert not routes._RESTART_LOCK.locked()
+    
+    result = routes._handle_health_restart(handler)
+    assert result is True
+    assert responses == [({"ok": True, "message": "Gateway service restart initiated (in progress)"}, 200)]
+    
+    # Wait for background thread to run and finish wait_and_release
+    time.sleep(0.5)
+    
+    # The lock should be released even if wait() timed out
+    assert not routes._RESTART_LOCK.locked()
+    assert len(mock_instances) == 1
+    assert mock_instances[0].terminated is True
+    assert mock_instances[0].killed is True


### PR DESCRIPTION
## Release v0.51.533 — Release SR

Ships #3285 (gateway restart from the agent-health alert). Self-rebased onto current master (import-merge conflict in routes.py resolved — combined master's profiles re-export with the PR's `get_active_hermes_home`; routes code-diff verified to match the PR).

### Added
- **Restart the messaging gateway directly from the WebUI when its heartbeat fails (#3285).** The agent-health alert (shown when the gateway heartbeat stops) now offers a "Restart Service" button alongside Dismiss. It calls a new authenticated `POST /api/health/restart` that runs `hermes gateway restart` (graceful drain of in-flight runs) for the active profile's `HERMES_HOME`. Non-blocking lock (concurrent restarts → 429), 2s quick-path then background drain with a 240s timeout + SIGTERM→SIGKILL escalation; the client suppresses health-polling for 15s afterward so the alert doesn't flicker during the restart. Thanks @Chukwuebuka-2003.

### Gate
- Codex: SAFE TO SHIP (fixed-argv/no-shell restart, active-profile HERMES_HOME, POST auth/CSRF gating, single-release lock paths, bounded poll-suppression, unchanged dismiss/recovery).
- Opus: SAFE — ship (lock released exactly once across quick-path/drain/timeout/SIGKILL; no injection surface; 15s suppression self-expiring; per-request active-profile scoping). Optional non-blocking polish noted (reap proc if the drain thread fails to start; drop a redundant import).
- Full pytest suite: 9696 passed, 0 failed (incl. the new `test_health_restart.py`).
- Screenshot verified: the "Restart Service" + "Dismiss" buttons render cleanly in the health alert.

Original PR: #3285 by @Chukwuebuka-2003.
