### PR TITLE
fix(sidebar): keep hidden archived parents as child references

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1908,10 +1908,20 @@ def _build_session_list_cache_payload(
         1 for s in scoped
         if _is_cli_session_for_settings(s)
     )
-    if sidebar_source == "webui":
-        scoped = [s for s in scoped if not _is_cli_session_for_settings(s)]
-    elif sidebar_source == "cli":
-        scoped = [s for s in scoped if _is_cli_session_for_settings(s)]
+    def _filter_sidebar_source(rows: list[dict]) -> list[dict]:
+        if sidebar_source == "webui":
+            return [s for s in rows if not _is_cli_session_for_settings(s)]
+        if sidebar_source == "cli":
+            return [s for s in rows if _is_cli_session_for_settings(s)]
+        return list(rows)
+
+    scoped = _filter_sidebar_source(scoped)
+    sidebar_reference_sessions: list[dict] = []
+    if not include_archived:
+        sidebar_reference_sessions = _hidden_archived_sidebar_reference_sessions(
+            _filter_sidebar_source(visible_scoped),
+            _filter_sidebar_source(archived_scoped),
+        )
     if not include_archived:
         diag_stage("filter_archived_sessions")
     diag_stage("visible_lineage_metadata")
@@ -1920,6 +1930,10 @@ def _build_session_list_cache_payload(
         "sessions": [
             dict(s) if isinstance(s, dict) else {}
             for s in scoped
+        ],
+        "sidebar_reference_sessions": [
+            dict(s) if isinstance(s, dict) else {}
+            for s in sidebar_reference_sessions
         ],
         "cli_count": len(deduped_cli),
         "archived_count": archived_count,
@@ -1957,8 +1971,15 @@ def _session_list_payload_to_response(payload: dict) -> dict:
     for s in runtime_rows:
         item = _sidebar_session_response_item(s, redact_enabled=_redact_enabled) if isinstance(s, dict) else {}
         safe_merged.append(item)
+    safe_reference = []
+    for s in payload.get("sidebar_reference_sessions", []) or []:
+        item = _sidebar_session_response_item(s, redact_enabled=_redact_enabled) if isinstance(s, dict) else {}
+        if item:
+            item["_sidebar_reference_only"] = True
+        safe_reference.append(item)
     response = {
         "sessions": safe_merged,
+        "sidebar_reference_sessions": safe_reference,
         "cli_count": int(payload.get("cli_count", 0)),
         "archived_count": int(payload.get("archived_count", 0)),
         "archived_webui_count": int(payload.get("archived_webui_count", 0)),
@@ -1975,6 +1996,53 @@ def _session_list_payload_to_response(payload: dict) -> dict:
     if "cli_session_count" in payload:
         response["cli_session_count"] = int(payload.get("cli_session_count", 0))
     return response
+
+
+def _hidden_archived_sidebar_reference_sessions(
+    visible_rows: list[dict],
+    archived_rows: list[dict],
+) -> list[dict]:
+    """Return hidden archived ancestors needed for client-side sidebar nesting.
+
+    The default sidebar payload intentionally omits archived sessions. The
+    browser still needs a tiny reference row for an archived parent/ancestor so
+    `_attachChildSessionsToSidebarRows()` can suppress its visible child rows
+    instead of rendering them as orphan top-level conversations (#4293).
+    """
+    archived_by_id = {
+        str(row.get("session_id")): row
+        for row in archived_rows
+        if isinstance(row, dict) and row.get("archived") and row.get("session_id")
+    }
+    if not archived_by_id:
+        return []
+
+    references: list[dict] = []
+    added: set[str] = set()
+    visible_ids = {
+        str(row.get("session_id"))
+        for row in visible_rows
+        if isinstance(row, dict) and row.get("session_id")
+    }
+
+    for row in visible_rows:
+        if not isinstance(row, dict):
+            continue
+        parent_id = str(row.get("parent_session_id") or "").strip()
+        seen: set[str] = set()
+        while parent_id and parent_id not in seen:
+            seen.add(parent_id)
+            if parent_id in visible_ids:
+                break
+            parent = archived_by_id.get(parent_id)
+            if not parent:
+                break
+            if parent_id not in added:
+                references.append(parent)
+                added.add(parent_id)
+            parent_id = str(parent.get("parent_session_id") or "").strip()
+
+    return references
 
 
 def _get_cached_session_list_payload(

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3024,6 +3024,7 @@ async function _ensureAllMessagesLoaded() {
 }
 
 let _allSessions = [];  // cached for search filter
+let _sidebarReferenceSessions = [];  // hidden archived ancestor rows used only for nesting/suppression
 let _allSessionsScope = null;  // {profile, allProfiles} the cache was loaded under (#4167)
 let _sessionAttentionSoundPrimed = false;
 const _sessionAttentionSoundState = new Map();
@@ -4169,6 +4170,9 @@ function _applySessionListPayload(sessData, projData){
   const serverSessions=_optimisticallyRemovedSessionIds.size
     ? (sessData.sessions||[]).filter(s=>s&&!_optimisticallyRemovedSessionIds.has(s.session_id))
     : (sessData.sessions||[]);
+  _sidebarReferenceSessions = Array.isArray(sessData.sidebar_reference_sessions)
+    ? sessData.sidebar_reference_sessions
+    : [];
   _reconcileActiveSessionIdleStateFromList(serverSessions);
   _allSessions = _mergeOptimisticFirstTurnSessions(serverSessions);
   // Tag the cache with the scope it was loaded under (active profile +
@@ -4305,6 +4309,7 @@ async function _runRenderSessionListRefresh(opts, _gen){
       renderSessionListFromCache();
     } else {
       _allSessions = [];
+      _sidebarReferenceSessions = [];
       _allSessionsScope = _curScope;
       _clearSessionSourceTabCounts();
       renderSessionListFromCache();
@@ -5989,7 +5994,10 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
 }
 
 function _renderSidebarRowsFromRawSessions(sessionsRaw, referenceSessionsRaw){
-  const referenceRows=Array.isArray(referenceSessionsRaw)?referenceSessionsRaw:sessionsRaw;
+  let referenceRows=Array.isArray(referenceSessionsRaw)?referenceSessionsRaw:sessionsRaw;
+  if(typeof _sidebarReferenceSessions!=='undefined'&&Array.isArray(_sidebarReferenceSessions)&&_sidebarReferenceSessions.length){
+    referenceRows=[...referenceRows,..._sidebarReferenceSessions];
+  }
   return _attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw, referenceRows);
 }
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -5993,11 +5993,29 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
   };
 }
 
+// Hidden archived-ancestor reference rows (sidebar_reference_sessions) arrive
+// from /api/sessions WITHOUT the client-side project/source scoping that
+// _partitionSidebarSessionRows applies to the visible rows. Appending them to
+// EVERY render unconditionally let an archived parent from a DIFFERENT project
+// (or the other source bucket) enter a project/source-filtered render's
+// suppression context — silently hiding a visible child/fork whose archived
+// ancestor lives outside the current view. Scope the references to the same
+// project + source bucket as the render they feed before using them.
+function _scopedSidebarReferenceRows(isCli){
+  if(typeof _sidebarReferenceSessions==='undefined'||!Array.isArray(_sidebarReferenceSessions)||!_sidebarReferenceSessions.length) return [];
+  return _sidebarReferenceSessions.filter(s=>{
+    if(!s) return false;
+    // Source scope: only references in the same webui/cli bucket as this render.
+    if(_isCliSession(s)!==!!isCli) return false;
+    // Project scope: mirror _partitionSidebarSessionRows exactly.
+    if(_activeProject===NO_PROJECT_FILTER){ if(s.project_id) return false; }
+    else if(_activeProject){ if(s.project_id!==_activeProject) return false; }
+    return true;
+  });
+}
+
 function _renderSidebarRowsFromRawSessions(sessionsRaw, referenceSessionsRaw){
-  let referenceRows=Array.isArray(referenceSessionsRaw)?referenceSessionsRaw:sessionsRaw;
-  if(typeof _sidebarReferenceSessions!=='undefined'&&Array.isArray(_sidebarReferenceSessions)&&_sidebarReferenceSessions.length){
-    referenceRows=[...referenceRows,..._sidebarReferenceSessions];
-  }
+  const referenceRows=Array.isArray(referenceSessionsRaw)?referenceSessionsRaw:sessionsRaw;
   return _attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw, referenceRows);
 }
 
