### PR TITLE
fix(#4731): enlarge mobile message action tap targets [reopened]

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -6008,6 +6008,8 @@ main.main > .main-view:not([id="mainChat"]):not([id="mainSettings"]) .main-view-
   .msg-row[data-role="assistant"] .msg-foot,
   .assistant-turn .msg-foot{opacity:1;}
   .msg-actions{opacity:1;}
+  .msg-actions{gap:4px;}
+  .msg-action-btn{min-width:40px;min-height:40px;padding:8px;display:inline-flex;align-items:center;justify-content:center;}
 }
 
 /* ── /btw ephemeral side-question bubble ── */

--- a/tests/test_issue4731_mobile_message_actions.py
+++ b/tests/test_issue4731_mobile_message_actions.py
@@ -1,0 +1,32 @@
+"""Static regression coverage for the mobile message action touch-target fix."""
+from pathlib import Path
+
+
+STYLE_CSS = (Path(__file__).resolve().parent.parent / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _mobile_block():
+    marker = "@media(max-width:640px){"
+    start = STYLE_CSS.index(marker)
+    end = STYLE_CSS.index("/* ── /btw ephemeral side-question bubble ── */", start)
+    return STYLE_CSS[start:end]
+
+
+def test_mobile_block_enlarges_msg_action_buttons():
+    block = _mobile_block()
+    assert ".msg-action-btn{min-width:40px;min-height:40px;padding:8px;display:inline-flex;align-items:center;justify-content:center;}" in block
+
+
+def test_mobile_block_widens_msg_actions_gap():
+    block = _mobile_block()
+    assert ".msg-actions{gap:4px;}" in block
+
+
+def test_mobile_block_keeps_visibility_override():
+    block = _mobile_block()
+    assert ".msg-actions{opacity:1;}" in block
+
+
+def test_desktop_base_rules_remain_small_and_untouched():
+    assert ".msg-actions{display:flex;align-items:center;gap:2px;" in STYLE_CSS
+    assert ".msg-action-btn{background:none;border:none;color:var(--muted);cursor:pointer;font-size:13px;padding:2px 5px;" in STYLE_CSS


### PR DESCRIPTION
Reopened from the same branch as #5080 — GitHub's PR-head tracking got stuck on a stale SHA after the rebase-onto-master (the branch is correctly rebased + CI-green, but the old PR object wouldn't re-sync). Same commit, same credit.

Enlarges mobile message-action tap targets to the 40px a11y minimum (`min-width/min-height:40px`, `padding:8px`, `gap:4px`) inside the mobile media query. CSS-only (+2 lines style.css + a regression test), no markup/JS change. Fixes #4731. Thanks @rodboev.
