### PR TITLE
fix(#484): drop noisy "parse failed" note on JSON/YAML fragments

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -13624,15 +13624,12 @@ function initTreeViews(container){
     // Mark as initialised only after we've committed to a render decision
     wrap.setAttribute('data-tree-init','1');
     if(!parsed || typeof parsed!=='object'){
-      if(parseFailed){
-        const hint=wrap.querySelector('.tree-raw-view');
-        if(hint&&!hint.querySelector('.tree-parse-note')){
-          const note=document.createElement('div');
-          note.className='tree-parse-note';
-          note.textContent=t('parse_failed_note')||'parse failed';
-          hint.parentNode.insertBefore(note,hint.nextSibling);
-        }
-      }
+      // No tree view for non-object values or unparseable content. LLMs often
+      // emit JSON fragments (a bare "key": "val" line, snippets with ..., etc.)
+      // that legitimately fail JSON.parse; surfacing a "parse failed" note for
+      // those was pure noise. The block still renders as syntax-highlighted raw,
+      // so just fall through silently. (parseFailed is retained for clarity.)
+      void parseFailed;
       return; // leave as raw view
     }
     const lineCount=rawText.split('\n').length;


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI renders LLM output as markdown; valid JSON/YAML fences get a Tree-view affordance (#484).
- LLMs constantly emit **fragments** in those fences — a bare `"key": "value"` line, snippets with `...`, trailing commas — which are not valid top-level JSON.
- `initTreeViews()` reacted by stamping an unstyled `<div class="tree-parse-note">parse failed</div>` *below* the block, producing bare white text under an otherwise-clean code box.
- This removes that note: such blocks now fall through silently to the existing syntax-highlighted raw view.

## What Changed

- `static/ui.js` — removed the `.tree-parse-note` insertion in `initTreeViews()`. The non-parseable / non-object branch now returns straight to raw view.
- The per-block **Raw/Tree toggle**, the **YAML lazy-load**, and the **#484 default-view config** (`structured_code_default_view` / `auto_tree_lines`) are all unchanged.
- The `parse_failed_note` i18n key is **intentionally retained** in all 13 locales (kept green by `test_chinese_locale.py`) to avoid a 13-file churn for a now-unused string.

### Screenshots

before:

<img width="2240" height="360" alt="before" src="https://github.com/user-attachments/assets/68c91f45-0860-47da-a421-f48a9d4ecf63" />

after: 

<img width="2240" height="316" alt="after" src="https://github.com/user-attachments/assets/80e42702-3346-4333-a027-95cf3fd07d7b" />



## Why It Matters

The note was incidental, not designed: it was bolted onto the YAML lazy-load commit (`29a31a6e`), has **no CSS** (hence the bare white text), **no behavior test**, and originally even fired on *valid* YAML before the CDN script finished loading (later fixed). The block always renders fine as raw, so for the common LLM-fragment case the note added only visual noise.

## Verification

```
./scripts/test.sh tests/test_issue484_json_tree_viewer.py tests/test_chinese_locale.py
# 29 passed
```

Before/after rendered through the app's own `renderMd()` + `postProcessRenderedMessages()` pipeline on a booted `server.py` (real header chrome + Prism colors). The "before" re-inserts the exact `tree-parse-note` div the old code produced.

**Before** — bare white "parse failed" under the box · **After** — clean box, no note.

> _Before/after screenshots attached below._

## Risks / Follow-ups

- Low risk: pure removal, nothing depends on the note.
- Not contract-affecting — the note isn't described in any contract doc / RFC / product-semantics test (grep of `docs/`, `ARCHITECTURE.md`, `DESIGN.md`, `ROADMAP.md`, `TESTING.md` is empty).
- Follow-up option: if a "not valid JSON" signal is ever wanted, the right version would be styled + tested (and ideally a lenient fragment parse that wraps bare `key: val` lines in `{}` so they render as a Tree).

## Model Used

Anthropic Claude, `claude-opus-4-8` (Claude Code).

## AI Usage Disclosure

AI-assisted. Provider: Anthropic. Model: `claude-opus-4-8`. Tooling: Claude Code (analysis, edit, Playwright screenshot capture, test run).
