### PR TITLE
Release v0.51.583 — no legacy interim toggle in anchor Worklog (#4681)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.583] — 2026-06-22 — Release UP (no legacy interim toggle in anchor Worklog)
+
+### Fixed
+
+- **The legacy "Show N earlier updates" link no longer appears above the live Worklog.** When the anchor-scene took ownership of a live turn, the older `interim_assistant` collapse toggle could still be left behind or recreated as an orphan control above the Compact Worklog. The live anchor render now clears that legacy toggle, and the `interim_assistant` handler skips recreating it while the anchor scene owns the live turn — so you see the anchor-backed `Processed…` Worklog surface, not a stray legacy collapse affordance. Thanks @franksong2702. (#4681)
+
 ## [v0.51.582] — 2026-06-22 — Release UO (mobile Enter reliably inserts newline)
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -3807,28 +3807,33 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(visibleInterimSnippets.length>INTERIM_COLLAPSE_THRESHOLD&&assistantRow){
         const blocks=assistantRow.parentElement;
         if(blocks){
-          const allInterim=Array.from(blocks.querySelectorAll('[data-interim="1"]'));
-          const toHide=allInterim.slice(0,allInterim.length-INTERIM_COLLAPSE_THRESHOLD);
-          let toggle=blocks.querySelector('.interim-collapse-toggle');
-          if(!toggle){
-            toggle=document.createElement('span');
-            toggle.className='interim-collapse-toggle';
-            // No per-element listener: clicks are handled by a delegated
-            // document-level handler (see _interimCollapseDelegatedClick) so
-            // the toggle keeps working after a live-turn DOM restore
-            // (snapshotLiveTurnHtmlForSession/restoreLiveTurnHtmlForSession
-            // rebuild via innerHTML, which would drop a direct listener and
-            // leave the collapsed notes permanently unreachable). The
-            // threshold rides on the markup so the handler stays stateless.
-            toggle.dataset.threshold=String(INTERIM_COLLAPSE_THRESHOLD);
-            if(toHide.length) toHide[0].before(toggle);
+          const anchorSceneOwnsLive=!!(blocks.closest&&blocks.closest('[data-anchor-scene-live-owner="1"]'));
+          if(anchorSceneOwnsLive){
+            blocks.querySelectorAll('.interim-collapse-toggle').forEach(el=>el.remove());
+          }else{
+            const allInterim=Array.from(blocks.querySelectorAll('[data-interim="1"]'));
+            const toHide=allInterim.slice(0,allInterim.length-INTERIM_COLLAPSE_THRESHOLD);
+            let toggle=blocks.querySelector('.interim-collapse-toggle');
+            if(!toggle){
+              toggle=document.createElement('span');
+              toggle.className='interim-collapse-toggle';
+              // No per-element listener: clicks are handled by a delegated
+              // document-level handler (see _interimCollapseDelegatedClick) so
+              // the toggle keeps working after a live-turn DOM restore
+              // (snapshotLiveTurnHtmlForSession/restoreLiveTurnHtmlForSession
+              // rebuild via innerHTML, which would drop a direct listener and
+              // leave the collapsed notes permanently unreachable). The
+              // threshold rides on the markup so the handler stays stateless.
+              toggle.dataset.threshold=String(INTERIM_COLLAPSE_THRESHOLD);
+              if(toHide.length) toHide[0].before(toggle);
+            }
+            // Skip re-collapse when the user expanded manually; always update the stored count.
+            if(!toggle.dataset.expanded){
+              toHide.forEach(el=>el.classList.add('interim-collapsed'));
+            }
+            const stillHidden=blocks.querySelectorAll('[data-interim="1"].interim-collapsed').length;
+            if(stillHidden) toggle.textContent='Show '+stillHidden+' earlier update'+(stillHidden===1?'':'s');
           }
-          // Skip re-collapse when the user expanded manually; always update the stored count.
-          if(!toggle.dataset.expanded){
-            toHide.forEach(el=>el.classList.add('interim-collapsed'));
-          }
-          const stillHidden=blocks.querySelectorAll('[data-interim="1"].interim-collapsed').length;
-          if(stillHidden) toggle.textContent='Show '+stillHidden+' earlier update'+(stillHidden===1?'':'s');
         }
       }
       recordActivityBoundary();

--- a/static/ui.js
+++ b/static/ui.js
@@ -9578,7 +9578,7 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
     ? _captureWorklogDetailDisclosureState(blocks)
     : null;
   blocks.querySelectorAll('[data-anchor-scene-owner="1"],[data-anchor-scene-row="1"]').forEach(el=>el.remove());
-  blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-card-row[data-live-tid]:not(.transparent-event-row),.agent-activity-thinking[data-live-thinking="1"]').forEach(el=>el.remove());
+  blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-card-row[data-live-tid]:not(.transparent-event-row),.agent-activity-thinking[data-live-thinking="1"],.interim-collapse-toggle').forEach(el=>el.remove());
   blocks.querySelectorAll('[data-live-assistant="1"]').forEach(el=>{
     el.classList.add('assistant-segment-worklog-source');
     el.setAttribute('aria-hidden','true');

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -346,6 +346,21 @@ def test_scene_renderer_coalesces_row_updates_and_renders_in_scene_order():
     assert "assistant-segment-worklog-source" in live
 
 
+def test_live_anchor_scene_removes_legacy_interim_collapse_toggle():
+    live = _function_body(UI_JS, "renderLiveAnchorActivityScene")
+    interim = _event_listener_body(MESSAGES_JS, "interim_assistant")
+
+    cleanup_idx = live.index(".interim-collapse-toggle")
+    hide_idx = live.index("blocks.querySelectorAll('[data-live-assistant=\"1\"]')")
+    group_idx = live.index("const group=_anchorSceneWorklogGroup")
+    assert cleanup_idx < hide_idx < group_idx
+
+    guard_idx = interim.index("data-anchor-scene-live-owner")
+    remove_idx = interim.index("blocks.querySelectorAll('.interim-collapse-toggle').forEach(el=>el.remove())")
+    legacy_create_idx = interim.index("let toggle=blocks.querySelector('.interim-collapse-toggle')")
+    assert guard_idx < remove_idx < legacy_create_idx
+
+
 def test_tool_scene_rows_coalesce_by_logical_tool_call_identity():
     rows = _function_body(UI_JS, "_anchorSceneRowsForRendering")
     key = _function_body(UI_JS, "_anchorSceneToolRowLogicalKey")


### PR DESCRIPTION
## Release v0.51.583 — no legacy interim toggle in anchor Worklog (#4681)

Ships **#4681** (franksong2702) — stops the legacy "Show N earlier updates" collapse control from appearing as an orphan above the live Worklog.

### What
When the anchor scene took ownership of a live turn (`data-anchor-scene-live-owner="1"`), the older #2403 `interim_assistant` collapse toggle could still be left behind or recreated above the Compact Worklog. Now `renderLiveAnchorActivityScene()` clears `.interim-collapse-toggle` during cleanup, and the `interim_assistant` SSE handler removes any existing toggle and skips creating a new one while the anchor scene owns the turn.

### No regression for legacy turns
When the anchor scene does NOT own the turn, the original collapse logic is unchanged — the toggle still appears and the delegated click handler / collapsed-notes reachability is preserved.

### Review trail
- **Codex: SAFE TO SHIP** — confirmed the non-anchor path keeps the original collapse behavior and the cleanup is scoped to the live turn blocks.
- **Full suite: 10082 passed, 0 failed.** New regression test locks both directions of the invariant.

Co-authored-by: franksong2702 <franksong2702@users.noreply.github.com>

Closes #4681
