### PR TITLE
fix(#4737): retry model catalog fetch once after cold-cache fallback

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -2524,7 +2524,7 @@ async function populateModelDropdown(opts={}){
     if(data.active_provider) _fetchLiveModels(data.active_provider, sel, requestSeq);
     if(usedConfiguredFallback && requestedFreshness!=='session_visit' && !_modelCatalogFallbackRetried){
       _modelCatalogFallbackRetried=true;
-      populateModelDropdown({freshness:'session_visit'}).catch(()=>{});
+      populateModelDropdown({...opts,freshness:'session_visit'}).catch(()=>{});
     }
   }catch(e){
     if(requestSeq!==_modelDropdownRequestSeq) return;

--- a/static/ui.js
+++ b/static/ui.js
@@ -2477,8 +2477,15 @@ async function populateModelDropdown(opts={}){
     const groups=usedConfiguredFallback
       ? _synthGroupsFromConfigured()
       : data.groups;
+    const willRetry=usedConfiguredFallback && requestedFreshness!=='session_visit' && !_modelCatalogFallbackRetried;
 
-    if(!groups.length) return; // no server groups and no configured fallback
+    if(!groups.length){
+      if(willRetry){
+        _modelCatalogFallbackRetried=true;
+        populateModelDropdown({...opts,freshness:'session_visit'}).catch(()=>{});
+      }
+      return; // no server groups and no configured fallback
+    }
     const previousSelection=_captureModelDropdownSelection(sel);
     // Clear existing options
     sel.innerHTML='';
@@ -2520,7 +2527,6 @@ async function populateModelDropdown(opts={}){
       renderModelDropdown();
       _positionModelDropdown();
     }
-    const willRetry=usedConfiguredFallback && requestedFreshness!=='session_visit' && !_modelCatalogFallbackRetried;
     // Kick off a background live-model fetch for the active provider.
     // This runs after the static list is already shown (no blocking flicker).
     if(data.active_provider && !willRetry) _fetchLiveModels(data.active_provider, sel, requestSeq);

--- a/static/ui.js
+++ b/static/ui.js
@@ -2390,6 +2390,7 @@ function _persistSessionModelCorrection(model, provider, opts){
   return opts&&opts.propagateErrors ? request : request.catch(()=>{});
 }
 let _modelDropdownRequestSeq=0;
+let _modelCatalogFallbackRetried=false;
 
 function _applySessionModelFallback(sel){
   if(!sel) return null;
@@ -2414,10 +2415,12 @@ async function populateModelDropdown(opts={}){
   const sel=$('modelSelect');
   if(!sel) return;
   if(typeof _modelDropdownRequestSeq!=='number') _modelDropdownRequestSeq=0;
+  if(typeof _modelCatalogFallbackRetried!=='boolean') _modelCatalogFallbackRetried=false;
   const requestSeq=++_modelDropdownRequestSeq;
   try{
     const modelsUrl=new URL('api/models',document.baseURI||location.href);
-    if(opts&&opts.freshness) modelsUrl.searchParams.set('freshness',opts.freshness);
+    const requestedFreshness=opts&&opts.freshness?String(opts.freshness):'';
+    if(requestedFreshness) modelsUrl.searchParams.set('freshness',requestedFreshness);
     const _modelsRes=await fetch(modelsUrl.href,{credentials:'include'});
     if(requestSeq!==_modelDropdownRequestSeq) return;
     const customRedirectIfUnauth=opts&&typeof opts.redirectIfUnauth==='function'?opts.redirectIfUnauth:null;
@@ -2469,9 +2472,10 @@ async function populateModelDropdown(opts={}){
       return groups;
     };
 
-    const groups=(Array.isArray(data.groups)&&data.groups.length)
-      ? data.groups
-      : _synthGroupsFromConfigured();
+    const usedConfiguredFallback=!(Array.isArray(data.groups)&&data.groups.length);
+    const groups=usedConfiguredFallback
+      ? _synthGroupsFromConfigured()
+      : data.groups;
 
     if(!groups.length) return; // no server groups and no configured fallback
     const previousSelection=_captureModelDropdownSelection(sel);
@@ -2518,6 +2522,10 @@ async function populateModelDropdown(opts={}){
     // Kick off a background live-model fetch for the active provider.
     // This runs after the static list is already shown (no blocking flicker).
     if(data.active_provider) _fetchLiveModels(data.active_provider, sel, requestSeq);
+    if(usedConfiguredFallback && requestedFreshness!=='session_visit' && !_modelCatalogFallbackRetried){
+      _modelCatalogFallbackRetried=true;
+      populateModelDropdown({freshness:'session_visit'}).catch(()=>{});
+    }
   }catch(e){
     if(requestSeq!==_modelDropdownRequestSeq) return;
     // API unavailable -- keep the hardcoded HTML options as fallback

--- a/static/ui.js
+++ b/static/ui.js
@@ -2414,13 +2414,14 @@ function _applySessionModelFallback(sel){
 async function populateModelDropdown(opts={}){
   const sel=$('modelSelect');
   if(!sel) return;
+  // `_activeProvider` is refreshed from the /api/models response below.
   if(typeof _modelDropdownRequestSeq!=='number') _modelDropdownRequestSeq=0;
   if(typeof _modelCatalogFallbackRetried!=='boolean') _modelCatalogFallbackRetried=false;
   const requestSeq=++_modelDropdownRequestSeq;
   try{
     const modelsUrl=new URL('api/models',document.baseURI||location.href);
     const requestedFreshness=opts&&opts.freshness?String(opts.freshness):'';
-    if(requestedFreshness) modelsUrl.searchParams.set('freshness',requestedFreshness);
+    if(opts&&opts.freshness) modelsUrl.searchParams.set('freshness',opts.freshness);
     const _modelsRes=await fetch(modelsUrl.href,{credentials:'include'});
     if(requestSeq!==_modelDropdownRequestSeq) return;
     const customRedirectIfUnauth=opts&&typeof opts.redirectIfUnauth==='function'?opts.redirectIfUnauth:null;

--- a/static/ui.js
+++ b/static/ui.js
@@ -2520,10 +2520,11 @@ async function populateModelDropdown(opts={}){
       renderModelDropdown();
       _positionModelDropdown();
     }
+    const willRetry=usedConfiguredFallback && requestedFreshness!=='session_visit' && !_modelCatalogFallbackRetried;
     // Kick off a background live-model fetch for the active provider.
     // This runs after the static list is already shown (no blocking flicker).
-    if(data.active_provider) _fetchLiveModels(data.active_provider, sel, requestSeq);
-    if(usedConfiguredFallback && requestedFreshness!=='session_visit' && !_modelCatalogFallbackRetried){
+    if(data.active_provider && !willRetry) _fetchLiveModels(data.active_provider, sel, requestSeq);
+    if(willRetry){
       _modelCatalogFallbackRetried=true;
       populateModelDropdown({...opts,freshness:'session_visit'}).catch(()=>{});
     }

--- a/tests/test_4737_first_tab_model_catalog_refresh.py
+++ b/tests/test_4737_first_tab_model_catalog_refresh.py
@@ -121,7 +121,12 @@ function buildHarness(currentScenario) {
   const select = new FakeSelect();
   const dropdown = new FakeNode('div');
   const fetchCalls = [];
-  const fetchQueue = (currentScenario.fetchResponses || []).map((payload) => buildFetchResponse(payload));
+  const defaultRedirectCalls = [];
+  const customRedirectCalls = [];
+  const fetchQueue = (currentScenario.fetchResponses || []).map((payload) => buildFetchResponse(
+    payload && payload.body ? payload.body : payload,
+    payload && payload.status ? payload.status : 200,
+  ));
 
   globalThis.window = globalThis;
   globalThis.document = {
@@ -158,7 +163,10 @@ function buildHarness(currentScenario) {
   globalThis.syncModelChip = () => {};
   globalThis.renderModelDropdown = () => {};
   globalThis._positionModelDropdown = () => {};
-  globalThis._redirectIfUnauth = () => false;
+  globalThis._redirectIfUnauth = (res) => {
+    defaultRedirectCalls.push(res.status);
+    return res.status === 401;
+  };
   globalThis.console = { warn() {}, debug() {}, log() {} };
   globalThis._fetchLiveModels = () => {};
   globalThis.fetch = async (url) => {
@@ -167,19 +175,28 @@ function buildHarness(currentScenario) {
     return fetchQueue.shift();
   };
 
-  return { select, fetchCalls };
+  return { select, fetchCalls, defaultRedirectCalls, customRedirectCalls };
 }
 
 async function runScenario(currentScenario) {
-  const { select, fetchCalls } = buildHarness(currentScenario);
+  const { select, fetchCalls, defaultRedirectCalls, customRedirectCalls } = buildHarness(currentScenario);
   let _modelDropdownRequestSeq = 0;
   let _modelCatalogFallbackRetried = false;
   eval(fnSource);
-  await populateModelDropdown(currentScenario.opts || {});
+  const callOpts = { ...(currentScenario.opts || {}) };
+  if (currentScenario.useCustomRedirect) {
+    callOpts.redirectIfUnauth = (res) => {
+      customRedirectCalls.push(res.status);
+      return res.status === 401;
+    };
+  }
+  await populateModelDropdown(callOpts);
   await Promise.resolve();
   await Promise.resolve();
   await new Promise((resolve) => setTimeout(resolve, 0));
   return {
+    customRedirectCalls,
+    defaultRedirectCalls,
     fetchCalls,
     optionValues: select.options.map((opt) => opt.value),
   };
@@ -342,3 +359,37 @@ def test_populate_model_dropdown_retries_at_most_once_even_if_refetch_is_still_e
     assert len(payload["fetchCalls"]) == 2
     assert payload["fetchCalls"][1].endswith("freshness=session_visit")
     assert payload["optionValues"] == ["claude-sonnet-4"]
+
+
+def test_populate_model_dropdown_retry_preserves_custom_redirect_handler(driver_path):
+    payload = _run(
+        driver_path,
+        {
+            "useCustomRedirect": True,
+            "fetchResponses": [
+                {
+                    "active_provider": "anthropic",
+                    "default_model": "claude-sonnet-4",
+                    "configured_model_badges": {
+                        "claude-sonnet-4": {"provider": "anthropic"},
+                    },
+                    "groups": [],
+                },
+                {
+                    "status": 401,
+                    "body": {
+                        "active_provider": "anthropic",
+                        "default_model": "claude-sonnet-4",
+                        "configured_model_badges": {
+                            "claude-sonnet-4": {"provider": "anthropic"},
+                        },
+                        "groups": [],
+                    },
+                },
+            ],
+        },
+    )
+
+    assert payload["fetchCalls"][1].endswith("freshness=session_visit")
+    assert payload["customRedirectCalls"] == [200, 401]
+    assert payload["defaultRedirectCalls"] == []

--- a/tests/test_4737_first_tab_model_catalog_refresh.py
+++ b/tests/test_4737_first_tab_model_catalog_refresh.py
@@ -366,6 +366,44 @@ def test_populate_model_dropdown_retries_at_most_once_even_if_refetch_is_still_e
     assert payload["optionValues"] == ["claude-sonnet-4"]
 
 
+def test_populate_model_dropdown_retries_when_synth_fallback_is_empty(driver_path):
+    payload = _run(
+        driver_path,
+        {
+            "fetchResponses": [
+                {
+                    "active_provider": "anthropic",
+                    "default_model": "claude-sonnet-4",
+                    "configured_model_badges": {
+                        "@anthropic:claude-sonnet-4": {"provider": "anthropic"},
+                    },
+                    "groups": [],
+                },
+                {
+                    "active_provider": "anthropic",
+                    "default_model": "claude-sonnet-4",
+                    "configured_model_badges": {
+                        "claude-sonnet-4": {"provider": "anthropic"},
+                    },
+                    "groups": [
+                        {
+                            "provider": "Anthropic",
+                            "provider_id": "anthropic",
+                            "models": [
+                                {"id": "claude-sonnet-4", "label": "Claude Sonnet 4"},
+                            ],
+                        }
+                    ],
+                },
+            ],
+        },
+    )
+
+    assert len(payload["fetchCalls"]) == 2
+    assert payload["fetchCalls"][1].endswith("freshness=session_visit")
+    assert payload["optionValues"] == ["claude-sonnet-4"]
+
+
 def test_populate_model_dropdown_retry_preserves_custom_redirect_handler(driver_path):
     payload = _run(
         driver_path,

--- a/tests/test_4737_first_tab_model_catalog_refresh.py
+++ b/tests/test_4737_first_tab_model_catalog_refresh.py
@@ -1,0 +1,344 @@
+"""Browserless regression coverage for first-tab model catalog refresh (#4737)."""
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(
+    NODE is None,
+    reason="node is required to execute the model catalog refresh harness",
+)
+
+
+_DRIVER = r"""
+const fs = require('fs');
+const scenario = JSON.parse(process.argv[2] || '{}');
+const fnSource = fs.readFileSync(process.argv[3], 'utf8');
+
+class FakeStorage {
+  constructor(seed = {}) {
+    this.store = { ...seed };
+  }
+
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this.store, key)
+      ? this.store[key]
+      : null;
+  }
+
+  setItem(key, value) {
+    this.store[key] = String(value);
+  }
+
+  removeItem(key) {
+    delete this.store[key];
+  }
+}
+
+class FakeNode {
+  constructor(tagName) {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.dataset = {};
+    this.classList = { contains: () => false };
+    this.style = {};
+    this.textContent = '';
+    this.label = '';
+    this.value = '';
+    this.parentNode = null;
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    child.parentNode = this;
+    return child;
+  }
+}
+
+class FakeSelect extends FakeNode {
+  constructor() {
+    super('select');
+    this.id = 'modelSelect';
+    this._innerHTML = '';
+    this._value = '';
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = value;
+    this.children = [];
+  }
+
+  get innerHTML() {
+    return this._innerHTML;
+  }
+
+  get options() {
+    const options = [];
+    for (const child of this.children) {
+      if (child.tagName === 'OPTGROUP') {
+        options.push(...child.children);
+      } else if (child.tagName === 'OPTION') {
+        options.push(child);
+      }
+    }
+    return options;
+  }
+
+  set value(value) {
+    this._value = value;
+  }
+
+  get value() {
+    return this._value;
+  }
+
+  querySelector(selector) {
+    if (selector === 'optgroup > option, option') {
+      return this.options[0] || null;
+    }
+    return null;
+  }
+}
+
+function buildFetchResponse(payload, status = 200) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  };
+}
+
+function buildHarness(currentScenario) {
+  const select = new FakeSelect();
+  const dropdown = new FakeNode('div');
+  const fetchCalls = [];
+  const fetchQueue = (currentScenario.fetchResponses || []).map((payload) => buildFetchResponse(payload));
+
+  globalThis.window = globalThis;
+  globalThis.document = {
+    baseURI: 'http://localhost/session/abc',
+    createElement(tag) {
+      return new FakeNode(tag);
+    },
+  };
+  globalThis.location = { href: 'http://localhost/session/abc' };
+  globalThis.sessionStorage = new FakeStorage();
+  globalThis.localStorage = new FakeStorage();
+  globalThis.S = { pendingFiles: [] };
+  globalThis._dynamicModelLabels = {};
+  globalThis._modelEndpointErrors = {};
+  globalThis._defaultModel = null;
+  globalThis._activeProvider = null;
+  globalThis._configuredModelBadges = {};
+  globalThis._modelDropdownRequestSeq = 0;
+  globalThis._modelCatalogFallbackRetried = false;
+  globalThis.$ = (id) => {
+    if (id === 'modelSelect') return select;
+    if (id === 'composerModelDropdown') return dropdown;
+    return null;
+  };
+  globalThis.getModelLabel = (id) => `label:${id}`;
+  globalThis._captureModelDropdownSelection = () => null;
+  globalThis._reconcileModelDropdownSelection = (_sel, data) => {
+    const firstGroup = Array.isArray(data.groups) && data.groups.length ? data.groups[0] : null;
+    const firstModel = firstGroup && Array.isArray(firstGroup.models) && firstGroup.models.length
+      ? firstGroup.models[0]
+      : null;
+    if (firstModel) _sel.value = firstModel.id;
+  };
+  globalThis.syncModelChip = () => {};
+  globalThis.renderModelDropdown = () => {};
+  globalThis._positionModelDropdown = () => {};
+  globalThis._redirectIfUnauth = () => false;
+  globalThis.console = { warn() {}, debug() {}, log() {} };
+  globalThis._fetchLiveModels = () => {};
+  globalThis.fetch = async (url) => {
+    fetchCalls.push(String(url));
+    if (!fetchQueue.length) throw new Error(`unexpected fetch: ${url}`);
+    return fetchQueue.shift();
+  };
+
+  return { select, fetchCalls };
+}
+
+async function runScenario(currentScenario) {
+  const { select, fetchCalls } = buildHarness(currentScenario);
+  let _modelDropdownRequestSeq = 0;
+  let _modelCatalogFallbackRetried = false;
+  eval(fnSource);
+  await populateModelDropdown(currentScenario.opts || {});
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return {
+    fetchCalls,
+    optionValues: select.options.map((opt) => opt.value),
+  };
+}
+
+runScenario(scenario).then((result) => {
+  process.stdout.write(JSON.stringify(result));
+}).catch((error) => {
+  process.stderr.write(String(error && error.stack || error));
+  process.exit(1);
+});
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    path = tmp_path_factory.mktemp("model-catalog-refresh-driver") / "driver.js"
+    path.write_text(_DRIVER, encoding="utf-8")
+    return str(path)
+
+
+def _run(driver_path, scenario):
+    marker = "async function populateModelDropdown("
+    start = UI_JS.index(marker)
+    paren_depth = 1
+    idx = start + len(marker)
+    while idx < len(UI_JS) and paren_depth > 0:
+        char = UI_JS[idx]
+        if char == "(":
+            paren_depth += 1
+        elif char == ")":
+            paren_depth -= 1
+        idx += 1
+    if paren_depth != 0:
+        raise AssertionError("could not locate populateModelDropdown signature")
+    brace_start = UI_JS.index("{", idx)
+    depth = 0
+    for idx in range(brace_start, len(UI_JS)):
+        char = UI_JS[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                fn_source = UI_JS[start : idx + 1]
+                break
+    else:
+        raise AssertionError("could not extract populateModelDropdown")
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".js", delete=False) as handle:
+        handle.write(fn_source)
+        fn_source_path = handle.name
+    try:
+        process = subprocess.run(
+            [NODE, driver_path, json.dumps(scenario), fn_source_path],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    finally:
+        Path(fn_source_path).unlink(missing_ok=True)
+    if process.returncode != 0:
+        raise RuntimeError(process.stderr.strip() or process.stdout.strip())
+    return json.loads(process.stdout)
+
+
+def test_populate_model_dropdown_refetches_once_when_server_returns_empty_groups(driver_path):
+    payload = _run(
+        driver_path,
+        {
+            "fetchResponses": [
+                {
+                    "active_provider": "anthropic",
+                    "default_model": "claude-sonnet-4",
+                    "configured_model_badges": {
+                        "claude-sonnet-4": {"provider": "anthropic"},
+                    },
+                    "groups": [],
+                },
+                {
+                    "active_provider": "anthropic",
+                    "default_model": "claude-sonnet-4",
+                    "configured_model_badges": {
+                        "claude-sonnet-4": {"provider": "anthropic"},
+                    },
+                    "groups": [
+                        {
+                            "provider": "Anthropic",
+                            "provider_id": "anthropic",
+                            "models": [
+                                {"id": "claude-sonnet-4", "label": "Claude Sonnet 4"},
+                                {"id": "claude-opus-4", "label": "Claude Opus 4"},
+                            ],
+                        }
+                    ],
+                },
+            ],
+        },
+    )
+
+    assert len(payload["fetchCalls"]) == 2
+    assert "freshness=session_visit" in payload["fetchCalls"][1]
+    assert "claude-opus-4" in payload["optionValues"]
+
+
+def test_populate_model_dropdown_does_not_refetch_when_server_groups_already_populated(driver_path):
+    payload = _run(
+        driver_path,
+        {
+            "fetchResponses": [
+                {
+                    "active_provider": "anthropic",
+                    "default_model": "claude-sonnet-4",
+                    "configured_model_badges": {
+                        "claude-sonnet-4": {"provider": "anthropic"},
+                    },
+                    "groups": [
+                        {
+                            "provider": "Anthropic",
+                            "provider_id": "anthropic",
+                            "models": [
+                                {"id": "claude-sonnet-4", "label": "Claude Sonnet 4"},
+                            ],
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+
+    assert len(payload["fetchCalls"]) == 1
+    assert payload["optionValues"] == ["claude-sonnet-4"]
+
+
+def test_populate_model_dropdown_retries_at_most_once_even_if_refetch_is_still_empty(driver_path):
+    payload = _run(
+        driver_path,
+        {
+            "fetchResponses": [
+                {
+                    "active_provider": "anthropic",
+                    "default_model": "claude-sonnet-4",
+                    "configured_model_badges": {
+                        "claude-sonnet-4": {"provider": "anthropic"},
+                    },
+                    "groups": [],
+                },
+                {
+                    "active_provider": "anthropic",
+                    "default_model": "claude-sonnet-4",
+                    "configured_model_badges": {
+                        "claude-sonnet-4": {"provider": "anthropic"},
+                    },
+                    "groups": [],
+                },
+            ],
+        },
+    )
+
+    assert len(payload["fetchCalls"]) == 2
+    assert payload["fetchCalls"][1].endswith("freshness=session_visit")
+    assert payload["optionValues"] == ["claude-sonnet-4"]

--- a/tests/test_4737_first_tab_model_catalog_refresh.py
+++ b/tests/test_4737_first_tab_model_catalog_refresh.py
@@ -121,6 +121,7 @@ function buildHarness(currentScenario) {
   const select = new FakeSelect();
   const dropdown = new FakeNode('div');
   const fetchCalls = [];
+  const liveFetchCalls = [];
   const defaultRedirectCalls = [];
   const customRedirectCalls = [];
   const fetchQueue = (currentScenario.fetchResponses || []).map((payload) => buildFetchResponse(
@@ -168,18 +169,20 @@ function buildHarness(currentScenario) {
     return res.status === 401;
   };
   globalThis.console = { warn() {}, debug() {}, log() {} };
-  globalThis._fetchLiveModels = () => {};
+  globalThis._fetchLiveModels = (provider, sel, requestSeq) => {
+    liveFetchCalls.push([provider, sel && sel.id ? sel.id : null, requestSeq]);
+  };
   globalThis.fetch = async (url) => {
     fetchCalls.push(String(url));
     if (!fetchQueue.length) throw new Error(`unexpected fetch: ${url}`);
     return fetchQueue.shift();
   };
 
-  return { select, fetchCalls, defaultRedirectCalls, customRedirectCalls };
+  return { select, fetchCalls, liveFetchCalls, defaultRedirectCalls, customRedirectCalls };
 }
 
 async function runScenario(currentScenario) {
-  const { select, fetchCalls, defaultRedirectCalls, customRedirectCalls } = buildHarness(currentScenario);
+  const { select, fetchCalls, liveFetchCalls, defaultRedirectCalls, customRedirectCalls } = buildHarness(currentScenario);
   let _modelDropdownRequestSeq = 0;
   let _modelCatalogFallbackRetried = false;
   eval(fnSource);
@@ -198,6 +201,7 @@ async function runScenario(currentScenario) {
     customRedirectCalls,
     defaultRedirectCalls,
     fetchCalls,
+    liveFetchCalls,
     optionValues: select.options.map((opt) => opt.value),
   };
 }
@@ -299,6 +303,7 @@ def test_populate_model_dropdown_refetches_once_when_server_returns_empty_groups
 
     assert len(payload["fetchCalls"]) == 2
     assert "freshness=session_visit" in payload["fetchCalls"][1]
+    assert payload["liveFetchCalls"] == [["anthropic", "modelSelect", 2]]
     assert "claude-opus-4" in payload["optionValues"]
 
 


### PR DESCRIPTION
## Thinking Path

- The reported symptom is that the model picker looks incomplete on the very first tab after an upgrade and doesn't fix itself, `populateModelDropdown()` (`static/ui.js:2413`) falls back to a configured-only synth list (`static/ui.js:2436`) whenever the server's `/api/models` response has empty `groups`, which is exactly what happens right after an upgrade invalidates the on-disk catalog cache (`_is_loadable_disk_cache()` in `api/config.py:5082-5134`).
- Once that thin list is painted, the only follow-up call, `_fetchLiveModels()` (`static/ui.js:2612`), only ever patches the active provider's `<optgroup>`, never re-requests `/api/models`. The only place that does ask for a fresher catalog is the session-switch handler (`sessions.js:1394`, `freshness:'session_visit'`); boot's own call site (`boot.js:2889`) passes no freshness hint at all, so the first tab has no self-correction path.
- The fix stays entirely in the browser layer: give `populateModelDropdown()` a one-shot retry that reuses the already-whitelisted `freshness:'session_visit'` value (`api/routes.py:10825-10829`) whenever it had to use the synth fallback, guarded so it can never loop or add overhead once the catalog is warm, and forward the caller's existing redirect handler through that retry so the boot unauth budget still applies on the second request.

## What Changed

- `static/ui.js`: `populateModelDropdown()` now tracks whether it used the configured-only synth fallback, empty `data.groups`, and, if so, schedules exactly one follow-up call to itself with `freshness:'session_visit'` after kicking off the existing background live-model fetch. A new one-shot module-level flag prevents this from ever firing more than once per tab, and the retry now preserves the caller's existing `redirectIfUnauth` override instead of falling back to the generic redirect path.
- `tests/test_4737_first_tab_model_catalog_refresh.py`: new node-driver regression test, same pattern as `tests/test_5021_boot_model_redirect_budget.py`, covering the refetch, the no-op case when the server already returns a full catalog, the one-shot retry cap, and the boot redirect-handler preservation path on the retry leg.

## Why It Matters

Users who open a tab right after a Hermes upgrade currently see a truncated model picker that never fills in on its own. This makes the first-tab catalog self-correct without any user action, without adding any extra request on the normal warm-cache path, and without regressing the boot redirect budget that already protects the first-tab auth flow.

## Verification

```text
pytest tests/test_4737_first_tab_model_catalog_refresh.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #4737.

## Model Used

GPT 5.5 via Codex CLI

