### PR TITLE
feat(extensions): add llm-proxy quota-stats bridge (#5033)

### DIFF
--- a/api/providers.py
+++ b/api/providers.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -25,6 +26,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from urllib.parse import urlencode, urlsplit
 
 try:  # POSIX-only; Windows-style environments fall back to process-local locking.
     import fcntl
@@ -80,6 +82,9 @@ _ACCOUNT_USAGE_CACHE_TTL_SECONDS = 45.0
 _ACCOUNT_USAGE_CACHE_MAX_ENTRIES = 64
 _ACCOUNT_USAGE_WORKER_IDLE_SECONDS = 5 * 60
 _ACCOUNT_USAGE_PROVIDERS = frozenset({"openai-codex", "anthropic"})
+_LLM_PROXY_PROVIDER_ID = "llm-proxy"
+_LLM_PROXY_QUOTA_STATS_PATH = "/v1/quota-stats"
+_LLM_PROXY_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
 
 # Upper bound on simultaneous profile-isolated quota probe subprocesses.
 # Each probe runs a Python child for up to 35 s; capping concurrency prevents
@@ -2036,6 +2041,200 @@ def get_provider_quota(provider_id: str | None = None, *, refresh: bool = False)
         "quota": None,
         "message": f"Quota status is not available for {display_name}. {detail}",
     }
+
+
+def _llm_proxy_quota_stats_error(code: str, message: str, *, status: int) -> tuple[int, dict[str, Any]]:
+    return status, {"ok": False, "error": code, "message": message}
+
+
+def _llm_proxy_quota_stats_token(
+    value: Any,
+    field: str,
+    *,
+    required: bool = False,
+    max_len: int = 64,
+) -> tuple[str | None, str | None]:
+    if value is None:
+        return None, f"{field} is required." if required else None
+    text = str(value).strip()
+    if not text:
+        return None, f"{field} is required." if required else None
+    if len(text) > max_len or not _LLM_PROXY_TOKEN_RE.fullmatch(text):
+        return None, "Invalid llm-proxy quota-stats request."
+    return text, None
+
+
+def _llm_proxy_quota_stats_query_value(
+    query: dict[str, list[str]],
+    field: str,
+    *,
+    required: bool = False,
+    max_len: int = 64,
+) -> tuple[str | None, str | None]:
+    values = query.get(field)
+    if values is None:
+        return _llm_proxy_quota_stats_token(None, field, required=required, max_len=max_len)
+    if not isinstance(values, list) or len(values) != 1:
+        return None, "Invalid llm-proxy quota-stats request."
+    return _llm_proxy_quota_stats_token(values[0], field, required=required, max_len=max_len)
+
+
+def _llm_proxy_quota_stats_base_url() -> str | None:
+    cfg = get_config()
+    providers_cfg = cfg.get("providers") or {}
+    provider_cfg: dict[str, Any] = {}
+    if isinstance(providers_cfg, dict):
+        candidate = providers_cfg.get(_LLM_PROXY_PROVIDER_ID, {})
+        if isinstance(candidate, dict):
+            provider_cfg = candidate
+
+    base_url = str(provider_cfg.get("base_url") or "").strip()
+    if not base_url:
+        model_cfg = cfg.get("model", {})
+        if isinstance(model_cfg, dict):
+            model_provider = str(model_cfg.get("provider") or "").strip().lower()
+            if model_provider == _LLM_PROXY_PROVIDER_ID:
+                base_url = str(model_cfg.get("base_url") or "").strip()
+    if not base_url:
+        return None
+
+    parsed = urlsplit(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    if parsed.username or parsed.password:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path.rstrip('/')}"
+
+
+def _llm_proxy_quota_stats_config() -> tuple[str | None, str | None]:
+    return _llm_proxy_quota_stats_base_url(), _get_provider_api_key(_LLM_PROXY_PROVIDER_ID)
+
+
+def get_llm_proxy_quota_stats(
+    *,
+    query: dict[str, list[str]] | None = None,
+    body: dict[str, Any] | None = None,
+) -> tuple[int, Any]:
+    """Fetch the fixed llm-proxy quota-stats bridge target."""
+    if body is None:
+        if query is None:
+            query = {}
+        if not isinstance(query, dict):
+            return _llm_proxy_quota_stats_error(
+                "llm_proxy_quota_stats_invalid_request",
+                "Invalid llm-proxy quota-stats request.",
+                status=400,
+            )
+        if set(query) - {"provider"}:
+            return _llm_proxy_quota_stats_error(
+                "llm_proxy_quota_stats_invalid_request",
+                "Invalid llm-proxy quota-stats request.",
+                status=400,
+            )
+        provider, error = _llm_proxy_quota_stats_query_value(query, "provider", max_len=128)
+        if error:
+            return _llm_proxy_quota_stats_error(
+                "llm_proxy_quota_stats_invalid_request",
+                error,
+                status=400,
+            )
+        request_body = None
+    else:
+        if not isinstance(body, dict):
+            return _llm_proxy_quota_stats_error(
+                "llm_proxy_quota_stats_invalid_request",
+                "Invalid llm-proxy quota-stats request.",
+                status=400,
+            )
+        if set(body) - {"action", "scope", "provider", "credential"}:
+            return _llm_proxy_quota_stats_error(
+                "llm_proxy_quota_stats_invalid_request",
+                "Invalid llm-proxy quota-stats request.",
+                status=400,
+            )
+        action, error = _llm_proxy_quota_stats_token(body.get("action"), "action", required=True, max_len=64)
+        if error:
+            return _llm_proxy_quota_stats_error(
+                "llm_proxy_quota_stats_invalid_request",
+                error,
+                status=400,
+            )
+        scope, error = _llm_proxy_quota_stats_token(body.get("scope"), "scope", required=True, max_len=64)
+        if error:
+            return _llm_proxy_quota_stats_error(
+                "llm_proxy_quota_stats_invalid_request",
+                error,
+                status=400,
+            )
+        provider, error = _llm_proxy_quota_stats_token(body.get("provider"), "provider", max_len=128)
+        if error:
+            return _llm_proxy_quota_stats_error(
+                "llm_proxy_quota_stats_invalid_request",
+                error,
+                status=400,
+            )
+        credential, error = _llm_proxy_quota_stats_token(body.get("credential"), "credential", max_len=128)
+        if error:
+            return _llm_proxy_quota_stats_error(
+                "llm_proxy_quota_stats_invalid_request",
+                error,
+                status=400,
+            )
+        request_body = {"action": action, "scope": scope}
+        if provider is not None:
+            request_body["provider"] = provider
+        if credential is not None:
+            request_body["credential"] = credential
+
+    base_url, api_key = _llm_proxy_quota_stats_config()
+    if not base_url or not api_key:
+        return _llm_proxy_quota_stats_error(
+            "llm_proxy_quota_stats_unconfigured",
+            "llm-proxy quota stats is not configured.",
+            status=503,
+        )
+
+    target_url = f"{base_url}{_LLM_PROXY_QUOTA_STATS_PATH}"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+    }
+    if body is None:
+        if provider is not None:
+            target_url = f"{target_url}?{urlencode({'provider': provider})}"
+        request = urllib.request.Request(target_url, headers=headers)
+    else:
+        headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            target_url,
+            data=json.dumps(request_body).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+
+    try:
+        with urllib.request.urlopen(request, timeout=_PROVIDER_QUOTA_TIMEOUT_SECONDS) as resp:
+            raw = resp.read()
+        payload = json.loads(raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw)
+        return 200, payload
+    except urllib.error.HTTPError as exc:
+        if exc.code in (401, 403):
+            return _llm_proxy_quota_stats_error(
+                "llm_proxy_quota_stats_upstream_rejected",
+                "llm-proxy quota stats rejected the configured credentials.",
+                status=502,
+            )
+        return _llm_proxy_quota_stats_error(
+            "llm_proxy_quota_stats_unavailable",
+            "llm-proxy quota stats is temporarily unavailable.",
+            status=503,
+        )
+    except (TimeoutError, urllib.error.URLError, json.JSONDecodeError, OSError, ValueError):
+        return _llm_proxy_quota_stats_error(
+            "llm_proxy_quota_stats_unavailable",
+            "llm-proxy quota stats is temporarily unavailable.",
+            status=503,
+        )
 
 
 def _provider_is_oauth(provider_id: str) -> bool:

--- a/api/providers.py
+++ b/api/providers.py
@@ -78,6 +78,7 @@ def _custom_provider_name_matches(provider_id: str, name: object) -> bool:
 
 _OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key"
 _PROVIDER_QUOTA_TIMEOUT_SECONDS = 3.0
+_LLM_PROXY_QUOTA_STATS_MAX_RESPONSE_BYTES = 512 * 1024
 _ACCOUNT_USAGE_SUBPROCESS_TIMEOUT_SECONDS = 35.0
 _ACCOUNT_USAGE_CACHE_TTL_SECONDS = 45.0
 _ACCOUNT_USAGE_CACHE_MAX_ENTRIES = 64
@@ -2238,7 +2239,13 @@ def get_llm_proxy_quota_stats(
 
     try:
         with urllib.request.urlopen(request, timeout=_PROVIDER_QUOTA_TIMEOUT_SECONDS) as resp:
-            raw = resp.read()
+            raw = resp.read(_LLM_PROXY_QUOTA_STATS_MAX_RESPONSE_BYTES + 1)
+        if isinstance(raw, (bytes, bytearray)) and len(raw) > _LLM_PROXY_QUOTA_STATS_MAX_RESPONSE_BYTES:
+            return _llm_proxy_quota_stats_error(
+                "llm_proxy_quota_stats_invalid_response",
+                "llm-proxy quota stats returned an invalid response.",
+                status=502,
+            )
         payload = json.loads(raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw)
         return 200, payload
     except urllib.error.HTTPError as exc:

--- a/api/providers.py
+++ b/api/providers.py
@@ -2049,6 +2049,22 @@ def _llm_proxy_quota_stats_error(code: str, message: str, *, status: int) -> tup
     return status, {"ok": False, "error": code, "message": message}
 
 
+class _LlmProxyQuotaStatsNoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Reject redirects so a credentialed bridge never forwards its bearer token."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[override]
+        raise urllib.error.HTTPError(req.full_url, code, msg, headers, fp)
+
+
+def _llm_proxy_quota_stats_open(
+    request: urllib.request.Request,
+    *,
+    timeout: float,
+):
+    opener = urllib.request.build_opener(_LlmProxyQuotaStatsNoRedirectHandler)
+    return opener.open(request, timeout=timeout)
+
+
 def _llm_proxy_quota_stats_token(
     value: Any,
     field: str,
@@ -2133,6 +2149,27 @@ def _llm_proxy_quota_stats_config() -> tuple[str | None, str | None]:
         _normalize_llm_proxy_quota_stats_base_url(base_url),
         _get_provider_api_key(_LLM_PROXY_PROVIDER_ID),
     )
+
+
+def _llm_proxy_quota_stats_redact_text(value: str, api_key: str) -> str:
+    redacted = value.replace(f"Bearer {api_key}", "[REDACTED]")
+    return redacted.replace(api_key, "[REDACTED]")
+
+
+def _llm_proxy_quota_stats_redact_payload(value: Any, api_key: str) -> Any:
+    if isinstance(value, dict):
+        return {
+            _llm_proxy_quota_stats_redact_text(key, api_key) if isinstance(key, str) else key:
+            _llm_proxy_quota_stats_redact_payload(item, api_key)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_llm_proxy_quota_stats_redact_payload(item, api_key) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_llm_proxy_quota_stats_redact_payload(item, api_key) for item in value)
+    if isinstance(value, str):
+        return _llm_proxy_quota_stats_redact_text(value, api_key)
+    return value
 
 
 def get_llm_proxy_quota_stats(
@@ -2238,7 +2275,7 @@ def get_llm_proxy_quota_stats(
         )
 
     try:
-        with urllib.request.urlopen(request, timeout=_PROVIDER_QUOTA_TIMEOUT_SECONDS) as resp:
+        with _llm_proxy_quota_stats_open(request, timeout=_PROVIDER_QUOTA_TIMEOUT_SECONDS) as resp:
             raw = resp.read(_LLM_PROXY_QUOTA_STATS_MAX_RESPONSE_BYTES + 1)
         if isinstance(raw, (bytes, bytearray)) and len(raw) > _LLM_PROXY_QUOTA_STATS_MAX_RESPONSE_BYTES:
             return _llm_proxy_quota_stats_error(
@@ -2247,8 +2284,14 @@ def get_llm_proxy_quota_stats(
                 status=502,
             )
         payload = json.loads(raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw)
-        return 200, payload
+        return 200, _llm_proxy_quota_stats_redact_payload(payload, api_key)
     except urllib.error.HTTPError as exc:
+        if 300 <= exc.code < 400:
+            return _llm_proxy_quota_stats_error(
+                "llm_proxy_quota_stats_unavailable",
+                "llm-proxy quota stats is temporarily unavailable.",
+                status=503,
+            )
         if exc.code in (401, 403):
             return _llm_proxy_quota_stats_error(
                 "llm_proxy_quota_stats_upstream_rejected",

--- a/api/providers.py
+++ b/api/providers.py
@@ -2094,12 +2094,26 @@ def _normalize_llm_proxy_quota_stats_base_url(base_url: str | None) -> str | Non
     return f"{parsed.scheme}://{parsed.netloc}{path}"
 
 
+def _has_named_llm_proxy_custom_provider(cfg: dict[str, Any]) -> bool:
+    target_slug = f"custom:{_LLM_PROXY_PROVIDER_ID}"
+    custom_providers = cfg.get("custom_providers", [])
+    if not isinstance(custom_providers, list):
+        return False
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "").strip()
+        if _custom_provider_slug_from_name(name) == target_slug:
+            return True
+    return False
+
+
 def _llm_proxy_quota_stats_config() -> tuple[str | None, str | None]:
-    custom_api_key, custom_base_url = resolve_custom_provider_connection("custom:llm-proxy")
-    if custom_api_key or custom_base_url:
+    cfg = get_config()
+    if _has_named_llm_proxy_custom_provider(cfg):
+        custom_api_key, custom_base_url = resolve_custom_provider_connection("custom:llm-proxy")
         return _normalize_llm_proxy_quota_stats_base_url(custom_base_url), custom_api_key
 
-    cfg = get_config()
     providers_cfg = cfg.get("providers") or {}
     provider_cfg: dict[str, Any] = {}
     if isinstance(providers_cfg, dict):

--- a/api/providers.py
+++ b/api/providers.py
@@ -47,6 +47,7 @@ from api.config import (
     get_config,
     invalidate_models_cache,
     reload_config,
+    resolve_custom_provider_connection,
 )
 from api.plugin_providers import (
     effective_provider_display_name,
@@ -2079,7 +2080,25 @@ def _llm_proxy_quota_stats_query_value(
     return _llm_proxy_quota_stats_token(values[0], field, required=required, max_len=max_len)
 
 
-def _llm_proxy_quota_stats_base_url() -> str | None:
+def _normalize_llm_proxy_quota_stats_base_url(base_url: str | None) -> str | None:
+    if not base_url:
+        return None
+    parsed = urlsplit(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    if parsed.username or parsed.password:
+        return None
+    path = parsed.path.rstrip("/")
+    if path.endswith("/v1"):
+        path = path[:-3]
+    return f"{parsed.scheme}://{parsed.netloc}{path}"
+
+
+def _llm_proxy_quota_stats_config() -> tuple[str | None, str | None]:
+    custom_api_key, custom_base_url = resolve_custom_provider_connection("custom:llm-proxy")
+    if custom_api_key or custom_base_url:
+        return _normalize_llm_proxy_quota_stats_base_url(custom_base_url), custom_api_key
+
     cfg = get_config()
     providers_cfg = cfg.get("providers") or {}
     provider_cfg: dict[str, Any] = {}
@@ -2095,19 +2114,10 @@ def _llm_proxy_quota_stats_base_url() -> str | None:
             model_provider = str(model_cfg.get("provider") or "").strip().lower()
             if model_provider == _LLM_PROXY_PROVIDER_ID:
                 base_url = str(model_cfg.get("base_url") or "").strip()
-    if not base_url:
-        return None
-
-    parsed = urlsplit(base_url)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        return None
-    if parsed.username or parsed.password:
-        return None
-    return f"{parsed.scheme}://{parsed.netloc}{parsed.path.rstrip('/')}"
-
-
-def _llm_proxy_quota_stats_config() -> tuple[str | None, str | None]:
-    return _llm_proxy_quota_stats_base_url(), _get_provider_api_key(_LLM_PROXY_PROVIDER_ID)
+    return (
+        _normalize_llm_proxy_quota_stats_base_url(base_url),
+        _get_provider_api_key(_LLM_PROXY_PROVIDER_ID),
+    )
 
 
 def get_llm_proxy_quota_stats(

--- a/api/routes.py
+++ b/api/routes.py
@@ -7479,7 +7479,7 @@ from api.run_journal import (
     stale_interrupted_event,
 )
 from api.todo_state import attach_todo_state
-from api.providers import get_providers, get_provider_quota, get_provider_cost_history, set_provider_key, remove_provider_key
+from api.providers import get_llm_proxy_quota_stats, get_providers, get_provider_quota, get_provider_cost_history, set_provider_key, remove_provider_key
 from api.onboarding import (
     apply_onboarding_setup,
     get_onboarding_status,
@@ -10161,6 +10161,14 @@ def handle_get(handler, parsed) -> bool:
 
         return j(handler, get_extension_status())
 
+    if parsed.path == "/api/extensions/proxies/llm-proxy/quota-stats":
+        query = parse_qs(parsed.query, keep_blank_values=True)
+        from api.profiles import profile_env_for_active_request_readonly
+
+        with profile_env_for_active_request_readonly("/api/extensions/proxies/llm-proxy/quota-stats", logger_override=logger):
+            status, payload = get_llm_proxy_quota_stats(query=query)
+        return j(handler, payload, status=status)
+
     if parsed.path == "/api/extensions/registry":
         from api.extensions import get_extension_registry
 
@@ -11491,6 +11499,13 @@ def handle_post(handler, parsed) -> bool:
         except Exception:
             logger.exception("extension toggle failed")
             return bad(handler, "Failed to update extension state", status=500)
+
+    if parsed.path == "/api/extensions/proxies/llm-proxy/quota-stats":
+        from api.profiles import profile_env_for_active_request_readonly
+
+        with profile_env_for_active_request_readonly("/api/extensions/proxies/llm-proxy/quota-stats", logger_override=logger):
+            status, payload = get_llm_proxy_quota_stats(body=body)
+        return j(handler, payload, status=status)
 
     if parsed.path == "/api/extensions/install":
         from api.extensions import ExtensionInstallError, install_extension

--- a/api/routes.py
+++ b/api/routes.py
@@ -10162,7 +10162,7 @@ def handle_get(handler, parsed) -> bool:
         return j(handler, get_extension_status())
 
     if parsed.path == "/api/extensions/proxies/llm-proxy/quota-stats":
-        query = parse_qs(parsed.query, keep_blank_values=True)
+        query = parse_qs(parsed.query)
         from api.profiles import profile_env_for_active_request_readonly
 
         with profile_env_for_active_request_readonly("/api/extensions/proxies/llm-proxy/quota-stats", logger_override=logger):

--- a/api/routes.py
+++ b/api/routes.py
@@ -11503,6 +11503,8 @@ def handle_post(handler, parsed) -> bool:
     if parsed.path == "/api/extensions/proxies/llm-proxy/quota-stats":
         from api.profiles import profile_env_for_active_request_readonly
 
+        if body is None:
+            return bad(handler, "Invalid llm-proxy quota-stats request.", status=400)
         with profile_env_for_active_request_readonly("/api/extensions/proxies/llm-proxy/quota-stats", logger_override=logger):
             status, payload = get_llm_proxy_quota_stats(body=body)
         return j(handler, payload, status=status)

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -206,6 +206,18 @@ extension JavaScript talks to that sidecar directly from the browser; Hermes
 WebUI does not proxy those requests and does not create extension-owned backend
 routes.
 
+## Authenticated llm-proxy quota stats bridge
+
+There is one fixed backend exception for extensions that need server-held
+`llm-proxy` credentials to read quota data without exposing bearer auth to
+browser JavaScript.
+
+- `GET /api/extensions/proxies/llm-proxy/quota-stats` forwards only an optional `provider` query parameter.
+- `POST /api/extensions/proxies/llm-proxy/quota-stats` accepts validated `action` and `scope` fields plus optional `provider` and `credential` fields.
+- WebUI resolves the active profile's `llm-proxy` config and supplies the bearer token server-side.
+- The bridge forwards to the fixed upstream `/v1/quota-stats` path only.
+- Generic extension proxying, caller-chosen hosts, and caller-chosen paths stay out of scope.
+
 Loopback sidecar origins are already included in WebUI's enforced CSP
 `connect-src` directive:
 

--- a/tests/test_extension_llm_proxy_quota_stats.py
+++ b/tests/test_extension_llm_proxy_quota_stats.py
@@ -23,8 +23,10 @@ class _FakeResponse:
     def __exit__(self, *exc):
         return False
 
-    def read(self):
-        return self._payload
+    def read(self, size: int = -1):
+        if size is None or size < 0:
+            return self._payload
+        return self._payload[:size]
 
 
 def _set_llm_proxy_config(monkeypatch, *, base_url: str | None, api_key: str | None):
@@ -205,6 +207,28 @@ def test_get_quota_stats_rejects_unrelated_single_custom_provider(monkeypatch):
         "message": "llm-proxy quota stats is not configured.",
     }
     assert called is False
+
+
+def test_get_quota_stats_rejects_oversized_upstream_response(monkeypatch):
+    _set_llm_proxy_config(
+        monkeypatch,
+        base_url="https://llm-proxy.example.test",
+        api_key="server-held-secret",
+    )
+
+    def fake_urlopen(req, timeout):
+        return _FakeResponse(b"x" * (providers._LLM_PROXY_QUOTA_STATS_MAX_RESPONSE_BYTES + 1))
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+
+    status, payload = providers.get_llm_proxy_quota_stats(query={"provider": ["anthropic"]})
+
+    assert status == 502
+    assert payload == {
+        "ok": False,
+        "error": "llm_proxy_quota_stats_invalid_response",
+        "message": "llm-proxy quota stats returned an invalid response.",
+    }
 
 
 def test_post_quota_stats_rejects_invalid_action_or_scope_without_network(monkeypatch):

--- a/tests/test_extension_llm_proxy_quota_stats.py
+++ b/tests/test_extension_llm_proxy_quota_stats.py
@@ -62,7 +62,7 @@ def test_get_quota_stats_forwards_provider_query_and_bearer_auth(monkeypatch):
     )
     seen = {}
 
-    def fake_urlopen(req, timeout):
+    def fake_open(req, *, timeout):
         seen["url"] = req.full_url
         seen["method"] = req.get_method()
         seen["authorization"] = req.headers.get("Authorization")
@@ -71,7 +71,7 @@ def test_get_quota_stats_forwards_provider_query_and_bearer_auth(monkeypatch):
         seen["timeout"] = timeout
         return _FakeResponse(json.dumps({"ok": True, "quota": {"limit_remaining": 7}}).encode("utf-8"))
 
-    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(providers, "_llm_proxy_quota_stats_open", fake_open)
 
     status, payload = providers.get_llm_proxy_quota_stats(query={"provider": ["anthropic"]})
 
@@ -95,7 +95,7 @@ def test_post_quota_stats_forwards_validated_body(monkeypatch):
     )
     seen = {}
 
-    def fake_urlopen(req, timeout):
+    def fake_open(req, *, timeout):
         seen["url"] = req.full_url
         seen["method"] = req.get_method()
         seen["authorization"] = req.headers.get("Authorization")
@@ -103,7 +103,7 @@ def test_post_quota_stats_forwards_validated_body(monkeypatch):
         seen["timeout"] = timeout
         return _FakeResponse(json.dumps({"quota": {"limit_remaining": 6}, "reload": True}).encode("utf-8"))
 
-    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(providers, "_llm_proxy_quota_stats_open", fake_open)
 
     status, payload = providers.get_llm_proxy_quota_stats(
         body={
@@ -153,7 +153,7 @@ def test_get_quota_stats_uses_custom_provider_authority_and_strips_duplicate_v1(
     )
     seen = {}
 
-    def fake_urlopen(req, timeout):
+    def fake_open(req, *, timeout):
         seen["url"] = req.full_url
         seen["method"] = req.get_method()
         seen["authorization"] = req.headers.get("Authorization")
@@ -162,7 +162,7 @@ def test_get_quota_stats_uses_custom_provider_authority_and_strips_duplicate_v1(
         seen["timeout"] = timeout
         return _FakeResponse(json.dumps({"ok": True, "quota": {"limit_remaining": 4}}).encode("utf-8"))
 
-    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(providers, "_llm_proxy_quota_stats_open", fake_open)
 
     status, payload = providers.get_llm_proxy_quota_stats(query={"provider": ["anthropic"]})
 
@@ -196,7 +196,7 @@ def test_get_quota_stats_rejects_unrelated_single_custom_provider(monkeypatch):
         called = True
         raise AssertionError("network should not be reached for unrelated custom providers")
 
-    monkeypatch.setattr(providers.urllib.request, "urlopen", explode)
+    monkeypatch.setattr(providers, "_llm_proxy_quota_stats_open", explode)
 
     status, payload = providers.get_llm_proxy_quota_stats(query={"provider": ["anthropic"]})
 
@@ -216,10 +216,10 @@ def test_get_quota_stats_rejects_oversized_upstream_response(monkeypatch):
         api_key="server-held-secret",
     )
 
-    def fake_urlopen(req, timeout):
+    def fake_open(req, *, timeout):
         return _FakeResponse(b"x" * (providers._LLM_PROXY_QUOTA_STATS_MAX_RESPONSE_BYTES + 1))
 
-    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(providers, "_llm_proxy_quota_stats_open", fake_open)
 
     status, payload = providers.get_llm_proxy_quota_stats(query={"provider": ["anthropic"]})
 
@@ -244,7 +244,7 @@ def test_post_quota_stats_rejects_invalid_action_or_scope_without_network(monkey
         called = True
         raise AssertionError("network should not be reached for invalid llm-proxy quota requests")
 
-    monkeypatch.setattr(providers.urllib.request, "urlopen", explode)
+    monkeypatch.setattr(providers, "_llm_proxy_quota_stats_open", explode)
 
     for body in (
         {"action": "", "scope": "provider"},
@@ -280,7 +280,7 @@ def test_post_quota_stats_null_body_fails_before_network(monkeypatch):
         called = True
         raise AssertionError("network should not be reached for null llm-proxy quota requests")
 
-    monkeypatch.setattr(providers.urllib.request, "urlopen", explode)
+    monkeypatch.setattr(providers, "_llm_proxy_quota_stats_open", explode)
 
     result = routes.handle_post(
         SimpleNamespace(headers={}, rfile=BytesIO()),
@@ -292,6 +292,84 @@ def test_post_quota_stats_null_body_fails_before_network(monkeypatch):
         "status": 400,
     }
     assert called is False
+
+
+def test_get_quota_stats_rejects_upstream_redirects_without_following(monkeypatch):
+    _set_llm_proxy_config(
+        monkeypatch,
+        base_url="https://llm-proxy.example.test",
+        api_key="server-held-secret",
+    )
+    seen = []
+
+    def fake_open(req, *, timeout):
+        seen.append({
+            "url": req.full_url,
+            "authorization": req.headers.get("Authorization"),
+            "timeout": timeout,
+        })
+        raise providers.urllib.error.HTTPError(
+            req.full_url,
+            302,
+            "Found",
+            {"Location": "https://attacker.example.test/steal"},
+            None,
+        )
+
+    monkeypatch.setattr(providers, "_llm_proxy_quota_stats_open", fake_open)
+
+    status, payload = providers.get_llm_proxy_quota_stats(query={"provider": ["anthropic"]})
+
+    assert status == 503
+    assert payload == {
+        "ok": False,
+        "error": "llm_proxy_quota_stats_unavailable",
+        "message": "llm-proxy quota stats is temporarily unavailable.",
+    }
+    assert seen == [{
+        "url": "https://llm-proxy.example.test/v1/quota-stats?provider=anthropic",
+        "authorization": "Bearer server-held-secret",
+        "timeout": 3.0,
+    }]
+
+
+def test_get_quota_stats_redacts_upstream_echo_payload(monkeypatch):
+    _set_llm_proxy_config(
+        monkeypatch,
+        base_url="https://llm-proxy.example.test",
+        api_key="server-held-secret",
+    )
+
+    def fake_open(req, *, timeout):
+        return _FakeResponse(json.dumps({
+            "api_key": "server-held-secret",
+            "authorization": "Bearer server-held-secret",
+            "nested": {
+                "tokens": [
+                    "server-held-secret",
+                    "Bearer server-held-secret",
+                    "safe-value",
+                ]
+            },
+        }).encode("utf-8"))
+
+    monkeypatch.setattr(providers, "_llm_proxy_quota_stats_open", fake_open)
+
+    status, payload = providers.get_llm_proxy_quota_stats(query={"provider": ["anthropic"]})
+
+    assert status == 200
+    assert payload == {
+        "api_key": "[REDACTED]",
+        "authorization": "[REDACTED]",
+        "nested": {
+            "tokens": [
+                "[REDACTED]",
+                "[REDACTED]",
+                "safe-value",
+            ]
+        },
+    }
+    assert "server-held-secret" not in json.dumps(payload)
 
 
 def test_quota_stats_route_reports_unconfigured_proxy_without_secret_leak(monkeypatch):

--- a/tests/test_extension_llm_proxy_quota_stats.py
+++ b/tests/test_extension_llm_proxy_quota_stats.py
@@ -1,0 +1,220 @@
+"""Regression coverage for the fixed llm-proxy quota-stats extension bridge."""
+
+from __future__ import annotations
+
+import json
+from contextlib import nullcontext
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+
+import api.providers as providers
+import api.routes as routes
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return self._payload
+
+
+def _set_llm_proxy_config(monkeypatch, *, base_url: str | None, api_key: str | None):
+    monkeypatch.setattr(
+        providers,
+        "get_config",
+        lambda: {
+            "providers": {
+                "llm-proxy": {
+                    **({"base_url": base_url} if base_url is not None else {}),
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        providers,
+        "_get_provider_api_key",
+        lambda provider_id: api_key if provider_id == "llm-proxy" else None,
+    )
+
+
+def test_get_quota_stats_forwards_provider_query_and_bearer_auth(monkeypatch):
+    _set_llm_proxy_config(
+        monkeypatch,
+        base_url="https://llm-proxy.example.test",
+        api_key="server-held-secret",
+    )
+    seen = {}
+
+    def fake_urlopen(req, timeout):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        seen["authorization"] = req.headers.get("Authorization")
+        seen["accept"] = req.headers.get("Accept")
+        seen["data"] = req.data
+        seen["timeout"] = timeout
+        return _FakeResponse(json.dumps({"ok": True, "quota": {"limit_remaining": 7}}).encode("utf-8"))
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+
+    status, payload = providers.get_llm_proxy_quota_stats(query={"provider": ["anthropic"]})
+
+    assert status == 200
+    assert payload == {"ok": True, "quota": {"limit_remaining": 7}}
+    assert seen == {
+        "url": "https://llm-proxy.example.test/v1/quota-stats?provider=anthropic",
+        "method": "GET",
+        "authorization": "Bearer server-held-secret",
+        "accept": "application/json",
+        "data": None,
+        "timeout": 3.0,
+    }
+
+
+def test_post_quota_stats_forwards_validated_body(monkeypatch):
+    _set_llm_proxy_config(
+        monkeypatch,
+        base_url="https://llm-proxy.example.test/api",
+        api_key="server-held-secret",
+    )
+    seen = {}
+
+    def fake_urlopen(req, timeout):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        seen["authorization"] = req.headers.get("Authorization")
+        seen["body"] = json.loads(req.data.decode("utf-8"))
+        seen["timeout"] = timeout
+        return _FakeResponse(json.dumps({"quota": {"limit_remaining": 6}, "reload": True}).encode("utf-8"))
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+
+    status, payload = providers.get_llm_proxy_quota_stats(
+        body={
+            "action": "force-refresh",
+            "scope": "provider",
+            "provider": "anthropic",
+            "credential": "primary",
+        }
+    )
+
+    assert status == 200
+    assert payload == {"quota": {"limit_remaining": 6}, "reload": True}
+    assert seen == {
+        "url": "https://llm-proxy.example.test/api/v1/quota-stats",
+        "method": "POST",
+        "authorization": "Bearer server-held-secret",
+        "body": {
+            "action": "force-refresh",
+            "scope": "provider",
+            "provider": "anthropic",
+            "credential": "primary",
+        },
+        "timeout": 3.0,
+    }
+
+
+def test_post_quota_stats_rejects_invalid_action_or_scope_without_network(monkeypatch):
+    _set_llm_proxy_config(
+        monkeypatch,
+        base_url="https://llm-proxy.example.test",
+        api_key="server-held-secret",
+    )
+    called = False
+
+    def explode(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("network should not be reached for invalid llm-proxy quota requests")
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", explode)
+
+    for body in (
+        {"action": "", "scope": "provider"},
+        {"action": "force refresh", "scope": "provider"},
+        {"action": "force-refresh", "scope": ""},
+        {"action": "force-refresh", "scope": "provider scope"},
+    ):
+        status, payload = providers.get_llm_proxy_quota_stats(body=body)
+        assert status == 400
+        assert payload["ok"] is False
+        assert payload["error"] == "llm_proxy_quota_stats_invalid_request"
+        assert payload["message"]
+
+    assert called is False
+
+
+def test_quota_stats_route_reports_unconfigured_proxy_without_secret_leak(monkeypatch):
+    monkeypatch.setattr(
+        providers,
+        "get_config",
+        lambda: {"providers": {"llm-proxy": {}}},
+    )
+    monkeypatch.setattr(
+        providers,
+        "_get_provider_api_key",
+        lambda provider_id: "server-held-secret" if provider_id == "llm-proxy" else None,
+    )
+    monkeypatch.setattr(routes, "j", lambda handler, payload, status=200, headers=None: {
+        "payload": payload,
+        "status": status,
+    })
+    monkeypatch.setattr(
+        "api.profiles.profile_env_for_active_request_readonly",
+        lambda *_args, **_kwargs: nullcontext(),
+    )
+
+    result = routes.handle_get(
+        SimpleNamespace(),
+        SimpleNamespace(path="/api/extensions/proxies/llm-proxy/quota-stats", query="provider=anthropic"),
+    )
+
+    assert result == {
+        "payload": {
+            "ok": False,
+            "error": "llm_proxy_quota_stats_unconfigured",
+            "message": "llm-proxy quota stats is not configured.",
+        },
+        "status": 503,
+    }
+    assert "server-held-secret" not in repr(result)
+
+
+def test_non_allowlisted_extension_proxy_paths_remain_unavailable(monkeypatch):
+    monkeypatch.setattr(routes, "read_body", lambda handler: {})
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+
+    assert routes.handle_get(
+        SimpleNamespace(),
+        SimpleNamespace(path="/api/extensions/proxies/llm-proxy"),
+    ) is False
+    assert routes.handle_get(
+        SimpleNamespace(),
+        SimpleNamespace(path="/api/extensions/proxies/llm-proxy/quota-stats/extra"),
+    ) is False
+    assert routes.handle_post(
+        SimpleNamespace(headers={}, rfile=BytesIO()),
+        SimpleNamespace(path="/api/extensions/proxies/llm-proxy"),
+    ) is False
+    assert routes.handle_post(
+        SimpleNamespace(headers={}, rfile=BytesIO()),
+        SimpleNamespace(path="/api/extensions/proxies/llm-proxy/quota-stats/extra"),
+    ) is False
+
+
+def test_extensions_docs_describe_fixed_quota_stats_bridge_only():
+    docs = Path(__file__).resolve().parents[1].joinpath("docs", "EXTENSIONS.md").read_text(encoding="utf-8")
+
+    assert "/api/extensions/proxies/llm-proxy/quota-stats" in docs
+    assert "optional `provider` query parameter" in docs
+    assert "validated `action` and `scope` fields" in docs
+    assert "server-side" in docs
+    assert "/v1/quota-stats" in docs
+    assert "Generic extension proxying, caller-chosen hosts, and caller-chosen paths stay out of scope." in docs

--- a/tests/test_extension_llm_proxy_quota_stats.py
+++ b/tests/test_extension_llm_proxy_quota_stats.py
@@ -8,6 +8,7 @@ from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
 
+import api.config as config
 import api.providers as providers
 import api.routes as routes
 
@@ -117,6 +118,52 @@ def test_post_quota_stats_forwards_validated_body(monkeypatch):
             "provider": "anthropic",
             "credential": "primary",
         },
+        "timeout": 3.0,
+    }
+
+
+def test_get_quota_stats_uses_custom_provider_authority_and_strips_duplicate_v1(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "llm-proxy",
+                    "base_url": "https://llm-proxy.example.test/v1",
+                    "key_env": "ISSUE_5033_LLM_PROXY_KEY",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        config,
+        "_thread_local_env_value",
+        lambda name: "server-held-secret" if name == "ISSUE_5033_LLM_PROXY_KEY" else "",
+    )
+    seen = {}
+
+    def fake_urlopen(req, timeout):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        seen["authorization"] = req.headers.get("Authorization")
+        seen["accept"] = req.headers.get("Accept")
+        seen["data"] = req.data
+        seen["timeout"] = timeout
+        return _FakeResponse(json.dumps({"ok": True, "quota": {"limit_remaining": 4}}).encode("utf-8"))
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+
+    status, payload = providers.get_llm_proxy_quota_stats(query={"provider": ["anthropic"]})
+
+    assert status == 200
+    assert payload == {"ok": True, "quota": {"limit_remaining": 4}}
+    assert seen == {
+        "url": "https://llm-proxy.example.test/v1/quota-stats?provider=anthropic",
+        "method": "GET",
+        "authorization": "Bearer server-held-secret",
+        "accept": "application/json",
+        "data": None,
         "timeout": 3.0,
     }
 

--- a/tests/test_extension_llm_proxy_quota_stats.py
+++ b/tests/test_extension_llm_proxy_quota_stats.py
@@ -46,6 +46,12 @@ def _set_llm_proxy_config(monkeypatch, *, base_url: str | None, api_key: str | N
     )
 
 
+def _set_custom_llm_proxy_config(monkeypatch, custom_providers):
+    cfg = {"custom_providers": custom_providers}
+    monkeypatch.setattr(providers, "get_config", lambda: cfg)
+    monkeypatch.setattr(config, "get_config", lambda: cfg)
+
+
 def test_get_quota_stats_forwards_provider_query_and_bearer_auth(monkeypatch):
     _set_llm_proxy_config(
         monkeypatch,
@@ -124,22 +130,24 @@ def test_post_quota_stats_forwards_validated_body(monkeypatch):
 
 def test_get_quota_stats_uses_custom_provider_authority_and_strips_duplicate_v1(monkeypatch):
     monkeypatch.setattr(
-        config,
+        providers,
         "get_config",
         lambda: {
             "custom_providers": [
                 {
                     "name": "llm-proxy",
                     "base_url": "https://llm-proxy.example.test/v1",
-                    "key_env": "ISSUE_5033_LLM_PROXY_KEY",
                 }
             ]
         },
     )
     monkeypatch.setattr(
-        config,
-        "_thread_local_env_value",
-        lambda name: "server-held-secret" if name == "ISSUE_5033_LLM_PROXY_KEY" else "",
+        providers,
+        "resolve_custom_provider_connection",
+        lambda provider_id: (
+            "server-held-secret",
+            "https://llm-proxy.example.test/v1",
+        ) if provider_id == "custom:llm-proxy" else (None, None),
     )
     seen = {}
 
@@ -166,6 +174,37 @@ def test_get_quota_stats_uses_custom_provider_authority_and_strips_duplicate_v1(
         "data": None,
         "timeout": 3.0,
     }
+
+
+def test_get_quota_stats_rejects_unrelated_single_custom_provider(monkeypatch):
+    _set_custom_llm_proxy_config(
+        monkeypatch,
+        [
+            {
+                "name": "unrelated",
+                "base_url": "https://unrelated.example.test/v1",
+                "api_key": "sk-unrelated-secret",
+            }
+        ],
+    )
+    called = False
+
+    def explode(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("network should not be reached for unrelated custom providers")
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", explode)
+
+    status, payload = providers.get_llm_proxy_quota_stats(query={"provider": ["anthropic"]})
+
+    assert status == 503
+    assert payload == {
+        "ok": False,
+        "error": "llm_proxy_quota_stats_unconfigured",
+        "message": "llm-proxy quota stats is not configured.",
+    }
+    assert called is False
 
 
 def test_post_quota_stats_rejects_invalid_action_or_scope_without_network(monkeypatch):

--- a/tests/test_extension_llm_proxy_quota_stats.py
+++ b/tests/test_extension_llm_proxy_quota_stats.py
@@ -151,6 +151,39 @@ def test_post_quota_stats_rejects_invalid_action_or_scope_without_network(monkey
     assert called is False
 
 
+def test_post_quota_stats_null_body_fails_before_network(monkeypatch):
+    _set_llm_proxy_config(
+        monkeypatch,
+        base_url="https://llm-proxy.example.test",
+        api_key="server-held-secret",
+    )
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda handler: None)
+    monkeypatch.setattr(routes, "bad", lambda handler, message, status=400: {
+        "message": message,
+        "status": status,
+    })
+    called = False
+
+    def explode(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("network should not be reached for null llm-proxy quota requests")
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", explode)
+
+    result = routes.handle_post(
+        SimpleNamespace(headers={}, rfile=BytesIO()),
+        SimpleNamespace(path="/api/extensions/proxies/llm-proxy/quota-stats"),
+    )
+
+    assert result == {
+        "message": "Invalid llm-proxy quota-stats request.",
+        "status": 400,
+    }
+    assert called is False
+
+
 def test_quota_stats_route_reports_unconfigured_proxy_without_secret_leak(monkeypatch):
     monkeypatch.setattr(
         providers,

--- a/tests/test_issue3957_profile_providers_models.py
+++ b/tests/test_issue3957_profile_providers_models.py
@@ -383,6 +383,15 @@ def test_providers_and_models_routes_wrap_in_profile_env():
     assert "_get_models_cache_path" in config_src
 
 
+def test_extension_quota_route_uses_profile_env_wrapper():
+    """The fixed llm-proxy bridge also runs inside the active-profile wrapper."""
+    routes_src = Path(profiles.__file__).resolve().parent.joinpath("routes.py").read_text(
+        encoding="utf-8"
+    )
+    needle = 'profile_env_for_active_request_readonly("/api/extensions/proxies/llm-proxy/quota-stats"'
+    assert routes_src.count(needle) == 2
+
+
 def test_models_sync_rebuild_uses_legacy_mirrored_env(monkeypatch, tmp_path):
     """The budget<=0 sync rebuild still mirrors profile env into os.environ."""
     base = tmp_path / ".hermes"

--- a/tests/test_provider_quota_status.py
+++ b/tests/test_provider_quota_status.py
@@ -1208,6 +1208,15 @@ def test_provider_quota_route_is_registered():
     assert "get_provider_quota(provider_id, refresh=refresh)" in routes
 
 
+def test_extension_quota_stats_route_is_registered_and_distinct():
+    """The extension bridge must stay fixed and separate from /api/provider/quota."""
+    routes = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+    assert 'parsed.path == "/api/extensions/proxies/llm-proxy/quota-stats"' in routes
+    assert 'profile_env_for_active_request_readonly("/api/extensions/proxies/llm-proxy/quota-stats"' in routes
+    assert 'parsed.path == "/api/provider/quota"' in routes
+    assert "get_llm_proxy_quota_stats" in routes
+
+
 def test_provider_quota_card_is_rendered_in_providers_panel():
     """The Providers panel should show active provider quota/status before cards."""
     panels = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")


### PR DESCRIPTION
## Thinking Path

- Extensions already have browser-session authority, but the docs deliberately stop short of arbitrary backend proxying, so a quota panel still has no same-origin path to a remote or credentialed llm-proxy.
- `/api/provider/quota` was the obvious reuse candidate, but it returns a provider-card payload rather than the llm-proxy quota document or its reload contract.
- The narrow fix is one core-owned authenticated bridge for one fixed upstream path, `/v1/quota-stats`, under the extension namespace.

## What Changed

- `api/providers.py`: add a dedicated llm-proxy quota-stats helper that reuses the existing named `custom:llm-proxy` connection authority when present, keeps the bridge scoped to that exact provider, blocks upstream redirects on the credentialed request, bounds the upstream response size, validates supported GET and POST inputs, redacts echoed bearer material from successful JSON, and sanitizes failures.
- `api/routes.py`: add authenticated `GET` and `POST` handling for `/api/extensions/proxies/llm-proxy/quota-stats`, wrapped in `profile_env_for_active_request_readonly(...)`, while keeping the GET query parsing aligned with the rest of `routes.py`.
- `docs/EXTENSIONS.md`: document the exact extension-facing quota-stats contract and keep the no-generic-proxy boundary explicit.
- `tests/test_extension_llm_proxy_quota_stats.py`, `tests/test_issue3957_profile_providers_models.py`, and `tests/test_provider_quota_status.py`: cover forwarding, oversized-response rejection, validation, named custom-provider reuse, rejection of unrelated custom providers, profile isolation, route guards, and negative-space paths.

## Why It Matters

Extension authors can ship a reviewed quota panel without exposing llm-proxy credentials in browser code and without turning WebUI into a general-purpose extension proxy. The review surface stays narrow and the server-held bearer now stays server-side even if upstream redirects or echoes secrets.

## Verification

```text
python -m pytest tests/test_extension_llm_proxy_quota_stats.py tests/test_issue3957_profile_providers_models.py tests/test_provider_quota_status.py -v --timeout=60
```

Focused local rerun passed, `87 passed`.

Full-suite CI context: `python -m pytest tests/ -v --timeout=60`.

## Upstream

Closes #5033.

This route follows the maintainer's 2026-06-27 scoping note that narrowed the issue to a fixed allowlisted quota-stats bridge rather than a generic extension proxy, and the 2026-06-29 follow-up closes the reproduced redirect and echo leak paths on that bridge.

## Model Used

GPT 5.5 via Codex CLI
