### PR TITLE
Release v0.51.770 — priority-queue batch (#5168 #5211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 
 ### Fixed
 
+- **`/pet` now works in the WebUI, handing off to the Desktop Companion extension.** Typing `/pet` (and its subcommands) is intercepted client-side and routed to the petdex companion extension with graceful per-stage guidance when the extension isn't installed; the command output is XSS-safe. Thanks @rodboev. (#5168, #4843)
+- **Settings search results are now ranked by match source.** Results are ordered title/label > value/option > description, with a stable prefix + earlier-index tie-break, and the result cap is applied after ranking so the best matches are never dropped; supplemental and provider/plugin-card terms remain searchable (reorder-only). XSS-safe. Thanks @rodboev. (#5211, #5149)
+
 - **Opt-in busy composer placeholder hint.** A new default-off setting swaps the composer placeholder to a busy-mode-specific hint (queue / steer / interrupt) when the agent is running, deferring to the compression placeholder and any user draft, and restoring on idle. Text-only (no layout change), XSS-safe, localized across all 14 locales. Thanks @rodboev. (#5161, #5144)
 
 - **A server-initiated turn that finished during an SSE gap now renders correctly on a visible-tab wake.** When a tab regained focus after the SSE stream had a gap, a self-heal reload could clobber a concurrent same-session `server_turn_started`, losing live-render ownership. The active stream id is now re-read after the awaited message load and scoped to the same session, so a concurrent same-session stream is honored by the attach/idle decision. The original SSE-gap self-heal (metadata-only server-ahead, in-place replace, no jump) is intact. Thanks @allenliang2022. (#5248)

--- a/static/commands.js
+++ b/static/commands.js
@@ -139,7 +139,7 @@ async function handlePetSlashCommand(rawCommandText,meta){
         source:'webui-slash-command',
         metadata:{name:commandName},
       });
-      if(result===true||(result&&result.handled===true)){
+      if(result){
         return {handled:true,message:''};
       }
     }catch(_e){}

--- a/static/commands.js
+++ b/static/commands.js
@@ -48,6 +48,105 @@ function parseCommand(text){
   return {name,args};
 }
 
+const DESKTOP_COMPANION_EXTENSION_ID='desktop-companion';
+const DESKTOP_COMPANION_NAME='Desktop Companion';
+const DESKTOP_COMPANION_INSTALL_PATH='Settings -> Extensions -> Gallery -> Desktop Companion';
+const DESKTOP_COMPANION_SETUP_GUIDE_URL='https://github.com/franksong2702/hermes-webui-desktop-companion#after-gallery-install';
+const DESKTOP_COMPANION_LOCAL_APP_LABEL='Desktop Companion app';
+
+function _getDesktopCompanionStatusGlobal(){
+  if(typeof window==='undefined') return null;
+  return window.__HERMES_WEBUI_DESKTOP_COMPANION_STATUS__||null;
+}
+
+function _getDesktopCompanionExtensionStatus(status){
+  return Array.isArray(status&&status.extensions)
+    ? status.extensions.find(ext=>String(ext&&ext.id||'')===DESKTOP_COMPANION_EXTENSION_ID)||null
+    : null;
+}
+
+function _petSlashCommandArgs(rawCommandText){
+  const parsed=parseCommand(String(rawCommandText||'').trim());
+  return parsed&&parsed.name==='pet' ? parsed.args : String(rawCommandText||'').trim().replace(/^\/pet\b\s*/i,'').trim();
+}
+
+function _desktopCompanionMissingMessage(){
+  return `${DESKTOP_COMPANION_NAME} is not installed yet.
+
+Install it from ${DESKTOP_COMPANION_INSTALL_PATH}, then follow the setup guide: ${DESKTOP_COMPANION_SETUP_GUIDE_URL}.
+
+The guide also shows how to start the ${DESKTOP_COMPANION_LOCAL_APP_LABEL}.`;
+}
+
+function _desktopCompanionDisabledMessage(){
+  return `${DESKTOP_COMPANION_NAME} is installed but disabled.
+
+Enable it in Settings -> Extensions, then reload WebUI if you just changed that and start the ${DESKTOP_COMPANION_LOCAL_APP_LABEL}.
+
+Setup guide: ${DESKTOP_COMPANION_SETUP_GUIDE_URL}`;
+}
+
+function _desktopCompanionReloadMessage(){
+  return `${DESKTOP_COMPANION_NAME} is enabled, but the adapter status is not loaded yet.
+
+Reload WebUI if you just enabled it, then start the ${DESKTOP_COMPANION_LOCAL_APP_LABEL}.`;
+}
+
+function _desktopCompanionConnectMessage(){
+  return `${DESKTOP_COMPANION_NAME} is enabled, but the local app is not connected yet.
+
+Start or connect the ${DESKTOP_COMPANION_LOCAL_APP_LABEL}, then retry /pet.
+
+Setup guide: ${DESKTOP_COMPANION_SETUP_GUIDE_URL}`;
+}
+
+function _desktopCompanionUnavailableMessage(){
+  return `${DESKTOP_COMPANION_NAME} is installed and connected, but /pet is not available yet in this Desktop Companion version.
+
+Update the ${DESKTOP_COMPANION_LOCAL_APP_LABEL}, then follow the setup guide: ${DESKTOP_COMPANION_SETUP_GUIDE_URL}.`;
+}
+
+async function handlePetSlashCommand(rawCommandText,meta){
+  const command=String(rawCommandText||'');
+  const commandName=String((meta&&meta.name)||'pet').trim()||'pet';
+  const args=_petSlashCommandArgs(command);
+  let status=null;
+  try{
+    status=await api('/api/extensions/status');
+  }catch(_e){
+    status=null;
+  }
+  const companion=_getDesktopCompanionExtensionStatus(status);
+  if(!companion){
+    return {handled:false,message:_desktopCompanionMissingMessage()};
+  }
+  if(companion.effective_enabled!==true){
+    return {handled:false,message:_desktopCompanionDisabledMessage()};
+  }
+  const companionStatus=_getDesktopCompanionStatusGlobal();
+  if(!companionStatus){
+    return {handled:false,message:_desktopCompanionReloadMessage()};
+  }
+  if(companionStatus.connected!==true){
+    return {handled:false,message:_desktopCompanionConnectMessage()};
+  }
+  const hook=typeof window!=='undefined'&&window.__hermesHandlePetSlashCommand;
+  if(typeof hook==='function'){
+    try{
+      const result=await hook({
+        command,
+        args,
+        source:'webui-slash-command',
+        metadata:{name:commandName},
+      });
+      if(result===true||(result&&result.handled===true)){
+        return {handled:true,message:''};
+      }
+    }catch(_e){}
+  }
+  return {handled:false,message:_desktopCompanionUnavailableMessage()};
+}
+
 function executeCommand(text){
   const parsed=parseCommand(text);
   if(!parsed)return null;
@@ -76,11 +175,22 @@ function getMatchingCommands(prefix){
     });
     seen.add(name);
   }
+  if('pet'.startsWith(q)&&!seen.has('pet')){
+    const petMeta=Array.isArray(_agentCommandCache)
+      ? _agentCommandCache.find(cmd=>String(cmd&&cmd.name||'').toLowerCase()==='pet')
+      : null;
+    matches.push({
+      name:'pet',
+      desc:String((petMeta&&petMeta.description)||'Desktop Companion command').trim()||'Desktop Companion command',
+      source:'agent',
+    });
+    seen.add('pet');
+  }
   // Include agent/plugin commands from /api/commands metadata
   for(const cmd of (_agentCommandCache||[])){
     const name=String(cmd&&cmd.name||'').toLowerCase();
     if(!name.startsWith(q)||seen.has(name))continue;
-    if(cmd.cli_only)continue;
+    if(cmd.cli_only&&name!=='pet')continue;
     matches.push({
       name,
       desc:String(cmd&&cmd.description||'').trim()||'Agent command',

--- a/static/commands.js
+++ b/static/commands.js
@@ -100,21 +100,33 @@ Start or connect the ${DESKTOP_COMPANION_LOCAL_APP_LABEL}, then retry /pet.
 Setup guide: ${DESKTOP_COMPANION_SETUP_GUIDE_URL}`;
 }
 
+function _desktopCompanionStatusUnavailableMessage(){
+  return `${DESKTOP_COMPANION_NAME} status is unavailable right now.
+
+Reload WebUI or check your connection, then retry /pet.`;
+}
+
 function _desktopCompanionUnavailableMessage(){
   return `${DESKTOP_COMPANION_NAME} is installed and connected, but /pet is not available yet in this Desktop Companion version.
 
 Update the ${DESKTOP_COMPANION_LOCAL_APP_LABEL}, then follow the setup guide: ${DESKTOP_COMPANION_SETUP_GUIDE_URL}.`;
 }
 
+function _desktopCompanionHookErrorMessage(){
+  return `${DESKTOP_COMPANION_NAME} is installed and connected, but it hit an error while handling /pet.
+
+Check the browser console and the ${DESKTOP_COMPANION_LOCAL_APP_LABEL}, then retry /pet.`;
+}
+
 async function handlePetSlashCommand(rawCommandText,meta){
   const command=String(rawCommandText||'');
   const commandName=String((meta&&meta.name)||'pet').trim()||'pet';
   const args=_petSlashCommandArgs(command);
-  let status=null;
+  let status;
   try{
     status=await api('/api/extensions/status');
   }catch(_e){
-    status=null;
+    return {handled:false,message:_desktopCompanionStatusUnavailableMessage()};
   }
   const companion=_getDesktopCompanionExtensionStatus(status);
   if(!companion){
@@ -140,9 +152,19 @@ async function handlePetSlashCommand(rawCommandText,meta){
         metadata:{name:commandName},
       });
       if(result){
-        return {handled:true,message:''};
+        return {
+          handled:true,
+          message:result&&typeof result==='object'&&'message' in result
+            ? String(result.message||'')
+            : '',
+        };
       }
-    }catch(_e){}
+    }catch(_e){
+      if(typeof console!=='undefined'&&console.error){
+        console.error('[hermes] Desktop Companion /pet hook error:',_e);
+      }
+      return {handled:false,message:_desktopCompanionHookErrorMessage()};
+    }
   }
   return {handled:false,message:_desktopCompanionUnavailableMessage()};
 }

--- a/static/commands.js
+++ b/static/commands.js
@@ -155,7 +155,7 @@ async function handlePetSlashCommand(rawCommandText,meta){
         return {
           handled:true,
           message:result&&typeof result==='object'&&'message' in result
-            ? String(result.message||'')
+            ? String(result.message??'')
             : '',
         };
       }

--- a/static/messages.js
+++ b/static/messages.js
@@ -1351,6 +1351,23 @@ async function send(){
       }
     }
     if(_parsedCmd&&!_cmd){
+      if(_parsedCmd.name==='pet'){
+        if(!S.session){await newSession();await renderSessionList();}
+        S.messages.push({role:'user',content:text,_ts:Date.now()/1000});
+        let _petOutput=null;
+        try{
+          _petOutput=typeof handlePetSlashCommand==='function'
+            ? await handlePetSlashCommand(text,{name:'pet'})
+            : {handled:false,message:'Desktop Companion is unavailable in WebUI.'};
+        }catch(e){
+          _petOutput={handled:false,message:`Desktop Companion command error: ${e&&e.message||e}`};
+        }
+        if(_petOutput&&_petOutput.message){
+          S.messages.push({role:'assistant',content:String(_petOutput.message),_ts:Date.now()/1000});
+        }
+        renderMessages();
+        $('msg').value='';autoResize();hideCmdDropdown();return;
+      }
       const _agentCmd=typeof getAgentCommandMetadata==='function'
         ? await getAgentCommandMetadata(_parsedCmd.name)
         : null;

--- a/static/panels.js
+++ b/static/panels.js
@@ -7125,9 +7125,6 @@ async function filterSettings(query) {
     if (left.score.bucketIndex !== right.score.bucketIndex) {
       return left.score.bucketIndex - right.score.bucketIndex;
     }
-    if (left.score.matchType !== right.score.matchType) {
-      return left.score.matchType === 'prefix' ? -1 : 1;
-    }
     if (left.score.matchIndex !== right.score.matchIndex) {
       return left.score.matchIndex - right.score.matchIndex;
     }

--- a/static/panels.js
+++ b/static/panels.js
@@ -6925,11 +6925,7 @@ function _extractSettingsDescriptionText(field, labelEl) {
   field.querySelectorAll('[data-i18n]').forEach(node => {
     if (labelEl && (node === labelEl || labelEl.contains(node))) return;
     const key = node.dataset ? node.dataset.i18n : null;
-    if (key) {
-      chunks.push(t(key));
-      return;
-    }
-    chunks.push(node.textContent);
+    if (key) chunks.push(t(key));
   });
   return chunks.join(' ');
 }

--- a/static/panels.js
+++ b/static/panels.js
@@ -6911,6 +6911,51 @@ function switchSettingsSection(name,opts){
   if(opts&&opts.fromSidebarItem)_closeMobileSidebarAfterPanelSelection();
 }
 
+function _normalizeSettingsSearchText(value) {
+  return String(value || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function _extractSettingsDescriptionText(field, labelEl) {
+  const chunks = [];
+  const settingsSearch = (field.dataset && field.dataset.settingsSearch) || '';
+  if (settingsSearch) chunks.push(settingsSearch);
+  field.querySelectorAll('[data-i18n]').forEach(node => {
+    if (labelEl && (node === labelEl || labelEl.contains(node))) return;
+    const key = node.dataset ? node.dataset.i18n : null;
+    if (key) {
+      chunks.push(t(key));
+      return;
+    }
+    chunks.push(node.textContent);
+  });
+  return chunks.join(' ');
+}
+
+function _extractSettingsValueText(field) {
+  const chunks = [];
+  const controls = [...field.querySelectorAll('select, input, textarea')];
+  controls.forEach(control => {
+    const tagName = (control.tagName || '').toLowerCase();
+    if (tagName === 'select') {
+      control.querySelectorAll('option').forEach(option => {
+        if (option.dataset && option.dataset.i18n) {
+          chunks.push(t(option.dataset.i18n));
+        } else {
+          chunks.push(option.textContent);
+        }
+      });
+      return;
+    }
+    const type = (control.getAttribute && control.getAttribute('type')) || control.type || '';
+    if (tagName === 'input' && ['checkbox', 'radio', 'file', 'submit', 'reset', 'button'].includes(type)) return;
+    if (control.value) chunks.push(control.value);
+  });
+  return chunks.join(' ');
+}
+
 async function _buildSettingsIndex() {
   if (_settingsIndex) return;
   // Memoize the in-flight build so concurrent searches share one pass; the
@@ -6920,6 +6965,9 @@ async function _buildSettingsIndex() {
     // Ensure lazy-loaded panes are populated before reading the DOM
     await Promise.all([loadProvidersPanel(), loadPluginsPanel(), loadExtensionsPanel()]);
     const index = [];
+    const add = (entry) => {
+      index.push({ ...entry, _settingsSearchIndex: index.length });
+    };
     const sectionMap = {
       settingsPaneConversation: 'conversation',
       settingsPaneAppearance: 'appearance',
@@ -6943,31 +6991,96 @@ async function _buildSettingsIndex() {
         const labelEl = field.querySelector('label[data-i18n], label [data-i18n], label');
         if (!labelEl) return;
         const i18nKey = labelEl.dataset ? labelEl.dataset.i18n : undefined;
-        const label = (i18nKey && t(i18nKey)) || labelEl.textContent.trim();
-        if (label) {
-          const searchBlob = [label, field.textContent, field.dataset ? field.dataset.settingsSearch : '']
-            .filter(Boolean)
-            .join(' ')
-            .replace(/\s+/g, ' ')
-            .trim();
-          index.push({ label, searchBlob, sectionKey, i18nKey, el: field });
-        }
+        const titleText = (i18nKey && t(i18nKey)) || labelEl.textContent.trim();
+        if (!titleText) return;
+        const valueText = _normalizeSettingsSearchText(_extractSettingsValueText(field));
+        const descriptionText = _normalizeSettingsSearchText(_extractSettingsDescriptionText(field, labelEl));
+        const searchBlob = [titleText, valueText, descriptionText, field.textContent]
+          .filter(Boolean)
+          .join(' ')
+          .replace(/\s+/g, ' ')
+          .trim();
+        add({
+          label: titleText,
+          titleText,
+          valueText,
+          descriptionText,
+          searchBlob,
+          sectionKey,
+          i18nKey,
+          el: field,
+        });
       });
       if (sectionKey === 'providers') {
         pane.querySelectorAll('.provider-card').forEach(card => {
           const cardName = ((card.querySelector('.provider-card-name') || {}).textContent || '').trim();
-          if (cardName) index.push({ label: cardName, sectionKey, el: card, cardName });
+          if (cardName) {
+            const titleText = cardName;
+            const valueText = _normalizeSettingsSearchText(_extractSettingsValueText(card));
+            const descriptionText = _normalizeSettingsSearchText(_extractSettingsDescriptionText(card));
+            const searchBlob = [cardName, valueText, descriptionText, card.textContent]
+              .filter(Boolean)
+              .join(' ')
+              .replace(/\s+/g, ' ')
+              .trim();
+            add({
+              label: cardName,
+              titleText,
+              valueText,
+              descriptionText,
+              searchBlob,
+              sectionKey,
+              el: card,
+              cardName,
+            });
+          }
           card.querySelectorAll('.provider-card-field').forEach(field => {
             const fieldLabel = ((field.querySelector('.provider-card-label') || {}).textContent || '').trim();
             const label = [cardName, fieldLabel].filter(Boolean).join(' ');
-            if (label) index.push({ label, sectionKey, el: field, cardName, fieldLabel });
+            if (!label) return;
+            const valueText = _normalizeSettingsSearchText(_extractSettingsValueText(field));
+            const descriptionText = _normalizeSettingsSearchText(_extractSettingsDescriptionText(field));
+            const searchBlob = [label, valueText, descriptionText, field.textContent]
+              .filter(Boolean)
+              .join(' ')
+              .replace(/\s+/g, ' ')
+              .trim();
+            add({
+              label,
+              titleText: label,
+              valueText,
+              descriptionText,
+              searchBlob,
+              sectionKey,
+              el: field,
+              cardName,
+              fieldLabel,
+            });
           });
         });
       }
       if (sectionKey === 'plugins') {
         pane.querySelectorAll('.plugin-card').forEach(card => {
           const cardName = ((card.querySelector('.provider-card-name') || {}).textContent || '').trim();
-          if (cardName) index.push({ label: cardName, sectionKey, el: card, cardName });
+          if (!cardName) return;
+          const titleText = cardName;
+          const valueText = _normalizeSettingsSearchText(_extractSettingsValueText(card));
+          const descriptionText = _normalizeSettingsSearchText(_extractSettingsDescriptionText(card));
+          const searchBlob = [cardName, valueText, descriptionText, card.textContent]
+            .filter(Boolean)
+            .join(' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+          add({
+            label: cardName,
+            titleText,
+            valueText,
+            descriptionText,
+            searchBlob,
+            sectionKey,
+            el: card,
+            cardName,
+          });
         });
       }
     }
@@ -6998,16 +7111,29 @@ async function filterSettings(query) {
     system: t('settings_tab_system') || 'System',
     help: t('settings_tab_help') || 'Help',
   };
-  const matches = (_settingsIndex || []).filter(entry =>
-    (entry.searchBlob || entry.label).toLowerCase().includes(q)
-  );
+  const matches = (_settingsIndex || []).map((entry) => {
+    const score = _scoreSettingsSearchMatch(entry, q);
+    return score ? { entry, score, index: entry._settingsSearchIndex } : null;
+  }).filter(Boolean);
   if (!matches.length) {
     resultsEl.innerHTML = `<div class="settings-search-empty">${esc(t('settings_search_no_results') || 'No settings found.')}</div>`;
     resultsEl.style.display = '';
     return;
   }
   resultsEl.innerHTML = '';
-  for (const m of matches.slice(0, 12)) {
+  matches.sort((left, right) => {
+    if (left.score.bucketIndex !== right.score.bucketIndex) {
+      return left.score.bucketIndex - right.score.bucketIndex;
+    }
+    if (left.score.matchType !== right.score.matchType) {
+      return left.score.matchType === 'prefix' ? -1 : 1;
+    }
+    if (left.score.matchIndex !== right.score.matchIndex) {
+      return left.score.matchIndex - right.score.matchIndex;
+    }
+    return left.index - right.index;
+  });
+  for (const { entry: m } of matches.slice(0, 12)) {
     const item = document.createElement('button');
     item.type = 'button';
     item.className = 'settings-search-result';
@@ -7024,6 +7150,29 @@ async function filterSettings(query) {
     resultsEl.appendChild(item);
   }
   resultsEl.style.display = '';
+}
+
+function _scoreSettingsSearchMatch(entry, q) {
+  const query = (q || '').toLowerCase().trim();
+  if (!query) return null;
+  const buckets = [
+    ['titleText', 0],
+    ['valueText', 1],
+    ['descriptionText', 2],
+    ['searchBlob', 3],
+  ];
+  for (const [bucketName, bucketIndex] of buckets) {
+    const hay = _normalizeSettingsSearchText(entry[bucketName]);
+    if (!hay) continue;
+    const matchIndex = hay.indexOf(query);
+    if (matchIndex < 0) continue;
+    return {
+      bucketIndex,
+      matchType: matchIndex === 0 ? 'prefix' : 'contains',
+      matchIndex,
+    };
+  }
+  return null;
 }
 
 function _navigateToSettingsField(entry) {

--- a/tests/test_3850_settings_search.py
+++ b/tests/test_3850_settings_search.py
@@ -49,6 +49,15 @@ class TestSettingsSearch:
         assert "searchBlob" in body, (
             "_buildSettingsIndex must store a searchBlob for settings fields"
         )
+        assert "titleText" in body, (
+            "_buildSettingsIndex must store title bucket text"
+        )
+        assert "valueText" in body, (
+            "_buildSettingsIndex must store value bucket text"
+        )
+        assert "descriptionText" in body, (
+            "_buildSettingsIndex must store description bucket text"
+        )
 
     def test_panels_js_has_filter_settings_function(self):
         """panels.js must contain filterSettings function."""
@@ -56,11 +65,14 @@ class TestSettingsSearch:
             "panels.js must contain filterSettings(query) function"
         )
         body = PANELS_JS[PANELS_JS.find("function filterSettings(query)"):]
-        assert "(entry.searchBlob || entry.label).toLowerCase().includes(q)" in body, (
-            "filterSettings must do case-insensitive substring matching over the search blob"
+        assert "_scoreSettingsSearchMatch" in body, (
+            "filterSettings must call _scoreSettingsSearchMatch for ranking"
         )
         assert "esc(m.label)" in body, (
             "filterSettings must keep rendering the visible label text"
+        )
+        assert ".sort(" in body, (
+            "filterSettings must order matches deterministically"
         )
 
     def test_panels_js_has_navigate_to_field_function(self):
@@ -169,7 +181,11 @@ class TestSettingsSearch:
         """Plugins pane entries must index plugin cards by plugin name."""
         idx = PANELS_JS.find("function _buildSettingsIndex()")
         assert idx >= 0, "_buildSettingsIndex not found"
-        body = PANELS_JS[idx:idx + 3500]
+        end = PANELS_JS.find("function _resolveSettingsField(entry)", idx)
+        body = PANELS_JS[idx:end]
+        assert "if (sectionKey === 'plugins')" in body, (
+            "_buildSettingsIndex should include a plugins section branch"
+        )
         assert "pane.querySelectorAll('.plugin-card')" in body, (
             "_buildSettingsIndex must scan plugin cards so Plugins search is not empty"
         )
@@ -214,8 +230,11 @@ class TestSettingsSearchReviewFixes:
         label[data-i18n]. Otherwise most checkbox settings are unsearchable."""
         idx = PANELS_JS.find("function _buildSettingsIndex")
         assert idx >= 0, "_buildSettingsIndex not found"
-        body = PANELS_JS[idx:idx + 1600]
-        assert "label[data-i18n], label [data-i18n], label" in body, (
+        body = PANELS_JS[idx:idx + 2600]
+        assert "field.querySelector(" in body, (
+            "field index query should run a querySelector against field"
+        )
+        assert "label[data-i18n]" in body, (
             "field index query must include 'label [data-i18n]' (span-in-label) "
             "and plain 'label' so toggle settings are searchable"
         )

--- a/tests/test_5148_settings_search_busy_input_terms.py
+++ b/tests/test_5148_settings_search_busy_input_terms.py
@@ -24,24 +24,24 @@ class TestBusyInputSettingsSearchTerms:
         body = PANELS_JS[idx:]
         assert "searchBlob" in body, "_buildSettingsIndex must build a searchBlob"
         assert "field.textContent" in body, "_buildSettingsIndex must include field text in searchBlob"
-        assert "field.dataset ? field.dataset.settingsSearch : ''" in body, (
-            "_buildSettingsIndex must include supplemental search terms in searchBlob"
+        assert "settingsSearch" in body, (
+            "_buildSettingsIndex must include supplemental data-settings-search terms in searchBlob"
         )
 
     def test_filter_settings_uses_search_blob_and_keeps_label_rendering(self):
-        """filterSettings must match searchBlob, render labels, and keep the cap."""
+        """filterSettings must rank by source and keep visible labels."""
         idx = PANELS_JS.find("function filterSettings(query)")
         assert idx >= 0, "filterSettings not found"
         body = PANELS_JS[idx:]
-        assert "(entry.searchBlob || entry.label).toLowerCase().includes(q)" in body, (
-            "filterSettings must search the richer blob instead of label-only text"
-        )
         assert "esc(m.label)" in body, (
             "filterSettings must keep rendering the visible label"
         )
         assert ".slice(0, 12)" in body, (
             "filterSettings must keep the existing 12-result cap"
         )
-        assert ".sort(" not in body, (
-            "filterSettings must not introduce ranking or reordering"
+        assert ".sort(" in body, (
+            "filterSettings must apply deterministic ranking"
+        )
+        assert "_scoreSettingsSearchMatch" in body, (
+            "filterSettings must score ranked matches by source"
         )

--- a/tests/test_5149_settings_search_ranking.py
+++ b/tests/test_5149_settings_search_ranking.py
@@ -384,16 +384,16 @@ function setupDom(mode) {
   if (mode === 'title-vs-description') {
     conversation.appendChild(makeSettingsField({
       labelText: 'Descriptor-only field',
-      descriptionText: 'this contains priority in the descriptor',
+      descriptionI18nKey: 'settings_desc_priority_only',
     }));
     conversation.appendChild(makeSettingsField({
       labelText: 'Priority title field',
-      descriptionText: 'nothing about query there',
+      descriptionI18nKey: 'settings_desc_irrelevant',
     }));
   } else if (mode === 'value-vs-description') {
     conversation.appendChild(makeSettingsField({
       labelText: 'Value-later field',
-      descriptionText: 'contains rank token in descriptor only',
+      descriptionI18nKey: 'settings_desc_rank_only',
     }));
     conversation.appendChild(makeSettingsField({
       labelText: 'Value field',
@@ -401,12 +401,16 @@ function setupDom(mode) {
     }));
   } else if (mode === 'same-tier-order') {
     conversation.appendChild(makeSettingsField({
-      labelText: 'Description-first',
-      descriptionText: 'first field has needle around index 5',
+      labelText: 'Description-prefix',
+      descriptionI18nKey: 'settings_desc_needle_prefix',
     }));
     conversation.appendChild(makeSettingsField({
-      labelText: 'Description-second',
-      descriptionText: 'second field has the needle a little later in the text',
+      labelText: 'Description-earlier-contains',
+      descriptionI18nKey: 'settings_desc_needle_contains_early',
+    }));
+    conversation.appendChild(makeSettingsField({
+      labelText: 'Description-later-contains',
+      descriptionI18nKey: 'settings_desc_needle_contains_late',
     }));
   } else if (mode === 'label-rendering') {
     conversation.appendChild(makeSettingsField({
@@ -459,6 +463,12 @@ function runScenario(command) {
           settings_tab_extensions: 'Extensions',
           settings_tab_system: 'System',
           settings_tab_help: 'Help',
+          settings_desc_priority_only: 'this contains priority in the descriptor',
+          settings_desc_irrelevant: 'nothing about query there',
+          settings_desc_rank_only: 'contains rank token in descriptor only',
+          settings_desc_needle_prefix: 'needle appears at the start of this description',
+          settings_desc_needle_contains_early: 'this field has needle near the front',
+          settings_desc_needle_contains_late: 'this field waits a while before it reaches needle',
         };
         return translations[key] || String(key || '');
       };
@@ -546,8 +556,9 @@ def test_value_or_option_match_outranks_descriptor_match(driver_file):
 
 def test_same_tier_order_uses_prefix_and_earlier_index(driver_file):
     payload = _run_driver(driver_file, "same-tier-order")
-    assert payload["labels"][0] == "Description-first"
-    assert payload["labels"][1] == "Description-second"
+    assert payload["labels"][0] == "Description-prefix"
+    assert payload["labels"][1] == "Description-earlier-contains"
+    assert payload["labels"][2] == "Description-later-contains"
 
 
 def test_rendered_label_is_visible_field_title(driver_file):

--- a/tests/test_5149_settings_search_ranking.py
+++ b/tests/test_5149_settings_search_ranking.py
@@ -387,6 +387,10 @@ function setupDom(mode) {
       descriptionI18nKey: 'settings_desc_priority_only',
     }));
     conversation.appendChild(makeSettingsField({
+      labelText: 'Blob field',
+      descriptionText: 'priority appears only in this plain-text fallback',
+    }));
+    conversation.appendChild(makeSettingsField({
       labelText: 'Priority title field',
       descriptionI18nKey: 'settings_desc_irrelevant',
     }));
@@ -394,6 +398,10 @@ function setupDom(mode) {
     conversation.appendChild(makeSettingsField({
       labelText: 'Value-later field',
       descriptionI18nKey: 'settings_desc_rank_only',
+    }));
+    conversation.appendChild(makeSettingsField({
+      labelText: 'Blob value field',
+      descriptionText: 'rank only lives in this plain-text fallback text',
     }));
     conversation.appendChild(makeSettingsField({
       labelText: 'Value field',
@@ -417,6 +425,12 @@ function setupDom(mode) {
       labelText: 'Visible Label',
       options: ['token-label-option'],
       descriptionText: 'description with token-label-option',
+    }));
+  } else if (mode === 'supplemental-term') {
+    conversation.appendChild(makeSettingsField({
+      labelText: 'Supplemental alias field',
+      descriptionText: 'description without the alias query',
+      settingsSearch: 'steer alias query',
     }));
   } else if (mode === 'twelve-result-cap') {
     for (let i = 0; i < 13; i++) {
@@ -485,8 +499,9 @@ function runScenario(command) {
       else if (command === 'value-vs-description') query = 'rank';
       else if (command === 'same-tier-order') query = 'needle';
       else if (command === 'label-rendering') query = 'token-label-option';
+      else if (command === 'supplemental-term') query = 'steer alias';
       else if (command === 'twelve-result-cap') query = 'shared';
-      else if (command === 'provider-plugin') query = 'plugin';
+      else if (command === 'provider-plugin') query = scenario.query || 'plugin';
       await filterSettings(query);
 
       const results = $('settingsSearchResults');
@@ -531,7 +546,12 @@ def driver_file(driver_path):
 
 def _run_driver(driver_file, command):
     process = subprocess.run(
-        [NODE, driver_file, str(PANELS_JS), json.dumps({"command": command})],
+        [
+            NODE,
+            driver_file,
+            str(PANELS_JS),
+            json.dumps(command if isinstance(command, dict) else {"command": command}),
+        ],
         capture_output=True,
         text=True,
         check=False,
@@ -545,12 +565,16 @@ def _run_driver(driver_file, command):
 def test_title_matches_outrank_descriptor_only(driver_file):
     payload = _run_driver(driver_file, "title-vs-description")
     assert payload["labels"][0] == "Priority title field"
+    assert payload["labels"][1] == "Descriptor-only field"
+    assert payload["labels"][2] == "Blob field"
     assert not payload["noResults"]
 
 
 def test_value_or_option_match_outranks_descriptor_match(driver_file):
     payload = _run_driver(driver_file, "value-vs-description")
     assert payload["labels"][0] == "Value field"
+    assert payload["labels"][1] == "Value-later field"
+    assert payload["labels"][2] == "Blob value field"
     assert not payload["noResults"]
 
 
@@ -566,6 +590,11 @@ def test_rendered_label_is_visible_field_title(driver_file):
     assert payload["labels"][0] == "Visible Label"
 
 
+def test_supplemental_search_terms_remain_behaviorally_searchable(driver_file):
+    payload = _run_driver(driver_file, "supplemental-term")
+    assert payload["labels"] == ["Supplemental alias field"]
+
+
 def test_results_cap_still_applies_to_ranked_matches(driver_file):
     payload = _run_driver(driver_file, "twelve-result-cap")
     assert payload["resultCount"] == 12
@@ -573,5 +602,18 @@ def test_results_cap_still_applies_to_ranked_matches(driver_file):
 
 
 def test_provider_and_plugin_cards_remain_searchable(driver_file):
-    payload = _run_driver(driver_file, "provider-plugin")
-    assert "Plugin Sample" in payload["labels"]
+    provider_payload = _run_driver(
+        driver_file,
+        {"command": "provider-plugin", "query": "alpha"},
+    )
+    field_payload = _run_driver(
+        driver_file,
+        {"command": "provider-plugin", "query": "key"},
+    )
+    plugin_payload = _run_driver(
+        driver_file,
+        {"command": "provider-plugin", "query": "plugin"},
+    )
+    assert "Provider Alpha" in provider_payload["labels"]
+    assert "Provider Alpha API Key" in field_payload["labels"]
+    assert "Plugin Sample" in plugin_payload["labels"]

--- a/tests/test_5149_settings_search_ranking.py
+++ b/tests/test_5149_settings_search_ranking.py
@@ -1,0 +1,566 @@
+"""Browserless behavioral coverage for settings search ranking."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+PANELS_JS = ROOT / "static" / "panels.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(
+    NODE is None,
+    reason="node is required to execute browserless settings-search ranking harness",
+)
+
+
+_DRIVER = r"""
+const fs = require('fs');
+
+const panelsPath = process.argv[2];
+const scenario = JSON.parse(process.argv[3] || '{}');
+const src = fs.readFileSync(panelsPath, 'utf8');
+
+function extractSearchFunctions(source) {
+  const start = source.indexOf('function _normalizeSettingsSearchText(value)');
+  if (start < 0) throw new Error('missing settings search helpers');
+  const endMarker = 'function _navigateToSettingsField(entry)';
+  const end = source.indexOf(endMarker, start);
+  if (end < 0) throw new Error('missing end marker before _navigateToSettingsField');
+  return source.slice(start, end);
+}
+
+function normalizeText(value) {
+  return String(value || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function parseDataAttributeName(name) {
+  return String(name || '')
+    .split('-')
+    .map((part, index) => index === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+function createClassList(owner) {
+  const tokens = new Set();
+  const update = (value) => {
+    owner._className = Array.from(tokens).join(' ');
+  };
+  return {
+    contains(name) {
+      return tokens.has(name);
+    },
+    add(name) {
+      if (!name) return;
+      const token = String(name).trim();
+      if (!token) return;
+      tokens.add(token);
+      update();
+    },
+    remove(name) {
+      tokens.delete(String(name));
+      update();
+    },
+    toggle(name, force) {
+      const token = String(name);
+      const enabled = force !== undefined ? force : !tokens.has(token);
+      if (enabled) tokens.add(token);
+      else tokens.delete(token);
+      update();
+      return enabled;
+    },
+    _set(value) {
+      tokens.clear();
+      for (const token of String(value || '').split(/\s+/)) {
+        if (token) tokens.add(token);
+      }
+      update();
+    },
+  };
+}
+
+class FakeElement {
+  constructor(tagName = 'div') {
+    this.tagName = String(tagName || '').toLowerCase();
+    this.children = [];
+    this.parentElement = null;
+    this.parentNode = null;
+    this.attributes = {};
+    this.dataset = {};
+    this.style = {};
+    this.classList = createClassList(this);
+    this.classList._set('');
+    this._text = '';
+    this._innerHTML = '';
+    this._className = '';
+    this.value = '';
+  }
+
+  set id(value) {
+    this._id = String(value || '');
+  }
+
+  get id() {
+    return this._id || '';
+  }
+
+  set className(value) {
+    this._className = String(value || '');
+    this.classList._set(this._className);
+  }
+
+  get className() {
+    return this._className;
+  }
+
+  get textContent() {
+    const childText = this.children.map((child) => child.textContent).filter(Boolean).join(' ');
+    return [this._text, childText].filter(Boolean).join(' ').replace(/\s+/g, ' ').trim();
+  }
+
+  set textContent(value) {
+    this._text = String(value || '');
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = String(value || '');
+  }
+
+  get innerHTML() {
+    return this._innerHTML;
+  }
+
+  setAttribute(name, value) {
+    const key = String(name || '');
+    const v = String(value || '');
+    this.attributes[key] = v;
+    if (key.startsWith('data-')) {
+      this.dataset[parseDataAttributeName(key.slice(5))] = v;
+    }
+    if (key === 'class') this.className = v;
+    if (key === 'id') this.id = v;
+  }
+
+  getAttribute(name) {
+    if (name === 'class') return this.className;
+    if (name === 'id') return this.id;
+    return this.attributes[String(name)] || null;
+  }
+
+  appendChild(child) {
+    if (!child) return child;
+    this.children.push(child);
+    child.parentElement = this;
+    child.parentNode = this;
+    return child;
+  }
+
+  contains(node) {
+    let current = node;
+    while (current) {
+      if (current === this) return true;
+      current = current.parentElement;
+    }
+    return false;
+  }
+
+  closest(selector) {
+    let current = this;
+    while (current) {
+      if (matchesSelector(current, selector)) return current;
+      current = current.parentElement;
+    }
+    return null;
+  }
+
+  querySelectorAll(selector) {
+    return querySelectorAll(this, selector);
+  }
+
+  querySelector(selector) {
+    const found = this.querySelectorAll(selector);
+    return found[0] || null;
+  }
+
+  addEventListener() {}
+}
+
+function allNodes(root) {
+  const nodes = [root];
+  for (const child of root.children || []) {
+    nodes.push(...allNodes(child));
+  }
+  return nodes;
+}
+
+function isNodeMatch(node, selector) {
+  if (!node || !selector) return false;
+  const tagOnly = selector.match(/^([a-z0-9-]+)$/i);
+  if (selector === '*') return true;
+  if (selector === '[data-i18n]') {
+    return !!(node.dataset && node.dataset.i18n);
+  }
+  if (selector.startsWith('[') && selector.endsWith(']')) {
+    const body = selector.slice(1, -1);
+    const [key, expected] = body.split('=').map((it) => it.trim());
+    const actual = key.startsWith('data-')
+      ? (node.dataset ? node.dataset[parseDataAttributeName(key.slice(5))] : null)
+      : (node.getAttribute ? node.getAttribute(key) : null);
+    if (expected === undefined) return !!actual;
+    const expectedValue = expected.replace(/^["']|["']$/g, '');
+    return actual === expectedValue;
+  }
+  if (selector.startsWith('.')) {
+    return node.classList.contains(selector.slice(1));
+  }
+  const withAttr = selector.match(/^([a-z0-9-]+)\[([^\]]+)\]$/i);
+  if (withAttr) {
+    const tag = withAttr[1].toLowerCase();
+    const attr = withAttr[2];
+    if (node.tagName !== tag) return false;
+    if (attr === 'data-i18n') return !!(node.dataset && node.dataset.i18n);
+    return !!node.getAttribute(attr);
+  }
+  return node.tagName === selector.toLowerCase();
+}
+
+function matchesSelector(node, selector) {
+  const value = selector.trim();
+  if (!value.includes(' ')) return isNodeMatch(node, value);
+  const [ancestorSelector, targetSelector] = value.split(/\s+/);
+  if (!ancestorSelector || !targetSelector) return false;
+  const ancestors = allNodes(node);
+  for (const candidate of ancestors) {
+    if (!isNodeMatch(candidate, ancestorSelector)) continue;
+    for (const child of allNodes(candidate).slice(1)) {
+      if (isNodeMatch(child, targetSelector)) return true;
+    }
+  }
+  return false;
+}
+
+function querySelectorAll(node, selector) {
+  const parts = selector.split(',').map((part) => part.trim()).filter(Boolean);
+  const found = [];
+  const seen = new Set();
+  for (const part of parts) {
+    if (part.includes(' ')) {
+      const [ancestorSelector, targetSelector] = part.split(/\s+/);
+      for (const candidate of allNodes(node)) {
+        if (!isNodeMatch(candidate, ancestorSelector)) continue;
+        for (const child of allNodes(candidate).slice(1)) {
+          if (!isNodeMatch(child, targetSelector)) continue;
+          if (!seen.has(child)) {
+            seen.add(child);
+            found.push(child);
+          }
+        }
+      }
+      continue;
+    }
+    for (const candidate of allNodes(node)) {
+      if (!isNodeMatch(candidate, part)) continue;
+      if (!seen.has(candidate)) {
+        seen.add(candidate);
+        found.push(candidate);
+      }
+    }
+  }
+  return found;
+}
+
+const registry = new Map();
+
+function register(node) {
+  if (node && node.id) registry.set(node.id, node);
+  return node;
+}
+
+function $(id) {
+  return registry.get(id) || null;
+}
+
+function createElement(tagName) {
+  return new FakeElement(tagName);
+}
+
+function makePane(id) {
+  return register(Object.assign(createElement('div'), { id }));
+}
+
+function makeLabel(text) {
+  const label = createElement('label');
+  label.textContent = text;
+  return label;
+}
+
+function makeSettingsField({
+  labelText,
+  descriptionText = '',
+  descriptionI18nKey = '',
+  settingsSearch = '',
+  options = [],
+}) {
+  const field = createElement('div');
+  field.className = 'settings-field';
+  if (settingsSearch) field.dataset.settingsSearch = settingsSearch;
+  const label = makeLabel(labelText);
+  field.appendChild(label);
+  if (options.length) {
+    const select = createElement('select');
+    for (const optionText of options) {
+      const option = createElement('option');
+      option.textContent = optionText;
+      select.appendChild(option);
+    }
+    field.appendChild(select);
+  }
+  if (descriptionText || descriptionI18nKey) {
+    const description = createElement('div');
+    if (descriptionI18nKey) description.dataset.i18n = descriptionI18nKey;
+    description.textContent = descriptionText || '';
+    field.appendChild(description);
+  }
+  return field;
+}
+
+function makeProviderCard(name) {
+  const card = createElement('div');
+  card.className = 'provider-card';
+  const cardName = createElement('div');
+  cardName.className = 'provider-card-name';
+  cardName.textContent = name;
+  card.appendChild(cardName);
+  return card;
+}
+
+function makeProviderField(cardName, fieldLabel, valueText) {
+  const field = createElement('div');
+  field.className = 'provider-card-field';
+  const label = createElement('div');
+  label.className = 'provider-card-label';
+  label.textContent = fieldLabel;
+  field.appendChild(label);
+  if (valueText) {
+    const input = createElement('input');
+    input.value = valueText;
+    field.appendChild(input);
+  }
+  return field;
+}
+
+function makePluginCard(name) {
+  const card = createElement('div');
+  card.className = 'provider-card plugin-card';
+  const cardName = createElement('div');
+  cardName.className = 'provider-card-name';
+  cardName.textContent = name;
+  card.appendChild(cardName);
+  return card;
+}
+
+function setupDom(mode) {
+  const conversation = makePane('settingsPaneConversation');
+  const providers = makePane('settingsPaneProviders');
+  const plugins = makePane('settingsPanePlugins');
+  register(createElement('div')).id = 'settingsPaneAppearance';
+  register(createElement('div')).id = 'settingsPanePreferences';
+  register(createElement('div')).id = 'settingsPaneExtensions';
+  register(createElement('div')).id = 'settingsPaneSystem';
+  register(createElement('div')).id = 'settingsPaneHelp';
+  const settingsSearch = createElement('input');
+  settingsSearch.id = 'settingsSearch';
+  register(settingsSearch);
+  const results = createElement('div');
+  results.id = 'settingsSearchResults';
+  register(results);
+
+  if (mode === 'title-vs-description') {
+    conversation.appendChild(makeSettingsField({
+      labelText: 'Descriptor-only field',
+      descriptionText: 'this contains priority in the descriptor',
+    }));
+    conversation.appendChild(makeSettingsField({
+      labelText: 'Priority title field',
+      descriptionText: 'nothing about query there',
+    }));
+  } else if (mode === 'value-vs-description') {
+    conversation.appendChild(makeSettingsField({
+      labelText: 'Value-later field',
+      descriptionText: 'contains rank token in descriptor only',
+    }));
+    conversation.appendChild(makeSettingsField({
+      labelText: 'Value field',
+      options: ['rank-value option'],
+    }));
+  } else if (mode === 'same-tier-order') {
+    conversation.appendChild(makeSettingsField({
+      labelText: 'Description-first',
+      descriptionText: 'first field has needle around index 5',
+    }));
+    conversation.appendChild(makeSettingsField({
+      labelText: 'Description-second',
+      descriptionText: 'second field has the needle a little later in the text',
+    }));
+  } else if (mode === 'label-rendering') {
+    conversation.appendChild(makeSettingsField({
+      labelText: 'Visible Label',
+      options: ['token-label-option'],
+      descriptionText: 'description with token-label-option',
+    }));
+  } else if (mode === 'twelve-result-cap') {
+    for (let i = 0; i < 13; i++) {
+      conversation.appendChild(makeSettingsField({
+        labelText: `Entry ${String(i + 1).padStart(2, '0')}`,
+        descriptionText: `shared token for cap ${i}`,
+      }));
+    }
+  } else if (mode === 'provider-plugin') {
+    conversation.appendChild(makeSettingsField({
+      labelText: 'Conversation field',
+      descriptionText: 'provider plugin terms plugin',
+    }));
+    const providerCard = makeProviderCard('Provider Alpha');
+    providerCard.appendChild(makeProviderField('provider', 'API Key', 'sk-test'));
+    providers.appendChild(providerCard);
+    plugins.appendChild(makePluginCard('Plugin Sample'));
+  }
+
+  return {
+    conversation,
+    providers,
+    plugins,
+  };
+}
+
+function runScenario(command) {
+  setupDom(command);
+  return new Promise(async (resolve, reject) => {
+    try {
+      const block = extractSearchFunctions(src);
+      eval(block);
+      globalThis.$ = $;
+      globalThis.document = {
+        createElement: createElement,
+      };
+      globalThis.t = (key) => {
+        const translations = {
+          settings_tab_conversation: 'Conversation',
+          settings_tab_appearance: 'Appearance',
+          settings_tab_preferences: 'Preferences',
+          providers_tab_title: 'Providers',
+          settings_tab_plugins: 'Plugins',
+          settings_tab_extensions: 'Extensions',
+          settings_tab_system: 'System',
+          settings_tab_help: 'Help',
+        };
+        return translations[key] || String(key || '');
+      };
+      globalThis.esc = (value) => String(value || '');
+      globalThis.loadProvidersPanel = async () => undefined;
+      globalThis.loadPluginsPanel = async () => undefined;
+      globalThis.loadExtensionsPanel = async () => undefined;
+      globalThis._settingsIndex = null;
+      globalThis._settingsIndexPromise = null;
+      globalThis._settingsSearchSeq = 0;
+
+      let query = '';
+      if (command === 'title-vs-description') query = 'priority';
+      else if (command === 'value-vs-description') query = 'rank';
+      else if (command === 'same-tier-order') query = 'needle';
+      else if (command === 'label-rendering') query = 'token-label-option';
+      else if (command === 'twelve-result-cap') query = 'shared';
+      else if (command === 'provider-plugin') query = 'plugin';
+      await filterSettings(query);
+
+      const results = $('settingsSearchResults');
+      const labels = [];
+      const html = results.innerHTML || '';
+      for (const child of results.children || []) {
+        if (!child || typeof child.innerHTML !== 'string') continue;
+        const re = /<span class=\"settings-search-label\">([^<]*)<\/span>/g;
+        let match;
+        while ((match = re.exec(child.innerHTML)) !== null) labels.push(match[1]);
+      }
+      resolve({
+        query,
+        labels,
+        html,
+        resultCount: (results.children || []).length,
+        noResults: html.includes('settings-search-empty'),
+      });
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+(async () => {
+  const payload = await runScenario(scenario.command);
+  process.stdout.write(JSON.stringify(payload));
+})();
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    return str(tmp_path_factory.mktemp("settings-search-ranking-driver") / "driver.js")
+
+
+@pytest.fixture
+def driver_file(driver_path):
+    Path(driver_path).write_text(_DRIVER, encoding="utf-8")
+    return driver_path
+
+
+def _run_driver(driver_file, command):
+    process = subprocess.run(
+        [NODE, driver_file, str(PANELS_JS), json.dumps({"command": command})],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+    if process.returncode != 0:
+        raise RuntimeError(process.stderr.strip() or process.stdout.strip())
+    return json.loads(process.stdout)
+
+
+def test_title_matches_outrank_descriptor_only(driver_file):
+    payload = _run_driver(driver_file, "title-vs-description")
+    assert payload["labels"][0] == "Priority title field"
+    assert not payload["noResults"]
+
+
+def test_value_or_option_match_outranks_descriptor_match(driver_file):
+    payload = _run_driver(driver_file, "value-vs-description")
+    assert payload["labels"][0] == "Value field"
+    assert not payload["noResults"]
+
+
+def test_same_tier_order_uses_prefix_and_earlier_index(driver_file):
+    payload = _run_driver(driver_file, "same-tier-order")
+    assert payload["labels"][0] == "Description-first"
+    assert payload["labels"][1] == "Description-second"
+
+
+def test_rendered_label_is_visible_field_title(driver_file):
+    payload = _run_driver(driver_file, "label-rendering")
+    assert payload["labels"][0] == "Visible Label"
+
+
+def test_results_cap_still_applies_to_ranked_matches(driver_file):
+    payload = _run_driver(driver_file, "twelve-result-cap")
+    assert payload["resultCount"] == 12
+    assert not payload["noResults"]
+
+
+def test_provider_and_plugin_cards_remain_searchable(driver_file):
+    payload = _run_driver(driver_file, "provider-plugin")
+    assert "Plugin Sample" in payload["labels"]

--- a/tests/test_5149_settings_search_ranking.py
+++ b/tests/test_5149_settings_search_ranking.py
@@ -383,12 +383,12 @@ function setupDom(mode) {
 
   if (mode === 'title-vs-description') {
     conversation.appendChild(makeSettingsField({
-      labelText: 'Descriptor-only field',
-      descriptionI18nKey: 'settings_desc_priority_only',
-    }));
-    conversation.appendChild(makeSettingsField({
       labelText: 'Blob field',
       descriptionText: 'priority appears only in this plain-text fallback',
+    }));
+    conversation.appendChild(makeSettingsField({
+      labelText: 'Descriptor-only field',
+      descriptionI18nKey: 'settings_desc_priority_only',
     }));
     conversation.appendChild(makeSettingsField({
       labelText: 'Priority title field',
@@ -396,12 +396,12 @@ function setupDom(mode) {
     }));
   } else if (mode === 'value-vs-description') {
     conversation.appendChild(makeSettingsField({
-      labelText: 'Value-later field',
-      descriptionI18nKey: 'settings_desc_rank_only',
-    }));
-    conversation.appendChild(makeSettingsField({
       labelText: 'Blob value field',
       descriptionText: 'rank only lives in this plain-text fallback text',
+    }));
+    conversation.appendChild(makeSettingsField({
+      labelText: 'Value-later field',
+      descriptionI18nKey: 'settings_desc_rank_only',
     }));
     conversation.appendChild(makeSettingsField({
       labelText: 'Value field',
@@ -409,16 +409,16 @@ function setupDom(mode) {
     }));
   } else if (mode === 'same-tier-order') {
     conversation.appendChild(makeSettingsField({
+      labelText: 'Description-later-contains',
+      descriptionI18nKey: 'settings_desc_needle_contains_late',
+    }));
+    conversation.appendChild(makeSettingsField({
       labelText: 'Description-prefix',
       descriptionI18nKey: 'settings_desc_needle_prefix',
     }));
     conversation.appendChild(makeSettingsField({
       labelText: 'Description-earlier-contains',
       descriptionI18nKey: 'settings_desc_needle_contains_early',
-    }));
-    conversation.appendChild(makeSettingsField({
-      labelText: 'Description-later-contains',
-      descriptionI18nKey: 'settings_desc_needle_contains_late',
     }));
   } else if (mode === 'label-rendering') {
     conversation.appendChild(makeSettingsField({

--- a/tests/test_cli_only_slash_commands.py
+++ b/tests/test_cli_only_slash_commands.py
@@ -101,6 +101,14 @@ def _run_commands_js(script_body: str) -> dict:
             if (path === '/api/commands') return {{
               commands: [
                 {{
+                  name: 'pet',
+                  description: 'Desktop Companion command',
+                  category: 'Tools',
+                  aliases: [],
+                  cli_only: true,
+                  gateway_only: false
+                }},
+                {{
                   name: 'browser',
                   description: 'Attach browser tools',
                   category: 'Tools',
@@ -312,6 +320,7 @@ def test_cli_only_slugs_reserve_skill_autocomplete_namespace():
         return {
           pet_names: pet.map(item => item.name),
           pet_sources: pet.map(item => item.source),
+          pet_descs: pet.map(item => item.desc),
           browser_names: browser.map(item => item.name),
           handoff_names: handoff.map(item => item.name),
           delegate_names: delegate.map(item => item.name),
@@ -329,6 +338,7 @@ def test_cli_only_slugs_reserve_skill_autocomplete_namespace():
 
     assert result["pet_names"] == ["pet"]
     assert result["pet_sources"] == ["agent"]
+    assert result["pet_descs"] == ["Desktop Companion command"]
     assert result["browser_names"] == []
     assert result["handoff_names"] == []
     assert result["delegate_names"] == []

--- a/tests/test_cli_only_slash_commands.py
+++ b/tests/test_cli_only_slash_commands.py
@@ -300,6 +300,8 @@ def test_cli_only_slugs_reserve_skill_autocomplete_namespace():
         await loadAgentCommandMetadata(true);
         await loadBundleCommands(true);
         await loadSkillCommands(true);
+        const pet = await getSlashAutocompleteMatches('/pet');
+        const browser = await getSlashAutocompleteMatches('/bro');
         const handoff = await getSlashAutocompleteMatches('/handoff');
         const delegate = await getSlashAutocompleteMatches('/delegate');
         const incident = await getSlashAutocompleteMatches('/incident');
@@ -308,6 +310,9 @@ def test_cli_only_slugs_reserve_skill_autocomplete_namespace():
         const skills = await getSlashAutocompleteMatches('/skills');
         const use = await getSlashAutocompleteMatches('/use');
         return {
+          pet_names: pet.map(item => item.name),
+          pet_sources: pet.map(item => item.source),
+          browser_names: browser.map(item => item.name),
           handoff_names: handoff.map(item => item.name),
           delegate_names: delegate.map(item => item.name),
           incident_names: incident.map(item => item.name),
@@ -322,6 +327,9 @@ def test_cli_only_slugs_reserve_skill_autocomplete_namespace():
         """
     )
 
+    assert result["pet_names"] == ["pet"]
+    assert result["pet_sources"] == ["agent"]
+    assert result["browser_names"] == []
     assert result["handoff_names"] == []
     assert result["delegate_names"] == []
     assert result["incident_names"] == ["incident-review"]

--- a/tests/test_issue4843_pet_webui_command.py
+++ b/tests/test_issue4843_pet_webui_command.py
@@ -73,6 +73,140 @@ def _run_pet_js(*, status, adapter_status=None, hook_result=None, hook_throws=Fa
     return json.loads(proc.stdout)
 
 
+def _run_send_js(*, command, status, adapter_status=None):
+    script = textwrap.dedent(
+        f"""
+        const vm = require('vm');
+        const msgInput = {{
+          value: {json.dumps(command)},
+          style: {{}},
+          scrollHeight: 0,
+          addEventListener(){{}},
+          removeEventListener(){{}},
+          focus(){{}},
+          blur(){{}},
+          setSelectionRange(){{}},
+        }};
+        const commandExecCalls = [];
+        const genericEl = {{
+          addEventListener(){{}},
+          removeEventListener(){{}},
+          classList: {{ add(){{}}, remove(){{}} }},
+          style: {{}},
+          dataset: {{}},
+          value: '',
+          textContent: '',
+          innerHTML: '',
+        }};
+        const ctx = {{
+          console,
+          window: {{
+            __HERMES_WEBUI_DESKTOP_COMPANION_STATUS__: {json.dumps(adapter_status)},
+            addEventListener(){{}},
+            requestAnimationFrame(cb){{ return 1; }},
+          }},
+          document: {{
+            addEventListener(){{}},
+            getElementById(id){{ return id === 'msg' ? msgInput : genericEl; }},
+            querySelector(){{ return null; }},
+          }},
+          localStorage: {{ getItem(){{return null;}}, setItem(){{}}, removeItem(){{}} }},
+          t: key => key,
+          S: {{
+            busy: false,
+            session: null,
+            pendingFiles: [],
+            messages: [],
+            activeProfile: 'default',
+            activeStreamId: null,
+          }},
+          INFLIGHT: {{}},
+          _pendingSelections: [],
+          _sendInProgress: false,
+          _sendInProgressSid: null,
+          _composerTextWithPendingSelections(){{ return msgInput.value; }},
+          _flushSelectionBlocksToComposer(){{}},
+          _dismissHandoffHint(){{}},
+          _clearStaleBusyStateBeforeSend(){{ return false; }},
+          _clearComposerAfterQueuedSelectionSend(){{}},
+          _chatPayloadModelState(){{ return {{ model: '', model_provider: '' }}; }},
+          queueSessionMessage(){{}},
+          updateQueueBadge(){{}},
+          renderTray(){{}},
+          showToast(){{}},
+          renderMessages(){{}},
+          renderSessionList(){{}},
+          autoResize(){{}},
+          hideCmdDropdown(){{}},
+          syncTopbar(){{}},
+          setBusy(){{}},
+          setComposerStatus(){{}},
+          setStatus(){{}},
+          updateSendBtn(){{}},
+          clearOptimisticSessionStreaming(){{}},
+          newSession: async () => {{
+            ctx.S.session = {{ session_id: 'sid-1', title: 'New Chat' }};
+          }},
+          $: id => {{
+            if (id === 'msg') return msgInput;
+            return genericEl;
+          }},
+          api: async (path, options) => {{
+            if (path === '/api/commands') return {{
+              commands: [
+                {{
+                  name: 'pet',
+                  description: 'Desktop Companion command',
+                  category: 'Tools',
+                  aliases: [],
+                  cli_only: true,
+                  gateway_only: false
+                }},
+                {{
+                  name: 'browser',
+                  description: 'Attach browser tools',
+                  category: 'Tools',
+                  aliases: ['browse'],
+                  cli_only: true,
+                  gateway_only: false
+                }}
+              ]
+            }};
+            if (path === '/api/extensions/status') return {json.dumps(status)};
+            if (path === '/api/commands/exec') {{
+              commandExecCalls.push(JSON.parse(options.body).command);
+              return {{ output: 'unexpected exec' }};
+            }}
+            throw new Error('unexpected api path: ' + path);
+          }},
+        }};
+        ctx.window.window = ctx.window;
+        vm.createContext(ctx);
+        vm.runInContext({json.dumps(COMMANDS_JS)}, ctx);
+        vm.runInContext({json.dumps(MESSAGES_JS)}, ctx);
+        (async () => {{
+          await vm.runInContext('send()', ctx);
+          process.stdout.write(JSON.stringify({{
+            messages: ctx.S.messages,
+            commandExecCalls,
+            remainingInput: msgInput.value,
+          }}));
+        }})().catch(err => {{
+          console.error(err && err.stack || err);
+          process.exit(1);
+        }});
+        """
+    )
+    with tempfile.NamedTemporaryFile("w", suffix=".js", encoding="utf-8", delete=False) as handle:
+        handle.write(script)
+        script_path = Path(handle.name)
+    try:
+        proc = subprocess.run(["node", str(script_path)], check=True, capture_output=True, text=True)
+    finally:
+        script_path.unlink(missing_ok=True)
+    return json.loads(proc.stdout)
+
+
 def test_pet_help_routes_to_install_guidance_when_companion_is_missing():
     result = _run_pet_js(
         status={"enabled": False, "extensions": [], "gallery_installed": {}},
@@ -233,12 +367,23 @@ def test_pet_help_falls_back_when_hook_is_missing_or_fails():
 
 
 def test_pet_slash_intercept_bypasses_generic_agent_execution():
-    intercept_idx = MESSAGES_JS.find("Slash command intercept")
-    normal_send_idx = MESSAGES_JS.find("const activeSid=S.session.session_id", intercept_idx)
-    assert intercept_idx != -1
-    assert normal_send_idx != -1
-    intercept = MESSAGES_JS[intercept_idx:normal_send_idx]
+    pet = _run_send_js(
+        command="/pet feed tuna",
+        status={"enabled": False, "extensions": []},
+        adapter_status=None,
+    )
+    browser = _run_send_js(
+        command="/browser open",
+        status={"enabled": False, "extensions": []},
+        adapter_status=None,
+    )
 
-    assert "if(_parsedCmd.name==='pet')" in intercept
-    assert "handlePetSlashCommand(text,{name:'pet'})" in intercept
-    assert "executeAgentCommand(text,_agentCmd||{name:_agentCmdName})" in intercept
+    assert [item["role"] for item in pet["messages"]] == ["user", "assistant"]
+    assert "Desktop Companion is not installed yet." in pet["messages"][1]["content"]
+    assert "Hermes CLI-only command" not in pet["messages"][1]["content"]
+    assert pet["commandExecCalls"] == []
+    assert pet["remainingInput"] == ""
+
+    assert [item["role"] for item in browser["messages"]] == ["user", "assistant"]
+    assert "`/browser` is a Hermes CLI-only command" in browser["messages"][1]["content"]
+    assert browser["commandExecCalls"] == []

--- a/tests/test_issue4843_pet_webui_command.py
+++ b/tests/test_issue4843_pet_webui_command.py
@@ -324,6 +324,36 @@ def test_pet_help_hands_off_to_desktop_companion_hook_when_connected():
     ]
 
 
+def test_pet_help_treats_truthy_hook_result_as_handled():
+    result = _run_pet_js(
+        status={
+            "enabled": True,
+            "extensions": [
+                {
+                    "id": "desktop-companion",
+                    "name": "Desktop Companion",
+                    "effective_enabled": True,
+                    "user_disabled": False,
+                    "status": "enabled",
+                }
+            ],
+        },
+        adapter_status={"connected": True},
+        hook_result="mascot handled",
+        command="/pet wave",
+    )
+
+    assert result["result"] == {"handled": True, "message": ""}
+    assert result["hookCalls"] == [
+        {
+            "command": "/pet wave",
+            "args": "wave",
+            "source": "webui-slash-command",
+            "metadata": {"name": "pet"},
+        }
+    ]
+
+
 def test_pet_help_falls_back_when_hook_is_missing_or_fails():
     absent = _run_pet_js(
         status={

--- a/tests/test_issue4843_pet_webui_command.py
+++ b/tests/test_issue4843_pet_webui_command.py
@@ -12,7 +12,15 @@ COMMANDS_JS = (REPO_ROOT / "static" / "commands.js").read_text(encoding="utf-8")
 MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 
 
-def _run_pet_js(*, status, adapter_status=None, hook_result=None, hook_throws=False, command="/pet feed tuna"):
+def _run_pet_js(
+    *,
+    status,
+    adapter_status=None,
+    status_throws=False,
+    hook_result=None,
+    hook_throws=False,
+    command="/pet feed tuna",
+):
     hook_setup = ""
     if hook_throws:
         hook_setup += textwrap.dedent(
@@ -37,17 +45,27 @@ def _run_pet_js(*, status, adapter_status=None, hook_result=None, hook_throws=Fa
         f"""
         const vm = require('vm');
         const hookCalls = [];
+        const consoleErrors = [];
+        const captureConsole = {{
+          ...console,
+          error: (...args) => {{
+            consoleErrors.push(args.map(arg => String(arg && arg.message ? arg.message : arg)).join(' '));
+          }},
+        }};
         const window = {{
           __HERMES_WEBUI_DESKTOP_COMPANION_STATUS__: {json.dumps(adapter_status)},
         }};
         window.window = window;
         const ctx = {{
-          console,
+          console: captureConsole,
           window,
           localStorage: {{ getItem(){{return null;}}, setItem(){{}}, removeItem(){{}} }},
           t: key => key,
           api: async path => {{
-            if (path === '/api/extensions/status') return {json.dumps(status)};
+            if (path === '/api/extensions/status') {{
+              if ({json.dumps(status_throws)}) throw new Error('extensions api failed');
+              return {json.dumps(status)};
+            }}
             throw new Error('unexpected api path: ' + path);
           }},
         }};
@@ -56,7 +74,7 @@ def _run_pet_js(*, status, adapter_status=None, hook_result=None, hook_throws=Fa
         vm.runInContext({json.dumps(COMMANDS_JS)}, ctx);
         (async () => {{
           const result = await vm.runInContext(`(async () => {{ return await handlePetSlashCommand({json.dumps(command)}, {{name:'pet'}}); }})()`, ctx);
-          process.stdout.write(JSON.stringify({{result, hookCalls}}));
+          process.stdout.write(JSON.stringify({{result, hookCalls, consoleErrors}}));
         }})().catch(err => {{
           console.error(err && err.stack || err);
           process.exit(1);
@@ -73,7 +91,24 @@ def _run_pet_js(*, status, adapter_status=None, hook_result=None, hook_throws=Fa
     return json.loads(proc.stdout)
 
 
-def _run_send_js(*, command, status, adapter_status=None):
+def _run_send_js(*, command, status, adapter_status=None, hook_result=None, hook_throws=False):
+    hook_setup = ""
+    if hook_throws:
+        hook_setup += textwrap.dedent(
+            """
+            ctx.window.__hermesHandlePetSlashCommand = async payload => {
+              throw new Error('hook failed');
+            };
+            """
+        )
+    elif hook_result is not None:
+        hook_setup += textwrap.dedent(
+            f"""
+            ctx.window.__hermesHandlePetSlashCommand = async payload => {{
+              return {json.dumps(hook_result)};
+            }};
+            """
+        )
     script = textwrap.dedent(
         f"""
         const vm = require('vm');
@@ -183,6 +218,7 @@ def _run_send_js(*, command, status, adapter_status=None):
         ctx.window.window = ctx.window;
         vm.createContext(ctx);
         vm.runInContext({json.dumps(COMMANDS_JS)}, ctx);
+        {hook_setup}
         vm.runInContext({json.dumps(MESSAGES_JS)}, ctx);
         (async () => {{
           await vm.runInContext('send()', ctx);
@@ -313,7 +349,7 @@ def test_pet_help_hands_off_to_desktop_companion_hook_when_connected():
         command="/pet   feed  tuna  ",
     )
 
-    assert result["result"] == {"handled": True, "message": ""}
+    assert result["result"] == {"handled": True, "message": "mascot handled"}
     assert result["hookCalls"] == [
         {
             "command": "/pet   feed  tuna  ",
@@ -354,8 +390,22 @@ def test_pet_help_treats_truthy_hook_result_as_handled():
     ]
 
 
-def test_pet_help_falls_back_when_hook_is_missing_or_fails():
-    absent = _run_pet_js(
+def test_pet_help_routes_to_status_error_when_extension_status_api_fails():
+    result = _run_pet_js(
+        status={"enabled": False, "extensions": []},
+        status_throws=True,
+        adapter_status=None,
+    )
+
+    assert result["result"]["handled"] is False
+    assert result["result"]["message"] == (
+        "Desktop Companion status is unavailable right now.\n\n"
+        "Reload WebUI or check your connection, then retry /pet."
+    )
+
+
+def test_pet_help_falls_back_to_unavailable_guidance_when_hook_is_missing():
+    result = _run_pet_js(
         status={
             "enabled": True,
             "extensions": [
@@ -370,7 +420,17 @@ def test_pet_help_falls_back_when_hook_is_missing_or_fails():
         },
         adapter_status={"connected": True},
     )
-    failed = _run_pet_js(
+
+    message = result["result"]["message"]
+    assert result["result"]["handled"] is False
+    assert "Desktop Companion is installed and connected" in message
+    assert "/pet is not available yet in this Desktop Companion version" in message
+    assert "Update the Desktop Companion app" in message
+    assert "https://github.com/franksong2702/hermes-webui-desktop-companion#after-gallery-install" in message
+
+
+def test_pet_help_routes_to_hook_error_guidance_when_hook_throws():
+    result = _run_pet_js(
         status={
             "enabled": True,
             "extensions": [
@@ -387,13 +447,13 @@ def test_pet_help_falls_back_when_hook_is_missing_or_fails():
         hook_throws=True,
     )
 
-    for result in (absent, failed):
-        message = result["result"]["message"]
-        assert result["result"]["handled"] is False
-        assert "Desktop Companion is installed and connected" in message
-        assert "/pet is not available yet in this Desktop Companion version" in message
-        assert "Update the Desktop Companion app" in message
-        assert "https://github.com/franksong2702/hermes-webui-desktop-companion#after-gallery-install" in message
+    assert result["result"]["handled"] is False
+    assert result["result"]["message"] == (
+        "Desktop Companion is installed and connected, but it hit an error while handling /pet.\n\n"
+        "Check the browser console and the Desktop Companion app, then retry /pet."
+    )
+    assert any("Desktop Companion /pet hook error:" in entry for entry in result["consoleErrors"])
+    assert any("hook failed" in entry for entry in result["consoleErrors"])
 
 
 def test_pet_slash_intercept_bypasses_generic_agent_execution():
@@ -417,3 +477,52 @@ def test_pet_slash_intercept_bypasses_generic_agent_execution():
     assert [item["role"] for item in browser["messages"]] == ["user", "assistant"]
     assert "`/browser` is a Hermes CLI-only command" in browser["messages"][1]["content"]
     assert browser["commandExecCalls"] == []
+
+
+def test_pet_send_uses_extension_message_when_hook_returns_one():
+    result = _run_send_js(
+        command="/pet feed tuna",
+        status={
+            "enabled": True,
+            "extensions": [
+                {
+                    "id": "desktop-companion",
+                    "name": "Desktop Companion",
+                    "effective_enabled": True,
+                    "user_disabled": False,
+                    "status": "enabled",
+                }
+            ],
+        },
+        adapter_status={"connected": True},
+        hook_result={"handled": True, "message": "mascot handled"},
+    )
+
+    assert [item["role"] for item in result["messages"]] == ["user", "assistant"]
+    assert result["messages"][1]["content"] == "mascot handled"
+    assert result["commandExecCalls"] == []
+    assert result["remainingInput"] == ""
+
+
+def test_pet_send_leaves_chat_reply_to_extension_when_hook_handles_silently():
+    result = _run_send_js(
+        command="/pet wave",
+        status={
+            "enabled": True,
+            "extensions": [
+                {
+                    "id": "desktop-companion",
+                    "name": "Desktop Companion",
+                    "effective_enabled": True,
+                    "user_disabled": False,
+                    "status": "enabled",
+                }
+            ],
+        },
+        adapter_status={"connected": True},
+        hook_result=True,
+    )
+
+    assert [item["role"] for item in result["messages"]] == ["user"]
+    assert result["commandExecCalls"] == []
+    assert result["remainingInput"] == ""

--- a/tests/test_issue4843_pet_webui_command.py
+++ b/tests/test_issue4843_pet_webui_command.py
@@ -1,0 +1,244 @@
+"""Regression tests for the WebUI /pet handoff."""
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMMANDS_JS = (REPO_ROOT / "static" / "commands.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+
+
+def _run_pet_js(*, status, adapter_status=None, hook_result=None, hook_throws=False, command="/pet feed tuna"):
+    hook_setup = ""
+    if hook_throws:
+        hook_setup += textwrap.dedent(
+            """
+            ctx.window.__hermesHandlePetSlashCommand = async payload => {
+              hookCalls.push(payload);
+              throw new Error('hook failed');
+            };
+            """
+        )
+    elif hook_result is not None:
+        hook_setup += textwrap.dedent(
+            f"""
+            ctx.window.__hermesHandlePetSlashCommand = async payload => {{
+              hookCalls.push(payload);
+              return {json.dumps(hook_result)};
+            }};
+            """
+        )
+
+    script = textwrap.dedent(
+        f"""
+        const vm = require('vm');
+        const hookCalls = [];
+        const window = {{
+          __HERMES_WEBUI_DESKTOP_COMPANION_STATUS__: {json.dumps(adapter_status)},
+        }};
+        window.window = window;
+        const ctx = {{
+          console,
+          window,
+          localStorage: {{ getItem(){{return null;}}, setItem(){{}}, removeItem(){{}} }},
+          t: key => key,
+          api: async path => {{
+            if (path === '/api/extensions/status') return {json.dumps(status)};
+            throw new Error('unexpected api path: ' + path);
+          }},
+        }};
+        {hook_setup}
+        vm.createContext(ctx);
+        vm.runInContext({json.dumps(COMMANDS_JS)}, ctx);
+        (async () => {{
+          const result = await vm.runInContext(`(async () => {{ return await handlePetSlashCommand({json.dumps(command)}, {{name:'pet'}}); }})()`, ctx);
+          process.stdout.write(JSON.stringify({{result, hookCalls}}));
+        }})().catch(err => {{
+          console.error(err && err.stack || err);
+          process.exit(1);
+        }});
+        """
+    )
+    with tempfile.NamedTemporaryFile("w", suffix=".js", encoding="utf-8", delete=False) as handle:
+        handle.write(script)
+        script_path = Path(handle.name)
+    try:
+        proc = subprocess.run(["node", str(script_path)], check=True, capture_output=True, text=True)
+    finally:
+        script_path.unlink(missing_ok=True)
+    return json.loads(proc.stdout)
+
+
+def test_pet_help_routes_to_install_guidance_when_companion_is_missing():
+    result = _run_pet_js(
+        status={"enabled": False, "extensions": [], "gallery_installed": {}},
+        adapter_status=None,
+    )
+
+    assert result["result"]["handled"] is False
+    message = result["result"]["message"]
+    assert "Desktop Companion is not installed yet." in message
+    assert "Settings -> Extensions -> Gallery -> Desktop Companion" in message
+    assert "https://github.com/franksong2702/hermes-webui-desktop-companion#after-gallery-install" in message
+    assert "Desktop Companion app" in message
+
+
+def test_pet_help_routes_to_enable_guidance_when_companion_is_disabled():
+    result = _run_pet_js(
+        status={
+            "enabled": True,
+            "extensions": [
+                {
+                    "id": "desktop-companion",
+                    "name": "Desktop Companion",
+                    "effective_enabled": False,
+                    "user_disabled": True,
+                    "status": "user_disabled",
+                }
+            ],
+        },
+        adapter_status=None,
+    )
+
+    assert result["result"]["handled"] is False
+    message = result["result"]["message"]
+    assert "Desktop Companion is installed but disabled." in message
+    assert "Enable it in Settings -> Extensions" in message
+    assert "Desktop Companion app" in message
+    assert "https://github.com/franksong2702/hermes-webui-desktop-companion#after-gallery-install" in message
+
+
+def test_pet_help_routes_to_reload_and_start_guidance_when_adapter_status_is_missing():
+    result = _run_pet_js(
+        status={
+            "enabled": True,
+            "extensions": [
+                {
+                    "id": "desktop-companion",
+                    "name": "Desktop Companion",
+                    "effective_enabled": True,
+                    "user_disabled": False,
+                    "status": "enabled",
+                }
+            ],
+        },
+        adapter_status=None,
+    )
+
+    assert result["result"]["handled"] is False
+    message = result["result"]["message"]
+    assert "adapter status is not loaded yet" in message
+    assert "Reload WebUI if you just enabled it" in message
+    assert "Desktop Companion app" in message
+
+
+def test_pet_help_routes_to_connect_guidance_when_adapter_is_not_connected():
+    result = _run_pet_js(
+        status={
+            "enabled": True,
+            "extensions": [
+                {
+                    "id": "desktop-companion",
+                    "name": "Desktop Companion",
+                    "effective_enabled": True,
+                    "user_disabled": False,
+                    "status": "enabled",
+                }
+            ],
+        },
+        adapter_status={"connected": False},
+    )
+
+    assert result["result"]["handled"] is False
+    message = result["result"]["message"]
+    assert "local app is not connected yet" in message
+    assert "Start or connect the Desktop Companion app" in message
+    assert "Setup guide:" in message
+
+
+def test_pet_help_hands_off_to_desktop_companion_hook_when_connected():
+    result = _run_pet_js(
+        status={
+            "enabled": True,
+            "extensions": [
+                {
+                    "id": "desktop-companion",
+                    "name": "Desktop Companion",
+                    "effective_enabled": True,
+                    "user_disabled": False,
+                    "status": "enabled",
+                }
+            ],
+        },
+        adapter_status={"connected": True},
+        hook_result={"handled": True, "message": "mascot handled"},
+        command="/pet   feed  tuna  ",
+    )
+
+    assert result["result"] == {"handled": True, "message": ""}
+    assert result["hookCalls"] == [
+        {
+            "command": "/pet   feed  tuna  ",
+            "args": "feed tuna",
+            "source": "webui-slash-command",
+            "metadata": {"name": "pet"},
+        }
+    ]
+
+
+def test_pet_help_falls_back_when_hook_is_missing_or_fails():
+    absent = _run_pet_js(
+        status={
+            "enabled": True,
+            "extensions": [
+                {
+                    "id": "desktop-companion",
+                    "name": "Desktop Companion",
+                    "effective_enabled": True,
+                    "user_disabled": False,
+                    "status": "enabled",
+                }
+            ],
+        },
+        adapter_status={"connected": True},
+    )
+    failed = _run_pet_js(
+        status={
+            "enabled": True,
+            "extensions": [
+                {
+                    "id": "desktop-companion",
+                    "name": "Desktop Companion",
+                    "effective_enabled": True,
+                    "user_disabled": False,
+                    "status": "enabled",
+                }
+            ],
+        },
+        adapter_status={"connected": True},
+        hook_throws=True,
+    )
+
+    for result in (absent, failed):
+        message = result["result"]["message"]
+        assert result["result"]["handled"] is False
+        assert "Desktop Companion is installed and connected" in message
+        assert "/pet is not available yet in this Desktop Companion version" in message
+        assert "Update the Desktop Companion app" in message
+        assert "https://github.com/franksong2702/hermes-webui-desktop-companion#after-gallery-install" in message
+
+
+def test_pet_slash_intercept_bypasses_generic_agent_execution():
+    intercept_idx = MESSAGES_JS.find("Slash command intercept")
+    normal_send_idx = MESSAGES_JS.find("const activeSid=S.session.session_id", intercept_idx)
+    assert intercept_idx != -1
+    assert normal_send_idx != -1
+    intercept = MESSAGES_JS[intercept_idx:normal_send_idx]
+
+    assert "if(_parsedCmd.name==='pet')" in intercept
+    assert "handlePetSlashCommand(text,{name:'pet'})" in intercept
+    assert "executeAgentCommand(text,_agentCmd||{name:_agentCmdName})" in intercept

--- a/tests/test_issue4843_pet_webui_command.py
+++ b/tests/test_issue4843_pet_webui_command.py
@@ -360,6 +360,36 @@ def test_pet_help_hands_off_to_desktop_companion_hook_when_connected():
     ]
 
 
+def test_pet_help_preserves_explicit_falsy_hook_message_values():
+    result = _run_pet_js(
+        status={
+            "enabled": True,
+            "extensions": [
+                {
+                    "id": "desktop-companion",
+                    "name": "Desktop Companion",
+                    "effective_enabled": True,
+                    "user_disabled": False,
+                    "status": "enabled",
+                }
+            ],
+        },
+        adapter_status={"connected": True},
+        hook_result={"handled": True, "message": 0},
+        command="/pet count snacks",
+    )
+
+    assert result["result"] == {"handled": True, "message": "0"}
+    assert result["hookCalls"] == [
+        {
+            "command": "/pet count snacks",
+            "args": "count snacks",
+            "source": "webui-slash-command",
+            "metadata": {"name": "pet"},
+        }
+    ]
+
+
 def test_pet_help_treats_truthy_hook_result_as_handled():
     result = _run_pet_js(
         status={


### PR DESCRIPTION
## Release v0.51.770 — Priority-queue batch (#5168 #5211)

Two gate-certified, file-disjoint priority-queue PRs (built on v0.51.769). NOTE: #4969 was originally in this batch but **bounced** — the combined-stage Codex gate reproduced 2 silent `?q=` prefill-boot contract bugs (prefill lost after login; `?q=` silently creating a session). Re-gated clean without it.

### Included
- **#5168** (@rodboev) — `/pet` WebUI handoff to the Desktop Companion extension; client-side slash-command intercept, graceful per-stage guidance, XSS-safe (#4843)
- **#5211** (@rodboev) — rank settings-search results by match source (title/label > value/option > description; reorder-only, never drops; cap applied after ranking; XSS-safe) (#5149)

### Gate
- Files disjoint (#5168 commands.js+messages.js; #5211 panels.js).
- **Full pytest suite: 11193 passed** (only the 2 pre-existing `test_scheduled_jobs_profile_isolation.py` serial-ordering artifacts; no cron code here).
- ESLint runtime gate CLEAN, ruff forward gate CLEAN, node --check clean.
- **Codex regression gate: SAFE TO SHIP** (re-gated on the trimmed 2-PR stage after #4969 removal).

CHANGELOG updated under `[Unreleased] → Fixed` with per-author credit.