### PR TITLE
Release YS (v0.51.689): bounded post-upgrade active-profile 401 recovery (#5018, fixes #5001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.689] — 2026-06-26 — Release YS (WebUI no longer gets stuck in a 401 loop after an upgrade)
+
+### Fixed
+
+- **WebUI no longer hangs in a repeating `401` loop on `GET /api/profile/active` after an upgrade.** The boot path inherited the shared `api()` helper's automatic 401→login redirect and kept retrying the active-profile bootstrap read without a bounded decision, so a post-upgrade session-not-re-established state could spin indefinitely and leave the app unresponsive. The bootstrap read now opts out of the automatic redirect (`redirect401: false`, scoped to this one call) and a dedicated `_resolveActiveProfileBootstrapState()` makes a one-shot recovery decision: on the first 401 it redirects to login once; if that's already been attempted it falls back to the default profile for display. The one-shot marker is cleared on both success and fallback, so a recovered/re-logged-in user re-establishes their real profile normally — and a genuinely logged-out user still gets the normal login redirect (server auth/profile cookies remain authoritative; the fallback is display-state only). Reported by the community. Thanks @rodboev. (#5018, fixes #5001)
+
 ## [v0.51.688] — 2026-06-26 — Release YR (docs: clarify how WebUI chat runs by default)
 
 ### Changed

--- a/static/boot.js
+++ b/static/boot.js
@@ -2261,7 +2261,30 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
     api(_checkUrl,{method:_testUpdates?'GET':'POST',body:_testUpdates?undefined:JSON.stringify({force:false})}).then(d=>{if(!_testUpdates)sessionStorage.setItem('hermes-update-checked','1');if((d.webui&&d.webui.behind>0)||(d.agent&&d.agent.behind>0))_showUpdateBanner(d);}).catch(()=>{});
   }
   async function _resolveActiveProfileBootstrapState({
-    loadActiveProfile = () => api('/api/profile/active'),
+    loadActiveProfile = async () => {
+      const rel = 'api/profile/active';
+      const url = new URL(rel, document.baseURI || location.href);
+      const res = await fetch(url.href, {
+        credentials: 'include',
+        headers: {'Content-Type': 'application/json'},
+      });
+      if (res.status === 401) return undefined;
+      if (!res.ok) {
+        const text = await res.text();
+        let message = text;
+        try {
+          const j = JSON.parse(text);
+          message = j.error || j.message || text;
+        } catch (_) {}
+        const err = new Error(message);
+        err.status = res.status;
+        err.statusText = res.statusText;
+        err.body = text;
+        throw err;
+      }
+      const ct = res.headers.get('content-type') || '';
+      return ct.includes('application/json') ? await res.json() : await res.text();
+    },
     getNextUrl = () => window.location.pathname + window.location.search,
     redirectToLogin = (nextUrl) => {
       window.location.href = 'login?next=' + encodeURIComponent(nextUrl);

--- a/static/boot.js
+++ b/static/boot.js
@@ -2261,30 +2261,7 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
     api(_checkUrl,{method:_testUpdates?'GET':'POST',body:_testUpdates?undefined:JSON.stringify({force:false})}).then(d=>{if(!_testUpdates)sessionStorage.setItem('hermes-update-checked','1');if((d.webui&&d.webui.behind>0)||(d.agent&&d.agent.behind>0))_showUpdateBanner(d);}).catch(()=>{});
   }
   async function _resolveActiveProfileBootstrapState({
-    loadActiveProfile = async () => {
-      const rel = 'api/profile/active';
-      const url = new URL(rel, document.baseURI || location.href);
-      const res = await fetch(url.href, {
-        credentials: 'include',
-        headers: {'Content-Type': 'application/json'},
-      });
-      if (res.status === 401) return undefined;
-      if (!res.ok) {
-        const text = await res.text();
-        let message = text;
-        try {
-          const j = JSON.parse(text);
-          message = j.error || j.message || text;
-        } catch (_) {}
-        const err = new Error(message);
-        err.status = res.status;
-        err.statusText = res.statusText;
-        err.body = text;
-        throw err;
-      }
-      const ct = res.headers.get('content-type') || '';
-      return ct.includes('application/json') ? await res.json() : await res.text();
-    },
+    loadActiveProfile = () => api('/api/profile/active', {redirect401: false}),
     getNextUrl = () => window.location.pathname + window.location.search,
     redirectToLogin = (nextUrl) => {
       window.location.href = 'login?next=' + encodeURIComponent(nextUrl);

--- a/static/boot.js
+++ b/static/boot.js
@@ -2260,9 +2260,65 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
     const _checkUrl='api/updates/check'+(_testUpdates?'?simulate=1':'');
     api(_checkUrl,{method:_testUpdates?'GET':'POST',body:_testUpdates?undefined:JSON.stringify({force:false})}).then(d=>{if(!_testUpdates)sessionStorage.setItem('hermes-update-checked','1');if((d.webui&&d.webui.behind>0)||(d.agent&&d.agent.behind>0))_showUpdateBanner(d);}).catch(()=>{});
   }
+  async function _resolveActiveProfileBootstrapState({
+    loadActiveProfile = () => api('/api/profile/active'),
+    getNextUrl = () => window.location.pathname + window.location.search,
+    redirectToLogin = (nextUrl) => {
+      window.location.href = 'login?next=' + encodeURIComponent(nextUrl);
+    },
+    markerStorage = sessionStorage,
+    markerKey = 'hermes-webui-active-profile-bootstrap-401',
+  } = {}) {
+    const getAttempted = () => {
+      try {
+        return markerStorage && markerStorage.getItem
+          ? markerStorage.getItem(markerKey) === '1'
+          : false;
+      } catch (_) {
+        return false;
+      }
+    };
+    const markAttempt = () => {
+      try {
+        if (markerStorage && markerStorage.setItem) markerStorage.setItem(markerKey, '1');
+      } catch (_) {}
+    };
+    const clearAttempt = () => {
+      try {
+        if (markerStorage && markerStorage.removeItem) markerStorage.removeItem(markerKey);
+      } catch (_) {}
+    };
+
+    const alreadyAttempted = getAttempted();
+    try {
+      const p = await loadActiveProfile();
+      if (p && typeof p === 'object' && typeof p.name === 'string') {
+        clearAttempt();
+        return {status: 'resolved', profile: p.name || 'default', isDefault: !!p.is_default};
+      }
+      if (p === undefined && !alreadyAttempted) {
+        markAttempt();
+        redirectToLogin(getNextUrl());
+        return {status: 'recovery-redirect'};
+      }
+      clearAttempt();
+      return {status: 'fallback', profile: 'default', isDefault: true};
+    } catch (e) {
+      clearAttempt();
+      if (!alreadyAttempted && e && e.status === 401) {
+        markAttempt();
+        redirectToLogin(getNextUrl());
+        return {status: 'recovery-redirect'};
+      }
+      return {status: 'fallback', profile: 'default', isDefault: true};
+    }
+  }
+
   // Fetch active profile
-  try{const p=await api('/api/profile/active');S.activeProfile=p.name||'default';S.activeProfileIsDefault=!!p.is_default;}catch(e){S.activeProfile='default';S.activeProfileIsDefault=true;}
-  applyBotName();
+  const activeProfileState = await _resolveActiveProfileBootstrapState();
+  if (activeProfileState.status === 'recovery-redirect') return;
+  S.activeProfile = activeProfileState.profile;
+  S.activeProfileIsDefault = activeProfileState.isDefault;
   // Update profile chip label immediately
   const profileLabel=$('profileChipLabel');
   if(profileLabel) profileLabel.textContent=S.activeProfile||'default';

--- a/static/boot.js
+++ b/static/boot.js
@@ -2319,6 +2319,7 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
   if (activeProfileState.status === 'recovery-redirect') return;
   S.activeProfile = activeProfileState.profile;
   S.activeProfileIsDefault = activeProfileState.isDefault;
+  applyBotName();
   // Update profile chip label immediately
   const profileLabel=$('profileChipLabel');
   if(profileLabel) profileLabel.textContent=S.activeProfile||'default';

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -4,6 +4,7 @@ async function api(path,opts={}){
   const url=new URL(rel,document.baseURI||location.href);
   const timeoutMs=Object.prototype.hasOwnProperty.call(opts,'timeoutMs')?opts.timeoutMs:30000;
   const timeoutToast=opts.timeoutToast!==false;
+  const redirect401=opts.redirect401!==false;
   const maxAttempts=Object.prototype.hasOwnProperty.call(opts,'retries')?Math.max(0,Number(opts.retries)||0)+1:3;
   const retryTimeouts=opts.retryTimeouts===true;
   const retryStatuses=Array.isArray(opts.retryStatuses)?opts.retryStatuses.map(Number).filter(Number.isFinite):[];
@@ -21,6 +22,7 @@ async function api(path,opts={}){
       const fetchOpts={...opts};
       delete fetchOpts.timeoutMs;
       delete fetchOpts.timeoutToast;
+      delete fetchOpts.redirect401;
       delete fetchOpts.retries;
       delete fetchOpts.retryTimeouts;
       delete fetchOpts.retryStatuses;
@@ -43,7 +45,10 @@ async function api(path,opts={}){
           // 401 means the auth session expired. Redirect to login so the user can
           // re-authenticate. This is especially important for iOS PWA (standalone mode)
           // and for subpath mounts like /hermes/, where /login escapes to the site root.
-          if(res.status===401){window.location.href='login?next='+encodeURIComponent(window.location.pathname+window.location.search);return;}
+          if(res.status===401){
+            if(redirect401) window.location.href='login?next='+encodeURIComponent(window.location.pathname+window.location.search);
+            return;
+          }
           const text=await res.text();
           // Parse JSON error body and surface the human-readable message,
           // rather than showing raw JSON like {"error":"Profile 'x' does not exist."}

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -47,6 +47,7 @@ async function api(path,opts={}){
           // and for subpath mounts like /hermes/, where /login escapes to the site root.
           if(res.status===401){
             if(redirect401) window.location.href='login?next='+encodeURIComponent(window.location.pathname+window.location.search);
+            // Callers can opt out of navigation and handle the unauthenticated state themselves.
             return;
           }
           const text=await res.text();

--- a/tests/test_5001_active_profile_recovery.py
+++ b/tests/test_5001_active_profile_recovery.py
@@ -115,6 +115,35 @@ function makeFetchResponse(attempt) {
   };
 }
 
+function makeApiAttempt(attempt) {
+  return async function (_path, opts = {}) {
+    if (!opts || opts.redirect401 !== false) {
+      throw new Error('expected redirect401:false for active-profile bootstrap');
+    }
+    const response = makeFetchResponse(attempt);
+    if (response.status === 401) {
+      return undefined;
+    }
+    if (!response.ok) {
+      const text = await response.text();
+      let message = text;
+      try {
+        const parsed = JSON.parse(text);
+        message = parsed.error || parsed.message || text;
+      } catch (_) {}
+      const error = new Error(message);
+      error.status = response.status;
+      error.statusText = response.statusText;
+      error.body = text;
+      throw error;
+    }
+    const ct = response.headers.get('content-type') || '';
+    return ct.includes('application/json')
+      ? await response.json()
+      : await response.text();
+  };
+}
+
 eval(extractFunction(bootSrc, '_resolveActiveProfileBootstrapState'));
 const bootActiveProfileBlock = extractBlock(
   bootSrc,
@@ -145,7 +174,7 @@ return (async () => {
 
   for (const attempt of attempts) {
     const nextUrl = attempt.nextUrl || '/';
-    const originalFetch = globalThis.fetch;
+    const originalApi = globalThis.api;
     const originalWindow = globalThis.window;
     const originalLocation = globalThis.location;
     const originalDocument = globalThis.document;
@@ -153,15 +182,7 @@ return (async () => {
 
     try {
       if (scenario.useDefaultLoader) {
-        const location = {
-          href: `http://example.test${nextUrl}`,
-          pathname: nextUrl,
-          search: '',
-        };
-        globalThis.fetch = async () => makeFetchResponse(attempt);
-        globalThis.location = location;
-        globalThis.document = {baseURI: 'http://example.test/'};
-        globalThis.window = {location};
+        globalThis.api = makeApiAttempt(attempt);
         state = await _resolveActiveProfileBootstrapState({
           markerStorage: storage,
           markerKey,
@@ -169,7 +190,6 @@ return (async () => {
           redirectToLogin: (value) => {
             const href = `login?next=${encodeURIComponent(value)}`;
             redirectUrls.push(href);
-            location.href = href;
           },
         });
       } else {
@@ -184,7 +204,7 @@ return (async () => {
         });
       }
     } finally {
-      globalThis.fetch = originalFetch;
+      globalThis.api = originalApi;
       globalThis.window = originalWindow;
       globalThis.location = originalLocation;
       globalThis.document = originalDocument;

--- a/tests/test_5001_active_profile_recovery.py
+++ b/tests/test_5001_active_profile_recovery.py
@@ -91,6 +91,30 @@ function makeAttempt(attempt) {
   };
 }
 
+function makeFetchResponse(attempt) {
+  const status = attempt.status === undefined ? 200 : attempt.status;
+  const payload = Object.prototype.hasOwnProperty.call(attempt, 'payload')
+    ? attempt.payload
+    : {name: 'default', is_default: true};
+  const textBody = Object.prototype.hasOwnProperty.call(attempt, 'text')
+    ? attempt.text
+    : JSON.stringify(payload);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: attempt.statusText || '',
+    headers: {
+      get(name) {
+        return String(name).toLowerCase() === 'content-type'
+          ? attempt.contentType || 'application/json'
+          : '';
+      },
+    },
+    json: async () => payload,
+    text: async () => textBody,
+  };
+}
+
 eval(extractFunction(bootSrc, '_resolveActiveProfileBootstrapState'));
 const bootActiveProfileBlock = extractBlock(
   bootSrc,
@@ -120,15 +144,52 @@ return (async () => {
   const storageHistory = [];
 
   for (const attempt of attempts) {
-    const state = await _resolveActiveProfileBootstrapState({
-      loadActiveProfile: makeAttempt(attempt),
-      markerStorage: storage,
-      markerKey,
-      getNextUrl: () => attempt.nextUrl || '/',
-      redirectToLogin: (nextUrl) => {
-        redirectUrls.push(`login?next=${encodeURIComponent(nextUrl)}`);
-      },
-    });
+    const nextUrl = attempt.nextUrl || '/';
+    const originalFetch = globalThis.fetch;
+    const originalWindow = globalThis.window;
+    const originalLocation = globalThis.location;
+    const originalDocument = globalThis.document;
+    let state;
+
+    try {
+      if (scenario.useDefaultLoader) {
+        const location = {
+          href: `http://example.test${nextUrl}`,
+          pathname: nextUrl,
+          search: '',
+        };
+        globalThis.fetch = async () => makeFetchResponse(attempt);
+        globalThis.location = location;
+        globalThis.document = {baseURI: 'http://example.test/'};
+        globalThis.window = {location};
+        state = await _resolveActiveProfileBootstrapState({
+          markerStorage: storage,
+          markerKey,
+          getNextUrl: () => nextUrl,
+          redirectToLogin: (value) => {
+            const href = `login?next=${encodeURIComponent(value)}`;
+            redirectUrls.push(href);
+            location.href = href;
+          },
+        });
+      } else {
+        state = await _resolveActiveProfileBootstrapState({
+          loadActiveProfile: makeAttempt(attempt),
+          markerStorage: storage,
+          markerKey,
+          getNextUrl: () => nextUrl,
+          redirectToLogin: (value) => {
+            redirectUrls.push(`login?next=${encodeURIComponent(value)}`);
+          },
+        });
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.window = originalWindow;
+      globalThis.location = originalLocation;
+      globalThis.document = originalDocument;
+    }
+
     const bootState = {};
     let applyBotNameCalls = 0;
     const bootResult = await runBootActiveProfileBlock(
@@ -194,9 +255,10 @@ def test_active_profile_boot_recovery_is_one_shot_and_bounded(driver_path):
         driver_path,
         {
             "markerKey": "test-5001-active-profile-recovery",
+            "useDefaultLoader": True,
             "attempts": [
-                {"type": "undefined", "nextUrl": "/"},
-                {"type": "undefined", "nextUrl": "/"},
+                {"status": 401, "payload": {"error": "Authentication required"}, "nextUrl": "/"},
+                {"status": 401, "payload": {"error": "Authentication required"}, "nextUrl": "/"},
             ],
         },
     )
@@ -255,8 +317,9 @@ def test_active_profile_boot_non_401_errors_fallback_without_redirect(driver_pat
         driver_path,
         {
             "markerKey": "test-5001-active-profile-recovery-non-401",
+            "useDefaultLoader": True,
             "attempts": [
-                {"type": "error", "status": 500, "nextUrl": "/"},
+                {"status": 500, "payload": {"error": "server failure"}, "nextUrl": "/"},
             ],
         },
     )
@@ -278,8 +341,9 @@ def test_active_profile_boot_invalid_payload_falls_back_without_redirect(driver_
         driver_path,
         {
             "markerKey": "test-5001-active-profile-recovery-invalid-payload",
+            "useDefaultLoader": True,
             "attempts": [
-                {"type": "return", "value": {"is_default": False}, "nextUrl": "/"},
+                {"status": 200, "payload": {"is_default": False}, "nextUrl": "/"},
             ],
         },
     )
@@ -301,10 +365,10 @@ def test_active_profile_success_path_applies_boot_state_and_continues(driver_pat
         driver_path,
         {
             "markerKey": "test-5001-active-profile-recovery-success",
-            "simulateBootContinue": True,
+            "useDefaultLoader": True,
             "attempts": [
                 {
-                    "type": "success",
+                    "status": 200,
                     "payload": {"name": "team-profile", "is_default": False},
                 }
             ],

--- a/tests/test_5001_active_profile_recovery.py
+++ b/tests/test_5001_active_profile_recovery.py
@@ -1,0 +1,203 @@
+"""Behavioural checks for #5001 active-profile recovery."""
+
+import json
+import subprocess
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+BOOT_JS = ROOT / "static" / "boot.js"
+NODE = shutil.which("node")
+
+
+pytestmark = pytest.mark.skipif(
+    NODE is None,
+    reason="node is required to execute boot.js recovery-path behavior",
+)
+
+
+_BOOT_DRIVER = r"""
+const fs = require('fs');
+const bootSrc = fs.readFileSync(process.argv[2], 'utf8');
+const scenario = JSON.parse(process.argv[3] || '{}');
+
+function extractFunction(source, name) {
+  const marker = `async function ${name}`;
+  const start = source.indexOf(marker);
+  if (start < 0) {
+    throw new Error(`missing function: ${name}`);
+  }
+  const end = source.indexOf('\n  // Fetch active profile', start);
+  if (end < 0) {
+    throw new Error(`missing marker following function: ${name}`);
+  }
+  return source.slice(start, end);
+}
+
+class FakeStorage {
+  constructor(seed = {}) {
+    this.store = { ...seed };
+  }
+
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this.store, key)
+      ? this.store[key]
+      : null;
+  }
+
+  setItem(key, value) {
+    this.store[key] = String(value);
+  }
+
+  removeItem(key) {
+    delete this.store[key];
+  }
+
+  snapshot() {
+    return { ...this.store };
+  }
+}
+
+function makeAttempt(attempt) {
+  return async function () {
+    if (attempt.type === 'success') {
+      const payload = attempt.payload || {name: 'default', is_default: true};
+      return payload;
+    }
+    if (attempt.type === 'undefined') {
+      return undefined;
+    }
+    const error = new Error(attempt.message || 'active profile bootstrap failure');
+    if (attempt.status !== undefined) error.status = attempt.status;
+    throw error;
+  };
+}
+
+eval(extractFunction(bootSrc, '_resolveActiveProfileBootstrapState'));
+
+(async () => {
+  const attempts = Array.isArray(scenario.attempts) ? scenario.attempts : [];
+  const markerKey =
+    scenario.markerKey || 'hermes-webui-active-profile-bootstrap-401';
+  const storage = new FakeStorage(scenario.initialStorage || {});
+  const redirectUrls = [];
+  const results = [];
+  const storageHistory = [];
+
+  let applyBotNameCalls = 0;
+  let bootProfile = null;
+  let bootIsDefault = null;
+
+  for (const attempt of attempts) {
+    const state = await _resolveActiveProfileBootstrapState({
+      loadActiveProfile: makeAttempt(
+        attempt,
+        storage,
+        markerKey,
+        redirectUrls,
+        attempt.nextUrl || '/'
+      ),
+      markerStorage: storage,
+      markerKey,
+      getNextUrl: () => attempt.nextUrl || '/',
+      redirectToLogin: (nextUrl) => {
+        redirectUrls.push(`login?next=${encodeURIComponent(nextUrl)}`);
+      },
+    });
+
+    results.push(state);
+    storageHistory.push(storage.snapshot());
+
+    if (scenario.simulateBootContinue && state.status === 'resolved') {
+      bootProfile = state.profile;
+      bootIsDefault = state.isDefault;
+      applyBotNameCalls += 1;
+    }
+  }
+
+  console.log(
+    JSON.stringify({
+      attempts: results,
+      redirects: redirectUrls,
+      storageHistory,
+      storageSnapshot: storage.snapshot(),
+      loadCalls: attempts.length,
+      bootProfile,
+      bootIsDefault,
+      applyBotNameCalls,
+    })
+  );
+})();
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    path = tmp_path_factory.mktemp("boot-profile-driver") / "boot_profile_driver.js"
+    path.write_text(_BOOT_DRIVER, encoding="utf-8")
+    return str(path)
+
+
+def _run_boot_profile_scenario(driver_path, scenario):
+    process = subprocess.run(
+        [NODE, driver_path, str(BOOT_JS), json.dumps(scenario)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if process.returncode != 0:
+        raise RuntimeError(f"node profile driver failed: {process.stderr.strip()}")
+    return json.loads(process.stdout)
+
+
+def test_active_profile_boot_recovery_is_one_shot_and_bounded(driver_path):
+    payload = _run_boot_profile_scenario(
+        driver_path,
+        {
+            "markerKey": "test-5001-active-profile-recovery",
+            "attempts": [
+                {"type": "error", "status": 401, "nextUrl": "/"},
+                {"type": "error", "status": 401, "nextUrl": "/"},
+            ],
+        },
+    )
+
+    assert payload["attempts"][0]["status"] == "recovery-redirect"
+    assert payload["attempts"][1]["status"] == "fallback"
+    assert payload["attempts"][1]["profile"] == "default"
+    assert payload["attempts"][1]["isDefault"] is True
+    assert payload["loadCalls"] == 2
+    assert payload["redirects"] == ["login?next=%2F"]
+    assert payload["storageHistory"][0].get("test-5001-active-profile-recovery") == "1"
+    assert payload["storageHistory"][1].get("test-5001-active-profile-recovery") is None
+    assert payload["storageSnapshot"] == {}
+
+
+def test_active_profile_success_path_applies_boot_state_and_continues(driver_path):
+    payload = _run_boot_profile_scenario(
+        driver_path,
+        {
+            "markerKey": "test-5001-active-profile-recovery-success",
+            "simulateBootContinue": True,
+            "attempts": [
+                {
+                    "type": "success",
+                    "payload": {"name": "team-profile", "is_default": False},
+                }
+            ],
+        },
+    )
+
+    assert payload["attempts"][0]["status"] == "resolved"
+    assert payload["attempts"][0]["profile"] == "team-profile"
+    assert payload["attempts"][0]["isDefault"] is False
+    assert payload["bootProfile"] == "team-profile"
+    assert payload["bootIsDefault"] is False
+    assert payload["applyBotNameCalls"] == 1
+    assert payload["redirects"] == []
+    assert payload["storageHistory"][0].get("test-5001-active-profile-recovery-success") is None
+    assert payload["storageSnapshot"] == {}

--- a/tests/test_5001_active_profile_recovery.py
+++ b/tests/test_5001_active_profile_recovery.py
@@ -37,6 +37,18 @@ function extractFunction(source, name) {
   return source.slice(start, end);
 }
 
+function extractBlock(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  if (start < 0) {
+    throw new Error(`missing block start: ${startMarker}`);
+  }
+  const end = source.indexOf(endMarker, start);
+  if (end < 0) {
+    throw new Error(`missing block end: ${endMarker}`);
+  }
+  return source.slice(start, end);
+}
+
 class FakeStorage {
   constructor(seed = {}) {
     this.store = { ...seed };
@@ -80,6 +92,23 @@ function makeAttempt(attempt) {
 }
 
 eval(extractFunction(bootSrc, '_resolveActiveProfileBootstrapState'));
+const bootActiveProfileBlock = extractBlock(
+  bootSrc,
+  'const activeProfileState = await _resolveActiveProfileBootstrapState();',
+  '\n  // Update profile chip label immediately'
+);
+const runBootActiveProfileBlock = new Function(
+  'resolveState',
+  'S',
+  'applyBotName',
+  `
+const _resolveActiveProfileBootstrapState = resolveState;
+return (async () => {
+  ${bootActiveProfileBlock}
+  return {continued: true};
+})();
+`
+);
 
 (async () => {
   const attempts = Array.isArray(scenario.attempts) ? scenario.attempts : [];
@@ -89,10 +118,6 @@ eval(extractFunction(bootSrc, '_resolveActiveProfileBootstrapState'));
   const redirectUrls = [];
   const results = [];
   const storageHistory = [];
-
-  let applyBotNameCalls = 0;
-  let bootProfile = null;
-  let bootIsDefault = null;
 
   for (const attempt of attempts) {
     const state = await _resolveActiveProfileBootstrapState({
@@ -104,16 +129,31 @@ eval(extractFunction(bootSrc, '_resolveActiveProfileBootstrapState'));
         redirectUrls.push(`login?next=${encodeURIComponent(nextUrl)}`);
       },
     });
-    const bootContinues = state.status !== 'recovery-redirect';
+    const bootState = {};
+    let applyBotNameCalls = 0;
+    const bootResult = await runBootActiveProfileBlock(
+      async () => state,
+      bootState,
+      () => {
+        applyBotNameCalls += 1;
+      }
+    );
 
-    results.push({...state, bootContinues});
+    results.push({
+      ...state,
+      bootContinues: !!(bootResult && bootResult.continued === true),
+      bootProfile: Object.prototype.hasOwnProperty.call(bootState, 'activeProfile')
+        ? bootState.activeProfile
+        : null,
+      bootIsDefault: Object.prototype.hasOwnProperty.call(
+        bootState,
+        'activeProfileIsDefault'
+      )
+        ? bootState.activeProfileIsDefault
+        : null,
+      applyBotNameCalls,
+    });
     storageHistory.push(storage.snapshot());
-
-    if (scenario.simulateBootContinue && bootContinues) {
-      bootProfile = state.profile;
-      bootIsDefault = state.isDefault;
-      applyBotNameCalls += 1;
-    }
   }
 
   console.log(
@@ -123,9 +163,6 @@ eval(extractFunction(bootSrc, '_resolveActiveProfileBootstrapState'));
       storageHistory,
       storageSnapshot: storage.snapshot(),
       loadCalls: attempts.length,
-      bootProfile,
-      bootIsDefault,
-      applyBotNameCalls,
     })
   );
 })();
@@ -166,10 +203,16 @@ def test_active_profile_boot_recovery_is_one_shot_and_bounded(driver_path):
 
     assert payload["attempts"][0]["status"] == "recovery-redirect"
     assert payload["attempts"][0]["bootContinues"] is False
+    assert payload["attempts"][0]["bootProfile"] is None
+    assert payload["attempts"][0]["bootIsDefault"] is None
+    assert payload["attempts"][0]["applyBotNameCalls"] == 0
     assert payload["attempts"][1]["status"] == "fallback"
     assert payload["attempts"][1]["bootContinues"] is True
     assert payload["attempts"][1]["profile"] == "default"
     assert payload["attempts"][1]["isDefault"] is True
+    assert payload["attempts"][1]["bootProfile"] == "default"
+    assert payload["attempts"][1]["bootIsDefault"] is True
+    assert payload["attempts"][1]["applyBotNameCalls"] == 1
     assert payload["loadCalls"] == 2
     assert payload["redirects"] == ["login?next=%2F"]
     assert payload["storageHistory"][0].get("test-5001-active-profile-recovery") == "1"
@@ -191,10 +234,16 @@ def test_active_profile_boot_recovery_handles_loader_thrown_401s(driver_path):
 
     assert payload["attempts"][0]["status"] == "recovery-redirect"
     assert payload["attempts"][0]["bootContinues"] is False
+    assert payload["attempts"][0]["bootProfile"] is None
+    assert payload["attempts"][0]["bootIsDefault"] is None
+    assert payload["attempts"][0]["applyBotNameCalls"] == 0
     assert payload["attempts"][1]["status"] == "fallback"
     assert payload["attempts"][1]["bootContinues"] is True
     assert payload["attempts"][1]["profile"] == "default"
     assert payload["attempts"][1]["isDefault"] is True
+    assert payload["attempts"][1]["bootProfile"] == "default"
+    assert payload["attempts"][1]["bootIsDefault"] is True
+    assert payload["attempts"][1]["applyBotNameCalls"] == 1
     assert payload["redirects"] == ["login?next=%2F"]
     assert payload["storageHistory"][0].get("test-5001-active-profile-recovery-throws") == "1"
     assert payload["storageHistory"][1].get("test-5001-active-profile-recovery-throws") is None
@@ -216,6 +265,9 @@ def test_active_profile_boot_non_401_errors_fallback_without_redirect(driver_pat
     assert payload["attempts"][0]["bootContinues"] is True
     assert payload["attempts"][0]["profile"] == "default"
     assert payload["attempts"][0]["isDefault"] is True
+    assert payload["attempts"][0]["bootProfile"] == "default"
+    assert payload["attempts"][0]["bootIsDefault"] is True
+    assert payload["attempts"][0]["applyBotNameCalls"] == 1
     assert payload["redirects"] == []
     assert payload["storageHistory"][0].get("test-5001-active-profile-recovery-non-401") is None
     assert payload["storageSnapshot"] == {}
@@ -236,6 +288,9 @@ def test_active_profile_boot_invalid_payload_falls_back_without_redirect(driver_
     assert payload["attempts"][0]["bootContinues"] is True
     assert payload["attempts"][0]["profile"] == "default"
     assert payload["attempts"][0]["isDefault"] is True
+    assert payload["attempts"][0]["bootProfile"] == "default"
+    assert payload["attempts"][0]["bootIsDefault"] is True
+    assert payload["attempts"][0]["applyBotNameCalls"] == 1
     assert payload["redirects"] == []
     assert payload["storageHistory"][0].get("test-5001-active-profile-recovery-invalid-payload") is None
     assert payload["storageSnapshot"] == {}
@@ -260,9 +315,9 @@ def test_active_profile_success_path_applies_boot_state_and_continues(driver_pat
     assert payload["attempts"][0]["bootContinues"] is True
     assert payload["attempts"][0]["profile"] == "team-profile"
     assert payload["attempts"][0]["isDefault"] is False
-    assert payload["bootProfile"] == "team-profile"
-    assert payload["bootIsDefault"] is False
-    assert payload["applyBotNameCalls"] == 1
+    assert payload["attempts"][0]["bootProfile"] == "team-profile"
+    assert payload["attempts"][0]["bootIsDefault"] is False
+    assert payload["attempts"][0]["applyBotNameCalls"] == 1
     assert payload["redirects"] == []
     assert payload["storageHistory"][0].get("test-5001-active-profile-recovery-success") is None
     assert payload["storageSnapshot"] == {}

--- a/tests/test_5001_active_profile_recovery.py
+++ b/tests/test_5001_active_profile_recovery.py
@@ -104,11 +104,12 @@ eval(extractFunction(bootSrc, '_resolveActiveProfileBootstrapState'));
         redirectUrls.push(`login?next=${encodeURIComponent(nextUrl)}`);
       },
     });
+    const bootContinues = state.status !== 'recovery-redirect';
 
-    results.push(state);
+    results.push({...state, bootContinues});
     storageHistory.push(storage.snapshot());
 
-    if (scenario.simulateBootContinue && state.status === 'resolved') {
+    if (scenario.simulateBootContinue && bootContinues) {
       bootProfile = state.profile;
       bootIsDefault = state.isDefault;
       applyBotNameCalls += 1;
@@ -164,7 +165,9 @@ def test_active_profile_boot_recovery_is_one_shot_and_bounded(driver_path):
     )
 
     assert payload["attempts"][0]["status"] == "recovery-redirect"
+    assert payload["attempts"][0]["bootContinues"] is False
     assert payload["attempts"][1]["status"] == "fallback"
+    assert payload["attempts"][1]["bootContinues"] is True
     assert payload["attempts"][1]["profile"] == "default"
     assert payload["attempts"][1]["isDefault"] is True
     assert payload["loadCalls"] == 2
@@ -187,7 +190,9 @@ def test_active_profile_boot_recovery_handles_loader_thrown_401s(driver_path):
     )
 
     assert payload["attempts"][0]["status"] == "recovery-redirect"
+    assert payload["attempts"][0]["bootContinues"] is False
     assert payload["attempts"][1]["status"] == "fallback"
+    assert payload["attempts"][1]["bootContinues"] is True
     assert payload["attempts"][1]["profile"] == "default"
     assert payload["attempts"][1]["isDefault"] is True
     assert payload["redirects"] == ["login?next=%2F"]
@@ -208,6 +213,7 @@ def test_active_profile_boot_non_401_errors_fallback_without_redirect(driver_pat
     )
 
     assert payload["attempts"][0]["status"] == "fallback"
+    assert payload["attempts"][0]["bootContinues"] is True
     assert payload["attempts"][0]["profile"] == "default"
     assert payload["attempts"][0]["isDefault"] is True
     assert payload["redirects"] == []
@@ -227,6 +233,7 @@ def test_active_profile_boot_invalid_payload_falls_back_without_redirect(driver_
     )
 
     assert payload["attempts"][0]["status"] == "fallback"
+    assert payload["attempts"][0]["bootContinues"] is True
     assert payload["attempts"][0]["profile"] == "default"
     assert payload["attempts"][0]["isDefault"] is True
     assert payload["redirects"] == []
@@ -250,6 +257,7 @@ def test_active_profile_success_path_applies_boot_state_and_continues(driver_pat
     )
 
     assert payload["attempts"][0]["status"] == "resolved"
+    assert payload["attempts"][0]["bootContinues"] is True
     assert payload["attempts"][0]["profile"] == "team-profile"
     assert payload["attempts"][0]["isDefault"] is False
     assert payload["bootProfile"] == "team-profile"

--- a/tests/test_5001_active_profile_recovery.py
+++ b/tests/test_5001_active_profile_recovery.py
@@ -67,6 +67,9 @@ function makeAttempt(attempt) {
       const payload = attempt.payload || {name: 'default', is_default: true};
       return payload;
     }
+    if (attempt.type === 'return') {
+      return attempt.value;
+    }
     if (attempt.type === 'undefined') {
       return undefined;
     }
@@ -190,6 +193,44 @@ def test_active_profile_boot_recovery_handles_loader_thrown_401s(driver_path):
     assert payload["redirects"] == ["login?next=%2F"]
     assert payload["storageHistory"][0].get("test-5001-active-profile-recovery-throws") == "1"
     assert payload["storageHistory"][1].get("test-5001-active-profile-recovery-throws") is None
+    assert payload["storageSnapshot"] == {}
+
+
+def test_active_profile_boot_non_401_errors_fallback_without_redirect(driver_path):
+    payload = _run_boot_profile_scenario(
+        driver_path,
+        {
+            "markerKey": "test-5001-active-profile-recovery-non-401",
+            "attempts": [
+                {"type": "error", "status": 500, "nextUrl": "/"},
+            ],
+        },
+    )
+
+    assert payload["attempts"][0]["status"] == "fallback"
+    assert payload["attempts"][0]["profile"] == "default"
+    assert payload["attempts"][0]["isDefault"] is True
+    assert payload["redirects"] == []
+    assert payload["storageHistory"][0].get("test-5001-active-profile-recovery-non-401") is None
+    assert payload["storageSnapshot"] == {}
+
+
+def test_active_profile_boot_invalid_payload_falls_back_without_redirect(driver_path):
+    payload = _run_boot_profile_scenario(
+        driver_path,
+        {
+            "markerKey": "test-5001-active-profile-recovery-invalid-payload",
+            "attempts": [
+                {"type": "return", "value": {"is_default": False}, "nextUrl": "/"},
+            ],
+        },
+    )
+
+    assert payload["attempts"][0]["status"] == "fallback"
+    assert payload["attempts"][0]["profile"] == "default"
+    assert payload["attempts"][0]["isDefault"] is True
+    assert payload["redirects"] == []
+    assert payload["storageHistory"][0].get("test-5001-active-profile-recovery-invalid-payload") is None
     assert payload["storageSnapshot"] == {}
 
 

--- a/tests/test_5001_active_profile_recovery.py
+++ b/tests/test_5001_active_profile_recovery.py
@@ -93,13 +93,7 @@ eval(extractFunction(bootSrc, '_resolveActiveProfileBootstrapState'));
 
   for (const attempt of attempts) {
     const state = await _resolveActiveProfileBootstrapState({
-      loadActiveProfile: makeAttempt(
-        attempt,
-        storage,
-        markerKey,
-        redirectUrls,
-        attempt.nextUrl || '/'
-      ),
+      loadActiveProfile: makeAttempt(attempt),
       markerStorage: storage,
       markerKey,
       getNextUrl: () => attempt.nextUrl || '/',
@@ -160,8 +154,8 @@ def test_active_profile_boot_recovery_is_one_shot_and_bounded(driver_path):
         {
             "markerKey": "test-5001-active-profile-recovery",
             "attempts": [
-                {"type": "error", "status": 401, "nextUrl": "/"},
-                {"type": "error", "status": 401, "nextUrl": "/"},
+                {"type": "undefined", "nextUrl": "/"},
+                {"type": "undefined", "nextUrl": "/"},
             ],
         },
     )
@@ -174,6 +168,28 @@ def test_active_profile_boot_recovery_is_one_shot_and_bounded(driver_path):
     assert payload["redirects"] == ["login?next=%2F"]
     assert payload["storageHistory"][0].get("test-5001-active-profile-recovery") == "1"
     assert payload["storageHistory"][1].get("test-5001-active-profile-recovery") is None
+    assert payload["storageSnapshot"] == {}
+
+
+def test_active_profile_boot_recovery_handles_loader_thrown_401s(driver_path):
+    payload = _run_boot_profile_scenario(
+        driver_path,
+        {
+            "markerKey": "test-5001-active-profile-recovery-throws",
+            "attempts": [
+                {"type": "error", "status": 401, "nextUrl": "/"},
+                {"type": "error", "status": 401, "nextUrl": "/"},
+            ],
+        },
+    )
+
+    assert payload["attempts"][0]["status"] == "recovery-redirect"
+    assert payload["attempts"][1]["status"] == "fallback"
+    assert payload["attempts"][1]["profile"] == "default"
+    assert payload["attempts"][1]["isDefault"] is True
+    assert payload["redirects"] == ["login?next=%2F"]
+    assert payload["storageHistory"][0].get("test-5001-active-profile-recovery-throws") == "1"
+    assert payload["storageHistory"][1].get("test-5001-active-profile-recovery-throws") is None
     assert payload["storageSnapshot"] == {}
 
 

--- a/tests/test_issue1116_composer_placeholder.py
+++ b/tests/test_issue1116_composer_placeholder.py
@@ -53,8 +53,8 @@ class TestComposerPlaceholderProfile:
     def test_boot_applies_placeholder_after_active_profile_loads(self):
         """Boot must set the composer placeholder after S.activeProfile is known."""
         src = _src("boot.js")
-        fetch_idx = src.find("api('/api/profile/active')")
-        assert fetch_idx >= 0, "boot.js should fetch the active profile during boot"
+        fetch_idx = src.find("const activeProfileState = await _resolveActiveProfileBootstrapState();")
+        assert fetch_idx >= 0, "boot.js should resolve the active profile during boot"
         label_idx = src.find("const profileLabel=$('profileChipLabel');", fetch_idx)
         assert label_idx >= 0, "profile chip sync should follow active profile fetch"
         assert "applyBotName();" in src[fetch_idx:label_idx], (

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -78,7 +78,8 @@ def test_session_event_profile_filter_tolerates_default_root_aliases():
     assert "function _sessionEventProfilesMatch(eventProfile, activeProfile)" in SESSIONS_JS
     assert "if (!_profileMatchesActiveProfile(sessionProfile, activeProfile)) return false;" in SESSIONS_JS
     assert "activeProfileIsDefault:true" in UI_JS
-    assert "S.activeProfileIsDefault=!!p.is_default;" in BOOT_JS
+    assert "const activeProfileState = await _resolveActiveProfileBootstrapState();" in BOOT_JS
+    assert "S.activeProfileIsDefault = activeProfileState.isDefault;" in BOOT_JS
     assert "S.activeProfileIsDefault = !!data.is_default;" in PANELS_JS
 
 


### PR DESCRIPTION
## Release YS (v0.51.689) — fix post-upgrade 401-loop brick

Ships **#5018** (@rodboev) — fixes **#5001** (community report: WebUI stuck/unresponsive after upgrade, repeating 401 loop on `/api/profile/active`).

### Gate
- **Codex: SAFE TO SHIP** + **Opus: SHIP IT** — verified: the loop is bounded to one login-redirect then default-fallback; the one-shot `sessionStorage` marker is **cleared on both success and fallback** so a recovered/re-logged-in user re-establishes their real profile (no permanent wedge); `redirect401:false` is used in exactly ONE production spot (boot.js:2264) and does NOT weaken 401→login for any other `api()` caller (workspace.js strips the option, redirect stays default-on); a genuinely logged-out user still gets the login redirect; the fallback is display-state only (server auth/profile cookies remain authoritative — no privilege/data exposure).
- **Full suite: 10733 passed** (1 unrelated known order-flake `test_skills_stats_cache`, passes in isolation). +407 regression tests driving the real boot path.
- Brick-class fix on a confirmed reporter issue; root cause matches the maintainer triage on #5001.

From a fork — release branch carries rodboev's commits; #5018 closed as shipped with credit. Closes #5001.
