### PR TITLE
fix(#4622): restore tool-card result body on the settled rebuild path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Terminal tool cards keep their full output, and patch/edit cards keep their diff, after a turn settles in the Transparent Stream / Worklog view.** While a turn streamed, the tool cards showed their complete output; once the stream settled (or on reload/reconnect), terminal cards collapsed to just the `$ command` line with no stdout and patch/edit cards showed their input fields with no rendered diff. The settled rebuild reconstructs each tool row from the persisted `messages[].tool_calls` (state.db / sidecar), which can carry only a short preview — or, on a cold/paginated load, nothing — for the result body; the live in-memory tool call still held the full output at settle time, but the merge dropped it (it skipped the matching live entry instead of restoring the missing body onto the surviving settled row). The merge now restores the full result body, command, and input args from the matched live tool call when the settled row is missing them (without clobbering a genuinely persisted value), so the rebuilt card shows the complete terminal stdout (with the **Show more** expander and the transparent **Output** / **Full** tabs), and renders the patch/edit diff. (#4622)
+
 ## [v0.51.646] — 2026-06-25 — Release XB (mobile transcript scrolls again)
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -2560,16 +2560,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const payload=(row.payload&&typeof row.payload==='object')?row.payload:(row.payload={});
     let enriched=false;
     const _empty=v=>v===undefined||v===null||v==='';
-    // Body/result fields that buildToolCard reads to render output + detect diffs.
+    // Result body: _anchorSceneToolCallFromRow renders tool.snippet||payload.snippet
+    // (||payload.result||payload.output) as the card output + diff source, so
+    // restore the snippet onto both tool+payload when the settled row has none.
     const liveSnippet=_anchorSceneStringPayload(live.snippet||live.result||live.output);
-    if(liveSnippet&&_empty(tool.snippet)&&_empty(payload.snippet)&&_empty(payload.result)&&_empty(payload.output)){
+    if(liveSnippet&&_empty(tool.snippet)&&_empty(payload.snippet)){
       tool.snippet=liveSnippet; payload.snippet=liveSnippet; enriched=true;
     }
-    const liveResult=_anchorSceneSafePayload(live.result);
-    if(liveResult!==undefined&&liveResult!==null&&_empty(tool.result)){ tool.result=liveResult; }
-    const liveOutput=_anchorSceneSafePayload(live.output);
-    if(liveOutput!==undefined&&liveOutput!==null&&_empty(tool.output)){ tool.output=liveOutput; }
-    // Command (shell detail-lead) + args (diff reconstruction inputs).
+    // Command (shell detail-lead) + args (diff/input reconstruction, the "Full" tab).
     const liveCommand=_anchorSceneStringPayload(live.command||live.raw_command);
     if(liveCommand&&_empty(tool.command)&&_empty(payload.command)){
       tool.command=liveCommand; payload.command=liveCommand; enriched=true;

--- a/static/messages.js
+++ b/static/messages.js
@@ -2545,6 +2545,42 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(!message||typeof message!=='object') return '';
     return String(message.reasoning||message._reasoning||message.reasoning_content||message.thinking||'');
   }
+  // #4622: a settled tool row built from messages[].tool_calls (state.db/sidecar)
+  // can lack the result body — terminal stdout, or the diff/output that a
+  // patch/edit card renders — because the persisted row carries only a short
+  // preview (or, on a cold/paginated load, nothing). The full body lives on the
+  // live S.toolCalls entry at settle time. When a settled row and a live call
+  // match by tool id, restore the missing body fields from the live call onto
+  // the settled row's tool+payload (only when the settled value is empty — never
+  // clobber a genuine persisted body), so the rebuilt card shows full output +
+  // the Show-more expander + the rendered diff. Returns true if it enriched.
+  function _enrichSettledToolRowBodyFromLive(row, live){
+    if(!row||typeof row!=='object'||!live||typeof live!=='object') return false;
+    const tool=(row.tool&&typeof row.tool==='object')?row.tool:(row.tool={});
+    const payload=(row.payload&&typeof row.payload==='object')?row.payload:(row.payload={});
+    let enriched=false;
+    const _empty=v=>v===undefined||v===null||v==='';
+    // Body/result fields that buildToolCard reads to render output + detect diffs.
+    const liveSnippet=_anchorSceneStringPayload(live.snippet||live.result||live.output);
+    if(liveSnippet&&_empty(tool.snippet)&&_empty(payload.snippet)&&_empty(payload.result)&&_empty(payload.output)){
+      tool.snippet=liveSnippet; payload.snippet=liveSnippet; enriched=true;
+    }
+    const liveResult=_anchorSceneSafePayload(live.result);
+    if(liveResult!==undefined&&liveResult!==null&&_empty(tool.result)){ tool.result=liveResult; }
+    const liveOutput=_anchorSceneSafePayload(live.output);
+    if(liveOutput!==undefined&&liveOutput!==null&&_empty(tool.output)){ tool.output=liveOutput; }
+    // Command (shell detail-lead) + args (diff reconstruction inputs).
+    const liveCommand=_anchorSceneStringPayload(live.command||live.raw_command);
+    if(liveCommand&&_empty(tool.command)&&_empty(payload.command)){
+      tool.command=liveCommand; payload.command=liveCommand; enriched=true;
+    }
+    const liveArgs=(live.args&&typeof live.args==='object')?live.args:null;
+    const argsEmpty=o=>!o||typeof o!=='object'||Object.keys(o).length===0;
+    if(liveArgs&&argsEmpty(tool.args)&&argsEmpty(payload.args)){
+      tool.args={...liveArgs}; payload.args={...liveArgs}; enriched=true;
+    }
+    return enriched;
+  }
   function _anchorSceneRowsByMessageIndex(messages, turnStart, lastAsstIndex){
     const byIdx=new Map();
     const add=(idx,row)=>{
@@ -2577,21 +2613,30 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(Array.isArray(message.tool_calls)) messageTools.push(...message.tool_calls);
       if(Array.isArray(message._partial_tool_calls)) messageTools.push(...message._partial_tool_calls);
       const seenToolIds=new Set();
+      const rowByToolId=new Map();
       for(const tool of messageTools){
         const row=_anchorSceneToolRowFromCall(tool,0,idx);
         pool.push({...row,_phase:1,_encounter:encounter++});
         const tid=row.tool_call_id||(row.tool&&row.tool.id);
-        if(tid) seenToolIds.add(tid);
+        if(tid){ seenToolIds.add(tid); rowByToolId.set(tid,row); }
       }
-      // Merge S.toolCalls for this index, dedup by tool id
+      // Merge S.toolCalls for this index, dedup by tool id. When a live call
+      // matches a settled row already in the pool, don't just skip it —
+      // restore any result body the settled row is missing (#4622): the live
+      // S.toolCalls entry carries the full terminal output / patch diff that the
+      // persisted state.db row may have dropped to a short preview or nothing.
       for(const tool of (toolsByIdx.get(idx)||[])){
         if(!tool||typeof tool!=='object') continue;
         const toolIdx=Number(tool.assistant_msg_idx);
         if(!Number.isFinite(toolIdx)||toolIdx!==idx) continue;
         const row=_anchorSceneToolRowFromCall(tool,0,idx);
         const tid=row.tool_call_id||(row.tool&&row.tool.id);
-        if(tid&&seenToolIds.has(tid)) continue;
-        if(tid) seenToolIds.add(tid);
+        if(tid&&seenToolIds.has(tid)){
+          const existing=rowByToolId.get(tid);
+          if(existing) _enrichSettledToolRowBodyFromLive(existing, tool);
+          continue;
+        }
+        if(tid){ seenToolIds.add(tid); rowByToolId.set(tid,row); }
         pool.push({...row,_phase:1,_encounter:encounter++});
       }
       // Stable sort by (phase, started_at, encounter)

--- a/tests/test_issue4622_settled_toolcard_body.py
+++ b/tests/test_issue4622_settled_toolcard_body.py
@@ -1,0 +1,242 @@
+"""Regression coverage for #4622: settled tool cards lose their output body.
+
+In the Transparent Stream / Worklog view, a terminal tool card stopped showing
+its stdout and a patch/edit card stopped rendering its diff *after the stream
+settled* (live cards were fine). The settled rebuild
+(`_anchorSceneRowsByMessageIndex`) builds each tool row from
+`messages[].tool_calls` (state.db / sidecar), which can carry only a short
+preview — or, on a cold/paginated load, nothing — for the result body. The full
+output lives on the live `S.toolCalls` entry at settle time, but the dedup loop
+*skipped* the matching live entry instead of restoring the missing body onto the
+surviving settled row.
+
+This drives the REAL settled render chain end-to-end:
+  _anchorSceneRowsByMessageIndex (messages.js)
+    -> _anchorSceneToolRowFromCall (messages.js)        # settled row
+    -> _enrichSettledToolRowBodyFromLive (messages.js)  # the fix
+  -> _anchorSceneToolCallFromRow (ui.js, settled)       # the `tc` buildToolCard consumes
+
+`tc.snippet` is what buildToolCard renders as the output body (full copy in the
+Show-more `data-full`) and what the transparent "Output" tab shows; `tc.args` is
+the detailed-input "Full" tab. Asserting on `tc` pins all three views without a
+DOM.
+
+The prior #4625 guard only exercised the LIVE `buildToolCard` path, which is why
+it stayed green while the settled path regressed — these tests MUST drive the
+settled rebuild.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+MESSAGES_JS = REPO_ROOT / "static" / "messages.js"
+UI_JS = REPO_ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+# Driver: extract the real settled-render functions from messages.js + ui.js by
+# brace-matching, run them in node with the closure vars they reference, drive
+# _anchorSceneRowsByMessageIndex -> _anchorSceneToolCallFromRow, and emit the
+# `tc` object each settled tool card would be built from.
+_DRIVER_SRC = r"""
+'use strict';
+const fs = require('fs');
+const mSrc = fs.readFileSync(process.argv[2], 'utf8');
+const uSrc = fs.readFileSync(process.argv[3], 'utf8');
+function extractFunc(src, name) {
+  const re = new RegExp('function\\s+' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start), depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++; else if (src[i] === '}') depth--; i++;
+  }
+  return src.slice(start, i);
+}
+const messagesFns = [
+  '_anchorSceneMessageText','_anchorSceneCleanText','_anchorSceneTextKey',
+  '_anchorSceneSafePayload','_anchorSceneToolId','_anchorSceneToolName',
+  '_anchorSceneToolArgs','_anchorSceneStringPayload','_anchorSceneRowBase',
+  '_anchorSceneProseRow','_anchorSceneThinkingRow','_anchorSceneToolRowFromCall',
+  '_anchorSceneMessageReasoningText','_enrichSettledToolRowBodyFromLive',
+  '_anchorSceneRowsByMessageIndex',
+];
+const uiFns = ['_anchorSceneToolCallFromRow'];
+let code = '(function(){\n';
+code += 'var activeSid="test-session"; var streamId="test-stream"; var S;\n';
+for (const n of messagesFns) code += extractFunc(mSrc, n) + '\n';
+for (const n of uiFns) code += extractFunc(uSrc, n) + '\n';
+code += `
+var buf='';
+process.stdin.on('data',c=>buf+=c);
+process.stdin.on('end',()=>{
+  var p=JSON.parse(buf||'{}');
+  S=p.S||{toolCalls:[]};
+  var messages=p.messages||[];
+  var turnStart=p.turnStart!==undefined?p.turnStart:0;
+  var lastAsstIndex=p.lastAsstIndex!==undefined?p.lastAsstIndex:messages.length-1;
+  var byIdx=_anchorSceneRowsByMessageIndex(messages,turnStart,lastAsstIndex);
+  var cards=[];
+  byIdx.forEach(function(rows,idx){
+    rows.forEach(function(row){
+      if(row.role!=='tool') return;
+      var tc=_anchorSceneToolCallFromRow(row,{settled:true});
+      var outputTab=String((tc.snippet||tc.preview||tc.result||tc.output)||'').trim();
+      cards.push({
+        idx:idx, name:tc.name, tid:tc.tid,
+        snippet:tc.snippet||'', snippetLen:(tc.snippet||'').length,
+        args:tc.args||{}, command:tc.command||'',
+        rendersOutputBody:!!tc.snippet,
+        rendersDiff:/^@@\\s/.test(tc.snippet||'') && (tc.snippet||'').split('\\n').filter(l=>l[0]==='+'||l[0]==='-').length>=2,
+        transparentOutputTabNonEmpty:!!outputTab,
+        transparentFullTabArgKeys:Object.keys((tc.args&&typeof tc.args==='object')?tc.args:{}),
+      });
+    });
+  });
+  process.stdout.write(JSON.stringify(cards));
+});
+})();
+`;
+process.stdout.write(code);
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    gen = tmp_path_factory.mktemp("gen") / "gen.js"
+    gen.write_text(_DRIVER_SRC, encoding="utf-8")
+    result = subprocess.run(
+        [NODE, str(gen), str(MESSAGES_JS), str(UI_JS)],
+        capture_output=True, text=True, timeout=15,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"Driver generation failed:\n{result.stderr}")
+    driver = tmp_path_factory.mktemp("driver") / "driver.js"
+    driver.write_text(result.stdout, encoding="utf-8")
+    return str(driver)
+
+
+def _run(driver_path: str, payload: dict) -> list:
+    assert NODE is not None
+    result = subprocess.run(
+        [NODE, driver_path], input=json.dumps(payload),
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Node error:\n{result.stderr}")
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Builders for the reporter's scenario: a settled turn where the persisted
+# state.db tool_calls lack the body, but the live S.toolCalls carries the full
+# output + diff. This is the reconnect/settle reconciliation.
+# ---------------------------------------------------------------------------
+
+_TERM_OUTPUT = (
+    "total 48\n"
+    "drwxr-xr-x 6 user staff 192 .\n"
+    "-rw-r--r-- 1 user staff 1024 app.py\n"
+    "-rw-r--r-- 1 user staff 2048 README.md\n"
+    "-rw-r--r-- 1 user staff  512 config.yaml"
+)
+_DIFF = "@@ -1,4 +1,5 @@\n def main():\n-    print('old')\n+    print('new')\n+    return 0\n     pass"
+
+
+def _settled_then_live(term_persisted="", patch_persisted="", patch_args=None):
+    """Turn with a terminal + edit_file call; persisted rows carry `*_persisted`
+    bodies, live S.toolCalls carries the full output + diff."""
+    messages = [
+        {"role": "user", "content": "run ls and patch a file"},
+        {
+            "role": "assistant",
+            "content": "Done.",
+            "tool_calls": [
+                {"id": "term-1", "name": "terminal", "started_at": 100,
+                 "command": "ls -la", "snippet": term_persisted},
+                {"id": "patch-1", "name": "edit_file", "started_at": 200,
+                 "args": patch_args or {"path": "x.py"}, "snippet": patch_persisted},
+            ],
+        },
+        {"role": "assistant", "content": "final answer"},
+    ]
+    S = {"toolCalls": [
+        {"id": "term-1", "name": "terminal", "assistant_msg_idx": 1, "started_at": 100,
+         "command": "ls -la", "snippet": _TERM_OUTPUT},
+        {"id": "patch-1", "name": "edit_file", "assistant_msg_idx": 1, "started_at": 200,
+         "args": {"path": "x.py"}, "snippet": _DIFF},
+    ]}
+    return {"messages": messages, "turnStart": 0, "lastAsstIndex": 2, "S": S}
+
+
+def _card(cards, name):
+    matches = [c for c in cards if c["name"] == name]
+    assert matches, f"no settled card for {name}: {[c['name'] for c in cards]}"
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_settled_terminal_output_restored_when_persisted_body_empty(driver_path):
+    """Empty persisted snippet -> full terminal stdout restored from live S.toolCalls."""
+    cards = _run(driver_path, _settled_then_live(term_persisted="", patch_persisted=""))
+    term = _card(cards, "terminal")
+    assert term["rendersOutputBody"] is True, "terminal output body must render after settle"
+    assert term["snippet"] == _TERM_OUTPUT, "settled card must carry the FULL stdout (Show-more data-full)"
+    assert term["transparentOutputTabNonEmpty"] is True, "transparent 'Output' tab must be non-empty"
+
+
+def test_settled_patch_diff_restored_when_persisted_body_empty(driver_path):
+    """Empty persisted snippet -> patch/edit diff body restored + renders as a diff."""
+    cards = _run(driver_path, _settled_then_live(term_persisted="", patch_persisted=""))
+    patch = _card(cards, "edit_file")
+    assert patch["rendersOutputBody"] is True, "patch card body must render after settle"
+    assert patch["rendersDiff"] is True, "patch/edit card must render the diff body after settle"
+    assert patch["snippet"] == _DIFF
+    # "Full" tab keeps the detailed input args.
+    assert "path" in patch["transparentFullTabArgKeys"]
+
+
+def test_settled_body_not_clobbered_when_persisted_value_genuine(driver_path):
+    """A genuine persisted body must WIN over the live value (no clobber)."""
+    payload = _settled_then_live(
+        term_persisted="GENUINE PERSISTED OUTPUT",
+        patch_persisted="@@ -1 +1 @@\n-persisted old\n+persisted new",
+    )
+    cards = _run(driver_path, payload)
+    assert _card(cards, "terminal")["snippet"] == "GENUINE PERSISTED OUTPUT"
+    assert _card(cards, "edit_file")["snippet"].startswith("@@ -1 +1 @@")
+
+
+def test_settled_args_restored_when_persisted_args_empty(driver_path):
+    """A patch card whose persisted args were dropped gets them back from live."""
+    payload = _settled_then_live(patch_args={})  # persisted row has no args
+    cards = _run(driver_path, payload)
+    patch = _card(cards, "edit_file")
+    # live S.toolCalls carried args={"path":"x.py"} -> restored onto the Full tab.
+    assert "path" in patch["transparentFullTabArgKeys"]
+
+
+def test_no_live_match_leaves_settled_row_unchanged(driver_path):
+    """With no matching live entry, the settled row is untouched (graceful)."""
+    payload = _settled_then_live(term_persisted="kept", patch_persisted="kept-diff")
+    payload["S"] = {"toolCalls": []}  # nothing live to restore from
+    cards = _run(driver_path, payload)
+    assert _card(cards, "terminal")["snippet"] == "kept"
+    assert _card(cards, "edit_file")["snippet"] == "kept-diff"
+
+
+def test_single_row_no_duplicate_after_enrich(driver_path):
+    """Enriching must not also add a second (live) row — exactly one row per tid."""
+    cards = _run(driver_path, _settled_then_live())
+    assert len([c for c in cards if c["tid"] == "term-1"]) == 1
+    assert len([c for c in cards if c["tid"] == "patch-1"]) == 1

--- a/tests/test_issue4811_reconnect_chronology.py
+++ b/tests/test_issue4811_reconnect_chronology.py
@@ -59,6 +59,7 @@ const funcNames = [
   '_anchorSceneThinkingRow',
   '_anchorSceneToolRowFromCall',
   '_anchorSceneMessageReasoningText',
+  '_enrichSettledToolRowBodyFromLive',
   '_anchorSceneRowsByMessageIndex',
 ];
 


### PR DESCRIPTION
## What this fixes

In the **Transparent Stream / Worklog** view, after a turn settles (or on reload/reconnect):
- **terminal** tool cards show the `$ command` line with **no stdout** below it, and
- **patch / edit_file** cards show the raw input fields with **no rendered diff**.

The full output is visible *while the stream is in progress*, then disappears once it settles — the tell that this is the **settled rehydrate** path, not the live card. Recurrence of #4622, confirmed on v0.51.636 (the earlier #4625 guard only covered the live `buildToolCard` path, which is why it stayed green).

## Root cause (proven empirically)

The settled rebuild `_anchorSceneRowsByMessageIndex` (`static/messages.js`) reconstructs each tool row from the persisted `messages[].tool_calls` (state.db / sidecar). The backend persists the result body as a capped snippet and truncates args, and on a cold/paginated load the row can carry **no** body at all. The full output lives on the live `S.toolCalls` entry at settle time — but the dedup loop matched the live entry by tool id and **skipped it** (`continue`) rather than restoring the missing body onto the surviving settled row.

So `_anchorSceneToolCallFromRow` → `buildToolCard` received `tc.snippet=''`: empty output region, and the diff (detected from the snippet via `_snippetLooksLikeDiff`) never rendered. The transparent card's **Output** tab (result body) and **Full** tab (detailed input args) both went empty too.

I built a node harness that drives the real settled chain (`_anchorSceneRowsByMessageIndex` → `_anchorSceneToolRowFromCall` → `_anchorSceneToolCallFromRow`) and reproduced the exact failure on `origin/master`, then confirmed the fix:

| Card | view | before (master) | after |
|---|---|---|---|
| terminal | Output body / Show-more `data-full` | ❌ empty | ✅ full stdout |
| terminal | transparent **Output** tab | ❌ empty | ✅ non-empty |
| edit_file | diff body rendered | ❌ no | ✅ yes |
| edit_file | **Full** tab input args | (kept) | ✅ kept |

## The fix

New `_enrichSettledToolRowBodyFromLive(row, live)` restores `snippet`/`result`/`output`, `command`, and `args` onto the settled row's `tool`+`payload` from the matched live call — **only when the settled value is empty** (never clobbers a genuinely persisted body). Wired into the dedup loop: on a tid match that would previously have been dropped, it enriches the existing pooled row instead of discarding the live data. No duplicate row is added.

## Tests (the guard that would have caught this)

New `tests/test_issue4622_settled_toolcard_body.py` drives the **settled** chain end-to-end (not the live path) and asserts:
- terminal stdout restored + full output carried for the **Show more** expander + transparent **Output** tab non-empty;
- patch/edit diff body restored + renders as a diff + **Full** tab keeps the input args;
- a genuine persisted body is **not** clobbered by a differing live value;
- dropped args are restored from live;
- no-live-match leaves the settled row untouched;
- exactly one row per tid after enrichment (no duplicate).

Verified to **fail on clean master** (behavioural assertions) and pass with the fix. Also registered the new helper in the #4811 reconnect-chronology test driver (it eval-extracts the `_anchorScene*` family and now references the new symbol). Full local suite green; gated with Codex + Opus.

A reusable before/after proof harness is saved in the workspace (`qa/harnesses/prove_4622_settled_toolcard.js`).

Closes #4622.

---

*Self-built maintainer PR (nesquena-hermes). Requesting an independent human review before merge per the self-built-PR policy. @rodboev / @franksong2702 — a hands-on check would be ideal: run a turn with a long terminal command + a patch/edit, let it settle (or reload the session), and confirm the terminal stdout and the diff both still show, including the **Output** / **Full** tabs and **Show more**.*