### PR TITLE
fix(#3954): move new chat shortcut to ctrl/cmd+shift+o

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -679,7 +679,7 @@ restriction from the UI yet (see ROADMAP.md Wave 4 for the plan).
 | B11 | Low      | GET /api/session no-ID silently creates session      | FIXED Sprint 1   | Returns 400 with error message |
 | B12 | Low      | Preview panel display:none to flex layout jump       | FIXED Sprint 4   | visibility/opacity transition replaces display:none toggle |
 | B13 | Low      | No CORS headers                                      | Open             | Phase H |
-| B14 | Low      | No keyboard shortcut for new chat                    | FIXED Sprint 3   | Cmd/Ctrl+K triggers newSession() from anywhere |
+| B14 | Low      | No keyboard shortcut for new chat                    | FIXED Sprint 3   | Cmd/Ctrl+Shift+O triggers newSession() from anywhere |
 | TD1 | Critical | Env vars are process-global (concurrent request bug) | PARTIAL Sprint 5 | Thread-local _set_thread_env() added. Per-session lock from Sprint 4. Process-level env still written as fallback. Full fix needs terminal tool to read thread-local. |
 | TD2 | High     | SESSIONS cache: no eviction, locking missing         | FIXED Sprint 5   | OrderedDict + LRU cap 100 + move_to_end on access. LOCK from Sprint 1. Complete. |
 | TD3 | High     | No test coverage                                     | PARTIAL Sprint 1 | 19 HTTP integration tests added; unit tests pending Phase A split |
@@ -1501,8 +1501,8 @@ B10: `es.addEventListener('tool', ...)` now calls `removeThinking()` before upda
      status and shows a compact `.msg-role + .msg-body` tool-running row. `ensureAssistantRow()`
      also removes `#toolRunningRow` when first token arrives.
 
-B14: `document.addEventListener('keydown', ...)` at global scope catches Cmd/Ctrl+K
-     and calls `newSession()` if not busy.
+B14: `document.addEventListener('keydown', ...)` at global scope catches Cmd/Ctrl+Shift+O
+and calls `newSession()` if not busy.
 
 
 ### Sprint 4 (March 30, 2026): Relocation + Session Power Features + Phase A/B

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1501,8 +1501,9 @@ B10: `es.addEventListener('tool', ...)` now calls `removeThinking()` before upda
      status and shows a compact `.msg-role + .msg-body` tool-running row. `ensureAssistantRow()`
      also removes `#toolRunningRow` when first token arrives.
 
-B14: `document.addEventListener('keydown', ...)` at global scope catches Cmd/Ctrl+Shift+O
-     and calls `newSession()` if not busy.
+B14: `document.addEventListener('keydown', ...)` at global scope catches Cmd/Ctrl+Shift+O,
+     preserves the empty-idle guard, reopens a remembered draft session when one exists,
+     and otherwise falls through to `newSession()`.
 
 
 ### Sprint 4 (March 30, 2026): Relocation + Session Power Features + Phase A/B

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1502,7 +1502,7 @@ B10: `es.addEventListener('tool', ...)` now calls `removeThinking()` before upda
      also removes `#toolRunningRow` when first token arrives.
 
 B14: `document.addEventListener('keydown', ...)` at global scope catches Cmd/Ctrl+Shift+O
-and calls `newSession()` if not busy.
+     and calls `newSession()` if not busy.
 
 
 ### Sprint 4 (March 30, 2026): Relocation + Session Power Features + Phase A/B

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,7 @@ Remaining gaps and forward work live in [Forward Work](#forward-work) below.
 - [x] Pure-text + tool-call streams both recover
 
 ### Sessions
-- [x] Create session (+ button or Cmd/Ctrl+K)
+- [x] Create session (+ button or Cmd/Ctrl+Shift+O)
 - [x] Load session (click in sidebar)
 - [x] Delete session (hover trash, toast undo, fallback)
 - [x] Auto-title from first user message + adaptive title refresh (configurable cadence)

--- a/TESTING.md
+++ b/TESTING.md
@@ -870,9 +870,9 @@ EXPECT:
   - NOT: thinking dots AND "Running..." AND streaming text all visible at once
 FAIL: Thinking dots stay while tool runs, or multiple rows stacked confusingly.
 
-### T17.3: B14 - Cmd/Ctrl+K Creates New Chat
+### T17.3: B14 - Cmd/Ctrl+Shift+O Creates New Chat
 STEPS:
-  1. Press Cmd+K (Mac) or Ctrl+K (Windows/Linux) while on the Chat tab
+  1. Press Cmd+Shift+O (Mac) or Ctrl+Shift+O (Windows/Linux) while on the Chat tab
 EXPECT:
   - A new "Untitled" session is created
   - Empty state shown, input focused

--- a/TESTING.md
+++ b/TESTING.md
@@ -876,6 +876,8 @@ STEPS:
 EXPECT:
   - A new "Untitled" session is created
   - Empty state shown, input focused
+  - If a remembered draft session exists, the shortcut reopens that draft instead
+    of creating a blank chat
   - Does NOT work if a request is in-flight (Send is disabled)
 FAIL: Nothing happens, browser intercepts shortcut for its own purpose, crash.
 

--- a/static/boot.js
+++ b/static/boot.js
@@ -1712,7 +1712,7 @@ $('msg').addEventListener('keydown',e=>{
     }
   }
 });
