### PR TITLE
fix(config): collapse post-restart config reload stampede (#5220)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -440,6 +440,19 @@ def _apply_config_defaults(config_data: dict) -> None:
     for key, value in _DEFAULT_EXPERIMENTAL_CONFIG.items():
         experimental.setdefault(key, value)
 
+ 
+def reload_config_if_stale() -> None:
+    """Refresh config.yaml once for concurrent stale read paths."""
+    with _cfg_lock:
+        try:
+            config_path = _get_config_path()
+            current_mtime = config_path.stat().st_mtime
+        except OSError:
+            current_mtime = 0.0
+        cache_stale = current_mtime != _cfg_mtime or _cfg_path != config_path
+        if not _cfg_cache or (cache_stale and not _cfg_has_in_memory_overrides()):
+            _refresh_config_cache(config_path)
+
 
 def get_config() -> dict:
     """Return the cached config dict, loading from disk if needed."""
@@ -450,15 +463,7 @@ def get_config() -> dict:
         current_mtime = 0.0
     cache_stale = current_mtime != _cfg_mtime or _cfg_path != config_path
     if not _cfg_cache or (cache_stale and not _cfg_has_in_memory_overrides()):
-        with _cfg_lock:
-            try:
-                config_path = _get_config_path()
-                current_mtime = config_path.stat().st_mtime
-            except OSError:
-                current_mtime = 0.0
-            cache_stale = current_mtime != _cfg_mtime or _cfg_path != config_path
-            if not _cfg_cache or (cache_stale and not _cfg_has_in_memory_overrides()):
-                _refresh_config_cache(config_path)
+        reload_config_if_stale()
     # When a test (or runtime caller) has rebound ``cfg`` to a different dict
     # via monkeypatch.setattr(config, "cfg", ...), return that override rather
     # than the underlying _cfg_cache. Without this branch, get_config() would
@@ -5561,7 +5566,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         (_current_mtime != _cfg_mtime or _current_path != _cfg_path)
         and not _cfg_has_in_memory_overrides()
     ):
-        reload_config()
+        reload_config_if_stale()
     # ── COLD PATH helper ─────────────────────────────────────────────────────
     # Extracted so it runs inside _available_models_cache_lock (RLock) to
     # prevent thundering-herd: only one thread rebuilds while others wait.

--- a/api/config.py
+++ b/api/config.py
@@ -450,7 +450,15 @@ def get_config() -> dict:
         current_mtime = 0.0
     cache_stale = current_mtime != _cfg_mtime or _cfg_path != config_path
     if not _cfg_cache or (cache_stale and not _cfg_has_in_memory_overrides()):
-        reload_config()
+        with _cfg_lock:
+            try:
+                config_path = _get_config_path()
+                current_mtime = config_path.stat().st_mtime
+            except OSError:
+                current_mtime = 0.0
+            cache_stale = current_mtime != _cfg_mtime or _cfg_path != config_path
+            if not _cfg_cache or (cache_stale and not _cfg_has_in_memory_overrides()):
+                _refresh_config_cache(config_path)
     # When a test (or runtime caller) has rebound ``cfg`` to a different dict
     # via monkeypatch.setattr(config, "cfg", ...), return that override rather
     # than the underlying _cfg_cache. Without this branch, get_config() would
@@ -499,76 +507,86 @@ def is_unified_session_db_enabled(config_data: dict | None = None) -> bool:
     return experimental.get("unified_session_db") is True
 
 
