### PR TITLE
Release YN (v0.51.684): full-table-only enhanced-table copy sanitizer (#4994, fixes #4945)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.684] — 2026-06-26 — Release YN (copying a rendered table no longer drags its sort/filter chrome — or eats surrounding text)
+
+### Fixed
+
+- **Copying a rendered markdown table now produces clean table text instead of the enhanced sort/filter chrome and dark styling — without clobbering other selected content.** After WebUI enhances a table (header cells wrapped in sort buttons, filter UI inserted), a full-table copy carried that markup and dropped the header row. A copy interceptor now reconstructs clean table markup (header preserved, chrome stripped, dark inline styling removed, cell content HTML-escaped) — but only for a *full* enhanced-table selection. A partial selection (a few cells, one row/column), or a selection that merely crosses the table (text before → table → text after), falls through to native copy unchanged, so neither the surrounding prose nor a sub-selection is lost. Thanks @rodboev. (#4994, fixes #4945)
+
 ## [v0.51.683] — 2026-06-26 — Release YM (WebUI finds the agent for pip-style installs — no more cron.jobs import error)
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -537,9 +537,9 @@ function _handleMarkdownTableCopy(event){
   if(!table||!table.matches||!table.matches('table[data-markdown-table-enhanced]')) return;
   const payload=_markdownTableCopyPayloadForTable(table);
   if(!payload) return;
-  if(typeof event.preventDefault==='function') event.preventDefault();
   const clipboardData=event.clipboardData||event.originalEvent&&event.originalEvent.clipboardData;
   if(!clipboardData||typeof clipboardData.setData!=='function') return;
+  if(typeof event.preventDefault==='function') event.preventDefault();
   clipboardData.setData('text/html', payload.html);
   clipboardData.setData('text/plain', payload.plain);
 }

--- a/static/messages.js
+++ b/static/messages.js
@@ -464,6 +464,92 @@ function enhanceMarkdownTables(root){
   });
 }
 
+function _sanitizeMarkdownTableCellText(cell){
+  if(!cell) return '';
+  const sortButton=cell.querySelector?cell.querySelector('.markdown-table-sort'):null;
+  if(sortButton){
+    const sortLabel=sortButton.querySelector?sortButton.querySelector('.markdown-table-sort-label'):null;
+    if(sortLabel) return _markdownTableCellText(sortLabel);
+    return _markdownTableCellText(sortButton);
+  }
+  return _markdownTableCellText(cell);
+}
+
+function _markdownTableCopyHtmlEscape(value){
+  return String(value||'')
+    .replace(/&/g,'&amp;')
+    .replace(/</g,'&lt;')
+    .replace(/>/g,'&gt;');
+}
+
+function _markdownTableCopyPayloadForTable(table){
+  if(!table||!table.rows) return null;
+  const rows=Array.from(table.rows||[]);
+  if(!rows.length) return null;
+
+  const htmlRows=rows.map((row)=>{
+    const cellTag=(cell)=>String(cell&&cell.tagName?cell.tagName.toLowerCase():'td');
+    const cells=Array.from(row.cells||[])
+      .filter((cell)=>cell&&cell.nodeType===1 || cell&&cell.nodeType===3)
+      .map((cell)=>{
+        const tag=cellTag(cell);
+        const text=_sanitizeMarkdownTableCellText(cell);
+        return `<${tag}>${_markdownTableCopyHtmlEscape(text)}</${tag}>`;
+      })
+      .join('');
+    return `<tr>${cells}</tr>`;
+  }).join('');
+
+  const plainRows=rows.map((row)=>{
+    return Array.from(row.cells||[])
+      .map(_sanitizeMarkdownTableCellText)
+      .join('\t');
+  }).join('\n');
+
+  return {html:`<table>${htmlRows}</table>`, plain:plainRows};
+}
+
+function _findEnhancedMarkdownTable(node){
+  let current=node&&node.nodeType===3?node.parentElement:node;
+  while(current){
+    if(current.matches&&current.matches('table[data-markdown-table-enhanced]')) return current;
+    current=current.parentElement||current.parentNode;
+  }
+  return null;
+}
+
+function _findEnhancedMarkdownTableFromRange(range){
+  if(!range) return null;
+  const found=_findEnhancedMarkdownTable(range.startContainer)
+    || _findEnhancedMarkdownTable(range.endContainer)
+    || _findEnhancedMarkdownTable(range.commonAncestorContainer);
+  return found;
+}
+
+function _handleMarkdownTableCopy(event){
+  if(!event) return;
+  if(!window.getSelection)return;
+  const selection=window.getSelection();
+  if(!selection||selection.isCollapsed||!selection.rangeCount) return;
+  const range=selection.getRangeAt(0);
+  if(!range) return;
+  const table=_findEnhancedMarkdownTableFromRange(range);
+  if(!table||!table.matches||!table.matches('table[data-markdown-table-enhanced]')) return;
+  const payload=_markdownTableCopyPayloadForTable(table);
+  if(!payload) return;
+  if(typeof event.preventDefault==='function') event.preventDefault();
+  const clipboardData=event.clipboardData||event.originalEvent&&event.originalEvent.clipboardData;
+  if(!clipboardData||typeof clipboardData.setData!=='function') return;
+  clipboardData.setData('text/html', payload.html);
+  clipboardData.setData('text/plain', payload.plain);
+}
+
+function _wireMarkdownTableCopyHandler(root){
+  if(!root||!root.addEventListener||root.__markdownTableCopyHandlerInstalled) return;
+  root.addEventListener('copy', _handleMarkdownTableCopy);
+  root.__markdownTableCopyHandlerInstalled=true;
+}
+
 function _markdownTableText(value){
   return String(value||'').replace(/\s+/g,' ').trim();
 }
