### PR TITLE
fix(#5030): read gateway runtime status from gateway_state.json

### DIFF
--- a/api/agent_health.py
+++ b/api/agent_health.py
@@ -217,17 +217,18 @@ def _read_gateway_runtime_status(gateway_status: Any, pid_path: Path | None) -> 
         try:
             return read_runtime_status(pid_path=pid_path)
         except TypeError:
+            runtime_status_file = str(
+                getattr(gateway_status, "_RUNTIME_STATUS_FILE", _GATEWAY_RUNTIME_STATUS_FILE)
+            )
+            runtime_status_path = pid_path.with_name(runtime_status_file)
             try:
-                return read_runtime_status(pid_path)
+                return read_runtime_status(runtime_status_path)
             except TypeError:
                 if getattr(gateway_status, "__name__", "") == "gateway.status" or hasattr(
                     gateway_status,
                     "_read_json_file",
                 ):
-                    runtime_status_file = str(
-                        getattr(gateway_status, "_RUNTIME_STATUS_FILE", _GATEWAY_RUNTIME_STATUS_FILE)
-                    )
-                    runtime_status = _read_runtime_status_path(pid_path.with_name(runtime_status_file))
+                    runtime_status = _read_runtime_status_path(runtime_status_path)
                     if runtime_status is not None:
                         return runtime_status
     return read_runtime_status()

--- a/tests/test_issue1879_cross_container_gateway_liveness.py
+++ b/tests/test_issue1879_cross_container_gateway_liveness.py
@@ -28,6 +28,7 @@ These tests pin every behavior the fix promises:
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -44,6 +45,19 @@ class _FakeGatewayStatus:
     def get_running_pid(self, cleanup_stale=False):
         assert cleanup_stale is False
         return self._running_pid
+
+
+class _PathReadingGatewayStatus:
+    def __init__(self):
+        self.read_paths = []
+
+    def read_runtime_status(self, path=None):
+        self.read_paths.append(path)
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def get_running_pid(self, cleanup_stale=False):
+        assert cleanup_stale is False
+        return None
 
 
 def _runtime_status(updated_at: str | None, **overrides):
@@ -114,6 +128,42 @@ def test_cross_container_alive_path_does_not_leak_raw_process_fields(monkeypatch
 
 
 # -- Stale / missing / malformed timestamps -----------------------------------
+
+
+def test_cross_container_runtime_status_reads_sibling_runtime_file(monkeypatch, tmp_path):
+    """#5030: the positional fallback must open gateway_state.json, not gateway.pid."""
+    from api import agent_health
+
+    pid_path = tmp_path / "gateway.pid"
+    runtime_status_path = tmp_path / "gateway_state.json"
+    fresh_ts = _iso(datetime.now(timezone.utc) - timedelta(seconds=30))
+
+    pid_path.write_text(
+        json.dumps(
+            {
+                "pid": 2468,
+                "command": "hermes-agent --gateway",
+            }
+        ),
+        encoding="utf-8",
+    )
+    runtime_status_path.write_text(
+        json.dumps(_runtime_status(fresh_ts)),
+        encoding="utf-8",
+    )
+
+    gateway_status = _PathReadingGatewayStatus()
+    monkeypatch.setattr(agent_health, "_gateway_status_module", lambda: gateway_status)
+    monkeypatch.setattr(agent_health, "_gateway_root_pid_path", lambda: pid_path)
+
+    payload = agent_health.build_agent_health_payload()
+
+    assert payload["alive"] is True
+    assert payload["details"]["state"] == "alive"
+    assert payload["details"]["reason"] == "cross_container_freshness"
+    assert payload["details"]["gateway_state"] == "running"
+    assert payload["details"]["updated_at"] == fresh_ts
+    assert gateway_status.read_paths == [runtime_status_path]
 
 
 def test_stale_updated_at_with_running_state_reports_unknown(monkeypatch):


### PR DESCRIPTION
## Thinking Path

- Cross-container gateway health already trusts a fresh `gateway_state.json`, but `_read_gateway_runtime_status()` still hands the agent-side `read_runtime_status(path)` contract the sibling `gateway.pid` path after the keyword compatibility call fails.
- That makes the health path parse PID metadata as runtime metadata, so `gateway_state` and `updated_at` never reach the freshness check and the UI reports the gateway as down.
- The fix keeps the compatibility structure, routes the positional fallback to `gateway_state.json`, and locks the dashboard-facing payload with a focused cross-container regression.

## What Changed

- `api/agent_health.py`: switch the positional `read_runtime_status(path)` fallback from `gateway.pid` to the sibling runtime-status file while preserving the existing keyword and no-argument compatibility paths.
- `tests/test_issue1879_cross_container_gateway_liveness.py`: add a regression that models the real `path`-only gateway status contract and proves `build_agent_health_payload()` now reports `cross_container_freshness` instead of `gateway_not_running`.

## Why It Matters

Multi-container Docker installs can share `HERMES_HOME` without sharing a PID namespace. In that layout, `gateway_state.json` is the authoritative liveness signal, so reading `gateway.pid` as runtime JSON creates a false `Gateway not running` banner even while the gateway is healthy.

## Verification

```bash
pytest tests/test_issue1879_cross_container_gateway_liveness.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5030.

Attribution: maintainer confirmation on https://github.com/nesquena/hermes-webui/issues/5030#issuecomment-4815057618 pinned the unreachable fallback and requested the regression test shape.

## Model Used

GPT 5.5 via Codex CLI
