### PR TITLE
fix: eliminate transparent stream flickering during token-by-token rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixed
 
+- **Transparent Stream no longer flickers during token-by-token streaming.** The 180ms enter animation (`transparent-event-enter`) on new event rows caused visible shimmer when rows were rapidly added. Replaced with `animation: none !important`, scoped to `#liveAssistantTurn` so settled message transitions (hover, recency-fade) are unaffected.
+
 - **The composer footer shows your model and workspace names again on desktop.** The Export-to-HTML button added to the composer footer in the previous release pushed the control row past its width budget, which collapsed the footer into icon-only mode and hid the model / workspace / profile text labels. The export button has been removed from the composer footer (export remains available from Settings), so the labels are visible again.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@
 
 ### Fixed
 
-- **Transparent Stream no longer flickers during token-by-token streaming.** The 180ms enter animation (`transparent-event-enter`) on new event rows caused visible shimmer when rows were rapidly added. Replaced with `animation: none !important`, scoped to `#liveAssistantTurn` so settled message transitions (hover, recency-fade) are unaffected.
-
 - **The composer footer shows your model and workspace names again on desktop.** The Export-to-HTML button added to the composer footer in the previous release pushed the control row past its width budget, which collapsed the footer into icon-only mode and hid the model / workspace / profile text labels. The export button has been removed from the composer footer (export remains available from Settings), so the labels are visible again.
 
 ### Added

--- a/static/style.css
+++ b/static/style.css
@@ -1472,15 +1472,7 @@
   .agent-activity-thinking[data-live-thinking="1"],
   .agent-activity-thinking[data-live-thinking="1"] *,
   .live-worklog[data-live-worklog-shell="1"],
-  .live-worklog[data-live-worklog-shell="1"] *,
-  #liveAssistantTurn .transparent-event-row,
-  #liveAssistantTurn .transparent-event-row *,
-  #liveAssistantTurn .transparent-event-controls,
-  #liveAssistantTurn .transparent-event-controls *,
-  #liveAssistantTurn .transparent-turn-footer,
-  #liveAssistantTurn .transparent-turn-footer *,
-  #liveAssistantTurn .transparent-detail-modes,
-  #liveAssistantTurn .transparent-detail-modes *{transition-property:none!important;transition-duration:0s!important;transition-delay:0s!important;}
+  .live-worklog[data-live-worklog-shell="1"] *{transition-property:none!important;transition-duration:0s!important;transition-delay:0s!important;}
   :root{--app-titlebar-safe-top:0px;}
   .pwa-standalone{overscroll-behavior:none;}
   .pwa-standalone body{-webkit-tap-highlight-color:transparent;}

--- a/static/style.css
+++ b/static/style.css
@@ -4266,10 +4266,6 @@ body.resizing .sidebar{transition:none!important;}
   .transparent-event-row .thinking-card-header{min-height:30px;padding:5px 8px;}
   .transparent-detail-mode{padding:4px 6px 5px;}
 }
-@keyframes transparent-event-enter{
-  from{opacity:0;transform:translateY(2px);}
-  to{opacity:1;transform:translateY(0);}
-}
 
 /* ── Old-event fading (transparent mode: medium → low) ─────────────── */
 /* ── Old-event fading (transparent mode, LIVE turn only — gated in JS) ───── */

--- a/static/style.css
+++ b/static/style.css
@@ -1472,7 +1472,15 @@
   .agent-activity-thinking[data-live-thinking="1"],
   .agent-activity-thinking[data-live-thinking="1"] *,
   .live-worklog[data-live-worklog-shell="1"],
-  .live-worklog[data-live-worklog-shell="1"] *{transition-property:none!important;transition-duration:0s!important;transition-delay:0s!important;}
+  .live-worklog[data-live-worklog-shell="1"] *,
+  #liveAssistantTurn .transparent-event-row,
+  #liveAssistantTurn .transparent-event-row *,
+  #liveAssistantTurn .transparent-event-controls,
+  #liveAssistantTurn .transparent-event-controls *,
+  #liveAssistantTurn .transparent-turn-footer,
+  #liveAssistantTurn .transparent-turn-footer *,
+  #liveAssistantTurn .transparent-detail-modes,
+  #liveAssistantTurn .transparent-detail-modes *{transition-property:none!important;transition-duration:0s!important;transition-delay:0s!important;}
   :root{--app-titlebar-safe-top:0px;}
   .pwa-standalone{overscroll-behavior:none;}
   .pwa-standalone body{-webkit-tap-highlight-color:transparent;}
