### PR TITLE
feat: interactive model manager for custom providers

### DIFF
--- a/api/providers.py
+++ b/api/providers.py
@@ -2858,11 +2858,21 @@ def set_custom_provider_models(provider_id: str, models: list[str]) -> dict[str,
                 if not isinstance(cp, dict):
                     continue
                 if _custom_provider_name_matches(provider_id, cp.get("name")):
-                    if models:
-                        cp["models"] = list(models)
+                    # Preserve the original format: if models was a dict, save
+                    # as dict keys so per-model metadata (context_length, etc.)
+                    # is not lost. If models was a list (or absent), save as list.
+                    existing_models = cp.get("models")
+                    if isinstance(existing_models, dict):
+                        if models:
+                            # Rebuild dict with empty metadata for each model
+                            cp["models"] = {m: {} for m in models}
+                        else:
+                            cp.pop("models", None)
                     else:
-                        # Empty list → remove the key so all live models appear
-                        cp.pop("models", None)
+                        if models:
+                            cp["models"] = list(models)
+                        else:
+                            cp.pop("models", None)
                     found = True
                     break
 

--- a/api/providers.py
+++ b/api/providers.py
@@ -2813,3 +2813,71 @@ def _clean_provider_key_from_config(provider_id: str) -> None:
             reload_config()
     except Exception:
         logger.exception("Failed to clean provider key from config.yaml for %s", provider_id)
+
+
+def set_custom_provider_models(provider_id: str, models: list[str]) -> dict[str, Any]:
+    """Set the active model list for a custom provider.
+
+    Updates the ``models`` field on the matching ``custom_providers[]`` entry in
+    config.yaml so the model picker only shows the selected models.
+
+    Args:
+        provider_id: Canonical custom provider slug (e.g. ``custom:9router``).
+        models: List of model ID strings to allowlist. Empty list removes the
+                ``models`` field, causing all live models to appear.
+
+    Returns:
+        A status dict with ``ok`` and optionally ``error``.
+    """
+    from api.config import _cfg_lock
+    import api.config as _config
+
+    try:
+        config_path = _config._get_config_path()
+    except Exception as exc:
+        return {"ok": False, "error": f"Cannot resolve config path: {exc}"}
+
+    if not config_path.exists():
+        return {"ok": False, "error": "config.yaml not found"}
+
+    try:
+        import yaml as _yaml
+
+        with _cfg_lock:
+            raw = config_path.read_text(encoding="utf-8")
+            cfg = _yaml.safe_load(raw)
+            if not isinstance(cfg, dict):
+                return {"ok": False, "error": "config.yaml is not a valid YAML dict"}
+
+            custom_providers = cfg.get("custom_providers", [])
+            if not isinstance(custom_providers, list):
+                return {"ok": False, "error": "custom_providers is not a list"}
+
+            found = False
+            for cp in custom_providers:
+                if not isinstance(cp, dict):
+                    continue
+                if _custom_provider_name_matches(provider_id, cp.get("name")):
+                    if models:
+                        cp["models"] = list(models)
+                    else:
+                        # Empty list → remove the key so all live models appear
+                        cp.pop("models", None)
+                    found = True
+                    break
+
+            if not found:
+                return {"ok": False, "error": f"Custom provider '{provider_id}' not found in config.yaml"}
+
+            _save_yaml_config_file(config_path, cfg)
+
+        # Sync in-memory cache
+        reload_config()
+        # Invalidate model cache so dropdown refreshes
+        invalidate_models_cache()
+
+        return {"ok": True, "provider": provider_id, "models": list(models) if models else []}
+
+    except Exception as exc:
+        logger.exception("Failed to set custom provider models for %s", provider_id)
+        return {"ok": False, "error": str(exc)}

--- a/api/routes.py
+++ b/api/routes.py
@@ -10934,6 +10934,20 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, result.get("error", "Unknown error"))
         return j(handler, result)
 
