### PR TITLE
fix(#5250): let settings search results escape the menu clip

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -356,38 +356,40 @@
             placeholder="Search settings…" oninput="filterSettings(this.value)" autocomplete="off">
           <div id="settingsSearchResults" class="settings-search-results" style="display:none"></div>
         </div>
-        <button type="button" class="side-menu-item active" data-settings-section="conversation" onclick="switchSettingsSection('conversation',{fromSidebarItem:true})">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-          <span data-i18n="settings_tab_conversation">Conversation</span>
-        </button>
-        <button type="button" class="side-menu-item" data-settings-section="appearance" onclick="switchSettingsSection('appearance',{fromSidebarItem:true})">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
-          <span data-i18n="settings_tab_appearance">Appearance</span>
-        </button>
-        <button type="button" class="side-menu-item" data-settings-section="preferences" onclick="switchSettingsSection('preferences',{fromSidebarItem:true})">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
-          <span data-i18n="settings_tab_preferences">Preferences</span>
-        </button>
-        <button type="button" class="side-menu-item" data-settings-section="providers" onclick="switchSettingsSection('providers',{fromSidebarItem:true})">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
-          <span data-i18n="providers_tab_title">Providers</span>
-        </button>
-        <button type="button" class="side-menu-item" data-settings-section="plugins" onclick="switchSettingsSection('plugins',{fromSidebarItem:true})">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2l3 7h7l-5.5 4.3 2.1 7L12 16.2 5.4 20.3l2.1-7L2 9h7z"/></svg>
-          <span data-i18n="settings_tab_plugins">Plugins</span>
-        </button>
-        <button type="button" class="side-menu-item" data-settings-section="extensions" onclick="switchSettingsSection('extensions',{fromSidebarItem:true})">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 2v6"/><path d="M15 2v6"/><path d="M7 8h10v4a5 5 0 0 1-10 0V8z"/><path d="M12 17v5"/></svg>
-          <span data-i18n="settings_tab_extensions">Extensions</span>
-        </button>
-        <button type="button" class="side-menu-item" data-settings-section="system" onclick="switchSettingsSection('system',{fromSidebarItem:true})">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="3" width="20" height="8" rx="2"/><rect x="2" y="13" width="20" height="8" rx="2"/><line x1="6" y1="7" x2="6.01" y2="7"/><line x1="6" y1="17" x2="6.01" y2="17"/></svg>
-          <span data-i18n="settings_tab_system">System</span>
-        </button>
-        <button type="button" class="side-menu-item" data-settings-section="help" onclick="switchSettingsSection('help',{fromSidebarItem:true})">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-          <span data-i18n="settings_tab_help">Help</span>
-        </button>
+        <div class="settings-menu-items">
+          <button type="button" class="side-menu-item active" data-settings-section="conversation" onclick="switchSettingsSection('conversation',{fromSidebarItem:true})">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+            <span data-i18n="settings_tab_conversation">Conversation</span>
+          </button>
+          <button type="button" class="side-menu-item" data-settings-section="appearance" onclick="switchSettingsSection('appearance',{fromSidebarItem:true})">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+            <span data-i18n="settings_tab_appearance">Appearance</span>
+          </button>
+          <button type="button" class="side-menu-item" data-settings-section="preferences" onclick="switchSettingsSection('preferences',{fromSidebarItem:true})">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
+            <span data-i18n="settings_tab_preferences">Preferences</span>
+          </button>
+          <button type="button" class="side-menu-item" data-settings-section="providers" onclick="switchSettingsSection('providers',{fromSidebarItem:true})">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+            <span data-i18n="providers_tab_title">Providers</span>
+          </button>
+          <button type="button" class="side-menu-item" data-settings-section="plugins" onclick="switchSettingsSection('plugins',{fromSidebarItem:true})">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2l3 7h7l-5.5 4.3 2.1 7L12 16.2 5.4 20.3l2.1-7L2 9h7z"/></svg>
+            <span data-i18n="settings_tab_plugins">Plugins</span>
+          </button>
+          <button type="button" class="side-menu-item" data-settings-section="extensions" onclick="switchSettingsSection('extensions',{fromSidebarItem:true})">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 2v6"/><path d="M15 2v6"/><path d="M7 8h10v4a5 5 0 0 1-10 0V8z"/><path d="M12 17v5"/></svg>
+            <span data-i18n="settings_tab_extensions">Extensions</span>
+          </button>
+          <button type="button" class="side-menu-item" data-settings-section="system" onclick="switchSettingsSection('system',{fromSidebarItem:true})">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="3" width="20" height="8" rx="2"/><rect x="2" y="13" width="20" height="8" rx="2"/><line x1="6" y1="7" x2="6.01" y2="7"/><line x1="6" y1="17" x2="6.01" y2="17"/></svg>
+            <span data-i18n="settings_tab_system">System</span>
+          </button>
+          <button type="button" class="side-menu-item" data-settings-section="help" onclick="switchSettingsSection('help',{fromSidebarItem:true})">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            <span data-i18n="settings_tab_help">Help</span>
+          </button>
+        </div>
       </div>
     </div>
   <div class="resize-handle" id="sidebarResize"></div>

--- a/static/style.css
+++ b/static/style.css
@@ -6705,6 +6705,15 @@ html[data-conversation-outline="enabled"] #outlineToggleBtn:not([hidden]){displa
 }
 
 /* Settings search */