@@ -6043,9 +6061,10 @@ function renderSessionListFromCache(){
     cliSessionsRaw,
   }=_partitionSidebarSessionRows(allMatched, activeSidForSidebar);
   const referenceRaw=_sessionSourceFilter==='cli'?cliReferenceRaw:webuiReferenceRaw;
-  const sessions=_renderSidebarRowsFromRawSessions(sessionsRaw, referenceRaw);
-  const renderedWebuiSessionCount=_renderSidebarRowsFromRawSessions(webuiSessionsRaw, webuiReferenceRaw).length;
-  const renderedCliSessionCount=_renderSidebarRowsFromRawSessions(cliSessionsRaw, cliReferenceRaw).length;
+  const isCliView=_sessionSourceFilter==='cli';
+  const sessions=_renderSidebarRowsFromRawSessions(sessionsRaw, [...referenceRaw, ..._scopedSidebarReferenceRows(isCliView)]);
+  const renderedWebuiSessionCount=_renderSidebarRowsFromRawSessions(webuiSessionsRaw, [...webuiReferenceRaw, ..._scopedSidebarReferenceRows(false)]).length;
+  const renderedCliSessionCount=_renderSidebarRowsFromRawSessions(cliSessionsRaw, [...cliReferenceRaw, ..._scopedSidebarReferenceRows(true)]).length;
   const webuiSessionTabCount=_sessionSourceTabCount('webui', renderedWebuiSessionCount, renderedCliSessionCount);
   const cliSessionTabCount=_sessionSourceTabCount('cli', renderedWebuiSessionCount, renderedCliSessionCount);
   _syncSidebarExpansionForActiveSession(sessions, activeSidForSidebar);

