### PR TITLE
fix(#4557): eliminate settings-mtime cache collision behind flaky gateway_sync test

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -7372,6 +7372,9 @@ _SETTINGS_BOOL_KEYS = {
 # Language codes are validated as short alphanumeric BCP-47-like tags (e.g. 'en', 'zh', 'fr')
 _SETTINGS_LANG_RE = __import__("re").compile(r"^[a-zA-Z]{2,10}(-[a-zA-Z0-9]{2,8})?$")
 
+_SETTINGS_WRITE_VERSION = 0
+_SETTINGS_WRITE_LOCK = __import__("threading").Lock()
+
 
 def save_settings(settings: dict) -> dict:
     """Save settings to disk. Returns the merged settings. Ignores unknown keys."""
@@ -7481,6 +7484,9 @@ def save_settings(settings: dict) -> dict:
         json.dumps(persisted, ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
+    global _SETTINGS_WRITE_VERSION
+    with _SETTINGS_WRITE_LOCK:
+        _SETTINGS_WRITE_VERSION += 1
     # Invalidate the in-memory password hash cache so the next call to
     # get_password_hash() picks up the new value from disk immediately.
     if _password_changed:

--- a/api/routes.py
+++ b/api/routes.py
@@ -1690,10 +1690,10 @@ def _session_list_cache_path_stamp(path: Path | None) -> tuple[int, int]:
         return (0, 0)
 
 
-def _session_list_cache_source_stamp(key: tuple) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int]]:
+def _session_list_cache_source_stamp(key: tuple) -> tuple:
     _cache_profile, _cache_all_profiles, cache_show_cli_sessions, *_rest = key
     if not cache_show_cli_sessions:
-        return ((0, 0), (0, 0), (0, 0), (0, 0), (0, 0))
+        return ((0, 0), (0, 0), (0, 0), (0, 0), (0, 0), None, 0)
     try:
         state_db_path = Path(_active_state_db_path())
     except Exception:
@@ -1714,6 +1714,11 @@ def _session_list_cache_source_stamp(key: tuple) -> tuple[tuple[int, int], tuple
         settings_file = SETTINGS_FILE
     except Exception:
         settings_file = None
+    try:
+        from api.config import _SETTINGS_WRITE_VERSION
+        swv = _SETTINGS_WRITE_VERSION
+    except Exception:
+        swv = 0
     return (
         _session_list_cache_path_stamp(state_db_path),
         _session_list_cache_path_stamp(state_db_wal_path),
@@ -1725,6 +1730,7 @@ def _session_list_cache_source_stamp(key: tuple) -> tuple[tuple[int, int], tuple
         # frame size), so without this a freshly-committed CLI/gateway session
         # could be served stale for the cache TTL. Mirrors the models-layer fix.
         _session_list_cache_state_db_fingerprint(state_db_path),
+        swv,
     )
 
 
@@ -11424,6 +11430,11 @@ def handle_post(handler, parsed) -> bool:
         ):
             try:
                 _clear_session_list_cache()
+            except Exception:
+                pass
+            try:
+                from api.models import clear_cli_sessions_cache
+                clear_cli_sessions_cache()
             except Exception:
                 pass
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1690,7 +1690,7 @@ def _session_list_cache_path_stamp(path: Path | None) -> tuple[int, int]:
         return (0, 0)
 
 
-def _session_list_cache_source_stamp(key: tuple) -> tuple:
+def _session_list_cache_source_stamp(key: tuple) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], object, int]:
     _cache_profile, _cache_all_profiles, cache_show_cli_sessions, *_rest = key
     if not cache_show_cli_sessions:
         return ((0, 0), (0, 0), (0, 0), (0, 0), (0, 0), None, 0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1086,6 +1086,11 @@ def cleanup_test_sessions():
         _post(TEST_BASE, "/api/settings", {"show_cli_sessions": False})
     except Exception:
         pass
+    try:
+        from api.models import clear_cli_sessions_cache
+        clear_cli_sessions_cache()
+    except Exception:
+        pass
     yield created
 
     for sid in created:
@@ -1109,6 +1114,11 @@ def cleanup_test_sessions():
     # across tests (33 gateway_sync tests flip it on; only ~30 reset it).
     try:
         _post(TEST_BASE, "/api/settings", {"show_cli_sessions": False})
+    except Exception:
+        pass
+    try:
+        from api.models import clear_cli_sessions_cache
+        clear_cli_sessions_cache()
     except Exception:
         pass
 


### PR DESCRIPTION
## What Changed

The `gateway_sync` test (`gw_legacy_import_weixin_001`) flaked because two cache layers could serve stale session lists after a `show_cli_sessions` settings toggle:

1. **Routes-layer `_session_list_cache`** used `SETTINGS_FILE` mtime as part of its source stamp. When a settings write landed in the same filesystem timestamp bucket as the previous write, the stamp was identical and the cache served stale data. Fixed by adding a monotonic `_SETTINGS_WRITE_VERSION` counter (`api/config.py`) that is appended to the stamp tuple, guaranteeing a cache miss after every settings save regardless of mtime granularity.

2. **Models-layer `_CLI_SESSIONS_CACHE`** (~5s TTL) was never invalidated on a visibility toggle. A snapshot taken before the test session was inserted could replay for the full TTL window. Fixed by calling `clear_cli_sessions_cache()` after visibility-related settings changes in `routes.py`, and in test setup/teardown in `conftest.py`.

### Files

- `api/config.py`: added `_SETTINGS_WRITE_VERSION` counter and `_SETTINGS_WRITE_LOCK`; counter increments under lock after each successful `SETTINGS_FILE` write.
- `api/routes.py`: reads counter into `swv` (lazy in-function import so it always sees the latest value) and appends it as the 7th stamp element; calls `clear_cli_sessions_cache()` on visibility toggles; updated return annotation and early-return tuple to match 7-element shape.
- `tests/conftest.py`: added `clear_cli_sessions_cache()` in setup and teardown of `cleanup_test_sessions` to prevent cache bleed across test shards.

## Verification

```
pytest tests/test_gateway_sync.py -v
```

Re-run the offending CI shard several times to confirm the previously-collidable window stays green.

## Closes #4557