### PR TITLE
fix(auth): enforce active-profile session IDs

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -7416,6 +7416,10 @@ def create_stream_channel() -> StreamChannel:
 
 STREAMS: dict = {}
 STREAMS_LOCK = threading.Lock()
+# stream_id -> session_id owner, populated synchronously before worker startup so
+# stream-id authorization does not depend on worker lifecycle registration.
+STREAM_SESSION_OWNERS: dict = {}
+STREAM_SESSION_OWNERS_LOCK = threading.Lock()
 CANCEL_FLAGS: dict = {}
 AGENT_INSTANCES: dict = {}  # stream_id -> AIAgent instance for interrupt propagation
 STREAM_PARTIAL_TEXT: dict = {}  # stream_id -> partial assistant text accumulated during streaming
@@ -7424,6 +7428,37 @@ STREAM_LIVE_TOOL_CALLS: dict = {}  # stream_id -> live tool calls accumulated du
 STREAM_GOAL_RELATED: dict = {}  # stream_id -> bool: only evaluate goal for goal-related turns (#1932)
 STREAM_LAST_EVENT_ID: dict = {}  # stream_id -> latest journal event_id for `id:` field on live SSE frames (stage-364)
 PENDING_GOAL_CONTINUATION: set = set()  # session_ids awaiting a goal continuation turn (#1932)
+
+
+def register_stream_owner(stream_id: str, session_id: str) -> None:
+    """Record the session that owns a stream before worker startup."""
+    stream_id = str(stream_id or "").strip()
+    session_id = str(session_id or "").strip()
+    if not stream_id or not session_id:
+        return
+    with STREAM_SESSION_OWNERS_LOCK:
+        STREAM_SESSION_OWNERS[stream_id] = session_id
+
+
+def stream_owner_session_id(stream_id: str) -> str | None:
+    """Return the synchronously-recorded owner session for a stream, if any."""
+    stream_id = str(stream_id or "").strip()
+    if not stream_id:
+        return None
+    with STREAM_SESSION_OWNERS_LOCK:
+        owner = STREAM_SESSION_OWNERS.get(stream_id)
+    owner = str(owner or "").strip()
+    return owner or None
+
+
+def unregister_stream_owner(stream_id: str) -> None:
+    """Forget the pre-worker stream owner once the stream has torn down."""
+    stream_id = str(stream_id or "").strip()
+    if not stream_id:
+        return
+    with STREAM_SESSION_OWNERS_LOCK:
+        STREAM_SESSION_OWNERS.pop(stream_id, None)
+
 
 # ── Gateway capability cache ─────────────────────────────────────────────────
 # Probes /v1/capabilities once per base_url/api-key pair and caches the result
@@ -7608,6 +7643,7 @@ def unregister_active_run(stream_id: str) -> None:
     with ACTIVE_RUNS_LOCK:
         ACTIVE_RUNS.pop(stream_id, None)
         LAST_RUN_FINISHED_AT = time.time()
+    unregister_stream_owner(stream_id)
 
 # Agent cache: reuse AIAgent across messages in the same WebUI session so that
 # _user_turn_count survives between turns.  This mirrors the gateway's

--- a/api/routes.py
+++ b/api/routes.py
@@ -18021,18 +18021,6 @@ def _handle_chat_start(handler, body, diag=None):
                 s.profile = requested_profile
             else:
                 return bad(handler, "Session not found", 404)
-        elif (
-            requested_profile
-            and _profiles_match(requested_profile, active_profile)
-            and not _profiles_match(session_profile, requested_profile)
-        ):
-            # Empty sessions are placeholders. If the user switches profiles
-            # before sending the first turn, run the placeholder under the
-            # active request profile instead of the stale one stamped at
-            # creation time. The request body alone must not retag a session to
-            # a different profile than the server-selected active profile.
-            if not has_persisted_turns:
-                s.profile = requested_profile
         diag.stage("normalize_message") if diag else None
         msg = str(body.get("message", "")).strip()
         if not msg:

--- a/api/routes.py
+++ b/api/routes.py
@@ -497,6 +497,50 @@ def _session_visible_to_active_profile(session_profile, handler=None) -> bool:
     return _profiles_match(session_profile, active_profile)
 
 
