### PR TITLE
fix(chat): preserve transparent stream prose order for mixed turns (#3397)

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -11089,6 +11089,7 @@ let _assistantTurnAnchorSettledFinalAnswerWarned=false;
 function _transparentStreamOrderedParts(message){
   if(typeof isTransparentStream==='function'&&!isTransparentStream()) return null;
   if(!message||message.role!=='assistant'||message._live||!Array.isArray(message.content)) return null;
+  if(message._anchor_activity_scene) return null;
   const ordered=[];
   let hasText=false;
   let hasTool=false;
@@ -11114,6 +11115,13 @@ function _transparentStreamOrderedParts(message){
     }
   }
   return hasText&&hasTool?ordered:null;
+}
+function _transparentOrderedDisplayText(text){
+  return _stripWorkspaceDisplayPrefix(
+    _stripAttachedFilesMarkerForDisplay(
+      _stripLeadingAssistantThinkingMarkup(String(text||''))
+    )
+  );
 }
 function _collectToolResultSnippetsByTid(messages){
   const resultsByTid={};
@@ -11144,7 +11152,7 @@ function _transparentOrderedToolCall(part, rawIdx, toolCallsByTid, resultsByTid)
   const liveTool=tid&&toolCallsByTid&&toolCallsByTid.get(tid);
   if(liveTool){
     const next={...liveTool};
-    if((next.snippet===undefined||next.snippet===null||next.snippet==='')&&resultsByTid&&resultsByTid[tid]){
+    if(resultsByTid&&resultsByTid[tid]){
       const patchSnippet=_cliPatchSnippetFromArgs(next.name||part.name||'tool', next.args||part.input||{});
       next.snippet=_cliToolCardSnippet(resultsByTid[tid],patchSnippet);
       next.is_diff=_cliToolCardHasDiffSnippet(resultsByTid[tid],patchSnippet);
@@ -11707,7 +11715,11 @@ function renderMessages(options){
       const messageAnchorKey=_messageViewportAnchorKeyForMessage(m);
       const lastTextPartIdx=(()=>{
         for(let i=orderedTransparentParts.length-1;i>=0;i--){
-          if(orderedTransparentParts[i]&&orderedTransparentParts[i].kind==='text') return i;
+          if(
+            orderedTransparentParts[i]&&
+            orderedTransparentParts[i].kind==='text'&&
+            String(_transparentOrderedDisplayText(orderedTransparentParts[i].text)).trim()
+          ) return i;
         }
         return -1;
       })();
@@ -11732,19 +11744,19 @@ function renderMessages(options){
           return;
         }
         const orderedSeg=document.createElement('div');
+        const partDisplayText=_transparentOrderedDisplayText(part.text);
+        if(!String(partDisplayText).trim()) return;
         orderedSeg.className='assistant-segment';
         orderedSeg.dataset.msgIdx=rawIdx;
         orderedSeg.dataset.sessionMsgIdx=sessionMsgIdx;
         orderedSeg.dataset.messageAnchorKey=messageAnchorKey;
-        orderedSeg.dataset.rawText=String(part.text||'').trim();
+        orderedSeg.dataset.rawText=String(partDisplayText||'').trim();
         if(m._activityBurstId!==undefined&&m._activityBurstId!==null) orderedSeg.setAttribute('data-activity-burst-id',String(m._activityBurstId));
         if(Number.isFinite(Number(m._liveSegmentSeq))) orderedSeg.setAttribute('data-live-segment-seq',String(Number(m._liveSegmentSeq)));
-        if(_ERR_MSG_RE.test(String(part.text||'').trim())) orderedSeg.dataset.error='1';
-        if(!firstSeg&&thinkingText&&window._showThinking!==false&&!((isCompactWorklogMode()||isTransparentStream())&&_assistantThinkingBelongsInWorklog(m, rawIdx, toolCallAssistantIdxs))){
-          orderedSeg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText));
-        }
+        if(_ERR_MSG_RE.test(String(partDisplayText||'').trim())) orderedSeg.dataset.error='1';
+        if(!firstSeg&&thinkingText&&window._showThinking!==false&&!((isCompactWorklogMode()||isTransparentStream())&&_assistantThinkingBelongsInWorklog(m, rawIdx, toolCallAssistantIdxs))) orderedSeg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText));
         const isLastTextPart=partIdx===lastTextPartIdx;
-        const partBodyHtml=_getCachedRender(part.text,false);
+        const partBodyHtml=_getCachedRender(partDisplayText,false);
         if(isLastTextPart&&statusHtml){
           orderedSeg.insertAdjacentHTML('beforeend', statusHtml);
         }

--- a/static/ui.js
+++ b/static/ui.js
@@ -11086,6 +11086,87 @@ function _renderMessagesWithScrollSnapshot(options){
   _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
 }
 let _assistantTurnAnchorSettledFinalAnswerWarned=false;
+function _transparentStreamOrderedParts(message){
+  if(typeof isTransparentStream==='function'&&!isTransparentStream()) return null;
+  if(!message||message.role!=='assistant'||message._live||!Array.isArray(message.content)) return null;
+  const ordered=[];
+  let hasText=false;
+  let hasTool=false;
+  for(const part of message.content){
+    if(!part||typeof part!=='object') continue;
+    if(part.type==='text'){
+      const text=typeof part.text==='string'?part.text:(typeof part.content==='string'?part.content:'');
+      if(!String(text||'').trim()) continue;
+      ordered.push({kind:'text', text});
+      hasText=true;
+      continue;
+    }
+    if(part.type==='tool_use'){
+      const toolUseId=String(part.id||'').trim();
+      if(!toolUseId) return null;
+      ordered.push({
+        kind:'tool',
+        toolUseId,
+        name:part.name||'tool',
+        input:(part.input&&typeof part.input==='object')?part.input:{},
+      });
+      hasTool=true;
+    }
+  }
+  return hasText&&hasTool?ordered:null;
+}
+function _collectToolResultSnippetsByTid(messages){
+  const resultsByTid={};
+  for(const message of (messages||[])){
+    if(!message) continue;
+    if(message.role==='tool'){
+      const tid=message.tool_call_id||message.tool_use_id||'';
+      if(tid) resultsByTid[tid]=_cliToolResultSnippet(message.content);
+      continue;
+    }
+    if(!Array.isArray(message.content)) continue;
+    for(const part of message.content){
+      if(!part||typeof part!=='object'||part.type!=='tool_result') continue;
+      const tid=part.tool_use_id||'';
+      if(!tid) continue;
+      const raw=typeof part.content==='string'
+        ? part.content
+        : Array.isArray(part.content)
+          ? part.content.map(c=>c&&c.text?c.text:'').join('')
+          : '';
+      resultsByTid[tid]=_cliToolResultSnippet(raw);
+    }
+  }
+  return resultsByTid;
+}
+function _transparentOrderedToolCall(part, rawIdx, toolCallsByTid, resultsByTid){
+  const tid=String(part&&part.toolUseId||'').trim();
+  const liveTool=tid&&toolCallsByTid&&toolCallsByTid.get(tid);
+  if(liveTool){
+    const next={...liveTool};
+    if((next.snippet===undefined||next.snippet===null||next.snippet==='')&&resultsByTid&&resultsByTid[tid]){
+      const patchSnippet=_cliPatchSnippetFromArgs(next.name||part.name||'tool', next.args||part.input||{});
+      next.snippet=_cliToolCardSnippet(resultsByTid[tid],patchSnippet);
+      next.is_diff=_cliToolCardHasDiffSnippet(resultsByTid[tid],patchSnippet);
+    }
+    if(next.done===undefined) next.done=true;
+    return next;
+  }
+  const name=part&&part.name||'tool';
+  const args=(part&&part.input&&typeof part.input==='object')?part.input:{};
+  const patchSnippet=_cliPatchSnippetFromArgs(name,args);
+  const resultSnippet=(resultsByTid&&tid&&resultsByTid[tid])||'';
+  return {
+    name,
+    tid,
+    id:tid,
+    assistant_msg_idx:rawIdx,
+    args:_toolArgsSnapshot(args),
+    snippet:_cliToolCardSnippet(resultSnippet,patchSnippet),
+    is_diff:_cliToolCardHasDiffSnippet(resultSnippet,patchSnippet),
+    done:true,
+  };
+}
 function _assistantTurnAnchorSettledFinalAnswer(message, content, context){
   const sceneFinal=_assistantAnchorSceneFinalAnswerText(message);
   const effectiveContent=String(content||'').trim()?content:sceneFinal;
@@ -11422,6 +11503,16 @@ function renderMessages(options){
       }
     }
   }
