### PR TITLE
Fix reconnect chronology by sorting anchor-scene rows by phase and started_at

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -2551,29 +2551,56 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!byIdx.has(idx)) byIdx.set(idx,[]);
       byIdx.get(idx).push(row);
     };
-    let order=0;
+    let encounter=0;
     for(let idx=turnStart+1;idx<lastAsstIndex;idx+=1){
       const message=messages[idx];
       if(!message||message.role!=='assistant') continue;
+      const pool=[];
       const text=_anchorSceneMessageText(message);
-      if(_anchorSceneCleanText(text)) add(idx,_anchorSceneProseRow(text,order++,idx));
+      if(_anchorSceneCleanText(text)){
+        pool.push({..._anchorSceneProseRow(text,0,idx),_phase:2,_encounter:encounter++});
+      }
       const reasoning=_anchorSceneMessageReasoningText(message);
       if(_anchorSceneCleanText(reasoning)&&_anchorSceneTextKey(reasoning)!==_anchorSceneTextKey(text)){
-        add(idx,_anchorSceneThinkingRow(reasoning,order++,idx));
+        pool.push({..._anchorSceneThinkingRow(reasoning,0,idx),_phase:0,_encounter:encounter++});
       }
       const messageTools=[];
       if(Array.isArray(message.tool_calls)) messageTools.push(...message.tool_calls);
       if(Array.isArray(message._partial_tool_calls)) messageTools.push(...message._partial_tool_calls);
+      const seenToolIds=new Set();
       for(const tool of messageTools){
-        add(idx,_anchorSceneToolRowFromCall(tool,order++,idx));
+        const row=_anchorSceneToolRowFromCall(tool,0,idx);
+        pool.push({...row,_phase:1,_encounter:encounter++});
+        const tid=row.tool_call_id||(row.tool&&row.tool.id);
+        if(tid) seenToolIds.add(tid);
       }
-    }
-    const toolCalls=Array.isArray(S.toolCalls)?S.toolCalls:[];
-    for(const tool of toolCalls){
-      if(!tool||typeof tool!=='object') continue;
-      const idx=Number(tool.assistant_msg_idx);
-      if(!Number.isFinite(idx)||idx<=turnStart||idx>=lastAsstIndex) continue;
-      add(idx,_anchorSceneToolRowFromCall(tool,order++,idx));
+      // Merge S.toolCalls for this index, dedup by tool id
+      const toolCalls=Array.isArray(S.toolCalls)?S.toolCalls:[];
+      for(const tool of toolCalls){
+        if(!tool||typeof tool!=='object') continue;
+        const toolIdx=Number(tool.assistant_msg_idx);
+        if(!Number.isFinite(toolIdx)||toolIdx!==idx) continue;
+        if(toolIdx<=turnStart||toolIdx>=lastAsstIndex) continue;
+        const row=_anchorSceneToolRowFromCall(tool,0,idx);
+        const tid=row.tool_call_id||(row.tool&&row.tool.id);
+        if(tid&&seenToolIds.has(tid)) continue;
+        if(tid) seenToolIds.add(tid);
+        pool.push({...row,_phase:1,_encounter:encounter++});
+      }
+      // Stable sort by (phase, started_at, encounter)
+      pool.sort((a,b)=>{
+        if(a._phase!==b._phase) return a._phase-b._phase;
+        const aTime=(a.tool&&a.tool.started_at!=null)?a.tool.started_at:Infinity;
+        const bTime=(b.tool&&b.tool.started_at!=null)?b.tool.started_at:Infinity;
+        if(aTime!==bTime) return aTime-bTime;
+        return a._encounter-b._encounter;
+      });
+      // Emit with sequential order_index values, strip temp props
+      for(const row of pool){
+        const {_phase,_encounter,...clean}=row;
+        clean.order_index=byIdx.has(idx)?byIdx.get(idx).length:0;
+        add(idx,clean);
+      }
     }
     return byIdx;
   }

--- a/static/messages.js
+++ b/static/messages.js
@@ -2551,6 +2551,15 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!byIdx.has(idx)) byIdx.set(idx,[]);
       byIdx.get(idx).push(row);
     };
