### PR TITLE
fix(chat): preserve scroll across live Compact Worklog rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- **Live Compact Worklog refreshes no longer jump the transcript while you are reading in-progress output.** The live anchor scene rebuild now captures and restores the outer message viewport around Worklog DOM replacement before applying the normal pinned-at-bottom follow behavior, so manually-unpinned readers keep their place while active Worklog rows refresh or settle. (#4742)
-
 ## [v0.51.596] — 2026-06-23 — Release VC (throttle reasoning SSE to stop tab freeze)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Live Compact Worklog refreshes no longer jump the transcript while you are reading in-progress output.** The live anchor scene rebuild now captures and restores the outer message viewport around Worklog DOM replacement before applying the normal pinned-at-bottom follow behavior, so manually-unpinned readers keep their place while active Worklog rows refresh or settle. (#4742)
+
 ## [v0.51.596] — 2026-06-23 — Release VC (throttle reasoning SSE to stop tab freeze)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -9593,6 +9593,7 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   const liveDisclosureState=typeof _captureWorklogDetailDisclosureState==='function'
     ? _captureWorklogDetailDisclosureState(blocks)
     : null;
+  const scrollSnapshot=_captureMessageScrollSnapshot();
   blocks.querySelectorAll('[data-anchor-scene-owner="1"],[data-anchor-scene-row="1"]').forEach(el=>el.remove());
   blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-card-row[data-live-tid]:not(.transparent-event-row),.agent-activity-thinking[data-live-thinking="1"],.interim-collapse-toggle').forEach(el=>el.remove());
   blocks.querySelectorAll('[data-live-assistant="1"]').forEach(el=>{
@@ -9616,6 +9617,7 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   if(typeof _startActivityElapsedTimer==='function') _startActivityElapsedTimer(group);
   _dedupeLiveProcessedWorklogAnchors(turn);
   if(typeof _moveLiveRunStatusToTurnEnd==='function') _moveLiveRunStatusToTurnEnd();
+  _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
   if(typeof scrollIfPinned==='function') scrollIfPinned();
   return true;
 }

--- a/tests/test_issue3479_ios_stream_scroll_jump.py
+++ b/tests/test_issue3479_ios_stream_scroll_jump.py
@@ -64,6 +64,20 @@ def test_live_compression_card_replacement_restores_snapshot_before_follow_settl
     assert capture_idx < replace_idx < restore_idx < settle_idx
 
 
+def test_live_anchor_worklog_rebuild_restores_snapshot_before_follow_settle():
+    body = _function_body(UI_JS, "renderLiveAnchorActivityScene")
+
+    capture_idx = body.index("const scrollSnapshot=_captureMessageScrollSnapshot();")
+    remove_idx = body.index("blocks.querySelectorAll('[data-anchor-scene-owner=\"1\"],[data-anchor-scene-row=\"1\"]')")
+    restore_detail_idx = body.index("_restoreWorklogDetailDisclosureState(blocks, liveDisclosureState);")
+    dedupe_idx = body.index("_dedupeLiveProcessedWorklogAnchors(turn);")
+    move_status_idx = body.index("_moveLiveRunStatusToTurnEnd();")
+    restore_idx = body.index("_restoreMessageScrollSnapshotSameFrame(scrollSnapshot);")
+    settle_idx = body.index("if(typeof scrollIfPinned==='function') scrollIfPinned();")
+
+    assert capture_idx < remove_idx < restore_detail_idx < dedupe_idx < move_status_idx < restore_idx < settle_idx
+
+
 def test_same_frame_snapshot_preserves_bottom_distance_and_unpinned_state():
     capture = _function_body(UI_JS, "_captureMessageScrollSnapshot")
     restore = _function_body(UI_JS, "_restoreMessageScrollSnapshotSameFrame")


### PR DESCRIPTION
## Thinking Path

- Compact Worklog is supposed to keep live work readable while a turn streams, then collapse into settled history without moving the reader unexpectedly.
- #4295 / #4584 fixed the scroll state machine re-pinning users to the bottom, but live anchor scene rendering still replaces the Worklog node a reader may be anchored to.
- `renderLiveAnchorActivityScene()` already preserved Worklog detail disclosure state, but not the outer `#messages` viewport around the live scene rebuild.
- The existing same-frame message scroll snapshot helpers are the right layer: they preserve reader position for DOM replacement while still allowing pinned-at-bottom readers to follow.

## Contract Routing

Task type: streaming UI regression fix.

Touched areas:
- `static/ui.js` live anchor Compact Worklog rendering
- scroll snapshot regression tests

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/UIUX-GUIDE.md`
- `docs/rfcs/live-to-final-assistant-replies.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`

State layer changed: live UI scene/cache and outer transcript viewport restoration. This does not change persisted transcript, model context, SSE schema, settled anchor data, or release changelog state.

## What Changed

- Captures the outer message scroll snapshot before live anchor Worklog rows are removed and rebuilt.
- Restores that snapshot after the live Worklog DOM has been rebuilt, deduped, and moved to the turn end, but before `scrollIfPinned()` applies normal follow behavior.
- Adds a regression test that locks the capture/rebuild/restore/follow ordering.

## Why It Matters

This prevents a user who is manually reading in-progress Compact Worklog output from being jumped to an unexpected transcript position when live rows refresh or the turn settles. Readers at the bottom still follow the live stream normally.

Fixes #4742.

## Verification

- `node --check static/ui.js`
- `./scripts/test.sh tests/test_issue3479_ios_stream_scroll_jump.py tests/test_live_to_final_anchor_visible_order.py tests/test_issue4295_scroll_pin_reentry.py tests/test_issue4295_midstream_scroll_anchor.py` — 70 passed
- `.venv/bin/python scripts/ruff_lint.py --diff origin/master`

No screenshots attached: this is a scroll-position preservation fix with no visual layout change. The regression is locked by the call-order test around the live Worklog DOM replacement path.

## Risks / Follow-ups

- This PR only fixes the viewport jump caused by live anchor Worklog rebuilds. It does not add a new setting or make the live `Processed ...` summary collapsible; that remains a separate UX improvement if desired.
- Browser-level manual verification with a long live stream is still useful, but the code path now follows the same snapshot/restore pattern already used by live compression card replacement.
- Per review feedback, this PR intentionally leaves `CHANGELOG.md` untouched so the release process can own release-note entries.

## Model Used

AI-assisted by OpenAI Codex (GPT-5) in the Codex desktop app, with local repository inspection, GitHub CLI, and focused regression testing.