### PR TITLE
Release YR (v0.51.688): README clarify in-process chat + HERMES_API_URL scope (#5015)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.688] — 2026-06-26 — Release YR (docs: clarify how WebUI chat runs by default)
+
+### Changed
+
+- **README: clarified that WebUI runs the Hermes agent in-process by default** (reading `HERMES_HOME` directly) rather than connecting to an external Hermes/agent OpenAI-compatible API server, and that `HERMES_API_URL` is only read by the Tasks/cron health probe — it does not route chat. Documents the two supported options for an external endpoint (add it as a custom OpenAI-compatible chat provider, or route chat through a Hermes Gateway via `HERMES_WEBUI_CHAT_BACKEND=gateway`, see `docs/advanced-chat-setup.md`). Addresses a recurring user confusion (#3873). Thanks @sr-dotcom. (#5015)
+
 ## [v0.51.687] — 2026-06-26 — Release YQ (system-health CPU/RAM metrics work on macOS and other non-procfs platforms)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -145,6 +145,19 @@ For self-hosted VM or homelab installs, `ctl.sh` wraps the common daemon lifecyc
 >
 > `./ctl.sh stop` cannot stop a server launched by `bootstrap.py` or `start.sh` directly — it only manages processes it started itself.
 
+> **How chat runs by default.** WebUI runs the Hermes agent in-process, reading
+> your `HERMES_HOME` config directly. It does not connect to an external
+> Hermes/agent OpenAI-compatible API server to run chat. `HERMES_API_URL` is only
+> read by the Tasks/cron health probe and does not route chat.
+>
+> Two options if you run an external endpoint:
+>
+> 1. **Use its models as a chat provider** (supported today): add it in
+>    **Settings → Providers** as a custom OpenAI-compatible provider with
+>    `base_url = http://127.0.0.1:8642/v1` and your bearer token.
+> 2. **Delegate the whole agent loop to an external runtime**: not how Quick Start
+>    works today. Tracked in [#1925](https://github.com/nesquena/hermes-webui/issues/1925).
+
 ### Advanced: dynamic recall prefill & Gateway-backed chat
 
 Two optional, self-hosted-deployment features — attaching dynamic **session-recall prefill** to browser turns (Joplin/Obsidian/Notion/llm-wiki routers), and routing browser chat through a running **Hermes Gateway** — are documented in [`docs/advanced-chat-setup.md`](docs/advanced-chat-setup.md). Most users need neither.

--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ For self-hosted VM or homelab installs, `ctl.sh` wraps the common daemon lifecyc
 > 1. **Use its models as a chat provider** (supported today): add it in
 >    **Settings → Providers** as a custom OpenAI-compatible provider with
 >    `base_url = http://127.0.0.1:8642/v1` and your bearer token.
-> 2. **Delegate the whole agent loop to an external runtime**: not how Quick Start
->    works today. Tracked in [#1925](https://github.com/nesquena/hermes-webui/issues/1925).
+> 2. **Route chat through a Hermes Gateway API server** (supported today via
+>    `HERMES_WEBUI_CHAT_BACKEND=gateway`): see [`docs/advanced-chat-setup.md`](docs/advanced-chat-setup.md).
+>    Full agent-loop delegation is not yet shipped; tracked in [#1925](https://github.com/nesquena/hermes-webui/issues/1925).
 
 ### Advanced: dynamic recall prefill & Gateway-backed chat
 


### PR DESCRIPTION
Ships #5015 (@sr-dotcom) — README clarification addressing recurring confusion (#3873) about how WebUI chat runs.

**Docs-only (+14/-0, README.md).** All four technical claims verified against the codebase before shipping:
- HERMES_API_URL is read only by api/agent_health.py (Tasks/cron health probe), priority GATEWAY_HEALTH_URL > HERMES_GATEWAY_HEALTH_URL > HERMES_API_URL — not the chat path ✓
- HERMES_WEBUI_CHAT_BACKEND=gateway exists (api/gateway_chat.py:37, accepts gateway/api_server) ✓
- docs/advanced-chat-setup.md exists ✓
- #1925 is OPEN (RFC: thin observability/control client) — tracks agent-loop delegation ✓

19 README-referencing tests pass; full suite running. From a fork — release branch carries the commit; #5015 closed as shipped with credit.