### PR TITLE
perf(#4842): cache sidebar-projection sidecar reads + hoist per-row I/O on the cron path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`GET /api/sessions` no longer pins CPU to 100% and takes multiple seconds on profiles with many cron sessions.** The sidebar projection that turns agent state.db rows into sidebar entries did three pieces of redundant per-row file I/O — an uncached sidecar JSON read (open + 64KB prefix read + key scan), a `get_last_workspace()` resolve (up to two file reads + a directory probe), and a full `cron/jobs.json` read+parse for each untitled cron row — across both the visible pass and the higher-capped (up to 200 rows) cron-only second pass. On a cron-heavy install that was hundreds of file reads per build, and because the session-list cache is keyed on a state.db fingerprint that advances on every streamed message, the whole scan was re-paid on essentially every 5s poll during a live turn (the recurring "100% CPU / slow `/api/sessions`" from #4672 → #4808 → #4842). The sidecar metadata read is now memoized per file by its `(path, mtime_ns, size, ctime_ns)` stat signature so a warm build re-stats instead of re-reads (a rename/archive/edit still invalidates just that one entry), and the workspace resolve + jobs.json parse now happen once per build instead of once per row. Output is unchanged. (#4842)
+
 ## [v0.51.638] — 2026-06-25 — Release WS (faster session list — bounded continuation-fallback sidecar reads)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -41,6 +41,26 @@ _CLI_SESSIONS_CACHE_TTL_SECONDS = 5.0
 _CLI_SESSIONS_CACHE_LOCK = threading.Lock()
 _CLI_SESSIONS_CACHE = {}
 
+# Per-file cache for the UI-owned sidecar metadata (title + archived) that the
+# state.db sidebar projection overlays onto each CLI/cron row (#4842). The
+# projection calls _state_projection_sidecar_metadata() once per row in BOTH
+# the main visible pass AND the higher-capped (CRON_PROJECT_CHIP_LIMIT=200)
+# cron-only second pass, and each call was an uncached open() + 64KB prefix
+# read + a pure-Python JSON-key scan. On a cron-heavy profile that is up to
+# ~200 sidecar file reads per /api/sessions build — and because the enclosing
+# _CLI_SESSIONS_CACHE is keyed on a state.db content fingerprint that advances
+# on every streamed message row, that whole scan was re-paid on essentially
+# every 5s poll during a live turn (the "100% CPU / multi-second get_cli_sessions"
+# in #4842/#4808/#4672). This memoizes the parse result keyed by the sidecar's
+# (path, mtime_ns, size, ctime_ns) stat signature: a warm projection re-stats
+# each file (~1 stat) instead of re-reading+parsing it, while any genuine
+# rename/archive/edit bumps the signature and transparently invalidates just
+# that one entry. Bounded so a pathological session store can't grow it without
+# limit. Mirrors the Claude Code parse cache (#4718).
+_SIDECAR_METADATA_CACHE_LOCK = threading.Lock()
+_SIDECAR_METADATA_CACHE: "collections.OrderedDict[tuple, dict]" = collections.OrderedDict()
+_SIDECAR_METADATA_CACHE_MAX = 2000
+
 # ---------------------------------------------------------------------------
 # Stale temp-file cleanup
 # ---------------------------------------------------------------------------
@@ -3971,6 +3991,10 @@ def get_claude_code_session_messages(sid, projects_dir: Path | str | None = None
 def clear_cli_sessions_cache() -> None:
     with _CLI_SESSIONS_CACHE_LOCK:
         _CLI_SESSIONS_CACHE.clear()
+    # The sidecar-metadata projection cache is stat-keyed (self-invalidating on
+    # any file change), but clear it alongside the CLI cache so an explicit
+    # reset — a mutating sidebar action or test isolation — starts fully cold.
+    clear_sidecar_metadata_cache()
 
 
 def _copy_cli_sessions(sessions: list) -> list:
@@ -4176,20 +4200,61 @@ def _all_profiles_cli_contexts() -> tuple[list[tuple[Path, Path, str | None]], t
     return contexts, tuple(cache_entries)
 
 
+def clear_sidecar_metadata_cache() -> None:
+    """Drop all memoized sidebar-projection sidecar metadata (test/lifecycle hook)."""
+    with _SIDECAR_METADATA_CACHE_LOCK:
+        _SIDECAR_METADATA_CACHE.clear()
+
+
 def _state_projection_sidecar_metadata(sid: str) -> dict:
-    """Return UI-owned metadata for a state.db-projected sidebar row."""
-    metadata = {"title": None, "archived": False}
+    """Return UI-owned metadata (title + archived) for a state.db-projected row.
+
+    Memoized by the sidecar file's (path, mtime_ns, size, ctime_ns) stat
+    signature so the sidebar projection — which calls this once per row in both
+    the visible pass and the up-to-200-row cron pass — pays a single os.stat per
+    file on a warm build instead of an open() + 64KB read + JSON-key scan
+    (#4842). A rename/archive/edit bumps the signature and invalidates just that
+    entry, so a stale title/archived flag is impossible without re-reading.
+    Returns a COPY so callers can't mutate the cached dict.
+    """
+    default = {"title": None, "archived": False}
+    if not is_safe_session_id(sid):
+        return dict(default)
+    p = SESSION_DIR / f'{sid}.json'
+    try:
+        st = p.stat()
+        key = (str(p), st.st_mtime_ns, st.st_size, st.st_ctime_ns)
+    except OSError:
+        # No sidecar file (the common case for a pure state.db row) or it
+        # vanished mid-build — nothing to project, and nothing worth caching.
+        return dict(default)
+
+    with _SIDECAR_METADATA_CACHE_LOCK:
+        hit = _SIDECAR_METADATA_CACHE.get(key)
+        if hit is not None:
+            _SIDECAR_METADATA_CACHE.move_to_end(key)
+            return dict(hit)
+
+    metadata = dict(default)
     try:
         webui_meta = Session.load_metadata_only(sid)
     except Exception:
-        return metadata
-    if not webui_meta:
-        return metadata
-    title = getattr(webui_meta, 'title', None)
-    if title:
-        metadata["title"] = title
-    metadata["archived"] = bool(getattr(webui_meta, 'archived', False))
-    return metadata
+        webui_meta = None
+    if webui_meta:
+        title = getattr(webui_meta, 'title', None)
+        if title:
+            metadata["title"] = title
+        metadata["archived"] = bool(getattr(webui_meta, 'archived', False))
+
+    with _SIDECAR_METADATA_CACHE_LOCK:
+        # Re-check under lock in case a concurrent build populated it; either
+        # entry is equally valid for the same stat signature.
+        if key not in _SIDECAR_METADATA_CACHE:
+            _SIDECAR_METADATA_CACHE[key] = metadata
+            _SIDECAR_METADATA_CACHE.move_to_end(key)
+            while len(_SIDECAR_METADATA_CACHE) > _SIDECAR_METADATA_CACHE_MAX:
+                _SIDECAR_METADATA_CACHE.popitem(last=False)
+    return dict(metadata)
 
 
 def _load_cli_sessions_uncached(
@@ -4225,6 +4290,48 @@ def _load_cli_sessions_uncached(
             _cron_pid_cache[0] = ensure_cron_project()
         return _cron_pid_cache[0]
 
+    # Memoize the cron jobs.json job_id -> name map for this scan. The two row
+    # loops below each looked up a cron job's friendly name by re-reading and
+    # re-parsing hermes_home/cron/jobs.json PER untitled cron row — up to ~200
+    # full-file JSON parses on a cron-heavy profile (#4842). Parse it once,
+    # lazily, on the first untitled cron row we hit. {} when absent/unreadable.
+    _cron_job_names_cache: list = [None]  # list-as-cell; None = not yet resolved
+    def _cron_job_names():
+        if _cron_job_names_cache[0] is None:
+            names: dict[str, str] = {}
+            try:
+                _jobs_path = hermes_home / 'cron' / 'jobs.json'
+                if _jobs_path.exists():
+                    _jobs_data = json.loads(_jobs_path.read_text(encoding='utf-8'))
+                    for _j in _jobs_data.get('jobs', []):
+                        _jid = _j.get('id')
+                        _jname = _j.get('name')
+                        if _jid and _jname:
+                            names[str(_jid)] = _jname
+            except Exception:
+                pass  # degrade gracefully — fall back to the generic title
+            _cron_job_names_cache[0] = names
+        return _cron_job_names_cache[0]
+
+    def _cron_title_from_jobs(sid: str):
+        """Friendly cron job name for a cron_{job_id}_{ts} sid, or None."""
+        if not sid.startswith('cron_'):
+            return None
+        parts = sid.split('_')
+        if len(parts) < 3:
+            return None
+        return _cron_job_names().get(parts[1])
+
+    # get_last_workspace() reads up to two files + an is_dir()/remote probe and
+    # returns the SAME active workspace for every projected row, so calling it
+    # per row was redundant I/O on the cold sidebar build (#4842; mirrors the
+    # #4718 hoist on the Claude Code path). Resolve it once for this scan.
+    _cli_workspace_cache: list = [None]  # list-as-cell; None = not yet resolved
+    def _cli_workspace():
+        if _cli_workspace_cache[0] is None:
+            _cli_workspace_cache[0] = str(get_last_workspace())
+        return _cli_workspace_cache[0]
+
     profile_value = _cli_profile or 'default'
     for row in read_importable_agent_session_rows(
         db_path,
@@ -4241,23 +4348,10 @@ def _load_cli_sessions_uncached(
 
         _source = row['source'] or 'cli'
         _title = row['title']
-        if not _title and _source == 'cron' and sid.startswith('cron_'):
-            # Extract job_id from session ID (cron_{job_id}_{timestamp})
-            # and look up the human-friendly job name from jobs.json
-            parts = sid.split('_')
-            if len(parts) >= 3:
-                _job_id = parts[1]
-                try:
-                    _jobs_path = hermes_home / 'cron' / 'jobs.json'
-                    if _jobs_path.exists():
-                        import json as _json
-                        _jobs_data = _json.loads(_jobs_path.read_text())
-                        for _j in _jobs_data.get('jobs', []):
-                            if _j.get('id') == _job_id:
-                                _title = _j.get('name') or _title
-                                break
-                except Exception:
-                    pass  # degrade gracefully
+        if not _title and _source == 'cron':
+            # Look up the human-friendly cron job name (cron_{job_id}_{ts}) from
+            # the once-parsed jobs.json map instead of re-reading the file here.
+            _title = _cron_title_from_jobs(sid) or _title
         # If a WebUI JSON file exists for this session (e.g. previously
         # imported or renamed in the sidebar), prefer its UI-owned metadata over
         # the state.db projection. This keeps archived cron/tool/API runs hidden
@@ -4271,7 +4365,7 @@ def _load_cli_sessions_uncached(
         cli_sessions.append({
             'session_id': sid,
             'title': _display_title,
-            'workspace': str(get_last_workspace()),
+            'workspace': _cli_workspace(),
             'model': row['model'] or None,
             'message_count': row['message_count'] or row['actual_message_count'] or 0,
             'created_at': row['started_at'],
@@ -4332,21 +4426,9 @@ def _load_cli_sessions_uncached(
                     continue
                 raw_ts = row['last_activity'] or row['started_at']
                 _title = row['title']
-                if not _title and sid.startswith('cron_'):
-                    parts = sid.split('_')
-                    if len(parts) >= 3:
-                        _job_id = parts[1]
-                        try:
-                            _jobs_path = hermes_home / 'cron' / 'jobs.json'
-                            if _jobs_path.exists():
-                                import json as _json
-                                _jobs_data = _json.loads(_jobs_path.read_text())
-                                for _j in _jobs_data.get('jobs', []):
-                                    if _j.get('id') == _job_id:
-                                        _title = _j.get('name') or _title
-                                        break
-                        except Exception:
-                            pass
+                if not _title:
+                    # Friendly cron job name from the once-parsed jobs.json map.
+                    _title = _cron_title_from_jobs(sid) or _title
                 _sidecar_meta = _state_projection_sidecar_metadata(sid)
                 if _sidecar_meta.get('title'):
                     _title = _sidecar_meta['title']
@@ -4355,7 +4437,7 @@ def _load_cli_sessions_uncached(
                 cli_sessions.append({
                     'session_id': sid,
                     'title': _display_title,
-                    'workspace': str(get_last_workspace()),
+                    'workspace': _cli_workspace(),
                     'model': row['model'] or None,
                     'message_count': row['message_count'] or row['actual_message_count'] or 0,
                     'created_at': row['started_at'],

--- a/api/models.py
+++ b/api/models.py
@@ -4216,6 +4216,11 @@ def _state_projection_sidecar_metadata(sid: str) -> dict:
     (#4842). A rename/archive/edit bumps the signature and invalidates just that
     entry, so a stale title/archived flag is impossible without re-reading.
     Returns a COPY so callers can't mutate the cached dict.
+
+    NOTE: this stat-gates on ``SESSION_DIR / f'{sid}.json'`` because that file is
+    ``Session.load_metadata_only``'s sole source for title+archived. If that ever
+    stops being true (metadata moves to another store), this gate would short-
+    circuit before the real source — update both together.
     """
     default = {"title": None, "archived": False}
     if not is_safe_session_id(sid):

--- a/tests/test_issue4385_cron_archive_reappears.py
+++ b/tests/test_issue4385_cron_archive_reappears.py
@@ -109,16 +109,22 @@ def test_cron_state_projection_preserves_archived_sidecar(monkeypatch, tmp_path)
             (sid, "Cron Session", "test-model", 1, 20, "cron", "cron"),
         )
 
-    class ArchivedSidecar:
-        title = "Cron Session"
-        archived = True
-
-    monkeypatch.setattr(
-        models.Session,
-        "load_metadata_only",
-        staticmethod(lambda candidate: ArchivedSidecar() if candidate == sid else None),
+    # Write a real archived sidecar JSON under a patched SESSION_DIR so the
+    # projection's sidecar read exercises the production path (the #4842 perf
+    # fix stat-gates on SESSION_DIR/{sid}.json before consulting metadata, so a
+    # mock of load_metadata_only without a real file would never be reached —
+    # which mirrors production, where archived metadata only exists when the
+    # file does).
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    (session_dir / f"{sid}.json").write_text(
+        '{"session_id": "%s", "title": "Cron Session", "created_at": 1.0,'
+        ' "updated_at": 2.0, "archived": true, "messages": []}' % sid,
+        encoding="utf-8",
     )
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "ensure_cron_project", lambda: "cron-project")
+    models.clear_sidecar_metadata_cache()
 
     rows = models._load_cli_sessions_uncached(
         tmp_path,
@@ -195,15 +201,17 @@ def test_webhook_state_projection_preserves_archived_sidecar(monkeypatch, tmp_pa
             (sid,),
         )
 
-    class ArchivedWebhookSidecar:
-        title = "Webhook Session"
-        archived = True
-
-    monkeypatch.setattr(
-        models.Session,
-        "load_metadata_only",
-        staticmethod(lambda candidate: ArchivedWebhookSidecar() if candidate == sid else None),
+    # Real archived sidecar JSON under a patched SESSION_DIR (see the cron test
+    # above — the #4842 stat-gate requires the file to exist, matching prod).
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    (session_dir / f"{sid}.json").write_text(
+        '{"session_id": "%s", "title": "Webhook Session", "created_at": 1.0,'
+        ' "updated_at": 2.0, "archived": true, "messages": []}' % sid,
+        encoding="utf-8",
     )
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    models.clear_sidecar_metadata_cache()
 
     rows = models._load_cli_sessions_uncached(
         tmp_path,

--- a/tests/test_issue4842_cron_projection_perf.py
+++ b/tests/test_issue4842_cron_projection_perf.py
@@ -1,0 +1,285 @@
+"""Regression coverage for the cron sidebar-projection I/O blowup (#4842).
+
+`get_cli_sessions()` projects state.db rows into sidebar entries in two passes:
+a visible-window pass and a higher-capped (CRON_PROJECT_CHIP_LIMIT=200) cron-only
+second pass. For EACH projected row the old code did three pieces of redundant
+per-row I/O:
+
+  1. `_state_projection_sidecar_metadata(sid)` — an uncached open() + 64KB read +
+     JSON-key scan of the session's sidecar JSON.
+  2. `get_last_workspace()` — up to two file reads + an is_dir()/remote probe,
+     returning the SAME active workspace for every row.
+  3. A full read + parse of `cron/jobs.json` per untitled cron row.
+
+On a cron-heavy profile (the #4842 reporter had 200+ cron sessions) that was
+hundreds of file reads per `/api/sessions` build, and because the enclosing
+`_CLI_SESSIONS_CACHE` is keyed on a state.db content fingerprint that advances
+on every streamed message row, the whole scan was re-paid on essentially every
+5s poll during a live turn — pinning CPU to 100% and making `get_cli_sessions`
+take multiple seconds (#4842 / #4808 / #4672).
+
+These tests pin the fix: the expensive per-row work is now O(unique files), the
+sidecar parse is memoized across builds (so a streaming re-poll stays warm), and
+the jobs.json parse + workspace resolve happen once per build.
+"""
+
+import pathlib
+import sqlite3
+import time
+from unittest import mock
+
+import api.models as models
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _make_cron_state_db(path, *, cron_count=30):
+    """state.db with a batch of titled cron sessions."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            session_source TEXT,
+            title TEXT,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            parent_session_id TEXT,
+            ended_at REAL,
+            end_reason TEXT
+        );
+        CREATE INDEX idx_sessions_started ON sessions(started_at);
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        );
+        CREATE INDEX idx_messages_session ON messages(session_id, timestamp);
+        """
+    )
+    now = time.time()
+    for i in range(cron_count):
+        sid = f"cron_job{i:04d}_{int(now) + i}"
+        started = now + i
+        conn.execute(
+            "INSERT INTO sessions (id, source, session_source, title, model,"
+            " started_at, message_count, parent_session_id, ended_at, end_reason)"
+            " VALUES (?, 'cron', 'cron', NULL, 'deepseek/deepseek-chat', ?, 1,"
+            " NULL, NULL, NULL)",
+            (sid, started),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp)"
+            " VALUES (?, ?, 'user', 'cron task', ?)",
+            (f"cron_msg_{i:04d}", sid, started),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_sidecar_metadata_cached_across_rebuilds(tmp_path):
+    """The expensive sidecar read happens once per file, not once per build.
+
+    Simulates the streaming re-poll: build the projection twice (the inner CLI
+    cache is bypassed here by calling _load_cli_sessions_uncached directly, which
+    is exactly what happens when the state.db fingerprint busts the 5s cache on
+    every streamed token). The second build must NOT re-read sidecars.
+    """
+    models.clear_sidecar_metadata_cache()
+    db = tmp_path / "state.db"
+    _make_cron_state_db(db, cron_count=30)
+
+    # Give every cron session a real WebUI sidecar JSON so the projection's
+    # load_metadata_only() path actually opens a file per row.
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    sids = []
+    conn = sqlite3.connect(str(db))
+    for (sid,) in conn.execute("SELECT id FROM sessions"):
+        sids.append(sid)
+        (session_dir / f"{sid}.json").write_text(
+            '{"session_id": "%s", "title": "Renamed %s", "created_at": 1.0,'
+            ' "updated_at": 2.0, "archived": false, "messages": []}' % (sid, sid),
+            encoding="utf-8",
+        )
+    conn.close()
+
+    real_prefix = models._read_metadata_json_prefix
+    reads = {"n": 0}
+
+    def _counting_prefix(p, *a, **k):
+        reads["n"] += 1
+        return real_prefix(p, *a, **k)
+
+    with (
+        mock.patch("api.models.get_claude_code_sessions", return_value=[]),
+        mock.patch("api.models.get_last_workspace", return_value=str(tmp_path)),
+        mock.patch("api.models.ensure_cron_project", return_value="cron-pid"),
+        mock.patch("api.models.SESSION_DIR", session_dir),
+        mock.patch("api.models._read_metadata_json_prefix", side_effect=_counting_prefix),
+    ):
+        first = models._load_cli_sessions_uncached(tmp_path, db, _cli_profile=None)
+        cold_reads = reads["n"]
+        second = models._load_cli_sessions_uncached(tmp_path, db, _cli_profile=None)
+
+    # Cold build read each sidecar (at least once per unique file).
+    assert cold_reads >= len(sids)
+    # Warm rebuild re-stats but does NOT re-read any sidecar — the streaming
+    # re-poll no longer re-pays the per-row file read.
+    assert reads["n"] == cold_reads, (
+        f"warm rebuild re-read sidecars ({reads['n'] - cold_reads} extra reads); "
+        "the projection cache is not engaging across builds"
+    )
+    # The renamed sidecar title is projected onto the cron rows in both builds.
+    titles_first = {s["session_id"]: s["title"] for s in first}
+    titles_second = {s["session_id"]: s["title"] for s in second}
+    assert titles_first == titles_second
+    assert any(t.startswith("Renamed ") for t in titles_first.values())
+
+
+def test_sidecar_cache_invalidates_on_rename(tmp_path):
+    """A sidecar rename/archive bumps the stat signature → fresh read, fresh title."""
+    models.clear_sidecar_metadata_cache()
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    sid = "cron_jobAAAA_111"
+    sidecar = session_dir / f"{sid}.json"
+    sidecar.write_text(
+        '{"session_id": "%s", "title": "First", "created_at": 1.0,'
+        ' "updated_at": 2.0, "archived": false, "messages": []}' % sid,
+        encoding="utf-8",
+    )
+
+    with mock.patch("api.models.SESSION_DIR", session_dir):
+        first = models._state_projection_sidecar_metadata(sid)
+        assert first["title"] == "First"
+        assert first["archived"] is False
+
+        # Rewrite with a new title + archived flag; sleep so ctime/mtime move.
+        time.sleep(0.02)
+        sidecar.write_text(
+            '{"session_id": "%s", "title": "Renamed", "created_at": 1.0,'
+            ' "updated_at": 3.0, "archived": true, "messages": []}' % sid,
+            encoding="utf-8",
+        )
+        second = models._state_projection_sidecar_metadata(sid)
+
+    assert second["title"] == "Renamed"
+    assert second["archived"] is True
+
+
+def test_sidecar_metadata_returns_independent_copies(tmp_path):
+    """A caller mutating the returned dict must not corrupt the cached entry."""
+    models.clear_sidecar_metadata_cache()
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    sid = "cron_jobBBBB_222"
+    (session_dir / f"{sid}.json").write_text(
+        '{"session_id": "%s", "title": "Keep", "created_at": 1.0,'
+        ' "updated_at": 2.0, "archived": false, "messages": []}' % sid,
+        encoding="utf-8",
+    )
+    with mock.patch("api.models.SESSION_DIR", session_dir):
+        first = models._state_projection_sidecar_metadata(sid)
+        first["title"] = "MUTATED"
+        first["archived"] = True
+        second = models._state_projection_sidecar_metadata(sid)
+    assert second["title"] == "Keep"
+    assert second["archived"] is False
+
+
+def test_missing_sidecar_returns_default_without_caching_growth(tmp_path):
+    """A pure state.db row with no sidecar returns the default and is cheap."""
+    models.clear_sidecar_metadata_cache()
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    with mock.patch("api.models.SESSION_DIR", session_dir):
+        meta = models._state_projection_sidecar_metadata("cron_nope_999")
+    assert meta == {"title": None, "archived": False}
+    # No file → nothing cached (so the cache can't be poisoned by absent files).
+    assert len(models._SIDECAR_METADATA_CACHE) == 0
+
+
+def test_jobs_json_parsed_once_per_build(tmp_path):
+    """cron/jobs.json is read+parsed once per build, not once per untitled row."""
+    models.clear_sidecar_metadata_cache()
+    db = tmp_path / "state.db"
+    _make_cron_state_db(db, cron_count=25)
+
+    cron_dir = tmp_path / "cron"
+    cron_dir.mkdir()
+    jobs = {"jobs": [{"id": f"job{i:04d}", "name": f"My Job {i}"} for i in range(25)]}
+    import json as _json
+    (cron_dir / "jobs.json").write_text(_json.dumps(jobs), encoding="utf-8")
+
+    real_read_text = pathlib.Path.read_text
+    jobs_reads = {"n": 0}
+
+    def _counting_read_text(self, *a, **k):
+        if self.name == "jobs.json":
+            jobs_reads["n"] += 1
+        return real_read_text(self, *a, **k)
+
+    with (
+        mock.patch("api.models.get_claude_code_sessions", return_value=[]),
+        mock.patch("api.models.get_last_workspace", return_value=str(tmp_path)),
+        mock.patch("api.models.ensure_cron_project", return_value="cron-pid"),
+        mock.patch("api.models.Session.load_metadata_only", return_value=None),
+        mock.patch.object(pathlib.Path, "read_text", _counting_read_text),
+    ):
+        result = models._load_cli_sessions_uncached(tmp_path, db, _cli_profile=None)
+
+    # jobs.json read at most once despite 25 untitled cron rows across both passes.
+    assert jobs_reads["n"] <= 1, f"jobs.json read {jobs_reads['n']} times (expected <=1)"
+    # The friendly job names were still applied.
+    titles = {s["title"] for s in result if s["source_tag"] == "cron"}
+    assert any(t.startswith("My Job ") for t in titles)
+
+
+def test_get_last_workspace_called_once_per_build(tmp_path):
+    """get_last_workspace() is resolved once, not once per projected row."""
+    models.clear_sidecar_metadata_cache()
+    db = tmp_path / "state.db"
+    _make_cron_state_db(db, cron_count=20)
+
+    ws_calls = {"n": 0}
+
+    def _counting_ws():
+        ws_calls["n"] += 1
+        return str(tmp_path)
+
+    with (
+        mock.patch("api.models.get_claude_code_sessions", return_value=[]),
+        mock.patch("api.models.get_last_workspace", side_effect=_counting_ws),
+        mock.patch("api.models.ensure_cron_project", return_value="cron-pid"),
+        mock.patch("api.models.Session.load_metadata_only", return_value=None),
+    ):
+        result = models._load_cli_sessions_uncached(tmp_path, db, _cli_profile=None)
+
+    assert len(result) > 0
+    # One resolve for the whole build (lazy, memoized) regardless of row count.
+    assert ws_calls["n"] <= 1, (
+        f"get_last_workspace() called {ws_calls['n']} times for {len(result)} rows"
+    )
+
+
+def test_clear_cli_sessions_cache_also_clears_sidecar_cache(tmp_path):
+    """The lifecycle reset clears the sidecar projection cache too."""
+    models.clear_sidecar_metadata_cache()
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    sid = "cron_jobCCCC_333"
+    (session_dir / f"{sid}.json").write_text(
+        '{"session_id": "%s", "title": "X", "created_at": 1.0,'
+        ' "updated_at": 2.0, "archived": false, "messages": []}' % sid,
+        encoding="utf-8",
+    )
+    with mock.patch("api.models.SESSION_DIR", session_dir):
+        models._state_projection_sidecar_metadata(sid)
+        assert len(models._SIDECAR_METADATA_CACHE) == 1
+        models.clear_cli_sessions_cache()
+        assert len(models._SIDECAR_METADATA_CACHE) == 0


### PR DESCRIPTION
## What this fixes

`GET /api/sessions` pins CPU to 100% and takes multiple seconds on profiles with **many cron sessions** — the recurring symptom from #4672 → #4808 → **#4842** (the reporter's 4th ticket on it). The earlier fixes each addressed a different layer (the `/api/reasoning` storm in #4650, the cache re-fingerprinting in #4672, the cache-miss-vs-poll cadence in #4808), but the reporter's stage trace pins **all** remaining latency in a single stage:

```
{"ms": 2601.8, "name": "get_cli_sessions"}   ... next poll ...
{"ms": 3106.2, "name": "get_cli_sessions"}
```

His profile: **200+ cron sessions, zero Claude Code sessions, slow even with one visible session.** That last detail is the key — the visible-window cap (`CLI_VISIBLE_SESSION_LIMIT = 20`) doesn't bound the cost, because the cron projection runs a **second, higher-capped pass** (`CRON_PROJECT_CHIP_LIMIT = 200`) independent of how many sessions are filtered into view.

## Root cause

The state.db → sidebar projection in `_load_cli_sessions_uncached` does three pieces of redundant per-row file I/O, in **both** the visible pass and the up-to-200-row cron-only second pass:

1. **`_state_projection_sidecar_metadata(sid)`** — an uncached `open()` + 64 KB prefix read + a pure-Python JSON-key scan, once per row.
2. **`get_last_workspace()`** — up to two file reads + an `is_dir()`/remote probe, returning the **same** active workspace for every row.
3. **`cron/jobs.json`** — a full file read + JSON parse for **each** untitled cron row.

On a cron-heavy install that's hundreds of file operations per build. And because the enclosing `_CLI_SESSIONS_CACHE` (5 s TTL) is keyed on `_sqlite_content_fingerprint` = `MAX(rowid)` of the `messages` table — which advances on **every streamed token** — the cache misses on essentially every poll during a live turn, so the whole 200-row scan is re-paid every ~5 s. That's the 100% CPU + multi-second `get_cli_sessions`.

This is a distinct hot path from #4822 (which caches the *Claude Code* transcript parse). On a profile with zero Claude Code sessions, #4822's cache never engages — so it does not help this reporter. This PR is the cron/CLI-side counterpart.

## The fix

1. **Memoize `_state_projection_sidecar_metadata`** in a bounded module-level cache keyed by the sidecar's `(path, mtime_ns, size, ctime_ns)` stat signature. A warm build re-stats each file (~1 syscall) instead of re-reading+parsing it. Any rename/archive/edit bumps the signature and transparently invalidates just that one entry, so a stale title/archived flag is impossible without a re-read. Crucially this cache is **separate** from `_CLI_SESSIONS_CACHE`, so it survives the per-token fingerprint busting that defeats the 5 s TTL during streaming — which is the actual trigger. Mirrors the Claude Code parse cache (#4718). Returns dict copies so callers can't corrupt it; folded into `clear_cli_sessions_cache()` for explicit-reset/test parity.
2. **Build-scoped memos** for `cron/jobs.json` (parsed once into a `job_id → name` map) and `get_last_workspace()` (resolved once), matching the existing `_cron_pid()` closure pattern already in the function.

Output is unchanged — these are pure I/O-dedup hoists. The expensive per-row work is now **O(unique files)** instead of **O(rows × polls)**.

## Tests

New `tests/test_issue4842_cron_projection_perf.py` (7 tests):
- warm rebuild does **not** re-read sidecars (the streaming re-poll scenario)
- stat-change (rename/archive) invalidates and returns fresh metadata
- returned dicts are independent copies (no cache corruption)
- missing sidecar returns the default and isn't cached
- `jobs.json` read ≤ 1× per build despite many untitled cron rows
- `get_last_workspace()` resolved ≤ 1× per build
- `clear_cli_sessions_cache()` also clears the sidecar cache

Also updated the two `#4385` archive-reappears regression tests to write a **real** archived sidecar JSON under a monkeypatched `SESSION_DIR` (rather than mocking `load_metadata_only` with no file on disk). The perf fix stat-gates on `SESSION_DIR/{sid}.json` before consulting metadata — which exactly mirrors production, where archived metadata only exists when that file does — so the tests now exercise the real read path. This is an intentional move of the projection's mock boundary from `load_metadata_only` to the filesystem; any other test mocking at that boundary is affected.

Full suite green locally (10481 passed after the test fix); gated with Codex (SAFE TO SHIP) + Opus (the #4385 test breakage was Opus's blocking finding, now fixed).

Closes #4842.

---

*Self-built maintainer PR (nesquena-hermes). Requesting an independent human review before merge per the self-built-PR policy. @rodboev / @franksong2702 — if either of you has a cron-heavy profile, a before/after `get_cli_sessions` stage timing on `/api/sessions` during a live turn would be the ideal real-world confirmation.*