### PR TITLE
Release v0.51.540 — cross-provider model selection + gateway reasoning effort (#4554, #4552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## [Unreleased]
 
+## [v0.51.540] — 2026-06-20 — Release SY (cross-provider model selection sticks + gateway reasoning effort)
+
+### Fixed
+
+- **A cross-provider relay model no longer silently reverts to the profile default after the first message (#3737).** When you selected a cross-provider relay model (e.g. `custom:glm-free-relay`), the explicit-pick marker was consumed after the first send, so subsequent turns lost the explicit pick and the server "repaired" the model back to the profile default. The composer now treats a non-default model from a different provider than the profile's active provider as an explicit pick on every send, and `_catalog_has_provider()` correctly recognizes compound provider IDs (`custom:glm-free-relay` → `custom`). Thanks @jja881.
+- **The gateway chat path now forwards the reasoning-effort control (#4550).** The browser's reasoning-effort setting was silently ignored in remote/gateway mode while the local path already honored it. The gateway request now reads and coerces `agent.reasoning_effort` with the same logic as the local path and forwards it on both the runs-API and legacy chat-completions branches (explicit "none" preserved; absent/invalid values omitted). Thanks @rodboev.
+
 ## [v0.51.539] — 2026-06-20 — Release SX (gateway session continuity + local slash-model routing)
 
 ### Fixed

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -108,6 +108,7 @@ def _gateway_reasoning_effort_for_request(cfg, *, model=None, model_provider=Non
             model,
             provider_id=model_provider,
         )
+        # Preserve explicit "none" while still omitting absent or invalid effort.
         return None if not coerced else str(coerced)
     except Exception:
         return None

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -19,6 +19,7 @@ from api.config import (
     STREAM_PARTIAL_TEXT,
     STREAM_REASONING_TEXT,
     _get_session_agent_lock,
+    coerce_reasoning_effort_for_model,
     gateway_supports_approval,
     register_active_run,
     unregister_active_run,
@@ -94,6 +95,22 @@ def _gateway_use_runs_api_enabled(config_data=None, environ: dict[str, str] | No
         or ""
     ).strip().lower()
     return raw in ("1", "true", "yes", "on")
+
+
+def _gateway_reasoning_effort_for_request(cfg, *, model=None, model_provider=None):
+    """Read and coerce user-configured reasoning effort for a gateway request."""
+    try:
+        cfg_data = cfg if isinstance(cfg, dict) else {}
+        effort_cfg = cfg_data.get("agent", {}) if isinstance(cfg_data, dict) else {}
+        effort_raw = effort_cfg.get("reasoning_effort") if isinstance(effort_cfg, dict) else None
+        coerced = coerce_reasoning_effort_for_model(
+            effort_raw,
+            model,
+            provider_id=model_provider,
+        )
+        return None if not coerced else str(coerced)
+    except Exception:
+        return None
 
 
 def gateway_chat_config_status(config_data=None, environ: dict[str, str] | None = None) -> dict:
@@ -528,6 +545,11 @@ def _run_gateway_chat_streaming(
         from api.config import get_config  # imported lazily to avoid config-cycle churn
 
         cfg = get_config()
+        reasoning_effort = _gateway_reasoning_effort_for_request(
+            cfg,
+            model=model,
+            model_provider=model_provider,
+        )
         try:
             from api.streaming import (
                 _load_webui_prefill_context,
@@ -574,6 +596,8 @@ def _run_gateway_chat_streaming(
             body_extras = {}
             if model_provider:
                 body_extras["provider"] = model_provider
+            if reasoning_effort is not None:
+                body_extras["reasoning_effort"] = reasoning_effort
             try:
                 final_text, usage = _run_gateway_runs_api_streaming(
                     session_id, msg_text, model, workspace, stream_id,
@@ -634,6 +658,8 @@ def _run_gateway_chat_streaming(
             }
             if model_provider:
                 body["provider"] = model_provider
+            if reasoning_effort is not None:
+                body["reasoning_effort"] = reasoning_effort
             req = urllib.request.Request(
                 url,
                 data=json.dumps(body).encode("utf-8"),

--- a/api/routes.py
+++ b/api/routes.py
@@ -3196,18 +3196,7 @@ def _catalog_has_provider(
         provider_raw in raw_provider_ids
         or (provider_normalized and provider_normalized in raw_provider_ids)
         or (provider_normalized and provider_normalized in normalized_provider_ids)
-        # Compound provider IDs like "custom:zenmux-relay" normalize to
-        # "custom" which is a raw catalog provider_id.  The three checks
-        # above compare raw-vs-raw and normalized-vs-normalized but miss
-        # normalized-vs-raw for compound hints.  Without this, a
-        # @custom:relay-name:model selection is silently reverted to the
-        # profile default on every non-explicit turn because the catalog
-        # lookup fails and the fallback branch at line ~3932 fires.
-        or (
-            provider_normalized
-            and ":" in provider_raw
-            and provider_normalized in raw_provider_ids
-        )
+
     )
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -3196,6 +3196,18 @@ def _catalog_has_provider(
         provider_raw in raw_provider_ids
         or (provider_normalized and provider_normalized in raw_provider_ids)
         or (provider_normalized and provider_normalized in normalized_provider_ids)
+        # Compound provider IDs like "custom:zenmux-relay" normalize to
+        # "custom" which is a raw catalog provider_id.  The three checks
+        # above compare raw-vs-raw and normalized-vs-normalized but miss
+        # normalized-vs-raw for compound hints.  Without this, a
+        # @custom:relay-name:model selection is silently reverted to the
+        # profile default on every non-explicit turn because the catalog
+        # lookup fails and the fallback branch at line ~3932 fires.
+        or (
+            provider_normalized
+            and ":" in provider_raw
+            and provider_normalized in raw_provider_ids
+        )
     )
 
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -1267,15 +1267,29 @@ async function send(){
     const _pendingPick=(typeof _readPendingSessionModel==='function')
       ? _readPendingSessionModel(activeSid)
       : null;
-    const _explicitPick=_pendingPick
+    const _pendingPickMatch=_pendingPick
       && _pendingPick.model===_modelState.model
       && String(_pendingPick.model_provider||'')===String(_modelState.model_provider||'');
+    // ── Persisted cross-provider pick (#3737 follow-up) ──
+    // The onchange marker is consumed after the first send, so subsequent sends
+    // lose explicit_model_pick and the server "repairs" the model back to the
+    // profile default.  When the session has a non-default model from a different
+    // provider than the profile's active provider, treat every send as explicit
+    // so the server honors the user's choice across the entire conversation.
+    const _defaultModel=(typeof window!=='undefined' && window._defaultModel)||'';
+    const _activeProvider=(typeof window!=='undefined' && window._activeProvider)||null;
+    const _isCrossProviderPick = _modelState.model
+      && _modelState.model_provider
+      && _defaultModel
+      && _modelState.model !== _defaultModel
+      && String(_modelState.model_provider||'') !== String(_activeProvider||'');
+    const _explicitPick = _pendingPickMatch || _isCrossProviderPick;
     // Consume the pending explicit-pick marker for THIS send only. The marker is
     // recorded on modelSelect.onchange and intentionally kept (not cleared on
     // session-update) so it survives the normal pick→update→send flow; clear it here
     // once read so a later send of an unchanged dropdown isn't treated as an explicit
     // pick. (#3739/#3737, Codex catch)
-    if(_explicitPick && typeof _clearPendingSessionModel==='function') _clearPendingSessionModel(activeSid);
+    if(_pendingPickMatch && typeof _clearPendingSessionModel==='function') _clearPendingSessionModel(activeSid);
     explicitPickForPostStart=_explicitPick;
     const startData=await api('/api/chat/start',{method:'POST',body:JSON.stringify({
       session_id:activeSid,message:msgText,

--- a/static/messages.js
+++ b/static/messages.js
@@ -1281,6 +1281,7 @@ async function send(){
     const _isCrossProviderPick = _modelState.model
       && _modelState.model_provider
       && _defaultModel
+      && _activeProvider
       && _modelState.model !== _defaultModel
       && String(_modelState.model_provider||'') !== String(_activeProvider||'');
     const _explicitPick = _pendingPickMatch || _isCrossProviderPick;

--- a/tests/test_catalog_has_provider_compound_ids.py
+++ b/tests/test_catalog_has_provider_compound_ids.py
@@ -1,0 +1,66 @@
+"""Tests for _catalog_has_provider() with compound provider IDs.
+
+Compound provider IDs like "custom:zenmux-relay" or "custom:glm-free-relay"
+normalize to "custom" via _normalize_provider_id(). The existing three
+clauses in _catalog_has_provider() already handle these correctly:
+
+  C1: exact raw match  ("custom:zenmux-relay" ∈ raw_ids)
+  C2: normalized ∈ raw_ids  ("custom" ∈ raw_ids)
+  C3: normalized ∈ norm_ids ("custom" ∈ norm_ids)
+
+This test guards against regressions and verifies that no 4th clause is
+needed for compound IDs.
+"""
+from __future__ import annotations
+
+from api.routes import _catalog_has_provider
+
+
+def test_compound_provider_exact_raw_match():
+    """C1: exact raw match for a compound ID like 'custom:zenmux-relay'."""
+    assert _catalog_has_provider(
+        "custom:zenmux-relay",
+        "custom",
+        {"custom:zenmux-relay"},
+        {"custom"},
+    )
+
+
+def test_compound_provider_normalized_in_raw_ids():
+    """C2: normalized form 'custom' found in raw_provider_ids."""
+    assert _catalog_has_provider(
+        "custom:zenmux-relay",
+        "custom",
+        {"custom"},
+        {"custom"},
+    )
+
+
+def test_compound_provider_normalized_in_norm_ids():
+    """C3: normalized form 'custom' found in normalized_provider_ids."""
+    assert _catalog_has_provider(
+        "custom:zenmux-relay",
+        "custom",
+        {"other"},
+        {"custom"},
+    )
+
+
+def test_compound_provider_not_found():
+    """Returns False when neither raw nor normalized form is in the catalog."""
+    assert not _catalog_has_provider(
+        "custom:unknown-relay",
+        "custom",
+        {"openrouter", "nous"},
+        {"openrouter", "nous"},
+    )
+
+
+def test_compound_provider_glm_free_relay():
+    """Real-world case: custom:glm-free-relay providing z-ai/glm-5.2-free."""
+    assert _catalog_has_provider(
+        "custom:glm-free-relay",
+        "custom",
+        {"custom:glm-free-relay"},
+        {"custom"},
+    )

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -132,10 +132,15 @@ def test_gateway_runs_api_submission():
         STREAMS[stream_id] = q
 
     runs_called = {"called": False}
+    captured = {}
     original_text = "hello from runs"
 
     def fake_runs_streaming(*args, **kwargs):
         runs_called["called"] = True
+        captured["body_extras"] = kwargs.get("body_extras")
+        if captured["body_extras"] is None:
+            if len(args) > 8:
+                captured["body_extras"] = args[8]
         return (original_text, {"input_tokens": 10, "output_tokens": 5})
 
     mock_session = MagicMock()
@@ -154,6 +159,7 @@ def test_gateway_runs_api_submission():
         with patch.dict("os.environ", {"HERMES_WEBUI_CHAT_BACKEND": "gateway", "HERMES_WEBUI_GATEWAY_USE_RUNS_API": "1"}):
             with patch("api.gateway_chat.gateway_supports_approval", lambda *_args, **_kwargs: True), \
                  patch("api.gateway_chat._run_gateway_runs_api_streaming", fake_runs_streaming), \
+                 patch("api.gateway_chat._gateway_reasoning_effort_for_request", return_value="high"), \
                  patch("api.gateway_chat.get_session", return_value=mock_session), \
                  patch("api.gateway_chat._stream_writeback_is_current", return_value=True), \
                  patch("api.gateway_chat.merge_session_messages_append_only", return_value=[]):
@@ -169,6 +175,7 @@ def test_gateway_runs_api_submission():
             STREAMS.pop(stream_id, None)
 
     assert runs_called["called"], "The runs-API streaming path should have been invoked"
+    assert captured["body_extras"]["reasoning_effort"] == "high"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -135,12 +135,20 @@ def test_gateway_runs_api_submission():
     captured = {}
     original_text = "hello from runs"
 
-    def fake_runs_streaming(*args, **kwargs):
+    def fake_runs_streaming(
+        session_id,
+        msg_text,
+        model,
+        workspace,
+        stream_id,
+        base_url,
+        api_key,
+        prefill_messages,
+        body_extras,
+        **kwargs,
+    ):
         runs_called["called"] = True
-        captured["body_extras"] = kwargs.get("body_extras")
-        if captured["body_extras"] is None:
-            if len(args) > 8:
-                captured["body_extras"] = args[8]
+        captured["body_extras"] = body_extras
         return (original_text, {"input_tokens": 10, "output_tokens": 5})
 
     mock_session = MagicMock()

--- a/tests/test_issue3737_explicit_pick_client_wiring.py
+++ b/tests/test_issue3737_explicit_pick_client_wiring.py
@@ -61,9 +61,11 @@ def test_send_consumes_pending_pick_after_reading_it():
     assert "_clearPendingSessionModel(activeSid)" in region, (
         "send() must consume (clear) the pending explicit-pick marker after reading it"
     )
-    # The clear must be gated on _explicitPick (only consume a genuine, matching pick).
-    assert re.search(r"_explicitPick\s*&&[^\n]*_clearPendingSessionModel", region), (
-        "the consume-clear must be gated on _explicitPick"
+    # The clear must be gated on a genuine, matching pending pick (not on the
+    # broadened _explicitPick which may also be true from a cross-provider
+    # inference without a pending marker to consume).
+    assert re.search(r"_pendingPickMatch\s*&&[^\\n]*_clearPendingSessionModel", region), (
+        "the consume-clear must be gated on _pendingPickMatch (a genuine, matching pending pick)"
     )
 
 

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -283,6 +283,7 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
 
     monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
     monkeypatch.setenv("HERMES_WEBUI_GATEWAY_API_KEY", "secret-token")
+    monkeypatch.setattr(gateway_chat, "_gateway_reasoning_effort_for_request", lambda *args, **kwargs: "high")
     monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {
         "status": "loaded",
         "source": "test",
@@ -330,6 +331,7 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     assert captured["headers"]["X-hermes-session-key"] == f"webui:{s.session_id}"
     assert '"stream": true' in captured["body"]
     payload = json.loads(captured["body"])
+    assert payload["reasoning_effort"] == "high"
     # #3324: the gateway path's first system message is now the full WebUI
     # ephemeral system prompt (progress prompt + session/delivery context),
     # NOT the bare _WEBUI_PROGRESS_PROMPT — otherwise the delivery/session


### PR DESCRIPTION
## Release v0.51.540 — Release SY (cross-provider model selection sticks + gateway reasoning effort)

Batch of two independent, gated fix-class PRs. Cherry-picked onto current master with original author attribution preserved.

### Fixed

- **A cross-provider relay model no longer silently reverts to the profile default after the first message (#3737).** When you selected a cross-provider relay model (e.g. `custom:glm-free-relay`), the explicit-pick marker was consumed after the first send, so subsequent turns lost the explicit pick and the server "repaired" the model back to the profile default. The composer now treats a non-default model from a different provider than the profile's active provider as an explicit pick on every send, and `_catalog_has_provider()` correctly recognizes compound provider IDs. Thanks @jja881 (#4554).
- **The gateway chat path now forwards the reasoning-effort control (#4550).** The browser's reasoning-effort setting was silently ignored in remote/gateway mode while the local path already honored it. The gateway request now reads and coerces `agent.reasoning_effort` with the same logic as the local path and forwards it on both the runs-API and legacy chat-completions branches. Thanks @rodboev (#4552).

### Gate

- Full pytest suite: **9741 passed**, 0 failed
- Codex regression gate: **SAFE TO SHIP**
- Opus advisor: **SAFE — SHIP** (one optional non-blocking parity note, no action needed)

Closes #3737, #4550.
