### PR TITLE
feat(kanban): wake WebUI agent on task terminal events

### DIFF
--- a/api/kanban_notifier.py
+++ b/api/kanban_notifier.py
@@ -24,7 +24,7 @@ import logging
 import threading
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -35,10 +35,17 @@ _TERMINAL_STATUSES = {"done", "archived"}
 _NOTIFIER_THREAD: Optional[threading.Thread] = None
 _NOTIFIER_STOP = threading.Event()
 
-# Dedup: per-subscription set of already-processed (task_id, event_id) pairs.
+# Dedup: per-subscription set of already-processed event IDs.
 # Prevents double-wakeup if the cursor advance races with a re-poll.
+# Keys are cleaned up on terminal unsubscribe, so growth is bounded by the
+# number of active (non-terminal) subscriptions.
 _DELIVERED_EVENTS: dict[str, set[int]] = {}
 _DELIVERED_LOCK = threading.Lock()
+
+
+def _dedup_key(board: str, task_id: str, chat_id: str) -> str:
+    """Build the dedup dict key for a subscription."""
+    return f"{board}:{task_id}:{chat_id}"
 
 
 def _kb():
@@ -64,10 +71,11 @@ def _format_wakeup_prompt(task_id: str, title: str, assignee: str,
     }
     parts = [kind_labels.get(k, k) for k in sorted(kinds)]
     status = ", ".join(parts) or "status changed"
+    assignee_str = f"@{assignee}" if assignee else ""
     return (
         f"[kanban] Task {task_id} {status}.\n"
         f"Title: {title}\n"
-        f"Assignee: @{assignee}\n"
+        f"Assignee: {assignee_str}\n"
         f"Board: {board}\n\n"
         f"Check the result or decide the next step."
     )
@@ -130,7 +138,7 @@ def _poll_once() -> list[dict]:
                     continue
 
                 # Filter out already-delivered events (dedup safety net)
-                task_key = f"{slug}:{task_id}:{sub['chat_id']}"
+                task_key = _dedup_key(slug, task_id, sub["chat_id"])
                 with _DELIVERED_LOCK:
                     delivered = _DELIVERED_EVENTS.setdefault(task_key, set())
                     fresh = [ev for ev in events if ev.id not in delivered]
@@ -166,10 +174,15 @@ def _poll_once() -> list[dict]:
 
 
 def _deliver(deliveries: list[dict]) -> None:
-    """Start server-side wakeup turns for each delivery."""
+    """Start server-side wakeup turns for each delivery.
+
+    Unlike background_process._start_server_side_wakeup_turn (which spawns a
+    daemon and returns before the result is known), this calls
+    start_session_turn synchronously so we can distinguish success (200),
+    race (409 → defer), and genuine failure (≥400 / exception → rewind cursor).
+    """
     from api.background_process import (
         _session_has_active_turn,
-        _start_server_side_wakeup_turn,
         record_deferred_wakeup,
     )
 
@@ -183,7 +196,7 @@ def _deliver(deliveries: list[dict]) -> None:
 
         task_id = sub["task_id"]
         title = (task.title if task else task_id)[:120]
-        assignee = task.assignee if task else ""
+        assignee = task.assignee or ""
         kinds = {ev.kind for ev in d["events"]}
 
         prompt = _format_wakeup_prompt(task_id, title, assignee, board_slug, kinds)
@@ -191,6 +204,7 @@ def _deliver(deliveries: list[dict]) -> None:
         # Use a stable process_id for dedup: kanban:{task_id}:{board}
         process_id = f"kanban:{board_slug}:{task_id}"
 
+        delivery_ok = False
         try:
             if _session_has_active_turn(session_id):
                 # Session is busy — defer for next teardown/turn drain
@@ -200,16 +214,40 @@ def _deliver(deliveries: list[dict]) -> None:
                     "(task %s, events %s)",
                     session_id, task_id, kinds,
                 )
+                delivery_ok = True
             else:
-                _start_server_side_wakeup_turn(
-                    session_id, prompt, process_id=process_id,
+                # Call start_session_turn synchronously to get the real status.
+                # _start_server_side_wakeup_turn spawns a daemon that we cannot
+                # await, so we call the underlying primitive directly.
+                from api.routes import start_session_turn
+                resp = start_session_turn(
+                    session_id, prompt, source="kanban_wakeup"
                 )
-                logger.info(
-                    "kanban webui notifier: wakeup turn started for session %s "
-                    "(task %s, events %s)",
-                    session_id, task_id, kinds,
-                )
-            delivery_ok = True
+                status = int((resp or {}).get("_status", 200) or 200)
+                if status == 409:
+                    # Raced an active turn — defer for redelivery
+                    record_deferred_wakeup(session_id, process_id, prompt)
+                    logger.info(
+                        "kanban webui notifier: wakeup raced active turn for "
+                        "session %s (task %s); deferred",
+                        session_id, task_id,
+                    )
+                    delivery_ok = True
+                elif status >= 400:
+                    logger.warning(
+                        "kanban webui notifier: wakeup failed for session %s "
+                        "(task %s): status=%s err=%r",
+                        session_id, task_id, status,
+                        (resp or {}).get("error"),
+                    )
+                    delivery_ok = False
+                else:
+                    logger.info(
+                        "kanban webui notifier: wakeup turn started for session "
+                        "%s (task %s, events %s)",
+                        session_id, task_id, kinds,
+                    )
+                    delivery_ok = True
         except Exception:
             logger.warning(
                 "kanban webui notifier: wakeup failed for session %s (task %s) "
@@ -217,6 +255,8 @@ def _deliver(deliveries: list[dict]) -> None:
                 session_id, task_id, exc_info=True,
             )
             delivery_ok = False
+
+        if not delivery_ok:
             # Rewind the DB cursor so the event is re-delivered on the next
             # tick instead of being permanently lost. The in-memory dedup set
             # is also cleared for this sub so the retry is not skipped.
@@ -235,7 +275,7 @@ def _deliver(deliveries: list[dict]) -> None:
                     )
                 finally:
                     conn.close()
-                task_key = f"{board_slug}:{task_id}:{sub['chat_id']}"
+                task_key = _dedup_key(board_slug, task_id, sub["chat_id"])
                 with _DELIVERED_LOCK:
                     _DELIVERED_EVENTS.pop(task_key, None)
             except Exception:
@@ -268,6 +308,10 @@ def _deliver(deliveries: list[dict]) -> None:
                     "kanban webui notifier: failed to unsub %s", task_id,
                     exc_info=True,
                 )
+            # Clean up the in-memory dedup key as well
+            task_key = _dedup_key(board_slug, task_id, sub["chat_id"])
+            with _DELIVERED_LOCK:
+                _DELIVERED_EVENTS.pop(task_key, None)
 
 
 def _notifier_loop() -> None:
@@ -294,10 +338,29 @@ def start_notifier_thread() -> bool:
     Returns True on first start, False if already running.
     Called from ``server.py`` at WebUI startup, alongside
     ``background_process.start_drain_thread``.
+
+    Gated by ``kanban.webui_notifier`` in config.yaml (default: True).
+    Disable to turn off the polling thread entirely, e.g. when kanban
+    is not in use or the gateway's own notifier is sufficient.
     """
     global _NOTIFIER_THREAD
     if _NOTIFIER_THREAD is not None and _NOTIFIER_THREAD.is_alive():
         return False
+
+    # Config gate: allow disabling the notifier via config
+    try:
+        from hermes_cli.config import load_config, cfg_get
+        cfg = load_config()
+        enabled = cfg_get(cfg, "kanban", "webui_notifier", default=True)
+        if not enabled:
+            logger.info(
+                "kanban webui notifier: disabled via config kanban.webui_notifier=false"
+            )
+            return False
+    except Exception:
+        # If config can't load, default to enabled (same as auto_subscribe_on_create)
+        pass
+
     _NOTIFIER_STOP.clear()
     _NOTIFIER_THREAD = threading.Thread(
         target=_notifier_loop,

--- a/api/kanban_notifier.py
+++ b/api/kanban_notifier.py
@@ -362,27 +362,34 @@ def start_notifier_thread() -> bool:
     Called from ``server.py`` at WebUI startup, alongside
     ``background_process.start_drain_thread``.
 
-    Gated by ``kanban.webui_notifier`` in config.yaml (default: True).
-    Disable to turn off the polling thread entirely, e.g. when kanban
-    is not in use or the gateway's own notifier is sufficient.
+    Gated by ``kanban.webui_notifier`` in config.yaml (default: False — opt-in).
+    Enable to turn on the polling thread for kanban→agent wake notifications.
+    When unset or false, the thread never starts — no always-on background
+    subsystem for users who don't use kanban.
     """
     global _NOTIFIER_THREAD
     if _NOTIFIER_THREAD is not None and _NOTIFIER_THREAD.is_alive():
         return False
 
