### PR TITLE
fix(session): drop interleaved tool rows after mid-history truncate (#5134)

### DIFF
--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -79,9 +79,7 @@ def truncate_context_for_display_keep(
     msgs = full_messages if isinstance(full_messages, list) else []
     if not ctx:
         return []
-    if len(ctx) == len(msgs):
-        return ctx[:keep]
-    if len(ctx) < len(msgs):
+    if len(ctx) <= len(msgs):
         return ctx[:keep]
     if len(msgs) == 0:
         return []
@@ -129,13 +127,20 @@ def truncate_context_for_display_keep(
     # Cut at the first unkept display turn, or fallback to the last kept turn
     # if the boundary is not directly alignable.
     if keep < len(msgs):
-        first_unkept = matches[keep]
-        if first_unkept is not None:
-            return ctx[:first_unkept]
+        last_kept = None
         if keep > 0:
             last_kept = matches[keep - 1]
-            if last_kept is not None:
+        first_unkept = matches[keep]
+        if first_unkept is not None:
+            if (
+                last_kept is not None
+                and isinstance(msgs[keep - 1], dict)
+                and msgs[keep - 1].get('role') == 'user'
+            ):
                 return ctx[:last_kept + 1]
+            return ctx[:first_unkept]
+        if last_kept is not None:
+            return ctx[:last_kept + 1]
 
     # Final fallback preserves #5096 behavior when alignment is unreliable.
     prefix_len = max(0, len(ctx) - len(msgs))

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -6,6 +6,7 @@ Behavior parity reference: gateway/run.py:_handle_*_command in
 the hermes-agent repo.
 """
 from __future__ import annotations
+import json
 import logging
 from typing import Any
 
@@ -84,37 +85,52 @@ def truncate_context_for_display_keep(
     if len(msgs) == 0:
         return []
 
-    def _row_matches(context_row: Any, msg_row: Any) -> bool:
-        """Match rows by stable id, then (role, content, timestamp), then
-        (role, content)."""
-        if not isinstance(context_row, dict) or not isinstance(msg_row, dict):
-            return False
-
-        context_id = context_row.get('id')
-        msg_id = msg_row.get('id')
-        if context_id is not None and msg_id is not None and context_id == msg_id:
-            return True
-
-        context_ts = context_row.get('timestamp')
-        msg_ts = msg_row.get('timestamp')
-        if context_ts is not None and msg_ts is not None:
-            if (
-                context_row.get('role') == msg_row.get('role')
-                and context_row.get('content') == msg_row.get('content')
-                and context_ts == msg_ts
-            ):
-                return True
-
+    def _row_signature(row: Any) -> tuple[str, ...] | None:
+        if not isinstance(row, dict):
+            return None
+        tool_calls = row.get('tool_calls')
+        tool_calls_sig = json.dumps(tool_calls, sort_keys=True, default=str) if tool_calls else ''
         return (
-            context_row.get('role') == msg_row.get('role')
-            and context_row.get('content') == msg_row.get('content')
+            str(row.get('role') or ''),
+            str(row.get('content') or ''),
+            str(row.get('tool_call_id') or ''),
+            str(row.get('tool_use_id') or ''),
+            str(row.get('tool_name') or row.get('name') or ''),
+            tool_calls_sig,
         )
 
     def _first_match_from(message: Any, start_idx: int) -> int | None:
+        msg_sig = _row_signature(message)
+        if msg_sig is None:
+            return None
+        msg_id = message.get('id')
+        msg_ts = message.get('timestamp')
+        weak_matches: list[int] = []
         for idx in range(start_idx, len(ctx)):
-            if _row_matches(ctx[idx], message):
-                return idx
-        return None
+            context_row = ctx[idx]
+            context_sig = _row_signature(context_row)
+            if context_sig is None:
+                continue
+
+            context_id = context_row.get('id')
+            if context_id is not None and msg_id is not None:
+                if context_id == msg_id:
+                    return idx
+                continue
+
+            if context_sig != msg_sig:
+                continue
+
+            context_ts = context_row.get('timestamp')
+            if context_ts is not None and msg_ts is not None:
+                if context_ts == msg_ts:
+                    return idx
+                continue
+
+            weak_matches.append(idx)
+            if len(weak_matches) > 1:
+                return None
+        return weak_matches[0] if len(weak_matches) == 1 else None
 
     matches = [None] * len(msgs)
     next_ctx_idx = 0

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -81,9 +81,63 @@ def truncate_context_for_display_keep(
         return []
     if len(ctx) == len(msgs):
         return ctx[:keep]
+    if len(ctx) < len(msgs):
+        return ctx[:keep]
     if len(msgs) == 0:
         return []
-    # Context tail aligns with full display transcript; preserve leading-only rows.
+
+    def _row_matches(context_row: Any, msg_row: Any) -> bool:
+        """Match rows by stable id, then (role, content, timestamp), then
+        (role, content)."""
+        if not isinstance(context_row, dict) or not isinstance(msg_row, dict):
+            return False
+
+        context_id = context_row.get('id')
+        msg_id = msg_row.get('id')
+        if context_id is not None and msg_id is not None and context_id == msg_id:
+            return True
+
+        context_ts = context_row.get('timestamp')
+        msg_ts = msg_row.get('timestamp')
+        if context_ts is not None and msg_ts is not None:
+            if (
+                context_row.get('role') == msg_row.get('role')
+                and context_row.get('content') == msg_row.get('content')
+                and context_ts == msg_ts
+            ):
+                return True
+
+        return (
+            context_row.get('role') == msg_row.get('role')
+            and context_row.get('content') == msg_row.get('content')
+        )
+
+    def _first_match_from(message: Any, start_idx: int) -> int | None:
+        for idx in range(start_idx, len(ctx)):
+            if _row_matches(ctx[idx], message):
+                return idx
+        return None
+
+    matches = [None] * len(msgs)
+    next_ctx_idx = 0
+    for msg_idx, message in enumerate(msgs):
+        match_idx = _first_match_from(message, next_ctx_idx)
+        matches[msg_idx] = match_idx
+        if match_idx is not None:
+            next_ctx_idx = match_idx + 1
+
+    # Cut at the first unkept display turn, or fallback to the last kept turn
+    # if the boundary is not directly alignable.
+    if keep < len(msgs):
+        first_unkept = matches[keep]
+        if first_unkept is not None:
+            return ctx[:first_unkept]
+        if keep > 0:
+            last_kept = matches[keep - 1]
+            if last_kept is not None:
+                return ctx[:last_kept + 1]
+
+    # Final fallback preserves #5096 behavior when alignment is unreliable.
     prefix_len = max(0, len(ctx) - len(msgs))
     prefix = ctx[:prefix_len]
     suffix = ctx[prefix_len:]

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -99,10 +99,10 @@ def truncate_context_for_display_keep(
             tool_calls_sig,
         )
 
-    def _first_match_from(message: Any, start_idx: int) -> int | None:
+    def _first_match_from(message: Any, start_idx: int) -> tuple[int | None, int | None]:
         msg_sig = _row_signature(message)
         if msg_sig is None:
-            return None
+            return None, None
         msg_id = message.get('id')
         msg_ts = message.get('timestamp')
         weak_matches: list[int] = []
@@ -115,7 +115,7 @@ def truncate_context_for_display_keep(
             context_id = context_row.get('id')
             if context_id is not None and msg_id is not None:
                 if context_id == msg_id:
-                    return idx
+                    return idx, None
                 continue
 
             if context_sig != msg_sig:
@@ -124,19 +124,21 @@ def truncate_context_for_display_keep(
             context_ts = context_row.get('timestamp')
             if context_ts is not None and msg_ts is not None:
                 if context_ts == msg_ts:
-                    return idx
+                    return idx, None
                 continue
 
             weak_matches.append(idx)
             if len(weak_matches) > 1:
-                return None
-        return weak_matches[0] if len(weak_matches) == 1 else None
+                return None, weak_matches[0]
+        return (weak_matches[0], None) if len(weak_matches) == 1 else (None, None)
 
     matches = [None] * len(msgs)
+    ambiguous_matches = [None] * len(msgs)
     next_ctx_idx = 0
     for msg_idx, message in enumerate(msgs):
-        match_idx = _first_match_from(message, next_ctx_idx)
+        match_idx, ambiguous_idx = _first_match_from(message, next_ctx_idx)
         matches[msg_idx] = match_idx
+        ambiguous_matches[msg_idx] = ambiguous_idx
         if match_idx is not None:
             next_ctx_idx = match_idx + 1
 
@@ -156,6 +158,13 @@ def truncate_context_for_display_keep(
                 return ctx[:last_kept + 1]
             return ctx[:first_unkept]
         if last_kept is not None:
+            ambiguous_first_unkept = ambiguous_matches[keep]
+            if (
+                ambiguous_first_unkept is not None
+                and isinstance(msgs[keep - 1], dict)
+                and msgs[keep - 1].get('role') != 'user'
+            ):
+                return ctx[:ambiguous_first_unkept]
             return ctx[:last_kept + 1]
 
     # Final fallback preserves #5096 behavior when alignment is unreliable.

--- a/tests/test_issue_branch_context_at_fork.py
+++ b/tests/test_issue_branch_context_at_fork.py
@@ -32,3 +32,68 @@ def test_truncate_context_preserves_leading_compaction_row():
     out = truncate_context_for_display_keep(ctx, msgs, 2)
     assert len(out) == 3
     assert out[0]["content"] == "compaction-ref-only"
+
+
+def test_truncate_context_for_display_keep_drops_interleaved_tool_tail():
+    msgs = [
+        {"role": "user", "content": "u1", "id": "u1", "timestamp": 1.0},
+        {"role": "assistant", "content": "a1", "id": "a1", "timestamp": 2.0},
+        {"role": "user", "content": "u2", "id": "u2", "timestamp": 3.0},
+        {"role": "assistant", "content": "a2", "id": "a2", "timestamp": 4.0},
+    ]
+    ctx = [
+        {"role": "user", "content": "u1", "id": "u1", "timestamp": 1.0},
+        {"role": "assistant", "content": "a1", "id": "a1", "timestamp": 2.0},
+        {"role": "user", "content": "u2", "id": "u2", "timestamp": 3.0},
+        {"role": "assistant", "content": "tool-call-after-cut", "id": "tool-call-after-cut"},
+        {"role": "tool", "content": "tool-result-after-cut", "id": "tool-result-after-cut"},
+        {"role": "assistant", "content": "a2", "id": "a2", "timestamp": 4.0},
+    ]
+    out = truncate_context_for_display_keep(ctx, msgs, 2)
+    contents = [m["content"] for m in out]
+    assert contents == ["u1", "a1"]
+    assert "u2" not in contents
+    assert "tool-call-after-cut" not in contents
+    assert "tool-result-after-cut" not in contents
+
+
+def test_truncate_context_for_display_keep_keeps_tool_rows_before_next_display_anchor():
+    msgs = [
+        {"role": "user", "content": "u1", "id": "u1", "timestamp": 1.0},
+        {"role": "assistant", "content": "a1", "id": "a1", "timestamp": 2.0},
+        {"role": "user", "content": "u2", "id": "u2", "timestamp": 3.0},
+        {"role": "assistant", "content": "a2", "id": "a2", "timestamp": 4.0},
+    ]
+    ctx = [
+        {"role": "user", "content": "u1", "id": "u1", "timestamp": 1.0},
+        {"role": "assistant", "content": "a1", "id": "a1", "timestamp": 2.0},
+        {"role": "assistant", "content": "assistant-think", "id": "a1-think"},
+        {"role": "assistant", "content": "assistant-tool-result", "id": "a1-tool", "timestamp": 2.5},
+        {"role": "user", "content": "u2", "id": "u2", "timestamp": 3.0},
+        {"role": "assistant", "content": "a2", "id": "a2", "timestamp": 4.0},
+    ]
+    out = truncate_context_for_display_keep(ctx, msgs, 2)
+    contents = [m["content"] for m in out]
+    assert contents == [
+        "u1",
+        "a1",
+        "assistant-think",
+        "assistant-tool-result",
+    ]
+    assert contents[-1] != "u2"
+
+
+def test_truncate_context_for_display_keep_prefers_compact_summary_fallback():
+    msgs = [
+        {"role": "user", "content": "u1", "id": "u1", "timestamp": 1.0},
+        {"role": "assistant", "content": "a1", "id": "a1", "timestamp": 2.0},
+        {"role": "user", "content": "u2", "id": "u2", "timestamp": 3.0},
+        {"role": "assistant", "content": "a2", "id": "a2", "timestamp": 4.0},
+    ]
+    ctx = [
+        {"role": "user", "content": "compact", "id": "summary"},
+        {"role": "user", "content": "u1", "id": "u1", "timestamp": 1.0},
+        {"role": "assistant", "content": "a1", "id": "a1", "timestamp": 2.0},
+    ]
+    out = truncate_context_for_display_keep(ctx, msgs, 2)
+    assert out == ctx[:2]

--- a/tests/test_issue_branch_context_at_fork.py
+++ b/tests/test_issue_branch_context_at_fork.py
@@ -120,3 +120,17 @@ def test_truncate_context_for_display_keep_prefers_compact_summary_fallback():
     ]
     out = truncate_context_for_display_keep(ctx, msgs, 2)
     assert out == ctx[:2]
+
+
+def test_truncate_context_for_display_keep_keeps_real_user_turn_when_duplicate_rows_lack_identity():
+    msgs = [
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+    ]
+    ctx = [
+        {"role": "user", "content": "u1"},
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+    ]
+    out = truncate_context_for_display_keep(ctx, msgs, 1)
+    assert [row["content"] for row in out] == ["u1", "u1"]

--- a/tests/test_issue_branch_context_at_fork.py
+++ b/tests/test_issue_branch_context_at_fork.py
@@ -83,6 +83,29 @@ def test_truncate_context_for_display_keep_keeps_tool_rows_before_next_display_a
     assert contents[-1] != "u2"
 
 
+def test_truncate_context_for_display_keep_drops_unkept_tool_rows_after_user_boundary():
+    msgs = [
+        {"role": "user", "content": "u1", "id": "u1", "timestamp": 1.0},
+        {"role": "assistant", "content": "a1", "id": "a1", "timestamp": 2.0},
+        {"role": "user", "content": "u2", "id": "u2", "timestamp": 3.0},
+        {"role": "assistant", "content": "a2", "id": "a2", "timestamp": 4.0},
+    ]
+    ctx = [
+        {"role": "user", "content": "u1", "id": "u1", "timestamp": 1.0},
+        {"role": "assistant", "content": "a1", "id": "a1", "timestamp": 2.0},
+        {"role": "user", "content": "u2", "id": "u2", "timestamp": 3.0},
+        {"role": "assistant", "content": "tool-call-after-user-keep", "id": "tool-call-after-user-keep"},
+        {"role": "tool", "content": "tool-result-after-user-keep", "id": "tool-result-after-user-keep"},
+        {"role": "assistant", "content": "a2", "id": "a2", "timestamp": 4.0},
+    ]
+    out = truncate_context_for_display_keep(ctx, msgs, 3)
+    contents = [m["content"] for m in out]
+    assert contents == ["u1", "a1", "u2"]
+    assert "tool-call-after-user-keep" not in contents
+    assert "tool-result-after-user-keep" not in contents
+    assert "a2" not in contents
+
+
 def test_truncate_context_for_display_keep_prefers_compact_summary_fallback():
     msgs = [
         {"role": "user", "content": "u1", "id": "u1", "timestamp": 1.0},

--- a/tests/test_issue_branch_context_at_fork.py
+++ b/tests/test_issue_branch_context_at_fork.py
@@ -134,3 +134,20 @@ def test_truncate_context_for_display_keep_keeps_real_user_turn_when_duplicate_r
     ]
     out = truncate_context_for_display_keep(ctx, msgs, 1)
     assert [row["content"] for row in out] == ["u1", "u1"]
+
+def test_truncate_context_for_display_keep_keeps_tool_tail_before_ambiguous_unkept_anchor():
+    msgs = [
+        {"role": "user", "content": "u1", "id": "u1"},
+        {"role": "assistant", "content": "a1", "id": "a1", "tool_calls": [{"id": "kept-tool"}]},
+        {"role": "user", "content": "u2"},
+    ]
+    ctx = [
+        {"role": "user", "content": "u1", "id": "u1"},
+        {"role": "assistant", "content": "a1", "id": "a1", "tool_calls": [{"id": "kept-tool"}]},
+        {"role": "tool", "content": "kept-tool-result", "tool_call_id": "kept-tool"},
+        {"role": "user", "content": "u2"},
+        {"role": "user", "content": "u2"},
+        {"role": "assistant", "content": "a2", "id": "a2"},
+    ]
+    out = truncate_context_for_display_keep(ctx, msgs, 2)
+    assert [row["content"] for row in out] == ["u1", "a1", "kept-tool-result"]


### PR DESCRIPTION
## Thinking Path

- The `#5096` context-truncation bundle fixed the broad parent-context leak by routing branch, edit, regenerate, and truncate rewinds through `truncate_context_for_display_keep()`.
- The remaining edge is narrower: provider-facing `context_messages` can contain tool calls, tool results, and assistant continuation rows between display rows, so a positional length-delta cut can keep part of the first unkept turn.
- The fix stays inside the existing helper owner and cuts at the first unkept display anchor instead of treating every extra context row as a leading compaction prefix.

## What Changed

- `api/session_ops.py`: align display rows inside `context_messages` and cut at the first unkept display anchor, while preserving same-length, leading-prefix, and compact-short-context fallback behavior.
- `tests/test_issue_branch_context_at_fork.py`: add regressions for interleaved later tool rows, kept-turn tool rows, and the `len(ctx) < len(msgs)` compact-summary fallback.

## Why It Matters

Mid-history branch, edit, regenerate, and truncate actions should leave the model context at the same boundary the user sees in the display transcript. This prevents post-cut tool rows from leaking into the next model call while keeping the `#5096` improvements intact.

## Verification

- `pytest tests/test_issue_branch_context_at_fork.py -v --timeout=60`
- Full-suite CI context: `pytest tests/ -v --timeout=60`

## Upstream

Closes #5134.

## Model Used

GPT 5.5 via Codex CLI
