### PR TITLE
fix(#4550): forward gateway reasoning effort

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -108,6 +108,7 @@ def _gateway_reasoning_effort_for_request(cfg, *, model=None, model_provider=Non
             model,
             provider_id=model_provider,
         )
+        # Preserve explicit "none" while still omitting absent or invalid effort.
         return None if not coerced else str(coerced)
     except Exception:
         return None

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -19,6 +19,7 @@ from api.config import (
     STREAM_PARTIAL_TEXT,
     STREAM_REASONING_TEXT,
     _get_session_agent_lock,
+    coerce_reasoning_effort_for_model,
     gateway_supports_approval,
     register_active_run,
     unregister_active_run,
@@ -94,6 +95,22 @@ def _gateway_use_runs_api_enabled(config_data=None, environ: dict[str, str] | No
         or ""
     ).strip().lower()
     return raw in ("1", "true", "yes", "on")
+
+
+def _gateway_reasoning_effort_for_request(cfg, *, model=None, model_provider=None):
+    """Read and coerce user-configured reasoning effort for a gateway request."""
+    try:
+        cfg_data = cfg if isinstance(cfg, dict) else {}
+        effort_cfg = cfg_data.get("agent", {}) if isinstance(cfg_data, dict) else {}
+        effort_raw = effort_cfg.get("reasoning_effort") if isinstance(effort_cfg, dict) else None
+        coerced = coerce_reasoning_effort_for_model(
+            effort_raw,
+            model,
+            provider_id=model_provider,
+        )
+        return None if not coerced else str(coerced)
+    except Exception:
+        return None
 
 
 def gateway_chat_config_status(config_data=None, environ: dict[str, str] | None = None) -> dict:
@@ -527,6 +544,11 @@ def _run_gateway_chat_streaming(
         from api.config import get_config  # imported lazily to avoid config-cycle churn
 
         cfg = get_config()
+        reasoning_effort = _gateway_reasoning_effort_for_request(
+            cfg,
+            model=model,
+            model_provider=model_provider,
+        )
         try:
             from api.streaming import (
                 _load_webui_prefill_context,
@@ -573,6 +595,8 @@ def _run_gateway_chat_streaming(
             body_extras = {}
             if model_provider:
                 body_extras["provider"] = model_provider
+            if reasoning_effort is not None:
+                body_extras["reasoning_effort"] = reasoning_effort
             try:
                 final_text, usage = _run_gateway_runs_api_streaming(
                     session_id, msg_text, model, workspace, stream_id,
@@ -633,6 +657,8 @@ def _run_gateway_chat_streaming(
             }
             if model_provider:
                 body["provider"] = model_provider
+            if reasoning_effort is not None:
+                body["reasoning_effort"] = reasoning_effort
             req = urllib.request.Request(
                 url,
                 data=json.dumps(body).encode("utf-8"),

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -132,10 +132,15 @@ def test_gateway_runs_api_submission():
         STREAMS[stream_id] = q
 
     runs_called = {"called": False}
+    captured = {}
     original_text = "hello from runs"
 
     def fake_runs_streaming(*args, **kwargs):
         runs_called["called"] = True
+        captured["body_extras"] = kwargs.get("body_extras")
+        if captured["body_extras"] is None:
+            if len(args) > 8:
+                captured["body_extras"] = args[8]
         return (original_text, {"input_tokens": 10, "output_tokens": 5})
 
     mock_session = MagicMock()
@@ -154,6 +159,7 @@ def test_gateway_runs_api_submission():
         with patch.dict("os.environ", {"HERMES_WEBUI_CHAT_BACKEND": "gateway", "HERMES_WEBUI_GATEWAY_USE_RUNS_API": "1"}):
             with patch("api.gateway_chat.gateway_supports_approval", lambda *_args, **_kwargs: True), \
                  patch("api.gateway_chat._run_gateway_runs_api_streaming", fake_runs_streaming), \
+                 patch("api.gateway_chat._gateway_reasoning_effort_for_request", return_value="high"), \
                  patch("api.gateway_chat.get_session", return_value=mock_session), \
                  patch("api.gateway_chat._stream_writeback_is_current", return_value=True), \
                  patch("api.gateway_chat.merge_session_messages_append_only", return_value=[]):
@@ -169,6 +175,7 @@ def test_gateway_runs_api_submission():
             STREAMS.pop(stream_id, None)
 
     assert runs_called["called"], "The runs-API streaming path should have been invoked"
+    assert captured["body_extras"]["reasoning_effort"] == "high"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -135,12 +135,20 @@ def test_gateway_runs_api_submission():
     captured = {}
     original_text = "hello from runs"
 
-    def fake_runs_streaming(*args, **kwargs):
+    def fake_runs_streaming(
+        session_id,
+        msg_text,
+        model,
+        workspace,
+        stream_id,
+        base_url,
+        api_key,
+        prefill_messages,
+        body_extras,
+        **kwargs,
+    ):
         runs_called["called"] = True
-        captured["body_extras"] = kwargs.get("body_extras")
-        if captured["body_extras"] is None:
-            if len(args) > 8:
-                captured["body_extras"] = args[8]
+        captured["body_extras"] = body_extras
         return (original_text, {"input_tokens": 10, "output_tokens": 5})
 
     mock_session = MagicMock()

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -283,6 +283,7 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
 
     monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
     monkeypatch.setenv("HERMES_WEBUI_GATEWAY_API_KEY", "secret-token")
+    monkeypatch.setattr(gateway_chat, "_gateway_reasoning_effort_for_request", lambda *args, **kwargs: "high")
     monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {
         "status": "loaded",
         "source": "test",
@@ -330,6 +331,7 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     assert captured["headers"]["X-hermes-session-key"] == f"webui:{s.session_id}"
     assert '"stream": true' in captured["body"]
     payload = json.loads(captured["body"])
+    assert payload["reasoning_effort"] == "high"
     # #3324: the gateway path's first system message is now the full WebUI
     # ephemeral system prompt (progress prompt + session/delivery context),
     # NOT the bare _WEBUI_PROGRESS_PROMPT — otherwise the delivery/session


### PR DESCRIPTION
## Thinking Path

- The issue started as “model and reasoning effort do not affect gateway runs”, but the collaborator follow-up at https://github.com/nesquena/hermes-webui/issues/4550#issuecomment-4757962350 narrowed the live WebUI defect on current `origin/master`, model forwarding already works and reasoning effort forwarding does not.
- The local non-gateway path already has the right source of truth at `api/streaming.py:6758-6771`, where `agent.reasoning_effort` is coerced per model and provider before the actual request is built.
- The gateway path diverges at `api/gateway_chat.py:572-575` and `api/gateway_chat.py:629-635`, where both remote request branches forward `provider` but never add top-level `reasoning_effort`, so the fix is to reuse the existing coercion source and send the value in the same request shape the sibling gateway transport already expects.

## What Changed

- `api/gateway_chat.py`: mirror the existing local reasoning-effort coercion path, then forward top-level `reasoning_effort` through both gateway request branches.
- `tests/test_gateway_approval_runs_api.py`: prove the runs worker forwards `reasoning_effort` into the `body_extras` passed to `_run_gateway_runs_api_streaming(...)`.
- `tests/test_webui_gateway_chat_backend.py`: prove the legacy `/v1/chat/completions` payload now carries top-level `reasoning_effort`.

## Why It Matters

Gateway-backed WebUI chats should honor the same reasoning effort selection that local chats already honor. This keeps the browser control effective in remote mode, without changing the existing provider forwarding or widening into gateway-side policy work.

## Verification

`pytest tests/test_gateway_approval_runs_api.py tests/test_webui_gateway_chat_backend.py -v --timeout=60`

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- This only fixes the live WebUI gap, it does not guarantee every deployed gateway version will honor the forwarded field once received.
- If maintainers want explicit disable-path proof later, a focused `"none"` regression assertion can be added without widening the production scope.

## Upstream

Closes #4550.

Scope narrowed by the collaborator comment at https://github.com/nesquena/hermes-webui/issues/4550#issuecomment-4757962350, which confirmed model forwarding already exists and isolated the remaining WebUI bug to reasoning effort forwarding.

## Model Used

GPT-5 via Codex CLI