+def _request_session_visibility_exempt(method: str, path: str | None) -> bool:
+    if not path:
+        return False
+    if method != "POST":
+        return False
+    # Import routes create/claim sessions before normal ownership exists, and
+    # chat/start has inline placeholder-retag rules that must run before the
+    # generic request-session guard.
+    return path in {
+        "/api/session/import",
+        "/api/session/import_cli",
+        "/api/chat/start",
+    }
+
+
+def _session_id_visible_to_request_profile(handler, sid) -> bool:
+    """Return whether ``sid`` belongs to the active profile."""
+    if not isinstance(sid, str) or not sid:
+        return True
+    if not is_safe_session_id(sid):
+        return True
+    try:
+        session = get_session(sid, metadata_only=True)
+    except KeyError:
+        return True
+    if not _session_visible_to_active_profile(getattr(session, "profile", None), handler):
+        bad(handler, "Session not found", 404)
+        return False
+    return True
+
+
+def _guard_request_session_visibility(handler, parsed, body=None, method="GET") -> bool:
+    """Apply request session-profile visibility check to request-supplied IDs."""
+    method = str(method).upper()
+    if _request_session_visibility_exempt(method, getattr(parsed, "path", "")):
+        return True
+    sid = parse_qs(parsed.query).get("session_id", [None])[0]
+    if not _session_id_visible_to_request_profile(handler, sid):
+        return False
+    if isinstance(body, dict) and not _session_id_visible_to_request_profile(handler, body.get("session_id")):
+        return False
+    return True
+
+
 def _active_skills_dir() -> Path:
     """Return the skills directory for the request's active Hermes profile.
 
@@ -9907,6 +9951,9 @@ def handle_get(handler, parsed) -> bool:
             handler.end_headers()
         return True
 
+    if parsed.path.startswith("/api/") and not _guard_request_session_visibility(handler, parsed, method="GET"):
+        return True
+
     # ── Insights / knowledge status ──
     if parsed.path == "/api/insights":
         return _handle_insights(handler, parsed)
@@ -11494,6 +11541,10 @@ def handle_post(handler, parsed) -> bool:
         if diag:
             diag.finish()
         raise
+    if not _guard_request_session_visibility(handler, parsed, body=body, method="POST"):
+        if diag:
+            diag.finish()
+        return True
 
     if parsed.path == "/api/escape/authorize":
         return _handle_escape_authorize(handler, parsed, body)
@@ -13647,6 +13698,8 @@ def handle_patch(handler, parsed) -> bool:
     if not _check_csrf(handler):
         return j(handler, {"error": _csrf_rejection_error(handler)}, status=403)
     body = read_body(handler)
+    if not _guard_request_session_visibility(handler, parsed, body=body, method="PATCH"):
+        return True
     if parsed.path.startswith("/api/mcp/servers/"):
         name = parsed.path[len("/api/mcp/servers/"):]
         return _handle_mcp_server_toggle(handler, name, body)
@@ -13665,6 +13718,8 @@ def handle_delete(handler, parsed) -> bool:
     if not _check_csrf(handler):
         return j(handler, {"error": _csrf_rejection_error(handler)}, status=403)
     body = read_body(handler)
+    if not _guard_request_session_visibility(handler, parsed, body=body, method="DELETE"):
+        return True
     if parsed.path.startswith("/api/mcp/servers/"):
         name = parsed.path[len("/api/mcp/servers/"):]
         return _handle_mcp_server_delete(handler, name)
@@ -13691,6 +13746,8 @@ def handle_put(handler, parsed) -> bool:
     if not _check_csrf(handler):
         return j(handler, {"error": "Cross-origin request rejected"}, status=403)
     body = read_body(handler)
+    if not _guard_request_session_visibility(handler, parsed, body=body, method="PUT"):
+        return True
     if parsed.path.startswith("/api/mcp/servers/"):
         name = parsed.path[len("/api/mcp/servers/"):]
         return _handle_mcp_server_update(handler, name, body)
@@ -17938,6 +17995,7 @@ def _handle_chat_start(handler, body, diag=None):
             return bad(handler, "Read-only imported sessions cannot be continued from WebUI", 403)
         diag.stage("validate_profile") if diag else None
         requested_profile = str(body.get("profile") or "").strip()
+        active_profile = _get_active_profile_name()
         if requested_profile:
             try:
                 from api.profiles import _PROFILE_ID_RE
@@ -17946,17 +18004,34 @@ def _handle_chat_start(handler, body, diag=None):
                     return bad(handler, "invalid profile", 400)
             except ImportError:
                 requested_profile = ""
-        if requested_profile and not _profiles_match(getattr(s, "profile", None), requested_profile):
-            has_persisted_turns = bool(
-                getattr(s, "messages", None)
-                or getattr(s, "context_messages", None)
-                or getattr(s, "pending_user_message", None)
-            )
+        session_profile = getattr(s, "profile", None)
+        has_persisted_turns = bool(
+            getattr(s, "messages", None)
+            or getattr(s, "context_messages", None)
+            or getattr(s, "pending_user_message", None)
+        )
+        if not _session_visible_to_active_profile(session_profile, handler):
+            if (
+                requested_profile
+                and _profiles_match(requested_profile, active_profile)
+                and not has_persisted_turns
+            ):
+                # Empty placeholders can still be retagged when the
+                # requested profile matches the active request profile.
+                s.profile = requested_profile
+            else:
+                return bad(handler, "Session not found", 404)
+        elif (
+            requested_profile
+            and _profiles_match(requested_profile, active_profile)
+            and not _profiles_match(session_profile, requested_profile)
+        ):
+            # Empty sessions are placeholders. If the user switches profiles
+            # before sending the first turn, run the placeholder under the
+            # active request profile instead of the stale one stamped at
+            # creation time. The request body alone must not retag a session to
+            # a different profile than the server-selected active profile.
             if not has_persisted_turns:
-                # Empty sessions are placeholders. If the user switches profiles
-                # before sending the first turn, run the placeholder under the
-                # currently-selected profile instead of the stale one stamped at
-                # creation time.
                 s.profile = requested_profile
         diag.stage("normalize_message") if diag else None
         msg = str(body.get("message", "")).strip()

--- a/api/routes.py
+++ b/api/routes.py
@@ -533,7 +533,7 @@ def _guard_request_session_visibility(handler, parsed, body=None, method="GET") 
     method = str(method).upper()
     if _request_session_visibility_exempt(method, getattr(parsed, "path", "")):
         return True
-    sid = parse_qs(parsed.query).get("session_id", [None])[0]
+    sid = parse_qs(getattr(parsed, "query", "") or "").get("session_id", [None])[0]
     if not _session_id_visible_to_request_profile(handler, sid):
         return False
     if isinstance(body, dict) and not _session_id_visible_to_request_profile(handler, body.get("session_id")):

--- a/api/routes.py
+++ b/api/routes.py
@@ -529,7 +529,11 @@ def _session_id_visible_to_request_profile(handler, sid) -> bool:
 
 
 def _guard_request_session_visibility(handler, parsed, body=None, method="GET") -> bool:
-    """Apply request session-profile visibility check to request-supplied IDs."""
+    """Apply request session-profile visibility check to request-supplied IDs.
+
+    Covers top-level `session_id` in the query/body. Routes that accept session
+    IDs under other keys must enforce their own visibility checks.
+    """
     method = str(method).upper()
     if _request_session_visibility_exempt(method, getattr(parsed, "path", "")):
         return True

--- a/api/routes.py
+++ b/api/routes.py
@@ -512,7 +512,7 @@ def _request_session_visibility_exempt(method: str, path: str | None) -> bool:
     }
 
 
-def _session_id_visible_to_request_profile(handler, sid) -> bool:
+def _session_id_visible_to_request_profile(handler, sid, *, emit_error: bool = True) -> bool:
     """Return whether ``sid`` belongs to the active profile."""
     if not isinstance(sid, str) or not sid:
         return True
@@ -523,9 +523,55 @@ def _session_id_visible_to_request_profile(handler, sid) -> bool:
     except KeyError:
         return True
     if not _session_visible_to_active_profile(getattr(session, "profile", None), handler):
-        bad(handler, "Session not found", 404)
+        if emit_error:
+            bad(handler, "Session not found", 404)
         return False
     return True
+
+
+def _stream_id_owner_session_id(stream_id: str | None) -> str | None:
+    """Resolve stream owner session_id via active-run registry first, fallback to journal."""
+    stream_id = str(stream_id or "").strip()
+    if not stream_id:
+        return None
+    try:
+        with ACTIVE_RUNS_LOCK:
+            raw = (ACTIVE_RUNS or {}).get(stream_id)
+        if isinstance(raw, dict):
+            owner = str(raw.get("session_id") or "").strip()
+            if owner:
+                return owner
+    except Exception:
+        logger.debug("Failed reading ACTIVE_RUNS owner for stream %s", stream_id, exc_info=True)
+    try:
+        owner = stream_owner_session_id(stream_id)
+        if owner:
+            return owner
+    except Exception:
+        logger.debug("Failed reading registered owner for stream %s", stream_id, exc_info=True)
+    if not is_safe_session_id(stream_id):
+        return None
+    try:
+        summary = find_run_summary(stream_id)
+        if isinstance(summary, dict):
+            owner = str(summary.get("session_id") or "").strip()
+            return owner or None
+    except Exception:
+        logger.debug("Failed reading run summary for stream %s", stream_id, exc_info=True)
+    return None
+
+
+def _stream_id_visible_to_request_profile(
+    handler,
+    stream_id: str | None,
+    *,
+    emit_error: bool = True,
+) -> bool:
+    """Return whether the stream owner is visible to the request's profile."""
+    owner_session_id = _stream_id_owner_session_id(stream_id)
+    if not owner_session_id:
+        return True
+    return _session_id_visible_to_request_profile(handler, owner_session_id, emit_error=emit_error)
 
 
 def _guard_request_session_visibility(handler, parsed, body=None, method="GET") -> bool:
