### PR TITLE
fix: keep question jump visible on desktop

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -5100,6 +5100,38 @@ main.main > #mainPlugin{display:none;}
 .msg-row[data-role="assistant"]:hover .msg-foot,
 .assistant-turn:hover .msg-foot,
 .assistant-turn:focus-within .msg-foot { opacity: 1; }
+/* Desktop/tablet keeps the per-turn jump affordance discoverable without
+   exposing the quieter timestamp/action chrome until hover or keyboard focus. */
+@media (min-width: 641px) {
+  .msg-row[data-role="assistant"] .msg-foot:has(.msg-question-jump-btn),
+  .assistant-turn .msg-foot:has(.msg-question-jump-btn) {
+    opacity: 1;
+  }
+  .msg-row[data-role="assistant"] .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .msg-row[data-role="assistant"] .msg-foot:has(.msg-question-jump-btn) .msg-actions,
+  .assistant-turn .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .assistant-turn .msg-foot:has(.msg-question-jump-btn) .msg-actions {
+    opacity: 0;
+    transition: opacity .15s;
+  }
+  .msg-row[data-role="assistant"] .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .msg-row[data-role="assistant"] .msg-foot:has(.msg-question-jump-btn) .msg-actions,
+  .assistant-turn .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .assistant-turn .msg-foot:has(.msg-question-jump-btn) .msg-actions {
+    pointer-events: none;
+  }
+  .msg-row[data-role="assistant"]:hover .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .msg-row[data-role="assistant"]:hover .msg-foot:has(.msg-question-jump-btn) .msg-actions,
+  .msg-row[data-role="assistant"]:focus-within .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .msg-row[data-role="assistant"]:focus-within .msg-foot:has(.msg-question-jump-btn) .msg-actions,
+  .assistant-turn:hover .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .assistant-turn:hover .msg-foot:has(.msg-question-jump-btn) .msg-actions,
+  .assistant-turn:focus-within .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .assistant-turn:focus-within .msg-foot:has(.msg-question-jump-btn) .msg-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
 .assistant-turn .msg-foot-with-usage,
 .msg-row[data-role="assistant"] .msg-foot-with-usage {
   opacity: 1;

--- a/tests/test_issue2246_question_jump.py
+++ b/tests/test_issue2246_question_jump.py
@@ -63,6 +63,28 @@ def test_question_jump_button_matches_bottom_button_size_on_mobile():
     assert ".msg-question-jump-btn span:last-child { display: none; }" in STYLE_CSS
 
 
+def test_question_jump_footer_is_discoverable_on_desktop_without_exposing_actions():
+    # Desktop cannot rely on the mobile always-visible footer override, but the
+    # per-turn jump affordance is navigation, not quiet action chrome. Keep only
+    # the jump button discoverable at rest; reveal timestamp/actions on hover or
+    # keyboard focus.
+    block_anchor = "Desktop/tablet keeps the per-turn jump affordance discoverable"
+    block_start = STYLE_CSS.index(block_anchor)
+    block_end = STYLE_CSS.index(".assistant-turn .msg-foot-with-usage", block_start)
+    desktop_jump_block = STYLE_CSS[block_start:block_end]
+
+    assert "@media (min-width: 641px)" in desktop_jump_block
+
+    assert ".assistant-turn .msg-foot:has(.msg-question-jump-btn)" in desktop_jump_block
+    assert "opacity: 1;" in desktop_jump_block
+    assert ".msg-foot:has(.msg-question-jump-btn) .msg-time" in desktop_jump_block
+    assert ".msg-foot:has(.msg-question-jump-btn) .msg-actions" in desktop_jump_block
+    assert "pointer-events: none;" in desktop_jump_block
+    assert ".assistant-turn:hover .msg-foot:has(.msg-question-jump-btn) .msg-actions" in desktop_jump_block
+    assert ".assistant-turn:focus-within .msg-foot:has(.msg-question-jump-btn) .msg-actions" in desktop_jump_block
+    assert "pointer-events: auto;" in desktop_jump_block
+
+
 def test_question_jump_text_is_localized():
     for key in ("jump_to_question", "jump_to_question_label"):
         assert I18N_JS.count(f"{key}:") >= 12


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI keeps transcript chrome quiet on desktop by hiding assistant footers until hover/focus.
- The per-turn jump-to-question button is navigation, not routine action chrome.
- Mobile already forces message footers visible because touch users cannot rely on hover.
- Desktop/tablet should expose the jump affordance at rest while keeping timestamp/actions progressively disclosed.

## What Changed
- Keeps assistant footers that contain `.msg-question-jump-btn` visible at desktop/tablet widths.
- Keeps timestamp and message action buttons hidden and non-clickable at rest, then restores them on hover/focus.
- Adds focused regression coverage for the desktop jump-button visibility rule alongside existing mobile coverage.

## Why It Matters
- The jump-to-question affordance is now discoverable on desktop without making all message footer controls visually noisy.
- Existing mobile behavior remains unchanged.

## Verification
- `./scripts/test.sh tests/test_issue2246_question_jump.py tests/test_issue3851_jump_to_question_mobile.py` — 10 passed.
- `node --check static/ui.js && python3 -m py_compile server.py bootstrap.py` — passed.
- `git diff --check origin/master...HEAD` — passed.
- Isolated browser probe confirmed desktop computed styles: jump-bearing footer visible; timestamp/actions hidden and non-clickable at rest; jump button visible/clickable. The existing mobile always-visible footer rule remains present.
- Independent Steward review returned APPROVE with no blockers.

## Risks / Follow-ups
- Uses `:has(.msg-question-jump-btn)`, which is already used in the stylesheet.
- This is a CSS-only visibility tweak; no server, streaming, storage, or routing behavior changes.

## Contract Routing
Task type: UI/UX visibility fix.
Touched areas: chat message footer styling and existing question-jump regression tests.
Relevant public docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/UIUX-GUIDE.md`, `DESIGN.md`.
Scope boundaries: no new controls, no backend/API changes, no mobile behavior change.
Evidence needed before claiming done: focused tests, syntax/diff checks, and responsive/browser-style evidence.

## Model Used
AI-assisted: OpenAI GPT-5.5 for implementation drafting; Claude Code for read-only review.
