### PR TITLE
fix(#5139): distinguish offline gateway approval warnings

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -7463,6 +7463,10 @@ def get_gateway_caps(base_url: str, api_key: str = "") -> dict:
             features = {}
         caps["approval_events"] = bool(features.get("approval_events"))
         caps["run_approval_response"] = bool(features.get("run_approval_response"))
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            caps["capabilities_reachable"] = True
+        caps["probe_error"] = f"{type(exc).__name__}: {exc}"
     except Exception as exc:
         caps["probe_error"] = f"{type(exc).__name__}: {exc}"
     with _GATEWAY_CAPS_LOCK:

--- a/api/config.py
+++ b/api/config.py
@@ -7443,7 +7443,13 @@ def get_gateway_caps(base_url: str, api_key: str = "") -> dict:
         cached = _GATEWAY_CAPS_CACHE.get(cache_key)
         if cached and now - cached.get("fetched_at", 0) < _GATEWAY_CAPS_TTL_S:
             return cached
-    caps = {"approval_events": False, "run_approval_response": False, "fetched_at": 0.0}
+    caps = {
+        "approval_events": False,
+        "run_approval_response": False,
+        "capabilities_reachable": False,
+        "probe_error": None,
+        "fetched_at": 0.0,
+    }
     try:
         headers = {}
         if api_key:
@@ -7451,13 +7457,14 @@ def get_gateway_caps(base_url: str, api_key: str = "") -> dict:
         req = urllib.request.Request(f"{base_url}/v1/capabilities", headers=headers, method="GET")
         with urllib.request.urlopen(req, timeout=3) as resp:
             body = json.loads(resp.read(65536))
+        caps["capabilities_reachable"] = True
         features = body.get("features") if isinstance(body, dict) else {}
         if not isinstance(features, dict):
             features = {}
         caps["approval_events"] = bool(features.get("approval_events"))
         caps["run_approval_response"] = bool(features.get("run_approval_response"))
-    except Exception:
-        pass
+    except Exception as exc:
+        caps["probe_error"] = f"{type(exc).__name__}: {exc}"
     with _GATEWAY_CAPS_LOCK:
         current = _GATEWAY_CAPS_CACHE.get(cache_key)
         if current and current.get("fetched_at", 0) > probe_started_at:
@@ -7465,6 +7472,16 @@ def get_gateway_caps(base_url: str, api_key: str = "") -> dict:
         caps["fetched_at"] = time.time()
         _GATEWAY_CAPS_CACHE[cache_key] = caps
     return caps
+
+
+def gateway_approval_unavailable_reason(base_url: str, api_key: str = "") -> str | None:
+    """Return why approval support is unavailable, if it is unavailable."""
+    caps = get_gateway_caps(base_url, api_key)
+    if bool(caps.get("approval_events") and caps.get("run_approval_response")):
+        return None
+    if not caps.get("capabilities_reachable"):
+        return "unreachable"
+    return "unsupported"
 
 
 def gateway_supports_approval(base_url: str, api_key: str = "") -> bool:

--- a/api/config.py
+++ b/api/config.py
@@ -17,6 +17,7 @@ import logging
 import os
 import queue
 import re
+import socket
 import sys
 import threading
 import time
@@ -7433,6 +7434,15 @@ _GATEWAY_CAPS_LOCK = threading.Lock()
 _GATEWAY_CAPS_TTL_S: float = 60.0
 
 
+def _gateway_caps_probe_timed_out(exc: BaseException) -> bool:
+    """Keep slow capability probes on the legacy reachable-but-unsupported path."""
+    reason = exc.reason if isinstance(exc, urllib.error.URLError) else exc
+    if isinstance(reason, (TimeoutError, socket.timeout)):
+        return True
+    reason_text = str(reason).lower()
+    return "timed out" in reason_text or "timeout" in reason_text
+
+
 def get_gateway_caps(base_url: str, api_key: str = "") -> dict:
     """Return cached gateway capability flags, probing /v1/capabilities if stale."""
     base_url = str(base_url or "").rstrip("/")
@@ -7456,16 +7466,24 @@ def get_gateway_caps(base_url: str, api_key: str = "") -> dict:
             headers["Authorization"] = f"Bearer {api_key}"
         req = urllib.request.Request(f"{base_url}/v1/capabilities", headers=headers, method="GET")
         with urllib.request.urlopen(req, timeout=3) as resp:
+            caps["capabilities_reachable"] = True
             body = json.loads(resp.read(65536))
-        caps["capabilities_reachable"] = True
         features = body.get("features") if isinstance(body, dict) else {}
         if not isinstance(features, dict):
             features = {}
         caps["approval_events"] = bool(features.get("approval_events"))
         caps["run_approval_response"] = bool(features.get("run_approval_response"))
     except urllib.error.HTTPError as exc:
-        if exc.code == 404:
+        caps["capabilities_reachable"] = True
+        caps["probe_error"] = f"{type(exc).__name__}: {exc}"
+    except urllib.error.URLError as exc:
+        if _gateway_caps_probe_timed_out(exc):
             caps["capabilities_reachable"] = True
+        caps["probe_error"] = f"{type(exc).__name__}: {exc}"
+    except (TimeoutError, socket.timeout) as exc:
+        caps["capabilities_reachable"] = True
+        caps["probe_error"] = f"{type(exc).__name__}: {exc}"
+    except OSError as exc:
         caps["probe_error"] = f"{type(exc).__name__}: {exc}"
     except Exception as exc:
         caps["probe_error"] = f"{type(exc).__name__}: {exc}"

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -639,8 +639,8 @@ def _run_gateway_chat_streaming(
         else:
             # Legacy gateway path: emit unsupported approval notice once per session,
             # but only when the gateway genuinely lacks approval capability.
-            if not gateway_supports_approval(base_url, api_key):
-                approval_reason = gateway_approval_unavailable_reason(base_url, api_key)
+            approval_reason = gateway_approval_unavailable_reason(base_url, api_key)
+            if approval_reason is not None:
                 if not hasattr(s, "_approval_notice_emitted"):
                     s._approval_notice_emitted = False
                 if not s._approval_notice_emitted:

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -20,6 +20,7 @@ from api.config import (
     STREAM_REASONING_TEXT,
     _get_session_agent_lock,
     coerce_reasoning_effort_for_model,
+    gateway_approval_unavailable_reason,
     gateway_supports_approval,
     register_active_run,
     unregister_active_run,
@@ -639,12 +640,18 @@ def _run_gateway_chat_streaming(
             # Legacy gateway path: emit unsupported approval notice once per session,
             # but only when the gateway genuinely lacks approval capability.
             if not gateway_supports_approval(base_url, api_key):
+                approval_reason = gateway_approval_unavailable_reason(base_url, api_key)
                 if not hasattr(s, "_approval_notice_emitted"):
                     s._approval_notice_emitted = False
                 if not s._approval_notice_emitted:
+                    approval_message = "Approvals require a newer gateway. Upgrade the connected Hermes gateway to enable this."
+                    approval_type = "approval_gateway_unsupported"
+                    if approval_reason == "unreachable":
+                        approval_type = "approval_gateway_offline"
+                        approval_message = "Gateway connection failed. Check that the connected Hermes gateway is running and reachable."
                     put_gateway_event("warning", {
-                        "type": "approval_gateway_unsupported",
-                        "message": "Approvals require a newer gateway. Upgrade the connected Hermes gateway to enable this.",
+                        "type": approval_type,
+                        "message": approval_message,
                     })
                     s._approval_notice_emitted = True
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -5447,6 +5447,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           if(typeof showToast==='function') showToast(typeof t==='function'?t('approval_gateway_unsupported_label'):'Approvals not supported',4000,'warning');
           return;
         }
+        if(d.type==='approval_gateway_offline'){
+          if(typeof showToast==='function') showToast(d.message||'Gateway offline',4000,'warning');
+          return;
+        }
         // Show as a small inline notice, not a full error
         setComposerStatus(`${d.message||'Warning'}`);
         // If it's a fallback notice, show it briefly then clear

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -92,6 +92,31 @@ def test_gateway_capability_detection_marks_probe_failures_unreachable():
     invalidate_gateway_caps()
 
 
+def test_gateway_capability_detection_treats_404_probe_as_reachable_unsupported():
+    """Older reachable gateways can 404 /v1/capabilities without becoming "offline"."""
+    from api.config import (
+        gateway_approval_unavailable_reason,
+        gateway_supports_approval,
+        get_gateway_caps,
+        invalidate_gateway_caps,
+    )
+
+    invalidate_gateway_caps()
+
+    def _fake_urlopen_404(req, *, timeout=None):
+        assert req.full_url == "http://fake:7777/v1/capabilities"
+        raise urllib.error.HTTPError(req.full_url, 404, "Not Found", hdrs=None, fp=io.BytesIO(b""))
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen_404):
+        caps = get_gateway_caps("http://fake:7777", "secret")
+        assert caps["capabilities_reachable"] is True
+        assert caps["probe_error"]
+        assert gateway_approval_unavailable_reason("http://fake:7777", "secret") == "unsupported"
+        assert gateway_supports_approval("http://fake:7777", "secret") is False
+
+    invalidate_gateway_caps()
+
+
 def test_gateway_capability_cache_keeps_fresher_success_on_probe_race():
     """A slower failed probe must not overwrite a fresher successful capability result."""
     from api.config import gateway_supports_approval, invalidate_gateway_caps

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -15,7 +15,9 @@ from unittest.mock import MagicMock, patch
 def test_gateway_capability_detection():
     """get_gateway_caps / gateway_supports_approval correctly parse /v1/capabilities."""
     from api.config import (
+        gateway_approval_unavailable_reason,
         gateway_supports_approval,
+        get_gateway_caps,
         invalidate_gateway_caps,
     )
 
@@ -38,6 +40,10 @@ def test_gateway_capability_detection():
         return resp
 
     with patch("urllib.request.urlopen", side_effect=_fake_urlopen_capable):
+        caps = get_gateway_caps("http://fake:1234", "secret")
+        assert caps["capabilities_reachable"] is True
+        assert caps["probe_error"] is None
+        assert gateway_approval_unavailable_reason("http://fake:1234", "secret") is None
         assert gateway_supports_approval("http://fake:1234", "secret") is True
 
     invalidate_gateway_caps()
@@ -52,7 +58,36 @@ def test_gateway_capability_detection():
         return resp
 
     with patch("urllib.request.urlopen", side_effect=_fake_urlopen_incapable):
+        caps = get_gateway_caps("http://fake:5678")
+        assert caps["capabilities_reachable"] is True
+        assert caps["probe_error"] is None
+        assert gateway_approval_unavailable_reason("http://fake:5678") == "unsupported"
         assert gateway_supports_approval("http://fake:5678") is False
+
+    invalidate_gateway_caps()
+
+
+def test_gateway_capability_detection_marks_probe_failures_unreachable():
+    """Probe failures stay non-fatal but remain distinguishable from unsupported gateways."""
+    from api.config import (
+        gateway_approval_unavailable_reason,
+        gateway_supports_approval,
+        get_gateway_caps,
+        invalidate_gateway_caps,
+    )
+
+    invalidate_gateway_caps()
+
+    def _fake_urlopen_fail(req, *, timeout=None):
+        assert req.full_url == "http://fake:9999/v1/capabilities"
+        raise urllib.error.URLError("gateway unreachable")
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen_fail):
+        caps = get_gateway_caps("http://fake:9999", "secret")
+        assert caps["capabilities_reachable"] is False
+        assert caps["probe_error"]
+        assert gateway_approval_unavailable_reason("http://fake:9999", "secret") == "unreachable"
+        assert gateway_supports_approval("http://fake:9999", "secret") is False
 
     invalidate_gateway_caps()
 

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import io
 import json
+import socket
 import threading
 import urllib.error
 from unittest.mock import MagicMock, patch
@@ -80,7 +81,7 @@ def test_gateway_capability_detection_marks_probe_failures_unreachable():
 
     def _fake_urlopen_fail(req, *, timeout=None):
         assert req.full_url == "http://fake:9999/v1/capabilities"
-        raise urllib.error.URLError("gateway unreachable")
+        raise urllib.error.URLError(ConnectionRefusedError("connection refused"))
 
     with patch("urllib.request.urlopen", side_effect=_fake_urlopen_fail):
         caps = get_gateway_caps("http://fake:9999", "secret")
@@ -88,6 +89,31 @@ def test_gateway_capability_detection_marks_probe_failures_unreachable():
         assert caps["probe_error"]
         assert gateway_approval_unavailable_reason("http://fake:9999", "secret") == "unreachable"
         assert gateway_supports_approval("http://fake:9999", "secret") is False
+
+    invalidate_gateway_caps()
+
+
+def test_gateway_capability_detection_treats_timeout_probe_as_reachable_unsupported():
+    """Slow probes should preserve the reachable-but-unsupported warning contract."""
+    from api.config import (
+        gateway_approval_unavailable_reason,
+        gateway_supports_approval,
+        get_gateway_caps,
+        invalidate_gateway_caps,
+    )
+
+    invalidate_gateway_caps()
+
+    def _fake_urlopen_timeout(req, *, timeout=None):
+        assert req.full_url == "http://fake:8888/v1/capabilities"
+        raise socket.timeout("timed out")
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen_timeout):
+        caps = get_gateway_caps("http://fake:8888", "secret")
+        assert caps["capabilities_reachable"] is True
+        assert caps["probe_error"]
+        assert gateway_approval_unavailable_reason("http://fake:8888", "secret") == "unsupported"
+        assert gateway_supports_approval("http://fake:8888", "secret") is False
 
     invalidate_gateway_caps()
 

