### PR TITLE
fix(#5231): unblock Run dispatcher on the default Kanban board

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -2380,10 +2380,6 @@ async function runKanbanDispatcher(){
   // Confirmation dialog first because this actually consumes API budget on
   // each spawned worker.  Result toast surfaces what happened so users see
   // the dispatcher actually doing work.
-  if (!_kanbanCurrentBoard) {
-    showToast(t('kanban_unavailable') || 'Kanban unavailable', 'error');
-    return;
-  }
 
   _kanbanIsDispatching = true;
   _setKanbanDispatcherButtonsDisabled(true);

--- a/tests/js_source_extract.py
+++ b/tests/js_source_extract.py
@@ -1,0 +1,16 @@
+def extract_function(js: str, name: str, prefix: str = "function") -> str:
+    marker = f"{prefix} {name}("
+    start = js.find(marker)
+    assert start >= 0, f"{name} function not found in static/panels.js"
+    brace = js.find("{", start)
+    assert brace >= 0, f"{name} opening brace not found"
+    depth = 1
+    i = brace + 1
+    while i < len(js) and depth > 0:
+        if js[i] == "{":
+            depth += 1
+        elif js[i] == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{name} function braces unbalanced"
+    return js[start:i]

--- a/tests/test_issue5231_default_kanban_dispatch.py
+++ b/tests/test_issue5231_default_kanban_dispatch.py
@@ -1,0 +1,134 @@
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PANELS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _extract_async_function(js: str, name: str) -> str:
+    marker = f"async function {name}("
+    start = js.find(marker)
+    assert start >= 0, f"{name} function not found in static/panels.js"
+    brace = js.find("{", start)
+    assert brace >= 0, f"{name} opening brace not found"
+    depth = 1
+    i = brace + 1
+    while i < len(js) and depth > 0:
+        if js[i] == "{":
+            depth += 1
+        elif js[i] == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{name} function braces unbalanced"
+    return js[start:i]
+
+
+def _run_node(js: str) -> dict:
+    with tempfile.NamedTemporaryFile("w", suffix=".cjs", encoding="utf-8", dir=ROOT, delete=False) as script:
+        script.write(js)
+        script_path = Path(script.name)
+    try:
+        proc = subprocess.run(
+            [NODE, str(script_path)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    finally:
+        script_path.unlink(missing_ok=True)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip())
+    return json.loads(proc.stdout.strip())
+
+
+def _run_dispatcher_case(function_name: str, current_board, confirm: bool) -> dict:
+    fn_source = _extract_async_function(PANELS, function_name)
+    source = f"""
+const fnSource = {json.dumps(fn_source)};
+eval(fnSource);
+
+let _kanbanCurrentBoard = {json.dumps(current_board)};
+let _kanbanIsDispatching = false;
+const apiCalls = [];
+const confirmCalls = [];
+const toastCalls = [];
+const showConfirmDialog = async (opts) => {{
+  confirmCalls.push(opts);
+  return {str(confirm).lower()};
+}};
+const api = async (path, opts = {{}}) => {{
+  apiCalls.push({{ path, method: opts.method || "GET", body: ("body" in opts ? opts.body : null) }});
+  return {{
+    spawned: 1,
+    skipped_unassigned: 0,
+    skipped_nonspawnable: 0,
+    promoted: 0,
+    auto_blocked: 0,
+  }};
+}};
+const showToast = (...args) => {{
+  toastCalls.push(args);
+}};
+const t = (key) => key;
+const _setKanbanDispatcherButtonsDisabled = () => {{}};
+const loadKanban = async () => {{}};
+const _kanbanFormatDispatchResult = () => "ok";
+const document = {{
+  querySelectorAll: () => [],
+}};
+
+(async () => {{
+  try {{
+    await {function_name}();
+    console.log(JSON.stringify({{
+      apiCalls,
+      confirmCalls,
+      toastCalls,
+      ok: true,
+    }}));
+  }} catch (err) {{
+    console.error(err && err.stack ? err.stack : String(err));
+    process.exit(1);
+  }}
+}})();
+"""
+    return _run_node(source)
+
+
+def test_default_board_real_dispatch_sends_boardless_post_when_confirmed():
+    result = _run_dispatcher_case("runKanbanDispatcher", None, True)
+    assert result["confirmCalls"], "expected confirmation dialog"
+    assert result["apiCalls"] == [
+        {"path": "/api/kanban/dispatch?max=8", "method": "POST", "body": None},
+    ]
+
+
+def test_default_board_preview_dispatch_stays_dry_run_and_boardless():
+    result = _run_dispatcher_case("nudgeKanbanDispatcher", None, True)
+    assert result["confirmCalls"] == []
+    assert result["apiCalls"] == [
+        {"path": "/api/kanban/dispatch?dry_run=1&max=8", "method": "POST", "body": None},
+    ]
+
+
+def test_named_board_real_dispatch_preserves_board_parameter():
+    result = _run_dispatcher_case("runKanbanDispatcher", "qa", True)
+    assert result["apiCalls"] == [
+        {"path": "/api/kanban/dispatch?max=8&board=qa", "method": "POST", "body": None},
+    ]
+
+
+def test_confirmation_decline_prevents_real_dispatch_post():
+    result = _run_dispatcher_case("runKanbanDispatcher", None, False)
+    assert result["confirmCalls"], "expected confirmation attempt before dispatch"
+    assert result["apiCalls"] == []

--- a/tests/test_issue5231_default_kanban_dispatch.py
+++ b/tests/test_issue5231_default_kanban_dispatch.py
@@ -6,30 +6,14 @@ from pathlib import Path
 
 import pytest
 
+from tests.js_source_extract import extract_function
+
 
 ROOT = Path(__file__).resolve().parents[1]
 PANELS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 NODE = shutil.which("node")
 
 pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
-
-
-def _extract_async_function(js: str, name: str) -> str:
-    marker = f"async function {name}("
-    start = js.find(marker)
-    assert start >= 0, f"{name} function not found in static/panels.js"
-    brace = js.find("{", start)
-    assert brace >= 0, f"{name} opening brace not found"
-    depth = 1
-    i = brace + 1
-    while i < len(js) and depth > 0:
-        if js[i] == "{":
-            depth += 1
-        elif js[i] == "}":
-            depth -= 1
-        i += 1
-    assert depth == 0, f"{name} function braces unbalanced"
-    return js[start:i]
 
 
 def _run_node(js: str) -> dict:
@@ -52,7 +36,7 @@ def _run_node(js: str) -> dict:
 
 
 def _run_dispatcher_case(function_name: str, current_board, confirm: bool) -> dict:
-    fn_source = _extract_async_function(PANELS, function_name)
+    fn_source = extract_function(PANELS, function_name, prefix="async function")
     source = f"""
 const fnSource = {json.dumps(fn_source)};
 eval(fnSource);

--- a/tests/test_kanban_ui_static.py
+++ b/tests/test_kanban_ui_static.py
@@ -11,6 +11,24 @@ COMPACT_PANELS = re.sub(r"\s+", "", PANELS)
 COMPACT_STYLE = re.sub(r"\s+", "", STYLE)
 
 
+def _extract_function(js: str, name: str) -> str:
+    marker = f"function {name}("
+    start = js.find(marker)
+    assert start >= 0, f"{name} function not found in static/panels.js"
+    brace = js.find("{", start)
+    assert brace >= 0, f"{name} opening brace not found"
+    depth = 1
+    i = brace + 1
+    while i < len(js) and depth > 0:
+        if js[i] == "{":
+            depth += 1
+        elif js[i] == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{name} function braces unbalanced"
+    return js[start:i]
+
+
 def _locale_blocks_with_body(i18n_text: str):
     locale_blocks = re.findall(
         r"\n\s*(?:'(?P<quoted>[a-z]{2}(?:-[A-Z][A-Za-z]+)?)'|(?P<plain>[a-z]{2}(?:-[A-Z]{2})?))\s*:\s*\{(.*?)\n\s*\},",
@@ -524,6 +542,17 @@ def test_kanban_dispatcher_inflight_guard_prevents_double_click_toast_confusion(
     assert 'kanban-nudge-dispatch-btn' in INDEX
     assert 'btnKanbanRunDispatcher' in INDEX
     assert 'btnKanbanPreviewDispatcher' in INDEX
+
+
+def test_kanban_dispatcher_no_longer_blocks_default_board():
+    """Pin removal of the previous null-board guard in runKanbanDispatcher()."""
+    run_match = re.search(r"async function runKanbanDispatcher\(\)\{(.*?)\n\}", PANELS, re.DOTALL)
+    assert run_match, "runKanbanDispatcher() not found"
+    run_body = run_match.group(1)
+    assert "if (!_kanbanCurrentBoard)" not in run_body, (
+        "runKanbanDispatcher() must not block when _kanbanCurrentBoard is null; "
+        "default board should dispatch through a board-less path."
+    )
 
 
 def test_kanban_board_has_native_css_classes():
@@ -1107,17 +1136,11 @@ def test_kanban_board_color_is_validated_against_css_injection():
     """
     import json
     import subprocess
+    fn_source = _extract_function(PANELS, "_kanbanSafeColor")
     script = """
-const fs = require('fs');
-const src = fs.readFileSync('static/panels.js', 'utf8');
-const start = src.indexOf('function _kanbanSafeColor');
-if (start < 0) { console.error('_kanbanSafeColor missing'); process.exit(2); }
-// Grab the function body up to and including the closing `}` line.
-const tail = src.slice(start);
-const end = tail.indexOf('\\n}\\n') + 2;
-const fn = tail.slice(0, end);
+const fnSource = __FN__;
 const ctx = {};
-new Function('out', fn + '; out.fn = _kanbanSafeColor;')(ctx);
+new Function('out', fnSource + '; out.fn = _kanbanSafeColor;')(ctx);
 const cases = [
   ['#fff', '#fff'],
   ['#3b82f6', '#3b82f6'],
@@ -1137,7 +1160,7 @@ const results = cases.map(([input, expected]) => ({
   input, expected, actual: ctx.fn(input)
 }));
 console.log(JSON.stringify(results));
-"""
+""".replace("__FN__", json.dumps(fn_source))
     result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
     results = json.loads(result.stdout)
     failures = [r for r in results if r["actual"] != r["expected"]]

--- a/tests/test_kanban_ui_static.py
+++ b/tests/test_kanban_ui_static.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 import re
 
+from tests.js_source_extract import extract_function
+
 ROOT = Path(__file__).resolve().parents[1]
 INDEX = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
 PANELS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
@@ -9,24 +11,6 @@ I18N = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
 COMPACT_INDEX = re.sub(r"\s+", "", INDEX)
 COMPACT_PANELS = re.sub(r"\s+", "", PANELS)
 COMPACT_STYLE = re.sub(r"\s+", "", STYLE)
-
-
-def _extract_function(js: str, name: str) -> str:
-    marker = f"function {name}("
-    start = js.find(marker)
-    assert start >= 0, f"{name} function not found in static/panels.js"
-    brace = js.find("{", start)
-    assert brace >= 0, f"{name} opening brace not found"
-    depth = 1
-    i = brace + 1
-    while i < len(js) and depth > 0:
-        if js[i] == "{":
-            depth += 1
-        elif js[i] == "}":
-            depth -= 1
-        i += 1
-    assert depth == 0, f"{name} function braces unbalanced"
-    return js[start:i]
 
 
 def _locale_blocks_with_body(i18n_text: str):
@@ -546,10 +530,8 @@ def test_kanban_dispatcher_inflight_guard_prevents_double_click_toast_confusion(
 
 def test_kanban_dispatcher_no_longer_blocks_default_board():
     """Pin removal of the previous null-board guard in runKanbanDispatcher()."""
-    run_match = re.search(r"async function runKanbanDispatcher\(\)\{(.*?)\n\}", PANELS, re.DOTALL)
-    assert run_match, "runKanbanDispatcher() not found"
-    run_body = run_match.group(1)
-    assert "if (!_kanbanCurrentBoard)" not in run_body, (
+    run_source = extract_function(PANELS, "runKanbanDispatcher", prefix="async function")
+    assert "if (!_kanbanCurrentBoard)" not in run_source, (
         "runKanbanDispatcher() must not block when _kanbanCurrentBoard is null; "
         "default board should dispatch through a board-less path."
     )
@@ -1136,7 +1118,7 @@ def test_kanban_board_color_is_validated_against_css_injection():
     """
     import json
     import subprocess
-    fn_source = _extract_function(PANELS, "_kanbanSafeColor")
+    fn_source = extract_function(PANELS, "_kanbanSafeColor")
     script = """
 const fnSource = __FN__;
 const ctx = {};


### PR DESCRIPTION
## Thinking Path

- The default Kanban board is intentionally stored as `null`, and the backend already treats a missing `board` query parameter as "use the default board."
- The dry-run Preview dispatcher already follows that contract, but the real Run dispatcher treats the same `null` value as unavailable and returns before it can call `/api/kanban/dispatch`.
- The fix stays entirely in the browser layer: remove the blocking guard, keep the existing confirmation and in-flight behavior, and lock the change down with a browserless regression plus a small static dispatcher guardrail.

## What Changed

- `static/panels.js`: removes the pre-POST `if (!_kanbanCurrentBoard)` early return in `runKanbanDispatcher()` so the default board can post `/api/kanban/dispatch?max=8` without `board=`.
- `tests/js_source_extract.py`: shares a balanced-brace JavaScript extractor so the dispatcher harness and existing static Kanban checks parse function bodies without depending on exact whitespace.
- `tests/test_kanban_ui_static.py`: adds a secondary source-level assertion so the null-board pre-POST guard cannot quietly return, and reuses the shared extractor for `_kanbanSafeColor` instead of a brittle inline slice.
- `tests/test_issue5231_default_kanban_dispatch.py`: adds behavioral harness coverage for default-board real dispatch, named-board preservation, Preview dry-run preservation, and confirmation decline, and now reuses the shared extractor for the real async dispatcher functions.

## Why It Matters

The default board is the common case, so this guard turned the manual Run dispatcher button into a dead end for many installs. After the fix, clicking Run dispatcher on the default board reaches the existing in-process dispatch endpoint instead of stopping at an unavailable toast with no network request.

## Verification

- `npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs static/panels.js`
- `pytest tests/test_issue5231_default_kanban_dispatch.py tests/test_kanban_ui_static.py tests/test_kanban_bridge.py::test_kanban_only_mine_bulk_dispatch_and_block_unblock -v --timeout=60`

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5231.

Maintainer analysis in [issuecomment-4841878503](https://github.com/nesquena/hermes-webui/issues/5231#issuecomment-4841878503) and [issuecomment-4845478031](https://github.com/nesquena/hermes-webui/issues/5231#issuecomment-4845478031) materially shaped this slice by separating the gateway discussion from the WebUI bug and confirming the default-board `null` root cause.

## Model Used

GPT 5.5 via Codex CLI

