### PR TITLE
fix(updates): resolve git under macOS launchd (#5175)

### DIFF
--- a/api/updates.py
+++ b/api/updates.py
@@ -15,6 +15,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import threading
 import time
 import urllib.error
@@ -186,9 +187,12 @@ def _run_git(args, cwd, timeout=10):
     On failure, returns stderr (or stdout as fallback) so callers can
     surface actionable git error messages instead of empty strings.
     """
+    git_executable = _resolve_git_executable()
+    if not git_executable:
+        return 'git executable not found', False
     try:
         r = subprocess.run(
-            ['git'] + args, cwd=str(cwd), capture_output=True,
+            [git_executable] + args, cwd=str(cwd), capture_output=True,
             text=True, timeout=timeout,
             encoding='utf-8', errors='replace',
         )
@@ -207,6 +211,15 @@ def _run_git(args, cwd, timeout=10):
         return 'git executable not found', False
     except OSError as exc:
         return f'git failed to start: {exc}', False
+
+
+def _resolve_git_executable():
+    git_executable = shutil.which('git')
+    if git_executable:
+        return git_executable
+    if sys.platform == 'darwin' and os.path.exists('/usr/bin/git'):
+        return '/usr/bin/git'
+    return None
 
 
 def _dirty_suffix(path: Path, timeout=1) -> str:

--- a/tests/test_issue5175_macos_launchd_git.py
+++ b/tests/test_issue5175_macos_launchd_git.py
@@ -1,0 +1,134 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import api.updates as updates
+
+
+def test_run_git_uses_which_result_when_available(tmp_path):
+    with patch.object(updates.shutil, 'which', return_value='C:/Tools/git.exe'), \
+         patch.object(updates.subprocess, 'run') as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout='v0.51.999\n', stderr='')
+
+        out, ok = updates._run_git(['describe', '--tags'], tmp_path)
+
+    assert ok is True
+    assert out == 'v0.51.999'
+    assert mock_run.call_args.args[0][0] == 'C:/Tools/git.exe'
+
+
+def test_run_git_falls_back_to_usr_bin_git_on_darwin(tmp_path):
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == 'git':
+            raise FileNotFoundError
+        if cmd[0] != '/usr/bin/git':
+            raise AssertionError(f'unexpected executable: {cmd[0]!r}')
+        return MagicMock(returncode=0, stdout='v0.51.999\n', stderr='')
+
+    with patch.object(updates.shutil, 'which', return_value=None), \
+         patch.object(sys, 'platform', 'darwin'), \
+         patch.object(updates.os.path, 'exists', return_value=True), \
+         patch.object(updates.subprocess, 'run', side_effect=fake_run):
+        out, ok = updates._run_git(['describe', '--tags'], tmp_path)
+
+    assert ok is True
+    assert out == 'v0.51.999'
+
+
+def test_run_git_returns_not_found_when_no_executable(tmp_path):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd[0])
+        if cmd[0] == '/usr/bin/git':
+            raise AssertionError('non-macOS path miss must not use /usr/bin/git')
+        raise FileNotFoundError
+
+    with patch.object(updates.shutil, 'which', return_value=None), \
+         patch.object(sys, 'platform', 'linux'), \
+         patch.object(updates.os.path, 'exists', return_value=True), \
+         patch.object(updates.subprocess, 'run', side_effect=fake_run):
+        out, ok = updates._run_git(['status'], tmp_path)
+
+    assert ok is False
+    assert out == 'git executable not found'
+    assert '/usr/bin/git' not in calls
+
+
+def test_run_git_returns_not_found_when_usr_bin_git_absent_on_darwin(tmp_path):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd[0])
+        raise FileNotFoundError
+
+    with patch.object(updates.shutil, 'which', return_value=None), \
+         patch.object(sys, 'platform', 'darwin'), \
+         patch.object(updates.os.path, 'exists', return_value=False), \
+         patch.object(updates.subprocess, 'run', side_effect=fake_run):
+        out, ok = updates._run_git(['status'], tmp_path)
+
+    assert ok is False
+    assert out == 'git executable not found'
+    assert '/usr/bin/git' not in calls
+
+
+def test_detect_webui_version_recovers_via_launchd_fallback(tmp_path):
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == 'git':
+            raise FileNotFoundError
+        if cmd[1:] == ['describe', '--tags', '--always']:
+            return MagicMock(returncode=0, stdout='v0.51.999\n', stderr='')
+        if cmd[1:] == ['diff-index', '--quiet', 'HEAD', '--']:
+            return MagicMock(returncode=0, stdout='', stderr='')
+        raise AssertionError(f'unexpected git args: {cmd[1:]!r}')
+
+    with patch.object(updates.shutil, 'which', return_value=None), \
+         patch.object(sys, 'platform', 'darwin'), \
+         patch.object(updates.os.path, 'exists', return_value=True), \
+         patch.object(updates, 'REPO_ROOT', tmp_path), \
+         patch.object(updates.subprocess, 'run', side_effect=fake_run):
+        version = updates._detect_webui_version()
+
+    assert version == 'v0.51.999'
+
+
+def test_check_repo_does_not_report_git_not_found_via_launchd_fallback(tmp_path):
+    (tmp_path / '.git').mkdir()
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == 'git':
+            raise FileNotFoundError
+        git_args = cmd[1:]
+        if git_args == ['fetch', 'origin', '--tags', '--force']:
+            return MagicMock(returncode=0, stdout='', stderr='')
+        if git_args == ['tag', '--list', 'v*', '--sort=-v:refname']:
+            return MagicMock(returncode=0, stdout='', stderr='')
+        if git_args == ['rev-parse', '--abbrev-ref', '@{upstream}']:
+            return MagicMock(returncode=0, stdout='origin/master\n', stderr='')
+        if git_args == ['rev-list', '--count', 'HEAD..origin/master']:
+            return MagicMock(returncode=0, stdout='0\n', stderr='')
+        if git_args == ['merge-base', 'HEAD', 'origin/master']:
+            return MagicMock(returncode=0, stdout='abcdef1234567890\n', stderr='')
+        if git_args == ['rev-parse', '--short', 'abcdef1234567890']:
+            return MagicMock(returncode=0, stdout='abcdef1\n', stderr='')
+        if git_args == ['rev-parse', '--short', 'origin/master']:
+            return MagicMock(returncode=0, stdout='fedcba9\n', stderr='')
+        if git_args == ['remote', 'get-url', 'origin']:
+            return MagicMock(
+                returncode=0,
+                stdout='https://github.com/nesquena/hermes-webui.git\n',
+                stderr='',
+            )
+        if git_args == ['diff-index', '--quiet', 'HEAD', '--']:
+            return MagicMock(returncode=0, stdout='', stderr='')
+        raise AssertionError(f'unexpected git args: {git_args!r}')
+
+    with patch.object(updates.shutil, 'which', return_value=None), \
+         patch.object(sys, 'platform', 'darwin'), \
+         patch.object(updates.os.path, 'exists', return_value=True), \
+         patch.object(updates.subprocess, 'run', side_effect=fake_run):
+        info = updates._check_repo(tmp_path, 'webui')
+
+    assert info['behind'] == 0
+    assert info['dirty'] is False
+    assert 'error' not in info

--- a/tests/test_issue5175_macos_launchd_git.py
+++ b/tests/test_issue5175_macos_launchd_git.py
@@ -18,10 +18,7 @@ def test_run_git_uses_which_result_when_available(tmp_path):
 
 def test_run_git_falls_back_to_usr_bin_git_on_darwin(tmp_path):
     def fake_run(cmd, **kwargs):
-        if cmd[0] == 'git':
-            raise FileNotFoundError
-        if cmd[0] != '/usr/bin/git':
-            raise AssertionError(f'unexpected executable: {cmd[0]!r}')
+        assert cmd[0] == '/usr/bin/git'
         return MagicMock(returncode=0, stdout='v0.51.999\n', stderr='')
 
     with patch.object(updates.shutil, 'which', return_value=None), \
@@ -74,8 +71,7 @@ def test_run_git_returns_not_found_when_usr_bin_git_absent_on_darwin(tmp_path):
 
 def test_detect_webui_version_recovers_via_launchd_fallback(tmp_path):
     def fake_run(cmd, **kwargs):
-        if cmd[0] == 'git':
-            raise FileNotFoundError
+        assert cmd[0] == '/usr/bin/git'
         if cmd[1:] == ['describe', '--tags', '--always']:
             return MagicMock(returncode=0, stdout='v0.51.999\n', stderr='')
         if cmd[1:] == ['diff-index', '--quiet', 'HEAD', '--']:
@@ -96,8 +92,7 @@ def test_check_repo_does_not_report_git_not_found_via_launchd_fallback(tmp_path)
     (tmp_path / '.git').mkdir()
 
     def fake_run(cmd, **kwargs):
-        if cmd[0] == 'git':
-            raise FileNotFoundError
+        assert cmd[0] == '/usr/bin/git'
         git_args = cmd[1:]
         if git_args == ['fetch', 'origin', '--tags', '--force']:
             return MagicMock(returncode=0, stdout='', stderr='')

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -288,7 +288,8 @@ def test_update_cache_is_scoped_by_agent_inclusion(tmp_path):
 
 def test_run_git_returns_stderr_on_failure(tmp_path):
     """When a git command fails, _run_git should return stderr (not empty string)."""
-    with patch('subprocess.run') as mock_run:
+    with patch.object(updates.shutil, 'which', return_value='C:/Tools/git.exe'), \
+         patch('subprocess.run') as mock_run:
         mock_run.return_value = MagicMock(
             returncode=1,
             stdout='',
@@ -302,7 +303,8 @@ def test_run_git_returns_stderr_on_failure(tmp_path):
 
 def test_run_git_returns_stdout_when_no_stderr(tmp_path):
     """If stderr is empty on failure, fall back to stdout."""
-    with patch('subprocess.run') as mock_run:
+    with patch.object(updates.shutil, 'which', return_value='C:/Tools/git.exe'), \
+         patch('subprocess.run') as mock_run:
         mock_run.return_value = MagicMock(
             returncode=128,
             stdout='Already up to date.',
@@ -316,7 +318,8 @@ def test_run_git_returns_stdout_when_no_stderr(tmp_path):
 
 def test_run_git_returns_exit_code_when_no_output(tmp_path):
     """If both stdout and stderr are empty, report the exit code."""
-    with patch('subprocess.run') as mock_run:
+    with patch.object(updates.shutil, 'which', return_value='C:/Tools/git.exe'), \
+         patch('subprocess.run') as mock_run:
         mock_run.return_value = MagicMock(
             returncode=1,
             stdout='',
@@ -330,7 +333,8 @@ def test_run_git_returns_exit_code_when_no_output(tmp_path):
 
 def test_run_git_uses_utf8_replacement_for_windows_console_output(tmp_path):
     """Git output can contain Unicode even when Windows' active code page cannot."""
-    with patch('subprocess.run') as mock_run:
+    with patch.object(updates.shutil, 'which', return_value='C:/Tools/git.exe'), \
+         patch('subprocess.run') as mock_run:
         mock_run.return_value = MagicMock(returncode=0, stdout='v0.51.184\n', stderr=None)
 
         out, ok = updates._run_git(['describe', '--tags'], tmp_path)
@@ -344,7 +348,8 @@ def test_run_git_uses_utf8_replacement_for_windows_console_output(tmp_path):
 
 def test_run_git_handles_missing_stdout_after_decode_thread_failure(tmp_path):
     """A subprocess reader failure must not make version detection crash on import."""
-    with patch('subprocess.run') as mock_run:
+    with patch.object(updates.shutil, 'which', return_value='C:/Tools/git.exe'), \
+         patch('subprocess.run') as mock_run:
         mock_run.return_value = MagicMock(returncode=0, stdout=None, stderr=None)
 
         out, ok = updates._run_git(['diff', '--binary', 'HEAD', '--'], tmp_path)


### PR DESCRIPTION
## Thinking Path

- The version badge and the update checker both fail on the same helper path, because `api/updates.py` launches bare `git` from `_run_git()` and launchd does not inherit the user's shell PATH.
- The narrow fix is to resolve the executable once in `_run_git()`, keep normal PATH lookup first, and use `/usr/bin/git` only for the macOS launchd miss that the issue demonstrates.
- That keeps `.git`-absent installs on their existing `no_git` path, preserves the current missing-git diagnostic when no executable exists, and fixes every git-backed caller through the single launch owner.

## What Changed

- `api/updates.py`: added a private git-executable resolver used only by `_run_git()`, keeping the existing timeout and diagnostic behavior while recovering macOS launchd installs through `/usr/bin/git`.
- `tests/test_issue5175_macos_launchd_git.py`: added focused behavioral regressions for launchd PATH loss, the macOS fallback, WebUI version recovery, update-check recovery, and the true-missing-git invariants.
- `tests/test_updates.py`: made the pre-existing `_run_git()` unit tests patch `shutil.which(...)` explicitly so they stay hermetic when git is absent from PATH.

## Why It Matters

WebUI instances launched by macOS launchd can now report their git-backed version and run update checks when the system git exists at `/usr/bin/git`. Installs that truly lack git, or lack `.git` metadata, keep their current behavior and messaging.

## Verification

```bash
pytest tests/test_issue5175_macos_launchd_git.py -v --timeout=60
pytest tests/test_version_badge.py tests/test_issue4356_no_git_update_check.py tests/test_updates.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5175.
Reporter workaround details in #5175 informed the resolver shape.

## Model Used

GPT 5.5 via Codex CLI
