### PR TITLE
Release YJ (v0.51.680): explicit session-index rebuild thread ownership (#4993, #3894)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.680] — 2026-06-26 — Release YJ (session-index rebuild can't be clobbered by a late worker)
+
+### Fixed
+
+- **A late-finishing background session-index rebuild can no longer clobber a newer rebuild's state.** When a session-index rebuild worker finished, it cleared the rebuild bookkeeping globals if only the target tuple matched — so an older worker completing after a newer rebuild had already taken over could wipe the newer owner's registration. The cleanup now also requires that the finishing worker is still the registered owner thread (`_SESSION_INDEX_REBUILD_THREAD is current_thread`, checked under the rebuild lock), so an out-of-order older worker leaves the newer owner's state intact while the genuine owner still clears normally. Thanks @rodboev. (#4993, #3894)
+
 ## [v0.51.679] — 2026-06-26 — Release YI (faster fresh sidebar boot — parallel session/project fetches)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -200,6 +200,7 @@ def _session_dir_has_persisted_session_files() -> bool:
 
 def _rebuild_session_index_background(expected_session_dir: Path, expected_index_file: Path) -> None:
     global _SESSION_INDEX_REBUILD_THREAD, _SESSION_INDEX_REBUILD_THREAD_TARGET
+    current_thread = threading.current_thread()
     try:
         with _SESSION_INDEX_REBUILD_LOCK:
             if SESSION_DIR != expected_session_dir or SESSION_INDEX_FILE != expected_index_file:
@@ -213,7 +214,7 @@ def _rebuild_session_index_background(expected_session_dir: Path, expected_index
         logger.debug("Background session-index rebuild failed", exc_info=True)
     finally:
         with _SESSION_INDEX_REBUILD_LOCK:
-            if _SESSION_INDEX_REBUILD_THREAD_TARGET == (
+            if _SESSION_INDEX_REBUILD_THREAD is current_thread and _SESSION_INDEX_REBUILD_THREAD_TARGET == (
                 expected_session_dir,
                 expected_index_file,
             ):

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -1666,3 +1666,30 @@ def test_background_index_rebuild_skips_after_session_dir_switch(tmp_path, monke
     assert not new_index_file.exists()
     rows = _read_index(original_index_file)
     assert [row["session_id"] for row in rows] == ["late_switch_sid"]
+
+
+def test_background_rebuild_old_thread_finally_preserves_new_same_target_owner(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(exist_ok=True)
+    index_file = session_dir / "_index.json"
+    target = (session_dir, index_file)
+
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+
+    old_thread = object()
+    new_thread = object()
+    monkeypatch.setattr(models, "_SESSION_INDEX_REBUILD_THREAD", old_thread)
+    monkeypatch.setattr(models, "_SESSION_INDEX_REBUILD_THREAD_TARGET", target)
+    monkeypatch.setattr(models.threading, "current_thread", lambda: old_thread)
+
+    def _handoff_then_write(*args, **kwargs):
+        monkeypatch.setattr(models, "_SESSION_INDEX_REBUILD_THREAD", new_thread)
+        monkeypatch.setattr(models, "_SESSION_INDEX_REBUILD_THREAD_TARGET", target)
+
+    monkeypatch.setattr(models, "_write_session_index", _handoff_then_write)
+
+    models._rebuild_session_index_background(*target)
+
+    assert models._SESSION_INDEX_REBUILD_THREAD is new_thread
+    assert models._SESSION_INDEX_REBUILD_THREAD_TARGET == target


### PR DESCRIPTION
## Release YJ (v0.51.680) — session-index rebuild ownership hardening

Ships **#4993** (@rodboev) — addresses #3894 (bookkeeping hardening).

### What it fixes
`_rebuild_session_index_background()` cleared the rebuild bookkeeping globals in its `finally` block when only the target tuple matched — so a late-finishing older worker could wipe a newer rebuild's registered state. The cleanup now also requires `_SESSION_INDEX_REBUILD_THREAD is current_thread` (under the rebuild lock), so an out-of-order older worker leaves the newer owner intact.

### Gate
- **Codex: SAFE TO SHIP** — check is under `_SESSION_INDEX_REBUILD_LOCK` (no TOCTOU); an older worker can't clear a newer same-target owner; the genuine owner still clears the globals (no stuck-owner leak). The +27 test is non-vacuous (simulates a same-target handoff, asserts the newer owner survives).
- **Full suite: 10693 passed** (1 unrelated known order-flake `test_skills_stats_cache`, passes in isolation).
- Pre-merge head re-check: gated == live (54f2f72b).

Credit @rodboev.
