### PR TITLE
feat: add Neuralwatt provider env var mapping

### DIFF
--- a/api/providers.py
+++ b/api/providers.py
@@ -701,6 +701,7 @@ _PROVIDER_ENV_VAR: dict[str, str] = {
     "mistralai": "MISTRAL_API_KEY",
     "x-ai": "XAI_API_KEY",
     "xiaomi": "XIAOMI_API_KEY",
+    "neuralwatt": "NEURALWATT_API_KEY",
     "opencode-zen": "OPENCODE_ZEN_API_KEY",
     "opencode-go": "OPENCODE_GO_API_KEY",
     # NOTE: bare "ollama" (local) deliberately omitted — local Ollama is keyless

--- a/tests/test_issue_neuralwatt_env_key.py
+++ b/tests/test_issue_neuralwatt_env_key.py
@@ -1,0 +1,94 @@
+"""Regression coverage for Neuralwatt provider env-var mapping.
+
+Mirrors test_issue2025_xiaomi_env_key.py — ensures the provider ID maps to
+the correct env var and that key detection works when the env var is set.
+"""
+
+from __future__ import annotations
+
+import builtins
+
+import api.config as config
+import api.providers as providers
+
+
+def _force_env_fallback(monkeypatch):
+    """Force get_available_models() down its explicit env-var fallback path."""
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in ("hermes_cli.models", "hermes_cli.auth"):
+            raise ImportError(name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def _run_available_models_with_cfg(monkeypatch, tmp_path, cfg):
+    old_cfg = dict(config.cfg)
+    old_mtime = config._cfg_mtime
+    monkeypatch.setattr(config, "_models_cache_path", tmp_path / "models_cache.json")
+    monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "missing-config.yaml")
+    monkeypatch.setattr("api.profiles.get_active_hermes_home", lambda: tmp_path, raising=False)
+    config.cfg.clear()
+    config.cfg.update(cfg)
+    config._cfg_mtime = 0.0
+    config.invalidate_models_cache()
+    try:
+        return config.get_available_models()
+    finally:
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+        config._cfg_mtime = old_mtime
+        config.invalidate_models_cache()
+
+
+def test_neuralwatt_env_var_mapping():
+    """Neuralwatt maps to NEURALWATT_API_KEY in the provider env-var table."""
+    assert providers._PROVIDER_ENV_VAR["neuralwatt"] == "NEURALWATT_API_KEY"
+
+
+def test_neuralwatt_provider_has_key_when_env_set(monkeypatch, tmp_path):
+    """Key detection returns True when NEURALWATT_API_KEY is in the environment."""
+    monkeypatch.setattr(providers, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("NEURALWATT_API_KEY", "test-neuralwatt-key")
+
+    assert providers._provider_has_key("neuralwatt") is True
+
+
+def test_neuralwatt_provider_has_key_false_without_env(monkeypatch, tmp_path):
+    """Key detection returns False when NEURALWATT_API_KEY is not set."""
+    monkeypatch.setattr(providers, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.delenv("NEURALWATT_API_KEY", raising=False)
+
+    assert providers._provider_has_key("neuralwatt") is False
+
+
+def test_neuralwatt_model_group_appears_with_models_in_config(monkeypatch, tmp_path):
+    """Neuralwatt appears as a provider group when config.yaml lists its models."""
+    _force_env_fallback(monkeypatch)
+    monkeypatch.setenv("NEURALWATT_API_KEY", "test-neuralwatt-key")
+
+    result = _run_available_models_with_cfg(
+        monkeypatch,
+        tmp_path,
+        {
+            "model": {"default": "glm-5.2", "provider": "neuralwatt"},
+            "providers": {
+                "neuralwatt": {
+                    "base_url": "https://api.neuralwatt.com/v1",
+                    "key_env": "NEURALWATT_API_KEY",
+                    "api_mode": "chat_completions",
+                    "default_model": "glm-5.2",
+                    "models": ["glm-5.2", "glm-5.2-short"],
+                }
+            },
+        },
+    )
+
+    groups = {group["provider_id"]: group for group in result["groups"]}
+    assert "neuralwatt" in groups, f"neuralwatt missing from groups: {list(groups.keys())}"
+    assert groups["neuralwatt"]["provider"] == "Neuralwatt"
+    model_ids = {model["id"] for model in groups["neuralwatt"]["models"]}
+    assert "glm-5.2" in model_ids
+    assert "glm-5.2-short" in model_ids


### PR DESCRIPTION
## What this does

Adds `neuralwatt` to `_PROVIDER_ENV_VAR` in `api/providers.py` so the WebUI correctly detects API keys and exposes Neuralwatt as a configurable provider. Also adds regression tests mirroring the existing `test_issue2025_xiaomi_env_key.py` pattern.

**Before:** Neuralwatt configured in Hermes `config.yaml` would not appear in the WebUI provider/model picker because the WebUI had no mapping from the `neuralwatt` provider ID to the `NEURALWATT_API_KEY` environment variable. The key was invisible to `has_key` detection and the provider could not appear as `configurable`.

**After:** Neuralwatt users who have `providers.neuralwatt` in their `config.yaml` and `NEURALWATT_API_KEY` in their `.env` will see Neuralwatt in the Providers settings and model picker with key detection working correctly.

## Security review

- **No secrets, keys, tokens, or credentials in this diff.** Only the provider ID string `"neuralwatt"` and the env var name string `"NEURALWATT_API_KEY"` — a mapping, not a value.
- **No environment variable values are exposed.** The change adds a key to an internal lookup dict; it never reads or transmits the actual API key value.
- **No new network endpoints or data paths.** Identical pattern to the adjacent `xiaomi` and `opencode-*` entries already in the table.
- **No PII, no configuration leakage, no auth bypass.** This is purely a provider recognition mapping.

## Testing

- Verified key detection: `has_key` = `True`, `key_source` = `"env_file"` via `/api/providers`
- Verified model catalog: Neuralwatt appears as a provider group with models listed from `config.yaml` `providers.neuralwatt.models`
- Verified live fetch: no regression on existing providers
- Manually tested provider/model selection in WebUI
- **New regression tests** (`tests/test_issue_neuralwatt_env_key.py`, 4 tests, all passing):
  - `test_neuralwatt_env_var_mapping` — asserts `_PROVIDER_ENV_VAR["neuralwatt"] == "NEURALWATT_API_KEY"`
  - `test_neuralwatt_provider_has_key_when_env_set` — asserts `_provider_has_key("neuralwatt")` returns True with env var present
  - `test_neuralwatt_provider_has_key_false_without_env` — asserts `_provider_has_key("neuralwatt")` returns False without env var
  - `test_neuralwatt_model_group_appears_with_models_in_config` — asserts Neuralwatt appears as a group in `get_available_models()` when config.yaml includes models

## Diff

```diff
+    "neuralwatt": "NEURALWATT_API_KEY",
```

Single line, same pattern as the 30+ other entries already in `_PROVIDER_ENV_VAR`.