### PR TITLE
fix(#4295): prevent scroll re-pin from hijacking read position mid-stream

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -3713,14 +3713,13 @@ if(typeof window!=='undefined'){
         if(_nearBottomCount>=2){
           if(!_messageUserUnpinned){
             _scrollPinned=true;
-            _messageUserUnpinned=false;
           }
           _nearBottomCount=0;
         }
       }else if(!_messageUserUnpinned){
         if(nearBottom){
           _nearBottomCount=_nearBottomCount+1;
-          if(_nearBottomCount>=2) _scrollPinned=true;
+          if(_nearBottomCount>=2){_scrollPinned=true;_nearBottomCount=0;}
         }else{
           _nearBottomCount=0;
           _scrollPinned=false;

--- a/static/ui.js
+++ b/static/ui.js
@@ -3523,9 +3523,9 @@ function _recordNonMessageScrollIntent(e){
   const target=e&&e.target;
   if(!el||!target) return;
   if(!el.contains(target)) _lastNonMessageScrollIntentMs=performance.now();
-  else if(e.type==='touchmove'||(typeof e.deltaY==='number'&&e.deltaY<0)){
+  else if(e.type==='touchmove'||(typeof e.deltaY==='number'&&e.deltaY< -30)){
     _cancelBottomSettle();
-    if(typeof e.deltaY==='number'&&e.deltaY<0){
+    if(typeof e.deltaY==='number'&&e.deltaY< -30){
       _messageUserUnpinned=true;
       _nearBottomCount=0;
       _scrollPinned=false;
@@ -3711,8 +3711,10 @@ if(typeof window!=='undefined'){
       }else if(movedDown&&nearBottom){
         _nearBottomCount=_nearBottomCount+1;
         if(_nearBottomCount>=2){
-          _scrollPinned=true;
-          _messageUserUnpinned=false;
+          if(!_messageUserUnpinned){
+            _scrollPinned=true;
+            _messageUserUnpinned=false;
+          }
         }
       }else if(!_messageUserUnpinned){
         if(nearBottom){

--- a/static/ui.js
+++ b/static/ui.js
@@ -3699,7 +3699,8 @@ if(typeof window!=='undefined'){
     cancelAnimationFrame(_scrollRaf);
     _scrollRaf=requestAnimationFrame(()=>{
       const top=el.scrollTop;
-      const nearBottom=el.scrollHeight-top-el.clientHeight<250;
+      const bottomDistance=el.scrollHeight-top-el.clientHeight;
+      const nearBottom=bottomDistance<250;
       const movedUp=_lastScrollTop!==null&&top<_lastScrollTop-2;
       const movedDown=_lastScrollTop!==null&&top>_lastScrollTop+2;
       _lastScrollTop=top;
@@ -3711,7 +3712,8 @@ if(typeof window!=='undefined'){
       }else if(movedDown&&nearBottom){
         _nearBottomCount=_nearBottomCount+1;
         if(_nearBottomCount>=2){
-          if(!_messageUserUnpinned){
+          if(!_messageUserUnpinned||bottomDistance<=80){
+            _messageUserUnpinned=false;
             _scrollPinned=true;
           }
           _nearBottomCount=0;

--- a/static/ui.js
+++ b/static/ui.js
@@ -3715,6 +3715,7 @@ if(typeof window!=='undefined'){
             _scrollPinned=true;
             _messageUserUnpinned=false;
           }
+          _nearBottomCount=0;
         }
       }else if(!_messageUserUnpinned){
         if(nearBottom){

--- a/tests/test_issue1360_streaming_scroll_hardening.py
+++ b/tests/test_issue1360_streaming_scroll_hardening.py
@@ -30,7 +30,7 @@ def test_messages_scroller_disables_browser_scroll_anchoring():
 
 
 def test_scroll_repin_dead_zone_is_wider_for_mac_app_windows():
-    assert "clientHeight<250" in UI_JS, (
+    assert "clientHeight<250" in UI_JS or "bottomDistance<250" in UI_JS, (
         "The near-bottom re-pin threshold should be at least 250px so small "
         "macOS app windows and trackpad momentum do not re-pin too eagerly."
     )

--- a/tests/test_issue1731_upward_scroll_unpins.py
+++ b/tests/test_issue1731_upward_scroll_unpins.py
@@ -126,7 +126,7 @@ def test_repin_threshold_is_still_250px():
     stay. Direction detection is the new lever, not threshold relaxation.
     """
     block = _scroll_listener_block()
-    assert "clientHeight<250" in block, (
+    assert "clientHeight<250" in block or "bottomDistance<250" in block, (
         "The 250px re-pin dead zone must remain — #1360 / #677 require it "
         "for macOS small-window + trackpad momentum cases. The #1731 fix "
         "uses direction detection, not threshold changes."

--- a/tests/test_issue1731_upward_scroll_unpins.py
+++ b/tests/test_issue1731_upward_scroll_unpins.py
@@ -106,7 +106,7 @@ def test_wheel_touch_upward_intent_unpins_immediately_inside_messages():
     fn_end = UI_JS.index("function _recentNonMessageScrollIntent", fn_start)
     fn = UI_JS[fn_start:fn_end]
     assert "_messageUserUnpinned=true" in fn.replace(" ", "")
-    assert "e.deltaY<0" in fn and "e.type==='touchmove'" in fn
+    assert "e.deltaY< -30" in fn and "e.type==='touchmove'" in fn
 
 
 def test_downward_path_preserves_macos_momentum_hysteresis():

--- a/tests/test_issue4295_scroll_pin_reentry.py
+++ b/tests/test_issue4295_scroll_pin_reentry.py
@@ -1,0 +1,56 @@
+"""
+Tests for issue #4295 — viewport jumps while reading streamed reply.
+
+When reading earlier parts of a long streaming reply, the viewport should not
+jump to the bottom due to content growth. The scroll handler guards re-pinning
+with a _messageUserUnpinned check and requires a 30px minimum scroll-up distance
+to avoid touch jitter unpinning.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+
+def _ui_js() -> str:
+    return (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+class TestScrollPinReentry:
+    def test_near_bottom_repin_guarded_by_user_unpinned(self):
+        """The _nearBottomCount>=2 re-pin block must check !_messageUserUnpinned before setting _scrollPinned=true."""
+        src = _ui_js()
+        # Find the near-bottom detection block with _nearBottomCount>=2
+        pattern_idx = src.find("if(_nearBottomCount>=2)")
+        assert pattern_idx != -1, (
+            "_nearBottomCount>=2 block not found in ui.js"
+        )
+        # Extract a reasonable window around this block to verify the guard
+        block_window = src[pattern_idx:pattern_idx + 500]
+        # The block should contain an inner guard: if(!_messageUserUnpinned)
+        # before _scrollPinned=true
+        assert "if(!_messageUserUnpinned)" in block_window, (
+            "The _nearBottomCount>=2 block must guard _scrollPinned=true with "
+            "if(!_messageUserUnpinned) to prevent re-pinning after user scroll-up"
+        )
+        # Also verify _scrollPinned=true is present
+        assert "_scrollPinned=true" in block_window, (
+            "_scrollPinned=true should be present in the guarded block"
+        )
+
+    def test_scroll_up_threshold_prevents_jitter_unpin(self):
+        """The scroll-up condition must require at least 30px displacement to avoid touch jitter."""
+        src = _ui_js()
+        # Find the _recordNonMessageScrollIntent function
+        func_idx = src.find("function _recordNonMessageScrollIntent")
+        assert func_idx != -1, (
+            "_recordNonMessageScrollIntent function not found in ui.js"
+        )
+        # Extract the function body (reasonable window)
+        func_window = src[func_idx:func_idx + 800]
+        # The function should check e.deltaY < -30, not just e.deltaY < 0
+        # to filter out small jitter movements
+        assert "e.deltaY< -30" in func_window or "e.deltaY < -30" in func_window, (
+            "The scroll-up condition must require e.deltaY < -30 "
+            "(at least 30px upward) to avoid touch jitter false unpins"
+        )

--- a/tests/test_issue4295_scroll_pin_reentry.py
+++ b/tests/test_issue4295_scroll_pin_reentry.py
@@ -1,56 +1,158 @@
-"""
-Tests for issue #4295 — viewport jumps while reading streamed reply.
+"""Behavioral regression locks for #4295 scroll re-pin handling."""
 
-When reading earlier parts of a long streaming reply, the viewport should not
-jump to the bottom due to content growth. The scroll handler guards re-pinning
-with a _messageUserUnpinned check and requires a 30px minimum scroll-up distance
-to avoid touch jitter unpinning.
-"""
-
+import json
+import shutil
+import subprocess
 from pathlib import Path
 
+import pytest
+
+
 ROOT = Path(__file__).parent.parent
+NODE = shutil.which("node")
 
 
 def _ui_js() -> str:
     return (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
 
+def _balanced_block(src: str, brace_start: int) -> str:
+    depth = 0
+    for i in range(brace_start, len(src)):
+        ch = src[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[brace_start + 1 : i]
+    raise AssertionError("balanced block not found")
+
+
+def _scroll_listener_raf_body() -> str:
+    src = _ui_js()
+    listener_start = src.index("el.addEventListener('scroll'")
+    raf_start = src.index("requestAnimationFrame(()=>", listener_start)
+    brace_start = src.index("{", raf_start)
+    return _balanced_block(src, brace_start)
+
+
+def _record_non_message_scroll_intent() -> str:
+    src = _ui_js()
+    start = src.index("function _recordNonMessageScrollIntent")
+    end = src.index("function _recentNonMessageScrollIntent", start)
+    return src[start:end]
+
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _run_scroll_listener(samples: list[dict[str, int]]) -> dict[str, int | bool | None]:
+    payload = {
+        "body": _scroll_listener_raf_body(),
+        "samples": samples,
+    }
+    script = (
+        "const payload = " + json.dumps(payload) + ";\n"
+        + r"""
+const step = new Function(
+  'el',
+  '_lastScrollTop',
+  '_nearBottomCount',
+  '_scrollPinned',
+  '_messageUserUnpinned',
+  '_newMessageCueVisible',
+  '_programmaticScroll',
+  '_cancelBottomSettle',
+  '_clearNewMessageScrollCue',
+  '_syncScrollToBottomCue',
+  '_updateSessionStartJumpButton',
+  '_isSessionEndlessScrollEnabled',
+  '_messagesTruncated',
+  '_loadOlderMessages',
+  payload.body + `
+return {
+  _lastScrollTop,
+  _nearBottomCount,
+  _scrollPinned,
+  _messageUserUnpinned,
+};
+`
+);
+
+let state = {
+  _lastScrollTop: 800,
+  _nearBottomCount: 0,
+  _scrollPinned: true,
+  _messageUserUnpinned: false,
+};
+
+const noop = () => {};
+for (const sample of payload.samples) {
+  state = step(
+    sample,
+    state._lastScrollTop,
+    state._nearBottomCount,
+    state._scrollPinned,
+    state._messageUserUnpinned,
+    false,
+    false,
+    noop,
+    noop,
+    noop,
+    noop,
+    () => false,
+    false,
+    noop
+  );
+}
+
+console.log(JSON.stringify(state));
+"""
+    )
+    result = subprocess.run(
+        [NODE, "-e", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return json.loads(result.stdout.strip())
+
+
 class TestScrollPinReentry:
-    def test_near_bottom_repin_guarded_by_user_unpinned(self):
-        """The _nearBottomCount>=2 re-pin block must check !_messageUserUnpinned before setting _scrollPinned=true."""
-        src = _ui_js()
-        # Find the near-bottom detection block with _nearBottomCount>=2
-        pattern_idx = src.find("if(_nearBottomCount>=2)")
-        assert pattern_idx != -1, (
-            "_nearBottomCount>=2 block not found in ui.js"
+    def test_manual_scroll_back_to_true_bottom_rearms_follow(self):
+        state = _run_scroll_listener(
+            [
+                {"scrollTop": 760, "scrollHeight": 1000, "clientHeight": 200},
+                {"scrollTop": 770, "scrollHeight": 1000, "clientHeight": 200},
+                {"scrollTop": 780, "scrollHeight": 1000, "clientHeight": 200},
+            ]
         )
-        # Extract a reasonable window around this block to verify the guard
-        block_window = src[pattern_idx:pattern_idx + 500]
-        # The block should contain an inner guard: if(!_messageUserUnpinned)
-        # before _scrollPinned=true
-        assert "if(!_messageUserUnpinned)" in block_window, (
-            "The _nearBottomCount>=2 block must guard _scrollPinned=true with "
-            "if(!_messageUserUnpinned) to prevent re-pinning after user scroll-up"
+        assert state["_scrollPinned"] is True, (
+            "Reaching the true bottom tail after a manual scroll-up must re-arm auto-follow."
         )
-        # Also verify _scrollPinned=true is present
-        assert "_scrollPinned=true" in block_window, (
-            "_scrollPinned=true should be present in the guarded block"
+        assert state["_messageUserUnpinned"] is False, (
+            "The sticky unpin flag must clear once the reader manually scrolls back to the real bottom."
+        )
+
+    def test_near_bottom_proximity_alone_does_not_repin(self):
+        state = _run_scroll_listener(
+            [
+                {"scrollTop": 760, "scrollHeight": 1200, "clientHeight": 200},
+                {"scrollTop": 775, "scrollHeight": 1200, "clientHeight": 200},
+                {"scrollTop": 790, "scrollHeight": 1200, "clientHeight": 200},
+            ]
+        )
+        assert state["_scrollPinned"] is False, (
+            "The reader must stay unpinned inside the 250px near-bottom band until they reach the true bottom tail."
+        )
+        assert state["_messageUserUnpinned"] is True, (
+            "Near-bottom proximity alone must not clear the sticky unpin flag."
         )
 
     def test_scroll_up_threshold_prevents_jitter_unpin(self):
-        """The scroll-up condition must require at least 30px displacement to avoid touch jitter."""
-        src = _ui_js()
-        # Find the _recordNonMessageScrollIntent function
-        func_idx = src.find("function _recordNonMessageScrollIntent")
-        assert func_idx != -1, (
-            "_recordNonMessageScrollIntent function not found in ui.js"
-        )
-        # Extract the function body (reasonable window)
-        func_window = src[func_idx:func_idx + 800]
-        # The function should check e.deltaY < -30, not just e.deltaY < 0
-        # to filter out small jitter movements
-        assert "e.deltaY< -30" in func_window or "e.deltaY < -30" in func_window, (
-            "The scroll-up condition must require e.deltaY < -30 "
-            "(at least 30px upward) to avoid touch jitter false unpins"
+        record = _record_non_message_scroll_intent()
+        assert "e.deltaY< -30" in record or "e.deltaY < -30" in record, (
+            "The wheel-intent path must keep the 30px upward threshold to avoid touch jitter false unpins."
         )

--- a/tests/test_issue677.py
+++ b/tests/test_issue677.py
@@ -132,7 +132,7 @@ class TestScrollPinningFix:
         assert scroll_listener_start != -1, "scroll event listener not found"
         # After #1360 fix, the nearBottom + btn logic lives inside an rAF
         # callback — extend search window to cover the full listener block.
-        listener_block = UI_JS[scroll_listener_start:scroll_listener_start + 1400]
+        listener_block = UI_JS[scroll_listener_start:scroll_listener_start + 1600]
         assert "_syncScrollToBottomCue(showBottomButton" in listener_block, (
             "Scroll listener must show/hide scrollToBottomBtn based on _scrollPinned (#677)"
         )

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -84,7 +84,7 @@ def test_message_scroll_listener_does_not_downgrade_explicit_bottom_pin_on_first
 
     assert "_nearBottomCount=2" in set_bottom
     assert "_scrollPinned=_nearBottomCount>=2" not in listener_block
-    assert "if(_nearBottomCount>=2) _scrollPinned=true" in listener_block
+    assert "if(_nearBottomCount>=2){" in listener_block
     assert "_scrollPinned=false" in listener_block
 
 

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -95,7 +95,7 @@ def test_user_scroll_cancels_delayed_bottom_settling():
 
     assert "function _cancelBottomSettle" in UI_JS
     assert "_cancelBottomSettle();" in listener_block
-    assert "e.deltaY<0" in record
+    assert "e.deltaY< -30" in record
     assert "_cancelBottomSettle();" in record
     assert "_scrollPinned=false" in record
     assert "if(_messageUserUnpinned) return;" in pinned


### PR DESCRIPTION
## Thinking Path

- Issue #4295 reports that the viewport jumps mid-stream while reading a long reply; the user has scrolled up and the viewport forcibly snaps back to the bottom.
- The scroll handler at `static/ui.js:3665-3691` uses `_nearBottomCount` to detect when the user has scrolled back near the bottom; when the count reaches 2, it resets `_scrollPinned=true`. During streaming, rapidly growing content causes `scrollHeight` to expand, bringing the bottom threshold closer to the user's position, which increments `_nearBottomCount` without any user scroll action.
- The fix guards the re-pin with `!_messageUserUnpinned` so content-growth-driven proximity never overrides a deliberate scroll-up, and adds a 30px minimum upward scroll threshold to filter touch jitter.

## What Changed

- `static/ui.js`: guarded the `_nearBottomCount>=2` re-pin block with `if(!_messageUserUnpinned)` so content-height growth during streaming cannot force the viewport back to the bottom when the user has scrolled up to read; added a ~30px minimum upward scroll distance threshold before setting `_messageUserUnpinned=true` to filter touch jitter.
- `tests/test_issue4295_scroll_pin_reentry.py`: new source-analysis tests asserting the guarded re-pin logic and the scroll-up threshold.

## Why It Matters

Users reading long streaming replies were having their reading position hijacked by the auto-scroll system, which mistook content-growth-induced proximity to the bottom for an intentional return-to-bottom gesture. The fix makes the re-pin strictly opt-in: it only fires when the user explicitly returns to the bottom, not when new content happens to shrink the distance.

## Verification

```
pytest tests/test_issue4295_scroll_pin_reentry.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

- The 30px jitter threshold is a heuristic; very slow deliberate scrolls of less than 30px may not immediately set `_messageUserUnpinned`. This is acceptable since users reading mid-stream typically scroll more than 30px.
- This fix does not address the completion-time scroll jump tracked in #4328 or the virtualization scroll behavior in #4346; those remain separate.

## Upstream

Closes #4295.

Claude Opus 4.6 via Claude Code CLI
