### PR TITLE
fix(kanban): bound column card list height

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -5736,7 +5736,7 @@ main.main.showing-insights > #mainInsights{display:flex;overflow-y:auto;}
 .kanban-column{display:flex;flex-direction:column;min-width:260px;max-width:320px;flex:1;background:var(--panel);border:1px solid var(--border);border-radius:10px;min-height:240px;}
 .kanban-column-head{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:10px 12px;border-bottom:1px solid var(--border);font-size:13px;font-weight:600;color:var(--text);}
 .kanban-count{font-size:11px;color:var(--muted);background:var(--input-bg);border:1px solid var(--border);border-radius:999px;padding:1px 7px;}
-.kanban-column-body{display:flex;flex-direction:column;gap:8px;padding:10px;min-height:0;overflow-y:auto;}
+.kanban-column-body{display:flex;flex-direction:column;gap:8px;padding:10px;min-height:0;max-height:min(68vh,720px);overflow-y:auto;overscroll-behavior:contain;scrollbar-gutter:stable;}
 .kanban-card{border:1px solid var(--border);border-radius:9px;background:var(--bg);padding:10px;cursor:pointer;box-shadow:var(--shadow-sm);}
 .kanban-card:hover,.kanban-card.selected{border-color:var(--accent);}
 .kanban-card-title{font-size:13px;font-weight:650;color:var(--text);line-height:1.35;margin-bottom:6px;}

--- a/tests/test_kanban_board_ui.py
+++ b/tests/test_kanban_board_ui.py
@@ -1,0 +1,27 @@
+"""Source-level regression tests for the Kanban board UI."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
+PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+
+
+def _css_rule(selector: str) -> str:
+    start = STYLE_CSS.find(selector + "{")
+    assert start != -1, f"missing CSS selector: {selector}"
+    end = STYLE_CSS.find("}", start)
+    assert end != -1, f"unterminated CSS selector: {selector}"
+    return STYLE_CSS[start : end + 1]
+
+
+def test_kanban_columns_render_scrollable_card_lists():
+    assert 'class="kanban-column-body"' in PANELS_JS
+    assert "tasks.map(task => _kanbanCard(task, col.name)).join('')" in PANELS_JS
+
+    rule = _css_rule(".kanban-column-body")
+    assert "max-height:min(68vh,720px)" in rule
+    assert "overflow-y:auto" in rule
+    assert "overscroll-behavior:contain" in rule
+    assert "scrollbar-gutter:stable" in rule


### PR DESCRIPTION
## Summary
- Cap Kanban column card-list height with `max-height:min(68vh,720px)`.
- Keep overflow scrolling inside `.kanban-column-body` with `overflow-y:auto`, `overscroll-behavior:contain`, and stable scrollbar gutter.
- Add a source-level regression test so the Tasks/Kanban board keeps rendering cards inside the scrollable list container.

## Test plan
- `./scripts/test.sh tests/test_kanban_board_ui.py -q` → `1 passed`
- `.venv/bin/ruff check tests/test_kanban_board_ui.py` → passed
- `node --check static/panels.js` → passed
- `git diff --check` → passed
- `.venv/bin/python tests/browser_smoke.py` → passed (`/`, `/#settings`, `/#sessions` no console errors)
