### PR TITLE
Release WS (v0.51.638): bound continuation-fallback sidecar reads (#4882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.638] — 2026-06-25 — Release WS (faster session list — bounded continuation-fallback sidecar reads)
+
+### Fixed
+
+- **Listing sessions no longer reads entire session sidecar files when probing for compression continuations.** While `/api/sessions` builds sidebar metadata, a stale-pending repair path scans sibling sidecars for a continuation marker. That scan was documented as a shallow metadata-prefix check but `read_text()[:4096]` still loaded the whole file into memory before slicing, so it scaled with full transcript size on large sessions. It now reads a bounded head (up to 16 KB — enough to cover the first 4096 characters even with multi-byte content) and slices to the same 4096-character prefix, preserving the exact detection semantics while avoiding full-file I/O. Thanks @starship-s. (#4882)
+
 ## [v0.51.637] — 2026-06-25 — Release WR (all continuation prompts stay out of the transcript)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -540,6 +540,16 @@ def _find_top_level_json_key(text, key):
     return None
 
 
+def _read_file_head(path: Path, max_prefix_bytes: int = 4096) -> str:
+    """Read at most ``max_prefix_bytes`` bytes from ``path`` and decode UTF-8."""
+    if not isinstance(path, Path):
+        path = Path(path)
+    if max_prefix_bytes <= 0:
+        return ''
+    with path.open('rb') as fp:
+        return fp.read(max_prefix_bytes).decode('utf-8', errors='ignore')
+
+
 def _read_metadata_json_prefix(path, max_prefix_bytes=65536):
     """Read only the metadata portion before the top-level messages array."""
     buf = ''
@@ -2129,9 +2139,7 @@ def _has_compression_continuation(session) -> bool:
             if path.name.startswith('_') or path.stem == sid:
                 continue
             try:
-                head = path.read_text(encoding='utf-8', errors='ignore')[:4096]
-            except TypeError:
-                head = path.read_text(encoding='utf-8')[:4096]
+                head = _read_file_head(path, max_prefix_bytes=4096)
             except OSError:
                 continue
             if needle in head:

--- a/api/models.py
+++ b/api/models.py
@@ -2139,7 +2139,13 @@ def _has_compression_continuation(session) -> bool:
             if path.name.startswith('_') or path.stem == sid:
                 continue
             try:
-                head = _read_file_head(path, max_prefix_bytes=4096)
+                # Preserve the old read_text()[:4096] CHARACTER-prefix semantics
+                # with bounded I/O: a UTF-8 char is at most 4 bytes, so 4096 chars
+                # fit in <=16384 bytes. Reading bytes then slicing to 4096 chars
+                # avoids a regression where a multi-byte (e.g. emoji) compression
+                # summary written before parent_session_id pushes the needle past a
+                # 4096-BYTE cutoff even though it was within the old 4096-CHAR one.
+                head = _read_file_head(path, max_prefix_bytes=16384)[:4096]
             except OSError:
                 continue
             if needle in head:

--- a/tests/test_session_switch_performance.py
+++ b/tests/test_session_switch_performance.py
@@ -31,6 +31,7 @@ def test_compression_continuation_fallback_reads_only_file_head(monkeypatch, tmp
             return self._inner.read(size)
 
         def __enter__(self):
+            self._inner.__enter__()
             return self
 
         def __exit__(self, exc_type, exc, tb):

--- a/tests/test_session_switch_performance.py
+++ b/tests/test_session_switch_performance.py
@@ -1,0 +1,80 @@
+import api.models as models
+
+
+def test_compression_continuation_fallback_reads_only_file_head(monkeypatch, tmp_path):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = tmp_path / "_index.json"
+    index_file.write_text("[]", encoding="utf-8")
+
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    models.SESSIONS.clear()
+
+    parent_sid = "parent"
+    candidate = session_dir / "child.json"
+    candidate.write_text("x" * 8192 + f'"parent_session_id": "{parent_sid}"', encoding="utf-8")
+
+    opened_for_read = []
+    read_text_calls = []
+
+    original_path_open = models.Path.open
+    original_path_read_text = models.Path.read_text
+
+    class _TrackingHandle:
+        def __init__(self, path, inner):
+            self._path = str(path)
+            self._inner = inner
+
+        def read(self, size=-1):
+            opened_for_read.append((self._path, size))
+            return self._inner.read(size)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return self._inner.__exit__(exc_type, exc, tb)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    def tracking_open(path, *args, **kwargs):
+        return _TrackingHandle(path, original_path_open(path, *args, **kwargs))
+
+    def tracking_read_text(self, *args, **kwargs):
+        read_text_calls.append(str(self))
+        return original_path_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(models.Path, "open", tracking_open)
+    monkeypatch.setattr(models.Path, "read_text", tracking_read_text)
+
+    session = models.Session(session_id=parent_sid)
+
+    assert models._has_compression_continuation(session) is False
+
+    assert str(index_file) in read_text_calls
+    assert all(path != str(candidate) for path in read_text_calls)
+
+    candidate_reads = [size for path, size in opened_for_read if path == str(candidate)]
+    assert candidate_reads, "fallback should read the candidate sidecar"
+    assert all(size != -1 and size <= 4096 for size in candidate_reads)
+
+
+def test_compression_continuation_prefix_match_stays_true(monkeypatch, tmp_path):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = tmp_path / "_index.json"
+    index_file.write_text("[]", encoding="utf-8")
+
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    models.SESSIONS.clear()
+
+    parent_sid = "parent"
+    candidate = session_dir / "child.json"
+    candidate.write_text('{"session_id":"child", "parent_session_id": "parent",', encoding="utf-8")
+
+    session = models.Session(session_id=parent_sid)
+
+    assert models._has_compression_continuation(session) is True

--- a/tests/test_session_switch_performance.py
+++ b/tests/test_session_switch_performance.py
@@ -59,7 +59,9 @@ def test_compression_continuation_fallback_reads_only_file_head(monkeypatch, tmp
 
     candidate_reads = [size for path, size in opened_for_read if path == str(candidate)]
     assert candidate_reads, "fallback should read the candidate sidecar"
-    assert all(size != -1 and size <= 4096 for size in candidate_reads)
+    # Bounded read: at most 16384 bytes (== 4096 UTF-8 chars worst case), never
+    # an unbounded -1 read of the full sidecar.
+    assert all(size != -1 and size <= 16384 for size in candidate_reads)
 
 
 def test_compression_continuation_prefix_match_stays_true(monkeypatch, tmp_path):
@@ -78,4 +80,40 @@ def test_compression_continuation_prefix_match_stays_true(monkeypatch, tmp_path)
 
     session = models.Session(session_id=parent_sid)
 
+    assert models._has_compression_continuation(session) is True
+
+
+def test_compression_continuation_multibyte_summary_before_marker(monkeypatch, tmp_path):
+    """A multi-byte (emoji) compression summary written BEFORE parent_session_id
+    can push the marker past a 4096-BYTE cutoff while still inside the old
+    4096-CHARACTER prefix. The bounded read must preserve the char-prefix
+    semantics (read 16384 bytes, slice 4096 chars) so the continuation is still
+    detected. Regression for the gate-found byte-vs-char truncation."""
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = tmp_path / "_index.json"
+    index_file.write_text("[]", encoding="utf-8")
+
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    models.SESSIONS.clear()
+
+    parent_sid = "parent"
+    candidate = session_dir / "child.json"
+    # 1200 emoji (4 bytes each in UTF-8) → marker at char offset ~1230 but byte
+    # offset ~4900: within the old 4096-char window, PAST a 4096-byte window.
+    emoji_summary = "😀" * 1200
+    candidate.write_text(
+        '{"session_id":"child", "compression_anchor_summary": "' + emoji_summary
+        + '", "parent_session_id": "parent",',
+        encoding="utf-8",
+    )
+
+    # sanity: the marker is past 4096 bytes but within 4096 chars
+    text = candidate.read_text(encoding="utf-8")
+    needle = '"parent_session_id": "parent"'
+    assert text.encode("utf-8").index(needle.encode()) > 4096, "test setup: needle must be past 4096 bytes"
+    assert text.index(needle) < 4096, "test setup: needle must be within 4096 chars"
+
+    session = models.Session(session_id=parent_sid)
     assert models._has_compression_continuation(session) is True


### PR DESCRIPTION
## Release WS (v0.51.638) — bounded continuation-fallback sidecar reads

Round perf ship. Ships **#4882** (@starship-s).

### What it fixes
The compression-continuation fallback (`_row_is_continuation` in api/models.py), run while `/api/sessions` builds sidebar metadata, scanned sibling sidecars with `read_text()[:4096]` — loading the ENTIRE file before slicing. On large session sidecars this scaled with full transcript size. Now a bounded `_read_file_head` reads at most 16 KB and slices to 4096 chars.

### Gate hardening (maintainer, gate finding)
Codex reproduced a SILENT regression in the contributor's first cut: a 4096-BYTE read could miss the marker the old 4096-CHAR read found — `Session.save()` writes `compression_anchor_summary` (`ensure_ascii=False`) before `parent_session_id`, so a multi-byte emoji summary puts the marker at char offset ~1230 but byte offset ~4900. Fix: read 16384 bytes (4096 chars worst-case for 4-byte UTF-8) then slice `[:4096]` chars — exact old char-prefix semantics, still bounded. Multibyte regression test added.

### Gate (clean)
- Codex: **SAFE TO SHIP** (multi-byte regression closed, bounded I/O preserved, read-only detection path — no data-loss risk)
- Full suite: **10474 passed**, 0 failures
- +92/-3, 2f (incl perf + multibyte regression tests)

Credit @starship-s (git commits authored under the hermes-agent identity; PR author is starship-s).