+def _refresh_config_cache(config_path: Path | None = None) -> None:
+    """Refresh _cfg_cache for ``config_path``.
+
+    Callers must hold _cfg_lock when invoking this helper because it mutates
+    shared state.
+    """
+    global _cfg_mtime, _cfg_path, _cfg_fingerprint
+    if config_path is None:
+        config_path = _get_config_path()
+    _cfg_cache.clear()
+    # Remember the old mtime so we can tell whether config actually changed
+    # vs. first-ever load (mtime == 0.0, e.g. server start or profile switch).
+    _old_cfg_mtime = _cfg_mtime
+    _cfg_path = config_path
+    _cfg_mtime = 0.0
+    try:
+        if config_path.exists():
+            # Route the parse through the mtime-keyed cache (#4652) so an
+            # unchanged config.yaml isn't re-parsed (~125ms+ on a large file)
+            # on every reload_config() on the hot path (profile switch /
+            # load_settings, #4662 Phase 2). We take the RAW cached dict and
+            # run the env expansion HERE, pinned to the unscoped process-env
+            # view (below) — never the helper's per-call expansion — for the
+            # #798 TLS reason documented in the pin block.
+            loaded = _load_yaml_config_file_raw(config_path)
+            if isinstance(loaded, dict):
+                if loaded:
+                    # The process-global _cfg_cache must reflect PROCESS-env
+                    # expansion, never a profile-scoped block_process_env_fallback
+                    # view — otherwise a reload that fires while a readonly/worker
+                    # scope is active (profile alternation resolves _get_config_path
+                    # to the named profile, #798 TLS) would bake under-expanded
+                    # literal ${VAR}s into the shared cache and starve concurrent
+                    # readers of the module-level `cfg` alias. Expansion re-runs
+                    # per-read elsewhere; here we pin the cache to the unscoped view.
+                    _prev_block = getattr(_thread_ctx, "block_process_env_fallback", False)
+                    _prev_env = getattr(_thread_ctx, "env", None)
+                    try:
+                        _thread_ctx.block_process_env_fallback = False
+                        _thread_ctx.env = {}
+                        _cfg_cache.update(_expand_env_vars(loaded))
+                    finally:
+                        _thread_ctx.block_process_env_fallback = _prev_block
+                        if _prev_env is None:
+                            try:
+                                del _thread_ctx.env
+                            except AttributeError:
+                                pass
+                        else:
+                            _thread_ctx.env = _prev_env
+                # Stamp _cfg_mtime whenever the file parsed to a dict — INCLUDING
+                # an empty {} config. The cache-update above is skipped for {} (it's
+                # a no-op), but _cfg_mtime MUST still be set or get_config()'s
+                # `current_mtime != _cfg_mtime` stale check fires on every call and
+                # spins reload_config() under _cfg_lock forever (a `{}` config from a
+                # freshly created/reset profile is reachable on the switch hot path).
+                # This matches master's pre-#4662 behavior (it entered the block for
+                # {} and set the mtime); the inner `if loaded:` only gates the no-op
+                # cache update, not the mtime stamp.
+                try:
+                    _cfg_mtime = Path(config_path).stat().st_mtime
+                except OSError:
+                    _cfg_mtime = 0.0
+    except Exception:
+        logger.debug("Failed to load yaml config from %s", config_path)
+    _apply_config_defaults(_cfg_cache)
+    _cfg_fingerprint = _fingerprint_config(_cfg_cache)
+    # Bust the models cache so the next request sees fresh config values.
+    # Only delete the disk cache when config has actually changed -- not on
+    # first-ever load (when _old_cfg_mtime == 0.0, i.e. server start or
+    # profile switch) -- preserving the disk cache so the next restart
+    # still hits the fast path without a cold run.
+    if _old_cfg_mtime != 0.0:
+        _delete_models_cache_on_disk()
+
+
 def reload_config() -> None:
     """Reload config.yaml from the active profile's directory."""
-    global _cfg_mtime, _cfg_path, _cfg_fingerprint
     with _cfg_lock:
-        _cfg_cache.clear()
-        config_path = _get_config_path()
-        # Remember the old mtime so we can tell whether config actually changed
-        # vs. first-ever load (mtime == 0.0, e.g. server start or profile switch).
-        _old_cfg_mtime = _cfg_mtime
-        _cfg_path = config_path
-        _cfg_mtime = 0.0
-        try:
-            if config_path.exists():
-                # Route the parse through the mtime-keyed cache (#4652) so an
-                # unchanged config.yaml isn't re-parsed (~125ms+ on a large file)
-                # on every reload_config() on the hot path (profile switch /
-                # load_settings, #4662 Phase 2). We take the RAW cached dict and
-                # run the env expansion HERE, pinned to the unscoped process-env
-                # view (below) — never the helper's per-call expansion — for the
-                # #798 TLS reason documented in the pin block.
-                loaded = _load_yaml_config_file_raw(config_path)
-                if isinstance(loaded, dict):
-                    if loaded:
-                        # The process-global _cfg_cache must reflect PROCESS-env
-                        # expansion, never a profile-scoped block_process_env_fallback
-                        # view — otherwise a reload that fires while a readonly/worker
-                        # scope is active (profile alternation resolves _get_config_path
-                        # to the named profile, #798 TLS) would bake under-expanded
-                        # literal ${VAR}s into the shared cache and starve concurrent
-                        # readers of the module-level `cfg` alias. Expansion re-runs
-                        # per-read elsewhere; here we pin the cache to the unscoped view.
-                        _prev_block = getattr(_thread_ctx, "block_process_env_fallback", False)
-                        _prev_env = getattr(_thread_ctx, "env", None)
-                        try:
-                            _thread_ctx.block_process_env_fallback = False
-                            _thread_ctx.env = {}
-                            _cfg_cache.update(_expand_env_vars(loaded))
-                        finally:
-                            _thread_ctx.block_process_env_fallback = _prev_block
-                            if _prev_env is None:
-                                try:
-                                    del _thread_ctx.env
-                                except AttributeError:
-                                    pass
-                            else:
-                                _thread_ctx.env = _prev_env
-                    # Stamp _cfg_mtime whenever the file parsed to a dict — INCLUDING
-                    # an empty {} config. The cache-update above is skipped for {} (it's
-                    # a no-op), but _cfg_mtime MUST still be set or get_config()'s
-                    # `current_mtime != _cfg_mtime` stale check fires on every call and
-                    # spins reload_config() under _cfg_lock forever (a `{}` config from a
-                    # freshly created/reset profile is reachable on the switch hot path).
-                    # This matches master's pre-#4662 behavior (it entered the block for
-                    # {} and set the mtime); the inner `if loaded:` only gates the no-op
-                    # cache update, not the mtime stamp.
-                    try:
-                        _cfg_mtime = Path(config_path).stat().st_mtime
-                    except OSError:
-                        _cfg_mtime = 0.0
-        except Exception:
-            logger.debug("Failed to load yaml config from %s", config_path)
-        _apply_config_defaults(_cfg_cache)
-        _cfg_fingerprint = _fingerprint_config(_cfg_cache)
-        # Bust the models cache so the next request sees fresh config values.
-        # Only delete the disk cache when config has actually changed -- not on
-        # first-ever load (when _old_cfg_mtime == 0.0, i.e. server start or
-        # profile switch) -- preserving the disk cache so the next restart
-        # still hits the fast path without a cold run.
-        if _old_cfg_mtime != 0.0:
-            _delete_models_cache_on_disk()
+        _refresh_config_cache(_get_config_path())
 
 
 # Memoized parse cache for _load_yaml_config_file, keyed on (resolved path,

