### PR TITLE
Release YE (v0.51.675): bounded state.db tail reads for paginated session loads (#4920, fixes #4918 P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.675] — 2026-06-26 — Release YE (long conversations open fast — bounded state.db tail reads)
+
+### Fixed
+
+- **Opening a long conversation no longer shows "Loading…" for 1-2 seconds.** `/api/session` loaded the entire `state.db` message history before trimming to the visible window; for an 844-message session that cold read took ~1.75s. The paginated path now pushes the client's `msg_limit` into SQL via a `since_timestamp` floor derived from the sidecar tail, reading only the tail window (expected drop to a few hundred ms). The optimization is taken only when it is provably output-identical to the full read: it keeps NULL-timestamp rows (`timestamp IS NULL OR timestamp >= ?`), and a below-floor prefix guard compares the **full merge identity** (`role`, `content`, and parsed `tool_calls`) between the sidecar and `state.db` prefixes — bailing to the full read whenever they can't be proven equal (or the schema lacks the needed columns), so `message_count`/`_messages_offset` and "load older" paging stay byte-identical. Callers needing all rows are unaffected (the floor is opt-in). Thanks @franksong2702. (#4920, fixes #4918 Problem-1)
+
 ## [v0.51.674] — 2026-06-26 — Release YD (server no longer exhausts threads under sidebar-poll load)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -5023,7 +5023,13 @@ def _json_loads_if_string(value):
         return value
 
 
-def get_state_db_session_messages(sid, *, stitch_continuations: bool = False, profile=None) -> list:
+def get_state_db_session_messages(
+    sid,
+    *,
+    stitch_continuations: bool = False,
+    profile=None,
+    since_timestamp=None,
+) -> list:
     """Read messages for a Hermes session from state.db.
 
     When *profile* is supplied, reads from that profile's state.db; otherwise
@@ -5033,6 +5039,11 @@ def get_state_db_session_messages(sid, *, stitch_continuations: bool = False, pr
     ``stitch_continuations`` is true it preserves the historical CLI/external-agent
     behavior of walking compatible compression/close parent segments before reading
     messages.
+
+    ``since_timestamp`` is an optional display-path optimization.  It limits the
+    raw state.db scan to rows at or after a sidecar-derived timestamp floor while
+    preserving the caller's normal merge/window logic.  Full-history callers must
+    leave it unset.
     """
     try:
         import sqlite3
@@ -5114,12 +5125,23 @@ def get_state_db_session_messages(sid, *, stitch_continuations: bool = False, pr
                             seen.add(current_id)
 
             placeholders = ', '.join('?' for _ in session_chain)
+            params = list(session_chain)
+            since_clause = ""
+            if since_timestamp is not None:
+                try:
+                    since_ts = float(since_timestamp)
+                except (TypeError, ValueError):
+                    since_ts = None
+                if since_ts is not None:
+                    since_clause = " AND timestamp >= ?"
+                    params.append(since_ts)
             cur.execute(f"""
                 SELECT {', '.join(selected)}, session_id
                 FROM messages
                 WHERE session_id IN ({placeholders})
+                {since_clause}
                 ORDER BY timestamp ASC, id ASC
-            """, session_chain)
+            """, params)
             msgs = []
             for row in cur.fetchall():
                 msg = {

--- a/api/models.py
+++ b/api/models.py
@@ -5133,7 +5133,7 @@ def get_state_db_session_messages(
                 except (TypeError, ValueError):
                     since_ts = None
                 if since_ts is not None:
-                    since_clause = " AND timestamp >= ?"
+                    since_clause = " AND (timestamp IS NULL OR timestamp >= ?)"
                     params.append(since_ts)
             cur.execute(f"""
                 SELECT {', '.join(selected)}, session_id
@@ -5164,6 +5164,62 @@ def get_state_db_session_messages(
     except Exception:
         return []
     return msgs
+
+
+def count_state_db_session_messages_before_timestamp(
+    sid,
+    before_timestamp,
+    *,
+    profile=None,
+) -> int | None:
+    """Return the raw state.db row count before ``before_timestamp`` for ``sid``.
+
+    Missing timestamps are intentionally excluded because the bounded reader
+    keeps them with ``timestamp IS NULL OR timestamp >= ?``.  The caller uses
+    this as a conservative coordinate-space guard before taking the optimized
+    tail-read path.
+    """
+    try:
+        import sqlite3
+    except ImportError:
+        return None
+
+    if not sid:
+        return None
+    try:
+        before_ts = float(before_timestamp)
+    except (TypeError, ValueError):
+        return None
+
+    if isinstance(profile, str) and profile:
+        db_path = _get_profile_home(profile) / 'state.db'
+        if not db_path.exists():
+            db_path = _active_state_db_path()
+    else:
+        db_path = _active_state_db_path()
+    if not db_path.exists():
+        return 0
+
+    try:
+        with closing(sqlite3.connect(str(db_path))) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("PRAGMA table_info(messages)")
+            available = {str(row['name']) for row in cur.fetchall()}
+            if not {'session_id', 'timestamp'}.issubset(available):
+                return None
+            cur.execute(
+                """
+                SELECT COUNT(*) AS message_count
+                FROM messages
+                WHERE session_id = ? AND timestamp IS NOT NULL AND timestamp < ?
+                """,
+                (str(sid), before_ts),
+            )
+            row = cur.fetchone()
+            return max(0, int(row['message_count'] or 0)) if row else 0
+    except Exception:
+        return None
 
 
 def get_state_db_session_summary(sid, *, profile=None) -> dict:

--- a/api/models.py
+++ b/api/models.py
@@ -5171,13 +5171,14 @@ def get_state_db_session_message_keys_before_timestamp(
     before_timestamp,
     *,
     profile=None,
-) -> list[tuple[str, str]] | None:
-    """Return sorted raw ``(role, content)`` keys before ``before_timestamp``.
+) -> list[tuple] | None:
+    """Return visible-identity keys before ``before_timestamp`` in DB order.
 
     Missing timestamps are intentionally excluded because the bounded reader
     keeps them with ``timestamp IS NULL OR timestamp >= ?``.  The caller uses
     this as a conservative prefix-identity guard before taking the optimized
-    tail-read path.
+    tail-read path, so schemas that cannot prove the merge-visible identity
+    force a full read.
     """
     try:
         import sqlite3
@@ -5206,21 +5207,30 @@ def get_state_db_session_message_keys_before_timestamp(
             cur = conn.cursor()
             cur.execute("PRAGMA table_info(messages)")
             available = {str(row['name']) for row in cur.fetchall()}
-            if not {'session_id', 'role', 'content', 'timestamp'}.issubset(available):
+            if not {'id', 'session_id', 'role', 'content', 'timestamp', 'tool_calls'}.issubset(available):
                 return None
             cur.execute(
                 """
-                SELECT COALESCE(role, '') AS role, COALESCE(content, '') AS content
+                SELECT
+                    COALESCE(role, '') AS role,
+                    COALESCE(content, '') AS content,
+                    tool_calls
                 FROM messages
                 WHERE session_id = ? AND timestamp IS NOT NULL AND timestamp < ?
                 ORDER BY timestamp ASC, id ASC
                 """,
                 (str(sid), before_ts),
             )
-            return sorted(
-                (str(row['role'] or ''), str(row['content'] or ''))
+            return [
+                _session_message_visible_key(
+                    {
+                        "role": row["role"],
+                        "content": row["content"],
+                        "tool_calls": _json_loads_if_string(row["tool_calls"]),
+                    }
+                )
                 for row in cur.fetchall()
-            )
+            ]
     except Exception:
         return None
 

--- a/api/models.py
+++ b/api/models.py
@@ -5166,17 +5166,17 @@ def get_state_db_session_messages(
     return msgs
 
 
-def count_state_db_session_messages_before_timestamp(
+def get_state_db_session_message_keys_before_timestamp(
     sid,
     before_timestamp,
     *,
     profile=None,
-) -> int | None:
-    """Return the raw state.db row count before ``before_timestamp`` for ``sid``.
+) -> list[tuple[str, str]] | None:
+    """Return sorted raw ``(role, content)`` keys before ``before_timestamp``.
 
     Missing timestamps are intentionally excluded because the bounded reader
     keeps them with ``timestamp IS NULL OR timestamp >= ?``.  The caller uses
-    this as a conservative coordinate-space guard before taking the optimized
+    this as a conservative prefix-identity guard before taking the optimized
     tail-read path.
     """
     try:
@@ -5198,7 +5198,7 @@ def count_state_db_session_messages_before_timestamp(
     else:
         db_path = _active_state_db_path()
     if not db_path.exists():
-        return 0
+        return []
 
     try:
         with closing(sqlite3.connect(str(db_path))) as conn:
@@ -5206,18 +5206,21 @@ def count_state_db_session_messages_before_timestamp(
             cur = conn.cursor()
             cur.execute("PRAGMA table_info(messages)")
             available = {str(row['name']) for row in cur.fetchall()}
-            if not {'session_id', 'timestamp'}.issubset(available):
+            if not {'session_id', 'role', 'content', 'timestamp'}.issubset(available):
                 return None
             cur.execute(
                 """
-                SELECT COUNT(*) AS message_count
+                SELECT COALESCE(role, '') AS role, COALESCE(content, '') AS content
                 FROM messages
                 WHERE session_id = ? AND timestamp IS NOT NULL AND timestamp < ?
+                ORDER BY timestamp ASC, id ASC
                 """,
                 (str(sid), before_ts),
             )
-            row = cur.fetchone()
-            return max(0, int(row['message_count'] or 0)) if row else 0
+            return sorted(
+                (str(row['role'] or ''), str(row['content'] or ''))
+                for row in cur.fetchall()
+            )
     except Exception:
         return None
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -6087,6 +6087,55 @@ def _limited_webui_messages_for_display(session, state_db_messages) -> list:
     )
 
 
+def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before=None):
+    """Return (timestamp floor, sidecar messages) for bounded state.db tail reads.
+
+    The display window limit counts visible transcript rows after WebUI sidecar
+    and state.db reconciliation, so this deliberately does not SQL ``LIMIT`` raw
+    rows.  Instead, for the common initial tail load, keep the full sidecar
+    coordinate space and read a conservative recent state.db superset.  Older
+    page loads and edit/truncation recovery shapes stay on the full state.db
+    path because their correctness depends on older reconciliation rows.
+    """
+    if msg_limit is None or msg_before is not None:
+        return None, None
+    if getattr(session, "truncation_watermark", None) not in (None, ""):
+        return None, None
+
+    sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)
+    if not sidecar_messages:
+        return None, sidecar_messages
+
+    try:
+        limit = max(1, int(msg_limit))
+    except (TypeError, ValueError):
+        return None, sidecar_messages
+    raw_budget = max(300, limit * 10)
+    if len(sidecar_messages) <= raw_budget:
+        return None, sidecar_messages
+
+    tail = sidecar_messages[-raw_budget:]
+    timestamps = [
+        ts
+        for ts in (_message_timestamp_as_float(msg) for msg in tail)
+        if ts is not None
+    ]
+    if not timestamps:
+        return None, sidecar_messages
+    return min(timestamps), sidecar_messages
+
+
+def _limited_webui_messages_for_display_with_sidecar(session, sidecar_messages, state_db_messages) -> list:
+    if sidecar_messages is None:
+        return _limited_webui_messages_for_display(session, state_db_messages)
+    return merge_session_messages_append_only(
+        sidecar_messages,
+        state_db_messages,
+        truncation_watermark=getattr(session, "truncation_watermark", None),
+        truncation_boundary=getattr(session, "truncation_boundary", None),
+    )
+
+
 def _messages_start_with_visible_prefix(messages, prefix) -> bool:
     """Return True when ``messages`` already replays ``prefix`` in display order."""
     messages = list(messages or [])
@@ -6668,6 +6717,7 @@ from api.models import (
     _merge_session_display_metadata,
     _session_message_merge_key,
     _session_message_visible_key,
+    _message_timestamp_as_float,
     _is_empty_partial_activity_message,
     _hide_from_default_sidebar,
     prune_session_from_index,
@@ -9541,10 +9591,27 @@ def handle_get(handler, parsed) -> bool:
             cli_messages = []
             state_db_messages = []
             metadata_summary = None
+            limited_sidecar_messages = None
+            state_db_since_timestamp = None
             if is_messaging_session:
                 cli_messages = get_cli_session_messages(sid)
             elif load_messages:
-                state_db_messages = get_state_db_session_messages(sid, profile=_session_profile)
+                if msg_limit is not None:
+                    (
+                        state_db_since_timestamp,
+                        limited_sidecar_messages,
+                    ) = _state_db_since_timestamp_for_limited_display(
+                        s,
+                        msg_limit,
+                        msg_before=msg_before,
+                    )
+                _state_db_reader_kwargs = {"profile": _session_profile}
+                if state_db_since_timestamp is not None:
+                    _state_db_reader_kwargs["since_timestamp"] = state_db_since_timestamp
+                state_db_messages = get_state_db_session_messages(
+                    sid,
+                    **_state_db_reader_kwargs,
+                )
             elif not is_messaging_session:
                 # Metadata-only callers still need the same append-only
                 # reconciliation contract as full loads so stale/replayed
@@ -9575,7 +9642,11 @@ def handle_get(handler, parsed) -> bool:
                     # them chronologically and dedupe exact repeats.
                     _all_msgs = _merged_session_messages_for_display(s, cli_messages)
                 elif msg_limit is not None:
-                    _all_msgs = _limited_webui_messages_for_display(s, state_db_messages)
+                    _all_msgs = _limited_webui_messages_for_display_with_sidecar(
+                        s,
+                        limited_sidecar_messages,
+                        state_db_messages,
+                    )
                 else:
                     _all_msgs = merge_session_messages_append_only(
                         _webui_sidecar_lineage_messages_for_display(s),

--- a/api/routes.py
+++ b/api/routes.py
@@ -6137,7 +6137,7 @@ def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before
             str(msg.get("role") or ""),
             str(msg.get("content") or ""),
         )
-        for msg, ts in zip(sidecar_messages, sidecar_timestamps)
+        for msg, ts in zip(sidecar_messages, sidecar_timestamps, strict=True)
         if ts < floor
     )
     state_before_keys = get_state_db_session_message_keys_before_timestamp(

--- a/api/routes.py
+++ b/api/routes.py
@@ -6113,9 +6113,14 @@ def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before
         return None, None
     if getattr(session, "truncation_watermark", None) not in (None, ""):
         return None, None
+    if getattr(session, "truncation_boundary", None) not in (None, ""):
+        return None, None
 
     sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)
     if not sidecar_messages:
+        return None, sidecar_messages
+    sidecar_timestamps = [_message_timestamp_as_float(msg) for msg in sidecar_messages]
+    if any(ts is None for ts in sidecar_timestamps):
         return None, sidecar_messages
 
     try:
@@ -6126,15 +6131,16 @@ def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before
     if len(sidecar_messages) <= raw_budget:
         return None, sidecar_messages
 
-    tail = sidecar_messages[-raw_budget:]
-    timestamps = [
-        ts
-        for ts in (_message_timestamp_as_float(msg) for msg in tail)
-        if ts is not None
-    ]
-    if not timestamps:
+    floor = min(sidecar_timestamps[-raw_budget:])
+    sidecar_before_count = sum(1 for ts in sidecar_timestamps if ts < floor)
+    state_before_count = count_state_db_session_messages_before_timestamp(
+        getattr(session, "session_id", None),
+        floor,
+        profile=getattr(session, "profile", None) or None,
+    )
+    if state_before_count is None or state_before_count != sidecar_before_count:
         return None, sidecar_messages
-    return min(timestamps), sidecar_messages
+    return floor, sidecar_messages
 
 
 def _messages_start_with_visible_prefix(messages, prefix) -> bool:
@@ -6711,6 +6717,7 @@ from api.models import (
     get_cli_sessions,
     get_cli_session_messages,
     get_state_db_session_messages,
+    count_state_db_session_messages_before_timestamp,
     get_state_db_session_summary,
     merge_session_messages_append_only,
     _enrich_sidebar_lineage_metadata,

--- a/api/routes.py
+++ b/api/routes.py
@@ -6068,6 +6068,18 @@ def _limited_webui_messages_for_display(session, state_db_messages) -> list:
     the sidecar yet.
     """
     sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)
+    return _limited_webui_messages_for_display_with_sidecar(
+        session,
+        sidecar_messages,
+        state_db_messages,
+    )
+
+
+def _limited_webui_messages_for_display_with_sidecar(session, sidecar_messages, state_db_messages) -> list:
+    if sidecar_messages is None:
+        sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)
+    else:
+        sidecar_messages = list(sidecar_messages or [])
     state_db_messages = list(state_db_messages or [])
     if not state_db_messages:
         return sidecar_messages
@@ -6123,17 +6135,6 @@ def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before
     if not timestamps:
         return None, sidecar_messages
     return min(timestamps), sidecar_messages
-
-
-def _limited_webui_messages_for_display_with_sidecar(session, sidecar_messages, state_db_messages) -> list:
-    if sidecar_messages is None:
-        return _limited_webui_messages_for_display(session, state_db_messages)
-    return merge_session_messages_append_only(
-        sidecar_messages,
-        state_db_messages,
-        truncation_watermark=getattr(session, "truncation_watermark", None),
-        truncation_boundary=getattr(session, "truncation_boundary", None),
-    )
 
 
 def _messages_start_with_visible_prefix(messages, prefix) -> bool:

--- a/api/routes.py
+++ b/api/routes.py
@@ -6132,14 +6132,11 @@ def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before
         return None, sidecar_messages
 
     floor = min(sidecar_timestamps[-raw_budget:])
-    sidecar_before_keys = sorted(
-        (
-            str(msg.get("role") or ""),
-            str(msg.get("content") or ""),
-        )
+    sidecar_before_keys = [
+        _session_message_visible_key(msg)
         for msg, ts in zip(sidecar_messages, sidecar_timestamps, strict=True)
         if ts < floor
-    )
+    ]
     state_before_keys = get_state_db_session_message_keys_before_timestamp(
         getattr(session, "session_id", None),
         floor,

--- a/api/routes.py
+++ b/api/routes.py
@@ -6132,13 +6132,20 @@ def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before
         return None, sidecar_messages
 
     floor = min(sidecar_timestamps[-raw_budget:])
-    sidecar_before_count = sum(1 for ts in sidecar_timestamps if ts < floor)
-    state_before_count = count_state_db_session_messages_before_timestamp(
+    sidecar_before_keys = sorted(
+        (
+            str(msg.get("role") or ""),
+            str(msg.get("content") or ""),
+        )
+        for msg, ts in zip(sidecar_messages, sidecar_timestamps)
+        if ts < floor
+    )
+    state_before_keys = get_state_db_session_message_keys_before_timestamp(
         getattr(session, "session_id", None),
         floor,
         profile=getattr(session, "profile", None) or None,
     )
-    if state_before_count is None or state_before_count != sidecar_before_count:
+    if state_before_keys is None or state_before_keys != sidecar_before_keys:
         return None, sidecar_messages
     return floor, sidecar_messages
 
@@ -6717,7 +6724,7 @@ from api.models import (
     get_cli_sessions,
     get_cli_session_messages,
     get_state_db_session_messages,
-    count_state_db_session_messages_before_timestamp,
+    get_state_db_session_message_keys_before_timestamp,
     get_state_db_session_summary,
     merge_session_messages_append_only,
     _enrich_sidebar_lineage_metadata,

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -337,6 +337,113 @@ def test_api_session_includes_state_db_messages_newer_than_webui_sidecar(monkeyp
     assert payload["session"]["message_count"] == 4
 
 
+def test_state_db_reader_can_filter_by_timestamp_floor(monkeypatch, tmp_path):
+    import api.models as models
+
+    sid = "webui_reconcile_since_001"
+    _install_test_session(monkeypatch, tmp_path, sid, [])
+    _make_state_db(
+        tmp_path / "state.db",
+        sid,
+        [
+            {"role": "user", "content": "old", "timestamp": 10.0},
+            {"role": "assistant", "content": "kept", "timestamp": 20.0},
+            {"role": "user", "content": "also kept", "timestamp": 30.0},
+        ],
+    )
+
+    messages = models.get_state_db_session_messages(sid, since_timestamp=20.0)
+
+    assert [m["content"] for m in messages] == ["kept", "also kept"]
+
+
+def test_msg_limit_session_load_reads_only_recent_state_db_tail(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_reconcile_limited_tail"
+    sidecar_messages = [
+        {"role": "user", "content": f"sidecar {idx}", "timestamp": float(idx)}
+        for idx in range(500)
+    ]
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    _make_state_db(
+        tmp_path / "state.db",
+        sid,
+        sidecar_messages
+        + [
+            {"role": "user", "content": "external user", "timestamp": 500.0},
+            {"role": "assistant", "content": "external answer", "timestamp": 501.0},
+        ],
+    )
+
+    real_reader = routes.get_state_db_session_messages
+    full_state_messages = real_reader(sid)
+    full_all_messages = routes._limited_webui_messages_for_display(
+        session,
+        full_state_messages,
+    )
+    expected_window, expected_offset = routes._message_window_for_display(
+        full_all_messages,
+        msg_limit=30,
+    )
+    captured = {}
+
+    def wrapped_reader(*args, **kwargs):
+        captured["since_timestamp"] = kwargs.get("since_timestamp")
+        messages = real_reader(*args, **kwargs)
+        captured["row_count"] = len(messages)
+        return messages
+
+    monkeypatch.setattr(routes, "get_state_db_session_messages", wrapped_reader)
+
+    handler = _GetHandler(
+        f"/api/session?session_id={sid}&messages=1&resolve_model=0&msg_limit=30"
+    )
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    assert captured["since_timestamp"] == 200.0
+    assert captured["row_count"] == 302
+    messages = handler.response_json["session"]["messages"]
+    assert messages == expected_window
+    assert handler.response_json["session"]["_messages_offset"] == expected_offset
+    assert messages[0]["content"] == "sidecar 472"
+    assert messages[-2]["content"] == "external user"
+    assert messages[-1]["content"] == "external answer"
+
+
+def test_msg_before_session_load_keeps_full_state_db_reader(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_reconcile_msg_before"
+    sidecar_messages = [
+        {"role": "user", "content": f"sidecar {idx}", "timestamp": float(idx)}
+        for idx in range(500)
+    ]
+    _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    _make_state_db(tmp_path / "state.db", sid, sidecar_messages)
+
+    real_reader = routes.get_state_db_session_messages
+    captured = {}
+
+    def wrapped_reader(*args, **kwargs):
+        captured["since_timestamp"] = kwargs.get("since_timestamp")
+        return real_reader(*args, **kwargs)
+
+    monkeypatch.setattr(routes, "get_state_db_session_messages", wrapped_reader)
+
+    handler = _GetHandler(
+        f"/api/session?session_id={sid}&messages=1&resolve_model=0&msg_before=400&msg_limit=30"
+    )
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    assert captured["since_timestamp"] is None
+    messages = handler.response_json["session"]["messages"]
+    assert messages[0]["content"] == "sidecar 370"
+    assert messages[-1]["content"] == "sidecar 399"
+
+
 def test_metadata_poll_uses_sidecar_message_count_for_external_updates(monkeypatch, tmp_path):
     """Active-session external refresh relies on metadata-only counts.
 

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -357,6 +357,26 @@ def test_state_db_reader_can_filter_by_timestamp_floor(monkeypatch, tmp_path):
     assert [m["content"] for m in messages] == ["kept", "also kept"]
 
 
+def test_state_db_reader_since_timestamp_keeps_null_timestamp_rows(monkeypatch, tmp_path):
+    import api.models as models
+
+    sid = "webui_reconcile_since_null_001"
+    _install_test_session(monkeypatch, tmp_path, sid, [])
+    _make_state_db(
+        tmp_path / "state.db",
+        sid,
+        [
+            {"role": "user", "content": "old", "timestamp": 10.0},
+            {"role": "assistant", "content": "null timestamp kept", "timestamp": None},
+            {"role": "assistant", "content": "kept", "timestamp": 20.0},
+        ],
+    )
+
+    messages = models.get_state_db_session_messages(sid, since_timestamp=20.0)
+
+    assert [m["content"] for m in messages] == ["null timestamp kept", "kept"]
+
+
 def test_limited_display_with_precomputed_sidecar_keeps_empty_state_db_guard(monkeypatch, tmp_path):
     import api.routes as routes
 
@@ -428,6 +448,146 @@ def test_msg_limit_session_load_reads_only_recent_state_db_tail(monkeypatch, tmp
     assert messages[0]["content"] == "sidecar 472"
     assert messages[-2]["content"] == "external user"
     assert messages[-1]["content"] == "external answer"
+
+
+def test_msg_limit_session_load_matches_full_read_with_null_state_db_timestamp(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_reconcile_limited_tail_null"
+    sidecar_messages = [
+        {"role": "user", "content": f"sidecar {idx}", "timestamp": float(idx)}
+        for idx in range(500)
+    ]
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    _make_state_db(
+        tmp_path / "state.db",
+        sid,
+        sidecar_messages
+        + [
+            {
+                "role": "assistant",
+                "content": "state null timestamp only",
+                "timestamp": None,
+            },
+        ],
+    )
+
+    real_reader = routes.get_state_db_session_messages
+    full_state_messages = real_reader(sid)
+    full_all_messages = routes._limited_webui_messages_for_display(
+        session,
+        full_state_messages,
+    )
+    expected_window, expected_offset = routes._message_window_for_display(
+        full_all_messages,
+        msg_limit=30,
+    )
+    captured = {}
+
+    def wrapped_reader(*args, **kwargs):
+        captured["since_timestamp"] = kwargs.get("since_timestamp")
+        messages = real_reader(*args, **kwargs)
+        captured["row_count"] = len(messages)
+        return messages
+
+    monkeypatch.setattr(routes, "get_state_db_session_messages", wrapped_reader)
+
+    handler = _GetHandler(
+        f"/api/session?session_id={sid}&messages=1&resolve_model=0&msg_limit=30"
+    )
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    assert captured["since_timestamp"] == 200.0
+    assert captured["row_count"] == 301
+    session_payload = handler.response_json["session"]
+    assert session_payload["messages"] == expected_window
+    assert session_payload["message_count"] == len(full_all_messages)
+    assert session_payload["_messages_offset"] == expected_offset
+
+
+def test_msg_limit_session_load_bails_when_older_state_db_row_changes_offsets(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_reconcile_limited_tail_offset_bail"
+    sidecar_messages = [
+        {"role": "user", "content": f"sidecar {idx}", "timestamp": float(idx)}
+        for idx in range(500)
+    ]
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    _make_state_db(
+        tmp_path / "state.db",
+        sid,
+        sidecar_messages
+        + [
+            {
+                "role": "assistant",
+                "content": "state older than floor only",
+                "timestamp": 199.5,
+            },
+        ],
+    )
+
+    real_reader = routes.get_state_db_session_messages
+    full_state_messages = real_reader(sid)
+    full_all_messages = routes._limited_webui_messages_for_display(
+        session,
+        full_state_messages,
+    )
+    expected_window, expected_offset = routes._message_window_for_display(
+        full_all_messages,
+        msg_limit=30,
+    )
+    captured = {}
+
+    def wrapped_reader(*args, **kwargs):
+        captured["since_timestamp"] = kwargs.get("since_timestamp")
+        return real_reader(*args, **kwargs)
+
+    monkeypatch.setattr(routes, "get_state_db_session_messages", wrapped_reader)
+
+    handler = _GetHandler(
+        f"/api/session?session_id={sid}&messages=1&resolve_model=0&msg_limit=30"
+    )
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    assert captured["since_timestamp"] is None
+    session_payload = handler.response_json["session"]
+    assert session_payload["messages"] == expected_window
+    assert session_payload["message_count"] == len(full_all_messages)
+    assert session_payload["_messages_offset"] == expected_offset
+
+
+def test_msg_limit_session_load_bails_when_truncation_boundary_is_set(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_reconcile_limited_tail_boundary"
+    sidecar_messages = [
+        {"role": "user", "content": f"sidecar {idx}", "timestamp": float(idx)}
+        for idx in range(500)
+    ]
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    session.truncation_boundary = 250.0
+    session.save(touch_updated_at=False)
+    _make_state_db(tmp_path / "state.db", sid, sidecar_messages)
+
+    real_reader = routes.get_state_db_session_messages
+    captured = {}
+
+    def wrapped_reader(*args, **kwargs):
+        captured["since_timestamp"] = kwargs.get("since_timestamp")
+        return real_reader(*args, **kwargs)
+
+    monkeypatch.setattr(routes, "get_state_db_session_messages", wrapped_reader)
+
+    handler = _GetHandler(
+        f"/api/session?session_id={sid}&messages=1&resolve_model=0&msg_limit=30"
+    )
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    assert captured["since_timestamp"] is None
 
 
 def test_msg_before_session_load_keeps_full_state_db_reader(monkeypatch, tmp_path):

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -357,6 +357,24 @@ def test_state_db_reader_can_filter_by_timestamp_floor(monkeypatch, tmp_path):
     assert [m["content"] for m in messages] == ["kept", "also kept"]
 
 
+def test_limited_display_with_precomputed_sidecar_keeps_empty_state_db_guard(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_reconcile_empty_state_guard"
+    sidecar_messages = [
+        {"role": "user", "content": "sidecar only", "timestamp": 10.0},
+    ]
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+
+    messages = routes._limited_webui_messages_for_display_with_sidecar(
+        session,
+        list(sidecar_messages),
+        [],
+    )
+
+    assert messages == sidecar_messages
+
+
 def test_msg_limit_session_load_reads_only_recent_state_db_tail(monkeypatch, tmp_path):
     import api.routes as routes
 

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -666,6 +666,69 @@ def test_msg_limit_session_load_bails_when_prefloor_key_counts_mask_offset_chang
     assert len(full_all_messages) == len(sidecar_messages) + 1
 
 
+def test_msg_limit_session_load_bails_when_prefloor_tool_calls_mask_offset_change(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_reconcile_limited_tail_tool_calls_bail"
+    sidecar_tool_calls = [{"id": "call_sidecar", "function": {"name": "terminal", "arguments": "{}"}}]
+    state_tool_calls = [{"id": "call_state", "function": {"name": "terminal", "arguments": "{}"}}]
+    sidecar_messages = [
+        {"role": "user", "content": f"sidecar {idx}", "timestamp": float(idx)}
+        for idx in range(500)
+    ]
+    sidecar_messages[100] = {
+        "role": "assistant",
+        "content": "",
+        "timestamp": 100.0,
+        "tool_calls": sidecar_tool_calls,
+    }
+    state_messages = [
+        dict(msg, tool_calls=json.dumps(msg["tool_calls"]))
+        if msg.get("tool_calls")
+        else dict(msg)
+        for msg in sidecar_messages
+    ]
+    state_messages[100] = {
+        "role": "assistant",
+        "content": "",
+        "timestamp": 100.0,
+        "tool_calls": json.dumps(state_tool_calls),
+    }
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    _make_state_db(tmp_path / "state.db", sid, state_messages)
+
+    real_reader = routes.get_state_db_session_messages
+    full_state_messages = real_reader(sid)
+    full_all_messages = routes._limited_webui_messages_for_display(
+        session,
+        full_state_messages,
+    )
+    expected_window, expected_offset = routes._message_window_for_display(
+        full_all_messages,
+        msg_limit=30,
+    )
+    captured = {}
+
+    def wrapped_reader(*args, **kwargs):
+        captured["since_timestamp"] = kwargs.get("since_timestamp")
+        return real_reader(*args, **kwargs)
+
+    monkeypatch.setattr(routes, "get_state_db_session_messages", wrapped_reader)
+
+    handler = _GetHandler(
+        f"/api/session?session_id={sid}&messages=1&resolve_model=0&msg_limit=30"
+    )
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    assert captured["since_timestamp"] is None
+    session_payload = handler.response_json["session"]
+    assert session_payload["messages"] == expected_window
+    assert session_payload["message_count"] == len(full_all_messages)
+    assert session_payload["_messages_offset"] == expected_offset
+    assert len(full_all_messages) == len(sidecar_messages) + 1
+
+
 def test_msg_limit_session_load_bails_when_truncation_boundary_is_set(monkeypatch, tmp_path):
     import api.routes as routes
 

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -559,6 +559,113 @@ def test_msg_limit_session_load_bails_when_older_state_db_row_changes_offsets(mo
     assert session_payload["_messages_offset"] == expected_offset
 
 
+def test_msg_limit_session_load_bails_when_older_state_db_user_changes_offsets(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_reconcile_limited_tail_user_offset_bail"
+    sidecar_messages = [
+        {"role": "user", "content": f"sidecar {idx}", "timestamp": float(idx)}
+        for idx in range(500)
+    ]
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    _make_state_db(
+        tmp_path / "state.db",
+        sid,
+        sidecar_messages
+        + [
+            {
+                "role": "user",
+                "content": "state older user than floor only",
+                "timestamp": 199.5,
+            },
+        ],
+    )
+
+    real_reader = routes.get_state_db_session_messages
+    full_state_messages = real_reader(sid)
+    full_all_messages = routes._limited_webui_messages_for_display(
+        session,
+        full_state_messages,
+    )
+    expected_window, expected_offset = routes._message_window_for_display(
+        full_all_messages,
+        msg_limit=30,
+    )
+    captured = {}
+
+    def wrapped_reader(*args, **kwargs):
+        captured["since_timestamp"] = kwargs.get("since_timestamp")
+        return real_reader(*args, **kwargs)
+
+    monkeypatch.setattr(routes, "get_state_db_session_messages", wrapped_reader)
+
+    handler = _GetHandler(
+        f"/api/session?session_id={sid}&messages=1&resolve_model=0&msg_limit=30"
+    )
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    assert captured["since_timestamp"] is None
+    session_payload = handler.response_json["session"]
+    assert session_payload["messages"] == expected_window
+    assert session_payload["message_count"] == len(full_all_messages)
+    assert session_payload["_messages_offset"] == expected_offset
+
+
+def test_msg_limit_session_load_bails_when_prefloor_key_counts_mask_offset_change(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_reconcile_limited_tail_count_mask_bail"
+    sidecar_messages = [
+        {"role": "user", "content": f"sidecar {idx}", "timestamp": float(idx)}
+        for idx in range(500)
+    ]
+    state_messages = [
+        msg for msg in sidecar_messages if msg["content"] != "sidecar 100"
+    ]
+    state_messages.append(
+        {
+            "role": "user",
+            "content": "state masked older user than floor only",
+            "timestamp": 199.5,
+        }
+    )
+    state_messages.sort(key=lambda msg: msg["timestamp"])
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    _make_state_db(tmp_path / "state.db", sid, state_messages)
+
+    real_reader = routes.get_state_db_session_messages
+    full_state_messages = real_reader(sid)
+    full_all_messages = routes._limited_webui_messages_for_display(
+        session,
+        full_state_messages,
+    )
+    expected_window, expected_offset = routes._message_window_for_display(
+        full_all_messages,
+        msg_limit=30,
+    )
+    captured = {}
+
+    def wrapped_reader(*args, **kwargs):
+        captured["since_timestamp"] = kwargs.get("since_timestamp")
+        return real_reader(*args, **kwargs)
+
+    monkeypatch.setattr(routes, "get_state_db_session_messages", wrapped_reader)
+
+    handler = _GetHandler(
+        f"/api/session?session_id={sid}&messages=1&resolve_model=0&msg_limit=30"
+    )
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    assert captured["since_timestamp"] is None
+    session_payload = handler.response_json["session"]
+    assert session_payload["messages"] == expected_window
+    assert session_payload["message_count"] == len(full_all_messages)
+    assert session_payload["_messages_offset"] == expected_offset
+    assert len(full_all_messages) == len(sidecar_messages) + 1
+
+
 def test_msg_limit_session_load_bails_when_truncation_boundary_is_set(monkeypatch, tmp_path):
     import api.routes as routes
 


### PR DESCRIPTION
## Release YE (v0.51.675) — long conversations open fast (bounded state.db tail reads)

Ships **#4920** (@franksong2702, T1) — fixes #4918 Problem-1 (the "opening a long conversation shows Loading 1-2s" regression).

### What it fixes
`/api/session` read the entire `state.db` history before trimming to the visible window (~1.75s cold on an 844-msg session). Now pushes `msg_limit` into SQL via a `since_timestamp` floor from the sidecar tail (reads only the tail window).

### Gate (converged after 5 rounds — each surfacing a subtler byte-identity edge)
The optimization is taken ONLY when provably output-identical to the full read. Across 5 gate rounds the prefix-parity guard was hardened: NULL-timestamp superset → single-anomaly bail → (role,content) multiset masking → and finally the **full merge identity** (`role`, `content`, parsed `tool_calls` via `_session_message_visible_key`), bailing to full read whenever the sidecar/state prefixes can't be proven equal or the schema lacks columns.
- **Codex: SAFE TO SHIP** + **Opus: SHIP IT** — the tool_calls-identity divergence is closed with the merge-identical key; symmetry/perf preserved (genuinely-equal rows still match → perf win retained); prior NULL/single-anomaly/role-content fixes hold; schema-degrade bails safely; full-read callers unaffected.
- **Full suite: 10672 passed**, 0 failures. +392 lines of byte-identity reconciliation tests incl the tool_calls-masking bail.
- Pre-merge head re-check: gated == live (425dfc04).

Credit @franksong2702 — persistent work through 5 reconciliation rounds on the crown-jewel transcript-load path.
