### PR TITLE
Release XH (v0.51.652): deliver async_delegation subagent completions to chat (#4912)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.652] — 2026-06-25 — Release XH (background subagent results return to chat)
+
+### Fixed
+
+- **Background `delegate_task` subagent results now re-enter the conversation instead of being silently dropped.** When a subagent dispatched via `delegate_task` finished, the WebUI showed it as perpetually "running" and its consolidated result never appeared in chat. The wakeup-prompt builder only recognized `completion` and watch-pattern events, so the `async_delegation` completion event a finished subagent emits hit the catch-all and was discarded before the server-side wakeup turn could start. The builder now renders `async_delegation` events (via the shared agent-side notification formatter), so the subagent's result is delivered back into the parent conversation. Genuinely-unrecognized event types are still skipped. Thanks @mydelren for the report and root-cause. (#4912)
+
 ## [v0.51.651] — 2026-06-25 — Release XG (force update no longer aborts on undeletable Windows files)
 
 ### Fixed

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -384,6 +384,25 @@ def format_wakeup_prompt(evt: object) -> str | None:
         if sup:
             body += f"\n({sup} earlier matches were suppressed by rate limit)"
         return body + "]"
+    if evt_type == "async_delegation":
+        # A background ``delegate_task`` completion. The agent-side formatter
+        # renders these; delegate to it so the subagent result re-enters the
+        # parent conversation instead of being silently dropped (#4912).
+        try:
+            from tools.process_registry import (
+                format_process_notification as _agent_fmt,
+            )
+            result = _agent_fmt(evt)
+            if result:
+                return result
+        except Exception:
+            logger.debug(
+                "agent-side format_process_notification fallback failed for "
+                "evt_type=%s",
+                evt_type,
+                exc_info=True,
+            )
+        return None
     if evt_type != "completion":
         return None
 

--- a/tests/test_background_process_wakeup_format.py
+++ b/tests/test_background_process_wakeup_format.py
@@ -15,6 +15,28 @@ def test_format_wakeup_prompt_skips_unknown_event_type():
     assert format_wakeup_prompt(evt) is None
 
 
+def test_format_wakeup_prompt_handles_async_delegation():
+    """#4912 — async_delegation completion events (from a background
+    delegate_task) must be rendered, not silently dropped, so the subagent
+    result re-enters the parent conversation. Delegates to the agent-side
+    formatter, which knows the async_delegation shape."""
+    evt = {
+        "type": "async_delegation",
+        "session_id": "proc_deleg1",
+        "session_key": "webui-session",
+        "task_id": "t_1",
+        "summary": "Subagent finished: computed the answer is 42.",
+        "status": "completed",
+    }
+    result = format_wakeup_prompt(evt)
+    assert result is not None, (
+        "async_delegation completion must produce a wakeup prompt (#4912), "
+        "not be dropped"
+    )
+    # The agent-side formatter renders an async-delegation notification.
+    assert "ASYNC DELEGATION" in result.upper() or "subagent" in result.lower()
+
+
 def test_format_wakeup_prompt_handles_watch_disabled():
     evt = {
         "type": "watch_disabled",

--- a/tests/test_background_process_wakeup_format.py
+++ b/tests/test_background_process_wakeup_format.py
@@ -15,17 +15,37 @@ def test_format_wakeup_prompt_skips_unknown_event_type():
     assert format_wakeup_prompt(evt) is None
 
 
-def test_format_wakeup_prompt_handles_async_delegation():
+def test_format_wakeup_prompt_handles_async_delegation(monkeypatch):
     """#4912 — async_delegation completion events (from a background
     delegate_task) must be rendered, not silently dropped, so the subagent
-    result re-enters the parent conversation. Delegates to the agent-side
-    formatter, which knows the async_delegation shape."""
+    result re-enters the parent conversation. format_wakeup_prompt delegates
+    to the agent-side tools.process_registry.format_process_notification.
+
+    We inject a stub agent module so this validates the delegation WIRING
+    independent of whether the full hermes-agent package is importable in the
+    test environment (it isn't in WebUI-only CI shards).
+    """
+    import sys
+    import types
+
+    seen = {}
+
+    def _fake_fmt(evt):
+        seen["evt"] = evt
+        return "[ASYNC DELEGATION COMPLETE — t_1]\nSubagent finished: the answer is 42."
+
+    fake_mod = types.ModuleType("tools.process_registry")
+    fake_mod.format_process_notification = _fake_fmt
+    fake_pkg = sys.modules.get("tools") or types.ModuleType("tools")
+    monkeypatch.setitem(sys.modules, "tools", fake_pkg)
+    monkeypatch.setitem(sys.modules, "tools.process_registry", fake_mod)
+
     evt = {
         "type": "async_delegation",
         "session_id": "proc_deleg1",
         "session_key": "webui-session",
         "task_id": "t_1",
-        "summary": "Subagent finished: computed the answer is 42.",
+        "summary": "Subagent finished: the answer is 42.",
         "status": "completed",
     }
     result = format_wakeup_prompt(evt)
@@ -33,8 +53,27 @@ def test_format_wakeup_prompt_handles_async_delegation():
         "async_delegation completion must produce a wakeup prompt (#4912), "
         "not be dropped"
     )
-    # The agent-side formatter renders an async-delegation notification.
-    assert "ASYNC DELEGATION" in result.upper() or "subagent" in result.lower()
+    assert "ASYNC DELEGATION" in result.upper()
+    # Confirm it actually delegated the event to the agent-side formatter.
+    assert seen.get("evt", {}).get("type") == "async_delegation"
+
+
+def test_format_wakeup_prompt_async_delegation_drops_gracefully_without_agent(monkeypatch):
+    """If the agent-side formatter is unavailable (import fails), async_delegation
+    degrades to None instead of raising — same safe behavior as before #4912."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocking_import(name, *args, **kwargs):
+        if name == "tools.process_registry" or name.startswith("tools.process_registry"):
+            raise ImportError("simulated: agent module unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocking_import)
+    evt = {"type": "async_delegation", "session_id": "s", "task_id": "t"}
+    # Must not raise; returns None when the agent formatter can't be imported.
+    assert format_wakeup_prompt(evt) is None
 
 
 def test_format_wakeup_prompt_handles_watch_disabled():


### PR DESCRIPTION
## Release XH (v0.51.652) — background subagent results return to chat

Resolves **#4912** (reported + root-caused by @mydelren). Self-built fix.

### What it fixes
`delegate_task` background subagents completed but their result never re-entered the WebUI chat — they showed as perpetually "running". `format_wakeup_prompt()` only handled `completion` + watch-pattern events; the `async_delegation` completion event hit `if evt_type != "completion": return None` and was dropped before the server-side wakeup turn could start. Now an `async_delegation` branch delegates to the shared agent-side `format_process_notification` (which already renders that shape), so the result is delivered back into the parent conversation. Scoped to `async_delegation` specifically so genuinely-unknown event types are still skipped.

### Note on #4799
#4799 ("Fix WebUI async delegation completion delivery") targets the same issue with a larger (+552) approach labeled `hold`/`upstream-change`. This is a minimal, self-contained WebUI-side fix (delegates to the existing agent formatter) that resolves it without the upstream dependency.

### Gate (clean)
- Codex: **SAFE TO SHIP** — enumerated all producer event types (completion, watch_match/disabled/overflow_*, async_delegation); confirmed no other legitimate type is newly dropped, unknown-event skip preserved, `_process_one()` delivers once by session_key (no double-fire), graceful if the agent module is unavailable.
- Full suite: **10560 passed**, 0 failures
- New regression test (proven non-vacuous) + preserved the skip-unknown-event test.

Reported + root-caused by @mydelren.