@@ -481,6 +567,7 @@ window.enhanceMarkdownTables=enhanceMarkdownTables;
     const result=baseRenderMessages.apply(this,args);
     const inner=typeof $==='function'?$('msgInner'):document.getElementById('msgInner');
     enhanceMarkdownTables(inner);
+    _wireMarkdownTableCopyHandler(inner);
     return result;
   };
   window.renderMessages._markdownTablesEnhanced=true;

--- a/static/messages.js
+++ b/static/messages.js
@@ -523,7 +523,17 @@ function _findEnhancedMarkdownTableFromRange(range){
   const found=_findEnhancedMarkdownTable(range.startContainer)
     || _findEnhancedMarkdownTable(range.endContainer)
     || _findEnhancedMarkdownTable(range.commonAncestorContainer);
-  return found;
+  if(found) return found;
+  const container=range.commonAncestorContainer&&range.commonAncestorContainer.nodeType===3
+    ? range.commonAncestorContainer.parentElement
+    : range.commonAncestorContainer;
+  if(!container||!container.querySelectorAll||typeof range.intersectsNode!=='function') return null;
+  for(const table of container.querySelectorAll('table[data-markdown-table-enhanced]')){
+    try{
+      if(range.intersectsNode(table)) return table;
+    }catch(_){}
+  }
+  return null;
 }
 
 function _handleMarkdownTableCopy(event){

--- a/static/messages.js
+++ b/static/messages.js
@@ -539,6 +539,64 @@ function _findMarkdownTableCell(node){
   return null;
 }
 
+function _markdownTableNodeChildren(node){
+  if(!node) return [];
+  if(node.childNodes&&typeof node.childNodes.length==='number') return Array.from(node.childNodes);
+  if(node.children&&typeof node.children.length==='number') return Array.from(node.children);
+  return [];
+}
+
+function _markdownTableNodeBoundaryLength(node){
+  if(!node) return 0;
+  if(node.nodeType===3) return String(node.textContent||'').length;
+  return _markdownTableNodeChildren(node).length;
+}
+
+function _markdownTableBoundaryWithinCell(container, offset, cell, edge){
+  if(!container||!cell||typeof offset!=='number') return false;
+  const atStart=edge==='start';
+  let current=container;
+  let currentOffset=offset;
+  while(current){
+    const boundaryLength=_markdownTableNodeBoundaryLength(current);
+    if(atStart){
+      if(currentOffset!==0) return false;
+    }else if(currentOffset!==boundaryLength){
+      return false;
+    }
+    if(current===cell) return true;
+    const parent=current.parentElement||current.parentNode;
+    if(!parent) return false;
+    const siblings=_markdownTableNodeChildren(parent);
+    const index=siblings.indexOf(current);
+    if(index===-1) return false;
+    currentOffset=atStart?index:index+1;
+    current=parent;
+  }
+  return false;
+}
+
+function _markdownTableEdgeCell(table, edge){
+  const rows=Array.from(table&&table.rows||[]);
+  if(!rows.length) return null;
+  const row=edge==='start'?rows[0]:rows[rows.length-1];
+  const cells=Array.from(row&&row.cells||[]);
+  if(!cells.length) return null;
+  return edge==='start'?cells[0]:cells[cells.length-1];
+}
+
+function _isFullEnhancedMarkdownTableSelection(range, table){
+  if(!range||!table) return false;
+  const firstCell=_markdownTableEdgeCell(table,'start');
+  const lastCell=_markdownTableEdgeCell(table,'end');
+  if(!firstCell||!lastCell) return false;
+  const startCell=_findMarkdownTableCell(range.startContainer);
+  const endCell=_findMarkdownTableCell(range.endContainer);
+  if(startCell!==firstCell||endCell!==lastCell) return false;
+  return _markdownTableBoundaryWithinCell(range.startContainer, range.startOffset, firstCell, 'start')
+    && _markdownTableBoundaryWithinCell(range.endContainer, range.endOffset, lastCell, 'end');
+}
+
 function _findEnhancedMarkdownTableFromRange(range){
   if(!range) return null;
   const found=_findEnhancedMarkdownTable(range.startContainer)
@@ -569,6 +627,7 @@ function _handleMarkdownTableCopy(event){
   if(startCell&&endCell&&startCell===endCell) return;
   const table=_findEnhancedMarkdownTableFromRange(range);
   if(!table||!table.matches||!table.matches('table[data-markdown-table-enhanced]')) return;
+  if(!_isFullEnhancedMarkdownTableSelection(range, table)) return;
   const payload=_markdownTableCopyPayloadForTable(table);
   if(!payload) return;
   const clipboardData=event.clipboardData||event.originalEvent&&event.originalEvent.clipboardData;

--- a/static/messages.js
+++ b/static/messages.js
@@ -486,11 +486,17 @@ function _markdownTableCopyPayloadForTable(table){
   if(!table||!table.rows) return null;
   const rows=Array.from(table.rows||[]);
   if(!rows.length) return null;
+  let headerRowCount=0;
+  while(headerRowCount<rows.length){
+    const cells=Array.from(rows[headerRowCount].cells||[]);
+    if(!cells.length||!cells.every((cell)=>cell&&cell.tagName==='TH')) break;
+    headerRowCount++;
+  }
 
-  const htmlRows=rows.map((row)=>{
+  const renderRows=(rowSet)=>rowSet.map((row)=>{
     const cellTag=(cell)=>String(cell&&cell.tagName?cell.tagName.toLowerCase():'td');
     const cells=Array.from(row.cells||[])
-      .filter((cell)=>cell&&cell.nodeType===1 || cell&&cell.nodeType===3)
+      .filter((cell)=>cell&&cell.nodeType===1)
       .map((cell)=>{
         const tag=cellTag(cell);
         const text=_sanitizeMarkdownTableCellText(cell);
@@ -499,6 +505,12 @@ function _markdownTableCopyPayloadForTable(table){
       .join('');
     return `<tr>${cells}</tr>`;
   }).join('');
+  const headerRows=headerRowCount?renderRows(rows.slice(0, headerRowCount)):'';
+  const bodyRows=renderRows(rows.slice(headerRowCount));
+  const tableSections=[
+    headerRows?`<thead>${headerRows}</thead>`:'',
+    bodyRows?`<tbody>${bodyRows}</tbody>`:'',
+  ].join('');
 
   const plainRows=rows.map((row)=>{
     return Array.from(row.cells||[])
@@ -506,13 +518,22 @@ function _markdownTableCopyPayloadForTable(table){
       .join('\t');
   }).join('\n');
 
-  return {html:`<table>${htmlRows}</table>`, plain:plainRows};
+  return {html:`<table>${tableSections}</table>`, plain:plainRows};
 }
 
 function _findEnhancedMarkdownTable(node){
   let current=node&&node.nodeType===3?node.parentElement:node;
   while(current){
     if(current.matches&&current.matches('table[data-markdown-table-enhanced]')) return current;
+    current=current.parentElement||current.parentNode;
+  }
+  return null;
+}
+
+function _findMarkdownTableCell(node){
+  let current=node&&node.nodeType===3?node.parentElement:node;
+  while(current){
+    if(current.matches&&current.matches('th,td')) return current;
     current=current.parentElement||current.parentNode;
   }
   return null;
@@ -543,6 +564,9 @@ function _handleMarkdownTableCopy(event){
   if(!selection||selection.isCollapsed||!selection.rangeCount) return;
   const range=selection.getRangeAt(0);
   if(!range) return;
+  const startCell=_findMarkdownTableCell(range.startContainer);
+  const endCell=_findMarkdownTableCell(range.endContainer);
+  if(startCell&&endCell&&startCell===endCell) return;
   const table=_findEnhancedMarkdownTableFromRange(range);
   if(!table||!table.matches||!table.matches('table[data-markdown-table-enhanced]')) return;
   const payload=_markdownTableCopyPayloadForTable(table);

--- a/tests/test_issue4945_markdown_table_copy.py
+++ b/tests/test_issue4945_markdown_table_copy.py
@@ -351,3 +351,34 @@ console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipbo
     )
     assert out["prevented"] is False
     assert out["data"] == {}
+
+
+def test_table_copy_without_clipboard_data_leaves_native_copy_unmodified():
+    out = _run_js(
+        """
+const {table, body} = buildEnhancedTableFixture(true);
+
+const range = {
+  startContainer: body.cells[0].children[0],
+  endContainer: body.cells[1].children[0],
+  commonAncestorContainer: table,
+};
+
+window.getSelection = () => ({
+  isCollapsed: false,
+  rangeCount: 1,
+  getRangeAt: () => range,
+});
+
+const event = {
+  preventDefaultCalled: false,
+  preventDefault() {
+    this.preventDefaultCalled = true;
+  },
+};
+
+_handleMarkdownTableCopy(event);
+console.log(JSON.stringify({ prevented: event.preventDefaultCalled }));
+"""
+    )
+    assert out["prevented"] is False

--- a/tests/test_issue4945_markdown_table_copy.py
+++ b/tests/test_issue4945_markdown_table_copy.py
@@ -382,3 +382,55 @@ console.log(JSON.stringify({ prevented: event.preventDefaultCalled }));
 """
     )
     assert out["prevented"] is False
+
+
+def test_mixed_selection_that_crosses_table_still_sanitizes_table_copy():
+    out = _run_js(
+        """
+const {root, table, body} = buildEnhancedTableFixture(true);
+const before = makeElement('p');
+before.appendChild(new FakeText('before table'));
+const after = makeElement('p');
+after.appendChild(new FakeText('after table'));
+root.children.unshift(before);
+before.parentElement = root;
+before.parentNode = root;
+root.appendChild(after);
+
+const range = {
+  startContainer: before.children[0],
+  endContainer: after.children[0],
+  commonAncestorContainer: root,
+  intersectsNode(node) {
+    return node === table;
+  },
+};
+
+window.getSelection = () => ({
+  isCollapsed: false,
+  rangeCount: 1,
+  getRangeAt: () => range,
+});
+
+const clipboard = {
+  data: {},
+  setData(type, value) {
+    this.data[type] = value;
+  }
+};
+
+const event = {
+  preventDefaultCalled: false,
+  preventDefault() {
+    this.preventDefaultCalled = true;
+  },
+  clipboardData: clipboard,
+};
+
+_handleMarkdownTableCopy(event);
+console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipboard.data }));
+"""
+    )
+    assert out["prevented"] is True
+    assert "<th>Product</th>" in out["data"]["text/html"]
+    assert out["data"]["text/plain"].startswith("Product\tPrice")

--- a/tests/test_issue4945_markdown_table_copy.py
+++ b/tests/test_issue4945_markdown_table_copy.py
@@ -1,0 +1,353 @@
+"""Regression tests for #4945: copy from rendered markdown tables."""
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+MESSAGES_JS = ROOT / "static" / "messages.js"
+NODE = shutil.which("node")
+
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node is required")
+
+
+_DRIVER = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1;
+  i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+
+const required = [
+  '_markdownTableCopyHtmlEscape',
+  '_markdownTableText',
+  '_markdownTableCellText',
+  '_sanitizeMarkdownTableCellText',
+  '_findEnhancedMarkdownTable',
+  '_findEnhancedMarkdownTableFromRange',
+  '_markdownTableCopyPayloadForTable',
+  '_handleMarkdownTableCopy',
+];
+
+for (const name of required) {
+  eval(extractFunc(name));
+}
+
+function toNodeTypeElement(tagName) {
+  return tagName ? 1 : 3;
+}
+
+function classSet(value) {
+  return new Set((value || '').split(/\\s+/).filter(Boolean));
+}
+
+class FakeClassList {
+  constructor(node) {
+    this.node = node;
+  }
+
+  contains(name) {
+    return classSet(this.node.className).has(name);
+  }
+}
+
+class FakeText {
+  constructor(text = '') {
+    this.nodeType = 3;
+    this.textContent = String(text);
+  }
+}
+
+class FakeElement {
+  constructor(tagName = '', {className = '', text = '', attrs = {}} = {}) {
+    this.nodeType = toNodeTypeElement(tagName);
+    this.tagName = tagName ? String(tagName).toUpperCase() : undefined;
+    this.children = [];
+    this.parentElement = null;
+    this.parentNode = null;
+    this.className = className;
+    this._text = text;
+    this.attrs = {...attrs};
+    this.classList = new FakeClassList(this);
+  }
+
+  appendChild(child) {
+    child.parentElement = this;
+    child.parentNode = this;
+    this.children.push(child);
+    if (this.nodeType === 1 && this.tagName && this.tagName.toUpperCase() === 'TR') {
+      if (!this.cells) this.cells = [];
+      if (child.nodeType === 1 && (child.tagName === 'TD' || child.tagName === 'TH')) {
+        this.cells.push(child);
+      }
+    }
+    return child;
+  }
+
+  get textContent() {
+    if (this._text) return this._text;
+    return this.children.map((child) => child.textContent).join('');
+  }
+
+  set textContent(value) {
+    this.children = [new FakeText(String(value))];
+    this.children[0].parentElement = this;
+    this.children[0].parentNode = this;
+    this._text = '';
+  }
+
+  setAttribute(name, value) {
+    this.attrs[name] = String(value);
+  }
+
+  hasAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attrs, name);
+  }
+
+  removeAttribute(name) {
+    delete this.attrs[name];
+  }
+
+  querySelector(selector) {
+    return this.querySelectorAll(selector)[0] || null;
+  }
+
+  querySelectorAll(selector) {
+    const out = [];
+    const walk = (node) => {
+      node.children.forEach((child) => {
+        if (child.nodeType === 1 && child.matches(selector)) {
+          out.push(child);
+        }
+        if (child.children && child.children.length) {
+          walk(child);
+        }
+      });
+    };
+    walk(this);
+    return out;
+  }
+
+  matches(selector) {
+    if (!selector || this.nodeType !== 1) return false;
+    if (selector.startsWith('.')) {
+      return this.classList.contains(selector.slice(1));
+    }
+    const dataMatch = selector.match(/^([a-zA-Z0-9-]+)\[([^=\]]+)(?:=['"]?([^'"]*)['"]?)?\]$/);
+    if (dataMatch) {
+      const tag = dataMatch[1].toUpperCase();
+      const attr = dataMatch[2];
+      const expected = dataMatch[3];
+      if (this.tagName !== tag) return false;
+      if (!Object.prototype.hasOwnProperty.call(this.attrs, attr)) return false;
+      if (!expected) return true;
+      return String(this.attrs[attr]) === expected;
+    }
+    return selector && this.tagName && this.tagName.toLowerCase() === selector.toLowerCase();
+  }
+
+  get rows() {
+    return this._rows || [];
+  }
+
+  set rows(values) {
+    this._rows = values || [];
+  }
+}
+
+function makeElement(tagName, options = {}) {
+  return new FakeElement(tagName, options);
+}
+
+function makeCell(tagName, text, withSortControls = false) {
+  const cell = makeElement(tagName);
+  if (withSortControls) {
+    const button = makeElement('button', {className: 'markdown-table-sort'});
+    const label = makeElement('span', {className: 'markdown-table-sort-label'});
+    label.appendChild(new FakeText(text));
+    const indicator = makeElement('span', {className: 'markdown-table-sort-indicator'});
+    indicator.appendChild(new FakeText('↑'));
+    button.appendChild(label);
+    button.appendChild(indicator);
+    cell.appendChild(button);
+    return cell;
+  }
+  cell.appendChild(new FakeText(text));
+  return cell;
+}
+
+function makeRow(cells) {
+  const row = makeElement('tr');
+  cells.forEach((cell) => row.appendChild(cell));
+  return row;
+}
+
+function buildEnhancedTableFixture(includeFilter) {
+  const root = makeElement('div');
+  if (includeFilter) {
+    const filter = makeElement('input', {className: 'markdown-table-filter'});
+    filter.appendChild(new FakeText('Filter by text'));
+    root.appendChild(filter);
+  }
+
+  const table = makeElement('table', {attrs: {'data-markdown-table-enhanced': '1'}});
+  const header = makeRow([
+    makeCell('th', 'Product', true),
+    makeCell('th', 'Price', true),
+  ]);
+  const body = makeRow([
+    makeCell('td', 'Widget'),
+    makeCell('td', '12'),
+  ]);
+  table.rows = [header, body];
+  root.appendChild(table);
+  return {root, table, header, body};
+}
+
+global.window = {
+  getSelection() {
+    return null;
+  }
+};
+
+"""
+
+
+def _run_js(driver_body: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".cjs", encoding="utf-8", dir=ROOT, delete=False) as handle:
+        handle.write(_DRIVER)
+        handle.write(driver_body)
+        script = Path(handle.name)
+
+    try:
+        result = subprocess.run(
+            [NODE, str(script), str(MESSAGES_JS)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=str(ROOT),
+        )
+    finally:
+        script.unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        raise RuntimeError(f"node helper failed: {result.stderr}")
+    return json.loads(result.stdout.strip())
+
+
+def test_copy_payload_restores_header_row_and_plain_cells():
+    out = _run_js(
+        """
+const {root, table} = buildEnhancedTableFixture(false);
+const payload = _markdownTableCopyPayloadForTable(table);
+console.log(JSON.stringify(payload));
+"""
+    )
+    assert "<th>Product</th>" in out["html"]
+    assert "<th>Price</th>" in out["html"]
+    assert "markdown-table-sort" not in out["html"]
+    assert out["plain"].startswith("Product\tPrice\n")
+    assert "\nWidget\t12" in out["plain"]
+
+
+def test_copy_payload_strips_sort_controls_and_filter_ui():
+    out = _run_js(
+        """
+const {root, table, body} = buildEnhancedTableFixture(true);
+
+const range = {
+  startContainer: body.cells[0].children[0],
+  endContainer: body.cells[1].children[0],
+  commonAncestorContainer: table,
+};
+
+window.getSelection = () => ({
+  isCollapsed: false,
+  rangeCount: 1,
+  getRangeAt: () => range,
+});
+
+const clipboard = {
+  data: {},
+  setData(type, value) {
+    this.data[type] = value;
+  }
+};
+
+const event = {
+  preventDefaultCalled: false,
+  preventDefault() {
+    this.preventDefaultCalled = true;
+  },
+  clipboardData: clipboard,
+};
+
+_handleMarkdownTableCopy(event);
+console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipboard.data }));
+"""
+    )
+    data = out["data"]
+    assert out["prevented"] is True
+    assert "<table>" in data["text/html"]
+    assert "markdown-table-filter" not in data["text/html"]
+    assert "markdown-table-sort" not in data["text/html"]
+    assert out["data"]["text/plain"].startswith("Product\tPrice")
+    assert "Widget" in out["data"]["text/plain"]
+
+
+def test_non_table_selection_leaves_native_copy_unmodified():
+    out = _run_js(
+        """
+const plain = makeElement('p');
+plain.appendChild(new FakeText('plain text'));
+
+const range = {
+  startContainer: plain.children[0],
+  endContainer: plain.children[0],
+  commonAncestorContainer: plain,
+};
+
+window.getSelection = () => ({
+  isCollapsed: false,
+  rangeCount: 1,
+  getRangeAt: () => range,
+});
+
+const clipboard = {
+  data: {},
+  setData(type, value) {
+    this.data[type] = value;
+  }
+};
+
+const event = {
+  preventDefaultCalled: false,
+  preventDefault() {
+    this.preventDefaultCalled = true;
+  },
+  clipboardData: clipboard,
+};
+
+_handleMarkdownTableCopy(event);
+console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipboard.data }));
+"""
+    )
+    assert out["prevented"] is False
+    assert out["data"] == {}

--- a/tests/test_issue4945_markdown_table_copy.py
+++ b/tests/test_issue4945_markdown_table_copy.py
@@ -80,6 +80,11 @@ const required = [
   '_sanitizeMarkdownTableCellText',
   '_findEnhancedMarkdownTable',
   '_findMarkdownTableCell',
+  '_markdownTableNodeChildren',
+  '_markdownTableNodeBoundaryLength',
+  '_markdownTableBoundaryWithinCell',
+  '_markdownTableEdgeCell',
+  '_isFullEnhancedMarkdownTableSelection',
   '_findEnhancedMarkdownTableFromRange',
   '_markdownTableCopyPayloadForTable',
   '_handleMarkdownTableCopy',
@@ -186,6 +191,13 @@ class FakeElement {
 
   matches(selector) {
     if (!selector || this.nodeType !== 1) return false;
+    if (selector.includes(',')) {
+      return selector
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .some((part) => this.matches(part));
+    }
     if (selector.startsWith('.')) {
       return this.classList.contains(selector.slice(1));
     }
@@ -238,7 +250,9 @@ function makeRow(cells) {
   return row;
 }
 
-function buildEnhancedTableFixture(includeFilter) {
+function buildEnhancedTableFixture(includeFilter, options = {}) {
+  const headerTexts = options.headerTexts || ['Product', 'Price'];
+  const bodyTexts = options.bodyTexts || ['Widget', '12'];
   const root = makeElement('div');
   if (includeFilter) {
     const filter = makeElement('input', {className: 'markdown-table-filter'});
@@ -248,12 +262,12 @@ function buildEnhancedTableFixture(includeFilter) {
 
   const table = makeElement('table', {attrs: {'data-markdown-table-enhanced': '1'}});
   const header = makeRow([
-    makeCell('th', 'Product', true),
-    makeCell('th', 'Price', true),
+    makeCell('th', headerTexts[0], true),
+    makeCell('th', headerTexts[1], true),
   ]);
   const body = makeRow([
-    makeCell('td', 'Widget'),
-    makeCell('td', '12'),
+    makeCell('td', bodyTexts[0]),
+    makeCell('td', bodyTexts[1]),
   ]);
   table.rows = [header, body];
   root.appendChild(table);
@@ -294,28 +308,76 @@ def _run_js(driver_body: str):
 def test_copy_payload_restores_header_row_and_plain_cells():
     out = _run_js(
         """
