### PR TITLE
Fix manual /compress undone by reconciliation and .bak recovery (#4836)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -19377,7 +19377,12 @@ def _handle_session_compress(handler, body):
             if _sanitize_messages_for_api(s.messages) != original_messages:
                 return bad(handler, "Session was modified during compression; please retry.", 409)
 
-            s.context_messages = copy.deepcopy(compressed)
+            from api.session_ops import _truncation_watermark_for
+            from api.streaming import _stamp_missing_message_timestamps
+
+            compressed_copy = copy.deepcopy(compressed)
+            _stamp_missing_message_timestamps(compressed_copy)
+            s.context_messages = compressed_copy
             s.active_stream_id = None
             s.pending_user_message = None
             s.pending_attachments = []
@@ -19392,7 +19397,19 @@ def _handle_session_compress(handler, body):
             s.compression_anchor_summary = _compact_summary_text(
                 summary_text or _compression_summary_from_messages(compressed) or ""
             )
+            # Persist an intentional-shrink boundary so append-only state.db
+            # reconciliation does not replay pre-compression rows (#4836).
+            compress_watermark = _truncation_watermark_for(compressed_copy)
+            s.truncation_watermark = compress_watermark
+            s.truncation_boundary = compress_watermark
+            s.compression_anchor_mode = "manual"
+            s.last_prompt_tokens = new_tokens
             s.save()
+            # Drop stale backups that would undo an intentional manual compress.
+            try:
+                s.path.with_suffix(".json.bak").unlink(missing_ok=True)
+            except OSError:
+                pass
 
         session_payload = redact_session_data(
             s.compact() | {

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -65,6 +65,42 @@ def _msg_count(p: Path) -> int:
     return len(msgs) if isinstance(msgs, list) else -1
 
 
+def _session_records_intentional_compress_shrink(session_path: Path) -> bool:
+    """Return True when the live sidecar records an intentional context shrink.
+
+    Manual ``/compress`` keeps the visible transcript but replaces the
+    model-facing ``context_messages`` with a smaller compacted prefix. That
+    operation must not be treated as accidental data loss by the #1558
+    ``.bak`` safeguard or startup recovery (#4836).
+    """
+    try:
+        data = json.loads(session_path.read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(data, dict):
+        return False
+
+    context_messages = data.get('context_messages')
+    messages = data.get('messages')
+    has_shorter_context = (
+        isinstance(context_messages, list)
+        and isinstance(messages, list)
+        and len(context_messages) < len(messages)
+    )
+    anchor_summary = str(data.get('compression_anchor_summary') or '').strip()
+    anchor_key = data.get('compression_anchor_message_key')
+    mode = str(data.get('compression_anchor_mode') or '').strip().lower()
+    watermark = data.get('truncation_watermark')
+
+    if mode == 'manual':
+        return True
+    if has_shorter_context and anchor_summary and anchor_key is not None:
+        return True
+    if has_shorter_context and watermark is not None:
+        return True
+    return False
+
+
 def inspect_session_recovery_status(session_path: Path) -> dict:
     """Return a status dict describing whether recovery is recommended.
 
@@ -86,6 +122,14 @@ def inspect_session_recovery_status(session_path: Path) -> dict:
         }
     bak_count = _msg_count(bak_path)
     if bak_count > live_count:
+        if _session_records_intentional_compress_shrink(session_path):
+            return {
+                "session_id": session_path.stem,
+                "live_messages": live_count,
+                "bak_messages": bak_count,
+                "recommend": "no_action",
+                "intentional_compress_shrink": True,
+            }
         return {
             "session_id": session_path.stem,
             "live_messages": live_count,

--- a/tests/test_issue4836_manual_compression_recovery.py
+++ b/tests/test_issue4836_manual_compression_recovery.py
@@ -1,0 +1,223 @@
+"""Regression tests for #4836 — manual /compress undone by reconciliation/recovery."""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import time
+import types
+
+import api.models as models
+from api.models import Session, reconciled_state_db_messages_for_session
+from api.routes import _handle_session_compress, get_session
+from api.session_recovery import inspect_session_recovery_status, recover_all_sessions_on_startup
+from tests._pytest_port import BASE
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.wfile = io.BytesIO()
+        self.status = None
+        self.sent_headers = {}
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.sent_headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def payload(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+class _FakeCompressor:
+    def compress(self, messages, current_tokens=None, focus_topic=None):
+        if len(messages) >= 2:
+            return [messages[0], messages[-1]]
+        return list(messages)
+
+
+class _FakeAgent:
+    last_instance = None
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.context_compressor = _FakeCompressor()
+        _FakeAgent.last_instance = self
+
+
+def _install_fake_compression_runtime(monkeypatch, agent_cls):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = agent_cls
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    import api.config as _cfg
+
+    fake_runtime_provider = types.ModuleType("hermes_cli.runtime_provider")
+    fake_runtime_provider.resolve_runtime_provider = lambda requested=None: {
+        "api_key": "fake-key",
+        "provider": requested or "openai",
+        "base_url": "https://api.openai.com/v1",
+    }
+    fake_hermes_cli = types.ModuleType("hermes_cli")
+    fake_hermes_cli.__path__ = []
+    fake_hermes_cli.runtime_provider = fake_runtime_provider
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", fake_runtime_provider)
+    import hermes_cli.runtime_provider as _rtp
+
+    monkeypatch.setattr(
+        _cfg,
+        "resolve_model_provider",
+        lambda model: ("openai/gpt-5.4-mini", "openai", "https://api.openai.com/v1"),
+    )
+    monkeypatch.setattr(
+        _cfg,
+        "_get_session_agent_lock",
+        lambda sid: contextlib.nullcontext(),
+    )
+    monkeypatch.setattr(
+        _rtp,
+        "resolve_runtime_provider",
+        lambda requested=None: {
+            "api_key": "fake-key",
+            "provider": requested or "openai",
+            "base_url": "https://api.openai.com/v1",
+        },
+    )
+
+
+def _msg(role, content, ts):
+    return {"role": role, "content": content, "timestamp": ts, "_ts": ts}
+
+
+def test_manual_compress_persists_truncation_boundary(monkeypatch, cleanup_test_sessions, tmp_path):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    original_messages = [
+        _msg("user", "one", 1.0),
+        _msg("assistant", "two", 2.0),
+        _msg("user", "three", 3.0),
+        _msg("assistant", "four", 4.0),
+    ]
+    sid = f"issue4836_{time.time_ns()}"
+    cleanup_test_sessions.append(sid)
+    session = Session(
+        session_id=sid,
+        title="Untitled",
+        workspace=str(tmp_path),
+        model="openai/gpt-5.4-mini",
+        messages=original_messages,
+    )
+    session.save(touch_updated_at=False)
+
+    _install_fake_compression_runtime(monkeypatch, _FakeAgent)
+    handler = _FakeHandler()
+    _handle_session_compress(handler, {"session_id": sid})
+
+    assert handler.status == 200
+    loaded = Session.load(sid)
+    assert loaded.compression_anchor_mode == "manual"
+    assert loaded.truncation_watermark is not None
+    assert loaded.truncation_boundary == loaded.truncation_watermark
+    assert loaded.last_prompt_tokens is not None
+    assert len(loaded.context_messages) == 2
+    assert loaded.messages == original_messages
+
+
+def test_manual_compress_blocks_state_db_replay(monkeypatch, cleanup_test_sessions, tmp_path):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    sidecar = [
+        _msg("user", "one", 1.0),
+        _msg("assistant", "two", 2.0),
+        _msg("user", "three", 3.0),
+        _msg("assistant", "four", 4.0),
+    ]
+    state_db = [
+        _msg("user", "one", 1.0),
+        _msg("assistant", "two", 2.0),
+        _msg("user", "three", 3.0),
+        _msg("assistant", "four", 4.0),
+        _msg("assistant", "", 4.1),  # reasoning-only row that used to replay
+    ]
+    session = Session(
+        session_id=f"issue4836_reconcile_{time.time_ns()}",
+        title="Untitled",
+        workspace=str(tmp_path),
+        model="openai/gpt-5.4-mini",
+        messages=sidecar,
+        context_messages=sidecar,
+    )
+    session.save(touch_updated_at=False)
+    cleanup_test_sessions.append(session.session_id)
+
+    _install_fake_compression_runtime(monkeypatch, _FakeAgent)
+    handler = _FakeHandler()
+    _handle_session_compress(handler, {"session_id": session.session_id})
+    assert handler.status == 200
+
+    loaded = Session.load(session.session_id)
+    merged = reconciled_state_db_messages_for_session(
+        loaded,
+        prefer_context=True,
+        state_messages=state_db,
+    )
+    assert len(merged) == len(loaded.context_messages)
+
+
+def test_startup_recovery_skips_intentional_manual_compress(monkeypatch, tmp_path):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    sid = "issue4836_recovery"
+    live_path = session_dir / f"{sid}.json"
+    bak_path = session_dir / f"{sid}.json.bak"
+
+    live = {
+        "session_id": sid,
+        "title": "Untitled",
+        "workspace": str(tmp_path),
+        "model": "openai/gpt-5.4-mini",
+        "messages": [
+            _msg("user", "one", 1.0),
+            _msg("assistant", "two", 2.0),
+        ],
+        "context_messages": [
+            _msg("user", "one", 1.0),
+        ],
+        "compression_anchor_summary": "Compressed: 2 -> 1 messages",
+        "compression_anchor_message_key": {"role": "assistant", "ts": 2.0, "text": "two", "attachments": 0},
+        "compression_anchor_mode": "manual",
+        "truncation_watermark": 1.0,
+        "truncation_boundary": 1.0,
+        "message_count": 2,
+    }
+    bak = dict(live)
+    bak["messages"] = live["messages"] + [
+        _msg("user", "three", 3.0),
+        _msg("assistant", "four", 4.0),
+    ] * 150
+    live_path.write_text(json.dumps(live), encoding="utf-8")
+    bak_path.write_text(json.dumps(bak), encoding="utf-8")
+
+    status = inspect_session_recovery_status(live_path)
+    assert status["recommend"] == "no_action"
+    assert status.get("intentional_compress_shrink") is True
+
+    result = recover_all_sessions_on_startup(session_dir)
+    assert result["restored"] == 0
+    restored = json.loads(live_path.read_text(encoding="utf-8"))
+    assert len(restored["messages"]) == 2
+    assert len(restored["context_messages"]) == 1

--- a/tests/test_sprint46.py
+++ b/tests/test_sprint46.py
@@ -172,14 +172,24 @@ def test_session_compress_roundtrip(monkeypatch, cleanup_test_sessions):
     loaded = get_session(sid)
     persisted = Session.load(sid)
     assert loaded.messages == original_messages
-    assert loaded.context_messages == compressed_messages
+    assert [m.get("role") for m in loaded.context_messages] == [m.get("role") for m in compressed_messages]
+    assert [m.get("content") for m in loaded.context_messages] == [m.get("content") for m in compressed_messages]
     assert loaded.tool_calls == settled_tool_calls
     assert persisted.messages == original_messages
-    assert persisted.context_messages == compressed_messages
+    assert [m.get("role") for m in persisted.context_messages] == [m.get("role") for m in compressed_messages]
+    assert [m.get("content") for m in persisted.context_messages] == [m.get("content") for m in compressed_messages]
     assert persisted.tool_calls == settled_tool_calls
     assert loaded.compression_anchor_summary == payload["session"]["compression_anchor_summary"]
     assert loaded.compression_anchor_visible_idx == payload["session"]["compression_anchor_visible_idx"]
     assert loaded.compression_anchor_message_key == payload["session"]["compression_anchor_message_key"]
+    assert loaded.compression_anchor_mode == "manual"
+    assert loaded.truncation_watermark is not None
+    assert loaded.truncation_boundary == loaded.truncation_watermark
+    assert loaded.last_prompt_tokens is not None
+    assert persisted.compression_anchor_mode == "manual"
+    assert persisted.truncation_watermark == loaded.truncation_watermark
+    assert persisted.truncation_boundary == loaded.truncation_boundary
+    assert not (SESSION_DIR / f"{sid}.json.bak").exists()
     assert persisted.compression_anchor_visible_idx == 3
     assert persisted.compression_anchor_message_key == payload["session"]["compression_anchor_message_key"]
     assert _FakeAgent.last_instance is not None


### PR DESCRIPTION
## Summary
- Persist `truncation_watermark` / `truncation_boundary` when manual `/compress` completes
- Mark compression as intentional (`compression_anchor_mode=manual`) and refresh `last_prompt_tokens`
- Skip startup `.bak` restore for intentional manual compress sessions
- Remove stale `.bak` after successful manual compress

## Why
Fixes #4836 — compressed context could reappear after reload or restart via state.db reconciliation or `.bak` recovery.

## Test plan
- [x] `pytest tests/test_issue4836_manual_compression_recovery.py tests/test_sprint46.py::test_session_compress_roundtrip -q`
- [x] `pytest tests/test_metadata_save_wipe_1558.py tests/test_issue2914_truncation_watermark.py -q`