### PR TITLE
fix(updates): restart gateway after in-app agent update (#5156)

### DIFF
--- a/api/gateway_restart.py
+++ b/api/gateway_restart.py
@@ -100,7 +100,7 @@ def restart_active_profile_gateway(
             logger.error("Gateway service restart failed with code %s: %s", proc.returncode, stderr)
             return {
                 "status": "failed",
-                "message": f"Restart failed: {stderr or stdout or f'exit code {proc.returncode}'}",
+                "message": f"Restart failed: {stderr or stdout}",
                 "detail": stdout or stderr,
                 "returncode": proc.returncode,
             }

--- a/api/gateway_restart.py
+++ b/api/gateway_restart.py
@@ -1,0 +1,154 @@
+"""Helpers for restarting the active-profile Hermes gateway."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+from api.profiles import get_active_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_GATEWAY_RESTART_LOCK = threading.Lock()
+
+
+def _resolve_hermes_command() -> str:
+    """Resolve the CLI path used for active-profile gateway restarts."""
+    hermes_cmd = shutil.which("hermes")
+    if hermes_cmd:
+        return hermes_cmd
+
+    sibling = Path(sys.executable).parent / "hermes"
+    if sibling.exists():
+        return str(sibling)
+    return "hermes"
+
+
+def _consume_stream(stream) -> None:
+    """Drain a subprocess stream to prevent stdout/stderr pipe deadlocks."""
+    try:
+        while stream and stream.read(4096):
+            pass
+    except Exception:
+        pass
+
+
+def _release_lock() -> None:
+    try:
+        _GATEWAY_RESTART_LOCK.release()
+    except RuntimeError:
+        # The lock may already have been released by another path.
+        pass
+
+
+def restart_active_profile_gateway(
+    *,
+    quick_timeout_seconds: float = 2.0,
+    background_wait_seconds: float = 240.0,
+) -> dict:
+    """Run a non-blocking ``hermes gateway restart`` for the active profile.
+
+    Returns a short status dict with these values:
+    - completed: command finished quickly and succeeded.
+    - in_progress: command did not finish within ``quick_timeout_seconds``.
+    - failed: command finished quickly with non-zero exit status.
+    - busy: restart already in progress from another caller.
+    """
+    if not _GATEWAY_RESTART_LOCK.acquire(blocking=False):
+        return {
+            "status": "busy",
+            "message": "Restart already in progress. Please wait a moment and try again.",
+        }
+
+    try:
+        active_home = get_active_hermes_home()
+        env = os.environ.copy()
+        env["HERMES_HOME"] = str(active_home)
+        hermes_cmd = _resolve_hermes_command()
+
+        logger.info(
+            "Restarting gateway service via CLI command: %s gateway restart (HERMES_HOME=%s)",
+            hermes_cmd,
+            active_home,
+        )
+        proc = subprocess.Popen(
+            [hermes_cmd, "gateway", "restart"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+
+        try:
+            stdout, stderr = proc.communicate(timeout=quick_timeout_seconds)
+            _release_lock()
+            stdout = (stdout or "").strip()
+            stderr = (stderr or "").strip()
+            if proc.returncode == 0:
+                logger.info("Gateway service restarted successfully: %s", stdout)
+                return {
+                    "status": "completed",
+                    "message": "Gateway service restarted successfully",
+                    "detail": stdout or stderr,
+                }
+
+            logger.error("Gateway service restart failed with code %s: %s", proc.returncode, stderr)
+            return {
+                "status": "failed",
+                "message": f"Restart failed: {stderr or stdout or f'exit code {proc.returncode}'}",
+                "detail": stdout or stderr,
+                "returncode": proc.returncode,
+            }
+
+        except subprocess.TimeoutExpired:
+            logger.info(
+                "Gateway restart is taking longer than %.1fs (likely draining in-flight runs);"
+                " continuing in background",
+                quick_timeout_seconds,
+            )
+
+            threading.Thread(target=_consume_stream, args=(proc.stdout,), daemon=True).start()
+            threading.Thread(target=_consume_stream, args=(proc.stderr,), daemon=True).start()
+
+            def _wait_and_release() -> None:
+                try:
+                    proc.wait(timeout=background_wait_seconds)
+                except subprocess.TimeoutExpired:
+                    logger.error(
+                        "Gateway restart process timed out after %.1fs. Terminating process.",
+                        background_wait_seconds,
+                    )
+                    try:
+                        proc.terminate()
+                        try:
+                            proc.wait(timeout=5.0)
+                        except subprocess.TimeoutExpired:
+                            proc.kill()
+                            try:
+                                proc.wait(timeout=5.0)
+                            except subprocess.TimeoutExpired:
+                                logger.error(
+                                    "Gateway restart process refused to die even after SIGKILL.",
+                                )
+                    except Exception:
+                        logger.exception("Failed to terminate timed out gateway restart process.")
+                finally:
+                    _release_lock()
+
+            threading.Thread(target=_wait_and_release, daemon=True).start()
+            return {
+                "status": "in_progress",
+                "message": "Gateway service restart initiated (in progress)",
+            }
+    except Exception as exc:
+        _release_lock()
+        logger.exception("Failed to run gateway restart command")
+        return {
+            "status": "failed",
+            "message": f"Internal error running restart: {type(exc).__name__}: {exc}",
+        }

--- a/api/routes.py
+++ b/api/routes.py
@@ -43,6 +43,7 @@ from api.session_events import (
     subscribe_session_events,
     unsubscribe_session_events,
 )
+from api.gateway_restart import restart_active_profile_gateway
 
 logger = logging.getLogger(__name__)
 
@@ -9652,120 +9653,28 @@ def _handle_shutdown(handler) -> bool:
     return True
 
 
-_RESTART_LOCK = threading.Lock()
-
-
 def _handle_health_restart(handler) -> bool:
     """Restart the Hermes messaging gateway service."""
-    # Acquire the lock to prevent concurrent restart invocations
-    if not _RESTART_LOCK.acquire(blocking=False):
-        logger.warning("Gateway restart already in progress, rejecting concurrent request.")
+    outcome = restart_active_profile_gateway()
+
+    if outcome.get("status") == "completed":
+        return j(handler, {"ok": True, "message": "Gateway service restarted successfully"})
+
+    if outcome.get("status") == "in_progress":
+        return j(handler, {"ok": True, "message": "Gateway service restart initiated (in progress)"})
+
+    if outcome.get("status") == "busy":
         return j(
             handler,
-            {"ok": False, "error": "Restart already in progress. Please wait a moment and try again."},
-            status=429
+            {"ok": False, "error": outcome.get("message", "Restart already in progress. Please wait a moment and try again.")},
+            status=429,
         )
 
-    lock_released = False
-    try:
-        # 1. Resolve HERMES_HOME for the active profile
-        active_home = get_active_hermes_home()
-
-        # 2. Build the environment dictionary with the correct HERMES_HOME
-        env = os.environ.copy()
-        env["HERMES_HOME"] = str(active_home)
-
-        # 3. Resolve the path to the hermes CLI binary
-        hermes_cmd = shutil.which("hermes")
-        if not hermes_cmd:
-            sys_exe = Path(sys.executable)
-            sibling = sys_exe.parent / "hermes"
-            if sibling.exists():
-                hermes_cmd = str(sibling)
-            else:
-                hermes_cmd = "hermes"
-
-        # 4. Run the restart command
-        logger.info("Restarting gateway service via CLI command: %s gateway restart (HERMES_HOME=%s)", hermes_cmd, active_home)
-        
-        proc = subprocess.Popen(
-            [hermes_cmd, "gateway", "restart"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            env=env
-        )
-        try:
-            # Wait up to 2.0 seconds for the restart command to complete quickly
-            stdout, stderr = proc.communicate(timeout=2.0)
-            # Since it finished quickly, we can release the lock now
-            _RESTART_LOCK.release()
-            lock_released = True
-
-            if proc.returncode == 0:
-                logger.info("Gateway service restarted successfully: %s", stdout)
-                return j(handler, {"ok": True, "message": "Gateway service restarted successfully"})
-            else:
-                logger.error("Gateway service restart failed with code %d: %s", proc.returncode, stderr)
-                return j(
-                    handler,
-                    {"ok": False, "error": f"Restart failed: {stderr.strip() or stdout.strip()}"},
-                    status=500
-                )
-        except subprocess.TimeoutExpired:
-            # If the process doesn't finish within 2 seconds, it is likely draining
-            # in-flight agent runs. We let it continue running in the background.
-            logger.info("Gateway restart is taking longer than 2.0s (likely draining in-flight runs). Letting it run in the background.")
-
-            # Start background threads to consume the stdout/stderr streams to prevent
-            # the child process from blocking on pipe buffer limits when printing logs.
-            import threading
-
-            def consume_stream(stream):
-                try:
-                    while stream.read(4096):
-                        pass
-                except Exception:
-                    pass
-
-            def wait_and_release():
-                try:
-                    proc.wait(timeout=240.0)
-                except subprocess.TimeoutExpired:
-                    logger.error("Gateway restart process timed out after 240.0s. Terminating process.")
-                    try:
-                        proc.terminate()
-                        try:
-                            proc.wait(timeout=5.0)
-                        except subprocess.TimeoutExpired:
-                            proc.kill()
-                            try:
-                                proc.wait(timeout=5.0)
-                            except subprocess.TimeoutExpired:
-                                logger.error("Gateway restart process refused to die even after SIGKILL.")
-                    except Exception as e:
-                        logger.exception("Failed to terminate timed out gateway restart process: %s", e)
-                finally:
-                    try:
-                        _RESTART_LOCK.release()
-                    except RuntimeError:
-                        # Already released or similar
-                        pass
-
-            threading.Thread(target=consume_stream, args=(proc.stdout,), daemon=True).start()
-            threading.Thread(target=consume_stream, args=(proc.stderr,), daemon=True).start()
-            # This thread will release the lock when the child process exits
-            threading.Thread(target=wait_and_release, daemon=True).start()
-            
-            # Lock will be released by wait_and_release thread
-            lock_released = True
-
-            return j(handler, {"ok": True, "message": "Gateway service restart initiated (in progress)"})
-    except Exception as exc:
-        if not lock_released:
-            _RESTART_LOCK.release()
-        logger.exception("Failed to run gateway restart command")
-        return j(handler, {"ok": False, "error": f"Internal error running restart: {type(exc).__name__}: {exc}"}, status=500)
+    return j(
+        handler,
+        {"ok": False, "error": outcome.get("message", "Internal error running restart")},
+        status=500,
+    )
 
 
 def _serve_manifest(handler) -> bool:

--- a/api/updates.py
+++ b/api/updates.py
@@ -23,6 +23,7 @@ from collections import OrderedDict
 from pathlib import Path
 from urllib.parse import urlparse
 
+from api.gateway_restart import restart_active_profile_gateway
 from api.config import REPO_ROOT, STREAMS, STREAMS_LOCK
 
 logger = logging.getLogger(__name__)
@@ -1245,6 +1246,38 @@ def _schedule_restart(delay: float = 2.0) -> None:
     threading.Thread(target=_do, daemon=True).start()
 
 
+def _ensure_gateway_restart_for_agent_update() -> tuple[bool, dict]:
+    """Run the active-profile gateway restart when agent checkout changed.
+
+    Returns:
+        (ok, restart_payload) where:
+        - ok is False when restart did not complete and callers must abort success.
+        - restart_payload contains helper status fields for response shaping.
+    """
+    restart_result = restart_active_profile_gateway()
+    status = str(restart_result.get("status") or "")
+    if status in {"completed", "in_progress"}:
+        return True, restart_result
+    return False, restart_result
+
+
+def _agent_gateway_restart_failure_message(target: str, restart_result: dict) -> str:
+    if not isinstance(restart_result, dict):
+        return (
+            f'{target} updated, but gateway restart did not complete. '
+            'Run `hermes gateway restart` manually.'
+        )
+    if restart_result.get("message"):
+        return (
+            f'{target} updated, but gateway restart did not complete: '
+            f'{restart_result["message"]}. Run `hermes gateway restart` manually.'
+        )
+    return (
+        f'{target} updated, but gateway restart did not complete. '
+        'Run `hermes gateway restart` manually.'
+    )
+
+
 def apply_force_update(target: str) -> dict:
     """Force-reset the target repo to the latest remote HEAD.
 
@@ -1316,14 +1349,27 @@ def apply_force_update(target: str) -> dict:
         with _cache_lock:
             _update_cache['checked_at'] = 0
 
+        if target == 'agent':
+            gateway_ok, gateway_result = _ensure_gateway_restart_for_agent_update()
+            if not gateway_ok:
+                return {
+                    'ok': False,
+                    'message': _agent_gateway_restart_failure_message(target, gateway_result),
+                    'target': target,
+                    'gateway_restart': gateway_result.get('status'),
+                }
+
         _schedule_restart()
 
-        return {
+        response = {
             'ok': True,
             'message': f'{target} force-updated to {compare_ref}',
             'target': target,
             'restart_scheduled': True,
         }
+        if target == 'agent':
+            response['gateway_restart'] = gateway_result.get('status')
+        return response
     finally:
         _apply_lock.release()
 
@@ -1532,8 +1578,18 @@ def _apply_update_inner(target):
                 }
             with _cache_lock:
                 _update_cache['checked_at'] = 0
+
+            if target == 'agent':
+                gateway_ok, gateway_result = _ensure_gateway_restart_for_agent_update()
+                if not gateway_ok:
+                    return {
+                        'ok': False,
+                        'message': _agent_gateway_restart_failure_message(target, gateway_result),
+                        'target': target,
+                        'gateway_restart': gateway_result.get('status'),
+                    }
             _schedule_restart()
-            return {
+            response = {
                 'ok': True,
                 'message': (
                     f'{target} updated to the latest version. Your local '
@@ -1547,10 +1603,23 @@ def _apply_update_inner(target):
                 'restart_scheduled': True,
                 'stash_conflict': True,
             }
+            if target == 'agent':
+                response['gateway_restart'] = gateway_result.get('status')
+            return response
 
     # Invalidate cache
     with _cache_lock:
         _update_cache['checked_at'] = 0
+
+    if target == 'agent':
+        gateway_ok, gateway_result = _ensure_gateway_restart_for_agent_update()
+        if not gateway_ok:
+            return {
+                'ok': False,
+                'message': _agent_gateway_restart_failure_message(target, gateway_result),
+                'target': target,
+                'gateway_restart': gateway_result.get('status'),
+            }
 
     # Schedule a self-restart so the updated code is loaded fresh.  A plain
     # git pull leaves stale Python modules in sys.modules — agent imports that
@@ -1571,9 +1640,12 @@ def _apply_update_inner(target):
             'entry may still be present because git stash drop failed.'
         )
 
-    return {
+    response = {
         'ok': True,
         'message': message,
         'target': target,
         'restart_scheduled': True,
     }
+    if target == 'agent':
+        response['gateway_restart'] = gateway_result.get('status')
+    return response

--- a/api/updates.py
+++ b/api/updates.py
@@ -1262,11 +1262,6 @@ def _ensure_gateway_restart_for_agent_update() -> tuple[bool, dict]:
 
 
 def _agent_gateway_restart_failure_message(target: str, restart_result: dict) -> str:
-    if not isinstance(restart_result, dict):
-        return (
-            f'{target} updated, but gateway restart did not complete. '
-            'Run `hermes gateway restart` manually.'
-        )
     if restart_result.get("message"):
         return (
             f'{target} updated, but gateway restart did not complete: '

--- a/static/ui.js
+++ b/static/ui.js
@@ -7813,8 +7813,8 @@ async function applyUpdates(){
   const forceBtnReset=$('btnForceUpdate');
   if(forceBtnReset){forceBtnReset.style.display='none';forceBtnReset.dataset.target='';}
   const targets=[];
-  if(window._updateData?.webui?.behind>0) targets.push('webui');
   if(window._updateData?.agent?.behind>0) targets.push('agent');
+  if(window._updateData?.webui?.behind>0) targets.push('webui');
   if(!targets.length){
     const msg='No update target selected. Refresh update status and retry.';
     if(errEl){errEl.textContent=msg;errEl.style.display='block';}

--- a/tests/test_health_restart.py
+++ b/tests/test_health_restart.py
@@ -1,232 +1,62 @@
-import io
-import subprocess
+"""Health route restart contract checks for /api/health/restart."""
+
 import types
-from api import routes
 
 
-class MockPopen:
-    def __init__(self, args, stdout=None, stderr=None, text=True, env=None):
-        self.args = args
-        self.env = env
-        self.returncode = 0
-        self.stdout = io.StringIO("✓ Service restarted")
-        self.stderr = io.StringIO("")
-        self._should_timeout = False
-        self._should_raise = False
-        self._wait_should_timeout = False
-        self.terminated = False
-        self.killed = False
+import api.routes as routes
 
-    def communicate(self, timeout=None):
-        if self._should_raise:
-            raise OSError("Subprocess execution failed")
-        if self._should_timeout:
-            raise subprocess.TimeoutExpired(self.args, timeout)
-        return self.stdout.getvalue(), self.stderr.getvalue()
 
-    def wait(self, timeout=None):
-        if self._wait_should_timeout:
-            raise subprocess.TimeoutExpired(self.args, timeout)
-        return self.returncode
-
-    def terminate(self):
-        self.terminated = True
-
-    def kill(self):
-        self.killed = True
+def _call_health_restart(monkeypatch, helper_result):
+    handler = types.SimpleNamespace()
+    responses = []
+    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
+    monkeypatch.setattr(routes, "restart_active_profile_gateway", lambda: dict(helper_result))
+    return routes._handle_health_restart(handler), responses
 
 
 def test_handle_health_restart_success(monkeypatch):
-    import threading
-    routes._RESTART_LOCK = threading.Lock()
-    # Mock profiles home path
-    monkeypatch.setattr("api.routes.get_active_hermes_home", lambda: "/mock/hermes/home")
-
-    # Mock shutil.which to find hermes CLI
-    monkeypatch.setattr("shutil.which", lambda cmd: "/mock/bin/hermes" if cmd == "hermes" else None)
-
-    called_args = []
-    called_env = {}
-
-    def mock_popen(args, stdout=None, stderr=None, text=True, env=None):
-        called_args.append(args)
-        called_env.update(env or {})
-        return MockPopen(args, stdout, stderr, text, env)
-
-    monkeypatch.setattr(subprocess, "Popen", mock_popen)
-
-    # Mock response helper j
-    responses = []
-    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
-
-    handler = types.SimpleNamespace()
-
-    # Call _handle_health_restart
-    result = routes._handle_health_restart(handler)
-
+    result, responses = _call_health_restart(
+        monkeypatch,
+        {"status": "completed", "message": "Gateway service restarted successfully"},
+    )
     assert result is True
-    assert called_args == [["/mock/bin/hermes", "gateway", "restart"]]
-    assert called_env.get("HERMES_HOME") == "/mock/hermes/home"
     assert responses == [({"ok": True, "message": "Gateway service restarted successfully"}, 200)]
 
 
-def test_handle_health_restart_failure(monkeypatch):
-    import threading
-    routes._RESTART_LOCK = threading.Lock()
-    # Mock profiles home path
-    monkeypatch.setattr("api.routes.get_active_hermes_home", lambda: "/mock/hermes/home")
-    monkeypatch.setattr("shutil.which", lambda cmd: "/mock/bin/hermes" if cmd == "hermes" else None)
-
-    # Mock subprocess.Popen failure
-    def mock_popen(args, stdout=None, stderr=None, text=True, env=None):
-        mp = MockPopen(args, stdout, stderr, text, env)
-        mp.returncode = 1
-        mp.stdout = io.StringIO("")
-        mp.stderr = io.StringIO("Error: something went wrong")
-        return mp
-
-    monkeypatch.setattr(subprocess, "Popen", mock_popen)
-
-    responses = []
-    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
-
-    handler = types.SimpleNamespace()
-    result = routes._handle_health_restart(handler)
-
-    assert result is True
-    assert responses == [({"ok": False, "error": "Restart failed: Error: something went wrong"}, 500)]
-
-
-def test_handle_health_restart_exception(monkeypatch):
-    import threading
-    routes._RESTART_LOCK = threading.Lock()
-    # Mock profiles home path
-    monkeypatch.setattr("api.routes.get_active_hermes_home", lambda: "/mock/hermes/home")
-    monkeypatch.setattr("shutil.which", lambda cmd: "/mock/bin/hermes" if cmd == "hermes" else None)
-
-    # Mock Popen raising OSError immediately on start
-    def mock_popen(args, **kwargs):
-        raise OSError("Subprocess execution failed")
-
-    monkeypatch.setattr(subprocess, "Popen", mock_popen)
-
-    responses = []
-    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
-
-    handler = types.SimpleNamespace()
-    result = routes._handle_health_restart(handler)
-
-    assert result is True
-    assert responses[0][0]["ok"] is False
-    assert "Internal error running restart" in responses[0][0]["error"]
-    assert responses[0][1] == 500
-
-
 def test_handle_health_restart_timeout(monkeypatch):
-    import threading
-    routes._RESTART_LOCK = threading.Lock()
-    # Mock profiles home path
-    monkeypatch.setattr("api.routes.get_active_hermes_home", lambda: "/mock/hermes/home")
-    monkeypatch.setattr("shutil.which", lambda cmd: "/mock/bin/hermes" if cmd == "hermes" else None)
-
-    # Mock Popen raising TimeoutExpired on communicate
-    def mock_popen(args, stdout=None, stderr=None, text=True, env=None):
-        mp = MockPopen(args, stdout, stderr, text, env)
-        mp._should_timeout = True
-        return mp
-
-    monkeypatch.setattr(subprocess, "Popen", mock_popen)
-
-    responses = []
-    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
-
-    handler = types.SimpleNamespace()
-    result = routes._handle_health_restart(handler)
-
+    result, responses = _call_health_restart(
+        monkeypatch,
+        {"status": "in_progress", "message": "Gateway service restart initiated (in progress)"},
+    )
     assert result is True
     assert responses == [({"ok": True, "message": "Gateway service restart initiated (in progress)"}, 200)]
+
+
+def test_handle_health_restart_failure(monkeypatch):
+    result, responses = _call_health_restart(
+        monkeypatch,
+        {"status": "failed", "message": "Restart failed: bad thing"},
+    )
+    assert result is True
+    assert responses == [({"ok": False, "error": "Restart failed: bad thing"}, 500)]
+
+
+def test_handle_health_restart_internal_error(monkeypatch):
+    _, responses = _call_health_restart(
+        monkeypatch,
+        {"status": "failed", "message": "Internal error running restart: OSError: bad spawn"},
+    )
+    assert responses == [({"ok": False, "error": "Internal error running restart: OSError: bad spawn"}, 500)]
 
 
 def test_handle_health_restart_concurrency(monkeypatch):
-    import threading
-    import time
-    routes._RESTART_LOCK = threading.Lock()
-    
-    # Mock profiles home path
-    monkeypatch.setattr("api.routes.get_active_hermes_home", lambda: "/mock/hermes/home")
-    monkeypatch.setattr("shutil.which", lambda cmd: "/mock/bin/hermes" if cmd == "hermes" else None)
-
-    # Mock Popen that blocks on communicate
-    barrier = threading.Barrier(2)
-
-    class BlockingMockPopen(MockPopen):
-        def communicate(self, timeout=None):
-            barrier.wait()  # synchronize with test thread
-            time.sleep(0.5)  # hold the lock briefly
-            return self.stdout.getvalue(), self.stderr.getvalue()
-
-    def mock_popen(args, stdout=None, stderr=None, text=True, env=None):
-        return BlockingMockPopen(args, stdout, stderr, text, env)
-
-    monkeypatch.setattr(subprocess, "Popen", mock_popen)
-
-    responses = []
-    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
-
-    handler1 = types.SimpleNamespace()
-    handler2 = types.SimpleNamespace()
-
-    # Run first restart in a separate thread (it will block on communicate)
-    t1 = threading.Thread(target=routes._handle_health_restart, args=(handler1,))
-    t1.start()
-
-    # Wait until the first thread starts Popen and blocks on communicate
-    barrier.wait()
-
-    # Attempt a second restart concurrently; it should fail immediately with 429
-    result2 = routes._handle_health_restart(handler2)
-
-    t1.join()
-
-    assert result2 is True
-    # The second response must be a 429 Conflict / Too Many Requests
-    assert responses[0][0]["ok"] is False
-    assert "Restart already in progress" in responses[0][0]["error"]
-    assert responses[0][1] == 429
-
-
-def test_handle_health_restart_wait_timeout(monkeypatch):
-    import threading
-    import time
-    routes._RESTART_LOCK = threading.Lock()
-    monkeypatch.setattr("api.routes.get_active_hermes_home", lambda: "/mock/hermes/home")
-    monkeypatch.setattr("shutil.which", lambda cmd: "/mock/bin/hermes" if cmd == "hermes" else None)
-
-    mock_instances = []
-    def mock_popen(args, stdout=None, stderr=None, text=True, env=None):
-        mp = MockPopen(args, stdout, stderr, text, env)
-        mp._should_timeout = True
-        mp._wait_should_timeout = True
-        mock_instances.append(mp)
-        return mp
-
-    monkeypatch.setattr(subprocess, "Popen", mock_popen)
-
-    responses = []
-    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
-
-    handler = types.SimpleNamespace()
-    assert not routes._RESTART_LOCK.locked()
-    
-    result = routes._handle_health_restart(handler)
-    assert result is True
-    assert responses == [({"ok": True, "message": "Gateway service restart initiated (in progress)"}, 200)]
-    
-    # Wait for background thread to run and finish wait_and_release
-    time.sleep(0.5)
-    
-    # The lock should be released even if wait() timed out
-    assert not routes._RESTART_LOCK.locked()
-    assert len(mock_instances) == 1
-    assert mock_instances[0].terminated is True
-    assert mock_instances[0].killed is True
+    _, responses = _call_health_restart(
+        monkeypatch,
+        {"status": "busy", "message": "Restart already in progress. Please wait a moment and try again."},
+    )
+    assert responses == [
+        (
+            {"ok": False, "error": "Restart already in progress. Please wait a moment and try again."},
+            429,
+        )
+    ]

--- a/tests/test_health_restart.py
+++ b/tests/test_health_restart.py
@@ -1,17 +1,163 @@
-"""Health route restart contract checks for /api/health/restart."""
+"""Health route and shared gateway restart helper checks."""
 
+import io
+import subprocess
+import threading
 import types
 
-
+import api.gateway_restart as gateway_restart
 import api.routes as routes
+
+
+class MockPopen:
+    def __init__(
+        self,
+        args,
+        *,
+        stdout_text="",
+        stderr_text="",
+        returncode=0,
+        communicate_timeout=False,
+        wait_timeout=False,
+        env=None,
+    ):
+        self.args = args
+        self.env = env or {}
+        self.returncode = returncode
+        self.stdout = io.StringIO(stdout_text)
+        self.stderr = io.StringIO(stderr_text)
+        self.communicate_timeout = communicate_timeout
+        self.wait_timeout = wait_timeout
+        self.terminated = False
+        self.killed = False
+        self.communicate_timeout_arg = None
+        self.wait_timeout_arg = None
+
+    def communicate(self, timeout=None):
+        self.communicate_timeout_arg = timeout
+        if self.communicate_timeout:
+            raise subprocess.TimeoutExpired(self.args, timeout)
+        return self.stdout.getvalue(), self.stderr.getvalue()
+
+    def wait(self, timeout=None):
+        self.wait_timeout_arg = timeout
+        if self.wait_timeout:
+            raise subprocess.TimeoutExpired(self.args, timeout)
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+
+
+class InlineThread:
+    def __init__(self, *, target, args=(), daemon=None):
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+
+    def start(self):
+        self.target(*self.args)
 
 
 def _call_health_restart(monkeypatch, helper_result):
     handler = types.SimpleNamespace()
     responses = []
-    monkeypatch.setattr(routes, "j", lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True)
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda handler, payload, **kw: responses.append((payload, kw.get("status", 200))) or True,
+    )
     monkeypatch.setattr(routes, "restart_active_profile_gateway", lambda: dict(helper_result))
     return routes._handle_health_restart(handler), responses
+
+
+def test_restart_active_profile_gateway_success_uses_active_profile_home(monkeypatch):
+    gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
+    called = {}
+
+    def fake_popen(args, stdout=None, stderr=None, text=True, env=None):
+        called["args"] = args
+        called["env"] = env
+        return MockPopen(
+            args,
+            stdout_text="✓ Service restarted",
+            returncode=0,
+            env=env,
+        )
+
+    monkeypatch.setattr(gateway_restart, "get_active_hermes_home", lambda: "/mock/hermes/home")
+    monkeypatch.setattr(gateway_restart.shutil, "which", lambda cmd: "/mock/bin/hermes")
+    monkeypatch.setattr(gateway_restart.subprocess, "Popen", fake_popen)
+
+    result = gateway_restart.restart_active_profile_gateway()
+
+    assert result["status"] == "completed"
+    assert result["message"] == "Gateway service restarted successfully"
+    assert called["args"] == ["/mock/bin/hermes", "gateway", "restart"]
+    assert called["env"]["HERMES_HOME"] == "/mock/hermes/home"
+    assert gateway_restart._GATEWAY_RESTART_LOCK.locked() is False
+
+
+def test_restart_active_profile_gateway_failure_preserves_empty_output_contract(monkeypatch):
+    gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
+
+    monkeypatch.setattr(gateway_restart, "get_active_hermes_home", lambda: "/mock/hermes/home")
+    monkeypatch.setattr(gateway_restart.shutil, "which", lambda cmd: "/mock/bin/hermes")
+    monkeypatch.setattr(
+        gateway_restart.subprocess,
+        "Popen",
+        lambda args, stdout=None, stderr=None, text=True, env=None: MockPopen(
+            args,
+            returncode=7,
+            env=env,
+        ),
+    )
+
+    result = gateway_restart.restart_active_profile_gateway()
+
+    assert result["status"] == "failed"
+    assert result["message"] == "Restart failed: "
+    assert result["returncode"] == 7
+    assert gateway_restart._GATEWAY_RESTART_LOCK.locked() is False
+
+
+def test_restart_active_profile_gateway_timeout_releases_lock_after_background_wait(monkeypatch):
+    gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
+    proc = MockPopen(
+        ["/mock/bin/hermes", "gateway", "restart"],
+        communicate_timeout=True,
+        env={"HERMES_HOME": "/mock/hermes/home"},
+    )
+
+    monkeypatch.setattr(gateway_restart, "get_active_hermes_home", lambda: "/mock/hermes/home")
+    monkeypatch.setattr(gateway_restart.shutil, "which", lambda cmd: "/mock/bin/hermes")
+    monkeypatch.setattr(gateway_restart.subprocess, "Popen", lambda *args, **kwargs: proc)
+    monkeypatch.setattr(gateway_restart.threading, "Thread", InlineThread)
+
+    result = gateway_restart.restart_active_profile_gateway()
+
+    assert result["status"] == "in_progress"
+    assert proc.communicate_timeout_arg == 2.0
+    assert proc.wait_timeout_arg == 240.0
+    assert gateway_restart._GATEWAY_RESTART_LOCK.locked() is False
+
+
+def test_restart_active_profile_gateway_busy_reports_contention(monkeypatch):
+    gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
+    assert gateway_restart._GATEWAY_RESTART_LOCK.acquire(blocking=False) is True
+
+    try:
+        result = gateway_restart.restart_active_profile_gateway()
+    finally:
+        gateway_restart._GATEWAY_RESTART_LOCK.release()
+
+    assert result == {
+        "status": "busy",
+        "message": "Restart already in progress. Please wait a moment and try again.",
+    }
 
 
 def test_handle_health_restart_success(monkeypatch):
@@ -30,6 +176,15 @@ def test_handle_health_restart_timeout(monkeypatch):
     )
     assert result is True
     assert responses == [({"ok": True, "message": "Gateway service restart initiated (in progress)"}, 200)]
+
+
+def test_handle_health_restart_failure_preserves_empty_output_message(monkeypatch):
+    result, responses = _call_health_restart(
+        monkeypatch,
+        {"status": "failed", "message": "Restart failed: "},
+    )
+    assert result is True
+    assert responses == [({"ok": False, "error": "Restart failed: "}, 500)]
 
 
 def test_handle_health_restart_failure(monkeypatch):

--- a/tests/test_update_apply_ui.py
+++ b/tests/test_update_apply_ui.py
@@ -1,13 +1,123 @@
 """Frontend regression coverage for Update Now apply failures (#1321)."""
+import json
 from pathlib import Path
 import re
+import shutil
+import subprocess
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 UI_JS = ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
 
 
 def _ui_js() -> str:
     return UI_JS.read_text(encoding="utf-8")
+
+
+def _run_apply_updates_harness(update_data, responses):
+    if NODE is None:
+        pytest.skip("node not available for applyUpdates harness")
+    js = r"""
+const fs = require('fs');
+const updateData = JSON.parse(process.argv[1]);
+const responses = JSON.parse(process.argv[2]);
+const uiPath = process.argv[3];
+const src = fs.readFileSync(uiPath, 'utf8');
+const start = src.indexOf('async function applyUpdates()');
+const end = src.indexOf('function _showUpdateError', start);
+const snippet = src.slice(start, end);
+
+const button = { disabled: false, textContent: 'Update Now' };
+const errorEl = { style: { display: 'none' }, textContent: '' };
+const forceBtn = { style: { display: 'block' }, dataset: { target: 'stale-target' } };
+const dom = {
+  btnApplyUpdate: button,
+  updateError: errorEl,
+  btnForceUpdate: forceBtn,
+};
+const sessionStorage = {
+  removed: [],
+  removeItem(key) { this.removed.push(key); },
+};
+const showToasts = [];
+const apiCalls = [];
+const waitCalls = [];
+const errors = [];
+let readHealthCalls = 0;
+
+function $(id) { return dom[id] || null; }
+async function api(url, opts) {
+  const payload = JSON.parse(opts.body);
+  apiCalls.push(payload.target);
+  const res = responses[apiCalls.length - 1];
+  if (res.throwMessage) throw new Error(res.throwMessage);
+  return res;
+}
+async function _readHealthServerIdentity() {
+  readHealthCalls += 1;
+  return 'baseline-id';
+}
+function _waitForServerThenReload(opts) {
+  waitCalls.push({
+    baselineServerIdentity: opts.baselineServerIdentity,
+    apiCallsSnapshot: apiCalls.slice(),
+  });
+}
+function _showUpdateError(target, res) { errors.push({ target, message: res.message || '' }); }
+function _formatUpdateApplyExceptionMessage(e) { return 'Update failed: ' + e.message; }
+function showToast(message, duration, kind) {
+  showToasts.push({ message, duration, kind });
+}
+function setTimeout(cb, ms) { cb(); return 1; }
+function clearTimeout() {}
+
+global.window = { _updateApplyInFlight: false, _updateData: updateData };
+global.sessionStorage = sessionStorage;
+global.$ = $;
+global.api = api;
+global._readHealthServerIdentity = _readHealthServerIdentity;
+global._waitForServerThenReload = _waitForServerThenReload;
+global._showUpdateError = _showUpdateError;
+global._formatUpdateApplyExceptionMessage = _formatUpdateApplyExceptionMessage;
+global.showToast = showToast;
+global.setTimeout = setTimeout;
+global.clearTimeout = clearTimeout;
+
+eval(snippet);
+
+(async () => {
+  await applyUpdates();
+  console.log(JSON.stringify({
+    apiCalls,
+    waitCalls,
+    errors,
+    showToasts,
+    errorDisplay: errorEl.style.display,
+    errorText: errorEl.textContent,
+    removedKeys: sessionStorage.removed,
+    inFlight: window._updateApplyInFlight,
+    buttonDisabled: button.disabled,
+    buttonText: button.textContent,
+    forceHidden: forceBtn.style.display,
+    forceTarget: forceBtn.dataset.target,
+    readHealthCalls,
+  }));
+})().catch((error) => {
+  console.error(error.stack || String(error));
+  process.exit(1);
+});
+"""
+    result = subprocess.run(
+        [NODE, "-e", js, json.dumps(update_data), json.dumps(responses), str(UI_JS)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node harness failed: {result.stderr or result.stdout}")
+    return json.loads(result.stdout.strip().splitlines()[-1])
 
 
 def test_update_apply_network_error_has_recovery_message_not_raw_failed_to_fetch():
@@ -91,37 +201,37 @@ def test_update_apply_prevents_duplicate_apply_requests_while_in_flight():
 
 
 def test_update_apply_rejects_zero_target_success_path():
-    """Update Now must not claim success when no webui/agent target is selected."""
-    src = _ui_js()
-    apply_start = src.index("async function applyUpdates()")
-    target_agent = src.index("if(window._updateData?.agent?.behind>0) targets.push('agent');", apply_start)
-    try_start = src.index("try{", target_agent)
-    zero_target_guard = src.find("if(!targets.length)", target_agent, try_start)
-
-    assert zero_target_guard >= 0, (
-        "applyUpdates must return before the success/restart flow when targets is empty"
+    """Update Now must return before the toast and reload flow when nothing is behind."""
+    result = _run_apply_updates_harness(
+        {"agent": {"behind": 0}, "webui": {"behind": 0}},
+        [],
     )
+    assert result["apiCalls"] == []
+    assert result["waitCalls"] == []
+    assert result["showToasts"] == []
+    assert result["errorDisplay"] == "block"
+    assert "No update target selected" in result["errorText"]
 
 
 def test_apply_updates_queues_agent_before_webui():
-    src = _ui_js()
-    apply_start = src.index("async function applyUpdates()")
-    next_fn = src.index("function _showUpdateError", apply_start)
-    body = src[apply_start:next_fn]
-
-    agent_idx = body.index("if(window._updateData?.agent?.behind>0) targets.push('agent');")
-    webui_idx = body.index("if(window._updateData?.webui?.behind>0) targets.push('webui');")
-    assert agent_idx < webui_idx, "agent target should be queued before webui"
+    result = _run_apply_updates_harness(
+        {"agent": {"behind": 1}, "webui": {"behind": 1}},
+        [{"ok": True}, {"ok": True}],
+    )
+    assert result["apiCalls"] == ["agent", "webui"]
+    assert result["waitCalls"] == [
+        {
+            "baselineServerIdentity": "baseline-id",
+            "apiCallsSnapshot": ["agent", "webui"],
+        }
+    ]
 
 
 def test_apply_updates_wait_for_all_targets_before_reload():
-    src = _ui_js()
-    apply_start = src.index("async function applyUpdates()")
-    next_fn = src.index("function _showUpdateError", apply_start)
-    body = src[apply_start:next_fn]
-
-    loop_end = body.index("for(const target of targets)")
-    restart_wait = body.index("_waitForServerThenReload({baselineServerIdentity});")
-    assert loop_end < restart_wait, (
-        "_waitForServerThenReload should happen only after the update loop"
+    result = _run_apply_updates_harness(
+        {"agent": {"behind": 1}, "webui": {"behind": 1}},
+        [{"ok": True}, {"ok": False, "message": "webui failed"}],
     )
+    assert result["apiCalls"] == ["agent", "webui"]
+    assert result["waitCalls"] == []
+    assert result["errors"] == [{"target": "webui", "message": "webui failed"}]

--- a/tests/test_update_apply_ui.py
+++ b/tests/test_update_apply_ui.py
@@ -101,3 +101,27 @@ def test_update_apply_rejects_zero_target_success_path():
     assert zero_target_guard >= 0, (
         "applyUpdates must return before the success/restart flow when targets is empty"
     )
+
+
+def test_apply_updates_queues_agent_before_webui():
+    src = _ui_js()
+    apply_start = src.index("async function applyUpdates()")
+    next_fn = src.index("function _showUpdateError", apply_start)
+    body = src[apply_start:next_fn]
+
+    agent_idx = body.index("if(window._updateData?.agent?.behind>0) targets.push('agent');")
+    webui_idx = body.index("if(window._updateData?.webui?.behind>0) targets.push('webui');")
+    assert agent_idx < webui_idx, "agent target should be queued before webui"
+
+
+def test_apply_updates_wait_for_all_targets_before_reload():
+    src = _ui_js()
+    apply_start = src.index("async function applyUpdates()")
+    next_fn = src.index("function _showUpdateError", apply_start)
+    body = src[apply_start:next_fn]
+
+    loop_end = body.index("for(const target of targets)")
+    restart_wait = body.index("_waitForServerThenReload({baselineServerIdentity});")
+    assert loop_end < restart_wait, (
+        "_waitForServerThenReload should happen only after the update loop"
+    )

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -696,6 +696,10 @@ class TestSuccessfulUpdateReturnsRestartScheduled:
         monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
         monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
         monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: None)
+        monkeypatch.setattr(
+            'api.updates.restart_active_profile_gateway',
+            lambda: {'status': 'completed', 'message': 'Gateway service restarted successfully'},
+        )
 
         result = upd.apply_update('agent')
         assert result['ok'] is True
@@ -789,6 +793,230 @@ class TestApplyForceUpdate:
         monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
         result = upd.apply_force_update('invalid')
         assert result['ok'] is False
+
+
+class TestAgentUpdateRequiresGatewayRestart:
+    """Agent updates must prove gateway restart before returning ok=True."""
+
+    def test_apply_update_agent_requires_gateway_restart(self, tmp_path, monkeypatch):
+        import api.updates as upd
+
+        (tmp_path / '.git').mkdir()
+        ran = []
+        gateway_restarts = []
+
+        def fake_run(args, cwd, timeout=10):
+            ran.append(args)
+            if args[0] == 'fetch':
+                return '', True
+            if args[0] == 'tag':
+                return '', True
+            if args[:2] == ['status', '--porcelain']:
+                return '', True
+            if args[:2] == ['rev-parse', '--abbrev-ref']:
+                return 'origin/master', True
+            if args[0] == 'pull':
+                return 'Already up to date.', True
+            return '', True
+
+        def fake_gateway_restart():
+            gateway_restarts.append('called')
+            return {'status': 'completed', 'message': 'Gateway service restarted successfully'}
+
+        monkeypatch.setattr(upd, '_run_git', fake_run)
+        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
+        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: None)
+        monkeypatch.setattr('api.updates.restart_active_profile_gateway', fake_gateway_restart)
+
+        result = upd.apply_update('agent')
+        assert result['ok'] is True
+        assert result['target'] == 'agent'
+        assert result['restart_scheduled'] is True
+        assert result['gateway_restart'] == 'completed'
+        assert gateway_restarts == ['called']
+
+    def test_apply_update_agent_stash_conflict_success_invokes_gateway_restart(self, tmp_path, monkeypatch):
+        import api.updates as upd
+
+        (tmp_path / '.git').mkdir()
+        gateway_restarts = []
+        ran = []
+
+        def fake_run(args, cwd, timeout=10):
+            ran.append(args)
+            if args[0] == 'fetch':
+                return '', True
+            if args[0] == 'tag':
+                return '', True
+            if args[:2] == ['status', '--porcelain']:
+                return 'M file', True
+            if args[:2] == ['status', '--porcelain', '--untracked-files=no']:
+                return 'M file', True
+            if args[:2] == ['rev-parse', '--abbrev-ref']:
+                return 'origin/master', True
+            if args[:2] == ['rev-parse', '--short']:
+                return 'abc1234', True
+            if args[:2] == ['stash', 'push']:
+                return '', True
+            if args[:2] == ['stash', 'apply']:
+                return '', False
+            if args[0] == 'stash':
+                return '', True
+            if args[:2] == ['reset', '--hard', 'HEAD']:
+                return '', True
+            if args[0] == 'pull':
+                return 'Updating', True
+            return '', True
+
+        def fake_gateway_restart():
+            gateway_restarts.append('called')
+            return {'status': 'in_progress', 'message': 'Gateway service restart initiated (in progress)'}
+
+        monkeypatch.setattr(upd, '_run_git', fake_run)
+        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
+        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: None)
+        monkeypatch.setattr('api.updates.restart_active_profile_gateway', fake_gateway_restart)
+
+        result = upd.apply_update('agent')
+        assert result['ok'] is True
+        assert result['stash_conflict'] is True
+        assert result['target'] == 'agent'
+        assert result['restart_scheduled'] is True
+        assert result['gateway_restart'] == 'in_progress'
+        assert gateway_restarts == ['called']
+
+    def test_apply_update_agent_without_gateway_restart_result_fails(self, tmp_path, monkeypatch):
+        import api.updates as upd
+
+        (tmp_path / '.git').mkdir()
+
+        def fake_run(args, cwd, timeout=10):
+            if args[0] == 'fetch':
+                return '', True
+            if args[0] == 'tag':
+                return '', True
+            if args[:2] == ['status', '--porcelain']:
+                return '', True
+            if args[:2] == ['rev-parse', '--abbrev-ref']:
+                return 'origin/master', True
+            if args[:2] == ['rev-parse', '--short', 'origin/master']:
+                return 'abc1234', True
+            if args[0] == 'pull':
+                return 'Already up to date.', True
+            return '', True
+
+        restart_calls = []
+        monkeypatch.setattr(upd, '_run_git', fake_run)
+        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
+        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: (_ for _ in ()).throw(AssertionError('must not restart')))
+        monkeypatch.setattr('api.updates.restart_active_profile_gateway', lambda: (
+            restart_calls.append('called'),
+            {'status': 'busy', 'message': 'Restart already in progress. Please wait a moment and try again.'},
+        )[1])
+
+        result = upd.apply_update('agent')
+        assert result['ok'] is False
+        assert 'restart_scheduled' not in result
+        assert result['target'] == 'agent'
+        assert result['gateway_restart'] == 'busy'
+        assert 'hermes gateway restart' in result['message']
+        assert restart_calls == ['called']
+
+    def test_apply_force_update_agent_uses_gateway_restart_status(self, tmp_path, monkeypatch):
+        import api.updates as upd
+
+        (tmp_path / '.git').mkdir()
+        ran = []
+
+        def fake_run(args, cwd, timeout=10):
+            ran.append(args)
+            if args[0] == 'fetch':
+                return '', True
+            if args[:2] == ['rev-parse', '--abbrev-ref']:
+                return 'origin/master', True
+            if args[0] == 'checkout':
+                return '', True
+            if args[0] == 'reset':
+                return '', True
+            return '', True
+
+        monkeypatch.setattr(upd, '_run_git', fake_run)
+        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
+        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: None)
+        monkeypatch.setattr('api.updates.restart_active_profile_gateway', lambda: {'status': 'completed', 'message': 'Gateway service restarted successfully'})
+
+        result = upd.apply_force_update('agent')
+        assert result['ok'] is True
+        assert result['target'] == 'agent'
+        assert result['restart_scheduled'] is True
+        assert result['gateway_restart'] == 'completed'
+
+    def test_apply_force_update_agent_fails_when_gateway_restart_busy(self, tmp_path, monkeypatch):
+        import api.updates as upd
+
+        (tmp_path / '.git').mkdir()
+
+        def fake_run(args, cwd, timeout=10):
+            if args[0] == 'fetch':
+                return '', True
+            if args[:2] == ['rev-parse', '--abbrev-ref']:
+                return 'origin/master', True
+            if args[0] == 'checkout':
+                return '', True
+            if args[0] == 'reset':
+                return '', True
+            return '', True
+
+        monkeypatch.setattr(upd, '_run_git', fake_run)
+        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
+        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: (_ for _ in ()).throw(AssertionError('must not restart')))
+        monkeypatch.setattr(
+            'api.updates.restart_active_profile_gateway',
+            lambda: {'status': 'busy', 'message': 'Restart already in progress. Please wait a moment and try again.'},
+        )
+
+        result = upd.apply_force_update('agent')
+        assert result['ok'] is False
+        assert result['target'] == 'agent'
+        assert result['gateway_restart'] == 'busy'
+        assert 'hermes gateway restart' in result['message']
+
+    def test_apply_update_webui_does_not_call_gateway_restart(self, tmp_path, monkeypatch):
+        import api.updates as upd
+
+        (tmp_path / '.git').mkdir()
+        monkeypatch.setattr(
+            'api.updates.restart_active_profile_gateway',
+            lambda: (_ for _ in ()).throw(AssertionError('helper must not run for webui updates')),
+        )
+
+        def fake_run(args, cwd, timeout=10):
+            if args[0] == 'fetch':
+                return '', True
+            if args[0] == 'tag':
+                return '', True
+            if args[:2] == ['status', '--porcelain']:
+                return '', True
+            if args[:2] == ['rev-parse', '--abbrev-ref']:
+                return 'origin/master', True
+            if args[0] == 'pull':
+                return 'Already up to date.', True
+            return '', True
+
+        monkeypatch.setattr(upd, '_run_git', fake_run)
+        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
+        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: None)
+
+        result = upd.apply_update('webui')
+        assert result['ok'] is True
+        assert result['target'] == 'webui'
+        assert result['restart_scheduled'] is True
 
 
 # ── api/routes.py ─────────────────────────────────────────────────────────────

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -863,7 +863,7 @@ class TestAgentUpdateRequiresGatewayRestart:
                 return '', False
             if args[0] == 'stash':
                 return '', True
-            if args[:2] == ['reset', '--hard', 'HEAD']:
+            if args[:3] == ['reset', '--hard', 'HEAD']:
                 return '', True
             if args[0] == 'pull':
                 return 'Updating', True


### PR DESCRIPTION
## Thinking Path

- The in-app updater already re-execs the WebUI after a successful update, but Agent updates also need the gateway process to reload the new checkout.
- WebUI already has an active-profile gateway restart flow in the health banner, so the update path should reuse that behavior instead of growing another restart launcher.
- Applying Agent before WebUI when both are pending avoids arming the WebUI self-restart before the Agent slice has actually proved its gateway restart.

## What Changed

- `api/gateway_restart.py`: centralize the active-profile non-blocking `hermes gateway restart` launcher and single-flight behavior used by WebUI restart flows.
- `api/routes.py`: route `/api/health/restart` through the shared helper while preserving its current response contract.
- `api/updates.py`: require successful Agent updates and Agent force-updates to initiate or complete the gateway restart before reporting success, while keeping WebUI-only updates unchanged.
- `static/ui.js`: apply Agent updates before WebUI updates when both are pending, then keep the existing WebUI restart wait and reload flow.
- `tests/test_health_restart.py`, `tests/test_update_banner_fixes.py`, and `tests/test_update_apply_ui.py`: cover the shared helper, the Agent-update restart requirement, the WebUI negative space, and the client ordering change.

## Why It Matters

After an in-app Agent update, users currently hit a stale-module dead end on the next model switch because the gateway is still running old code. This fixes that path without widening the change into the broader full-`hermes update` parity work still tracked on the issue.

## Verification

```text
pytest tests/test_update_banner_fixes.py -v --timeout=60
pytest tests/test_health_restart.py -v --timeout=60
pytest tests/test_update_apply_ui.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Refs #5156. This addresses the stale-gateway slice of the issue; the broader full-update parity work stays tracked there.

Related prior work: [#816](https://github.com/nesquena/hermes-webui/pull/816) established the current update-banner WebUI self-restart flow this change extends to the gateway.

## Model Used

GPT 5.5 via Codex CLI

