### PR TITLE
Release XB (v0.51.646): mobile transcript scrolls again — overflow-x:clip (#4898, closes #4856)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+## [v0.51.646] — 2026-06-25 — Release XB (mobile transcript scrolls again)
+
+### Fixed
+
 - **The transcript is no longer stuck at the top and unscrollable on mobile.** On phones (Android and iOS), opening a conversation — and every send/receive after — left the view pinned to the oldest message with no way to scroll down to the latest. Root cause: the mobile `.messages-inner` rule used `overflow-x:hidden`, which (per the CSS spec) silently coerces `overflow-y` to `auto`, turning the inner element into a scroll container. A scroll container's `min-height:auto` resolves to `0`, so the inner — a flex item inside the `.messages` column flexbox — collapsed to the viewport height instead of growing to its content; the transcript then overflowed the (clipped) inner rather than the real scroller, leaving nothing to scroll and pinning `scrollTop` at 0. Switching to `overflow-x:clip` suppresses horizontal overflow exactly as intended without creating a scroll container, so the inner grows to full height and the transcript scrolls normally. Desktop was unaffected. (#4856)
 
 ## [v0.51.645] — 2026-06-25 — Release XA (cron-heavy session lists no longer pin the CPU)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+- **The transcript is no longer stuck at the top and unscrollable on mobile.** On phones (Android and iOS), opening a conversation — and every send/receive after — left the view pinned to the oldest message with no way to scroll down to the latest. Root cause: the mobile `.messages-inner` rule used `overflow-x:hidden`, which (per the CSS spec) silently coerces `overflow-y` to `auto`, turning the inner element into a scroll container. A scroll container's `min-height:auto` resolves to `0`, so the inner — a flex item inside the `.messages` column flexbox — collapsed to the viewport height instead of growing to its content; the transcript then overflowed the (clipped) inner rather than the real scroller, leaving nothing to scroll and pinning `scrollTop` at 0. Switching to `overflow-x:clip` suppresses horizontal overflow exactly as intended without creating a scroll container, so the inner grows to full height and the transcript scrolls normally. Desktop was unaffected. (#4856)
+
 ## [v0.51.645] — 2026-06-25 — Release XA (cron-heavy session lists no longer pin the CPU)
 
 ### Fixed

--- a/static/style.css
+++ b/static/style.css
@@ -2493,7 +2493,19 @@
     .topbar-chips .chip,.topbar-chips .ws-chip,.topbar-chips button{font-size:11px!important;padding:4px 8px!important;white-space:nowrap;}
     .settings-main{padding:18px 16px;}
     .hermes-action-grid{grid-template-columns:1fr;}
-    .messages-inner{padding:12px 10px 20px;max-width:100%;overflow-x:hidden;word-break:break-word;min-width:0;}
+    /* #4856: use overflow-x:clip, NOT hidden. `overflow-x:hidden` forces
+       overflow-y from visible to auto (CSS spec: the two axes can't be
+       visible+clipped), which turns .messages-inner into a scroll container.
+       A scroll container's `min-height:auto` resolves to 0, so this flex item
+       (flex-shrink:1 inside the .messages column flexbox) collapses to the
+       scroller's height instead of growing to its content — the transcript
+       then overflows the INNER (clipped) rather than the .messages scroller,
+       leaving nothing to scroll and pinning scrollTop at 0. On mobile that
+       made every conversation land at the top and refuse to scroll down.
+       `overflow-x:clip` suppresses horizontal overflow (the original #4583
+       intent) WITHOUT coercing overflow-y or creating a scroll container, so
+       min-height:auto stays min-content and the inner grows normally. */
+    .messages-inner{padding:12px 10px 20px;max-width:100%;overflow-x:clip;word-break:break-word;min-width:0;}
     .msg-body{padding-left:0;max-width:100%;}
     .msg-role{font-size:12px;}
     .composer-wrap{padding:8px 10px 12px!important;}

--- a/tests/test_issue4553_mobile_transcript_overflow.py
+++ b/tests/test_issue4553_mobile_transcript_overflow.py
@@ -40,8 +40,21 @@ def test_messages_inner_mobile_has_containment():
     assert 'max-width:100%' in messages_inner_rule, (
         ".messages-inner in mobile block missing max-width:100%"
     )
-    assert 'overflow-x:hidden' in messages_inner_rule, (
-        ".messages-inner in mobile block missing overflow-x:hidden"
+    # #4856: the mobile .messages-inner must clip horizontal overflow WITHOUT
+    # becoming a scroll container. `overflow-x:hidden` coerces overflow-y to
+    # auto (CSS spec), which made the inner a scroll container whose
+    # min-height:auto resolved to 0 and collapsed it inside the .messages
+    # column flexbox — leaving the transcript unscrollable on mobile (stuck at
+    # top). `overflow-x:clip` clips horizontally without that side effect and
+    # still satisfies the original #4553 horizontal-pan-prevention goal.
+    assert 'overflow-x:clip' in messages_inner_rule, (
+        ".messages-inner in mobile block must use overflow-x:clip (not hidden, "
+        "which coerces overflow-y:auto and makes it an unscrollable scroll "
+        "container — #4856)"
+    )
+    assert 'overflow-x:hidden' not in messages_inner_rule, (
+        ".messages-inner in mobile block must NOT use overflow-x:hidden; that "
+        "regresses #4856 (transcript collapses and won't scroll on mobile)"
     )
     assert 'word-break:break-word' in messages_inner_rule, (
         ".messages-inner in mobile block missing word-break:break-word"

--- a/tests/test_issue4856_mobile_transcript_unscrollable.py
+++ b/tests/test_issue4856_mobile_transcript_unscrollable.py
@@ -1,0 +1,75 @@
+"""Regression test for #4856: mobile transcript collapses and won't scroll.
+
+Root cause (proven empirically via headless Chrome mobile emulation):
+
+  The mobile `.messages-inner` rule carried `overflow-x:hidden` (added in the
+  #4583/#4584 batch, v0.51.576 — the user's bisected "first broken" version).
+  Per the CSS overflow spec, when one axis is `hidden` and the other is
+  `visible`, the `visible` axis is coerced to `auto`. So `overflow-x:hidden`
+  silently turned `overflow-y` into `auto`, making `.messages-inner` a SCROLL
+  CONTAINER.
+
+  A scroll container's `min-height:auto` resolves to `0` (not `min-content`).
+  `.messages-inner` is a flex item (default `flex-shrink:1`) inside the
+  `.messages` column flexbox, so with min-height 0 it collapsed to the
+  scroller's height (~681px) instead of growing to its content (~8251px). The
+  transcript then overflowed the INNER (which clipped it) rather than the
+  `.messages` scroller — so the scroller had nothing to scroll, `scrollTop`
+  was pinned at 0, and every open/send/receive left the reader stuck at the
+  top with no way to scroll down. Desktop escaped the collapse; mobile didn't.
+
+Fix: `overflow-x:clip` clips horizontal overflow (the original #4553/#4583
+intent) WITHOUT coercing `overflow-y` or creating a scroll container, so
+`min-height:auto` stays `min-content` and the inner grows to its full height.
+
+These are source-level guards; the runtime collapse is layout/viewport
+specific and not reproducible in headless CI without a full browser.
+"""
+import re
+from pathlib import Path
+
+CSS = (Path(__file__).resolve().parent.parent / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _mobile_messages_inner_rule() -> str:
+    media = re.search(r"@media\(max-width:640px\)\{", CSS)
+    assert media, "@media(max-width:640px) block not found"
+    window = CSS[media.start(): media.start() + 8000]
+    m = re.search(r"\.messages-inner\{([^}]*)\}", window)
+    assert m, ".messages-inner rule not found in mobile media block"
+    return m.group(0)
+
+
+def test_mobile_inner_does_not_become_scroll_container():
+    """overflow-x:hidden coerces overflow-y:auto, making the inner a scroll
+    container whose min-height:auto resolves to 0 — the #4856 collapse. The
+    mobile inner must use overflow-x:clip instead."""
+    rule = _mobile_messages_inner_rule()
+    assert "overflow-x:clip" in rule, (
+        "mobile .messages-inner must use overflow-x:clip so it clips horizontal "
+        "overflow without becoming an unscrollable scroll container (#4856)"
+    )
+    assert "overflow-x:hidden" not in rule, (
+        "mobile .messages-inner must NOT use overflow-x:hidden — it coerces "
+        "overflow-y to auto and collapses the transcript (#4856 regression)"
+    )
+
+
+def test_mobile_inner_must_not_set_overflow_y_auto_or_scroll():
+    """Belt-and-suspenders: an explicit overflow-y:auto/scroll on the inner
+    would reintroduce the scroll-container collapse even with overflow-x:clip."""
+    rule = _mobile_messages_inner_rule()
+    assert "overflow-y:auto" not in rule and "overflow-y:scroll" not in rule, (
+        "mobile .messages-inner must not be a scroll container on the Y axis "
+        "(would re-trigger the #4856 min-height:0 flex collapse)"
+    )
+
+
+def test_messages_scroller_keeps_overflow_y_auto():
+    """The actual scroller is .messages, not .messages-inner — confirm it
+    still owns vertical scrolling so the transcript scrolls there."""
+    m = re.search(r"\.messages\{[^}]*\}", CSS)
+    assert m, ".messages rule not found"
+    assert "overflow-y:auto" in m.group(0), (
+        ".messages must remain the overflow-y:auto scroll container (#4856)"
+    )


### PR DESCRIPTION
## Release XB (v0.51.646) — mobile transcript scrolls again

Ships **#4898** (@nesquena-hermes) — **closes #4856 for real.** Nathan greenlit with full authority after browser-proof.

### What it fixes
On phones (Android + iOS), the transcript was stuck at the top and **completely unscrollable** — opening a conversation landed on the oldest message and every send/receive left you pinned there. Reporter bisected to v0.51.575→576.

### Root cause (the real one)
The mobile `.messages-inner` rule had `overflow-x:hidden`, which per the CSS spec **coerces `overflow-y` to `auto`** → `.messages-inner` becomes a scroll container → its `min-height:auto` resolves to `0` → as a flex item in the `.messages` column it collapses to the viewport height instead of growing to content → the transcript overflows the clipped inner (not the real scroller) → `scrollTop` pinned at 0. Fix: `overflow-x:hidden` → `overflow-x:clip` (clips horizontal overflow WITHOUT creating a scroll container).

### ⚠️ Note on the prior #4878
#4878 (v0.51.636) closed #4856 by toggling `overflow-anchor` — a real but **secondary** concern; its test never checked scrollability, so the actual CSS-collapse bug persisted and users kept reporting it. #4898 is the actual fix; #4878's anchor guards are orthogonal and left in place.

### Proof + gate
- **Browser-proven (mine):** real WebUI chat on a phone viewport with the fix scrolls to the latest message (Messages 20–25 at bottom); deterministic A/B confirmed `hidden`→overflow-y:auto/collapse-to-400px vs `clip`→overflow-y:visible/grows-to-1800px
- Codex: **SAFE TO SHIP** (clip is clipped-but-not-scroll-container per MDN/W3C; Android Chrome + iOS Safari supported; desktop unaffected; no conflict with #4878 anchor guards)
- Full suite: **10541 passed**, 0 failures (the #4842 cron tests pass alongside — #4898 doesn't revert #4889)

Will leave #4856 with a note that #4878 was insufficient + #4898 is the real fix.
