### PR TITLE
fix(#4856): suppress Chromium scroll-anchor re-selection during mobile DOM rebuild

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -3892,8 +3892,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _renderPending=false;
       // Guard: a pending setTimeout+rAF can outlive stream finalization.
       if(_streamFinalized) return;
-      // Mobile scroll-jank guard: enable overflow-anchor before DOM writes so
-      // the browser preserves scroll position during streaming content growth.
+      // Mobile scroll-jank guard: temporarily disable overflow-anchor before DOM
+      // writes to suppress Chromium scroll re-anchoring during streaming growth.
       if(typeof window._fixMobileScrollJank==='function') window._fixMobileScrollJank();
       _lastRenderMs=performance.now();
       const parsed=_cachedParsed&&_cachedParsedText===assistantText&&_cachedParsedReasoning===liveReasoningText ? _cachedParsed : _parseStreamState();

--- a/static/ui.js
+++ b/static/ui.js
@@ -11029,22 +11029,19 @@ function _restoreMessageScrollSnapshot(snapshot){
   }
 }
 /**
- * Mobile scroll-jank guard: temporarily re-enable overflow-anchor so the
- * browser preserves scroll position across the innerHTML='' + DOM rebuild gap.
- * Safari/Chrome on iOS/Android can paint a frame with scrollTop=0 between
- * innerHTML='' and snapshot restore, scroll-janking the user to the top.
- * Called from renderMessages() before the DOM wipe — not from streaming ticks,
- * since CSS already gives overflow-anchor:auto on mobile via media query.
+ * Mobile scroll-jank guard: temporarily disable overflow-anchor so
+ * Chromium cannot re-anchor to the topmost row during the innerHTML=''
+ * wipe-and-rebuild gap. The rAF callback restores CSS default afterward.
  */
 window._fixMobileScrollJank=function _fixMobileScrollJank(){
   const el=document.getElementById('messages');
   if(!el) return;
   // Desktop with a mouse: keep overflow-anchor:none (explicitly set by CSS).
-  // Mobile touch devices only: temporarily enable it.
+  // Mobile touch devices only: temporarily suppress anchor re-selection.
   if(window.matchMedia('(hover:hover) and (pointer:fine)').matches) return;
-  el.style.overflowAnchor='auto';
+  el.style.overflowAnchor='none';
   requestAnimationFrame(()=>{
-    if(el.style.overflowAnchor==='auto') el.style.overflowAnchor='';
+    if(el.style.overflowAnchor==='none') el.style.overflowAnchor='';
   });
 };
 
@@ -11282,10 +11279,8 @@ function renderMessages(options){
       _recycleStash.set(Number(key), child);
     }
   }
-  // Mobile scroll-jank fix: temporarily re-enable overflow-anchor so browser
-  // preserves scroll position across the DOM wipe-and-rebuild gap.
-  // Safari/Chrome on iOS/Android can paint a frame with scrollTop=0 between
-  // innerHTML='' and snapshot restore, scroll-janking the user to the top.
+  // Mobile scroll-jank fix: temporarily disable overflow-anchor so Chromium
+  // cannot re-anchor to the topmost row during the DOM wipe-and-rebuild gap.
   if(window._fixMobileScrollJank) window._fixMobileScrollJank();
   inner.innerHTML='';
   const compressionNode=compressionState?_compressionCardsNode(compressionState):null;