+  const transparentOrderedToolIds=new Set();
+  const transparentOrderedToolCallsByTid=new Map();
+  if(Array.isArray(S.toolCalls)){
+    for(const tc of S.toolCalls){
+      if(!tc||typeof tc!=='object') continue;
+      const tid=tc.tid||tc.id||tc.tool_call_id||tc.tool_use_id||tc.call_id||'';
+      if(tid&&!transparentOrderedToolCallsByTid.has(tid)) transparentOrderedToolCallsByTid.set(tid,tc);
+    }
+  }
+  const transparentToolResultsByTid=_collectToolResultSnippetsByTid(S.messages);
   // Windowed render loop replaces the legacy full loop:
   // for(let vi=0;vi<visWithIdx.length;vi++)
   for(let vi=0;vi<renderVisWithIdx.length;vi++){
@@ -11447,6 +11538,7 @@ function renderMessages(options){
     }
     let content=m.content||'';
     let thinkingText='';
+    let orderedTransparentParts=_transparentStreamOrderedParts(m);
     if(Array.isArray(content)){
       content=content.filter(p=>p&&p.type==='text').map(p=>p.text||p.content||'').join('\n');
     }
@@ -11455,7 +11547,17 @@ function renderMessages(options){
         session_id:sid,
         raw_idx:rawIdx,
       });
