### PR TITLE
fix(#5047): coalesce session-visit refresh followers

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -6891,18 +6891,38 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         # of re-entering the cold path (avoids duplicate 10s zai load_pool calls).
         if should_wait:
             wait_timeout = 60.0
-            if force_refresh and _LIVE_REBUILD_BUDGET_SECONDS <= 0:
-                # The legacy synchronous path is explicitly unbounded. A forced
-                # refresh follower should keep coalescing behind that live
-                # rebuild instead of giving up after 60s and duplicating it.
-                wait_timeout = None
+            if force_refresh and force_refresh_started_at is not None:
+                if _LIVE_REBUILD_BUDGET_SECONDS <= 0:
+                    # The legacy synchronous path is explicitly unbounded. A
+                    # forced refresh follower should keep coalescing behind
+                    # that live rebuild instead of giving up after 60s and
+                    # duplicating it.
+                    wait_timeout = None
+                else:
+                    wait_timeout = max(
+                        0.0,
+                        _LIVE_REBUILD_BUDGET_SECONDS - (time.monotonic() - force_refresh_started_at),
+                    )
             _cache_build_cv.wait_for(
                 lambda: not _cache_build_in_progress,
                 timeout=wait_timeout
             )
             cached = _get_fresh_memory_models_cache(time.monotonic())
-            if cached is not None:
+            if (
+                cached is not None
+                and (
+                    not force_refresh
+                    or (
+                        force_refresh_started_at is not None
+                        and _available_models_live_rebuild_ts >= force_refresh_started_at
+                    )
+                )
+            ):
                 return cached
+            if force_refresh and _LIVE_REBUILD_BUDGET_SECONDS > 0 and _cache_build_in_progress:
+                if stale_disk_groups is not None:
+                    return copy.deepcopy(stale_disk_groups)
+                return copy.deepcopy(_static_models_catalog_without_live_probes())
 
         # Reload config if changed
         if _cfg_changed:

--- a/api/config.py
+++ b/api/config.py
@@ -6897,7 +6897,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 # rebuild instead of giving up after 60s and duplicating it.
                 wait_timeout = None
             _cache_build_cv.wait_for(
-                lambda: not _cache_build_in_progress and _available_models_cache is not None,
+                lambda: not _cache_build_in_progress,
                 timeout=wait_timeout
             )
             cached = _get_fresh_memory_models_cache(time.monotonic())

--- a/api/config.py
+++ b/api/config.py
@@ -6890,9 +6890,15 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         # If another thread is already building, wait for its result instead
         # of re-entering the cold path (avoids duplicate 10s zai load_pool calls).
         if should_wait:
+            wait_timeout = 60.0
+            if force_refresh and _LIVE_REBUILD_BUDGET_SECONDS <= 0:
+                # The legacy synchronous path is explicitly unbounded. A forced
+                # refresh follower should keep coalescing behind that live
+                # rebuild instead of giving up after 60s and duplicating it.
+                wait_timeout = None
             _cache_build_cv.wait_for(
                 lambda: not _cache_build_in_progress and _available_models_cache is not None,
-                timeout=60
+                timeout=wait_timeout
             )
             cached = _get_fresh_memory_models_cache(time.monotonic())
             if cached is not None:
@@ -6928,13 +6934,13 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             and force_refresh_started_at is not None
             and _cache_build_in_progress
         ):
-            remaining_budget = 60.0
+            remaining_budget = None
             if _LIVE_REBUILD_BUDGET_SECONDS > 0:
                 remaining_budget = max(
                     0.0,
                     _LIVE_REBUILD_BUDGET_SECONDS - (time.monotonic() - force_refresh_started_at),
                 )