--- a/tests/test_issue4766_sidebar_source_pushdown.py
+++ b/tests/test_issue4766_sidebar_source_pushdown.py
@@ -156,6 +156,49 @@ def test_sidebar_source_webui_excludes_cli_rows(monkeypatch):
     assert set(enriched[0]) == expected
 
 
+def test_sidebar_source_webui_includes_hidden_archived_parent_reference(monkeypatch):
+    rows = [
+        {
+            "session_id": "webui-parent",
+            "title": "Archived parent",
+            "profile": "default",
+            "archived": True,
+            "message_count": 10,
+            "updated_at": 1000,
+            "last_message_at": 1000,
+            "source": "webui",
+            "raw_source": "webui",
+            "session_source": "webui",
+            "source_tag": "webui",
+        },
+        {
+            "session_id": "webui-child",
+            "title": "Subagent Session",
+            "profile": "default",
+            "archived": False,
+            "message_count": 4,
+            "updated_at": 1100,
+            "last_message_at": 1100,
+            "source": "subagent",
+            "raw_source": "subagent",
+            "session_source": "other",
+            "source_tag": "subagent",
+            "parent_session_id": "webui-parent",
+            "relationship_type": "child_session",
+        },
+    ]
+    _install_common_monkeypatches(monkeypatch, rows)
+
+    handler = _handle_sessions("http://example.com/api/sessions?sidebar_source=webui&exclude_hidden=1")
+
+    body = handler.json_body()
+    assert handler.status == 200
+    assert [row["session_id"] for row in body["sessions"]] == ["webui-child"]
+    assert [row["session_id"] for row in body["sidebar_reference_sessions"]] == ["webui-parent"]
+    assert body["sidebar_reference_sessions"][0]["archived"] is True
+    assert body["sidebar_reference_sessions"][0]["_sidebar_reference_only"] is True
+
+
 def test_sidebar_source_cli_excludes_webui_rows(monkeypatch):
     rows = _session_rows(webui_count=30, cli_count=20)
     _install_common_monkeypatches(monkeypatch, rows)

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -421,6 +421,41 @@ console.log(JSON.stringify(rows));
     assert "_child_sessions" not in rows[0]
 
 
+def test_sidebar_reference_rows_suppress_source_filtered_archived_parent_child():
+    """Source-filtered payloads keep archived parents as non-rendered references."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+var _showArchived = false;
+var _sidebarReferenceSessions = [{{session_id:'parent', title:'Archived parent', archived:true, updated_at:10, last_message_at:10}}];
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+eval(extractFunc('_renderSidebarRowsFromRawSessions'));
+const child = {{session_id:'child', title:'Subagent', parent_session_id:'parent', relationship_type:'child_session', updated_at:20, last_message_at:20}};
+const rows = _renderSidebarRowsFromRawSessions([child], [child]);
+console.log(JSON.stringify(rows));
+"""
+    assert json.loads(_run_node(source)) == []
+
+
 def test_archived_hidden_parent_suppresses_child_and_fork_orphans():
     """Archived parents should not leave child/delegate clutter behind (#4293)."""
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -422,7 +422,12 @@ console.log(JSON.stringify(rows));
 
 
 def test_sidebar_reference_rows_suppress_source_filtered_archived_parent_child():