-      if(anchorFinal!==null) content=anchorFinal;
+      if(anchorFinal!==null){
+        content=anchorFinal;
+        if(Array.isArray(orderedTransparentParts)){
+          for(let i=orderedTransparentParts.length-1;i>=0;i--){
+            if(orderedTransparentParts[i]&&orderedTransparentParts[i].kind==='text'){
+              orderedTransparentParts[i]={...orderedTransparentParts[i], text:anchorFinal};
+              break;
+            }
+          }
+        }
+      }
     }
     if(typeof content==='string'){
       if(typeof window!=='undefined'&&typeof window._extractInlineThinkingFromContentForRender==='function'){
@@ -11597,6 +11699,60 @@ function renderMessages(options){
       if(S.session) currentAssistantTurn.dataset.sessionId=S.session.session_id;
       currentAssistantTurn.dataset.recycleKey=rawIdx;
       inner.appendChild(currentAssistantTurn);
+    }
+    if(Array.isArray(orderedTransparentParts)&&orderedTransparentParts.length){
+      const blocks=_assistantTurnBlocks(currentAssistantTurn);
+      const sessionMsgIdx=_messageSessionIndexForRawIdx(rawIdx);
+      const messageAnchorKey=_messageViewportAnchorKeyForMessage(m);
+      const lastTextPartIdx=(()=>{
+        for(let i=orderedTransparentParts.length-1;i>=0;i--){
+          if(orderedTransparentParts[i]&&orderedTransparentParts[i].kind==='text') return i;
+        }
+        return -1;
+      })();
+      let firstSeg=null;
+      if(thinkingText&&window._showThinking!==false){
+        if((isCompactWorklogMode()||isTransparentStream())&&_assistantThinkingBelongsInWorklog(m, rawIdx, toolCallAssistantIdxs)) assistantThinking.set(rawIdx, thinkingText);
+      }
+      orderedTransparentParts.forEach((part, partIdx)=>{
+        if(!part) return;
+        if(part.kind==='tool'){
+          const toolCall=_transparentOrderedToolCall(part, rawIdx, transparentOrderedToolCallsByTid, transparentToolResultsByTid);
+          const toolRow=_decorateTransparentEventRow(buildToolCard(toolCall),{
+            type:'tool',
+            name:toolCall&&toolCall.name,
+            status:_transparentToolStatus(toolCall,true),
+            toolCall,
+            segmentSeq:toolCall&&toolCall.activitySegmentSeq,
+            burstId:(toolCall&&toolCall.activityBurstId)||m._activityBurstId,
+          });
+          blocks.appendChild(toolRow);
+          if(part.toolUseId) transparentOrderedToolIds.add(part.toolUseId);
+          return;
+        }
+        const seg=document.createElement('div');
+        seg.className='assistant-segment';
+        seg.dataset.msgIdx=rawIdx;
+        seg.dataset.sessionMsgIdx=sessionMsgIdx;
+        seg.dataset.messageAnchorKey=messageAnchorKey;
+        seg.dataset.rawText=String(part.text||'').trim();
+        if(m._activityBurstId!==undefined&&m._activityBurstId!==null) seg.setAttribute('data-activity-burst-id',String(m._activityBurstId));
+        if(Number.isFinite(Number(m._liveSegmentSeq))) seg.setAttribute('data-live-segment-seq',String(Number(m._liveSegmentSeq)));
+        if(_ERR_MSG_RE.test(String(part.text||'').trim())) seg.dataset.error='1';
+        if(!firstSeg&&thinkingText&&window._showThinking!==false&&!((isCompactWorklogMode()||isTransparentStream())&&_assistantThinkingBelongsInWorklog(m, rawIdx, toolCallAssistantIdxs))){
+          seg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText));
+        }
+        const isLastTextPart=partIdx===lastTextPartIdx;
+        const partBodyHtml=_getCachedRender(part.text,false);
+        if(isLastTextPart&&statusHtml){
+          seg.insertAdjacentHTML('beforeend', statusHtml);
+        }
+        seg.insertAdjacentHTML('beforeend', `${isLastTextPart?filesHtml:''}<div class="msg-body">${partBodyHtml}</div>${isLastTextPart?footHtml:''}`);
+        blocks.appendChild(seg);
+        if(!firstSeg) firstSeg=seg;
+      });
+      assistantSegments.set(rawIdx, firstSeg||null);
+      continue;
     }
     const seg=document.createElement('div');
     seg.className='assistant-segment';
