### PR TITLE
Defer PWA new-chat model hydration

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -2764,7 +2764,14 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
   if(pwaLaunchAction==='new-chat'){
     try{
       await newSession(true);
-      if(S.session) await _startBootModelDropdown();
+      // New-chat PWA launches need the empty conversation visible immediately.
+      // Boot model hydration can take several seconds when /api/models falls
+      // into a cold provider-catalog rebuild; it is already safe to finish in
+      // the background because newSession() posted the configured default and
+      // rendered the session's authoritative model/provider.
+      if(S.session){
+        try{Promise.resolve(_startBootModelDropdown()).catch(()=>{});}catch(_){}
+      }
       S._bootReady=true;
       syncTopbar();syncWorkspacePanelState();await renderSessionList();if(typeof startGatewaySSE==='function')startGatewaySSE();return;
     }catch(e){console.warn('[pwa] new-chat launch action failed', e);}

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -68,6 +68,19 @@ def test_hard_refresh_hydrates_saved_session_model_before_revealing_model_chip()
     )
 
 
+def test_pwa_new_chat_launch_does_not_block_first_paint_on_model_catalog():
+    boot_js = Path("static/boot.js").read_text(encoding="utf-8")
+    launch_marker = "if(pwaLaunchAction==='new-chat'){"
+    assert launch_marker in boot_js
+    launch_branch = boot_js[boot_js.index(launch_marker) : boot_js.index("const savedLocal=localStorage.getItem", boot_js.index(launch_marker))]
+    assert "await newSession(true);" in launch_branch
+    assert "await _startBootModelDropdown();" not in launch_branch
+    assert "Promise.resolve(_startBootModelDropdown()).catch(()=>{})" in launch_branch
+    assert launch_branch.index("Promise.resolve(_startBootModelDropdown()).catch(()=>{})") < launch_branch.index("S._bootReady=true;"), (
+        "PWA new-chat launches should kick model hydration in the background before revealing the empty chat"
+    )
+
+
 def test_hard_refresh_injects_missing_active_session_model_option():
     boot_js = Path("static/boot.js").read_text(encoding="utf-8")
     marker = "if(!applied&&sessionModelState&&typeof _ensureModelOptionInDropdown==='function')"


### PR DESCRIPTION
## Summary
- make PWA/deep-link new-chat launches show the empty conversation immediately
- run boot model dropdown hydration in the background for fresh new-chat launches
- keep saved-session restore model hydration awaited so restored model chips stay correct

## Verification
- `node -c static/boot.js`
- `node -c static/sessions.js`
- `./scripts/test.sh tests/test_new_chat_default_model_frontend.py tests/test_session_metadata_fast_path.py tests/test_profile_switch_ux.py tests/test_issue4728_new_chat_default_model.py tests/test_issue4756_session_visit_model_refresh.py tests/test_issue4755_profile_default_workspace.py -q`
- `git diff --check`
- isolated browser smoke for `?action=new-chat`: empty chat and composer became visible while model hydration remained pending