-    """Source-filtered payloads keep archived parents as non-rendered references."""
+    """Source-filtered payloads keep archived parents as non-rendered references.
+
+    The hidden archived parent reaches the render via the scoped reference helper
+    (`_scopedSidebarReferenceRows`), mirroring how renderSessionListFromCache feeds
+    project/source-scoped references into _renderSidebarRowsFromRawSessions.
+    """
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
     source = f"""
 const src = {js!r};
@@ -440,7 +445,11 @@ function extractFunc(name) {{
   return src.slice(start, i);
 }}
 var _showArchived = false;
-var _sidebarReferenceSessions = [{{session_id:'parent', title:'Archived parent', archived:true, updated_at:10, last_message_at:10}}];
+var NO_PROJECT_FILTER = '__none__';
+var _activeProject;
+var _sidebarReferenceSessions = [{{session_id:'parent', title:'Archived parent', archived:true, updated_at:10, last_message_at:10, source:'webui'}}];
+function _isMessagingSession(s) {{ return false; }}
+function _isCliSession(s) {{ return !!(s && (s.source === 'cli' || s.raw_source === 'cli')); }}
 eval(extractFunc('_sessionTimestampMs'));
 eval(extractFunc('_isChildSession'));
 eval(extractFunc('_isForkWithResolvableParent'));
@@ -448,12 +457,62 @@ eval(extractFunc('_sessionLineageKey'));
 eval(extractFunc('_sidebarLineageKeyForRow'));
 eval(extractFunc('_collapseSessionLineageForSidebar'));
 eval(extractFunc('_attachChildSessionsToSidebarRows'));
+eval(extractFunc('_scopedSidebarReferenceRows'));
 eval(extractFunc('_renderSidebarRowsFromRawSessions'));
-const child = {{session_id:'child', title:'Subagent', parent_session_id:'parent', relationship_type:'child_session', updated_at:20, last_message_at:20}};
-const rows = _renderSidebarRowsFromRawSessions([child], [child]);
+const child = {{session_id:'child', title:'Subagent', parent_session_id:'parent', relationship_type:'child_session', updated_at:20, last_message_at:20, source:'webui'}};
+const refs = _scopedSidebarReferenceRows(false);
+const rows = _renderSidebarRowsFromRawSessions([child], [child, ...refs]);
 console.log(JSON.stringify(rows));
 """
     assert json.loads(_run_node(source)) == []
