### PR TITLE
fix: explain insecure microphone origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- **Microphone errors on insecure non-local HTTP origins now explain the HTTPS/localhost requirement (#4571).** Browser dictation and hands-free voice mode now distinguish insecure-origin capture failures from normal permission denials, while preserving HTTPS and localhost/loopback behavior.
-
 ## [v0.51.560] — 2026-06-21 — Release TS (recovered run-journal output reaches the model)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Microphone errors on insecure non-local HTTP origins now explain the HTTPS/localhost requirement (#4571).** Browser dictation and hands-free voice mode now distinguish insecure-origin capture failures from normal permission denials, while preserving HTTPS and localhost/loopback behavior.
+
 ## [v0.51.560] — 2026-06-21 — Release TS (recovered run-journal output reaches the model)
 
 ### Fixed

--- a/static/boot.js
+++ b/static/boot.js
@@ -487,7 +487,6 @@ function _micToastKeyForRecognitionError(error){
   const msgs={
     'not-allowed':'mic_denied',
     'service-not-allowed':'mic_denied',
-    'audio-capture':'mic_denied',
     'no-speech':'mic_no_speech',
     'network':'mic_network',
   };
@@ -1000,7 +999,8 @@ window._micPendingSend=window._micPendingSend||false;
       }
       if(event.error==='not-allowed'||event.error==='service-not-allowed'||event.error==='audio-capture'){
         _deactivate();
-        showToast(t(_micToastKeyForRecognitionError(event.error)||'mic_denied'));
+        const messageKey=_micToastKeyForRecognitionError(event.error);
+        showToast(messageKey?t(messageKey):t('mic_error')+event.error);
         return;
       }
       // Other errors — try to restart

--- a/static/boot.js
+++ b/static/boot.js
@@ -463,6 +463,37 @@ $('mainChat')?.addEventListener('pointerdown', closeMobileWorkspacePanelFromChat
 $('btnAttach').onclick=e=>{if(e&&e.preventDefault)e.preventDefault();$('fileInput').value='';$('fileInput').click();};
 
 // ── Voice input (Web Speech API + MediaRecorder fallback) ───────────────────
+function _micIsLocalhostOrLoopback(hostname){
+  const host=String(hostname||'').toLowerCase().replace(/^\[|\]$/g,'');
+  return host==='localhost'
+    || host.endsWith('.localhost')
+    || host==='::1'
+    || host==='0:0:0:0:0:0:0:1'
+    || /^127\./.test(host);
+}
+
+function _micOriginNeedsSecureContext(){
+  if(window.isSecureContext===true) return false;
+  const loc=window.location||{};
+  const protocol=loc.protocol||'';
+  return protocol==='http:'&&!_micIsLocalhostOrLoopback(loc.hostname);
+}
+
+function _micToastKeyForRecognitionError(error){
+  if((error==='not-allowed'||error==='service-not-allowed'||error==='audio-capture')
+      && _micOriginNeedsSecureContext()){
+    return 'mic_insecure_origin';
+  }
+  const msgs={
+    'not-allowed':'mic_denied',
+    'service-not-allowed':'mic_denied',
+    'audio-capture':'mic_denied',
+    'no-speech':'mic_no_speech',
+    'network':'mic_network',
+  };
+  return msgs[error]||null;
+}
+
 (function(){
   const SpeechRecognition=window.SpeechRecognition||window.webkitSpeechRecognition;
   const _canRecordAudio=!!(navigator.mediaDevices&&navigator.mediaDevices.getUserMedia&&window.MediaRecorder);
@@ -677,12 +708,8 @@ $('btnAttach').onclick=e=>{if(e&&e.preventDefault)e.preventDefault();$('fileInpu
         _forceMediaRecorder=true;
         recognition=null;
       }
-      const msgs={
-        'not-allowed':t('mic_denied'),
-        'no-speech':t('mic_no_speech'),
-        'network':t('mic_network'),
-      };
-      showToast(msgs[event.error]||t('mic_error')+event.error);
+      const messageKey=_micToastKeyForRecognitionError(event.error);
+      showToast(messageKey?t(messageKey):t('mic_error')+event.error);
     };
 
     return sr;
@@ -739,6 +766,12 @@ $('btnAttach').onclick=e=>{if(e&&e.preventDefault)e.preventDefault();$('fileInpu
     _isRecording=true;
     _finalText='';
     _prefix=ta.value;
+    if(_micOriginNeedsSecureContext()){
+      _isRecording=false;
+      window._micPendingSend=false;
+      showToast(t('mic_insecure_origin'));
+      return;
+    }
     if(recognition && !_forceMediaRecorder && !_rawAudioMode){
       _activeCaptureMode='speech';
       recognition.start();
@@ -788,7 +821,7 @@ $('btnAttach').onclick=e=>{if(e&&e.preventDefault)e.preventDefault();$('fileInpu
       _isRecording=false;
       window._micPendingSend=false;
       _stopTracks();
-      showToast(t('mic_denied'));
+      showToast(t(_micToastKeyForRecognitionError('not-allowed')||'mic_denied'));
     }
   };
 
@@ -907,6 +940,11 @@ window._micPendingSend=window._micPendingSend||false;
 
   function _startListening(){
     if(!_voiceModeActive) return;
+    if(_micOriginNeedsSecureContext()){
+      _deactivate();
+      showToast(t('mic_insecure_origin'));
+      return;
+    }
     _clearBrowserTtsRecovery();
     _setState('listening');
 
@@ -962,7 +1000,7 @@ window._micPendingSend=window._micPendingSend||false;
       }
       if(event.error==='not-allowed'||event.error==='service-not-allowed'||event.error==='audio-capture'){
         _deactivate();
-        showToast(t('mic_denied'));
+        showToast(t(_micToastKeyForRecognitionError(event.error)||'mic_denied'));
         return;
       }
       // Other errors — try to restart
@@ -1197,6 +1235,10 @@ window._micPendingSend=window._micPendingSend||false;
   };
 
   function _activate(){
+    if(_micOriginNeedsSecureContext()){
+      showToast(t('mic_insecure_origin'));
+      return;
+    }
     _voiceModeActive=true;
     modeBtn.classList.add('active');
     _setButtonTooltip(modeBtn, t('voice_mode_toggle_active'));

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -19,6 +19,7 @@ const LOCALES = {
     cancelling: 'Cancelling\u2026',
     cancel_failed: 'Cancel failed: ',
     mic_denied: 'Microphone access denied. Check browser permissions.',
+    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.',
     mic_no_speech: 'No speech detected. Try again.',
     mic_network: 'Speech recognition unavailable.',
     mic_error: 'Voice input error: ',
@@ -1566,6 +1567,7 @@ const LOCALES = {
     cancelling: 'Annullamento\u2026',
     cancel_failed: 'Annullamento fallito: ',
     mic_denied: 'Accesso al microfono negato. Controlla i permessi del browser.',
+    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.', // TODO: translate
     mic_no_speech: 'Nessuna voce rilevata. Riprova.',
     mic_network: 'Riconoscimento vocale non disponibile.',
     mic_error: 'Errore input vocale: ',
@@ -3104,6 +3106,7 @@ const LOCALES = {
     cancelling: 'キャンセル中…',
     cancel_failed: 'キャンセル失敗: ',
     mic_denied: 'マイクへのアクセスが拒否されました。ブラウザの権限を確認してください。',
+    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.', // TODO: translate
     mic_no_speech: '音声が検出されませんでした。もう一度お試しください。',
     mic_network: '音声認識を利用できません。',
     mic_error: '音声入力エラー: ',
@@ -4646,6 +4649,7 @@ const LOCALES = {
     cancelling: 'Отменяю…',
     cancel_failed: 'Не удалось отменить: ',
     mic_denied: 'Доступ к микрофону запрещён. Проверьте разрешения браузера.',
+    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.', // TODO: translate
     mic_no_speech: 'Речь не распознана. Попробуйте ещё раз.',
     mic_network: 'Распознавание речи недоступно.',
     mic_error: 'Ошибка ввода речи: ',
@@ -6127,6 +6131,7 @@ const LOCALES = {
     cancelling: 'Cancelando…',
     cancel_failed: 'Error al cancelar: ',
     mic_denied: 'Acceso al micrófono denegado. Revisa los permisos del navegador.',
+    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.', // TODO: translate
     mic_no_speech: 'No se detectó voz. Inténtalo de nuevo.',
     mic_network: 'El reconocimiento de voz no está disponible.',
     mic_error: 'Error de entrada por voz: ',
@@ -7601,6 +7606,7 @@ const LOCALES = {
     cancelling: 'Wird abgebrochen\u2026',
     cancel_failed: 'Abbrechen fehlgeschlagen: ',
     mic_denied: 'Mikrofonzugriff verweigert. Überprüfen Sie die Browserberechtigungen.',
+    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.', // TODO: translate
     mic_no_speech: 'Keine Sprache erkannt. Versuchen Sie es erneut.',
     mic_network: 'Spracherkennung nicht verfügbar.',
     mic_error: 'Spracheingabefehler: ',
@@ -9079,6 +9085,7 @@ const LOCALES = {
     cancelling: '正在取消...',
     cancel_failed: '取消失败：',
     mic_denied: '麦克风访问被拒绝，请检查浏览器权限。',
+    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.', // TODO: translate
     mic_no_speech: '没有检测到语音，请再试一次。',
     mic_network: '语音识别当前不可用。',
     mic_error: '语音输入出错：',
@@ -10552,6 +10559,7 @@ const LOCALES = {
     cancelling: '正在取消……',
     cancel_failed: '取消失敗：',
     mic_denied: '麥克風存取遭拒。請檢查瀏覽器權限。',
+    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.', // TODO: translate
     mic_no_speech: '未偵測到語音。請再試一次。',
     mic_network: '語音辨識無法使用。',
     mic_error: '語音輸入錯誤：',
@@ -12092,6 +12100,7 @@ const LOCALES = {
     cancelling: 'Cancelando…',
     cancel_failed: 'Falha ao cancelar: ',
     mic_denied: 'Acesso ao microfone negado. Verifique as permissões do navegador.',
+    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.', // TODO: translate
     mic_no_speech: 'Nenhuma fala detectada. Tente novamente.',
     mic_network: 'Reconhecimento de fala indisponível.',
     mic_error: 'Erro no input de voz: ',
@@ -13452,6 +13461,7 @@ const LOCALES = {
     cancelling: '취소 중\u2026',
     cancel_failed: '취소 실패: ',
     mic_denied: '마이크 접근이 거부되었습니다. 브라우저 권한을 확인하세요.',
+    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.', // TODO: translate
     mic_no_speech: '음성이 감지되지 않았습니다. 다시 시도하세요.',
     mic_network: '음성 인식을 사용할 수 없습니다.',
     mic_error: '음성 입력 오류: ',
@@ -14979,6 +14989,7 @@ const LOCALES = {
     cancelling: 'Annulation\u2026',
     cancel_failed: 'Échec de l\'annulation :',
     mic_denied: 'Accès au microphone refusé. Vérifiez les autorisations du navigateur.',
+    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.', // TODO: translate
     mic_no_speech: 'Aucune parole détectée. Essayer à nouveau.',
     mic_network: 'Reconnaissance vocale indisponible.',
     mic_error: 'Erreur de saisie vocale :',
@@ -16457,6 +16468,7 @@ const LOCALES = {
     cancelling: 'İptal ediliyor\u2026',
     cancel_failed: 'İptal başarısız oldu:',
     mic_denied: 'Mikrofon erişimi reddedildi. Tarayıcı izinlerini kontrol edin.',
+    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.', // TODO: translate
     mic_no_speech: 'Konuşma algılanmadı. Tekrar deneyin.',
     mic_network: 'Konuşma tanıma kullanılamıyor.',
     mic_error: 'Ses girişi hatası:',
@@ -17986,6 +17998,7 @@ const LOCALES = {
     cancelling: 'Anulowanie…',
     cancel_failed: 'Anulowanie nie powiodło się: ',
     mic_denied: 'Odmowa dostępu do mikrofonu. Sprawdź uprawnienia przeglądarki.',
+    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.', // TODO: translate
     mic_no_speech: 'Nie wykryto mowy. Spróbuj ponownie.',
     mic_network: 'Rozpoznawanie mowy jest niedostępne.',
     mic_error: 'Błąd wejścia głosowego: ',
@@ -19770,4 +19783,3 @@ function applyLocaleToDOM() {
 
 // Apply saved locale immediately so there's no flash of English on reload.
 loadLocale();
-

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -10559,7 +10559,7 @@ const LOCALES = {
     cancelling: '正在取消……',
     cancel_failed: '取消失敗：',
     mic_denied: '麥克風存取遭拒。請檢查瀏覽器權限。',
-    mic_insecure_origin: 'Voice input needs a secure connection. Open Hermes over HTTPS or from localhost to use the microphone.', // TODO: translate
+    mic_insecure_origin: '語音輸入需要安全連線。請透過 HTTPS 或 localhost 開啟 Hermes 才能使用麥克風。',
     mic_no_speech: '未偵測到語音。請再試一次。',
     mic_network: '語音辨識無法使用。',
     mic_error: '語音輸入錯誤：',

--- a/tests/test_issue4571_mic_insecure_origin.py
+++ b/tests/test_issue4571_mic_insecure_origin.py
@@ -1,0 +1,113 @@
+"""Regression tests for #4571 insecure-origin microphone messaging.
+
+Browser speech/microphone APIs can report permission-style errors when the real
+problem is that the page was opened over insecure HTTP from a non-local origin.
+The UI must explain the HTTPS/localhost requirement instead of only saying the
+browser permission was denied.
+"""
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+I18N_JS = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
+
+
+def _locale_count() -> int:
+    return len(re.findall(r"^  ['\"]?[\w-]+['\"]?: \{", I18N_JS, re.MULTILINE))
+
+
+def _slice_between(src: str, start_marker: str, end_marker: str) -> str:
+    start = src.index(start_marker)
+    end = src.index(end_marker, start)
+    return src[start:end]
+
+
+def test_i18n_key_exists_in_every_locale_and_names_https_localhost():
+    assert I18N_JS.count("mic_insecure_origin") == _locale_count()
+
+    english = re.search(r"mic_insecure_origin: '([^']+)'", I18N_JS)
+    assert english, "English mic_insecure_origin string must exist"
+    value = english.group(1).lower()
+    assert "https" in value
+    assert "localhost" in value
+    assert "microphone" in value
+
+
+def test_secure_context_and_localhost_loopback_are_explicitly_preserved():
+    assert "function _micOriginNeedsSecureContext()" in BOOT_JS
+    assert "window.isSecureContext===true" in BOOT_JS
+    assert "protocol==='http:'" in BOOT_JS
+    assert "!_micIsLocalhostOrLoopback(loc.hostname)" in BOOT_JS
+
+    localhost_helper = _slice_between(
+        BOOT_JS,
+        "function _micIsLocalhostOrLoopback(hostname)",
+        "\n}\n\nfunction _micOriginNeedsSecureContext",
+    )
+    assert "host==='localhost'" in localhost_helper
+    assert "host.endsWith('.localhost')" in localhost_helper
+    assert "host==='::1'" in localhost_helper
+    assert "/^127\\./.test(host)" in localhost_helper
+
+
+def test_permission_style_speech_errors_use_insecure_origin_key_only_on_that_branch():
+    helper = _slice_between(
+        BOOT_JS,
+        "function _micToastKeyForRecognitionError(error)",
+        "\n}\n\n(function(){",
+    )
+    for error in ("not-allowed", "service-not-allowed", "audio-capture"):
+        assert error in helper
+    assert "_micOriginNeedsSecureContext()" in helper
+    assert "return 'mic_insecure_origin';" in helper
+    assert "'network':'mic_network'" in helper
+    assert "'no-speech':'mic_no_speech'" in helper
+
+
+def test_dictation_preflights_insecure_origin_before_speech_or_media_capture():
+    body = _slice_between(
+        BOOT_JS,
+        "btn.onclick=async()=>{",
+        "\n  // Wire up the settings checkbox",
+    )
+    insecure_idx = body.index("_micOriginNeedsSecureContext()")
+    speech_idx = body.index("recognition.start()")
+    media_idx = body.index("navigator.mediaDevices.getUserMedia")
+
+    assert insecure_idx < speech_idx
+    assert insecure_idx < media_idx
+    assert "showToast(t('mic_insecure_origin'))" in body
+
+
+def test_dictation_speechrecognition_errors_route_through_shared_helper():
+    body = _slice_between(
+        BOOT_JS,
+        "sr.onerror=(event)=>{",
+        "\n    return sr;",
+    )
+    assert "_micToastKeyForRecognitionError(event.error)" in body
+    assert "messageKey?t(messageKey):t('mic_error')+event.error" in body
+
+
+def test_voice_mode_preflights_and_routes_permission_errors_through_shared_helper():
+    activate_body = _slice_between(
+        BOOT_JS,
+        "function _activate(){",
+        "\n  function _deactivate(){",
+    )
+    assert "_micOriginNeedsSecureContext()" in activate_body
+    assert "showToast(t('mic_insecure_origin'))" in activate_body
+    assert "_voiceModeActive=true" in activate_body
+    assert activate_body.index("_micOriginNeedsSecureContext()") < activate_body.index("_voiceModeActive=true")
+
+    start_body = _slice_between(
+        BOOT_JS,
+        "function _startListening(){",
+        "\n  function _voiceModeSend(){",
+    )
+    assert "_micOriginNeedsSecureContext()" in start_body
+    assert "showToast(t('mic_insecure_origin'))" in start_body
+    assert "_micToastKeyForRecognitionError(event.error)" in start_body
+    assert "showToast(t(_micToastKeyForRecognitionError(event.error)||'mic_denied'))" in start_body

--- a/tests/test_issue4571_mic_insecure_origin.py
+++ b/tests/test_issue4571_mic_insecure_origin.py
@@ -62,6 +62,7 @@ def test_permission_style_speech_errors_use_insecure_origin_key_only_on_that_bra
         assert error in helper
     assert "_micOriginNeedsSecureContext()" in helper
     assert "return 'mic_insecure_origin';" in helper
+    assert "'audio-capture':'mic_denied'" not in helper
     assert "'network':'mic_network'" in helper
     assert "'no-speech':'mic_no_speech'" in helper
 
@@ -110,4 +111,4 @@ def test_voice_mode_preflights_and_routes_permission_errors_through_shared_helpe
     assert "_micOriginNeedsSecureContext()" in start_body
     assert "showToast(t('mic_insecure_origin'))" in start_body
     assert "_micToastKeyForRecognitionError(event.error)" in start_body
-    assert "showToast(t(_micToastKeyForRecognitionError(event.error)||'mic_denied'))" in start_body
+    assert "messageKey?t(messageKey):t('mic_error')+event.error" in start_body


### PR DESCRIPTION
## Thinking Path

Fixes #4571.

Browsers can surface insecure-origin microphone failures as permission-style Web Speech errors. The UI was treating those as a generic permission denial, which is misleading when the page is opened over non-local HTTP.

## What Changed

- Add shared microphone-origin helpers in `static/boot.js`.
- Detect insecure non-local `http:` origins while preserving HTTPS, `localhost`, `.localhost`, IPv4 loopback, and IPv6 loopback.
- Route dictation and hands-free voice mode permission-style failures through the insecure-origin message when appropriate.
- Preflight insecure origins before starting SpeechRecognition or MediaRecorder capture.
- Add `mic_insecure_origin` to all locale bundles, using English TODO fallbacks where translations are not already available and a real `zh-Hant` translation to satisfy the existing Traditional Chinese locale guard.
- Preserve the previous secure-origin `audio-capture` behavior by falling through to `mic_error + raw error` instead of mapping hardware capture failures to permission denied.
- Add regression tests for the insecure-origin branch, localhost/loopback preservation, shared error routing, and the `audio-capture` fallthrough.
- Follow-up: removed the contributor-side `CHANGELOG.md` entry after bot feedback that release notes are release-agent owned.

## Why It Matters

Users should not be told browser permission was denied when the actual fix is to use HTTPS or localhost. This makes the failure actionable and preserves the normal permission-denied behavior on secure/local origins.

## Verification

- `node` behavior probe against the extracted helper logic for remote HTTP, localhost, `.localhost`, `127.0.0.1`, `[::1]`, HTTPS, and `audio-capture` secure/insecure routing.
- `./scripts/test.sh tests/test_issue4571_mic_insecure_origin.py tests/test_sprint20.py::test_boot_js_not_allowed_error_message tests/test_zh_hant_locale.py -q`
- `node --check static/boot.js`
- `node --check static/i18n.js`
- `git diff --check`

## Risks / Follow-ups

- No live browser microphone test was run in this pass; coverage is static plus JS helper behavior and syntax checks.
- Most non-English locale strings use English fallback TODOs where translations were not available; `zh-Hant` is translated because that locale has an explicit no-TODO guard.

## Model Used

Implemented with AI assistance (Codex coordinator + worker workflow) and reviewed by the coordinator before submission.
