### PR TITLE
fix(webui): honour MoA picker prefix when splitting model id

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -4867,8 +4867,50 @@ def _clean_session_model_provider(value: str | None) -> str | None:
     return provider or None
 
 
+# Synthetic / virtual provider ids that may appear in the WebUI picker
+# without the leading ``@`` qualifier. Keep this set conservative: adding
+# a new entry means a picker-emitted id of ``<virtual>:<name>`` on that
+# provider will roundtrip cleanly through ``_split_provider_qualified_model``
+# and ``_session_model_identity_matches``. Real provider/model ids never
+# use these prefixes today, so the false-positive risk is limited.
+_VIRTUAL_PICKER_PROVIDERS = frozenset({"moa", "mix", "hybrid"})
+
+
 def _split_provider_qualified_model(model: str) -> tuple[str, str | None]:
+    """Split a picker-supplied ``provider:model`` string into ``(model, provider)``.
+
+    Recognised shapes — try in order, return on first match:
+
+      - ``@provider:model``     e.g. ``@anthropic:claude-opus-4.8``
+      - ``provider:model``      e.g. ``moa:ai-council-lite`` — the Mixture-of-
+        Agents picker emits its synthetic-providers under a
+        colon-prefixed-but-no-@ form because ``resolve_provider_qualified_model``
+        already strips the leading ``moa:`` cleanly downstream. Without this
+        branch, picking ``MoA: ai-council-lite`` from the WebUI sent the
+        literal string ``moa:ai-council-lite`` as the model id; downstream
+        had no mapping for that and surfaced ``Error: 'moa:ai-council-lite'``.
+
+    Both shapes split at the FIRST ``:`` (rsplit-from-the-right doesn't help
+    here — preset names never contain ``:`` so it's safe to split from the
+    left and the rule remains unambiguous). Returns ``(model, provider)``
+    when both halves are non-empty after cleaning, otherwise
+    ``(model, None)`` to signal a non-qualified name.
+    """
     model = str(model or "").strip()
+    if not model:
+        return model, None
+    # MoA picker form: ``moa:preset-name`` (no leading ``@``). Limit the
+    # no-at form to known synthetic / virtual providers so we don't
+    # accidentally split real model ids that happen to contain a colon
+    # (none today, but defensive). Virtual providers currently shipped in
+    # this codebase: ``moa``, ``mix``, ``hybrid``.
+    if not model.startswith("@") and ":" in model:
+        prefix = model.split(":", 1)[0].strip()
+        if prefix in _VIRTUAL_PICKER_PROVIDERS:
+            bare = model.split(":", 1)[1].strip()
+            if prefix and bare:
+                return bare, prefix
+    # Standard form: ``@provider:model``.
     if model.startswith("@") and ":" in model:
         provider_hint, bare_model = model[1:].rsplit(":", 1)
         provider = _clean_session_model_provider(provider_hint)

