### PR TITLE
fix(#4755): honor profile default workspace on fresh sessions

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -5536,6 +5536,7 @@ async function switchToWorkspace(path,name){
     }catch(e){if(typeof setStatus==='function')setStatus(t('switch_failed')+e.message);return;}
     if(!S.session)return;
   }
+  // Workspace mutation during a live turn would desync the active stream context.
   if(S.busy){
     showToast(t('workspace_busy_switch'));
     return;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -788,13 +788,10 @@ async function newSession(flash, options={}){
     _messagesTruncated=false;
     _oldestIdx=0;
     clearLiveToolCards();
-    // One-shot profile-switch workspace: applied to the first new session after a profile
-    // switch, then cleared.  Use a dedicated flag so S._profileDefaultWorkspace (the
-    // persistent boot/settings default) is not consumed and remains available for the
-    // blank-page display on all subsequent returns to the empty state (#823).
+    // One-shot profile-switch workspace wins first; otherwise prefer the profile default.
     const switchWs=S._profileSwitchWorkspace;
     S._profileSwitchWorkspace=null;
-    const inheritWs=switchWs||(S.session?S.session.workspace:null)||(S._profileDefaultWorkspace||null);
+    const inheritWs=switchWs||(S._profileDefaultWorkspace||null)||(S.session?S.session.workspace:null);
     const reqBody={
       workspace:inheritWs,
       profile:S.activeProfile||'default',

--- a/tests/test_issue4755_profile_default_workspace.py
+++ b/tests/test_issue4755_profile_default_workspace.py
@@ -1,0 +1,178 @@
+"""Behavior coverage for #4755 profile default workspace precedence."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+PANELS_JS = ROOT / "static" / "panels.js"
+NODE = shutil.which("node")
+
+node_test = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _extract_async_function(source: str, name: str) -> str:
+    marker = f"async function {name}("
+    start = source.find(marker)
+    assert start >= 0, f"{name}() function must exist"
+    brace = source.find("{", source.find(")", start))
+    assert brace > start, f"{name}() function body must start"
+    depth = 0
+    in_string = None
+    escaped = False
+    in_line_comment = False
+    in_block_comment = False
+    for idx in range(brace, len(source)):
+        ch = source[idx]
+        nxt = source[idx + 1] if idx + 1 < len(source) else ""
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+            continue
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment = False
+            continue
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == in_string:
+                in_string = None
+            continue
+        if ch == "/" and nxt == "/":
+            in_line_comment = True
+            continue
+        if ch == "/" and nxt == "*":
+            in_block_comment = True
+            continue
+        if ch in ("'", '"', "`"):
+            in_string = ch
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : idx + 1]
+    raise AssertionError(f"could not extract {name}()")
+
+
+def _run_node(script: str) -> dict:
+    result = subprocess.run(
+        [NODE, "-e", script],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    return json.loads(result.stdout)
+
+
+def _new_session_driver(session_workspace: str, default_workspace: str, switch_workspace: str | None) -> str:
+    new_session = _extract_async_function(SESSIONS_JS.read_text(encoding="utf-8"), "newSession")
+    return textwrap.dedent(
+        f"""
+        let captured=null;
+        var _newSessionInFlight=null;
+        var _messagesTruncated=false;
+        var _oldestIdx=0;
+        var _activeProject=null;
+        var NO_PROJECT_FILTER='__all__';
+        var _sessionSourceFilter='webui';
+        var S={{
+          session:{{session_id:'previous-session',workspace:{json.dumps(session_workspace)}}},
+          _profileDefaultWorkspace:{json.dumps(default_workspace)},
+          _profileSwitchWorkspace:{json.dumps(switch_workspace)},
+          activeProfile:'default',
+          toolCalls:[],
+        }};
+        global.window={{}};
+        global.document={{createElement:()=>({{dataset:{{}},appendChild:()=>{{}}}})}};
+        global.localStorage={{setItem:()=>{{}}}};
+        function $(id){{return null;}}
+        function _newSessionPendingText(){{return 'Creating';}}
+        function _setNewSessionPending(){{}}
+        function updateQueueBadge(){{}}
+        function clearLiveToolCards(){{}}
+        function api(path,opts){{
+          captured={{path,body:JSON.parse(opts.body)}};
+          return Promise.resolve({{session:{{session_id:'new-session',messages:[],workspace:captured.body.workspace}}}});
+        }}
+        function _rememberNewChatDraftSession(){{}}
+        function _setActiveSessionUrl(){{}}
+        function _setSessionViewedCount(){{}}
+        function updateSendBtn(){{}}
+        function setStatus(){{}}
+        function setComposerStatus(){{}}
+        function syncTopbar(){{}}
+        function renderMessages(){{}}
+        function loadDir(){{return Promise.resolve();}}
+        {new_session}
+        newSession().then(()=>{{
+          process.stdout.write(JSON.stringify({{captured,switchWorkspace:S._profileSwitchWorkspace}}));
+        }}).catch(err=>{{
+          console.error(err && err.stack || err);
+          process.exit(1);
+        }});
+        """
+    )
+
+
+@node_test
+def test_new_session_prefers_profile_default_over_current_session_workspace():
+    payload = _run_node(_new_session_driver(
+        session_workspace="/current-workspace",
+        default_workspace="/profile-default",
+        switch_workspace=None,
+    ))
+
+    assert payload["captured"]["path"] == "/api/session/new"
+    assert payload["captured"]["body"]["workspace"] == "/profile-default"
+    assert payload["captured"]["body"]["prev_session_id"] == "previous-session"
+
+
+@node_test
+def test_new_session_one_shot_switch_workspace_still_wins_and_clears():
+    payload = _run_node(_new_session_driver(
+        session_workspace="/current-workspace",
+        default_workspace="/profile-default",
+        switch_workspace="/explicit-switch",
+    ))
+
+    assert payload["captured"]["body"]["workspace"] == "/explicit-switch"
+    assert payload["switchWorkspace"] is None
+
+
+@node_test
+def test_busy_workspace_switch_returns_before_session_update():
+    switch_to_workspace = _extract_async_function(PANELS_JS.read_text(encoding="utf-8"), "switchToWorkspace")
+    script = textwrap.dedent(
+        f"""
+        const calls=[];
+        var S={{busy:true,session:{{session_id:'session-1',workspace:'/old',model:'gpt-5',model_provider:null}}}};
+        function t(key){{return key;}}
+        function showToast(message){{calls.push(['toast',message]);}}
+        function api(path,opts){{calls.push(['api',path]);return Promise.resolve({{}});}}
+        {switch_to_workspace}
+        switchToWorkspace('/new','New').then(()=>{{
+          process.stdout.write(JSON.stringify({{calls}}));
+        }}).catch(err=>{{
+          console.error(err && err.stack || err);
+          process.exit(1);
+        }});
+        """
+    )
+    payload = _run_node(script)
+
+    assert payload["calls"] == [["toast", "workspace_busy_switch"]]

--- a/tests/test_profile_default_workspace_823.py
+++ b/tests/test_profile_default_workspace_823.py
@@ -48,18 +48,18 @@ class TestProfileDefaultWorkspacePersistence:
         )
 
     def test_new_session_still_inherits_default_workspace(self):
-        """newSession must still pass a workspace to /api/session/new —
-        now via the _profileSwitchWorkspace → current session → _profileDefaultWorkspace chain."""
+        """newSession must still pass a workspace to /api/session/new,
+        now via the _profileSwitchWorkspace -> _profileDefaultWorkspace -> current session chain."""
         src = read('static/sessions.js')
         m = re.search(r'async function newSession\(.*?\n\}', src, re.DOTALL)
         assert m
         fn = m.group(0)
         # inheritWs must be computed and passed to /api/session/new
         assert 'inheritWs' in fn or 'inherit' in fn.lower(), (
-            "newSession must compute an inheritWs from switch/current/default workspace"
+            "newSession must compute an inheritWs from switch/default/current workspace"
         )
         assert '_profileDefaultWorkspace' in fn, (
-            "newSession must fall through to S._profileDefaultWorkspace as last resort"
+            "newSession must prefer S._profileDefaultWorkspace before current session workspace"
         )
 
 

--- a/tests/test_workspace_blank_page_fix.py
+++ b/tests/test_workspace_blank_page_fix.py
@@ -129,6 +129,22 @@ class TestWorkspaceSwitcherBlankPage:
             "switchToWorkspace must call /api/session/new when S.session is null"
         )
 
+    def test_switch_to_workspace_keeps_busy_guard_after_blank_page_create(self):
+        src = read('static/panels.js')
+        start = src.find('async function switchToWorkspace(')
+        assert start != -1, "switchToWorkspace not found"
+        fn = src[start:src.find('async function toggleWorktreePanel', start)]
+        assert "t('workspace_busy_switch')" in fn, (
+            "switchToWorkspace must keep the busy-session workspace switch toast"
+        )
+        blank_create = fn.index("api('/api/session/new'")
+        busy_guard = fn.index('if(S.busy)')
+        update_call = fn.index("api('/api/session/update'")
+        assert blank_create < busy_guard < update_call, (
+            "switchToWorkspace must auto-create blank-page sessions before the busy guard, "
+            "then return before workspace update while busy"
+        )
+
     def test_prompt_workspace_path_auto_creates_session(self):
         src = read('static/panels.js')
         m = re.search(r'async function promptWorkspacePath\(\)\{.*?\n\}', src, re.DOTALL)

--- a/tests/test_workspace_blank_page_fix.py
+++ b/tests/test_workspace_blank_page_fix.py
@@ -131,9 +131,9 @@ class TestWorkspaceSwitcherBlankPage:
 
     def test_switch_to_workspace_keeps_busy_guard_after_blank_page_create(self):
         src = read('static/panels.js')
-        start = src.find('async function switchToWorkspace(')
-        assert start != -1, "switchToWorkspace not found"
-        fn = src[start:src.find('async function toggleWorktreePanel', start)]
+        m = re.search(r'async function switchToWorkspace\(path,name\)\{.*?\n\}', src, re.DOTALL)
+        assert m, "switchToWorkspace not found"
+        fn = m.group(0)
         assert "t('workspace_busy_switch')" in fn, (
             "switchToWorkspace must keep the busy-session workspace switch toast"
         )


### PR DESCRIPTION
## Thinking Path

- The issue mixes one verified bug with one open UX decision, so the safe contribution is to fix the wrong fresh-session workspace precedence and keep the busy-session branch explicit instead of inventing new queued state.
- `newSession()` already has every signal it needs: one-shot override, profile default, then current-session fallback. The only bug is the current ordering.
- Blank-page workspace creation already works, so the regression surface is narrow: reorder the new-session payload, preserve the blank-page path, and lock the busy-session rule in tests.

## What Changed

- `static/sessions.js`: reordered fresh-session workspace precedence so the profile default wins over the current session workspace unless a one-shot profile-switch workspace was explicitly set.
- `static/panels.js`: kept the existing blank-page auto-create flow and made the busy-session workspace block explicit.
- `tests/test_profile_default_workspace_823.py`, `tests/test_workspace_blank_page_fix.py`, and `tests/test_issue4755_profile_default_workspace.py`: covered the corrected precedence, the one-shot override, the blank-page path, and the intentional busy-session block.

## Why It Matters

New chats now land in the workspace the active profile actually configured, instead of inheriting whichever workspace happened to be open in the previous chat. The mid-turn branch also becomes an explicit, tested contract instead of an ambiguous side effect.

## Verification

```text
pytest tests/test_profile_default_workspace_823.py tests/test_workspace_blank_page_fix.py tests/test_issue4755_profile_default_workspace.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #4755.

## Model Used

GPT 5.5 via Codex CLI