-const {root, table} = buildEnhancedTableFixture(false);
+const {table} = buildEnhancedTableFixture(false, {
+  headerTexts: ['Product <Name>', 'Price & Tax'],
+  bodyTexts: ['Widget > Basic', '12 & change'],
+});
 const payload = _markdownTableCopyPayloadForTable(table);
 console.log(JSON.stringify(payload));
 """
     )
-    assert "<thead><tr><th>Product</th><th>Price</th></tr></thead>" in out["html"]
-    assert "<tbody><tr><td>Widget</td><td>12</td></tr></tbody>" in out["html"]
-    assert "<th>Product</th>" in out["html"]
-    assert "<th>Price</th>" in out["html"]
+    assert "<thead><tr><th>Product &lt;Name&gt;</th><th>Price &amp; Tax</th></tr></thead>" in out["html"]
+    assert "<tbody><tr><td>Widget &gt; Basic</td><td>12 &amp; change</td></tr></tbody>" in out["html"]
     assert "markdown-table-sort" not in out["html"]
-    assert out["plain"].startswith("Product\tPrice\n")
-    assert "\nWidget\t12" in out["plain"]
+    assert out["plain"].startswith("Product <Name>\tPrice & Tax\n")
+    assert "\nWidget > Basic\t12 & change" in out["plain"]
 
 
-def test_copy_payload_strips_sort_controls_and_filter_ui():
+def test_partial_multi_cell_selection_leaves_native_copy_unmodified():
     out = _run_js(
         """
 const {root, table, body} = buildEnhancedTableFixture(true);
 
 const range = {
   startContainer: body.cells[0].children[0],
+  startOffset: 0,
   endContainer: body.cells[1].children[0],
+  endOffset: body.cells[1].children[0].textContent.length,
+  commonAncestorContainer: table,
+};
+
+window.getSelection = () => ({
+  isCollapsed: false,
+  rangeCount: 1,
+  getRangeAt: () => range,
+});
+
+const clipboard = {
+  data: {},
+  setData(type, value) {
+    this.data[type] = value;
+  }
+};
+
+const event = {
+  preventDefaultCalled: false,
+  preventDefault() {
+    this.preventDefaultCalled = true;
+  },
+  clipboardData: clipboard,
+};
+
+_handleMarkdownTableCopy(event);
+console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipboard.data }));
+"""
+    )
+    assert out["prevented"] is False
+    assert out["data"] == {}
+
+
+def test_full_table_selection_exports_sanitized_table_payload():
+    out = _run_js(
+        """
+const {table, header, body} = buildEnhancedTableFixture(true, {
+  headerTexts: ['Product <Name>', 'Price & Tax'],
+  bodyTexts: ['Widget > Basic', '12 & change'],
+});
+
+const range = {
+  startContainer: header.cells[0].children[0].children[0],
+  startOffset: 0,
+  endContainer: body.cells[1].children[0],
+  endOffset: body.cells[1].children[0].textContent.length,
   commonAncestorContainer: table,
 };
 
