### PR TITLE
fix(webui): stop transparent stream row flicker

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3978,6 +3978,17 @@ body.resizing .sidebar{transition:none!important;}
    base row class replayed the whole transcript's shimmer on every renderMessages
    rebuild. (Trifecta finding V9.) */
 #liveAssistantTurn .transparent-event-row{animation:transparent-event-enter .18s ease-out both;}
+/* Live transparent anchor scene rows are rebuilt during streaming as the anchor
+   projection receives token/reasoning updates. Replaying the entrance animation
+   on those replacement rows restarts opacity at 0 and produces visible flicker. */
+#liveAssistantTurn .transparent-event-row[data-anchor-live-scene-row="1"],
+#liveAssistantTurn .transparent-event-row[data-live-stream-owned="1"]{
+  animation:none!important;
+  opacity:1!important;
+  transition-property:none!important;
+  transition-duration:0s!important;
+  transition-delay:0s!important;
+}
 .transparent-event-row[data-event-type="thinking"]{
   background:transparent;
   border-color:transparent;

--- a/tests/test_smooth_text_fade.py
+++ b/tests/test_smooth_text_fade.py
@@ -234,6 +234,33 @@ def test_live_streaming_assistant_content_opts_out_of_global_theme_transitions()
     )
 
 
+def test_live_anchor_transparent_rows_do_not_replay_entrance_animation_on_stream_updates():
+    """Live Transparent Stream rows are rebuilt during token/reasoning updates.
+
+    The base live-row entrance animation starts at opacity 0. If it applies to
+    anchor-scene rows that are replaced on every stream update, the visible trace
+    flashes/fades repeatedly even when the assistant text node itself is stable.
+    """
+    assert "#liveAssistantTurn .transparent-event-row{animation:transparent-event-enter" in STYLE_CSS
+    guard = STYLE_CSS[
+        STYLE_CSS.index("Live transparent anchor scene rows are rebuilt during streaming") : STYLE_CSS.index(
+            ".transparent-event-row[data-event-type=\"thinking\"]"
+        )
+    ]
+    assert_contains_all(
+        guard,
+        [
+            '#liveAssistantTurn .transparent-event-row[data-anchor-live-scene-row="1"]',
+            '#liveAssistantTurn .transparent-event-row[data-live-stream-owned="1"]',
+            "animation:none!important",
+            "opacity:1!important",
+            "transition-property:none!important",
+            "transition-duration:0s!important",
+            "transition-delay:0s!important",
+        ],
+    )
+
+
 def test_stream_fade_css_is_opacity_only_and_hides_live_cursor():
     fade_css = STYLE_CSS[STYLE_CSS.index("OpenWebUI-style streaming word fade") :]
     assert "filter:" not in STYLE_CSS[STYLE_CSS.index("OpenWebUI-style streaming word fade") :].split(


### PR DESCRIPTION
## Summary
- Disable the live entrance animation for Transparent Stream anchor-scene rows that are rebuilt during token/reasoning updates.
- Keep the existing entrance animation for normal live transparent rows.
- Add regression coverage so rebuilt live anchor rows stay at `opacity: 1` with no animation/transition replay.

## Root cause
`_renderLiveAnchorActivitySceneTransparent()` rebuilds visible anchor-scene rows as the live stream receives token/reasoning updates. The base live CSS applied `transparent-event-enter` to every `#liveAssistantTurn .transparent-event-row`, so each replacement row restarted at opacity 0 and produced a visible flicker even though the assistant source segment remained stable.

## Verification
- `python3 -m pytest tests/test_smooth_text_fade.py tests/test_issue3877_midstream_flicker.py tests/test_issue3820_chat_activity_display_mode.py -q`
- Browser replay probe against the live WebUI: sampled live `data-anchor-live-scene-row="1"` rows had `animation: none`, `opacity: 1`, and `transition: none`; base non-anchor rows still used `transparent-event-enter`.