@@ -2214,6 +2260,10 @@ from api.config import (
     MIME_MAP,
     MAX_FILE_BYTES,
     MAX_UPLOAD_BYTES,
+    ACTIVE_RUNS,
+    ACTIVE_RUNS_LOCK,
+    register_stream_owner,
+    stream_owner_session_id,
     CHAT_LOCK,
     _get_session_agent_lock,
     SESSION_AGENT_LOCKS,
@@ -2492,9 +2542,15 @@ def _truncate_journal_snapshot_value(value, *, limit: int = 120):
     return value
 
 
-def _run_journal_live_snapshot(stream_id: str | None) -> dict | None:
+def _run_journal_live_snapshot(stream_id: str | None, *, handler=None) -> dict | None:
     stream_id = str(stream_id or "").strip()
     if not stream_id:
+        return None
+    if handler is not None and not _stream_id_visible_to_request_profile(
+        handler,
+        stream_id,
+        emit_error=False,
+    ):
         return None
     summary = find_run_summary(stream_id)
     if not summary:
@@ -9298,14 +9354,16 @@ def _run_lifecycle_health() -> dict:
     now = time.time()
     with _live_config.ACTIVE_RUNS_LOCK:
         runs = []
-        for stream_id, raw in (_live_config.ACTIVE_RUNS or {}).items():
+        for _stream_id, raw in (_live_config.ACTIVE_RUNS or {}).items():
             item = dict(raw or {})
+            item.pop("session_id", None)
+            item.pop("stream_id", None)
+            item.pop("workspace", None)
             started_at = item.get("started_at")
             try:
                 age = max(0.0, now - float(started_at))
             except Exception:
                 age = 0.0
-            item.setdefault("stream_id", stream_id)
             item["age_seconds"] = round(age, 1)
             runs.append(item)
         last_finished = _live_config.LAST_RUN_FINISHED_AT
@@ -10547,7 +10605,7 @@ def handle_get(handler, parsed) -> bool:
                     )
                     if journal_active:
                         try:
