### PR TITLE
fix: slash-model routing for configured providers

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2515,8 +2515,19 @@ def model_with_provider_context(model_id: str, model_provider: str | None = None
     if provider == "openrouter":
         return f"@{provider}:{model}"
 
-    # For non-OpenRouter slash IDs, keep the ID intact so existing custom/proxy
-    # base_url routing and portal-provider handling remain in charge.
+    # Explicit providers configured in config.yaml (for example local llama.cpp,
+    # Ollama, LM Studio, vLLM, or other OpenAI-compatible endpoints) must keep
+    # their provider hint even when the model ID is HuggingFace-style and
+    # contains '/'. Otherwise a selected local model such as
+    # 'unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL' inherits the default provider
+    # (e.g. openai-codex) and is sent to the wrong backend.
+    providers_cfg = cfg.get("providers") if isinstance(cfg, dict) else {}
+    if isinstance(providers_cfg, dict) and provider in providers_cfg:
+        return f"@{provider}:{model}"
+
+    # For non-OpenRouter slash IDs without an explicit configured provider,
+    # keep the ID intact so existing custom/proxy base_url routing and
+    # portal-provider handling remain in charge.
     if "/" in model:
         return model
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -3713,6 +3713,15 @@ def _resolve_compatible_session_model_state(
     """
     model = str(model_id or "").strip()
     requested_provider = _clean_session_model_provider(model_provider)
+    if model and requested_provider and model.startswith(f"@{requested_provider}:"):
+        try:
+            from api.config import cfg as _active_cfg
+
+            providers_cfg = _active_cfg.get("providers") if isinstance(_active_cfg, dict) else {}
+        except Exception:
+            providers_cfg = {}
+        if isinstance(providers_cfg, dict) and requested_provider in providers_cfg:
+            return model, requested_provider, False
     if model and requested_provider:
         # Only safe when the model itself does not carry an ``@provider:model``
         # qualifier — qualified strings require the catalog to decide whether

--- a/tests/test_issue1855_resolve_model_provider_fast_path.py
+++ b/tests/test_issue1855_resolve_model_provider_fast_path.py
@@ -30,7 +30,6 @@ Coverage:
    through).
 """
 import pathlib
-import re
 from unittest.mock import patch
 
 
@@ -174,6 +173,40 @@ class TestSlowPathStillFires:
             "the qualifier matches the active provider and to detect stale "
             "cross-provider artifacts (#1253)."
         )
+
+    def test_configured_provider_qualified_model_skips_catalog(self):
+        """Configured providers already carry trusted routing context."""
+        import api.config as config
+        from api.routes import _resolve_compatible_session_model_state
+
+        old_cfg = dict(config.cfg)
+        config.cfg["model"] = {
+            "provider": "openai-codex",
+            "default": "gpt-5.5",
+        }
+        config.cfg["providers"] = {
+            "local-llama": {
+                "base_url": "http://127.0.0.1:8088/v1",
+                "api_key": "test-key",
+            },
+        }
+        try:
+            with patch("api.routes.get_available_models") as mock_catalog:
+                mock_catalog.side_effect = AssertionError("catalog should not be called")
+                result = _resolve_compatible_session_model_state(
+                    "@local-llama:unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL",
+                    "local-llama",
+                )
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+
+        assert result == (
+            "@local-llama:unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL",
+            "local-llama",
+            False,
+        )
+        assert mock_catalog.call_count == 0
 
     def test_no_requested_provider_goes_to_slow_path(self):
         """When provider isn't supplied, slow path must repair from catalog."""

--- a/tests/test_provider_mismatch.py
+++ b/tests/test_provider_mismatch.py
@@ -522,6 +522,37 @@ def test_non_openrouter_slash_model_provider_context_stays_unqualified():
     assert runtime_model == "anthropic/claude-sonnet-4.6"
 
 
+def test_configured_provider_slash_model_keeps_provider_context():
+    """Configured OpenAI-compatible providers need explicit context for slash IDs."""
+    import api.config as config
+
+    old_cfg = dict(config.cfg)
+    config.cfg["model"] = {
+        "provider": "openai-codex",
+        "default": "gpt-5.5",
+    }
+    config.cfg["providers"] = {
+        "local-llama": {
+            "base_url": "http://127.0.0.1:8088/v1",
+            "api_key": "test-key",
+        },
+    }
+    try:
+        runtime_model = config.model_with_provider_context(
+            "unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL",
+            "local-llama",
+        )
+        model, provider, base_url = config.resolve_model_provider(runtime_model)
+    finally:
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+
+    assert runtime_model == "@local-llama:unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL"
+    assert model == "unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL"
+    assert provider == "local-llama"
+    assert base_url == "http://127.0.0.1:8088/v1"
+
+
 def test_cursor_acp_slash_model_always_gets_provider_hint():
     """ACP subprocess models with '/' must not fall through to config default."""
     import api.config as config


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI keeps the selected model and provider as separate session fields, then uses `model_with_provider_context()` and the session resolver to preserve routing when a request is sent.
- Slash-qualified model IDs are common for local OpenAI-compatible backends that use HuggingFace-style names, for example `unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL`.
- The existing non-OpenRouter slash-model guard preserved those IDs as bare strings, which is correct for some portal/custom cases but wrong when the selected provider is explicitly configured in `config.yaml`.
- In that configured-provider case, the provider hint is already known and must be preserved, otherwise the bare slash model can fall back to the default provider such as `openai-codex`.
- This PR narrows the fix to configured providers only and keeps the existing OpenRouter/removed-provider slow-path behavior intact.

## What Changed
- `api.config.model_with_provider_context()` now qualifies slash model IDs when the selected provider exists in `cfg["providers"]`.
- `_resolve_compatible_session_model_state()` now fast-paths an already-qualified `@provider:model` only when that provider is configured locally.
- Added regression coverage for both the model-provider wrapping path and the configured-provider resolver fast path.
- Removed one unused `re` import from the touched resolver test file.

## Why It Matters
Users with a configured local/OpenAI-compatible provider can select a HuggingFace-style model ID without the request being routed to the default provider. This keeps local llama.cpp, vLLM, LM Studio, or similar configured providers from accidentally inheriting `openai-codex` routing when the model ID contains `/`.

## Contract Routing
Task type: provider/model routing bug fix.
Touched areas: model provider context wrapping and session model resolver fast path.
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
Scope boundaries: no frontend behavior, no changelog entry, no provider catalog shape changes.
Evidence needed before claiming done: configured-provider regression tests pass, existing OpenRouter/removed-provider slow-path tests still pass.

## Verification
- RED: `/tmp/hermes-webui-pr-venv/bin/python -m pytest tests/test_provider_mismatch.py::test_configured_provider_slash_model_keeps_provider_context tests/test_issue1855_resolve_model_provider_fast_path.py::TestSlowPathStillFires::test_configured_provider_qualified_model_skips_catalog -q --timeout=60` -> both tests failed on clean upstream for the expected reasons.
- GREEN: `./scripts/test.sh tests/test_provider_mismatch.py::test_non_openrouter_slash_model_provider_context_stays_unqualified tests/test_provider_mismatch.py::test_configured_provider_slash_model_keeps_provider_context tests/test_provider_mismatch.py::test_cursor_acp_slash_model_always_gets_provider_hint tests/test_issue1855_resolve_model_provider_fast_path.py::TestSlowPathStillFires::test_at_provider_qualified_model_goes_to_slow_path tests/test_issue1855_resolve_model_provider_fast_path.py::TestSlowPathStillFires::test_configured_provider_qualified_model_skips_catalog tests/test_issue1855_resolve_model_provider_fast_path.py::TestSlowPathStillFires::test_no_requested_provider_goes_to_slow_path -q --timeout=60` -> `6 passed`
- `./scripts/test.sh tests/test_issue1855_resolve_model_provider_fast_path.py tests/test_resolve_model_provider_free_suffix.py tests/test_issue1894_provider_overlap.py tests/test_custom_provider_prefix_collisions.py tests/test_chat_start_provider_fallback.py -q --timeout=60` -> `52 passed`
- `./scripts/test.sh tests/test_provider_mismatch.py::test_api_session_is_side_effect_free_for_stale_models -q --timeout=60` -> passed on rerun; a wider local provider-mismatch batch still hit a pre-existing HTTP fixture timeout in that same test while the other 116 tests passed.
- `.venv/bin/ruff check tests/test_provider_mismatch.py tests/test_issue1855_resolve_model_provider_fast_path.py --select F401,F841,F811,B007,B009,B904` -> passed
- `git diff --cached --check` -> passed before commit

## Risks / Follow-ups
Low risk. The provider qualification change is limited to providers explicitly present in `cfg["providers"]`, and the route fast path preserves the existing catalog slow path for OpenRouter and unconfigured/removed providers.

## Model Used
OpenAI GPT-5 via Codex, with local shell-based repository inspection, TDD red/green verification, and GitHub CLI for PR publication.
