### PR TITLE
Release WG (v0.51.626): restore mobile streaming scroll-jank guard (#4857)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.626] — 2026-06-24 — Release WG (restore the mobile streaming scroll-jank guard)
+
+### Fixed
+
+- **On iOS Safari / installed PWAs, the transcript no longer jumps to the first/oldest message while assistant output streams.** The mobile scroll-jank protection had three layers — the `overflow-anchor: auto` mobile CSS, the `_fixMobileScrollJank()` helper, and a streaming-time call that re-enables anchoring right before each live DOM write. The streaming-time call was inadvertently dropped during the streaming parse-cache work, so Safari could paint a transient `scrollTop = 0` frame during streamed DOM rebuilds and yank the reader to the top. That third layer is restored (the helper still self-gates to touch devices, so desktop is unaffected), with a regression test so it can't silently disappear again. Thanks @b-yelverton. (#4857)
+
 ## [v0.51.625] — 2026-06-24 — Release WF (cron job model override no longer keeps the @provider: display prefix)
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -3844,6 +3844,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _renderPending=false;
       // Guard: a pending setTimeout+rAF can outlive stream finalization.
       if(_streamFinalized) return;
+      // Mobile scroll-jank guard: enable overflow-anchor before DOM writes so
+      // the browser preserves scroll position during streaming content growth.
+      if(typeof window._fixMobileScrollJank==='function') window._fixMobileScrollJank();
       _lastRenderMs=performance.now();
       const parsed=_cachedParsed&&_cachedParsedText===assistantText&&_cachedParsedReasoning===liveReasoningText ? _cachedParsed : _parseStreamState();
       _cachedParsed=null;

--- a/tests/test_issue1360_streaming_scroll_hardening.py
+++ b/tests/test_issue1360_streaming_scroll_hardening.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 REPO = Path(__file__).parent.parent
 UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
 STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 
 
@@ -40,6 +41,28 @@ def test_messages_scroller_uses_overflow_anchor_auto_on_mobile():
         "On mobile/touch devices #messages must default to overflow-anchor:auto "
         "to prevent the browser painting a frame with scrollTop=0 between "
         "innerHTML='' and snapshot restore."
+    )
+
+
+def test_streaming_render_enables_mobile_scroll_jank_guard_before_dom_writes():
+    """Streaming must re-enable mobile scroll anchoring before every DOM write.
+
+    Regression: #MOBILESCROLL originally added _fixMobileScrollJank() in the
+    live-stream render tick, but a later streaming parse-cache change dropped
+    that call while leaving the helper/CSS in place. On iOS PWA this lets Safari
+    paint a transient scrollTop=0 frame during streamed DOM rebuilds.
+    """
+    guard_idx = MESSAGES_JS.find("window._fixMobileScrollJank")
+    assert guard_idx != -1, (
+        "attachLiveStream() must call window._fixMobileScrollJank() during the "
+        "streaming render tick, before DOM writes, so iOS PWA does not jump to "
+        "the first/oldest message while assistant output streams."
+    )
+
+    render_idx = MESSAGES_JS.find("_lastRenderMs=performance.now()")
+    assert render_idx != -1, "streaming render timestamp not found"
+    assert guard_idx < render_idx, (
+        "The mobile scroll-jank guard must run before streaming DOM work begins."
     )
 
 


### PR DESCRIPTION
## Release WG (v0.51.626) — restore the mobile streaming scroll-jank guard

Phase-0 regression hotfix. Ships **#4857** (@b-yelverton).

### What broke
The mobile scroll-jank protection had three layers:
1. `overflow-anchor: auto` mobile CSS (still present)
2. the `_fixMobileScrollJank()` helper in `ui.js` (still present)
3. a streaming-time call in `messages.js` that re-enables anchoring right before each live DOM write

Layer 3 was inadvertently dropped during the streaming parse-cache work, so on iOS Safari / installed PWAs the browser could paint a transient `scrollTop = 0` frame during streamed DOM rebuilds and yank the reader to the first/oldest message mid-stream.

### Fix
Restore the streaming-time `window._fixMobileScrollJank()` call in `attachLiveStream`'s render tick, placed after the `_streamFinalized` guard and before the parse + DOM writes. The helper self-gates to touch devices (`(hover:hover) and (pointer:fine)` returns early on desktop), so desktop is unaffected. A regression test pins the call so it can't silently disappear again.

### Gate
- Codex: **SAFE TO SHIP** (verified placement, desktop self-gating, non-vacuous test, `node --check` clean)
- Full suite: **10365 passed**, 0 failures (only usual skips/xfails)
- +26/-0, 2 files

Closes nothing (reported via Discord); credit @b-yelverton.
