### PR TITLE
feat(#2422): add Nix flake package and NixOS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This gives you nearly **1:1 parity with Hermes CLI from a convenient web UI** wh
 - [Quick start](#quick-start) — clone + `bootstrap.py` / `start.sh` / `ctl.sh`
 - [Features](#features) — chat, sessions, workspace, voice, profiles, security, themes, panels, mobile
 - [Configuration & access](#configuration--access) — auto-discovery, overrides, remote/Tailscale/phone, manual launch
+- [Nix flake/module](#nix-flake-and-nixos-module) — declarative install and service
 - [Docker](#docker) — single- and multi-container deploys
 - [Running tests](#running-tests)
 - [Architecture](#architecture) — backend/frontend layout, state dir
@@ -372,6 +373,63 @@ Full list of environment variables:
 Extension deployments can inspect sanitized, authenticated diagnostics at `GET /api/extensions/status`; see [WebUI Extensions](docs/EXTENSIONS.md#diagnostics).
 
 ---
+
+### Nix flake and NixOS module
+
+Hermes WebUI has a Nix flake package and a NixOS service module so you can run it declaratively.
+
+Install the latest package with:
+
+```bash
+nix shell github:nesquena/hermes-webui#default
+```
+
+Use this flake input in your system configuration:
+
+```nix
+inputs.hermes-webui.url = "github:nesquena/hermes-webui";
+```
+
+Then add the module and configure it in `nixosModules`:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    hermes-webui.url = "github:nesquena/hermes-webui";
+  };
+
+  outputs = { self, nixpkgs, hermes-webui, ... }: {
+    nixosConfigurations.<host> = nixpkgs.lib.nixosSystem {
+      modules = [
+        hermes-webui.nixosModules.default
+      ];
+    };
+  };
+}
+```
+
+Service example:
+
+```nix
+services.hermes-webui = {
+  enable = true;
+  host = "0.0.0.0";
+  port = 8787;
+  stateDir = "/var/lib/hermes-webui";
+  agent.dir = "/var/lib/hermes/hermes-agent";
+  environmentFiles = [ "/run/secrets/hermes-webui.env" ];
+};
+```
+
+Keep the module default host at `127.0.0.1`. Set `host = "0.0.0.0"` only when you also provide auth, for example `HERMES_WEBUI_PASSWORD` via `environmentFiles`.
+
+You can also set `agent.package` instead of `agent.dir` when you are using a compatible Hermes Agent package layout. The module derives `HERMES_WEBUI_AGENT_DIR` from `<pkg>/share/hermes-agent` and sets `HERMES_WEBUI_PYTHON` from the package's `passthru.hermesVenv` interpreter so bootstrap can use agent dependencies without creating a local `.venv`.
+
+The module maps directly onto existing WebUI environment variables, including:
+`HERMES_WEBUI_HOST`, `HERMES_WEBUI_PORT`, `HERMES_WEBUI_STATE_DIR`, `HERMES_HOME`, `HERMES_WEBUI_AGENT_DIR`, and `HERMES_WEBUI_PYTHON`.
+
+Set `environmentFiles` for secrets like API keys. Protected WebUI runtime keys from the module are rejected there, so keep host, port, state, and agent wiring in the module options. Keep reverse proxy and TLS configuration in your surrounding deployment module because those details are deployment-specific.
 
 ### Remote access (SSH tunnel, Tailscale, phone)
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ If an AI assistant is helping with install, reinstall, bootstrap, provider setup
 
 | Thing | How it finds it |
 |---|---|
-| Hermes agent dir | `HERMES_WEBUI_AGENT_DIR` env, then `$HERMES_HOME/hermes-agent` (Windows default `%LOCALAPPDATA%\hermes\hermes-agent`, POSIX default `~/.hermes/hermes-agent`), then sibling `../hermes-agent` |
+| Hermes agent dir | `HERMES_WEBUI_AGENT_DIR`, then known checkout paths, the `hermes` launcher on `PATH`, and finally the installed `run_agent` module exposed by `HERMES_WEBUI_PYTHON` |
 | Python executable | Agent venv first, then `.venv` in this repo, then system `python3` |
 | State directory | `HERMES_WEBUI_STATE_DIR` env, then `$HERMES_HOME/webui` (Windows default `%LOCALAPPDATA%\hermes\webui`, POSIX default `~/.hermes/webui`) |
 | Default workspace | `HERMES_WEBUI_DEFAULT_WORKSPACE` env, then `~/workspace`, then state dir |
@@ -350,7 +350,7 @@ Full list of environment variables:
 
 | Variable | Default | Description |
 |---|---|---|
-| `HERMES_WEBUI_AGENT_DIR` | auto-discovered | Path to the hermes-agent checkout |
+| `HERMES_WEBUI_AGENT_DIR` | auto-discovered | Path to the Hermes Agent source or installed module root |
 | `HERMES_WEBUI_PYTHON` | auto-discovered | Python executable |
 | `HERMES_WEBUI_HOST` | `127.0.0.1` | Bind address (`0.0.0.0` for all IPv4, `::` for all IPv6, `::1` for IPv6 loopback) |
 | `HERMES_WEBUI_PORT` | `8787` | Port |
@@ -396,35 +396,38 @@ Then add the module and configure it in `nixosModules`:
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    hermes-agent.url = "github:NousResearch/hermes-agent";
     hermes-webui.url = "github:nesquena/hermes-webui";
   };
 
-  outputs = { self, nixpkgs, hermes-webui, ... }: {
+  outputs = { self, nixpkgs, hermes-agent, hermes-webui, ... }: {
     nixosConfigurations.<host> = nixpkgs.lib.nixosSystem {
       modules = [
+        hermes-agent.nixosModules.default
         hermes-webui.nixosModules.default
+        ({ pkgs, ... }: {
+          services.hermes-agent.enable = true;
+          services.hermes-webui = {
+            enable = true;
+            host = "127.0.0.1";
+            port = 8787;
+            stateDir = "/var/lib/hermes-webui";
+            user = "hermes";
+            group = "hermes";
+            hermesHome = "/var/lib/hermes/.hermes";
+            agent.package = hermes-agent.packages.${pkgs.stdenv.hostPlatform.system}.default;
+            environmentFiles = [ "/run/secrets/hermes-webui.env" ];
+          };
+        })
       ];
     };
   };
 }
 ```
 
-Service example:
-
-```nix
-services.hermes-webui = {
-  enable = true;
-  host = "127.0.0.1";
-  port = 8787;
-  stateDir = "/var/lib/hermes-webui";
-  agent.dir = "/var/lib/hermes/hermes-agent";
-  environmentFiles = [ "/run/secrets/hermes-webui.env" ];
-};
-```
-
 The module defaults to `127.0.0.1`. Set `host = "0.0.0.0"` and `openFirewall = true` only when you want direct network access, and pair that with auth, for example `HERMES_WEBUI_PASSWORD` via `environmentFiles`.
 
-You can also set `agent.package` instead of `agent.dir` when you are using a compatible Hermes Agent package layout. This path depends on package metadata that the current published Hermes Agent flake may not expose yet, so explicit `agent.dir` and `agent.python` are the reliable integration options for existing agent packages. When the package exposes `passthru.hermesAgentDir`, the module derives `HERMES_WEBUI_AGENT_DIR` from that path. When it exposes `passthru.hermesVenv`, the module derives `HERMES_WEBUI_PYTHON` from the venv interpreter so bootstrap can use agent dependencies without creating a local `.venv`.
+The published Hermes Agent package exposes `passthru.hermesVenv`, so the module derives `HERMES_WEBUI_PYTHON` from its interpreter. Bootstrap then locates the installed `run_agent.py` through that interpreter without importing Agent code and exports its parent as `HERMES_WEBUI_AGENT_DIR`. Packages may expose `passthru.hermesAgentDir` as a direct path instead. Use `agent.dir` and `agent.python` as explicit overrides for custom package layouts.
 
 When WebUI reads shared Hermes Agent state, run the service as a user that can already read that state. For a co-located Hermes Agent service, set `user` and `group` to the agent service account; the module only creates the default `hermes-webui` account and never changes ownership of an existing `hermesHome`.
 

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ services.hermes-webui = {
 };
 ```
 
-Keep the module default host at `127.0.0.1`. Set `host = "0.0.0.0"` only when you also provide auth, for example `HERMES_WEBUI_PASSWORD` via `environmentFiles`.
+The module defaults to `0.0.0.0` for a network-reachable system service. Pair that with auth, for example `HERMES_WEBUI_PASSWORD` via `environmentFiles`, or override `host = "127.0.0.1"` when you want loopback-only access.
 
 You can also set `agent.package` instead of `agent.dir` when you are using a compatible Hermes Agent package layout. The module derives `HERMES_WEBUI_AGENT_DIR` from `<pkg>/share/hermes-agent` and sets `HERMES_WEBUI_PYTHON` from the package's `passthru.hermesVenv` interpreter so bootstrap can use agent dependencies without creating a local `.venv`.
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ services.hermes-webui = {
 
 The module defaults to `127.0.0.1`. Set `host = "0.0.0.0"` and `openFirewall = true` only when you want direct network access, and pair that with auth, for example `HERMES_WEBUI_PASSWORD` via `environmentFiles`.
 
-You can also set `agent.package` instead of `agent.dir` when you are using a compatible Hermes Agent package layout. When the package exposes `passthru.hermesVenv`, the module derives `HERMES_WEBUI_AGENT_DIR` from that venv's site-packages path and sets `HERMES_WEBUI_PYTHON` from the same venv interpreter so bootstrap can use agent dependencies without creating a local `.venv`. If the package does not expose that venv metadata, set `agent.dir` and `agent.python` explicitly.
+You can also set `agent.package` instead of `agent.dir` when you are using a compatible Hermes Agent package layout. When the package exposes `passthru.hermesAgentDir`, the module derives `HERMES_WEBUI_AGENT_DIR` from that path. When it exposes `passthru.hermesVenv`, the module derives `HERMES_WEBUI_PYTHON` from the venv interpreter so bootstrap can use agent dependencies without creating a local `.venv`. If the package does not expose either metadata path, set `agent.dir` and `agent.python` explicitly.
 
 When WebUI reads shared Hermes Agent state, run the service as a user that can already read that state. For a co-located Hermes Agent service, set `user` and `group` to the agent service account; the module only creates the default `hermes-webui` account and never changes ownership of an existing `hermesHome`.
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ services.hermes-webui = {
 
 The module defaults to `127.0.0.1`. Set `host = "0.0.0.0"` and `openFirewall = true` only when you want direct network access, and pair that with auth, for example `HERMES_WEBUI_PASSWORD` via `environmentFiles`.
 
-You can also set `agent.package` instead of `agent.dir` when you are using a compatible Hermes Agent package layout. When the package exposes `passthru.hermesAgentDir`, the module derives `HERMES_WEBUI_AGENT_DIR` from that path. When it exposes `passthru.hermesVenv`, the module derives `HERMES_WEBUI_PYTHON` from the venv interpreter so bootstrap can use agent dependencies without creating a local `.venv`. If the package does not expose either metadata path, set `agent.dir` and `agent.python` explicitly.
+You can also set `agent.package` instead of `agent.dir` when you are using a compatible Hermes Agent package layout. This path depends on package metadata that the current published Hermes Agent flake may not expose yet, so explicit `agent.dir` and `agent.python` are the reliable integration options for existing agent packages. When the package exposes `passthru.hermesAgentDir`, the module derives `HERMES_WEBUI_AGENT_DIR` from that path. When it exposes `passthru.hermesVenv`, the module derives `HERMES_WEBUI_PYTHON` from the venv interpreter so bootstrap can use agent dependencies without creating a local `.venv`.
 
 When WebUI reads shared Hermes Agent state, run the service as a user that can already read that state. For a co-located Hermes Agent service, set `user` and `group` to the agent service account; the module only creates the default `hermes-webui` account and never changes ownership of an existing `hermesHome`.
 

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Service example:
 ```nix
 services.hermes-webui = {
   enable = true;
-  host = "0.0.0.0";
+  host = "127.0.0.1";
   port = 8787;
   stateDir = "/var/lib/hermes-webui";
   agent.dir = "/var/lib/hermes/hermes-agent";
@@ -422,9 +422,11 @@ services.hermes-webui = {
 };
 ```
 
-The module defaults to `0.0.0.0` for a network-reachable system service. Pair that with auth, for example `HERMES_WEBUI_PASSWORD` via `environmentFiles`, or override `host = "127.0.0.1"` when you want loopback-only access.
+The module defaults to `127.0.0.1`. Set `host = "0.0.0.0"` and `openFirewall = true` only when you want direct network access, and pair that with auth, for example `HERMES_WEBUI_PASSWORD` via `environmentFiles`.
 
-You can also set `agent.package` instead of `agent.dir` when you are using a compatible Hermes Agent package layout. The module derives `HERMES_WEBUI_AGENT_DIR` from `<pkg>/share/hermes-agent` and sets `HERMES_WEBUI_PYTHON` from the package's `passthru.hermesVenv` interpreter so bootstrap can use agent dependencies without creating a local `.venv`.
+You can also set `agent.package` instead of `agent.dir` when you are using a compatible Hermes Agent package layout. When the package exposes `passthru.hermesVenv`, the module derives `HERMES_WEBUI_AGENT_DIR` from that venv's site-packages path and sets `HERMES_WEBUI_PYTHON` from the same venv interpreter so bootstrap can use agent dependencies without creating a local `.venv`. If the package does not expose that venv metadata, set `agent.dir` and `agent.python` explicitly.
+
+When WebUI reads shared Hermes Agent state, run the service as a user that can already read that state. For a co-located Hermes Agent service, set `user` and `group` to the agent service account; the module only creates the default `hermes-webui` account and never changes ownership of an existing `hermesHome`.
 
 The module maps directly onto existing WebUI environment variables, including:
 `HERMES_WEBUI_HOST`, `HERMES_WEBUI_PORT`, `HERMES_WEBUI_STATE_DIR`, `HERMES_HOME`, `HERMES_WEBUI_AGENT_DIR`, and `HERMES_WEBUI_PYTHON`.

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -270,6 +270,13 @@ def ensure_python_has_webui_deps(python_exe: str, agent_dir: Path | None = None)
                 if _python_can_run_webui_and_agent(str(candidate), agent_dir):
                     return str(candidate)
 
+    if (os.getenv("HERMES_WEBUI_DISABLE_LOCAL_VENV") or "").strip().lower() in {"1", "true", "yes", "on"}:
+        raise RuntimeError(
+            "Python environment cannot import both WebUI dependencies and Hermes Agent, "
+            "and local .venv creation is disabled for this packaged launch. Set "
+            "HERMES_WEBUI_PYTHON to an interpreter with Hermes Agent dependencies."
+        )
+
     venv_dir = REPO_ROOT / ".venv"
     venv_python = venv_dir / (
         "Scripts/python.exe" if platform.system() == "Windows" else "bin/python"

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -182,6 +182,31 @@ def _agent_dir_from_hermes_cli() -> Path | None:
     return None
 
 
+def _agent_dir_from_python(python_exe: str) -> Path | None:
+    script = (
+        'import importlib.util\n'
+        'spec = importlib.util.find_spec("run_agent")\n'
+        'print(spec.origin if spec else "")\n'
+    )
+    try:
+        check = subprocess.run(
+            [python_exe, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if check.returncode != 0:
+        return None
+    lines = check.stdout.splitlines()
+    if not lines:
+        return None
+    origin = Path(lines[0].strip())
+    if not origin.is_absolute() or origin.name != "run_agent.py" or not origin.is_file():
+        return None
+    return origin.parent.resolve()
+
+
 def discover_agent_dir() -> Path | None:
     home = Path(os.getenv("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser()
     candidates = [
@@ -202,7 +227,10 @@ def discover_agent_dir() -> Path | None:
         candidate = Path(raw).expanduser().resolve()
         if candidate.exists() and (candidate / "run_agent.py").exists():
             return candidate
-    return _agent_dir_from_hermes_cli()
+    agent_dir = _agent_dir_from_hermes_cli()
+    if agent_dir:
+        return agent_dir
+    return _agent_dir_from_python(discover_launcher_python(None))
 
 
 def discover_launcher_python(agent_dir: Path | None) -> str:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,88 @@
+{
+  description = "Hermes Web UI";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      linuxSystems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      hermesModule = import ./nix/nixosModules.nix { inherit self; };
+      perSystem = forAllSystems (system: let
+        pkgs = import nixpkgs { inherit system; };
+        package = import ./nix/packages.nix {
+          inherit pkgs;
+          version = "0.51.0";
+        };
+        moduleChecks = if builtins.elem system linuxSystems then
+          let
+            moduleConfig = nixpkgs.lib.nixosSystem {
+              inherit system;
+              modules = [
+                hermesModule
+                {
+                  services.hermes-webui = {
+                    enable = true;
+                    package = package;
+                    host = "0.0.0.0";
+                    port = 8787;
+                    stateDir = "/var/lib/hermes-webui";
+                    agent.dir = "/var/lib/hermes-agent";
+                  };
+                }
+              ];
+            };
+            moduleServiceEnvironment = nixpkgs.lib.concatStringsSep "\n" moduleConfig.config.systemd.services.hermes-webui.serviceConfig.Environment;
+            envProbe = pkgs.writeText "hermes-webui-nixos-env-${system}.txt" moduleServiceEnvironment;
+          in
+          {
+            module-env-mapping = pkgs.runCommand "hermes-webui-nixos-module-${system}" {
+              nativeBuildInputs = [ pkgs.coreutils ];
+            } ''
+              grep -q 'HERMES_WEBUI_HOST=0.0.0.0' ${envProbe}
+              grep -q 'HERMES_WEBUI_PORT=8787' ${envProbe}
+              grep -q 'HERMES_WEBUI_STATE_DIR=/var/lib/hermes-webui' ${envProbe}
+              grep -q 'HERMES_WEBUI_AGENT_DIR=/var/lib/hermes-agent' ${envProbe}
+              touch "$out"
+            '';
+          }
+        else
+          { };
+      in
+      {
+        packages = {
+          hermes-webui = package;
+          default = package;
+        };
+
+        apps = {
+          default = {
+            type = "app";
+            program = "${package}/bin/hermes-webui";
+          };
+        };
+
+        checks = moduleChecks // {
+          package = package;
+        };
+      });
+    in
+    {
+      packages = forAllSystems (system: perSystem.${system}.packages);
+      apps = forAllSystems (system: perSystem.${system}.apps);
+      checks = nixpkgs.lib.genAttrs linuxSystems (system: perSystem.${system}.checks);
+
+      nixosModules = {
+        default = hermesModule;
+        hermes-webui = hermesModule;
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
                   services.hermes-webui = {
                     enable = true;
                     package = package;
-                    host = "0.0.0.0";
+                    host = "127.0.0.1";
                     port = 8787;
                     stateDir = "/var/lib/hermes-webui";
                     agent.dir = "/var/lib/hermes-agent";
@@ -47,10 +47,23 @@
             module-env-mapping = pkgs.runCommand "hermes-webui-nixos-module-${system}" {
               nativeBuildInputs = [ pkgs.coreutils ];
             } ''
-              grep -q 'HERMES_WEBUI_HOST=0.0.0.0' ${envProbe}
+              grep -q 'HERMES_WEBUI_HOST=127.0.0.1' ${envProbe}
               grep -q 'HERMES_WEBUI_PORT=8787' ${envProbe}
               grep -q 'HERMES_WEBUI_STATE_DIR=/var/lib/hermes-webui' ${envProbe}
               grep -q 'HERMES_WEBUI_AGENT_DIR=/var/lib/hermes-agent' ${envProbe}
+              touch "$out"
+            '';
+            runtime-layout = pkgs.runCommand "hermes-webui-runtime-layout-${system}" {
+              nativeBuildInputs = [ pkgs.coreutils ];
+            } ''
+              test -f ${package}/hermes-webui/bootstrap.py
+              test -f ${package}/hermes-webui/server.py
+              test -d ${package}/hermes-webui/api
+              test -d ${package}/hermes-webui/static
+              cd ${package}/hermes-webui
+              ${package}/bin/hermes-webui --help >/dev/null
+              ${package}/bin/hermes-webui --help 2>&1 | grep -q -- '--foreground'
+              PYTHONPATH=${package}/hermes-webui ${pkgs.python3.withPackages (ps: with ps; [ pyyaml cryptography ])}/bin/python3 -c 'import api.config, server; print("runtime imports ok")'
               touch "$out"
             '';
           }

--- a/flake.nix
+++ b/flake.nix
@@ -16,11 +16,12 @@
       linuxSystems = [ "x86_64-linux" "aarch64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
       hermesModule = import ./nix/nixosModules.nix { inherit self; };
+      packageVersion = self.shortRev or (self.dirtyShortRev or "unstable");
       perSystem = forAllSystems (system: let
         pkgs = import nixpkgs { inherit system; };
         package = import ./nix/packages.nix {
           inherit pkgs;
-          version = "0.51.0";
+          version = packageVersion;
         };
         moduleChecks = if builtins.elem system linuxSystems then
           let

--- a/flake.nix
+++ b/flake.nix
@@ -41,8 +41,32 @@
                 }
               ];
             };
+            packageOnlyAgentVenv = pkgs.runCommand "hermes-agent-package-only-venv-${system}" { } ''
+              mkdir -p "$out/bin"
+              touch "$out/bin/python3"
+            '';
+            packageOnlyAgentPackage = pkgs.runCommand "hermes-agent-package-only-${system}" {
+              passthru.hermesVenv = packageOnlyAgentVenv;
+            } ''
+              touch "$out"
+            '';
+            packageOnlyModuleConfig = nixpkgs.lib.nixosSystem {
+              inherit system;
+              modules = [
+                hermesModule
+                {
+                  services.hermes-webui = {
+                    enable = true;
+                    package = package;
+                    agent.package = packageOnlyAgentPackage;
+                  };
+                }
+              ];
+            };
             moduleServiceEnvironment = nixpkgs.lib.concatStringsSep "\n" moduleConfig.config.systemd.services.hermes-webui.serviceConfig.Environment;
             envProbe = pkgs.writeText "hermes-webui-nixos-env-${system}.txt" moduleServiceEnvironment;
+            packageOnlyServiceEnvironment = nixpkgs.lib.concatStringsSep "\n" packageOnlyModuleConfig.config.systemd.services.hermes-webui.serviceConfig.Environment;
+            packageOnlyEnvProbe = pkgs.writeText "hermes-webui-nixos-package-only-env-${system}.txt" packageOnlyServiceEnvironment;
           in
           {
             module-env-mapping = pkgs.runCommand "hermes-webui-nixos-module-${system}" {
@@ -52,6 +76,8 @@
               grep -q 'HERMES_WEBUI_PORT=8787' ${envProbe}
               grep -q 'HERMES_WEBUI_STATE_DIR=/var/lib/hermes-webui' ${envProbe}
               grep -q 'HERMES_WEBUI_AGENT_DIR=/var/lib/hermes-agent' ${envProbe}
+              grep -q 'HERMES_WEBUI_PYTHON=${packageOnlyAgentVenv}/bin/python3' ${packageOnlyEnvProbe}
+              ! grep -q 'HERMES_WEBUI_AGENT_DIR=' ${packageOnlyEnvProbe}
               touch "$out"
             '';
             runtime-layout = pkgs.runCommand "hermes-webui-runtime-layout-${system}" {

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -1,0 +1,201 @@
+{ self }:
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.hermes-webui;
+  defaultPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  defaultStateDir = "/var/lib/hermes-webui";
+
+  protectedEnvironment = [
+    "HERMES_WEBUI_HOST"
+    "HERMES_WEBUI_PORT"
+    "HERMES_WEBUI_STATE_DIR"
+    "HERMES_HOME"
+    "HERMES_WEBUI_AGENT_DIR"
+    "HERMES_WEBUI_PYTHON"
+  ];
+
+  protectedEnvironmentFileCheck = pkgs.writeShellScript "hermes-webui-protected-envfile-check" ''
+    set -eu
+    for env_file in "$@"; do
+      [ -f "$env_file" ] || continue
+      while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+        line=$(printf '%s' "$raw_line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        case "$line" in
+          ""|\#*) continue ;;
+          export\ *) line=''${line#export } ;;
+        esac
+        key=''${line%%=*}
+        case "$key" in
+          HERMES_WEBUI_HOST|HERMES_WEBUI_PORT|HERMES_WEBUI_STATE_DIR|HERMES_HOME|HERMES_WEBUI_AGENT_DIR|HERMES_WEBUI_PYTHON)
+            echo "environmentFiles must not set protected WebUI runtime key $key; use module options or extraEnvironment for supported keys." >&2
+            exit 1
+            ;;
+        esac
+      done < "$env_file"
+    done
+  '';
+
+  inferredAgentPython =
+    if cfg.agent.package == null then
+      null
+    else if (cfg.agent.package ? passthru) && (cfg.agent.package.passthru ? hermesVenv) then
+      "${cfg.agent.package.passthru.hermesVenv}/bin/python3"
+    else
+      null;
+
+  inferredAgentDir =
+    if cfg.agent.package == null then
+      null
+    else
+      "${cfg.agent.package}/share/hermes-agent";
+
+  mappedEnvironment = (lib.mapAttrsToList
+    (name: value: "${name}=${value}")
+    ({
+      HERMES_WEBUI_HOST = cfg.host;
+      HERMES_WEBUI_PORT = toString cfg.port;
+      HERMES_WEBUI_STATE_DIR = cfg.stateDir;
+    }
+    // lib.optionalAttrs (cfg.hermesHome != null) {
+      HERMES_HOME = cfg.hermesHome;
+    }
+    // lib.optionalAttrs (cfg.agent.dir != null) {
+      HERMES_WEBUI_AGENT_DIR = cfg.agent.dir;
+    }
+    // lib.optionalAttrs (cfg.agent.dir == null && inferredAgentDir != null) {
+      HERMES_WEBUI_AGENT_DIR = inferredAgentDir;
+    }
+    // lib.optionalAttrs (cfg.agent.dir == null && inferredAgentPython != null) {
+      HERMES_WEBUI_PYTHON = inferredAgentPython;
+    }
+    // lib.filterAttrs
+      (name: _: !(lib.elem name protectedEnvironment))
+      cfg.extraEnvironment));
+
+  needsWritableStateDir = cfg.stateDir != defaultStateDir;
+  writableServiceDirs =
+    lib.optionals needsWritableStateDir [ cfg.stateDir ]
+    ++ lib.optionals (cfg.hermesHome != null) [ cfg.hermesHome ];
+
+  userspaceDirs = lib.optionals (cfg.hermesHome != null) [
+    "d ${cfg.hermesHome} 2770 ${cfg.user} ${cfg.group} - -"
+  ];
+
+  tmpfilesRules =
+    (lib.optionals needsWritableStateDir [
+      "d ${cfg.stateDir} 2770 ${cfg.user} ${cfg.group} - -"
+    ])
+    ++ userspaceDirs;
+in
+{
+  options.services.hermes-webui = {
+    enable = lib.mkEnableOption "Hermes WebUI service";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = defaultPackage;
+      defaultText = lib.literalExpression "self.packages.${pkgs.stdenv.hostPlatform.system}.default";
+      description = "Package that provides the `bin/hermes-webui` executable.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "hermes-webui";
+      description = "User that runs the Hermes WebUI service.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "hermes-webui";
+      description = "Group that runs the Hermes WebUI service.";
+    };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "Value for HERMES_WEBUI_HOST.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8787;
+      description = "Value for HERMES_WEBUI_PORT.";
+    };
+
+    stateDir = lib.mkOption {
+      type = lib.types.strMatching "^/.+";
+      default = defaultStateDir;
+      defaultText = lib.literalExpression ''"/var/lib/hermes-webui"'';
+      description = "Value for HERMES_WEBUI_STATE_DIR.";
+    };
+
+    hermesHome = lib.mkOption {
+      type = lib.types.nullOr (lib.types.strMatching "^/.+");
+      default = null;
+      description = "Optional value for HERMES_HOME.";
+    };
+
+    agent = {
+      package = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+        description = "Package to derive HERMES_WEBUI_AGENT_DIR from when `agent.dir` is unset.";
+      };
+
+      dir = lib.mkOption {
+        type = lib.types.nullOr (lib.types.strMatching "^/.+");
+        default = null;
+        description = "Explicit path for HERMES_WEBUI_AGENT_DIR.";
+      };
+    };
+
+    environmentFiles = lib.mkOption {
+      type = lib.types.listOf (lib.types.strMatching "^/.+");
+      default = [ ];
+      description = "Paths with extra environment variables for the service, including API keys. Protected WebUI runtime keys from module options are rejected here.";
+    };
+
+    extraEnvironment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = "Additional environment entries for the service. Required WebUI variables remain enforced.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.hermes-webui = {
+      description = "Hermes Web UI service";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig =
+        {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+          ExecStartPre = lib.optional (cfg.environmentFiles != [ ]) "${protectedEnvironmentFileCheck} ${lib.escapeShellArgs (map builtins.toString cfg.environmentFiles)}";
+          ExecStart = "${cfg.package}/bin/hermes-webui";
+          Restart = "on-failure";
+          Environment = mappedEnvironment;
+          EnvironmentFile = map builtins.toString cfg.environmentFiles;
+          ReadWritePaths = map builtins.toString writableServiceDirs;
+        }
+        // lib.optionalAttrs (cfg.stateDir == defaultStateDir) {
+          StateDirectory = "hermes-webui";
+        };
+    };
+
+    users.groups.${cfg.group} = { };
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+      createHome = true;
+      home = cfg.stateDir;
+    };
+
+    systemd.tmpfiles.rules = tmpfilesRules;
+  };
+}

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -175,7 +175,7 @@ in
           Type = "simple";
           User = cfg.user;
           Group = cfg.group;
-          ExecStartPre = lib.optional (cfg.environmentFiles != [ ]) "${protectedEnvironmentFileCheck} ${lib.escapeShellArgs (map builtins.toString cfg.environmentFiles)}";
+          ExecStartPre = lib.optional (cfg.environmentFiles != [ ]) "+${protectedEnvironmentFileCheck} ${lib.escapeShellArgs (map builtins.toString cfg.environmentFiles)}";
           ExecStart = "${cfg.package}/bin/hermes-webui";
           Restart = "on-failure";
           Environment = mappedEnvironment;

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -85,7 +85,6 @@ let
       cfg.extraEnvironment));
 
   needsWritableStateDir = cfg.stateDir != defaultStateDir;
-  writableServiceDirs = lib.optionals needsWritableStateDir [ cfg.stateDir ];
   tmpfilesRules = lib.optionals needsWritableStateDir [
     "d ${cfg.stateDir} 0700 ${cfg.user} ${cfg.group} - -"
   ];
@@ -194,7 +193,6 @@ in
           Restart = "on-failure";
           Environment = mappedEnvironment;
           EnvironmentFile = map builtins.toString cfg.environmentFiles;
-          ReadWritePaths = map builtins.toString writableServiceDirs;
           StateDirectoryMode = "0700";
           UMask = "0077";
         }
@@ -213,7 +211,6 @@ in
       ${cfg.user} = {
         isSystemUser = true;
         group = cfg.group;
-        createHome = true;
         home = cfg.stateDir;
       };
     };

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -50,8 +50,8 @@ let
   inferredAgentDir =
     if cfg.agent.package == null then
       null
-    else if (cfg.agent.package ? passthru) && (cfg.agent.package.passthru ? hermesVenv) then
-      "${cfg.agent.package.passthru.hermesVenv}/lib/python3.12/site-packages"
+    else if (cfg.agent.package ? passthru) && (cfg.agent.package.passthru ? hermesAgentDir) then
+      "${cfg.agent.package.passthru.hermesAgentDir}"
     else
       null;
 
@@ -148,7 +148,7 @@ in
       package = lib.mkOption {
         type = lib.types.nullOr lib.types.package;
         default = null;
-        description = "Package to derive HERMES_WEBUI_AGENT_DIR and HERMES_WEBUI_PYTHON from when it exposes passthru.hermesVenv.";
+        description = "Package to derive HERMES_WEBUI_AGENT_DIR from passthru.hermesAgentDir and HERMES_WEBUI_PYTHON from passthru.hermesVenv.";
       };
 
       dir = lib.mkOption {

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -15,6 +15,9 @@ let
     "HERMES_WEBUI_PYTHON"
   ];
 
+  defaultUser = "hermes-webui";
+  defaultGroup = "hermes-webui";
+
   protectedEnvironmentFileCheck = pkgs.writeShellScript "hermes-webui-protected-envfile-check" ''
     set -eu
     for env_file in "$@"; do
@@ -47,8 +50,16 @@ let
   inferredAgentDir =
     if cfg.agent.package == null then
       null
+    else if (cfg.agent.package ? passthru) && (cfg.agent.package.passthru ? hermesVenv) then
+      "${cfg.agent.package.passthru.hermesVenv}/lib/python3.12/site-packages"
     else
-      "${cfg.agent.package}/share/hermes-agent";
+      null;
+
+  configuredAgentPython =
+    if cfg.agent.python != null then
+      cfg.agent.python
+    else
+      inferredAgentPython;
 
   mappedEnvironment = (lib.mapAttrsToList
     (name: value: "${name}=${value}")
@@ -66,27 +77,18 @@ let
     // lib.optionalAttrs (cfg.agent.dir == null && inferredAgentDir != null) {
       HERMES_WEBUI_AGENT_DIR = inferredAgentDir;
     }
-    // lib.optionalAttrs (cfg.agent.dir == null && inferredAgentPython != null) {
-      HERMES_WEBUI_PYTHON = inferredAgentPython;
+    // lib.optionalAttrs (configuredAgentPython != null) {
+      HERMES_WEBUI_PYTHON = configuredAgentPython;
     }
     // lib.filterAttrs
       (name: _: !(lib.elem name protectedEnvironment))
       cfg.extraEnvironment));
 
   needsWritableStateDir = cfg.stateDir != defaultStateDir;
-  writableServiceDirs =
-    lib.optionals needsWritableStateDir [ cfg.stateDir ]
-    ++ lib.optionals (cfg.hermesHome != null) [ cfg.hermesHome ];
-
-  userspaceDirs = lib.optionals (cfg.hermesHome != null) [
-    "d ${cfg.hermesHome} 2770 ${cfg.user} ${cfg.group} - -"
+  writableServiceDirs = lib.optionals needsWritableStateDir [ cfg.stateDir ];
+  tmpfilesRules = lib.optionals needsWritableStateDir [
+    "d ${cfg.stateDir} 2770 ${cfg.user} ${cfg.group} - -"
   ];
-
-  tmpfilesRules =
-    (lib.optionals needsWritableStateDir [
-      "d ${cfg.stateDir} 2770 ${cfg.user} ${cfg.group} - -"
-    ])
-    ++ userspaceDirs;
 in
 {
   options.services.hermes-webui = {
@@ -101,19 +103,19 @@ in
 
     user = lib.mkOption {
       type = lib.types.str;
-      default = "hermes-webui";
+      default = defaultUser;
       description = "User that runs the Hermes WebUI service.";
     };
 
     group = lib.mkOption {
       type = lib.types.str;
-      default = "hermes-webui";
+      default = defaultGroup;
       description = "Group that runs the Hermes WebUI service.";
     };
 
     host = lib.mkOption {
       type = lib.types.str;
-      default = "0.0.0.0";
+      default = "127.0.0.1";
       description = "Value for HERMES_WEBUI_HOST.";
     };
 
@@ -121,6 +123,12 @@ in
       type = lib.types.port;
       default = 8787;
       description = "Value for HERMES_WEBUI_PORT.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open the configured TCP port in the NixOS firewall.";
     };
 
     stateDir = lib.mkOption {
@@ -140,13 +148,19 @@ in
       package = lib.mkOption {
         type = lib.types.nullOr lib.types.package;
         default = null;
-        description = "Package to derive HERMES_WEBUI_AGENT_DIR from when `agent.dir` is unset.";
+        description = "Package to derive HERMES_WEBUI_AGENT_DIR and HERMES_WEBUI_PYTHON from when it exposes passthru.hermesVenv.";
       };
 
       dir = lib.mkOption {
         type = lib.types.nullOr (lib.types.strMatching "^/.+");
         default = null;
         description = "Explicit path for HERMES_WEBUI_AGENT_DIR.";
+      };
+
+      python = lib.mkOption {
+        type = lib.types.nullOr (lib.types.strMatching "^/.+");
+        default = null;
+        description = "Explicit path for HERMES_WEBUI_PYTHON when the service must run with agent dependencies from a separately managed environment.";
       };
     };
 
@@ -187,13 +201,19 @@ in
         };
     };
 
-    users.groups.${cfg.group} = { };
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
 
-    users.users.${cfg.user} = {
-      isSystemUser = true;
-      group = cfg.group;
-      createHome = true;
-      home = cfg.stateDir;
+    users.groups = lib.mkIf (cfg.group == defaultGroup) {
+      ${cfg.group} = { };
+    };
+
+    users.users = lib.mkIf (cfg.user == defaultUser) {
+      ${cfg.user} = {
+        isSystemUser = true;
+        group = cfg.group;
+        createHome = true;
+        home = cfg.stateDir;
+      };
     };
 
     systemd.tmpfiles.rules = tmpfilesRules;

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -87,7 +87,7 @@ let
   needsWritableStateDir = cfg.stateDir != defaultStateDir;
   writableServiceDirs = lib.optionals needsWritableStateDir [ cfg.stateDir ];
   tmpfilesRules = lib.optionals needsWritableStateDir [
-    "d ${cfg.stateDir} 2770 ${cfg.user} ${cfg.group} - -"
+    "d ${cfg.stateDir} 0700 ${cfg.user} ${cfg.group} - -"
   ];
 in
 {
@@ -195,6 +195,8 @@ in
           Environment = mappedEnvironment;
           EnvironmentFile = map builtins.toString cfg.environmentFiles;
           ReadWritePaths = map builtins.toString writableServiceDirs;
+          StateDirectoryMode = "0700";
+          UMask = "0077";
         }
         // lib.optionalAttrs (cfg.stateDir == defaultStateDir) {
           StateDirectory = "hermes-webui";

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -113,7 +113,7 @@ in
 
     host = lib.mkOption {
       type = lib.types.str;
-      default = "127.0.0.1";
+      default = "0.0.0.0";
       description = "Value for HERMES_WEBUI_HOST.";
     };
 

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -147,7 +147,7 @@ in
       package = lib.mkOption {
         type = lib.types.nullOr lib.types.package;
         default = null;
-        description = "Package to derive HERMES_WEBUI_AGENT_DIR from passthru.hermesAgentDir and HERMES_WEBUI_PYTHON from passthru.hermesVenv.";
+        description = "Package to derive HERMES_WEBUI_PYTHON from passthru.hermesVenv and optionally HERMES_WEBUI_AGENT_DIR from passthru.hermesAgentDir.";
       };
 
       dir = lib.mkOption {

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -31,7 +31,7 @@ pkgs.stdenv.mkDerivation {
     cp -r "${./../static}" "$out/${runtimeDir}/"
 
     makeWrapper ${pythonEnv}/bin/python3 "$out/bin/hermes-webui" \
-      --add-flags "$out/${runtimeDir}/bootstrap.py --foreground --no-browser"
+      --add-flags "$out/${runtimeDir}/bootstrap.py --foreground --no-browser --skip-agent-install"
 
     runHook postInstall
   '';

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,43 @@
+{ pkgs, version ? "0.51.0" }:
+
+let
+  pythonEnv = pkgs.python3.withPackages (
+    ps: with ps; [
+      pyyaml
+      cryptography
+    ]
+  );
+
+  runtimeDir = "hermes-webui";
+in
+pkgs.stdenv.mkDerivation {
+  pname = "hermes-webui";
+  inherit version;
+
+  dontUnpack = true;
+  dontBuild = true;
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/${runtimeDir}" "$out/bin"
+
+    cp "${./../bootstrap.py}" "$out/${runtimeDir}/bootstrap.py"
+    cp "${./../server.py}" "$out/${runtimeDir}/server.py"
+    cp "${./../mcp_server.py}" "$out/${runtimeDir}/mcp_server.py"
+    cp "${./../requirements.txt}" "$out/${runtimeDir}/requirements.txt"
+    cp -r "${./../api}" "$out/${runtimeDir}/"
+    cp -r "${./../static}" "$out/${runtimeDir}/"
+
+    makeWrapper ${pythonEnv}/bin/python3 "$out/bin/hermes-webui" \
+      --add-flags "$out/${runtimeDir}/bootstrap.py --foreground --no-browser"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Hermes WebUI package";
+    mainProgram = "hermes-webui";
+  };
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -27,10 +27,11 @@ pkgs.stdenv.mkDerivation {
     cp "${./../server.py}" "$out/${runtimeDir}/server.py"
     cp "${./../mcp_server.py}" "$out/${runtimeDir}/mcp_server.py"
     cp "${./../requirements.txt}" "$out/${runtimeDir}/requirements.txt"
-    cp -r "${./../api}" "$out/${runtimeDir}/"
-    cp -r "${./../static}" "$out/${runtimeDir}/"
+    cp -r "${./../api}" "$out/${runtimeDir}/api"
+    cp -r "${./../static}" "$out/${runtimeDir}/static"
 
     makeWrapper ${pythonEnv}/bin/python3 "$out/bin/hermes-webui" \
+      --set HERMES_WEBUI_DISABLE_LOCAL_VENV 1 \
       --add-flags "$out/${runtimeDir}/bootstrap.py --foreground --no-browser --skip-agent-install"
 
     runHook postInstall

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -28,6 +28,7 @@ pkgs.stdenv.mkDerivation {
     cp "${./../mcp_server.py}" "$out/${runtimeDir}/mcp_server.py"
     cp "${./../requirements.txt}" "$out/${runtimeDir}/requirements.txt"
     cp -r "${./../api}" "$out/${runtimeDir}/api"
+    chmod u+w "$out/${runtimeDir}/api"
     cp -r "${./../static}" "$out/${runtimeDir}/static"
     printf "__version__ = '%s'\n" "$version" > "$out/${runtimeDir}/api/_version.py"
 

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,4 +1,4 @@
-{ pkgs, version ? "0.51.0" }:
+{ pkgs, version ? "unstable" }:
 
 let
   pythonEnv = pkgs.python3.withPackages (
@@ -29,6 +29,7 @@ pkgs.stdenv.mkDerivation {
     cp "${./../requirements.txt}" "$out/${runtimeDir}/requirements.txt"
     cp -r "${./../api}" "$out/${runtimeDir}/api"
     cp -r "${./../static}" "$out/${runtimeDir}/static"
+    printf "__version__ = '%s'\n" "$version" > "$out/${runtimeDir}/api/_version.py"
 
     makeWrapper ${pythonEnv}/bin/python3 "$out/bin/hermes-webui" \
       --set HERMES_WEBUI_DISABLE_LOCAL_VENV 1 \

--- a/tests/test_bootstrap_discover_agent.py
+++ b/tests/test_bootstrap_discover_agent.py
@@ -1,15 +1,16 @@
-"""Tests for `discover_agent_dir` shebang-based fallback.
+"""Tests for `discover_agent_dir` launcher and interpreter fallbacks.
 
 When the standard candidate paths (`~/.hermes/hermes-agent`, `~/hermes-agent`,
 `<webui-parent>/hermes-agent`, `HERMES_WEBUI_AGENT_DIR`) don't match, bootstrap
-should fall back to introspecting the `hermes` console-script's shebang —
-that's a reliable pointer to the install root because the installer writes the
-venv-relative interpreter path there.
+bootstrap checks the `hermes` launcher, then asks the configured Python for the
+installed `run_agent` module without importing it.
 """
 
 from __future__ import annotations
 
 import textwrap
+
+import pytest
 
 import bootstrap
 
@@ -75,6 +76,8 @@ def _isolate_discover_agent_dir(monkeypatch, tmp_path, hermes_path):
     monkeypatch.setattr(bootstrap.shutil, "which", lambda name: str(hermes_path) if name == "hermes" else None)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "no-such-hermes-home"))
     monkeypatch.delenv("HERMES_WEBUI_AGENT_DIR", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_PYTHON", raising=False)
+    monkeypatch.setattr(bootstrap, "_agent_dir_from_python", lambda _python: None)
     # Force REPO_ROOT.parent to a dir that won't accidentally contain a
     # `hermes-agent` sibling on the dev machine running these tests.
     monkeypatch.setattr(bootstrap, "REPO_ROOT", tmp_path / "isolated-repo-root")
@@ -133,6 +136,11 @@ def test_explicit_candidate_takes_precedence_over_shebang(monkeypatch, tmp_path)
     hermes = _make_hermes_cli(tmp_path, str(venv_python))
     _isolate_discover_agent_dir(monkeypatch, tmp_path, hermes)
     monkeypatch.setenv("HERMES_WEBUI_AGENT_DIR", str(explicit_install))
+    monkeypatch.setattr(
+        bootstrap,
+        "_agent_dir_from_python",
+        lambda _python: (_ for _ in ()).throw(AssertionError("Python probe must not run")),
+    )
 
     assert bootstrap.discover_agent_dir() == explicit_install.resolve()
 
@@ -189,3 +197,112 @@ def test_bash_wrapper_without_agent_target_returns_none(monkeypatch, tmp_path):
     _isolate_discover_agent_dir(monkeypatch, tmp_path, hermes)
 
     assert bootstrap.discover_agent_dir() is None
+
+
+def test_discovers_installed_agent_dir_from_configured_python(monkeypatch, tmp_path):
+    agent_dir = tmp_path / "site-packages"
+    python_exe = str(tmp_path / "venv" / "python")
+    run_agent = agent_dir / "run_agent.py"
+    agent_dir.mkdir()
+    run_agent.write_text("raise AssertionError('must not import run_agent')", encoding="utf-8")
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return bootstrap.subprocess.CompletedProcess(argv, 0, stdout=f"{run_agent}\n", stderr="")
+
+    monkeypatch.setattr(bootstrap.subprocess, "run", fake_run)
+
+    assert bootstrap._agent_dir_from_python(python_exe) == agent_dir.resolve()
+    argv, kwargs = calls[0]
+    assert argv[:2] == [python_exe, "-c"]
+    assert 'find_spec("run_agent")' in argv[2]
+    assert "import run_agent" not in argv[2]
+    assert kwargs == {"capture_output": True, "text": True}
+
+
+def test_python_probe_returns_none_when_run_agent_spec_is_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        bootstrap.subprocess,
+        "run",
+        lambda argv, **kwargs: bootstrap.subprocess.CompletedProcess(argv, 0, stdout="\n", stderr=""),
+    )
+
+    assert bootstrap._agent_dir_from_python(str(tmp_path / "python")) is None
+
+
+def test_python_probe_rejects_malformed_relative_origin(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        bootstrap.subprocess,
+        "run",
+        lambda argv, **kwargs: bootstrap.subprocess.CompletedProcess(argv, 0, stdout="run_agent.py\n", stderr=""),
+    )
+
+    assert bootstrap._agent_dir_from_python(str(tmp_path / "python")) is None
+
+
+def test_python_probe_rejects_non_file_origin(monkeypatch, tmp_path):
+    missing = tmp_path / "site-packages" / "run_agent.py"
+    monkeypatch.setattr(
+        bootstrap.subprocess,
+        "run",
+        lambda argv, **kwargs: bootstrap.subprocess.CompletedProcess(argv, 0, stdout=f"{missing}\n", stderr=""),
+    )
+
+    assert bootstrap._agent_dir_from_python(str(tmp_path / "python")) is None
+
+
+@pytest.mark.parametrize("error", [FileNotFoundError(), PermissionError()])
+def test_python_probe_returns_none_when_interpreter_cannot_start(monkeypatch, tmp_path, error):
+    monkeypatch.setattr(bootstrap.subprocess, "run", lambda *args, **kwargs: (_ for _ in ()).throw(error))
+
+    assert bootstrap._agent_dir_from_python(str(tmp_path / "python")) is None
+
+
+def test_python_probe_returns_none_on_nonzero_exit(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        bootstrap.subprocess,
+        "run",
+        lambda argv, **kwargs: bootstrap.subprocess.CompletedProcess(argv, 1, stdout="", stderr="probe failed"),
+    )
+
+    assert bootstrap._agent_dir_from_python(str(tmp_path / "python")) is None
+
+
+def test_python_probe_accepts_valid_origin_with_benign_stderr(monkeypatch, tmp_path):
+    run_agent = tmp_path / "site-packages" / "run_agent.py"
+    run_agent.parent.mkdir()
+    run_agent.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        bootstrap.subprocess,
+        "run",
+        lambda argv, **kwargs: bootstrap.subprocess.CompletedProcess(argv, 0, stdout=f"{run_agent}\n", stderr="warning\n"),
+    )
+
+    assert bootstrap._agent_dir_from_python(str(tmp_path / "python")) == run_agent.parent.resolve()
+
+
+def test_python_probe_rejects_existing_file_with_wrong_name(monkeypatch, tmp_path):
+    origin = tmp_path / "site-packages" / "agent_entry.py"
+    origin.parent.mkdir()
+    origin.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        bootstrap.subprocess,
+        "run",
+        lambda argv, **kwargs: bootstrap.subprocess.CompletedProcess(argv, 0, stdout=f"{origin}\n", stderr=""),
+    )
+
+    assert bootstrap._agent_dir_from_python(str(tmp_path / "python")) is None
+
+
+def test_hermes_cli_takes_precedence_over_configured_python(monkeypatch, tmp_path):
+    install, venv_python = _make_agent_install(tmp_path)
+    hermes = _make_hermes_cli(tmp_path, str(venv_python))
+    _isolate_discover_agent_dir(monkeypatch, tmp_path, hermes)
+    monkeypatch.setattr(
+        bootstrap,
+        "_agent_dir_from_python",
+        lambda _python: (_ for _ in ()).throw(AssertionError("Python probe must not run")),
+    )
+
+    assert bootstrap.discover_agent_dir() == install.resolve()

--- a/tests/test_bootstrap_foreground.py
+++ b/tests/test_bootstrap_foreground.py
@@ -92,6 +92,8 @@ def clean_env(monkeypatch):
         "HERMES_WEBUI_HOST",
         "HERMES_WEBUI_PORT",
         "HERMES_WEBUI_AGENT_DIR",
+        "HERMES_WEBUI_PYTHON",
+        "HERMES_WEBUI_DISABLE_LOCAL_VENV",
         "HERMES_WEBUI_STATE_DIR",
         "HERMES_WEBUI_SERVER_CWD",
         "HERMES_HOME",
@@ -531,3 +533,63 @@ class TestForegroundExecutabilityGuard:
             bs.main()
         # execv must NOT have been called when the guard fires
         assert len(execv_calls) == 0
+
+
+def test_package_python_discovers_agent_before_skip_install_gate(import_bootstrap, clean_env, monkeypatch, tmp_path):
+    bs = import_bootstrap
+    agent_dir = tmp_path / "site-packages"
+    agent_dir.mkdir()
+    (agent_dir / "run_agent.py").write_text("class AIAgent:\n    pass\n", encoding="utf-8")
+    state_dir = tmp_path / "state"
+    python_exe = sys.executable
+    execv_calls = []
+
+    monkeypatch.setenv("HERMES_WEBUI_PYTHON", python_exe)
+    monkeypatch.setenv("HERMES_WEBUI_DISABLE_LOCAL_VENV", "1")
+    monkeypatch.setenv("HERMES_WEBUI_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.setenv("PYTHONPATH", str(agent_dir))
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr(bs, "REPO_ROOT", tmp_path / "webui")
+    monkeypatch.setattr(bs.Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    monkeypatch.setattr(bs, "ensure_supported_platform", lambda: None)
+    monkeypatch.setattr(sys, "argv", ["bootstrap.py", "--foreground", "--skip-agent-install"])
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(os, "access", lambda path, mode: True)
+    monkeypatch.setattr(os, "chdir", lambda path: None)
+
+    def fake_execv(path, argv):
+        execv_calls.append((path, argv))
+        raise SystemExit(0)
+
+    monkeypatch.setattr(os, "execv", fake_execv)
+
+    with patch.object(bs, "install_hermes_agent") as mock_install, patch.object(bs.venv, "EnvBuilder") as mock_builder, pytest.raises(SystemExit):
+        bs.main()
+
+    assert execv_calls == [(python_exe, [python_exe, str(bs.REPO_ROOT / "server.py")])]
+    assert os.environ["HERMES_WEBUI_AGENT_DIR"] == str(agent_dir.resolve())
+    mock_install.assert_not_called()
+    mock_builder.assert_not_called()
+
+
+def test_package_python_without_agent_stays_fail_closed(import_bootstrap, clean_env, monkeypatch, tmp_path):
+    bs = import_bootstrap
+    python_exe = sys.executable
+
+    monkeypatch.setenv("HERMES_WEBUI_PYTHON", python_exe)
+    monkeypatch.setenv("HERMES_WEBUI_DISABLE_LOCAL_VENV", "1")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr(bs, "REPO_ROOT", tmp_path / "webui")
+    monkeypatch.setattr(bs.Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    monkeypatch.setattr(bs, "ensure_supported_platform", lambda: None)
+    monkeypatch.setattr(sys, "argv", ["bootstrap.py", "--foreground", "--skip-agent-install"])
+
+    with patch.object(bs, "_agent_dir_from_python", return_value=None) as mock_probe, patch.object(bs, "install_hermes_agent") as mock_install, patch.object(bs.venv, "EnvBuilder") as mock_builder, patch.object(os, "execv") as mock_execv, pytest.raises(RuntimeError, match="Hermes Agent was not found"):
+        bs.main()
+
+    mock_probe.assert_called_once_with(python_exe)
+    mock_install.assert_not_called()
+    mock_builder.assert_not_called()
+    mock_execv.assert_not_called()

--- a/tests/test_bootstrap_python_selection.py
+++ b/tests/test_bootstrap_python_selection.py
@@ -72,6 +72,24 @@ def test_ensure_python_fails_loudly_when_no_interpreter_can_import_agent(monkeyp
         raise AssertionError("expected RuntimeError")
 
 
+def test_packaged_launch_disables_repo_local_venv_creation(monkeypatch, tmp_path):
+    local_python = tmp_path / "webui" / ".venv" / "bin" / "python"
+    monkeypatch.setattr(bootstrap, "REPO_ROOT", tmp_path)
+    monkeypatch.setenv("HERMES_WEBUI_DISABLE_LOCAL_VENV", "1")
+    monkeypatch.setattr(bootstrap, "_python_can_run_webui_and_agent", lambda *a, **k: False)
+
+    with patch.object(bootstrap.venv, "EnvBuilder") as mock_builder:
+        try:
+            bootstrap.ensure_python_has_webui_deps(str(local_python), tmp_path / "agent")
+        except RuntimeError as exc:
+            assert "local .venv creation is disabled" in str(exc)
+            assert "HERMES_WEBUI_PYTHON" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")
+
+    mock_builder.assert_not_called()
+
+
 def test_local_venv_is_created_with_symlinks(monkeypatch, tmp_path):
     """Regression: mise/asdf macOS Pythons need symlinks=True to avoid SIGABRT.
 

--- a/tests/test_nix_flake_module_source.py
+++ b/tests/test_nix_flake_module_source.py
@@ -32,9 +32,14 @@ def test_nixos_module_decouples_agent_dir_from_python_inference():
     assert "cfg.agent.dir == null && configuredAgentPython" not in MODULE_NIX
 
 
-def test_nixos_module_uses_agent_venv_site_packages_when_available():
-    assert "${cfg.agent.package.passthru.hermesVenv}/lib/python3.12/site-packages" in MODULE_NIX
-    assert "${cfg.agent.package}/share/hermes-agent" not in MODULE_NIX
+def test_nixos_module_uses_explicit_agent_dir_passthru_when_available():
+    hardcoded_python_site_packages = "lib/" + "python3.12" + "/site-packages"
+    legacy_agent_share_dir = "${cfg.agent.package}" + "/share/" + "hermes-agent"
+
+    assert "cfg.agent.package.passthru ? hermesAgentDir" in MODULE_NIX
+    assert "${cfg.agent.package.passthru.hermesAgentDir}" in MODULE_NIX
+    assert hardcoded_python_site_packages not in MODULE_NIX
+    assert legacy_agent_share_dir not in MODULE_NIX
 
 
 def test_nixos_module_does_not_chown_existing_hermes_home():

--- a/tests/test_nix_flake_module_source.py
+++ b/tests/test_nix_flake_module_source.py
@@ -32,6 +32,7 @@ def test_nix_package_version_comes_from_flake_source_revision():
     assert "0.51.0" not in FLAKE_NIX
     assert "0.51.0" not in PACKAGES_NIX
     assert 'api/_version.py' in PACKAGES_NIX
+    assert 'chmod u+w "$out/${runtimeDir}/api"' in PACKAGES_NIX
 
 
 def test_nixos_module_decouples_agent_dir_from_python_inference():

--- a/tests/test_nix_flake_module_source.py
+++ b/tests/test_nix_flake_module_source.py
@@ -25,6 +25,15 @@ def test_nix_package_disables_store_local_venv_fallback():
     assert "--set HERMES_WEBUI_DISABLE_LOCAL_VENV 1" in PACKAGES_NIX
 
 
+def test_nix_package_version_comes_from_flake_source_revision():
+    assert 'version ? "unstable"' in PACKAGES_NIX
+    assert 'packageVersion = self.shortRev or (self.dirtyShortRev or "unstable");' in FLAKE_NIX
+    assert "version = packageVersion;" in FLAKE_NIX
+    assert "0.51.0" not in FLAKE_NIX
+    assert "0.51.0" not in PACKAGES_NIX
+    assert 'api/_version.py' in PACKAGES_NIX
+
+
 def test_nixos_module_decouples_agent_dir_from_python_inference():
     assert "agent.python" in MODULE_NIX
     assert "configuredAgentPython" in MODULE_NIX
@@ -50,6 +59,7 @@ def test_nixos_module_keeps_webui_state_private_by_default_and_custom_path():
     assert 'StateDirectoryMode = "0700";' in MODULE_NIX
     assert 'UMask = "0077";' in MODULE_NIX
     assert '"d ${cfg.stateDir} 0700 ${cfg.user} ${cfg.group} - -"' in MODULE_NIX
+    assert "ReadWritePaths" not in MODULE_NIX
     assert "2770" not in MODULE_NIX
 
 
@@ -58,6 +68,7 @@ def test_nixos_module_only_creates_default_service_identity():
     assert "cfg.user == defaultUser" in MODULE_NIX
     assert "users.groups.${cfg.group}" not in MODULE_NIX
     assert "users.users.${cfg.user}" not in MODULE_NIX
+    assert "createHome = true;" not in MODULE_NIX
 
 
 def test_nixos_module_defaults_to_loopback_with_explicit_firewall_opt_in():

--- a/tests/test_nix_flake_module_source.py
+++ b/tests/test_nix_flake_module_source.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FLAKE_NIX = (ROOT / "flake.nix").read_text(encoding="utf-8")
+PACKAGES_NIX = (ROOT / "nix" / "packages.nix").read_text(encoding="utf-8")
+MODULE_NIX = (ROOT / "nix" / "nixosModules.nix").read_text(encoding="utf-8")
+README = (ROOT / "README.md").read_text(encoding="utf-8")
+
+
+def test_nix_package_installs_runtime_directories_with_stable_names():
+    assert 'cp -r "${./../api}" "$out/${runtimeDir}/api"' in PACKAGES_NIX
+    assert 'cp -r "${./../static}" "$out/${runtimeDir}/static"' in PACKAGES_NIX
+
+
+def test_flake_check_covers_runtime_layout_and_wrapper_help():
+    assert "runtime-layout" in FLAKE_NIX
+    assert "test -d ${package}/hermes-webui/api" in FLAKE_NIX
+    assert "test -d ${package}/hermes-webui/static" in FLAKE_NIX
+    assert "${package}/bin/hermes-webui --help >/dev/null" in FLAKE_NIX
+    assert "import api.config, server" in FLAKE_NIX
+
+
+def test_nix_package_disables_store_local_venv_fallback():
+    assert "--set HERMES_WEBUI_DISABLE_LOCAL_VENV 1" in PACKAGES_NIX
+
+
+def test_nixos_module_decouples_agent_dir_from_python_inference():
+    assert "agent.python" in MODULE_NIX
+    assert "configuredAgentPython" in MODULE_NIX
+    assert "configuredAgentPython != null" in MODULE_NIX
+    assert "cfg.agent.dir == null && configuredAgentPython" not in MODULE_NIX
+
+
+def test_nixos_module_uses_agent_venv_site_packages_when_available():
+    assert "${cfg.agent.package.passthru.hermesVenv}/lib/python3.12/site-packages" in MODULE_NIX
+    assert "${cfg.agent.package}/share/hermes-agent" not in MODULE_NIX
+
+
+def test_nixos_module_does_not_chown_existing_hermes_home():
+    assert "d ${cfg.hermesHome}" not in MODULE_NIX
+
+
+def test_nixos_module_only_creates_default_service_identity():
+    assert "cfg.group == defaultGroup" in MODULE_NIX
+    assert "cfg.user == defaultUser" in MODULE_NIX
+    assert "users.groups.${cfg.group}" not in MODULE_NIX
+    assert "users.users.${cfg.user}" not in MODULE_NIX
+
+
+def test_nixos_module_defaults_to_loopback_with_explicit_firewall_opt_in():
+    nix_section = README.split("### Nix flake and NixOS module", 1)[1].split(
+        "### Remote access", 1
+    )[0]
+    assert 'default = "127.0.0.1";' in MODULE_NIX
+    assert "openFirewall" in MODULE_NIX
+    assert "networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];" in MODULE_NIX
+    assert 'host = "127.0.0.1";' in nix_section
+    assert 'Set `host = "0.0.0.0"` and `openFirewall = true`' in nix_section

--- a/tests/test_nix_flake_module_source.py
+++ b/tests/test_nix_flake_module_source.py
@@ -46,6 +46,13 @@ def test_nixos_module_does_not_chown_existing_hermes_home():
     assert "d ${cfg.hermesHome}" not in MODULE_NIX
 
 
+def test_nixos_module_keeps_webui_state_private_by_default_and_custom_path():
+    assert 'StateDirectoryMode = "0700";' in MODULE_NIX
+    assert 'UMask = "0077";' in MODULE_NIX
+    assert '"d ${cfg.stateDir} 0700 ${cfg.user} ${cfg.group} - -"' in MODULE_NIX
+    assert "2770" not in MODULE_NIX
+
+
 def test_nixos_module_only_creates_default_service_identity():
     assert "cfg.group == defaultGroup" in MODULE_NIX
     assert "cfg.user == defaultUser" in MODULE_NIX

--- a/tests/test_nix_flake_module_source.py
+++ b/tests/test_nix_flake_module_source.py
@@ -52,6 +52,19 @@ def test_nixos_module_uses_explicit_agent_dir_passthru_when_available():
     assert legacy_agent_share_dir not in MODULE_NIX
 
 
+def test_flake_checks_package_with_only_hermes_venv_metadata():
+    assert "packageOnlyAgentPackage" in FLAKE_NIX
+    assert "passthru.hermesVenv = packageOnlyAgentVenv;" in FLAKE_NIX
+    assert "HERMES_WEBUI_PYTHON=${packageOnlyAgentVenv}/bin/python3" in FLAKE_NIX
+    assert "! grep -q 'HERMES_WEBUI_AGENT_DIR=' ${packageOnlyEnvProbe}" in FLAKE_NIX
+
+
+def test_readme_wires_published_agent_flake_package():
+    assert 'hermes-agent.url = "github:NousResearch/hermes-agent";' in README
+    assert "agent.package = hermes-agent.packages.${pkgs.stdenv.hostPlatform.system}.default;" in README
+    assert 'hermesHome = "/var/lib/hermes/.hermes";' in README
+
+
 def test_nixos_module_does_not_chown_existing_hermes_home():
     assert "d ${cfg.hermesHome}" not in MODULE_NIX
 


### PR DESCRIPTION
## Thinking Path

- Issue #2422 asks for a NixOS installer path, and the accepted first slice is a flake-packaged WebUI plus a NixOS systemd module.
- Real NixOS testing exposed several package and service constraints: stable store paths, no writes into the Nix store, private service state, explicit shared-agent ownership, and compatibility with the published Hermes Agent flake package.
- The published Agent package exposes its sealed Python environment through `passthru.hermesVenv`, so WebUI can discover the installed `run_agent.py` through that interpreter while preserving the existing `HERMES_WEBUI_AGENT_DIR` runtime contract.

## What Changed

- `flake.nix` and `flake.lock`: add pinned package, app, checks, and NixOS module outputs, including runtime-layout and package-only Agent metadata checks.
- `nix/packages.nix`: installs the WebUI runtime under stable names, generates package version metadata, and wraps supervised startup without Agent self-install or local `.venv` creation.
- `bootstrap.py`: keeps packaged launches out of the read-only Nix store, derives an installed Agent module root from configured Python with `find_spec`, validates Agent imports once, and exports the discovered root for existing consumers.
- `nix/nixosModules.nix`: adds `services.hermes-webui` with loopback defaults, explicit firewall opt-in, private state, external service-account support, protected environment mappings, and Agent package, directory, and Python options.
- `README.md`: documents package usage and a complete two-flake NixOS configuration using `hermes-agent.packages.${pkgs.stdenv.hostPlatform.system}.default`, the shared `hermes` service identity, and shared `HERMES_HOME` state.
- Focused tests cover package-only Agent discovery through startup and exec, explicit discovery precedence, subprocess failures, packaged no-local-venv behavior, Nix module environment mapping, package layout, and the documented consumer configuration.

## Why It Matters

NixOS users can run Hermes WebUI with the published Hermes Agent flake package without maintaining a source checkout or guessing a Python site-packages path. The package remains declarative, WebUI state stays private, and shared Agent state keeps its existing ownership.

## Verification

The new package-only startup and probe regressions pass locally, including base-fails/head-passes coverage for the reported early startup failure. Source-level Nix contracts and diff checks pass; native Nix evaluation was unavailable on this host, and CI runs the repository test matrix.

## Upstream

Closes #2422.

Scope follows the maintainer comment at https://github.com/nesquena/hermes-webui/issues/2422#issuecomment-4471647134: flake package plus NixOS systemd module, with devShell left out of the first slice.

## Model Used

GPT-5 via Codex CLI
