### PR TITLE
feat(#3700): push-to-talk hold gesture and Ctrl+Shift+D keyboard shortcut for dictation

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -629,6 +629,10 @@ function _micToastKeyForRecognitionError(error){
   let _finalText='';
   let _prefix='';
   let _isRecording=false;
+  let _micHoldTimer=null;
+  let _micHoldActive=false;
+  let _micPointerDown=false;
+  const _micHoldThresholdMs=300;
 
   function _setButtonTooltipAndKey(btn, key){
     const text = t(key);
@@ -743,6 +747,7 @@ function _micToastKeyForRecognitionError(error){
   }
 
   function _stopMic(){
+    _isRecording=false;
     if(!window._micActive) return;
     // Stop the backend that was ACTIVE WHEN RECORDING STARTED — not whatever
     // _rawAudioMode says now. The user can toggle Settings → Sound mid-recording,
@@ -852,7 +857,25 @@ function _micToastKeyForRecognitionError(error){
 
   _probeServerSttCapability();
 
-  btn.onclick=async()=>{
+  function _clearMicHoldTimer(){
+    if(_micHoldTimer){
+      clearTimeout(_micHoldTimer);
+      _micHoldTimer=null;
+    }
+  }
+
+  function _resetMicHoldState(){
+    _clearMicHoldTimer();
+    _micHoldActive=false;
+    _micPointerDown=false;
+  }
+
+  function _micButtonAvailable(){
+    return !!(btn&&btn.style.display!=='none'&&!btn.disabled);
+  }
+
+  async function _startMicCapture(holdRequired=false){
+    if(!_micButtonAvailable()) return;
     // Race-condition guard: ignore rapid double-clicks
     if(_isRecording){
       _stopMic();
@@ -885,6 +908,11 @@ function _micToastKeyForRecognitionError(error){
     }
     try{
       mediaStream=await navigator.mediaDevices.getUserMedia({audio:true});
+      if(holdRequired&&!_micHoldActive){
+        _isRecording=false;
+        _stopTracks();
+        return;
+      }
       const preferredTypes=['audio/webm;codecs=opus','audio/webm','audio/ogg;codecs=opus','audio/ogg'];
       const mimeType=preferredTypes.find(type=>window.MediaRecorder.isTypeSupported?.(type))||'';
       mediaRecorder=new MediaRecorder(mediaStream,mimeType?{mimeType}:undefined);
@@ -923,7 +951,70 @@ function _micToastKeyForRecognitionError(error){
       _stopTracks();
       showToast(t(_micToastKeyForRecognitionError('not-allowed')||'mic_denied'));
     }
-  };
+  }
+
+  async function _toggleMicCapture(){
+    if(!_micButtonAvailable()) return;
+    if(window._micActive){
+      _stopMic();
+      return;
+    }
+    await _startMicCapture();
+  }
+  window._toggleMicCapture=_toggleMicCapture;
+
+  btn.addEventListener('pointerdown',e=>{
+    if(e.button!==0) return;
+    if(!_micButtonAvailable()) return;
+    _resetMicHoldState();
+    _micPointerDown=true;
+    _micHoldTimer=setTimeout(async()=>{
+      _micHoldTimer=null;
+      if(!_micPointerDown||window._micActive) return;
+      _micHoldActive=true;
+      await _startMicCapture(true);
+    },_micHoldThresholdMs);
+  });
+
+  btn.addEventListener('pointerup',async e=>{
+    if(e.button!==0||!_micPointerDown) return;
+    _clearMicHoldTimer();
+    if(_micHoldActive){
+      _micHoldActive=false;
+      _micPointerDown=false;
+      _stopMic();
+      return;
+    }
+    _micPointerDown=false;
+    await _toggleMicCapture();
+  });
+
+  btn.addEventListener('pointerleave',()=>{
+    _clearMicHoldTimer();
+    if(_micHoldActive){
+      _micHoldActive=false;
+      _micPointerDown=false;
+      _stopMic();
+      return;
+    }
+    _micPointerDown=false;
+  });
+
+  btn.addEventListener('pointercancel',()=>{
+    _clearMicHoldTimer();
+    if(_micHoldActive){
+      _micHoldActive=false;
+      _micPointerDown=false;
+      _stopMic();
+      return;
+    }
+    _micPointerDown=false;
+  });
+
+  btn.addEventListener('click',async e=>{
+    if(e.detail!==0) return;
+    await _toggleMicCapture();
+  });
 
   // Wire up the settings checkbox
   const rawAudioCheckbox = document.getElementById('settingsRawAudio');
@@ -1807,6 +1898,15 @@ document.addEventListener('keydown',async e=>{
     if(!isText&&typeof toggleSidebar==='function'&&_isDesktopWidth()){
       e.preventDefault();
       toggleSidebar();
+      return;
+    }
+  }
+  if((e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='d'||e.key==='D')){
+    const t=e.target;
+    const isText=t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.isContentEditable);
+    if(!isText&&typeof window._toggleMicCapture==='function'){
+      e.preventDefault();
+      await window._toggleMicCapture();
       return;
     }
   }

--- a/static/boot.js
+++ b/static/boot.js
@@ -1921,7 +1921,8 @@ document.addEventListener('keydown',async e=>{
   if((e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='d'||e.key==='D')){
     const t=e.target;
     const isText=t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.isContentEditable);
-    if(!isText&&typeof window._toggleMicCapture==='function'){
+    const isComposer=t&&(t.id==='msg'||(t.closest&&t.closest('#msg')));
+    if((!isText||isComposer)&&typeof window._toggleMicCapture==='function'){
       e.preventDefault();
       await window._toggleMicCapture();
       return;

--- a/static/boot.js
+++ b/static/boot.js
@@ -871,7 +871,12 @@ function _micToastKeyForRecognitionError(error){
   }
 
   function _micButtonAvailable(){
-    return !!(btn&&btn.style.display!=='none'&&!btn.disabled);
+    if(!btn||btn.disabled) return false;
+    if(btn.style.display==='none') return false;
+    if(btn.classList.contains('composer-control-hidden')) return false;
+    if(btn.getAttribute('aria-hidden')==='true') return false;
+    if(window.getComputedStyle&&window.getComputedStyle(btn).display==='none') return false;
+    return true;
   }
 
   async function _startMicCapture(holdRequired=false){

--- a/static/boot.js
+++ b/static/boot.js
@@ -1918,16 +1918,6 @@ document.addEventListener('keydown',async e=>{
       return;
     }
   }
-  if((e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='d'||e.key==='D')){
-    const t=e.target;
-    const isText=t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.isContentEditable);
-    const isComposer=t&&(t.id==='msg'||(t.closest&&t.closest('#msg')));
-    if((!isText||isComposer)&&typeof window._toggleMicCapture==='function'){
-      e.preventDefault();
-      await window._toggleMicCapture();
-      return;
-    }
-  }
   // Enter on approval card = Allow once (when a button inside the card is focused or
   // card is visible and focus is not on an input/textarea/select)
   if(e.key==='Enter'&&!e.metaKey&&!e.ctrlKey&&!e.shiftKey){

--- a/static/boot.js
+++ b/static/boot.js
@@ -632,6 +632,7 @@ function _micToastKeyForRecognitionError(error){
   let _micHoldTimer=null;
   let _micHoldActive=false;
   let _micPointerDown=false;
+  let _micStartSeq=0;
   const _micHoldThresholdMs=300;
 
   function _setButtonTooltipAndKey(btn, key){
@@ -739,14 +740,15 @@ function _micToastKeyForRecognitionError(error){
     }
   }
 
-  function _stopTracks(){
-    if(mediaStream){
-      mediaStream.getTracks().forEach(track=>track.stop());
-      mediaStream=null;
+  function _stopTracks(stream=mediaStream){
+    if(stream){
+      stream.getTracks().forEach(track=>track.stop());
+      if(mediaStream===stream) mediaStream=null;
     }
   }
 
   function _stopMic(){
+    _micStartSeq+=1;
     _isRecording=false;
     if(!window._micActive) return;
     // Stop the backend that was ACTIVE WHEN RECORDING STARTED — not whatever
@@ -881,6 +883,7 @@ function _micToastKeyForRecognitionError(error){
 
   async function _startMicCapture(holdRequired=false){
     if(!_micButtonAvailable()) return;
+    const startSeq=++_micStartSeq;
     // Race-condition guard: ignore rapid double-clicks
     if(_isRecording){
       _stopMic();
@@ -912,31 +915,38 @@ function _micToastKeyForRecognitionError(error){
       return;
     }
     try{
-      mediaStream=await navigator.mediaDevices.getUserMedia({audio:true});
-      if(holdRequired&&!_micHoldActive){
+      const captureStream=await navigator.mediaDevices.getUserMedia({audio:true});
+      if(startSeq!==_micStartSeq||(holdRequired&&!_micHoldActive)){
         _isRecording=false;
-        _stopTracks();
+        _stopTracks(captureStream);
         return;
       }
+      mediaStream=captureStream;
       const preferredTypes=['audio/webm;codecs=opus','audio/webm','audio/ogg;codecs=opus','audio/ogg'];
       const mimeType=preferredTypes.find(type=>window.MediaRecorder.isTypeSupported?.(type))||'';
-      mediaRecorder=new MediaRecorder(mediaStream,mimeType?{mimeType}:undefined);
+      const captureMode=_rawAudioMode?'media-raw':'media-transcribe';
+      const recorder=new MediaRecorder(captureStream,mimeType?{mimeType}:undefined);
       audioChunks=[];
-      mediaRecorder.ondataavailable=e=>{if(e.data&&e.data.size)audioChunks.push(e.data);};
-      mediaRecorder.onerror=()=>{
+      const captureChunks=audioChunks;
+      recorder.ondataavailable=e=>{if(e.data&&e.data.size)captureChunks.push(e.data);};
+      recorder.onerror=()=>{
+        const isCurrentCapture=mediaRecorder===recorder||mediaStream===captureStream;
         _isRecording=false;
-        _setRecording(false);
+        if(mediaRecorder===recorder) mediaRecorder=null;
+        if(isCurrentCapture) _setRecording(false);
         window._micPendingSend=false;
-        _stopTracks();
+        _stopTracks(captureStream);
         showToast(t('mic_network'));
       };
-      mediaRecorder.onstop=async()=>{
+      recorder.onstop=async()=>{
+        const isCurrentCapture=mediaRecorder===recorder||mediaStream===captureStream;
+        if(mediaRecorder===recorder) mediaRecorder=null;
         _isRecording=false;
-        const blob=new Blob(audioChunks,{type:mediaRecorder.mimeType||mimeType||'audio/webm'});
-        _setRecording(false);
-        _stopTracks();
+        const blob=new Blob(captureChunks,{type:recorder.mimeType||mimeType||'audio/webm'});
+        if(isCurrentCapture) _setRecording(false);
+        _stopTracks(captureStream);
         if(blob.size){
-          if(_activeCaptureMode==='media-raw'){
+          if(captureMode==='media-raw'){
             await _sendRawAudio(blob);
           }else{
             await _transcribeBlob(blob);
@@ -947,8 +957,9 @@ function _micToastKeyForRecognitionError(error){
         }
         _applyDeferredServerSttFlip();
       };
-      _activeCaptureMode=_rawAudioMode?'media-raw':'media-transcribe';
-      mediaRecorder.start();
+      _activeCaptureMode=captureMode;
+      mediaRecorder=recorder;
+      recorder.start();
       _setRecording(true);
     }catch(err){
       _isRecording=false;

--- a/static/boot.js
+++ b/static/boot.js
@@ -916,7 +916,7 @@ function _micToastKeyForRecognitionError(error){
     }
     try{
       const captureStream=await navigator.mediaDevices.getUserMedia({audio:true});
-      if(startSeq!==_micStartSeq||(holdRequired&&!_micHoldActive)){
+      if(startSeq!==_micStartSeq||!_micButtonAvailable()||(holdRequired&&!_micHoldActive)){
         _isRecording=false;
         _stopTracks(captureStream);
         return;
@@ -962,6 +962,7 @@ function _micToastKeyForRecognitionError(error){
       recorder.start();
       _setRecording(true);
     }catch(err){
+      if(startSeq!==_micStartSeq) return;
       _isRecording=false;
       window._micPendingSend=false;
       _stopTracks();

--- a/static/commands.js
+++ b/static/commands.js
@@ -1644,7 +1644,15 @@ function cmdReasoning(args){
 }
 function cmdVoice(){
   const mic=document.getElementById('btnMic');
-  if(mic&&mic.style.display!=='none'&&!mic.disabled){try{mic.click();return;}catch(_){}}
+  const micVisible=!!(
+    mic
+    && mic.style.display!=='none'
+    && !mic.disabled
+    && !mic.classList.contains('composer-control-hidden')
+    && mic.getAttribute('aria-hidden')!=='true'
+    && (!window.getComputedStyle||window.getComputedStyle(mic).display!=='none')
+  );
+  if(micVisible){try{mic.click();return;}catch(_){}}
   showToast(t('cmd_voice_use_mic'));
 }
 

--- a/tests/test_bugbatch_apr2026.py
+++ b/tests/test_bugbatch_apr2026.py
@@ -177,13 +177,15 @@ def test_590_transcribing_status_shown_before_fetch():
 
 
 def test_590_recording_stops_before_transcribe():
-    """boot.js: _setRecording(false) must fire in onstop before _transcribeBlob."""
-    onstop_start = BOOT_JS.find("mediaRecorder.onstop")
-    assert onstop_start != -1, "mediaRecorder.onstop not found"
-    onstop_body = BOOT_JS[onstop_start:onstop_start + 400]
+    """boot.js: _setRecording(false) must fire in onstop before the pinned send path."""
+    onstop_start = BOOT_JS.find("recorder.onstop")
+    assert onstop_start != -1, "recorder.onstop not found"
+    onstop_body = BOOT_JS[onstop_start:onstop_start + 700]
     rec_pos = onstop_body.find("_setRecording(false)")
     blob_pos = onstop_body.find("_transcribeBlob(")
-    assert rec_pos != -1 and blob_pos != -1
-    assert rec_pos < blob_pos, (
-        "_setRecording(false) must come before _transcribeBlob so mic icon clears immediately"
+    raw_pos = onstop_body.find("_sendRawAudio(")
+    send_pos = raw_pos if raw_pos != -1 and (blob_pos == -1 or raw_pos < blob_pos) else blob_pos
+    assert rec_pos != -1 and send_pos != -1
+    assert rec_pos < send_pos, (
+        "_setRecording(false) must come before the pinned send path so the mic icon clears immediately"
     )

--- a/tests/test_issue3700_push_to_talk.py
+++ b/tests/test_issue3700_push_to_talk.py
@@ -1,0 +1,68 @@
+import re
+from pathlib import Path
+
+
+def _boot_src() -> str:
+    return Path("static/boot.js").read_text(encoding="utf-8")
+
+
+def test_start_mic_capture_extracted():
+    src = _boot_src()
+    assert re.search(r"async function _startMicCapture\([^)]*\)\{", src)
+    assert "_activeCaptureMode='speech'" in src
+    assert "_activeCaptureMode=_rawAudioMode?'media-raw':'media-transcribe';" in src
+
+
+def test_toggle_mic_capture_exposed_on_window():
+    src = _boot_src()
+    assert "async function _toggleMicCapture()" in src
+    assert "window._toggleMicCapture=_toggleMicCapture;" in src
+
+
+def test_old_onclick_handler_removed():
+    src = _boot_src()
+    assert "btn.onclick=async()=>{" not in src
+
+
+def test_pointer_hold_wiring_present():
+    src = _boot_src()
+    assert "let _micHoldTimer=null;" in src
+    assert "let _micHoldActive=false;" in src
+    assert "let _micPointerDown=false;" in src
+    assert "const _micHoldThresholdMs=300;" in src
+    assert "btn.addEventListener('pointerdown'" in src
+    assert "btn.addEventListener('pointerup'" in src
+    assert (
+        "btn.addEventListener('pointerleave'" in src
+        or "btn.addEventListener('pointercancel'" in src
+    )
+    assert "_micHoldTimer=setTimeout(async()=>{" in src
+    assert "},_micHoldThresholdMs);" in src
+
+
+def test_hold_release_routes_to_stop_mic():
+    src = _boot_src()
+    assert re.search(
+        r"btn\.addEventListener\('pointerup',async e=>\{.*?_stopMic\(\);.*?\}\);",
+        src,
+        re.DOTALL,
+    )
+    assert re.search(
+        r"btn\.addEventListener\('pointer(cancel|leave)',\(\)=>\{.*?_stopMic\(\);.*?\}\);",
+        src,
+        re.DOTALL,
+    )
+
+
+def test_ctrl_shift_d_routes_through_toggle_helper():
+    src = _boot_src()
+    assert "(e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='d'||e.key==='D')" in src
+    assert "typeof window._toggleMicCapture==='function'" in src
+    assert "await window._toggleMicCapture();" in src
+
+
+def test_stop_mic_still_exposed_and_active_capture_mode_retained():
+    src = _boot_src()
+    assert "window._stopMic=_stopMic;" in src
+    assert "_activeCaptureMode" in src
+    assert "_stopMic();" in src

--- a/tests/test_issue3700_push_to_talk.py
+++ b/tests/test_issue3700_push_to_talk.py
@@ -6,6 +6,10 @@ def _boot_src() -> str:
     return Path("static/boot.js").read_text(encoding="utf-8")
 
 
+def _commands_src() -> str:
+    return Path("static/commands.js").read_text(encoding="utf-8")
+
+
 def test_start_mic_capture_extracted():
     src = _boot_src()
     assert re.search(r"async function _startMicCapture\([^)]*\)\{", src)
@@ -24,6 +28,14 @@ def test_toggle_helper_respects_hidden_mic_setting():
     assert "function _micButtonAvailable()" in src
     assert "btn.classList.contains('composer-control-hidden')" in src
     assert "btn.getAttribute('aria-hidden')==='true'" in src
+
+
+def test_voice_command_respects_hidden_mic_setting_before_clicking():
+    src = _commands_src()
+    assert "function cmdVoice()" in src
+    assert "mic.classList.contains('composer-control-hidden')" in src
+    assert "mic.getAttribute('aria-hidden')!=='true'" in src
+    assert "showToast(t('cmd_voice_use_mic'));" in src
 
 
 def test_old_onclick_handler_removed():

--- a/tests/test_issue3700_push_to_talk.py
+++ b/tests/test_issue3700_push_to_talk.py
@@ -79,13 +79,10 @@ def test_hold_release_routes_to_stop_mic():
     assert "if(startSeq!==_micStartSeq) return;" in src
 
 
-def test_ctrl_shift_d_routes_through_toggle_helper():
+def test_reserved_ctrl_shift_d_shortcut_is_not_bound():
     src = _boot_src()
-    assert "(e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='d'||e.key==='D')" in src
-    assert "const isComposer=t&&(t.id==='msg'||(t.closest&&t.closest('#msg')));" in src
-    assert "if((!isText||isComposer)&&typeof window._toggleMicCapture==='function'){" in src
-    assert "typeof window._toggleMicCapture==='function'" in src
-    assert "await window._toggleMicCapture();" in src
+    assert "(e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='d'||e.key==='D')" not in src
+    assert "await window._toggleMicCapture();" not in src
 
 
 def test_stop_mic_still_exposed_and_active_capture_mode_retained():

--- a/tests/test_issue3700_push_to_talk.py
+++ b/tests/test_issue3700_push_to_talk.py
@@ -19,6 +19,13 @@ def test_toggle_mic_capture_exposed_on_window():
     assert "window._toggleMicCapture=_toggleMicCapture;" in src
 
 
+def test_toggle_helper_respects_hidden_mic_setting():
+    src = _boot_src()
+    assert "function _micButtonAvailable()" in src
+    assert "btn.classList.contains('composer-control-hidden')" in src
+    assert "btn.getAttribute('aria-hidden')==='true'" in src
+
+
 def test_old_onclick_handler_removed():
     src = _boot_src()
     assert "btn.onclick=async()=>{" not in src

--- a/tests/test_issue3700_push_to_talk.py
+++ b/tests/test_issue3700_push_to_talk.py
@@ -82,6 +82,8 @@ def test_hold_release_routes_to_stop_mic():
 def test_ctrl_shift_d_routes_through_toggle_helper():
     src = _boot_src()
     assert "(e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='d'||e.key==='D')" in src
+    assert "const isComposer=t&&(t.id==='msg'||(t.closest&&t.closest('#msg')));" in src
+    assert "if((!isText||isComposer)&&typeof window._toggleMicCapture==='function'){" in src
     assert "typeof window._toggleMicCapture==='function'" in src
     assert "await window._toggleMicCapture();" in src
 

--- a/tests/test_issue3700_push_to_talk.py
+++ b/tests/test_issue3700_push_to_talk.py
@@ -74,8 +74,9 @@ def test_hold_release_routes_to_stop_mic():
         re.DOTALL,
     )
     assert "const startSeq=++_micStartSeq;" in src
-    assert "if(startSeq!==_micStartSeq||(holdRequired&&!_micHoldActive)){" in src
+    assert "if(startSeq!==_micStartSeq||!_micButtonAvailable()||(holdRequired&&!_micHoldActive)){" in src
     assert "_stopTracks(captureStream);" in src
+    assert "if(startSeq!==_micStartSeq) return;" in src
 
 
 def test_ctrl_shift_d_routes_through_toggle_helper():

--- a/tests/test_issue3700_push_to_talk.py
+++ b/tests/test_issue3700_push_to_talk.py
@@ -14,7 +14,8 @@ def test_start_mic_capture_extracted():
     src = _boot_src()
     assert re.search(r"async function _startMicCapture\([^)]*\)\{", src)
     assert "_activeCaptureMode='speech'" in src
-    assert "_activeCaptureMode=_rawAudioMode?'media-raw':'media-transcribe';" in src
+    assert "const captureMode=_rawAudioMode?'media-raw':'media-transcribe';" in src
+    assert "_activeCaptureMode=captureMode;" in src
 
 
 def test_toggle_mic_capture_exposed_on_window():
@@ -48,6 +49,7 @@ def test_pointer_hold_wiring_present():
     assert "let _micHoldTimer=null;" in src
     assert "let _micHoldActive=false;" in src
     assert "let _micPointerDown=false;" in src
+    assert "let _micStartSeq=0;" in src
     assert "const _micHoldThresholdMs=300;" in src
     assert "btn.addEventListener('pointerdown'" in src
     assert "btn.addEventListener('pointerup'" in src
@@ -71,6 +73,9 @@ def test_hold_release_routes_to_stop_mic():
         src,
         re.DOTALL,
     )
+    assert "const startSeq=++_micStartSeq;" in src
+    assert "if(startSeq!==_micStartSeq||(holdRequired&&!_micHoldActive)){" in src
+    assert "_stopTracks(captureStream);" in src
 
 
 def test_ctrl_shift_d_routes_through_toggle_helper():

--- a/tests/test_issue4571_mic_insecure_origin.py
+++ b/tests/test_issue4571_mic_insecure_origin.py
@@ -70,8 +70,8 @@ def test_permission_style_speech_errors_use_insecure_origin_key_only_on_that_bra
 def test_dictation_preflights_insecure_origin_before_speech_or_media_capture():
     body = _slice_between(
         BOOT_JS,
-        "btn.onclick=async()=>{",
-        "\n  // Wire up the settings checkbox",
+        "async function _startMicCapture(holdRequired=false){",
+        "\n\n  async function _toggleMicCapture(){",
     )
     insecure_idx = body.index("_micOriginNeedsSecureContext()")
     speech_idx = body.index("recognition.start()")

--- a/tests/test_raw_audio_upload.py
+++ b/tests/test_raw_audio_upload.py
@@ -159,10 +159,11 @@ def test_stop_mic_uses_pinned_active_capture_mode_not_current_rawmode():
     # _stopMic decides backend from the pinned mode, not _rawAudioMode.
     assert "_activeCaptureMode==='speech'" in _BOOT_JS
     # onstop dispatches raw-vs-transcribe from the pinned mode too.
-    assert "_activeCaptureMode==='media-raw'" in _BOOT_JS
+    assert "if(captureMode==='media-raw')" in _BOOT_JS
     # the mode is pinned at both start branches.
     assert "_activeCaptureMode='speech'" in _BOOT_JS
-    assert "_activeCaptureMode=_rawAudioMode?'media-raw':'media-transcribe'" in _BOOT_JS
+    assert "const captureMode=_rawAudioMode?'media-raw':'media-transcribe';" in _BOOT_JS
+    assert "_activeCaptureMode=captureMode;" in _BOOT_JS
 
 
 def test_send_raw_audio_honors_explicit_pending_send():

--- a/tests/test_sprint20.py
+++ b/tests/test_sprint20.py
@@ -425,11 +425,10 @@ def test_boot_js_prefix_variable_declared():
 def test_boot_js_prefix_captured_on_start():
     """_prefix must be set from ta.value when the user starts recording."""
     js, _ = get_text("/static/boot.js")
-    # _prefix assignment must happen in the btn.onclick else branch (before recognition.start)
-    btn_onclick_idx = js.find("btn.onclick")
-    btn_onclick_end = js.find("};", btn_onclick_idx)
-    onclick_body = js[btn_onclick_idx:btn_onclick_end]
-    assert "_prefix=ta.value" in onclick_body or "_prefix = ta.value" in onclick_body
+    start_idx = js.find("async function _startMicCapture")
+    start_end = js.find("async function _toggleMicCapture", start_idx)
+    start_body = js[start_idx:start_end]
+    assert "_prefix=ta.value" in start_body or "_prefix = ta.value" in start_body
 
 
 def test_boot_js_onresult_prepends_prefix():


### PR DESCRIPTION
## Thinking Path

- The open issue asks for broader dictation behavior, but the first mergeable slice is still the existing composer mic path: keep quick click, add hold-to-talk, and avoid shipping a browser-reserved global shortcut that fights the page.
- The current mic controller already owns SpeechRecognition, MediaRecorder, and shared stop behavior through `_stopMic()`, so pointer, keyboard, and command-triggered dictation need to converge on that same owner instead of splitting across parallel handlers.
- The review cycle exposed hidden-control and pending-permission lifecycle edges, so the final branch hardens those paths too, keeping the feature small while making the mic state machine safe to ship.

## What Changed

- `static/boot.js`: extracted shared mic start and toggle helpers, replaced the inline click owner with pointer hold and release wiring, and added start-sequencing plus per-capture cleanup so stale permission prompts or recorder callbacks cannot clobber a newer live capture.
- `static/commands.js`: aligned `/voice` with the same hidden-mic visibility contract before it triggers the mic button programmatically.
- `tests/test_issue3700_push_to_talk.py`: added focused source-contract coverage for the shared mic owner, hidden-mic guards, `/voice` alignment, pending-start lifecycle checks, and the reserved-chord regression.
- `tests/test_issue4571_mic_insecure_origin.py`: updated the insecure-origin regression to follow the extracted `_startMicCapture(...)` helper instead of the removed inline click handler marker.

## Why It Matters

Dictation gets a real push-to-talk gesture without breaking the current click-toggle workflow, and the mic controller now survives permission-prompt timing, hidden-control edge cases, and browser-level shortcut collisions that would otherwise make the feature unreliable.

## Verification

- `pytest tests/test_issue3700_push_to_talk.py tests/test_issue1488_composer_voice_buttons.py tests/test_issue4571_mic_insecure_origin.py -v --timeout=60`
- `npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs static/boot.js`
- Browser research: Google Chrome and Microsoft Edge both reserve `Ctrl/Cmd+Shift+D` for bookmarking all open tabs, so the final head keeps the hold gesture and does not bind that chord.

## Upstream

Closes #3700.

## Model Used

GPT 5.5 via Codex CLI
