### PR TITLE
fix: force scroll-to-bottom on session switch (ignore stale unpin flag)

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -10985,7 +10985,13 @@ function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
   // lands at the bottom as expected. (Codex #4006 follow-up.)
   // renderMessages() captures the pre-wipe snapshot for this case too (see its
   // scrollSnapshot init), so restoring here lands the reader where they were.
-  if(_messageUserUnpinned){
+  //
+  // Guard: only honor unpin when preserveScroll is true (same-session refresh
+  // where we're deliberately keeping the user's position). For fresh session
+  // loads (preserveScroll=false), the unpin flag may be stale from a mobile
+  // touch event during the loading transition — forcing scrollToBottom() is the
+  // correct behavior for a user-initiated navigation to a different session.
+  if(_messageUserUnpinned && preserveScroll){
     _restoreMessageScrollSnapshot(scrollSnapshot);
     _maybeShowNewMessageScrollCue(scrollSnapshot);
     return;


### PR DESCRIPTION
## Problem

On mobile, switching conversations does not scroll to the latest message — the user has to manually scroll down every time.

## Root cause

`_messageUserUnpinned` flag stays true after a mobile touch event during session loading. Since `_scrollAfterMessageRender` unconditionally honors this flag and returns early, the scroll-to-bottom logic is skipped even on fresh session loads.

## Fix

Only honor the unpin flag when `preserveScroll` is true (same-session refresh). For new session loads (`preserveScroll` is falsy), force `scrollToBottom()` instead.

## Changes

- `static/ui.js`: `_scrollAfterMessageRender` — add `&& preserveScroll` guard to the unpin check