### PR TITLE
fix(#5060): preserve typed composer input during boot restore

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -2484,7 +2484,7 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
         await renderSessionList();if(typeof startGatewaySSE==='function')startGatewaySSE();
         return;
       }
-      await loadSession(saved);
+      await loadSession(saved, {preserveActiveInput:true});
       // Hard refresh starts from the static HTML model list. Hydrate the live
       // catalog after the saved session is known, then re-apply that session's
       // model before S._bootReady lets syncModelChip reveal the composer label.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1633,7 +1633,7 @@ async function loadSession(sid){
   // against stale writes from slow responses racing to restore the previous draft).
   const _draft = S.session && S.session.composer_draft;
   if (_draft && (typeof _restoreComposerDraft === 'function')) {
-    _restoreComposerDraft(_draft, sid, {preserveActiveInput:currentSid===sid&&forceReload});
+    _restoreComposerDraft(_draft, sid, {preserveActiveInput:!!opts.preserveActiveInput || (currentSid===sid&&forceReload)});
   }
 
   // Clear the in-flight session marker now that this load has completed (#1060).

--- a/tests/test_1694_root_saved_running_policy.py
+++ b/tests/test_1694_root_saved_running_policy.py
@@ -45,7 +45,7 @@ def test_root_saved_running_session_is_checked_before_load_session_projection():
     block = _boot_saved_session_block()
     guard = "!urlSession&&savedLocal"
     guard_pos = block.replace(" ", "").find(guard)
