### PR TITLE
Fix WebUI async delegation completion delivery

### DIFF
--- a/api/background_process.py
+++ b/api/background_process.py
@@ -48,6 +48,11 @@ import time
 import uuid
 from typing import Any, Optional
 
+from api.process_event_utils import (
+    completion_delivery_id,
+    mark_async_delegation_record_consumed,
+)
+
 logger = logging.getLogger(__name__)
 
 _DRAIN_THREAD: Optional[threading.Thread] = None
@@ -441,9 +446,9 @@ def _build_payload(evt: dict, session_id: str) -> dict:
       ``(session_id, event_id)`` to dedupe across reconnects.
     """
     # ProcessRegistry completion events use the field name ``session_id`` for
-    # the process id. Alias it locally before exposing it as payload ``task_id``
-    # to avoid confusing that wire-format name with the WebUI session id.
-    process_id = str(evt.get("session_id") or "")
+    # the process id. Async delegation completions carry ``delegation_id``
+    # instead; expose either stable delivery id as payload ``task_id``.
+    process_id = completion_delivery_id(evt)
     payload: dict[str, Any] = {
         "session_id": str(session_id),
         "task_id": process_id,
@@ -787,7 +792,7 @@ def _process_one(evt: dict) -> None:
     except Exception:
         _process_registry = None
 
-    process_id = str(evt.get("session_id") or "")
+    process_id = completion_delivery_id(evt)
     session_key = str(evt.get("session_key") or "")
     # Root-cause fix (t_0f447014): the notify_on_complete completion event
     # enqueued by ProcessRegistry._move_to_finished() carries NO "session_key"
@@ -933,6 +938,8 @@ def _process_one(evt: dict) -> None:
                 # here cannot cause a double-fire — the atomic claim in
                 # ``claim_deferred_wakeups`` guarantees exactly one delivery.
                 record_deferred_wakeup(session_id, process_id, wakeup_prompt)
+                if evt.get("type") == "async_delegation":
+                    mark_async_delegation_record_consumed(process_id)
                 logger.debug(
                     "server-side wakeup deferred: turn active for session %s "
                     "(persisted for turn-teardown idle-hook redelivery)",
@@ -950,6 +957,8 @@ def _process_one(evt: dict) -> None:
                 _start_server_side_wakeup_turn(
                     session_id, wakeup_prompt, process_id=process_id
                 )
+                if evt.get("type") == "async_delegation":
+                    mark_async_delegation_record_consumed(process_id)
     except Exception:
         logger.warning(
             "server-side wakeup dispatch failed for session %s", session_id, exc_info=True

--- a/api/process_event_utils.py
+++ b/api/process_event_utils.py
@@ -1,0 +1,53 @@
+"""Shared helpers for WebUI completion/delegation delivery."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def completion_delivery_id(evt: Any) -> str:
+    """Return the stable WebUI delivery/dedupe id for a completion event.
+
+    Terminal background-process events use ``session_id`` for the process id.
+    Async ``delegate_task`` completions carry ``delegation_id`` instead, so both
+    WebUI delivery paths must key those events by ``delegation_id``.
+    """
+    if not isinstance(evt, dict):
+        return ""
+    if evt.get("type") == "async_delegation":
+        return str(evt.get("delegation_id") or "").strip()
+    return str(evt.get("session_id") or "").strip()
+
+
+def mark_async_delegation_record_consumed(delegation_id: str) -> bool:
+    """Best-effort marker for Hermes async-delegation recovery records.
+
+    Newer Hermes Agent builds expose
+    ``tools.async_delegation.mark_async_delegation_consumed`` so recovery
+    sweeps do not re-inject a delegation result that WebUI already delivered.
+    WebUI must not hard-require that API while mixed deployments are common, so
+    absence or failure is a safe no-op.
+    """
+    deleg_id = str(delegation_id or "").strip()
+    if not deleg_id:
+        return False
+    try:
+        from tools.async_delegation import mark_async_delegation_consumed
+    except Exception:
+        logger.debug(
+            "Async delegation consumed marker unavailable; skipping record marker",
+            exc_info=True,
+        )
+        return False
+    try:
+        mark_async_delegation_consumed(deleg_id)
+        return True
+    except Exception:
+        logger.debug(
+            "Failed to mark async delegation record consumed for %s",
+            deleg_id,
+            exc_info=True,
+        )
+        return False

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -40,6 +40,7 @@ from api.config import (
     parse_reasoning_effort,
     coerce_reasoning_effort_for_model,
     _main_model_request_overrides,
+    PROCESS_SESSION_INDEX, PROCESS_SESSION_INDEX_LOCK,
 )
 from api.helpers import redact_session_data, _redact_text
 from api.compression_anchor import is_context_compression_marker, visible_messages_for_anchor
