### PR TITLE
fix: avoid transcript reload on metadata-only refresh

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4363,8 +4363,26 @@ async function refreshActiveSessionIfExternallyUpdated(reason){
     if(S.busy || S.activeStreamId) return;
     const remoteCount = Number(data.session.message_count || 0);
     const remoteLast = Number(data.session.last_message_at || data.session.updated_at || 0);
-    if(remoteCount > localCount || remoteLast > localLast){
+    // Only force-reload the whole transcript when the visible conversation
+    // actually grew (more messages). A bump in last_message_at WITHOUT a higher
+    // message_count means a non-transcript write touched the session — most
+    // commonly the post-turn background skill/memory review, which rewrites
+    // memory/skills and advances updated_at but adds no chat messages. Reloading
+    // on that bump tears down and re-fetches the transcript: loadSession(force)
+    // clears S.messages and awaits a round-trip before re-rendering, so the whole
+    // conversation visibly disappears and "reappears a moment later" with no new
+    // content. Skip the destructive reload in that case and just refresh the
+    // lightweight sidebar list metadata. A real new message (remoteCount higher)
+    // still force-reloads as before. Also keep the local last-seen marker current
+    // so the same metadata bump doesn't re-trigger on every subsequent poll.
+    if(remoteCount > localCount){
       await loadSession(sid, {force:true, externalRefreshReason:reason||'poll'});
+      if(typeof renderSessionList==='function') void renderSessionList();
+    }else if(remoteLast > localLast){
+      if(S.session && S.session.session_id === sid){
+        S.session.last_message_at = remoteLast;
+        if(data.session.updated_at) S.session.updated_at = data.session.updated_at;
+      }
       if(typeof renderSessionList==='function') void renderSessionList();
     }
   }catch(e){

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -19,10 +19,31 @@ def test_active_session_external_refresh_uses_metadata_then_force_reload():
     assert "function ensureActiveSessionExternalRefreshPoll()" in SESSIONS_JS
     assert "async function refreshActiveSessionIfExternallyUpdated(reason)" in SESSIONS_JS
     assert "messages=0&resolve_model=0" in SESSIONS_JS
-    assert "remoteCount > localCount || remoteLast > localLast" in SESSIONS_JS
+    assert "if(remoteCount > localCount)" in SESSIONS_JS
+    assert "else if(remoteLast > localLast)" in SESSIONS_JS
     assert "if(S.busy || S.activeStreamId) return;" in SESSIONS_JS
     assert "document.hidden" in SESSIONS_JS
     assert "externalRefreshReason:reason||'poll'" in SESSIONS_JS
+
+
+def test_active_session_external_refresh_skips_destructive_reload_on_metadata_only_bump():
+    """A timestamp-only active-session update should not blank the transcript.
+
+    Background skill/memory review can update session timestamps without adding
+    chat messages. The old `remoteCount > localCount || remoteLast > localLast`
+    condition called `loadSession(..., {force:true})` for that metadata-only
+    bump; `loadSession(force)` clears S.messages before async message fetches,
+    so the whole transcript visibly disappeared and reappeared with no new
+    content. Only a higher message_count should force-reload the transcript;
+    timestamp-only bumps update local metadata and refresh the lightweight
+    sidebar list.
+    """
+    assert "remoteCount > localCount || remoteLast > localLast" not in SESSIONS_JS
+    assert "if(remoteCount > localCount){" in SESSIONS_JS
+    assert "await loadSession(sid, {force:true, externalRefreshReason:reason||'poll'});" in SESSIONS_JS
+    assert "}else if(remoteLast > localLast){" in SESSIONS_JS
+    assert "S.session.last_message_at = remoteLast" in SESSIONS_JS
+    assert "if(data.session.updated_at) S.session.updated_at = data.session.updated_at;" in SESSIONS_JS
 
 
 def test_webui_source_never_counts_as_external_session():


### PR DESCRIPTION
## Summary

- avoid destructive same-session transcript reloads when only session metadata timestamps changed
- keep force reload behavior for real transcript growth (`remoteCount > localCount`)
- refresh sidebar metadata and advance the local last-seen timestamp for metadata-only bumps so the same event does not retrigger polling
- add a frontend regression test for timestamp-only active-session refreshes

## Why

After a WebUI turn finishes, background skill/memory review can touch session metadata and advance `last_message_at` / `updated_at` without adding any chat messages. The active-session external refresh path treated `remoteLast > localLast` the same as a real transcript change and called `loadSession(..., {force:true})`.

That force reload clears `S.messages` before awaiting the metadata/messages fetches, so the visible transcript can briefly disappear and then reappear with the same content. Refreshing the page also brings it back because the data was never lost; only the render had a blank gap.

This change only force-reloads when `remoteCount > localCount` (visible transcript actually grew). Timestamp-only bumps now update local metadata and refresh the lightweight sidebar list instead.

## Tests

- `node --check static/sessions.js`
- `python -m pytest tests/test_webui_external_refresh_frontend.py tests/test_issue3916_external_refresh_poll.py tests/test_tars_scroll_reset_regressions.py -q` → 27 passed
