### PR TITLE
Release v0.51.585 — suppress duplicate live process echoes (#4689)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.585] — 2026-06-22 — Release UR (suppress duplicate live process echoes)
+
+### Fixed
+
+- **Live progress text no longer appears twice during streaming.** When the same process prose surfaced through both the visible assistant stream and the live Thinking/interim updates (differing only by paragraph or line-break formatting), it could render duplicated. The server-side visible-output echo detection now ignores all whitespace when comparing, so an `interim_assistant` update that only reformats already-visible token prose is correctly recognized as an echo and suppressed at the source. Thanks @franksong2702. (#4689)
+
 ## [v0.51.584] — 2026-06-22 — Release UQ (freeze /api/sessions cache during streaming)
 
 ### Fixed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -74,6 +74,11 @@ def _session_payload_with_full_messages(session, *, tool_calls=None):
     return raw
 
 
+def _compact_for_echo_compare(value: str) -> str:
+    """Normalize visible stream text for duplicate echo detection."""
+    return re.sub(r'\s+', '', str(value or ''))
+
+
 # Global lock for os.environ writes. Per-session locks (_agent_lock) prevent
 # concurrent runs of the SAME session, but two DIFFERENT sessions can still
 # interleave their os.environ writes. This global lock serializes the env
@@ -6346,9 +6351,6 @@ def _run_agent_streaming(
                 stats.setdefault('tps_available', False)
                 stats.setdefault('estimated', False)
                 put('metering', stats)
-
-            def _compact_for_echo_compare(value: str) -> str:
-                return re.sub(r'\s+', ' ', str(value or '')).strip()
 
             def _is_visible_output_echo(text: str) -> bool:
                 candidate = _compact_for_echo_compare(text)

--- a/tests/test_run_journal_streaming_static.py
+++ b/tests/test_run_journal_streaming_static.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from api.streaming import _compact_for_echo_compare
+
 
 def test_streaming_initializes_one_run_journal_writer_per_stream():
     src = Path("api/streaming.py").read_text(encoding="utf-8")
@@ -21,3 +23,10 @@ def test_streaming_journals_sse_events_before_queue_delivery():
     assert put_idx < journal_idx < queue_idx
     assert "Failed to append run journal event" in block
     assert "queue_item = (event, data, event_id) if event_id and hasattr(q, \"subscribe_with_snapshot\") else (event, data)" in block
+
+
+def test_visible_process_echo_compare_ignores_all_whitespace():
+    token_text = "先把 issue 4249 拉下来\n\n先看正文和评论"
+    interim_text = "先把 issue 4249 拉下来先看正文和评论"
+
+    assert _compact_for_echo_compare(token_text) == _compact_for_echo_compare(interim_text)


### PR DESCRIPTION
## Release v0.51.585 — suppress duplicate live process echoes (#4689)

Ships **#4689** (franksong2702) — stops the same live process prose rendering twice (visible assistant stream + live Thinking/interim) when it differs only by whitespace/line-break formatting.

### What
The server-side `_compact_for_echo_compare` helper (used by `_is_visible_output_echo` to detect when an `interim_assistant` update merely reformats already-visible token prose) collapsed whitespace to a single space, so echoes that differed only by paragraph/line-break formatting slipped through and rendered twice. It now strips **all** whitespace before the comparison. The helper was also hoisted to module scope so it's directly importable + unit-testable.

### Safety
`_is_visible_output_echo` does an exact **suffix** match (`visible_tail.endswith(candidate)`) against the compacted accumulated visible token stream, requiring a non-empty candidate — not an arbitrary substring search. Stripping whitespace only makes it correctly catch reformatted echoes; it can't false-suppress genuinely distinct interim content.

### Review trail
- **Codex: SAFE TO SHIP** — verified it's exact suffix-matching against the compacted visible stream tail (not substring), non-empty candidate required.
- **Full suite: 10087 passed, 0 failed.** New behavior-based test asserts real token-vs-interim text equality after whitespace normalization.

Note: the contributor iterated this PR tonight (frontend approach → backend approach → module-level helper + behavior test); shipped from the final authoritative head `14e8fba6`.

Co-authored-by: franksong2702 <franksong2702@users.noreply.github.com>

Closes #4689
