### PR TITLE
Hide process wakeup prompts from transcripts

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -504,6 +504,8 @@ def _append_recovered_pending_turn(session, *, timestamp: int | None = None) -> 
     pending_text = str(session.pending_user_message or '')
     if not pending_text:
         return None
+    if str(getattr(session, 'pending_user_source', None) or '').strip() == 'process_wakeup':
+        return None
     recovered_ts = int(time.time())
     if isinstance(timestamp, (int, float)) and timestamp > 0:
         recovered_ts = int(timestamp)
@@ -590,6 +592,26 @@ def _message_role(message):
     if not isinstance(message, dict):
         return ''
     return str(message.get('role', '')).strip().lower()
+
+
+def _message_source(message):
+    if not isinstance(message, dict):
+        return ''
+    return str(message.get('_source') or '').strip()
+
+
+def is_hidden_process_wakeup_message(message) -> bool:
+    """Return True for legacy internal wakeup rows that must not render/count."""
+    return _message_role(message) == 'user' and _message_source(message) == 'process_wakeup'
+
+
+def filter_hidden_internal_messages(messages) -> list:
+    """Strip legacy hidden/internal rows from visible transcript consumers.
+
+    New process wakeups should not be persisted as user messages, but older
+    sidecars/state.db rows may already contain role=user + _source=process_wakeup.
+    """
+    return [m for m in list(messages or []) if not is_hidden_process_wakeup_message(m)]
 
 
 def _find_top_level_json_key(text, key):
@@ -5356,6 +5378,7 @@ def get_state_db_session_messages(
                 'codex_reasoning_items',
                 'reasoning_content',
                 'codex_message_items',
+                '_source',
             ]
             id_col = ['id'] if 'id' in available else []
             selected = id_col + ['role', 'content', 'timestamp'] + [c for c in optional if c in available]
@@ -5538,6 +5561,31 @@ def get_state_db_session_summary(sid, *, profile=None) -> dict:
             available = {str(row['name']) for row in cur.fetchall()}
             if 'session_id' not in available:
                 return {"message_count": 0, "last_message_at": 0.0}
