### PR TITLE
fix: auto-switch profiles for session links

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -518,6 +518,11 @@ def _session_visible_to_active_profile(session_profile, handler=None) -> bool:
 def _request_session_visibility_exempt(method: str, path: str | None) -> bool:
     if not path:
         return False
+    if method == "GET" and path == "/api/session":
+        # Detail-load owns profile mismatch handling so the frontend can switch
+        # to the session's profile instead of treating a valid cross-profile
+        # deep link as a deleted/stale session.
+        return True
     if method != "POST":
         return False
     # Import routes create/claim sessions before normal ownership exists, and
@@ -11579,7 +11584,12 @@ def handle_get(handler, parsed) -> bool:
             s = get_session(sid, metadata_only=(not load_messages))
             _session_profile = getattr(s, 'profile', None) or None
             if not _session_visible_to_active_profile(_session_profile, handler):
-                return bad(handler, "Session not found", 404)
+                return j(handler, {
+                    "error": "Session belongs to a different profile",
+                    "code": "session_profile_mismatch",
+                    "session_id": sid,
+                    "profile": _session_profile,
+                }, status=409)
             original_stream_id = getattr(s, "active_stream_id", None)
             _clear_stale_stream_state(s)
             cli_meta = _lookup_cli_session_metadata(sid) if _session_requires_cli_metadata_lookup(s) else {}
@@ -11906,7 +11916,12 @@ def handle_get(handler, parsed) -> bool:
             cli_meta = _lookup_cli_session_metadata(sid)
             _session_profile = (cli_meta or {}).get("profile") or None
             if not _session_visible_to_active_profile(_session_profile, handler):
-                return bad(handler, "Session not found", 404)
+                return j(handler, {
+                    "error": "Session belongs to a different profile",
+                    "code": "session_profile_mismatch",
+                    "session_id": sid,
+                    "profile": _session_profile,
+                }, status=409)
             synth, reason = _claim_or_synthesize_cli_session(sid, cli_meta=cli_meta or {})
             if reason == "was_webui":
                 # Deleted WebUI session: 404 so the client self-heals

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1176,6 +1176,41 @@ function _rearmActiveSessionStream(){
   if(activeSid) startSessionStream(activeSid);
 }
 
+function _sessionProfileMismatchFromError(e){
+  if(!e || e.status!==409 || !e.body) return null;
+  try{
+    const body=JSON.parse(e.body);
+    if(body && body.code==='session_profile_mismatch' && body.profile){
+      return {profile:String(body.profile), session_id:String(body.session_id||'')};
+    }
+  }catch(_){ }
+  return null;
+}
+
+async function _switchProfileForSessionLoad(profile){
+  const name=String(profile||'').trim();
+  if(!name) throw new Error('missing profile');
+  if(name===S.activeProfile) return;
+  if(typeof _invalidateSessionListRenders==='function') _invalidateSessionListRenders();
+  if(typeof _setProfileSwitchListEmbargo==='function') _setProfileSwitchListEmbargo(true);
+  if(typeof showSessionListSkeleton==='function') showSessionListSkeleton(name);
+  try{
+    const data=await api('/api/profile/switch',{method:'POST',body:JSON.stringify({name}),timeoutToast:false});
+    S.activeProfile=data.active||name;
+    S.activeProfileIsDefault=!!data.is_default;
+    if(typeof _clearPersistedModelState==='function') _clearPersistedModelState();
+    else localStorage.removeItem('hermes-webui-model');
+    if(data.default_model) window._defaultModel=data.default_model;
+    if(data.default_model_provider) window._activeProvider=data.default_model_provider;
+    if(typeof startGatewaySSE==='function') startGatewaySSE();
+    if(typeof syncTopbar==='function') syncTopbar();
+    if(typeof _setProfileSwitchListEmbargo==='function') _setProfileSwitchListEmbargo(false);
+    if(typeof renderSessionList==='function') await renderSessionList();
+  }finally{
+    if(typeof _setProfileSwitchListEmbargo==='function') _setProfileSwitchListEmbargo(false);
+  }
+}
+
 async function loadSession(sid){
   const opts = arguments[1] || {};
   if(!opts.skipLineageResolve && typeof _resolveSessionIdFromSidebarLineage==='function'){
@@ -1304,6 +1339,21 @@ async function loadSession(sid){
   try {
     data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`);
   } catch(e) {
+    const profileMismatch=_sessionProfileMismatchFromError(e);
+    if(profileMismatch && profileMismatch.profile && !opts.skipProfileResolve){
+      if (_loadingSessionId !== sid) {
+        _rearmActiveSessionStream();
+        return;
+      }
+      try{
+        if(typeof showToast==='function') showToast(`Switching to ${profileMismatch.profile} profile for this session…`,2200);
+        await _switchProfileForSessionLoad(profileMismatch.profile);
+        if (_loadingSessionId === sid) _loadingSessionId = null;
+        return loadSession(sid,{...opts,skipProfileResolve:true,force:true});
+      }catch(switchErr){
+        e=switchErr;
+      }
+    }
     const _msgInner = $('msgInner');
     // Stale-load guard (Codex): a newer loadSession() may have started while this
     // request was awaiting (e.g. the user clicked a healthy session during a

--- a/tests/test_bugfix_sweep.py
+++ b/tests/test_bugfix_sweep.py
@@ -141,6 +141,17 @@ def test_session_url_builder_strips_legacy_session_query_alias():
     assert "current.searchParams.delete('session_id');" in helper
 
 
+def test_cross_profile_session_deep_links_switch_profile_instead_of_self_healing():
+    routes = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+    sessions = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+    assert '"code": "session_profile_mismatch"' in routes
+    assert 'if method == "GET" and path == "/api/session":' in routes
+    assert "function _sessionProfileMismatchFromError" in sessions
+    assert "_switchProfileForSessionLoad(profileMismatch.profile)" in sessions
+    assert "skipProfileResolve:true" in sessions
+
+
 def test_service_worker_precaches_same_origin_vendor_shell_assets():
     sw = (ROOT / "static" / "sw.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Thinking Path

A valid `session://...` deep link can point at a session owned by a different Hermes profile than the currently-active browser profile. Today that looks identical to a deleted/missing session: `/api/session` returns `404`, the frontend self-heals the route/localStorage, and the user sees “Session not available in web UI” or falls back to another session.

## What Changed

- `GET /api/session` now distinguishes valid-but-wrong-profile sessions from missing sessions.
- Wrong-profile detail loads return structured `409 session_profile_mismatch` with the owning profile name.
- `loadSession()` catches that response, switches to the owning profile, and retries the session load once.
- True missing/deleted sessions still use the existing `404` self-heal path.

## Why It Matters

Cross-profile session links should open the real conversation, not imply data loss. This preserves the existing profile isolation boundary while making direct links and `session://` links usable across profiles.

## Verification

- `./scripts/test.sh tests/test_bugfix_sweep.py tests/test_issue803.py -q`
  - `45 passed`
- Manual local smoke on a multi-profile install:
  - opening a `deepresearcher` session while active profile was `default` returned `409 session_profile_mismatch`
  - after profile switch, the same session loaded successfully

## Risks / Follow-ups

Low risk: the change is scoped to session detail loads. Mutation endpoints still use the existing request profile guard. Missing/deleted sessions keep returning `404`.

## Model Used

AI-assisted by Hermes Agent using OpenAI Codex `gpt-5.5`.
