### PR TITLE
fix(webui): handle stale clarify polling after profile switch

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -7528,7 +7528,18 @@ function _startClarifyFallbackPoll(sid) {
       else { _clearClarifyPendingForSession(sid); _hideClarifyCardIfOwner(sid, false, 'expired'); }
     } catch(e) {
       const msg = String((e && e.message) || "");
-      if (!_clarifyMissingEndpointWarned && /(^|\b)(404|not found)(\b|$)/i.test(msg)) {
+      const status = e && e.status;
+      // A profile switch can leave an old-profile session polling briefly under
+      // the new profile cookie.  The backend correctly returns 404 "Session not
+      // found" in that case; it is not a missing clarify endpoint and should not
+      // tell the user to restart the server.
+      if (status === 404 && /session\s+not\s+found/i.test(msg)) {
+        _clearClarifyPendingForSession(sid);
+        _hideClarifyCardIfOwner(sid, true, 'session');
+        stopClarifyPolling();
+        return;
+      }
+      if (!_clarifyMissingEndpointWarned && (status === 404 || /(^|\b)(404|not found)(\b|$)/i.test(msg))) {
         _clarifyMissingEndpointWarned = true;
         setComposerStatus("Clarify unavailable on current server build. Restart server.");
         if (typeof showToast === "function") {


### PR DESCRIPTION
## Summary

- handle the stale clarify polling case that can happen immediately after switching profiles
- treat `404 Session not found` from the old session as a terminal stale-session response, not as a missing clarify endpoint
- stop the old clarify poll and hide the stale card instead of telling the user to restart the server

## Why

When the user switches profiles, the old profile's active session can briefly keep polling `/api/clarify/pending` while subsequent requests already carry the new profile cookie. The backend correctly answers `404 Session not found`, but the frontend currently treats any 404 as a missing clarify endpoint and surfaces a misleading restart warning.

## Validation

- `git diff --check origin/master...HEAD`
- private/site marker scan on the PR diff
- `node --check static/messages.js`
- `pytest -q tests/test_clarify_sse.py tests/test_clarify_unblock.py tests/test_4504_clarify_stuck_on_expiry.py tests/test_1466_sidebar_cancel_clarify.py tests/test_issue2883_clarify_padding.py` — 62 passed
