### PR TITLE
fix(#4728): use configured default for new conversations

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3555,7 +3555,7 @@ def _apply_advanced_model_options(model_cfg: dict, advanced: dict | None) -> Non
         model_cfg["api_key"] = api_key
 
 
-def set_hermes_default_model(model_id: str, advanced: dict | None = None) -> dict:
+def set_hermes_default_model(model_id: str, provider: str | None = None, advanced: dict | None = None) -> dict:
     """Persist the Hermes default model in config.yaml and reload runtime config."""
     selected_model = str(model_id or "").strip()
     if not selected_model:
@@ -3572,6 +3572,7 @@ def set_hermes_default_model(model_id: str, advanced: dict | None = None) -> dic
             model_cfg = {}
 
         previous_provider = str(model_cfg.get("provider") or "").strip()
+        requested_provider = str(provider or "").strip()
         resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(
             selected_model
         )
@@ -3585,7 +3586,7 @@ def set_hermes_default_model(model_id: str, advanced: dict | None = None) -> dic
         # CLI-shaped bare form via `_applyModelToDropdown()`'s normalising
         # matcher — see `static/panels.js` (#895).
         persisted_model = str(resolved_model or selected_model).strip()
-        persisted_provider = str(resolved_provider or previous_provider or "").strip()
+        persisted_provider = str(requested_provider or resolved_provider or previous_provider or "").strip()
         # Never persist the bogus ``local`` value — see #1384. The auto-detect
         # block in ``_build_available_models_uncached`` was rewriting unknown
         # loopback hosts to ``provider: "local"``, which is not registered and
@@ -3617,7 +3618,7 @@ def set_hermes_default_model(model_id: str, advanced: dict | None = None) -> dic
     # it triggers a live provider fetch (up to 8s) that blocks the HTTP response
     # to the browser, causing a visible freeze on every Settings save (#895).
     invalidate_models_cache()
-    return {"ok": True, "model": persisted_model}
+    return {"ok": True, "model": persisted_model, "provider": persisted_provider or None}
 
 
 # ── Auxiliary model configuration ──────────────────────────────────────────

--- a/api/config.py
+++ b/api/config.py
@@ -3587,6 +3587,7 @@ def set_hermes_default_model(model_id: str, provider: str | None = None, advance
         # matcher — see `static/panels.js` (#895).
         persisted_model = str(resolved_model or selected_model).strip()
         persisted_provider = str(requested_provider or resolved_provider or previous_provider or "").strip()
+        provider_override_won = bool(requested_provider and requested_provider != str(resolved_provider or "").strip())
         # Never persist the bogus ``local`` value — see #1384. The auto-detect
         # block in ``_build_available_models_uncached`` was rewriting unknown
         # loopback hosts to ``provider: "local"``, which is not registered and
@@ -3599,7 +3600,7 @@ def set_hermes_default_model(model_id: str, provider: str | None = None, advance
         if persisted_provider:
             model_cfg["provider"] = persisted_provider
 
-        if resolved_base_url:
+        if resolved_base_url and not provider_override_won:
             model_cfg["base_url"] = str(resolved_base_url).strip().rstrip("/")
         elif persisted_provider != previous_provider:
             if persisted_provider == "openai":

--- a/api/routes.py
+++ b/api/routes.py
@@ -10910,7 +10910,7 @@ def handle_post(handler, parsed) -> bool:
                 return bad(handler, str(exc), status=400)
         if scope == "main":
             try:
-                main_provider = provider if provider != "auto" else None
+                main_provider = provider if str(provider or "").strip().lower() != "auto" else None
                 return j(handler, set_hermes_default_model(model, provider=main_provider, advanced=advanced))
             except ValueError as exc:
                 return bad(handler, str(exc), status=400)

--- a/api/routes.py
+++ b/api/routes.py
@@ -10887,6 +10887,8 @@ def handle_post(handler, parsed) -> bool:
         try:
             advanced = body.get("advanced") if isinstance(body, dict) else None
             provider = body.get("provider") if isinstance(body, dict) else None
+            if str(provider or "").strip().lower() == "auto":
+                provider = None
             return j(handler, set_hermes_default_model(body.get("model"), provider=provider, advanced=advanced))
         except ValueError as e:
             return bad(handler, str(e))
@@ -10908,7 +10910,8 @@ def handle_post(handler, parsed) -> bool:
                 return bad(handler, str(exc), status=400)
         if scope == "main":
             try:
-                return j(handler, set_hermes_default_model(model, provider=provider, advanced=advanced))
+                main_provider = provider if provider != "auto" else None
+                return j(handler, set_hermes_default_model(model, provider=main_provider, advanced=advanced))
             except ValueError as exc:
                 return bad(handler, str(exc), status=400)
         return bad(handler, f"unknown scope: {scope}", status=400)

--- a/api/routes.py
+++ b/api/routes.py
@@ -10886,7 +10886,8 @@ def handle_post(handler, parsed) -> bool:
     if parsed.path == "/api/default-model":
         try:
             advanced = body.get("advanced") if isinstance(body, dict) else None
-            return j(handler, set_hermes_default_model(body.get("model"), advanced=advanced))
+            provider = body.get("provider") if isinstance(body, dict) else None
+            return j(handler, set_hermes_default_model(body.get("model"), provider=provider, advanced=advanced))
         except ValueError as e:
             return bad(handler, str(e))
         except RuntimeError as e:
@@ -10907,7 +10908,7 @@ def handle_post(handler, parsed) -> bool:
                 return bad(handler, str(exc), status=400)
         if scope == "main":
             try:
-                return j(handler, set_hermes_default_model(model, advanced=advanced))
+                return j(handler, set_hermes_default_model(model, provider=provider, advanced=advanced))
             except ValueError as exc:
                 return bad(handler, str(exc), status=400)
         return bad(handler, f"unknown scope: {scope}", status=400)

--- a/static/boot.js
+++ b/static/boot.js
@@ -1426,6 +1426,7 @@ $('modelSelect').onchange=async()=>{
   if(typeof _writePersistedModelState==='function') _writePersistedModelState(modelState.model,modelState.model_provider);
   else try{localStorage.setItem('hermes-webui-model',modelState.model)}catch{}
   if(!S.session){
+    if(typeof _rememberEmptyComposerModelOverride==='function') _rememberEmptyComposerModelOverride(modelState.model,modelState.model_provider);
     if(typeof syncModelChip==='function') syncModelChip();
     if(typeof syncReasoningChip==='function') syncReasoningChip();
     return;

--- a/static/panels.js
+++ b/static/panels.js
@@ -9795,7 +9795,7 @@ async function saveSettings(andClose){
       const saved=await api('/api/settings',{method:'POST',body:JSON.stringify(payload)});
       if(modelChanged && model){
         try{
-          await api('/api/default-model',{method:'POST',body:JSON.stringify({model})});
+          await api('/api/default-model',{method:'POST',body:JSON.stringify({model,provider:modelState.model_provider||null})});
           body.default_model=model;
           body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;
         }catch(_modelErr){
@@ -9825,7 +9825,7 @@ async function saveSettings(andClose){
     const saved=await api('/api/settings',{method:'POST',body:JSON.stringify(body)});
     if(modelChanged && model){
       try{
-        await api('/api/default-model',{method:'POST',body:JSON.stringify({model})});
+        await api('/api/default-model',{method:'POST',body:JSON.stringify({model,provider:modelState.model_provider||null})});
         body.default_model=model;
         body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;
       }catch(_modelErr){

--- a/static/panels.js
+++ b/static/panels.js
@@ -7377,7 +7377,7 @@ async function _autosavePreferencesSettings(payload){
     const pwDirty=!!(pwField&&pwField.value);
     const modelSel=$('settingsModel');
     const modelState=(typeof _captureModelDropdownSelection==='function'&&modelSel)
-      ? _captureModelDropdownSelection(modelSel)
+      ? (_captureModelDropdownSelection(modelSel)||{model:String((modelSel&&modelSel.value)||''),model_provider:null})
       : {model:String((modelSel&&modelSel.value)||''),model_provider:null};
     const modelDirty=!!(
       modelSel&&(
@@ -9720,7 +9720,7 @@ async function _applyAuxModels(){
 async function saveSettings(andClose){
   const model=($('settingsModel')||{}).value;
   const modelState=(typeof _captureModelDropdownSelection==='function'&&$('settingsModel'))
-    ? _captureModelDropdownSelection($('settingsModel'))
+    ? (_captureModelDropdownSelection($('settingsModel'))||{model:String(model||''),model_provider:null})
     : {model:String(model||''),model_provider:null};
   const modelChanged=(model||'')!==(_settingsHermesDefaultModelOnOpen||'')||((modelState.model_provider||null)!==(_settingsHermesDefaultModelProviderOnOpen||null));
   const sendKey=($('settingsSendKey')||{}).value;

--- a/static/panels.js
+++ b/static/panels.js
@@ -6461,6 +6461,7 @@ let _settingsThemeOnOpen = null; // track theme at open time for discard revert
 let _settingsSkinOnOpen = null; // track skin at open time for discard revert
 let _settingsFontSizeOnOpen = null; // track font size at open time for discard revert
 let _settingsHermesDefaultModelOnOpen = '';
+let _settingsHermesDefaultModelProviderOnOpen = null;
 let _settingsSection = 'conversation';
 let _currentSettingsSection = 'conversation';
 let _settingsIndex = null;
@@ -7375,7 +7376,15 @@ async function _autosavePreferencesSettings(payload){
     const pwField=$('settingsPassword');
     const pwDirty=!!(pwField&&pwField.value);
     const modelSel=$('settingsModel');
-    const modelDirty=!!(modelSel&&((modelSel.value||'')!==(_settingsHermesDefaultModelOnOpen||'')));
+    const modelState=(typeof _captureModelDropdownSelection==='function'&&modelSel)
+      ? _captureModelDropdownSelection(modelSel)
+      : {model:String((modelSel&&modelSel.value)||''),model_provider:null};
+    const modelDirty=!!(
+      modelSel&&(
+        (modelState.model||'')!==(_settingsHermesDefaultModelOnOpen||'')||
+        ((modelState.model_provider||null)!==(_settingsHermesDefaultModelProviderOnOpen||null))
+      )
+    );
     if(!pwDirty&&!modelDirty){
       _settingsDirty=false;
       const bar=$('settingsUnsavedBar');
@@ -7593,6 +7602,7 @@ async function loadSettingsPanel(){
         }
       }catch(e){}
       _settingsHermesDefaultModelOnOpen=(models&&models.default_model)||'';
+      _settingsHermesDefaultModelProviderOnOpen=(models&&models.active_provider)||null;
       // Use the smart matcher so a saved bare form like "anthropic/claude-opus-4.6"
       // (what the CLI's `hermes model` command writes) still selects the matching
       // `@nous:anthropic/claude-opus-4.6` option on a Nous setup. Without this, the
@@ -9231,6 +9241,7 @@ function _applySavedSettingsUi(saved, body, opts){
   const bar=$('settingsUnsavedBar');
   if(bar) bar.style.display='none';
   _settingsHermesDefaultModelOnOpen=body.default_model||_settingsHermesDefaultModelOnOpen||'';
+  if(Object.prototype.hasOwnProperty.call(body,'default_model_provider')) _settingsHermesDefaultModelProviderOnOpen=body.default_model_provider||null;
   // Sync window._defaultModel so newSession() uses the just-saved default without a reload (#908).
   if(body.default_model) window._defaultModel=body.default_model;
   if(Object.prototype.hasOwnProperty.call(body,'default_model_provider')) window._activeProvider=body.default_model_provider||null;
@@ -9711,7 +9722,7 @@ async function saveSettings(andClose){
   const modelState=(typeof _captureModelDropdownSelection==='function'&&$('settingsModel'))
     ? _captureModelDropdownSelection($('settingsModel'))
     : {model:String(model||''),model_provider:null};
-  const modelChanged=(model||'')!==(_settingsHermesDefaultModelOnOpen||'');
+  const modelChanged=(model||'')!==(_settingsHermesDefaultModelOnOpen||'')||((modelState.model_provider||null)!==(_settingsHermesDefaultModelProviderOnOpen||null));
   const sendKey=($('settingsSendKey')||{}).value;
   const showTokenUsage=!!($('settingsShowTokenUsage')||{}).checked;
   const showQuotaChip=!!($('settingsShowQuotaChip')||{}).checked;

--- a/static/panels.js
+++ b/static/panels.js
@@ -9233,6 +9233,7 @@ function _applySavedSettingsUi(saved, body, opts){
   _settingsHermesDefaultModelOnOpen=body.default_model||_settingsHermesDefaultModelOnOpen||'';
   // Sync window._defaultModel so newSession() uses the just-saved default without a reload (#908).
   if(body.default_model) window._defaultModel=body.default_model;
+  if(Object.prototype.hasOwnProperty.call(body,'default_model_provider')) window._activeProvider=body.default_model_provider||null;
   if(typeof clearMessageRenderCache==='function') clearMessageRenderCache();
   renderMessages();
   if(typeof syncTopbar==='function') syncTopbar();
@@ -9707,6 +9708,9 @@ async function _applyAuxModels(){
 
 async function saveSettings(andClose){
   const model=($('settingsModel')||{}).value;
+  const modelState=(typeof _captureModelDropdownSelection==='function'&&$('settingsModel'))
+    ? _captureModelDropdownSelection($('settingsModel'))
+    : {model:String(model||''),model_provider:null};
   const modelChanged=(model||'')!==(_settingsHermesDefaultModelOnOpen||'');
   const sendKey=($('settingsSendKey')||{}).value;
   const showTokenUsage=!!($('settingsShowTokenUsage')||{}).checked;
@@ -9782,6 +9786,7 @@ async function saveSettings(andClose){
         try{
           await api('/api/default-model',{method:'POST',body:JSON.stringify({model})});
           body.default_model=model;
+          body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;
         }catch(_modelErr){
           if(typeof showToast==='function') showToast('Failed to update default model — settings saved');
         }
@@ -9811,6 +9816,7 @@ async function saveSettings(andClose){
       try{
         await api('/api/default-model',{method:'POST',body:JSON.stringify({model})});
         body.default_model=model;
+        body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;
       }catch(_modelErr){
         if(typeof showToast==='function') showToast('Failed to update default model — settings saved');
       }

--- a/static/panels.js
+++ b/static/panels.js
@@ -9795,9 +9795,9 @@ async function saveSettings(andClose){
       const saved=await api('/api/settings',{method:'POST',body:JSON.stringify(payload)});
       if(modelChanged && model){
         try{
-          await api('/api/default-model',{method:'POST',body:JSON.stringify({model,provider:modelState.model_provider||null})});
+          const defaultModelSaved=await api('/api/default-model',{method:'POST',body:JSON.stringify({model,provider:modelState.model_provider||null})});
           body.default_model=model;
-          body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;
+          if(Object.prototype.hasOwnProperty.call(defaultModelSaved,'provider')) body.default_model_provider=defaultModelSaved.provider||null;
         }catch(_modelErr){
           if(typeof showToast==='function') showToast('Failed to update default model — settings saved');
         }
@@ -9825,9 +9825,9 @@ async function saveSettings(andClose){
     const saved=await api('/api/settings',{method:'POST',body:JSON.stringify(body)});
     if(modelChanged && model){
       try{
-        await api('/api/default-model',{method:'POST',body:JSON.stringify({model,provider:modelState.model_provider||null})});
+        const defaultModelSaved=await api('/api/default-model',{method:'POST',body:JSON.stringify({model,provider:modelState.model_provider||null})});
         body.default_model=model;
-        body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;
+        if(Object.prototype.hasOwnProperty.call(defaultModelSaved,'provider')) body.default_model_provider=defaultModelSaved.provider||null;
       }catch(_modelErr){
         if(typeof showToast==='function') showToast('Failed to update default model — settings saved');
       }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -802,6 +802,32 @@ function _markPollingCompletionUnreadTransitions(sessions) {
 
 let _newSessionInFlight=null;
 const _newSessionPendingText=()=>t('new_session_creating')||'Creating new conversation…';
+const _emptyComposerModelOverrideHost=typeof window!=='undefined'?window:globalThis;
+
+function _rememberEmptyComposerModelOverride(model, modelProvider){
+  const resolvedModel=String(model||'').trim();
+  if(!resolvedModel) return;
+  _emptyComposerModelOverrideHost._emptyComposerModelOverride={
+    model:resolvedModel,
+    model_provider:modelProvider||null,
+    saved_at:Date.now(),
+  };
+}
+
+function _readEmptyComposerModelOverride(){
+  const state=_emptyComposerModelOverrideHost._emptyComposerModelOverride;
+  if(!state||!state.model) return null;
+  return {
+    model:String(state.model||''),
+    model_provider:state.model_provider||null,
+    saved_at:Number(state.saved_at||0)||0,
+  };
+}
+
+function _clearEmptyComposerModelOverride(){
+  _emptyComposerModelOverrideHost._emptyComposerModelOverride=null;
+}
+
 function _setNewSessionPending(pending){
   const ids=['btnNewChat','btnTitlebarNewChat'];
   for (let i=0;i<ids.length;i++){
@@ -849,12 +875,21 @@ async function newSession(flash, options={}){
     if(_activeProject&&_activeProject!==NO_PROJECT_FILTER) reqBody.project_id=_activeProject;
     // Forward a pre-session toolset override only from the empty composer (#4490).
     if(!S.session && Array.isArray(S._pendingSessionToolsets)) reqBody.enabled_toolsets=S._pendingSessionToolsets;
-    // Carry the visible picker selection into the new session. Without this,
-    // /api/session/new falls back to config.yaml defaults (e.g. gpt-5.5) even
-    // when the user already chose cursor/composer-2.5 in the composer chip.
     const modelSelForNew=$('modelSelect');
+    const explicitModelOverride=(typeof _readEmptyComposerModelOverride==='function')
+      ? _readEmptyComposerModelOverride()
+      : null;
+    const hasLoadedSession=!!(S.session&&S.session.session_id);
     let newModelState=null;
-    if(modelSelForNew&&modelSelForNew.value&&typeof _modelStateForSelect==='function'){
+    let consumedExplicitModelOverride=false;
+    if(!hasLoadedSession&&explicitModelOverride&&explicitModelOverride.model){
+      newModelState=explicitModelOverride;
+      consumedExplicitModelOverride=true;
+    }else if(hasLoadedSession&&window._defaultModel){
+      newModelState=(typeof _modelStateForSelect==='function'&&modelSelForNew)
+        ? _modelStateForSelect(modelSelForNew,window._defaultModel)
+        : {model:window._defaultModel,model_provider:window._activeProvider||null};
+    }else if(modelSelForNew&&modelSelForNew.value&&typeof _modelStateForSelect==='function'){
       newModelState=_modelStateForSelect(modelSelForNew,modelSelForNew.value);
     }else if(typeof _readPersistedModelState==='function'){
       newModelState=_readPersistedModelState();
@@ -903,6 +938,9 @@ async function newSession(flash, options={}){
         ||null;
     }
     const data=await api('/api/session/new',{method:'POST',body:JSON.stringify(reqBody)});
+    if(consumedExplicitModelOverride&&typeof _clearEmptyComposerModelOverride==='function'){
+      _clearEmptyComposerModelOverride();
+    }
     S.session=data.session;S.messages=data.session.messages||[];
     S._pendingSessionToolsets=null;
     if(_sessionSourceFilter==='cli') _sessionSourceFilter='webui';
@@ -1244,6 +1282,7 @@ async function loadSession(sid){
     return loadSession(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,force:true});
   }
   S.session=data.session;
+  if(typeof _clearEmptyComposerModelOverride==='function') _clearEmptyComposerModelOverride();
   // Loading a real existing session abandons any pre-session toolset override
   // staged on the empty composer before any deferred refresh work runs.
   S._pendingSessionToolsets=null;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -882,13 +882,13 @@ async function newSession(flash, options={}){
     const hasLoadedSession=!!(S.session&&S.session.session_id);
     let newModelState=null;
     let consumedExplicitModelOverride=false;
+    let usingConfiguredDefault=false;
     if(!hasLoadedSession&&explicitModelOverride&&explicitModelOverride.model){
       newModelState=explicitModelOverride;
       consumedExplicitModelOverride=true;
     }else if(hasLoadedSession&&window._defaultModel){
-      newModelState=(typeof _modelStateForSelect==='function'&&modelSelForNew)
-        ? _modelStateForSelect(modelSelForNew,window._defaultModel)
-        : {model:window._defaultModel,model_provider:window._activeProvider||null};
+      newModelState={model:window._defaultModel,model_provider:window._activeProvider||null};
+      usingConfiguredDefault=true;
     }else if(modelSelForNew&&modelSelForNew.value&&typeof _modelStateForSelect==='function'){
       newModelState=_modelStateForSelect(modelSelForNew,modelSelForNew.value);
     }else if(typeof _readPersistedModelState==='function'){
@@ -924,7 +924,9 @@ async function newSession(flash, options={}){
       // server fast path passes the pair through verbatim (no validation) and
       // silently routes to the wrong backend — so leave model_provider=null and
       // let the slow-path family repair run (mirrors routes.py _normalize_provider_id).
-      const _fallbackProvider=_bareModel?(window._activeProvider||(S.session&&S.session.model_provider)||''):'';
+      const _fallbackProvider=_bareModel
+        ? ((usingConfiguredDefault?window._activeProvider:(window._activeProvider||(S.session&&S.session.model_provider)))||'')
+        : '';
       const _familyProvider=(m=>{const s=String(m||'').toLowerCase();
         if(s.startsWith('gpt'))return 'openai';if(s.startsWith('claude'))return 'anthropic';
         if(s.startsWith('gemini'))return 'google';return '';})(newModelState.model);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -887,7 +887,7 @@ async function newSession(flash, options={}){
       newModelState=explicitModelOverride;
       consumedExplicitModelOverride=true;
     }else if(hasLoadedSession&&window._defaultModel){
-      newModelState={model:window._defaultModel,model_provider:window._activeProvider||null};
+      newModelState={model:window._defaultModel,model_provider:null};
       usingConfiguredDefault=true;
     }else if(modelSelForNew&&modelSelForNew.value&&typeof _modelStateForSelect==='function'){
       newModelState=_modelStateForSelect(modelSelForNew,modelSelForNew.value);

--- a/tests/test_auxiliary_models_settings.py
+++ b/tests/test_auxiliary_models_settings.py
@@ -474,6 +474,23 @@ class TestAuxiliaryModelsBackend:
         assert "reasoning_effort: none" in text
         assert "DUMMY_KEY_DO_NOT_PRINT" in text
 
+    def test_set_hermes_default_model_persists_explicit_provider_override(self, monkeypatch, tmp_path):
+        from api import config
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model:\n  provider: openai\n  default: gpt-5.5\n", encoding="utf-8")
+        monkeypatch.setattr(config, "_get_config_path", lambda: config_path)
+        monkeypatch.setattr(config, "reload_config", lambda: None)
+        monkeypatch.setattr(config, "invalidate_models_cache", lambda: None)
+        monkeypatch.setattr(config, "resolve_model_provider", lambda model: (model, "", None))
+
+        result = config.set_hermes_default_model("gpt-5.5", provider="anthropic")
+
+        assert result["ok"] is True
+        assert result["provider"] == "anthropic"
+        text = config_path.read_text(encoding="utf-8")
+        assert "provider: anthropic" in text
+
     def test_set_auxiliary_model_persists_advanced_options(self, monkeypatch, tmp_path):
         """Gear-modal payload should persist supported per-slot options."""
         from api import config

--- a/tests/test_auxiliary_models_settings.py
+++ b/tests/test_auxiliary_models_settings.py
@@ -491,6 +491,24 @@ class TestAuxiliaryModelsBackend:
         text = config_path.read_text(encoding="utf-8")
         assert "provider: anthropic" in text
 
+    def test_set_hermes_default_model_provider_override_replaces_stale_custom_base_url(self, monkeypatch, tmp_path):
+        from api import config
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model:\n  provider: custom\n  default: gpt-5.5\n  base_url: http://old.local/v1\n", encoding="utf-8")
+        monkeypatch.setattr(config, "_get_config_path", lambda: config_path)
+        monkeypatch.setattr(config, "reload_config", lambda: None)
+        monkeypatch.setattr(config, "invalidate_models_cache", lambda: None)
+        monkeypatch.setattr(config, "resolve_model_provider", lambda model: (model, "custom", "http://old.local/v1"))
+
+        result = config.set_hermes_default_model("gpt-5.5", provider="openai")
+
+        assert result["ok"] is True
+        saved = config_path.read_text(encoding="utf-8")
+        assert "provider: openai" in saved
+        assert "base_url: https://api.openai.com/v1" in saved
+        assert "http://old.local/v1" not in saved
+
     def test_set_auxiliary_model_persists_advanced_options(self, monkeypatch, tmp_path):
         """Gear-modal payload should persist supported per-slot options."""
         from api import config

--- a/tests/test_auxiliary_models_settings.py
+++ b/tests/test_auxiliary_models_settings.py
@@ -356,7 +356,7 @@ class TestAuxiliaryModelsBackend:
             "/api/model/set": {
                 "scope": "main",
                 "model": "gpt-5.5",
-                "provider": "auto",
+                "provider": "AUTO",
                 "advanced": {"base_url": "https://example.invalid/v1"},
             },
         }

--- a/tests/test_auxiliary_models_settings.py
+++ b/tests/test_auxiliary_models_settings.py
@@ -5,6 +5,7 @@ that the JS loading/saving logic is wired up, and that all locales have the
 required i18n keys.
 """
 from pathlib import Path
+from types import SimpleNamespace
 
 ROOT = Path(__file__).parent.parent
 PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
@@ -327,6 +328,55 @@ class TestAuxiliaryModelsBackend:
         assert '"/api/model/set"' in self.ROUTES_PY, (
             "Missing /api/model/set route in routes.py"
         )
+
+    def test_default_model_routes_drop_auxiliary_auto_provider_sentinel(self, monkeypatch):
+        from api import routes
+
+        seen = []
+
+        monkeypatch.setattr(routes, "_csrf_exempt_path", lambda _path: True)
+        monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: payload)
+
+        def fake_set_default_model(model, provider=None, advanced=None):
+            seen.append({
+                "model": model,
+                "provider": provider,
+                "advanced": advanced,
+            })
+            return {"ok": True, "model": model, "provider": provider}
+
+        monkeypatch.setattr(routes, "set_hermes_default_model", fake_set_default_model)
+
+        bodies = {
+            "/api/default-model": {
+                "model": "gpt-5.5",
+                "provider": "auto",
+                "advanced": {"base_url": "https://example.invalid/v1"},
+            },
+            "/api/model/set": {
+                "scope": "main",
+                "model": "gpt-5.5",
+                "provider": "auto",
+                "advanced": {"base_url": "https://example.invalid/v1"},
+            },
+        }
+
+        for path, body in bodies.items():
+            monkeypatch.setattr(routes, "read_body", lambda _handler, payload=body: payload)
+            routes.handle_post(object(), SimpleNamespace(path=path, query=""))
+
+        assert seen == [
+            {
+                "model": "gpt-5.5",
+                "provider": None,
+                "advanced": {"base_url": "https://example.invalid/v1"},
+            },
+            {
+                "model": "gpt-5.5",
+                "provider": None,
+                "advanced": {"base_url": "https://example.invalid/v1"},
+            },
+        ]
 
     def test_get_auxiliary_models_function_exists(self):
         """get_auxiliary_models() must exist in api/config.py."""

--- a/tests/test_issue4728_new_chat_default_model.py
+++ b/tests/test_issue4728_new_chat_default_model.py
@@ -31,7 +31,15 @@ function extractNewSession(src) {
 
 const src = fs.readFileSync(process.argv[2], 'utf8');
 const args = JSON.parse(process.argv[3]);
-const modelSelect = { value: args.currentModel || '', options: [] };
+const modelSelect = {
+  value: args.currentModel || '',
+  options: [],
+  selectedOptions: [{
+    dataset: {
+      provider: args.selectedOptionProvider || '',
+    },
+  }],
+};
 const store = new Map();
 const captured = [];
 
@@ -93,15 +101,14 @@ globalThis._readEmptyComposerModelOverride = () => globalThis._emptyComposerMode
 globalThis._clearEmptyComposerModelOverride = () => {
   globalThis._emptyComposerModelOverride = null;
 };
-globalThis._modelStateForSelect = (_sel, modelId) => {
-  if (args.modelStates && Object.prototype.hasOwnProperty.call(args.modelStates, modelId)) {
-    const state = args.modelStates[modelId];
-    return {
-      model: state.model || modelId,
-      model_provider: state.model_provider || null,
-    };
-  }
-  return { model: modelId, model_provider: null };
+globalThis._modelStateForSelect = (sel, modelId) => {
+  const value = String(modelId || '').trim();
+  if (!value) return { model: '', model_provider: null };
+  const provider = String(((sel && sel.selectedOptions && sel.selectedOptions[0] && sel.selectedOptions[0].dataset) || {}).provider || '').trim();
+  return {
+    model: value,
+    model_provider: provider && provider !== 'default' ? provider : null,
+  };
 };
 globalThis._applyModelToDropdown = (modelId, sel, provider) => {
   sel.value = modelId;
@@ -196,12 +203,9 @@ def test_loaded_session_picker_value_posts_configured_default_model(driver_path)
             "model_provider": "session-provider",
         },
         "currentModel": "GPT-5.4",
+        "selectedOptionProvider": "session-provider",
         "defaultModel": "deepseek-v4-flash",
         "activeProvider": "deepseek",
-        "modelStates": {
-            "GPT-5.4": {"model": "GPT-5.4", "model_provider": "session-provider"},
-            "deepseek-v4-flash": {"model": "deepseek-v4-flash", "model_provider": "deepseek"},
-        },
     })
 
     assert data["reqBody"]["model"] == "deepseek-v4-flash"
@@ -220,11 +224,6 @@ def test_explicit_empty_composer_override_wins_over_configured_default(driver_pa
             "model_provider": "cursor",
             "saved_at": 123,
         },
-        "modelStates": {
-            "GPT-5.4": {"model": "GPT-5.4", "model_provider": "session-provider"},
-            "cursor/composer-2.5": {"model": "cursor/composer-2.5", "model_provider": "cursor"},
-            "deepseek-v4-flash": {"model": "deepseek-v4-flash", "model_provider": "deepseek"},
-        },
     })
 
     assert data["reqBody"]["model"] == "cursor/composer-2.5"
@@ -242,9 +241,6 @@ def test_matching_fallback_provider_still_routes_bare_models(driver_path):
         },
         "currentModel": "gpt-4o",
         "activeProvider": "openai",
-        "modelStates": {
-            "gpt-4o": {"model": "gpt-4o"},
-        },
     })
 
     assert data["reqBody"]["model"] == "gpt-4o"
@@ -261,9 +257,6 @@ def test_family_mismatched_fallback_provider_stays_null(driver_path):
         },
         "currentModel": "gpt-4o",
         "activeProvider": "anthropic",
-        "modelStates": {
-            "gpt-4o": {"model": "gpt-4o"},
-        },
     })
 
     assert data["reqBody"]["model"] == "gpt-4o"

--- a/tests/test_issue4728_new_chat_default_model.py
+++ b/tests/test_issue4728_new_chat_default_model.py
@@ -1,0 +1,270 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS_PATH = REPO_ROOT / "static" / "sessions.js"
+NODE = shutil.which("node")
+
+
+_DRIVER_SRC = r"""
+const fs = require('fs');
+
+function extractNewSession(src) {
+  const start = src.indexOf('async function newSession(');
+  if (start < 0) throw new Error('newSession not found');
+  let depth = 0;
+  let bodyStart = src.indexOf('{', src.indexOf(')', start));
+  for (let i = bodyStart; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  throw new Error('newSession body not closed');
+}
+
+const src = fs.readFileSync(process.argv[2], 'utf8');
+const args = JSON.parse(process.argv[3]);
+const modelSelect = { value: args.currentModel || '', options: [] };
+const store = new Map();
+const captured = [];
+
+function $(id) {
+  return id === 'modelSelect' ? modelSelect : null;
+}
+
+const localStorage = {
+  getItem(key) {
+    return store.has(key) ? store.get(key) : null;
+  },
+  setItem(key, value) {
+    store.set(key, String(value));
+  },
+  removeItem(key) {
+    store.delete(key);
+  },
+};
+
+globalThis.window = globalThis;
+globalThis.document = {
+  baseURI: 'http://example.test/',
+  createElement(tag) {
+    return {
+      tagName: String(tag || '').toUpperCase(),
+      dataset: {},
+      appendChild(child) {
+        (this.children || (this.children = [])).push(child);
+      },
+      textContent: '',
+      value: '',
+    };
+  },
+};
+globalThis.localStorage = localStorage;
+globalThis.history = { replaceState() {} };
+globalThis.$ = $;
+globalThis.NO_PROJECT_FILTER = '__NO_PROJECT_FILTER__';
+globalThis._activeProject = '';
+globalThis._sessionSourceFilter = 'webui';
+globalThis._newSessionInFlight = null;
+globalThis._messagesTruncated = false;
+globalThis._oldestIdx = 0;
+globalThis.INFLIGHT = {};
+globalThis.S = {
+  session: args.session || null,
+  toolCalls: [],
+  messages: [],
+  activeProfile: args.activeProfile || 'default',
+  _pendingSessionToolsets: null,
+  _profileSwitchWorkspace: null,
+  _profileDefaultWorkspace: null,
+};
+globalThis._defaultModel = args.defaultModel || null;
+globalThis._activeProvider = args.activeProvider || null;
+globalThis._emptyComposerModelOverride = args.emptyComposerOverride || null;
+globalThis._readPersistedModelState = () => args.persisted || null;
+globalThis._readEmptyComposerModelOverride = () => globalThis._emptyComposerModelOverride;
+globalThis._clearEmptyComposerModelOverride = () => {
+  globalThis._emptyComposerModelOverride = null;
+};
+globalThis._modelStateForSelect = (_sel, modelId) => {
+  if (args.modelStates && Object.prototype.hasOwnProperty.call(args.modelStates, modelId)) {
+    const state = args.modelStates[modelId];
+    return {
+      model: state.model || modelId,
+      model_provider: state.model_provider || null,
+    };
+  }
+  return { model: modelId, model_provider: null };
+};
+globalThis._applyModelToDropdown = (modelId, sel, provider) => {
+  sel.value = modelId;
+  sel._provider = provider || null;
+  return true;
+};
+for (const name of [
+  'clearLiveToolCards',
+  'updateQueueBadge',
+  '_clearPendingSelections',
+  'setComposerStatus',
+  'setStatus',
+  'updateSendBtn',
+  'syncTopbar',
+  'renderMessages',
+  'startSessionStream',
+  '_setSessionViewedCount',
+  '_setActiveSessionUrl',
+  '_rememberNewChatDraftSession',
+  '_hydrateTodosFromSession',
+  'syncModelChip',
+  'syncReasoningChip',
+  '_setLiveAssistantTps',
+  '_syncCtxIndicator',
+  'showToast',
+]) {
+  globalThis[name] = () => {};
+}
+globalThis.loadDir = async () => null;
+globalThis._setNewSessionPending = () => {};
+globalThis.api = async (url, opts) => {
+  const body = JSON.parse(opts.body);
+  captured.push({ url, body });
+  if (url !== '/api/session/new') throw new Error('unexpected api call: ' + url);
+  return {
+    session: {
+      session_id: 'session-1',
+      messages: [],
+      model: body.model,
+      model_provider: body.model_provider,
+      workspace: body.workspace,
+      message_count: 0,
+      last_usage: {},
+    },
+  };
+};
+
+eval(extractNewSession(src));
+
+(async () => {
+  await newSession(false, {});
+  process.stdout.write(JSON.stringify({
+    reqBody: captured[0].body,
+    modelValue: modelSelect.value,
+    override: globalThis._emptyComposerModelOverride,
+  }));
+})().catch(err => {
+  process.stderr.write(String(err && err.stack ? err.stack : err));
+  process.exit(1);
+});
+"""
+
+
+node_test = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    path = tmp_path_factory.mktemp("issue4728_new_chat_default_model") / "driver.js"
+    path.write_text(_DRIVER_SRC, encoding="utf-8")
+    return str(path)
+
+
+def _run_case(driver_path, payload):
+    result = subprocess.run(
+        [NODE, driver_path, str(SESSIONS_JS_PATH), json.dumps(payload)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed:\nSTDOUT={result.stdout}\nSTDERR={result.stderr}")
+    return json.loads(result.stdout)
+
+
+@node_test
+def test_loaded_session_picker_value_posts_configured_default_model(driver_path):
+    data = _run_case(driver_path, {
+        "session": {
+            "session_id": "loaded-session",
+            "model": "GPT-5.4",
+            "model_provider": "session-provider",
+        },
+        "currentModel": "GPT-5.4",
+        "defaultModel": "deepseek-v4-flash",
+        "activeProvider": "deepseek",
+        "modelStates": {
+            "GPT-5.4": {"model": "GPT-5.4", "model_provider": "session-provider"},
+            "deepseek-v4-flash": {"model": "deepseek-v4-flash", "model_provider": "deepseek"},
+        },
+    })
+
+    assert data["reqBody"]["model"] == "deepseek-v4-flash"
+    assert data["reqBody"]["model_provider"] == "deepseek"
+    assert data["modelValue"] == "deepseek-v4-flash"
+
+
+@node_test
+def test_explicit_empty_composer_override_wins_over_configured_default(driver_path):
+    data = _run_case(driver_path, {
+        "currentModel": "GPT-5.4",
+        "defaultModel": "deepseek-v4-flash",
+        "activeProvider": "deepseek",
+        "emptyComposerOverride": {
+            "model": "cursor/composer-2.5",
+            "model_provider": "cursor",
+            "saved_at": 123,
+        },
+        "modelStates": {
+            "GPT-5.4": {"model": "GPT-5.4", "model_provider": "session-provider"},
+            "cursor/composer-2.5": {"model": "cursor/composer-2.5", "model_provider": "cursor"},
+            "deepseek-v4-flash": {"model": "deepseek-v4-flash", "model_provider": "deepseek"},
+        },
+    })
+
+    assert data["reqBody"]["model"] == "cursor/composer-2.5"
+    assert data["reqBody"]["model_provider"] == "cursor"
+    assert data["override"] is None
+
+
+@node_test
+def test_matching_fallback_provider_still_routes_bare_models(driver_path):
+    data = _run_case(driver_path, {
+        "session": {
+            "session_id": "loaded-session",
+            "model": "gpt-4o",
+            "model_provider": "session-provider",
+        },
+        "currentModel": "gpt-4o",
+        "activeProvider": "openai",
+        "modelStates": {
+            "gpt-4o": {"model": "gpt-4o"},
+        },
+    })
+
+    assert data["reqBody"]["model"] == "gpt-4o"
+    assert data["reqBody"]["model_provider"] == "openai"
+
+
+@node_test
+def test_family_mismatched_fallback_provider_stays_null(driver_path):
+    data = _run_case(driver_path, {
+        "session": {
+            "session_id": "loaded-session",
+            "model": "gpt-4o",
+            "model_provider": "session-provider",
+        },
+        "currentModel": "gpt-4o",
+        "activeProvider": "anthropic",
+        "modelStates": {
+            "gpt-4o": {"model": "gpt-4o"},
+        },
+    })
+
+    assert data["reqBody"]["model"] == "gpt-4o"
+    assert data["reqBody"]["model_provider"] is None

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -169,6 +169,8 @@ def test_save_settings_syncs_default_model_provider_with_saved_model():
     assert "_settingsHermesDefaultModelProviderOnOpen=(models&&models.active_provider)||null;" in panels_js
     assert "if(Object.prototype.hasOwnProperty.call(body,'default_model_provider')) _settingsHermesDefaultModelProviderOnOpen=body.default_model_provider||null;" in apply_saved_block
     assert "(modelState.model_provider||null)!==(_settingsHermesDefaultModelProviderOnOpen||null)" in autosave_block
+    assert "_captureModelDropdownSelection(modelSel)||{model:String((modelSel&&modelSel.value)||''),model_provider:null}" in panels_js
+    assert "_captureModelDropdownSelection($('settingsModel'))||{model:String(model||''),model_provider:null}" in save_block
 
 
 def test_changelog_mentions_new_chat_default_model_provider_sync():

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -155,6 +155,16 @@ def test_new_session_keeps_provider_fallback_guards_after_model_precedence():
     assert "usingConfiguredDefault?window._activeProvider" in fn
 
 
+def test_save_settings_syncs_default_model_provider_with_saved_model():
+    panels_js = Path("static/panels.js").read_text(encoding="utf-8")
+    save_block = _extract_function(panels_js, "async function saveSettings")
+    apply_saved_block = _extract_function(panels_js, "function _applySavedSettingsUi")
+
+    assert "_captureModelDropdownSelection($('settingsModel'))" in save_block
+    assert "body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;" in save_block
+    assert "if(Object.prototype.hasOwnProperty.call(body,'default_model_provider')) window._activeProvider=body.default_model_provider||null;" in apply_saved_block
+
+
 def test_changelog_mentions_new_chat_default_model_provider_sync():
     unreleased = CHANGELOG.split("## [v0.51.103]", 1)[0]
     assert "New conversations now resync" in unreleased

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -159,10 +159,15 @@ def test_save_settings_syncs_default_model_provider_with_saved_model():
     panels_js = Path("static/panels.js").read_text(encoding="utf-8")
     save_block = _extract_function(panels_js, "async function saveSettings")
     apply_saved_block = _extract_function(panels_js, "function _applySavedSettingsUi")
+    autosave_block = panels_js[panels_js.index("const pwField=$('settingsPassword');"):panels_js.index("if(!pwDirty&&!modelDirty){", panels_js.index("const pwField=$('settingsPassword');")) + 24]
 
     assert "_captureModelDropdownSelection($('settingsModel'))" in save_block
     assert "body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;" in save_block
+    assert "const modelChanged=(model||'')!==(_settingsHermesDefaultModelOnOpen||'')||((modelState.model_provider||null)!==(_settingsHermesDefaultModelProviderOnOpen||null));" in save_block
     assert "if(Object.prototype.hasOwnProperty.call(body,'default_model_provider')) window._activeProvider=body.default_model_provider||null;" in apply_saved_block
+    assert "_settingsHermesDefaultModelProviderOnOpen=(models&&models.active_provider)||null;" in panels_js
+    assert "if(Object.prototype.hasOwnProperty.call(body,'default_model_provider')) _settingsHermesDefaultModelProviderOnOpen=body.default_model_provider||null;" in apply_saved_block
+    assert "(modelState.model_provider||null)!==(_settingsHermesDefaultModelProviderOnOpen||null)" in autosave_block
 
 
 def test_changelog_mentions_new_chat_default_model_provider_sync():

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -137,8 +137,9 @@ def test_new_chat_prefers_explicit_empty_composer_override_before_configured_def
     assert "explicitModelOverride" in fn
     assert "hasLoadedSession" in fn
     assert "consumedExplicitModelOverride" in fn
+    assert "usingConfiguredDefault" in fn
     assert "_clearEmptyComposerModelOverride" in fn
-    assert "hasLoadedSession&&window._defaultModel" in fn
+    assert "newModelState={model:window._defaultModel,model_provider:window._activeProvider||null};" in fn
     assert fn.index("explicitModelOverride") < fn.index("hasLoadedSession&&window._defaultModel") < fn.index("_modelStateForSelect"), (
         "newSession() must prefer the empty-composer override first, then the configured default for loaded-session flows, then legacy picker state"
     )
@@ -151,6 +152,7 @@ def test_new_session_keeps_provider_fallback_guards_after_model_precedence():
     assert "_fallbackProvider" in provider_assignment
     assert "_familyMismatch" in provider_assignment
     assert "_fallbackIsNamedCustom" in provider_assignment
+    assert "usingConfiguredDefault?window._activeProvider" in fn
 
 
 def test_changelog_mentions_new_chat_default_model_provider_sync():

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -96,43 +96,21 @@ def test_new_chat_does_not_send_stale_dropdown_model_when_session_has_default_mo
 
 def test_new_session_posts_picker_model_before_server_default():
     fn = _new_session_function()
-    # Behavior contract: the picker model goes into reqBody so /api/session/new
-    # uses the user's selection before falling back to the server default
-    # (#872). The previous literal-string assertion
-    # "reqBody.model_provider=newModelState.model_provider||null" became a
-    # change-detector once the #2518 follow-up added a fallback chain; the
-    # contract that newModelState.model_provider is the FIRST source of
-    # reqBody.model_provider is now verified by substring + ordering.
     assert "reqBody.model=newModelState.model" in fn
-    assert "newModelState.model_provider" in fn
-    assert "window._activeProvider" in fn, (
-        "Cold-start fallback must consult window._activeProvider so "
-        "/api/session/new hits the resolve fast path (follow-up from #2518)."
-    )
-    assert "S.session&&S.session.model_provider" in fn, (
-        "Unhydrated-dropdown fallback must consult S.session.model_provider "
-        "before sending model_provider=null (follow-up from #2518)."
-    )
+    assert "explicitModelOverride" in fn
+    assert "hasLoadedSession&&window._defaultModel" in fn
+    assert "modelSelForNew&&modelSelForNew.value&&typeof _modelStateForSelect==='function'" in fn
     provider_assignment = fn[fn.index("reqBody.model_provider="):].split(";", 1)[0]
-    # The assignment sources from the explicit picker value first, then the
-    # bare-model fallback (_fallbackProvider, wired above from _activeProvider /
-    # prev-session), gated so a family-mismatched bare model defers to the
-    # server slow path. Anchor on the real `reqBody.model_provider=` assignment
-    # (not a comment) and verify the fallback wiring exists in the function body.
     assert "newModelState.model_provider" in provider_assignment
     assert "_fallbackProvider" in provider_assignment
     assert "window._activeProvider" in fn
     assert "S.session&&S.session.model_provider" in fn
-    # Ordering in the body: explicit picker value referenced before the
-    # _activeProvider fallback, which is referenced before prev-session.
-    pos_explicit = fn.index("newModelState.model_provider")
-    pos_active = fn.index("window._activeProvider")
-    pos_prev = fn.index("S.session&&S.session.model_provider")
-    assert pos_explicit < pos_active < pos_prev, (
-        "Fallback chain must be: explicit > _activeProvider > prev-session."
+    pos_override = fn.index("explicitModelOverride")
+    pos_default = fn.index("hasLoadedSession&&window._defaultModel")
+    pos_legacy = fn.index("modelSelForNew&&modelSelForNew.value&&typeof _modelStateForSelect==='function'")
+    assert pos_override < pos_default < pos_legacy, (
+        "newSession() must prefer the empty-composer override first, then the configured default for loaded-session flows, then legacy picker state"
     )
-    # Family-mismatch guard (Codex #3410-followup finding): a bare known-family
-    # model whose family differs from the fallback provider must NOT fast-path.
     assert "_familyMismatch" in fn
     assert "_readPersistedModelState" in fn
 
@@ -141,8 +119,38 @@ def test_model_picker_persists_without_active_session():
     boot_js = Path("static/boot.js").read_text(encoding="utf-8")
     body = boot_js[boot_js.index("$('modelSelect').onchange=async()=>") : boot_js.index("$('msg').addEventListener", boot_js.index("$('modelSelect').onchange=async()=>"))]
     assert "_writePersistedModelState(modelState.model,modelState.model_provider)" in body
+    assert "_rememberEmptyComposerModelOverride(modelState.model,modelState.model_provider)" in body
     assert "if(!S.session){" in body
     assert body.index("if(!S.session){") < body.index("await api('/api/session/update'")
+
+
+def test_session_model_changes_do_not_write_empty_composer_override():
+    boot_js = Path("static/boot.js").read_text(encoding="utf-8")
+    body = boot_js[boot_js.index("$('modelSelect').onchange=async()=>") : boot_js.index("$('msg').addEventListener", boot_js.index("$('modelSelect').onchange=async()=>"))]
+    session_branch = body[body.index("if(typeof _rememberPendingSessionModel==='function')"):]
+    assert "_rememberPendingSessionModel(S.session.session_id,modelState.model,modelState.model_provider)" in body
+    assert "_rememberEmptyComposerModelOverride(modelState.model,modelState.model_provider)" not in session_branch
+
+
+def test_new_chat_prefers_explicit_empty_composer_override_before_configured_default():
+    fn = _new_session_function()
+    assert "explicitModelOverride" in fn
+    assert "hasLoadedSession" in fn
+    assert "consumedExplicitModelOverride" in fn
+    assert "_clearEmptyComposerModelOverride" in fn
+    assert "hasLoadedSession&&window._defaultModel" in fn
+    assert fn.index("explicitModelOverride") < fn.index("hasLoadedSession&&window._defaultModel") < fn.index("_modelStateForSelect"), (
+        "newSession() must prefer the empty-composer override first, then the configured default for loaded-session flows, then legacy picker state"
+    )
+
+
+def test_new_session_keeps_provider_fallback_guards_after_model_precedence():
+    fn = _new_session_function()
+    provider_assignment = fn[fn.index("reqBody.model_provider="):].split(";", 1)[0]
+    assert "newModelState.model_provider" in provider_assignment
+    assert "_fallbackProvider" in provider_assignment
+    assert "_familyMismatch" in provider_assignment
+    assert "_fallbackIsNamedCustom" in provider_assignment
 
 
 def test_changelog_mentions_new_chat_default_model_provider_sync():

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -162,6 +162,7 @@ def test_save_settings_syncs_default_model_provider_with_saved_model():
     autosave_block = panels_js[panels_js.index("const pwField=$('settingsPassword');"):panels_js.index("if(!pwDirty&&!modelDirty){", panels_js.index("const pwField=$('settingsPassword');")) + 24]
 
     assert "_captureModelDropdownSelection($('settingsModel'))" in save_block
+    assert "JSON.stringify({model,provider:modelState.model_provider||null})" in save_block
     assert "body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;" in save_block
     assert "const modelChanged=(model||'')!==(_settingsHermesDefaultModelOnOpen||'')||((modelState.model_provider||null)!==(_settingsHermesDefaultModelProviderOnOpen||null));" in save_block
     assert "if(Object.prototype.hasOwnProperty.call(body,'default_model_provider')) window._activeProvider=body.default_model_provider||null;" in apply_saved_block

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -139,7 +139,7 @@ def test_new_chat_prefers_explicit_empty_composer_override_before_configured_def
     assert "consumedExplicitModelOverride" in fn
     assert "usingConfiguredDefault" in fn
     assert "_clearEmptyComposerModelOverride" in fn
-    assert "newModelState={model:window._defaultModel,model_provider:window._activeProvider||null};" in fn
+    assert "newModelState={model:window._defaultModel,model_provider:null};" in fn
     assert fn.index("explicitModelOverride") < fn.index("hasLoadedSession&&window._defaultModel") < fn.index("_modelStateForSelect"), (
         "newSession() must prefer the empty-composer override first, then the configured default for loaded-session flows, then legacy picker state"
     )

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -163,7 +163,8 @@ def test_save_settings_syncs_default_model_provider_with_saved_model():
 
     assert "_captureModelDropdownSelection($('settingsModel'))" in save_block
     assert "JSON.stringify({model,provider:modelState.model_provider||null})" in save_block
-    assert "body.default_model_provider=(modelState&&modelState.model===model)?(modelState.model_provider||null):null;" in save_block
+    assert "const defaultModelSaved=await api('/api/default-model',{method:'POST',body:JSON.stringify({model,provider:modelState.model_provider||null})});" in save_block
+    assert "if(Object.prototype.hasOwnProperty.call(defaultModelSaved,'provider')) body.default_model_provider=defaultModelSaved.provider||null;" in save_block
     assert "const modelChanged=(model||'')!==(_settingsHermesDefaultModelOnOpen||'')||((modelState.model_provider||null)!==(_settingsHermesDefaultModelProviderOnOpen||null));" in save_block
     assert "if(Object.prototype.hasOwnProperty.call(body,'default_model_provider')) window._activeProvider=body.default_model_provider||null;" in apply_saved_block
     assert "_settingsHermesDefaultModelProviderOnOpen=(models&&models.active_provider)||null;" in panels_js


### PR DESCRIPTION
## Thinking Path

- The bug is not that Hermes lacks a default-model concept, because boot already prefers the configured default over stale browser state.
- The leak spreads across both startup and settings persistence, because `newSession()` can read a loaded session's picker state while the settings save path can drift the saved provider away from the model that New Chat should use next.
- The fix needs explicit pre-session intent tracking, aligned default-model provider persistence, and route-side normalization so the main model never stores the auxiliary-only `"auto"` sentinel.

## What Changed

- `static/boot.js`: remember explicit empty-composer model overrides separately from generic persisted picker state.
- `static/sessions.js`: make `newSession()` choose between explicit empty-composer overrides, configured defaults, and legacy no-default fallback paths in the right order, while keeping the existing provider-resolution guards intact.
- `static/panels.js`, `api/routes.py`, and `api/config.py`: keep default-model provider changes in sync across the Settings UI, the persistence routes, and the saved config, including dropping the auxiliary-only `"auto"` sentinel before it reaches main-model persistence.
- `tests/test_new_chat_default_model_frontend.py`, `tests/test_issue4728_new_chat_default_model.py`, `tests/test_auxiliary_models_settings.py`, and `tests/test_issue2518_active_provider_fallback.py`: cover the loaded-session regression, preserved empty-composer override path, route-level provider normalization, and fallback-provider guard rails.

## Why It Matters

New conversations finally follow the documented "use the configured default" contract instead of inheriting the last session's model by accident. Provider-only default-model edits now persist cleanly end to end, and the main model no longer saves the auxiliary `"auto"` sentinel, so New Chat and the saved settings stay aligned.

## Verification

```text
pytest tests/test_auxiliary_models_settings.py tests/test_issue4728_new_chat_default_model.py tests/test_new_chat_default_model_frontend.py tests/test_issue2518_active_provider_fallback.py -v --timeout=60
```

- Manual: switch an existing conversation to a different model, click New Chat, and confirm the new conversation returns to the configured default; then verify that an explicit picker change made before any session exists still wins.

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #4728.
Preserves the maintainer-confirmed empty-composer override constraint from https://github.com/nesquena/hermes-webui/issues/4728#issuecomment-4780824013.

## Model Used

GPT 5.5 via Codex CLI