@@ -347,10 +409,12 @@ console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipbo
     data = out["data"]
     assert out["prevented"] is True
     assert "<table>" in data["text/html"]
+    assert "<thead><tr><th>Product &lt;Name&gt;</th><th>Price &amp; Tax</th></tr></thead>" in data["text/html"]
+    assert "<tbody><tr><td>Widget &gt; Basic</td><td>12 &amp; change</td></tr></tbody>" in data["text/html"]
     assert "markdown-table-filter" not in data["text/html"]
     assert "markdown-table-sort" not in data["text/html"]
-    assert out["data"]["text/plain"].startswith("Product\tPrice")
-    assert "Widget" in out["data"]["text/plain"]
+    assert data["text/plain"].startswith("Product <Name>\tPrice & Tax")
+    assert "\nWidget > Basic\t12 & change" in data["text/plain"]
 
 
 def test_non_table_selection_leaves_native_copy_unmodified():
@@ -361,7 +425,9 @@ plain.appendChild(new FakeText('plain text'));
 
 const range = {
   startContainer: plain.children[0],
+  startOffset: 0,
   endContainer: plain.children[0],
+  endOffset: plain.children[0].textContent.length,
   commonAncestorContainer: plain,
 };
 
@@ -401,7 +467,9 @@ const {table, body} = buildEnhancedTableFixture(true);
 
 const range = {
   startContainer: body.cells[0].children[0],
+  startOffset: 0,
   endContainer: body.cells[1].children[0],
+  endOffset: body.cells[1].children[0].textContent.length,
   commonAncestorContainer: table,
 };
 
