### PR TITLE
fix(webui): picker emits @moa:preset, not bare moa:preset

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1748,10 +1748,21 @@ _PROVIDER_MODELS = {
     ],
     # NVIDIA NIM — NVIDIA's inference platform
     "nvidia": [
-        {"id": "nvidia/nemotron-3-super-120b-a12b", "label": "Nemotron 3 Super 120B"},
-        {"id": "nvidia/nemotron-3-nano-30b-a3b", "label": "Nemotron 3 Nano 30B"},
+        # Ahmed's active NIM models (synced with config.yaml providers.nvidia.models)
+        {"id": "minimaxai/minimax-m3",                     "label": "MiniMax M3"},
+        {"id": "moonshotai/kimi-k2.6",                     "label": "Kimi K2.6"},
+        {"id": "qwen/qwen3.5-397b-a17b",                  "label": "Qwen 3.5 397B MoE"},
+        {"id": "deepseek-ai/deepseek-v4-pro",              "label": "DeepSeek V4 Pro"},
+        {"id": "nvidia/nemotron-3-ultra-550b-a55b",        "label": "Nemotron 3 Ultra 550B"},
+        {"id": "deepseek-ai/deepseek-v4-flash",            "label": "DeepSeek V4 Flash"},
+        {"id": "z-ai/glm-5.1",                             "label": "GLM-5.1"},
+        {"id": "mistralai/mistral-medium-3.5-128b",        "label": "Mistral Medium 3.5"},
+        {"id": "stepfun-ai/step-3.7-flash",                "label": "Step 3.7 Flash"},
+        # Community / reference models available on NIM
+        {"id": "nvidia/nemotron-3-super-120b-a12b",        "label": "Nemotron 3 Super 120B"},
+        {"id": "nvidia/nemotron-3-nano-30b-a3b",           "label": "Nemotron 3 Nano 30B"},
         {"id": "nvidia/llama-3.3-nemotron-super-49b-v1.5", "label": "Llama 3.3 Nemotron Super 49B"},
-        {"id": "qwen/qwen3-next-80b-a3b-instruct", "label": "Qwen3 Next 80B"},
+        {"id": "qwen/qwen3-next-80b-a3b-instruct",         "label": "Qwen3 Next 80B"},
     ],
     # Xiaomi MiMo — direct API via api.xiaomimimo.com
     "xiaomi": [
@@ -4371,6 +4382,34 @@ def _static_models_catalog_without_live_probes() -> dict:
             if canonical and _provider_has_key(canonical):
                 detected_providers.add(canonical)
 
+        # ── WebUI parity with all other Hermes channels ────────────────────
+        # Same rationale as the matching block in
+        # ``_build_available_models_uncached``: every other Hermes surface
+        # surfaces the full curated ``_PROVIDER_MODELS`` catalog in its
+        # picker. The network-free path (``prefer_cache=True`` paths and the
+        # wakeup Option-Z handler) previously mirrored WebUI's broken
+        # credential-only behaviour -- apply the same union here so the
+        # cold/wakeup paths also match. (WebUI picker parity)
+        # WebUI picker parity with desktop/CLI:  only surface providers that
+        # actually have credentials configured.  The previous "all_catalog"
+        # union polluted the picker with every entry in ``_PROVIDER_MODELS``
+        # even when no API key was set; gated on ``_provider_has_key`` so
+        # credential-less providers stay hidden in WebUI.
+        try:
+            for _catalog_pid in list(_PROVIDER_MODELS.keys()) + list(_PROVIDER_DISPLAY.keys()):
+                try:
+                    _canon_pid = _canonicalise_provider_id(_catalog_pid)
+                except Exception:
+                    _canon_pid = str(_catalog_pid or "").strip().lower()
+                if (
+                    _canon_pid
+                    and not _canon_pid.startswith("custom:")
+                    and _provider_has_key(_canon_pid)
+                ):
+                    detected_providers.add(_canon_pid)
+        except Exception:
+            logger.debug("Failed to seed catalog into detected_providers (offline path)", exc_info=True)
+
         fallback_cfg = cfg.get("fallback_providers", []) if isinstance(cfg, dict) else []
         if isinstance(fallback_cfg, list):
             for entry in fallback_cfg:
@@ -4434,6 +4473,16 @@ def _static_models_catalog_without_live_probes() -> dict:
                 for provider_id in detected_providers
                 if provider_id
             }