-    # Config gate: allow disabling the notifier via config
+    # Config gate: opt-in (default-off) per the optional-capability convention.
+    # A user who doesn't use kanban shouldn't get a new always-on background thread.
     try:
         from hermes_cli.config import load_config, cfg_get
         cfg = load_config()
-        enabled = cfg_get(cfg, "kanban", "webui_notifier", default=True)
+        enabled = cfg_get(cfg, "kanban", "webui_notifier", default=False)
         if not enabled:
-            logger.info(
-                "kanban webui notifier: disabled via config kanban.webui_notifier=false"
+            logger.debug(
+                "kanban webui notifier: not started (kanban.webui_notifier "
+                "not set or false — opt-in feature)"
             )
             return False
     except Exception:
-        # If config can't load, default to enabled (same as auto_subscribe_on_create)
-        pass
+        # If config can't load, stay default-off (don't start an always-on
+        # thread without explicit user opt-in)
+        logger.debug(
+            "kanban webui notifier: config unreadable, staying default-off"
+        )
+        return False
 
     _NOTIFIER_STOP.clear()
     _NOTIFIER_THREAD = threading.Thread(

--- a/api/kanban_notifier.py
+++ b/api/kanban_notifier.py
@@ -209,12 +209,14 @@ def _deliver(deliveries: list[dict]) -> None:
                     "(task %s, events %s)",
                     session_id, task_id, kinds,
                 )
+            delivery_ok = True
         except Exception:
             logger.warning(
                 "kanban webui notifier: wakeup failed for session %s (task %s) "
                 "— rewinding cursor so the event is retried next tick",
                 session_id, task_id, exc_info=True,
             )
+            delivery_ok = False
             # Rewind the DB cursor so the event is re-delivered on the next
             # tick instead of being permanently lost. The in-memory dedup set
             # is also cleared for this sub so the retry is not skipped.
@@ -243,9 +245,11 @@ def _deliver(deliveries: list[dict]) -> None:
                     task_id, exc_info=True,
                 )
 
-        # If the task reached a truly terminal status, clean up the subscription
+        # If the task reached a truly terminal status and delivery succeeded,
+        # clean up the subscription. Skip removal when delivery failed (cursor
+        # was rewound) so the retry on the next tick can still find the sub.
         task_terminal = task and task.status in _TERMINAL_STATUSES
-        if task_terminal:
+        if task_terminal and delivery_ok:
             try:
                 kb = _kb()
                 conn = kb.connect(board=board_slug)

--- a/api/kanban_notifier.py
+++ b/api/kanban_notifier.py
@@ -211,9 +211,37 @@ def _deliver(deliveries: list[dict]) -> None:
                 )
         except Exception:
             logger.warning(
-                "kanban webui notifier: wakeup failed for session %s (task %s)",
+                "kanban webui notifier: wakeup failed for session %s (task %s) "
+                "— rewinding cursor so the event is retried next tick",
                 session_id, task_id, exc_info=True,
             )
+            # Rewind the DB cursor so the event is re-delivered on the next
+            # tick instead of being permanently lost. The in-memory dedup set
+            # is also cleared for this sub so the retry is not skipped.
+            try:
+                kb = _kb()
+                conn = kb.connect(board=board_slug)
+                try:
+                    kb.rewind_notify_cursor(
+                        conn,
+                        task_id=task_id,
+                        platform=sub["platform"],
+                        chat_id=sub["chat_id"],
+                        thread_id=sub.get("thread_id") or None,
+                        claimed_cursor=d["new_cursor"],
+                        old_cursor=d["old_cursor"],
+                    )
+                finally:
+                    conn.close()
+                task_key = f"{board_slug}:{task_id}:{sub['chat_id']}"
+                with _DELIVERED_LOCK:
+                    _DELIVERED_EVENTS.pop(task_key, None)
+            except Exception:
+                logger.warning(
+                    "kanban webui notifier: cursor rewind also failed for %s — "
+                    "event will be lost",
+                    task_id, exc_info=True,
+                )
 
         # If the task reached a truly terminal status, clean up the subscription
         task_terminal = task and task.status in _TERMINAL_STATUSES

--- a/api/kanban_notifier.py
+++ b/api/kanban_notifier.py
@@ -29,7 +29,15 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 _POLL_INTERVAL_SECONDS = 15
+# Kinds that trigger a wakeup prompt to the creator agent
 _WAKE_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out")
+# Additional kinds that don't wake the agent but signal a silent terminal
+# transition — we claim them so _deliver can clean up the subscription
+# and dedup entry. Without this, a task that reaches done/archived via
+# a non-wake event would leak its subscription forever.
+_SILENT_TERMINAL_KINDS = ("status", "archived", "unblocked")
+# Kinds to claim from the DB: wake kinds + silent terminal kinds
+_CLAIM_KINDS = _WAKE_KINDS + _SILENT_TERMINAL_KINDS
 _TERMINAL_STATUSES = {"done", "archived"}
 
 _NOTIFIER_THREAD: Optional[threading.Thread] = None
@@ -131,7 +139,7 @@ def _poll_once() -> list[dict]:
                     platform=sub["platform"],
                     chat_id=sub["chat_id"],
                     thread_id=sub.get("thread_id") or None,
-                    kinds=_WAKE_KINDS,
+                    kinds=_CLAIM_KINDS,
                 )
 
                 if not events:
@@ -195,66 +203,81 @@ def _deliver(deliveries: list[dict]) -> None:
             continue
 
         task_id = sub["task_id"]
+        all_kinds = {ev.kind for ev in d["events"]}
+        # Split into wake kinds (trigger prompt) and silent kinds (cleanup only)
+        wake_kinds = all_kinds & set(_WAKE_KINDS)
+        silent_kinds = all_kinds - set(_WAKE_KINDS)
+
         title = (task.title if task else task_id)[:120]
         assignee = (task.assignee if task else None) or ""
-        kinds = {ev.kind for ev in d["events"]}
-
-        prompt = _format_wakeup_prompt(task_id, title, assignee, board_slug, kinds)
 
         # Use a stable process_id for dedup: kanban:{task_id}:{board}
         process_id = f"kanban:{board_slug}:{task_id}"
 
