### PR TITLE
Release XZ (v0.51.670): chronological tool-call rows before final answer incl equal-ts (#4893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.670] — 2026-06-26 — Release XZ (settled tool-call rows stay before the final answer)
+
+### Fixed
+
+- **A complete final answer no longer looks unfinished when an earlier tool call shares its timestamp.** On a paginated load, older `state.db` assistant rows carrying distinct tool calls were appended after the settled final answer instead of inserted in order, so the renderer treated the real final answer as a non-final segment until a refresh. The merge now inserts those tool-call rows chronologically — including the equal-timestamp case (a fast tool call and the final answer landing in the same second), where the final answer now correctly stays last. The existing dedupe, tool-call→result block integrity, and watermark reconciliation are unchanged. Thanks @franksong2702. (#4893)
+
 ## [v0.51.669] — 2026-06-26 — Release XY (set OpenAI priority service tier from the model picker)
 
 ### Added

--- a/api/models.py
+++ b/api/models.py
@@ -5405,6 +5405,19 @@ def _state_db_anchor_index(state_messages: list, anchor_key) -> int | None:
     return None
 
 
+def _tool_call_assistant_should_precede_content_assistant(existing: dict, msg: dict) -> bool:
+    return (
+        isinstance(existing, dict)
+        and isinstance(msg, dict)
+        and str(msg.get("role") or "").lower() == "assistant"
+        and bool(msg.get("tool_calls"))
+        and not _message_content_text(msg).strip()
+        and str(existing.get("role") or "").lower() == "assistant"
+        and not existing.get("tool_calls")
+        and bool(_message_content_text(existing).strip())
+    )
+
+
 def _insert_state_message_chronologically(messages: list, msg: dict) -> bool:
     """Insert a state.db-only row before newer sidecar rows when safe.
 
@@ -5424,8 +5437,13 @@ def _insert_state_message_chronologically(messages: list, msg: dict) -> bool:
             existing_timestamp > timestamp
             or (
                 existing_timestamp == timestamp
-                and msg.get("role") == "user"
-                and existing.get("role") == "assistant"
+                and (
+                    (
+                        msg.get("role") == "user"
+                        and existing.get("role") == "assistant"
+                    )
+                    or _tool_call_assistant_should_precede_content_assistant(existing, msg)
+                )
             )
         )
         if not should_insert:
@@ -5477,6 +5495,7 @@ def _insert_state_message_chronologically(messages: list, msg: dict) -> bool:
                 and idx > 0
                 and messages[idx - 1].get("role") == msg.get("role")
                 and _message_timestamp_as_float(messages[idx]) == timestamp
+                and not _tool_call_assistant_should_precede_content_assistant(messages[idx], msg)
             ):
                 idx += 1
                 advanced = True

--- a/api/models.py
+++ b/api/models.py
@@ -5822,7 +5822,17 @@ def merge_session_messages_append_only(
                 if _tc:
                     _ck = _session_message_content_key(msg)
                     if _ck in seen_content_keys and dedup_key not in seen_dedup_keys:
-                        pass  # different tool_calls from sidecar — preserve
+                        # Different tool_calls from sidecar — preserve, but keep
+                        # the row in timestamp order. Falling through to the
+                        # generic append path would move older tool-call-only
+                        # assistant rows after the settled final answer.
+                        if _insert_state_message_chronologically(merged_messages, msg):
+                            seen_message_keys.add(key)
+                            seen_dedup_keys.add(dedup_key)
+                            seen_content_keys.add(_session_message_content_key(msg))
+                            seen_visible_keys.add(visible_key)
+                            _remember_merged_message(msg)
+                        continue
                     else:
                         _merge_session_display_metadata(merged_by_message_key.get(key), msg)
                         continue

--- a/tests/test_merge_key_tool_calls.py
+++ b/tests/test_merge_key_tool_calls.py
@@ -154,6 +154,46 @@ class TestMergeToolCallsEndToEnd:
             "call_2",
         ]
 
+    def test_equal_timestamp_state_tool_call_stays_before_final_answer(self):
+        """Same-second tool-call rows must still stay before the final answer."""
+        sidecar_tool = _assistant_tc("call_1", "read_file", timestamp=1000)
+        final_answer = {
+            "role": "assistant",
+            "content": "Final answer.",
+            "timestamp": 1000,
+        }
+        state_tool = _assistant_tc("call_2", "terminal", timestamp=1000)
+
+        result = merge_session_messages_append_only(
+            [sidecar_tool, final_answer],
+            [state_tool],
+        )
+
+        assert result[-1] == final_answer
+        assert [
+            m.get("tool_calls", [{}])[0].get("id")
+            for m in result
+            if m.get("tool_calls")
+        ] == ["call_1", "call_2"]
+
+    def test_pre_window_state_tool_call_row_is_not_tail_appended(self):
+        """Pre-window tool-call resurrection candidates stay dropped."""
+        sidecar_tool = _assistant_tc("call_1", "read_file", timestamp=1000)
+        final_answer = {
+            "role": "assistant",
+            "content": "Final answer.",
+            "timestamp": 1001,
+        }
+        state_tool = _assistant_tc("call_2", "terminal", timestamp=999)
+
+        result = merge_session_messages_append_only(
+            [sidecar_tool, final_answer],
+            [state_tool],
+        )
+
+        assert result == [sidecar_tool, final_answer]
+        assert result[-1] == final_answer
+
     def test_no_tool_calls_still_deduped(self):
         """Messages without tool_calls are deduplicated by legacy key as before."""
         msg = {"role": "assistant", "content": "hello", "timestamp": 1000}

--- a/tests/test_merge_key_tool_calls.py
+++ b/tests/test_merge_key_tool_calls.py
@@ -126,6 +126,34 @@ class TestMergeToolCallsEndToEnd:
         }
         assert tc_ids == {"call_1", "call_2"}
 
+    def test_older_state_tool_call_assistant_stays_before_final_answer(self):
+        """Older tool-call-only state.db rows must not become the final tail.
+
+        The WebUI sidecar can already contain a settled final answer while
+        state.db still has empty-content assistant rows that carry distinct
+        tool_calls from earlier in the turn. Those rows are real activity and
+        should be preserved, but appending them after the final answer makes the
+        renderer treat the final answer as a non-final assistant segment.
+        """
+        sidecar_tool = _assistant_tc("call_1", "read_file", timestamp=1000.0)
+        final_answer = {
+            "role": "assistant",
+            "content": "Final answer is complete.",
+            "timestamp": 1001.0,
+        }
+        state_tool = _assistant_tc("call_2", "terminal", timestamp=1000.5)
+
+        result = merge_session_messages_append_only(
+            [sidecar_tool, final_answer],
+            [state_tool],
+        )
+
+        assert result[-1] == final_answer
+        assert [m.get("tool_calls", [{}])[0].get("id") for m in result if m.get("tool_calls")] == [
+            "call_1",
+            "call_2",
+        ]
+
     def test_no_tool_calls_still_deduped(self):
         """Messages without tool_calls are deduplicated by legacy key as before."""
         msg = {"role": "assistant", "content": "hello", "timestamp": 1000}

--- a/tests/test_merge_key_tool_calls.py
+++ b/tests/test_merge_key_tool_calls.py
@@ -176,6 +176,49 @@ class TestMergeToolCallsEndToEnd:
             if m.get("tool_calls")
         ] == ["call_1", "call_2"]
 
+    def test_multiple_equal_timestamp_state_tool_calls_stay_before_final(self):
+        """Several same-second state tool-call rows all stay before the final
+        answer, in order (Opus coverage gap: multi-tool tie shape)."""
+        sidecar_tool = _assistant_tc("call_1", "read_file", timestamp=1000)
+        final_answer = {"role": "assistant", "content": "Final answer.", "timestamp": 1000}
+        state_a = _assistant_tc("call_2", "terminal", timestamp=1000)
+        state_b = _assistant_tc("call_3", "write_file", timestamp=1000)
+
+        result = merge_session_messages_append_only(
+            [sidecar_tool, final_answer],
+            [state_a, state_b],
+        )
+
+        assert result[-1] == final_answer, result
+        assert [
+            m.get("tool_calls", [{}])[0].get("id")
+            for m in result
+            if m.get("tool_calls")
+        ] == ["call_1", "call_2", "call_3"]
+
+    def test_tie_insert_does_not_split_tool_call_result_block(self):
+        """The equal-timestamp tool-call insert must not land between an
+        assistant(tool_calls) and its tool result (Opus coverage gap:
+        guard-a block-split interaction)."""
+        sidecar_tool = _assistant_tc("call_1", "read_file", timestamp=1000)
+        sidecar_result = _tool_result("call_1", "read_file", "file contents")
+        final_answer = {"role": "assistant", "content": "Final answer.", "timestamp": 1000}
+        state_tool = _assistant_tc("call_2", "terminal", timestamp=1000)
+
+        result = merge_session_messages_append_only(
+            [sidecar_tool, sidecar_result, final_answer],
+            [state_tool],
+        )
+
+        # The tool result must stay immediately after its assistant(tool_calls).
+        idxs = {id(m): i for i, m in enumerate(result)}
+        asst_idx = next(i for i, m in enumerate(result)
+                        if m.get("tool_calls") and m["tool_calls"][0]["id"] == "call_1")
+        res_idx = next(i for i, m in enumerate(result)
+                       if m.get("role") == "tool" and m.get("tool_call_id") == "call_1")
+        assert res_idx == asst_idx + 1, f"tool_calls->result block split: {result}"
+        assert result[-1] == final_answer, result
+
     def test_pre_window_state_tool_call_row_is_not_tail_appended(self):
         """Pre-window tool-call resurrection candidates stay dropped."""
         sidecar_tool = _assistant_tc("call_1", "read_file", timestamp=1000)

--- a/tests/test_merge_key_tool_calls.py
+++ b/tests/test_merge_key_tool_calls.py
@@ -211,7 +211,6 @@ class TestMergeToolCallsEndToEnd:
         )
 
         # The tool result must stay immediately after its assistant(tool_calls).
-        idxs = {id(m): i for i, m in enumerate(result)}
         asst_idx = next(i for i, m in enumerate(result)
                         if m.get("tool_calls") and m["tool_calls"][0]["id"] == "call_1")
         res_idx = next(i for i, m in enumerate(result)


### PR DESCRIPTION
## Release XZ (v0.51.670) — settled tool-call rows stay before the final answer

Ships **#4893** (@franksong2702, T1). Crown-jewel append-only transcript merge.

### What it fixes
On a paginated load, older `state.db` assistant rows carrying distinct tool calls were tail-appended **after** the settled final answer, so the renderer treated the real final answer as a non-final segment until a refresh. Now inserted chronologically — including the **equal-timestamp** case (fast tool call + final answer in the same second), where the final answer correctly stays last.

### Gate (converged after a tie-edge bounce)
The original fix shipped the strictly-older case; both gates then reproduced an equal-timestamp tie (`[call_1, Final answer, call_2]`). The re-push added `_tool_call_assistant_should_precede_content_assistant` wired into BOTH the `should_insert` disjunct AND a fixpoint guard-b exception (the non-obvious part — the bare disjunct was defeated by guard-b skipping past the final answer).
- **Codex: SAFE TO SHIP** — guard-b exception scoped to empty-content tool-call assistant before content assistant; **cannot fire for user rows** (user-path byte-identical); tool-result block integrity + watermark reconciliation unchanged. Verified all permutations.
- **Opus: SHIP** — questions 1-4 correct, user-path provably byte-identical; flagged 2 test-coverage gaps (multi-tool tie + block-split) which **I added** (both pass, confirming final-answer-last + no block split).
- **Full suite: 10643 passed**, 0 failures.
- Pre-merge head re-check: gated == live (11c263ec).

Credit @franksong2702.
