### PR TITLE
fix: hold down /api/sessions cache invalidation during streaming (#4672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/api/sessions` no longer crawls (and token output no longer drops to ~2 tok/s) during an active chat turn.** The sidebar session-list cache keyed its freshness on a content fingerprint of `state.db`, but an in-flight turn writes message rows continuously — so the fingerprint changed on essentially every poll, popping the cache and forcing a full `all_sessions()` rebuild mid-stream. Each forced rebuild then contended for the global session lock the streaming worker holds while writing, producing multi-second (occasionally ~15s) `/api/sessions` latencies and starving token rendering. The cache now applies a streaming hold-down: while any session is actively streaming, the volatile `state.db`-derived stamp components collapse to a marker keyed only on the set of active streams, so per-token writes stop busting the cache. Rebuilds are bounded to the existing TTL cadence instead of one-per-poll, the 2.5s TTL still refreshes a streaming session's own title/count, live streaming indicators are unaffected (overlaid post-cache), and structural changes (new/deleted/renamed/imported sessions) still invalidate immediately via the explicit listener. Thanks @batkuip. (#4672)
+
+- **Removed a stray merge-conflict marker from the changelog.** A dangling `>>>>>>>` line left over from an earlier merge is gone.
+
 ## [v0.51.579] — 2026-06-22 — Release UL (deflake TLS end-to-end tests)
 
 ### Fixed
@@ -27,7 +33,6 @@
 
 - **The transcript no longer yanks you back to the bottom while you're reading mid-stream.** Scroll re-pinning now requires a deliberate move toward the bottom (and ignores tiny scroll jitter), so reading earlier messages during an active stream stays put instead of getting hijacked back to the latest token. Thanks @rodboev. (#4584, fixes #4295)
 - **No more accidental horizontal panning of the mobile transcript.** Wide content (long code lines, URLs) could let the message area pan sideways on phones; the transcript now clips horizontal overflow and wraps long words. Thanks @rodboev. (#4583, fixes #4553)
->>>>>>> baa5869e4 (stage #4577 (dso2ng): keep failed steer from cancelling active runs)
 
 ## [v0.51.575] — 2026-06-22 — Release UH (session-list perf for long histories)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1699,10 +1699,80 @@ def _session_list_cache_path_stamp(path: Path | None) -> tuple[int, int]:
         return (0, 0)
 
 
+def _session_list_cache_streaming_freeze_marker():
+    """Return a hold-down marker while any session is actively streaming, else None.
+
+    During an active chat turn the gateway/CLI writes message rows to state.db
+    continuously. Each write advances the WAL stat and the content fingerprint
+    (``MAX(rowid)`` of ``messages``) that ``_session_list_cache_source_stamp``
+    folds in, so the source stamp changes on essentially every ``/api/sessions``
+    poll — popping the cache and forcing a full ``all_sessions()`` rebuild
+    mid-stream. That rebuild then contends for the global ``LOCK`` the streaming
+    worker holds while writing, which is what drags token output down to
+    ~2 tok/s and produces the multi-second (and occasional ~15s) ``/api/sessions``
+    latencies in issue #4672.
+
+    The marker is keyed only on the *set* of active stream ids, not on any
+    per-write state, so:
+      * while the same turn(s) stream, the marker is constant → the cache holds
+        steady and rebuilds are bounded to the TTL cadence (one per
+        ``_SESSIONS_CACHE_TTL_SECONDS``) instead of one per poll;
+      * the instant a stream starts or stops, the active set changes → the
+        marker changes → the cache re-validates and the just-finished turn's
+        final title/message_count is picked up immediately.
+
+    Structural sidebar mutations (new/deleted/renamed/imported sessions,
+    attention, cron completion) do NOT rely on this stamp — they invalidate the
+    cache directly through the ``publish_session_list_changed`` listener — so the
+    only thing that can lag under the hold-down is a streaming session's own
+    title/message_count, which already tolerates a <=TTL refresh delay.
+    """
+    try:
+        active = _active_stream_ids()
+    except Exception:
+        return None
+    if not active:
+        return None
+    try:
+        return ("streaming", tuple(sorted(str(x) for x in active)))
+    except Exception:
+        return ("streaming",)
+
+
 def _session_list_cache_source_stamp(key: tuple) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], object, int]:
     _cache_profile, _cache_all_profiles, cache_show_cli_sessions, *_rest = key
     if not cache_show_cli_sessions:
         return ((0, 0), (0, 0), (0, 0), (0, 0), (0, 0), None, 0)
+    try:
+        settings_file = SETTINGS_FILE
+    except Exception:
+        settings_file = None
+    try:
+        from api.config import _SETTINGS_WRITE_VERSION
+        swv = _SETTINGS_WRITE_VERSION
+    except Exception:
+        swv = 0
+    # Streaming hold-down (#4672): while a turn is in flight, collapse the
+    # volatile state.db-derived components (db/WAL stat, gateway metadata, index
+    # stat, content fingerprint) to a marker that only changes when a stream
+    # starts or stops. This stops per-token message writes from busting the
+    # cache and triggering LOCK-contending rebuilds on every poll. The TTL still
+    # forces a periodic rebuild so the streaming session's own count/title stay
+    # fresh within the TTL window, and settings_file + the settings write
+    # version stay live so user-initiated sidebar/setting toggles invalidate
+    # immediately. Skipping the fingerprint's SQLite connect here also makes the
+    # streaming-path stamp strictly cheaper than the idle path.
+    streaming_marker = _session_list_cache_streaming_freeze_marker()
+    if streaming_marker is not None:
+        return (
+            streaming_marker,
+            streaming_marker,
+            streaming_marker,
+            streaming_marker,
+            _session_list_cache_path_stamp(settings_file),
+            streaming_marker,
+            swv,
+        )
     try:
         state_db_path = Path(_active_state_db_path())
     except Exception:
@@ -1719,15 +1789,6 @@ def _session_list_cache_source_stamp(key: tuple) -> tuple[tuple[int, int], tuple
         session_index_path = SESSION_DIR / "_index.json"
     except Exception:
         session_index_path = None
-    try:
-        settings_file = SETTINGS_FILE
-    except Exception:
-        settings_file = None
-    try:
-        from api.config import _SETTINGS_WRITE_VERSION
-        swv = _SETTINGS_WRITE_VERSION
-    except Exception:
-        swv = 0
     return (
         _session_list_cache_path_stamp(state_db_path),
         _session_list_cache_path_stamp(state_db_wal_path),

--- a/tests/test_session_sidebar_cache.py
+++ b/tests/test_session_sidebar_cache.py
@@ -406,3 +406,112 @@ def test_session_list_payload_to_response_overlays_live_stream_runtime(monkeypat
     assert by_id["stale-session"]["active_stream_id"] is None
     assert by_id["stale-session"]["is_streaming"] is False
     assert by_id["stale-session"]["has_pending_user_message"] is False
+
+
+def _build_stamp_env(tmp_path, monkeypatch):
+    """Wire a self-contained source-stamp environment and return its key."""
+    state_db = tmp_path / "state.db"
+    state_db.write_text("db", encoding="utf-8")
+    state_db_wal = tmp_path / "state.db-wal"
+    state_db_wal.write_text("wal-1", encoding="utf-8")
+    gateway = tmp_path / "gateway-sessions.json"
+    gateway.write_text("{}", encoding="utf-8")
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    (session_dir / "_index.json").write_text("{}", encoding="utf-8")
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: str(state_db))
+    monkeypatch.setattr(routes, "_gateway_session_metadata_path", lambda: gateway)
+    monkeypatch.setattr(routes, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(routes, "SETTINGS_FILE", settings_file)
+    # Make the content fingerprint deterministic and unaffected by the dummy
+    # text-file state.db (a real sqlite connect would just return None here).
+    fingerprint = {"value": (1, 1)}
+    monkeypatch.setattr(
+        routes,
+        "_session_list_cache_state_db_fingerprint",
+        lambda _p: fingerprint["value"],
+    )
+
+    key = routes._session_list_cache_key(
+        active_profile="default",
+        all_profiles=False,
+        show_cli_sessions=True,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+    return key, state_db_wal, settings_file, fingerprint
+
+
+def test_source_stamp_freezes_during_streaming_message_writes(tmp_path, monkeypatch):
+    """#4672: per-token state.db churn must not bust the cache mid-stream.
+
+    With an active stream the volatile state.db-derived components are collapsed
+    to a stream-set marker, so advancing the WAL stat AND the content
+    fingerprint (the per-message-write signals) leaves the stamp unchanged.
+    Before the fix each of these advanced the stamp and forced a rebuild on
+    every poll.
+    """
+    key, state_db_wal, _settings_file, fingerprint = _build_stamp_env(
+        tmp_path, monkeypatch
+    )
+    monkeypatch.setattr(routes, "_active_stream_ids", lambda: {"turn-1"})
+
+    before = routes._session_list_cache_source_stamp(key)
+    # Simulate the writes an active chat turn makes to state.db: WAL grows and
+    # the messages-table fingerprint advances.
+    state_db_wal.write_text("wal-2-grew-a-lot", encoding="utf-8")
+    fingerprint["value"] = (2, 99)
+    after = routes._session_list_cache_source_stamp(key)
+
+    assert after == before
+
+
+def test_source_stamp_changes_when_stream_set_transitions(tmp_path, monkeypatch):
+    """The hold-down marker tracks the active-stream SET, so a turn starting or
+    finishing re-validates the cache and the final title/count is picked up."""
+    key, _wal, _settings, _fp = _build_stamp_env(tmp_path, monkeypatch)
+
+    streams = {"value": set()}
+    monkeypatch.setattr(routes, "_active_stream_ids", lambda: set(streams["value"]))
+
+    idle = routes._session_list_cache_source_stamp(key)
+    streams["value"] = {"turn-1"}
+    streaming = routes._session_list_cache_source_stamp(key)
+    streams["value"] = {"turn-1", "turn-2"}
+    two_streams = routes._session_list_cache_source_stamp(key)
+    streams["value"] = set()
+    idle_again = routes._session_list_cache_source_stamp(key)
+
+    assert idle != streaming
+    assert streaming != two_streams
+    # Returning to idle re-engages the live state.db stamp path.
+    assert idle_again != streaming
+
+
+def test_source_stamp_tracks_settings_even_while_streaming(tmp_path, monkeypatch):
+    """Settings-file / sidebar-toggle changes must still invalidate the cache
+    during streaming so user-initiated changes are never held stale."""
+    key, _wal, settings_file, _fp = _build_stamp_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(routes, "_active_stream_ids", lambda: {"turn-1"})
+
+    before = routes._session_list_cache_source_stamp(key)
+    settings_file.write_text('{"show_cli_sessions": true}', encoding="utf-8")
+    after = routes._session_list_cache_source_stamp(key)
+
+    assert after != before
+
+
+def test_source_stamp_still_tracks_wal_when_idle(tmp_path, monkeypatch):
+    """Regression guard: with NO active stream the stamp must still advance on a
+    state.db/WAL write (the original commit-reliable behavior is preserved)."""
+    key, state_db_wal, _settings, _fp = _build_stamp_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(routes, "_active_stream_ids", lambda: set())
+
+    before = routes._session_list_cache_source_stamp(key)
+    state_db_wal.write_text("wal-2-more", encoding="utf-8")
+    after = routes._session_list_cache_source_stamp(key)
+
+    assert after != before


### PR DESCRIPTION
## Problem

`/api/sessions` is intermittently extremely slow during an active chat turn — multi-second, occasionally ~15–18s — despite returning a tiny (~20KB) payload, and token rendering crawls to ~2 tok/s. Reported and profiled in #4672 by @batkuip, who traced the hot path to `_build_session_list_cache_payload()` → `all_sessions()` → `load_metadata_only()`.

The three perf fixes that shipped on the 21st/22nd (#4650, #4638, #4597) made each rebuild **cheaper** but did not change the *invalidate-on-every-write* cadence — which is the part the prior triage explicitly flagged as still open. @batkuip confirmed it persists on `v0.51.577` with all three present.

## Root cause

`_session_list_cache_get()` recomputes `_session_list_cache_source_stamp()` on every request. That stamp folds in:
- `_session_list_cache_state_db_fingerprint(state.db)` = `MAX(rowid)` of the `messages` table, and
- the `state.db-wal` file stat.

During an active turn the worker writes message rows continuously, so **both signals change on essentially every poll** → `stamp != current_stamp` → the cache entry is popped → a full `all_sessions()` rebuild runs on (almost) every poll. That rebuild then takes the global session `LOCK` (to overlay in-memory sessions) — the same lock the streaming worker holds while writing. The resulting lock/GIL contention is what starves token output to ~2 tok/s and produces the multi-second / ~15s `/api/sessions` latencies. The 2.5s TTL and single-flight never get to help because the stamp invalidates faster than the TTL.

## Fix

Add a **streaming hold-down**. New helper `_session_list_cache_streaming_freeze_marker()` returns a marker keyed only on the *set* of active stream ids (via `_active_stream_ids()`), or `None` when idle. While any session is streaming, `_session_list_cache_source_stamp()` collapses the volatile `state.db`-derived components (db stat, WAL stat, gateway-metadata stat, session-index stat, content fingerprint) to that marker. `settings_file` stat and the settings write-version stay live.

Result:
- Per-token message writes no longer bust the cache → rebuilds are bounded to the existing 2.5s TTL cadence instead of one-per-poll.
- The streaming path also **stops opening a per-poll SQLite connection** to the very `state.db` the worker is hammering (it skips the fingerprint read), so the hot-path stamp is strictly cheaper than idle.
- The instant a stream starts or finishes, the active-stream set changes → the marker changes → the cache re-validates and the just-finished turn's final title/count is picked up immediately.

## Why it's safe (verified by both gates)

1. **Live streaming indicators are never stale** — `is_streaming` / `active_stream_id` / `has_pending_user_message` are overlaid *after* cache retrieval in `_session_list_cache_overlay_runtime_rows()`. A held cache keeps the dots live.
2. **Structural sidebar mutations invalidate independently of this stamp** — new/deleted/renamed/imported/cron-complete/attention changes pop the cache directly through the `publish_session_list_changed` → `_on_session_list_changed` listener.
3. **Settings/sidebar-toggle changes stay live** during streaming (settings stat + write-version kept in the stamp).
4. **Bounded staleness only** — the single thing a held cache can lag during streaming is a *streaming session's own* title/message_count, bounded by the 2.5s TTL (title renames already tolerate ≤5s).
5. **No lock-ordering inversion** — `_active_stream_ids()` uses `STREAMS_LOCK`/`ACTIVE_RUNS_LOCK`, both distinct from the global `LOCK`, and is computed before `_SESSIONS_CACHE_LOCK` is taken.
6. **Idle path is byte-identical** to before (a new regression test asserts idle still tracks WAL writes).

## Honest scope notes

- **External-CLI-only turns:** the hold-down engages on the in-process WebUI worker path (`STREAMS ∪ ACTIVE_RUNS`), which is the reported scenario. A turn driven by a *separate* CLI process writing to a shared `state.db` wouldn't appear in the active set, so it sees no benefit (and no regression). Can be extended later if that case is reported.
- **Tail latency:** the 2.5s TTL still forces a periodic rebuild that takes the global `LOCK`, so a single worst-case collision is still possible. The reliable win here is "per-poll SQLite-connect eliminated + rebuilds bounded to TTL," not "the ~15s outlier is impossible."

## Tests

Four new regression tests in `tests/test_session_sidebar_cache.py`:
- stamp freezes under simulated per-token WAL + fingerprint churn while streaming
- stamp changes on active-stream-set transitions (start / add / finish)
- settings changes still invalidate during streaming
- idle path still tracks WAL writes (no regression)

Full `tests/test_session_sidebar_cache.py` (13) + related session/cache/perf slice (231) pass locally.

## Gates

- **Codex (regression):** SAFE TO SHIP — no regression risk; independently verified post-cache overlay, listener-based invalidation, marker transition, and stream-completion sidebar refresh.
- **Opus (architecture/correctness):** "Ship it." — confirmed correct, no unbounded staleness traps, no lock inversion, streaming path strictly cheaper than idle.

Thanks @batkuip for the unusually precise profiling — it made the residual obvious. Fixes #4672.