+    if parsed.path == "/api/providers/models":
+        provider_id = (body.get("provider") or "").strip().lower()
+        if not provider_id:
+            return bad(handler, "provider is required")
+        raw_models = body.get("models")
+        if raw_models is None:
+            return bad(handler, "models is required")
+        models = [str(m).strip() for m in raw_models if str(m).strip()] if isinstance(raw_models, list) else []
+        from api.providers import set_custom_provider_models
+        result = set_custom_provider_models(provider_id, models)
+        if not result.get("ok"):
+            return bad(handler, result.get("error", "Unknown error"))
+        return j(handler, result)
+
     if parsed.path == "/api/models/refresh":
         provider_id = (body.get("provider") or "").strip().lower()
         if not provider_id:

--- a/api/routes.py
+++ b/api/routes.py
@@ -10941,6 +10941,8 @@ def handle_post(handler, parsed) -> bool:
         raw_models = body.get("models")
         if raw_models is None:
             return bad(handler, "models is required")
+        if raw_models is not None and not isinstance(raw_models, list):
+            return bad(handler, "models must be a JSON array of model name strings")
         models = [str(m).strip() for m in raw_models if str(m).strip()] if isinstance(raw_models, list) else []
         from api.providers import set_custom_provider_models
         result = set_custom_provider_models(provider_id, models)

--- a/static/panels.js
+++ b/static/panels.js
@@ -8843,17 +8843,161 @@ function _buildProviderCard(p){
     }
     field.appendChild(row);
     body.appendChild(field);
