### PR TITLE
feat: add 'max' reasoning effort level for DeepSeek models

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2656,7 +2656,7 @@ def get_effective_default_model(config_data: dict | None = None) -> str:
 # importing from the agent tree (which may not be installed).  Any drift here
 # will show up in the shared test suite since both sides accept the same set.
 # Keep this WebUI-visible set aligned with hermes-agent#29248.
-VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
 
 def parse_reasoning_effort(effort):
@@ -3186,9 +3186,6 @@ def coerce_reasoning_effort_for_model(
         return ""
     if raw == "none":
         return "none"
-    accepts_max_as_xhigh = raw == "max"
-    if accepts_max_as_xhigh:
-        raw = "xhigh"
     if raw not in VALID_REASONING_EFFORTS:
         return ""
     supported = resolve_model_reasoning_efforts(
@@ -3204,17 +3201,15 @@ def coerce_reasoning_effort_for_model(
     # those paths return a NON-empty clamped set, so the degrade ladder below
     # still applies. When the set is empty we can't tell "unsupported" from
     # "unknown", so preserve the user's configured effort verbatim where it is
-    # still valid. A stale 'max' value is no longer parser-valid on the WebUI
-    # side, so degrade that unknown-model case to xhigh instead of silently
-    # dropping reasoning later in parse_reasoning_effort(). (#3505 review)
+    # still valid. (#3505 review)
     if not supported:
-        return "xhigh" if accepts_max_as_xhigh else raw
+        return raw
     if raw in supported:
-        return "xhigh" if accepts_max_as_xhigh else raw
+        return raw
     # Degrade to the closest *lower* supported level instead of silently
     # disabling reasoning. e.g. max -> xhigh -> high, or xhigh -> high when the
     # target model caps below the configured effort. Never escalate.
-    ladder = list(VALID_REASONING_EFFORTS)  # ascending: minimal..xhigh
+    ladder = list(VALID_REASONING_EFFORTS)  # ascending: minimal..xhigh..max
     try:
         raw_idx = ladder.index(raw)
     except ValueError:
@@ -3267,10 +3262,8 @@ def get_reasoning_status(
     return {
         # Match CLI default (True if unset in config.yaml)
         "show_reasoning": bool(show_raw) if isinstance(show_raw, bool) else True,
-        # Report the COERCED effort (not the raw config value) so boot/status/chip
-        # read paths agree with what streaming actually sends — e.g. a stale
-        # `reasoning_effort: max` surfaces as `xhigh`, not the now-unsupported `max`.
-        # (Codex review of the drop-max alignment.)
+        # Report the COERCED effort so boot/status/chip read paths agree with
+        # what streaming actually sends. (Codex review of the drop-max alignment.)
         "reasoning_effort": coerce_reasoning_effort_for_model(
             str(effort_raw or "").strip().lower(),
             resolve_model,
@@ -3312,7 +3305,7 @@ def set_reasoning_effort(
     """Persist ``agent.reasoning_effort`` to the active profile's config.yaml.
 
     Mirrors CLI ``/reasoning <level>``: same key, same valid values
-    (``none`` | ``minimal`` | ``low`` | ``medium`` | ``high`` | ``xhigh``).
+    (``none`` | ``minimal`` | ``low`` | ``medium`` | ``high`` | ``xhigh`` | ``max``).
     Raises ``ValueError`` on an unrecognised level so callers can return 400.
     """
     raw = str(effort or "").strip().lower()

--- a/static/commands.js
+++ b/static/commands.js
@@ -30,7 +30,7 @@ const COMMANDS=[
   {name:'background',desc:t('cmd_background'),fn:cmdBackground,arg:'prompt',  noEcho:true},
   {name:'status',    desc:t('cmd_status'),   fn:cmdStatus},
   {name:'voice',     desc:t('cmd_voice'),    fn:cmdVoice,     noEcho:true},
-  {name:'reasoning', desc:t('cmd_reasoning'), fn:cmdReasoning, arg:'show|hide|none|minimal|low|medium|high|xhigh', subArgs:['show','hide','none','minimal','low','medium','high','xhigh'], noEcho:true},
+  {name:'reasoning', desc:t('cmd_reasoning'), fn:cmdReasoning, arg:'show|hide|none|minimal|low|medium|high|xhigh|max', subArgs:['show','hide','none','minimal','low','medium','high','xhigh','max'], noEcho:true},
   {name:'yolo', desc:t('cmd_yolo'), fn:cmdYolo, noEcho:true},
   {name:'branch', desc:t('cmd_branch'), fn:cmdBranch, arg:'[name]', noEcho:true},
 ];
@@ -1426,13 +1426,13 @@ function cmdReasoning(args){
   const BRAIN='\uD83E\uDDE0';
   // Matches hermes_constants.VALID_REASONING_EFFORTS + 'none' (CLI parity).
   // Keep this WebUI effort list in sync with hermes-agent#29248.
-  const EFFORTS=['none','minimal','low','medium','high','xhigh'];
+  const EFFORTS=['none','minimal','low','medium','high','xhigh','max'];
   // Shared status renderer used by the no-args branch and as a fallback.
   function _fmtStatus(st){
     const vis=(st && st.show_reasoning===false)?'off':'on';
     const eff=(st && st.reasoning_effort)||'default';
     return BRAIN+' Reasoning effort: '+eff+' \u00B7 display: '+vis
-      +'  |  /reasoning show|hide|none|minimal|low|medium|high|xhigh';
+      +'  |  /reasoning show|hide|none|minimal|low|medium|high|xhigh|max';
   }
   if(!arg){
     // Status — read from the same config.yaml keys the CLI uses.

--- a/static/index.html
+++ b/static/index.html
@@ -753,6 +753,7 @@
             <div class="reasoning-option" data-effort="medium">Medium</div>
             <div class="reasoning-option" data-effort="high">High</div>
             <div class="reasoning-option" data-effort="xhigh">Extra High</div>
+            <div class="reasoning-option" data-effort="max">Max</div>
           </div>
           <div class="composer-toolsets-dropdown" id="composerToolsetsDropdown">
             <div class="toolsets-dropdown-desc" id="toolsetsDropdownDesc"></div>

--- a/static/ui.js
+++ b/static/ui.js
@@ -2956,6 +2956,7 @@ function _normalizeReasoningEffort(eff){
 
 function _formatReasoningEffortLabel(effort){
   if(effort==='none') return 'None';
+  if(effort==='max') return 'Max';
   if(!effort) return 'Default';
   return effort;
 }

--- a/tests/test_issue1103_reasoning_chip_visibility.py
+++ b/tests/test_issue1103_reasoning_chip_visibility.py
@@ -45,8 +45,8 @@ def test_reasoning_chip_html_starts_hidden():
         src
     )
     assert m, "composerReasoningWrap must start with style='display:none'"
-    assert 'data-effort="max"' not in src, (
-        "composer reasoning dropdown must not include Max"
+    assert 'data-effort="max"' in src, (
+        "composer reasoning dropdown must include Max option"
     )
 
 

--- a/tests/test_reasoning_effort_model_capabilities.py
+++ b/tests/test_reasoning_effort_model_capabilities.py
@@ -83,7 +83,7 @@ def test_coerce_preserves_effort_for_unrecognized_model():
         "max",
         "brand-new-model-2099",
         provider_id="some-custom-provider",
-    ) == "xhigh"
+    ) == "max"
     # 'none' / unset still pass through unchanged for unknown models.
     assert cfg.coerce_reasoning_effort_for_model(
         "none", "some-unknown-model-xyz", provider_id="custom"

--- a/tests/test_reasoning_show_hide.py
+++ b/tests/test_reasoning_show_hide.py
@@ -312,14 +312,11 @@ class TestReasoningCommand:
         m = re.search(r'function cmdReasoning\(.*?\n\}', src, re.DOTALL)
         assert m
         fn = m.group(0)
-        for level in ('none', 'minimal', 'low', 'medium', 'high', 'xhigh'):
+        for level in ('none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'):
             assert f"'{level}'" in fn, (
                 f"cmdReasoning must accept '{level}' (CLI parity with "
                 f"hermes_constants.parse_reasoning_effort)"
             )
-        assert "'max'" not in fn, (
-            "cmdReasoning should only expose efforts up to xhigh"
-        )
 
     def test_reasoning_subargs_match_cli_levels(self):
         """Autocomplete subArgs must expose every CLI effort level + show/hide."""
@@ -328,14 +325,11 @@ class TestReasoningCommand:
         assert m, "reasoning COMMANDS entry not found"
         entry = m.group(0)
         for suggestion in (
-            'show', 'hide', 'none', 'minimal', 'low', 'medium', 'high', 'xhigh'
+            'show', 'hide', 'none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'
         ):
             assert f"'{suggestion}'" in entry, (
                 f"reasoning subArgs must include '{suggestion}' for CLI parity"
             )
-        assert "'max'" not in entry, (
-            "reasoning command subArgs must not include 'max'"
-        )
 
 
 # ── api/config.py — reasoning helpers ────────────────────────────────────────


### PR DESCRIPTION
## Summary

DeepSeek models (deepseek-v4-flash, deepseek-reasoner) support `reasoning_effort: "max"` as their highest reasoning level — distinct from OpenAI's `"xhigh"`. The Hermes WebUI currently only offers options up to `xhigh`, so DeepSeek users cannot explicitly select `max` even though the underlying provider plugin already maps `xhigh → max` on the wire.

This PR adds `"max"` as a first-class valid reasoning effort level, making it selectable in the dropdown, via `/reasoning max`, and in autocomplete.

## Changes

### `api/config.py`
- Add `"max"` to `VALID_REASONING_EFFORTS`
- Remove the blanket `max → xhigh` coercion in `coerce_reasoning_effort_for_model` — now `max` passes through as itself
- Existing degrade ladder still handles models that don't support `max` (OpenAI GPT-5, o1/o3/o4) by degrading to `xhigh`
- Update docstrings and comments

### `static/index.html`
- Add `Max` option to reasoning dropdown (between Extra High and the end)

### `static/ui.js`
- Add `'Max' label formatter for the reasoning chip

### `static/commands.js`
- Add `'max'` to the `/reasoning` valid efforts list, help text, and autocomplete subArgs

### Tests updated
- `test_issue1103_reasoning_chip_visibility.py`: assert `max` IS present
- `test_reasoning_effort_model_capabilities.py`: assert `max` preserved for unknown models
- `test_reasoning_show_hide.py`: include `max` in CLI-parity checks, remove exclusion assertions

## Model compatibility

- **DeepSeek** (opencode-go, native, OpenRouter): ✅ `max` passes through, provider plugin sends as-is
- **Anthropic / Qwen 3+ / Kimi / Gemini 2.5+**: ✅ `max` passes through
- **OpenAI (openai-codex gpt-5)**: ✅ `max` filtered out by provider filter, degrades to `xhigh`
- **Unknown/custom providers**: ✅ `max` preserved (same as other unknown-model efforts)

## Testing

All 13 reasoning-effort unit tests pass. Verified:
- `max` is available for DeepSeek models (`deepseek-v4-flash`, `deepseek-reasoner`)
- `max` is NOT available for OpenAI models that cap at `xhigh`
- Degrade ladder correctly steps down: `max → xhigh → high → medium → low → minimal`
- Stale config values and unknown models handle `max` gracefully

## Companion change needed (separate PR)

The Hermes Agent's `hermes_constants.py` also needs `"max"` added to its `VALID_REASONING_EFFORTS` so the gateway run.py and CLI accept the value when saved to config.yaml. The WebUI itself (local streaming path) already handles `max` through its own `parse_reasoning_effort`.