### PR TITLE
fix(chat): preserve visible transcript on terminal stream failure (#5224)

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -5743,13 +5743,22 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         S.session=session;
         const _nextMsgs3018=(session.messages||[]).filter(m=>m&&m.role);
         const _currentMessages=Array.isArray(S.messages)?S.messages:[];
+        const _currentVisibleMessages=_filterRecoveryControlMessages(_currentMessages || []);
         const _stagedMessages=_carryForwardEphemeralTurnFields(_currentMessages, _nextMsgs3018);
-        const _preserveCurrentTranscript=preserveVisibleOnShorterTerminalSnapshot&&
-          _stagedMessages.length>0&&
-          _stagedMessages.length<_currentMessages.length;
-        const _nextMessageKeys=new Set(_stagedMessages.map(_messageIdentityKey).filter(Boolean));
-        const _tailMessages=_currentMessages.filter(m=>!_nextMessageKeys.has(_messageIdentityKey(m)));
-        const _resolvedMessages=_preserveCurrentTranscript?[..._stagedMessages,..._tailMessages]:_stagedMessages;
+        const _stagedMatchesCurrentPrefix=(
+          _stagedMessages.length>0 &&
+          _stagedMessages.length<_currentVisibleMessages.length &&
+          _currentVisibleMessages.some(_isTerminalStreamErrorMarkerMessage) &&
+          _stagedMessages.every((message, idx)=>{
+            const stagedKey=_messageIdentityKey(message);
+            const currentKey=_messageIdentityKey(_currentVisibleMessages[idx]);
+            return !!stagedKey && stagedKey===currentKey;
+          })
+        );
+        const _preserveCurrentTranscript=preserveVisibleOnShorterTerminalSnapshot&&_stagedMatchesCurrentPrefix;
+        const _resolvedMessages=_preserveCurrentTranscript
+          ? [..._stagedMessages,..._currentVisibleMessages.slice(_stagedMessages.length)]
+          : _stagedMessages;
         S.messages=_filterRecoveryControlMessages(_resolvedMessages || []);
         _attachProjectedAnchorSceneToLastAssistant(S.messages);
         if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);

--- a/static/messages.js
+++ b/static/messages.js
@@ -5745,10 +5745,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         const _currentMessages=Array.isArray(S.messages)?S.messages:[];
         const _currentVisibleMessages=_filterRecoveryControlMessages(_currentMessages || []);
         const _stagedMessages=_carryForwardEphemeralTurnFields(_currentMessages, _nextMsgs3018);
