### PR TITLE
Release — fix false clarify-unavailable toast + interrupt provenance (#5345)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 
 ## [Unreleased]
 
-_No unreleased changes. Entries are moved into their version block when a release is tagged._
+### Fixed
+
+- **The "Clarify endpoint unavailable. Please restart server." toast no longer fires falsely.** `/api/clarify/pending` always returns HTTP 200 when present (it answers `{"pending": null}` for an unknown session — it never 404s), yet the front-end poller warned "restart the server" on *any* caught error whose message merely contained "404" or "not found". An unrelated stale-session 404 (`Session not found`, e.g. an old-profile session still polling briefly after a profile switch) or a transient error therefore surfaced a misleading missing-endpoint toast pointing operators at the wrong layer. Clarify polling now branches on the structured HTTP status (`err.status`) that `api()` attaches: a `404 Session not found` is handled as a stale-session poll (stop + hide the card silently), and the restart-server warning fires only on a genuine route-not-found 404 whose body is not session-scoped. Poll failures are also logged with the request path, HTTP status, polling session id, and current session id for diagnosis. Thanks @claw-io for the report and @ruizanthony for the initial profile-switch fix. (#5345, absorbs #5343)
+
+- **Stream cancellation now records its provenance.** `cancelStream()` / `cancelSessionStream()` log a `[stream] cancel requested` line with the trigger (`composer-stop`, `slash-stop`, `slash-interrupt`, `busy-interrupt`, `sidebar-stop`) so a backend interrupt (SIGINT / exit code 130) can be attributed to an explicit user action. Passive UI lifecycle events (session switch, tab hide, page unload) continue to tear down only the local SSE transport and never send an interrupt to the running agent or tool — only explicit Stop/interrupt paths do. (#5345)
+
+_Entries are moved into their version block when a release is tagged._
 
 ## [v0.51.792] — 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ _No unreleased changes. Entries are moved into their version block when a releas
 
 ### Fixed
 
+- **No more false "Clarify endpoint unavailable. Please restart server." toast.** The clarify-pending poll used to fire the restart-server warning on any error whose message merely contained "404"/"not found" — so a harmless stale `Session not found` from a just-switched profile mis-triggered it even though the clarify endpoint was fine. The poll now branches on the structured HTTP status: a session-scoped 404 is treated as a stale poll (silently stops), and the restart warning fires only on a genuine missing-route 404. Interrupt provenance is also now labeled (explicit Stop vs stream-lifecycle) for clearer settlement. (#5345)
+
 - **Ghost sessions can be cleared from the sidebar.** Bulk index-only "Untitled" sessions — rows left in the session index with no backing conversation file — are now pruned by the session cleanup sweep instead of lingering forever and un-removable. A legitimate session (with a saved file or an active in-memory session) is never touched. (#5331)
 
 - **Delegated subagent sessions open correctly and are treated as view-only.** Opening a `delegate_task` subagent child from the sidebar now loads its transcript from Hermes `state.db` instead of showing an empty pane (it has no WebUI sidecar of its own). Subagent children are view-only — owned by the delegate runner — so they render read-only and every session-mutation route (delete / rename / truncate / clear / pin / duplicate / branch / retry / undo / archive / compress / draft / personality / goal / btw) refuses them, preventing accidental edits or deletion of the child's state.db transcript. (#5307)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,7 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- **The "Clarify endpoint unavailable. Please restart server." toast no longer fires falsely.** `/api/clarify/pending` always returns HTTP 200 when present (it answers `{"pending": null}` for an unknown session — it never 404s), yet the front-end poller warned "restart the server" on *any* caught error whose message merely contained "404" or "not found". An unrelated stale-session 404 (`Session not found`, e.g. an old-profile session still polling briefly after a profile switch) or a transient error therefore surfaced a misleading missing-endpoint toast pointing operators at the wrong layer. Clarify polling now branches on the structured HTTP status (`err.status`) that `api()` attaches: a `404 Session not found` is handled as a stale-session poll (stop + hide the card silently), and the restart-server warning fires only on a genuine route-not-found 404 whose body is not session-scoped. Poll failures are also logged with the request path, HTTP status, polling session id, and current session id for diagnosis. Thanks @claw-io for the report and @ruizanthony for the initial profile-switch fix. (#5345, absorbs #5343)
-
-- **Stream cancellation now records its provenance.** `cancelStream()` / `cancelSessionStream()` log a `[stream] cancel requested` line with the trigger (`composer-stop`, `slash-stop`, `slash-interrupt`, `busy-interrupt`, `sidebar-stop`) so a backend interrupt (SIGINT / exit code 130) can be attributed to an explicit user action. Passive UI lifecycle events (session switch, tab hide, page unload) continue to tear down only the local SSE transport and never send an interrupt to the running agent or tool — only explicit Stop/interrupt paths do. (#5345)
-
-_Entries are moved into their version block when a release is tagged._
+_No unreleased changes. Entries are moved into their version block when a release is tagged._
 
 ## [v0.51.792] — 2026-07-01
 

--- a/static/boot.js
+++ b/static/boot.js
@@ -14,10 +14,21 @@
 // cancelStream: stop the active chat stream.
 // See docs/rfcs/webui-run-state-consistency-contract.md (Invariants #2, #4)
 // for the owner-aware + terminal-settle rationale.
-async function cancelStream(){
+async function cancelStream(reason){
   const sid = S.session && S.session.session_id;
   const streamId = S.activeStreamId;
   if(!streamId) return;
+  // Interrupt provenance: log WHY the active run is being cancelled so operators
+  // can tell an explicit Stop / interrupt from any other trigger when they see a
+  // SIGINT/exit-code-130 in the backend logs. Only explicit user paths reach
+  // this function (Stop button, /stop, /interrupt, busy-interrupt); passive
+  // lifecycle events — session switch, tab hide, page unload — tear down the
+  // LOCAL SSE transport via closeLiveStream() and never call /api/chat/cancel,
+  // so they never interrupt the backend agent/tool run. (#5345)
+  const _reason = reason || 'explicit-cancel';
+  if(typeof console !== 'undefined' && console.info){
+    console.info('[stream] cancel requested', {reason:_reason, streamId, sessionId:sid});
+  }
   let respBody=null;
   try{
     const r=await fetch(new URL(`api/chat/cancel?stream_id=${encodeURIComponent(streamId)}`,document.baseURI||location.href).href,{credentials:'include'});
@@ -54,6 +65,11 @@ async function cancelSessionStream(session){
   const streamId = session&&session.active_stream_id;
   const sid = session&&session.session_id;
   if(!streamId||!sid) return;
+  // Explicit sidebar "Stop response" — log provenance for the same reason as
+  // cancelStream(). (#5345)
+  if(typeof console !== 'undefined' && console.info){
+    console.info('[stream] cancel requested', {reason:'sidebar-stop', streamId, sessionId:sid});
+  }
   try{
     await fetch(new URL(`api/chat/cancel?stream_id=${encodeURIComponent(streamId)}`,document.baseURI||location.href).href,{credentials:'include'});
   }catch(e){/* close local stream; keep UI state honest below */}

--- a/static/commands.js
+++ b/static/commands.js
@@ -1211,7 +1211,7 @@ async function cmdPersonality(args){
 async function cmdStop(){
   if(!S.session){showToast(t('no_active_session'));return;}
   if(!S.activeStreamId){showToast(t('no_active_task'));return;}
-  if(typeof cancelStream==='function'){await cancelStream();showToast(t('stream_stopped'));}
+  if(typeof cancelStream==='function'){await cancelStream('slash-stop');showToast(t('stream_stopped'));}
   else showToast(t('cancel_unavailable'));
 }
 
@@ -1317,7 +1317,7 @@ async function cmdInterrupt(args){
   updateQueueBadge(S.session.session_id);
   S.pendingFiles=[];renderTray();
   // Cancel the active stream; setBusy(false) will drain the queue
-  if(typeof cancelStream==='function'){await cancelStream();}
+  if(typeof cancelStream==='function'){await cancelStream('slash-interrupt');}
   showToast(t('cmd_interrupt_confirm'),2000);
 }
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -1299,7 +1299,7 @@ async function send(){
         S.pendingFiles=[];renderTray();
         if(S.activeStreamId&&typeof cancelStream==='function'){
           showToast(t('busy_interrupt_confirm'),2000);
-          await cancelStream();
+          await cancelStream('busy-interrupt');
         } else {
           showToast(`Queued: "${text.slice(0,40)}${text.length>40?'…':''}"`,2000);
         }
@@ -7528,7 +7528,49 @@ function _startClarifyFallbackPoll(sid) {
       else { _clearClarifyPendingForSession(sid); _hideClarifyCardIfOwner(sid, false, 'expired'); }
     } catch(e) {
       const msg = String((e && e.message) || "");
-      if (!_clarifyMissingEndpointWarned && /(^|\b)(404|not found)(\b|$)/i.test(msg)) {
+      // `api()` attaches the raw HTTP status on the thrown Error (err.status).
+      // Branch on that structured value instead of scraping the message string
+      // so an unrelated stale-session or lifecycle error can never masquerade as
+      // a missing clarify endpoint. (#5345)
+      const status = (e && typeof e.status === "number") ? e.status : null;
+      const currentSid = (S.session && S.session.session_id) || null;
+      // Structured diagnostics: a clarify poll failure should be inspectable
+      // without guessing from a toast — log the failed path, HTTP status (if
+      // any), the session id we were polling, and the current active session
+      // id. (#5345)
+      if (typeof console !== "undefined" && console.warn) {
+        console.warn("[clarify] pending poll failed", {
+          path: "/api/clarify/pending",
+          status: status,
+          pollingSessionId: sid,
+          currentSessionId: currentSid,
+          message: msg,
+        });
+      }
+      // A 404 whose body is "Session not found" is a STALE-SESSION signal — e.g.
+      // the old profile's session still polling briefly after a profile switch,
+      // or a session deleted server-side — NOT a missing clarify endpoint. Stop
+      // this stale poll and hide its card silently instead of telling the user
+      // to restart the server. (#5343 / #5345)
+      if (status === 404 && /session\s+not\s+found/i.test(msg)) {
+        _clearClarifyPendingForSession(sid);
+        _hideClarifyCardIfOwner(sid, true, 'session');
+        stopClarifyPolling();
+        return;
+      }
+      // Only a GENUINE missing-endpoint 404 (the route-not-found fall-through,
+      // body {"error":"not found"}, from a server build that predates
+      // /api/clarify/pending) should surface the restart-server warning. The
+      // previous code matched arbitrary "404"/"not found" text in ANY caught
+      // error message, so an unrelated stale-session 404 or a transient network
+      // error produced a false "Clarify endpoint unavailable" toast even though
+      // the endpoint is present and returning HTTP 200 on every request. Gate
+      // strictly on the structured status + a route-not-found body that is not
+      // a session-scoped 404. (#5345)
+      const isMissingEndpoint = status === 404
+        && /(^|\b)not\s+found(\b|$)/i.test(msg)
+        && !/session/i.test(msg);
+      if (!_clarifyMissingEndpointWarned && isMissingEndpoint) {
         _clarifyMissingEndpointWarned = true;
         setComposerStatus("Clarify unavailable on current server build. Restart server.");
         if (typeof showToast === "function") {

--- a/static/messages.js
+++ b/static/messages.js
@@ -7534,25 +7534,23 @@ function _startClarifyFallbackPoll(sid) {
       // a missing clarify endpoint. (#5345)
       const status = (e && typeof e.status === "number") ? e.status : null;
       const currentSid = (S.session && S.session.session_id) || null;
-      // Structured diagnostics: a clarify poll failure should be inspectable
-      // without guessing from a toast — log the failed path, HTTP status (if
-      // any), the session id we were polling, and the current active session
-      // id. (#5345)
-      if (typeof console !== "undefined" && console.warn) {
-        console.warn("[clarify] pending poll failed", {
-          path: "/api/clarify/pending",
-          status: status,
-          pollingSessionId: sid,
-          currentSessionId: currentSid,
-          message: msg,
-        });
-      }
-      // A 404 whose body is "Session not found" is a STALE-SESSION signal — e.g.
+      const logDetails = {
+        path: "/api/clarify/pending",
+        status: status,
+        pollingSessionId: sid,
+        currentSessionId: currentSid,
+        message: msg,
+      };
+      // A 404 from the active session domain is a STALE-SESSION signal — e.g.
       // the old profile's session still polling briefly after a profile switch,
       // or a session deleted server-side — NOT a missing clarify endpoint. Stop
       // this stale poll and hide its card silently instead of telling the user
-      // to restart the server. (#5343 / #5345)
-      if (status === 404 && /session\s+not\s+found/i.test(msg)) {
+      // to restart the server. Keep this branch before any warn-level logging:
+      // routine profile switches must not fill DevTools with expected warnings.
+      // (#5343 / #5345)
+      const isSessionScoped404 = status === 404
+        && (/session/i.test(msg) || (currentSid !== null && currentSid !== sid));
+      if (isSessionScoped404) {
         _clearClarifyPendingForSession(sid);
         _hideClarifyCardIfOwner(sid, true, 'session');
         stopClarifyPolling();
@@ -7569,14 +7567,26 @@ function _startClarifyFallbackPoll(sid) {
       // a session-scoped 404. (#5345)
       const isMissingEndpoint = status === 404
         && /(^|\b)not\s+found(\b|$)/i.test(msg)
-        && !/session/i.test(msg);
-      if (!_clarifyMissingEndpointWarned && isMissingEndpoint) {
-        _clarifyMissingEndpointWarned = true;
-        setComposerStatus("Clarify unavailable on current server build. Restart server.");
-        if (typeof showToast === "function") {
-          showToast("Clarify endpoint unavailable. Please restart server.", 5000);
+        && !isSessionScoped404;
+      if (isMissingEndpoint) {
+        if (!_clarifyMissingEndpointWarned) {
+          _clarifyMissingEndpointWarned = true;
+          setComposerStatus("Clarify unavailable on current server build. Restart server.");
+          if (typeof showToast === "function") {
+            showToast("Clarify endpoint unavailable. Please restart server.", 5000);
+          }
+          if (typeof console !== "undefined" && console.warn) {
+            console.warn("[clarify] pending poll endpoint unavailable", logDetails);
+          }
         }
         stopClarifyPolling();
+        return;
+      }
+      // Structured diagnostics: unexpected clarify poll failures should be
+      // inspectable without guessing from a toast. Expected stale-session 404s
+      // and the handled missing-endpoint route have already returned above.
+      if (typeof console !== "undefined" && console.warn) {
+        console.warn("[clarify] pending poll failed", logDetails);
       }
     } finally {
       _clarifyFallbackPollInFlight = false;

--- a/static/ui.js
+++ b/static/ui.js
@@ -6437,7 +6437,7 @@ async function handleComposerPrimaryAction(){
   const action=typeof getComposerPrimaryAction==='function'?getComposerPrimaryAction():'send';
   if(action==='disabled') return;
   if(action==='stop'){
-    if(typeof cancelStream==='function') await cancelStream();
+    if(typeof cancelStream==='function') await cancelStream('composer-stop');
     return;
   }
   await send();

--- a/tests/test_cancel_stream_owner_guard.py
+++ b/tests/test_cancel_stream_owner_guard.py
@@ -329,7 +329,16 @@ def _run_cancel_stream_scenarios() -> dict:
             f"--- stderr ---\n{completed.stderr}"
         )
     try:
-        return json.loads(completed.stdout)
+        # The function under test legitimately emits diagnostic lines on stdout
+        # (e.g. cancelStream's '[stream] cancel requested' provenance log, added
+        # for #5345). Those fire DURING runAll(); the result JSON is written by
+        # `console.log(JSON.stringify(r))` only after runAll() resolves, so it is
+        # always the LAST non-empty stdout line. Parse that rather than assuming
+        # stdout is pure JSON.
+        lines = [ln for ln in completed.stdout.splitlines() if ln.strip()]
+        if not lines:
+            raise json.JSONDecodeError("empty stdout", completed.stdout or "", 0)
+        return json.loads(lines[-1])
     except json.JSONDecodeError as e:
         raise AssertionError(
             f"node subprocess returned non-JSON output:\n"

--- a/tests/test_issue5345_clarify_toast_and_interrupt_provenance.py
+++ b/tests/test_issue5345_clarify_toast_and_interrupt_provenance.py
@@ -1,0 +1,178 @@
+"""Regression tests for issue #5345.
+
+Two symptoms, both surfaced from front-end source guards (these are static-source
+assertions — no server needed):
+
+1. Misleading "Clarify endpoint unavailable. Please restart server." toast.
+   `/api/clarify/pending` ALWAYS returns HTTP 200 when the route is present (it
+   returns {"pending": null} for an unknown session — never 404). The old catch
+   block fired the restart-server toast on ANY caught error whose message matched
+   the broad regex ``/(^|\\b)(404|not found)(\\b|$)/i``. An unrelated stale-session
+   404 ("Session not found") or transient error therefore produced a false
+   missing-endpoint toast. The fix branches on the STRUCTURED HTTP status that
+   `api()` attaches to the thrown Error (err.status) and only warns on a genuine
+   route-not-found 404 whose body is not session-scoped.
+
+2. Interrupt provenance. The issue asks that only explicit cancellation reach the
+   backend and that cancellation source be observable. Passive lifecycle events
+   (session switch / tab hide / page unload) already tear down only the LOCAL SSE
+   transport via closeLiveStream() and never call /api/chat/cancel; the fix adds a
+   provenance log to cancelStream()/cancelSessionStream() and threads a distinct
+   `reason` from every explicit call site so a backend SIGINT/exit-130 can be
+   attributed.
+
+Backend fact locked by test_clarify_pending_never_404s: the handler returns 200
+with {"pending": None} for an unknown session, so a real 404 can only be a
+missing route (server predates the endpoint) or an unrelated session-scoped 404.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+
+
+def _clarify_catch_block():
+    """Return the source of the clarify fallback-poll catch block."""
+    idx = MESSAGES_JS.find("function _startClarifyFallbackPoll")
+    assert idx != -1, "_startClarifyFallbackPoll not found in messages.js"
+    # Grab a generous window covering the catch/finally of the poll tick.
+    return MESSAGES_JS[idx: idx + 3500]
+
+
+# ── Part 1: clarify toast false positive ────────────────────────────────────
+
+def test_clarify_toast_no_longer_uses_broad_message_regex():
+    """The old broad ``(404|not found)`` message-scrape must be gone — that is the
+    exact matcher that turned an unrelated stale-session 404 into a false
+    'restart server' toast."""
+    block = _clarify_catch_block()
+    assert r"/(^|\b)(404|not found)(\b|$)/i.test(msg)" not in block, (
+        "The broad clarify missing-endpoint regex is still present — an unrelated "
+        "404/'not found' error message can still trigger a false restart-server toast."
+    )
+
+
+def test_clarify_toast_branches_on_structured_status():
+    """The catch block must read the structured HTTP status (err.status) that
+    api() attaches, not infer it from the message string."""
+    block = _clarify_catch_block()
+    assert "e.status" in block, (
+        "clarify poll catch block must branch on the structured err.status "
+        "(set by api()), not scrape the message text."
+    )
+
+
+def test_clarify_missing_endpoint_requires_404_and_non_session_body():
+    """The missing-endpoint warning must be gated on status===404 AND a
+    route-not-found body that is NOT session-scoped, so a 'Session not found'
+    404 never surfaces the restart-server toast."""
+    block = _clarify_catch_block()
+    m = re.search(r"const\s+isMissingEndpoint\s*=([^;]+);", block, re.DOTALL)
+    assert m, "expected an isMissingEndpoint guard expression in the catch block"
+    guard = m.group(1)
+    assert "status === 404" in guard or "status===404" in guard, (
+        "missing-endpoint guard must require a 404 status"
+    )
+    assert "!/session/i.test(msg)" in guard.replace(" ", "") or "!/session/i.test(msg)" in guard, (
+        "missing-endpoint guard must EXCLUDE session-scoped 404s so a "
+        "'Session not found' error is not mistaken for a missing endpoint."
+    )
+
+
+def test_stale_session_404_handled_before_missing_endpoint():
+    """A 404 'Session not found' must be treated as a stale-session poll (stop +
+    hide silently), and that branch must appear BEFORE the missing-endpoint
+    warning branch so the warning can never fire for it."""
+    block = _clarify_catch_block()
+    stale_idx = block.find("session\\s+not\\s+found")
+    warn_idx = block.find("isMissingEndpoint")
+    assert stale_idx != -1, "stale-session 404 branch (session not found) not found"
+    assert warn_idx != -1, "missing-endpoint guard not found"
+    assert stale_idx < warn_idx, (
+        "the stale-session 404 branch must be evaluated before the "
+        "missing-endpoint warning so a session-scoped 404 never warns."
+    )
+
+
+def test_clarify_poll_failure_is_logged_with_context():
+    """Clarify poll failures must be observable: path, status, polling session
+    id, and current session id (maintainer question #2)."""
+    block = _clarify_catch_block()
+    assert "[clarify] pending poll failed" in block, (
+        "clarify poll failure should log a structured diagnostic line"
+    )
+    for field in ("path", "status", "pollingSessionId", "currentSessionId"):
+        assert field in block, f"clarify failure log must include {field!r}"
+
+
+# ── Part 2: interrupt provenance ────────────────────────────────────────────
+
+def test_cancel_stream_accepts_reason_param():
+    """cancelStream must take a `reason` so explicit-cancel provenance is
+    attributable in the logs."""
+    m = re.search(r"async\s+function\s+cancelStream\s*\(([^)]*)\)", BOOT_JS)
+    assert m, "cancelStream declaration not found in boot.js"
+    params = [p.strip() for p in m.group(1).split(",") if p.strip()]
+    assert "reason" in params, (
+        f"cancelStream must accept a `reason` parameter; got params {params}"
+    )
+
+
+def test_cancel_stream_logs_provenance():
+    """cancelStream / cancelSessionStream must log the cancellation reason so a
+    backend SIGINT/exit-130 can be attributed to an explicit user action."""
+    assert "[stream] cancel requested" in BOOT_JS, (
+        "cancelStream must log a '[stream] cancel requested' provenance line"
+    )
+    # both explicit backend-cancel functions log it
+    assert BOOT_JS.count("[stream] cancel requested") >= 2, (
+        "both cancelStream and cancelSessionStream should log provenance"
+    )
+
+
+def test_explicit_cancel_call_sites_pass_a_reason():
+    """Every explicit cancelStream() call site should pass a descriptive reason
+    string (composer-stop, slash-stop, slash-interrupt, busy-interrupt) so the
+    provenance log is meaningful rather than a bare 'explicit-cancel'."""
+    ui = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+    commands = (ROOT / "static" / "commands.js").read_text(encoding="utf-8")
+    messages = MESSAGES_JS
+    combined = ui + commands + messages
+    # No bare await cancelStream() with empty args at the explicit call sites.
+    bare = re.findall(r"await\s+cancelStream\(\s*\)", combined)
+    assert not bare, (
+        f"found {len(bare)} bare cancelStream() call(s) with no reason — each "
+        "explicit call site must pass a provenance reason string."
+    )
+    for reason in ("composer-stop", "slash-stop", "slash-interrupt", "busy-interrupt"):
+        assert f"cancelStream('{reason}')" in combined or f'cancelStream("{reason}")' in combined, (
+            f"expected an explicit cancelStream call with reason {reason!r}"
+        )
+
+
+# ── Backend invariant that the front-end fix depends on ─────────────────────
+
+def test_clarify_pending_never_404s():
+    """The whole Part-1 fix rests on /api/clarify/pending returning 200 (with
+    {"pending": None}) for any session — a 404 from that path is ALWAYS either a
+    missing route or an unrelated error. Lock the handler shape."""
+    routes = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+    m = re.search(
+        r"def _handle_clarify_pending\(handler, parsed\):(.*?)\ndef ",
+        routes,
+        re.DOTALL,
+    )
+    assert m, "_handle_clarify_pending not found"
+    handler_src = m.group(1)
+    assert "404" not in handler_src, (
+        "_handle_clarify_pending must never return 404 — it returns 200 with "
+        "{'pending': None} for unknown sessions. If this changes, the front-end "
+        "clarify toast logic in messages.js must be revisited."
+    )
+    assert '{"pending": None}' in handler_src or "{'pending': None}" in handler_src, (
+        "_handle_clarify_pending should return {'pending': None} for no pending clarify"
+    )

--- a/tests/test_issue5345_clarify_toast_and_interrupt_provenance.py
+++ b/tests/test_issue5345_clarify_toast_and_interrupt_provenance.py
@@ -40,7 +40,7 @@ def _clarify_catch_block():
     idx = MESSAGES_JS.find("function _startClarifyFallbackPoll")
     assert idx != -1, "_startClarifyFallbackPoll not found in messages.js"
     # Grab a generous window covering the catch/finally of the poll tick.
-    return MESSAGES_JS[idx: idx + 3500]
+    return MESSAGES_JS[idx: idx + 5500]
 
 
 # ── Part 1: clarify toast false positive ────────────────────────────────────
@@ -77,24 +77,60 @@ def test_clarify_missing_endpoint_requires_404_and_non_session_body():
     assert "status === 404" in guard or "status===404" in guard, (
         "missing-endpoint guard must require a 404 status"
     )
-    assert "!/session/i.test(msg)" in guard.replace(" ", "") or "!/session/i.test(msg)" in guard, (
+    assert "!isSessionScoped404" in guard.replace(" ", ""), (
         "missing-endpoint guard must EXCLUDE session-scoped 404s so a "
         "'Session not found' error is not mistaken for a missing endpoint."
     )
 
 
+def test_stale_session_guard_is_not_tied_to_one_exact_backend_message():
+    """The stale-session branch should not depend only on the exact
+    'Session not found' wording: session-like 404 bodies and a current-session
+    mismatch after a profile switch are expected stale polls."""
+    block = _clarify_catch_block()
+    m = re.search(r"const\s+isSessionScoped404\s*=([^;]+);", block, re.DOTALL)
+    assert m, "expected an isSessionScoped404 guard expression in the catch block"
+    guard = m.group(1).replace(" ", "")
+    assert "status===404" in guard, "stale-session guard must require a 404 status"
+    assert "/session/i.test(msg)" in guard, (
+        "stale-session guard should classify session-scoped 404 bodies without "
+        "requiring the exact 'Session not found' wording"
+    )
+    assert "currentSid!==null&&currentSid!==sid" in guard, (
+        "stale-session guard should also cover the profile-switch race where the "
+        "active session changed while the old poll request was in flight"
+    )
+
+
 def test_stale_session_404_handled_before_missing_endpoint():
-    """A 404 'Session not found' must be treated as a stale-session poll (stop +
+    """A session-scoped 404 must be treated as a stale-session poll (stop +
     hide silently), and that branch must appear BEFORE the missing-endpoint
     warning branch so the warning can never fire for it."""
     block = _clarify_catch_block()
-    stale_idx = block.find("session\\s+not\\s+found")
+    stale_idx = block.find("isSessionScoped404")
     warn_idx = block.find("isMissingEndpoint")
-    assert stale_idx != -1, "stale-session 404 branch (session not found) not found"
+    assert stale_idx != -1, "stale-session 404 branch (isSessionScoped404) not found"
     assert warn_idx != -1, "missing-endpoint guard not found"
     assert stale_idx < warn_idx, (
         "the stale-session 404 branch must be evaluated before the "
         "missing-endpoint warning so a session-scoped 404 never warns."
+    )
+
+
+def test_expected_handled_clarify_404s_do_not_emit_poll_failed_warn():
+    """Routine stale-session 404s and handled missing-endpoint 404s should return
+    before the generic warn-level 'pending poll failed' diagnostic. Expected
+    profile-switch teardown must not create warn-level DevTools noise."""
+    block = _clarify_catch_block()
+    stale_idx = block.find("if (isSessionScoped404)")
+    missing_idx = block.find("if (isMissingEndpoint)")
+    warn_idx = block.find('console.warn("[clarify] pending poll failed"')
+    assert stale_idx != -1, "expected stale-session branch"
+    assert missing_idx != -1, "expected missing-endpoint branch"
+    assert warn_idx != -1, "expected generic unexpected-failure warning"
+    assert stale_idx < missing_idx < warn_idx, (
+        "generic warn-level clarify poll logging must come only after handled "
+        "stale-session and missing-endpoint branches return"
     )
 
 

--- a/tests/test_issue5345_clarify_toast_and_interrupt_provenance.py
+++ b/tests/test_issue5345_clarify_toast_and_interrupt_provenance.py
@@ -28,8 +28,6 @@ missing route (server predates the endpoint) or an unrelated session-scoped 404.
 import re
 from pathlib import Path
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[1]
 MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")

--- a/tests/test_sprint36.py
+++ b/tests/test_sprint36.py
@@ -46,8 +46,11 @@ class TestCancelStreamCleanup:
     def _get_cancel_block(self):
         """Extract the cancelStream function body from boot.js."""
         src = read("static/boot.js")
-        idx = src.find("async function cancelStream()")
-        assert idx != -1, "cancelStream not found in boot.js"
+        # Signature-tolerant: cancelStream now takes a `reason` param (#5345), so
+        # match the declaration regardless of its parameter list.
+        m = re.search(r"async function cancelStream\s*\(", src)
+        assert m is not None, "cancelStream not found in boot.js"
+        idx = m.start()
         # Find the closing brace — scan for the matching }
         depth = 0
         end = idx
@@ -122,8 +125,13 @@ class TestCancelStreamErrorPath:
         The status is cleared by setStatus('') unconditionally.
         """
         src = read("static/boot.js")
-        idx = src.find("async function cancelStream()")
-        block = src[idx:idx + 400]
+        # Signature-tolerant match (cancelStream now takes a `reason` param, #5345).
+        m = re.search(r"async function cancelStream\s*\(", src)
+        assert m is not None, "cancelStream not found in boot.js"
+        idx = m.start()
+        # Widen the window: the provenance log + comments added for #5345 sit
+        # before the try/catch, so 400 chars no longer reaches the catch block.
+        block = src[idx:idx + 1200]
         # The old pattern was setStatus inside catch; new pattern has it outside
         # Look for the catch block specifically
         catch_idx = block.find("}catch(")


### PR DESCRIPTION
## Release — fix false clarify-unavailable toast + interrupt provenance (#5345)

Fixes #5345. Combines PR #5346 (@nesquena-hermes) + the #5348 Greptile follow-up (@ruizanthony).

### Problem
Self-hosted users saw *"Clarify endpoint unavailable. Please restart server."* even though `/api/clarify/pending` returned HTTP 200 on every request. The front-end poll's catch block fired the restart-server toast on **any** caught error whose message matched a broad `/(404|not found)/i` regex — so an unrelated stale `Session not found` 404 (e.g. an old-profile session still polling briefly after a profile switch) mis-triggered it.

### Fix (`static/messages.js` + boot/commands/ui.js)
- Branch on the **structured HTTP status** (`err.status`) that `api()` attaches, not the message string.
- Session-scoped 404 → stale poll: stop polling + hide the card silently, **no toast**.
- Restart-server warning fires **only** on a genuine route-not-found 404 (`{"error":"not found"}`).
- #5348: broadened the stale-session guard beyond the exact string; kept the generic `[clarify] pending poll failed` warn only for genuinely unexpected failures.
- Interrupt provenance: `cancelStream()` call sites pass provenance labels (explicit Stop vs stream-lifecycle) — request URL + settlement semantics unchanged.

### Gate
- **Codex: SAFE TO SHIP** — a genuinely missing endpoint still warns (no signal suppressed); `err.status` branching verified against `api()`; cancel/settlement (`exit_code 130`) + SSE contract unchanged.
- Full suite: **11452 passed** (only the 2 pre-existing `test_scheduled_jobs_profile_isolation` serial artifacts).
- 35 targeted clarify + cancel-guard + sprint36 tests pass.

Credit: @nesquena-hermes (#5346) + @ruizanthony (#5348). Closes #5345 (supersedes #5343).