### PR TITLE
fix(chat): keep just-settled worklog open for unpinned readers too (mobile scroll jump-back)

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -5193,13 +5193,20 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           // turn boundary so the following syncTopbar() refetches the authoritative
           // effort exactly once (not per-token — the storm short-circuit is intact).
           if(typeof _lastReasoningFetchKey!=='undefined') _lastReasoningFetchKey=null;
-          // Arm the one-shot keep-open token for JUST this settled turn so a
-          // pinned follower's worklog stays height-stable (no STREAM_DONE shrink
-          // jump); disarm right after the render so historical worklogs collapse
-          // compact as normal. Scoped to the just-settled stream id.
+          // Arm one-shot keep-open so the JUST-settled worklog stays open on the
+          // settle render (height-stable swap, no shrink jump). Disarm, then run a
+          // scroll-PRESERVING collapse pass for BOTH pin states so the worklog
+          // returns to its copied live/user disclosure state (a pinned follower's
+          // scrollToBottom() only settles scroll, it does NOT re-render, so without
+          // this pass the forced-open DOM would persist for them). This unarmed
+          // render also populates the cache with the correctly-collapsed DOM, and
+          // the same-frame JS restore absorbs the collapse so there is no jump.
+          // (#5260 gate-cert: keep-open must be transient + uncached for everyone.)
           if(typeof _armKeepSettledWorklogOpen==='function') _armKeepSettledWorklogOpen(_settledStreamId);
           syncTopbar();renderMessages({preserveScroll:true});
           if(typeof _disarmKeepSettledWorklogOpen==='function') _disarmKeepSettledWorklogOpen();
+          if(typeof _renderMessagesWithScrollSnapshot==='function') _renderMessagesWithScrollSnapshot();
+          else renderMessages({preserveScroll:true});
           if(shouldFollowOnDone&&typeof scrollToBottom==='function') scrollToBottom();
           if(typeof noteWorkspaceMutationsFromToolCalls==='function') noteWorkspaceMutationsFromToolCalls(S.toolCalls);
           loadDir('.', { preservePreview: true });

