### PR TITLE
Reduce session index global lock window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- **Streaming-time session index updates now hold the global session lock for less work.** `_write_session_index()` now snapshots in-memory session rows under `LOCK`, but reads/parses the existing `_index.json`, sorts, serializes, and writes the updated index outside that lock. This reduces avoidable `/api/session` and `/api/sessions` contention while a running stream saves session metadata, addressing the lock-window half of #4918 without changing the active-stream lifecycle.
-
 ## [v0.51.653] — 2026-06-25 — Release XI (gateway approval failures stay actionable instead of dead-ending)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Streaming-time session index updates now hold the global session lock for less work.** `_write_session_index()` now snapshots in-memory session rows under `LOCK`, but reads/parses the existing `_index.json`, sorts, serializes, and writes the updated index outside that lock. This reduces avoidable `/api/session` and `/api/sessions` contention while a running stream saves session metadata, addressing the lock-window half of #4918 without changing the active-stream lifecycle.
+
 ## [v0.51.653] — 2026-06-25 — Release XI (gateway approval failures stay actionable instead of dead-ending)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -260,8 +260,9 @@ def _write_session_index(updates=None, *, session_dir: Path | None = None, sessi
     the existing index — O(1) for single-session changes.  When *updates*
     is None, a full rebuild is performed (used on startup / first call).
 
