### PR TITLE
Add Shift+Enter send key option

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -7791,7 +7791,7 @@ def _get_session_agent_lock(session_id: str) -> threading.Lock:
 _SETTINGS_DEFAULTS = {
     "default_workspace": str(DEFAULT_WORKSPACE),
     "onboarding_completed": False,
-    "send_key": "enter",  # 'enter' or 'ctrl+enter'
+    "send_key": "enter",  # 'enter', 'ctrl+enter', or 'shift+enter'
     "show_token_usage": False,  # show input/output token badge below assistant messages
     "show_quota_chip": False,  # show ambient provider quota chip in composer footer (default off; wide desktop only when enabled, see style.css @media)
     "show_conversation_outline": False,  # show opt-in desktop jump-to-question outline panel
@@ -8019,7 +8019,7 @@ _SETTINGS_ALLOWED_KEYS = set(_SETTINGS_DEFAULTS.keys()) - {
     "simplified_tool_calling",
 }
 _SETTINGS_ENUM_VALUES = {
-    "send_key": {"enter", "ctrl+enter"},
+    "send_key": {"enter", "ctrl+enter", "shift+enter"},
     "sidebar_density": {"compact", "detailed"},
     "font_size": {"small", "default", "large", "xlarge"},
     "auto_title_refresh_every": {"0", "5", "10", "20"},

--- a/static/boot.js
+++ b/static/boot.js
@@ -1697,6 +1697,9 @@ $('msg').addEventListener('keydown',e=>{
     if(e.key==='Escape'){e.preventDefault();e.stopPropagation();hideCmdDropdown();return;}
     if(e.key==='Enter'&&!e.shiftKey){
       if(_isImeEnter(e)){return;}
+      if(window._sendKey==='shift+enter'){
+        return;
+      }
       e.preventDefault();
       selectCmdDropdownItem();
       return;
@@ -1710,7 +1713,8 @@ $('msg').addEventListener('keydown',e=>{
   // doesn't consistently reduce vv.height by >120px. The pointer media query
   // pair is a sufficient and more reliable signal for "software keyboard only".
   // Hardware keyboards on tablets are covered by _hasFinePointerCoexisting.
-  // The 'ctrl+enter' setting also uses this behavior (Enter = newline).
+  // The 'ctrl+enter' and 'shift+enter' settings also use this behavior
+  // (plain Enter = newline).
   // Users can override in Settings by explicitly choosing 'enter' mode.
   if(e.key==='Enter'){
     if(_isImeEnter(e)){return;}
@@ -1718,7 +1722,9 @@ $('msg').addEventListener('keydown',e=>{
     const _mobileDefault=matchMedia('(pointer:coarse)').matches
       &&!_hasFinePointerCoexisting()
       &&window._sendKey==='enter';
-    if(window._sendKey==='ctrl+enter'||_mobileDefault){
+    if(window._sendKey==='shift+enter'){
+      if(e.shiftKey){e.preventDefault();send();}
+    } else if(window._sendKey==='ctrl+enter'||_mobileDefault){
       if(isNumpadEnter||e.ctrlKey||e.metaKey){e.preventDefault();send();}
     } else {
       if(!e.shiftKey){e.preventDefault();send();}

--- a/static/index.html
+++ b/static/index.html
@@ -1146,6 +1146,7 @@
               <select id="settingsSendKey" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px">
                 <option value="enter">Enter (Shift+Enter for newline)</option>
                 <option value="ctrl+enter">Ctrl+Enter (Enter for newline)</option>
+                <option value="shift+enter">Shift+Enter (Enter for newline)</option>
               </select>
             </div>
             <div class="settings-field">

--- a/tests/test_shift_enter_send_key.py
+++ b/tests/test_shift_enter_send_key.py
@@ -1,0 +1,54 @@
+"""Keyboard contract for the Shift+Enter send-key preference."""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+INDEX_HTML = (REPO / "static" / "index.html").read_text(encoding="utf-8")
+CONFIG_PY = (REPO / "api" / "config.py").read_text(encoding="utf-8")
+
+
+def _listener_body() -> str:
+    signature = "$('msg').addEventListener('keydown',e=>"
+    start = BOOT_JS.index(signature)
+    brace = BOOT_JS.index("{", start)
+    depth = 0
+    for idx in range(brace, len(BOOT_JS)):
+        char = BOOT_JS[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return BOOT_JS[start : idx + 1]
+    raise AssertionError("could not extract composer keydown listener")
+
+
+def test_settings_expose_shift_enter_send_key_option():
+    assert '<option value="shift+enter">Shift+Enter (Enter for newline)</option>' in INDEX_HTML
+    assert '"send_key": {"enter", "ctrl+enter", "shift+enter"}' in CONFIG_PY
+
+
+def test_shift_enter_mode_sends_only_with_shift_enter():
+    handler = _listener_body()
+    shift_branch = handler.split("if(window._sendKey==='shift+enter')", 1)[1]
+    shift_branch = shift_branch.split("} else if(window._sendKey==='ctrl+enter'||_mobileDefault)", 1)[0]
+    assert "if(e.shiftKey){e.preventDefault();send();}" in shift_branch
+    assert "if(!e.shiftKey){e.preventDefault();send();}" not in shift_branch
+
+
+def test_shift_enter_mode_leaves_plain_enter_to_textarea_when_autocomplete_open():
+    handler = _listener_body()
+    dropdown_enter = handler[
+        handler.index("if(e.key==='Enter'&&!e.shiftKey)") :
+        handler.index("// Send key: respect user preference.")
+    ]
+    assert "if(window._sendKey==='shift+enter')" in dropdown_enter
+    guarded = dropdown_enter.split("if(window._sendKey==='shift+enter')", 1)[1].split("e.preventDefault();", 1)[0]
+    assert "return;" in guarded
+
+
+def test_existing_enter_and_ctrl_enter_modes_stay_available():
+    handler = _listener_body()
+    assert "if(!e.shiftKey){e.preventDefault();send();}" in handler
+    assert "if(isNumpadEnter||e.ctrlKey||e.metaKey){e.preventDefault();send();}" in handler

--- a/tests/test_sprint17.py
+++ b/tests/test_sprint17.py
@@ -47,6 +47,12 @@ def test_settings_save_send_key():
         # Verify it persisted
         data, _ = get("/api/settings")
         assert data["send_key"] == "ctrl+enter"
+        # Save shift+enter
+        _, status = post("/api/settings", {"send_key": "shift+enter"})
+        assert status == 200
+        # Verify it persisted
+        data, _ = get("/api/settings")
+        assert data["send_key"] == "shift+enter"
     finally:
         # Always restore default
         post("/api/settings", {"send_key": "enter"})


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI already has a configurable composer send key for `enter` and `ctrl+enter`.
- Some users prefer plain Enter to stay inside the textarea for multi-line drafting, but still want a keyboard-only submit path.
- Adding `shift+enter` as a third explicit preference preserves the current default and avoids changing existing user muscle memory.
- The frontend needs to keep autocomplete behavior compatible: in `shift+enter` mode, plain Enter should remain textarea input even when the command dropdown is open.

## What Changed

- Added `shift+enter` as an allowed `send_key` setting and Settings dropdown option.
- Updated composer key handling so `shift+enter` mode sends only on Shift+Enter while plain Enter remains newline input.
- Preserved existing Enter-to-send default and Ctrl/Cmd/Numpad Enter behavior in `ctrl+enter` mode.
- Added static regression coverage for the new mode and expanded settings round-trip coverage.
- Added an Unreleased changelog entry.

## Why It Matters

Users who compose multi-line messages frequently can keep Enter as newline without losing a keyboard submit shortcut. The change is opt-in, so existing desktop and mobile defaults remain compatible.

## Verification

- `./scripts/test.sh tests/test_sprint17.py tests/test_shift_enter_send_key.py tests/test_numpad_enter_submit.py tests/test_mobile_layout.py -q` → 80 passed
- `./scripts/test.sh tests/test_index_shell_template_cache.py tests/test_sprint17.py tests/test_shift_enter_send_key.py tests/test_numpad_enter_submit.py tests/test_mobile_layout.py -q` → 85 passed
- `npm run lint:runtime` → passed
- Manual Playwright event probe confirmed:
  - default `enter`: Enter sends, Shift+Enter does not send
  - `shift+enter`: Enter does not send, Shift+Enter sends and prevents default
  - autocomplete open + `shift+enter`: plain Enter does not select/dropdown-submit

## Risks / Follow-ups

- The setting label is English-only, matching the existing send-key labels.
- This is a keyboard interaction change plus one dropdown option; no layout or theme structure changed. Before/after visual evidence is limited to the Settings select containing one additional option.

## Contract Routing

Task type: UI/UX behavior preference and settings validation
Touched areas: composer keyboard handling, Settings send-key enum/dropdown, static regression tests, changelog
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/UIUX-GUIDE.md`
- `DESIGN.md`
Scope boundaries: no streaming, session recovery, persistence-layer, auth, or runtime state contract changes.
Evidence needed before claiming done: focused settings and composer keyboard tests, JS runtime lint, and manual event probe.

## Model Used

AI-assisted: OpenAI GPT-5.5 via Hermes Agent, using local file, terminal, and GitHub API tools. Human requested the behavior and PR submission.
