### PR TITLE
Release v0.51.553 — extensions diagnostics panel (#4588)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.553] — 2026-06-21 — Release TL (extensions diagnostics panel in Settings)
+
+### Added
+
+- **A read-only "Extensions" diagnostics pane in Settings (#4569 follow-up).** Backed by the `/api/extensions/status` endpoint, it shows whether the extension runtime/manifest loaded, the final same-origin asset URLs that get injected, and any sanitized warnings (stable codes and coarse sources only — never the configured filesystem path, raw environment values, or rejected URL strings). Includes an up-front trust-model note that extensions run in the WebUI browser origin. Read-only and observational. Thanks @santastabber.
+
 ## [v0.51.552] — 2026-06-21 — Release TK (extension sidecar CSP documentation)
 
 ### Changed

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -300,14 +300,19 @@ Authenticated administrators can inspect sanitized extension configuration at:
 GET /api/extensions/status
 ```
 
-The endpoint is read-only and follows the normal WebUI authentication rules. It
-returns the same public asset URLs that can already be injected into the HTML,
-plus coarse manifest status, asset counts, and warning codes for rejected or
-unavailable configuration. `manifest.script_count` and
+The endpoint is read-only and follows the normal WebUI authentication rules. The
+same sanitized diagnostics are also shown in **Settings → Extensions** for
+operators who prefer to inspect extension state from the browser. The panel does
+not enable, disable, install, or mutate extensions; it only fetches
+`/api/extensions/status` and offers a copy-diagnostics action.
+
+The diagnostics return the same public asset URLs that can already be injected
+into the HTML, plus coarse manifest status, asset counts, and warning codes for
+rejected or unavailable configuration. `manifest.script_count` and
 `manifest.stylesheet_count` count accepted assets from the manifest only;
 `counts.script_urls` and `counts.stylesheet_urls` count the final post-env-merge
 URLs. `manifest.entry_count` counts the loaded top-level manifest object and
 enabled extension entries that were inspected, not every extension object in the
-file. The endpoint does **not** return
+file. The endpoint and Settings panel do **not** return
 `HERMES_WEBUI_EXTENSION_DIR`, resolved manifest paths, raw environment values, or
 rejected URL strings.

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -618,6 +618,7 @@ const LOCALES = {
     settings_tab_appearance: 'Appearance',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
+    settings_tab_extensions: 'Extensions',
     settings_plugins_title: 'Plugins',
     plugins_enable_toggle: 'Enable',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',
@@ -2162,6 +2163,7 @@ const LOCALES = {
     settings_tab_appearance: 'Aspetto',
     settings_tab_preferences: 'Preferenze',
     settings_tab_plugins: 'Plugin',
+    settings_tab_extensions: 'Extensions',  // TODO: translate
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: 'Abilita',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -3697,6 +3699,7 @@ const LOCALES = {
     settings_tab_appearance: '外観',
     settings_tab_preferences: '環境設定',
     settings_tab_plugins: 'プラグイン',
+    settings_tab_extensions: '拡張機能',
     settings_plugins_title: 'プラグイン',
     plugins_enable_toggle: '有効化',
     settings_plugins_meta: 'インストール済みのHermesプラグインと登録されているライフサイクルフックを確認できます。このパネルは読み取り専用です。',
@@ -5927,6 +5930,7 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Плагины',
+    settings_tab_extensions: 'Extensions',  // TODO: translate
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: 'Включить',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -7387,6 +7391,7 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
+    settings_tab_extensions: 'Extensions',
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: 'Activar',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -8532,6 +8537,7 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
+    settings_tab_extensions: 'Extensions',
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: 'Aktivieren',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -10342,6 +10348,7 @@ const LOCALES = {
     settings_tab_conversation: '对话',
     settings_tab_preferences: '偏好',
     settings_tab_plugins: '插件',
+    settings_tab_extensions: '扩展',
     settings_tab_system: '系统',
     settings_tab_help: 'Help',
     settings_help_meta: 'Resources and support for Hermes WebUI.',
@@ -11121,6 +11128,7 @@ const LOCALES = {
     settings_tab_appearance: '外觀',
     settings_tab_preferences: '偏好設定',
     settings_tab_plugins: '外掛',
+    settings_tab_extensions: '擴充功能',
     settings_plugins_title: '外掛',
     plugins_enable_toggle: '啟用',
     settings_plugins_meta: '檢視已安裝的 Hermes 外掛及其註冊的生命週期掛鉤。此面板為唯讀。',
@@ -12552,6 +12560,7 @@ const LOCALES = {
     settings_tab_appearance: 'Aparência',
     settings_tab_preferences: 'Preferências',
     settings_tab_plugins: 'Plugins',
+    settings_tab_extensions: 'Extensions',
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: 'Ativar',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -13989,6 +13998,7 @@ const LOCALES = {
     settings_tab_appearance: '외형',
     settings_tab_preferences: '환경설정',
     settings_tab_plugins: '플러그인',
+    settings_tab_extensions: 'Extensions',  // TODO: translate
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: '활성화',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -15448,6 +15458,7 @@ const LOCALES = {
     settings_tab_appearance: 'Apparence',
     settings_tab_preferences: 'Préférences',
     settings_tab_plugins: 'Plugins',
+    settings_tab_extensions: 'Extensions',
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: 'Activer',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -17001,6 +17012,7 @@ const LOCALES = {
     settings_tab_appearance: 'Dış görünüş',
     settings_tab_preferences: 'Tercihler',
     settings_tab_plugins: 'Eklentiler',
+    settings_tab_extensions: 'Extensions',  // TODO: translate
     settings_plugins_title: 'Eklentiler',
     plugins_enable_toggle: 'Etkinleştir',
     settings_plugins_meta: 'Yüklü Hermes eklentilerini ve yaşam döngüsü kancalarını görüntüleyin. Bu panel salt okunurdur.',
@@ -18550,6 +18562,7 @@ const LOCALES = {
     settings_tab_appearance: 'Wygląd',
     settings_tab_preferences: 'Preferencje',
     settings_tab_plugins: 'Wtyczki',
+    settings_tab_extensions: 'Extensions',  // TODO: translate
     settings_plugins_title: 'Wtyczki',
     plugins_enable_toggle: 'Włącz',
     settings_plugins_meta: 'Zobacz zainstalowane wtyczki Hermes oraz rejestrowane przez nie haki cyklu życia. Ten panel jest tylko do odczytu.',

--- a/static/index.html
+++ b/static/index.html
@@ -378,6 +378,10 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2l3 7h7l-5.5 4.3 2.1 7L12 16.2 5.4 20.3l2.1-7L2 9h7z"/></svg>
           <span data-i18n="settings_tab_plugins">Plugins</span>
         </button>
+        <button type="button" class="side-menu-item" data-settings-section="extensions" onclick="switchSettingsSection('extensions')">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 2v6"/><path d="M15 2v6"/><path d="M7 8h10v4a5 5 0 0 1-10 0V8z"/><path d="M12 17v5"/></svg>
+          <span data-i18n="settings_tab_extensions">Extensions</span>
+        </button>
         <button type="button" class="side-menu-item" data-settings-section="system" onclick="switchSettingsSection('system')">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="3" width="20" height="8" rx="2"/><rect x="2" y="13" width="20" height="8" rx="2"/><line x1="6" y1="7" x2="6.01" y2="7"/><line x1="6" y1="17" x2="6.01" y2="17"/></svg>
           <span data-i18n="settings_tab_system">System</span>
@@ -1363,6 +1367,22 @@
             </div>
             <div id="pluginsEmpty" style="display:none;text-align:center;padding:32px 0;color:var(--muted);font-size:13px" data-i18n="settings_plugins_empty">
               No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.
+            </div>
+          </div>
+          <div class="settings-pane" id="settingsPaneExtensions">
+            <div class="settings-section-head">
+              <div>
+                <div class="settings-section-title" data-i18n="settings_tab_extensions">Extensions</div>
+                <div class="settings-section-meta">Read-only diagnostics for configured WebUI extensions.</div>
+              </div>
+              <button class="sm-btn extensions-copy-diagnostics-btn" id="extensionsCopyDiagnosticsBtn" type="button" onclick="copyExtensionsDiagnostics()" disabled>Copy diagnostics</button>
+            </div>
+            <div class="settings-field extensions-trust-note" id="extensionsTrustModel">
+              <label>Trust model</label>
+              <div>Extensions run in the WebUI browser origin and can access the same authenticated APIs as this session. Only load trusted local extension directories.</div>
+            </div>
+            <div id="extensionsDiagnostics" class="extensions-diagnostics" aria-live="polite">
+              <div class="extensions-loading">Loading extension diagnostics…</div>
             </div>
           </div>
           <div class="settings-pane" id="settingsPaneSystem">

--- a/static/panels.js
+++ b/static/panels.js
@@ -6222,6 +6222,7 @@ let _currentSettingsSection = 'conversation';
 let _settingsIndex = null;
 let _settingsIndexPromise = null;
 let _settingsSearchSeq = 0;
+let _extensionsStatusData = null;
 let _settingsSearchDismissListenerRegistered = false;
 let _settingsAppearanceAutosaveTimer = null;
 let _settingsAppearanceAutosaveRetryPayload = null;
@@ -6420,7 +6421,7 @@ function switchSettingsSection(name,opts){
     _settingsSection = name;
     return;
   }
-  let section=(name==='appearance'||name==='preferences'||name==='providers'||name==='plugins'||name==='system'||name==='help')?name:'conversation';
+  let section=(name==='appearance'||name==='preferences'||name==='providers'||name==='plugins'||name==='extensions'||name==='system'||name==='help')?name:'conversation';
   // Deep-linking to the Plugins pane when the tab is hidden (no plugins
   // installed, #3457) falls back to Conversation. Resolve this BEFORE toggling
   // panes/sidebar/dropdown below so every downstream selection uses the
@@ -6432,13 +6433,13 @@ function switchSettingsSection(name,opts){
   }
   _settingsSection=section;
   _currentSettingsSection=section;
-  const map={conversation:'Conversation',appearance:'Appearance',preferences:'Preferences',providers:'Providers',plugins:'Plugins',system:'System',help:'Help'};
+  const map={conversation:'Conversation',appearance:'Appearance',preferences:'Preferences',providers:'Providers',plugins:'Plugins',extensions:'Extensions',system:'System',help:'Help'};
   // Sidebar menu items
   document.querySelectorAll('#settingsMenu .side-menu-item').forEach(it=>{
     it.classList.toggle('active', it.dataset.settingsSection===section);
   });
   // Panes in main
-  ['conversation','appearance','preferences','providers','plugins','system','help'].forEach(key=>{
+  ['conversation','appearance','preferences','providers','plugins','extensions','system','help'].forEach(key=>{
     const pane=$('settingsPane'+map[key]);
     if(pane) pane.classList.toggle('active', key===section);
   });
@@ -6451,6 +6452,7 @@ function switchSettingsSection(name,opts){
   if(!(opts&&opts.skipLazyLoad)){
     if(section==='providers') loadProvidersPanel();
     if(section==='plugins') loadPluginsPanel();
+    if(section==='extensions') loadExtensionsPanel();
   }
 }
 
@@ -6461,7 +6463,7 @@ async function _buildSettingsIndex() {
   if (_settingsIndexPromise) return _settingsIndexPromise;
   const promise = (async () => {
     // Ensure lazy-loaded panes are populated before reading the DOM
-    await Promise.all([loadProvidersPanel(), loadPluginsPanel()]);
+    await Promise.all([loadProvidersPanel(), loadPluginsPanel(), loadExtensionsPanel()]);
     const index = [];
     const sectionMap = {
       settingsPaneConversation: 'conversation',
@@ -6469,6 +6471,7 @@ async function _buildSettingsIndex() {
       settingsPanePreferences: 'preferences',
       settingsPaneProviders: 'providers',
       settingsPanePlugins: 'plugins',
+      settingsPaneExtensions: 'extensions',
       settingsPaneSystem: 'system',
       settingsPaneHelp: 'help',
     };
@@ -6529,6 +6532,7 @@ async function filterSettings(query) {
     preferences: t('settings_tab_preferences') || 'Preferences',
     providers: t('providers_tab_title') || 'Providers',
     plugins: t('settings_tab_plugins') || 'Plugins',
+    extensions: t('settings_tab_extensions') || 'Extensions',
     system: t('settings_tab_system') || 'System',
     help: t('settings_tab_help') || 'Help',
   };
@@ -6582,6 +6586,7 @@ function _resolveSettingsField(entry) {
     preferences: 'settingsPanePreferences',
     providers: 'settingsPaneProviders',
     plugins: 'settingsPanePlugins',
+    extensions: 'settingsPaneExtensions',
     system: 'settingsPaneSystem',
     help: 'settingsPaneHelp',
   };
@@ -7488,9 +7493,142 @@ async function loadSettingsPanel(){
     if(typeof loadDashboardSettings==='function') loadDashboardSettings();
     loadProvidersPanel(); // load provider cards in background
     loadPluginsPanel(); // load plugin/hook visibility in background
+    loadExtensionsPanel(); // load extension diagnostics in background
     switchSettingsSection(_settingsSection);
   }catch(e){
     showToast(t('settings_load_failed')+e.message);
+  }
+}
+
+
+// ── Extensions panel (read-only browser-origin diagnostics) ────────────────
+
+function _extensionStatusLabel(value){
+  return value ? 'Enabled' : 'Disabled';
+}
+
+function _extensionBooleanBadge(value){
+  const cls=value?'extension-status-badge-on':'extension-status-badge-off';
+  return `<span class="extension-status-badge ${cls}">${value?'true':'false'}</span>`;
+}
+
+function _extensionAssetList(urls){
+  if(!Array.isArray(urls)||urls.length===0){
+    return '<div class="extension-url-empty">None</div>';
+  }
+  return '<ul class="extension-url-list">'+urls.map(url=>`<li><code>${esc(url)}</code></li>`).join('')+'</ul>';
+}
+
+function _extensionWarningList(warnings){
+  if(!Array.isArray(warnings)||warnings.length===0){
+    return '<div class="extension-url-empty">No warnings.</div>';
+  }
+  return '<ul class="extension-warning-list">'+warnings.map(item=>{
+    const code=esc((item&&item.code)||'unknown_warning');
+    const source=esc((item&&item.source)||'unknown');
+    return `<li><code>${code}</code><span>${source}</span></li>`;
+  }).join('')+'</ul>';
+}
+
+function _extensionCountValue(counts,key,urls){
+  if(counts&&Number.isFinite(Number(counts[key]))) return Number(counts[key]);
+  return Array.isArray(urls)?urls.length:0;
+}
+
+function _renderExtensionsPanel(data){
+  const target=$('extensionsDiagnostics');
+  const copyBtn=$('extensionsCopyDiagnosticsBtn');
+  if(!target) return;
+  _extensionsStatusData=data||null;
+  if(copyBtn) copyBtn.disabled=!data;
+  const manifest=(data&&data.manifest)||{};
+  const counts=(data&&data.counts)||{};
+  const scripts=Array.isArray(data&&data.script_urls)?data.script_urls:[];
+  const styles=Array.isArray(data&&data.stylesheet_urls)?data.stylesheet_urls:[];
+  const statusClass=(data&&data.enabled)?'extension-card-enabled':'extension-card-disabled';
+  const scriptCount=_extensionCountValue(counts,'script_urls',scripts);
+  const styleCount=_extensionCountValue(counts,'stylesheet_urls',styles);
+  target.innerHTML=`
+    <div class="provider-card extension-status-card ${statusClass}">
+      <div class="provider-card-header plugin-card-header">
+        <div class="provider-card-info">
+          <div class="provider-card-name">Extension runtime</div>
+          <div class="provider-card-meta">Read-only status from /api/extensions/status</div>
+        </div>
+        <span class="provider-card-badge ${data&&data.enabled?'':'plugin-card-badge-disabled'}">${_extensionStatusLabel(!!(data&&data.enabled))}</span>
+      </div>
+      <div class="provider-card-body extension-card-body">
+        <div class="extension-summary-grid">
+          <div><span>Extension dir configured</span>${_extensionBooleanBadge(!!(data&&data.extension_dir_configured))}</div>
+          <div><span>Extension dir valid</span>${_extensionBooleanBadge(!!(data&&data.extension_dir_valid))}</div>
+          <div><span>Manifest configured</span>${_extensionBooleanBadge(!!manifest.configured)}</div>
+          <div><span>Manifest loaded</span>${_extensionBooleanBadge(!!manifest.loaded)}</div>
+          <div><span>Manifest status</span><code>${esc(manifest.status||'unknown')}</code></div>
+          <div><span>Manifest entries inspected</span><code>${Number(manifest.entry_count)||0}</code></div>
+          <div><span>Manifest script count</span><code>${Number(manifest.script_count)||0}</code></div>
+          <div><span>Manifest stylesheet count</span><code>${Number(manifest.stylesheet_count)||0}</code></div>
+          <div><span>Final script count</span><code>${scriptCount}</code></div>
+          <div><span>Final stylesheet count</span><code>${styleCount}</code></div>
+        </div>
+      </div>
+    </div>
+    <div class="provider-card extension-assets-card">
+      <div class="provider-card-header plugin-card-header">
+        <div class="provider-card-info">
+          <div class="provider-card-name">Final public asset URLs</div>
+          <div class="provider-card-meta">Same-origin URLs that may be injected into the app shell.</div>
+        </div>
+      </div>
+      <div class="provider-card-body extension-card-body">
+        <div class="provider-card-label">Scripts</div>
+        ${_extensionAssetList(scripts)}
+        <div class="provider-card-label extension-section-label">Stylesheets</div>
+        ${_extensionAssetList(styles)}
+      </div>
+    </div>
+    <div class="provider-card extension-warnings-card">
+      <div class="provider-card-header plugin-card-header">
+        <div class="provider-card-info">
+          <div class="provider-card-name">Sanitized warnings</div>
+          <div class="provider-card-meta">Codes and coarse sources only; paths and rejected values are not shown.</div>
+        </div>
+      </div>
+      <div class="provider-card-body extension-card-body">
+        ${_extensionWarningList(data&&data.warnings)}
+      </div>
+    </div>
+  `;
+}
+
+async function loadExtensionsPanel(){
+  const target=$('extensionsDiagnostics');
+  const copyBtn=$('extensionsCopyDiagnosticsBtn');
+  if(!target) return;
+  if(copyBtn) copyBtn.disabled=true;
+  target.innerHTML='<div class="extensions-loading">Loading extension diagnostics…</div>';
+  try{
+    const data=await api('/api/extensions/status');
+    _renderExtensionsPanel(data);
+  }catch(e){
+    _extensionsStatusData=null;
+    if(copyBtn) copyBtn.disabled=true;
+    target.innerHTML='<div class="extensions-error">Failed to load extension diagnostics: '+esc(e.message||String(e))+'</div>';
+  }
+}
+
+async function copyExtensionsDiagnostics(){
+  if(!_extensionsStatusData) return;
+  const text=JSON.stringify(_extensionsStatusData,null,2);
+  const success=()=>showToast(t('copied')||'Copied!');
+  const fail=()=>showToast(t('copy_failed')||'Copy failed');
+  if(typeof _copyText==='function'){
+    _copyText(text).then(success).catch(fail);
+    return;
+  }
+  if(typeof navigator!=='undefined'&&navigator&&navigator.clipboard&&navigator.clipboard.writeText){
+    navigator.clipboard.writeText(text).then(success).catch(fail);
+  }else{
+    fail();
   }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -4570,6 +4570,33 @@ main.main > #mainPlugin{display:none;}
 .plugin-open-btn{display:inline-flex;align-items:center;gap:6px;padding:6px 14px;background:transparent;color:var(--accent);border:1px solid var(--accent);border-radius:7px;font-size:13px;font-weight:600;cursor:pointer;text-decoration:none;}
 .plugin-open-btn:hover{background:var(--accent);color:var(--bg);}
 
+/* ── Extension diagnostics cards ── */
+.extensions-copy-diagnostics-btn{white-space:nowrap;}
+.extensions-copy-diagnostics-btn:disabled{opacity:.45;cursor:not-allowed;}
+.extensions-trust-note{border-color:rgba(245,158,11,.35)!important;background:rgba(245,158,11,.08)!important;}
+#mainSettings .extensions-trust-note > label{color:var(--text);font-size:13px;font-weight:600;}
+.extensions-diagnostics{display:flex;flex-direction:column;gap:12px;margin-top:4px;}
+.extensions-loading,.extensions-error{padding:12px 14px;border:1px solid var(--border);border-radius:10px;background:var(--sidebar);font-size:13px;color:var(--muted);}
+.extensions-error{color:var(--error);border-color:color-mix(in srgb,var(--error) 35%,var(--border));}
+.extension-card-body{display:block;}
+.extension-summary-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px;}
+.extension-summary-grid>div{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:8px 10px;border:1px solid var(--border);border-radius:8px;background:var(--surface);font-size:12px;color:var(--muted);min-width:0;}
+.extension-summary-grid span{min-width:0;overflow-wrap:anywhere;}
+.extension-summary-grid code{font-family:var(--font-mono);font-size:11px;color:var(--text);background:var(--code-bg);border:1px solid var(--border2);border-radius:5px;padding:2px 6px;overflow-wrap:anywhere;}
+.extension-status-badge{display:inline-flex;align-items:center;border-radius:999px;padding:2px 7px;font-size:10.5px;font-weight:700;font-family:var(--font-mono);line-height:1.45;}
+.extension-status-badge-on{background:rgba(34,197,94,.14);color:#22c55e;}
+.extension-status-badge-off{background:var(--code-bg);color:var(--muted);}
+.extension-section-label{margin-top:14px;}
+.extension-url-list,.extension-warning-list{list-style:none;margin:6px 0 0 0;padding:0;display:flex;flex-direction:column;gap:6px;}
+.extension-url-list li,.extension-warning-list li{display:flex;align-items:center;gap:8px;min-width:0;padding:7px 9px;border:1px solid var(--border);border-radius:8px;background:var(--surface);font-size:12px;color:var(--muted);}
+.extension-url-list code,.extension-warning-list code{font-family:var(--font-mono);font-size:11px;color:var(--text);overflow-wrap:anywhere;word-break:break-word;}
+.extension-warning-list span{font-size:11px;color:var(--muted);overflow-wrap:anywhere;}
+.extension-url-empty{margin-top:6px;font-size:12px;color:var(--muted);font-style:italic;}
+@media (max-width: 768px){
+  .extensions-copy-diagnostics-btn{width:100%;}
+  .extension-summary-grid{grid-template-columns:1fr;}
+}
+
 /* ── Provider model tags ── */
 .provider-card-models{
   margin-bottom:10px;

--- a/tests/test_extensions_settings_panel.py
+++ b/tests/test_extensions_settings_panel.py
@@ -1,0 +1,154 @@
+"""Regression tests for the read-only Settings → Extensions diagnostics panel."""
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).parent.parent
+INDEX_HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+I18N_JS = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
+DOCS_EXTENSIONS = (ROOT / "docs" / "EXTENSIONS.md").read_text(encoding="utf-8")
+
+
+def _function_block(name: str, *, extra: int = 2200) -> str:
+    start = PANELS_JS.find(f"function {name}")
+    assert start >= 0, f"{name} not found"
+    return PANELS_JS[start:start + extra]
+
+
+def _between(start_marker: str, end_marker: str) -> str:
+    start = PANELS_JS.find(start_marker)
+    assert start >= 0, f"{start_marker} not found"
+    end = PANELS_JS.find(end_marker, start)
+    assert end >= 0, f"{end_marker} not found after {start_marker}"
+    return PANELS_JS[start:end]
+
+
+def _locale_count() -> int:
+    return len(re.findall(r"^  (?:[A-Za-z_][A-Za-z0-9_]*|'[^']+'):\s*\{", I18N_JS, re.MULTILINE))
+
+
+def _locale_blocks() -> dict[str, str]:
+    matches = list(re.finditer(r"^  ((?:[A-Za-z_][A-Za-z0-9_]*|'[^']+')):\s*\{", I18N_JS, re.MULTILINE))
+    blocks = {}
+    for idx, match in enumerate(matches):
+        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(I18N_JS)
+        blocks[match.group(1)] = I18N_JS[match.start():end]
+    return blocks
+
+
+def _contains_post_method(block: str) -> bool:
+    """Return True when a JS block contains a method: 'POST' style mutation."""
+    return bool(re.search(r"\bmethod\s*:\s*([\"'`])POST\1", block))
+
+
+def test_settings_sidebar_has_extensions_section_and_pane():
+    assert 'data-settings-section="extensions"' in INDEX_HTML
+    assert "switchSettingsSection('extensions')" in INDEX_HTML
+    assert 'id="settingsPaneExtensions"' in INDEX_HTML
+    assert 'id="extensionsDiagnostics"' in INDEX_HTML
+    assert 'id="extensionsCopyDiagnosticsBtn"' in INDEX_HTML
+    assert 'data-i18n="settings_tab_extensions"' in INDEX_HTML
+
+
+def test_extensions_panel_is_read_only_and_warns_about_trust_model():
+    pane_start = INDEX_HTML.index('id="settingsPaneExtensions"')
+    pane_end = INDEX_HTML.index('id="settingsPaneSystem"', pane_start)
+    pane = INDEX_HTML[pane_start:pane_end]
+
+    assert "Read-only diagnostics" in pane
+    assert "Extensions run in the WebUI browser origin" in pane
+    assert "Only load trusted local extension directories" in pane
+    assert "copyExtensionsDiagnostics()" in pane
+    assert "saveSettings(" not in pane
+    assert "api('/api/settings'" not in pane
+    assert "type=\"checkbox\"" not in pane
+    assert "toggle" not in pane.lower()
+    assert "install" not in pane.lower()
+    assert "marketplace" not in pane.lower()
+
+
+def test_switch_settings_section_supports_extensions_lazy_load():
+    switch_block = _function_block("switchSettingsSection", extra=2300)
+
+    assert "name==='extensions'" in switch_block
+    assert "plugins:'Plugins',extensions:'Extensions'" in switch_block
+    assert "'plugins','extensions','system'" in switch_block.replace("\n", "")
+    assert "if(section==='extensions') loadExtensionsPanel();" in switch_block
+
+
+def test_settings_search_knows_extensions_pane():
+    build_block = _function_block("_buildSettingsIndex", extra=2600)
+    filter_block = _function_block("filterSettings", extra=1700)
+    resolve_block = _function_block("_resolveSettingsField", extra=1400)
+
+    assert "loadExtensionsPanel()" in build_block
+    assert "settingsPaneExtensions: 'extensions'" in build_block
+    assert "extensions: t('settings_tab_extensions') || 'Extensions'" in filter_block
+    assert "extensions: 'settingsPaneExtensions'" in resolve_block
+
+
+def test_extensions_panel_fetches_status_endpoint_only():
+    load_block = _function_block("loadExtensionsPanel", extra=900)
+
+    assert "api('/api/extensions/status')" in load_block
+    assert "api('/api/settings'" not in load_block
+    assert not _contains_post_method(load_block)
+    assert "extensions-error" in load_block
+
+
+def test_extensions_panel_renders_sanitized_status_payload():
+    render_block = _between("function _renderExtensionsPanel", "async function loadExtensionsPanel")
+    warning_block = _function_block("_extensionWarningList", extra=900)
+    asset_block = _function_block("_extensionAssetList", extra=500)
+
+    assert "extension_dir_configured" in render_block
+    assert "extension_dir_valid" in render_block
+    assert "manifest.status" in render_block
+    assert "manifest.entry_count" in render_block
+    assert "manifest.script_count" in render_block
+    assert "manifest.stylesheet_count" in render_block
+    assert "script_urls" in render_block
+    assert "stylesheet_urls" in render_block
+    assert "data&&data.warnings" in render_block
+    assert "esc(url)" in asset_block
+    assert "esc(manifest.status||'unknown')" in render_block
+    assert "esc((item&&item.code)||'unknown_warning')" in warning_block
+    assert "esc((item&&item.source)||'unknown')" in warning_block
+    assert "Rejected" not in render_block  # rejected values must never be rendered directly
+
+
+def test_copy_extensions_diagnostics_copies_current_sanitized_payload():
+    copy_block = _between("function copyExtensionsDiagnostics", "// ── Plugins panel")
+
+    assert "JSON.stringify(_extensionsStatusData,null,2)" in copy_block
+    assert "navigator.clipboard.writeText(text)" in copy_block
+    assert "api('/api/settings'" not in copy_block
+    assert "api('/api/extensions'" not in copy_block
+    assert not _contains_post_method(copy_block)
+
+
+def test_extensions_styles_are_scoped_to_extensions_panel():
+    assert ".extensions-diagnostics" in STYLE_CSS
+    assert ".extensions-trust-note" in STYLE_CSS
+    assert ".extension-summary-grid" in STYLE_CSS
+    assert ".extension-warning-list" in STYLE_CSS
+    assert ".extension-url-list" in STYLE_CSS
+
+
+def test_extensions_tab_i18n_key_exists_for_all_locales():
+    blocks = _locale_blocks()
+
+    assert len(blocks) == _locale_count()
+    missing = [name for name, block in blocks.items() if "settings_tab_extensions" not in block]
+    assert not missing, f"Locale(s) missing settings_tab_extensions: {missing}"
+
+
+def test_extensions_docs_mentions_settings_panel_without_mutation_claims():
+    diagnostics_section = DOCS_EXTENSIONS[DOCS_EXTENSIONS.index("## Diagnostics"):]
+
+    assert "Settings → Extensions" in diagnostics_section
+    assert "enable, disable, install, or mutate extensions" in diagnostics_section
+    assert "`/api/extensions/status`" in diagnostics_section
+    assert "do **not** return" in diagnostics_section


### PR DESCRIPTION
## Release v0.51.553 — Release TL (extensions diagnostics panel in Settings)

Ships #4588 (santastabber) — read-only Settings → Extensions diagnostics UI for the #4569 status endpoint.

### Added
- Read-only Extensions diagnostics pane: runtime/manifest status, final same-origin asset URLs, sanitized warnings (codes + coarse sources only — no paths/env/rejected values). Trust-model note up front. Thanks @santastabber.

### Gate
- Full suite: **9925 passed**, 0 failed (incl. new test_extensions_settings_panel.py)
- Codex: **SAFE TO SHIP**; Opus: **SAFE TO SHIP** — XSS-escaped rendering, client-side no-leak preserved, read-only, default-safe
- Screenshot verified (clean read-only diagnostics layout)
