### PR TITLE
Release v0.51.575 — session-list perf for long histories (#4597)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.575] — 2026-06-22 — Release UH (session-list perf for long histories)
+
+### Fixed
+
+- **Faster session sidebar for accounts with long or archived conversation histories.** Building the session list did redundant per-session work (lineage/metadata enrichment and filtering) across the full history even when most of it was archived/off-screen, making `GET /api/sessions` slow for heavy users. The route now skips that work for archived histories and applies the cheap state-DB source corrections before filtering, so visible sessions and their child lineage still render correctly while the list builds substantially faster. Thanks @santastabber. (#4597)
+
 ## [v0.51.574] — 2026-06-22 — Release UG (transparent-stream collapsed tool previews)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -24,6 +24,7 @@ from api.usage import prompt_cache_hit_percent
 from api.agent_sessions import (
     _is_continuation_session,
     is_cli_session_row,
+    normalize_agent_session_source,
     read_importable_agent_session_rows,
     read_session_lineage_metadata,
 )
@@ -3199,6 +3200,106 @@ def _sidebar_title_is_generic_webui(title: str | None) -> bool:
     return text.startswith(prefix) and text[len(prefix):].isdigit()
 
 
+def _read_state_db_sidebar_overrides(db_path: Path, session_ids: set[str]) -> dict[str, dict]:
+    """Return cheap state.db source/title overrides for sidebar rows.
+
+    This intentionally does not chase lineage parents/children. It is used on
+    the /api/sessions hot path before CLI filtering so state.db can correct
+    stale JSON source flags without paying the full lineage-enrichment cost.
+    """
+    wanted = {str(sid) for sid in (session_ids or set()) if sid}
+    if not wanted or not db_path.exists():
+        return {}
+    try:
+        import sqlite3
+    except ImportError:
+        return {}
+    try:
+        with closing(sqlite3.connect(str(db_path))) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("PRAGMA table_info(sessions)")
+            session_cols = {row[1] for row in cur.fetchall()}
+            if 'id' not in session_cols:
+                return {}
+            source_expr = 's.source' if 'source' in session_cols else 'NULL AS source'
+            session_source_expr = 's.session_source' if 'session_source' in session_cols else 'NULL AS session_source'
+            title_expr = 's.title' if 'title' in session_cols else 'NULL AS title'
+            overrides: dict[str, dict] = {}
+            ids = list(wanted)
+            chunk_size = 500
+            for i in range(0, len(ids), chunk_size):
+                chunk = ids[i:i + chunk_size]
+                placeholders = ','.join('?' * len(chunk))
+                cur.execute(
+                    f"""
+                    SELECT s.id, {source_expr}, {session_source_expr}, {title_expr}
+                    FROM sessions s
+                    WHERE s.id IN ({placeholders})
+                    """,
+                    chunk,
+                )
+                for row in cur.fetchall():
+                    sid = str(row['id'])
+                    entry: dict[str, object] = {}
+                    state_title = str(row['title'] or '').strip()
+                    if state_title:
+                        entry['_state_db_title'] = state_title
+                    state_source = str(row['source'] or '').strip().lower()
+                    if state_source:
+                        entry['_state_db_source'] = state_source
+                        source_meta = normalize_agent_session_source(state_source)
+                        entry['_state_db_source_tag'] = state_source
+                        entry['_state_db_raw_source'] = source_meta.get('raw_source')
+                        entry['_state_db_session_source'] = source_meta.get('session_source')
+                        entry['_state_db_source_label'] = source_meta.get('source_label')
+                    if entry:
+                        overrides[sid] = entry
+            return overrides
+    except Exception:
+        return {}
+
+
+def _apply_sidebar_state_db_overrides(sessions: list[dict]) -> None:
+    """Apply state.db source/title overrides without full lineage enrichment."""
+    try:
+        metadata = _read_state_db_sidebar_overrides(
+            _active_state_db_path(),
+            {str(s.get('session_id')) for s in sessions if s.get('session_id')},
+        )
+    except Exception:
+        return
+    _apply_sidebar_state_db_override_metadata(sessions, metadata)
+
+
+def _apply_sidebar_state_db_override_metadata(sessions: list[dict], metadata: dict[str, dict]) -> None:
+    for session in sessions:
+        sid = session.get('session_id')
+        if sid not in metadata:
+            continue
+        entry = dict(metadata[sid])
+        state_db_title = entry.pop('_state_db_title', None)
+        state_db_source = entry.pop('_state_db_source', None)
+        state_db_source_tag = entry.pop('_state_db_source_tag', None)
+        state_db_raw_source = entry.pop('_state_db_raw_source', None)
+        state_db_session_source = entry.pop('_state_db_session_source', None)
+        state_db_source_label = entry.pop('_state_db_source_label', None)
+        if state_db_source == 'webui':
+            session['source_tag'] = state_db_source_tag
+            session['raw_source'] = state_db_raw_source
+            session['session_source'] = state_db_session_source
+            session['source_label'] = state_db_source_label
+            session['is_cli_session'] = False
+        title = session.get('title')
+        if (
+            state_db_title
+            and state_db_title != title
+            and _sidebar_title_is_generic_webui(title)
+        ):
+            session['_state_db_title'] = state_db_title
+            session['display_title'] = state_db_title
+
+
 def _enrich_sidebar_lineage_metadata(sessions: list[dict]) -> None:
     """Attach state.db compression lineage metadata used by sidebar collapse.
 
@@ -3227,31 +3328,21 @@ def _enrich_sidebar_lineage_metadata(sessions: list[dict]) -> None:
         )
     except Exception:
         return
+    _apply_sidebar_state_db_override_metadata(sessions, metadata)
     for session in sessions:
         sid = session.get('session_id')
         if sid in metadata:
             entry = dict(metadata[sid])
-            state_db_title = entry.pop('_state_db_title', None)
-            state_db_source = entry.pop('_state_db_source', None)
-            state_db_source_tag = entry.pop('_state_db_source_tag', None)
-            state_db_raw_source = entry.pop('_state_db_raw_source', None)
-            state_db_session_source = entry.pop('_state_db_session_source', None)
-            state_db_source_label = entry.pop('_state_db_source_label', None)
-            session.update(entry)
-            if state_db_source == 'webui':
-                session['source_tag'] = state_db_source_tag
-                session['raw_source'] = state_db_raw_source
-                session['session_source'] = state_db_session_source
-                session['source_label'] = state_db_source_label
-                session['is_cli_session'] = False
-            title = session.get('title')
-            if (
-                state_db_title
-                and state_db_title != title
-                and _sidebar_title_is_generic_webui(title)
+            for key in (
+                '_state_db_title',
+                '_state_db_source',
+                '_state_db_source_tag',
+                '_state_db_raw_source',
+                '_state_db_session_source',
+                '_state_db_source_label',
             ):
-                session['_state_db_title'] = state_db_title
-                session['display_title'] = state_db_title
+                entry.pop(key, None)
+            session.update(entry)
 
 
 def _diag_stage(diag, name: str) -> None:
@@ -3262,7 +3353,7 @@ def _diag_stage(diag, name: str) -> None:
             pass
 
 
-def all_sessions(diag=None):
+def all_sessions(diag=None, *, include_lineage_metadata: bool = True):
     _diag_stage(diag, "all_sessions.active_streams")
     active_stream_ids = _active_stream_ids()
     # Phase C: try index first for O(1) read; fall back to full scan
@@ -3356,8 +3447,13 @@ def all_sessions(diag=None):
                 and not s.get('has_pending_user_message')
                 and not s.get('worktree_path')
             )]
-            _diag_stage(diag, "all_sessions.lineage_metadata")
-            _enrich_sidebar_lineage_metadata(result)
+            if include_lineage_metadata:
+                _diag_stage(diag, "all_sessions.lineage_metadata")
+                _enrich_sidebar_lineage_metadata(result)
+            else:
+                _diag_stage(diag, "all_sessions.state_db_overrides")
+                _apply_sidebar_state_db_overrides(result)
+                _diag_stage(diag, "all_sessions.lineage_metadata_skipped")
             result = _prefer_fuller_snapshots_for_sidebar(result)
             sidebar_candidates = result
             visible_result = [s for s in sidebar_candidates if not _hide_from_default_sidebar(s)]
@@ -3397,8 +3493,13 @@ def all_sessions(diag=None):
         and not s.pending_user_message
         and not getattr(s, 'worktree_path', None)
     )]
-    _diag_stage(diag, "all_sessions.lineage_metadata")
-    _enrich_sidebar_lineage_metadata(result)
+    if include_lineage_metadata:
+        _diag_stage(diag, "all_sessions.lineage_metadata")
+        _enrich_sidebar_lineage_metadata(result)
+    else:
+        _diag_stage(diag, "all_sessions.state_db_overrides")
+        _apply_sidebar_state_db_overrides(result)
+        _diag_stage(diag, "all_sessions.lineage_metadata_skipped")
     result = _prefer_fuller_snapshots_for_sidebar(result)
     sidebar_candidates = result
     visible_result = [s for s in sidebar_candidates if not _hide_from_default_sidebar(s)]

--- a/api/routes.py
+++ b/api/routes.py
@@ -453,6 +453,13 @@ def _all_profiles_enabled(parsed_url) -> bool:
     return _all_profiles_query_flag(parsed_url) and not _is_isolated_profile_mode()
 
 
+def _query_flag(parsed_url, name: str) -> bool:
+    """Return True for a truthy query flag value."""
+    qs = parse_qs(parsed_url.query)
+    raw = qs.get(name, [''])[0].strip().lower()
+    return raw in ('1', 'true', 'yes', 'on')
+
+
 def _session_visible_to_active_profile(session_profile, handler=None) -> bool:
     """Return whether a detail-load session belongs to the active profile.
 
@@ -1589,6 +1596,7 @@ def _session_list_cache_key(
     show_cli_sessions: bool,
     show_previous_messaging_sessions: bool,
     show_cron_sessions: bool,
+    include_archived: bool = False,
     source_filter: str | None = None,
 ) -> tuple:
     return (
@@ -1597,6 +1605,7 @@ def _session_list_cache_key(
         bool(show_cli_sessions),
         bool(show_previous_messaging_sessions),
         bool(show_cron_sessions),
+        bool(include_archived),
         source_filter,
     )
 
@@ -1806,17 +1815,32 @@ def _build_session_list_cache_payload(
     show_cli_sessions: bool,
     show_previous_messaging_sessions: bool,
     show_cron_sessions: bool,
+    include_archived: bool = False,
     source_filter: str | None = None,
     diag=None,
 ) -> dict:
     diag_stage = diag.stage if diag is not None else lambda *_a, **_k: None
 
+    def _all_sessions_for_sidebar():
+        try:
+            return all_sessions(diag=diag, include_lineage_metadata=False)
+        except TypeError as exc:
+            message = str(exc)
+            if (
+                "unexpected keyword argument" not in message
+                or "include_lineage_metadata" not in message
+            ):
+                raise
+            # Focused tests and third-party callers sometimes monkeypatch
+            # routes.all_sessions with the historical diag-only signature.
+            return all_sessions(diag=diag)
+
     diag_stage("all_sessions")
-    webui_sessions = all_sessions(diag=diag)
+    webui_sessions = _all_sessions_for_sidebar()
     diag_stage("reconcile_stale_stream_state")
     if _reconcile_stale_stream_state_for_session_rows(webui_sessions):
         diag_stage("all_sessions_after_stale_stream_reconcile")
-        webui_sessions = all_sessions(diag=diag)
+        webui_sessions = _all_sessions_for_sidebar()
     diag_stage("normalize_cli_rows")
     show_cli_sessions = bool(show_cli_sessions)
     show_previous_messaging_sessions = bool(show_previous_messaging_sessions)
@@ -1943,19 +1967,42 @@ def _build_session_list_cache_payload(
         scoped = [s for s in merged if _profiles_match(s.get("profile"), active_profile)]
         other_profile_count = 0 if _is_isolated_profile_mode() else len(merged) - len(scoped)
     diag_stage("messaging_dedupe")
-    scoped = _keep_latest_messaging_session_per_source(
-        scoped,
+    archived_scoped = _keep_latest_messaging_session_per_source(
+        list(scoped),
+        show_previous_messaging_sessions=show_previous_messaging_sessions,
+    )
+    visible_scoped = _keep_latest_messaging_session_per_source(
+        [s for s in scoped if not s.get("archived")],
         show_previous_messaging_sessions=show_previous_messaging_sessions,
     )
     if show_cli_sessions:
         diag_stage("cli_cap")
-        scoped = _cap_recent_cli_sessions(scoped, cli_cap=CLI_VISIBLE_SESSION_CAP)
+        archived_scoped = _cap_recent_cli_sessions(archived_scoped, cli_cap=CLI_VISIBLE_SESSION_CAP)
+        visible_scoped = _cap_recent_cli_sessions(visible_scoped, cli_cap=CLI_VISIBLE_SESSION_CAP)
+    archived_webui_count = sum(
+        1 for s in archived_scoped
+        if s.get("archived") and not _is_cli_session_for_settings(s)
+    )
+    archived_cli_count = sum(
+        1 for s in archived_scoped
+        if s.get("archived") and _is_cli_session_for_settings(s)
+    )
+    archived_count = archived_webui_count + archived_cli_count
+    scoped = archived_scoped if include_archived else visible_scoped
+    if not include_archived:
+        diag_stage("filter_archived_sessions")
+    diag_stage("visible_lineage_metadata")
+    _enrich_sidebar_lineage_metadata(scoped)
     return {
         "sessions": [
             dict(s) if isinstance(s, dict) else {}
             for s in scoped
         ],
         "cli_count": len(deduped_cli),
+        "archived_count": archived_count,
+        "archived_webui_count": archived_webui_count,
+        "archived_cli_count": archived_cli_count,
+        "include_archived": include_archived,
         "all_profiles": all_profiles,
         "active_profile": active_profile,
         "other_profile_count": other_profile_count,
@@ -1976,6 +2023,10 @@ def _session_list_payload_to_response(payload: dict) -> dict:
     return {
         "sessions": safe_merged,
         "cli_count": int(payload.get("cli_count", 0)),
+        "archived_count": int(payload.get("archived_count", 0)),
+        "archived_webui_count": int(payload.get("archived_webui_count", 0)),
+        "archived_cli_count": int(payload.get("archived_cli_count", 0)),
+        "include_archived": bool(payload.get("include_archived", False)),
         "all_profiles": bool(payload.get("all_profiles", False)),
         "active_profile": payload.get("active_profile"),
         "other_profile_count": int(payload.get("other_profile_count", 0)),
@@ -6320,6 +6371,7 @@ from api.models import (
     get_state_db_session_messages,
     get_state_db_session_summary,
     merge_session_messages_append_only,
+    _enrich_sidebar_lineage_metadata,
     _active_stream_ids,
     _session_message_merge_key,
     _session_message_visible_key,
@@ -9553,12 +9605,14 @@ def handle_get(handler, parsed) -> bool:
             agent_session_source_filter = settings.get("agent_session_source_filter")
             active_profile = get_active_profile_name()
             all_profiles = _all_profiles_enabled(parsed)
+            include_archived = _query_flag(parsed, "include_archived")
             key = _session_list_cache_key(
                 active_profile=active_profile,
                 all_profiles=all_profiles,
                 show_cli_sessions=show_cli_sessions,
                 show_previous_messaging_sessions=show_previous_messaging_sessions,
                 show_cron_sessions=show_cron_sessions,
+                include_archived=include_archived,
                 source_filter=agent_session_source_filter,
             )
             # Keep the visible /api/sessions contract unchanged even though the
@@ -9573,6 +9627,7 @@ def handle_get(handler, parsed) -> bool:
                     show_cli_sessions=show_cli_sessions,
                     show_previous_messaging_sessions=show_previous_messaging_sessions,
                     show_cron_sessions=show_cron_sessions,
+                    include_archived=include_archived,
                     source_filter=agent_session_source_filter,
                     diag=diag,
                 ),

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2658,6 +2658,8 @@ const NO_PROJECT_FILTER = '__none__';
 let _activeProject = null;  // project_id filter (null = show all, NO_PROJECT_FILTER = unassigned only)
 let _showAllProfiles = false;  // false = filter to active profile only
 let _otherProfileCount = 0;       // count of sessions from other profiles (server-reported)
+let _archivedWebuiCount = 0;      // archived WebUI sessions not fetched until requested
+let _archivedCliCount = 0;        // archived non-WebUI sessions not fetched until requested
 let _sessionSourceFilter = 'webui';  // 'webui' keeps WebUI chats separate from read-only CLI sessions
 _restoreSessionSourceFilter();
 let _sessionActionMenu = null;
@@ -3633,6 +3635,8 @@ function _applySessionListPayload(sessData, projData){
   // active profile so the "Show N from other profiles" toggle can render
   // without a second round-trip. Stashed on the module for renderSessionListFromCache.
   _otherProfileCount = sessData.other_profile_count || 0;
+  _archivedWebuiCount = Number(sessData.archived_webui_count ?? sessData.archived_count ?? 0);
+  _archivedCliCount = Number(sessData.archived_cli_count ?? 0);
   // Capture server clock for clock-skew compensation (issue #1144).
   // server_time is epoch seconds from the server's time.time().
   // _serverTimeDelta = client - server, so (Date.now() - _serverTimeDelta)
@@ -3707,7 +3711,10 @@ async function _runRenderSessionListRefresh(opts, _gen){
   if(!deferWhileInteracting) _pendingSessionListPayload=null;
   try{
     if(!($('sessionSearch').value||'').trim()) _contentSearchResults = [];
-    const allProfilesQS = _showAllProfiles ? '?all_profiles=1' : '';
+    const qs = new URLSearchParams();
+    if(_showAllProfiles) qs.set('all_profiles','1');
+    if(_showArchived) qs.set('include_archived','1');
+    const sessionListQS = qs.toString() ? `?${qs.toString()}` : '';
     const sessionRequestOpts={
       timeoutToast:false,
       timeoutMs:_sessionListHasLoadedOnce?30000:_SESSION_LIST_BOOT_TIMEOUT_MS,
@@ -3716,11 +3723,12 @@ async function _runRenderSessionListRefresh(opts, _gen){
       retryStatuses:[502,503,504],
     };
     const sessData = _sessionListHasLoadedOnce
-      ? await api('/api/sessions' + allProfilesQS,{timeoutToast:false})
-      : await api('/api/sessions' + allProfilesQS,sessionRequestOpts);
+      ? await api('/api/sessions' + sessionListQS,{timeoutToast:false})
+      : await api('/api/sessions' + sessionListQS,sessionRequestOpts);
     let projData={projects:_allProjects||[]};
     try{
-      projData = await api('/api/projects' + allProfilesQS,{timeoutToast:false});
+      const projectQS = _showAllProfiles ? '?all_profiles=1' : '';
+      projData = await api('/api/projects' + projectQS,{timeoutToast:false});
     }catch(projectError){
       console.warn('renderProjectsList',projectError);
     }
@@ -5259,11 +5267,12 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
     _sessionSourceFilter='webui';
   }
   const showCliOnly=_sessionSourceFilter==='cli';
+  const serverArchivedCount=showCliOnly?_archivedCliCount:_archivedWebuiCount;
   return {
     cliSessionCount,
     profileFiltered: showCliOnly ? cliProfileFiltered : webuiProfileFiltered,
     sessionsRaw: showCliOnly ? cliSessionsRaw : webuiSessionsRaw,
-    archivedCount: showCliOnly ? cliArchivedCount : webuiArchivedCount,
+    archivedCount: Math.max(showCliOnly ? cliArchivedCount : webuiArchivedCount, Number(serverArchivedCount||0)),
     webuiReferenceRaw,
     cliReferenceRaw,
     webuiSessionsRaw,
@@ -5498,12 +5507,13 @@ function renderSessionListFromCache(){
     pfToggle.onclick=()=>{_showAllProfiles=false;renderSessionList();};
     list.appendChild(pfToggle);
   }
-  // Show/hide archived toggle if there are archived sessions
-  if(archivedCount>0){
+  // Show/hide archived toggle if there are archived sessions. Archived rows
+  // are fetched on demand so large histories do not bloat every sidebar poll.
+  if(archivedCount>0||_showArchived){
     const toggle=document.createElement('div');
     toggle.style.cssText='font-size:10px;padding:4px 10px;color:var(--muted);cursor:pointer;text-align:center;opacity:.7;';
     toggle.textContent=_showArchived?'Hide archived':'Show '+archivedCount+' archived';
-    toggle.onclick=()=>{_showArchived=!_showArchived;renderSessionListFromCache();};
+    toggle.onclick=()=>{_showArchived=!_showArchived;renderSessionList();};
     list.appendChild(toggle);
   }
   // Empty state for active project filter

--- a/tests/test_api_timeout.py
+++ b/tests/test_api_timeout.py
@@ -226,8 +226,8 @@ def test_passive_background_polls_suppress_timeout_toasts():
     panels = _source(PANELS_JS)
 
     assert "api('/api/client-events/log',{method:'POST',body:JSON.stringify(payload),timeoutMs:3000,timeoutToast:false})" in workspace
-    assert "api('/api/sessions' + allProfilesQS,{timeoutToast:false})" in sessions
-    assert "api('/api/projects' + allProfilesQS,{timeoutToast:false})" in sessions
+    assert "api('/api/sessions' + sessionListQS,{timeoutToast:false})" in sessions
+    assert "api('/api/projects' + projectQS,{timeoutToast:false})" in sessions
     assert "api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`,{timeoutToast:false})" in sessions
     assert 'api("/api/approval/pending?session_id=" + encodeURIComponent(sid),{timeoutToast:false})' in messages
     assert 'api("/api/clarify/pending?session_id=" + encodeURIComponent(sid),{timeoutToast:false})' in messages

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -158,13 +158,16 @@ def test_static_sessions_js_uses_all_profiles_query_when_toggle_on():
     repo_root = Path(__file__).parent.parent
     src = (repo_root / 'static' / 'sessions.js').read_text(encoding='utf-8')
 
-    assert "_showAllProfiles ? '?all_profiles=1' : ''" in src, (
-        "Expected fetch path to flip on the toggle state"
+    assert "if(_showAllProfiles) qs.set('all_profiles','1');" in src, (
+        "Expected session-list fetch query to flip on the all-profiles toggle state"
     )
-    assert "api('/api/sessions' + allProfilesQS" in src, (
+    assert "const projectQS = _showAllProfiles ? '?all_profiles=1' : '';" in src, (
+        "Expected project fetch path to flip on the all-profiles toggle state"
+    )
+    assert "api('/api/sessions' + sessionListQS" in src, (
         "Expected /api/sessions fetch to use the variant query"
     )
-    assert "api('/api/projects' + allProfilesQS" in src, (
+    assert "api('/api/projects' + projectQS" in src, (
         "Expected /api/projects fetch to use the variant query"
     )
 

--- a/tests/test_issue1855_request_diagnostics.py
+++ b/tests/test_issue1855_request_diagnostics.py
@@ -95,7 +95,7 @@ def test_issue1855_target_routes_are_wired_to_diagnostics():
     src = Path("api/routes.py").read_text(encoding="utf-8")
 
     assert 'RequestDiagnostics.maybe_start("GET", parsed.path' in src
-    assert "all_sessions(diag=diag)" in src
+    assert "all_sessions(diag=diag, include_lineage_metadata=False)" in src
     assert 'RequestDiagnostics.maybe_start("POST", parsed.path' in src
     assert "_handle_chat_start(handler, body, diag=diag)" in src
     for stage in (

--- a/tests/test_issue2157_sessions_list_stale_stream_state.py
+++ b/tests/test_issue2157_sessions_list_stale_stream_state.py
@@ -26,6 +26,7 @@ class _FakeHandler:
 
 
 def test_sessions_list_reconciles_stale_stream_state_before_serializing(monkeypatch):
+    routes._session_list_cache_clear()
     repaired = {"value": False}
     all_sessions_calls = {"count": 0}
 
@@ -34,7 +35,7 @@ def test_sessions_list_reconciles_stale_stream_state_before_serializing(monkeypa
             self.session_id = "stale-session"
             self.active_stream_id = "stale-stream"
 
-    def fake_all_sessions(diag=None):
+    def fake_all_sessions(diag=None, **_kwargs):
         all_sessions_calls["count"] += 1
         if repaired["value"]:
             active_stream_id = None
@@ -81,6 +82,7 @@ def test_sessions_list_reconciles_stale_stream_state_before_serializing(monkeypa
     assert repaired["value"] is True
     assert sessions[0]["active_stream_id"] is None
     assert sessions[0]["is_streaming"] is False
+    routes._session_list_cache_clear()
 
 
 def test_reconcile_stale_stream_state_skips_live_stream_rows(monkeypatch):

--- a/tests/test_issue4385_cron_archive_reappears.py
+++ b/tests/test_issue4385_cron_archive_reappears.py
@@ -225,7 +225,7 @@ def test_webhook_state_projection_preserves_archived_sidecar(monkeypatch, tmp_pa
 
 
 def test_archived_webhook_projection_reaches_sidebar_payload(monkeypatch):
-    """The sidebar payload must preserve archived state for webhook projections."""
+    """Archived webhook projections are counted by default and fetched on demand."""
     import api.routes as routes
 
     sid = "webhook_archive_20260618"
@@ -249,12 +249,24 @@ def test_archived_webhook_projection_reaches_sidebar_payload(monkeypatch):
     monkeypatch.setattr(routes, "get_cli_sessions", lambda source_filter=None, all_profiles=False: [raw_webhook_row])
     monkeypatch.setattr(routes, "_reconcile_stale_stream_state_for_session_rows", lambda _sessions: False)
 
+    default_payload = routes._build_session_list_cache_payload(
+        active_profile="default",
+        all_profiles=False,
+        show_cli_sessions=True,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+    assert [row for row in default_payload["sessions"] if row["session_id"] == sid] == []
+    assert default_payload["archived_count"] == 1
+    assert default_payload["archived_webui_count"] == 1
+
     payload = routes._build_session_list_cache_payload(
         active_profile="default",
         all_profiles=False,
         show_cli_sessions=True,
         show_previous_messaging_sessions=False,
         show_cron_sessions=False,
+        include_archived=True,
     )
 
     rows = payload["sessions"]
@@ -266,7 +278,7 @@ def test_archived_webhook_projection_reaches_sidebar_payload(monkeypatch):
 
 
 def test_archived_cron_sidecar_suppresses_raw_unarchived_cron_row(monkeypatch):
-    """An archived cron sidecar should keep the raw state.db cron row hidden."""
+    """Archived cron sidecars stay out of the hot list but win on archive fetch."""
     import api.routes as routes
 
     sid = "cron_job123_20260618"
@@ -306,12 +318,25 @@ def test_archived_cron_sidecar_suppresses_raw_unarchived_cron_row(monkeypatch):
     monkeypatch.setattr(routes, "get_cli_sessions", lambda source_filter=None, all_profiles=False: [raw_cron_row])
     monkeypatch.setattr(routes, "_reconcile_stale_stream_state_for_session_rows", lambda _sessions: False)
 
+    default_payload = routes._build_session_list_cache_payload(
+        active_profile="default",
+        all_profiles=False,
+        show_cli_sessions=True,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=True,
+    )
+    assert [row for row in default_payload["sessions"] if row["session_id"] == sid] == []
+    assert default_payload["archived_count"] == 1
+    assert default_payload["archived_webui_count"] == 1
+    assert default_payload["archived_cli_count"] == 0
+
     payload = routes._build_session_list_cache_payload(
         active_profile="default",
         all_profiles=False,
         show_cli_sessions=True,
         show_previous_messaging_sessions=False,
         show_cron_sessions=True,
+        include_archived=True,
     )
 
     rows = payload["sessions"]

--- a/tests/test_performance_polling_hardening.py
+++ b/tests/test_performance_polling_hardening.py
@@ -24,8 +24,8 @@ def test_session_list_refreshes_are_coalesced_while_in_flight():
     assert "_renderSessionListQueuedRequest={" in src
     assert "opts:_mergeRenderSessionListOptions" in src
     assert "if (_gen !== _renderSessionListGen) return" in src
-    assert "api('/api/sessions' + allProfilesQS,{timeoutToast:false})" in src
-    assert "api('/api/projects' + allProfilesQS,{timeoutToast:false})" in src
+    assert "api('/api/sessions' + sessionListQS,{timeoutToast:false})" in src
+    assert "api('/api/projects' + projectQS,{timeoutToast:false})" in src
 
 
 def test_approval_and_clarify_fallback_polls_do_not_overlap():

--- a/tests/test_session_attention_badges.py
+++ b/tests/test_session_attention_badges.py
@@ -94,7 +94,7 @@ def test_sessions_api_includes_attention_summary_for_sidebar_rows(monkeypatch):
     try:
         routes.submit_pending(sid, {"command": "sudo service restart", "description": "Restart"})
 
-        monkeypatch.setattr(routes, "all_sessions", lambda diag=None: [{
+        monkeypatch.setattr(routes, "all_sessions", lambda diag=None, **_kwargs: [{
             "session_id": sid,
             "title": "Needs approval",
             "profile": "default",

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -6,6 +6,7 @@ import time
 import pytest
 
 import api.models as models
+import api.routes as routes
 from api.models import SESSIONS, STREAMS, Session, all_sessions
 
 
@@ -15,9 +16,20 @@ def _isolate(tmp_path, monkeypatch):
     session_dir.mkdir()
     index_file = session_dir / "_index.json"
     state_db = tmp_path / "state.db"
+    index_file.write_text("[]", encoding="utf-8")
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
     monkeypatch.setattr(models, "_active_state_db_path", lambda: state_db)
+    monkeypatch.setattr(models, "_start_session_index_rebuild_thread", lambda: None)
+
+    def uncached_persisted_session_ids():
+        return frozenset(
+            p.stem
+            for p in models.SESSION_DIR.glob("*.json")
+            if not p.name.startswith("_")
+        )
+
+    monkeypatch.setattr(models, "_persisted_session_ids_snapshot", uncached_persisted_session_ids)
     SESSIONS.clear()
     STREAMS.clear()
     yield state_db
@@ -306,6 +318,54 @@ def test_state_db_webui_source_overrides_stale_cli_json_metadata(_isolate):
         conn.close()
 
 
+def test_sessions_route_keeps_state_db_webui_row_with_stale_cli_json_when_cli_hidden(_isolate, monkeypatch):
+    """The hot route must apply state.db source correction before CLI filtering."""
+    conn = _ensure_state_db(_isolate)
+    t0 = time.time() - 100
+    try:
+        session = Session(
+            session_id="lineage_api_route_stale_cli_source",
+            title="WebUI Chatnachrichten verschwinden nach Neustart #9",
+            messages=[{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}],
+            updated_at=t0,
+            is_cli_session=True,
+            source_tag="cli",
+            raw_source="cli",
+            session_source="cli",
+            source_label="CLI",
+        )
+        session.save(touch_updated_at=False)
+        _insert_state_row(
+            conn,
+            "lineage_api_route_stale_cli_source",
+            source="webui",
+            started_at=t0,
+        )
+
+        monkeypatch.setattr(routes, "all_sessions", models.all_sessions)
+        monkeypatch.setattr(routes, "_enrich_sidebar_lineage_metadata", models._enrich_sidebar_lineage_metadata)
+        monkeypatch.setattr(routes, "_reconcile_stale_stream_state_for_session_rows", lambda _sessions: False)
+
+        payload = routes._build_session_list_cache_payload(
+            active_profile="default",
+            all_profiles=False,
+            show_cli_sessions=False,
+            show_previous_messaging_sessions=False,
+            show_cron_sessions=False,
+            include_archived=False,
+        )
+
+        rows = {row["session_id"]: row for row in payload["sessions"]}
+        row = rows["lineage_api_route_stale_cli_source"]
+        assert row["source_tag"] == "webui"
+        assert row["raw_source"] == "webui"
+        assert row["session_source"] == "webui"
+        assert row["source_label"] == "WebUI"
+        assert row["is_cli_session"] is False
+    finally:
+        conn.close()
+
+
 def test_generic_webui_title_gets_read_only_state_db_display_title(_isolate):
     """Sidebar rows can display the fresher state.db title without mutating JSON."""
     conn = _ensure_state_db(_isolate)
@@ -346,5 +406,78 @@ def test_state_db_display_title_does_not_override_custom_json_title(_isolate):
         assert row["title"] == "Customer escalation notes"
         assert "display_title" not in row
         assert "_state_db_title" not in row
+    finally:
+        conn.close()
+
+
+def test_sessions_route_preserves_visible_child_lineage_when_archived_parent_filtered(_isolate, monkeypatch):
+    """Default /api/sessions omits archived rows but keeps their lineage metadata.
+
+    The route builds the hot sidebar payload with archived rows filtered out by
+    default. A visible continuation child still needs lineage metadata from its
+    archived parent so the client can collapse/display the logical conversation
+    correctly.
+    """
+    conn = _ensure_state_db(_isolate)
+    t0 = time.time() - 100
+    try:
+        archived_parent = _save_webui_session(
+            "lineage_api_archived_parent",
+            title="Hermes WebUI",
+            updated_at=t0,
+        )
+        archived_parent.archived = True
+        archived_parent.save(touch_updated_at=False)
+        _save_webui_session(
+            "lineage_api_visible_tip",
+            title="Hermes WebUI #2",
+            updated_at=t0 + 10,
+        )
+        _insert_state_row(
+            conn,
+            "lineage_api_archived_parent",
+            started_at=t0,
+            ended_at=t0 + 5,
+            end_reason="compression",
+        )
+        _insert_state_row(
+            conn,
+            "lineage_api_visible_tip",
+            parent="lineage_api_archived_parent",
+            started_at=t0 + 6,
+        )
+
+        monkeypatch.setattr(routes, "all_sessions", models.all_sessions)
+        monkeypatch.setattr(routes, "_enrich_sidebar_lineage_metadata", models._enrich_sidebar_lineage_metadata)
+        monkeypatch.setattr(routes, "_reconcile_stale_stream_state_for_session_rows", lambda _sessions: False)
+
+        default_payload = routes._build_session_list_cache_payload(
+            active_profile="default",
+            all_profiles=False,
+            show_cli_sessions=False,
+            show_previous_messaging_sessions=False,
+            show_cron_sessions=False,
+            include_archived=False,
+        )
+
+        assert [row["session_id"] for row in default_payload["sessions"]] == ["lineage_api_visible_tip"]
+        assert default_payload["archived_count"] == 1
+        tip = default_payload["sessions"][0]
+        assert tip.get("parent_session_id") == "lineage_api_archived_parent"
+        assert tip.get("_lineage_root_id") == "lineage_api_archived_parent"
+        assert tip.get("_compression_segment_count") == 2
+
+        archived_payload = routes._build_session_list_cache_payload(
+            active_profile="default",
+            all_profiles=False,
+            show_cli_sessions=False,
+            show_previous_messaging_sessions=False,
+            show_cron_sessions=False,
+            include_archived=True,
+        )
+        assert [row["session_id"] for row in archived_payload["sessions"]] == [
+            "lineage_api_visible_tip",
+            "lineage_api_archived_parent",
+        ]
     finally:
         conn.close()

--- a/tests/test_session_list_long_history_perf.py
+++ b/tests/test_session_list_long_history_perf.py
@@ -1,0 +1,177 @@
+import io
+import json
+import pathlib
+from urllib.parse import urlparse
+
+import api.profiles as profiles
+import api.routes as routes
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_session_list_cache_between_tests():
+    routes._session_list_cache_clear()
+    yield
+    routes._session_list_cache_clear()
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.status = None
+        self.headers = {}
+        self.wfile = io.BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def json_body(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+def _sessions_payload_rows():
+    return [
+        {
+            "session_id": "visible-active",
+            "title": "Visible active",
+            "profile": "default",
+            "archived": False,
+            "message_count": 3,
+            "updated_at": 30,
+            "last_message_at": 30,
+        },
+        {
+            "session_id": "archived-history",
+            "title": "Archived history",
+            "profile": "default",
+            "archived": True,
+            "message_count": 4,
+            "updated_at": 20,
+            "last_message_at": 20,
+        },
+        {
+            "session_id": "other-profile",
+            "title": "Other profile",
+            "profile": "other",
+            "archived": False,
+            "message_count": 5,
+            "updated_at": 10,
+            "last_message_at": 10,
+        },
+    ]
+
+
+def test_sessions_api_enriches_only_returned_rows_by_default(monkeypatch):
+    all_sessions_kwargs = []
+    enriched_batches = []
+
+    def fake_all_sessions(**kwargs):
+        all_sessions_kwargs.append(kwargs)
+        return _sessions_payload_rows()
+
+    def fake_enrich(rows):
+        enriched_batches.append([row["session_id"] for row in rows])
+        for row in rows:
+            row["_lineage_root_id"] = row["session_id"]
+
+    monkeypatch.setattr(routes, "all_sessions", fake_all_sessions)
+    monkeypatch.setattr(routes, "_enrich_sidebar_lineage_metadata", fake_enrich)
+    monkeypatch.setattr(routes, "_reconcile_stale_stream_state_for_session_rows", lambda rows: False)
+    monkeypatch.setattr(routes, "load_settings", lambda: {"show_cli_sessions": False})
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    routes._session_list_cache_clear()
+
+    handler = _FakeHandler()
+    routes.handle_get(handler, urlparse("http://example.com/api/sessions"))
+
+    assert handler.status == 200
+    body = handler.json_body()
+    assert [row["session_id"] for row in body["sessions"]] == ["visible-active"]
+    assert body["archived_count"] == 1
+    assert body["archived_webui_count"] == 1
+    assert body["include_archived"] is False
+    assert enriched_batches == [["visible-active"]]
+    assert all_sessions_kwargs[0]["include_lineage_metadata"] is False
+
+
+def test_sessions_api_fetches_archived_rows_only_when_requested(monkeypatch):
+    enriched_batches = []
+
+    monkeypatch.setattr(routes, "all_sessions", lambda **_kwargs: _sessions_payload_rows())
+    monkeypatch.setattr(
+        routes,
+        "_enrich_sidebar_lineage_metadata",
+        lambda rows: enriched_batches.append([row["session_id"] for row in rows]),
+    )
+    monkeypatch.setattr(routes, "_reconcile_stale_stream_state_for_session_rows", lambda rows: False)
+    monkeypatch.setattr(routes, "load_settings", lambda: {"show_cli_sessions": False})
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    routes._session_list_cache_clear()
+
+    handler = _FakeHandler()
+    routes.handle_get(handler, urlparse("http://example.com/api/sessions?include_archived=1"))
+
+    assert handler.status == 200
+    body = handler.json_body()
+    assert [row["session_id"] for row in body["sessions"]] == [
+        "visible-active",
+        "archived-history",
+    ]
+    assert body["archived_count"] == 1
+    assert body["include_archived"] is True
+    assert enriched_batches == [["visible-active", "archived-history"]]
+
+
+def test_sessions_api_legacy_all_sessions_monkeypatch_fallback_is_narrow(monkeypatch):
+    calls = []
+
+    def legacy_all_sessions(*, diag=None):
+        calls.append(diag)
+        return _sessions_payload_rows()
+
+    monkeypatch.setattr(routes, "all_sessions", legacy_all_sessions)
+    monkeypatch.setattr(routes, "_enrich_sidebar_lineage_metadata", lambda rows: None)
+    monkeypatch.setattr(routes, "_reconcile_stale_stream_state_for_session_rows", lambda rows: False)
+    monkeypatch.setattr(routes, "load_settings", lambda: {"show_cli_sessions": False})
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+
+    handler = _FakeHandler()
+    routes.handle_get(handler, urlparse("http://example.com/api/sessions"))
+
+    assert handler.status == 200
+    assert len(calls) == 1
+
+
+def test_sessions_api_internal_typeerror_is_not_hidden_by_legacy_fallback(monkeypatch):
+    def broken_all_sessions(**_kwargs):
+        raise TypeError("internal include_lineage_metadata transformation failed")
+
+    monkeypatch.setattr(routes, "all_sessions", broken_all_sessions)
+    monkeypatch.setattr(routes, "_reconcile_stale_stream_state_for_session_rows", lambda rows: False)
+    monkeypatch.setattr(routes, "load_settings", lambda: {"show_cli_sessions": False})
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+
+    with pytest.raises(TypeError, match="internal include_lineage_metadata"):
+        routes._build_session_list_cache_payload(
+            active_profile="default",
+            all_profiles=False,
+            show_cli_sessions=False,
+            show_previous_messaging_sessions=False,
+            show_cron_sessions=False,
+        )
+
+
+def test_session_list_fetch_adds_include_archived_only_when_toggle_is_on():
+    src = (pathlib.Path(__file__).parent.parent / "static" / "sessions.js").read_text(encoding="utf-8")
+
+    assert "if(_showArchived) qs.set('include_archived','1');" in src
+    assert "api('/api/sessions' + sessionListQS" in src
+    assert "toggle.onclick=()=>{_showArchived=!_showArchived;renderSessionList();};" in src
+    assert "_archivedWebuiCount" in src
+    assert "sessData.archived_webui_count ?? sessData.archived_count ?? 0" in src
+    assert "archived_webui_count" in src

--- a/tests/test_session_sidebar_resilience.py
+++ b/tests/test_session_sidebar_resilience.py
@@ -43,8 +43,8 @@ def test_sessions_and_projects_load_independently_so_projects_failure_cannot_bla
     block = src[block_start:block_end]
 
     assert "Promise.all" not in block
-    assert "api('/api/sessions' + allProfilesQS" in block
-    assert "try{\n      projData = await api('/api/projects'" in block
+    assert "api('/api/sessions' + sessionListQS" in block
+    assert "try{\n      const projectQS = _showAllProfiles ? '?all_profiles=1' : '';\n      projData = await api('/api/projects' + projectQS" in block
     assert "console.warn('renderProjectsList'," in block
     assert "_applySessionListPayload(sessData,projData)" in block
 

--- a/tests/test_sidebar_session_partition.py
+++ b/tests/test_sidebar_session_partition.py
@@ -49,7 +49,8 @@ def test_partition_helper_applies_message_source_project_and_archive_gates():
     assert "const showCliOnly=_sessionSourceFilter==='cli';" in block
     assert "if(!_showArchived&&s.archived) continue;" in block
     assert "if(s.archived){" in block
-    assert "archivedCount: showCliOnly ? cliArchivedCount : webuiArchivedCount," in block
+    assert "const serverArchivedCount=showCliOnly?_archivedCliCount:_archivedWebuiCount;" in block
+    assert "archivedCount: Math.max(showCliOnly ? cliArchivedCount : webuiArchivedCount, Number(serverArchivedCount||0))," in block
     assert "return {" in block
     assert "profileFiltered: showCliOnly ? cliProfileFiltered : webuiProfileFiltered," in block
     assert "sessionsRaw: showCliOnly ? cliSessionsRaw : webuiSessionsRaw," in block


### PR DESCRIPTION
## Release v0.51.575 — session-list perf for long histories (#4597)

Ships **#4597** (santastabber) — reduces session-list work for accounts with long/archived conversation histories.

### What
`GET /api/sessions` did redundant per-session work (lineage/metadata enrichment + filtering) across the full history even when most of it was archived/off-screen, making the sidebar slow for heavy users. The route now skips that work for archived rows and applies the cheap state-DB source corrections **before** the CLI-hidden filter, so visible sessions and the visible children of archived parents still render correctly while the list builds substantially faster.

### Review trail (converged after deep bounce cycles)
- **Finding A (production regression) — FIXED & verified:** the earlier version skipped the state.db `source=='webui'` correction before the route's CLI filter, which would drop WebUI sessions carrying stale-CLI sidecar flags when `show_cli_sessions` is default-false. `_apply_sidebar_state_db_overrides(result)` now runs on the full set before the filter on **both** the index path (`models.py:3454`) and the full-scan fallback (`models.py:3500`); route filter at `routes.py:1939`. Visible children of archived/filtered parents keep lineage (`read_session_lineage_metadata`).
- **Finding B (flaky lineage test) — FIXED:** the `_isolate` fixture now neutralizes the mtime-keyed `_persisted_session_ids_snapshot` cache; the previously ~50%-flaky co-run is now deterministic (16 passed, 3/3).
- **Codex gate: SAFE TO SHIP** — "no regression risks found"; verified the override-before-filter ordering on both paths and that the archive toggle only refetches with `include_archived=1` when enabled.
- **Full suite: 10057 passed** (sole failure was the known TLS flake `test_https_server_responds_to_health` — passes in isolation; #4597 touches no TLS code).

Note: staged from the authoritative PR head `e1a3ecf22eca` (verified via GitHub API + fresh named-ref fetch; the stage's code contribution is byte-identical to that head).

Co-authored-by: santastabber <santastabber@users.noreply.github.com>

Closes #4597
