### PR TITLE
Release — MoA fail-closed on gateway, ctl.sh .env load, push-to-talk hold gesture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Push-to-talk hold gesture for dictation.** Hold the mic button (or its keyboard activation) to dictate and release to stop, in addition to the existing click-to-toggle mode — a more reliable way to capture a quick voice note. The browser-reserved `Ctrl+Shift+D` chord that an earlier draft proposed was dropped (it collides with browser bookmark shortcuts); only the page-safe hold gesture ships, and the restart/teardown paths are race-hardened so there's no stuck or zombie microphone. Thanks @rodboev. (#5310, #3700)
+
 ### Fixed
+
+- **MoA (Mixture-of-Agents) overrides fail closed on gateway-backed sessions instead of silently running the wrong model.** When WebUI chat is routed through a Hermes Gateway, a per-turn MoA override can't be honored gateway-side, so the request now returns an honest `409` ("MoA override is unavailable on gateway-backed sessions") rather than quietly dropping the override and running the base model. The non-gateway MoA path is unchanged. Thanks @ruizanthony. (#5153)
+
+- **`ctl.sh` loads `~/.hermes/.env` so `${VAR}` references in `config.yaml` resolve.** The control script now reads the environment file before launching, using a literal parser (no `source`/`eval`, so it's injection-safe) that correctly handles quoted values, inline comments, and `export`-prefixed lines. Thanks @hogehou-cmi. (#5309)
 
 - **Manual title regeneration honors your configured auxiliary title-generation timeout.** The manual "regenerate title" action used the frontend's default 30s request timeout, so a slow-but-valid generation timed out on the client when `auxiliary.title_generation.timeout` was set higher. It now fetches the current timeout fresh per regen (no stale cache across profile switches) and applies it only when valid, falling back to the 30s default on any fetch failure. Thanks @Stacey2911. (#5374)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -19367,11 +19367,15 @@ def _handle_chat_start(handler, body, diag=None):
             if "model_provider" in body
             else getattr(s, "model_provider", None)
         )
+<<<<<<< ours
         _pp_provider, _pp_default, _pp_cfg = _read_profile_model_config(s, requested_provider)
+=======
+>>>>>>> theirs
         explicit_model_pick = bool(body.get("explicit_model_pick"))
         moa_config = None
+        gateway_chat_enabled = webui_gateway_chat_enabled(get_config())
         if body.get("moa_config"):
-            if webui_gateway_chat_enabled(get_config()):
+            if gateway_chat_enabled:
                 return bad(handler, "MoA override is unavailable on gateway-backed sessions", 409)
             from api.commands import resolve_moa_config
 
@@ -19379,6 +19383,7 @@ def _handle_chat_start(handler, body, diag=None):
                 moa_config = resolve_moa_config()
             except RuntimeError as e:
                 return bad(handler, str(e), 503)
+        _pp_provider, _pp_default = _read_profile_model_config(s, requested_provider)
         diag.stage("resolve_model_provider") if diag else None
         model, model_provider, normalized_model = _resolve_compatible_session_model_state(
             requested_model,
@@ -19401,18 +19406,22 @@ def _handle_chat_start(handler, body, diag=None):
         # with start_session_turn so both entry points behave identically
         # under runtime_adapter_enabled() / runtime_adapter_runner_enabled()
         # — Q-2979-A2 / Copilot discussion_r3305864087/r3305864173).
+        start_run_kwargs = {
+            "msg": msg,
+            "attachments": attachments,
+            "workspace": workspace,
+            "model": model,
+            "model_provider": model_provider,
+            "normalized_model": normalized_model,
+            "source": "webui",
+            "route": "/api/chat/start",
+            "diag": diag,
+        }
+        if not gateway_chat_enabled and moa_config is not None:
+            start_run_kwargs["moa_config"] = moa_config
         response = _start_run(
             s,
-            msg=msg,
-            attachments=attachments,
-            workspace=workspace,
-            model=model,
-            model_provider=model_provider,
-            normalized_model=normalized_model,
-            source="webui",
-            route="/api/chat/start",
-            diag=diag,
-            moa_config=moa_config,
+            **start_run_kwargs,
         )
         # Map adapter-selection NotImplementedError (501) onto the legacy
         # bad-request response shape that this route exposed historically

--- a/api/routes.py
+++ b/api/routes.py
@@ -19367,10 +19367,7 @@ def _handle_chat_start(handler, body, diag=None):
             if "model_provider" in body
             else getattr(s, "model_provider", None)
         )
-<<<<<<< ours
         _pp_provider, _pp_default, _pp_cfg = _read_profile_model_config(s, requested_provider)
