### PR TITLE
Release YF (v0.51.676): scope pending user-turn dedupe to current tail (#4826, fixes #4825)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,7 +234,6 @@
 ### Fixed
 
 - **Internal "continue where you left off" prompts no longer leak into the visible transcript when a response is truncated by the output-length cap or a too-large tool call.** When the agent's response is cut short it emits a `[System: …]` continuation prompt, which the WebUI hides from the chat. The filter only matched the network-error variant (it required the literal "cut off by a network error" phrase), so the output-length and tool-call-too-large variants rendered as stray system bubbles. The filter now matches any `[System: …]` prompt carrying either "continue exactly where you left off" or "do not retry the same tool call", covering all three variants while still leaving genuine non-`[System:]` messages alone. Thanks @rodboev. (#4880, closes #4875)
-
 ## [v0.51.636] — 2026-06-25 — Release WQ (Android Chromium no longer jumps the transcript to the top)
 
 ### Fixed
@@ -312,7 +311,6 @@
 ### Fixed
 
 - **Kanban columns with many cards no longer grow unbounded and stretch the board.** The column card list is now capped at `min(68vh, 720px)` and scrolls internally (contained overscroll + stable scrollbar gutter), so a busy column stays a fixed height instead of pushing the whole Tasks board layout. Thanks @jkobject. (#4832)
-
 ## [v0.51.623] — 2026-06-24 — Release WD (iOS portrait: opening a conversation lands at the bottom)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.676] — 2026-06-26 — Release YF (submitted message no longer renders twice — or vanishes — on active reload)
+
+### Fixed
+
+- **On an active-session reload/reconnect, the submitted user turn no longer renders twice (and a distinct repeated prompt no longer vanishes).** The browser can see the current turn through several recovery sources (optimistic/in-flight, `pending_user_message`, replay/checkpoint), and the de-duplication had to balance two failure modes. Pending/in-flight user-turn dedupe is now scoped to the **current-turn tail** only (stopping at the most recent non-live assistant), so: a genuine double-render of the *same* current turn is still collapsed to one, while a *new* turn whose text matches an *earlier* historical message (e.g. sending the same prompt twice, including under the default deferred save mode where only `pending_user_message` exists) is correctly preserved instead of being suppressed. Display-only wrappers (workspace/attachment/forced-skill envelopes) are normalized for the comparison; pending attachments reattach only on a genuine same-turn match. Thanks @franksong2702. (#4826, fixes #4825)
+
 ## [v0.51.675] — 2026-06-26 — Release YE (long conversations open fast — bounded state.db tail reads)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,7 @@
 ### Fixed
 
 - **Internal "continue where you left off" prompts no longer leak into the visible transcript when a response is truncated by the output-length cap or a too-large tool call.** When the agent's response is cut short it emits a `[System: …]` continuation prompt, which the WebUI hides from the chat. The filter only matched the network-error variant (it required the literal "cut off by a network error" phrase), so the output-length and tool-call-too-large variants rendered as stray system bubbles. The filter now matches any `[System: …]` prompt carrying either "continue exactly where you left off" or "do not retry the same tool call", covering all three variants while still leaving genuine non-`[System:]` messages alone. Thanks @rodboev. (#4880, closes #4875)
+
 ## [v0.51.636] — 2026-06-25 — Release WQ (Android Chromium no longer jumps the transcript to the top)
 
 ### Fixed
@@ -311,6 +312,7 @@
 ### Fixed
 
 - **Kanban columns with many cards no longer grow unbounded and stretch the board.** The column card list is now capped at `min(68vh, 720px)` and scrolls internally (contained overscroll + stable scrollbar gutter), so a busy column stays a fixed height instead of pushing the whole Tasks board layout. Thanks @jkobject. (#4832)
+
 ## [v0.51.623] — 2026-06-24 — Release WD (iOS portrait: opening a conversation lands at the bottom)
 
 ### Fixed

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2339,7 +2339,11 @@ function _stripForcedSkillEnvelope(text){
 }
 
 function _normalizeUserTranscriptText(text){
-  let value=_stripAttachedFilesMarker(_stripForcedSkillEnvelope(text));
+  const value=_stripAttachedFilesMarker(_stripForcedSkillEnvelope(text));
+  // ui.js is loaded before sessions.js in index.html and owns the canonical
+  // workspace-sentinel parser used by rendering.  Keep a small fallback for
+  // static/helper tests and defensive partial loads, but prefer the renderer's
+  // parser whenever it is available.
   if(typeof _stripWorkspaceDisplayPrefix==='function'){
     return _stripWorkspaceDisplayPrefix(value);
   }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -581,7 +581,9 @@ function _inflightHasVisibleLiveState(inflight) {
   if (Array.isArray(inflight.activityBurstAnchors) && inflight.activityBurstAnchors.length) return true;
   if (Array.isArray(inflight.messages)) {
     return inflight.messages.some((msg) => {
-      if (!msg || msg.role !== 'assistant') return false;
+      if (!msg) return false;
+      if (msg.role === 'user') return Boolean(_messageComparableText(msg));
+      if (msg.role !== 'assistant') return false;
       const content = msg.content;
       if (typeof content === 'string') return content.trim();
       if (Array.isArray(content)) return content.length > 0;
@@ -2325,6 +2327,28 @@ function _stripAttachedFilesMarker(text){
   return String(text||'').replace(/\n\n\[Attached files: [^\]]+\]$/,'').trim();
 }
 
+function _stripForcedSkillEnvelope(text){
+  let value=String(text||'').trim();
+  // `/use <skill>` augments the model-facing prompt with a directive and a
+  // hidden skill-content envelope, while the optimistic UI row keeps the human
+  // prompt.  Treat them as the same submitted turn for active reload/reconnect
+  // dedupe without rewriting the persisted pending prompt.
+  value=value.replace(/^\[USER OVERRIDE\][^\n]*\n*/,'').trim();
+  value=value.replace(/\[FORCED SKILL CONTEXT:[^\]]+\][\s\S]*?\[\/FORCED SKILL CONTEXT\]\s*/g,'').trim();
+  return value;
+}
+
+function _normalizeUserTranscriptText(text){
+  let value=_stripAttachedFilesMarker(_stripForcedSkillEnvelope(text));
+  if(typeof _stripWorkspaceDisplayPrefix==='function'){
+    return _stripWorkspaceDisplayPrefix(value);
+  }
+  const raw=String(value||'');
+  const strippedV1=raw.replace(/^\s*\[Workspace::v1:\s*(?:\\.|[^\]\\])+\]\s*/,'');
+  if(strippedV1!==raw) return strippedV1.trim();
+  return raw.replace(/^\s*\[Workspace:[^\]]+\]\s*/,'').trim();
+}
+
 function _sameTranscriptMessage(a,b){
   if(!(a&&b)) return false;
   const role=String(a.role||'');
@@ -2333,7 +2357,7 @@ function _sameTranscriptMessage(a,b){
   const bText=_messageComparableText(b);
   if(aText===bText) return true;
   if(role==='user'){
-    return _stripAttachedFilesMarker(aText)===_stripAttachedFilesMarker(bText);
+    return _normalizeUserTranscriptText(aText)===_normalizeUserTranscriptText(bText);
   }
   return false;
 }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1348,8 +1348,9 @@ async function loadSession(sid){
     if(!Array.isArray(messages)) return false;
     const pendingMsg=typeof getPendingSessionMessage==='function'?getPendingSessionMessage(session,messages):null;
     if(!pendingMsg) return false;
-    if(messages.some(existing=>_sameTranscriptMessage(existing,pendingMsg))) return false;
     const liveAssistantIdx=messages.findIndex(m=>m&&m.role==='assistant'&&m._live);
+    const currentTurnMessages=liveAssistantIdx>=0?messages.slice(0,liveAssistantIdx):messages;
+    if(_hasCurrentTailUserDuplicate(currentTurnMessages,pendingMsg)) return false;
     if(liveAssistantIdx>=0) messages.splice(liveAssistantIdx,0,pendingMsg);
     else messages.push(pendingMsg);
     return true;
@@ -2366,6 +2367,24 @@ function _sameTranscriptMessage(a,b){
   return false;
 }
 
+function _currentTailUserMessage(messages){
+  const list=Array.isArray(messages)?messages:[];
+  for(let i=list.length-1;i>=0;i--){
+    const msg=list[i];
+    if(!msg) continue;
+    if(String(msg.role||'')==='user') return msg;
+    if(msg._live||String(msg.role||'')==='tool') continue;
+    return null;
+  }
+  return null;
+}
+
+function _hasCurrentTailUserDuplicate(messages,candidate){
+  if(!candidate||String(candidate.role||'')!=='user') return false;
+  const existing=_currentTailUserMessage(messages);
+  return !!(existing&&_sameTranscriptMessage(existing,candidate));
+}
+
 function _currentTurnAssistantText(messages){
   const list=Array.isArray(messages)?messages:[];
   let start=-1;
@@ -2658,7 +2677,9 @@ function _mergeInflightTailMessages(baseMessages, inflightMessages){
   for(const msg of tail){
     let candidate=msg;
     if(!candidate) continue;
-    const duplicate=merged.slice(-Math.max(5,tail.length+2)).some(existing=>_sameTranscriptMessage(existing,candidate));
+    const duplicate=String(candidate.role||'')==='user'
+      ? _hasCurrentTailUserDuplicate(merged,candidate)
+      : merged.slice(-Math.max(5,tail.length+2)).some(existing=>_sameTranscriptMessage(existing,candidate));
     if(!duplicate) merged.push(candidate);
   }
   return merged;

--- a/static/ui.js
+++ b/static/ui.js
@@ -7754,17 +7754,32 @@ async function _waitForServerThenReload(opts){
   if(msgEl) msgEl.textContent='⚠️ Server is taking longer than expected — click Reload when ready';
 }
 
+function _pendingCurrentTailUserMessage(messages){
+  const list=Array.isArray(messages)?messages:[];
+  for(let i=list.length-1;i>=0;i--){
+    const msg=list[i];
+    if(!msg) continue;
+    if(String(msg.role||'')==='user') return msg;
+    if(msg._live||String(msg.role||'')==='tool') continue;
+    return null;
+  }
+  return null;
+}
+
 function getPendingSessionMessage(session, messagesOverride=null){
   const text=String(session?.pending_user_message||'').trim();
   if(!text) return null;
   const attachments=Array.isArray(session?.pending_attachments)?session.pending_attachments.filter(Boolean):[];
   const sourceMessages=Array.isArray(messagesOverride)?messagesOverride:session?.messages;
   const messages=Array.isArray(sourceMessages)?sourceMessages:[];
-  const lastUser=[...messages].reverse().find(m=>m&&m.role==='user');
-  if(lastUser){
-    const lastText=String(msgContent(lastUser)||'').trim();
-    if(lastText===text){
-      if(attachments.length&&!lastUser.attachments?.length) lastUser.attachments=attachments;
+  const currentTailUser=_pendingCurrentTailUserMessage(messages);
+  if(currentTailUser){
+    const pendingCandidate={role:'user',content:text};
+    const sameCurrentTurn=typeof _sameTranscriptMessage==='function'
+      ? _sameTranscriptMessage(currentTailUser,pendingCandidate)
+      : String(msgContent(currentTailUser)||'').trim()===text;
+    if(sameCurrentTurn){
+      if(attachments.length&&!currentTailUser.attachments?.length) currentTailUser.attachments=attachments;
       return null;
     }
   }

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -951,8 +951,10 @@ def test_merge_inflight_tail_preserves_all_segmented_live_progress():
     groups whose burst ids point to those anchors pile up at the bottom.
     """
     assert NODE, "node not on PATH"
+    helper_start = SESSIONS_JS.index("function _currentTailUserMessage")
     fn_start = SESSIONS_JS.index("function _mergeInflightTailMessages")
     fn_end = SESSIONS_JS.index("// Load older messages", fn_start)
+    tail_user_helpers = SESSIONS_JS[helper_start:fn_start]
     merge_fn = SESSIONS_JS[fn_start:fn_end]
     script = f"""
 const assert = require('assert');
@@ -960,6 +962,7 @@ function _messageComparableText(m) {{ return String((m&&m.content)||'').trim(); 
 function _sameTranscriptMessage(a,b) {{
   return !!(a&&b&&a.role===b.role&&_messageComparableText(a)===_messageComparableText(b));
 }}
+{tail_user_helpers}
 {merge_fn}
 const base = [{{role:'user', content:'go'}}];
 const inflight = [

--- a/tests/test_issue2341_pending_user_reattach.py
+++ b/tests/test_issue2341_pending_user_reattach.py
@@ -64,7 +64,14 @@ def test_pending_user_message_dedup_checks_current_message_array():
         "Pending-message dedup must inspect the current S.messages/INFLIGHT "
         "array, not only session.messages from the metadata response"
     )
-    assert "lastText===text" in helper, (
-        "Pending-message merge must suppress duplicates when the last user row "
-        "already matches pending_user_message"
+    assert "_pendingCurrentTailUserMessage(messages)" in helper, (
+        "Pending-message dedup must inspect only the current tail user row, "
+        "not a historical same-text row"
+    )
+    assert "sameCurrentTurn" in helper and "return null;" in helper, (
+        "Pending-message merge must still suppress duplicates when the current "
+        "tail user row already matches pending_user_message"
+    )
+    assert "[...messages].reverse().find" not in helper, (
+        "Pending-message dedup must not reverse-scan historical user rows"
     )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -812,10 +812,13 @@ def test_inflight_merge_dedupes_uploaded_user_message(cleanup_test_sessions):
     merge must treat those as the same user turn instead of rendering both.
     """
     src = (REPO_ROOT / "static/sessions.js").read_text()
-    assert "function _stripAttachedFilesMarker" in src, (
-        "sessions.js must normalize the server-side attached-files suffix before deduping user turns"
+    assert "function _normalizeUserTranscriptText" in src, (
+        "sessions.js should normalize user transcript text before deduping user turns"
     )
-    assert "_stripAttachedFilesMarker(aText)===_stripAttachedFilesMarker(bText)" in src, (
+    assert "_stripAttachedFilesMarker(_stripForcedSkillEnvelope(text))" in src, (
+        "user transcript normalization should still remove the server-side attached-files suffix"
+    )
+    assert "_normalizeUserTranscriptText(aText)===_normalizeUserTranscriptText(bText)" in src, (
         "INFLIGHT user-message comparison should dedupe optimistic upload text against final pending text"
     )
     assert "role==='user'" in src, (

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -827,8 +827,11 @@ def test_inflight_merge_dedupes_uploaded_user_message(cleanup_test_sessions):
     pending_idx = src.find("function _mergePendingSessionMessage")
     assert pending_idx >= 0, "pending session merge helper not found"
     pending_block = src[pending_idx:pending_idx+500]
-    assert "_sameTranscriptMessage(existing,pendingMsg)" in pending_block, (
-        "pending-user merge should reuse transcript identity dedupe before inserting the server pending message"
+    assert "_hasCurrentTailUserDuplicate(currentTurnMessages,pendingMsg)" in pending_block, (
+        "pending-user merge should dedupe only against the current active-turn user row"
+    )
+    assert "messages.some(" not in pending_block, (
+        "pending-user merge must not scan historical user rows by normalized content"
     )
 
 

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -1,9 +1,12 @@
+import json
+import subprocess
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 MESSAGES_SRC = (ROOT / "static" / "messages.js").read_text()
 SESSIONS_SRC = (ROOT / "static" / "sessions.js").read_text()
+UI_SRC = (ROOT / "static" / "ui.js").read_text()
 
 
 def _function_body(src: str, signature: str) -> str:
@@ -19,6 +22,53 @@ def _function_body(src: str, signature: str) -> str:
             if depth == 0:
                 return src[start : idx + 1]
     raise AssertionError(f"could not extract function body for {signature!r}")
+
+
+def _run_session_identity_probe() -> dict:
+    prompt = "same submitted prompt\nwith a second line"
+    workspace_prompt = f"[Workspace::v1: /tmp/hermes-webui]\n{prompt}"
+    legacy_workspace_prompt = f"[Workspace: /tmp/hermes-webui]\n{prompt}"
+    attached_prompt = f"{prompt}\n\n[Attached files: /tmp/a.txt]"
+    forced_prompt = (
+        "[USER OVERRIDE] You MUST follow the skill 'hermes-webui-coordinator' "
+        "content provided below before responding to the next message.\n\n"
+        "[FORCED SKILL CONTEXT: hermes-webui-coordinator]\n"
+        "skill body that should not make a second user bubble\n"
+        "[/FORCED SKILL CONTEXT]\n\n"
+        f"{prompt}"
+    )
+    helpers = "\n".join(
+        [
+            _function_body(UI_SRC, "function _stripWorkspaceDisplayPrefix"),
+            _function_body(SESSIONS_SRC, "function _messageComparableText"),
+            _function_body(SESSIONS_SRC, "function _stripAttachedFilesMarker"),
+            _function_body(SESSIONS_SRC, "function _stripForcedSkillEnvelope"),
+            _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText"),
+            _function_body(SESSIONS_SRC, "function _sameTranscriptMessage"),
+            _function_body(SESSIONS_SRC, "function _inflightHasVisibleLiveState"),
+        ]
+    )
+    script = f"""
+{helpers}
+const plain = {{role:'user', content:{json.dumps(prompt)}}};
+const workspace = {{role:'user', content:{json.dumps(workspace_prompt)}}};
+const legacyWorkspace = {{role:'user', content:{json.dumps(legacy_workspace_prompt)}}};
+const attached = {{role:'user', content:{json.dumps(attached_prompt)}}};
+const forced = {{role:'user', content:{json.dumps(forced_prompt)}}};
+const different = {{role:'user', content:'a different submitted prompt'}};
+process.stdout.write(JSON.stringify({{
+  workspaceDedupe: _sameTranscriptMessage(plain, workspace),
+  legacyWorkspaceDedupe: _sameTranscriptMessage(plain, legacyWorkspace),
+  attachedDedupe: _sameTranscriptMessage(plain, attached),
+  forcedSkillDedupe: _sameTranscriptMessage(plain, forced),
+  differentUserNotDedupe: !_sameTranscriptMessage(plain, different),
+  roleMismatchNotDedupe: !_sameTranscriptMessage(plain, {{role:'assistant', content:{json.dumps(prompt)}}}),
+  userOnlyInflightVisible: _inflightHasVisibleLiveState({{messages:[plain]}}),
+  emptyUserOnlyInflightNotVisible: !_inflightHasVisibleLiveState({{messages:[{{role:'user', content:'   '}}]}}),
+}}));
+"""
+    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    return json.loads(proc.stdout)
 
 
 def test_reattach_path_uses_replay_when_status_reports_journal():
@@ -150,31 +200,26 @@ def test_active_reload_keeps_user_only_inflight_visible_until_pending_dedupe():
     The browser must not discard the user-only optimistic INFLIGHT entry as a
     cursor-only snapshot before pending/live replay reconciliation runs.
     """
-    helper = _function_body(SESSIONS_SRC, "function _inflightHasVisibleLiveState")
+    result = _run_session_identity_probe()
 
-    assert "msg.role === 'user'" in helper or "msg.role==='user'" in helper
-    assert "_messageComparableText(msg)" in helper or "msg.content" in helper
+    assert result["userOnlyInflightVisible"] is True
+    assert result["emptyUserOnlyInflightNotVisible"] is True
 
 
-def test_pending_user_merge_dedupes_workspace_prefixed_replay_rows():
+def test_pending_user_merge_dedupes_user_turn_variants_by_behavior():
     """Pending user rows and replayed/checkpointed user rows share one turn.
 
-    The model-facing current user message may carry the WebUI workspace sentinel,
-    while pending_user_message stores only the human prompt.  Frontend transcript
-    equality must normalize the same way the renderer and backend context
-    identity do, otherwise active reload/reconnect can show two user bubbles for
-    one submitted turn.
+    Execute the same JavaScript helpers the browser uses so the regression test
+    catches regex/order/trim mistakes, not just identifier wiring.
     """
-    same = _function_body(SESSIONS_SRC, "function _sameTranscriptMessage")
-    normalizer = _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText")
-    forced = _function_body(SESSIONS_SRC, "function _stripForcedSkillEnvelope")
+    result = _run_session_identity_probe()
 
-    assert "_normalizeUserTranscriptText" in same
-    assert "_stripWorkspaceDisplayPrefix" in normalizer
-    assert "_stripAttachedFilesMarker" in normalizer
-    assert "Workspace::v1" in normalizer
-    assert "FORCED SKILL CONTEXT" in forced
-    assert "USER OVERRIDE" in forced
+    assert result["workspaceDedupe"] is True
+    assert result["legacyWorkspaceDedupe"] is True
+    assert result["attachedDedupe"] is True
+    assert result["forcedSkillDedupe"] is True
+    assert result["differentUserNotDedupe"] is True
+    assert result["roleMismatchNotDedupe"] is True
 
 
 def test_live_tool_matching_uses_the_same_aliases_as_live_card_dedup():

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -6,6 +6,21 @@ MESSAGES_SRC = (ROOT / "static" / "messages.js").read_text()
 SESSIONS_SRC = (ROOT / "static" / "sessions.js").read_text()
 
 
+def _function_body(src: str, signature: str) -> str:
+    start = src.index(signature)
+    brace = src.index("{", start)
+    depth = 0
+    for idx in range(brace, len(src)):
+        char = src[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : idx + 1]
+    raise AssertionError(f"could not extract function body for {signature!r}")
+
+
 def test_reattach_path_uses_replay_when_status_reports_journal():
     reattach_pos = MESSAGES_SRC.index("let replayOnly=false;")
     block = MESSAGES_SRC[reattach_pos : reattach_pos + 1200]
@@ -125,6 +140,41 @@ def test_server_runtime_journal_snapshot_restores_structured_inflight_state():
     assert "activity_burst_anchors" in helper_block
     for key in ("tid", "id", "tool_call_id", "tool_use_id", "call_id"):
         assert key in helper_block
+
+
+def test_active_reload_keeps_user_only_inflight_visible_until_pending_dedupe():
+    """A just-submitted user row is visible live state before first assistant text.
+
+    On an active first-turn reload, the sidecar can still have messages=[] while
+    pending_user_message and the submitted turn journal record the same prompt.
+    The browser must not discard the user-only optimistic INFLIGHT entry as a
+    cursor-only snapshot before pending/live replay reconciliation runs.
+    """
+    helper = _function_body(SESSIONS_SRC, "function _inflightHasVisibleLiveState")
+
+    assert "msg.role === 'user'" in helper or "msg.role==='user'" in helper
+    assert "_messageComparableText(msg)" in helper or "msg.content" in helper
+
+
+def test_pending_user_merge_dedupes_workspace_prefixed_replay_rows():
+    """Pending user rows and replayed/checkpointed user rows share one turn.
+
+    The model-facing current user message may carry the WebUI workspace sentinel,
+    while pending_user_message stores only the human prompt.  Frontend transcript
+    equality must normalize the same way the renderer and backend context
+    identity do, otherwise active reload/reconnect can show two user bubbles for
+    one submitted turn.
+    """
+    same = _function_body(SESSIONS_SRC, "function _sameTranscriptMessage")
+    normalizer = _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText")
+    forced = _function_body(SESSIONS_SRC, "function _stripForcedSkillEnvelope")
+
+    assert "_normalizeUserTranscriptText" in same
+    assert "_stripWorkspaceDisplayPrefix" in normalizer
+    assert "_stripAttachedFilesMarker" in normalizer
+    assert "Workspace::v1" in normalizer
+    assert "FORCED SKILL CONTEXT" in forced
+    assert "USER OVERRIDE" in forced
 
 
 def test_live_tool_matching_uses_the_same_aliases_as_live_card_dedup():

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -143,6 +143,74 @@ process.stdout.write(JSON.stringify({{
     return json.loads(proc.stdout)
 
 
+def _run_pending_session_message_probe() -> dict:
+    prompt = "repeat me"
+    historical_workspace_prompt = f"[Workspace::v1: /tmp/old]\n{prompt}"
+    current_workspace_prompt = f"[Workspace::v1: /tmp/current]\n{prompt}"
+    helpers = "\n".join(
+        [
+            _function_body(UI_SRC, "function _stripWorkspaceDisplayPrefix"),
+            _function_body(UI_SRC, "function msgContent"),
+            _function_body(SESSIONS_SRC, "function _messageComparableText"),
+            _function_body(SESSIONS_SRC, "function _stripAttachedFilesMarker"),
+            _function_body(SESSIONS_SRC, "function _stripForcedSkillEnvelope"),
+            _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText"),
+            _function_body(SESSIONS_SRC, "function _sameTranscriptMessage"),
+            _function_body(UI_SRC, "function _pendingCurrentTailUserMessage"),
+            _function_body(UI_SRC, "function getPendingSessionMessage"),
+        ]
+    )
+    script = f"""
+{helpers}
+const prompt = {json.dumps(prompt)};
+const historical = {{role:'user', content:prompt, _ts:1}};
+const historicalWorkspace = {{role:'user', content:{json.dumps(historical_workspace_prompt)}, _ts:1}};
+const historicalAnswer = {{role:'assistant', content:'done', _ts:2}};
+const currentTail = {{role:'user', content:prompt, _ts:3}};
+const currentWorkspaceTail = {{role:'user', content:{json.dumps(current_workspace_prompt)}, _ts:3}};
+const liveAssistant = {{role:'assistant', content:'working', _live:true, _ts:4}};
+const attachments = [{{name:'note.txt', path:'note.txt', mime:'text/plain'}}];
+
+const fromHistoricalSameText = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:3}},
+  [historical, historicalAnswer]
+);
+const fromHistoricalWorkspace = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:3}},
+  [historicalWorkspace, historicalAnswer]
+);
+const exactCurrentMessages = [historical, historicalAnswer, currentTail];
+const exactCurrentResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:4, pending_attachments:attachments}},
+  exactCurrentMessages
+);
+const workspaceCurrentResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:4}},
+  [historical, historicalAnswer, currentWorkspaceTail]
+);
+const liveAfterCurrentResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:4}},
+  [historical, historicalAnswer, currentWorkspaceTail, liveAssistant]
+);
+const differentTailResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:4}},
+  [historical, historicalAnswer, {{role:'user', content:'different prompt', _ts:3}}]
+);
+
+process.stdout.write(JSON.stringify({{
+  historicalSameTextSurvives: !!fromHistoricalSameText && fromHistoricalSameText.content===prompt && fromHistoricalSameText._pending===true,
+  historicalWorkspaceSurvives: !!fromHistoricalWorkspace && fromHistoricalWorkspace.content===prompt && fromHistoricalWorkspace._pending===true,
+  exactCurrentTailDedupe: exactCurrentResult===null,
+  exactCurrentTailAttachmentsCopied: Array.isArray(currentTail.attachments) && currentTail.attachments[0].name==='note.txt',
+  workspaceCurrentTailDedupe: workspaceCurrentResult===null,
+  liveAfterCurrentTailDedupe: liveAfterCurrentResult===null,
+  differentCurrentTailSurvives: !!differentTailResult && differentTailResult.content===prompt && differentTailResult._pending===true,
+}}));
+"""
+    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    return json.loads(proc.stdout)
+
+
 def test_reattach_path_uses_replay_when_status_reports_journal():
     reattach_pos = MESSAGES_SRC.index("let replayOnly=false;")
     block = MESSAGES_SRC[reattach_pos : reattach_pos + 1200]
@@ -307,6 +375,26 @@ def test_user_turn_dedupe_is_scoped_to_current_turn_by_behavior():
 
     assert result["inflightAfterHistoryRoles"] == ["user", "assistant", "user", "assistant"]
     assert result["inflightWithCurrentRoles"] == ["user", "assistant", "user", "assistant"]
+
+
+def test_get_pending_session_message_keeps_deferred_repeat_prompt_by_behavior():
+    """Deferred active reload must not hide a current repeat prompt.
+
+    In the default deferred save mode, chat start persists only
+    pending_user_message before the worker appends the display row.  If an older
+    turn has the same visible user text, getPendingSessionMessage still has to
+    return the current pending row; downstream merge code then dedupes only
+    against the current tail.
+    """
+    result = _run_pending_session_message_probe()
+
+    assert result["historicalSameTextSurvives"] is True
+    assert result["historicalWorkspaceSurvives"] is True
+    assert result["exactCurrentTailDedupe"] is True
+    assert result["exactCurrentTailAttachmentsCopied"] is True
+    assert result["workspaceCurrentTailDedupe"] is True
+    assert result["liveAfterCurrentTailDedupe"] is True
+    assert result["differentCurrentTailSurvives"] is True
 
 
 def test_live_tool_matching_uses_the_same_aliases_as_live_card_dedup():

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -45,6 +45,8 @@ def _run_session_identity_probe() -> dict:
             _function_body(SESSIONS_SRC, "function _stripForcedSkillEnvelope"),
             _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText"),
             _function_body(SESSIONS_SRC, "function _sameTranscriptMessage"),
+            _function_body(SESSIONS_SRC, "function _currentTailUserMessage"),
+            _function_body(SESSIONS_SRC, "function _hasCurrentTailUserDuplicate"),
             _function_body(SESSIONS_SRC, "function _inflightHasVisibleLiveState"),
         ]
     )
@@ -65,6 +67,76 @@ process.stdout.write(JSON.stringify({{
   roleMismatchNotDedupe: !_sameTranscriptMessage(plain, {{role:'assistant', content:{json.dumps(prompt)}}}),
   userOnlyInflightVisible: _inflightHasVisibleLiveState({{messages:[plain]}}),
   emptyUserOnlyInflightNotVisible: !_inflightHasVisibleLiveState({{messages:[{{role:'user', content:'   '}}]}}),
+}}));
+"""
+    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    return json.loads(proc.stdout)
+
+
+def _run_current_turn_scope_probe() -> dict:
+    prompt = "repeat me"
+    historical_workspace_prompt = f"[Workspace::v1: /tmp/old]\n{prompt}"
+    current_workspace_prompt = f"[Workspace::v1: /tmp/current]\n{prompt}"
+    helpers = "\n".join(
+        [
+            _function_body(UI_SRC, "function _stripWorkspaceDisplayPrefix"),
+            _function_body(SESSIONS_SRC, "function _messageComparableText"),
+            _function_body(SESSIONS_SRC, "function _stripAttachedFilesMarker"),
+            _function_body(SESSIONS_SRC, "function _stripForcedSkillEnvelope"),
+            _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText"),
+            _function_body(SESSIONS_SRC, "function _sameTranscriptMessage"),
+            _function_body(SESSIONS_SRC, "function _currentTailUserMessage"),
+            _function_body(SESSIONS_SRC, "function _hasCurrentTailUserDuplicate"),
+            _function_body(SESSIONS_SRC, "function _mergePendingSessionMessage"),
+            _function_body(SESSIONS_SRC, "function _mergeInflightTailMessages"),
+        ]
+    )
+    script = f"""
+{helpers}
+function getPendingSessionMessage(session, messages){{
+  const text=String(session&&session.pending_user_message||'').trim();
+  if(!text) return null;
+  return {{
+    role:'user',
+    content:text,
+    _ts:session.pending_started_at||10,
+    _pending:true,
+  }};
+}}
+const historical = {{role:'user', content:{json.dumps(historical_workspace_prompt)}, _ts:1}};
+const historicalAnswer = {{role:'assistant', content:'done', _ts:2}};
+const liveAssistant = {{role:'assistant', content:'working', _live:true, _ts:4}};
+const pendingSession = {{pending_user_message:{json.dumps(prompt)}, pending_started_at:3}};
+
+const pendingAfterHistory = [historical, historicalAnswer];
+const insertedAfterHistory = _mergePendingSessionMessage(pendingSession, pendingAfterHistory);
+
+const pendingBeforeLive = [historical, historicalAnswer, liveAssistant];
+const insertedBeforeLive = _mergePendingSessionMessage(pendingSession, pendingBeforeLive);
+
+const optimisticCurrent = {{role:'user', content:{json.dumps(current_workspace_prompt)}, _ts:3}};
+const pendingWithCurrent = [historical, historicalAnswer, optimisticCurrent, liveAssistant];
+const insertedWithCurrent = _mergePendingSessionMessage(pendingSession, pendingWithCurrent);
+
+const inflightAfterHistory = _mergeInflightTailMessages(
+  [historical, historicalAnswer],
+  [{{role:'user', content:{json.dumps(prompt)}, _ts:3}}, liveAssistant]
+);
+
+const inflightWithCurrent = _mergeInflightTailMessages(
+  [historical, historicalAnswer, optimisticCurrent],
+  [{{role:'user', content:{json.dumps(prompt)}, _ts:3}}, liveAssistant]
+);
+
+process.stdout.write(JSON.stringify({{
+  insertedAfterHistory,
+  pendingAfterHistoryRoles: pendingAfterHistory.map(m=>m.role),
+  insertedBeforeLive,
+  pendingBeforeLiveRoles: pendingBeforeLive.map(m=>m.role),
+  insertedWithCurrent,
+  pendingWithCurrentRoles: pendingWithCurrent.map(m=>m.role),
+  inflightAfterHistoryRoles: inflightAfterHistory.map(m=>m.role),
+  inflightWithCurrentRoles: inflightWithCurrent.map(m=>m.role),
 }}));
 """
     proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
@@ -220,6 +292,21 @@ def test_pending_user_merge_dedupes_user_turn_variants_by_behavior():
     assert result["forcedSkillDedupe"] is True
     assert result["differentUserNotDedupe"] is True
     assert result["roleMismatchNotDedupe"] is True
+
+
+def test_user_turn_dedupe_is_scoped_to_current_turn_by_behavior():
+    result = _run_current_turn_scope_probe()
+
+    assert result["insertedAfterHistory"] is True
+    assert result["pendingAfterHistoryRoles"] == ["user", "assistant", "user"]
+    assert result["insertedBeforeLive"] is True
+    assert result["pendingBeforeLiveRoles"] == ["user", "assistant", "user", "assistant"]
+
+    assert result["insertedWithCurrent"] is False
+    assert result["pendingWithCurrentRoles"] == ["user", "assistant", "user", "assistant"]
+
+    assert result["inflightAfterHistoryRoles"] == ["user", "assistant", "user", "assistant"]
+    assert result["inflightWithCurrentRoles"] == ["user", "assistant", "user", "assistant"]
 
 
 def test_live_tool_matching_uses_the_same_aliases_as_live_card_dedup():

--- a/tests/test_session_save_mode.py
+++ b/tests/test_session_save_mode.py
@@ -119,32 +119,34 @@ def test_eager_checkpointed_user_is_removed_from_model_context():
     assert [m["content"] for m in context] == ["older", "prior"]
 
 
-def test_submitted_turn_journal_does_not_duplicate_current_model_context(tmp_path):
-    from api.turn_journal import append_turn_journal_event
+def test_active_pending_current_user_is_removed_from_model_context():
+    """Current pending user text must not appear in conversation_history twice.
 
+    The provider receives the active turn as `user_message`; if an eager
+    checkpoint/recovery path has already put the same current user text at the
+    end of `context_messages`, `_context_messages_for_new_turn` must strip it
+    before building the model-facing history.  Turn-journal `submitted` records
+    are intentionally not a context source for this helper.
+    """
     session = Session(
         session_id="journal_context_current_turn",
         title="journal context",
-        messages=[{"role": "user", "content": "older"}],
-        context_messages=[{"role": "user", "content": "older"}],
+        messages=[
+            {"role": "user", "content": "older"},
+            {"role": "assistant", "content": "prior"},
+        ],
+        context_messages=[
+            {"role": "user", "content": "older"},
+            {"role": "assistant", "content": "prior"},
+            {"role": "user", "content": "[Workspace::v1: /tmp/hermes]\ncurrent prompt"},
+        ],
         active_stream_id="stream-current",
         pending_user_message="current prompt",
-    )
-    append_turn_journal_event(
-        session.session_id,
-        {
-            "event": "submitted",
-            "stream_id": "stream-current",
-            "role": "user",
-            "content": "current prompt",
-            "created_at": 123.0,
-        },
-        session_dir=tmp_path,
     )
 
     context = streaming._context_messages_for_new_turn(session, "current prompt")
 
-    assert [m["content"] for m in context] == ["older"]
+    assert [m["content"] for m in context] == ["older", "prior"]
 
 
 def test_eager_checkpointed_user_is_not_duplicated_after_agent_result():

--- a/tests/test_session_save_mode.py
+++ b/tests/test_session_save_mode.py
@@ -119,6 +119,34 @@ def test_eager_checkpointed_user_is_removed_from_model_context():
     assert [m["content"] for m in context] == ["older", "prior"]
 
 
+def test_submitted_turn_journal_does_not_duplicate_current_model_context(tmp_path):
+    from api.turn_journal import append_turn_journal_event
+
+    session = Session(
+        session_id="journal_context_current_turn",
+        title="journal context",
+        messages=[{"role": "user", "content": "older"}],
+        context_messages=[{"role": "user", "content": "older"}],
+        active_stream_id="stream-current",
+        pending_user_message="current prompt",
+    )
+    append_turn_journal_event(
+        session.session_id,
+        {
+            "event": "submitted",
+            "stream_id": "stream-current",
+            "role": "user",
+            "content": "current prompt",
+            "created_at": 123.0,
+        },
+        session_dir=tmp_path,
+    )
+
+    context = streaming._context_messages_for_new_turn(session, "current prompt")
+
+    assert [m["content"] for m in context] == ["older"]
+
+
 def test_eager_checkpointed_user_is_not_duplicated_after_agent_result():
     merged = streaming._merge_display_messages_after_agent_result(
         previous_display=[{"role": "user", "content": "repeat me"}],


### PR DESCRIPTION
## Release YF (v0.51.676) — submitted message no longer renders twice (or vanishes) on active reload

Ships **#4826** (@franksong2702, T1) — fixes #4825.

### What it fixes
On active-session reload, the current turn is visible through optimistic/in-flight + `pending_user_message` + replay. The dedupe is now scoped to the **current-turn tail** (stopping at the most recent non-live assistant): a genuine double-render of the same current turn is collapsed to one, while a *new* turn matching an *earlier historical* message (same prompt sent twice, incl default deferred save mode) is preserved instead of suppressed.

### Gate (converged after the over-dedup bounce)
Prior bounce (Codex-reproduced): the first fix scoped `_mergePendingSessionMessage` but the upstream `getPendingSessionMessage()` still whole-history reverse-scanned, so a distinct repeated prompt still vanished under deferred mode. Re-push routes `getPendingSessionMessage` through `_pendingCurrentTailUserMessage` (current-tail only).
- **Codex: SAFE TO SHIP** + **Opus: SHIP IT** — over-dedup fixed (current-tail detection stops at a non-live assistant, so historical same-text turns aren't treated as current), no under-dedup regression (same-current-turn double-render still collapses), both sessions.js merge paths route through the same rule, attachments reattach only on genuine same-turn match.
- **Full suite: 10677 passed**, 0 failures. +270 lines of dedupe regression tests incl the deferred-mode repeated-prompt case.
- Pre-merge head re-check: gated == live (e75e5155).

Credit @franksong2702.
