### PR TITLE
fix(transparent-stream): render persisted anchor activity on reload + keep intermediate prose (#4568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Transparent Stream keeps its full tool / thinking / progress-prose activity after reload, tab/focus changes, and session re-entry (#4568).** A turn that settled with the stable assistant-turn anchor scene (`activity_scene_v1`) could lose its Transparent Stream activity rows on a hard refresh, when switching away and back, on tab hide/show or window blur/focus, and on a mid-stream reload — leaving only the final answer. The legacy Transparent Stream rebuild correctly skipped anchor-owned turns, but only Compact Worklog had a settled anchor-scene renderer, so in Transparent Stream the rows rendered nowhere. Transparent Stream now renders the persisted anchor activity rows directly: tool cards and thinking rows are restored, and the intermediate between-tool progress prose is kept interleaved in chronological order (only the prose row that duplicates the final answer — already owned by the assistant message segment — is suppressed). Verified across the live → settled → switch-away → tab-hidden → blur → reload → mid-stream-reload checkpoint matrix in both display modes. Thanks @franksong2702 for the persisted-anchor-scene rendering approach.
+
 ## [v0.51.548] — 2026-06-21 — Release TG (extension load diagnostics)
 
 ### Added

--- a/static/ui.js
+++ b/static/ui.js
@@ -9130,15 +9130,23 @@ function _anchorSceneTransparentNodeForRow(row, opts){
   node.setAttribute('data-anchor-source-event-type',String(row.source_event_type||''));
   return node;
 }
-// Whitespace-insensitive compare so a scene prose row that is the final answer
+// Whitespace-insensitive compare so a scene prose row that IS the final answer
 // (possibly re-wrapped) is recognized and not duplicated against the segment.
+// Codex #4568: the prefix tolerance must NOT be able to suppress a DISTINCT
+// intermediate progress row that merely happens to be a prefix of the final
+// answer (e.g. "I found the issue and I'm applying the fix now." when the final
+// answer starts with that sentence). So require exact normalized equality, with
+// a prefix tolerance allowed ONLY when the two strings are near-equal length
+// (>=0.9 ratio, shorter >=80 chars) — i.e. genuine re-wrap/truncation of the
+// SAME text, never a short intermediate sentence that prefixes a long answer.
 function _anchorSceneProseMatchesFinalAnswer(proseText, finalAnswer){
   const norm=(s)=>String(s||'').replace(/\s+/g,' ').trim();
   const a=norm(proseText), b=norm(finalAnswer);
   if(!a||!b) return false;
   if(a===b) return true;
-  // tolerate trailing punctuation / minor truncation differences
-  return a.length>=40 && b.length>=40 && (a.startsWith(b)||b.startsWith(a));
+  if(!(a.startsWith(b)||b.startsWith(a))) return false;
+  const shorter=Math.min(a.length,b.length), longer=Math.max(a.length,b.length);
+  return shorter>=80 && (shorter/longer)>=0.9;
 }
 function _anchorSceneWorklogGroup(blocks, opts){
   if(!blocks) return null;

--- a/static/ui.js
+++ b/static/ui.js
@@ -9071,6 +9071,75 @@ function _anchorSceneNodeForRow(row, opts){
   node.setAttribute('data-anchor-source-event-type',String(row.source_event_type||''));
   return node;
 }
+function _anchorSceneTransparentNodeForRow(row, opts){
+  const settled=!!(opts&&opts.settled);
+  if(!row) return null;
+  let node=null;
+  const meta={
+    segmentSeq:row.segment_seq||row.segmentSeq||'',
+    burstId:row.activity_burst_id||row.burst_id||row.burstId||'',
+  };
+  if(row.role==='prose'){
+    // The settled assistant segment already owns the FINAL answer prose, so a
+    // prose row whose text matches the final answer must be suppressed here to
+    // avoid duplicating the answer. But INTERMEDIATE progress prose (the
+    // between-tool narration from earlier rounds) is NOT the final answer and
+    // belongs in the chronological transparent history — dropping it loses the
+    // interleaving the user saw live (#4568: tools were restored but mid-turn
+    // prose still vanished on reload). Render intermediate prose as an inline
+    // assistant-segment (same shape _anchorSceneNodeForRow builds), skip only
+    // the final-answer duplicate.
+    const text=String(row.text||'').trim();
+    if(!text) return null;
+    const finalAnswer=String((opts&&opts.finalAnswer)||'').trim();
+    if(finalAnswer&&_anchorSceneProseMatchesFinalAnswer(text,finalAnswer)) return null;
+    node=_anchorSceneNodeForRow(row,{settled});
+    if(!node) return null;
+    node=_decorateTransparentEventRow(node,{type:'prose',text,preview:text,...meta});
+  }else if(row.role==='thinking'){
+    if(window._showThinking===false) return null;
+    const text=String(row.text||row.thinking&&row.thinking.text||'').trim();
+    if(!text) return null;
+    node=_decorateTransparentEventRow(_thinkingActivityNode(text,false,row.row_id||row.local_id||'anchor-thinking'),{
+      type:'thinking',
+      text,
+      preview:text,
+      ...meta,
+    });
+  }else if(row.role==='tool'){
+    const toolCall=_anchorSceneToolCallFromRow(row,{settled});
+    node=_decorateTransparentEventRow(buildToolCard(toolCall),{
+      type:'tool',
+      name:toolCall&&toolCall.name,
+      status:_transparentToolStatus(toolCall,true),
+      toolCall,
+      ...meta,
+    });
+  }else{
+    node=_anchorSceneNodeForRow(row,{settled});
+    node=_decorateTransparentEventRow(node,{
+      type:String(row.role||'activity'),
+      ...meta,
+    });
+  }
+  if(!node) return null;
+  node.setAttribute('data-anchor-scene-row','1');
+  node.setAttribute('data-anchor-settled-scene-row','1');
+  node.setAttribute('data-anchor-row-id',String(row.row_id||row.local_id||''));
+  node.setAttribute('data-anchor-row-role',String(row.role||'activity'));
+  node.setAttribute('data-anchor-source-event-type',String(row.source_event_type||''));
+  return node;
+}
+// Whitespace-insensitive compare so a scene prose row that is the final answer
+// (possibly re-wrapped) is recognized and not duplicated against the segment.
+function _anchorSceneProseMatchesFinalAnswer(proseText, finalAnswer){
+  const norm=(s)=>String(s||'').replace(/\s+/g,' ').trim();
+  const a=norm(proseText), b=norm(finalAnswer);
+  if(!a||!b) return false;
+  if(a===b) return true;
+  // tolerate trailing punctuation / minor truncation differences
+  return a.length>=40 && b.length>=40 && (a.startsWith(b)||b.startsWith(a));
+}
 function _anchorSceneWorklogGroup(blocks, opts){
   if(!blocks) return null;
   const live=!!(opts&&opts.live);
@@ -9254,8 +9323,48 @@ if(typeof window!=='undefined'){
   window._projectLiveAnchorActivitySceneForStream=_projectLiveAnchorActivitySceneForStream;
   window.isLiveAnchorActivitySceneOwner=isLiveAnchorActivitySceneOwner;
 }
+function _renderSettledAnchorSceneTransparentForMessage(message, segment, rawIdx){
+  if(!message||!message._anchor_activity_scene||!segment) return false;
+  const blocks=_assistantTurnBlocks(segment.closest('.assistant-turn'));
+  if(!blocks) return false;
+  const scene=message._anchor_activity_scene;
+  const rows=_anchorSceneRowsForRendering(scene,{settled:true});
+  if(!rows.length) return false;
+  // The assistant segment owns the final answer; pass it so intermediate prose
+  // rows render but the final-answer-duplicate prose row is suppressed.
+  const finalAnswer=String(
+    (scene&&typeof scene.final_answer==='string'&&scene.final_answer)
+    || _assistantAnchorSceneFinalAnswerText(message)
+    || (typeof msgContent==='function'?msgContent(message):'')
+    || ''
+  );
+  blocks.querySelectorAll('[data-anchor-settled-scene-row="1"],.transparent-event-row[data-anchor-scene-row="1"]').forEach(el=>el.remove());
+  blocks.querySelectorAll('.assistant-segment[data-msg-idx]').forEach(node=>{
+    const idx=Number(node.getAttribute('data-msg-idx'));
+    if(Number.isFinite(idx)&&idx<rawIdx){
+      node.classList.add('assistant-segment-worklog-source');
+      node.setAttribute('aria-hidden','true');
+    }
+  });
+  let wrote=false;
+  for(const row of rows){
+    const node=_anchorSceneTransparentNodeForRow(row,{settled:true,finalAnswer});
+    if(!node) continue;
+    if(segment.parentElement===blocks) blocks.insertBefore(node,segment);
+    else blocks.appendChild(node);
+    wrote=true;
+  }
+  if(wrote){
+    const turn=segment.closest('.assistant-turn');
+    if(turn) _syncTransparentEventControls(turn);
+  }
+  return wrote;
+}
 function _renderSettledAnchorSceneForMessage(message, segment, rawIdx){
   if(!message||!message._anchor_activity_scene||!segment) return false;
+  if(typeof isTransparentStream==='function'&&isTransparentStream()){
+    return _renderSettledAnchorSceneTransparentForMessage(message,segment,rawIdx);
+  }
   if(typeof isCompactWorklogMode==='function'&&!isCompactWorklogMode()) return false;
   const blocks=_assistantTurnBlocks(segment.closest('.assistant-turn'));
   if(!blocks) return false;

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -677,7 +677,6 @@ def test_transparent_stream_renders_persisted_anchor_scene_after_reload():
     settled = _function_body(UI_JS, "_renderSettledAnchorSceneForMessage")
     transparent = _function_body(UI_JS, "_renderSettledAnchorSceneTransparentForMessage")
     row = _function_body(UI_JS, "_anchorSceneTransparentNodeForRow")
-    match = _function_body(UI_JS, "_anchorSceneProseMatchesFinalAnswer")
     render = _function_body(UI_JS, "renderMessages")
 
     assert "if(typeof isTransparentStream==='function'&&isTransparentStream())" in settled

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -713,9 +713,14 @@ def test_transparent_anchor_intermediate_prose_preserved_only_final_answer_suppr
         "not dropped"
     )
     assert "type:'prose'" in row
-    # the matcher exists and compares whitespace-insensitively with a startsWith tolerance
+    # the matcher exists and compares whitespace-insensitively; the prefix
+    # tolerance is length-ratio-guarded so a short intermediate sentence that
+    # merely prefixes a long final answer is NOT suppressed (Codex #4568).
     assert "replace(/\\s+/g,' ')" in match
     assert "startsWith" in match
+    assert "0.9" in match and ">=80" in match.replace(" ", ""), (
+        "prefix tolerance must be guarded by a near-equal length ratio, not a bare >=40 floor"
+    )
     # guard against the regression where ALL prose rows were dropped:
     assert "// avoid duplicating the answer" in row or "duplicates the final answer" in row
 

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -673,6 +673,54 @@ def test_anchor_owned_settled_turn_skips_legacy_worklog_rebuild():
     assert "!anchorOwnedAssistantRawIdxs.has(S.messages.indexOf(m))" in render
 
 
+def test_transparent_stream_renders_persisted_anchor_scene_after_reload():
+    settled = _function_body(UI_JS, "_renderSettledAnchorSceneForMessage")
+    transparent = _function_body(UI_JS, "_renderSettledAnchorSceneTransparentForMessage")
+    row = _function_body(UI_JS, "_anchorSceneTransparentNodeForRow")
+    match = _function_body(UI_JS, "_anchorSceneProseMatchesFinalAnswer")
+    render = _function_body(UI_JS, "renderMessages")
+
+    assert "if(typeof isTransparentStream==='function'&&isTransparentStream())" in settled
+    assert "return _renderSettledAnchorSceneTransparentForMessage(message,segment,rawIdx);" in settled
+    assert "_anchorSceneRowsForRendering(scene,{settled:true})" in transparent
+    assert 'blocks.querySelectorAll(\'[data-anchor-settled-scene-row="1"],.transparent-event-row[data-anchor-scene-row="1"]\')' in transparent
+    # combined fix: the final answer text is computed and threaded into the row
+    # renderer so intermediate prose survives while the final-answer duplicate is dropped.
+    assert "_anchorSceneTransparentNodeForRow(row,{settled:true,finalAnswer})" in transparent
+    assert "finalAnswer" in transparent
+    assert "blocks.insertBefore(node,segment)" in transparent
+    assert "_syncTransparentEventControls(turn)" in transparent
+    # tool + thinking rows are rendered as transparent event rows
+    assert "_decorateTransparentEventRow(_thinkingActivityNode" in row
+    assert "_decorateTransparentEventRow(buildToolCard(toolCall)" in row
+    assert "_transparentToolStatus(toolCall,true)" in row
+    assert 'data-anchor-settled-scene-row' in row
+    assert "if(anchorOwnedAssistantRawIdxs.has(aIdx)) continue;" in render
+
+
+def test_transparent_anchor_intermediate_prose_preserved_only_final_answer_suppressed():
+    """#4568 combined fix: intermediate between-tool progress prose must render in
+    Transparent Stream reload (not be blanket-dropped like the first pass did);
+    ONLY the prose row that duplicates the final answer is suppressed."""
+    row = _function_body(UI_JS, "_anchorSceneTransparentNodeForRow")
+    match = _function_body(UI_JS, "_anchorSceneProseMatchesFinalAnswer")
+    # the prose branch must RENDER intermediate prose via the shared node builder,
+    # gated only on the final-answer match — NOT an unconditional `return null`.
+    assert "row.role==='prose'" in row
+    assert "_anchorSceneProseMatchesFinalAnswer(text,finalAnswer)" in row
+    assert "_anchorSceneNodeForRow(row,{settled})" in row, (
+        "intermediate prose must be rendered as an inline assistant-segment node, "
+        "not dropped"
+    )
+    assert "type:'prose'" in row
+    # the matcher exists and compares whitespace-insensitively with a startsWith tolerance
+    assert "replace(/\\s+/g,' ')" in match
+    assert "startsWith" in match
+    # guard against the regression where ALL prose rows were dropped:
+    assert "// avoid duplicating the answer" in row or "duplicates the final answer" in row
+
+
+
 def test_settled_anchor_scene_final_answer_does_not_fold_into_worklog_source():
     belongs = _function_body(UI_JS, "_assistantMessageBelongsInWorklog")
     render = _function_body(UI_JS, "renderMessages")


### PR DESCRIPTION
## Summary

Fixes #4568. In **Transparent Stream** activity mode, a turn that settled with a persisted assistant-turn anchor scene (`activity_scene_v1`, #3926/#4411) lost **all** its tool-call and thinking activity on every rehydrate path — after the turn settled, when switching away and back, on tab hide/show, on window blur/focus, on a hard reload, and on a mid-stream reload — leaving only the final answer prose.

**Root cause:** `renderMessages()` marks anchor-scene-carrying turns "anchor-owned" and skips the legacy derived-tool rebuild, but the settled anchor-scene renderer `_renderSettledAnchorSceneForMessage` only ran in Compact Worklog mode (early `return false` otherwise). So in Transparent Stream the activity rendered nowhere on settle/reload.

## Approach — combines two solutions

This builds directly on **@franksong2702's #4576**, which introduced the right architecture: render the persisted anchor scene **as transparent event rows** on settle/reload (deterministic, and #3926-aligned — both display modes consume the *same* persisted scene instead of a second normalizer). I verified that approach reliably restores the **tool and thinking rows**.

It adds **intermediate-prose preservation** on top: #4576 dropped *all* `prose` rows to avoid duplicating the final answer, which also lost the between-tool progress narration from earlier rounds. `_anchorSceneTransparentNodeForRow` now renders intermediate prose as inline `assistant-segment` rows and suppresses **only** the prose row that duplicates the final answer (`_anchorSceneProseMatchesFinalAnswer` — exact normalized match, with a length-ratio-guarded prefix tolerance for re-wraps). Result: tools + thinking + intermediate prose all survive, interleaved in chronological order, at every checkpoint, in both modes.

Compact Worklog rendering is unchanged.

## Verification

Verified with a **checkpoint-matrix harness** (in the private workspace) that drives a real multi-round streaming turn (12 tool calls across 3 rounds + reasoning + progress prose + final answer) through every transcript lifecycle checkpoint, in **both** display modes:

| checkpoint | master | this PR |
|---|---|---|
| during_stream | ✅ | ✅ |
| after_done | ❌ tools→0 | ✅ |
| switch_away_back | ❌ tools→0 | ✅ |
| tab_hidden_visible | ❌ tools→0 | ✅ |
| blur_focus | ❌ tools→0 | ✅ |
| reload_after_done | ❌ tools→0 | ✅ |
| reload_mid_stream | ❌ tools→0 | ✅ |

- **Transparent Stream:** all 7 checkpoints render 12 tool rows + thinking + 4 prose rows, interleaved.
- **Compact Worklog:** all 7 checkpoints render the folded worklog group + final answer (no regression).
- **Full pytest suite:** 9881 passed, 0 failed.
- **Codex + Opus** both reviewed the diff: no XSS/double-render/orphan-row/compact regression; the one finding (over-broad final-answer prefix match) was fixed with a length-ratio guard, with a regression test.

Regression coverage added in `tests/test_live_to_final_anchor_visible_order.py` (the settled-scene transparent renderer route + intermediate-prose-preserved / final-answer-suppressed invariants).

## Credit

Co-authored with @franksong2702 (#4576 persisted-anchor-scene rendering approach). Supersedes #4576.