@@ -3977,7 +3985,9 @@ body.resizing .sidebar{transition:none!important;}
 /* Only animate entrance for rows in the LIVE turn — putting the animation on the
    base row class replayed the whole transcript's shimmer on every renderMessages
    rebuild. (Trifecta finding V9.) */
-#liveAssistantTurn .transparent-event-row{animation:transparent-event-enter .18s ease-out both;}
+/* Enter animation disabled to prevent flickering during token-by-token streaming.
+   New event rows appear instantly; recency-fade (data-transparent-fade) is unaffected. */
+#liveAssistantTurn .transparent-event-row{animation:none!important;}
 .transparent-event-row[data-event-type="thinking"]{
   background:transparent;
   border-color:transparent;

--- a/tests/test_issue3820_chat_activity_display_mode.py
+++ b/tests/test_issue3820_chat_activity_display_mode.py
@@ -641,10 +641,10 @@ def test_transparent_tool_completion_preserves_expand_state():
 
 
 def test_transparent_entrance_animation_is_live_turn_only():
-    """The entrance animation on live-turn rows must stay scoped to the live turn
-    so it doesn't replay across the whole transcript on every renderMessages.
-    The animation is now disabled (none) rather than a fade-in — the scope guard
-    still protects against the original renderMessages-replay bug. (Trifecta V9.)"""
+    """The live-turn entrance animation was disabled (animation:none) to prevent
+    flickering during streaming. The rule must stay scoped to #liveAssistantTurn
+    so any future animation added to the base .transparent-event-row class does
+    not replay across the whole transcript on every renderMessages. (Trifecta V9.)"""
     assert "#liveAssistantTurn .transparent-event-row{animation:none" in STYLE_CSS
 
 

--- a/tests/test_issue3820_chat_activity_display_mode.py
+++ b/tests/test_issue3820_chat_activity_display_mode.py
@@ -641,9 +641,11 @@ def test_transparent_tool_completion_preserves_expand_state():
 
 
 def test_transparent_entrance_animation_is_live_turn_only():
-    """The entrance animation must be scoped to the live turn so it doesn't
-    replay across the whole transcript on every renderMessages. (Trifecta V9.)"""
-    assert "#liveAssistantTurn .transparent-event-row{animation:transparent-event-enter" in STYLE_CSS
+    """The entrance animation on live-turn rows must stay scoped to the live turn
+    so it doesn't replay across the whole transcript on every renderMessages.
+    The animation is now disabled (none) rather than a fade-in — the scope guard
+    still protects against the original renderMessages-replay bug. (Trifecta V9.)"""
+    assert "#liveAssistantTurn .transparent-event-row{animation:none" in STYLE_CSS
 
 
 def test_live_worklog_reason_mirror_is_gated_to_compact_mode():


### PR DESCRIPTION
## Problem

When Transparent Stream mode is enabled, the UI visibly flickers during token-by-token streaming. Each new tool execution event row triggers a CSS enter animation that appears as a brief flash/shimmer.

## Root Cause

`style.css` line 3988 — new `.transparent-event-row` elements in the live turn animate `opacity: 0→1` and `transform: translateY(2px→0)` over 180ms:

```css
#liveAssistantTurn .transparent-event-row {
  animation: transparent-event-enter .18s ease-out both;
}

@keyframes transparent-event-enter {
  from { opacity: 0; transform: translateY(2px); }
  to   { opacity: 1; transform: translateY(0); }
}
```

During rapid streaming, this animation fires on every new row, creating visible flicker.

## Solution

Replace the enter animation with `animation: none !important`:

```css
#liveAssistantTurn .transparent-event-row {
  animation: none !important;
}
```

The `#liveAssistantTurn` scope ensures this only affects the live turn during streaming — settled/historical messages are untouched.

The transition suppression is **not needed** here because `#liveAssistantTurn *` (lines 1464–1465) already provides `transition-property: none !important` for all live-turn descendants, including transparent stream elements.

## What's preserved

- ✅ `data-transparent-fade` recency opacity transition on settled messages
- ✅ Hover background/border transitions on all transparent event rows
- ✅ Detail mode tab switching transitions
- ✅ All other existing behavior

## Before/After

**Before**: New event rows fade in + slide down over 180ms → visible flicker during streaming  
**After**: New event rows appear instantly → no visual artifacts

## Testing

Tested on iOS Safari with cache cleared. Sent multi-step commands in Transparent Stream mode. Event rows appear instantly without flicker.

## Release Note

- **Fixed:** Transparent Stream no longer flickers during token-by-token streaming. The 180ms enter animation on new event rows caused visible shimmer when rows were rapidly added. Replaced with `animation: none !important`, scoped to `#liveAssistantTurn` so settled message transitions are unaffected.