### PR TITLE
Release WP (v0.51.635): drop noisy parse-failed note on JSON/YAML fragments (#4858, #484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.635] — 2026-06-24 — Release WP (no more "parse failed" note under JSON/YAML fragments)
+
+### Fixed
+
+- **JSON/YAML code blocks that aren't valid top-level documents no longer show a bare "parse failed" note.** The chat renderer's Tree-view affordance stamped an unstyled `parse failed` line below any fenced block it couldn't `JSON.parse` — but assistants routinely emit fragments (a bare `key: value` line, `…` snippets, trailing commas) that legitimately don't parse, so the note was pure noise under an otherwise-clean code box. Those blocks now fall through silently to the normal syntax-highlighted raw view; the per-block Raw/Tree toggle and the configurable default-view behavior are unchanged. Thanks @metaember. (#4858, #484)
+
 ## [v0.51.634] — 2026-06-24 — Release WO (faster profile list — skill stats are cached with an mtime probe)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -13636,15 +13636,12 @@ function initTreeViews(container){
     // Mark as initialised only after we've committed to a render decision
     wrap.setAttribute('data-tree-init','1');
     if(!parsed || typeof parsed!=='object'){
-      if(parseFailed){
-        const hint=wrap.querySelector('.tree-raw-view');
-        if(hint&&!hint.querySelector('.tree-parse-note')){
-          const note=document.createElement('div');
-          note.className='tree-parse-note';
-          note.textContent=t('parse_failed_note')||'parse failed';
-          hint.parentNode.insertBefore(note,hint.nextSibling);
-        }
-      }
+      // No tree view for non-object values or unparseable content. LLMs often
+      // emit JSON fragments (a bare "key": "val" line, snippets with ..., etc.)
+      // that legitimately fail JSON.parse; surfacing a "parse failed" note for
+      // those was pure noise. The block still renders as syntax-highlighted raw,
+      // so just fall through silently. (parseFailed is retained for clarity.)
+      void parseFailed;
       return; // leave as raw view
     }
     const lineCount=rawText.split('\n').length;


### PR DESCRIPTION
## Release WP (v0.51.635) — no "parse failed" note under JSON/YAML fragments

Round-1 fix-class ship (clean +6/-9 pure removal). Ships **#4858** (@metaember) — #484.

### What it fixes
initTreeViews() stamped an unstyled `parse failed` note below any fenced JSON/YAML block it couldn't `JSON.parse`. Assistants routinely emit fragments (bare `key: value`, `…` snippets, trailing commas) that legitimately don't parse, so the note was bare white noise under a clean code box. Those blocks now fall through silently to the syntax-highlighted raw view.

### Gate (clean)
- Codex: **SAFE TO SHIP** (valid-JSON Tree rendering unchanged, nothing else references the removed `.tree-parse-note`, Raw/Tree toggle + #484 default-view unchanged, retained `parse_failed_note` i18n key keeps locale-parity green)
- Full suite: **10461 passed**, 0 failures
- static/ui.js only

Credit @metaember.