+        const _currentVisibleEndsWithTerminalMarker=(
+          _currentVisibleMessages.length>0 &&
+          _isTerminalStreamErrorMarkerMessage(_currentVisibleMessages[_currentVisibleMessages.length-1])
+        );
         const _stagedMatchesCurrentPrefix=(
           _stagedMessages.length>0 &&
           _stagedMessages.length<_currentVisibleMessages.length &&
-          _currentVisibleMessages.some(_isTerminalStreamErrorMarkerMessage) &&
+          _currentVisibleEndsWithTerminalMarker &&
           _stagedMessages.every((message, idx)=>{
             const stagedKey=_messageIdentityKey(message);
             const currentKey=_messageIdentityKey(_currentVisibleMessages[idx]);

--- a/static/messages.js
+++ b/static/messages.js
@@ -2062,7 +2062,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     return message&&message.role==='assistant'&&typeof message.content==='string'&&
       message.content.startsWith('**Connection interrupted:** The browser lost the live SSE connection before the response finished.');
   }
-  function _appendTerminalStreamErrorMarkerIfMissing(messages){
+  function _ensureSingleTerminalStreamErrorMarker(messages){
     if(!Array.isArray(messages)) return;
     while(messages.length && _isTerminalStreamErrorMarkerMessage(messages[messages.length-1])){
       messages.pop();
@@ -5831,7 +5831,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         session_id:activeSid,
       },null);
       clearLiveToolCards();if(!assistantText)removeThinking();
-      _appendTerminalStreamErrorMarkerIfMissing(S.messages);
+      _ensureSingleTerminalStreamErrorMarker(S.messages);
       _attachProjectedAnchorSceneToLastAssistant(S.messages);
       renderMessages({preserveScroll:true});
       _markSessionViewed(activeSid, S.messages.length);

--- a/static/messages.js
+++ b/static/messages.js
@@ -2058,6 +2058,20 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     msg.provider_details='The only assistant text returned for this turn was the internal preserved-task-list compression marker, so the WebUI replaced it with an explicit error instead of rendering the marker as a model response.';
     return true;
   }
+  function _isTerminalStreamErrorMarkerMessage(message){
+    return message&&message.role==='assistant'&&typeof message.content==='string'&&
+      message.content.startsWith('**Connection interrupted:** The browser lost the live SSE connection before the response finished.');
+  }
+  function _appendTerminalStreamErrorMarkerIfMissing(messages){
+    if(!Array.isArray(messages)) return;
+    while(messages.length && _isTerminalStreamErrorMarkerMessage(messages[messages.length-1])){
+      messages.pop();
+    }
+    messages.push({
+      role:'assistant',
+      content:'**Connection interrupted:** The browser lost the live SSE connection before the response finished. If the worker completed, reopening this session should restore the settled transcript.',
+    });
+  }
   function _setActivePaneIdleIfOwner(){
     if(_isActiveSession()||!S.session||!INFLIGHT[S.session.session_id]){
       setBusy(false);
@@ -2348,7 +2362,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }catch(_){
         if(_deferStreamErrorIfOffline()||_pageHiddenForStreamError()) return;
       }
-      if(await _restoreSettledSession(source)) return;
+      if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;
       if(_deferStreamErrorIfOffline()||_pageHiddenForStreamError()) return;
       _flushReasoningToAnchor();
       _scheduleAnchorRegistryCleanup(120000);
@@ -5450,7 +5464,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }
         if(isRecoveryControlMessage){
           (async()=>{
-            if(await _restoreSettledSession(source)) return;
+            if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;
             if(S.session&&S.session.session_id===activeSid){
               S.messages=_filterRecoveryControlMessages(S.messages||[]);
               _markSessionViewed(activeSid, S.messages.length);
@@ -5546,7 +5560,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           }catch(_){
             if(_deferStreamErrorIfOffline()) return;
           }
-          if(await _restoreSettledSession(source)) return;
+          if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;
           if(_deferStreamErrorIfOffline()) return;
           if(_deferStreamErrorIfPageHidden(source)) return;
           const nextDelay=_retryDelays[attempt+1];
@@ -5562,7 +5576,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         setTimeout(()=>{void _probeReconnect(0);},_retryDelays[0]);
         return;
       }
-      if(await _restoreSettledSession(source)) return;
+      if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;
       if(_deferStreamErrorIfOffline()) return;
       if(_deferStreamErrorIfPageHidden(source)) return;
       _flushReasoningToAnchor();
@@ -5692,6 +5706,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
   async function _restoreSettledSession(source, options=null){
     const returnStatus=!!(options&&options.status);
+    const preserveVisibleOnShorterTerminalSnapshot=!!(options&&options.preserveVisibleOnShorterTerminalSnapshot);
     if(_isActiveSession() && S.activeStreamId!==streamId){
       _closeSource(source);
       return returnStatus?'stale':false;
@@ -5727,9 +5742,16 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         clearLiveToolCards();if(!assistantText)removeThinking();
         S.session=session;
         const _nextMsgs3018=(session.messages||[]).filter(m=>m&&m.role);
-        _attachProjectedAnchorSceneToLastAssistant(_nextMsgs3018);
-        S.messages=_carryForwardEphemeralTurnFields(S.messages||[], _nextMsgs3018);
-        S.messages=_filterRecoveryControlMessages(S.messages || []);
+        const _currentMessages=Array.isArray(S.messages)?S.messages:[];
+        const _stagedMessages=_carryForwardEphemeralTurnFields(_currentMessages, _nextMsgs3018);
+        const _preserveCurrentTranscript=preserveVisibleOnShorterTerminalSnapshot&&
+          _stagedMessages.length>0&&
+          _stagedMessages.length<_currentMessages.length;
+        const _nextMessageKeys=new Set(_stagedMessages.map(_messageIdentityKey).filter(Boolean));
+        const _tailMessages=_currentMessages.filter(m=>!_nextMessageKeys.has(_messageIdentityKey(m)));
+        const _resolvedMessages=_preserveCurrentTranscript?[..._stagedMessages,..._tailMessages]:_stagedMessages;
+        S.messages=_filterRecoveryControlMessages(_resolvedMessages || []);
+        _attachProjectedAnchorSceneToLastAssistant(S.messages);
         if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
         if(S.session&&S.session.session_id){
           try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
@@ -5796,7 +5818,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         session_id:activeSid,
       },null);
       clearLiveToolCards();if(!assistantText)removeThinking();
-      S.messages.push({role:'assistant',content:'**Connection interrupted:** The browser lost the live SSE connection before the response finished. If the worker completed, reopening this session should restore the settled transcript.'});
+      _appendTerminalStreamErrorMarkerIfMissing(S.messages);
       _attachProjectedAnchorSceneToLastAssistant(S.messages);
       renderMessages({preserveScroll:true});
       _markSessionViewed(activeSid, S.messages.length);

--- a/tests/test_1694_terminal_cleanup_ownership.py
+++ b/tests/test_1694_terminal_cleanup_ownership.py
@@ -123,7 +123,7 @@ def test_settled_restore_and_error_close_only_the_event_source_owner():
     assert "function _handleStreamError(source)" in MESSAGES_JS
     assert "_closeSource(source);" in restore_body
     assert "_closeSource(source);" in error_body
-    assert "_restoreSettledSession(source)" in event_body
+    assert "_restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})" in event_body
     assert "_handleStreamError(source)" in event_body
     assert "_restoreSettledSession())" not in event_body
     assert "_handleStreamError();" not in event_body

--- a/tests/test_issue5224_terminal_error_transcript_preserve.py
+++ b/tests/test_issue5224_terminal_error_transcript_preserve.py
@@ -63,7 +63,7 @@ function installRuntimeHelpers() {
     "_messageIdentityKey",
     "_carryForwardEphemeralTurnFields",
     "_isTerminalStreamErrorMarkerMessage",
-    "_appendTerminalStreamErrorMarkerIfMissing",
+    "_ensureSingleTerminalStreamErrorMarker",
     "_restoreSettledSession",
     "_handleStreamError",
   ];
@@ -183,8 +183,8 @@ function buildRuntime() {
 
   if (scenario.action === 'terminal_marker_idempotent') {
     const messages = JSON.parse(JSON.stringify(scenario.messages || []));
-    _appendTerminalStreamErrorMarkerIfMissing(messages);
-    _appendTerminalStreamErrorMarkerIfMissing(messages);
+    _ensureSingleTerminalStreamErrorMarker(messages);
+    _ensureSingleTerminalStreamErrorMarker(messages);
     const terminalMarkerCount = messages.filter(_isTerminalStreamErrorMarkerMessage).length;
     console.log(JSON.stringify({
       action: scenario.action,

--- a/tests/test_issue5224_terminal_error_transcript_preserve.py
+++ b/tests/test_issue5224_terminal_error_transcript_preserve.py
@@ -310,6 +310,48 @@ def test_terminal_error_restore_replaces_when_snapshots_are_fuller(driver_path):
     assert observed == expected, f"fuller settled snapshot should replace visible messages: {observed}"
 
 
+def test_terminal_error_restore_replaces_shorter_authoritative_snapshot_when_prefix_does_not_match(driver_path):
+    """A shorter settled snapshot that changes the assistant turn must replace stale live fragments."""
+    outcome = _run_scenario(driver_path, {
+        "action": "restore_shorter_terminal",
+        "state": {
+            "session": {"session_id": "session-5224", "message_count": 5},
+            "messages": [
+                {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                {"role": "assistant", "content": "Visible assistant fragment one", "_ts": "a1"},
+                {"role": "assistant", "content": "Visible assistant fragment two", "_ts": "a2"},
+                {"role": "assistant", "content": "**Connection interrupted:** The browser lost the live SSE connection before the response finished.", "_ts": "err"},
+            ],
+            "activeStreamId": "stream-5224",
+        },
+        "apiPayload": {
+            "session": {
+                "session_id": "session-5224",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                    {"role": "assistant", "content": "Settled final answer", "_ts": "final"},
+                ],
+            },
+        },
+        "activeSid": "session-5224",
+        "streamId": "stream-5224",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+        "isSessionActivelyViewed": False,
+    })
+
+    observed = [(item["role"], item["content"]) for item in outcome["messages"]]
+    assert observed == [
+        ("user", "Question about data?"),
+        ("assistant", "Settled final answer"),
+    ], f"authoritative settled snapshot should replace stale live tail: {observed}"
+    assert outcome["terminalMarkerCount"] == 0, (
+        f"terminal marker should not survive authoritative settled replacement, got {outcome['terminalMarkerCount']}"
+    )
+
+
 def test_terminal_error_marker_is_single_instance_and_not_duplicated(driver_path):
     """Appending terminal error marker repeatedly should keep one marker and remove duplicates."""
     outcome = _run_scenario(driver_path, {

--- a/tests/test_issue5224_terminal_error_transcript_preserve.py
+++ b/tests/test_issue5224_terminal_error_transcript_preserve.py
@@ -1,0 +1,328 @@
+"""Regression tests for #5224: preserve terminal-visible transcript on recovery."""
+
+import json
+import subprocess
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+MESSAGES_JS = REPO_ROOT / "static" / "messages.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node is required to execute message runtime tests")
+
+
+_DRIVER = r"""
+const fs = require('fs');
+
+const src = fs.readFileSync(process.argv[2], 'utf8');
+const scenario = JSON.parse(process.argv[3] || '{}');
+
+function extractFunction(source, name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  let start = -1;
+  for (const marker of markers) {
+    start = source.indexOf(marker);
+    if (start >= 0) break;
+  }
+  if (start < 0) {
+    throw new Error(`missing ${name}`);
+  }
+  let i = source.indexOf('{', start);
+  if (i < 0) {
+    throw new Error(`missing function body for ${name}`);
+  }
+  let depth = 1;
+  i++;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    if (ch === '}') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+    i++;
+  }
+  throw new Error(`unterminated function body for ${name}`);
+}
+
+function extractFunctionByName(name) {
+  return extractFunction(src, name);
+}
+
+function installRuntimeHelpers() {
+  const helpers = [
+    "_isMarkerOnlyAssistantMessage",
+    "_streamRecoveryControlMessageText",
+    "_streamRecoveryControlMessage",
+    "_filterRecoveryControlMessages",
+    "_replaceMarkerOnlyAssistantWithStreamError",
+    "_messageIdentityKey",
+    "_carryForwardEphemeralTurnFields",
+    "_isTerminalStreamErrorMarkerMessage",
+    "_appendTerminalStreamErrorMarkerIfMissing",
+    "_restoreSettledSession",
+    "_handleStreamError",
+  ];
+  for (const helper of helpers) {
+    const body = extractFunctionByName(helper);
+    const factory = new Function(`${body}; return ${helper};`);
+    globalThis[helper] = factory();
+  }
+}
+
+function buildRuntime() {
+  const activeSid = scenario.activeSid || 'session-5224';
+  const streamId = scenario.streamId || 'stream-5224';
+  const calls = [];
+  globalThis.activeSid = activeSid;
+  globalThis.streamId = streamId;
+  globalThis.assistantText = false;
+  globalThis.S = JSON.parse(JSON.stringify(scenario.state || {}));
+  if (!globalThis.S.session) {
+    globalThis.S.session = { session_id: activeSid };
+  }
+  if (!Object.prototype.hasOwnProperty.call(globalThis.S, 'activeStreamId')) {
+    globalThis.S.activeStreamId = streamId;
+  }
+  globalThis.INFLIGHT = {};
+  globalThis._EPHEMERAL_TURN_FIELDS = [
+    '_turnUsage',
+    '_turnDuration',
+    '_turnTps',
+    '_gatewayRouting',
+    '_statusCard',
+    '_anchor_stream_id',
+    '_anchor_activity_scene',
+  ];
+  globalThis._isActiveSession = () => scenario.isActiveSession !== false;
+  globalThis._isSessionCurrentPane = () => scenario.isSessionCurrentPane !== false;
+  globalThis._isSessionActivelyViewed = () => !!scenario.isSessionActivelyViewed;
+  globalThis._closeSource = () => calls.push('closeSource');
+  globalThis._clearStreamEndRecovery = () => calls.push('clearStreamEndRecovery');
+  globalThis._clearOwnerInflightState = () => calls.push('clearOwnerInflight');
+  globalThis.clearLiveToolCards = () => calls.push('clearLiveToolCards');
+  globalThis.removeThinking = () => calls.push('removeThinking');
+  globalThis._flushReasoningToAnchor = () => calls.push('flushReasoning');
+  globalThis._applyToAnchor = () => calls.push('applyToAnchor');
+  globalThis._attachProjectedAnchorSceneToLastAssistant = () => calls.push('attachProjected');
+  globalThis._hydrateTodosFromSession = () => calls.push('hydrateTodos');
+  globalThis._scheduleAnchorRegistryCleanup = () => calls.push('scheduleAnchorRegistryCleanup');
+  globalThis._smdEndParser = () => calls.push('smdEndParser');
+  globalThis._markSessionCompletionUnread = () => calls.push('markCompletionUnread');
+  globalThis._markSessionViewed = () => calls.push('markSessionViewed');
+  globalThis.localStorage = {
+    setItem: () => calls.push('setLocalStorageItem'),
+    getItem: () => null,
+    removeItem: () => calls.push('removeLocalStorageItem'),
+  };
+  globalThis._setActiveSessionUrl = () => calls.push('setActiveSessionUrl');
+  globalThis.showToast = () => calls.push('showToast');
+  globalThis._clearApprovalForOwner = () => calls.push('clearApprovalForOwner');
+  globalThis._clearClarifyForOwner = () => calls.push('clearClarifyForOwner');
+  globalThis._streamFadeCleanupReduceMotionListener = () => calls.push('streamFadeCleanup');
+  globalThis._cancelAnimationFramePendingStreamRender = () => calls.push('cancelRaf');
+  globalThis.finalizeThinkingCard = () => calls.push('finalizeThinkingCard');
+  globalThis.syncTopbar = () => calls.push('syncTopbar');
+  globalThis.renderMessages = () => calls.push('renderMessages');
+  globalThis.renderSessionList = () => calls.push('renderSessionList');
+  globalThis._setActivePaneIdleIfOwner = () => calls.push('setActivePaneIdle');
+  globalThis.setBusy = () => calls.push('setBusy');
+  globalThis.setComposerStatus = () => calls.push('setComposerStatus');
+  globalThis.setStatus = () => calls.push('setStatus');
+  globalThis._messageRenderableMessageCount = () => scenario.messageRenderableCount || 50;
+  globalThis._currentMessageRenderWindowSize = () => scenario.currentWindowSize || 12;
+  globalThis._messageRenderWindowSize = 20;
+  globalThis._streamFinalized = !!scenario.streamFinalized;
+  globalThis._persistTimer = null;
+  globalThis.api = async () => scenario.apiPayload || { session: null };
+  globalThis.msgContent = undefined;
+  globalThis._isPreservedCompressionTaskListMarkerOnlyText = () => false;
+  return calls;
+}
+
+(async () => {
+  installRuntimeHelpers();
+  const calls = buildRuntime();
+  if (scenario.action === 'restore_shorter_terminal') {
+    const status = await _restoreSettledSession({}, {
+      status: true,
+      preserveVisibleOnShorterTerminalSnapshot: true,
+    });
+    const messages = Array.isArray(S.messages) ? S.messages : [];
+    const terminalMarkerCount = messages.filter(_isTerminalStreamErrorMarkerMessage).length;
+    console.log(JSON.stringify({
+      action: scenario.action,
+      status,
+      messages: messages.map((m) => ({ role: m.role, content: m.content })),
+      terminalMarkerCount,
+      calls,
+    }));
+    return;
+  }
+
+  if (scenario.action === 'restore_fuller_terminal') {
+    const status = await _restoreSettledSession({}, {
+      status: true,
+      preserveVisibleOnShorterTerminalSnapshot: true,
+    });
+    const messages = Array.isArray(S.messages) ? S.messages : [];
+    const terminalMarkerCount = messages.filter(_isTerminalStreamErrorMarkerMessage).length;
+    console.log(JSON.stringify({
+      action: scenario.action,
+      status,
+      messages: messages.map((m) => ({ role: m.role, content: m.content })),
+      terminalMarkerCount,
+      calls,
+    }));
+    return;
+  }
+
+  if (scenario.action === 'terminal_marker_idempotent') {
+    const messages = JSON.parse(JSON.stringify(scenario.messages || []));
+    _appendTerminalStreamErrorMarkerIfMissing(messages);
+    _appendTerminalStreamErrorMarkerIfMissing(messages);
+    const terminalMarkerCount = messages.filter(_isTerminalStreamErrorMarkerMessage).length;
+    console.log(JSON.stringify({
+      action: scenario.action,
+      messages: messages.map((m) => ({ role: m.role, content: m.content })),
+      terminalMarkerCount,
+      calls,
+    }));
+    return;
+  }
+
+  throw new Error(`unknown action: ${scenario.action}`);
+})().catch((err) => {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(1);
+});
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    driver = tmp_path_factory.mktemp("issue5224_driver") / "driver.js"
+    driver.write_text(_DRIVER, encoding="utf-8")
+    return str(driver)
+
+
+def _run_scenario(driver_path: str, scenario: dict) -> dict:
+    command = [NODE, driver_path, str(MESSAGES_JS), json.dumps(scenario)]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed: {result.stderr}")
+    return json.loads(result.stdout.strip())
+
+
+def test_terminal_error_restore_preserves_visible_transcript_when_server_snapshot_shorter(driver_path):
+    """Terminal recovery must keep richer visible transcript when restored snapshot is shorter."""
+    outcome = _run_scenario(driver_path, {
+        "action": "restore_shorter_terminal",
+        "state": {
+            "session": {"session_id": "session-5224", "message_count": 5},
+            "messages": [
+                {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                {"role": "assistant", "content": "Visible assistant answer segment one", "_ts": "a1"},
+                {"role": "assistant", "content": "Visible assistant answer segment two", "_ts": "a2"},
+                {"role": "assistant", "content": "**Connection interrupted:** The browser lost the live SSE connection before the response finished.", "_ts": "err"},
+            ],
+            "activeStreamId": "stream-5224",
+        },
+        "apiPayload": {
+            "session": {
+                "session_id": "session-5224",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                    {"role": "assistant", "content": "Visible assistant answer segment one", "_ts": "a1"},
+                ],
+            },
+        },
+        "activeSid": "session-5224",
+        "streamId": "stream-5224",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+        "isSessionActivelyViewed": False,
+    })
+
+    assert outcome["status"] == "restored"
+    roles_and_contents = [(item["role"], item["content"]) for item in outcome["messages"]]
+    assert ("assistant", "**Connection interrupted:** The browser lost the live SSE connection before the response finished.") in roles_and_contents, (
+        f"terminal error marker missing: {roles_and_contents}"
+    )
+    assert outcome["terminalMarkerCount"] == 1, f"expected exactly one terminal marker, got {outcome['terminalMarkerCount']}"
+    assert any("Visible assistant answer segment two" in content for _, content in roles_and_contents), (
+        "visible transcript tail was dropped after stale shorter restore"
+    )
+
+
+def test_terminal_error_restore_replaces_when_snapshots_are_fuller(driver_path):
+    """A fuller settled snapshot must replace the visible transcript to keep the pane current."""
+    outcome = _run_scenario(driver_path, {
+        "action": "restore_fuller_terminal",
+        "state": {
+            "session": {"session_id": "session-5224", "message_count": 1},
+            "messages": [
+                {"role": "assistant", "content": "Old interrupted shell", "_ts": "old"},
+            ],
+            "activeStreamId": "stream-5224",
+        },
+        "apiPayload": {
+            "session": {
+                "session_id": "session-5224",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Question about data?", "_ts": "u1"},
+                    {"role": "assistant", "content": "Settled first segment", "_ts": "a1"},
+                    {"role": "assistant", "content": "Settled second segment", "_ts": "a2"},
+                    {"role": "assistant", "content": "Settled third segment", "_ts": "a3"},
+                ],
+            },
+        },
+        "activeSid": "session-5224",
+        "streamId": "stream-5224",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+        "isSessionActivelyViewed": False,
+    })
+
+    assert outcome["status"] == "restored"
+    expected = [
+        ("user", "Question about data?"),
+        ("assistant", "Settled first segment"),
+        ("assistant", "Settled second segment"),
+        ("assistant", "Settled third segment"),
+    ]
+    observed = [(item["role"], item["content"]) for item in outcome["messages"]]
+    assert observed == expected, f"fuller settled snapshot should replace visible messages: {observed}"
+
+
+def test_terminal_error_marker_is_single_instance_and_not_duplicated(driver_path):
+    """Appending terminal error marker repeatedly should keep one marker and remove duplicates."""
+    outcome = _run_scenario(driver_path, {
+        "action": "terminal_marker_idempotent",
+        "messages": [
+            {"role": "user", "content": "Question", "_ts": "u1"},
+            {"role": "assistant", "content": "Answer", "_ts": "a1"},
+        ],
+        "activeSid": "session-5224",
+        "streamId": "stream-5224",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+    })
+
+    assert outcome["terminalMarkerCount"] == 1, f"terminal marker should be deduped to one, got {outcome['terminalMarkerCount']}"
+    assert outcome["messages"][-1]["content"].startswith("**Connection interrupted:**")

--- a/tests/test_issue5224_terminal_error_transcript_preserve.py
+++ b/tests/test_issue5224_terminal_error_transcript_preserve.py
@@ -352,6 +352,56 @@ def test_terminal_error_restore_replaces_shorter_authoritative_snapshot_when_pre
     )
 
 
+def test_terminal_error_restore_does_not_preserve_from_historical_marker_on_older_turn(driver_path):
+    """An old terminal marker earlier in the session must not preserve a later unrelated live tail."""
+    outcome = _run_scenario(driver_path, {
+        "action": "restore_shorter_terminal",
+        "state": {
+            "session": {"session_id": "session-5224", "message_count": 7},
+            "messages": [
+                {"role": "user", "content": "Earlier question", "_ts": "u0"},
+                {"role": "assistant", "content": "Earlier answer", "_ts": "a0"},
+                {"role": "assistant", "content": "**Connection interrupted:** The browser lost the live SSE connection before the response finished.", "_ts": "err0"},
+                {"role": "user", "content": "Current question", "_ts": "u1"},
+                {"role": "assistant", "content": "Current fragment one", "_ts": "a1"},
+                {"role": "assistant", "content": "Current fragment two", "_ts": "a2"},
+            ],
+            "activeStreamId": "stream-5224",
+        },
+        "apiPayload": {
+            "session": {
+                "session_id": "session-5224",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Earlier question", "_ts": "u0"},
+                    {"role": "assistant", "content": "Earlier answer", "_ts": "a0"},
+                    {"role": "assistant", "content": "**Connection interrupted:** The browser lost the live SSE connection before the response finished.", "_ts": "err0"},
+                    {"role": "user", "content": "Current question", "_ts": "u1"},
+                    {"role": "assistant", "content": "Current fragment one", "_ts": "a1"},
+                ],
+            },
+        },
+        "activeSid": "session-5224",
+        "streamId": "stream-5224",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+        "isSessionActivelyViewed": False,
+    })
+
+    observed = [(item["role"], item["content"]) for item in outcome["messages"]]
+    assert observed == [
+        ("user", "Earlier question"),
+        ("assistant", "Earlier answer"),
+        ("assistant", "**Connection interrupted:** The browser lost the live SSE connection before the response finished."),
+        ("user", "Current question"),
+        ("assistant", "Current fragment one"),
+    ], f"historical marker should not preserve later unrelated tail: {observed}"
+    assert outcome["terminalMarkerCount"] == 1, (
+        f"historical marker count should stay unchanged, got {outcome['terminalMarkerCount']}"
+    )
+
+
 def test_terminal_error_marker_is_single_instance_and_not_duplicated(driver_path):
     """Appending terminal error marker repeatedly should keep one marker and remove duplicates."""
     outcome = _run_scenario(driver_path, {

--- a/tests/test_live_stream_ux.py
+++ b/tests/test_live_stream_ux.py
@@ -20,7 +20,7 @@ def test_done_and_restore_filters_recovery_messages_from_frontend_state():
 def test_apererror_recovers_on_recovery_control_event():
     assert "isRecoveryControlMessage=isInterrupted && (d.recovery_control===true || _streamRecoveryControlMessageText(d.message));" in MESSAGES_JS
     assert "Stream recovery signal received. Restoring transcript..." in MESSAGES_JS
-    assert "if(await _restoreSettledSession(source)) return;" in MESSAGES_JS
+    assert "if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;" in MESSAGES_JS
 
 
 def test_ui_rejects_recovery_control_as_visible_assistant_content():

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -657,7 +657,7 @@ def test_connection_error_terminal_message_attaches_projected_anchor_scene_befor
     error = _function_body(MESSAGES_JS, "_handleStreamError")
 
     assert "_applyToAnchor('error'" in error
-    push_idx = error.index("_appendTerminalStreamErrorMarkerIfMissing(S.messages);")
+    push_idx = error.index("_ensureSingleTerminalStreamErrorMarker(S.messages);")
     attach_idx = error.index("_attachProjectedAnchorSceneToLastAssistant(S.messages);")
     render_idx = error.index("renderMessages({preserveScroll:true});")
     assert push_idx < attach_idx < render_idx

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -611,10 +611,11 @@ def test_stream_end_restore_attaches_projected_anchor_scene_before_render():
     restore = _function_body(MESSAGES_JS, "_restoreSettledSession")
 
     assert "function _attachProjectedAnchorSceneToLastAssistant" in MESSAGES_JS
-    attach_idx = restore.index("_attachProjectedAnchorSceneToLastAssistant(_nextMsgs3018);")
-    carry_idx = restore.index("S.messages=_carryForwardEphemeralTurnFields")
+    carry_idx = restore.index("const _stagedMessages=_carryForwardEphemeralTurnFields(_currentMessages, _nextMsgs3018);")
+    filter_idx = restore.index("S.messages=_filterRecoveryControlMessages(_resolvedMessages || []);")
+    attach_idx = restore.index("_attachProjectedAnchorSceneToLastAssistant(S.messages);")
     render_idx = restore.index("syncTopbar();renderMessages({preserveScroll:true})")
-    assert attach_idx < carry_idx < render_idx
+    assert carry_idx < filter_idx < attach_idx < render_idx
 
 
 def test_cancel_settlement_attaches_projected_anchor_scene_before_render():
@@ -656,7 +657,7 @@ def test_connection_error_terminal_message_attaches_projected_anchor_scene_befor
     error = _function_body(MESSAGES_JS, "_handleStreamError")
 
     assert "_applyToAnchor('error'" in error
-    push_idx = error.index("S.messages.push({role:'assistant',content:'**Connection interrupted:**")
+    push_idx = error.index("_appendTerminalStreamErrorMarkerIfMissing(S.messages);")
     attach_idx = error.index("_attachProjectedAnchorSceneToLastAssistant(S.messages);")
     render_idx = error.index("renderMessages({preserveScroll:true});")
     assert push_idx < attach_idx < render_idx

--- a/tests/test_offline_banner.py
+++ b/tests/test_offline_banner.py
@@ -88,5 +88,5 @@ def test_deferred_hidden_stream_error_reattaches_or_restores_before_inline_error
     assert "api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`)" in recovery_block
     assert "if(st.active)" in recovery_block
     assert "_wireSSE(new EventSource" in recovery_block
-    assert "if(await _restoreSettledSession(source)) return;" in recovery_block
-    assert recovery_block.find("if(await _restoreSettledSession(source)) return;") < recovery_block.rfind("_handleStreamError(source)")
+    assert "if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;" in recovery_block
+    assert recovery_block.find("if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;") < recovery_block.rfind("_handleStreamError(source)")

--- a/tests/test_session_rotate_url_sync.py
+++ b/tests/test_session_rotate_url_sync.py
@@ -23,13 +23,12 @@ def test_stream_completion_syncs_rotated_session_id_to_tab_state():
     assert settled_pos != -1
 
     # Proximity window scoping "the completion/settled handler block near the
-    # session assignment". #4720 added a documented `_oldestIdx` reset statement
-    # into the completion block (between the marker and the localStorage sync),
-    # growing it past the original 800; widen to 1000 — still well within the
-    # single done/settled handler, so the guard's intent (the rotated session id
-    # is synced to tab state right after the session assignment) is preserved.
+    # session assignment". The settled restore block now includes the terminal
+    # stale-prefix guard before the tab-state sync, so keep the assertion local
+    # to the handler while widening the slice enough to cover the new helper
+    # state and the unchanged localStorage/update-url writes.
     completion_block = MESSAGES_JS[completion_pos : completion_pos + 1000]
-    settled_block = MESSAGES_JS[settled_pos : settled_pos + 1000]
+    settled_block = MESSAGES_JS[settled_pos : settled_pos + 1800]
 
     for block in (completion_block, settled_block):
         assert "localStorage.setItem('hermes-webui-session',S.session.session_id);" in block


### PR DESCRIPTION
## Thinking Path

- The issue is not "provider failures look ugly"; it is that a terminal failure can make the active pane forget transcript rows the browser already had.
- The live replacement seam is client-side: `_handleStreamError()` appends the inline marker, then `_restoreSettledSession()` can still replace the pane from fetched `session.messages`.
- The fix therefore belongs in transcript reconciliation, with a regression harness that proves shorter stale snapshots stop replacing richer visible history without preserving unrelated later tails from older terminal markers.

## What Changed

- `static/messages.js`: preserve the richer visible transcript only when terminal recovery fetches a stale shorter snapshot that is still a prefix of the visible pane and the visible pane currently ends in the terminal marker, so older historical markers cannot preserve unrelated later live text.
- `tests/test_issue5224_terminal_error_transcript_preserve.py`: add behavioral regressions for stale shorter restores, authoritative shorter replacements, and the historical-marker negative-space case.
- `tests/test_live_stream_ux.py`, `tests/test_offline_banner.py`, and `tests/test_live_to_final_anchor_visible_order.py`: refresh source-shape guards to the helper-based restore and terminal-marker call sites the final branch now uses.
- `tests/test_session_rotate_url_sync.py` and `tests/test_1694_terminal_cleanup_ownership.py`: refresh two additional static guard tests so CI tracks the option-bearing restore call shape and the widened settled-restore block after the terminal-tail guard landed.

## Why It Matters

When a terminal stream failure happens late in a long run, users keep the transcript they were already reading instead of seeing it collapse into an error-only view. At the same time, legitimate shorter authoritative settlements still replace stale live fragments, an old interruption marker from a previous turn can no longer pin unrelated later text in place, and the static guard coverage now follows the real restore/error call shapes the branch ships.

## Verification

- `pytest tests/test_session_rotate_url_sync.py tests/test_1694_terminal_cleanup_ownership.py tests/test_issue5224_terminal_error_transcript_preserve.py tests/test_live_stream_ux.py tests/test_offline_banner.py tests/test_live_to_final_anchor_visible_order.py -v --timeout=60`

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5224.

Issue narrowing and acceptance notes came from [claw-io on the issue thread](https://github.com/nesquena/hermes-webui/issues/5224#issuecomment-4835649061).

## Model Used

GPT 5.5 via Codex CLI