+            if {'role', '_source'}.issubset(available):
+                select_cols = ['role', '_source']
+                if 'content' in available:
+                    select_cols.append('content')
+                if 'timestamp' in available:
+                    select_cols.append('timestamp')
+                query = f"SELECT {', '.join(select_cols)} FROM messages WHERE session_id = ?"
+                cur.execute(query, (str(sid),))
+                rows = cur.fetchall()
+                count = 0
+                last_message_at = 0.0
+                for row in rows:
+                    message = {key: row[key] for key in row.keys()}
+                    if is_hidden_process_wakeup_message(message):
+                        continue
+                    count += 1
+                    if 'timestamp' in available:
+                        try:
+                            last_message_at = max(last_message_at, float(row['timestamp'] or 0))
+                        except (TypeError, ValueError):
+                            pass
+                return {
+                    "message_count": max(0, int(count)),
+                    "last_message_at": last_message_at,
+                }
             if 'timestamp' in available:
                 cur.execute(
                     "SELECT COUNT(*) AS message_count, MAX(timestamp) AS last_message_at "

--- a/api/routes.py
+++ b/api/routes.py
@@ -6622,6 +6622,8 @@ def _message_counts_as_renderable_for_window(message) -> bool:
         return False
     if _is_empty_partial_activity_message(message):
         return False
+    if is_hidden_process_wakeup_message(message):
+        return False
     role = str(message.get("role") or "").strip().lower()
     return bool(role and role != "tool")
 
@@ -7003,7 +7005,7 @@ def _merged_webui_lineage_messages_for_display(session, messages=None) -> list:
 
 
 def _message_summary(messages) -> dict:
-    messages = list(messages or [])
+    messages = filter_hidden_internal_messages(messages)
     last_message_at = 0.0
     for msg in messages:
         if not isinstance(msg, dict):
@@ -7040,6 +7042,29 @@ def _metadata_only_message_summary(sid: str, profile: str | None = None) -> dict
             sidecar_last_message_at = float(getattr(sidecar_session, "updated_at", 0) or 0)
         except (TypeError, ValueError):
             sidecar_last_message_at = 0.0
+        try:
+            # Metadata-only loads skip messages for speed. If an older sidecar
+            # already persisted a hidden process_wakeup row, the stored
+            # message_count/updated_at can stay inflated and make sidebar polling
+            # refresh forever. Do the full read only for sidecars that mention the
+            # internal marker.
+            sidecar_path = getattr(sidecar_session, "path", None)
+            if sidecar_path and Path(sidecar_path).exists():
+                sidecar_text = Path(sidecar_path).read_text(encoding="utf-8", errors="ignore")
+                if "process_wakeup" in sidecar_text:
+                    full_sidecar = Session.load(sid)
+                    if full_sidecar:
+                        visible_sidecar_messages = filter_hidden_internal_messages(
+                            getattr(full_sidecar, "messages", None) or []
+                        )
+                        hidden_count = len(getattr(full_sidecar, "messages", None) or []) - len(visible_sidecar_messages)
+                        if hidden_count > 0:
+                            sidecar_count = len(visible_sidecar_messages)
+                            sidecar_last_message_at = _message_summary(
+                                visible_sidecar_messages
+                            )["last_message_at"] or float(getattr(full_sidecar, "updated_at", 0) or 0)
+        except Exception:
+            logger.debug("Failed to adjust metadata-only hidden wakeup count", exc_info=True)
         if getattr(sidecar_session, "truncation_watermark", None) is not None:
             # Intentional: once the user has truncated this sidecar, metadata
             # polling must keep the sidecar as authoritative.  A full message
@@ -7415,6 +7440,8 @@ def _keep_latest_messaging_session_per_source(
 
 from api.models import (
     Session,
+    filter_hidden_internal_messages,
+    is_hidden_process_wakeup_message,
     get_session,
     get_session_for_file_ops,
     new_session,
@@ -10446,6 +10473,7 @@ def handle_get(handler, parsed) -> bool:
                 _summary_message_count = None
                 _summary_last_message_at = None
             if load_messages:
+                _all_msgs = filter_hidden_internal_messages(_all_msgs)
                 _truncated_msgs, _messages_offset = _message_window_for_display(
                     _all_msgs,
                     msg_limit=msg_limit,
@@ -17145,6 +17173,8 @@ def _checkpoint_user_message_for_eager_session_save(s, msg: str, attachments, st
     only adds a durable display-message checkpoint before the agent launches.
     """
     if not msg:
+        return
+    if str(source or "").strip() == "process_wakeup":
         return
     existing = list(getattr(s, "messages", None) or [])
     if existing:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -50,6 +50,7 @@ from api.turn_journal import append_turn_journal_event_for_stream
 from api.usage import prompt_cache_hit_percent
 from api.models import (
     _is_empty_partial_activity_message,
+    is_hidden_process_wakeup_message,
     get_state_db_session_messages,
     reconciled_state_db_messages_for_session,
 )
@@ -2507,6 +2508,10 @@ def _strip_workspace_prefix(text: str, *, include_legacy: bool = False) -> str:
     return stripped.strip()
 
 
+def _is_process_wakeup_source(source) -> bool:
+    return str(source or '').strip() == 'process_wakeup'
+
+
 def _looks_like_current_user_turn(msg, msg_text) -> bool:
     """Match the current human turn even if an internal workspace tag leaked mid-text.
 
@@ -4798,7 +4803,9 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
     previous_display = [
         m for m in list(previous_display or [])
         if not _is_context_compression_marker(m)
+        and not is_hidden_process_wakeup_message(m)
     ]
+    process_wakeup_source = _is_process_wakeup_source(source)
     # Deduplicate stale _partial messages that accumulated in previous_display.
     # A bug in cancel_stream() could insert multiple identical _partial messages
     # when _stripped was empty but _has_reasoning/_has_tools was True. The
@@ -4883,7 +4890,7 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
                         for _k in range(_cursor, _j):
                             _ckey = context_keys[_k]
                             _cmsg = previous_context[_k]
-                            if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg):
+                            if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg) and not is_hidden_process_wakeup_message(_cmsg):
                                 _backfilled.append(copy.deepcopy(_cmsg))
                                 _context_inserted.add(_ckey)
                         # Sync multiset: decrement keys consumed by advancing
@@ -4904,7 +4911,7 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
                         for _k in range(_cursor, len(context_keys)):
                             _ckey = context_keys[_k]
                             _cmsg = previous_context[_k]
-                            if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg):
+                            if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg) and not is_hidden_process_wakeup_message(_cmsg):
                                 _backfilled.append(copy.deepcopy(_cmsg))
                                 _context_inserted.add(_ckey)
                         _cursor = len(context_keys)
@@ -4917,7 +4924,7 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
                 _ckey = context_keys[_cursor]
                 _cmsg = previous_context[_cursor]
                 _cursor += 1
-                if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg):
+                if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg) and not is_hidden_process_wakeup_message(_cmsg):
                     _backfilled.append(copy.deepcopy(_cmsg))
                     _context_inserted.add(_ckey)
             if len(_backfilled) > len(previous_display):
