### PR TITLE
fix: bound large session loading

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -5837,6 +5837,8 @@ def _message_window_for_display(messages, msg_limit=None, msg_before=None, expan
     return window, start_idx
 
 
+_DEFAULT_SESSION_MSG_LIMIT = 100
+_MAX_SESSION_MSG_LIMIT = 300
 _LIMITED_TOOL_CONTENT_MAX_CHARS = 4096
 _LIMITED_TOOL_CONTENT_NOTICE = (
     "\n\n[Tool output truncated in paginated session response; "
@@ -5883,27 +5885,58 @@ def _messages_for_limited_payload(messages) -> list:
 def _limited_webui_messages_for_display(session, state_db_messages) -> list:
     """Return the display sidecar plus only necessary state.db rows for msg_limit.
 
-    Paginated session loads are latency-sensitive and should not stitch every
-    lineage segment before slicing the tail. Keep the lightweight
-    pre-compression snapshot stitch so continuation sessions can still reveal
-    archived history, then merge only newer state.db rows that have not reached
-    the sidecar yet.
+    Paginated session loads are latency-sensitive.  The full append-only merge
+    has intentionally broad fuzzy duplicate handling for recovery/import cases,
+    but that fuzzy pass is too expensive for ordinary large WebUI sidecars: a
+    6k-message transcript with only old state.db mirror rows can spend tens of
+    seconds comparing historical visible text before the response is sliced to a
+    100-message window.  For the limited display path, keep the sidecar as the
+    coordinate space and only merge state.db rows that are strictly newer than
+    the sidecar tail; older reconciliation remains available through the
+    deliberate full/heavy path.
     """
-    sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)
+    sidecar_messages = list(getattr(session, "messages", []) or [])
+    if not sidecar_messages:
+        sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)
     state_db_messages = list(state_db_messages or [])
     if not state_db_messages:
         return sidecar_messages
-    # NOTE: do not short-circuit to the sidecar when state.db has no strictly
-    # newer rows. A state.db row whose timestamp is at-or-before the sidecar's
-    # newest (recovery / edited-in-place / missing-timestamp cases) is still
-    # absent from the sidecar and must be reconciled — dropping it would render
-    # a tail that differs from the full merge path (silent wrong-transcript on
-    # the paginated load). The append-only merge is O(n) over already-bounded
-    # in-memory lists; the real latency win here is skipping the lineage-parent
-    # DISK load above, which we still skip. (#4070 ship-review)
+    if not sidecar_messages:
+        return merge_session_messages_append_only(
+            sidecar_messages,
+            state_db_messages,
+            truncation_watermark=getattr(session, "truncation_watermark", None),
+        )
+
+    max_sidecar_timestamp = None
+    for msg in sidecar_messages:
+        timestamp = _message_timestamp_as_float(msg)
+        if timestamp is not None:
+            max_sidecar_timestamp = (
+                timestamp
+                if max_sidecar_timestamp is None
+                else max(max_sidecar_timestamp, timestamp)
+            )
+    if max_sidecar_timestamp is None:
+        # Without timestamps we cannot safely identify a tiny state.db delta, so
+        # fall back to the precise merge. This shape is uncommon for modern
+        # WebUI sessions and preserves old recovery semantics.
+        return merge_session_messages_append_only(
+            sidecar_messages,
+            state_db_messages,
+            truncation_watermark=getattr(session, "truncation_watermark", None),
+        )
+
+    newer_state_rows = []
+    for msg in state_db_messages:
+        timestamp = _message_timestamp_as_float(msg)
+        if timestamp is not None and timestamp > max_sidecar_timestamp:
+            newer_state_rows.append(msg)
+    if not newer_state_rows:
+        return sidecar_messages
     return merge_session_messages_append_only(
         sidecar_messages,
-        state_db_messages,
+        newer_state_rows,
         truncation_watermark=getattr(session, "truncation_watermark", None),
     )
 