-                            snapshot = _run_journal_live_snapshot(original_stream_id)
+                            snapshot = _run_journal_live_snapshot(original_stream_id, handler=handler)
                         except Exception:
                             logger.debug(
                                 "Failed to build runtime journal snapshot for %s",
@@ -10959,6 +11017,8 @@ def handle_get(handler, parsed) -> bool:
 
     if parsed.path == "/api/chat/stream/status":
         stream_id = parse_qs(parsed.query).get("stream_id", [""])[0]
+        if not _stream_id_visible_to_request_profile(handler, stream_id):
+            return True
         active = stream_id in STREAMS
         payload = {"active": active, "stream_id": stream_id, "replay_available": False}
         try:
@@ -10974,6 +11034,8 @@ def handle_get(handler, parsed) -> bool:
         stream_id = parse_qs(parsed.query).get("stream_id", [""])[0]
         if not stream_id:
             return bad(handler, "stream_id required")
+        if not _stream_id_visible_to_request_profile(handler, stream_id):
+            return True
         from api.runtime_adapter import LegacyJournalRuntimeAdapter, runtime_adapter_enabled
 
         if runtime_adapter_enabled():
@@ -11680,6 +11742,8 @@ def handle_post(handler, parsed) -> bool:
         # ── Memory lifecycle: commit the previous session before starting a new one ──
         prev_session_id = body.get("prev_session_id")
         if prev_session_id:
+            if not _session_id_visible_to_request_profile(handler, prev_session_id):
+                return True
             try:
                 from api.session_lifecycle import commit_session_memory
                 from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
@@ -14347,6 +14411,8 @@ def _stream_runner_run_events(handler, run_id: str, cursor: str | None = None) -
 def _handle_sse_stream(handler, parsed):
     qs = parse_qs(parsed.query)
     stream_id = qs.get("stream_id", [""])[0]
+    if not _stream_id_visible_to_request_profile(handler, stream_id):
+        return True
     stream = STREAMS.get(stream_id)
     if stream is None:
         if _stream_runner_run_events(handler, stream_id, _runner_stream_cursor_from_query(qs)):
@@ -17000,6 +17066,7 @@ def _handle_btw(handler, body):
     ephemeral.active_stream_id = stream_id
     ephemeral.save()
     stream = create_stream_channel()
+    register_stream_owner(stream_id, ephemeral.session_id)
     with STREAMS_LOCK:
         STREAMS[stream_id] = stream
     from api.background import track_btw
@@ -17046,6 +17113,7 @@ def _handle_background(handler, body):
     bg.active_stream_id = stream_id
     bg.save()
     stream = create_stream_channel()
+    register_stream_owner(stream_id, bg.session_id)
     with STREAMS_LOCK:
         STREAMS[stream_id] = stream
     task_id = uuid.uuid4().hex[:8]
@@ -17431,6 +17499,7 @@ def _start_chat_stream_for_session(
     set_last_workspace(workspace)
     diag.stage("stream_registration") if diag else None
     stream = create_stream_channel()
+    register_stream_owner(stream_id, s.session_id)
     with STREAMS_LOCK:
         STREAMS[stream_id] = stream
     # #1932: mark stream as goal-related so the streaming hook evaluates the goal.

--- a/api/upload.py
+++ b/api/upload.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from api.config import MAX_UPLOAD_BYTES, STATE_DIR
 from api.helpers import j, bad
 from api.models import get_session
+from api.profiles import _profiles_match, get_active_profile_name as _get_active_profile_name
 from api.workspace import (
     safe_resolve_ws,
     resolve_trusted_workspace,
@@ -150,6 +151,21 @@ def _session_attachment_dir(session_id: str, *, root: Path | None = None) -> Pat
     return dest_dir
 
 
+def _session_visible_to_active_profile(session) -> bool:
+    """Return whether an upload target session belongs to the active profile."""
+    session_profile = getattr(session, 'profile', None)
+    if not isinstance(session_profile, str):
+        session_profile = None
+    return _profiles_match(session_profile, _get_active_profile_name())
+
+
+def _reject_invisible_session(handler, session) -> bool:
+    if _session_visible_to_active_profile(session):
+        return False
+    j(handler, {'error': 'Session not found'}, status=404)
+    return True
+
+
 def handle_upload(handler):
     import traceback as _tb
     try:
@@ -168,6 +184,8 @@ def handle_upload(handler):
             s = get_session(session_id)
         except KeyError:
             return j(handler, {'error': 'Session not found'}, status=404)
+        if _reject_invisible_session(handler, s):
+            return True
         safe_name = _sanitize_upload_name(filename)
         dest = _upload_destination(session_id, safe_name)
         dest.write_bytes(file_bytes)
@@ -344,6 +362,8 @@ def handle_upload_extract(handler):
             s = get_session(session_id)
         except KeyError:
             return j(handler, {'error': 'Session not found'}, status=404)
+        if _reject_invisible_session(handler, s):
+            return True
         session_dir = _session_attachment_dir(session_id)
         session_dir.mkdir(parents=True, exist_ok=True)
         result = extract_archive(file_bytes, filename, session_dir)
@@ -563,6 +583,8 @@ def handle_workspace_upload(handler):
             session = get_session(session_id)
         except KeyError:
             return j(handler, {'error': 'Session not found'}, status=404)
+        if _reject_invisible_session(handler, session):
+            return True
 
         # Resolve workspace root from session
         workspace = resolve_trusted_workspace(session.workspace)

--- a/tests/test_profile_switch_1200.py
+++ b/tests/test_profile_switch_1200.py
@@ -478,6 +478,7 @@ def test_chat_start_retags_empty_session_to_request_profile(monkeypatch, tmp_pat
 
     fake = FakeSession()
     monkeypatch.setattr(routes, "get_session", lambda sid: fake)
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "work")
     monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda path: tmp_path)
     monkeypatch.setattr(
         routes,

--- a/tests/test_run_journal_routes.py
+++ b/tests/test_run_journal_routes.py
@@ -265,7 +265,7 @@ def test_session_payload_exposes_runtime_journal_for_stale_streams():
     assert "original_stream_id = getattr(s, \"active_stream_id\", None)" in ROUTES_SRC
     assert '"runtime_journal"' in ROUTES_SRC
     assert '"runtime_journal_snapshot"' in ROUTES_SRC
-    assert "_run_journal_live_snapshot(original_stream_id)" in ROUTES_SRC
+    assert "_run_journal_live_snapshot(original_stream_id, handler=handler)" in ROUTES_SRC
     assert 'terminal_state = "lost-worker-bookkeeping"' in ROUTES_SRC
     assert "active=journal_active" in ROUTES_SRC
     assert "journal_active = bool(original_stream_id in active_stream_ids)" in ROUTES_SRC

--- a/tests/test_run_lifecycle_health.py
+++ b/tests/test_run_lifecycle_health.py
@@ -14,6 +14,7 @@ def test_health_counts_active_runs_even_when_no_sse_streams():
         config.ACTIVE_RUNS["stream-1"] = {
             "stream_id": "stream-1",
             "session_id": "session-1",
+            "workspace": "/private/workspace",
             "started_at": time.time() - 42,
             "phase": "running",
         }
@@ -25,7 +26,10 @@ def test_health_counts_active_runs_even_when_no_sse_streams():
         assert stream_check["active_streams"] == 0
         assert run_check["active_runs"] == 1
         assert run_check["oldest_run_age_seconds"] >= 40
-        assert run_check["runs"][0]["session_id"] == "session-1"
+        run = run_check["runs"][0]
+        assert "session_id" not in run
+        assert "stream_id" not in run
+        assert "workspace" not in run
     finally:
         with config.ACTIVE_RUNS_LOCK:
             config.ACTIVE_RUNS.clear()
@@ -38,13 +42,16 @@ def test_run_registry_unregister_records_last_finished_time():
     with config.ACTIVE_RUNS_LOCK:
         config.ACTIVE_RUNS.clear()
         config.LAST_RUN_FINISHED_AT = None
+    config.register_stream_owner("stream-2", "session-2")
 
     config.register_active_run("stream-2", session_id="session-2", phase="starting")
     with config.ACTIVE_RUNS_LOCK:
         assert "stream-2" in config.ACTIVE_RUNS
+    assert config.stream_owner_session_id("stream-2") == "session-2"
 
     config.unregister_active_run("stream-2")
 
     with config.ACTIVE_RUNS_LOCK:
         assert "stream-2" not in config.ACTIVE_RUNS
         assert isinstance(config.LAST_RUN_FINISHED_AT, float)
+    assert config.stream_owner_session_id("stream-2") is None

--- a/tests/test_session_active_profile_authorization.py
+++ b/tests/test_session_active_profile_authorization.py
@@ -1,0 +1,261 @@
+"""Regression tests for session-profile visibility on request-scoped session_id uses.
+
+The security contract is now enforced with a generic preflight for request-supplied
+session IDs. These tests cover the most sensitive paths that previously loaded
+foreign-profile sessions directly: duplicate, file reads, and chat/start.
+"""
+
+from __future__ import annotations
+
+import io
+from urllib.parse import urlparse
+
+import api.routes as routes
+import api.upload as upload
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.status = None
+        self.headers = {"Content-Type": "multipart/form-data; boundary=test", "Content-Length": "1"}
+        self.rfile = io.BytesIO(b"")
+        self.wfile = io.BytesIO()
+        self.command = "GET"
+        self.path = "/"
+        self.client_address = ("127.0.0.1", 12345)
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.headers[key] = value
+
+    def end_headers(self):
+        pass
+
+
+def _capture(monkeypatch):
+    cap = {}
+
+    def _j(_h, obj, *_, **__):
+        cap["ok"] = obj
+        return True
+
+    def _bad(_h, msg, code=400):
+        cap["bad"] = (msg, code)
+        return True
+
+    monkeypatch.setattr(routes, "j", _j)
+    monkeypatch.setattr(routes, "bad", _bad)
+    return cap
+
+
+def _capture_upload(monkeypatch):
+    cap = {}
+
+    def _j(_h, obj, *_, **kwargs):
+        cap["ok"] = obj
+        cap["status"] = kwargs.get("status", 200)
+        return True
+
+    monkeypatch.setattr(upload, "j", _j)
+    return cap
+
+
+class _SimpleSession:
+    def __init__(self, sid, profile="default", workspace="/workspace", messages=None, context_messages=None, pending_user_message=None):
+        self.session_id = sid
+        self.profile = profile
+        self.workspace = workspace
+        self.model = "test-model"
+        self.model_provider = None
+        self.title = "Test"
+        self.messages = messages or []
+        self.tool_calls = []
+        self.project_id = None
+        self.context_messages = context_messages
+        self.pending_user_message = pending_user_message
+        self.personality = None
+        self.enabled_toolsets = None
+        self.context_length = None
+        self.threshold_tokens = None
+        self.truncation_watermark = None
+        self.truncation_boundary = None
+        self.gateway_routing = None
+        self.gateway_routing_history = []
+        self.llm_title_generated = False
+        self.manual_title = False
+        self.composer_draft = {}
+        self.context_engine = None
+        self.context_engine_state = {}
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.estimated_cost = 0.0
+        self.cache_read_tokens = 0
+        self.cache_write_tokens = 0
+
+
+def test_session_duplicate_foreign_profile_session_blocked_by_visibility_guard(monkeypatch):
+    handler = _FakeHandler()
+    foreign = _SimpleSession("foreign_duplicate", profile="other")
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: foreign)
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": "foreign_duplicate"})
+    monkeypatch.setattr(routes.Session, "load", staticmethod(lambda sid: (_ for _ in ()).throw(AssertionError("duplicate should not materialize foreign session"))))
+
+    cap = _capture(monkeypatch)
+    routes.handle_post(handler, urlparse("/api/session/duplicate"))
+
+    assert cap["bad"] == ("Session not found", 404)
+
+
+def test_session_duplicate_same_profile_still_duplicates(monkeypatch):
+    handler = _FakeHandler()
+    source = _SimpleSession("session_visible", profile="default")
+    calls = {"load": 0, "save": 0}
+
+    def _load(_sid):
+        calls["load"] += 1
+        return source
+
+    monkeypatch.setattr(routes.Session, "load", staticmethod(_load))
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: source)
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": "session_visible"})
+
+    def _session_save(_self, *_, **__):
+        calls["save"] += 1
+
+    monkeypatch.setattr(routes.Session, "save", _session_save)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_, **__: None)
+
+    cap = _capture(monkeypatch)
+    routes.handle_post(handler, urlparse("/api/session/duplicate"))
+
+    assert calls["load"] == 1
+    assert calls["save"] == 1
+    assert "bad" not in cap
+    assert cap["ok"]["session"]["session_id"] != "session_visible"
+
+
+def test_file_read_foreign_profile_session_returns_404_before_file_ops(monkeypatch):
+    handler = _FakeHandler()
+    foreign = _SimpleSession("foreign_file", profile="other", workspace="/workspace")
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: foreign)
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(routes, "get_session_for_file_ops", lambda sid: (_ for _ in ()).throw(AssertionError("file ops should not run")))
+    cap = _capture(monkeypatch)
+
+    routes.handle_get(handler, urlparse("/api/file?session_id=foreign_file&path=notes.txt"))
+
+    assert cap["bad"] == ("Session not found", 404)
+
+
+def test_chat_start_foreign_persisted_session_returns_404_before_start_run(monkeypatch):
+    handler = _FakeHandler()
+    persisted_foreign = _SimpleSession(
+        "chat_foreign",
+        profile="other",
+        messages=[{"role": "user", "content": "first"}],
+    )
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": "chat_foreign", "message": "hello"})
+    monkeypatch.setattr(routes, "_get_or_materialize_session", lambda sid: persisted_foreign)
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(routes, "_start_run", lambda *_, **__: (_ for _ in ()).throw(AssertionError("_start_run should not run")))
+
+    cap = _capture(monkeypatch)
+    routes.handle_post(handler, urlparse("/api/chat/start"))
+
+    assert cap["bad"] == ("Session not found", 404)
+
+
+def test_chat_start_body_profile_cannot_retag_visible_empty_session_without_active_profile(monkeypatch):
+    handler = _FakeHandler()
+    empty_visible = _SimpleSession("chat_empty", profile="default", messages=[])
+    captured = {}
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(
+        routes,
+        "read_body",
+        lambda _handler: {"session_id": "chat_empty", "message": "hello", "profile": "other"},
+    )
+    monkeypatch.setattr(routes, "_get_or_materialize_session", lambda sid: empty_visible)
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(routes, "_resolve_chat_workspace_with_recovery", lambda *_args, **_kwargs: "/workspace")
+    monkeypatch.setattr(routes, "_read_profile_model_config", lambda *_args, **_kwargs: (None, None))
+    monkeypatch.setattr(
+        routes,
+        "_resolve_compatible_session_model_state",
+        lambda *_args, **_kwargs: ("test-model", None, "test-model"),
+    )
+
+    def _start_run(session, **_kwargs):
+        captured["profile"] = session.profile
+        return {"ok": True, "stream_id": "stream-test", "session_id": session.session_id}
+
+    monkeypatch.setattr(routes, "_start_run", _start_run)
+
+    cap = _capture(monkeypatch)
+    routes.handle_post(handler, urlparse("/api/chat/start"))
+
+    assert "bad" not in cap
+    assert captured["profile"] == "default"
+
+
+def test_attachment_upload_foreign_profile_session_returns_404_before_write(monkeypatch):
+    handler = _FakeHandler()
+    foreign = _SimpleSession("upload_foreign", profile="other")
+    monkeypatch.setattr(upload, "parse_multipart", lambda *_args: ({"session_id": "upload_foreign"}, {"file": ("note.txt", b"x")}))
+    monkeypatch.setattr(upload, "get_session", lambda sid: foreign)
+    monkeypatch.setattr(upload, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        upload,
+        "_upload_destination",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("upload destination should not be resolved")),
+    )
+
+    cap = _capture_upload(monkeypatch)
+    upload.handle_upload(handler)
+
+    assert cap == {"ok": {"error": "Session not found"}, "status": 404}
+
+
+def test_archive_upload_extract_foreign_profile_session_returns_404_before_extract(monkeypatch):
+    handler = _FakeHandler()
+    foreign = _SimpleSession("extract_foreign", profile="other")
+    monkeypatch.setattr(upload, "parse_multipart", lambda *_args: ({"session_id": "extract_foreign"}, {"file": ("archive.zip", b"zip")}))
+    monkeypatch.setattr(upload, "get_session", lambda sid: foreign)
+    monkeypatch.setattr(upload, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        upload,
+        "extract_archive",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("archive extraction should not run")),
+    )
+
+    cap = _capture_upload(monkeypatch)
+    upload.handle_upload_extract(handler)
+
+    assert cap == {"ok": {"error": "Session not found"}, "status": 404}
+
+
+def test_workspace_upload_foreign_profile_session_returns_404_before_workspace_resolution(monkeypatch):
+    handler = _FakeHandler()
+    foreign = _SimpleSession("workspace_foreign", profile="other", workspace="/workspace/foreign")
+    monkeypatch.setattr(upload, "parse_multipart", lambda *_args: ({"session_id": "workspace_foreign"}, {"file": ("note.txt", b"x")}))
+    monkeypatch.setattr(upload, "get_session", lambda sid: foreign)
+    monkeypatch.setattr(upload, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        upload,
+        "resolve_trusted_workspace",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("workspace should not be resolved")),
+    )
+
+    cap = _capture_upload(monkeypatch)
+    upload.handle_workspace_upload(handler)
+
+    assert cap == {"ok": {"error": "Session not found"}, "status": 404}

