### PR TITLE
Release WK (v0.51.630): surface real git fetch errors on update failure (#4862, closes #4694)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.630] — 2026-06-24 — Release WK (update failures show the real git error, not just "check your connection")
+
+### Fixed
+
+- **When an update can't fetch, the WebUI now shows the actual git error instead of always blaming the network.** The apply-update paths previously discarded git's stderr and hard-coded "Could not reach the remote repository," which hid real, fixable failures (e.g. a locked ref, an auth rejection, a repository-not-found). They now surface the sanitized git diagnostic (`fetch failed: …`) for non-network failures while still showing the friendly connection message for genuine network errors (DNS, connect timeout, TLS, unreachable). The diagnostic is run through the existing secret-stripping redactor — broadened in this change to also redact `client_secret`, `private_token`, `oauth_token`, `app_secret`, and `api_key` query params — so credentials embedded in a remote URL never appear in the error. Thanks @rodboev. (#4862, closes #4694)
+
 ## [v0.51.629] — 2026-06-24 — Release WJ (macOS workspace drag-drop now lands)
 
 ### Fixed

--- a/api/updates.py
+++ b/api/updates.py
@@ -43,7 +43,7 @@ CACHE_TTL = 1800  # 30 minutes
 _GIT_DIAGNOSTIC_MAX_CHARS = 300
 _CREDENTIAL_IN_URL_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.-]*://)([^/@\s'\"]+)@")
 _GITHUB_TOKEN_RE = re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b")
-_QUERY_SECRET_RE = re.compile(r"([?&](?:access_token|token|password|auth|key)=)[^&\s'\"]+", re.IGNORECASE)
+_QUERY_SECRET_RE = re.compile(r"([?&](?:access_token|oauth_token|private_token|client_secret|app_secret|api[_-]?key|token|password|secret|auth|key)=)[^&\s'\"]+", re.IGNORECASE)
 _FETCH_NETWORK_FAILURE_SIGNATURES = (
     'could not resolve host',
     'failed to connect',

--- a/api/updates.py
+++ b/api/updates.py
@@ -44,6 +44,17 @@ _GIT_DIAGNOSTIC_MAX_CHARS = 300
 _CREDENTIAL_IN_URL_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.-]*://)([^/@\s'\"]+)@")
 _GITHUB_TOKEN_RE = re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b")
 _QUERY_SECRET_RE = re.compile(r"([?&](?:access_token|token|password|auth|key)=)[^&\s'\"]+", re.IGNORECASE)
+_FETCH_NETWORK_FAILURE_SIGNATURES = (
+    'could not resolve host',
+    'failed to connect',
+    'network is unreachable',
+    'no route to host',
+    'connection timed out',
+    'connection reset by peer',
+    'remote end hung up unexpectedly',
+    'tls connection was non-properly terminated',
+    'ssl certificate problem',
+)
 
 
 def _sanitize_git_diagnostic(output: str, *, limit: int = _GIT_DIAGNOSTIC_MAX_CHARS) -> str:
@@ -62,6 +73,17 @@ def _sanitize_git_diagnostic(output: str, *, limit: int = _GIT_DIAGNOSTIC_MAX_CH
     if len(sanitized) > limit:
         sanitized = sanitized[:limit].rstrip() + "…"
     return sanitized
+
+
+def _apply_fetch_failure_message(fetch_out: str, network_message: str) -> str:
+    """Return the apply-path fetch failure message for the given stderr."""
+    detail = _sanitize_git_diagnostic(fetch_out)
+    if not detail:
+        return network_message
+    detail_lower = detail.lower()
+    if any(signature in detail_lower for signature in _FETCH_NETWORK_FAILURE_SIGNATURES):
+        return network_message
+    return f'fetch failed: {detail}'
 
 
 def _restart_blocker_snapshot() -> dict:
@@ -1254,11 +1276,14 @@ def apply_force_update(target: str) -> dict:
         # --force so a remote re-tag (e.g. squash-merge that re-points an
         # existing release tag) doesn't jam the apply path with "would clobber
         # existing tag". See #2756.
-        _, fetch_ok = _run_git(['fetch', 'origin', '--quiet', '--tags', '--force'], path, timeout=15)
+        fetch_out, fetch_ok = _run_git(['fetch', 'origin', '--quiet', '--tags', '--force'], path, timeout=15)
         if not fetch_ok:
             return {
                 'ok': False,
-                'message': 'Could not reach the remote repository. Check your connection.',
+                'message': _apply_fetch_failure_message(
+                    fetch_out,
+                    'Could not reach the remote repository. Check your connection.',
+                ),
             }
 
         compare_ref = _select_apply_compare_ref(path)
@@ -1319,13 +1344,13 @@ def _apply_update_inner(target):
 
     # Fetch before attempting pull, so the remote ref is current.
     # --force so a remote re-tag doesn't block the update path (see #2756).
-    _, fetch_ok = _run_git(['fetch', 'origin', '--quiet', '--tags', '--force'], path, timeout=15)
+    fetch_out, fetch_ok = _run_git(['fetch', 'origin', '--quiet', '--tags', '--force'], path, timeout=15)
     if not fetch_ok:
         return {
             'ok': False,
-            'message': (
-                'Could not reach the remote repository. '
-                'Check your internet connection and try again.'
+            'message': _apply_fetch_failure_message(
+                fetch_out,
+                'Could not reach the remote repository. Check your internet connection and try again.',
             ),
         }
 

--- a/api/updates.py
+++ b/api/updates.py
@@ -50,6 +50,7 @@ _FETCH_NETWORK_FAILURE_SIGNATURES = (
     'network is unreachable',
     'no route to host',
     'connection timed out',
+    'timed out after',
     'connection reset by peer',
     'remote end hung up unexpectedly',
     'tls connection was non-properly terminated',

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -204,6 +204,40 @@ def test_apply_force_update_fetch_failure_redacts_credentials(tmp_path):
     )
 
 
+def test_apply_force_update_fetch_failure_redacts_query_secrets(tmp_path):
+    """Apply-path diagnostics must redact secret-bearing query params, not just
+    credential-in-URL and GitHub tokens. The apply path now surfaces sanitized
+    non-network stderr, so query secrets like client_secret/private_token/
+    oauth_token/api_key must be redacted before reaching the user."""
+    (tmp_path / '.git').mkdir()
+    secrets = {
+        'client_secret': 'CS_s3cr3t',
+        'private_token': 'PT_s3cr3t',
+        'oauth_token': 'OA_s3cr3t',
+        'api_key': 'AK_s3cr3t',
+    }
+    remote = (
+        'https://gitlab.example.com/group/repo.git/?'
+        + '&'.join(f'{k}={v}' for k, v in secrets.items())
+    )
+
+    def fake_git(args, cwd, timeout=10):
+        if args == ['fetch', 'origin', '--quiet', '--tags', '--force']:
+            return (f"fatal: repository not found at {remote}"), False
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    with patch.object(updates, '_run_git', side_effect=fake_git), \
+         patch.object(updates, 'REPO_ROOT', tmp_path), \
+         patch.object(updates, '_restart_blocker_snapshot', return_value={'restart_blocked': False, 'active_streams': 0, 'active_runs': 0}):
+        result = updates.apply_force_update('webui')
+
+    for name, value in secrets.items():
+        assert value not in result['message'], f'{name} value leaked: {result["message"]!r}'
+    # The fetch failure (non-network) is still surfaced as a diagnostic.
+    assert result['message'].startswith('fetch failed:')
+    assert '<redacted>' in result['message']
+
+
 def test_check_for_updates_can_skip_agent_repo(tmp_path):
     """Ignoring Agent updates should still check WebUI but avoid touching Agent git."""
     webui_path = tmp_path / 'webui'

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -92,6 +92,95 @@ def test_check_repo_fetch_failure_without_tags_is_not_up_to_date(tmp_path):
     assert info['error'] == 'fetch failed: network unavailable'
 
 
+def test_apply_force_update_fetch_failure_reports_local_diagnostic(tmp_path):
+    """Force update should surface local git fetch failures."""
+    (tmp_path / '.git').mkdir()
+
+    def fake_git(args, cwd, timeout=10):
+        if args == ['fetch', 'origin', '--quiet', '--tags', '--force']:
+            return "fatal: cannot lock ref 'refs/tags/v0.51.106': is at 123 but expected 456", False
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    with patch.object(updates, '_run_git', side_effect=fake_git), \
+         patch.object(updates, 'REPO_ROOT', tmp_path), \
+         patch.object(updates, '_restart_blocker_snapshot', return_value={'restart_blocked': False, 'active_streams': 0, 'active_runs': 0}):
+        result = updates.apply_force_update('webui')
+
+    assert result == {
+        'ok': False,
+        'message': "fetch failed: fatal: cannot lock ref 'refs/tags/v0.51.106': is at 123 but expected 456",
+    }
+
+
+def test_apply_update_fetch_failure_reports_local_diagnostic(tmp_path):
+    """Update should surface local git fetch failures."""
+    (tmp_path / '.git').mkdir()
+
+    def fake_git(args, cwd, timeout=10):
+        if args == ['fetch', 'origin', '--quiet', '--tags', '--force']:
+            return "fatal: cannot lock ref 'refs/tags/v0.51.106': is at 123 but expected 456", False
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    with patch.object(updates, '_run_git', side_effect=fake_git), \
+         patch.object(updates, 'REPO_ROOT', tmp_path), \
+         patch.object(updates, '_restart_blocker_snapshot', return_value={'restart_blocked': False, 'active_streams': 0, 'active_runs': 0}):
+        result = updates.apply_update('webui')
+
+    assert result == {
+        'ok': False,
+        'message': "fetch failed: fatal: cannot lock ref 'refs/tags/v0.51.106': is at 123 but expected 456",
+    }
+
+
+def test_apply_fetch_failure_keeps_connectivity_guidance_for_network_errors(tmp_path):
+    """Known network fetch failures should keep the connectivity guidance."""
+    (tmp_path / '.git').mkdir()
+
+    def fake_git(args, cwd, timeout=10):
+        if args == ['fetch', 'origin', '--quiet', '--tags', '--force']:
+            return 'fatal: unable to access https://github.com/nesquena/hermes-webui.git/: Could not resolve host: github.com', False
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    cases = [
+        (updates.apply_force_update, 'Could not reach the remote repository. Check your connection.'),
+        (updates.apply_update, 'Could not reach the remote repository. Check your internet connection and try again.'),
+    ]
+
+    for apply_fn, expected_message in cases:
+        with patch.object(updates, '_run_git', side_effect=fake_git), \
+             patch.object(updates, 'REPO_ROOT', tmp_path), \
+             patch.object(updates, '_restart_blocker_snapshot', return_value={'restart_blocked': False, 'active_streams': 0, 'active_runs': 0}):
+            result = apply_fn('webui')
+
+        assert result == {'ok': False, 'message': expected_message}
+
+
+def test_apply_force_update_fetch_failure_redacts_credentials(tmp_path):
+    """Apply-path fetch diagnostics must redact credential-bearing URLs."""
+    (tmp_path / '.git').mkdir()
+    secret = 'ghp_' + 'A' * 36
+
+    def fake_git(args, cwd, timeout=10):
+        if args == ['fetch', 'origin', '--quiet', '--tags', '--force']:
+            return (
+                "fatal: cannot lock ref 'refs/tags/v0.51.106': is at 123 but expected 456 "
+                f"from https://ash:{secret}@github.com/private/repo.git/"
+            ), False
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    with patch.object(updates, '_run_git', side_effect=fake_git), \
+         patch.object(updates, 'REPO_ROOT', tmp_path), \
+         patch.object(updates, '_restart_blocker_snapshot', return_value={'restart_blocked': False, 'active_streams': 0, 'active_runs': 0}):
+        result = updates.apply_force_update('webui')
+
+    assert secret not in result['message']
+    assert 'ash:' not in result['message']
+    assert result['message'] == (
+        "fetch failed: fatal: cannot lock ref 'refs/tags/v0.51.106': is at 123 but expected 456 "
+        'from https://<redacted>@github.com/private/repo.git/'
+    )
+
+
 def test_check_for_updates_can_skip_agent_repo(tmp_path):
     """Ignoring Agent updates should still check WebUI but avoid touching Agent git."""
     webui_path = tmp_path / 'webui'

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -155,6 +155,29 @@ def test_apply_fetch_failure_keeps_connectivity_guidance_for_network_errors(tmp_
         assert result == {'ok': False, 'message': expected_message}
 
 
+def test_apply_fetch_failure_keeps_connectivity_guidance_for_timeout_shape(tmp_path):
+    """The _run_git timeout string should stay on the network-guidance branch."""
+    (tmp_path / '.git').mkdir()
+
+    def fake_git(args, cwd, timeout=10):
+        if args == ['fetch', 'origin', '--quiet', '--tags', '--force']:
+            return 'git fetch origin --quiet --tags --force timed out after 15s', False
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    cases = [
+        (updates.apply_force_update, 'Could not reach the remote repository. Check your connection.'),
+        (updates.apply_update, 'Could not reach the remote repository. Check your internet connection and try again.'),
+    ]
+
+    for apply_fn, expected_message in cases:
+        with patch.object(updates, '_run_git', side_effect=fake_git), \
+             patch.object(updates, 'REPO_ROOT', tmp_path), \
+             patch.object(updates, '_restart_blocker_snapshot', return_value={'restart_blocked': False, 'active_streams': 0, 'active_runs': 0}):
+            result = apply_fn('webui')
+
+        assert result == {'ok': False, 'message': expected_message}
+
+
 def test_apply_force_update_fetch_failure_redacts_credentials(tmp_path):
     """Apply-path fetch diagnostics must redact credential-bearing URLs."""
     (tmp_path / '.git').mkdir()


### PR DESCRIPTION
## Release WK (v0.51.630) — update failures show the real git error

Round-1 fix-class ship. Ships **#4862** (@rodboev) — closes #4694.

### What it fixes
The apply-update paths discarded git's stderr and hard-coded "Could not reach the remote repository" on **any** fetch failure, hiding real fixable errors (locked ref, auth rejection, repo-not-found). They now surface the sanitized diagnostic (`fetch failed: …`) for non-network failures and keep the friendly connection message only for genuine network errors (DNS / connect-timeout / TLS / unreachable, matched by signature).

### Gate hardening (maintainer, gate finding)
Codex flagged that surfacing the diagnostic newly exposes query-string secrets the redactor didn't cover. Broadened `_QUERY_SECRET_RE` to also redact `client_secret`, `private_token`, `oauth_token`, `app_secret`, `secret`, and `api[_-]?key` (it already covered `access_token`/`token`/`password`/`auth`/`key`). Credentials embedded in a remote URL never reach the user-facing error.

### Gate (clean)
- Codex: **SAFE TO SHIP** (no secret leak, network classification correct, no check-path regression)
- Full suite: **10398 passed**, 0 failures
- +secret-redaction regression test, proven non-vacuous

Credit @rodboev.
