### PR TITLE
Release WH (v0.51.627): cron Task APIs survive a shadowing top-level cron package (#4855)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.627] — 2026-06-24 — Release WH (Tasks cron APIs survive a shadowing top-level `cron` package)
+
+### Fixed
+
+- **The Tasks panel no longer shows an empty cron list (or "cron unavailable") when another `cron` package shadows the agent's on `sys.path`.** In some deployments (two-container / shared-venv Docker setups) an unrelated top-level `cron` package can appear earlier on `sys.path` than the Hermes agent checkout, so `import cron` resolved to the wrong package and the cron Task APIs caught `ModuleNotFoundError: cron.jobs` and returned `{"jobs": [], "cron_unavailable": true}` even though the agent's cron jobs file was present. The cron API handlers now ensure the agent's cron package takes import precedence (re-ordering `sys.path` ahead of any shadowing entry and clearing a previously-imported unrelated `cron` module before retrying), so cron jobs surface correctly. Thanks @luckfu. (#4855)
+
 ## [v0.51.626] — 2026-06-24 — Release WG (restore the mobile streaming scroll-jank guard)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -1243,6 +1243,52 @@ def _cron_jobs_for_api(jobs) -> list[dict]:
     return [_cron_job_for_api(job) for job in (jobs or [])]
 
 
+_AGENT_CRON_IMPORT_PATH_LOCK = threading.Lock()
+_AGENT_CRON_IMPORT_PATH_READY: str | None = None
+
+
+def _ensure_agent_cron_import_path() -> None:
+    """Prefer the agent's cron package over unrelated top-level cron packages."""
+    try:
+        from api import config as api_config
+    except Exception:
+        return
+
+    agent_dir = getattr(api_config, "_AGENT_DIR", None)
+    if not agent_dir:
+        return
+    agent_path = str(Path(agent_dir).expanduser().resolve())
+    agent_cron_path = str(Path(agent_path) / "cron")
+
+    global _AGENT_CRON_IMPORT_PATH_READY
+    with _AGENT_CRON_IMPORT_PATH_LOCK:
+        cron_mod = sys.modules.get("cron")
+        cron_file = str(getattr(cron_mod, "__file__", "") or "") if cron_mod else ""
+        cron_is_agent = bool(cron_mod is not None and cron_file.startswith(agent_cron_path + os.sep))
+        if _AGENT_CRON_IMPORT_PATH_READY == agent_path and (cron_mod is None or cron_is_agent):
+            return
+
+        while agent_path in sys.path:
+            sys.path.remove(agent_path)
+        shadow_indexes = [
+            idx
+            for idx, path_entry in enumerate(sys.path)
+            if path_entry
+            and Path(path_entry).resolve() != Path(agent_path)
+            and (Path(path_entry) / "cron" / "__init__.py").exists()
+        ]
+        if shadow_indexes:
+            sys.path.insert(min(shadow_indexes), agent_path)
+        else:
+            sys.path.append(agent_path)
+        _AGENT_CRON_IMPORT_PATH_READY = agent_path
+
+        if cron_mod is not None and not cron_is_agent:
+            for name in list(sys.modules):
+                if name == "cron" or name.startswith("cron."):
+                    sys.modules.pop(name, None)
+
+
 def _available_cron_profile_names() -> set[str]:
     from api.profiles import list_profiles_api
 
@@ -10203,6 +10249,7 @@ def handle_get(handler, parsed) -> bool:
         # Only treat a genuinely-absent cron package as "unavailable"; a
         # ModuleNotFoundError whose missing module is an internal dependency of an
         # existing cron/jobs.py is a real bug and must still surface.
+        _ensure_agent_cron_import_path()
         try:
             from cron.jobs import list_jobs
         except ModuleNotFoundError as exc:
@@ -10218,24 +10265,28 @@ def handle_get(handler, parsed) -> bool:
         from api.profiles import cron_profile_context
 
         with cron_profile_context():
+            _ensure_agent_cron_import_path()
             return _handle_cron_output(handler, parsed)
 
     if parsed.path == "/api/crons/history":
         from api.profiles import cron_profile_context
 
         with cron_profile_context():
+            _ensure_agent_cron_import_path()
             return _handle_cron_history(handler, parsed)
 
     if parsed.path == "/api/crons/run":
         from api.profiles import cron_profile_context
 
         with cron_profile_context():
+            _ensure_agent_cron_import_path()
             return _handle_cron_run_detail(handler, parsed)
 
     if parsed.path == "/api/crons/recent":
         from api.profiles import cron_profile_context
 
         with cron_profile_context():
+            _ensure_agent_cron_import_path()
             return _handle_cron_recent(handler, parsed)
 
     if parsed.path == "/api/crons/status":
@@ -10248,6 +10299,7 @@ def handle_get(handler, parsed) -> bool:
         from api.profiles import cron_profile_context
 
         with cron_profile_context():
+            _ensure_agent_cron_import_path()
             return _handle_cron_delivery_options(handler)
 
     # ── Skills API (GET) ──
@@ -11638,36 +11690,42 @@ def handle_post(handler, parsed) -> bool:
         from api.profiles import cron_profile_context
 
         with cron_profile_context():
+            _ensure_agent_cron_import_path()
             return _handle_cron_create(handler, body)
 
     if parsed.path == "/api/crons/update":
         from api.profiles import cron_profile_context
 
         with cron_profile_context():
+            _ensure_agent_cron_import_path()
             return _handle_cron_update(handler, body)
 
     if parsed.path == "/api/crons/delete":
         from api.profiles import cron_profile_context
 
         with cron_profile_context():
+            _ensure_agent_cron_import_path()
             return _handle_cron_delete(handler, body)
 
     if parsed.path == "/api/crons/run":
         from api.profiles import cron_profile_context
 
         with cron_profile_context():
+            _ensure_agent_cron_import_path()
             return _handle_cron_run(handler, body)
 
     if parsed.path == "/api/crons/pause":
         from api.profiles import cron_profile_context
 
         with cron_profile_context():
+            _ensure_agent_cron_import_path()
             return _handle_cron_pause(handler, body)
 
     if parsed.path == "/api/crons/resume":
         from api.profiles import cron_profile_context
 
         with cron_profile_context():
+            _ensure_agent_cron_import_path()
             return _handle_cron_resume(handler, body)
 
     # ── Git workspace ops (POST) ──

--- a/tests/test_cron_import_shadowing.py
+++ b/tests/test_cron_import_shadowing.py
@@ -1,0 +1,60 @@
+"""Regression coverage for top-level cron packages shadowing agent cron.jobs."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def _drop_cron_modules() -> None:
+    for name in list(sys.modules):
+        if name == "cron" or name.startswith("cron."):
+            sys.modules.pop(name, None)
+
+
+def _reset_cron_import_path_ready(routes) -> None:
+    routes._AGENT_CRON_IMPORT_PATH_READY = None
+
+
+def test_agent_cron_import_path_prefers_agent_cron_over_plugin_shadow(monkeypatch, tmp_path):
+    import api.config as config
+    import api.routes as routes
+
+    agent_dir = tmp_path / "hermes-agent"
+    site_packages = tmp_path / "site-packages"
+    agent_cron = agent_dir / "cron"
+    shadow_cron = site_packages / "cron"
+    agent_cron.mkdir(parents=True)
+    shadow_cron.mkdir(parents=True)
+    (agent_cron / "__init__.py").write_text("", encoding="utf-8")
+    (agent_cron / "jobs.py").write_text(
+        "def list_jobs(include_disabled=False):\n"
+        "    return [{'id': 'agent-cron', 'include_disabled': include_disabled}]\n",
+        encoding="utf-8",
+    )
+    (shadow_cron / "__init__.py").write_text("SHADOW_CRON = True\n", encoding="utf-8")
+
+    monkeypatch.setattr(config, "_AGENT_DIR", agent_dir)
+    monkeypatch.setattr(routes, "_AGENT_CRON_IMPORT_PATH_READY", None)
+    monkeypatch.syspath_prepend(str(agent_dir))
+    monkeypatch.syspath_prepend(str(site_packages))
+    _drop_cron_modules()
+    try:
+        shadowed_cron = importlib.import_module("cron")
+        assert Path(shadowed_cron.__file__).resolve() == shadow_cron / "__init__.py"
+
+        routes._ensure_agent_cron_import_path()
+        cron_jobs = importlib.import_module("cron.jobs")
+
+        assert Path(cron_jobs.__file__).resolve() == agent_cron / "jobs.py"
+        assert cron_jobs.list_jobs(include_disabled=True) == [
+            {"id": "agent-cron", "include_disabled": True}
+        ]
+
+        sys_path_after_first_call = list(sys.path)
+        routes._ensure_agent_cron_import_path()
+        assert sys.path == sys_path_after_first_call
+    finally:
+        _drop_cron_modules()
+        _reset_cron_import_path_ready(routes)


### PR DESCRIPTION
## Release WH (v0.51.627) — Tasks cron APIs survive a shadowing top-level `cron` package

Phase-0 breakage hotfix. Ships **#4855** (@luckfu).

### What broke
In deployments where an unrelated top-level `cron` package appears earlier on `sys.path` than the Hermes agent checkout (two-container / shared-venv Docker setups), `import cron` resolves to the wrong package. The cron Task APIs then caught `ModuleNotFoundError: cron.jobs` and returned `{"jobs": [], "cron_unavailable": true}` even though the agent's cron jobs file exists — so the Tasks panel showed no cron jobs. Same cluster as #4768 / #4631 / #4790.

### Fix
`_ensure_agent_cron_import_path()` (lock-guarded, idempotent) ensures the agent's cron package takes import precedence before each cron API handler: it re-orders `sys.path` to put the agent dir ahead of any shadowing entry that carries a `cron/__init__.py`, and if a non-agent `cron` module is already imported it clears `cron`/`cron.*` from `sys.modules` so the next `from cron.jobs import …` resolves to the agent package.

### Gate
- Codex: **SAFE TO SHIP** — wrote an independent shadow-vs-agent reproduction probe; verified the fix resolves to the agent cron, the `sys.modules` pop only fires when replacing a non-agent `cron` (no harm to legitimate external importers), idempotent (`sys.path` unchanged on repeat calls), and `_AGENT_DIR is None` no-ops safely
- Full suite: **10365 passed**, 0 failures
- +118/-0, 2 files (regression test included)

Closes the cron-shadow half of the #4768/#4631 cluster; credit @luckfu.