--- a/tests/test_session_active_profile_authorization.py
+++ b/tests/test_session_active_profile_authorization.py
@@ -8,6 +8,7 @@ foreign-profile sessions directly: duplicate, file reads, and chat/start.
 from __future__ import annotations
 
 import io
+import time
 from urllib.parse import urlparse
 
 import api.routes as routes
@@ -259,3 +260,254 @@ def test_workspace_upload_foreign_profile_session_returns_404_before_workspace_r
     upload.handle_workspace_upload(handler)
 
     assert cap == {"ok": {"error": "Session not found"}, "status": 404}
+
+
+def test_chat_stream_status_blocks_foreign_active_stream(monkeypatch):
+    from api import config
+
+    handler = _FakeHandler()
+    foreign = _SimpleSession("foreign_session", profile="other")
+
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: foreign if sid == "foreign_session" else (_ for _ in ()).throw(KeyError("Session not found")))
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    with config.ACTIVE_RUNS_LOCK:
+        previous = dict(config.ACTIVE_RUNS)
+        config.ACTIVE_RUNS.clear()
+        config.ACTIVE_RUNS["stream-foreign"] = {
+            "session_id": "foreign_session",
+            "started_at": time.time(),
+            "phase": "running",
+        }
+
+    try:
+        cap = _capture(monkeypatch)
+        routes.handle_get(handler, urlparse("/api/chat/stream/status?stream_id=stream-foreign"))
+    finally:
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+            config.ACTIVE_RUNS.update(previous)
+
+    assert cap["bad"] == ("Session not found", 404)
+
+
+def test_chat_stream_status_blocks_foreign_registered_stream_before_worker_start(monkeypatch):
+    from api import config
+
+    handler = _FakeHandler()
+    foreign = _SimpleSession("foreign_session", profile="other")
+
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda sid, metadata_only=False: foreign
+        if sid == "foreign_session"
+        else (_ for _ in ()).throw(KeyError("Session not found")),
+    )
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        routes,
+        "find_run_summary",
+        lambda _stream_id: (_ for _ in ()).throw(AssertionError("journal fallback should not run")),
+    )
+    with config.ACTIVE_RUNS_LOCK:
+        previous_runs = dict(config.ACTIVE_RUNS)
+        config.ACTIVE_RUNS.clear()
+    with config.STREAM_SESSION_OWNERS_LOCK:
+        previous_owners = dict(config.STREAM_SESSION_OWNERS)
+        config.STREAM_SESSION_OWNERS.clear()
+    config.register_stream_owner("stream-registered", "foreign_session")
+
+    try:
+        cap = _capture(monkeypatch)
+        routes.handle_get(handler, urlparse("/api/chat/stream/status?stream_id=stream-registered"))
+    finally:
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+            config.ACTIVE_RUNS.update(previous_runs)
+        with config.STREAM_SESSION_OWNERS_LOCK:
+            config.STREAM_SESSION_OWNERS.clear()
+            config.STREAM_SESSION_OWNERS.update(previous_owners)
+
+    assert cap["bad"] == ("Session not found", 404)
+
+
+def test_chat_stream_status_keeps_same_profile_stream_visible(monkeypatch):
+    from api import config
+
+    handler = _FakeHandler()
+    visible = _SimpleSession("visible_session", profile="default")
+
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: visible if sid == "visible_session" else (_ for _ in ()).throw(KeyError("Session not found")))
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    with config.ACTIVE_RUNS_LOCK:
+        previous = dict(config.ACTIVE_RUNS)
+        config.ACTIVE_RUNS.clear()
+        config.ACTIVE_RUNS["stream-visible"] = {
+            "session_id": "visible_session",
+            "started_at": time.time(),
+            "phase": "running",
+        }
+
+    try:
+        cap = _capture(monkeypatch)
+        routes.handle_get(handler, urlparse("/api/chat/stream/status?stream_id=stream-visible"))
+    finally:
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+            config.ACTIVE_RUNS.update(previous)
+
+    assert cap["ok"]["stream_id"] == "stream-visible"
+    assert cap["ok"]["active"] is False
+
+
+def test_chat_cancel_blocks_foreign_owned_stream_before_cancel_call(monkeypatch):
+    from api import runtime_adapter
+    from api import config
+    handler = _FakeHandler()
+    foreign = _SimpleSession("foreign_session", profile="other")
+    calls = {"cancel": 0}
+
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: foreign if sid == "foreign_session" else (_ for _ in ()).throw(KeyError("Session not found")))
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    with config.ACTIVE_RUNS_LOCK:
+        previous = dict(config.ACTIVE_RUNS)
+        config.ACTIVE_RUNS.clear()
+        config.ACTIVE_RUNS["stream-foreign"] = {
+            "session_id": "foreign_session",
+            "started_at": time.time(),
+            "phase": "running",
+        }
+    monkeypatch.setattr(runtime_adapter, "runtime_adapter_enabled", lambda: False)
+    monkeypatch.setattr(routes, "cancel_stream", lambda _stream_id: calls.__setitem__("cancel", calls["cancel"] + 1) or True)
+
+    cap = _capture(monkeypatch)
+    try:
+        routes.handle_get(
+            handler,
+            urlparse("/api/chat/cancel?stream_id=stream-foreign"),
+        )
+    finally:
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+            config.ACTIVE_RUNS.update(previous)
+
+    assert calls["cancel"] == 0
+    assert cap["bad"] == ("Session not found", 404)
+
+
+def test_chat_cancel_same_profile_stream_still_passes_through(monkeypatch):
+    from api import runtime_adapter
+    handler = _FakeHandler()
+    visible = _SimpleSession("visible_session", profile="default")
+    calls = {"cancel": 0}
+
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: visible if sid == "visible_session" else (_ for _ in ()).throw(KeyError("Session not found")))
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(runtime_adapter, "runtime_adapter_enabled", lambda: False)
+    monkeypatch.setattr(routes, "cancel_stream", lambda _stream_id: calls.__setitem__("cancel", calls["cancel"] + 1) or True)
+
+    cap = _capture(monkeypatch)
+
+    with routes.ACTIVE_RUNS_LOCK:
+        previous = dict(routes.ACTIVE_RUNS)
+        routes.ACTIVE_RUNS.clear()
+        routes.ACTIVE_RUNS["stream-visible"] = {
+            "session_id": "visible_session",
+            "started_at": time.time(),
+            "phase": "running",
+        }
+
+    try:
+        routes.handle_get(handler, urlparse("/api/chat/cancel?stream_id=stream-visible"))
+    finally:
+        with routes.ACTIVE_RUNS_LOCK:
+            routes.ACTIVE_RUNS.clear()
+            routes.ACTIVE_RUNS.update(previous)
+
+    assert calls["cancel"] == 1
+    assert cap["ok"]["cancelled"] is True
+
+
+def test_chat_stream_blocks_foreign_owned_dead_stream_before_replay(monkeypatch):
+    from api import runtime_adapter
+    handler = _FakeHandler()
+    foreign = _SimpleSession("foreign_session", profile="other")
+
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: foreign if sid == "foreign_session" else (_ for _ in ()).throw(KeyError("Session not found")))
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(runtime_adapter, "runtime_adapter_enabled", lambda: False)
+    monkeypatch.setattr(routes, "_stream_runner_run_events", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(routes, "find_run_summary", lambda _stream_id: {"session_id": "foreign_session", "terminal": False})
+    monkeypatch.setattr(routes, "_replay_run_journal", lambda *_, **__: (_ for _ in ()).throw(AssertionError("replay should not run")))
+
+    cap = _capture(monkeypatch)
+    routes.handle_get(handler, urlparse("/api/chat/stream?stream_id=stream-dead-foreign"))
+
+    assert cap["bad"] == ("Session not found", 404)
+
+
+def test_chat_stream_allows_unknown_dead_stream_fallback_replay_path(monkeypatch):
+    handler = _FakeHandler()
+    calls = {"replay": 0}
+
+    monkeypatch.setattr(routes, "get_session", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("session lookup should be avoided")))
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(routes, "_stream_runner_run_events", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(routes, "find_run_summary", lambda _stream_id: None)
+    monkeypatch.setattr(routes, "_replay_run_journal", lambda *_args, **_kwargs: calls.__setitem__("replay", calls["replay"] + 1))
+
+    cap = _capture(monkeypatch)
+    routes.handle_get(handler, urlparse("/api/chat/stream?stream_id=does-not-exist"))
+
+    assert cap["ok"] == {"error": "stream not found"}
+    assert calls["replay"] == 0
+
+
+def test_session_new_blocks_prev_session_from_other_profile(monkeypatch):
+    import api.session_lifecycle as session_lifecycle
+    handler = _FakeHandler()
+    foreign = _SimpleSession("foreign_session", profile="other")
+    calls = {"commit": 0, "new": 0}
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {"prev_session_id": "foreign_session"})
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: foreign if sid == "foreign_session" else (_ for _ in ()).throw(KeyError("Session not found")))
+    monkeypatch.setattr(session_lifecycle, "commit_session_memory", lambda sid, agent=None: calls.__setitem__("commit", calls["commit"] + 1))
+    monkeypatch.setattr(routes, "new_session", lambda **_kwargs: (_ for _ in ()).throw(AssertionError("new session should not be created")))
+
+    cap = _capture(monkeypatch)
+    routes.handle_post(handler, urlparse("/api/session/new"))
+
+    assert calls["commit"] == 0
+    assert calls["new"] == 0
+    assert cap["bad"] == ("Session not found", 404)
+
+
+def test_session_new_keeps_prev_session_commit_for_same_profile(monkeypatch):
+    import api.session_lifecycle as session_lifecycle
+    handler = _FakeHandler()
+    visible = _SimpleSession("visible_session", profile="default")
+    calls = {"commit": 0, "new": 0}
+
+    class _NewSession:
+        def __init__(self):
+            self.session_id = "new_session"
+            self.messages = []
+
+        def compact(self):
+            return {"session_id": self.session_id}
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {"prev_session_id": "visible_session"})
+    monkeypatch.setattr(routes, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: visible if sid == "visible_session" else (_ for _ in ()).throw(KeyError("Session not found")))
+    monkeypatch.setattr(session_lifecycle, "commit_session_memory", lambda sid, agent=None: calls.__setitem__("commit", calls["commit"] + 1))
+    monkeypatch.setattr(routes, "new_session", lambda **_kwargs: calls.__setitem__("new", calls["new"] + 1) or _NewSession())
+
+    cap = _capture(monkeypatch)
+    routes.handle_post(handler, urlparse("/api/session/new"))
+
+    assert calls["commit"] == 1
+    assert calls["new"] == 1
+    assert cap["ok"]["session"]["session_id"] == "new_session"

