### PR TITLE
fix(#4856): mobile transcript stuck at top & unscrollable — overflow-x:hidden coerces overflow-y:auto into a collapsing scroll container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **The transcript is no longer stuck at the top and unscrollable on mobile.** On phones (Android and iOS), opening a conversation — and every send/receive after — left the view pinned to the oldest message with no way to scroll down to the latest. Root cause: the mobile `.messages-inner` rule used `overflow-x:hidden`, which (per the CSS spec) silently coerces `overflow-y` to `auto`, turning the inner element into a scroll container. A scroll container's `min-height:auto` resolves to `0`, so the inner — a flex item inside the `.messages` column flexbox — collapsed to the viewport height instead of growing to its content; the transcript then overflowed the (clipped) inner rather than the real scroller, leaving nothing to scroll and pinning `scrollTop` at 0. Switching to `overflow-x:clip` suppresses horizontal overflow exactly as intended without creating a scroll container, so the inner grows to full height and the transcript scrolls normally. Desktop was unaffected. Thanks @Josh for the detailed report (Android app + mobile browser, confirmed on v0.51.641). (#4856)
+
 ## [v0.51.642] — 2026-06-25 — Release WW (a failed steer now shows why, with Retry / Dismiss)
 
 ### Fixed

--- a/static/style.css
+++ b/static/style.css
@@ -2493,7 +2493,19 @@
     .topbar-chips .chip,.topbar-chips .ws-chip,.topbar-chips button{font-size:11px!important;padding:4px 8px!important;white-space:nowrap;}
     .settings-main{padding:18px 16px;}
     .hermes-action-grid{grid-template-columns:1fr;}
-    .messages-inner{padding:12px 10px 20px;max-width:100%;overflow-x:hidden;word-break:break-word;min-width:0;}
+    /* #4856: use overflow-x:clip, NOT hidden. `overflow-x:hidden` forces
+       overflow-y from visible to auto (CSS spec: the two axes can't be
+       visible+clipped), which turns .messages-inner into a scroll container.
+       A scroll container's `min-height:auto` resolves to 0, so this flex item
+       (flex-shrink:1 inside the .messages column flexbox) collapses to the
+       scroller's height instead of growing to its content — the transcript
+       then overflows the INNER (clipped) rather than the .messages scroller,
+       leaving nothing to scroll and pinning scrollTop at 0. On mobile that
+       made every conversation land at the top and refuse to scroll down.
+       `overflow-x:clip` suppresses horizontal overflow (the original #4583
+       intent) WITHOUT coercing overflow-y or creating a scroll container, so
+       min-height:auto stays min-content and the inner grows normally. */
+    .messages-inner{padding:12px 10px 20px;max-width:100%;overflow-x:clip;word-break:break-word;min-width:0;}
     .msg-body{padding-left:0;max-width:100%;}
     .msg-role{font-size:12px;}
     .composer-wrap{padding:8px 10px 12px!important;}

--- a/tests/test_issue4553_mobile_transcript_overflow.py
+++ b/tests/test_issue4553_mobile_transcript_overflow.py
@@ -40,8 +40,21 @@ def test_messages_inner_mobile_has_containment():
     assert 'max-width:100%' in messages_inner_rule, (
         ".messages-inner in mobile block missing max-width:100%"
     )
-    assert 'overflow-x:hidden' in messages_inner_rule, (
-        ".messages-inner in mobile block missing overflow-x:hidden"
+    # #4856: the mobile .messages-inner must clip horizontal overflow WITHOUT
+    # becoming a scroll container. `overflow-x:hidden` coerces overflow-y to
+    # auto (CSS spec), which made the inner a scroll container whose
+    # min-height:auto resolved to 0 and collapsed it inside the .messages
+    # column flexbox — leaving the transcript unscrollable on mobile (stuck at
+    # top). `overflow-x:clip` clips horizontally without that side effect and
+    # still satisfies the original #4553 horizontal-pan-prevention goal.
+    assert 'overflow-x:clip' in messages_inner_rule, (
+        ".messages-inner in mobile block must use overflow-x:clip (not hidden, "
+        "which coerces overflow-y:auto and makes it an unscrollable scroll "
+        "container — #4856)"
+    )
+    assert 'overflow-x:hidden' not in messages_inner_rule, (
+        ".messages-inner in mobile block must NOT use overflow-x:hidden; that "
+        "regresses #4856 (transcript collapses and won't scroll on mobile)"
     )
     assert 'word-break:break-word' in messages_inner_rule, (
         ".messages-inner in mobile block missing word-break:break-word"

--- a/tests/test_issue4856_mobile_transcript_unscrollable.py
+++ b/tests/test_issue4856_mobile_transcript_unscrollable.py
@@ -1,0 +1,75 @@
+"""Regression test for #4856: mobile transcript collapses and won't scroll.
+
+Root cause (proven empirically via headless Chrome mobile emulation):
+
+  The mobile `.messages-inner` rule carried `overflow-x:hidden` (added in the
+  #4583/#4584 batch, v0.51.576 — the user's bisected "first broken" version).
+  Per the CSS overflow spec, when one axis is `hidden` and the other is
+  `visible`, the `visible` axis is coerced to `auto`. So `overflow-x:hidden`
+  silently turned `overflow-y` into `auto`, making `.messages-inner` a SCROLL
+  CONTAINER.
+
+  A scroll container's `min-height:auto` resolves to `0` (not `min-content`).
+  `.messages-inner` is a flex item (default `flex-shrink:1`) inside the
+  `.messages` column flexbox, so with min-height 0 it collapsed to the
+  scroller's height (~681px) instead of growing to its content (~8251px). The
+  transcript then overflowed the INNER (which clipped it) rather than the
+  `.messages` scroller — so the scroller had nothing to scroll, `scrollTop`
+  was pinned at 0, and every open/send/receive left the reader stuck at the
+  top with no way to scroll down. Desktop escaped the collapse; mobile didn't.
+
+Fix: `overflow-x:clip` clips horizontal overflow (the original #4553/#4583
+intent) WITHOUT coercing `overflow-y` or creating a scroll container, so
+`min-height:auto` stays `min-content` and the inner grows to its full height.
+
+These are source-level guards; the runtime collapse is layout/viewport
+specific and not reproducible in headless CI without a full browser.
+"""
+import re
+from pathlib import Path
+
+CSS = (Path(__file__).resolve().parent.parent / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _mobile_messages_inner_rule() -> str:
+    media = re.search(r"@media\(max-width:640px\)\{", CSS)
+    assert media, "@media(max-width:640px) block not found"
+    window = CSS[media.start(): media.start() + 8000]
+    m = re.search(r"\.messages-inner\{([^}]*)\}", window)
+    assert m, ".messages-inner rule not found in mobile media block"
+    return m.group(0)
+
+
+def test_mobile_inner_does_not_become_scroll_container():
+    """overflow-x:hidden coerces overflow-y:auto, making the inner a scroll
+    container whose min-height:auto resolves to 0 — the #4856 collapse. The
+    mobile inner must use overflow-x:clip instead."""
+    rule = _mobile_messages_inner_rule()
+    assert "overflow-x:clip" in rule, (
+        "mobile .messages-inner must use overflow-x:clip so it clips horizontal "
+        "overflow without becoming an unscrollable scroll container (#4856)"
+    )
+    assert "overflow-x:hidden" not in rule, (
+        "mobile .messages-inner must NOT use overflow-x:hidden — it coerces "
+        "overflow-y to auto and collapses the transcript (#4856 regression)"
+    )
+
+
+def test_mobile_inner_must_not_set_overflow_y_auto_or_scroll():
+    """Belt-and-suspenders: an explicit overflow-y:auto/scroll on the inner
+    would reintroduce the scroll-container collapse even with overflow-x:clip."""
+    rule = _mobile_messages_inner_rule()
+    assert "overflow-y:auto" not in rule and "overflow-y:scroll" not in rule, (
+        "mobile .messages-inner must not be a scroll container on the Y axis "
+        "(would re-trigger the #4856 min-height:0 flex collapse)"
+    )
+
+
+def test_messages_scroller_keeps_overflow_y_auto():
+    """The actual scroller is .messages, not .messages-inner — confirm it
+    still owns vertical scrolling so the transcript scrolls there."""
+    m = re.search(r"\.messages\{[^}]*\}", CSS)
+    assert m, ".messages rule not found"
+    assert "overflow-y:auto" in m.group(0), (
+        ".messages must remain the overflow-y:auto scroll container (#4856)"
+    )


### PR DESCRIPTION
## Summary

Fixes #4856 — **the transcript is stuck at the top and completely unscrollable on mobile** (Android app, Android Chrome/Edge, and iOS). Opening a conversation lands on the oldest message, and every send/receive leaves you pinned to the top with no way to scroll down to the latest. Desktop is unaffected.

Reproduced and root-caused empirically via headless Chrome mobile emulation (390×844, `mobile:true`) against current master (v0.51.642). The reporter's bisection — last good **v0.51.575**, first broken **v0.51.576** — points exactly at the change that introduced this.

## Root cause

The mobile `.messages-inner` rule carried `overflow-x:hidden` (added in the #4583/#4584 batch shipped in **v0.51.576**). The failure chain:

1. Per the CSS overflow spec, when one axis is `hidden` and the other is `visible`, the `visible` axis is coerced to **`auto`**. So `overflow-x:hidden` silently turned `overflow-y` into `auto`, making `.messages-inner` a **scroll container**.
2. A scroll container's `min-height:auto` resolves to **`0`** (not `min-content`).
3. `.messages-inner` is a flex item (default `flex-shrink:1`) inside the `.messages` column flexbox. With `min-height` 0 it **collapsed to the scroller's height** (~681px) instead of growing to its content (~8251px).
4. The transcript then overflowed the **inner** (which clipped it) rather than the `.messages` scroller — so the scroller had nothing to scroll, `scrollTop` was pinned at 0, and every open/send/receive stranded the reader at the top.

Desktop escaped the collapse (its inner grew to full content height and scrolled normally); mobile did not. This also explains the reporter's observation that **auto-follow on/off made no difference** — the transcript was fundamentally unscrollable, not mis-pinned.

### Why the earlier #4856 attempts didn't fix it

The prior attempts toggled `overflow-anchor` (`auto`↔`none`) during the DOM-rebuild window — a compositor-repaint theory. But the bug isn't a repaint race; it's a layout collapse that makes the transcript unscrollable in the first place. Those guards are orthogonal and left in place (harmless); this PR fixes the actual layout cause.

## Fix

One property on the mobile `.messages-inner` rule:

```diff
- .messages-inner{padding:12px 10px 20px;max-width:100%;overflow-x:hidden;word-break:break-word;min-width:0;}
+ .messages-inner{padding:12px 10px 20px;max-width:100%;overflow-x:clip;word-break:break-word;min-width:0;}
```

`overflow-x:clip` suppresses horizontal overflow exactly as the original #4583/#4553 work intended, but **without** coercing `overflow-y` or creating a scroll container — so `min-height:auto` stays `min-content` and the inner grows to its full height. (`overflow:clip` is already used elsewhere in `style.css`; supported in all current Android Chrome / iOS Safari.)

## Verification (empirical, against the real served fix)

Headless Chrome mobile emulation, 390×844, `mobile:true`, against a 30-message session:

| Check | Before | After |
|---|---|---|
| `messages` scrollable delta | **0** (stuck) | **7746px** |
| inner offsetHeight | clamped to 681 | grows to 8427 |
| Open session | top | **bottom (latest)** |
| After send/receive re-render | jumps to top | **stays at bottom** |
| Re-render while scrolled mid-transcript | → scrollTop 0 | **position preserved** |
| Horizontal overflow (clip still works) | n/a | clipped, no h-scroll |

Desktop emulation: unchanged (inner already grew to content and scrolled).

## Tests

- Added `tests/test_issue4856_mobile_transcript_unscrollable.py` — asserts the mobile inner uses `overflow-x:clip`, never `overflow-x:hidden` / `overflow-y:auto|scroll`, and that `.messages` remains the real scroll container.
- Updated `tests/test_issue4553_mobile_transcript_overflow.py` — `overflow-x:clip` satisfies #4553's original horizontal-pan-prevention goal; updated the assertion accordingly.

Thanks to the reporter for the precise bisected report (Android app + mobile browser, confirmed broken on v0.51.641).

Closes #4856.