### PR TITLE
fix(ui): absolute keep_count for edit and regenerate truncate (#5096 Bug B)

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -14086,16 +14086,19 @@ function autoResizeTextarea(ta) {
 
 async function submitEdit(msgIdx, newText) {
   if(!S.session || S.busy) return;
-  // Truncate session at msgIdx (keep messages before the edited one)
-  // then re-send the edited text
+  const initialSid = S.session.session_id;
+  const absoluteKeepCount = _oldestIdx + msgIdx;
+  if(typeof _ensureAllMessagesLoaded==='function'){
+    await _ensureAllMessagesLoaded();
+  }
+  if(!S.session || S.session.session_id !== initialSid) return;
   try {
     await api('/api/session/truncate', {method:'POST', body:JSON.stringify({
-      session_id: S.session.session_id,
-      keep_count: msgIdx  // keep messages[0..msgIdx-1], discard from msgIdx onward
+      session_id: initialSid,
+      keep_count: absoluteKeepCount
     })});
-    S.messages = S.messages.slice(0, msgIdx);
+    S.messages = S.messages.slice(0, absoluteKeepCount);
     renderMessages();
-    // Now send the edited message as a new chat
     $('msg').value = newText;
     await send();
   } catch(e) { setStatus(t('edit_failed') + e.message); }
@@ -14103,24 +14106,27 @@ async function submitEdit(msgIdx, newText) {
 
 async function regenerateResponse(btn) {
   if(!S.session || S.busy) return;
-  // Find the last user message and re-run it
-  // Remove the last assistant message first (truncate to before it)
   const row = btn.closest('[data-msg-idx]');
   if(!row) return;
   const assistantIdx = parseInt(row.dataset.msgIdx, 10);
-  // Find the last user message text (one before this assistant message)
+  const absoluteKeepCount = _oldestIdx + assistantIdx;
+  const initialSid = S.session.session_id;
   let lastUserText = '';
   for(let i = assistantIdx - 1; i >= 0; i--) {
     const m = S.messages[i];
     if(m && m.role === 'user') { lastUserText = msgContent(m); break; }
   }
   if(!lastUserText) return;
+  if(typeof _ensureAllMessagesLoaded==='function'){
+    await _ensureAllMessagesLoaded();
+  }
+  if(!S.session || S.session.session_id !== initialSid) return;
   try {
     await api('/api/session/truncate', {method:'POST', body:JSON.stringify({
-      session_id: S.session.session_id,
-      keep_count: assistantIdx  // remove the assistant message
+      session_id: initialSid,
+      keep_count: absoluteKeepCount
     })});
-    S.messages = S.messages.slice(0, assistantIdx);
+    S.messages = S.messages.slice(0, absoluteKeepCount);
     renderMessages();
     $('msg').value = lastUserText;
     await send();

--- a/tests/test_issue_edit_regenerate_absolute_keep_count.py
+++ b/tests/test_issue_edit_regenerate_absolute_keep_count.py
@@ -1,0 +1,42 @@
+"""Regression: edit/regenerate use absolute keep_count (#2184 pattern)."""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, name: str) -> str:
+    needle_async = f"async function {name}"
+    start = src.index(needle_async)
+    brace = src.index("{", start)
+    depth = 0
+    for i in range(brace, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise AssertionError(f"function {name!r} body not found")
+
+
+def test_submit_edit_uses_absolute_keep_count():
+    body = _function_body(UI_JS, "submitEdit")
+    assert re.search(r"absoluteKeepCount\s*=\s*_oldestIdx\s*\+\s*msgIdx", body)
+    assert "keep_count: absoluteKeepCount" in body
+
+
+def test_regenerate_uses_absolute_keep_count():
+    body = _function_body(UI_JS, "regenerateResponse")
+    assert re.search(r"absoluteKeepCount\s*=\s*_oldestIdx\s*\+\s*assistantIdx", body)
+    assert "keep_count: absoluteKeepCount" in body
+
+
+def test_submit_edit_captures_absolute_before_await():
+    body = _function_body(UI_JS, "submitEdit")
+    cap = re.search(r"absoluteKeepCount\s*=\s*_oldestIdx\s*\+\s*msgIdx", body)
+    assert cap
+    first_await = re.search(r"\bawait\b", body)
+    assert first_await and cap.start() < first_await.start()


### PR DESCRIPTION
# Fix #5096 (Bug B): absolute keep_count for edit and regenerate truncate

Refs nesquena/hermes-webui#5096 (does not close the full bundle; A/C/D are separate PRs).

## Thinking Path

- Hermes WebUI aims for CLI-like session control in the browser: users can edit a turn, regenerate a reply, or fork from a point in history.
- Long transcripts paginate in the client (`_oldestIdx`); server truncate uses an absolute message index (`keep_count`), not a window-relative DOM index.
- `forkFromMessage` already computes `absoluteKeepCount = _oldestIdx + msgIdx` before async work (#2184); **edit** and **regenerate** still sent window-relative `msgIdx` only.
- After “Load earlier messages”, edit/regenerate could truncate at the wrong point while the UI looked correct — the agent on the next turn still behaved as if later turns existed (#5096 Bug B).
- This PR aligns `submitEdit` and `regenerateResponse` with the fork path: capture absolute index before the first `await`, load the full transcript before truncate, guard stale session after truncate.

## What Changed

- **`static/ui.js`** — `submitEdit` and `regenerateResponse`: `absoluteKeepCount = _oldestIdx + msgIdx` before `_ensureAllMessagesLoaded`; truncate with absolute `keep_count`; stale-session check after truncate (same pattern as fork).
- **`tests/test_issue_edit_regenerate_absolute_keep_count.py`** — regression that edit/regenerate source uses absolute keep_count.
- **`tests/test_issue2184_fork_from_here_absolute_index.py`** — existing fork regression (unchanged behavior).

No `CHANGELOG.md` edits (per CONTRIBUTING: release notes in PR body only).

## Why It Matters

Users who edit or regenerate after loading older messages were silently rewinding the **wrong** slice of history. The model could still see context from turns the UI had removed. Matching fork semantics makes rewind/edit/regenerate trustworthy on long sessions.

## Verification

- `./scripts/test.sh tests/test_issue_edit_regenerate_absolute_keep_count.py tests/test_issue2184_fork_from_here_absolute_index.py` — passed locally after rebase on `upstream/master`.
- `node --check static/ui.js` — OK.
- Manual (recommended): long session → “Load earlier messages” → edit a mid-history user message → confirm transcript truncates at that turn and the next reply does not reference removed turns.

## Risks / Follow-ups

- Server-side context alignment for arbitrary `keep_count` is **#5096 Bug C** (separate PR). This PR fixes **client index math** only; land C+D for full model-context correctness after mid-history edit.
- Regenerate remains last-assistant-only by design; not expanded here.

## Release note (for maintainers)

**Fixed:** Edit and regenerate on paginated transcripts now truncate at the correct absolute message index (same as “fork from here”), so rewind from an older visible user turn does not leave the agent using context from discarded turns.

## Model Used

- Provider: custom (llm-proxy) / Hermes developer profile
- Model: `x-ai/grok-composer-2.5-fast`
- AI disclosure: AI assisted implementation, tests, and this PR description; human (b3nw) owns review and merge decisions.

Co-authored-by: b3nw <b3nw@users.noreply.github.com>