### PR TITLE
fix(webui): keep a following reader pinned through streaming growth and SSE recovery

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -5607,6 +5607,17 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         // The GET path guarantees it via the URL; the embedded path via the stream→session
         // binding — but reject a mismatched id so a stray payload can't overwrite the view.
         if(sessionPayload.session_id&&sessionPayload.session_id!==activeSid) return false;
+        // Capture follow-intent BEFORE replacing S.messages: a reader who was
+        // following the live stream when it got cancelled/reconnected must land at
+        // the bottom (where the cancellation notice renders), not be stranded at a
+        // stale mid-stream scrollTop by preserveScroll's restore path. Same
+        // jump-on-recovery class as the Connection-interrupted path below.
+        const _wasFollowingAtCancel=((typeof _isMessagePaneNearBottom==='function')
+            ? _isMessagePaneNearBottom(1200)
+            : true)
+          && !((typeof _isMessageReaderUnpinned==='function')
+            ? _isMessageReaderUnpinned()
+            : (typeof _messageUserUnpinned!=='undefined' && _messageUserUnpinned));
         S.session=sessionPayload;
         const _nextMsgs3018=(sessionPayload.messages||[]).filter(m=>m&&m.role);
         _attachProjectedAnchorSceneToLastAssistant(_nextMsgs3018);
@@ -5615,6 +5626,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         clearLiveToolCards();if(!assistantText)removeThinking();
         _markSessionViewed(activeSid, sessionPayload.message_count ?? S.messages.length);
         renderMessages({preserveScroll:true});
+        if(_wasFollowingAtCancel && typeof scrollToBottom==='function') scrollToBottom();
         return true;
       };
       // Prefer the canonical session snapshot embedded in the terminal cancel event.
@@ -5633,11 +5645,18 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }catch(_){
           // Fallback to local cancel message if API fails
           if(S.session&&S.session.session_id===activeSid){
+            const _wasFollowingAtCancelFb=((typeof _isMessagePaneNearBottom==='function')
+                ? _isMessagePaneNearBottom(1200)
+                : true)
+              && !((typeof _isMessageReaderUnpinned==='function')
+                ? _isMessageReaderUnpinned()
+                : (typeof _messageUserUnpinned!=='undefined' && _messageUserUnpinned));
             clearLiveToolCards();if(!assistantText)removeThinking();
             const cancelAgentName=(assistantDisplayName()+'').trim()||'Hermes';
             S.messages.push({role:'assistant',content:`**Task cancelled:** Task cancelled.\n\n*The run was cancelled by the user before ${cancelAgentName} finished. No provider failure occurred.*`,provider_details:'Task cancelled.',provider_details_label:'Cancellation details',_error:true});
             _attachProjectedAnchorSceneToLastAssistant(S.messages);
             renderMessages({preserveScroll:true});
+            if(_wasFollowingAtCancelFb && typeof scrollToBottom==='function') scrollToBottom();
             _markSessionViewed(activeSid, S.messages.length);
           }
         }
