### PR TITLE
Release v0.51.586 — eliminate iOS button tap delay (#4696)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.586] — 2026-06-22 — Release US (eliminate iOS button tap delay)
+
+### Fixed
+
+- **No more double-tap delay on buttons on iOS.** On iOS Safari, tapping interactive controls (the send button, icon buttons, approval buttons, etc.) often needed two taps — the first only "selected" the control — because the browser waited ~300ms to disambiguate a double-tap zoom. Those controls now declare `touch-action:manipulation` (with a transparent tap highlight), so they fire on the first tap. Thanks @rodboev. (#4696, fixes #4693)
+
 ## [v0.51.585] — 2026-06-22 — Release UR (suppress duplicate live process echoes)
 
 ### Fixed

--- a/static/style.css
+++ b/static/style.css
@@ -2068,6 +2068,7 @@
   .send-btn:active{transform:scale(0.95);box-shadow:0 1px 4px var(--accent-bg);}
   .send-btn:disabled{opacity:.35;cursor:not-allowed;transform:none;box-shadow:none;}
   .send-btn.visible{animation:send-pop-in .18s cubic-bezier(.34,1.56,.64,1) forwards;}
+  button,.icon-btn,.panel-icon-btn,.send-btn,.approval-btn,[onclick]{touch-action:manipulation;-webkit-tap-highlight-color:transparent;}
   .composer-terminal-panel{position:absolute;left:0;right:0;bottom:-24px;width:min(calc(100% - 64px),720px);margin:0 auto;box-sizing:border-box;overflow:hidden;pointer-events:none;z-index:1;}
   .composer-terminal-panel.is-open,.composer-terminal-panel.is-collapsed{pointer-events:auto;}
   .composer-terminal-panel[hidden]{display:none!important;}

--- a/tests/test_issue4696_ios_tap_delay.py
+++ b/tests/test_issue4696_ios_tap_delay.py
@@ -1,0 +1,24 @@
+"""Regression test for #4696 — eliminate the iOS tap delay on interactive buttons.
+
+iOS Safari adds a ~300ms delay (and a double-tap "select then fire" behavior) on
+tappable elements unless `touch-action:manipulation` is set. The fix adds that —
+plus `-webkit-tap-highlight-color:transparent` — to interactive controls in the
+touch/compact media block so the send button and friends fire on the first tap.
+"""
+from pathlib import Path
+
+CSS = (Path(__file__).resolve().parents[1] / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def test_interactive_buttons_have_touch_action_manipulation():
+    # The rule must cover the common interactive selectors and set both
+    # touch-action:manipulation (kills the 300ms tap delay) and a transparent
+    # tap highlight. We assert the exact rule the fix introduced.
+    rule = (
+        "button,.icon-btn,.panel-icon-btn,.send-btn,.approval-btn,[onclick]"
+        "{touch-action:manipulation;-webkit-tap-highlight-color:transparent;}"
+    )
+    assert rule in CSS, (
+        "interactive controls must declare touch-action:manipulation to remove the "
+        "iOS tap delay (#4696)"
+    )


### PR DESCRIPTION
## Release v0.51.586 — eliminate iOS button tap delay (#4696)

Ships **#4696** (rodboev) — fixes #4693: on iOS Safari, tapping interactive controls (send button, icon buttons, approval buttons, anything with `[onclick]`) often needed two taps because the browser held ~300ms to disambiguate a double-tap zoom.

### What
Adds `touch-action:manipulation` (which opts out of the double-tap-zoom delay) and `-webkit-tap-highlight-color:transparent` to interactive controls, inside the touch/compact media block (`@media (max-width:1399.98px)`), so they fire on the first tap.

### Review trail
- 1-line CSS rule; no logic change. `touch-action:manipulation` is the standard, well-understood iOS tap-delay remedy and is harmless on non-touch devices.
- **Full suite: 10088 passed, 0 failed.** Added a regression test pinning the rule.

Co-authored-by: rodboev <rodboev@users.noreply.github.com>

Closes #4696
