### PR TITLE
Suppress duplicate live process updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Live process updates no longer duplicate when token output and interim progress differ only by whitespace.** The streaming echo guard now compares visible progress text after removing whitespace, so an interim assistant update is marked as already streamed instead of being appended again when only paragraph or line-break formatting changed.
+
 ## [v0.51.584] — 2026-06-22 — Release UQ (freeze /api/sessions cache during streaming)
 
 ### Fixed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -74,6 +74,11 @@ def _session_payload_with_full_messages(session, *, tool_calls=None):
     return raw
 
 
+def _compact_for_echo_compare(value: str) -> str:
+    """Normalize visible stream text for duplicate echo detection."""
+    return re.sub(r'\s+', '', str(value or ''))
+
+
 # Global lock for os.environ writes. Per-session locks (_agent_lock) prevent
 # concurrent runs of the SAME session, but two DIFFERENT sessions can still
 # interleave their os.environ writes. This global lock serializes the env
@@ -6346,9 +6351,6 @@ def _run_agent_streaming(
                 stats.setdefault('tps_available', False)
                 stats.setdefault('estimated', False)
                 put('metering', stats)
-
-            def _compact_for_echo_compare(value: str) -> str:
-                return re.sub(r'\s+', '', str(value or ''))
 
             def _is_visible_output_echo(text: str) -> bool:
                 candidate = _compact_for_echo_compare(text)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -6348,7 +6348,7 @@ def _run_agent_streaming(
                 put('metering', stats)
 
             def _compact_for_echo_compare(value: str) -> str:
-                return re.sub(r'\s+', ' ', str(value or '')).strip()
+                return re.sub(r'\s+', '', str(value or ''))
 
             def _is_visible_output_echo(text: str) -> bool:
                 candidate = _compact_for_echo_compare(text)

--- a/tests/test_run_journal_streaming_static.py
+++ b/tests/test_run_journal_streaming_static.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from api.streaming import _compact_for_echo_compare
+
 
 def test_streaming_initializes_one_run_journal_writer_per_stream():
     src = Path("api/streaming.py").read_text(encoding="utf-8")
@@ -24,12 +26,7 @@ def test_streaming_journals_sse_events_before_queue_delivery():
 
 
 def test_visible_process_echo_compare_ignores_all_whitespace():
-    src = Path("api/streaming.py").read_text(encoding="utf-8")
-    helper_idx = src.index("def _compact_for_echo_compare(value: str) -> str:")
-    helper = src[helper_idx:src.index("def _is_visible_output_echo", helper_idx)]
+    token_text = "先把 issue 4249 拉下来\n\n先看正文和评论"
+    interim_text = "先把 issue 4249 拉下来先看正文和评论"
 
-    assert "re.sub(r'\\s+', '', str(value or ''))" in helper, (
-        "Visible process-prose echo detection must ignore paragraph and line-break "
-        "formatting so interim_assistant does not duplicate token prose that only "
-        "differs by whitespace."
-    )
+    assert _compact_for_echo_compare(token_text) == _compact_for_echo_compare(interim_text)

--- a/tests/test_run_journal_streaming_static.py
+++ b/tests/test_run_journal_streaming_static.py
@@ -21,3 +21,15 @@ def test_streaming_journals_sse_events_before_queue_delivery():
     assert put_idx < journal_idx < queue_idx
     assert "Failed to append run journal event" in block
     assert "queue_item = (event, data, event_id) if event_id and hasattr(q, \"subscribe_with_snapshot\") else (event, data)" in block
+
+
+def test_visible_process_echo_compare_ignores_all_whitespace():
+    src = Path("api/streaming.py").read_text(encoding="utf-8")
+    helper_idx = src.index("def _compact_for_echo_compare(value: str) -> str:")
+    helper = src[helper_idx:src.index("def _is_visible_output_echo", helper_idx)]
+
+    assert "re.sub(r'\\s+', '', str(value or ''))" in helper, (
+        "Visible process-prose echo detection must ignore paragraph and line-break "
+        "formatting so interim_assistant does not duplicate token prose that only "
+        "differs by whitespace."
+    )


### PR DESCRIPTION
## Thinking Path

- The user-visible bug is duplicate process prose in the live assistant stream, not duplicate Thinking-card chrome.
- The streaming backend already tries to prevent this by marking `interim_assistant` events as `already_streamed` when their text is already present in `STREAM_PARTIAL_TEXT`.
- The failing case is formatting-sensitive: token output may contain paragraph/line-break whitespace while the interim callback carries the same process prose without that whitespace.
- This PR fixes the existing visible-output echo guard so whitespace-only formatting differences do not cause the same process update to be appended twice.

## What Changed

- Changed the streaming visible-output echo comparator to remove whitespace before comparing token output against interim assistant text.
- Added a regression guard that locks the all-whitespace-insensitive comparison.
- Added an Unreleased changelog entry for duplicate live process updates.

## Why It Matters

During live streams, users should see each process update once. If token output and interim progress differ only by paragraph or line-break formatting, WebUI should treat them as the same visible text and avoid appending a duplicate process paragraph.

## Verification

- `./scripts/test.sh tests/test_run_journal_streaming_static.py -q`
- `./scripts/test.sh tests/test_run_journal_streaming_static.py tests/test_ui_tool_call_cleanup.py -q`
- `git diff --check origin/master`

## Risks / Follow-ups

- The comparison remains strict: it only treats text as duplicate when the non-whitespace content is identical.
- This PR does not implement the full Assistant Turn Anchor model.
- Session sidebar ordering is handled separately in #4688.

## Model Used

OpenAI Codex (GPT-5). AI assisted with implementation, runtime inspection, test updates, and PR preparation.