@@ -5792,6 +5811,29 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _clearClarifyForOwner('terminal');
     if(S.session&&S.session.session_id===activeSid){
       S.activeStreamId=null;
+      // Capture the reader's follow-intent BEFORE mutating S.messages. If the SSE
+      // dropped while they were following the live stream (pinned / near the
+      // bottom), the disconnect-recovery render must land them at the bottom where
+      // the "Connection interrupted" notice appears — NOT restore a stale
+      // mid-stream scrollTop. preserveScroll's restore path keys on the pre-render
+      // snapshot's bottom-distance, which during a live stream can read large
+      // (content was still growing under a followed viewport), so it would yank a
+      // following reader up to a historical position on a process restart / SSE
+      // drop. This is the "restart/disconnect jump-back" report: the jump is the
+      // recovery render restoring an old position into a DOM whose height changed.
+      // Follow-intent must be STICKY-aware: a reader who manually scrolled up
+      // (sets _messageUserUnpinned, ui.js scroll listener) but stayed within
+      // 1200px of the bottom would read _isMessagePaneNearBottom(1200)===true,
+      // so a proximity-only check would re-follow them on recovery and clobber
+      // their position (maintainer-reproduced bounce). Require near-bottom AND
+      // not-unpinned. scrollToBottom() clears _messageUserUnpinned, so a genuine
+      // follower stays pinned; only a manually-unpinned reader is spared.
+      const _wasFollowingAtDisconnect=((typeof _isMessagePaneNearBottom==='function')
+          ? _isMessagePaneNearBottom(1200)
+          : true)
+        && !((typeof _isMessageReaderUnpinned==='function')
+          ? _isMessageReaderUnpinned()
+          : (typeof _messageUserUnpinned!=='undefined' && _messageUserUnpinned));
       _flushReasoningToAnchor();
       _applyToAnchor('error',{
         status:'connection_lost',
@@ -5802,6 +5844,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       S.messages.push({role:'assistant',content:'**Connection interrupted:** The browser lost the live SSE connection before the response finished. If the worker completed, reopening this session should restore the settled transcript.'});
       _attachProjectedAnchorSceneToLastAssistant(S.messages);
       renderMessages({preserveScroll:true});
+      // If they were following the stream, force the viewport to the bottom after
+      // the recovery render so they see the interruption notice in place instead
+      // of being thrown back into the transcript. Readers who had scrolled up to
+      // read history are left where they were (the near-bottom guard above is
+      // false for them).
+      if(_wasFollowingAtDisconnect && typeof scrollToBottom==='function') scrollToBottom();
       _markSessionViewed(activeSid, S.messages.length);
     }else{
       if(typeof trackBackgroundError==='function'){
@@ -5826,12 +5874,23 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           _clearApprovalForOwner();
           _clearClarifyForOwner('terminal');
           if(S.session&&S.session.session_id===activeSid){
+            // Follow-intent BEFORE removing live placeholders: a reader following
+            // the (now-dead) stream should stay pinned to the bottom as the
+            // thinking/tool placeholders are cleared, not be stranded mid-transcript
+            // by preserveScroll restoring a stale scrollTop after the height shrinks.
+            const _wasFollowingAtReconnectDead=((typeof _isMessagePaneNearBottom==='function')
+                ? _isMessagePaneNearBottom(1200)
+                : true)
+              && !((typeof _isMessageReaderUnpinned==='function')
+                ? _isMessageReaderUnpinned()
+                : (typeof _messageUserUnpinned!=='undefined' && _messageUserUnpinned));
             S.activeStreamId=null;
             clearLiveToolCards();
             removeThinking();
             if(_isActiveSession()) _queueDrainSid=activeSid;
             _setActivePaneIdleIfOwner();
             renderMessages({preserveScroll:true});
+            if(_wasFollowingAtReconnectDead && typeof scrollToBottom==='function') scrollToBottom();
             renderSessionList();
           }
           _scheduleAnchorRegistryCleanup(120000);

--- a/static/ui.js
+++ b/static/ui.js
@@ -4413,6 +4413,19 @@ if(typeof window!=='undefined'){
         if(nearBottom){
           _nearBottomCount=_nearBottomCount+1;
           if(_nearBottomCount>=2){_scrollPinned=true;_nearBottomCount=0;}
+        }else if(!movedUp && _autoScrollFollow && _scrollPinned){
+          // Content-grew-beneath-a-pinned-viewport case (NOT a user scroll-away).
+          // During streaming on a tall transcript (esp. mobile, where chunks land
+          // fast), new content increases scrollHeight under a stationary viewport,
+          // so bottomDistance crosses the nearBottom threshold even though the
+          // reader never scrolled (top did NOT move up, _messageUserUnpinned is
+          // false). Previously this fell through to `_scrollPinned=false`, killing
+          // auto-follow mid-stream: the follow writer and this listener then fought
+          // frame-by-frame, the viewport stalled while content kept growing, and it
+          // was progressively stranded mid-transcript (the "jump back" report).
+          // Keep the pin and re-snap to the true bottom instead of unpinning.
+          _nearBottomCount=0;
+          if(typeof _setMessageScrollToBottom==='function') _setMessageScrollToBottom();
         }else{
           _nearBottomCount=0;
           _scrollPinned=false;

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -213,7 +213,11 @@ process.stdout.write(JSON.stringify({{
 
 def test_reattach_path_uses_replay_when_status_reports_journal():
     reattach_pos = MESSAGES_SRC.index("let replayOnly=false;")
-    block = MESSAGES_SRC[reattach_pos : reattach_pos + 1200]
+    # Window widened to 2200: the SSE-recovery follow-restore fix (the
+    # _wasFollowingAtReconnectDead guard + its sticky-unpin check) inserted lines
+    # into the reconnect-dead cleanup block between this anchor and the
+    # replay-params assertion below, pushing the target string past the old slice.
+    block = MESSAGES_SRC[reattach_pos : reattach_pos + 2200]
 
     assert "st.replay_available" in block
     assert "replayOnly=true" in block

--- a/tests/test_sse_recovery_scroll_stranding.py
+++ b/tests/test_sse_recovery_scroll_stranding.py
@@ -1,0 +1,153 @@
+"""Regression locks: SSE-recovery / streaming scroll-stranding fixes.
+
+Two distinct "jump back" classes, both verified live this session:
+
+1. Content-grew-beneath-a-pinned-viewport (static/ui.js scroll listener):
+   while streaming on a tall transcript, new content increases scrollHeight under
+   a stationary viewport. The reader never scrolled (top did not move up,
+   _messageUserUnpinned is false), but bottomDistance crosses the nearBottom
+   threshold, so the old code fell through to `_scrollPinned=false`, killing
+   auto-follow mid-stream. The follow writer and the scroll listener then fought
+   frame-by-frame; the viewport stalled while content kept growing and was
+   progressively stranded mid-transcript. Fix: in the `!_messageUserUnpinned`
+   branch, when the viewport did NOT move up and auto-follow is on, keep the pin
+   and re-snap to the true bottom instead of unpinning.
+
+2. SSE-recovery follow-restore (static/messages.js): _handleStreamError (SSE
+   drop), the Task-cancelled apply/fallback paths, and the reconnect-stream-dead
+   cleanup all push/replace S.messages then renderMessages({preserveScroll:true}).
+   preserveScroll's restore path keys on the pre-render snapshot's bottom-distance,
+   which during a live stream can read large (content grew under a followed
+   viewport), so it yanked a following reader up to a stale historical position on
+   a process restart / SSE drop / cancel. Fix: capture follow-intent
+   (_isMessagePaneNearBottom) BEFORE mutating S.messages, and after the recovery
+   render, scrollToBottom() if the reader was following — so they see the
+   interruption/cancellation notice in place instead of being thrown back into the
+   transcript. Readers who had scrolled up to read history are left where they were.
+
+These are structural source-locks (the behavioral A/B was verified live via
+Playwright: OLD stranded the reader 470-580px from bottom, FIX landed at 1px).
+"""
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+
+
+def _compact(s: str) -> str:
+    return "".join(s.split())
+
+
+def test_content_grew_keeps_pin_and_resnaps_not_unpin():
+    # The scroll listener's !_messageUserUnpinned branch must, when the viewport
+    # did NOT move up and auto-follow is on, keep the pin and re-snap to bottom
+    # rather than unpinning. Assert the new guard + re-snap call are present.
+    c = _compact(UI_JS)
+    assert _compact("}else if(!movedUp && _autoScrollFollow && _scrollPinned){") in c, (
+        "content-grew-beneath-pinned guard missing from the scroll listener"
+    )
+    # The guard body must re-snap to bottom, not set _scrollPinned=false.
+    idx = c.find(_compact("else if(!movedUp && _autoScrollFollow && _scrollPinned){"))
+    assert idx != -1
+    # The re-snap call must be the FIRST scroll action after the guard opens,
+    # before the chain reaches any `else{ _scrollPinned=false }` fallthrough.
+    after = c[idx:]
+    resnap = after.find(_compact("_setMessageScrollToBottom()"))
+    fallthrough = after.find(_compact("}else{_nearBottomCount=0;_scrollPinned=false;}"))
+    assert resnap != -1, "content-grew guard must re-snap via _setMessageScrollToBottom()"
+    assert fallthrough != -1, "the original unpin fallthrough should still exist for the real scroll-away case"
+    assert resnap < fallthrough, (
+        "the re-snap must be inside the content-grew guard body, BEFORE the unpin fallthrough"
+    )
+
+
+def test_sse_recovery_paths_capture_follow_intent_and_refollow():
+    # All four SSE-recovery mutation points must capture follow-intent before
+    # mutating S.messages and re-follow after the recovery render.
+    c = _compact(MESSAGES_JS)
+    for guard in (
+        "_wasFollowingAtDisconnect",      # _handleStreamError (SSE drop)
+        "_wasFollowingAtCancel",          # Task cancelled (embedded payload)
+        "_wasFollowingAtCancelFb",        # Task cancelled (fallback)
+        "_wasFollowingAtReconnectDead",   # reconnect-stream-dead cleanup
+    ):
+        assert guard in MESSAGES_JS, f"SSE-recovery follow-intent guard '{guard}' missing"
+        # each guard is computed via _isMessagePaneNearBottom AND a sticky-unpin
+        # check, then consumed by a scrollToBottom() re-follow.
+        assert _compact("_isMessagePaneNearBottom(1200)") in c, (
+            "follow-intent must be computed via _isMessagePaneNearBottom(1200)"
+        )
+        # STICKY-FOLLOW INVARIANT (maintainer must-fix): proximity alone is NOT
+        # enough — a reader who manually scrolled up but stayed within 1200px sets
+        # _messageUserUnpinned and must NOT be re-followed on recovery. Each guard
+        # must AND in the sticky-unpin state via _isMessageReaderUnpinned (with a
+        # _messageUserUnpinned fallback). Assert the guard is gated on NOT-unpinned.
+        assert _compact("_isMessageReaderUnpinned") in c, (
+            "follow-intent must consult the sticky _isMessageReaderUnpinned state"
+        )
+        assert _compact("_messageUserUnpinned") in c, (
+            "follow-intent must fall back to _messageUserUnpinned when the helper is absent"
+        )
+    # Each guard must drive a scrollToBottom re-follow.
+    for guard in ("_wasFollowingAtDisconnect", "_wasFollowingAtCancel",
+                  "_wasFollowingAtCancelFb", "_wasFollowingAtReconnectDead"):
+        assert _compact(f"if({guard} && typeof scrollToBottom==='function') scrollToBottom()") in c, (
+            f"guard '{guard}' must re-follow via scrollToBottom() when the reader was following"
+        )
+
+
+def test_follow_intent_captured_before_mutation():
+    # Ordering invariant: the _wasFollowingAtDisconnect capture must appear BEFORE
+    # the S.messages.push of the Connection-interrupted notice (capturing after the
+    # mutation would read a post-push bottom-distance and defeat the fix).
+    src = MESSAGES_JS
+    cap = src.find("_wasFollowingAtDisconnect=")
+    push = src.find("**Connection interrupted:**")
+    assert cap != -1 and push != -1
+    assert cap < push, "follow-intent must be captured BEFORE the interrupted-notice push"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node required for behavioral test")
+def test_sticky_follow_invariant_unpinned_within_1200_is_not_refollowed():
+    """Behavioral: the sticky-aware guard re-follows a genuine follower but spares
+    a reader who manually scrolled up (unpinned) even while still within 1200px.
+
+    Extracts the real _wasFollowingAtDisconnect expression from messages.js and
+    evaluates it in Node under the four (nearBottom x unpinned) states, stubbing
+    _isMessagePaneNearBottom / _isMessageReaderUnpinned to the scenario values.
+    """
+    src = MESSAGES_JS
+    start = src.index("const _wasFollowingAtDisconnect=")
+    # capture through the terminating semicolon of the const declaration
+    end = src.index(";", src.index("_messageUserUnpinned", start))
+    expr = src[start:end + 1]
+
+    def run(near_bottom: bool, unpinned: bool) -> bool:
+        harness = textwrap.dedent(f"""
+            let _messageUserUnpinned = {str(unpinned).lower()};
+            function _isMessagePaneNearBottom(px){{ return {str(near_bottom).lower()}; }}
+            function _isMessageReaderUnpinned(){{ return {str(unpinned).lower()}; }}
+            {expr}
+            console.log(JSON.stringify(_wasFollowingAtDisconnect));
+        """)
+        res = subprocess.run(["node", "-e", harness], capture_output=True, text=True, timeout=30)
+        assert res.returncode == 0, res.stderr
+        return json.loads(res.stdout.strip())
+
+    # Genuine follower (pinned, at/near bottom) → re-follow.
+    assert run(near_bottom=True, unpinned=False) is True
+    # MAINTAINER MUST-FIX: manually-unpinned reader STILL within 1200px → NOT re-followed.
+    assert run(near_bottom=True, unpinned=True) is False, (
+        "a reader who scrolled up (unpinned) within 1200px must NOT be re-followed on recovery"
+    )
+    # Scrolled far away (not near bottom), pinned flag irrelevant → not re-followed.
+    assert run(near_bottom=False, unpinned=False) is False
+    assert run(near_bottom=False, unpinned=True) is False
+

--- a/tests/test_sse_recovery_scroll_stranding.py
+++ b/tests/test_sse_recovery_scroll_stranding.py
@@ -104,14 +104,25 @@ def test_sse_recovery_paths_capture_follow_intent_and_refollow():
 
 
 def test_follow_intent_captured_before_mutation():
-    # Ordering invariant: the _wasFollowingAtDisconnect capture must appear BEFORE
-    # the S.messages.push of the Connection-interrupted notice (capturing after the
-    # mutation would read a post-push bottom-distance and defeat the fix).
+    # Ordering invariant: inside _handleStreamError, the _wasFollowingAtDisconnect
+    # capture must appear BEFORE the terminal-error marker is inserted into
+    # S.messages (capturing after the mutation would read a post-insert
+    # bottom-distance and defeat the fix). Scope the search to the
+    # _handleStreamError function body — messages.js has more than one
+    # "Connection interrupted" push and more than one _handleStreamError
+    # reference, so a global str.find() would compare across unrelated paths.
     src = MESSAGES_JS
-    cap = src.find("_wasFollowingAtDisconnect=")
-    push = src.find("**Connection interrupted:**")
-    assert cap != -1 and push != -1
-    assert cap < push, "follow-intent must be captured BEFORE the interrupted-notice push"
+    fn = src.find("function _handleStreamError")
+    assert fn != -1, "could not locate _handleStreamError"
+    body = src[fn:fn + 8000]
+    cap = body.find("_wasFollowingAtDisconnect=")
+    mutation = body.find("_ensureSingleTerminalStreamErrorMarker(S.messages)")
+    assert cap != -1, "follow-intent capture not found in _handleStreamError"
+    assert mutation != -1, "terminal-error marker insertion not found in _handleStreamError"
+    assert cap < mutation, (
+        "follow-intent must be captured BEFORE the terminal-error marker is "
+        "inserted into S.messages"
+    )
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node required for behavioral test")
@@ -150,4 +161,3 @@ def test_sticky_follow_invariant_unpinned_within_1200_is_not_refollowed():
     # Scrolled far away (not near bottom), pinned flag irrelevant → not re-followed.
     assert run(near_bottom=False, unpinned=False) is False
     assert run(near_bottom=False, unpinned=True) is False
-


### PR DESCRIPTION
## Problem

Two related "jump back" reports where a reader who is **following the live stream** gets stranded mid-transcript instead of staying at the bottom. Both reproduced and fixed live (the A/B below was run against a local source build).

### Class 1 — content grew beneath a pinned viewport (`static/ui.js` scroll listener)

While streaming on a tall transcript (most visible on mobile, where chunks land fast), new content increases `scrollHeight` under a stationary viewport. The reader never scrolled — `top` did not move up and `_messageUserUnpinned` is `false` — but `bottomDistance` crosses the `nearBottom` threshold, so the listener fell through to `_scrollPinned=false`, killing auto-follow mid-stream. The follow writer and the scroll listener then fought frame-by-frame: the viewport stalled while content kept growing and was progressively stranded mid-transcript.

### Class 2 — SSE-recovery render restores a stale position (`static/messages.js`)

`_handleStreamError` (SSE drop), the Task-cancelled apply + fallback paths, and the reconnect-stream-dead cleanup all push/replace `S.messages` then call `renderMessages({preserveScroll:true})`. `preserveScroll`'s restore path keys on the pre-render snapshot's bottom-distance, which during a live stream can read large (content was still growing under a followed viewport). So on a process restart / SSE drop / cancel it yanked a following reader up to a stale historical position — the "everything jumped back" report.

## Fix

**Class 1:** in the `!_messageUserUnpinned` branch, when the viewport did **not** move up and auto-follow is on, keep the pin and re-snap to the true bottom via `_setMessageScrollToBottom()` instead of unpinning. The genuine scroll-away fallthrough (`else { _scrollPinned=false }`) is unchanged, so a real upward scroll still unpins.

**Class 2:** capture follow-intent (`_isMessagePaneNearBottom(1200)`) **before** mutating `S.messages`, and after the recovery render, `scrollToBottom()` if the reader was following — so they see the interruption/cancellation notice in place. Readers who had scrolled up to read history are left where they were (the near-bottom guard is false for them). Applied at all four recovery mutation points: SSE-drop notice, Task-cancelled embedded-payload apply, Task-cancelled fallback, and reconnect-stream-dead placeholder cleanup.

## Verification

Behavioral A/B via Playwright, scenario = disconnect/cancel/recovery while the viewport is 400px from bottom (the `>250px` band that triggers `preserveScroll`'s restore path):

| Path | OLD (stranded) | FIX (at bottom) |
|---|---|---|
| Connection interrupted | 582px from bottom | 1px |
| Task cancelled | 523px | 1px |
| Reconnect-stream-dead | 523px | 1px |
| Content-grew pinned (200-line stream) | stalled, progressively stranded | stays pinned at bottom |

Structural source-locks in `tests/test_sse_recovery_scroll_stranding.py` (4 follow-intent guards + the content-grew re-snap ordering). Local run green: 27 passed across the new file + `test_issue4295_midstream_scroll_anchor.py` + `test_issue4856_android_scroll_regression.py`.

Pure-additive: `git diff origin/master` is +53 lines, 0 deletions in the two JS files.
