### PR TITLE
Improve latest assistant response landmark

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -453,6 +453,9 @@ const _recycleResetAttrs=[
   'data-transparent-turn-toggle-bound',
   'data-anchor-scene-live-owner',
   'data-anchor-stream-id',
+  'data-latest-assistant-response',
+  'role',
+  'aria-label',
   // Defensive reset for legacy/restored shells that may still carry the fallback live-turn marker.
   'data-live-assistant-turn',
 ];
@@ -8617,6 +8620,24 @@ function _createAssistantTurn(tsTitle='', tpsText=''){
   row.innerHTML=`${_assistantRoleHtml(tsTitle, tpsText)}<div class="assistant-turn-blocks"></div>`;
   return row;
 }
+function _setLatestAssistantTurnLandmark(turn, isLatest){
+  if(!turn) return;
+  const label='Latest Hermes response';
+  if(isLatest){
+    if(typeof document!=='undefined'){
+      document.querySelectorAll('.assistant-turn[data-latest-assistant-response="true"]').forEach(el=>{
+        if(el!==turn) _setLatestAssistantTurnLandmark(el, false);
+      });
+    }
+    turn.setAttribute('role','region');
+    turn.setAttribute('aria-label',label);
+    turn.dataset.latestAssistantResponse='true';
+    return;
+  }
+  if(turn.getAttribute('role')==='region') turn.removeAttribute('role');
+  if(turn.getAttribute('aria-label')===label) turn.removeAttribute('aria-label');
+  delete turn.dataset.latestAssistantResponse;
+}
 function _assistantTurnBlocks(turn){
   return turn?turn.querySelector('.assistant-turn-blocks'):null;
 }
@@ -12214,6 +12235,13 @@ function renderMessages(options){
     }catch(e){}
   }
   const transparentToolResultsByTid=_transparentModeActive?_collectToolResultSnippetsByTid(S.messages):{};
+  const latestRenderedAssistantRawIdx=(()=>{
+    for(let i=renderVisWithIdx.length-1;i>=0;i--){
+      const entry=renderVisWithIdx[i];
+      if(entry&&entry.m&&entry.m.role==='assistant'&&!entry.m._live) return entry.rawIdx;
+    }
+    return -1;
+  })();
   // Windowed render loop replaces the legacy full loop:
   // for(let vi=0;vi<visWithIdx.length;vi++)
   for(let vi=0;vi<renderVisWithIdx.length;vi++){
@@ -12401,6 +12429,7 @@ function renderMessages(options){
       currentAssistantTurn.dataset.recycleKey=rawIdx;
       inner.appendChild(currentAssistantTurn);
     }
+    _setLatestAssistantTurnLandmark(currentAssistantTurn, !m._live&&rawIdx===latestRenderedAssistantRawIdx);
     const seg=document.createElement('div');
     if(Array.isArray(orderedTransparentParts)&&orderedTransparentParts.length){
       const blocks=_assistantTurnBlocks(currentAssistantTurn);

--- a/tests/test_a11y_transcript_landmarks.py
+++ b/tests/test_a11y_transcript_landmarks.py
@@ -1,0 +1,54 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX_HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _function_body(source: str, name: str) -> str:
+    start = source.find(f"function {name}(")
+    assert start != -1, f"{name}() not found"
+    end = source.find("\nfunction ", start + 1)
+    if end == -1:
+        end = len(source)
+    return source[start:end]
+
+
+def test_conversation_transcript_is_not_a_named_region():
+    match = re.search(r'<div class="messages" id="messages"[^>]*>', INDEX_HTML)
+    assert match, "#messages container not found"
+    tag = match.group(0)
+    assert 'role="region"' not in tag
+    assert 'Conversation transcript' not in tag
+    assert "tabindex" not in tag.lower()
+
+
+def test_latest_assistant_landmark_helper_is_named_but_not_focusable():
+    helper = _function_body(UI_JS, "_setLatestAssistantTurnLandmark")
+    assert "Latest Hermes response" in helper
+    assert "setAttribute('role','region')" in helper
+    assert "setAttribute('aria-label',label)" in helper
+    assert "data-latest-assistant-response" in helper
+    assert "tabindex" not in helper.lower()
+    assert "<h" not in helper.lower()
+
+
+def test_settled_render_marks_only_the_latest_assistant_turn():
+    render_messages = _function_body(UI_JS, "renderMessages")
+    assert "const latestRenderedAssistantRawIdx=(()=>{" in render_messages
+    assert "if(entry&&entry.m&&entry.m.role==='assistant'&&!entry.m._live) return entry.rawIdx;" in render_messages
+    assert "_setLatestAssistantTurnLandmark(currentAssistantTurn, !m._live&&rawIdx===latestRenderedAssistantRawIdx);" in render_messages
+    assert "seg.setAttribute('role','region')" not in render_messages
+    assert "orderedSeg.setAttribute('role','region')" not in render_messages
+
+
+def test_live_assistant_turn_paths_do_not_own_final_response_landmark():
+    restore_live_turn = _function_body(UI_JS, "restoreLiveTurnHtmlForSession")
+    render_live_scene = _function_body(UI_JS, "renderLiveAnchorActivityScene")
+    append_thinking = _function_body(UI_JS, "appendThinking")
+
+    assert "_setLatestAssistantTurnLandmark(restored, true);" not in restore_live_turn
+    assert "_setLatestAssistantTurnLandmark(turn, true);" not in render_live_scene
+    assert "_setLatestAssistantTurnLandmark(turn, true);" not in append_thinking

--- a/tests/test_anchor_fallback_ownership.py
+++ b/tests/test_anchor_fallback_ownership.py
@@ -604,6 +604,7 @@ def test_render_messages_keeps_anchor_owned_turn_out_of_legacy_activity_rebuilds
           return turn;
         }}
         function _assistantTurnBlocks(turn) {{ return turn ? turn.querySelector('.assistant-turn-blocks') : null; }}
