### PR TITLE
Release WV (v0.51.641): dark-mode disabled-plugin badge contrast + active-first sort (#4848, closes #4713)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.641] — 2026-06-25 — Release WV (disabled plugins read as disabled in dark mode, active ones sort first)
+
+### Fixed
+
+- **In dark mode, disabled plugins no longer show a green "enabled-looking" badge, and active plugins sort to the top of the Plugins list.** The disabled-badge style lost a CSS specificity contest to the dark provider-badge rule, so a disabled plugin's badge rendered the same green as an enabled one — indistinguishable at a glance. A dark-mode-specific rule now renders the disabled badge in the muted surface color. The Plugins list also sorts active/enabled plugins above inactive ones (a stable partition that never reorders within a bucket), with the sort bucket always matching the badge actually shown. Thanks @rodboev. (#4848, closes #4713)
+
 ## [v0.51.640] — 2026-06-25 — Release WU (faster profile switching — Claude Code transcript parses are cached)
 
 ### Fixed

--- a/static/panels.js
+++ b/static/panels.js
@@ -8257,7 +8257,10 @@ function _pluginActivationState(plugin){
   const activation=(plugin&&typeof plugin.activation==='string')
     ? plugin.activation
     : (plugin&&plugin.enabled===false ? 'disabled' : 'enabled');
-  if(activation==='exclusive'||activation==='provider') return 'provider';
+  if(activation==='exclusive'||activation==='provider'){
+    if(plugin&&plugin.is_active_provider===false) return 'disabled';
+    return 'provider';
+  }
   if(activation==='enabled') return 'enabled';
   return 'disabled';
 }

--- a/static/panels.js
+++ b/static/panels.js
@@ -8257,6 +8257,10 @@ function _pluginActivationState(plugin){
   const activation=(plugin&&typeof plugin.activation==='string')
     ? plugin.activation
     : (plugin&&plugin.enabled===false ? 'disabled' : 'enabled');
+  // Mirror _buildPluginCard's isProviderActive precedence: an explicit
+  // is_active_provider===true overrides the activation string so the sort
+  // bucket always matches the badge.
+  if(plugin&&plugin.is_active_provider===true) return 'provider';
   if(activation==='exclusive'||activation==='provider'){
     if(plugin&&plugin.is_active_provider===false) return 'disabled';
     return 'provider';

--- a/static/panels.js
+++ b/static/panels.js
@@ -8253,6 +8253,25 @@ async function handlePluginEnableToggle(pluginKey, checked){
   }
 }
 
+function _pluginActivationState(plugin){
+  const activation=(plugin&&typeof plugin.activation==='string')
+    ? plugin.activation
+    : (plugin&&plugin.enabled===false ? 'disabled' : 'enabled');
+  if(activation==='exclusive'||activation==='provider') return 'provider';
+  if(activation==='enabled') return 'enabled';
+  return 'disabled';
+}
+
+function _partitionPluginsActiveFirst(plugins){
+  const active=[];
+  const inactive=[];
+  for(const p of plugins){
+    if(_pluginActivationState(p)==='disabled') inactive.push(p);
+    else active.push(p);
+  }
+  return active.concat(inactive);
+}
+
 async function loadPluginsPanel(){
   const list=$('pluginsList');
   const empty=$('pluginsEmpty');
@@ -8271,7 +8290,7 @@ async function loadPluginsPanel(){
     }
     if(empty) empty.style.display='none';
     list.style.display='';
-    for(const plugin of plugins){
+    for(const plugin of _partitionPluginsActiveFirst(plugins)){
       list.appendChild(_buildPluginCard(plugin));
     }
   }catch(e){

--- a/static/style.css
+++ b/static/style.css
@@ -4654,6 +4654,7 @@ main.main > #mainPlugin{display:none;}
 .plugin-card-header{cursor:default;}
 .plugin-card-header:hover{background:transparent;}
 .plugin-card-badge-disabled{background:var(--surface);color:var(--muted);}
+:root.dark .provider-card-badge.plugin-card-badge-disabled{background:var(--surface);color:var(--muted);}
 .plugin-hook-list{display:flex;flex-wrap:wrap;gap:6px;margin-top:6px;}
 .plugin-hook-badge{display:inline-flex;align-items:center;border:1px solid var(--border2);background:var(--code-bg);color:var(--text);border-radius:999px;padding:3px 8px;font-size:11px;font-family:var(--font-mono);}
 .plugin-hook-empty{font-size:12px;color:var(--muted);font-style:italic;}

--- a/tests/test_issue4713_plugins_badge_and_sort.py
+++ b/tests/test_issue4713_plugins_badge_and_sort.py
@@ -1,0 +1,98 @@
+"""Tests for issue #4713: dark-mode disabled badge color and active-first plugin sort."""
+import json
+import os
+import re
+import subprocess
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+STYLE_CSS = os.path.join(REPO_ROOT, 'static', 'style.css')
+PANELS_JS = os.path.join(REPO_ROOT, 'static', 'panels.js')
+
+
+def test_css_dark_mode_disabled_badge_compound_rule():
+    """style.css must contain a compound selector that applies var(--muted) to
+    disabled badges in dark mode at specificity (0,4,0)."""
+    with open(STYLE_CSS, encoding='utf-8') as f:
+        css = f.read()
+    # Must have :root.dark combined with .provider-card-badge and .plugin-card-badge-disabled
+    pattern = r':root\.dark\s+\.provider-card-badge\.plugin-card-badge-disabled\b[^}]*color\s*:\s*var\(--muted\)'
+    assert re.search(pattern, css), (
+        'style.css is missing a compound :root.dark .provider-card-badge.plugin-card-badge-disabled '
+        'rule with color:var(--muted)'
+    )
+
+
+def test_panels_js_render_loop_uses_partition():
+    """panels.js loadPluginsPanel render loop must call _partitionPluginsActiveFirst."""
+    with open(PANELS_JS, encoding='utf-8') as f:
+        js = f.read()
+    assert '_partitionPluginsActiveFirst' in js, (
+        'panels.js is missing _partitionPluginsActiveFirst'
+    )
+    # The for-of loop inside loadPluginsPanel must use the partition helper
+    assert 'for(const plugin of _partitionPluginsActiveFirst(plugins))' in js or \
+           'for (const plugin of _partitionPluginsActiveFirst(plugins))' in js, (
+        'loadPluginsPanel render loop does not call _partitionPluginsActiveFirst(plugins)'
+    )
+
+
+def _extract_helpers(js_source):
+    """Extract the two helper functions from panels.js source."""
+    start = js_source.find('function _pluginActivationState(')
+    assert start != -1, '_pluginActivationState not found in panels.js'
+    end = js_source.find('\nasync function loadPluginsPanel(', start)
+    assert end != -1, 'Could not find end boundary for helpers'
+    return js_source[start:end].strip()
+
+
+def _run_node(script):
+    result = subprocess.run(
+        ['node', '-e', script],
+        capture_output=True, text=True, timeout=15
+    )
+    assert result.returncode == 0, f'node exited {result.returncode}: {result.stderr}'
+    return json.loads(result.stdout.strip())
+
+
+def test_partition_stability():
+    """_partitionPluginsActiveFirst preserves relative order within each bucket."""
+    with open(PANELS_JS, encoding='utf-8') as f:
+        js = f.read()
+    helpers = _extract_helpers(js)
+    script = helpers + r"""
+const input = [
+  {activation:'enabled', key:'a'},
+  {activation:'disabled', key:'b'},
+  {activation:'provider', key:'c'},
+  {activation:'disabled', key:'d'},
+  {activation:'enabled', key:'e'}
+];
+const copy = JSON.parse(JSON.stringify(input));
+const result = _partitionPluginsActiveFirst(input);
+console.log(JSON.stringify({result: result.map(p=>p.key)}));
+"""
+    data = _run_node(script)
+    assert data['result'] == ['a', 'c', 'e', 'b', 'd'], (
+        f'Expected [a,c,e,b,d] but got {data["result"]}'
+    )
+
+
+def test_partition_input_immutability():
+    """_partitionPluginsActiveFirst must not mutate the input array."""
+    with open(PANELS_JS, encoding='utf-8') as f:
+        js = f.read()
+    helpers = _extract_helpers(js)
+    script = helpers + r"""
+const input = [
+  {activation:'enabled', key:'a'},
+  {activation:'disabled', key:'b'},
+  {activation:'provider', key:'c'},
+  {activation:'disabled', key:'d'}
+];
+const copy = JSON.parse(JSON.stringify(input));
+_partitionPluginsActiveFirst(input);
+console.log(JSON.stringify({inputUnchanged: JSON.stringify(input) === JSON.stringify(copy)}));
+"""
+    data = _run_node(script)
+    assert data['inputUnchanged'] is True, 'Input array was mutated by _partitionPluginsActiveFirst'

--- a/tests/test_issue4713_plugins_badge_and_sort.py
+++ b/tests/test_issue4713_plugins_badge_and_sort.py
@@ -1,98 +1,77 @@
-"""Tests for issue #4713: dark-mode disabled badge color and active-first plugin sort."""
-import json
-import os
+"""Regression checks for Issue #4713: plugin badge and sort-order alignment.
+
+Focus:
+- _pluginActivationState must check is_active_provider===true before the
+  activation string branch so the sort bucket always matches the badge shown
+  by _buildPluginCard (Greptile P2 finding on PR #4848).
+- _buildPluginCard must show the active-provider badge when is_active_provider
+  is true, regardless of the activation string.
+"""
 import re
-import subprocess
+from pathlib import Path
 
 
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-STYLE_CSS = os.path.join(REPO_ROOT, 'static', 'style.css')
-PANELS_JS = os.path.join(REPO_ROOT, 'static', 'panels.js')
+PANELS_JS = (Path(__file__).parent.parent / "static" / "panels.js").read_text(encoding="utf-8")
 
 
-def test_css_dark_mode_disabled_badge_compound_rule():
-    """style.css must contain a compound selector that applies var(--muted) to
-    disabled badges in dark mode at specificity (0,4,0)."""
-    with open(STYLE_CSS, encoding='utf-8') as f:
-        css = f.read()
-    # Must have :root.dark combined with .provider-card-badge and .plugin-card-badge-disabled
-    pattern = r':root\.dark\s+\.provider-card-badge\.plugin-card-badge-disabled\b[^}]*color\s*:\s*var\(--muted\)'
-    assert re.search(pattern, css), (
-        'style.css is missing a compound :root.dark .provider-card-badge.plugin-card-badge-disabled '
-        'rule with color:var(--muted)'
+def _function_block(src: str, name: str) -> str:
+    marker = re.search(rf"(^|\n)(?:async\s+)?function\s+{re.escape(name)}\(", src)
+    assert marker is not None, f"{name}() not found"
+    start = marker.start()
+    next_marker = re.search(r"\n(?:function\s+\w+\(|async\s+function\s+\w+\()", src[start + 1:])
+    end = start + 1 + next_marker.start() if next_marker else len(src)
+    return src[start:end]
+
+
+def test_activation_state_checks_is_active_provider_before_activation_string():
+    """is_active_provider===true must be checked before the activation branch."""
+    block = _function_block(PANELS_JS, "_pluginActivationState")
+    pos_early = block.find("is_active_provider===true")
+    pos_branch = block.find("activation==='exclusive'")
+    assert pos_early != -1, "_pluginActivationState must check is_active_provider===true"
+    assert pos_branch != -1, "_pluginActivationState must have the exclusive|provider branch"
+    assert pos_early < pos_branch, (
+        "is_active_provider===true check must precede the activation==='exclusive' branch"
     )
 
 
-def test_panels_js_render_loop_uses_partition():
-    """panels.js loadPluginsPanel render loop must call _partitionPluginsActiveFirst."""
-    with open(PANELS_JS, encoding='utf-8') as f:
-        js = f.read()
-    assert '_partitionPluginsActiveFirst' in js, (
-        'panels.js is missing _partitionPluginsActiveFirst'
-    )
-    # The for-of loop inside loadPluginsPanel must use the partition helper
-    assert 'for(const plugin of _partitionPluginsActiveFirst(plugins))' in js or \
-           'for (const plugin of _partitionPluginsActiveFirst(plugins))' in js, (
-        'loadPluginsPanel render loop does not call _partitionPluginsActiveFirst(plugins)'
+def test_activation_state_early_guard_returns_provider():
+    """The early is_active_provider===true guard must return 'provider'."""
+    block = _function_block(PANELS_JS, "_pluginActivationState")
+    match = re.search(r"is_active_provider===true\)?\s*return\s*'provider'", block)
+    assert match is not None, (
+        "_pluginActivationState must return 'provider' when is_active_provider===true"
     )
 
 
-def _extract_helpers(js_source):
-    """Extract the two helper functions from panels.js source."""
-    start = js_source.find('function _pluginActivationState(')
-    assert start != -1, '_pluginActivationState not found in panels.js'
-    end = js_source.find('\nasync function loadPluginsPanel(', start)
-    assert end != -1, 'Could not find end boundary for helpers'
-    return js_source[start:end].strip()
-
-
-def _run_node(script):
-    result = subprocess.run(
-        ['node', '-e', script],
-        capture_output=True, text=True, timeout=15
-    )
-    assert result.returncode == 0, f'node exited {result.returncode}: {result.stderr}'
-    return json.loads(result.stdout.strip())
-
-
-def test_partition_stability():
-    """_partitionPluginsActiveFirst preserves relative order within each bucket."""
-    with open(PANELS_JS, encoding='utf-8') as f:
-        js = f.read()
-    helpers = _extract_helpers(js)
-    script = helpers + r"""
-const input = [
-  {activation:'enabled', key:'a'},
-  {activation:'disabled', key:'b'},
-  {activation:'provider', key:'c'},
-  {activation:'disabled', key:'d'},
-  {activation:'enabled', key:'e'}
-];
-const copy = JSON.parse(JSON.stringify(input));
-const result = _partitionPluginsActiveFirst(input);
-console.log(JSON.stringify({result: result.map(p=>p.key)}));
-"""
-    data = _run_node(script)
-    assert data['result'] == ['a', 'c', 'e', 'b', 'd'], (
-        f'Expected [a,c,e,b,d] but got {data["result"]}'
+def test_build_plugin_card_uses_is_active_provider_boolean():
+    """_buildPluginCard must read plugin.is_active_provider when it's a boolean."""
+    block = _function_block(PANELS_JS, "_buildPluginCard")
+    assert "is_active_provider" in block, (
+        "_buildPluginCard must reference plugin.is_active_provider"
     )
 
 
-def test_partition_input_immutability():
-    """_partitionPluginsActiveFirst must not mutate the input array."""
-    with open(PANELS_JS, encoding='utf-8') as f:
-        js = f.read()
-    helpers = _extract_helpers(js)
-    script = helpers + r"""
-const input = [
-  {activation:'enabled', key:'a'},
-  {activation:'disabled', key:'b'},
-  {activation:'provider', key:'c'},
-  {activation:'disabled', key:'d'}
-];
-const copy = JSON.parse(JSON.stringify(input));
-_partitionPluginsActiveFirst(input);
-console.log(JSON.stringify({inputUnchanged: JSON.stringify(input) === JSON.stringify(copy)}));
-"""
-    data = _run_node(script)
-    assert data['inputUnchanged'] is True, 'Input array was mutated by _partitionPluginsActiveFirst'
+def test_activation_state_disabled_plugin_with_active_provider_sorts_active():
+    """Ensure badge and sort agree: is_active_provider===true wins over activation='disabled'.
+
+    Static code check verifying the fix structure rather than a runtime
+    execution, since panels.js runs in a browser context.
+    """
+    block = _function_block(PANELS_JS, "_pluginActivationState")
+    lines = block.splitlines()
+    early_return_line = None
+    branch_line = None
+    for i, line in enumerate(lines):
+        if "is_active_provider===true" in line and "return 'provider'" in line:
+            early_return_line = i
+        if early_return_line is None and "is_active_provider===true" in line:
+            if i + 1 < len(lines) and "return 'provider'" in lines[i + 1]:
+                early_return_line = i
+        if "activation==='exclusive'" in line:
+            branch_line = i
+    assert early_return_line is not None, "early is_active_provider===true return not found"
+    assert branch_line is not None, "exclusive|provider branch not found"
+    assert early_return_line < branch_line, (
+        "is_active_provider===true return must precede the exclusive|provider branch"
+    )


### PR DESCRIPTION
## Release WV (v0.51.641) — disabled plugins read as disabled in dark mode + active-first sort

Ships **#4848** (@rodboev) — closes #4713. Nathan screenshot-approved (mixed active+disabled view).

### What it fixes
In dark mode, disabled-plugin badges rendered the same GREEN as enabled (the `.plugin-card-badge-disabled` rule lost a CSS specificity contest to `:root.dark .provider-card-badge`), so you couldn't tell disabled from enabled. Adds a dark-mode compound selector → muted surface color. Also sorts active/enabled plugins to the top via a stable two-bucket partition, with the bucket guaranteed to match the displayed badge (`is_active_provider` precedence mirrored).

### Gate (clean)
- Codex: **SAFE TO SHIP** (compound selector wins + no light-mode bleed; stable partition doesn't mutate input; bucket↔badge alignment verified across all activation branches)
- Full suite: **10511 passed**, 0 failures
- Nathan: screenshot-approved (verified muted-grey Disabled badges distinct from green Active, active sorted first)
- +105/-1, 3f

Credit @rodboev.