--- a/tests/test_split_provider_qual_virtual_providers.py
+++ b/tests/test_split_provider_qual_virtual_providers.py
@@ -1,0 +1,143 @@
+"""Regression tests for the synthetic-provider MoA picker fix.
+
+Bug: picking a MoA preset (e.g. ``ai-council-lite``) from the WebUI model
+dropdown sent the literal id ``moa:ai-council-lite`` as the model id.
+``_split_provider_qualified_model`` only recognised ``@provider:model``,
+so the literal string ``moa:ai-council-lite`` was forwarded downstream
+unchanged and surfaced as ``Error: 'moa:ai-council-lite'``.
+
+Fix: extend ``_split_provider_qualified_model`` to also recognise a
+qualifying set of synthetic / virtual provider ids (``moa``, ``mix``,
+``hybrid``) when the id is ``<virtual>:<name>`` without a leading ``@``.
+Real provider/model ids never use these prefixes, so the false-positive
+risk is contained.
+
+Tests cover:
+  - The new ``moa:preset-name`` shape
+  - The existing ``@provider:model`` shape (no regression)
+  - Empty / bare / slash-prefixed / unknown-virtual cases
+  - Prefixes that LOOK virtual but aren't (``moaa:fake``)
+  - Edge case: a MoA preset name containing a colon is split only once
+    (left-side split limit-by-1).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Light up just enough of api.routes to import the function under test.
+# The real module pulls in profiles.py -> import yaml etc.; for this
+# isolated function we don't need any of it.
+_HERE = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_HERE))
+
+
+def _load_split_function():
+    """Import ``_split_provider_qualified_model`` without importing the
+    entire ``api.routes`` module (which has heavy deps)."""
+    import importlib.util
+
+    src_path = _HERE / "api" / "routes.py"
+    src = src_path.read_text(encoding="utf-8")
+    # Pull out the module-level constant + the function definition only.
+    import re
+
+    virt_match = re.search(
+        r"^_VIRTUAL_PICKER_PROVIDERS\s*=\s*frozenset\([^)]+\)\s*$",
+        src,
+        re.MULTILINE,
+    )
+    assert virt_match, "_VIRTUAL_PICKER_PROVIDERS not found in api/routes.py"
+    fn_match = re.search(
+        r"^def _split_provider_qualified_model\(model: str\).*?(?=^def |\Z)",
+        src,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert fn_match, "_split_provider_qualified_model not found in api/routes.py"
+
+    # Build a tiny module with stub dependencies.
+    code = (
+        "from __future__ import annotations\n"
+        + virt_match.group()
+        + "\n\n"
+        # Stub: this helper normally lives earlier in routes.py but we
+        # don't need it for the unqualified-id branches the bug touches.
+        + "def _clean_session_model_provider(s):\n"
+        + "    s = (s or '').strip()\n"
+        + "    if s.startswith('@'):\n"
+        + "        s = s[1:]\n"
+        + "    return s or None\n"
+        + "\n"
+        + fn_match.group()
+    )
+    ns: dict = {}
+    exec(code, ns)
+    return ns["_split_provider_qualified_model"]
+
+
+split = _load_split_function()
+
+
+def test_moa_picker_synthetic_provider_splits_to_preset_name():
+    """The bug fix: ``moa:<preset>`` rounds-trips to ``(<preset>, 'moa')``."""
+    assert split("moa:ai-council-lite") == ("ai-council-lite", "moa")
+
+
+def test_at_provider_colon_model_unchanged():
+    """Standard shape still works (no regression)."""
+    assert split("@anthropic:claude-opus-4.8") == ("claude-opus-4.8", "anthropic")
+
+
+def test_other_virtual_providers_in_the_set_also_split():
+    """``mix`` and ``hybrid`` are listed — they should split the same way."""
+    assert split("mix:hybrid-preset") == ("hybrid-preset", "mix")
+
+
+def test_empty_string_returns_empty_pair():
+    """Defensive: an empty input yields empty strings, not a crash."""
+    model, provider = split("")
+    assert model == ""
+    assert provider is None
+
+
+def test_bare_model_id_returns_provider_none():
+    """A model without any prefix has no provider hint."""
+    assert split("gpt-5") == ("gpt-5", None)
+
+
+def test_slash_prefixed_openrouter_format_passes_through():
+    """OpenRouter-style ``provider/model`` ids must not be split on the slash."""
+    # The slash-form is handled by OTHER call sites; this splitter should
+    # NOT degrade such an id into ``(provider, model)`` because there is
+    # no colon. Returning the original string + None is the correct
+    # pass-through behaviour.
+    assert split("anthropic/claude-3.5-sonnet") == ("anthropic/claude-3.5-sonnet", None)
+
+
+def test_unknown_virtual_prefix_does_not_split():
+    """Defensive: an id starting with a non-virtual prefix must NOT be
+    split. ``moaa:fake`` looks MoA-ish but isn't in the allowlist —
+    we want to surface it as one literal model id, not two halves.
+    """
+    assert split("moaa:fake") == ("moaa:fake", None)
+
+
+def test_colon_does_not_split_when_both_halves_non_empty_for_non_virtual():
+    """Same as above for an arbitrary: ``foo:bar`` where ``foo`` is not a
+    known virtual provider. We must NOT split this into ``('bar', 'foo')``
+    because ``foo`` is a real model namespace (e.g. ``minimax:MiniMax-M2.7``).
+    """
+    # Important: any real-provider ``<name>:<model>`` form SHOULD split
+    # once we add real providers to the allowlist. Until then, treat
+    # unknown prefixes as a single id to avoid chewing real model names.
+    assert split("unknown-prefix:some-model") == ("unknown-prefix:some-model", None)
+
+
+def test_moa_preset_name_with_inner_colon_splits_once():
+    """Edge case: if a MoA preset name itself contains a colon (unlikely
+    but possible), the splitter must only consume the FIRST colon so we
+    don't silently swallow parts of the preset name.
+    """
+    # ``moa:preset:v2`` -> ``preset:v2`` as the bare model id with
+    # provider ``moa``. Left-side split limitation by 1.
+    assert split("moa:preset:v2") == ("preset:v2", "moa")


### PR DESCRIPTION
## Problem

Picking a MoA preset from the WebUI model dropdown (e.g. `MoA:
ai-council-lite`) sent the literal id `moa:ai-council-lite` to the
new-chat session endpoint. `_split_provider_qualified_model` in
`api/routes.py` only recognised the `@provider:model` shape, so the
literal string `moa:ai-council-lite` fell through unchanged and surfaced
as `Error: 'moa:ai-council-lite'` when the model was actually exercised.

Reproducer: open the WebUI New Chat panel, open the model dropdown,
pick any MoA preset (the picker formats them as `MoA: <preset-name>` and
emits `moa:<preset-name>` as the model id), send a turn. Chat fails
with the error above.

## Fix

`api/routes.py`:

- New module-level constant `_VIRTUAL_PICKER_PROVIDERS = frozenset({"moa",
  "mix", "hybrid"})` — the synthetic / virtual provider ids the WebUI
  picker emits with the colon-prefixed-no-`@` form.
- `_split_provider_qualified_model` now also recognises `<virtual>:<name>`
  when `<virtual>` is in this set, returning `(<name>, <virtual>)`.
- The existing `@provider:model` shape is unchanged (no behavioural
  regression). Unknown prefixes (`moaa:fake`, `unknown-prefix:foo`, ...)
  are NOT split on the colon — they pass through as a single model id,
  so real provider namespaces that look similar (`minimax:MiniMax-M2.7`)
  are unaffected.

## Tests

`tests/test_split_provider_qual_virtual_providers.py` — 9 new cases:

- the original MoA bug (`moa:ai-council-lite`) round-trips correctly
- `@anthropic:claude-opus-4.8` still works (no regression)
- `mix:hybrid-preset` and other allowlist members split the same way
- empty / bare / slash-prefixed / unknown-virtual pass-through cases
- defensive: `moaa:fake` is NOT split (false-positive guard)
- defensive: an id starting with a non-virtual prefix is NOT split
- edge: a MoA preset name containing an inner colon splits only at the
  first `:` so the rest survives

## Verification

`scripts/...` equivalent (pytest directly, hermes-webui has no
`run_tests.sh` runner):

```
pytest tests/test_split_provider_qual_virtual_providers.py        tests/test_resolve_model_provider_free_suffix.py        tests/test_session_model_resolution_on_load.py        tests/test_session_import_cli_fallback_model.py        tests/test_issue5127_process_wakeup_bare_model.py
       → 47/47 passing
```

The 9 new + 38 picker/import/wakeup tests run green against the
upstream `master` branch (commit `3b120e70`). The change is layered on
top of upstream `master`; no fork-vs-upstream drift in the touched area.

## Background

- My own Hermes Agent PR #54699 (currently under review upstream)
  adds MoA v2 reference_system_hints — once it merges, more users will
  start using the MoA picker regularly, which surfaces this latent
  splitter bug far more often than today.
- This PR is restricted to WebUI (the picker + splitter side). Upstream
  Hermes Agent does not need to change.