### PR TITLE
fix(tts): add id-ID-GadisNeural to Edge TTS and fix Listen button playback

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -13437,6 +13437,7 @@ def _handle_tts(handler, parsed):
         "fr-CA-AntoineNeural", "fr-CA-JeanNeural",
         "fr-CA-SylvieNeural", "fr-CA-ThierryNeural",
         "fr-FR-DeniseNeural", "fr-FR-EloiseNeural", "fr-FR-HenriNeural",
+        "id-ID-GadisNeural",
     }
     if voice not in allowed:
         from api.helpers import bad as _bad

--- a/static/panels.js
+++ b/static/panels.js
@@ -7367,6 +7367,7 @@ async function loadSettingsPanel(){
           {value:'zh-CN-YunyangNeural',label:'Yunyang (Chinese, Male)'},
           {value:'en-US-AriaNeural',label:'Aria (English, Female)'},
           {value:'en-US-GuyNeural',label:'Guy (English, Male)'},
+          {value:'id-ID-GadisNeural',label:'Gadis (Indonesian, Female)'},
         ];
         ttsVoiceSel.innerHTML='<option value="">Default (Xiaoxiao)</option>';
         edgeVoices.forEach(v=>{

--- a/static/ui.js
+++ b/static/ui.js
@@ -6068,6 +6068,7 @@ function _buildBrowserUtterance(text, btn){
 
 function _playEdgeTtsChunked(text, btn){
   _ttsSpeaking=true;
+  if(btn) btn.dataset.speaking='1';
   const chunks=_splitForTTS(text);
   const _playOne=function(idx){
     if(idx>=chunks.length){

--- a/static/ui.js
+++ b/static/ui.js
@@ -6067,6 +6067,7 @@ function _buildBrowserUtterance(text, btn){
 }
 
 function _playEdgeTtsChunked(text, btn){
+  _ttsSpeaking=true;
   const chunks=_splitForTTS(text);
   const _playOne=function(idx){
     if(idx>=chunks.length){


### PR DESCRIPTION
## Summary

Three small changes to improve Edge TTS support:

### Changes

1. **api/routes.py** — Add `id-ID-GadisNeural` to the Edge TTS server voice allowlist so Indonesian voice is available via the /api/tts endpoint.

2. **static/panels.js** — Add `Gadis (Indonesian, Female)` to the Edge TTS voice dropdown in Settings so users can select it.

3. **static/ui.js** — Fix `_playEdgeTtsChunked` not setting `_ttsSpeaking=true` before the fetch chain, causing the Listen button to silently drop audio (the `if(!_ttsSpeaking) return` guard at the start of the blob handler would immediately abort playback).

### Testing

- Verified `edge_tts.Communicate('...', 'id-ID-GadisNeural')` produces valid audio
- Verified /api/tts returns HTTP 200 with correct audio Content-Type
- Verified Listen button plays audio after the ui.js fix (hard refresh required)