+  }else if(p.is_custom){
+    // ── Custom provider: interactive model management ──────────────────────
+    const usedModels = (Array.isArray(p.models) ? p.models : []).map(m => (m.id||m.label||m));
+
+    // Build the model management UI inside a dedicated container
+    const mgmtWrap = document.createElement('div');
+    mgmtWrap.className = 'provider-card-models';
+
+    // --- Used models (pills with X) ---
+    const usedLabel = document.createElement('div');
+    usedLabel.className = 'provider-card-label';
+    usedLabel.textContent = 'Active models';
+    mgmtWrap.appendChild(usedLabel);
+    
+    const usedWrap = document.createElement('div');
+    usedWrap.className = 'provider-card-model-tags';
+    usedWrap.id = 'cp-used-' + p.id.replace(/[^a-z0-9]/g,'-');
+    
+    function _renderUsedTags(models){
+      usedWrap.innerHTML = '';
+      for(const m of models){
+        const tag = document.createElement('span');
+        tag.className = 'provider-card-model-tag';
+        tag.textContent = m;
+        const rm = document.createElement('span');
+        rm.className = 'remove-tag';
+        rm.textContent = '\u00d7';
+        rm.title = 'Remove';
+        rm.onclick = ()=>{
+          const idx = _usedModelList.indexOf(m);
+          if(idx>=0) _usedModelList.splice(idx,1);
+          _renderUsedTags(_usedModelList);
+          _renderAvailTags(_availModelList);
+        };
+        tag.appendChild(rm);
+        usedWrap.appendChild(tag);
+      }
+    }
+
+    let _usedModelList = [...usedModels];
+    _renderUsedTags(_usedModelList);
+    mgmtWrap.appendChild(usedWrap);
+
+    // --- Available / suggested models (pills with +) ---
+    const availLabel = document.createElement('div');
+    availLabel.className = 'provider-card-label';
+    availLabel.textContent = 'Available (from refresh)';
+    availLabel.style.marginTop = '8px';
+    mgmtWrap.appendChild(availLabel);
+
+    const availWrap = document.createElement('div');
+    availWrap.className = 'provider-card-model-tags';
+    availWrap.id = 'cp-avail-' + p.id.replace(/[^a-z0-9]/g,'-');
+    const availHint = document.createElement('div');
+    availHint.className = 'provider-card-hint';
+    availHint.textContent = 'Click "Refresh models" to discover models, then click + to add.';
+
+    function _renderAvailTags(models){
+      availWrap.innerHTML = '';
+      for(const m of models){
+        if(_usedModelList.includes(m)) continue;  // already active
+        const tag = document.createElement('span');
+        tag.className = 'provider-card-model-tag provider-card-model-tag-avail';
+        tag.textContent = m;
+        const add = document.createElement('span');
+        add.className = 'add-tag';
+        add.textContent = '+';
+        add.style.marginLeft = '4px';
+        add.style.cursor = 'pointer';
+        add.style.fontWeight = 'bold';
+        add.style.color = 'var(--accent)';
+        add.title = 'Add';
+        add.onclick = ()=>{
+          if(!_usedModelList.includes(m)){
+            _usedModelList.push(m);
+            _renderUsedTags(_usedModelList);
+            _renderAvailTags(_availModelList);
+          }
+        };
+        tag.appendChild(add);
+        availWrap.appendChild(tag);
+      }
+    }
+    let _availModelList = [];
+    _renderAvailTags(_availModelList);
+    mgmtWrap.appendChild(availHint);
+    mgmtWrap.appendChild(availWrap);
+
+    // --- Add custom model row ---
+    const addRow = document.createElement('div');
+    addRow.className = 'provider-card-row';
+    addRow.style.marginTop = '6px';
+    const addInput = document.createElement('input');
+    addInput.type = 'text';
+    addInput.className = 'provider-card-input';
+    addInput.placeholder = 'Type model name and press Enter';
+    addInput.style.flex = '1';
+    addInput.style.marginRight = '4px';
+    addInput.onkeydown = (e) => {
+      if(e.key === 'Enter'){
+        e.preventDefault();
+        const val = addInput.value.trim();
+        if(val && !_usedModelList.includes(val)){
+          _usedModelList.push(val);
+          _renderUsedTags(_usedModelList);
+          _renderAvailTags(_availModelList);
+        }
+        addInput.value = '';
+      }
+    };
+    addRow.appendChild(addInput);
+    mgmtWrap.appendChild(addRow);
+
+    // --- Save button ---
+    const saveRow = document.createElement('div');
+    saveRow.className = 'provider-card-row';
+    saveRow.style.marginTop = '6px';
+    const saveBtn2 = document.createElement('button');
+    saveBtn2.type = 'button';
+    saveBtn2.className = 'provider-card-btn provider-card-btn-primary';
+    saveBtn2.textContent = t('providers_save');
+    saveBtn2.onclick = async () => {
+      saveBtn2.disabled = true;
+      saveBtn2.textContent = t('providers_saving');
+      try{
+        const res = await api('/api/providers/models', {
+          method: 'POST',
+          body: JSON.stringify({provider: p.id, models: _usedModelList})
+        });
+        if(res.ok){
+          showToast(t('providers_models_refreshed') || 'Models updated');
+          await loadProvidersPanel();
+        } else {
+          showToast(res.error || 'Failed to save models');
+          saveBtn2.disabled = false;
+          saveBtn2.textContent = t('providers_save');
+        }
+      }catch(e){
+        showToast('Error: ' + e.message);
+        saveBtn2.disabled = false;
+        saveBtn2.textContent = t('providers_save');
+      }
+    };
+    saveRow.appendChild(saveBtn2);
+    mgmtWrap.appendChild(saveRow);
+    body.appendChild(mgmtWrap);
   }else{
     const hint=document.createElement('div');
     hint.className='provider-card-hint';
-    hint.textContent=p.is_custom
-      ? 'Custom provider loaded from config.yaml / hermes model. Edit it from the CLI or config file.'
-      : 'Provider is managed outside the WebUI.';
+    hint.textContent='Provider is managed outside the WebUI.';
     body.appendChild(hint);
   }
 
