### PR TITLE
fix(models): use stale disk cache on catalog timeout

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -4612,6 +4612,36 @@ def _load_models_cache_from_disk() -> dict | None:
         return None
 
 
+def _load_stale_models_cache_from_disk() -> dict | None:
+    """Load a shape-valid stale /api/models disk cache for timeout fallback only.
+
+    The main cache loader enforces metadata stamps for a full cold-path cache hit.
+    This helper intentionally does not apply that stricter policy, so we can still
+    recover a useful fallback payload when the strict loader rejected cache because
+    metadata or fingerprint fields are stale.
+    """
+    try:
+        import json as _j
+
+        cache_path = _get_models_cache_path()
+        if not cache_path.exists():
+            return None
+        with open(cache_path, encoding="utf-8") as f:
+            cache = _j.load(f)
+        if not _is_valid_models_cache(cache):
+            return None
+        aliases = cache.get("aliases")
+        return {
+            "active_provider": cache["active_provider"],
+            "default_model": cache["default_model"],
+            "configured_model_badges": cache["configured_model_badges"],
+            "groups": cache["groups"],
+            "aliases": aliases if isinstance(aliases, dict) else {},
+        }
+    except Exception:
+        return None
+
+
 def _save_models_cache_to_disk(cache: dict) -> None:
     """Save cache to disk so it survives server restarts.
 
@@ -6349,8 +6379,11 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
     # Then acquire lock and check memory cache.  Cold path runs inside the lock
     # so only one thread rebuilds while others wait.
     disk_groups = None
+    stale_disk_groups = None
     if _available_models_cache is None:
         disk_groups = _load_models_cache_from_disk()
+        if disk_groups is None:
+            stale_disk_groups = _load_stale_models_cache_from_disk()
 
     with _available_models_cache_lock:
         # If another thread is already building, wait for its result instead
@@ -6371,6 +6404,7 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
             _available_models_cache_ts = 0.0
             _available_models_cache_source_fingerprint = None
             disk_groups = None
+            stale_disk_groups = None
 
         # Serve from memory cache if fresh
         now = time.monotonic()
@@ -6590,14 +6624,12 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
             logger.warning(_budget_log_msg, _LIVE_REBUILD_BUDGET_SECONDS)
         else:
             logger.info(_budget_log_msg, _LIVE_REBUILD_BUDGET_SECONDS)
-        # Note: ``disk_groups``, if non-None, was already consumed by the
-        # cold-path early-return at the "Cold path: disk cache hit" branch
-        # above (line ~4608). Any execution that reaches HERE necessarily
-        # took the live-rebuild branch, which means ``disk_groups is None``
-        # at this point — so we don't re-check it. Per Copilot review on
-        # PR #2971: the previous ``if disk_groups is not None`` branch
-        # here was dead code. Fall back directly to the static minimal
-        # catalog (no second disk read).
+        # ``stale_disk_groups`` is shape-valid but failed the strict metadata
+        # checks required for authoritative cold-path use. It was read before
+        # acquiring _available_models_cache_lock so this over-budget fallback
+        # does not extend the lock hold while the worker is ready to publish.
+        if stale_disk_groups is not None:
+            return copy.deepcopy(stale_disk_groups)
         return copy.deepcopy(_static_models_catalog_without_live_probes())
 
 

--- a/tests/test_issue3928_models_budget_fallback.py
+++ b/tests/test_issue3928_models_budget_fallback.py
@@ -50,6 +50,7 @@ def isolate_models_catalog_state(monkeypatch, tmp_path):
 
     return {
         "auth_store_path": auth_store_path,
+        "models_cache_path": tmp_path / "models_cache.json",
     }
 
 
@@ -103,6 +104,39 @@ def _configure_local_sources(
     )
     env_lookup = dict(env_vars or {})
     monkeypatch.setattr(cfg.os, "getenv", lambda key, default=None: env_lookup.get(key, default or ""))
+
+
+def _build_stale_disk_cache_payload() -> dict:
+    return {
+        "active_provider": "ollama-cloud",
+        "default_model": "ollama-cloud/chat-1",
+        "configured_model_badges": {
+            "ollama-cloud/chat-1": {
+                "role": "primary",
+                "provider": "ollama-cloud",
+                "label": "Primary",
+            }
+        },
+        "groups": [
+            {
+                "provider": "Ollama Cloud",
+                "provider_id": "ollama-cloud",
+                "models": [
+                    {"id": "ollama-cloud/chat-1", "label": "Chat 1"},
+                ],
+            }
+        ],
+        "aliases": {
+            "chat": "ollama-cloud/chat-1",
+        },
+        "_schema_version": 999,
+        "_webui_version": "v999",
+        "_source_fingerprint": {
+            "catalog": "stale",
+            "config_yaml": {"size": 42},
+            "auth_json": {"size": 7},
+        },
+    }
 
 
 def test_static_catalog_budget_fallback_lists_local_providers(
@@ -192,6 +226,153 @@ def test_budget_exceeded_foreground_uses_richer_static_catalog_and_refreshes_out
     assert rebuild_calls["count"] == 1
     assert cfg._available_models_cache == live_result
     assert cfg._cache_build_in_progress is False
+
+
+def test_budget_exceeded_uses_shape_only_stale_cache_before_static_fallback(
+    monkeypatch,
+    isolate_models_catalog_state,
+):
+    _configure_local_sources(
+        monkeypatch,
+        isolate_models_catalog_state["auth_store_path"],
+    )
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
+    models_cache_path = isolate_models_catalog_state["models_cache_path"]
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: models_cache_path)
+    models_cache_path.write_text(
+        json.dumps(_build_stale_disk_cache_payload()),
+        encoding="utf-8",
+    )
+
+    live_result = {
+        "active_provider": "openrouter",
+        "default_model": "openrouter/google/gemini-2.5-pro",
+        "configured_model_badges": {},
+        "groups": [
+            {
+                "provider": "OpenRouter",
+                "provider_id": "openrouter",
+                "models": [
+                    {
+                        "id": "openrouter/google/gemini-2.5-pro",
+                        "label": "Gemini 2.5 Pro",
+                    }
+                ],
+            }
+        ],
+        "aliases": {},
+    }
+    rebuild_calls = {"count": 0}
+
+    def _slow_rebuild(_builder):
+        rebuild_calls["count"] += 1
+        time.sleep(0.2)
+        return copy.deepcopy(live_result)
+
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _slow_rebuild)
+
+    expected_fallback = _build_stale_disk_cache_payload()
+    expected_fallback.pop("_schema_version")
+    expected_fallback.pop("_webui_version")
+    expected_fallback.pop("_source_fingerprint")
+    result = cfg.get_available_models()
+
+    assert any(
+        g["provider_id"] == "ollama-cloud" for g in result["groups"]
+    )
+    assert result == expected_fallback
+    assert "ollama-cloud" not in {
+        g["provider_id"] for g in cfg._static_models_catalog_without_live_probes()["groups"]
+    }
+    assert (
+        cfg._available_models_cache is None
+        or cfg._available_models_cache != expected_fallback
+    )
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if cfg._available_models_cache == live_result:
+            break
+        time.sleep(0.01)
+
+    assert rebuild_calls["count"] == 1
+    assert cfg._available_models_cache == live_result
+    assert cfg._cache_build_in_progress is False
+
+
+def test_budget_exceeded_fallback_uses_static_when_stale_disk_cache_invalid(
+    monkeypatch,
+    isolate_models_catalog_state,
+):
+    _configure_local_sources(
+        monkeypatch,
+        isolate_models_catalog_state["auth_store_path"],
+    )
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
+    models_cache_path = isolate_models_catalog_state["models_cache_path"]
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: models_cache_path)
+    models_cache_path.write_text(
+        json.dumps({"active_provider": "openai-api", "default_model": "gpt-5.5"}),
+        encoding="utf-8",
+    )
+    assert cfg._load_stale_models_cache_from_disk() is None
+
+    live_result = {
+        "active_provider": "openrouter",
+        "default_model": "openrouter/google/gemini-2.5-pro",
+        "configured_model_badges": {},
+        "groups": [
+            {
+                "provider": "OpenRouter",
+                "provider_id": "openrouter",
+                "models": [
+                    {
+                        "id": "openrouter/google/gemini-2.5-pro",
+                        "label": "Gemini 2.5 Pro",
+                    }
+                ],
+            }
+        ],
+        "aliases": {},
+    }
+    rebuild_calls = {"count": 0}
+
+    def _slow_rebuild(_builder):
+        rebuild_calls["count"] += 1
+        time.sleep(0.2)
+        return copy.deepcopy(live_result)
+
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _slow_rebuild)
+
+    expected_static = cfg._static_models_catalog_without_live_probes()
+    result = cfg.get_available_models()
+
+    assert result == expected_static
+    assert all(g["provider_id"] != "ollama-cloud" for g in result["groups"])
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if cfg._available_models_cache == live_result:
+            break
+        time.sleep(0.01)
+
+    assert rebuild_calls["count"] == 1
+    assert cfg._available_models_cache == live_result
+
+
+def test_load_stale_models_cache_from_disk_defaults_missing_aliases(
+    monkeypatch,
+    isolate_models_catalog_state,
+):
+    payload = _build_stale_disk_cache_payload()
+    payload.pop("aliases")
+    models_cache_path = isolate_models_catalog_state["models_cache_path"]
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: models_cache_path)
+    models_cache_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    stale = cfg._load_stale_models_cache_from_disk()
+    assert stale is not None
+    assert stale["aliases"] == {}
 
 
 def test_default_group_survives_only_as_emergency_last_resort(


### PR DESCRIPTION
## Thinking Path

- `/api/models` keeps the foreground request bounded so a slow provider probe cannot hang the model picker.
- #4052 made the over-budget fallback useful for cold/no-cache cases by returning a richer static catalog instead of a one-model `Default` group.
- There is still a middle case where `models_cache.json` exists and has a valid `/api/models` payload, but strict metadata/fingerprint validation rejects it for normal cold-path use.
- In that case, falling straight to the static catalog can drop provider groups that the last-known cache already had.
- The narrow fix is to use a shape-valid stale disk cache only as the over-budget foreground response, while leaving strict cold-path cache validation and background live refresh publication unchanged.

## What Changed

- Added a shape-only stale disk-cache loader for `/api/models` timeout fallback.
- Updated the bounded live-rebuild timeout path to try that stale cache before the static fallback.
- Kept the stale payload response-only: it is not written into the in-memory catalog cache and is not saved back to disk.
- Added regression coverage for valid stale cache use, invalid stale cache fallback, missing `aliases`, and continued out-of-band live publication.

## Why It Matters

- The first model-picker response after a slow live rebuild can preserve last-known provider groups instead of dropping to a smaller static catalog.
- Users with providers discovered through live catalogs are less likely to see options disappear during a timeout.
- The live rebuild still refreshes the authoritative cache when it completes, so stale cache use remains a temporary fallback rather than a new source of truth.
- The final static fallback remains available when no shape-valid disk cache exists.

## Verification

Targeted coverage:

```text
./scripts/test.sh tests/test_issue3928_models_budget_fallback.py tests/test_wakeup_model_resolve_hang.py -q
# 14 passed in 4.18s
```

Syntax / hygiene checks:

```text
python -m py_compile api/config.py tests/test_issue3928_models_budget_fallback.py
# passed

git diff --check
# passed
```

Independent review:

```text
Claude Opus review found no blocking issues.
```

## Risks / Follow-ups

- This intentionally does not relax the strict cold-path disk cache loader; stale cache use is limited to the over-budget foreground fallback.
- The disk cache currently may not contain every optional top-level field from a live response; the stale fallback defaults missing `aliases` to `{}` and the background rebuild still publishes the fresh full result when it completes.

## Model Used

- OpenAI / GPT-5.5 via OpenCode for implementation.
- Anthropic / Claude Opus 4.8 for independent review.
