### PR TITLE
docs(extensions): link EXTENSIONS.md to the vetted extension library repo

### DIFF
--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -17,6 +17,15 @@ This is intentionally not a plugin marketplace or dependency system. It is a
 safe escape hatch for local dashboards, internal tooling, and workflow-specific
 panels that should not live in core Hermes WebUI.
 
+> **The vetted extension library.** The curated, one-click-installable extensions
+> that appear in the gallery live in a separate public repo:
+> **[hermes-webui/hermes-webui-extensions](https://github.com/hermes-webui/hermes-webui-extensions)**.
+> "In the registry == vetted." That repo holds the entries, the authoring
+> conventions ([`docs/extension-entry.md`](https://github.com/hermes-webui/hermes-webui-extensions/blob/main/docs/extension-entry.md)),
+> the JSON schema, and the CI safety gates. This document covers the WebUI-side
+> *infrastructure* (loader, manifest contract, capabilities, install client);
+> see the library repo to browse existing extensions or contribute a new one.
+
 ## What extensions can do
 
 Extensions can:
@@ -532,6 +541,16 @@ If host CSS overrides `[hidden]`, add an extension-scoped rule such as:
   display: none !important;
 }
 ```
+
+### Contributing to the extension library
+
+To publish an extension in the vetted gallery, open a PR against
+**[hermes-webui/hermes-webui-extensions](https://github.com/hermes-webui/hermes-webui-extensions)**
+following [`docs/extension-entry.md`](https://github.com/hermes-webui/hermes-webui-extensions/blob/main/docs/extension-entry.md)
+(entry layout, `extension.json`/`manifest.json` shape, and the capability +
+best-practice conventions). Every entry PR runs the repo's CI validators and
+safety scan before it can merge, and merged entries are published to the registry
+that powers Settings → Extensions.
 
 ## Minimal example
 


### PR DESCRIPTION
## Link the extension docs to the vetted library repo

`docs/EXTENSIONS.md` thoroughly documents the WebUI-side extension *infrastructure* — the loader, manifest contract, capabilities (`settings_schema`, `registerHermesSkin` + `scheme`, `registerHermesTtsEngine`), and the install client — but it never linked to **[hermes-webui/hermes-webui-extensions](https://github.com/hermes-webui/hermes-webui-extensions)**, the public repo where the vetted, one-click-installable gallery entries actually live and where new extensions are contributed. A reader learns how the machinery works but not where to find or contribute the extensions themselves.

This adds two cross-links, **no behavior change, docs-only**:
- An intro callout pointing to the library repo + its `docs/extension-entry.md`, framing this doc as the infrastructure side and the library repo as where entries live ("in the registry == vetted").
- A short "Contributing to the extension library" pointer at the end of the authoring guidance, describing the entry-PR → CI safety-gate → registry-publish flow.

Everything else in EXTENSIONS.md is already accurate against current behavior (the `scheme` and `settings_schema` sections that shipped with those capabilities are correct), so this is deliberately a minimal, targeted link pass rather than a rewrite.

Companion PRs on the library side: hermes-webui/hermes-webui-extensions#37 (Capabilities & Best Practices section in `docs/extension-entry.md`) and #36 (first `settings_schema` retrofit).