### PR TITLE
docs(quickstart): clarify WebUI runs the agent in-process, not via an external API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,19 @@ For self-hosted VM or homelab installs, `ctl.sh` wraps the common daemon lifecyc
 >
 > `./ctl.sh stop` cannot stop a server launched by `bootstrap.py` or `start.sh` directly — it only manages processes it started itself.
 
+> **How chat runs by default.** WebUI runs the Hermes agent in-process, reading
+> your `HERMES_HOME` config directly. It does not connect to an external
+> Hermes/agent OpenAI-compatible API server to run chat. `HERMES_API_URL` is only
+> read by the Tasks/cron health probe and does not route chat.
+>
+> Two options if you run an external endpoint:
+>
+> 1. **Use its models as a chat provider** (supported today): add it in
+>    **Settings → Providers** as a custom OpenAI-compatible provider with
+>    `base_url = http://127.0.0.1:8642/v1` and your bearer token.
+> 2. **Delegate the whole agent loop to an external runtime**: not how Quick Start
+>    works today. Tracked in [#1925](https://github.com/nesquena/hermes-webui/issues/1925).
+
 ### Advanced: dynamic recall prefill & Gateway-backed chat
 
 Two optional, self-hosted-deployment features — attaching dynamic **session-recall prefill** to browser turns (Joplin/Obsidian/Notion/llm-wiki routers), and routing browser chat through a running **Hermes Gateway** — are documented in [`docs/advanced-chat-setup.md`](docs/advanced-chat-setup.md). Most users need neither.

--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ For self-hosted VM or homelab installs, `ctl.sh` wraps the common daemon lifecyc
 > 1. **Use its models as a chat provider** (supported today): add it in
 >    **Settings → Providers** as a custom OpenAI-compatible provider with
 >    `base_url = http://127.0.0.1:8642/v1` and your bearer token.
-> 2. **Delegate the whole agent loop to an external runtime**: not how Quick Start
->    works today. Tracked in [#1925](https://github.com/nesquena/hermes-webui/issues/1925).
+> 2. **Route chat through a Hermes Gateway API server** (supported today via
+>    `HERMES_WEBUI_CHAT_BACKEND=gateway`): see [`docs/advanced-chat-setup.md`](docs/advanced-chat-setup.md).
+>    Full agent-loop delegation is not yet shipped; tracked in [#1925](https://github.com/nesquena/hermes-webui/issues/1925).
 
 ### Advanced: dynamic recall prefill & Gateway-backed chat
 


### PR DESCRIPTION
### Thinking Path

- Issue #3873: a user expected WebUI chat to connect to an external OpenAI-compatible API server via `HERMES_API_URL`
- @nesquena-hermes clarified in the thread: chat runs in-process by default (reads `HERMES_HOME` directly); `HERMES_API_URL` is consumed only by the Tasks/cron health probe in `api/agent_health.py` and never routes chat
- Issue labeled `documentation`; maintainer asked for a PR to fold this into Quick Start

### What Changed

Added a blockquote callout to README.md Quick Start, placed after the stop-server note and before the existing `### Advanced` subsection. The callout covers:

- Chat runs in-process by default, reading `HERMES_HOME` config directly
- Two options for users who run an external endpoint: add it as a provider in Settings, or follow RFC [#1925](https://github.com/nesquena/hermes-webui/issues/1925) for full external delegation (not yet shipped)

### Why It Matters

The Quick Start is the first place a new user lands. Without this note, a user who sets `HERMES_API_URL` expecting it to wire up chat gets no feedback. The fix puts the answer at the point of confusion.

### Verification

- Markdown renders correctly
- Both links resolve: [#1925](https://github.com/nesquena/hermes-webui/issues/1925) (open tracking RFC), [`docs/advanced-chat-setup.md`](docs/advanced-chat-setup.md) (exists in repo)
- No code touched; `./scripts/test.sh` passes unaffected

### Risks / Follow-ups

- Docs-only change; no functional risk
- Possible follow-up: add `HERMES_API_URL` to the env-var reference table in README (out of scope here)

### Model Used

Provider: Anthropic. Model: claude-sonnet-4-6. Used for planning and drafting. Facts verified directly from source (`api/gateway_chat.py`, `api/agent_health.py`).

---

Closes #3873