### PR TITLE
Serve dashboard plugin backends (plugin_api.py)

### DIFF
--- a/api/plugins.py
+++ b/api/plugins.py
@@ -183,3 +183,108 @@ def get_plugin_metadata() -> list[dict]:
             "hooks": [],
         })
     return plugins
+
+
+# ── Dashboard plugin backends (plugin_api.py) ──────────────────────────────
+# A dashboard plugin may declare an optional Python backend via manifest "api"
+# (e.g. "plugin_api.py") that exposes a FastAPI ``APIRouter`` named ``router``.
+# The WebUI serves its GET routes (read-only) under /api/plugins/<name>/<route>
+# so the plugin's built frontend can fetch its own data. Without this, such a
+# dashboard loads its assets but every data fetch 404s (blank panel).
+#
+# Requires FastAPI to be importable so the plugin's ``@router.get(...)`` routes
+# are registered; if it is not installed, plugin backends are skipped gracefully
+# (the panel still loads, just without live data).
+
+# plugin_name -> imported plugin_api module (or None if absent/failed)
+_PLUGIN_API_MODULES: dict[str, object] = {}
+
+
+def _load_plugin_api(plugin_name: str):
+    if plugin_name in _PLUGIN_API_MODULES:
+        return _PLUGIN_API_MODULES[plugin_name]
+    module = None
+    manifest = PLUGIN_MANIFESTS.get(plugin_name)
+    root = _PLUGIN_STATIC_ROOTS.get(plugin_name)
+    api_file = (manifest or {}).get("api")
+    if manifest and root and api_file:
+        try:
+            api_path = (root / api_file).resolve()
+            api_path.relative_to(root)  # reject traversal outside dashboard/
+            if api_path.is_file():
+                import importlib.util
+                import sys
+                spec = importlib.util.spec_from_file_location(f"_hermes_plugin_api_{plugin_name}", api_path)
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[spec.name] = module
+                spec.loader.exec_module(module)
+        except Exception:
+            logger.exception("Failed to import plugin_api for plugin %s", plugin_name)
+            module = None
+    _PLUGIN_API_MODULES[plugin_name] = module
+    return module
+
+
+def _coerce_endpoint_kwargs(endpoint, query: dict) -> dict:
+    """Build call kwargs for a router endpoint from the query string.
+
+    Coerces present query values to the parameter's annotation, and unwraps a
+    FastAPI ``Query(...)``/``Param(...)`` default object to its plain default for
+    absent params (so the endpoint isn't called with the marker object).
+    """
+    import inspect
+    kwargs: dict = {}
+    for name, p in inspect.signature(endpoint).parameters.items():
+        if name in query and query[name]:
+            raw = query[name][0]
+            # annotation may be a real type or a string (PEP 563 / from __future__ import annotations)
+            ann = p.annotation
+            ann_name = ann if isinstance(ann, str) else getattr(ann, "__name__", ann)
+            try:
+                if ann_name == "int":
+                    kwargs[name] = int(raw)
+                elif ann_name == "float":
+                    kwargs[name] = float(raw)
+                elif ann_name == "bool":
+                    kwargs[name] = raw.strip().lower() in ("1", "true", "yes", "on")
+                else:
+                    kwargs[name] = raw
+            except (ValueError, TypeError):
+                pass  # uncoercible → fall back to the endpoint's own default
+        else:
+            d = p.default
+            if d is not inspect.Parameter.empty and type(d).__module__.split(".")[0] == "fastapi":
+                inner = getattr(d, "default", inspect.Parameter.empty)
+                if inner is not inspect.Parameter.empty and inner is not Ellipsis:
+                    kwargs[name] = inner
+    return kwargs
+
+
+def dispatch_plugin_api(plugin_name: str, sub_path: str, query: dict):
+    """Dispatch a GET request to a dashboard plugin's plugin_api router.
+
+    Returns (status_code, payload) on a matched route, or None if there is no
+    such plugin/route (caller should 404). Read-only: only GET routes served.
+    """
+    if not _VALID_PLUGIN_NAME.match(plugin_name or ""):
+        return None
+    module = _load_plugin_api(plugin_name)
+    if module is None:
+        return None
+    router = getattr(module, "router", None)
+    routes = getattr(router, "routes", None) or []
+    want = "/" + (sub_path or "").strip("/")
+    for route in routes:
+        if getattr(route, "path", None) != want:
+            continue
+        if "GET" not in (getattr(route, "methods", None) or set()):
+            continue
+        endpoint = getattr(route, "endpoint", None)
+        if endpoint is None:
+            continue
+        try:
+            return (200, endpoint(**_coerce_endpoint_kwargs(endpoint, query)))
+        except Exception:
+            logger.exception("plugin_api %s %s raised", plugin_name, want)
+            return (500, {"error": "plugin backend error"})
+    return None

