### PR TITLE
fix(sidebar): stack subagent sessions under parent

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -5673,10 +5673,6 @@ function _attachChildSessionsToSidebarRows(collapsedRows, rawSessions, rawRefere
     const childLineageKey=child&&(child._lineage_root_id||child.lineage_root_id||child.parent_session_id);
     const isHiddenLineageReferenceChild=!!(child&&child.archived&&child.parent_session_id&&childLineageKey&&!child.pinned&&!childRenderable);
     if(!_isChildSession(child)&&!isForkChild&&!isHiddenLineageReferenceChild) continue;
-    if(!isForkChild&&child._cross_surface_child_session){
-      if(childRenderable) orphans.push({...child,_orphan_child_session:true});
-      continue;
-    }
     const parentSid=child.parent_session_id;
     let parentRow=visibleBySid.get(parentSid);
     let parentSegment=null;
@@ -5693,6 +5689,25 @@ function _attachChildSessionsToSidebarRows(collapsedRows, rawSessions, rawRefere
     }
     if(!parentRow&&hasHiddenArchivedAncestor(child)){
       hiddenArchivedChildTree.add(child.session_id);
+      continue;
+    }
+    // Cross-surface rows (for example a WebUI continuation from a Telegram
+    // conversation) should remain top-level when there is no WebUI-owned parent
+    // row to stack under.  But if the parent is visible in this same sidebar
+    // render, attach normally — delegated subagent rows are also cross-source
+    // relative to their WebUI parent and should not be forced into orphans.
+    const parentSourceMarker=String(parentRow&&(
+      parentRow.session_source||parentRow.raw_source||parentRow.source_tag||parentRow.source
+    )||'').toLowerCase();
+    const parentIsExternal=parentRow&&(
+      (typeof _isExternalSession==='function'&&_isExternalSession(parentRow))||
+      (typeof _isMessagingSession==='function'&&_isMessagingSession(parentRow))||
+      parentRow.is_cli_session===true||
+      parentRow.session_source==='messaging'||
+      (parentSourceMarker&&parentSourceMarker!=='webui'&&parentSourceMarker!=='subagent'&&parentSourceMarker!=='other'&&parentSourceMarker!=='fork')
+    );
+    if(parentRow&&child._cross_surface_child_session&&parentIsExternal){
+      if(childRenderable) orphans.push({...child,_orphan_child_session:true});
       continue;
     }
     if(parentRow){

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -376,6 +376,154 @@ console.log(JSON.stringify(attached));
     assert rows[0]["_child_sessions"][0]["session_id"] == "child"
 
 
+
+def test_cross_surface_subagent_child_stacks_under_visible_webui_parent():
+    """Delegate subagent rows are cross-source but still belong under their WebUI parent."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+function _isExternalSession(s) {{ return !!(s && (s.is_cli_session || s.session_source === 'messaging')); }}
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+const collapsed = [{{
+  session_id:'webui_parent',
+  title:'Parent WebUI conversation',
+  raw_source:'webui',
+  source_tag:'webui',
+  session_source:'webui',
+  message_count:3,
+}}];
+const raw = [
+  collapsed[0],
+  {{
+    session_id:'subagent_child',
+    title:'Subagent Session',
+    parent_session_id:'webui_parent',
+    relationship_type:'child_session',
+    raw_source:'subagent',
+    source_tag:'subagent',
+    session_source:'other',
+    source_label:'Subagent',
+    _parent_lineage_root_id:'webui_parent',
+    _cross_surface_child_session:true,
+  }},
+];
+const rows = _attachChildSessionsToSidebarRows(collapsed, raw);
+console.log(JSON.stringify(rows));
+"""
+    rows = json.loads(_run_node(source))
+    assert [row["session_id"] for row in rows] == ["webui_parent"]
+    assert rows[0]["_child_session_count"] == 1
+    assert rows[0]["_child_sessions"][0]["session_id"] == "subagent_child"
+    assert "_orphan_child_session" not in rows[0]["_child_sessions"][0]
+
+
+
+def test_cross_surface_subagent_child_stacks_under_visible_fork_parent():
+    """Forked WebUI conversations can still own subagent child rows."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+function _isExternalSession(s) {{ return !!(s && (s.is_cli_session || s.session_source === 'messaging')); }}
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+const collapsed = [{{
+  session_id:'fork_parent',
+  title:'Forked WebUI conversation',
+  session_source:'fork',
+  parent_session_id:'original_parent',
+  message_count:3,
+}}];
+const raw = [
+  collapsed[0],
+  {{
+    session_id:'subagent_child',
+    title:'Subagent Session',
+    parent_session_id:'fork_parent',
+    relationship_type:'child_session',
+    raw_source:'subagent',
+    source_tag:'subagent',
+    session_source:'other',
+    source_label:'Subagent',
+    _parent_lineage_root_id:'fork_parent',
+    _cross_surface_child_session:true,
+  }},
+];
+const rows = _attachChildSessionsToSidebarRows(collapsed, raw);
+console.log(JSON.stringify(rows));
+"""
+    rows = json.loads(_run_node(source))
+    assert [row["session_id"] for row in rows] == ["fork_parent"]
+    assert rows[0]["_child_session_count"] == 1
+    assert rows[0]["_child_sessions"][0]["session_id"] == "subagent_child"
+
+
+def test_parent_source_label_display_text_does_not_force_external_orphaning():
+    """Display-only source labels must not drive machine source classification."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+function _isExternalSession(s) {{ return !!(s && (s.is_cli_session || s.session_source === 'messaging')); }}
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+const collapsed = [{{session_id:'parent', title:'Parent', source_label:'WebUI Continuation'}}];
+const raw = [
+  collapsed[0],
+  {{session_id:'child', title:'Subagent', parent_session_id:'parent', relationship_type:'child_session', raw_source:'subagent', source_tag:'subagent', session_source:'other', _cross_surface_child_session:true}},
+];
+const rows = _attachChildSessionsToSidebarRows(collapsed, raw);
+console.log(JSON.stringify(rows));
+"""
+    rows = json.loads(_run_node(source))
+    assert [row["session_id"] for row in rows] == ["parent"]
+    assert rows[0]["_child_session_count"] == 1
+
+
 def test_cross_surface_webui_child_session_remains_top_level_when_parent_is_messaging():
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
     source = f"""
@@ -397,7 +545,7 @@ eval(extractFunc('_isChildSession'));
 eval(extractFunc('_isForkWithResolvableParent'));
 eval(extractFunc('_sidebarLineageKeyForRow'));
 eval(extractFunc('_attachChildSessionsToSidebarRows'));
-const collapsed = [{{session_id:'telegram_parent', title:'Telegram parent', source_label:'Telegram'}}];
+const collapsed = [{{session_id:'telegram_parent', title:'Telegram parent', session_source:'messaging', raw_source:'telegram', source_label:'Telegram'}}];
 const raw = [
   collapsed[0],
   {{
@@ -513,6 +661,50 @@ const rows = _renderSidebarRowsFromRawSessions([child], [child, ...refs]);
 console.log(JSON.stringify(rows.map(r => r.session_id)));
 """
     assert json.loads(_run_node(source)) == ["child"]
+
+
+
+def test_archived_hidden_parent_suppresses_cross_surface_child_orphan():
+    """A cross-surface child should not leak when its archived parent is hidden."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+var _showArchived = false;
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+const parent = {{session_id:'parent', title:'Archived parent', archived:true, updated_at:10, last_message_at:10}};
+const child = {{
+  session_id:'child',
+  title:'Subagent',
+  parent_session_id:'parent',
+  relationship_type:'child_session',
+  raw_source:'subagent',
+  source_tag:'subagent',
+  session_source:'other',
+  _cross_surface_child_session:true,
+  updated_at:20,
+  last_message_at:20,
+}};
+const rows = _attachChildSessionsToSidebarRows([child], [child], [parent, child]);
+console.log(JSON.stringify(rows));
+"""
+    assert json.loads(_run_node(source)) == []
 
 
 def test_archived_hidden_parent_suppresses_child_and_fork_orphans():


### PR DESCRIPTION
## Thinking Path

- The sidebar payload can contain a normal WebUI parent row plus delegated subagent rows marked `relationship_type: "child_session"`.
- Subagent rows can also carry `_cross_surface_child_session` because their source marker is `subagent` while the parent is `webui`.
- The render path was forcing those cross-source rows into orphan/top-level rows before trying visible-parent attachment.
- The fix preserves existing behavior for external/messaging parents while letting WebUI-parented subagents attach normally.

## What Changed

- Resolve the visible parent row before deciding whether a `_cross_surface_child_session` must remain top-level.
- Keep cross-surface child rows top-level only when the resolved parent is external/messaging/CLI.
- Allow subagent rows whose visible parent is a WebUI conversation to stack under that parent.
- Added runtime-style regressions covering:
  - WebUI parent + subagent child rows stack under the parent.
  - External/messaging parent cross-surface rows remain top-level/orphan.
  - Hidden archived parents still suppress cross-surface child orphans.

## Why It Matters

Delegated subagent sessions should not clutter the main sidebar as separate conversations when their parent WebUI conversation is visible. This restores the intended parent/child grouping without changing archived-session persistence or external-session import behavior.

## Verification

- `node --check static/sessions.js`
- `git diff --check origin/master...HEAD`
- `./scripts/test.sh tests/test_session_lineage_collapse.py tests/test_sidebar_session_partition.py tests/test_issue4766_sidebar_source_pushdown.py tests/test_session_lineage_metadata_api.py tests/test_session_lineage_report.py -q`
  - `89 passed`
- `./scripts/test.sh tests/test_static_js_runtime_lint.py tests/test_ruff_forward_lint.py -q`
  - `4 passed, 1 skipped`
- `.venv/bin/python scripts/ruff_lint.py --diff origin/master`
  - no new violations
- Deterministic Node transform smoke:
  - WebUI parent + 3 subagent cross-surface children renders as one parent row with `_child_session_count=3` and no top-level child rows.
  - Telegram/messaging parent + cross-surface WebUI child remains top-level/orphan.
- TruffleHog commit-range scan on a normal clone: no findings.
- Gitleaks changed-files and commit-range scans: no findings.
- CodeRabbit CLI review: `findings: 0`.
- Claude Code read-only review: `APPROVE`.

## Risks / Follow-ups

- This is render-path only. It does not cascade archive state or mutate saved child sessions.
- Cross-surface rows with messaging/CLI parents intentionally remain top-level so external-session behavior is preserved.

## Contract Routing

Task type: sidebar/session metadata render-state bug fix.

Touched areas:
- `static/sessions.js`
- `tests/test_session_lineage_collapse.py`

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/UIUX-GUIDE.md`

Scope boundaries:
- No service restart.
- No server-side archive cascade.
- No persistence-schema changes.

Evidence needed before claiming done:
- Runtime-style sidebar transform regression.
- Existing cross-surface external-parent behavior remains covered.
- Focused sidebar/source/lineage tests remain green.

## Model Used

AI-assisted with Hermes Agent using OpenAI GPT-5.5. Claude Code and CodeRabbit were used for read-only review. No code was generated from secrets or private credentials.
