### PR TITLE
Release v0.51.596 — Release VC (throttle reasoning SSE, #4729)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+## [v0.51.596] — 2026-06-23 — Release VC (throttle reasoning SSE to stop tab freeze)
+
 ### Fixed
 
 - **Reasoning SSE events no longer flood the frontend renderer.** During the reasoning/thinking phase of models like DeepSeek, the server emitted one SSE `reasoning` event per token — tens of thousands per turn — each triggering a full-text scan in the frontend renderer, locking the JS main thread (browser tab freeze). Reasoning SSE events are now throttled to ~10 Hz via a coalescing buffer: delta text is accumulated server-side and flushed in batches, so every reasoning token reaches the browser's live Thinking view while capping SSE events to ~10 Hz. The accumulated reasoning text remains complete for persistence. Thanks @wlknight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Reasoning SSE events no longer flood the frontend renderer.** During the reasoning/thinking phase of models like DeepSeek, the server emitted one SSE `reasoning` event per token — tens of thousands per turn — each triggering a full-text scan in the frontend renderer, locking the JS main thread (browser tab freeze). Reasoning SSE events are now throttled to ~10 Hz via a coalescing buffer: delta text is accumulated server-side and flushed in batches, so every reasoning token reaches the browser's live Thinking view while capping SSE events to ~10 Hz. The accumulated reasoning text remains complete for persistence. Thanks @wlknight.
+
 ## [v0.51.594] — 2026-06-22 — Release VA (profile-switch loading skeletons)
 
 ### Added

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -6337,6 +6337,8 @@ def _run_agent_streaming(
             # Throttle: emit metering events at most every 100 ms so the per-message
             # TPS label feels live during fast token streams without flooding SSE.
             _metering_last_emit = [time.monotonic() - 1]  # fire immediately on first token
+            _reasoning_last_put = [0.0]
+            _reasoning_buffer = ['']
             _metering_output_deltas = [0]
             _metering_reasoning_deltas = [0]
 
@@ -6380,6 +6382,11 @@ def _run_agent_streaming(
             def on_reasoning(text):
                 nonlocal _reasoning_segments, _current_reasoning_idx, _tool_boundary_advanced
                 if text is None:
+                    # Flush any remaining coalesced reasoning buffer so the last
+                    # partial window is not lost when the reasoning phase ends.
+                    if _reasoning_buffer[0]:
+                        put('reasoning', {'text': _reasoning_buffer[0]})
+                        _reasoning_buffer[0] = ''
                     return
                 _tool_boundary_advanced = False
                 reasoning_delta = str(text)
@@ -6398,7 +6405,19 @@ def _run_agent_streaming(
                 # concatenation is correct there.
                 if stream_id in STREAM_REASONING_TEXT:
                     STREAM_REASONING_TEXT[stream_id] += reasoning_delta
-                put('reasoning', {'text': reasoning_delta})
+                # Accumulate into a coalescing buffer so every delta reaches the
+                # browser — reasoning deltas are incremental, not idempotent.
+                _reasoning_buffer[0] += reasoning_delta
+                # Throttle reasoning SSE events to ~10 Hz to avoid overwhelming the
+                # frontend renderer. Each event triggers _parseStreamState() which
+                # scans the full accumulated text — 10k+ reasoning tokens/second
+                # builds up and locks the JS main thread. The user still sees live
+                # Thinking updates, just at a sustainable rate.
+                now = time.monotonic()
+                if now - _reasoning_last_put[0] >= 0.1:
+                    _reasoning_last_put[0] = now
+                    put('reasoning', {'text': _reasoning_buffer[0]})
+                    _reasoning_buffer[0] = ''
                 # Track reasoning deltas in the meter so live TPS reflects all AI output.
                 _metering_reasoning_deltas[0] += 1
                 meter().record_reasoning(stream_id, _metering_reasoning_deltas[0])

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -6342,6 +6342,18 @@ def _run_agent_streaming(
             _metering_output_deltas = [0]
             _metering_reasoning_deltas = [0]
 
+            def _flush_reasoning_buffer():
+                # #4729: emit any coalesced-but-not-yet-flushed reasoning text immediately.
+                # The ~10 Hz throttle in on_reasoning leaves a sub-100ms tail in the buffer;
+                # the agent never calls reasoning_callback(None), and reasoning can transition
+                # to tool calls / visible output, so we must flush at every boundary that
+                # closes or reorders the live reasoning stream — otherwise the tail is
+                # silently lost from the live Thinking view (the frontend appends deltas).
+                if _reasoning_buffer[0]:
+                    put('reasoning', {'text': _reasoning_buffer[0]})
+                    _reasoning_buffer[0] = ''
+
+
             def _emit_metering():
                 now = time.monotonic()
                 if now - _metering_last_emit[0] < 0.1:
@@ -6367,6 +6379,9 @@ def _run_agent_streaming(
                 nonlocal _token_sent
                 if text is None:
                     return  # end-of-stream sentinel
+                # #4729: visible output is starting — flush any buffered reasoning tail
+                # first so the live Thinking stream is complete before/at the transition.
+                _flush_reasoning_buffer()
                 _token_sent = True
                 # Accumulate partial text so cancel_stream() can persist it (#893)
                 if stream_id in STREAM_PARTIAL_TEXT:
@@ -6384,9 +6399,7 @@ def _run_agent_streaming(
                 if text is None:
                     # Flush any remaining coalesced reasoning buffer so the last
                     # partial window is not lost when the reasoning phase ends.
-                    if _reasoning_buffer[0]:
-                        put('reasoning', {'text': _reasoning_buffer[0]})
-                        _reasoning_buffer[0] = ''
+                    _flush_reasoning_buffer()
                     return
                 _tool_boundary_advanced = False
                 reasoning_delta = str(text)
@@ -6489,6 +6502,9 @@ def _run_agent_streaming(
 
             def on_tool(*cb_args, **cb_kwargs):
                 nonlocal _reasoning_segments, _current_reasoning_idx, _tool_boundary_advanced
+                # #4729: a tool boundary closes/reorders the live reasoning stream — flush
+                # any buffered reasoning tail first so it isn't stranded behind the tool event.
+                _flush_reasoning_buffer()
                 event_type = None
                 name = None
                 preview = None
@@ -7334,6 +7350,11 @@ def _run_agent_streaming(
                 task_id=session_id,
                 persist_user_message=msg_text,
             )
+            # #4729: the run is done — flush any reasoning tail still in the coalescing
+            # buffer (the agent never calls reasoning_callback(None), and a turn can end on
+            # reasoning with no trailing token/tool boundary to trigger a flush) so the last
+            # sub-100ms window reaches the live Thinking view before the terminal done event.
+            _flush_reasoning_buffer()
             if cancel_event.is_set():
                 if _checkpoint_stop is not None:
                     _checkpoint_stop.set()

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8618,6 +8618,16 @@ def _run_agent_streaming(
                 # so it doesn't block the stream.
                 _maybe_schedule_title_refresh(s, put, agent)
         finally:
+            # #4729: guaranteed-exit flush of any reasoning tail still buffered. On the
+            # normal path the on_token/on_tool/post-run flushes already emptied it (no-op
+            # here); on an exception or retry path that bypassed those, this emits the tail
+            # before the outer handler sends apperror — so the live Thinking view never
+            # loses its last coalesced chunk. Runs before stream teardown; STREAM_REASONING_TEXT
+            # already mirrors the full text for persistence regardless.
+            try:
+                _flush_reasoning_buffer()
+            except Exception:
+                pass
             # Stop the live metering ticker
             _metering_stop.set()
             # Unregister the gateway approval callback and unblock any threads

--- a/tests/test_issue4729_reasoning_sse_coalesce.py
+++ b/tests/test_issue4729_reasoning_sse_coalesce.py
@@ -63,9 +63,44 @@ def test_reasoning_tail_flushed_on_phase_end():
     # When the reasoning phase ends (text is None), any remaining buffered text must be
     # flushed so the last partial (<100ms) window isn't lost.
     none_branch = body[body.index("if text is None:"): body.index("if text is None:") + 400]
-    assert "_reasoning_buffer[0]" in none_branch and "put('reasoning'" in none_branch, (
+    assert "_flush_reasoning_buffer()" in none_branch, (
         "on_reasoning(text=None) must flush any remaining coalesced buffer (the tail)"
     )
+
+
+def test_reasoning_buffer_flushed_at_every_boundary():
+    # #4729 (Codex re-gate): on_reasoning(None) is effectively dead — the agent never
+    # calls reasoning_callback(None) — so the buffered tail must be flushed at the REAL
+    # boundaries that close/reorder the live reasoning stream, or it's silently lost:
+    #   - a shared _flush_reasoning_buffer() helper
+    #   - on_token (visible output starting)
+    #   - on_tool (tool boundary)
+    #   - after agent.run_conversation() returns (terminal catch-all: a turn can end on
+    #     reasoning with no trailing token/tool)
+    assert "def _flush_reasoning_buffer():" in STREAMING, "must have a shared flush helper"
+    # helper emits the buffer chunk then clears it (since-last-flush delta semantics)
+    helper = STREAMING[STREAMING.index("def _flush_reasoning_buffer():"):]
+    helper = helper[: helper.index("\n\n")]
+    assert "put('reasoning', {'text': _reasoning_buffer[0]})" in helper and "_reasoning_buffer[0] = ''" in helper, (
+        "the flush helper must emit the buffered chunk then clear it"
+    )
+    # on_token flushes before emitting visible output
+    on_token = STREAMING[STREAMING.index("def on_token(text):"): STREAMING.index("def on_reasoning(text):")]
+    assert "_flush_reasoning_buffer()" in on_token, (
+        "on_token must flush the reasoning tail before visible output (the reasoning→answer transition)"
+    )
+    # on_tool flushes before the tool event
+    on_tool = STREAMING[STREAMING.index("def on_tool(*cb_args"): STREAMING.index("def on_tool(*cb_args") + 600]
+    assert "_flush_reasoning_buffer()" in on_tool, (
+        "on_tool must flush the reasoning tail before the tool event (reasoning→tool transition)"
+    )
+    # terminal catch-all: flush right after the agent run returns
+    assert "persist_user_message=msg_text,\n            )\n            # #4729" in STREAMING and \
+        STREAMING.count("_flush_reasoning_buffer()") >= 4, (
+        "must flush after agent.run_conversation() returns (a turn can end on reasoning "
+        "with no trailing token/tool boundary)"
+    )
+
 
 
 def test_frontend_appends_reasoning_deltas():

--- a/tests/test_issue4729_reasoning_sse_coalesce.py
+++ b/tests/test_issue4729_reasoning_sse_coalesce.py
@@ -1,0 +1,77 @@
+"""Regression test for #4729 — reasoning SSE coalescing throttle.
+
+The bug: during the reasoning/thinking phase of models like DeepSeek the server
+emitted one SSE `reasoning` event per token (tens of thousands per turn), each
+triggering a full-text scan in the frontend renderer and freezing the JS main thread.
+
+The fix throttles reasoning SSE events to ~10 Hz. The SUBTLE correctness requirement
+(the reason the first attempt was bounced): reasoning deltas are INCREMENTAL and the
+frontend APPENDS them (`reasoningText += text` in static/messages.js), so the throttle
+must COALESCE — accumulate dropped deltas into a buffer and flush the buffer, NOT drop
+deltas — otherwise live reasoning text is permanently lost. And the tail (the last
+sub-100ms window) must be flushed when the reasoning phase ends, or it's lost too.
+
+These are source-structure assertions on the on_reasoning closure in api/streaming.py
+(the closure isn't unit-testable in isolation), pinning the three properties so the
+coalescing contract can't silently regress to the drop-based version.
+"""
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).parent.parent
+STREAMING = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")
+MESSAGES = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+
+
+def _on_reasoning_body() -> str:
+    """Extract the body of the on_reasoning closure by brace/indent scanning."""
+    start = STREAMING.index("def on_reasoning(text):")
+    # grab a generous slice (the closure is short) bounded by the next top-level
+    # `def on_` callback in the same scope.
+    nxt = STREAMING.find("\n            def on_", start + 1)
+    return STREAMING[start: nxt if nxt != -1 else start + 2500]
+
+
+def test_reasoning_uses_coalescing_buffer_not_drop():
+    body = _on_reasoning_body()
+    # A coalescing buffer accumulates every delta...
+    assert "_reasoning_buffer[0] += reasoning_delta" in body, (
+        "on_reasoning must ACCUMULATE each delta into the coalescing buffer — dropping "
+        "deltas would permanently lose live reasoning text (the frontend appends them)"
+    )
+    # ...and the throttled flush emits the WHOLE buffer, then CLEARS it (so the next
+    # emit carries only the since-last-flush accumulation — coarse delta, not cumulative).
+    assert "put('reasoning', {'text': _reasoning_buffer[0]})" in body, (
+        "the throttled flush must emit the accumulated buffer, not a single delta"
+    )
+    # the clear must follow the flush so we don't re-send already-delivered text
+    flush_idx = body.index("put('reasoning', {'text': _reasoning_buffer[0]})")
+    clear_idx = body.index("_reasoning_buffer[0] = ''", flush_idx)
+    assert clear_idx > flush_idx, "the buffer must be cleared right after each flush"
+
+
+def test_reasoning_throttle_is_rate_limited():
+    body = _on_reasoning_body()
+    # ~10 Hz gate (0.1s) on the flush
+    assert "_reasoning_last_put" in body and "0.1" in body, (
+        "reasoning flush must be rate-limited to ~10 Hz (0.1s gate)"
+    )
+
+
+def test_reasoning_tail_flushed_on_phase_end():
+    body = _on_reasoning_body()
+    # When the reasoning phase ends (text is None), any remaining buffered text must be
+    # flushed so the last partial (<100ms) window isn't lost.
+    none_branch = body[body.index("if text is None:"): body.index("if text is None:") + 400]
+    assert "_reasoning_buffer[0]" in none_branch and "put('reasoning'" in none_branch, (
+        "on_reasoning(text=None) must flush any remaining coalesced buffer (the tail)"
+    )
+
+
+def test_frontend_appends_reasoning_deltas():
+    # The whole coalesce requirement hinges on the frontend APPENDING (not replacing).
+    # If this ever changes to assignment, the throttle design must change with it.
+    assert "reasoningText += text" in MESSAGES, (
+        "frontend reasoning handler must append deltas — if this changes, revisit the "
+        "server-side coalescing throttle (#4729)"
+    )

--- a/tests/test_issue4729_reasoning_sse_coalesce.py
+++ b/tests/test_issue4729_reasoning_sse_coalesce.py
@@ -94,11 +94,20 @@ def test_reasoning_buffer_flushed_at_every_boundary():
     assert "_flush_reasoning_buffer()" in on_tool, (
         "on_tool must flush the reasoning tail before the tool event (reasoning→tool transition)"
     )
-    # terminal catch-all: flush right after the agent run returns
-    assert "persist_user_message=msg_text,\n            )\n            # #4729" in STREAMING and \
-        STREAMING.count("_flush_reasoning_buffer()") >= 4, (
-        "must flush after agent.run_conversation() returns (a turn can end on reasoning "
-        "with no trailing token/tool boundary)"
+    # terminal catch-all: flush right after the agent run returns, AND a guaranteed-exit
+    # flush in the inner finally so exception / retry paths (which bypass the post-run
+    # flush) still emit the tail before the outer apperror.
+    assert "persist_user_message=msg_text,\n            )\n            # #4729" in STREAMING, (
+        "must flush after agent.run_conversation() returns (success path, before done)"
+    )
+    # the inner finally must also flush (covers exception/retry exits)
+    fin = STREAMING[STREAMING.index("        finally:\n            # #4729"):]
+    fin = fin[:700]
+    assert "_flush_reasoning_buffer()" in fin, (
+        "the inner finally must flush the reasoning tail on exception/retry exit paths"
+    )
+    assert STREAMING.count("_flush_reasoning_buffer()") >= 5, (
+        "expected flush at on_token, on_reasoning(None), on_tool, post-run, and the finally"
     )
 
 

--- a/tests/test_issue4729_reasoning_sse_coalesce.py
+++ b/tests/test_issue4729_reasoning_sse_coalesce.py
@@ -16,7 +16,6 @@ These are source-structure assertions on the on_reasoning closure in api/streami
 coalescing contract can't silently regress to the drop-based version.
 """
 import pathlib
-import re
 
 REPO = pathlib.Path(__file__).parent.parent
 STREAMING = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Release v0.51.596 — Release VC

Ships **#4729** (@wlknight) — throttle reasoning SSE events to ~10 Hz to stop the browser tab freeze.

### What's in it
During the reasoning/thinking phase of models like DeepSeek, the server emitted one SSE `reasoning` event per token (tens of thousands/turn), each triggering a full-text scan in the frontend renderer → JS main-thread lock (tab freeze). Now throttled to ~10 Hz via a **coalescing buffer**: deltas accumulate server-side and flush in batches, so every token still reaches the live Thinking view while capping SSE event rate.

### Review trail (this is a stream-path fix — gated hard; bounced once, converged)
- **First version BOUNCED** — it *dropped* deltas inside the 100ms window, but the frontend appends (`reasoningText += text`), so dropped tokens were permanently lost. Gave @wlknight the coalesce fix-spec.
- **Re-push implemented coalesce faithfully** (accumulate + flush-buffer + clear). Then two more Codex passes hardened the tail-flush:
  - tail-flush only ran on `on_reasoning(None)` which **the agent never calls** → added a shared `_flush_reasoning_buffer()` at `on_token` (visible-output start), `on_tool` (tool boundary), and after `run_conversation()` returns.
  - those are bypassed on **exception/retry** paths → added a guaranteed-exit flush in the inner `finally`, so the tail always reaches the live view before teardown/apperror.
- **Codex re-gate 3: SAFE TO SHIP** (the finally-flush structurally closes the tail-loss class — every exit flushes). **Full suite: 10161 passed** (lone failure = known cross-test isolation artifact, passes alone). +5 regression tests pinning the coalesce contract + every flush site.

`STREAM_REASONING_TEXT` still mirrors the full text for persistence throughout. Rebased onto fresh master. Authored by @wlknight (#4729); hardening co-authored.
