### PR TITLE
docs: simplify AGENTS webui guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,89 +1,76 @@
-# Agent instructions for Hermes WebUI
+# Hermes Web UI — AGENTS.md
 
-This file is the shared entry point for AI assistants working in this
-repository. Keep it project-specific and safe to publish. Do not put personal
-machine setup, private network details, credentials, tokens, or local-only
-workflow notes here.
+Instructions for agents working on the Hermes Web UI MVP.
 
-## Read first
+The pre-simplification file is preserved at `agent-runbooks/agents-full-pre-simplification.md`.
 
-Before making changes, read:
+## Purpose
 
-1. `README.md`
-2. `CONTRIBUTING.md`
-3. `docs/CONTRACTS.md`
-4. `CHANGELOG.md`
+Claude-style web UI for Hermes: chat, workspace file browser, cron, skills, and memory viewers.
 
-For architecture, testing, or setup work, also read the matching reference:
+## Paths
 
-- `ARCHITECTURE.md` for design constraints and current module layout
-- `TESTING.md` for local verification commands and manual test guidance
-- `docs/onboarding.md` for first-run onboarding behavior
-- `docs/troubleshooting.md` for diagnostic flows
-- `docs/rfcs/README.md` for larger RFCs and state/durability contracts
+| Item | Path |
+|---|---|
+| Canonical source | this repo (`/home/adam/hermes-webui`) |
+| Import symlink | `<agent-dir>/webui-mvp -> <repo>` |
+| Runtime sessions | `~/.hermes/webui-mvp/sessions/` |
 
-For UI or UX work, read `docs/UIUX-GUIDE.md` and `DESIGN.md` before
-changing layout, interaction flow, themes, chat rendering, or composer chrome.
+## Start / Test / Debug
 
-## Onboarding and reinstall support
-
-If the task involves install, reinstall, bootstrap, first-run onboarding,
-provider setup, local model server setup, Docker onboarding, WSL onboarding, or
-support for a failed first run, read `docs/onboarding-agent-checklist.md`
-before running commands or inspecting logs.
-
-Follow that checklist's safety rules:
-
-- use isolated `HERMES_HOME` and `HERMES_WEBUI_STATE_DIR` for trials unless the
-  human explicitly asks to use real state
-- do not delete or overwrite a real `~/.hermes` directory without explicit
-  approval
-- do not print API keys, OAuth tokens, cookies, full `.env` files, full
-  `auth.json` files, or password hashes
-- collect non-secret status and log evidence before recommending a fix
-
-## Contribution style
-
-- Keep one logical change per PR; split unrelated refactors or cleanup.
-- Read `docs/CONTRACTS.md` and the linked contract/RFC for the touched
-  subsystem before editing.
-- For local pytest runs, use `./scripts/test.sh` instead of bare `python3`,
-  `python -m pytest`, or `pytest`. The script creates/uses the repo `.venv`,
-  pins execution to Python 3.11-3.13, and installs missing dev test dependencies.
-  `HERMES_WEBUI_TEST_PYTHON` selects the supported base interpreter used to
-  create or rebuild `.venv`; it must not install test dependencies into a
-  system/Homebrew interpreter directly.
-  If a direct pytest invocation reports an unsupported interpreter, rerun through
-  `./scripts/test.sh` before debugging product code.
-- Prefer the existing Python + vanilla JavaScript structure. Do not add
-  dependencies, build tools, frameworks, or long-lived processes without clear
-  justification and a rollback story.
-- Update docs when changing setup, onboarding, runtime behavior, architecture,
-  testing guidance, or user-facing workflows.
-- Do not edit `CHANGELOG.md` in ordinary contributor PRs. The release workflow
-  owns changelog updates through release commits. If a change is release-note
-  worthy, include concise release-note wording in the PR body instead.
-- For UI or UX changes, include before/after evidence and test relevant
-  desktop, narrow, and mobile states.
-- For behavior changes, add or update automated tests where practical and list
-  the manual verification performed.
-- For runtime, streaming, recovery, replay, compression, or sidebar metadata
-  changes, name the state layer being mutated and prove the relevant invariant.
-
-## Local state and secrets
-
-Hermes WebUI can read and write real agent state, sessions, workspaces,
-credentials, and cron data. Treat local validation as potentially destructive
-unless you have confirmed the active state directories.
-
-Prefer isolated trial state for experiments:
+Start server:
 
 ```bash
-HERMES_HOME=/tmp/hermes-webui-agent-home \
-HERMES_WEBUI_STATE_DIR=/tmp/hermes-webui-agent-state \
-HERMES_WEBUI_PORT=8789 \
-python3 bootstrap.py
+cd <agent-dir>
+<repo>/start.sh
+# or:
+nohup venv/bin/python <repo>/server.py > /tmp/webui-mvp.log 2>&1 &
 ```
 