@@ -6483,6 +6516,7 @@ from api.models import (
     _active_stream_ids,
     _session_message_merge_key,
     _session_message_visible_key,
+    _message_timestamp_as_float,
     _is_empty_partial_activity_message,
     _hide_from_default_sidebar,
     prune_session_from_index,
@@ -9258,12 +9292,27 @@ def handle_get(handler, parsed) -> bool:
         # ?msg_limit=N returns a tail window containing the last N visible
         # transcript rows. Hidden tool-result rows do not consume the budget;
         # they are included only when they sit inside the selected window and
-        # are bounded before serialization. Older rows load on-demand.
+        # are bounded before serialization. Older rows load on-demand. Ordinary
+        # UI paths default to a bounded recent window; full transcript loading is
+        # deliberately opt-in through include_heavy=1.
+        include_heavy = str(query.get("include_heavy", [""])[0]).strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
         _msg_limit = query.get("msg_limit", [None])[0]
         try:
-            msg_limit = max(1, int(_msg_limit)) if _msg_limit else None
+            parsed_msg_limit = max(1, int(_msg_limit)) if _msg_limit else None
         except (ValueError, TypeError):
-            msg_limit = None
+            parsed_msg_limit = None
+        if load_messages and not include_heavy:
+            if parsed_msg_limit is None:
+                msg_limit = _DEFAULT_SESSION_MSG_LIMIT
+            else:
+                msg_limit = min(parsed_msg_limit, _MAX_SESSION_MSG_LIMIT)
+        else:
+            msg_limit = parsed_msg_limit
         # ?msg_before=N — 0-based index into the full message array.
         # Returns messages before this index (for scroll-to-top lazy loading).
         # Combined with msg_limit for paging.

--- a/static/commands.js
+++ b/static/commands.js
@@ -824,7 +824,7 @@ async function _runManualCompression(focusTopic){
     // Preflight: verify the viewed session still exists before compressing.
     // This avoids a confusing "not found" toast when the UI is stale.
     try{
-      const live=await api(`/api/session?session_id=${encodeURIComponent(sid)}`);
+      const live=await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`);
       if(!live||!live.session||live.session.session_id!==sid){
         throw new Error('session no longer available');
       }
@@ -1313,8 +1313,8 @@ async function cmdRetry(){
     const r=await api('/api/session/retry',{method:'POST',body:JSON.stringify({session_id:activeSid})});
     if(r&&r.error){showToast(r.error);return;}
     if(!S.session||S.session.session_id!==activeSid)return;
-    const data=await api('/api/session?session_id='+encodeURIComponent(activeSid));
-    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();if(typeof _messagesTruncated!=='undefined')_messagesTruncated=false;renderMessages();}
+    const data=await api('/api/session?session_id='+encodeURIComponent(activeSid)+'&messages=1&resolve_model=0&msg_limit=100');
+    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();if(typeof _messagesTruncated!=='undefined')_messagesTruncated=!!data.session._messages_truncated;if(typeof _oldestIdx!=='undefined')_oldestIdx=data.session._messages_offset||0;renderMessages();}
     $('msg').value=r.last_user_text||'';if(typeof autoResize==='function')autoResize();await send();
   }catch(e){showToast(t('retry_failed')+e.message);}
 }
@@ -1326,8 +1326,8 @@ async function cmdUndo(){
     const r=await api('/api/session/undo',{method:'POST',body:JSON.stringify({session_id:activeSid})});
     if(r&&r.error){showToast(r.error);return;}
     if(!S.session||S.session.session_id!==activeSid)return;
-    const data=await api('/api/session?session_id='+encodeURIComponent(activeSid));
-    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();if(typeof _messagesTruncated!=='undefined')_messagesTruncated=false;renderMessages();}
+    const data=await api('/api/session?session_id='+encodeURIComponent(activeSid)+'&messages=1&resolve_model=0&msg_limit=100');
+    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();if(typeof _messagesTruncated!=='undefined')_messagesTruncated=!!data.session._messages_truncated;if(typeof _oldestIdx!=='undefined')_oldestIdx=data.session._messages_offset||0;renderMessages();}
     showToast(`↩ ${t('undid_n_messages')} ${r.removed_count} ${t('undid_messages_suffix')}`);
   }catch(e){showToast(t('undo_failed')+e.message);}
 }

--- a/static/messages.js
+++ b/static/messages.js
@@ -4718,9 +4718,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // "*Task cancelled.*" message gets lost when done event overwrites S.messages
       (async()=>{
         try{
-          const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}`);
+          const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}&messages=1&resolve_model=0&msg_limit=100`);
           if(data&&data.session&&S.session&&S.session.session_id===activeSid){
             S.session=data.session;
+            if(typeof _messagesTruncated!=='undefined') _messagesTruncated=!!data.session._messages_truncated;
+            if(typeof _oldestIdx!=='undefined') _oldestIdx=data.session._messages_offset||0;
             const _nextMsgs3018=(data.session.messages||[]).filter(m=>m&&m.role);
             _attachProjectedAnchorSceneToLastAssistant(_nextMsgs3018);
             S.messages=_carryForwardEphemeralTurnFields(S.messages||[], _nextMsgs3018);
@@ -4799,7 +4801,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       return returnStatus?'stale':false;
     }
     try{
-      const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}`);
+      const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}&messages=1&resolve_model=0&msg_limit=100`);
       // Opus #2852 race-fix: if a late `done` event ran the finalize path while
       // we were awaiting the network roundtrip, bail out — done already settled.
       if(_streamFinalized) return returnStatus?'restored':true;
@@ -4828,6 +4830,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         S.activeStreamId=null;
         clearLiveToolCards();if(!assistantText)removeThinking();
         S.session=session;
+        if(typeof _messagesTruncated!=='undefined') _messagesTruncated=!!session._messages_truncated;
+        if(typeof _oldestIdx!=='undefined') _oldestIdx=session._messages_offset||0;
         const _nextMsgs3018=(session.messages||[]).filter(m=>m&&m.role);
         _attachProjectedAnchorSceneToLastAssistant(_nextMsgs3018);
         S.messages=_carryForwardEphemeralTurnFields(S.messages||[], _nextMsgs3018);

--- a/static/outline.js
+++ b/static/outline.js
@@ -61,18 +61,12 @@ function _expandOutlineRenderWindow() {
 }
 
 function _ensureOutlineMessagesLoaded(sid) {
-  if (!sid || S.busy || S.activeStreamId) return Promise.resolve(false);
-  if (typeof _messagesTruncated === 'undefined' || !_messagesTruncated) {
-    return Promise.resolve(false);
-  }
-  if (typeof _ensureAllMessagesLoaded !== 'function') return Promise.resolve(false);
-  return _ensureAllMessagesLoaded().then(function() {
-    if (!S.session || S.session.session_id !== sid) return false;
-    _expandOutlineRenderWindow();
-    return true;
-  }).catch(function() {
-    return false;
-  });
+  if (!sid || !S.session || S.session.session_id !== sid) return Promise.resolve(false);
+  // Keep the outline bounded to the messages already loaded in the transcript.
+  // Large sessions must not trigger a hidden full-history fetch just because the
+  // outline opened; users can scroll/load older messages to add more entries.
+  _expandOutlineRenderWindow();
+  return Promise.resolve(false);
 }
 
 // Extracts the first 60 visible characters from a message content value.
@@ -103,24 +97,15 @@ function _jumpToMessage(rawIdx) {
     return;
   }
 
-  // Row is outside the render window — reload the full session and retry.
-  if (typeof api !== 'function') return;
-  if (S.busy || S.activeStreamId) return;
-  api('/api/session?session_id=' + encodeURIComponent(sid) +
-      '&messages=1&resolve_model=0&msg_limit=9999')
-    .then(function(data) {
-      if (!data || !data.session) return;
-      if (!S.session || S.session.session_id !== sid) return;  // session switched
-      S.messages = data.session.messages || [];                // populate S
-      _expandOutlineRenderWindow();
-      if (typeof renderMessages === 'function') renderMessages({ preserveScroll: true });
-      window.setTimeout(function() {
-        if (!S.session || S.session.session_id !== sid) return;
-        const r = document.getElementById('msg-user-' + rawIdx);
-        if (r) { r.scrollIntoView({ block: 'center', behavior: 'smooth' }); _flashRow(r); }
-      }, 120);
-    })
-    .catch(function() {});
+  // Row is loaded but currently outside the render window. Expand locally and
+  // retry; do not fetch the whole transcript from the server.
+  _expandOutlineRenderWindow();
+  if (typeof renderMessages === 'function') renderMessages({ preserveScroll: true });
+  window.setTimeout(function() {
+    if (!S.session || S.session.session_id !== sid) return;
+    const r = document.getElementById('msg-user-' + rawIdx);
+    if (r) { r.scrollIntoView({ block: 'center', behavior: 'smooth' }); _flashRow(r); }
+  }, 120);
 }
 
 // Brief highlight flash on a message row after jumping.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2450,15 +2450,10 @@ async function _loadOlderMessages() {
   // rebuilt transcript (#1937).
   const startGeneration = _messagesGeneration;
   try {
-    // Ask the server for a larger authoritative tail window instead of a
-    // separate msg_before page. The same /api/session contract handles both —
-    // post-#2716 the backend always runs the full append-only merge, so a
-    // larger msg_limit on the same call produces the same merged transcript
-    // we'd get by stitching pages, but without client-side index bookkeeping.
-    // Cumulative growth: each "load more" asks for currentLoaded + 30, and the
-    // newly exposed head is what we expose to the user.
-    const requestedLimit = Math.max(_INITIAL_MSG_LIMIT, (S.messages || []).length + _INITIAL_MSG_LIMIT);
-    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${requestedLimit}`);
+    // Ask the server for the next older bounded page. Do not request an
+    // ever-growing cumulative tail: large transcripts must stay page-based so
+    // both API payload size and frontend render work remain bounded.
+    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`);
     // Guard: api() may have redirected (401) and returned undefined.
     if (!data || !data.session) { _loadingOlder = false; return; }
     //  - response shape sane
@@ -2476,46 +2471,11 @@ async function _loadOlderMessages() {
     // counter and abort cleanly. _oldestIdx and _messagesTruncated were
     // already reset by the wholesale-replace path, so no rollback needed.
     if (_messagesGeneration !== startGeneration) return;
-    let responseSession = data.session;
-    let expandedMsgs = (responseSession.messages || []).filter(m => m && m.role);
-    const currentMsgs = (S.messages || []).filter(m => m && m.role);
-    const currentLen = currentMsgs.length;
-    // Suffix-continuity check: the cumulative tail is only safe to wholesale-
-    // replace when our currently-displayed messages are still its suffix. If
-    // the server appended new messages (or merge filtered something) while we
-    // were awaiting, the suffix won't line up — fall back to the legacy
-    // msg_before page so we never drop visible older messages on the floor.
-    let tailMatches = expandedMsgs.length >= currentLen;
-    if (tailMatches && currentLen > 0) {
-      const start = expandedMsgs.length - currentLen;
-      for (let i = 0; i < currentLen; i++) {
-        if (!_sameTranscriptMessage(expandedMsgs[start + i], currentMsgs[i])) {
-          tailMatches = false;
-          break;
-        }
-      }
-    }
-    let olderCount = Math.max(0, expandedMsgs.length - currentLen);
-    let olderMsgs = expandedMsgs.slice(0, olderCount);
-    let nextMessages = expandedMsgs;
-    if (!tailMatches) {
-      // Race fallback: keep the legacy index-page request as the
-      // correctness-preserving alternative. Same guards reapplied because
-      // we just awaited again.
-      const fallback = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`);
-      if (!fallback || !fallback.session) { _loadingOlder = false; return; }
-      if (!S.session || S.session.session_id !== sid) return;
-      if (_loadingSessionId !== null && _loadingSessionId !== sid) return;
-      if (_messagesGeneration !== startGeneration) return;
-      responseSession = fallback.session;
-      olderMsgs = (responseSession.messages || []).filter(m => m && m.role);
-      nextMessages = [...olderMsgs, ...S.messages];
-    }
+    const responseSession = data.session;
+    const olderMsgs = (responseSession.messages || []).filter(m => m && m.role);
+    let nextMessages = [...olderMsgs, ...S.messages];
     if (!olderMsgs.length) { _messagesTruncated = !!responseSession._messages_truncated; return; }