+        function _setLatestAssistantTurnLandmark() {{}}
         function _assistantRoleHtml() {{ return ''; }}
         function _userMessageDomId(rawIdx) {{ return `user-${{rawIdx}}`; }}
         function _messageSessionIndexForRawIdx(rawIdx) {{ return rawIdx; }}

--- a/tests/test_issue4793_dom_recycle_hardening.py
+++ b/tests/test_issue4793_dom_recycle_hardening.py
@@ -89,6 +89,8 @@ const S = { session: { session_id: 'sess-1' } };
 const _assistantRoleHtml = (title, tps) => `role:${title}:${tps}`;
 const isTpsDisplayEnabled = () => true;
 const _formatTurnTps = value => `tps:${value}`;
+const latestRenderedAssistantRawIdx = rawIdx;
+function _setLatestAssistantTurnLandmark() {}
 eval(recycleChunk);
 console.log(JSON.stringify({
   removedAttrs,
@@ -110,6 +112,9 @@ console.log(JSON.stringify({
         "data-transparent-turn-toggle-bound",
         "data-anchor-scene-live-owner",
         "data-anchor-stream-id",
+        "data-latest-assistant-response",
+        "role",
+        "aria-label",
         "data-live-assistant-turn",
     }
     assert set(result["resetAttrs"]) == expected_attrs
@@ -155,6 +160,8 @@ const S = { session: { session_id: 'sess-1' } };
 const _assistantRoleHtml = (title, tps) => `role:${title}:${tps}`;
 const isTpsDisplayEnabled = () => true;
 const _formatTurnTps = value => `tps:${value}`;
+const latestRenderedAssistantRawIdx = rawIdx;
+function _setLatestAssistantTurnLandmark() {}
 eval(recycleChunk);
 console.log(JSON.stringify({
   blocksInnerHTML: blocks.innerHTML,


### PR DESCRIPTION
## Thinking Path

This is a small screen-reader navigation improvement for the settled final assistant response.

The original accessibility problem appears after streaming completes: the live assistant DOM can be replaced by the settled transcript render, and screen-reader users may need a stable way to return to the final response. To keep the state model simple, this PR does not mark the streaming/live assistant turn. It only marks the latest assistant turn during settled transcript rendering.

## What Changed

- Adds a helper that marks one assistant turn as the `Latest Hermes response` region and clears stale latest-response markers.
- Applies that helper from the settled transcript render path only.
- Keeps the transcript container, live assistant turn paths, and older assistant turns out of the landmark list.
- Adds regression coverage that verifies:
  - the transcript container is not a named region,
  - only settled render owns the latest-response landmark,
  - live/restored-live paths do not own the final-response landmark,
  - no generated headings or `tabindex` are introduced.

## Why It Matters

Assistant responses often contain Markdown headings. A response-level landmark gives screen-reader users a stable boundary for the final response while keeping heading navigation available for structure inside the answer.

Keeping the marker final-only also avoids competing ownership between live streaming DOM and the settled transcript render.

## Verification

- `./scripts/test.sh tests/test_a11y_transcript_landmarks.py`
- `./scripts/test.sh tests/test_anchor_fallback_ownership.py::test_render_messages_keeps_anchor_owned_turn_out_of_legacy_activity_rebuilds tests/test_issue4793_dom_recycle_hardening.py::test_recycled_assistant_turn_reuse_clears_live_anchor_attrs tests/test_issue4793_dom_recycle_hardening.py::test_recycled_assistant_turn_reuse_keeps_block_clear_and_role_refresh tests/test_a11y_transcript_landmarks.py`
- `node --check static/ui.js`
- `git diff --check`
- `.venv/bin/python scripts/ruff_lint.py --diff upstream/master`

Manual NVDA check on a live patched server before opening the PR: only the latest assistant response was exposed as the `Latest Hermes response` landmark, and it read cleanly. This update narrows the implementation to the settled final render path.

## Risks / Follow-ups

- This intentionally does not provide a landmark for the currently streaming live response. If live-response navigation is useful, it should be designed separately with explicit ownership across live and settled render paths.
- This intentionally does not solve navigation to older assistant responses. That may need a separate design discussion because headings, landmarks, and transcript navigation each have tradeoffs.

## Model Used

OpenAI GPT-5.5 via Hermes Agent, with local shell/git/test tooling.
