### PR TITLE
fix(#4693): eliminate iOS tap delay on interactive buttons

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2068,6 +2068,7 @@
   .send-btn:active{transform:scale(0.95);box-shadow:0 1px 4px var(--accent-bg);}
   .send-btn:disabled{opacity:.35;cursor:not-allowed;transform:none;box-shadow:none;}
   .send-btn.visible{animation:send-pop-in .18s cubic-bezier(.34,1.56,.64,1) forwards;}
+  button,.icon-btn,.panel-icon-btn,.send-btn,.approval-btn,[onclick]{touch-action:manipulation;-webkit-tap-highlight-color:transparent;}
   .composer-terminal-panel{position:absolute;left:0;right:0;bottom:-24px;width:min(calc(100% - 64px),720px);margin:0 auto;box-sizing:border-box;overflow:hidden;pointer-events:none;z-index:1;}
   .composer-terminal-panel.is-open,.composer-terminal-panel.is-collapsed{pointer-events:auto;}
   .composer-terminal-panel[hidden]{display:none!important;}


### PR DESCRIPTION
## Thinking Path

- On iOS Safari, tapping the send button often requires two taps: the first appears to "select" the button, and the second fires the action. Worse, during streaming, the second tap can land after the button has transitioned to "stop" mode, immediately cancelling the response.
- The root cause is the ~300 ms click delay iOS applies to elements without `touch-action: manipulation`, waiting to distinguish tap from double-tap-to-zoom. No button in the codebase declares this property; the only element that does is `.project-chip`.
- A single CSS rule adding `touch-action: manipulation` and `-webkit-tap-highlight-color: transparent` to all interactive button elements eliminates the delay without changing any event handling logic.

## What Changed

- `static/style.css`: added one rule covering `button`, `.icon-btn`, `.panel-icon-btn`, `.send-btn`, `.approval-btn`, and `[onclick]` with `touch-action: manipulation` and `-webkit-tap-highlight-color: transparent`

## Why It Matters

The send button is used on every message. On iOS, the missed-first-tap and send-then-stop behaviors make the app feel broken. This fix eliminates the root cause (the 300 ms click delay) for all interactive controls using a single CSS line that follows the existing `.project-chip` pattern.

## Verification

- Manual: on iOS Safari, tap send with a non-empty composer; confirm first-tap response
- Manual: during streaming, tap stop; confirm it stops without ghost-sending
- Manual: on desktop, confirm mouse click and keyboard activation are unaffected
- `npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"` (no JS changes, but confirms no accidental edits)

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #4693.

## Model Used

Claude Opus 4.6 via Claude Code CLI
