### PR TITLE
Release v0.51.541 — stale models-cache fallback on catalog timeout (#4555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.541] — 2026-06-20 — Release SZ (model picker recovers a stale disk cache on catalog timeout)
+
+### Fixed
+
+- **The model picker now falls back to a stale disk cache instead of a thin "Default" group when the live catalog rebuild times out (#3928 follow-up).** The strict cache loader rejects `models_cache.json` when its metadata/fingerprint stamps are out of date, which previously forced the over-budget rebuild path to fall all the way back to the minimal static catalog — losing the user's real provider/model groups whenever a rebuild ran long with only a stale cache on disk. A new shape-validated loader reads that stale payload (read before acquiring the cache lock, so it doesn't extend the lock hold) and serves it as the over-budget fallback, preferring it over the static minimal catalog. Strict cold-path cache hits and the static fallback for a truly empty cache are unchanged. Thanks @starship-s.
+
 ## [v0.51.540] — 2026-06-20 — Release SY (cross-provider model selection sticks + gateway reasoning effort)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -4618,7 +4618,10 @@ def _load_stale_models_cache_from_disk() -> dict | None:
     The main cache loader enforces metadata stamps for a full cold-path cache hit.
     This helper intentionally does not apply that stricter policy, so we can still
     recover a useful fallback payload when the strict loader rejected cache because
-    metadata or fingerprint fields are stale.
+    metadata or fingerprint fields are stale. It DOES still enforce the schema
+    version: a cross-schema cache can have an incompatible groups/badge shape, so
+    serving it to the picker could surface a broken catalog — schema mismatch is a
+    hard reject even on the fallback path.
     """
     try:
         import json as _j
@@ -4629,6 +4632,8 @@ def _load_stale_models_cache_from_disk() -> dict | None:
         with open(cache_path, encoding="utf-8") as f:
             cache = _j.load(f)
         if not _is_valid_models_cache(cache):
+            return None
+        if cache.get("_schema_version") != _MODELS_CACHE_SCHEMA_VERSION:
             return None
         aliases = cache.get("aliases")
         return {

--- a/api/config.py
+++ b/api/config.py
@@ -4601,15 +4601,44 @@ def _load_models_cache_from_disk() -> dict | None:
         if not _is_loadable_disk_cache(cache):
             return None
         # Strip the disk-only metadata before returning, so the in-memory
-        # cache shape stays exactly what the rest of the code expects.
+        # cache shape stays exactly what the rest of the code expects. The
+        # disk save path does not persist `aliases`, so reconstruct them from
+        # current config to keep the /api/models.aliases contract intact (a
+        # disk-cache hit must not silently drop `/model <alias>` resolution).
         return {
             "active_provider": cache["active_provider"],
             "default_model": cache["default_model"],
             "configured_model_badges": cache["configured_model_badges"],
             "groups": cache["groups"],
+            "aliases": (
+                cache["aliases"]
+                if isinstance(cache.get("aliases"), dict)
+                else _model_aliases_from_config()
+            ),
         }
     except Exception:
         return None
+
+
+def _model_aliases_from_config() -> dict[str, str]:
+    """Build the normalized model-alias map from current config.
+
+    Mirrors the alias construction used by the live and static catalog paths so
+    the `/api/models.aliases` contract is consistent across every catalog source
+    (live, static, and the stale-disk fallback, which can't read aliases from a
+    disk cache that never persisted them).
+    """
+    try:
+        raw_aliases = cfg.get("model", {}).get("aliases", {})
+        if isinstance(raw_aliases, dict):
+            return {
+                str(k).strip(): str(v).strip()
+                for k, v in raw_aliases.items()
+                if k and v
+            }
+    except Exception:
+        pass
+    return {}
 
 
 def _load_stale_models_cache_from_disk() -> dict | None:
@@ -4636,12 +4665,20 @@ def _load_stale_models_cache_from_disk() -> dict | None:
         if cache.get("_schema_version") != _MODELS_CACHE_SCHEMA_VERSION:
             return None
         aliases = cache.get("aliases")
+        if not isinstance(aliases, dict):
+            # The disk cache save path does not persist `aliases`, so a cache
+            # read back from disk lacks them. Defaulting to {} would silently
+            # break `/model <alias>` slash-command resolution (static/commands.js
+            # resolves slash aliases only from /api/models.aliases) for the
+            # duration of the over-budget stale fallback. Reconstruct from
+            # current config, mirroring the live/static catalog alias build.
+            aliases = _model_aliases_from_config()
         return {
             "active_provider": cache["active_provider"],
             "default_model": cache["default_model"],
             "configured_model_badges": cache["configured_model_badges"],
             "groups": cache["groups"],
-            "aliases": aliases if isinstance(aliases, dict) else {},
+            "aliases": aliases,
         }
     except Exception:
         return None

--- a/api/config.py
+++ b/api/config.py
@@ -4612,6 +4612,36 @@ def _load_models_cache_from_disk() -> dict | None:
         return None
 
 
+def _load_stale_models_cache_from_disk() -> dict | None:
+    """Load a shape-valid stale /api/models disk cache for timeout fallback only.
+
+    The main cache loader enforces metadata stamps for a full cold-path cache hit.
+    This helper intentionally does not apply that stricter policy, so we can still
+    recover a useful fallback payload when the strict loader rejected cache because
+    metadata or fingerprint fields are stale.
+    """
+    try:
+        import json as _j
+
+        cache_path = _get_models_cache_path()
+        if not cache_path.exists():
+            return None
+        with open(cache_path, encoding="utf-8") as f:
+            cache = _j.load(f)
+        if not _is_valid_models_cache(cache):
+            return None
+        aliases = cache.get("aliases")
+        return {
+            "active_provider": cache["active_provider"],
+            "default_model": cache["default_model"],
+            "configured_model_badges": cache["configured_model_badges"],
+            "groups": cache["groups"],
+            "aliases": aliases if isinstance(aliases, dict) else {},
+        }
+    except Exception:
+        return None
+
+
 def _save_models_cache_to_disk(cache: dict) -> None:
     """Save cache to disk so it survives server restarts.
 
@@ -6349,8 +6379,11 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
     # Then acquire lock and check memory cache.  Cold path runs inside the lock
     # so only one thread rebuilds while others wait.
     disk_groups = None
+    stale_disk_groups = None
     if _available_models_cache is None:
         disk_groups = _load_models_cache_from_disk()
+        if disk_groups is None:
+            stale_disk_groups = _load_stale_models_cache_from_disk()
 
     with _available_models_cache_lock:
         # If another thread is already building, wait for its result instead
@@ -6371,6 +6404,7 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
             _available_models_cache_ts = 0.0
             _available_models_cache_source_fingerprint = None
             disk_groups = None
+            stale_disk_groups = None
 
         # Serve from memory cache if fresh
         now = time.monotonic()
@@ -6590,14 +6624,12 @@ def get_available_models(*, prefer_cache: bool = False) -> dict:
             logger.warning(_budget_log_msg, _LIVE_REBUILD_BUDGET_SECONDS)
         else:
             logger.info(_budget_log_msg, _LIVE_REBUILD_BUDGET_SECONDS)
-        # Note: ``disk_groups``, if non-None, was already consumed by the
-        # cold-path early-return at the "Cold path: disk cache hit" branch
-        # above (line ~4608). Any execution that reaches HERE necessarily
-        # took the live-rebuild branch, which means ``disk_groups is None``
-        # at this point — so we don't re-check it. Per Copilot review on
-        # PR #2971: the previous ``if disk_groups is not None`` branch
-        # here was dead code. Fall back directly to the static minimal
-        # catalog (no second disk read).
+        # ``stale_disk_groups`` is shape-valid but failed the strict metadata
+        # checks required for authoritative cold-path use. It was read before
+        # acquiring _available_models_cache_lock so this over-budget fallback
+        # does not extend the lock hold while the worker is ready to publish.
+        if stale_disk_groups is not None:
+            return copy.deepcopy(stale_disk_groups)
         return copy.deepcopy(_static_models_catalog_without_live_probes())
 
 

--- a/tests/test_issue1699_model_cache_source_fingerprint.py
+++ b/tests/test_issue1699_model_cache_source_fingerprint.py
@@ -141,7 +141,9 @@ def test_disk_models_cache_still_loads_when_auth_and_config_sources_are_unchange
 
     result = config.get_available_models()
 
-    assert result == fresh_opencode
+    # The disk-cache hit reconstructs `aliases` from current config (the save
+    # path doesn't persist aliases); no config aliases here, so it's {}.
+    assert result == {**fresh_opencode, "aliases": {}}
 
 
 def test_memory_models_cache_invalidates_when_static_catalog_changes(tmp_path, monkeypatch):

--- a/tests/test_issue3928_models_budget_fallback.py
+++ b/tests/test_issue3928_models_budget_fallback.py
@@ -50,6 +50,7 @@ def isolate_models_catalog_state(monkeypatch, tmp_path):
 
     return {
         "auth_store_path": auth_store_path,
+        "models_cache_path": tmp_path / "models_cache.json",
     }
 
 
@@ -103,6 +104,39 @@ def _configure_local_sources(
     )
     env_lookup = dict(env_vars or {})
     monkeypatch.setattr(cfg.os, "getenv", lambda key, default=None: env_lookup.get(key, default or ""))
+
+
+def _build_stale_disk_cache_payload() -> dict:
+    return {
+        "active_provider": "ollama-cloud",
+        "default_model": "ollama-cloud/chat-1",
+        "configured_model_badges": {
+            "ollama-cloud/chat-1": {
+                "role": "primary",
+                "provider": "ollama-cloud",
+                "label": "Primary",
+            }
+        },
+        "groups": [
+            {
+                "provider": "Ollama Cloud",
+                "provider_id": "ollama-cloud",
+                "models": [
+                    {"id": "ollama-cloud/chat-1", "label": "Chat 1"},
+                ],
+            }
+        ],
+        "aliases": {
+            "chat": "ollama-cloud/chat-1",
+        },
+        "_schema_version": 999,
+        "_webui_version": "v999",
+        "_source_fingerprint": {
+            "catalog": "stale",
+            "config_yaml": {"size": 42},
+            "auth_json": {"size": 7},
+        },
+    }
 
 
 def test_static_catalog_budget_fallback_lists_local_providers(
@@ -192,6 +226,153 @@ def test_budget_exceeded_foreground_uses_richer_static_catalog_and_refreshes_out
     assert rebuild_calls["count"] == 1
     assert cfg._available_models_cache == live_result
     assert cfg._cache_build_in_progress is False
+
+
+def test_budget_exceeded_uses_shape_only_stale_cache_before_static_fallback(
+    monkeypatch,
+    isolate_models_catalog_state,
+):
+    _configure_local_sources(
+        monkeypatch,
+        isolate_models_catalog_state["auth_store_path"],
+    )
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
+    models_cache_path = isolate_models_catalog_state["models_cache_path"]
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: models_cache_path)
+    models_cache_path.write_text(
+        json.dumps(_build_stale_disk_cache_payload()),
+        encoding="utf-8",
+    )
+
+    live_result = {
+        "active_provider": "openrouter",
+        "default_model": "openrouter/google/gemini-2.5-pro",
+        "configured_model_badges": {},
+        "groups": [
+            {
+                "provider": "OpenRouter",
+                "provider_id": "openrouter",
+                "models": [
+                    {
+                        "id": "openrouter/google/gemini-2.5-pro",
+                        "label": "Gemini 2.5 Pro",
+                    }
+                ],
+            }
+        ],
+        "aliases": {},
+    }
+    rebuild_calls = {"count": 0}
+
+    def _slow_rebuild(_builder):
+        rebuild_calls["count"] += 1
+        time.sleep(0.2)
+        return copy.deepcopy(live_result)
+
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _slow_rebuild)
+
+    expected_fallback = _build_stale_disk_cache_payload()
+    expected_fallback.pop("_schema_version")
+    expected_fallback.pop("_webui_version")
+    expected_fallback.pop("_source_fingerprint")
+    result = cfg.get_available_models()
+
+    assert any(
+        g["provider_id"] == "ollama-cloud" for g in result["groups"]
+    )
+    assert result == expected_fallback
+    assert "ollama-cloud" not in {
+        g["provider_id"] for g in cfg._static_models_catalog_without_live_probes()["groups"]
+    }
+    assert (
+        cfg._available_models_cache is None
+        or cfg._available_models_cache != expected_fallback
+    )
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if cfg._available_models_cache == live_result:
+            break
+        time.sleep(0.01)
+
+    assert rebuild_calls["count"] == 1
+    assert cfg._available_models_cache == live_result
+    assert cfg._cache_build_in_progress is False
+
+
+def test_budget_exceeded_fallback_uses_static_when_stale_disk_cache_invalid(
+    monkeypatch,
+    isolate_models_catalog_state,
+):
+    _configure_local_sources(
+        monkeypatch,
+        isolate_models_catalog_state["auth_store_path"],
+    )
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
+    models_cache_path = isolate_models_catalog_state["models_cache_path"]
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: models_cache_path)
+    models_cache_path.write_text(
+        json.dumps({"active_provider": "openai-api", "default_model": "gpt-5.5"}),
+        encoding="utf-8",
+    )
+    assert cfg._load_stale_models_cache_from_disk() is None
+
+    live_result = {
+        "active_provider": "openrouter",
+        "default_model": "openrouter/google/gemini-2.5-pro",
+        "configured_model_badges": {},
+        "groups": [
+            {
+                "provider": "OpenRouter",
+                "provider_id": "openrouter",
+                "models": [
+                    {
+                        "id": "openrouter/google/gemini-2.5-pro",
+                        "label": "Gemini 2.5 Pro",
+                    }
+                ],
+            }
+        ],
+        "aliases": {},
+    }
+    rebuild_calls = {"count": 0}
+
+    def _slow_rebuild(_builder):
+        rebuild_calls["count"] += 1
+        time.sleep(0.2)
+        return copy.deepcopy(live_result)
+
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _slow_rebuild)
+
+    expected_static = cfg._static_models_catalog_without_live_probes()
+    result = cfg.get_available_models()
+
+    assert result == expected_static
+    assert all(g["provider_id"] != "ollama-cloud" for g in result["groups"])
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if cfg._available_models_cache == live_result:
+            break
+        time.sleep(0.01)
+
+    assert rebuild_calls["count"] == 1
+    assert cfg._available_models_cache == live_result
+
+
+def test_load_stale_models_cache_from_disk_defaults_missing_aliases(
+    monkeypatch,
+    isolate_models_catalog_state,
+):
+    payload = _build_stale_disk_cache_payload()
+    payload.pop("aliases")
+    models_cache_path = isolate_models_catalog_state["models_cache_path"]
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: models_cache_path)
+    models_cache_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    stale = cfg._load_stale_models_cache_from_disk()
+    assert stale is not None
+    assert stale["aliases"] == {}
 
 
 def test_default_group_survives_only_as_emergency_last_resort(

--- a/tests/test_issue3928_models_budget_fallback.py
+++ b/tests/test_issue3928_models_budget_fallback.py
@@ -29,6 +29,13 @@ def isolate_models_catalog_state(monkeypatch, tmp_path):
     monkeypatch.setattr(cfg, "_get_auth_store_path", lambda: auth_store_path)
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
     monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda *_a, **_k: None)
