### PR TITLE
perf: skip gateway poll when hidden/streaming, re-init smd parser before innerHTML fallback

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -3352,6 +3352,17 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       : _stripXmlToolCalls(assistantText.slice(segmentStart));
     if(_smdParser){
       _smdWrite(displayText);
+    } else if(window.smd){
+      // Parser was nulled out (e.g. by a prior segment end) but smd is
+      // available — recreate it on the existing element. Uses the non-fade
+      // renderer to match standard rendering, avoiding O(n²) innerHTML
+      // churn on long responses (#4704).
+      // Clear existing content before re-initializing the parser
+      // to prevent duplicate DOM nodes when _smdParser was previously
+      // ended by _smdEndParser / _resetAssistantSegment (#4704).
+      assistantBody.innerHTML = '';
+      _smdNewParser(assistantBody, false);
+      if(_smdParser) _smdWrite(displayText);
     } else if(renderMd){
       assistantBody.innerHTML=renderMd(displayText);
     } else {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4098,16 +4098,39 @@ function ensureSessionEventsSSE(){
 
 if(typeof window!=='undefined') window.refreshSessionList = refreshSessionList;
 
+let _gatewayPollVisibilityHandler = null; // saved for cleanup in stopGatewayPollFallback
+
 function startGatewayPollFallback(ms){
   const intervalMs = Math.max(5000, Number(ms) || _gatewayFallbackPollMs);
   if(_gatewayPollTimer) clearInterval(_gatewayPollTimer);
-  _gatewayPollTimer = setInterval(() => { renderSessionList({deferWhileInteracting:true}); }, intervalMs);
+  _gatewayPollTimer = setInterval(() => {
+    // Skip poll when tab is hidden or a stream is active — saves CPU
+    // and avoids redundant DOM renders during active streaming (#4704).
+    if(typeof document !== 'undefined' && document.hidden) return;
+    if(typeof S !== 'undefined' && (S.busy || S.activeStreamId)) return;
+    renderSessionList({deferWhileInteracting:true});
+  }, intervalMs);
+  // Visibility catch-up: refresh immediately when tab re-gains focus,
+  // so no gateway updates are dropped during hidden-skip periods.
+  // Save the handler so it can be removed when polling stops (see Greptile review #4730).
+  if(typeof document !== 'undefined' && !_gatewayPollVisibilityHandler){
+    _gatewayPollVisibilityHandler = () => {
+      if(!document.hidden && typeof renderSessionList === 'function'){
+        void renderSessionList({deferWhileInteracting:false});
+      }
+    };
+    document.addEventListener('visibilitychange', _gatewayPollVisibilityHandler);
+  }
 }
 
 function stopGatewayPollFallback(){
   if(_gatewayPollTimer){
     clearInterval(_gatewayPollTimer);
     _gatewayPollTimer = null;
+  }
+  if(_gatewayPollVisibilityHandler && typeof document !== 'undefined'){
+    document.removeEventListener('visibilitychange', _gatewayPollVisibilityHandler);
+    _gatewayPollVisibilityHandler = null;
   }
 }
 


### PR DESCRIPTION
## Problem

Two independent CPU waste sources during active streaming:

1. **`startGatewayPollFallback()` fires every N seconds unconditionally** — even when the tab is hidden or a stream is in progress, it calls `renderSessionList()` which does full sidebar DOM diffs. This wastes CPU on backgrounded tabs and competes with the SSE stream that is already the authoritative source.

2. **`_flushPendingSegmentRender()` falls through to `innerHTML = renderMd(displayText)` too readily** — when `_smdParser` is null (e.g. after a prior segment end), it re-parses the entire growing message body on every flush instead of re-creating the parser. This causes O(n²) DOM churn over the lifetime of a long agent response.

## Changes

| File | Change | Impact |
|---|---|---|
| `static/sessions.js` | `startGatewayPollFallback()` skips tick when `document.hidden` or `S.busy` / `S.activeStreamId`; adds `visibilitychange` catch-up | Eliminates background-tab CPU waste; no gateway updates are dropped |
| `static/messages.js` | `_flushPendingSegmentRender()` re-inits `_smdParser` via `_smdNewParser(el, false)` before falling back to `innerHTML` | Avoids O(n²) re-parse of long responses; uses non-fade renderer to match standard rendering |

## Review notes

- Feedback addressed from https://github.com/nesquena/hermes-webui/pull/4704#issuecomment-4773475189
- `startStreamingPoll()` already guards on `S.busy || S.activeStreamId` (line 423) — no conflict
- `renderSessionList()` already guards on `document.hidden` (line 3941) — gateway poll mirrors the same pattern
- `_smdNewParser()` with `fade=false` is the same renderer the normal init path uses