### PR TITLE
Release XN (v0.51.658): tool cards keep long content args + reconstruct diffs (#4928, #4925)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.658] — 2026-06-25 — Release XN (tool cards keep long commands and reconstruct diffs)
+
+### Fixed
+
+- **Long tool-call commands, paths, and reconstructed diffs are no longer cut to 120 characters in tool cards.** Tool-call arguments were truncated to 120 chars when persisted and when rebuilt for rendering, which clipped long single-line commands and file paths and — most damagingly — broke the diff shown for recovery-rebuilt sessions (whose diffs are reconstructed from the `old_string`/`new_string`/`patch` args). Content/diff-bearing arg keys (`command`, `cmd`, `script`, `code`, `patch`, `diff`, `old_string`, `new_string`, `content`, `path`, `file_path`) now keep their full value (bounded at a much larger storage-safe cap); incidental args still use the short cap. Secret-bearing values newly visible in the full command are masked at every render and clipboard-copy path. (#4928, part of #4925)
+
 ## [v0.51.657] — 2026-06-25 — Release XM (expanded shell tool cards show the full command)
 
 ### Fixed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4930,6 +4930,16 @@ def _agent_result_terminal_failure(result) -> bool:
 
 _TOOL_RESULT_SNIPPET_MAX = 4000
 
+# Tool-arg keys whose values are card content / diff-reconstruction inputs.
+# These must not be capped to the short incidental-arg limit (#4928), or long
+# commands/paths get cut and recovery-rebuilt diffs (built from old_string/
+# new_string/patch) break. Matched case-insensitively against the arg key.
+_TOOL_ARG_CONTENT_KEYS = frozenset({
+    'command', 'cmd', 'script', 'code', 'patch', 'diff',
+    'old_string', 'new_string', 'content', 'path', 'file_path',
+})
+_TOOL_ARG_CONTENT_CAP = _TOOL_RESULT_SNIPPET_MAX
+
 
 _LIVE_TOOL_PROMPT_DELTA_MAX = 12_000
 _LIVE_TOOL_PROMPT_TURN_MAX = 24_000
@@ -5030,13 +5040,21 @@ def _tool_result_snippet(raw, limit: int = _TOOL_RESULT_SNIPPET_MAX) -> str:
 
 
 def _truncate_tool_args(args, limit: int = 6) -> dict:
-    """Truncate tool args for compact session persistence."""
+    """Truncate tool args for compact session persistence.
+
+    Incidental args keep a short 120-char cap, but content/diff-bearing keys
+    (the command, code, and patch fields that tool cards and recovery-rebuilt
+    diffs are reconstructed from) get a much larger cap so a long command, file
+    path, or reconstructed diff is not silently corrupted (#4928). A hard cap is
+    still applied for storage safety, aligned with the result snippet cap.
+    """
     out = {}
     if not isinstance(args, dict):
         return out
     for k, v in list(args.items())[:limit]:
         s = str(v)
-        out[k] = s[:120] + ('...' if len(s) > 120 else '')
+        cap = _TOOL_ARG_CONTENT_CAP if str(k).lower() in _TOOL_ARG_CONTENT_KEYS else 120
+        out[k] = s[:cap] + ('...' if len(s) > cap else '')
     return out
 
 
@@ -6632,7 +6650,8 @@ def _run_agent_streaming(
                 if isinstance(args, dict):
                     for k, v in list(args.items())[:4]:
                         s2 = str(v)
-                        args_snap[k] = s2[:120] + ('...' if len(s2) > 120 else '')
+                        cap = _TOOL_ARG_CONTENT_CAP if str(k).lower() in _TOOL_ARG_CONTENT_KEYS else 120
+                        args_snap[k] = s2[:cap] + ('...' if len(s2) > cap else '')
                 return args_snap
 
             def _record_live_tool_start(tool_call_id, name, args):

--- a/static/ui.js
+++ b/static/ui.js
@@ -8451,7 +8451,21 @@ function _copyEventToClipboard(row){
     const fallbackName=row.getAttribute('data-event-name')||row.getAttribute('data-tool-name')||'tool';
     label=`tool ${tc.name||fallbackName}`;
     const parts=[`tool: ${tc.name||fallbackName}`];
-    if(tc.args&&Object.keys(tc.args).length) parts.push('args: '+JSON.stringify(tc.args,null,2));
+    if(tc.args&&Object.keys(tc.args).length){
+      // Redact secret-bearing arg values before copying to clipboard, mirroring
+      // the Full-tab render — content args can be long commands with secrets
+      // past the first line (#4928 gate).
+      let argsForCopy=tc.args;
+      if(typeof _redactToolTargetLabel==='function'){
+        try{
+          argsForCopy={};
+          Object.entries(tc.args).forEach(([k,v])=>{
+            argsForCopy[k]=typeof v==='string'?_redactToolTargetLabel(v):v;
+          });
+        }catch(e){ argsForCopy=tc.args; }
+      }
+      parts.push('args: '+JSON.stringify(argsForCopy,null,2));
+    }
     if(tc.snippet) parts.push('output:\n'+String(tc.snippet));
     if(parts.length===1){
       const argsText=Array.from(row.querySelectorAll('.tool-card-args .tool-arg-pair'))
@@ -8586,7 +8600,14 @@ function _transparentToolDetailHtml(tc, status){
   const meta=[];
   if(tc&&tc.duration!==undefined&&tc.duration!==null) meta.push(['duration', String(tc.duration)]);
   const preview=String((tc&&(tc.snippet||tc.preview||tc.result||tc.output))||'').trim();
-  const argHtml=[...meta,...argEntries].map(([k,v])=>`<div class="tool-arg-pair"><span class="tool-arg-key">${esc(String(k))}</span><span class="tool-arg-val">${esc(typeof v==='string'?v:JSON.stringify(v,null,2))}</span></div>`).join('');
+  const argHtml=[...meta,...argEntries].map(([k,v])=>{
+    let sv=typeof v==='string'?v:JSON.stringify(v,null,2);
+    // Redact secret-bearing arg values before rendering the transparent Full
+    // tab — content args can be long multi-line commands (#4928) whose later
+    // lines may carry secrets the short label never showed (#4928 gate).
+    if(typeof _redactToolTargetLabel==='function'){ try{ sv=_redactToolTargetLabel(sv); }catch(e){} }
+    return `<div class="tool-arg-pair"><span class="tool-arg-key">${esc(String(k))}</span><span class="tool-arg-val">${esc(sv)}</span></div>`;
+  }).join('');
   return `<div class="tool-card-detail" data-transparent-detail-mode="full"><div class="transparent-detail-modes" role="tablist"><span class="transparent-detail-mode active" role="tab" tabindex="0" data-mode="full" onclick="_setTransparentDetailMode(this,'full')">Full</span><span class="transparent-detail-mode" role="tab" tabindex="0" data-mode="output" onclick="_setTransparentDetailMode(this,'output')">Output</span></div><div class="tool-card-args">${argHtml}</div>${preview?`<div class="tool-card-result"><pre>${esc(preview)}</pre></div>`:''}</div>`;
 }
 function _syncTransparentEventControls(turn){
@@ -10974,7 +10995,13 @@ function _toolArgsSnapshot(args, limit){
   keys.forEach(k=>{
     const v=String(args[k]);
     const cap=contentKeys.has(String(k).toLowerCase())?CONTENT_CAP:120;
-    out[k]=v.slice(0,cap)+(v.length>cap?'...':'');
+    let val=v.slice(0,cap)+(v.length>cap?'...':'');
+    // Now that content args are retained up to 4000 chars (#4928), a secret on
+    // a non-first line / past char 120 would otherwise reach the args block,
+    // the Full tab, and clipboard copy unredacted. Redact at the snapshot so
+    // every downstream renderer receives already-masked args (#4928 gate).
+    if(typeof _redactToolTargetLabel==='function'){ try{ val=_redactToolTargetLabel(val); }catch(e){} }
+    out[k]=val;
   });
   return out;
 }
@@ -13032,7 +13059,11 @@ function buildToolCard(tc){
       ${hasDetail?`<div class="tool-card-detail">
         ${detailLead}
         ${visibleArgs.length?`<div class="tool-card-args">${
-          visibleArgs.map(([k,v])=>`<div class="tool-arg-pair"><span class="tool-arg-key">${esc(k)}</span><span class="tool-arg-val">${esc(String(v))}</span></div>`).join('')
+          visibleArgs.map(([k,v])=>{
+            let sv=String(v);
+            if(typeof _redactToolTargetLabel==='function'){ try{ sv=_redactToolTargetLabel(sv); }catch(e){} }
+            return `<div class="tool-arg-pair"><span class="tool-arg-key">${esc(k)}</span><span class="tool-arg-val">${esc(sv)}</span></div>`;
+          }).join('')
         }</div>`:''}
         ${displaySnippet?`<div class="tool-card-result">
           <pre>${tc.is_diff||_snippetLooksLikeDiff(displaySnippet)?`<code class="diff-block" data-highlighted="1">${_colorDiffLines(displaySnippet)}</code>`:esc(displaySnippet)}</pre>

--- a/static/ui.js
+++ b/static/ui.js
@@ -10960,6 +10960,12 @@ function _toolArgsSnapshot(args, limit){
     'url','uri','command','cmd','path','file','file_path','filename','file_glob',
     'glob','offset','limit',
   ];
+  // Content / diff-reconstruction keys must not be capped to the short
+  // incidental-arg limit, or long commands/paths get cut and recovery-rebuilt
+  // diffs (built from old_string/new_string/patch) break (#4928). Mirrors the
+  // backend _TOOL_ARG_CONTENT_KEYS / _TOOL_ARG_CONTENT_CAP.
+  const contentKeys=new Set(['command','cmd','script','code','patch','diff','old_string','new_string','content','path','file_path']);
+  const CONTENT_CAP=4000;
   const keys=[
     ...priority.filter(k=>Object.prototype.hasOwnProperty.call(args,k)),
     ...Object.keys(args).filter(k=>!priority.includes(k)),
@@ -10967,7 +10973,8 @@ function _toolArgsSnapshot(args, limit){
   const out={};
   keys.forEach(k=>{
     const v=String(args[k]);
-    out[k]=v.slice(0,120)+(v.length>120?'...':'');
+    const cap=contentKeys.has(String(k).toLowerCase())?CONTENT_CAP:120;
+    out[k]=v.slice(0,cap)+(v.length>cap?'...':'');
   });
   return out;
 }

--- a/tests/test_issue4928_tool_arg_content_cap.py
+++ b/tests/test_issue4928_tool_arg_content_cap.py
@@ -133,3 +133,57 @@ def test_frontend_keeps_patch_args(fe_driver):
 def test_frontend_incidental_arg_still_capped(fe_driver):
     out = _fe_snapshot(fe_driver, {"label": "z" * 300})
     assert out["label"] == "z" * 120 + "..."
+
+
+# ---------- frontend: transparent Full-tab args render must redact ----------
+
+_DETAIL_DRIVER = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+function grab(name){
+  const re = new RegExp('function ' + name + '\\([^]*?\\n}', 'm');
+  const m = src.match(re);
+  if (!m) throw new Error('not found: ' + name);
+  return m[0];
+}
+global.esc = (s) => String(s);   // identity so we can scan the raw value
+global._decodeToolLabelEntities = (s) => s;
+eval(grab('_redactToolTargetLabel'));
+eval(grab('_transparentToolDetailHtml'));
+let buf = '';
+process.stdin.on('data', c => { buf += c; });
+process.stdin.on('end', () => {
+  const payload = JSON.parse(buf || '{}');
+  process.stdout.write(_transparentToolDetailHtml(payload.tc || {}, 'done'));
+});
+"""
+
+
+@pytest.fixture(scope="module")
+def detail_driver(tmp_path_factory):
+    if NODE is None:
+        pytest.skip("node not on PATH")
+    p = tmp_path_factory.mktemp("detail_driver") / "driver.js"
+    p.write_text(_DETAIL_DRIVER, encoding="utf-8")
+    return str(p)
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_transparent_full_tab_redacts_secret_in_long_command(detail_driver):
+    """#4928 gate: now that content args are retained to 4000 chars, the Full-tab
+    args render must redact secrets past char 120 (it renders tc.args directly)."""
+    cmd = "echo start\n" + ("x" * 130) + "\nexport OPENAI_API_KEY=sk_LEAKsecret123\necho end"
+    result = subprocess.run(
+        [NODE, detail_driver, str(UI_JS_PATH)],
+        input=json.dumps({"tc": {"name": "shell", "args": {"command": cmd}}}),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+    html = result.stdout
+    assert "sk_LEAKsecret123" not in html, f"secret leaked into Full-tab args: {html[:600]}"
+    assert "[redacted]" in html
+    # The non-secret structure should still be present (full command retained).
+    assert "echo end" in html

--- a/tests/test_issue4928_tool_arg_content_cap.py
+++ b/tests/test_issue4928_tool_arg_content_cap.py
@@ -1,0 +1,135 @@
+"""Regression coverage for #4928 — tool-call content args must not be capped to
+120 chars (which corrupts long commands/paths and breaks recovery-rebuilt diffs).
+
+Tool-call args were truncated to 120 chars at two backend points
+(`_truncate_tool_args`, the live `_tool_args_snapshot`) and one frontend point
+(`_toolArgsSnapshot`). For incidental args that's fine, but content/diff-bearing
+keys (command/cmd/script/code/patch/diff/old_string/new_string/content/path/
+file_path) feed the rendered tool card AND the diff reconstruction in
+recovery-rebuilt sessions, so a 120-char cap silently corrupted them. The fix
+exempts those keys with a much larger cap (aligned with the result-snippet cap)
+at every site, keyed by key name.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from api.streaming import (
+    _TOOL_ARG_CONTENT_CAP,
+    _TOOL_ARG_CONTENT_KEYS,
+    _truncate_tool_args,
+)
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+_LONG_CMD = "echo start\n" + ("x" * 300) + "\necho end"  # 320 chars, multi-line
+_LONG_PATCH = "@@ -1 +1 @@\n-" + ("a" * 200) + "\n+" + ("b" * 200)  # ~420 chars
+
+
+# ---------- backend: _truncate_tool_args ----------
+
+def test_backend_keeps_full_command_arg():
+    """A long `command` arg must survive well past 120 chars."""
+    out = _truncate_tool_args({"command": _LONG_CMD})
+    # Not truncated at 120; retained up to the content cap.
+    assert len(out["command"].rstrip(".")) > 120
+    assert "echo end" in out["command"], out["command"]
+
+
+def test_backend_keeps_patch_diff_args():
+    """old_string/new_string/patch (diff reconstruction inputs) survive."""
+    out = _truncate_tool_args({
+        "old_string": "o" * 300,
+        "new_string": "n" * 300,
+        "patch": _LONG_PATCH,
+    })
+    assert len(out["old_string"].rstrip(".")) > 120
+    assert len(out["new_string"].rstrip(".")) > 120
+    assert "@@ -1 +1 @@" in out["patch"]
+
+
+def test_backend_incidental_arg_still_capped():
+    """A non-content arg (e.g. a random label) keeps the short 120 cap."""
+    out = _truncate_tool_args({"label": "z" * 300})
+    assert out["label"] == "z" * 120 + "..."
+
+
+def test_backend_content_cap_is_large():
+    """The content cap is the larger snippet-aligned bound, not 120."""
+    assert _TOOL_ARG_CONTENT_CAP >= 4000
+    assert "command" in _TOOL_ARG_CONTENT_KEYS
+    assert "old_string" in _TOOL_ARG_CONTENT_KEYS
+
+
+def test_backend_very_large_content_still_bounded():
+    """Storage safety: even content keys are bounded at the (large) content cap."""
+    huge = "q" * (_TOOL_ARG_CONTENT_CAP + 5000)
+    out = _truncate_tool_args({"command": huge})
+    assert out["command"].endswith("...")
+    assert len(out["command"]) == _TOOL_ARG_CONTENT_CAP + 3  # cap + '...'
+
+
+# ---------- frontend: _toolArgsSnapshot ----------
+
+_FE_DRIVER = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+const m = src.match(/function _toolArgsSnapshot\([^]*?\n}/m);
+if (!m) throw new Error('_toolArgsSnapshot not found');
+eval(m[0]);
+let buf = '';
+process.stdin.on('data', c => { buf += c; });
+process.stdin.on('end', () => {
+  const payload = JSON.parse(buf || '{}');
+  process.stdout.write(JSON.stringify(_toolArgsSnapshot(payload.args || {}, payload.limit)));
+});
+"""
+
+
+@pytest.fixture(scope="module")
+def fe_driver(tmp_path_factory):
+    if NODE is None:
+        pytest.skip("node not on PATH")
+    p = tmp_path_factory.mktemp("args_snapshot_driver") / "driver.js"
+    p.write_text(_FE_DRIVER, encoding="utf-8")
+    return str(p)
+
+
+def _fe_snapshot(fe_driver: str, args: dict) -> dict:
+    result = subprocess.run(
+        [NODE, fe_driver, str(UI_JS_PATH)],
+        input=json.dumps({"args": args}),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+    return json.loads(result.stdout)
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_frontend_keeps_full_command_arg(fe_driver):
+    out = _fe_snapshot(fe_driver, {"command": _LONG_CMD})
+    assert len(out["command"].rstrip(".")) > 120
+    assert "echo end" in out["command"]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_frontend_keeps_patch_args(fe_driver):
+    out = _fe_snapshot(fe_driver, {"old_string": "o" * 300, "new_string": "n" * 300})
+    assert len(out["old_string"].rstrip(".")) > 120
+    assert len(out["new_string"].rstrip(".")) > 120
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_frontend_incidental_arg_still_capped(fe_driver):
+    out = _fe_snapshot(fe_driver, {"label": "z" * 300})
+    assert out["label"] == "z" * 120 + "..."


### PR DESCRIPTION
## Release XN (v0.51.658) — tool cards keep long commands and reconstruct diffs

Resolves **#4928** (part of #4925, the transparent-stream cluster). Self-built fix.

### What it fixes
Tool-call args were truncated to 120 chars at three sites (`_truncate_tool_args`, the live `_tool_args_snapshot`, frontend `_toolArgsSnapshot`), clipping long commands/paths and breaking diff reconstruction in recovery-rebuilt sessions (whose diffs are rebuilt from `old_string`/`new_string`/`patch`). Content/diff-bearing keys now keep their full value (bounded at `_TOOL_RESULT_SNIPPET_MAX`=4000 for storage safety); incidental args keep the 120 cap.

### Security (gate-driven)
Showing full-length content args re-opened a redaction gap on paths that render `tc.args` directly. `_redactToolTargetLabel` is now applied at **every** render/copy site: the transparent Full-tab args, the non-transparent tool-card args block, clipboard copy, and the arg snapshot.

### Gate decision (documented)
Codex's final round asked to ALSO redact the backend `_truncate_tool_args` persistence and the localStorage inflight snapshot. **Declined, with reasoning:** redacting `old_string`/`new_string`/`patch` in *storage* would break the diff reconstruction this PR exists to fix — those paths need the real values. The full command/diff already lives unredacted in state.db and the raw assistant messages, so masking only the compact `session.tool_calls` copy is inconsistent theater, not a real exposure boundary. Redaction is correctly a **render-time** concern (store real, mask on display), which is the layer this fixes. localStorage mirrors state.db's single-user-local trust model (per the project's security scope, local storage is low-risk, not the high-risk public surface).

### Gate
- Codex: render/copy redaction SAFE; backend-storage-redaction asks declined with the diff-reconstruction reasoning above.
- Full suite: 10589 passed (1 known pre-existing order-flake `test_skills_stats_cache`, passes in isolation).
- 9 regression tests (backend direct + frontend node-driven, proven non-vacuous, incl. Full-tab secret-masking).