-    load_pos = block.find("await loadSession(saved)")
+    load_pos = block.find("await loadSession(saved, {preserveActiveInput:true})")
     assert guard_pos >= 0, (
         "root `/` boot must have a !urlSession && savedLocal guard for saved "
         "running sessions before projecting them into the active pane"

--- a/tests/test_bugbatch_apr2026.py
+++ b/tests/test_bugbatch_apr2026.py
@@ -116,7 +116,7 @@ def test_576_panel_restore_gated_on_workspace():
 
 def test_576_restore_happens_after_load_session():
     """boot.js: loadSession() must come before the panel restore guard."""
-    load_pos    = BOOT_JS.find("await loadSession(saved)")
+    load_pos    = BOOT_JS.find("await loadSession(saved, {preserveActiveInput:true})")
     restore_pos = BOOT_JS.find("panelPref")
     assert load_pos != -1, "loadSession call not found in boot.js"
     assert restore_pos != -1, "workspace panel restore guard not found"

--- a/tests/test_issue5060_boot_composer_preserve.py
+++ b/tests/test_issue5060_boot_composer_preserve.py
@@ -18,24 +18,140 @@ def _function_block(source: str, marker: str) -> str:
     start = source.index(marker)
     signature_end = source.index(") {", start)
     brace = source.index("{", signature_end)
-    depth = 1
-    idx = brace + 1
-    while depth:
-        char = source[idx]
-        if char == "{":
-            depth += 1
-        elif char == "}":
-            depth -= 1
-        idx += 1
+    idx = _find_matching_brace(source, brace)
     return source[start:idx]
 
 
 def _draft_restore_block() -> str:
-    start_marker = "// Restore server-persisted composer draft (synced across clients + survives refresh)."
-    end_marker = "// Clear the in-flight session marker now that this load has completed (#1060)."
+    start_marker = "const _draft = S.session && S.session.composer_draft;"
+    end_marker = "if (_loadingSessionId === sid) _loadingSessionId = null;"
     start = SESSIONS_JS.index(start_marker)
     end = SESSIONS_JS.index(end_marker, start)
-    return SESSIONS_JS[start:end]
+    return SESSIONS_JS[start:end + len(end_marker)]
+
+
+def _find_matching_brace(source: str, brace: int) -> int:
+    depth = 1
+    idx = brace + 1
+    mode = "code"
+    template_expr_depth = 0
+    while depth:
+        char = source[idx]
+        nxt = source[idx + 1] if idx + 1 < len(source) else ""
+        if mode == "code":
+            if char == "/" and nxt == "/":
+                mode = "line_comment"
+                idx += 2
+                continue
+            if char == "/" and nxt == "*":
+                mode = "block_comment"
+                idx += 2
+                continue
+            if char == "'":
+                mode = "single"
+                idx += 1
+                continue
+            if char == '"':
+                mode = "double"
+                idx += 1
+                continue
+            if char == "`":
+                mode = "template"
+                idx += 1
+                continue
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+            idx += 1
+            continue
+        if mode == "line_comment":
+            idx += 1
+            if char == "\n":
+                mode = "code"
+            continue
+        if mode == "block_comment":
+            idx += 2 if char == "*" and nxt == "/" else 1
+            if char == "*" and nxt == "/":
+                mode = "code"
+            continue
+        if mode in {"single", "double"}:
+            if char == "\\":
+                idx += 2
+                continue
+            idx += 1
+            if (mode == "single" and char == "'") or (mode == "double" and char == '"'):
+                mode = "code"
+            continue
+        if mode == "template":
+            if char == "\\":
+                idx += 2
+                continue
+            if char == "`":
+                mode = "code"
+                idx += 1
+                continue
+            if char == "$" and nxt == "{":
+                mode = "template_expr"
+                template_expr_depth = 1
+                idx += 2
+                continue
+            idx += 1
+            continue
+        if mode == "template_expr":
+            if char == "/" and nxt == "/":
+                mode = "template_line_comment"
+                idx += 2
+                continue
+            if char == "/" and nxt == "*":
+                mode = "template_block_comment"
+                idx += 2
+                continue
+            if char == "'":
+                mode = "template_single"
+                idx += 1
+                continue
+            if char == '"':
+                mode = "template_double"
+                idx += 1
+                continue
+            if char == "`":
+                mode = "template_nested"
+                idx += 1
+                continue
+            if char == "{":
+                template_expr_depth += 1
+                idx += 1
+                continue
+            if char == "}":
+                template_expr_depth -= 1
+                idx += 1
+                if template_expr_depth == 0:
+                    mode = "template"
+                continue
+            idx += 1
+            continue
+        if mode == "template_line_comment":
+            idx += 1
+            if char == "\n":
+                mode = "template_expr"
+            continue
+        if mode == "template_block_comment":
+            idx += 2 if char == "*" and nxt == "/" else 1
+            if char == "*" and nxt == "/":
+                mode = "template_expr"
+            continue
+        if char == "\\":
+            idx += 2
+            continue
+        idx += 1
+        if mode == "template_single" and char == "'":
+            mode = "template_expr"
+        elif mode == "template_double" and char == '"':
+            mode = "template_expr"
+        elif mode == "template_nested" and char == "`":
+            mode = "template_expr"
+    return idx
 
 
 def _run_case(*, initial_text: str, draft: dict | None, opts: dict | None, current_sid, force_reload: bool) -> dict:

--- a/tests/test_issue5060_boot_composer_preserve.py
+++ b/tests/test_issue5060_boot_composer_preserve.py
@@ -1,0 +1,137 @@
+"""Regression tests for #5060: preserve typed composer input during boot restore."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+
+def _function_block(source: str, marker: str) -> str:
+    start = source.index(marker)
+    signature_end = source.index(") {", start)
+    brace = source.index("{", signature_end)
+    depth = 1
+    idx = brace + 1
+    while depth:
+        char = source[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+        idx += 1
+    return source[start:idx]
+
+
+def _draft_restore_block() -> str:
+    start_marker = "// Restore server-persisted composer draft (synced across clients + survives refresh)."
+    end_marker = "// Clear the in-flight session marker now that this load has completed (#1060)."
+    start = SESSIONS_JS.index(start_marker)
+    end = SESSIONS_JS.index(end_marker, start)
+    return SESSIONS_JS[start:end]
+
+
+def _run_case(*, initial_text: str, draft: dict | None, opts: dict | None, current_sid, force_reload: bool) -> dict:
+    if NODE is None:
+        pytest.skip("node not on PATH")
+    restore_fn = _function_block(SESSIONS_JS, "function _restoreComposerDraft(draft, targetSid, opts={}) {")
+    draft_block = _draft_restore_block()
+    script = f"""
+const state = {{
+  value: {json.dumps(initial_text)},
+  autoResizeCount: 0,
+  updateSendBtnCount: 0,
+}};
+function $() {{
+  return state;
+}}
+function autoResize() {{
+  state.autoResizeCount += 1;
+}}
+function updateSendBtn() {{
+  state.updateSendBtnCount += 1;
+}}
+const S = {{
+  session: {{
+    composer_draft: {json.dumps(draft)},
+  }},
+}};
+let _loadingSessionId = null;
+const sid = 'boot-session';
+const currentSid = {json.dumps(current_sid)};
+const forceReload = {json.dumps(force_reload)};
+const opts = {json.dumps(opts or {})};
+{restore_fn}
+{draft_block}
+process.stdout.write(JSON.stringify({{
+  value: state.value,
+  autoResizeCount: state.autoResizeCount,
+  updateSendBtnCount: state.updateSendBtnCount,
+}}));
+"""
+    result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, timeout=20)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_boot_restore_preserves_typed_input_against_remote_draft():
+    """Boot restore should keep local typed text when the saved draft arrives later."""
+    data = _run_case(
+        initial_text="typed locally",
+        draft={"text": "server draft", "files": []},
+        opts={"preserveActiveInput": True},
+        current_sid=None,
+        force_reload=False,
+    )
+    assert data["value"] == "typed locally"
+    assert data["autoResizeCount"] == 0
+    assert data["updateSendBtnCount"] == 0
+
+
+def test_boot_restore_preserves_typed_input_when_saved_draft_is_empty():
+    """Boot restore should keep local typed text even when the restored draft is empty."""
+    data = _run_case(
+        initial_text="typed locally",
+        draft={"text": "", "files": []},
+        opts={"preserveActiveInput": True},
+        current_sid=None,
+        force_reload=False,
+    )
+    assert data["value"] == "typed locally"
+    assert data["autoResizeCount"] == 0
+    assert data["updateSendBtnCount"] == 0
+
+
+def test_boot_restore_still_populates_empty_composer_from_saved_draft():
+    """A blank composer should still take the server draft during boot restore."""
+    data = _run_case(
+        initial_text="",
+        draft={"text": "server draft", "files": []},
+        opts={"preserveActiveInput": True},
+        current_sid=None,
+        force_reload=False,
+    )
+    assert data["value"] == "server draft"
+    assert data["autoResizeCount"] == 1
+    assert data["updateSendBtnCount"] == 1
+
+
+def test_cross_session_restore_keeps_existing_draft_semantics():
+    """Ordinary cross-session loads should still restore the target session draft."""
+    data = _run_case(
+        initial_text="typed locally",
+        draft={"text": "server draft", "files": []},
+        opts={},
+        current_sid="other-session",
+        force_reload=False,
+    )
+    assert data["value"] == "server draft"
+    assert data["autoResizeCount"] == 1
+    assert data["updateSendBtnCount"] == 1

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -58,7 +58,7 @@ def test_boot_model_hydration_prefers_active_session_over_persisted_model():
 
 def test_hard_refresh_hydrates_saved_session_model_before_revealing_model_chip():
     boot_js = Path("static/boot.js").read_text(encoding="utf-8")
-    load_marker = "await loadSession(saved);"
+    load_marker = "await loadSession(saved, {preserveActiveInput:true});"
     assert load_marker in boot_js
     saved_restore = boot_js[boot_js.index(load_marker) : boot_js.index("await checkInflightOnBoot(saved);return;", boot_js.index(load_marker))]
     assert "await _startBootModelDropdown();" in saved_restore

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -149,7 +149,7 @@ def test_same_session_force_reload_preserves_non_empty_composer_input():
     assert "function _restoreComposerDraft(draft, targetSid, opts={})" in SESSIONS_JS
     assert "const preserveActiveInput = !!(opts && opts.preserveActiveInput);" in SESSIONS_JS
     assert "if (preserveActiveInput && current && current !== text) return;" in SESSIONS_JS
-    assert "_restoreComposerDraft(_draft, sid, {preserveActiveInput:currentSid===sid&&forceReload});" in SESSIONS_JS
+    assert "_restoreComposerDraft(_draft, sid, {preserveActiveInput:!!opts.preserveActiveInput || (currentSid===sid&&forceReload)});" in SESSIONS_JS
 
 
 def test_same_session_force_reload_keeps_loaded_transcript_width_hint():


### PR DESCRIPTION
## Thinking Path

- Boot restore already auto-opens the saved session from localStorage, but that can finish after the user has started typing into the fresh page composer.
- `_restoreComposerDraft()` already has the right local-input preservation guard, but the saved-session boot path never routes that intent into the helper.
- The fix makes boot restore explicitly preserve active composer input while keeping normal cross-session draft restore behavior unchanged.

## What Changed

- `static/boot.js`: marks saved-session boot restore as active-input-preserving when it calls `loadSession()`.
- `static/sessions.js`: forwards explicit preserve intent into `_restoreComposerDraft()` alongside the existing same-session force-refresh guard.
- `tests/test_issue5060_boot_composer_preserve.py`: adds browserless behavioral coverage for the boot-time composer clobber path, including the empty server-draft boundary.
- `tests/test_webui_external_refresh_frontend.py`: keeps the existing same-session refresh guard pinned with the updated callsite shape.
- `tests/test_1694_root_saved_running_policy.py`, `tests/test_bugbatch_apr2026.py`, and `tests/test_new_chat_default_model_frontend.py`: refresh source-pinned boot-call snapshots that would otherwise fail after the new `loadSession(saved, {preserveActiveInput:true})` call shape landed.

## Why It Matters

Users can type immediately after a hard refresh without losing that text when the last session finishes auto-opening. Existing saved server drafts still restore when the composer is empty.

## Verification

```cmd
pytest tests/test_issue5060_boot_composer_preserve.py tests/test_webui_external_refresh_frontend.py tests/test_issue_new_chat_draft_restore.py tests/test_new_chat_default_model_frontend.py tests/test_1694_root_saved_running_policy.py tests/test_bugbatch_apr2026.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5060.

## Model Used

GPT 5.5 via Codex CLI