-    // Replace with the larger tail window and preserve scroll as if older
-    // messages were prepended. When the suffix check fails, nextMessages
-    // already encodes the legacy prepend fallback so the visible behavior
-    // matches the old msg_before page path exactly.
+    // Replace by prepending the older page and preserve scroll position.
     // Use $('messages') — the scrollable container (#msgInner is not scrollable).
     const container = $('messages');
     const prevScrollH = container ? container.scrollHeight : 0;
@@ -2582,8 +2542,9 @@ async function _loadOlderMessages() {
   }
 }
 
-// Ensure the full message history is loaded (for undo, export, etc).
-// If the session was loaded with msg_limit, this fetches all messages.
+// Ensure the full message history is loaded (for jump-to-start/export-style UI affordances).
+// If the session was loaded with msg_limit, this walks older pages in bounded
+// chunks instead of issuing one monolithic /api/session request.
 //
 // Race-safety (#1937): with the endless-scroll opt-in, _loadOlderMessages
 // may be in flight when this runs (e.g. user scrolled near the top, then
@@ -2614,14 +2575,30 @@ async function _ensureAllMessagesLoaded() {
   _loadingOlder = true;
   try {
     const sid = S.session.session_id;
-    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`, {timeoutMs:120000});
-    // Guard: api() may have redirected (401) and returned undefined.
-    if (!data || !data.session) return;
-    // Session may have been switched while we awaited. Bail rather than
-    // overwrite the new session's messages.
-    if (!S.session || S.session.session_id !== sid) return;
-    if (_loadingSessionId !== null && _loadingSessionId !== sid) return;
-    const msgs = (data.session.messages || []).filter(m => m && m.role);
+    let combined = (S.messages || []).filter(m => m && m.role);
+    let oldest = Number(_oldestIdx || 0);
+    let responseSession = S.session;
+    let safety = 0;
+    while (oldest > 0 && safety < 200) {
+      safety += 1;
+      const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${oldest}&msg_limit=300`, {timeoutMs:120000});
+      // Guard: api() may have redirected (401) and returned undefined.
+      if (!data || !data.session) return;
+      // Session may have been switched while we awaited. Bail rather than
+      // overwrite the new session's messages.
+      if (!S.session || S.session.session_id !== sid) return;
+      if (_loadingSessionId !== null && _loadingSessionId !== sid) return;
+      responseSession = data.session;
+      const page = (responseSession.messages || []).filter(m => m && m.role);
+      if (!page.length) break;
+      combined = [...page, ...combined];
+      const nextOldest = Number(responseSession._messages_offset || 0);
+      if (!responseSession._messages_truncated || nextOldest <= 0 || nextOldest >= oldest) {
+        oldest = 0;
+        break;
+      }
+      oldest = nextOldest;
+    }
     // Bump the generation BEFORE the wholesale replace so any racing
     // prefetch (whose snapshot was taken before this call's mutex
     // acquisition) sees the new value and aborts.