--- a/tests/test_issue5220_config_reload_stampede.py
+++ b/tests/test_issue5220_config_reload_stampede.py
@@ -1,0 +1,81 @@
+"""Regression coverage for #5220 config reload stampede collapse."""
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+
+def test_stale_readers_collapse_to_single_reload_when_config_is_hot_reload(tmp_path, monkeypatch):
+    import api.config as config
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("marker: stale\n", encoding="utf-8")
+    monkeypatch.setattr(config, "_get_config_path", lambda: config_path)
+    with config._yaml_file_cache_lock:
+        config._yaml_file_cache.clear()
+
+    config.reload_config()
+    old_mtime = config._cfg_mtime
+    config_path.write_text("marker: refreshed\n", encoding="utf-8")
+    # Keep cache state stale for every thread entering the read path.
+    config._cfg_mtime = old_mtime - 1.0
+
+    calls = {"n": 0}
+    calls_lock = threading.Lock()
+    real_load = config._load_yaml_config_file_raw
+
+    def _counted_load(path):
+        with calls_lock:
+            calls["n"] += 1
+            call_no = calls["n"]
+        if call_no == 1:
+            time.sleep(0.1)
+        return real_load(path)
+
+    monkeypatch.setattr(config, "_load_yaml_config_file_raw", _counted_load)
+
+    def _get():
+        cfg = config.get_config()
+        return cfg.get("marker")
+
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        values = [value for value in executor.map(lambda _idx: _get(), range(6))]
+
+    assert all(value == "refreshed" for value in values), (
+        f"stale readers should observe refreshed config, got {values!r}"
+    )
+    assert calls["n"] == 1, (
+        f"expected one refresh for concurrent stale readers, got {calls['n']} "
+        "(base would re-enter refresh work per stale reader)"
+    )
+
+
+def test_explicit_reload_config_forces_disk_refresh(tmp_path, monkeypatch):
+    import api.config as config
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("marker: cold\n", encoding="utf-8")
+    monkeypatch.setattr(config, "_get_config_path", lambda: config_path)
+    with config._yaml_file_cache_lock:
+        config._yaml_file_cache.clear()
+
+    config.reload_config()
+    assert config.get_config().get("marker") == "cold"
+
+    calls = {"n": 0}
+    calls_lock = threading.Lock()
+    real_load = config._load_yaml_config_file_raw
+
+    def _counted_load(path):
+        with calls_lock:
+            calls["n"] += 1
+        return real_load(path)
+
+    monkeypatch.setattr(config, "_load_yaml_config_file_raw", _counted_load)
+    config_path.write_text("marker: hot\n", encoding="utf-8")
+
+    config.reload_config()
+    assert config.get_config().get("marker") == "hot"
+    assert calls["n"] == 1, (
+        "explicit reload_config() should refresh from disk even when caller requests it"
+    )

--- a/tests/test_issue5220_config_reload_stampede.py
+++ b/tests/test_issue5220_config_reload_stampede.py
@@ -1,7 +1,9 @@
 """Regression coverage for #5220 config reload stampede collapse."""
 
+import sys
 import threading
 import time
+import types
 from concurrent.futures import ThreadPoolExecutor
 
 