-        delivery_ok = False
-        try:
-            if _session_has_active_turn(session_id):
-                # Session is busy — defer for next teardown/turn drain
-                record_deferred_wakeup(session_id, process_id, prompt)
-                logger.info(
-                    "kanban webui notifier: deferred wakeup for session %s "
-                    "(task %s, events %s)",
-                    session_id, task_id, kinds,
-                )
-                delivery_ok = True
-            else:
-                # Call start_session_turn synchronously to get the real status.
-                # _start_server_side_wakeup_turn spawns a daemon that we cannot
-                # await, so we call the underlying primitive directly.
-                from api.routes import start_session_turn
-                resp = start_session_turn(
-                    session_id, prompt, source="kanban_wakeup"
-                )
-                status = int((resp or {}).get("_status", 200) or 200)
-                if status == 409:
-                    # Raced an active turn — defer for redelivery
-                    record_deferred_wakeup(session_id, process_id, prompt)
-                    logger.info(
-                        "kanban webui notifier: wakeup raced active turn for "
-                        "session %s (task %s); deferred",
-                        session_id, task_id,
-                    )
-                    delivery_ok = True
-                elif status >= 400:
-                    logger.warning(
-                        "kanban webui notifier: wakeup failed for session %s "
-                        "(task %s): status=%s err=%r",
-                        session_id, task_id, status,
-                        (resp or {}).get("error"),
-                    )
-                    delivery_ok = False
-                else:
-                    logger.info(
-                        "kanban webui notifier: wakeup turn started for session "
-                        "%s (task %s, events %s)",
-                        session_id, task_id, kinds,
-                    )
-                    delivery_ok = True
-        except Exception:
-            logger.warning(
-                "kanban webui notifier: wakeup failed for session %s (task %s) "
-                "— rewinding cursor so the event is retried next tick",
-                session_id, task_id, exc_info=True,
+        # If there are no wake kinds, this is a silent-terminal delivery.
+        # Skip the prompt but still clean up if the task is terminal.
+        if not wake_kinds:
+            delivery_ok = True  # nothing to deliver, so no failure
+            logger.debug(
+                "kanban webui notifier: silent terminal event for task %s "
+                "(kinds=%s) — skipping prompt, checking cleanup",
+                task_id, silent_kinds,
+            )
+        else:
+            prompt = _format_wakeup_prompt(
+                task_id, title, assignee, board_slug, wake_kinds
             )
             delivery_ok = False
+            try:
+                if _session_has_active_turn(session_id):
+                    # Session is busy — defer for next teardown/turn drain
+                    record_deferred_wakeup(session_id, process_id, prompt)
+                    logger.info(
+                        "kanban webui notifier: deferred wakeup for session %s "
+                        "(task %s, events %s)",
+                        session_id, task_id, wake_kinds,
+                    )
+                    delivery_ok = True
+                else:
+                    # Call start_session_turn synchronously to get the real status.
+                    # _start_server_side_wakeup_turn spawns a daemon that we cannot
+                    # await, so we call the underlying primitive directly.
+                    from api.routes import start_session_turn
+                    resp = start_session_turn(
+                        session_id, prompt, source="kanban_wakeup"
+                    )
+                    status = int((resp or {}).get("_status", 200) or 200)
+                    if status == 409:
+                        # Raced an active turn — defer for redelivery
+                        record_deferred_wakeup(session_id, process_id, prompt)
+                        logger.info(
+                            "kanban webui notifier: wakeup raced active turn for "
+                            "session %s (task %s); deferred",
+                            session_id, task_id,
+                        )
+                        delivery_ok = True
+                    elif status >= 400:
+                        logger.warning(
+                            "kanban webui notifier: wakeup failed for session %s "
+                            "(task %s): status=%s err=%r",
+                            session_id, task_id, status,
+                            (resp or {}).get("error"),
+                        )
+                        delivery_ok = False
+                    else:
+                        logger.info(
+                            "kanban webui notifier: wakeup turn started for session "
+                            "%s (task %s, events %s)",
+                            session_id, task_id, wake_kinds,
+                        )
+                        delivery_ok = True
+            except Exception:
+                logger.warning(
+                    "kanban webui notifier: wakeup failed for session %s (task %s) "
+                    "— rewinding cursor so the event is retried next tick",
+                    session_id, task_id, exc_info=True,
+                )
+                delivery_ok = False
 
         if not delivery_ok:
             # Rewind the DB cursor so the event is re-delivered on the next

--- a/api/kanban_notifier.py
+++ b/api/kanban_notifier.py
@@ -196,7 +196,7 @@ def _deliver(deliveries: list[dict]) -> None:
 
         task_id = sub["task_id"]
         title = (task.title if task else task_id)[:120]
-        assignee = task.assignee or ""
+        assignee = (task.assignee if task else None) or ""
         kinds = {ev.kind for ev in d["events"]}
 
         prompt = _format_wakeup_prompt(task_id, title, assignee, board_slug, kinds)

--- a/api/kanban_notifier.py
+++ b/api/kanban_notifier.py
@@ -1,0 +1,284 @@
+"""Kanban task-event notifier for WebUI agent wakeup.
+
+The Hermes gateway's ``kanban_watchers.py`` delivers kanban task terminal
+events (completed / blocked / gave_up / crashed / timed_out) to messaging
+platforms (Telegram, Discord, etc.) and wakes the creator agent by injecting
+a synthetic message. However, WebUI sessions set ``platform="webui"`` in
+the subscription row, and the gateway has no ``"webui"`` adapter — so those
+events are silently skipped.
+
+This module bridges that gap. A background polling thread (started at WebUI
+startup alongside the ``background_process`` drain thread) reads
+``kanban_notify_subs`` rows for ``platform='webui'``, claims unseen terminal
+events via ``claim_unseen_events_for_sub``, and triggers a server-side agent
+wakeup turn using the same ``_start_server_side_wakeup_turn`` infrastructure
+that ``notify_on_complete`` uses for background process completions.
+
+Thread lifecycle mirrors ``background_process.start_drain_thread`` /
+``stop_drain_thread``: started once at server boot, stopped on shutdown.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_POLL_INTERVAL_SECONDS = 15
+_WAKE_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out")
+_TERMINAL_STATUSES = {"done", "archived"}
+
+_NOTIFIER_THREAD: Optional[threading.Thread] = None
+_NOTIFIER_STOP = threading.Event()
+
+# Dedup: per-subscription set of already-processed (task_id, event_id) pairs.
+# Prevents double-wakeup if the cursor advance races with a re-poll.
+_DELIVERED_EVENTS: dict[str, set[int]] = {}
+_DELIVERED_LOCK = threading.Lock()
+
+
+def _kb():
+    """Lazily import hermes_cli.kanban_db to avoid circular imports."""
+    from hermes_cli import kanban_db as kb
+    return kb
+
+
+def _format_wakeup_prompt(task_id: str, title: str, assignee: str,
+                          board: str, kinds: set[str]) -> str:
+    """Build the synthetic wakeup message injected into the agent session.
+
+    Mirrors the gateway's i18n wake message template
+    (``gateway.kanban.wake.message``) so the agent sees the same payload
+    regardless of whether it was created from Telegram, Discord, or WebUI.
+    """
+    kind_labels = {
+        "completed": "completed",
+        "blocked": "blocked; needs attention",
+        "gave_up": "gave up (retries exhausted)",
+        "crashed": "crashed (worker exited); dispatcher will retry",
+        "timed_out": "timed out; dispatcher will retry",
+    }
+    parts = [kind_labels.get(k, k) for k in sorted(kinds)]
+    status = ", ".join(parts) or "status changed"
+    return (
+        f"[kanban] Task {task_id} {status}.\n"
+        f"Title: {title}\n"
+        f"Assignee: @{assignee}\n"
+        f"Board: {board}\n\n"
+        f"Check the result or decide the next step."
+    )
+
+
+def _poll_once() -> list[dict]:
+    """Collect all deliverable terminal events for ``platform='webui'`` subs.
+
+    Returns a list of dicts with keys: ``sub``, ``task``, ``events``,
+    ``board``. Atomically claims events (advances the cursor) so a concurrent
+    gateway notifier tick cannot double-deliver.
+    """
+    kb = _kb()
+    deliveries: list[dict] = []
+
+    try:
+        boards = kb.list_boards(include_archived=False)
+    except Exception:
+        boards = [kb.read_board_metadata(kb.DEFAULT_BOARD)]
+
+    seen_db_paths: set[str] = set()
+    for board_meta in boards:
+        slug = board_meta.get("slug") or kb.DEFAULT_BOARD
+        db_path = board_meta.get("db_path")
+        try:
+            if db_path:
+                resolved = str(Path(db_path).expanduser().resolve())
+            else:
+                resolved = str(kb.kanban_db_path(slug).resolve())
+        except Exception:
+            resolved = f"slug:{slug}"
+        if resolved in seen_db_paths:
+            continue
+        seen_db_paths.add(resolved)
+
+        try:
+            conn = kb.connect(board=slug)
+        except Exception as exc:
+            logger.debug("kanban webui notifier: cannot open board %s: %s", slug, exc)
+            continue
+
+        try:
+            subs = kb.list_notify_subs(conn)
+            for sub in subs:
+                platform = (sub.get("platform") or "").lower()
+                if platform != "webui":
+                    continue
+
+                task_id = sub["task_id"]
+                old_cursor, new_cursor, events = kb.claim_unseen_events_for_sub(
+                    conn,
+                    task_id=task_id,
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or None,
+                    kinds=_WAKE_KINDS,
+                )
+
+                if not events:
+                    continue
+
+                # Filter out already-delivered events (dedup safety net)
+                task_key = f"{slug}:{task_id}:{sub['chat_id']}"
+                with _DELIVERED_LOCK:
+                    delivered = _DELIVERED_EVENTS.setdefault(task_key, set())
+                    fresh = [ev for ev in events if ev.id not in delivered]
+                    if not fresh:
+                        continue
+                    for ev in fresh:
+                        delivered.add(ev.id)
+                    # Trim the set to prevent unbounded growth
+                    if len(delivered) > 200:
+                        delivered.clear()
+                        for ev in fresh:
+                            delivered.add(ev.id)
+
+                # Fetch task info for the wakeup prompt
+                task = None
+                try:
+                    task = kb.get_task(conn, task_id)
+                except Exception:
+                    pass
+
+                deliveries.append({
+                    "sub": sub,
+                    "task": task,
+                    "events": fresh,
+                    "board": slug,
+                    "old_cursor": old_cursor,
+                    "new_cursor": new_cursor,
+                })
+        finally:
+            conn.close()
+
+    return deliveries
+
+
+def _deliver(deliveries: list[dict]) -> None:
+    """Start server-side wakeup turns for each delivery."""
+    from api.background_process import (
+        _session_has_active_turn,
+        _start_server_side_wakeup_turn,
+        record_deferred_wakeup,
+    )
+
+    for d in deliveries:
+        sub = d["sub"]
+        task = d["task"]
+        board_slug = d["board"]
+        session_id = sub.get("chat_id") or ""
+        if not session_id:
+            continue
+
+        task_id = sub["task_id"]
+        title = (task.title if task else task_id)[:120]
+        assignee = task.assignee if task else ""
+        kinds = {ev.kind for ev in d["events"]}
+
+        prompt = _format_wakeup_prompt(task_id, title, assignee, board_slug, kinds)
+
+        # Use a stable process_id for dedup: kanban:{task_id}:{board}
+        process_id = f"kanban:{board_slug}:{task_id}"
+
+        try:
+            if _session_has_active_turn(session_id):
+                # Session is busy — defer for next teardown/turn drain
+                record_deferred_wakeup(session_id, process_id, prompt)
+                logger.info(
+                    "kanban webui notifier: deferred wakeup for session %s "
+                    "(task %s, events %s)",
+                    session_id, task_id, kinds,
+                )
+            else:
+                _start_server_side_wakeup_turn(
+                    session_id, prompt, process_id=process_id,
+                )
+                logger.info(
+                    "kanban webui notifier: wakeup turn started for session %s "
+                    "(task %s, events %s)",
+                    session_id, task_id, kinds,
+                )
+        except Exception:
+            logger.warning(
+                "kanban webui notifier: wakeup failed for session %s (task %s)",
+                session_id, task_id, exc_info=True,
+            )
+
+        # If the task reached a truly terminal status, clean up the subscription
+        task_terminal = task and task.status in _TERMINAL_STATUSES
+        if task_terminal:
+            try:
+                kb = _kb()
+                conn = kb.connect(board=board_slug)
+                try:
+                    kb.remove_notify_sub(
+                        conn,
+                        task_id=task_id,
+                        platform=sub["platform"],
+                        chat_id=sub["chat_id"],
+                        thread_id=sub.get("thread_id") or None,
+                    )
+                finally:
+                    conn.close()
+            except Exception:
+                logger.debug(
+                    "kanban webui notifier: failed to unsub %s", task_id,
+                    exc_info=True,
+                )
+
+
+def _notifier_loop() -> None:
+    """Main polling loop — runs in a daemon thread."""
+    logger.info("kanban webui notifier thread started")
+    while not _NOTIFIER_STOP.is_set():
+        try:
+            deliveries = _poll_once()
+            if deliveries:
+                _deliver(deliveries)
+        except Exception:
+            logger.warning("kanban webui notifier tick failed", exc_info=True)
+
+        # Sleep with cancellation checks
+        for _ in range(_POLL_INTERVAL_SECONDS):
+            if _NOTIFIER_STOP.is_set():
+                return
+            time.sleep(1)
+
+
+def start_notifier_thread() -> bool:
+    """Start the kanban notifier polling thread idempotently.
+
+    Returns True on first start, False if already running.
+    Called from ``server.py`` at WebUI startup, alongside
+    ``background_process.start_drain_thread``.
+    """
+    global _NOTIFIER_THREAD
+    if _NOTIFIER_THREAD is not None and _NOTIFIER_THREAD.is_alive():
+        return False
+    _NOTIFIER_STOP.clear()
+    _NOTIFIER_THREAD = threading.Thread(
+        target=_notifier_loop,
+        name="hermes-webui-kanban-notifier",
+        daemon=True,
+    )
+    _NOTIFIER_THREAD.start()
+    return True
+
+
+def stop_notifier_thread(timeout: float = 2.0) -> None:
+    """Signal the notifier thread to stop and wait briefly."""
+    _NOTIFIER_STOP.set()
+    th = _NOTIFIER_THREAD
+    if th is not None and th.is_alive():
+        th.join(timeout=timeout)

--- a/server.py
+++ b/server.py
@@ -656,6 +656,13 @@ def main() -> None:
         print(f'[!!] WARNING: bg_task_complete drain failed to start: {e}', flush=True)
 
     try:
+        from api.kanban_notifier import start_notifier_thread
+        if start_notifier_thread():
+            print('[ok] kanban notifier thread started', flush=True)
+    except Exception as e:
+        print(f'[!!] WARNING: kanban notifier failed to start: {e}', flush=True)
+
+    try:
         from api.background_process import start_session_channel_reaper
         if start_session_channel_reaper():
             print('[ok] SessionChannel reaper thread started', flush=True)

--- a/server.py
+++ b/server.py
@@ -656,13 +656,6 @@ def main() -> None:
         print(f'[!!] WARNING: bg_task_complete drain failed to start: {e}', flush=True)
 
     try:
-        from api.kanban_notifier import start_notifier_thread
-        if start_notifier_thread():
-            print('[ok] kanban notifier thread started', flush=True)
-    except Exception as e:
-        print(f'[!!] WARNING: kanban notifier failed to start: {e}', flush=True)
-
-    try:
         from api.background_process import start_session_channel_reaper
         if start_session_channel_reaper():
             print('[ok] SessionChannel reaper thread started', flush=True)
@@ -677,6 +670,16 @@ def main() -> None:
 
     _abort_if_already_serving(HOST, PORT)
     httpd = QuietHTTPServer((HOST, PORT), Handler)
+
+    # Start the kanban notifier AFTER the port is bound so a duplicate/failed
+    # startup does not steal wakeups from the real server. If any later
+    # startup step fails, the finally block below calls stop_notifier_thread().
+    try:
+        from api.kanban_notifier import start_notifier_thread
+        if start_notifier_thread():
+            print('[ok] kanban notifier thread started', flush=True)
+    except Exception as e:
+        print(f'[!!] WARNING: kanban notifier failed to start: {e}', flush=True)
 
     from api.config import TLS_ENABLED, TLS_CERT, TLS_KEY
     scheme = 'https' if TLS_ENABLED else 'http'

--- a/server.py
+++ b/server.py
@@ -748,6 +748,11 @@ def main() -> None:
         except Exception:
             logger.debug("Failed to stop bg_task_complete drain thread during shutdown", exc_info=True)
         try:
+            from api.kanban_notifier import stop_notifier_thread
+            stop_notifier_thread()
+        except Exception:
+            logger.debug("Failed to stop kanban notifier thread during shutdown", exc_info=True)
+        try:
             from api.background_process import stop_session_channel_reaper
             stop_session_channel_reaper()
         except Exception:

--- a/tests/test_kanban_notifier.py
+++ b/tests/test_kanban_notifier.py
@@ -582,6 +582,29 @@ class TestDeliver:
         )
         assert "@None" not in prompt
 
+    def test_deliver_when_task_is_none(self, fake_kanban, clean_notifier):
+        """When get_task returns None (task deleted), _deliver should still
+        work without AttributeError — title falls back to task_id, assignee
+        is empty, and the prompt is delivered."""
+        fake_kanban.tasks = []  # No tasks — get_task returns None
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "blocked", {"reason": "x"}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 1
+        assert deliveries[0]["task"] is None
+
+        mock_resp = {"_status": 200, "stream_id": "s1"}
+        with patch("api.background_process._session_has_active_turn", return_value=False), \
+             patch("api.routes.start_session_turn", return_value=mock_resp) as mock_turn:
+            clean_notifier._deliver(deliveries)
+            mock_turn.assert_called_once()
+            prompt = mock_turn.call_args[0][1]
+            assert "t_1" in prompt
+            assert "@None" not in prompt
+
 
 class TestThreadLifecycle:
     def test_start_and_stop(self, clean_notifier):

--- a/tests/test_kanban_notifier.py
+++ b/tests/test_kanban_notifier.py
@@ -360,18 +360,19 @@ class TestDeliver:
 
         deliveries = clean_notifier._poll_once()
 
+        mock_resp = {"_status": 200, "stream_id": "s1"}
         with patch("api.background_process._session_has_active_turn", return_value=False) as mock_active, \
-             patch("api.background_process._start_server_side_wakeup_turn") as mock_wakeup, \
+             patch("api.routes.start_session_turn", return_value=mock_resp) as mock_turn, \
              patch("api.background_process.record_deferred_wakeup") as mock_defer:
             clean_notifier._deliver(deliveries)
 
             mock_active.assert_called_once_with("sess-1")
-            mock_wakeup.assert_called_once()
+            mock_turn.assert_called_once()
             mock_defer.assert_not_called()
             # Check the prompt
-            args = mock_wakeup.call_args
-            assert "sess-1" == args[0][0] or "sess-1" == args[1].get("session_id", args[0][0])
-            prompt = args[0][1] if len(args[0]) > 1 else args.kwargs.get("wakeup_prompt", "")
+            args = mock_turn.call_args
+            assert "sess-1" == args[0][0]
+            prompt = args[0][1]
             assert "t_1" in prompt
             assert "blocked" in prompt
 
@@ -385,15 +386,54 @@ class TestDeliver:
         deliveries = clean_notifier._poll_once()
 
         with patch("api.background_process._session_has_active_turn", return_value=True), \
-             patch("api.background_process._start_server_side_wakeup_turn") as mock_wakeup, \
+             patch("api.routes.start_session_turn") as mock_turn, \
              patch("api.background_process.record_deferred_wakeup") as mock_defer:
             clean_notifier._deliver(deliveries)
 
-            mock_wakeup.assert_not_called()
+            mock_turn.assert_not_called()
             mock_defer.assert_called_once()
             # Check the deferred prompt
             args = mock_defer.call_args
             assert args[0][0] == "sess-1" or args.kwargs.get("session_id") == "sess-1"
+
+    def test_defers_on_409_race(self, fake_kanban, clean_notifier):
+        """When start_session_turn returns 409 (active turn race),
+        the wakeup should be deferred, not treated as failure."""
+        fake_kanban.tasks = [FakeTask("t_1", "Test", "blocked", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "blocked", {}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+
+        mock_resp = {"_status": 409, "error": "turn active"}
+        with patch("api.background_process._session_has_active_turn", return_value=False), \
+             patch("api.routes.start_session_turn", return_value=mock_resp), \
+             patch("api.background_process.record_deferred_wakeup") as mock_defer:
+            clean_notifier._deliver(deliveries)
+            mock_defer.assert_called_once()
+
+    def test_rewinds_on_400_failure(self, fake_kanban, clean_notifier):
+        """When start_session_turn returns >=400 (not 409), the cursor
+        should be rewound for retry."""
+        fake_kanban.tasks = [FakeTask("t_1", "Test", "blocked", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "blocked", {}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+        assert fake_kanban.subs[0]["last_event_id"] == 1
+
+        mock_resp = {"_status": 404, "error": "session not found"}
+        with patch("api.background_process._session_has_active_turn", return_value=False), \
+             patch("api.routes.start_session_turn", return_value=mock_resp), \
+             patch("api.background_process.record_deferred_wakeup"):
+            clean_notifier._deliver(deliveries)
+
+        # Cursor should be rewound
+        assert fake_kanban.subs[0]["last_event_id"] == 0
 
     def test_cleans_up_terminal_subscription(self, fake_kanban, clean_notifier):
         fake_kanban.tasks = [FakeTask("t_1", "Done Task", "done", "w")]
@@ -405,8 +445,9 @@ class TestDeliver:
         deliveries = clean_notifier._poll_once()
         assert len(deliveries) == 1
 
+        mock_resp = {"_status": 200, "stream_id": "s1"}
         with patch("api.background_process._session_has_active_turn", return_value=False), \
-             patch("api.background_process._start_server_side_wakeup_turn"), \
+             patch("api.routes.start_session_turn", return_value=mock_resp), \
              patch("api.background_process.record_deferred_wakeup"):
             clean_notifier._deliver(deliveries)
 
@@ -422,8 +463,9 @@ class TestDeliver:
 
         deliveries = clean_notifier._poll_once()
 
+        mock_resp = {"_status": 200, "stream_id": "s1"}
         with patch("api.background_process._session_has_active_turn", return_value=False), \
-             patch("api.background_process._start_server_side_wakeup_turn"), \
+             patch("api.routes.start_session_turn", return_value=mock_resp), \
              patch("api.background_process.record_deferred_wakeup"):
             clean_notifier._deliver(deliveries)
 
@@ -438,16 +480,14 @@ class TestDeliver:
         fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="")]
 
         deliveries = clean_notifier._poll_once()
-        # With empty chat_id, should still poll but _deliver skips
         if deliveries:
-            with patch("api.background_process._start_server_side_wakeup_turn") as mock_wakeup:
+            with patch("api.routes.start_session_turn") as mock_turn:
                 clean_notifier._deliver(deliveries)
-                mock_wakeup.assert_not_called()
+                mock_turn.assert_not_called()
 
-    def test_rewinds_cursor_on_delivery_failure(self, fake_kanban, clean_notifier):
-        """When _start_server_side_wakeup_turn raises, the DB cursor is
-        rewound so the event is retried on the next tick instead of
-        being permanently lost."""
+    def test_rewinds_cursor_on_delivery_exception(self, fake_kanban, clean_notifier):
+        """When start_session_turn raises an exception, the DB cursor is
+        rewound so the event is retried on the next tick."""
         fake_kanban.tasks = [FakeTask("t_1", "Test", "blocked", "w")]
         fake_kanban.events = [
             FakeEvent(1, "t_1", None, "blocked", {"reason": "x"}, 100),
@@ -455,28 +495,14 @@ class TestDeliver:
         fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
 
         deliveries = clean_notifier._poll_once()
-        assert len(deliveries) == 1
-        old_cursor = deliveries[0]["old_cursor"]
-        new_cursor = deliveries[0]["new_cursor"]
-        assert old_cursor == 0
-        assert new_cursor == 1
-
-        # Verify cursor was advanced
         assert fake_kanban.subs[0]["last_event_id"] == 1
 
         with patch("api.background_process._session_has_active_turn", return_value=False), \
-             patch("api.background_process._start_server_side_wakeup_turn",
-                   side_effect=Exception("RPC failed")), \
+             patch("api.routes.start_session_turn", side_effect=Exception("RPC failed")), \
              patch("api.background_process.record_deferred_wakeup"):
             clean_notifier._deliver(deliveries)
 
-        # Cursor should be rewound back to old_cursor (0)
         assert fake_kanban.subs[0]["last_event_id"] == 0
-
-        # In-memory dedup should be cleared so retry is not skipped
-        task_key = f"default:t_1:sess-1"
-        assert task_key not in clean_notifier._DELIVERED_EVENTS or \
-               len(clean_notifier._DELIVERED_EVENTS.get(task_key, set())) == 0
 
     def test_retry_succeeds_after_rewind(self, fake_kanban, clean_notifier):
         """After a cursor rewind, the next _poll_once should re-claim the
@@ -487,27 +513,23 @@ class TestDeliver:
         ]
         fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
 
