### PR TITLE
fix: deliver async delegation (background subagent) results to WebUI

### DIFF
--- a/api/background_process.py
+++ b/api/background_process.py
@@ -753,9 +753,75 @@ def _resolve_wakeup_target(
     return owner
 
 
+def _process_async_delegation(evt: dict, _cfg) -> None:
+    """Route an async_delegation completion event to its WebUI session.
+
+    Async delegation events carry session_key (which equals the WebUI
+    session_id) and a full result summary. Unlike terminal completion
+    events, they have no process_id, so we route directly by session_key
+    → PROCESS_SESSION_INDEX → session_id, then format and emit + wake.
+    """
+    session_key = str(evt.get('session_key') or '')
+    if not session_key:
+        logger.debug("async_delegation drop: no session_key on event %s",
+                     evt.get('delegation_id', ''))
+        return
+
+    with _cfg.PROCESS_SESSION_INDEX_LOCK:
+        session_id = _cfg.PROCESS_SESSION_INDEX.get(session_key)
+
+    if not session_id:
+        # session_key might BE the session_id directly (WebUI sets them equal)
+        session_id = session_key
+
+    # Format the notification using the streaming module's formatter
+    from api.streaming import _format_process_notification
+    notification = _format_process_notification(evt)
+    if not notification:
+        logger.debug("async_delegation drop: empty notification for %s",
+                     evt.get('delegation_id', ''))
+        return
+
+    logger.info("async_delegation: delivering result for delegation_id=%s to session_id=%s",
+                evt.get('delegation_id', ''), session_id)
+
+    # Emit the bg_task_complete SSE event to the persistent session channel
+    _emit_to_session_streams(session_id, 'bg_task_complete', {
+        'session_id': session_id,
+        'notification': notification,
+        'delegation_id': evt.get('delegation_id', ''),
+    })
+
+    # Mark consumed so the hermes-agent recovery sweep won't re-inject
+    try:
+        from tools.async_delegation import mark_async_delegation_consumed
+        mark_async_delegation_consumed(evt.get('delegation_id', ''))
+    except Exception:
+        logger.debug("async_delegation: mark_consumed failed for %s",
+                      evt.get('delegation_id', ''), exc_info=True)
+
+    # Start a server-side wakeup turn so the agent processes the result
+    try:
+        _start_server_side_wakeup_turn(session_id, notification)
+    except Exception:
+        logger.debug("async_delegation: wakeup turn start failed for session %s",
+                      session_id, exc_info=True)
+
+
 def _process_one(evt: dict) -> None:
     """Route a single completion_queue event to the matching WebUI session."""
     from api import config as _cfg
+
+    # ── Async delegation completions ──────────────────────────────────
+    # These events carry session_key (the WebUI session_id) and a full
+    # result summary. They don't have a process_id, so the terminal
+    # process-registry lookup below doesn't apply. Route directly by
+    # session_key → session_id via PROCESS_SESSION_INDEX, format the
+    # notification, and emit + wake the agent.
+    evt_type = evt.get('type', 'completion')
+    if evt_type == 'async_delegation':
+        _process_async_delegation(evt, _cfg)
+        return
 
     # Hoist the process-registry import once per event: it was imported in
     # three separate blocks below (session_key recovery, env-immune owner

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1659,7 +1659,61 @@ def _format_process_notification(evt: dict) -> str:
     """Format a completed background process notification for agent input."""
     if not isinstance(evt, dict):
         return ''
-    if evt.get('type') != 'completion':
+    evt_type = evt.get('type', 'completion')
+
+    # Async delegation completions carry the full task source + result
+    if evt_type == 'async_delegation':
+        deleg_id = evt.get('delegation_id', 'unknown')
+        goal = evt.get('goal', '') or ''
+        status = evt.get('status') or 'completed'
+        duration = evt.get('duration_seconds') or evt.get('total_duration_seconds', '?')
+        api_calls = evt.get('api_calls', 0)
+        error = evt.get('error') or ''
+
+        # Batch events carry a 'results' list (one entry per subagent)
+        batch_results = evt.get('results')
+        if evt.get('is_batch') or isinstance(batch_results, list):
+            results = batch_results or []
+            goals = evt.get('goals') or []
+            n = len(results) if results else len(goals)
+            lines = [
+                f"[ASYNC DELEGATION BATCH COMPLETE — {deleg_id}]",
+                f"A background fan-out of {n} subagent(s) has finished.",
+                f"Goal: {goal}",
+                f"Duration: {duration}s",
+            ]
+            for i, r in enumerate(results):
+                task_goal = goals[i] if i < len(goals) else f"Task {i+1}"
+                task_status = r.get('status', 'unknown')
+                task_summary = r.get('summary') or ''
+                task_error = r.get('error') or ''
+                lines.append(f"--- TASK {i+1}/{n}: {task_goal} (status={task_status}) ---")
+                if task_summary:
+                    lines.append(task_summary)
+                elif task_error:
+                    lines.append(f"Error: {task_error}")
+                else:
+                    lines.append(f"(no output — status={task_status})")
+            return "\n".join(lines)
+
+        # Single-task event
+        summary = evt.get('summary') or ''
+        if status in ('completed', 'success') and summary:
+            result = summary
+        elif error:
+            result = f"Error ({status}): {error}"
+            if summary:
+                result += f"\nPartial output:\n{summary}"
+        else:
+            result = f"Status: {status}"
+        return (
+            f"[ASYNC DELEGATION COMPLETE — {deleg_id}]\n"
+            f"Goal: {goal}\n"
+            f"Duration: {duration}s   API calls: {api_calls}\n"
+            f"--- RESULT ---\n{result}]"
+        )
+
+    if evt_type != 'completion':
         return ''
     _sid = evt.get('session_id', '')
     _cmd = evt.get('command', '')
@@ -1717,6 +1771,22 @@ def _drain_webui_process_notifications(session_id: str) -> list[str]:
             break
 
         evt_sid = str(evt.get('session_id') or '') if isinstance(evt, dict) else ''
+        # Async delegation events don't carry session_id — match by session_key
+        if not evt_sid and isinstance(evt, dict) and evt.get('type') == 'async_delegation':
+            evt_session_key = str(evt.get('session_key') or '')
+            if evt_session_key == session_id:
+                notification = _format_process_notification(evt)
+                if notification:
+                    notifications.append(notification)
+                    try:
+                        from tools.async_delegation import mark_async_delegation_consumed
+                        mark_async_delegation_consumed(evt.get('delegation_id', ''))
+                    except Exception:
+                        pass
+                continue
+            # session_key doesn't match this session — requeue
+            skipped_events.append(evt)
+            continue
         if not evt_sid:
             skipped_events.append(evt)
             continue


### PR DESCRIPTION
## Summary

Background subagent results from `delegate_task` were silently dropped by the WebUI. The agent would dispatch a subagent, the subagent would complete successfully, but the result never reached the user — the agent would say "subagent came back empty" and either retry or fall back to doing the task directly.

## Root Cause (4 bugs)

1. **`_format_process_notification()`** only handled terminal `completion` events. `async_delegation` events returned empty string.

2. **`_drain_webui_process_notifications()`** matched events by `session_id`, but async delegation events carry `session_key` instead. Events were skipped.

3. **`_process_one()` in `background_process.py`** (the existing `bg_task_complete` drain thread) consumed ALL events from the completion_queue but only processed `completion` type. `async_delegation` events were silently dropped.

4. **The formatter read `summary`** from events, but `delegate_task` always dispatches via the batch path (`is_batch=True`, `results=[...]`). Batch events don't have a `summary` field, producing empty output even when the event was delivered.

## Changes

### `api/streaming.py`
- `_format_process_notification()` now handles `async_delegation` events
- Handles batch format (`is_batch=True`, `results=[...]`) by iterating each subagent's summary/error
- Handles single-task format as fallback

### `api/background_process.py`
- `_process_one()` routes `async_delegation` events to new `_process_async_delegation()` handler
- Handler routes by `session_key` (not `process_id` which async events don't have)
- Formats via `_format_process_notification`, emits `bg_task_complete` SSE via `_emit_to_session_streams`
- Triggers server-side wakeup turn via `_start_server_side_wakeup_turn`
- Marks delegation consumed in async_delegation records

## Dependency

**Depends on** NousResearch/hermes-agent#51577 — adds `mark_async_delegation_consumed()` function imported by this PR.

## Testing

Tested end-to-end with Playwright (real browser):
1. Logged into WebUI
2. Sent message: "Use delegate_task to spawn a background subagent that runs `TZ=Pacific/Auckland date '+%H:%M:%S NZST'`"
3. Agent dispatched subagent
4. Result delivered automatically: `00:16:57 NZST`
5. Agent confirmed: "The subagent came back with a full result — no empty/stripped content this time"

## Related Issues
- Closes #4691
- Companion: NousResearch/hermes-agent#51577