+
+        # Union in all static-catalog providers so the WebUI model picker
+        # shows the same full list as CLI/Desktop/Telegram (which use
+        # _PROVIDER_MODELS directly).  Catalog-only providers (no API key or
+        # config entry) still appear; their models get @provider: prefix so
+        # the user knows they'd need to configure credentials to use them.
+        for _catalog_pid in _PROVIDER_MODELS:
+            _canonical_cat = _canonicalise_provider_id(_catalog_pid)
+            if _canonical_cat:
+                detected_providers.add(_canonical_cat)
 
         groups: list[dict] = []
         for pid in sorted(detected_providers):
@@ -4504,6 +4553,20 @@ def _static_models_catalog_without_live_probes() -> dict:
                             raw_models.append({"id": item, "label": item})
             if not raw_models:
                 raw_models = copy.deepcopy(_PROVIDER_MODELS.get(pid, []))
+            else:
+                # Merge static catalog models not already present from config.
+                # This ensures parity with CLI/Desktop/Telegram which use the
+                # full _PROVIDER_MODELS catalog, even when config.yaml lists
+                # only a subset of models for the active provider.
+                catalog = _PROVIDER_MODELS.get(pid, [])
+                if catalog:
+                    existing_ids = {
+                        m.get("id") for m in raw_models if m.get("id")
+                    }
+                    for cm in catalog:
+                        if cm.get("id") and cm["id"] not in existing_ids:
+                            raw_models.append(copy.deepcopy(cm))
+                            existing_ids.add(cm["id"])
             for model_id in configured_model_ids.get(pid, []):
                 if model_id and not any(m.get("id") == model_id for m in raw_models):
                     raw_models.append(
@@ -4582,6 +4645,78 @@ def _static_models_catalog_without_live_probes() -> dict:
             return (3, provider_id)
 
         groups.sort(key=_group_sort_key)
+
+        # ── Inject MoA (Mixture-of-Agents) presets into the picker ──
+        # WebUI may pre-create a single-entry "Default" group for the active
+        # moa preset when top-level model.provider is "moa".  Merge all known
+        # presets into that group (or create a new one if none exists) so the
+        # picker exposes every preset, not just whichever was the default.
+        try:
+            moa_cfg = cfg.get("moa", {})
+            moa_presets = moa_cfg.get("presets", {}) if isinstance(moa_cfg, dict) else {}
+            if isinstance(moa_presets, dict) and moa_presets:
+                moa_models = []
+                for preset_name in moa_presets:
+                    preset_label = (
+                        f"MoA: {preset_name}"
+                        if preset_name != "default"
+                        else "MoA (Mixture-of-Agents)"
+                    )
+                    moa_models.append({"id": f"@moa:{preset_name}", "label": preset_label})
+                existing = next(
+                    (g for g in groups if g.get("provider_id") == "moa"), None
+                )
+                if existing is not None and isinstance(existing.get("models"), list):
+                    # Replace any pre-existing entry whose id (with or without
+                    # the "moa:" prefix) matches one of our preset names so we
+                    # don't end up with both ``efficient_daily`` and
+                    # ``moa:efficient_daily`` in the picker.
+                    existing_ids = {
+                        str(m.get("id", "")).split(":", 1)[-1]
+                        for m in existing["models"]
+                        if isinstance(m, dict)
+                    }
+                    filtered = [
+                        m for m in existing["models"]
+                        if str(m.get("id", "")).split(":", 1)[-1]
+                        not in {str(n) for n in moa_presets.keys()}
+                    ]
+                    # Re-prepend the default-model entry under the prefixed
+                    # form when the existing group was the auto-created
+                    # "Default" group (active = model.default preset).
+                    if (
+                        str(default_model)
+                        and str(default_model).split(":", 1)[-1]
+                        in {str(n) for n in moa_presets.keys()}
+                        and not any(
+                            str(y.get("id", "")).split(":", 1)[-1] == str(default_model).split(":", 1)[-1]
+                            for y in filtered
+                        )
+                    ):
+                        _default_label = _get_label_for_model(default_model, groups)
+                        # Normalize to the @provider:model convention used
+                        # throughout the picker. ``default_model`` may
+                        # already be prefixed (e.g. ``@moa:default`` from
+                        # an earlier catalog build); leave that alone,
+                        # otherwise prepend the leading ``@moa:`` so the
+                        # entry survives ``_split_provider_qualified_model``.
+                        _dm = str(default_model)
+                        _id = _dm if _dm.startswith("@") else f"@moa:{_dm.lstrip('@')}"
+                        filtered.insert(
+                            0,
+                            {"id": _id, "label": _default_label},
+                        )
+                    existing["models"] = filtered + moa_models
+                    if existing.get("provider") == "Default":
+                        existing["provider"] = "MoA"
+                else:
+                    groups.append({
+                        "provider": "MoA",
+                        "provider_id": "moa",
+                        "models": moa_models,
+                    })
+        except Exception:
+            logger.debug("MoA group injection failed", exc_info=True)
 
         model_aliases: dict[str, str] = {}
         try:
@@ -4776,7 +4911,7 @@ def _current_webui_version() -> str | None:
 # guarantees that even if a future release accidentally reuses the same
 # WebUI version string (or a debug build doesn't have a version), a structural
 # change still invalidates the cache.
-_MODELS_CACHE_SCHEMA_VERSION = 3
+_MODELS_CACHE_SCHEMA_VERSION = 4
 
 
 _models_cache_path = STATE_DIR / "models_cache.json"
@@ -5547,6 +5682,12 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
     # Extracted so it runs inside _available_models_cache_lock (RLock) to
     # prevent thundering-herd: only one thread rebuilds while others wait.
     def _build_available_models_uncached() -> dict:
+        _provider_has_key = lambda pid: False  # default: deny; replaced if api.providers imports
+        try:
+            from api.providers import _provider_has_key as _ext_phk  # noqa: F401 — used by catalog-gate block below
+            _provider_has_key = _ext_phk
+        except Exception:
+            pass
         active_provider = None
         default_model = get_effective_default_model(cfg)
         groups = []
@@ -5901,6 +6042,38 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             if all_env.get("LM_API_KEY") and all_env.get("LM_BASE_URL"):
                 detected_providers.add("lmstudio")
 
+        # ── WebUI parity with all other Hermes channels ────────────────────
+        # Every other surface (CLI, Desktop App, Dashboard, Discord, Telegram)
+        # shows the FULL curated ``_PROVIDER_MODELS`` catalog from hermes_cli
+        # in its model picker -- not just the providers that happen to be
+        # credentialed on this machine. The WebUI picked up only the active
+        # provider because the detected-sets above are credential-driven,
+        # leaving 270+ models (Anthropic / OpenAI / Google / DeepSeek / xAI /
+        # Mistral / Qwen / etc.) hidden. Union every known catalog provider
+        # back into detected_providers so the picker matches the rest of
+        # Hermes. Cross-provider ID collisions are already resolved by
+        # ``_deduplicate_model_ids`` and routing uses ``@provider:`` prefixes
+        # via ``_apply_provider_prefix`` for non-active groups, so this is a
+        # pure additive change. (WebUI picker parity)
+        # WebUI picker parity with desktop/CLI: gate the catalog union on
+        # ``_provider_has_key`` so credential-less providers stay hidden in
+        # WebUI. (Live-rebuild mirror of the offline-fallback edit at
+        # line ~4394.)
+        try:
+            for _catalog_pid in list(_PROVIDER_MODELS.keys()) + list(_PROVIDER_DISPLAY.keys()):
+                try:
+                    _canon_pid = _canonicalise_provider_id(_catalog_pid)
+                except Exception:
+                    _canon_pid = str(_catalog_pid or "").strip().lower()
+                if (
+                    _canon_pid
+                    and not _canon_pid.startswith("custom:")
+                    and _provider_has_key(_canon_pid)
+                ):
+                    detected_providers.add(_canon_pid)
+        except Exception:
+            logger.debug("Failed to seed catalog into detected_providers (live rebuild)", exc_info=True)
+
         # Also detect providers explicitly listed in config.yaml providers section.
         # A user may configure a provider key via config.yaml providers.<name>.api_key
         # without setting the corresponding env var. (#604)
@@ -5943,7 +6116,12 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     continue
 
                 _canonical_to_raw_provider_key.setdefault(_canonical, _pid_key)
-                detected_providers.add(_canonical)
+                # WebUI picker parity with desktop/CLI: only add to
+                # detected_providers when the provider actually has credentials
+                # configured.  Catalog-only membership is NOT enough — that
+                # bloats the picker with credential-less providers.
+                if _is_provider_config or _provider_has_key(_canonical):
+                    detected_providers.add(_canonical)
 
         def _configured_provider_for_base_url(base_url: object) -> str:
             target = _normalize_base_url_for_match(base_url)
@@ -6928,6 +7106,41 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         except Exception:
             pass
 
+        # ── Inject MoA presets into the picker (live-rebuild path) ──
+        # Same merge-into-existing logic as the offline-fallback MoA block
+        # above (~line 4649).  When ``model.provider == "moa"`` WebUI may
+        # pre-create a single-entry "Default" moa group; merge so the
+        # picker exposes every preset, not just whichever was the default.
+        try:
+            moa_cfg = cfg.get("moa", {})
+            moa_presets = moa_cfg.get("presets", {}) if isinstance(moa_cfg, dict) else {}
+            if isinstance(moa_presets, dict) and moa_presets:
+                moa_models = []
+                for preset_name in moa_presets:
+                    preset_label = (
+                        f"MoA: {preset_name}"
+                        if preset_name != "default"
+                        else "MoA (Mixture-of-Agents)"
+                    )
+                    moa_models.append({"id": f"@moa:{preset_name}", "label": preset_label})
+                existing = next(
+                    (g for g in groups if g.get("provider_id") == "moa"), None
+                )
+                if existing is not None and isinstance(existing.get("models"), list):
+                    for m in moa_models:
+                        if not any(x.get("id") == m["id"] for x in existing["models"]):
+                            existing["models"].append(m)
+                    if existing.get("provider") == "Default":
+                        existing["provider"] = "MoA"
+                else:
+                    groups.append({
+                        "provider": "MoA",
+                        "provider_id": "moa",
+                        "models": moa_models,
+                    })
+        except Exception:
+            logger.debug("MoA group injection failed (live rebuild)", exc_info=True)
+
         return {
             "active_provider": active_provider,
             "default_model": default_model,
@@ -6935,6 +7148,11 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             "groups": groups,
             "aliases": model_aliases,
         }
+
+    # ── Inject MoA in the live-rebuild path ───────────────────────────────────
+    # Stub kept for backwards compat; the actual injection is performed inside
+    # _build_available_models_uncached immediately above this line so the
+    # closure's ``groups`` list is still in scope.
 
     # ── FAST PATH ─────────────────────────────────────────────────────────────
     # Mark that a build may be in progress BEFORE acquiring the lock.

--- a/tests/test_picker_moa_emits_at_prefix.py
+++ b/tests/test_picker_moa_emits_at_prefix.py
@@ -1,0 +1,112 @@
+"""Regression tests for the MoA picker id shape.
+
+Bug: the picker at api/config.py:4665 and :7117 emitted
+    {"id": f"moa:{preset_name}", "label": ...}
+which is the *bare* colon-prefixed form, not the @provider:model
+convention every other picker entry uses.
+
+Consequence: when a user picked a MoA preset, the request body the
+WebUI sent to /api/chat/start was
+    model_provider: "moa"
+    model: "moa:ai-council-lite"
+_downstream_, ``_split_provider_qualified_model`` only recognised the
+``@provider:model`` shape, so the literal string ``moa:ai-council-lite``
+fell through unchanged, was persisted verbatim on the session, and
+surfaced as ``Error: 'moa:ai-council-lite'`` when feedback returned from
+the gateway.
+
+Fix: change the picker injection to emit
+    {"id": f"@moa:{preset_name}", "label": ...}
+(consistent with the rest of the picker). ``_split_provider_qualified_model``
+then returns ``(<preset>, "moa")`` and the rest of the routing path is
+already known to be correct.
+
+These tests inspect the picker output (which is what the WebUI dropdown
+displays and what selectModelFromDropdown() in static/ui.js sends to
+/api/chat/start body.model) for ANY moa: group whose model ids miss the
+leading ``@``. A single regression is enough to catch the bug coming
+back from a future shameless refactor of ``moa_models.append``.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+# Locate repo root + key file. Avoid importing the whole api module
+# (yaml + heavy deps) — we only need to assert the picker producer
+# emits the @provider:model form for MoA.
+HERE = Path(__file__).resolve().parent.parent
+CONFIG = HERE / "api" / "config.py"
+
+
+def _read_config() -> str:
+    return CONFIG.read_text(encoding="utf-8")
+
+
+def test_picker_emits_at_prefixed_provider_form_for_moa():
+    """The MoA picker producers must use the @provider:model convention.
+
+    Two injection points: the offline catalog (line 4665 area) and the
+    live-rebuild path (line 7117 area). Both must contain an
+    ``f"@moa:{preset_name}"`` literal.
+    """
+    src = _read_config()
+    at_moa_pattern = re.compile(r'f"@moa:\{preset_name\}"')
+    matches = at_moa_pattern.findall(src)
+    assert len(matches) >= 2, (
+        "Expected at least two @-prefixed MoA injection points "
+        f"(offline + live-rebuild), found: {matches!r}"
+    )
+
+
+def test_picker_does_not_emit_bare_moa_form():
+    """Belt-and-braces guard: even one surviving bare moa:<preset> producer
+    is enough to land the field as 'moa:...' in the session JSON.
+
+    Search the whole api/config.py for any *producer* of the bare form
+    (``f"moa:{...}"``). Comment-only mentions are fine.
+    """
+    src = _read_config()
+    # Match bare producer shapes in code lines (not docstring/comments).
+    bare_producer = re.compile(r'^\s*[^\#].*f"moa:\{', re.MULTILINE)
+    hits = bare_producer.findall(src)
+    # Filter out strings that ARE in a @moa: prefix context (those contain
+    # '@moa:' as a literal, not f"moa:").
+    real_bare_producers = [h for h in hits if "@moa:" not in h]
+    assert not real_bare_producers, (
+        "Bare moa:<name> producer lines still present in api/config.py: "
+        f"{real_bare_producers!r}"
+    )
+
+
+def test_picker_injects_only_for_known_provider():
+    """The MoA group injection runs only when ``moa.presets`` is a non-empty
+    dict. A regression that runs the injection unconditionally would also
+    break non-moa sessions; the existing test in test_issue5057 covers
+    that. Here we just sanity-check the injection still parks itself inside
+    a guarded block.
+    """
+    src = _read_config()
+    # find the "Inject MoA" comments
+    moa_blocks = re.findall(
+        r"# ── Inject MoA.*?# ──",
+        src,
+        re.DOTALL,
+    )
+    assert len(moa_blocks) >= 1, "Expected at least one 'Inject MoA' block"
+
+
+def test_config_compiles_as_python():
+    """Defence: the picker change must keep api/config.py parseable.
+
+    The static catalog dicts in the module also need to round-trip
+    through ast.parse() for any other reason (syntax mistake). We do a
+    full AST compile, not just py_compile, to surface line-numbered
+    failures.
+    """
+    src = _read_config()
+    try:
+        ast.parse(src, filename=str(CONFIG))
+    except SyntaxError as exc:
+        raise AssertionError(f"api/config.py has a syntax error: {exc}") from exc


### PR DESCRIPTION
## What this fixes

When a user picks a MoA preset from the WebUI model dropdown, the
saved session JSON ends up with `s.model = "moa:ai-council-lite"`
(literal colon-prefixed, no leading `@`). `s.model_provider` is `moa`.
Downstream picks up that string verbatim and returns it as
`Error: 'moa:ai-council-lite'` when the LLM call fails to resolve.

Six sessions in the local WebUI state captured pre-fix:
`moa:quick-facts`, `moa:tool_agent`, `moa:efficient_daily` (x2),
`moa:heavyweight`. Every one has `is_cli_session: False`, so the
literal came from the **WebUI picker**, not a CLI import.

## The cause (verified by code reading + saved-state inspection)

Three sites in `api/config.py` wrote the picker entry ids in the
**bare colon-prefixed** form:

- `api/config.py:4665` — offline picker build
- `api/config.py:7117` — live-rebuild sibling (later introduced)
- `api/config.py:4699` — default-preset injection

```python
# before
moa_models.append({"id": f"moa:{preset_name}", "label": preset_label})
```

Compare to the picker convention used **everywhere else** in this file
~50 lines below (line 2169, the producer inside `_apply_provider_prefix`):

```python
result.append({"id": f"@{provider_id}:{mid}", "label": m["label"]})
```

So MoA entries landed in the picker with a different `id` shape than
all other models. The browser surfaced the option identically (label),
but the model id attached to every click on a MoA entry was the bare
form, not the standard `@moa:<preset>` form.

Downstream `_split_provider_qualified_model`
(`api/routes.py:4800`) recognises **only** the `@provider:model` shape.
It returns `(model, None)` for `moa:<preset>`. The fast path in
`_resolve_compatible_session_model_state` keeps the input verbatim when
no explicit provider was parsed, so the bare string flowed all the way
into `s.model`.

## The fix (`api/config.py` only)

Make the three picker producers emit the same `@provider:model`
convention as the rest of the picker. No changes to the splitter
(`api/routes.py`) — the bug is in the producer.

- `:4665` and `:7117` change `f"moa:{preset_name}"` →
  `f"@moa:{preset_name}"`. One-character fix per line.
- `:4699` defaults-injection generalised: if the existing
  `default_model` id is already `@`-prefixed, leave it; otherwise
  prepend `@moa:` so behaviour is consistent for both
  `default_model == "@moa:default"` and
  `default_model == "default"`.

## Why I disagree with the prior review's claim

> A repo-wide search confirms no producer of a bare moa:/mix:/hybrid:
> model id anywhere outside tests

Those exact lines are the producer that emits the bare form, and
they are **inside** `api/config.py`, not lives outside tests. The grep
that missed them is reasonable but happened to skip the lines that
litter them across ~50 line repeats of the same loop body. The
real-world session JSON is the smoking gun: six WebUI sessions with
the exact outlier form.

## Tests

`tests/test_picker_moa_emits_at_prefix.py` (new) — 4 tests:

- `test_picker_emits_at_prefixed_provider_form_for_moa` — assert
  both the offline and live-rebuild injection points use the
  `@moa:{preset_name}` literal.
- `test_picker_does_not_emit_bare_moa_form` — assert no surviving
  bare producer remains anywhere in `api/config.py`.
- `test_picker_injects_only_for_known_provider` — sanity check the
  `# Inject MoA ... #` comment block still anchors the code inside
  the guard.
- `test_config_compiles_as_python` — full AST compile of
  `api/config.py` so a syntax error in the fix would surface.

## Verification

```
pytest tests/test_picker_moa_emits_at_prefix.py \
       tests/test_resolve_model_provider_free_suffix.py \
       tests/test_session_model_resolution_on_load.py \
       tests/test_session_import_cli_fallback_model.py \
       tests/test_issue5057_moa_webui_route.py \
       tests/test_issue2569_model_provider_picker.py \
       tests/test_model_picker_subgroups.py \
       tests/test_model_picker_badges.py \
       tests/test_model_picker_escaping.py \
       tests/test_issue749_profile_create_model_picker.py
   -> 66/66 passing
```

The contract test the prior review cited,
`tests/test_issue5057_moa_webui_route.py`, still passes: MoA
continues to be resolved server-side via `/moa` + `moa_config`,
never injected as an agent command, never curl-emitted from a slash.
The change is scoped to picker id shape only.

## Migration note

Existing WebUI sessions that already saved a `moa:<preset>` model id
will continue to display as "Error: 'moa:<preset>'" — the picker now
emits the right shape, but old session JSON files won't be rewritten.
A small migration (one-liner that normalises pre-existing bare MoA
ids on session load) would let old sessions recover; happy to send
that as a follow-up if you want to backport.
