### PR TITLE
fix: sync stale sidecars from newer state.db

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -2379,30 +2379,56 @@ def _sync_sidecar_from_state_db_if_newer(session) -> bool:
         session,
         state_messages=state_messages,
     )
+    # The reconciler is append-only: when state.db genuinely advances the
+    # transcript (new assistant/tool output that the lost stream never wrote
+    # back), that shows up as MORE rows than the sidecar. A merged length that
+    # is not greater than the sidecar means there is nothing new to recover, so
+    # leave the sidecar untouched rather than rewriting it in place.
     if len(merged_messages) <= sidecar_count:
         return False
-
-    # Avoid claiming a stream is still active after we have incorporated rows
-    # from state.db that are newer than the pending turn. The stream may still
-    # lack a journal terminal event, but the durable transcript is no longer the
-    # stale sidecar; clearing pending state lets refresh/loadSession render the
-    # reconciled conversation instead of treating it as an unfinished run forever.
-    session.messages = merged_messages
-    session.context_messages = reconciled_state_db_messages_for_session(
+    merged_context = reconciled_state_db_messages_for_session(
         session,
         prefer_context=True,
         state_messages=state_messages,
     )
+
+    # Persist FIRST on a private snapshot so a failed write never mutates the
+    # shared (and cached) Session object. Mutating ``session`` before the save
+    # succeeds means a raising ``save()`` would leave the in-memory object with
+    # cleared active_stream_id/pending fields while the on-disk sidecar still
+    # holds the unfinished stream — later get_session() reads in this process
+    # would then skip recovery state that still exists durably. (greptile P1:
+    # save failure mutates cache) Only after the durable write succeeds do we
+    # copy the reconciled state back onto the live object.
+    try:
+        snapshot = Session.load(sid)
+    except Exception:
+        snapshot = None
+    if snapshot is None:
+        logger.debug("state.db newer-sidecar sync: snapshot load failed for session %s", sid, exc_info=True)
+        return False
+    snapshot.messages = merged_messages
+    snapshot.context_messages = merged_context
+    snapshot.active_stream_id = None
+    snapshot.pending_user_message = None
+    snapshot.pending_attachments = []
+    snapshot.pending_started_at = None
+    snapshot.pending_user_source = None
+    try:
+        snapshot.save(touch_updated_at=True)
+    except Exception:
+        logger.debug("state.db newer-sidecar sync save failed for session %s", sid, exc_info=True)
+        return False
+
+    # Durable write succeeded — now it is safe to reflect the reconciled state
+    # on the shared/cached object the caller is holding.
+    session.messages = merged_messages
+    session.context_messages = merged_context
     session.active_stream_id = None
     session.pending_user_message = None
     session.pending_attachments = []
     session.pending_started_at = None
     session.pending_user_source = None
-    try:
-        session.save(touch_updated_at=True)
-    except Exception:
-        logger.debug("state.db newer-sidecar sync save failed for session %s", sid, exc_info=True)
-        return False
     logger.info(
         "Session %s: synced sidecar from newer state.db transcript (%d -> %d messages)",
         sid,

--- a/api/models.py
+++ b/api/models.py
@@ -2311,15 +2311,6 @@ def _repair_stale_pending(session) -> bool:
         return False
 
 
-# Grace window (seconds) for the state.db->sidecar read-side self-heal. A turn's
-# active_stream_id + pending_started_at are persisted to the sidecar a moment
-# BEFORE the worker registers the stream in STREAMS/ACTIVE_RUNS. Within this
-# window an in-flight, not-yet-registered stream must not be mistaken for a dead
-# one and cleared. Streams that genuinely lost their terminal event are far
-# older than this, so they still self-heal.
-_STATE_DB_SYNC_REGISTRATION_GRACE_SECONDS = 30.0
-
-
 def _sync_sidecar_from_state_db_if_newer(session) -> bool:
     """Read-side self-heal when WebUI sidecar lags Hermes state.db.
 
@@ -2337,11 +2328,11 @@ def _sync_sidecar_from_state_db_if_newer(session) -> bool:
     if session is None or getattr(session, '_loaded_metadata_only', False):
         return False
     sid = getattr(session, 'session_id', None)
-    if not sid:
+    if not sid or not is_safe_session_id(sid):
         return False
+    seen_stream_id = getattr(session, 'active_stream_id', None)
     has_unfinished_sidecar_turn = bool(
-        getattr(session, 'active_stream_id', None)
-        or getattr(session, 'pending_user_message', None)
+        seen_stream_id or getattr(session, 'pending_user_message', None)
     )
     if not has_unfinished_sidecar_turn:
         return False
@@ -2349,28 +2340,29 @@ def _sync_sidecar_from_state_db_if_newer(session) -> bool:
     # worker. A running turn owns the final writeback (it merges the agent
     # result and clears pending state itself); racing it here would drop its
     # active_stream_id mid-run and make the normal terminal writeback skip as
-    # "stale". Only self-heal once the worker is truly gone from both the SSE
-    # (STREAMS) and worker-lifecycle (ACTIVE_RUNS) registries — the shape where
-    # a stream lost its terminal done/stream_end but state.db kept advancing.
-    active_stream_id = getattr(session, 'active_stream_id', None)
-    if active_stream_id and active_stream_id in _active_stream_ids():
+    # "stale". Only self-heal once the worker is gone from both the SSE
+    # (STREAMS) and worker-lifecycle (ACTIVE_RUNS) registries.
+    if seen_stream_id and seen_stream_id in _active_stream_ids():
         return False
-    # Registration-window race guard. A turn is registered in STREAMS/ACTIVE_RUNS
-    # by the worker thread a moment AFTER the request handler persists
-    # active_stream_id + pending_started_at to the sidecar. In that brief window
-    # the stream is legitimately in flight yet not yet visible in the registries,
-    # so the check above would mis-classify it as a dead stream and clear it.
-    # Treat a *recent* pending_started_at as "still starting up" and refuse to
-    # self-heal it; a stream that genuinely lost its terminal event will have a
-    # pending_started_at well older than this window.
-    if active_stream_id:
-        pending_started_at = getattr(session, 'pending_started_at', None)
-        try:
-            pending_age = time.time() - float(pending_started_at)
-        except (TypeError, ValueError):
-            pending_age = None
-        if pending_age is not None and pending_age < _STATE_DB_SYNC_REGISTRATION_GRACE_SECONDS:
-            return False
+    # Registration-window grace guard (mirrors _repair_stale_pending). A turn is
+    # registered in STREAMS/ACTIVE_RUNS by the worker thread a moment AFTER the
+    # request handler persists active_stream_id + pending_started_at to the
+    # sidecar. Within that window the stream is legitimately in flight yet not
+    # yet visible in the registries, so the liveness check above would
+    # mis-classify it as a dead stream. A recent pending_started_at means "still
+    # starting up" — bail. This also covers cross-process / gateway turns the
+    # local registries cannot see. Falsy pending_started_at (None/0/missing) is
+    # treated as "old enough" so legacy/orphaned sidecars still self-heal.
+    if seen_stream_id:
+        _started = getattr(session, 'pending_started_at', None)
+        if _started:
+            try:
+                _age = time.time() - float(_started)
+            except (TypeError, ValueError):
+                _age = float('inf')
+            if _age < _REPAIR_STALE_PENDING_GRACE_SECONDS:
+                return False
+
     try:
         state_summary = get_state_db_session_summary(
             sid,
@@ -2381,7 +2373,6 @@ def _sync_sidecar_from_state_db_if_newer(session) -> bool:
     except Exception:
         logger.debug("state.db summary check failed for session %s", sid, exc_info=True)
         return False
-
     if state_count <= 0:
         return False
 
@@ -2389,79 +2380,123 @@ def _sync_sidecar_from_state_db_if_newer(session) -> bool:
     sidecar_count = len(sidecar_messages)
     sidecar_last = _last_message_timestamp(sidecar_messages) or 0.0
 
-    # Fast negative: if state.db is not ahead by either count or timestamp, do
-    # not touch the sidecar. This keeps normal in-flight turns cheap and avoids
-    # manufacturing stale recovery rows from older state snapshots.
+    # Fast negative (pre-lock): if state.db is not ahead by either count or
+    # timestamp, do not pay for the lock. This keeps normal reads cheap.
     if state_count <= sidecar_count and state_last <= sidecar_last:
         return False
 
-    state_messages = get_state_db_session_messages(
-        sid,
-        profile=getattr(session, 'profile', None),
-    )
-    if not state_messages:
+    # ── Under-lock critical section ──────────────────────────────────────────
+    # The merge + sidecar write must hold the per-session lock so a concurrent
+    # worker/checkpoint save can neither (a) be clobbered by a stale full-record
+    # write here, nor (b) revive the stream between our liveness check and our
+    # write. Non-blocking acquire: if a caller already holds the lock (retry_last,
+    # undo_last, cancel_stream, the streaming worker's own finalize), bail rather
+    # than deadlock — a later read will retry the self-heal.
+    lock = _get_session_agent_lock(sid)
+    if not lock.acquire(blocking=False):
+        logger.debug(
+            "state.db newer-sidecar sync: lock contended, skipping for session %s", sid,
+        )
         return False
-    merged_messages = reconciled_state_db_messages_for_session(
-        session,
-        state_messages=state_messages,
-    )
-    # The reconciler is append-only: when state.db genuinely advances the
-    # transcript (new assistant/tool output that the lost stream never wrote
-    # back), that shows up as MORE rows than the sidecar. A merged length that
-    # is not greater than the sidecar means there is nothing new to recover, so
-    # leave the sidecar untouched rather than rewriting it in place.
-    if len(merged_messages) <= sidecar_count:
-        return False
-    merged_context = reconciled_state_db_messages_for_session(
-        session,
-        prefer_context=True,
-        state_messages=state_messages,
-    )
-
-    # Persist FIRST on a private snapshot so a failed write never mutates the
-    # shared (and cached) Session object. Mutating ``session`` before the save
-    # succeeds means a raising ``save()`` would leave the in-memory object with
-    # cleared active_stream_id/pending fields while the on-disk sidecar still
-    # holds the unfinished stream — later get_session() reads in this process
-    # would then skip recovery state that still exists durably. (greptile P1:
-    # save failure mutates cache) Only after the durable write succeeds do we
-    # copy the reconciled state back onto the live object.
     try:
-        snapshot = Session.load(sid)
-    except Exception:
-        snapshot = None
-    if snapshot is None:
-        logger.debug("state.db newer-sidecar sync: snapshot load failed for session %s", sid, exc_info=True)
-        return False
-    snapshot.messages = merged_messages
-    snapshot.context_messages = merged_context
-    snapshot.active_stream_id = None
-    snapshot.pending_user_message = None
-    snapshot.pending_attachments = []
-    snapshot.pending_started_at = None
-    snapshot.pending_user_source = None
-    try:
-        snapshot.save(touch_updated_at=True)
-    except Exception:
-        logger.debug("state.db newer-sidecar sync save failed for session %s", sid, exc_info=True)
-        return False
+        # Re-load the authoritative on-disk session under the lock so we both
+        # validate against (and write back) the very latest sidecar — never a
+        # snapshot captured before the lock that could clobber a newer write.
+        try:
+            locked = Session.load(sid)
+        except Exception:
+            logger.debug(
+                "state.db newer-sidecar sync: locked reload failed for session %s",
+                sid, exc_info=True,
+            )
+            return False
+        if locked is None:
+            return False
 
-    # Durable write succeeded — now it is safe to reflect the reconciled state
-    # on the shared/cached object the caller is holding.
-    session.messages = merged_messages
-    session.context_messages = merged_context
-    session.active_stream_id = None
-    session.pending_user_message = None
-    session.pending_attachments = []
-    session.pending_started_at = None
-    session.pending_user_source = None
-    logger.info(
-        "Session %s: synced sidecar from newer state.db transcript (%d -> %d messages)",
-        sid,
-        sidecar_count,
-        len(merged_messages),
-    )
-    return True
+        # Re-check liveness conditions against the freshly-loaded state: the
+        # stream may have rotated (compression), come back alive, terminated and
+        # cleared its own pending state, or had its turn finalized while we
+        # waited. Any of these means there is nothing stale to repair.
+        locked_stream_id = getattr(locked, 'active_stream_id', None)
+        if locked_stream_id != seen_stream_id:
+            return False
+        if not (locked_stream_id or getattr(locked, 'pending_user_message', None)):
+            return False
+        if locked_stream_id and locked_stream_id in _active_stream_ids():
+            return False
+        if locked_stream_id:
+            _lstarted = getattr(locked, 'pending_started_at', None)
+            if _lstarted:
+                try:
+                    _lage = time.time() - float(_lstarted)
+                except (TypeError, ValueError):
+                    _lage = float('inf')
+                if _lage < _REPAIR_STALE_PENDING_GRACE_SECONDS:
+                    return False
+
+        locked_messages = list(getattr(locked, 'messages', None) or [])
+        locked_count = len(locked_messages)
+
+        state_messages = get_state_db_session_messages(
+            sid,
+            profile=getattr(locked, 'profile', None),
+        )
+        if not state_messages:
+            return False
+        merged_messages = reconciled_state_db_messages_for_session(
+            locked,
+            state_messages=state_messages,
+        )
+        # The reconciler is append-only: a genuine state.db advance (output the
+        # lost stream never wrote back) shows up as MORE rows than the sidecar.
+        # A merged length not greater than the sidecar means nothing new to
+        # recover — leave the sidecar untouched rather than rewriting in place.
+        if len(merged_messages) <= locked_count:
+            return False
+        merged_context = reconciled_state_db_messages_for_session(
+            locked,
+            prefer_context=True,
+            state_messages=state_messages,
+        )
+
+        # Mutate + persist the freshly-loaded, locked object. Because we hold the
+        # lock and reloaded under it, this save cannot clobber a concurrent
+        # writer's newer record.
+        locked.messages = merged_messages
+        locked.context_messages = merged_context
+        locked.active_stream_id = None
+        locked.pending_user_message = None
+        locked.pending_attachments = []
+        locked.pending_started_at = None
+        locked.pending_user_source = None
+        try:
+            locked.save(touch_updated_at=True)
+        except Exception:
+            logger.debug(
+                "state.db newer-sidecar sync save failed for session %s",
+                sid, exc_info=True,
+            )
+            return False
+
+        # Durable write succeeded — reflect the reconciled state on the caller's
+        # shared/cached object so the in-flight read returns the recovered data.
+        session.messages = merged_messages
+        session.context_messages = merged_context
+        session.active_stream_id = None
+        session.pending_user_message = None
+        session.pending_attachments = []
+        session.pending_started_at = None
+        session.pending_user_source = None
+        logger.info(
+            "Session %s: synced sidecar from newer state.db transcript (%d -> %d messages)",
+            sid,
+            locked_count,
+            len(merged_messages),
+        )
+        return True
+    finally:
+        lock.release()
+
 
 
 def _last_non_tool_role(messages) -> str:

--- a/api/models.py
+++ b/api/models.py
@@ -2311,6 +2311,15 @@ def _repair_stale_pending(session) -> bool:
         return False
 
 
+# Grace window (seconds) for the state.db->sidecar read-side self-heal. A turn's
+# active_stream_id + pending_started_at are persisted to the sidecar a moment
+# BEFORE the worker registers the stream in STREAMS/ACTIVE_RUNS. Within this
+# window an in-flight, not-yet-registered stream must not be mistaken for a dead
+# one and cleared. Streams that genuinely lost their terminal event are far
+# older than this, so they still self-heal.
+_STATE_DB_SYNC_REGISTRATION_GRACE_SECONDS = 30.0
+
+
 def _sync_sidecar_from_state_db_if_newer(session) -> bool:
     """Read-side self-heal when WebUI sidecar lags Hermes state.db.
 
@@ -2346,6 +2355,22 @@ def _sync_sidecar_from_state_db_if_newer(session) -> bool:
     active_stream_id = getattr(session, 'active_stream_id', None)
     if active_stream_id and active_stream_id in _active_stream_ids():
         return False
+    # Registration-window race guard. A turn is registered in STREAMS/ACTIVE_RUNS
+    # by the worker thread a moment AFTER the request handler persists
+    # active_stream_id + pending_started_at to the sidecar. In that brief window
+    # the stream is legitimately in flight yet not yet visible in the registries,
+    # so the check above would mis-classify it as a dead stream and clear it.
+    # Treat a *recent* pending_started_at as "still starting up" and refuse to
+    # self-heal it; a stream that genuinely lost its terminal event will have a
+    # pending_started_at well older than this window.
+    if active_stream_id:
+        pending_started_at = getattr(session, 'pending_started_at', None)
+        try:
+            pending_age = time.time() - float(pending_started_at)
+        except (TypeError, ValueError):
+            pending_age = None
+        if pending_age is not None and pending_age < _STATE_DB_SYNC_REGISTRATION_GRACE_SECONDS:
+            return False
     try:
         state_summary = get_state_db_session_summary(
             sid,
@@ -2356,6 +2381,7 @@ def _sync_sidecar_from_state_db_if_newer(session) -> bool:
     except Exception:
         logger.debug("state.db summary check failed for session %s", sid, exc_info=True)
         return False
+
     if state_count <= 0:
         return False
 

--- a/api/models.py
+++ b/api/models.py
@@ -2311,6 +2311,107 @@ def _repair_stale_pending(session) -> bool:
         return False
 
 
+def _sync_sidecar_from_state_db_if_newer(session) -> bool:
+    """Read-side self-heal when WebUI sidecar lags Hermes state.db.
+
+    A WebUI stream can lose its terminal ``done``/``stream_end`` path while the
+    underlying agent continues writing messages to ``state.db``. In that shape
+    the browser briefly shows live SSE output, but a refresh reloads the stale
+    sidecar JSON and the already-produced text appears to vanish. Reconcile the
+    sidecar from state.db whenever the state transcript is visibly newer than
+    the sidecar, even if the sidecar still carries an ``active_stream_id``.
+
+    This deliberately reuses the existing append-only reconciler so workspace
+    prefixes, timestamp drift, compaction watermarks, and tool metadata keep the
+    same semantics as normal WebUI/state.db display merging.
+    """
+    if session is None or getattr(session, '_loaded_metadata_only', False):
+        return False
+    sid = getattr(session, 'session_id', None)
+    if not sid:
+        return False
+    has_unfinished_sidecar_turn = bool(
+        getattr(session, 'active_stream_id', None)
+        or getattr(session, 'pending_user_message', None)
+    )
+    if not has_unfinished_sidecar_turn:
+        return False
+    # Never reconcile while the sidecar's stream is still a LIVE in-process
+    # worker. A running turn owns the final writeback (it merges the agent
+    # result and clears pending state itself); racing it here would drop its
+    # active_stream_id mid-run and make the normal terminal writeback skip as
+    # "stale". Only self-heal once the worker is truly gone from both the SSE
+    # (STREAMS) and worker-lifecycle (ACTIVE_RUNS) registries — the shape where
+    # a stream lost its terminal done/stream_end but state.db kept advancing.
+    active_stream_id = getattr(session, 'active_stream_id', None)
+    if active_stream_id and active_stream_id in _active_stream_ids():
+        return False
+    try:
+        state_summary = get_state_db_session_summary(
+            sid,
+            profile=getattr(session, 'profile', None),
+        )
+        state_count = int(state_summary.get('message_count') or 0)
+        state_last = float(state_summary.get('last_message_at') or 0.0)
+    except Exception:
+        logger.debug("state.db summary check failed for session %s", sid, exc_info=True)
+        return False
+    if state_count <= 0:
+        return False
+
+    sidecar_messages = list(getattr(session, 'messages', None) or [])
+    sidecar_count = len(sidecar_messages)
+    sidecar_last = _last_message_timestamp(sidecar_messages) or 0.0
+
+    # Fast negative: if state.db is not ahead by either count or timestamp, do
+    # not touch the sidecar. This keeps normal in-flight turns cheap and avoids
+    # manufacturing stale recovery rows from older state snapshots.
+    if state_count <= sidecar_count and state_last <= sidecar_last:
+        return False
+
+    state_messages = get_state_db_session_messages(
+        sid,
+        profile=getattr(session, 'profile', None),
+    )
+    if not state_messages:
+        return False
+    merged_messages = reconciled_state_db_messages_for_session(
+        session,
+        state_messages=state_messages,
+    )
+    if len(merged_messages) <= sidecar_count:
+        return False
+
+    # Avoid claiming a stream is still active after we have incorporated rows
+    # from state.db that are newer than the pending turn. The stream may still
+    # lack a journal terminal event, but the durable transcript is no longer the
+    # stale sidecar; clearing pending state lets refresh/loadSession render the
+    # reconciled conversation instead of treating it as an unfinished run forever.
+    session.messages = merged_messages
+    session.context_messages = reconciled_state_db_messages_for_session(
+        session,
+        prefer_context=True,
+        state_messages=state_messages,
+    )
+    session.active_stream_id = None
+    session.pending_user_message = None
+    session.pending_attachments = []
+    session.pending_started_at = None
+    session.pending_user_source = None
+    try:
+        session.save(touch_updated_at=True)
+    except Exception:
+        logger.debug("state.db newer-sidecar sync save failed for session %s", sid, exc_info=True)
+        return False
+    logger.info(
+        "Session %s: synced sidecar from newer state.db transcript (%d -> %d messages)",
+        sid,
+        sidecar_count,
+        len(merged_messages),
+    )
+    return True
+
+
 def _last_non_tool_role(messages) -> str:
     if not isinstance(messages, list):
         return ''
@@ -2546,6 +2647,14 @@ def get_session(sid, metadata_only=False):
                     "lazy journal-retry failed on cache hit for session %s",
                     sid, exc_info=True,
                 )
+        if not metadata_only:
+            try:
+                _sync_sidecar_from_state_db_if_newer(cached)
+            except Exception:
+                logger.debug(
+                    "state.db newer-sidecar sync failed on cache hit for session %s",
+                    sid, exc_info=True,
+                )
         return cached
     if metadata_only:
         s = Session.load_metadata_only(sid)
@@ -2561,12 +2670,13 @@ def get_session(sid, metadata_only=False):
                 SESSIONS.popitem(last=False)  # evict least recently used
         if not metadata_only:
             try:
-                repaired = _repair_stale_pending(s)
+                synced_from_state = _sync_sidecar_from_state_db_if_newer(s)
+                repaired = False if synced_from_state else _repair_stale_pending(s)
                 # If the stale-pending repair did not fire but the session
                 # already carries a pending-journal-retry marker (e.g. set on
                 # a previous repair pass), give the lazy-retry path one
                 # chance to self-heal on this read.
-                if not repaired and _session_has_pending_journal_retry(s):
+                if not repaired and not synced_from_state and _session_has_pending_journal_retry(s):
                     try:
                         _try_retry_journal_recovery_in_place(s)
                     except Exception:

--- a/tests/test_session_lost_response_regression.py
+++ b/tests/test_session_lost_response_regression.py
@@ -870,3 +870,111 @@ def test_get_session_does_not_sync_while_stream_is_still_live(monkeypatch):
     assert loaded.active_stream_id == stream_id
     assert loaded.pending_user_message == "new request"
     assert [m["content"] for m in loaded.messages] == ["old question", "old answer"]
+
+
+def test_sync_save_failure_does_not_mutate_session(monkeypatch):
+    """If the durable snapshot save raises, the live object must stay untouched.
+
+    The sync mutates the shared/cached Session only AFTER persisting a private
+    snapshot. A failing save must leave active_stream_id/pending fields intact
+    so later reads still see the unfinished stream that is still on disk.
+    Tests the helper directly to isolate it from _repair_stale_pending, which
+    has its own (separate) dead-stream pending cleanup. (greptile P1)
+    """
+    sid = "state_sync_save_fail_sid"
+    stream_id = "stream_save_fail_no_done"
+    s = Session(
+        session_id=sid,
+        title="Save failure",
+        messages=[
+            {"role": "user", "content": "old question", "timestamp": 100.0},
+            {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        ],
+        active_stream_id=stream_id,
+        pending_user_message="new request",
+        pending_started_at=102.0,
+    )
+    s.save()
+
+    state_messages = [
+        {"role": "user", "content": "old question", "timestamp": 100.0},
+        {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        {"role": "user", "content": "new request", "timestamp": 102.0},
+        {"role": "assistant", "content": "recovered text", "timestamp": 103.0},
+    ]
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_summary",
+        lambda sid_arg, profile=None: {"message_count": len(state_messages), "last_message_at": 103.0},
+    )
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_messages",
+        lambda sid_arg, **kwargs: list(state_messages),
+    )
+
+    # Force the snapshot save to fail.
+    def boom(self, *args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Session, "save", boom)
+
+    result = models._sync_sidecar_from_state_db_if_newer(s)
+
+    # Sync reports failure and the live object is NOT mutated.
+    assert result is False
+    assert s.active_stream_id == stream_id
+    assert s.pending_user_message == "new request"
+    assert [m["content"] for m in s.messages] == ["old question", "old answer"]
+
+
+def test_sync_persists_recovered_state_db_tail_when_stream_dead(monkeypatch):
+    """Happy path: dead stream + newer state.db tail is written back durably.
+
+    Mutates the live object only after the snapshot save succeeds, and the
+    reconciled transcript reaches both memory and disk.
+    """
+    sid = "state_sync_ok_sid"
+    stream_id = "stream_dead_no_done"
+    s = Session(
+        session_id=sid,
+        title="Recover tail",
+        messages=[
+            {"role": "user", "content": "old question", "timestamp": 100.0},
+            {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        ],
+        active_stream_id=stream_id,
+        pending_user_message="new request",
+        pending_started_at=102.0,
+    )
+    s.save()
+
+    state_messages = [
+        {"role": "user", "content": "old question", "timestamp": 100.0},
+        {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        {"role": "user", "content": "new request", "timestamp": 102.0},
+        {"role": "assistant", "content": "recovered tail", "timestamp": 103.0},
+    ]
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_summary",
+        lambda sid_arg, profile=None: {"message_count": len(state_messages), "last_message_at": 103.0},
+    )
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_messages",
+        lambda sid_arg, **kwargs: list(state_messages),
+    )
+
+    result = models._sync_sidecar_from_state_db_if_newer(s)
+
+    assert result is True
+    assert s.active_stream_id is None
+    assert s.pending_user_message is None
+    assert [m["content"] for m in s.messages] == [m["content"] for m in state_messages]
+
+    reloaded = Session.load(sid)
+    assert reloaded.active_stream_id is None
+    assert reloaded.messages[-1]["content"] == "recovered tail"
+
+

--- a/tests/test_session_lost_response_regression.py
+++ b/tests/test_session_lost_response_regression.py
@@ -1041,4 +1041,123 @@ def test_sync_skips_during_registration_window_recent_pending(monkeypatch):
     assert reloaded.pending_user_message == "new request"
 
 
+def test_sync_backs_off_when_session_lock_is_held(monkeypatch):
+    """Lock contention: self-heal must not write while another writer holds the
+    per-session lock.
+
+    The reconcile + sidecar write happen under the per-session agent lock so a
+    concurrent worker/checkpoint save can't be clobbered. If the lock is already
+    held (the worker is mid-writeback), the self-heal must back off entirely and
+    leave the sidecar untouched rather than racing a full-record overwrite.
+    """
+    sid = "state_lock_contended_sid"
+    stream_id = "stream_dead_but_locked"
+    s = Session(
+        session_id=sid,
+        title="Lock contended",
+        messages=[
+            {"role": "user", "content": "old question", "timestamp": 100.0},
+            {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        ],
+        active_stream_id=stream_id,
+        pending_user_message="new request",
+        pending_started_at=102.0,  # old → past grace window
+    )
+    s.save()
+
+    state_messages = [
+        {"role": "user", "content": "old question", "timestamp": 100.0},
+        {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        {"role": "user", "content": "new request", "timestamp": 102.0},
+        {"role": "assistant", "content": "recovered tail", "timestamp": 103.0},
+    ]
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_summary",
+        lambda sid_arg, profile=None: {"message_count": len(state_messages), "last_message_at": 103.0},
+    )
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_messages",
+        lambda sid_arg, **kwargs: list(state_messages),
+    )
+
+    # Simulate a concurrent holder of the per-session lock (e.g. the worker's own
+    # finalize path) so the non-blocking acquire fails.
+    lock = models._get_session_agent_lock(sid)
+    assert lock.acquire(blocking=False)
+    try:
+        result = models._sync_sidecar_from_state_db_if_newer(s)
+    finally:
+        lock.release()
+
+    # Self-heal backed off; nothing was written and the live object is untouched.
+    assert result is False
+    assert s.active_stream_id == stream_id
+    assert s.pending_user_message == "new request"
+    assert [m["content"] for m in s.messages] == ["old question", "old answer"]
+
+    reloaded = Session.load(sid)
+    assert reloaded.active_stream_id == stream_id
+    assert [m["content"] for m in reloaded.messages] == ["old question", "old answer"]
+
+
+def test_sync_revalidates_against_concurrent_disk_write_under_lock(monkeypatch):
+    """Under-lock reload: a newer concurrent sidecar write is not clobbered.
+
+    The self-heal reloads the session under the lock and writes back the
+    reconciled result based on that fresh load, not a snapshot captured before
+    the lock. If a concurrent writer rotated the stream / cleared pending on disk
+    after our pre-lock read, the under-lock recheck must observe it and back off
+    rather than overwriting the whole record with our stale view.
+    """
+    sid = "state_concurrent_disk_write_sid"
+    stream_id = "stream_pre_lock"
+    s = Session(
+        session_id=sid,
+        title="Concurrent disk write",
+        messages=[
+            {"role": "user", "content": "old question", "timestamp": 100.0},
+            {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        ],
+        active_stream_id=stream_id,
+        pending_user_message="new request",
+        pending_started_at=102.0,
+    )
+    s.save()
+
+    state_messages = [
+        {"role": "user", "content": "old question", "timestamp": 100.0},
+        {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        {"role": "user", "content": "new request", "timestamp": 102.0},
+        {"role": "assistant", "content": "recovered tail", "timestamp": 103.0},
+    ]
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_summary",
+        lambda sid_arg, profile=None: {"message_count": len(state_messages), "last_message_at": 103.0},
+    )
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_messages",
+        lambda sid_arg, **kwargs: list(state_messages),
+    )
+
+    # Between the caller's pre-lock view (s, still pointing at stream_id) and the
+    # under-lock reload, a concurrent worker finalized the turn on disk: the
+    # sidecar now has a DIFFERENT active_stream_id. The under-lock recheck must
+    # detect the mismatch and refuse to clobber.
+    disk = Session.load(sid)
+    disk.active_stream_id = "rotated_stream_after_compression"
+    disk.save(touch_updated_at=False)
+
+    result = models._sync_sidecar_from_state_db_if_newer(s)
+
+    assert result is False
+    # On-disk record keeps the concurrent writer's value — not overwritten.
+    reloaded = Session.load(sid)
+    assert reloaded.active_stream_id == "rotated_stream_after_compression"
+
+
+
 

--- a/tests/test_session_lost_response_regression.py
+++ b/tests/test_session_lost_response_regression.py
@@ -17,6 +17,7 @@ The scenario this test pins down:
 """
 from concurrent.futures import ThreadPoolExecutor
 import threading
+import time
 
 import pytest
 
@@ -976,5 +977,68 @@ def test_sync_persists_recovered_state_db_tail_when_stream_dead(monkeypatch):
     reloaded = Session.load(sid)
     assert reloaded.active_stream_id is None
     assert reloaded.messages[-1]["content"] == "recovered tail"
+
+
+def test_sync_skips_during_registration_window_recent_pending(monkeypatch):
+    """Registration-window race: a just-submitted, not-yet-registered stream
+    must NOT be cleared by the self-heal.
+
+    The request handler persists active_stream_id + pending_started_at to the
+    sidecar a moment BEFORE the worker thread registers the stream in
+    STREAMS/ACTIVE_RUNS. In that window the stream is absent from the registries
+    but the turn is legitimately starting. A *recent* pending_started_at must
+    keep the self-heal off so it can't drop a turn that is about to run.
+    (maintainer-requested regression)
+    """
+    sid = "state_registration_window_sid"
+    stream_id = "stream_just_submitted_not_registered"
+    s = Session(
+        session_id=sid,
+        title="Registration window",
+        messages=[
+            {"role": "user", "content": "old question", "timestamp": 100.0},
+            {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        ],
+        active_stream_id=stream_id,
+        pending_user_message="new request",
+        # Submitted just now: inside the registration grace window.
+        pending_started_at=time.time(),
+    )
+    s.save()
+
+    # state.db is ahead (the new turn's worker has started writing rows), which
+    # would otherwise satisfy the "newer transcript" gate.
+    state_messages = [
+        {"role": "user", "content": "old question", "timestamp": 100.0},
+        {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        {"role": "user", "content": "new request", "timestamp": time.time()},
+        {"role": "assistant", "content": "first streamed token", "timestamp": time.time()},
+    ]
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_summary",
+        lambda sid_arg, profile=None: {"message_count": len(state_messages), "last_message_at": time.time()},
+    )
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_messages",
+        lambda sid_arg, **kwargs: list(state_messages),
+    )
+    # The stream is NOT in STREAMS/ACTIVE_RUNS yet (registration not done).
+    config.STREAMS.pop(stream_id, None)
+    config.ACTIVE_RUNS.pop(stream_id, None)
+
+    result = models._sync_sidecar_from_state_db_if_newer(s)
+
+    # Self-heal must back off: the turn is still starting up.
+    assert result is False
+    assert s.active_stream_id == stream_id
+    assert s.pending_user_message == "new request"
+    assert [m["content"] for m in s.messages] == ["old question", "old answer"]
+
+    reloaded = Session.load(sid)
+    assert reloaded.active_stream_id == stream_id
+    assert reloaded.pending_user_message == "new request"
+
 
 

--- a/tests/test_session_lost_response_regression.py
+++ b/tests/test_session_lost_response_regression.py
@@ -755,3 +755,118 @@ def test_repair_stale_pending_skips_parent_when_continuation_exists(hermes_home)
     assert parent.active_stream_id == "rotated-stream"
     assert parent.pending_user_message
 
+def test_get_session_syncs_sidecar_from_newer_state_db_even_when_stream_not_terminal(monkeypatch):
+    """Refresh should not lose text that already reached state.db.
+
+    Repro shape from a source-WebUI run: sidecar JSON still has
+    active_stream_id/pending_user_message and ends at the previous completed
+    turn, while the underlying Hermes agent has already written the current
+    user/assistant/tool rows to state.db. The run journal has no terminal done,
+    so stale-pending repair deliberately does not fire; read-side reconciliation
+    must still sync the sidecar from state.db.
+    """
+    sid = "state_newer_sid"
+    stream_id = "stream_live_no_done"
+    s = Session(
+        session_id=sid,
+        title="State newer",
+        messages=[
+            {"role": "user", "content": "old question", "timestamp": 100.0},
+            {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        ],
+        context_messages=[
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ],
+        active_stream_id=stream_id,
+        pending_user_message="new request",
+        pending_started_at=102.0,
+    )
+    s.save()
+    models.SESSIONS.pop(sid, None)
+
+    state_messages = [
+        {"role": "user", "content": "old question", "timestamp": 100.0},
+        {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        {"role": "user", "content": "new request", "timestamp": 102.0},
+        {"role": "assistant", "content": "visible text that disappeared", "timestamp": 103.0},
+        {"role": "tool", "content": "tool result", "timestamp": 104.0},
+        {"role": "assistant", "content": "latest live progress", "timestamp": 105.0},
+    ]
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_summary",
+        lambda sid_arg, profile=None: {"message_count": len(state_messages), "last_message_at": 105.0},
+    )
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_messages",
+        lambda sid_arg, **kwargs: list(state_messages),
+    )
+
+    loaded = models.get_session(sid)
+
+    assert loaded.active_stream_id is None
+    assert loaded.pending_user_message is None
+    assert [m["content"] for m in loaded.messages] == [m["content"] for m in state_messages]
+    assert loaded.context_messages[-1]["content"] == "latest live progress"
+
+    reloaded = Session.load(sid)
+    assert reloaded.active_stream_id is None
+    assert reloaded.pending_user_message is None
+    assert reloaded.messages[-1]["content"] == "latest live progress"
+
+
+def test_get_session_does_not_sync_while_stream_is_still_live(monkeypatch):
+    """A still-running worker owns its own writeback; do not race it.
+
+    If the sidecar's active_stream_id is still present in STREAMS/ACTIVE_RUNS,
+    the turn is live and will merge the agent result + clear pending state when
+    it ends. Read-side reconciliation must skip so it cannot drop the active
+    stream mid-run and make the terminal writeback look stale.
+    """
+    sid = "state_newer_live_stream_sid"
+    stream_id = "stream_still_live"
+    s = Session(
+        session_id=sid,
+        title="Live stream",
+        messages=[
+            {"role": "user", "content": "old question", "timestamp": 100.0},
+            {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        ],
+        active_stream_id=stream_id,
+        pending_user_message="new request",
+        pending_started_at=102.0,
+    )
+    s.save()
+    models.SESSIONS.pop(sid, None)
+
+    state_messages = [
+        {"role": "user", "content": "old question", "timestamp": 100.0},
+        {"role": "assistant", "content": "old answer", "timestamp": 101.0},
+        {"role": "user", "content": "new request", "timestamp": 102.0},
+        {"role": "assistant", "content": "partial live text", "timestamp": 103.0},
+    ]
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_summary",
+        lambda sid_arg, profile=None: {"message_count": len(state_messages), "last_message_at": 103.0},
+    )
+    monkeypatch.setattr(
+        models,
+        "get_state_db_session_messages",
+        lambda sid_arg, **kwargs: list(state_messages),
+    )
+
+    # Mark the stream as a live in-process worker.
+    config.ACTIVE_RUNS[stream_id] = {"session_id": sid, "stream_id": stream_id}
+    try:
+        loaded = models.get_session(sid)
+    finally:
+        config.ACTIVE_RUNS.pop(stream_id, None)
+
+    # The live turn keeps owning its writeback: pending state is untouched and
+    # the sidecar transcript is not force-synced from the mid-run state.db rows.
+    assert loaded.active_stream_id == stream_id
+    assert loaded.pending_user_message == "new request"
+    assert [m["content"] for m in loaded.messages] == ["old question", "old answer"]


### PR DESCRIPTION
## Summary

- add a read-side self-heal that reconciles a WebUI session sidecar from `state.db` when the state transcript is visibly newer than the sidecar
- clear stale `active_stream_id` / pending-turn fields after syncing the durable transcript so refreshes do not keep treating the run as unfinished
- add a regression covering a non-terminal stream where the live text already reached `state.db` but not the WebUI JSON sidecar

## Why

A source WebUI stream can lose its terminal `done` / `stream_end` path while the underlying Hermes agent continues writing messages to `state.db`. In that shape, the browser can briefly show live SSE output, but refreshing reloads the stale WebUI sidecar JSON, making already-produced assistant text appear to disappear permanently.

The new sync path only runs when `state.db` is ahead by message count or latest timestamp, and it reuses the existing append-only reconciliation logic to preserve workspace-prefix, timestamp-drift, compaction, and tool metadata semantics.

## Tests

- `python -m py_compile api/models.py`
- `python -m pytest tests/test_session_lost_response_regression.py -q`
- `python -m pytest tests/test_session_lost_response_regression.py tests/test_session_sidecar_repair.py -q` → 89 passed
