### PR TITLE
Release v0.51.626 — keep sidebar in sync after Desktop app continues a session (#4834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **WebUI-created sessions stay in sync after the official Hermes Desktop App continues the same Hermes Agent session.** The conversation sidebar now refreshes WebUI-origin rows from settled `state.db` message counts/timestamps even when external/CLI sessions are hidden, full session loads avoid duplicating the sidecar prefix when merging `state.db`, and the next WebUI turn saves a single reconciled transcript instead of re-writing duplicated history.
+
 ## [v0.51.623] — 2026-06-24 — Release WD (iOS portrait: opening a conversation lands at the bottom)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 
 ## [Unreleased]
 
+## [v0.51.626] — 2026-06-24 — Release WG (keep the sidebar in sync after the Desktop app continues a session)
+
 ### Fixed
 
-- **WebUI-created sessions stay in sync after the official Hermes Desktop App continues the same Hermes Agent session.** The conversation sidebar now refreshes WebUI-origin rows from settled `state.db` message counts/timestamps even when external/CLI sessions are hidden, full session loads avoid duplicating the sidecar prefix when merging `state.db`, and the next WebUI turn saves a single reconciled transcript instead of re-writing duplicated history.
+- **The conversation sidebar stays in sync after the official Hermes Desktop App continues a session that was started in the WebUI.** When the Desktop app appends settled rows to the same Hermes Agent `state.db` session, the WebUI sidebar now refreshes the WebUI-origin row's message count and timestamp from `state.db` even while external/CLI sessions are hidden (previously it could show a stale count). The existing no-duplicate-prefix merge and single-reconciled-transcript-on-next-turn behaviors are now covered by regression tests against this Desktop-continuation scenario. The change is read-only and content-free — it adjusts the sidebar's count/timestamp/source overlay only, never message content. Thanks @franksong2702. (#4834)
 
 ## [v0.51.625] — 2026-06-24 — Release WF (cron job model override no longer keeps the @provider: display prefix)
 

--- a/api/models.py
+++ b/api/models.py
@@ -3226,6 +3226,18 @@ def _read_state_db_sidebar_overrides(db_path: Path, session_ids: set[str]) -> di
             source_expr = 's.source' if 'source' in session_cols else 'NULL AS source'
             session_source_expr = 's.session_source' if 'session_source' in session_cols else 'NULL AS session_source'
             title_expr = 's.title' if 'title' in session_cols else 'NULL AS title'
+            message_count_expr = 's.message_count' if 'message_count' in session_cols else 'NULL AS message_count'
+
+            cur.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'messages'")
+            has_messages_table = cur.fetchone() is not None
+            messages_has_session_id = False
+            messages_has_timestamp = False
+            if has_messages_table:
+                cur.execute("PRAGMA table_info(messages)")
+                message_cols = {str(row[1]) for row in cur.fetchall()}
+                messages_has_session_id = 'session_id' in message_cols
+                messages_has_timestamp = 'timestamp' in message_cols
+
             overrides: dict[str, dict] = {}
             ids = list(wanted)
             chunk_size = 500
@@ -3234,7 +3246,7 @@ def _read_state_db_sidebar_overrides(db_path: Path, session_ids: set[str]) -> di
                 placeholders = ','.join('?' * len(chunk))
                 cur.execute(
                     f"""
-                    SELECT s.id, {source_expr}, {session_source_expr}, {title_expr}
+                    SELECT s.id, {source_expr}, {session_source_expr}, {title_expr}, {message_count_expr}
                     FROM sessions s
                     WHERE s.id IN ({placeholders})
                     """,
@@ -3254,8 +3266,39 @@ def _read_state_db_sidebar_overrides(db_path: Path, session_ids: set[str]) -> di
                         entry['_state_db_raw_source'] = source_meta.get('raw_source')
                         entry['_state_db_session_source'] = source_meta.get('session_source')
                         entry['_state_db_source_label'] = source_meta.get('source_label')
+                    if row['message_count'] is not None:
+                        try:
+                            entry['_state_db_message_count'] = max(0, int(row['message_count'] or 0))
+                        except (TypeError, ValueError):
+                            pass
                     if entry:
                         overrides[sid] = entry
+                if has_messages_table and messages_has_session_id:
+                    last_at_expr = "MAX(timestamp) AS last_message_at" if messages_has_timestamp else "NULL AS last_message_at"
+                    cur.execute(
+                        f"""
+                        SELECT session_id, COUNT(*) AS actual_message_count, {last_at_expr}
+                        FROM messages
+                        WHERE session_id IN ({placeholders})
+                        GROUP BY session_id
+                        """,
+                        chunk,
+                    )
+                    for row in cur.fetchall():
+                        sid = str(row['session_id'])
+                        entry = overrides.setdefault(sid, {})
+                        try:
+                            entry['_state_db_message_count'] = max(
+                                int(entry.get('_state_db_message_count') or 0),
+                                int(row['actual_message_count'] or 0),
+                            )
+                        except (TypeError, ValueError):
+                            pass
+                        if row['last_message_at'] is not None:
+                            try:
+                                entry['_state_db_last_message_at'] = float(row['last_message_at'] or 0)
+                            except (TypeError, ValueError):
+                                pass
             return overrides
     except Exception:
         return {}
@@ -3285,12 +3328,40 @@ def _apply_sidebar_state_db_override_metadata(sessions: list[dict], metadata: di
         state_db_raw_source = entry.pop('_state_db_raw_source', None)
         state_db_session_source = entry.pop('_state_db_session_source', None)
         state_db_source_label = entry.pop('_state_db_source_label', None)
+        state_db_message_count = entry.pop('_state_db_message_count', None)
+        state_db_last_message_at = entry.pop('_state_db_last_message_at', None)
         if state_db_source == 'webui':
             session['source_tag'] = state_db_source_tag
             session['raw_source'] = state_db_raw_source
             session['session_source'] = state_db_session_source
             session['source_label'] = state_db_source_label
             session['is_cli_session'] = False
+            try:
+                current_count = max(0, int(session.get('message_count') or 0))
+                state_count = max(0, int(state_db_message_count or 0))
+            except (TypeError, ValueError):
+                current_count = 0
+                state_count = 0
+            try:
+                current_last = max(
+                    float(session.get('last_message_at') or 0),
+                    float(session.get('updated_at') or 0),
+                )
+            except (TypeError, ValueError):
+                current_last = 0.0
+            try:
+                state_last = float(state_db_last_message_at or 0)
+            except (TypeError, ValueError):
+                state_last = 0.0
+            if state_count > current_count and (state_last <= 0 or state_last > current_last):
+                session['message_count'] = state_count
+                session['actual_message_count'] = max(
+                    state_count,
+                    int(session.get('actual_message_count') or 0) if str(session.get('actual_message_count') or '').isdigit() else 0,
+                )
+                if state_last > 0:
+                    session['last_message_at'] = max(float(session.get('last_message_at') or 0), state_last)
+                    session['updated_at'] = max(float(session.get('updated_at') or 0), state_last)
         title = session.get('title')
         if (
             state_db_title

--- a/api/routes.py
+++ b/api/routes.py
@@ -1761,9 +1761,7 @@ def _session_list_cache_streaming_freeze_marker():
 
 
 def _session_list_cache_source_stamp(key: tuple) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int], object, int]:
-    _cache_profile, _cache_all_profiles, cache_show_cli_sessions, *_rest = key
-    if not cache_show_cli_sessions:
-        return ((0, 0), (0, 0), (0, 0), (0, 0), (0, 0), None, 0)
+    _cache_profile, _cache_all_profiles, _cache_show_cli_sessions, *_rest = key
     try:
         settings_file = SETTINGS_FILE
     except Exception:
@@ -1773,6 +1771,10 @@ def _session_list_cache_source_stamp(key: tuple) -> tuple[tuple[int, int], tuple
         swv = _SETTINGS_WRITE_VERSION
     except Exception:
         swv = 0
+    # WebUI-origin sessions can also receive settled rows in state.db when the
+    # official Hermes Desktop App continues the same agent session.  The sidebar
+    # therefore watches state.db even when the CLI/external-session tab is hidden.
+    #
     # Streaming hold-down (#4672): while a turn is in flight, collapse the
     # volatile state.db-derived components (db/WAL stat, gateway metadata, index
     # stat, content fingerprint) to a marker that only changes when a stream

--- a/tests/test_webui_state_db_context_reconciliation.py
+++ b/tests/test_webui_state_db_context_reconciliation.py
@@ -1,4 +1,3 @@
-import json
 import queue
 import sqlite3
 from collections import OrderedDict
@@ -130,6 +129,19 @@ def test_next_webui_turn_context_includes_state_db_external_messages(monkeypatch
         "external gateway user",
         "external gateway assistant",
     ]
+
+    reloaded = models.Session.load(sid)
+    saved_contents = [m.get("content") for m in (reloaded.messages if reloaded else [])]
+    assert saved_contents == [
+        "old user",
+        "old assistant",
+        "external gateway user",
+        "external gateway assistant",
+        "new webui turn",
+        "ok",
+    ]
+    assert saved_contents.count("old user") == 1
+    assert saved_contents.count("external gateway user") == 1
 
 
 def test_state_db_delta_after_context_allows_recovered_turn_prefix():

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -69,6 +69,31 @@ def _make_state_db(path: Path, sid: str, rows):
     conn.close()
 
 
+def _append_state_db_rows(path: Path, sid: str, rows):
+    conn = sqlite3.connect(path)
+    try:
+        for row in rows:
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content, timestamp, tool_call_id, tool_calls, tool_name) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    sid,
+                    row["role"],
+                    row["content"],
+                    row.get("timestamp", 1000.0),
+                    row.get("tool_call_id"),
+                    row.get("tool_calls"),
+                    row.get("tool_name"),
+                ),
+            )
+        conn.execute(
+            "UPDATE sessions SET message_count = (SELECT COUNT(*) FROM messages WHERE session_id = ?) WHERE id = ?",
+            (sid, sid),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages):
     import api.config as config
     import api.models as models
@@ -171,6 +196,80 @@ def test_state_db_duplicate_backfills_turn_duration():
 
     assert len(merged) == 1
     assert merged[0]["_turnDuration"] == 42.5
+
+
+def test_api_sessions_overlays_webui_state_db_summary_after_desktop_append(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_desktop_sidebar_reconcile"
+    sidecar_messages = [
+        {"role": "user", "content": "old user", "timestamp": 1000.0},
+        {"role": "assistant", "content": "old assistant", "timestamp": 1001.0},
+    ]
+    _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    _make_state_db(tmp_path / "state.db", sid, list(sidecar_messages))
+    monkeypatch.setattr(routes, "load_settings", lambda: {"show_cli_sessions": False})
+    routes._clear_session_list_cache()
+
+    first = _GetHandler("/api/sessions?sidebar_source=webui")
+    routes.handle_get(first, urlparse(first.path))
+    assert first.status == 200
+    first_row = next(row for row in first.response_json["sessions"] if row["session_id"] == sid)
+    assert first_row["message_count"] == 2
+
+    # Simulate the official Hermes Desktop App continuing the same WebUI-origin
+    # Hermes Agent session and settling its final rows into state.db. The second
+    # request happens immediately, so it only updates if the WebUI sidebar cache
+    # observes state.db changes even when the CLI/external-session tab is hidden.
+    _append_state_db_rows(
+        tmp_path / "state.db",
+        sid,
+        [
+            {"role": "user", "content": "desktop user", "timestamp": 1002.0},
+            {"role": "assistant", "content": "desktop assistant", "timestamp": 1003.0},
+        ],
+    )
+
+    second = _GetHandler("/api/sessions?sidebar_source=webui")
+    routes.handle_get(second, urlparse(second.path))
+    assert second.status == 200
+    row = next(row for row in second.response_json["sessions"] if row["session_id"] == sid)
+    assert row["message_count"] == 4
+    assert row["last_message_at"] == 1003.0
+    assert row["updated_at"] == 1003.0
+
+
+def test_api_session_full_load_does_not_duplicate_state_db_prefix(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_desktop_full_reconcile"
+    sidecar_messages = [
+        {"role": "user", "content": "turn 1", "timestamp": 1000.0},
+        {"role": "assistant", "content": "answer 1", "timestamp": 1001.0},
+        {"role": "user", "content": "turn 2", "timestamp": 1002.0},
+    ]
+    desktop_tail = [
+        {"role": "assistant", "content": "answer 2 from desktop", "timestamp": 1003.0},
+        {"role": "user", "content": "desktop follow-up", "timestamp": 1004.0},
+        {"role": "assistant", "content": "desktop final", "timestamp": 1005.0},
+    ]
+    _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    _make_state_db(tmp_path / "state.db", sid, sidecar_messages + desktop_tail)
+
+    handler = _GetHandler(f"/api/session?session_id={sid}&messages=1&resolve_model=0")
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    messages = handler.response_json["session"]["messages"]
+    assert [m["content"] for m in messages] == [
+        "turn 1",
+        "answer 1",
+        "turn 2",
+        "answer 2 from desktop",
+        "desktop follow-up",
+        "desktop final",
+    ]
+    assert handler.response_json["session"]["message_count"] == 6
 
 
 def test_api_session_includes_state_db_messages_newer_than_webui_sidecar(monkeypatch, tmp_path):


### PR DESCRIPTION
## Release v0.51.626 — keep the sidebar in sync after the Desktop app continues a session (#4834)

Ships **#4834** (by @franksong2702). Reconciliation fix on the WebUI↔state.db sidebar path.

### What it does
When the official Hermes Desktop App appends settled rows to the same Hermes Agent `state.db` session that was started in the WebUI, the WebUI conversation sidebar showed a stale message count. It now refreshes the WebUI-origin row's count/timestamp from `state.db` even while external/CLI sessions are hidden. The no-duplicate-prefix merge and single-reconciled-transcript-on-next-turn behaviors (pre-existing) are now covered by regression tests for this Desktop-continuation scenario.

### Gate (deep — this is the crown-jewel reconciliation family where the #4772 P0 lives)
- **Codex** (GPT-5.5): SAFE TO SHIP — sidebar override applies only count/timestamp/source-tag (no hidden-session content leak), no message-loss/duplication across the reconciliation hunks; 31 reconciliation tests pass.
- **Opus** (claude-opus-4-8): SAFE TO SHIP — confirmed the genuinely-new surface is "read-only, webui-gated, content-free, monotonic-up — structurally cannot cause the ghost/message-loss class because it never writes message content and never touches the merge/save path." (Flagged a cosmetic count-vs-watermark display divergence — display-only, no data loss.)
- **Full suite:** 10366 passed, 0 failed.

CHANGELOG wording tightened per the Opus review to reflect that the dedup/writeback guarantees are *tested* here, not introduced.

Closes #4834.
