### PR TITLE
fix(Windows): suppress console window on WebUI restart

### DIFF
--- a/api/updates.py
+++ b/api/updates.py
@@ -1174,12 +1174,33 @@ def _schedule_restart(delay: float = 2.0) -> None:
                         args = sys.argv
                     else:
                         args = [sys.executable] + sys.argv
-                    # Start new process detached, redirect all stdio to
-                    # avoid broken-pipe errors when the parent exits.
+                    # Prefer pythonw.exe over python.exe so the restarted
+                    # server does not create a visible console window.
+                    # sys.executable may point at python.exe (console
+                    # subsystem); substitute pythonw.exe if it exists
+                    # next to python.exe.
+                    _exe = sys.executable
+                    if _exe.lower().endswith('python.exe'):
+                        _w_exe = _exe[:-4] + 'w.exe'  # python.exe -> pythonw.exe
+                        if os.path.isfile(_w_exe):
+                            if getattr(sys, "frozen", False):
+                                args = sys.argv
+                            else:
+                                args = [_w_exe] + sys.argv
+                    # Start new process fully detached with NO console
+                    # window.  DETACHED_PROCESS alone is not sufficient
+                    # on modern Windows — without CREATE_NO_WINDOW a
+                    # python.exe (console-subsystem) child still flashes
+                    # an empty terminal window, which the user then
+                    # manually kills (taking the WebUI with it).
                     subprocess.Popen(
                         args,
                         cwd=os.getcwd(),
-                        creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP,
+                        creationflags=(
+                            subprocess.DETACHED_PROCESS
+                            | subprocess.CREATE_NEW_PROCESS_GROUP
+                            | subprocess.CREATE_NO_WINDOW
+                        ),
                         close_fds=True,
                         stdin=subprocess.DEVNULL,
                         stdout=subprocess.DEVNULL,

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -542,16 +542,30 @@ def main() -> int:
         # spawns a new process instead of replacing (Python calls CreateProcess),
         # orphaning it from any supervisor. Use Popen + exit there instead.
         if sys.platform == "win32":
-            # CREATE_NEW_PROCESS_GROUP only exists in the subprocess module on
-            # Windows; resolve it defensively (0 = no extra flags) so this line
-            # can't AttributeError if reached on a non-Windows interpreter
-            # (e.g. a win32-simulating test) — mirrors the getattr() guard used
-            # for SO_EXCLUSIVEADDRUSE.
-            _CREATE_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-            subprocess.Popen([python_exe, server_path],
-                             cwd=server_cwd,
-                             env=os.environ.copy(),
-                             creationflags=_CREATE_NEW_PROCESS_GROUP)
+            # Mirror the robust pattern from api/updates._schedule_restart:
+            # 1. Prefer pythonw.exe (windowless subsystem) over python.exe
+            #    so the restarted server never creates a visible console window.
+            # 2. DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW
+            #    suppresses the brief console flash even when python.exe is used.
+            _exe = str(python_exe)
+            if _exe.lower().endswith("python.exe"):
+                _w = _exe[:-4] + "w.exe"  # python.exe -> pythonw.exe
+                if os.path.isfile(_w):
+                    _exe = _w
+            _flags = 0
+            for _attr in ("DETACHED_PROCESS", "CREATE_NEW_PROCESS_GROUP",
+                          "CREATE_NO_WINDOW"):
+                _flags |= getattr(subprocess, _attr, 0)
+            subprocess.Popen(
+                [_exe, str(server_path)],
+                cwd=str(server_cwd),
+                env=os.environ.copy(),
+                creationflags=_flags,
+                close_fds=True,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
             sys.exit(0)
         os.execv(python_exe, [python_exe, server_path])
         # Unreachable — execv either replaces the process or raises.


### PR DESCRIPTION
## Problem

On Windows, two independent restart paths spawn `server.py` without suppressing the console window:

1. **`bootstrap.py` foreground path** (supervisor auto-restart / Task Scheduler): uses only `CREATE_NEW_PROCESS_GROUP` — flashes an empty terminal window on every restart.
2. **`api/updates.py` `_schedule_restart()`** (Update button in UI): uses `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` but **not** `CREATE_NO_WINDOW` — still flashes when `python.exe` (console subsystem) is the interpreter.

Users see an empty terminal window and may mistakenly kill it — taking down the WebUI.

## Root cause

Both paths predate the `CREATE_NO_WINDOW` flag and `pythonw.exe` substitution. The fix pattern existed in `tests/browser_smoke.py` but was never applied to the production restart paths.

## Fix

Apply the same robust pattern to both files:

1. **Prefer `pythonw.exe`** (windowless subsystem) over `python.exe` — zero console window by design
2. **Full creationflags**: `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW` — suppresses the flash even when `python.exe` is the only available interpreter
3. **Redirect stdin/stdout/stderr** to `DEVNULL` — prevents console attachment
4. **Set `close_fds=True`** — standard hygiene for detached processes

### Files changed
- `bootstrap.py` — supervisor foreground restart path (lines 544-555 → 544-571)
- `api/updates.py` — `_schedule_restart()` Windows branch (lines 1174-1186 → 1174-1208)

## Verification

- `python -c "import py_compile; py_compile.compile('bootstrap.py', doraise=True)"` — passes
- `python -c "import py_compile; py_compile.compile('api/updates.py', doraise=True)"` — passes
- The pattern matches `tests/browser_smoke.py` which already uses `CREATE_NO_WINDOW` for its Popen calls

## Contract Routing

No contract, RFC, or design doc changes — runtime-only fix for existing Windows restart paths.