### PR TITLE
Release v0.51.600 — Release VG (suppress footer jitter during virtual-scroll measurement, #4474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.600] — 2026-06-23 — Release VG (suppress footer jitter during virtual-scroll measurement)
+
+### Fixed
+
+- **The message footer (timestamp + usage stats + actions) no longer flickers/jitters during virtualized-list measurement re-renders.** While the virtual transcript re-measured row heights, the footer's fade transitions fired on each measurement pass, producing a visible jitter. Footer transitions are now suppressed for the duration of the measurement re-render only (a scoped `vscroll-measuring` class, removed in a `finally` so it can never leak), so the footer stays stable while scrolling a long conversation. Thanks @rodboev. (#4474)
+
 ## [v0.51.599] — 2026-06-23 — Release VF (dedupe live progress reasoning echoes)
 
 ### Fixed

--- a/static/style.css
+++ b/static/style.css
@@ -2728,6 +2728,8 @@
 /* ── Message action buttons (copy, edit, retry) ── */
 .msg-actions{display:flex;align-items:center;gap:2px;opacity:0;transition:opacity .15s;margin-left:auto;}
 .msg-row:hover .msg-actions{opacity:1;}
+.vscroll-measuring .msg-foot,
+.vscroll-measuring .msg-actions{transition:none !important;}
 .msg-action-btn{background:none;border:none;color:var(--muted);cursor:pointer;font-size:13px;padding:2px 5px;border-radius:5px;transition:color .12s,background .12s;line-height:1;}
 .msg-action-btn:hover{color:var(--accent-text);background:var(--accent-bg);}
 .selected-text-reply-btn{position:fixed;z-index:1200;display:inline-flex;align-items:center;gap:6px;padding:7px 11px;border:2px solid var(--accent);border-radius:999px;background:var(--bg);color:var(--text);box-shadow:0 8px 24px rgba(0,0,0,.26),0 0 0 1px var(--surface);font-size:12px;font-weight:700;line-height:1;cursor:pointer;opacity:0;pointer-events:none;transform:translateY(4px);transition:opacity .12s ease,transform .12s ease,background .12s ease,border-color .12s ease;user-select:none;}

--- a/static/style.css
+++ b/static/style.css
@@ -2729,7 +2729,8 @@
 .msg-actions{display:flex;align-items:center;gap:2px;opacity:0;transition:opacity .15s;margin-left:auto;}
 .msg-row:hover .msg-actions{opacity:1;}
 .vscroll-measuring .msg-foot,
-.vscroll-measuring .msg-actions{transition:none !important;}
+.vscroll-measuring .msg-actions,
+.vscroll-measuring .msg-time{transition:none !important;}
 .msg-action-btn{background:none;border:none;color:var(--muted);cursor:pointer;font-size:13px;padding:2px 5px;border-radius:5px;transition:color .12s,background .12s;line-height:1;}
 .msg-action-btn:hover{color:var(--accent-text);background:var(--accent-bg);}
 .selected-text-reply-btn{position:fixed;z-index:1200;display:inline-flex;align-items:center;gap:6px;padding:7px 11px;border:2px solid var(--accent);border-radius:999px;background:var(--bg);color:var(--text);box-shadow:0 8px 24px rgba(0,0,0,.26),0 0 0 1px var(--surface);font-size:12px;font-weight:700;line-height:1;cursor:pointer;opacity:0;pointer-events:none;transform:translateY(4px);transition:opacity .12s ease,transform .12s ease,background .12s ease,border-color .12s ease;user-select:none;}

--- a/static/style.css
+++ b/static/style.css
@@ -2728,6 +2728,7 @@
 /* ── Message action buttons (copy, edit, retry) ── */
 .msg-actions{display:flex;align-items:center;gap:2px;opacity:0;transition:opacity .15s;margin-left:auto;}
 .msg-row:hover .msg-actions{opacity:1;}
+/* Keep !important so this beats equal-specificity .msg-foot-with-usage fades during measurement rerenders. */
 .vscroll-measuring .msg-foot,
 .vscroll-measuring .msg-actions,
 .vscroll-measuring .msg-time{transition:none !important;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -871,7 +871,8 @@ function _compensateScrollForMeasurementDelta(renderFn){
   if(!container) return renderFn();
   const anchorBefore=_captureMessageViewportAnchor();
   const scrollTopBefore=container.scrollTop;
-  renderFn();
+  container.classList.add('vscroll-measuring');
+  try{ renderFn(); }finally{ container.classList.remove('vscroll-measuring'); }
   if(!anchorBefore) return;
   if(scrollTopBefore<1){
     const spacer=container.querySelector('[data-virtual-spacer="before"]');

--- a/tests/test_issue4346_vscroll_footer_jitter.py
+++ b/tests/test_issue4346_vscroll_footer_jitter.py
@@ -12,18 +12,14 @@ def test_css_vscroll_measuring_guard():
     """style.css suppresses opacity transitions on .msg-foot and .msg-actions
     while .vscroll-measuring is present on the scroll container."""
     assert 'vscroll-measuring' in CSS
-    assert re.search(
-        r'\.vscroll-measuring\s+\.msg-foot.*transition\s*:\s*none\s*!important',
-        CSS, re.DOTALL
-    ), "missing transition:none !important for .vscroll-measuring .msg-foot"
-    assert re.search(
-        r'\.vscroll-measuring\s+\.msg-actions.*transition\s*:\s*none\s*!important',
-        CSS, re.DOTALL
-    ), "missing transition:none !important for .vscroll-measuring .msg-actions"
-    assert re.search(
-        r'\.vscroll-measuring\s+\.msg-time.*transition\s*:\s*none\s*!important',
-        CSS, re.DOTALL
-    ), "missing transition:none !important for .vscroll-measuring .msg-time"
+    guard_match = re.search(
+        r'(?m)^\.vscroll-measuring\s+\.msg-foot,\n'
+        r'^\.vscroll-measuring\s+\.msg-actions,\n'
+        r'^\.vscroll-measuring\s+\.msg-time\{transition:none !important;\}$',
+        CSS,
+    )
+    assert guard_match, \
+        "missing contiguous .vscroll-measuring transition:none !important guard block"
 
 
 def test_js_compensate_adds_vscroll_measuring():

--- a/tests/test_issue4346_vscroll_footer_jitter.py
+++ b/tests/test_issue4346_vscroll_footer_jitter.py
@@ -1,0 +1,50 @@
+"""Static source assertions for issue #4346 virtual-scroll footer jitter fix."""
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).parent.parent
+
+CSS = (ROOT / 'static' / 'style.css').read_text(encoding='utf-8')
+JS  = (ROOT / 'static' / 'ui.js').read_text(encoding='utf-8')
+
+
+def test_css_vscroll_measuring_guard():
+    """style.css suppresses opacity transitions on .msg-foot and .msg-actions
+    while .vscroll-measuring is present on the scroll container."""
+    assert 'vscroll-measuring' in CSS
+    assert re.search(
+        r'\.vscroll-measuring\s+\.msg-foot.*transition\s*:\s*none\s*!important',
+        CSS, re.DOTALL
+    ), "missing transition:none !important for .vscroll-measuring .msg-foot"
+    assert re.search(
+        r'\.vscroll-measuring\s+\.msg-actions.*transition\s*:\s*none\s*!important',
+        CSS, re.DOTALL
+    ), "missing transition:none !important for .vscroll-measuring .msg-actions"
+
+
+def test_js_compensate_adds_vscroll_measuring():
+    """_compensateScrollForMeasurementDelta adds and removes the vscroll-measuring
+    class around the render callback."""
+    fn_match = re.search(
+        r'function _compensateScrollForMeasurementDelta\(renderFn\)\{(.+?)^(?=function )',
+        JS, re.DOTALL | re.MULTILINE
+    )
+    assert fn_match, "_compensateScrollForMeasurementDelta not found"
+    body = fn_match.group(1)
+    assert "classList.add('vscroll-measuring')" in body
+    assert "classList.remove('vscroll-measuring')" in body
+
+
+def test_js_try_finally_guards_class_removal():
+    """The classList.remove is in a finally block so the class is always cleared."""
+    fn_match = re.search(
+        r'function _compensateScrollForMeasurementDelta\(renderFn\)\{(.+?)^(?=function )',
+        JS, re.DOTALL | re.MULTILINE
+    )
+    assert fn_match
+    body = fn_match.group(1)
+    add_pos = body.find("classList.add('vscroll-measuring')")
+    try_pos = body.find('try{', add_pos) if add_pos != -1 else -1
+    finally_pos = body.find('finally{', try_pos) if try_pos != -1 else -1
+    remove_pos = body.find("classList.remove('vscroll-measuring')", finally_pos) if finally_pos != -1 else -1
+    assert remove_pos != -1, "classList.remove must be inside a finally block after classList.add"

--- a/tests/test_issue4346_vscroll_footer_jitter.py
+++ b/tests/test_issue4346_vscroll_footer_jitter.py
@@ -20,6 +20,10 @@ def test_css_vscroll_measuring_guard():
         r'\.vscroll-measuring\s+\.msg-actions.*transition\s*:\s*none\s*!important',
         CSS, re.DOTALL
     ), "missing transition:none !important for .vscroll-measuring .msg-actions"
+    assert re.search(
+        r'\.vscroll-measuring\s+\.msg-time.*transition\s*:\s*none\s*!important',
+        CSS, re.DOTALL
+    ), "missing transition:none !important for .vscroll-measuring .msg-time"
 
 
 def test_js_compensate_adds_vscroll_measuring():
@@ -36,15 +40,18 @@ def test_js_compensate_adds_vscroll_measuring():
 
 
 def test_js_try_finally_guards_class_removal():
-    """The classList.remove is in a finally block so the class is always cleared."""
+    """The classList.remove is inside the finally{} block, not after it."""
     fn_match = re.search(
         r'function _compensateScrollForMeasurementDelta\(renderFn\)\{(.+?)^(?=function )',
         JS, re.DOTALL | re.MULTILINE
     )
     assert fn_match
     body = fn_match.group(1)
-    add_pos = body.find("classList.add('vscroll-measuring')")
-    try_pos = body.find('try{', add_pos) if add_pos != -1 else -1
-    finally_pos = body.find('finally{', try_pos) if try_pos != -1 else -1
-    remove_pos = body.find("classList.remove('vscroll-measuring')", finally_pos) if finally_pos != -1 else -1
-    assert remove_pos != -1, "classList.remove must be inside a finally block after classList.add"
+    finally_match = re.search(
+        r'finally\{([^}]*)\}',
+        body
+    )
+    assert finally_match, "no finally block found in _compensateScrollForMeasurementDelta"
+    finally_body = finally_match.group(1)
+    assert "classList.remove('vscroll-measuring')" in finally_body, \
+        "classList.remove must be inside the finally{} block, not after it"

--- a/tests/test_issue4346_vscroll_footer_jitter.py
+++ b/tests/test_issue4346_vscroll_footer_jitter.py
@@ -47,11 +47,11 @@ def test_js_try_finally_guards_class_removal():
     )
     assert fn_match
     body = fn_match.group(1)
-    finally_match = re.search(
-        r'finally\{([^}]*)\}',
-        body
-    )
-    assert finally_match, "no finally block found in _compensateScrollForMeasurementDelta"
-    finally_body = finally_match.group(1)
-    assert "classList.remove('vscroll-measuring')" in finally_body, \
-        "classList.remove must be inside the finally{} block, not after it"
+    try_idx = body.find('try{')
+    finally_idx = body.find('finally{')
+    remove_idx = body.find("classList.remove('vscroll-measuring')")
+    assert try_idx != -1, "no try block found in _compensateScrollForMeasurementDelta"
+    assert finally_idx != -1, "no finally block found in _compensateScrollForMeasurementDelta"
+    assert remove_idx != -1, "missing classList.remove('vscroll-measuring')"
+    assert try_idx < finally_idx < remove_idx, \
+        "classList.remove must remain in the finally{} cleanup path"

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -878,6 +878,7 @@ const container = {
   set scrollTop(v){ scrollTopWasMutated = true; scrollTopValue = v; },
   getBoundingClientRect(){ return {top: 0}; },
   querySelector(){ return null; },
+  classList: { add(){}, remove(){} },
 };
 function $(id){ return id === 'messages' ? container : null; }
 function _captureMessageViewportAnchor(){ return null; }
@@ -908,6 +909,7 @@ const container = {
   get scrollTop(){ return scrollTopValue; },
   set scrollTop(v){ scrollHistory.push(v); scrollTopValue = v; },
   getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  classList: { add(){}, remove(){} },
   querySelector(selector){
     if(selector === '[data-msg-idx="42"]'){
       // After render, the row moved from relative offset 100 to 150 (50px shift)
@@ -954,6 +956,7 @@ const container = {
   get scrollTop(){ return scrollTopValue; },
   set scrollTop(v){ scrollHistory.push(v); scrollTopValue = v; },
   getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  classList: { add(){}, remove(){} },
   querySelector(selector){
     if(selector === '[data-msg-idx="42"]'){
       // Row moved by only 1px, within tolerance
@@ -1002,6 +1005,7 @@ const container = {
     scrollTopValue = v;
   },
   getBoundingClientRect(){ return {top: 50, bottom: 650}; },
+  classList: { add(){}, remove(){} },
   querySelector(selector){
     if(selector === '[data-msg-idx="42"]'){
       return {


### PR DESCRIPTION
## Release v0.51.600 — Release VG

Ships **#4474** (@rodboev) — suppress footer jitter during virtual-scroll measurement re-renders.

### What's in it
While the virtualized transcript re-measured row heights, the message footer's fade transitions (timestamp / usage stats / actions) fired on each measurement pass, producing a visible jitter on long conversations. The fix adds a scoped `.vscroll-measuring` class around the measurement `renderFn()` (in `_compensateScrollForMeasurementDelta`) that suppresses those transitions for the measurement window only — removed in a `finally` so it can never leak and permanently kill footer fades. Pure CSS + a 3-line JS guard (+63/-1).

### Review trail (previously bounced, now clean)
I bounced an earlier head (`b862e905`) for a CORE measurement regression: it stamped `data-msg-idx` on the `.assistant-turn` container, which collided with the same attr on its `.assistant-segment` child so `_measureMessageVirtualRow`'s `querySelector` matched the container → inflated/duplicated row heights on every multi-segment turn (the exact jitter class this fixes), plus un-typed `_recycleStash` reuse. @rodboev **removed the assistant-turn recycling entirely** in the re-push, bringing it back to the clean CSS-jitter-fix scope.

### Gate
- **Codex: SAFE TO SHIP** — confirmed the CORE regression is gone (no `data-msg-idx` on `.assistant-turn`, no un-typed recycle reuse), the `vscroll-measuring` class is try/finally-scoped, and the CSS `!important` is bounded to the measurement window.
- **Full suite: 10173 passed** (lone failure = the known `test_active_request_readonly_scope_blocks_pool_env_seed` cross-test isolation artifact, passes in isolation — being fixed separately in #4762; CI shards green).
- 32 targeted virtualization/jitter tests pass.

Authored by @rodboev (#4474). Shipped autonomously per overnight fix-class mandate.