--- a/tests/test_issue4300_gateway_approval_notice.py
+++ b/tests/test_issue4300_gateway_approval_notice.py
@@ -22,12 +22,13 @@ def test_gateway_chat_emits_approval_gateway_unsupported_event():
 
 def test_gateway_chat_once_per_session_guard_pattern():
     """Verify the once-per-session guard: capability check + hasattr + flag check + flag set."""
-    assert "if not gateway_supports_approval(base_url, api_key):" in GATEWAY_CHAT
+    assert "approval_reason = gateway_approval_unavailable_reason(base_url, api_key)" in GATEWAY_CHAT
+    assert "if approval_reason is not None:" in GATEWAY_CHAT
     assert "if not hasattr(s, \"_approval_notice_emitted\"):" in GATEWAY_CHAT
     assert "if not s._approval_notice_emitted:" in GATEWAY_CHAT
     assert "s._approval_notice_emitted = True" in GATEWAY_CHAT
     # Verify order: capability gate before session guard before flag set
-    cap_pos = GATEWAY_CHAT.find("if not gateway_supports_approval(base_url, api_key):")
+    cap_pos = GATEWAY_CHAT.find("if approval_reason is not None:")
     hasattr_pos = GATEWAY_CHAT.find("if not hasattr(s, \"_approval_notice_emitted\"):")
     flag_check_pos = GATEWAY_CHAT.find("if not s._approval_notice_emitted:")
     flag_set_pos = GATEWAY_CHAT.find("s._approval_notice_emitted = True")

