### PR TITLE
Preserve Thinking detail scroll across render rebuilds

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -8224,6 +8224,10 @@ function _worklogDetailBaseKey(el){
 function _worklogDetailDisclosureIsOpen(el){
   return !!(el&&el.classList&&el.classList.contains('open'));
 }
+function _worklogDetailScrollableBody(el){
+  if(!el||!el.querySelector) return null;
+  return el.querySelector('.thinking-card-body,.tool-card-detail');
+}
 function _setWorklogDetailDisclosureOpen(el, open){
   if(!el||!el.classList) return;
   el.classList.toggle('open', !!open);
@@ -8252,7 +8256,12 @@ function _captureWorklogDetailDisclosureState(root){
   const counts=Object.create(null);
   root.querySelectorAll(_worklogDetailDisclosureSelector).forEach(el=>{
     const key=_worklogDetailDisclosureKeyForElement(el, counts);
-    if(key) state.set(key, _worklogDetailDisclosureIsOpen(el));
+    if(!key) return;
+    const body=_worklogDetailScrollableBody(el);
+    state.set(key,{
+      open:_worklogDetailDisclosureIsOpen(el),
+      scrollTop:body?Math.max(0,Number(body.scrollTop)||0):0,
+    });
   });
   return state;
 }
@@ -8264,7 +8273,14 @@ function _restoreWorklogDetailDisclosureState(root, state){
   root.querySelectorAll(_worklogDetailDisclosureSelector).forEach(el=>{
     const key=_worklogDetailDisclosureKeyForElement(el, counts);
     if(!key||!state.has(key)) return;
-    _setWorklogDetailDisclosureOpen(el, state.get(key));
+    const saved=state.get(key);
+    const open=(saved&&typeof saved==='object'&&'open' in saved)?saved.open:saved;
+    _setWorklogDetailDisclosureOpen(el, open);
+    const scrollTop=(saved&&typeof saved==='object')?Number(saved.scrollTop):0;
+    if(open&&Number.isFinite(scrollTop)&&scrollTop>0){
+      const body=_worklogDetailScrollableBody(el);
+      if(body) body.scrollTop=Math.min(scrollTop, Math.max(0, body.scrollHeight-body.clientHeight));
+    }
   });
 }
 function _thinkingCardHtml(text, open){

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -279,6 +279,30 @@ class TestToolCallGroupingStatic:
             "Restoring multi-tool groups must sync both CSS state and accessibility state."
         )
 
+    def test_render_rebuild_preserves_nested_worklog_detail_scroll_position(self):
+        capture_fn = _function_body(UI_JS, "_captureWorklogDetailDisclosureState")
+        restore_fn = _function_body(UI_JS, "_restoreWorklogDetailDisclosureState")
+        body_fn = _function_body(UI_JS, "_worklogDetailScrollableBody")
+
+        assert ".thinking-card-body,.tool-card-detail" in body_fn, (
+            "Nested scroll preservation must cover Thinking bodies and Tool details."
+        )
+        assert "_worklogDetailScrollableBody(el)" in capture_fn, (
+            "The rebuild-state capture must inspect each detail's nested scroll container."
+        )
+        assert "scrollTop:body?Math.max(0,Number(body.scrollTop)||0):0" in capture_fn, (
+            "The captured Worklog detail state must retain the nested scrollTop value."
+        )
+        assert "const saved=state.get(key)" in restore_fn, (
+            "Restoration should read the structured state object for each detail."
+        )
+        assert "const open=(saved&&typeof saved==='object'&&'open' in saved)?saved.open:saved" in restore_fn, (
+            "Restoration must remain backward-compatible with legacy boolean snapshots."
+        )
+        assert "body.scrollTop=Math.min(scrollTop, Math.max(0, body.scrollHeight-body.clientHeight))" in restore_fn, (
+            "Restoration must reapply nested scrollTop after the rebuilt detail is opened."
+        )
+
     def test_worklog_detail_keys_stay_stable_while_streaming_content_grows(self):
         key_fn = _function_body(UI_JS, "_worklogDetailBaseKey")
         append_thinking_fn = _function_body(UI_JS, "appendThinking")


### PR DESCRIPTION
## Thinking Path

- #4707 reports that an expanded Thinking / reasoning block snaps its own inner scroll position back to the top while the user is reading it.
- The main transcript scroll preservation path already captures and restores the outer `#messages` scroll position.
- The missed state is narrower: `renderMessages()` and the live anchor-scene path rebuild Worklog detail DOM while only preserving open/closed disclosure state.
- The rebuilt `.thinking-card-body` / `.tool-card-detail` node starts with `scrollTop = 0`, so a render pass can make an expanded Thinking panel jump to the top.
- The fix keeps the existing disclosure-key mechanism and adds nested detail scroll preservation to that same renderer-state snapshot.

## What Changed

- Added `_worklogDetailScrollableBody()` for Worklog detail panels with nested scroll containers.
- Changed Worklog detail snapshot values from boolean-only to `{ open, scrollTop }`.
- Restored the saved nested `scrollTop` after reopening the rebuilt detail element.
- Kept backward compatibility with legacy boolean snapshots.
- Added static regression coverage that pins capture/restore of nested scroll position for Thinking bodies and Tool details.

## Why It Matters

Users can expand a long Thinking / reasoning block and keep reading lower content while the chat renderer refreshes. This fixes the Windows desktop report without changing the main transcript auto-scroll / anchor behavior.

## Contract Routing

Task type: chat rendering / UI scene-state bugfix
Touched areas: `static/ui.js` Worklog detail disclosure state, render rebuild preservation tests
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/UIUX-GUIDE.md`
- `DESIGN.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
- `docs/architecture/stable-assistant-turn-anchor-phase0.md`
State layer: Live UI scene/cache renderer state. This preserves local nested detail scroll state across DOM rebuilds; it does not change transcript data, model context, SSE events, or the main transcript scroll anchor.
Evidence needed before claiming done: targeted tests prove Worklog detail rebuild snapshots carry nested scrollTop and restore it after the rebuilt element is opened.

## Verification

- `node --check static/ui.js`
- `git diff --check origin/master`
- `./scripts/test.sh tests/test_ui_tool_call_cleanup.py -q` -> 35 passed
- `./scripts/test.sh tests/test_ui_card_animation.py tests/test_live_to_final_anchor_visible_order.py -q` -> 60 passed

## Risks / Follow-ups

- No browser screenshot/video is attached because this is a scroll-state preservation fix rather than a visual styling change; the DOM-state regression is covered by static tests.
- Session HTML-cache restores still render from cached HTML; this PR targets the reported repeated snap during live/rebuild refreshes where the previous DOM is available for capture.
- No `CHANGELOG.md` entry in this contributor PR; release notes are handled by the maintainer release flow.

Fixes #4707.

## Model Used

AI-assisted implementation and review.

- OpenAI GPT-5 Codex in Codex desktop.
