### PR TITLE
Release v0.51.612 — background-tab notifications + profile default workspace (#4753, #4755)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## [Unreleased]
 
+## [v0.51.612] — 2026-06-23 — Release VS (background-tab notifications + profile default workspace on fresh sessions)
+
+### Fixed
+
+- **Background (visible-but-unfocused) desktop-app tabs now fire OS notifications without closing their live stream.** The browser-notification gate previously used only `document.hidden` as the background signal, so a desktop-host tab that was visible but unfocused either missed notifications or, if it spoofed hidden state, tore down its SSE stream. A desktop-owned notification-only background flag now drives the notification gate; all `document.hidden`-based stream/visibility logic is unchanged. Thanks @rodboev. (#4753)
+- **New sessions now land on the profile's default workspace instead of inheriting the current session's workspace.** Fresh-session workspace precedence is corrected to one-shot override → profile default → current-session fallback, so a configured profile default wins on New Chat (when no default is set, behavior is unchanged). The blank-page workspace-creation path and the busy-session rule are preserved. Thanks @rodboev. (#4755)
+
 ## [v0.51.610] — 2026-06-23 — Release VQ (read-only access to escape-target symlinks in the workspace tree)
 
 ### Added

--- a/static/messages.js
+++ b/static/messages.js
@@ -56,6 +56,23 @@ function _isDocumentVisibleAndFocused() {
   return true;
 }
 
+let _desktopBackgroundedForNotifications=false;
+// Desktop shells can background a visible document; keep that signal notification-only.
+if(typeof window!=='undefined'){
+  window.__hermesSetBackgrounded=(value)=>{
+    _desktopBackgroundedForNotifications=!!value;
+    if(_desktopBackgroundedForNotifications){
+      for(const k in _STREAM_NOTIFICATION_BACKGROUND){
+        const e=_STREAM_NOTIFICATION_BACKGROUND[k];
+        if(e) e.wasBackgrounded=true;
+      }
+    }
+  };
+}
+function _isBackgroundedForBrowserNotification(){
+  return !!(typeof document!=='undefined'&&document.hidden)||_desktopBackgroundedForNotifications;
+}
+
 function _isSessionCurrentPane(sid) {
   if(!sid || !S.session || S.session.session_id!==sid) return false;
   // During session switching, S.session still points at the previous row until
@@ -1521,6 +1538,7 @@ async function send(){
 }
 
 const LIVE_STREAMS={};
+const _STREAM_NOTIFICATION_BACKGROUND={};
 
 // #4416: track whether the tab was hidden at ANY point during a live stream, so
 // the response-complete notification fires for a backgrounded tab even when
@@ -1549,6 +1567,22 @@ function _clearStreamHidden(sid, streamId){
   if(!e) return;
   if(streamId&&e.streamId&&e.streamId!==streamId) return;
   delete _STREAM_WAS_HIDDEN[sid];
+}
+function _clearStreamNotificationBackground(sid, streamId){
+  if(!sid) return;
+  const e=_STREAM_NOTIFICATION_BACKGROUND[sid];
+  if(!e) return;
+  if(streamId&&e.streamId&&e.streamId!==streamId) return;
+  delete _STREAM_NOTIFICATION_BACKGROUND[sid];
+}
+function _shouldForceCompletionNotification(sid, streamId){
+  const hiddenEntry=_STREAM_WAS_HIDDEN[sid];
+  const backgroundEntry=_STREAM_NOTIFICATION_BACKGROUND[sid];
+  const wasHidden=!!(hiddenEntry&&hiddenEntry.wasHidden);
+  const wasBackgrounded=!!(backgroundEntry&&backgroundEntry.wasBackgrounded);
+  _clearStreamHidden(sid, streamId);
+  _clearStreamNotificationBackground(sid, streamId);
+  return wasHidden||wasBackgrounded;
 }
 
 function closeLiveStream(sessionId, streamId, source){
@@ -1627,6 +1661,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const _keep=reconnecting&&_prev&&_prev.streamId===streamId;
     if(!_keep){
       _STREAM_WAS_HIDDEN[activeSid]={streamId,wasHidden:(typeof document!=='undefined'&&!!document.hidden)};
+    }
+    const _prevBackground=_STREAM_NOTIFICATION_BACKGROUND[activeSid];
+    const _keepBackground=reconnecting&&_prevBackground&&_prevBackground.streamId===streamId;
+    if(!_keepBackground){
+      _STREAM_NOTIFICATION_BACKGROUND[activeSid]={streamId,wasBackgrounded:_desktopBackgroundedForNotifications};
     }
   }
   if(!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[...uploaded],toolCalls:[]};
@@ -1898,6 +1937,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
     _clearOwnerInflightState();
     _clearStreamHidden(activeSid, streamId);  // #4416: terminal path, drop hidden tracker
+    _clearStreamNotificationBackground(activeSid, streamId);
     _flushReasoningToAnchor();
     _scheduleAnchorRegistryCleanup();
     _clearApprovalForOwner();
@@ -4414,10 +4454,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         // delivers late — after the user returns and document.hidden is false).
         // If the user watched the whole stream, _wasEverHidden stays false and
         // the notification is suppressed (matches Slack/Discord/Gmail/Claude).
-        const _hiddenEntry=_STREAM_WAS_HIDDEN[activeSid];
-        const _wasEverHidden=!!(_hiddenEntry&&_hiddenEntry.wasHidden);
-        _clearStreamHidden(activeSid, streamId);
-        sendBrowserNotification('Response complete',assistantText?assistantText.slice(0,100):'Task finished',{forceHidden:_wasEverHidden,sid:activeSid});
+        const _wasEverBackgrounded=_shouldForceCompletionNotification(activeSid, streamId);
+        sendBrowserNotification('Response complete',assistantText?assistantText.slice(0,100):'Task finished',{forceHidden:_wasEverBackgrounded,sid:activeSid});
       };
       if(_shouldUseStreamFade()&&assistantBody){
         _cancelAnimationFramePendingStreamRender();
@@ -4583,6 +4621,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       try{if(source&&source.readyState!==2)source.close();}catch(_){ }
       _clearOwnerInflightState();
       _clearStreamHidden(activeSid, streamId);  // #4416: terminal path, drop hidden tracker
+      _clearStreamNotificationBackground(activeSid, streamId);
       _clearApprovalForOwner();
       _clearClarifyForOwner('terminal');
       let d={};
@@ -4760,6 +4799,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       try{if(source&&source.readyState!==2)source.close();}catch(_){ }
       _clearOwnerInflightState();
       _clearStreamHidden(activeSid, streamId);  // #4416: terminal path, drop hidden tracker
+      _clearStreamNotificationBackground(activeSid, streamId);
       _clearApprovalForOwner();
       _clearClarifyForOwner('cancelled');
       let _cancelData={};
@@ -6307,7 +6347,7 @@ function sendBrowserNotification(title,body,options={}){
   // explicit "Send test" override); only the visibility gate is bypassed.
   const forceHidden=!!(options&&options.forceHidden);
   if(!force&&!window._notificationsEnabled) return;
-  if(!force&&!forceHidden&&!document.hidden) return;
+  if(!force&&!forceHidden&&!_isBackgroundedForBrowserNotification()) return;
   if(!('Notification' in window)) return;
   if(Notification.permission==='granted'){
     _showPwaNotification(title,body,options).catch(()=>{try{new Notification(title||assistantDisplayName(),_notificationOptions(body,options));}catch(_err){}});

--- a/static/panels.js
+++ b/static/panels.js
@@ -5536,6 +5536,7 @@ async function switchToWorkspace(path,name){
     }catch(e){if(typeof setStatus==='function')setStatus(t('switch_failed')+e.message);return;}
     if(!S.session)return;
   }
+  // Workspace mutation during a live turn would desync the active stream context.
   if(S.busy){
     showToast(t('workspace_busy_switch'));
     return;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -788,13 +788,10 @@ async function newSession(flash, options={}){
     _messagesTruncated=false;
     _oldestIdx=0;
     clearLiveToolCards();
-    // One-shot profile-switch workspace: applied to the first new session after a profile
-    // switch, then cleared.  Use a dedicated flag so S._profileDefaultWorkspace (the
-    // persistent boot/settings default) is not consumed and remains available for the
-    // blank-page display on all subsequent returns to the empty state (#823).
+    // One-shot profile-switch workspace wins first; otherwise prefer the profile default.
     const switchWs=S._profileSwitchWorkspace;
     S._profileSwitchWorkspace=null;
-    const inheritWs=switchWs||(S.session?S.session.workspace:null)||(S._profileDefaultWorkspace||null);
+    const inheritWs=switchWs||(S._profileDefaultWorkspace||null)||(S.session?S.session.workspace:null);
     const reqBody={
       workspace:inheritWs,
       profile:S.activeProfile||'default',

--- a/tests/test_issue4753_desktop_background_notifications.py
+++ b/tests/test_issue4753_desktop_background_notifications.py
@@ -1,0 +1,187 @@
+"""Behavioral coverage for desktop-backgrounded notification delivery (#4753)."""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_SRC = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _extract_function(source: str, name: str) -> str:
+    start = source.index(f"function {name}(")
+    body_start = source.index("){", start) + 1
+    depth = 0
+    for idx in range(body_start, len(source)):
+        char = source[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : idx + 1]
+    raise AssertionError(f"{name} function body did not close")
+
+
+def _notification_contract_source() -> str:
+    start = MESSAGES_SRC.index("let _desktopBackgroundedForNotifications=false;")
+    end = MESSAGES_SRC.index("function _isSessionCurrentPane", start)
+    tracker_start = MESSAGES_SRC.index("const _STREAM_NOTIFICATION_BACKGROUND={};")
+    tracker_end = MESSAGES_SRC.index("\n", tracker_start)
+    send = _extract_function(MESSAGES_SRC, "sendBrowserNotification")
+    return MESSAGES_SRC[start:end] + "\n" + MESSAGES_SRC[tracker_start:tracker_end] + "\n" + send
+
+
+def _background_history_contract_source() -> str:
+    notification_start = MESSAGES_SRC.index("let _desktopBackgroundedForNotifications=false;")
+    notification_end = MESSAGES_SRC.index("function _isSessionCurrentPane", notification_start)
+    tracker_start = MESSAGES_SRC.index("const LIVE_STREAMS={};")
+    tracker_end = MESSAGES_SRC.index("function closeLiveStream", tracker_start)
+    return (
+        MESSAGES_SRC[notification_start:notification_end]
+        + "\n"
+        + MESSAGES_SRC[tracker_start:tracker_end]
+    )
+
+
+def _run_notification_case(*, document_hidden: bool, desktop_backgrounded: bool = False, options=None):
+    payload = {
+        "documentHidden": document_hidden,
+        "desktopBackgrounded": desktop_backgrounded,
+        "options": options or {},
+    }
+    script = (
+        "const source = " + json.dumps(_notification_contract_source()) + ";\n"
+        + "const params = " + json.dumps(payload) + ";\n"
+        + r"""
+const vm = require('vm');
+const shown = [];
+const direct = [];
+
+function Notification(title, options) {
+  direct.push({ title, options });
+}
+Notification.permission = 'granted';
+
+const context = {
+  document: { hidden: params.documentHidden },
+  window: { _notificationsEnabled: true },
+  Notification,
+  assistantDisplayName: () => 'Hermes',
+  _notificationOptions: (body, options) => ({ body, tag: options && options.sid ? options.sid : '' }),
+  _showPwaNotification: (title, body, options) => {
+    shown.push({ title, body, options });
+    return Promise.resolve();
+  },
+};
+context.window.Notification = Notification;
+
+vm.createContext(context);
+vm.runInContext(source, context);
+context.window.__hermesSetBackgrounded(params.desktopBackgrounded);
+vm.runInContext(
+  "sendBrowserNotification('Response complete','Task finished'," + JSON.stringify(params.options) + ");",
+  context
+);
+
+console.log(JSON.stringify({
+  shown,
+  direct,
+  documentHidden: context.document.hidden,
+  setterType: typeof context.window.__hermesSetBackgrounded,
+}));
+"""
+    )
+    temp = tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False, encoding="utf-8")
+    temp.write(script)
+    temp.close()
+    try:
+        result = subprocess.run([NODE, temp.name], capture_output=True, text=True, timeout=30)
+        if result.returncode != 0:
+            raise RuntimeError(f"node failed: {result.stderr}")
+        return json.loads(result.stdout.strip().splitlines()[-1])
+    finally:
+        os.unlink(temp.name)
+
+
+def test_visible_desktop_backgrounded_tab_notifies_without_page_visibility_hidden():
+    result = _run_notification_case(document_hidden=False, desktop_backgrounded=True)
+
+    assert result["setterType"] == "function"
+    assert result["documentHidden"] is False
+    assert len(result["shown"]) == 1
+    assert result["shown"][0]["title"] == "Response complete"
+
+
+def test_visible_foreground_tab_stays_silent_without_force():
+    result = _run_notification_case(document_hidden=False, desktop_backgrounded=False)
+
+    assert result["shown"] == []
+    assert result["direct"] == []
+
+
+def test_real_hidden_tab_still_notifies_without_desktop_background_flag():
+    result = _run_notification_case(document_hidden=True, desktop_backgrounded=False)
+
+    assert len(result["shown"]) == 1
+    assert result["shown"][0]["body"] == "Task finished"
+
+
+def test_force_hidden_still_notifies_visible_documents():
+    result = _run_notification_case(
+        document_hidden=False,
+        desktop_backgrounded=False,
+        options={"forceHidden": True},
+    )
+
+    assert len(result["shown"]) == 1
+
+
+def test_late_done_still_notifies_after_desktop_backgrounded_tab_returns_foreground():
+    script = (
+        "const source = " + json.dumps(_background_history_contract_source()) + ";\n"
+        + r"""
+const vm = require('vm');
+const context = {
+  document: {
+    hidden: false,
+    addEventListener: () => {},
+  },
+  window: {},
+};
+vm.createContext(context);
+vm.runInContext(source, context);
+vm.runInContext(
+  "_STREAM_WAS_HIDDEN['session-1']={streamId:'stream-1',wasHidden:false};" +
+  "_STREAM_NOTIFICATION_BACKGROUND['session-1']={streamId:'stream-1',wasBackgrounded:false};",
+  context
+);
+context.window.__hermesSetBackgrounded(true);
+context.window.__hermesSetBackgrounded(false);
+const first = vm.runInContext("_shouldForceCompletionNotification('session-1','stream-1')", context);
+const second = vm.runInContext("_shouldForceCompletionNotification('session-1','stream-1')", context);
+console.log(JSON.stringify({ first, second }));
+"""
+    )
+    temp = tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False, encoding="utf-8")
+    temp.write(script)
+    temp.close()
+    try:
+        result = subprocess.run([NODE, temp.name], capture_output=True, text=True, timeout=30)
+        if result.returncode != 0:
+            raise RuntimeError(f"node failed: {result.stderr}")
+        payload = json.loads(result.stdout.strip().splitlines()[-1])
+    finally:
+        os.unlink(temp.name)
+
+    assert payload["first"] is True
+    assert payload["second"] is False

--- a/tests/test_issue4755_profile_default_workspace.py
+++ b/tests/test_issue4755_profile_default_workspace.py
@@ -1,0 +1,178 @@
+"""Behavior coverage for #4755 profile default workspace precedence."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+PANELS_JS = ROOT / "static" / "panels.js"
+NODE = shutil.which("node")
+
+node_test = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _extract_async_function(source: str, name: str) -> str:
+    marker = f"async function {name}("
+    start = source.find(marker)
+    assert start >= 0, f"{name}() function must exist"
+    brace = source.find("{", source.find(")", start))
+    assert brace > start, f"{name}() function body must start"
+    depth = 0
+    in_string = None
+    escaped = False
+    in_line_comment = False
+    in_block_comment = False
+    for idx in range(brace, len(source)):
+        ch = source[idx]
+        nxt = source[idx + 1] if idx + 1 < len(source) else ""
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+            continue
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment = False
+            continue
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == in_string:
+                in_string = None
+            continue
+        if ch == "/" and nxt == "/":
+            in_line_comment = True
+            continue
+        if ch == "/" and nxt == "*":
+            in_block_comment = True
+            continue
+        if ch in ("'", '"', "`"):
+            in_string = ch
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : idx + 1]
+    raise AssertionError(f"could not extract {name}()")
+
+
+def _run_node(script: str) -> dict:
+    result = subprocess.run(
+        [NODE, "-e", script],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    return json.loads(result.stdout)
+
+
+def _new_session_driver(session_workspace: str, default_workspace: str, switch_workspace: str | None) -> str:
+    new_session = _extract_async_function(SESSIONS_JS.read_text(encoding="utf-8"), "newSession")
+    return textwrap.dedent(
+        f"""
+        let captured=null;
+        var _newSessionInFlight=null;
+        var _messagesTruncated=false;
+        var _oldestIdx=0;
+        var _activeProject=null;
+        var NO_PROJECT_FILTER='__all__';
+        var _sessionSourceFilter='webui';
+        var S={{
+          session:{{session_id:'previous-session',workspace:{json.dumps(session_workspace)}}},
+          _profileDefaultWorkspace:{json.dumps(default_workspace)},
+          _profileSwitchWorkspace:{json.dumps(switch_workspace)},
+          activeProfile:'default',
+          toolCalls:[],
+        }};
+        global.window={{}};
+        global.document={{createElement:()=>({{dataset:{{}},appendChild:()=>{{}}}})}};
+        global.localStorage={{setItem:()=>{{}}}};
+        function $(id){{return null;}}
+        function _newSessionPendingText(){{return 'Creating';}}
+        function _setNewSessionPending(){{}}
+        function updateQueueBadge(){{}}
+        function clearLiveToolCards(){{}}
+        function api(path,opts){{
+          captured={{path,body:JSON.parse(opts.body)}};
+          return Promise.resolve({{session:{{session_id:'new-session',messages:[],workspace:captured.body.workspace}}}});
+        }}
+        function _rememberNewChatDraftSession(){{}}
+        function _setActiveSessionUrl(){{}}
+        function _setSessionViewedCount(){{}}
+        function updateSendBtn(){{}}
+        function setStatus(){{}}
+        function setComposerStatus(){{}}
+        function syncTopbar(){{}}
+        function renderMessages(){{}}
+        function loadDir(){{return Promise.resolve();}}
+        {new_session}
+        newSession().then(()=>{{
+          process.stdout.write(JSON.stringify({{captured,switchWorkspace:S._profileSwitchWorkspace}}));
+        }}).catch(err=>{{
+          console.error(err && err.stack || err);
+          process.exit(1);
+        }});
+        """
+    )
+
+
+@node_test
+def test_new_session_prefers_profile_default_over_current_session_workspace():
+    payload = _run_node(_new_session_driver(
+        session_workspace="/current-workspace",
+        default_workspace="/profile-default",
+        switch_workspace=None,
+    ))
+
+    assert payload["captured"]["path"] == "/api/session/new"
+    assert payload["captured"]["body"]["workspace"] == "/profile-default"
+    assert payload["captured"]["body"]["prev_session_id"] == "previous-session"
+
+
+@node_test
+def test_new_session_one_shot_switch_workspace_still_wins_and_clears():
+    payload = _run_node(_new_session_driver(
+        session_workspace="/current-workspace",
+        default_workspace="/profile-default",
+        switch_workspace="/explicit-switch",
+    ))
+
+    assert payload["captured"]["body"]["workspace"] == "/explicit-switch"
+    assert payload["switchWorkspace"] is None
+
+
+@node_test
+def test_busy_workspace_switch_returns_before_session_update():
+    switch_to_workspace = _extract_async_function(PANELS_JS.read_text(encoding="utf-8"), "switchToWorkspace")
+    script = textwrap.dedent(
+        f"""
+        const calls=[];
+        var S={{busy:true,session:{{session_id:'session-1',workspace:'/old',model:'gpt-5',model_provider:null}}}};
+        function t(key){{return key;}}
+        function showToast(message){{calls.push(['toast',message]);}}
+        function api(path,opts){{calls.push(['api',path]);return Promise.resolve({{}});}}
+        {switch_to_workspace}
+        switchToWorkspace('/new','New').then(()=>{{
+          process.stdout.write(JSON.stringify({{calls}}));
+        }}).catch(err=>{{
+          console.error(err && err.stack || err);
+          process.exit(1);
+        }});
+        """
+    )
+    payload = _run_node(script)
+
+    assert payload["calls"] == [["toast", "workspace_busy_switch"]]

--- a/tests/test_profile_default_workspace_823.py
+++ b/tests/test_profile_default_workspace_823.py
@@ -48,18 +48,18 @@ class TestProfileDefaultWorkspacePersistence:
         )
 
     def test_new_session_still_inherits_default_workspace(self):
-        """newSession must still pass a workspace to /api/session/new —
-        now via the _profileSwitchWorkspace → current session → _profileDefaultWorkspace chain."""
+        """newSession must still pass a workspace to /api/session/new,
+        now via the _profileSwitchWorkspace -> _profileDefaultWorkspace -> current session chain."""
         src = read('static/sessions.js')
         m = re.search(r'async function newSession\(.*?\n\}', src, re.DOTALL)
         assert m
         fn = m.group(0)
         # inheritWs must be computed and passed to /api/session/new
         assert 'inheritWs' in fn or 'inherit' in fn.lower(), (
-            "newSession must compute an inheritWs from switch/current/default workspace"
+            "newSession must compute an inheritWs from switch/default/current workspace"
         )
         assert '_profileDefaultWorkspace' in fn, (
-            "newSession must fall through to S._profileDefaultWorkspace as last resort"
+            "newSession must prefer S._profileDefaultWorkspace before current session workspace"
         )
 
 

--- a/tests/test_pwa_notification_controls.py
+++ b/tests/test_pwa_notification_controls.py
@@ -10,6 +10,18 @@ PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 I18N_JS = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
 CHANGELOG = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
 
+DESKTOP_BACKGROUND_NOTIFICATION_NAMES = (
+    "_desktopBackgroundedForNotifications",
+    "__hermesSetBackgrounded",
+    "_isBackgroundedForBrowserNotification",
+)
+
+
+def _source_between(start_marker: str, end_marker: str) -> str:
+    start = MESSAGES_JS.index(start_marker)
+    end = MESSAGES_JS.index(end_marker, start)
+    return MESSAGES_JS[start:end]
+
 
 def test_browser_notifications_use_service_worker_when_available():
     assert "function _showPwaNotification" in MESSAGES_JS
@@ -25,7 +37,7 @@ def test_notification_payload_uses_completion_session_when_provided():
     assert "_sessionUrlForSid(sid)" in MESSAGES_JS
     assert "data:{url}" in MESSAGES_JS
     assert "tag:sid?`hermes-${sid}`" in MESSAGES_JS
-    assert "sendBrowserNotification('Response complete',assistantText?assistantText.slice(0,100):'Task finished',{forceHidden:_wasEverHidden,sid:activeSid})" in MESSAGES_JS
+    assert "sendBrowserNotification('Response complete',assistantText?assistantText.slice(0,100):'Task finished',{forceHidden:_wasEverBackgrounded,sid:activeSid})" in MESSAGES_JS
     assert "sendBrowserNotification('Approval required',d.description||'Tool approval needed',{sid:activeSid})" in MESSAGES_JS
     assert "sendBrowserNotification('Clarification needed',d.question||'Tool clarification needed',{sid:activeSid})" in MESSAGES_JS
 
@@ -42,16 +54,38 @@ def test_completion_notification_fires_when_tab_was_hidden_during_stream():
     assert "function _bindStreamHiddenTracker" in MESSAGES_JS
     # Entries are stream-owned ({streamId, wasHidden}) so a stale entry from a
     # non-`done` terminal path can't be mis-attributed to a later same-sid stream.
-    assert "const _wasEverHidden=!!(_hiddenEntry&&_hiddenEntry.wasHidden);" in MESSAGES_JS
+    assert "function _shouldForceCompletionNotification(sid, streamId){" in MESSAGES_JS
+    assert "return wasHidden||wasBackgrounded;" in MESSAGES_JS
     assert "function _clearStreamHidden" in MESSAGES_JS
-    # Cleared on the non-done terminal paths too (belt-and-suspenders alongside
-    # the streamId-ownership guard).
-    assert MESSAGES_JS.count("_clearStreamHidden(activeSid, streamId)") >= 4
+    assert "function _clearStreamNotificationBackground" in MESSAGES_JS
+    # Done-path cleanup lives inside _shouldForceCompletionNotification(); the
+    # activeSid call sites are the non-done terminal paths.
+    assert "_clearStreamHidden(sid, streamId);" in MESSAGES_JS
+    assert "_clearStreamNotificationBackground(sid, streamId);" in MESSAGES_JS
+    assert MESSAGES_JS.count("_clearStreamHidden(activeSid, streamId)") >= 3
+    assert MESSAGES_JS.count("_clearStreamNotificationBackground(activeSid, streamId)") >= 3
     # sendBrowserNotification honors forceHidden but still respects the
     # notifications-enabled setting (forceHidden is NOT the test-button force).
     assert "const forceHidden=!!(options&&options.forceHidden);" in MESSAGES_JS
     assert "if(!force&&!window._notificationsEnabled) return;" in MESSAGES_JS
-    assert "if(!force&&!forceHidden&&!document.hidden) return;" in MESSAGES_JS
+    assert "function _isBackgroundedForBrowserNotification(){" in MESSAGES_JS
+    assert "window.__hermesSetBackgrounded=(value)=>{" in MESSAGES_JS
+    assert "if(!force&&!forceHidden&&!_isBackgroundedForBrowserNotification()) return;" in MESSAGES_JS
+
+
+def test_desktop_background_notification_signal_stays_out_of_stream_visibility():
+    stream_tracker = _source_between(
+        "const LIVE_STREAMS={};",
+        "function closeLiveStream(sessionId, streamId, source){",
+    )
+    deferred_recovery = _source_between(
+        "function _reattachOrRestoreAfterDeferredStreamError(source){",
+        "  // Bug A fix (#631):",
+    )
+
+    for name in DESKTOP_BACKGROUND_NOTIFICATION_NAMES:
+        assert name not in stream_tracker
+        assert name not in deferred_recovery
 
 
 def test_service_worker_handles_notification_clicks_without_hijacking_other_sessions():

--- a/tests/test_workspace_blank_page_fix.py
+++ b/tests/test_workspace_blank_page_fix.py
@@ -129,6 +129,22 @@ class TestWorkspaceSwitcherBlankPage:
             "switchToWorkspace must call /api/session/new when S.session is null"
         )
 
+    def test_switch_to_workspace_keeps_busy_guard_after_blank_page_create(self):
+        src = read('static/panels.js')
+        start = src.find('async function switchToWorkspace(')
+        assert start != -1, "switchToWorkspace not found"
+        fn = src[start:src.find('async function toggleWorktreePanel', start)]
+        assert "t('workspace_busy_switch')" in fn, (
+            "switchToWorkspace must keep the busy-session workspace switch toast"
+        )
+        blank_create = fn.index("api('/api/session/new'")
+        busy_guard = fn.index('if(S.busy)')
+        update_call = fn.index("api('/api/session/update'")
+        assert blank_create < busy_guard < update_call, (
+            "switchToWorkspace must auto-create blank-page sessions before the busy guard, "
+            "then return before workspace update while busy"
+        )
+
     def test_prompt_workspace_path_auto_creates_session(self):
         src = read('static/panels.js')
         m = re.search(r'async function promptWorkspacePath\(\)\{.*?\n\}', src, re.DOTALL)


### PR DESCRIPTION
## Release v0.51.612 — background-tab notifications + profile default workspace (#4753, #4755)

Ships **#4797** and **#4796** (by @rodboev) — two `priority`-labeled bug fixes from the morning triage. (Sibling #4798 from the same batch was bounced for a model-precedence regression the full suite caught; these two are independent and gate-clean.)

### #4797 → #4753: background desktop tabs notify without closing streams
The browser-notification gate used only `document.hidden`, so a desktop-host tab that's visible-but-unfocused either missed notifications or (spoofing hidden) tore down its SSE stream. A desktop-owned notification-only background flag now drives the gate; all `document.hidden`-based stream/visibility logic is byte-unchanged.

### #4796 → #4755: fresh sessions honor the profile default workspace
New-session workspace precedence corrected to one-shot override → profile default → current-session fallback (profile default now wins on New Chat; unchanged when no default is set). Blank-page workspace creation + busy-session rule preserved.

### Gate results (all clean)
- **Codex** (GPT-5.5): SAFE — #4797 flag is notification-only (messages.js:59), stream paths still `document.hidden`; #4796 precedence verified (sessions.js:839, blank-page precedes busy guard panels.js:5527).
- **Opus** (claude-opus-4-8): SAFE both; no cross-PR interaction (orthogonal state domains).
- Isolated check (#4797+#4796 without #4798): 45 targeted tests passed. Full suite run on the staged batch before merge.

Independent fixes — verified each merges clean onto current master in distinct functions.

Closes #4753, closes #4755.
