### PR TITLE
fix(mobile): hide the dashboard rail link on narrow viewports (#4712)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2571,6 +2571,8 @@
     .sidebar-nav .nav-tab svg{width:20px;height:20px;}
     .sidebar-nav .nav-tab.active{background:var(--accent-bg);}
     .sidebar-nav .nav-tab.active::before{left:-4px;top:50%;bottom:auto;transform:translateY(-50%);width:3px;height:16px;border-radius:0 2px 2px 0;}
+    .sidebar-nav .dashboard-link,
+    .sidebar-nav .dashboard-link.dashboard-link-visible{display:none!important;}
     .sidebar .panel-view{height:100%;margin-left:52px;}
     .sidebar .panel-head{padding-right:52px;}
     .mobile-sidebar-close{display:inline-flex!important;position:absolute;right:10px;top:calc(8px + var(--app-titlebar-safe-top));width:32px;height:32px;z-index:4;background:var(--surface);border:1px solid var(--border);}

--- a/tests/test_dashboard_link_ui.py
+++ b/tests/test_dashboard_link_ui.py
@@ -68,3 +68,25 @@ def test_dashboard_frontend_uses_browser_url_without_requiring_probe_port():
     assert "status.browser_url||status.url" in helper
     assert "!status.port" in helper
     assert helper.index("status.browser_url||status.url") < helper.index("!status.port")
+
+
+def test_mobile_dashboard_link_is_scoped_hidden_in_narrow_viewport_css():
+    match = re.search(
+        r"@media\(max-width:640px\)\{([\s\S]*?)\n\s*}\s*\n\s*@media \(hover:none\)",
+        STYLE_CSS,
+        re.DOTALL,
+    )
+    assert match is not None
+    mobile_css = match.group(1)
+    assert re.search(
+        r"\.sidebar-nav\s+\.dashboard-link,\s*\.sidebar-nav\s+\.dashboard-link\.dashboard-link-visible\s*\{\s*display\s*:\s*none\s*!important\s*;\s*}",
+        mobile_css,
+        re.DOTALL,
+    )
+
+
+def test_desktop_dashboard_link_button_stays_in_desktop_nav():
+    rail_nav = re.search(r'<nav class="rail".*?</nav>', INDEX_HTML, re.DOTALL).group(0)
+    assert 'id="dashboardRailBtn"' in rail_nav
+    mobile_nav = re.search(r'<div class="sidebar-nav">.*?</div>', INDEX_HTML, re.DOTALL).group(0)
+    assert 'id="dashboardMobileBtn"' in mobile_nav

--- a/tests/test_dashboard_link_ui.py
+++ b/tests/test_dashboard_link_ui.py
@@ -88,5 +88,10 @@ def test_mobile_dashboard_link_is_scoped_hidden_in_narrow_viewport_css():
 def test_desktop_dashboard_link_button_stays_in_desktop_nav():
     rail_nav = re.search(r'<nav class="rail".*?</nav>', INDEX_HTML, re.DOTALL).group(0)
     assert 'id="dashboardRailBtn"' in rail_nav
-    mobile_nav = re.search(r'<div class="sidebar-nav">.*?</div>', INDEX_HTML, re.DOTALL).group(0)
+    mobile_nav_match = re.search(
+        r'<div class="sidebar-nav">([\s\S]*?)</div>\s*(?=<!--)',
+        INDEX_HTML,
+    )
+    assert mobile_nav_match is not None
+    mobile_nav = mobile_nav_match.group(0)
     assert 'id="dashboardMobileBtn"' in mobile_nav


### PR DESCRIPTION
## Thinking Path

- The mobile and desktop dashboard buttons already exist as separate elements, but the running-state logic and the CSS visibility class treat them as one shared surface.
- The issue already points at the correct seam: below the mobile breakpoint, `.sidebar-nav` becomes the vertical rail, so a scoped CSS override can hide only the mobile entry without disturbing the desktop rail button.
- Keeping this CSS-only preserves the current dashboard-status logic and avoids broadening a small UI cleanup into a JS or server behavior change.

## What Changed

- `static/style.css`: adds a narrow-viewport override that hides dashboard links only inside `.sidebar-nav`, even when `dashboard-link-visible` is present.
- `tests/test_dashboard_link_ui.py`: extends the direct regression coverage to lock in the mobile-only scope of the new rule.

## Why It Matters

Phone-width layouts stop advertising a desktop-oriented dashboard surface in the mobile rail, while the desktop dashboard entry still behaves exactly as it does today. The fix is narrow, resilient to resize and rotation, and applies equally to mobile web, the PWA, and the native wrappers.

## Verification

```text
pytest tests/test_dashboard_link_ui.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #4712.

Fix shape follows [Issue #4712](https://github.com/nesquena/hermes-webui/issues/4712), which scoped this to a CSS-only mobile hide rule on `.sidebar-nav .dashboard-link`.

## Model Used

GPT 5.5 via Codex CLI
