### PR TITLE
Release XT (v0.51.664): transparent stream keeps prose chronological for mixed turns (#4932, #3397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.664] — 2026-06-25 — Release XT (transparent stream keeps prose in chronological order)
+
+### Fixed
+
+- **In the transparent activity stream, a settled assistant turn that mixes commentary and tool activity now keeps its prose in chronological order instead of collapsing all text above the tool rows.** Settled mixed-content messages previously merged every text segment into one block before the activity rows landed, so the natural "explain → run tool → explain → run tool" reading order was lost. The transcript now interleaves text and tool cards in their original order for those turns. The Worklog / Transparent Stream model is unchanged; this only fixes the surviving ordering gap. Thanks @rodboev. (#4932, #3397)
+
 ## [v0.51.663] — 2026-06-25 — Release XS (mobile reload button shows outside standalone mode)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -11123,6 +11123,7 @@ let _assistantTurnAnchorSettledFinalAnswerWarned=false;
 function _transparentStreamOrderedParts(message){
   if(typeof isTransparentStream==='function'&&!isTransparentStream()) return null;
   if(!message||message.role!=='assistant'||message._live||!Array.isArray(message.content)) return null;
+  if(message._anchor_activity_scene) return null;
   const ordered=[];
   let hasText=false;
   let hasTool=false;
@@ -11148,6 +11149,13 @@ function _transparentStreamOrderedParts(message){
     }
   }
   return hasText&&hasTool?ordered:null;
+}
+function _transparentOrderedDisplayText(text){
+  return _stripWorkspaceDisplayPrefix(
+    _stripAttachedFilesMarkerForDisplay(
+      _stripLeadingAssistantThinkingMarkup(String(text||''))
+    )
+  );
 }
 function _collectToolResultSnippetsByTid(messages){
   const resultsByTid={};
@@ -11178,7 +11186,7 @@ function _transparentOrderedToolCall(part, rawIdx, toolCallsByTid, resultsByTid)
   const liveTool=tid&&toolCallsByTid&&toolCallsByTid.get(tid);
   if(liveTool){
     const next={...liveTool};
-    if((next.snippet===undefined||next.snippet===null||next.snippet==='')&&resultsByTid&&resultsByTid[tid]){
+    if(resultsByTid&&resultsByTid[tid]){
       const patchSnippet=_cliPatchSnippetFromArgs(next.name||part.name||'tool', next.args||part.input||{});
       next.snippet=_cliToolCardSnippet(resultsByTid[tid],patchSnippet);
       next.is_diff=_cliToolCardHasDiffSnippet(resultsByTid[tid],patchSnippet);
@@ -11748,7 +11756,11 @@ function renderMessages(options){
       const messageAnchorKey=_messageViewportAnchorKeyForMessage(m);
       const lastTextPartIdx=(()=>{
         for(let i=orderedTransparentParts.length-1;i>=0;i--){
-          if(orderedTransparentParts[i]&&orderedTransparentParts[i].kind==='text') return i;
+          if(
+            orderedTransparentParts[i]&&
+            orderedTransparentParts[i].kind==='text'&&
+            String(_transparentOrderedDisplayText(orderedTransparentParts[i].text)).trim()
+          ) return i;
         }
         return -1;
       })();
@@ -11773,19 +11785,19 @@ function renderMessages(options){
           return;
         }
         const orderedSeg=document.createElement('div');
+        const partDisplayText=_transparentOrderedDisplayText(part.text);
+        if(!String(partDisplayText).trim()) return;
         orderedSeg.className='assistant-segment';
         orderedSeg.dataset.msgIdx=rawIdx;
         orderedSeg.dataset.sessionMsgIdx=sessionMsgIdx;
         orderedSeg.dataset.messageAnchorKey=messageAnchorKey;
-        orderedSeg.dataset.rawText=String(part.text||'').trim();
+        orderedSeg.dataset.rawText=String(partDisplayText||'').trim();
         if(m._activityBurstId!==undefined&&m._activityBurstId!==null) orderedSeg.setAttribute('data-activity-burst-id',String(m._activityBurstId));
         if(Number.isFinite(Number(m._liveSegmentSeq))) orderedSeg.setAttribute('data-live-segment-seq',String(Number(m._liveSegmentSeq)));
-        if(_ERR_MSG_RE.test(String(part.text||'').trim())) orderedSeg.dataset.error='1';
-        if(!firstSeg&&thinkingText&&window._showThinking!==false&&!((isCompactWorklogMode()||isTransparentStream())&&_assistantThinkingBelongsInWorklog(m, rawIdx, toolCallAssistantIdxs))){
-          orderedSeg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText));
-        }
+        if(_ERR_MSG_RE.test(String(partDisplayText||'').trim())) orderedSeg.dataset.error='1';
+        if(!firstSeg&&thinkingText&&window._showThinking!==false&&!((isCompactWorklogMode()||isTransparentStream())&&_assistantThinkingBelongsInWorklog(m, rawIdx, toolCallAssistantIdxs))) orderedSeg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText));
         const isLastTextPart=partIdx===lastTextPartIdx;
-        const partBodyHtml=_getCachedRender(part.text,false);
+        const partBodyHtml=_getCachedRender(partDisplayText,false);
         if(isLastTextPart&&statusHtml){
           orderedSeg.insertAdjacentHTML('beforeend', statusHtml);
         }

--- a/static/ui.js
+++ b/static/ui.js
@@ -11181,15 +11181,16 @@ function _collectToolResultSnippetsByTid(messages){
   }
   return resultsByTid;
 }
-function _transparentOrderedToolCall(part, rawIdx, toolCallsByTid, resultsByTid){
+function _transparentOrderedToolCall(part, rawIdx, toolCallsByTid, resultsByTid, persistedByTid){
   const tid=String(part&&part.toolUseId||'').trim();
   const liveTool=tid&&toolCallsByTid&&toolCallsByTid.get(tid);
   if(liveTool){
     const next={...liveTool};
-    if(resultsByTid&&resultsByTid[tid]){
+    const liveSnip=(resultsByTid&&resultsByTid[tid])||(persistedByTid&&persistedByTid[tid])||'';
+    if(liveSnip){
       const patchSnippet=_cliPatchSnippetFromArgs(next.name||part.name||'tool', next.args||part.input||{});
-      next.snippet=_cliToolCardSnippet(resultsByTid[tid],patchSnippet);
-      next.is_diff=_cliToolCardHasDiffSnippet(resultsByTid[tid],patchSnippet);
+      next.snippet=_cliToolCardSnippet(liveSnip,patchSnippet);
+      next.is_diff=_cliToolCardHasDiffSnippet(liveSnip,patchSnippet);
     }
     if(next.done===undefined) next.done=true;
     return next;
@@ -11197,7 +11198,7 @@ function _transparentOrderedToolCall(part, rawIdx, toolCallsByTid, resultsByTid)
   const name=part&&part.name||'tool';
   const args=(part&&part.input&&typeof part.input==='object')?part.input:{};
   const patchSnippet=_cliPatchSnippetFromArgs(name,args);
-  const resultSnippet=(resultsByTid&&tid&&resultsByTid[tid])||'';
+  const resultSnippet=(resultsByTid&&tid&&resultsByTid[tid])||(persistedByTid&&tid&&persistedByTid[tid])||'';
   return {
     name,
     tid,
@@ -11554,14 +11555,33 @@ function renderMessages(options){
   }
   const transparentOrderedToolIds=new Set();
   const transparentOrderedToolCallsByTid=new Map();
-  if(Array.isArray(S.toolCalls)){
-    for(const tc of S.toolCalls){
-      if(!tc||typeof tc!=='object') continue;
-      const tid=tc.tid||tc.id||tc.tool_call_id||tc.tool_use_id||tc.call_id||'';
-      if(tid&&!transparentOrderedToolCallsByTid.has(tid)) transparentOrderedToolCallsByTid.set(tid,tc);
+  // These scans only feed the transparent-stream ordered render path; skip the
+  // O(messages×parts) work entirely in other modes (Opus perf finding #4932).
+  const _transparentModeActive=(typeof isTransparentStream==='function')&&isTransparentStream();
+  const transparentPersistedSnippetByTid={};
+  if(_transparentModeActive){
+    if(Array.isArray(S.toolCalls)){
+      for(const tc of S.toolCalls){
+        if(!tc||typeof tc!=='object') continue;
+        const tid=tc.tid||tc.id||tc.tool_call_id||tc.tool_use_id||tc.call_id||'';
+        if(tid&&!transparentOrderedToolCallsByTid.has(tid)) transparentOrderedToolCallsByTid.set(tid,tc);
+      }
     }
+    // #4927 durable fallback: the ordered path must consult the persisted
+    // session.tool_calls snippet by tid too, or a cold/paginated load where the
+    // S.messages tool_result join misses renders an empty body — and its inline
+    // card then suppresses the post-loop derived card that WOULD have recovered.
+    try{
+      const persisted=(S.session&&Array.isArray(S.session.tool_calls))?S.session.tool_calls:[];
+      persisted.forEach(tc=>{
+        if(!tc||typeof tc!=='object') return;
+        const ptid=tc.tid||tc.id||tc.tool_call_id||tc.call_id||'';
+        const psnip=tc.snippet||tc.result||tc.output||tc.preview||'';
+        if(ptid&&psnip&&!transparentPersistedSnippetByTid[ptid]) transparentPersistedSnippetByTid[ptid]=String(psnip);
+      });
+    }catch(e){}
   }
-  const transparentToolResultsByTid=_collectToolResultSnippetsByTid(S.messages);
+  const transparentToolResultsByTid=_transparentModeActive?_collectToolResultSnippetsByTid(S.messages):{};
   // Windowed render loop replaces the legacy full loop:
   // for(let vi=0;vi<visWithIdx.length;vi++)
   for(let vi=0;vi<renderVisWithIdx.length;vi++){
@@ -11771,7 +11791,7 @@ function renderMessages(options){
       orderedTransparentParts.forEach((part, partIdx)=>{
         if(!part) return;
         if(part.kind==='tool'){
-          const toolCall=_transparentOrderedToolCall(part, rawIdx, transparentOrderedToolCallsByTid, transparentToolResultsByTid);
+          const toolCall=_transparentOrderedToolCall(part, rawIdx, transparentOrderedToolCallsByTid, transparentToolResultsByTid, transparentPersistedSnippetByTid);
           const toolRow=_decorateTransparentEventRow(buildToolCard(toolCall),{
             type:'tool',
             name:toolCall&&toolCall.name,

--- a/static/ui.js
+++ b/static/ui.js
@@ -11741,6 +11741,7 @@ function renderMessages(options){
       currentAssistantTurn.dataset.recycleKey=rawIdx;
       inner.appendChild(currentAssistantTurn);
     }
+    const seg=document.createElement('div');
     if(Array.isArray(orderedTransparentParts)&&orderedTransparentParts.length){
       const blocks=_assistantTurnBlocks(currentAssistantTurn);
       const sessionMsgIdx=_messageSessionIndexForRawIdx(rawIdx);
@@ -11771,31 +11772,30 @@ function renderMessages(options){
           if(part.toolUseId) transparentOrderedToolIds.add(part.toolUseId);
           return;
         }
-        const seg=document.createElement('div');
-        seg.className='assistant-segment';
-        seg.dataset.msgIdx=rawIdx;
-        seg.dataset.sessionMsgIdx=sessionMsgIdx;
-        seg.dataset.messageAnchorKey=messageAnchorKey;
-        seg.dataset.rawText=String(part.text||'').trim();
-        if(m._activityBurstId!==undefined&&m._activityBurstId!==null) seg.setAttribute('data-activity-burst-id',String(m._activityBurstId));
-        if(Number.isFinite(Number(m._liveSegmentSeq))) seg.setAttribute('data-live-segment-seq',String(Number(m._liveSegmentSeq)));
-        if(_ERR_MSG_RE.test(String(part.text||'').trim())) seg.dataset.error='1';
+        const orderedSeg=document.createElement('div');
+        orderedSeg.className='assistant-segment';
+        orderedSeg.dataset.msgIdx=rawIdx;
+        orderedSeg.dataset.sessionMsgIdx=sessionMsgIdx;
+        orderedSeg.dataset.messageAnchorKey=messageAnchorKey;
+        orderedSeg.dataset.rawText=String(part.text||'').trim();
+        if(m._activityBurstId!==undefined&&m._activityBurstId!==null) orderedSeg.setAttribute('data-activity-burst-id',String(m._activityBurstId));
+        if(Number.isFinite(Number(m._liveSegmentSeq))) orderedSeg.setAttribute('data-live-segment-seq',String(Number(m._liveSegmentSeq)));
+        if(_ERR_MSG_RE.test(String(part.text||'').trim())) orderedSeg.dataset.error='1';
         if(!firstSeg&&thinkingText&&window._showThinking!==false&&!((isCompactWorklogMode()||isTransparentStream())&&_assistantThinkingBelongsInWorklog(m, rawIdx, toolCallAssistantIdxs))){
-          seg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText));
+          orderedSeg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText));
         }
         const isLastTextPart=partIdx===lastTextPartIdx;
         const partBodyHtml=_getCachedRender(part.text,false);
         if(isLastTextPart&&statusHtml){
-          seg.insertAdjacentHTML('beforeend', statusHtml);
+          orderedSeg.insertAdjacentHTML('beforeend', statusHtml);
         }
-        seg.insertAdjacentHTML('beforeend', `${isLastTextPart?filesHtml:''}<div class="msg-body">${partBodyHtml}</div>${isLastTextPart?footHtml:''}`);
-        blocks.appendChild(seg);
-        if(!firstSeg) firstSeg=seg;
+        orderedSeg.insertAdjacentHTML('beforeend', `${isLastTextPart?filesHtml:''}<div class="msg-body">${partBodyHtml}</div>${isLastTextPart?footHtml:''}`);
+        blocks.appendChild(orderedSeg);
+        if(!firstSeg) firstSeg=orderedSeg;
       });
       assistantSegments.set(rawIdx, firstSeg||null);
       continue;
     }
-    const seg=document.createElement('div');
     seg.className='assistant-segment';
     seg.dataset.msgIdx=rawIdx;
     seg.dataset.sessionMsgIdx=_messageSessionIndexForRawIdx(rawIdx);

--- a/static/ui.js
+++ b/static/ui.js
@@ -11120,6 +11120,87 @@ function _renderMessagesWithScrollSnapshot(options){
   _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
 }
 let _assistantTurnAnchorSettledFinalAnswerWarned=false;
+function _transparentStreamOrderedParts(message){
+  if(typeof isTransparentStream==='function'&&!isTransparentStream()) return null;
+  if(!message||message.role!=='assistant'||message._live||!Array.isArray(message.content)) return null;
+  const ordered=[];
+  let hasText=false;
+  let hasTool=false;
+  for(const part of message.content){
+    if(!part||typeof part!=='object') continue;
+    if(part.type==='text'){
+      const text=typeof part.text==='string'?part.text:(typeof part.content==='string'?part.content:'');
+      if(!String(text||'').trim()) continue;
+      ordered.push({kind:'text', text});
+      hasText=true;
+      continue;
+    }
+    if(part.type==='tool_use'){
+      const toolUseId=String(part.id||'').trim();
+      if(!toolUseId) return null;
+      ordered.push({
+        kind:'tool',
+        toolUseId,
+        name:part.name||'tool',
+        input:(part.input&&typeof part.input==='object')?part.input:{},
+      });
+      hasTool=true;
+    }
+  }
+  return hasText&&hasTool?ordered:null;
+}
+function _collectToolResultSnippetsByTid(messages){
+  const resultsByTid={};
+  for(const message of (messages||[])){
+    if(!message) continue;
+    if(message.role==='tool'){
+      const tid=message.tool_call_id||message.tool_use_id||'';
+      if(tid) resultsByTid[tid]=_cliToolResultSnippet(message.content);
+      continue;
+    }
+    if(!Array.isArray(message.content)) continue;
+    for(const part of message.content){
+      if(!part||typeof part!=='object'||part.type!=='tool_result') continue;
+      const tid=part.tool_use_id||'';
+      if(!tid) continue;
+      const raw=typeof part.content==='string'
+        ? part.content
+        : Array.isArray(part.content)
+          ? part.content.map(c=>c&&c.text?c.text:'').join('')
+          : '';
+      resultsByTid[tid]=_cliToolResultSnippet(raw);
+    }
+  }
+  return resultsByTid;
+}
+function _transparentOrderedToolCall(part, rawIdx, toolCallsByTid, resultsByTid){
+  const tid=String(part&&part.toolUseId||'').trim();
+  const liveTool=tid&&toolCallsByTid&&toolCallsByTid.get(tid);
+  if(liveTool){
+    const next={...liveTool};
+    if((next.snippet===undefined||next.snippet===null||next.snippet==='')&&resultsByTid&&resultsByTid[tid]){
+      const patchSnippet=_cliPatchSnippetFromArgs(next.name||part.name||'tool', next.args||part.input||{});
+      next.snippet=_cliToolCardSnippet(resultsByTid[tid],patchSnippet);
+      next.is_diff=_cliToolCardHasDiffSnippet(resultsByTid[tid],patchSnippet);
+    }
+    if(next.done===undefined) next.done=true;
+    return next;
+  }
+  const name=part&&part.name||'tool';
+  const args=(part&&part.input&&typeof part.input==='object')?part.input:{};
+  const patchSnippet=_cliPatchSnippetFromArgs(name,args);
+  const resultSnippet=(resultsByTid&&tid&&resultsByTid[tid])||'';
+  return {
+    name,
+    tid,
+    id:tid,
+    assistant_msg_idx:rawIdx,
+    args:_toolArgsSnapshot(args),
+    snippet:_cliToolCardSnippet(resultSnippet,patchSnippet),
+    is_diff:_cliToolCardHasDiffSnippet(resultSnippet,patchSnippet),
+    done:true,
+  };
+}
 function _assistantTurnAnchorSettledFinalAnswer(message, content, context){
   const sceneFinal=_assistantAnchorSceneFinalAnswerText(message);
   const effectiveContent=String(content||'').trim()?content:sceneFinal;
@@ -11463,6 +11544,16 @@ function renderMessages(options){
       }
     }
   }
+  const transparentOrderedToolIds=new Set();
+  const transparentOrderedToolCallsByTid=new Map();
+  if(Array.isArray(S.toolCalls)){
+    for(const tc of S.toolCalls){
+      if(!tc||typeof tc!=='object') continue;
+      const tid=tc.tid||tc.id||tc.tool_call_id||tc.tool_use_id||tc.call_id||'';
+      if(tid&&!transparentOrderedToolCallsByTid.has(tid)) transparentOrderedToolCallsByTid.set(tid,tc);
+    }
+  }
+  const transparentToolResultsByTid=_collectToolResultSnippetsByTid(S.messages);
   // Windowed render loop replaces the legacy full loop:
   // for(let vi=0;vi<visWithIdx.length;vi++)
   for(let vi=0;vi<renderVisWithIdx.length;vi++){
@@ -11488,6 +11579,7 @@ function renderMessages(options){
     }
     let content=m.content||'';
     let thinkingText='';
+    let orderedTransparentParts=_transparentStreamOrderedParts(m);
     if(Array.isArray(content)){
       content=content.filter(p=>p&&p.type==='text').map(p=>p.text||p.content||'').join('\n');
     }
@@ -11496,7 +11588,17 @@ function renderMessages(options){
         session_id:sid,
         raw_idx:rawIdx,
       });
-      if(anchorFinal!==null) content=anchorFinal;
+      if(anchorFinal!==null){
+        content=anchorFinal;
+        if(Array.isArray(orderedTransparentParts)){
+          for(let i=orderedTransparentParts.length-1;i>=0;i--){
+            if(orderedTransparentParts[i]&&orderedTransparentParts[i].kind==='text'){
+              orderedTransparentParts[i]={...orderedTransparentParts[i], text:anchorFinal};
+              break;
+            }
+          }
+        }
+      }
     }
     if(typeof content==='string'){
       if(typeof window!=='undefined'&&typeof window._extractInlineThinkingFromContentForRender==='function'){
@@ -11638,6 +11740,60 @@ function renderMessages(options){
       if(S.session) currentAssistantTurn.dataset.sessionId=S.session.session_id;
       currentAssistantTurn.dataset.recycleKey=rawIdx;
       inner.appendChild(currentAssistantTurn);
+    }
+    if(Array.isArray(orderedTransparentParts)&&orderedTransparentParts.length){
+      const blocks=_assistantTurnBlocks(currentAssistantTurn);
+      const sessionMsgIdx=_messageSessionIndexForRawIdx(rawIdx);
+      const messageAnchorKey=_messageViewportAnchorKeyForMessage(m);
+      const lastTextPartIdx=(()=>{
+        for(let i=orderedTransparentParts.length-1;i>=0;i--){
+          if(orderedTransparentParts[i]&&orderedTransparentParts[i].kind==='text') return i;
+        }
+        return -1;
+      })();
+      let firstSeg=null;
+      if(thinkingText&&window._showThinking!==false){
+        if((isCompactWorklogMode()||isTransparentStream())&&_assistantThinkingBelongsInWorklog(m, rawIdx, toolCallAssistantIdxs)) assistantThinking.set(rawIdx, thinkingText);
+      }
+      orderedTransparentParts.forEach((part, partIdx)=>{
+        if(!part) return;
+        if(part.kind==='tool'){
+          const toolCall=_transparentOrderedToolCall(part, rawIdx, transparentOrderedToolCallsByTid, transparentToolResultsByTid);
+          const toolRow=_decorateTransparentEventRow(buildToolCard(toolCall),{
+            type:'tool',
+            name:toolCall&&toolCall.name,
+            status:_transparentToolStatus(toolCall,true),
+            toolCall,
+            segmentSeq:toolCall&&toolCall.activitySegmentSeq,
+            burstId:(toolCall&&toolCall.activityBurstId)||m._activityBurstId,
+          });
+          blocks.appendChild(toolRow);
+          if(part.toolUseId) transparentOrderedToolIds.add(part.toolUseId);
+          return;
+        }
+        const seg=document.createElement('div');
+        seg.className='assistant-segment';
+        seg.dataset.msgIdx=rawIdx;
+        seg.dataset.sessionMsgIdx=sessionMsgIdx;
+        seg.dataset.messageAnchorKey=messageAnchorKey;
+        seg.dataset.rawText=String(part.text||'').trim();
+        if(m._activityBurstId!==undefined&&m._activityBurstId!==null) seg.setAttribute('data-activity-burst-id',String(m._activityBurstId));
+        if(Number.isFinite(Number(m._liveSegmentSeq))) seg.setAttribute('data-live-segment-seq',String(Number(m._liveSegmentSeq)));
+        if(_ERR_MSG_RE.test(String(part.text||'').trim())) seg.dataset.error='1';
+        if(!firstSeg&&thinkingText&&window._showThinking!==false&&!((isCompactWorklogMode()||isTransparentStream())&&_assistantThinkingBelongsInWorklog(m, rawIdx, toolCallAssistantIdxs))){
+          seg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText));
+        }
+        const isLastTextPart=partIdx===lastTextPartIdx;
+        const partBodyHtml=_getCachedRender(part.text,false);
+        if(isLastTextPart&&statusHtml){
+          seg.insertAdjacentHTML('beforeend', statusHtml);
+        }
+        seg.insertAdjacentHTML('beforeend', `${isLastTextPart?filesHtml:''}<div class="msg-body">${partBodyHtml}</div>${isLastTextPart?footHtml:''}`);
+        blocks.appendChild(seg);
+        if(!firstSeg) firstSeg=seg;
+      });
+      assistantSegments.set(rawIdx, firstSeg||null);
+      continue;
     }
     const seg=document.createElement('div');
     seg.className='assistant-segment';
@@ -12046,6 +12202,8 @@ function renderMessages(options){
     for(const s of assistantSegments.values()) if(s){const b=s.getAttribute('data-activity-burst-id');if(b)knownBurstIds.add(b);}
     for(const tc of (S.toolCalls||[])){
       if(!tc) continue;
+      const tid=tc.tid||tc.id||tc.tool_call_id||tc.tool_use_id||tc.call_id||'';
+      if(tid&&transparentOrderedToolIds.has(tid)) continue;
       const aIdx=tc.assistant_msg_idx!==undefined?parseInt(tc.assistant_msg_idx):-1;
       if(anchorOwnedAssistantRawIdxs.has(aIdx)) continue;
       if(virtualWindow.virtualized&&renderableRawIdxs.has(aIdx)&&!renderedRawIdxs.has(aIdx)) continue;

--- a/tests/test_issue3397_transparent_stream_prose_segments.py
+++ b/tests/test_issue3397_transparent_stream_prose_segments.py
@@ -116,11 +116,47 @@ def test_render_messages_wires_ordered_parts_into_transparent_stream_and_skips_d
     assert "const partDisplayText=_transparentOrderedDisplayText(part.text);" in UI_JS
     assert "const partBodyHtml=_getCachedRender(partDisplayText,false);" in UI_JS
     assert "const transparentOrderedToolIds=new Set();" in UI_JS
-    assert "const toolCall=_transparentOrderedToolCall(part, rawIdx, transparentOrderedToolCallsByTid, transparentToolResultsByTid);" in UI_JS
+    assert "const toolCall=_transparentOrderedToolCall(part, rawIdx, transparentOrderedToolCallsByTid, transparentToolResultsByTid, transparentPersistedSnippetByTid);" in UI_JS
     assert "if(part.toolUseId) transparentOrderedToolIds.add(part.toolUseId);" in UI_JS
     assert "if(tid&&transparentOrderedToolIds.has(tid)) continue;" in UI_JS
 
 
 def test_ordered_tool_cards_refresh_from_settled_results_even_after_live_preview():
-    assert "if(resultsByTid&&resultsByTid[tid]){" in UI_JS
+    assert "const liveSnip=(resultsByTid&&resultsByTid[tid])||(persistedByTid&&persistedByTid[tid])||'';" in UI_JS
     assert "(next.snippet===undefined||next.snippet===null||next.snippet==='')" not in UI_JS
+
+
+def test_ordered_tool_card_falls_back_to_persisted_snippet_on_cold_load():
+    # #4932 gate (#4927 parity): on a cold/paginated load the S.messages
+    # tool_result join misses; the ordered inline card must still recover the
+    # body from the persisted session.tool_calls snippet (persistedByTid),
+    # otherwise its card renders empty AND suppresses the post-loop derived card
+    # that would have recovered it.
+    if NODE is None:
+        import pytest
+        pytest.skip("node not on PATH")
+    driver = r"""
+const fs=require('fs');
+const src=fs.readFileSync(process.argv[2],'utf8');
+function grab(n){const re=new RegExp('function '+n+'\\([^]*?\\n}','m');const m=src.match(re);if(!m)throw new Error('not found '+n);return m[0];}
+global._cliPatchSnippetFromArgs=()=> '';
+global._cliToolCardSnippet=(a,b)=> a||b||'';
+global._cliToolCardHasDiffSnippet=()=> false;
+global._toolArgsSnapshot=(a)=> a||{};
+eval(grab('_transparentOrderedToolCall'));
+const part={kind:'tool', toolUseId:'call_x', name:'terminal', input:{command:'ls'}};
+// resultsByTid MISSES (cold load), persistedByTid HAS the snippet.
+const out=_transparentOrderedToolCall(part, 3, new Map(), {}, {call_x:'PERSISTED_OUTPUT_42'});
+process.stdout.write(JSON.stringify({snippet: out.snippet}));
+"""
+    import tempfile, os
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as fh:
+        fh.write(driver)
+        path = fh.name
+    try:
+        result = subprocess.run([NODE, path, str(UI_JS_PATH)], capture_output=True, text=True, timeout=30)
+    finally:
+        os.unlink(path)
+    assert result.returncode == 0, result.stderr
+    import json as _json
+    assert _json.loads(result.stdout)["snippet"] == "PERSISTED_OUTPUT_42", result.stdout

--- a/tests/test_issue3397_transparent_stream_prose_segments.py
+++ b/tests/test_issue3397_transparent_stream_prose_segments.py
@@ -1,0 +1,103 @@
+"""Regression tests for issue #3397 Transparent Stream settled prose segments."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS_PATH = ROOT / "static" / "ui.js"
+UI_JS = UI_JS_PATH.read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+_DRIVER_SRC = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+const transparent = process.argv[3] === '1';
+const message = JSON.parse(process.argv[4]);
+
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+
+function isTransparentStream() { return transparent; }
+eval(extractFunc('_transparentStreamOrderedParts'));
+process.stdout.write(JSON.stringify(_transparentStreamOrderedParts(message)));
+"""
+
+
+def _run_helper(message: dict, transparent: bool) -> object:
+    if NODE is None:
+        pytest.skip("node not on PATH")
+    with tempfile.NamedTemporaryFile("w", suffix=".js", encoding="utf-8", delete=False) as handle:
+        handle.write(_DRIVER_SRC)
+        script_path = Path(handle.name)
+    try:
+        result = subprocess.run(
+            [NODE, str(script_path), str(UI_JS_PATH), "1" if transparent else "0", json.dumps(message)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    finally:
+        script_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed: {result.stderr}")
+    return json.loads(result.stdout)
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_transparent_stream_ordered_parts_preserve_text_tool_text_sequence():
+    message = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Let me search first."},
+            {"type": "tool_use", "id": "toolu_1", "name": "grep", "input": {"pattern": "TODO"}},
+            {"type": "text", "text": "Found it, here's the fix."},
+        ],
+    }
+
+    ordered = _run_helper(message, transparent=True)
+
+    assert [part["kind"] for part in ordered] == ["text", "tool", "text"]
+    assert ordered[0]["text"] == "Let me search first."
+    assert ordered[1]["toolUseId"] == "toolu_1"
+    assert ordered[2]["text"] == "Found it, here's the fix."
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_compact_mode_keeps_ordered_parts_helper_off():
+    message = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Before"},
+            {"type": "tool_use", "id": "toolu_1", "name": "grep", "input": {}},
+            {"type": "text", "text": "After"},
+        ],
+    }
+
+    assert _run_helper(message, transparent=False) is None
+
+
+def test_render_messages_wires_ordered_parts_into_transparent_stream_and_skips_duplicate_tool_rows():
+    assert "let orderedTransparentParts=_transparentStreamOrderedParts(m);" in UI_JS
+    assert "const transparentOrderedToolIds=new Set();" in UI_JS
+    assert "const toolCall=_transparentOrderedToolCall(part, rawIdx, transparentOrderedToolCallsByTid, transparentToolResultsByTid);" in UI_JS
+    assert "if(part.toolUseId) transparentOrderedToolIds.add(part.toolUseId);" in UI_JS
+    assert "if(tid&&transparentOrderedToolIds.has(tid)) continue;" in UI_JS

--- a/tests/test_issue3397_transparent_stream_prose_segments.py
+++ b/tests/test_issue3397_transparent_stream_prose_segments.py
@@ -95,9 +95,32 @@ def test_compact_mode_keeps_ordered_parts_helper_off():
     assert _run_helper(message, transparent=False) is None
 
 
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_anchor_scene_messages_keep_dedicated_transparent_renderer():
+    message = {
+        "role": "assistant",
+        "_anchor_activity_scene": {"version": "activity_scene_v1"},
+        "content": [
+            {"type": "text", "text": "Before"},
+            {"type": "tool_use", "id": "toolu_1", "name": "grep", "input": {}},
+            {"type": "text", "text": "After"},
+        ],
+    }
+
+    assert _run_helper(message, transparent=True) is None
+
+
 def test_render_messages_wires_ordered_parts_into_transparent_stream_and_skips_duplicate_tool_rows():
     assert "let orderedTransparentParts=_transparentStreamOrderedParts(m);" in UI_JS
+    assert "if(message._anchor_activity_scene) return null;" in UI_JS
+    assert "const partDisplayText=_transparentOrderedDisplayText(part.text);" in UI_JS
+    assert "const partBodyHtml=_getCachedRender(partDisplayText,false);" in UI_JS
     assert "const transparentOrderedToolIds=new Set();" in UI_JS
     assert "const toolCall=_transparentOrderedToolCall(part, rawIdx, transparentOrderedToolCallsByTid, transparentToolResultsByTid);" in UI_JS
     assert "if(part.toolUseId) transparentOrderedToolIds.add(part.toolUseId);" in UI_JS
     assert "if(tid&&transparentOrderedToolIds.has(tid)) continue;" in UI_JS
+
+
+def test_ordered_tool_cards_refresh_from_settled_results_even_after_live_preview():
+    assert "if(resultsByTid&&resultsByTid[tid]){" in UI_JS
+    assert "(next.snippet===undefined||next.snippet===null||next.snippet==='')" not in UI_JS

--- a/tests/test_issue4927_durable_tool_snippet.py
+++ b/tests/test_issue4927_durable_tool_snippet.py
@@ -24,11 +24,16 @@ SESSIONS_JS = (Path(__file__).parent.parent / "static" / "sessions.js").read_tex
 
 
 def _slice_derived_rebuild() -> str:
-    """Return the renderMessages fallback-rebuild region (resultsByTid block)."""
-    start = UI_JS.index("const resultsByTid={};")
+    """Return the renderMessages fallback-rebuild region (resultsByTid block).
+
+    Anchored on `const fallbackToolSources=[];` which is unique to the
+    renderMessages derived-rebuild block — `const resultsByTid={};` alone is no
+    longer unique (the transparent-stream ordered path added its own at #4932).
+    """
+    start = UI_JS.index("const fallbackToolSources=[];")
     # The region runs through the _partial_tool_calls derived push; bound it
-    # generously so both derived-push sites are included.
-    return UI_JS[start:start + 6000]
+    # generously so all derived-push sites are included.
+    return UI_JS[start:start + 7000]
 
 
 def test_persisted_snippet_lookup_is_built_from_session_tool_calls():


### PR DESCRIPTION
## Release XT (v0.51.664) — transparent stream keeps prose in chronological order

Ships **#4932** (@rodboev) — addresses #3397. Aligns with the shipped Worklog/Transparent Stream direction (does NOT revive the held #3568 parallel-bubble mode).

### What it fixes
A settled assistant turn mixing commentary + tool activity collapsed all prose into one block above the tool rows, losing chronological reading order. The transparent stream now interleaves text and tool cards in original order for those turns (`_transparentStreamOrderedParts`, gated to settled mixed-content messages only).

### Gate (clean, 2 rounds — caught a real cross-PR regression)
- Codex + Opus round 1: both reproduced that the new ordered render path bypassed the **#4927 durable-snippet fallback** (`persistedSnippetByTid` from `S.session.tool_calls`) AND suppressed the post-loop derived card via the dedup set — reintroducing the #4927 cold-load empty-body for mixed turns. Opus also flagged the transparent-only scans running unconditionally (perf).
- Fix: threaded `transparentPersistedSnippetByTid` into the ordered path (both branches fall back to it), and gated the scans behind `isTransparentStream()`. Redaction (#4926/#4928) was already safe (shared `buildToolCard`).
- Round 2: Codex **SAFE TO SHIP** ("No regression risks found"); cold-load recovery + dedup ordering verified.
- Full suite: **10608 passed**, 0 failures; 6 targeted tests (incl. a cold-load persisted-fallback regression).
- Pre-merge head re-check: gated == live (ae82280c).

Credit @rodboev.
