### PR TITLE
fix(#4875): widen continuation-prompt filter to cover output-length and tool-call variants

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1825,8 +1825,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const normalized=String(text||'').replace(/\s+/g,' ').trim();
     if(!normalized) return false;
     const systemRecovery=/^\[System:/i.test(normalized)
-      && /previous response was cut off by a network error/i.test(normalized)
-      && /continue exactly where you left off/i.test(normalized);
+      && (/continue exactly where you left off/i.test(normalized)
+        || /do not retry the same tool call/i.test(normalized));
     const backendRecovery=/^the live worker stopped before this run finished\.?$/i.test(normalized);
     return !!(systemRecovery || backendRecovery);
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -7981,8 +7981,8 @@ function _isRecoveryControlMessageText(text){
   const normalized=String(text||'').replace(/\s+/g,' ').trim();
   if(!normalized) return false;
   const systemRecovery=/^\[System:/i.test(normalized)
-    && /previous response was cut off by a network error/i.test(normalized)
-    && /continue exactly where you left off/i.test(normalized);
+    && (/continue exactly where you left off/i.test(normalized)
+      || /do not retry the same tool call/i.test(normalized));
   const backendRecovery=/^the live worker stopped before this run finished\.?$/i.test(normalized);
   return !!(systemRecovery || backendRecovery);
 }

--- a/tests/test_issue4875_recovery_prompt_filter.py
+++ b/tests/test_issue4875_recovery_prompt_filter.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+import json
+import shutil
+import subprocess
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not available")
+
+
+def _extract_function(src: str, name: str) -> str:
+    start = src.index(f"function {name}(")
+    brace = src.index("{", start)
+    depth = 0
+    for i in range(brace, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start:i + 1]
+    raise AssertionError(f"{name} body not closed")
+
+
+def _eval_filter(src: str, name: str, cases: list[str]) -> list[bool]:
+    script = (
+        _extract_function(src, name)
+        + "\nconst cases = JSON.parse(process.argv[1]);\n"
+        + f"process.stdout.write(JSON.stringify(cases.map({name})));\n"
+    )
+    result = subprocess.run(
+        [NODE, "-e", script, json.dumps(cases)],
+        check=True, capture_output=True, text=True, timeout=15,
+    )
+    return json.loads(result.stdout)
+
+
+RECOVERY_VARIANTS = [
+    "[System: Your previous response was cut off by a network error. Continue exactly where you left off.]",
+    "[System: Your previous response was truncated by the output length limit. Continue exactly where you left off.]",
+    "[System: Your previous tool call (shell_command) was too large. Do not retry the same tool call.]",
+]
+
+FALSE_POSITIVES = [
+    "",
+    "Continue exactly where you left off.",
+    "Do not retry the same tool call.",
+    "[System: Some other note.]",
+    "[System: previous response was cut off by a network error.]",
+    "User said: [System: continue exactly where you left off.]",
+    "**Response interrupted:** the model stopped early",
+]
+
+_PARAMS = [
+    pytest.param(UI_JS, "_isRecoveryControlMessageText", id="ui_js"),
+    pytest.param(MESSAGES_JS, "_streamRecoveryControlMessageText", id="messages_js"),
+]
+
+
+@pytest.mark.parametrize(("src", "name"), _PARAMS)
+def test_all_continuation_variants_filtered(src, name):
+    assert _eval_filter(src, name, RECOVERY_VARIANTS) == [True, True, True]
+
+
+@pytest.mark.parametrize(("src", "name"), _PARAMS)
+def test_false_positives_not_filtered(src, name):
+    assert _eval_filter(src, name, FALSE_POSITIVES) == [False] * len(FALSE_POSITIVES)
+
+
+@pytest.mark.parametrize(("src", "name"), _PARAMS)
+def test_backend_recovery_string_filtered(src, name):
+    assert _eval_filter(src, name, ["The live worker stopped before this run finished."]) == [True]

--- a/tests/test_live_stream_ux.py
+++ b/tests/test_live_stream_ux.py
@@ -13,8 +13,8 @@ def test_done_and_restore_filters_recovery_messages_from_frontend_state():
     assert "_filterRecoveryControlMessages(S.messages || [])" in MESSAGES_JS
     assert "if(!m||m.role==='tool') return false;" in MESSAGES_JS
     assert "if(m.recovery_control===true) return true;" in MESSAGES_JS
-    assert "previous response was cut off by a network error" in MESSAGES_JS
     assert "continue exactly where you left off" in MESSAGES_JS
+    assert "do not retry the same tool call" in MESSAGES_JS
 
 
 def test_apererror_recovers_on_recovery_control_event():


### PR DESCRIPTION
## Thinking Path

- The agent core emits three continuation-prompt variants when a response is truncated (network error, output-length cap, tool-call-too-large). WebUI's filter only catches the network-error variant because it requires the literal phrase "cut off by a network error".
- Both `_isRecoveryControlMessageText` (ui.js) and `_streamRecoveryControlMessageText` (messages.js) have the same three-part AND: `[System:` prefix AND the network-error phrase AND `"continue exactly where you left off"`. Variants 2 and 3 don't contain the network-error phrase, so they fall through as visible transcript bubbles.
- The stable discriminator across all three variants is the instruction phrase, not the diagnosis phrase. Variants 1+2 always end with "continue exactly where you left off"; variant 3 uses "do not retry the same tool call". Dropping the narrow middle clause and OR-ing the two instruction phrases covers all three while keeping the `[System:` anchor against false positives.

## What Changed

- `static/ui.js`: replaced the three-part AND in `_isRecoveryControlMessageText()` with a two-part check: `[System:` prefix AND either instruction phrase
- `static/messages.js`: same replacement in `_streamRecoveryControlMessageText()`
- `tests/test_issue4875_recovery_prompt_filter.py` (new): Node-execution regression tests verifying all three variants are filtered and false positives are not, for both filter functions

## Why It Matters

When a model hits its output-length cap or produces a too-large tool call, the auto-continue system prompts ("Your previous response was truncated by the output length limit…") were appearing as right-aligned user bubbles in the transcript. Users saw internal control prompts as part of their conversation. This fix closes the gap for the two missed variants without affecting the primary `recovery_control===true` marker path used by all current sessions.

## Verification

```
pytest tests/test_issue4875_recovery_prompt_filter.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #4875.

## Model Used

Claude Sonnet 4.6 via Claude Code CLI

