### PR TITLE
fix(#4535): include session_id in Runs API request body

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -313,6 +313,7 @@ def _run_gateway_runs_api_streaming(
         "model": model or "default",
         "input": run_input,
         **body_extras,
+        "session_id": session_id,
     }
     if instructions_parts:
         run_body["instructions"] = "\n\n".join(part for part in instructions_parts if part)

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -300,6 +300,7 @@ def test_gateway_runs_api_streaming_parses_real_run_events():
     assert run_body["instructions"] == "system prompt"
     assert run_body["conversation_history"] == [{"role": "assistant", "content": "earlier reply"}]
     assert run_body["provider"] == "anthropic"
+    assert run_body["session_id"] == "sess1"
     assert "messages" not in run_body
 
     assert final_text == "Hello"

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -854,6 +854,70 @@ def test_gateway_use_runs_api_env_wins_over_config():
     ) is False
 
 
+def test_gateway_runs_api_body_includes_session_id():
+    """#4535: the runs API body must carry session_id so the agent reuses the
+    browser session instead of creating a fresh run_<uuid> per message."""
+    from unittest.mock import patch, MagicMock
+    from api.config import STREAMS, STREAMS_LOCK
+    from api.gateway_chat import _run_gateway_chat_streaming
+
+    captured = {}
+    events = []
+    q = MagicMock()
+    q.put_nowait = lambda item: events.append(item)
+    stream_id = "sid-runs-session-id"
+    with STREAMS_LOCK:
+        STREAMS[stream_id] = q
+
+    call_count = [0]
+
+    def fake_urlopen(req, *, timeout=None):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            captured["url"] = req.full_url
+            resp = MagicMock()
+            resp.read = lambda sz=65536: json.dumps({"run_id": "run_abc"}).encode()
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+        resp = MagicMock()
+        resp.__iter__ = lambda s: iter([
+            b'data: {"choices":[{"delta":{"content":"ok"}}]}\n',
+            b'data: [DONE]\n',
+        ])
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        return resp
+
+    import os
+    env = {k: v for k, v in os.environ.items()}
+    env["HERMES_WEBUI_CHAT_BACKEND"] = "gateway"
+    env["HERMES_WEBUI_GATEWAY_USE_RUNS_API"] = "1"
+    env["HERMES_WEBUI_GATEWAY_BASE_URL"] = "http://gateway.local"
+
+    try:
+        with patch.dict("os.environ", env, clear=True):
+            with patch("api.gateway_chat.gateway_supports_approval", return_value=True), \
+                 patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+                 patch("api.gateway_chat.get_session", return_value=MagicMock(
+                     active_stream_id=stream_id, workspace="/tmp",
+                     profile=None, context_messages=[], messages=[],
+                 )):
+                _run_gateway_chat_streaming(
+                    session_id="sess-stable-uuid",
+                    msg_text="hi",
+                    model="test",
+                    workspace="/tmp",
+                    stream_id=stream_id,
+                )
+        assert "/v1/runs" in captured["url"]
+        assert captured["body"]["session_id"] == "sess-stable-uuid"
+    finally:
+        with STREAMS_LOCK:
+            STREAMS.pop(stream_id, None)
+
+
 def test_gateway_worker_skips_runs_api_when_opt_in_absent():
     """Worker uses chat/completions even when gateway advertises approval support, unless opt-in is set."""
     from unittest.mock import patch, MagicMock


### PR DESCRIPTION
## Thinking Path

- The WebUI sends `X-Hermes-Session-Id` as an HTTP header, which works for `/v1/chat/completions` because that handler reads it from the header. The `/v1/runs` handler reads `session_id` from the request body instead.
- Both code paths need the same stable browser session UUID but consume it differently. The fix is to supply the value in the body as well, which is a one-line addition that is safe because the only other source of body keys (`body_extras`) provably never contains `session_id`.

## What Changed

- `api/gateway_chat.py`: added `"session_id": session_id` to the `run_body` dict in `_run_gateway_runs_api_streaming`, placed after the `**body_extras` spread so the explicit session id wins over any caller-supplied extras.
- `tests/test_gateway_approval_runs_api.py`: added `session_id` assertion to existing runs API body validation.
- `tests/test_webui_gateway_chat_backend.py`: added a focused test verifying the runs API request body carries the stable WebUI session id.

## Why It Matters

Gateway Runs API chats now reuse the same agent session across messages instead of creating a fresh `run_<uuid>` entry for every turn. This stops the sidebar from flooding with duplicate `Api_Server` sessions and preserves conversation continuity, memory, and tool context across turns.

## Verification

```
pytest tests/test_gateway_approval_runs_api.py tests/test_webui_gateway_chat_backend.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

Manual: enable `HERMES_WEBUI_GATEWAY_USE_RUNS_API=1`, select OpenAI API provider, send two messages in the same session, confirm the agent sidebar shows one session entry rather than two.

## Risks / Follow-ups

Low risk. The change is additive: a previously absent body key is now present. Agents that do not read `session_id` from the body are unaffected. Agents that do read it now receive the correct value and skip session creation.

A possible agent-side follow-up would be teaching `/v1/runs` to accept `X-Hermes-Session-Id` as a fallback for symmetry with `/v1/chat/completions`, but that is not required for this WebUI fix.

## Upstream

Closes #4535.

## Model Used

Claude Opus 4.6 via Claude Code CLI
