### PR TITLE
Release WT (v0.51.639): persist + session-scope approval-card dismissal (#4846, closes #4754)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.639] — 2026-06-25 — Release WT (approval cards can be dismissed and stay dismissed)
+
+### Fixed
+
+- **Dismissing an approval card now sticks across tab switches, polls, and restarts.** The 1.5s approval poll re-rendered the card whenever the server still reported a pending approval, so collapsing it was undone on the next tick and duplicate cards re-surfaced in every open tab after a reload. The card now has an explicit dismiss (✕) button, and dismissals are remembered in `localStorage` (capped, pruned when the approval resolves) so a card you dismissed stays gone. Dismissals are scoped per session, so dismissing one session's approval can't hide another session's still-pending approval that happens to share an id. Thanks @rodboev. (#4846, closes #4754)
+
 ## [v0.51.638] — 2026-06-25 — Release WS (faster session list — bounded continuation-fallback sidecar reads)
 
 ### Fixed

--- a/static/index.html
+++ b/static/index.html
@@ -499,6 +499,7 @@
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
             <span id="approvalHeading" data-i18n="approval_heading">Approval required</span>
             <button type="button" class="approval-collapse" id="approvalCollapse" aria-expanded="true" aria-label="Collapse approval" aria-controls="approvalDesc approvalCmd approvalCounter approvalBtns" onclick="toggleApprovalCardCollapsed()" title="Collapse approval"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg></button>
+            <button type="button" class="approval-dismiss" onclick="dismissApprovalCard()" aria-label="Dismiss approval" title="Dismiss approval"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
           </div>
           <div class="approval-desc" id="approvalDesc"></div>
           <div class="approval-cmd" id="approvalCmd"></div>

--- a/static/messages.js
+++ b/static/messages.js
@@ -5303,6 +5303,33 @@ let _approvalSessionId = null;
 let _approvalCurrentId = null;  // approval_id of the card currently shown
 let _approvalPendingBySession = new Map();
 
+const _DISMISSED_APPROVALS_KEY = 'hermes_dismissed_approvals';
+
+function _getDismissedApprovals() {
+  try { return JSON.parse(localStorage.getItem(_DISMISSED_APPROVALS_KEY) || '[]'); }
+  catch (_) { return []; }
+}
+
+function _isApprovalDismissed(approvalId) {
+  if (!approvalId) return false;
+  return _getDismissedApprovals().includes(approvalId);
+}
+
+function _markApprovalDismissed(approvalId) {
+  if (!approvalId) return;
+  const set = _getDismissedApprovals().filter(id => id !== approvalId);
+  set.push(approvalId);
+  try { localStorage.setItem(_DISMISSED_APPROVALS_KEY, JSON.stringify(set.slice(-100))); }
+  catch (_) {}
+}
+
+function _unmarkApprovalDismissed(approvalId) {
+  if (!approvalId) return;
+  const set = _getDismissedApprovals().filter(id => id !== approvalId);
+  try { localStorage.setItem(_DISMISSED_APPROVALS_KEY, JSON.stringify(set)); }
+  catch (_) {}
+}
+
 function _promptActiveSessionId() {
   return (S.session && S.session.session_id) || null;
 }
@@ -5360,6 +5387,7 @@ function showApprovalForSession(sid, pending, pendingCount) {
 function showApprovalCard(pending, pendingCount) {
   const sid = _rememberApprovalPending(pending, pendingCount);
   if (!_approvalPromptBelongsToActiveSession(sid)) return;
+  if (pending && pending.approval_id && _isApprovalDismissed(pending.approval_id)) return;
   const keys = pending.pattern_keys || (pending.pattern_key ? [pending.pattern_key] : []);
   const desc = (pending.description || "") + (keys.length ? " [" + keys.join(", ") + "]" : "");
   const cmd = pending.command || "";
@@ -5401,6 +5429,11 @@ function showApprovalCard(pending, pendingCount) {
     setTimeout(() => onceBtn.focus({preventScroll: true}), 50);
   }
   if (typeof syncTopbar === 'function') syncTopbar();
+}
+
+function dismissApprovalCard() {
+  if (_approvalCurrentId) _markApprovalDismissed(_approvalCurrentId);
+  hideApprovalCard(true);
 }
 
 function _syncApprovalCollapseButton(card) {
@@ -5466,6 +5499,7 @@ async function respondApproval(choice) {
   const sid = _approvalSessionId || (S.session && S.session.session_id);
   if (!sid) return;
   const approvalId = _approvalCurrentId;
+  _unmarkApprovalDismissed(approvalId);
   // Disable all buttons immediately to prevent double-submit
   ["approvalBtnOnce","approvalBtnSession","approvalBtnAlways","approvalBtnDeny"].forEach(id => {
     const b = $(id);
@@ -5520,6 +5554,7 @@ function _startApprovalFallbackPoll(sid) {
       if (data.pending) { showApprovalForSession(sid, data.pending, data.pending_count||1); }
       else if (!_approvalPollingSessionMissingOrMismatched(sid)) {
         _clearApprovalPendingForSession(sid);
+        if (_approvalCurrentId) _unmarkApprovalDismissed(_approvalCurrentId);
         _hideApprovalCardIfOwner(sid);
         if (!S.busy) {
           stopApprovalPollingForSession(sid);

--- a/static/messages.js
+++ b/static/messages.js
@@ -5553,8 +5553,10 @@ function _startApprovalFallbackPoll(sid) {
       const data = await api("/api/approval/pending?session_id=" + encodeURIComponent(sid),{timeoutToast:false});
       if (data.pending) { showApprovalForSession(sid, data.pending, data.pending_count||1); }
       else if (!_approvalPollingSessionMissingOrMismatched(sid)) {
+        const _resolvedEntry = _approvalPendingBySession.get(sid);
         _clearApprovalPendingForSession(sid);
-        if (_approvalCurrentId) _unmarkApprovalDismissed(_approvalCurrentId);
+        const _resolvedId = _resolvedEntry && _resolvedEntry.pending && _resolvedEntry.pending.approval_id;
+        if (_resolvedId) _unmarkApprovalDismissed(_resolvedId);
         _hideApprovalCardIfOwner(sid);
         if (!S.busy) {
           stopApprovalPollingForSession(sid);

--- a/static/messages.js
+++ b/static/messages.js
@@ -5433,7 +5433,9 @@ function showApprovalCard(pending, pendingCount) {
 
 function dismissApprovalCard() {
   if (_approvalCurrentId) _markApprovalDismissed(_approvalCurrentId);
+  const sid = _approvalSessionId;
   hideApprovalCard(true);
+  if (sid) _clearApprovalPendingForSession(sid);
 }
 
 function _syncApprovalCollapseButton(card) {

--- a/static/messages.js
+++ b/static/messages.js
@@ -5305,27 +5305,39 @@ let _approvalPendingBySession = new Map();
 
 const _DISMISSED_APPROVALS_KEY = 'hermes_dismissed_approvals';
 
+// Dismissed approvals are namespaced by session so that two sessions carrying
+// the SAME approval_id (e.g. a gateway/run source that reuses externally
+// supplied IDs across sessions) can't have a dismissal in one session hide the
+// other's still-pending approval. Stored value is "<sid>\u0000<approval_id>".
+function _approvalDismissKey(sid, approvalId) {
+  if (!approvalId) return '';
+  return String(sid || '') + '\u0000' + String(approvalId);
+}
+
 function _getDismissedApprovals() {
   try { return JSON.parse(localStorage.getItem(_DISMISSED_APPROVALS_KEY) || '[]'); }
   catch (_) { return []; }
 }
 
-function _isApprovalDismissed(approvalId) {
-  if (!approvalId) return false;
-  return _getDismissedApprovals().includes(approvalId);
+function _isApprovalDismissed(sid, approvalId) {
+  const key = _approvalDismissKey(sid, approvalId);
+  if (!key) return false;
+  return _getDismissedApprovals().includes(key);
 }
 
-function _markApprovalDismissed(approvalId) {
-  if (!approvalId) return;
-  const set = _getDismissedApprovals().filter(id => id !== approvalId);
-  set.push(approvalId);
+function _markApprovalDismissed(sid, approvalId) {
+  const key = _approvalDismissKey(sid, approvalId);
+  if (!key) return;
+  const set = _getDismissedApprovals().filter(k => k !== key);
+  set.push(key);
   try { localStorage.setItem(_DISMISSED_APPROVALS_KEY, JSON.stringify(set.slice(-100))); }
   catch (_) {}
 }
 
-function _unmarkApprovalDismissed(approvalId) {
-  if (!approvalId) return;
-  const set = _getDismissedApprovals().filter(id => id !== approvalId);
+function _unmarkApprovalDismissed(sid, approvalId) {
+  const key = _approvalDismissKey(sid, approvalId);
+  if (!key) return;
+  const set = _getDismissedApprovals().filter(k => k !== key);
   try { localStorage.setItem(_DISMISSED_APPROVALS_KEY, JSON.stringify(set)); }
   catch (_) {}
 }
@@ -5387,7 +5399,7 @@ function showApprovalForSession(sid, pending, pendingCount) {
 function showApprovalCard(pending, pendingCount) {
   const sid = _rememberApprovalPending(pending, pendingCount);
   if (!_approvalPromptBelongsToActiveSession(sid)) return;
-  if (pending && pending.approval_id && _isApprovalDismissed(pending.approval_id)) return;
+  if (pending && pending.approval_id && _isApprovalDismissed(sid, pending.approval_id)) return;
   const keys = pending.pattern_keys || (pending.pattern_key ? [pending.pattern_key] : []);
   const desc = (pending.description || "") + (keys.length ? " [" + keys.join(", ") + "]" : "");
   const cmd = pending.command || "";
@@ -5432,8 +5444,8 @@ function showApprovalCard(pending, pendingCount) {
 }
 
 function dismissApprovalCard() {
-  if (_approvalCurrentId) _markApprovalDismissed(_approvalCurrentId);
   const sid = _approvalSessionId;
+  if (_approvalCurrentId) _markApprovalDismissed(sid, _approvalCurrentId);
   hideApprovalCard(true);
   if (sid) _clearApprovalPendingForSession(sid);
 }
@@ -5501,7 +5513,7 @@ async function respondApproval(choice) {
   const sid = _approvalSessionId || (S.session && S.session.session_id);
   if (!sid) return;
   const approvalId = _approvalCurrentId;
-  _unmarkApprovalDismissed(approvalId);
+  _unmarkApprovalDismissed(sid, approvalId);
   // Disable all buttons immediately to prevent double-submit
   ["approvalBtnOnce","approvalBtnSession","approvalBtnAlways","approvalBtnDeny"].forEach(id => {
     const b = $(id);
@@ -5558,7 +5570,7 @@ function _startApprovalFallbackPoll(sid) {
         const _resolvedEntry = _approvalPendingBySession.get(sid);
         _clearApprovalPendingForSession(sid);
         const _resolvedId = _resolvedEntry && _resolvedEntry.pending && _resolvedEntry.pending.approval_id;
-        if (_resolvedId) _unmarkApprovalDismissed(_resolvedId);
+        if (_resolvedId) _unmarkApprovalDismissed(sid, _resolvedId);
         _hideApprovalCardIfOwner(sid);
         if (!S.busy) {
           stopApprovalPollingForSession(sid);

--- a/static/style.css
+++ b/static/style.css
@@ -1430,6 +1430,10 @@
   .approval-collapse:hover{color:var(--text);border-color:var(--accent-bg-strong);}
   .approval-collapse svg{width:14px;height:14px;display:block;}
   .approval-collapse:focus-visible{outline:2px solid var(--blue);outline-offset:2px;}
+  .approval-dismiss{display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border:1px solid var(--border2);border-radius:999px;background:var(--surface);color:var(--muted);font:inherit;padding:0;cursor:pointer;}
+  .approval-dismiss:hover{color:var(--text);border-color:var(--accent-bg-strong);}
+  .approval-dismiss svg{width:14px;height:14px;display:block;}
+  .approval-dismiss:focus-visible{outline:2px solid var(--blue);outline-offset:2px;}
   .approval-card.collapsed{max-height:56px;bottom:8px;}
   .approval-card.collapsed .approval-inner{max-height:48px;overflow:hidden;padding:10px 14px;}
   .approval-card.collapsed .approval-header{margin-bottom:0;}

--- a/tests/test_issue4754_approval_dismiss_persist.py
+++ b/tests/test_issue4754_approval_dismiss_persist.py
@@ -101,6 +101,34 @@ def test_dismiss_approval_card_hides_card():
     assert "hideApprovalCard(true)" in body
 
 
+def test_dismiss_approval_card_clears_pending_attention():
+    # dismissApprovalCard must call _clearApprovalPendingForSession so the tab
+    # indicator stops blinking after dismiss. Without this, _rememberApprovalPending
+    # reinsertes the pending entry on every poll tick and the indicator stays lit.
+    compact = _compact(MESSAGES_JS)
+    func_start = compact.find("functiondismissApprovalCard(")
+    assert func_start != -1
+    body_end = compact.find("}", func_start)
+    body = compact[func_start:body_end + 1]
+    assert "_clearApprovalPendingForSession(sid)" in body, (
+        "dismissApprovalCard must call _clearApprovalPendingForSession(sid)"
+    )
+
+
+def test_dismiss_approval_card_captures_sid_before_hide():
+    # The session ID must be captured before hideApprovalCard(true) nulls out
+    # _approvalSessionId so the clear call receives the correct ID.
+    compact = _compact(MESSAGES_JS)
+    func_start = compact.find("functiondismissApprovalCard(")
+    assert func_start != -1
+    body_end = compact.find("}", func_start)
+    body = compact[func_start:body_end + 1]
+    sid_pos = body.find("constsid=_approvalSessionId")
+    hide_pos = body.find("hideApprovalCard(true)")
+    assert sid_pos != -1, "sid must be captured via const sid=_approvalSessionId"
+    assert sid_pos < hide_pos, "sid must be captured before hideApprovalCard is called"
+
+
 # ---------------------------------------------------------------------------
 # respondApproval prunes dismissed set
 # ---------------------------------------------------------------------------

--- a/tests/test_issue4754_approval_dismiss_persist.py
+++ b/tests/test_issue4754_approval_dismiss_persist.py
@@ -58,8 +58,9 @@ def test_guard_in_show_approval_card():
     # Guard must appear inside showApprovalCard, after _rememberApprovalPending
     func_start = compact.find("functionshowApprovalCard(")
     assert func_start != -1
-    # Locate the guard after the function start
-    guard = "_isApprovalDismissed(pending.approval_id)"
+    # Locate the guard after the function start (dismissals are namespaced by
+    # session, so the guard passes sid + approval_id).
+    guard = "_isApprovalDismissed(sid,pending.approval_id)"
     guard_idx = compact.find(guard, func_start)
     assert guard_idx != -1, "guard _isApprovalDismissed must appear in showApprovalCard"
     # _rememberApprovalPending must appear before the guard
@@ -72,7 +73,7 @@ def test_guard_in_show_approval_card():
 def test_guard_returns_early():
     # The guard must be a return statement
     compact = _compact(MESSAGES_JS)
-    assert "if(pending&&pending.approval_id&&_isApprovalDismissed(pending.approval_id))return;" in compact
+    assert "if(pending&&pending.approval_id&&_isApprovalDismissed(sid,pending.approval_id))return;" in compact
 
 
 # ---------------------------------------------------------------------------
@@ -89,7 +90,7 @@ def test_dismiss_approval_card_marks_dismissed():
     assert func_start != -1
     body_end = compact.find("}", func_start)
     body = compact[func_start:body_end + 1]
-    assert "_markApprovalDismissed(_approvalCurrentId)" in body
+    assert "_markApprovalDismissed(sid,_approvalCurrentId)" in body
 
 
 def test_dismiss_approval_card_hides_card():
@@ -138,8 +139,8 @@ def test_respond_approval_unmarks_dismissed():
     func_start = compact.find("asyncfunctionrespondApproval(")
     assert func_start != -1
     # Find the closing brace of the function (scan for matching })
-    assert "_unmarkApprovalDismissed(approvalId)" in compact[func_start:], \
-        "_unmarkApprovalDismissed(approvalId) must be called inside respondApproval"
+    assert "_unmarkApprovalDismissed(sid,approvalId)" in compact[func_start:], \
+        "_unmarkApprovalDismissed(sid,approvalId) must be called inside respondApproval"
 
 
 def test_respond_approval_unmarks_before_clear():
@@ -148,7 +149,7 @@ def test_respond_approval_unmarks_before_clear():
     compact = _compact(MESSAGES_JS)
     func_start = compact.find("asyncfunctionrespondApproval(")
     assert func_start != -1
-    unmark_idx = compact.find("_unmarkApprovalDismissed(approvalId)", func_start)
+    unmark_idx = compact.find("_unmarkApprovalDismissed(sid,approvalId)", func_start)
     clear_idx = compact.find("_approvalCurrentId=null;", func_start)
     assert unmark_idx != -1
     assert clear_idx != -1
@@ -170,10 +171,10 @@ def test_no_pending_branch_unmarks_dismissed():
     # Must use session-scoped lookup, not the global _approvalCurrentId
     assert "_approvalPendingBySession.get(sid)" in nearby, \
         "no-pending poll branch must read session-scoped pending via _approvalPendingBySession.get(sid)"
-    assert "_unmarkApprovalDismissed(_resolvedId)" in nearby, \
+    assert "_unmarkApprovalDismissed(sid,_resolvedId)" in nearby, \
         "no-pending poll branch must unmark the session-scoped resolved ID"
     # Must NOT use the global _approvalCurrentId to unmark (that caused the cross-session bug)
-    assert "_unmarkApprovalDismissed(_approvalCurrentId)" not in nearby, \
+    assert "_unmarkApprovalDismissed(sid,_approvalCurrentId)" not in nearby, \
         "no-pending poll branch must not unmark via the global _approvalCurrentId"
 
 
@@ -248,3 +249,75 @@ def test_dismiss_button_near_collapse_button():
 
 def test_approval_dismiss_css_defined():
     assert ".approval-dismiss" in STYLE_CSS
+
+
+# ---------------------------------------------------------------------------
+# Functional: session-namespaced dismissal (the cross-session collision fix)
+# ---------------------------------------------------------------------------
+
+import json
+import shutil
+import subprocess
+
+NODE = shutil.which("node")
+
+
+def _extract_fn(src: str, name: str) -> str:
+    start = src.index(f"function {name}(")
+    brace = src.index("{", start)
+    depth = 0
+    for i in range(brace, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start:i + 1]
+    raise AssertionError(f"{name} body not closed")
+
+
+def test_same_approval_id_in_two_sessions_does_not_collide():
+    """The bug Codex found: dismissing approval_id 'X' in session A must NOT hide
+    a still-pending approval_id 'X' in session B (gateway/run sources can reuse
+    externally-supplied IDs across sessions). Drives the real helper functions in
+    node with a mocked localStorage."""
+    if NODE is None:
+        import pytest
+        pytest.skip("node not available")
+    helpers = "\n".join(
+        _extract_fn(MESSAGES_JS, n)
+        for n in ("_approvalDismissKey", "_getDismissedApprovals",
+                  "_isApprovalDismissed", "_markApprovalDismissed", "_unmarkApprovalDismissed")
+    )
+    script = (
+        "const _store = {};\n"
+        "const localStorage = {\n"
+        "  getItem: k => (k in _store ? _store[k] : null),\n"
+        "  setItem: (k, v) => { _store[k] = String(v); },\n"
+        "};\n"
+        "const _DISMISSED_APPROVALS_KEY = 'hermes_dismissed_approvals';\n"
+        + helpers +
+        "\n"
+        "// Dismiss approval 'X' in session A.\n"
+        "_markApprovalDismissed('sessionA', 'X');\n"
+        "const out = {\n"
+        "  a_dismissed: _isApprovalDismissed('sessionA', 'X'),\n"
+        "  b_not_dismissed: _isApprovalDismissed('sessionB', 'X'),\n"
+        "  diff_id_same_session_not_dismissed: _isApprovalDismissed('sessionA', 'Y'),\n"
+        "};\n"
+        "// Responding in session B (unmark) must not clear session A's dismissal.\n"
+        "_unmarkApprovalDismissed('sessionB', 'X');\n"
+        "out.a_still_dismissed_after_b_unmark = _isApprovalDismissed('sessionA', 'X');\n"
+        "process.stdout.write(JSON.stringify(out));\n"
+    )
+    result = subprocess.run([NODE, "-e", script], check=True, capture_output=True, text=True, timeout=15)
+    out = json.loads(result.stdout)
+    assert out["a_dismissed"] is True, "session A's own dismissal must register"
+    assert out["b_not_dismissed"] is False, (
+        "CROSS-SESSION COLLISION: dismissing approval_id 'X' in session A must NOT "
+        "hide the same approval_id 'X' in session B"
+    )
+    assert out["diff_id_same_session_not_dismissed"] is False
+    assert out["a_still_dismissed_after_b_unmark"] is True, (
+        "un-dismissing 'X' in session B must not clear session A's dismissal of 'X'"
+    )

--- a/tests/test_issue4754_approval_dismiss_persist.py
+++ b/tests/test_issue4754_approval_dismiss_persist.py
@@ -2,8 +2,6 @@
 
 Uses the node-driver (static source extraction) pattern — no browser required.
 """
-import json
-import re
 from pathlib import Path
 
 

--- a/tests/test_issue4754_approval_dismiss_persist.py
+++ b/tests/test_issue4754_approval_dismiss_persist.py
@@ -140,10 +140,55 @@ def test_no_pending_branch_unmarks_dismissed():
     branch_marker = "elseif(!_approvalPollingSessionMissingOrMismatched(sid)){"
     branch_start = compact.find(branch_marker)
     assert branch_start != -1, "no-pending poll else-if branch must exist"
-    # _unmarkApprovalDismissed must appear within the branch (before _hideApprovalCardIfOwner)
-    nearby = compact[branch_start:branch_start + 300]
-    assert "_unmarkApprovalDismissed(_approvalCurrentId)" in nearby, \
-        "no-pending poll branch must unmark dismissed when server clears the approval"
+    nearby = compact[branch_start:branch_start + 400]
+    # Must use session-scoped lookup, not the global _approvalCurrentId
+    assert "_approvalPendingBySession.get(sid)" in nearby, \
+        "no-pending poll branch must read session-scoped pending via _approvalPendingBySession.get(sid)"
+    assert "_unmarkApprovalDismissed(_resolvedId)" in nearby, \
+        "no-pending poll branch must unmark the session-scoped resolved ID"
+    # Must NOT use the global _approvalCurrentId to unmark (that caused the cross-session bug)
+    assert "_unmarkApprovalDismissed(_approvalCurrentId)" not in nearby, \
+        "no-pending poll branch must not unmark via the global _approvalCurrentId"
+
+
+def test_no_pending_branch_reads_pending_before_clear():
+    # The session-scoped entry must be read BEFORE _clearApprovalPendingForSession erases it.
+    compact = _compact(MESSAGES_JS)
+    branch_marker = "elseif(!_approvalPollingSessionMissingOrMismatched(sid)){"
+    branch_start = compact.find(branch_marker)
+    assert branch_start != -1
+    nearby = compact[branch_start:branch_start + 400]
+    get_idx = nearby.find("_approvalPendingBySession.get(sid)")
+    clear_idx = nearby.find("_clearApprovalPendingForSession(sid)")
+    assert get_idx != -1, "_approvalPendingBySession.get(sid) must appear in branch"
+    assert clear_idx != -1, "_clearApprovalPendingForSession(sid) must appear in branch"
+    assert get_idx < clear_idx, \
+        "_approvalPendingBySession.get(sid) must come before _clearApprovalPendingForSession"
+
+
+def test_cross_session_dismiss_not_cleared_by_other_session_poll():
+    """Polling session B with no pending must not un-dismiss session A's dismissed approval.
+
+    Simulates the node-driver scenario:
+    - session A has approval X in _approvalPendingBySession (it was dismissed)
+    - _approvalCurrentId still holds X from before a session switch
+    - polling session B returns no-pending
+    - the branch must NOT unmark X because _approvalPendingBySession.get(sid_B) is empty
+    """
+    compact = _compact(MESSAGES_JS)
+    branch_marker = "elseif(!_approvalPollingSessionMissingOrMismatched(sid)){"
+    branch_start = compact.find(branch_marker)
+    assert branch_start != -1
+    nearby = compact[branch_start:branch_start + 400]
+
+    # The resolved ID must come from the session map, not the global
+    assert "_approvalPendingBySession.get(sid)" in nearby, \
+        "resolved ID source must be session-scoped, not the global _approvalCurrentId"
+
+    # The guard must be conditional on the resolved ID being truthy so that when
+    # the session being polled has no pending entry, _unmarkApprovalDismissed is skipped.
+    assert "if(_resolvedId)" in nearby, \
+        "unmark must be gated on _resolvedId so it fires only for the resolved session"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue4754_approval_dismiss_persist.py
+++ b/tests/test_issue4754_approval_dismiss_persist.py
@@ -1,0 +1,179 @@
+"""Tests for #4754: approval card dismissal persists across tab switches and restarts.
+
+Uses the node-driver (static source extraction) pattern — no browser required.
+"""
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+INDEX_HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _compact(text: str) -> str:
+    return "".join(text.split())
+
+
+# ---------------------------------------------------------------------------
+# localStorage helper presence
+# ---------------------------------------------------------------------------
+
+def test_dismissed_approvals_key_defined():
+    assert "_DISMISSED_APPROVALS_KEY" in MESSAGES_JS
+    assert "hermes_dismissed_approvals" in MESSAGES_JS
+
+
+def test_get_dismissed_approvals_defined():
+    assert "function _getDismissedApprovals(" in MESSAGES_JS
+
+
+def test_is_approval_dismissed_defined():
+    assert "function _isApprovalDismissed(" in MESSAGES_JS
+
+
+def test_mark_approval_dismissed_defined():
+    assert "function _markApprovalDismissed(" in MESSAGES_JS
+
+
+def test_unmark_approval_dismissed_defined():
+    assert "function _unmarkApprovalDismissed(" in MESSAGES_JS
+
+
+# ---------------------------------------------------------------------------
+# 100-entry cap: _markApprovalDismissed must call .slice(-100)
+# ---------------------------------------------------------------------------
+
+def test_dismissed_set_capped_at_100():
+    compact = _compact(MESSAGES_JS)
+    assert ".slice(-100)" in compact, "_markApprovalDismissed must cap the set at 100"
+
+
+# ---------------------------------------------------------------------------
+# Guard in showApprovalCard
+# ---------------------------------------------------------------------------
+
+def test_guard_in_show_approval_card():
+    compact = _compact(MESSAGES_JS)
+    # Guard must appear inside showApprovalCard, after _rememberApprovalPending
+    func_start = compact.find("functionshowApprovalCard(")
+    assert func_start != -1
+    # Locate the guard after the function start
+    guard = "_isApprovalDismissed(pending.approval_id)"
+    guard_idx = compact.find(guard, func_start)
+    assert guard_idx != -1, "guard _isApprovalDismissed must appear in showApprovalCard"
+    # _rememberApprovalPending must appear before the guard
+    remember = "_rememberApprovalPending("
+    remember_idx = compact.find(remember, func_start)
+    assert remember_idx != -1
+    assert remember_idx < guard_idx, "guard must come after _rememberApprovalPending"
+
+
+def test_guard_returns_early():
+    # The guard must be a return statement
+    compact = _compact(MESSAGES_JS)
+    assert "if(pending&&pending.approval_id&&_isApprovalDismissed(pending.approval_id))return;" in compact
+
+
+# ---------------------------------------------------------------------------
+# dismissApprovalCard function
+# ---------------------------------------------------------------------------
+
+def test_dismiss_approval_card_defined():
+    assert "function dismissApprovalCard(" in MESSAGES_JS
+
+
+def test_dismiss_approval_card_marks_dismissed():
+    compact = _compact(MESSAGES_JS)
+    func_start = compact.find("functiondismissApprovalCard(")
+    assert func_start != -1
+    body_end = compact.find("}", func_start)
+    body = compact[func_start:body_end + 1]
+    assert "_markApprovalDismissed(_approvalCurrentId)" in body
+
+
+def test_dismiss_approval_card_hides_card():
+    compact = _compact(MESSAGES_JS)
+    func_start = compact.find("functiondismissApprovalCard(")
+    assert func_start != -1
+    body_end = compact.find("}", func_start)
+    body = compact[func_start:body_end + 1]
+    assert "hideApprovalCard(true)" in body
+
+
+# ---------------------------------------------------------------------------
+# respondApproval prunes dismissed set
+# ---------------------------------------------------------------------------
+
+def test_respond_approval_unmarks_dismissed():
+    compact = _compact(MESSAGES_JS)
+    func_start = compact.find("asyncfunctionrespondApproval(")
+    assert func_start != -1
+    # Find the closing brace of the function (scan for matching })
+    assert "_unmarkApprovalDismissed(approvalId)" in compact[func_start:], \
+        "_unmarkApprovalDismissed(approvalId) must be called inside respondApproval"
+
+
+def test_respond_approval_unmarks_before_clear():
+    # _unmarkApprovalDismissed must come before _approvalCurrentId is set to null
+    # so approvalId still holds the right value
+    compact = _compact(MESSAGES_JS)
+    func_start = compact.find("asyncfunctionrespondApproval(")
+    assert func_start != -1
+    unmark_idx = compact.find("_unmarkApprovalDismissed(approvalId)", func_start)
+    clear_idx = compact.find("_approvalCurrentId=null;", func_start)
+    assert unmark_idx != -1
+    assert clear_idx != -1
+    assert unmark_idx < clear_idx, \
+        "_unmarkApprovalDismissed must be called before _approvalCurrentId is cleared"
+
+
+# ---------------------------------------------------------------------------
+# No-pending poll branch prunes dismissed set
+# ---------------------------------------------------------------------------
+
+def test_no_pending_branch_unmarks_dismissed():
+    compact = _compact(MESSAGES_JS)
+    # Anchor on the poll-specific else-if branch that checks mismatched session
+    branch_marker = "elseif(!_approvalPollingSessionMissingOrMismatched(sid)){"
+    branch_start = compact.find(branch_marker)
+    assert branch_start != -1, "no-pending poll else-if branch must exist"
+    # _unmarkApprovalDismissed must appear within the branch (before _hideApprovalCardIfOwner)
+    nearby = compact[branch_start:branch_start + 300]
+    assert "_unmarkApprovalDismissed(_approvalCurrentId)" in nearby, \
+        "no-pending poll branch must unmark dismissed when server clears the approval"
+
+
+# ---------------------------------------------------------------------------
+# index.html: dismiss button present
+# ---------------------------------------------------------------------------
+
+def test_dismiss_button_in_html():
+    assert 'class="approval-dismiss"' in INDEX_HTML
+
+
+def test_dismiss_button_onclick():
+    assert 'onclick="dismissApprovalCard()"' in INDEX_HTML
+
+
+def test_dismiss_button_aria_label():
+    assert 'aria-label="Dismiss approval"' in INDEX_HTML
+
+
+def test_dismiss_button_near_collapse_button():
+    # Dismiss button must appear after collapse button in document order
+    collapse_idx = INDEX_HTML.find('id="approvalCollapse"')
+    dismiss_idx = INDEX_HTML.find('class="approval-dismiss"')
+    assert collapse_idx != -1
+    assert dismiss_idx != -1
+    assert dismiss_idx > collapse_idx, "dismiss button must follow collapse button"
+
+
+# ---------------------------------------------------------------------------
+# CSS: .approval-dismiss styled
+# ---------------------------------------------------------------------------
+
+def test_approval_dismiss_css_defined():
+    assert ".approval-dismiss" in STYLE_CSS


### PR DESCRIPTION
## Release WT (v0.51.639) — approval cards can be dismissed and stay dismissed

Ships **#4846** (@rodboev) — closes #4754. Nathan approved from the screenshot.

### What it fixes
The 1.5s approval poll re-rendered the card whenever the server still reported a pending approval → collapsing it was undone every tick + dup cards re-surfaced in every tab on reload. Adds an explicit dismiss (✕) button + localStorage-backed dismissal (capped, pruned on resolve).

### Maintainer gate-hardening (Codex CORE)
Dismissals were keyed by bare `approval_id`; gateway/run sources preserve externally-supplied IDs without session namespacing → two sessions sharing an id collide and dismissing in session A hid session B's still-pending approval. Fixed: `_approvalDismissKey(sid, approval_id)` namespaces the key, threaded through all 5 call sites + a functional node-driver cross-session-collision regression test.

### Gate (clean)
- Codex: **SAFE TO SHIP** (cross-session fix confirmed, cap/prune intact, no XSS)
- Full suite: **10498 passed**, 0 failures
- Nathan: screenshot-approved

### 2 UX-judgment items (surfaced to Nathan, product calls not defects)
attention-dot re-lights ~1.5s post-dismiss (server still reports pending); dismissing an unresolved approval hides the response UI. Shipping as 'dismiss = declutter, not resolve.'

Credit @rodboev.