@@ -425,7 +493,7 @@ console.log(JSON.stringify({ prevented: event.preventDefaultCalled }));
     assert out["prevented"] is False
 
 
-def test_mixed_selection_that_crosses_table_still_sanitizes_table_copy():
+def test_mixed_selection_that_crosses_table_leaves_native_copy_unmodified():
     out = _run_js(
         """
 const {root, table, body} = buildEnhancedTableFixture(true);
@@ -440,7 +508,9 @@ root.appendChild(after);
 
 const range = {
   startContainer: before.children[0],
+  startOffset: 0,
   endContainer: after.children[0],
+  endOffset: after.children[0].textContent.length,
   commonAncestorContainer: root,
   intersectsNode(node) {
     return node === table;
@@ -472,9 +542,8 @@ _handleMarkdownTableCopy(event);
 console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipboard.data }));
 """
     )
-    assert out["prevented"] is True
-    assert "<th>Product</th>" in out["data"]["text/html"]
-    assert out["data"]["text/plain"].startswith("Product\tPrice")
+    assert out["prevented"] is False
+    assert out["data"] == {}
 
 
 def test_single_cell_subselection_leaves_native_copy_unmodified():
@@ -484,7 +553,9 @@ const {table, body} = buildEnhancedTableFixture(true);
 
 const range = {
   startContainer: body.cells[0].children[0],
+  startOffset: 0,
   endContainer: body.cells[0].children[0],
+  endOffset: body.cells[0].children[0].textContent.length,
   commonAncestorContainer: body.cells[0],
 };
 

