### PR TITLE
feat: surface loopback sidecar diagnostics

### DIFF
--- a/api/extensions.py
+++ b/api/extensions.py
@@ -42,6 +42,9 @@ _EXTENSION_SCRIPT_URLS_ENV = "HERMES_WEBUI_EXTENSION_SCRIPT_URLS"
 _EXTENSION_STYLESHEET_URLS_ENV = "HERMES_WEBUI_EXTENSION_STYLESHEET_URLS"
 _EXTENSION_MANIFEST_ENV = "HERMES_WEBUI_EXTENSION_MANIFEST"
 _ALLOWED_ASSET_PREFIXES = ("/extensions/", "/static/")
+_SIDECAR_WARNING_SOURCE = "manifest:sidecars"
+_DEFAULT_SIDECAR_HEALTH_PATH = "/health"
+_LOOPBACK_SIDECAR_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 _EXTENSION_MIME = {
     "css": "text/css",
@@ -261,6 +264,122 @@ def _manifest_asset_url(value: object) -> str:
     return EXTENSION_ROUTE_PREFIX + item
 
 
+def _manifest_entry_text(entry: Dict[str, object], key: str) -> str:
+    value = entry.get(key)
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _normalize_loopback_sidecar_origin(value: object) -> Optional[str]:
+    """Return a canonical loopback origin or None when unsafe.
+
+    Only browser-addressable loopback HTTP(S) origins are accepted. The returned
+    value is rebuilt from parsed components so rejected raw input is never echoed
+    into diagnostics.
+    """
+    if not isinstance(value, str):
+        return None
+    origin = value.strip()
+    if not origin or any(
+        ch in origin for ch in ("\x00", "\r", "\n", '"', "'", "<", ">", "\\")
+    ):
+        return None
+    parsed = urlsplit(origin)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return None
+    if parsed.username or parsed.password:
+        return None
+    if parsed.path or parsed.query or parsed.fragment:
+        return None
+    host = (parsed.hostname or "").lower()
+    if host not in _LOOPBACK_SIDECAR_HOSTS:
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    display_host = f"[{host}]" if ":" in host else host
+    return f"{parsed.scheme}://{display_host}{':' + str(port) if port is not None else ''}"
+
+
+def _normalize_sidecar_health_path(value: object) -> Optional[str]:
+    """Return a safe sidecar health path, or None when unsafe.
+
+    Health paths are same-origin paths relative to the validated sidecar origin.
+    Queries are rejected even though they are not cross-origin: health checks are
+    diagnostics, and query strings often accidentally carry tokens.
+    """
+    if not isinstance(value, str):
+        return None
+    path = value.strip()
+    if not path or not path.startswith("/") or path.startswith("//"):
+        return None
+    if any(ch in path for ch in ("\x00", "\r", "\n", '"', "'", "<", ">", "\\")):
+        return None
+    parsed = urlsplit(path)
+    if parsed.scheme or parsed.netloc or parsed.query or parsed.fragment:
+        return None
+    decoded_path = _fully_unquote_path(parsed.path)
+    if any(ch in decoded_path for ch in ("\x00", "\r", "\n", '"', "'", "<", ">", "\\")):
+        return None
+    if any(ch.isspace() for ch in decoded_path):
+        return None
+    if not decoded_path.startswith("/") or decoded_path.startswith("//"):
+        return None
+    segments = decoded_path.split("/")[1:]
+    if not segments:
+        return None
+    for segment in segments:
+        if not segment or segment in (".", ".."):
+            return None
+    return decoded_path
+
+
+def _sidecar_from_manifest_entry(
+    entry: Dict[str, object], diagnostics: Optional[Dict[str, Any]] = None
+) -> Optional[Dict[str, str]]:
+    raw = entry.get("sidecar")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        _add_diagnostic_warning(diagnostics, "sidecar_invalid", _SIDECAR_WARNING_SOURCE)
+        return None
+    if raw.get("type") != "loopback":
+        _add_diagnostic_warning(
+            diagnostics, "sidecar_type_unsupported", _SIDECAR_WARNING_SOURCE
+        )
+        return None
+    origin = _normalize_loopback_sidecar_origin(raw.get("origin"))
+    if origin is None:
+        _add_diagnostic_warning(
+            diagnostics, "sidecar_origin_rejected", _SIDECAR_WARNING_SOURCE
+        )
+        return None
+    if "health_path" in raw:
+        health_path = _normalize_sidecar_health_path(raw.get("health_path"))
+        if health_path is None:
+            # Missing health_path defaults to /health; an explicitly invalid path
+            # rejects the sidecar so the browser does not probe a declaration the
+            # administrator needs to fix.
+            _add_diagnostic_warning(
+                diagnostics, "sidecar_health_path_rejected", _SIDECAR_WARNING_SOURCE
+            )
+            return None
+    else:
+        health_path = _DEFAULT_SIDECAR_HEALTH_PATH
+    sidecar_id = _manifest_entry_text(entry, "id")
+    name = _manifest_entry_text(entry, "name")
+    return {
+        "id": sidecar_id,
+        "name": name,
+        "type": "loopback",
+        "origin": origin,
+        "health_path": health_path,
+        "health_url": f"{origin}{health_path}",
+    }
+
+
 def _iter_manifest_entries(manifest: object) -> List[Tuple[str, object]]:
     entries: List[Tuple[str, object]] = []
     extension_entries: object = []
@@ -294,7 +413,7 @@ def _read_manifest_text(manifest_file: Path) -> str:
 
 def _read_manifest_urls_with_diagnostics(
     root: Path, diagnostics: Optional[Dict[str, Any]] = None
-) -> Tuple[List[str], List[str], Dict[str, Any]]:
+) -> Tuple[List[str], List[str], List[Dict[str, str]], Dict[str, Any]]:
     manifest_file, path_status = _manifest_path_with_status(root)
     manifest_status: Dict[str, Any] = {
         "configured": path_status != "not_configured",
@@ -303,28 +422,29 @@ def _read_manifest_urls_with_diagnostics(
         "entry_count": 0,
         "script_count": 0,
         "stylesheet_count": 0,
+        "sidecar_count": 0,
     }
     if manifest_file is None:
         if path_status == "invalid_path":
             _add_diagnostic_warning(diagnostics, "manifest_invalid_path", "manifest")
-        return [], [], manifest_status
+        return [], [], [], manifest_status
     try:
         if not manifest_file.exists() or not manifest_file.is_file():
             _log.warning("Configured extension manifest was not found")
             manifest_status["status"] = "missing"
             _add_diagnostic_warning(diagnostics, "manifest_missing", "manifest")
-            return [], [], manifest_status
+            return [], [], [], manifest_status
         manifest = json.loads(_read_manifest_text(manifest_file))
     except _ManifestTooLarge:
         _log.warning("Configured extension manifest exceeds %d bytes", _MAX_MANIFEST_BYTES)
         manifest_status["status"] = "oversized"
         _add_diagnostic_warning(diagnostics, "manifest_oversized", "manifest")
-        return [], [], manifest_status
+        return [], [], [], manifest_status
     except json.JSONDecodeError:
         _log.warning("Configured extension manifest is not valid JSON")
         manifest_status["status"] = "malformed"
         _add_diagnostic_warning(diagnostics, "manifest_malformed", "manifest")
-        return [], [], manifest_status
+        return [], [], [], manifest_status
     except RecursionError:
         # A <=64KB but deeply-nested manifest makes json.loads exceed the
         # interpreter recursion limit. Without this, the RecursionError escapes
@@ -332,15 +452,16 @@ def _read_manifest_urls_with_diagnostics(
         _log.warning("Configured extension manifest is too deeply nested")
         manifest_status["status"] = "too_deeply_nested"
         _add_diagnostic_warning(diagnostics, "manifest_too_deeply_nested", "manifest")
-        return [], [], manifest_status
+        return [], [], [], manifest_status
     except (OSError, UnicodeDecodeError):
         _log.warning("Configured extension manifest could not be read")
         manifest_status["status"] = "unreadable"
         _add_diagnostic_warning(diagnostics, "manifest_unreadable", "manifest")
-        return [], [], manifest_status
+        return [], [], [], manifest_status
 
     scripts: List[str] = []
     stylesheets: List[str] = []
+    sidecars: List[Dict[str, str]] = []
     entries = _iter_manifest_entries(manifest)
     manifest_status["entry_count"] = len(entries)
     scripts_full = False
@@ -348,6 +469,15 @@ def _read_manifest_urls_with_diagnostics(
     for _source, entry in entries:
         if not isinstance(entry, dict):
             continue
+        if _source.startswith("manifest.extensions["):
+            sidecar = _sidecar_from_manifest_entry(entry, diagnostics)
+            if sidecar is not None:
+                if len(sidecars) < _MAX_URL_LIST:
+                    sidecars.append(sidecar)
+                else:
+                    _add_diagnostic_warning(
+                        diagnostics, "sidecar_list_truncated", _SIDECAR_WARNING_SOURCE
+                    )
         script_source = "manifest:scripts"
         stylesheet_source = "manifest:stylesheets"
         if not scripts_full:
@@ -370,21 +500,20 @@ def _read_manifest_urls_with_diagnostics(
                 ):
                     stylesheets_full = True
                     break
-        if scripts_full and stylesheets_full:
-            break
     manifest_status.update(
         {
             "loaded": True,
             "status": "loaded",
             "script_count": len(scripts),
             "stylesheet_count": len(stylesheets),
+            "sidecar_count": len(sidecars),
         }
     )
-    return scripts, stylesheets, manifest_status
+    return scripts, stylesheets, sidecars, manifest_status
 
 
 def _read_manifest_urls(root: Path) -> Tuple[List[str], List[str]]:
-    scripts, stylesheets, _ = _read_manifest_urls_with_diagnostics(root)
+    scripts, stylesheets, _, _ = _read_manifest_urls_with_diagnostics(root)
     return scripts, stylesheets
 
 
@@ -417,6 +546,7 @@ def get_extension_status() -> Dict[str, Any]:
         "entry_count": 0,
         "script_count": 0,
         "stylesheet_count": 0,
+        "sidecar_count": 0,
     }
     if dir_configured and not dir_valid:
         _add_diagnostic_warning(diagnostics, "extension_dir_unavailable", "extension_dir")
@@ -428,12 +558,13 @@ def get_extension_status() -> Dict[str, Any]:
             "extension_dir_valid": False,
             "script_urls": [],
             "stylesheet_urls": [],
-            "counts": {"script_urls": 0, "stylesheet_urls": 0},
+            "sidecars": [],
+            "counts": {"script_urls": 0, "stylesheet_urls": 0, "sidecars": 0},
             "manifest": manifest_status,
             "warnings": diagnostics["warnings"],
         }
 
-    manifest_scripts, manifest_stylesheets, manifest_status = _read_manifest_urls_with_diagnostics(
+    manifest_scripts, manifest_stylesheets, sidecars, manifest_status = _read_manifest_urls_with_diagnostics(
         root, diagnostics
     )
     script_urls = _read_url_list(
@@ -452,9 +583,11 @@ def get_extension_status() -> Dict[str, Any]:
         "extension_dir_valid": True,
         "script_urls": script_urls,
         "stylesheet_urls": stylesheet_urls,
+        "sidecars": sidecars,
         "counts": {
             "script_urls": len(script_urls),
             "stylesheet_urls": len(stylesheet_urls),
+            "sidecars": len(sidecars),
         },
         "manifest": manifest_status,
         "warnings": diagnostics["warnings"],

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -261,14 +261,19 @@ Authenticated administrators can inspect sanitized extension configuration at:
 GET /api/extensions/status
 ```
 
-The endpoint is read-only and follows the normal WebUI authentication rules. It
-returns the same public asset URLs that can already be injected into the HTML,
-plus coarse manifest status, asset counts, and warning codes for rejected or
-unavailable configuration. `manifest.script_count` and
+The endpoint is read-only and follows the normal WebUI authentication rules. The
+same sanitized diagnostics are also shown in **Settings → Extensions** for
+operators who prefer to inspect extension state from the browser. The panel does
+not enable, disable, install, or mutate extensions; it only fetches
+`/api/extensions/status` and offers a copy-diagnostics action.
+
+The diagnostics return the same public asset URLs that can already be injected
+into the HTML, plus coarse manifest status, asset counts, and warning codes for
+rejected or unavailable configuration. `manifest.script_count` and
 `manifest.stylesheet_count` count accepted assets from the manifest only;
 `counts.script_urls` and `counts.stylesheet_urls` count the final post-env-merge
 URLs. `manifest.entry_count` counts the loaded top-level manifest object and
 enabled extension entries that were inspected, not every extension object in the
-file. The endpoint does **not** return
+file. The endpoint and Settings panel do **not** return
 `HERMES_WEBUI_EXTENSION_DIR`, resolved manifest paths, raw environment values, or
 rejected URL strings.

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -92,6 +92,30 @@ may be kept in the manifest with the JSON boolean `"enabled": false`. Explicit
 `HERMES_WEBUI_EXTENSION_STYLESHEET_URLS` still work and are appended after
 manifest assets, with duplicates ignored.
 
+Extension entries may also declare a read-only loopback sidecar for diagnostics:
+
+```json
+{
+  "extensions": [
+    {
+      "id": "desktop-companion",
+      "name": "Desktop Companion",
+      "scripts": ["companion-adapter.js"],
+      "stylesheets": ["companion-adapter.css"],
+      "sidecar": {
+        "type": "loopback",
+        "origin": "http://127.0.0.1:17787",
+        "health_path": "/health"
+      }
+    }
+  ]
+}
+```
+
+Loopback sidecars do **not** change asset injection behavior. They are only
+reported by diagnostics so an operator can see that a local companion service was
+declared and optionally check its health from the browser.
+
 ## URL rules
 
 Injected asset URLs are deliberately restricted:
@@ -124,6 +148,26 @@ javascript:alert(1)
 These restrictions keep the existing Content Security Policy intact and avoid
 turning the extension hook into a third-party script loader. Invalid configured
 URLs are ignored rather than injected.
+
+## Loopback sidecar declarations
+
+Sidecar declarations are sanitized before they appear in diagnostics:
+
+- only `"type": "loopback"` is supported
+- `origin` must be an `http` or `https` origin on `127.0.0.1`, `localhost`, or
+  `[::1]`
+- `origin` must not include a username, password, path, query string, or fragment
+- `health_path` is optional and defaults to `/health`
+- when present, `health_path` must start with `/` and must not contain a scheme,
+  host, query string, fragment, quotes, control characters, backslashes, empty
+  segments, or path traversal
+
+Invalid sidecars are skipped with a stable warning code such as
+`sidecar_origin_rejected`, `sidecar_type_unsupported`,
+`sidecar_health_path_rejected`, or `sidecar_invalid`. Raw rejected origins and
+paths are never returned by the status endpoint. If `health_path` is omitted,
+diagnostics use `/health`; if `health_path` is present but invalid, the sidecar is
+skipped rather than probed.
 
 ## Static file serving
 
@@ -268,12 +312,22 @@ not enable, disable, install, or mutate extensions; it only fetches
 `/api/extensions/status` and offers a copy-diagnostics action.
 
 The diagnostics return the same public asset URLs that can already be injected
-into the HTML, plus coarse manifest status, asset counts, and warning codes for
-rejected or unavailable configuration. `manifest.script_count` and
-`manifest.stylesheet_count` count accepted assets from the manifest only;
-`counts.script_urls` and `counts.stylesheet_urls` count the final post-env-merge
-URLs. `manifest.entry_count` counts the loaded top-level manifest object and
-enabled extension entries that were inspected, not every extension object in the
-file. The endpoint and Settings panel do **not** return
-`HERMES_WEBUI_EXTENSION_DIR`, resolved manifest paths, raw environment values, or
-rejected URL strings.
+into the HTML, plus coarse manifest status, asset counts, sanitized declared
+loopback sidecars, and warning codes for rejected or unavailable configuration.
+`manifest.script_count` and `manifest.stylesheet_count` count accepted assets
+from the manifest only; `manifest.sidecar_count` counts accepted enabled loopback
+sidecars from the manifest. `counts.script_urls` and `counts.stylesheet_urls`
+count the final post-env-merge URLs, while `counts.sidecars` counts the sanitized
+sidecar list returned in `sidecars`. `manifest.entry_count` counts the loaded
+top-level manifest object and enabled extension entries that were inspected, not
+every extension object in the file. The endpoint and Settings panel do **not**
+return `HERMES_WEBUI_EXTENSION_DIR`, resolved manifest paths, raw environment
+values, rejected URL strings, rejected sidecar origins, or rejected health paths.
+
+When sanitized loopback sidecars are present, **Settings → Extensions** renders a
+read-only sidecar monitor card. The browser checks each declared `health_url`
+directly with `fetch(..., { credentials: 'omit', cache: 'no-store' })` and a
+short timeout. WebUI does **not** proxy sidecar requests and does not send WebUI
+cookies to sidecars. A successful HTTP response is shown as healthy, a non-OK
+HTTP response as unhealthy, and CORS/network/timeouts as unreachable or blocked;
+health response bodies are never rendered.

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -618,6 +618,7 @@ const LOCALES = {
     settings_tab_appearance: 'Appearance',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
+    settings_tab_extensions: 'Extensions',
     settings_plugins_title: 'Plugins',
     plugins_enable_toggle: 'Enable',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',
@@ -2162,6 +2163,7 @@ const LOCALES = {
     settings_tab_appearance: 'Aspetto',
     settings_tab_preferences: 'Preferenze',
     settings_tab_plugins: 'Plugin',
+    settings_tab_extensions: 'Extensions',  // TODO: translate
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: 'Abilita',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -3697,6 +3699,7 @@ const LOCALES = {
     settings_tab_appearance: '外観',
     settings_tab_preferences: '環境設定',
     settings_tab_plugins: 'プラグイン',
+    settings_tab_extensions: '拡張機能',
     settings_plugins_title: 'プラグイン',
     plugins_enable_toggle: '有効化',
     settings_plugins_meta: 'インストール済みのHermesプラグインと登録されているライフサイクルフックを確認できます。このパネルは読み取り専用です。',
@@ -5927,6 +5930,7 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Плагины',
+    settings_tab_extensions: 'Extensions',  // TODO: translate
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: 'Включить',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -7387,6 +7391,7 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
+    settings_tab_extensions: 'Extensions',
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: 'Activar',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -8532,6 +8537,7 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
+    settings_tab_extensions: 'Extensions',
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: 'Aktivieren',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -10342,6 +10348,7 @@ const LOCALES = {
     settings_tab_conversation: '对话',
     settings_tab_preferences: '偏好',
     settings_tab_plugins: '插件',
+    settings_tab_extensions: '扩展',
     settings_tab_system: '系统',
     settings_tab_help: 'Help',
     settings_help_meta: 'Resources and support for Hermes WebUI.',
@@ -11121,6 +11128,7 @@ const LOCALES = {
     settings_tab_appearance: '外觀',
     settings_tab_preferences: '偏好設定',
     settings_tab_plugins: '外掛',
+    settings_tab_extensions: '擴充功能',
     settings_plugins_title: '外掛',
     plugins_enable_toggle: '啟用',
     settings_plugins_meta: '檢視已安裝的 Hermes 外掛及其註冊的生命週期掛鉤。此面板為唯讀。',
@@ -12552,6 +12560,7 @@ const LOCALES = {
     settings_tab_appearance: 'Aparência',
     settings_tab_preferences: 'Preferências',
     settings_tab_plugins: 'Plugins',
+    settings_tab_extensions: 'Extensions',
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: 'Ativar',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -13989,6 +13998,7 @@ const LOCALES = {
     settings_tab_appearance: '외형',
     settings_tab_preferences: '환경설정',
     settings_tab_plugins: '플러그인',
+    settings_tab_extensions: 'Extensions',  // TODO: translate
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: '활성화',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -15448,6 +15458,7 @@ const LOCALES = {
     settings_tab_appearance: 'Apparence',
     settings_tab_preferences: 'Préférences',
     settings_tab_plugins: 'Plugins',
+    settings_tab_extensions: 'Extensions',
     settings_plugins_title: 'Plugins',  // TODO: translate
     plugins_enable_toggle: 'Activer',
     settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
@@ -17001,6 +17012,7 @@ const LOCALES = {
     settings_tab_appearance: 'Dış görünüş',
     settings_tab_preferences: 'Tercihler',
     settings_tab_plugins: 'Eklentiler',
+    settings_tab_extensions: 'Extensions',  // TODO: translate
     settings_plugins_title: 'Eklentiler',
     plugins_enable_toggle: 'Etkinleştir',
     settings_plugins_meta: 'Yüklü Hermes eklentilerini ve yaşam döngüsü kancalarını görüntüleyin. Bu panel salt okunurdur.',
@@ -18550,6 +18562,7 @@ const LOCALES = {
     settings_tab_appearance: 'Wygląd',
     settings_tab_preferences: 'Preferencje',
     settings_tab_plugins: 'Wtyczki',
+    settings_tab_extensions: 'Extensions',  // TODO: translate
     settings_plugins_title: 'Wtyczki',
     plugins_enable_toggle: 'Włącz',
     settings_plugins_meta: 'Zobacz zainstalowane wtyczki Hermes oraz rejestrowane przez nie haki cyklu życia. Ten panel jest tylko do odczytu.',

--- a/static/index.html
+++ b/static/index.html
@@ -378,6 +378,10 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2l3 7h7l-5.5 4.3 2.1 7L12 16.2 5.4 20.3l2.1-7L2 9h7z"/></svg>
           <span data-i18n="settings_tab_plugins">Plugins</span>
         </button>
+        <button type="button" class="side-menu-item" data-settings-section="extensions" onclick="switchSettingsSection('extensions')">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 2v6"/><path d="M15 2v6"/><path d="M7 8h10v4a5 5 0 0 1-10 0V8z"/><path d="M12 17v5"/></svg>
+          <span data-i18n="settings_tab_extensions">Extensions</span>
+        </button>
         <button type="button" class="side-menu-item" data-settings-section="system" onclick="switchSettingsSection('system')">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="3" width="20" height="8" rx="2"/><rect x="2" y="13" width="20" height="8" rx="2"/><line x1="6" y1="7" x2="6.01" y2="7"/><line x1="6" y1="17" x2="6.01" y2="17"/></svg>
           <span data-i18n="settings_tab_system">System</span>
@@ -1363,6 +1367,22 @@
             </div>
             <div id="pluginsEmpty" style="display:none;text-align:center;padding:32px 0;color:var(--muted);font-size:13px" data-i18n="settings_plugins_empty">
               No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.
+            </div>
+          </div>
+          <div class="settings-pane" id="settingsPaneExtensions">
+            <div class="settings-section-head">
+              <div>
+                <div class="settings-section-title" data-i18n="settings_tab_extensions">Extensions</div>
+                <div class="settings-section-meta">Read-only diagnostics for configured WebUI extensions.</div>
+              </div>
+              <button class="sm-btn extensions-copy-diagnostics-btn" id="extensionsCopyDiagnosticsBtn" type="button" onclick="copyExtensionsDiagnostics()" disabled>Copy diagnostics</button>
+            </div>
+            <div class="settings-field extensions-trust-note" id="extensionsTrustModel">
+              <label>Trust model</label>
+              <div>Extensions run in the WebUI browser origin and can access the same authenticated APIs as this session. Only load trusted local extension directories.</div>
+            </div>
+            <div id="extensionsDiagnostics" class="extensions-diagnostics" aria-live="polite">
+              <div class="extensions-loading">Loading extension diagnostics…</div>
             </div>
           </div>
           <div class="settings-pane" id="settingsPaneSystem">

--- a/static/panels.js
+++ b/static/panels.js
@@ -6222,6 +6222,7 @@ let _currentSettingsSection = 'conversation';
 let _settingsIndex = null;
 let _settingsIndexPromise = null;
 let _settingsSearchSeq = 0;
+let _extensionsStatusData = null;
 let _settingsSearchDismissListenerRegistered = false;
 let _settingsAppearanceAutosaveTimer = null;
 let _settingsAppearanceAutosaveRetryPayload = null;
@@ -6420,7 +6421,7 @@ function switchSettingsSection(name,opts){
     _settingsSection = name;
     return;
   }
-  let section=(name==='appearance'||name==='preferences'||name==='providers'||name==='plugins'||name==='system'||name==='help')?name:'conversation';
+  let section=(name==='appearance'||name==='preferences'||name==='providers'||name==='plugins'||name==='extensions'||name==='system'||name==='help')?name:'conversation';
   // Deep-linking to the Plugins pane when the tab is hidden (no plugins
   // installed, #3457) falls back to Conversation. Resolve this BEFORE toggling
   // panes/sidebar/dropdown below so every downstream selection uses the
@@ -6432,13 +6433,13 @@ function switchSettingsSection(name,opts){
   }
   _settingsSection=section;
   _currentSettingsSection=section;
-  const map={conversation:'Conversation',appearance:'Appearance',preferences:'Preferences',providers:'Providers',plugins:'Plugins',system:'System',help:'Help'};
+  const map={conversation:'Conversation',appearance:'Appearance',preferences:'Preferences',providers:'Providers',plugins:'Plugins',extensions:'Extensions',system:'System',help:'Help'};
   // Sidebar menu items
   document.querySelectorAll('#settingsMenu .side-menu-item').forEach(it=>{
     it.classList.toggle('active', it.dataset.settingsSection===section);
   });
   // Panes in main
-  ['conversation','appearance','preferences','providers','plugins','system','help'].forEach(key=>{
+  ['conversation','appearance','preferences','providers','plugins','extensions','system','help'].forEach(key=>{
     const pane=$('settingsPane'+map[key]);
     if(pane) pane.classList.toggle('active', key===section);
   });
@@ -6451,6 +6452,7 @@ function switchSettingsSection(name,opts){
   if(!(opts&&opts.skipLazyLoad)){
     if(section==='providers') loadProvidersPanel();
     if(section==='plugins') loadPluginsPanel();
+    if(section==='extensions') loadExtensionsPanel();
   }
 }
 
@@ -6461,7 +6463,7 @@ async function _buildSettingsIndex() {
   if (_settingsIndexPromise) return _settingsIndexPromise;
   const promise = (async () => {
     // Ensure lazy-loaded panes are populated before reading the DOM
-    await Promise.all([loadProvidersPanel(), loadPluginsPanel()]);
+    await Promise.all([loadProvidersPanel(), loadPluginsPanel(), loadExtensionsPanel()]);
     const index = [];
     const sectionMap = {
       settingsPaneConversation: 'conversation',
@@ -6469,6 +6471,7 @@ async function _buildSettingsIndex() {
       settingsPanePreferences: 'preferences',
       settingsPaneProviders: 'providers',
       settingsPanePlugins: 'plugins',
+      settingsPaneExtensions: 'extensions',
       settingsPaneSystem: 'system',
       settingsPaneHelp: 'help',
     };
@@ -6529,6 +6532,7 @@ async function filterSettings(query) {
     preferences: t('settings_tab_preferences') || 'Preferences',
     providers: t('providers_tab_title') || 'Providers',
     plugins: t('settings_tab_plugins') || 'Plugins',
+    extensions: t('settings_tab_extensions') || 'Extensions',
     system: t('settings_tab_system') || 'System',
     help: t('settings_tab_help') || 'Help',
   };
@@ -6582,6 +6586,7 @@ function _resolveSettingsField(entry) {
     preferences: 'settingsPanePreferences',
     providers: 'settingsPaneProviders',
     plugins: 'settingsPanePlugins',
+    extensions: 'settingsPaneExtensions',
     system: 'settingsPaneSystem',
     help: 'settingsPaneHelp',
   };
@@ -7488,9 +7493,142 @@ async function loadSettingsPanel(){
     if(typeof loadDashboardSettings==='function') loadDashboardSettings();
     loadProvidersPanel(); // load provider cards in background
     loadPluginsPanel(); // load plugin/hook visibility in background
+    loadExtensionsPanel(); // load extension diagnostics in background
     switchSettingsSection(_settingsSection);
   }catch(e){
     showToast(t('settings_load_failed')+e.message);
+  }
+}
+
+
+// ── Extensions panel (read-only browser-origin diagnostics) ────────────────
+
+function _extensionStatusLabel(value){
+  return value ? 'Enabled' : 'Disabled';
+}
+
+function _extensionBooleanBadge(value){
+  const cls=value?'extension-status-badge-on':'extension-status-badge-off';
+  return `<span class="extension-status-badge ${cls}">${value?'true':'false'}</span>`;
+}
+
+function _extensionAssetList(urls){
+  if(!Array.isArray(urls)||urls.length===0){
+    return '<div class="extension-url-empty">None</div>';
+  }
+  return '<ul class="extension-url-list">'+urls.map(url=>`<li><code>${esc(url)}</code></li>`).join('')+'</ul>';
+}
+
+function _extensionWarningList(warnings){
+  if(!Array.isArray(warnings)||warnings.length===0){
+    return '<div class="extension-url-empty">No warnings.</div>';
+  }
+  return '<ul class="extension-warning-list">'+warnings.map(item=>{
+    const code=esc((item&&item.code)||'unknown_warning');
+    const source=esc((item&&item.source)||'unknown');
+    return `<li><code>${code}</code><span>${source}</span></li>`;
+  }).join('')+'</ul>';
+}
+
+function _extensionCountValue(counts,key,urls){
+  if(counts&&Number.isFinite(Number(counts[key]))) return Number(counts[key]);
+  return Array.isArray(urls)?urls.length:0;
+}
+
+function _renderExtensionsPanel(data){
+  const target=$('extensionsDiagnostics');
+  const copyBtn=$('extensionsCopyDiagnosticsBtn');
+  if(!target) return;
+  _extensionsStatusData=data||null;
+  if(copyBtn) copyBtn.disabled=!data;
+  const manifest=(data&&data.manifest)||{};
+  const counts=(data&&data.counts)||{};
+  const scripts=Array.isArray(data&&data.script_urls)?data.script_urls:[];
+  const styles=Array.isArray(data&&data.stylesheet_urls)?data.stylesheet_urls:[];
+  const statusClass=(data&&data.enabled)?'extension-card-enabled':'extension-card-disabled';
+  const scriptCount=_extensionCountValue(counts,'script_urls',scripts);
+  const styleCount=_extensionCountValue(counts,'stylesheet_urls',styles);
+  target.innerHTML=`
+    <div class="provider-card extension-status-card ${statusClass}">
+      <div class="provider-card-header plugin-card-header">
+        <div class="provider-card-info">
+          <div class="provider-card-name">Extension runtime</div>
+          <div class="provider-card-meta">Read-only status from /api/extensions/status</div>
+        </div>
+        <span class="provider-card-badge ${data&&data.enabled?'':'plugin-card-badge-disabled'}">${_extensionStatusLabel(!!(data&&data.enabled))}</span>
+      </div>
+      <div class="provider-card-body extension-card-body">
+        <div class="extension-summary-grid">
+          <div><span>Extension dir configured</span>${_extensionBooleanBadge(!!(data&&data.extension_dir_configured))}</div>
+          <div><span>Extension dir valid</span>${_extensionBooleanBadge(!!(data&&data.extension_dir_valid))}</div>
+          <div><span>Manifest configured</span>${_extensionBooleanBadge(!!manifest.configured)}</div>
+          <div><span>Manifest loaded</span>${_extensionBooleanBadge(!!manifest.loaded)}</div>
+          <div><span>Manifest status</span><code>${esc(manifest.status||'unknown')}</code></div>
+          <div><span>Manifest entries inspected</span><code>${Number(manifest.entry_count)||0}</code></div>
+          <div><span>Manifest script count</span><code>${Number(manifest.script_count)||0}</code></div>
+          <div><span>Manifest stylesheet count</span><code>${Number(manifest.stylesheet_count)||0}</code></div>
+          <div><span>Final script count</span><code>${scriptCount}</code></div>
+          <div><span>Final stylesheet count</span><code>${styleCount}</code></div>
+        </div>
+      </div>
+    </div>
+    <div class="provider-card extension-assets-card">
+      <div class="provider-card-header plugin-card-header">
+        <div class="provider-card-info">
+          <div class="provider-card-name">Final public asset URLs</div>
+          <div class="provider-card-meta">Same-origin URLs that may be injected into the app shell.</div>
+        </div>
+      </div>
+      <div class="provider-card-body extension-card-body">
+        <div class="provider-card-label">Scripts</div>
+        ${_extensionAssetList(scripts)}
+        <div class="provider-card-label extension-section-label">Stylesheets</div>
+        ${_extensionAssetList(styles)}
+      </div>
+    </div>
+    <div class="provider-card extension-warnings-card">
+      <div class="provider-card-header plugin-card-header">
+        <div class="provider-card-info">
+          <div class="provider-card-name">Sanitized warnings</div>
+          <div class="provider-card-meta">Codes and coarse sources only; paths and rejected values are not shown.</div>
+        </div>
+      </div>
+      <div class="provider-card-body extension-card-body">
+        ${_extensionWarningList(data&&data.warnings)}
+      </div>
+    </div>
+  `;
+}
+
+async function loadExtensionsPanel(){
+  const target=$('extensionsDiagnostics');
+  const copyBtn=$('extensionsCopyDiagnosticsBtn');
+  if(!target) return;
+  if(copyBtn) copyBtn.disabled=true;
+  target.innerHTML='<div class="extensions-loading">Loading extension diagnostics…</div>';
+  try{
+    const data=await api('/api/extensions/status');
+    _renderExtensionsPanel(data);
+  }catch(e){
+    _extensionsStatusData=null;
+    if(copyBtn) copyBtn.disabled=true;
+    target.innerHTML='<div class="extensions-error">Failed to load extension diagnostics: '+esc(e.message||String(e))+'</div>';
+  }
+}
+
+async function copyExtensionsDiagnostics(){
+  if(!_extensionsStatusData) return;
+  const text=JSON.stringify(_extensionsStatusData,null,2);
+  const success=()=>showToast(t('copied')||'Copied!');
+  const fail=()=>showToast(t('copy_failed')||'Copy failed');
+  if(typeof _copyText==='function'){
+    _copyText(text).then(success).catch(fail);
+    return;
+  }
+  if(typeof navigator!=='undefined'&&navigator&&navigator.clipboard&&navigator.clipboard.writeText){
+    navigator.clipboard.writeText(text).then(success).catch(fail);
+  }else{
+    fail();
   }
 }
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -6223,6 +6223,7 @@ let _settingsIndex = null;
 let _settingsIndexPromise = null;
 let _settingsSearchSeq = 0;
 let _extensionsStatusData = null;
+let _extensionsSidecarMonitorSeq = 0;
 let _settingsSearchDismissListenerRegistered = false;
 let _settingsAppearanceAutosaveTimer = null;
 let _settingsAppearanceAutosaveRetryPayload = null;
@@ -7535,6 +7536,84 @@ function _extensionCountValue(counts,key,urls){
   return Array.isArray(urls)?urls.length:0;
 }
 
+function _extensionSidecarHealthBadge(status,label){
+  const safeStatus=['checking','healthy','unhealthy','blocked'].includes(status)?status:'checking';
+  return `<span class="extension-sidecar-status-badge extension-sidecar-status-${safeStatus}">${esc(label||safeStatus)}</span>`;
+}
+
+function _extensionSidecarCard(sidecars){
+  const list=Array.isArray(sidecars)?sidecars:[];
+  const body=list.length?`<div class="extension-sidecar-list">${list.map((sidecar,index)=>{
+    const id=(sidecar&&sidecar.id)||'';
+    const name=(sidecar&&sidecar.name)||'';
+    const title=name||id||'Unnamed extension';
+    const meta=(name&&id)?id:(sidecar&&sidecar.type)||'loopback';
+    const origin=(sidecar&&sidecar.origin)||'';
+    const healthPath=(sidecar&&sidecar.health_path)||'';
+    const healthUrl=(sidecar&&sidecar.health_url)||'';
+    return `<div class="extension-sidecar-row" data-sidecar-index="${index}">
+      <div class="extension-sidecar-row-head">
+        <div class="extension-sidecar-title">${esc(title)}</div>
+        <span id="extensionSidecarHealth${index}" data-sidecar-health-index="${index}">${_extensionSidecarHealthBadge('checking','checking')}</span>
+      </div>
+      <div class="extension-sidecar-meta">${esc(meta)}</div>
+      <div class="extension-sidecar-fields">
+        <div><span>Origin</span><code>${esc(origin)}</code></div>
+        <div><span>Health path</span><code>${esc(healthPath)}</code></div>
+        <div><span>Health URL</span><code>${esc(healthUrl)}</code></div>
+      </div>
+    </div>`;
+  }).join('')}</div>`:'<div class="extension-url-empty">No loopback sidecars declared.</div>';
+  return `
+    <div class="provider-card extension-sidecars-card">
+      <div class="provider-card-header plugin-card-header">
+        <div class="provider-card-info">
+          <div class="provider-card-name">Loopback sidecars</div>
+          <div class="provider-card-meta">Declared local companions; health is checked directly from this browser with WebUI credentials omitted.</div>
+        </div>
+      </div>
+      <div class="provider-card-body extension-card-body">
+        ${body}
+      </div>
+    </div>`;
+}
+
+function _setExtensionSidecarHealth(index,status,label){
+  const el=document.querySelector(`[data-sidecar-health-index="${index}"]`);
+  if(el) el.innerHTML=_extensionSidecarHealthBadge(status,label);
+}
+
+async function _checkExtensionSidecarHealth(sidecar,index,seq){
+  const healthUrl=sidecar&&sidecar.health_url;
+  if(!healthUrl){
+    _setExtensionSidecarHealth(index,'blocked','unreachable / blocked');
+    return;
+  }
+  let controller=null;
+  let timeoutId=null;
+  try{
+    if(typeof AbortController!=='undefined'){
+      controller=new AbortController();
+      timeoutId=setTimeout(()=>controller.abort(),2500);
+    }
+    const res=await fetch(healthUrl,{credentials:'omit',cache:'no-store',signal:controller?controller.signal:undefined});
+    if(seq!==_extensionsSidecarMonitorSeq) return;
+    if(res.ok) _setExtensionSidecarHealth(index,'healthy','healthy');
+    else _setExtensionSidecarHealth(index,'unhealthy','unhealthy');
+  }catch(_e){
+    if(seq!==_extensionsSidecarMonitorSeq) return;
+    _setExtensionSidecarHealth(index,'blocked','unreachable / blocked');
+  }finally{
+    if(timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+function _monitorExtensionSidecars(sidecars){
+  const seq=_extensionsSidecarMonitorSeq;
+  if(!Array.isArray(sidecars)||sidecars.length===0) return;
+  sidecars.forEach((sidecar,index)=>_checkExtensionSidecarHealth(sidecar,index,seq));
+}
+
 function _renderExtensionsPanel(data){
   const target=$('extensionsDiagnostics');
   const copyBtn=$('extensionsCopyDiagnosticsBtn');
@@ -7545,9 +7624,11 @@ function _renderExtensionsPanel(data){
   const counts=(data&&data.counts)||{};
   const scripts=Array.isArray(data&&data.script_urls)?data.script_urls:[];
   const styles=Array.isArray(data&&data.stylesheet_urls)?data.stylesheet_urls:[];
+  const sidecars=Array.isArray(data&&data.sidecars)?data.sidecars:[];
   const statusClass=(data&&data.enabled)?'extension-card-enabled':'extension-card-disabled';
   const scriptCount=_extensionCountValue(counts,'script_urls',scripts);
   const styleCount=_extensionCountValue(counts,'stylesheet_urls',styles);
+  const sidecarCount=_extensionCountValue(counts,'sidecars',sidecars);
   target.innerHTML=`
     <div class="provider-card extension-status-card ${statusClass}">
       <div class="provider-card-header plugin-card-header">
@@ -7567,8 +7648,10 @@ function _renderExtensionsPanel(data){
           <div><span>Manifest entries inspected</span><code>${Number(manifest.entry_count)||0}</code></div>
           <div><span>Manifest script count</span><code>${Number(manifest.script_count)||0}</code></div>
           <div><span>Manifest stylesheet count</span><code>${Number(manifest.stylesheet_count)||0}</code></div>
+          <div><span>Manifest sidecar count</span><code>${Number(manifest.sidecar_count)||0}</code></div>
           <div><span>Final script count</span><code>${scriptCount}</code></div>
           <div><span>Final stylesheet count</span><code>${styleCount}</code></div>
+          <div><span>Loopback sidecar count</span><code>${sidecarCount}</code></div>
         </div>
       </div>
     </div>
@@ -7586,6 +7669,7 @@ function _renderExtensionsPanel(data){
         ${_extensionAssetList(styles)}
       </div>
     </div>
+    ${_extensionSidecarCard(sidecars)}
     <div class="provider-card extension-warnings-card">
       <div class="provider-card-header plugin-card-header">
         <div class="provider-card-info">
@@ -7598,6 +7682,7 @@ function _renderExtensionsPanel(data){
       </div>
     </div>
   `;
+  _monitorExtensionSidecars(sidecars);
 }
 
 async function loadExtensionsPanel(){
@@ -7605,6 +7690,7 @@ async function loadExtensionsPanel(){
   const copyBtn=$('extensionsCopyDiagnosticsBtn');
   if(!target) return;
   if(copyBtn) copyBtn.disabled=true;
+  ++_extensionsSidecarMonitorSeq;
   target.innerHTML='<div class="extensions-loading">Loading extension diagnostics…</div>';
   try{
     const data=await api('/api/extensions/status');

--- a/static/style.css
+++ b/static/style.css
@@ -4570,6 +4570,33 @@ main.main > #mainPlugin{display:none;}
 .plugin-open-btn{display:inline-flex;align-items:center;gap:6px;padding:6px 14px;background:transparent;color:var(--accent);border:1px solid var(--accent);border-radius:7px;font-size:13px;font-weight:600;cursor:pointer;text-decoration:none;}
 .plugin-open-btn:hover{background:var(--accent);color:var(--bg);}
 
+/* ── Extension diagnostics cards ── */
+.extensions-copy-diagnostics-btn{white-space:nowrap;}
+.extensions-copy-diagnostics-btn:disabled{opacity:.45;cursor:not-allowed;}
+.extensions-trust-note{border-color:rgba(245,158,11,.35)!important;background:rgba(245,158,11,.08)!important;}
+#mainSettings .extensions-trust-note > label{color:var(--text);font-size:13px;font-weight:600;}
+.extensions-diagnostics{display:flex;flex-direction:column;gap:12px;margin-top:4px;}
+.extensions-loading,.extensions-error{padding:12px 14px;border:1px solid var(--border);border-radius:10px;background:var(--sidebar);font-size:13px;color:var(--muted);}
+.extensions-error{color:var(--error);border-color:color-mix(in srgb,var(--error) 35%,var(--border));}
+.extension-card-body{display:block;}
+.extension-summary-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px;}
+.extension-summary-grid>div{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:8px 10px;border:1px solid var(--border);border-radius:8px;background:var(--surface);font-size:12px;color:var(--muted);min-width:0;}
+.extension-summary-grid span{min-width:0;overflow-wrap:anywhere;}
+.extension-summary-grid code{font-family:var(--font-mono);font-size:11px;color:var(--text);background:var(--code-bg);border:1px solid var(--border2);border-radius:5px;padding:2px 6px;overflow-wrap:anywhere;}
+.extension-status-badge{display:inline-flex;align-items:center;border-radius:999px;padding:2px 7px;font-size:10.5px;font-weight:700;font-family:var(--font-mono);line-height:1.45;}
+.extension-status-badge-on{background:rgba(34,197,94,.14);color:#22c55e;}
+.extension-status-badge-off{background:var(--code-bg);color:var(--muted);}
+.extension-section-label{margin-top:14px;}
+.extension-url-list,.extension-warning-list{list-style:none;margin:6px 0 0 0;padding:0;display:flex;flex-direction:column;gap:6px;}
+.extension-url-list li,.extension-warning-list li{display:flex;align-items:center;gap:8px;min-width:0;padding:7px 9px;border:1px solid var(--border);border-radius:8px;background:var(--surface);font-size:12px;color:var(--muted);}
+.extension-url-list code,.extension-warning-list code{font-family:var(--font-mono);font-size:11px;color:var(--text);overflow-wrap:anywhere;word-break:break-word;}
+.extension-warning-list span{font-size:11px;color:var(--muted);overflow-wrap:anywhere;}
+.extension-url-empty{margin-top:6px;font-size:12px;color:var(--muted);font-style:italic;}
+@media (max-width: 768px){
+  .extensions-copy-diagnostics-btn{width:100%;}
+  .extension-summary-grid{grid-template-columns:1fr;}
+}
+
 /* ── Provider model tags ── */
 .provider-card-models{
   margin-bottom:10px;

--- a/static/style.css
+++ b/static/style.css
@@ -4592,9 +4592,25 @@ main.main > #mainPlugin{display:none;}
 .extension-url-list code,.extension-warning-list code{font-family:var(--font-mono);font-size:11px;color:var(--text);overflow-wrap:anywhere;word-break:break-word;}
 .extension-warning-list span{font-size:11px;color:var(--muted);overflow-wrap:anywhere;}
 .extension-url-empty{margin-top:6px;font-size:12px;color:var(--muted);font-style:italic;}
+.extension-sidecar-list{display:flex;flex-direction:column;gap:8px;}
+.extension-sidecar-row{padding:9px 10px;border:1px solid var(--border);border-radius:8px;background:var(--surface);min-width:0;}
+.extension-sidecar-row-head{display:flex;align-items:center;justify-content:space-between;gap:10px;min-width:0;}
+.extension-sidecar-title{font-size:13px;font-weight:600;color:var(--text);overflow-wrap:anywhere;min-width:0;}
+.extension-sidecar-meta{margin-top:2px;font-size:11px;color:var(--muted);overflow-wrap:anywhere;}
+.extension-sidecar-fields{display:grid;grid-template-columns:1fr;gap:5px;margin-top:8px;}
+.extension-sidecar-fields>div{display:flex;align-items:flex-start;gap:8px;min-width:0;font-size:12px;color:var(--muted);}
+.extension-sidecar-fields span{flex:0 0 82px;}
+.extension-sidecar-fields code{font-family:var(--font-mono);font-size:11px;color:var(--text);overflow-wrap:anywhere;word-break:break-word;}
+.extension-sidecar-status-badge{display:inline-flex;align-items:center;white-space:nowrap;border-radius:999px;padding:2px 7px;font-size:10.5px;font-weight:700;font-family:var(--font-mono);line-height:1.45;background:var(--code-bg);color:var(--muted);}
+.extension-sidecar-status-healthy{background:rgba(34,197,94,.14);color:#22c55e;}
+.extension-sidecar-status-unhealthy{background:rgba(245,158,11,.14);color:#f59e0b;}
+.extension-sidecar-status-blocked{background:rgba(239,68,68,.14);color:var(--error);}
 @media (max-width: 768px){
   .extensions-copy-diagnostics-btn{width:100%;}
   .extension-summary-grid{grid-template-columns:1fr;}
+  .extension-sidecar-row-head{align-items:flex-start;flex-direction:column;}
+  .extension-sidecar-fields>div{flex-direction:column;gap:2px;}
+  .extension-sidecar-fields span{flex:0 0 auto;}
 }
 
 /* ── Provider model tags ── */

--- a/tests/test_extension_status_endpoint.py
+++ b/tests/test_extension_status_endpoint.py
@@ -58,7 +58,8 @@ def test_extension_status_disabled_by_default():
         "extension_dir_valid": False,
         "script_urls": [],
         "stylesheet_urls": [],
-        "counts": {"script_urls": 0, "stylesheet_urls": 0},
+        "sidecars": [],
+        "counts": {"script_urls": 0, "stylesheet_urls": 0, "sidecars": 0},
         "manifest": {
             "configured": False,
             "loaded": False,
@@ -66,6 +67,7 @@ def test_extension_status_disabled_by_default():
             "entry_count": 0,
             "script_count": 0,
             "stylesheet_count": 0,
+            "sidecar_count": 0,
         },
         "warnings": [],
     }
@@ -124,7 +126,8 @@ def test_extension_status_reports_loaded_manifest_counts_and_urls(tmp_path, monk
         "/extensions/base.css",
         "/extensions/templates/app.css",
     ]
-    assert status["counts"] == {"script_urls": 3, "stylesheet_urls": 2}
+    assert status["sidecars"] == []
+    assert status["counts"] == {"script_urls": 3, "stylesheet_urls": 2, "sidecars": 0}
     assert status["manifest"] == {
         "configured": True,
         "loaded": True,
@@ -132,6 +135,7 @@ def test_extension_status_reports_loaded_manifest_counts_and_urls(tmp_path, monk
         "entry_count": 2,
         "script_count": 2,
         "stylesheet_count": 2,
+        "sidecar_count": 0,
     }
     assert status["warnings"] == []
 
@@ -163,6 +167,8 @@ def test_extension_status_ignores_non_dict_manifest_extensions_in_entry_count(
     assert status["script_urls"] == ["/extensions/templates/app.js"]
     assert status["manifest"]["entry_count"] == 2
     assert status["manifest"]["script_count"] == 1
+    assert status["manifest"]["sidecar_count"] == 0
+    assert status["sidecars"] == []
     assert status["warnings"] == []
 
 
@@ -330,6 +336,281 @@ def test_extension_status_reports_rejected_env_assets_without_rejected_values(tm
     rendered = repr(status)
     assert "evil.example" not in rendered
     assert "env.js" not in rendered
+
+
+def test_extension_status_reports_sanitized_loopback_sidecars(tmp_path, monkeypatch):
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "extensions.json").write_text(
+        """
+        {
+          "extensions": [
+            {
+              "id": "desktop-companion",
+              "name": "Desktop Companion",
+              "scripts": ["companion-adapter.js"],
+              "stylesheets": ["companion-adapter.css"],
+              "sidecar": {
+                "type": "loopback",
+                "origin": "http://127.0.0.1:17787",
+                "health_path": "/health"
+              }
+            },
+            {
+              "id": "implicit-health",
+              "sidecar": {
+                "type": "loopback",
+                "origin": "http://localhost:17788"
+              }
+            },
+            {
+              "id": "ipv6-loopback",
+              "sidecar": {
+                "type": "loopback",
+                "origin": "http://[::1]:17789",
+                "health_path": "/ready"
+              }
+            }
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import get_extension_status
+
+    status = get_extension_status()
+    assert status["script_urls"] == ["/extensions/companion-adapter.js"]
+    assert status["stylesheet_urls"] == ["/extensions/companion-adapter.css"]
+    assert status["sidecars"] == [
+        {
+            "id": "desktop-companion",
+            "name": "Desktop Companion",
+            "type": "loopback",
+            "origin": "http://127.0.0.1:17787",
+            "health_path": "/health",
+            "health_url": "http://127.0.0.1:17787/health",
+        },
+        {
+            "id": "implicit-health",
+            "name": "",
+            "type": "loopback",
+            "origin": "http://localhost:17788",
+            "health_path": "/health",
+            "health_url": "http://localhost:17788/health",
+        },
+        {
+            "id": "ipv6-loopback",
+            "name": "",
+            "type": "loopback",
+            "origin": "http://[::1]:17789",
+            "health_path": "/ready",
+            "health_url": "http://[::1]:17789/ready",
+        },
+    ]
+    assert status["counts"]["sidecars"] == 3
+    assert status["manifest"]["sidecar_count"] == 3
+    assert status["warnings"] == []
+
+
+def test_extension_status_skips_disabled_sidecar_entries(tmp_path, monkeypatch):
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "extensions.json").write_text(
+        """
+        {
+          "extensions": [
+            {
+              "id": "off",
+              "enabled": false,
+              "sidecar": {"type": "loopback", "origin": "http://127.0.0.1:17787"}
+            }
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import get_extension_status
+
+    status = get_extension_status()
+    assert status["sidecars"] == []
+    # The top-level manifest object is still inspected; the disabled extension
+    # entry is skipped and must not contribute a sidecar.
+    assert status["manifest"]["entry_count"] == 1
+    assert status["manifest"]["sidecar_count"] == 0
+    assert status["warnings"] == []
+
+
+def test_extension_status_rejects_non_loopback_sidecars_without_raw_value_leak(tmp_path, monkeypatch):
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "extensions.json").write_text(
+        """
+        {
+          "extensions": [
+            {
+              "id": "bad-origin",
+              "sidecar": {
+                "type": "loopback",
+                "origin": "http://10.0.0.5:17787",
+                "health_path": "/health"
+              }
+            }
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import get_extension_status
+
+    status = get_extension_status()
+    assert status["sidecars"] == []
+    assert status["manifest"]["sidecar_count"] == 0
+    assert status["warnings"] == [
+        {"code": "sidecar_origin_rejected", "source": "manifest:sidecars"}
+    ]
+    rendered = repr(status)
+    assert "10.0.0.5" not in rendered
+    assert "17787" not in rendered
+
+
+def test_extension_status_rejects_invalid_sidecar_health_path_without_leak(tmp_path, monkeypatch):
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "extensions.json").write_text(
+        """
+        {
+          "extensions": [
+            {
+              "id": "bad-health",
+              "sidecar": {
+                "type": "loopback",
+                "origin": "http://127.0.0.1:17787",
+                "health_path": "/../secret-health"
+              }
+            }
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import get_extension_status
+
+    status = get_extension_status()
+    assert status["sidecars"] == []
+    assert status["manifest"]["sidecar_count"] == 0
+    assert status["warnings"] == [
+        {"code": "sidecar_health_path_rejected", "source": "manifest:sidecars"}
+    ]
+    assert "secret-health" not in repr(status)
+
+
+def test_extension_status_rejects_decoded_whitespace_sidecar_health_path(tmp_path, monkeypatch):
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "extensions.json").write_text(
+        """
+        {
+          "extensions": [
+            {
+              "id": "bad-health-space",
+              "sidecar": {
+                "type": "loopback",
+                "origin": "http://127.0.0.1:17787",
+                "health_path": "/health%20check"
+              }
+            }
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import get_extension_status
+
+    status = get_extension_status()
+    assert status["sidecars"] == []
+    assert status["warnings"] == [
+        {"code": "sidecar_health_path_rejected", "source": "manifest:sidecars"}
+    ]
+    rendered = repr(status)
+    assert "health check" not in rendered
+    assert "health%20check" not in rendered
+
+
+def test_extension_status_rejects_unsupported_sidecar_type_without_origin_probe(tmp_path, monkeypatch):
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "extensions.json").write_text(
+        """
+        {
+          "extensions": [
+            {
+              "id": "unsupported",
+              "sidecar": {"type": "unix-socket", "origin": "http://127.0.0.1:17787"}
+            }
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import get_extension_status
+
+    status = get_extension_status()
+    assert status["sidecars"] == []
+    assert status["warnings"] == [
+        {"code": "sidecar_type_unsupported", "source": "manifest:sidecars"}
+    ]
+
+
+def test_extension_status_truncates_many_sidecars_with_sanitized_warning(tmp_path, monkeypatch):
+    import json
+
+    root = tmp_path / "extensions"
+    root.mkdir()
+    entries = [
+        {
+            "id": f"sidecar-{index}",
+            "sidecar": {
+                "type": "loopback",
+                "origin": f"http://127.0.0.1:{18000 + index}",
+            },
+        }
+        for index in range(40)
+    ]
+    (root / "extensions.json").write_text(
+        json.dumps({"extensions": entries}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import get_extension_status
+
+    status = get_extension_status()
+    assert len(status["sidecars"]) == 32
+    assert status["counts"]["sidecars"] == 32
+    assert status["manifest"]["sidecar_count"] == 32
+    assert status["warnings"] == [
+        {"code": "sidecar_list_truncated", "source": "manifest:sidecars"}
+    ]
+
 
 
 def test_extension_status_route_is_wired(monkeypatch):

--- a/tests/test_extensions_settings_panel.py
+++ b/tests/test_extensions_settings_panel.py
@@ -1,0 +1,154 @@
+"""Regression tests for the read-only Settings → Extensions diagnostics panel."""
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).parent.parent
+INDEX_HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+I18N_JS = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
+DOCS_EXTENSIONS = (ROOT / "docs" / "EXTENSIONS.md").read_text(encoding="utf-8")
+
+
+def _function_block(name: str, *, extra: int = 2200) -> str:
+    start = PANELS_JS.find(f"function {name}")
+    assert start >= 0, f"{name} not found"
+    return PANELS_JS[start:start + extra]
+
+
+def _between(start_marker: str, end_marker: str) -> str:
+    start = PANELS_JS.find(start_marker)
+    assert start >= 0, f"{start_marker} not found"
+    end = PANELS_JS.find(end_marker, start)
+    assert end >= 0, f"{end_marker} not found after {start_marker}"
+    return PANELS_JS[start:end]
+
+
+def _locale_count() -> int:
+    return len(re.findall(r"^  (?:[A-Za-z_][A-Za-z0-9_]*|'[^']+'):\s*\{", I18N_JS, re.MULTILINE))
+
+
+def _locale_blocks() -> dict[str, str]:
+    matches = list(re.finditer(r"^  ((?:[A-Za-z_][A-Za-z0-9_]*|'[^']+')):\s*\{", I18N_JS, re.MULTILINE))
+    blocks = {}
+    for idx, match in enumerate(matches):
+        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(I18N_JS)
+        blocks[match.group(1)] = I18N_JS[match.start():end]
+    return blocks
+
+
+def _contains_post_method(block: str) -> bool:
+    """Return True when a JS block contains a method: 'POST' style mutation."""
+    return bool(re.search(r"\bmethod\s*:\s*([\"'`])POST\1", block))
+
+
+def test_settings_sidebar_has_extensions_section_and_pane():
+    assert 'data-settings-section="extensions"' in INDEX_HTML
+    assert "switchSettingsSection('extensions')" in INDEX_HTML
+    assert 'id="settingsPaneExtensions"' in INDEX_HTML
+    assert 'id="extensionsDiagnostics"' in INDEX_HTML
+    assert 'id="extensionsCopyDiagnosticsBtn"' in INDEX_HTML
+    assert 'data-i18n="settings_tab_extensions"' in INDEX_HTML
+
+
+def test_extensions_panel_is_read_only_and_warns_about_trust_model():
+    pane_start = INDEX_HTML.index('id="settingsPaneExtensions"')
+    pane_end = INDEX_HTML.index('id="settingsPaneSystem"', pane_start)
+    pane = INDEX_HTML[pane_start:pane_end]
+
+    assert "Read-only diagnostics" in pane
+    assert "Extensions run in the WebUI browser origin" in pane
+    assert "Only load trusted local extension directories" in pane
+    assert "copyExtensionsDiagnostics()" in pane
+    assert "saveSettings(" not in pane
+    assert "api('/api/settings'" not in pane
+    assert "type=\"checkbox\"" not in pane
+    assert "toggle" not in pane.lower()
+    assert "install" not in pane.lower()
+    assert "marketplace" not in pane.lower()
+
+
+def test_switch_settings_section_supports_extensions_lazy_load():
+    switch_block = _function_block("switchSettingsSection", extra=2300)
+
+    assert "name==='extensions'" in switch_block
+    assert "plugins:'Plugins',extensions:'Extensions'" in switch_block
+    assert "'plugins','extensions','system'" in switch_block.replace("\n", "")
+    assert "if(section==='extensions') loadExtensionsPanel();" in switch_block
+
+
+def test_settings_search_knows_extensions_pane():
+    build_block = _function_block("_buildSettingsIndex", extra=2600)
+    filter_block = _function_block("filterSettings", extra=1700)
+    resolve_block = _function_block("_resolveSettingsField", extra=1400)
+
+    assert "loadExtensionsPanel()" in build_block
+    assert "settingsPaneExtensions: 'extensions'" in build_block
+    assert "extensions: t('settings_tab_extensions') || 'Extensions'" in filter_block
+    assert "extensions: 'settingsPaneExtensions'" in resolve_block
+
+
+def test_extensions_panel_fetches_status_endpoint_only():
+    load_block = _function_block("loadExtensionsPanel", extra=900)
+
+    assert "api('/api/extensions/status')" in load_block
+    assert "api('/api/settings'" not in load_block
+    assert not _contains_post_method(load_block)
+    assert "extensions-error" in load_block
+
+
+def test_extensions_panel_renders_sanitized_status_payload():
+    render_block = _between("function _renderExtensionsPanel", "async function loadExtensionsPanel")
+    warning_block = _function_block("_extensionWarningList", extra=900)
+    asset_block = _function_block("_extensionAssetList", extra=500)
+
+    assert "extension_dir_configured" in render_block
+    assert "extension_dir_valid" in render_block
+    assert "manifest.status" in render_block
+    assert "manifest.entry_count" in render_block
+    assert "manifest.script_count" in render_block
+    assert "manifest.stylesheet_count" in render_block
+    assert "script_urls" in render_block
+    assert "stylesheet_urls" in render_block
+    assert "data&&data.warnings" in render_block
+    assert "esc(url)" in asset_block
+    assert "esc(manifest.status||'unknown')" in render_block
+    assert "esc((item&&item.code)||'unknown_warning')" in warning_block
+    assert "esc((item&&item.source)||'unknown')" in warning_block
+    assert "Rejected" not in render_block  # rejected values must never be rendered directly
+
+
+def test_copy_extensions_diagnostics_copies_current_sanitized_payload():
+    copy_block = _between("function copyExtensionsDiagnostics", "// ── Plugins panel")
+
+    assert "JSON.stringify(_extensionsStatusData,null,2)" in copy_block
+    assert "navigator.clipboard.writeText(text)" in copy_block
+    assert "api('/api/settings'" not in copy_block
+    assert "api('/api/extensions'" not in copy_block
+    assert not _contains_post_method(copy_block)
+
+
+def test_extensions_styles_are_scoped_to_extensions_panel():
+    assert ".extensions-diagnostics" in STYLE_CSS
+    assert ".extensions-trust-note" in STYLE_CSS
+    assert ".extension-summary-grid" in STYLE_CSS
+    assert ".extension-warning-list" in STYLE_CSS
+    assert ".extension-url-list" in STYLE_CSS
+
+
+def test_extensions_tab_i18n_key_exists_for_all_locales():
+    blocks = _locale_blocks()
+
+    assert len(blocks) == _locale_count()
+    missing = [name for name, block in blocks.items() if "settings_tab_extensions" not in block]
+    assert not missing, f"Locale(s) missing settings_tab_extensions: {missing}"
+
+
+def test_extensions_docs_mentions_settings_panel_without_mutation_claims():
+    diagnostics_section = DOCS_EXTENSIONS[DOCS_EXTENSIONS.index("## Diagnostics"):]
+
+    assert "Settings → Extensions" in diagnostics_section
+    assert "enable, disable, install, or mutate extensions" in diagnostics_section
+    assert "`/api/extensions/status`" in diagnostics_section
+    assert "do **not** return" in diagnostics_section

--- a/tests/test_extensions_settings_panel.py
+++ b/tests/test_extensions_settings_panel.py
@@ -109,14 +109,38 @@ def test_extensions_panel_renders_sanitized_status_payload():
     assert "manifest.entry_count" in render_block
     assert "manifest.script_count" in render_block
     assert "manifest.stylesheet_count" in render_block
+    assert "manifest.sidecar_count" in render_block
     assert "script_urls" in render_block
     assert "stylesheet_urls" in render_block
+    assert "data&&data.sidecars" in render_block
+    assert "_extensionSidecarCard(sidecars)" in render_block
     assert "data&&data.warnings" in render_block
     assert "esc(url)" in asset_block
     assert "esc(manifest.status||'unknown')" in render_block
     assert "esc((item&&item.code)||'unknown_warning')" in warning_block
     assert "esc((item&&item.source)||'unknown')" in warning_block
     assert "Rejected" not in render_block  # rejected values must never be rendered directly
+
+
+def test_extensions_panel_renders_loopback_sidecar_monitor_safely():
+    sidecar_block = _between("function _extensionSidecarCard", "function _setExtensionSidecarHealth")
+    monitor_block = _between("async function _checkExtensionSidecarHealth", "function _renderExtensionsPanel")
+
+    assert "Loopback sidecars" in sidecar_block
+    assert "No loopback sidecars declared." in sidecar_block
+    assert "esc(title)" in sidecar_block
+    assert "esc(meta)" in sidecar_block
+    assert "esc(origin)" in sidecar_block
+    assert "esc(healthPath)" in sidecar_block
+    assert "esc(healthUrl)" in sidecar_block
+    assert "fetch(healthUrl,{credentials:'omit',cache:'no-store'" in monitor_block
+    assert "res.ok" in monitor_block
+    assert "res.text" not in monitor_block
+    assert "res.json" not in monitor_block
+    assert "api('/api/settings'" not in monitor_block
+    assert "api('/extensions/" not in monitor_block
+    assert "sidecar/*" not in monitor_block
+    assert not _contains_post_method(monitor_block)
 
 
 def test_copy_extensions_diagnostics_copies_current_sanitized_payload():
@@ -135,6 +159,8 @@ def test_extensions_styles_are_scoped_to_extensions_panel():
     assert ".extension-summary-grid" in STYLE_CSS
     assert ".extension-warning-list" in STYLE_CSS
     assert ".extension-url-list" in STYLE_CSS
+    assert ".extension-sidecar-list" in STYLE_CSS
+    assert ".extension-sidecar-status-badge" in STYLE_CSS
 
 
 def test_extensions_tab_i18n_key_exists_for_all_locales():
@@ -151,4 +177,8 @@ def test_extensions_docs_mentions_settings_panel_without_mutation_claims():
     assert "Settings → Extensions" in diagnostics_section
     assert "enable, disable, install, or mutate extensions" in diagnostics_section
     assert "`/api/extensions/status`" in diagnostics_section
-    assert "do **not** return" in diagnostics_section
+    assert "sanitized loopback sidecars" in diagnostics_section
+    assert "credentials: 'omit'" in diagnostics_section
+    assert "does **not** proxy sidecar requests" in diagnostics_section
+    assert "do **not**" in diagnostics_section
+    assert "return `HERMES_WEBUI_EXTENSION_DIR`" in diagnostics_section


### PR DESCRIPTION
> **Stacked PR:** this branch is based on `santastabber:extension-settings-diagnostics-panel` / PR #4588. Review this after or together with #4588; the intended incremental commit is `feat: surface loopback sidecar diagnostics`.

## Thinking Path

- Manifest-bundled extensions can already declare local assets and run trusted JavaScript in the WebUI browser origin.
- Sidecar-class extensions need an operator-visible way to confirm that their declared local companion service was parsed and reachable.
- This follow-up keeps the boundary narrow: it extends the existing read-only extension diagnostics/status surface and Settings panel, but does not add backend proxying, install/manage mutation, or new extension-owned server routes.

## What Changed

- Parse optional per-extension `sidecar` declarations from enabled manifest extension entries:
  - supports only `type: "loopback"`;
  - accepts only `http(s)` origins on `127.0.0.1`, `localhost`, or `[::1]`;
  - rejects userinfo, paths, queries, fragments, unsafe characters, external hosts, and malformed ports;
  - defaults missing `health_path` to `/health` and rejects unsafe explicit health paths.
- Add sanitized sidecar diagnostics to `GET /api/extensions/status`:
  - `sidecars[]` with `id`, `name`, `type`, `origin`, `health_path`, and `health_url`;
  - `counts.sidecars` and `manifest.sidecar_count`;
  - stable warning codes for rejected/unsupported/truncated sidecars without returning raw rejected origins or paths.
- Render a read-only **Loopback sidecars** card in Settings → Extensions.
- Check declared sidecar health directly from the browser with `fetch(health_url, { credentials: 'omit', cache: 'no-store' })` and a short timeout.
- Document the sidecar declaration shape, sanitization rules, and no-proxy/no-cookie boundary.

## Why It Matters

Operators can now see whether sidecar-class extensions such as Desktop Companion declared a local companion service correctly and whether the local health endpoint is reachable, without WebUI becoming a sidecar proxy or forwarding authenticated WebUI cookies to local helper processes.

## Verification

- `./scripts/test.sh tests/test_extension_status_endpoint.py tests/test_extensions_settings_panel.py -q`
  - Result: `33 passed`
- `python3 -m py_compile api/extensions.py tests/test_extension_status_endpoint.py tests/test_extensions_settings_panel.py`
- `node --check static/panels.js`
- `git diff --check`
- Isolated API/browser smoke with temporary WebUI state and a mock loopback sidecar:
  - `/health` returned `200`;
  - `/api/extensions/status` returned the accepted Desktop Companion sidecar with `health_url: http://127.0.0.1:17787/health`;
  - an external sidecar origin was rejected with only `sidecar_origin_rejected` / `manifest:sidecars` and no raw host/port/path leakage;
  - Settings → Extensions rendered the Loopback sidecars card and the health badge changed to `healthy`;
  - browser console probe reported no captured errors.

## Risks / Follow-ups

- Browser health checks depend on the sidecar allowing the browser request through CORS. A CORS/network/timeout failure is shown as unreachable/blocked; WebUI intentionally does not proxy the request.
- This does not start, install, enable, disable, or uninstall sidecars or extensions.
- The sidecar list is capped at the same defensive bound as extension asset URLs to keep diagnostics small.

## Contract Routing

Task type: extension diagnostics / trusted loopback sidecar visibility.

Touched areas:
- extension manifest diagnostics
- Settings → Extensions read-only diagnostics panel
- extension documentation
- extension security/static regression tests

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/EXTENSIONS.md`

Scope boundaries:
- Does not add extension backend routes.
- Does not proxy sidecar traffic through WebUI.
- Does not send WebUI credentials or cookies to sidecars.
- Does not add install, enable/disable, uninstall, marketplace, or dependency-system behavior.
- Does not expose local filesystem paths, raw env values, rejected sidecar origins, rejected health paths, or health response bodies.

Evidence needed before claiming done:
- focused extension endpoint/panel tests pass;
- syntax/static checks pass;
- isolated API/browser smoke confirms sanitized status and sidecar health rendering.

## Model Used

AI-assisted. Hermes Agent was used for implementation orchestration, and Claude Code was used for a read-only review pass before drafting the PR.