### PR TITLE
test(#4740): fix two order/load-dependent full-suite flakes (test-only)

### DIFF
--- a/tests/test_issue3957_profile_providers_models.py
+++ b/tests/test_issue3957_profile_providers_models.py
@@ -331,6 +331,19 @@ def test_active_request_readonly_scope_blocks_pool_env_seed(monkeypatch, tmp_pat
     work_home = base / "profiles" / "work"
     work_home.mkdir(parents=True)
     monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", base)
+    # Point HERMES_HOME at this test's own tmp base too (#4740). The readonly scope
+    # blocks the process-env credential fallback correctly, but the credential pool's
+    # global-root fallback (read_credential_pool -> _load_global_auth_store) resolves
+    # the root via get_default_hermes_root(), which reads os.environ["HERMES_HOME"]
+    # DIRECTLY — not the thread-local/scoped home. Under full-suite ordering that env
+    # var points at the shared persistent test state dir, where an EARLIER test
+    # persisted an openrouter credential_pool entry (source: env:OPENROUTER_API_KEY)
+    # into auth.json. read_credential_pool then falls back to that global store, finds
+    # the leaked openrouter entry, and _has_explicit_pool_credentials returns True —
+    # an order-dependent false failure that doesn't reproduce in isolation. Pinning
+    # HERMES_HOME to this test's empty tmp base makes the global-root fallback resolve
+    # to a clean dir with no leaked auth.json.
+    monkeypatch.setenv("HERMES_HOME", str(base))
     monkeypatch.setenv("OPENROUTER_API_KEY", "from-process-env")
 
     profiles.set_request_profile("work")

--- a/tests/test_tls_support.py
+++ b/tests/test_tls_support.py
@@ -23,6 +23,38 @@ from conftest import requires_fcntl
 ROOT = Path(__file__).parent.parent
 
 
+def _run_config_probe(code: str, env=None, *, attempts: int = 3, timeout: int = 60):
+    """Run a short `python -c` probe that imports api.config, with retries.
+
+    Importing api.config in a fresh subprocess is heavyweight, and under a fully
+    parallel test suite the box can be saturated enough that a 10s timeout trips
+    and the runner SIGKILLs the child (returncode -9) — a pure resource-contention
+    flake, not a logic failure. Use a generous timeout and retry the spawn on
+    TimeoutExpired / SIGKILL so the full-suite run is deterministic (#4740 sweep:
+    zero tolerance for load-dependent flakes). A genuine non-zero exit with output
+    is returned immediately (no retry) so real failures still surface fast.
+    """
+    last_exc = None
+    for attempt in range(attempts):
+        try:
+            r = subprocess.run(
+                [sys.executable, "-c", code],
+                capture_output=True, text=True, timeout=timeout,
+                cwd=str(ROOT), env=env,
+            )
+        except subprocess.TimeoutExpired as exc:
+            last_exc = exc
+            continue  # contention — respawn
+        # returncode -9 == SIGKILL (OOM/oversubscription under load): retry.
+        if r.returncode == -9 and attempt < attempts - 1:
+            continue
+        return r
+    raise AssertionError(
+        f"config probe subprocess did not complete after {attempts} attempts "
+        f"(timeout={timeout}s each); last error: {last_exc!r}"
+    )
+
+
 def _gen_test_cert(tmpdir: Path) -> tuple[str, str]:
     """Generate a self-signed cert and key pair for testing."""
     cert = str(tmpdir / "test_cert.pem")
@@ -149,11 +181,7 @@ class TestTLSConfigFlag(unittest.TestCase):
             from api.config import TLS_ENABLED
             print(TLS_ENABLED)
         """)
-        r = subprocess.run(
-            [os.sys.executable, "-c", code],
-            capture_output=True, text=True, timeout=10,
-            cwd=str(ROOT),
-        )
+        r = _run_config_probe(code)
         self.assertEqual(r.stdout.strip(), "True")
 
     def test_tls_enabled_false_when_env_absent(self):
@@ -166,11 +194,7 @@ class TestTLSConfigFlag(unittest.TestCase):
             from api.config import TLS_ENABLED
             print(TLS_ENABLED)
         """)
-        r = subprocess.run(
-            [os.sys.executable, "-c", code],
-            capture_output=True, text=True, timeout=10,
-            cwd=str(ROOT), env=env,
-        )
+        r = _run_config_probe(code, env=env)
         self.assertEqual(r.stdout.strip(), "False")
 
     def test_tls_enabled_false_when_only_cert_set(self):
@@ -181,11 +205,7 @@ class TestTLSConfigFlag(unittest.TestCase):
             from api.config import TLS_ENABLED
             print(TLS_ENABLED)
         """)
-        r = subprocess.run(
-            [os.sys.executable, "-c", code],
-            capture_output=True, text=True, timeout=10,
-            cwd=str(ROOT), env=env,
-        )
+        r = _run_config_probe(code, env=env)
         self.assertEqual(r.stdout.strip(), "False")
 
 


### PR DESCRIPTION
## Test-only — fixes the two order/load-dependent flakes surfaced in #4740

No source-code changes (two test files only). Closes #4740.

### 1. `test_active_request_readonly_scope_blocks_pool_env_seed` — order-dependent flake
Failed only under full-suite ordering; passed in isolation. Root-caused via an assertion-time diagnostic (captured *inside* the readonly scope, before teardown):

- The readonly scope correctly blocks the process-env credential fallback (`_thread_local_env_value` returns `''`, `block_process_env_fallback=True`). ✅
- But `_provider_has_key` branch 3 (`_has_explicit_pool_credentials` → `read_credential_pool`) falls back to the **global-root** `auth.json` via `get_default_hermes_root()`, which reads **`os.environ["HERMES_HOME"]` directly** — not the thread-local/scoped home.
- Under full-suite ordering that env var pointed at the shared persistent test state dir (`/tmp/hermes-webui-tests/…`), where an **earlier test had persisted an openrouter `credential_pool` entry** (`source: env:OPENROUTER_API_KEY`) into `auth.json`. The global-root fallback found it → `_provider_has_key("openrouter")` returned `True` → assertion failed.

**Fix:** `monkeypatch.setenv("HERMES_HOME", str(base))` so the global-root fallback resolves to this test's own empty tmp dir with no leaked `auth.json`. The test already set `_DEFAULT_HERMES_HOME` but not the env var that `get_default_hermes_root()` actually reads.

### 2. `test_tls_support.py::TestTLSConfigFlag` ×3 — load-dependent subprocess-timeout flake
These spawn a `python -c` subprocess that imports `api.config` (heavyweight) with a hard `timeout=10`. Under the fully parallel full suite the box gets saturated enough that the import exceeds 10s and the runner SIGKILLs the child (returncode -9) — a pure resource-contention flake (passes in isolation).

**Fix:** new `_run_config_probe()` helper — 60s timeout + retry on `TimeoutExpired`/SIGKILL, returning a genuine non-zero exit immediately so real failures still surface fast. All 3 `TestTLSConfigFlag` cases use it.

### Verification
**Two consecutive full-suite runs, both fully green** (10165 passed, 9 skipped, 0 failed, exit 0) — the first clean full-suite runs after these were the only two flaking tests. Both fixes also pass in isolation.

Test-only, no release needed.
