### PR TITLE
Release WU (v0.51.640): cache Claude Code transcript parses on the profile-switch path (#4718, #4662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+## [v0.51.640] — 2026-06-25 — Release WU (faster profile switching — Claude Code transcript parses are cached)
+
+### Fixed
+
 - **Profile switching and sidebar loads are no longer dominated by re-parsing Claude Code transcripts.** On an installation with a large `~/.claude/projects` history, every `/api/sessions` build (which a profile switch triggers) re-read and JSON-parsed every Claude Code transcript file from scratch — line by line — just to recover each session's title and message count. On a 200-file / ~130MB tree that single step measured 650–1000ms and dominated the cold sidebar latency; because the directory is global but the higher session cache is keyed per active profile, it repeated in full on every switch, on the 5s CLI-cache expiry, and on every sidebar poll. The transcript parse is now memoized per file by its `(path, mtime, size)` signature, so a warm build re-stats the files (~4ms for 200) instead of re-parsing them, while any genuine edit or append transparently invalidates just that one file's entry. The redundant per-row `get_last_workspace()` call (which stats config + probes the terminal cwd) was also hoisted out of the Claude Code row loop. Measured cold-rebuild `/api/sessions` latency on a 250-session profile dropped from ~670–880ms to ~100–200ms. Output is byte-identical to the previous behavior. Thanks @rodboev for the browser-level profiling that isolated the real bottleneck. (#4718, #4662)
 
 ## [v0.51.639] — 2026-06-25 — Release WT (approval cards can be dismissed and stay dismissed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+- **Profile switching and sidebar loads are no longer dominated by re-parsing Claude Code transcripts.** On an installation with a large `~/.claude/projects` history, every `/api/sessions` build (which a profile switch triggers) re-read and JSON-parsed every Claude Code transcript file from scratch — line by line — just to recover each session's title and message count. On a 200-file / ~130MB tree that single step measured 650–1000ms and dominated the cold sidebar latency; because the directory is global but the higher session cache is keyed per active profile, it repeated in full on every switch, on the 5s CLI-cache expiry, and on every sidebar poll. The transcript parse is now memoized per file by its `(path, mtime, size)` signature, so a warm build re-stats the files (~4ms for 200) instead of re-parsing them, while any genuine edit or append transparently invalidates just that one file's entry. The redundant per-row `get_last_workspace()` call (which stats config + probes the terminal cwd) was also hoisted out of the Claude Code row loop. Measured cold-rebuild `/api/sessions` latency on a 250-session profile dropped from ~670–880ms to ~100–200ms. Output is byte-identical to the previous behavior. Thanks @rodboev for the browser-level profiling that isolated the real bottleneck. (#4718, #4662)
+
 ## [v0.51.639] — 2026-06-25 — Release WT (approval cards can be dismissed and stay dismissed)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -41,6 +41,24 @@ _CLI_SESSIONS_CACHE_TTL_SECONDS = 5.0
 _CLI_SESSIONS_CACHE_LOCK = threading.Lock()
 _CLI_SESSIONS_CACHE = {}
 
+# Per-file parse cache for Claude Code JSONL transcripts (#4718/#4662 phase 4).
+# ``~/.claude/projects`` is a GLOBAL, profile-independent directory, but the
+# sidebar re-derives every Claude Code row from scratch on each /api/sessions
+# build — fully re-reading and JSON-parsing up to CLAUDE_CODE_MAX_FILES
+# transcripts line-by-line (hundreds of MB) just to recover a title + message
+# count. That parse dominates the cold sidebar build (~650-1000ms measured on a
+# 200-file / ~130MB tree) and it repeats on every profile switch, on the 5s
+# CLI-cache expiry, and on every sidebar poll, because the higher CLI cache is
+# keyed per active profile while the underlying transcripts never change between
+# switches. This cache memoizes the EXPENSIVE per-file parse result keyed by the
+# file's (resolved path, mtime_ns, size); a warm sidebar build then re-stats the
+# files (~4ms for 200) instead of re-parsing them. Any external edit/append to a
+# transcript changes mtime_ns/size and transparently invalidates just that one
+# file's entry. Bounded so a pathological projects tree can't grow it unbounded.
+_CLAUDE_CODE_PARSE_CACHE_LOCK = threading.Lock()
+_CLAUDE_CODE_PARSE_CACHE: "collections.OrderedDict[tuple, tuple]" = collections.OrderedDict()
+_CLAUDE_CODE_PARSE_CACHE_MAX = 1000
+
 # ---------------------------------------------------------------------------
 # Stale temp-file cleanup
 # ---------------------------------------------------------------------------
@@ -3871,6 +3889,60 @@ def _parse_claude_code_jsonl(path: Path, *, max_messages: int = CLAUDE_CODE_MAX_
     return messages, summary_title, first_ts, last_ts
 
 
+def _parse_claude_code_jsonl_cached(
+    path: Path, *, max_messages: int = CLAUDE_CODE_MAX_MESSAGES_PER_FILE
+) -> tuple[list[dict], str | None, float | None, float | None]:
+    """``_parse_claude_code_jsonl`` memoized by the file's (path, mtime_ns, size).
+
+    The transcript files under ``~/.claude/projects`` are global and rarely
+    change between sidebar builds, but parsing them dominates the cold
+    /api/sessions latency (and repeats on every profile switch). Caching the
+    parse result keyed by the file's stat signature collapses the warm cost to a
+    single ``os.stat`` per file. A genuine append/edit bumps ``mtime_ns``/``size``
+    and misses the cache, so staleness is impossible without re-parsing.
+
+    ``max_messages`` is part of the key so a caller asking for a different cap
+    never reads a result truncated to a smaller one.
+    """
+    try:
+        st = path.stat()
+        key = (str(path), st.st_mtime_ns, st.st_size, int(max_messages))
+    except OSError:
+        # Can't stat -> fall back to a direct (uncached) parse; it will also
+        # likely fail and return the empty tuple, matching prior behavior.
+        return _parse_claude_code_jsonl(path, max_messages=max_messages)
+
+    with _CLAUDE_CODE_PARSE_CACHE_LOCK:
+        hit = _CLAUDE_CODE_PARSE_CACHE.get(key)
+        if hit is not None:
+            _CLAUDE_CODE_PARSE_CACHE.move_to_end(key)
+            messages, summary_title, first_ts, last_ts = hit
+            # Return a shallow copy of the message list so a caller mutating it
+            # can't corrupt the cached entry; the per-message dicts are treated
+            # as read-only by all current callers.
+            return list(messages), summary_title, first_ts, last_ts
+
+    parsed = _parse_claude_code_jsonl(path, max_messages=max_messages)
+
+    with _CLAUDE_CODE_PARSE_CACHE_LOCK:
+        # Re-check under lock in case a concurrent build populated it; either
+        # entry is equally valid for the same stat signature.
+        existing = _CLAUDE_CODE_PARSE_CACHE.get(key)
+        if existing is None:
+            _CLAUDE_CODE_PARSE_CACHE[key] = parsed
+            _CLAUDE_CODE_PARSE_CACHE.move_to_end(key)
+            while len(_CLAUDE_CODE_PARSE_CACHE) > _CLAUDE_CODE_PARSE_CACHE_MAX:
+                _CLAUDE_CODE_PARSE_CACHE.popitem(last=False)
+    messages, summary_title, first_ts, last_ts = parsed
+    return list(messages), summary_title, first_ts, last_ts
+
+
+def clear_claude_code_parse_cache() -> None:
+    """Drop all memoized Claude Code transcript parses (test/lifecycle hook)."""
+    with _CLAUDE_CODE_PARSE_CACHE_LOCK:
+        _CLAUDE_CODE_PARSE_CACHE.clear()
+
+
 def _iter_claude_code_jsonl_files(projects_dir: Path | str | None = None, *, max_files: int = CLAUDE_CODE_MAX_FILES, max_file_bytes: int = CLAUDE_CODE_MAX_FILE_BYTES):
     root = Path(projects_dir).expanduser() if projects_dir is not None else _default_claude_code_projects_dir()
     if root is None:
@@ -3926,20 +3998,34 @@ def get_claude_code_sessions(projects_dir: Path | str | None = None, *, max_file
     never read during test runs.
     """
     sessions = []
+    # ``get_last_workspace()`` is loop-invariant (the same active workspace for
+    # every Claude Code row) but internally stats config.yaml + probes terminal
+    # cwd, so calling it once per row was ~200 redundant stat()s on the cold
+    # sidebar build (#4718). Resolve it a single time.
+    cc_workspace = str(get_last_workspace())
     for path in _iter_claude_code_jsonl_files(projects_dir, max_files=max_files, max_file_bytes=max_file_bytes) or []:
-        messages, summary_title, first_ts, last_ts = _parse_claude_code_jsonl(path)
+        messages, summary_title, first_ts, last_ts = _parse_claude_code_jsonl_cached(path)
         if not messages:
             continue
         sid = _claude_code_session_id(path)
+        if first_ts is None and last_ts is None:
+            try:
+                _mtime = path.stat().st_mtime
+            except OSError:
+                _mtime = 0.0
+        else:
+            _mtime = None
+        created_at = first_ts or last_ts or _mtime
+        updated_at = last_ts or first_ts or _mtime
         sessions.append({
             'session_id': sid,
             'title': _claude_code_title(messages, summary_title),
-            'workspace': str(get_last_workspace()),
+            'workspace': cc_workspace,
             'model': 'claude-code',
             'message_count': len(messages),
-            'created_at': first_ts or last_ts or path.stat().st_mtime,
-            'updated_at': last_ts or first_ts or path.stat().st_mtime,
-            'last_message_at': last_ts or first_ts or path.stat().st_mtime,
+            'created_at': created_at,
+            'updated_at': updated_at,
+            'last_message_at': updated_at,
             'pinned': False,
             'archived': False,
             'project_id': None,
@@ -3963,7 +4049,7 @@ def get_claude_code_session_messages(sid, projects_dir: Path | str | None = None
     for path in _iter_claude_code_jsonl_files(projects_dir) or []:
         if _claude_code_session_id(path) != sid:
             continue
-        messages, _summary_title, _first_ts, _last_ts = _parse_claude_code_jsonl(path)
+        messages, _summary_title, _first_ts, _last_ts = _parse_claude_code_jsonl_cached(path)
         return messages
     return []
 

--- a/api/models.py
+++ b/api/models.py
@@ -51,10 +51,10 @@ _CLI_SESSIONS_CACHE = {}
 # CLI-cache expiry, and on every sidebar poll, because the higher CLI cache is
 # keyed per active profile while the underlying transcripts never change between
 # switches. This cache memoizes the EXPENSIVE per-file parse result keyed by the
-# file's (resolved path, mtime_ns, size); a warm sidebar build then re-stats the
+# file's (path, mtime_ns, size, ctime_ns); a warm sidebar build then re-stats the
 # files (~4ms for 200) instead of re-parsing them. Any external edit/append to a
-# transcript changes mtime_ns/size and transparently invalidates just that one
-# file's entry. Bounded so a pathological projects tree can't grow it unbounded.
+# transcript changes mtime_ns/size/ctime_ns and transparently invalidates just
+# that one file's entry. Bounded so a pathological projects tree can't grow it unbounded.
 _CLAUDE_CODE_PARSE_CACHE_LOCK = threading.Lock()
 _CLAUDE_CODE_PARSE_CACHE: "collections.OrderedDict[tuple, tuple]" = collections.OrderedDict()
 _CLAUDE_CODE_PARSE_CACHE_MAX = 1000
@@ -3892,21 +3892,26 @@ def _parse_claude_code_jsonl(path: Path, *, max_messages: int = CLAUDE_CODE_MAX_
 def _parse_claude_code_jsonl_cached(
     path: Path, *, max_messages: int = CLAUDE_CODE_MAX_MESSAGES_PER_FILE
 ) -> tuple[list[dict], str | None, float | None, float | None]:
-    """``_parse_claude_code_jsonl`` memoized by the file's (path, mtime_ns, size).
+    """``_parse_claude_code_jsonl`` memoized by the file's (path, mtime_ns, size, ctime_ns).
 
     The transcript files under ``~/.claude/projects`` are global and rarely
     change between sidebar builds, but parsing them dominates the cold
     /api/sessions latency (and repeats on every profile switch). Caching the
     parse result keyed by the file's stat signature collapses the warm cost to a
     single ``os.stat`` per file. A genuine append/edit bumps ``mtime_ns``/``size``
-    and misses the cache, so staleness is impossible without re-parsing.
+    /``ctime_ns`` and misses the cache, so staleness is impossible without
+    re-parsing.
 
     ``max_messages`` is part of the key so a caller asking for a different cap
     never reads a result truncated to a smaller one.
     """
     try:
         st = path.stat()
-        key = (str(path), st.st_mtime_ns, st.st_size, int(max_messages))
+        # Key on mtime_ns + size + ctime_ns: size is the strong discriminator for
+        # append-only JSONL (any write changes it), and ctime_ns guards the rare
+        # same-size, same-mtime in-place edit so a content change can never serve
+        # a stale parse. A spurious ctime bump only costs one harmless re-parse.
+        key = (str(path), st.st_mtime_ns, st.st_size, st.st_ctime_ns, int(max_messages))
     except OSError:
         # Can't stat -> fall back to a direct (uncached) parse; it will also
         # likely fail and return the empty tuple, matching prior behavior.
@@ -4008,7 +4013,13 @@ def get_claude_code_sessions(projects_dir: Path | str | None = None, *, max_file
         if not messages:
             continue
         sid = _claude_code_session_id(path)
-        if first_ts is None and last_ts is None:
+        # Match the truthiness fallback used in the assignments below: the old
+        # inline code was ``first_ts or last_ts or path.stat().st_mtime``, which
+        # also fell back to mtime for a falsy-but-not-None ``0.0`` timestamp
+        # (epoch-0 / 1970 transcripts). An identity (``is None``) guard would
+        # leave those rows with ``None`` instead of the file mtime, so use the
+        # same ``not`` test the assignments use to stay bug-for-bug compatible.
+        if not first_ts and not last_ts:
             try:
                 _mtime = path.stat().st_mtime
             except OSError:

--- a/tests/test_issue4718_claude_code_parse_cache.py
+++ b/tests/test_issue4718_claude_code_parse_cache.py
@@ -147,3 +147,98 @@ def test_get_claude_code_sessions_warm_uses_cache(tmp_path, monkeypatch):
     assert cold_calls == 3            # parsed each file once on the cold build
     assert calls["n"] == cold_calls   # warm build added zero re-parses
     assert [s["title"] for s in cold] == [s["title"] for s in warm]
+
+
+def test_epoch_zero_timestamps_fall_back_to_mtime(tmp_path):
+    """A transcript whose timestamps parse to 0.0 still gets a real mtime fallback.
+
+    The cached row-builder guards the mtime fallback with ``not first_ts and not
+    last_ts`` so a falsy-but-not-None ``0.0`` timestamp (epoch-0 / 1970
+    transcript) falls back to the file mtime, matching the pre-cache inline
+    ``first_ts or last_ts or path.stat().st_mtime``. An identity (``is None``)
+    guard would have left these rows with ``None``.
+    """
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    projects_dir = tmp_path / "claude" / "projects"
+    fixture = projects_dir / "p" / "s.jsonl"
+    # All message timestamps are epoch 0 -> _parse_claude_code_timestamp -> 0.0.
+    rows = [
+        {"summary": "Epoch QA"},
+        {"timestamp": "1970-01-01T00:00:00Z", "message": {"role": "user", "content": "hi"}},
+        {"timestamp": "1970-01-01T00:00:00Z", "message": {"role": "assistant", "content": "ok"}},
+    ]
+    _write_jsonl(fixture, rows)
+
+    sessions = models.get_claude_code_sessions(projects_dir=projects_dir)
+    assert len(sessions) == 1
+    s = sessions[0]
+    # Must NOT be None — falls back to the file mtime (a real positive float).
+    assert s["created_at"] is not None
+    assert s["updated_at"] is not None
+    assert s["last_message_at"] is not None
+    assert s["created_at"] > 0
+
+
+def test_parse_cache_dicts_are_read_only_contract(tmp_path):
+    """Pin the load-bearing invariant: per-message dicts are SHARED across hits.
+
+    The cache returns a shallow ``list(messages)`` copy, so the per-message dicts
+    are shared between calls. Every production caller treats them as read-only;
+    this test documents that contract by proving the sharing exists — a future
+    caller that mutates a returned dict in place would corrupt the cache, and
+    this test makes that sharing explicit so such a change is a conscious one.
+    """
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    fixture = tmp_path / "claude" / "projects" / "p" / "s.jsonl"
+    _write_jsonl(fixture, _rows())
+
+    first_msgs, *_ = models._parse_claude_code_jsonl_cached(fixture)
+    second_msgs, *_ = models._parse_claude_code_jsonl_cached(fixture)
+    # List wrappers are distinct copies (append isolation, covered above)...
+    assert first_msgs is not second_msgs
+    # ...but the dict objects are shared (the read-only contract). If a future
+    # change deep-copies on read, update this assertion deliberately.
+    assert first_msgs[0] is second_msgs[0]
+
+
+def test_parse_cache_invalidates_on_same_size_mtime_ctime_edit(tmp_path, monkeypatch):
+    """A same-size, same-mtime in-place edit still misses the cache via ctime_ns."""
+    import os
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    fixture = tmp_path / "claude" / "projects" / "p" / "s.jsonl"
+    _write_jsonl(fixture, _rows("aaaaa"))
+
+    calls = {"n": 0}
+    real = models._parse_claude_code_jsonl
+
+    def _counting(path, **kw):
+        calls["n"] += 1
+        return real(path, **kw)
+
+    monkeypatch.setattr(models, "_parse_claude_code_jsonl", _counting)
+
+    first = models._parse_claude_code_jsonl_cached(fixture)
+    assert first[0][0]["content"] == "aaaaa"
+    st = fixture.stat()
+
+    # Rewrite with same byte length and force the SAME mtime back; the os.utime
+    # call still stamps ctime with the current wall clock, so a real in-place
+    # edit moves ctime even when size+mtime are unchanged. Sleep so that ctime is
+    # measurably distinct from the original mtime_ns we restore.
+    time.sleep(0.02)
+    _write_jsonl(fixture, _rows("bbbbb"))
+    os.utime(fixture, ns=(st.st_atime_ns, st.st_mtime_ns))
+    st2 = fixture.stat()
+    assert st2.st_size == st.st_size
+    assert st2.st_mtime_ns == st.st_mtime_ns
+    assert st2.st_ctime_ns != st.st_ctime_ns  # only ctime moved (the edit signal)
+
+    second = models._parse_claude_code_jsonl_cached(fixture)
+    assert calls["n"] == 2  # re-parsed despite identical size+mtime (ctime caught it)
+    assert second[0][0]["content"] == "bbbbb"

--- a/tests/test_issue4718_claude_code_parse_cache.py
+++ b/tests/test_issue4718_claude_code_parse_cache.py
@@ -1,0 +1,149 @@
+"""Regression tests for the Claude Code transcript parse cache (#4718/#4662).
+
+The sidebar/profile-switch cold path was dominated by re-parsing every Claude
+Code JSONL transcript on each /api/sessions build. ``_parse_claude_code_jsonl``
+is now memoized by the file's (path, mtime_ns, size) so a warm build re-stats
+instead of re-parsing, while any genuine edit transparently invalidates just
+the changed file. These tests pin that behavior.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+
+def _write_jsonl(path: Path, rows: list) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def _rows(text: str = "hello") -> list:
+    return [
+        {"summary": "Cache QA"},
+        {"timestamp": "2026-04-18T12:00:01Z", "message": {"role": "user", "content": text}},
+        {"timestamp": "2026-04-18T12:00:02Z", "message": {"role": "assistant", "content": "ok"}},
+    ]
+
+
+def test_parse_cache_hit_skips_reparse(tmp_path, monkeypatch):
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    fixture = tmp_path / "claude" / "projects" / "p" / "s.jsonl"
+    _write_jsonl(fixture, _rows())
+
+    calls = {"n": 0}
+    real = models._parse_claude_code_jsonl
+
+    def _counting(path, **kw):
+        calls["n"] += 1
+        return real(path, **kw)
+
+    monkeypatch.setattr(models, "_parse_claude_code_jsonl", _counting)
+
+    first = models._parse_claude_code_jsonl_cached(fixture)
+    second = models._parse_claude_code_jsonl_cached(fixture)
+
+    # Second call is served from cache: underlying parser ran exactly once.
+    assert calls["n"] == 1
+    assert first == second
+    assert first[0][0]["content"] == "hello"
+
+
+def test_parse_cache_invalidates_on_content_change(tmp_path, monkeypatch):
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    fixture = tmp_path / "claude" / "projects" / "p" / "s.jsonl"
+    _write_jsonl(fixture, _rows("first"))
+
+    calls = {"n": 0}
+    real = models._parse_claude_code_jsonl
+
+    def _counting(path, **kw):
+        calls["n"] += 1
+        return real(path, **kw)
+
+    monkeypatch.setattr(models, "_parse_claude_code_jsonl", _counting)
+
+    first = models._parse_claude_code_jsonl_cached(fixture)
+    assert first[0][0]["content"] == "first"
+
+    # Rewrite with different content + a guaranteed-distinct mtime/size so the
+    # stat signature changes and the cache must miss.
+    time.sleep(0.01)
+    _write_jsonl(fixture, _rows("second-edition-longer"))
+    import os
+    st = fixture.stat()
+    os.utime(fixture, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+    second = models._parse_claude_code_jsonl_cached(fixture)
+
+    assert calls["n"] == 2  # re-parsed after the edit
+    assert second[0][0]["content"] == "second-edition-longer"
+
+
+def test_parse_cache_returns_independent_message_lists(tmp_path):
+    """A caller mutating the returned list must not corrupt the cached entry."""
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    fixture = tmp_path / "claude" / "projects" / "p" / "s.jsonl"
+    _write_jsonl(fixture, _rows())
+
+    first_msgs, *_ = models._parse_claude_code_jsonl_cached(fixture)
+    first_msgs.append({"role": "user", "content": "injected"})
+
+    second_msgs, *_ = models._parse_claude_code_jsonl_cached(fixture)
+    assert not any(m.get("content") == "injected" for m in second_msgs)
+
+
+def test_parse_cache_is_bounded(tmp_path, monkeypatch):
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    monkeypatch.setattr(models, "_CLAUDE_CODE_PARSE_CACHE_MAX", 5)
+
+    for i in range(12):
+        f = tmp_path / "claude" / "projects" / "p" / f"s{i}.jsonl"
+        _write_jsonl(f, _rows(f"msg-{i}"))
+        models._parse_claude_code_jsonl_cached(f)
+
+    assert len(models._CLAUDE_CODE_PARSE_CACHE) <= 5
+
+
+def test_parse_cache_handles_missing_file(tmp_path):
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    missing = tmp_path / "nope.jsonl"
+    # Must not raise; matches the empty-tuple contract of the uncached parser.
+    assert models._parse_claude_code_jsonl_cached(missing) == ([], None, None, None)
+
+
+def test_get_claude_code_sessions_warm_uses_cache(tmp_path, monkeypatch):
+    """End-to-end: a 2nd get_claude_code_sessions() does not re-parse files."""
+    import api.models as models
+
+    models.clear_claude_code_parse_cache()
+    projects_dir = tmp_path / "claude" / "projects"
+    for i in range(3):
+        _write_jsonl(projects_dir / f"proj{i}" / "s.jsonl", _rows(f"row-{i}"))
+
+    calls = {"n": 0}
+    real = models._parse_claude_code_jsonl
+
+    def _counting(path, **kw):
+        calls["n"] += 1
+        return real(path, **kw)
+
+    monkeypatch.setattr(models, "_parse_claude_code_jsonl", _counting)
+
+    cold = models.get_claude_code_sessions(projects_dir=projects_dir)
+    cold_calls = calls["n"]
+    warm = models.get_claude_code_sessions(projects_dir=projects_dir)
+
+    assert cold_calls == 3            # parsed each file once on the cold build
+    assert calls["n"] == cold_calls   # warm build added zero re-parses
+    assert [s["title"] for s in cold] == [s["title"] for s in warm]


### PR DESCRIPTION
## Release WU (v0.51.640) — faster profile switching (Claude Code transcript parse cache)

Ships **#4822** (@nesquena-hermes, profiling by @rodboev) — #4718, #4662. Nathan greenlit moving forward absent a regression.

### What it fixes
`/api/sessions` (which a profile switch triggers) re-read + JSON-parsed every `~/.claude/projects` transcript from scratch on every build — 650–1000ms on a 200-file/130MB tree, repeated on every switch, 5s CLI-cache expiry, and sidebar poll. Now memoized per file by `(path, mtime_ns, size, ctime_ns, max_messages)`, LRU-1000, byte-identical output; redundant per-row `get_last_workspace()` hoisted out of the loop. Measured 250-session cold rebuild: ~670–880ms → ~100–200ms (rodboev: 19ms warm).

### Review + gate (clean)
- Human: **nesquena APPROVED + rodboev hands-on validated**
- Codex: **SAFE TO SHIP** (no regression post-rebase; cache key staleness-proof + cap-safe; byte-identical output; thread-safe; no profile-isolation break)
- Opus: **SHIP IT** (no regression across all 6 axes)
- Full suite: 10482 passed (the 1 `test_workspace_upload` failure is a pre-existing order-dependent flake, NOT in this diff, passes in isolation)
- 2 prior gate findings already fixed at the gated head (ctime_ns added to the cache key for stale-read defense; epoch-0 timestamp mtime fallback)

Credit @rodboev for the browser-level profiling that isolated the real bottleneck.
