### PR TITLE
perf(#4662): backend hot-path caching — config reparse + sidebar redaction read-once (phase 2+3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Faster profile switching: the backend stops re-reading config and settings on the hot path.** Two behavior-preserving caching wins on the `/api/sessions` path that a profile switch hits cold (#4662, phase 2+3). (1) `reload_config()` no longer re-parses `config.yaml` from disk when the file is unchanged — it now routes through the same mtime-keyed parse cache used elsewhere, removing a ~hundreds-of-ms YAML reparse from each switch while preserving the exact process-env-expansion semantics that keep per-client profile isolation correct. (2) The sidebar session-list response now reads the redaction setting once per response instead of once per conversation row, eliminating a per-row `settings.json` read that grew into a multi-second serialization stage on large session lists. No user-visible behavior change — redaction still applies exactly as before; switching is just quicker. Part of the phased profile-switch performance work. (#4662)
+
 ## [v0.51.599] — 2026-06-23 — Release VF (dedupe live progress reasoning echoes)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -559,7 +559,7 @@ _yaml_file_cache: dict[str, tuple] = {}
 _yaml_file_cache_lock = threading.Lock()
 
 
-def _load_yaml_config_file_raw(config_path: Path) -> dict:
+def _load_yaml_config_file_raw(config_path: Path, *, _copy: bool = True) -> dict:
     """Return the RAW (un-env-expanded) parsed config dict, memoized on
     (resolved path, st_mtime_ns, st_size). Shared parse core for
     _load_yaml_config_file() and reload_config(): the former runs the helper's
@@ -569,6 +569,11 @@ def _load_yaml_config_file_raw(config_path: Path) -> dict:
     (mtime, size) — a UI sync storm can't turn into a YAML-reparse storm (#4650),
     and an unchanged config.yaml isn't reparsed on the profile-switch hot path
     (#4662 Phase 2).
+
+    By default returns a deep copy so a caller can never mutate the shared cache
+    entry (greptile #4741). Internal callers that immediately pass the result
+    through _expand_env_vars() (which itself returns a fresh structure and never
+    mutates its input) pass _copy=False to skip the redundant copy on the hot path.
     """
     try:
         import yaml as _yaml
@@ -587,7 +592,9 @@ def _load_yaml_config_file_raw(config_path: Path) -> dict:
         cached = _yaml_file_cache.get(cache_key)
         if cached is not None and cached[0] == stat_key:
             raw = cached[1]
-            return raw if isinstance(raw, dict) else {}
+            if not isinstance(raw, dict):
+                return {}
+            return copy.deepcopy(raw) if _copy else raw
 
     # Cache miss / stale: parse off disk. Done outside the lock so a slow parse
     # doesn't serialize unrelated paths; a concurrent duplicate parse is harmless.
@@ -600,11 +607,14 @@ def _load_yaml_config_file_raw(config_path: Path) -> dict:
     raw = loaded if isinstance(loaded, dict) else {}
     with _yaml_file_cache_lock:
         _yaml_file_cache[cache_key] = (stat_key, raw)
-    return raw
+    return copy.deepcopy(raw) if _copy else raw
 
 
 def _load_yaml_config_file(config_path: Path) -> dict:
-    raw = _load_yaml_config_file_raw(config_path)
+    # _copy=False: _expand_env_vars returns a fresh structure and never mutates
+    # its input, so the env-expanded result is already cache-safe — no need to
+    # deep-copy the raw dict first (keeps the /api/reasoning hot path cheap).
+    raw = _load_yaml_config_file_raw(config_path, _copy=False)
     if not raw:
         return {}
     expanded = _expand_env_vars(raw)

--- a/api/config.py
+++ b/api/config.py
@@ -485,11 +485,16 @@ def reload_config() -> None:
         _cfg_path = config_path
         _cfg_mtime = 0.0
         try:
-            import yaml as _yaml
-
             if config_path.exists():
-                loaded = _yaml.safe_load(config_path.read_text(encoding="utf-8"))
-                if isinstance(loaded, dict):
+                # Route the parse through the mtime-keyed cache (#4652) so an
+                # unchanged config.yaml isn't re-parsed (~125ms+ on a large file)
+                # on every reload_config() on the hot path (profile switch /
+                # load_settings, #4662 Phase 2). We take the RAW cached dict and
+                # run the env expansion HERE, pinned to the unscoped process-env
+                # view (below) — never the helper's per-call expansion — for the
+                # #798 TLS reason documented in the pin block.
+                loaded = _load_yaml_config_file_raw(config_path)
+                if isinstance(loaded, dict) and loaded:
                     # The process-global _cfg_cache must reflect PROCESS-env
                     # expansion, never a profile-scoped block_process_env_fallback
                     # view — otherwise a reload that fires while a readonly/worker
@@ -544,7 +549,17 @@ _yaml_file_cache: dict[str, tuple] = {}
 _yaml_file_cache_lock = threading.Lock()
 
 
-def _load_yaml_config_file(config_path: Path) -> dict:
+def _load_yaml_config_file_raw(config_path: Path) -> dict:
+    """Return the RAW (un-env-expanded) parsed config dict, memoized on
+    (resolved path, st_mtime_ns, st_size). Shared parse core for
+    _load_yaml_config_file() and reload_config(): the former runs the helper's
+    own per-call env expansion on the result; the latter must run expansion
+    under its own process-env-pinned thread context (#798), so it takes the raw
+    dict and expands it itself. Either way the file is parsed at most once per
+    (mtime, size) — a UI sync storm can't turn into a YAML-reparse storm (#4650),
+    and an unchanged config.yaml isn't reparsed on the profile-switch hot path
+    (#4662 Phase 2).
+    """
     try:
         import yaml as _yaml
     except ImportError:
@@ -561,8 +576,8 @@ def _load_yaml_config_file(config_path: Path) -> dict:
     with _yaml_file_cache_lock:
         cached = _yaml_file_cache.get(cache_key)
         if cached is not None and cached[0] == stat_key:
-            expanded = _expand_env_vars(cached[1])
-            return expanded if isinstance(expanded, dict) else {}
+            raw = cached[1]
+            return raw if isinstance(raw, dict) else {}
 
     # Cache miss / stale: parse off disk. Done outside the lock so a slow parse
     # doesn't serialize unrelated paths; a concurrent duplicate parse is harmless.
@@ -575,6 +590,11 @@ def _load_yaml_config_file(config_path: Path) -> dict:
     raw = loaded if isinstance(loaded, dict) else {}
     with _yaml_file_cache_lock:
         _yaml_file_cache[cache_key] = (stat_key, raw)
+    return raw
+
+
+def _load_yaml_config_file(config_path: Path) -> dict:
+    raw = _load_yaml_config_file_raw(config_path)
     if not raw:
         return {}
     expanded = _expand_env_vars(raw)

--- a/api/config.py
+++ b/api/config.py
@@ -494,30 +494,40 @@ def reload_config() -> None:
                 # view (below) — never the helper's per-call expansion — for the
                 # #798 TLS reason documented in the pin block.
                 loaded = _load_yaml_config_file_raw(config_path)
-                if isinstance(loaded, dict) and loaded:
-                    # The process-global _cfg_cache must reflect PROCESS-env
-                    # expansion, never a profile-scoped block_process_env_fallback
-                    # view — otherwise a reload that fires while a readonly/worker
-                    # scope is active (profile alternation resolves _get_config_path
-                    # to the named profile, #798 TLS) would bake under-expanded
-                    # literal ${VAR}s into the shared cache and starve concurrent
-                    # readers of the module-level `cfg` alias. Expansion re-runs
-                    # per-read elsewhere; here we pin the cache to the unscoped view.
-                    _prev_block = getattr(_thread_ctx, "block_process_env_fallback", False)
-                    _prev_env = getattr(_thread_ctx, "env", None)
-                    try:
-                        _thread_ctx.block_process_env_fallback = False
-                        _thread_ctx.env = {}
-                        _cfg_cache.update(_expand_env_vars(loaded))
-                    finally:
-                        _thread_ctx.block_process_env_fallback = _prev_block
-                        if _prev_env is None:
-                            try:
-                                del _thread_ctx.env
-                            except AttributeError:
-                                pass
-                        else:
-                            _thread_ctx.env = _prev_env
+                if isinstance(loaded, dict):
+                    if loaded:
+                        # The process-global _cfg_cache must reflect PROCESS-env
+                        # expansion, never a profile-scoped block_process_env_fallback
+                        # view — otherwise a reload that fires while a readonly/worker
+                        # scope is active (profile alternation resolves _get_config_path
+                        # to the named profile, #798 TLS) would bake under-expanded
+                        # literal ${VAR}s into the shared cache and starve concurrent
+                        # readers of the module-level `cfg` alias. Expansion re-runs
+                        # per-read elsewhere; here we pin the cache to the unscoped view.
+                        _prev_block = getattr(_thread_ctx, "block_process_env_fallback", False)
+                        _prev_env = getattr(_thread_ctx, "env", None)
+                        try:
+                            _thread_ctx.block_process_env_fallback = False
+                            _thread_ctx.env = {}
+                            _cfg_cache.update(_expand_env_vars(loaded))
+                        finally:
+                            _thread_ctx.block_process_env_fallback = _prev_block
+                            if _prev_env is None:
+                                try:
+                                    del _thread_ctx.env
+                                except AttributeError:
+                                    pass
+                            else:
+                                _thread_ctx.env = _prev_env
+                    # Stamp _cfg_mtime whenever the file parsed to a dict — INCLUDING
+                    # an empty {} config. The cache-update above is skipped for {} (it's
+                    # a no-op), but _cfg_mtime MUST still be set or get_config()'s
+                    # `current_mtime != _cfg_mtime` stale check fires on every call and
+                    # spins reload_config() under _cfg_lock forever (a `{}` config from a
+                    # freshly created/reset profile is reachable on the switch hot path).
+                    # This matches master's pre-#4662 behavior (it entered the block for
+                    # {} and set the mtime); the inner `if loaded:` only gates the no-op
+                    # cache update, not the mtime stamp.
                     try:
                         _cfg_mtime = Path(config_path).stat().st_mtime
                     except OSError:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2131,8 +2131,9 @@ def _session_list_payload_to_response(payload: dict) -> dict:
     # plumbing already exists; this wires the caller so the sidebar list path gets the
     # same read-once optimization redact_session_data() already uses. On a large list
     # this was the multi-second response_write stage in /api/sessions diagnostics. (#4662 Phase 3)
+    # load_settings is imported at module scope (below); this function only runs at
+    # request time, well after module load, so no lazy import is needed.
     try:
-        from api.config import load_settings
         _redact_enabled = bool(load_settings().get("api_redact_enabled", True))
     except Exception:
         _redact_enabled = True  # fail safe: redact when settings are unreadable

--- a/api/routes.py
+++ b/api/routes.py
@@ -2125,8 +2125,19 @@ def _build_session_list_cache_payload(
 def _session_list_payload_to_response(payload: dict) -> dict:
     safe_merged = []
     runtime_rows = _session_list_cache_overlay_runtime_rows(payload.get("sessions", []) or [])
+    # Read the redaction setting ONCE for the whole response and thread it through
+    # every row, instead of letting each row's _redact_text() re-read settings.json
+    # from disk (per title). The _sidebar_session_response_item -> _redact_text(_enabled=...)
+    # plumbing already exists; this wires the caller so the sidebar list path gets the
+    # same read-once optimization redact_session_data() already uses. On a large list
+    # this was the multi-second response_write stage in /api/sessions diagnostics. (#4662 Phase 3)
+    try:
+        from api.config import load_settings
+        _redact_enabled = bool(load_settings().get("api_redact_enabled", True))
+    except Exception:
+        _redact_enabled = True  # fail safe: redact when settings are unreadable
     for s in runtime_rows:
-        item = _sidebar_session_response_item(s) if isinstance(s, dict) else {}
+        item = _sidebar_session_response_item(s, redact_enabled=_redact_enabled) if isinstance(s, dict) else {}
         safe_merged.append(item)
     return {
         "sessions": safe_merged,

--- a/tests/test_issue4662_reload_config_mtime_cache.py
+++ b/tests/test_issue4662_reload_config_mtime_cache.py
@@ -1,0 +1,78 @@
+"""Phase 2 (#4662): reload_config() must not re-run yaml.safe_load on the hot path
+when config.yaml is unchanged. It now routes its parse through the mtime-keyed
+_load_yaml_config_file cache (#4652). Behavior-preserving: the process-global
+_cfg_cache is still pinned to the unscoped process-env expansion (#798 TLS), env
+expansion still runs per call, and an mtime change still busts the cache.
+"""
+import os
+import time
+
+import yaml as _yaml
+
+
+def test_reload_config_uses_mtime_cache(tmp_path, monkeypatch):
+    import api.config as cfg
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("providers:\n  openai:\n    models: [gpt-5.5]\n", encoding="utf-8")
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+
+    parse_calls = {"n": 0}
+    real_safe_load = _yaml.safe_load
+
+    def _counting_safe_load(s):
+        parse_calls["n"] += 1
+        return real_safe_load(s)
+
+    monkeypatch.setattr(_yaml, "safe_load", _counting_safe_load)
+    # Clear the shared file cache so the first reload is a genuine miss.
+    with cfg._yaml_file_cache_lock:
+        cfg._yaml_file_cache.clear()
+
+    cfg.reload_config()
+    first = parse_calls["n"]
+    cfg.reload_config()          # same file, unchanged mtime -> must hit cache
+    second = parse_calls["n"]
+
+    assert first >= 1, "first reload should parse the file at least once"
+    assert second == first, f"unchanged config.yaml was reparsed (parse went {first}->{second})"
+
+
+def test_reload_config_busts_on_mtime_change(tmp_path, monkeypatch):
+    import api.config as cfg
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("providers: {}\n", encoding="utf-8")
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+    with cfg._yaml_file_cache_lock:
+        cfg._yaml_file_cache.clear()
+
+    cfg.reload_config()
+    assert (cfg.get_config().get("providers") or {}) == {}
+
+    # Edit + bump mtime; the next reload must pick up the change, not the cache.
+    time.sleep(0.01)
+    config_path.write_text("providers:\n  openai: {}\n", encoding="utf-8")
+    os.utime(config_path, None)
+    cfg.reload_config()
+    assert "openai" in (cfg.get_config().get("providers") or {}), "mtime change not picked up"
+
+
+def test_reload_config_expands_env_vars(tmp_path, monkeypatch):
+    """The pinned process-env expansion must still run: a ${VAR} in config.yaml
+    resolves against os.environ after reload_config (the #798 invariant)."""
+    import api.config as cfg
+
+    monkeypatch.setenv("HERMES_TEST_RELOAD_TOKEN", "expanded-value-xyz")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "providers:\n  openai:\n    api_key: ${HERMES_TEST_RELOAD_TOKEN}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+    with cfg._yaml_file_cache_lock:
+        cfg._yaml_file_cache.clear()
+
+    cfg.reload_config()
+    key = ((cfg.get_config().get("providers") or {}).get("openai") or {}).get("api_key")
+    assert key == "expanded-value-xyz", f"env var not expanded after reload: {key!r}"

--- a/tests/test_issue4662_reload_config_mtime_cache.py
+++ b/tests/test_issue4662_reload_config_mtime_cache.py
@@ -76,3 +76,43 @@ def test_reload_config_expands_env_vars(tmp_path, monkeypatch):
     cfg.reload_config()
     key = ((cfg.get_config().get("providers") or {}).get("openai") or {}).get("api_key")
     assert key == "expanded-value-xyz", f"env var not expanded after reload: {key!r}"
+
+
+def test_reload_config_empty_dict_config_does_not_spin(tmp_path, monkeypatch):
+    """An empty ``{}`` config must still stamp _cfg_mtime, or get_config()'s
+    `current_mtime != _cfg_mtime` stale check fires forever and re-enters
+    reload_config() under _cfg_lock on every call. The cache-update is correctly
+    skipped for {} (no-op), but the mtime stamp must not be. (Opus gate finding —
+    a {} config is reachable on the profile-switch hot path via a freshly
+    created/reset profile, and this also fixes the pre-existing empty/None-config
+    spin on master.)
+    """
+    import api.config as cfg
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("{}\n", encoding="utf-8")
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+    with cfg._yaml_file_cache_lock:
+        cfg._yaml_file_cache.clear()
+
+    cfg.reload_config()
+    # _cfg_mtime must equal the file's real mtime, not 0.0.
+    assert cfg._cfg_mtime == config_path.stat().st_mtime, (
+        f"_cfg_mtime not stamped for empty-dict config (got {cfg._cfg_mtime!r}); "
+        "get_config() would spin reload_config() forever"
+    )
+
+    # And get_config() must NOT re-enter reload_config() on subsequent calls.
+    reloads = {"n": 0}
+    real_reload = cfg.reload_config
+
+    def _counting_reload():
+        reloads["n"] += 1
+        return real_reload()
+
+    monkeypatch.setattr(cfg, "reload_config", _counting_reload)
+    cfg.get_config()
+    cfg.get_config()
+    cfg.get_config()
+    assert reloads["n"] == 0, f"get_config() re-entered reload_config() {reloads['n']}x on a stable {{}} config (spin)"
+

--- a/tests/test_issue4662_sidebar_redaction_read_once.py
+++ b/tests/test_issue4662_sidebar_redaction_read_once.py
@@ -1,0 +1,67 @@
+"""Phase 3 (#4662): sidebar session-list serialization must read the redaction
+setting ONCE per response, not once per row. Regression guard for the per-row
+settings.json reload that dominated /api/sessions response_write on large lists.
+"""
+import api.routes as routes
+
+
+def test_sidebar_payload_reads_redaction_setting_once(monkeypatch):
+    calls = {"n": 0}
+
+    def _counting_load_settings():
+        calls["n"] += 1
+        return {"api_redact_enabled": True}
+
+    # _redact_text() falls back to load_settings() only when _enabled is None,
+    # so a per-row read shows up as a load_settings() call per row. After the
+    # fix the caller reads it once and threads redact_enabled to every row.
+    monkeypatch.setattr("api.config.load_settings", _counting_load_settings)
+    monkeypatch.setattr("api.helpers.load_settings", _counting_load_settings, raising=False)
+
+    payload = {
+        "sessions": [
+            {"session_id": f"s{i}", "title": f"title {i}", "preview": f"preview {i}"}
+            for i in range(12)
+        ],
+        "cli_count": 0,
+    }
+    # Pass rows straight through — avoid runtime-overlay noise from the cache layer.
+    monkeypatch.setattr(routes, "_session_list_cache_overlay_runtime_rows", lambda rows: rows)
+
+    routes._session_list_payload_to_response(payload)
+
+    # Before the fix: ~1 read per row (>=12). After: exactly 1 for the whole response.
+    assert calls["n"] <= 1, f"settings read {calls['n']}x; expected <=1 (read-once per response)"
+
+
+def test_sidebar_payload_still_redacts_titles(monkeypatch):
+    """The read-once optimization must not disable redaction: a title that looks
+    like a credential is still redacted when api_redact_enabled is True."""
+    monkeypatch.setattr("api.config.load_settings", lambda: {"api_redact_enabled": True})
+    monkeypatch.setattr("api.helpers.load_settings", lambda: {"api_redact_enabled": True}, raising=False)
+    monkeypatch.setattr(routes, "_session_list_cache_overlay_runtime_rows", lambda rows: rows)
+
+    secret = "sk-ant-api03-" + ("A" * 40)
+    payload = {"sessions": [{"session_id": "s1", "title": f"key {secret}"}], "cli_count": 0}
+    resp = routes._session_list_payload_to_response(payload)
+    title = resp["sessions"][0]["title"]
+    assert secret not in title, f"credential leaked into sidebar title: {title!r}"
+
+
+def test_sidebar_payload_no_redaction_when_disabled(monkeypatch):
+    """When api_redact_enabled is False, titles pass through unchanged (and we
+    still only read the setting once)."""
+    calls = {"n": 0}
+
+    def _load():
+        calls["n"] += 1
+        return {"api_redact_enabled": False}
+
+    monkeypatch.setattr("api.config.load_settings", _load)
+    monkeypatch.setattr("api.helpers.load_settings", _load, raising=False)
+    monkeypatch.setattr(routes, "_session_list_cache_overlay_runtime_rows", lambda rows: rows)
+
+    payload = {"sessions": [{"session_id": "s1", "title": "plain title"}], "cli_count": 0}
+    resp = routes._session_list_payload_to_response(payload)
+    assert resp["sessions"][0]["title"] == "plain title"
+    assert calls["n"] <= 1, f"settings read {calls['n']}x with redaction disabled; expected <=1"


### PR DESCRIPTION
## What this is

**Phase 2+3 of #4662** (profile-switch performance), built on the now-merged Phase 1 skeletons (#4671, shipped v0.51.594). Two **behavior-preserving backend caching wins** on the `/api/sessions` path that a profile switch hits cold. No data-shape changes, no new dependencies, no threading.

This is the "make it actually faster" follow-on to the "make it feel instant" skeleton work. It's deliberately scoped small and standalone-reviewable; the watcher-restart latency work (#4718) and pre-warm are separate later PRs.

## Changes

### B — `reload_config()` stops re-parsing `config.yaml` on the hot path (`api/config.py`)
`reload_config()` did a raw `yaml.safe_load(config_path.read_text())` on **every** call, including on the profile-switch hot path (the ~446ms `load_settings` stage in the investigation's `/api/sessions` diagnostics). It now routes the **parse** through the same mtime+size-keyed cache added in #4652, via a shared `_load_yaml_config_file_raw()` core (`_load_yaml_config_file` = raw + env-expand — DRY, no duplicated stat/parse logic).

**The #798 profile-isolation invariant is preserved byte-for-byte:** `reload_config` still runs its *own* env expansion under the process-env-pinned thread context (`block_process_env_fallback=False` + `_thread_ctx.env={}`). Only the disk *parse* is cached; the cache stores the **raw, un-expanded** dict, so no expanded/under-expanded/profile-scoped value can ever be what's cached. The cache key is the resolved path, so profiles A and B never collide.

Micro-benchmark (14KB / 483-line config): `reload_config()` on an unchanged file drops from **~61ms → ~1.3ms** per call (~60ms parse removed per reload; larger 24KB configs save the full ~125ms+).

### C — sidebar list reads the redaction setting once per response, not per row (`api/routes.py`)
`_session_list_payload_to_response` called `_sidebar_session_response_item(s)` per row **without** `redact_enabled`, so each row's `_redact_text` re-read `settings.json` from disk (the multi-second `response_write` stage on large lists). It now reads `api_redact_enabled` **once** and threads it to every row via the **already-existing** `redact_enabled` param (the same read-once optimization `redact_session_data()` already uses). Fail-safe: redact-on-error.

Benchmark (500-row list): settings reads collapse **500 → 1** (each was a real disk read).

## Tests
- `tests/test_issue4662_reload_config_mtime_cache.py` — unchanged file not reparsed; mtime change still busts the cache; `${VAR}` expansion still works; **empty `{}` config doesn't spin `reload_config()`** (the Opus-gate regression below).
- `tests/test_issue4662_sidebar_redaction_read_once.py` — settings read ≤1× per response; redaction still applies when enabled; passes through when disabled.
- **Full suite: 10162 passed.** The one full-suite failure (`test_issue3957…readonly_scope_blocks_pool_env_seed`) is a **pre-existing ordering flake** that fails *identically on clean master* (10156 passed, same 1 fail) and passes in isolation — filed separately as #4740, not caused by this diff.

## Gate
- **Codex: SAFE TO SHIP** — confirmed the #798 expansion-pinning and `_save_yaml_config_file` cache-eviction hold; ruff + py_compile clean on the diff.
- **Opus: SAFE TO SHIP** — caught one real defect in review (an `and loaded` guard that skipped the `_cfg_mtime` stamp for a `{}` config → would spin `reload_config()` under lock; reproduced 3 reloads vs master's 0). **Fixed** (split the guard so the no-op cache update is skipped for `{}` but the mtime is always stamped, matching master) + regression test added; Opus re-gated SAFE. This fix incidentally repairs a pre-existing empty/None-config spin on master.

## Reviewers — requesting human review + browser regression testing 🙏

This is a meaty backend perf change on the crown-jewel `/api/sessions` path, so per our process it needs independent human review before merge (do **not** auto-merge — tagged `review-requested`).

@rodboev @franksong2702 @dso2ng @santastabber — could one or two of you give this a code review **and** a hands-on browser pass? You all work these surfaces (rodboev especially — this directly continues your profile-switch perf investigation and #4718). Rough things to exercise in the browser:

- **Profile switching** across profiles with many / few / zero conversations — sidebar list + workspace tree still load correctly and faster; no stale wrong-profile content.
- **Rapid back-to-back profile switches** — no errors, correct final profile.
- **Sidebar conversation titles still render correctly**, and **redaction still works** — if you have `api_redact_enabled` on, confirm credential-looking titles are still masked in the sidebar (Change C must not have disabled redaction).
- **Edit `config.yaml` while the server runs**, then trigger a reload (profile switch / settings change) — the edit is picked up (the mtime cache must bust on a real change, not serve a stale parse).
- **A freshly created / empty profile** — switch into it; no hang or runaway CPU (guards the `{}`-config spin fix).
- General smoke: settings panel, model picker, a normal chat turn — nothing in the config/redaction path regressed.

A quick "code: ✅/notes" + "browser pass: ✅/❌ + what I saw" is perfect. Thanks!

Closes part of #4662 (phases 2+3). Cross-ref: #4671 (phase 1), #4718 (phase 2 latency, separate).
