### PR TITLE
fix(streaming): restore mobile scroll-jank guard during live renders

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -3844,6 +3844,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _renderPending=false;
       // Guard: a pending setTimeout+rAF can outlive stream finalization.
       if(_streamFinalized) return;
+      // Mobile scroll-jank guard: enable overflow-anchor before DOM writes so
+      // the browser preserves scroll position during streaming content growth.
+      if(typeof window._fixMobileScrollJank==='function') window._fixMobileScrollJank();
       _lastRenderMs=performance.now();
       const parsed=_cachedParsed&&_cachedParsedText===assistantText&&_cachedParsedReasoning===liveReasoningText ? _cachedParsed : _parseStreamState();
       _cachedParsed=null;

--- a/tests/test_issue1360_streaming_scroll_hardening.py
+++ b/tests/test_issue1360_streaming_scroll_hardening.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 REPO = Path(__file__).parent.parent
 UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
 STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 
 
@@ -40,6 +41,28 @@ def test_messages_scroller_uses_overflow_anchor_auto_on_mobile():
         "On mobile/touch devices #messages must default to overflow-anchor:auto "
         "to prevent the browser painting a frame with scrollTop=0 between "
         "innerHTML='' and snapshot restore."
+    )
+
+
+def test_streaming_render_enables_mobile_scroll_jank_guard_before_dom_writes():
+    """Streaming must re-enable mobile scroll anchoring before every DOM write.
+
+    Regression: #MOBILESCROLL originally added _fixMobileScrollJank() in the
+    live-stream render tick, but a later streaming parse-cache change dropped
+    that call while leaving the helper/CSS in place. On iOS PWA this lets Safari
+    paint a transient scrollTop=0 frame during streamed DOM rebuilds.
+    """
+    guard_idx = MESSAGES_JS.find("window._fixMobileScrollJank")
+    assert guard_idx != -1, (
+        "attachLiveStream() must call window._fixMobileScrollJank() during the "
+        "streaming render tick, before DOM writes, so iOS PWA does not jump to "
+        "the first/oldest message while assistant output streams."
+    )
+
+    render_idx = MESSAGES_JS.find("_lastRenderMs=performance.now()")
+    assert render_idx != -1, "streaming render timestamp not found"
+    assert guard_idx < render_idx, (
+        "The mobile scroll-jank guard must run before streaming DOM work begins."
     )
 
 


### PR DESCRIPTION
## Thinking Path

- iOS Safari/PWA users can get yanked to the first/oldest message while assistant output streams.
- The original #MOBILESCROLL fix had three layers: mobile `overflow-anchor:auto`, `_fixMobileScrollJank()` in `ui.js`, and a streaming-time call in `messages.js` before DOM writes.
- Current master still has the CSS and helper, but the streaming-time call was dropped after the streaming parse-cache work.
- Without that call, Safari can paint a transient `scrollTop=0` frame during streamed DOM rebuilds.
- This PR restores the missing third layer and adds a regression test so it cannot silently disappear again.

## What Changed

- `static/messages.js`
  - Re-added `window._fixMobileScrollJank()` inside `attachLiveStream()`’s `_doRender()` tick.
  - The guard runs immediately after `_streamFinalized` check and before `_lastRenderMs=performance.now()` / live DOM rendering.

- `tests/test_issue1360_streaming_scroll_hardening.py`
  - Added `MESSAGES_JS` fixture text.
  - Added `test_streaming_render_enables_mobile_scroll_jank_guard_before_dom_writes()`.
  - The test asserts the guard exists and appears before streaming render work begins.

## Why It Matters

This fixes the iPhone PWA symptom where a user is forced to the top of the chat every time new assistant output streams. The previous mobile-scroll fix was partially present but incomplete after a later change removed the streaming hook.

## Verification

RED before fix:

```bash
./scripts/test.sh tests/test_issue1360_streaming_scroll_hardening.py::test_streaming_render_enables_mobile_scroll_jank_guard_before_dom_writes -v
# FAILED: window._fixMobileScrollJank not found in static/messages.js
```

GREEN after fix:

```bash
./scripts/test.sh tests/test_issue1360_streaming_scroll_hardening.py::test_streaming_render_enables_mobile_scroll_jank_guard_before_dom_writes -v
# 1 passed

./scripts/test.sh tests/test_issue1360_streaming_scroll_hardening.py -v
# 7 passed
```

Static security scan: clean — no secrets, shell injection, eval/exec, pickle, or SQL patterns in added lines.

## Risks / Follow-ups

Low risk. The call is guardrailed with `typeof window._fixMobileScrollJank === "function"`, and the helper itself no-ops on desktop pointer/fine devices. This restores behavior that was already part of #MOBILESCROLL.

## Model Used

- Provider: OpenAI (Codex)
- Model: GPT-5.5 / Codex environment
- Tools: Hermes terminal/file tools, targeted pytest, static security scan