--- a/tests/test_issue4945_markdown_table_copy.py
+++ b/tests/test_issue4945_markdown_table_copy.py
@@ -463,10 +463,10 @@ console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipbo
 def test_table_copy_without_clipboard_data_leaves_native_copy_unmodified():
     out = _run_js(
         """
-const {table, body} = buildEnhancedTableFixture(true);
+const {table, header, body} = buildEnhancedTableFixture(true);
 
 const range = {
-  startContainer: body.cells[0].children[0],
+  startContainer: header.cells[0].children[0].children[0],
   startOffset: 0,
   endContainer: body.cells[1].children[0],
   endOffset: body.cells[1].children[0].textContent.length,

--- a/tests/test_issue4945_markdown_table_copy.py
+++ b/tests/test_issue4945_markdown_table_copy.py
@@ -24,15 +24,53 @@ function extractFunc(name) {
   const re = new RegExp('function\\s+' + name + '\\s*\\(');
   const start = src.search(re);
   if (start < 0) throw new Error(name + ' not found');
-  let i = src.indexOf('{', start);
-  let depth = 1;
-  i++;
-  while (depth > 0 && i < src.length) {
-    if (src[i] === '{') depth++;
-    else if (src[i] === '}') depth--;
-    i++;
+  const braceStart = src.indexOf('{', start);
+  let depth = 0;
+  let inString = null;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  for (let i = braceStart; i < src.length; i++) {
+    const ch = src[i];
+    const next = i + 1 < src.length ? src[i + 1] : '';
+    if (inLineComment) {
+      if (ch === '\n') inLineComment = false;
+      continue;
+    }
+    if (inBlockComment) {
+      if (ch === '*' && next === '/') {
+        inBlockComment = false;
+        i++;
+      }
+      continue;
+    }
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === inString) inString = null;
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      inLineComment = true;
+      i++;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      inBlockComment = true;
+      i++;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      inString = ch;
+      continue;
+    }
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
   }
-  return src.slice(start, i);
+  throw new Error(name + ' brace scan failed');
 }
 
 const required = [
@@ -41,6 +79,7 @@ const required = [
   '_markdownTableCellText',
   '_sanitizeMarkdownTableCellText',
   '_findEnhancedMarkdownTable',
+  '_findMarkdownTableCell',
   '_findEnhancedMarkdownTableFromRange',
   '_markdownTableCopyPayloadForTable',
   '_handleMarkdownTableCopy',
@@ -260,6 +299,8 @@ const payload = _markdownTableCopyPayloadForTable(table);
 console.log(JSON.stringify(payload));
 """
     )