-    LOCK protects in-memory state snapshots and payload construction only;
-    disk I/O (write/flush/fsync/replace) always runs outside LOCK.
+    LOCK protects only in-memory session snapshots.  JSON parsing, payload
+    construction, and disk I/O run outside LOCK so active-stream saves do not
+    block ordinary session reads longer than necessary.
     """
     session_dir = session_dir or SESSION_DIR
     session_index_file = session_index_file or SESSION_INDEX_FILE
@@ -293,13 +294,16 @@ def _write_session_index(updates=None, *, session_dir: Path | None = None, sessi
                     logger.debug("Failed to load session from %s", p)
             entries = list(entry_map.values())
 
+            existing_ids = set(entry_map.keys())
             with LOCK:
-                existing_ids = set(entry_map.keys())
-                for s in SESSIONS.values():
-                    if s.session_id not in existing_ids:
-                        entries.append(s.compact())
-                entries.sort(key=lambda s: s.get('updated_at', 0), reverse=True)
-                _payload = json.dumps(entries, ensure_ascii=False, indent=2)
+                in_memory_entries = [
+                    s.compact()
+                    for s in SESSIONS.values()
+                    if s.session_id not in existing_ids
+                ]
+            entries.extend(in_memory_entries)
+            entries.sort(key=lambda s: s.get('updated_at', 0), reverse=True)
+            _payload = json.dumps(entries, ensure_ascii=False, indent=2)
 
             try:
                 with open(_tmp, 'w', encoding='utf-8') as f:
@@ -323,29 +327,30 @@ def _write_session_index(updates=None, *, session_dir: Path | None = None, sessi
             # Avoid N filesystem exists() checks under LOCK by collecting
             # on-disk IDs once before entering the critical section.
             on_disk_ids = _persisted_session_ids_snapshot()
+            existing = json.loads(session_index_file.read_text(encoding='utf-8'))
+            if not isinstance(existing, list):
+                raise ValueError("session index must be a list")
             with LOCK:
-                existing = json.loads(session_index_file.read_text(encoding='utf-8'))
                 in_memory_ids = set(SESSIONS.keys())
-
-                existing = [
-                    e for e in existing
-                    if (e.get('session_id') in in_memory_ids or e.get('session_id') in on_disk_ids)
-                ]
-
-                # Build lookup of updated entries
                 updated_map = {s.session_id: s.compact() for s in updates}
-                existing_ids = {e.get('session_id') for e in existing}
-                # Add any updated entries not yet in the index
-                for sid, entry in updated_map.items():
-                    if sid not in existing_ids:
-                        existing.append(entry)
-                # Replace matching entries in-place
-                for i, e in enumerate(existing):
-                    sid = e.get('session_id')
-                    if sid in updated_map:
-                        existing[i] = updated_map[sid]
-                existing.sort(key=lambda s: s.get('updated_at', 0), reverse=True)
-                _payload = json.dumps(existing, ensure_ascii=False, indent=2)
+
+            existing = [
+                e for e in existing
+                if (e.get('session_id') in in_memory_ids or e.get('session_id') in on_disk_ids)
+            ]
+
+            existing_ids = {e.get('session_id') for e in existing}
+            # Add any updated entries not yet in the index.
+            for sid, entry in updated_map.items():
+                if sid not in existing_ids:
+                    existing.append(entry)
+            # Replace matching entries in-place.
+            for i, e in enumerate(existing):
+                sid = e.get('session_id')
+                if sid in updated_map:
+                    existing[i] = updated_map[sid]
+            existing.sort(key=lambda s: s.get('updated_at', 0), reverse=True)
+            _payload = json.dumps(existing, ensure_ascii=False, indent=2)
 
             try:
                 with open(_tmp, 'w', encoding='utf-8') as f:

--- a/tests/test_session_index_lock_window.py
+++ b/tests/test_session_index_lock_window.py
@@ -1,0 +1,71 @@
+import collections
+import json
+import threading
+
+
+class RecordingLock:
+    def __init__(self):
+        self._lock = threading.RLock()
+        self.depth = 0
+
+    def __enter__(self):
+        self._lock.acquire()
+        self.depth += 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.depth -= 1
+        self._lock.release()
+
+    @property
+    def held(self):
+        return self.depth > 0
+
+
+def test_session_index_fast_path_keeps_json_work_outside_global_lock(monkeypatch, tmp_path):
+    import api.models as models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+
+    old = models.Session(session_id="idx_old", title="Old", updated_at=1.0)
+    updated = models.Session(session_id="idx_updated", title="Updated", updated_at=20.0)
+    (session_dir / "idx_old.json").write_text("{}", encoding="utf-8")
+    (session_dir / "idx_updated.json").write_text("{}", encoding="utf-8")
+    index_file.write_text(
+        json.dumps(
+            [
+                old.compact(),
+                models.Session(session_id="idx_updated", title="Stale", updated_at=2.0).compact(),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    lock = RecordingLock()
+    monkeypatch.setattr(models, "LOCK", lock)
+    monkeypatch.setattr(models, "SESSIONS", collections.OrderedDict())
+
+    original_loads = models.json.loads
+    original_dumps = models.json.dumps
+
+    def loads_outside_lock(*args, **kwargs):
+        assert not lock.held
+        return original_loads(*args, **kwargs)
+
+    def dumps_outside_lock(*args, **kwargs):
+        assert not lock.held
+        return original_dumps(*args, **kwargs)
+
+    monkeypatch.setattr(models.json, "loads", loads_outside_lock)
+    monkeypatch.setattr(models.json, "dumps", dumps_outside_lock)
+
+    models._write_session_index(updates=[updated])
+
+    rows = json.loads(index_file.read_text(encoding="utf-8"))
+    assert [row["session_id"] for row in rows] == ["idx_updated", "idx_old"]
+    assert rows[0]["title"] == "Updated"
+    assert rows[0]["updated_at"] == 20.0


### PR DESCRIPTION
## Thinking Path

Issue #4918 has two separate performance costs. PR #4920 targets the per-session `state.db` full-read cost on initial paginated loads. This PR targets a smaller piece of the streaming-time lock contention: session saves update the sidebar `_index.json`, and the fast path was doing index file reads, JSON parsing, sorting, and JSON serialization while holding the process-global session `LOCK`.

That lock is also touched by ordinary `/api/session` and `/api/sessions` reads. During active streams, keeping JSON/index work inside the shared lock makes unrelated reads wait longer than necessary.

## What Changed

- Narrowed `_write_session_index()` so `LOCK` protects only in-memory session snapshots.
- Moved existing `_index.json` read/parse, row filtering, sorting, JSON serialization, and disk writes outside `LOCK` while keeping `_INDEX_WRITE_LOCK` as the file-write serialization guard.
- Applied the same lock-window shape to the lazy full-rebuild path's in-memory overlay snapshot.
- Added a regression test that fails if the fast path performs JSON parse/dump while the global session lock is held, while still asserting the index row update and ordering are unchanged.
- Added a release-note entry for the #4918 lock-window improvement.

## Why It Matters

Active streams call `Session.save()`, which updates the session index. Reducing the amount of work done under the global session lock lowers avoidable contention for `/api/session` and `/api/sessions` while a run is streaming.

This does not remove all streaming-time contention, and it does not change the active-stream lifecycle. It is the low-risk lock-window part of #4918, separate from the deeper per-session locking/runtime architecture work.

Refs #4918.
Related to #4920.

## Contract Routing

Task type: runtime/session metadata performance fix.
Touched areas: `_write_session_index()` in `api/models.py`, session sidebar index persistence.
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
Scope boundaries: no frontend changes, no active-stream lifecycle changes, no state.db tail-window changes, no cancellation/compression behavior changes.
Evidence needed before claiming done: regression coverage that index output is preserved and JSON/index work is outside global `LOCK`, plus existing session persistence/list tests.

## Verification

- `./scripts/test.sh tests/test_session_index_lock_window.py tests/test_empty_session_no_disk_write.py tests/test_issue856_session_streaming_state.py tests/test_session_save_mode.py tests/test_session_list_long_history_perf.py tests/test_issue1855_request_diagnostics.py tests/test_issue765_streaming_persistence.py tests/test_metadata_save_wipe_1558.py -q`
  - `83 passed in 5.92s`
- `./.venv/bin/python -m py_compile api/models.py tests/test_session_index_lock_window.py`
- `git diff --check origin/master...HEAD`

## Risks / Follow-ups

- This reduces the shared-lock window for session index updates, but does not fully replace global session locking with per-session snapshots.
- A deeper follow-up can move more streaming writeback coordination behind per-session locks, but that has a larger blast radius across cancel, compression, title refresh, and final writeback paths.

## Model Used

OpenAI GPT-5, using local repo inspection, codegraph, shell tests, and GitHub CLI.