-// B14: Cmd/Ctrl+K creates a new chat from anywhere
+// B14: Cmd/Ctrl+Shift+O creates a new chat from anywhere
 document.addEventListener('keydown',async e=>{
   // Cmd/Ctrl+B toggles desktop sidebar collapse (VS Code convention).
   // Skip when typing in an input/textarea/contenteditable so text-edit
@@ -1737,7 +1737,7 @@ document.addEventListener('keydown',async e=>{
       return;
     }
   }
-  if((e.metaKey||e.ctrlKey)&&e.key==='k'){
+  if((e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='o'||e.key==='O')){
     e.preventDefault();
     // If the current session has no messages AND nothing is in flight, just focus
     // the composer rather than creating another empty session that will clutter
@@ -1750,7 +1750,7 @@ document.addEventListener('keydown',async e=>{
        && !S.session.pending_user_message){
       $('msg').focus();return;
     }
-    // Cmd/Ctrl+K should always create a new conversation, even while the current
+    // Cmd/Ctrl+Shift+O should always create a new conversation, even while the current
     // one is still streaming. The old !S.busy guard meant users had to wait for
     // a long generation to finish before they could start something new — exactly
     // the moment they want to switch context. newSession() leaves the in-flight

--- a/static/boot.js
+++ b/static/boot.js
@@ -1750,6 +1750,8 @@ document.addEventListener('keydown',async e=>{
        && !S.session.pending_user_message){
       $('msg').focus();return;
     }
+    // Keep keyboard and button entry points in sync: if a remembered draft
+    // session exists, reopen it before creating a blank chat.
     if(typeof _restoreRememberedNewChatDraftSession==='function'
        && await _restoreRememberedNewChatDraftSession()){
       await renderSessionList();closeMobileSidebar();$('msg').focus();return;

--- a/static/boot.js
+++ b/static/boot.js
@@ -1750,6 +1750,10 @@ document.addEventListener('keydown',async e=>{
        && !S.session.pending_user_message){
       $('msg').focus();return;
     }
+    if(typeof _restoreRememberedNewChatDraftSession==='function'
+       && await _restoreRememberedNewChatDraftSession()){
+      await renderSessionList();closeMobileSidebar();$('msg').focus();return;
+    }
     // Cmd/Ctrl+Shift+O should always create a new conversation, even while the current
     // one is still streaming. The old !S.busy guard meant users had to wait for
     // a long generation to finish before they could start something new — exactly

--- a/static/index.html
+++ b/static/index.html
@@ -194,7 +194,7 @@
       <div class="panel-head">
         <span data-i18n="tab_chat">Chat</span>
         <div class="panel-head-actions">
-          <button class="panel-head-btn has-tooltip has-tooltip--bottom-right" id="btnNewChat" data-tooltip="New conversation (Cmd+K)" data-i18n-title="new_conversation" aria-label="New conversation">
+          <button class="panel-head-btn has-tooltip has-tooltip--bottom-right" id="btnNewChat" data-tooltip="New conversation (Cmd+Shift+O)" data-i18n-title="new_conversation" aria-label="New conversation">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
           </button>
         </div>

--- a/tests/test_1432_newchat_and_1423_profile_input.py
+++ b/tests/test_1432_newchat_and_1423_profile_input.py
@@ -15,7 +15,8 @@ def _read(filename):
 
 
 class TestIssue1432NewChatGuardInFlight:
-    """`+` button and Cmd/Ctrl+K must create a new chat even while the current
+    """`+` button and Cmd/Ctrl+Shift+O must create a new chat even while the
+    current
     session is still streaming. The empty-session guard from #1171 was checking
     `message_count===0` only, which is true the entire time the first user
     message is in flight (server-side count not yet updated). The guard now
@@ -43,21 +44,21 @@ class TestIssue1432NewChatGuardInFlight:
         assert 'pending_user_message' in body, \
             "btnNewChat guard missing pending_user_message check (#1432)"
 
-    def test_cmdK_handler_checks_in_flight_state(self):
+    def test_ctrl_shift_O_handler_checks_in_flight_state(self):
         src = _read('boot.js')
-        # Locate the Cmd/Ctrl+K branch — it sits inside a keydown listener
-        idx = src.find("(e.metaKey||e.ctrlKey)&&e.key==='k'")
-        assert idx >= 0, "Cmd/Ctrl+K handler not found in boot.js"
+        # Locate the Cmd/Ctrl+Shift+O branch — it sits inside a keydown listener
+        idx = src.find("(e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='o'||e.key==='O')")
+        assert idx >= 0, "Cmd/Ctrl+Shift+O handler not found in boot.js"
         # Read the next ~1500 chars (handler body)
         body = src[idx:idx + 1500]
         assert 'message_count' in body, \
-            "Cmd/Ctrl+K guard missing message_count check"
+            "Cmd/Ctrl+Shift+O guard missing message_count check"
         assert 'S.busy' in body, \
-            "Cmd/Ctrl+K guard missing S.busy check (#1432)"
+            "Cmd/Ctrl+Shift+O guard missing S.busy check (#1432)"
         assert 'active_stream_id' in body, \
-            "Cmd/Ctrl+K guard missing active_stream_id check (#1432)"
+            "Cmd/Ctrl+Shift+O guard missing active_stream_id check (#1432)"
         assert 'pending_user_message' in body, \
-            "Cmd/Ctrl+K guard missing pending_user_message check (#1432)"
+            "Cmd/Ctrl+Shift+O guard missing pending_user_message check (#1432)"
 
     def test_in_flight_signal_matches_restoreSettledSession(self):
         """The new in-flight check uses the same signal as the canonical

--- a/tests/test_issue3952_escape_blur_composer.py
+++ b/tests/test_issue3952_escape_blur_composer.py
@@ -23,7 +23,7 @@ def _block_from_opening_brace(src: str, brace: int, label: str) -> str:
 
 
 def _escape_block() -> str:
-    document_keydown = BOOT_JS.index("// B14: Cmd/Ctrl+K creates a new chat from anywhere")
+    document_keydown = BOOT_JS.index("// B14: Cmd/Ctrl+Shift+O creates a new chat from anywhere")
     start = BOOT_JS.index("if(e.key==='Escape'){", document_keydown)
     brace = BOOT_JS.index("{", start)
     return _block_from_opening_brace(BOOT_JS, brace, "document Escape handler")

--- a/tests/test_issue3954_new_chat_shortcut.py
+++ b/tests/test_issue3954_new_chat_shortcut.py
@@ -1,0 +1,243 @@
+"""Shortcut remap behavior checks for #3954."""
+
+import base64
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+INDEX = (REPO / "static" / "index.html").read_text(encoding="utf-8")
+ARCH = (REPO / "ARCHITECTURE.md").read_text(encoding="utf-8")
+
+
+_B14_MARKER = "if((e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='o'||e.key==='O'))"
+
+
+def _extract_block(source: str, marker: str, *, label: str) -> str:
+    start = source.find(marker)
+    assert start >= 0, f"{label} marker not found in source"
+    open_brace = source.index("{", start)
+    depth = 1
+    index = open_brace + 1
+    while index < len(source) and depth:
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+        index += 1
+    assert depth == 0, f"Failed to parse {label} block"
+    return source[start : index]
+
+
+_B14_STATEMENT = _extract_block(BOOT_JS, _B14_MARKER, label="B14")
+
+
+def _run_b14_handler(cases):
+    payload = {
+        "cases": cases,
+        "block_b64": base64.b64encode(_B14_STATEMENT.encode("utf-8")).decode("ascii"),
+    }
+
+    script = r'''
+const payload = JSON.parse(process.env.B14_PAYLOAD);
+const block = Buffer.from(payload.block_b64, "base64").toString("utf-8");
+
+(async () => {
+  const results = [];
+
+  for (const scenario of payload.cases) {
+    const calls = [];
+    const event = Object.assign({
+      altKey: false,
+      shiftKey: false,
+      metaKey: false,
+      ctrlKey: false,
+      key: "",
+      target: null,
+      preventDefault: () => calls.push("preventDefault"),
+      stopPropagation: () => {}
+    }, scenario.event);
+
+    const $ = (selector) => {
+      if (selector === "msg") return { focus: () => calls.push("focus") };
+      if (selector === "approvalCard")
+        return { classList: { contains: () => false } };
+      return null;
+    };
+
+    const runner = new Function(
+      "e",
+      "S",
+      "$",
+      "newSession",
+      "renderSessionList",
+      "closeMobileSidebar",
+      "return (async () => {" + block + "})();"
+    );
+
+    try {
+      await runner(
+        event,
+        scenario.session,
+        $,
+        async () => calls.push("newSession"),
+        async () => calls.push("renderSessionList"),
+        () => calls.push("closeMobileSidebar")
+      );
+      results.push({
+        name: scenario.name,
+        calls,
+        prevented: calls.includes("preventDefault"),
+        error: null
+      });
+    } catch (error) {
+      results.push({
+        name: scenario.name,
+        calls,
+        prevented: calls.includes("preventDefault"),
+        error: String(error)
+      });
+    }
+  }
+
+  process.stdout.write(JSON.stringify(results));
+})();
+'''
+
+    env = os.environ.copy()
+    env["B14_PAYLOAD"] = json.dumps(payload)
+    out = subprocess.check_output(["node", "-e", script], text=True, env=env)
+    return json.loads(out)
+
+
+def _event(*, ctrl_key: bool, meta_key: bool, shift_key: bool, key: str, alt_key=False):
+    return {
+        "ctrlKey": ctrl_key,
+        "metaKey": meta_key,
+        "shiftKey": shift_key,
+        "altKey": alt_key,
+        "key": key,
+    }
+
+
+def _empty_idle_session():
+    return {
+        "message_count": 0,
+        "active_stream_id": None,
+        "pending_user_message": False,
+    }
+
+
+def _streaming_session():
+    return {
+        "message_count": 1,
+        "active_stream_id": "stream-xyz",
+        "pending_user_message": True,
+        "busy": True,
+    }
+
+
+def _scenario(name, *, event, session_idle=False, include_busy=False):
+    base_session = {"workspace": "default"}
+    if session_idle:
+        base_session["session"] = _empty_idle_session()
+        base_session["busy"] = False
+    else:
+        base_session["session"] = _streaming_session() if include_busy else {"message_count": 1}
+        base_session["busy"] = include_busy
+    return {"name": name, "event": event, "session": base_session}
+
+
+def _expect_order(result, expected):
+    assert not result["error"], f"Handler crashed: {result['error']}"
+    assert result["calls"] == expected, f"{result['name']} call order mismatch: {result['calls']}"
+
+
+def test_ctrl_k_no_longer_creates_new_chat():
+    """Ctrl/Cmd+K should be ignored and must not create a new session."""
+    results = _run_b14_handler([
+        _scenario("ctrl_k", event=_event(ctrl_key=True, meta_key=False, shift_key=False, key="k")),
+        _scenario("cmd_k", event=_event(ctrl_key=False, meta_key=True, shift_key=False, key="k")),
+    ])
+    by_name = {row["name"]: row for row in results}
+
+    for name in ("ctrl_k", "cmd_k"):
+        row = by_name[name]
+        assert row["error"] is None, f"{name}: handler crashed {row['error']}"
+        assert not row["prevented"], f"{name}: must not call e.preventDefault()"
+        assert "newSession" not in row["calls"], f"{name}: must not call newSession()"
+        assert row["calls"] == [], f"{name}: unexpected calls: {row['calls']}"
+
+
+def test_ctrl_shift_o_creates_new_chat_and_keeps_mobile_close_sequence():
+    """Ctrl+Shift+O must create and activate the new chat surface."""
+    results = _run_b14_handler([
+        _scenario(
+            "ctrl_shift_o",
+            event=_event(ctrl_key=True, meta_key=False, shift_key=True, key="o"),
+            include_busy=True,
+        ),
+    ])
+    row = results[0]
+    assert row["error"] is None, f"ctrl_shift_o: handler crashed {row['error']}"
+    assert row["prevented"], "ctrl_shift_o: must call e.preventDefault()"
+    _expect_order(
+        row,
+        ["preventDefault", "newSession", "renderSessionList", "closeMobileSidebar", "focus"],
+    )
+
+
+def test_cmd_shift_o_creates_new_chat():
+    """Cmd+Shift+O must follow the same new-chat sequence."""
+    results = _run_b14_handler([
+        _scenario(
+            "cmd_shift_o",
+            event=_event(ctrl_key=False, meta_key=True, shift_key=True, key="O"),
+            include_busy=True,
+        ),
+    ])
+    row = results[0]
+    assert row["error"] is None, f"cmd_shift_o: handler crashed {row['error']}"
+    assert row["prevented"], "cmd_shift_o: must call e.preventDefault()"
+    _expect_order(
+        row,
+        ["preventDefault", "newSession", "renderSessionList", "closeMobileSidebar", "focus"],
+    )
+
+
+def test_ctrl_shift_o_keeps_empty_idle_guard():
+    """Empty, in-flight-free sessions must only focus the composer."""
+    results = _run_b14_handler([
+        _scenario(
+            "ctrl_shift_o_empty",
+            event=_event(ctrl_key=True, meta_key=False, shift_key=True, key="o"),
+            session_idle=True,
+        ),
+        _scenario(
+            "cmd_shift_o_empty",
+            event=_event(ctrl_key=False, meta_key=True, shift_key=True, key="o"),
+            session_idle=True,
+        ),
+    ])
+    by_name = {row["name"]: row for row in results}
+    expected = ["preventDefault", "focus"]
+    for name, row in by_name.items():
+        assert row["error"] is None, f"{name}: handler crashed {row['error']}"
+        assert row["prevented"], f"{name}: should prevent default before guard returns"
+        assert row["calls"] == expected, f"{name}: expected {expected}, got {row['calls']}"
+
+
+def test_new_chat_tooltip_advertises_shift_o():
+    """The visible tooltip should advertise Cmd+Shift+O."""
+    assert "New conversation (Cmd+Shift+O)" in INDEX
+    assert "Cmd/Ctrl+Shift+O" in ARCH
+
+
+def test_ctrl_shift_o_binding_is_unique_in_checked_shortcut_surface():
+    """Keep uniqueness and legacy-surface checks for the remapped binding."""
+    assert BOOT_JS.count(_B14_MARKER) == 1
+    assert "Cmd/Ctrl+K" not in ARCH and "Cmd/Ctrl+K" not in INDEX
+    assert "(e.key==='k')" not in BOOT_JS
+    assert _B14_MARKER in BOOT_JS

--- a/tests/test_issue3954_new_chat_shortcut.py
+++ b/tests/test_issue3954_new_chat_shortcut.py
@@ -15,7 +15,7 @@ BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
 INDEX = (REPO / "static" / "index.html").read_text(encoding="utf-8")
 ARCH = (REPO / "ARCHITECTURE.md").read_text(encoding="utf-8")
 NODE = shutil.which("node")
-pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+requires_node = pytest.mark.skipif(NODE is None, reason="node not on PATH")
 
 
 _B14_MARKER = "if((e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='o'||e.key==='O'))"
@@ -171,6 +171,7 @@ def _expect_order(result, expected):
     assert result["calls"] == expected, f"{result['name']} call order mismatch: {result['calls']}"
 
 
+@requires_node
 def test_ctrl_k_no_longer_creates_new_chat():
     """Ctrl/Cmd+K should be ignored and must not create a new session."""
     results = _run_b14_handler([
@@ -187,6 +188,7 @@ def test_ctrl_k_no_longer_creates_new_chat():
         assert row["calls"] == [], f"{name}: unexpected calls: {row['calls']}"
 
 
+@requires_node
 def test_ctrl_shift_o_creates_new_chat_and_keeps_mobile_close_sequence():
     """Ctrl+Shift+O must create and activate the new chat surface."""
     results = _run_b14_handler([
@@ -205,6 +207,7 @@ def test_ctrl_shift_o_creates_new_chat_and_keeps_mobile_close_sequence():
     )
 
 
+@requires_node
 def test_cmd_shift_o_creates_new_chat():
     """Cmd+Shift+O must follow the same new-chat sequence."""
     results = _run_b14_handler([
@@ -223,6 +226,7 @@ def test_cmd_shift_o_creates_new_chat():
     )
 
 
+@requires_node
 def test_ctrl_shift_o_keeps_empty_idle_guard():
     """Empty, in-flight-free sessions must only focus the composer."""
     results = _run_b14_handler([
@@ -245,6 +249,7 @@ def test_ctrl_shift_o_keeps_empty_idle_guard():
         assert row["calls"] == expected, f"{name}: expected {expected}, got {row['calls']}"
 
 
+@requires_node
 def test_ctrl_shift_o_restores_remembered_draft_before_new_session():
     """The shortcut should match the New Conversation button's draft restore path."""
     results = _run_b14_handler([

--- a/tests/test_issue3954_new_chat_shortcut.py
+++ b/tests/test_issue3954_new_chat_shortcut.py
@@ -3,13 +3,19 @@
 import base64
 import json
 import os
+import shutil
 import subprocess
+from functools import lru_cache
 from pathlib import Path
+
+import pytest
 
 REPO = Path(__file__).resolve().parents[1]
 BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
 INDEX = (REPO / "static" / "index.html").read_text(encoding="utf-8")
 ARCH = (REPO / "ARCHITECTURE.md").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
 
 
 _B14_MARKER = "if((e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='o'||e.key==='O'))"
@@ -31,13 +37,15 @@ def _extract_block(source: str, marker: str, *, label: str) -> str:
     return source[start : index]
 
 
-_B14_STATEMENT = _extract_block(BOOT_JS, _B14_MARKER, label="B14")
+@lru_cache(maxsize=1)
+def _b14_statement() -> str:
+    return _extract_block(BOOT_JS, _B14_MARKER, label="B14")
 
 
 def _run_b14_handler(cases):
     payload = {
         "cases": cases,
-        "block_b64": base64.b64encode(_B14_STATEMENT.encode("utf-8")).decode("ascii"),
+        "block_b64": base64.b64encode(_b14_statement().encode("utf-8")).decode("ascii"),
     }
 
     script = r'''
@@ -74,6 +82,7 @@ const block = Buffer.from(payload.block_b64, "base64").toString("utf-8");
       "newSession",
       "renderSessionList",
       "closeMobileSidebar",
+      "_restoreRememberedNewChatDraftSession",
       "return (async () => {" + block + "})();"
     );
 
@@ -84,7 +93,14 @@ const block = Buffer.from(payload.block_b64, "base64").toString("utf-8");
         $,
         async () => calls.push("newSession"),
         async () => calls.push("renderSessionList"),
-        () => calls.push("closeMobileSidebar")
+        () => calls.push("closeMobileSidebar"),
+        async () => {
+          if (scenario.restoreRememberedDraft) {
+            calls.push("restoreRememberedDraft");
+            return true;
+          }
+          return false;
+        }
       );
       results.push({
         name: scenario.name,
@@ -108,7 +124,7 @@ const block = Buffer.from(payload.block_b64, "base64").toString("utf-8");
 
     env = os.environ.copy()
     env["B14_PAYLOAD"] = json.dumps(payload)
-    out = subprocess.check_output(["node", "-e", script], text=True, env=env)
+    out = subprocess.check_output([NODE, "-e", script], text=True, env=env)
     return json.loads(out)
 
 
@@ -227,6 +243,27 @@ def test_ctrl_shift_o_keeps_empty_idle_guard():
         assert row["error"] is None, f"{name}: handler crashed {row['error']}"
         assert row["prevented"], f"{name}: should prevent default before guard returns"
         assert row["calls"] == expected, f"{name}: expected {expected}, got {row['calls']}"
+
+
+def test_ctrl_shift_o_restores_remembered_draft_before_new_session():
+    """The shortcut should match the New Conversation button's draft restore path."""
+    results = _run_b14_handler([
+        {
+            **_scenario(
+                "ctrl_shift_o_restore",
+                event=_event(ctrl_key=True, meta_key=False, shift_key=True, key="o"),
+                include_busy=True,
+            ),
+            "restoreRememberedDraft": True,
+        },
+    ])
+    row = results[0]
+    assert row["error"] is None, f"ctrl_shift_o_restore: handler crashed {row['error']}"
+    assert row["prevented"], "ctrl_shift_o_restore: must call e.preventDefault()"
+    _expect_order(
+        row,
+        ["preventDefault", "restoreRememberedDraft", "renderSessionList", "closeMobileSidebar", "focus"],
+    )
 
 
 def test_new_chat_tooltip_advertises_shift_o():

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -843,23 +843,39 @@ def test_new_conversation_closes_mobile_sidebar():
     assert "closeMobileSidebar" in handler_block, \
         "btnNewChat handler must closeMobileSidebar() after creating the new session"
 
-    shortcut_line = next((ln for ln in boot_js.splitlines() if "e.key==='k'" in ln or "e.key === 'k'" in ln), "")
-    assert shortcut_line, "Cmd/Ctrl+K new chat shortcut missing from static/boot.js"
+    shortcut_line = next(
+        (
+            ln for ln in boot_js.splitlines()
+            if "(e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&" in ln
+            and "(e.key==='o'||" in ln
+        ),
+        "",
+    )
+    assert shortcut_line, "Cmd/Ctrl+Shift+O new chat shortcut missing from static/boot.js"
     shortcut_block = "\n".join(boot_js.splitlines()[boot_js.splitlines().index(shortcut_line):boot_js.splitlines().index(shortcut_line)+24])
-    assert "closeMobileSidebar" in shortcut_block, \
-        "Cmd/Ctrl+K new chat shortcut must closeMobileSidebar() after creating the new session"
+    assert "closeMobileSidebar" in shortcut_block, (
+        "Cmd/Ctrl+Shift+O new chat shortcut must closeMobileSidebar() "
+        "after creating the new session"
+    )
 
 
 def test_new_conversation_shortcut_works_while_busy():
-    """Cmd/Ctrl+K should still create a new conversation while the current one is busy.
+    """Cmd/Ctrl+Shift+O should still create a new conversation while the current one is busy.
 
     The previous behavior gated the shortcut on !S.busy, which meant users had
     to wait for a long generation to finish before they could start something
     new — the exact moment they want to switch context.
     """
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    shortcut_line = next((ln for ln in boot_js.splitlines() if "e.key==='k'" in ln or "e.key === 'k'" in ln), "")
-    assert shortcut_line, "Cmd/Ctrl+K new chat shortcut missing from static/boot.js"
+    shortcut_line = next(
+        (
+            ln for ln in boot_js.splitlines()
+            if "(e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&" in ln
+            and "(e.key==='o'||" in ln
+        ),
+        "",
+    )
+    assert shortcut_line, "Cmd/Ctrl+Shift+O new chat shortcut missing from static/boot.js"
     # Inspect the next 10 lines after the keybinding match — the gating block
     # would live there if it had been kept.
     idx = boot_js.splitlines().index(shortcut_line)
@@ -867,10 +883,10 @@ def test_new_conversation_shortcut_works_while_busy():
     # Strip the existing message-count guard (which is unrelated and stays) so
     # we only check for an S.busy gate on the newSession() call itself.
     assert "if(!S.busy)" not in shortcut_block, (
-        "Cmd/Ctrl+K must not be blocked by the current session's busy state"
+        "Cmd/Ctrl+Shift+O must not be blocked by the current session's busy state"
     )
     assert "if (!S.busy)" not in shortcut_block, (
-        "Cmd/Ctrl+K must not be blocked by the current session's busy state"
+        "Cmd/Ctrl+Shift+O must not be blocked by the current session's busy state"
     )
 
 


### PR DESCRIPTION
## Thinking Path

- The J/K session-navigation workflow is already present, but the global new-chat handler still owns Ctrl/Cmd+K and can create a fresh conversation when users are working near the K navigation key.
- Ctrl/Cmd+Shift+O has no existing binding in the checked shortcut surface and matches the shortcut proposed in #3954.
- The final shape keeps ownership in the existing B14 global new-chat handler, restores the keyboard path's remembered-draft recovery parity with `$('btnNewChat').onclick`, updates the visible shortcut references, and adds behavioral regression coverage around both the remap and the recovered-draft path.

## What Changed

- `static/boot.js`: rebinds the global new-chat shortcut from Ctrl/Cmd+K to Ctrl/Cmd+Shift+O, preserves the empty-session guard, and makes the keyboard path reopen a remembered draft session before falling through to blank-session creation, matching `$('btnNewChat').onclick`.
- `static/index.html`: updates the New Conversation tooltip to advertise Cmd+Shift+O.
- `ARCHITECTURE.md`, `ROADMAP.md`, and `TESTING.md`: refresh the B14 shortcut references so the docs and manual test notes match the new binding, and now call out the remembered-draft recovery path explicitly.
- `tests/test_issue3954_new_chat_shortcut.py`: adds browserless behavioral coverage for Ctrl/Cmd+K removal, Ctrl/Cmd+Shift+O creation, the empty idle guard, the remembered-draft recovery path, tooltip text, and the Shift+O collision check.
- `tests/test_1432_newchat_and_1423_profile_input.py`, `tests/test_mobile_layout.py`, and `tests/test_issue3952_escape_blur_composer.py`: update existing shortcut assertions and anchors for the new binding.

## Why It Matters

Keyboard-navigation users can keep using J/K without accidentally opening a fresh conversation through Ctrl/Cmd+K. The replacement shortcut also lands on the same remembered draft session that the New Conversation button would restore after a reload, instead of always forcing a blank chat.

## Verification

- `python -m pytest tests/test_issue3954_new_chat_shortcut.py tests/test_3845_keyboard_session_nav.py tests/test_issue4391_settings_shortcut.py tests/test_1432_newchat_and_1423_profile_input.py::TestIssue1432NewChatGuardInFlight tests/test_mobile_layout.py::test_new_conversation_closes_mobile_sidebar tests/test_mobile_layout.py::test_new_conversation_shortcut_works_while_busy tests/test_issue3952_escape_blur_composer.py -v --timeout=60`

Full-suite CI context: `python -m pytest tests/ -v --timeout=60`.

## Upstream

Closes #3954.
Related implementation direction: https://github.com/nesquena/hermes-webui/pull/3953.

## Model Used

GPT 5.5 via Codex CLI