### PR TITLE
fix(mobile): show the reload button outside standalone mode (#4784)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2462,6 +2462,7 @@
     .app-titlebar{justify-content:space-between;}
     .app-titlebar-hamburger,.app-titlebar-spacer{display:flex;}
     .app-titlebar-new-chat{display:inline-flex;}
+    .app-titlebar-reload{display:inline-flex;}
     .app-titlebar-inner{flex:1 1 auto;}
     .system-health-panel.insights-card{gap:10px;padding:12px;}
     .system-health-head{align-items:flex-start;}

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -914,6 +914,46 @@ def test_titlebar_new_chat_button_mobile_visibility_css():
     )
 
 
+def test_titlebar_reload_button_visibility_css_contract():
+    """Keep reload hidden by default, keep standalone visibility, and expose it on mobile width."""
+    base_rule = _declarations(_rule_body(CSS, ".app-titlebar-reload"))
+    assert _display_hidden(base_rule), "app-titlebar reload button should stay hidden by default"
+
+    standalone_mode_pattern = re.compile(
+        r"@media\s*\(\s*display-mode:\s*standalone\s*\)\s*,\s*"
+        r"\(\s*display-mode:\s*fullscreen\s*\)\s*\{"
+    )
+    standalone_rule_body = None
+    for match in standalone_mode_pattern.finditer(CSS):
+        open_brace = match.end() - 1
+        depth = 0
+        for idx in range(open_brace, len(CSS)):
+            if CSS[idx] == "{":
+                depth += 1
+            elif CSS[idx] == "}":
+                depth -= 1
+                if depth == 0:
+                    block = CSS[open_brace + 1 : idx]
+                    if ".app-titlebar-reload" in block:
+                        standalone_rule_body = block
+                    break
+        if standalone_rule_body is not None:
+            break
+    assert standalone_rule_body is not None, (
+        "standalone/fullscreen media block for titlebar reload could not be parsed"
+    )
+    standalone_rule = _declarations(_rule_body(standalone_rule_body, ".app-titlebar-reload"))
+    assert standalone_rule.get("display") == "inline-flex", (
+        "titlebar reload should remain inline-flex in standalone/fullscreen"
+    )
+
+    mobile_blocks = "".join(_max_width_media_blocks(640))
+    mobile_rule = _declarations(_rule_body(mobile_blocks, ".app-titlebar-reload"))
+    assert _display_inline_flex(mobile_rule), (
+        "app-titlebar reload button should be visible in phone-width titlebar rules"
+    )
+
+
 # ── Viewport and scroll safety ────────────────────────────────────────────────
 
 def test_body_overflow_hidden():


### PR DESCRIPTION
## Thinking Path

- The reload affordance already exists in the titlebar markup, so the bug is a visibility gate, not missing UI wiring.
- The base titlebar CSS hides both mobile icon buttons, then the phone-width block re-shows only new chat while the standalone/fullscreen block separately re-shows reload.
- The narrowest fix is to mirror the existing mobile new-chat visibility rule for `.app-titlebar-reload` and lock that behavior in with a focused titlebar CSS regression.

## What Changed

- `static/style.css`: re-show `.app-titlebar-reload` inside the existing `@media(max-width:640px)` titlebar block while leaving the default hidden rule and the standalone/fullscreen rule untouched.
- `tests/test_mobile_layout.py`: add a focused regression that asserts reload is hidden by default, visible in standalone/fullscreen, and also visible in the phone-width mobile block.

## Why It Matters

Mobile browser sessions and native mobile shells get an explicit reload affordance again without changing desktop titlebar clutter or the standalone behavior that already worked.

## Verification

`pytest tests/test_mobile_layout.py -v --timeout=60`

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #4784

## Model Used

GPT 5.5 via Codex CLI