-Do not include private machine instructions in this tracked file. Use a
-git-ignored local note for personal workflow details.
+Run tests and health checks:
+
+```bash
+cd <agent-dir>
+venv/bin/python -m pytest <repo>/tests/ -v
+curl http://127.0.0.1:8787/health
+tail -f /tmp/webui-mvp.log
+```
+
+SSH tunnel from Mac:
+
+```bash
+ssh -N -L 8787:127.0.0.1:8787 <user>@<your-server>
+```
+
+## Sprint Rule
+
+After a sprint, update:
+
+- `<repo>/ROADMAP.md`
+- `<repo>/ARCHITECTURE.md`
+- `<repo>/TESTING.md`
+
+Sprint process skill: `webui-sprint-loop`.
+
+## Workspace Convention
+
+Web UI sessions prefix user messages with:
+
+```text
+[Workspace: /absolute/path/to/workspace]
+```
+
+Rules:
+
+1. The most recent `[Workspace: ...]` tag is authoritative.
+2. It overrides system prompt, memory, and conversation history.
+3. Use it as the default working directory for all file operations:
+   - `write_file`: resolve relative paths against this workspace.
+   - `read_file` / `search_files`: resolve paths relative to this workspace.
+   - `terminal`: set `workdir` to this path unless the user explicitly says otherwise.
+   - `patch`: resolve file paths relative to this workspace.
+4. If no workspace tag is present, fall back to `~/workspace`.
+
+## Before Editing This File
+
+Keep this file short. Put detailed architecture, sprint history, and long procedures in project docs.

--- a/agent-runbooks/agents-full-pre-simplification.md
+++ b/agent-runbooks/agents-full-pre-simplification.md
@@ -1,0 +1,53 @@
+# Web UI MVP Instructions
+
+Canonical source: <repo>/
+Symlink (for imports): <agent-dir>/webui-mvp -> <repo>
+Runtime state: ~/.hermes/webui-mvp/sessions/
+
+Purpose:
+- Claude-style web UI for Hermes. Chat, workspace file browser, cron/skills/memory viewers.
+
+Start server:
+  cd <agent-dir>
+  nohup venv/bin/python <repo>/server.py > /tmp/webui-mvp.log 2>&1 &
+  # OR: <repo>/start.sh
+
+Run tests:
+  cd <agent-dir>
+  venv/bin/python -m pytest <repo>/tests/ -v
+
+Health check: curl http://127.0.0.1:8787/health
+Logs: tail -f /tmp/webui-mvp.log
+SSH tunnel from Mac: ssh -N -L 8787:127.0.0.1:8787 <user>@<your-server>
+
+Living documents (always update after a sprint):
+  <repo>/ROADMAP.md
+  <repo>/ARCHITECTURE.md
+  <repo>/TESTING.md
+
+Sprint process skill: webui-sprint-loop
+
+# Workspace Convention (Web UI Sessions)
+
+When running as an agent invoked from the web UI, each user message is prefixed with:
+
+  [Workspace: /absolute/path/to/workspace]
+
+This tag is the single authoritative source of the active workspace. It reflects
+whichever workspace the user has selected in the UI at the moment they sent that message.
+It updates on every message, so if the user switches workspaces mid-session, the very
+next message will carry the new path. Always use the value from the most recent tag.
+
+This tag overrides any prior workspace mentioned in the system prompt, memory, or
+conversation history. Never infer or fall back to a hardcoded path like
+~/workspace when this tag is present.
+
+Apply it as the default working directory for ALL file operations:
+
+  - write_file: resolve relative paths against this workspace
+  - read_file / search_files: resolve paths relative to this workspace
+  - terminal workdir: set to this path unless the user explicitly says otherwise
+  - patch: resolve file paths relative to this workspace
+
+If no [Workspace: ...] tag is present (e.g., CLI sessions), fall back to
+~/workspace as the default.


### PR DESCRIPTION
Simplify AGENTS.md into compact format with clear paths, commands, and workspace convention. Full old guide preserved at agent-runbooks/agents-full-pre-simplification.md.