@@ -4972,6 +4979,18 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
     merged = previous_display[:]
     seen = {_message_identity(m) for m in merged}
     current_user_key = _message_identity({'role': 'user', 'content': msg_text})
+    if process_wakeup_source:
+        candidates = [
+            m for m in candidates
+            if not (
+                isinstance(m, dict)
+                and (
+                    is_hidden_process_wakeup_message(m)
+                    or _message_identity(m) == current_user_key
+                    or _looks_like_current_user_turn(m, msg_text)
+                )
+            )
+        ]
     current_user_in_candidates = any(
         _message_identity(m) == current_user_key or _looks_like_current_user_turn(m, msg_text)
         for m in candidates
@@ -4985,6 +5004,7 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
     )
     if (
         current_user_key is not None
+        and not process_wakeup_source
         and not current_user_in_candidates
         and not current_user_already_checkpointed
         and any(
@@ -5042,8 +5062,10 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
         if (
             ((key is not None and key == current_user_key) or is_current_user_turn)
             and isinstance(msg, dict)
-            and msg.get('role') == 'user'
+            and str(msg.get('role') or '').strip().lower() == 'user'
         ):
+            if process_wakeup_source:
+                continue
             display_msg = copy.deepcopy(msg)
             display_msg['content'] = msg_text
             if source and source != 'webui':
@@ -5137,6 +5159,35 @@ def _merged_transcript_lacks_final_assistant_answer(
         msg_text,
         source=source,
     )
+    if _is_process_wakeup_source(source):
+        previous_visible = [
+            msg for msg in previous_display
+            if not _is_context_compression_marker(msg)
+            and not is_hidden_process_wakeup_message(msg)
+        ]
+        tail_messages = merged_messages[len(previous_visible):]
+        if drop_replayed_assistant:
+            # Only drop replayed assistant rows when they carry a durable id-ish
+            # identity. Text-only equality is too broad: a new wakeup answer may
+            # legitimately have the same prose as an older assistant response.
+            prior_stable_assistant_ids = {
+                _message_identity(msg)
+                for msg in previous_visible
+                if isinstance(msg, dict)
+                and msg.get('role') == 'assistant'
+                and (msg.get('id') or msg.get('message_id') or msg.get('tool_call_id') or msg.get('tool_calls'))
+            }
+            tail_messages = [
+                msg for msg in tail_messages
+                if not (
+                    isinstance(msg, dict)
+                    and msg.get('role') == 'assistant'
+                    and (msg.get('id') or msg.get('message_id') or msg.get('tool_call_id') or msg.get('tool_calls'))
+                    and _message_identity(msg) in prior_stable_assistant_ids
+                )
+            ]
+        return _session_lacks_final_assistant_answer(tail_messages)
+
     current_user_idx = _find_current_user_turn(merged_messages, msg_text)
     if current_user_idx is None or current_user_idx < len(previous_display):
         # The active turn lives after the durable transcript boundary. If the
@@ -5521,6 +5572,8 @@ def _materialize_pending_user_turn_before_error(session) -> bool:
     """
     pending_text = str(getattr(session, 'pending_user_message', None) or '')
     if not pending_text:
+        return False
+    if _is_process_wakeup_source(getattr(session, 'pending_user_source', None)):
         return False
     normalized_pending = " ".join(pending_text.split())
     if normalized_pending:

--- a/tests/test_process_wakeup_synthetic.py
+++ b/tests/test_process_wakeup_synthetic.py
@@ -3,24 +3,21 @@
 import time
 from pathlib import Path
 
-from api.models import Session, _append_recovered_pending_turn, _apply_core_sync_or_error_marker
-from api.routes import _checkpoint_user_message_for_eager_session_save
-from api.streaming import _materialize_pending_user_turn_before_error, _merge_display_messages_after_agent_result
+from api.models import Session, _append_recovered_pending_turn, _apply_core_sync_or_error_marker, filter_hidden_internal_messages
+from api.routes import _checkpoint_user_message_for_eager_session_save, _message_counts_as_renderable_for_window, _message_summary, _message_window_for_display
+from api.streaming import _materialize_pending_user_turn_before_error, _merge_display_messages_after_agent_result, _merged_transcript_lacks_final_assistant_answer
 
 
-def test_append_recovered_pending_turn_stamps_process_wakeup_source():
-    """Verify _append_recovered_pending_turn stamps _source when pending_user_source is process_wakeup."""
+def test_append_recovered_pending_turn_skips_process_wakeup_source():
+    """process_wakeup prompts are internal wakeups, not visible recovered user turns."""
     s = Session(
         session_id="test-session-1",
         pending_user_message="[IMPORTANT: Process completed]",
         pending_user_source="process_wakeup",
     )
     recovered = _append_recovered_pending_turn(s)
-    assert recovered is not None
-    assert recovered["role"] == "user"
-    assert recovered["content"] == "[IMPORTANT: Process completed]"
-    assert recovered["_source"] == "process_wakeup"
-    assert recovered["_recovered"] is True
+    assert recovered is None
+    assert s.messages == []
 
 
 def test_append_recovered_pending_turn_skips_webui_source():
@@ -51,8 +48,8 @@ def test_append_recovered_pending_turn_defaults_to_no_source():
     assert "_source" not in recovered
 
 
-def test_checkpoint_user_message_stamps_process_wakeup_source():
-    """Verify eager-path checkpoint stamps _source on message dict when source is process_wakeup."""
+def test_checkpoint_user_message_skips_process_wakeup_source():
+    """Eager persistence must not save process wakeups as human user bubbles."""
     s = Session(session_id="test-session-4")
     s.messages = []
     _checkpoint_user_message_for_eager_session_save(
@@ -62,11 +59,7 @@ def test_checkpoint_user_message_stamps_process_wakeup_source():
         started_at=time.time(),
         source="process_wakeup",
     )
-    assert len(s.messages) == 1
-    user_msg = s.messages[0]
-    assert user_msg["role"] == "user"
-    assert user_msg["content"] == "[IMPORTANT: Wakeup prompt]"
-    assert user_msg["_source"] == "process_wakeup"
+    assert s.messages == []
 
 
 def test_checkpoint_user_message_skips_webui_source():
@@ -121,7 +114,7 @@ def test_session_pending_user_source_persisted():
     assert s2.pending_user_source == "process_wakeup"
 
 
-def test_merge_display_materializes_missing_process_wakeup_user_turn():
+def test_merge_display_hides_missing_process_wakeup_user_turn():
     merged = _merge_display_messages_after_agent_result(
         [],
         [],
@@ -130,13 +123,10 @@ def test_merge_display_materializes_missing_process_wakeup_user_turn():
         source="process_wakeup",
     )
 
-    assert merged[0]["role"] == "user"
-    assert merged[0]["content"] == "[IMPORTANT: Wakeup prompt]"
-    assert merged[0]["_source"] == "process_wakeup"
-    assert merged[1]["role"] == "assistant"
+    assert merged == [{"role": "assistant", "content": "done"}]
 
 
-def test_merge_display_stamps_process_wakeup_source_on_echoed_user_turn():
+def test_merge_display_drops_echoed_process_wakeup_user_turn():
     merged = _merge_display_messages_after_agent_result(
         [],
         [],
@@ -148,9 +138,7 @@ def test_merge_display_stamps_process_wakeup_source_on_echoed_user_turn():
         source="process_wakeup",
     )
 
-    assert merged[0]["role"] == "user"
-    assert merged[0]["_source"] == "process_wakeup"
-    assert merged[1]["role"] == "assistant"
+    assert merged == [{"role": "assistant", "content": "done"}]
 
 
 def test_merge_display_leaves_webui_user_turn_unmarked():
@@ -166,7 +154,7 @@ def test_merge_display_leaves_webui_user_turn_unmarked():
     assert "_source" not in merged[0]
 
 
-def test_materialize_pending_user_turn_before_error_stamps_process_wakeup_source():
+def test_materialize_pending_user_turn_before_error_skips_process_wakeup_source():
     s = Session(
         session_id="test-session-8",
         pending_user_message="[IMPORTANT: Wakeup prompt]",
@@ -174,8 +162,8 @@ def test_materialize_pending_user_turn_before_error_stamps_process_wakeup_source
     )
     s.messages = []
 
-    assert _materialize_pending_user_turn_before_error(s) is True
-    assert s.messages[0]["_source"] == "process_wakeup"
+    assert _materialize_pending_user_turn_before_error(s) is False
+    assert s.messages == []
 
 
 def test_apply_core_sync_or_error_marker_clears_pending_user_source(tmp_path):
@@ -190,3 +178,175 @@ def test_apply_core_sync_or_error_marker_clears_pending_user_source(tmp_path):
 
     assert _apply_core_sync_or_error_marker(s, Path(tmp_path / "missing-core.json")) is True
     assert s.pending_user_source is None
+
+
+def test_process_wakeup_user_rows_are_not_renderable_or_counted():
+    hidden = {
+        "role": "user",
+        "content": "[IMPORTANT: Background process done]",
+        "_source": "process_wakeup",
+        "timestamp": 123.0,
+    }
+    visible = {"role": "assistant", "content": "done", "timestamp": 124.0}
+
+    assert _message_counts_as_renderable_for_window(hidden) is False
+    assert _message_counts_as_renderable_for_window(visible) is True
+    assert _message_summary([hidden, visible]) == {
+        "message_count": 1,
+        "last_message_at": 124.0,
+    }
+
+
+def test_filter_hidden_internal_messages_removes_legacy_process_wakeup_rows():
+    hidden = {
+        "role": "User",
+        "content": "[IMPORTANT: Background process done]",
+        "_source": "process_wakeup",
+        "timestamp": 123.0,
+    }
+    visible = {"role": "user", "content": "real user", "timestamp": 124.0}
+
+    assert filter_hidden_internal_messages([hidden, visible]) == [visible]
+
+
+def test_message_window_excludes_process_wakeup_rows_from_visible_budget():
+    messages = [
+        {"role": "assistant", "content": "older"},
+        {
+            "role": "user",
+            "content": "[IMPORTANT: Background process done]",
+            "_source": "process_wakeup",
+        },
+        {"role": "assistant", "content": "newer"},
+    ]
+
+    window, offset = _message_window_for_display(messages, msg_limit=2)
+
+    assert window == [messages[0], messages[1], messages[2]]
+    assert offset == 0
+    assert sum(1 for msg in window if _message_counts_as_renderable_for_window(msg)) == 2
+
+
+def test_process_wakeup_assistant_answer_satisfies_settlement():
+    assert _merged_transcript_lacks_final_assistant_answer(
+        [],
+        [],
+        [{"role": "assistant", "content": "done"}],
+        "[IMPORTANT: Background process done]",
+        source="process_wakeup",
+    ) is False
+
+
+def test_process_wakeup_without_visible_assistant_still_lacks_final_answer():
+    assert _merged_transcript_lacks_final_assistant_answer(
+        [],
+        [],
+        [],
+        "[IMPORTANT: Background process done]",
+        source="process_wakeup",
+    ) is True
+
+
+def test_process_wakeup_settlement_with_existing_history_and_fresh_answer():
+    previous_display = [
+        {"role": "user", "content": "older user"},
+        {"role": "assistant", "content": "older answer"},
+    ]
+
+    assert _merged_transcript_lacks_final_assistant_answer(
+        previous_display,
+        [],
+        [{"role": "assistant", "content": "fresh wakeup answer"}],
+        "[IMPORTANT: Background process done]",
+        source="process_wakeup",
+    ) is False
+
+
+def test_process_wakeup_settlement_ignores_hidden_rows_and_markers_before_tail():
+    previous_display = [
+        {"role": "assistant", "content": "older answer"},
+        {"role": "user", "content": "hidden wakeup", "_source": "process_wakeup"},
+        {"role": "assistant", "content": "context compressed", "_context_compression_marker": True},
+    ]
+
+    assert _merged_transcript_lacks_final_assistant_answer(
+        previous_display,
+        [],
+        [{"role": "assistant", "content": "fresh wakeup answer"}],
+        "[IMPORTANT: Background process done]",
+        source="process_wakeup",
+    ) is False
+
+
+def test_process_wakeup_settlement_still_fails_without_new_answer_after_history():
+    previous_display = [
+        {"role": "user", "content": "older user"},
+        {"role": "assistant", "content": "older answer"},
+    ]
+
+    assert _merged_transcript_lacks_final_assistant_answer(
+        previous_display,
+        [],
+        [],
+        "[IMPORTANT: Background process done]",
+        source="process_wakeup",
+    ) is True
+
+
+def test_process_wakeup_drop_replayed_stable_assistant_still_requires_fresh_answer():
+    previous_display = [
+        {"role": "assistant", "content": "old", "id": "assistant-1"},
+    ]
+
+    assert _merged_transcript_lacks_final_assistant_answer(
+        previous_display,
+        [],
+        [{"role": "assistant", "content": "old", "id": "assistant-1"}],
+        "[IMPORTANT: Background process done]",
+        source="process_wakeup",
+        drop_replayed_assistant=True,
+    ) is True
+
+
+def test_process_wakeup_drop_replayed_keeps_fresh_answer_after_replay():
+    previous_display = [
+        {"role": "assistant", "content": "old answer", "id": "assistant-1"},
+    ]
+
+    assert _merged_transcript_lacks_final_assistant_answer(
+        previous_display,
+        [],
+        [
+            {"role": "assistant", "content": "old answer", "id": "assistant-1"},
+            {"role": "assistant", "content": "fresh wakeup answer", "id": "assistant-2"},
+        ],
+        "[IMPORTANT: Background process done]",
+        source="process_wakeup",
+        drop_replayed_assistant=True,
+    ) is False
+
+
+def test_merge_display_does_not_backfill_hidden_process_wakeup_context_tail():
+    previous_display = [
+        {"role": "user", "content": "real user"},
+        {"role": "assistant", "content": "real answer"},
+    ]
+    previous_context = [
+        *previous_display,
+        {
+            "role": "user",
+            "content": "[IMPORTANT: Background process completed]",
+            "_source": "process_wakeup",
+        },
+    ]
+
+    merged = _merge_display_messages_after_agent_result(
+        previous_display,
+        previous_context,
+        [*previous_context, {"role": "assistant", "content": "fresh answer"}],
+        "[IMPORTANT: Background process completed]",
+        source="process_wakeup",
+    )
+
+    assert all(not (m.get("role") == "user" and m.get("_source") == "process_wakeup") for m in merged)
+    assert merged[-1] == {"role": "assistant", "content": "fresh answer"}

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -46,7 +46,7 @@ def _make_state_db(path: Path, sid: str, rows):
         "CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, title TEXT, model TEXT, started_at REAL, message_count INTEGER)"
     )
     conn.execute(
-        "CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, role TEXT, content TEXT, timestamp REAL, tool_call_id TEXT, tool_calls TEXT, tool_name TEXT)"
+        "CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, role TEXT, content TEXT, timestamp REAL, tool_call_id TEXT, tool_calls TEXT, tool_name TEXT, _source TEXT)"
     )
     conn.execute(
         "INSERT INTO sessions (id, source, title, model, started_at, message_count) VALUES (?, ?, ?, ?, ?, ?)",
@@ -54,7 +54,7 @@ def _make_state_db(path: Path, sid: str, rows):
     )
     for row in rows:
         conn.execute(
-            "INSERT INTO messages (session_id, role, content, timestamp, tool_call_id, tool_calls, tool_name) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO messages (session_id, role, content, timestamp, tool_call_id, tool_calls, tool_name, _source) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 sid,
                 row["role"],
@@ -63,6 +63,7 @@ def _make_state_db(path: Path, sid: str, rows):
                 row.get("tool_call_id"),
                 row.get("tool_calls"),
                 row.get("tool_name"),
+                row.get("_source"),
             ),
         )
     conn.commit()
@@ -74,7 +75,7 @@ def _append_state_db_rows(path: Path, sid: str, rows):
     try:
         for row in rows:
             conn.execute(
-                "INSERT INTO messages (session_id, role, content, timestamp, tool_call_id, tool_calls, tool_name) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO messages (session_id, role, content, timestamp, tool_call_id, tool_calls, tool_name, _source) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     sid,
                     row["role"],
@@ -83,6 +84,7 @@ def _append_state_db_rows(path: Path, sid: str, rows):
                     row.get("tool_call_id"),
                     row.get("tool_calls"),
                     row.get("tool_name"),
+                    row.get("_source"),
                 ),
             )
         conn.execute(
@@ -1590,3 +1592,60 @@ def test_state_db_reconciliation_preserves_tool_metadata(monkeypatch, tmp_path):
     assert messages[-1]["content"] == "used a tool"
     assert messages[-1]["tool_name"] == "terminal"
     assert messages[-1]["tool_calls"] == [{"id": "call_1", "function": {"name": "terminal"}}]
+
+
+def test_metadata_only_summary_ignores_legacy_process_wakeup_rows(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_reconcile_metadata_hidden_wakeup"
+    visible_messages = [
+        {"role": "user", "content": "real user", "timestamp": 1000.0},
+        {"role": "assistant", "content": "real answer", "timestamp": 1001.0},
+    ]
+    _install_test_session(monkeypatch, tmp_path, sid, visible_messages)
+    _make_state_db(
+        tmp_path / "state.db",
+        sid,
+        [
+            *visible_messages,
+            {
+                "role": "user",
+                "content": "[IMPORTANT: Background process done]",
+                "timestamp": 1002.0,
+                "_source": "process_wakeup",
+            },
+        ],
+    )
+
+    handler = _GetHandler(f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    session = handler.response_json["session"]
+    assert session["message_count"] == 2
+    assert session["last_message_at"] == 1001.0
+
+
+def test_metadata_only_summary_ignores_legacy_process_wakeup_sidecar_row(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_reconcile_metadata_hidden_wakeup_sidecar"
+    sidecar_messages = [
+        {"role": "user", "content": "real user", "timestamp": 1000.0},
+        {
+            "role": "user",
+            "content": "[IMPORTANT: Background process done]",
+            "timestamp": 1002.0,
+            "_source": "process_wakeup",
+        },
+        {"role": "assistant", "content": "real answer", "timestamp": 1001.0},
+    ]
+    _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+
+    handler = _GetHandler(f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    session = handler.response_json["session"]
+    assert session["message_count"] == 2
+    assert session["last_message_at"] == 1001.0


### PR DESCRIPTION
## Summary

- keep background process wakeup prompts internal instead of materializing them as visible user transcript rows
- filter legacy `process_wakeup` user rows from display windows, message summaries, and renderable-message counts
- add focused regressions for recovery, eager checkpointing, display merge, pagination, and legacy hidden-row filtering

## Tests

- `git diff --check origin/master...HEAD`
- `python3 -m py_compile api/models.py api/routes.py api/streaming.py`
- `./scripts/test.sh tests/test_process_wakeup_synthetic.py -q`
- `trufflehog filesystem --no-update --fail --only-verified api/models.py api/routes.py api/streaming.py tests/test_process_wakeup_synthetic.py`
- `gitleaks detect --no-git --redact --verbose --source /tmp/webui-process-wakeup-committed.diff --report-path /tmp/webui-process-wakeup-gitleaks-committed.json --report-format json`
