### PR TITLE
Avoid repeated session loads in live usage metering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Live metering during active streams no longer reloads the session on every usage tick.** The streaming worker now reuses its current session object for `_live_usage_snapshot()` and only falls back to `get_session()` once before the worker has loaded that object. This removes another avoidable global-session-lock touch point while tokens and tool events are streaming, narrowing the lock-contention half of #4918 without changing usage payloads or active-stream state.
+
 ## [v0.51.653] — 2026-06-25 — Release XI (gateway approval failures stay actionable instead of dead-ending)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- **Live metering during active streams no longer reloads the session on every usage tick.** The streaming worker now reuses its current session object for `_live_usage_snapshot()` and only falls back to `get_session()` once before the worker has loaded that object. This removes another avoidable global-session-lock touch point while tokens and tool events are streaming, narrowing the lock-contention half of #4918 without changing usage payloads or active-stream state.
-
 ## [v0.51.653] — 2026-06-25 — Release XI (gateway approval failures stay actionable instead of dead-ending)
 
 ### Fixed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4923,6 +4923,31 @@ def live_usage_prompt_estimate_after_tool_delta(
     }
 
 
+def _live_usage_session_snapshot(session_id, current_session, cache_ref, *, loader=get_session):
+    """Return a session object for hot live-metering paths without repeated loads."""
+    if current_session is not None:
+        try:
+            cache_ref[0] = current_session
+        except Exception:
+            pass
+        return current_session
+    try:
+        cached = cache_ref[0]
+    except Exception:
+        cached = None
+    if cached is not None:
+        return cached
+    try:
+        loaded = loader(session_id)
+    except Exception:
+        return None
+    try:
+        cache_ref[0] = loaded
+    except Exception:
+        pass
+    return loaded
+
+
 def _tool_result_snippet(raw, limit: int = _TOOL_RESULT_SNIPPET_MAX) -> str:
     """Extract a bounded result preview from a stored tool message payload."""
     if limit <= 0:
@@ -5744,6 +5769,14 @@ def _run_agent_streaming(
     # (model, base_url, provider) within one stream, so resolve it at most
     # once. Sentinel: None=not computed, 0=not applicable/failed, >0=real cap.
     _real_ctx_cache = [None]
+    _live_usage_session_cache = [None]
+
+    def _current_live_usage_session():
+        return _live_usage_session_snapshot(
+            session_id,
+            s,
+            _live_usage_session_cache,
+        )
 
     def _seed_live_prompt_estimate() -> int:
         """Capture the latest exact prompt size before adding live tool deltas."""
@@ -5760,7 +5793,7 @@ def _run_agent_streaming(
                 _base = 0
         if not _base:
             try:
-                _session_obj = get_session(session_id)
+                _session_obj = _current_live_usage_session()
                 _base = getattr(_session_obj, 'last_prompt_tokens', 0) or 0
             except Exception:
                 _base = 0
@@ -5802,10 +5835,7 @@ def _run_agent_streaming(
             'threshold_tokens': 0,
             'last_prompt_tokens': 0,
         }
-        try:
-            _session_obj = get_session(session_id)
-        except Exception:
-            _session_obj = None
+        _session_obj = _current_live_usage_session()
 
         _agent = agent
         if _agent is not None:

--- a/tests/test_streaming_live_usage_estimate.py
+++ b/tests/test_streaming_live_usage_estimate.py
@@ -1,4 +1,7 @@
-from api.streaming import live_usage_prompt_estimate_after_tool_delta
+from api.streaming import (
+    _live_usage_session_snapshot,
+    live_usage_prompt_estimate_after_tool_delta,
+)
 
 
 def test_live_usage_estimate_caps_tool_delta_against_previous_prompt():
@@ -48,3 +51,28 @@ def test_live_usage_estimate_caps_cumulative_tool_delta_per_turn():
     assert usage["turn_tool_prompt_tokens"] == 24_000
     assert usage["last_prompt_tokens"] == base_prompt_tokens + 24_000
     assert usage["last_prompt_tokens"] < base_prompt_tokens + (20 * 12_000)
+
+
+def test_live_usage_session_snapshot_prefers_current_stream_session():
+    current = object()
+    cache = [None]
+
+    def fail_loader(_sid):
+        raise AssertionError("hot live usage path should not reload the current session")
+
+    assert _live_usage_session_snapshot("sid", current, cache, loader=fail_loader) is current
+    assert cache[0] is current
+
+
+def test_live_usage_session_snapshot_falls_back_once_then_uses_cache():
+    loaded = object()
+    calls = []
+    cache = [None]
+
+    def loader(sid):
+        calls.append(sid)
+        return loaded
+
+    assert _live_usage_session_snapshot("sid", None, cache, loader=loader) is loaded
+    assert _live_usage_session_snapshot("sid", None, cache, loader=loader) is loaded
+    assert calls == ["sid"]


### PR DESCRIPTION
## Thinking Path

Issue #4918's second half is streaming-time lock contention. After #4921 reduces the session-index save lock window, another hot path remains: live metering calls `_live_usage_snapshot()` repeatedly while tokens and tool events stream, and that snapshot reloaded the session with `get_session(session_id)` every time.

`get_session()` touches the process-global session `LOCK` and can run cache freshness checks. Doing that on every metering tick/token/tool update creates avoidable contention exactly while the user is most likely to switch sessions during an active run.

## What Changed

- Added `_live_usage_session_snapshot()` to reuse the current streaming worker's session object for hot live-usage reads.
- `_live_usage_snapshot()` and `_seed_live_prompt_estimate()` now use that cached/current session path instead of calling `get_session()` on every usage snapshot.
- The helper still falls back to loading the session once before the worker has populated `s`, then reuses that cached object for later early metering reads.
- Added regression coverage proving the hot path does not reload when a current stream session is available, and that fallback loading happens only once.
- Added a release-note entry for the #4918 live-metering lock-contention slice.

## Why It Matters

Live metering can run frequently during active output. Removing repeated session reloads from that path reduces another source of global session-lock traffic while streaming, without changing the usage payload shape or active-stream lifecycle.

This is a narrow follow-up to #4921 and still does not attempt the larger per-session locking/runtime ownership redesign.

Refs #4918.
Related to #4920 and #4921.

## Contract Routing

Task type: runtime/streaming performance fix.
Touched areas: live usage metering inside `api/streaming.py`.
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
Scope boundaries: no frontend changes, no active-stream lifecycle changes, no usage payload shape change, no session index or state.db tail-window changes.
Evidence needed before claiming done: tests showing repeated live usage snapshots do not repeatedly reload sessions, plus existing streaming/live-usage regressions.

## Verification

- `./scripts/test.sh tests/test_streaming_live_usage_estimate.py tests/test_auto_compression_card.py tests/test_issue765_streaming_persistence.py tests/test_issue856_session_streaming_state.py tests/test_session_tail_payload.py -q`
  - `96 passed in 4.91s`
- `./.venv/bin/python -m py_compile api/streaming.py tests/test_streaming_live_usage_estimate.py`
- `git diff --check origin/master...HEAD`

## Risks / Follow-ups

- This removes repeated session reloads from live metering, but does not remove every global `LOCK` touch in streaming.
- The larger follow-up remains per-session coordination for final writeback/cancel/compression/title-refresh paths, ideally after these low-risk lock-window reductions land and are measured together.

## Model Used

OpenAI GPT-5, using local repo inspection, codegraph, shell tests, and GitHub CLI.
