### PR TITLE
fix(scroll): keep session switches and background streams anchored

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1776,6 +1776,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _isActiveSession(){
     return !!(S.session&&S.session.session_id===activeSid);
   }
+  function _isLivePaneCurrent(){
+    return _isActiveSession() && S.activeStreamId===streamId;
+  }
+  function _scrollIfLivePanePinned(){
+    if(!_isLivePaneCurrent()) return;
+    scrollIfPinned();
+  }
   function _ownsActiveStreamOrBackground(){
     return !_isActiveSession() || S.activeStreamId===streamId;
   }
@@ -3593,7 +3600,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!assistantBody){onDone();return;}
       const target=_streamFadeCurrentDisplayText();
       const caughtUp=_renderStreamingFadeMarkdown(target);
-      scrollIfPinned();
+      _scrollIfLivePanePinned();
       if(caughtUp){
         // parser_end can flush pending markdown text; include that final text in
         // the fade wait instead of replacing it immediately in renderMessages().
@@ -3960,6 +3967,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _renderPending=false;
       // Guard: a pending setTimeout+rAF can outlive stream finalization.
       if(_streamFinalized) return;
+      // Guard against stale callbacks after switching tabs/sessions.
+      if(!_isLivePaneCurrent()) return;
       // Mobile scroll-jank guard: temporarily disable overflow-anchor before DOM
       // writes to suppress Chromium scroll re-anchoring during streaming growth.
       if(typeof window._fixMobileScrollJank==='function') window._fixMobileScrollJank();
@@ -4000,7 +4009,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         _upsertAnchorProcessProse(displayText);
         if(typeof _syncLiveWorklogReasonsForAnchor==='function') _syncLiveWorklogReasonsForAnchor(assistantRow, displayText);
       }
-      scrollIfPinned();
+      _scrollIfLivePanePinned();
       snapshotLiveTurn();
     };
     const frameIntervalMs=_shouldUseStreamFade()?33:66;
@@ -4193,7 +4202,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _freshSegment=true;
       _smdEndParser();
       _resetAssistantSegment();
