### PR TITLE
Release v0.51.539 — gateway session continuity + local slash-model routing (#4548, #4547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## [Unreleased]
 
+## [v0.51.539] — 2026-06-20 — Release SX (gateway session continuity + local slash-model routing)
+
+### Fixed
+
+- **The gateway Runs API no longer spawns a fresh session for every message (#4535).** The `/v1/runs` request body omitted `session_id`, so each turn created a new `run_<uuid>` session instead of reusing the stable WebUI session — flooding the sidebar with duplicate `Api_Server` sessions and breaking conversation continuity. The body now carries `session_id`. Thanks @rodboev.
+- **HuggingFace-style slash model IDs now route to the configured local provider instead of the default backend.** A selected local model such as `unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL` was being sent to the default provider (e.g. `openai-codex`) because the slash in the ID suppressed provider qualification. When the selected provider is explicitly configured in `config.yaml` (llama.cpp, Ollama, LM Studio, vLLM, or any OpenAI-compatible endpoint), the model ID is now qualified as `@provider:model` so it reaches the right backend; OpenRouter and removed-provider slow paths are preserved. Thanks @MinhoJJang.
+
 ## [v0.51.538] — 2026-06-20 — Release SW (gateway approval cards work on the default legacy path)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -2515,8 +2515,19 @@ def model_with_provider_context(model_id: str, model_provider: str | None = None
     if provider == "openrouter":
         return f"@{provider}:{model}"
 
-    # For non-OpenRouter slash IDs, keep the ID intact so existing custom/proxy
-    # base_url routing and portal-provider handling remain in charge.
+    # Explicit providers configured in config.yaml (for example local llama.cpp,
+    # Ollama, LM Studio, vLLM, or other OpenAI-compatible endpoints) must keep
+    # their provider hint even when the model ID is HuggingFace-style and
+    # contains '/'. Otherwise a selected local model such as
+    # 'unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL' inherits the default provider
+    # (e.g. openai-codex) and is sent to the wrong backend.
+    providers_cfg = cfg.get("providers") if isinstance(cfg, dict) else {}
+    if isinstance(providers_cfg, dict) and provider in providers_cfg:
+        return f"@{provider}:{model}"
+
+    # For non-OpenRouter slash IDs without an explicit configured provider,
+    # keep the ID intact so existing custom/proxy base_url routing and
+    # portal-provider handling remain in charge.
     if "/" in model:
         return model
 

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -313,6 +313,7 @@ def _run_gateway_runs_api_streaming(
         "model": model or "default",
         "input": run_input,
         **body_extras,
+        "session_id": session_id,
     }
     if instructions_parts:
         run_body["instructions"] = "\n\n".join(part for part in instructions_parts if part)

--- a/api/routes.py
+++ b/api/routes.py
@@ -3713,6 +3713,15 @@ def _resolve_compatible_session_model_state(
     """
     model = str(model_id or "").strip()
     requested_provider = _clean_session_model_provider(model_provider)
+    if model and requested_provider and model.startswith(f"@{requested_provider}:"):
+        try:
+            from api.config import cfg as _active_cfg
+
+            providers_cfg = _active_cfg.get("providers") if isinstance(_active_cfg, dict) else {}
+        except Exception:
+            providers_cfg = {}
+        if isinstance(providers_cfg, dict) and requested_provider in providers_cfg:
+            return model, requested_provider, False
     if model and requested_provider:
         # Only safe when the model itself does not carry an ``@provider:model``
         # qualifier — qualified strings require the catalog to decide whether

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -300,6 +300,7 @@ def test_gateway_runs_api_streaming_parses_real_run_events():
     assert run_body["instructions"] == "system prompt"
     assert run_body["conversation_history"] == [{"role": "assistant", "content": "earlier reply"}]
     assert run_body["provider"] == "anthropic"
+    assert run_body["session_id"] == "sess1"
     assert "messages" not in run_body
 
     assert final_text == "Hello"

--- a/tests/test_issue1855_resolve_model_provider_fast_path.py
+++ b/tests/test_issue1855_resolve_model_provider_fast_path.py
@@ -30,7 +30,6 @@ Coverage:
    through).
 """
 import pathlib
-import re
 from unittest.mock import patch
 
 
@@ -174,6 +173,40 @@ class TestSlowPathStillFires:
             "the qualifier matches the active provider and to detect stale "
             "cross-provider artifacts (#1253)."
         )
+
+    def test_configured_provider_qualified_model_skips_catalog(self):
+        """Configured providers already carry trusted routing context."""
+        import api.config as config
+        from api.routes import _resolve_compatible_session_model_state
+
+        old_cfg = dict(config.cfg)
+        config.cfg["model"] = {
+            "provider": "openai-codex",
+            "default": "gpt-5.5",
+        }
+        config.cfg["providers"] = {
+            "local-llama": {
+                "base_url": "http://127.0.0.1:8088/v1",
+                "api_key": "test-key",
+            },
+        }
+        try:
+            with patch("api.routes.get_available_models") as mock_catalog:
+                mock_catalog.side_effect = AssertionError("catalog should not be called")
+                result = _resolve_compatible_session_model_state(
+                    "@local-llama:unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL",
+                    "local-llama",
+                )
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+
+        assert result == (
+            "@local-llama:unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL",
+            "local-llama",
+            False,
+        )
+        assert mock_catalog.call_count == 0
 
     def test_no_requested_provider_goes_to_slow_path(self):
         """When provider isn't supplied, slow path must repair from catalog."""

--- a/tests/test_provider_mismatch.py
+++ b/tests/test_provider_mismatch.py
@@ -522,6 +522,37 @@ def test_non_openrouter_slash_model_provider_context_stays_unqualified():
     assert runtime_model == "anthropic/claude-sonnet-4.6"
 
 
+def test_configured_provider_slash_model_keeps_provider_context():
+    """Configured OpenAI-compatible providers need explicit context for slash IDs."""
+    import api.config as config
+
+    old_cfg = dict(config.cfg)
+    config.cfg["model"] = {
+        "provider": "openai-codex",
+        "default": "gpt-5.5",
+    }
+    config.cfg["providers"] = {
+        "local-llama": {
+            "base_url": "http://127.0.0.1:8088/v1",
+            "api_key": "test-key",
+        },
+    }
+    try:
+        runtime_model = config.model_with_provider_context(
+            "unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL",
+            "local-llama",
+        )
+        model, provider, base_url = config.resolve_model_provider(runtime_model)
+    finally:
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+
+    assert runtime_model == "@local-llama:unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL"
+    assert model == "unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL"
+    assert provider == "local-llama"
+    assert base_url == "http://127.0.0.1:8088/v1"
+
+
 def test_cursor_acp_slash_model_always_gets_provider_hint():
     """ACP subprocess models with '/' must not fall through to config default."""
     import api.config as config

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -854,6 +854,70 @@ def test_gateway_use_runs_api_env_wins_over_config():
     ) is False
 
 
+def test_gateway_runs_api_body_includes_session_id():
+    """#4535: the runs API body must carry session_id so the agent reuses the
+    browser session instead of creating a fresh run_<uuid> per message."""
+    from unittest.mock import patch, MagicMock
+    from api.config import STREAMS, STREAMS_LOCK
+    from api.gateway_chat import _run_gateway_chat_streaming
+
+    captured = {}
+    events = []
+    q = MagicMock()
+    q.put_nowait = lambda item: events.append(item)
+    stream_id = "sid-runs-session-id"
+    with STREAMS_LOCK:
+        STREAMS[stream_id] = q
+
+    call_count = [0]
+
+    def fake_urlopen(req, *, timeout=None):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            captured["url"] = req.full_url
+            resp = MagicMock()
+            resp.read = lambda sz=65536: json.dumps({"run_id": "run_abc"}).encode()
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            return resp
+        resp = MagicMock()
+        resp.__iter__ = lambda s: iter([
+            b'data: {"choices":[{"delta":{"content":"ok"}}]}\n',
+            b'data: [DONE]\n',
+        ])
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        return resp
+
+    import os
+    env = {k: v for k, v in os.environ.items()}
+    env["HERMES_WEBUI_CHAT_BACKEND"] = "gateway"
+    env["HERMES_WEBUI_GATEWAY_USE_RUNS_API"] = "1"
+    env["HERMES_WEBUI_GATEWAY_BASE_URL"] = "http://gateway.local"
+
+    try:
+        with patch.dict("os.environ", env, clear=True):
+            with patch("api.gateway_chat.gateway_supports_approval", return_value=True), \
+                 patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+                 patch("api.gateway_chat.get_session", return_value=MagicMock(
+                     active_stream_id=stream_id, workspace="/tmp",
+                     profile=None, context_messages=[], messages=[],
+                 )):
+                _run_gateway_chat_streaming(
+                    session_id="sess-stable-uuid",
+                    msg_text="hi",
+                    model="test",
+                    workspace="/tmp",
+                    stream_id=stream_id,
+                )
+        assert "/v1/runs" in captured["url"]
+        assert captured["body"]["session_id"] == "sess-stable-uuid"
+    finally:
+        with STREAMS_LOCK:
+            STREAMS.pop(stream_id, None)
+
+
 def test_gateway_worker_skips_runs_api_when_opt_in_absent():
     """Worker uses chat/completions even when gateway advertises approval support, unless opt-in is set."""
     from unittest.mock import patch, MagicMock


### PR DESCRIPTION
## Release v0.51.539 — Release SX (gateway session continuity + local slash-model routing)

Batch of two independent, gated breaking-flow fixes. Cherry-picked onto current master with original author attribution preserved.

### Fixed

- **The gateway Runs API no longer spawns a fresh session for every message (#4535).** The `/v1/runs` request body omitted `session_id`, so each turn created a new `run_<uuid>` session instead of reusing the stable WebUI session — flooding the sidebar with duplicate `Api_Server` sessions and breaking conversation continuity. The body now carries `session_id`. Thanks @rodboev (#4548).
- **HuggingFace-style slash model IDs now route to the configured local provider instead of the default backend.** A selected local model such as `unsloth/gemma-4-12b-it-GGUF:UD-Q4_K_XL` was being sent to the default provider (e.g. `openai-codex`) because the slash in the ID suppressed provider qualification. When the selected provider is explicitly configured in `config.yaml` (llama.cpp, Ollama, LM Studio, vLLM, or any OpenAI-compatible endpoint), the model ID is now qualified as `@provider:model`; OpenRouter and removed-provider slow paths are preserved. Thanks @MinhoJJang (#4547).

### Gate

- Full pytest suite: **9736 passed**, 0 failed
- Codex regression gate: **SAFE TO SHIP**
- Opus advisor: **SAFE** (verified None-safety, ordering, mutual independence, no OpenRouter/custom-path/gateway-consumer regression)

Closes #4535.