+    // Pre-index S.toolCalls by assistant_msg_idx for O(m+n) lookup
+    const toolsByIdx=new Map();
+    if(S.toolCalls) for(const tc of S.toolCalls){
+      const ti=typeof tc.toolIdx==='number'? tc.toolIdx : parseInt(tc.assistant_msg_idx,10);
+      if(Number.isFinite(ti)){
+        if(!toolsByIdx.has(ti)) toolsByIdx.set(ti,[]);
+        toolsByIdx.get(ti).push(tc);
+      }
+    }
     let encounter=0;
     for(let idx=turnStart+1;idx<lastAsstIndex;idx+=1){
       const message=messages[idx];
@@ -2575,12 +2584,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         if(tid) seenToolIds.add(tid);
       }
       // Merge S.toolCalls for this index, dedup by tool id
-      const toolCalls=Array.isArray(S.toolCalls)?S.toolCalls:[];
-      for(const tool of toolCalls){
+      for(const tool of (toolsByIdx.get(idx)||[])){
         if(!tool||typeof tool!=='object') continue;
         const toolIdx=Number(tool.assistant_msg_idx);
         if(!Number.isFinite(toolIdx)||toolIdx!==idx) continue;
-        if(toolIdx<=turnStart||toolIdx>=lastAsstIndex) continue;
         const row=_anchorSceneToolRowFromCall(tool,0,idx);
         const tid=row.tool_call_id||(row.tool&&row.tool.id);
         if(tid&&seenToolIds.has(tid)) continue;

--- a/tests/test_issue4811_reconnect_chronology.py
+++ b/tests/test_issue4811_reconnect_chronology.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
-import textwrap
 from pathlib import Path
 
 import pytest

--- a/tests/test_issue4811_reconnect_chronology.py
+++ b/tests/test_issue4811_reconnect_chronology.py
@@ -1,0 +1,302 @@
+"""Regression coverage for #4811: reconnect session scrambles message chronology.
+
+_anchorSceneRowsByMessageIndex must emit rows in chronological order
+(thinking first, then tools sorted by started_at, then prose) regardless of
+whether tools come from the message object or from S.toolCalls.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+MESSAGES_JS = REPO_ROOT / "static" / "messages.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+# Driver: extracts all helper functions in the _anchorScene* family by scanning
+# the source for `function _anchorScene` blocks, then evaluates them with the
+# required closure variables (activeSid, streamId, S) in scope.  Accepts a JSON
+# payload on stdin and writes the byIdx map (as an object keyed by index) on stdout.
+_DRIVER_SRC = r"""
+'use strict';
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+
+// Extract every function whose name starts with _anchorScene
+// by brace-matching from the `function` keyword.
+function extractFunc(src, name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found in source');
+  let i = src.indexOf('{', start);
+  if (i < 0) throw new Error('No opening brace for ' + name);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+
+const funcNames = [
+  '_anchorSceneMessageText',
+  '_anchorSceneCleanText',
+  '_anchorSceneTextKey',
+  '_anchorSceneSafePayload',
+  '_anchorSceneToolId',
+  '_anchorSceneToolName',
+  '_anchorSceneToolArgs',
+  '_anchorSceneStringPayload',
+  '_anchorSceneRowBase',
+  '_anchorSceneProseRow',
+  '_anchorSceneThinkingRow',
+  '_anchorSceneToolRowFromCall',
+  '_anchorSceneMessageReasoningText',
+  '_anchorSceneRowsByMessageIndex',
+];
+
+// Build a self-contained module: closure variables + all functions + runner
+let code = '(function() {\n';
+// Closure variables that the functions reference
+code += 'var activeSid = "test-session";\n';
+code += 'var streamId = "test-stream";\n';
+// S is passed in from the test payload
+code += 'var S;\n';
+for (const name of funcNames) {
+  code += extractFunc(src, name) + '\n';
+}
+code += `
+var buf = '';
+process.stdin.on('data', function(c) { buf += c; });
+process.stdin.on('end', function() {
+  var payload = JSON.parse(buf || '{}');
+  S = payload.S || { toolCalls: [] };
+  var messages = payload.messages || [];
+  var turnStart = payload.turnStart !== undefined ? payload.turnStart : 0;
+  var lastAsstIndex = payload.lastAsstIndex !== undefined ? payload.lastAsstIndex : messages.length - 1;
+  var result = _anchorSceneRowsByMessageIndex(messages, turnStart, lastAsstIndex);
+  // Convert Map to plain object keyed by index
+  var out = {};
+  result.forEach(function(rows, idx) { out[idx] = rows; });
+  process.stdout.write(JSON.stringify(out));
+});
+})();
+`;
+
+process.stdout.write(code);
+"""
+
+# Generator driver: write the driver script to a temp file and return its path
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    gen_path = tmp_path_factory.mktemp("gen") / "gen.js"
+    gen_path.write_text(_DRIVER_SRC, encoding="utf-8")
+    # Run the generator to produce the actual driver
+    result = subprocess.run(
+        [NODE, str(gen_path), str(MESSAGES_JS)],
+        capture_output=True, text=True, timeout=15,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"Driver generation failed:\n{result.stderr}")
+    driver = tmp_path_factory.mktemp("driver") / "driver.js"
+    driver.write_text(result.stdout, encoding="utf-8")
+    return str(driver)
+
+
+def _run(driver_path: str, payload: dict) -> dict:
+    """Run the driver with the given payload; return parsed stdout as dict."""
+    assert NODE is not None
+    result = subprocess.run(
+        [NODE, driver_path],
+        input=json.dumps(payload),
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Node error:\n{result.stderr}")
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Helper builders
+# ---------------------------------------------------------------------------
+
+def _tool(tool_id: str, name: str = "terminal", started_at=None, args=None):
+    t = {"id": tool_id, "name": name, "done": True}
+    if started_at is not None:
+        t["started_at"] = started_at
+    if args is not None:
+        t["args"] = args
+    return t
+
+
+def _s_tool(tool_id: str, assistant_msg_idx: int, name: str = "terminal", started_at=None):
+    t = {"id": tool_id, "name": name, "done": True, "assistant_msg_idx": assistant_msg_idx}
+    if started_at is not None:
+        t["started_at"] = started_at
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_thinking_before_tools_before_prose(driver_path):
+    """Phase ordering: thinking (0) < tools (1) < prose (2)."""
+    messages = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": "I did it",
+            "reasoning": "thinking first",
+            "tool_calls": [_tool("t1", started_at=100)],
+        },
+        {"role": "assistant", "content": "final answer"},
+    ]
+    payload = {"messages": messages, "turnStart": 0, "lastAsstIndex": 2, "S": {"toolCalls": []}}
+    out = _run(driver_path, payload)
+    assert "1" in out
+    rows = out["1"]
+    roles = [r["role"] for r in rows]
+    assert roles == ["thinking", "tool", "prose"], f"Expected thinking/tool/prose, got {roles}"
+
+
+def test_reconnect_tools_interleave_by_started_at(driver_path):
+    """S.toolCalls entries interleave chronologically with message-local tools."""
+    messages = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": "progress",
+            "tool_calls": [
+                _tool("t-100", started_at=100),
+                _tool("t-300", started_at=300),
+            ],
+        },
+        {"role": "assistant", "content": "final"},
+    ]
+    # reconnect tool at started_at=150 should land between t-100 and t-300
+    s_tool_calls = [_s_tool("t-150", assistant_msg_idx=1, started_at=150)]
+    payload = {"messages": messages, "turnStart": 0, "lastAsstIndex": 2, "S": {"toolCalls": s_tool_calls}}
+    out = _run(driver_path, payload)
+    rows = out["1"]
+    tool_rows = [r for r in rows if r["role"] == "tool"]
+    tool_ids = [r["tool_call_id"] for r in tool_rows]
+    assert tool_ids == ["t-100", "t-150", "t-300"], f"Expected t-100/t-150/t-300 order, got {tool_ids}"
+
+
+def test_no_duplicate_when_s_toolcalls_repeats_message_tool(driver_path):
+    """Dedup: S.toolCalls must not add a second row for a tool already in message.tool_calls."""
+    messages = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": "progress",
+            "tool_calls": [_tool("dup-id", started_at=100)],
+        },
+        {"role": "assistant", "content": "final"},
+    ]
+    s_tool_calls = [_s_tool("dup-id", assistant_msg_idx=1, started_at=100)]
+    payload = {"messages": messages, "turnStart": 0, "lastAsstIndex": 2, "S": {"toolCalls": s_tool_calls}}
+    out = _run(driver_path, payload)
+    rows = out["1"]
+    tool_rows = [r for r in rows if r["role"] == "tool"]
+    assert len(tool_rows) == 1, f"Expected 1 tool row (deduped), got {len(tool_rows)}"
+    assert tool_rows[0]["tool_call_id"] == "dup-id"
+
+
+def test_deterministic_order_without_started_at(driver_path):
+    """When started_at is missing, encounter order (insertion order) is the tiebreaker."""
+    messages = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": "progress",
+            "tool_calls": [
+                _tool("first"),
+                _tool("second"),
+                _tool("third"),
+            ],
+        },
+        {"role": "assistant", "content": "final"},
+    ]
+    payload = {"messages": messages, "turnStart": 0, "lastAsstIndex": 2, "S": {"toolCalls": []}}
+    out = _run(driver_path, payload)
+    rows = out["1"]
+    tool_rows = [r for r in rows if r["role"] == "tool"]
+    tool_ids = [r["tool_call_id"] for r in tool_rows]
+    assert tool_ids == ["first", "second", "third"], f"Expected insertion order, got {tool_ids}"
+
+
+def test_cross_message_index_ordering_preserved(driver_path):
+    """Tools from different message indices stay in their own buckets."""
+    messages = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": "step 1",
+            "tool_calls": [_tool("t-idx1", started_at=100)],
+        },
+        {
+            "role": "assistant",
+            "content": "step 2",
+            "tool_calls": [_tool("t-idx2", started_at=50)],
+        },
+        {"role": "assistant", "content": "final"},
+    ]
+    payload = {"messages": messages, "turnStart": 0, "lastAsstIndex": 3, "S": {"toolCalls": []}}
+    out = _run(driver_path, payload)
+    assert "1" in out and "2" in out
+    idx1_tools = [r["tool_call_id"] for r in out["1"] if r["role"] == "tool"]
+    idx2_tools = [r["tool_call_id"] for r in out["2"] if r["role"] == "tool"]
+    assert idx1_tools == ["t-idx1"]
+    assert idx2_tools == ["t-idx2"]
+
+
+def test_s_toolcalls_outside_turn_range_ignored(driver_path):
+    """S.toolCalls entries with assistant_msg_idx outside [turnStart+1, lastAsstIndex) are dropped."""
+    messages = [
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "content": "step"},
+        {"role": "assistant", "content": "final"},
+    ]
+    s_tool_calls = [
+        # idx 0 = turnStart, must be excluded
+        _s_tool("t-0", assistant_msg_idx=0, started_at=10),
+        # idx 2 = lastAsstIndex, must be excluded
+        _s_tool("t-2", assistant_msg_idx=2, started_at=10),
+        # valid
+        _s_tool("t-1", assistant_msg_idx=1, started_at=10),
+    ]
+    payload = {"messages": messages, "turnStart": 0, "lastAsstIndex": 2, "S": {"toolCalls": s_tool_calls}}
+    out = _run(driver_path, payload)
+    all_tool_ids = [r["tool_call_id"] for rows in out.values() for r in rows if r["role"] == "tool"]
+    assert "t-0" not in all_tool_ids
+    assert "t-2" not in all_tool_ids
+    assert "t-1" in all_tool_ids
+
+
+def test_order_index_sequential_within_bucket(driver_path):
+    """order_index is 0-based sequential within each message index bucket."""
+    messages = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": "prose",
+            "reasoning": "think",
+            "tool_calls": [_tool("t1", started_at=100)],
+        },
+        {"role": "assistant", "content": "final"},
+    ]
+    payload = {"messages": messages, "turnStart": 0, "lastAsstIndex": 2, "S": {"toolCalls": []}}
+    out = _run(driver_path, payload)
+    rows = out["1"]
+    indices = [r["order_index"] for r in rows]
+    assert indices == list(range(len(rows))), f"order_index not sequential: {indices}"

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -709,8 +709,9 @@ def test_settled_anchor_scene_persists_the_full_assistant_turn_not_only_tail():
     assert "messages.slice(turnStart+1,lastAsstIndex+1)" in complete
     assert "message.reasoning||message._reasoning||message.reasoning_content||message.thinking" in reasoning_text
     assert "const reasoning=_anchorSceneMessageReasoningText(message);" in rows_by_message
-    assert "const toolCalls=Array.isArray(S.toolCalls)?S.toolCalls:[]" in rows_by_message
-    assert "toolIdx<=turnStart||toolIdx>=lastAsstIndex" in rows_by_message
+    assert "const toolsByIdx=new Map();" in rows_by_message
+    assert "if(S.toolCalls) for(const tc of S.toolCalls){" in rows_by_message
+    assert "for(const tool of (toolsByIdx.get(idx)||[]))" in rows_by_message
     assert "_anchorSceneToolRowFromCall(tool,0,idx)" in rows_by_message
 
 

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -710,8 +710,8 @@ def test_settled_anchor_scene_persists_the_full_assistant_turn_not_only_tail():
     assert "message.reasoning||message._reasoning||message.reasoning_content||message.thinking" in reasoning_text
     assert "const reasoning=_anchorSceneMessageReasoningText(message);" in rows_by_message
     assert "const toolCalls=Array.isArray(S.toolCalls)?S.toolCalls:[]" in rows_by_message
-    assert "idx<=turnStart||idx>=lastAsstIndex" in rows_by_message
-    assert "add(idx,_anchorSceneToolRowFromCall(tool,order++,idx));" in rows_by_message
+    assert "toolIdx<=turnStart||toolIdx>=lastAsstIndex" in rows_by_message
+    assert "_anchorSceneToolRowFromCall(tool,0,idx)" in rows_by_message
 
 
 def test_settled_anchor_scene_preserves_live_projected_order_before_backfill():


### PR DESCRIPTION
## Thinking Path

When reconnecting to a running session, the anchor-scene settlement reconstructs the activity timeline from message history plus any reconnect-supplied `S.toolCalls`. The current code in `_anchorSceneRowsByMessageIndex` emits rows grouped by role: prose first, then thinking, then tools from the message body, then `S.toolCalls` entries appended in a separate loop. This means a tool that started before the prose appears after it, and reconnect-supplied tools always land at the tail of each message bucket regardless of their actual `started_at` timestamp.

The fix replaces role-grouped emission with chronological emission: collect all rows per message index into a single pool with phase tags (thinking=0, tools=1, prose=2), merge `S.toolCalls` into the same pool (deduped by tool id), then stable-sort by `(phase, started_at, encounterIndex)`. This ensures thinking precedes tools, tools are ordered by their real start time regardless of source, and prose follows. The `encounterIndex` tiebreaker guarantees determinism when timestamps are missing or tied.

## What Changed

- **`static/messages.js`** (`_anchorSceneRowsByMessageIndex`, ~30-40 LOC): Replaced role-grouped row emission with a collect-tag-merge-sort pattern. All rows for a given message index are collected into a flat array with `_phase` tags (0=thinking, 1=tool, 2=prose) and `_encounter` counters. `S.toolCalls` entries are merged into the same per-index pool (deduped against message-local tools by tool id) before sorting. A single stable sort by `(_phase, started_at, _encounter)` produces correct chronological order. Temporary tags are stripped before the rows enter the `byIdx` map.

No other functions are modified. The downstream consumer `_completeSettledAnchorSceneForTurn` already respects bucket order, so fixing the bucket order fixes the rendered timeline.

## Why It Matters

Users who disconnect and reconnect mid-turn see a scrambled activity timeline where tools appear out of order and reconnect-supplied tool events pile up at the end. This makes it hard to follow what the agent did and in what sequence, breaking the mental model of the conversation. The fix restores correct chronological ordering for all row types and sources.

## Verification

- Unit test (`tests/test_issue4811_reconnect_chronology.py`) with fixture messages containing interleaved `started_at` values across message-local and reconnect-supplied tools
- Asserts: thinking before tools before prose within each index, tools sorted by `started_at` regardless of source, deterministic order when `started_at` is missing, no duplicate rows, cross-message ordering preserved

## Upstream

Closes #4811.

## Model Used

Claude Opus 4.8 via Claude Code CLI