+    # Point the stale-cache loader's path at an isolated (by default nonexistent)
+    # temp file so the over-budget stale fallback (#3928 follow-up) stays
+    # hermetic — otherwise it would read the real ~/.../models_cache.json and
+    # tests asserting the static fallback become order/environment-dependent
+    # flakes. Tests exercising the stale path override _get_models_cache_path
+    # to write their own payload.
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: tmp_path / "models_cache.json")
     monkeypatch.setattr(cfg, "_delete_models_cache_on_disk", lambda: None)
     monkeypatch.setattr(
         cfg,
@@ -129,7 +136,10 @@ def _build_stale_disk_cache_payload() -> dict:
         "aliases": {
             "chat": "ollama-cloud/chat-1",
         },
-        "_schema_version": 999,
+        # Current schema (so the stale-cache loader's schema guard accepts it),
+        # but a deliberately stale _webui_version + fingerprint so the STRICT
+        # loader rejects it — this is exactly the "recoverable stale cache" case.
+        "_schema_version": cfg._MODELS_CACHE_SCHEMA_VERSION,
         "_webui_version": "v999",
         "_source_fingerprint": {
             "catalog": "stale",
@@ -373,6 +383,22 @@ def test_load_stale_models_cache_from_disk_defaults_missing_aliases(
     stale = cfg._load_stale_models_cache_from_disk()
     assert stale is not None
     assert stale["aliases"] == {}
+
+
+def test_load_stale_models_cache_from_disk_rejects_cross_schema(
+    monkeypatch,
+    isolate_models_catalog_state,
+):
+    """A shape-valid but cross-schema cache must be rejected even on the stale
+    fallback path — its groups/badge shape may be incompatible with the current
+    picker and serving it could surface a broken catalog."""
+    payload = _build_stale_disk_cache_payload()
+    payload["_schema_version"] = cfg._MODELS_CACHE_SCHEMA_VERSION + 1
+    models_cache_path = isolate_models_catalog_state["models_cache_path"]
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: models_cache_path)
+    models_cache_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert cfg._load_stale_models_cache_from_disk() is None
 
 
 def test_default_group_survives_only_as_emergency_last_resort(

--- a/tests/test_issue3928_models_budget_fallback.py
+++ b/tests/test_issue3928_models_budget_fallback.py
@@ -401,6 +401,27 @@ def test_load_stale_models_cache_from_disk_rejects_cross_schema(
     assert cfg._load_stale_models_cache_from_disk() is None
 
 
+def test_load_stale_models_cache_reconstructs_aliases_from_config(
+    monkeypatch,
+    isolate_models_catalog_state,
+):
+    """When the disk cache lacks aliases (the save path never persisted them),
+    the stale loader must reconstruct them from current config so /model <alias>
+    slash-command resolution keeps working during the over-budget fallback."""
+    payload = _build_stale_disk_cache_payload()
+    payload.pop("aliases", None)
+    models_cache_path = isolate_models_catalog_state["models_cache_path"]
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: models_cache_path)
+    models_cache_path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(
+        cfg, "cfg", {"model": {"aliases": {"fast": "ollama-cloud/chat-1"}}}, raising=False
+    )
+
+    stale = cfg._load_stale_models_cache_from_disk()
+    assert stale is not None
+    assert stale["aliases"] == {"fast": "ollama-cloud/chat-1"}
+
+
 def test_default_group_survives_only_as_emergency_last_resort(
     monkeypatch,
     isolate_models_catalog_state,

--- a/tests/test_model_cache_metadata.py
+++ b/tests/test_model_cache_metadata.py
@@ -46,9 +46,12 @@ def test_save_models_cache_to_disk_preserves_response_metadata(tmp_path, monkeyp
     if "api.updates" in sys.modules:
         assert on_disk.get("_webui_version") == sys.modules["api.updates"].WEBUI_VERSION
 
-    # Load returns ONLY the response-shape fields (stamps stripped).
+    # Load returns the response-shape fields (stamps stripped) plus `aliases`,
+    # which the loader reconstructs from current config because the save path
+    # does not persist aliases on disk (keeps /model <alias> resolution working
+    # on a disk-cache hit). No config aliases here, so it reconstructs to {}.
     loaded = config._load_models_cache_from_disk()
-    assert loaded == payload
+    assert loaded == {**payload, "aliases": {}}
 
 
 def test_load_models_cache_from_disk_rejects_legacy_groups_only_cache(tmp_path, monkeypatch):


### PR DESCRIPTION
## Release v0.51.541 — Release SZ (model picker recovers a stale disk cache on catalog timeout)

Ships #4555 (starship-s) with maintainer hardening applied from the ship-gate. Cherry-picked with author attribution preserved.

### Fixed

- **The model picker now falls back to a stale disk cache instead of a thin "Default" group when the live catalog rebuild times out (#3928 follow-up).** The strict cache loader rejects `models_cache.json` when its metadata/fingerprint stamps are out of date, which previously forced the over-budget rebuild path all the way back to the minimal static catalog — losing the user's real provider/model groups whenever a rebuild ran long with only a stale cache on disk. A new shape-validated loader reads that stale payload (read before acquiring the cache lock, so it doesn't extend the lock hold) and serves it as the over-budget fallback. Strict cold-path cache hits and the static fallback for a truly empty cache are unchanged. Thanks @starship-s.

### Hardening applied at ship-gate (Codex + Opus)

- **Schema guard:** the stale loader rejects a cross-schema cache (`_schema_version` mismatch) so an incompatible groups/badge shape can't reach the picker.
- **`/api/models` aliases contract preserved:** the disk save path never persisted `aliases`, so BOTH disk loaders (strict cold-path AND the new stale fallback) were dropping them — silently breaking `/model <alias>` slash-command resolution on any disk-cache hit. A shared `_model_aliases_from_config()` helper now reconstructs aliases from current config in both loaders (preserving a present dict, reconstructing only when absent). This also fixes a pre-existing gap in the strict loader.
- **Test hermeticity:** the autouse fixture isolates the cache path so the static-fallback test can't read a real `models_cache.json` and become an order-dependent flake.

### Gate

- Full pytest suite: **9746 passed**, 0 failed
- Codex regression gate: **SAFE TO SHIP**
- Opus advisor: **SAFE — SHIP** (alias reconstruction symmetric in both loaders, no cross-profile leak, schema guard sound)

Closes #3928.