--- a/tests/test_issue4856_android_scroll_regression.py
+++ b/tests/test_issue4856_android_scroll_regression.py
@@ -1,0 +1,98 @@
+"""Regression tests for #4856: Android scroll-to-top on every interaction."""
+
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+
+_FUNC_MARKER = "window._fixMobileScrollJank=function _fixMobileScrollJank(){"
+_RAF_MARKER = "requestAnimationFrame(()=>{"
+
+
+def _extract_fix_mobile_scroll_jank(src: str) -> str:
+    idx = src.find(_FUNC_MARKER)
+    assert idx != -1, "_fixMobileScrollJank not found in ui.js"
+    depth = 0
+    for i, ch in enumerate(src[idx:], idx):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[idx : i + 1]
+    raise AssertionError("Could not extract _fixMobileScrollJank")
+
+
+def _extract_raf_body(fn_src: str) -> str:
+    idx = fn_src.find(_RAF_MARKER)
+    assert idx != -1, "requestAnimationFrame callback not found in function"
+    depth = 0
+    for i, ch in enumerate(fn_src[idx:], idx):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return fn_src[idx : i + 1]
+    raise AssertionError("Could not extract rAF body")
+
+
+def test_fix_sets_none_not_auto():
+    # Base-fails/head-passes: function must set 'none' to suppress Chromium
+    # scroll-anchor re-selection; 'auto' is already the CSS default so setting
+    # it is a no-op and leaves the anchor engine active during the DOM wipe.
+    fn = _extract_fix_mobile_scroll_jank(UI_JS)
+    assert "overflowAnchor='none'" in fn, (
+        "_fixMobileScrollJank() must set overflowAnchor='none' to suppress "
+        "Chromium scroll-anchor re-selection during the DOM wipe (#4856)."
+    )
+    assert "overflowAnchor='auto'" not in fn, (
+        "_fixMobileScrollJank() must not set overflowAnchor='auto'; that is "
+        "already the CSS resting value on mobile and is a no-op."
+    )
+
+
+def test_raf_cleanup_checks_none():
+    # The rAF guard must check for 'none' so it only clears the inline style
+    # it set; checking 'auto' was always false and left the inline style on.
+    fn = _extract_fix_mobile_scroll_jank(UI_JS)
+    raf = _extract_raf_body(fn)
+    assert "overflowAnchor==='none'" in raf, (
+        "The rAF cleanup in _fixMobileScrollJank() must check for 'none' so it "
+        "clears the inline style after the synchronous scrollTop write lands."
+    )
+    assert "overflowAnchor==='auto'" not in raf, (
+        "The rAF cleanup must not check for 'auto'; that check was always false."
+    )
+
+
+def test_rebuild_path_calls_fix_before_wipe():
+    # renderMessages() must call _fixMobileScrollJank() before innerHTML='' so
+    # anchor suppression is active during the full wipe-and-rebuild window.
+    fix_idx = UI_JS.find("window._fixMobileScrollJank()")
+    assert fix_idx != -1, (
+        "renderMessages() must call window._fixMobileScrollJank() before innerHTML=''."
+    )
+    wipe_idx = UI_JS.find("innerHTML=''", fix_idx)
+    assert wipe_idx != -1, (
+        "innerHTML='' not found after _fixMobileScrollJank() call site."
+    )
+    assert fix_idx < wipe_idx, (
+        "_fixMobileScrollJank() must be called before innerHTML='' in renderMessages()."
+    )
+
+
+def test_streaming_tick_calls_fix_before_dom_writes():
+    # The streaming render tick in messages.js must call _fixMobileScrollJank()
+    # before _lastRenderMs=performance.now() so anchor suppression covers every
+    # incremental DOM update during streaming.
+    guard_idx = MESSAGES_JS.find("window._fixMobileScrollJank")
+    assert guard_idx != -1, (
+        "The streaming tick must call window._fixMobileScrollJank() before DOM writes."
+    )
+    render_idx = MESSAGES_JS.find("_lastRenderMs=performance.now()")
+    assert render_idx != -1, "streaming render timestamp not found in messages.js"
+    assert guard_idx < render_idx, (
+        "The mobile scroll-jank guard must run before streaming DOM work begins."
+    )


### PR DESCRIPTION
## Thinking Path

- Android Chromium was jumping the transcript to scrollTop=0 on every interaction since v0.51.576 — opening a session, sending a message, receiving a response. Desktop was unaffected.
- Two follow-up fixes (PR #4818 for `overflow-anchor`, PR #4702 for iOS toolbar collapse) shipped but neither resolved Android. The reporter confirmed the problem on v0.51.625.
- Reading the code, `_fixMobileScrollJank()` sets `overflow-anchor:auto` before the `innerHTML=''` DOM wipe. But `auto` is already the CSS resting value on mobile, so the write is a no-op. Chrome's aggressive scroll-anchor re-selection stays active, and when the anchor node disappears in the wipe, Chrome picks the topmost surviving row.
- The fix sets `overflow-anchor:none` instead, suppressing anchor re-selection during the rebuild window. The `requestAnimationFrame` callback then clears the inline style, restoring the CSS default after the synchronous scrollTop write has landed.

## What Changed

- `static/ui.js`: `_fixMobileScrollJank()` now sets `overflowAnchor='none'` (not `'auto'`) before mobile DOM rebuilds, and the rAF cleanup guard checks for `'none'` to match.
- `tests/test_issue4856_android_scroll_regression.py` (new): four regression tests covering the helper value, rAF guard match, and call ordering at both rebuild paths (renderMessages and streaming ticks).

## Why It Matters

Android users on Edge and Chrome have seen the transcript snap to the top on every message since v0.51.576. The guard was written with the right intent but the wrong value: `'auto'` is the computed default, so Chrome never saw any change and kept re-anchoring to row 0 after every DOM wipe.

## Verification

```
pytest tests/test_issue4856_android_scroll_regression.py -v --timeout=60
pytest tests/test_issue1360_streaming_scroll_hardening.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #4856.

## Model Used

Claude Opus 4.6 via Claude Code CLI