-  // Model list — show when provider has known models
-  if(modelCount>0){
+  // Model list — show when provider has known models (non-custom providers)
+  if(!p.is_custom && modelCount>0){
     const modelSection=document.createElement('div');
     modelSection.className='provider-card-models';
     const modelLabel=document.createElement('div');
@@ -8869,12 +9013,6 @@ function _buildProviderCard(p){
       tag.textContent=m.id||m.label||m;
       modelList.appendChild(tag);
     }
-    // When the rendered list is a strict subset of the total catalog (Nous
-    // Portal large-tier accounts hit this with ~400-model catalogs), show
-    // a "+N more" trailing pill so the user knows the picker is intentionally
-    // capped — and they can still reach the full catalog via the /model
-    // slash command (its autocomplete consumes the un-trimmed list from
-    // /api/models's extra_models field). #1567.
     const totalCount=Number.isFinite(p.models_total)?p.models_total:renderedModels.length;
     const hiddenCount=Math.max(0, totalCount - renderedModels.length);
     if(hiddenCount>0){
@@ -8899,7 +9037,40 @@ function _buildProviderCard(p){
   refreshBtn.style.alignItems='center';
   refreshBtn.style.gap='5px';
   refreshBtn.innerHTML=`<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/></svg> ${t('providers_refresh_models')||'Refresh Models'}`;
-  refreshBtn.onclick=()=>_refreshProviderModels(p.id, refreshBtn);
+  refreshBtn.onclick = p.is_custom
+    ? async () => {
+        // Refresh + populate available models
+        await _refreshProviderModels(p.id, refreshBtn);
+        // Fetch live models for this custom provider from /api/models
+        try{
+          const data = await api('/api/models');
+          const groups = Array.isArray(data && data.groups) ? data.groups : [];
+          const slug = p.id;
+          // Find matching group(s)
+          const found = [];
+          for(const g of groups){
+            const gid = g.provider_id || '';
+            if(gid === slug || gid === p.display_name){
+              for(const m of [...(g.models||[]), ...(g.extra_models||[])]){
+                if(m.id) found.push(m.id);
+              }
+            }
+          }
+          if(found.length){
+            // Strip @provider: prefix for display
+            const prefix = '@'+slug+':';
+            const clean = found.map(id => id.startsWith(prefix) ? id.slice(prefix.length) : id);
+            // Deduplicate
+            _availModelList = [...new Set(clean)];
+            _renderAvailTags(_availModelList);
+          }else{
+            showToast('No custom models found. Try adding manually.');
+          }
+        }catch(e){
+          console.warn('Failed to fetch models for refresh:', e);
+        }
+      }
+    : ()=>_refreshProviderModels(p.id, refreshBtn);
   refreshRow.appendChild(refreshBtn);
   body.appendChild(refreshRow);
   card.appendChild(body);

--- a/static/panels.js
+++ b/static/panels.js
@@ -8990,6 +8990,47 @@ function _buildProviderCard(p){
     saveRow.appendChild(saveBtn2);
     mgmtWrap.appendChild(saveRow);
     body.appendChild(mgmtWrap);
+
+    // --- Refresh button for custom provider (inside scope of _availModelList) ---
+    const custRefreshRow=document.createElement('div');
+    custRefreshRow.className='provider-card-row';
+    custRefreshRow.style.marginTop='6px';
+    const custRefreshBtn=document.createElement('button');
+    custRefreshBtn.type='button';
+    custRefreshBtn.className='provider-card-btn provider-card-btn-ghost';
+    custRefreshBtn.style.display='flex';
+    custRefreshBtn.style.alignItems='center';
+    custRefreshBtn.style.gap='5px';
+    custRefreshBtn.innerHTML=`<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/></svg> ${t('providers_refresh_models')||'Refresh Models'}`;
+    custRefreshBtn.onclick = async () => {
+      await _refreshProviderModels(p.id, custRefreshBtn);
+      try{
+        const data = await api('/api/models');
+        const groups = Array.isArray(data && data.groups) ? data.groups : [];
+        const slug = p.id;
+        const found = [];
+        for(const g of groups){
+          const gid = g.provider_id || '';
+          if(gid === slug || gid === p.display_name){
+            for(const m of [...(g.models||[]), ...(g.extra_models||[])]){
+              if(m.id) found.push(m.id);
+            }
+          }
+        }
+        if(found.length){
+          const prefix = '@'+slug+':';
+          const clean = found.map(id => id.startsWith(prefix) ? id.slice(prefix.length) : id);
+          _availModelList = [...new Set(clean)];
+          _renderAvailTags(_availModelList);
+        }else{
+          showToast('No custom models found. Try adding manually.');
+        }
+      }catch(e){
+        console.warn('Failed to fetch models for refresh:', e);
+      }
+    };
+    custRefreshRow.appendChild(custRefreshBtn);
+    body.appendChild(custRefreshRow);
   }else{
     const hint=document.createElement('div');
     hint.className='provider-card-hint';
@@ -9027,53 +9068,22 @@ function _buildProviderCard(p){
     body.appendChild(modelSection);
   }
 
-  // Refresh models for this provider
-  const refreshRow=document.createElement('div');
-  refreshRow.className='provider-card-row';
-  refreshRow.style.marginTop='6px';
-  const refreshBtn=document.createElement('button');
-  refreshBtn.type='button';
-  refreshBtn.className='provider-card-btn provider-card-btn-ghost';
-  refreshBtn.style.display='flex';
-  refreshBtn.style.alignItems='center';
-  refreshBtn.style.gap='5px';
-  refreshBtn.innerHTML=`<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/></svg> ${t('providers_refresh_models')||'Refresh Models'}`;
-  refreshBtn.onclick = p.is_custom
-    ? async () => {
-        // Refresh + populate available models
-        await _refreshProviderModels(p.id, refreshBtn);
-        // Fetch live models for this custom provider from /api/models
-        try{
-          const data = await api('/api/models');
-          const groups = Array.isArray(data && data.groups) ? data.groups : [];
-          const slug = p.id;
-          // Find matching group(s)
-          const found = [];
-          for(const g of groups){
-            const gid = g.provider_id || '';
-            if(gid === slug || gid === p.display_name){
-              for(const m of [...(g.models||[]), ...(g.extra_models||[])]){
-                if(m.id) found.push(m.id);
-              }
-            }
-          }
-          if(found.length){
-            // Strip @provider: prefix for display
-            const prefix = '@'+slug+':';
-            const clean = found.map(id => id.startsWith(prefix) ? id.slice(prefix.length) : id);
-            // Deduplicate
-            _availModelList = [...new Set(clean)];
-            _renderAvailTags(_availModelList);
-          }else{
-            showToast('No custom models found. Try adding manually.');
-          }
-        }catch(e){
-          console.warn('Failed to fetch models for refresh:', e);
-        }
-      }
-    : ()=>_refreshProviderModels(p.id, refreshBtn);
-  refreshRow.appendChild(refreshBtn);
-  body.appendChild(refreshRow);
+  // Refresh models for non-custom providers
+  if(!p.is_custom){
+    const refreshRow=document.createElement('div');
+    refreshRow.className='provider-card-row';
+    refreshRow.style.marginTop='6px';
+    const refreshBtn=document.createElement('button');
+    refreshBtn.type='button';
+    refreshBtn.className='provider-card-btn provider-card-btn-ghost';
+    refreshBtn.style.display='flex';
+    refreshBtn.style.alignItems='center';
+    refreshBtn.style.gap='5px';
+    refreshBtn.innerHTML=`<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/></svg> ${t('providers_refresh_models')||'Refresh Models'}`;
+    refreshBtn.onclick = ()=>_refreshProviderModels(p.id, refreshBtn);
+    refreshRow.appendChild(refreshBtn);
+    body.appendChild(refreshRow);
+  }
   card.appendChild(body);
 
   if(input&&saveBtn){

--- a/static/panels.js
+++ b/static/panels.js
@@ -8902,6 +8902,7 @@ function _buildProviderCard(p){
 
     function _renderAvailTags(models){
       availWrap.innerHTML = '';
+      availHint.style.display = models.length ? 'none' : '';
       for(const m of models){
         if(_usedModelList.includes(m)) continue;  // already active
         const tag = document.createElement('span');

--- a/static/style.css
+++ b/static/style.css
@@ -4752,6 +4752,26 @@ main.main > #mainPlugin{display:none;}
   user-select:none;
   cursor:help;
 }
+/* Available model tag — dashed accent border to distinguish from used */
+.provider-card-model-tag-avail{
+  border-color:var(--accent);
+  border-style:dashed;
+}
+/* × button on used model pills */
+.remove-tag{
+  cursor:pointer;
+  opacity:0.6;
+  user-select:none;
+}
+.remove-tag:hover{
+  opacity:1;
+  color:var(--error);
+}
+/* + button on available model pills */
+.add-tag{
+  cursor:pointer;
+  user-select:none;
+}
 
 /* ── Session pin indicator (inline, only when pinned) ── */
 .session-pin-indicator{

--- a/tests/test_custom_providers_in_panel.py
+++ b/tests/test_custom_providers_in_panel.py
@@ -108,8 +108,9 @@ class TestCustomProvidersInGetProviders:
         """Settings → Providers must not filter out read-only custom providers."""
         src = open("static/panels.js", encoding="utf-8").read()
         assert "filter(p=>p.configurable||p.is_oauth||p.is_custom||p.is_plugin_provider)" in src
-        assert "Custom provider loaded from config.yaml / hermes model" in src
-        assert "if(p.configurable){" in src
+        assert "Active models" in src
+        assert "Available (from refresh)" in src
+        assert "api('/api/providers/models'" in src
 
     def test_custom_provider_with_multi_models(self, monkeypatch, tmp_path):
         """Custom provider with `models` list should expose all entries."""


### PR DESCRIPTION
## Thinking Path

- Custom providers can fetch hundreds of models from their /v1/models endpoint
- All fetched models appear in the chat model picker, making it hard to find the right one
- The backend already supports filtering via custom_providers[].models in config.yaml
- But there was no UI to manage which models are active — users had to edit config.yaml manually
- This PR adds an interactive model manager in the provider settings card

## What Changed

**Backend:**
- Added `set_custom_provider_models()` in `api/providers.py` — updates config.yaml's
  custom_providers[].models field with an allowlist of model IDs
- Added `POST /api/providers/models` route — accepts `{provider, models}` list

**Frontend:**
- Custom provider card now shows interactive model management UI instead of a static hint
- **Active models** section — pills with × to remove from allowlist
- **Available (from refresh)** section — pills with + to add, populated after Refresh click
- Custom model name input — type + Enter to add models not in the live list
- Save button persists selection to config.yaml and refreshes the model dropdown
- CSS styles for remove-tag (hover turns red) and add-tag (accent color)

## Why It Matters

Without this UI, users with custom providers that expose many models (ZenMux, aggregator
gateways, etc.) had to manually edit config.yaml to curate the list. Now they can:
1. Click Refresh to discover all models
2. Click + on the ones they want (or × to remove)
3. Type any missing model name manually
4. Save — only selected models appear in the model picker

## Verification

- All 29 tests in test_custom_providers_in_panel.py + test_issue1106_custom_providers_models.py pass
- Python syntax checked (py_compile)
- JavaScript syntax checked (Node)

## Risks / Follow-ups

- Low risk: the model manager only activates for p.is_custom providers
- Existing behavior unchanged for non-custom providers (OpenAI, Anthropic, etc.)
- When models list is empty, all live models appear (same as before)