+
+
+def test_sidebar_reference_rows_do_not_suppress_cross_project_child():
+    """A cross-project archived parent must NOT hide a visible child in another project.
+
+    Regression for the silent project-scope leak: sidebar_reference_sessions arrive
+    project-unscoped from /api/sessions, so an archived parent in project B must not
+    enter a project-A-filtered render's suppression context and erase a visible
+    project-A fork. _scopedSidebarReferenceRows filters references to the active
+    project/source before they feed the render.
+    """
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+var _showArchived = false;
+var NO_PROJECT_FILTER = '__none__';
+var _activeProject = 'projA';
+var _sidebarReferenceSessions = [{{session_id:'parent', title:'Archived parent (projB)', archived:true, project_id:'projB', updated_at:10, last_message_at:10, source:'webui'}}];
+function _isMessagingSession(s) {{ return false; }}
+function _isCliSession(s) {{ return !!(s && (s.source === 'cli' || s.raw_source === 'cli')); }}
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+eval(extractFunc('_scopedSidebarReferenceRows'));
+eval(extractFunc('_renderSidebarRowsFromRawSessions'));
+const child = {{session_id:'child', title:'Fork in projA', parent_session_id:'parent', relationship_type:'child_session', project_id:'projA', message_count:3, updated_at:20, last_message_at:20, source:'webui'}};
+const refs = _scopedSidebarReferenceRows(false);
+const rows = _renderSidebarRowsFromRawSessions([child], [child, ...refs]);
+console.log(JSON.stringify(rows.map(r => r.session_id)));
+"""
+    assert json.loads(_run_node(source)) == ["child"]
 
 
 def test_archived_hidden_parent_suppresses_child_and_fork_orphans():

--- a/tests/test_sidebar_session_partition.py
+++ b/tests/test_sidebar_session_partition.py
@@ -31,9 +31,9 @@ def test_render_uses_single_pass_partition_helper():
     render_body = _function_block("renderSessionListFromCache")
 
     assert "_partitionSidebarSessionRows(allMatched, activeSidForSidebar)" in render_body
-    assert "_renderSidebarRowsFromRawSessions(sessionsRaw, referenceRaw)" in render_body
-    assert "const renderedWebuiSessionCount=_renderSidebarRowsFromRawSessions(webuiSessionsRaw, webuiReferenceRaw).length;" in render_body
-    assert "const renderedCliSessionCount=_renderSidebarRowsFromRawSessions(cliSessionsRaw, cliReferenceRaw).length;" in render_body
+    assert "_renderSidebarRowsFromRawSessions(sessionsRaw, [...referenceRaw, ..._scopedSidebarReferenceRows(isCliView)])" in render_body
+    assert "const renderedWebuiSessionCount=_renderSidebarRowsFromRawSessions(webuiSessionsRaw, [...webuiReferenceRaw, ..._scopedSidebarReferenceRows(false)]).length;" in render_body
+    assert "const renderedCliSessionCount=_renderSidebarRowsFromRawSessions(cliSessionsRaw, [...cliReferenceRaw, ..._scopedSidebarReferenceRows(true)]).length;" in render_body
     assert "const webuiSessionTabCount=_sessionSourceTabCount('webui', renderedWebuiSessionCount, renderedCliSessionCount);" in render_body
     assert "const cliSessionTabCount=_sessionSourceTabCount('cli', renderedWebuiSessionCount, renderedCliSessionCount);" in render_body
     assert "const count=filter==='cli'?cliSessionTabCount:webuiSessionTabCount;" in render_body
@@ -68,8 +68,8 @@ def test_partition_helper_keeps_raw_source_counts_while_render_owns_visible_coun
     assert "cliSessionsRaw," in _partition_block()
     assert "const renderedWebuiSessionCount=" in render_body
     assert "const renderedCliSessionCount=" in render_body
-    assert "_renderSidebarRowsFromRawSessions(webuiSessionsRaw, webuiReferenceRaw).length" in render_body
-    assert "_renderSidebarRowsFromRawSessions(cliSessionsRaw, cliReferenceRaw).length" in render_body
+    assert "_renderSidebarRowsFromRawSessions(webuiSessionsRaw, [...webuiReferenceRaw, ..._scopedSidebarReferenceRows(false)]).length" in render_body
+    assert "_renderSidebarRowsFromRawSessions(cliSessionsRaw, [...cliReferenceRaw, ..._scopedSidebarReferenceRows(true)]).length" in render_body
     assert "function _countRenderedSidebarRowsFromRawSessions" not in SESSIONS_JS
     assert "function _renderSidebarRowsFromRawSessions(sessionsRaw, referenceSessionsRaw){" in SESSIONS_JS
     assert "_attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw, referenceRows)" in SESSIONS_JS


### PR DESCRIPTION
## Thinking Path

- The sidebar already has client-side logic to keep archived parent conversations from leaving child/subagent rows behind.
- The newer source-filtered `/api/sessions?sidebar_source=...` path can omit the hidden archived parent while still returning the visible child row.
- Without the parent as reference context, the browser cannot tell that the child belongs to a hidden archived ancestor, so the child can render as a top-level/orphan sidebar row.
- This PR keeps the visible list unchanged while sending a tiny reference-only ancestor payload for the sidebar's existing nesting/suppression logic.

## What Changed

- Adds `sidebar_reference_sessions` to the `/api/sessions` payload for hidden archived ancestors needed by visible child rows.
- Marks those rows `_sidebar_reference_only` after applying the normal bounded sidebar response shape/redaction path.
- Stores reference rows separately on the frontend and passes them only into child-session attachment/suppression.
- Adds regression coverage for the source-filtered API payload and the frontend render path.

## Why It Matters

Archiving a parent conversation should not leave delegated/subagent/fork child rows cluttering the sidebar when archived sessions are hidden. This preserves the existing no-cascade behavior while giving the frontend enough context to apply the already-existing archive/child-session rule.

## Verification

- `python3 -m py_compile api/routes.py api/agent_sessions.py api/models.py`
- `node --check static/sessions.js`
- `node --check static/*.js`
- `./scripts/test.sh tests/test_session_lineage_collapse.py tests/test_issue4766_sidebar_source_pushdown.py -q` — 61 passed
- `./scripts/test.sh tests/test_sidebar_session_partition.py tests/test_session_lineage_collapse.py tests/test_issue4766_sidebar_source_pushdown.py tests/test_issue4385_cron_archive_reappears.py tests/test_session_sidebar_cache.py tests/test_issue4662_sidebar_redaction_read_once.py -q` — 90 passed

## Risks / Follow-ups

- The new reference payload is intentionally narrow: only hidden archived ancestors for currently visible rows. It should not make archived rows render, and it avoids cascade-mutating child session state.
- If future sidebar filters need similar hidden context, they should use the same reference-only pattern rather than widening the primary `sessions` list.

## Model Used

AI-assisted using Hermes Agent with GPT-5.5 via OpenRouter. Verification was performed locally with the commands above.