--- a/tests/test_issue4300_gateway_approval_notice.py
+++ b/tests/test_issue4300_gateway_approval_notice.py
@@ -17,7 +17,7 @@ def test_gateway_chat_has_approval_notice_emitted_attribute_check():
 def test_gateway_chat_emits_approval_gateway_unsupported_event():
     """Verify put_gateway_event is called with approval_gateway_unsupported type on non-terminal channel."""
     assert "put_gateway_event(\"warning\"" in GATEWAY_CHAT
-    assert "\"type\": \"approval_gateway_unsupported\"" in GATEWAY_CHAT
+    assert "approval_type = \"approval_gateway_unsupported\"" in GATEWAY_CHAT
 
 
 def test_gateway_chat_once_per_session_guard_pattern():
@@ -36,8 +36,8 @@ def test_gateway_chat_once_per_session_guard_pattern():
 
 def test_gateway_chat_event_payload_contains_type_and_message():
     """Verify the event payload has type and message fields."""
-    assert "\"type\": \"approval_gateway_unsupported\"" in GATEWAY_CHAT
-    assert "\"message\": \"Approvals require a newer gateway. Upgrade the connected Hermes gateway to enable this.\"" in GATEWAY_CHAT
+    assert "approval_type = \"approval_gateway_unsupported\"" in GATEWAY_CHAT
+    assert "approval_message = \"Approvals require a newer gateway. Upgrade the connected Hermes gateway to enable this.\"" in GATEWAY_CHAT
 
 
 def test_messages_js_handles_approval_gateway_unsupported_event():