@@ -54,6 +55,10 @@ from api.models import (
     reconciled_state_db_messages_for_session,
 )
 from api.session_ops import mark_session_title_generated, session_has_manual_title
+from api.process_event_utils import (
+    completion_delivery_id,
+    mark_async_delegation_record_consumed,
+)
 
 
 def _session_payload_with_full_messages(session, *, tool_calls=None):
@@ -1659,6 +1664,14 @@ def _format_process_notification(evt: dict) -> str:
     """Format a completed background process notification for agent input."""
     if not isinstance(evt, dict):
         return ''
+    if evt.get('type') == 'async_delegation':
+        try:
+            from tools.process_registry import format_process_notification
+
+            return format_process_notification(evt) or ''
+        except Exception:
+            logger.debug("Failed to format async delegation notification", exc_info=True)
+            return ''
     if evt.get('type') != 'completion':
         return ''
     _sid = evt.get('session_id', '')
@@ -1681,6 +1694,26 @@ def _mark_process_completion_consumed(process_registry, process_id: str) -> None
             process_registry._completion_consumed.add(process_id)
     except Exception:
         logger.debug("Failed to mark process completion consumed", exc_info=True)
+
+
+def _completion_event_targets_webui_session(evt_session_key: str, session_id: str) -> bool:
+    """Return whether a completion event belongs to this WebUI session.
+
+    WebUI normally registers ``PROCESS_SESSION_INDEX[session_id] = session_id``.
+    Gateway/agent session keys can differ, so match the direct WebUI case first
+    and otherwise resolve through the same session-key index used by the
+    background wakeup path.
+    """
+    if not evt_session_key or not session_id:
+        return False
+    if evt_session_key == session_id:
+        return True
+    try:
+        with PROCESS_SESSION_INDEX_LOCK:
+            return PROCESS_SESSION_INDEX.get(evt_session_key) == session_id
+    except Exception:
+        logger.debug("Failed to resolve completion event session key", exc_info=True)
+        return False
 
 
 def _drain_webui_process_notifications(session_id: str) -> list[str]:
@@ -1716,17 +1749,20 @@ def _drain_webui_process_notifications(session_id: str) -> list[str]:
             logger.debug("Failed to drain process completion queue", exc_info=True)
             break
 
-        evt_sid = str(evt.get('session_id') or '') if isinstance(evt, dict) else ''
+        evt_sid = completion_delivery_id(evt) if isinstance(evt, dict) else ''
         if not evt_sid:
             skipped_events.append(evt)
             continue
         try:
             if process_registry.is_completion_consumed(evt_sid):
                 continue
-            proc = process_registry.get(evt_sid)
+            evt_session_key = str(evt.get('session_key') or '') if isinstance(evt, dict) else ''
+            if not evt_session_key:
+                proc = process_registry.get(evt_sid)
+                evt_session_key = str(getattr(proc, 'session_key', '') or '')
         except Exception:
-            proc = None
-        if getattr(proc, 'session_key', None) != session_id:
+            evt_session_key = ''
+        if not _completion_event_targets_webui_session(evt_session_key, session_id):
             skipped_events.append(evt)
             continue
 
@@ -1752,7 +1788,13 @@ def _drain_webui_process_notifications(session_id: str) -> list[str]:
         notification = _format_process_notification(evt)
         if notification:
             notifications.append(notification)
-            _mark_process_completion_consumed(process_registry, evt_sid)
+        # Matched but unformattable completions are consumed rather than
+        # replayed forever on later turns. Valid async_delegation events use the
+        # agent-side formatter above, so an empty notification here means the
+        # matched event is malformed/unsupported for this WebUI build.
+        _mark_process_completion_consumed(process_registry, evt_sid)
+        if isinstance(evt, dict) and evt.get('type') == 'async_delegation':
+            mark_async_delegation_record_consumed(evt_sid)
 
     for evt in skipped_events:
         try:

