### PR TITLE
Release v0.51.568 — toggle installed extensions (#4637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.568] — 2026-06-22 — Release UA (toggle installed extensions)
+
+### Added
+
+- **Enable or disable installed extensions from Settings → Extensions.** You can now toggle already-installed manifest extensions on or off directly in the UI, without editing the extension manifest. The choice is stored in a small WebUI-managed state file (`extension-overrides.json`); a disabled extension's scripts, stylesheets, and loopback sidecars are suppressed end-to-end. Extensions that are disabled in their own manifest stay non-toggleable. The toggle endpoint is authentication- and CSRF-gated, and WebUI never edits extension manifests, fetches their assets, or proxies their sidecars. Thanks @santastabber. (#4637)
+
 ## [v0.51.567] — 2026-06-22 — Release TZ (optional titlebar profile switcher)
 
 ### Added

--- a/api/extensions.py
+++ b/api/extensions.py
@@ -9,8 +9,10 @@ import html
 import json
 import logging
 import os
+import re
+import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import unquote, urlsplit
 
 from api.helpers import _security_headers, j
@@ -36,6 +38,14 @@ class _ManifestTooLarge(ValueError):
     pass
 
 
+class ExtensionToggleError(Exception):
+    """Sanitized extension mutation error safe to return to the browser."""
+
+    def __init__(self, message: str, status: int = 400):
+        super().__init__(message)
+        self.status = status
+
+
 EXTENSION_ROUTE_PREFIX = "/extensions/"
 _EXTENSION_DIR_ENV = "HERMES_WEBUI_EXTENSION_DIR"
 _EXTENSION_SCRIPT_URLS_ENV = "HERMES_WEBUI_EXTENSION_SCRIPT_URLS"
@@ -45,6 +55,12 @@ _ALLOWED_ASSET_PREFIXES = ("/extensions/", "/static/")
 _SIDECAR_WARNING_SOURCE = "manifest:sidecars"
 _DEFAULT_SIDECAR_HEALTH_PATH = "/health"
 _LOOPBACK_SIDECAR_HOSTS = {"127.0.0.1", "localhost", "::1"}
+_EXTENSION_STATE_FILENAME = "extension-overrides.json"
+_MAX_EXTENSION_STATE_BYTES = 32 * 1024
+_MAX_DISABLED_EXTENSION_IDS = 512
+_EXTENSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_EXTENSION_STATE_WARNING_SOURCE = "extension_state"
+_EXTENSION_STATE_LOCK = threading.Lock()
 
 _EXTENSION_MIME = {
     "css": "text/css",
@@ -112,6 +128,117 @@ def _add_diagnostic_warning(
     warning = {"code": code, "source": source}
     if warning not in warnings:
         warnings.append(warning)
+
+
+def _valid_extension_id(value: object) -> bool:
+    return isinstance(value, str) and bool(_EXTENSION_ID_RE.fullmatch(value.strip()))
+
+
+def _extension_state_dir() -> Path:
+    """Return the WebUI-managed state directory for extension overrides."""
+    try:
+        from api.config import STATE_DIR
+
+        return Path(STATE_DIR)
+    except Exception:
+        return Path(os.getenv("HERMES_WEBUI_STATE_DIR", str(Path.home() / ".hermes" / "webui"))).expanduser()
+
+
+def _extension_state_file() -> Path:
+    return _extension_state_dir() / _EXTENSION_STATE_FILENAME
+
+
+def _empty_extension_state() -> Dict[str, Any]:
+    return {"version": 1, "disabled_extensions": []}
+
+
+def _load_extension_state(diagnostics: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Load UI-managed extension overrides, failing safe without path leaks."""
+    state_file = _extension_state_file()
+    try:
+        if not state_file.exists() or not state_file.is_file():
+            return _empty_extension_state()
+        with state_file.open("rb") as fh:
+            raw = fh.read(_MAX_EXTENSION_STATE_BYTES + 1)
+        if len(raw) > _MAX_EXTENSION_STATE_BYTES:
+            _add_diagnostic_warning(
+                diagnostics, "extension_state_oversized", _EXTENSION_STATE_WARNING_SOURCE
+            )
+            return _empty_extension_state()
+        parsed = json.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, RecursionError):
+        _add_diagnostic_warning(
+            diagnostics, "extension_state_unreadable", _EXTENSION_STATE_WARNING_SOURCE
+        )
+        return _empty_extension_state()
+    if not isinstance(parsed, dict):
+        _add_diagnostic_warning(
+            diagnostics, "extension_state_invalid", _EXTENSION_STATE_WARNING_SOURCE
+        )
+        return _empty_extension_state()
+    disabled_raw = parsed.get("disabled_extensions", [])
+    if not isinstance(disabled_raw, list):
+        _add_diagnostic_warning(
+            diagnostics, "extension_state_invalid", _EXTENSION_STATE_WARNING_SOURCE
+        )
+        return _empty_extension_state()
+    disabled: List[str] = []
+    seen: Set[str] = set()
+    invalid = False
+    for value in disabled_raw:
+        if not _valid_extension_id(value):
+            invalid = True
+            continue
+        ext_id = str(value).strip()
+        if ext_id in seen:
+            continue
+        seen.add(ext_id)
+        disabled.append(ext_id)
+        if len(disabled) >= _MAX_DISABLED_EXTENSION_IDS:
+            _add_diagnostic_warning(
+                diagnostics, "extension_state_truncated", _EXTENSION_STATE_WARNING_SOURCE
+            )
+            break
+    if invalid:
+        _add_diagnostic_warning(
+            diagnostics, "extension_state_invalid_entries", _EXTENSION_STATE_WARNING_SOURCE
+        )
+    return {"version": 1, "disabled_extensions": disabled}
+
+
+def _write_extension_state(state: Dict[str, Any]) -> None:
+    """Persist extension overrides with an atomic same-directory replace."""
+    disabled_raw = state.get("disabled_extensions", [])
+    disabled: List[str] = []
+    seen: Set[str] = set()
+    if isinstance(disabled_raw, list):
+        for value in disabled_raw:
+            if not _valid_extension_id(value):
+                continue
+            ext_id = str(value).strip()
+            if ext_id in seen:
+                continue
+            seen.add(ext_id)
+            disabled.append(ext_id)
+            if len(disabled) >= _MAX_DISABLED_EXTENSION_IDS:
+                break
+    payload = {"version": 1, "disabled_extensions": disabled}
+    target = _extension_state_file()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(f".{target.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+    data = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+    try:
+        with tmp.open("wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, target)
+    finally:
+        try:
+            if tmp.exists():
+                tmp.unlink()
+        except OSError:
+            pass
 
 
 def _fully_unquote_path(path: str) -> str:
@@ -386,21 +513,34 @@ def _sidecar_from_manifest_entry(
     }
 
 
-def _iter_manifest_entries(manifest: object) -> List[Tuple[str, object]]:
-    entries: List[Tuple[str, object]] = []
+def _manifest_extension_entries(manifest: object) -> List[Tuple[str, int, Dict[str, object]]]:
     extension_entries: object = []
     if isinstance(manifest, dict):
-        entries.append(("manifest", manifest))
         extension_entries = manifest.get("extensions", [])
     elif isinstance(manifest, list):
         extension_entries = manifest
+    entries: List[Tuple[str, int, Dict[str, object]]] = []
     if isinstance(extension_entries, list):
         for index, extension in enumerate(extension_entries):
-            if not isinstance(extension, dict):
-                continue
-            if extension.get("enabled", True) is False:
-                continue
-            entries.append((f"manifest.extensions[{index}]", extension))
+            if isinstance(extension, dict):
+                entries.append((f"manifest.extensions[{index}]", index, extension))
+    return entries
+
+
+def _iter_manifest_entries(
+    manifest: object, disabled_ids: Optional[Set[str]] = None
+) -> List[Tuple[str, object]]:
+    disabled_ids = disabled_ids or set()
+    entries: List[Tuple[str, object]] = []
+    if isinstance(manifest, dict):
+        entries.append(("manifest", manifest))
+    for source, _index, extension in _manifest_extension_entries(manifest):
+        if extension.get("enabled", True) is False:
+            continue
+        ext_id = _manifest_entry_text(extension, "id")
+        if _valid_extension_id(ext_id) and ext_id in disabled_ids:
+            continue
+        entries.append((source, extension))
     return entries
 
 
@@ -417,11 +557,8 @@ def _read_manifest_text(manifest_file: Path) -> str:
     return data.decode("utf-8")
 
 
-def _read_manifest_urls_with_diagnostics(
-    root: Path, diagnostics: Optional[Dict[str, Any]] = None
-) -> Tuple[List[str], List[str], List[Dict[str, str]], Dict[str, Any]]:
-    manifest_file, path_status = _manifest_path_with_status(root)
-    manifest_status: Dict[str, Any] = {
+def _empty_manifest_status(path_status: str) -> Dict[str, Any]:
+    return {
         "configured": path_status != "not_configured",
         "loaded": False,
         "status": path_status,
@@ -430,27 +567,35 @@ def _read_manifest_urls_with_diagnostics(
         "stylesheet_count": 0,
         "sidecar_count": 0,
     }
+
+
+def _load_manifest_with_status(
+    root: Path, diagnostics: Optional[Dict[str, Any]] = None
+) -> Tuple[Optional[object], Dict[str, Any]]:
+    """Load the configured manifest once, returning sanitized status/warnings."""
+    manifest_file, path_status = _manifest_path_with_status(root)
+    manifest_status = _empty_manifest_status(path_status)
     if manifest_file is None:
         if path_status == "invalid_path":
             _add_diagnostic_warning(diagnostics, "manifest_invalid_path", "manifest")
-        return [], [], [], manifest_status
+        return None, manifest_status
     try:
         if not manifest_file.exists() or not manifest_file.is_file():
             _log.warning("Configured extension manifest was not found")
             manifest_status["status"] = "missing"
             _add_diagnostic_warning(diagnostics, "manifest_missing", "manifest")
-            return [], [], [], manifest_status
+            return None, manifest_status
         manifest = json.loads(_read_manifest_text(manifest_file))
+        manifest_status.update({"loaded": True, "status": "loaded"})
+        return manifest, manifest_status
     except _ManifestTooLarge:
         _log.warning("Configured extension manifest exceeds %d bytes", _MAX_MANIFEST_BYTES)
         manifest_status["status"] = "oversized"
         _add_diagnostic_warning(diagnostics, "manifest_oversized", "manifest")
-        return [], [], [], manifest_status
     except json.JSONDecodeError:
         _log.warning("Configured extension manifest is not valid JSON")
         manifest_status["status"] = "malformed"
         _add_diagnostic_warning(diagnostics, "manifest_malformed", "manifest")
-        return [], [], [], manifest_status
     except RecursionError:
         # A <=64KB but deeply-nested manifest makes json.loads exceed the
         # interpreter recursion limit. Without this, the RecursionError escapes
@@ -458,17 +603,89 @@ def _read_manifest_urls_with_diagnostics(
         _log.warning("Configured extension manifest is too deeply nested")
         manifest_status["status"] = "too_deeply_nested"
         _add_diagnostic_warning(diagnostics, "manifest_too_deeply_nested", "manifest")
-        return [], [], [], manifest_status
     except (OSError, UnicodeDecodeError):
         _log.warning("Configured extension manifest could not be read")
         manifest_status["status"] = "unreadable"
         _add_diagnostic_warning(diagnostics, "manifest_unreadable", "manifest")
+    return None, manifest_status
+
+
+def _manifest_extension_state(
+    manifest: object, disabled_ids: Set[str], diagnostics: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Return sanitized per-extension state for manifest extension entries."""
+    extension_entries: List[Dict[str, Any]] = []
+    known_ids: Set[str] = set()
+    manifest_disabled_ids: Set[str] = set()
+    seen_ids: Set[str] = set()
+    invalid_seen = False
+    duplicate_seen = False
+    for _source, _index, entry in _manifest_extension_entries(manifest):
+        raw_id = _manifest_entry_text(entry, "id")
+        if not _valid_extension_id(raw_id):
+            invalid_seen = True
+            continue
+        ext_id = raw_id.strip()
+        if ext_id in seen_ids:
+            duplicate_seen = True
+            continue
+        seen_ids.add(ext_id)
+        known_ids.add(ext_id)
+        name = _manifest_entry_text(entry, "name")
+        manifest_enabled = entry.get("enabled", True) is not False
+        user_disabled = ext_id in disabled_ids
+        can_toggle = manifest_enabled
+        effective_enabled = manifest_enabled and not user_disabled
+        if not manifest_enabled:
+            manifest_disabled_ids.add(ext_id)
+        extension_entries.append(
+            {
+                "id": ext_id,
+                "name": name or ext_id,
+                "manifest_enabled": manifest_enabled,
+                "user_enabled": (not user_disabled) if can_toggle else False,
+                "user_disabled": user_disabled,
+                "effective_enabled": effective_enabled,
+                "can_toggle": can_toggle,
+                "reload_required": True,
+                "status": (
+                    "manifest_disabled"
+                    if not manifest_enabled
+                    else ("user_disabled" if user_disabled else "enabled")
+                ),
+            }
+        )
+    if invalid_seen:
+        _add_diagnostic_warning(diagnostics, "manifest_extension_id_invalid", "manifest:extensions")
+    if duplicate_seen:
+        _add_diagnostic_warning(diagnostics, "manifest_extension_id_duplicate", "manifest:extensions")
+    stale_ids = sorted(disabled_ids - known_ids)
+    if stale_ids:
+        _add_diagnostic_warning(diagnostics, "extension_state_unknown_ids", _EXTENSION_STATE_WARNING_SOURCE)
+    return {
+        "extensions": extension_entries,
+        "known_ids": known_ids,
+        "manifest_disabled_ids": manifest_disabled_ids,
+    }
+
+
+def _read_manifest_urls_with_diagnostics(
+    root: Path,
+    diagnostics: Optional[Dict[str, Any]] = None,
+    disabled_ids: Optional[Set[str]] = None,
+    manifest: Optional[object] = None,
+    manifest_status: Optional[Dict[str, Any]] = None,
+) -> Tuple[List[str], List[str], List[Dict[str, str]], Dict[str, Any]]:
+    disabled_ids = disabled_ids or set()
+    if manifest is None or manifest_status is None:
+        manifest, manifest_status = _load_manifest_with_status(root, diagnostics)
+    if manifest is None:
         return [], [], [], manifest_status
 
     scripts: List[str] = []
     stylesheets: List[str] = []
     sidecars: List[Dict[str, str]] = []
-    entries = _iter_manifest_entries(manifest)
+    entries = _iter_manifest_entries(manifest, disabled_ids=disabled_ids)
     manifest_status["entry_count"] = len(entries)
     scripts_full = False
     stylesheets_full = False
@@ -518,8 +735,12 @@ def _read_manifest_urls_with_diagnostics(
     return scripts, stylesheets, sidecars, manifest_status
 
 
-def _read_manifest_urls(root: Path) -> Tuple[List[str], List[str]]:
-    scripts, stylesheets, _, _ = _read_manifest_urls_with_diagnostics(root)
+def _read_manifest_urls(
+    root: Path, disabled_ids: Optional[Set[str]] = None
+) -> Tuple[List[str], List[str]]:
+    scripts, stylesheets, _, _ = _read_manifest_urls_with_diagnostics(
+        root, disabled_ids=disabled_ids
+    )
     return scripts, stylesheets
 
 
@@ -528,7 +749,9 @@ def get_extension_config() -> Dict[str, Any]:
     root = _extension_root()
     if root is None:
         return {"enabled": False, "script_urls": [], "stylesheet_urls": []}
-    manifest_scripts, manifest_stylesheets = _read_manifest_urls(root)
+    state = _load_extension_state()
+    disabled_ids = set(state.get("disabled_extensions") or [])
+    manifest_scripts, manifest_stylesheets = _read_manifest_urls(root, disabled_ids=disabled_ids)
     return {
         "enabled": True,
         "script_urls": _read_url_list(
@@ -540,10 +763,13 @@ def get_extension_config() -> Dict[str, Any]:
     }
 
 
+
 def get_extension_status() -> Dict[str, Any]:
-    """Return sanitized read-only extension diagnostics for administrators."""
+    """Return sanitized extension diagnostics for administrators."""
     diagnostics = _new_diagnostics()
     root, dir_configured, dir_valid = _extension_root_status()
+    state = _load_extension_state(diagnostics)
+    disabled_ids = set(state.get("disabled_extensions") or [])
     manifest_configured = bool(os.getenv(_EXTENSION_MANIFEST_ENV, "").strip())
     manifest_status: Dict[str, Any] = {
         "configured": manifest_configured,
@@ -565,14 +791,34 @@ def get_extension_status() -> Dict[str, Any]:
             "script_urls": [],
             "stylesheet_urls": [],
             "sidecars": [],
-            "counts": {"script_urls": 0, "stylesheet_urls": 0, "sidecars": 0},
+            "counts": {
+                "script_urls": 0,
+                "stylesheet_urls": 0,
+                "sidecars": 0,
+                "manifest_extensions": 0,
+                "user_disabled": 0,
+            },
             "manifest": manifest_status,
+            "extensions": [],
             "warnings": diagnostics["warnings"],
         }
 
+    manifest, manifest_status = _load_manifest_with_status(root, diagnostics)
+    extension_state = _manifest_extension_state(manifest, disabled_ids, diagnostics) if manifest is not None else {
+        "extensions": [],
+        "known_ids": set(),
+        "manifest_disabled_ids": set(),
+    }
     manifest_scripts, manifest_stylesheets, sidecars, manifest_status = _read_manifest_urls_with_diagnostics(
-        root, diagnostics
+        root,
+        diagnostics,
+        disabled_ids=disabled_ids,
+        manifest=manifest,
+        manifest_status=manifest_status,
     )
+    extensions = extension_state["extensions"]
+    known_ids = extension_state["known_ids"]
+    user_disabled_count = len(disabled_ids & known_ids)
     script_urls = _read_url_list(
         _EXTENSION_SCRIPT_URLS_ENV,
         manifest_scripts or None,
@@ -594,10 +840,49 @@ def get_extension_status() -> Dict[str, Any]:
             "script_urls": len(script_urls),
             "stylesheet_urls": len(stylesheet_urls),
             "sidecars": len(sidecars),
+            "manifest_extensions": len(extensions),
+            "user_disabled": user_disabled_count,
         },
         "manifest": manifest_status,
+        "extensions": extensions,
         "warnings": diagnostics["warnings"],
     }
+
+
+def set_extension_user_enabled(extension_id: object, enabled: object) -> Dict[str, Any]:
+    """Set the UI-managed enabled override for an installed manifest extension."""
+    if not _valid_extension_id(extension_id):
+        raise ExtensionToggleError("Invalid extension id", status=400)
+    ext_id = str(extension_id).strip()
+    if not isinstance(enabled, bool):
+        raise ExtensionToggleError("enabled must be a boolean", status=400)
+    root = _extension_root()
+    if root is None:
+        raise ExtensionToggleError("Extensions are not configured", status=404)
+    with _EXTENSION_STATE_LOCK:
+        diagnostics = _new_diagnostics()
+        state = _load_extension_state(diagnostics)
+        disabled_ids = set(state.get("disabled_extensions") or [])
+        manifest, manifest_status = _load_manifest_with_status(root, diagnostics)
+        if manifest is None or not manifest_status.get("loaded", False):
+            raise ExtensionToggleError("Extension manifest is not loaded", status=409)
+        extension_state = _manifest_extension_state(manifest, disabled_ids, diagnostics)
+        known_ids: Set[str] = extension_state["known_ids"]
+        manifest_disabled_ids: Set[str] = extension_state["manifest_disabled_ids"]
+        if ext_id not in known_ids:
+            raise ExtensionToggleError("Extension not found", status=404)
+        if ext_id in manifest_disabled_ids:
+            raise ExtensionToggleError("Extension is disabled by its manifest", status=409)
+        if enabled:
+            disabled_ids.discard(ext_id)
+        else:
+            disabled_ids.add(ext_id)
+        _write_extension_state({"disabled_extensions": sorted(disabled_ids)})
+    # Return a fresh status snapshot after the atomic write is visible. Keeping
+    # the readback outside the lock avoids doing the full manifest/status parse
+    # while blocking other toggles; a concurrent toggle may be reflected too,
+    # which is fine because the UI re-renders from the current effective state.
+    return get_extension_status()
 
 
 def inject_extension_tags(index_html: str) -> str:

--- a/api/routes.py
+++ b/api/routes.py
@@ -10307,6 +10307,20 @@ def handle_post(handler, parsed) -> bool:
 
         return j(handler, check_for_updates(force=force, include_agent=include_agent_updates))
 
+    if parsed.path == "/api/extensions/toggle":
+        from api.extensions import ExtensionToggleError, set_extension_user_enabled
+
+        try:
+            return j(
+                handler,
+                set_extension_user_enabled(body.get("id"), body.get("enabled")),
+            )
+        except ExtensionToggleError as exc:
+            return bad(handler, str(exc), status=exc.status)
+        except Exception:
+            logger.exception("extension toggle failed")
+            return bad(handler, "Failed to update extension state", status=500)
+
     if parsed.path == "/api/session/recovery/repair-safe":
         from api.session_recovery import repair_safe_session_recovery
         result = repair_safe_session_recovery(SESSION_DIR, state_db_path=_active_state_db_path())

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -341,24 +341,33 @@ Authenticated administrators can inspect sanitized extension configuration at:
 GET /api/extensions/status
 ```
 
-The endpoint is read-only and follows the normal WebUI authentication rules. The
-same sanitized diagnostics are also shown in **Settings → Extensions** for
-operators who prefer to inspect extension state from the browser. The panel does
-not enable, disable, install, or mutate extensions; it only fetches
-`/api/extensions/status` and offers a copy-diagnostics action.
+The status endpoint is read-only and follows the normal WebUI authentication
+rules. The same sanitized diagnostics are also shown in **Settings → Extensions**
+for operators who prefer to inspect extension state from the browser. Installed
+manifest entries can be enabled or disabled from that panel through the
+authenticated `POST /api/extensions/toggle` endpoint. The toggle writes only a
+WebUI-managed override in the WebUI state directory; it does not edit extension
+manifests, fetch new extension assets, uninstall files, proxy sidecars, or add
+extension-owned backend routes. Manifest entries with `"enabled": false` remain
+manifest-disabled and cannot be re-enabled from WebUI.
 
 The diagnostics return the same public asset URLs that can already be injected
-into the HTML, plus coarse manifest status, asset counts, sanitized declared
-loopback sidecars, and warning codes for rejected or unavailable configuration.
-`manifest.script_count` and `manifest.stylesheet_count` count accepted assets
-from the manifest only; `manifest.sidecar_count` counts accepted enabled loopback
+into the HTML, plus coarse manifest status, per-extension effective state, asset
+counts, sanitized declared loopback sidecars, and warning codes for rejected or
+unavailable configuration. `manifest.script_count` and
+`manifest.stylesheet_count` count accepted assets from the effectively enabled
+manifest entries only; `manifest.sidecar_count` counts accepted enabled loopback
 sidecars from the manifest. `counts.script_urls` and `counts.stylesheet_urls`
 count the final post-env-merge URLs, while `counts.sidecars` counts the sanitized
-sidecar list returned in `sidecars`. `manifest.entry_count` counts the loaded
-top-level manifest object and enabled extension entries that were inspected, not
+sidecar list returned in `sidecars`. `counts.manifest_extensions` counts
+sanitized manifest extension entries with valid IDs, and `counts.user_disabled`
+counts installed manifest entries currently suppressed by the WebUI-managed
+override. `manifest.entry_count` counts the loaded top-level manifest object and
+effectively enabled extension entries that were inspected for injection, not
 every extension object in the file. The endpoint and Settings panel do **not**
 return `HERMES_WEBUI_EXTENSION_DIR`, resolved manifest paths, raw environment
-values, rejected URL strings, rejected sidecar origins, or rejected health paths.
+values, rejected URL strings, rejected sidecar origins, rejected health paths, or
+the override state-file path.
 
 When sanitized loopback sidecars are present, **Settings → Extensions** renders a
 read-only sidecar monitor card. The browser checks each declared `health_url`

--- a/static/index.html
+++ b/static/index.html
@@ -1396,13 +1396,13 @@
             <div class="settings-section-head">
               <div>
                 <div class="settings-section-title" data-i18n="settings_tab_extensions">Extensions</div>
-                <div class="settings-section-meta">Read-only diagnostics for configured WebUI extensions.</div>
+                <div class="settings-section-meta">Diagnostics and enable/disable controls for configured WebUI extensions.</div>
               </div>
               <button class="sm-btn extensions-copy-diagnostics-btn" id="extensionsCopyDiagnosticsBtn" type="button" onclick="copyExtensionsDiagnostics()" disabled>Copy diagnostics</button>
             </div>
             <div class="settings-field extensions-trust-note" id="extensionsTrustModel">
               <label>Trust model</label>
-              <div>Extensions run in the WebUI browser origin and can access the same authenticated APIs as this session. Only load trusted local extension directories.</div>
+              <div>Extensions run in the WebUI browser origin and can access the same authenticated APIs as this session. Only load trusted local extension directories; disabling an extension takes effect after reload for already-injected assets.</div>
             </div>
             <div id="extensionsDiagnostics" class="extensions-diagnostics" aria-live="polite">
               <div class="extensions-loading">Loading extension diagnostics…</div>

--- a/static/panels.js
+++ b/static/panels.js
@@ -7635,7 +7635,7 @@ async function loadSettingsPanel(){
 }
 
 
-// ── Extensions panel (read-only browser-origin diagnostics) ────────────────
+// ── Extensions panel (browser-origin diagnostics + local enable controls) ──
 
 function _extensionStatusLabel(value){
   return value ? 'Enabled' : 'Disabled';
@@ -7658,15 +7658,63 @@ function _extensionWarningList(warnings){
     return '<div class="extension-url-empty">No warnings.</div>';
   }
   return '<ul class="extension-warning-list">'+warnings.map(item=>{
-    const code=esc((item&&item.code)||'unknown_warning');
+    const rawCode=(item&&item.code)||'unknown_warning';
+    const code=esc(rawCode);
     const source=esc((item&&item.source)||'unknown');
-    return `<li><code>${code}</code><span>${source}</span></li>`;
+    const hint=rawCode==='extension_state_unknown_ids'
+      ? '<span>Some saved disabled-extension overrides no longer match the current manifest; re-added extensions with the same id may stay disabled.</span>'
+      : '';
+    return `<li><code>${code}</code><span>${source}</span>${hint}</li>`;
   }).join('')+'</ul>';
 }
 
 function _extensionCountValue(counts,key,urls){
   if(counts&&Number.isFinite(Number(counts[key]))) return Number(counts[key]);
   return Array.isArray(urls)?urls.length:0;
+}
+
+function _extensionEntryStatusLabel(entry){
+  const status=(entry&&entry.status)||'';
+  if(status==='manifest_disabled') return 'Disabled in manifest';
+  if(status==='user_disabled') return 'Disabled';
+  if(status==='enabled') return 'Enabled';
+  return 'Unknown';
+}
+
+function _extensionEntryBadge(entry){
+  const enabled=!!(entry&&entry.effective_enabled);
+  const cls=enabled?'extension-status-badge-on':'extension-status-badge-off';
+  return `<span class="extension-status-badge ${cls}">${esc(_extensionEntryStatusLabel(entry))}</span>`;
+}
+
+function _extensionInstalledList(extensions,extensionDirConfigured){
+  const list=Array.isArray(extensions)?extensions:[];
+  if(!list.length){
+    if(!extensionDirConfigured) return '<div class="extension-url-empty">No extension directory is configured.</div>';
+    return '<div class="extension-url-empty">No manifest extensions are installed in the configured bundle.</div>';
+  }
+  return `<div class="extension-installed-list">${list.map(entry=>{
+    const id=(entry&&entry.id)||'';
+    const name=(entry&&entry.name)||id||'Unnamed extension';
+    const canToggle=!!(entry&&entry.can_toggle);
+    const userEnabled=!!(entry&&entry.user_enabled);
+    const disabledAttr=canToggle?'':' disabled aria-disabled="true"';
+    const buttonText=userEnabled?'Disable':'Enable';
+    const nextEnabled=userEnabled?'false':'true';
+    const note=canToggle
+      ? 'Toggles the WebUI-managed override for the next app load.'
+      : 'Manifest-disabled entries cannot be enabled from WebUI.';
+    return `<div class="extension-installed-row" data-extension-id="${esc(id)}">
+      <div class="extension-installed-main">
+        <div class="extension-installed-title-row">
+          <div class="extension-installed-title">${esc(name)}</div>
+          ${_extensionEntryBadge(entry)}
+        </div>
+        <div class="extension-installed-meta"><code>${esc(id)}</code><span>${esc(note)}</span></div>
+      </div>
+      <button class="sm-btn extension-toggle-btn" type="button" data-extension-toggle-id="${esc(id)}" data-extension-next-enabled="${nextEnabled}"${disabledAttr}>${esc(buttonText)}</button>
+    </div>`;
+  }).join('')}</div>`;
 }
 
 function _extensionSidecarHealthBadge(status,label){
@@ -7757,16 +7805,19 @@ function _renderExtensionsPanel(data,seq){
   const scripts=Array.isArray(data&&data.script_urls)?data.script_urls:[];
   const styles=Array.isArray(data&&data.stylesheet_urls)?data.stylesheet_urls:[];
   const sidecars=Array.isArray(data&&data.sidecars)?data.sidecars:[];
+  const extensions=Array.isArray(data&&data.extensions)?data.extensions:[];
   const statusClass=(data&&data.enabled)?'extension-card-enabled':'extension-card-disabled';
   const scriptCount=_extensionCountValue(counts,'script_urls',scripts);
   const styleCount=_extensionCountValue(counts,'stylesheet_urls',styles);
   const sidecarCount=_extensionCountValue(counts,'sidecars',sidecars);
+  const manifestExtensionCount=_extensionCountValue(counts,'manifest_extensions',extensions);
+  const userDisabledCount=_extensionCountValue(counts,'user_disabled',[]);
   target.innerHTML=`
     <div class="provider-card extension-status-card ${statusClass}">
       <div class="provider-card-header plugin-card-header">
         <div class="provider-card-info">
           <div class="provider-card-name">Extension runtime</div>
-          <div class="provider-card-meta">Read-only status from /api/extensions/status</div>
+          <div class="provider-card-meta">Status from /api/extensions/status; toggles persist a local override for installed manifest entries.</div>
         </div>
         <span class="provider-card-badge ${data&&data.enabled?'':'plugin-card-badge-disabled'}">${_extensionStatusLabel(!!(data&&data.enabled))}</span>
       </div>
@@ -7784,7 +7835,20 @@ function _renderExtensionsPanel(data,seq){
           <div><span>Final script count</span><code>${scriptCount}</code></div>
           <div><span>Final stylesheet count</span><code>${styleCount}</code></div>
           <div><span>Loopback sidecar count</span><code>${sidecarCount}</code></div>
+          <div><span>Installed manifest extensions</span><code>${manifestExtensionCount}</code></div>
+          <div><span>User-disabled extensions</span><code>${userDisabledCount}</code></div>
         </div>
+      </div>
+    </div>
+    <div class="provider-card extension-installed-card">
+      <div class="provider-card-header plugin-card-header">
+        <div class="provider-card-info">
+          <div class="provider-card-name">Installed manifest extensions</div>
+          <div class="provider-card-meta">Enable or disable already-present local extensions. Reload WebUI to apply injected asset changes to this browser tab.</div>
+        </div>
+      </div>
+      <div class="provider-card-body extension-card-body">
+        ${_extensionInstalledList(extensions,!!(data&&data.extension_dir_configured))}
       </div>
     </div>
     <div class="provider-card extension-assets-card">
@@ -7814,7 +7878,34 @@ function _renderExtensionsPanel(data,seq){
       </div>
     </div>
   `;
+  _bindExtensionToggleButtons(target);
   _monitorExtensionSidecars(sidecars,seq);
+}
+
+function _bindExtensionToggleButtons(root){
+  if(!root) return;
+  root.querySelectorAll('[data-extension-toggle-id]').forEach(btn=>{
+    btn.addEventListener('click',()=>handleExtensionToggle(btn));
+  });
+}
+
+async function handleExtensionToggle(btn){
+  if(!btn||btn.disabled) return;
+  const id=btn.dataset.extensionToggleId||'';
+  const enabled=btn.dataset.extensionNextEnabled==='true';
+  if(!id) return;
+  const previousText=btn.textContent;
+  btn.disabled=true;
+  btn.textContent=enabled?'Enabling…':'Disabling…';
+  try{
+    const data=await api('/api/extensions/toggle',{method:'POST',body:JSON.stringify({id,enabled})});
+    showToast(enabled?'Extension enabled. Reload WebUI to apply changes.':'Extension disabled. Reload WebUI to apply changes.');
+    _renderExtensionsPanel(data,++_extensionsSidecarMonitorSeq);
+  }catch(e){
+    btn.disabled=false;
+    btn.textContent=previousText;
+    showToast('Failed to update extension: '+(e&&e.message?e.message:String(e)));
+  }
 }
 
 async function loadExtensionsPanel(){

--- a/static/style.css
+++ b/static/style.css
@@ -4616,6 +4616,15 @@ main.main > #mainPlugin{display:none;}
 .extension-url-list code,.extension-warning-list code{font-family:var(--font-mono);font-size:11px;color:var(--text);overflow-wrap:anywhere;word-break:break-word;}
 .extension-warning-list span{font-size:11px;color:var(--muted);overflow-wrap:anywhere;}
 .extension-url-empty{margin-top:6px;font-size:12px;color:var(--muted);font-style:italic;}
+.extension-installed-list{display:flex;flex-direction:column;gap:8px;}
+.extension-installed-row{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:9px 10px;border:1px solid var(--border);border-radius:8px;background:var(--surface);min-width:0;}
+.extension-installed-main{min-width:0;display:flex;flex-direction:column;gap:4px;}
+.extension-installed-title-row{display:flex;align-items:center;gap:8px;flex-wrap:wrap;min-width:0;}
+.extension-installed-title{font-size:13px;font-weight:600;color:var(--text);overflow-wrap:anywhere;min-width:0;}
+.extension-installed-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:11px;color:var(--muted);}
+.extension-installed-meta code{font-family:var(--font-mono);font-size:11px;color:var(--text);overflow-wrap:anywhere;word-break:break-word;}
+.extension-toggle-btn{white-space:nowrap;flex:0 0 auto;}
+.extension-toggle-btn:disabled{opacity:.55;cursor:not-allowed;}
 .extension-sidecar-list{display:flex;flex-direction:column;gap:8px;}
 .extension-sidecar-row{padding:9px 10px;border:1px solid var(--border);border-radius:8px;background:var(--surface);min-width:0;}
 .extension-sidecar-row-head{display:flex;align-items:center;justify-content:space-between;gap:10px;min-width:0;}
@@ -4632,6 +4641,8 @@ main.main > #mainPlugin{display:none;}
 @media (max-width: 768px){
   .extensions-copy-diagnostics-btn{width:100%;}
   .extension-summary-grid{grid-template-columns:1fr;}
+  .extension-installed-row{align-items:flex-start;flex-direction:column;}
+  .extension-toggle-btn{width:100%;}
   .extension-sidecar-row-head{align-items:flex-start;flex-direction:column;}
   .extension-sidecar-fields>div{flex-direction:column;gap:2px;}
   .extension-sidecar-fields span{flex:0 0 auto;}

--- a/tests/test_extension_status_endpoint.py
+++ b/tests/test_extension_status_endpoint.py
@@ -1,6 +1,7 @@
 """Tests for sanitized WebUI extension diagnostics."""
 
 from types import SimpleNamespace
+import json
 
 import pytest
 
@@ -49,6 +50,26 @@ def _clear_extension_env(monkeypatch):
     auth_mod._invalidate_password_hash_cache()
 
 
+def _use_extension_state_dir(monkeypatch, tmp_path):
+    state_dir = tmp_path / "webui-state"
+    state_dir.mkdir()
+    monkeypatch.setenv("HERMES_WEBUI_STATE_DIR", str(state_dir))
+    import api.extensions as extensions
+
+    monkeypatch.setattr(extensions, "_extension_state_dir", lambda: state_dir)
+    return state_dir
+
+
+def _status_counts_empty():
+    return {
+        "script_urls": 0,
+        "stylesheet_urls": 0,
+        "sidecars": 0,
+        "manifest_extensions": 0,
+        "user_disabled": 0,
+    }
+
+
 def test_extension_status_disabled_by_default():
     from api.extensions import get_extension_status
 
@@ -59,7 +80,7 @@ def test_extension_status_disabled_by_default():
         "script_urls": [],
         "stylesheet_urls": [],
         "sidecars": [],
-        "counts": {"script_urls": 0, "stylesheet_urls": 0, "sidecars": 0},
+        "counts": _status_counts_empty(),
         "manifest": {
             "configured": False,
             "loaded": False,
@@ -69,6 +90,7 @@ def test_extension_status_disabled_by_default():
             "stylesheet_count": 0,
             "sidecar_count": 0,
         },
+        "extensions": [],
         "warnings": [],
     }
 
@@ -127,7 +149,31 @@ def test_extension_status_reports_loaded_manifest_counts_and_urls(tmp_path, monk
         "/extensions/templates/app.css",
     ]
     assert status["sidecars"] == []
-    assert status["counts"] == {"script_urls": 3, "stylesheet_urls": 2, "sidecars": 0}
+    assert status["counts"] == {"script_urls": 3, "stylesheet_urls": 2, "sidecars": 0, "manifest_extensions": 2, "user_disabled": 0}
+    assert status["extensions"] == [
+        {
+            "id": "templates",
+            "name": "templates",
+            "manifest_enabled": True,
+            "user_enabled": True,
+            "user_disabled": False,
+            "effective_enabled": True,
+            "can_toggle": True,
+            "reload_required": True,
+            "status": "enabled",
+        },
+        {
+            "id": "off",
+            "name": "off",
+            "manifest_enabled": False,
+            "user_enabled": False,
+            "user_disabled": False,
+            "effective_enabled": False,
+            "can_toggle": False,
+            "reload_required": True,
+            "status": "manifest_disabled",
+        },
+    ]
     assert status["manifest"] == {
         "configured": True,
         "loaded": True,
@@ -652,6 +698,395 @@ def test_extension_status_truncates_many_sidecars_with_sanitized_warning(tmp_pat
         {"code": "sidecar_list_truncated", "source": "manifest:sidecars"}
     ]
 
+
+
+
+def test_extension_user_disabled_override_suppresses_manifest_assets_and_sidecars(tmp_path, monkeypatch):
+    state_dir = _use_extension_state_dir(monkeypatch, tmp_path)
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "extensions.json").write_text(
+        """
+        {
+          "extensions": [
+            {
+              "id": "desktop-companion",
+              "name": "Desktop Companion",
+              "scripts": ["companion.js"],
+              "stylesheets": ["companion.css"],
+              "sidecar": {"type": "loopback", "origin": "http://127.0.0.1:17787"}
+            },
+            {"id": "templates", "scripts": ["templates.js"]}
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+    (state_dir / "extension-overrides.json").write_text(
+        json.dumps({"version": 1, "disabled_extensions": ["desktop-companion"]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import get_extension_config, get_extension_status
+
+    status = get_extension_status()
+    assert status["script_urls"] == ["/extensions/templates.js"]
+    assert status["stylesheet_urls"] == []
+    assert status["sidecars"] == []
+    assert status["manifest"]["script_count"] == 1
+    assert status["manifest"]["stylesheet_count"] == 0
+    assert status["manifest"]["sidecar_count"] == 0
+    assert status["counts"]["manifest_extensions"] == 2
+    assert status["counts"]["user_disabled"] == 1
+    companion = next(item for item in status["extensions"] if item["id"] == "desktop-companion")
+    assert companion["user_disabled"] is True
+    assert companion["user_enabled"] is False
+    assert companion["effective_enabled"] is False
+    assert companion["can_toggle"] is True
+    assert companion["status"] == "user_disabled"
+    assert "17787" not in repr(status)
+
+    config = get_extension_config()
+    assert config["script_urls"] == ["/extensions/templates.js"]
+    assert config["stylesheet_urls"] == []
+
+
+def test_extension_state_invalid_file_fails_safe_without_path_leak(tmp_path, monkeypatch):
+    state_dir = _use_extension_state_dir(monkeypatch, tmp_path)
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "extensions.json").write_text(
+        '{"extensions":[{"id":"templates","scripts":["templates.js"]}]}',
+        encoding="utf-8",
+    )
+    state_file = state_dir / "extension-overrides.json"
+    state_file.write_text("{not json", encoding="utf-8")
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import get_extension_status
+
+    status = get_extension_status()
+    assert status["script_urls"] == ["/extensions/templates.js"]
+    assert status["warnings"] == [
+        {"code": "extension_state_unreadable", "source": "extension_state"}
+    ]
+    rendered = repr(status)
+    assert str(state_file) not in rendered
+    assert str(state_dir) not in rendered
+
+
+def test_set_extension_user_enabled_persists_override_and_reenables(tmp_path, monkeypatch):
+    state_dir = _use_extension_state_dir(monkeypatch, tmp_path)
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "extensions.json").write_text(
+        '{"extensions":[{"id":"templates","scripts":["templates.js"]}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import set_extension_user_enabled
+
+    disabled = set_extension_user_enabled("templates", False)
+    assert disabled["script_urls"] == []
+    assert disabled["counts"]["user_disabled"] == 1
+    assert json.loads((state_dir / "extension-overrides.json").read_text(encoding="utf-8")) == {
+        "version": 1,
+        "disabled_extensions": ["templates"],
+    }
+
+    enabled = set_extension_user_enabled("templates", True)
+    assert enabled["script_urls"] == ["/extensions/templates.js"]
+    assert enabled["counts"]["user_disabled"] == 0
+    assert json.loads((state_dir / "extension-overrides.json").read_text(encoding="utf-8")) == {
+        "version": 1,
+        "disabled_extensions": [],
+    }
+
+
+def test_set_extension_user_enabled_rejects_unknown_manifest_disabled_and_bad_shapes(tmp_path, monkeypatch):
+    _use_extension_state_dir(monkeypatch, tmp_path)
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "extensions.json").write_text(
+        '{"extensions":[{"id":"templates"},{"id":"off","enabled":false}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import ExtensionToggleError, set_extension_user_enabled
+
+    with pytest.raises(ExtensionToggleError) as bad_id:
+        set_extension_user_enabled("../templates", False)
+    assert bad_id.value.status == 400
+
+    with pytest.raises(ExtensionToggleError) as bad_enabled:
+        set_extension_user_enabled("templates", "false")
+    assert bad_enabled.value.status == 400
+
+    with pytest.raises(ExtensionToggleError) as unknown:
+        set_extension_user_enabled("missing", False)
+    assert unknown.value.status == 404
+
+    with pytest.raises(ExtensionToggleError) as manifest_disabled_enable:
+        set_extension_user_enabled("off", True)
+    assert manifest_disabled_enable.value.status == 409
+
+    with pytest.raises(ExtensionToggleError) as manifest_disabled_disable:
+        set_extension_user_enabled("off", False)
+    assert manifest_disabled_disable.value.status == 409
+
+
+
+def test_extension_state_fails_safe_for_invalid_shapes_without_path_leak(tmp_path, monkeypatch):
+    state_dir = _use_extension_state_dir(monkeypatch, tmp_path)
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "extensions.json").write_text(
+        '{"extensions":[{"id":"templates","scripts":["templates.js"]}]}',
+        encoding="utf-8",
+    )
+    state_file = state_dir / "extension-overrides.json"
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import get_extension_status
+
+    cases = [
+        (b"\xff\xfe", "extension_state_unreadable"),
+        (json.dumps(["templates"]).encode("utf-8"), "extension_state_invalid"),
+        (json.dumps({"disabled_extensions": "templates"}).encode("utf-8"), "extension_state_invalid"),
+    ]
+    for raw, warning_code in cases:
+        state_file.write_bytes(raw)
+        status = get_extension_status()
+        assert status["script_urls"] == ["/extensions/templates.js"]
+        assert {tuple(sorted(item.items())) for item in status["warnings"]} == {
+            tuple(sorted({"code": warning_code, "source": "extension_state"}.items()))
+        }
+        rendered = repr(status)
+        assert str(state_file) not in rendered
+        assert str(state_dir) not in rendered
+
+
+def test_extension_state_oversized_and_truncated_are_sanitized(tmp_path, monkeypatch):
+    state_dir = _use_extension_state_dir(monkeypatch, tmp_path)
+    root = tmp_path / "extensions"
+    root.mkdir()
+    entries = [
+        {"id": f"ext-{index}", "scripts": [f"ext-{index}.js"] if index in (0, 511, 512) else []}
+        for index in range(520)
+    ]
+    (root / "extensions.json").write_text(
+        json.dumps({"extensions": entries}),
+        encoding="utf-8",
+    )
+    state_file = state_dir / "extension-overrides.json"
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import get_extension_status
+
+    state_file.write_text(" " * (32 * 1024 + 1), encoding="utf-8")
+    oversized = get_extension_status()
+    assert oversized["counts"]["user_disabled"] == 0
+    assert oversized["warnings"] == [
+        {"code": "extension_state_oversized", "source": "extension_state"}
+    ]
+    assert str(state_file) not in repr(oversized)
+
+    state_file.write_text(
+        json.dumps({"disabled_extensions": [f"ext-{index}" for index in range(520)]}),
+        encoding="utf-8",
+    )
+    truncated = get_extension_status()
+    assert truncated["counts"]["user_disabled"] == 512
+    assert {tuple(sorted(item.items())) for item in truncated["warnings"]} == {
+        tuple(sorted({"code": "extension_state_truncated", "source": "extension_state"}.items()))
+    }
+    assert "/extensions/ext-0.js" not in truncated["script_urls"]
+    assert "/extensions/ext-511.js" not in truncated["script_urls"]
+    assert "/extensions/ext-512.js" in truncated["script_urls"]
+
+
+def test_extension_state_recursion_error_fails_safe(tmp_path, monkeypatch):
+    state_dir = _use_extension_state_dir(monkeypatch, tmp_path)
+    state_file = state_dir / "extension-overrides.json"
+    state_file.write_text('{"disabled_extensions":["templates"]}', encoding="utf-8")
+
+    import api.extensions as extensions
+
+    def raise_recursion_error(_text):
+        raise RecursionError("state nesting exceeded")
+
+    monkeypatch.setattr(extensions.json, "loads", raise_recursion_error)
+    state = extensions._load_extension_state({"warnings": []})
+    assert state == {"version": 1, "disabled_extensions": []}
+
+    diagnostics = {"warnings": []}
+    extensions._load_extension_state(diagnostics)
+    assert diagnostics["warnings"] == [
+        {"code": "extension_state_unreadable", "source": "extension_state"}
+    ]
+
+
+def test_extension_state_invalid_entries_and_stale_ids_are_sanitized(tmp_path, monkeypatch):
+    state_dir = _use_extension_state_dir(monkeypatch, tmp_path)
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "extensions.json").write_text(
+        '{"extensions":[{"id":"templates","scripts":["templates.js"]}]}',
+        encoding="utf-8",
+    )
+    (state_dir / "extension-overrides.json").write_text(
+        json.dumps({"disabled_extensions": ["templates", "../bad", "missing"]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import get_extension_status
+
+    status = get_extension_status()
+    assert status["script_urls"] == []
+    assert status["counts"]["user_disabled"] == 1
+    assert {tuple(sorted(item.items())) for item in status["warnings"]} == {
+        tuple(sorted({"code": "extension_state_invalid_entries", "source": "extension_state"}.items())),
+        tuple(sorted({"code": "extension_state_unknown_ids", "source": "extension_state"}.items())),
+    }
+    rendered = repr(status)
+    assert "../bad" not in rendered
+    assert "missing" not in rendered
+
+
+def test_set_extension_user_enabled_is_idempotent_and_preserves_stale_ids(tmp_path, monkeypatch):
+    state_dir = _use_extension_state_dir(monkeypatch, tmp_path)
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "extensions.json").write_text(
+        '{"extensions":[{"id":"templates","scripts":["templates.js"]}]}',
+        encoding="utf-8",
+    )
+    (state_dir / "extension-overrides.json").write_text(
+        json.dumps({"version": 1, "disabled_extensions": ["stale"]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "extensions.json")
+
+    from api.extensions import set_extension_user_enabled
+
+    set_extension_user_enabled("templates", False)
+    set_extension_user_enabled("templates", False)
+    assert json.loads((state_dir / "extension-overrides.json").read_text(encoding="utf-8")) == {
+        "version": 1,
+        "disabled_extensions": ["stale", "templates"],
+    }
+
+    status = set_extension_user_enabled("templates", True)
+    assert status["script_urls"] == ["/extensions/templates.js"]
+    assert json.loads((state_dir / "extension-overrides.json").read_text(encoding="utf-8")) == {
+        "version": 1,
+        "disabled_extensions": ["stale"],
+    }
+    assert status["warnings"] == [
+        {"code": "extension_state_unknown_ids", "source": "extension_state"}
+    ]
+
+
+def test_set_extension_user_enabled_rejects_when_extensions_unconfigured(monkeypatch):
+    from api.extensions import ExtensionToggleError, set_extension_user_enabled
+
+    with pytest.raises(ExtensionToggleError) as exc:
+        set_extension_user_enabled("templates", False)
+    assert exc.value.status == 404
+
+
+def test_extension_toggle_route_uses_csrf_gate(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_PASSWORD", "test-password")
+    from api import auth as auth_mod, routes
+
+    auth_mod._invalidate_password_hash_cache()
+    handler = FakeHandler()
+    handler.headers = {
+        "Origin": "http://example.com",
+        "Host": "example.com",
+        "Content-Length": "2",
+    }
+
+    result = routes.handle_post(handler, SimpleNamespace(path="/api/extensions/toggle"))
+    assert result is None
+    assert handler.status == 403
+    assert json.loads(handler.body.decode("utf-8"))["error"] == "Session expired - reload the page"
+    assert routes._csrf_exempt_path("/api/extensions/toggle") is False
+
+
+def test_extension_toggle_route_requires_webui_auth(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_PASSWORD", "test-password")
+
+    from api import auth as auth_mod
+    from api.auth import check_auth
+
+    auth_mod._invalidate_password_hash_cache()
+    handler = FakeHandler()
+
+    assert check_auth(handler, SimpleNamespace(path="/api/extensions/toggle", query="")) is False
+    assert handler.status == 401
+    assert handler.header("Location") is None
+    assert json.loads(handler.body.decode("utf-8"))["error"] == "Authentication required"
+
+
+def test_extension_toggle_route_is_wired_for_enable_disable(monkeypatch, tmp_path):
+    from api import routes
+
+    captured = {}
+
+    def fake_j(handler, data, status=200, headers=None):
+        captured["data"] = data
+        captured["status"] = status
+        return True
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda handler: {"id": "templates", "enabled": False})
+    monkeypatch.setattr(routes, "j", fake_j)
+    monkeypatch.setattr(
+        "api.extensions.set_extension_user_enabled",
+        lambda extension_id, enabled: {"ok": True, "id": extension_id, "enabled": enabled},
+    )
+    handler = FakeHandler()
+
+    assert routes.handle_post(handler, SimpleNamespace(path="/api/extensions/toggle")) is True
+    assert captured == {"status": 200, "data": {"ok": True, "id": "templates", "enabled": False}}
+
+
+def test_extension_toggle_route_returns_sanitized_errors(monkeypatch):
+    from api import routes
+    from api.extensions import ExtensionToggleError
+
+    captured = {}
+
+    def fake_bad(handler, msg, status=400):
+        captured["error"] = msg
+        captured["status"] = status
+        return True
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda handler: {"id": "missing", "enabled": False})
+    monkeypatch.setattr(routes, "bad", fake_bad)
+
+    def raise_toggle_error(_extension_id, _enabled):
+        raise ExtensionToggleError("Extension not found", status=404)
+
+    monkeypatch.setattr("api.extensions.set_extension_user_enabled", raise_toggle_error)
+    handler = FakeHandler()
+
+    assert routes.handle_post(handler, SimpleNamespace(path="/api/extensions/toggle")) is True
+    assert captured == {"error": "Extension not found", "status": 404}
 
 
 def test_extension_status_route_is_wired(monkeypatch):

--- a/tests/test_extensions_settings_panel.py
+++ b/tests/test_extensions_settings_panel.py
@@ -1,4 +1,4 @@
-"""Regression tests for the read-only Settings → Extensions diagnostics panel."""
+"""Regression tests for the Settings → Extensions diagnostics and toggles."""
 from pathlib import Path
 import re
 
@@ -52,20 +52,21 @@ def test_settings_sidebar_has_extensions_section_and_pane():
     assert 'data-i18n="settings_tab_extensions"' in INDEX_HTML
 
 
-def test_extensions_panel_is_read_only_and_warns_about_trust_model():
+def test_extensions_panel_warns_about_trust_model_and_stays_install_free():
     pane_start = INDEX_HTML.index('id="settingsPaneExtensions"')
     pane_end = INDEX_HTML.index('id="settingsPaneSystem"', pane_start)
     pane = INDEX_HTML[pane_start:pane_end]
 
-    assert "Read-only diagnostics" in pane
+    assert "Diagnostics and enable/disable controls" in pane
     assert "Extensions run in the WebUI browser origin" in pane
     assert "Only load trusted local extension directories" in pane
+    assert "takes effect after reload" in pane
     assert "copyExtensionsDiagnostics()" in pane
     assert "saveSettings(" not in pane
     assert "api('/api/settings'" not in pane
     assert "type=\"checkbox\"" not in pane
-    assert "toggle" not in pane.lower()
-    assert "install" not in pane.lower()
+    assert "Install" not in pane
+    assert "Uninstall" not in pane
     assert "marketplace" not in pane.lower()
 
 
@@ -89,7 +90,7 @@ def test_settings_search_knows_extensions_pane():
     assert "extensions: 'settingsPaneExtensions'" in resolve_block
 
 
-def test_extensions_panel_fetches_status_endpoint_only():
+def test_extensions_panel_fetches_status_endpoint_without_mutating_settings():
     load_block = _function_block("loadExtensionsPanel", extra=900)
 
     assert "api('/api/extensions/status')" in load_block
@@ -113,12 +114,19 @@ def test_extensions_panel_renders_sanitized_status_payload():
     assert "script_urls" in render_block
     assert "stylesheet_urls" in render_block
     assert "data&&data.sidecars" in render_block
+    assert "data&&data.extensions" in render_block
+    assert "counts,'manifest_extensions'" in render_block
+    assert "counts,'user_disabled'" in render_block
+    assert "_extensionInstalledList(extensions,!!(data&&data.extension_dir_configured))" in render_block
     assert "_extensionSidecarCard(sidecars)" in render_block
     assert "data&&data.warnings" in render_block
     assert "esc(url)" in asset_block
     assert "esc(manifest.status||'unknown')" in render_block
-    assert "esc((item&&item.code)||'unknown_warning')" in warning_block
+    assert "const rawCode=(item&&item.code)||'unknown_warning'" in warning_block
+    assert "const code=esc(rawCode)" in warning_block
     assert "esc((item&&item.source)||'unknown')" in warning_block
+    assert "extension_state_unknown_ids" in warning_block
+    assert "Some saved disabled-extension overrides no longer match the current manifest" in warning_block
     assert "Rejected" not in render_block  # rejected values must never be rendered directly
 
 
@@ -152,6 +160,26 @@ def test_extensions_panel_renders_loopback_sidecar_monitor_safely():
     assert not _contains_post_method(monitor_block)
 
 
+def test_extensions_panel_toggle_uses_dedicated_endpoint_without_settings_or_install():
+    installed_block = _between("function _extensionInstalledList", "function _extensionSidecarHealthBadge")
+    toggle_block = _between("async function handleExtensionToggle", "async function loadExtensionsPanel")
+
+    assert "data-extension-toggle-id" in installed_block
+    assert "data-extension-next-enabled" in installed_block
+    assert "No extension directory is configured." in installed_block
+    assert "No manifest extensions are installed in the configured bundle." in installed_block
+    assert "extensionDirConfigured" in installed_block
+    assert "Manifest-disabled entries cannot be enabled from WebUI." in installed_block
+    assert "api('/api/extensions/toggle',{method:'POST',body:JSON.stringify({id,enabled})})" in toggle_block
+    assert "Reload WebUI to apply changes" in toggle_block
+    combined = installed_block + toggle_block
+    assert "api('/api/settings'" not in combined
+    assert ">Install<" not in combined
+    assert "Install extension" not in combined
+    assert "Uninstall" not in combined
+    assert "marketplace" not in combined.lower()
+
+
 def test_copy_extensions_diagnostics_copies_current_sanitized_payload():
     copy_block = _between("function copyExtensionsDiagnostics", "// ── Plugins panel")
 
@@ -168,6 +196,8 @@ def test_extensions_styles_are_scoped_to_extensions_panel():
     assert ".extension-summary-grid" in STYLE_CSS
     assert ".extension-warning-list" in STYLE_CSS
     assert ".extension-url-list" in STYLE_CSS
+    assert ".extension-installed-list" in STYLE_CSS
+    assert ".extension-toggle-btn" in STYLE_CSS
     assert ".extension-sidecar-list" in STYLE_CSS
     assert ".extension-sidecar-status-badge" in STYLE_CSS
 
@@ -180,14 +210,21 @@ def test_extensions_tab_i18n_key_exists_for_all_locales():
     assert not missing, f"Locale(s) missing settings_tab_extensions: {missing}"
 
 
-def test_extensions_docs_mentions_settings_panel_without_mutation_claims():
+def test_extensions_docs_mentions_settings_panel_without_install_or_proxy_claims():
     diagnostics_section = DOCS_EXTENSIONS[DOCS_EXTENSIONS.index("## Diagnostics"):]
 
     assert "Settings → Extensions" in diagnostics_section
-    assert "enable, disable, install, or mutate extensions" in diagnostics_section
-    assert "`/api/extensions/status`" in diagnostics_section
+    assert "`POST /api/extensions/toggle`" in diagnostics_section
+    assert "WebUI-managed override" in diagnostics_section
+    assert "does not edit extension" in diagnostics_section
+    assert "manifests" in diagnostics_section
+    assert "fetch new extension assets" in diagnostics_section
+    assert "uninstall files" in diagnostics_section
+    assert "proxy sidecars" in diagnostics_section
+    assert "GET /api/extensions/status" in diagnostics_section
     assert "sanitized loopback sidecars" in diagnostics_section
     assert "credentials: 'omit'" in diagnostics_section
     assert "does **not** proxy sidecar requests" in diagnostics_section
     assert "do **not**" in diagnostics_section
     assert "return `HERMES_WEBUI_EXTENSION_DIR`" in diagnostics_section
+    assert "override state-file path" in diagnostics_section


### PR DESCRIPTION
## Release v0.51.568 — toggle installed extensions (#4637)

Ships **#4637** (santastabber) — Phase 2 of the extensions ecosystem, following the shipped #4612 sidecar diagnostics. Nathan greenlit the concept.

### What

Adds UI enable/disable of installed manifest extensions from **Settings → Extensions**, backed by a small WebUI-managed `extension-overrides.json` state file. A disabled extension's scripts, stylesheets, and loopback sidecars are suppressed end-to-end. Extensions disabled in their own manifest stay non-toggleable. WebUI never edits extension manifests, fetches their assets, or proxies their sidecars.

### Security boundary (new authenticated mutating endpoint in a security-sensitive subsystem)
- **No path traversal:** extension id is anchored-regex validated (`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`, fullmatch) and used only as a JSON key — never concatenated into a filesystem path; the state file is a fixed name in a fixed dir; toggle gated on `id ∈ known_ids` (404 otherwise).
- **Auth + CSRF:** `/api/extensions/toggle` is not CSRF-exempt → global 403 + auth 401, fails closed.
- **Atomic write:** same-dir tmp → fsync → `os.replace` under `_EXTENSION_STATE_LOCK`, UTF-8.
- **DoS bounds:** 32 KiB state cap, 512-id disabled-list cap, 128-char id cap — all fail safe to empty state.
- **XSS-safe UI:** every dynamic field escaped via `esc()`.

### Review trail
- **Codex (regression gate): SAFE TO SHIP** — full security trace verified (path-traversal boundary, auth/CSRF gating, atomicity, disabled-override suppression end-to-end, manifest-disabled non-toggleable, existing status surface unchanged).
- **Opus (advisor): SAFE** — DoS caps fail-safe, `_read_manifest_urls_with_diagnostics` refactor preserves the #4612 sidecar diagnostics, no XSS.
- **Full suite: 10011 passed** (the sole failure was the known `test_tls_startup_failure_fallback_to_http` flake — passes in isolation, #4637 touches no TLS/server code).

Co-authored-by: santastabber <santastabber@users.noreply.github.com>

Closes #4637
