### PR TITLE
fix(#4553): prevent horizontal pan in mobile transcript

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1618,7 +1618,7 @@
   .workspace-toggle-btn:disabled{opacity:.38;cursor:not-allowed;}
   .chip.model{color:var(--accent-text);border-color:var(--accent-bg-strong);background:var(--accent-bg);}
   .messages-shell{flex:1;min-height:0;position:relative;display:flex;flex-direction:column;}
-  .messages{flex:1;overflow-y:auto;display:flex;flex-direction:column;min-height:0;position:relative;z-index:0;-webkit-overflow-scrolling:touch;touch-action:pan-y;overscroll-behavior-y:contain;overflow-anchor:none;}
+  .messages{flex:1;overflow-y:auto;overflow-x:hidden;display:flex;flex-direction:column;min-height:0;position:relative;z-index:0;-webkit-overflow-scrolling:touch;touch-action:pan-y;overscroll-behavior-y:contain;overflow-anchor:none;}
   /* Overlay scroll controls so they do not affect the transcript's native scroll geometry. */
   .scroll-to-bottom-btn{position:absolute;right:20px;bottom:16px;width:32px;height:32px;border-radius:50%;border:1px solid var(--border2);background:var(--code-bg);color:var(--muted);font-size:16px;cursor:pointer;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,.25);z-index:10;transition:color .12s,border-color .12s,background .12s,transform .12s;}
   .scroll-to-bottom-btn:hover{color:var(--text);border-color:var(--border);background:var(--hover-bg);}
@@ -2385,7 +2385,7 @@
     .topbar-chips .chip,.topbar-chips .ws-chip,.topbar-chips button{font-size:11px!important;padding:4px 8px!important;white-space:nowrap;}
     .settings-main{padding:18px 16px;}
     .hermes-action-grid{grid-template-columns:1fr;}
-    .messages-inner{padding:12px 10px 20px;}
+    .messages-inner{padding:12px 10px 20px;max-width:100%;overflow-x:hidden;word-break:break-word;min-width:0;}
     .msg-body{padding-left:0;max-width:100%;}
     .msg-role{font-size:12px;}
     .composer-wrap{padding:8px 10px 12px!important;}

--- a/tests/test_issue4553_mobile_transcript_overflow.py
+++ b/tests/test_issue4553_mobile_transcript_overflow.py
@@ -1,0 +1,51 @@
+import re
+from pathlib import Path
+
+
+def test_messages_rule_has_overflow_x_hidden():
+    """Verify .messages rule includes overflow-x:hidden property."""
+    css_file = Path(__file__).resolve().parent.parent / "static" / "style.css"
+    content = css_file.read_text()
+
+    # Find the .messages{ rule
+    messages_rule_match = re.search(r'\.messages\{[^}]*overflow-y:auto[^}]*\}', content)
+    assert messages_rule_match, ".messages rule not found"
+
+    messages_rule = messages_rule_match.group(0)
+    assert 'overflow-x:hidden' in messages_rule, (
+        ".messages rule does not contain overflow-x:hidden"
+    )
+
+
+def test_messages_inner_mobile_has_containment():
+    """Verify .messages-inner in mobile breakpoint includes containment properties."""
+    css_file = Path(__file__).resolve().parent.parent / "static" / "style.css"
+    content = css_file.read_text()
+
+    # Find the @media(max-width:640px) block and then .messages-inner within a reasonable window
+    media_match = re.search(r'@media\(max-width:640px\)\{', content)
+    assert media_match, "@media(max-width:640px) block not found"
+
+    # Extract content after the media query opening brace
+    media_start = media_match.start()
+    remaining_content = content[media_start:media_start + 5000]  # Look ahead 5000 chars
+
+    # Find .messages-inner rule within this section
+    messages_inner_match = re.search(r'\.messages-inner\{([^}]*)\}', remaining_content)
+    assert messages_inner_match, ".messages-inner rule not found in @media(max-width:640px) block"
+
+    messages_inner_rule = messages_inner_match.group(0)
+
+    # Verify all required properties are present
+    assert 'max-width:100%' in messages_inner_rule, (
+        ".messages-inner in mobile block missing max-width:100%"
+    )
+    assert 'overflow-x:hidden' in messages_inner_rule, (
+        ".messages-inner in mobile block missing overflow-x:hidden"
+    )
+    assert 'word-break:break-word' in messages_inner_rule, (
+        ".messages-inner in mobile block missing word-break:break-word"
+    )
+    assert 'min-width:0' in messages_inner_rule, (
+        ".messages-inner in mobile block missing min-width:0"
+    )


### PR DESCRIPTION
## Thinking Path

- Issue #4553 reports horizontal panning in the transcript on mobile; wide content causes `.messages` to overflow beyond the viewport.
- The `.messages` rule sets `touch-action:pan-y` to prefer vertical touch gestures, but without `overflow-x:hidden` the container still allows horizontal scroll when child content is wider than the viewport.
- The fix adds `overflow-x:hidden` to the `.messages` container and mobile `.messages-inner` containment rules to prevent wide children from expanding past viewport width.

## What Changed

- `static/style.css`: added `overflow-x:hidden` to the `.messages` base rule; added `.messages-inner{max-width:100%;overflow-x:hidden;word-break:break-word;min-width:0;}` inside the `@media (max-width: 640px)` block.

## Why It Matters

Mobile users could swipe the transcript sideways when reading responses containing wide code blocks or long unbroken URLs, losing their reading position and causing disorienting layout shifts. This fix locks the transcript to vertical-only scroll on touch devices without affecting desktop layout.

## Verification

```
pytest tests/test_issue4553_mobile_transcript_overflow.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- `overflow-x:hidden` on `.messages` means any intentionally horizontally-scrollable content inside the transcript must have its own scroll container; the inner code-block containers already use `overflow-x:auto` in their own rules, so nested horizontal scrollbars are preserved.
- `word-break:break-word` applies only at the mobile breakpoint; desktop layout is unchanged.

## Upstream

Closes #4553.

Claude Opus 4.6 via Claude Code CLI