@@ -11990,6 +12146,8 @@ function renderMessages(options){
     for(const s of assistantSegments.values()) if(s){const b=s.getAttribute('data-activity-burst-id');if(b)knownBurstIds.add(b);}
     for(const tc of (S.toolCalls||[])){
       if(!tc) continue;
+      const tid=tc.tid||tc.id||tc.tool_call_id||tc.tool_use_id||tc.call_id||'';
+      if(tid&&transparentOrderedToolIds.has(tid)) continue;
       const aIdx=tc.assistant_msg_idx!==undefined?parseInt(tc.assistant_msg_idx):-1;
       if(anchorOwnedAssistantRawIdxs.has(aIdx)) continue;
       if(virtualWindow.virtualized&&renderableRawIdxs.has(aIdx)&&!renderedRawIdxs.has(aIdx)) continue;

--- a/static/ui.js
+++ b/static/ui.js
@@ -11700,6 +11700,7 @@ function renderMessages(options){
       currentAssistantTurn.dataset.recycleKey=rawIdx;
       inner.appendChild(currentAssistantTurn);
     }
+    const seg=document.createElement('div');
     if(Array.isArray(orderedTransparentParts)&&orderedTransparentParts.length){
       const blocks=_assistantTurnBlocks(currentAssistantTurn);
       const sessionMsgIdx=_messageSessionIndexForRawIdx(rawIdx);
@@ -11730,31 +11731,30 @@ function renderMessages(options){
           if(part.toolUseId) transparentOrderedToolIds.add(part.toolUseId);
           return;
         }
-        const seg=document.createElement('div');
-        seg.className='assistant-segment';
-        seg.dataset.msgIdx=rawIdx;
-        seg.dataset.sessionMsgIdx=sessionMsgIdx;
-        seg.dataset.messageAnchorKey=messageAnchorKey;
-        seg.dataset.rawText=String(part.text||'').trim();
-        if(m._activityBurstId!==undefined&&m._activityBurstId!==null) seg.setAttribute('data-activity-burst-id',String(m._activityBurstId));
-        if(Number.isFinite(Number(m._liveSegmentSeq))) seg.setAttribute('data-live-segment-seq',String(Number(m._liveSegmentSeq)));
-        if(_ERR_MSG_RE.test(String(part.text||'').trim())) seg.dataset.error='1';
+        const orderedSeg=document.createElement('div');
+        orderedSeg.className='assistant-segment';
+        orderedSeg.dataset.msgIdx=rawIdx;
+        orderedSeg.dataset.sessionMsgIdx=sessionMsgIdx;
+        orderedSeg.dataset.messageAnchorKey=messageAnchorKey;
+        orderedSeg.dataset.rawText=String(part.text||'').trim();
+        if(m._activityBurstId!==undefined&&m._activityBurstId!==null) orderedSeg.setAttribute('data-activity-burst-id',String(m._activityBurstId));
+        if(Number.isFinite(Number(m._liveSegmentSeq))) orderedSeg.setAttribute('data-live-segment-seq',String(Number(m._liveSegmentSeq)));
+        if(_ERR_MSG_RE.test(String(part.text||'').trim())) orderedSeg.dataset.error='1';
         if(!firstSeg&&thinkingText&&window._showThinking!==false&&!((isCompactWorklogMode()||isTransparentStream())&&_assistantThinkingBelongsInWorklog(m, rawIdx, toolCallAssistantIdxs))){
-          seg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText));
+          orderedSeg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText));
         }
         const isLastTextPart=partIdx===lastTextPartIdx;
         const partBodyHtml=_getCachedRender(part.text,false);
         if(isLastTextPart&&statusHtml){
-          seg.insertAdjacentHTML('beforeend', statusHtml);
+          orderedSeg.insertAdjacentHTML('beforeend', statusHtml);
         }
