### PR TITLE
fix(#4533): clear queued card on session switch

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -915,6 +915,7 @@ async function loadSession(sid){
   // draft survives page refresh and syncs across clients.
   if (currentSid && currentSid !== sid) {
     if(typeof window._clearPendingSelections==='function') window._clearPendingSelections();
+    if(typeof _clearQueueCardDisplay==='function') _clearQueueCardDisplay(currentSid);
     await _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
     // The awaited draft save above yields the event loop. If another
     // loadSession() started for a different session while we were waiting

--- a/static/ui.js
+++ b/static/ui.js
@@ -5414,6 +5414,29 @@ function setBusy(v){
 // normal user bubble in the chat — the chip is removed at drain time.
 const _queueRenderKeys={};  // per-session fingerprint to avoid redundant rebuilds
 const _queueCollapsed={};   // per-session: true when user explicitly collapsed the card
+let _queueRenderEpoch=0;
+function _clearQueueCardDisplay(sid){
+  const card=document.getElementById('queueCard');
+  const chips=document.getElementById('queueChips');
+  if(sid) delete _queueRenderKeys[sid];
+  if(card) card.classList.remove('visible');
+  if(chips){
+    const _chips=chips;
+    const _card=card;
+    const _sid=String(sid||'');
+    const _epoch=_chips.getAttribute('data-queue-render-epoch')||'';
+    setTimeout(()=>{
+      if((_card&&!_card.classList.contains('visible'))||!_card){
+        if((_chips.getAttribute('data-queue-render-sid')||'')===_sid&&(_chips.getAttribute('data-queue-render-epoch')||'')===_epoch){
+          _chips.innerHTML='';
+        }
+      }
+    },360);
+  }
+  const _msgsEl=document.getElementById('messages');
+  if(_msgsEl) _msgsEl.classList.remove('queue-open');
+  _updateQueuePill(sid,0);
+}
 
 function _renderQueueChips(sid){
   const card=document.getElementById('queueCard');
@@ -5425,6 +5448,8 @@ function _renderQueueChips(sid){
   // Skip re-render if user is actively editing inside the queue panel
   if(inner.contains(document.activeElement)&&document.activeElement!==inner) return;
   _queueRenderKeys[sid]=key;
+  inner.setAttribute('data-queue-render-sid',sid);
+  inner.setAttribute('data-queue-render-epoch',String(++_queueRenderEpoch));
   inner.innerHTML='';
   if(!q.length){
     card.classList.remove('visible');
@@ -5663,14 +5688,7 @@ function updateQueueBadge(sessionId){
     // Only wipe global DOM if this is the currently active session
     const isActive=S.session&&sid===S.session.session_id;
     if(isActive){
-      const card=document.getElementById('queueCard');
-      const chips=document.getElementById('queueChips');
-      if(card) card.classList.remove('visible');
-      // Defer clear until after slide-out transition so content doesn't vanish mid-animation
-      if(chips){const _chips=chips;const _card=card;setTimeout(()=>{if(!_card||!_card.classList.contains('visible'))_chips.innerHTML='';},360);}
-      const _msgsEl=document.getElementById('messages');
-      if(_msgsEl) _msgsEl.classList.remove('queue-open');
-      _updateQueuePill(sid,0);
+      _clearQueueCardDisplay(sid);
     }
   }
 }

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -534,6 +534,59 @@ def test_session_scoped_message_queue_frontend_wiring(cleanup_test_sessions):
     assert "updateQueueBadge(sid);" in sessions_src
 
 
+def test_queue_card_cross_session_clear_called_before_draft_save(cleanup_test_sessions):
+    """R15c: switching away from one session to another should clear the old
+    session's queue card before the async draft-save await, so stale DOM cannot
+    survive into the destination session.
+    """
+    src = (REPO_ROOT / "static/sessions.js").read_text()
+    block_pattern = re.compile(
+        r"if \(currentSid && currentSid !== sid\) \{\s*"
+        r"if\(typeof window\._clearPendingSelections==='function'\) window\._clearPendingSelections\(\);\s*"
+        r"if\(typeof _clearQueueCardDisplay==='function'\) _clearQueueCardDisplay\(currentSid\);\s*"
+        r"await _saveComposerDraftNow\(currentSid",
+        re.S,
+    )
+    assert block_pattern.search(src), (
+        "cross-session loadSession path must clear queue card display via"
+        " _clearQueueCardDisplay(currentSid) before awaiting _saveComposerDraftNow"
+    )
+
+
+def test_queue_card_cross_session_helper_used_only_for_session_change(cleanup_test_sessions):
+    """R15c: _clearQueueCardDisplay(sid) must only fire on cross-session switches,
+    not on same-session navigation/force-reload code paths.
+    """
+    src = (REPO_ROOT / "static/sessions.js").read_text()
+    load_start = src.find("async function loadSession(sid){")
+    assert load_start >= 0
+    load_end = src.find("  // Sync context usage indicator from session data", load_start)
+    load_body = src[load_start:load_end]
+    cross_start = load_body.find("if (currentSid && currentSid !== sid) {")
+    cross_end = load_body.find("if (currentSid !== sid || forceReload) {", cross_start)
+    assert cross_start >= 0 and cross_end >= 0
+    assert "_clearQueueCardDisplay(currentSid);" in load_body[cross_start:cross_end], (
+        "queue-card clear helper must be inside the cross-session branch"
+    )
+    same_session_idx = load_body.find("if(currentSid===sid && !forceReload && !_loadingSessionId) return;")
+    assert same_session_idx >= 0
+    assert same_session_idx < cross_start
+
+
+def test_queue_card_clear_helper_tracks_render_epoch(cleanup_test_sessions):
+    """R15d: the delayed queue clear must only wipe the chips from the render it
+    was asked to dismiss, not a later render for the same shared queue DOM.
+    """
+    src = (REPO_ROOT / "static/ui.js").read_text()
+    assert "let _queueRenderEpoch=0;" in src
+    assert "if(sid) delete _queueRenderKeys[sid];" in src
+    assert "inner.setAttribute('data-queue-render-sid',sid);" in src
+    assert "inner.setAttribute('data-queue-render-epoch',String(++_queueRenderEpoch));" in src
+    assert "const _epoch=_chips.getAttribute('data-queue-render-epoch')||'';" in src
+    assert "(_chips.getAttribute('data-queue-render-sid')||'')===_sid" in src
+    assert "(_chips.getAttribute('data-queue-render-epoch')||'')===_epoch" in src
+
+
 def test_chat_start_persists_pending_turn_metadata_for_reload_recovery(cleanup_test_sessions):
     """R15c: chat/start must expose enough pending-turn metadata for a reload to
     rebuild the in-flight conversation instead of showing a blank session.


### PR DESCRIPTION
## Thinking Path

- The queued follow-up state is already scoped correctly in `SESSION_QUEUES`; the remaining bug is that the departing session's queue card DOM survives into the next conversation while `loadSession()` is still waiting on the destination fetch.
- Calling `updateQueueBadge(currentSid)` in that window would be the wrong fix, because the old session still has queued turns and the count-aware branch would just render the card again.
- The safest repair is a DOM-only queue-card clear on true cross-session switches, plus a shared helper so the switch path and the normal zero-count clear path cannot drift apart later.

## What Changed

- `static/ui.js`: extract the visible queue-card teardown into a small DOM-only helper, reuse it from `updateQueueBadge()`'s active-session clear path, and guard the delayed chip clear with a per-render epoch so one session's teardown cannot wipe a later queue render in the shared flyout DOM.
- `static/sessions.js`: clear stale queue-card UI immediately when switching to a different session, before the destination session await path starts.
- `tests/test_regressions.py`: add focused source-level regressions for early cross-session queue-card clearing, same-session guard behavior, and the new render-epoch contract that keeps delayed clears tied to the render they dismissed.

## Why It Matters

Switching away from a busy conversation should never make another conversation look queued when it is not. This keeps queued-card ownership visually aligned with the actual session state, without touching queue routing or backend behavior that was already fixed earlier.

## Verification

```cmd
pytest tests/test_regressions.py -k queue_card -v --timeout=60
npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"
```

Full-suite CI context, not run locally: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- Open PR [#4415](https://github.com/nesquena/hermes-webui/pull/4415) overlaps `static/ui.js` and `static/sessions.js`, so this fix should be rebased carefully if that branch lands first.
- The helper is intentionally DOM-only; if future work needs queue ownership changes, that should stay separate from this display fix.

## Upstream

Closes #4533.
Related: [#2584](https://github.com/nesquena/hermes-webui/pull/2584) already fixed queued-turn routing, so this PR stays on the cross-session display leak only.

## Model Used

GPT 5.5 via Codex CLI