--- a/tests/test_issue5139_gateway_approval_offline_notice.py
+++ b/tests/test_issue5139_gateway_approval_offline_notice.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import io
 import json
+import urllib.error
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -90,6 +92,72 @@ def test_gateway_chat_emits_offline_warning_for_unreachable_probe():
 
 def test_gateway_chat_keeps_unsupported_warning_for_reachable_older_gateway():
     events = _run_gateway_warning_case("unsupported")
+    warnings = [item for item in events if isinstance(item, tuple) and item[0] == "warning"]
+    assert warnings
+    assert warnings[0][1]["type"] == "approval_gateway_unsupported"
+    assert warnings[0][1]["message"] == "Approvals require a newer gateway. Upgrade the connected Hermes gateway to enable this."
+    assert any(isinstance(item, tuple) and item[0] == "done" for item in events)
+    assert not any(
+        isinstance(item, tuple) and item[0] == "warning" and item[1].get("type") == "approval_gateway_offline"
+        for item in events
+    )
+
+
+def test_gateway_chat_keeps_unsupported_warning_for_404_capabilities_probe():
+    events = []
+    q = MagicMock()
+    q.put_nowait = lambda item: events.append(item)
+
+    stream_id = "sid-http-404"
+    with STREAMS_LOCK:
+        STREAMS[stream_id] = q
+
+    mock_session = MagicMock()
+    mock_session.active_stream_id = stream_id
+    mock_session.workspace = "/tmp"
+    mock_session.model = "test"
+    mock_session.model_provider = None
+    mock_session.profile = None
+    mock_session.context_messages = []
+    mock_session.messages = []
+    mock_session.pending_user_message = None
+    mock_session.pending_attachments = None
+    mock_session.pending_started_at = None
+    mock_session._approval_notice_emitted = False
+
+    def fake_urlopen(req, *, timeout=None):
+        if req.full_url == "http://127.0.0.1:8642/v1/capabilities":
+            raise urllib.error.HTTPError(req.full_url, 404, "Not Found", hdrs=None, fp=io.BytesIO(b""))
+        assert req.full_url == "http://127.0.0.1:8642/v1/chat/completions"
+        resp = MagicMock()
+        resp.__iter__ = lambda s: iter(
+            [
+                b'data: {"choices":[{"delta":{"content":"Done"}}]}\n',
+                b"\n",
+                b"data: [DONE]\n",
+            ]
+        )
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        return resp
+
+    try:
+        with patch.dict("os.environ", {"HERMES_WEBUI_CHAT_BACKEND": "gateway"}):
+            with patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+                 patch("api.gateway_chat.get_session", return_value=mock_session), \
+                 patch("api.gateway_chat._stream_writeback_is_current", return_value=True), \
+                 patch("api.gateway_chat.merge_session_messages_append_only", return_value=[]):
+                _run_gateway_chat_streaming(
+                    session_id="sess-404",
+                    msg_text="hi",
+                    model="test-model",
+                    workspace="/tmp",
+                    stream_id=stream_id,
+                )
+    finally:
+        with STREAMS_LOCK:
+            STREAMS.pop(stream_id, None)
+
     warnings = [item for item in events if isinstance(item, tuple) and item[0] == "warning"]
     assert warnings
     assert warnings[0][1]["type"] == "approval_gateway_unsupported"

