### PR TITLE
fix(#4731): enlarge mobile message action tap targets

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -6001,6 +6001,8 @@ main.main > .main-view:not([id="mainChat"]):not([id="mainSettings"]) .main-view-
   .msg-row[data-role="assistant"] .msg-foot,
   .assistant-turn .msg-foot{opacity:1;}
   .msg-actions{opacity:1;}
+  .msg-actions{gap:4px;}
+  .msg-action-btn{min-width:40px;min-height:40px;padding:8px;display:inline-flex;align-items:center;justify-content:center;}
 }
 
 /* ── /btw ephemeral side-question bubble ── */

--- a/tests/test_issue4731_mobile_message_actions.py
+++ b/tests/test_issue4731_mobile_message_actions.py
@@ -1,0 +1,32 @@
+"""Static regression coverage for the mobile message action touch-target fix."""
+from pathlib import Path
+
+
+STYLE_CSS = (Path(__file__).resolve().parent.parent / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _mobile_block():
+    marker = "@media(max-width:640px){"
+    start = STYLE_CSS.index(marker)
+    end = STYLE_CSS.index("/* ── /btw ephemeral side-question bubble ── */", start)
+    return STYLE_CSS[start:end]
+
+
+def test_mobile_block_enlarges_msg_action_buttons():
+    block = _mobile_block()
+    assert ".msg-action-btn{min-width:40px;min-height:40px;padding:8px;display:inline-flex;align-items:center;justify-content:center;}" in block
+
+
+def test_mobile_block_widens_msg_actions_gap():
+    block = _mobile_block()
+    assert ".msg-actions{gap:4px;}" in block
+
+
+def test_mobile_block_keeps_visibility_override():
+    block = _mobile_block()
+    assert ".msg-actions{opacity:1;}" in block
+
+
+def test_desktop_base_rules_remain_small_and_untouched():
+    assert ".msg-actions{display:flex;align-items:center;gap:2px;" in STYLE_CSS
+    assert ".msg-action-btn{background:none;border:none;color:var(--muted);cursor:pointer;font-size:13px;padding:2px 5px;" in STYLE_CSS


### PR DESCRIPTION
## Thinking Path

- The message action icons are always visible on mobile, but they still use the desktop `padding:2px 5px` and `gap:2px` sizing, so the tap targets stay cramped.
- The issue already scoped the right fix: extend the existing mobile message-controls block in `static/style.css` instead of widening this into a broader touch-target pass.
- The patch keeps the glyphs the same size and only grows the mobile hit area and spacing, with one focused static regression test to lock the CSS shape.

## What Changed

- `static/style.css`: extended the existing `@media(max-width:640px)` message-controls block with larger `.msg-action-btn` hit areas and a wider `.msg-actions` gap on mobile.
- `tests/test_issue4731_mobile_message_actions.py`: added a focused static regression test for the mobile CSS overrides and the preserved desktop base rules.

## Why It Matters

Copy, edit, retry, fork, and TTS actions become reliably tappable on phones without changing the compact desktop presentation.

## Verification

```powershell
D:\Repos\hermes-agent\venv\Scripts\python.exe -m pytest tests/test_issue4731_mobile_message_actions.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #4731.

## Model Used

GPT 5.5 via Codex CLI

