### PR TITLE
fix: prevent TLS handshake from stalling the accept loop

### DIFF
--- a/server.py
+++ b/server.py
@@ -8,6 +8,7 @@ import os
 import re
 import signal
 import socket
+import ssl
 import sys
 import threading
 import time
@@ -157,6 +158,7 @@ class QuietHTTPServer(ThreadingHTTPServer):
         server_address = args[0] if args else kwargs.get('server_address', None)
         if server_address and ':' in server_address[0]:
             self.address_family = socket.AF_INET6
+        self.ssl_context: object | None = None
         super().__init__(*args, **kwargs)
         self.accept_loop_requests_total = 0
         self.accept_loop_last_request_at = 0.0
@@ -185,6 +187,31 @@ class QuietHTTPServer(ThreadingHTTPServer):
         else:
             super().server_bind()
 
+    def get_request(self):
+        """Accept a connection without letting TLS handshakes block the loop.
+
+        ``ssl.wrap_socket(listening_socket)`` performs the TLS handshake inside
+        ``accept()``. A browser/network probe that opens TCP but never sends a
+        ClientHello can then freeze the one accept loop, leaving the process
+        alive but unable to serve any later clients. Accept the raw socket here
+        and wrap the accepted connection with ``do_handshake_on_connect=False``
+        so any slow/broken handshake times out in its own request thread.
+        """
+        request, client_address = self.socket.accept()
+        ssl_context = getattr(self, "ssl_context", None)
+        if ssl_context is None:
+            return request, client_address
+        try:
+            tls_request = ssl_context.wrap_socket(
+                request,
+                server_side=True,
+                do_handshake_on_connect=False,
+            )
+        except Exception:
+            request.close()
+            raise
+        return tls_request, client_address
+
     def _handle_request_noblock(self):
         """Record accept-loop progress before dispatching a request handler.
 
@@ -207,7 +234,10 @@ class QuietHTTPServer(ThreadingHTTPServer):
         exc_type, exc_value, _ = sys.exc_info()
         
         # Silently ignore common connection errors caused by client disconnects
-        if exc_type in (ConnectionResetError, BrokenPipeError, ConnectionAbortedError, TimeoutError):
+        if exc_type in (
+            ConnectionResetError, BrokenPipeError, ConnectionAbortedError,
+            TimeoutError, ssl.SSLError, ssl.SSLEOFError,
+        ):
             return
         
         # Also handle socket errors that indicate client disconnect
@@ -648,7 +678,7 @@ def main() -> None:
             ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
             ctx.minimum_version = ssl.TLSVersion.TLSv1_2
             ctx.load_cert_chain(TLS_CERT, TLS_KEY)
-            httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+            httpd.ssl_context = ctx
             print(f'  TLS enabled: cert={TLS_CERT}, key={TLS_KEY}', flush=True)
         except Exception as e:
             print(f'[!!] WARNING: TLS setup failed ({e}), falling back to HTTP', flush=True)

--- a/tests/test_tls_support.py
+++ b/tests/test_tls_support.py
@@ -6,6 +6,7 @@ Tests use a self-signed certificate generated at test time via openssl.
 import http.client
 import json
 import os
+import socket
 import ssl
 import subprocess
 import sys
@@ -222,6 +223,39 @@ class TestTLSEndToEnd(unittest.TestCase):
         data = json.loads(resp.read())
         self.assertEqual(data.get("status"), "ok")
         conn.close()
+
+    def test_stalled_tls_handshake_does_not_block_other_clients(self):
+        """A raw TCP client that never speaks TLS must not wedge HTTPS accept()."""
+        port = _find_free_port()
+        self._proc = _start_server(port, cert=self._cert, key=self._key)
+        self.assertTrue(
+            _wait_for_server("127.0.0.1", port, use_ssl=True),
+            "TLS server did not start in time",
+        )
+
+        raw = socket.create_connection(("127.0.0.1", port), timeout=2)
+        try:
+            # Give the kernel a moment to deliver the TCP connection so the
+            # server's accept loop dequeues the raw socket before the HTTPS
+            # request arrives — this guarantees the test exercises the fix.
+            time.sleep(0.05)
+            # Do not send a TLS ClientHello. Before the fix, the listening
+            # SSLSocket performed the handshake in the single accept loop, so
+            # this one idle client blocked every later browser/API request.
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            conn = http.client.HTTPSConnection(
+                "127.0.0.1", port, timeout=2, context=ctx,
+            )
+            conn.request("GET", "/health")
+            resp = conn.getresponse()
+            self.assertEqual(resp.status, 200)
+            data = json.loads(resp.read())
+            self.assertEqual(data.get("status"), "ok")
+            conn.close()
+        finally:
+            raw.close()
 
     def test_http_without_tls_still_works(self):
         self._proc = _start_and_wait(use_ssl=False)


### PR DESCRIPTION
## Summary

Prevents a stalled TLS handshake from blocking the entire accept loop, which can leave the WebUI process alive but unable to serve any clients.

### Problem

When TLS is enabled, `ssl.wrap_socket(listening_socket)` performs the TLS handshake synchronously inside `accept()`. If a browser, health-check probe, or network scanner opens a TCP connection but never sends a ClientHello (or sends a malformed one), the single accept loop freezes — the process stays alive but every subsequent client hangs forever.

### Solution

Override `get_request()` to accept the raw socket, then wrap it with `do_handshake_on_connect=False`. The TLS handshake now happens in the request thread instead of the accept loop, so any slow/broken handshake times out in its own thread without affecting other clients.

### Test Plan

- [x] TLS connections continue to work normally
- [x] A TCP probe that never sends a ClientHello no longer blocks the server
- [x] Unit test included: `tests/test_tls_support.py`

### Changes

- `server.py`: override `get_request()` with non-blocking TLS wrapping
- `tests/test_tls_support.py`: test for TLS accept loop resilience