### PR TITLE
fix(#4732): keep mobile dictation active through pauses

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -604,6 +604,8 @@ function _micToastKeyForRecognitionError(error){
   let _finalText='';
   let _prefix='';
   let _isRecording=false;
+  let _speechStopRequested=false;
+  let _micWakeLock=null;
 
   function _setButtonTooltipAndKey(btn, key){
     const text = t(key);
@@ -717,6 +719,34 @@ function _micToastKeyForRecognitionError(error){
     }
   }
 
+  async function _acquireMicWakeLock(){
+    if(!navigator.wakeLock||_micWakeLock) return;
+    try{
+      _micWakeLock=await navigator.wakeLock.request('screen');
+      _micWakeLock.addEventListener?.('release',()=>{ _micWakeLock=null; },{once:true});
+    }catch(_){
+      _micWakeLock=null;
+    }
+  }
+
+  async function _releaseMicWakeLock(){
+    const lock=_micWakeLock;
+    _micWakeLock=null;
+    if(!lock) return;
+    try{ await lock.release(); }catch(_){}
+  }
+
+  document.addEventListener('visibilitychange',()=>{
+    if(document.visibilityState==='hidden'){
+      void _releaseMicWakeLock();
+      return;
+    }
+
+    if(window._micActive&&_activeCaptureMode==='speech'){
+      void _acquireMicWakeLock();
+    }
+  });
+
   function _stopMic(){
     if(!window._micActive) return;
     // Stop the backend that was ACTIVE WHEN RECORDING STARTED — not whatever
@@ -724,6 +754,7 @@ function _micToastKeyForRecognitionError(error){
     // which would otherwise make us stop the wrong backend and orphan the other
     // (#3169 Codex review). _activeCaptureMode is pinned at start.
     if(recognition && _activeCaptureMode==='speech'){
+      _speechStopRequested=true;
       recognition.stop();
       return;
     }
@@ -739,7 +770,7 @@ function _micToastKeyForRecognitionError(error){
   function _ensureSpeechRecognition(){
     if(!SpeechRecognition) return null;
     const sr=recognition||new SpeechRecognition();
-    sr.continuous=false;
+    sr.continuous=true;
     sr.interimResults=true;
     sr.lang=(typeof _locale!=='undefined'&&_locale._speech)||'en-US';
 
@@ -763,9 +794,22 @@ function _micToastKeyForRecognitionError(error){
             ? _prefix+' '+_finalText.trimStart()
             : _prefix+_finalText)
         : ta.value;
-      _setRecording(false);
       ta.value=committed;
       autoResize();
+      if(!_speechStopRequested&&window._micActive&&_activeCaptureMode==='speech'){
+        _prefix=committed&&!committed.endsWith(' ')&&!committed.endsWith('\n')
+          ? committed+' '
+          : committed;
+        _finalText='';
+        try{
+          sr.start();
+          return;
+        }catch(_){}
+      }
+      _speechStopRequested=false;
+      _isRecording=false;
+      void _releaseMicWakeLock();
+      _setRecording(false);
       if(window._micPendingSend){
         window._micPendingSend=false;
         send();
@@ -774,10 +818,19 @@ function _micToastKeyForRecognitionError(error){
     };
 
     sr.onerror=(event)=>{
+      if((event.error==='no-speech'||event.error==='aborted')
+          && window._micActive
+          && _activeCaptureMode==='speech'
+          && !_speechStopRequested){
+        return;
+      }
+
+      _speechStopRequested=false;
       _setRecording(false);
       window._micPendingSend=false;
       _isRecording=false;
-      if(event.error==='network'||event.error==='not-allowed'){
+      void _releaseMicWakeLock();
+      if(event.error==='network'||event.error==='not-allowed'||event.error==='service-not-allowed'||event.error==='audio-capture'){
         // Persist SR failure: next reload will skip SpeechRecognition
         localStorage.setItem(_micForceMediaRecorderKey,'1');
         _forceMediaRecorder=true;
@@ -849,7 +902,9 @@ function _micToastKeyForRecognitionError(error){
     }
     if(recognition && !_forceMediaRecorder && !_rawAudioMode){
       _activeCaptureMode='speech';
+      _speechStopRequested=false;
       recognition.start();
+      void _acquireMicWakeLock();
       _setRecording(true);
       return;
     }


### PR DESCRIPTION
## Thinking Path

Hermes WebUI keeps the browser client intentionally simple: vanilla JS in `static/boot.js`, with no build step or frontend framework.

The reported mobile dictation bug lives in the browser `SpeechRecognition` path. Mobile dictation was ending too early because the recognizer used single-utterance mode and treated a thinking pause as the end of speech. It also did not hold a screen wake lock, so the page could sleep during active dictation.

Desktop server-side STT via `/api/transcribe` already records until the user stops, so this PR keeps the fix scoped to the browser `SpeechRecognition` dictation path.

## What Changed

- Set browser dictation `SpeechRecognition.continuous = true`
- Added restart-on-`onend` behavior while the user is still actively dictating
- Added a `_speechStopRequested` guard so manual stop and send actions do not restart recognition
- Preserved accumulated transcript text across recognition restarts
- Added optional Screen Wake Lock support while browser dictation is active
- Released/reacquired the wake lock on page visibility changes
- Kept the MediaRecorder `/api/transcribe` path unchanged

## Why It Matters

Mobile users can pause mid-dictation without losing the recording session, and the page is less likely to sleep while they are actively speaking.

This makes mobile browser/PWA/native-wrapper dictation closer to the desktop server-STT behavior, where capture continues until the user manually stops.

## Verification

- Ran `node --check static/boot.js`
- Ran `./scripts/test.sh`
  - Initial run: 11102 passed, 144 skipped, 2 xfailed, 1 xpassed
  - 2 tests timed out during the full run:
    - `tests/test_terminal_process_cleanup.py::test_terminal_module_registers_graceful_shutdown_reaper`
    - `tests/test_tls_aware_probe.py::test_ctl_status_survives_readonly_env_vars`
- Re-ran both timed-out tests individually and both passed:
  - `./.venv/bin/pytest tests/test_terminal_process_cleanup.py::test_terminal_module_registers_graceful_shutdown_reaper -q -vv`
  - `./.venv/bin/pytest tests/test_tls_aware_probe.py::test_ctl_status_survives_readonly_env_vars -q -vv`

Manual checks:
- Forced browser SpeechRecognition path with `mic_force_mediarecorder = 0`
- Confirmed dictation continued after a 5–7 second pause
- Confirmed manual mic stop did not restart recognition
- Confirmed send while dictating stopped recognition cleanly
- Confirmed wake-lock feature detection does not break dictation flow

## Risks / Follow-ups

- Mobile browser `SpeechRecognition` behavior differs across Chrome, Safari, and WebView wrappers
- Some browsers may still end recognition despite `continuous = true`, so this PR also restarts on `onend` while dictation is active
- Screen Wake Lock is not available in every mobile browser; unsupported browsers safely continue without it

## Release Note

Closes #4732

Improves mobile browser dictation so pausing mid-sentence no longer ends transcription early and active dictation can keep the screen awake where Wake Lock is supported.

## Model Used

Provider: OpenAI  
Model: GPT-5.5 Thinking  
Notable use: Assisted with issue analysis, implementation planning and local verification checklist.
 I reviewed and applied the code changes manually.