### PR TITLE
Hotfix — remove Export-to-HTML button from composer footer (restores model/workspace labels)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **The composer footer shows your model and workspace names again on desktop.** The Export-to-HTML button added to the composer footer in the previous release pushed the control row past its width budget, which collapsed the footer into icon-only mode and hid the model / workspace / profile text labels. The export button has been removed from the composer footer (export remains available from Settings), so the labels are visible again.
+
 ### Added
 
 - **Export a conversation to a self-contained, theme-matched HTML file.** From a session you can now download a single standalone `.html` of the transcript with the current theme's palette baked in — no external resource loads (fully offline/portable), messages rendered as escaped text (no script/style/raw-HTML injection from conversation content), and remote images neutralized. Thanks @brick-hard. (#4968)

--- a/static/boot.js
+++ b/static/boot.js
@@ -1763,7 +1763,6 @@ function exportSessionHTML(){
   a.download=`hermes-${S.session.session_id}.html`;a.click();
 }
 $('btnExportHTML').onclick=exportSessionHTML;
-if($('btnExportHTMLComposer'))$('btnExportHTMLComposer').onclick=exportSessionHTML;
 $('btnImportJSON').onclick=()=>$('importFileInput').click();
 $('importFileInput').onchange=async(e)=>{
   const file=e.target.files[0];

--- a/static/index.html
+++ b/static/index.html
@@ -584,9 +584,6 @@
             <button type="button" class="icon-btn has-tooltip" id="btnSavedPrompts" data-tooltip="Saved prompts" onclick="toggleSavedPromptsPopup()" aria-haspopup="menu" aria-expanded="false" aria-controls="savedPromptsPopup">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
             </button>
-            <button type="button" class="icon-btn has-tooltip" id="btnExportHTMLComposer" data-tooltip="Export chat as HTML" data-i18n-title="export_session_html_tooltip">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><path d="M9 13l-2 2 2 2"/><path d="M15 13l2 2-2 2"/></svg>
-            </button>
             <button class="icon-btn mic-btn has-tooltip" id="btnMic" data-tooltip="Dictate" data-i18n-title="voice_dictate" style="display:none">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <rect x="9" y="1" width="6" height="12" rx="3"/>


### PR DESCRIPTION
## Hotfix — remove Export-to-HTML button from the composer footer

Fixes a regression from #4968 (v0.51.818): the HTML-export button was hard-inserted into the composer footer's `.composer-left` control row, bypassing the configurable composer-control framework. On desktop the extra button pushed the footer past its overflow threshold, tripping `_fitComposerFooter()` into `cf-icons` mode — which hides the model, workspace, and profile **text labels** (`#composerModelLabel` / `#composerWorkspaceLabel` / `#composerProfileLabel`, style.css:2926-2935). Reported: model + workspace names disappeared from the composer footer on desktop.

### Fix
Remove `#btnExportHTMLComposer` from `static/index.html` and its `onclick` wiring in `static/boot.js`. The export capability is unchanged — it stays available via the **settings-panel** button (`#btnExportHTML`) and the `exportSessionHTML()` function is untouched.

### Verified
- **Live desktop screenshot + DOM assertions:** footer class is `composer-footer` (no `cf-icons`/`cf-burger` — no overflow), `btnExportHTMLComposer` absent, `composerModelLabel`="Sonnet 4.6" visible, `composerWorkspaceLabel`="Home" visible. Screenshot reviewed by maintainer.
- **124/124** composer-control + export-palette tests pass (`test_issue4598_composer_control_visibility`, `test_issue1431_toolsets_chip_responsive`, `test_reasoning_chip_btw_fixes`, `test_mobile_layout`, `test_session_export_html_palette`).
- Full suite green (see CI).

Fixes the composer-footer overflow regression introduced by #4968.