-            if remaining_budget > 0:
+            if remaining_budget is None or remaining_budget > 0:
                 _cache_build_cv.wait_for(
                     lambda: not _cache_build_in_progress,
                     timeout=remaining_budget,

--- a/api/config.py
+++ b/api/config.py
@@ -3915,6 +3915,7 @@ def set_auxiliary_model(task: str, provider: str, model: str, advanced: dict | N
 # ── TTL cache for get_available_models() ─────────────────────────────────────
 _available_models_cache: dict | None = None
 _available_models_cache_ts: float = 0.0
+_available_models_live_rebuild_ts: float = 0.0
 _available_models_cache_source_fingerprint: dict | None = None
 _AVAILABLE_MODELS_CACHE_TTL: float = 86400.0  # 24 hours
 _SESSION_VISIT_MODELS_FRESHNESS_SECONDS: float = 300.0
@@ -5167,7 +5168,8 @@ def _save_models_cache_to_disk(cache: dict) -> None:
 
 def _get_fresh_memory_models_cache(now: float) -> dict | None:
     """Return a valid fresh in-memory /api/models cache, or clear stale shapes."""
-    global _available_models_cache, _available_models_cache_ts, _available_models_cache_source_fingerprint
+    global _available_models_cache, _available_models_cache_ts
+    global _available_models_live_rebuild_ts, _available_models_cache_source_fingerprint
     if _available_models_cache is None:
         return None
     if (now - _available_models_cache_ts) >= _AVAILABLE_MODELS_CACHE_TTL:
@@ -5181,12 +5183,14 @@ def _get_fresh_memory_models_cache(now: float) -> dict | None:
         )
         _available_models_cache = None
         _available_models_cache_ts = 0.0
+        _available_models_live_rebuild_ts = 0.0
         _available_models_cache_source_fingerprint = None
         return None
     if _is_valid_models_cache(_available_models_cache):
         return copy.deepcopy(_available_models_cache)
     _available_models_cache = None
     _available_models_cache_ts = 0.0
+    _available_models_live_rebuild_ts = 0.0
     _available_models_cache_source_fingerprint = None
     return None
 
@@ -5205,10 +5209,12 @@ def invalidate_models_cache():
     result from the disk cache because the disk hit is checked before the memory
     cache rebuild runs.
     """
-    global _cache_build_in_progress, _available_models_cache, _available_models_cache_ts, _available_models_cache_source_fingerprint, _cache_build_cv
+    global _cache_build_in_progress, _available_models_cache, _available_models_cache_ts
+    global _available_models_live_rebuild_ts, _available_models_cache_source_fingerprint, _cache_build_cv
     with _available_models_cache_lock:
         _available_models_cache = None
         _available_models_cache_ts = 0.0
+        _available_models_live_rebuild_ts = 0.0
         _available_models_cache_source_fingerprint = None
         _cache_build_in_progress = False
         _cache_build_cv.notify_all()
@@ -5262,10 +5268,12 @@ def invalidate_provider_models_cache(provider_id: str):
     Args:
         provider_id: canonical provider id (e.g. 'openai', 'anthropic', 'custom:my-key')
     """
-    global _available_models_cache, _available_models_cache_ts, _available_models_cache_source_fingerprint, _CREDENTIAL_POOL_CACHE
+    global _available_models_cache, _available_models_cache_ts
+    global _available_models_live_rebuild_ts, _available_models_cache_source_fingerprint, _CREDENTIAL_POOL_CACHE
     with _available_models_cache_lock:
         _available_models_cache = None
         _available_models_cache_ts = 0.0
+        _available_models_live_rebuild_ts = 0.0
         _available_models_cache_source_fingerprint = None
         _provider_models_invalidated_ts[provider_id] = time.time()
         # Also evict the credential pool so the next cold path re-loads it.
@@ -5443,7 +5451,8 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
     checks that need a real live rebuild while preserving the default cache
     contract for every existing caller.
     """
-    global _cache_build_in_progress, _available_models_cache, _available_models_cache_ts, _available_models_cache_source_fingerprint, _cache_build_cv
+    global _cache_build_in_progress, _available_models_cache, _available_models_cache_ts
+    global _available_models_live_rebuild_ts, _available_models_cache_source_fingerprint, _cache_build_cv
     # Config mtime check — must come before any config reads.
     # (Test #585 verifies _current_mtime appears before active_provider = None)
     try:
@@ -6894,6 +6903,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             reload_config()
             _available_models_cache = None
             _available_models_cache_ts = 0.0
+            _available_models_live_rebuild_ts = 0.0
             _available_models_cache_source_fingerprint = None
             disk_groups = None
             stale_disk_groups = None
@@ -6904,7 +6914,10 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         if cached is not None:
             if not force_refresh:
                 return cached
-            if force_refresh_started_at is not None and _available_models_cache_ts >= force_refresh_started_at:
+            if (
+                force_refresh_started_at is not None
+                and _available_models_live_rebuild_ts >= force_refresh_started_at
+            ):
                 return cached
 
         # A concurrent forced refresh may have started after this caller sampled
@@ -6929,7 +6942,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 cached = _get_fresh_memory_models_cache(time.monotonic())
                 if (
                     cached is not None
-                    and _available_models_cache_ts >= force_refresh_started_at
+                    and _available_models_live_rebuild_ts >= force_refresh_started_at
                 ):
                     return cached
             if _cache_build_in_progress and _LIVE_REBUILD_BUDGET_SECONDS > 0:
@@ -7013,8 +7026,10 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     _cache_build_cv.notify_all()
                 raise
             with _cache_build_cv:
+                published_at = time.monotonic()
                 _available_models_cache = result
-                _available_models_cache_ts = time.monotonic()
+                _available_models_cache_ts = published_at
+                _available_models_live_rebuild_ts = published_at
                 _available_models_cache_source_fingerprint = _models_cache_source_fingerprint()
             try:
                 _save_models_cache_to_disk(result)
@@ -7055,10 +7070,13 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
 
         def _publish_models_result(result):
             global _cache_build_in_progress, _available_models_cache
-            global _available_models_cache_ts, _available_models_cache_source_fingerprint
+            global _available_models_cache_ts, _available_models_live_rebuild_ts
+            global _available_models_cache_source_fingerprint
             with _cache_build_cv:
+                published_at = time.monotonic()
                 _available_models_cache = result
-                _available_models_cache_ts = time.monotonic()
+                _available_models_cache_ts = published_at
+                _available_models_live_rebuild_ts = published_at
                 _available_models_cache_source_fingerprint = (
                     _models_cache_source_fingerprint()
                 )

--- a/api/config.py
+++ b/api/config.py
@@ -6855,6 +6855,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
     # If another thread has already started the cold path, we will wait for
     # its result rather than running the cold path concurrently.
     should_wait = _cache_build_in_progress
+    force_refresh_started_at = time.monotonic() if force_refresh else None
 
     # Check config mtime OUTSIDE the lock so this cheap check doesn't serialize
     # concurrent requests.  Must come before any config reads in the cold path.
@@ -6899,9 +6900,11 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
 
         # Serve from memory cache if fresh
         now = time.monotonic()
-        if not force_refresh:
-            cached = _get_fresh_memory_models_cache(now)
-            if cached is not None:
+        cached = _get_fresh_memory_models_cache(now)
+        if cached is not None:
+            if not force_refresh:
+                return cached
+            if force_refresh_started_at is not None and _available_models_cache_ts >= force_refresh_started_at:
                 return cached
 
         # Cold path: disk cache hit — use it (fast, no lock contention)

--- a/api/config.py
+++ b/api/config.py
@@ -6907,6 +6907,36 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             if force_refresh_started_at is not None and _available_models_cache_ts >= force_refresh_started_at:
                 return cached
 
+        # A concurrent forced refresh may have started after this caller sampled
+        # should_wait but before it acquired the lock. Reuse that in-flight build
+        # instead of launching another one, and preserve this caller's budget.
+        if (
+            force_refresh
+            and force_refresh_started_at is not None
+            and _cache_build_in_progress
+        ):
+            remaining_budget = 60.0
+            if _LIVE_REBUILD_BUDGET_SECONDS > 0:
+                remaining_budget = max(
+                    0.0,
+                    _LIVE_REBUILD_BUDGET_SECONDS - (time.monotonic() - force_refresh_started_at),
+                )
+            if remaining_budget > 0:
+                _cache_build_cv.wait_for(
+                    lambda: not _cache_build_in_progress,
+                    timeout=remaining_budget,
+                )
+                cached = _get_fresh_memory_models_cache(time.monotonic())
+                if (
+                    cached is not None
+                    and _available_models_cache_ts >= force_refresh_started_at
+                ):
+                    return cached
+            if _cache_build_in_progress and _LIVE_REBUILD_BUDGET_SECONDS > 0:
+                if stale_disk_groups is not None:
+                    return copy.deepcopy(stale_disk_groups)
+                return copy.deepcopy(_static_models_catalog_without_live_probes())
+
         # Cold path: disk cache hit — use it (fast, no lock contention)
         if disk_groups is not None and not force_refresh:
             _available_models_cache = disk_groups

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -177,6 +177,65 @@ def test_session_visit_overlapping_stale_calls_coalesce_to_single_live_rebuild(t
     assert rebuild_count == 1
 
 
+def test_force_refresh_sync_followers_wait_past_legacy_timeout(tmp_path, monkeypatch):
+    import api.config as cfg
+    import threading
+
+    _reset_models_memory_cache(monkeypatch)
+    stale_catalog = _catalog("stale-model")
+    rebuilt_catalog = _catalog("rebuilt-model")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("{}", encoding="utf-8")
+    cache_path = tmp_path / "models_cache.profile.json"
+    cache_path.write_text("{}", encoding="utf-8")
+    old = time.time() - 600.0
+    os.utime(cache_path, (old, old))
+    fingerprint = {"profile": "demo"}
+    rebuild_count = 0
+    timeout_waits = []
+    original_wait_for = threading.Condition.wait_for
+
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+    monkeypatch.setattr(cfg, "_cfg_path", config_path, raising=False)
+    monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
+    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda: stale_catalog)
+    monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: fingerprint)
+    monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda _cache: None)
+
+    def _wait_for(self, predicate, timeout=None):
+        if self is not cfg._cache_build_cv:
+            return original_wait_for(self, predicate, timeout)
+        timeout_waits.append(timeout)
+        if timeout is None:
+            published_at = time.monotonic()
+            cfg._available_models_cache = rebuilt_catalog
+            cfg._available_models_cache_ts = published_at
+            cfg._available_models_live_rebuild_ts = published_at
+            cfg._available_models_cache_source_fingerprint = fingerprint
+            cfg._cache_build_in_progress = False
+            return True
+        if timeout == 60.0:
+            return False
+        return original_wait_for(self, predicate, timeout=timeout)
+
+    def _invoke_models_rebuild(_builder):
+        nonlocal rebuild_count
+        rebuild_count += 1
+        return rebuilt_catalog
+
+    monkeypatch.setattr(cfg, "_cache_build_in_progress", True, raising=False)
+    monkeypatch.setattr(threading.Condition, "wait_for", _wait_for)
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _invoke_models_rebuild)
+
+    assert cfg.get_available_models(force_refresh=True) == rebuilt_catalog
+    assert rebuild_count == 0
+    assert None in timeout_waits
+    assert 60.0 not in timeout_waits
+
+
 def test_session_visit_overlapping_stale_calls_do_not_duplicate_over_budget_rebuild(tmp_path, monkeypatch):
     import api.config as cfg
     import threading

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -119,6 +119,63 @@ def test_session_visit_stale_profile_cache_revalidates_with_live_rebuild(tmp_pat
     assert calls == [{"force_refresh": True}]
 
 
+def test_session_visit_overlapping_stale_calls_coalesce_to_single_live_rebuild(tmp_path, monkeypatch):
+    import api.config as cfg
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    _reset_models_memory_cache(monkeypatch)
+    stale_catalog = _catalog("stale-model")
+    rebuilt_catalog = _catalog("rebuilt-model")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("{}", encoding="utf-8")
+    cache_path = tmp_path / "models_cache.profile.json"
+    cache_path.write_text("{}", encoding="utf-8")
+    old = time.time() - 600.0
+    os.utime(cache_path, (old, old))
+    fingerprint = {"profile": "demo"}
+    stale_load_counts = {}
+    stale_load_lock = threading.Lock()
+    second_load_gate = threading.Barrier(2)
+    rebuild_count = 0
+    rebuild_lock = threading.Lock()
+
+    monkeypatch.setattr(cfg, "_SESSION_VISIT_MODELS_FRESHNESS_SECONDS", 300.0, raising=False)
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+    monkeypatch.setattr(cfg, "_cfg_path", config_path, raising=False)
+    monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
+    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: fingerprint)
+    monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda _cache: None)
+
+    def _load_stale_models_cache_from_disk():
+        ident = threading.get_ident()
+        with stale_load_lock:
+            count = stale_load_counts.get(ident, 0) + 1
+            stale_load_counts[ident] = count
+        if count == 2:
+            second_load_gate.wait(timeout=5)
+        return stale_catalog
+
+    def _invoke_models_rebuild(_builder):
+        nonlocal rebuild_count
+        with rebuild_lock:
+            rebuild_count += 1
+        return rebuilt_catalog
+
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", _load_stale_models_cache_from_disk)
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _invoke_models_rebuild)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(cfg.get_available_models_for_session_visit) for _ in range(2)]
+        results = [future.result(timeout=10) for future in futures]
+
+    assert all(result == rebuilt_catalog for result in results)
+    assert rebuild_count == 1
+
+
 def test_session_visit_fresh_disk_hit_does_not_overwrite_newer_memory_cache(tmp_path, monkeypatch):
     import api.config as cfg
 

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -33,6 +33,7 @@ def _reset_models_memory_cache(monkeypatch):
 
     monkeypatch.setattr(cfg, "_available_models_cache", None, raising=False)
     monkeypatch.setattr(cfg, "_available_models_cache_ts", 0.0, raising=False)
+    monkeypatch.setattr(cfg, "_available_models_live_rebuild_ts", 0.0, raising=False)
     monkeypatch.setattr(cfg, "_available_models_cache_source_fingerprint", None, raising=False)
     monkeypatch.setattr(cfg, "_cache_build_in_progress", False, raising=False)
 
@@ -235,6 +236,74 @@ def test_session_visit_overlapping_stale_calls_do_not_duplicate_over_budget_rebu
     time.sleep(0.1)
     assert cfg._available_models_cache == rebuilt_catalog
     assert cfg._cache_build_in_progress is False
+
+
+def test_session_visit_force_refresh_ignores_plain_disk_publish_started_after_refresh(tmp_path, monkeypatch):
+    import api.config as cfg
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    _reset_models_memory_cache(monkeypatch)
+    stale_catalog = _catalog("stale-model")
+    rebuilt_catalog = _catalog("rebuilt-model")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("{}", encoding="utf-8")
+    cache_path = tmp_path / "models_cache.profile.json"
+    cache_path.write_text("{}", encoding="utf-8")
+    old = time.time() - 600.0
+    os.utime(cache_path, (old, old))
+    fingerprint = {"profile": "demo"}
+    stale_load_counts = {}
+    stale_load_lock = threading.Lock()
+    force_refresh_waiting = threading.Event()
+    plain_publish_done = threading.Event()
+    rebuild_count = 0
+    rebuild_lock = threading.Lock()
+
+    monkeypatch.setattr(cfg, "_SESSION_VISIT_MODELS_FRESHNESS_SECONDS", 300.0, raising=False)
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+    monkeypatch.setattr(cfg, "_cfg_path", config_path, raising=False)
+    monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
+    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: stale_catalog)
+    monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: fingerprint)
+    monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda _cache: None)
+
+    def _load_stale_models_cache_from_disk():
+        ident = threading.get_ident()
+        with stale_load_lock:
+            count = stale_load_counts.get(ident, 0) + 1
+            stale_load_counts[ident] = count
+        if count == 2:
+            force_refresh_waiting.set()
+            assert plain_publish_done.wait(timeout=5)
+        return stale_catalog
+
+    def _invoke_models_rebuild(_builder):
+        nonlocal rebuild_count
+        with rebuild_lock:
+            rebuild_count += 1
+        return rebuilt_catalog
+
+    def _plain_disk_hit():
+        result = cfg.get_available_models()
+        plain_publish_done.set()
+        return result
+
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", _load_stale_models_cache_from_disk)
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _invoke_models_rebuild)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        refresh_future = executor.submit(cfg.get_available_models_for_session_visit)
+        assert force_refresh_waiting.wait(timeout=5)
+        plain_result = executor.submit(_plain_disk_hit).result(timeout=10)
+        refresh_result = refresh_future.result(timeout=10)
+
+    assert plain_result == stale_catalog
+    assert refresh_result == rebuilt_catalog
+    assert rebuild_count == 1
+    assert cfg._available_models_cache == rebuilt_catalog
 
 
 def test_session_visit_fresh_disk_hit_does_not_overwrite_newer_memory_cache(tmp_path, monkeypatch):

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -235,6 +235,58 @@ def test_force_refresh_sync_followers_wait_past_legacy_timeout(tmp_path, monkeyp
     assert None in timeout_waits
     assert 60.0 not in timeout_waits
 
+def test_force_refresh_sync_followers_retry_after_failed_active_rebuild(tmp_path, monkeypatch):
+    import api.config as cfg
+    import threading
+
+    _reset_models_memory_cache(monkeypatch)
+    stale_catalog = _catalog("stale-model")
+    rebuilt_catalog = _catalog("rebuilt-model")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("{}", encoding="utf-8")
+    cache_path = tmp_path / "models_cache.profile.json"
+    cache_path.write_text("{}", encoding="utf-8")
+    old = time.time() - 600.0
+    os.utime(cache_path, (old, old))
+    fingerprint = {"profile": "demo"}
+    rebuild_count = 0
+    timeout_waits = []
+    original_wait_for = threading.Condition.wait_for
+
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+    monkeypatch.setattr(cfg, "_cfg_path", config_path, raising=False)
+    monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
+    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda: stale_catalog)
+    monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: fingerprint)
+    monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda _cache: None)
+
+    def _wait_for(self, predicate, timeout=None):
+        if self is not cfg._cache_build_cv:
+            return original_wait_for(self, predicate, timeout)
+        timeout_waits.append(timeout)
+        if timeout is None:
+            cfg._cache_build_in_progress = False
+            return True
+        return original_wait_for(self, predicate, timeout=timeout)
+
+    def _invoke_models_rebuild(_builder):
+        nonlocal rebuild_count
+        rebuild_count += 1
+        return rebuilt_catalog
+
+    monkeypatch.setattr(cfg, "_cache_build_in_progress", True, raising=False)
+    monkeypatch.setattr(threading.Condition, "wait_for", _wait_for)
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _invoke_models_rebuild)
+
+    assert cfg.get_available_models(force_refresh=True) == rebuilt_catalog
+    assert rebuild_count == 1
+    assert None in timeout_waits
+    assert cfg._available_models_cache == rebuilt_catalog
+    assert cfg._cache_build_in_progress is False
+
 
 def test_session_visit_overlapping_stale_calls_do_not_duplicate_over_budget_rebuild(tmp_path, monkeypatch):
     import api.config as cfg

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -176,6 +176,67 @@ def test_session_visit_overlapping_stale_calls_coalesce_to_single_live_rebuild(t
     assert rebuild_count == 1
 
 
+def test_session_visit_overlapping_stale_calls_do_not_duplicate_over_budget_rebuild(tmp_path, monkeypatch):
+    import api.config as cfg
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    _reset_models_memory_cache(monkeypatch)
+    stale_catalog = _catalog("stale-model")
+    rebuilt_catalog = _catalog("rebuilt-model")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("{}", encoding="utf-8")
+    cache_path = tmp_path / "models_cache.profile.json"
+    cache_path.write_text("{}", encoding="utf-8")
+    old = time.time() - 600.0
+    os.utime(cache_path, (old, old))
+    fingerprint = {"profile": "demo"}
+    stale_load_counts = {}
+    stale_load_lock = threading.Lock()
+    second_load_gate = threading.Barrier(2)
+    rebuild_count = 0
+    rebuild_lock = threading.Lock()
+
+    monkeypatch.setattr(cfg, "_SESSION_VISIT_MODELS_FRESHNESS_SECONDS", 300.0, raising=False)
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.01, raising=False)
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+    monkeypatch.setattr(cfg, "_cfg_path", config_path, raising=False)
+    monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
+    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: fingerprint)
+    monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda _cache: None)
+
+    def _load_stale_models_cache_from_disk():
+        ident = threading.get_ident()
+        with stale_load_lock:
+            count = stale_load_counts.get(ident, 0) + 1
+            stale_load_counts[ident] = count
+        if count == 2:
+            second_load_gate.wait(timeout=5)
+        return stale_catalog
+
+    def _invoke_models_rebuild(_builder):
+        nonlocal rebuild_count
+        with rebuild_lock:
+            rebuild_count += 1
+        time.sleep(0.05)
+        return rebuilt_catalog
+
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", _load_stale_models_cache_from_disk)
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _invoke_models_rebuild)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(cfg.get_available_models_for_session_visit) for _ in range(2)]
+        results = [future.result(timeout=10) for future in futures]
+
+    assert all(result == stale_catalog for result in results)
+    assert rebuild_count == 1
+    time.sleep(0.1)
+    assert cfg._available_models_cache == rebuilt_catalog
+    assert cfg._cache_build_in_progress is False
+
+
 def test_session_visit_fresh_disk_hit_does_not_overwrite_newer_memory_cache(tmp_path, monkeypatch):
     import api.config as cfg
 

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -288,6 +288,54 @@ def test_force_refresh_sync_followers_retry_after_failed_active_rebuild(tmp_path
     assert cfg._cache_build_in_progress is False
 
 
+def test_force_refresh_bounded_followers_wait_only_remaining_budget(tmp_path, monkeypatch):
+    import api.config as cfg
+    import threading
+
+    _reset_models_memory_cache(monkeypatch)
+    stale_catalog = _catalog("stale-model")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("{}", encoding="utf-8")
+    cache_path = tmp_path / "models_cache.profile.json"
+    cache_path.write_text("{}", encoding="utf-8")
+    old = time.time() - 600.0
+    os.utime(cache_path, (old, old))
+    fingerprint = {"profile": "demo"}
+    timeout_waits = []
+    original_wait_for = threading.Condition.wait_for
+
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+    monkeypatch.setattr(cfg, "_cfg_path", config_path, raising=False)
+    monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
+    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
+    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda: stale_catalog)
+    monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: fingerprint)
+    monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda _cache: None)
+
+    def _wait_for(self, predicate, timeout=None):
+        if self is not cfg._cache_build_cv:
+            return original_wait_for(self, predicate, timeout)
+        timeout_waits.append(timeout)
+        time.sleep(min(timeout or 0.0, 0.01))
+        return False
+
+    monkeypatch.setattr(cfg, "_cache_build_in_progress", True, raising=False)
+    monkeypatch.setattr(threading.Condition, "wait_for", _wait_for)
+
+    started_at = time.monotonic()
+    result = cfg.get_available_models(force_refresh=True)
+    elapsed = time.monotonic() - started_at
+
+    assert result == stale_catalog
+    assert len(timeout_waits) == 1
+    assert timeout_waits[0] is not None
+    assert 0.0 <= timeout_waits[0] <= 0.05
+    assert 60.0 not in timeout_waits
+    assert elapsed < 0.1
+
+
 def test_session_visit_overlapping_stale_calls_do_not_duplicate_over_budget_rebuild(tmp_path, monkeypatch):
     import api.config as cfg
     import threading


### PR DESCRIPTION
## Thinking Path

- PR `#4798` fixed stale session-load model catalogs by routing stale session visits into `get_available_models(force_refresh=True)`, but overlapping stale visits can still each pay for a full live rebuild because forced-refresh callers skip the post-lock fresh-memory recheck.
- The first coalescing pass needed one more guard, because a plain `/api/models` disk hit can also publish stale memory after a session-visit refresh starts; the follower must only reuse a publication that came from a real live rebuild.
- The final follow-up closes the remaining bounded-latency gap: forced-refresh followers now spend only their remaining foreground budget while another rebuild is already running, ordinary disk-cache publication still can't satisfy a stale session-visit refresh, and the legacy synchronous `HERMES_WEBUI_MODELS_REBUILD_BUDGET=0` path still coalesces behind the active rebuild instead of forking a duplicate one.
- Focused concurrency regressions in the existing `#4756` test module now cover all three edges: the original base bug still drops from two rebuilds to one, the plain `/api/models` interleaving still rebuilds once even if stale memory is warmed mid-flight, and bounded forced-refresh followers now return on their configured budget instead of waiting on the leader's full runtime.

## What Changed

- `api/config.py`: add a live-rebuild publication marker alongside the existing memory-cache timestamp, reset it on cache invalidation paths, require that marker for forced-refresh reuse, cap the `should_wait` follower path to each forced refresh's remaining foreground budget, keep over-budget followers on the existing bounded fallback, and let `force_refresh=True` followers wait indefinitely behind an already-running legacy synchronous rebuild when the configured budget is `0`.
- `tests/test_issue4756_session_visit_model_refresh.py`: keep the overlapping-session-visit regressions, keep the deterministic plain `/api/models` interleaving, and add focused forced-refresh regressions that prove both the legacy synchronous follower path and the bounded follower path honor the intended coalescing and latency contracts.
- Preserve the existing `#4756` session-visit stale-cache and failure-fallback tests without widening the target beyond the current helper path.

## Why It Matters

Rapid tab opens or overlapping boot and session-load paths should not trigger duplicate live provider probes, and they also shouldn't let a stale plain `/api/models` disk hit short-circuit a session-visit refresh, let the legacy synchronous follower path re-enter a rebuild after 60 seconds, or let bounded followers sit behind an in-flight worker longer than their configured foreground budget. This keeps `freshness=session_visit` fresh for the first caller, keeps bounded callers on the existing fallback path when the rebuild runs long, and still avoids redundant provider work without weakening the stale-cache contract that shipped in `#4798`.

## Verification

```text
python -m pytest tests/test_issue4756_session_visit_model_refresh.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `python -m pytest tests/ -v --timeout=60`.

## Upstream

Closes #5047.

Scope follows the session-visit freshness path that shipped in PR #4798.

## Model Used

GPT 5.5 via Codex CLI
