### PR TITLE
feat(titlebar): show active model/provider in subtitle line

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -63,6 +63,16 @@ function syncAppTitlebar() {
     sourceLabel = S.session.source_label || S.session.source_tag || S.session.raw_source || '';
     // Recovered sidecars stamp source_label 'WebUI' (api/session_recovery.py); don't badge a native session as its own source (#3338).
     if (/^webui$/i.test(sourceLabel)) sourceLabel = '';
+    // Append active model/provider chip so it's always visible in the titlebar.
+    const _routing = typeof _latestGatewayRoutingForSession === 'function'
+      ? _latestGatewayRoutingForSession(S.session) : null;
+    const _usedModel = (_routing && _routing.used_model) || S.session.model || '';
+    const _usedProvider = (_routing && (_routing.used_provider || _routing.provider)) || S.session.model_provider || '';
+    if (_usedModel || _usedProvider) {
+      const _modelShort = _usedModel.includes('/') ? _usedModel.split('/').pop() : _usedModel;
+      subText = subText ? subText + '  ·  ' + _modelShort : _modelShort;
+      if (_usedProvider) subText += ' via ' + _usedProvider;
+    }
   } else {
     const key = APP_TITLEBAR_KEYS[panel];
     mainText = key && typeof t === 'function' ? t(key) : (panel.charAt(0).toUpperCase() + panel.slice(1));


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI lets users switch models and providers, but it is not visible which provider is actually serving without opening the model picker
- When fallback provider chains fire, the active model may differ from the configured one
- The chat titlebar already shows message count — it is natural to also show the current model
- This PR appends the model name (with provider) to the subtitle line: "42 messages · claude-sonnet-4-6 via anthropic"

## What Changed

**`static/panels.js`** — 10 lines in `syncAppTitlebar()`
- Uses `_latestGatewayRoutingForSession()` when available (with type-safety guard), falls back to `S.session.model` / `S.session.model_provider`
- Strips provider prefix from prefixed models (e.g. "anthropic/claude-sonnet-4-6" → "claude-sonnet-4-6")
- Appends " via <provider>" when provider is known
- Only active on the chat panel

## Why It Matters

Transparency — users can see which provider is serving their session without opening the model picker. Especially useful during provider outages and fallback transitions.

## Verification

Built and ran locally — the titlebar shows the active model on the chat panel and disappears (correctly) on other panels like Kanban, Settings, etc.

## Risks

None. The change is purely cosmetic, guardrailed by `typeof _latestGatewayRoutingForSession === 'function'` check, and falls back silently when data is unavailable.

## Model Used

- Provider: Anthropic (Claude Max)
- Model: Claude Sonnet 4.6