### PR TITLE
fix: keep Studio model selection session-scoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **The model picker is now session-authoritative instead of browser-global.** Changing the model inside an existing conversation updates only that session; it no longer writes the choice into browser `localStorage`, no longer uses stale browser state to infer a provider for later sends, and New Chat falls back to the profile default instead of silently inheriting the previous conversation's model. Pre-session picker choices still seed the first new chat.
+
 ## [v0.51.580] — 2026-06-22 — Release UM (wrap markdown source previews)
 
 ### Fixed

--- a/static/boot.js
+++ b/static/boot.js
@@ -1390,9 +1390,13 @@ $('modelSelect').onchange=async()=>{
     ? _modelStateForSelect($('modelSelect'),selectedModel)
     : {model:selectedModel,model_provider:null};
   if(typeof closeModelDropdown==='function') closeModelDropdown();
-  if(typeof _writePersistedModelState==='function') _writePersistedModelState(modelState.model,modelState.model_provider);
-  else try{localStorage.setItem('hermes-webui-model',modelState.model)}catch{}
   if(!S.session){
+    // Browser-local model state is only a pre-session draft seed. Once a chat
+    // exists, its persisted Session.model / model_provider is authoritative;
+    // writing every in-chat pick to localStorage lets one conversation bleed into
+    // later sessions and hard-refresh restores (#4669 follow-up).
+    if(typeof _writePersistedModelState==='function') _writePersistedModelState(modelState.model,modelState.model_provider);
+    else try{localStorage.setItem('hermes-webui-model',modelState.model)}catch{}
     if(typeof syncModelChip==='function') syncModelChip();
     if(typeof syncReasoningChip==='function') syncReasoningChip();
     return;

--- a/static/messages.js
+++ b/static/messages.js
@@ -1464,13 +1464,10 @@ async function send(){
       }
       S.session.model=startData.effective_model;
       S.session.model_provider=startData.effective_model_provider||S.session.model_provider||null;
-      localStorage.setItem('hermes-webui-model', startData.effective_model);
-      if(typeof _writePersistedModelState==='function') _writePersistedModelState(startData.effective_model,S.session.model_provider||null);
       if($('modelSelect')) _applyModelToDropdown(startData.effective_model, $('modelSelect'),S.session.model_provider||null);
       if(typeof syncTopbar==='function') syncTopbar();
     }else if(startData&&startData.effective_model_provider && S.session){
       S.session.model_provider=startData.effective_model_provider;
-      if(typeof _writePersistedModelState==='function') _writePersistedModelState(S.session.model||'',S.session.model_provider||null);
       if($('modelSelect')&&typeof _applyModelToDropdown==='function') _applyModelToDropdown(S.session.model||'', $('modelSelect'), S.session.model_provider||null);
       if(typeof syncModelChip==='function') syncModelChip();
       if(typeof syncTopbar==='function') syncTopbar();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -731,14 +731,17 @@ async function newSession(flash, options={}){
     if(_activeProject&&_activeProject!==NO_PROJECT_FILTER) reqBody.project_id=_activeProject;
     // Forward a pre-session toolset override only from the empty composer (#4490).
     if(!S.session && Array.isArray(S._pendingSessionToolsets)) reqBody.enabled_toolsets=S._pendingSessionToolsets;
-    // Carry the visible picker selection into the new session. Without this,
-    // /api/session/new falls back to config.yaml defaults (e.g. gpt-5.5) even
-    // when the user already chose cursor/composer-2.5 in the composer chip.
+    // Carry the visible picker selection into the new session only when there
+    // is no active session yet (empty composer / boot draft). If an existing
+    // conversation is active, its picker reflects that conversation's own model
+    // and must not become the implicit model for every future New Chat. In that
+    // normal case, /api/session/new intentionally falls back to the profile's
+    // configured default model/provider.
     const modelSelForNew=$('modelSelect');
     let newModelState=null;
-    if(modelSelForNew&&modelSelForNew.value&&typeof _modelStateForSelect==='function'){
+    if(!S.session&&modelSelForNew&&modelSelForNew.value&&typeof _modelStateForSelect==='function'){
       newModelState=_modelStateForSelect(modelSelForNew,modelSelForNew.value);
-    }else if(typeof _readPersistedModelState==='function'){
+    }else if(!S.session&&typeof _readPersistedModelState==='function'){
       newModelState=_readPersistedModelState();
     }
     if(newModelState&&newModelState.model){

--- a/static/ui.js
+++ b/static/ui.js
@@ -1708,14 +1708,6 @@ function _modelProviderForSend(modelId){
       }
     }catch(_){}
   }
-  if(typeof _readPersistedModelState==='function'){
-    try{
-      const persisted=_readPersistedModelState();
-      if(persisted&&String(persisted.model||'').trim()===model){
-        return persisted.model_provider||null;
-      }
-    }catch(_){}
-  }
   return null;
 }
 function _reconcileModelDropdownSelection(sel,data,previousState,opts){

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -94,15 +94,18 @@ def test_new_chat_does_not_send_stale_dropdown_model_when_session_has_default_mo
     assert "model_provider:S.session.model_provider||null" in MESSAGES_JS
 
 
-def test_new_session_posts_picker_model_before_server_default():
+def test_new_session_posts_picker_model_before_server_default_only_without_active_session():
     fn = _new_session_function()
-    # Behavior contract: the picker model goes into reqBody so /api/session/new
-    # uses the user's selection before falling back to the server default
-    # (#872). The previous literal-string assertion
+    # Behavior contract: the picker model goes into reqBody only for the empty
+    # composer / pre-session path. Once a session exists, its picker is that
+    # session's model and New Chat must fall back to the profile default instead
+    # of inheriting the previous chat's model. The previous literal-string assertion
     # "reqBody.model_provider=newModelState.model_provider||null" became a
     # change-detector once the #2518 follow-up added a fallback chain; the
     # contract that newModelState.model_provider is the FIRST source of
     # reqBody.model_provider is now verified by substring + ordering.
+    assert "!S.session&&modelSelForNew&&modelSelForNew.value" in fn
+    assert "!S.session&&typeof _readPersistedModelState==='function'" in fn
     assert "reqBody.model=newModelState.model" in fn
     assert "newModelState.model_provider" in fn
     assert "window._activeProvider" in fn, (
@@ -142,7 +145,21 @@ def test_model_picker_persists_without_active_session():
     body = boot_js[boot_js.index("$('modelSelect').onchange=async()=>") : boot_js.index("$('msg').addEventListener", boot_js.index("$('modelSelect').onchange=async()=>"))]
     assert "_writePersistedModelState(modelState.model,modelState.model_provider)" in body
     assert "if(!S.session){" in body
-    assert body.index("if(!S.session){") < body.index("await api('/api/session/update'")
+    assert body.index("if(!S.session){") < body.index("_writePersistedModelState(modelState.model,modelState.model_provider)")
+    assert body.index("_writePersistedModelState(modelState.model,modelState.model_provider)") < body.index("return;")
+    assert body.index("return;") < body.index("await api('/api/session/update'")
+
+
+def test_active_session_model_changes_do_not_update_browser_model_preference():
+    messages_js = Path("static/messages.js").read_text(encoding="utf-8")
+    start = messages_js.index("if(startData&&startData.effective_model && S.session)")
+    branch = messages_js[start : messages_js.index("if(S.session&&typeof startData.pending_started_at", start)]
+    assert "localStorage.setItem('hermes-webui-model'" not in branch
+    assert "_writePersistedModelState" not in branch
+
+    ui_js = Path("static/ui.js").read_text(encoding="utf-8")
+    provider_for_send = _extract_function(ui_js, "function _modelProviderForSend")
+    assert "_readPersistedModelState" not in provider_for_send
 
 
 def test_changelog_mentions_new_chat_default_model_provider_sync():


### PR DESCRIPTION
## Summary
- Make Studio/WebUI model selection session-authoritative instead of browser-global.
- Stop active chat model updates from writing `hermes-webui-model` / model-state localStorage.
- Stop provider inference for sends from reading stale browser model state.
- Make New Chat use the profile default when launched from an existing conversation; only pre-session picker choices seed the first session.

## Test Plan
- `python -m pytest tests/test_new_chat_default_model_frontend.py tests/test_issue2518_active_provider_fallback.py tests/test_issue1855_resolve_model_provider_fast_path.py -q`
- `node --check static/boot.js && node --check static/messages.js && node --check static/ui.js && node --check static/sessions.js`

*Written by Zephyr (AI Assistant) — raisalpwardana+zephyr@gmail.com*