--- a/tests/test_issue5139_gateway_approval_offline_notice.py
+++ b/tests/test_issue5139_gateway_approval_offline_notice.py
@@ -8,7 +8,7 @@ import urllib.error
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from api.config import STREAMS, STREAMS_LOCK
+from api.config import STREAMS, STREAMS_LOCK, invalidate_gateway_caps
 from api.gateway_chat import _run_gateway_chat_streaming
 
 REPO = Path(__file__).resolve().parents[1]
@@ -141,6 +141,8 @@ def test_gateway_chat_keeps_unsupported_warning_for_404_capabilities_probe():
         resp.__exit__ = lambda s, *a: None
         return resp
 
+    invalidate_gateway_caps()
+
     try:
         with patch.dict("os.environ", {"HERMES_WEBUI_CHAT_BACKEND": "gateway"}):
             with patch("urllib.request.urlopen", side_effect=fake_urlopen), \
@@ -157,6 +159,7 @@ def test_gateway_chat_keeps_unsupported_warning_for_404_capabilities_probe():
     finally:
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)
+        invalidate_gateway_caps()
 
     warnings = [item for item in events if isinstance(item, tuple) and item[0] == "warning"]
     assert warnings

--- a/tests/test_issue5139_gateway_approval_offline_notice.py
+++ b/tests/test_issue5139_gateway_approval_offline_notice.py
@@ -1,0 +1,115 @@
+"""Regression coverage for #5139 gateway approval offline notice."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from api.config import STREAMS, STREAMS_LOCK
+from api.gateway_chat import _run_gateway_chat_streaming
+
+REPO = Path(__file__).resolve().parents[1]
+GATEWAY_CHAT = (REPO / "api" / "gateway_chat.py").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+
+
+def _run_gateway_warning_case(unavailable_reason: str) -> list:
+    events = []
+    q = MagicMock()
+    q.put_nowait = lambda item: events.append(item)
+
+    stream_id = f"sid-{unavailable_reason}"
+    with STREAMS_LOCK:
+        STREAMS[stream_id] = q
+
+    mock_session = MagicMock()
+    mock_session.active_stream_id = stream_id
+    mock_session.workspace = "/tmp"
+    mock_session.model = "test"
+    mock_session.model_provider = None
+    mock_session.profile = None
+    mock_session.context_messages = []
+    mock_session.messages = []
+    mock_session.pending_user_message = None
+    mock_session.pending_attachments = None
+    mock_session.pending_started_at = None
+    mock_session._approval_notice_emitted = False
+
+    def fake_urlopen(req, *, timeout=None):
+        assert req.full_url == "http://127.0.0.1:8642/v1/chat/completions"
+        assert req.get_method() == "POST"
+        payload = req.data.decode("utf-8")
+        assert json.loads(payload)["messages"][-1]["content"] == "hi"
+        resp = MagicMock()
+        resp.__iter__ = lambda s: iter(
+            [
+                b'data: {"choices":[{"delta":{"content":"Done"}}]}\n',
+                b"\n",
+                b"data: [DONE]\n",
+            ]
+        )
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        return resp
+
+    try:
+        with patch.dict("os.environ", {"HERMES_WEBUI_CHAT_BACKEND": "gateway"}):
+            with patch("api.gateway_chat.gateway_supports_approval", return_value=False), \
+                 patch("api.gateway_chat.gateway_approval_unavailable_reason", return_value=unavailable_reason), \
+                 patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+                 patch("api.gateway_chat.get_session", return_value=mock_session), \
+                 patch("api.gateway_chat._stream_writeback_is_current", return_value=True), \
+                 patch("api.gateway_chat.merge_session_messages_append_only", return_value=[]):
+                _run_gateway_chat_streaming(
+                    session_id="sess-warning",
+                    msg_text="hi",
+                    model="test-model",
+                    workspace="/tmp",
+                    stream_id=stream_id,
+                )
+    finally:
+        with STREAMS_LOCK:
+            STREAMS.pop(stream_id, None)
+
+    return events
+
+
+def test_gateway_chat_emits_offline_warning_for_unreachable_probe():
+    events = _run_gateway_warning_case("unreachable")
+    warnings = [item for item in events if isinstance(item, tuple) and item[0] == "warning"]
+    assert warnings
+    assert warnings[0][1]["type"] == "approval_gateway_offline"
+    assert warnings[0][1]["message"] == "Gateway connection failed. Check that the connected Hermes gateway is running and reachable."
+    assert any(isinstance(item, tuple) and item[0] == "done" for item in events)
+    assert not any(
+        isinstance(item, tuple) and item[0] == "warning" and item[1].get("type") == "approval_gateway_unsupported"
+        for item in events
+    )
+
+
+def test_gateway_chat_keeps_unsupported_warning_for_reachable_older_gateway():
+    events = _run_gateway_warning_case("unsupported")
+    warnings = [item for item in events if isinstance(item, tuple) and item[0] == "warning"]
+    assert warnings
+    assert warnings[0][1]["type"] == "approval_gateway_unsupported"
+    assert warnings[0][1]["message"] == "Approvals require a newer gateway. Upgrade the connected Hermes gateway to enable this."
+    assert any(isinstance(item, tuple) and item[0] == "done" for item in events)
+    assert not any(
+        isinstance(item, tuple) and item[0] == "warning" and item[1].get("type") == "approval_gateway_offline"
+        for item in events
+    )
+
+
+def test_messages_js_handles_offline_warning_without_touching_unsupported_branch():
+    assert "d.type==='approval_gateway_offline'" in MESSAGES_JS
+    assert "Gateway offline" in MESSAGES_JS
+    assert "d.type==='approval_gateway_unsupported'" in MESSAGES_JS
+    assert "Approvals not supported" in MESSAGES_JS
+    assert "setComposerStatus(`${d.message||'Warning'}`);" in MESSAGES_JS
+
+
+def test_gateway_chat_source_mentions_offline_warning_type():
+    assert "approval_type = \"approval_gateway_offline\"" in GATEWAY_CHAT
+    assert "approval_type = \"approval_gateway_unsupported\"" in GATEWAY_CHAT
+    assert "approval_message = \"Gateway connection failed. Check that the connected Hermes gateway is running and reachable.\"" in GATEWAY_CHAT

--- a/tests/test_issue5139_gateway_approval_offline_notice.py
+++ b/tests/test_issue5139_gateway_approval_offline_notice.py
@@ -172,6 +172,75 @@ def test_gateway_chat_keeps_unsupported_warning_for_404_capabilities_probe():
     )
 
 
+def test_gateway_chat_keeps_unsupported_warning_for_timeout_capabilities_probe():
+    events = []
+    q = MagicMock()
+    q.put_nowait = lambda item: events.append(item)
+
+    stream_id = "sid-timeout"
+    with STREAMS_LOCK:
+        STREAMS[stream_id] = q
+
+    mock_session = MagicMock()
+    mock_session.active_stream_id = stream_id
+    mock_session.workspace = "/tmp"
+    mock_session.model = "test"
+    mock_session.model_provider = None
+    mock_session.profile = None
+    mock_session.context_messages = []
+    mock_session.messages = []
+    mock_session.pending_user_message = None
+    mock_session.pending_attachments = None
+    mock_session.pending_started_at = None
+    mock_session._approval_notice_emitted = False
+
+    def fake_urlopen(req, *, timeout=None):
+        if req.full_url == "http://127.0.0.1:8642/v1/capabilities":
+            raise TimeoutError("timed out")
+        assert req.full_url == "http://127.0.0.1:8642/v1/chat/completions"
+        resp = MagicMock()
+        resp.__iter__ = lambda s: iter(
+            [
+                b'data: {"choices":[{"delta":{"content":"Done"}}]}\n',
+                b"\n",
+                b"data: [DONE]\n",
+            ]
+        )
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        return resp
+
+    invalidate_gateway_caps()
+
+    try:
+        with patch.dict("os.environ", {"HERMES_WEBUI_CHAT_BACKEND": "gateway"}):
+            with patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+                 patch("api.gateway_chat.get_session", return_value=mock_session), \
+                 patch("api.gateway_chat._stream_writeback_is_current", return_value=True), \
+                 patch("api.gateway_chat.merge_session_messages_append_only", return_value=[]):
+                _run_gateway_chat_streaming(
+                    session_id="sess-timeout",
+                    msg_text="hi",
+                    model="test-model",
+                    workspace="/tmp",
+                    stream_id=stream_id,
+                )
+    finally:
+        with STREAMS_LOCK:
+            STREAMS.pop(stream_id, None)
+        invalidate_gateway_caps()
+
+    warnings = [item for item in events if isinstance(item, tuple) and item[0] == "warning"]
+    assert warnings
+    assert warnings[0][1]["type"] == "approval_gateway_unsupported"
+    assert warnings[0][1]["message"] == "Approvals require a newer gateway. Upgrade the connected Hermes gateway to enable this."
+    assert any(isinstance(item, tuple) and item[0] == "done" for item in events)
+    assert not any(
+        isinstance(item, tuple) and item[0] == "warning" and item[1].get("type") == "approval_gateway_offline"
+        for item in events
+    )
+
+
 def test_messages_js_handles_offline_warning_without_touching_unsupported_branch():
     assert "d.type==='approval_gateway_offline'" in MESSAGES_JS
     assert "Gateway offline" in MESSAGES_JS


### PR DESCRIPTION
## Thinking Path

- The unsupported approval notice added by #4456 is still correct for reachable gateways that genuinely lack approval support.
- The current capability probe collapses connection failures into that same false result, so the legacy gateway path cannot tell an older gateway from an unreachable one.
- The fix keeps the distinction in the shared capability probe, adds one offline warning type on the legacy path, and leaves the existing unsupported contract intact for reachable feature-negative gateways.

## What Changed

- `api/config.py`: extend the cached capability result with probe metadata and add one shared helper that distinguishes reachable unsupported gateways from unreachable probes, while preserving `gateway_supports_approval()` as the boolean API.
- `api/gateway_chat.py`: emit `approval_gateway_offline` only when the capability probe failed, and keep `approval_gateway_unsupported` unchanged for reachable feature-negative gateways.
- `static/messages.js`: add a narrow dedicated branch for `approval_gateway_offline` that shows the backend payload message in a warning toast.
- `tests/test_gateway_approval_runs_api.py`: add focused capability distinction coverage.
- `tests/test_issue4300_gateway_approval_notice.py`: keep the existing unsupported warning contract pinned.
- `tests/test_issue5139_gateway_approval_offline_notice.py`: add regression coverage for the offline warning path and the adjacent reachable-unsupported case.

## Why It Matters

Users should not be told to upgrade a gateway when WebUI could not reach the gateway at all. This keeps the existing upgrade warning for older reachable gateways and makes the offline case actionable without widening the fix into a broader gateway-health UI change.

## Verification

```text
pytest tests/test_gateway_approval_runs_api.py -v --timeout=60
pytest tests/test_issue4300_gateway_approval_notice.py tests/test_issue5139_gateway_approval_offline_notice.py -v --timeout=60
npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/messages.js"
```

Full-suite CI context: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5139.

Related prior work: #4456 introduced the unsupported approval notice this fix preserves, and #4551 kept legacy approval events flowing on the same gateway path.

## Model Used

GPT 5.5 via Codex CLI
