### PR TITLE
fix: route moa webui turns through gateway

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -19209,18 +19209,24 @@ def _handle_chat_start(handler, body, diag=None):
             if "model_provider" in body
             else getattr(s, "model_provider", None)
         )
-        _pp_provider, _pp_default = _read_profile_model_config(s, requested_provider)
         explicit_model_pick = bool(body.get("explicit_model_pick"))
         moa_config = None
         if body.get("moa_config"):
-            if webui_gateway_chat_enabled(get_config()):
-                return bad(handler, "MoA override is unavailable on gateway-backed sessions", 409)
             from api.commands import resolve_moa_config
 
             try:
                 moa_config = resolve_moa_config()
             except RuntimeError as e:
                 return bad(handler, str(e), 503)
+            if webui_gateway_chat_enabled(get_config()):
+                requested_model = str(
+                    moa_config.get("preset") or moa_config.get("default_preset") or ""
+                ).strip()
+                if not requested_model:
+                    return bad(handler, "MoA preset is not configured", 503)
+                requested_provider = "moa"
+                explicit_model_pick = True
+        _pp_provider, _pp_default = _read_profile_model_config(s, requested_provider)
         diag.stage("resolve_model_provider") if diag else None
         model, model_provider, normalized_model = _resolve_compatible_session_model_state(
             requested_model,

--- a/api/routes.py
+++ b/api/routes.py
@@ -19211,6 +19211,7 @@ def _handle_chat_start(handler, body, diag=None):
         )
         explicit_model_pick = bool(body.get("explicit_model_pick"))
         moa_config = None
+        gateway_chat_enabled = webui_gateway_chat_enabled(get_config())
         if body.get("moa_config"):
             from api.commands import resolve_moa_config
 
@@ -19218,7 +19219,7 @@ def _handle_chat_start(handler, body, diag=None):
                 moa_config = resolve_moa_config()
             except RuntimeError as e:
                 return bad(handler, str(e), 503)
-            if webui_gateway_chat_enabled(get_config()):
+            if gateway_chat_enabled:
                 requested_model = str(
                     moa_config.get("preset") or moa_config.get("default_preset") or ""
                 ).strip()
@@ -19239,18 +19240,22 @@ def _handle_chat_start(handler, body, diag=None):
         # with start_session_turn so both entry points behave identically
         # under runtime_adapter_enabled() / runtime_adapter_runner_enabled()
         # — Q-2979-A2 / Copilot discussion_r3305864087/r3305864173).
+        start_run_kwargs = {
+            "msg": msg,
+            "attachments": attachments,
+            "workspace": workspace,
+            "model": model,
+            "model_provider": model_provider,
+            "normalized_model": normalized_model,
+            "source": "webui",
+            "route": "/api/chat/start",
+            "diag": diag,
+        }
+        if not gateway_chat_enabled and moa_config is not None:
+            start_run_kwargs["moa_config"] = moa_config
         response = _start_run(
             s,
-            msg=msg,
-            attachments=attachments,
-            workspace=workspace,
-            model=model,
-            model_provider=model_provider,
-            normalized_model=normalized_model,
-            source="webui",
-            route="/api/chat/start",
-            diag=diag,
-            moa_config=moa_config,
+            **start_run_kwargs,
         )
         # Map adapter-selection NotImplementedError (501) onto the legacy
         # bad-request response shape that this route exposed historically

--- a/api/routes.py
+++ b/api/routes.py
@@ -19213,20 +19213,14 @@ def _handle_chat_start(handler, body, diag=None):
         moa_config = None
         gateway_chat_enabled = webui_gateway_chat_enabled(get_config())
         if body.get("moa_config"):
+            if gateway_chat_enabled:
+                return bad(handler, "MoA override is unavailable on gateway-backed sessions", 409)
             from api.commands import resolve_moa_config
 
             try:
                 moa_config = resolve_moa_config()
             except RuntimeError as e:
                 return bad(handler, str(e), 503)
