### PR TITLE
Release v0.51.582 — mobile Enter reliably inserts newline (#4678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.582] — 2026-06-22 — Release UO (mobile Enter reliably inserts newline)
+
+### Fixed
+
+- **On phones, Enter reliably inserts a newline in the message composer.** The mobile Enter=newline default was previously also gated on a viewport-shrink heuristic that was unreliable on iOS Safari and some Android browsers (the on-screen keyboard didn't consistently shrink the visual viewport), so Enter sometimes sent the message instead of adding a line break. Touch-primary devices (coarse pointer, no co-existing fine pointer) now default to Enter=newline regardless of viewport height; tablets with a hardware keyboard keep desktop send behavior, and you can still override the send key in Settings. Thanks @neaucode-bot. (#4678)
+
 ## [v0.51.581] — 2026-06-22 — Release UN (full-screen PWA mobile sidebar drawer)
 
 ### Changed

--- a/static/boot.js
+++ b/static/boot.js
@@ -1512,11 +1512,6 @@ let _imeComposing=false;
 })();
 function _isImeEnter(e){return e.isComposing||e.keyCode===229||_imeComposing;}
 window._isImeEnter=_isImeEnter;
-function _isVirtualKeyboardLikelyOpen(){
-  const vv=window.visualViewport;
-  if(!vv||!window.innerHeight)return true;
-  return window.innerHeight-vv.height>120;
-}
 // #3076: a touch-primary device (`pointer:coarse`) can still have a
 // physical keyboard attached (Android tablet + Bluetooth keyboard,
 // detachable Surface in tablet mode, iPad + Magic Keyboard). When that
@@ -1549,9 +1544,13 @@ $('msg').addEventListener('keydown',e=>{
     }
   }
   // Send key: respect user preference.
-  // On touch-primary devices with the software keyboard open, default to
-  // Enter = newline since there's no physical Shift key. Hardware keyboards on
-  // tablets keep desktop behavior when the viewport is not keyboard-shrunk.
+  // On touch-primary devices (coarse pointer, no fine pointer co-existing),
+  // default to Enter = newline regardless of whether the visual viewport has
+  // shrunk. The viewport-shrink heuristic (_isVirtualKeyboardLikelyOpen) was
+  // unreliable on iOS Safari and some Android browsers where the keyboard
+  // doesn't consistently reduce vv.height by >120px. The pointer media query
+  // pair is a sufficient and more reliable signal for "software keyboard only".
+  // Hardware keyboards on tablets are covered by _hasFinePointerCoexisting.
   // The 'ctrl+enter' setting also uses this behavior (Enter = newline).
   // Users can override in Settings by explicitly choosing 'enter' mode.
   if(e.key==='Enter'){
@@ -1559,8 +1558,7 @@ $('msg').addEventListener('keydown',e=>{
     const isNumpadEnter=_isNumpadEnter(e);
     const _mobileDefault=matchMedia('(pointer:coarse)').matches
       &&!_hasFinePointerCoexisting()
-      &&window._sendKey==='enter'
-      &&_isVirtualKeyboardLikelyOpen();
+      &&window._sendKey==='enter';
     if(window._sendKey==='ctrl+enter'||_mobileDefault){
       if(isNumpadEnter||e.ctrlKey||e.metaKey){e.preventDefault();send();}
     } else {

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -1514,22 +1514,24 @@ def test_mobile_enter_newline_uses_match_media():
         "boot.js must use matchMedia('(pointer:coarse)') for mobile detection"
 
 
-def test_mobile_enter_newline_checks_virtual_keyboard_viewport():
-    """Touch devices should only force newline while the software keyboard is likely open."""
+def test_mobile_enter_newline_does_not_depend_on_viewport_heuristic():
+    """The viewport-shrink heuristic was unreliable on iOS/Android and must be gone."""
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    assert "function _isVirtualKeyboardLikelyOpen()" in boot_js, \
-        "boot.js must isolate the software-keyboard viewport heuristic"
-    assert "window.visualViewport" in boot_js and "window.innerHeight-vv.height>120" in boot_js, \
-        "software-keyboard detection must compare visualViewport height against window.innerHeight"
-    assert "&&_isVirtualKeyboardLikelyOpen()" in boot_js, \
-        "mobile Enter newline override must not apply when a hardware keyboard leaves the viewport unshrunk"
+    assert "function _isVirtualKeyboardLikelyOpen()" not in boot_js, \
+        "the unreliable visualViewport keyboard heuristic function must be removed"
+    assert "&&_isVirtualKeyboardLikelyOpen()" not in boot_js, \
+        "the mobile Enter override must no longer call the viewport heuristic"
+    assert "window.innerHeight-vv.height>120" not in boot_js, \
+        "the viewport height-delta probe must no longer gate the mobile Enter override"
 
 
-def test_mobile_enter_newline_preserves_legacy_fallback_without_visual_viewport():
-    """Browsers without visualViewport should keep the previous touch Enter=newline behavior."""
+def test_mobile_enter_newline_respects_hardware_keyboard_on_touch_devices():
+    """Touch devices with a co-existing fine pointer (hardware keyboard) keep desktop Enter=send."""
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    assert "if(!vv||!window.innerHeight)return true;" in boot_js, \
-        "missing visualViewport support must preserve the legacy touch-primary newline fallback"
+    assert "any-pointer:fine" in boot_js, \
+        "boot.js must use any-pointer:fine to detect a co-existing hardware keyboard/trackpad"
+    assert "!_hasFinePointerCoexisting()" in boot_js, \
+        "mobile Enter newline override must skip touch devices that also expose a fine pointer"
 
 
 def test_mobile_enter_newline_only_overrides_enter_default():


### PR DESCRIPTION
## Release v0.51.582 — mobile Enter reliably inserts newline (#4678)

Ships **#4678** (neaucode-bot) — fixes Enter sometimes sending instead of inserting a newline on phone composers.

### What
The mobile Enter=newline default was gated on `_isVirtualKeyboardLikelyOpen()`, a viewport-shrink heuristic that was unreliable on iOS Safari and some Android browsers (the on-screen keyboard didn't consistently reduce `visualViewport.height` by >120px). Enter therefore sometimes sent the message instead of adding a line break. The default now keys solely on `matchMedia('(pointer:coarse)').matches && !_hasFinePointerCoexisting()` — a more reliable "software-keyboard-only" signal. The unreliable heuristic function is removed entirely.

### Behavior preserved
- Desktop / fine-pointer devices: Enter still sends per the `_sendKey` setting.
- Tablets with a hardware keyboard (coarse + fine pointer coexisting): keep desktop send behavior via `_hasFinePointerCoexisting()`.
- `ctrl+enter` mode, numpad Enter, and IME-composing guards all intact.
- Users can still override the send key in Settings.

### Review trail
- **Codex: SAFE TO SHIP** — verified desktop fall-through unchanged, coarse+fine devices skip the mobile default, ctrl+enter/numpad/IME paths intact, removed function has no remaining call site.
- **Full suite: 10081 passed, 0 failed.** 2 new mobile Enter-newline tests.

Co-authored-by: neaucode-bot <neaucode-bot@users.noreply.github.com>

Closes #4678
