### PR TITLE
Release v0.51.556 — Indonesian Edge TTS voice + Listen button fix (#4599)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 
 ## [Unreleased]
 
+## [v0.51.556] — 2026-06-21 — Release TO (Indonesian Edge TTS voice + Listen button state fix)
+
+### Added
+
+- **Indonesian Edge TTS voice (`Gadis`).** Added `id-ID-GadisNeural` to the Edge TTS voice allowlist and the voice picker. Thanks @latipun7.
+
+### Fixed
+
+- **The Listen (text-to-speech) button now reflects playing state for chunked Edge TTS playback.** It marks the speaking state at the start of playback so the button shows it's active instead of looking idle while audio plays. Thanks @latipun7.
+
 ## [v0.51.555] — 2026-06-21 — Release TN (mobile reloads recover after compression rotation)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -13577,6 +13577,7 @@ def _handle_tts(handler, parsed):
         "fr-CA-AntoineNeural", "fr-CA-JeanNeural",
         "fr-CA-SylvieNeural", "fr-CA-ThierryNeural",
         "fr-FR-DeniseNeural", "fr-FR-EloiseNeural", "fr-FR-HenriNeural",
+        "id-ID-GadisNeural",
     }
     if voice not in allowed:
         from api.helpers import bad as _bad

--- a/static/panels.js
+++ b/static/panels.js
@@ -7372,6 +7372,7 @@ async function loadSettingsPanel(){
           {value:'zh-CN-YunyangNeural',label:'Yunyang (Chinese, Male)'},
           {value:'en-US-AriaNeural',label:'Aria (English, Female)'},
           {value:'en-US-GuyNeural',label:'Guy (English, Male)'},
+          {value:'id-ID-GadisNeural',label:'Gadis (Indonesian, Female)'},
         ];
         ttsVoiceSel.innerHTML='<option value="">Default (Xiaoxiao)</option>';
         edgeVoices.forEach(v=>{

--- a/static/ui.js
+++ b/static/ui.js
@@ -6095,6 +6095,8 @@ function _buildBrowserUtterance(text, btn){
 }
 
 function _playEdgeTtsChunked(text, btn){
+  _ttsSpeaking=true;
+  if(btn) btn.dataset.speaking='1';
   const chunks=_splitForTTS(text);
   const _playOne=function(idx){
     if(idx>=chunks.length){


### PR DESCRIPTION
## Release v0.51.556 — Release TO (Indonesian Edge TTS voice + Listen button fix)

Ships #4599 (latipun7). Small parity + bugfix.

### Added
- Indonesian Edge TTS voice `id-ID-GadisNeural` (allowlist + picker). Edge TTS is a core builtin, so this is a parity voice addition.

### Fixed
- Listen button now reflects playing state for chunked Edge TTS playback.

### Gate
- Full suite: **9935 passed**, 0 failed
- Codex: **SAFE TO SHIP** (allowlist-only server change, speaking-state set/clear correct, no browser-TTS regression)
