### PR TITLE
fix(models): make session-index rebuild thread ownership explicit (#3894)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -200,6 +200,7 @@ def _session_dir_has_persisted_session_files() -> bool:
 
 def _rebuild_session_index_background(expected_session_dir: Path, expected_index_file: Path) -> None:
     global _SESSION_INDEX_REBUILD_THREAD, _SESSION_INDEX_REBUILD_THREAD_TARGET
+    current_thread = threading.current_thread()
     try:
         with _SESSION_INDEX_REBUILD_LOCK:
             if SESSION_DIR != expected_session_dir or SESSION_INDEX_FILE != expected_index_file:
@@ -213,7 +214,7 @@ def _rebuild_session_index_background(expected_session_dir: Path, expected_index
         logger.debug("Background session-index rebuild failed", exc_info=True)
     finally:
         with _SESSION_INDEX_REBUILD_LOCK:
-            if _SESSION_INDEX_REBUILD_THREAD_TARGET == (
+            if _SESSION_INDEX_REBUILD_THREAD is current_thread and _SESSION_INDEX_REBUILD_THREAD_TARGET == (
                 expected_session_dir,
                 expected_index_file,
             ):

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -1666,3 +1666,30 @@ def test_background_index_rebuild_skips_after_session_dir_switch(tmp_path, monke
     assert not new_index_file.exists()
     rows = _read_index(original_index_file)
     assert [row["session_id"] for row in rows] == ["late_switch_sid"]
+
+
+def test_background_rebuild_old_thread_finally_preserves_new_same_target_owner(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(exist_ok=True)
+    index_file = session_dir / "_index.json"
+    target = (session_dir, index_file)
+
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+
+    old_thread = object()
+    new_thread = object()
+    monkeypatch.setattr(models, "_SESSION_INDEX_REBUILD_THREAD", old_thread)
+    monkeypatch.setattr(models, "_SESSION_INDEX_REBUILD_THREAD_TARGET", target)
+    monkeypatch.setattr(models.threading, "current_thread", lambda: old_thread)
+
+    def _handoff_then_write(*args, **kwargs):
+        monkeypatch.setattr(models, "_SESSION_INDEX_REBUILD_THREAD", new_thread)
+        monkeypatch.setattr(models, "_SESSION_INDEX_REBUILD_THREAD_TARGET", target)
+
+    monkeypatch.setattr(models, "_write_session_index", _handoff_then_write)
+
+    models._rebuild_session_index_background(*target)
+
+    assert models._SESSION_INDEX_REBUILD_THREAD is new_thread
+    assert models._SESSION_INDEX_REBUILD_THREAD_TARGET == target


### PR DESCRIPTION
## Thinking Path

- `#3894` is a bookkeeping hardening follow-up, not a user-visible bug report. The safest change is the one the issue already points at: make cleanup depend on explicit ownership, not just a matching target tuple.
- `api/models.py` already records both the current owner thread and the current target. The missing guard is simply that the worker finishing never checks whether it is still the registered owner before clearing those globals.
- This PR keeps the rebuild model intact. It only makes the owner handoff explicit and locks the latent same-target handoff window with a deterministic regression test.

## What Changed

- `api/models.py`: captures the current worker thread in `_rebuild_session_index_background(...)` and clears the rebuild globals only when the finishing worker is still the registered owner for the matching target tuple.
- `tests/test_session_index.py`: adds a deterministic same-target handoff regression that proves an older worker no longer clears a newer owner's globals.

## Why It Matters

This closes a subtle ownership window in the background rebuild bookkeeping without changing scheduling or user-visible behavior. The code becomes explicit about who is allowed to clear the shared globals, which makes future thread-hand-off work safer.

## Verification

```text
pytest tests/test_session_index.py -v --timeout=60
pytest tests/test_issue2863_session_index_prime.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #3894.

Follow-up to [#3884](https://github.com/nesquena/hermes-webui/pull/3884), which introduced the target-pinned rebuild ownership this PR hardens.

## Model Used

GPT 5.5 via Codex CLI
