### PR TITLE
Fix legacy interim toggle leaking into anchor Worklog

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -3807,28 +3807,33 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(visibleInterimSnippets.length>INTERIM_COLLAPSE_THRESHOLD&&assistantRow){
         const blocks=assistantRow.parentElement;
         if(blocks){
-          const allInterim=Array.from(blocks.querySelectorAll('[data-interim="1"]'));
-          const toHide=allInterim.slice(0,allInterim.length-INTERIM_COLLAPSE_THRESHOLD);
-          let toggle=blocks.querySelector('.interim-collapse-toggle');
-          if(!toggle){
-            toggle=document.createElement('span');
-            toggle.className='interim-collapse-toggle';
-            // No per-element listener: clicks are handled by a delegated
-            // document-level handler (see _interimCollapseDelegatedClick) so
-            // the toggle keeps working after a live-turn DOM restore
-            // (snapshotLiveTurnHtmlForSession/restoreLiveTurnHtmlForSession
-            // rebuild via innerHTML, which would drop a direct listener and
-            // leave the collapsed notes permanently unreachable). The
-            // threshold rides on the markup so the handler stays stateless.
-            toggle.dataset.threshold=String(INTERIM_COLLAPSE_THRESHOLD);
-            if(toHide.length) toHide[0].before(toggle);
+          const anchorSceneOwnsLive=!!(blocks.closest&&blocks.closest('[data-anchor-scene-live-owner="1"]'));
+          if(anchorSceneOwnsLive){
+            blocks.querySelectorAll('.interim-collapse-toggle').forEach(el=>el.remove());
+          }else{
+            const allInterim=Array.from(blocks.querySelectorAll('[data-interim="1"]'));
+            const toHide=allInterim.slice(0,allInterim.length-INTERIM_COLLAPSE_THRESHOLD);
+            let toggle=blocks.querySelector('.interim-collapse-toggle');
+            if(!toggle){
+              toggle=document.createElement('span');
+              toggle.className='interim-collapse-toggle';
+              // No per-element listener: clicks are handled by a delegated
+              // document-level handler (see _interimCollapseDelegatedClick) so
+              // the toggle keeps working after a live-turn DOM restore
+              // (snapshotLiveTurnHtmlForSession/restoreLiveTurnHtmlForSession
+              // rebuild via innerHTML, which would drop a direct listener and
+              // leave the collapsed notes permanently unreachable). The
+              // threshold rides on the markup so the handler stays stateless.
+              toggle.dataset.threshold=String(INTERIM_COLLAPSE_THRESHOLD);
+              if(toHide.length) toHide[0].before(toggle);
+            }
+            // Skip re-collapse when the user expanded manually; always update the stored count.
+            if(!toggle.dataset.expanded){
+              toHide.forEach(el=>el.classList.add('interim-collapsed'));
+            }
+            const stillHidden=blocks.querySelectorAll('[data-interim="1"].interim-collapsed').length;
+            if(stillHidden) toggle.textContent='Show '+stillHidden+' earlier update'+(stillHidden===1?'':'s');
           }
-          // Skip re-collapse when the user expanded manually; always update the stored count.
-          if(!toggle.dataset.expanded){
-            toHide.forEach(el=>el.classList.add('interim-collapsed'));
-          }
-          const stillHidden=blocks.querySelectorAll('[data-interim="1"].interim-collapsed').length;
-          if(stillHidden) toggle.textContent='Show '+stillHidden+' earlier update'+(stillHidden===1?'':'s');
         }
       }
       recordActivityBoundary();

--- a/static/ui.js
+++ b/static/ui.js
@@ -9578,7 +9578,7 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
     ? _captureWorklogDetailDisclosureState(blocks)
     : null;
   blocks.querySelectorAll('[data-anchor-scene-owner="1"],[data-anchor-scene-row="1"]').forEach(el=>el.remove());
-  blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-card-row[data-live-tid]:not(.transparent-event-row),.agent-activity-thinking[data-live-thinking="1"]').forEach(el=>el.remove());
+  blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-card-row[data-live-tid]:not(.transparent-event-row),.agent-activity-thinking[data-live-thinking="1"],.interim-collapse-toggle').forEach(el=>el.remove());
   blocks.querySelectorAll('[data-live-assistant="1"]').forEach(el=>{
     el.classList.add('assistant-segment-worklog-source');
     el.setAttribute('aria-hidden','true');

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -346,6 +346,21 @@ def test_scene_renderer_coalesces_row_updates_and_renders_in_scene_order():
     assert "assistant-segment-worklog-source" in live
 
 
+def test_live_anchor_scene_removes_legacy_interim_collapse_toggle():
+    live = _function_body(UI_JS, "renderLiveAnchorActivityScene")
+    interim = _event_listener_body(MESSAGES_JS, "interim_assistant")
+
+    cleanup_idx = live.index(".interim-collapse-toggle")
+    hide_idx = live.index("blocks.querySelectorAll('[data-live-assistant=\"1\"]')")
+    group_idx = live.index("const group=_anchorSceneWorklogGroup")
+    assert cleanup_idx < hide_idx < group_idx
+
+    guard_idx = interim.index("data-anchor-scene-live-owner")
+    remove_idx = interim.index("blocks.querySelectorAll('.interim-collapse-toggle').forEach(el=>el.remove())")
+    legacy_create_idx = interim.index("let toggle=blocks.querySelector('.interim-collapse-toggle')")
+    assert guard_idx < remove_idx < legacy_create_idx
+
+
 def test_tool_scene_rows_coalesce_by_logical_tool_call_identity():
     rows = _function_body(UI_JS, "_anchorSceneRowsForRendering")
     key = _function_body(UI_JS, "_anchorSceneToolRowLogicalKey")


### PR DESCRIPTION
## Thinking Path

The reported live session showed a visible `Show 3 earlier updates` link above the anchor-backed `Processed ... / Thinking` Worklog. Inspecting the live DOM and code path pointed to a mixed-renderer leak: the #2403 legacy `interim_assistant` collapse control can still be present or recreated after the Live-to-Final anchor scene takes ownership of the live turn and hides `[data-live-assistant="1"]` source segments.

The correct layer is the derived frontend live rendering path, not persisted transcript state. The legacy collapse toggle is only meaningful when legacy interim assistant snippets are visible; once `data-anchor-scene-live-owner="1"` is set, anchor scene rows own the Worklog UI.

## What Changed

- `renderLiveAnchorActivityScene()` now removes `.interim-collapse-toggle` along with other legacy live Worklog artifacts before hiding legacy live assistant source segments.
- The `interim_assistant` SSE handler now detects anchor-owned live turns, removes any existing legacy interim collapse toggle, and skips creating a new one.
- Added a regression test that locks both sides of the invariant: anchor scene render cleanup and later `interim_assistant` events must not leave or recreate the legacy toggle while the anchor scene owns the live Worklog.

## Why It Matters

This prevents the old blue `Show N earlier updates` control from appearing as an orphan above the Compact Worklog during live streaming. The user should see the anchor-backed `Processed ...` Worklog surface, not a legacy interim text collapse affordance for hidden source segments.

## Verification

- `node --check static/ui.js`
- `node --check static/messages.js`
- `./scripts/test.sh tests/test_live_to_final_anchor_visible_order.py tests/test_issue2403_interim_collapse.py`
- `git diff --check`

Manual before evidence came from the live 8787 session that showed the orphan `Show 3 earlier updates` control above `Processed ... / Thinking`. I did not restart 8787 or interrupt the active run; this PR is validated by code inspection and targeted regression coverage.

## Risks / Follow-ups

- The legacy interim collapse behavior remains in place for non-anchor live rendering paths.
- This PR does not change persisted session data or settled transcript hydration.
- No 8787 runtime restart was performed for an after screenshot because the user had an active real run on that port.

## Contract Routing

- Frontend rendering layer: `static/messages.js`, `static/ui.js`
- Relevant contracts/docs reviewed: `docs/CONTRACTS.md`, `docs/rfcs/live-to-final-assistant-replies.md`, `docs/rfcs/stable-assistant-turn-anchors.md`, `docs/UIUX-GUIDE.md`, `DESIGN.md`
- State layer affected: derived live DOM only; no API, DB, transcript, or inflight-state schema changes.

## Model Used

OpenAI Codex (GPT-5) assisted with investigation, implementation, and verification.