+    assert "<thead><tr><th>Product</th><th>Price</th></tr></thead>" in out["html"]
+    assert "<tbody><tr><td>Widget</td><td>12</td></tr></tbody>" in out["html"]
     assert "<th>Product</th>" in out["html"]
     assert "<th>Price</th>" in out["html"]
     assert "markdown-table-sort" not in out["html"]
@@ -434,3 +475,43 @@ console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipbo
     assert out["prevented"] is True
     assert "<th>Product</th>" in out["data"]["text/html"]
     assert out["data"]["text/plain"].startswith("Product\tPrice")
+
+
+def test_single_cell_subselection_leaves_native_copy_unmodified():
+    out = _run_js(
+        """
+const {table, body} = buildEnhancedTableFixture(true);
+
+const range = {
+  startContainer: body.cells[0].children[0],
+  endContainer: body.cells[0].children[0],
+  commonAncestorContainer: body.cells[0],
+};
+
+window.getSelection = () => ({
+  isCollapsed: false,
+  rangeCount: 1,
+  getRangeAt: () => range,
+});
+
+const clipboard = {
+  data: {},
+  setData(type, value) {
+    this.data[type] = value;
+  }
+};
+
+const event = {
+  preventDefaultCalled: false,
+  preventDefault() {
+    this.preventDefaultCalled = true;
+  },
+  clipboardData: clipboard,
+};
+
+_handleMarkdownTableCopy(event);
+console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipboard.data }));
+"""
+    )
+    assert out["prevented"] is False
+    assert out["data"] == {}


### PR DESCRIPTION
## Release YN (v0.51.684) — clean enhanced-table copy

Ships **#4994** (@rodboev) — fixes #4945 (table copy carried dark styling + dropped the header row).

### Gate (converged after a selection-scope bounce)
Prior bounce (both gates reproduced): the interceptor over-broadly captured prose-crossing selections (dropped surrounding prose) and multi-cell partial selections (clobbered to the full table).
- **Codex: SAFE TO SHIP** + **Opus: SHIP IT** — `_isFullEnhancedMarkdownTableSelection()` now gates interception on a true full-table selection (cell-identity + boundary-bubbling check); prose-crossing and partial/sub-cell selections fall through to native copy; full-table selection still gets the sanitized payload (header preserved, chrome stripped, escaped). Both prior bounces genuinely closed; escaping sound; tests non-vacuous.
- **Full suite: 10716 passed**, 0 failures. +588 regression tests (prose-crossing-native, partial-multi-cell-native, full-table-sanitized, escaping).
- Opus noted 2 optional coverage follow-ups (a `<table>`-anchored drag degrades gracefully to native copy; a start-in-cell/end-in-prose case) — non-blocking.

From a fork — release branch carries rodboev's commits; #4994 closed as shipped with credit.