-=======
->>>>>>> theirs
         explicit_model_pick = bool(body.get("explicit_model_pick"))
         moa_config = None
         gateway_chat_enabled = webui_gateway_chat_enabled(get_config())
@@ -19383,7 +19380,6 @@ def _handle_chat_start(handler, body, diag=None):
                 moa_config = resolve_moa_config()
             except RuntimeError as e:
                 return bad(handler, str(e), 503)
-        _pp_provider, _pp_default = _read_profile_model_config(s, requested_provider)
         diag.stage("resolve_model_provider") if diag else None
         model, model_provider, normalized_model = _resolve_compatible_session_model_state(
             requested_model,

--- a/ctl.sh
+++ b/ctl.sh
@@ -29,6 +29,60 @@ ensure_home() {
   mkdir -p "${HERMES_HOME}" "${DEFAULT_STATE_DIR}"
 }
 
+_apply_env_file_safely() {
+  local env_file="$1"
+  local line key value
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line="${line#${line%%[![:space:]]*}}"
+    [[ -z "${line}" || "${line}" == \#* ]] && continue
+    if [[ "${line}" =~ ^export[[:space:]]+(.+)$ ]]; then
+      line="${BASH_REMATCH[1]}"
+      line="${line#${line%%[![:space:]]*}}"
+    fi
+    [[ "${line}" == *=* ]] || continue
+
+    key="${line%%=*}"
+    value="${line#*=}"
+    key="${key//[[:space:]]/}"
+    [[ "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    case "${key}" in
+      UID | GID | EUID | EGID | PPID) continue ;;
+    esac
+
+    value="${value#${value%%[![:space:]]*}}"
+    if [[ "${value}" =~ ^\"(([^\"\\]|\\.)*)\"([[:space:]]*\#.*)?[[:space:]]*$ ]]; then
+      value="${BASH_REMATCH[1]}"
+      value="$(printf '%s' "$value" | awk '{
+        i = 1
+        len = length($0)
+        while (i <= len) {
+          c = substr($0, i, 1)
+          if (c == "\\" && i < len) {
+            nc = substr($0, i+1, 1)
+            if (nc == "n") printf "\n"
+            else if (nc == "r") printf "\r"
+            else if (nc == "t") printf "\t"
+            else if (nc == "\"") printf "\""
+            else if (nc == "\\") printf "\\"
+            else { printf "\\%s", nc }
+            i += 2
+          } else {
+            printf "%s", c
+            i++
+          }
+        }
+      }')"
+    elif [[ "${value}" =~ ^\'([^\']*)\'([[:space:]]*\#.*)?[[:space:]]*$ ]]; then
+      value="${BASH_REMATCH[1]}"
+    else
+      value="${value%%[[:space:]]\#*}"
+      value="${value%${value##*[![:space:]]}}"
+    fi
+
+    export "${key}=${value}"
+  done < "${env_file}"
+}
+
 _load_repo_dotenv_preserving_env() {
   [[ "${HERMES_WEBUI_NO_DOTENV:-0}" == "1" ]] && return 0
   local env_file="${REPO_ROOT}/.env"
@@ -40,7 +94,9 @@ _load_repo_dotenv_preserving_env() {
     line="${line#${line%%[![:space:]]*}}"
     [[ -z "${line}" || "${line}" == \#* || "${line}" != *=* ]] && continue
     key="${line%%=*}"
-    key="${key#export }"
+    if [[ "${key}" =~ ^export[[:space:]]+(.+)$ ]]; then
+      key="${BASH_REMATCH[1]}"
+    fi
     key="${key//[[:space:]]/}"
     [[ "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     # Skip shell-readonly names (UID/GID/EUID/EGID/PPID); re-exporting them
@@ -54,21 +110,50 @@ _load_repo_dotenv_preserving_env() {
     fi
   done < "${env_file}"
 
-  set -a
-  # Filter out shell-readonly vars (UID, GID, EUID, EGID, PPID) before
-  # sourcing.  docker-compose.yml's macOS instructions document
-  # `echo "UID=$(id -u)" >> .env`; under `set -euo pipefail` a raw
-  # `source .env` then aborts with "UID: readonly variable" before
-  # `ctl.sh status` can print anything.  Mirrors the guard start.sh uses.
-  local _ctl_env_filtered
-  _ctl_env_filtered="$(mktemp "${TMPDIR:-/tmp}/hermes-webui-ctl-env.XXXXXX")"
-  # shellcheck disable=SC2064
-  trap "rm -f '${_ctl_env_filtered}'" RETURN
-  grep -vE '^[[:space:]]*(export[[:space:]]+)?(UID|GID|EUID|EGID|PPID)=' "${env_file}" > "${_ctl_env_filtered}" || true
-  # shellcheck source=/dev/null
-  source "${_ctl_env_filtered}"
-  rm -f "${_ctl_env_filtered}"
-  set +a
+  _apply_env_file_safely "${env_file}"
+
+  local assignment
+  if [[ ${#preserved[@]} -gt 0 ]]; then
+    for assignment in "${preserved[@]}"; do
+      export "${assignment}"
+    done
+  fi
+}
+
+_load_hermes_dotenv() {
+  # Also load ~/.hermes/.env so that ${VAR} references in config.yaml can
+  # resolve against provider credentials defined in the Hermes env file.
+  # Repo .env takes precedence (loaded above); variables already exported
+  # into the shell environment (including those just set by repo .env) are
+  # captured in preserved[] before _apply_env_file_safely runs and are
+  # restored afterwards, so this acts as a fallback source for vars the
+  # repo .env did not define.
+  [[ "${HERMES_WEBUI_NO_DOTENV:-0}" == "1" ]] && return 0
+  local hermes_home="${HERMES_HOME:-${HOME}/.hermes}"
+  local hermes_env="${hermes_home}/.env"
+  [[ -f "${hermes_env}" ]] || return 0
+
+  local -a preserved=()
+  local line key value
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line="${line#${line%%[![:space:]]*}}"
+    [[ -z "${line}" || "${line}" == \#* || "${line}" != *=* ]] && continue
+    key="${line%%=*}"
+    if [[ "${key}" =~ ^export[[:space:]]+(.+)$ ]]; then
+      key="${BASH_REMATCH[1]}"
+    fi
+    key="${key//[[:space:]]/}"
+    [[ "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    case "${key}" in
+      UID | GID | EUID | EGID | PPID) continue ;;
+    esac
+    if [[ -n "${!key+x}" ]]; then
+      value="${!key}"
+      preserved+=("${key}=${value}")
+    fi
+  done < "${hermes_env}"
+
+  _apply_env_file_safely "${hermes_env}"
 
   local assignment
   if [[ ${#preserved[@]} -gt 0 ]]; then
@@ -342,6 +427,7 @@ _launchd_webui_pid() {
 start_cmd() {
   ensure_home
   _load_repo_dotenv_preserving_env
+  _load_hermes_dotenv
   export HERMES_WEBUI_STATE_DIR="${HERMES_WEBUI_STATE_DIR:-${DEFAULT_STATE_DIR}}"
   mkdir -p "${HERMES_WEBUI_STATE_DIR}"
   _parse_launch_binding "$@"
@@ -447,6 +533,7 @@ except Exception:
 status_cmd() {
   ensure_home
   _load_repo_dotenv_preserving_env
+  _load_hermes_dotenv
   _load_state_if_present
   local host="${HOST:-${HERMES_WEBUI_HOST:-127.0.0.1}}"
   local port="${PORT:-${HERMES_WEBUI_PORT:-8787}}"

--- a/static/boot.js
+++ b/static/boot.js
@@ -645,6 +645,11 @@ function _micToastKeyForRecognitionError(error){
   let _finalText='';
   let _prefix='';
   let _isRecording=false;
+  let _micHoldTimer=null;
+  let _micHoldActive=false;
+  let _micPointerDown=false;
+  let _micStartSeq=0;
+  const _micHoldThresholdMs=300;
 
   function _setButtonTooltipAndKey(btn, key){
     const text = t(key);
@@ -751,14 +756,16 @@ function _micToastKeyForRecognitionError(error){
     }
   }
 
-  function _stopTracks(){
-    if(mediaStream){
-      mediaStream.getTracks().forEach(track=>track.stop());
-      mediaStream=null;
+  function _stopTracks(stream=mediaStream){
+    if(stream){
+      stream.getTracks().forEach(track=>track.stop());
+      if(mediaStream===stream) mediaStream=null;
     }
   }
 
   function _stopMic(){
+    _micStartSeq+=1;
+    _isRecording=false;
     if(!window._micActive) return;
     // Stop the backend that was ACTIVE WHEN RECORDING STARTED — not whatever
     // _rawAudioMode says now. The user can toggle Settings → Sound mid-recording,
@@ -868,7 +875,31 @@ function _micToastKeyForRecognitionError(error){
 
   _probeServerSttCapability();
 
-  btn.onclick=async()=>{
+  function _clearMicHoldTimer(){
+    if(_micHoldTimer){
+      clearTimeout(_micHoldTimer);
+      _micHoldTimer=null;
+    }
+  }
+
+  function _resetMicHoldState(){
+    _clearMicHoldTimer();
+    _micHoldActive=false;
+    _micPointerDown=false;
+  }
+
+  function _micButtonAvailable(){
+    if(!btn||btn.disabled) return false;
+    if(btn.style.display==='none') return false;
+    if(btn.classList.contains('composer-control-hidden')) return false;
+    if(btn.getAttribute('aria-hidden')==='true') return false;
+    if(window.getComputedStyle&&window.getComputedStyle(btn).display==='none') return false;
+    return true;
+  }
+
+  async function _startMicCapture(holdRequired=false){
+    if(!_micButtonAvailable()) return;
+    const startSeq=++_micStartSeq;
     // Race-condition guard: ignore rapid double-clicks
     if(_isRecording){
       _stopMic();
@@ -900,26 +931,38 @@ function _micToastKeyForRecognitionError(error){
       return;
     }
     try{
-      mediaStream=await navigator.mediaDevices.getUserMedia({audio:true});
+      const captureStream=await navigator.mediaDevices.getUserMedia({audio:true});
+      if(startSeq!==_micStartSeq||!_micButtonAvailable()||(holdRequired&&!_micHoldActive)){
+        _isRecording=false;
+        _stopTracks(captureStream);
+        return;
+      }
+      mediaStream=captureStream;
       const preferredTypes=['audio/webm;codecs=opus','audio/webm','audio/ogg;codecs=opus','audio/ogg'];
       const mimeType=preferredTypes.find(type=>window.MediaRecorder.isTypeSupported?.(type))||'';
-      mediaRecorder=new MediaRecorder(mediaStream,mimeType?{mimeType}:undefined);
+      const captureMode=_rawAudioMode?'media-raw':'media-transcribe';
+      const recorder=new MediaRecorder(captureStream,mimeType?{mimeType}:undefined);
       audioChunks=[];
-      mediaRecorder.ondataavailable=e=>{if(e.data&&e.data.size)audioChunks.push(e.data);};
-      mediaRecorder.onerror=()=>{
+      const captureChunks=audioChunks;
+      recorder.ondataavailable=e=>{if(e.data&&e.data.size)captureChunks.push(e.data);};
+      recorder.onerror=()=>{
+        const isCurrentCapture=mediaRecorder===recorder||mediaStream===captureStream;
         _isRecording=false;
-        _setRecording(false);
+        if(mediaRecorder===recorder) mediaRecorder=null;
+        if(isCurrentCapture) _setRecording(false);
         window._micPendingSend=false;
-        _stopTracks();
+        _stopTracks(captureStream);
         showToast(t('mic_network'));
       };
-      mediaRecorder.onstop=async()=>{
+      recorder.onstop=async()=>{
+        const isCurrentCapture=mediaRecorder===recorder||mediaStream===captureStream;
+        if(mediaRecorder===recorder) mediaRecorder=null;
         _isRecording=false;
-        const blob=new Blob(audioChunks,{type:mediaRecorder.mimeType||mimeType||'audio/webm'});
-        _setRecording(false);
-        _stopTracks();
+        const blob=new Blob(captureChunks,{type:recorder.mimeType||mimeType||'audio/webm'});
+        if(isCurrentCapture) _setRecording(false);
+        _stopTracks(captureStream);
         if(blob.size){
-          if(_activeCaptureMode==='media-raw'){
+          if(captureMode==='media-raw'){
             await _sendRawAudio(blob);
           }else{
             await _transcribeBlob(blob);
@@ -930,16 +973,81 @@ function _micToastKeyForRecognitionError(error){
         }
         _applyDeferredServerSttFlip();
       };
-      _activeCaptureMode=_rawAudioMode?'media-raw':'media-transcribe';
-      mediaRecorder.start();
+      _activeCaptureMode=captureMode;
+      mediaRecorder=recorder;
+      recorder.start();
       _setRecording(true);
     }catch(err){
+      if(startSeq!==_micStartSeq) return;
       _isRecording=false;
       window._micPendingSend=false;
       _stopTracks();
       showToast(t(_micToastKeyForRecognitionError('not-allowed')||'mic_denied'));
     }
-  };
+  }
+
+  async function _toggleMicCapture(){
+    if(!_micButtonAvailable()) return;
+    if(window._micActive){
+      _stopMic();
+      return;
+    }
+    await _startMicCapture();
+  }
+  window._toggleMicCapture=_toggleMicCapture;
+
+  btn.addEventListener('pointerdown',e=>{
+    if(e.button!==0) return;
+    if(!_micButtonAvailable()) return;
+    _resetMicHoldState();
+    _micPointerDown=true;
+    _micHoldTimer=setTimeout(async()=>{
+      _micHoldTimer=null;
+      if(!_micPointerDown||window._micActive) return;
+      _micHoldActive=true;
+      await _startMicCapture(true);
+    },_micHoldThresholdMs);
+  });
+
+  btn.addEventListener('pointerup',async e=>{
+    if(e.button!==0||!_micPointerDown) return;
+    _clearMicHoldTimer();
+    if(_micHoldActive){
+      _micHoldActive=false;
+      _micPointerDown=false;
+      _stopMic();
+      return;
+    }
+    _micPointerDown=false;
+    await _toggleMicCapture();
+  });
+
+  btn.addEventListener('pointerleave',()=>{
+    _clearMicHoldTimer();
+    if(_micHoldActive){
+      _micHoldActive=false;
+      _micPointerDown=false;
+      _stopMic();
+      return;
+    }
+    _micPointerDown=false;
+  });
+
+  btn.addEventListener('pointercancel',()=>{
+    _clearMicHoldTimer();
+    if(_micHoldActive){
+      _micHoldActive=false;
+      _micPointerDown=false;
+      _stopMic();
+      return;
+    }
+    _micPointerDown=false;
+  });
+
+  btn.addEventListener('click',async e=>{
+    if(e.detail!==0) return;
+    await _toggleMicCapture();
+  });
 
   // Wire up the settings checkbox
   const rawAudioCheckbox = document.getElementById('settingsRawAudio');

--- a/static/commands.js
+++ b/static/commands.js
@@ -1644,7 +1644,15 @@ function cmdReasoning(args){
 }
 function cmdVoice(){
   const mic=document.getElementById('btnMic');
-  if(mic&&mic.style.display!=='none'&&!mic.disabled){try{mic.click();return;}catch(_){}}
+  const micVisible=!!(
+    mic
+    && mic.style.display!=='none'
+    && !mic.disabled
+    && !mic.classList.contains('composer-control-hidden')
+    && mic.getAttribute('aria-hidden')!=='true'
+    && (!window.getComputedStyle||window.getComputedStyle(mic).display!=='none')
+  );
+  if(micVisible){try{mic.click();return;}catch(_){}}
   showToast(t('cmd_voice_use_mic'));
 }
 

--- a/tests/test_bugbatch_apr2026.py
+++ b/tests/test_bugbatch_apr2026.py
@@ -177,13 +177,15 @@ def test_590_transcribing_status_shown_before_fetch():
 
 
 def test_590_recording_stops_before_transcribe():
-    """boot.js: _setRecording(false) must fire in onstop before _transcribeBlob."""
-    onstop_start = BOOT_JS.find("mediaRecorder.onstop")
-    assert onstop_start != -1, "mediaRecorder.onstop not found"
-    onstop_body = BOOT_JS[onstop_start:onstop_start + 400]
+    """boot.js: _setRecording(false) must fire in onstop before the pinned send path."""
+    onstop_start = BOOT_JS.find("recorder.onstop")
+    assert onstop_start != -1, "recorder.onstop not found"
+    onstop_body = BOOT_JS[onstop_start:onstop_start + 700]
     rec_pos = onstop_body.find("_setRecording(false)")
     blob_pos = onstop_body.find("_transcribeBlob(")
-    assert rec_pos != -1 and blob_pos != -1
-    assert rec_pos < blob_pos, (
-        "_setRecording(false) must come before _transcribeBlob so mic icon clears immediately"
+    raw_pos = onstop_body.find("_sendRawAudio(")
+    send_pos = raw_pos if raw_pos != -1 and (blob_pos == -1 or raw_pos < blob_pos) else blob_pos
+    assert rec_pos != -1 and send_pos != -1
+    assert rec_pos < send_pos, (
+        "_setRecording(false) must come before the pinned send path so the mic icon clears immediately"
     )

--- a/tests/test_ctl_script.py
+++ b/tests/test_ctl_script.py
@@ -325,6 +325,82 @@ def test_start_loads_dotenv_but_inline_overrides_win(tmp_path):
         assert_process_exits(pid)
 
 
+def test_start_loads_dotenv_double_quoted_port_with_trailing_comment(tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _seed_ctl_repo(repo_root)
+    (repo_root / "bootstrap.py").write_text("# fake bootstrap target\n", encoding="utf-8")
+
+    fake_python = tmp_path / "fake-python"
+    fake_log = tmp_path / "fake-python.log"
+    write_fake_python(fake_python)
+    (repo_root / ".env").write_text(
+        'HERMES_WEBUI_PORT="19004" # inline comment\n',
+        encoding="utf-8",
+    )
+
+    result = run_ctl(
+        tmp_path,
+        "start",
+        env={
+            "HERMES_WEBUI_PYTHON": str(fake_python),
+            "FAKE_PYTHON_LOG": str(fake_log),
+            "HERMES_WEBUI_CTL_ALLOW_LAUNCHD_CONFLICT": "1",
+        },
+        repo_root=repo_root,
+        load_dotenv=True,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    pid = wait_for_pid_file(tmp_path / ".hermes" / "webui.pid")
+    try:
+        fake_output = wait_for_file_text(fake_log, contains="host=127.0.0.1 port=19004")
+        assert "host=127.0.0.1 port=19004" in fake_output
+    finally:
+        stop = run_ctl(tmp_path, "stop", repo_root=repo_root)
+        assert stop.returncode == 0, stop.stderr + stop.stdout
+        _kill_tree(pid)
+        assert_process_exits(pid)
+
+
+def test_start_loads_dotenv_export_tab_host_assignment(tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _seed_ctl_repo(repo_root)
+    (repo_root / "bootstrap.py").write_text("# fake bootstrap target\n", encoding="utf-8")
+
+    fake_python = tmp_path / "fake-python"
+    fake_log = tmp_path / "fake-python.log"
+    write_fake_python(fake_python)
+    (repo_root / ".env").write_text(
+        "export\tHERMES_WEBUI_HOST=0.0.0.0\nHERMES_WEBUI_PORT=19005\n",
+        encoding="utf-8",
+    )
+
+    result = run_ctl(
+        tmp_path,
+        "start",
+        env={
+            "HERMES_WEBUI_PYTHON": str(fake_python),
+            "FAKE_PYTHON_LOG": str(fake_log),
+            "HERMES_WEBUI_CTL_ALLOW_LAUNCHD_CONFLICT": "1",
+        },
+        repo_root=repo_root,
+        load_dotenv=True,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    pid = wait_for_pid_file(tmp_path / ".hermes" / "webui.pid")
+    try:
+        fake_output = wait_for_file_text(fake_log, contains="host=0.0.0.0 port=19005")
+        assert "host=0.0.0.0 port=19005" in fake_output
+    finally:
+        stop = run_ctl(tmp_path, "stop", repo_root=repo_root)
+        assert stop.returncode == 0, stop.stderr + stop.stdout
+        _kill_tree(pid)
+        assert_process_exits(pid)
+
+
 def test_stale_pid_file_is_removed_without_killing_unrelated_process(tmp_path):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()

--- a/tests/test_issue3700_push_to_talk.py
+++ b/tests/test_issue3700_push_to_talk.py
@@ -1,0 +1,92 @@
+import re
+from pathlib import Path
+
+
+def _boot_src() -> str:
+    return Path("static/boot.js").read_text(encoding="utf-8")
+
+
+def _commands_src() -> str:
+    return Path("static/commands.js").read_text(encoding="utf-8")
+
+
+def test_start_mic_capture_extracted():
+    src = _boot_src()
+    assert re.search(r"async function _startMicCapture\([^)]*\)\{", src)
+    assert "_activeCaptureMode='speech'" in src
+    assert "const captureMode=_rawAudioMode?'media-raw':'media-transcribe';" in src
+    assert "_activeCaptureMode=captureMode;" in src
+
+
+def test_toggle_mic_capture_exposed_on_window():
+    src = _boot_src()
+    assert "async function _toggleMicCapture()" in src
+    assert "window._toggleMicCapture=_toggleMicCapture;" in src
+
+
+def test_toggle_helper_respects_hidden_mic_setting():
+    src = _boot_src()
+    assert "function _micButtonAvailable()" in src
+    assert "btn.classList.contains('composer-control-hidden')" in src
+    assert "btn.getAttribute('aria-hidden')==='true'" in src
+
+
+def test_voice_command_respects_hidden_mic_setting_before_clicking():
+    src = _commands_src()
+    assert "function cmdVoice()" in src
+    assert "mic.classList.contains('composer-control-hidden')" in src
+    assert "mic.getAttribute('aria-hidden')!=='true'" in src
+    assert "showToast(t('cmd_voice_use_mic'));" in src
+
+
+def test_old_onclick_handler_removed():
+    src = _boot_src()
+    assert "btn.onclick=async()=>{" not in src
+
+
+def test_pointer_hold_wiring_present():
+    src = _boot_src()
+    assert "let _micHoldTimer=null;" in src
+    assert "let _micHoldActive=false;" in src
+    assert "let _micPointerDown=false;" in src
+    assert "let _micStartSeq=0;" in src
+    assert "const _micHoldThresholdMs=300;" in src
+    assert "btn.addEventListener('pointerdown'" in src
+    assert "btn.addEventListener('pointerup'" in src
+    assert (
+        "btn.addEventListener('pointerleave'" in src
+        or "btn.addEventListener('pointercancel'" in src
+    )
+    assert "_micHoldTimer=setTimeout(async()=>{" in src
+    assert "},_micHoldThresholdMs);" in src
+
+
+def test_hold_release_routes_to_stop_mic():
+    src = _boot_src()
+    assert re.search(
+        r"btn\.addEventListener\('pointerup',async e=>\{.*?_stopMic\(\);.*?\}\);",
+        src,
+        re.DOTALL,
+    )
+    assert re.search(
+        r"btn\.addEventListener\('pointer(cancel|leave)',\(\)=>\{.*?_stopMic\(\);.*?\}\);",
+        src,
+        re.DOTALL,
+    )
+    assert "const startSeq=++_micStartSeq;" in src
+    assert "if(startSeq!==_micStartSeq||!_micButtonAvailable()||(holdRequired&&!_micHoldActive)){" in src
+    assert "_stopTracks(captureStream);" in src
+    assert "if(startSeq!==_micStartSeq) return;" in src
+
+
+def test_reserved_ctrl_shift_d_shortcut_is_not_bound():
+    src = _boot_src()
+    assert "(e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='d'||e.key==='D')" not in src
+    assert "await window._toggleMicCapture();" not in src
+
+
+def test_stop_mic_still_exposed_and_active_capture_mode_retained():
+    src = _boot_src()
+    assert "window._stopMic=_stopMic;" in src
+    assert "_activeCaptureMode" in src
+    assert "_stopMic();" in src

--- a/tests/test_issue4571_mic_insecure_origin.py
+++ b/tests/test_issue4571_mic_insecure_origin.py
@@ -70,8 +70,8 @@ def test_permission_style_speech_errors_use_insecure_origin_key_only_on_that_bra
 def test_dictation_preflights_insecure_origin_before_speech_or_media_capture():
     body = _slice_between(
         BOOT_JS,
-        "btn.onclick=async()=>{",
-        "\n  // Wire up the settings checkbox",
+        "async function _startMicCapture(holdRequired=false){",
+        "\n\n  async function _toggleMicCapture(){",
     )
     insecure_idx = body.index("_micOriginNeedsSecureContext()")
     speech_idx = body.index("recognition.start()")

--- a/tests/test_issue5057_moa_webui_route.py
+++ b/tests/test_issue5057_moa_webui_route.py
@@ -127,3 +127,64 @@ def test_moa_config_is_per_turn_not_persisted():
     js_source = js_path.read_text(encoding="utf-8")
     assert "moa_config:_pendingMoaConfig?true:undefined" in js_source
     assert "_pendingMoaConfig=null" in js_source
+
+
+def test_moa_gateway_chat_start_fails_closed(monkeypatch, tmp_path):
+    """Gateway-backed WebUI sessions must reject /moa until the gateway consumes runtime overrides."""
+    import api.commands as commands
+    import api.routes as routes
+
+    class _Handler:
+        def __init__(self):
+            import io
+
+            self.status = None
+            self.response_headers = []
+            self.wfile = io.BytesIO()
+
+        def send_response(self, status):
+            self.status = status
+
+        def send_header(self, key, value):
+            self.response_headers.append((key, value))
+
+        def end_headers(self):
+            self.response_headers.append(("__end__", ""))
+
+    class _Session:
+        session_id = "sess-moa-gateway"
+        workspace = str(tmp_path)
+        model = "gpt-5.5"
+        model_provider = "openai-codex"
+        profile = "default"
+        messages = []
+        context_messages = []
+        pending_user_message = None
+
+    def start_run(*_args, **_kwargs):  # pragma: no cover - should fail before run start
+        raise AssertionError("gateway-backed /moa must fail closed before starting a run")
+
+    def resolve_moa_config():  # pragma: no cover - should fail before resolving MoA
+        raise AssertionError("gateway-backed /moa must fail before resolving MoA config")
+
+    monkeypatch.setattr(routes, "get_session", lambda _sid: _Session())
+    monkeypatch.setattr(routes, "_resolve_chat_workspace_with_recovery", lambda _s, _w: str(tmp_path))
+    monkeypatch.setattr(routes, "_start_run", start_run)
+    monkeypatch.setattr(routes, "get_config", lambda: {"chat_backend": "gateway"})
+    monkeypatch.setattr(routes, "webui_gateway_chat_enabled", lambda _cfg: True)
+    monkeypatch.setattr(commands, "resolve_moa_config", resolve_moa_config)
+
+    handler = _Handler()
+    routes._handle_chat_start(
+        handler,
+        {
+            "session_id": "sess-moa-gateway",
+            "message": "diagnose issue",
+            "workspace": str(tmp_path),
+            "moa_config": True,
+        },
+    )
+
+    body = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert handler.status == 409
+    assert body["error"] == "MoA override is unavailable on gateway-backed sessions"

--- a/tests/test_raw_audio_upload.py
+++ b/tests/test_raw_audio_upload.py
@@ -159,10 +159,11 @@ def test_stop_mic_uses_pinned_active_capture_mode_not_current_rawmode():
     # _stopMic decides backend from the pinned mode, not _rawAudioMode.
     assert "_activeCaptureMode==='speech'" in _BOOT_JS
     # onstop dispatches raw-vs-transcribe from the pinned mode too.
-    assert "_activeCaptureMode==='media-raw'" in _BOOT_JS
+    assert "if(captureMode==='media-raw')" in _BOOT_JS
     # the mode is pinned at both start branches.
     assert "_activeCaptureMode='speech'" in _BOOT_JS
-    assert "_activeCaptureMode=_rawAudioMode?'media-raw':'media-transcribe'" in _BOOT_JS
+    assert "const captureMode=_rawAudioMode?'media-raw':'media-transcribe';" in _BOOT_JS
+    assert "_activeCaptureMode=captureMode;" in _BOOT_JS
 
 
 def test_send_raw_audio_honors_explicit_pending_send():

--- a/tests/test_sprint20.py
+++ b/tests/test_sprint20.py
@@ -425,11 +425,10 @@ def test_boot_js_prefix_variable_declared():
 def test_boot_js_prefix_captured_on_start():
     """_prefix must be set from ta.value when the user starts recording."""
     js, _ = get_text("/static/boot.js")
-    # _prefix assignment must happen in the btn.onclick else branch (before recognition.start)
-    btn_onclick_idx = js.find("btn.onclick")
-    btn_onclick_end = js.find("};", btn_onclick_idx)
-    onclick_body = js[btn_onclick_idx:btn_onclick_end]
-    assert "_prefix=ta.value" in onclick_body or "_prefix = ta.value" in onclick_body
+    start_idx = js.find("async function _startMicCapture")
+    start_end = js.find("async function _toggleMicCapture", start_idx)
+    start_body = js[start_idx:start_end]
+    assert "_prefix=ta.value" in start_body or "_prefix = ta.value" in start_body
 
 
 def test_boot_js_onresult_prepends_prefix():


### PR DESCRIPTION
## Phase-1 low-risk batch release

Three file-disjoint, gate-pass PRs shipped together. Each was individually gate-certified GREEN; this combined stage was rebased onto current `master` and re-gated.

### PRs
| PR | Author | Change | Files |
|---|---|---|---|
| #5153 | @ruizanthony | MoA overrides **fail closed** on gateway-backed sessions (honest `409`, no silent-wrong-model path) | `api/routes.py` |
| #5309 | @hogehou-cmi | `ctl.sh` loads `~/.hermes/.env` so `${VAR}` refs in `config.yaml` resolve (literal parser, injection-safe) | `ctl.sh` |
| #5310 | @rodboev | Push-to-talk hold gesture (#3700); browser-reserved `Ctrl+Shift+D` chord dropped; race-hardened | `static/boot.js`, `static/commands.js` |

### Gate results (combined stage on current master)
- **Codex regression gate: SAFE TO SHIP** — read every changed file, traced hunks into callers, no regression risk found.
- **Full pytest suite: 11639 passed, 11 skipped, 1 xfailed, 2 xpassed, 0 failures** (7m14s, `-p no:xdist`).
- **Targeted tests: 115/115 passed** (`test_issue5057_moa_webui_route`, `test_issue3700_push_to_talk`, `test_ctl_script`, `test_issue4571_mic_insecure_origin`, `test_raw_audio_upload`, `test_sprint20`, `test_bugbatch_apr2026`).

### Note on #5153 stale-base resolution
The PR was authored when `_read_profile_model_config()` returned 2 values; master now returns 3 (`_pp_provider, _pp_default, _pp_cfg`, with `profile_config=_pp_cfg` threaded into `_resolve_compatible_session_model_state`). The stage keeps master's 3-value call and drops the PR's stray relocated 2-value line — the fail-closed `409` logic and `start_run_kwargs` are intact. Verified: no conflict markers, `routes.py` parses, `_pp_cfg` threading preserved.

Closes #5153, #5309, #5310. Fixes #3700.
