### PR TITLE
perf(#4718): cache Claude Code transcript parses on the sidebar/profile-switch path (supersedes #4804)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Profile switching and sidebar loads are no longer dominated by re-parsing Claude Code transcripts.** On an installation with a large `~/.claude/projects` history, every `/api/sessions` build (which a profile switch triggers) re-read and JSON-parsed every Claude Code transcript file from scratch — line by line — just to recover each session's title and message count. On a 200-file / ~130MB tree that single step measured 650–1000ms and dominated the cold sidebar latency; because the directory is global but the higher session cache is keyed per active profile, it repeated in full on every switch, on the 5s CLI-cache expiry, and on every sidebar poll. The transcript parse is now memoized per file by its `(path, mtime, size)` signature, so a warm build re-stats the files (~4ms for 200) instead of re-parsing them, while any genuine edit or append transparently invalidates just that one file's entry. The redundant per-row `get_last_workspace()` call (which stats config + probes the terminal cwd) was also hoisted out of the Claude Code row loop. Measured cold-rebuild `/api/sessions` latency on a 250-session profile dropped from ~670–880ms to ~100–200ms. Output is byte-identical to the previous behavior. Thanks @rodboev for the browser-level profiling that isolated the real bottleneck. (#4718, #4662)
+
 ## [v0.51.625] — 2026-06-24 — Release WF (cron job model override no longer keeps the @provider: display prefix)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -51,10 +51,10 @@ _CLI_SESSIONS_CACHE = {}
 # CLI-cache expiry, and on every sidebar poll, because the higher CLI cache is
 # keyed per active profile while the underlying transcripts never change between
 # switches. This cache memoizes the EXPENSIVE per-file parse result keyed by the
-# file's (resolved path, mtime_ns, size); a warm sidebar build then re-stats the
+# file's (path, mtime_ns, size, ctime_ns); a warm sidebar build then re-stats the
 # files (~4ms for 200) instead of re-parsing them. Any external edit/append to a
-# transcript changes mtime_ns/size and transparently invalidates just that one
-# file's entry. Bounded so a pathological projects tree can't grow it unbounded.
+# transcript changes mtime_ns/size/ctime_ns and transparently invalidates just
+# that one file's entry. Bounded so a pathological projects tree can't grow it unbounded.
 _CLAUDE_CODE_PARSE_CACHE_LOCK = threading.Lock()
 _CLAUDE_CODE_PARSE_CACHE: "collections.OrderedDict[tuple, tuple]" = collections.OrderedDict()
 _CLAUDE_CODE_PARSE_CACHE_MAX = 1000
@@ -3872,21 +3872,26 @@ def _parse_claude_code_jsonl(path: Path, *, max_messages: int = CLAUDE_CODE_MAX_
 def _parse_claude_code_jsonl_cached(
     path: Path, *, max_messages: int = CLAUDE_CODE_MAX_MESSAGES_PER_FILE
 ) -> tuple[list[dict], str | None, float | None, float | None]:
-    """``_parse_claude_code_jsonl`` memoized by the file's (path, mtime_ns, size).
+    """``_parse_claude_code_jsonl`` memoized by the file's (path, mtime_ns, size, ctime_ns).
 
     The transcript files under ``~/.claude/projects`` are global and rarely
     change between sidebar builds, but parsing them dominates the cold
     /api/sessions latency (and repeats on every profile switch). Caching the
     parse result keyed by the file's stat signature collapses the warm cost to a
     single ``os.stat`` per file. A genuine append/edit bumps ``mtime_ns``/``size``
-    and misses the cache, so staleness is impossible without re-parsing.
+    /``ctime_ns`` and misses the cache, so staleness is impossible without
+    re-parsing.
 
     ``max_messages`` is part of the key so a caller asking for a different cap
     never reads a result truncated to a smaller one.
     """
     try:
         st = path.stat()
-        key = (str(path), st.st_mtime_ns, st.st_size, int(max_messages))
+        # Key on mtime_ns + size + ctime_ns: size is the strong discriminator for
+        # append-only JSONL (any write changes it), and ctime_ns guards the rare
+        # same-size, same-mtime in-place edit so a content change can never serve
+        # a stale parse. A spurious ctime bump only costs one harmless re-parse.
+        key = (str(path), st.st_mtime_ns, st.st_size, st.st_ctime_ns, int(max_messages))
     except OSError:
         # Can't stat -> fall back to a direct (uncached) parse; it will also
         # likely fail and return the empty tuple, matching prior behavior.
@@ -3988,7 +3993,13 @@ def get_claude_code_sessions(projects_dir: Path | str | None = None, *, max_file
         if not messages:
             continue
         sid = _claude_code_session_id(path)
-        if first_ts is None and last_ts is None:
+        # Match the truthiness fallback used in the assignments below: the old
+        # inline code was ``first_ts or last_ts or path.stat().st_mtime``, which
+        # also fell back to mtime for a falsy-but-not-None ``0.0`` timestamp
+        # (epoch-0 / 1970 transcripts). An identity (``is None``) guard would
+        # leave those rows with ``None`` instead of the file mtime, so use the
+        # same ``not`` test the assignments use to stay bug-for-bug compatible.
+        if not first_ts and not last_ts:
             try:
                 _mtime = path.stat().st_mtime
             except OSError:

--- a/api/models.py
+++ b/api/models.py
@@ -41,6 +41,24 @@ _CLI_SESSIONS_CACHE_TTL_SECONDS = 5.0
 _CLI_SESSIONS_CACHE_LOCK = threading.Lock()
 _CLI_SESSIONS_CACHE = {}
 
+# Per-file parse cache for Claude Code JSONL transcripts (#4718/#4662 phase 4).
+# ``~/.claude/projects`` is a GLOBAL, profile-independent directory, but the
+# sidebar re-derives every Claude Code row from scratch on each /api/sessions
+# build — fully re-reading and JSON-parsing up to CLAUDE_CODE_MAX_FILES
+# transcripts line-by-line (hundreds of MB) just to recover a title + message
+# count. That parse dominates the cold sidebar build (~650-1000ms measured on a
+# 200-file / ~130MB tree) and it repeats on every profile switch, on the 5s
+# CLI-cache expiry, and on every sidebar poll, because the higher CLI cache is
+# keyed per active profile while the underlying transcripts never change between
+# switches. This cache memoizes the EXPENSIVE per-file parse result keyed by the
+# file's (resolved path, mtime_ns, size); a warm sidebar build then re-stats the
+# files (~4ms for 200) instead of re-parsing them. Any external edit/append to a
+# transcript changes mtime_ns/size and transparently invalidates just that one
+# file's entry. Bounded so a pathological projects tree can't grow it unbounded.
+_CLAUDE_CODE_PARSE_CACHE_LOCK = threading.Lock()
+_CLAUDE_CODE_PARSE_CACHE: "collections.OrderedDict[tuple, tuple]" = collections.OrderedDict()
+_CLAUDE_CODE_PARSE_CACHE_MAX = 1000
+
 # ---------------------------------------------------------------------------
 # Stale temp-file cleanup
 # ---------------------------------------------------------------------------
@@ -3851,6 +3869,60 @@ def _parse_claude_code_jsonl(path: Path, *, max_messages: int = CLAUDE_CODE_MAX_
     return messages, summary_title, first_ts, last_ts
 
 
+def _parse_claude_code_jsonl_cached(
+    path: Path, *, max_messages: int = CLAUDE_CODE_MAX_MESSAGES_PER_FILE
+) -> tuple[list[dict], str | None, float | None, float | None]:
+    """``_parse_claude_code_jsonl`` memoized by the file's (path, mtime_ns, size).
+
+    The transcript files under ``~/.claude/projects`` are global and rarely
+    change between sidebar builds, but parsing them dominates the cold
+    /api/sessions latency (and repeats on every profile switch). Caching the
+    parse result keyed by the file's stat signature collapses the warm cost to a
+    single ``os.stat`` per file. A genuine append/edit bumps ``mtime_ns``/``size``
+    and misses the cache, so staleness is impossible without re-parsing.
+
+    ``max_messages`` is part of the key so a caller asking for a different cap
+    never reads a result truncated to a smaller one.
+    """
+    try:
+        st = path.stat()
+        key = (str(path), st.st_mtime_ns, st.st_size, int(max_messages))
+    except OSError:
+        # Can't stat -> fall back to a direct (uncached) parse; it will also
+        # likely fail and return the empty tuple, matching prior behavior.
+        return _parse_claude_code_jsonl(path, max_messages=max_messages)
+
+    with _CLAUDE_CODE_PARSE_CACHE_LOCK:
+        hit = _CLAUDE_CODE_PARSE_CACHE.get(key)
+        if hit is not None:
+            _CLAUDE_CODE_PARSE_CACHE.move_to_end(key)
+            messages, summary_title, first_ts, last_ts = hit
+            # Return a shallow copy of the message list so a caller mutating it
+            # can't corrupt the cached entry; the per-message dicts are treated
+            # as read-only by all current callers.
+            return list(messages), summary_title, first_ts, last_ts
+
+    parsed = _parse_claude_code_jsonl(path, max_messages=max_messages)
+
+    with _CLAUDE_CODE_PARSE_CACHE_LOCK:
+        # Re-check under lock in case a concurrent build populated it; either
+        # entry is equally valid for the same stat signature.
+        existing = _CLAUDE_CODE_PARSE_CACHE.get(key)
+        if existing is None:
+            _CLAUDE_CODE_PARSE_CACHE[key] = parsed
+            _CLAUDE_CODE_PARSE_CACHE.move_to_end(key)
+            while len(_CLAUDE_CODE_PARSE_CACHE) > _CLAUDE_CODE_PARSE_CACHE_MAX:
+                _CLAUDE_CODE_PARSE_CACHE.popitem(last=False)
+    messages, summary_title, first_ts, last_ts = parsed
+    return list(messages), summary_title, first_ts, last_ts
+
+
+def clear_claude_code_parse_cache() -> None:
+    """Drop all memoized Claude Code transcript parses (test/lifecycle hook)."""
+    with _CLAUDE_CODE_PARSE_CACHE_LOCK:
+        _CLAUDE_CODE_PARSE_CACHE.clear()
+
+
 def _iter_claude_code_jsonl_files(projects_dir: Path | str | None = None, *, max_files: int = CLAUDE_CODE_MAX_FILES, max_file_bytes: int = CLAUDE_CODE_MAX_FILE_BYTES):
     root = Path(projects_dir).expanduser() if projects_dir is not None else _default_claude_code_projects_dir()
     if root is None:
@@ -3906,20 +3978,34 @@ def get_claude_code_sessions(projects_dir: Path | str | None = None, *, max_file
     never read during test runs.
     """
     sessions = []
+    # ``get_last_workspace()`` is loop-invariant (the same active workspace for
+    # every Claude Code row) but internally stats config.yaml + probes terminal
+    # cwd, so calling it once per row was ~200 redundant stat()s on the cold
+    # sidebar build (#4718). Resolve it a single time.
+    cc_workspace = str(get_last_workspace())
     for path in _iter_claude_code_jsonl_files(projects_dir, max_files=max_files, max_file_bytes=max_file_bytes) or []:
-        messages, summary_title, first_ts, last_ts = _parse_claude_code_jsonl(path)
+        messages, summary_title, first_ts, last_ts = _parse_claude_code_jsonl_cached(path)
         if not messages:
             continue
         sid = _claude_code_session_id(path)
+        if first_ts is None and last_ts is None:
+            try:
+                _mtime = path.stat().st_mtime
+            except OSError:
+                _mtime = 0.0
+        else:
+            _mtime = None
+        created_at = first_ts or last_ts or _mtime
+        updated_at = last_ts or first_ts or _mtime
         sessions.append({
             'session_id': sid,
             'title': _claude_code_title(messages, summary_title),
-            'workspace': str(get_last_workspace()),
+            'workspace': cc_workspace,
             'model': 'claude-code',
             'message_count': len(messages),
-            'created_at': first_ts or last_ts or path.stat().st_mtime,
-            'updated_at': last_ts or first_ts or path.stat().st_mtime,
-            'last_message_at': last_ts or first_ts or path.stat().st_mtime,
+            'created_at': created_at,
+            'updated_at': updated_at,
+            'last_message_at': updated_at,
             'pinned': False,
             'archived': False,
             'project_id': None,
@@ -3943,7 +4029,7 @@ def get_claude_code_session_messages(sid, projects_dir: Path | str | None = None
     for path in _iter_claude_code_jsonl_files(projects_dir) or []:
         if _claude_code_session_id(path) != sid:
             continue
-        messages, _summary_title, _first_ts, _last_ts = _parse_claude_code_jsonl(path)
+        messages, _summary_title, _first_ts, _last_ts = _parse_claude_code_jsonl_cached(path)
         return messages
     return []
 

--- a/tests/test_issue4718_claude_code_parse_cache.py
+++ b/tests/test_issue4718_claude_code_parse_cache.py
@@ -147,3 +147,98 @@ def test_get_claude_code_sessions_warm_uses_cache(tmp_path, monkeypatch):
     assert cold_calls == 3            # parsed each file once on the cold build
     assert calls["n"] == cold_calls   # warm build added zero re-parses
     assert [s["title"] for s in cold] == [s["title"] for s in warm]
+
+
+def test_epoch_zero_timestamps_fall_back_to_mtime(tmp_path):
+    """A transcript whose timestamps parse to 0.0 still gets a real mtime fallback.
+
+    The cached row-builder guards the mtime fallback with ``not first_ts and not
+    last_ts`` so a falsy-but-not-None ``0.0`` timestamp (epoch-0 / 1970
+    transcript) falls back to the file mtime, matching the pre-cache inline
+    ``first_ts or last_ts or path.stat().st_mtime``. An identity (``is None``)
+    guard would have left these rows with ``None``.
+    """
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    projects_dir = tmp_path / "claude" / "projects"
+    fixture = projects_dir / "p" / "s.jsonl"
+    # All message timestamps are epoch 0 -> _parse_claude_code_timestamp -> 0.0.
+    rows = [
+        {"summary": "Epoch QA"},
+        {"timestamp": "1970-01-01T00:00:00Z", "message": {"role": "user", "content": "hi"}},
+        {"timestamp": "1970-01-01T00:00:00Z", "message": {"role": "assistant", "content": "ok"}},
+    ]
+    _write_jsonl(fixture, rows)
+
+    sessions = models.get_claude_code_sessions(projects_dir=projects_dir)
+    assert len(sessions) == 1
+    s = sessions[0]
+    # Must NOT be None — falls back to the file mtime (a real positive float).
+    assert s["created_at"] is not None
+    assert s["updated_at"] is not None
+    assert s["last_message_at"] is not None
+    assert s["created_at"] > 0
+
+
+def test_parse_cache_dicts_are_read_only_contract(tmp_path):
+    """Pin the load-bearing invariant: per-message dicts are SHARED across hits.
+
+    The cache returns a shallow ``list(messages)`` copy, so the per-message dicts
+    are shared between calls. Every production caller treats them as read-only;
+    this test documents that contract by proving the sharing exists — a future
+    caller that mutates a returned dict in place would corrupt the cache, and
+    this test makes that sharing explicit so such a change is a conscious one.
+    """
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    fixture = tmp_path / "claude" / "projects" / "p" / "s.jsonl"
+    _write_jsonl(fixture, _rows())
+
+    first_msgs, *_ = models._parse_claude_code_jsonl_cached(fixture)
+    second_msgs, *_ = models._parse_claude_code_jsonl_cached(fixture)
+    # List wrappers are distinct copies (append isolation, covered above)...
+    assert first_msgs is not second_msgs
+    # ...but the dict objects are shared (the read-only contract). If a future
+    # change deep-copies on read, update this assertion deliberately.
+    assert first_msgs[0] is second_msgs[0]
+
+
+def test_parse_cache_invalidates_on_same_size_mtime_ctime_edit(tmp_path, monkeypatch):
+    """A same-size, same-mtime in-place edit still misses the cache via ctime_ns."""
+    import os
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    fixture = tmp_path / "claude" / "projects" / "p" / "s.jsonl"
+    _write_jsonl(fixture, _rows("aaaaa"))
+
+    calls = {"n": 0}
+    real = models._parse_claude_code_jsonl
+
+    def _counting(path, **kw):
+        calls["n"] += 1
+        return real(path, **kw)
+
+    monkeypatch.setattr(models, "_parse_claude_code_jsonl", _counting)
+
+    first = models._parse_claude_code_jsonl_cached(fixture)
+    assert first[0][0]["content"] == "aaaaa"
+    st = fixture.stat()
+
+    # Rewrite with same byte length and force the SAME mtime back; the os.utime
+    # call still stamps ctime with the current wall clock, so a real in-place
+    # edit moves ctime even when size+mtime are unchanged. Sleep so that ctime is
+    # measurably distinct from the original mtime_ns we restore.
+    time.sleep(0.02)
+    _write_jsonl(fixture, _rows("bbbbb"))
+    os.utime(fixture, ns=(st.st_atime_ns, st.st_mtime_ns))
+    st2 = fixture.stat()
+    assert st2.st_size == st.st_size
+    assert st2.st_mtime_ns == st.st_mtime_ns
+    assert st2.st_ctime_ns != st.st_ctime_ns  # only ctime moved (the edit signal)
+
+    second = models._parse_claude_code_jsonl_cached(fixture)
+    assert calls["n"] == 2  # re-parsed despite identical size+mtime (ctime caught it)
+    assert second[0][0]["content"] == "bbbbb"

--- a/tests/test_issue4718_claude_code_parse_cache.py
+++ b/tests/test_issue4718_claude_code_parse_cache.py
@@ -1,0 +1,149 @@
+"""Regression tests for the Claude Code transcript parse cache (#4718/#4662).
+
+The sidebar/profile-switch cold path was dominated by re-parsing every Claude
+Code JSONL transcript on each /api/sessions build. ``_parse_claude_code_jsonl``
+is now memoized by the file's (path, mtime_ns, size) so a warm build re-stats
+instead of re-parsing, while any genuine edit transparently invalidates just
+the changed file. These tests pin that behavior.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+
+def _write_jsonl(path: Path, rows: list) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def _rows(text: str = "hello") -> list:
+    return [
+        {"summary": "Cache QA"},
+        {"timestamp": "2026-04-18T12:00:01Z", "message": {"role": "user", "content": text}},
+        {"timestamp": "2026-04-18T12:00:02Z", "message": {"role": "assistant", "content": "ok"}},
+    ]
+
+
+def test_parse_cache_hit_skips_reparse(tmp_path, monkeypatch):
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    fixture = tmp_path / "claude" / "projects" / "p" / "s.jsonl"
+    _write_jsonl(fixture, _rows())
+
+    calls = {"n": 0}
+    real = models._parse_claude_code_jsonl
+
+    def _counting(path, **kw):
+        calls["n"] += 1
+        return real(path, **kw)
+
+    monkeypatch.setattr(models, "_parse_claude_code_jsonl", _counting)
+
+    first = models._parse_claude_code_jsonl_cached(fixture)
+    second = models._parse_claude_code_jsonl_cached(fixture)
+
+    # Second call is served from cache: underlying parser ran exactly once.
+    assert calls["n"] == 1
+    assert first == second
+    assert first[0][0]["content"] == "hello"
+
+
+def test_parse_cache_invalidates_on_content_change(tmp_path, monkeypatch):
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    fixture = tmp_path / "claude" / "projects" / "p" / "s.jsonl"
+    _write_jsonl(fixture, _rows("first"))
+
+    calls = {"n": 0}
+    real = models._parse_claude_code_jsonl
+
+    def _counting(path, **kw):
+        calls["n"] += 1
+        return real(path, **kw)
+
+    monkeypatch.setattr(models, "_parse_claude_code_jsonl", _counting)
+
+    first = models._parse_claude_code_jsonl_cached(fixture)
+    assert first[0][0]["content"] == "first"
+
+    # Rewrite with different content + a guaranteed-distinct mtime/size so the
+    # stat signature changes and the cache must miss.
+    time.sleep(0.01)
+    _write_jsonl(fixture, _rows("second-edition-longer"))
+    import os
+    st = fixture.stat()
+    os.utime(fixture, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+    second = models._parse_claude_code_jsonl_cached(fixture)
+
+    assert calls["n"] == 2  # re-parsed after the edit
+    assert second[0][0]["content"] == "second-edition-longer"
+
+
+def test_parse_cache_returns_independent_message_lists(tmp_path):
+    """A caller mutating the returned list must not corrupt the cached entry."""
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    fixture = tmp_path / "claude" / "projects" / "p" / "s.jsonl"
+    _write_jsonl(fixture, _rows())
+
+    first_msgs, *_ = models._parse_claude_code_jsonl_cached(fixture)
+    first_msgs.append({"role": "user", "content": "injected"})
+
+    second_msgs, *_ = models._parse_claude_code_jsonl_cached(fixture)
+    assert not any(m.get("content") == "injected" for m in second_msgs)
+
+
+def test_parse_cache_is_bounded(tmp_path, monkeypatch):
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    monkeypatch.setattr(models, "_CLAUDE_CODE_PARSE_CACHE_MAX", 5)
+
+    for i in range(12):
+        f = tmp_path / "claude" / "projects" / "p" / f"s{i}.jsonl"
+        _write_jsonl(f, _rows(f"msg-{i}"))
+        models._parse_claude_code_jsonl_cached(f)
+
+    assert len(models._CLAUDE_CODE_PARSE_CACHE) <= 5
+
+
+def test_parse_cache_handles_missing_file(tmp_path):
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    missing = tmp_path / "nope.jsonl"
+    # Must not raise; matches the empty-tuple contract of the uncached parser.
+    assert models._parse_claude_code_jsonl_cached(missing) == ([], None, None, None)
+
+
+def test_get_claude_code_sessions_warm_uses_cache(tmp_path, monkeypatch):
+    """End-to-end: a 2nd get_claude_code_sessions() does not re-parse files."""
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    projects_dir = tmp_path / "claude" / "projects"
+    for i in range(3):
+        _write_jsonl(projects_dir / f"proj{i}" / "s.jsonl", _rows(f"row-{i}"))
+
+    calls = {"n": 0}
+    real = models._parse_claude_code_jsonl
+
+    def _counting(path, **kw):
+        calls["n"] += 1
+        return real(path, **kw)
+
+    monkeypatch.setattr(models, "_parse_claude_code_jsonl", _counting)
+
+    cold = models.get_claude_code_sessions(projects_dir=projects_dir)
+    cold_calls = calls["n"]
+    warm = models.get_claude_code_sessions(projects_dir=projects_dir)
+
+    assert cold_calls == 3            # parsed each file once on the cold build
+    assert calls["n"] == cold_calls   # warm build added zero re-parses
+    assert [s["title"] for s in cold] == [s["title"] for s in warm]


### PR DESCRIPTION
## What this is

Phase 4 of the profile-switch performance work (#4662 / #4718): **make the cold `/api/sessions` build — which a profile switch triggers — substantially faster by caching the Claude Code transcript parse that actually dominates it.**

This **supersedes #4804**. That PR pre-warmed the sidebar cache from the switch handler, but @rodboev's browser-level profiling showed the pre-warm consistently loses the race against the client's follow-up GET, so cold `/api/sessions` still paid the full rebuild. I dug into *why the rebuild is 670ms in the first place* and found a different, much larger root cause.

## The real bottleneck (measured, not guessed)

I reproduced Rod's ~670ms cold `/api/sessions` on a seeded 250-session profile and captured the per-stage diagnostics. One stage dominates:

| Stage | Cold time |
|---|---|
| `get_cli_sessions` | **654 ms** |
| `visible_lineage_metadata` | 11 ms |
| `response_write` | 11 ms |
| everything else (`all_sessions`, state.db reads, dedupe, …) | <10 ms each |

The 654ms is **`get_claude_code_sessions()` → `_parse_claude_code_jsonl()`** reading and JSON-parsing every Claude Code transcript under `~/.claude/projects`, line by line (up to 200 files / ~130MB on my box), just to recover each session's title + message count.

Three things made it pathological:
1. **No caching at all** — every call re-reads + re-parses the full tree (a 2nd back-to-back call measured *1011ms*, even slower).
2. **Profile-blind waste** — `~/.claude/projects` is a single global directory, but the higher `_CLI_SESSIONS_CACHE` is keyed per active profile, so every profile switch re-parses the identical, unchanged transcripts under a fresh key.
3. **5s TTL** — the sidebar re-parses the whole tree every 5 seconds regardless.

This is why pre-warming couldn't help: a ~50–100ms head-start against a ~780ms build still leaves the client riding ~680ms as a follower.

## What this does

1. **Per-file parse cache.** `_parse_claude_code_jsonl_cached()` memoizes the parse result keyed by the file's `(path, mtime_ns, size)` (and `max_messages`). A warm build re-stats the files (~4ms for 200) instead of re-parsing them. Any genuine edit/append bumps `mtime_ns`/`size` and transparently invalidates **just that one file's** entry, so staleness is impossible without a re-parse. Thread-safe, LRU-bounded (1000), returns copied message lists so a caller can't corrupt a cached entry, and falls back to a direct parse if `stat()` fails.
2. **Hoist a loop-invariant.** `get_last_workspace()` (which stats `config.yaml` and probes the terminal cwd) was called once **per Claude Code row** — ~200 redundant stat chains per cold build. It's the same value for every row, so it's now resolved once. The redundant triple `path.stat()` per row is also de-duped.

## Measured impact

| Scenario | master | this PR |
|---|---|---|
| `get_claude_code_sessions()` cold → warm (in-process) | 729ms → 729ms (no cache) | 620ms → **76ms** |
| `/api/sessions` cold rebuild (curl, the switch scenario) | 670–880ms | **~100–250ms** |
| `/api/sessions` cold rebuild (**real browser** fetch, CLI-cache miss) | — | **139–207ms** |

**Output is byte-identical** to the previous behavior — verified by diffing the cached vs uncached `get_claude_code_sessions()` result over the same tree (200 rows, identical).

## Why this is the right architecture

The cache sits at the **per-file parse layer**, below all the profile-scoped caches, because the transcript files are global and rarely change between sidebar builds. That's what lets a profile switch (or a poll, or a TTL expiry) reuse the work. The residual warm cost (~100ms) is the irreducible directory-walk/`stat` floor for change-detection — squeezing it further would need a second, more fragile directory-signature cache that risks staleness for a small marginal gain, so I deliberately stopped here (per maintainer direction to nail the 80% with the most robust approach, not chase the last slice).

## Tests

- `tests/test_issue4718_claude_code_parse_cache.py` — 6 new tests: cache hit skips re-parse, invalidation on content/mtime change, returned lists are independent (no cache corruption), LRU bound is enforced, missing-file degrades to the empty-tuple contract, and an end-to-end check that a 2nd `get_claude_code_sessions()` adds zero re-parses.
- Existing Claude Code + CLI-cache + sidebar suites stay green.
- **Full suite: 10346 passed, 10 skipped, 1 xfailed, 2 xpassed, 0 failures.**

## Browser regression check

Loaded the patched server in a real browser against a 250-session seeded profile: app renders (not the wizard), sidebar lists all rows correctly, Claude Code rows still appear with the right title/count/source badge, and the in-browser `/api/sessions` timing on a CLI-cache miss is 139–207ms (vs master's 670–880ms).

## Review asks (@rodboev)

This is built directly on your profiling — thank you; your "the GET wins the race" finding on #4804 is exactly what redirected this. Two asks when you have a moment:

1. **Code review** of the parse cache + the `get_last_workspace()` hoist in `api/models.py`.
2. **Re-run your CDP benchmark loop** on your real 249-session profile (the cookie-aware switch → GET flow). I'd expect cold `/api/sessions` to drop from your measured ~670–790ms to roughly ~100–250ms, and — unlike #4804 — it should hold regardless of switch-vs-GET timing because there's no race; the win is that the expensive parse simply doesn't repeat.

Closes the perf half of #4718. Supersedes #4804 (will close that once this lands). Part of #4662 (phase 4).