-      scrollIfPinned();
+      _scrollIfLivePanePinned();
     });
 
     source.addEventListener('tool_complete',e=>{
@@ -4231,7 +4240,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         appendLiveToolCard(tc,{sessionId:activeSid,streamId});
       }
       snapshotLiveTurn();
-      scrollIfPinned();
+      _scrollIfLivePanePinned();
     });
 
     // Phase 2: dedicated `todo_state` event carries a full snapshot of

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1093,24 +1093,24 @@ async function loadSession(sid){
   // Reset scroll state for fresh session navigation — the reader expects to
   // land at the bottom of the new transcript, not wherever a stale unpin flag
   // from a prior session or a stray touch event during loading would place them.
-  if (freshSessionSwitch) {
-    if (typeof window !== 'undefined' && typeof window._resetSessionSwitchScrollState === 'function') {
-      window._resetSessionSwitchScrollState();
-    } else if (
+  if (currentSid !== sid && typeof window !== 'undefined' && typeof window._resetScrollDirectionTracker === 'function') {
+    window._resetScrollDirectionTracker();
+  }
+  if (currentSid !== sid && typeof window !== 'undefined' && typeof window._resetSessionSwitchScrollState === 'function') {
+    window._resetSessionSwitchScrollState();
+  } else if (currentSid !== sid &&
       typeof _messageUserUnpinned !== 'undefined' &&
-      typeof _scrollPinned !== 'undefined'
-    ) {
-      if (typeof _clearNewMessageScrollCue === 'function') _clearNewMessageScrollCue();
-      _messageUserUnpinned = false;
-      _scrollPinned = true;
-      if (typeof _lastScrollTop !== 'undefined') _lastScrollTop = null;
-      if (typeof _lastMessageClientHeight !== 'undefined') _lastMessageClientHeight = null;
-      if (typeof _nearBottomCount !== 'undefined') _nearBottomCount = 0;
-      if (typeof _touchStartY !== 'undefined') _touchStartY = null;
-      if (typeof _messageTouchScrollActive !== 'undefined') _messageTouchScrollActive = false;
-      if (typeof _lastMessageTouchScrollIntentMs !== 'undefined') _lastMessageTouchScrollIntentMs = -Infinity;
-      if (typeof _cancelBottomSettle === 'function') _cancelBottomSettle();
-    }
+      typeof _scrollPinned !== 'undefined') {
+    if (typeof _clearNewMessageScrollCue === 'function') _clearNewMessageScrollCue();
+    _messageUserUnpinned = false;
+    _scrollPinned = true;
+    if (typeof _lastScrollTop !== 'undefined') _lastScrollTop = null;
+    if (typeof _lastMessageClientHeight !== 'undefined') _lastMessageClientHeight = null;
+    if (typeof _nearBottomCount !== 'undefined') _nearBottomCount = 0;
+    if (typeof _touchStartY !== 'undefined') _touchStartY = null;
+    if (typeof _messageTouchScrollActive !== 'undefined') _messageTouchScrollActive = false;
+    if (typeof _lastMessageTouchScrollIntentMs !== 'undefined') _lastMessageTouchScrollIntentMs = -Infinity;
+    if (typeof _cancelBottomSettle === 'function') _cancelBottomSettle();
   }
   stopApprovalPolling();hideApprovalCard(forceReload);
   if(typeof stopSessionStream==='function') stopSessionStream();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2748,8 +2748,10 @@ async function _loadOlderMessages() {
     // messages were prepended. When the suffix check fails, nextMessages
     // already encodes the legacy prepend fallback so the visible behavior
     // matches the old msg_before page path exactly.
-    // Use $('messages') — the scrollable container (#msgInner is not scrollable).
-    const container = $('messages');
+    // Use the active transcript scroll owner so prepend restore works on mobile/desktop.
+    const container = (typeof _messageScrollElement==='function')
+      ? _messageScrollElement()
+      : $('messages');
     const prevScrollH = container ? container.scrollHeight : 0;
     const oldTop = container ? container.scrollTop : 0;
     const viewportAnchor = (container && typeof _captureMessageViewportAnchor === 'function')

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1122,7 +1122,7 @@ async function loadSession(sid){
   // Persist the current composer draft before switching away so it can be
   // restored when the user switches back (#1060). Save to server now so the
   // draft survives page refresh and syncs across clients.
-  if (currentSid && freshSessionSwitch) {
+  if (currentSid && currentSid !== sid) {
     if(typeof window._clearPendingSelections==='function') window._clearPendingSelections();
     if(typeof _clearQueueCardDisplay==='function') _clearQueueCardDisplay(currentSid);
     await _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
@@ -1151,7 +1151,7 @@ async function loadSession(sid){
       snapshotLiveTurnHtmlForSession(currentSid);
     }
   }
-  if (freshSessionSwitch || forceReload) {
+  if (currentSid !== sid || forceReload) {
     // #3306: When force-reloading the currently-active session (e.g. external
     // poll triggering a refresh), snapshot the existing messages BEFORE we
     // clear them. _ensureMessagesLoaded() runs the ephemeral-field

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1075,6 +1075,7 @@ async function loadSession(sid){
   const forceReload = !!opts.force;
   const currentSid = S.session ? S.session.session_id : null;
   const sameSessionForceReload = forceReload && currentSid===sid;
+  const freshSessionSwitch = currentSid !== sid;
   // Clicking the already-open session in the sidebar is a no-op. Reloading it
   // tears down active pane state and can reset the long-session scroll window
   // to the top even though the user did not navigate anywhere. Explicit
@@ -1092,9 +1093,24 @@ async function loadSession(sid){
   // Reset scroll state for fresh session navigation — the reader expects to
   // land at the bottom of the new transcript, not wherever a stale unpin flag
   // from a prior session or a stray touch event during loading would place them.
-  if (currentSid !== sid && typeof _messageUserUnpinned !== 'undefined') {
-    _messageUserUnpinned = false;
-    _scrollPinned = true;
+  if (freshSessionSwitch) {
+    if (typeof window !== 'undefined' && typeof window._resetSessionSwitchScrollState === 'function') {
+      window._resetSessionSwitchScrollState();
+    } else if (
+      typeof _messageUserUnpinned !== 'undefined' &&
+      typeof _scrollPinned !== 'undefined'
+    ) {
+      if (typeof _clearNewMessageScrollCue === 'function') _clearNewMessageScrollCue();
+      _messageUserUnpinned = false;
+      _scrollPinned = true;
+      if (typeof _lastScrollTop !== 'undefined') _lastScrollTop = null;
+      if (typeof _lastMessageClientHeight !== 'undefined') _lastMessageClientHeight = null;
+      if (typeof _nearBottomCount !== 'undefined') _nearBottomCount = 0;
+      if (typeof _touchStartY !== 'undefined') _touchStartY = null;
+      if (typeof _messageTouchScrollActive !== 'undefined') _messageTouchScrollActive = false;
+      if (typeof _lastMessageTouchScrollIntentMs !== 'undefined') _lastMessageTouchScrollIntentMs = -Infinity;
+      if (typeof _cancelBottomSettle === 'function') _cancelBottomSettle();
+    }
   }
   stopApprovalPolling();hideApprovalCard(forceReload);
   if(typeof stopSessionStream==='function') stopSessionStream();
@@ -1106,7 +1122,7 @@ async function loadSession(sid){
   // Persist the current composer draft before switching away so it can be
   // restored when the user switches back (#1060). Save to server now so the
   // draft survives page refresh and syncs across clients.
-  if (currentSid && currentSid !== sid) {
+  if (currentSid && freshSessionSwitch) {
     if(typeof window._clearPendingSelections==='function') window._clearPendingSelections();
     if(typeof _clearQueueCardDisplay==='function') _clearQueueCardDisplay(currentSid);
     await _saveComposerDraftNow(currentSid, ($('msg') || {}).value || '', S.pendingFiles ? [...S.pendingFiles] : []);
@@ -1135,7 +1151,7 @@ async function loadSession(sid){
       snapshotLiveTurnHtmlForSession(currentSid);
     }
   }
-  if (currentSid !== sid || forceReload) {
+  if (freshSessionSwitch || forceReload) {
     // #3306: When force-reloading the currently-active session (e.g. external
     // poll triggering a refresh), snapshot the existing messages BEFORE we
     // clear them. _ensureMessagesLoaded() runs the ephemeral-field
@@ -1310,9 +1326,6 @@ async function loadSession(sid){
   if (currentSid !== sid) {
     _clearDeferredActiveSessionExternalRefresh();
   }
-  if (currentSid !== sid && typeof window !== 'undefined' && typeof window._resetScrollDirectionTracker === 'function') {
-    try { window._resetScrollDirectionTracker(); } catch (_) {}
-  }
   if(typeof _applyPendingSessionModelForSession==='function') _applyPendingSessionModelForSession(sid);
   _resolveSessionModelForDisplaySoon(sid);
   // Sync workspace display immediately so the chip label reflects the new session's workspace
@@ -1452,7 +1465,7 @@ async function loadSession(sid){
       didReconnect=true;
       attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
     }
-    syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
+    syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:(freshSessionSwitch?{freshSessionLoad:true}:undefined));
     const restoredAnchorScene=activeStreamId&&typeof window!=='undefined'
       ? ((typeof window._renderLiveAnchorActivitySceneForStream==='function'&&window._renderLiveAnchorActivitySceneForStream(activeStreamId, sid, {mode:'compact_worklog'}))||
         _renderRuntimeJournalAnchorActivityScene(activeStreamId, sid))
@@ -1563,7 +1576,7 @@ async function loadSession(sid){
       updateSendBtn();
       setStatus('');
       setComposerStatus('');
-      syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
+      syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:(freshSessionSwitch?{freshSessionLoad:true}:undefined));
       const restoredAnchorScene=activeStreamId&&typeof window!=='undefined'
         ? ((typeof window._renderLiveAnchorActivitySceneForStream==='function'&&window._renderLiveAnchorActivitySceneForStream(activeStreamId, sid, {mode:'compact_worklog'}))||
           _renderRuntimeJournalAnchorActivityScene(activeStreamId, sid))
@@ -1588,7 +1601,7 @@ async function loadSession(sid){
       setStatus('');
       setComposerStatus('');
       updateQueueBadge(sid);
-      syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
+      syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:(freshSessionSwitch?{freshSessionLoad:true}:undefined));
       if(typeof resumeManualCompressionForSession==='function') resumeManualCompressionForSession(sid);
       const _dirP=loadDir('.');
       // Workspace refresh is guarded by session id inside loadDir(); do not

--- a/static/ui.js
+++ b/static/ui.js
@@ -4667,6 +4667,13 @@ function scrollIfPinned(){
   if(_messageUserUnpinned) return;
   if(!_scrollPinned) return;
   if(_recentNonMessageScrollIntent()) return;
+  const el=(typeof _messageScrollElement==='function')?_messageScrollElement():$('messages');
+  if(el&&Number.isFinite(_lastScrollTop)&&el.scrollTop<_lastScrollTop-5){
+    _messageUserUnpinned=true;
+    _scrollPinned=false;
+    _nearBottomCount=0;
+    return;
+  }
   if(_messageBottomDistance()>500) _setMessageScrollToBottom();
   _settleMessageScrollToBottom(false);
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -812,7 +812,7 @@ function _captureMessageViewportAnchor(){
   return null;
 }
 function _restoreMessageViewportAnchor(anchor, rawIdxDelta){
-  const container=_messageScrollElement();
+  const container=(typeof _messageScrollElement==='function')?_messageScrollElement():$('messages');
   if(!container||!anchor) return false;
   const anchorKey=String(anchor.key||'');
   let row=anchorKey?Array.from(container.querySelectorAll('[data-message-anchor-key]')).find(el=>el&&el.dataset&&el.dataset.messageAnchorKey===anchorKey):null;
@@ -836,7 +836,7 @@ function _restoreMessageViewportAnchor(anchor, rawIdxDelta){
 }
 let _messageViewportAnchorRemounting=false;
 function _remountMessageViewportAnchor(anchor){
-  const container=_messageScrollElement();
+  const container=(typeof _messageScrollElement==='function')?_messageScrollElement():$('messages');
   if(!container||!anchor||_messageViewportAnchorRemounting) return false;
   const anchorKey=String(anchor.key||'');
   const visibleKeyNode=anchorKey
@@ -9726,7 +9726,7 @@ function _projectLiveAnchorActivitySceneForStream(streamId, mode){
   }
 }
 function _prepareLiveAnchorScrollRebuildGuard(scrollSnapshot){
-  const messagesEl=_messageScrollElement();
+  const messagesEl=(typeof _messageScrollElement==='function')?_messageScrollElement():$('messages');
   if(!messagesEl||!scrollSnapshot) return {readerAwayFromBottom:false,release:null};
   const beforeBottomDistance=Math.max(0,messagesEl.scrollHeight-messagesEl.scrollTop-messagesEl.clientHeight);
   // Only treat the reader as away if they were ALREADY in a non-follow state.
@@ -11048,7 +11048,7 @@ function _toolArgsSnapshot(args, limit){
 }
 
 function _captureMessageScrollSnapshot(){
-  const el=_messageScrollElement();
+  const el=(typeof _messageScrollElement==='function')?_messageScrollElement():$('messages');
   if(!el) return null;
   const bottom=Math.max(0,el.scrollHeight-el.scrollTop-el.clientHeight);
   return {
@@ -11061,7 +11061,7 @@ function _captureMessageScrollSnapshot(){
   };
 }
 function _restoreMessageScrollSnapshot(snapshot){
-  const el=_messageScrollElement();
+  const el=(typeof _messageScrollElement==='function')?_messageScrollElement():$('messages');
   if(!el||!snapshot) return;
   const maxTop=Math.max(0,el.scrollHeight-el.clientHeight);
   let restoredViaAnchor=(snapshot.anchor&&typeof _restoreMessageViewportAnchor==='function')
@@ -11121,7 +11121,7 @@ window._fixMobileScrollJank=function _fixMobileScrollJank(){
 };
 
 function _restoreMessageScrollSnapshotSameFrame(snapshot){
-  const el=_messageScrollElement();
+  const el=(typeof _messageScrollElement==='function')?_messageScrollElement():$('messages');
   if(!el||!snapshot) return;
   let restoredViaAnchor=(snapshot.anchor&&typeof _restoreMessageViewportAnchor==='function')
     ? _restoreMessageViewportAnchor(snapshot.anchor,0)

--- a/static/ui.js
+++ b/static/ui.js
@@ -3763,7 +3763,11 @@ function _recentMessageTouchScrollIntent(){
   return _messageTouchScrollActive || performance.now()-_lastMessageTouchScrollIntentMs<MESSAGE_TOUCH_SCROLL_SUPPRESS_MS;
 }
 function _isMessageReaderUnpinned(){
-  return !!_messageUserUnpinned;
+  if(_messageUserUnpinned) return true;
+  const el=(typeof _messageScrollElement==='function')?_messageScrollElement():$('messages');
+  if(!el) return false;
+  const bottomDistance=el.scrollHeight-el.scrollTop-el.clientHeight;
+  return bottomDistance>250;
 }
 function _olderMessagesPrefetchReady(){
   const el=_messageScrollElement();

--- a/static/ui.js
+++ b/static/ui.js
@@ -705,7 +705,7 @@ function _messageVirtualRoleForEntry(entry){
 }
 function _currentMessageVirtualWindow(visWithIdx, keepTailCount){
   _syncMessageVirtualHeightCache(visWithIdx);
-  const container=_messageScrollElement();
+  const container=(typeof _messageScrollElement==='function')?_messageScrollElement():$('messages');
   // #4325 opt-out: when the user disables transcript virtualization, always
   // render the full transcript (no windowing). Mirrors the <=threshold path so
   // every downstream consumer (render, anchor, prepend-delta) treats it as a
@@ -879,7 +879,7 @@ function _remountMessageViewportAnchor(anchor){
   return Number.isFinite(targetIdx)&&!!container.querySelector(`[data-msg-idx="${targetIdx}"]`);
 }
 function _compensateScrollForMeasurementDelta(renderFn){
-  const container=_messageScrollElement();
+  const container=(typeof _messageScrollElement==='function')?_messageScrollElement():$('messages');
   if(!container) return renderFn();
   const anchorBefore=_captureMessageViewportAnchor();
   const scrollTopBefore=container.scrollTop;
@@ -903,7 +903,7 @@ function _compensateScrollForMeasurementDelta(renderFn){
   _deferClearProgrammaticScroll();
 }
 function _messageViewportIntersectsRenderedRow(){
-  const container=_messageScrollElement();
+  const container=(typeof _messageScrollElement==='function')?_messageScrollElement():$('messages');
   if(!container) return true;
   const containerRect=container.getBoundingClientRect();
   const rows=Array.from(container.querySelectorAll('[data-msg-idx]'));

--- a/static/ui.js
+++ b/static/ui.js
@@ -705,7 +705,7 @@ function _messageVirtualRoleForEntry(entry){
 }
 function _currentMessageVirtualWindow(visWithIdx, keepTailCount){
   _syncMessageVirtualHeightCache(visWithIdx);
-  const container=$('messages');
+  const container=_messageScrollElement();
   // #4325 opt-out: when the user disables transcript virtualization, always
   // render the full transcript (no windowing). Mirrors the <=threshold path so
   // every downstream consumer (render, anchor, prepend-delta) treats it as a
@@ -791,7 +791,7 @@ function _messageVirtualKeepTailCount(){
   return Math.min(_currentMessageRenderWindowSize(), MESSAGE_RENDER_WINDOW_DEFAULT);
 }
 function _captureMessageViewportAnchor(){
-  const container=$('messages');
+  const container=_messageScrollElement();
   if(!container) return null;
   const containerRect=container.getBoundingClientRect();
   const rows=Array.from(container.querySelectorAll('[data-msg-idx]'));
@@ -812,7 +812,7 @@ function _captureMessageViewportAnchor(){
   return null;
 }
 function _restoreMessageViewportAnchor(anchor, rawIdxDelta){
-  const container=$('messages');
+  const container=_messageScrollElement();
   if(!container||!anchor) return false;
   const anchorKey=String(anchor.key||'');
   let row=anchorKey?Array.from(container.querySelectorAll('[data-message-anchor-key]')).find(el=>el&&el.dataset&&el.dataset.messageAnchorKey===anchorKey):null;
@@ -836,7 +836,7 @@ function _restoreMessageViewportAnchor(anchor, rawIdxDelta){
 }
 let _messageViewportAnchorRemounting=false;
 function _remountMessageViewportAnchor(anchor){
-  const container=$('messages');
+  const container=_messageScrollElement();
   if(!container||!anchor||_messageViewportAnchorRemounting) return false;
   const anchorKey=String(anchor.key||'');
   const visibleKeyNode=anchorKey
@@ -879,7 +879,7 @@ function _remountMessageViewportAnchor(anchor){
   return Number.isFinite(targetIdx)&&!!container.querySelector(`[data-msg-idx="${targetIdx}"]`);
 }
 function _compensateScrollForMeasurementDelta(renderFn){
-  const container=$('messages');
+  const container=_messageScrollElement();
   if(!container) return renderFn();
   const anchorBefore=_captureMessageViewportAnchor();
   const scrollTopBefore=container.scrollTop;
@@ -903,7 +903,7 @@ function _compensateScrollForMeasurementDelta(renderFn){
   _deferClearProgrammaticScroll();
 }
 function _messageViewportIntersectsRenderedRow(){
-  const container=$('messages');
+  const container=_messageScrollElement();
   if(!container) return true;
   const containerRect=container.getBoundingClientRect();
   const rows=Array.from(container.querySelectorAll('[data-msg-idx]'));
@@ -959,7 +959,7 @@ function _updateMessageVirtualMeasurements(renderVisWithIdx, renderVisibleIdxs, 
   }
 }
 function _scheduleMessageVirtualizedRender(force){
-  const container=$('messages');
+  const container=_messageScrollElement();
   const inner=$('msgInner');
   if(!container||!inner) return;
   const visWithIdx=_getVisibleMessagesWithIdx();
@@ -1000,15 +1000,28 @@ function _scheduleMessageVirtualizedRender(force){
 const _renderCache = new Map();
 const _renderCacheMax = 300;
 function _clearRenderCache(){ _renderCache.clear(); }
+function _renderCacheTextHash(text){
+  // Long-message cache keys must distinguish messages that share length,
+  // prefix, and suffix (common in templated/numbered transcripts). Keep the
+  // key compact without falling back to storing every full long message string.
+  let h=0x811c9dc5;
+  const s=String(text||'');
+  for(let i=0;i<s.length;i++){
+    h^=s.charCodeAt(i);
+    h=Math.imul(h,0x01000193);
+  }
+  return (h>>>0).toString(36);
+}
 function _renderCacheKey(text, isUser){
   // Fold render_user_markdown state into user-message keys so toggling the
   // setting invalidates cached plain-text renders (#3870).
   const p = isUser ? (window._renderUserMarkdown ? 'um' : 'u') : 'a';
   // Short content: use the full string as key (cheap Map lookup).
-  // Long content: length + prefix + suffix is good enough — collisions on
-  // 20-char prefix+suffix are vanishingly rare for chat messages.
+  // Long content: include length + a full-content hash + prefix/suffix. The
+  // hash prevents stale HTML when templated long messages differ only in the
+  // middle (e.g. numbered session-tail messages at mobile size).
   if(text.length <= 500) return p + ':' + text;
-  return p + ':' + text.length + ':' + text.slice(0,20) + ':' + text.slice(-20);
+  return p + ':' + text.length + ':' + _renderCacheTextHash(text) + ':' + text.slice(0,20) + ':' + text.slice(-20);
 }
 function _getCachedRender(text, isUser){
   const key = _renderCacheKey(text, isUser);
@@ -1047,13 +1060,13 @@ function _isSessionJumpButtonsEnabled(){
   return window._sessionJumpButtonsEnabled===true;
 }
 function _applySessionNavigationPrefs(){
-  const container=$('messages');
+  const container=_messageScrollElement();
   if(container) container.classList.toggle('session-nav-enabled',_isSessionJumpButtonsEnabled());
   _updateSessionStartJumpButton();
 }
 function _updateSessionStartJumpButton(){
   const btn=$('jumpToSessionStartBtn');
-  const container=$('messages');
+  const container=_messageScrollElement();
   if(!btn||!container) return;
   if(!_isSessionJumpButtonsEnabled()){
     btn.style.display='none';
@@ -1066,7 +1079,7 @@ function _updateSessionStartJumpButton(){
   btn.style.display=(hasSession&&canRevealStart&&awayFromStart)?'flex':'none';
 }
 async function jumpToSessionStart(){
-  const container=$('messages');
+  const container=_messageScrollElement();
   if(!container||!S.session) return;
   _scrollPinned=false;
   _messageUserUnpinned=true;
@@ -1118,7 +1131,7 @@ function _highlightQuestionRow(row){
 }
 
 async function jumpToTurnQuestion(questionRawIdx, assistantRawIdx){
-  const container=$('messages');
+  const container=_messageScrollElement();
   if(!container||typeof questionRawIdx!=='number'||questionRawIdx<0) return;
   const scrollToTarget=()=>{
     const hasAssistant=typeof assistantRawIdx==='number'&&assistantRawIdx>=0;
@@ -3732,6 +3745,15 @@ let _lastMessageTouchScrollIntentMs=-Infinity;
 let _deferredOlderMessagesTimer=0;
 const MESSAGE_TOUCH_SCROLL_SUPPRESS_MS=1200;
 let _newMessageCueVisible=false;
+function _messageScrollElement(){
+  const messages=$('messages');
+  const msgInner=$('msgInner');
+  const messagesScrollable=!!(messages&&messages.scrollHeight>messages.clientHeight+1);
+  const msgInnerScrollable=!!(msgInner&&msgInner.scrollHeight>msgInner.clientHeight+1);
+  if(messagesScrollable) return messages;
+  if(msgInnerScrollable) return msgInner;
+  return msgInner||messages;
+}
 function _cancelBottomSettle(){ _bottomSettleToken++; if(_settleRO){ _settleRO.disconnect(); _settleRO=null; } clearTimeout(_settleTimer); clearTimeout(_settleFinalTimer); cancelAnimationFrame(_settleRAF); }
 function _markMessageTouchScrollIntent(active=true){
   _messageTouchScrollActive=!!active;
@@ -3744,7 +3766,7 @@ function _isMessageReaderUnpinned(){
   return !!_messageUserUnpinned;
 }
 function _olderMessagesPrefetchReady(){
-  const el=document.getElementById('messages');
+  const el=_messageScrollElement();
   if(!el) return false;
   const olderPrefetchPx=Math.max(600,el.clientHeight*1.5);
   return _isSessionEndlessScrollEnabled()&&el.scrollTop<olderPrefetchPx && typeof _messagesTruncated!=='undefined' && _messagesTruncated && typeof _loadOlderMessages==='function';
@@ -3761,7 +3783,7 @@ function _scheduleDeferredOlderMessagesLoad(){
   },MESSAGE_TOUCH_SCROLL_SUPPRESS_MS+50);
 }
 function _recordNonMessageScrollIntent(e){
-  const el=document.getElementById('messages');
+  const el=_messageScrollElement();
   const target=e&&e.target;
   if(!el||!target) return;
   if(!el.contains(target)) _lastNonMessageScrollIntentMs=performance.now();
@@ -3823,7 +3845,7 @@ function _clearNewMessageScrollCue(){
   _syncScrollToBottomCue(false,{newMessage:false});
 }
 function _maybeShowNewMessageScrollCue(scrollSnapshot){
-  const el=document.getElementById('messages');
+  const el=_messageScrollElement();
   if(!el||!scrollSnapshot) return;
   const previousHeight=Number(scrollSnapshot.scrollHeight)||0;
   const distance=el.scrollHeight-el.scrollTop-el.clientHeight;
@@ -3834,7 +3856,7 @@ if(typeof document!=='undefined'){
   document.addEventListener('wheel',_recordNonMessageScrollIntent,{capture:true,passive:true});
   document.addEventListener('touchmove',_recordNonMessageScrollIntent,{capture:true,passive:true});
   document.addEventListener('touchstart',function(e){
-    const el=document.getElementById('messages');
+    const el=_messageScrollElement();
     if(e.touches&&e.touches[0]) _touchStartY=e.touches[0].clientY;
     if(el&&e.target&&el.contains(e.target)) _markMessageTouchScrollIntent(true);
   },{capture:true,passive:true});
@@ -3883,7 +3905,7 @@ if(typeof window!=='undefined'){
   if(typeof document==='undefined') return;
   const isStandalone=window.navigator?.standalone||matchMedia('(display-mode:standalone),(display-mode:fullscreen)').matches;
   if(!isStandalone) return;
-  const el=document.getElementById('messages');
+  const el=_messageScrollElement();
   if(!el) return;
   let _ptrState=0; // 0=idle, 1=pulling, 2=ready
   let _ptrStartY=0;
@@ -3912,12 +3934,12 @@ if(typeof window!=='undefined'){
     _ptrCurrentY=0;
     if(_indicator) _indicator.classList.remove('active');
   }
-  el.addEventListener('touchstart',function(e){
+  const onTouchStart=(e)=>{
     if(el.scrollTop>0||_ptrState!==0) return;
     _ptrStartY=e.touches[0].clientY;
     _ptrState=1;
-  },{passive:true});
-  el.addEventListener('touchmove',function(e){
+  };
+  const onTouchMove=(e)=>{
     if(_ptrState!==1) return;
     _ptrCurrentY=e.touches[0].clientY;
     const pull=_ptrCurrentY-_ptrStartY;
@@ -3933,8 +3955,8 @@ if(typeof window!=='undefined'){
     _ptrUpdate(progress);
     _ptrState=progress>=1?2:1;
     if(progress>0.3) e.preventDefault();
-  },{passive:false});
-  el.addEventListener('touchend',function(){
+  };
+  const onTouchEnd=()=>{
     if(_ptrState===2){
       if(typeof window.refreshSessionList==='function'){
         Promise.resolve(window.refreshSessionList('pull', {force:true, refreshActive:true})).catch(()=>{}).finally(_ptrReset);
@@ -3944,15 +3966,23 @@ if(typeof window!=='undefined'){
       return;
     }
     _ptrReset();
-  },{passive:true});
+  };
+  el.addEventListener('touchstart',onTouchStart,{passive:true});
+  el.addEventListener('touchmove',onTouchMove,{passive:false});
+  el.addEventListener('touchend',onTouchEnd,{passive:true});
   el.addEventListener('touchcancel',_ptrReset,{passive:true});
 })();
 (function(){
-  const el=document.getElementById('messages');
-  if(!el) return;
-  el.addEventListener('pointerdown',(e)=>{
-    if(e.target===el&&e.offsetX>=el.clientWidth) _scrollbarDragActive=true;
-  },{passive:true});
+  const bindableScrollElements=[_messageScrollElement(),$('messages'),$('msgInner')].filter((el,idx,arr)=>{
+    if(!el) return false;
+    return arr.indexOf(el)===idx;
+  });
+  if(!bindableScrollElements.length) return;
+  bindableScrollElements.forEach(el=>{
+    el.addEventListener('pointerdown',(e)=>{
+      if(e.target===el&&e.offsetX>=el.clientWidth) _scrollbarDragActive=true;
+    },{passive:true});
+  });
   window.addEventListener('pointerup',()=>{
     if(!_scrollbarDragActive) return;
     _scrollbarDragActive=false;
@@ -3968,67 +3998,69 @@ if(typeof window!=='undefined'){
     if(document.visibilityState==='hidden') _scrollbarDragActive=false;
   },{passive:true});
   let _scrollRaf=0;
-  el.addEventListener('scroll',()=>{
-    _scheduleMessageVirtualizedRender();
-    if(_programmaticScroll&&(performance.now()-_programmaticScrollSetAt)>150) _programmaticScroll=false;
-    if(_programmaticScroll) return;
-    _markMessageVirtualScrollActive();
-    cancelAnimationFrame(_scrollRaf);
-    _scrollRaf=requestAnimationFrame(()=>{
-      const top=el.scrollTop;
-      const bottomDistance=el.scrollHeight-top-el.clientHeight;
-      const nearBottom=bottomDistance<250;
-      // #4702: iOS Safari (esp. portrait) resolves its dynamic toolbar height
-      // AFTER first paint. When the toolbar collapses the scroller GROWS
-      // (clientHeight increases), which fires a scroll event with a DECREASED
-      // scrollTop even though the user never scrolled. Without this guard that
-      // reflow is misread as an upward scroll and falsely unpins a freshly-opened
-      // session, stranding portrait readers at the top (sibling: #4701). On
-      // desktop/landscape the scroller height is stable, so `grew` is always
-      // false and behavior is byte-identical.
-      const grew=_lastMessageClientHeight!==null&&el.clientHeight>_lastMessageClientHeight+1;
-      _lastMessageClientHeight=el.clientHeight;
-      const movedUp=!grew&&_lastScrollTop!==null&&top<_lastScrollTop-2;
-      const movedDown=_lastScrollTop!==null&&top>_lastScrollTop+2;
-      _lastScrollTop=top;
-      if(movedUp){
-        _cancelBottomSettle();
-        _nearBottomCount=0;
-        _scrollPinned=false;
-        _messageUserUnpinned=true;
-      }else if(movedDown&&nearBottom){
-        _nearBottomCount=_nearBottomCount+1;
-        if(_nearBottomCount>=2){
-          if(!_messageUserUnpinned||bottomDistance<=80){
-            _messageUserUnpinned=false;
-            _scrollPinned=true;
-          }
+  bindableScrollElements.forEach(el=>{
+    el.addEventListener('scroll',function(){
+      _scheduleMessageVirtualizedRender();
+      if(_programmaticScroll&&(performance.now()-_programmaticScrollSetAt)>150) _programmaticScroll=false;
+      if(_programmaticScroll) return;
+      _markMessageVirtualScrollActive();
+      cancelAnimationFrame(_scrollRaf);
+      _scrollRaf=requestAnimationFrame(()=>{
+        const top=el.scrollTop;
+        const bottomDistance=el.scrollHeight-top-el.clientHeight;
+        const nearBottom=bottomDistance<250;
+        // #4702: iOS Safari (esp. portrait) resolves its dynamic toolbar height
+        // AFTER first paint. When the toolbar collapses the scroller GROWS
+        // (clientHeight increases), which fires a scroll event with a DECREASED
+        // scrollTop even though the user never scrolled. Without this guard that
+        // reflow is misread as an upward scroll and falsely unpins a freshly-opened
+        // session, stranding portrait readers at the top (sibling: #4701). On
+        // desktop/landscape the scroller height is stable, so `grew` is always
+        // false and behavior is byte-identical.
+        const grew=_lastMessageClientHeight!==null&&el.clientHeight>_lastMessageClientHeight+1;
+        _lastMessageClientHeight=el.clientHeight;
+        const movedUp=!grew&&_lastScrollTop!==null&&top<_lastScrollTop-2;
+        const movedDown=_lastScrollTop!==null&&top>_lastScrollTop+2;
+        _lastScrollTop=top;
+        if(movedUp){
+          _cancelBottomSettle();
           _nearBottomCount=0;
-        }
-      }else if(!_messageUserUnpinned){
-        if(nearBottom){
+          _scrollPinned=false;
+          _messageUserUnpinned=true;
+        }else if(movedDown&&nearBottom){
           _nearBottomCount=_nearBottomCount+1;
-          if(_nearBottomCount>=2){_scrollPinned=true;_nearBottomCount=0;}
-        }else{
+          if(_nearBottomCount>=2){
+            if(!_messageUserUnpinned||bottomDistance<=80){
+              _messageUserUnpinned=false;
+              _scrollPinned=true;
+            }
+            _nearBottomCount=0;
+          }
+        }else if(!_messageUserUnpinned){
+          if(nearBottom){
+            _nearBottomCount=_nearBottomCount+1;
+            if(_nearBottomCount>=2){_scrollPinned=true;_nearBottomCount=0;}
+          }else{
+            _nearBottomCount=0;
+            _scrollPinned=false;
+          }
+        }else if(!nearBottom){
           _nearBottomCount=0;
           _scrollPinned=false;
         }
-      }else if(!nearBottom){
-        _nearBottomCount=0;
-        _scrollPinned=false;
-      }
-      if(nearBottom) _clearNewMessageScrollCue();
-      const showBottomButton=!_scrollPinned && el.scrollHeight-top-el.clientHeight>80;
-      _syncScrollToBottomCue(showBottomButton,{newMessage:_newMessageCueVisible});
-      if(typeof _updateSessionStartJumpButton==='function') _updateSessionStartJumpButton();
-      // Prefetch older messages before the reader hits the hard top. Prepending
-      // then preserving scrollTop is seamless only if there is runway left for
-      // the user's continued upward wheel/touch movement.
-      const olderPrefetchPx=Math.max(600,el.clientHeight*1.5);
-      if(_isSessionEndlessScrollEnabled()&&el.scrollTop<olderPrefetchPx && typeof _messagesTruncated!=='undefined' && _messagesTruncated && typeof _loadOlderMessages==='function'){
-        if(_recentMessageTouchScrollIntent()) _scheduleDeferredOlderMessagesLoad();
-        else _loadOlderMessages();
-      }
+        if(nearBottom) _clearNewMessageScrollCue();
+        const showBottomButton=!_scrollPinned && el.scrollHeight-top-el.clientHeight>80;
+        _syncScrollToBottomCue(showBottomButton,{newMessage:_newMessageCueVisible});
+        if(typeof _updateSessionStartJumpButton==='function') _updateSessionStartJumpButton();
+        // Prefetch older messages before the reader hits the hard top. Prepending
+        // then preserving scrollTop is seamless only if there is runway left for
+        // the user's continued upward wheel/touch movement.
+        const olderPrefetchPx=Math.max(600,el.clientHeight*1.5);
+        if(_isSessionEndlessScrollEnabled()&&el.scrollTop<olderPrefetchPx && typeof _messagesTruncated!=='undefined' && _messagesTruncated && typeof _loadOlderMessages==='function'){
+          if(_recentMessageTouchScrollIntent()) _scheduleDeferredOlderMessagesLoad();
+          else _loadOlderMessages();
+        }
+      });
     });
   });
 })();
@@ -4477,7 +4509,7 @@ document.addEventListener('DOMContentLoaded',function(){
 });
 
 function _setMessageScrollToBottom(){
-  const el=$('messages');
+  const el=_messageScrollElement();
   if(!el) return;
   _programmaticScroll=true;_programmaticScrollSetAt=performance.now();
   el.scrollTop=el.scrollHeight;
@@ -4503,12 +4535,12 @@ function _setMessageScrollToBottom(){
   });
 }
 function _isMessagePaneNearBottom(threshold=250){
-  const el=$('messages');
+  const el=_messageScrollElement();
   if(!el) return false;
   return el.scrollHeight-el.scrollTop-el.clientHeight<=threshold;
 }
 function _messageBottomDistance(){
-  const el=$('messages');
+  const el=_messageScrollElement();
   if(!el) return 0;
   return el.scrollHeight-el.scrollTop-el.clientHeight;
 }
@@ -4554,7 +4586,7 @@ function _settleMessageScrollToBottom(force, explicit){
 
   if(force) return;
 
-  const el=document.getElementById('messages');
+  const el=_messageScrollElement();
   if(!el) return;
   // Observe the GROWING content node, not the scroll container. #messages is the
   // scroller but its box is fixed by the flex layout, so it never resizes — the
@@ -4613,7 +4645,7 @@ function _settleMessageScrollToBottom(force, explicit){
 
 function _settleFinalScroll(token){
   if(token!==_bottomSettleToken) return;
-  const el=document.getElementById('messages');
+  const el=_messageScrollElement();
   if(!el){ _programmaticScroll=false; return; }
   if(_messageUserUnpinned||!_scrollPinned||_recentNonMessageScrollIntent()||_recentMessageTouchScrollIntent()){
     _programmaticScroll=false;
@@ -9694,7 +9726,7 @@ function _projectLiveAnchorActivitySceneForStream(streamId, mode){
   }
 }
 function _prepareLiveAnchorScrollRebuildGuard(scrollSnapshot){
-  const messagesEl=$('messages');
+  const messagesEl=_messageScrollElement();
   if(!messagesEl||!scrollSnapshot) return {readerAwayFromBottom:false,release:null};
   const beforeBottomDistance=Math.max(0,messagesEl.scrollHeight-messagesEl.scrollTop-messagesEl.clientHeight);
   // Only treat the reader as away if they were ALREADY in a non-follow state.
@@ -11016,7 +11048,7 @@ function _toolArgsSnapshot(args, limit){
 }
 
 function _captureMessageScrollSnapshot(){
-  const el=$('messages');
+  const el=_messageScrollElement();
   if(!el) return null;
   const bottom=Math.max(0,el.scrollHeight-el.scrollTop-el.clientHeight);
   return {
@@ -11029,7 +11061,7 @@ function _captureMessageScrollSnapshot(){
   };
 }
 function _restoreMessageScrollSnapshot(snapshot){
-  const el=$('messages');
+  const el=_messageScrollElement();
   if(!el||!snapshot) return;
   const maxTop=Math.max(0,el.scrollHeight-el.clientHeight);
   let restoredViaAnchor=(snapshot.anchor&&typeof _restoreMessageViewportAnchor==='function')
@@ -11077,7 +11109,7 @@ function _restoreMessageScrollSnapshot(snapshot){
  * wipe-and-rebuild gap. The rAF callback restores CSS default afterward.
  */
 window._fixMobileScrollJank=function _fixMobileScrollJank(){
-  const el=document.getElementById('messages');
+  const el=_messageScrollElement();
   if(!el) return;
   // Desktop with a mouse: keep overflow-anchor:none (explicitly set by CSS).
   // Mobile touch devices only: temporarily suppress anchor re-selection.
@@ -11089,7 +11121,7 @@ window._fixMobileScrollJank=function _fixMobileScrollJank(){
 };
 
 function _restoreMessageScrollSnapshotSameFrame(snapshot){
-  const el=$('messages');
+  const el=_messageScrollElement();
   if(!el||!snapshot) return;
   let restoredViaAnchor=(snapshot.anchor&&typeof _restoreMessageViewportAnchor==='function')
     ? _restoreMessageViewportAnchor(snapshot.anchor,0)

--- a/static/ui.js
+++ b/static/ui.js
@@ -3857,6 +3857,14 @@ function _resetScrollDirectionTracker(){
   clearTimeout(_deferredOlderMessagesTimer);
   _deferredOlderMessagesTimer=0;
 }
+function _resetSessionSwitchScrollState(){
+  // Clear sticky manual-unpin and old scroll snapshot state before a fresh session
+  // lands in the renderer. This keeps the first meaningful paint on session switch
+  // pinned to the latest message unless same-session preserveScroll is explicitly
+  // requested.
+  _resetScrollDirectionTracker();
+  _resetStreamScrollFollow();
+}
 function _resetStreamScrollFollow(){
   _clearNewMessageScrollCue();
   _messageUserUnpinned=false;
@@ -3867,6 +3875,7 @@ function _resetStreamScrollFollow(){
 }
 if(typeof window!=='undefined'){
   window._resetScrollDirectionTracker=_resetScrollDirectionTracker;
+  window._resetSessionSwitchScrollState=_resetSessionSwitchScrollState;
   window._resetStreamScrollFollow=_resetStreamScrollFollow;
 }
 /* ── Pull-to-refresh for PWA standalone (Android) ── */
@@ -11141,7 +11150,11 @@ function _assistantTurnAnchorSettledFinalAnswer(message, content, context){
     return null;
   }
 }
-function _scrollAfterMessageRender(preserveScroll, scrollSnapshot){
+function _scrollAfterMessageRender(preserveScroll, scrollSnapshot, forceBottom){
+  if(forceBottom){
+    scrollToBottom();
+    return;
+  }
   // Terminal stream renders can happen after S.activeStreamId is cleared.
   // In that case, preserveScroll asks the normal pin-state helper to decide:
   // pinned users stay at bottom; users who manually scrolled up get their
@@ -11196,11 +11209,12 @@ function _maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualW
 
 function renderMessages(options){
   const preserveScroll=!!(options&&options.preserveScroll);
+  const forceBottom=!!(options&&options.freshSessionLoad);
   const virtualFallback=!!(options&&options._virtualFallback);
   // Capture the pre-wipe scroll position when preserving OR when the reader has
   // manually unpinned; both need to restore the reader's position after the DOM
   // rebuild rather than snap to the bottom. (Codex #4006 r3 follow-up.)
-  const scrollSnapshot=(preserveScroll||_messageUserUnpinned)?_captureMessageScrollSnapshot():null;
+  const scrollSnapshot=(!forceBottom&&(preserveScroll||_messageUserUnpinned))?_captureMessageScrollSnapshot():null;
   const inner=$('msgInner');
   const sid=S.session?S.session.session_id:null;
   const msgCount=S.messages.length;
@@ -11255,7 +11269,7 @@ function renderMessages(options){
       _rehydrateTransparentStreamDom(inner);
       _wireMessageWindowLoadEarlierButton();
       if(typeof _applySessionNavigationPrefs==='function') _applySessionNavigationPrefs();
-      _scrollAfterMessageRender(preserveScroll, scrollSnapshot);
+      _scrollAfterMessageRender(preserveScroll, scrollSnapshot, forceBottom);
       if(_maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualWindow)) return;
       _updateMessageVirtualMeasurements(renderVisWithIdx, renderVisibleIdxs, virtualWindow);
       requestAnimationFrame(()=>postProcessRenderedMessages(inner));
@@ -12508,7 +12522,7 @@ function renderMessages(options){
   // (tool completion, session switch) must not override the user's scroll position.
   // scrollIfPinned() respects _scrollPinned, so it's a no-op if user scrolled up.
   if(typeof _syncLiveRunStatusAfterRender==='function') _syncLiveRunStatusAfterRender();
-  _scrollAfterMessageRender(preserveScroll, scrollSnapshot);
+  _scrollAfterMessageRender(preserveScroll, scrollSnapshot, forceBottom);
   if(_maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualWindow)) return;
   // Apply syntax highlighting after DOM is built
   requestAnimationFrame(()=>postProcessRenderedMessages(inner));

--- a/tests/test_issue1360_streaming_scroll_hardening.py
+++ b/tests/test_issue1360_streaming_scroll_hardening.py
@@ -111,6 +111,9 @@ def test_idle_render_preserves_manual_unpin_until_explicit_bottom():
         "idle render must restore the manually-unpinned viewport instead of "
         "falling through to scrollToBottom()."
     )
-    manual_unpin_block = scroll_helper[scroll_helper.index("if(_messageUserUnpinned)") : scroll_helper.index("scrollToBottom();")]
+    manual_unpin_start = scroll_helper.index("if(_messageUserUnpinned)")
+    manual_unpin_end = scroll_helper.find("scrollToBottom();", manual_unpin_start + 1)
+    assert manual_unpin_end != -1, "manual unpin block must include a final scrollToBottom fallback"
+    manual_unpin_block = scroll_helper[manual_unpin_start:manual_unpin_end]
     assert "_restoreMessageScrollSnapshot(scrollSnapshot);" in manual_unpin_block
     assert "_maybeShowNewMessageScrollCue(scrollSnapshot);" in manual_unpin_block

--- a/tests/test_issue1690_scroll_completion.py
+++ b/tests/test_issue1690_scroll_completion.py
@@ -55,8 +55,8 @@ def test_render_messages_preserve_scroll_option_uses_user_pin_state_not_stream_l
 
     assert "function renderMessages(options)" in render_body
     assert "const preserveScroll=!!(options&&options.preserveScroll);" in render_body
-    assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in render_body
-    assert "const scrollSnapshot=(preserveScroll||_messageUserUnpinned)?_captureMessageScrollSnapshot():null" in render_body
+    assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot, forceBottom);" in render_body
+    assert "const scrollSnapshot=(!forceBottom&&(preserveScroll||_messageUserUnpinned))?_captureMessageScrollSnapshot():null" in render_body
     assert "if(preserveScroll){" in scroll_helper
     # #4124: a reader clearly away from the bottom (>250px) is treated as an active
     # reading position, so the forced follow-to-bottom is gated behind it.
@@ -73,7 +73,7 @@ def test_cached_render_path_uses_same_scroll_policy_as_fresh_render():
     render_body = _function_body(UI_JS, "renderMessages")
     cached_branch = render_body[render_body.index("if(sid&&sid!==_sessionHtmlCacheSid") : render_body.index("const compressionState=")]
 
-    assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in cached_branch
+    assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot, forceBottom);" in cached_branch
     assert "if(S.activeStreamId){scrollIfPinned();}else{scrollToBottom();}" not in cached_branch
 
 
@@ -81,13 +81,11 @@ def test_session_switch_and_idle_session_load_keep_default_bottom_pin_behavior()
     load_session = _function_body(SESSIONS_JS, "loadSession")
     idle_branch = load_session[load_session.index("}else{\n      S.busy=false;") : load_session.index("// Sync context usage indicator")]
 
-    # #3326: the idle branch now renders with a CONDITIONAL preserveScroll —
-    # `renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined)`.
-    # For a normal cross-session idle load (currentSid!==sid) sameSessionForceReload
-    # is false, so the arg is undefined and the default bottom-pin behavior (#1690)
-    # is unchanged. preserveScroll only applies to a same-session external
-    # force-refresh (#3239), which is a different code path from #1690's scenario.
-    assert "syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);" in idle_branch
+    # #3326: the idle branch renders with a CONDITIONAL preserveScroll for
+    # same-session force-refreshes. Fresh session switches now pass
+    # freshSessionLoad so they intentionally bottom-pin after the new transcript
+    # renders, while same-session refreshes keep preserveScroll.
+    assert "syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:(freshSessionSwitch?{freshSessionLoad:true}:undefined));" in idle_branch
     # The idle path must NOT unconditionally preserveScroll — it stays bottom-pinned
     # for cross-session loads. Guard against a regression to an always-on preserve.
     assert "renderMessages({preserveScroll:true})" not in idle_branch

--- a/tests/test_issue3319_pinned_scroll_jump.py
+++ b/tests/test_issue3319_pinned_scroll_jump.py
@@ -37,3 +37,17 @@ def test_scroll_if_pinned_recovers_when_far_from_bottom():
     assert "_setMessageScrollToBottom();" in fn
     assert fn.index("_messageBottomDistance()>500") < fn.index("_settleMessageScrollToBottom(false)")
 
+
+def test_scroll_if_pinned_treats_missed_upward_scroll_as_unpinned():
+    fn = _extract_fn(UI_JS, "scrollIfPinned")
+
+    movement_idx = fn.index("el.scrollTop<_lastScrollTop-5")
+    unpin_idx = fn.index("_messageUserUnpinned=true", movement_idx)
+    return_idx = fn.index("return;", unpin_idx)
+    follow_idx = fn.index("_messageBottomDistance()>500")
+
+    assert "Number.isFinite(_lastScrollTop)" in fn
+    assert "_scrollPinned=false" in fn[movement_idx:return_idx]
+    assert "_nearBottomCount=0" in fn[movement_idx:return_idx]
+    assert movement_idx < unpin_idx < return_idx < follow_idx
+

--- a/tests/test_issue500_message_list_virtualization.py
+++ b/tests/test_issue500_message_list_virtualization.py
@@ -1080,7 +1080,10 @@ def test_scroll_listener_guards_programmatic_scroll_before_marking_active():
     in the scroll listener so that programmatic scrolls (e.g. from
     _compensateScrollForMeasurementDelta) do not arm the 150ms settle timer."""
     js = UI_JS_PATH.read_text(encoding="utf-8")
-    listener_start = js.index("el.addEventListener('scroll',()=>{")
+    listener_start = js.find("el.addEventListener('scroll',()=>{")
+    if listener_start < 0:
+        listener_start = js.find("el.addEventListener('scroll',function(){")
+    assert listener_start != -1, "transcript scroll listener must exist"
     listener_end = js.index("});", listener_start)
     listener_body = js[listener_start:listener_end]
 

--- a/tests/test_issue677.py
+++ b/tests/test_issue677.py
@@ -40,7 +40,7 @@ class TestScrollPinningFix:
             "unconditional scrollToBottom() overrides user scroll position (#677)"
         )
         # scrollIfPinned must be called through the renderMessages scroll policy (stream path)
-        assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in rm_body
+        assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot, forceBottom);" in rm_body
         assert "scrollIfPinned()" in helper_body, (
             "renderMessages() must call scrollIfPinned() during streaming (#677)"
         )

--- a/tests/test_issue734_message_windowing.py
+++ b/tests/test_issue734_message_windowing.py
@@ -28,7 +28,7 @@ def test_load_earlier_only_pages_server_history_and_preserves_scroll():
 
 
 def test_windowed_render_keeps_streaming_and_tool_activity_anchored_to_rendered_messages():
-    assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in UI_JS
+    assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot, forceBottom);" in UI_JS
     assert "const assistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);" in UI_JS
     assert "if(aIdx<assistantIdxs[0]) continue;" in UI_JS
     assert "const renderedAssistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);" in UI_JS

--- a/tests/test_issue_session_switch_jump_to_bottom.py
+++ b/tests/test_issue_session_switch_jump_to_bottom.py
@@ -58,6 +58,43 @@ def test_fresh_session_render_forces_bottom_without_snapshot_restore():
     assert "const scrollSnapshot=(!forceBottom&&(preserveScroll||_messageUserUnpinned))?_captureMessageScrollSnapshot():null;" in UI_JS
 
 
+def test_message_scroll_owner_prefers_effective_scrollable_transcript_element():
+    """Mobile layouts can make #msgInner the actual scroller while #messages is fixed."""
+    helper_start = UI_JS.index("function _messageScrollElement")
+    helper_end = UI_JS.index("function _cancelBottomSettle", helper_start)
+    helper = UI_JS[helper_start:helper_end]
+
+    assert "const messages=$('messages');" in helper
+    assert "const msgInner=$('msgInner');" in helper
+    assert "messages.scrollHeight>messages.clientHeight+1" in helper
+    assert "msgInner.scrollHeight>msgInner.clientHeight+1" in helper
+    assert "if(messagesScrollable) return messages;" in helper
+    assert "if(msgInnerScrollable) return msgInner;" in helper
+    assert "return msgInner||messages;" in helper
+
+
+def test_bottom_helpers_use_canonical_message_scroll_owner():
+    """Force-bottom and near-bottom logic must target the real mobile/desktop scroller."""
+    for signature in (
+        "function _setMessageScrollToBottom",
+        "function _isMessagePaneNearBottom",
+        "function _messageBottomDistance",
+        "function _captureMessageScrollSnapshot",
+        "function _restoreMessageScrollSnapshot",
+    ):
+        start = UI_JS.index(signature)
+        end = UI_JS.index("function ", start + len(signature))
+        body = UI_JS[start:end]
+        assert "_messageScrollElement()" in body, f"{signature} should use the canonical scroll owner"
+
+
+def test_scroll_listener_binds_both_possible_scroll_owners():
+    """User scroll intent must be heard from the same element that bottom-follow scrolls."""
+    assert "const bindableScrollElements=[_messageScrollElement(),$('messages'),$('msgInner')]" in UI_JS
+    assert "bindableScrollElements.forEach(el=>" in UI_JS
+    assert "el.addEventListener('scroll',function()" in UI_JS
+
+
 def test_session_switch_scroll_helpers_are_scoped_to_real_switches():
     """Scroll reset helper call should remain conditional on currentSid !== sid."""
     block = _extract_load_session_block()

--- a/tests/test_issue_session_switch_jump_to_bottom.py
+++ b/tests/test_issue_session_switch_jump_to_bottom.py
@@ -1,0 +1,69 @@
+"""Regression checks for session-switch scroll reset behavior.
+
+These tests enforce that cross-session navigation uses a named helper to clear
+sticky scroll state before rendering the new transcript, while keeping
+same-session force-reload preserveScroll behavior intact.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _extract_load_session_block():
+    start = SESSIONS_JS.index("async function loadSession(sid){")
+    end = SESSIONS_JS.index("  // Sync context usage indicator from session data", start)
+    return SESSIONS_JS[start:end]
+
+
+def test_session_switch_uses_named_scroll_reset_helper():
+    """Fresh cross-session switches must call a named helper to reset sticky state."""
+    assert "function _resetSessionSwitchScrollState" in UI_JS, (
+        "ui.js should expose a dedicated _resetSessionSwitchScrollState() helper "
+        "for session-switch fresh-load scroll resets."
+    )
+    assert "window._resetSessionSwitchScrollState=_resetSessionSwitchScrollState" in UI_JS, (
+        "ui.js should export _resetSessionSwitchScrollState for cross-module use."
+    )
+    block = _extract_load_session_block()
+    assert "_resetSessionSwitchScrollState();" in block, (
+        "loadSession() should invoke _resetSessionSwitchScrollState() on real session "
+        "switches (currentSid !== sid)."
+    )
+
+
+def test_session_switch_renders_new_session_without_preserve_scroll():
+    """Fresh session renders must stay on bottom unless same-session preserveScroll is requested."""
+    block = _extract_load_session_block()
+    explicit_preserve_calls = block.count("renderMessages({preserveScroll:true})")
+    assert explicit_preserve_calls == 0, (
+        "renderMessages for session switch must not force preserveScroll for new sessions."
+    )
+    assert "freshSessionSwitch?{freshSessionLoad:true}:undefined" in block, (
+        "fresh session switches should render with freshSessionLoad:true so the "
+        "post-render scroll path explicitly lands at the bottom."
+    )
+    assert "sameSessionForceReload?{preserveScroll:true}:" in block, (
+        "same-session force reload behavior should still pass preserveScroll:true when "
+        "sameSessionForceReload is true."
+    )
+
+
+def test_fresh_session_render_forces_bottom_without_snapshot_restore():
+    """freshSessionLoad must bypass stale snapshot restoration and force bottom."""
+    assert "const forceBottom=!!(options&&options.freshSessionLoad);" in UI_JS
+    assert "if(forceBottom){\n    scrollToBottom();\n    return;\n  }" in UI_JS
+    assert "const scrollSnapshot=(!forceBottom&&(preserveScroll||_messageUserUnpinned))?_captureMessageScrollSnapshot():null;" in UI_JS
+
+
+def test_session_switch_scroll_helpers_are_scoped_to_real_switches():
+    """Scroll reset helper call should remain conditional on currentSid !== sid."""
+    block = _extract_load_session_block()
+    marker = "if (currentSid !== sid)"
+    helper_idx = block.find("_resetSessionSwitchScrollState()")
+    assert helper_idx >= 0, "expected reset helper invocation in loadSession()"
+    assert block.rfind(marker, 0, helper_idx) < helper_idx, (
+        "_resetSessionSwitchScrollState() must be inside a real-switch guard (currentSid !== sid)."
+    )

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -87,8 +87,51 @@ def _render(driver_path, markdown: str) -> str:
     return result.stdout
 
 
+def test_long_render_cache_key_hashes_full_content_to_avoid_template_collisions():
+    """Long templated messages can share length, prefix, and suffix while differing in the middle."""
+    driver = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[1], 'utf8');
+global.window = { _renderUserMarkdown: false };
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+eval(extractFunc('_renderCacheTextHash'));
+eval(extractFunc('_renderCacheKey'));
+const prefix = 'same twenty char pre';
+const suffix = 'same twenty char end';
+const a = prefix + ' A'.repeat(320) + suffix;
+const b = prefix + ' B'.repeat(320) + suffix;
+if (a.length !== b.length) throw new Error('fixture length mismatch');
+if (a.slice(0,20) !== b.slice(0,20)) throw new Error('fixture prefix mismatch');
+if (a.slice(-20) !== b.slice(-20)) throw new Error('fixture suffix mismatch');
+process.stdout.write(JSON.stringify({ a: _renderCacheKey(a, false), b: _renderCacheKey(b, false) }));
+"""
+    node = NODE
+    assert node is not None
+    result = subprocess.run(
+        [node, "-e", driver, str(UI_JS_PATH)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert '"a"' in result.stdout and '"b"' in result.stdout
+    assert result.stdout.split('"a":"', 1)[1].split('"', 1)[0] != result.stdout.split('"b":"', 1)[1].split('"', 1)[0]
+
 
 class TestSessionInternalLinks:
+
     """Drive renderMd() so session:// hardening covers the real sanitizer path."""
 
     def test_session_scheme_renders_same_origin_internal_anchor(self, driver_path):

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -6,6 +6,21 @@ MESSAGES_SRC = (ROOT / "static" / "messages.js").read_text()
 SESSIONS_SRC = (ROOT / "static" / "sessions.js").read_text()
 
 
+def _extract_function(src: str, name: str) -> str:
+    marker = f"function {name}("
+    idx = src.find(marker)
+    assert idx != -1, f"{name} not found"
+    depth = 0
+    for i, ch in enumerate(src[idx:], idx):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[idx : i + 1]
+    raise AssertionError(f"Could not extract {name}")
+
+
 def test_reattach_path_uses_replay_when_status_reports_journal():
     reattach_pos = MESSAGES_SRC.index("let replayOnly=false;")
     block = MESSAGES_SRC[reattach_pos : reattach_pos + 1200]
@@ -113,8 +128,7 @@ def test_run_journal_cursor_tracks_every_long_task_timeline_event():
 def test_server_runtime_journal_snapshot_restores_structured_inflight_state():
     helper_pos = SESSIONS_SRC.index("function _serverLiveSnapshotToolId")
     helper_block = SESSIONS_SRC[helper_pos : helper_pos + 3600]
-    load_pos = SESSIONS_SRC.index("async function loadSession")
-    load_block = SESSIONS_SRC[load_pos : load_pos + 20000]
+    load_block = _extract_function(SESSIONS_SRC, "loadSession")
 
     assert "runtime_journal_snapshot" in load_block
     assert "_serverLiveSnapshotInflight(S.session.runtime_journal_snapshot" in load_block

--- a/tests/test_session_channel_option_x.py
+++ b/tests/test_session_channel_option_x.py
@@ -846,9 +846,24 @@ def test_load_session_rearms_stream_on_every_early_return():
         "helper must (re)arm startSessionStream for the currently-shown S.session"
     )
 
-    # Isolate the loadSession body.
+    # Isolate the full loadSession body. Keep this brace-aware rather than using
+    # a fixed character window; loadSession legitimately grows as session-load
+    # state invariants are added, and the fetch-error catch lives late in the
+    # function.
     fn_ix = js.index("async function loadSession(")
-    body = js[fn_ix:fn_ix + 12000]
+    brace_ix = js.index("{", fn_ix)
+    depth = 0
+    end_ix = None
+    for idx, ch in enumerate(js[brace_ix:], brace_ix):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                end_ix = idx + 1
+                break
+    assert end_ix is not None, "loadSession body did not terminate"
+    body = js[fn_ix:end_ix]
 
     # The unconditional teardown must still be there (this is what creates the
     # dead-stream window the re-arm closes).

--- a/tests/test_streaming_race_fix.py
+++ b/tests/test_streaming_race_fix.py
@@ -25,6 +25,26 @@ def read(rel):
     return (REPO / rel).read_text(encoding='utf-8')
 
 
+def _function_body(src: str, name: str) -> str:
+    marker = f"function {name}"
+    start = src.find(marker)
+    assert start >= 0, f"{name} not found"
+    # Some JS signatures contain default object literals, e.g. options={}; skip
+    # those and start at the function-body brace.
+    signature_end = src.find("){", start)
+    brace = signature_end + 1 if signature_end >= 0 else src.find("{", start)
+    assert brace >= 0, f"{name} body not found"
+    depth = 0
+    for i, ch in enumerate(src[brace:], brace):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise AssertionError(f"{name} body did not terminate")
+
+
 class TestStreamFinalized:
     """_streamFinalized flag and rAF cancellation."""
 
@@ -227,3 +247,39 @@ class TestReconnectAccumulatorPreservation:
         assert 'S.session&&S.session.session_id' in fn
         assert '!==activeSid' in fn
         assert fn.index('!==activeSid') < fn.index('api(`/api/chat/stream/status?stream_id=')
+
+
+class TestCrossSessionStreamScrollIsolation:
+    """Background stream callbacks must not scroll the currently viewed session."""
+
+    def test_scroll_helper_requires_current_session_and_stream(self):
+        src = read('static/messages.js')
+        assert "function _isLivePaneCurrent(){" in src
+        assert "return _isActiveSession() && S.activeStreamId===streamId;" in src
+        assert "function _scrollIfLivePanePinned(){" in src
+        helper_idx = src.index("function _scrollIfLivePanePinned(){")
+        guard_idx = src.index("if(!_isLivePaneCurrent()) return;", helper_idx)
+        scroll_idx = src.index("scrollIfPinned();", helper_idx)
+        assert guard_idx < scroll_idx, (
+            "live stream callbacks must verify the visible session+stream before scrolling"
+        )
+
+    def test_attach_live_stream_has_no_raw_scroll_if_pinned_call_sites(self):
+        src = read('static/messages.js')
+        attach = _function_body(src, 'attachLiveStream')
+        assert attach.count("scrollIfPinned();") == 1, (
+            "attachLiveStream must route stream-triggered scrolls through the "
+            "current-pane helper so background streams cannot scroll another session"
+        )
+        assert "_scrollIfLivePanePinned();" in attach
+
+    def test_deferred_render_bails_before_dom_writes_after_session_switch(self):
+        src = read('static/messages.js')
+        schedule_idx = src.index("function _scheduleRender")
+        do_render_idx = src.index("const _doRender=()=>{", schedule_idx)
+        current_guard_idx = src.index("if(!_isLivePaneCurrent()) return;", do_render_idx)
+        dom_write_idx = src.index("if(typeof window._fixMobileScrollJank==='function')", do_render_idx)
+        assert current_guard_idx < dom_write_idx, (
+            "a delayed token render that fires after session switch must exit before "
+            "mutating DOM or scroll state in the newly viewed session"
+        )

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -115,6 +115,15 @@ def test_external_active_refresh_defers_while_reader_is_manually_unpinned():
     assert "await loadSession(sid, {force:true, externalRefreshReason:reason||'poll'});" in refresh
 
 
+def test_reader_unpinned_uses_physical_distance_from_bottom():
+    reader = _function_body(UI_JS, "function _isMessageReaderUnpinned")
+
+    assert "if(_messageUserUnpinned) return true;" in reader
+    assert "_messageScrollElement" in reader
+    assert "const bottomDistance=el.scrollHeight-el.scrollTop-el.clientHeight;" in reader
+    assert "return bottomDistance>250;" in reader
+
+
 def test_session_switch_clears_deferred_active_refresh_reason():
     load = _function_body(SESSIONS_JS, "async function loadSession")
     assert "function _clearDeferredActiveSessionExternalRefresh()" in SESSIONS_JS

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -143,9 +143,9 @@ def test_preserve_scroll_restores_unpinned_viewport_after_dom_rebuild():
     capture = _function_body(UI_JS, "function _captureMessageScrollSnapshot")
     restore = _function_body(UI_JS, "function _restoreMessageScrollSnapshot")
 
-    snapshot_idx = render.index("const scrollSnapshot=(preserveScroll||_messageUserUnpinned)?_captureMessageScrollSnapshot():null")
+    snapshot_idx = render.index("const scrollSnapshot=(!forceBottom&&(preserveScroll||_messageUserUnpinned))?_captureMessageScrollSnapshot():null")
     inner_idx = render.index("const inner=$('msgInner')")
-    final_scroll_idx = render.rindex("_scrollAfterMessageRender(preserveScroll, scrollSnapshot)")
+    final_scroll_idx = render.rindex("_scrollAfterMessageRender(preserveScroll, scrollSnapshot, forceBottom)")
 
     assert snapshot_idx < inner_idx < final_scroll_idx, (
         "renderMessages({preserveScroll:true}) must capture #messages.scrollTop before "

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -135,7 +135,7 @@ def test_same_session_force_reload_keeps_loaded_transcript_width_hint():
     reset_pos = load_body.index("S.messages = [];", clear_pos)
     assert capture_pos < clear_pos < reset_pos
     assert "const sameSessionForceReload = forceReload && currentSid===sid;" in load_body
-    assert "renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined)" in load_body
+    assert "renderMessages(sameSessionForceReload?{preserveScroll:true}:(freshSessionSwitch?{freshSessionLoad:true}:undefined))" in load_body
 
 
 def test_same_width_force_reload_invalidates_visible_message_cache():


### PR DESCRIPTION
## Thinking Path

- Opening a conversation should land on the latest reply, not restore stale scroll state from a previously viewed transcript.
- Mobile layouts can make the transcript's effective scroll owner differ from the desktop `#messages` container, so capture/restore/follow logic needs one consistent owner contract.
- Background streams should not be able to mutate scroll position in a different session the user is currently reading.
- Same-session refresh/reconcile should preserve the reader's viewport whenever the transcript is physically away from bottom, even if sticky unpin state missed the scroll gesture.
- The narrow fix is to split session-switch behavior from same-session refresh behavior: real switches force latest/bottom, while same-session updates preserve reader position.

## What Changed

- Added a fresh-session-load path so real session switches reset stale scroll-follow state and force the transcript to latest/bottom after render.
- Canonicalized transcript scroll helpers around the effective scroll owner, covering mobile cases where `#msgInner` is the active scroller.
- Guarded live-stream scroll callbacks so a background stream cannot scroll the currently viewed different session.
- Made reader-away detection geometry-aware so external refresh defers when the visible transcript is physically away from bottom.
- Hardened long-message render cache keys to avoid stale rendered bodies when templated messages share length/prefix/suffix.
- Added focused regression coverage for session-switch bottoming, scroll-owner behavior, stream callback isolation, and same-session refresh preservation.

## Why It Matters

- Fixes conversation open/switch flows landing at the first message instead of the latest reply.
- Keeps mobile transcript scroll behavior aligned with the actual scroller instead of desktop-only assumptions.
- Prevents active background streams from yanking the visible transcript while the user is reading another session.
- Preserves same-session reading position during refresh/reconcile paths without weakening normal auto-follow behavior.

Refs #4859

## Verification

Targeted and formerly failing coverage:

`./scripts/test.sh tests/test_issue_session_switch_jump_to_bottom.py tests/test_tars_scroll_reset_regressions.py tests/test_issue4006_auto_scroll_follow_default.py tests/test_issue1731_upward_scroll_unpins.py tests/test_issue4856_android_scroll_regression.py tests/test_issue3470_touch_unpin_streaming_scroll.py tests/test_issue3479_ios_stream_scroll_jump.py tests/test_issue4295_midstream_scroll_anchor.py tests/test_issue4295_scroll_pin_reentry.py tests/test_streaming_race_fix.py tests/test_webui_external_refresh_frontend.py tests/test_renderer_js_behaviour.py tests/test_issue2543_named_context_session_switch.py tests/test_issue3306_loadsession_carry_forward.py tests/test_regressions.py tests/test_issue_new_chat_draft_restore.py tests/test_parallel_session_switch.py -q`

Result: `258 passed, 1 skipped`

Broader JS-referencing surface:

`./scripts/test.sh $(grep -rlE --include='*.py' "static/(ui|sessions|messages)\\.js" tests/ | sort) tests/test_issue_new_chat_draft_restore.py tests/test_parallel_session_switch.py -q`

Result: `2039 passed, 15 skipped, 6 failed`

The 6 failures are all in `tests/test_update_banner_fixes.py`. That file passes in isolation:

`./scripts/test.sh tests/test_update_banner_fixes.py -q`

Result: `85 passed`

Syntax / hygiene:

`node --check static/ui.js`

`node --check static/sessions.js`

`node --check static/messages.js`

`git diff --check origin/master...HEAD`

Result: all passed.

## Risks / Follow-ups

- This is opened as a draft for maintainer review because the branch touches several scroll-state surfaces.
- The broad JS-referencing test command exposes pre-existing order-pollution in update-banner tests when run in one shard; those tests pass in isolation and this branch does not touch update mechanics.
- Real-device mobile browser smoke is still useful before marking ready, especially for Android wrapper/PWA scroll behavior.

## Model Used

- OpenAI / GPT-5.5 for implementation orchestration and verification.
- OpenAI / GPT-5.3 Codex Spark via OpenCode for focused implementation edits.
- Anthropic / Claude Opus 4.8 (`xhigh`) for independent pre-PR review and sign-off.