+#settingsMenu { overflow: visible; min-height: 0; }
+#settingsMenu .settings-menu-items {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+}
 #settingsMenu .settings-search { position: relative; }
 .settings-search-results { position: absolute; top: 100%; left: 0; right: 0; z-index: 200; background: var(--dropdown-bg, var(--bg)); border: 1px solid var(--border2); border-radius: 8px; box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18); overflow: hidden; margin-top: 2px; }
 .settings-search-result { display: flex; align-items: center; gap: 4px; width: 100%; padding: 7px 12px; background: none; border: none; text-align: left; cursor: pointer; font-size: 12px; color: var(--text); transition: background 0.1s; }

--- a/tests/test_3850_settings_search.py
+++ b/tests/test_3850_settings_search.py
@@ -142,14 +142,22 @@ class TestSettingsSearch:
             "index.html must keep the section buttons inside .settings-menu-items"
         )
 
-        menu_match = re.search(r"#settingsMenu\s*\{[^}]*\}", STYLE_CSS)
+        menu_match = re.search(
+            r"(^|\n)\s*#settingsMenu\s*\{[^}]*\}",
+            STYLE_CSS,
+            re.MULTILINE,
+        )
         assert menu_match is not None, "style.css must have a #settingsMenu rule"
         menu_rules = menu_match.group(0)
         assert "overflow: visible" in menu_rules, (
             "settings menu must not own vertical clipping overflow"
         )
 
