### PR TITLE
perf(sidebar): cap lineage enrichment to top-N sessions

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -3200,11 +3200,30 @@ def _sidebar_title_is_generic_webui(title: str | None) -> bool:
 
 
 def _enrich_sidebar_lineage_metadata(sessions: list[dict]) -> None:
-    """Attach state.db compression lineage metadata used by sidebar collapse."""
+    """Attach state.db compression lineage metadata used by sidebar collapse.
+
+    Cap the DB lookup to the top-N most recent sessions to bound wall-clock
+    on power users with thousands of sessions. The sidebar paints chronologically
+    newest first; older sessions almost never have visible lineage to collapse
+    (parents are themselves stale and rarely surface in the same render).
+    Lineage enrichment for those is loaded lazily when the user opens the
+    history panel. Issue #38914 / 2026-06-21 triage: /api/sessions was spending
+    4.9s on lineage_metadata across 2400+ rows.
+    """
+    # 2026-06-21: configurable via env to ease A/B and rollback without a redeploy.
+    import os as _os
+    try:
+        _cap = int(_os.environ.get("HERMES_WEBUI_LINEAGE_TOP_N", "300"))
+    except (TypeError, ValueError):
+        _cap = 300
+    if _cap > 0 and len(sessions) > _cap:
+        candidates = sessions[:_cap]
+    else:
+        candidates = sessions
     try:
         metadata = read_session_lineage_metadata(
             _active_state_db_path(),
-            {str(s.get('session_id')) for s in sessions if s.get('session_id')},
+            {str(s.get('session_id')) for s in candidates if s.get('session_id')},
         )
     except Exception:
         return


### PR DESCRIPTION
## Symptom

In our deployment with ~2400 sessions in `state.db`, `GET /api/sessions` was averaging 5–17 seconds wall-clock. Slow-request diagnostics consistently showed `all_sessions.lineage_metadata` as the dominant stage:

```json
{
  "path": "/api/sessions",
  "elapsed_ms": 16834.9,
  "stages": [
    {"ms": 0.6, "name": "all_sessions.read_index"},
    {"ms": 4924.2, "name": "all_sessions.lineage_metadata"},
    {"ms": 10266.1, "name": "reconcile_stale_stream_state"},
    ...
  ]
}
```

## Root cause

`_enrich_sidebar_lineage_metadata()` walks parent/descendant chains in `state.db` for **every** visible sidebar row. With 2400+ session rows, that's a multi-batch IN-clause walk that hits the index but still pays linear cost in N. Lineage data for older sessions is almost never visible to the user — the sidebar paints chronologically newest-first and older entries get scrolled out or hidden behind the history panel.

## Fix

Cap the DB lookup to the top-N (default 300) most-recent sessions. The cap is configurable via the `HERMES_WEBUI_LINEAGE_TOP_N` environment variable so operators can A/B or roll back without a redeploy. Setting it to `0` disables the cap entirely and restores prior behavior.

The chosen default of 300 covers "recent enough that the user might scroll to it without opening history" while bounding the worst case. Tail sessions still get their lineage enriched lazily when the user explicitly opens the history panel — that code path is unchanged.

## Expected effect

In our deployment: 4.9s → ~0.6s on the `lineage_metadata` stage (88% reduction in DB work, since 300/2398 ≈ 12.5%). For users with <300 sessions, behavior is unchanged.

## Test plan

```
pytest \ tests/test_pr1370_lineage_metadata_perf_and_orphan.py \ tests/test_session_lineage_metadata_api.py \ tests/test_issue1494_state_db_fd_leak.py \ tests/test_session_lineage_collapse.py \ tests/test_issue1855_request_diagnostics.py
68 passed
```

Also a quick functional check that verifies the cap actually slices and the env override works (cap=5 → 5 ids passed, cap=0 → all ids passed, no env → default 300).

## Risk

Low. Pure read-path optimization; no schema or DB-write changes. The collapse contract is preserved for the top-N visible sessions, which is what the sidebar actually paints. Worst case for users with <300 sessions: no change at all (the cap branch is a no-op). Worst case for users with >300 sessions: a lineage-enriched chunk in the tail that the sidebar never displays would need to be enriched lazily when the user opens the history panel (which already has its own loading code path). Disabling via env var = full rollback.