### PR TITLE
ci: add whole-tree Python syntax gate (compileall) — closes the gap behind #4641

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,17 @@ jobs:
       - name: Ensure origin/master ref is available for the diff gate
         run: git fetch --no-tags --depth=1 origin master || true
 
+      # Whole-tree Python syntax gate. The Python analog of the JS `node --check`
+      # pass. The ruff E9 gate below is diff-scoped (new/changed lines only), so a
+      # SyntaxError/IndentationError whose parser-reported line sits on an UNTOUCHED
+      # line (e.g. a dedented `try:` above an unchanged import) can slip the diff
+      # filter and only surface as a confusing mass-failure of every test shard at
+      # the conftest server-boot fixture. compileall fails in ~2s with a clear
+      # file:line, before the matrix suite runs. Whole-tree + unconditional so it
+      # cannot be bypassed by the diff scope. (#4641)
+      - name: Python syntax gate (whole tree — fails fast on any unparseable .py)
+        run: python3 -m compileall -q api server.py bootstrap.py mcp_server.py tests scripts
+
       - name: Ruff forward gate (new/changed lines only)
         run: python3 scripts/ruff_lint.py --diff origin/master
 


### PR DESCRIPTION
## What

Adds a fast, whole-tree Python **syntax gate** to the `lint` job in `.github/workflows/tests.yml`:

```yaml
- name: Python syntax gate (whole tree — fails fast on any unparseable .py)
  run: python3 -m compileall -q api server.py bootstrap.py mcp_server.py tests scripts
```

It runs before the ruff diff gate and the 9-shard matrix suite, takes ~2s, and is **unconditional + whole-tree** (not diff-scoped).

## Why

Prompted by #4641. That report turned out to be a false alarm — the claimed `IndentationError` in `api/gateway_chat.py` exists only in the reporter's local working tree, never in any commit on `master` (master compiles clean, CI is green, prod is healthy). But it surfaced a genuine **coverage gap**:

- The existing **ruff E9 gate** (`scripts/ruff_lint.py --diff origin/master`) catches `E999` syntax errors but is **diff-scoped** — only on lines the PR adds/modifies.
- The **whole-tree ruff pass** is explicitly *informational — never blocks*.

So a `SyntaxError`/`IndentationError` whose **parser-reported line sits on an untouched line** (e.g. a `try:` block dedented above an unchanged `import`, exactly the shape #4641 described) can slip the diff filter and only surface as a confusing **mass-failure of every test shard** at the conftest server-boot fixture (`server.py → api/routes.py → …`). `compileall` fails fast with a clear `file:line` instead.

This is the Python analog of the existing JS `node --check` / ESLint runtime-guard passes.

## Verification

- `compileall` passes clean on the current whole tree (rc=0).
- **RED→GREEN proven:** injecting the literal #4641 defect (the 16-space over-indented import) makes the gate fail with `IndentationError: unindent does not match any outer indentation level (gateway_chat.py, line 298)`, rc=1 — the exact error the reporter described. Reverting → rc=0.
- YAML validated with `yaml.safe_load`.
- Paths cover all runtime entrypoints (`server.py`, `bootstrap.py`, `mcp_server.py`) + `api/`, `tests/`, `scripts/`. `docs/` is intentionally excluded (its only `.py` is a pr-media benchmark snippet, not runtime code).

Infra-only change, no user-facing behavior — no CHANGELOG entry / version bump needed.

Closes the gap behind #4641.
