### PR TITLE
Release YP (v0.51.686): enhanced-table copy boundary-case test coverage (#5013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.686] — 2026-06-26 — Release YP (internal: enhanced-table copy boundary-case test coverage)
+
+### Changed
+
+- **Internal (tests only): added regression coverage for two enhanced-table copy boundary cases** flagged as optional follow-ups when the #4945 fix shipped — a selection anchored on the `<table>` element itself, and a selection that starts in a table cell and ends in surrounding prose. Both must fall through to native copy, and the shipped guard already handles them correctly (verified, no production change). Closes the coverage gap so a future refactor of the copy interceptor can't silently regress these paths. Thanks @rodboev. (#5013, follow-up to #4945/#4994)
+
 ## [v0.51.685] — 2026-06-26 — Release YO (internal: session-list cache extracted to its own module)
 
 ### Changed

--- a/tests/test_issue4945_markdown_table_copy.py
+++ b/tests/test_issue4945_markdown_table_copy.py
@@ -586,3 +586,102 @@ console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipbo
     )
     assert out["prevented"] is False
     assert out["data"] == {}
+
+
+def test_table_element_anchored_selection_leaves_native_copy_unmodified():
+    """#5013: a drag/selection anchored on the <table> element itself (rather than
+    inside corner cells) must fall through to native copy — sanitization only fires
+    for a true full-cell-span selection."""
+    out = _run_js(
+        """
+const {table} = buildEnhancedTableFixture(true);
+
+// Selection anchored on the <table> node itself (a real-browser whole-table drag
+// can land start/end on the table/tr rather than inside the corner text nodes).
+const range = {
+  startContainer: table,
+  startOffset: 0,
+  endContainer: table,
+  endOffset: table.rows.length,
+  commonAncestorContainer: table,
+};
+
+window.getSelection = () => ({
+  isCollapsed: false,
+  rangeCount: 1,
+  getRangeAt: () => range,
+});
+
+const clipboard = {
+  data: {},
+  setData(type, value) {
+    this.data[type] = value;
+  }
+};
+
+const event = {
+  preventDefaultCalled: false,
+  preventDefault() {
+    this.preventDefaultCalled = true;
+  },
+  clipboardData: clipboard,
+};
+
+_handleMarkdownTableCopy(event);
+console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipboard.data }));
+"""
+    )
+    assert out["prevented"] is False
+    assert out["data"] == {}
+
+
+def test_cell_to_prose_selection_leaves_native_copy_unmodified():
+    """#5013: a selection that starts inside a table cell and ends in surrounding
+    prose must fall through to native copy (it is not a full-table selection, and
+    capturing it would clobber the trailing prose)."""
+    out = _run_js(
+        """
+const {root, table, body} = buildEnhancedTableFixture(true);
+const after = makeElement('p');
+after.appendChild(new FakeText('trailing prose'));
+root.appendChild(after);
+
+// Start inside a body cell's text, end in the trailing prose paragraph.
+const range = {
+  startContainer: body.cells[0].children[0],
+  startOffset: 0,
+  endContainer: after.children[0],
+  endOffset: after.children[0].textContent.length,
+  commonAncestorContainer: root,
+  intersectsNode(node) {
+    return node === table;
+  },
+};
+
+window.getSelection = () => ({
+  isCollapsed: false,
+  rangeCount: 1,
+  getRangeAt: () => range,
+});
+
+const clipboard = {
+  data: {},
+  setData(type, value) {
+    this.data[type] = value;
+  }
+};
+
+const event = {
+  preventDefaultCalled: false,
+  preventDefault() {
+    this.preventDefaultCalled = true;
+  },
+  clipboardData: clipboard,
+};
+
+_handleMarkdownTableCopy(event);
+console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipboard.data }));
+"""
+    )
+    assert out["prevented"] is False
+    assert out["data"] == {}


### PR DESCRIPTION
Closes #5013 (rodboev) — adds the two optional coverage follow-ups Opus flagged when #4994 (fixes #4945) shipped:
- a selection anchored on the `<table>` element itself → native fallthrough
- a selection that starts in a cell and ends in surrounding prose → native fallthrough

**Test-only, no production change.** Both cases already fall through correctly against the shipped guard (verified by the new tests passing on current master). Full suite: 10725 passed. Closes the gap so a future copy-interceptor refactor can't silently regress these paths. Credit @rodboev.