### PR TITLE
fix: prune orphaned api sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- **API-server imported sidecars are now pruned when their backing Agent session is gone (#4591).** Read-only API/Gateway sidecar rows no longer accumulate indefinitely in the sidebar after the corresponding `state.db` session is deleted outside WebUI, while native WebUI sessions remain protected.
-
 ## [v0.51.560] — 2026-06-21 — Release TS (recovered run-journal output reaches the model)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **API-server imported sidecars are now pruned when their backing Agent session is gone (#4591).** Read-only API/Gateway sidecar rows no longer accumulate indefinitely in the sidebar after the corresponding `state.db` session is deleted outside WebUI, while native WebUI sessions remain protected.
+
 ## [v0.51.560] — 2026-06-21 — Release TS (recovered run-journal output reaches the model)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -1827,12 +1827,12 @@ def _build_session_list_cache_payload(
         cli = get_cli_sessions(source_filter=source_filter, all_profiles=all_profiles)
         diag_stage("merge_cli_sessions")
         cli_by_id = {s["session_id"]: s for s in cli}
-        # #3238: reconcile orphaned imported-CLI sidecars. When a CLI
-        # session was clicked in WebUI it gets a WebUI-owned sidecar that
-        # all_sessions() returns independently of state.db. If the user
-        # later deletes the backing CLI session from the command line,
-        # the sidecar is never pruned and the stale row lingers in the
-        # sidebar forever (there is no WebUI delete affordance for it).
+        # #3238/#4591: reconcile orphaned imported sidecars. When a CLI or
+        # API-server session is clicked in WebUI it gets a WebUI-owned sidecar
+        # that all_sessions() returns independently of state.db. If the user
+        # later deletes the backing agent session outside WebUI, the sidecar is
+        # never pruned and the stale row lingers in the sidebar forever (there
+        # is no WebUI delete affordance for read-only imported rows).
         # Drop rows whose backing agent row is genuinely gone. We probe
         # state.db directly (agent_session_rows_existing) rather than trust
         # cli_by_id absence, because get_cli_sessions() caps at
@@ -1846,7 +1846,7 @@ def _build_session_list_cache_payload(
             _sid = s.get("session_id")
             if (
                 _sid
-                and is_cli_session_row(s)
+                and (is_cli_session_row(s) or _is_api_server_sidecar_row(s))
                 and not _session_source_is_webui(s)
                 and _sid not in cli_by_id
             ):
@@ -1879,11 +1879,11 @@ def _build_session_list_cache_payload(
                         prune_session_from_index(_sid)
                     except Exception:
                         logger.debug(
-                            "Failed to prune orphaned CLI sidecar %s",
+                            "Failed to prune orphaned agent sidecar %s",
                             _sid,
                             exc_info=True,
                         )
-                    diag_stage("prune_orphaned_cli_sidecar")
+                    diag_stage("prune_orphaned_agent_sidecar")
                     continue
                 _kept_after_orphan_prune.append(s)
         webui_sessions = _kept_after_orphan_prune
@@ -6093,6 +6093,24 @@ def _session_source_is_webui(session: dict) -> bool:
         if str(session.get(key) or "").strip().lower() == "webui":
             return True
     return False
+
+
+def _normalized_source_marker(value) -> str:
+    marker = str(value or "").strip().lower()
+    if marker.endswith(" session"):
+        marker = marker[:-len(" session")].strip()
+    return marker.replace("-", "_").replace(" ", "_")
+
+
+def _is_api_server_sidecar_row(session: dict) -> bool:
+    """Return True for API-server imported sidecars that need orphan pruning."""
+    if not isinstance(session, dict) or _session_source_is_webui(session):
+        return False
+    markers = {
+        _normalized_source_marker(session.get(key))
+        for key in ("source", "source_tag", "raw_source", "session_source", "source_label")
+    }
+    return bool(markers & {"api", "api_server"})
 
 
 def _session_lineage_ids(session: dict) -> set[str]:

--- a/tests/test_issue3238_orphaned_cli_sidecar_prune.py
+++ b/tests/test_issue3238_orphaned_cli_sidecar_prune.py
@@ -1,5 +1,8 @@
-"""Regression coverage for #3238 — WebUI does not sync when CLI sessions are
-deleted outside WebUI.
+"""Regression coverage for orphaned imported sidecar pruning.
+
+#3238: WebUI does not sync when CLI sessions are deleted outside WebUI.
+#4591: API-server sidecars are read-only and accumulated indefinitely after
+their backing state.db row was deleted.
 
 When a CLI/agent session is clicked in the WebUI sidebar it gets a WebUI-owned
 sidecar (`webui/sessions/<id>.json` + an `_index.json` row) so it can render and
@@ -8,9 +11,9 @@ be reopened. From then on `all_sessions()` returns it independently of the agent
 storage, nothing prunes the orphaned sidecar, so the stale row lingers in the
 sidebar forever — there is no WebUI delete affordance for CLI rows.
 
-The fix probes `state.db` directly via `agent_session_row_exists()` (an exact,
-uncapped existence check) and prunes the sidecar only when the backing row is
-genuinely gone. It must NOT rely on the session's presence in
+The fix probes `state.db` directly via `agent_session_rows_existing()` (an
+exact, uncapped existence check) and prunes the sidecar only when the backing
+row is genuinely gone. It must NOT rely on the session's presence in
 `get_cli_sessions()`, which caps at `CLI_VISIBLE_SESSION_LIMIT` (20) — an
 existing session can fall out of that window and look deleted.
 """
@@ -203,3 +206,101 @@ def test_cli_row_present_in_cli_by_id_is_not_pruned():
     row = {"session_id": "cli-live", "source_tag": "cli", "is_cli_session": True}
     cli_by_id = {"cli-live": {"session_id": "cli-live"}}
     assert _is_orphaned_cli_sidecar(row, cli_by_id, exists_fn=lambda sid: False) is False
+
+
+def _payload_for_rows(monkeypatch, rows, existing_ids):
+    import api.routes as routes
+
+    pruned = []
+
+    monkeypatch.setattr(routes, "all_sessions", lambda diag=None: list(rows))
+    monkeypatch.setattr(routes, "get_cli_sessions", lambda source_filter=None, all_profiles=False: [])
+    monkeypatch.setattr(
+        routes,
+        "_reconcile_stale_stream_state_for_session_rows",
+        lambda _sessions: False,
+    )
+    monkeypatch.setattr(
+        routes,
+        "agent_session_rows_existing",
+        lambda ids, profile=None: frozenset(existing_ids),
+    )
+    monkeypatch.setattr(routes, "prune_session_from_index", lambda sid: pruned.append(sid))
+
+    payload = routes._build_session_list_cache_payload(
+        active_profile="default",
+        all_profiles=False,
+        show_cli_sessions=True,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+    return payload, pruned
+
+
+def test_orphaned_api_server_sidecar_is_pruned_from_sidebar_payload(monkeypatch):
+    """API-server sidecars take the same exact state.db orphan prune path."""
+    row = {
+        "session_id": "api-orphan",
+        "title": "API Session",
+        "profile": "default",
+        "updated_at": 20,
+        "last_message_at": 20,
+        "message_count": 2,
+        "read_only": True,
+        "source_tag": "api_server",
+        "raw_source": "api_server",
+        "session_source": "api",
+        "source_label": "API",
+        "is_cli_session": False,
+    }
+
+    payload, pruned = _payload_for_rows(monkeypatch, [row], existing_ids=[])
+
+    assert [session["session_id"] for session in payload["sessions"]] == []
+    assert pruned == ["api-orphan"]
+
+
+def test_api_server_sidecar_with_backing_state_row_is_retained(monkeypatch):
+    """Absence from get_cli_sessions() alone is not enough to prune API rows."""
+    row = {
+        "session_id": "api-live",
+        "title": "API Session",
+        "profile": "default",
+        "updated_at": 20,
+        "last_message_at": 20,
+        "message_count": 2,
+        "read_only": True,
+        "source_tag": "api_server",
+        "raw_source": "api_server",
+        "session_source": "api",
+        "source_label": "API",
+        "is_cli_session": False,
+    }
+
+    payload, pruned = _payload_for_rows(monkeypatch, [row], existing_ids=["api-live"])
+
+    assert [session["session_id"] for session in payload["sessions"]] == ["api-live"]
+    assert pruned == []
+
+
+def test_webui_owned_session_with_api_metadata_is_not_pruned(monkeypatch):
+    """A native WebUI row must stay safe even if stale metadata mentions API."""
+    row = {
+        "session_id": "webui-native",
+        "title": "Native WebUI",
+        "profile": "default",
+        "updated_at": 20,
+        "last_message_at": 20,
+        "message_count": 2,
+        "read_only": False,
+        "source_tag": "webui",
+        "raw_source": "api_server",
+        "session_source": "webui",
+        "source_label": "API",
+        "is_cli_session": False,
+    }
+
+    payload, pruned = _payload_for_rows(monkeypatch, [row], existing_ids=[])
+
+    assert [session["session_id"] for session in payload["sessions"]] == ["webui-native"]
+    assert pruned == []


### PR DESCRIPTION
## Thinking Path

Fixes #4591.

The #3238 orphan-prune path only probed rows classified as CLI sessions. API-server sidecars are intentionally excluded from `is_cli_session_row()`, so they were retained forever after the backing Agent `state.db` row disappeared. The delete endpoint still treats imported sidecars as read-only, so manual deletion could not clean them up either.

## What Changed

- Add an API-server sidecar predicate in `api/routes.py` without changing `is_cli_session_row()`.
- Feed API/API-server imported sidecars into the existing `agent_session_rows_existing()` orphan probe.
- Keep native WebUI-owned sessions protected even when stale metadata mentions API.
- Preserve the safe failure behavior of the existing probe: DB errors still degrade to “assume present”.
- Add route-level regression coverage for API sidecar prune, API sidecar retention when backing row exists, and native WebUI safety.
- Follow-up: removed the contributor-side `CHANGELOG.md` entry after bot feedback that release notes are release-agent owned.

## Why It Matters

Read-only API/Gateway sidecars should not accumulate indefinitely after their backing Agent session is deleted outside WebUI. This reuses the existing exact state-db existence check instead of weakening the read-only delete guard.

## Verification

- `./scripts/test.sh tests/test_issue3238_orphaned_cli_sidecar_prune.py tests/test_issue4385_cron_archive_reappears.py tests/test_ruff_forward_lint.py -q`
- `git diff --check`

## Risks / Follow-ups

- Low-to-medium risk because this touches session-list pruning. Tests cover the missing-row, present-row, and native-WebUI safety cases.
- This does not address the separate question from the issue comment about whether duplicate sidecars are being created on every click; it only fixes orphan cleanup.

## Model Used

Implemented with AI assistance (Codex coordinator + worker workflow) and reviewed by the coordinator before submission.