@@ -2630,16 +2607,16 @@ async function _ensureAllMessagesLoaded() {
     // Loading older messages also does a wholesale replace of S.messages
     // and would otherwise drop _turnUsage/_turnDuration/_turnTps/
     // _gatewayRouting/_statusCard/_anchor_stream_id on the existing turns.
-    let _msgsToAssign = msgs;
+    let _msgsToAssign = combined;
     if (typeof window._carryForwardEphemeralTurnFields === 'function') {
-      _msgsToAssign = window._carryForwardEphemeralTurnFields(S.messages || [], msgs);
+      _msgsToAssign = window._carryForwardEphemeralTurnFields(S.messages || [], combined);
     }
     S.messages = _msgsToAssign;
     _messagesTruncated = false;
     _oldestIdx = 0;
-    _syncToolCallsForLoadedMessages(msgs, data.session.tool_calls);
+    _syncToolCallsForLoadedMessages(combined, responseSession.tool_calls);
     if (S.session && S.session.session_id === sid) {
-      S.session.message_count = Number(data.session.message_count || msgs.length);
+      S.session.message_count = Number(responseSession.message_count || combined.length);
     }
   } finally {
     _loadingOlder = false;

--- a/static/ui.js
+++ b/static/ui.js
@@ -7129,7 +7129,7 @@ async function refreshSession() {
   dismissReconnect();
   if (!S.session) return;
   try {
-    const data = await api(`/api/session?session_id=${encodeURIComponent(S.session.session_id)}`);
+    const data = await api(`/api/session?session_id=${encodeURIComponent(S.session.session_id)}&messages=1&resolve_model=0&msg_limit=100`);
     S.session = data.session;
     S.messages = data.session.messages || [];
     _messagesTruncated = !!data.session._messages_truncated;

--- a/tests/test_large_session_windowing_regression.py
+++ b/tests/test_large_session_windowing_regression.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import api.routes as routes
+
+ROOT = Path(__file__).resolve().parents[1]
+STATIC = ROOT / "static"
+
+
+def test_limited_webui_messages_uses_sidecar_without_old_state_merge(monkeypatch):
+    """Windowed /api/session must not fuzzy-merge old state.db mirror rows."""
+
+    session = SimpleNamespace(
+        messages=[
+            {"role": "user", "content": "old", "timestamp": 10},
+            {"role": "assistant", "content": "tail", "timestamp": 20},
+        ],
+        truncation_watermark=None,
+    )
+
+    def forbidden_lineage(_session):  # pragma: no cover - failure path
+        raise AssertionError("lineage stitch should not run when current sidecar has messages")
+
+    def forbidden_merge(*_args, **_kwargs):  # pragma: no cover - failure path
+        raise AssertionError("old state mirror rows should not trigger full fuzzy merge")
+
+    monkeypatch.setattr(routes, "_webui_sidecar_lineage_messages_for_display", forbidden_lineage)
+    monkeypatch.setattr(routes, "merge_session_messages_append_only", forbidden_merge)
+
+    result = routes._limited_webui_messages_for_display(
+        session,
+        [{"role": "user", "content": "old mirror", "timestamp": 5}],
+    )
+
+    assert result is not session.messages
+    assert result == session.messages
+
+
+def test_limited_webui_messages_merges_only_newer_state_rows(monkeypatch):
+    session = SimpleNamespace(
+        messages=[{"role": "assistant", "content": "sidecar tail", "timestamp": 20}],
+        truncation_watermark=None,
+    )
+    calls = []
+
+    def fake_merge(sidecar, state_rows, **kwargs):
+        calls.append((list(sidecar), list(state_rows), kwargs))
+        return list(sidecar) + list(state_rows)
+
+    monkeypatch.setattr(routes, "merge_session_messages_append_only", fake_merge)
+
+    result = routes._limited_webui_messages_for_display(
+        session,
+        [
+            {"role": "user", "content": "old mirror", "timestamp": 10},
+            {"role": "assistant", "content": "new state tail", "timestamp": 30},
+        ],
+    )
+
+    assert len(calls) == 1
+    assert [m["content"] for m in calls[0][1]] == ["new state tail"]
+    assert [m["content"] for m in result] == ["sidecar tail", "new state tail"]
+
+
+def test_session_message_window_constants_are_bounded():
+    assert routes._DEFAULT_SESSION_MSG_LIMIT == 100
+    assert routes._MAX_SESSION_MSG_LIMIT == 300
+
+
+def test_outline_does_not_hidden_load_full_transcript():
+    outline = (STATIC / "outline.js").read_text(encoding="utf-8")
+
+    assert "msg_limit=9999" not in outline
+    assert "_ensureAllMessagesLoaded" not in outline
+    assert "Large sessions must not trigger a hidden full-history fetch" in outline
+
+
+def test_frontend_full_history_loader_is_page_based():
+    sessions = (STATIC / "sessions.js").read_text(encoding="utf-8")
+
+    assert "messages=1&resolve_model=0`, {timeoutMs:120000}" not in sessions
+    assert "msg_before=${oldest}&msg_limit=300" in sessions
+    assert "msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}" in sessions
+    assert "let nextMessages = [...olderMsgs, ...S.messages];" in sessions
+
+
+def test_static_session_message_fetches_are_bounded_or_metadata_only():
+    offenders = []
+    for path in STATIC.glob("*.js"):
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if "/api/session?session_id" not in line:
+                continue
+            if "messages=0" in line or "msg_limit=" in line or "${reloadLimitParam}" in line:
+                continue
+            offenders.append(f"{path.name}:{lineno}: {line.strip()}")
+
+    assert offenders == []


### PR DESCRIPTION
# Summary

Fix large Hermes WebUI sessions failing or taking tens of seconds to open by making ordinary session message loads windowed and removing hidden full-transcript frontend fetches.

# Problem

Large WebUI sidecar sessions can contain thousands of messages. Previously, even requests with `msg_limit=100` could still spend tens of seconds building the full display coordinate space through sidecar lineage stitching and fuzzy append-only merge work before slicing the result. Frontend paths also had hidden full-load triggers such as `msg_limit=9999` and naked `/api/session?messages=1` refreshes.

# Changes

- Default `/api/session?messages=1` to a bounded recent message window.
- Cap ordinary `msg_limit` requests at 300 unless `include_heavy=1` is explicitly set.
- Add a limited WebUI sidecar fast path that uses the current sidecar plus only strictly newer `state.db` rows, reserving full lineage/fuzzy reconciliation for explicit heavy loads.
- Keep tool-result payloads bounded in paginated responses.
- Replace frontend hidden full-history fetches with bounded window or metadata-only requests.
- Change scroll-up and ensure-all loading to bounded `msg_before` pagination.
- Remove the outline panel's `msg_limit=9999` full-transcript load.
- Add regression tests for backend bounds and static frontend fetch patterns.

# Verification

Ran locally:

```text
python3 -m pytest tests/test_large_session_windowing_regression.py -q
# 6 passed, 3 warnings

node --check static/sessions.js
node --check static/outline.js
node --check static/messages.js
node --check static/commands.js
node --check static/ui.js

python3 -m py_compile api/routes.py
git diff --check HEAD~1..HEAD
```

Runtime check against a 6,829-message local session:

```text
/api/session?messages=1&msg_limit=100       ~0.066s, 272 raw rows, _messages_offset=6557
/api/session?messages=1&msg_limit=9999      ~0.122s, capped, 902 raw rows
```

Also verified the WebUI page opens in a browser without `Failed to load conversation messages` and without console errors.
