### PR TITLE
Release v0.51.604 — live-stream worklog scroll/dedup + mobile session-switch scroll (#4778, #4777, #4780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Compact Worklog no longer shows duplicate live process prose while a response is still streaming.** When the same progress sentence arrives through both interim assistant text and Anchor activity rows, the live scene now keeps one visible Process row, removes matching live reasoning echoes from the Worklog DOM, and hides legacy source assistant segments so they cannot appear as duplicate transcript prose.
+
 ## [v0.51.603] — 2026-06-23 — Release VJ (cache the app-shell template)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Compact Worklog no longer snaps back to the user prompt during live-stream rebuilds.** Follow-up to the mid-stream scroll restore: the live Anchor scene now holds the transcript's scroll height stable while it removes and rebuilds Worklog rows, so the browser cannot temporarily clamp an unpinned reader's `scrollTop` to the top before the replacement rows land. Pinned-at-bottom streaming still follows the latest output.
+
 ## [v0.51.603] — 2026-06-23 — Release VJ (cache the app-shell template)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+## [v0.51.604] — 2026-06-23 — Release VK (live-stream worklog scroll + dedup + mobile session-switch scroll)
+
 ### Fixed
 
 - **Compact Worklog no longer snaps back to the user prompt during live-stream rebuilds.** Follow-up to the mid-stream scroll restore: the live Anchor scene now holds the transcript's scroll height stable while it removes and rebuilds Worklog rows, so the browser cannot temporarily clamp an unpinned reader's `scrollTop` to the top before the replacement rows land. Pinned-at-bottom streaming still follows the latest output. Thanks @franksong2702. (#4778)

--- a/static/messages.js
+++ b/static/messages.js
@@ -2831,6 +2831,34 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
     return false;
   }
+  function _removeLiveReasoningEchoRows(visible){
+    const turn=$('liveAssistantTurn');
+    const blocks=turn&&typeof _assistantTurnBlocks==='function'?_assistantTurnBlocks(turn):null;
+    if(!blocks||!visible) return false;
+    let removed=false;
+    const selector=[
+      '.agent-activity-thinking[data-anchor-scene-row="1"]',
+      '.agent-activity-thinking[data-live-thinking="1"]',
+      '.wl-reason[data-worklog-anchor-reason="1"]',
+      '.wl-reason[data-worklog-reason-source="reasoning"]'
+    ].join(',');
+    blocks.querySelectorAll(selector).forEach(row=>{
+      const textNode=row.querySelector&&(
+        row.querySelector('.thinking-card-body pre') ||
+        row.querySelector('.thinking-card-body')
+      );
+      const text=String((textNode&&textNode.textContent)||row.textContent||'');
+      if(!_stripCompactEchoSuffix(text, visible).removed) return;
+      row.remove();
+      removed=true;
+    });
+    if(removed&&typeof _syncToolCallGroupSummary==='function'){
+      blocks.querySelectorAll('.tool-worklog-group,.tool-call-group').forEach(group=>{
+        _syncToolCallGroupSummary(group);
+      });
+    }
+    return removed;
+  }
   function _stripLiveReasoningEcho(visible){
     let removed=false;
     const durable=_stripCompactEchoSuffix(reasoningText, visible);
@@ -2844,11 +2872,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       removed=true;
     }
     const anchorRemoved=_stripAnchorReasoningEcho(visible);
+    const domRemoved=_removeLiveReasoningEchoRows(visible);
     if(removed) syncInflightAssistantMessage();
-    if((removed||anchorRemoved)&&!String(liveReasoningText||'').trim()&&typeof removeThinking==='function'){
+    if((removed||anchorRemoved||domRemoved)&&!String(liveReasoningText||'').trim()&&typeof removeThinking==='function'){
       removeThinking();
     }
-    return removed||anchorRemoved;
+    return removed||anchorRemoved||domRemoved;
   }
   function _flushReasoningToAnchor(){
     if(_anchorReasoningFlushed||!reasoningText) return;
@@ -3404,6 +3433,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   }
   function _flushPendingSegmentRender(options={}){
     const force=!!(options&&options.force);
+    const skipAnchorProcessProse=!!(options&&options.skipAnchorProcessProse);
     if(!assistantBody||(!force&&!_renderPending)) return;
     if(_renderPending) _cancelAnimationFramePendingStreamRender();
     const displayText=segmentStart===0
@@ -3428,7 +3458,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     } else {
       assistantBody.innerHTML=esc(displayText);
     }
-    _upsertAnchorProcessProse(displayText,{sealed:force});
+    if(!skipAnchorProcessProse) _upsertAnchorProcessProse(displayText,{sealed:force});
     if(typeof _syncLiveWorklogReasonsForAnchor==='function') _syncLiveWorklogReasonsForAnchor(assistantRow, displayText);
   }
   function _resetAssistantSegment(){
@@ -3871,7 +3901,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _completeAutomaticCompressionOnLiveProgress(activeSid);
       ensureAssistantRow(true);
       if(assistantRow) assistantRow.setAttribute('data-interim','1');
-      _flushPendingSegmentRender({force:true});
+      _flushPendingSegmentRender({force:true,skipAnchorProcessProse:true});
       if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
       if(typeof closeCurrentLiveActivityGroup==='function') closeCurrentLiveActivityGroup();
       _applyToAnchor('interim_assistant',d,e);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1002,6 +1002,13 @@ async function loadSession(sid){
   // Mark this session as the in-flight load. Subsequent loadSession() calls
   // will overwrite this; stale awaits use the mismatch to bail out (#1060).
   _loadingSessionId = sid;
+  // Reset scroll state for fresh session navigation — the reader expects to
+  // land at the bottom of the new transcript, not wherever a stale unpin flag
+  // from a prior session or a stray touch event during loading would place them.
+  if (currentSid !== sid && typeof _messageUserUnpinned !== 'undefined') {
+    _messageUserUnpinned = false;
+    _scrollPinned = true;
+  }
   stopApprovalPolling();hideApprovalCard(forceReload);
   if(typeof stopSessionStream==='function') stopSessionStream();
   _yoloEnabled=false;_updateYoloPill();

--- a/static/ui.js
+++ b/static/ui.js
@@ -9571,6 +9571,39 @@ function _projectLiveAnchorActivitySceneForStream(streamId, mode){
     return null;
   }
 }
+function _prepareLiveAnchorScrollRebuildGuard(scrollSnapshot){
+  const messagesEl=$('messages');
+  if(!messagesEl||!scrollSnapshot) return {readerAwayFromBottom:false,release:null};
+  const beforeBottomDistance=Math.max(0,messagesEl.scrollHeight-messagesEl.scrollTop-messagesEl.clientHeight);
+  const readerAwayFromBottom=beforeBottomDistance>250&&(_messageUserUnpinned||messagesEl.scrollTop>0);
+  if(!readerAwayFromBottom) return {readerAwayFromBottom:false,release:null};
+  scrollSnapshot.pinned=false;
+  scrollSnapshot.userUnpinned=true;
+  scrollSnapshot.bottom=beforeBottomDistance;
+  _messageUserUnpinned=true;
+  _scrollPinned=false;
+  _nearBottomCount=0;
+  const msgInner=$('msgInner');
+  if(!msgInner||!msgInner.style) return {readerAwayFromBottom:true,release:null};
+  const guardPreviousKey='liveAnchorScrollGuardPreviousMinHeight';
+  let previousMinHeight=msgInner.style.minHeight||'';
+  if(msgInner.dataset&&Object.prototype.hasOwnProperty.call(msgInner.dataset,guardPreviousKey)){
+    previousMinHeight=msgInner.dataset[guardPreviousKey]||'';
+  }else if(msgInner.dataset){
+    msgInner.dataset[guardPreviousKey]=previousMinHeight;
+  }
+  const guardHeight=Math.max(messagesEl.scrollHeight,Number(scrollSnapshot.scrollHeight)||0);
+  if(guardHeight>0) msgInner.style.minHeight=`${guardHeight}px`;
+  return {
+    readerAwayFromBottom:true,
+    release:()=>{
+      msgInner.style.minHeight=previousMinHeight;
+      if(msgInner.dataset&&msgInner.dataset[guardPreviousKey]===previousMinHeight){
+        delete msgInner.dataset[guardPreviousKey];
+      }
+    },
+  };
+}
 function renderLiveAnchorActivityScene(streamId, scene, opts){
   opts=opts||{};
   if(typeof isCompactWorklogMode==='function'&&!isCompactWorklogMode()) return false;
@@ -9595,6 +9628,7 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
     ? _captureWorklogDetailDisclosureState(blocks)
     : null;
   const scrollSnapshot=_captureMessageScrollSnapshot();
+  const scrollRebuildGuard=_prepareLiveAnchorScrollRebuildGuard(scrollSnapshot);
   blocks.querySelectorAll('[data-anchor-scene-owner="1"],[data-anchor-scene-row="1"]').forEach(el=>el.remove());
   blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-card-row[data-live-tid]:not(.transparent-event-row),.agent-activity-thinking[data-live-thinking="1"],.interim-collapse-toggle').forEach(el=>el.remove());
   blocks.querySelectorAll('[data-live-assistant="1"]').forEach(el=>{
@@ -9619,7 +9653,13 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   _dedupeLiveProcessedWorklogAnchors(turn);
   if(typeof _moveLiveRunStatusToTurnEnd==='function') _moveLiveRunStatusToTurnEnd();
   _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
-  if(typeof scrollIfPinned==='function') scrollIfPinned();
+  if(scrollRebuildGuard&&scrollRebuildGuard.release){
+    requestAnimationFrame(()=>{
+      scrollRebuildGuard.release();
+      _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
+    });
+  }
+  if(!scrollRebuildGuard.readerAwayFromBottom&&typeof scrollIfPinned==='function') scrollIfPinned();
   return true;
 }
 function _renderLiveAnchorActivitySceneForStream(streamId, sessionId, opts){

--- a/static/ui.js
+++ b/static/ui.js
@@ -9079,6 +9079,7 @@ function _syncWorklogReasonFromAnchor(group, anchor, displayTextOverride){
   if(anchor){
     anchor.classList.add('assistant-segment-worklog-source');
     anchor.setAttribute('aria-hidden','true');
+    anchor.hidden=true;
   }
 }
 function ensureLiveWorklogContainer(blocks, opts){
@@ -9142,6 +9143,7 @@ function _appendWorklogReason(list, anchor){
   if(anchor){
     anchor.classList.add('assistant-segment-worklog-source');
     anchor.setAttribute('aria-hidden','true');
+    anchor.hidden=true;
   }
   return reason;
 }
@@ -9263,8 +9265,11 @@ function _appendWorklogStep(group, anchor, cards, thinkingText, opts){
 function _anchorSceneRowsForRendering(scene, opts){
   const rows=Array.isArray(scene&&scene.activity_rows)?scene.activity_rows:[];
   const settled=!!(opts&&opts.settled);
+  const live=!settled;
   const out=[];
   const byKey=new Map();
+  const liveProseTextKeys=new Map();
+  const proseTextKey=(value)=>String(value||'').replace(/\s+/g,' ').trim();
   const keyFor=(row)=>{
     if(!row) return '';
     if(row.role==='tool') return `tool:${_anchorSceneToolRowLogicalKey(row)||row.row_id||row.event_id||row.local_id||out.length}`;
@@ -9286,8 +9291,23 @@ function _anchorSceneRowsForRendering(scene, opts){
     const key=keyFor(row);
     if(byKey.has(key)){
       const index=byKey.get(key);
+      if(live&&row.role==='prose'){
+        const textKey=proseTextKey(text);
+        const duplicateIndex=textKey?liveProseTextKeys.get(textKey):undefined;
+        if(duplicateIndex!==undefined&&duplicateIndex!==index) continue;
+        const previousTextKey=proseTextKey(out[index]&&out[index].text);
+        if(previousTextKey&&previousTextKey!==textKey&&liveProseTextKeys.get(previousTextKey)===index){
+          liveProseTextKeys.delete(previousTextKey);
+        }
+        if(textKey) liveProseTextKeys.set(textKey,index);
+      }
       out[index]=row.role==='tool'?_anchorSceneMergeToolRows(out[index],row):row;
     }else{
+      if(live&&row.role==='prose'){
+        const textKey=proseTextKey(text);
+        if(textKey&&liveProseTextKeys.has(textKey)) continue;
+        if(textKey) liveProseTextKeys.set(textKey,out.length);
+      }
       byKey.set(key,out.length);
       out.push(row);
     }
@@ -9600,6 +9620,7 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   blocks.querySelectorAll('[data-live-assistant="1"]').forEach(el=>{
     el.classList.add('assistant-segment-worklog-source');
     el.setAttribute('aria-hidden','true');
+    el.hidden=true;
   });
   const group=_anchorSceneWorklogGroup(blocks,{
     live:true,
@@ -9664,6 +9685,7 @@ function _renderSettledAnchorSceneTransparentForMessage(message, segment, rawIdx
     if(Number.isFinite(idx)&&idx<rawIdx){
       node.classList.add('assistant-segment-worklog-source');
       node.setAttribute('aria-hidden','true');
+      node.hidden=true;
     }
   });
   let wrote=false;
@@ -9696,6 +9718,7 @@ function _renderSettledAnchorSceneForMessage(message, segment, rawIdx){
     if(Number.isFinite(idx)&&idx<rawIdx){
       node.classList.add('assistant-segment-worklog-source');
       node.setAttribute('aria-hidden','true');
+      node.hidden=true;
     }
   });
   blocks.querySelectorAll('.tool-worklog-group:not([data-anchor-scene-owner="1"]),.tool-call-group:not([data-anchor-scene-owner="1"]),.agent-activity-thinking:not([data-anchor-scene-row="1"]),.wl-reason').forEach(el=>el.remove());
@@ -11411,6 +11434,7 @@ function renderMessages(options){
     if(messageBelongsInWorklog){
       seg.classList.add('assistant-segment-worklog-source');
       seg.setAttribute('aria-hidden','true');
+      seg.hidden=true;
     }
     if(m._live){
       currentAssistantTurn.id='liveAssistantTurn';
@@ -12148,6 +12172,7 @@ function renderMessages(options){
           if(!(seg.textContent||'').trim()) continue;
           seg.classList.remove('assistant-segment-worklog-source');
           seg.removeAttribute('aria-hidden');
+          seg.hidden=false;
         }
       }
     }

--- a/static/ui.js
+++ b/static/ui.js
@@ -9682,7 +9682,10 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   if(scrollRebuildGuard&&scrollRebuildGuard.release){
     requestAnimationFrame(()=>{
       scrollRebuildGuard.release();
-      _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
+      // Only re-restore the unpinned snapshot if the reader is STILL unpinned at
+      // rAF time. If they re-pinned between guard-engage and this frame, the
+      // stale re-restore would yank them back off the bottom (Opus gate finding).
+      if(_messageUserUnpinned) _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
     });
   }
   if(!scrollRebuildGuard.readerAwayFromBottom&&typeof scrollIfPinned==='function') scrollIfPinned();

--- a/static/ui.js
+++ b/static/ui.js
@@ -9595,7 +9595,12 @@ function _prepareLiveAnchorScrollRebuildGuard(scrollSnapshot){
   const messagesEl=$('messages');
   if(!messagesEl||!scrollSnapshot) return {readerAwayFromBottom:false,release:null};
   const beforeBottomDistance=Math.max(0,messagesEl.scrollHeight-messagesEl.scrollTop-messagesEl.clientHeight);
-  const readerAwayFromBottom=beforeBottomDistance>250&&(_messageUserUnpinned||messagesEl.scrollTop>0);
+  // Only treat the reader as away if they were ALREADY in a non-follow state.
+  // A pinned follower can transiently have bottomDistance>250 mid-render (the
+  // assistant body grows before the anchor scene re-renders), so keying on a
+  // raw scrollTop>0 here would mis-classify a pinned reader as unpinned and kill
+  // auto-follow. Require an explicit unpin/non-pinned signal instead.
+  const readerAwayFromBottom=beforeBottomDistance>250&&(_messageUserUnpinned||_scrollPinned===false);
   if(!readerAwayFromBottom) return {readerAwayFromBottom:false,release:null};
   scrollSnapshot.pinned=false;
   scrollSnapshot.userUnpinned=true;

--- a/tests/test_issue2403_interim_collapse.py
+++ b/tests/test_issue2403_interim_collapse.py
@@ -30,6 +30,18 @@ def _extract_interim_handler(src):
         pos = idx
 
 
+def _visible_interim_flush_pos(fn):
+    attr_pos = fn.index("setAttribute('data-interim','1')")
+    candidates = [
+        "_flushPendingSegmentRender({force:true,skipAnchorProcessProse:true})",
+        "_flushPendingSegmentRender({force:true})",
+    ]
+    positions = [fn.find(candidate, attr_pos) for candidate in candidates]
+    positions = [pos for pos in positions if pos != -1]
+    assert positions, "visible interim flush call not found after data-interim marker"
+    return min(positions)
+
+
 class TestInterimCollapseHandlerStructure:
     """The interim_assistant handler must contain the collapse threshold and logic."""
 
@@ -93,7 +105,7 @@ class TestInterimCollapseHandlerStructure:
         src = read("static/messages.js")
         fn = _extract_interim_handler(src)
         attr_pos = fn.index("setAttribute('data-interim','1')")
-        flush_pos = fn.rindex("_flushPendingSegmentRender({force:true})")
+        flush_pos = _visible_interim_flush_pos(fn)
         assert attr_pos < flush_pos, (
             "data-interim attribute must be set before _flushPendingSegmentRender "
             "so the segment is marked before it is sealed"
@@ -102,7 +114,7 @@ class TestInterimCollapseHandlerStructure:
     def test_collapse_after_flush_before_reset(self):
         src = read("static/messages.js")
         fn = _extract_interim_handler(src)
-        flush_pos = fn.index("_flushPendingSegmentRender({force:true})")
+        flush_pos = _visible_interim_flush_pos(fn)
         collapse_pos = fn.index("INTERIM_COLLAPSE_THRESHOLD")
         reset_pos = fn.index("_resetAssistantSegment()", collapse_pos)
         assert flush_pos < collapse_pos < reset_pos, (
@@ -201,4 +213,3 @@ class TestInterimCollapseSurvivesLiveTurnRestore:
             "toggle must carry data-threshold so the delegated handler can "
             "recompute the collapse set without closure state after a restore."
         )
-

--- a/tests/test_issue3479_ios_stream_scroll_jump.py
+++ b/tests/test_issue3479_ios_stream_scroll_jump.py
@@ -85,7 +85,7 @@ def test_live_anchor_worklog_rebuild_guards_height_for_unpinned_reader():
     compact = _compact(guard)
 
     assert "constbeforeBottomDistance=Math.max(0,messagesEl.scrollHeight-messagesEl.scrollTop-messagesEl.clientHeight);" in compact
-    assert "beforeBottomDistance>250&&(_messageUserUnpinned||messagesEl.scrollTop>0)" in compact
+    assert "beforeBottomDistance>250&&(_messageUserUnpinned||_scrollPinned===false)" in compact
     assert "scrollSnapshot.pinned=false;" in compact
     assert "scrollSnapshot.userUnpinned=true;" in compact
     assert "scrollSnapshot.bottom=beforeBottomDistance;" in compact

--- a/tests/test_issue3479_ios_stream_scroll_jump.py
+++ b/tests/test_issue3479_ios_stream_scroll_jump.py
@@ -68,14 +68,31 @@ def test_live_anchor_worklog_rebuild_restores_snapshot_before_follow_settle():
     body = _function_body(UI_JS, "renderLiveAnchorActivityScene")
 
     capture_idx = body.index("const scrollSnapshot=_captureMessageScrollSnapshot();")
+    guard_idx = body.index("const scrollRebuildGuard=_prepareLiveAnchorScrollRebuildGuard(scrollSnapshot);")
     remove_idx = body.index("blocks.querySelectorAll('[data-anchor-scene-owner=\"1\"],[data-anchor-scene-row=\"1\"]')")
     restore_detail_idx = body.index("_restoreWorklogDetailDisclosureState(blocks, liveDisclosureState);")
     dedupe_idx = body.index("_dedupeLiveProcessedWorklogAnchors(turn);")
     move_status_idx = body.index("_moveLiveRunStatusToTurnEnd();")
     restore_idx = body.index("_restoreMessageScrollSnapshotSameFrame(scrollSnapshot);")
-    settle_idx = body.index("if(typeof scrollIfPinned==='function') scrollIfPinned();")
+    release_idx = body.index("if(scrollRebuildGuard&&scrollRebuildGuard.release)")
+    settle_idx = body.index("if(!scrollRebuildGuard.readerAwayFromBottom&&typeof scrollIfPinned==='function') scrollIfPinned();")
 
-    assert capture_idx < remove_idx < restore_detail_idx < dedupe_idx < move_status_idx < restore_idx < settle_idx
+    assert capture_idx < guard_idx < remove_idx < restore_detail_idx < dedupe_idx < move_status_idx < restore_idx < release_idx < settle_idx
+
+
+def test_live_anchor_worklog_rebuild_guards_height_for_unpinned_reader():
+    guard = _function_body(UI_JS, "_prepareLiveAnchorScrollRebuildGuard")
+    compact = _compact(guard)
+
+    assert "constbeforeBottomDistance=Math.max(0,messagesEl.scrollHeight-messagesEl.scrollTop-messagesEl.clientHeight);" in compact
+    assert "beforeBottomDistance>250&&(_messageUserUnpinned||messagesEl.scrollTop>0)" in compact
+    assert "scrollSnapshot.pinned=false;" in compact
+    assert "scrollSnapshot.userUnpinned=true;" in compact
+    assert "scrollSnapshot.bottom=beforeBottomDistance;" in compact
+    assert "_messageUserUnpinned=true;" in compact
+    assert "_scrollPinned=false;" in compact
+    assert "_nearBottomCount=0;" in compact
+    assert "msgInner.style.minHeight=`${guardHeight}px`;" in compact
 
 
 def test_same_frame_snapshot_preserves_bottom_distance_and_unpinned_state():

--- a/tests/test_issue4295_midstream_scroll_anchor.py
+++ b/tests/test_issue4295_midstream_scroll_anchor.py
@@ -107,6 +107,64 @@ assert.strictEqual(_programmaticScroll, false);
     subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
 
 
+def test_live_anchor_rebuild_guard_holds_height_and_marks_reader_unpinned():
+    """Live anchor rebuilds must not let the scroll container collapse mid-read."""
+
+    script = f"""
+const assert = require('assert');
+let _messageUserUnpinned = false;
+let _scrollPinned = true;
+let _nearBottomCount = 2;
+const messages = {{
+  scrollTop: 2000,
+  scrollHeight: 5000,
+  clientHeight: 600,
+}};
+const inner = {{ style: {{ minHeight: '' }}, dataset: {{}} }};
+function $(id) {{
+  if (id === 'messages') return messages;
+  if (id === 'msgInner') return inner;
+  return null;
+}}
+{_function_body(UI_JS, "_prepareLiveAnchorScrollRebuildGuard")}
+const snapshot = {{
+  top: 2000,
+  bottom: 0,
+  scrollHeight: 5000,
+  pinned: true,
+  userUnpinned: false,
+}};
+const guard = _prepareLiveAnchorScrollRebuildGuard(snapshot);
+assert.strictEqual(guard.readerAwayFromBottom, true);
+assert.strictEqual(snapshot.pinned, false);
+assert.strictEqual(snapshot.userUnpinned, true);
+assert.strictEqual(snapshot.bottom, 2400);
+assert.strictEqual(_messageUserUnpinned, true);
+assert.strictEqual(_scrollPinned, false);
+assert.strictEqual(_nearBottomCount, 0);
+assert.strictEqual(inner.style.minHeight, '5000px');
+assert.strictEqual(inner.dataset.liveAnchorScrollGuardPreviousMinHeight, '');
+messages.scrollHeight = 5200;
+const nestedSnapshot = {{
+  top: 2000,
+  bottom: 0,
+  scrollHeight: 5200,
+  pinned: true,
+  userUnpinned: false,
+}};
+const nestedGuard = _prepareLiveAnchorScrollRebuildGuard(nestedSnapshot);
+assert.strictEqual(nestedGuard.readerAwayFromBottom, true);
+assert.strictEqual(inner.style.minHeight, '5200px');
+assert.strictEqual(inner.dataset.liveAnchorScrollGuardPreviousMinHeight, '');
+guard.release();
+assert.strictEqual(inner.style.minHeight, '');
+nestedGuard.release();
+assert.strictEqual(inner.style.minHeight, '');
+assert.strictEqual(Object.prototype.hasOwnProperty.call(inner.dataset, 'liveAnchorScrollGuardPreviousMinHeight'), false);
+"""
+    subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+
 def test_restore_message_scroll_snapshot_keeps_intermediate_distance_state():
     script = f"""
 const assert = require('assert');

--- a/tests/test_issue4295_midstream_scroll_anchor.py
+++ b/tests/test_issue4295_midstream_scroll_anchor.py
@@ -112,8 +112,8 @@ def test_live_anchor_rebuild_guard_holds_height_and_marks_reader_unpinned():
 
     script = f"""
 const assert = require('assert');
-let _messageUserUnpinned = false;
-let _scrollPinned = true;
+let _messageUserUnpinned = true;
+let _scrollPinned = false;
 let _nearBottomCount = 2;
 const messages = {{
   scrollTop: 2000,
@@ -161,6 +161,50 @@ assert.strictEqual(inner.style.minHeight, '');
 nestedGuard.release();
 assert.strictEqual(inner.style.minHeight, '');
 assert.strictEqual(Object.prototype.hasOwnProperty.call(inner.dataset, 'liveAnchorScrollGuardPreviousMinHeight'), false);
+"""
+    subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+
+def test_live_anchor_rebuild_guard_keeps_pinned_follower_pinned_on_large_growth():
+    """A PINNED follower must NOT be reclassified as unpinned when a large live
+    render transiently pushes bottomDistance>250. Regression guard: the predicate
+    must require an explicit non-follow signal (_messageUserUnpinned / _scrollPinned
+    === false), not a raw scrollTop>0, or pinned live streams stop auto-following."""
+
+    script = f"""
+const assert = require('assert');
+let _messageUserUnpinned = false;
+let _scrollPinned = true;
+let _nearBottomCount = 2;
+const messages = {{
+  scrollTop: 4400,
+  scrollHeight: 5500,
+  clientHeight: 600,
+}};
+const inner = {{ style: {{ minHeight: '' }}, dataset: {{}} }};
+function $(id) {{
+  if (id === 'messages') return messages;
+  if (id === 'msgInner') return inner;
+  return null;
+}}
+{_function_body(UI_JS, "_prepareLiveAnchorScrollRebuildGuard")}
+const snapshot = {{
+  top: 4400,
+  bottom: 0,
+  scrollHeight: 5500,
+  pinned: true,
+  userUnpinned: false,
+}};
+const guard = _prepareLiveAnchorScrollRebuildGuard(snapshot);
+// bottomDistance = 5500 - 4400 - 600 = 500 (>250), but the reader is pinned and
+// has not manually unpinned -> must stay pinned, follow-scroll must NOT be skipped.
+assert.strictEqual(guard.readerAwayFromBottom, false);
+assert.strictEqual(guard.release, null);
+assert.strictEqual(_messageUserUnpinned, false);
+assert.strictEqual(_scrollPinned, true);
+assert.strictEqual(snapshot.pinned, true);
+assert.strictEqual(snapshot.userUnpinned, false);
+assert.strictEqual(inner.style.minHeight, '');
 """
     subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
 

--- a/tests/test_live_anchor_progress_echo.py
+++ b/tests/test_live_anchor_progress_echo.py
@@ -27,19 +27,30 @@ def test_interim_reasoning_echo_cleans_live_and_anchor_thinking():
     assert "const reasoningEcho=!!(d&&d.reasoning_echo);" in body
     assert "if(reasoningEcho) _stripLiveReasoningEcho(visible);" in body
     assert "function _stripAnchorReasoningEcho(visible)" in MESSAGES
+    assert "function _removeLiveReasoningEchoRows(visible)" in MESSAGES
     assert "events.splice(i,1);" in MESSAGES
+    assert '.agent-activity-thinking[data-anchor-scene-row="1"]' in MESSAGES
+    assert "_removeLiveReasoningEchoRows(visible)" in MESSAGES
     assert "reasoningText=durable.text;" in MESSAGES
     assert "liveReasoningText=live.text;" in MESSAGES
 
 
-def test_interim_anchor_render_runs_after_legacy_segment_flush():
+def test_interim_anchor_render_runs_after_legacy_segment_flush_without_duplicate_process_row():
     body = _interim_listener_body()
 
-    flush_idx = body.index("_flushPendingSegmentRender({force:true});")
+    flush_idx = body.index("_flushPendingSegmentRender({force:true,skipAnchorProcessProse:true});")
     anchor_idx = body.index("_applyToAnchor('interim_assistant',d,e);")
+    flush_fn_start = MESSAGES.index("function _flushPendingSegmentRender")
+    flush_fn = MESSAGES[flush_fn_start : MESSAGES.index("function _resetAssistantSegment", flush_fn_start)]
+
+    assert "const skipAnchorProcessProse=!!(options&&options.skipAnchorProcessProse);" in flush_fn
+    assert "if(!skipAnchorProcessProse) _upsertAnchorProcessProse(displayText,{sealed:force});" in flush_fn
     assert flush_idx < anchor_idx, (
         "Anchor live scene must render after the legacy interim segment is flushed, "
         "so renderLiveAnchorActivityScene can hide that source segment immediately."
+    )
+    assert "_flushPendingSegmentRender({force:true});" in body, (
+        "already_streamed interim updates must still flush the token-owned prose row."
     )
 
 

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -338,12 +338,78 @@ def test_scene_renderer_coalesces_row_updates_and_renders_in_scene_order():
     render = _function_body(UI_JS, "_renderAnchorSceneRowsIntoWorklog")
     live = _function_body(UI_JS, "renderLiveAnchorActivityScene")
 
+    assert "const live=!settled" in rows
+    assert "const liveProseTextKeys=new Map()" in rows
+    assert "if(textKey&&liveProseTextKeys.has(textKey)) continue;" in rows
     assert "byKey.set(key,out.length)" in rows
     assert "out[index]=row.role==='tool'?_anchorSceneMergeToolRows(out[index],row):row" in rows
     assert "for(const row of rows)" in render
     assert "_anchorSceneNodeForRow(row,opts)" in render
     assert "blocks.querySelectorAll('[data-live-assistant=\"1\"]')" in live
     assert "assistant-segment-worklog-source" in live
+    assert "el.hidden=true" in live
+
+
+@pytest.mark.skipif(NODE is None, reason="node is required for anchor row normalization tests")
+def test_live_anchor_scene_dedupes_exact_duplicate_process_prose_only_live():
+    script = f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(ROOT / "static" / "ui.js"))}, 'utf8');
+function extractFunc(name){{
+  const start = src.indexOf('function ' + name);
+  if(start === -1) throw new Error(name + ' not found');
+  const params = src.indexOf('(', start);
+  let depth = 0, close = -1;
+  for(let i=params; i<src.length; i++){{
+    if(src[i] === '(') depth++;
+    else if(src[i] === ')'){{
+      depth--;
+      if(depth === 0){{ close = i; break; }}
+    }}
+  }}
+  const brace = src.indexOf('{{', close);
+  depth = 0;
+  for(let i=brace; i<src.length; i++){{
+    if(src[i] === '{{') depth++;
+    else if(src[i] === '}}'){{
+      depth--;
+      if(depth === 0) return src.slice(start, i + 1);
+    }}
+  }}
+  throw new Error(name + ' body did not close');
+}}
+function _anchorSceneToolRowLogicalKey(){{ return ''; }}
+function _anchorSceneMergeToolRows(a,b){{ return b; }}
+function _anchorSceneIsSettledSuccessfulCompression(){{ return false; }}
+eval(extractFunc('_anchorSceneRowsForRendering'));
+const scene = {{
+  activity_rows: [
+    {{role:'prose', local_id:'reasoning:291', text:'same process prose'}},
+    {{role:'prose', local_id:'interim:293', text:' same\\nprocess prose '}},
+    {{role:'thinking', local_id:'thinking:1', text:'same process prose'}},
+    {{role:'prose', local_id:'process:294', text:'new process prose'}}
+  ]
+}};
+const liveRows = _anchorSceneRowsForRendering(scene, {{settled:false}});
+const settledRows = _anchorSceneRowsForRendering(scene, {{settled:true}});
+console.log(JSON.stringify({{
+  live: liveRows.map(row => row.role + ':' + row.text.replace(/\\s+/g, ' ').trim()),
+  settled: settledRows.map(row => row.role + ':' + row.text.replace(/\\s+/g, ' ').trim())
+}}));
+"""
+    result = _run_node_script(script)
+
+    assert result["live"] == [
+        "prose:same process prose",
+        "thinking:same process prose",
+        "prose:new process prose",
+    ]
+    assert result["settled"] == [
+        "prose:same process prose",
+        "prose:same process prose",
+        "thinking:same process prose",
+        "prose:new process prose",
+    ]
 
 
 def test_live_anchor_scene_removes_legacy_interim_collapse_toggle():
@@ -752,6 +818,7 @@ def test_settled_anchor_scene_final_answer_does_not_fold_into_worklog_source():
         "if(m._activityBurstId!==undefined||m._liveSegmentSeq!==undefined) return true;"
     )
     assert "seg.classList.add('assistant-segment-worklog-source')" in render
+    assert "seg.hidden=true" in render
     assert "_renderSettledAnchorSceneForMessage(msg, seg, rawIdx)" in render
 
 
@@ -763,6 +830,7 @@ def test_settled_anchor_scene_hides_prior_process_segments_not_final_answer():
     assert "idx<rawIdx" in settled
     assert "node.classList.add('assistant-segment-worklog-source')" in settled
     assert "node.setAttribute('aria-hidden','true')" in settled
+    assert "node.hidden=true" in settled
     assert "turnDuration:message._turnDuration!==undefined&&message._turnDuration!==null?message._turnDuration:scene.turn_duration" in settled
     assert "turnDuration:opts&&opts.turnDuration" in group
     assert "data-turn-duration" in group


### PR DESCRIPTION
## Release v0.51.604 — live-stream worklog scroll/dedup + mobile session-switch scroll

Batch of 3 fix-class chat-screen correctness PRs (all fresh-cut from master, `--no-ff` merged, attribution preserved), plus 2 maintainer gate-fix commits.

### Included PRs
| PR | Author | Fix |
|---|---|---|
| #4778 | @franksong2702 | Guard live Compact Worklog scroll rebuilds — hold transcript height stable so the browser can't clamp an unpinned reader to the top mid-rebuild |
| #4777 | @franksong2702 | Dedupe duplicate live process prose in the Compact Worklog while streaming |
| #4780 | @jcarvine | Reset scroll state on a genuine session switch so mobile lands at the latest message (supersedes #4779) |

### Maintainer gate-fixes applied (Codex + Opus regression gate)
1. **#4778 — pinned-follower misclassification (Codex CORE, reproduced).** The scroll-rebuild guard predicate keyed on a raw `messagesEl.scrollTop > 0`, so a pinned reader transiently at `bottomDistance > 250` mid-render got flipped to unpinned and lost auto-follow. Changed the predicate to require an explicit non-follow signal (`_messageUserUnpinned || _scrollPinned === false`); updated the guard test to a genuine unpinned reader + added a pinned-large-growth regression.
2. **#4778 — deferred-rAF re-restore race (Opus).** If a reader re-pins between the guard engaging and its deferred `requestAnimationFrame` firing, the stale re-restore would yank them back off the bottom. Gated the re-restore on `_messageUserUnpinned` at rAF time; the `minHeight` release still always runs.

### Gate results
- **Codex** (GPT-5.5, high reasoning, direct reproduction): SHIP-WITH-FIXES → both fixes applied + verified.
- **Opus** (claude-opus-4-8): SHIP-WITH-FIXES (1) → applied + verified; confirmed un-hide coverage complete, #4777 dedup correctly live-only, #4780 precisely scoped.
- **Full suite:** 10207 passed, 9 skipped, 0 failed (`-p no:xdist`, ~8m12s).
- node -c clean on all touched JS; ruff forward-gate clean.

Closes #4778, closes #4777, closes #4780.
