### PR TITLE
Release v0.51.588 — Release UU (preserve Thinking detail scroll, #4711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.588] — 2026-06-22 — Release UU (preserve Thinking detail scroll across rebuilds)
+
+### Fixed
+
+- **An expanded Thinking/reasoning block no longer snaps back to the top while you're scrolling inside it.** When the live transcript re-rendered (a streaming rebuild or live-anchor refresh), an open Thinking or tool-detail block preserved only its open/closed state, not how far you'd scrolled inside it — so the inner scroll jumped back to the top mid-read. The render rebuild now captures and restores each open detail's inner `scrollTop` (clamped to the content height, backward-compatible with the prior open/closed snapshots), so your place in a long reasoning block survives the rebuild. Thanks @franksong2702. (#4711, fixes #4707)
+
 ## [v0.51.587] — 2026-06-22 — Release UT (running-first session ordering in sidebar)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -8224,6 +8224,10 @@ function _worklogDetailBaseKey(el){
 function _worklogDetailDisclosureIsOpen(el){
   return !!(el&&el.classList&&el.classList.contains('open'));
 }
+function _worklogDetailScrollableBody(el){
+  if(!el||!el.querySelector) return null;
+  return el.querySelector('.thinking-card-body,.tool-card-detail');
+}
 function _setWorklogDetailDisclosureOpen(el, open){
   if(!el||!el.classList) return;
   el.classList.toggle('open', !!open);
@@ -8252,7 +8256,12 @@ function _captureWorklogDetailDisclosureState(root){
   const counts=Object.create(null);
   root.querySelectorAll(_worklogDetailDisclosureSelector).forEach(el=>{
     const key=_worklogDetailDisclosureKeyForElement(el, counts);
-    if(key) state.set(key, _worklogDetailDisclosureIsOpen(el));
+    if(!key) return;
+    const body=_worklogDetailScrollableBody(el);
+    state.set(key,{
+      open:_worklogDetailDisclosureIsOpen(el),
+      scrollTop:body?Math.max(0,Number(body.scrollTop)||0):0,
+    });
   });
   return state;
 }
@@ -8264,7 +8273,14 @@ function _restoreWorklogDetailDisclosureState(root, state){
   root.querySelectorAll(_worklogDetailDisclosureSelector).forEach(el=>{
     const key=_worklogDetailDisclosureKeyForElement(el, counts);
     if(!key||!state.has(key)) return;
-    _setWorklogDetailDisclosureOpen(el, state.get(key));
+    const saved=state.get(key);
+    const open=(saved&&typeof saved==='object'&&'open' in saved)?saved.open:saved;
+    _setWorklogDetailDisclosureOpen(el, open);
+    const scrollTop=(saved&&typeof saved==='object')?Number(saved.scrollTop):0;
+    if(open&&Number.isFinite(scrollTop)&&scrollTop>0){
+      const body=_worklogDetailScrollableBody(el);
+      if(body) body.scrollTop=Math.min(scrollTop, Math.max(0, body.scrollHeight-body.clientHeight));
+    }
   });
 }
 function _thinkingCardHtml(text, open){

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -279,6 +279,30 @@ class TestToolCallGroupingStatic:
             "Restoring multi-tool groups must sync both CSS state and accessibility state."
         )
 
+    def test_render_rebuild_preserves_nested_worklog_detail_scroll_position(self):
+        capture_fn = _function_body(UI_JS, "_captureWorklogDetailDisclosureState")
+        restore_fn = _function_body(UI_JS, "_restoreWorklogDetailDisclosureState")
+        body_fn = _function_body(UI_JS, "_worklogDetailScrollableBody")
+
+        assert ".thinking-card-body,.tool-card-detail" in body_fn, (
+            "Nested scroll preservation must cover Thinking bodies and Tool details."
+        )
+        assert "_worklogDetailScrollableBody(el)" in capture_fn, (
+            "The rebuild-state capture must inspect each detail's nested scroll container."
+        )
+        assert "scrollTop:body?Math.max(0,Number(body.scrollTop)||0):0" in capture_fn, (
+            "The captured Worklog detail state must retain the nested scrollTop value."
+        )
+        assert "const saved=state.get(key)" in restore_fn, (
+            "Restoration should read the structured state object for each detail."
+        )
+        assert "const open=(saved&&typeof saved==='object'&&'open' in saved)?saved.open:saved" in restore_fn, (
+            "Restoration must remain backward-compatible with legacy boolean snapshots."
+        )
+        assert "body.scrollTop=Math.min(scrollTop, Math.max(0, body.scrollHeight-body.clientHeight))" in restore_fn, (
+            "Restoration must reapply nested scrollTop after the rebuilt detail is opened."
+        )
+
     def test_worklog_detail_keys_stay_stable_while_streaming_content_grows(self):
         key_fn = _function_body(UI_JS, "_worklogDetailBaseKey")
         append_thinking_fn = _function_body(UI_JS, "appendThinking")


### PR DESCRIPTION
## Release v0.51.588 — Release UU

Ships **#4711** (@franksong2702) — preserve Thinking detail scroll across render rebuilds (fixes #4707).

### What's in it
- **#4711** — An expanded Thinking/reasoning (or tool-detail) block no longer snaps its inner scroll back to the top when the live transcript re-renders. The render rebuild now captures + restores each open detail's inner `scrollTop` (clamped to content height, backward-compatible with the prior open/closed-only snapshots).

### Gate (authoritative, all three legs)
- **Full pytest suite:** 10092 passed, 9 skipped, 0 failed (`-p no:xdist`).
- **Codex advisor:** SAFE TO SHIP — verified capture/restore is renderer-local, runs ahead of `scrollIfPinned()`, cannot move the `#messages` transcript scroll or trigger the live-anchor rebuild.
- **Opus advisor:** CLEAN — no MUST-FIX, no blocking SHOULD-FIX. (Optional cosmetic: gate `_worklogDetailScrollableBody` so `.tool-group` doesn't borrow a child card's body — idempotent double-write, document-order-safe, safe to defer.)
- ESLint runtime gate + `node -c`: clean.

### Attribution
Authored by @franksong2702 (#4711). Credit preserved via `--no-ff` merge of the PR head + CHANGELOG credit.

Closes #4707.
