### PR TITLE
docs(changelog): restore dropped #4765 bounded-SESSIONS-cache entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ _No unreleased changes. Entries are moved into their version block when a releas
 
 ### Fixed
 
+- **WebUI no longer grows memory without bound / crashes after hours of uptime.** The in-memory session cache is now safely bounded: sessions are evicted from RAM once past a configurable cap (`webui.sessions_cache_max` in config.yaml, default 300) and lazily reloaded from disk on next access. Eviction is data-safe — a session that is actively streaming, has an in-flight/queued turn, or whose full state is not yet provably on disk is never evicted. Fixes the memory-growth crash cluster on long-running self-hosted installs. (#4765, #2233, #4633)
+
 - **Silent server crashes now leave a diagnostic instead of vanishing.** Enabled `faulthandler` and installed thread/main-thread exception hooks plus an exit audit, so an uncaught handler-thread exception or a native fault is logged with a traceback rather than the process disappearing with no trace (previously a ~9-16h silent exit). Diagnostic hardening; stdlib-only, startup-only, no request-path change. (#4633)
 
 - **Internal verification-stop nudge no longer leaks into the transcript.** The Hermes Agent's internal verify-before-finish loop appends synthetic scaffolding turns (a "premature done" answer + a `[System: ...verification evidence...]` nudge) flagged with structured markers. WebUI now honors those markers (`_verification_stop_synthetic` / `_pre_verify_synthetic`) and drops the scaffolding turns from the visible transcript instead of rendering them as real user/assistant messages. (#5334)


### PR DESCRIPTION
The CHANGELOG entry for #4765 (bounded in-memory SESSIONS cache, shipped in v0.51.801 via #5357) was dropped during a merge-conflict resolution while several releases landed in parallel. Restoring it so the release history reflects the shipped fix. Docs-only, no code change.