--- a/api/routes.py
+++ b/api/routes.py
@@ -9173,6 +9173,17 @@ def handle_get(handler, parsed) -> bool:
     # ── Plugins/hooks visibility (read-only, no callback/source internals) ──
     if parsed.path == "/api/plugins":
         return _handle_plugins(handler, parsed)
+    # Dashboard plugin backends: GET /api/plugins/<name>/<route> → plugin_api router.
+    if parsed.path.startswith("/api/plugins/"):
+        from api.plugins import dispatch_plugin_api
+        name, _, sub = parsed.path[len("/api/plugins/"):].partition("/")
+        result = dispatch_plugin_api(name, sub, parse_qs(parsed.query))
+        if result is None:
+            return bad(handler, "Unknown plugin API route", 404)
+        status, payload = result
+        if status != 200:
+            return bad(handler, (payload or {}).get("error", "plugin backend error"), status)
+        return j(handler, payload)
     if parsed.path == "/api/provider/quota":
         query = parse_qs(parsed.query)
         provider_id = (query.get("provider", [""])[0] or None)

--- a/tests/test_plugin_api_mount.py
+++ b/tests/test_plugin_api_mount.py
@@ -1,0 +1,104 @@
+"""Coverage for dashboard plugin backend mounting (plugin_api.py).
+
+A dashboard plugin may ship an optional ``plugin_api.py`` exposing a FastAPI
+``APIRouter`` named ``router``.  ``dispatch_plugin_api`` serves that router's GET
+routes (read-only) under ``/api/plugins/<name>/<route>`` so the plugin's built
+frontend can fetch its own data instead of receiving a 404 (blank panel).
+
+The core dispatch/coercion logic is tested with a dependency-free duck-typed
+router; a separate fastapi-gated test exercises real APIRouter introspection
+including ``Query(...)`` default unwrapping.
+"""
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+import api.plugins as plugins
+
+
+def _seed_module(monkeypatch, name, router):
+    """Pre-seed the import cache so dispatch uses our fake module (no file I/O)."""
+    mod = ModuleType(f"_fake_plugin_api_{name}")
+    mod.router = router
+    cache = dict(plugins._PLUGIN_API_MODULES)
+    cache[name] = mod
+    monkeypatch.setattr(plugins, "_PLUGIN_API_MODULES", cache)
+
+
+def _route(path, methods, endpoint):
+    return SimpleNamespace(path=path, methods=set(methods), endpoint=endpoint)
+
+
+def test_dispatch_matches_get_route_and_coerces_query(monkeypatch):
+    def summary(hours: int = 24):
+        return {"hours": hours}
+
+    _seed_module(monkeypatch, "demo", SimpleNamespace(routes=[_route("/summary", ["GET"], summary)]))
+
+    assert plugins.dispatch_plugin_api("demo", "summary", {"hours": ["48"]}) == (200, {"hours": 48})
+
+
+def test_dispatch_uses_endpoint_default_when_param_absent(monkeypatch):
+    def summary(hours: int = 24):
+        return {"hours": hours}
+
+    _seed_module(monkeypatch, "demo", SimpleNamespace(routes=[_route("/summary", ["GET"], summary)]))
+
+    assert plugins.dispatch_plugin_api("demo", "summary", {}) == (200, {"hours": 24})
+
+
+def test_dispatch_unknown_route_returns_none(monkeypatch):
+    _seed_module(monkeypatch, "demo", SimpleNamespace(routes=[_route("/summary", ["GET"], lambda: {})]))
+
+    assert plugins.dispatch_plugin_api("demo", "missing", {}) is None
+
+
+def test_dispatch_ignores_non_get_routes(monkeypatch):
+    _seed_module(monkeypatch, "demo", SimpleNamespace(routes=[_route("/summary", ["POST"], lambda: {})]))
+
+    assert plugins.dispatch_plugin_api("demo", "summary", {}) is None
+
+
+def test_dispatch_rejects_invalid_plugin_name(monkeypatch):
+    _seed_module(monkeypatch, "demo", SimpleNamespace(routes=[_route("/summary", ["GET"], lambda: {})]))
+
+    assert plugins.dispatch_plugin_api("../etc", "summary", {}) is None
+    assert plugins.dispatch_plugin_api("Bad Name", "summary", {}) is None
+
+
+def test_dispatch_wraps_endpoint_errors_as_500(monkeypatch):
+    def boom():
+        raise RuntimeError("kaboom")
+
+    _seed_module(monkeypatch, "demo", SimpleNamespace(routes=[_route("/summary", ["GET"], boom)]))
+
+    status, payload = plugins.dispatch_plugin_api("demo", "summary", {})
+    assert status == 500 and "error" in payload
+
+
+def test_dispatch_no_router_returns_none(monkeypatch):
+    _seed_module(monkeypatch, "demo", SimpleNamespace())  # module without .router
+
+    assert plugins.dispatch_plugin_api("demo", "summary", {}) is None
+
+
+def test_dispatch_with_real_fastapi_router(monkeypatch):
+    fastapi = pytest.importorskip("fastapi")
+    router = fastapi.APIRouter()
+
+    @router.get("/summary")
+    def summary(hours: int = fastapi.Query(24, ge=1, le=720)):
+        return {"hours": hours}
+
+    _seed_module(monkeypatch, "demo", SimpleNamespace(routes=router.routes))
+
+    # Query(...) default object must be unwrapped to its plain default (24).
+    assert plugins.dispatch_plugin_api("demo", "summary", {}) == (200, {"hours": 24})
+    assert plugins.dispatch_plugin_api("demo", "summary", {"hours": ["12"]}) == (200, {"hours": 12})
+
+
+# silence unused-import lint without changing behaviour
+_ = (sys, ModuleType)


