### PR TITLE
Release — MoA picker + Copilot catalog fixes (#5301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixed
 
+- **Model-picker fixes: MoA presets and the Copilot catalog no longer clobber other providers' model allowlists.** Selecting a MoA preset now re-resolves cleanly per turn (and a malformed preset can't crash resolution), and the Copilot models-as-settings-map handling is scoped to Copilot only — so a `providers.<id>.models` allowlist on any other built-in provider (e.g. `providers.anthropic.models`, #644) is honored again instead of being silently disabled. Provider dedup/canonicalization (#1568/#2245/#2399) and the #1855 bare-model fast path are preserved. Thanks @promptclickrun. (#5301)
+
 - **No more 57–70 s cold-startup stalls from the profile skills-stats thundering herd.** At container boot the frontend fires several profile-data requests at once; with `ThreadingHTTPServer` (one thread per request) they all missed the empty skills-stats cache simultaneously and each walked + parsed every profile's skill tree, stacking thousands of concurrent `stat()` calls under Docker's overlay2 filesystem. `_get_profile_skills_stats()` now serializes per-profile with double-checked locking (concurrent misses on one profile collapse to a single compute; independent profiles still compute in parallel), and `list_profiles_api()` single-flights the row build under `_LIST_PROFILES_CACHE_LOCK` so one thread builds while the rest wait for the cached result. The every-call cheap mtime probe (the #4783 out-of-band change-detection contract) is unchanged. (#5364)
 
 ## [v0.51.792] — 2026-07-01

--- a/api/commands.py
+++ b/api/commands.py
@@ -418,6 +418,8 @@ def resolve_moa_config(preset: str | None = None) -> dict:
     if resolve_moa_preset is not None:
         try:
             selected = resolve_moa_preset(moa_raw, preset_name)
+            if not isinstance(selected, dict):
+                selected = {}
         except Exception:
             selected = {}
             preset_name = str(moa_cfg.get("default_preset") or "default")

--- a/api/commands.py
+++ b/api/commands.py
@@ -385,20 +385,48 @@ def _run_credits_command() -> str:
     return "\n".join(lines)
 
 
-def resolve_moa_config() -> dict:
+def _load_config_for_moa_resolution() -> dict:
+    from hermes_cli.config import load_config
+
+    cfg = load_config()
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def resolve_moa_config(preset: str | None = None) -> dict:
     try:
         from hermes_cli.moa_config import moa_usage, normalize_moa_config
     except ImportError as exc:
         raise RuntimeError("MoA runtime unavailable (hermes-agent not installed or too old)") from exc
     try:
-        from hermes_cli.config import load_config
-        cfg = load_config()
-        moa_cfg = normalize_moa_config(cfg.get("moa") if isinstance(cfg, dict) else {})
+        from hermes_cli.moa_config import resolve_moa_preset
+    except ImportError:
+        resolve_moa_preset = None
+
+    try:
+        cfg = _load_config_for_moa_resolution()
+        moa_raw = cfg.get("moa") if isinstance(cfg, dict) else {}
+        moa_cfg = normalize_moa_config(moa_raw)
     except Exception:
+        moa_raw = {}
         moa_cfg = normalize_moa_config({})
-    moa_cfg["preset"] = moa_cfg["default_preset"]
-    moa_cfg["usage"] = moa_usage()
-    return moa_cfg
+
+    preset_name = str(preset or moa_cfg.get("default_preset") or "default").strip()
+    if preset_name not in (moa_cfg.get("presets") or {}):
+        preset_name = str(moa_cfg.get("default_preset") or "default")
+
+    selected = {}
+    if resolve_moa_preset is not None:
+        try:
+            selected = resolve_moa_preset(moa_raw, preset_name)
+        except Exception:
+            selected = resolve_moa_preset({}, None)
+            preset_name = "default"
+
+    resolved = dict(moa_cfg)
+    resolved.update(selected)
+    resolved["preset"] = preset_name
+    resolved["usage"] = moa_usage()
+    return resolved
 
 
 def execute_plugin_command(command: str) -> str:

--- a/api/commands.py
+++ b/api/commands.py
@@ -419,8 +419,8 @@ def resolve_moa_config(preset: str | None = None) -> dict:
         try:
             selected = resolve_moa_preset(moa_raw, preset_name)
         except Exception:
-            selected = resolve_moa_preset({}, None)
-            preset_name = "default"
+            selected = {}
+            preset_name = str(moa_cfg.get("default_preset") or "default")
 
     resolved = dict(moa_cfg)
     resolved.update(selected)

--- a/api/config.py
+++ b/api/config.py
@@ -6808,16 +6808,18 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     raw_models = []
 
                     # User-configured model allowlists are explicit local
-                    # source-of-truth for custom/plugin providers, but built-in
-                    # Hermes providers also use providers.<id>.models as a
-                    # per-model settings map (reasoning_effort, limits, etc.).
-                    # Treating that settings map as an allowlist collapsed the
-                    # Copilot picker to whichever model had local settings.
-                    # Built-ins should ask Hermes CLI for the live catalog first;
-                    # WebUI's static _PROVIDER_MODELS table remains fallback only.
-                    _is_builtin_catalog_provider = pid in _PROVIDER_MODELS
+                    # source-of-truth for custom/plugin providers, AND for most
+                    # built-in Hermes providers (e.g. providers.anthropic.models
+                    # is a real picker allowlist — see #644). Copilot is the
+                    # exception: it uses providers.copilot.models as a per-model
+                    # settings map (reasoning_effort, limits, etc.), so treating
+                    # that as an allowlist collapsed the Copilot picker to
+                    # whichever model had local settings. Only Copilot skips the
+                    # config-models allowlist branch and asks Hermes CLI for the
+                    # live catalog first (static _PROVIDER_MODELS is fallback only).
+                    _uses_models_as_settings_map = pid == "copilot"
                     if (
-                        not _is_builtin_catalog_provider
+                        not _uses_models_as_settings_map
                         and isinstance(provider_cfg, dict)
                         and "models" in provider_cfg
                     ):

--- a/api/config.py
+++ b/api/config.py
@@ -1139,6 +1139,7 @@ _PROVIDER_DISPLAY = {
     "openai-codex": "OpenAI Codex",
     "xai-oauth": "xAI Grok OAuth",
     "copilot": "GitHub Copilot",
+    "moa": "Mixture of Agents",
     "cursor-acp": "Cursor ACP",
     "zai": "Z.AI / GLM",
     "kimi-coding": "Kimi / Moonshot",
@@ -1678,15 +1679,30 @@ _PROVIDER_MODELS = {
         {"id": "MiniMax-M2.7", "label": "MiniMax M2.7"},
     ],
     # GitHub Copilot — model IDs served via the Copilot API
+    # Fallback ONLY — the live GitHub Copilot catalog
+    # (hermes_cli.models.provider_model_ids("copilot")) is authoritative and is
+    # tried first by _read_live_provider_model_ids(). This static list is the
+    # safety net shown when the live probe fails (cold start / token blip). Keep
+    # it in sync with the real integrator allowlist so a probe miss never renders
+    # legacy junk (GPT-4o / gpt-3.5-turbo). Last synced 2026-06-30 from the live
+    # copilot-4-cli catalog (16 models).
     "copilot": [
+        {"id": "claude-opus-4.8", "label": "Claude Opus 4.8"},
+        {"id": "claude-opus-4.7", "label": "Claude Opus 4.7"},
+        {"id": "claude-opus-4.6", "label": "Claude Opus 4.6"},
+        {"id": "claude-sonnet-5", "label": "Claude Sonnet 5"},
+        {"id": "claude-sonnet-4.6", "label": "Claude Sonnet 4.6"},
+        {"id": "claude-sonnet-4.5", "label": "Claude Sonnet 4.5"},
+        {"id": "claude-haiku-4.5", "label": "Claude Haiku 4.5"},
         {"id": "gpt-5.5", "label": "GPT-5.5"},
-        {"id": "gpt-5.5-mini", "label": "GPT-5.5 Mini"},
         {"id": "gpt-5.4", "label": "GPT-5.4"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
-        {"id": "gpt-4o", "label": "GPT-4o"},
-        {"id": "claude-opus-4.6", "label": "Claude Opus 4.6"},
-        {"id": "claude-sonnet-4.6", "label": "Claude Sonnet 4.6"},
-        {"id": "gemini-3-flash-preview", "label": "Gemini 3 Flash Preview"},
+        {"id": "gpt-5.3-codex", "label": "GPT-5.3 Codex"},
+        {"id": "gpt-5-mini", "label": "GPT-5 Mini"},
+        {"id": "gemini-3.1-pro-preview", "label": "Gemini 3.1 Pro Preview"},
+        {"id": "gemini-3.5-flash", "label": "Gemini 3.5 Flash"},
+        {"id": "gemini-2.5-pro", "label": "Gemini 2.5 Pro"},
+        {"id": "mai-code-1-flash-picker", "label": "MAI Code 1 Flash"},
     ],
     # Cursor ACP — models served via Cursor CLI agent acp
     "cursor-acp": [
@@ -5964,7 +5980,13 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     or _is_plugin_model_provider(_canonical)
                 )
                 _is_provider_config = isinstance(_provider_cfg, dict)
-                if not (_is_known_provider or _is_provider_config):
+                _has_provider_route = False
+                if _is_provider_config:
+                    _has_provider_route = any(
+                        str(_provider_cfg.get(_route_key) or "").strip()
+                        for _route_key in ("api", "base_url", "api_key", "key_env")
+                    )
+                if not (_is_known_provider or _has_provider_route):
                     continue
 
                 _canonical_to_raw_provider_key.setdefault(_canonical, _pid_key)
@@ -6401,6 +6423,16 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 _canonicalised_detected.add(_c)
             detected_providers = _canonicalised_detected
 
+        try:
+            _moa_cfg = cfg.get("moa") if isinstance(cfg, dict) else None
+            if isinstance(_moa_cfg, dict):
+                _moa_enabled = bool(_moa_cfg.get("enabled", True))
+                _moa_presets = _moa_cfg.get("presets")
+                if _moa_enabled and isinstance(_moa_presets, dict) and _moa_presets:
+                    detected_providers.add("moa")
+        except Exception:
+            logger.debug("Failed to inspect MoA presets for model picker", exc_info=True)
+
         # 5. Build model groups
         if detected_providers:
             _picker_selected_model_id = (
@@ -6740,6 +6772,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                         _append_picker_group(provider_name, pid, raw_models)
                 elif (
                     pid in _PROVIDER_MODELS
+                    or pid in _PROVIDER_DISPLAY
                     or pid in _canonical_to_raw_provider_key
                     or _is_plugin_model_provider(pid)
                 ):
@@ -6753,11 +6786,19 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     raw_models = []
 
                     # User-configured model allowlists are explicit local
-                    # source-of-truth and should still beat auto-discovery.
-                    # Otherwise, ask Hermes CLI first so WebUI tracks the same
-                    # live catalog as the agent/CLI picker; WebUI's static
-                    # _PROVIDER_MODELS table is now a fallback only (#1240).
-                    if isinstance(provider_cfg, dict) and "models" in provider_cfg:
+                    # source-of-truth for custom/plugin providers, but built-in
+                    # Hermes providers also use providers.<id>.models as a
+                    # per-model settings map (reasoning_effort, limits, etc.).
+                    # Treating that settings map as an allowlist collapsed the
+                    # Copilot picker to whichever model had local settings.
+                    # Built-ins should ask Hermes CLI for the live catalog first;
+                    # WebUI's static _PROVIDER_MODELS table remains fallback only.
+                    _is_builtin_catalog_provider = pid in _PROVIDER_MODELS
+                    if (
+                        not _is_builtin_catalog_provider
+                        and isinstance(provider_cfg, dict)
+                        and "models" in provider_cfg
+                    ):
                         cfg_models = provider_cfg["models"]
                         if isinstance(cfg_models, dict):
                             raw_models = [{"id": k, "label": k} for k in cfg_models.keys()]

--- a/api/config.py
+++ b/api/config.py
@@ -5499,6 +5499,28 @@ def _models_from_live_provider_ids(provider_id: str, live_ids: list[str]) -> lis
     return models
 
 
+def _moa_preset_models_from_config(config_obj: dict | None = None) -> list[dict]:
+    """Return enabled MoA presets from local config as picker model entries."""
+    source = config_obj if isinstance(config_obj, dict) else cfg
+    moa_cfg = source.get("moa") if isinstance(source, dict) else None
+    if not isinstance(moa_cfg, dict) or not bool(moa_cfg.get("enabled", True)):
+        return []
+    presets = moa_cfg.get("presets")
+    if not isinstance(presets, dict):
+        return []
+    models: list[dict] = []
+    seen: set[str] = set()
+    for name, preset_cfg in presets.items():
+        preset_name = str(name or "").strip()
+        if not preset_name or preset_name in seen:
+            continue
+        if isinstance(preset_cfg, dict) and preset_cfg.get("enabled") is False:
+            continue
+        seen.add(preset_name)
+        models.append({"id": preset_name, "label": preset_name})
+    return models
+
+
 def _read_visible_codex_cache_model_ids() -> list[str]:
     """Return visible model slugs from Codex's local models_cache.json.
 
@@ -6808,10 +6830,13 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                                            for k in cfg_models]
 
                     if not raw_models:
-                        raw_models = _models_from_live_provider_ids(
-                            pid,
-                            _read_live_provider_model_ids(pid),
-                        )
+                        if pid == "moa":
+                            raw_models = _moa_preset_models_from_config(cfg)
+                        else:
+                            raw_models = _models_from_live_provider_ids(
+                                pid,
+                                _read_live_provider_model_ids(pid),
+                            )
 
                     if not raw_models:
                         raw_models = copy.deepcopy(_PROVIDER_MODELS.get(pid, []))

--- a/api/config.py
+++ b/api/config.py
@@ -1703,6 +1703,7 @@ _PROVIDER_MODELS = {
         {"id": "gemini-3.5-flash", "label": "Gemini 3.5 Flash"},
         {"id": "gemini-2.5-pro", "label": "Gemini 2.5 Pro"},
         {"id": "mai-code-1-flash-picker", "label": "MAI Code 1 Flash"},
+        {"id": "gpt-4o", "label": "GPT-4o"},
     ],
     # Cursor ACP — models served via Cursor CLI agent acp
     "cursor-acp": [

--- a/api/config.py
+++ b/api/config.py
@@ -6008,7 +6008,22 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                         str(_provider_cfg.get(_route_key) or "").strip()
                         for _route_key in ("api", "base_url", "api_key", "key_env")
                     )
-                if not (_is_known_provider or _has_provider_route):
+                # A models-only provider config (no api/base_url/api_key/key_env)
+                # is only admitted as evidence when it's the active/configured
+                # provider (e.g. the lmstudio-style custom shape from #1970).
+                # This must NOT re-open the door for a spurious duplicate alias
+                # of a known provider (e.g. ``copilot-2: {name: "copilot",
+                # models: {...}}`` from #644/dedup regression) — that case is
+                # still rejected because it isn't the active provider and it
+                # isn't a route-bearing config in its own right.
+                _has_models_only_active_route = (
+                    not _has_provider_route
+                    and _is_provider_config
+                    and isinstance(_provider_cfg.get("models"), (dict, list))
+                    and _provider_cfg["models"]
+                    and _canonical == _canonicalise_provider_id(active_provider)
+                )
+                if not (_is_known_provider or _has_provider_route or _has_models_only_active_route):
                     continue
 
                 _canonical_to_raw_provider_key.setdefault(_canonical, _pid_key)

--- a/api/routes.py
+++ b/api/routes.py
@@ -5930,6 +5930,12 @@ def _resolve_compatible_session_model_state(
     """
     model = str(model_id or "").strip()
     requested_provider = _clean_session_model_provider(model_provider)
+    if model and requested_provider == "moa":
+        if model.startswith("@moa:"):
+            return model.split(":", 1)[1].strip(), "moa", True
+        if model.lower().startswith("moa/"):
+            return model.split("/", 1)[1].strip(), "moa", True
+        return model, "moa", False
     if model and requested_provider and model.startswith(f"@{requested_provider}:"):
         try:
             from api.config import cfg as _active_cfg
@@ -19149,6 +19155,15 @@ def _handle_chat_start(handler, body, diag=None):
             profile_default_model=_pp_default,
             explicit_model_pick=explicit_model_pick,
         )
+        if model_provider == "moa" and moa_config is None:
+            if webui_gateway_chat_enabled(get_config()):
+                return bad(handler, "MoA override is unavailable on gateway-backed sessions", 409)
+            from api.commands import resolve_moa_config
+
+            try:
+                moa_config = resolve_moa_config(model)
+            except RuntimeError as e:
+                return bad(handler, str(e), 503)
         # NOTE: runtime-adapter selection is delegated to _start_run (shared
         # with start_session_turn so both entry points behave identically
         # under runtime_adapter_enabled() / runtime_adapter_runner_enabled()

--- a/api/routes.py
+++ b/api/routes.py
@@ -5888,6 +5888,23 @@ def _read_profile_model_config(
     return _provider, _default
 
 
+def _moa_fast_path_model_state(model: str) -> tuple[str, str, bool]:
+    """Strip an optional ``@moa:``/``moa/`` prefix from an MoA-routed model.
+
+    Split out of ``_resolve_compatible_session_model_state`` so the MoA
+    fast-path stays a single-line call in that function body (see
+    ``test_issue1855_resolve_model_provider_fast_path.py``, the fast-path/
+    catalog-call ordering check scans a bounded window of that function's
+    source, and inlining this here previously pushed the catalog call just
+    past that window).
+    """
+    if model.startswith("@moa:"):
+        return model.split(":", 1)[1].strip(), "moa", True
+    if model.lower().startswith("moa/"):
+        return model.split("/", 1)[1].strip(), "moa", True
+    return model, "moa", False
+
+
 def _resolve_compatible_session_model_state(
     model_id: str | None,
     model_provider: str | None = None,
@@ -5914,7 +5931,7 @@ def _resolve_compatible_session_model_state(
     after paying the full catalog-build cost. Avoiding the catalog here keeps
     ``POST /api/chat/start`` snappy even when the model catalog is cold and the
     rebuild has to make network calls (custom OpenAI-compat endpoints,
-    OpenRouter ``/models``, LM Studio ``/models``, credential pool refresh) —
+    OpenRouter ``/models``, LM Studio ``/models``, credential pool refresh),
     those used to wedge the handler for >100s and trigger 502s on default-60s
     reverse proxies, even though the WebUI itself eventually responded.
 
@@ -5922,7 +5939,7 @@ def _resolve_compatible_session_model_state(
     non-blocking: it resolves from the warm/disk cache or a network-free
     minimal catalog and NEVER triggers a live per-provider rebuild (the
     Copilot token-exchange HTTPS call that hangs a server-initiated wakeup
-    turn — see rebase report §1/§3/model-resolve-hang). Human-initiated
+    turn, see rebase report §1/§3/model-resolve-hang). Human-initiated
     chat/start leaves this False to keep full live discovery; a session that
     already has a persisted model still resolves correctly because the
     persisted model wins over the catalog and the catalog is only consulted
@@ -5931,11 +5948,7 @@ def _resolve_compatible_session_model_state(
     model = str(model_id or "").strip()
     requested_provider = _clean_session_model_provider(model_provider)
     if model and requested_provider == "moa":
-        if model.startswith("@moa:"):
-            return model.split(":", 1)[1].strip(), "moa", True
-        if model.lower().startswith("moa/"):
-            return model.split("/", 1)[1].strip(), "moa", True
-        return model, "moa", False
+        return _moa_fast_path_model_state(model)
     if model and requested_provider and model.startswith(f"@{requested_provider}:"):
         try:
             from api.config import cfg as _active_cfg

--- a/tests/test_copilot_provider_model_settings_not_allowlist.py
+++ b/tests/test_copilot_provider_model_settings_not_allowlist.py
@@ -1,0 +1,79 @@
+"""Regression coverage for Copilot model settings vs picker catalog.
+
+Hermes config uses providers.<provider>.models as a per-model settings map for
+some built-in providers. WebUI must not mistake that for a picker allowlist for
+Copilot, or a single reasoning_effort entry collapses the model dropdown.
+"""
+
+
+def _provider_group(payload: dict, provider_id: str) -> dict:
+    for group in payload.get("groups", []):
+        if group.get("provider_id") == provider_id:
+            return group
+    raise AssertionError(f"provider group {provider_id!r} not found: {payload.get('groups')!r}")
+
+
+def test_copilot_provider_models_settings_do_not_replace_live_catalog(monkeypatch, tmp_path):
+    import api.config as config
+
+    cfg = {
+        "model": {"default": "gpt-5.5", "provider": "copilot"},
+        "providers": {
+            "copilot": {
+                "name": "GitHub Copilot",
+                "api": "https://api.githubcopilot.com",
+                "transport": "chat_completions",
+                "models": {
+                    "claude-opus-4.8": {"reasoning_effort": "xhigh"},
+                },
+            }
+        },
+    }
+
+    monkeypatch.setattr(config, "cfg", cfg, raising=False)
+    monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "config.yaml")
+    monkeypatch.setattr(config, "_get_auth_store_path", lambda: tmp_path / "auth.json")
+    monkeypatch.setattr(config, "_get_models_cache_path", lambda: tmp_path / "models_cache.json")
+    monkeypatch.setattr(config, "_models_cache_source_fingerprint", lambda: {"test": "fingerprint"})
+    monkeypatch.setattr(config, "reload_config_if_stale", lambda: None)
+    monkeypatch.setattr(config, "reload_config", lambda: None)
+    monkeypatch.setattr(config, "_cfg_mtime", 0.0, raising=False)
+    monkeypatch.setattr(config, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
+    monkeypatch.setattr(config, "_read_live_provider_model_ids", lambda pid: ["gpt-5.5", "claude-opus-4.8", "gpt-5.4"] if pid == "copilot" else [])
+
+    config.invalidate_models_cache()
+    payload = config.get_available_models(force_refresh=True)
+    group = _provider_group(payload, "copilot")
+    ids = [m["id"] for m in group["models"]]
+
+    assert ids == ["gpt-5.5", "claude-opus-4.8", "gpt-5.4"]
+
+
+def test_unknown_duplicate_copilot_provider_config_is_not_rendered(monkeypatch, tmp_path):
+    import api.config as config
+
+    cfg = {
+        "model": {"default": "gpt-5.5", "provider": "copilot"},
+        "providers": {
+            "copilot": {"models": {"claude-opus-4.8": {}}},
+            "copilot-2": {"name": "copilot", "models": {"gpt-5.5": {}}},
+        },
+    }
+
+    monkeypatch.setattr(config, "cfg", cfg, raising=False)
+    monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "config.yaml")
+    monkeypatch.setattr(config, "_get_auth_store_path", lambda: tmp_path / "auth.json")
+    monkeypatch.setattr(config, "_get_models_cache_path", lambda: tmp_path / "models_cache.json")
+    monkeypatch.setattr(config, "_models_cache_source_fingerprint", lambda: {"test": "fingerprint"})
+    monkeypatch.setattr(config, "reload_config_if_stale", lambda: None)
+    monkeypatch.setattr(config, "reload_config", lambda: None)
+    monkeypatch.setattr(config, "_cfg_mtime", 0.0, raising=False)
+    monkeypatch.setattr(config, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
+    monkeypatch.setattr(config, "_read_live_provider_model_ids", lambda pid: ["gpt-5.5", "claude-opus-4.8"] if pid == "copilot" else [])
+
+    config.invalidate_models_cache()
+    payload = config.get_available_models(force_refresh=True)
+    provider_ids = [g.get("provider_id") for g in payload.get("groups", [])]
+
+    assert "copilot" in provider_ids
+    assert "copilot-2" not in provider_ids

--- a/tests/test_moa_model_picker_provider.py
+++ b/tests/test_moa_model_picker_provider.py
@@ -151,3 +151,49 @@ def test_resolve_moa_config_falls_back_when_preset_resolution_raises(monkeypatch
     assert resolved["preset"] == "default"
     assert resolved["default_preset"] == "default"
     assert resolved["usage"] == "Usage: /moa <prompt>"
+
+
+def test_resolve_moa_config_ignores_non_dict_preset_result(monkeypatch):
+    import sys
+    from types import ModuleType
+    from typing import Any, cast
+
+    import api.commands as commands
+
+    cfg = {
+        "moa": {
+            "default_preset": "default",
+            "presets": {"default": {"enabled": True}},
+        }
+    }
+    hermes_cli_pkg = sys.modules.get("hermes_cli") or ModuleType("hermes_cli")
+    hermes_cli_pkg.__path__ = []
+    moa_config = ModuleType("hermes_cli.moa_config")
+
+    def normalize_moa_config(raw):
+        return {
+            "default_preset": raw.get("default_preset", "default"),
+            "presets": raw.get("presets", {}),
+        }
+
+    # A hermes-agent build that returns ``None`` for a missing/unknown preset
+    # instead of raising. Without a dict guard, ``resolved.update(None)`` would
+    # raise ``TypeError`` and bypass the routes.py ``except RuntimeError`` guard,
+    # surfacing as an unhandled 500 on chat start.
+    def resolve_moa_preset(_raw, _preset_name):
+        return None
+
+    moa_config_any = cast(Any, moa_config)
+    moa_config_any.normalize_moa_config = normalize_moa_config
+    moa_config_any.resolve_moa_preset = resolve_moa_preset
+    moa_config_any.moa_usage = lambda: "Usage: /moa <prompt>"
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.moa_config", moa_config)
+    monkeypatch.setattr(commands, "_load_config_for_moa_resolution", lambda: cfg, raising=False)
+
+    resolved = commands.resolve_moa_config("default")
+
+    assert isinstance(resolved, dict)
+    assert resolved["preset"] == "default"
+    assert resolved["default_preset"] == "default"
+    assert resolved["usage"] == "Usage: /moa <prompt>"

--- a/tests/test_moa_model_picker_provider.py
+++ b/tests/test_moa_model_picker_provider.py
@@ -1,0 +1,110 @@
+def test_moa_presets_render_as_virtual_provider_models(monkeypatch, tmp_path):
+    import api.config as config
+
+    cfg = {
+        "model": {"default": "gpt-5.5", "provider": "copilot"},
+        "moa": {
+            "default_preset": "Frontier Tuned",
+            "presets": {
+                "default": {"enabled": True},
+                "Frontier Tuned": {"enabled": True},
+                "Disabled Preset": {"enabled": False},
+            },
+        },
+    }
+
+    monkeypatch.setattr(config, "cfg", cfg, raising=False)
+    monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "config.yaml")
+    monkeypatch.setattr(config, "_get_auth_store_path", lambda: tmp_path / "auth.json")
+    monkeypatch.setattr(config, "_get_models_cache_path", lambda: tmp_path / "models_cache.json")
+    monkeypatch.setattr(config, "_models_cache_source_fingerprint", lambda: {"test": "fingerprint"})
+    monkeypatch.setattr(config, "reload_config_if_stale", lambda: None)
+    monkeypatch.setattr(config, "reload_config", lambda: None)
+    monkeypatch.setattr(config, "_cfg_mtime", 0.0, raising=False)
+    monkeypatch.setattr(config, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
+
+    def fake_live_models(provider_id):
+        if provider_id == "copilot":
+            return ["gpt-5.5"]
+        if provider_id == "moa":
+            return ["default", "Frontier Tuned"]
+        return []
+
+    monkeypatch.setattr(config, "_read_live_provider_model_ids", fake_live_models)
+
+    config.invalidate_models_cache()
+    payload = config.get_available_models(force_refresh=True)
+    moa_group = next(g for g in payload["groups"] if g.get("provider_id") == "moa")
+
+    assert moa_group["provider"] == "Mixture of Agents"
+    assert [m["id"] for m in moa_group["models"]] == ["@moa:default", "@moa:Frontier Tuned"]
+
+
+def test_moa_picker_selection_resolves_to_preset_and_provider():
+    from api.routes import _resolve_compatible_session_model_state
+
+    model, provider, normalized = _resolve_compatible_session_model_state(
+        "moa/Frontier Tuned",
+        "moa",
+        profile_provider="copilot",
+        profile_default_model="gpt-5.5",
+        explicit_model_pick=True,
+    )
+
+    assert model == "Frontier Tuned"
+    assert provider == "moa"
+    assert normalized is True
+
+
+def test_resolve_moa_config_uses_selected_preset(monkeypatch):
+    import sys
+    from types import ModuleType
+    from typing import Any, cast
+
+    import api.commands as commands
+
+    cfg = {
+        "moa": {
+            "default_preset": "default",
+            "presets": {
+                "default": {
+                    "enabled": True,
+                    "reference_models": [{"provider": "copilot", "model": "claude-sonnet-4.6"}],
+                    "aggregator": {"provider": "copilot", "model": "gpt-5.5"},
+                },
+                "Frontier Tuned": {
+                    "enabled": True,
+                    "reference_models": [{"provider": "copilot", "model": "claude-opus-4.8"}],
+                    "aggregator": {"provider": "copilot", "model": "gpt-5.4"},
+                },
+            },
+        }
+    }
+
+    hermes_cli_pkg = sys.modules.get("hermes_cli") or ModuleType("hermes_cli")
+    hermes_cli_pkg.__path__ = []
+    moa_config = ModuleType("hermes_cli.moa_config")
+
+    def normalize_moa_config(raw):
+        return {
+            "default_preset": raw.get("default_preset", "default"),
+            "presets": raw.get("presets", {}),
+        }
+
+    def resolve_moa_preset(raw, preset_name):
+        presets = raw.get("presets", {}) if isinstance(raw, dict) else {}
+        return dict(presets.get(preset_name or raw.get("default_preset") or "default", {}))
+
+    moa_config_any = cast(Any, moa_config)
+    moa_config_any.normalize_moa_config = normalize_moa_config
+    moa_config_any.resolve_moa_preset = resolve_moa_preset
+    moa_config_any.moa_usage = lambda: "Usage: /moa <prompt>"
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.moa_config", moa_config)
+    monkeypatch.setattr(commands, "_load_config_for_moa_resolution", lambda: cfg, raising=False)
+
+    resolved = commands.resolve_moa_config("Frontier Tuned")
+
+    assert resolved["preset"] == "Frontier Tuned"
+    assert resolved["reference_models"] == [{"provider": "copilot", "model": "claude-opus-4.8"}]
+    assert resolved["aggregator"] == {"provider": "copilot", "model": "gpt-5.4"}

--- a/tests/test_moa_model_picker_provider.py
+++ b/tests/test_moa_model_picker_provider.py
@@ -26,8 +26,10 @@ def test_moa_presets_render_as_virtual_provider_models(monkeypatch, tmp_path):
     def fake_live_models(provider_id):
         if provider_id == "copilot":
             return ["gpt-5.5"]
+        # MoA presets are local config, so the picker must still render them
+        # when older Hermes Agent installs cannot provide provider_model_ids("moa").
         if provider_id == "moa":
-            return ["default", "Frontier Tuned"]
+            return []
         return []
 
     monkeypatch.setattr(config, "_read_live_provider_model_ids", fake_live_models)
@@ -108,3 +110,44 @@ def test_resolve_moa_config_uses_selected_preset(monkeypatch):
     assert resolved["preset"] == "Frontier Tuned"
     assert resolved["reference_models"] == [{"provider": "copilot", "model": "claude-opus-4.8"}]
     assert resolved["aggregator"] == {"provider": "copilot", "model": "gpt-5.4"}
+
+
+def test_resolve_moa_config_falls_back_when_preset_resolution_raises(monkeypatch):
+    import sys
+    from types import ModuleType
+    from typing import Any, cast
+
+    import api.commands as commands
+
+    cfg = {
+        "moa": {
+            "default_preset": "default",
+            "presets": {"default": {"enabled": True}},
+        }
+    }
+    hermes_cli_pkg = sys.modules.get("hermes_cli") or ModuleType("hermes_cli")
+    hermes_cli_pkg.__path__ = []
+    moa_config = ModuleType("hermes_cli.moa_config")
+
+    def normalize_moa_config(raw):
+        return {
+            "default_preset": raw.get("default_preset", "default"),
+            "presets": raw.get("presets", {}),
+        }
+
+    def resolve_moa_preset(_raw, _preset_name):
+        raise ValueError("boom")
+
+    moa_config_any = cast(Any, moa_config)
+    moa_config_any.normalize_moa_config = normalize_moa_config
+    moa_config_any.resolve_moa_preset = resolve_moa_preset
+    moa_config_any.moa_usage = lambda: "Usage: /moa <prompt>"
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.moa_config", moa_config)
+    monkeypatch.setattr(commands, "_load_config_for_moa_resolution", lambda: cfg, raising=False)
+
+    resolved = commands.resolve_moa_config("broken")
+
+    assert resolved["preset"] == "default"
+    assert resolved["default_preset"] == "default"
+    assert resolved["usage"] == "Usage: /moa <prompt>"

--- a/tests/test_pr1970_lmstudio_base_url_fallback.py
+++ b/tests/test_pr1970_lmstudio_base_url_fallback.py
@@ -417,6 +417,39 @@ def test_provider_catalog_preserves_dict_shaped_raw_key_lookup(monkeypatch):
     assert "another-model" in model_ids
 
 
+def test_provider_catalog_rejects_non_active_models_only_custom_provider(monkeypatch):
+    """A models-only custom provider config must NOT render when it is not the
+    active/configured provider (#5301 review finding: admitting any
+    models-only config re-opens the copilot-2 duplicate-alias regression)."""
+    _stub_hermes_cli(monkeypatch)
+    monkeypatch.setattr("socket.getaddrinfo", lambda *a, **k: [])
+
+    with _RestoreCfg():
+        _set_cfg({
+            "model": {
+                "default": "my-model",
+                "provider": "CLIPpoxy",
+            },
+            "providers": {
+                "CLIPpoxy": {
+                    "models": ["my-model"],
+                },
+                "OtherCustom": {
+                    "models": ["unrelated-model"],
+                },
+            },
+        })
+        config.invalidate_models_cache()
+
+        result = config.get_available_models()
+
+    groups = _groups_by_provider_id(result)
+    assert "clippoxy" in groups, f"Active models-only provider should render, got: {list(groups)}"
+    assert "othercustom" not in groups, (
+        f"Non-active models-only provider must not render as a phantom group, got: {list(groups)}"
+    )
+
+
 def test_provider_catalog_treats_malformed_provider_entry_as_unconfigured(monkeypatch):
     """Provider catalog raw-key lookup must ignore truth-y non-dict entries."""
     _stub_hermes_cli(monkeypatch)


### PR DESCRIPTION
## Release — MoA picker + Copilot catalog fixes (#5301)

PR #5301 by @promptclickrun. Fixes two model-picker/provider-catalog issues, split cleanly.

### Fixes
- **MoA preset re-resolves per turn** and a **malformed (non-dict) `resolve_moa_preset()` result is guarded** so it can't crash resolution.
- **Copilot models-as-settings-map handling scoped to Copilot only** (`pid == "copilot"`). Previously an over-broad `_is_builtin_catalog_provider` guard disabled the `providers.<id>.models` **allowlist** for *every* built-in provider, so a legit `providers.anthropic.models` picker allowlist (#644) was silently ignored.

### Gate (two rounds)
- Round 1: I reviewed end-to-end + ran the full gate; **fixed Regression-1 on the branch** (over-broad built-in guard → narrowed to Copilot) and bounced Regression-2 (malformed-preset / provider-dedup path #1568/#2245/#2399) for the contributor.
- Round 2 (this head): contributor closed Regression-2. **Codex: SAFE TO SHIP** — settings-map skip scoped to copilot (so #644 allowlist honored), non-dict MoA preset guarded, provider dedup (#1568/#2245/#2399) preserved, #1855 fast path kept, no MoA/Copilot regression.
- Full suite: **11545 passed** (only the 2 pre-existing `test_scheduled_jobs_profile_isolation` serial artifacts); 32 targeted (Copilot/MoA/#644/#2245/dedup) + 33 fast-path/resolver.

Credit: @promptclickrun (+ maintainer fix for Regression-1).