--- a/tests/test_session_ops.py
+++ b/tests/test_session_ops.py
@@ -14,9 +14,10 @@ import pytest
 from tests.conftest import TEST_BASE, TEST_STATE_DIR, _post, make_session_tracked
 
 
-def _get(path):
+def _get(path, headers=None):
     """GET helper -- returns parsed JSON, or raises HTTPError on non-2xx."""
-    with urllib.request.urlopen(TEST_BASE + path, timeout=10) as r:
+    req = urllib.request.Request(TEST_BASE + path, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=10) as r:
         return json.loads(r.read())
 
 
@@ -240,7 +241,10 @@ def test_status_returns_profile_specific_hermes_home(cleanup_test_sessions):
     sid = data['session']['session_id']
     cleanup_test_sessions.append(sid)
 
-    r = _get(f'/api/session/status?session_id={sid}')
+    r = _get(
+        f'/api/session/status?session_id={sid}',
+        headers={'Cookie': 'hermes_profile=research'},
+    )
 
     assert r['profile'] == 'research'
     assert r['hermes_home'] == str(TEST_STATE_DIR / 'profiles' / 'research')


### PR DESCRIPTION
## Thinking Path

- Profile-scoped session reads already hide sessions that belong to a different active profile, but several request paths still accepted a request-supplied `session_id` and loaded or mutated that session directly.
- That mismatch made the profile boundary depend on which route was called: detail reads returned `404`, while duplicate/delete/file/upload/chat-start paths could reach the foreign sidecar first.
- The narrow fix is to enforce the same active-profile visibility check at the HTTP request boundary for normal query/body `session_id` inputs, then keep explicit route-level handling only where ownership is created or retagged intentionally.
- Multipart uploads need their own check because they parse `session_id` from form fields before the normal JSON-body preflight can run.
- `POST /api/chat/start` remains special: persisted foreign sessions now 404 before a run can start, while empty placeholders can only be retagged when the requested profile matches the server-selected active profile.

