### PR TITLE
fix(redaction): memoize deterministic API response redactor to stop GIL-bound poll storms

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1,6 +1,7 @@
 """
 Hermes Web UI -- HTTP helper functions.
 """
+import functools
 import json as _json
 import logging
 import os
@@ -416,7 +417,25 @@ def _build_redact_fn():
     return _combined_redact
 
 
-_redact_fn_cached = _build_redact_fn()
+_redact_fn_uncached = _build_redact_fn()
+
+# Repeated dashboard polls re-request the same unchanged session payloads, so
+# the combined redactor (~15 regex passes per string) was the dominant CPU cost
+# under concurrent polling — enough to wedge the single-process server behind
+# the GIL and surface as "Mất kết nối" in the browser. The redactor is pure and
+# deterministic (force=True, fixed masking), so identical strings always map to
+# identical output and are safe to memoize without invalidation.
+_redact_fn_lru = functools.lru_cache(maxsize=4096)(_redact_fn_uncached)
+
+# Cap per-entry size so a handful of giant tool-output dumps can't evict the
+# thousands of small recurring strings that actually benefit, or balloon RSS.
+_REDACT_CACHE_MAX_TEXT_LEN = 16384
+
+
+def _redact_fn_cached(text):
+    if len(text) > _REDACT_CACHE_MAX_TEXT_LEN:
+        return _redact_fn_uncached(text)
+    return _redact_fn_lru(text)
 
 
 _SENSITIVE_CASE_MARKERS = (


### PR DESCRIPTION
## Problem

On a single-process WebUI server, repeated dashboard polling of unchanged session payloads pegged one core at ~50–57% CPU **even with zero in-flight requests**, and individual `/api/session` responses ballooned to 10–44s under concurrent polling. In the browser this surfaced as repeated "connection lost" / reconnect churn.

Root cause: every `/api/session` response runs `redact_session_data()` over the full message history. The combined redactor (`agent.redact.redact_sensitive_text` with `force=True` + the local fallback) is ~15 regex passes per string. It is CPU-bound, so under the GIL it serializes across the `ThreadingHTTPServer` worker threads. Repeated polls re-run the identical redaction over identical, unchanged strings, queueing requests until the browser/reverse-proxy times out — which triggers client retries and a thread pileup, feeding back into the stall.

## Fix

The combined redactor is **pure and deterministic** (`force=True`, fixed masking — identical input always yields identical output), so memoizing per-string is safe with no invalidation required.

`api/helpers.py`:
- Wrap the built redactor in `functools.lru_cache(maxsize=4096)`.
- Gate per-entry size at 16 KB (`_REDACT_CACHE_MAX_TEXT_LEN`) so a few giant tool-output dumps can't evict the thousands of small recurring strings that actually benefit, or balloon RSS.
- Keep the public `_redact_fn_cached` name as the call target (the redaction test suite monkeypatches it wholesale, so tests bypass the cache and remain unaffected).

The redaction safety boundary is unchanged: the same patterns run on a cache miss, secrets are still masked, and the `api_redact_enabled=false` fast-path is untouched.

## Benchmark

On a representative ~3 KB string containing a credential marker:

| | per call |
|---|---|
| full redact (cache miss) | 3.718 ms |
| cache hit | 0.0020 ms |

~1900x on the repeated-poll path. A large session has hundreds of such strings, which is the difference between the 10–44s responses observed and sub-millisecond ones.

## Verification

- `./scripts/test.sh tests/test_security_redaction.py` → 69 passed, 1 skipped.
- Manual: confirmed cache hits accumulate (`lru_cache` stats), secrets still masked on hit, `>16 KB` strings bypass the cache, and the `api_redact_enabled=false` bypass still returns text unchanged.
- Idle CPU after deploy dropped from ~57% to ~0%.

## Release note

Fix a CPU/latency regression where repeated session polling re-ran the full API-response redactor over unchanged payloads, serializing behind the GIL and surfacing as "connection lost" in the browser. The deterministic redactor is now memoized.