### PR DESCRIPTION
## Problem

Dashboard plugins may declare an optional Python backend via the manifest `"api"` field (e.g. `plugin_api.py`) exposing a FastAPI `APIRouter` named `router`. Until now that backend was never mounted — `api/plugins.py` even notes *"plugin_api.py — optional backend API (not used in WebUI MVP)"*. As a result, a plugin whose built frontend fetches `/api/plugins/<name>/<route>` receives a **404** and renders a blank panel.

## Change

Serve the router's **GET** routes (read-only) under `/api/plugins/<name>/<route>`:

- `dispatch_plugin_api()` imports the plugin's `plugin_api` module (path-confined to the plugin's `dashboard/` dir), introspects `router.routes`, matches the GET route, coerces query params to the endpoint signature (handling stringized PEP 563 annotations and unwrapping FastAPI `Query()`/`Param()` default objects), and returns the endpoint result as JSON.
- A dispatch branch for `GET /api/plugins/<name>/<route>` is added right after the existing `/api/plugins` route.

### Safety / scope

- **Read-only**: only `GET` routes are served.
- Plugin name is validated; module import is path-confined (no traversal, no source exposure).
- Endpoint exceptions return `500` with a generic message.
- **FastAPI is an optional dependency**: if it is not importable, the plugin's router registers no routes and backends are skipped gracefully (the panel still loads, just without live data).

## Tests

Adds `tests/test_plugin_api_mount.py`: dependency-free tests for the dispatch/coercion logic (route matching, GET-only, query coercion, default fallback, name validation, error wrapping) plus a fastapi-gated test exercising real `APIRouter` introspection including `Query(...)` default unwrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)