### PR TITLE
[Live Stream] Guard Compact Worklog scroll rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Compact Worklog no longer snaps back to the user prompt during live-stream rebuilds.** Follow-up to the mid-stream scroll restore: the live Anchor scene now holds the transcript's scroll height stable while it removes and rebuilds Worklog rows, so the browser cannot temporarily clamp an unpinned reader's `scrollTop` to the top before the replacement rows land. Pinned-at-bottom streaming still follows the latest output.
+
 ## [v0.51.603] — 2026-06-23 — Release VJ (cache the app-shell template)
 
 ### Changed

--- a/static/ui.js
+++ b/static/ui.js
@@ -9571,6 +9571,39 @@ function _projectLiveAnchorActivitySceneForStream(streamId, mode){
     return null;
   }
 }
+function _prepareLiveAnchorScrollRebuildGuard(scrollSnapshot){
+  const messagesEl=$('messages');
+  if(!messagesEl||!scrollSnapshot) return {readerAwayFromBottom:false,release:null};
+  const beforeBottomDistance=Math.max(0,messagesEl.scrollHeight-messagesEl.scrollTop-messagesEl.clientHeight);
+  const readerAwayFromBottom=beforeBottomDistance>250&&(_messageUserUnpinned||messagesEl.scrollTop>0);
+  if(!readerAwayFromBottom) return {readerAwayFromBottom:false,release:null};
+  scrollSnapshot.pinned=false;
+  scrollSnapshot.userUnpinned=true;
+  scrollSnapshot.bottom=beforeBottomDistance;
+  _messageUserUnpinned=true;
+  _scrollPinned=false;
+  _nearBottomCount=0;
+  const msgInner=$('msgInner');
+  if(!msgInner||!msgInner.style) return {readerAwayFromBottom:true,release:null};
+  const guardPreviousKey='liveAnchorScrollGuardPreviousMinHeight';
+  let previousMinHeight=msgInner.style.minHeight||'';
+  if(msgInner.dataset&&Object.prototype.hasOwnProperty.call(msgInner.dataset,guardPreviousKey)){
+    previousMinHeight=msgInner.dataset[guardPreviousKey]||'';
+  }else if(msgInner.dataset){
+    msgInner.dataset[guardPreviousKey]=previousMinHeight;
+  }
+  const guardHeight=Math.max(messagesEl.scrollHeight,Number(scrollSnapshot.scrollHeight)||0);
+  if(guardHeight>0) msgInner.style.minHeight=`${guardHeight}px`;
+  return {
+    readerAwayFromBottom:true,
+    release:()=>{
+      msgInner.style.minHeight=previousMinHeight;
+      if(msgInner.dataset&&msgInner.dataset[guardPreviousKey]===previousMinHeight){
+        delete msgInner.dataset[guardPreviousKey];
+      }
+    },
+  };
+}
 function renderLiveAnchorActivityScene(streamId, scene, opts){
   opts=opts||{};
   if(typeof isCompactWorklogMode==='function'&&!isCompactWorklogMode()) return false;
@@ -9595,6 +9628,7 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
     ? _captureWorklogDetailDisclosureState(blocks)
     : null;
   const scrollSnapshot=_captureMessageScrollSnapshot();
+  const scrollRebuildGuard=_prepareLiveAnchorScrollRebuildGuard(scrollSnapshot);
   blocks.querySelectorAll('[data-anchor-scene-owner="1"],[data-anchor-scene-row="1"]').forEach(el=>el.remove());
   blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-card-row[data-live-tid]:not(.transparent-event-row),.agent-activity-thinking[data-live-thinking="1"],.interim-collapse-toggle').forEach(el=>el.remove());
   blocks.querySelectorAll('[data-live-assistant="1"]').forEach(el=>{
@@ -9619,7 +9653,13 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   _dedupeLiveProcessedWorklogAnchors(turn);
   if(typeof _moveLiveRunStatusToTurnEnd==='function') _moveLiveRunStatusToTurnEnd();
   _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
-  if(typeof scrollIfPinned==='function') scrollIfPinned();
+  if(scrollRebuildGuard&&scrollRebuildGuard.release){
+    requestAnimationFrame(()=>{
+      scrollRebuildGuard.release();
+      _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
+    });
+  }
+  if(!scrollRebuildGuard.readerAwayFromBottom&&typeof scrollIfPinned==='function') scrollIfPinned();
   return true;
 }
 function _renderLiveAnchorActivitySceneForStream(streamId, sessionId, opts){

--- a/tests/test_issue3479_ios_stream_scroll_jump.py
+++ b/tests/test_issue3479_ios_stream_scroll_jump.py
@@ -68,14 +68,31 @@ def test_live_anchor_worklog_rebuild_restores_snapshot_before_follow_settle():
     body = _function_body(UI_JS, "renderLiveAnchorActivityScene")
 
     capture_idx = body.index("const scrollSnapshot=_captureMessageScrollSnapshot();")
+    guard_idx = body.index("const scrollRebuildGuard=_prepareLiveAnchorScrollRebuildGuard(scrollSnapshot);")
     remove_idx = body.index("blocks.querySelectorAll('[data-anchor-scene-owner=\"1\"],[data-anchor-scene-row=\"1\"]')")
     restore_detail_idx = body.index("_restoreWorklogDetailDisclosureState(blocks, liveDisclosureState);")
     dedupe_idx = body.index("_dedupeLiveProcessedWorklogAnchors(turn);")
     move_status_idx = body.index("_moveLiveRunStatusToTurnEnd();")
     restore_idx = body.index("_restoreMessageScrollSnapshotSameFrame(scrollSnapshot);")
-    settle_idx = body.index("if(typeof scrollIfPinned==='function') scrollIfPinned();")
+    release_idx = body.index("if(scrollRebuildGuard&&scrollRebuildGuard.release)")
+    settle_idx = body.index("if(!scrollRebuildGuard.readerAwayFromBottom&&typeof scrollIfPinned==='function') scrollIfPinned();")
 
-    assert capture_idx < remove_idx < restore_detail_idx < dedupe_idx < move_status_idx < restore_idx < settle_idx
+    assert capture_idx < guard_idx < remove_idx < restore_detail_idx < dedupe_idx < move_status_idx < restore_idx < release_idx < settle_idx
+
+
+def test_live_anchor_worklog_rebuild_guards_height_for_unpinned_reader():
+    guard = _function_body(UI_JS, "_prepareLiveAnchorScrollRebuildGuard")
+    compact = _compact(guard)
+
+    assert "constbeforeBottomDistance=Math.max(0,messagesEl.scrollHeight-messagesEl.scrollTop-messagesEl.clientHeight);" in compact
+    assert "beforeBottomDistance>250&&(_messageUserUnpinned||messagesEl.scrollTop>0)" in compact
+    assert "scrollSnapshot.pinned=false;" in compact
+    assert "scrollSnapshot.userUnpinned=true;" in compact
+    assert "scrollSnapshot.bottom=beforeBottomDistance;" in compact
+    assert "_messageUserUnpinned=true;" in compact
+    assert "_scrollPinned=false;" in compact
+    assert "_nearBottomCount=0;" in compact
+    assert "msgInner.style.minHeight=`${guardHeight}px`;" in compact
 
 
 def test_same_frame_snapshot_preserves_bottom_distance_and_unpinned_state():

--- a/tests/test_issue4295_midstream_scroll_anchor.py
+++ b/tests/test_issue4295_midstream_scroll_anchor.py
@@ -107,6 +107,64 @@ assert.strictEqual(_programmaticScroll, false);
     subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
 
 
+def test_live_anchor_rebuild_guard_holds_height_and_marks_reader_unpinned():
+    """Live anchor rebuilds must not let the scroll container collapse mid-read."""
+
+    script = f"""
+const assert = require('assert');
+let _messageUserUnpinned = false;
+let _scrollPinned = true;
+let _nearBottomCount = 2;
+const messages = {{
+  scrollTop: 2000,
+  scrollHeight: 5000,
+  clientHeight: 600,
+}};
+const inner = {{ style: {{ minHeight: '' }}, dataset: {{}} }};
+function $(id) {{
+  if (id === 'messages') return messages;
+  if (id === 'msgInner') return inner;
+  return null;
+}}
+{_function_body(UI_JS, "_prepareLiveAnchorScrollRebuildGuard")}
+const snapshot = {{
+  top: 2000,
+  bottom: 0,
+  scrollHeight: 5000,
+  pinned: true,
+  userUnpinned: false,
+}};
+const guard = _prepareLiveAnchorScrollRebuildGuard(snapshot);
+assert.strictEqual(guard.readerAwayFromBottom, true);
+assert.strictEqual(snapshot.pinned, false);
+assert.strictEqual(snapshot.userUnpinned, true);
+assert.strictEqual(snapshot.bottom, 2400);
+assert.strictEqual(_messageUserUnpinned, true);
+assert.strictEqual(_scrollPinned, false);
+assert.strictEqual(_nearBottomCount, 0);
+assert.strictEqual(inner.style.minHeight, '5000px');
+assert.strictEqual(inner.dataset.liveAnchorScrollGuardPreviousMinHeight, '');
+messages.scrollHeight = 5200;
+const nestedSnapshot = {{
+  top: 2000,
+  bottom: 0,
+  scrollHeight: 5200,
+  pinned: true,
+  userUnpinned: false,
+}};
+const nestedGuard = _prepareLiveAnchorScrollRebuildGuard(nestedSnapshot);
+assert.strictEqual(nestedGuard.readerAwayFromBottom, true);
+assert.strictEqual(inner.style.minHeight, '5200px');
+assert.strictEqual(inner.dataset.liveAnchorScrollGuardPreviousMinHeight, '');
+guard.release();
+assert.strictEqual(inner.style.minHeight, '');
+nestedGuard.release();
+assert.strictEqual(inner.style.minHeight, '');
+assert.strictEqual(Object.prototype.hasOwnProperty.call(inner.dataset, 'liveAnchorScrollGuardPreviousMinHeight'), false);
+"""
+    subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+
 def test_restore_message_scroll_snapshot_keeps_intermediate_distance_state():
     script = f"""
 const assert = require('assert');


### PR DESCRIPTION
## Thinking Path

- Live streaming should let pinned users follow the tail while preserving a mid-reader's current viewport.
- The Anchor-backed Compact Worklog renderer removes and rebuilds live scene rows on each activity update.
- During that remove/rebuild window, the transcript height can temporarily collapse, causing the browser to clamp `scrollTop` back near the user prompt before replacement rows are inserted.
- The fix guards the rebuild window so the scroll container never loses enough height to force that clamp.

## What Changed

- Add a live Anchor scroll rebuild guard that detects when the reader is away from the bottom.
- Temporarily hold `#msgInner` at the pre-rebuild scroll height while live Worklog rows are removed and reinserted.
- Force the captured snapshot into the unpinned path for mid-reader views, so `scrollIfPinned()` cannot pull the user back to the stream tail.
- Cover repeated/nested guard calls so rapid live ticks cannot leave a stale temporary `min-height` behind.

## Why It Matters

- Users reading live Worklog output should not periodically jump back to the original user message.
- The previous same-frame restore protected the end of the rebuild, but not the browser's intermediate scroll clamping while the DOM was briefly short.
- Pinned-at-bottom behavior remains intact: the guard only activates when the reader is away from the bottom.

## Verification

- `node --check static/ui.js`
- `./scripts/test.sh tests/test_issue4295_midstream_scroll_anchor.py tests/test_issue4295_scroll_pin_reentry.py tests/test_issue3479_ios_stream_scroll_jump.py tests/test_issue4720_done_scroll_jump_first_message.py`
- Browser synthetic verification on local 8787: rebuilt a tall live Anchor Worklog while scrolled mid-turn; `scrollTop` stayed at `1957` before/after rebuild and temporary `minHeight` released back to empty.
- GitHub Actions on current head `1269289d0`: `browser-smoke`, `lint`, and the Python 3.11 / 3.12 / 3.13 test matrix passed.

## Before / After Evidence

- Before: while a live Compact Worklog was streaming, a rebuild could briefly collapse transcript height; the browser then clamped the viewport back near `msg-user-0`, matching the observed periodic jump to the user's original prompt.
- After: the live rebuild holds transcript height stable until replacement rows land, restores the captured snapshot, then releases the temporary height guard.
- The local browser synthetic check measured the before/after invariant directly: `scrollTop` remained `1957` through the rebuild and the guard cleaned itself up.

## Risks / Follow-ups

- The guard intentionally targets the live Anchor Compact Worklog rebuild path only. Other transcript rebuild paths still rely on their existing scroll snapshot logic.
- The threshold follows the existing reader-away-from-bottom behavior; if that threshold changes globally, this helper should be reviewed with it.

## Model Used

- Provider: OpenAI
- Model: GPT-5 Codex via Codex
- Notable tool use: local repo inspection, `node --check`, `./scripts/test.sh`, Playwright/browser synthetic verification, GitHub CLI / GitHub REST API.