-        items_match = re.search(r"\.settings-menu-items\s*\{[^}]*\}", STYLE_CSS)
+        items_match = re.search(
+            r"(^|\n)\s*#settingsMenu\s+\.settings-menu-items\s*\{[^}]*\}",
+            STYLE_CSS,
+            re.MULTILINE,
+        )
         assert items_match is not None, "style.css must have a .settings-menu-items rule"
         items_rules = items_match.group(0)
         assert "overflow-y: auto" in items_rules, (

--- a/tests/test_3850_settings_search.py
+++ b/tests/test_3850_settings_search.py
@@ -6,6 +6,7 @@ users to find settings across all tabs without having to click through each sect
 Issue: #3850 (Add search input at top of Settings panel)
 """
 from pathlib import Path
+import re
 
 INDEX_HTML = (Path(__file__).parent.parent / "static" / "index.html").read_text(encoding="utf-8")
 PANELS_JS = (Path(__file__).parent.parent / "static" / "panels.js").read_text(encoding="utf-8")
@@ -133,6 +134,26 @@ class TestSettingsSearch:
         )
         assert "position:absolute" in STYLE_CSS and ".settings-search-results" in STYLE_CSS, (
             "style.css must make .settings-search-results absolutely positioned"
+        )
+
+    def test_settings_menu_layout_ownership_contract(self):
+        """Settings search should be anchored in the menu while scrolling is owned by the button list."""
+        assert 'class="settings-menu-items"' in INDEX_HTML, (
+            "index.html must keep the section buttons inside .settings-menu-items"
+        )
+
+        menu_match = re.search(r"#settingsMenu\s*\{[^}]*\}", STYLE_CSS)
+        assert menu_match is not None, "style.css must have a #settingsMenu rule"
+        menu_rules = menu_match.group(0)
+        assert "overflow: visible" in menu_rules, (
+            "settings menu must not own vertical clipping overflow"
+        )
+
+        items_match = re.search(r"\.settings-menu-items\s*\{[^}]*\}", STYLE_CSS)
+        assert items_match is not None, "style.css must have a .settings-menu-items rule"
+        items_rules = items_match.group(0)
+        assert "overflow-y: auto" in items_rules, (
+            "settings menu items wrapper must own vertical scrolling"
         )
 
     def test_panels_js_handles_providers_pane(self):

--- a/tests/test_issue5250_settings_search_dropdown_escape.py
+++ b/tests/test_issue5250_settings_search_dropdown_escape.py
@@ -1,0 +1,114 @@
+"""Regression test for the settings search dropdown escaping settings menu clipping."""
+
+from pathlib import Path
+
+import pytest
+
+
+STYLE_CSS = (Path(__file__).parent.parent / "static" / "style.css").read_text(
+    encoding="utf-8"
+)
+
+
+def _issue_html() -> str:
+    item_lines = "".join(
+        (
+            f'<button type="button" class="settings-search-result" '
+            f'onclick="window.__clicked = true">\n'
+            f"  <span class='settings-search-label'>Result {i}</span>\n"
+            f'  <span class="settings-search-section">Section</span>\n'
+            f"</button>\n"
+        )
+        for i in range(1, 10)
+    )
+    menu_lines = "".join(
+        (
+            f'<button type="button" class="side-menu-item" '
+            f"data-settings-section='section{i}' "
+            f"onclick=\"switchSettingsSection('section{i}',{{fromSidebarItem:true}})\">\n"
+            f"  <span>Section {i}</span>\n"
+            f"</button>\n"
+        )
+        for i in range(1, 18)
+    )
+    return f"""
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    {STYLE_CSS}
+    #settingsMenu {{
+      width: 320px;
+      height: 150px;
+      margin: 12px;
+    }}
+    body {{ margin: 0; padding: 0; }}
+  </style>
+</head>
+<body>
+  <div id="settingsMenu" class="side-menu">
+    <div class="settings-search sidebar-search">
+      <input id="settingsSearch" value="result"/>
+      <div id="settingsSearchResults" class="settings-search-results" style="display:block">
+        {item_lines}
+      </div>
+    </div>
+    <div class="settings-menu-items">
+      {menu_lines}
+    </div>
+  </div>
+</body>
+</html>
+"""
+
+
+def test_issue5250_settings_search_dropdown_escape():
+    """A point below the visible menu boundary should land on a search result."""
+    try:
+        from playwright.sync_api import sync_playwright
+    except Exception:  # pragma: no cover - dependency missing path
+        pytest.skip(
+            "playwright is unavailable; run manual local browser hit-test for issue #5250"
+        )
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(
+            headless=True,
+            args=["--no-sandbox", "--disable-dev-shm-usage"],
+        )
+        page = browser.new_page(viewport={"width": 480, "height": 320})
+        page.set_content(_issue_html())
+        hit = page.evaluate(
+            """
+            () => {
+              const menu = document.querySelector('#settingsMenu');
+              const results = document.querySelector('#settingsSearchResults');
+              const menuRect = menu.getBoundingClientRect();
+              const pointX = Math.floor(menuRect.left + 22);
+              const pointY = Math.floor(menuRect.bottom + 12);
+              const target = document.elementFromPoint(pointX, pointY);
+              const targetResult = target && target.closest('.settings-search-result');
+              const searchRect = results ? results.getBoundingClientRect() : { top: 0, bottom: 0 };
+              return {
+                menuBottom: Math.floor(menuRect.bottom),
+                pointY: pointY,
+                resultBottom: Math.floor(searchRect.bottom),
+                isResultHit: !!targetResult,
+                targetTag: target ? target.tagName : null,
+                targetClass: target ? target.className : '',
+              };
+            }
+            """
+        )
+        browser.close()
+
+    assert hit["isResultHit"], (
+        "the dropdown result should be hit-testable below #settingsMenu's visible boundary"
+    )
+    assert hit["pointY"] > hit["menuBottom"], (
+        "the hit-test point should be below the visible settings menu boundary"
+    )
+    assert hit["resultBottom"] > hit["menuBottom"], (
+        "rendered results must extend below #settingsMenu so the regression is meaningful"
+    )


### PR DESCRIPTION
## Thinking Path

- Settings search already renders and navigates correctly, but the dropdown lives inside the same scroll container as the Settings section list.
- The clipping comes from layout ownership, not from ranking or search logic: `.side-menu` makes `#settingsMenu` scroll, and the absolute dropdown is clipped by that boundary.
- The fix keeps the current search renderer and dropdown ids intact, then moves vertical scrolling to a wrapper around the Settings section buttons so the dropdown can escape the menu clip.

## What Changed

- `static/index.html`: wraps the Settings section buttons in a `.settings-menu-items` container below the existing search shell.
- `static/style.css`: keeps the shared `.side-menu` rule unchanged, makes `#settingsMenu` overflow visibly, and gives only `.settings-menu-items` vertical scrolling.
- `tests/test_3850_settings_search.py`: updates the searchable-settings layout contract without changing the search semantics it already covers.
- `tests/test_issue5250_settings_search_dropdown_escape.py`: adds a focused browser-level regression proof for the clipped dropdown case.

## Why It Matters

Users can now see and click Settings search results even when the dropdown extends past the visible menu boundary. The existing match list, result cap, and click-to-setting flow stay intact.

## Verification

`pytest tests/test_3850_settings_search.py tests/test_issue5250_settings_search_dropdown_escape.py -v --timeout=60`

If present after restacking with the ranking work from [#5211](https://github.com/nesquena/hermes-webui/pull/5211):

`pytest tests/test_5149_settings_search_ranking.py -v --timeout=60`

Manual browser proof fallback if Playwright is unavailable locally: open Settings, type a query with multiple matches, confirm a result remains visible and hit-testable below the menu boundary, then click it and confirm the target section switches and highlights the field.

Full-suite CI context, not a required local check unless explicitly run: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5250.

## Model Used

GPT 5.5 via Codex CLI