-            if gateway_chat_enabled:
-                requested_model = str(
-                    moa_config.get("preset") or moa_config.get("default_preset") or ""
-                ).strip()
-                if not requested_model:
-                    return bad(handler, "MoA preset is not configured", 503)
-                requested_provider = "moa"
-                explicit_model_pick = True
         _pp_provider, _pp_default = _read_profile_model_config(s, requested_provider)
         diag.stage("resolve_model_provider") if diag else None
         model, model_provider, normalized_model = _resolve_compatible_session_model_state(

--- a/tests/test_issue5057_moa_webui_route.py
+++ b/tests/test_issue5057_moa_webui_route.py
@@ -122,16 +122,15 @@ def test_moa_config_is_per_turn_not_persisted():
     routes_source = routes_path.read_text(encoding="utf-8")
     assert re.search(r"if body\.get\(\"moa_config\"\):[\s\S]*?moa_config = resolve_moa_config\(\)", routes_source), \
         "chat-start must re-resolve MoA config server-side instead of trusting the browser payload"
-    assert "MoA override is unavailable on gateway-backed sessions" not in routes_source
-    assert 'requested_provider = "moa"' in routes_source
+    assert "MoA override is unavailable on gateway-backed sessions" in routes_source
     js_path = Path(__file__).resolve().parent.parent / "static" / "messages.js"
     js_source = js_path.read_text(encoding="utf-8")
     assert "moa_config:_pendingMoaConfig?true:undefined" in js_source
     assert "_pendingMoaConfig=null" in js_source
 
 
-def test_moa_gateway_chat_start_routes_to_moa_provider(monkeypatch, tmp_path):
-    """Gateway-backed WebUI sessions should send /moa as provider=moa + preset model."""
+def test_moa_gateway_chat_start_fails_closed(monkeypatch, tmp_path):
+    """Gateway-backed WebUI sessions must reject /moa until the gateway consumes runtime overrides."""
     import api.commands as commands
     import api.routes as routes
 
@@ -162,25 +161,18 @@ def test_moa_gateway_chat_start_routes_to_moa_provider(monkeypatch, tmp_path):
         context_messages = []
         pending_user_message = None
 
-    captured = {}
+    def start_run(*_args, **_kwargs):  # pragma: no cover - should fail before run start
+        raise AssertionError("gateway-backed /moa must fail closed before starting a run")
 
-    def start_run(session, **kwargs):
-        captured["session"] = session
-        captured["kwargs"] = kwargs
-        return {"stream_id": "stream-moa", "session_id": session.session_id}
-
-    def resolve_model(model, provider, **_kwargs):
-        captured["resolve_model"] = (model, provider)
-        return model, provider, False
+    def resolve_moa_config():  # pragma: no cover - should fail before resolving MoA
+        raise AssertionError("gateway-backed /moa must fail before resolving MoA config")
 
     monkeypatch.setattr(routes, "get_session", lambda _sid: _Session())
     monkeypatch.setattr(routes, "_resolve_chat_workspace_with_recovery", lambda _s, _w: str(tmp_path))
-    monkeypatch.setattr(routes, "_read_profile_model_config", lambda _s, _provider: (None, None))
-    monkeypatch.setattr(routes, "_resolve_compatible_session_model_state", resolve_model)
     monkeypatch.setattr(routes, "_start_run", start_run)
     monkeypatch.setattr(routes, "get_config", lambda: {"chat_backend": "gateway"})
     monkeypatch.setattr(routes, "webui_gateway_chat_enabled", lambda _cfg: True)
-    monkeypatch.setattr(commands, "resolve_moa_config", lambda: {"preset": "moa-fast", "default_preset": "moa-fast"})
+    monkeypatch.setattr(commands, "resolve_moa_config", resolve_moa_config)
 
     handler = _Handler()
     routes._handle_chat_start(
@@ -194,9 +186,5 @@ def test_moa_gateway_chat_start_routes_to_moa_provider(monkeypatch, tmp_path):
     )
 
     body = json.loads(handler.wfile.getvalue().decode("utf-8"))
-    assert handler.status == 200
-    assert body["stream_id"] == "stream-moa"
-    assert captured["resolve_model"] == ("moa-fast", "moa")
-    assert captured["kwargs"]["model"] == "moa-fast"
-    assert captured["kwargs"]["model_provider"] == "moa"
-    assert "moa_config" not in captured["kwargs"]
+    assert handler.status == 409
+    assert body["error"] == "MoA override is unavailable on gateway-backed sessions"

--- a/tests/test_issue5057_moa_webui_route.py
+++ b/tests/test_issue5057_moa_webui_route.py
@@ -199,3 +199,4 @@ def test_moa_gateway_chat_start_routes_to_moa_provider(monkeypatch, tmp_path):
     assert captured["resolve_model"] == ("moa-fast", "moa")
     assert captured["kwargs"]["model"] == "moa-fast"
     assert captured["kwargs"]["model_provider"] == "moa"
+    assert "moa_config" not in captured["kwargs"]

--- a/tests/test_issue5057_moa_webui_route.py
+++ b/tests/test_issue5057_moa_webui_route.py
@@ -122,8 +122,80 @@ def test_moa_config_is_per_turn_not_persisted():
     routes_source = routes_path.read_text(encoding="utf-8")
     assert re.search(r"if body\.get\(\"moa_config\"\):[\s\S]*?moa_config = resolve_moa_config\(\)", routes_source), \
         "chat-start must re-resolve MoA config server-side instead of trusting the browser payload"
-    assert "MoA override is unavailable on gateway-backed sessions" in routes_source
+    assert "MoA override is unavailable on gateway-backed sessions" not in routes_source
+    assert 'requested_provider = "moa"' in routes_source
     js_path = Path(__file__).resolve().parent.parent / "static" / "messages.js"
     js_source = js_path.read_text(encoding="utf-8")
     assert "moa_config:_pendingMoaConfig?true:undefined" in js_source
     assert "_pendingMoaConfig=null" in js_source
+
+
+def test_moa_gateway_chat_start_routes_to_moa_provider(monkeypatch, tmp_path):
+    """Gateway-backed WebUI sessions should send /moa as provider=moa + preset model."""
+    import api.commands as commands
+    import api.routes as routes
+
+    class _Handler:
+        def __init__(self):
+            import io
+
+            self.status = None
+            self.response_headers = []
+            self.wfile = io.BytesIO()
+
+        def send_response(self, status):
+            self.status = status
+
+        def send_header(self, key, value):
+            self.response_headers.append((key, value))
+
+        def end_headers(self):
+            self.response_headers.append(("__end__", ""))
+
+    class _Session:
+        session_id = "sess-moa-gateway"
+        workspace = str(tmp_path)
+        model = "gpt-5.5"
+        model_provider = "openai-codex"
+        profile = "default"
+        messages = []
+        context_messages = []
+        pending_user_message = None
+
+    captured = {}
+
+    def start_run(session, **kwargs):
+        captured["session"] = session
+        captured["kwargs"] = kwargs
+        return {"stream_id": "stream-moa", "session_id": session.session_id}
+
+    def resolve_model(model, provider, **_kwargs):
+        captured["resolve_model"] = (model, provider)
+        return model, provider, False
+
+    monkeypatch.setattr(routes, "get_session", lambda _sid: _Session())
+    monkeypatch.setattr(routes, "_resolve_chat_workspace_with_recovery", lambda _s, _w: str(tmp_path))
+    monkeypatch.setattr(routes, "_read_profile_model_config", lambda _s, _provider: (None, None))
+    monkeypatch.setattr(routes, "_resolve_compatible_session_model_state", resolve_model)
+    monkeypatch.setattr(routes, "_start_run", start_run)
+    monkeypatch.setattr(routes, "get_config", lambda: {"chat_backend": "gateway"})
+    monkeypatch.setattr(routes, "webui_gateway_chat_enabled", lambda _cfg: True)
+    monkeypatch.setattr(commands, "resolve_moa_config", lambda: {"preset": "moa-fast", "default_preset": "moa-fast"})
+
+    handler = _Handler()
+    routes._handle_chat_start(
+        handler,
+        {
+            "session_id": "sess-moa-gateway",
+            "message": "diagnose issue",
+            "workspace": str(tmp_path),
+            "moa_config": True,
+        },
+    )
+
+    body = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert handler.status == 200
+    assert body["stream_id"] == "stream-moa"
+    assert captured["resolve_model"] == ("moa-fast", "moa")
+    assert captured["kwargs"]["model"] == "moa-fast"
+    assert captured["kwargs"]["model_provider"] == "moa"


### PR DESCRIPTION
## Thinking Path

WebUI already resolves `/moa` server-side and applies it per turn for the local backend, but it deliberately failed closed for gateway-backed sessions. With the gateway API server able to honor per-request `provider`/`model` overrides, WebUI can route `/moa` through `provider=moa` and the resolved preset instead of returning 409.

## What Changed

- Removes the gateway-specific 409 for `/moa` chat start.
- For gateway-backed sessions, resolves the MoA preset server-side and sets the current turn to `model=<preset>`, `model_provider=moa`.
- Keeps the existing local backend behavior: local turns still receive `moa_config` directly as a per-turn override.
- Adds regression coverage that a gateway-backed `/moa` chat start launches with `model_provider="moa"`.

## Why It Matters

Users can use `/moa <prompt>` consistently from the WebUI even when the WebUI is backed by Hermes Gateway/API server. The browser still cannot supply arbitrary MoA config; it only sends a boolean signal and the server resolves the preset.

## Verification

- `./scripts/test.sh tests/test_issue5057_moa_webui_route.py -q` → `8 passed`
- `./scripts/test.sh tests/test_issue5057_moa_webui_route.py tests/test_gateway_approval_legacy_path.py -q` → `25 passed`
- `.venv/bin/ruff check tests/test_issue5057_moa_webui_route.py` → `All checks passed!`
- `.venv/bin/python -m compileall -q api/routes.py tests/test_issue5057_moa_webui_route.py` → exit 0

Lint note: `.venv/bin/ruff check api/routes.py tests/test_issue5057_moa_webui_route.py` still reports pre-existing `api/routes.py` issues outside this diff (e.g. B009/F841/F811/B007 around unrelated sections), so I verified the modified test file and compiled the touched route file.

## Risks / Follow-ups

- Requires the paired Hermes Agent/API server change that honors request-scoped `provider=moa` / `model=<preset>` on gateway-backed requests.
- If the resolved MoA preset is missing, the route returns a 503 instead of starting a malformed gateway turn.

## Contract Routing

Task type: gateway-backed WebUI runtime behavior fix.
Touched areas:
- `api/routes.py`
- `tests/test_issue5057_moa_webui_route.py`
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
Scope boundaries:
- No browser-supplied MoA config.
- No UI/UX layout changes.
- No changelog edit in contributor PR; release-note wording is in this PR body.
Evidence needed before claiming done:
- Regression test for gateway `/moa` route behavior.
- Gateway-adjacent test coverage remains green.

## Model Used

AI-assisted: Hermes Agent using OpenAI Codex `gpt-5.5`, with local file/search/test/GitHub tools.
