### PR TITLE
fix(#5021): bound boot model 401 recovery

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -2355,6 +2355,7 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
   // after the saved session is visible.
   const _redirectBootModelDropdownIfUnauth=(res)=>{
     if(!res||res.status!==401) return false;
+    window._modelDropdownReady=null;
     if(_bootActiveProfileUnauthRedirectBudget.isConsumed()) return true;
     if(_bootActiveProfileUnauthRedirectBudget.spendOnRedirect(sessionStorage)){
       _bootActiveProfileUnauthRedirectBudget.redirectToLogin(window.location.pathname+window.location.search);

--- a/static/boot.js
+++ b/static/boot.js
@@ -2265,7 +2265,9 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
     let consumed=false;
     const readAttempted=(storage=sessionStorage)=>{
       try{
-        return storage&&storage.getItem?storage.getItem(markerKey)==='1':false;
+        const attempted=storage&&storage.getItem?storage.getItem(markerKey)==='1':false;
+        if(attempted) consumed=true;
+        return attempted;
       }catch(_){
         return false;
       }

--- a/static/boot.js
+++ b/static/boot.js
@@ -2417,6 +2417,7 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
     return next;
   };
   window._modelDropdownReady=null;
+  window._startBootModelDropdown=_startBootModelDropdown;
   window._ensureModelDropdownReady=_startModelDropdown;
   setTimeout(()=>{
     try{Promise.resolve(_startBootModelDropdown()).catch(()=>{});}catch(_){}

--- a/static/boot.js
+++ b/static/boot.js
@@ -2361,9 +2361,9 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
     }
     return true;
   };
-  const _hydrateBootModelDropdown=()=>populateModelDropdown({
+  const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({
     preferProfileDefaultOnFreshBoot:true,
-    redirectIfUnauth:_redirectBootModelDropdownIfUnauth,
+    ...(redirectIfUnauth?{redirectIfUnauth}:{}),
   }).then(()=>{
     const sessionModelState=S.session&&S.session.model
       ? {model:S.session.model,model_provider:S.session.model_provider||null}
@@ -2402,15 +2402,22 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
     window._modelDropdownReady=null;
     throw e;
   });
+  const _startModelDropdown=()=>{
+    const ready=window._modelDropdownReady;
+    if(ready&&typeof ready.then==='function') return ready;
+    const next=_hydrateModelDropdown();
+    window._modelDropdownReady=next;
+    return next;
+  };
   const _startBootModelDropdown=()=>{
     const ready=window._modelDropdownReady;
     if(ready&&typeof ready.then==='function') return ready;
-    const next=_hydrateBootModelDropdown();
+    const next=_hydrateModelDropdown({redirectIfUnauth:_redirectBootModelDropdownIfUnauth});
     window._modelDropdownReady=next;
     return next;
   };
   window._modelDropdownReady=null;
-  window._ensureModelDropdownReady=_startBootModelDropdown;
+  window._ensureModelDropdownReady=_startModelDropdown;
   setTimeout(()=>{
     try{Promise.resolve(_startBootModelDropdown()).catch(()=>{});}catch(_){}
   },0);

--- a/static/boot.js
+++ b/static/boot.js
@@ -2260,56 +2260,81 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
     const _checkUrl='api/updates/check'+(_testUpdates?'?simulate=1':'');
     api(_checkUrl,{method:_testUpdates?'GET':'POST',body:_testUpdates?undefined:JSON.stringify({force:false})}).then(d=>{if(!_testUpdates)sessionStorage.setItem('hermes-update-checked','1');if((d.webui&&d.webui.behind>0)||(d.agent&&d.agent.behind>0))_showUpdateBanner(d);}).catch(()=>{});
   }
+  const _bootActiveProfileUnauthRedirectBudget=(()=>{
+    const markerKey='hermes-webui-active-profile-bootstrap-401';
+    let consumed=false;
+    const readAttempted=(storage=sessionStorage)=>{
+      try{
+        return storage&&storage.getItem?storage.getItem(markerKey)==='1':false;
+      }catch(_){
+        return false;
+      }
+    };
+    const markAttempted=(storage=sessionStorage)=>{
+      consumed=true;
+      try{
+        if(storage&&storage.setItem) storage.setItem(markerKey,'1');
+      }catch(_){}
+    };
+    const clearAttempted=(storage=sessionStorage)=>{
+      try{
+        if(storage&&storage.removeItem) storage.removeItem(markerKey);
+      }catch(_){}
+    };
+    const spendOnFallback=(storage=sessionStorage)=>{
+      consumed=true;
+      clearAttempted(storage);
+    };
+    const spendOnRedirect=(storage=sessionStorage)=>{
+      if(consumed) return false;
+      markAttempted(storage);
+      return true;
+    };
+    const redirectToLogin=(nextUrl)=>{
+      window.location.href='login?next='+encodeURIComponent(nextUrl);
+    };
+    return {
+      readAttempted,
+      clearAttempted,
+      spendOnFallback,
+      spendOnRedirect,
+      redirectToLogin,
+      isConsumed:()=>consumed,
+    };
+  })();
   async function _resolveActiveProfileBootstrapState({
     loadActiveProfile = () => api('/api/profile/active', {redirect401: false}),
     getNextUrl = () => window.location.pathname + window.location.search,
     redirectToLogin = (nextUrl) => {
-      window.location.href = 'login?next=' + encodeURIComponent(nextUrl);
+      _bootActiveProfileUnauthRedirectBudget.redirectToLogin(nextUrl);
     },
     markerStorage = sessionStorage,
-    markerKey = 'hermes-webui-active-profile-bootstrap-401',
   } = {}) {
-    const getAttempted = () => {
-      try {
-        return markerStorage && markerStorage.getItem
-          ? markerStorage.getItem(markerKey) === '1'
-          : false;
-      } catch (_) {
-        return false;
-      }
-    };
-    const markAttempt = () => {
-      try {
-        if (markerStorage && markerStorage.setItem) markerStorage.setItem(markerKey, '1');
-      } catch (_) {}
-    };
-    const clearAttempt = () => {
-      try {
-        if (markerStorage && markerStorage.removeItem) markerStorage.removeItem(markerKey);
-      } catch (_) {}
-    };
-
-    const alreadyAttempted = getAttempted();
+    const alreadyAttempted = _bootActiveProfileUnauthRedirectBudget.readAttempted(markerStorage);
     try {
       const p = await loadActiveProfile();
       if (p && typeof p === 'object' && typeof p.name === 'string') {
-        clearAttempt();
+        _bootActiveProfileUnauthRedirectBudget.clearAttempted(markerStorage);
         return {status: 'resolved', profile: p.name || 'default', isDefault: !!p.is_default};
       }
       if (p === undefined && !alreadyAttempted) {
-        markAttempt();
-        redirectToLogin(getNextUrl());
+        if (_bootActiveProfileUnauthRedirectBudget.spendOnRedirect(markerStorage)) {
+          redirectToLogin(getNextUrl());
+        }
         return {status: 'recovery-redirect'};
       }
-      clearAttempt();
+      if (p === undefined) _bootActiveProfileUnauthRedirectBudget.spendOnFallback(markerStorage);
+      else _bootActiveProfileUnauthRedirectBudget.clearAttempted(markerStorage);
       return {status: 'fallback', profile: 'default', isDefault: true};
     } catch (e) {
-      clearAttempt();
+      _bootActiveProfileUnauthRedirectBudget.clearAttempted(markerStorage);
       if (!alreadyAttempted && e && e.status === 401) {
-        markAttempt();
-        redirectToLogin(getNextUrl());
+        if (_bootActiveProfileUnauthRedirectBudget.spendOnRedirect(markerStorage)) {
+          redirectToLogin(getNextUrl());
+        }
         return {status: 'recovery-redirect'};
       }
+      if (e && e.status === 401) _bootActiveProfileUnauthRedirectBudget.spendOnFallback(markerStorage);
       return {status: 'fallback', profile: 'default', isDefault: true};
     }
   }
@@ -2328,7 +2353,18 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
   // Fetch available models without blocking session restore. The static HTML
   // options are enough for first paint; the dynamic provider list can settle
   // after the saved session is visible.
-  const _hydrateBootModelDropdown=()=>populateModelDropdown({preferProfileDefaultOnFreshBoot:true}).then(()=>{
+  const _redirectBootModelDropdownIfUnauth=(res)=>{
+    if(!res||res.status!==401) return false;
+    if(_bootActiveProfileUnauthRedirectBudget.isConsumed()) return true;
+    if(_bootActiveProfileUnauthRedirectBudget.spendOnRedirect(sessionStorage)){
+      _bootActiveProfileUnauthRedirectBudget.redirectToLogin(window.location.pathname+window.location.search);
+    }
+    return true;
+  };
+  const _hydrateBootModelDropdown=()=>populateModelDropdown({
+    preferProfileDefaultOnFreshBoot:true,
+    redirectIfUnauth:_redirectBootModelDropdownIfUnauth,
+  }).then(()=>{
     const sessionModelState=S.session&&S.session.model
       ? {model:S.session.model,model_provider:S.session.model_provider||null}
       : null;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1296,6 +1296,9 @@ async function loadSession(sid){
     const modelRefreshSid=sid;
     const modelRefreshPromise=Promise.resolve().then(()=>{
       if(_loadingSessionId!==modelRefreshSid) return;
+      if(!S._bootReady&&typeof window!=='undefined'&&typeof window._startBootModelDropdown==='function'){
+        return window._startBootModelDropdown();
+      }
       return populateModelDropdown({freshness:'session_visit'});
     }).catch(()=>{});
     if(typeof window!=='undefined') window._modelDropdownReady=modelRefreshPromise;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1294,14 +1294,18 @@ async function loadSession(sid){
   S._pendingSessionToolsets=null;
   if(typeof populateModelDropdown==='function'){
     const modelRefreshSid=sid;
-    const modelRefreshPromise=Promise.resolve().then(()=>{
-      if(_loadingSessionId!==modelRefreshSid) return;
-      if(!S._bootReady&&typeof window!=='undefined'&&typeof window._startBootModelDropdown==='function'){
+    if(!S._bootReady&&typeof window!=='undefined'&&typeof window._startBootModelDropdown==='function'){
+      Promise.resolve().then(()=>{
+        if(_loadingSessionId!==modelRefreshSid) return;
         return window._startBootModelDropdown();
-      }
-      return populateModelDropdown({freshness:'session_visit'});
-    }).catch(()=>{});
-    if(typeof window!=='undefined') window._modelDropdownReady=modelRefreshPromise;
+      }).catch(()=>{});
+    }else{
+      const modelRefreshPromise=Promise.resolve().then(()=>{
+        if(_loadingSessionId!==modelRefreshSid) return;
+        return populateModelDropdown({freshness:'session_visit'});
+      }).catch(()=>{});
+      if(typeof window!=='undefined') window._modelDropdownReady=modelRefreshPromise;
+    }
   }
   if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
   S.session._modelResolutionDeferred=true;

--- a/static/ui.js
+++ b/static/ui.js
@@ -2047,17 +2047,16 @@ async function populateModelDropdown(opts={}){
     if(opts&&opts.freshness) modelsUrl.searchParams.set('freshness',opts.freshness);
     const _modelsRes=await fetch(modelsUrl.href,{credentials:'include'});
     if(requestSeq!==_modelDropdownRequestSeq) return;
-    if(_redirectIfUnauth(_modelsRes)) return;
+    const customRedirectIfUnauth=opts&&typeof opts.redirectIfUnauth==='function'?opts.redirectIfUnauth:null;
+    if(customRedirectIfUnauth){
+      if(customRedirectIfUnauth(_modelsRes)) return;
+    }else if(_redirectIfUnauth(_modelsRes)) return;
+    // `_activeProvider` is populated from the /api/models payload below.
     const data=await _modelsRes.json();
     if(requestSeq!==_modelDropdownRequestSeq) return;
-    // Store active provider globally so the send path can warn on mismatch
     window._activeProvider=data.active_provider||null;
-    // Store default model so newSession() can apply it (#872).
-    // Per-page-load — not synced across browser tabs.
     window._defaultModel=data.default_model||null;
     window._configuredModelBadges=data.configured_model_badges||{};
-    // Keep the g.extra_models label hydration path below in this function; tests
-    // assert populateModelDropdown preserves that full-catalog label contract.
     window._modelEndpointErrors={};
 
     const _synthGroupsFromConfigured=()=>{

--- a/static/ui.js
+++ b/static/ui.js
@@ -2058,6 +2058,7 @@ async function populateModelDropdown(opts={}){
     window._defaultModel=data.default_model||null;
     window._configuredModelBadges=data.configured_model_badges||{};
     window._modelEndpointErrors={};
+    // Keep g.extra_models label hydration in this function for /model and tail selections.
 
     const _synthGroupsFromConfigured=()=>{
       const badgeMap=window._configuredModelBadges||{};

--- a/tests/test_5001_active_profile_recovery.py
+++ b/tests/test_5001_active_profile_recovery.py
@@ -11,6 +11,7 @@ import pytest
 ROOT = Path(__file__).resolve().parent.parent
 BOOT_JS = ROOT / "static" / "boot.js"
 NODE = shutil.which("node")
+BOOT_MARKER_KEY = "hermes-webui-active-profile-bootstrap-401"
 
 
 pytestmark = pytest.mark.skipif(
@@ -144,6 +145,15 @@ function makeApiAttempt(attempt) {
   };
 }
 
+const budgetBlock = extractBlock(
+  bootSrc,
+  '  const _bootActiveProfileUnauthRedirectBudget=(()=>{',
+  '  // Fetch active profile'
+);
+eval(budgetBlock.replace(
+  '  const _bootActiveProfileUnauthRedirectBudget=(()=>{',
+  '  globalThis._bootActiveProfileUnauthRedirectBudget=(()=>{'
+));
 eval(extractFunction(bootSrc, '_resolveActiveProfileBootstrapState'));
 const bootActiveProfileBlock = extractBlock(
   bootSrc,
@@ -297,8 +307,8 @@ def test_active_profile_boot_recovery_is_one_shot_and_bounded(driver_path):
     assert payload["attempts"][1]["applyBotNameCalls"] == 1
     assert payload["loadCalls"] == 2
     assert payload["redirects"] == ["login?next=%2F"]
-    assert payload["storageHistory"][0].get("test-5001-active-profile-recovery") == "1"
-    assert payload["storageHistory"][1].get("test-5001-active-profile-recovery") is None
+    assert payload["storageHistory"][0].get(BOOT_MARKER_KEY) == "1"
+    assert payload["storageHistory"][1].get(BOOT_MARKER_KEY) is None
     assert payload["storageSnapshot"] == {}
 
 
@@ -327,8 +337,8 @@ def test_active_profile_boot_recovery_handles_loader_thrown_401s(driver_path):
     assert payload["attempts"][1]["bootIsDefault"] is True
     assert payload["attempts"][1]["applyBotNameCalls"] == 1
     assert payload["redirects"] == ["login?next=%2F"]
-    assert payload["storageHistory"][0].get("test-5001-active-profile-recovery-throws") == "1"
-    assert payload["storageHistory"][1].get("test-5001-active-profile-recovery-throws") is None
+    assert payload["storageHistory"][0].get(BOOT_MARKER_KEY) == "1"
+    assert payload["storageHistory"][1].get(BOOT_MARKER_KEY) is None
     assert payload["storageSnapshot"] == {}
 
 

--- a/tests/test_5021_boot_model_redirect_budget.py
+++ b/tests/test_5021_boot_model_redirect_budget.py
@@ -43,6 +43,14 @@ function extractFunction(source, name) {
   return source.slice(start, end);
 }
 
+function extractSingleLineFunction(source, marker) {
+  const start = source.indexOf(marker);
+  if (start < 0) throw new Error(`missing function marker: ${marker}`);
+  const end = source.indexOf("\n", start);
+  if (end < 0) throw new Error(`missing newline after function marker: ${marker}`);
+  return source.slice(start, end);
+}
+
 class FakeStorage {
   constructor(seed = {}) {
     this.store = { ...seed };
@@ -216,6 +224,15 @@ const resolveBlock = extractBlock(
   '  async function _resolveActiveProfileBootstrapState({',
   '  // Fetch active profile'
 );
+const bootRedirectCallbackBlock = extractBlock(
+  bootSrc,
+  '  const _redirectBootModelDropdownIfUnauth=(res)=>{',
+  '  const _hydrateModelDropdown=({'
+);
+const redirectIfUnauthLine = extractSingleLineFunction(
+  uiSrc,
+  'function _redirectIfUnauth(res){'
+);
 const uiBlock = extractFunction(uiSrc, 'populateModelDropdown');
 
 eval(bootBlock.replace(
@@ -223,18 +240,15 @@ eval(bootBlock.replace(
   '  globalThis._bootActiveProfileUnauthRedirectBudget=(()=>{'
 ));
 eval(resolveBlock);
+eval(bootRedirectCallbackBlock.replace(
+  '  const _redirectBootModelDropdownIfUnauth=(res)=>{',
+  '  globalThis._redirectBootModelDropdownIfUnauth=(res)=>{'
+));
+eval(redirectIfUnauthLine.replace(
+  'function _redirectIfUnauth(res){',
+  'globalThis._redirectIfUnauth=function _redirectIfUnauth(res){'
+));
 eval(uiBlock);
-
-function _redirectBootModelDropdownIfUnauth(res) {
-  if (!res || res.status !== 401) return false;
-  if (globalThis._bootActiveProfileUnauthRedirectBudget.isConsumed()) return true;
-  if (globalThis._bootActiveProfileUnauthRedirectBudget.spendOnRedirect(globalThis.sessionStorage)) {
-    globalThis._bootActiveProfileUnauthRedirectBudget.redirectToLogin(
-      globalThis.window.location.pathname + globalThis.window.location.search
-    );
-  }
-  return true;
-}
 
 async function runBootAttempt(attempt, redirects, storage, fetchQueue, jsonCalls) {
   const select = buildSelect();
@@ -442,5 +456,6 @@ def test_post_boot_model_refresh_keeps_normal_401_redirect(driver_path):
         },
     )
 
+    assert payload["redirects"] == ["login?next=%2Fsession%2Fabc%3Fworkspace%3Dtest"]
     assert payload["jsonCalls"] == 0
     assert "window._ensureModelDropdownReady=_startModelDropdown;" in BOOT_JS.read_text(encoding="utf-8")

--- a/tests/test_5021_boot_model_redirect_budget.py
+++ b/tests/test_5021_boot_model_redirect_budget.py
@@ -12,6 +12,7 @@ ROOT = Path(__file__).resolve().parent.parent
 BOOT_JS = ROOT / "static" / "boot.js"
 UI_JS = ROOT / "static" / "ui.js"
 NODE = shutil.which("node")
+BOOT_MARKER_KEY = "hermes-webui-active-profile-bootstrap-401"
 
 
 pytestmark = pytest.mark.skipif(
@@ -436,18 +437,31 @@ def test_boot_model_401_does_not_reopen_redirect_after_active_profile_fallback(d
 
 
 def test_boot_model_401_consumes_budget_when_profile_load_succeeds(driver_path):
-    payload = _run(
+    first = _run(
         driver_path,
         {
             "kind": "boot-model-only",
         },
     )
 
-    assert payload["redirects"] == ["login?next=%2Fsession%2Fabc%3Fworkspace%3Dtest"]
-    assert payload["results"][0]["state"]["status"] == "resolved"
-    assert payload["jsonCalls"] == 0
-    assert payload["activeProvider"] is None
-    assert payload["defaultModel"] is None
+    second = _run(
+        driver_path,
+        {
+            "kind": "boot-model-only",
+            "initialStorage": first["storage"],
+        },
+    )
+
+    assert first["redirects"] == ["login?next=%2Fsession%2Fabc%3Fworkspace%3Dtest"]
+    assert first["results"][0]["state"]["status"] == "resolved"
+    assert first["storage"] == {BOOT_MARKER_KEY: "1"}
+    assert first["jsonCalls"] == 0
+    assert first["activeProvider"] is None
+    assert first["defaultModel"] is None
+    assert second["redirects"] == []
+    assert second["results"][0]["state"]["status"] == "resolved"
+    assert second["storage"] == {}
+    assert second["jsonCalls"] == 0
 
 
 def test_boot_model_success_still_stores_active_provider(driver_path):

--- a/tests/test_5021_boot_model_redirect_budget.py
+++ b/tests/test_5021_boot_model_redirect_budget.py
@@ -25,6 +25,7 @@ const fs = require('fs');
 const bootSrc = fs.readFileSync(process.argv[2], 'utf8');
 const uiSrc = fs.readFileSync(process.argv[3], 'utf8');
 const scenario = JSON.parse(process.argv[4] || '{}');
+globalThis.window = globalThis;
 
 function extractBlock(source, startMarker, endMarker) {
   const start = source.indexOf(startMarker);
@@ -224,10 +225,10 @@ const resolveBlock = extractBlock(
   '  async function _resolveActiveProfileBootstrapState({',
   '  // Fetch active profile'
 );
-const bootRedirectCallbackBlock = extractBlock(
+const bootDropdownBlock = extractBlock(
   bootSrc,
   '  const _redirectBootModelDropdownIfUnauth=(res)=>{',
-  '  const _hydrateModelDropdown=({'
+  '  setTimeout(()=>{'
 );
 const redirectIfUnauthLine = extractSingleLineFunction(
   uiSrc,
@@ -240,10 +241,24 @@ eval(bootBlock.replace(
   '  globalThis._bootActiveProfileUnauthRedirectBudget=(()=>{'
 ));
 eval(resolveBlock);
-eval(bootRedirectCallbackBlock.replace(
+eval(bootDropdownBlock
+  .replace(
   '  const _redirectBootModelDropdownIfUnauth=(res)=>{',
   '  globalThis._redirectBootModelDropdownIfUnauth=(res)=>{'
-));
+  )
+  .replace(
+    '  const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({',
+    '  globalThis._hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({'
+  )
+  .replace(
+    '  const _startModelDropdown=()=>{',
+    '  globalThis._startModelDropdown=()=>{'
+  )
+  .replace(
+    '  const _startBootModelDropdown=()=>{',
+    '  globalThis._startBootModelDropdown=()=>{'
+  )
+);
 eval(redirectIfUnauthLine.replace(
   'function _redirectIfUnauth(res){',
   'globalThis._redirectIfUnauth=function _redirectIfUnauth(res){'
@@ -366,7 +381,8 @@ async function runBootAttempt(attempt, redirects, storage, fetchQueue, jsonCalls
       ok: false,
       json: async () => ({active_provider: 'openai', default_model: 'gpt-4o', configured_model_badges: {}, groups: []}),
     });
-    await populateModelDropdown({preferProfileDefaultOnFreshBoot: true});
+    await globalThis._startBootModelDropdown();
+    await globalThis._ensureModelDropdownReady();
   } else {
     throw new Error(`unknown scenario: ${scenario.kind}`);
   }
@@ -458,4 +474,5 @@ def test_post_boot_model_refresh_keeps_normal_401_redirect(driver_path):
 
     assert payload["redirects"] == ["login?next=%2Fsession%2Fabc%3Fworkspace%3Dtest"]
     assert payload["jsonCalls"] == 0
+    assert payload["storage"] == {}
     assert "window._ensureModelDropdownReady=_startModelDropdown;" in BOOT_JS.read_text(encoding="utf-8")

--- a/tests/test_5021_boot_model_redirect_budget.py
+++ b/tests/test_5021_boot_model_redirect_budget.py
@@ -1,0 +1,421 @@
+"""Browserless regression coverage for #5021 boot model redirect budgeting."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+BOOT_JS = ROOT / "static" / "boot.js"
+UI_JS = ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+
+pytestmark = pytest.mark.skipif(
+    NODE is None,
+    reason="node is required to execute the boot model redirect budget harness",
+)
+
+
+_DRIVER = r"""
+const fs = require('fs');
+const bootSrc = fs.readFileSync(process.argv[2], 'utf8');
+const uiSrc = fs.readFileSync(process.argv[3], 'utf8');
+const scenario = JSON.parse(process.argv[4] || '{}');
+
+function extractBlock(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  if (start < 0) throw new Error(`missing block start: ${startMarker}`);
+  const end = source.indexOf(endMarker, start);
+  if (end < 0) throw new Error(`missing block end: ${endMarker}`);
+  return source.slice(start, end);
+}
+
+function extractFunction(source, name) {
+  const marker = `async function ${name}`;
+  const start = source.indexOf(marker);
+  if (start < 0) throw new Error(`missing function: ${name}`);
+  const end = source.indexOf("\n// Cache so we don't re-fetch on every page load", start);
+  if (end < 0) throw new Error(`missing end marker after: ${name}`);
+  return source.slice(start, end);
+}
+
+class FakeStorage {
+  constructor(seed = {}) {
+    this.store = { ...seed };
+  }
+
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this.store, key)
+      ? this.store[key]
+      : null;
+  }
+
+  setItem(key, value) {
+    this.store[key] = String(value);
+  }
+
+  removeItem(key) {
+    delete this.store[key];
+  }
+
+  snapshot() {
+    return { ...this.store };
+  }
+}
+
+class FakeNode {
+  constructor(tagName) {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.dataset = {};
+    this.classList = { contains: () => false };
+    this.style = {};
+    this.textContent = '';
+    this.label = '';
+    this.value = '';
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    child.parentNode = this;
+    return child;
+  }
+}
+
+class FakeSelect extends FakeNode {
+  constructor() {
+    super('select');
+    this.id = 'modelSelect';
+    this._innerHTML = '';
+    this._value = '';
+    this.classList = { contains: () => false };
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = value;
+    this.children = [];
+  }
+
+  get innerHTML() {
+    return this._innerHTML;
+  }
+
+  get options() {
+    const options = [];
+    for (const child of this.children) {
+      if (child.tagName === 'OPTGROUP') {
+        options.push(...child.children);
+      } else if (child.tagName === 'OPTION') {
+        options.push(child);
+      }
+    }
+    return options;
+  }
+
+  set value(value) {
+    this._value = value;
+    const idx = this.options.findIndex((opt) => opt.value === value);
+    this.selectedIndex = idx >= 0 ? idx : -1;
+  }
+
+  get value() {
+    return this._value;
+  }
+
+  querySelector(selector) {
+    if (selector === 'optgroup > option, option') {
+      return this.options[0] || null;
+    }
+    return null;
+  }
+
+  querySelectorAll(selector) {
+    if (selector === 'optgroup') {
+      return this.children.filter((child) => child.tagName === 'OPTGROUP');
+    }
+    return [];
+  }
+}
+
+function buildSelect() {
+  return new FakeSelect();
+}
+
+function buildModelResponse(payload, status = 200) {
+  let jsonCalls = 0;
+  return {
+    response: {
+      status,
+      ok: status >= 200 && status < 300,
+      json: async () => {
+        jsonCalls += 1;
+        return payload;
+      },
+      text: async () => JSON.stringify(payload),
+    },
+    get jsonCalls() {
+      return jsonCalls;
+    },
+  };
+}
+
+function installGlobals(select, redirects, fetchQueue, jsonCalls) {
+  const windowObj = globalThis.window || globalThis;
+  globalThis.window = windowObj;
+  windowObj.location = {
+    pathname: '/session/abc',
+    search: '?workspace=test',
+    set href(value) {
+      redirects.push(value);
+    },
+  };
+  globalThis.location = windowObj.location;
+  globalThis.sessionStorage = new FakeStorage();
+  globalThis.document = {
+    baseURI: 'http://localhost/session/abc?workspace=test',
+    createElement(tag) {
+      return new FakeNode(tag);
+    },
+  };
+  globalThis.$ = (id) => (id === 'modelSelect' ? select : null);
+  globalThis.getModelLabel = (id) => `label:${id}`;
+  globalThis.syncModelChip = () => {};
+  globalThis.syncTopbar = () => {};
+  globalThis._captureModelDropdownSelection = () => null;
+  globalThis._reconcileModelDropdownSelection = () => {};
+  globalThis._applyModelToDropdown = () => false;
+  globalThis._ensureModelOptionInDropdown = () => {};
+  globalThis._refreshOpenModelDropdown = () => {};
+  globalThis._modelDropdownRequestSeq = 0;
+  globalThis._fetchLiveModels = () => {};
+  globalThis.console = { warn() {}, debug() {}, log() {} };
+  globalThis.fetch = async () => {
+    if (!fetchQueue.length) throw new Error('unexpected fetch');
+    const next = fetchQueue.shift();
+    if (next.kind === '401') return next.response;
+    if (next.kind === 'json') {
+      jsonCalls.count += 1;
+      return next.response;
+    }
+    return next.response;
+  };
+}
+
+const bootBlock = extractBlock(
+  bootSrc,
+  '  const _bootActiveProfileUnauthRedirectBudget=(()=>{',
+  '  // Fetch active profile'
+);
+const resolveBlock = extractBlock(
+  bootSrc,
+  '  async function _resolveActiveProfileBootstrapState({',
+  '  // Fetch active profile'
+);
+const uiBlock = extractFunction(uiSrc, 'populateModelDropdown');
+
+eval(bootBlock.replace(
+  '  const _bootActiveProfileUnauthRedirectBudget=(()=>{',
+  '  globalThis._bootActiveProfileUnauthRedirectBudget=(()=>{'
+));
+eval(resolveBlock);
+eval(uiBlock);
+
+function _redirectBootModelDropdownIfUnauth(res) {
+  if (!res || res.status !== 401) return false;
+  if (globalThis._bootActiveProfileUnauthRedirectBudget.isConsumed()) return true;
+  if (globalThis._bootActiveProfileUnauthRedirectBudget.spendOnRedirect(globalThis.sessionStorage)) {
+    globalThis._bootActiveProfileUnauthRedirectBudget.redirectToLogin(
+      globalThis.window.location.pathname + globalThis.window.location.search
+    );
+  }
+  return true;
+}
+
+async function runBootAttempt(attempt, redirects, storage, fetchQueue, jsonCalls) {
+  const select = buildSelect();
+  installGlobals(select, redirects, fetchQueue, jsonCalls);
+  globalThis.sessionStorage = storage;
+
+  const state = await _resolveActiveProfileBootstrapState({
+    loadActiveProfile: attempt.loadActiveProfile,
+    markerStorage: storage,
+    getNextUrl: () => attempt.nextUrl || '/session/abc?workspace=test',
+    redirectToLogin: (nextUrl) => {
+      redirects.push(`login?next=${encodeURIComponent(nextUrl)}`);
+    },
+  });
+
+  if (state.status !== 'recovery-redirect') {
+    globalThis.S = {
+      session: attempt.session || null,
+      activeProfile: state.profile,
+      activeProfileIsDefault: state.isDefault,
+    };
+    await populateModelDropdown({
+      preferProfileDefaultOnFreshBoot: true,
+      redirectIfUnauth: _redirectBootModelDropdownIfUnauth,
+    });
+  }
+
+  return {
+    state,
+    storage: storage.snapshot(),
+  };
+}
+
+(async () => {
+  const storage = new FakeStorage(scenario.initialStorage || {});
+  const redirects = [];
+  const jsonCalls = {count: 0};
+  const results = [];
+
+  if (scenario.kind === 'boot-fallback-loop') {
+    const firstLoad = async () => { const err = new Error('unauthorized'); err.status = 401; throw err; };
+    results.push(await runBootAttempt(
+      {
+        loadActiveProfile: firstLoad,
+        nextUrl: '/session/abc?workspace=test',
+      },
+      redirects,
+      storage,
+      [
+        {kind: '401', response: {status: 401, ok: false, json: async () => ({active_provider: 'openai', default_model: 'gpt-4o', configured_model_badges: {}, groups: []})}},
+      ],
+      jsonCalls,
+    ));
+
+    const secondLoad = async () => { const err = new Error('unauthorized'); err.status = 401; throw err; };
+    results.push(await runBootAttempt(
+      {
+        loadActiveProfile: secondLoad,
+        nextUrl: '/session/abc?workspace=test',
+      },
+      redirects,
+      storage,
+      [
+        {kind: '401', response: {status: 401, ok: false, json: async () => ({active_provider: 'openai', default_model: 'gpt-4o', configured_model_badges: {}, groups: []})}},
+      ],
+      jsonCalls,
+    ));
+  } else if (scenario.kind === 'boot-model-only') {
+    results.push(await runBootAttempt(
+      {
+        loadActiveProfile: async () => ({name: 'default', is_default: true}),
+        session: null,
+      },
+      redirects,
+      storage,
+      [
+        {kind: '401', response: {status: 401, ok: false, json: async () => ({active_provider: 'openai', default_model: 'gpt-4o', configured_model_badges: {}, groups: []})}},
+      ],
+      jsonCalls,
+    ));
+  } else if (scenario.kind === 'boot-model-success') {
+    results.push(await runBootAttempt(
+      {
+        loadActiveProfile: async () => ({name: 'default', is_default: true}),
+        session: null,
+      },
+      redirects,
+      storage,
+      [
+        {kind: 'json', response: buildModelResponse({
+          active_provider: 'anthropic',
+          default_model: 'claude-sonnet-4',
+          configured_model_badges: {
+            'claude-sonnet-4': {provider: 'anthropic'},
+          },
+          groups: [
+            {
+              provider: 'Anthropic',
+              provider_id: 'anthropic',
+              models: [{id: 'claude-sonnet-4', label: 'Claude Sonnet 4'}],
+            },
+          ],
+        }).response},
+      ],
+      jsonCalls,
+    ));
+  } else {
+    throw new Error(`unknown scenario: ${scenario.kind}`);
+  }
+
+  process.stdout.write(JSON.stringify({
+    redirects,
+    results,
+    jsonCalls: jsonCalls.count,
+    storage: storage.snapshot(),
+    activeProvider: globalThis.window._activeProvider || null,
+    defaultModel: globalThis.window._defaultModel || null,
+  }));
+})();
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    path = tmp_path_factory.mktemp("boot-model-budget-driver") / "driver.js"
+    path.write_text(_DRIVER, encoding="utf-8")
+    return str(path)
+
+
+def _run(driver_path, scenario):
+    process = subprocess.run(
+        [NODE, driver_path, str(BOOT_JS), str(UI_JS), json.dumps(scenario)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if process.returncode != 0:
+        raise RuntimeError(process.stderr.strip() or process.stdout.strip())
+    return json.loads(process.stdout)
+
+
+def test_boot_model_401_does_not_reopen_redirect_after_active_profile_fallback(driver_path):
+    payload = _run(
+        driver_path,
+        {
+            "kind": "boot-fallback-loop",
+        },
+    )
+
+    assert payload["redirects"] == ["login?next=%2Fsession%2Fabc%3Fworkspace%3Dtest"]
+    assert len(payload["results"]) == 2
+    assert payload["results"][0]["state"]["status"] == "recovery-redirect"
+    assert payload["results"][1]["state"]["status"] == "fallback"
+    assert payload["results"][1]["storage"] == {}
+    assert payload["jsonCalls"] == 0
+
+
+def test_boot_model_401_consumes_budget_when_profile_load_succeeds(driver_path):
+    payload = _run(
+        driver_path,
+        {
+            "kind": "boot-model-only",
+        },
+    )
+
+    assert payload["redirects"] == ["login?next=%2Fsession%2Fabc%3Fworkspace%3Dtest"]
+    assert payload["results"][0]["state"]["status"] == "resolved"
+    assert payload["jsonCalls"] == 0
+    assert payload["activeProvider"] is None
+    assert payload["defaultModel"] is None
+
+
+def test_boot_model_success_still_stores_active_provider(driver_path):
+    payload = _run(
+        driver_path,
+        {
+            "kind": "boot-model-success",
+        },
+    )
+
+    assert payload["redirects"] == []
+    assert payload["activeProvider"] == "anthropic"
+    assert payload["defaultModel"] == "claude-sonnet-4"
+    assert payload["jsonCalls"] == 1

--- a/tests/test_5021_boot_model_redirect_budget.py
+++ b/tests/test_5021_boot_model_redirect_budget.py
@@ -175,6 +175,7 @@ function installGlobals(select, redirects, fetchQueue, jsonCalls) {
   };
   globalThis.location = windowObj.location;
   globalThis.sessionStorage = new FakeStorage();
+  globalThis.localStorage = new FakeStorage();
   globalThis.document = {
     baseURI: 'http://localhost/session/abc?workspace=test',
     createElement(tag) {
@@ -340,6 +341,18 @@ async function runBootAttempt(attempt, redirects, storage, fetchQueue, jsonCalls
       ],
       jsonCalls,
     ));
+  } else if (scenario.kind === 'post-boot-refresh') {
+    const select = buildSelect();
+    installGlobals(select, redirects, [], jsonCalls);
+    globalThis.sessionStorage = storage;
+    globalThis.S = {session: null, activeProfile: 'default', activeProfileIsDefault: true};
+    globalThis._bootActiveProfileUnauthRedirectBudget.spendOnFallback(storage);
+    globalThis.fetch = async () => ({
+      status: 401,
+      ok: false,
+      json: async () => ({active_provider: 'openai', default_model: 'gpt-4o', configured_model_badges: {}, groups: []}),
+    });
+    await populateModelDropdown({preferProfileDefaultOnFreshBoot: true});
   } else {
     throw new Error(`unknown scenario: ${scenario.kind}`);
   }
@@ -419,3 +432,15 @@ def test_boot_model_success_still_stores_active_provider(driver_path):
     assert payload["activeProvider"] == "anthropic"
     assert payload["defaultModel"] == "claude-sonnet-4"
     assert payload["jsonCalls"] == 1
+
+
+def test_post_boot_model_refresh_keeps_normal_401_redirect(driver_path):
+    payload = _run(
+        driver_path,
+        {
+            "kind": "post-boot-refresh",
+        },
+    )
+
+    assert payload["jsonCalls"] == 0
+    assert "window._ensureModelDropdownReady=_startModelDropdown;" in BOOT_JS.read_text(encoding="utf-8")

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -329,12 +329,14 @@ def test_load_session_schedules_async_session_visit_model_refresh_after_metadata
 
     assign_idx = body.index("S.session=data.session")
     promise_idx = body.index("const modelRefreshPromise=Promise.resolve().then(")
+    boot_guard_idx = body.index("if(!S._bootReady&&typeof window!=='undefined'&&typeof window._startBootModelDropdown==='function'){")
+    boot_refresh_idx = body.index("return window._startBootModelDropdown();")
     ready_idx = body.index("window._modelDropdownReady=modelRefreshPromise")
     refresh_idx = body.index("populateModelDropdown({freshness:'session_visit'})")
     stale_guard_idx = body.index("_loadingSessionId!==modelRefreshSid")
 
-    assert assign_idx < promise_idx < refresh_idx < ready_idx
-    assert promise_idx < stale_guard_idx < refresh_idx
+    assert assign_idx < promise_idx < boot_guard_idx < boot_refresh_idx < refresh_idx < ready_idx
+    assert promise_idx < stale_guard_idx < boot_guard_idx
 
 
 def test_boot_model_dropdown_reuses_inflight_session_visit_refresh():
@@ -342,6 +344,6 @@ def test_boot_model_dropdown_reuses_inflight_session_visit_refresh():
 
     ready_idx = body.index("const ready=window._modelDropdownReady;")
     reuse_idx = body.index("if(ready&&typeof ready.then==='function') return ready;")
-    hydrate_idx = body.index("const next=_hydrateBootModelDropdown();")
+    hydrate_idx = body.index("const next=_hydrateModelDropdown({redirectIfUnauth:_redirectBootModelDropdownIfUnauth});")
 
     assert ready_idx < reuse_idx < hydrate_idx

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -328,22 +328,25 @@ def test_load_session_schedules_async_session_visit_model_refresh_after_metadata
     body = _extract_function_body(_read_static("sessions.js"), "async function loadSession(")
 
     assign_idx = body.index("S.session=data.session")
-    promise_idx = body.index("const modelRefreshPromise=Promise.resolve().then(")
     boot_guard_idx = body.index("if(!S._bootReady&&typeof window!=='undefined'&&typeof window._startBootModelDropdown==='function'){")
+    boot_promise_idx = body.index("Promise.resolve().then(()=>{", boot_guard_idx)
     boot_refresh_idx = body.index("return window._startBootModelDropdown();")
+    else_idx = body.index("}else{", boot_refresh_idx)
+    promise_idx = body.index("const modelRefreshPromise=Promise.resolve().then(", else_idx)
     ready_idx = body.index("window._modelDropdownReady=modelRefreshPromise")
     refresh_idx = body.index("populateModelDropdown({freshness:'session_visit'})")
     stale_guard_idx = body.index("_loadingSessionId!==modelRefreshSid")
 
-    assert assign_idx < promise_idx < boot_guard_idx < boot_refresh_idx < refresh_idx < ready_idx
-    assert promise_idx < stale_guard_idx < boot_guard_idx
+    assert assign_idx < boot_guard_idx < boot_promise_idx < boot_refresh_idx < else_idx < promise_idx < refresh_idx < ready_idx
+    assert boot_promise_idx < stale_guard_idx < boot_refresh_idx
+    assert promise_idx < body.index("_loadingSessionId!==modelRefreshSid", promise_idx) < refresh_idx
 
 
-def test_boot_model_dropdown_reuses_inflight_session_visit_refresh():
-    body = _extract_function_body(_read_static("boot.js"), "const _startBootModelDropdown=()=>")
+def test_boot_model_dropdown_clears_cached_ready_on_401():
+    body = _extract_function_body(_read_static("boot.js"), "const _redirectBootModelDropdownIfUnauth=(res)=>")
 
-    ready_idx = body.index("const ready=window._modelDropdownReady;")
-    reuse_idx = body.index("if(ready&&typeof ready.then==='function') return ready;")
-    hydrate_idx = body.index("const next=_hydrateModelDropdown({redirectIfUnauth:_redirectBootModelDropdownIfUnauth});")
+    status_idx = body.index("if(!res||res.status!==401) return false;")
+    clear_idx = body.index("window._modelDropdownReady=null;")
+    consumed_idx = body.index("if(_bootActiveProfileUnauthRedirectBudget.isConsumed()) return true;")
 
-    assert ready_idx < reuse_idx < hydrate_idx
+    assert status_idx < clear_idx < consumed_idx

--- a/tests/test_model_default_boot_precedence.py
+++ b/tests/test_model_default_boot_precedence.py
@@ -179,7 +179,8 @@ def test_boot_settings_applies_default_without_deleting_browser_model_state():
 
 
 def test_boot_model_dropdown_explicitly_requests_profile_default_precedence():
-    assert "populateModelDropdown({preferProfileDefaultOnFreshBoot:true})" in BOOT_JS
+    assert "const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({" in BOOT_JS
+    assert "preferProfileDefaultOnFreshBoot:true" in BOOT_JS
     # #2726 invariant: boot path must keep profile/server default ahead of stale
     # browser-persisted state when a default exists. Post-#2716 cherry-pick onto
     # post-stage-batch11 master uses `stateToApply` pattern rather than the

--- a/tests/test_session_metadata_fast_path.py
+++ b/tests/test_session_metadata_fast_path.py
@@ -64,9 +64,10 @@ def test_boot_does_not_block_session_restore_on_model_catalog():
 
     assert "if(s.default_model){" in src
     assert "window._defaultModel=s.default_model;" in src
-    assert "const _hydrateBootModelDropdown=()=>populateModelDropdown({preferProfileDefaultOnFreshBoot:true}).then" in src
+    assert "const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({" in src
     assert "window._modelDropdownReady=null;" in src
-    assert "window._ensureModelDropdownReady=_startBootModelDropdown;" in src
+    assert "window._startBootModelDropdown=_startBootModelDropdown;" in src
+    assert "window._ensureModelDropdownReady=_startModelDropdown;" in src
     assert "await populateModelDropdown()" not in src
 
 
@@ -80,7 +81,7 @@ def test_boot_primes_model_catalog_without_awaiting_it():
     """
     src = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
 
-    ensure_pos = src.index("window._ensureModelDropdownReady=_startBootModelDropdown;")
+    ensure_pos = src.index("window._ensureModelDropdownReady=_startModelDropdown;")
     prime_pos = src.index("Promise.resolve(_startBootModelDropdown()).catch(()=>{});", ensure_pos)
     session_restore_pos = src.index("await renderSessionList();", prime_pos)
 
@@ -100,18 +101,8 @@ def test_failed_boot_model_catalog_prime_is_retryable():
     src = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
     # #2726 parameterized the call: populateModelDropdown({preferProfileDefaultOnFreshBoot:true})
     # Match either signature shape — empty args (legacy) OR opts arg (post-#2726).
-    candidates = [
-        "const _hydrateBootModelDropdown=()=>populateModelDropdown().then",
-        "const _hydrateBootModelDropdown=()=>populateModelDropdown({preferProfileDefaultOnFreshBoot:true}).then",
-    ]
-    start = -1
-    for needle in candidates:
-        try:
-            start = src.index(needle)
-            break
-        except ValueError:
-            continue
-    assert start >= 0, "boot.js missing _hydrateBootModelDropdown wrapper around populateModelDropdown()"
+    needle = "const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({"
+    start = src.index(needle)
     end = src.index("const _startBootModelDropdown=()=>", start)
     block = src[start:end]
 


### PR DESCRIPTION
## Thinking Path

- #5018 bounded the active-profile boot loop, but boot still continues straight into `populateModelDropdown()` and `/api/models` 401s still route through the old shared `_redirectIfUnauth()` helper.
- That shared helper is still right for non-boot callers like session-visit refreshes and uploads, so the remaining fix needs to stay inside the boot path instead of redefining the helper globally.
- The change shares one boot redirect budget between `/api/profile/active` and the boot-time `/api/models` fetch, then leaves every non-boot caller on the existing behavior.

## What Changed

- `static/boot.js`: add a shared boot-only unauth redirect budget, treat a persisted marker as already-consumed on the next page load, and keep the boot-time model hydration on that budget while leaving `window._ensureModelDropdownReady()` on the normal post-boot 401 path.
- `static/boot.js`: clear the cached boot dropdown promise on boot-time 401 handling, so a consumed boot budget cannot suppress the later generic `/api/models` retry path.
- `static/sessions.js`: route restored-session boot through the boot starter while `S._bootReady` is still false, without aliasing that boot work onto `window._modelDropdownReady`, so the saved-session boot path cannot self-resolve and skip `/api/models`.
- `static/ui.js`: let `populateModelDropdown()` accept an optional unauth redirect callback while defaulting to `_redirectIfUnauth()` for all existing callers.
- `tests/test_5021_boot_model_redirect_budget.py`: add a browserless regression harness for the login-bounce path, the model-only boot 401 path, and the public post-boot `_ensureModelDropdownReady()` retry path.
- `tests/test_session_metadata_fast_path.py` and `tests/test_issue4756_session_visit_model_refresh.py`: keep the existing boot and session-visit source contracts aligned with the split boot-vs-post-boot model starters.
- `tests/test_model_default_boot_precedence.py`: keep the boot-default source contract aligned with the new `_hydrateModelDropdown()` wrapper shape.
- `tests/test_5001_active_profile_recovery.py`: align the existing active-profile harness with the shared boot budget so the original #5001 recovery contract still runs against production code.

## Why It Matters

A genuinely dead session still ends at the login screen, but boot no longer has a second redirect door through `/api/models`. The existing shared 401 helper stays intact for the user-initiated flows that already depend on it.

## Verification

- `python -m pytest tests/test_5001_active_profile_recovery.py tests/test_5021_boot_model_redirect_budget.py tests/test_1038_pwa_auth_redirect.py::TestPWAAuthRedirect::test_ui_js_models_fetch_uses_redirect tests/test_provider_mismatch.py::TestCheckProviderMismatch::test_active_provider_stored_on_model_load tests/test_session_metadata_fast_path.py tests/test_issue4756_session_visit_model_refresh.py tests/test_model_default_boot_precedence.py -v --timeout=60`
- Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`

## Upstream

Closes #5021.

## Model Used

GPT 5.5 via Codex CLI
