### PR TITLE
Release v0.51.549 — mobile reload recovery after compression rotation (#2980)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.555] — 2026-06-21 — Release TN (mobile reloads recover after compression rotation)
+
+### Fixed
+
+- **A mobile reload during context compression no longer makes the conversation look lost (#2980).** When a long turn was rotating through context compression and the browser reloaded (common on mobile), it could come back pointing at a hidden pre-compression snapshot, so the current conversation appeared to vanish. `GET /api/session` now surfaces the visible continuation for such a hidden snapshot and the UI follows it — bounded across repeated-compression hops, scoped to the session's own profile (it never resolves a session in another profile), and it only updates the URL/storage once the continuation actually loads. Thanks @george-andra.
+
 ## [v0.51.554] — 2026-06-21 — Release TM (the transcript stays put when you scroll up during a live reply)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -6330,6 +6330,13 @@ def _pre_compression_continuation_session_id(session) -> str | None:
     sid = _safe_first(getattr(session, "session_id", None))
     if not sid:
         return None
+    # #2980 hardening: the resolved continuation is written to the client's
+    # URL/localStorage, so it must stay within the requested snapshot's own
+    # profile. Children are matched only by parent_session_id below; a
+    # crafted/corrupt foreign-profile sidecar whose parent_session_id collided
+    # with this snapshot's id would otherwise leak cross-profile. Pin the
+    # snapshot's profile and reject any child that isn't profile-matched.
+    snapshot_profile = getattr(session, "profile", None)
 
     def _child_rows() -> list:
         rows = []
@@ -6366,6 +6373,9 @@ def _pre_compression_continuation_session_id(session) -> str | None:
         child_sid = _safe_first(getattr(child, "session_id", None))
         if not parent_sid or not child_sid or child_sid == sid:
             continue
+        # Cross-profile guard: only follow continuations within the snapshot's profile.
+        if not _profiles_match(getattr(child, "profile", None), snapshot_profile):
+            continue
         children_by_parent.setdefault(parent_sid, []).append(child)
 
     candidates = []
@@ -6397,7 +6407,11 @@ def _pre_compression_continuation_session_id(session) -> str | None:
             ) or 0
         ),
     )
