### PR TITLE
fix: make is_default follow active_profile in profile list API

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -1444,11 +1444,20 @@ def _build_profile_rows_fast() -> list | None:
         }
 
     rows: list = []
+
+    # Determine which profile is the "default" (startup) profile by reading
+    # the active_profile file.  When a user runs `hermes profile use <name>`,
+    # that profile should report is_default=True so that clients (desktop app,
+    # mobile app) treat it as the startup profile.  Previously is_default was
+    # hardcoded to True only for the root profile, making it impossible for a
+    # named profile to ever be the default — even after `hermes profile use`.
+    active_profile_name = _read_active_profile_file()
+
     default_home = _get_default_hermes_home()
     if default_home.is_dir():
         # Upstream hardcodes the base home's display name to "default" even when
         # the directory is literally ".hermes" — match that exactly.
-        rows.append(_row(default_home, 'default', True))
+        rows.append(_row(default_home, 'default', _is_root_profile(active_profile_name)))
 
     profiles_root = _get_profiles_root()
     if profiles_root.is_dir():
@@ -1457,7 +1466,7 @@ def _build_profile_rows_fast() -> list | None:
                 continue
             if not _UPSTREAM_PROFILE_ID_RE.match(entry.name):
                 continue
-            rows.append(_row(entry, entry.name, False))
+            rows.append(_row(entry, entry.name, entry.name == active_profile_name))
 
     return rows
 


### PR DESCRIPTION
## Summary

When a user runs `hermes profile use <name>` to set a named profile as the sticky default, the WebUI's profile list API continued to report `is_default: true` only for the root profile. Named profiles were always `is_default: false`, regardless of the `active_profile` setting.

This caused desktop and mobile clients to always show the root profile as the default, even after the user explicitly switched the default via CLI.

## Fix

Read `~/.hermes/active_profile` in `_build_profile_rows_fast()` and set `is_default` based on which profile is actually the startup profile, not just which one is the root.

- Root profile gets `is_default: true` only when it is the active profile (or when no active_profile file exists — the default behavior)
- Named profiles get `is_default: true` when they match the active_profile file

## Changes

`api/profiles.py` — `_build_profile_rows_fast()`:
- Read `_read_active_profile_file()` to determine the active profile name
- Use `_is_root_profile(active_profile_name)` for the root profile row
- Use `entry.name == active_profile_name` for named profile rows

Fixes #4722