-        seg.insertAdjacentHTML('beforeend', `${isLastTextPart?filesHtml:''}<div class="msg-body">${partBodyHtml}</div>${isLastTextPart?footHtml:''}`);
-        blocks.appendChild(seg);
-        if(!firstSeg) firstSeg=seg;
+        orderedSeg.insertAdjacentHTML('beforeend', `${isLastTextPart?filesHtml:''}<div class="msg-body">${partBodyHtml}</div>${isLastTextPart?footHtml:''}`);
+        blocks.appendChild(orderedSeg);
+        if(!firstSeg) firstSeg=orderedSeg;
       });
       assistantSegments.set(rawIdx, firstSeg||null);
       continue;
     }
-    const seg=document.createElement('div');
     seg.className='assistant-segment';
     seg.dataset.msgIdx=rawIdx;
     seg.dataset.sessionMsgIdx=_messageSessionIndexForRawIdx(rawIdx);

--- a/tests/test_issue3397_transparent_stream_prose_segments.py
+++ b/tests/test_issue3397_transparent_stream_prose_segments.py
@@ -1,0 +1,103 @@
+"""Regression tests for issue #3397 Transparent Stream settled prose segments."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS_PATH = ROOT / "static" / "ui.js"
+UI_JS = UI_JS_PATH.read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+_DRIVER_SRC = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+const transparent = process.argv[3] === '1';
+const message = JSON.parse(process.argv[4]);
+
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+
+function isTransparentStream() { return transparent; }
+eval(extractFunc('_transparentStreamOrderedParts'));
+process.stdout.write(JSON.stringify(_transparentStreamOrderedParts(message)));
+"""
+
+
+def _run_helper(message: dict, transparent: bool) -> object:
+    if NODE is None:
+        pytest.skip("node not on PATH")
+    with tempfile.NamedTemporaryFile("w", suffix=".js", encoding="utf-8", delete=False) as handle:
+        handle.write(_DRIVER_SRC)
+        script_path = Path(handle.name)
+    try:
+        result = subprocess.run(
+            [NODE, str(script_path), str(UI_JS_PATH), "1" if transparent else "0", json.dumps(message)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    finally:
+        script_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed: {result.stderr}")
+    return json.loads(result.stdout)
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_transparent_stream_ordered_parts_preserve_text_tool_text_sequence():
+    message = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Let me search first."},
+            {"type": "tool_use", "id": "toolu_1", "name": "grep", "input": {"pattern": "TODO"}},
+            {"type": "text", "text": "Found it, here's the fix."},
+        ],
+    }
+
+    ordered = _run_helper(message, transparent=True)
+
+    assert [part["kind"] for part in ordered] == ["text", "tool", "text"]
+    assert ordered[0]["text"] == "Let me search first."
+    assert ordered[1]["toolUseId"] == "toolu_1"
+    assert ordered[2]["text"] == "Found it, here's the fix."
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_compact_mode_keeps_ordered_parts_helper_off():
+    message = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Before"},
+            {"type": "tool_use", "id": "toolu_1", "name": "grep", "input": {}},
+            {"type": "text", "text": "After"},
+        ],
+    }
+
+    assert _run_helper(message, transparent=False) is None
+
+
+def test_render_messages_wires_ordered_parts_into_transparent_stream_and_skips_duplicate_tool_rows():
+    assert "let orderedTransparentParts=_transparentStreamOrderedParts(m);" in UI_JS
+    assert "const transparentOrderedToolIds=new Set();" in UI_JS
+    assert "const toolCall=_transparentOrderedToolCall(part, rawIdx, transparentOrderedToolCallsByTid, transparentToolResultsByTid);" in UI_JS
+    assert "if(part.toolUseId) transparentOrderedToolIds.add(part.toolUseId);" in UI_JS
+    assert "if(tid&&transparentOrderedToolIds.has(tid)) continue;" in UI_JS