-        # First poll: claim events
         deliveries = clean_notifier._poll_once()
         assert len(deliveries) == 1
 
-        # Simulate delivery failure → rewind
         with patch("api.background_process._session_has_active_turn", return_value=False), \
-             patch("api.background_process._start_server_side_wakeup_turn",
-                   side_effect=Exception("transient")), \
+             patch("api.routes.start_session_turn", side_effect=Exception("transient")), \
              patch("api.background_process.record_deferred_wakeup"):
             clean_notifier._deliver(deliveries)
 
-        # Second poll: should re-claim the same events
         deliveries2 = clean_notifier._poll_once()
         assert len(deliveries2) == 1
         assert len(deliveries2[0]["events"]) == 1
 
-        # This time delivery succeeds
+        mock_resp = {"_status": 200, "stream_id": "s1"}
         with patch("api.background_process._session_has_active_turn", return_value=False), \
-             patch("api.background_process._start_server_side_wakeup_turn") as mock_wakeup:
+             patch("api.routes.start_session_turn", return_value=mock_resp) as mock_turn:
             clean_notifier._deliver(deliveries2)
-            mock_wakeup.assert_called_once()
+            mock_turn.assert_called_once()
 
     def test_does_not_unsub_on_delivery_failure_for_terminal_task(
         self, fake_kanban, clean_notifier
@@ -524,16 +546,41 @@ class TestDeliver:
         deliveries = clean_notifier._poll_once()
         assert len(deliveries) == 1
 
+        mock_resp = {"_status": 500, "error": "internal"}
         with patch("api.background_process._session_has_active_turn", return_value=False), \
-             patch("api.background_process._start_server_side_wakeup_turn",
-                   side_effect=Exception("fail")), \
+             patch("api.routes.start_session_turn", return_value=mock_resp), \
              patch("api.background_process.record_deferred_wakeup"):
             clean_notifier._deliver(deliveries)
 
-        # Subscription should still exist (delivery failed, cursor rewound)
         assert len(fake_kanban.subs) == 1
-        # Cursor should be rewound
         assert fake_kanban.subs[0]["last_event_id"] == 0
+
+    def test_dedup_key_cleared_on_terminal_unsub(self, fake_kanban, clean_notifier):
+        """When a terminal task's subscription is removed, the in-memory
+        dedup key should also be removed to prevent unbounded growth."""
+        fake_kanban.tasks = [FakeTask("t_1", "Done", "done", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "completed", {}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+
+        mock_resp = {"_status": 200, "stream_id": "s1"}
+        with patch("api.background_process._session_has_active_turn", return_value=False), \
+             patch("api.routes.start_session_turn", return_value=mock_resp), \
+             patch("api.background_process.record_deferred_wakeup"):
+            clean_notifier._deliver(deliveries)
+
+        key = clean_notifier._dedup_key("default", "t_1", "sess-1")
+        assert key not in clean_notifier._DELIVERED_EVENTS
+
+    def test_none_assignee_renders_empty(self, fake_kanban, clean_notifier):
+        """None assignee should render as empty string, not @None."""
+        prompt = clean_notifier._format_wakeup_prompt(
+            "t_1", "Test", None, "default", {"blocked"}
+        )
+        assert "@None" not in prompt
 
 
 class TestThreadLifecycle:

--- a/tests/test_kanban_notifier.py
+++ b/tests/test_kanban_notifier.py
@@ -1,0 +1,445 @@
+"""Tests for the WebUI kanban agent wakeup notifier.
+
+These tests inject a fake ``hermes_cli.kanban_db`` module (same pattern as
+test_kanban_bridge.py) and verify that:
+
+1. ``_poll_once`` collects terminal events for ``platform='webui'`` subs
+2. ``_format_wakeup_prompt`` produces the expected message
+3. ``_deliver`` calls ``_start_server_side_wakeup_turn`` for idle sessions
+4. ``_deliver`` defers (records deferred wakeup) when the session is active
+5. Subscriptions for terminal (done/archived) tasks are cleaned up
+6. Non-webui subscriptions (telegram, discord) are skipped
+7. Non-terminal event kinds (created, assigned) are not delivered
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+@dataclass
+class FakeTask:
+    id: str
+    title: str
+    status: str = "ready"
+    assignee: str | None = None
+    tenant: str | None = None
+    priority: int = 0
+    body: str | None = None
+
+
+@dataclass
+class FakeEvent:
+    id: int
+    task_id: str
+    run_id: str | None
+    kind: str
+    payload: dict | None
+    created_at: int
+
+
+class FakeConn:
+    def __init__(self, tasks, events, subs):
+        self.tasks = tasks
+        self.events = events
+        self.subs = subs
+
+    def close(self):
+        pass
+
+    def execute(self, sql, params=()):
+        # SELECT last_event_id FROM kanban_notify_subs
+        if "SELECT last_event_id FROM kanban_notify_subs" in sql:
+            # params: (task_id, platform, chat_id, thread_id)
+            task_id = params[0]
+            for s in self.subs:
+                if s["task_id"] == task_id and s["platform"] == params[1]:
+                    row = SimpleNamespace(fetchone=lambda s=s: SimpleNamespace(
+                        __getitem__=lambda _, k="last_event_id": s["last_event_id"],
+                        __iter__=lambda s=s: iter([s["last_event_id"]]),
+                    ))
+                    # Return a dict-like row
+                    class _Row:
+                        def __init__(self, val):
+                            self._val = val
+                        def __getitem__(self, k):
+                            return self._val
+                    return SimpleNamespace(fetchone=lambda: _Row(s["last_event_id"]))
+            return SimpleNamespace(fetchone=lambda: None)
+
+        # SELECT * FROM task_events WHERE task_id = ? AND id > ?
+        if "SELECT * FROM task_events WHERE task_id = ? AND id > ?" in sql:
+            task_id = params[0]
+            cursor = params[1]
+            kinds = params[2:] if len(params) > 2 else None
+
+            matching = [
+                e for e in self.events
+                if e.task_id == task_id and e.id > cursor
+            ]
+            if kinds:
+                matching = [e for e in matching if e.kind in kinds]
+
+            class _EventRow:
+                def __init__(self, e):
+                    self.id = e.id
+                    self.task_id = e.task_id
+                    self.run_id = e.run_id
+                    self.kind = e.kind
+                    self.payload = '{"status":"test"}' if e.payload else None
+                    self.created_at = e.created_at
+
+                def __getitem__(self, k):
+                    return getattr(self, k)
+
+                def keys(self):
+                    return ["id", "task_id", "run_id", "kind", "payload", "created_at"]
+
+            return SimpleNamespace(fetchall=lambda: [_EventRow(e) for e in matching])
+
+        # UPDATE kanban_notify_subs SET last_event_id
+        if "UPDATE kanban_notify_subs SET last_event_id" in sql:
+            new_cursor = params[0]
+            task_id = params[1]
+            for s in self.subs:
+                if s["task_id"] == task_id and s["platform"] == params[2]:
+                    s["last_event_id"] = new_cursor
+            return SimpleNamespace(rowcount=1)
+
+        # DELETE FROM kanban_notify_subs
+        if "DELETE FROM kanban_notify_subs" in sql:
+            task_id = params[0]
+            before = len(self.subs)
+            self.subs = [
+                s for s in self.subs
+                if not (s["task_id"] == task_id and s["platform"] == params[1])
+            ]
+            return SimpleNamespace(rowcount=before - len(self.subs))
+
+        raise AssertionError(f"unexpected SQL: {sql} params={params}")
+
+
+class FakeKanbanDB:
+    DEFAULT_BOARD = "default"
+
+    def __init__(self):
+        self.tasks = []
+        self.events = []
+        self.subs = []
+        self._next_event_id = 1
+
+    def connect(self, *, board=None):
+        return FakeConn(self.tasks, self.events, self.subs)
+
+    def list_boards(self, *, include_archived=True):
+        return [{"slug": "default", "name": "Default", "archived": False}]
+
+    def get_task(self, conn, task_id):
+        return next((t for t in self.tasks if t.id == task_id), None)
+
+    def list_notify_subs(self, conn, task_id=None):
+        if task_id:
+            return [s for s in conn.subs if s["task_id"] == task_id]
+        return list(conn.subs)
+
+    def claim_unseen_events_for_sub(self, conn, *, task_id, platform, chat_id,
+                                    thread_id=None, kinds=None):
+        # Find the sub
+        sub = None
+        for s in conn.subs:
+            if (s["task_id"] == task_id and s["platform"] == platform
+                    and s["chat_id"] == chat_id):
+                sub = s
+                break
+        if not sub:
+            return 0, 0, []
+
+        old_cursor = sub["last_event_id"]
+
+        # Find events
+        matching = [
+            e for e in conn.events
+            if e.task_id == task_id and e.id > old_cursor
+        ]
+        if kinds:
+            matching = [e for e in matching if e.kind in kinds]
+
+        if not matching:
+            return old_cursor, old_cursor, []
+
+        new_cursor = max(e.id for e in matching)
+        sub["last_event_id"] = new_cursor
+
+        # Return as Event-like objects
+        from collections import namedtuple
+        Event = namedtuple("Event", ["id", "task_id", "kind", "payload", "created_at", "run_id"])
+        events = [
+            Event(id=e.id, task_id=e.task_id, kind=e.kind,
+                  payload=e.payload, created_at=e.created_at, run_id=e.run_id)
+            for e in matching
+        ]
+        return old_cursor, new_cursor, events
+
+    def remove_notify_sub(self, conn, *, task_id, platform, chat_id, thread_id=None):
+        before = len(conn.subs)
+        conn.subs[:] = [
+            s for s in conn.subs
+            if not (s["task_id"] == task_id and s["platform"] == platform
+                    and s["chat_id"] == chat_id)
+        ]
+        return before != len(conn.subs)
+
+    @staticmethod
+    def _normalize_board_slug(slug):
+        if slug is None:
+            return None
+        s = str(slug).strip().lower().replace(" ", "-")
+        if not s:
+            return None
+        return s
+
+
+@pytest.fixture
+def fake_kanban(monkeypatch):
+    """Install a fake hermes_cli.kanban_db module."""
+    fake = FakeKanbanDB()
+    fake_hermes_cli = types.ModuleType("hermes_cli")
+    fake_hermes_cli.kanban_db = fake
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.kanban_db", fake)
+    return fake
+
+
+@pytest.fixture
+def clean_notifier():
+    """Reset the notifier module's internal state."""
+    from api import kanban_notifier
+    kanban_notifier._DELIVERED_EVENTS.clear()
+    yield kanban_notifier
+    kanban_notifier._DELIVERED_EVENTS.clear()
+
+
+def _make_sub(task_id="t_1", platform="webui", chat_id="sess-123",
+              last_event_id=0, thread_id="", user_id=None, notifier_profile=""):
+    return {
+        "task_id": task_id,
+        "platform": platform,
+        "chat_id": chat_id,
+        "thread_id": thread_id,
+        "user_id": user_id,
+        "notifier_profile": notifier_profile,
+        "created_at": 0,
+        "last_event_id": last_event_id,
+    }
+
+
+class TestFormatWakeupPrompt:
+    def test_completed(self, clean_notifier):
+        prompt = clean_notifier._format_wakeup_prompt(
+            "t_1", "My Task", "worker", "default", {"completed"}
+        )
+        assert "t_1" in prompt
+        assert "completed" in prompt
+        assert "My Task" in prompt
+        assert "@worker" in prompt
+        assert "default" in prompt
+
+    def test_blocked(self, clean_notifier):
+        prompt = clean_notifier._format_wakeup_prompt(
+            "t_2", "Blocked Task", "dev", "ops-board", {"blocked"}
+        )
+        assert "blocked" in prompt
+        assert "needs attention" in prompt
+        assert "Blocked Task" in prompt
+
+    def test_multiple_kinds(self, clean_notifier):
+        prompt = clean_notifier._format_wakeup_prompt(
+            "t_3", "Triple Fail", "agent", "default",
+            {"crashed", "timed_out", "gave_up"}
+        )
+        assert "crashed" in prompt
+        assert "timed out" in prompt
+        assert "gave up" in prompt
+
+
+class TestPollOnce:
+    def test_collects_webui_terminal_events(self, fake_kanban, clean_notifier):
+        fake_kanban.tasks = [FakeTask("t_1", "Test Task", "blocked", "worker")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "blocked", {"reason": "needs input"}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+
+        assert len(deliveries) == 1
+        assert deliveries[0]["sub"]["chat_id"] == "sess-1"
+        assert len(deliveries[0]["events"]) == 1
+        assert deliveries[0]["events"][0].kind == "blocked"
+        assert deliveries[0]["board"] == "default"
+
+    def test_skips_non_webui_subs(self, fake_kanban, clean_notifier):
+        fake_kanban.tasks = [FakeTask("t_1", "Test", "blocked", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "blocked", {}, 100),
+        ]
+        fake_kanban.subs = [
+            _make_sub(task_id="t_1", platform="telegram", chat_id="123"),
+        ]
+
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 0
+
+    def test_skips_non_terminal_events(self, fake_kanban, clean_notifier):
+        fake_kanban.tasks = [FakeTask("t_1", "Test", "ready", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "created", {"status": "ready"}, 100),
+            FakeEvent(2, "t_1", None, "assigned", {"assignee": "w"}, 101),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 0
+
+    def test_advances_cursor(self, fake_kanban, clean_notifier):
+        fake_kanban.tasks = [FakeTask("t_1", "Test", "done", "w")]
+        fake_kanban.events = [
+            FakeEvent(5, "t_1", None, "completed", {"summary": "done"}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 1
+
+        # Second poll should find nothing — cursor advanced
+        deliveries2 = clean_notifier._poll_once()
+        assert len(deliveries2) == 0
+
+    def test_handles_empty_subs(self, fake_kanban, clean_notifier):
+        fake_kanban.subs = []
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 0
+
+    def test_handles_no_boards(self, fake_kanban, clean_notifier, monkeypatch):
+        monkeypatch.setattr(fake_kanban, "list_boards", lambda **kw: [])
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 0
+
+    def test_handles_db_connection_error(self, fake_kanban, clean_notifier, monkeypatch):
+        def bad_connect(*, board=None):
+            raise Exception("DB locked")
+        monkeypatch.setattr(fake_kanban, "connect", bad_connect)
+        # Should not raise
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 0
+
+
+class TestDeliver:
+    def test_starts_wakeup_for_idle_session(self, fake_kanban, clean_notifier):
+        fake_kanban.tasks = [FakeTask("t_1", "Test Task", "blocked", "worker")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "blocked", {"reason": "x"}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+
+        with patch("api.background_process._session_has_active_turn", return_value=False) as mock_active, \
+             patch("api.background_process._start_server_side_wakeup_turn") as mock_wakeup, \
+             patch("api.background_process.record_deferred_wakeup") as mock_defer:
+            clean_notifier._deliver(deliveries)
+
+            mock_active.assert_called_once_with("sess-1")
+            mock_wakeup.assert_called_once()
+            mock_defer.assert_not_called()
+            # Check the prompt
+            args = mock_wakeup.call_args
+            assert "sess-1" == args[0][0] or "sess-1" == args[1].get("session_id", args[0][0])
+            prompt = args[0][1] if len(args[0]) > 1 else args.kwargs.get("wakeup_prompt", "")
+            assert "t_1" in prompt
+            assert "blocked" in prompt
+
+    def test_defers_when_session_active(self, fake_kanban, clean_notifier):
+        fake_kanban.tasks = [FakeTask("t_1", "Test", "blocked", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "blocked", {}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+
+        with patch("api.background_process._session_has_active_turn", return_value=True), \
+             patch("api.background_process._start_server_side_wakeup_turn") as mock_wakeup, \
+             patch("api.background_process.record_deferred_wakeup") as mock_defer:
+            clean_notifier._deliver(deliveries)
+
+            mock_wakeup.assert_not_called()
+            mock_defer.assert_called_once()
+            # Check the deferred prompt
+            args = mock_defer.call_args
+            assert args[0][0] == "sess-1" or args.kwargs.get("session_id") == "sess-1"
+
+    def test_cleans_up_terminal_subscription(self, fake_kanban, clean_notifier):
+        fake_kanban.tasks = [FakeTask("t_1", "Done Task", "done", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "completed", {"summary": "all done"}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 1
+
+        with patch("api.background_process._session_has_active_turn", return_value=False), \
+             patch("api.background_process._start_server_side_wakeup_turn"), \
+             patch("api.background_process.record_deferred_wakeup"):
+            clean_notifier._deliver(deliveries)
+
+        # Subscription should be removed
+        assert len(fake_kanban.subs) == 0
+
+    def test_does_not_cleanup_non_terminal(self, fake_kanban, clean_notifier):
+        fake_kanban.tasks = [FakeTask("t_1", "Blocked Task", "blocked", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "blocked", {"reason": "x"}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+
+        with patch("api.background_process._session_has_active_turn", return_value=False), \
+             patch("api.background_process._start_server_side_wakeup_turn"), \
+             patch("api.background_process.record_deferred_wakeup"):
+            clean_notifier._deliver(deliveries)
+
+        # Subscription should still exist (task is "blocked", not "done")
+        assert len(fake_kanban.subs) == 1
+
+    def test_handles_missing_session_id(self, fake_kanban, clean_notifier):
+        fake_kanban.tasks = [FakeTask("t_1", "Test", "blocked", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "blocked", {}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="")]
+
+        deliveries = clean_notifier._poll_once()
+        # With empty chat_id, should still poll but _deliver skips
+        if deliveries:
+            with patch("api.background_process._start_server_side_wakeup_turn") as mock_wakeup:
+                clean_notifier._deliver(deliveries)
+                mock_wakeup.assert_not_called()
+
+
+class TestThreadLifecycle:
+    def test_start_and_stop(self, clean_notifier):
+        assert clean_notifier.start_notifier_thread() is True
+        assert clean_notifier.start_notifier_thread() is False  # already running
+        clean_notifier.stop_notifier_thread(timeout=1)
+        # After stop, can start again
+        assert clean_notifier.start_notifier_thread() is True
+        clean_notifier.stop_notifier_thread(timeout=1)

--- a/tests/test_kanban_notifier.py
+++ b/tests/test_kanban_notifier.py
@@ -683,9 +683,29 @@ class TestDeliver:
 
 class TestThreadLifecycle:
     def test_start_and_stop(self, clean_notifier):
-        assert clean_notifier.start_notifier_thread() is True
-        assert clean_notifier.start_notifier_thread() is False  # already running
-        clean_notifier.stop_notifier_thread(timeout=1)
-        # After stop, can start again
-        assert clean_notifier.start_notifier_thread() is True
-        clean_notifier.stop_notifier_thread(timeout=1)
+        # Config gate is default-off; patch to enable for this test
+        with patch("hermes_cli.config.load_config") as mock_cfg, \
+             patch("hermes_cli.config.cfg_get") as mock_get:
+            mock_cfg.return_value = {}
+            mock_get.return_value = True
+            assert clean_notifier.start_notifier_thread() is True
+            assert clean_notifier.start_notifier_thread() is False  # already running
+            clean_notifier.stop_notifier_thread(timeout=1)
+            # After stop, can start again
+            assert clean_notifier.start_notifier_thread() is True
+            clean_notifier.stop_notifier_thread(timeout=1)
+
+    def test_default_off_when_config_unset(self, clean_notifier):
+        """When kanban.webui_notifier is not set in config, the thread
+        should NOT start (default-off / opt-in per Footprint-Ladder)."""
+        with patch("hermes_cli.config.load_config") as mock_cfg, \
+             patch("hermes_cli.config.cfg_get") as mock_get:
+            mock_cfg.return_value = {}
+            mock_get.return_value = False  # default=False
+            assert clean_notifier.start_notifier_thread() is False
+
+    def test_default_off_when_config_unreadable(self, clean_notifier):
+        """If config.yaml can't be loaded, the thread should NOT start
+        — no always-on thread without explicit user opt-in."""
+        with patch("hermes_cli.config.load_config", side_effect=Exception("no config")):
+            assert clean_notifier.start_notifier_thread() is False

--- a/tests/test_kanban_notifier.py
+++ b/tests/test_kanban_notifier.py
@@ -605,6 +605,81 @@ class TestDeliver:
             assert "t_1" in prompt
             assert "@None" not in prompt
 
+    def test_silent_terminal_event_cleans_up_subscription(
+        self, fake_kanban, clean_notifier
+    ):
+        """A task that reaches done via a non-wake event (e.g. 'status')
+        should NOT trigger a wakeup prompt, but SHOULD clean up the
+        subscription and dedup entry — no stale-sub leak."""
+        fake_kanban.tasks = [FakeTask("t_1", "Done Task", "done", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "status", {"to": "done"}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 1
+
+        with patch("api.routes.start_session_turn") as mock_turn:
+            clean_notifier._deliver(deliveries)
+            # No prompt should be sent for a silent terminal event
+            mock_turn.assert_not_called()
+
+        # Subscription should be removed (cleanup ran)
+        assert len(fake_kanban.subs) == 0
+        # Dedup key should be cleaned up too
+        key = clean_notifier._dedup_key("default", "t_1", "sess-1")
+        assert key not in clean_notifier._DELIVERED_EVENTS
+
+    def test_silent_terminal_event_no_cleanup_for_non_terminal(
+        self, fake_kanban, clean_notifier
+    ):
+        """A silent event (e.g. 'status') for a non-terminal task should
+        neither prompt nor clean up — just skip."""
+        fake_kanban.tasks = [FakeTask("t_1", "Running Task", "running", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "status", {"to": "running"}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 1
+
+        with patch("api.routes.start_session_turn") as mock_turn:
+            clean_notifier._deliver(deliveries)
+            mock_turn.assert_not_called()
+
+        # Subscription should still exist (task is not terminal)
+        assert len(fake_kanban.subs) == 1
+
+    def test_mixed_wake_and_silent_events(self, fake_kanban, clean_notifier):
+        """When a delivery contains both wake and silent kinds, only the
+        wake kinds should appear in the prompt, and cleanup should still
+        run if the task is terminal."""
+        fake_kanban.tasks = [FakeTask("t_1", "Done Task", "done", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "completed", {"summary": "ok"}, 100),
+            FakeEvent(2, "t_1", None, "status", {"to": "done"}, 101),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 1
+        assert len(deliveries[0]["events"]) == 2
+
+        mock_resp = {"_status": 200, "stream_id": "s1"}
+        with patch("api.background_process._session_has_active_turn", return_value=False), \
+             patch("api.routes.start_session_turn", return_value=mock_resp) as mock_turn:
+            clean_notifier._deliver(deliveries)
+            mock_turn.assert_called_once()
+            prompt = mock_turn.call_args[0][1]
+            # Only "completed" should be in the prompt, not "status"
+            assert "completed" in prompt
+            assert "status changed" not in prompt
+
+        # Cleanup should run (task is done)
+        assert len(fake_kanban.subs) == 0
+
 
 class TestThreadLifecycle:
     def test_start_and_stop(self, clean_notifier):

--- a/tests/test_kanban_notifier.py
+++ b/tests/test_kanban_notifier.py
@@ -195,6 +195,16 @@ class FakeKanbanDB:
         ]
         return before != len(conn.subs)
 
+    def rewind_notify_cursor(self, conn, *, task_id, platform, chat_id,
+                             thread_id=None, claimed_cursor=None, old_cursor=None):
+        for s in conn.subs:
+            if (s["task_id"] == task_id and s["platform"] == platform
+                    and s["chat_id"] == chat_id):
+                if s["last_event_id"] == claimed_cursor:
+                    s["last_event_id"] = old_cursor
+                    return True
+        return False
+
     @staticmethod
     def _normalize_board_slug(slug):
         if slug is None:
@@ -433,6 +443,71 @@ class TestDeliver:
             with patch("api.background_process._start_server_side_wakeup_turn") as mock_wakeup:
                 clean_notifier._deliver(deliveries)
                 mock_wakeup.assert_not_called()
+
+    def test_rewinds_cursor_on_delivery_failure(self, fake_kanban, clean_notifier):
+        """When _start_server_side_wakeup_turn raises, the DB cursor is
+        rewound so the event is retried on the next tick instead of
+        being permanently lost."""
+        fake_kanban.tasks = [FakeTask("t_1", "Test", "blocked", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "blocked", {"reason": "x"}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 1
+        old_cursor = deliveries[0]["old_cursor"]
+        new_cursor = deliveries[0]["new_cursor"]
+        assert old_cursor == 0
+        assert new_cursor == 1
+
+        # Verify cursor was advanced
+        assert fake_kanban.subs[0]["last_event_id"] == 1
+
+        with patch("api.background_process._session_has_active_turn", return_value=False), \
+             patch("api.background_process._start_server_side_wakeup_turn",
+                   side_effect=Exception("RPC failed")), \
+             patch("api.background_process.record_deferred_wakeup"):
+            clean_notifier._deliver(deliveries)
+
+        # Cursor should be rewound back to old_cursor (0)
+        assert fake_kanban.subs[0]["last_event_id"] == 0
+
+        # In-memory dedup should be cleared so retry is not skipped
+        task_key = f"default:t_1:sess-1"
+        assert task_key not in clean_notifier._DELIVERED_EVENTS or \
+               len(clean_notifier._DELIVERED_EVENTS.get(task_key, set())) == 0
+
+    def test_retry_succeeds_after_rewind(self, fake_kanban, clean_notifier):
+        """After a cursor rewind, the next _poll_once should re-claim the
+        same events and successfully deliver them."""
+        fake_kanban.tasks = [FakeTask("t_1", "Test", "blocked", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "blocked", {"reason": "x"}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        # First poll: claim events
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 1
+
+        # Simulate delivery failure → rewind
+        with patch("api.background_process._session_has_active_turn", return_value=False), \
+             patch("api.background_process._start_server_side_wakeup_turn",
+                   side_effect=Exception("transient")), \
+             patch("api.background_process.record_deferred_wakeup"):
+            clean_notifier._deliver(deliveries)
+
+        # Second poll: should re-claim the same events
+        deliveries2 = clean_notifier._poll_once()
+        assert len(deliveries2) == 1
+        assert len(deliveries2[0]["events"]) == 1
+
+        # This time delivery succeeds
+        with patch("api.background_process._session_has_active_turn", return_value=False), \
+             patch("api.background_process._start_server_side_wakeup_turn") as mock_wakeup:
+            clean_notifier._deliver(deliveries2)
+            mock_wakeup.assert_called_once()
 
 
 class TestThreadLifecycle:

--- a/tests/test_kanban_notifier.py
+++ b/tests/test_kanban_notifier.py
@@ -509,6 +509,32 @@ class TestDeliver:
             clean_notifier._deliver(deliveries2)
             mock_wakeup.assert_called_once()
 
+    def test_does_not_unsub_on_delivery_failure_for_terminal_task(
+        self, fake_kanban, clean_notifier
+    ):
+        """When delivery fails for a done/archived task, the subscription
+        must NOT be removed — the cursor was rewound and the retry needs
+        the sub to still exist."""
+        fake_kanban.tasks = [FakeTask("t_1", "Done Task", "done", "w")]
+        fake_kanban.events = [
+            FakeEvent(1, "t_1", None, "completed", {"summary": "ok"}, 100),
+        ]
+        fake_kanban.subs = [_make_sub(task_id="t_1", chat_id="sess-1")]
+
+        deliveries = clean_notifier._poll_once()
+        assert len(deliveries) == 1
+
+        with patch("api.background_process._session_has_active_turn", return_value=False), \
+             patch("api.background_process._start_server_side_wakeup_turn",
+                   side_effect=Exception("fail")), \
+             patch("api.background_process.record_deferred_wakeup"):
+            clean_notifier._deliver(deliveries)
+
+        # Subscription should still exist (delivery failed, cursor rewound)
+        assert len(fake_kanban.subs) == 1
+        # Cursor should be rewound
+        assert fake_kanban.subs[0]["last_event_id"] == 0
+
 
 class TestThreadLifecycle:
     def test_start_and_stop(self, clean_notifier):


### PR DESCRIPTION
## Summary

The Hermes gateway's kanban notifier delivers task terminal events (completed/blocked/gave_up/crashed/timed_out) to messaging platform adapters (Telegram, Discord, etc.) and wakes the creator agent by injecting a synthetic message. However, WebUI sessions set `platform="webui"` in the subscription row, and the gateway has no `"webui"` adapter — so those events are silently skipped and the WebUI agent never learns that a kanban task it created needs attention.

This adds a background polling thread (`api/kanban_notifier.py`) that mirrors the gateway's `kanban_watchers._kanban_notifier_tick` logic but runs inside the WebUI process. Every 15 seconds it:

1. Reads `kanban_notify_subs` rows for `platform='webui'`
2. Atomically claims unseen terminal events via `claim_unseen_events_for_sub`
3. Calls `_start_server_side_wakeup_turn()` (same infrastructure used by `notify_on_complete` for background process completions) to inject a synthetic `[kanban] Task xxx blocked/completed` message into the creator's session
4. Defers the wakeup via `record_deferred_wakeup()` if the session is currently active (races with an in-flight turn)
5. Cleans up subscriptions for tasks that reached `done`/`archived` status

Thread lifecycle mirrors `background_process.start_drain_thread` / `stop_drain_thread`: started once at server boot, stopped on shutdown.

## Files Changed

- **`api/kanban_notifier.py`** (new) — 284 lines: the polling thread, event delivery, and subscription cleanup
- **`server.py`** — 7 lines: start the notifier thread at boot alongside the existing `bg_task_complete` drain thread
- **`tests/test_kanban_notifier.py`** (new) — 445 lines: 16 tests covering prompt formatting, event collection, delivery (idle + active session), subscription cleanup, cursor advancement, error handling, and thread lifecycle

## Test Plan

```bash
# Run the new test suite
python -m pytest tests/test_kanban_notifier.py -v

# Verify existing kanban tests are not broken
python -m pytest tests/test_kanban_bridge.py tests/test_kanban_notifier.py -v

# Integration test against real kanban DB
python -c "
import sys, os
sys.path.insert(0, '.')
os.environ.setdefault('HERMES_HOME', os.path.expanduser('~/.hermes'))
from api import kanban_notifier
deliveries = kanban_notifier._poll_once()
print(f'{len(deliveries)} deliveries found')
started = kanban_notifier.start_notifier_thread()
print(f'Thread started: {started}')
kanban_notifier.stop_notifier_thread(timeout=1)
print('Thread stopped: ok')
"
```

All 61 tests pass (45 existing + 16 new).