## What Changed

- Added a shared request preflight in `api/routes.py` that checks query/body `session_id` values against the active profile before normal API route dispatch.
- Applied the same `404 Session not found` response shape used by `GET /api/session` for foreign-profile session references.
- Preserved explicit exemptions for import/claim routes and `chat/start`, where the route has additional ownership or placeholder-retag rules.
- Added multipart-upload visibility checks in `api/upload.py` before attachment writes, archive extraction, or workspace resolution.
- Added regression coverage for duplicate, file read, chat start, empty-placeholder retagging, and all three upload handlers.
- Updated existing status/profile-switch coverage so profile-specific status and placeholder retagging are exercised under the matching active-profile context.

## Why It Matters

- Keeps the WebUI profile boundary consistent across read, write, destructive, and upload routes.
- Prevents request-supplied ids from becoming a cross-profile access or write primitive.
- Avoids leaking whether a foreign session exists by returning the same 404 shape as a missing session.
- Preserves legitimate import and empty-placeholder flows instead of blocking them with an overly broad guard.

## Verification

Targeted regression coverage:

`./scripts/test.sh tests/test_session_active_profile_authorization.py tests/test_issue4067_import_cli_cross_profile_guard.py tests/test_sprint1.py::test_session_delete_nonexistent`

Result: `12 passed`

