### PR TITLE
fix(ui): prevent usage footer wrapping timestamps

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -5070,8 +5070,9 @@ main.main > #mainPlugin{display:none;}
   font-size: 11px;
   color: var(--muted);
 }
-.msg-foot .msg-actions { opacity: 1; margin-left: 0; }
-.msg-foot .msg-time { font-size: 10.5px; opacity: .75; }
+.msg-foot .msg-actions { opacity: 1; margin-left: 0; flex: 0 0 auto; white-space: nowrap; }
+.msg-foot .msg-time { font-size: 10.5px; opacity: .75; white-space: nowrap; flex: 0 0 auto; }
+.msg-foot .msg-action-btn { flex: 0 0 auto; }
 .session-jump-btn--inline {
   position: static;
   right: auto;
@@ -5142,7 +5143,11 @@ main.main > #mainPlugin{display:none;}
   font-size: 11px;
   color: var(--muted);
   opacity: .7;
-  flex: 0 0 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 0 1 auto;
   font-variant-numeric: tabular-nums;
 }
 .gateway-failover-inline {

--- a/tests/test_message_footer_layout.py
+++ b/tests/test_message_footer_layout.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _normalize_selector(selector: str) -> str:
+    return " ".join(selector.split())
+
+
+def _selector_parts(prelude: str) -> set[str]:
+    return {_normalize_selector(part) for part in prelude.split(",") if part.strip()}
+
+
+def _css_rule_blocks() -> list[tuple[set[str], str]]:
+    blocks = []
+    stack: list[int] = []
+    segment_start = 0
+    for idx, char in enumerate(STYLE_CSS):
+        if char == "{":
+            stack.append(idx)
+            if len(stack) == 1:
+                prelude = STYLE_CSS[segment_start:idx].strip()
+                if prelude.startswith("@"):
+                    continue
+                depth = 1
+                for end in range(idx + 1, len(STYLE_CSS)):
+                    if STYLE_CSS[end] == "{":
+                        depth += 1
+                    elif STYLE_CSS[end] == "}":
+                        depth -= 1
+                        if depth == 0:
+                            blocks.append((_selector_parts(prelude), STYLE_CSS[idx + 1 : end]))
+                            break
+        elif char == "}":
+            if stack:
+                stack.pop()
+            if not stack:
+                segment_start = idx + 1
+    return blocks
+
+
+def _css_blocks(selector: str) -> list[str]:
+    normalized = _normalize_selector(selector)
+    blocks = [body for selectors, body in _css_rule_blocks() if normalized in selectors]
+    assert blocks, f"Missing CSS selector: {selector}"
+    return blocks
+
+
+def _assert_any_block_contains(selector: str, *properties: str) -> None:
+    blocks = _css_blocks(selector)
+    for block in blocks:
+        if all(prop in block for prop in properties):
+            return
+    raise AssertionError(f"No CSS block for {selector} contains {properties}")
+
+
+def test_usage_footer_text_can_shrink_instead_of_wrapping_timestamp():
+    for selector in (
+        ".msg-usage-inline",
+        ".msg-duration-inline",
+        ".msg-gateway-inline",
+        ".gateway-failover-inline",
+        ".msg-model-warning-inline",
+    ):
+        _assert_any_block_contains(
+            selector,
+            "flex: 0 1 auto",
+            "min-width: 0",
+            "overflow: hidden",
+            "text-overflow: ellipsis",
+            "white-space: nowrap",
+        )
+
+
+def test_message_footer_timestamp_and_actions_do_not_wrap_or_shrink():
+    _assert_any_block_contains(
+        ".msg-foot .msg-time",
+        "white-space: nowrap",
+        "flex: 0 0 auto",
+    )
+    _assert_any_block_contains(
+        ".msg-foot .msg-actions",
+        "white-space: nowrap",
+        "flex: 0 0 auto",
+    )
+    _assert_any_block_contains(".msg-foot .msg-action-btn", "flex: 0 0 auto")
+
+
+def test_usage_footer_hover_rules_do_not_override_nowrap_or_flex_contract():
+    for selector in (
+        ".msg-foot-with-usage .msg-time",
+        ".msg-foot-with-usage .msg-actions",
+    ):
+        for block in _css_blocks(selector):
+            assert "white-space:" not in block
+            assert "flex:" not in block


### PR DESCRIPTION
## Thinking Path

- Assistant footer metadata is supposed to stay quiet and readable below the message, even when a completed turn reports a long usage line.
- On mobile/narrow footer widths, the usage footer currently puts duration, token/cache usage, timestamp, and action buttons in one flex row with limited horizontal space.
- Long usage fragments were fixed-width flex items, so they could consume the row and force the timestamp into a min-content wrap such as one character per line.
- The narrow fix is to let usage fragments shrink with ellipsis while making timestamps and action buttons non-wrapping, non-shrinking controls.
- This keeps the existing footer visibility/hover behavior and does not touch streaming, virtualization, or message rendering logic.

## What Changed

- Updated assistant footer CSS so `.msg-usage-inline`, duration, gateway, failover, and warning fragments can shrink and ellipsize.
- Made `.msg-foot .msg-time`, `.msg-foot .msg-actions`, and footer action buttons stay on one line without flex-shrinking.
- Added a focused CSS regression test for the usage-footer shrink contract and timestamp/action nowrap contract.

## Why It Matters

- Prevents long usage metadata like high token counts plus cache percentage from crushing the timestamp into vertical characters on mobile/narrow footer widths.
- Keeps footer actions stable and readable when token/cache usage is enabled.
- Preserves the calm transcript hierarchy: metadata may truncate, but message controls should not visually break.

## Screenshots

Before: mobile Brave footer area with a long usage line squeezing the timestamp into vertical text.

<img width="1440" alt="Mobile footer timestamp wrapping vertically before fix" src="https://raw.githubusercontent.com/starship-s/hermes-webui/evidence/pr-4724-mobile-footer-before/pr-evidence/pr4724-mobile-footer-before.png" />

After: not captured separately. The CSS contract now makes usage metadata the shrink/ellipsis target while timestamps/actions stay non-wrapping.

## Verification

Targeted coverage:

```text
./scripts/test.sh tests/test_message_footer_layout.py -q
# Running 3 items in this shard
# 3 passed in 2.53s
```

Hygiene:

```text
git diff --check
# passed
```

## Risks / Follow-ups

- This is a CSS-only fix; no runtime/session behavior is changed.
- The regression coverage is static CSS contract coverage rather than a browser-rendered visual test.
- Visual before/after evidence can be added if review needs a rendered screenshot.

## Model Used

- OpenAI / GPT-5.5 for diagnosis, implementation, and PR preparation.
- OpenAI / GPT-5.3 Codex Spark via OpenCode for independent review.
- Anthropic / Claude Opus 4.8 via Claude Code for final independent review.
