### PR TITLE
fix(session): semantic context truncate on rewind + evict agent (#5096 Bug C+D)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -12227,24 +12227,9 @@ def handle_post(handler, parsed) -> bool:
         if keep < 0:
             return bad(handler, "keep_count must be non-negative")
         with _get_session_agent_lock(body["session_id"]):
-            old_msg_count = len(s.messages or [])
-            old_ctx_count = len(getattr(s, 'context_messages', None) or [])
-            s.messages = s.messages[:keep]
-            # Truncate context_messages in sync with messages so the agent's
-            # model-facing context doesn't retain rows the user removed via
-            # Edit / Regenerate.  Without this, context_messages still contains
-            # the full pre-truncation history and the agent sees "deleted"
-            # turns on the next turn (#2914).
-            if isinstance(getattr(s, 'context_messages', None), list):
-                s.context_messages = s.context_messages[:keep]
-            try:
-                from api.session_ops import _truncation_watermark_for
-                s.truncation_watermark = _truncation_watermark_for(s.messages)
-                # Persist the original truncate cutoff.
-                s.truncation_boundary = s.truncation_watermark
-            except Exception:
-                s.truncation_watermark = 0.0
-                s.truncation_boundary = 0.0
+            from api.session_ops import truncate_session_at_keep
+
+            old_msg_count, old_ctx_count = truncate_session_at_keep(s, keep)
             s.save()
             logger.info(
                 "truncate %s: messages %d→%d, context_messages %d→%d, watermark=%.2f",
@@ -12252,6 +12237,8 @@ def handle_post(handler, parsed) -> bool:
                 old_ctx_count, len(getattr(s, 'context_messages', None) or []),
                 s.truncation_watermark or 0,
             )
+        from api.config import _evict_session_agent
+        _evict_session_agent(body["session_id"])
         return j(
             handler, {"ok": True, "session": s.compact() | {"messages": s.messages}}
         )

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -67,6 +67,45 @@ def _truncation_watermark_for(messages):
         return 0.0
 
 
+def truncate_context_for_display_keep(
+    context_messages: list | None,
+    full_messages: list | None,
+    keep: int,
+) -> list:
+    """Align model context with display prefix ``full_messages[:keep]``."""
+    if keep <= 0:
+        return []
+    ctx = context_messages if isinstance(context_messages, list) else []
+    msgs = full_messages if isinstance(full_messages, list) else []
+    if not ctx:
+        return []
+    if len(ctx) == len(msgs):
+        return ctx[:keep]
+    if len(msgs) == 0:
+        return []
+    prefix_len = max(0, len(ctx) - len(msgs))
+    prefix = ctx[:prefix_len]
+    suffix = ctx[prefix_len:]
+    return prefix + suffix[:keep]
+
+
+def truncate_session_at_keep(session, keep: int) -> tuple[int, int]:
+    """Truncate display + context; set watermark/boundary. Returns old counts."""
+    full_messages = list(session.messages or [])
+    old_msg_count = len(full_messages)
+    old_ctx_count = len(getattr(session, 'context_messages', None) or [])
+    session.messages = full_messages[:keep]
+    if isinstance(getattr(session, 'context_messages', None), list):
+        session.context_messages = truncate_context_for_display_keep(
+            session.context_messages,
+            full_messages,
+            keep,
+        )
+    session.truncation_watermark = _truncation_watermark_for(session.messages)
+    session.truncation_boundary = session.truncation_watermark
+    return old_msg_count, old_ctx_count
+
+
 def retry_last(session_id: str) -> dict[str, Any]:
     """Truncate the session to before the last user message, return its text.
 

--- a/tests/test_issue2914_truncation_watermark.py
+++ b/tests/test_issue2914_truncation_watermark.py
@@ -139,6 +139,72 @@ def test_truncate_endpoint_also_truncates_context_messages(monkeypatch, tmp_path
     assert loaded.truncation_watermark == 2.0
 
 
+def test_truncate_endpoint_compaction_leading_context_row(monkeypatch, tmp_path):
+    """Context longer than display (leading compaction row): naive [:keep] would
+    leave a stale tail; truncate must align suffix to display prefix (#5096 / C).
+    """
+    import json
+    from io import BytesIO
+    from types import SimpleNamespace
+
+    import api.models as models
+    import api.routes as routes
+    from api.models import Session
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+    monkeypatch.setattr(
+        "api.config._evict_session_agent",
+        lambda _sid: None,
+    )
+
+    display = [
+        _msg("user", "u1", 1.0, "u1"),
+        _msg("assistant", "a1", 2.0, "a1"),
+        _msg("user", "REMOVE", 3.0, "u2"),
+    ]
+    context = [
+        _msg("user", "compaction-only", 0.5, "cref"),
+        _msg("user", "u1", 1.0, "cu1"),
+        _msg("assistant", "a1", 2.0, "ca1"),
+        _msg("user", "REMOVE", 3.0, "cu2"),
+    ]
+    session = Session(
+        session_id="issue5096truncatectx",
+        messages=display,
+        context_messages=context,
+    )
+    session.save()
+
+    body = {"session_id": "issue5096truncatectx", "keep_count": 2}
+    body_bytes = json.dumps(body).encode()
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+
+    captured_response = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured_response["payload"] = payload
+
+    monkeypatch.setattr(routes, "j", fake_j)
+
+    handler = SimpleNamespace(
+        headers={"Content-Length": str(len(body_bytes))},
+        rfile=BytesIO(body_bytes),
+    )
+    routes.handle_post(handler, SimpleNamespace(path="/api/session/truncate"))
+
+    assert captured_response["payload"].get("ok") is True
+    loaded = Session.load("issue5096truncatectx")
+    assert loaded is not None
+    assert [m["content"] for m in loaded.messages] == ["u1", "a1"]
+    assert len(loaded.context_messages) == 3
+    assert loaded.context_messages[0]["content"] == "compaction-only"
+    assert "REMOVE" not in [m["content"] for m in loaded.context_messages]
+
+
 def test_truncate_without_context_messages_truncation_leaks_to_agent(monkeypatch, tmp_path):
     """Prove the bug: if context_messages is NOT truncated, agent sees old rows."""
     import api.models as models

--- a/tests/test_truncate_session_at_keep.py
+++ b/tests/test_truncate_session_at_keep.py
@@ -1,0 +1,25 @@
+"""truncate_session_at_keep aligns context when lengths differ (#5096 C)."""
+
+from api.models import Session
+from api.session_ops import truncate_session_at_keep
+
+
+def test_truncate_session_at_keep_compaction_prefix():
+    s = Session(
+        session_id="t1",
+        messages=[
+            {"role": "user", "content": "u1", "timestamp": 1},
+            {"role": "assistant", "content": "a1", "timestamp": 2},
+            {"role": "user", "content": "gone", "timestamp": 3},
+        ],
+        context_messages=[
+            {"role": "user", "content": "cref", "timestamp": 0.5},
+            {"role": "user", "content": "u1", "timestamp": 1},
+            {"role": "assistant", "content": "a1", "timestamp": 2},
+            {"role": "user", "content": "gone", "timestamp": 3},
+        ],
+    )
+    truncate_session_at_keep(s, 2)
+    assert len(s.messages) == 2
+    assert len(s.context_messages) == 3
+    assert "gone" not in [m["content"] for m in s.context_messages]


### PR DESCRIPTION
# Fix #5096 (Bug C + D): semantic context truncate on rewind + evict cached agent

Refs nesquena/hermes-webui#5096 (C and D; maintainer suggested folding D into this PR).

## Thinking Path

- Hermes WebUI persists both display `messages` and model-facing `context_messages`; rewind paths must keep them aligned.
- `POST /api/session/truncate` used `context_messages[:keep]`, which breaks when context is longer than display (compaction-only leading rows) or shapes differ (#5096 Bug C).
- Retry/undo truncate the **last exchange** via `_truncate_at_last_user`; mid-history rewind (edit/regenerate) passes arbitrary `keep_count` and needs display-aligned slicing, not naive prefix length.
- After truncate, a cached in-process agent could still hold pre-truncate state (#5096 Bug D) — same class of bug as clear without eviction.
- This PR centralizes truncate semantics and evicts the session agent after successful truncate.

## What Changed

- **`api/session_ops.py`** — `truncate_session_at_keep`, `truncate_context_for_display_keep`; watermark handling preserved.
- **`api/routes.py`** — truncate endpoint uses `truncate_session_at_keep`; `_evict_session_agent` after successful truncate.
- **`tests/test_truncate_session_at_keep.py`** — unit tests for context alignment.
- **`tests/test_issue2914_truncation_watermark.py`** — includes `test_truncate_endpoint_compaction_leading_context_row` (maintainer-requested compaction case).

No `CHANGELOG.md` edits.

### Retry vs mid-history rewind (honest scope)

- **Retry/undo:** unchanged — still `_truncate_at_last_user` on the last user turn.
- **Arbitrary `keep_count`:** uses `truncate_context_for_display_keep` so kept context matches the visible prefix.

## Why It Matters

Users who edit or rewind mid-history were seeing a shortened transcript while the model still consumed stale tail context. Evicting the cached agent prevents the next turn from reusing pre-truncate in-memory state.

## Verification

- `./scripts/test.sh tests/test_truncate_session_at_keep.py tests/test_issue2914_truncation_watermark.py` — 14 passed locally after rebase on `upstream/master`.
- Manual: truncate via edit/regenerate after compaction-heavy session; confirm next turn does not reference removed content.

## Risks / Follow-ups

- Does not change `context_engine_state` on truncate; follow up if engine state still leaks after rewind.
- #4323 (separate layer) — does not subsume this issue per maintainer comment on #5096.

## Release note (for maintainers)

**Fixed:** Session truncate (including rewind from edit/regenerate) aligns persisted `context_messages` with the kept transcript prefix, including compaction-only leading context rows; cached session agents are evicted after truncate.

## Model Used

- Provider: custom (llm-proxy) / Hermes developer profile
- Model: `x-ai/grok-composer-2.5-fast`
- AI disclosure: AI assisted implementation, tests, and this PR description.

Co-authored-by: b3nw <b3nw@users.noreply.github.com>