### PR TITLE
fix(webui): profile default workspace on boot (#5169)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -11200,6 +11200,7 @@ def handle_get(handler, parsed) -> bool:
                 "name": active_profile_name,
                 "path": str(get_active_hermes_home()),
                 "is_default": _is_root_profile(active_profile_name),
+                "default_workspace": get_last_workspace(),
             },
         )
 

--- a/static/boot.js
+++ b/static/boot.js
@@ -2609,6 +2609,7 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
       const p = await loadActiveProfile();
       if (p && typeof p === 'object' && typeof p.name === 'string') {
         _bootActiveProfileUnauthRedirectBudget.clearAttempted(markerStorage);
+        if (p.default_workspace) S._profileDefaultWorkspace = p.default_workspace;
         return {status: 'resolved', profile: p.name || 'default', isDefault: !!p.is_default};
       }
       if (p === undefined && !alreadyAttempted) {

--- a/static/panels.js
+++ b/static/panels.js
@@ -5196,7 +5196,7 @@ function toggleWsDropdown(){
   else{
     closeProfileDropdown(); // close profile dropdown if open
     loadWorkspaceList().then(data=>{
-      renderWorkspaceDropdownInto(dd, data.workspaces, S.session?S.session.workspace:'');
+      renderWorkspaceDropdownInto(dd, data.workspaces, S.session?.workspace||S._profileDefaultWorkspace||data.last||'');
       dd.classList.add('open');
     });
   }
@@ -5216,7 +5216,7 @@ function toggleComposerWsDropdown(){
     if(typeof closeModelDropdown==='function') closeModelDropdown();
     if(typeof closeReasoningDropdown==='function') closeReasoningDropdown();
     loadWorkspaceList().then(data=>{
-      renderWorkspaceDropdownInto(dd, data.workspaces, S.session?S.session.workspace:'');
+      renderWorkspaceDropdownInto(dd, data.workspaces, S.session?.workspace||S._profileDefaultWorkspace||data.last||'');
       dd.classList.add('open');
       _positionComposerWsDropdown();
       if(chip) chip.classList.add('active');

--- a/tests/test_profile_default_workspace_823.py
+++ b/tests/test_profile_default_workspace_823.py
@@ -132,3 +132,31 @@ class TestBlankPageAfterSessionDelete:
         assert '_profileDefaultWorkspace' in fn, (
             "promptNewFile must read S._profileDefaultWorkspace (must persist after newSession)"
         )
+
+
+class TestProfileActiveDefaultWorkspaceApi:
+    """GET /api/profile/active must expose profile-scoped default_workspace (#5169)."""
+
+    def test_profile_active_includes_default_workspace(self, monkeypatch):
+        import api.profiles as profiles
+        import api.routes as routes
+
+        expected_ws = "/tmp/my-profile-workspace"
+
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "work")
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: "/home/.hermes/profiles/work")
+        monkeypatch.setattr(profiles, "_is_root_profile", lambda _n: False)
+        monkeypatch.setattr(routes, "get_last_workspace", lambda: expected_ws)
+        monkeypatch.setattr(
+            routes,
+            "j",
+            lambda _handler, payload, status=200: {"status": status, "payload": payload},
+        )
+
+        from types import SimpleNamespace
+        from urllib.parse import urlparse
+
+        response = routes.handle_get(SimpleNamespace(), urlparse("/api/profile/active"))
+
+        assert response["payload"]["default_workspace"] == expected_ws
+        assert response["payload"]["name"] == "work"

--- a/tests/test_workspace_blank_page_fix.py
+++ b/tests/test_workspace_blank_page_fix.py
@@ -71,6 +71,25 @@ class TestBootJsProfileDefaultWorkspace:
             "S._profileDefaultWorkspace must be set in the same settings-fetch block"
         )
 
+    def test_boot_sets_profile_default_workspace_from_profile_active(self):
+        """Profile active bootstrap must override settings with p.default_workspace (#5169)."""
+        src = read('static/boot.js')
+        active_idx = src.find("api('/api/profile/active'")
+        assert active_idx != -1, "/api/profile/active fetch not found in boot.js"
+        block = src[active_idx:active_idx + 1200]
+        assert 'p.default_workspace' in block, (
+            "boot.js must read default_workspace from /api/profile/active response"
+        )
+        assert '_profileDefaultWorkspace' in block, (
+            "boot.js must assign S._profileDefaultWorkspace from profile active bootstrap"
+        )
+        assert re.search(
+            r"if\s*\(\s*p\.default_workspace\s*\)\s*S\._profileDefaultWorkspace\s*=\s*p\.default_workspace",
+            block,
+        ), (
+            "boot.js must set S._profileDefaultWorkspace when p.default_workspace is present"
+        )
+
 
 class TestPromptNewFileNoSession:
     """promptNewFile/promptNewFolder must auto-create a session on blank page."""
@@ -166,4 +185,19 @@ class TestWorkspaceSwitcherBlankPage:
         )
         assert '!hasSession && composerDropdown' not in fn, (
             "Regression guard: !hasSession for dropdown close must be removed"
+        )
+
+
+class TestWorkspaceDropdownBlankPageCurrentWs:
+    """Blank-page workspace dropdown must highlight profile default (#5169)."""
+
+    def test_render_workspace_dropdown_uses_profile_default_on_blank_page(self):
+        src = read('static/panels.js')
+        assert re.search(
+            r"renderWorkspaceDropdownInto\([^,]+,\s*[^,]+,\s*"
+            r"S\.session\?\.workspace\|\|S\._profileDefaultWorkspace\|\|data\.last\|\|''\)",
+            src,
+        ), (
+            "renderWorkspaceDropdownInto must use session, profile default, or data.last "
+            "as current workspace on blank page"
         )


### PR DESCRIPTION
Fixes #5169.

## Thinking Path

- Blank new-chat shows the workspace chip from `S._profileDefaultWorkspace` or session workspace; boot only set that from **global** `GET /api/settings`, while per-profile defaults live on `POST /api/profile/switch` and server `get_last_workspace()`.
- Merging profile workspace into `GET /api/settings` was rejected: settings save would POST the profile path back into global `settings.json` and clobber other profiles.
- Minimal fix: expose profile-scoped `default_workspace` on `GET /api/profile/active` and hydrate boot from that response after settings load.

## What Changed

- **`api/routes.py`:** `GET /api/profile/active` includes `default_workspace` from `get_last_workspace()`.
- **`static/boot.js`:** After resolving active profile, set `S._profileDefaultWorkspace` from `p.default_workspace` when present.
- **`static/panels.js`:** Workspace dropdown highlights `session.workspace || _profileDefaultWorkspace || data.last` on blank page.
- **Tests:** `test_profile_default_workspace_823.py` (API), `test_workspace_blank_page_fix.py` (boot + panels wiring).

No `CHANGELOG.md` edits.

## Why It Matters

Named profiles with a working directory different from the global WebUI default showed **No workspace** (or the wrong folder) on cold load until the user switched profiles again. `newSession()` could POST `workspace: null` while the server assigned a path server-side, leaving the composer chip out of sync.

## Verification

```bash
./scripts/test.sh tests/test_profile_default_workspace_823.py tests/test_workspace_blank_page_fix.py -q
```

23 passed locally. `hermes-webui-pr-gate` with the same scoped tests: pass (ruff diff clean).

**Manual:** Hard-reload with a named profile cookie whose `terminal.cwd` / `last_workspace` differs from global settings → blank new-chat should show the profile workspace on the chip; new conversation should send that workspace in `POST /api/session/new`.

## Risks / Follow-ups

- `default_workspace` on `/api/profile/active` follows the same resolution as switch/last-workspace (including stale `last_workspace.txt` vs `terminal.cwd`); homelab config hygiene is separate from this client/API fix.
- Saving global WebUI settings is unchanged; global `default_workspace` in `settings.json` is not overwritten by this path.

## Release note (for maintainers)

**Fixed:** Blank new-chat now shows the active profile’s default workspace after reload by returning `default_workspace` on `GET /api/profile/active` and applying it during boot.

## Model Used

- Provider: custom (llm-proxy) / Hermes developer profile
- Model: `x-ai/grok-composer-2.5-fast`
- AI disclosure: AI assisted implementation, tests, delegation, and this PR description.

Co-authored-by: b3nw <b3nw@users.noreply.github.com>