### PR TITLE
fix(profiles): show active profile workspace on blank new-chat boot (#5169)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -11262,12 +11262,26 @@ def handle_get(handler, parsed) -> bool:
         )
 
         active_profile_name = get_active_profile_name()
+        # Resolve the ACTIVE PROFILE's configured workspace so a cold boot with a
+        # profile cookie shows the right composer workspace chip on a blank
+        # new-chat page (#5169). get_last_workspace() is already profile-scoped:
+        # server.py sets the per-request profile from the hermes_profile cookie
+        # before this handler runs, and it resolves in the same priority order as
+        # POST /api/profile/switch ({profile_home}/webui_state/last_workspace.txt
+        # -> config.yaml workspace/default_workspace -> terminal.cwd -> process
+        # default). Reuse it rather than duplicating that resolution here.
+        default_workspace = None
+        try:
+            default_workspace = get_last_workspace()
+        except Exception:
+            logger.debug("Failed to resolve profile default workspace for /api/profile/active")
         return j(
             handler,
             {
                 "name": active_profile_name,
                 "path": str(get_active_hermes_home()),
                 "is_default": _is_root_profile(active_profile_name),
+                "default_workspace": default_workspace,
             },
         )
 

--- a/static/boot.js
+++ b/static/boot.js
@@ -2609,7 +2609,18 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
       const p = await loadActiveProfile();
       if (p && typeof p === 'object' && typeof p.name === 'string') {
         _bootActiveProfileUnauthRedirectBudget.clearAttempted(markerStorage);
-        return {status: 'resolved', profile: p.name || 'default', isDefault: !!p.is_default};
+        return {
+          status: 'resolved',
+          profile: p.name || 'default',
+          isDefault: !!p.is_default,
+          // Profile-scoped workspace resolved by the backend (#5169). When set,
+          // this OVERRIDES the global value sourced from GET /api/settings so a
+          // cold boot with a profile cookie shows the active profile's configured
+          // workspace on the blank new-chat composer chip + inherit chain.
+          defaultWorkspace: (typeof p.default_workspace === 'string' && p.default_workspace)
+            ? p.default_workspace
+            : null,
+        };
       }
       if (p === undefined && !alreadyAttempted) {
         if (_bootActiveProfileUnauthRedirectBudget.spendOnRedirect(markerStorage)) {
@@ -2638,6 +2649,16 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
   if (activeProfileState.status === 'recovery-redirect') return;
   S.activeProfile = activeProfileState.profile;
   S.activeProfileIsDefault = activeProfileState.isDefault;
+  // #5169: the active profile's workspace OVERRIDES the global default that was
+  // sourced from GET /api/settings above. GET /api/settings only ever returns the
+  // global settings.json default (it must NOT carry a profile workspace — the
+  // settings UI would POST it back and clobber the global default for all
+  // profiles), so on a cold load with a named-profile cookie the blank new-chat
+  // composer chip and the newSession inherit chain would otherwise show the wrong
+  // workspace (or 'No workspace'). Apply the profile-scoped value when present.
+  if (activeProfileState.defaultWorkspace) {
+    S._profileDefaultWorkspace = activeProfileState.defaultWorkspace;
+  }
   applyBotName();
   // Update profile chip label immediately
   const profileLabel=$('profileChipLabel');

--- a/static/panels.js
+++ b/static/panels.js
@@ -5196,7 +5196,10 @@ function toggleWsDropdown(){
   else{
     closeProfileDropdown(); // close profile dropdown if open
     loadWorkspaceList().then(data=>{
-      renderWorkspaceDropdownInto(dd, data.workspaces, S.session?S.session.workspace:'');
+      // #5169: on a blank new-chat page (no active session) highlight the active
+      // profile's configured workspace, falling back to the server's last
+      // workspace, so the dropdown's active row matches the composer chip.
+      renderWorkspaceDropdownInto(dd, data.workspaces, S.session?.workspace||S._profileDefaultWorkspace||data.last);
       dd.classList.add('open');
     });
   }
@@ -5216,7 +5219,10 @@ function toggleComposerWsDropdown(){
     if(typeof closeModelDropdown==='function') closeModelDropdown();
     if(typeof closeReasoningDropdown==='function') closeReasoningDropdown();
     loadWorkspaceList().then(data=>{
-      renderWorkspaceDropdownInto(dd, data.workspaces, S.session?S.session.workspace:'');
+      // #5169: on a blank new-chat page (no active session) highlight the active
+      // profile's configured workspace, falling back to the server's last
+      // workspace, so the dropdown's active row matches the composer chip.
+      renderWorkspaceDropdownInto(dd, data.workspaces, S.session?.workspace||S._profileDefaultWorkspace||data.last);
       dd.classList.add('open');
       _positionComposerWsDropdown();
       if(chip) chip.classList.add('active');

--- a/tests/test_issue5169_profile_active_default_workspace.py
+++ b/tests/test_issue5169_profile_active_default_workspace.py
@@ -22,12 +22,8 @@ and the real filesystem resolution from a named profile's last_workspace.txt.
 
 from __future__ import annotations
 
-import os
 from types import SimpleNamespace
-from unittest import mock
 from urllib.parse import urlparse
-
-import pytest
 
 import api.profiles as profiles
 import api.routes as routes

--- a/tests/test_issue5169_profile_active_default_workspace.py
+++ b/tests/test_issue5169_profile_active_default_workspace.py
@@ -1,0 +1,165 @@
+"""Regression test for #5169 — GET /api/profile/active must return a
+profile-scoped ``default_workspace``.
+
+Bug: a blank new-chat page showed the wrong workspace (or "No workspace") for a
+named profile on cold load. Boot only ever sourced ``S._profileDefaultWorkspace``
+from GET /api/settings, which returns the GLOBAL default — never the active
+profile's configured workspace. The composer workspace chip therefore diverged
+from the workspace a new chat would actually inherit for that profile.
+
+Fix: GET /api/profile/active now includes ``default_workspace``, resolved with
+the SAME profile-scoped priority used by POST /api/profile/switch — reusing
+``api.workspace.get_last_workspace()`` (which is already keyed off the
+per-request hermes_profile cookie via the thread-local):
+    {profile_home}/webui_state/last_workspace.txt
+      -> config.yaml workspace / default_workspace
+      -> terminal.cwd
+      -> process default
+
+These tests cover both the wiring (the endpoint surfaces the resolver's value)
+and the real filesystem resolution from a named profile's last_workspace.txt.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest import mock
+from urllib.parse import urlparse
+
+import pytest
+
+import api.profiles as profiles
+import api.routes as routes
+import api.workspace as workspace
+import api.config as config_mod
+
+
+def _capture_j(monkeypatch):
+    """Patch routes.j to capture the JSON payload instead of writing a response."""
+    captured = {}
+
+    def fake_j(_handler, payload, status=200, **_kwargs):
+        captured["status"] = status
+        captured["payload"] = payload
+        return captured
+
+    monkeypatch.setattr(routes, "j", fake_j)
+    return captured
+
+
+def test_profile_active_includes_default_workspace_from_resolver(monkeypatch):
+    """The endpoint must surface whatever the profile-scoped resolver returns.
+
+    This pins the wiring: ``default_workspace`` is populated from
+    ``api.workspace.get_last_workspace()`` (imported into routes at module level),
+    the very helper POST /api/profile/switch resolution is built on — not from a
+    duplicated, divergent code path.
+    """
+    captured = _capture_j(monkeypatch)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "work")
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: "/home/u/.hermes/profiles/work")
+    monkeypatch.setattr(profiles, "_is_root_profile", lambda name: name in ("default", ""))
+    # The resolver is the single source of truth for the workspace value.
+    monkeypatch.setattr(routes, "get_last_workspace", lambda: "/srv/projects/work")
+
+    routes.handle_get(SimpleNamespace(), urlparse("/api/profile/active"))
+
+    assert captured["status"] == 200
+    payload = captured["payload"]
+    assert payload["name"] == "work"
+    assert payload["is_default"] is False
+    assert payload["default_workspace"] == "/srv/projects/work", (
+        "GET /api/profile/active must surface the profile-scoped workspace from "
+        "get_last_workspace() so the blank new-chat composer chip shows it (#5169)"
+    )
+
+
+def test_profile_active_default_workspace_resolves_from_named_profile(monkeypatch, tmp_path):
+    """End-to-end: a named profile's last_workspace.txt drives default_workspace.
+
+    Mirrors the real boot path — the per-request hermes_profile cookie sets the
+    thread-local profile (set_request_profile), so get_last_workspace() reads the
+    target profile's {home}/webui_state/last_workspace.txt rather than the global
+    default.
+    """
+    # ── Single-user layout: base ~/.hermes with a named 'work' profile ──
+    base_home = tmp_path / ".hermes"
+    profile_home = base_home / "profiles" / "work"
+    for subdir in ("memories", "sessions", "skills", "webui_state"):
+        (profile_home / subdir).mkdir(parents=True, exist_ok=True)
+
+    # The profile's previously-chosen workspace (top resolution priority).
+    workspace_dir = tmp_path / "code" / "work-project"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    resolved_ws = str(workspace_dir.resolve())
+    (profile_home / "webui_state" / "last_workspace.txt").write_text(
+        resolved_ws, encoding="utf-8"
+    )
+
+    captured = _capture_j(monkeypatch)
+
+    # Point the profile machinery at our temp base home and force normal
+    # multi-profile mode (no isolated opt-in) so the named profile resolves
+    # to {base}/profiles/work.
+    monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", base_home)
+    monkeypatch.delenv("HERMES_WEBUI_ISOLATED_PROFILE", raising=False)
+    monkeypatch.setattr(profiles, "_INITIAL_ISOLATED_PROFILE_OPT_IN", "")
+    # Defensive: keep resolution hermetic w.r.t. the test runner's real config —
+    # a remote terminal backend would otherwise reject the local last_workspace.
+    monkeypatch.setattr(workspace, "_remote_terminal_cwd", lambda: None)
+
+    # Simulate the request carrying a hermes_profile=work cookie.
+    profiles.set_request_profile("work")
+    try:
+        routes.handle_get(SimpleNamespace(), urlparse("/api/profile/active"))
+    finally:
+        profiles.clear_request_profile()
+
+    payload = captured["payload"]
+    assert payload["name"] == "work"
+    assert payload["is_default"] is False
+    assert payload["default_workspace"] == resolved_ws, (
+        "default_workspace must resolve from the active profile's "
+        "webui_state/last_workspace.txt, not the global/default workspace (#5169)"
+    )
+
+
+def test_profile_active_default_workspace_falls_back_to_config_workspace(monkeypatch, tmp_path):
+    """With no last_workspace.txt, config.yaml `workspace` drives the value.
+
+    This exercises the second tier of the shared resolution priority used by
+    POST /api/profile/switch.
+    """
+    base_home = tmp_path / ".hermes"
+    profile_home = base_home / "profiles" / "work"
+    (profile_home / "webui_state").mkdir(parents=True, exist_ok=True)
+
+    cfg_workspace = tmp_path / "cfg-workspace"
+    cfg_workspace.mkdir(parents=True, exist_ok=True)
+    resolved_cfg_ws = str(cfg_workspace.resolve())
+
+    captured = _capture_j(monkeypatch)
+    monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", base_home)
+    monkeypatch.delenv("HERMES_WEBUI_ISOLATED_PROFILE", raising=False)
+    monkeypatch.setattr(profiles, "_INITIAL_ISOLATED_PROFILE_OPT_IN", "")
+    monkeypatch.setattr(workspace, "_remote_terminal_cwd", lambda: None)
+    # Neutralize the global last_workspace.txt fallback so this test exercises the
+    # config.yaml tier deterministically regardless of the runner's real state dir.
+    monkeypatch.setattr(workspace, "_GLOBAL_LW_FILE", tmp_path / "nonexistent-global-lw.txt")
+    # No last_workspace.txt on disk -> resolver consults the profile config.yaml.
+    # _profile_default_workspace() does `from api.config import get_config`, so the
+    # patch must land on api.config (the lookup happens at call time).
+    monkeypatch.setattr(config_mod, "get_config", lambda: {"workspace": resolved_cfg_ws})
+
+    profiles.set_request_profile("work")
+    try:
+        routes.handle_get(SimpleNamespace(), urlparse("/api/profile/active"))
+    finally:
+        profiles.clear_request_profile()
+
+    payload = captured["payload"]
+    assert payload["default_workspace"] == resolved_cfg_ws, (
+        "default_workspace must fall back to config.yaml `workspace` when no "
+        "last_workspace.txt exists (mirrors POST /api/profile/switch priority, #5169)"
+    )


### PR DESCRIPTION
## Summary

Fixes #5169 — a blank new-chat page showed the **wrong workspace (or "No workspace")** for named profiles on cold load with a profile cookie set. The composer workspace chip and the new-session inherit chain now reflect the **active profile's** configured working directory instead of the global default.

### Root cause

On boot, `static/boot.js` only ever sourced `S._profileDefaultWorkspace` from `GET /api/settings`, which returns the **global** `settings.json` default — it never carries a per-profile workspace (and must not: the settings UI POSTs that value back, which would clobber the global default for *all* profiles). So a cold load under a named-profile cookie displayed the global default (or nothing), even though `POST /api/profile/switch` already resolves the correct profile-scoped workspace. The two paths diverged.

### Fix (per the issue's proposal)

1. **Backend** — `GET /api/profile/active` now returns a profile-scoped `default_workspace`, resolved by reusing the existing `api.workspace.get_last_workspace()` helper. That helper is already keyed off the per-request `hermes_profile` cookie (via the thread-local set in `server.py`) and resolves in the **same priority order** `POST /api/profile/switch` uses:
   `{profile_home}/webui_state/last_workspace.txt` → config.yaml `workspace`/`default_workspace` → `terminal.cwd` → process default. No resolution logic was duplicated.
2. **Frontend** — after the `GET /api/profile/active` call on boot, `static/boot.js` now sets `S._profileDefaultWorkspace = p.default_workspace` when present. This **overrides** the value previously taken from `GET /api/settings`, fixing both the blank-page composer chip display and the `newSession` inherit chain.
3. **`GET /api/settings` is left untouched** — profile defaults and global settings stay separated, exactly so the settings UI cannot POST a profile workspace back and clobber the global `settings.json` default.
4. **Follow-up (same PR)** — `renderWorkspaceDropdownInto` callers now pass `S.session?.workspace || S._profileDefaultWorkspace || data.last` so the dropdown's active row matches the composer chip on a blank page.

## Testing

- **Backend:** new `tests/test_issue5169_profile_active_default_workspace.py` (3 tests) asserts `GET /api/profile/active` returns `default_workspace`: that it surfaces the resolver's value, that it resolves end-to-end from a named profile's `webui_state/last_workspace.txt`, and that it falls back to config.yaml `workspace`. Run via `./scripts/test.sh` — **3 passed**.
- Re-ran related existing suites (`test_profiles_route_endpoint`, `test_profile_default_workspace_823`, `test_issue4755_profile_default_workspace`) — **13 passed**.
- **Frontend:** `node --check static/boot.js` and `node --check static/panels.js` pass; `python3 scripts/scope_undef_gate.py .` is **CLEAN**.

## Files changed

- `api/routes.py` — add `default_workspace` to the `GET /api/profile/active` payload via `get_last_workspace()`.
- `static/boot.js` — apply the profile-scoped workspace from `/api/profile/active` (overrides the `/api/settings` value).
- `static/panels.js` — workspace dropdown active-row fallback to the profile default on blank pages.
- `tests/test_issue5169_profile_active_default_workspace.py` — new backend regression tests.
