### PR TITLE
Release XS (v0.51.663): show mobile reload button outside standalone mode (#4939, fixes #4784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.663] — 2026-06-25 — Release XS (mobile reload button shows outside standalone mode)
+
+### Fixed
+
+- **The reload/refresh button is now visible in the mobile titlebar in a normal browser, not only in installed/standalone (PWA) mode.** The phone-width titlebar re-showed only the new-chat button while the reload button was re-shown by a separate standalone/fullscreen rule, so on a regular mobile browser there was no reload affordance. The phone-width rule now shows it too (it stays hidden on desktop, where it isn't needed). Thanks @rodboev. (#4939, fixes #4784)
+
 ## [v0.51.662] — 2026-06-25 — Release XR (live replies keep following during transcript rebuilds)
 
 ### Fixed

--- a/static/style.css
+++ b/static/style.css
@@ -2462,6 +2462,7 @@
     .app-titlebar{justify-content:space-between;}
     .app-titlebar-hamburger,.app-titlebar-spacer{display:flex;}
     .app-titlebar-new-chat{display:inline-flex;}
+    .app-titlebar-reload{display:inline-flex;}
     .app-titlebar-inner{flex:1 1 auto;}
     .system-health-panel.insights-card{gap:10px;padding:12px;}
     .system-health-head{align-items:flex-start;}

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -914,6 +914,46 @@ def test_titlebar_new_chat_button_mobile_visibility_css():
     )
 
 
+def test_titlebar_reload_button_visibility_css_contract():
+    """Keep reload hidden by default, keep standalone visibility, and expose it on mobile width."""
+    base_rule = _declarations(_rule_body(CSS, ".app-titlebar-reload"))
+    assert _display_hidden(base_rule), "app-titlebar reload button should stay hidden by default"
+
+    standalone_mode_pattern = re.compile(
+        r"@media\s*\(\s*display-mode:\s*standalone\s*\)\s*,\s*"
+        r"\(\s*display-mode:\s*fullscreen\s*\)\s*\{"
+    )
+    standalone_rule_body = None
+    for match in standalone_mode_pattern.finditer(CSS):
+        open_brace = match.end() - 1
+        depth = 0
+        for idx in range(open_brace, len(CSS)):
+            if CSS[idx] == "{":
+                depth += 1
+            elif CSS[idx] == "}":
+                depth -= 1
+                if depth == 0:
+                    block = CSS[open_brace + 1 : idx]
+                    if ".app-titlebar-reload" in block:
+                        standalone_rule_body = block
+                    break
+        if standalone_rule_body is not None:
+            break
+    assert standalone_rule_body is not None, (
+        "standalone/fullscreen media block for titlebar reload could not be parsed"
+    )
+    standalone_rule = _declarations(_rule_body(standalone_rule_body, ".app-titlebar-reload"))
+    assert standalone_rule.get("display") == "inline-flex", (
+        "titlebar reload should remain inline-flex in standalone/fullscreen"
+    )
+
+    mobile_blocks = "".join(_max_width_media_blocks(640))
+    mobile_rule = _declarations(_rule_body(mobile_blocks, ".app-titlebar-reload"))
+    assert _display_inline_flex(mobile_rule), (
+        "app-titlebar reload button should be visible in phone-width titlebar rules"
+    )
+
+
 # ── Viewport and scroll safety ────────────────────────────────────────────────
 
 def test_body_overflow_hidden():


### PR DESCRIPTION
## Release XS (v0.51.663) — mobile reload button shows outside standalone mode

Ships **#4939** (@rodboev) — fixes #4784. CSS-only (+41/-0).

### What it fixes
The reload/refresh button was only re-shown by the standalone/fullscreen (PWA) titlebar rule, so in a normal mobile browser it never appeared. The phone-width (max-width:640px) rule now shows `.app-titlebar-reload` (mirroring the new-chat button), while it stays hidden on desktop.

### Gate (clean)
- Codex: **SAFE TO SHIP** — scoped to the mobile block, no desktop regression (computed display verified `none` at 1280px), consistent with the standalone rule, regression test locks all three states.
- Full suite: **10602 passed**, 0 failures; +CSS-contract regression test in test_mobile_layout.py.
- Screenshot verified on 390px mobile: hamburger | ✝ Chat | + | ↻ — clean, no overlap (sent to maintainer).
- Pre-merge head re-check: gated == live (3dc4f540).

Credit @rodboev.
