### PR TITLE
fix(model): repair bare custom-provider suffix on resolver slow path (#5225)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -5578,6 +5578,24 @@ def _resolve_compatible_session_model_state(
             _target = _profile_default or default_model
             return _target, profile_provider, True
 
+        # Async server-side continuations (for example delegate_task completion
+        # re-entry) can arrive here with profile context but without a usable
+        # requested_provider, bypassing the fast-path custom-provider repair
+        # above. If the profile's configured custom-provider default is a
+        # slash-qualified model whose suffix matches the bare session model,
+        # repair back to the profile default before the provider call (#5225).
+        if (
+            "/" not in model
+            and _profile_default
+            and "/" in _profile_default
+            and _profile_default.rsplit("/", 1)[-1] == model
+            and (
+                _profile_provider_normalized == "custom"
+                or str(profile_provider).startswith("custom:")
+            )
+        ):
+            return _profile_default, profile_provider, True
+
         return model, profile_provider, False
 
     if not model:

--- a/tests/test_issue5127_process_wakeup_bare_model.py
+++ b/tests/test_issue5127_process_wakeup_bare_model.py
@@ -82,6 +82,47 @@ class TestIssue5127CustomProviderBareSuffixRepair:
         assert mock_catalog.call_count == 0
         assert result == ("x-ai/grok-composer-2.5-fast", "custom:my-proxy", False)
 
+    def test_slow_path_repairs_bare_suffix_to_profile_default_for_custom_provider(self):
+        """Regression #5225: async continuations may arrive without usable model_provider."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "openrouter",
+                "default_model": "openai/gpt-5.5",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "grok-composer-2.5-fast",
+                None,
+                profile_provider="custom:my-proxy",
+                profile_default_model="x-ai/grok-composer-2.5-fast",
+                prefer_cached_catalog=True,
+            )
+
+        assert mock_catalog.call_count == 1
+        assert result == ("x-ai/grok-composer-2.5-fast", "custom:my-proxy", True)
+
+    def test_slow_path_does_not_rewrite_unrelated_bare_model_for_custom_provider(self):
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "openrouter",
+                "default_model": "openai/gpt-5.5",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state(
+                "other-model",
+                None,
+                profile_provider="custom:my-proxy",
+                profile_default_model="x-ai/grok-composer-2.5-fast",
+                prefer_cached_catalog=True,
+            )
+
+        assert mock_catalog.call_count == 1
+        assert result == ("other-model", "custom:my-proxy", False)
+
     def test_openai_codex_stale_openai_slash_still_uses_slow_path(self):
         """Regression: openai/... under openai-codex must not take bare fast return."""
         from api.routes import _resolve_compatible_session_model_state


### PR DESCRIPTION
Fixes #5225.

## Thinking Path

- Read maintainer review on #5225: continuations reach `_resolve_compatible_session_model_state`, but when `requested_provider` is omitted (common after async `delegate_task` / `process_wakeup`), the resolver takes the **slow path**, which only repairs bare `gpt`/`claude`/`gemini` families—not a bare custom-provider suffix like `grok-composer-2.5-fast`.
- Agreed with the recommended fix: mirror the #5128 fast-path suffix→qualified repair in the profile-provider slow branch, gated on custom provider + exact suffix match to `profile_default_model`.
- Implemented in `api/routes.py` and extended `tests/test_issue5127_process_wakeup_bare_model.py` with slow-path cases (including mismatch guard).

## What Changed

- **`api/routes.py`:** Before the slow-path family repair, when profile context is present and the session model is a bare suffix matching the profile’s slash-qualified custom default, return `_profile_default` with `normalized=True` (#5225).
- **`tests/test_issue5127_process_wakeup_bare_model.py`:** `test_slow_path_repairs_bare_suffix_to_profile_default_for_custom_provider` (`requested_provider=None`); `test_slow_path_does_not_rewrite_unrelated_bare_model_for_custom_provider`.

No `CHANGELOG.md` edits.

## Why It Matters

Server-initiated continuations (especially delegation completion re-entry) could call the custom provider with only the bare model ID, producing `Invalid model format or no credentials for provider: grok-composer-2.5-fast` even when the session/profile default was `x-ai/grok-composer-2.5-fast`.

## Verification

```bash
./scripts/test.sh tests/test_issue5127_process_wakeup_bare_model.py -q
```

10 passed locally. `/opt/data/workspace/developer/scripts/hermes-webui-pr-gate <worktree> --with-tests "tests/test_issue5127_process_wakeup_bare_model.py -q"`: pass (committed-diff ruff, co-author trailer).

**Manual:** Resolver unit tests only; no browser UI change.

## Risks / Follow-ups

- Repair only fires when bare suffix exactly matches profile default suffix and provider is `custom` / `custom:*`; cross-custom-provider mismatch behavior unchanged (#5127 guard).
- End-to-end WebUI delegation injection test could be a follow-up if maintainers want stronger coverage than resolver-level regression.

## Release note (for maintainers)

**Fixed:** Bare custom-provider model suffixes are repaired to the profile’s vendor-qualified default on the resolver slow path when `model_provider` is omitted during server-side continuations (#5225).

## Model Used

- Provider: custom (x-ai via proxy)
- Model: x-ai/grok-composer-2.5-fast
- AI disclosure: Hermes developer agent assisted implementation and tests; human (Ben) directed push/PR.

Co-authored-by: b3nw <b3nw@users.noreply.github.com>