### PR TITLE
fix(mobile): PWA reflow guard + avoid redundant same-session refresh (salvage of #3976)

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -105,6 +105,29 @@ function _isCompactWorkspaceViewport(){
   return window.matchMedia('(max-width: 900px)').matches;
 }
 
+function _isPhoneWidthViewport(){
+  return window.matchMedia('(max-width: 640px)').matches;
+}
+
+// Mobile PWA viewport reflow guard. When the on-screen keyboard / browser
+// chrome shows or hides, visualViewport (or a plain resize on browsers without
+// it) changes height without a layout invalidation, leaving the phone layout
+// painted against stale geometry. Toggling a one-frame `viewport-reflow` class
+// (which applies a cheap GPU-promotion transform under the @media(max-width:640px)
+// rule) forces a repaint, then we resync the workspace panel + sidebar aria.
+function _forceMobileViewportReflow(){
+  if(!_isPhoneWidthViewport()) return;
+  const layout=document.querySelector('.layout');
+  if(!layout) return;
+  document.documentElement.classList.add('viewport-reflow');
+  void layout.offsetWidth;
+  requestAnimationFrame(()=>{
+    document.documentElement.classList.remove('viewport-reflow');
+    try{ syncWorkspacePanelState(); }catch(_){ }
+    try{ if(typeof _syncSidebarAria==='function') _syncSidebarAria(); }catch(_){ }
+  });
+}
+
 function _syncWorkspacePanelInlineWidth(){
   const {panel}= _workspacePanelEls();
   if(!panel) return;
@@ -1845,7 +1868,24 @@ function applyEmptyStateSuggestionPref(){
 window.addEventListener('resize',()=>{
   _syncWorkspacePanelInlineWidth();
   syncWorkspacePanelState();
+  if(!window.visualViewport) _forceMobileViewportReflow();
 });
+
+// On PWAs / mobile browsers that expose visualViewport, keyboard show/hide and
+// URL-bar collapse fire visualViewport resize/scroll rather than window resize.
+// Debounce a reflow so the phone layout repaints against the new geometry.
+if(window.visualViewport){
+  let _mobileViewportReflowTimer=0;
+  const _scheduleMobileViewportReflow=()=>{
+    if(_mobileViewportReflowTimer) clearTimeout(_mobileViewportReflowTimer);
+    _mobileViewportReflowTimer=setTimeout(()=>{
+      _mobileViewportReflowTimer=0;
+      _forceMobileViewportReflow();
+    },60);
+  };
+  window.visualViewport.addEventListener('resize', _scheduleMobileViewportReflow);
+  window.visualViewport.addEventListener('scroll', _scheduleMobileViewportReflow);
+}
 
 // Boot: restore last session or start fresh
 // ── Resizable panels ──────────────────────────────────────────────────────

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -479,7 +479,21 @@ function _scheduleActiveSessionIdleReload(sid) {
       return;
     }
     try{
-      await loadSession(sid, {force:true, externalRefreshReason:'idle-reconcile'});
+      // Avoid an unconditional same-session force reload the moment streaming
+      // settles. On mobile PWA this produces a visible end-of-turn flash and can
+      // briefly restore the pane with stale layout geometry. Reconcile against
+      // server metadata for the just-finished active turn first
+      // (ignoreStreamJustFinished bypasses only the post-stream cooldown; the
+      // reconcile still reloads ONLY when the message count actually changed).
+      // The 'idle-reconcile' reason is non-'poll', so it coexists with the
+      // #3916/#4195 poll-only external gate without bypassing it. Preserve the
+      // original forced reload as a fallback when the probe request itself fails.
+      const outcome = await refreshActiveSessionIfExternallyUpdated('idle-reconcile', {
+        ignoreStreamJustFinished: true,
+      });
+      if(outcome === 'failed'){
+        await loadSession(sid, {force:true, externalRefreshReason:'idle-reconcile'});
+      }
     }catch(_){}
   },0);
 }
@@ -4334,34 +4348,57 @@ function _flushDeferredActiveSessionExternalRefresh(){
   void refreshActiveSessionIfExternallyUpdated(reason);
 }
 
