### PR TITLE
Release WJ (v0.51.629): macOS workspace drag-drop now lands (#4845, closes #4757)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.629] — 2026-06-24 — Release WJ (macOS workspace drag-drop now lands)
+
+### Fixed
+
+- **Dragging a file or folder in the workspace tree now works on macOS.** macOS WebKit strips custom drag MIME types (`application/ws-path`) during `dragover`/`drop`, leaving only `text/plain`, so the move was silently rejected on macOS (it worked on Linux/Windows Chromium, which preserve the custom type). The drop handler now also recognizes an in-flight workspace drag via a module-scoped active-drag flag, and only treats a stripped-MIME `text/plain` drop as a move when its payload matches the dragged path — a foreign text drag from another app can't trigger a move, and the flag is cleared on `dragend`/`drop`/`pagehide`/`blur` so an abandoned drag can't leave it set. Thanks @rodboev. (#4845, closes #4757)
+
 ## [v0.51.628] — 2026-06-24 — Release WI (no ghost messages after edit/retry/undo)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -14772,16 +14772,39 @@ function _setWsDragData(e,item){
   _wsActiveDragPath=item.path;
   _wsActiveDragType=item.type;
 }
+function _clearWsDragData(){
+  _wsActiveDragPath=null;
+  _wsActiveDragType=null;
+}
+// Window-level fallback cleanup: if a workspace drag is abandoned without the
+// row's ondragend firing (drag cancelled, dropped outside any target, tab
+// blurred/hidden mid-drag), the active-drag flag must not survive — otherwise a
+// later FOREIGN text/plain drag could be misread as a workspace move.
+if(typeof window!=='undefined'&&!window._wsDragCleanupBound){
+  window._wsDragCleanupBound=true;
+  window.addEventListener('dragend',_clearWsDragData,true);
+  window.addEventListener('drop',_clearWsDragData,true);
+  window.addEventListener('pagehide',_clearWsDragData);
+  window.addEventListener('blur',_clearWsDragData);
+}
 function _isWorkspaceTreeMoveDrag(e){
   if(e.dataTransfer&&e.dataTransfer.types&&e.dataTransfer.types.includes('Files')) return false;
   if(e.dataTransfer&&e.dataTransfer.types&&e.dataTransfer.types.includes('application/ws-path')) return true;
+  // Stripped-MIME (macOS WebKit) fallback: accept text/plain ONLY while a
+  // workspace drag is genuinely in flight. dragover/drop events can't read the
+  // payload, so gate on the active flag alone here; the drop handler additionally
+  // proves text/plain === _wsActiveDragPath before performing the move.
   return !!(_wsActiveDragPath&&e.dataTransfer&&e.dataTransfer.types&&e.dataTransfer.types.includes('text/plain'));
 }
 function _wsDragSrcPath(e){
   const custom=e.dataTransfer.getData('application/ws-path');
   if(custom) return custom;
-  if(_wsActiveDragPath) return _wsActiveDragPath;
-  return e.dataTransfer.getData('text/plain')||'';
+  // Stripped-MIME fallback: only trust the active flag when the drop's own
+  // text/plain matches it. A foreign text/plain drag (different/empty content)
+  // must NOT resolve to our tracked workspace path even if the flag lingered.
+  const plain=e.dataTransfer.getData('text/plain')||'';
+  if(_wsActiveDragPath&&plain===_wsActiveDragPath) return _wsActiveDragPath;
+  return '';
 }
 function _wsDragSrcType(e){
   const custom=e.dataTransfer.getData('application/ws-type');
@@ -14872,10 +14895,14 @@ function _bindWorkspaceMoveDropTarget(el,destDir){
     if(!_isWorkspaceTreeMoveDrag(e))return;
     e.preventDefault();e.stopPropagation();
     el.classList.remove('drag-over');
-    const srcPath=_wsDragSrcPath(e);
-    if(!srcPath)return;
-    const srcType=_wsDragSrcType(e);
-    await _performWorkspaceMove(srcPath,destDir,srcType==='dir');
+    try{
+      const srcPath=_wsDragSrcPath(e);
+      if(!srcPath)return;
+      const srcType=_wsDragSrcType(e);
+      await _performWorkspaceMove(srcPath,destDir,srcType==='dir');
+    }finally{
+      _clearWsDragData();
+    }
   };
 }
 
@@ -14898,7 +14925,7 @@ function _renderTreeItems(container, entries, depth){
       e.preventDefault();e.stopPropagation();_showFileContextMenu(e,item);
     };
     el.ondragstart=(e)=>{_setWsDragData(e,item);e.dataTransfer.effectAllowed='copy';el.classList.add('dragging');};
-    el.ondragend=()=>{el.classList.remove('dragging');_clearWorkspaceMoveDragOver();_wsActiveDragPath=null;_wsActiveDragType=null;};
+    el.ondragend=()=>{el.classList.remove('dragging');_clearWorkspaceMoveDragOver();_clearWsDragData();};
 
     const isLk = item.type === 'symlink';
     const isExternalLink = isLk && item.target_outside_workspace;

--- a/static/ui.js
+++ b/static/ui.js
@@ -14763,8 +14763,30 @@ function renderFileTree(){
   _renderTreeItems(box, visibleEntries, 0);
 }
 
+let _wsActiveDragPath=null;
+let _wsActiveDragType=null;
+function _setWsDragData(e,item){
+  e.dataTransfer.setData('application/ws-path',item.path);
+  e.dataTransfer.setData('application/ws-type',item.type);
+  e.dataTransfer.setData('text/plain',item.path);
+  _wsActiveDragPath=item.path;
+  _wsActiveDragType=item.type;
+}
 function _isWorkspaceTreeMoveDrag(e){
-  return !!(e.dataTransfer&&e.dataTransfer.types&&e.dataTransfer.types.includes('application/ws-path')&&!e.dataTransfer.types.includes('Files'));
+  if(e.dataTransfer&&e.dataTransfer.types&&e.dataTransfer.types.includes('Files')) return false;
+  if(e.dataTransfer&&e.dataTransfer.types&&e.dataTransfer.types.includes('application/ws-path')) return true;
+  return !!(_wsActiveDragPath&&e.dataTransfer&&e.dataTransfer.types&&e.dataTransfer.types.includes('text/plain'));
+}
+function _wsDragSrcPath(e){
+  const custom=e.dataTransfer.getData('application/ws-path');
+  if(custom) return custom;
+  if(_wsActiveDragPath) return _wsActiveDragPath;
+  return e.dataTransfer.getData('text/plain')||'';
+}
+function _wsDragSrcType(e){
+  const custom=e.dataTransfer.getData('application/ws-type');
+  if(custom) return custom;
+  return _wsActiveDragType||'file';
 }
 
 function _workspaceParentDir(relPath){
@@ -14850,9 +14872,9 @@ function _bindWorkspaceMoveDropTarget(el,destDir){
     if(!_isWorkspaceTreeMoveDrag(e))return;
     e.preventDefault();e.stopPropagation();
     el.classList.remove('drag-over');
-    const srcPath=e.dataTransfer.getData('application/ws-path');
+    const srcPath=_wsDragSrcPath(e);
     if(!srcPath)return;
-    const srcType=e.dataTransfer.getData('application/ws-type');
+    const srcType=_wsDragSrcType(e);
     await _performWorkspaceMove(srcPath,destDir,srcType==='dir');
   };
 }
@@ -14875,8 +14897,8 @@ function _renderTreeItems(container, entries, depth){
       if(grant&&!isDirRow){e.preventDefault();e.stopPropagation();return;}
       e.preventDefault();e.stopPropagation();_showFileContextMenu(e,item);
     };
-    el.ondragstart=(e)=>{e.dataTransfer.setData('application/ws-path',item.path);e.dataTransfer.setData('application/ws-type',item.type);e.dataTransfer.effectAllowed='copy';el.classList.add('dragging');};
-    el.ondragend=()=>{el.classList.remove('dragging');_clearWorkspaceMoveDragOver();};
+    el.ondragstart=(e)=>{_setWsDragData(e,item);e.dataTransfer.effectAllowed='copy';el.classList.add('dragging');};
+    el.ondragend=()=>{el.classList.remove('dragging');_clearWorkspaceMoveDragOver();_wsActiveDragPath=null;_wsActiveDragType=null;};
 
     const isLk = item.type === 'symlink';
     const isExternalLink = isLk && item.target_outside_workspace;

--- a/static/ui.js
+++ b/static/ui.js
@@ -14783,7 +14783,12 @@ function _clearWsDragData(){
 if(typeof window!=='undefined'&&!window._wsDragCleanupBound){
   window._wsDragCleanupBound=true;
   window.addEventListener('dragend',_clearWsDragData,true);
-  window.addEventListener('drop',_clearWsDragData,true);
+  // Defer the drop cleanup a tick: this capture-phase window listener fires
+  // BEFORE the target element's ondrop, so clearing synchronously here would
+  // wipe _wsActiveDragPath before _isWorkspaceTreeMoveDrag()/_wsDragSrcPath()
+  // run in the target handler — re-breaking the macOS stripped-MIME move. The
+  // setTimeout lets the real drop handler complete, then clears the lingering flag.
+  window.addEventListener('drop',()=>setTimeout(_clearWsDragData,0),true);
   window.addEventListener('pagehide',_clearWsDragData);
   window.addEventListener('blur',_clearWsDragData);
 }

--- a/tests/test_issue4757_macos_drag_drop_mime.py
+++ b/tests/test_issue4757_macos_drag_drop_mime.py
@@ -1,0 +1,212 @@
+"""Regression tests for #4757 — macOS workspace drag-drop never lands.
+
+WebKit strips custom MIME types from DataTransfer during dragover/drop, so
+_isWorkspaceTreeMoveDrag must accept text/plain when the module-scoped active-drag
+flag is set. The node-driver extraction pattern runs all logic in Node.js without
+a browser.
+"""
+import os
+import subprocess
+import tempfile
+
+UI_JS = os.path.join(os.path.dirname(__file__), '..', 'static', 'ui.js')
+
+
+def _extract_drag_functions():
+    """Extract the six drag-drop functions from ui.js."""
+    src = open(UI_JS, encoding='utf-8').read()
+
+    # Extract module-scoped let declarations
+    lines = src.split('\n')
+    let_lines = []
+    for line in lines:
+        s = line.strip()
+        if s in ('let _wsActiveDragPath=null;', 'let _wsActiveDragType=null;'):
+            let_lines.append(s)
+
+    def extract_function(name):
+        start = src.find(f'function {name}(')
+        if start < 0:
+            raise AssertionError(f'{name} not found in ui.js')
+        i = src.find('{', start)
+        depth = 1
+        i += 1
+        while i < len(src) and depth:
+            if src[i] == '{':
+                depth += 1
+            elif src[i] == '}':
+                depth -= 1
+            i += 1
+        return src[start:i]
+
+    fns = '\n'.join(
+        extract_function(name)
+        for name in (
+            '_setWsDragData',
+            '_isWorkspaceTreeMoveDrag',
+            '_wsDragSrcPath',
+            '_wsDragSrcType',
+        )
+    )
+    return '\n'.join(let_lines), fns
+
+
+def _run_node(test_js):
+    """Run a Node.js snippet that includes the extracted functions, return stdout."""
+    lets, fns = _extract_drag_functions()
+    harness = """\
+// Fake DataTransfer
+class FakeDataTransfer {
+  constructor(typesArr, dataMap) {
+    this._map = dataMap || {};
+    this.types = typesArr || Object.keys(this._map);
+  }
+  getData(mime) { return this._map[mime] || ''; }
+  setData(mime, val) { this._map[mime] = val; if(!this.types.includes(mime)) this.types.push(mime); }
+}
+"""
+    js_code = harness + '\n' + lets + '\n' + fns + '\n' + test_js
+
+    tf = tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False, encoding='utf-8')
+    tf.write(js_code)
+    tf.close()
+    try:
+        result = subprocess.run(
+            ['node', tf.name],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f'node error: {result.stderr}')
+        return result.stdout.strip()
+    finally:
+        os.unlink(tf.name)
+
+
+class TestMacosDragDropMime:
+    """Module-scoped active-drag flags allow workspace drag-drop on macOS."""
+
+    def test_macos_stripped_drag_accepted(self):
+        """After _setWsDragData, gate accepts text/plain-only (WebKit strips custom MIME)."""
+        js = """\
+const item = {path: 'docs/readme.md', type: 'file'};
+const startDt = new FakeDataTransfer([], {});
+startDt.setData = function(mime, val){ this._map[mime]=val; if(!this.types.includes(mime)) this.types.push(mime); };
+_setWsDragData({dataTransfer: startDt}, item);
+
+// Simulate macOS: only text/plain survives into dragover/drop
+const dropDt = new FakeDataTransfer(['text/plain'], {'text/plain': item.path});
+const accepted = _isWorkspaceTreeMoveDrag({dataTransfer: dropDt});
+process.stdout.write(String(accepted));
+"""
+        assert _run_node(js) == 'true', \
+            'macOS-stripped drag must be accepted when active-drag flag is set'
+
+    def test_normal_drag_accepted(self):
+        """Custom MIME present — gate returns true without needing the flag."""
+        js = """\
+const dropDt = new FakeDataTransfer(
+  ['application/ws-path', 'text/plain'],
+  {'application/ws-path': 'notes.txt', 'text/plain': 'notes.txt'}
+);
+process.stdout.write(String(_isWorkspaceTreeMoveDrag({dataTransfer: dropDt})));
+"""
+        assert _run_node(js) == 'true', \
+            'normal drag (custom MIME present) must be accepted'
+
+    def test_foreign_text_drag_rejected(self):
+        """Foreign text (text/plain only, no active-drag flag) must be rejected."""
+        js = """\
+// Do NOT call _setWsDragData — flag stays null
+const dropDt = new FakeDataTransfer(['text/plain'], {'text/plain': 'hello world'});
+process.stdout.write(String(_isWorkspaceTreeMoveDrag({dataTransfer: dropDt})));
+"""
+        assert _run_node(js) == 'false', \
+            'foreign text drag must be rejected when no active-drag flag is set'
+
+    def test_files_drag_rejected_even_with_active_flag(self):
+        """Files drop must be rejected regardless of active-drag state."""
+        js = """\
+const item = {path: 'img.png', type: 'file'};
+const startDt = new FakeDataTransfer([], {});
+startDt.setData = function(mime, val){ this._map[mime]=val; if(!this.types.includes(mime)) this.types.push(mime); };
+_setWsDragData({dataTransfer: startDt}, item);
+
+const dropDt = new FakeDataTransfer(['Files', 'text/plain'], {});
+process.stdout.write(String(_isWorkspaceTreeMoveDrag({dataTransfer: dropDt})));
+"""
+        assert _run_node(js) == 'false', \
+            'Files drop must be rejected even when active-drag flag is set'
+
+    def test_resolver_returns_custom_mime_when_present(self):
+        """_wsDragSrcPath returns custom MIME value when available."""
+        js = """\
+const dropDt = new FakeDataTransfer(
+  ['application/ws-path', 'text/plain'],
+  {'application/ws-path': 'src/index.js', 'text/plain': 'fallback'}
+);
+process.stdout.write(_wsDragSrcPath({dataTransfer: dropDt}));
+"""
+        assert _run_node(js) == 'src/index.js', \
+            '_wsDragSrcPath must prefer custom MIME over text/plain'
+
+    def test_resolver_falls_back_to_active_drag_path(self):
+        """_wsDragSrcPath falls back to active-drag flag when custom MIME stripped."""
+        js = """\
+const item = {path: 'my file.txt', type: 'file'};
+const startDt = new FakeDataTransfer([], {});
+startDt.setData = function(mime, val){ this._map[mime]=val; if(!this.types.includes(mime)) this.types.push(mime); };
+_setWsDragData({dataTransfer: startDt}, item);
+
+// Custom MIME stripped; text/plain has the path too (as set by _setWsDragData)
+const dropDt = new FakeDataTransfer(['text/plain'], {'text/plain': item.path});
+// Override getData so custom MIME returns empty
+dropDt.getData = function(mime){ if(mime==='application/ws-path') return ''; return this._map[mime]||''; };
+process.stdout.write(_wsDragSrcPath({dataTransfer: dropDt}));
+"""
+        assert _run_node(js) == 'my file.txt', \
+            '_wsDragSrcPath must fall back to active-drag flag (supports paths with spaces)'
+
+    def test_resolver_type_returns_custom_mime_type(self):
+        """_wsDragSrcType returns custom type when available."""
+        js = """\
+const dropDt = new FakeDataTransfer(
+  ['application/ws-type'],
+  {'application/ws-type': 'dir'}
+);
+process.stdout.write(_wsDragSrcType({dataTransfer: dropDt}));
+"""
+        assert _run_node(js) == 'dir', \
+            '_wsDragSrcType must return custom MIME type value'
+
+    def test_resolver_type_falls_back_to_active_drag_type(self):
+        """_wsDragSrcType falls back to active-drag flag when custom MIME stripped."""
+        js = """\
+const item = {path: 'projects/', type: 'dir'};
+const startDt = new FakeDataTransfer([], {});
+startDt.setData = function(mime, val){ this._map[mime]=val; if(!this.types.includes(mime)) this.types.push(mime); };
+_setWsDragData({dataTransfer: startDt}, item);
+
+const dropDt = new FakeDataTransfer(['text/plain'], {'text/plain': item.path});
+dropDt.getData = function(mime){ if(mime==='application/ws-type') return ''; return this._map[mime]||''; };
+process.stdout.write(_wsDragSrcType({dataTransfer: dropDt}));
+"""
+        assert _run_node(js) == 'dir', \
+            '_wsDragSrcType must fall back to active-drag type flag'
+
+    def test_ondragend_equivalent_clears_state(self):
+        """Clearing flags causes text/plain-only drag to be rejected (ondragend effect)."""
+        js = """\
+const item = {path: 'tmp.txt', type: 'file'};
+const startDt = new FakeDataTransfer([], {});
+startDt.setData = function(mime, val){ this._map[mime]=val; if(!this.types.includes(mime)) this.types.push(mime); };
+_setWsDragData({dataTransfer: startDt}, item);
+
+// Simulate ondragend clearing flags
+_wsActiveDragPath = null;
+_wsActiveDragType = null;
+
+const dropDt = new FakeDataTransfer(['text/plain'], {'text/plain': item.path});
+process.stdout.write(String(_isWorkspaceTreeMoveDrag({dataTransfer: dropDt})));
+"""
+        assert _run_node(js) == 'false', \
+            'after ondragend clears flags, text/plain-only drag must be rejected'

--- a/tests/test_issue4757_macos_drag_drop_mime.py
+++ b/tests/test_issue4757_macos_drag_drop_mime.py
@@ -6,8 +6,14 @@ flag is set. The node-driver extraction pattern runs all logic in Node.js withou
 a browser.
 """
 import os
+import shutil
 import subprocess
 import tempfile
+
+import pytest
+
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
 
 UI_JS = os.path.join(os.path.dirname(__file__), '..', 'static', 'ui.js')
 
@@ -72,7 +78,7 @@ class FakeDataTransfer {
     tf.close()
     try:
         result = subprocess.run(
-            ['node', tf.name],
+            [NODE, tf.name],
             capture_output=True, text=True, timeout=30
         )
         if result.returncode != 0:

--- a/tests/test_issue4757_macos_drag_drop_mime.py
+++ b/tests/test_issue4757_macos_drag_drop_mime.py
@@ -51,6 +51,7 @@ def _extract_drag_functions():
         extract_function(name)
         for name in (
             '_setWsDragData',
+            '_clearWsDragData',
             '_isWorkspaceTreeMoveDrag',
             '_wsDragSrcPath',
             '_wsDragSrcType',
@@ -130,6 +131,42 @@ process.stdout.write(String(_isWorkspaceTreeMoveDrag({dataTransfer: dropDt})));
 """
         assert _run_node(js) == 'false', \
             'foreign text drag must be rejected when no active-drag flag is set'
+
+    def test_stale_flag_foreign_text_resolves_empty(self):
+        """If the active-drag flag lingers (lost dragend) and a FOREIGN text/plain
+        drag arrives whose content differs from the tracked path, _wsDragSrcPath
+        must return '' (not the stale path) so no spurious workspace move runs.
+
+        Regression guard for the gate-found SILENT hazard: the stripped-MIME
+        fallback now requires text/plain === _wsActiveDragPath."""
+        js = """\
+const item = {path: 'docs/readme.md', type: 'file'};
+const startDt = new FakeDataTransfer([], {});
+startDt.setData = function(mime, val){ this._map[mime]=val; if(!this.types.includes(mime)) this.types.push(mime); };
+_setWsDragData({dataTransfer: startDt}, item);
+// Flag still set (dragend never fired). A foreign text drag arrives with
+// DIFFERENT content and no custom MIME.
+const dropDt = new FakeDataTransfer(['text/plain'], {'text/plain': 'some pasted text'});
+dropDt.getData = function(mime){ if(mime==='application/ws-path') return ''; return this._map[mime]||''; };
+process.stdout.write('[' + _wsDragSrcPath({dataTransfer: dropDt}) + ']');
+"""
+        assert _run_node(js) == '[]', \
+            'stale flag + foreign text (content != tracked path) must resolve to empty'
+
+    def test_clear_ws_drag_data_resets_flags(self):
+        """_clearWsDragData nulls both flags so a later text/plain-only drag is rejected."""
+        js = """\
+const item = {path: 'tmp.txt', type: 'file'};
+const startDt = new FakeDataTransfer([], {});
+startDt.setData = function(mime, val){ this._map[mime]=val; if(!this.types.includes(mime)) this.types.push(mime); };
+_setWsDragData({dataTransfer: startDt}, item);
+_clearWsDragData();
+const dropDt = new FakeDataTransfer(['text/plain'], {'text/plain': item.path});
+process.stdout.write(String(_isWorkspaceTreeMoveDrag({dataTransfer: dropDt})));
+"""
+        assert _run_node(js) == 'false', \
+            '_clearWsDragData must reset flags so a stripped-MIME drag is no longer accepted'
+
 
     def test_files_drag_rejected_even_with_active_flag(self):
         """Files drop must be rejected regardless of active-drag state."""

--- a/tests/test_issue4757_macos_drag_drop_mime.py
+++ b/tests/test_issue4757_macos_drag_drop_mime.py
@@ -6,6 +6,7 @@ flag is set. The node-driver extraction pattern runs all logic in Node.js withou
 a browser.
 """
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -23,11 +24,12 @@ def _extract_drag_functions():
     src = open(UI_JS, encoding='utf-8').read()
 
     # Extract module-scoped let declarations
+    _let_re = re.compile(r'^let\s+(_wsActiveDragPath|_wsActiveDragType)\s*=\s*null\s*;$')
     lines = src.split('\n')
     let_lines = []
     for line in lines:
         s = line.strip()
-        if s in ('let _wsActiveDragPath=null;', 'let _wsActiveDragType=null;'):
+        if _let_re.match(s):
             let_lines.append(s)
 
     def extract_function(name):


### PR DESCRIPTION
## Release WJ (v0.51.629) — macOS workspace drag-drop now lands

Round-1 fix-class ship. Ships **#4845** (@rodboev) — closes #4757.

### What broke
macOS WebKit strips custom drag MIME types (`application/ws-path`) during `dragover`/`drop`, leaving only `text/plain`, so `_isWorkspaceTreeMoveDrag` rejected every workspace tree move on macOS. Linux/Windows Chromium preserve the custom type, so it worked there.

### Fix (contributor) + hardening (maintainer, gate findings)
- Contributor: module-scoped active-drag flags set on `ondragstart` / cleared on `ondragend`; the drop handler trusts `text/plain` only while a workspace drag is in flight.
- Gate hardening (on-branch, attribution preserved):
  - **(Codex SILENT)** A foreign `text/plain` drag could be misread as a move if the flag lingered (lost `dragend`). `_wsDragSrcPath` now only trusts the flag when the drop's `text/plain` **equals** the tracked path; added `_clearWsDragData()` wired to `ondragend`, a drop `finally`, and window `dragend`/`drop`/`pagehide`/`blur` fallbacks.
  - **(Codex CORE)** My window `drop` capture listener fired *before* the target `ondrop`, re-breaking the macOS move; deferred the cleanup a tick (`setTimeout`) so the real handler runs first.

### Gate (clean)
- Codex: **SAFE TO SHIP** (legit macOS move works; foreign-text hazard closed; no desktop regression)
- Full suite: **10403 passed**, 0 failures
- 11 node drag-drop tests incl. 2 new non-vacuous regressions (stale-flag foreign-text → no move; `_clearWsDragData` resets)

Credit @rodboev.