@@ -22,17 +24,23 @@ def test_stale_readers_collapse_to_single_reload_when_config_is_hot_reload(tmp_p
 
     calls = {"n": 0}
     calls_lock = threading.Lock()
-    real_load = config._load_yaml_config_file_raw
+    real_refresh = config._refresh_config_cache
 
-    def _counted_load(path):
+    def _counted_refresh(path=None):
         with calls_lock:
             calls["n"] += 1
             call_no = calls["n"]
         if call_no == 1:
             time.sleep(0.1)
-        return real_load(path)
+        return real_refresh(path)
 
-    monkeypatch.setattr(config, "_load_yaml_config_file_raw", _counted_load)
+    def _unexpected_reload():
+        raise AssertionError(
+            "stale model readers should route through reload_config_if_stale() instead of forced reload_config()"
+        )
+
+    monkeypatch.setattr(config, "_refresh_config_cache", _counted_refresh)
+    monkeypatch.setattr(config, "reload_config", _unexpected_reload)
 
     def _get():
         cfg = config.get_config()
@@ -78,4 +86,73 @@ def test_explicit_reload_config_forces_disk_refresh(tmp_path, monkeypatch):
     assert config.get_config().get("marker") == "hot"
     assert calls["n"] == 1, (
         "explicit reload_config() should refresh from disk even when caller requests it"
+    )
+
+
+def test_stale_model_readers_collapse_to_single_reload_when_models_are_requested(tmp_path, monkeypatch):
+    import api.config as config
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "model:\n  provider: openai\n  default: cold-model\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "_get_config_path", lambda: config_path)
+    with config._yaml_file_cache_lock:
+        config._yaml_file_cache.clear()
+    config.invalidate_models_cache()
+
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models._PROVIDER_ALIASES = {}
+    fake_models.list_available_providers = lambda: []
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda provider_id: {"logged_in": False, "key_source": ""}
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+    monkeypatch.setattr(config, "_load_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(config, "_load_stale_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(config, "_save_models_cache_to_disk", lambda _data: None)
+    monkeypatch.setattr(config, "_models_cache_source_fingerprint", lambda: {"config": "test"})
+
+    config.reload_config()
+    old_mtime = config._cfg_mtime
+    config_path.write_text(
+        "model:\n  provider: openai\n  default: refreshed-model\n",
+        encoding="utf-8",
+    )
+    config._cfg_mtime = old_mtime - 1.0
+    config.invalidate_models_cache()
+
+    calls = {"n": 0}
+    calls_lock = threading.Lock()
+    real_refresh = config._refresh_config_cache
+
+    def _counted_refresh(path=None):
+        with calls_lock:
+            calls["n"] += 1
+            call_no = calls["n"]
+        if call_no == 1:
+            time.sleep(0.1)
+        return real_refresh(path)
+
+    def _unexpected_reload():
+        raise AssertionError(
+            "stale model readers should route through reload_config_if_stale() instead of forced reload_config()"
+        )
+
+    monkeypatch.setattr(config, "_refresh_config_cache", _counted_refresh)
+    monkeypatch.setattr(config, "reload_config", _unexpected_reload)
+
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        results = list(executor.map(lambda _idx: config.get_available_models(), range(6)))
+
+    assert all(result.get("default_model") == "refreshed-model" for result in results), (
+        f"stale model readers should observe refreshed config, got {results!r}"
+    )
+    assert calls["n"] == 1, (
+        f"expected one config refresh for concurrent model reads, got {calls['n']} "
+        "(base would re-enter refresh work per stale reader)"
     )


### PR DESCRIPTION
## Thinking Path

- Post-restart stalls were attributed to `load_settings`, but the live issue narrowed that to `api/config.py`: stale read paths could still enter `reload_config()` before `_cfg_lock` decided whether the cache was already fresh.
- The right fix is at the config owner, not in HTTP backpressure or startup policy, because the bug is redundant reload work after the first thread already refreshed the cache.
- This patch keeps explicit write-side reloads intact and collapses concurrent stale reads into a single refresh for both `get_config()` and `get_available_models()`.

## What Changed

- `api/config.py`: add a shared in-lock freshness re-check for stale config reads, route both `get_config()` and `get_available_models()` through it, and preserve the existing forced `reload_config()` path for write-side callers.
- `tests/test_issue5220_config_reload_stampede.py`: add concurrency regressions that prove one stale read does the reload work for both direct config reads and `/api/models` reads, while queued readers reuse the fresh cache.

## Why It Matters

Post-restart authenticated requests no longer pile into serialized full config reloads just because several tabs woke up at once. The first cold read still refreshes the cache, and later settings or model-catalog readers reuse that refresh instead of paying the same parse cost again.

## Verification

`pytest tests/test_issue5220_config_reload_stampede.py -v --timeout=60`

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5220.

Maintainer root-cause confirmation came from [nesquena-hermes on the issue thread](https://github.com/nesquena/hermes-webui/issues/5220#issuecomment-4835228163).

## Model Used

GPT 5.5 via Codex CLI