+// Reconcile the active session against server-side metadata. Returns a status
+// string so callers (notably the post-stream idle reconcile) can decide how to
+// react:
+//   'skipped'   — a guard short-circuited before any network probe ran
+//   'unchanged' — server metadata matched local (or only a non-transcript bump)
+//   'reloaded'  — the transcript was force-reloaded to re-sync
+//   'failed'    — the probe request threw (transient); caller may fall back
+//
+// opts.ignoreStreamJustFinished — bypass the post-stream cooldown. Only the
+//   idle-reconcile path sets this: it runs once for the just-finished active
+//   turn and probes server metadata FIRST (reloading only on an actual count
+//   change), so it is safe to look even right after the "done" event without
+//   the unconditional force reload that produced the mobile-PWA end-of-turn
+//   flash (#3976). This intentionally COEXISTS with the #3916/#4195 poll-only
+//   external gate below, which is untouched.
 async function refreshActiveSessionIfExternallyUpdated(reason){
-  if(_activeSessionExternalRefreshInFlight) return;
-  if(!S.session || !S.session.session_id) return;
-  if(S.busy || S.activeStreamId) return;
+  // opts read via arguments[1] (same pattern as loadSession) so the public
+  // signature stays (reason) — callers like the poll/focus/visibility hooks and
+  // refreshSessionList keep passing a single reason. Only the post-stream idle
+  // reconcile passes opts (see _scheduleActiveSessionIdleReload).
+  const opts = arguments[1] || {};
+  if(_activeSessionExternalRefreshInFlight) return 'skipped';
+  if(!S.session || !S.session.session_id) return 'skipped';
+  if(S.busy || S.activeStreamId) return 'skipped';
   if(typeof _isMessageReaderUnpinned==='function'&&_isMessageReaderUnpinned()){
     _deferActiveSessionExternalRefresh(reason||'poll');
-    return;
+    return 'skipped';
   }
-  // #3916: the 30s timer is only a fallback for imported/external sessions.
+  // #3916/#4195: the 30s timer is only a fallback for imported/external sessions.
   // WebUI-native sessions should not keep probing forever when the sidebar SSE
   // is healthy, but they still must reconcile when an actual sessions_changed
   // event, focus, or visibility recovery says another client/process mutated
-  // the active transcript (#4205 follow-up shape).
-  if((reason||'poll')==='poll' && !_isExternalSession(S.session)) return;
+  // the active transcript (#4205 follow-up shape). The idle-reconcile path uses
+  // a non-'poll' reason, so it already sails through this gate untouched.
+  if((reason||'poll')==='poll' && !_isExternalSession(S.session)) return 'skipped';
   // Cooldown: don't force-reload immediately after streaming ends — the
   // "done" event already delivered the final messages. Reloading here would
-  // clear S.toolCalls and lose Activity.
-  if(typeof window !== 'undefined' && window._streamJustFinished) return;
-  if(typeof document !== 'undefined' && document.hidden) return;
+  // clear S.toolCalls and lose Activity. The idle-reconcile path may bypass
+  // this guard (opts.ignoreStreamJustFinished) because it probes server
+  // metadata first and only reloads when the count actually changed (#3976).
+  if(!opts.ignoreStreamJustFinished && typeof window !== 'undefined' && window._streamJustFinished) return 'skipped';
+  if(typeof document !== 'undefined' && document.hidden) return 'skipped';
   const sid = S.session.session_id;
   const localCount = Number(S.session.message_count || (Array.isArray(S.messages)?S.messages.length:0) || 0);
   const localLast = Number(S.session.last_message_at || S.session.updated_at || 0);
   _activeSessionExternalRefreshInFlight = true;
   try{
     const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`,{timeoutToast:false});
-    if(!data || !data.session) return;
-    if(!S.session || S.session.session_id !== sid) return;
-    if(S.busy || S.activeStreamId) return;
+    if(!data || !data.session) return 'unchanged';
+    if(!S.session || S.session.session_id !== sid) return 'skipped';
+    if(S.busy || S.activeStreamId) return 'skipped';
     const remoteCount = Number(data.session.message_count || 0);
     const remoteLast = Number(data.session.last_message_at || data.session.updated_at || 0);
     // Force-reload the whole transcript whenever the visible conversation's
@@ -4384,6 +4421,7 @@ async function refreshActiveSessionIfExternallyUpdated(reason){
     if(remoteCount !== localCount){
       await loadSession(sid, {force:true, externalRefreshReason:reason||'poll'});
       if(typeof renderSessionList==='function') void renderSessionList();
+      return 'reloaded';
     }else if(remoteLast > localLast){
       if(S.session && S.session.session_id === sid){
         S.session.last_message_at = remoteLast;
@@ -4391,8 +4429,10 @@ async function refreshActiveSessionIfExternallyUpdated(reason){
       }
       if(typeof renderSessionList==='function') void renderSessionList();
     }
+    return 'unchanged';
   }catch(e){
     // Ignore transient refresh failures; the next poll/focus event will retry.
+    return 'failed';
   }finally{
     _activeSessionExternalRefreshInFlight = false;
   }

--- a/static/style.css
+++ b/static/style.css
@@ -2841,6 +2841,13 @@
   }
 
   @media(max-width:640px){
+    /* Mobile PWA reflow guard (#3976): a one-frame GPU-promotion transform that
+       _forceMobileViewportReflow() toggles via html.viewport-reflow to force a
+       repaint after visualViewport/keyboard geometry changes. overflow-x:clip
+       (NOT hidden) suppresses any horizontal overflow without coercing
+       overflow-y into a scroll container — same #4856 lesson applied to .layout. */
+    html.viewport-reflow .layout{transform:translateZ(0);}
+    .layout{overflow-x:clip;}
     /* Viewport-phone rules handle app chrome and touch sizing; they intentionally
        overlap the container compact rules for actual phones. */
     /* ── Sidebar: slide-in overlay instead of hidden ── */
@@ -2877,7 +2884,7 @@
     .rightpanel .panel-header{row-gap:8px;}
     .rightpanel .panel-actions{align-items:center;gap:8px;}
     /* Topbar adjustments */
-    .topbar{padding:8px 12px;gap:8px;}
+    .topbar{padding:8px 12px;gap:8px;padding-left:max(12px,env(safe-area-inset-left,0));padding-right:max(12px,env(safe-area-inset-right,0));}
     .topbar-title{font-size:14px;}
     .topbar-meta{display:none;}
     .topbar-chips{flex-wrap:nowrap;gap:4px;overflow-x:auto;-webkit-overflow-scrolling:touch;}
@@ -2896,10 +2903,10 @@
        `overflow-x:clip` suppresses horizontal overflow (the original #4583
        intent) WITHOUT coercing overflow-y or creating a scroll container, so
        min-height:auto stays min-content and the inner grows normally. */
-    .messages-inner{padding:12px 10px 20px;max-width:100%;overflow-x:clip;word-break:break-word;min-width:0;}
+    .messages-inner{padding:12px 10px 20px;max-width:100%;overflow-x:clip;word-break:break-word;min-width:0;padding-left:max(10px,env(safe-area-inset-left,0));padding-right:max(10px,env(safe-area-inset-right,0));}
     .msg-body{padding-left:0;max-width:100%;}
     .msg-role{font-size:12px;}
-    .composer-wrap{padding:8px 10px 12px!important;}
+    .composer-wrap{padding:8px 10px 12px!important;padding-left:max(10px,env(safe-area-inset-left,0))!important;padding-right:max(10px,env(safe-area-inset-right,0))!important;}
     .composer-box{border-radius:12px;}
     .composer-box textarea{min-height:40px;}
     .composer-footer{padding:6px 8px 8px!important;gap:6px;flex-wrap:nowrap;align-items:center;}


### PR DESCRIPTION
Salvage of #3976 by @ksj5131513-ops — *"Fix mobile PWA reflow and avoid redundant session refresh"* — ported fresh onto current `master`.

The original PR was based on a pre-#4195 version of `refreshActiveSessionIfExternallyUpdated` and would have clobbered the #3916/#4195 external-refresh gate if merged as-is. This re-applies the PR's **intent** on top of today's code so it **coexists with #4195** rather than reverting it.

## Two parts

### 1. Avoid a redundant same-session force reload after a stream settles
`_scheduleActiveSessionIdleReload` previously called `loadSession(sid, {force:true})` unconditionally on every idle reconcile. On mobile PWA that produced a visible **end-of-turn flash** and could briefly restore the pane with stale layout geometry.

It now reconciles against server metadata first:

```js
const outcome = await refreshActiveSessionIfExternallyUpdated('idle-reconcile', {
  ignoreStreamJustFinished: true,
});
if(outcome === 'failed'){
  await loadSession(sid, {force:true, externalRefreshReason:'idle-reconcile'});
}
```

The transcript is force-reloaded **only when the message count actually changed**; otherwise the lightweight metadata path runs (no destructive reload, no flash). The original forced reload is preserved as a fallback when the metadata probe itself fails.

### How it coexists with #4195
- The #4195 poll-only external-session early-return is **left exactly as-is**:
  `if((reason||'poll')==='poll' && !_isExternalSession(S.session)) return;`
- The idle path uses a **non-`poll` reason** (`'idle-reconcile'`), so it sails through that gate without bypassing it — WebUI-native sessions still skip the 30s poll fallback.
- `opts` is read via `arguments[1]` (same pattern as `loadSession`), so the public **signature stays `(reason)`**. The only guard `ignoreStreamJustFinished` relaxes is the post-stream cooldown — never the external gate, the in-flight lock, the reader-unpinned deferral, or the `document.hidden` check.
- The function now returns a status string (`skipped`/`unchanged`/`reloaded`/`failed`) so callers can react; existing void callers are unaffected.

### 2. Mobile PWA viewport reflow guard
When the on-screen keyboard / browser chrome shows or hides, `visualViewport` changes height without a layout invalidation, leaving the phone layout painted against stale geometry. `_forceMobileViewportReflow()` toggles a one-frame `html.viewport-reflow` class (cheap GPU-promotion transform) to force a repaint, then resyncs the workspace panel + sidebar aria. Wired to debounced `visualViewport` `resize`/`scroll` where available, falling back to the `window` resize handler otherwise. Also adds `env(safe-area-inset-*)` padding to the topbar, messages-inner, and composer on phones.

> Note: the reflow CSS uses `overflow-x:clip` (not the original PR's `overflow-x:hidden`) on `.layout`, per the #4856 lesson that `overflow-x:hidden` coerces `overflow-y` into a scroll container.

## Testing
- `node --check` clean on `boot.js` + `sessions.js`
- Targeted suite (`-k 'mobile or pwa or reflow or refresh or viewport or external'`): **459 passed, 3 skipped**
- Full suite: **10807 passed**, only the known pre-existing flakes failing (scheduled-jobs profile isolation x2, TLS-fallback, sessiondb fd-leak idempotent)

Credit: @ksj5131513-ops (original #3976). Co-authored via commit trailer.