### PR TITLE
Release v0.51.557 — desktop question-jump discoverable (#4592)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.557] — 2026-06-21 — Release TP (jump-to-question stays discoverable on desktop)
+
+### Changed
+
+- **The per-turn "jump to question" button now stays visible on desktop/tablet, while the timestamp and action icons remain hover-only.** That affordance is navigation, not routine action chrome, so it no longer requires hovering to discover (mobile already showed it). The quieter timestamp/copy/action controls still reveal on hover or keyboard focus, keeping the transcript clean. Thanks @santastabber.
+
 ## [v0.51.556] — 2026-06-21 — Release TO (Indonesian Edge TTS voice + Listen button state fix)
 
 ### Added

--- a/static/style.css
+++ b/static/style.css
@@ -5127,6 +5127,38 @@ main.main > #mainPlugin{display:none;}
 .msg-row[data-role="assistant"]:hover .msg-foot,
 .assistant-turn:hover .msg-foot,
 .assistant-turn:focus-within .msg-foot { opacity: 1; }
+/* Desktop/tablet keeps the per-turn jump affordance discoverable without
+   exposing the quieter timestamp/action chrome until hover or keyboard focus. */
+@media (min-width: 641px) {
+  .msg-row[data-role="assistant"] .msg-foot:has(.msg-question-jump-btn),
+  .assistant-turn .msg-foot:has(.msg-question-jump-btn) {
+    opacity: 1;
+  }
+  .msg-row[data-role="assistant"] .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .msg-row[data-role="assistant"] .msg-foot:has(.msg-question-jump-btn) .msg-actions,
+  .assistant-turn .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .assistant-turn .msg-foot:has(.msg-question-jump-btn) .msg-actions {
+    opacity: 0;
+    transition: opacity .15s;
+  }
+  .msg-row[data-role="assistant"] .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .msg-row[data-role="assistant"] .msg-foot:has(.msg-question-jump-btn) .msg-actions,
+  .assistant-turn .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .assistant-turn .msg-foot:has(.msg-question-jump-btn) .msg-actions {
+    pointer-events: none;
+  }
+  .msg-row[data-role="assistant"]:hover .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .msg-row[data-role="assistant"]:hover .msg-foot:has(.msg-question-jump-btn) .msg-actions,
+  .msg-row[data-role="assistant"]:focus-within .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .msg-row[data-role="assistant"]:focus-within .msg-foot:has(.msg-question-jump-btn) .msg-actions,
+  .assistant-turn:hover .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .assistant-turn:hover .msg-foot:has(.msg-question-jump-btn) .msg-actions,
+  .assistant-turn:focus-within .msg-foot:has(.msg-question-jump-btn) .msg-time,
+  .assistant-turn:focus-within .msg-foot:has(.msg-question-jump-btn) .msg-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
 .assistant-turn .msg-foot-with-usage,
 .msg-row[data-role="assistant"] .msg-foot-with-usage {
   opacity: 1;

--- a/tests/test_issue2246_question_jump.py
+++ b/tests/test_issue2246_question_jump.py
@@ -63,6 +63,28 @@ def test_question_jump_button_matches_bottom_button_size_on_mobile():
     assert ".msg-question-jump-btn span:last-child { display: none; }" in STYLE_CSS
 
 
+def test_question_jump_footer_is_discoverable_on_desktop_without_exposing_actions():
+    # Desktop cannot rely on the mobile always-visible footer override, but the
+    # per-turn jump affordance is navigation, not quiet action chrome. Keep only
+    # the jump button discoverable at rest; reveal timestamp/actions on hover or
+    # keyboard focus.
+    block_anchor = "Desktop/tablet keeps the per-turn jump affordance discoverable"
+    block_start = STYLE_CSS.index(block_anchor)
+    block_end = STYLE_CSS.index(".assistant-turn .msg-foot-with-usage", block_start)
+    desktop_jump_block = STYLE_CSS[block_start:block_end]
+
+    assert "@media (min-width: 641px)" in desktop_jump_block
+
+    assert ".assistant-turn .msg-foot:has(.msg-question-jump-btn)" in desktop_jump_block
+    assert "opacity: 1;" in desktop_jump_block
+    assert ".msg-foot:has(.msg-question-jump-btn) .msg-time" in desktop_jump_block
+    assert ".msg-foot:has(.msg-question-jump-btn) .msg-actions" in desktop_jump_block
+    assert "pointer-events: none;" in desktop_jump_block
+    assert ".assistant-turn:hover .msg-foot:has(.msg-question-jump-btn) .msg-actions" in desktop_jump_block
+    assert ".assistant-turn:focus-within .msg-foot:has(.msg-question-jump-btn) .msg-actions" in desktop_jump_block
+    assert "pointer-events: auto;" in desktop_jump_block
+
+
 def test_question_jump_text_is_localized():
     for key in ("jump_to_question", "jump_to_question_label"):
         assert I18N_JS.count(f"{key}:") >= 12


### PR DESCRIPTION
## Release v0.51.557 — Release TP (jump-to-question discoverable on desktop)

Ships #4592 (santastabber). CSS-only + test.

### Changed
- Desktop/tablet keeps the per-turn jump-to-question button visible (navigation), while timestamp/action chrome stays hover/focus-only (`:has(.msg-question-jump-btn)` selectors, ≥641px). Preserves the clean-transcript / actions-on-hover preference. Thanks @santastabber.

### Gate
- Full suite: **9936 passed**, 0 failed
- Codex: **SAFE TO SHIP** (scoped to ≥641px, no regression to footers without a jump button, no mobile-path change)
- Screenshot verified: at rest only the jump button shows; timestamp/actions hidden until hover.
