### PR TITLE
feat(plugins): subprocess-isolated plugin API backend (salvage of #3645)

### DIFF
--- a/api/plugin_manager.py
+++ b/api/plugin_manager.py
@@ -1,0 +1,182 @@
+"""
+Plugin subprocess lifecycle manager.
+
+    Spawns, monitors, restarts, and kills plugin subprocesses.
+    Each plugin gets its own subprocess with resource limits and
+    a minimal environment.
+"""
+
+import logging
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_PROCESSES: dict[str, subprocess.Popen] = {}
+_PROCESS_LOCK = threading.Lock()
+_PIPE_LOCKS: dict[str, threading.Lock] = {}
+
+# Environment variable prefixes allowed in plugin subprocess
+_ENV_ALLOWED_PREFIXES = {
+    "HERMES_HOME",
+    "HERMES_PLUGIN_",
+    "HERMES_WEBUI_PLUGIN_",
+    "HOME",
+    "LANG",
+    "LC_",
+    "PATH",
+    "PYTHONPATH",
+    "PYTHONUNBUFFERED",
+    "USER",
+}
+
+
+def _build_plugin_env(plugin_name: str, plugin_dir: Path) -> dict:
+    env = {}
+    for k, v in os.environ.items():
+        for prefix in _ENV_ALLOWED_PREFIXES:
+            if k == prefix or k.startswith(prefix):
+                env[k] = v
+                break
+    env["HERMES_PLUGIN_NAME"] = plugin_name
+    env["HERMES_PLUGIN_DIR"] = str(plugin_dir)
+    env["PYTHONUNBUFFERED"] = "1"
+    return env
+
+
+def get_plugin_pipe_lock(plugin_name: str) -> threading.Lock:
+    with _PROCESS_LOCK:
+        if plugin_name not in _PIPE_LOCKS:
+            _PIPE_LOCKS[plugin_name] = threading.Lock()
+        return _PIPE_LOCKS[plugin_name]
+
+
+def _read_stderr(proc: subprocess.Popen, plugin_name: str):
+    if proc.stderr is None:
+        return
+    try:
+        for line in proc.stderr:
+            line_str = line.decode("utf-8", errors="replace")[:2000]  # cap per-line
+            line_str = line_str.rstrip()
+            if line_str:
+                logger.warning("[plugin:%s] %s", plugin_name, line_str)
+    except Exception:
+        pass
+
+
+def spawn_plugin(plugin_name: str, plugin_dir: Path) -> subprocess.Popen | None:
+    """Spawn a plugin subprocess if not already running.
+
+    Args:
+        plugin_name: e.g. 'my-plugin'
+        plugin_dir: Path to plugin root (contains __init__.py)
+
+    Returns the subprocess.Popen handle, or None on failure.
+    """
+    plugin_dir = plugin_dir.resolve()
+    runner = Path(__file__).parent / "plugin_runner.py"
+
+    with _PROCESS_LOCK:
+        existing = PLUGIN_PROCESSES.get(plugin_name)
+        if existing and existing.poll() is None:
+            return existing  # already running
+
+        # Kill stale process
+        if existing:
+            try:
+                existing.kill()
+                existing.wait(timeout=2)
+            except Exception:
+                pass
+            PLUGIN_PROCESSES.pop(plugin_name, None)
+
+        env = _build_plugin_env(plugin_name, plugin_dir)
+
+        try:
+            proc = subprocess.Popen(
+                [sys.executable, str(runner)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                text=False,
+            )
+
+            # Wait for ready signal from the subprocess
+            if proc.stdout is not None:
+                try:
+                    import json as _json
+                    import select
+                    ready, _, _ = select.select([proc.stdout], [], [], 10)
+                    if not ready:
+                        logger.warning("Plugin %s: no ready signal within 10s, killing", plugin_name)
+                        proc.kill()
+                        proc.wait()
+                        return None
+                    ready_line = proc.stdout.readline()
+                    if ready_line:
+                        ready_msg = _json.loads(ready_line.decode("utf-8").strip())
+                        if ready_msg.get("ready"):
+                            logger.info(
+                                "Plugin %s ready (pid=%d, routes=%s)",
+                                plugin_name, proc.pid, ready_msg.get("routes", []),
+                            )
+                        else:
+                            logger.warning("Plugin %s: unexpected startup message", plugin_name)
+                            proc.kill(); proc.wait(); return None
+                    else:
+                        logger.warning("Plugin %s: no startup message, process may have exited", plugin_name)
+                        proc.kill(); proc.wait(); return None
+                except Exception:
+                    logger.exception("Plugin %s: startup failed, killing", plugin_name)
+                    proc.kill()
+                    proc.wait()
+                    return None
+
+            PLUGIN_PROCESSES[plugin_name] = proc
+            # Start stderr reader thread
+            threading.Thread(
+                target=_read_stderr, args=(proc, plugin_name), daemon=True,
+            ).start()
+            return proc
+        except Exception:
+            logger.exception("Failed to spawn plugin subprocess: %s", plugin_name)
+            return None
+
+
+def get_plugin_process(plugin_name: str) -> subprocess.Popen | None:
+    with _PROCESS_LOCK:
+        proc = PLUGIN_PROCESSES.get(plugin_name)
+    if proc is None:
+        return None
+    if proc.poll() is not None:
+        logger.warning(
+            "Plugin subprocess %s exited (code=%d)", plugin_name, proc.returncode,
+        )
+        with _PROCESS_LOCK:
+            if PLUGIN_PROCESSES.get(plugin_name) is proc:
+                PLUGIN_PROCESSES.pop(plugin_name, None)
+        return None
+    return proc
+
+
+def kill_plugin(plugin_name: str, timeout: float = 5.0):
+    with _PROCESS_LOCK:
+        proc = PLUGIN_PROCESSES.pop(plugin_name, None)
+    if proc is None or proc.poll() is not None:
+        return
+    try:
+        proc.terminate()
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    logger.info("Terminated plugin subprocess: %s", plugin_name)
+
+
+def kill_all_plugins():
+    for name in list(PLUGIN_PROCESSES):
+        kill_plugin(name)

--- a/api/plugin_runner.py
+++ b/api/plugin_runner.py
@@ -1,0 +1,234 @@
+"""
+Plugin subprocess runner — stdin/stdout JSON-line protocol.
+
+Runs inside the plugin subprocess. Reads JSON requests from stdin,
+dispatches to registered handlers via CompatHandler, writes JSON
+responses to stdout.
+
+Set by plugin_manager.py at spawn time:
+  HERMES_PLUGIN_NAME=<plugin_name>
+  HERMES_PLUGIN_DIR=/path/to/plugin/root
+
+Protocol:
+  Request (stdin, one JSON line):
+    {"id": int, "method": "GET|POST", "path": "/sub_route",
+     "query": "...", "headers": {...}, "body_b64": "..."}
+
+  Response (stdout, one JSON line):
+    {"id": int, "status": 200, "headers": {...}, "body_b64": "..."}
+
+Lifecycle:
+  - On stdin EOF: exit 0
+  - On handler exception: write error response, continue
+  - On JSON decode error: write error, continue
+"""
+
+import base64
+import json
+import os
+import sys
+import traceback
+from types import SimpleNamespace
+
+
+class CompatHandler:
+    """Accumulates handler.write() calls and serializes to a JSON response."""
+
+    def __init__(self, request_headers: dict, body_bytes: bytes):
+        self._status = 200
+        self._resp_headers: dict[str, str] = {}
+        self._body_parts: list[bytes] = []
+        self._body_bytes = body_bytes
+        self._hdrs = {k.lower(): v for k, v in (request_headers or {}).items()}
+        self._read_pos = 0
+
+    @property
+    def headers(self):
+        return self
+
+    def get(self, key, default=None):
+        return self._hdrs.get(key.lower() if isinstance(key, str) else key, default)
+
+    def send_response(self, status: int):
+        self._status = status
+
+    def send_header(self, key: str, value: str):
+        self._resp_headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    @property
+    def wfile(self):
+        return self
+
+    def write(self, data: bytes | str):
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+        self._body_parts.append(data)
+
+    @property
+    def rfile(self):
+        return self
+
+    def read(self, length: int) -> bytes:
+        remaining = len(self._body_bytes) - self._read_pos
+        if remaining <= 0:
+            return b""
+        chunk = self._body_bytes[self._read_pos:self._read_pos + length]
+        self._read_pos += len(chunk)
+        return chunk
+
+    def to_response(self, request_id: int) -> dict:
+        body = b"".join(self._body_parts)
+        resp = {
+            "id": request_id,
+            "status": self._status,
+            "headers": self._resp_headers,
+        }
+        if body:
+            resp["body_b64"] = base64.b64encode(body).decode("ascii")
+        return resp
+
+    def j(self, data: dict, status: int = 200):
+        body = json.dumps(data, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def bad(self, msg: str, status: int = 400):
+        self.j({"error": msg}, status=status)
+
+
+def _load_plugin(plugin_name: str, plugin_dir: str):
+    import importlib.util
+
+    init_path = os.path.join(plugin_dir, "__init__.py")
+    if not os.path.isfile(init_path):
+        sys.stderr.write(f"[plugin:{plugin_name}] __init__.py not found\n")
+        sys.stderr.flush()
+        return None
+
+    spec = importlib.util.spec_from_file_location(plugin_name, init_path)
+    if spec is None:
+        sys.stderr.write(f"[plugin:{plugin_name}] failed to create module spec\n")
+        sys.stderr.flush()
+        return None
+    mod = importlib.util.module_from_spec(spec)
+
+    # Make adjacent modules (e.g. tools.py) importable
+    parent = os.path.dirname(plugin_dir)
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+
+    spec.loader.exec_module(mod)
+    if not hasattr(mod, "register"):
+        sys.stderr.write(f"[plugin:{plugin_name}] no register() found\n")
+        sys.stderr.flush()
+        return None
+    return mod
+
+
+def main():
+    plugin_name = os.environ.get("HERMES_PLUGIN_NAME", "unknown")
+    plugin_dir = os.environ.get("HERMES_PLUGIN_DIR", "")
+
+    # Apply resource limits to this process (POSIX; silently skipped elsewhere).
+    # NOTE: RLIMIT_AS caps *virtual address space*, not resident RAM. CPython
+    # plus shared libs already map 200-400MB before any plugin code runs, and a
+    # plugin importing numpy / Pillow / a cffi-backed lib can map well past that
+    # at startup. A tight value (e.g. 512MB) would make the interpreter abort
+    # before emitting the ready signal, so the plugin appears permanently
+    # unavailable. We set a generous ceiling that only trips on runaway
+    # allocation; true physical-RAM limiting belongs at the cgroup layer.
+    for name, value in {
+        "RLIMIT_AS": 3 * 1024 * 1024 * 1024, "RLIMIT_NPROC": 64,
+        "RLIMIT_NOFILE": 256, "RLIMIT_CPU": 300,
+    }.items():
+        try:
+            import resource
+            soft, hard = resource.getrlimit(getattr(resource, name))
+            resource.setrlimit(getattr(resource, name), (min(value, hard), hard))
+        except (OSError, ValueError, AttributeError, ImportError):
+            pass
+    try:
+        os.setpgrp()
+    except OSError:
+        pass
+
+    out = os.fdopen(os.dup(sys.stdout.fileno()), "w")
+    os.dup2(sys.stderr.fileno(), sys.stdout.fileno())
+
+    def send(data):
+        out.write(json.dumps(data) + "\n")
+        out.flush()
+
+    def err(status, message, request_id=0):
+        send({
+            "id": request_id,
+            "status": status,
+            "headers": {"content-type": "application/json; charset=utf-8"},
+            "body_b64": base64.b64encode(json.dumps({"error": message}).encode()).decode("ascii"),
+        })
+
+    if not plugin_dir:
+        err(500, "HERMES_PLUGIN_DIR not set")
+        return
+
+    mod = _load_plugin(plugin_name, plugin_dir)
+    if mod is None:
+        sys.stderr.write(f"[plugin:{plugin_name}] failed to load\n")
+        sys.stderr.flush()
+        return
+
+    routes = mod.register()
+    if not isinstance(routes, dict):
+        err(500, "register() did not return a route map")
+        return
+
+    send({"ready": True, "routes": list(routes.keys())})
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError:
+            err(400, "invalid JSON request")
+            continue
+
+        req_id = req.get("id", 0)
+        method = req.get("method", "GET")
+        path = req.get("path", "/")
+        query = req.get("query", "")
+        req_headers = req.get("headers", {})
+        body_b64 = req.get("body_b64") or ""
+        body_bytes = base64.b64decode(body_b64) if body_b64 else b""
+
+        parsed = SimpleNamespace(path=path, query=query)
+
+        method_handlers = routes.get(path, {})
+        handler_fn = method_handlers.get(method)
+        if handler_fn is None:
+            err(404, "not found", request_id=req_id)
+            continue
+
+        try:
+            ch = CompatHandler(req_headers, body_bytes)
+            handler_fn(ch, parsed)
+            resp = ch.to_response(req_id)
+        except Exception:
+            err(500, "plugin internal error", request_id=req_id)
+            sys.stderr.write(f"[plugin:{plugin_name}] handler error:\n")
+            traceback.print_exc(file=sys.stderr)
+            sys.stderr.flush()
+            continue
+
+        send(resp)
+
+
+if __name__ == "__main__":
+    main()

--- a/api/plugins.py
+++ b/api/plugins.py
@@ -1,5 +1,5 @@
 """
-Plugin discovery and static serving for Hermes Web UI.
+Plugin discovery, static serving, and subprocess management for Hermes Web UI.
 
 Scans ~/.hermes/plugins/<name>/dashboard/ for manifest.json files,
 matching the official Hermes dashboard plugin format.
@@ -11,7 +11,13 @@ Each plugin may have:
       index.js      -- plugin JS bundle (IIFE)
       style.css     -- optional plugin stylesheet
     plugin_api.py   -- optional backend API (not used in WebUI MVP)
+
+Each plugin runs in its own subprocess (stdin/stdout JSON protocol).
+The plugin's __init__.py must define a register() function that returns
+a route map. WebUI serves plugin API traffic under the unified path
+prefix /api/plugins/<plugin_name>/<sub_route>.
 """
+
 import json
 import logging
 import os
@@ -35,6 +41,14 @@ PLUGIN_MANIFESTS: dict[str, dict] = {}
 
 # plugin_name -> resolved static root dir
 _PLUGIN_STATIC_ROOTS: dict[str, Path] = {}
+
+
+def get_plugin_root(plugin_name: str) -> Path | None:
+    """Return the root directory (parent of dashboard/) for a plugin."""
+    base = _PLUGIN_STATIC_ROOTS.get(plugin_name)
+    if base:
+        return base.parent
+    return None
 
 
 def _get_plugin_base() -> Path:
@@ -95,6 +109,26 @@ def load_plugins() -> None:
         dashboard_dir = entry / "dashboard"
         if dashboard_dir.is_dir():
             _PLUGIN_STATIC_ROOTS[name] = dashboard_dir.resolve()
+
+
+def load_plugin_api_routes() -> None:
+    """Spawn subprocesses for each plugin that has an __init__.py."""
+    for plugin_name in list(PLUGIN_MANIFESTS):
+        base = _PLUGIN_STATIC_ROOTS.get(plugin_name)
+        if not base:
+            continue
+        init_file = base.parent / "__init__.py"
+        if not init_file.exists():
+            logger.debug("Plugin %s has no __init__.py, skipping API routes", plugin_name)
+            continue
+
+        from api.plugin_manager import spawn_plugin
+        plugin_root = base.parent
+        proc = spawn_plugin(plugin_name, plugin_root)
+        if proc is None:
+            logger.warning("Plugin %s: subprocess failed to spawn (dir=%s)", plugin_name, plugin_root)
+        else:
+            logger.info("Plugin %s: spawned subprocess (dir=%s)", plugin_name, plugin_root)
 
 
 def serve_plugin_static(plugin_name: str, rel_path: str) -> tuple[bytes, str] | None:

--- a/api/routes.py
+++ b/api/routes.py
@@ -4349,6 +4349,191 @@ def _csrf_exempt_path(path: str) -> bool:
     }
 
 
+def _is_plugin_request(handler, path: str) -> bool:
+    """Let a sandboxed plugin iframe skip the session CSRF token check.
+
+    A sandboxed iframe (no allow-same-origin) sends an opaque ``Origin: null``,
+    which ``_check_csrf`` rejects as an origin mismatch — so plugin fetches need
+    a narrow exemption. It is scoped to exactly that case: ``/api/plugins/``
+    paths carrying the ``X-Plugin-Request`` marker AND ``Origin: null``.
+
+    A cross-origin attacker page carries a concrete Origin (e.g.
+    ``https://evil.example``), so it never matches here and still falls through
+    to ``_check_csrf``, which rejects it. Same-origin and Origin-less requests
+    already pass ``_check_csrf`` on their own and do not rely on this path.
+    (Cross-origin cookie riding is independently impossible: the server never
+    sends ``Access-Control-Allow-Credentials``.)
+    """
+    return (
+        path.startswith("/api/plugins/")
+        and handler.headers.get("X-Plugin-Request") == "1"
+        and handler.headers.get("Origin") == "null"
+    )
+
+
+def _dispatch_plugin_subprocess(handler, plugin_name: str, sub_route: str, method: str, parsed) -> bool:
+    """Proxy a plugin API request to a subprocess via stdin/stdout JSON.
+
+    Each plugin is a single subprocess with a per-plugin pipe lock, so
+    requests are serial: one slow handler blocks all others for up to
+    PIPE_TIMEOUT (30s). Future versions may add concurrency per plugin.
+    """
+    import base64
+    import binascii
+    import json as _json
+    import select
+    import time as _time
+
+    from api.plugin_manager import get_plugin_process, spawn_plugin, kill_plugin, get_plugin_pipe_lock
+    from api.plugins import get_plugin_root
+
+    MAX_PLUGIN_BODY_BYTES = 1 * 1024 * 1024
+    PIPE_TIMEOUT = 30
+    # Bound how many stale/mismatched frames we'll skip while looking for our
+    # own response. A slow handler that wrote a frame just after a prior
+    # request's deadline elapsed can leave one orphan line in the pipe that
+    # would otherwise map onto THIS request. We skip a small, bounded number of
+    # such frames; if none of them carry our id we give up with a 502 rather
+    # than hang or return another request's body.
+    MAX_FRAME_SKIPS = 8
+
+    proc = get_plugin_process(plugin_name)
+    if proc is None:
+        root = get_plugin_root(plugin_name)
+        if root:
+            proc = spawn_plugin(plugin_name, root)
+    if proc is None or proc.poll() is not None:
+        return j(handler, {"error": "plugin unavailable"}, status=503)
+
+    body_bytes = b""
+    try:
+        length = int(handler.headers.get("Content-Length", 0))
+        if length > MAX_PLUGIN_BODY_BYTES:
+            return bad(handler, "request body too large", status=413)
+        if length > 0:
+            body_bytes = handler.rfile.read(length)
+    except (ValueError, OSError):
+        pass
+
+    req = {
+        "id": int(_time.time() * 1000) % 1000000,
+        "method": method,
+        "path": sub_route,
+        "query": parsed.query,
+        "headers": {
+            k: v for k, v in handler.headers.items()
+            if k.lower() not in ("cookie", "authorization")
+        },
+    }
+    if body_bytes:
+        req["body_b64"] = base64.b64encode(body_bytes).decode("ascii")
+
+    def _make_line_reader(stream, deadline):
+        """Yield newline-terminated frames from the pipe under one deadline.
+
+        Returns a `read_line()` closure backed by a persistent buffer so that
+        when the plugin coalesces several frames into one os.read() (e.g. an
+        orphaned stale line immediately followed by our real response), the
+        bytes that follow the first newline are NOT discarded — the id
+        correlation loop can pull the next frame straight out of the buffer.
+
+        select() only signals that *some* bytes are ready; a plugin that writes
+        a partial line and then stalls would hang a bare readline() forever
+        while holding the pipe lock. We loop on select with a shrinking deadline
+        so a stuck plugin trips PIPE_TIMEOUT instead.
+        """
+        import os as _os
+        fd = stream.fileno()
+        buf = bytearray()
+
+        def read_line() -> bytes:
+            nl = buf.find(b"\n")
+            while nl == -1:
+                remaining = deadline - _time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("plugin read deadline exceeded")
+                ready, _, _ = select.select([fd], [], [], remaining)
+                if not ready:
+                    raise TimeoutError("plugin read deadline exceeded")
+                chunk = _os.read(fd, 65536)
+                if not chunk:
+                    raise OSError("plugin closed pipe before responding")
+                buf.extend(chunk)
+                nl = buf.find(b"\n")
+            line = bytes(buf[:nl])
+            del buf[:nl + 1]
+            return line
+
+        return read_line
+
+    lock = get_plugin_pipe_lock(plugin_name)
+    with lock:
+        try:
+            proc.stdin.write((_json.dumps(req) + "\n").encode("utf-8"))
+            proc.stdin.flush()
+            # Response-id correlation: the per-plugin pipe lock serializes the
+            # happy path, and the timeout path kills+504, BUT a slow handler
+            # that wrote a frame just after a previous request's deadline
+            # elapsed could leave an orphan line in the pipe that maps onto
+            # THIS request. The id round-trips through the runner, so read
+            # lines until we see resp["id"] == req["id"]; skip a bounded number
+            # of stale frames, then give up with a 502 (never hang, never
+            # return another request's body). The single shared deadline keeps
+            # the whole exchange under PIPE_TIMEOUT.
+            deadline = _time.monotonic() + PIPE_TIMEOUT
+            read_line = _make_line_reader(proc.stdout, deadline)
+            resp = None
+            for _ in range(MAX_FRAME_SKIPS + 1):
+                resp_line = read_line().decode("utf-8").strip()
+                if not resp_line:
+                    continue
+                candidate = _json.loads(resp_line)
+                if candidate.get("id") == req["id"]:
+                    resp = candidate
+                    break
+                logger.warning(
+                    "Plugin subprocess %s: dropping stale frame id=%r (want %r)",
+                    plugin_name, candidate.get("id"), req["id"],
+                )
+            if resp is None:
+                logger.warning(
+                    "Plugin subprocess %s: no matching response id after %d frames",
+                    plugin_name, MAX_FRAME_SKIPS + 1,
+                )
+                kill_plugin(plugin_name)
+                return j(handler, {"error": "plugin response correlation failed"}, status=502)
+        except TimeoutError:
+            kill_plugin(plugin_name)
+            return j(handler, {"error": "plugin timeout"}, status=504)
+        except (BrokenPipeError, OSError, _json.JSONDecodeError, ValueError) as exc:
+            logger.warning("Plugin subprocess %s failed: %s", plugin_name, exc)
+            kill_plugin(plugin_name)
+            return j(handler, {"error": "plugin crashed"}, status=502)
+
+    resp_status = resp.get("status", 200)
+    resp_headers = resp.get("headers", {})
+    try:
+        resp_body = base64.b64decode(resp["body_b64"]) if resp.get("body_b64") else b""
+    except (binascii.Error, KeyError, ValueError):
+        return j(handler, {"error": "plugin returned invalid response"}, status=502)
+
+    _allowed_resp = {"cache-control", "content-type", "etag", "last-modified"}
+    handler.send_response(resp_status)
+    if handler.headers.get("Origin") == "null":
+        handler.send_header("Access-Control-Allow-Origin", "null")
+    for k, v in resp_headers.items():
+        kl = k.lower()
+        if kl in _allowed_resp or kl.startswith("x-"):
+            # Strip CRLF to prevent header injection from plugin-controlled values.
+            k = k.replace("\r", "").replace("\n", "")
+            v = str(v).replace("\r", "").replace("\n", "")
+            handler.send_header(k, v)
+    handler.send_header("Content-Length", str(len(resp_body)))
+    handler.end_headers()
+    handler.wfile.write(resp_body)
+    return True
+
+
 _CSRF_FAILURE_ATTR = "_hermes_csrf_failure_reason"
 
 
@@ -10062,6 +10247,19 @@ def handle_get(handler, parsed) -> bool:
     # ── Plugins/hooks visibility (read-only, no callback/source internals) ──
     if parsed.path == "/api/plugins":
         return _handle_plugins(handler, parsed)
+
+    if parsed.path.startswith("/api/plugins/"):
+        import urllib.parse
+        parts = parsed.path.split("/")
+        if len(parts) != 5:
+            return False
+        plugin_name = parts[3]
+        if not _dashboard_plugin_enabled(plugin_name):
+            return False  # 404 — disabled plugins serve nothing
+        sub_route = "/" + urllib.parse.unquote(parts[4])
+        if ".." in sub_route:
+            return False
+        return _dispatch_plugin_subprocess(handler, plugin_name, sub_route, handler.command, parsed)
     if parsed.path == "/api/provider/quota":
         query = parse_qs(parsed.query)
         provider_id = (query.get("provider", [""])[0] or None)
@@ -11266,7 +11464,7 @@ def handle_get(handler, parsed) -> bool:
                 # .html/.svg can't run privileged same-origin script if navigated
                 # to directly (the in-panel iframe sandbox doesn't cover direct
                 # navigation). nosniff prevents content-type confusion.
-                handler.send_header("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-popups")
+                handler.send_header("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox")
                 handler.send_header("X-Content-Type-Options", "nosniff")
                 handler.send_header("Content-Length", str(len(data)))
                 handler.end_headers()
@@ -11275,6 +11473,23 @@ def handle_get(handler, parsed) -> bool:
 
     # ── Plugin pages (HTML shell) ──
     from api.plugins import PLUGIN_MANIFESTS, _PLUGIN_STATIC_ROOTS
+    _FETCH_WRAPPER = b'<script>(function(){var _f=fetch;window.fetch=function(u,o){if(!u||u.indexOf("/api/plugins/")!==0)return _f(u,o);o=o||{};o.headers=new Headers(o.headers||{});if(!o.headers.has("X-Plugin-Request"))o.headers.set("X-Plugin-Request","1");return _f(u,o)}})()</script>'
+
+    def _inject_fetch_wrapper(html_bytes: bytes) -> bytes:
+        """Insert the X-Plugin-Request fetch shim so plugin POSTs pass CSRF.
+
+        Falls back through </head>, <head>, <body> and finally prepends —
+        plugin HTML that omits a </head> tag still gets the shim, instead
+        of silently losing it (which would break POST from those plugins).
+        """
+        import re
+        for pat, after in ((rb"</head\s*>", False), (rb"<head[^>]*>", True), (rb"<body[^>]*>", False)):
+            m = re.search(pat, html_bytes, re.IGNORECASE)
+            if m:
+                idx = m.end() if after else m.start()
+                return html_bytes[:idx] + _FETCH_WRAPPER + html_bytes[idx:]
+        return _FETCH_WRAPPER + html_bytes
+
     for name, manifest in PLUGIN_MANIFESTS.items():
         tab = manifest.get("tab", {})
         tab_path = tab.get("path", f"/{name}")
@@ -11288,9 +11503,10 @@ def handle_get(handler, parsed) -> bool:
                 index_html = dashboard_dir / "dist" / "index.html"
                 if index_html.is_file():
                     data = index_html.read_bytes()
+                    data = _inject_fetch_wrapper(data)
                     handler.send_response(200)
                     handler.send_header("Content-Type", "text/html; charset=utf-8")
-                    handler.send_header("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-popups")
+                    handler.send_header("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals")
                     handler.send_header("Content-Length", str(len(data)))
                     handler.end_headers()
                     handler.wfile.write(data)
@@ -11300,9 +11516,10 @@ def handle_get(handler, parsed) -> bool:
                 static_html = plugin_root / "static" / "index.html"
                 if static_html.is_file():
                     data = static_html.read_bytes()
+                    data = _inject_fetch_wrapper(data)
                     handler.send_response(200)
                     handler.send_header("Content-Type", "text/html; charset=utf-8")
-                    handler.send_header("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-popups")
+                    handler.send_header("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals")
                     handler.send_header("Content-Length", str(len(data)))
                     handler.end_headers()
                     handler.wfile.write(data)
@@ -11316,22 +11533,23 @@ def handle_get(handler, parsed) -> bool:
                     name_escaped = html.escape(name)
                     css_tag = f'<link rel="stylesheet" href="/dashboard-plugins/{name_escaped}/{css}">' if css else ""
                     html_content = (
-                        f"<!doctype html>\n"
-                        f"<html lang=\"en\">\n"
-                        f"<head>\n"
-                        f"  <meta charset=\"utf-8\">\n"
-                        f"  <title>{label}</title>\n"
-                        f"  {css_tag}\n"
-                        f"</head>\n"
-                        f"<body>\n"
-                        f'  <div id="pluginPageContainer"></div>\n'
+                        '<!doctype html>\n'
+                        "<html lang=\"en\">\n"
+                        "<head>\n"
+                        '  <meta charset="utf-8">\n'
+                        f'  <title>{label}</title>\n'
+                        f'  {css_tag}\n'
+                        '  <script>(function(){var _f=fetch;window.fetch=function(u,o){if(!u||u.indexOf("/api/plugins/")!==0)return _f(u,o);o=o||{};o.headers=new Headers(o.headers||{});if(!o.headers.has("X-Plugin-Request"))o.headers.set("X-Plugin-Request","1");return _f(u,o)}})()</script>\n'
+                        '</head>\n'
+                        '<body>\n'
+                        '  <div id="pluginPageContainer"></div>\n'
                         f'  <script src="/dashboard-plugins/{name_escaped}/dist/index.js"></script>\n'
-                        f"</body>\n"
-                        f"</html>\n"
+                        '</body>\n'
+                        '</html>\n'
                     ).encode("utf-8")
                     handler.send_response(200)
                     handler.send_header("Content-Type", "text/html; charset=utf-8")
-                    handler.send_header("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-popups")
+                    handler.send_header("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals")
                     handler.send_header("Content-Length", str(len(html_content)))
                     handler.end_headers()
                     handler.wfile.write(html_content)
@@ -11419,12 +11637,25 @@ def handle_post(handler, parsed) -> bool:
     # is intentionally unauthenticated for browser-generated violation reports.
     if diag:
         diag.stage("csrf")
-    if not _csrf_exempt_path(parsed.path) and not _check_csrf(handler):
+    if not _csrf_exempt_path(parsed.path) and not _is_plugin_request(handler, parsed.path) and not _check_csrf(handler):
         try:
             return j(handler, {"error": _csrf_rejection_error(handler)}, status=403)
         finally:
             if diag:
                 diag.finish()
+
+    if parsed.path.startswith("/api/plugins/"):
+        import urllib.parse
+        parts = parsed.path.split("/")
+        if len(parts) != 5:
+            return False
+        plugin_name = parts[3]
+        if not _dashboard_plugin_enabled(plugin_name):
+            return False  # 404 — disabled plugins serve nothing
+        sub_route = "/" + urllib.parse.unquote(parts[4])
+        if ".." in sub_route:
+            return False
+        return _dispatch_plugin_subprocess(handler, plugin_name, sub_route, handler.command, parsed)
 
     if parsed.path == "/api/shutdown":
         return _handle_shutdown(handler)

--- a/server.py
+++ b/server.py
@@ -428,7 +428,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Plugin-Request")
         self.end_headers()
 
     def do_DELETE(self) -> None:
@@ -667,6 +667,13 @@ def main() -> None:
     except Exception as e:
         print(f'[!!] WARNING: Plugin loading failed: {e}', flush=True)
 
+    # Load plugin API routes (proxy handlers registered by plugins)
+    try:
+        from api.plugins import load_plugin_api_routes
+        load_plugin_api_routes()
+    except Exception as e:
+        print(f'[!!] WARNING: Plugin API route loading failed: {e}', flush=True)
+
     _abort_if_already_serving(HOST, PORT)
     httpd = QuietHTTPServer((HOST, PORT), Handler)
 
@@ -707,6 +714,12 @@ def main() -> None:
             drain_all_on_shutdown()
         except Exception:
             logger.debug("Failed to drain lifecycle on shutdown", exc_info=True)
+        # Stop plugin subprocesses on shutdown
+        try:
+            from api.plugin_manager import kill_all_plugins
+            kill_all_plugins()
+        except Exception:
+            logger.debug("Failed to stop plugin subprocesses during shutdown")
         # Stop bg_task_complete drain + SessionChannel reaper (ours-original).
         # The drain thread emits the canonical ``bg_task_complete`` event
         # (with ``process_complete`` kept as a temporary backward-compat

--- a/static/panels.js
+++ b/static/panels.js
@@ -9027,11 +9027,18 @@ async function _loadPluginPage(path, label) {
   // Use an iframe for full isolation (styles, scripts, modals stay sandboxed).
   // Security note: plugins are locally-installed (~/.hermes/plugins/), similar
   // trust model to VS Code extensions — only install plugins you trust.
+  //
+  // allow-popups-to-escape-sandbox: without it, links a plugin opens via
+  // target="_blank" (e.g. an external workplus/gitlab URL) inherit this
+  // iframe's sandbox flags — they open in a forced opaque origin with no
+  // cookies or storage, so a real site renders blank/broken. The token lets
+  // popped-out windows load as normal top-level pages while the plugin's own
+  // document stays sandboxed.
   const iframe = document.createElement('iframe');
   iframe.src = path;
   iframe.style.cssText = 'width:100%;height:100%;border:none;display:block;';
   iframe.setAttribute('title', label || 'Plugin');
-  iframe.setAttribute('sandbox', 'allow-scripts allow-forms allow-popups');
+  iframe.setAttribute('sandbox', 'allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals');
   container.appendChild(iframe);
   _currentPluginPage = { path, label };
 }

--- a/tests/test_plugin_subprocess_isolation.py
+++ b/tests/test_plugin_subprocess_isolation.py
@@ -1,0 +1,377 @@
+"""RFC #3383: Failure isolation tests for plugin subprocess bridge."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _make_plugin(name: str, code: str) -> Path:
+    td = tempfile.mkdtemp(prefix="tpl_")
+    root = Path(td) / name
+    d = root / "dashboard"; d.mkdir(parents=True)
+    (d / "manifest.json").write_text(json.dumps({"name": name, "tab": {"path": f"/{name}"}, "label": name}))
+    (root / "__init__.py").write_text(code)
+    return root
+
+
+def _proc(plugin_dir: Path):
+    runner = Path(__file__).parent.parent / "api" / "plugin_runner.py"
+    return subprocess.Popen(
+        [sys.executable, str(runner)],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env={"HOME": os.environ.get("HOME", "/"), "PATH": os.environ.get("PATH", ""),
+             "HERMES_PLUGIN_NAME": plugin_dir.name, "HERMES_PLUGIN_DIR": str(plugin_dir),
+             "PYTHONUNBUFFERED": "1"},
+        text=True,
+    )
+
+
+def _send(proc, req: dict, timeout=5):
+    import select
+    proc.stdin.write(json.dumps(req) + "\n"); proc.stdin.flush()
+    assert select.select([proc.stdout], [], [], timeout)[0]
+    return json.loads(proc.stdout.readline().strip())
+
+
+_HELLO = 'def register():\n def h(h,p):\n  h.send_response(200);h.send_header("content-type","application/json");h.end_headers();h.wfile.write(b\'{"ok":1}\')\n return {"/":{"GET":h}}'
+_CRASH = 'def register():\n def c(h,p):raise RuntimeError("crash")\n return {"/c":{"GET":c}}'
+_HEADER = 'def register():\n def h(h,p):\n  h.send_response(200);h.send_header("set-cookie","s=h");h.send_header("content-type","text/plain");h.end_headers();h.wfile.write(b"ok")\n return {"/h":{"GET":h}}'
+
+
+class _H:
+    """Minimal handler for testing _dispatch_plugin_subprocess."""
+    def __init__(self, headers=None, body=b""):
+        self._h = headers or {}; self._b = body; self._r = 0
+    @property
+    def headers(self): return self._h
+    @property
+    def rfile(self): return self
+    def read(self, n):
+        c = self._b[self._r:self._r + n]; self._r += len(c); return c
+    def send_response(self, s): self._s = s
+    def send_header(self, k, v):
+        if not hasattr(self, "_rh"): self._rh = {}
+        self._rh[k] = v
+    def end_headers(self): pass
+    @property
+    def wfile(self): return self
+    def write(self, d):
+        if not hasattr(self, "_rb"): self._rb = b""
+        self._rb += d
+
+
+# ── Protocol: happy path, invalid JSON, handler crash ─────────────────
+
+def test_protocol():
+    hdir = _make_plugin("hp", _HELLO)
+    cdir = _make_plugin("cp", _CRASH)
+    try:
+        ph = _proc(hdir); pc = _proc(cdir)
+        assert json.loads(ph.stdout.readline().strip()).get("ready")
+        assert json.loads(pc.stdout.readline().strip()).get("ready")
+        try:
+            # happy path
+            assert _send(ph, {"id": 1, "method": "GET", "path": "/", "query": "", "headers": {}})["status"] == 200
+            # invalid JSON → 400, recover
+            ph.stdin.write("bad\n"); ph.stdin.flush()
+            import select; assert select.select([ph.stdout], [], [], 5)[0]
+            assert json.loads(ph.stdout.readline().strip())["status"] == 400
+            assert _send(ph, {"id": 2, "method": "GET", "path": "/", "query": "", "headers": {}})["status"] == 200
+            # crash → 500, still alive
+            assert _send(pc, {"id": 1, "method": "GET", "path": "/c", "query": "", "headers": {}})["status"] == 500
+            assert pc.poll() is None
+        finally:
+            ph.terminate(); ph.wait(); pc.terminate(); pc.wait()
+    finally:
+        import shutil; shutil.rmtree(hdir.parent, ignore_errors=True)
+        shutil.rmtree(cdir.parent, ignore_errors=True)
+
+
+# ── Env filtering (RFC: no secrets to subprocess) ─────────────────────
+
+def test_env():
+    from api.plugin_manager import _build_plugin_env
+    with patch.dict(os.environ, {"HOME": "/u", "PATH": "/b", "OPENAI_API_KEY": "sk-x"}, clear=True):
+        e = _build_plugin_env("t", Path("/t"))
+        assert e["HOME"] == "/u" and "OPENAI_API_KEY" not in e
+
+
+# ── Lifecycle + dispatch: spawn/kill, oversized, unavailable, headers ─
+
+def test_dispatch():
+    from api.plugin_manager import spawn_plugin, get_plugin_process, kill_plugin, PLUGIN_PROCESSES
+    from api.routes import _dispatch_plugin_subprocess
+    import api.plugins as m
+
+    hdir = _make_plugin("dd", _HELLO)
+    hadir = _make_plugin("hd", _HEADER)
+    PLUGIN_PROCESSES.clear()
+    try:
+        # lifecycle
+        p = spawn_plugin("dd", hdir); assert p and p.poll() is None
+        assert get_plugin_process("dd") is p
+        kill_plugin("dd"); assert get_plugin_process("dd") is None
+
+        # sized body → 413
+        p2 = spawn_plugin("dd", hdir); assert p2
+        old = dict(m._PLUGIN_STATIC_ROOTS); m._PLUGIN_STATIC_ROOTS["dd"] = hdir / "dashboard"
+        try:
+            h = _H(headers={"Content-Length": "2000000"})
+            _dispatch_plugin_subprocess(h, "dd", "/x", "POST", SimpleNamespace(path="", query=""))
+            assert getattr(h, "_s", None) is not None
+        finally:
+            kill_plugin("dd")
+
+        # unavailable → 503
+        with patch("api.plugins.get_plugin_root", return_value=None):
+            h2 = _H()
+            _dispatch_plugin_subprocess(h2, "nope", "/r", "GET", SimpleNamespace(path="", query=""))
+            assert getattr(h2, "_s", None) is not None
+
+        # header filtering
+        p3 = spawn_plugin("hd", hadir); assert p3
+        m._PLUGIN_STATIC_ROOTS["hd"] = hadir / "dashboard"
+        try:
+            h3 = _H()
+            assert _dispatch_plugin_subprocess(h3, "hd", "/h", "GET", SimpleNamespace(path="", query="")) is True
+            rh = {k.lower() for k in getattr(h3, "_rh", {})}
+            assert "set-cookie" not in rh and "content-type" in rh
+        finally:
+            kill_plugin("hd")
+        m._PLUGIN_STATIC_ROOTS = old
+    finally:
+        import shutil
+        shutil.rmtree(hdir.parent, ignore_errors=True)
+        shutil.rmtree(hadir.parent, ignore_errors=True)
+
+
+# ── FIX #2: response-id correlation ───────────────────────────────────
+#
+# _dispatch_plugin_subprocess writes a request carrying a numeric id and must
+# read frames until it finds the one whose id matches — skipping any stale
+# orphan frame a previous (slow/timed-out) handler left in the pipe. Without
+# the correlation loop the dispatcher would return the FIRST line it reads,
+# which could be another request's response body.
+
+def test_dispatch_skips_stale_frame_and_correlates_response_id():
+    """A stale frame (wrong id) sitting ahead of our real response must be
+    skipped; the dispatcher must return the body of the frame whose id matches
+    the request it sent. Non-vacuous: if the id-correlation loop is removed and
+    the dispatcher returns the first line read, it gets the STALE body and the
+    final assertion (b'{"ok":1}') fails."""
+    import os
+    import threading
+    import json as _json
+    import base64
+    import api.plugin_manager as pm
+    from api.routes import _dispatch_plugin_subprocess
+
+    stdin_r, stdin_w = os.pipe()    # dispatcher -> fake plugin
+    stdout_r, stdout_w = os.pipe()  # fake plugin -> dispatcher
+
+    class FakeProc:
+        def __init__(self):
+            self.stdin = os.fdopen(stdin_w, "wb", buffering=0)
+            self.stdout = os.fdopen(stdout_r, "rb", buffering=0)
+
+        def poll(self):
+            return None  # always "alive"
+
+    proc = FakeProc()
+    seen = {}
+
+    def fake_plugin():
+        rf = os.fdopen(stdin_r, "rb")
+        wf = os.fdopen(stdout_w, "wb", buffering=0)
+        line = rf.readline()
+        req = _json.loads(line.decode("utf-8"))
+        rid = req["id"]
+        seen["req_id"] = rid
+        # 1) a STALE orphan frame with a DIFFERENT id and a tell-tale body
+        stale = _json.dumps({
+            "id": (rid + 1) % 1000000, "status": 200, "headers": {},
+            "body_b64": base64.b64encode(b'{"stale":1}').decode("ascii"),
+        }) + "\n"
+        # 2) the CORRECT frame echoing our id
+        good = _json.dumps({
+            "id": rid, "status": 200,
+            "headers": {"content-type": "application/json"},
+            "body_b64": base64.b64encode(b'{"ok":1}').decode("ascii"),
+        }) + "\n"
+        wf.write(stale.encode("utf-8"))
+        wf.write(good.encode("utf-8"))
+        wf.flush()
+
+    t = threading.Thread(target=fake_plugin, daemon=True)
+    t.start()
+    try:
+        h = _H()
+        with patch.object(pm, "get_plugin_process", return_value=proc):
+            result = _dispatch_plugin_subprocess(
+                h, "corr", "/r", "GET", SimpleNamespace(path="", query=""),
+            )
+        t.join(timeout=5)
+        assert result is True
+        assert getattr(h, "_s", None) == 200
+        # The decisive check: we got the body of the id-matched frame, NOT the
+        # stale frame that arrived first.
+        assert getattr(h, "_rb", b"") == b'{"ok":1}'
+        assert seen.get("req_id") is not None
+    finally:
+        for fd in (stdin_r, stdin_w, stdout_r, stdout_w):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def test_dispatch_502_when_no_frame_matches_request_id():
+    """If the plugin only ever emits frames with the wrong id, the dispatcher
+    must give up with a 502 (correlation failed) rather than hang or return a
+    mismatched body. Non-vacuous: a dispatcher that returned the first frame
+    unconditionally would yield status 200 here, failing the 502 assertion."""
+    import os
+    import threading
+    import json as _json
+    import base64
+    import api.plugin_manager as pm
+    from api.routes import _dispatch_plugin_subprocess
+
+    stdin_r, stdin_w = os.pipe()
+    stdout_r, stdout_w = os.pipe()
+
+    class FakeProc:
+        def __init__(self):
+            self.stdin = os.fdopen(stdin_w, "wb", buffering=0)
+            self.stdout = os.fdopen(stdout_r, "rb", buffering=0)
+
+        def poll(self):
+            return None
+
+    proc = FakeProc()
+
+    def fake_plugin():
+        rf = os.fdopen(stdin_r, "rb")
+        wf = os.fdopen(stdout_w, "wb", buffering=0)
+        line = rf.readline()
+        req = _json.loads(line.decode("utf-8"))
+        rid = req["id"]
+        # Emit a flood of WRONG-id frames (more than MAX_FRAME_SKIPS+1).
+        for k in range(1, 20):
+            frame = _json.dumps({
+                "id": (rid + k) % 1000000, "status": 200, "headers": {},
+                "body_b64": base64.b64encode(b'{"wrong":1}').decode("ascii"),
+            }) + "\n"
+            try:
+                wf.write(frame.encode("utf-8"))
+                wf.flush()
+            except (BrokenPipeError, OSError):
+                break
+
+    t = threading.Thread(target=fake_plugin, daemon=True)
+    t.start()
+    try:
+        h = _H()
+        with patch.object(pm, "get_plugin_process", return_value=proc):
+            result = _dispatch_plugin_subprocess(
+                h, "nomatch", "/r", "GET", SimpleNamespace(path="", query=""),
+            )
+        t.join(timeout=5)
+        # j(handler, ..., status=502) returns True; the recorded status is 502.
+        assert getattr(h, "_s", None) == 502
+    finally:
+        for fd in (stdin_r, stdin_w, stdout_r, stdout_w):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+# ── FIX #3: CSRF narrowed to Origin: null (security) ──────────────────
+#
+# The plugin CSRF exemption must accept ONLY the sandboxed-iframe case
+# (Origin: null + X-Plugin-Request marker), NOT a blanket /api/plugins/
+# prefix exemption. A cross-origin attacker page carries a concrete Origin
+# and must still be rejected by _check_csrf.
+
+def test_is_plugin_request_only_exempts_null_origin():
+    """Unit: _is_plugin_request is True ONLY for Origin: null + marker on a
+    plugin path. A concrete cross-origin Origin must NOT be exempted."""
+    from api.routes import _is_plugin_request
+
+    class _Hdr(dict):
+        def get(self, k, default=None):
+            return dict.get(self, k, default)
+
+    class _Req:
+        def __init__(self, headers):
+            self.headers = _Hdr(headers)
+
+    path = "/api/plugins/foo/bar"
+    # Sandboxed iframe: Origin: null + marker → exempt
+    assert _is_plugin_request(_Req({"Origin": "null", "X-Plugin-Request": "1"}), path) is True
+    # Cross-origin attacker page: concrete Origin → NOT exempt
+    assert _is_plugin_request(_Req({"Origin": "https://evil.example", "X-Plugin-Request": "1"}), path) is False
+    # Marker without null Origin → NOT exempt
+    assert _is_plugin_request(_Req({"X-Plugin-Request": "1"}), path) is False
+    # null Origin but no marker → NOT exempt
+    assert _is_plugin_request(_Req({"Origin": "null"}), path) is False
+    # Right headers but non-plugin path → NOT exempt
+    assert _is_plugin_request(_Req({"Origin": "null", "X-Plugin-Request": "1"}), "/api/settings") is False
+
+
+def test_csrf_gate_rejects_cross_origin_plugin_post_allows_null_origin():
+    """Integration through handle_post: a plugin POST carrying a REAL
+    cross-origin Origin is rejected (403) by the CSRF gate, while an
+    Origin: null plugin POST is allowed through to dispatch.
+
+    Non-vacuous: if the exemption regressed to a blanket /api/plugins/ prefix,
+    _is_plugin_request would return True for the cross-origin request too, the
+    CSRF gate would be skipped, dispatch would be reached, and the status-403
+    assertion would fail."""
+    import api.routes as routes
+
+    class _Hdr(dict):
+        def get(self, k, default=None):
+            return dict.get(self, k, default)
+
+    class _Handler:
+        def __init__(self, headers):
+            self.headers = _Hdr(headers)
+            self.command = "POST"
+
+    parsed = SimpleNamespace(path="/api/plugins/foo/bar", query="")
+
+    # ── Cross-origin plugin POST → must be REJECTED (403) ──
+    captured = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["status"] = status
+        return True
+
+    h_cross = _Handler({
+        "X-Plugin-Request": "1", "Origin": "https://evil.example",
+        "Host": "localhost:8000",
+    })
+    with patch("api.routes._check_csrf", return_value=False), \
+         patch("api.routes.j", side_effect=fake_j), \
+         patch("api.routes._dispatch_plugin_subprocess", return_value="DISPATCHED") as disp_cross:
+        routes.handle_post(h_cross, parsed)
+    assert captured.get("status") == 403, "cross-origin plugin POST must be CSRF-rejected"
+    disp_cross.assert_not_called()
+
+    # ── Origin: null plugin POST → allowed past CSRF, reaches dispatch ──
+    h_null = _Handler({
+        "X-Plugin-Request": "1", "Origin": "null", "Host": "localhost:8000",
+    })
+    with patch("api.routes._check_csrf", return_value=False), \
+         patch("api.routes._dashboard_plugin_enabled", return_value=True), \
+         patch("api.routes._dispatch_plugin_subprocess", return_value="DISPATCHED") as disp_null:
+        result = routes.handle_post(h_null, parsed)
+    disp_null.assert_called_once()
+    assert result == "DISPATCHED"

--- a/tests/test_plugin_subprocess_isolation.py
+++ b/tests/test_plugin_subprocess_isolation.py
@@ -278,7 +278,7 @@ def test_dispatch_502_when_no_frame_matches_request_id():
     try:
         h = _H()
         with patch.object(pm, "get_plugin_process", return_value=proc):
-            result = _dispatch_plugin_subprocess(
+            _dispatch_plugin_subprocess(
                 h, "nomatch", "/r", "GET", SimpleNamespace(path="", query=""),
             )
         t.join(timeout=5)

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -299,6 +299,10 @@ class TestDashboardPluginsSecurity:
         assert "allow-scripts" in js
         assert "allow-forms" in js
         assert "allow-popups" in js
+        # External links a plugin opens via target="_blank" must escape the
+        # iframe sandbox, else they inherit it (opaque origin, no cookies) and
+        # render blank. See routes.py plugin-page CSP for the matching token.
+        assert "allow-popups-to-escape-sandbox" in js
 
     def test_plugins_api_returns_per_plugin_enabled_state(self):
         import api.routes as routes
@@ -415,6 +419,19 @@ class TestPluginAssetIsolationHardening:
         assert "sandbox allow-scripts" in seg
         assert "X-Content-Type-Options" in seg and "nosniff" in seg
 
+    def test_plugin_page_csp_allows_popups_to_escape_sandbox(self):
+        # The CSP sandbox on plugin-page HTML and the iframe sandbox attribute
+        # both gate the same flags. target="_blank" links to external sites
+        # (workplus/gitlab) must escape the sandbox in BOTH, else the popped-out
+        # window inherits an opaque origin and renders blank.
+        routes = read("api/routes.py")
+        start = routes.find("# ── Plugin pages")
+        seg = routes[start:routes.find("# ── GET route helpers", start)]
+        csp_lines = [line for line in seg.splitlines() if "sandbox allow-scripts" in line]
+        assert csp_lines, "expected plugin-page CSP sandbox headers"
+        for csp in csp_lines:
+            assert "allow-popups-to-escape-sandbox" in csp
+
     def test_both_plugin_routes_enforce_enable_gate_server_side(self):
         # Both the asset route and the page route must 404 a disabled plugin —
         # "disabled" cannot be UI-only.
@@ -423,6 +440,24 @@ class TestPluginAssetIsolationHardening:
         page_seg = routes[routes.find("# ── Plugin pages"):routes.find("# ── Plugin pages") + 2000]
         assert "_dashboard_plugin_enabled" in asset_seg
         assert "_dashboard_plugin_enabled" in page_seg
+
+    def test_api_plugin_routes_enforce_enable_gate_server_side(self):
+        # The /api/plugins/<name>/<sub> backend routes (GET + POST) must also
+        # 404 a disabled plugin, otherwise disabling a plugin in the UI leaves
+        # its API endpoints reachable. Both blocks must gate before dispatch.
+        routes = read("api/routes.py")
+        blocks = []
+        start = 0
+        marker = 'if parsed.path.startswith("/api/plugins/"):'
+        while (idx := routes.find(marker, start)) != -1:
+            blocks.append(routes[idx:idx + 600])
+            start = idx + len(marker)
+        assert len(blocks) >= 2, "expected both GET and POST /api/plugins/ blocks"
+        for seg in blocks:
+            gate = seg.find("_dashboard_plugin_enabled")
+            dispatch = seg.find("_dispatch_plugin_subprocess")
+            assert gate != -1, "API plugin route missing enable gate"
+            assert gate < dispatch, "enable gate must run before dispatch"
 
 
 class TestSettingsAllowlistGuard:


### PR DESCRIPTION
## Summary

Salvage of #3645 (by @pix0127), **ported fresh onto current `master`**.

Each plugin that ships an `__init__.py` now runs in its **own subprocess**, talking to WebUI over a stdin/stdout JSON-line protocol. WebUI proxies plugin API traffic under the unified prefix `/api/plugins/<plugin_name>/<sub_route>` to that subprocess. (`plugins` is a distinct core system from `extensions`.)

Per the maintainer's verdict on #3645 — *"Solid iteration, #1 (stdout/JSON-pipe corruption) was the must-fix and it's handled."* — this PR **preserves the verified-correct stdout-redirect fix** and **applies the two remaining fixes** (response-id correlation + CSRF narrowing).

## Preserved: stdout-redirect fix (maintainer-verified)

`api/plugin_runner.py` dup()s the real stdout to a protected fd (`out`) and redirects fd 1 → stderr **before** loading any plugin code. Every protocol frame — the `ready` signal, per-request responses, and error frames (`err()`) — goes through the single `send()` write path on the protected fd, while any stray plugin `print()` lands on the stderr reader thread in `plugin_manager._read_stderr`. This is what eliminates JSON-pipe corruption.

## Fix #2 — response-id correlation

**Problem:** `_dispatch_plugin_subprocess` built a request `id` but read one line back and `json.loads`'d it **without** correlating the id. The per-plugin pipe lock serializes the happy path and the timeout path kills+504s, but a slow handler that wrote a frame just after a previous request's 30s deadline elapsed could leave an **orphan frame** in the pipe that maps onto the *next* request.

**Fix:** the dispatcher now loops, reading frames until `resp["id"] == req["id"]`, skipping a **bounded** number of stale frames (`MAX_FRAME_SKIPS`). A persistent read buffer (`_make_line_reader`) handles the case where the plugin coalesces a stale frame and the real response into a single `os.read()` — bytes after the first newline are not discarded. If no frame matches after the bound, it returns **502** rather than hang or return another request's body. The id round-trips through the runner already (it echoes `req["id"]` into every response/error frame). The single shared deadline keeps the whole exchange under `PIPE_TIMEOUT`.

## Fix #3 — CSRF narrowed to `Origin: null` (security)

**Problem:** the earlier approach blanket-exempted the entire `/api/plugins/` prefix from CSRF. The rationale was that the sandboxed iframe sends `Origin: null` (which `_check_csrf` rejects), but a blanket prefix exemption lets a **state-changing plugin POST ride through cross-origin from any page** with the user's cookie when auth is ON.

**Fix:** `_is_plugin_request` now exempts **only** the sandboxed-iframe case — a `/api/plugins/` path carrying **both** the `X-Plugin-Request` marker **and** `Origin: null`. A cross-origin attacker page carries a concrete `Origin` (e.g. `https://evil.example`), never matches, and still falls through to `_check_csrf`, which rejects it. (Cross-origin cookie riding is independently impossible — the server never sends `Access-Control-Allow-Credentials`.)

## Tests (non-vacuous — verified by mutation)

New, in `tests/test_plugin_subprocess_isolation.py`:

- **`test_dispatch_skips_stale_frame_and_correlates_response_id`** — a stale wrong-id frame is queued ahead of the real response; the dispatcher must return the id-matched body (`{"ok":1}`), not the stale one. Removing the id check (return-first-frame mutant) → **fails**.
- **`test_dispatch_502_when_no_frame_matches_request_id`** — a flood of wrong-id frames must yield **502**, not a mismatched body. Return-first-frame mutant → **fails**.
- **`test_is_plugin_request_only_exempts_null_origin`** — exemption is True only for `Origin: null` + marker on a plugin path; a concrete cross-origin `Origin` is **not** exempt.
- **`test_csrf_gate_rejects_cross_origin_plugin_post_allows_null_origin`** — integration through `handle_post`: a cross-origin plugin POST is **403**'d; an `Origin: null` plugin POST reaches dispatch. Reverting to a blanket-prefix exemption → **fails**.

Mutation-tested both fixes: breaking fix #2 fails both #2 tests; breaking fix #3 (blanket prefix) fails both #3 tests.

Also ported the PR's protocol/env/dispatch isolation tests plus the plugin-page CSP and API enable-gate assertions in `tests/test_plugins_panel.py`.

## Test plan

- Targeted: `-k 'plugin and (subprocess or runner or dispatch or csrf or isolat or correlat)'` → **13 passed, 1 skipped**.
- Full suite → **10826 passed, 92 skipped, 1 xfailed, 2 xpassed**; the only 4 failures are pre-existing environmental flakes (cron profile-context ×2, TLS-fallback, sessiondb fd-leak idempotent) that also fail on clean `master` and pass in isolation.

Closes #3383

Co-authored-by: @pix0127
