### PR TITLE
fix(chat): ignore DOM-wipe scroll clamp during render

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -11282,6 +11282,13 @@ function renderMessages(options){
   // Mobile scroll-jank fix: temporarily disable overflow-anchor so Chromium
   // cannot re-anchor to the topmost row during the DOM wipe-and-rebuild gap.
   if(window._fixMobileScrollJank) window._fixMobileScrollJank();
+  // The DOM wipe can briefly collapse #msgInner to zero height, causing the
+  // browser to clamp #messages.scrollTop to 0 and emit a scroll event.  That
+  // event is a render artifact, not user intent; if the scroll listener sees it
+  // with _programmaticScroll=false, it marks the reader manually unpinned and
+  // the live reply stops following / appears to jump backward.
+  _programmaticScroll=true;
+  _programmaticScrollSetAt=performance.now();
   inner.innerHTML='';
   const compressionNode=compressionState?_compressionCardsNode(compressionState):null;
   const {message:referenceMessage, rawIdx:referenceMessageRawIdx}=_latestCompressionReferenceMessage(
@@ -12475,6 +12482,7 @@ function renderMessages(options){
   }
   _updateMessageVirtualMeasurements(renderVisWithIdx, renderVisibleIdxs, virtualWindow);
   _recycleStash.clear();
+  if(typeof _deferClearProgrammaticScroll==='function') _deferClearProgrammaticScroll(160);
 }
 
 function _toolDisplayName(tc){

--- a/tests/test_issue4856_android_scroll_regression.py
+++ b/tests/test_issue4856_android_scroll_regression.py
@@ -83,6 +83,27 @@ def test_rebuild_path_calls_fix_before_wipe():
     )
 
 
+def test_rebuild_path_marks_dom_wipe_scroll_as_programmatic():
+    # During innerHTML='' the scroller can transiently collapse to clientHeight
+    # and clamp scrollTop to 0. That browser event must be suppressed as
+    # programmatic; otherwise the scroll listener treats it as user upward
+    # intent and disables live auto-follow.
+    fix_idx = UI_JS.find("window._fixMobileScrollJank()")
+    assert fix_idx != -1, "renderMessages() guard call not found"
+    wipe_idx = UI_JS.find("innerHTML=''", fix_idx)
+    assert wipe_idx != -1, "innerHTML='' not found after _fixMobileScrollJank()"
+    window = UI_JS[fix_idx:wipe_idx]
+    assert "_programmaticScroll=true" in window, (
+        "renderMessages() must mark the DOM wipe/rebuild scroll event as "
+        "programmatic before innerHTML='' can clamp scrollTop."
+    )
+    assert "_programmaticScrollSetAt=performance.now()" in window
+    assert UI_JS.find("_deferClearProgrammaticScroll(160)", wipe_idx) != -1, (
+        "renderMessages() must clear the programmatic-scroll suppression after "
+        "the rebuild/post-render paint window."
+    )
+
+
 def test_streaming_tick_calls_fix_before_dom_writes():
     # The streaming render tick in messages.js must call _fixMobileScrollJank()
     # before _lastRenderMs=performance.now() so anchor suppression covers every


### PR DESCRIPTION
## Summary
- mark the message-pane DOM wipe/rebuild as a programmatic scroll window
- prevents the transient `scrollTop=0` clamp from being interpreted as user upward scroll intent
- add a regression guard to the existing #4856 Android scroll test suite

## Root cause
On a live stream, `renderMessages({ preserveScroll: true })` can rebuild the transcript by clearing `#msgInner` with `innerHTML=''`. During that short gap, the scroll container can temporarily collapse to its client height; Chromium clamps `#messages.scrollTop` to `0` and emits a scroll event.

If that event is observed while `_programmaticScroll` is false, the scroll listener treats the large upward delta as user intent and flips `_messageUserUnpinned` / `_scrollPinned`. The user then sees the live reply stop following or jump backward even though they did not scroll.

This PR marks the DOM wipe/rebuild interval as programmatic and clears the suppression shortly after the post-render paint window.

## Verification
- `python -m pytest tests/test_issue4856_android_scroll_regression.py tests/test_issue4856_mobile_transcript_unscrollable.py -q -n 0`
- Result: `8 passed`

## Local reproduction evidence
On the user's source WebUI session, a diagnostic log captured the failing state before this patch:

```text
scroll_jump source=messages-scroller:renderMessages
reason='large_up_without_recent_input top=0 last=20202 d=-20202 b=0 h=467 ch=467 pin=1 unp=0 prog=0 act=1 rs=renderMessages rp=1'
```

The key signal is `h=467 ch=467` with `top=0 last=20202`: the scroll container was clamped to the viewport height during a render rebuild, but the listener saw it as non-programmatic user scroll.

After applying the fix locally, a real long streamed WebUI reply loaded through `ui.js?...scrollfix5wipe` produced no upward jumps and kept `bottomDistance` at `0` throughout the sampled run.