--- a/tests/test_async_delegation_webui_bridge.py
+++ b/tests/test_async_delegation_webui_bridge.py
@@ -1,0 +1,135 @@
+"""Regression coverage for async delegate_task completion routing beyond #4912.
+
+#4912 taught ``format_wakeup_prompt`` how to render ``async_delegation`` events.
+These tests cover the remaining WebUI bridge contract: route those events by
+``session_key``, dedupe by ``delegation_id``, and coordinate with the optional
+agent-side async-delegation consumed marker when available.
+"""
+from __future__ import annotations
+
+import queue
+import sys
+import time
+import types
+
+from api import background_process as bp
+from api import config as cfg
+from api import streaming
+
+
+class _NoopLock:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeProcessRegistry:
+    def __init__(self):
+        self.completion_queue = queue.Queue()
+        self._completion_consumed: set[str] = set()
+        self._lock = _NoopLock()
+
+    def is_completion_consumed(self, process_id: str) -> bool:
+        return process_id in self._completion_consumed
+
+    def get(self, process_id: str):
+        return None
+
+
+def _install_fake_process_registry(monkeypatch):
+    registry = _FakeProcessRegistry()
+
+    def _format(evt):
+        return f"[ASYNC DELEGATION BATCH COMPLETE — {evt['delegation_id']}]\nbackend summary"
+
+    fake_mod = types.ModuleType("tools.process_registry")
+    fake_mod.process_registry = registry
+    fake_mod.format_process_notification = _format
+    fake_pkg = sys.modules.get("tools") or types.ModuleType("tools")
+    monkeypatch.setitem(sys.modules, "tools", fake_pkg)
+    monkeypatch.setitem(sys.modules, "tools.process_registry", fake_mod)
+    return registry
+
+
+def _reset_wakeup_state() -> None:
+    cfg.PROCESS_SESSION_INDEX.clear()
+    cfg.PENDING_BG_TASK_COMPLETIONS.clear()
+    cfg.BG_TASK_COMPLETE_EVENTS_SEEN.clear()
+    cfg.DEFERRED_PROCESS_WAKEUPS.clear()
+
+
+def _async_delegation_event(**overrides):
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_test123",
+        "session_key": "webui-session-1",
+        "status": "completed",
+        "is_batch": True,
+        "results": [{"task_index": 0, "status": "completed", "summary": "backend summary"}],
+        "dispatched_at": time.time() - 2,
+        "completed_at": time.time(),
+    }
+    evt.update(overrides)
+    return evt
+
+
+def test_background_wakeup_routes_async_delegation_by_delegation_id(monkeypatch):
+    _reset_wakeup_state()
+    _install_fake_process_registry(monkeypatch)
+    cfg.PROCESS_SESSION_INDEX["webui-session-1"] = "webui-session-1"
+    started: list[tuple[str, str, str]] = []
+    emitted: list[tuple[str, dict]] = []
+    marked: list[str] = []
+
+    monkeypatch.setattr(bp, "_session_has_active_turn", lambda session_id: False)
+    monkeypatch.setattr(
+        bp,
+        "_start_server_side_wakeup_turn",
+        lambda session_id, prompt, *, process_id="": started.append((session_id, prompt, process_id)),
+    )
+    monkeypatch.setattr(
+        bp,
+        "_emit_bg_task_complete_events_coalesced",
+        lambda session_id, payload: emitted.append((session_id, payload)) or 1,
+    )
+    monkeypatch.setattr(bp, "mark_async_delegation_record_consumed", lambda deleg_id: marked.append(deleg_id) or True)
+
+    bp._process_one(_async_delegation_event())
+
+    assert started == [("webui-session-1", started[0][1], "deleg_test123")]
+    assert "ASYNC DELEGATION BATCH COMPLETE" in started[0][1]
+    assert emitted[0][1]["task_id"] == "deleg_test123"
+    assert cfg.BG_TASK_COMPLETE_EVENTS_SEEN["webui-session-1"] == {"deleg_test123"}
+    assert marked == ["deleg_test123"]
+
+
+def test_streaming_next_turn_drain_handles_async_delegation_event(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    marked: list[str] = []
+    monkeypatch.setattr(streaming, "mark_async_delegation_record_consumed", lambda deleg_id: marked.append(deleg_id) or True)
+
+    registry.completion_queue.put(_async_delegation_event())
+
+    notifications = streaming._drain_webui_process_notifications("webui-session-1")
+
+    assert len(notifications) == 1
+    assert "ASYNC DELEGATION BATCH COMPLETE" in notifications[0]
+    assert registry.is_completion_consumed("deleg_test123")
+    assert marked == ["deleg_test123"]
+
+
+def test_streaming_next_turn_drain_routes_via_process_session_index_mapping(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    cfg.PROCESS_SESSION_INDEX["gateway-session-key"] = "webui-session-1"
+    registry.completion_queue.put(_async_delegation_event(session_key="gateway-session-key"))
+
+    wrong_session_notifications = streaming._drain_webui_process_notifications("webui-session-2")
+    right_session_notifications = streaming._drain_webui_process_notifications("webui-session-1")
+
+    assert wrong_session_notifications == []
+    assert len(right_session_notifications) == 1
+    assert "ASYNC DELEGATION BATCH COMPLETE" in right_session_notifications[0]

--- a/tests/test_notify_on_complete_webui.py
+++ b/tests/test_notify_on_complete_webui.py
@@ -7,7 +7,9 @@ def test_webui_drains_only_matching_background_completion_events():
     assert "def _drain_webui_process_notifications(session_id: str)" in src
     assert "from tools.process_registry import process_registry" in src
     assert "proc = process_registry.get(evt_sid)" in src
-    assert "getattr(proc, 'session_key', None) != session_id" in src
+    assert "def _completion_event_targets_webui_session(evt_session_key: str, session_id: str)" in src
+    assert "PROCESS_SESSION_INDEX.get(evt_session_key) == session_id" in src
+    assert "not _completion_event_targets_webui_session(evt_session_key, session_id)" in src
     assert "skipped_events.append(evt)" in src
     assert "completion_queue.put(evt)" in src
 


### PR DESCRIPTION
## Summary

This PR has been rebased on current `master` after the minimal #4912 / v0.51.652 WebUI fix landed.

#4912 already handles the core background wakeup formatting path by delegating `async_delegation` events to the agent-side `format_process_notification`. This PR is now narrowed to the remaining bridge contract beyond that minimal delivery fix:

- Use `delegation_id` as the stable WebUI delivery/dedupe id for `async_delegation` events.
- Keep terminal process completions keyed by their existing `session_id` process id.
- Route next-turn drain events by `session_key`, including non-identity `session_key -> session_id` mappings through `PROCESS_SESSION_INDEX`.
- Allow next-turn drain to format `async_delegation` events through the canonical agent formatter.
- Best-effort call `mark_async_delegation_consumed(delegation_id)` when newer Hermes Agent builds expose it, without hard-requiring the companion agent PR on older installations.
- Keep matched-but-unformattable events consumed rather than replaying them forever on later turns.

## What changed after #4912

Removed the broader fallback formatting work from this PR. WebUI now relies on the canonical agent formatter for async-delegation text, matching the #4912 direction.

The remaining delta is focused on dedupe/routing/recovery coordination:

- `api/process_event_utils.py`
  - `completion_delivery_id(evt)`
  - `mark_async_delegation_record_consumed(delegation_id)`
- `api/background_process.py`
  - background wakeup path uses `delegation_id` for async-delegation delivery ids
  - optional consumed marker is called after deferred/started WebUI delivery
- `api/streaming.py`
  - next-turn drain handles `async_delegation`
  - direct WebUI session match plus `PROCESS_SESSION_INDEX` fallback routing
  - shared completion consumed marker remains the cross-path dedupe key

## Validation

```text
python -m pytest tests/test_async_delegation_webui_bridge.py -q -o 'addopts='
3 passed

python -m pytest tests/test_background_process_wakeup_format.py -q -o 'addopts='
10 passed

python -m pytest \
  tests/test_async_delegation_webui_bridge.py \
  tests/test_background_process_wakeup_format.py \
  tests/test_notify_on_complete_webui.py \
  tests/test_background_tasks.py \
  tests/test_issue856_background_completion_unread.py \
  -q -o 'addopts=' -W "ignore:'audioop' is deprecated and slated for removal in Python 3.13:DeprecationWarning:discord.player"
45 passed

./scripts/test.sh tests/test_async_delegation_webui_bridge.py tests/test_background_process_wakeup_format.py tests/test_notify_on_complete_webui.py
17 passed

git diff --check OK
compileall OK
ruff on new/updated tests + helper OK
static added-lines scan clean
```

## Related

- Builds on the minimal WebUI delivery fix from #4912 / v0.51.652.
- Coordinates best-effort with NousResearch/hermes-agent#51577 when that optional consumed-marker API is available.
- Addresses the broader async delegation WebUI delivery/dedupe path for #4691.