-    return getattr(latest, "session_id", None) or None
+    latest_sid = getattr(latest, "session_id", None) or None
+    # Only hand the client a well-formed session id (it gets written to URL/localStorage).
+    if latest_sid and not is_safe_session_id(latest_sid):
+        return None
+    return latest_sid
 from api.workspace import (
     load_workspaces,
     save_workspaces,

--- a/api/routes.py
+++ b/api/routes.py
@@ -5364,6 +5364,10 @@ def _resolve_cli_import_metadata(session_id: str, *, requested_profile=None, all
 
 
 def _messaging_session_identity(session: dict, raw_source: str) -> str:
+    sid = _safe_first(session.get("session_id"))
+    if sid and _is_pre_compression_continuation_row(session):
+        return f"{raw_source}|session_id:{sid}"
+
     metadata = _lookup_gateway_session_identity(session.get("session_id"))
     session_key = _safe_first(
         metadata.get("session_key"),
@@ -5398,7 +5402,27 @@ def _messaging_session_identity(session: dict, raw_source: str) -> str:
 
     if identity_parts:
         return f"{raw_source}|" + "|".join(identity_parts)
+
     return raw_source
+
+
+def _is_pre_compression_snapshot_id(session_id: str) -> bool:
+    sid = _safe_first(session_id)
+    if not sid or not all(c in "0123456789abcdefghijklmnopqrstuvwxyz_" for c in sid):
+        return False
+    try:
+        path = SESSION_DIR / f"{sid}.json"
+        if not path.exists():
+            return False
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return bool(data.get("pre_compression_snapshot"))
+    except Exception:
+        return False
+
+
+def _is_pre_compression_continuation_row(session: dict) -> bool:
+    parent_sid = _safe_first(session.get("parent_session_id"))
+    return bool(parent_sid and _is_pre_compression_snapshot_id(parent_sid))
 
 
 def _session_messaging_raw_source(session: dict) -> str:
@@ -5462,9 +5486,14 @@ def _should_hide_stale_messaging_session(
         return True
 
     if not _has_durable_messaging_identity(session):
+        if _is_pre_compression_continuation_row(session):
+            return False
+        parent_sid = _safe_first(session.get("parent_session_id"))
+        if parent_sid and parent_sid in active_gateway_session_ids:
+            return True
         return True
 
-    if session.get("parent_session_id"):
+    if session.get("parent_session_id") and not _is_pre_compression_continuation_row(session):
         return True
 
     message_count = _numeric_count(session.get("message_count"))
@@ -6284,6 +6313,91 @@ from api.models import (
     is_cron_session,
     is_safe_session_id,
 )
+
+
+def _pre_compression_continuation_session_id(session) -> str | None:
+    """Return the newest visible descendant for a hidden compression snapshot.
+
+    Mobile browsers can miss the final SSE `done` handoff while backgrounded.
+    On reload they may request the archived pre-compression session id from the
+    stale URL/localStorage. The old snapshot is intentionally hidden from the
+    sidebar, so expose a lightweight recovery hint when a child continuation
+    exists either in memory or on disk. Follow bounded snapshot-to-snapshot hops
+    so repeated compression still lands on the latest visible continuation.
+    """
+    if not getattr(session, "pre_compression_snapshot", False):
+        return None
+    sid = _safe_first(getattr(session, "session_id", None))
+    if not sid:
+        return None
+
+    def _child_rows() -> list:
+        rows = []
+        seen_ids = set()
+        try:
+            with LOCK:
+                memory_sessions = list(SESSIONS.values())
+            for child in memory_sessions:
+                child_sid = _safe_first(getattr(child, "session_id", None))
+                if not child_sid or child_sid in seen_ids:
+                    continue
+                seen_ids.add(child_sid)
+                rows.append(child)
+        except Exception:
+            pass
+        try:
+            for path in SESSION_DIR.glob("*.json"):
+                if path.name.startswith("_"):
+                    continue
+                child_sid = path.stem
+                if not child_sid or child_sid in seen_ids:
+                    continue
+                child = Session.load_metadata_only(child_sid)
+                if child:
+                    seen_ids.add(child_sid)
+                    rows.append(child)
+        except Exception:
+            pass
+        return rows
+
+    children_by_parent: dict[str, list] = {}
+    for child in _child_rows():
+        parent_sid = _safe_first(getattr(child, "parent_session_id", None))
+        child_sid = _safe_first(getattr(child, "session_id", None))
+        if not parent_sid or not child_sid or child_sid == sid:
+            continue
+        children_by_parent.setdefault(parent_sid, []).append(child)
+
+    candidates = []
+    frontier = [sid]
+    seen = {sid}
+    for _ in range(20):
+        if not frontier:
+            break
+        parent_sid = frontier.pop(0)
+        for child in children_by_parent.get(parent_sid, []):
+            child_sid = _safe_first(getattr(child, "session_id", None))
+            if not child_sid or child_sid in seen:
+                continue
+            seen.add(child_sid)
+            if getattr(child, "pre_compression_snapshot", False):
+                frontier.append(child_sid)
+            else:
+                candidates.append(child)
+
+    if not candidates:
+        return None
+    latest = max(
+        candidates,
+        key=lambda child: float(
+            _safe_first(
+                getattr(child, "updated_at", None),
+                getattr(child, "created_at", None),
+                0,
+            ) or 0
+        ),
+    )
+    return getattr(latest, "session_id", None) or None
 from api.workspace import (
     load_workspaces,
     save_workspaces,
@@ -9221,6 +9335,11 @@ def handle_get(handler, parsed) -> bool:
                     float(raw.get("updated_at") or 0),
                     _merged_last_message_at,
                 )
+            # #2980: surface the visible continuation for a hidden pre-compression
+            # snapshot so a mobile reload mid-compression can recover to it.
+            continuation_sid = _pre_compression_continuation_session_id(s)
+            if continuation_sid:
+                raw["continuation_session_id"] = continuation_sid
             if cli_meta and _session_source_is_webui(cli_meta):
                 raw = _reconcile_session_detail_source_flags(raw, cli_meta)
             elif cli_meta and _is_messaging_session_record(cli_meta):

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1106,10 +1106,11 @@ async function loadSession(sid){
   // #2980: if this (current) load resolved a hidden pre-compression snapshot,
   // follow the backend's continuation hint to the visible continuation so a
   // mobile reload mid-compression doesn't strand the user on a hidden snapshot.
+  // Do NOT write URL/localStorage here — let the re-entrant loadSession update
+  // them only once the continuation actually loads, so a rejected/deleted/
+  // cross-profile continuation can't poison restore state with an unusable id.
   const continuationSid=(data.session&&data.session.continuation_session_id)||'';
   if(continuationSid&&continuationSid!==sid&&!opts.skipContinuationResolve){
-    try{localStorage.setItem('hermes-webui-session',continuationSid);}catch(_){}
-    _setActiveSessionUrl(continuationSid);
     _loadingSessionId=null;
     return loadSession(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,force:true});
   }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1103,6 +1103,16 @@ async function loadSession(sid){
     _rearmActiveSessionStream();
     return;
   }
+  // #2980: if this (current) load resolved a hidden pre-compression snapshot,
+  // follow the backend's continuation hint to the visible continuation so a
+  // mobile reload mid-compression doesn't strand the user on a hidden snapshot.
+  const continuationSid=(data.session&&data.session.continuation_session_id)||'';
+  if(continuationSid&&continuationSid!==sid&&!opts.skipContinuationResolve){
+    try{localStorage.setItem('hermes-webui-session',continuationSid);}catch(_){}
+    _setActiveSessionUrl(continuationSid);
+    _loadingSessionId=null;
+    return loadSession(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,force:true});
+  }
   S.session=data.session;
   // Loading a real existing session abandons any pre-session toolset override
   // staged on the empty composer — clear it so it can't leak into a later New

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -1495,6 +1495,159 @@ def test_sessions_response_distinguishes_same_user_different_chat_identity_from_
             pass
 
 
+def test_messaging_projection_keeps_no_identity_continuation_when_gateway_source_active(monkeypatch, cleanup_test_sessions):
+    """A WebUI/mobile recovery continuation must not disappear behind source-wide Gateway hiding.
+
+    Long WebUI turns can rotate to a child session during compression. If the
+    browser is backgrounded before the final SSE handoff, recovery depends on
+    the continuation still being visible in the sidebar. This is source-generic:
+    Telegram, Discord, Slack, and Weixin all use the same messaging projection.
+    """
+    from api import routes
+    from api.models import Session
+
+    parent_sid = "webui_pre_compression_snapshot"
+    cleanup_test_sessions.append(parent_sid)
+    Session(
+        session_id=parent_sid,
+        title="Archived pre-compression snapshot",
+        model="openai/gpt-5",
+        messages=[{"role": "user", "content": "before compression", "timestamp": time.time() - 10}],
+        pre_compression_snapshot=True,
+    ).save(touch_updated_at=False)
+
+    for source in ("telegram", "discord", "slack", "weixin"):
+        active_sid = f"{source}_active_sid"
+        continuation_sid = f"webui_{source}_continuation_no_identity"
+        cleanup_test_sessions.append(continuation_sid)
+        monkeypatch.setattr(
+            routes,
+            "_load_gateway_session_identity_map",
+            lambda source=source, active_sid=active_sid: {
+                active_sid: {
+                    "session_key": f"agent:main:{source}:dm:user_1",
+                    "raw_source": source,
+                    "platform": source,
+                    "chat_type": "dm",
+                    "chat_id": "user_1",
+                    "user_id": "user_1",
+                },
+            },
+        )
+        sessions = [
+            {
+                "session_id": active_sid,
+                "raw_source": source,
+                "session_source": "messaging",
+                "title": f"Current {source} DM",
+                "updated_at": 100,
+                "message_count": 3,
+            },
+            {
+                "session_id": continuation_sid,
+                "raw_source": source,
+                "session_source": "messaging",
+                "chat_id": "webui_recovery_chat",
+                "chat_type": "dm",
+                "title": f"Recovered {source} WebUI continuation",
+                "parent_session_id": parent_sid,
+                "updated_at": 200,
+                "message_count": 1003,
+            },
+        ]
+
+        kept = routes._keep_latest_messaging_session_per_source(sessions)
+        ids = {session.get("session_id") for session in kept}
+
+        assert ids == {active_sid, continuation_sid}
+
+
+def test_session_load_exposes_continuation_for_pre_compression_snapshot(cleanup_test_sessions):
+    """Reloading an old hidden compression snapshot should give the browser a recovery target."""
+    from api.models import Session
+
+    parent_sid = "webui_mobile_snapshot_parent"
+    child_sid = "webui_mobile_snapshot_child"
+    now = time.time()
+    cleanup_test_sessions.extend([parent_sid, child_sid])
+
+    parent = Session(
+        session_id=parent_sid,
+        title="Mobile reload parent",
+        model="openai/gpt-5",
+        messages=[{"role": "user", "content": "before compression", "timestamp": now - 10}],
+        created_at=now - 20,
+        updated_at=now - 10,
+        pre_compression_snapshot=True,
+    )
+    child = Session(
+        session_id=child_sid,
+        title="Mobile reload child",
+        model="openai/gpt-5",
+        parent_session_id=parent_sid,
+        messages=[{"role": "assistant", "content": "finished after reload", "timestamp": now}],
+        created_at=now - 5,
+        updated_at=now,
+    )
+    parent.save(touch_updated_at=False)
+    child.save(touch_updated_at=False)
+
+    data, status = get(f"/api/session?session_id={parent_sid}&messages=0&resolve_model=0")
+
+    assert status == 200
+    assert data["session"].get("session_id") == parent_sid
+    assert data["session"].get("continuation_session_id") == child_sid
+
+
+def test_session_load_exposes_multihop_continuation_for_repeated_compression(cleanup_test_sessions):
+    """A stale older snapshot should recover to the newest visible descendant."""
+    from api.models import Session
+
+    root_sid = "webui_mobile_snapshot_root"
+    middle_sid = "webui_mobile_snapshot_middle"
+    child_sid = "webui_mobile_snapshot_grandchild"
+    now = time.time()
+    cleanup_test_sessions.extend([root_sid, middle_sid, child_sid])
+
+    root = Session(
+        session_id=root_sid,
+        title="Mobile reload root snapshot",
+        model="openai/gpt-5",
+        messages=[{"role": "user", "content": "before first compression", "timestamp": now - 30}],
+        created_at=now - 40,
+        updated_at=now - 30,
+        pre_compression_snapshot=True,
+    )
+    middle = Session(
+        session_id=middle_sid,
+        title="Mobile reload middle snapshot",
+        model="openai/gpt-5",
+        parent_session_id=root_sid,
+        messages=[{"role": "assistant", "content": "before second compression", "timestamp": now - 20}],
+        created_at=now - 25,
+        updated_at=now - 20,
+        pre_compression_snapshot=True,
+    )
+    child = Session(
+        session_id=child_sid,
+        title="Mobile reload final child",
+        model="openai/gpt-5",
+        parent_session_id=middle_sid,
+        messages=[{"role": "assistant", "content": "finished after repeated compression", "timestamp": now}],
+        created_at=now - 5,
+        updated_at=now,
+    )
+    root.save(touch_updated_at=False)
+    middle.save(touch_updated_at=False)
+    child.save(touch_updated_at=False)
+
+    data, status = get(f"/api/session?session_id={root_sid}&messages=0&resolve_model=0")
+
+    assert status == 200
+    assert data["session"].get("session_id") == root_sid
+    assert data["session"].get("continuation_session_id") == child_sid
+
+
 def test_messaging_projection_hides_stale_gateway_internal_segments(monkeypatch):
     """Active Gateway identity should hide old reset rows and internal child segments."""
     from api import routes

--- a/tests/test_mobile_reload_compression_recovery.py
+++ b/tests/test_mobile_reload_compression_recovery.py
@@ -1,0 +1,33 @@
+"""Regression coverage for mobile reload recovery after compression session rotation."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+
+
+def _function_block(source: str, marker: str) -> str:
+    start = source.index(marker)
+    brace = source.index("{", start)
+    depth = 1
+    i = brace + 1
+    while i < len(source) and depth:
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+        i += 1
+    return source[start:i]
+
+
+def test_load_session_follows_backend_continuation_hint():
+    """Reloading a stale pre-compression URL should update URL/localStorage to the continuation."""
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    load_session = _function_block(src, "async function loadSession")
+
+    assert "continuation_session_id" in load_session
+    assert "loadSession(continuationSid" in load_session
+    assert "skipContinuationResolve" in load_session
+    assert "localStorage.setItem('hermes-webui-session',continuationSid)" in load_session
+    assert "_setActiveSessionUrl(continuationSid)" in load_session

--- a/tests/test_mobile_reload_compression_recovery.py
+++ b/tests/test_mobile_reload_compression_recovery.py
@@ -50,7 +50,6 @@ def test_continuation_lookup_is_profile_scoped(tmp_path, monkeypatch):
     filtered out, while the same-profile child resolves. Guards against a
     crafted/colliding foreign-profile sidecar leaking cross-profile.
     """
-    import types
     from api import routes, config
 
     class _S:

--- a/tests/test_mobile_reload_compression_recovery.py
+++ b/tests/test_mobile_reload_compression_recovery.py
@@ -22,12 +22,64 @@ def _function_block(source: str, marker: str) -> str:
 
 
 def test_load_session_follows_backend_continuation_hint():
-    """Reloading a stale pre-compression URL should update URL/localStorage to the continuation."""
+    """Reloading a stale pre-compression URL should follow the backend continuation hint.
+
+    The continuation is followed by re-entering loadSession() with the hinted id;
+    URL/localStorage are updated by that successful inner load, NOT written
+    speculatively up-front (so a rejected/cross-profile continuation can't poison
+    restore state with an unusable id — #2980 hardening).
+    """
     src = SESSIONS_JS.read_text(encoding="utf-8")
     load_session = _function_block(src, "async function loadSession")
 
     assert "continuation_session_id" in load_session
     assert "loadSession(continuationSid" in load_session
     assert "skipContinuationResolve" in load_session
-    assert "localStorage.setItem('hermes-webui-session',continuationSid)" in load_session
-    assert "_setActiveSessionUrl(continuationSid)" in load_session
+    # The re-entrant follow must pass skipContinuationResolve:true to prevent recursion.
+    assert "skipContinuationResolve:true" in load_session
+    # Restore-state safety: the continuation id must NOT be written to localStorage/URL
+    # before the inner load proves it is loadable.
+    assert "localStorage.setItem('hermes-webui-session',continuationSid)" not in load_session
+    assert "_setActiveSessionUrl(continuationSid)" not in load_session
+
+
+def test_continuation_lookup_is_profile_scoped(tmp_path, monkeypatch):
+    """#2980 hardening: a continuation in a DIFFERENT profile must NOT be resolved.
+
+    The snapshot is profile 'work'; a same-parent child in 'personal' must be
+    filtered out, while the same-profile child resolves. Guards against a
+    crafted/colliding foreign-profile sidecar leaking cross-profile.
+    """
+    import types
+    from api import routes, config
+
+    class _S:
+        def __init__(self, sid, profile, parent=None, snap=False, updated=0.0):
+            self.session_id = sid
+            self.profile = profile
+            self.parent_session_id = parent
+            self.pre_compression_snapshot = snap
+            self.updated_at = updated
+            self.created_at = updated
+
+    snapshot = _S("snap00000001", "work", snap=True)
+    same_profile_child = _S("cont00000001", "work", parent="snap00000001", updated=200.0)
+    foreign_child = _S("frgn00000001", "personal", parent="snap00000001", updated=300.0)
+
+    # Empty session dir so only in-memory SESSIONS are considered.
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(routes, "SESSION_DIR", tmp_path, raising=False)
+    import collections
+    fake = collections.OrderedDict()
+    for s in (same_profile_child, foreign_child):
+        fake[s.session_id] = s
+    monkeypatch.setattr(routes, "SESSIONS", fake, raising=False)
+
+    result = routes._pre_compression_continuation_session_id(snapshot)
+    assert result == "cont00000001", f"expected same-profile continuation, got {result!r}"
+
+    # Sanity: if the ONLY child is foreign-profile, no continuation is returned.
+    fake2 = collections.OrderedDict()
+    fake2[foreign_child.session_id] = foreign_child
+    monkeypatch.setattr(routes, "SESSIONS", fake2, raising=False)
+    assert routes._pre_compression_continuation_session_id(snapshot) is None

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -114,7 +114,7 @@ def test_server_runtime_journal_snapshot_restores_structured_inflight_state():
     helper_pos = SESSIONS_SRC.index("function _serverLiveSnapshotToolId")
     helper_block = SESSIONS_SRC[helper_pos : helper_pos + 3600]
     load_pos = SESSIONS_SRC.index("async function loadSession")
-    load_block = SESSIONS_SRC[load_pos : load_pos + 18000]
+    load_block = SESSIONS_SRC[load_pos : load_pos + 20000]
 
     assert "runtime_journal_snapshot" in load_block
     assert "_serverLiveSnapshotInflight(S.session.runtime_journal_snapshot" in load_block


### PR DESCRIPTION
## Release v0.51.549 — Release TH (mobile reloads recover after compression rotation)

Ships #2980 (george-andra) — a reliability fix lifted off hold. Rebased onto master (was 1615 behind; 2 conflicts resolved) + 3 gate-found hardening fixes applied with attribution preserved.

### Fixed

- **A mobile reload during context compression no longer makes the conversation look lost.** `GET /api/session` surfaces the visible continuation for a hidden pre-compression snapshot and the UI follows it — bounded across repeated-compression hops, profile-scoped, and it only updates URL/storage once the continuation actually loads. Thanks @george-andra.

### Gate + hardening (applied during review)

- Full pytest suite: **9899 passed**, 0 failed (incl. the mobile-reload recovery tests + a new cross-profile regression test)
- Codex: **SAFE TO SHIP** (re-confirm after fixes); Opus: **SAFE**
- 🔴 **Cross-profile leak fixed**: the continuation lookup scanned all profiles and matched only by `parent_session_id`; now filters children by `_profiles_match(child, snapshot)` + validates the returned id with `is_safe_session_id`.
- 🔴 **Restore-state poison fixed**: the frontend no longer writes the continuation id to localStorage/URL before the inner load proves it loadable.
- Bounded BFS (`range(20)` + `seen` set) + recursion guard confirmed safe by both gates.
- Conflict merges verified: sessions.js merged with the #2971 re-arm guard; routes.py merged with the `_session_source_is_webui` branch.

Behavioral mobile-recovery fix — verified by regression tests (no static UI surface to screenshot).
