### PR TITLE
Release v0.51.598 — Release VE (preserve scroll across live worklog rebuilds, #4743)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- **Live Compact Worklog refreshes no longer jump the transcript while you are reading in-progress output.** The live anchor scene rebuild now captures and restores the outer message viewport around Worklog DOM replacement before applying the normal pinned-at-bottom follow behavior, so manually-unpinned readers keep their place while active Worklog rows refresh or settle. (#4742)
-
 ## [v0.51.596] — 2026-06-23 — Release VC (throttle reasoning SSE to stop tab freeze)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Live Compact Worklog refreshes no longer jump the transcript while you are reading in-progress output.** The live anchor scene rebuild now captures and restores the outer message viewport around Worklog DOM replacement before applying the normal pinned-at-bottom follow behavior, so manually-unpinned readers keep their place while active Worklog rows refresh or settle. (#4742)
+
 ## [v0.51.596] — 2026-06-23 — Release VC (throttle reasoning SSE to stop tab freeze)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.598] — 2026-06-23 — Release VE (preserve scroll across live worklog rebuilds)
+
+### Fixed
+
+- **The transcript no longer jumps while a live tool/thinking worklog rebuilds mid-stream.** When the live "Compact Worklog" activity scene re-rendered (removing and re-adding its tool-card / thinking / anchor rows), the surrounding scroll position could shift, yanking the reader away from where they were. The rebuild now captures the scroll position before the DOM churn and restores it same-frame afterward (before the pinned-to-bottom follow), so an unpinned reader keeps their place and a pinned reader still follows the latest output. Thanks @franksong2702. (#4743)
+
 ## [v0.51.597] — 2026-06-23 — Release VD (message footer wraps instead of overflowing on narrow screens)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -9593,6 +9593,7 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   const liveDisclosureState=typeof _captureWorklogDetailDisclosureState==='function'
     ? _captureWorklogDetailDisclosureState(blocks)
     : null;
+  const scrollSnapshot=_captureMessageScrollSnapshot();
   blocks.querySelectorAll('[data-anchor-scene-owner="1"],[data-anchor-scene-row="1"]').forEach(el=>el.remove());
   blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-card-row[data-live-tid]:not(.transparent-event-row),.agent-activity-thinking[data-live-thinking="1"],.interim-collapse-toggle').forEach(el=>el.remove());
   blocks.querySelectorAll('[data-live-assistant="1"]').forEach(el=>{
@@ -9616,6 +9617,7 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   if(typeof _startActivityElapsedTimer==='function') _startActivityElapsedTimer(group);
   _dedupeLiveProcessedWorklogAnchors(turn);
   if(typeof _moveLiveRunStatusToTurnEnd==='function') _moveLiveRunStatusToTurnEnd();
+  _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
   if(typeof scrollIfPinned==='function') scrollIfPinned();
   return true;
 }

--- a/tests/test_issue3479_ios_stream_scroll_jump.py
+++ b/tests/test_issue3479_ios_stream_scroll_jump.py
@@ -64,6 +64,20 @@ def test_live_compression_card_replacement_restores_snapshot_before_follow_settl
     assert capture_idx < replace_idx < restore_idx < settle_idx
 
 
+def test_live_anchor_worklog_rebuild_restores_snapshot_before_follow_settle():
+    body = _function_body(UI_JS, "renderLiveAnchorActivityScene")
+
+    capture_idx = body.index("const scrollSnapshot=_captureMessageScrollSnapshot();")
+    remove_idx = body.index("blocks.querySelectorAll('[data-anchor-scene-owner=\"1\"],[data-anchor-scene-row=\"1\"]')")
+    restore_detail_idx = body.index("_restoreWorklogDetailDisclosureState(blocks, liveDisclosureState);")
+    dedupe_idx = body.index("_dedupeLiveProcessedWorklogAnchors(turn);")
+    move_status_idx = body.index("_moveLiveRunStatusToTurnEnd();")
+    restore_idx = body.index("_restoreMessageScrollSnapshotSameFrame(scrollSnapshot);")
+    settle_idx = body.index("if(typeof scrollIfPinned==='function') scrollIfPinned();")
+
+    assert capture_idx < remove_idx < restore_detail_idx < dedupe_idx < move_status_idx < restore_idx < settle_idx
+
+
 def test_same_frame_snapshot_preserves_bottom_distance_and_unpinned_state():
     capture = _function_body(UI_JS, "_captureMessageScrollSnapshot")
     restore = _function_body(UI_JS, "_restoreMessageScrollSnapshotSameFrame")


### PR DESCRIPTION
## Release v0.51.598 — Release VE

Ships **#4743** (@franksong2702) — preserve scroll across live Compact Worklog rebuilds.

### What's in it
`renderLiveAnchorActivityScene()` rebuilds the live worklog mid-stream (removing + re-adding tool-card / thinking / anchor-scene rows). That DOM churn could shift the transcript scroll position, yanking the reader away. The fix captures `_captureMessageScrollSnapshot()` before the removal and `_restoreMessageScrollSnapshotSameFrame()` after the rebuild, right before `scrollIfPinned()` — so an unpinned reader keeps their place and a pinned reader still follows to bottom.

### Why it's low-risk
- **Reuses the established pattern**: both helpers already exist on master (8 refs) and the exact same capture/restore is already applied to the sibling "live compression-card replacement" path in the same test file (`test_issue3479_ios_stream_scroll_jump.py`). This is a consistent +2-line extension, not a new mechanism.
- Ships a regression test asserting the ordering (capture → remove → restore-disclosure → dedupe → move-status → restore-scroll → scrollIfPinned).

### Gate
- **Codex: SAFE TO SHIP** — confirmed capture-before-remove / restore-after-rebuild ordering, the restore no-ops safely when pinned (doesn't fight scrollIfPinned), no interaction with the adjacent disclosure-state capture or the #4711/#4671 scroll work.
- **Full suite: 10165 passed** (lone failure = the known `test_active_request_readonly_scope_blocks_pool_env_seed` cross-test isolation artifact, passes in isolation; CI shards green). 9/9 scroll-jump tests pass incl. the new one.

Authored by @franksong2702 (#4743).
