### PR TITLE
fix(#4842): stop lock-held CLI cache rebuild stalls during streaming

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -4143,6 +4143,23 @@ def _cli_sessions_cache_done(cache_key: tuple, event: threading.Event | None) ->
         event.set()
 
 
+def _cache_cli_sessions_if_current(
+    cache_key: tuple,
+    ttl: float,
+    invalidation_stamp: int,
+    sessions: list,
+) -> bool:
+    with _CLI_SESSIONS_CACHE_LOCK:
+        if _CLI_SESSIONS_CACHE_INVALIDATION_VERSION != invalidation_stamp:
+            return False
+        _CLI_SESSIONS_CACHE[cache_key] = (
+            time.monotonic() + ttl,
+            invalidation_stamp,
+            _copy_cli_sessions(sessions),
+        )
+    return True
+
+
 def _reload_cli_sessions_after_inflight(
     *,
     cache_key: tuple,
@@ -4187,13 +4204,12 @@ def _reload_cli_sessions_after_inflight(
             if stale_sessions is not None and stale_stamp == _cli_sessions_cache_invalidation_stamp():
                 return stale_sessions
             return []
-        if _cli_sessions_cache_invalidation_stamp() == fallback_invalidation_stamp:
-            with _CLI_SESSIONS_CACHE_LOCK:
-                _CLI_SESSIONS_CACHE[cache_key] = (
-                    time.monotonic() + ttl,
-                    _CLI_SESSIONS_CACHE_INVALIDATION_VERSION,
-                    _copy_cli_sessions(sessions),
-                )
+        _cache_cli_sessions_if_current(
+            cache_key,
+            ttl,
+            fallback_invalidation_stamp,
+            sessions,
+        )
         return _copy_cli_sessions(sessions)
     finally:
         _cli_sessions_cache_done(cache_key, event)
@@ -4815,13 +4831,12 @@ def get_cli_sessions(source_filter=None, *, all_profiles: bool = False) -> list:
                         "all profiles" if all_profiles else db_path, _cli_err,
                     )
                     return []
-                if _cli_sessions_cache_invalidation_stamp() == invalidation_stamp:
-                    with _CLI_SESSIONS_CACHE_LOCK:
-                        _CLI_SESSIONS_CACHE[cache_key] = (
-                            time.monotonic() + ttl,
-                            _CLI_SESSIONS_CACHE_INVALIDATION_VERSION,
-                            _copy_cli_sessions(sessions),
-                        )
+                _cache_cli_sessions_if_current(
+                    cache_key,
+                    ttl,
+                    invalidation_stamp,
+                    sessions,
+                )
                 return _copy_cli_sessions(sessions)
             finally:
                 _cli_sessions_cache_done(cache_key, event)

--- a/api/models.py
+++ b/api/models.py
@@ -4773,9 +4773,9 @@ def get_cli_sessions(source_filter=None, *, all_profiles: bool = False) -> list:
                 _cli_sessions_cache_done(cache_key, event)
         try:
             timeout = (
-            _CLI_SESSIONS_CACHE_STALE_WAIT_SECONDS
-            if stale_sessions is not None
-            else _CLI_SESSIONS_CACHE_WAIT_SECONDS
+                _CLI_SESSIONS_CACHE_STALE_WAIT_SECONDS
+                if stale_sessions is not None
+                else _CLI_SESSIONS_CACHE_WAIT_SECONDS
             )
             event.wait(timeout)
         except Exception:

--- a/api/models.py
+++ b/api/models.py
@@ -49,7 +49,6 @@ _CLI_SESSIONS_CACHE_INFLIGHT: "dict[tuple, threading.Event]" = {}
 _CLI_SESSIONS_CACHE_INVALIDATION_VERSION = 0
 _CLI_SESSIONS_CACHE = {}
 # Event waits that keep stale rows visible while a rebuild is in flight.
-_CLI_SESSIONS_CACHE_WAIT_SECONDS = 0.25
 _CLI_SESSIONS_CACHE_STALE_WAIT_SECONDS = 0.10
 
 # Per-file parse cache for Claude Code JSONL transcripts (#4718/#4662 phase 4).
@@ -4109,7 +4108,6 @@ def clear_cli_sessions_cache() -> None:
         global _CLI_SESSIONS_CACHE_INVALIDATION_VERSION
         _CLI_SESSIONS_CACHE_INVALIDATION_VERSION += 1
         _CLI_SESSIONS_CACHE.clear()
-        _CLI_SESSIONS_CACHE_INFLIGHT.clear()
     # The sidecar-metadata projection cache is stat-keyed (self-invalidating on
     # any file change), but clear it alongside the CLI cache so an explicit
     # reset — a mutating sidebar action or test isolation — starts fully cold.
@@ -4143,6 +4141,61 @@ def _cli_sessions_cache_done(cache_key: tuple, event: threading.Event | None) ->
             _CLI_SESSIONS_CACHE_INFLIGHT.pop(cache_key, None)
     if event is not None:
         event.set()
+
+
+def _reload_cli_sessions_after_inflight(
+    *,
+    cache_key: tuple,
+    ttl: float,
+    stale_sessions,
+    stale_stamp,
+    load_sessions,
+    all_profiles: bool,
+    db_path: str,
+) -> list:
+    event, is_owner = _cli_sessions_cache_claim_rebuild(cache_key)
+    if not is_owner:
+        try:
+            event.wait()
+        except Exception:
+            pass
+        with _CLI_SESSIONS_CACHE_LOCK:
+            cached_entry = _CLI_SESSIONS_CACHE.get(cache_key)
+            if cached_entry is not None:
+                if len(cached_entry) == 3:
+                    cached_expires_at, cached_stamp, cached_sessions = cached_entry
+                else:
+                    cached_expires_at, cached_sessions = cached_entry
+                    cached_stamp = _CLI_SESSIONS_CACHE_INVALIDATION_VERSION
+                if (
+                    cached_stamp == _CLI_SESSIONS_CACHE_INVALIDATION_VERSION
+                    and cached_expires_at > time.monotonic()
+                ):
+                    return _copy_cli_sessions(cached_sessions)
+        if stale_sessions is not None and stale_stamp == _cli_sessions_cache_invalidation_stamp():
+            return stale_sessions
+        return []
+    try:
+        try:
+            sessions = load_sessions()
+        except Exception as _cli_err:
+            logger.warning(
+                "get_cli_sessions() failed â€” check state.db schema or path (%s): %s",
+                "all profiles" if all_profiles else db_path, _cli_err,
+            )
+            if stale_sessions is not None and stale_stamp == _cli_sessions_cache_invalidation_stamp():
+                return stale_sessions
+            return []
+        if _cli_sessions_cache_invalidation_stamp() == fallback_invalidation_stamp:
+            with _CLI_SESSIONS_CACHE_LOCK:
+                _CLI_SESSIONS_CACHE[cache_key] = (
+                    time.monotonic() + ttl,
+                    _CLI_SESSIONS_CACHE_INVALIDATION_VERSION,
+                    _copy_cli_sessions(sessions),
+                )
+        return _copy_cli_sessions(sessions)
+    finally:
+        _cli_sessions_cache_done(cache_key, event)
 
 
 def _cli_sessions_cache_ttl_seconds() -> float:
@@ -4772,12 +4825,11 @@ def get_cli_sessions(source_filter=None, *, all_profiles: bool = False) -> list:
             finally:
                 _cli_sessions_cache_done(cache_key, event)
         try:
-            timeout = (
+            event.wait(
                 _CLI_SESSIONS_CACHE_STALE_WAIT_SECONDS
                 if stale_sessions is not None
-                else _CLI_SESSIONS_CACHE_WAIT_SECONDS
+                else None
             )
-            event.wait(timeout)
         except Exception:
             pass
         with _CLI_SESSIONS_CACHE_LOCK:
@@ -4795,6 +4847,15 @@ def get_cli_sessions(source_filter=None, *, all_profiles: bool = False) -> list:
                     return _copy_cli_sessions(cached_sessions)
         if stale_sessions is not None and stale_stamp == _cli_sessions_cache_invalidation_stamp():
             return stale_sessions
+        return _reload_cli_sessions_after_inflight(
+            cache_key=cache_key,
+            ttl=ttl,
+            stale_sessions=stale_sessions,
+            stale_stamp=stale_stamp,
+            load_sessions=_load_sessions,
+            all_profiles=all_profiles,
+            db_path=db_path,
+        )
         fallback_invalidation_stamp = _cli_sessions_cache_invalidation_stamp()
         try:
             sessions = _load_sessions()

--- a/api/models.py
+++ b/api/models.py
@@ -4816,6 +4816,7 @@ def get_cli_sessions(source_filter=None, *, all_profiles: bool = False) -> list:
     source_filter = _normalize_cli_session_source_filter(source_filter)
     if all_profiles:
         contexts, context_cache_key = _all_profiles_cli_contexts()
+        db_path = "all profiles"
         # #4842: freeze the volatile per-profile state.db component while
         # streaming so a streamed message row in one profile doesn't bust the
         # all-profiles CLI cache and re-run every profile's heavy projection.

--- a/api/models.py
+++ b/api/models.py
@@ -48,6 +48,7 @@ _CLI_SESSIONS_CACHE_LOCK = threading.Lock()
 _CLI_SESSIONS_CACHE_INFLIGHT: "dict[tuple, threading.Event]" = {}
 _CLI_SESSIONS_CACHE_INVALIDATION_VERSION = 0
 _CLI_SESSIONS_CACHE = {}
+_CLI_SESSIONS_CACHE_WAIT_SECONDS = 0.25
 # Event waits that keep stale rows visible while a rebuild is in flight.
 _CLI_SESSIONS_CACHE_STALE_WAIT_SECONDS = 0.10
 
@@ -4160,6 +4161,54 @@ def _cache_cli_sessions_if_current(
     return True
 
 
+def _copy_fresh_cli_sessions_cache_entry(cache_key: tuple):
+    with _CLI_SESSIONS_CACHE_LOCK:
+        cached_entry = _CLI_SESSIONS_CACHE.get(cache_key)
+        if cached_entry is None:
+            return None
+        if len(cached_entry) == 3:
+            cached_expires_at, cached_stamp, cached_sessions = cached_entry
+        else:
+            cached_expires_at, cached_sessions = cached_entry
+            cached_stamp = _CLI_SESSIONS_CACHE_INVALIDATION_VERSION
+        if cached_stamp != _CLI_SESSIONS_CACHE_INVALIDATION_VERSION:
+            _CLI_SESSIONS_CACHE.pop(cache_key, None)
+            return None
+        if cached_expires_at <= time.monotonic():
+            return None
+        return _copy_cli_sessions(cached_sessions)
+
+
+def _load_and_cache_cli_sessions(
+    *,
+    cache_key: tuple,
+    ttl: float,
+    invalidation_stamp: int,
+    load_sessions,
+    stale_sessions,
+    stale_stamp,
+    all_profiles: bool,
+    db_path,
+) -> list:
+    try:
+        sessions = load_sessions()
+    except Exception as _cli_err:
+        logger.warning(
+            "get_cli_sessions() failed — check state.db schema or path (%s): %s",
+            "all profiles" if all_profiles else db_path, _cli_err,
+        )
+        if stale_sessions is not None and stale_stamp == _cli_sessions_cache_invalidation_stamp():
+            return stale_sessions
+        return []
+    _cache_cli_sessions_if_current(
+        cache_key,
+        ttl,
+        invalidation_stamp,
+        sessions,
+    )
+    return _copy_cli_sessions(sessions)
+
+
 def _reload_cli_sessions_after_inflight(
     *,
     cache_key: tuple,
@@ -4170,47 +4219,50 @@ def _reload_cli_sessions_after_inflight(
     all_profiles: bool,
     db_path: str,
 ) -> list:
-    event, is_owner = _cli_sessions_cache_claim_rebuild(cache_key)
-    if not is_owner:
+    while True:
+        event, is_owner = _cli_sessions_cache_claim_rebuild(cache_key)
+        if is_owner:
+            break
+        wait_finished = False
         try:
-            event.wait()
+            wait_finished = bool(
+                event.wait(
+                    _CLI_SESSIONS_CACHE_STALE_WAIT_SECONDS
+                    if stale_sessions is not None
+                    else _CLI_SESSIONS_CACHE_WAIT_SECONDS
+                )
+            )
         except Exception:
             pass
-        with _CLI_SESSIONS_CACHE_LOCK:
-            cached_entry = _CLI_SESSIONS_CACHE.get(cache_key)
-            if cached_entry is not None:
-                if len(cached_entry) == 3:
-                    cached_expires_at, cached_stamp, cached_sessions = cached_entry
-                else:
-                    cached_expires_at, cached_sessions = cached_entry
-                    cached_stamp = _CLI_SESSIONS_CACHE_INVALIDATION_VERSION
-                if (
-                    cached_stamp == _CLI_SESSIONS_CACHE_INVALIDATION_VERSION
-                    and cached_expires_at > time.monotonic()
-                ):
-                    return _copy_cli_sessions(cached_sessions)
+        cached_sessions = _copy_fresh_cli_sessions_cache_entry(cache_key)
+        if cached_sessions is not None:
+            return cached_sessions
         if stale_sessions is not None and stale_stamp == _cli_sessions_cache_invalidation_stamp():
             return stale_sessions
-        return []
-    try:
-        fallback_invalidation_stamp = _cli_sessions_cache_invalidation_stamp()
-        try:
-            sessions = load_sessions()
-        except Exception as _cli_err:
-            logger.warning(
-                "get_cli_sessions() failed â€” check state.db schema or path (%s): %s",
-                "all profiles" if all_profiles else db_path, _cli_err,
+        if not wait_finished:
+            fallback_invalidation_stamp = _cli_sessions_cache_invalidation_stamp()
+            return _load_and_cache_cli_sessions(
+                cache_key=cache_key,
+                ttl=ttl,
+                invalidation_stamp=fallback_invalidation_stamp,
+                load_sessions=load_sessions,
+                stale_sessions=stale_sessions,
+                stale_stamp=stale_stamp,
+                all_profiles=all_profiles,
+                db_path=db_path,
             )
-            if stale_sessions is not None and stale_stamp == _cli_sessions_cache_invalidation_stamp():
-                return stale_sessions
-            return []
-        _cache_cli_sessions_if_current(
-            cache_key,
-            ttl,
-            fallback_invalidation_stamp,
-            sessions,
+    try:
+        invalidation_stamp = _cli_sessions_cache_invalidation_stamp()
+        return _load_and_cache_cli_sessions(
+            cache_key=cache_key,
+            ttl=ttl,
+            invalidation_stamp=invalidation_stamp,
+            load_sessions=load_sessions,
+            stale_sessions=stale_sessions,
+            stale_stamp=stale_stamp,
+            all_profiles=all_profiles,
+            db_path=db_path,
         )
-        return _copy_cli_sessions(sessions)
     finally:
         _cli_sessions_cache_done(cache_key, event)
 
@@ -4823,46 +4875,18 @@ def get_cli_sessions(source_filter=None, *, all_profiles: bool = False) -> list:
         if is_owner:
             try:
                 invalidation_stamp = _cli_sessions_cache_invalidation_stamp()
-                try:
-                    sessions = _load_sessions()
-                except Exception as _cli_err:
-                    logger.warning(
-                        "get_cli_sessions() failed — check state.db schema or path (%s): %s",
-                        "all profiles" if all_profiles else db_path, _cli_err,
-                    )
-                    return []
-                _cache_cli_sessions_if_current(
-                    cache_key,
-                    ttl,
-                    invalidation_stamp,
-                    sessions,
+                return _load_and_cache_cli_sessions(
+                    cache_key=cache_key,
+                    ttl=ttl,
+                    invalidation_stamp=invalidation_stamp,
+                    load_sessions=_load_sessions,
+                    stale_sessions=stale_sessions,
+                    stale_stamp=stale_stamp,
+                    all_profiles=all_profiles,
+                    db_path=db_path,
                 )
-                return _copy_cli_sessions(sessions)
             finally:
                 _cli_sessions_cache_done(cache_key, event)
-        try:
-            event.wait(
-                _CLI_SESSIONS_CACHE_STALE_WAIT_SECONDS
-                if stale_sessions is not None
-                else None
-            )
-        except Exception:
-            pass
-        with _CLI_SESSIONS_CACHE_LOCK:
-            cached_entry = _CLI_SESSIONS_CACHE.get(cache_key)
-            if cached_entry is not None:
-                if len(cached_entry) == 3:
-                    cached_expires_at, cached_stamp, cached_sessions = cached_entry
-                else:
-                    cached_expires_at, cached_sessions = cached_entry
-                    cached_stamp = _CLI_SESSIONS_CACHE_INVALIDATION_VERSION
-                if (
-                    cached_stamp == _CLI_SESSIONS_CACHE_INVALIDATION_VERSION
-                    and cached_expires_at > time.monotonic()
-                ):
-                    return _copy_cli_sessions(cached_sessions)
-        if stale_sessions is not None and stale_stamp == _cli_sessions_cache_invalidation_stamp():
-            return stale_sessions
         return _reload_cli_sessions_after_inflight(
             cache_key=cache_key,
             ttl=ttl,
@@ -4872,25 +4896,6 @@ def get_cli_sessions(source_filter=None, *, all_profiles: bool = False) -> list:
             all_profiles=all_profiles,
             db_path=db_path,
         )
-        fallback_invalidation_stamp = _cli_sessions_cache_invalidation_stamp()
-        try:
-            sessions = _load_sessions()
-        except Exception as _cli_err:
-            logger.warning(
-                "get_cli_sessions() failed — check state.db schema or path (%s): %s",
-                "all profiles" if all_profiles else db_path, _cli_err,
-            )
-            if stale_sessions is not None and stale_stamp == _cli_sessions_cache_invalidation_stamp():
-                return stale_sessions
-            return []
-        if _cli_sessions_cache_invalidation_stamp() == fallback_invalidation_stamp:
-            with _CLI_SESSIONS_CACHE_LOCK:
-                _CLI_SESSIONS_CACHE[cache_key] = (
-                    time.monotonic() + ttl,
-                    _CLI_SESSIONS_CACHE_INVALIDATION_VERSION,
-                    _copy_cli_sessions(sessions),
-                )
-        return _copy_cli_sessions(sessions)
 
     try:
         return _load_sessions()
@@ -4900,7 +4905,6 @@ def get_cli_sessions(source_filter=None, *, all_profiles: bool = False) -> list:
             "all profiles" if all_profiles else db_path, _cli_err,
         )
         return []
-
 
 def _json_loads_if_string(value):
     if not isinstance(value, str):

--- a/api/models.py
+++ b/api/models.py
@@ -45,7 +45,12 @@ _CLI_SESSIONS_CACHE_TTL_SECONDS = 5.0
 # expensive state.db CLI/cron projection is re-run on every poll. (#4842)
 _CLI_SESSIONS_CACHE_STREAMING_TTL_SECONDS = 30.0
 _CLI_SESSIONS_CACHE_LOCK = threading.Lock()
+_CLI_SESSIONS_CACHE_INFLIGHT: "dict[tuple, threading.Event]" = {}
+_CLI_SESSIONS_CACHE_INVALIDATION_VERSION = 0
 _CLI_SESSIONS_CACHE = {}
+# Event waits that keep stale rows visible while a rebuild is in flight.
+_CLI_SESSIONS_CACHE_WAIT_SECONDS = 0.25
+_CLI_SESSIONS_CACHE_STALE_WAIT_SECONDS = 0.10
 
 # Per-file parse cache for Claude Code JSONL transcripts (#4718/#4662 phase 4).
 # ``~/.claude/projects`` is a GLOBAL, profile-independent directory, but the
@@ -4101,7 +4106,10 @@ def get_claude_code_session_messages(sid, projects_dir: Path | str | None = None
 
 def clear_cli_sessions_cache() -> None:
     with _CLI_SESSIONS_CACHE_LOCK:
+        global _CLI_SESSIONS_CACHE_INVALIDATION_VERSION
+        _CLI_SESSIONS_CACHE_INVALIDATION_VERSION += 1
         _CLI_SESSIONS_CACHE.clear()
+        _CLI_SESSIONS_CACHE_INFLIGHT.clear()
     # The sidecar-metadata projection cache is stat-keyed (self-invalidating on
     # any file change), but clear it alongside the CLI cache so an explicit
     # reset — a mutating sidebar action or test isolation — starts fully cold.
@@ -4110,6 +4118,31 @@ def clear_cli_sessions_cache() -> None:
 
 def _copy_cli_sessions(sessions: list) -> list:
     return copy.deepcopy(sessions)
+
+
+def _cli_sessions_cache_invalidation_stamp() -> int:
+    with _CLI_SESSIONS_CACHE_LOCK:
+        return int(_CLI_SESSIONS_CACHE_INVALIDATION_VERSION)
+
+
+def _cli_sessions_cache_claim_rebuild(cache_key: tuple) -> tuple[threading.Event, bool]:
+    with _CLI_SESSIONS_CACHE_LOCK:
+        current = _CLI_SESSIONS_CACHE_INFLIGHT.get(cache_key)
+        if current is not None:
+            return current, False
+        event = threading.Event()
+        _CLI_SESSIONS_CACHE_INFLIGHT[cache_key] = event
+        return event, True
+
+
+def _cli_sessions_cache_done(cache_key: tuple, event: threading.Event | None) -> None:
+    with _CLI_SESSIONS_CACHE_LOCK:
+        if event is None:
+            return
+        if _CLI_SESSIONS_CACHE_INFLIGHT.get(cache_key) is event:
+            _CLI_SESSIONS_CACHE_INFLIGHT.pop(cache_key, None)
+    if event is not None:
+        event.set()
 
 
 def _cli_sessions_cache_ttl_seconds() -> float:
@@ -4699,26 +4732,88 @@ def get_cli_sessions(source_filter=None, *, all_profiles: bool = False) -> list:
         return _load_cli_sessions_uncached(hermes_home, db_path, cli_profile, source_filter=source_filter)
 
     if ttl > 0:
+        stale_sessions = None
+        stale_stamp = None
         with _CLI_SESSIONS_CACHE_LOCK:
-            cached = _CLI_SESSIONS_CACHE.get(cache_key)
-            if cached:
-                expires_at, cached_sessions = cached
-                if expires_at > now:
+            cached_entry = _CLI_SESSIONS_CACHE.get(cache_key)
+            if cached_entry is not None:
+                if len(cached_entry) == 3:
+                    cached_expires_at, cached_stamp, cached_sessions = cached_entry
+                else:
+                    cached_expires_at, cached_sessions = cached_entry
+                    cached_stamp = _CLI_SESSIONS_CACHE_INVALIDATION_VERSION
+                if cached_stamp != _CLI_SESSIONS_CACHE_INVALIDATION_VERSION:
+                    _CLI_SESSIONS_CACHE.pop(cache_key, None)
+                elif cached_expires_at > now:
                     return _copy_cli_sessions(cached_sessions)
-                _CLI_SESSIONS_CACHE.pop(cache_key, None)
+                else:
+                    stale_sessions = _copy_cli_sessions(cached_sessions)
+                    stale_stamp = cached_stamp
+        event, is_owner = _cli_sessions_cache_claim_rebuild(cache_key)
+        if is_owner:
             try:
-                sessions = _load_sessions()
-            except Exception as _cli_err:
-                logger.warning(
-                    "get_cli_sessions() failed — check state.db schema or path (%s): %s",
-                    "all profiles" if all_profiles else db_path, _cli_err,
-                )
-                return []
-            _CLI_SESSIONS_CACHE[cache_key] = (
-                time.monotonic() + ttl,
-                _copy_cli_sessions(sessions),
+                invalidation_stamp = _cli_sessions_cache_invalidation_stamp()
+                try:
+                    sessions = _load_sessions()
+                except Exception as _cli_err:
+                    logger.warning(
+                        "get_cli_sessions() failed — check state.db schema or path (%s): %s",
+                        "all profiles" if all_profiles else db_path, _cli_err,
+                    )
+                    return []
+                if _cli_sessions_cache_invalidation_stamp() == invalidation_stamp:
+                    with _CLI_SESSIONS_CACHE_LOCK:
+                        _CLI_SESSIONS_CACHE[cache_key] = (
+                            time.monotonic() + ttl,
+                            _CLI_SESSIONS_CACHE_INVALIDATION_VERSION,
+                            _copy_cli_sessions(sessions),
+                        )
+                return _copy_cli_sessions(sessions)
+            finally:
+                _cli_sessions_cache_done(cache_key, event)
+        try:
+            timeout = (
+            _CLI_SESSIONS_CACHE_STALE_WAIT_SECONDS
+            if stale_sessions is not None
+            else _CLI_SESSIONS_CACHE_WAIT_SECONDS
             )
-            return _copy_cli_sessions(sessions)
+            event.wait(timeout)
+        except Exception:
+            pass
+        with _CLI_SESSIONS_CACHE_LOCK:
+            cached_entry = _CLI_SESSIONS_CACHE.get(cache_key)
+            if cached_entry is not None:
+                if len(cached_entry) == 3:
+                    cached_expires_at, cached_stamp, cached_sessions = cached_entry
+                else:
+                    cached_expires_at, cached_sessions = cached_entry
+                    cached_stamp = _CLI_SESSIONS_CACHE_INVALIDATION_VERSION
+                if (
+                    cached_stamp == _CLI_SESSIONS_CACHE_INVALIDATION_VERSION
+                    and cached_expires_at > time.monotonic()
+                ):
+                    return _copy_cli_sessions(cached_sessions)
+        if stale_sessions is not None and stale_stamp == _cli_sessions_cache_invalidation_stamp():
+            return stale_sessions
+        fallback_invalidation_stamp = _cli_sessions_cache_invalidation_stamp()
+        try:
+            sessions = _load_sessions()
+        except Exception as _cli_err:
+            logger.warning(
+                "get_cli_sessions() failed — check state.db schema or path (%s): %s",
+                "all profiles" if all_profiles else db_path, _cli_err,
+            )
+            if stale_sessions is not None and stale_stamp == _cli_sessions_cache_invalidation_stamp():
+                return stale_sessions
+            return []
+        if _cli_sessions_cache_invalidation_stamp() == fallback_invalidation_stamp:
+            with _CLI_SESSIONS_CACHE_LOCK:
+                _CLI_SESSIONS_CACHE[cache_key] = (
+                    time.monotonic() + ttl,
+                    _CLI_SESSIONS_CACHE_INVALIDATION_VERSION,
+                    _copy_cli_sessions(sessions),
+                )
+        return _copy_cli_sessions(sessions)
 
     try:
         return _load_sessions()

--- a/api/models.py
+++ b/api/models.py
@@ -4176,6 +4176,7 @@ def _reload_cli_sessions_after_inflight(
             return stale_sessions
         return []
     try:
+        fallback_invalidation_stamp = _cli_sessions_cache_invalidation_stamp()
         try:
             sessions = load_sessions()
         except Exception as _cli_err:

--- a/tests/test_issue4842_cli_cache_streaming.py
+++ b/tests/test_issue4842_cli_cache_streaming.py
@@ -100,6 +100,59 @@ def test_get_cli_sessions_follower_reuses_stale_rows_during_slow_rebuild(monkeyp
     assert results.get("owner") == [{"session_id": "fresh", "title": "fresh-row"}]
 
 
+def test_get_cli_sessions_cold_followers_join_single_rebuild(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(hermes_home))
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    models.clear_cli_sessions_cache()
+    monkeypatch.setattr(models, "_CLI_SESSIONS_CACHE_TTL_SECONDS", 60.0, raising=False)
+
+    owner_started = threading.Event()
+    owner_block = threading.Event()
+    load_count = {"value": 0}
+    load_count_lock = threading.Lock()
+    results = {}
+
+    def _blocking_loader(*_args, **_kwargs):
+        with load_count_lock:
+            load_count["value"] += 1
+            call_number = load_count["value"]
+        if call_number == 1:
+            owner_started.set()
+            owner_block.wait()
+        return [{"session_id": "fresh", "title": "fresh-row"}]
+
+    monkeypatch.setattr(models, "_load_cli_sessions_uncached", _blocking_loader)
+
+    def _owner():
+        results["owner"] = models.get_cli_sessions()
+
+    def _follower():
+        results["follower"] = models.get_cli_sessions()
+
+    owner = threading.Thread(target=_owner, daemon=True)
+    follower = threading.Thread(target=_follower, daemon=True)
+
+    owner.start()
+    assert owner_started.wait(1.0), "owner did not start"
+    follower.start()
+    time.sleep(0.2)
+
+    assert load_count["value"] == 1
+    assert follower.is_alive()
+
+    owner_block.set()
+    owner.join(2.0)
+    follower.join(2.0)
+
+    assert not owner.is_alive()
+    assert not follower.is_alive()
+    assert load_count["value"] == 1
+    assert results.get("owner") == [{"session_id": "fresh", "title": "fresh-row"}]
+    assert results.get("follower") == [{"session_id": "fresh", "title": "fresh-row"}]
+
+
 def test_get_cli_sessions_clear_during_rebuild_does_not_restore_stale_rows(monkeypatch, tmp_path):
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
@@ -142,3 +195,74 @@ def test_get_cli_sessions_clear_during_rebuild_does_not_restore_stale_rows(monke
     assert recovered == [{"session_id": "recovered", "title": "recovered-row"}]
     with models._CLI_SESSIONS_CACHE_LOCK:
         assert cache_key in models._CLI_SESSIONS_CACHE
+
+
+def test_get_cli_sessions_clear_during_rebuild_preserves_joiners(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(hermes_home))
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    models.clear_cli_sessions_cache()
+    monkeypatch.setattr(models, "_CLI_SESSIONS_CACHE_TTL_SECONDS", 60.0, raising=False)
+
+    owner_started = threading.Event()
+    owner_block = threading.Event()
+    second_started = threading.Event()
+    second_block = threading.Event()
+    load_count = {"value": 0}
+    load_count_lock = threading.Lock()
+    results = {}
+
+    def _blocking_loader(*_args, **_kwargs):
+        with load_count_lock:
+            load_count["value"] += 1
+            call_number = load_count["value"]
+        if call_number == 1:
+            owner_started.set()
+            owner_block.wait()
+            return [{"session_id": "owner", "title": "owner-row"}]
+        second_started.set()
+        second_block.wait()
+        return [{"session_id": "fresh", "title": "fresh-row"}]
+
+    monkeypatch.setattr(models, "_load_cli_sessions_uncached", _blocking_loader)
+
+    def _owner():
+        results["owner"] = models.get_cli_sessions()
+
+    def _follower(name):
+        results[name] = models.get_cli_sessions()
+
+    owner = threading.Thread(target=_owner, daemon=True)
+    follower_a = threading.Thread(target=lambda: _follower("follower_a"), daemon=True)
+    follower_b = threading.Thread(target=lambda: _follower("follower_b"), daemon=True)
+
+    owner.start()
+    assert owner_started.wait(1.0), "owner did not enter rebuild"
+    follower_a.start()
+    models.clear_cli_sessions_cache()
+    follower_b.start()
+    time.sleep(0.2)
+
+    assert load_count["value"] == 1
+    assert follower_a.is_alive()
+    assert follower_b.is_alive()
+
+    owner_block.set()
+    assert second_started.wait(1.0), "second rebuild did not start"
+    time.sleep(0.2)
+
+    assert load_count["value"] == 2
+    second_block.set()
+
+    owner.join(2.0)
+    follower_a.join(2.0)
+    follower_b.join(2.0)
+
+    assert not owner.is_alive()
+    assert not follower_a.is_alive()
+    assert not follower_b.is_alive()
+    assert load_count["value"] == 2
+    assert results.get("owner") == [{"session_id": "owner", "title": "owner-row"}]
+    assert results.get("follower_a") == [{"session_id": "fresh", "title": "fresh-row"}]
+    assert results.get("follower_b") == [{"session_id": "fresh", "title": "fresh-row"}]

--- a/tests/test_issue4842_cli_cache_streaming.py
+++ b/tests/test_issue4842_cli_cache_streaming.py
@@ -266,3 +266,28 @@ def test_get_cli_sessions_clear_during_rebuild_preserves_joiners(monkeypatch, tm
     assert results.get("owner") == [{"session_id": "owner", "title": "owner-row"}]
     assert results.get("follower_a") == [{"session_id": "fresh", "title": "fresh-row"}]
     assert results.get("follower_b") == [{"session_id": "fresh", "title": "fresh-row"}]
+
+
+def test_cache_cli_sessions_if_current_skips_stale_store(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(hermes_home))
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    models.clear_cli_sessions_cache()
+    monkeypatch.setattr(models, "_CLI_SESSIONS_CACHE_TTL_SECONDS", 60.0, raising=False)
+
+    _, _, _, cache_key = models._resolve_cli_sessions_context(None)
+    invalidation_stamp = models._cli_sessions_cache_invalidation_stamp()
+
+    models.clear_cli_sessions_cache()
+
+    stored = models._cache_cli_sessions_if_current(
+        cache_key,
+        60.0,
+        invalidation_stamp,
+        [{"session_id": "stale", "title": "stale-row"}],
+    )
+
+    assert stored is False
+    with models._CLI_SESSIONS_CACHE_LOCK:
+        assert cache_key not in models._CLI_SESSIONS_CACHE

--- a/tests/test_issue4842_cli_cache_streaming.py
+++ b/tests/test_issue4842_cli_cache_streaming.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import threading
+import time
+
+import api.models as models
+import api.profiles as profiles
+
+
+def _set_active_streams(monkeypatch, ids):
+    monkeypatch.setattr(models, "_active_stream_ids", lambda: set(ids))
+
+
+def test_cli_cache_key_stays_frozen_during_streaming(monkeypatch, tmp_path):
+    db_path = tmp_path / "state.db"
+    db_path.write_text("", encoding="utf-8")
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(hermes_home))
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        models,
+        "_default_claude_code_projects_dir",
+        lambda: tmp_path / "projects",
+    )
+
+    fp = {"value": 0}
+    monkeypatch.setattr(
+        models,
+        "_sqlite_file_stat_cache_key",
+        lambda _p: ("fp", fp["value"]),
+    )
+
+    _set_active_streams(monkeypatch, {"live-1"})
+    _, _, _, key_streaming_a = models._resolve_cli_sessions_context(None)
+    fp["value"] = 1
+    _, _, _, key_streaming_b = models._resolve_cli_sessions_context(None)
+    fp["value"] = 2
+    _, _, _, key_streaming_c = models._resolve_cli_sessions_context(None)
+
+    assert key_streaming_a == key_streaming_b == key_streaming_c
+
+    _set_active_streams(monkeypatch, set())
+    fp["value"] = 10
+    _, _, _, key_idle_a = models._resolve_cli_sessions_context(None)
+    fp["value"] = 11
+    _, _, _, key_idle_b = models._resolve_cli_sessions_context(None)
+
+    assert key_idle_a != key_idle_b
+
+
+def test_get_cli_sessions_follower_reuses_stale_rows_during_slow_rebuild(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(hermes_home))
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    models.clear_cli_sessions_cache()
+    monkeypatch.setattr(models, "_CLI_SESSIONS_CACHE_TTL_SECONDS", 60.0, raising=False)
+    (_, _, _, cache_key) = models._resolve_cli_sessions_context(None)
+    cache_stamp = models._cli_sessions_cache_invalidation_stamp()
+    with models._CLI_SESSIONS_CACHE_LOCK:
+        models._CLI_SESSIONS_CACHE[cache_key] = (
+            time.monotonic() - 1.0,
+            cache_stamp,
+            [{"session_id": "stale", "title": "stale-row"}],
+        )
+
+    started = threading.Event()
+    owner_block = threading.Event()
+    results = {}
+
+    def _blocking_loader(*_args, **_kwargs):
+        started.set()
+        owner_block.wait()
+        return [{"session_id": "fresh", "title": "fresh-row"}]
+
+    monkeypatch.setattr(models, "_load_cli_sessions_uncached", _blocking_loader)
+
+    def _owner():
+        results["owner"] = models.get_cli_sessions()
+
+    def _follower():
+        results["follower"] = models.get_cli_sessions()
+
+    owner = threading.Thread(target=_owner, daemon=True)
+    follower = threading.Thread(target=_follower, daemon=True)
+
+    owner.start()
+    assert started.wait(1.0), "owner did not start"
+    follower.start()
+    follower.join(1.0)
+
+    assert results.get("follower") == [{"session_id": "stale", "title": "stale-row"}]
+    assert not follower.is_alive()
+    owner_block.set()
+    owner.join(2.0)
+    assert not owner.is_alive()
+
+    assert results.get("owner") == [{"session_id": "fresh", "title": "fresh-row"}]
+
+
+def test_get_cli_sessions_clear_during_rebuild_does_not_restore_stale_rows(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(hermes_home))
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    models.clear_cli_sessions_cache()
+    monkeypatch.setattr(models, "_CLI_SESSIONS_CACHE_TTL_SECONDS", 60.0, raising=False)
+
+    owner_started = threading.Event()
+    owner_block = threading.Event()
+    results = {}
+
+    def _blocking_loader(*_args, **_kwargs):
+        owner_started.set()
+        owner_block.wait()
+        return [{"session_id": "fresh", "title": "fresh-row"}]
+
+    monkeypatch.setattr(models, "_load_cli_sessions_uncached", _blocking_loader)
+
+    _, _, _, cache_key = models._resolve_cli_sessions_context(None)
+
+    owner = threading.Thread(
+        target=lambda: results.setdefault("owner", models.get_cli_sessions()),
+        daemon=True,
+    )
+    owner.start()
+
+    assert owner_started.wait(1.0), "owner did not enter rebuild"
+    models.clear_cli_sessions_cache()
+
+    owner_block.set()
+    owner.join(1.0)
+
+    assert results.get("owner") == [{"session_id": "fresh", "title": "fresh-row"}]
+    with models._CLI_SESSIONS_CACHE_LOCK:
+        assert cache_key not in models._CLI_SESSIONS_CACHE
+
+    monkeypatch.setattr(models, "_load_cli_sessions_uncached", lambda *_args, **_kwargs: [{"session_id": "recovered", "title": "recovered-row"}])
+    recovered = models.get_cli_sessions()
+    assert recovered == [{"session_id": "recovered", "title": "recovered-row"}]
+    with models._CLI_SESSIONS_CACHE_LOCK:
+        assert cache_key in models._CLI_SESSIONS_CACHE

--- a/tests/test_issue4842_cli_cache_streaming.py
+++ b/tests/test_issue4842_cli_cache_streaming.py
@@ -153,6 +153,61 @@ def test_get_cli_sessions_cold_followers_join_single_rebuild(monkeypatch, tmp_pa
     assert results.get("follower") == [{"session_id": "fresh", "title": "fresh-row"}]
 
 
+def test_get_cli_sessions_cold_follower_times_out_to_independent_rebuild(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(hermes_home))
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    models.clear_cli_sessions_cache()
+    monkeypatch.setattr(models, "_CLI_SESSIONS_CACHE_TTL_SECONDS", 60.0, raising=False)
+    monkeypatch.setattr(models, "_CLI_SESSIONS_CACHE_WAIT_SECONDS", 0.05, raising=False)
+
+    owner_started = threading.Event()
+    owner_block = threading.Event()
+    fallback_started = threading.Event()
+    load_count = {"value": 0}
+    load_count_lock = threading.Lock()
+    results = {}
+
+    def _blocking_loader(*_args, **_kwargs):
+        with load_count_lock:
+            load_count["value"] += 1
+            call_number = load_count["value"]
+        if call_number == 1:
+            owner_started.set()
+            owner_block.wait()
+        else:
+            fallback_started.set()
+        return [{"session_id": "fresh", "title": "fresh-row"}]
+
+    monkeypatch.setattr(models, "_load_cli_sessions_uncached", _blocking_loader)
+
+    owner = threading.Thread(
+        target=lambda: results.setdefault("owner", models.get_cli_sessions()),
+        daemon=True,
+    )
+    follower = threading.Thread(
+        target=lambda: results.setdefault("follower", models.get_cli_sessions()),
+        daemon=True,
+    )
+
+    owner.start()
+    assert owner_started.wait(1.0), "owner did not start"
+    follower.start()
+    assert fallback_started.wait(1.0), "follower did not start fallback rebuild"
+    follower.join(1.0)
+
+    assert not follower.is_alive()
+    assert owner.is_alive()
+    assert load_count["value"] == 2
+    assert results.get("follower") == [{"session_id": "fresh", "title": "fresh-row"}]
+
+    owner_block.set()
+    owner.join(2.0)
+    assert not owner.is_alive()
+    assert results.get("owner") == [{"session_id": "fresh", "title": "fresh-row"}]
+
+
 def test_get_cli_sessions_clear_during_rebuild_does_not_restore_stale_rows(monkeypatch, tmp_path):
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
@@ -266,6 +321,71 @@ def test_get_cli_sessions_clear_during_rebuild_preserves_joiners(monkeypatch, tm
     assert results.get("owner") == [{"session_id": "owner", "title": "owner-row"}]
     assert results.get("follower_a") == [{"session_id": "fresh", "title": "fresh-row"}]
     assert results.get("follower_b") == [{"session_id": "fresh", "title": "fresh-row"}]
+
+
+def test_get_cli_sessions_clear_during_rebuild_reclaims_after_invalidated_wait(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(hermes_home))
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    models.clear_cli_sessions_cache()
+    monkeypatch.setattr(models, "_CLI_SESSIONS_CACHE_TTL_SECONDS", 60.0, raising=False)
+    monkeypatch.setattr(models, "_CLI_SESSIONS_CACHE_STALE_WAIT_SECONDS", 0.2, raising=False)
+
+    (_, _, _, cache_key) = models._resolve_cli_sessions_context(None)
+    cache_stamp = models._cli_sessions_cache_invalidation_stamp()
+    with models._CLI_SESSIONS_CACHE_LOCK:
+        models._CLI_SESSIONS_CACHE[cache_key] = (
+            time.monotonic() - 1.0,
+            cache_stamp,
+            [{"session_id": "stale", "title": "stale-row"}],
+        )
+
+    owner_started = threading.Event()
+    owner_block = threading.Event()
+    second_started = threading.Event()
+    load_count = {"value": 0}
+    load_count_lock = threading.Lock()
+    results = {}
+
+    def _blocking_loader(*_args, **_kwargs):
+        with load_count_lock:
+            load_count["value"] += 1
+            call_number = load_count["value"]
+        if call_number == 1:
+            owner_started.set()
+            owner_block.wait()
+            return [{"session_id": "owner", "title": "owner-row"}]
+        second_started.set()
+        return [{"session_id": "fresh", "title": "fresh-row"}]
+
+    monkeypatch.setattr(models, "_load_cli_sessions_uncached", _blocking_loader)
+
+    owner = threading.Thread(
+        target=lambda: results.setdefault("owner", models.get_cli_sessions()),
+        daemon=True,
+    )
+    follower = threading.Thread(
+        target=lambda: results.setdefault("follower", models.get_cli_sessions()),
+        daemon=True,
+    )
+
+    owner.start()
+    assert owner_started.wait(1.0), "owner did not enter rebuild"
+    follower.start()
+    time.sleep(0.05)
+    models.clear_cli_sessions_cache()
+    owner_block.set()
+
+    assert second_started.wait(1.0), "follower did not reclaim the rebuild"
+    owner.join(2.0)
+    follower.join(2.0)
+
+    assert not owner.is_alive()
+    assert not follower.is_alive()
+    assert load_count["value"] == 2
+    assert results.get("owner") == [{"session_id": "owner", "title": "owner-row"}]
+    assert results.get("follower") == [{"session_id": "fresh", "title": "fresh-row"}]
 
 
 def test_cache_cli_sessions_if_current_skips_stale_store(monkeypatch, tmp_path):


### PR DESCRIPTION
## Thinking Path

- [#4889](https://github.com/nesquena/hermes-webui/pull/4889) already removed the per-row cron sidecar I/O slice, and [#4949](https://github.com/nesquena/hermes-webui/pull/4949) already shipped the single-profile streaming-freeze path in current `api/models.py`.
- The remaining `get_cli_sessions()` stall was in the follower path after invalidation: a cold follower could wait forever, and a clear during rebuild could leave a joiner with no valid cache entry and fall through to `[]`.
- This keeps the shipped cache-key and payload semantics intact, then tightens the singleflight follow path so callers either reuse fresh cache, reuse still-valid stale rows, or do a bounded fallback rebuild.

## What Changed

- `api/models.py`: split the rebuild path into shared helpers, cap cold followers at a 0.25s wait before an independent rebuild, make invalidated joiners loop back and reclaim rebuild ownership after the old inflight slot drops, reuse fresh cache entries when available, remove the dead post-return fallback block, repair the warning log string, and keep the all-profiles branch on the shared cache path.
- `tests/test_issue4842_cli_cache_streaming.py`: add focused regressions for the cold-follower timeout fallback and the clear-during-rebuild joiner that used to return `[]`, alongside the existing streaming and invalidation coverage.

## Why It Matters

This keeps `/api/sessions` responsive on slow or wedged rebuilds, it closes the silent empty-sidebar case after `clear_cli_sessions_cache()`, and it preserves the all-profiles scan behavior that pulls named-profile CLI sessions into the aggregate view. Sidebar rows stay consistent, but followers no longer hang indefinitely or drop CLI and cron sessions.

## Verification

- `pytest tests/test_issue4842_cli_cache_streaming.py tests/test_cli_sessions_cache_fingerprint.py -v --timeout=60`
- `11 passed, 1 warning in 6.30s`

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #4842.

Attribution: the reporter's one-session traces and lock diagnosis on [#4842](https://github.com/nesquena/hermes-webui/issues/4842#issuecomment-4804814903) narrowed this fix to the CLI cache rebuild path after the earlier shipped slices in [#4889](https://github.com/nesquena/hermes-webui/pull/4889) and [#4949](https://github.com/nesquena/hermes-webui/pull/4949).

## Model Used

GPT 5.5 via Codex CLI