--- a/static/ui.js
+++ b/static/ui.js
@@ -10442,6 +10442,15 @@ function _armKeepSettledWorklogOpen(streamId){
 function _disarmKeepSettledWorklogOpen(){
   _keepSettledWorklogOpenForStreamId=null;
 }
+// True while a just-settled worklog is being force-rendered open (between
+// _armKeepSettledWorklogOpen and _disarmKeepSettledWorklogOpen). renderMessages()
+// consults this so it does NOT write the forced-open DOM into _sessionHtmlCache:
+// the keep-open is a transient settle-frame device, and caching it would persist
+// the forced-open worklog across session switches / restores, silently overriding
+// a user-collapsed worklog. (#5260 gate-cert: keep-open must not leak into cache.)
+function _isKeepSettledWorklogOpenArmed(){
+  return _keepSettledWorklogOpenForStreamId!==null;
+}
 if(typeof window!=='undefined'){
   window._armKeepSettledWorklogOpen=_armKeepSettledWorklogOpen;
   window._disarmKeepSettledWorklogOpen=_disarmKeepSettledWorklogOpen;
@@ -10473,15 +10482,15 @@ function _renderSettledAnchorSceneForMessage(message, segment, rawIdx){
   if(streamId&&!_readActivityDisclosureState(activityKey)){
     _copyActivityDisclosureState(`live:${streamId}`, activityKey);
   }
-  // keepSettledWorklogOpen forces collapsed:false for the ONE settle render of the
-  // just-settled turn so the live->settled swap is height-stable (no STREAM_DONE
-  // shrink jump) for both pinned followers AND unpinned mid-turn readers. If an
-  // unpinned reader had manually collapsed the live worklog, this overrides them
-  // for that single frame — but the disclosure state is preserved above
-  // (_copyActivityDisclosureState) and keep-open disarms right after the render
-  // (messages.js, _disarmKeepSettledWorklogOpen), so the NEXT re-render honors
-  // their collapsed state again. Net observable effect: a one-frame flash-open
-  // before it re-collapses — the accepted trade for removing the jump.
+  // keepSettledWorklogOpen forces collapsed:false for the ONE height-stable settle
+  // render of the just-settled turn (no STREAM_DONE shrink jump) for both pinned
+  // followers AND unpinned mid-turn readers. The keep-open is made genuinely
+  // transient by the STREAM_DONE handler (messages.js): right after this render it
+  // disarms the token and runs a scroll-PRESERVING collapse pass, so a worklog the
+  // reader had manually collapsed returns to its copied disclosure state
+  // (_copyActivityDisclosureState above) without the jump. While the token is
+  // armed this forced-open DOM is also kept OUT of _sessionHtmlCache
+  // (_isKeepSettledWorklogOpenArmed), so it never persists across restores.
   const group=_anchorSceneWorklogGroup(blocks,{
     live:false,
     collapsed:!keepSettledWorklogOpen,
@@ -13353,7 +13362,15 @@ function renderMessages(options){
   if(typeof _applyMediaPlaybackPreferences==='function') _applyMediaPlaybackPreferences(inner);
   // Populate session cache so switching back here skips a full rebuild.
   _sessionHtmlCacheSid=sid;
-  if(sid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi){
+  // Skip caching while the just-settled keep-open token is armed: that render
+  // force-opens the settled worklog for height-stability, and caching it would
+  // persist the forced-open DOM across session switches / restores, overriding a
+  // user-collapsed worklog. The follow-up collapse pass (after disarm) produces
+  // the correct cacheable DOM on its own render. (#5260 gate-cert.) The typeof
+  // guard keeps standalone renderMessages() test harnesses (which don't define
+  // the helper) working — absent helper == not armed == cache normally.
+  const _keepOpenArmed=(typeof _isKeepSettledWorklogOpenArmed==='function')&&_isKeepSettledWorklogOpenArmed();
+  if(sid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi&&!_keepOpenArmed){
     const _html=inner.innerHTML;
     // Only cache sessions with <300KB rendered HTML; evict oldest beyond 8 sessions.
     if(_html.length<300_000){

--- a/static/ui.js
+++ b/static/ui.js
@@ -10405,24 +10405,33 @@ function _renderSettledAnchorSceneTransparentForMessage(message, segment, rawIdx
 // renderMessages({preserveScroll:true}) call and cleared after the settled-scene
 // render pass; null at all other times.
 let _keepSettledWorklogOpenForStreamId=null;
-function _shouldKeepSettledWorklogOpenForPinnedFollow(streamId){
-  // Round 6 scroll-jump guard: while the reader is pinned at the live tail,
-  // collapsing the JUST-settled live worklog into a compact summary can shrink
-  // the transcript by hundreds of px at STREAM_DONE. The browser clamps scrollTop
-  // to the new max, which looks like a large backward jump even though pinned
-  // state is correct. Keep that one worklog open for pinned followers so the
-  // live->settled DOM swap is height-stable; unpinned readers still get compact
-  // settled worklogs and preserve their viewport normally. This intentionally
-  // wins over a transient user-collapsed live worklog while the reader remains
-  // pinned: avoiding the visible STREAM_DONE jump takes precedence for followers.
+function _shouldKeepSettledWorklogOpenForStreamSettle(streamId){
+  // Round 6 scroll-jump guard: collapsing the JUST-settled live worklog into a
+  // compact summary at STREAM_DONE shrinks the transcript by hundreds of px. The
+  // resulting backward jump hits readers in TWO positions, so keep that one
+  // worklog open for BOTH on the settle render — the live->settled DOM swap is
+  // then height-stable and there is no shrink for any scroll path to mishandle:
+  //
+  //  1. PINNED follower at the live tail: the shrink lowers scrollHeight, the
+  //     browser clamps scrollTop to the new max, and the viewport snaps upward
+  //     even though pin state is correct.
+  //  2. UNPINNED reader who scrolled UP to read inside the just-settled turn
+  //     (the mobile "往回大跳" report, #MOBILESCROLL follow-up): the worklog sits
+  //     ABOVE their viewport, so collapsing it pulls their content up to the top
+  //     of the turn. On desktop overflow-anchor:none + the JS snapshot restore
+  //     keep them put, but on mobile the CSS resting value is overflow-anchor:
+  //     auto AND _fixMobileScrollJank() flips an inline overflow-anchor:none over
+  //     the settle render — which is exactly the wrong state: native anchoring is
+  //     suppressed during the one frame the unpinned reader needs it to absorb
+  //     the above-viewport shrink, so the content leaps to the turn's top. Keeping
+  //     the worklog open removes the shrink entirely, which fixes it for every
+  //     device/anchor-mode combination instead of fighting the anchor engine.
+  //
   // SCOPING: the exception is gated on the one-shot token matching this turn's
   // stream id, so it applies ONLY to the turn that just settled — not to every
-  // historical settled worklog on every pinned re-render (which would defeat the
-  // compact-worklog default for past turns). Pin flags use the sticky pin state
-  // because during live DOM rebuilds the raw bottom distance can transiently
-  // exceed a threshold even for a pinned follower.
-  if(!streamId||_keepSettledWorklogOpenForStreamId!==streamId) return false;
-  return !!(_scrollPinned && !_messageUserUnpinned);
+  // historical settled worklog on every re-render (which would defeat the
+  // compact-worklog default for past turns).
+  return !!(streamId&&_keepSettledWorklogOpenForStreamId===streamId);
 }
 // One-shot token set/clear API used by the STREAM_DONE handler (messages.js):
 // arm the keep-open exception for exactly the turn that just settled, render,
@@ -10459,7 +10468,7 @@ function _renderSettledAnchorSceneForMessage(message, segment, rawIdx){
   });
   blocks.querySelectorAll('.tool-worklog-group:not([data-anchor-scene-owner="1"]),.tool-call-group:not([data-anchor-scene-owner="1"]),.agent-activity-thinking:not([data-anchor-scene-row="1"]),.wl-reason').forEach(el=>el.remove());
   const streamId=String(message._anchor_stream_id||scene.stream_id||scene.identity&&scene.identity.stream_id||'');
-  const keepSettledWorklogOpen=_shouldKeepSettledWorklogOpenForPinnedFollow(streamId);
+  const keepSettledWorklogOpen=_shouldKeepSettledWorklogOpenForStreamSettle(streamId);
   const activityKey=`anchor-scene:${rawIdx}`;
   if(streamId&&!_readActivityDisclosureState(activityKey)){
     _copyActivityDisclosureState(`live:${streamId}`, activityKey);

--- a/static/ui.js
+++ b/static/ui.js
@@ -10473,6 +10473,15 @@ function _renderSettledAnchorSceneForMessage(message, segment, rawIdx){
   if(streamId&&!_readActivityDisclosureState(activityKey)){
     _copyActivityDisclosureState(`live:${streamId}`, activityKey);
   }
+  // keepSettledWorklogOpen forces collapsed:false for the ONE settle render of the
+  // just-settled turn so the live->settled swap is height-stable (no STREAM_DONE
+  // shrink jump) for both pinned followers AND unpinned mid-turn readers. If an
+  // unpinned reader had manually collapsed the live worklog, this overrides them
+  // for that single frame — but the disclosure state is preserved above
+  // (_copyActivityDisclosureState) and keep-open disarms right after the render
+  // (messages.js, _disarmKeepSettledWorklogOpen), so the NEXT re-render honors
+  // their collapsed state again. Net observable effect: a one-frame flash-open
+  // before it re-collapses — the accepted trade for removing the jump.
   const group=_anchorSceneWorklogGroup(blocks,{
     live:false,
     collapsed:!keepSettledWorklogOpen,

--- a/tests/test_issue4970_stream_done_shrink_regression.py
+++ b/tests/test_issue4970_stream_done_shrink_regression.py
@@ -2,10 +2,26 @@
 
 Round 7 (scoping fix): the keep-open exception must apply to ONLY the turn that
 just settled, gated on a one-shot stream-id token, NOT to every historical
-settled worklog on every pinned re-render. These tests are BEHAVIORAL: they
-extract the real `_shouldKeepSettledWorklogOpenForPinnedFollow` helper plus its
-arm/disarm token API from static/ui.js and execute them in Node, then drive two
-settled turns while pinned and assert the second (historical) turn collapses.
+settled worklog on every re-render.
+
+Round 8 (mobile unpinned fix, #MOBILESCROLL follow-up): the keep-open exception
+must also cover the UNPINNED reader who scrolled up to read inside the
+just-settled turn. The earlier round scoped keep-open to pinned followers only,
+on the assumption that unpinned readers "preserve their viewport normally". That
+holds on desktop (overflow-anchor:none + JS snapshot restore) but NOT on mobile:
+the CSS resting value is overflow-anchor:auto and _fixMobileScrollJank() flips an
+inline overflow-anchor:none over the settle render, so native anchoring is
+suppressed during the one frame the unpinned reader needs it to absorb the
+above-viewport worklog shrink — the content leaps to the top of the turn (the
+"往回大跳" report). Keeping the just-settled worklog open removes the shrink for
+every device/anchor-mode, so the helper now returns true for the armed turn
+regardless of pin state.
+
+These tests are BEHAVIORAL: they extract the real
+`_shouldKeepSettledWorklogOpenForStreamSettle` helper plus its arm/disarm token
+API from static/ui.js and execute them in Node, then drive two settled turns and
+assert the second (historical) turn collapses while the just-settled one stays
+open for both pin states.
 """
 import json
 import shutil
@@ -48,11 +64,17 @@ def _extract(name: str) -> str:
 def test_helper_and_token_threaded_through_render():
     # Structural: the helper takes a streamId and gates on the one-shot token,
     # and the call site threads the message's stream id (not a no-arg call).
-    helper = _function_body(UI_JS, "_shouldKeepSettledWorklogOpenForPinnedFollow")
+    helper = _function_body(UI_JS, "_shouldKeepSettledWorklogOpenForStreamSettle")
     assert "_keepSettledWorklogOpenForStreamId" in helper
-    assert "_scrollPinned" in helper and "!_messageUserUnpinned" in helper
+    # Round 8: the helper must NOT re-narrow to pinned-only — keep-open now covers
+    # the unpinned reader too, so the pin-state gate is gone from the return.
+    assert "_scrollPinned" not in helper, (
+        "keep-open must apply to the just-settled turn regardless of pin state "
+        "(unpinned mobile readers also get the shrink jump); do not gate on "
+        "_scrollPinned/_messageUserUnpinned."
+    )
     render_fn = _function_body(UI_JS, "_renderSettledAnchorSceneForMessage")
-    assert "_shouldKeepSettledWorklogOpenForPinnedFollow(streamId)" in render_fn
+    assert "_shouldKeepSettledWorklogOpenForStreamSettle(streamId)" in render_fn
     assert "collapsed:!keepSettledWorklogOpen" in render_fn
     group_fn = _function_body(UI_JS, "_anchorSceneWorklogGroup")
     assert "collapsed:(opts&&opts.collapsed!==undefined)?opts.collapsed:!live" in group_fn
@@ -62,9 +84,9 @@ def test_helper_and_token_threaded_through_render():
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node required for behavioral test")
-def test_only_just_settled_turn_stays_open_pinned_history_collapses():
-    """Drive two settled turns while pinned; only the just-settled one stays open."""
-    helper = _extract("_shouldKeepSettledWorklogOpenForPinnedFollow")
+def test_just_settled_turn_stays_open_for_both_pin_states_history_collapses():
+    """Only the just-settled turn stays open; it does so for pinned AND unpinned."""
+    helper = _extract("_shouldKeepSettledWorklogOpenForStreamSettle")
     arm = _extract("_armKeepSettledWorklogOpen")
     disarm = _extract("_disarmKeepSettledWorklogOpen")
     harness = textwrap.dedent(f"""
@@ -76,20 +98,29 @@ def test_only_just_settled_turn_stays_open_pinned_history_collapses():
         const out={{}};
         // Turn A just settled: arm A, render A (open), render historical B (collapsed), disarm.
         _armKeepSettledWorklogOpen('streamA');
-        out.A_open = _shouldKeepSettledWorklogOpenForPinnedFollow('streamA');      // expect true
-        out.B_history = _shouldKeepSettledWorklogOpenForPinnedFollow('streamB');   // expect false
+        out.A_open_pinned = _shouldKeepSettledWorklogOpenForStreamSettle('streamA');   // expect true
+        out.B_history = _shouldKeepSettledWorklogOpenForStreamSettle('streamB');       // expect false
+        // Round 8: an UNPINNED reader of the just-settled turn must ALSO keep it open
+        // (the mobile above-viewport shrink jump). This is the behavior change.
+        _messageUserUnpinned=true; _scrollPinned=false;
+        out.A_open_unpinned = _shouldKeepSettledWorklogOpenForStreamSettle('streamA'); // expect true
+        out.B_history_unpinned = _shouldKeepSettledWorklogOpenForStreamSettle('streamB'); // expect false
         _disarmKeepSettledWorklogOpen();
-        // After disarm, even A collapses on a later pinned re-render.
-        out.A_after_disarm = _shouldKeepSettledWorklogOpenForPinnedFollow('streamA'); // false
-        // Unpinned reader never keeps open even for the armed turn.
-        _armKeepSettledWorklogOpen('streamA'); _messageUserUnpinned=true; _scrollPinned=false;
-        out.unpinned = _shouldKeepSettledWorklogOpenForPinnedFollow('streamA');     // false
+        // After disarm, even A collapses on a later re-render (one-shot scope intact).
+        out.A_after_disarm = _shouldKeepSettledWorklogOpenForStreamSettle('streamA');  // false
+        // No token at all → never keep open.
+        out.no_token = _shouldKeepSettledWorklogOpenForStreamSettle('');               // false
         console.log(JSON.stringify(out));
     """)
     res = subprocess.run(["node", "-e", harness], capture_output=True, text=True, timeout=30)
     assert res.returncode == 0, res.stderr
     out = json.loads(res.stdout.strip())
-    assert out["A_open"] is True, "just-settled turn must keep worklog open for pinned follower"
-    assert out["B_history"] is False, "historical settled worklog must stay collapsed while pinned"
+    assert out["A_open_pinned"] is True, "just-settled turn must keep worklog open for pinned follower"
+    assert out["A_open_unpinned"] is True, (
+        "just-settled turn must ALSO keep worklog open for an unpinned reader — "
+        "the above-viewport collapse shrink janks them to the turn top on mobile"
+    )
+    assert out["B_history"] is False, "historical settled worklog must stay collapsed (pinned)"
+    assert out["B_history_unpinned"] is False, "historical settled worklog must stay collapsed (unpinned)"
     assert out["A_after_disarm"] is False, "exception must be one-shot, cleared after the render"
-    assert out["unpinned"] is False, "unpinned reader always gets compact settled worklog"
+    assert out["no_token"] is False, "no armed stream id → never keep open"

--- a/tests/test_issue4970_stream_done_shrink_regression.py
+++ b/tests/test_issue4970_stream_done_shrink_regression.py
@@ -124,3 +124,74 @@ def test_just_settled_turn_stays_open_for_both_pin_states_history_collapses():
     assert out["B_history_unpinned"] is False, "historical settled worklog must stay collapsed (unpinned)"
     assert out["A_after_disarm"] is False, "exception must be one-shot, cleared after the render"
     assert out["no_token"] is False, "no armed stream id → never keep open"
+
+
+def test_forced_open_dom_is_not_cached_while_token_armed():
+    # Round 9 (#5260 gate-cert, RED): the keep-open settle render force-opens the
+    # worklog; that DOM must NOT be written into _sessionHtmlCache while the token
+    # is armed, or it persists the forced-open worklog across session switches /
+    # restores and silently overrides a user-collapsed worklog.
+    armed = _function_body(UI_JS, "_isKeepSettledWorklogOpenArmed")
+    assert "_keepSettledWorklogOpenForStreamId!==null" in armed, (
+        "_isKeepSettledWorklogOpenArmed() must report whether the one-shot "
+        "keep-open token is currently armed."
+    )
+    # The cache-write guard in renderMessages must consult the armed check (via a
+    # typeof-safe local) so the forced-open settle render is excluded from
+    # _sessionHtmlCache.set().
+    assert "typeof _isKeepSettledWorklogOpenArmed==='function'" in UI_JS, (
+        "the cache guard must call _isKeepSettledWorklogOpenArmed() through a "
+        "typeof check so standalone renderMessages() harnesses still work (#5260)."
+    )
+    assert "!_keepOpenArmed" in UI_JS, (
+        "the _sessionHtmlCache population guard must include !_keepOpenArmed so the "
+        "forced-open settle render DOM is not cached (#5260)."
+    )
+    # Anchor it to the actual cache-write site: the armed check sits on the same
+    # condition as the INFLIGHT / transient-UI guards that gate the cache .set().
+    cache_guard_idx = UI_JS.index("!_keepOpenArmed")
+    window = UI_JS[cache_guard_idx : cache_guard_idx + 400]
+    assert "_sessionHtmlCache.set(" in window, (
+        "the !_keepOpenArmed guard must gate the "
+        "_sessionHtmlCache.set() call, not some unrelated branch."
+    )
+
+
+def test_stream_done_runs_scroll_preserving_collapse_pass_after_disarm():
+    # Round 9 (#5260 gate-cert, RED x2): disarming the token alone leaves the
+    # forced-open worklog on screen. The first re-push collapse-rendered only the
+    # NON-following path and let a pinned follower fall through to scrollToBottom()
+    # — but scrollToBottom() does NOT re-render (ui.js), so the armed-open DOM
+    # persisted for pinned followers. Fix: run the scroll-PRESERVING collapse pass
+    # UNCONDITIONALLY right after disarm (covers both pin states), THEN scrollToBottom()
+    # only for followers to re-settle at the tail. This makes keep-open genuinely
+    # one-frame for everyone.
+    disarm_idx = MESSAGES_JS.index("_disarmKeepSettledWorklogOpen()")
+    after = MESSAGES_JS[disarm_idx : disarm_idx + 700]
+    # The collapse pass must run after disarm for BOTH pin states.
+    assert "_renderMessagesWithScrollSnapshot()" in after, (
+        "after _disarmKeepSettledWorklogOpen() the STREAM_DONE handler must run a "
+        "scroll-preserving collapse pass (_renderMessagesWithScrollSnapshot) so the "
+        "forced-open worklog collapses back to the user/live state without the jump."
+    )
+    # The follower re-settle (scrollToBottom) must come AFTER the collapse render —
+    # otherwise a pinned follower keeps the forced-open DOM (scrollToBottom does not
+    # re-render). This is the exact pinned-path bug the second RED gate-cert caught.
+    collapse_pos = after.index("_renderMessagesWithScrollSnapshot()")
+    follow_pos = after.index("shouldFollowOnDone")
+    assert collapse_pos < follow_pos, (
+        "the collapse render must run BEFORE the shouldFollowOnDone scrollToBottom() "
+        "so BOTH pinned and unpinned readers get the worklog collapsed; scrollToBottom() "
+        "alone does not re-render and would leave a pinned follower forced-open."
+    )
+    assert "scrollToBottom()" in after, (
+        "a pinned/near-bottom follower must scrollToBottom() after the collapse "
+        "render to re-settle exactly at the tail."
+    )
+    # And the wrapper must exist and be scroll-preserving (capture → render →
+    # restore same-frame), so the collapse height change is absorbed by the JS
+    # restore rather than left to native scroll-anchoring (suppressed on mobile).
+    wrapper = _function_body(UI_JS, "_renderMessagesWithScrollSnapshot")
+    assert "_captureMessageScrollSnapshot()" in wrapper
+    assert "_restoreMessageScrollSnapshotSameFrame" in wrapper
+


### PR DESCRIPTION
## Problem

On **mobile**, a reader who has scrolled **up to read inside the latest assistant turn** gets thrown to the **top of that turn** the moment it finishes (STREAM_DONE). This is the recurring "页面往回大跳 / jumps back after the answer settles" report, observed on Android Chrome.

## Root cause

The STREAM_DONE keep-open exception (`_shouldKeepSettledWorklogOpenForPinnedFollow`, #4970 round 6/7) keeps the just-settled live worklog expanded so the live→settled DOM swap is height-stable — but it was scoped to **pinned followers only**, on the explicit assumption that *"unpinned readers still get compact settled worklogs and preserve their viewport normally."*

That assumption holds on **desktop** (`overflow-anchor:none` + the JS snapshot restore keep an unpinned reader put), but **not on mobile**:

- Mobile CSS resting value is `.messages{overflow-anchor:auto}` (native scroll-anchoring **ON**), while `@media (hover:hover) and (pointer:fine)` gives desktop `overflow-anchor:none`.
- `_fixMobileScrollJank()` flips an **inline `overflow-anchor:none`** over the settle render.
- So during the exact frame the worklog collapses — shrinking the transcript by hundreds of px **above** the unpinned reader's viewport — native scroll-anchoring is suppressed. Nothing absorbs the above-viewport shrink, and the reader's content leaps up to the top of the turn.

### Measurement (single-variable, faithful mobile emulation)

Reproduced on an isolated debug instance with CDP touch emulation (`setTouchEmulationEnabled` + `setEmulatedMedia(hover:none, pointer:coarse)`), which makes desktop Chromium report the real mobile media-query state (`matchHoverFine:false`, `overflow-anchor:auto`). Reader unpinned mid-turn, worklog collapses 920px above the viewport:

| overflow-anchor during collapse | reader content shift |
|---|---|
| `auto` | **0px** (native anchoring absorbs the shrink) |
| `none` (current mobile settle-render state) | **−248px** (content leaps up = the jump) |

## Fix

Keep the just-settled worklog open for **both** pin states on the settle render — still one-shot scoped to the turn that just settled, so historical worklogs still collapse compact. This removes the height shrink entirely, fixing the jump for **every device / anchor-mode combination** instead of fighting the native anchor engine for one device.

- Rename `_shouldKeepSettledWorklogOpenForPinnedFollow` → `_shouldKeepSettledWorklogOpenForStreamSettle` (drops the `_scrollPinned` / `_messageUserUnpinned` gate; keeps the one-shot stream-id token).
- The `_fixMobileScrollJank` guard and the mobile `overflow-anchor:auto` CSS are **untouched**, so @rodboev's #4856 Android DOM-wipe fix and the original #MOBILESCROLL fix both stay intact.

## Tests

- Updated `tests/test_issue4970_stream_done_shrink_regression.py` to assert keep-open is `true` for the armed (just-settled) turn under **both** pin states, and `false` for historical turns / after disarm. The behavioral Node-harness check executes the real function.
- Full related suite green: `test_issue4856_android_scroll_regression.py`, `test_issue1360_streaming_scroll_hardening.py` (#MOBILESCROLL CSS + guard), and the #4970 / worklog-collapse tests — no regressions.

## Notes for maintainers

As an external contributor I can't set reviewers/labels. This is a direct follow-up to the #4970 keep-open work and interacts with #4856 / #MOBILESCROLL — @nesquena / @rodboev would be the right reviewers. The change is purely the scope of the keep-open exception; no behavior change for desktop or for pinned followers.