--- a/tests/test_issue3397_transparent_stream_prose_segments.py
+++ b/tests/test_issue3397_transparent_stream_prose_segments.py
@@ -95,9 +95,32 @@ def test_compact_mode_keeps_ordered_parts_helper_off():
     assert _run_helper(message, transparent=False) is None
 
 
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_anchor_scene_messages_keep_dedicated_transparent_renderer():
+    message = {
+        "role": "assistant",
+        "_anchor_activity_scene": {"version": "activity_scene_v1"},
+        "content": [
+            {"type": "text", "text": "Before"},
+            {"type": "tool_use", "id": "toolu_1", "name": "grep", "input": {}},
+            {"type": "text", "text": "After"},
+        ],
+    }
+
+    assert _run_helper(message, transparent=True) is None
+
+
 def test_render_messages_wires_ordered_parts_into_transparent_stream_and_skips_duplicate_tool_rows():
     assert "let orderedTransparentParts=_transparentStreamOrderedParts(m);" in UI_JS
+    assert "if(message._anchor_activity_scene) return null;" in UI_JS
+    assert "const partDisplayText=_transparentOrderedDisplayText(part.text);" in UI_JS
+    assert "const partBodyHtml=_getCachedRender(partDisplayText,false);" in UI_JS
     assert "const transparentOrderedToolIds=new Set();" in UI_JS
     assert "const toolCall=_transparentOrderedToolCall(part, rawIdx, transparentOrderedToolCallsByTid, transparentToolResultsByTid);" in UI_JS
     assert "if(part.toolUseId) transparentOrderedToolIds.add(part.toolUseId);" in UI_JS
     assert "if(tid&&transparentOrderedToolIds.has(tid)) continue;" in UI_JS
+
+
+def test_ordered_tool_cards_refresh_from_settled_results_even_after_live_preview():
+    assert "if(resultsByTid&&resultsByTid[tid]){" in UI_JS
+    assert "(next.snippet===undefined||next.snippet===null||next.snippet==='')" not in UI_JS


### PR DESCRIPTION
## Thinking Path

- `#3397` asked for a chronological transcript view where assistant commentary and tool activity are easier to read in order, but the current repo contract no longer accepts a full bubble-per-event layout.
- The shipped surface for chronological activity is now `chat_activity_display_mode`, specifically `transparent_stream`, and the current bug is narrower: settled mixed `content[]` messages still collapse all prose into one segment before the activity rows land.
- This PR fixes that surviving slice only, it preserves the Worklog and Transparent Stream direction that already shipped, and it does not revive the old parallel transcript mode from the held branch.

## What Changed

- `static/ui.js`: stop flattening mixed ordered `content[]` into one prose string in settled Transparent Stream mode, and preserve multiple prose anchors so existing tool activity rows can land between them chronologically.
- `tests/test_issue3397_transparent_stream_prose_segments.py`: add a focused regression harness for the surviving `text -> tool_use -> text` ordering case, plus a guard that Compact Worklog still stays on the old path.

## Why It Matters

Transparent Stream already promises chronological thinking and tool visibility, but mixed assistant turns can still bunch all prose at the top and push the tool rows below it. That makes the settled transcript harder to follow than the live one and leaves the current mode short of its own contract.

This change fixes the readable chronology gap without turning every internal event into a first-class chat card and without reopening the broader design debate that held the older branch.

## Verification

- `pytest tests/test_issue3397_transparent_stream_prose_segments.py -v --timeout=60`
- `pytest tests/test_issue3820_chat_activity_display_mode.py -v --timeout=60`
- Manual: open a session with mixed assistant `content[]` in Transparent Stream mode, verify prose appears before and after the related tool row instead of as one combined block at the top
- Manual: switch back to Compact Worklog, verify the same session still renders with the current folded behavior

## Risks / Follow-ups

- This is the contract-compatible slice of `#3397`, not the full bubble-mode request. If upstream still wants literal card-per-event parity later, that needs a separate maintainer design call.
- OpenAI-style top-level `tool_calls` do not carry the same ordered `content[]` shape, so this PR should keep the existing fallback behavior when safe chronological segmentation cannot be proven.

## Upstream

Closes #3397.

## Model Used

GPT 5.5 via Codex CLI