CI-failure reproduction sweep after follow-ups:

`./scripts/test.sh tests/test_anchor_scene_persistence.py tests/test_extension_status_endpoint.py tests/test_issue2914_truncation_watermark.py tests/test_metadata_save_wipe_1558.py tests/test_session_ops.py::test_status_returns_profile_specific_hermes_home tests/test_session_truncate_keep_count_validation.py tests/test_watermark_advance_after_edit.py tests/test_profile_switch_1200.py::test_chat_start_retags_empty_session_to_request_profile tests/test_session_active_profile_authorization.py tests/test_issue4067_import_cli_cross_profile_guard.py tests/test_sprint1.py::test_session_delete_nonexistent`

Result: `132 passed`

Static / hygiene checks:

`./.venv/bin/ruff check tests/test_session_active_profile_authorization.py`

Result: `All checks passed!`

`./.venv/bin/ruff check --select E9,F821 api/routes.py api/upload.py tests/test_session_active_profile_authorization.py tests/test_session_ops.py tests/test_profile_switch_1200.py`

Result: `All checks passed!`

`git diff --check`

Result: passed with no output.

`python3 scripts/ruff_lint.py --diff origin/master`

Result: `ruff_lint: no new violations on added/modified lines. OK.`

## Risks / Follow-ups

- Future endpoints that intentionally operate across profiles by `session_id` should add explicit route-specific handling rather than bypassing this guard implicitly.
- This PR does not change profile-list aggregation or import semantics; those remain governed by their existing `all_profiles` and import-specific checks.

## Model Used

- OpenAI / GPT-5.5 and OpenAI / GPT-5.3 Codex Spark for implementation and verification.
- Anthropic / Claude Opus 4.8 for independent review.
