### PR TITLE
feat: support per-provider reasoning_efforts in config.yaml

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3023,17 +3023,38 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
     return False
 
 
+# Matches the nested Gemini gateway route prefix anywhere it appears in a
+# model id, as long as it isn't embedded inside a larger alphanumeric token
+# (the negative lookbehind excludes false positives like "notvertex/gemini-x").
+# Scanning for the pattern at any position — rather than requiring the whole
+# string to start with it — makes the check independent of how many wrapper
+# layers precede the route: ``@provider:``, a named custom-provider slug
+# (``@custom:<slug>:``), or any future nesting scheme none of us have
+# invented yet. This invariant (Gemini image/embedding routes must never
+# expose a reasoning toggle) was bypassed twice via different edge cases in
+# the prefix-stripping logic before being made structurally boundary-based
+# instead of prefix-based — see PR #5313 review history.
+_NESTED_ROUTE_PATTERN = re.compile(r"(?<![a-z0-9])(vertex/gemini-|gemini_cli/gemini-)(.*)$")
+
+
 def _nested_route_reasoning_denied(model: str) -> bool:
-    """Hard deny for nested Gemini gateway routes that must never show a reasoning toggle."""
+    """Hard deny for nested Gemini gateway routes that must never show a reasoning toggle.
+
+    Matches the route pattern anywhere in *model*, not just when the whole
+    string starts with it, so this check does not depend on a caller having
+    stripped exactly the right wrapper prefix first. Callers should still
+    pass the least-wrapped form they have (e.g. after
+    ``_strip_provider_hint_for_reasoning``) for clarity, but correctness no
+    longer hinges on it.
+    """
     lower = str(model or "").strip().lower()
     if not lower:
         return False
-    for prefix in ("vertex/gemini-", "gemini_cli/gemini-"):
-        if lower.startswith(prefix):
-            tail = lower[len(prefix) :]
-            if tail.startswith("embedding") or "image" in tail or "imagine" in tail:
-                return True
-    return False
+    match = _NESTED_ROUTE_PATTERN.search(lower)
+    if not match:
+        return False
+    tail = match.group(2)
+    return tail.startswith("embedding") or "image" in tail or "imagine" in tail
 
 
 def _nested_gateway_route_reasoning(model: str) -> bool:

--- a/api/config.py
+++ b/api/config.py
@@ -3355,8 +3355,10 @@ def resolve_model_reasoning_efforts(
             if isinstance(_prov_entry, dict):
                 _re_list = _prov_entry.get("reasoning_efforts")
                 if isinstance(_re_list, list) and _re_list:
-                    return [str(x).strip().lower() for x in _re_list
-                            if str(x).strip().lower() in {*VALID_REASONING_EFFORTS, "none"}]
+                    _filtered = [str(x).strip().lower() for x in _re_list
+                                 if str(x).strip().lower() in {*VALID_REASONING_EFFORTS, "none"}]
+                    if _filtered:
+                        return _filtered
         except Exception:
             pass
 

--- a/api/config.py
+++ b/api/config.py
@@ -3340,10 +3340,17 @@ def resolve_model_reasoning_efforts(
 
     provider = _resolve_provider_alias(provider)
 
+    # IDE-copilot providers never expose reasoning effort options.
+    # Guard early so a stray config entry can't override this.
+    if provider in {"cursor-acp", "copilot-acp"}:
+        return []
+
     # 0. Provider config: providers.<name>.reasoning_efforts
     # When the user has explicitly listed valid efforts for a provider,
     # return that list directly — no heuristics, no models.dev lookup.
     # Handles both custom:<name> and bare registered provider names (e.g. wandb).
+    # Only short-circuits when the filtered list is non-empty; an all-invalid
+    # list (e.g. typos) falls through to heuristics instead of hiding reasoning.
     _prov_name = None
     if provider and provider.startswith("custom:"):
         _prov_name = provider.split(":", 1)[1]
@@ -3361,9 +3368,6 @@ def resolve_model_reasoning_efforts(
                         return _filtered
         except Exception:
             pass
-
-    if provider in {"cursor-acp", "copilot-acp"}:
-        return []
 
     hinted_model = _strip_provider_hint_for_reasoning(model)
 

--- a/api/config.py
+++ b/api/config.py
@@ -3345,34 +3345,39 @@ def resolve_model_reasoning_efforts(
     if provider in {"cursor-acp", "copilot-acp"}:
         return []
 
-    # 0. Provider config: providers.<name>.reasoning_efforts
-    # When the user has explicitly listed valid efforts for a provider,
-    # return that list directly — no heuristics, no models.dev lookup.
-    # Handles both custom:<name> and bare registered provider names (e.g. wandb).
-    # Only short-circuits when the filtered list is non-empty; an all-invalid
-    # list (e.g. typos) falls through to heuristics instead of hiding reasoning.
-    _prov_name = None
-    if provider and provider.startswith("custom:"):
-        _prov_name = provider.split(":", 1)[1]
-    elif provider:
-        _prov_name = provider
-    if _prov_name:
-        try:
-            _prov_entry = (cfg.get("providers") or {}).get(_prov_name, {})
-            if isinstance(_prov_entry, dict):
-                _re_list = _prov_entry.get("reasoning_efforts")
-                if isinstance(_re_list, list) and _re_list:
-                    _filtered = [str(x).strip().lower() for x in _re_list
-                                 if str(x).strip().lower() in {*VALID_REASONING_EFFORTS, "none"}]
-                    if _filtered:
-                        return _filtered
-        except Exception:
-            pass
-
     hinted_model = _strip_provider_hint_for_reasoning(model)
 
+    # Master hides reasoning controls for nested image/embedding routes. Keep
+    # that hard deny above provider config so an explicit allowlist cannot
+    # re-enable controls for routes that should never expose them.
     if _nested_route_reasoning_denied(hinted_model):
         return []
+
+    # 0. Provider config: providers.<name>.reasoning_efforts or named
+    # custom_providers[].reasoning_efforts. When the user has explicitly listed
+    # valid efforts for a provider, return that list directly — no heuristics,
+    # no models.dev lookup.
+    # Only short-circuits when the filtered list is non-empty; an all-invalid
+    # list (e.g. typos) falls through to heuristics instead of hiding reasoning.
+    _re_list = None
+    try:
+        if provider and provider.startswith("custom:"):
+            for _entry in _custom_provider_entries():
+                if _custom_provider_slug_from_name(_entry.get("name")) == provider:
+                    _re_list = _entry.get("reasoning_efforts")
+                    break
+        elif provider:
+            _prov_entry = (cfg.get("providers") or {}).get(provider, {})
+            if isinstance(_prov_entry, dict):
+                _re_list = _prov_entry.get("reasoning_efforts")
+        if isinstance(_re_list, list) and _re_list:
+            _filtered = [str(x).strip().lower() for x in _re_list
+                         if str(x).strip().lower() in {*VALID_REASONING_EFFORTS, "none"}]
+            _filtered = list(dict.fromkeys(_filtered))
+            if _filtered:
+                return _filtered
+    except Exception:
+        pass
 
     if provider in {"copilot", "github-copilot"}:
         try:

--- a/api/config.py
+++ b/api/config.py
@@ -2902,10 +2902,32 @@ def parse_reasoning_effort(effort):
     return None
 
 
-def _strip_provider_hint_for_reasoning(model_id: str) -> str:
-    """Remove WebUI routing hints before provider-specific capability lookup."""
+def _strip_provider_hint_for_reasoning(model_id: str, provider: str | None = None) -> str:
+    """Remove WebUI routing hints before provider-specific capability lookup.
+
+    A plain ``@provider:model`` hint strips cleanly on the first colon. But a
+    *named* custom provider hint is ``@custom:<slug>:model`` — two colons —
+    and the naive first-colon split only strips the leading ``@custom:``,
+    leaving ``<slug>:model`` behind. That leftover slug fragment can hide a
+    nested gateway route from prefix-based checks like
+    ``_nested_route_reasoning_denied()`` (e.g. ``agg:vertex/gemini-image-1.0``
+    no longer starts with ``vertex/gemini-``), silently re-enabling reasoning
+    controls on routes that must never expose them.
+
+    When the resolved *provider* is known (e.g. ``"custom:agg"``), strip the
+    exact ``@{provider}:`` prefix first so both segments are removed in one
+    pass. Falls back to the generic first-colon split when no provider is
+    given or it doesn't match — preserving prior behavior for plain
+    ``@provider:model`` hints.
+    """
     model = str(model_id or "").strip()
-    if model.startswith("@") and ":" in model:
+    if not model.startswith("@"):
+        return model
+    if provider:
+        exact_prefix = f"@{provider}:".lower()
+        if model.lower().startswith(exact_prefix):
+            return model[len(exact_prefix) :]
+    if ":" in model:
         return model.split(":", 1)[1]
     return model
 
@@ -3345,7 +3367,7 @@ def resolve_model_reasoning_efforts(
     if provider in {"cursor-acp", "copilot-acp"}:
         return []
 
-    hinted_model = _strip_provider_hint_for_reasoning(model)
+    hinted_model = _strip_provider_hint_for_reasoning(model, provider)
 
     # Master hides reasoning controls for nested image/embedding routes. Keep
     # that hard deny above provider config so an explicit allowlist cannot

--- a/api/config.py
+++ b/api/config.py
@@ -3339,6 +3339,27 @@ def resolve_model_reasoning_efforts(
             provider = str((cfg.get("model") or {}).get("provider") or "").strip().lower()
 
     provider = _resolve_provider_alias(provider)
+
+    # 0. Provider config: providers.<name>.reasoning_efforts
+    # When the user has explicitly listed valid efforts for a provider,
+    # return that list directly — no heuristics, no models.dev lookup.
+    # Handles both custom:<name> and bare registered provider names (e.g. wandb).
+    _prov_name = None
+    if provider and provider.startswith("custom:"):
+        _prov_name = provider.split(":", 1)[1]
+    elif provider:
+        _prov_name = provider
+    if _prov_name:
+        try:
+            _prov_entry = (cfg.get("providers") or {}).get(_prov_name, {})
+            if isinstance(_prov_entry, dict):
+                _re_list = _prov_entry.get("reasoning_efforts")
+                if isinstance(_re_list, list) and _re_list:
+                    return [str(x).strip().lower() for x in _re_list
+                            if str(x).strip().lower() in {*VALID_REASONING_EFFORTS, "none"}]
+        except Exception:
+            pass
+
     if provider in {"cursor-acp", "copilot-acp"}:
         return []
 

--- a/tests/test_reasoning_effort_model_capabilities.py
+++ b/tests/test_reasoning_effort_model_capabilities.py
@@ -257,6 +257,37 @@ def test_nested_route_deny_wins_for_provider_qualified_hinted_model(monkeypatch)
             monkeypatch.setitem(cfg.cfg, "custom_providers", original)
 
 
+def test_nested_route_deny_is_boundary_based_not_prefix_based():
+    # Structural regression test for the underlying invariant, independent
+    # of any particular wrapper/strip scheme: _nested_route_reasoning_denied
+    # must catch the vertex/gemini- or gemini_cli/gemini- route no matter
+    # how many opaque wrapper layers precede it in the raw string, as long
+    # as the route starts at a non-alphanumeric boundary. This was bypassed
+    # twice via different prefix-stripping edge cases (PR #5313) before the
+    # check itself was made boundary-based instead of prefix-based, so no
+    # future wrapper scheme can reintroduce the same class of bug.
+    denied_cases = [
+        "vertex/gemini-image-1.0",
+        "vertex/gemini-embedding-001",
+        "@custom:agg:vertex/gemini-image-1.0",
+        "agg:vertex/gemini-image-1.0",  # the literal leftover fragment from the historical bug
+        "gemini_cli/gemini-imagine-2",
+        "outer:inner:vertex/gemini-image-1.0",  # hypothetical deeper future nesting
+        "@custom:outer:@custom:inner:vertex/gemini-embedding-001",
+    ]
+    for model in denied_cases:
+        assert cfg._nested_route_reasoning_denied(model) is True, model
+
+    allowed_cases = [
+        "vertex/gemini-2.5-pro",
+        "notvertex/gemini-image-1.0",  # embedded in a larger token — must NOT match
+        "somegemini_cli/gemini-image-1",  # same — embedded substring, not a boundary
+        "",
+    ]
+    for model in allowed_cases:
+        assert cfg._nested_route_reasoning_denied(model) is False, model
+
+
 def test_get_reasoning_status_includes_supported_efforts(monkeypatch):
     monkeypatch.setattr(
         cfg,

--- a/tests/test_reasoning_effort_model_capabilities.py
+++ b/tests/test_reasoning_effort_model_capabilities.py
@@ -118,6 +118,115 @@ def test_non_reasoning_http_models_hide_reasoning_effort_levels():
     ) == []
 
 
+def test_provider_config_reasoning_efforts_return_filtered_deduped(monkeypatch):
+    original = cfg.cfg.get("providers")
+    monkeypatch.setitem(
+        cfg.cfg,
+        "providers",
+        {
+            "wandb": {
+                "reasoning_efforts": [
+                    " none ",
+                    "HIGH",
+                    "bogus",
+                    "high",
+                    "xhigh",
+                ]
+            }
+        },
+    )
+    try:
+        assert cfg.resolve_model_reasoning_efforts(
+            "zai-org/GLM-5.2",
+            provider_id="wandb",
+        ) == ["none", "high", "xhigh"]
+    finally:
+        if original is None:
+            cfg.cfg.pop("providers", None)
+        else:
+            monkeypatch.setitem(cfg.cfg, "providers", original)
+
+
+def test_provider_config_all_invalid_falls_through(monkeypatch):
+    original = cfg.cfg.get("providers")
+    monkeypatch.setitem(
+        cfg.cfg,
+        "providers",
+        {"wandb": {"reasoning_efforts": ["bogus", "typo"]}},
+    )
+    try:
+        result = cfg.resolve_model_reasoning_efforts(
+            "zai-org/GLM-5.2",
+            provider_id="wandb",
+        )
+        assert result != []
+        assert "bogus" not in result
+        assert "typo" not in result
+    finally:
+        if original is None:
+            cfg.cfg.pop("providers", None)
+        else:
+            monkeypatch.setitem(cfg.cfg, "providers", original)
+
+
+def test_named_custom_provider_config_reasoning_efforts(monkeypatch):
+    original = cfg.cfg.get("custom_providers")
+    monkeypatch.setitem(
+        cfg.cfg,
+        "custom_providers",
+        [{"name": "llm-proxy", "reasoning_efforts": ["none", "high", "xhigh"]}],
+    )
+    try:
+        assert cfg.resolve_model_reasoning_efforts(
+            "some-model",
+            provider_id="custom:llm-proxy",
+        ) == ["none", "high", "xhigh"]
+    finally:
+        if original is None:
+            cfg.cfg.pop("custom_providers", None)
+        else:
+            monkeypatch.setitem(cfg.cfg, "custom_providers", original)
+
+
+def test_acp_guards_win_over_configured_reasoning_efforts(monkeypatch):
+    original = cfg.cfg.get("providers")
+    monkeypatch.setitem(
+        cfg.cfg,
+        "providers",
+        {"copilot-acp": {"reasoning_efforts": ["high"]}},
+    )
+    try:
+        assert cfg.resolve_model_reasoning_efforts(
+            "some-model",
+            provider_id="copilot-acp",
+        ) == []
+    finally:
+        if original is None:
+            cfg.cfg.pop("providers", None)
+        else:
+            monkeypatch.setitem(cfg.cfg, "providers", original)
+
+
+def test_nested_route_deny_wins_over_configured_reasoning_efforts(monkeypatch):
+    original = cfg.cfg.get("custom_providers")
+    monkeypatch.setitem(
+        cfg.cfg,
+        "custom_providers",
+        [{"name": "agg", "reasoning_efforts": ["low", "high"]}],
+    )
+    try:
+        for model in ("vertex/gemini-image-1.0", "vertex/gemini-embedding-001"):
+            assert cfg.resolve_model_reasoning_efforts(
+                model,
+                provider_id="custom:agg",
+            ) == []
+    finally:
+        if original is None:
+            cfg.cfg.pop("custom_providers", None)
+        else:
+            monkeypatch.setitem(cfg.cfg, "custom_providers", original)
+
+
 def test_get_reasoning_status_includes_supported_efforts(monkeypatch):
     monkeypatch.setattr(
         cfg,

--- a/tests/test_reasoning_effort_model_capabilities.py
+++ b/tests/test_reasoning_effort_model_capabilities.py
@@ -227,6 +227,36 @@ def test_nested_route_deny_wins_over_configured_reasoning_efforts(monkeypatch):
             monkeypatch.setitem(cfg.cfg, "custom_providers", original)
 
 
+def test_nested_route_deny_wins_for_provider_qualified_hinted_model(monkeypatch):
+    # Regression for the deeper bypass: a provider-qualified hint like
+    # "@custom:agg:vertex/gemini-image-1.0" must strip BOTH the "@custom:"
+    # wrapper AND the named-provider slug "agg:" before the nested-route
+    # deny check runs. A naive first-colon split only strips "@custom:",
+    # leaving "agg:vertex/gemini-image-1.0" — which no longer starts with
+    # "vertex/gemini-" — so the deny is missed and the configured
+    # ["low", "high"] leaks through on an image/embedding route.
+    original = cfg.cfg.get("custom_providers")
+    monkeypatch.setitem(
+        cfg.cfg,
+        "custom_providers",
+        [{"name": "agg", "reasoning_efforts": ["low", "high"]}],
+    )
+    try:
+        for model in (
+            "@custom:agg:vertex/gemini-image-1.0",
+            "@custom:agg:vertex/gemini-embedding-001",
+        ):
+            assert cfg.resolve_model_reasoning_efforts(
+                model,
+                provider_id="custom:agg",
+            ) == []
+    finally:
+        if original is None:
+            cfg.cfg.pop("custom_providers", None)
+        else:
+            monkeypatch.setitem(cfg.cfg, "custom_providers", original)
+
+
 def test_get_reasoning_status_includes_supported_efforts(monkeypatch):
     monkeypatch.setattr(
         cfg,


### PR DESCRIPTION
## What
Adds `providers.<name>.reasoning_efforts` config support to `resolve_model_reasoning_efforts()`.

## Why
Some models only support a subset of Hermes's reasoning effort levels. For example, GLM-5.2 on W&B's vLLM endpoint only recognizes "high" and "max" (xhigh) for `reasoning_effort`, plus `enable_thinking: false` for non-think mode. The other levels ("minimal", "low", "medium") are silently ignored.

Without this change, the WebUI reasoning dropdown shows all 5 effort levels for every reasoning-capable model. With this change, users can declare which levels are valid:

```yaml
providers:
  wandb:
    base_url: https://api.inference.wandb.ai/v1
    reasoning_efforts:
      - none
      - high
      - xhigh
```

The dropdown then filters to only those options.

## How
Adds a new step 0 in `resolve_model_reasoning_efforts()` that checks `providers.<name>.reasoning_efforts` before falling back to existing heuristics. Handles both `custom:<name>` and bare registered provider names. Falls through gracefully when no config entry is present — zero behavior change for existing setups.