### PR TITLE
feat(mobile): prioritize titlebar session title with tap-to-reveal and long-press actions

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -170,6 +170,10 @@ function syncAppTitlebar() {
       titleEl._titlePopover = null;
       const _dismissTitlePopover = () => {
         if (titleEl._titlePopover) { titleEl._titlePopover.remove(); titleEl._titlePopover = null; }
+        if (titleEl._popoverOutsideHandler) {
+          document.removeEventListener('click', titleEl._popoverOutsideHandler, true);
+          titleEl._popoverOutsideHandler = null;
+        }
       };
       titleEl.addEventListener('click', function _onTitleClick(e) {
         if (_renamingAppTitlebar) return;

--- a/static/panels.js
+++ b/static/panels.js
@@ -154,7 +154,13 @@ function syncAppTitlebar() {
 
   // Dismiss stale popover on session/panel switch
   const _existingPop = document.querySelector('.app-titlebar-title-popover');
-  if (_existingPop) { _existingPop.remove(); titleEl._titlePopover = null; }
+  if (_existingPop) {
+    _existingPop.remove(); titleEl._titlePopover = null;
+    if (titleEl._popoverOutsideHandler) {
+      document.removeEventListener('click', titleEl._popoverOutsideHandler, true);
+      titleEl._popoverOutsideHandler = null;
+    }
+  }
 
   // Mobile touch interactions
   if ('ontouchstart' in window) {
@@ -182,10 +188,11 @@ function syncAppTitlebar() {
         pop.style.left = Math.max(8, rect.left) + 'px';
         pop.style.maxWidth = (window.innerWidth - 16) + 'px';
         titleEl._titlePopover = pop;
-        const _outside = (ev) => {
+        const _outside = titleEl._popoverOutsideHandler = (ev) => {
           if (!pop.contains(ev.target) && ev.target !== titleEl) {
             _dismissTitlePopover();
             document.removeEventListener('click', _outside, true);
+            titleEl._popoverOutsideHandler = null;
           }
         };
         setTimeout(() => document.addEventListener('click', _outside, true), 0);

--- a/static/panels.js
+++ b/static/panels.js
@@ -57,7 +57,7 @@ function syncAppTitlebar() {
   if (panel === 'chat' && typeof S !== 'undefined' && S && S.session) {
     mainText = S.session.title || (typeof t === 'function' ? t('untitled') : 'Untitled');
     const vis = Array.isArray(S.messages) ? S.messages.filter(m => m && m.role && m.role !== 'tool') : [];
-    if (typeof t === 'function') subText = t('n_messages', vis.length);
+    subText = String(vis.length);
     sourceLabel = S.session.source_label || S.session.source_tag || S.session.raw_source || '';
     // Recovered sidecars stamp source_label 'WebUI' (api/session_recovery.py); don't badge a native session as its own source (#3338).
     if (/^webui$/i.test(sourceLabel)) sourceLabel = '';
@@ -150,6 +150,85 @@ function syncAppTitlebar() {
       inp.focus();
       inp.select();
     };
+  }
+
+  // Mobile touch interactions — wired once per element lifetime.
+  if ('ontouchstart' in window && !titleEl._mobileTouchWired) {
+    titleEl._mobileTouchWired = true;
+
+    // Tap-to-reveal full title popover
+    let _titlePopover = null;
+    const _dismissTitlePopover = () => {
+      if (_titlePopover) { _titlePopover.remove(); _titlePopover = null; }
+    };
+    titleEl.addEventListener('click', function _onTitleClick(e) {
+      if (_renamingAppTitlebar) return;
+      if (_titlePopover) {
+        _dismissTitlePopover();
+        if (typeof titleEl.ondblclick === 'function') titleEl.ondblclick(e);
+        return;
+      }
+      e.stopPropagation();
+      const pop = document.createElement('div');
+      pop.className = 'app-titlebar-title-popover';
+      pop.textContent = (S && S.session && S.session.title) ||
+        (typeof t === 'function' ? t('untitled') : 'Untitled');
+      document.body.appendChild(pop);
+      const rect = titleEl.getBoundingClientRect();
+      pop.style.top = (rect.bottom + 6) + 'px';
+      pop.style.left = Math.max(8, rect.left) + 'px';
+      pop.style.maxWidth = (window.innerWidth - 16) + 'px';
+      _titlePopover = pop;
+      const _outside = (ev) => {
+        if (!pop.contains(ev.target) && ev.target !== titleEl) {
+          _dismissTitlePopover();
+          document.removeEventListener('click', _outside, true);
+        }
+      };
+      setTimeout(() => document.addEventListener('click', _outside, true), 0);
+    }, { passive: true });
+
+    // Long-press → session action menu (mirrors project-chip pattern, sessions.js:5362-5407)
+    if (panel === 'chat' && S && S.session && !S.session.read_only && !S.session.is_read_only &&
+        typeof _openSessionActionMenu === 'function') {
+      let _lpTimer = null;
+      let _lpHandled = false;
+      let _lpStartX = 0, _lpStartY = 0;
+      const _lpDelay = typeof SESSION_LONG_PRESS_DELAY_MS !== 'undefined' ?
+        SESSION_LONG_PRESS_DELAY_MS : 400;
+      titleEl.addEventListener('touchstart', (e) => {
+        const touch = e.changedTouches && e.changedTouches[0];
+        if (!touch) return;
+        if (_lpTimer) { clearTimeout(_lpTimer); _lpTimer = null; }
+        _lpHandled = false; _lpStartX = touch.clientX; _lpStartY = touch.clientY;
+        titleEl.classList.add('long-pressing');
+        _lpTimer = setTimeout(() => {
+          _lpTimer = null;
+          if (_lpHandled) return;
+          _lpHandled = true;
+          titleEl.classList.remove('long-pressing');
+          _openSessionActionMenu(S.session, titleEl);
+        }, _lpDelay);
+      }, { passive: true });
+      titleEl.addEventListener('touchmove', (e) => {
+        if (!_lpTimer) return;
+        const touch = e.changedTouches && e.changedTouches[0];
+        if (!touch) return;
+        if (Math.abs(touch.clientX - _lpStartX) > 10 || Math.abs(touch.clientY - _lpStartY) > 10) {
+          clearTimeout(_lpTimer); _lpTimer = null;
+          titleEl.classList.remove('long-pressing');
+        }
+      }, { passive: true });
+      titleEl.addEventListener('touchend', (e) => {
+        clearTimeout(_lpTimer); _lpTimer = null;
+        titleEl.classList.remove('long-pressing');
+        if (_lpHandled) { e.preventDefault(); e.stopPropagation(); }
+      }, { passive: false });
+      titleEl.addEventListener('touchcancel', () => {
+        clearTimeout(_lpTimer); _lpTimer = null; _lpHandled = false;
+        titleEl.classList.remove('long-pressing');
+      }, { passive: true });
+    }
   }
 }
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -152,45 +152,51 @@ function syncAppTitlebar() {
     };
   }
 
-  // Mobile touch interactions — wired once per element lifetime.
-  if ('ontouchstart' in window && !titleEl._mobileTouchWired) {
-    titleEl._mobileTouchWired = true;
+  // Dismiss stale popover on session/panel switch
+  const _existingPop = document.querySelector('.app-titlebar-title-popover');
+  if (_existingPop) _existingPop.remove();
 
-    // Tap-to-reveal full title popover
-    let _titlePopover = null;
-    const _dismissTitlePopover = () => {
-      if (_titlePopover) { _titlePopover.remove(); _titlePopover = null; }
-    };
-    titleEl.addEventListener('click', function _onTitleClick(e) {
-      if (_renamingAppTitlebar) return;
-      if (_titlePopover) {
-        _dismissTitlePopover();
-        if (typeof titleEl.ondblclick === 'function') titleEl.ondblclick(e);
-        return;
-      }
-      e.stopPropagation();
-      const pop = document.createElement('div');
-      pop.className = 'app-titlebar-title-popover';
-      pop.textContent = (S && S.session && S.session.title) ||
-        (typeof t === 'function' ? t('untitled') : 'Untitled');
-      document.body.appendChild(pop);
-      const rect = titleEl.getBoundingClientRect();
-      pop.style.top = (rect.bottom + 6) + 'px';
-      pop.style.left = Math.max(8, rect.left) + 'px';
-      pop.style.maxWidth = (window.innerWidth - 16) + 'px';
-      _titlePopover = pop;
-      const _outside = (ev) => {
-        if (!pop.contains(ev.target) && ev.target !== titleEl) {
-          _dismissTitlePopover();
-          document.removeEventListener('click', _outside, true);
-        }
+  // Mobile touch interactions
+  if ('ontouchstart' in window) {
+    // Tap-to-reveal full title popover — wired once per element lifetime
+    if (!titleEl._mobileTouchWired) {
+      titleEl._mobileTouchWired = true;
+      let _titlePopover = null;
+      const _dismissTitlePopover = () => {
+        if (_titlePopover) { _titlePopover.remove(); _titlePopover = null; }
       };
-      setTimeout(() => document.addEventListener('click', _outside, true), 0);
-    }, { passive: true });
+      titleEl.addEventListener('click', function _onTitleClick(e) {
+        if (_renamingAppTitlebar) return;
+        if (_titlePopover) {
+          _dismissTitlePopover();
+          return;
+        }
+        e.stopPropagation();
+        const pop = document.createElement('div');
+        pop.className = 'app-titlebar-title-popover';
+        pop.textContent = (S && S.session && S.session.title) ||
+          (typeof t === 'function' ? t('untitled') : 'Untitled');
+        document.body.appendChild(pop);
+        const rect = titleEl.getBoundingClientRect();
+        pop.style.top = (rect.bottom + 6) + 'px';
+        pop.style.left = Math.max(8, rect.left) + 'px';
+        pop.style.maxWidth = (window.innerWidth - 16) + 'px';
+        _titlePopover = pop;
+        const _outside = (ev) => {
+          if (!pop.contains(ev.target) && ev.target !== titleEl) {
+            _dismissTitlePopover();
+            document.removeEventListener('click', _outside, true);
+          }
+        };
+        setTimeout(() => document.addEventListener('click', _outside, true), 0);
+      }, { passive: true });
+    }
 
-    // Long-press → session action menu (mirrors project-chip pattern, sessions.js:5362-5407)
-    if (panel === 'chat' && S && S.session && !S.session.read_only && !S.session.is_read_only &&
+    // Long-press → session action menu (re-evaluated each sync so late-arriving sessions attach)
+    if (!titleEl._mobileLpWired && panel === 'chat' && S && S.session &&
+        !S.session.read_only && !S.session.is_read_only &&
         typeof _openSessionActionMenu === 'function') {
+      titleEl._mobileLpWired = true;
       let _lpTimer = null;
       let _lpHandled = false;
       let _lpStartX = 0, _lpStartY = 0;

--- a/static/panels.js
+++ b/static/panels.js
@@ -154,20 +154,20 @@ function syncAppTitlebar() {
 
   // Dismiss stale popover on session/panel switch
   const _existingPop = document.querySelector('.app-titlebar-title-popover');
-  if (_existingPop) _existingPop.remove();
+  if (_existingPop) { _existingPop.remove(); titleEl._titlePopover = null; }
 
   // Mobile touch interactions
   if ('ontouchstart' in window) {
     // Tap-to-reveal full title popover — wired once per element lifetime
     if (!titleEl._mobileTouchWired) {
       titleEl._mobileTouchWired = true;
-      let _titlePopover = null;
+      titleEl._titlePopover = null;
       const _dismissTitlePopover = () => {
-        if (_titlePopover) { _titlePopover.remove(); _titlePopover = null; }
+        if (titleEl._titlePopover) { titleEl._titlePopover.remove(); titleEl._titlePopover = null; }
       };
       titleEl.addEventListener('click', function _onTitleClick(e) {
         if (_renamingAppTitlebar) return;
-        if (_titlePopover) {
+        if (titleEl._titlePopover) {
           _dismissTitlePopover();
           return;
         }
@@ -181,7 +181,7 @@ function syncAppTitlebar() {
         pop.style.top = (rect.bottom + 6) + 'px';
         pop.style.left = Math.max(8, rect.left) + 'px';
         pop.style.maxWidth = (window.innerWidth - 16) + 'px';
-        _titlePopover = pop;
+        titleEl._titlePopover = pop;
         const _outside = (ev) => {
           if (!pop.contains(ev.target) && ev.target !== titleEl) {
             _dismissTitlePopover();

--- a/static/style.css
+++ b/static/style.css
@@ -989,6 +989,7 @@
   .app-titlebar-title{font-size:12px;font-weight:600;color:var(--text);letter-spacing:-.01em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:60vw;}
   .app-titlebar-sub{font-size:10px;color:var(--muted);background:var(--hover-bg);padding:2px 7px;border-radius:4px;font-family:'SF Mono',ui-monospace,monospace;white-space:nowrap;flex-shrink:0;}
   .app-titlebar-sub[hidden]{display:none;}
+  .app-titlebar-title-popover{position:fixed;z-index:300;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:8px 12px;font-size:13px;color:var(--text);box-shadow:0 4px 16px rgba(0,0,0,.18);word-break:break-word;line-height:1.4;max-width:calc(100vw - 16px);pointer-events:auto;}
   .app-titlebar-hamburger,.app-titlebar-spacer{display:none;width:44px;height:44px;flex-shrink:0;}
   .app-titlebar-hamburger{-webkit-app-region:no-drag;align-items:center;justify-content:center;background:none;border:none;color:var(--muted);border-radius:8px;cursor:pointer;padding:0;-webkit-tap-highlight-color:transparent;transition:background-color .15s,color .15s;}
   .app-titlebar-hamburger:hover{background:var(--hover-bg);color:var(--text);}
@@ -2356,6 +2357,9 @@
     .app-titlebar-hamburger,.app-titlebar-spacer{display:flex;}
     .app-titlebar-new-chat{display:inline-flex;}
     .app-titlebar-inner{flex:1 1 auto;}
+    .app-titlebar-title{max-width:72vw;}
+    .app-titlebar-sub{font-size:9px;padding:1px 5px;}
+    .app-titlebar-title.long-pressing{opacity:.6;transition:opacity .1s;}
     .system-health-panel.insights-card{gap:10px;padding:12px;}
     .system-health-head{align-items:flex-start;}
     .system-health-metrics{grid-template-columns:1fr;gap:8px;}

--- a/tests/test_app_titlebar_restore.py
+++ b/tests/test_app_titlebar_restore.py
@@ -18,7 +18,7 @@ def test_app_titlebar_returns_to_centered_desktop_layout():
 
 
 def test_app_titlebar_subtitle_shows_message_count_again():
-    assert "subText = t('n_messages', vis.length);" in PANELS_JS
+    assert "subText = String(vis.length);" in PANELS_JS
 
 
 def test_queue_updates_do_not_hijack_app_titlebar_subtitle():

--- a/tests/test_mobile_titlebar_session_actions.py
+++ b/tests/test_mobile_titlebar_session_actions.py
@@ -1,0 +1,28 @@
+"""Static regressions for mobile titlebar session title priority (#4520)."""
+import re, pathlib, pytest
+
+ROOT = pathlib.Path(__file__).parent.parent
+HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def test_titlebar_title_element_exists():
+    assert 'id="appTitlebarTitle"' in HTML
+    assert 'id="appTitlebarSub"' in HTML
+
+
+def test_syncappTitlebar_compact_metadata():
+    assert 'subText = String(vis.length)' in PANELS_JS
+    assert "t('n_messages', vis.length)" not in PANELS_JS
+
+
+def test_long_press_handler_wired():
+    assert '_lpTimer' in PANELS_JS
+    assert 'SESSION_LONG_PRESS_DELAY_MS' in PANELS_JS
+    assert 'long-pressing' in PANELS_JS
+
+
+def test_session_action_menu_callable_from_titlebar():
+    assert '_openSessionActionMenu(S.session, titleEl)' in PANELS_JS

--- a/tests/test_mobile_titlebar_session_actions.py
+++ b/tests/test_mobile_titlebar_session_actions.py
@@ -1,11 +1,9 @@
 """Static regressions for mobile titlebar session title priority (#4520)."""
-import re, pathlib, pytest
+import pathlib
 
 ROOT = pathlib.Path(__file__).parent.parent
 HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
 PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
-STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
-SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 
 
 def test_titlebar_title_element_exists():


### PR DESCRIPTION
## Thinking Path

- The mobile titlebar squeezes the session title between a hamburger button and a metadata chip that is `flex-shrink:0`, so the title is always the loser when a source badge appears. The `max-width:60vw` cap on `.app-titlebar-title` (style.css:989) compounds this: once the badge and its surrounding space are accounted for, titles longer than ~8 characters are cut off with no recovery path.
- The maintainer's direction on #4520 was clear: title is primary, metadata is secondary, tap for full title, long-press for actions. The existing `ondblclick` rename in `syncAppTitlebar()` (panels.js:97-152) is the right model; it wires behavior directly on `titleEl` inside that function, so we follow the same pattern.
- For the popover I chose a lightweight fixed-position `div` (not a modal) because the maintainer explicitly said "not a modal dialog". Positioning it below the title rect gives a tooltip-like feel with zero layout disruption.
- For long-press I copied the project-chip pattern (sessions.js:5362-5407) verbatim: same `touchstart`/`touchmove`/`touchend`/`touchcancel` quartet, same 10px drift cancel, same `long-pressing` class, same timer-clear-before-reschedule. The only differences are the delay constant (`SESSION_LONG_PRESS_DELAY_MS`) and the action (`_openSessionActionMenu(S.session, titleEl)`).
- The `_mobileTouchWired` guard is necessary because `syncAppTitlebar()` is called on every panel switch and session load; without it, each call would add another listener pair to the same element.

## What Changed

- `static/panels.js`: In `syncAppTitlebar()`, replaced `t('n_messages', vis.length)` with `String(vis.length)` for compact metadata. Added tap-to-reveal popover logic (gated on `'ontouchstart' in window`, wired once via `_mobileTouchWired`). Added long-press wiring using the project-chip pattern to call `_openSessionActionMenu` (separate `_mobileLpWired` guard, deferred until a writable session is loaded so late-arriving sessions still attach). Stale popovers are dismissed at the top of each `syncAppTitlebar()` call.
- `static/style.css`: In `@media(max-width:640px)`, widened `.app-titlebar-title` to `max-width:72vw` and compacted `.app-titlebar-sub` padding/font. Added `.app-titlebar-title-popover` rule for the full-title overlay. Added `.app-titlebar-title.long-pressing` feedback rule.
- `tests/test_mobile_titlebar_session_actions.py`: New focused static regression file with four tests pinning the HTML structure, compact metadata format, long-press infrastructure presence, and `_openSessionActionMenu` integration.

## Why It Matters

On mobile, session titles are the most important piece of context in the titlebar, but they were routinely cropped with no escape hatch. This change makes the title primary, gives users a tap path to the full title and a long-press path to rename/archive/delete, matching the UX pattern already established in session rows and project chips, without changing any desktop behavior.

## Verification

```
pytest tests/test_mobile_titlebar_session_actions.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- `syncAppTitlebar()` is called from multiple sites; the `_mobileTouchWired` and `_mobileLpWired` guards must be reset if the `titleEl` element is ever replaced (e.g., during the inline rename flow where `titleEl.replaceWith(inp)` and then `inp.replaceWith(titleEl)` are called). The flags set on the original element persist on re-insertion, so this is safe, but worth noting.
- The popover is positioned with `position:fixed` coordinates taken at click time. Rotation or soft-keyboard appearance after the popover is open will leave it mispositioned. A follow-up could reposition on `visualViewport.resize`.
- Source label compaction (abbreviating `CLI`, `Cron`, `API` etc.) was considered but deferred to keep this PR focused on the issue's stated scope.

## Upstream

Closes #4520.

## Model Used

Claude Opus 4.6 via Claude Code CLI
