### PR TITLE
Release WR (v0.51.637): widen continuation-prompt filter to all 3 variants (#4880, closes #4875)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.637] — 2026-06-25 — Release WR (all continuation prompts stay out of the transcript)
+
+### Fixed
+
+- **Internal "continue where you left off" prompts no longer leak into the visible transcript when a response is truncated by the output-length cap or a too-large tool call.** When the agent's response is cut short it emits a `[System: …]` continuation prompt, which the WebUI hides from the chat. The filter only matched the network-error variant (it required the literal "cut off by a network error" phrase), so the output-length and tool-call-too-large variants rendered as stray system bubbles. The filter now matches any `[System: …]` prompt carrying either "continue exactly where you left off" or "do not retry the same tool call", covering all three variants while still leaving genuine non-`[System:]` messages alone. Thanks @rodboev. (#4880, closes #4875)
+
 ## [v0.51.636] — 2026-06-25 — Release WQ (Android Chromium no longer jumps the transcript to the top)
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -1825,8 +1825,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const normalized=String(text||'').replace(/\s+/g,' ').trim();
     if(!normalized) return false;
     const systemRecovery=/^\[System:/i.test(normalized)
-      && /previous response was cut off by a network error/i.test(normalized)
-      && /continue exactly where you left off/i.test(normalized);
+      && (/continue exactly where you left off/i.test(normalized)
+        || /do not retry the same tool call/i.test(normalized));
     const backendRecovery=/^the live worker stopped before this run finished\.?$/i.test(normalized);
     return !!(systemRecovery || backendRecovery);
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -7981,8 +7981,8 @@ function _isRecoveryControlMessageText(text){
   const normalized=String(text||'').replace(/\s+/g,' ').trim();
   if(!normalized) return false;
   const systemRecovery=/^\[System:/i.test(normalized)
-    && /previous response was cut off by a network error/i.test(normalized)
-    && /continue exactly where you left off/i.test(normalized);
+    && (/continue exactly where you left off/i.test(normalized)
+      || /do not retry the same tool call/i.test(normalized));
   const backendRecovery=/^the live worker stopped before this run finished\.?$/i.test(normalized);
   return !!(systemRecovery || backendRecovery);
 }

--- a/tests/test_issue4875_recovery_prompt_filter.py
+++ b/tests/test_issue4875_recovery_prompt_filter.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+import json
+import shutil
+import subprocess
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not available")
+
+
+def _extract_function(src: str, name: str) -> str:
+    start = src.index(f"function {name}(")
+    brace = src.index("{", start)
+    depth = 0
+    for i in range(brace, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start:i + 1]
+    raise AssertionError(f"{name} body not closed")
+
+
+def _eval_filter(src: str, name: str, cases: list[str]) -> list[bool]:
+    script = (
+        _extract_function(src, name)
+        + "\nconst cases = JSON.parse(process.argv[1]);\n"
+        + f"process.stdout.write(JSON.stringify(cases.map({name})));\n"
+    )
+    result = subprocess.run(
+        [NODE, "-e", script, json.dumps(cases)],
+        check=True, capture_output=True, text=True, timeout=15,
+    )
+    return json.loads(result.stdout)
+
+
+RECOVERY_VARIANTS = [
+    "[System: Your previous response was cut off by a network error. Continue exactly where you left off.]",
+    "[System: Your previous response was truncated by the output length limit. Continue exactly where you left off.]",
+    "[System: Your previous tool call (shell_command) was too large. Do not retry the same tool call.]",
+]
+
+FALSE_POSITIVES = [
+    "",
+    "Continue exactly where you left off.",
+    "Do not retry the same tool call.",
+    "[System: Some other note.]",
+    "[System: previous response was cut off by a network error.]",
+    "User said: [System: continue exactly where you left off.]",
+    "**Response interrupted:** the model stopped early",
+]
+
+_PARAMS = [
+    pytest.param(UI_JS, "_isRecoveryControlMessageText", id="ui_js"),
+    pytest.param(MESSAGES_JS, "_streamRecoveryControlMessageText", id="messages_js"),
+]
+
+
+@pytest.mark.parametrize(("src", "name"), _PARAMS)
+def test_all_continuation_variants_filtered(src, name):
+    assert _eval_filter(src, name, RECOVERY_VARIANTS) == [True, True, True]
+
+
+@pytest.mark.parametrize(("src", "name"), _PARAMS)
+def test_false_positives_not_filtered(src, name):
+    assert _eval_filter(src, name, FALSE_POSITIVES) == [False] * len(FALSE_POSITIVES)
+
+
+@pytest.mark.parametrize(("src", "name"), _PARAMS)
+def test_backend_recovery_string_filtered(src, name):
+    assert _eval_filter(src, name, ["The live worker stopped before this run finished."]) == [True]

--- a/tests/test_live_stream_ux.py
+++ b/tests/test_live_stream_ux.py
@@ -13,8 +13,8 @@ def test_done_and_restore_filters_recovery_messages_from_frontend_state():
     assert "_filterRecoveryControlMessages(S.messages || [])" in MESSAGES_JS
     assert "if(!m||m.role==='tool') return false;" in MESSAGES_JS
     assert "if(m.recovery_control===true) return true;" in MESSAGES_JS
-    assert "previous response was cut off by a network error" in MESSAGES_JS
     assert "continue exactly where you left off" in MESSAGES_JS
+    assert "do not retry the same tool call" in MESSAGES_JS
 
 
 def test_apererror_recovers_on_recovery_control_event():


### PR DESCRIPTION
## Release WR (v0.51.637) — all continuation prompts stay out of the transcript

Round fix-class ship. Ships **#4880** (@rodboev) — closes #4875.

### What it fixes
The agent emits a `[System: …]` continuation prompt when a response is truncated (network error / output-length cap / tool-call-too-large). The WebUI filter only matched the network-error variant (required the literal "cut off by a network error" phrase), so variants 2 and 3 leaked as visible system bubbles. Both `_isRecoveryControlMessageText` (ui.js) and `_streamRecoveryControlMessageText` (messages.js) now match any `[System:`-prefixed prompt carrying "continue exactly where you left off" OR "do not retry the same tool call".

### Gate (clean)
- Codex: **SAFE TO SHIP** — `^[System:` prefix gate still anchors the match (bare phrases / mid-message variants still render), all 3 variants suppressed, both filters updated identically, backendRecovery branch unchanged
- Full suite: **10471 passed**, 0 failures
- +82/-5, 4f (ui.js + messages.js + 2 tests incl false-positive coverage)

Credit @rodboev.
