### PR TITLE
fix(#5413): restore readable Mermaid sizing

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -1397,7 +1397,6 @@ function _openImgLightbox(imgEl) {
 }
 
 const _MERMAID_VIEWER_MIN_SCALE = 0.25;
-const _MERMAID_VIEWER_LIGHTBOX_MIN_SCALE = 0.1;
 const _MERMAID_VIEWER_MAX_SCALE = 8;
 const _MERMAID_VIEWER_ZOOM_STEP = 1.2;
 const _MERMAID_VIEWER_INLINE_MIN_HEIGHT = 220;
@@ -1525,8 +1524,13 @@ function _mountMermaidViewer(svgEl, options = {}) {
     };
   }
 
+  function _rawFitScale(size){
+    return Math.min(size.width / Math.max(1, box.width), size.height / Math.max(1, box.height));
+  }
+
   function _minScale(){
-    return mode === 'lightbox' ? _MERMAID_VIEWER_LIGHTBOX_MIN_SCALE : _MERMAID_VIEWER_MIN_SCALE;
+    if(mode !== 'lightbox') return _MERMAID_VIEWER_MIN_SCALE;
+    return Math.min(_MERMAID_VIEWER_MIN_SCALE, _rawFitScale(_viewportSize()));
   }
 
   function _inlineViewportHeight(){
@@ -1552,7 +1556,7 @@ function _mountMermaidViewer(svgEl, options = {}) {
 
   function _fitScale(){
     const size = _viewportSize();
-    return Math.max(_minScale(), Math.min(_MERMAID_VIEWER_MAX_SCALE, Math.min(size.width / box.width, size.height / box.height)));
+    return Math.max(_minScale(), Math.min(_MERMAID_VIEWER_MAX_SCALE, _rawFitScale(size)));
   }
 
   function _setScale(nextScale, anchorX, anchorY){

--- a/static/ui.js
+++ b/static/ui.js
@@ -1678,9 +1678,13 @@ function _mountMermaidViewer(svgEl, options = {}) {
   }
 
   if(mode === 'lightbox'){
-    state.scale = _fitScale();
-    viewport.style.width = Math.max(1, Math.round(box.width * state.scale)) + 'px';
-    viewport.style.height = Math.max(1, Math.round(box.height * state.scale)) + 'px';
+    const envelope = _viewportFallbackSize();
+    const fitScale = Math.max(_minScale(), Math.min(_MERMAID_VIEWER_MAX_SCALE, _rawFitScale(envelope)));
+    const readableHeight = Math.max(_MERMAID_VIEWER_INLINE_MIN_HEIGHT, Math.min(envelope.height, Math.round(box.height)));
+    const readableScale = Math.min(_MERMAID_VIEWER_MAX_SCALE, readableHeight / Math.max(1, box.height));
+    state.scale = Math.max(fitScale, readableScale);
+    viewport.style.width = Math.max(1, Math.round(envelope.width)) + 'px';
+    viewport.style.height = Math.max(1, Math.round(envelope.height)) + 'px';
   } else {
     const initialHeight = _inlineViewportHeight();
     const readableScale = initialHeight / Math.max(1, box.height);

--- a/static/ui.js
+++ b/static/ui.js
@@ -1529,8 +1529,8 @@ function _mountMermaidViewer(svgEl, options = {}) {
   }
 
   function _minScale(){
-    if(mode !== 'lightbox') return _MERMAID_VIEWER_MIN_SCALE;
-    return Math.min(_MERMAID_VIEWER_MIN_SCALE, _rawFitScale(_viewportSize()));
+    if(mode === 'lightbox') return Math.min(_MERMAID_VIEWER_MIN_SCALE, _rawFitScale(_viewportSize()));
+    return Math.min(_MERMAID_VIEWER_MIN_SCALE, _inlineViewportHeight() / Math.max(1, box.height));
   }
 
   function _inlineViewportHeight(){
@@ -1684,7 +1684,7 @@ function _mountMermaidViewer(svgEl, options = {}) {
   } else {
     const initialHeight = _inlineViewportHeight();
     const readableScale = initialHeight / Math.max(1, box.height);
-    state.scale = Math.max(_MERMAID_VIEWER_MIN_SCALE, Math.min(_MERMAID_VIEWER_MAX_SCALE, readableScale));
+    state.scale = Math.max(_minScale(), Math.min(_MERMAID_VIEWER_MAX_SCALE, readableScale));
     viewport.style.width = '100%';
     viewport.style.height = Math.max(1, Math.round(initialHeight)) + 'px';
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -1397,8 +1397,10 @@ function _openImgLightbox(imgEl) {
 }
 
 const _MERMAID_VIEWER_MIN_SCALE = 0.25;
+const _MERMAID_VIEWER_LIGHTBOX_MIN_SCALE = 0.1;
 const _MERMAID_VIEWER_MAX_SCALE = 8;
 const _MERMAID_VIEWER_ZOOM_STEP = 1.2;
+const _MERMAID_VIEWER_INLINE_MIN_HEIGHT = 220;
 
 function _mermaidViewerIcon(kind) {
   const icons = {
@@ -1503,14 +1505,36 @@ function _mountMermaidViewer(svgEl, options = {}) {
   };
   root._mermaidViewer = state;
 
+  function _viewportFallbackSize(){
+    const width = mode === 'lightbox' ? Math.round((window.innerWidth || box.width) * 0.9) : Math.round(window.innerWidth || box.width);
+    const height = mode === 'lightbox' ? Math.round((window.innerHeight || box.height) * 0.9) : Math.round((window.innerHeight || box.height) * 0.7);
+    return {
+      width: Math.max(1, Number.isFinite(width) ? width : 1),
+      height: Math.max(1, Number.isFinite(height) ? height : 1),
+    };
+  }
+
   function _viewportSize(){
     const rect = viewport.getBoundingClientRect ? viewport.getBoundingClientRect() : null;
-    const width = viewport.clientWidth || (rect && rect.width) || (mode === 'lightbox' ? Math.round((window.innerWidth || box.width) * 0.9) : Math.round(window.innerWidth || box.width));
-    const height = viewport.clientHeight || (rect && rect.height) || (mode === 'lightbox' ? Math.round((window.innerHeight || box.height) * 0.9) : Math.round((window.innerHeight || box.height) * 0.7));
+    const fallback = _viewportFallbackSize();
+    const width = viewport.clientWidth || (rect && rect.width) || fallback.width;
+    const height = viewport.clientHeight || (rect && rect.height) || fallback.height;
     return {
       width: Math.max(1, Number(width) || box.width || 1),
       height: Math.max(1, Number(height) || box.height || 1),
     };
+  }
+
+  function _minScale(){
+    return mode === 'lightbox' ? _MERMAID_VIEWER_LIGHTBOX_MIN_SCALE : _MERMAID_VIEWER_MIN_SCALE;
+  }
+
+  function _inlineViewportHeight(){
+    const size = _viewportSize();
+    const widthFitScale = size.width / Math.max(1, box.width);
+    const widthBasedHeight = Math.max(1, Math.round(box.height * widthFitScale));
+    const fallback = _viewportFallbackSize();
+    return Math.min(fallback.height, Math.max(_MERMAID_VIEWER_INLINE_MIN_HEIGHT, widthBasedHeight));
   }
 
   function _applyTransform(){
@@ -1528,11 +1552,11 @@ function _mountMermaidViewer(svgEl, options = {}) {
 
   function _fitScale(){
     const size = _viewportSize();
-    return Math.max(_MERMAID_VIEWER_MIN_SCALE, Math.min(_MERMAID_VIEWER_MAX_SCALE, Math.min(size.width / box.width, size.height / box.height)));
+    return Math.max(_minScale(), Math.min(_MERMAID_VIEWER_MAX_SCALE, Math.min(size.width / box.width, size.height / box.height)));
   }
 
   function _setScale(nextScale, anchorX, anchorY){
-    const bounded = Math.max(_MERMAID_VIEWER_MIN_SCALE, Math.min(_MERMAID_VIEWER_MAX_SCALE, nextScale));
+    const bounded = Math.max(_minScale(), Math.min(_MERMAID_VIEWER_MAX_SCALE, nextScale));
     if(!Number.isFinite(bounded) || !box.width || !box.height) return;
     const focusX = Number.isFinite(anchorX) ? anchorX : _viewportSize().width / 2;
     const focusY = Number.isFinite(anchorY) ? anchorY : _viewportSize().height / 2;
@@ -1643,22 +1667,25 @@ function _mountMermaidViewer(svgEl, options = {}) {
   toolbar.appendChild(_createMermaidViewerButton('Zoom in', 'zoomIn', _zoomIn));
   toolbar.appendChild(_createMermaidViewerButton('Zoom out', 'zoomOut', _zoomOut));
   toolbar.appendChild(_createMermaidViewerButton('Reset view', 'reset', _resetViewer));
-  toolbar.appendChild(_createMermaidViewerButton('Fit to screen', 'fit', _fitViewer));
-  if(mode === 'inline'){
+  if(mode === 'lightbox'){
+    toolbar.appendChild(_createMermaidViewerButton('Fit to screen', 'fit', _fitViewer));
+  } else {
     toolbar.appendChild(_createMermaidViewerButton('Fullscreen', 'fullscreen', openLightbox));
   }
 
-  const initialFit = _fitScale();
-  state.scale = initialFit;
-  _centerForScale(initialFit);
-  _applyTransform();
   if(mode === 'lightbox'){
-    viewport.style.width = Math.max(1, Math.round(box.width * initialFit)) + 'px';
-    viewport.style.height = Math.max(1, Math.round(box.height * initialFit)) + 'px';
+    state.scale = _fitScale();
+    viewport.style.width = Math.max(1, Math.round(box.width * state.scale)) + 'px';
+    viewport.style.height = Math.max(1, Math.round(box.height * state.scale)) + 'px';
   } else {
+    const initialHeight = _inlineViewportHeight();
+    const readableScale = initialHeight / Math.max(1, box.height);
+    state.scale = Math.max(_MERMAID_VIEWER_MIN_SCALE, Math.min(_MERMAID_VIEWER_MAX_SCALE, readableScale));
     viewport.style.width = '100%';
-    viewport.style.height = Math.max(1, Math.round(box.height * initialFit)) + 'px';
+    viewport.style.height = Math.max(1, Math.round(initialHeight)) + 'px';
   }
+  _centerForScale(state.scale);
+  _applyTransform();
 
   return root;
 }

--- a/tests/test_issue4814_mermaid_toolbar.py
+++ b/tests/test_issue4814_mermaid_toolbar.py
@@ -397,7 +397,7 @@ def test_lightbox_mode_uses_same_viewer_helper_without_fullscreen(_driver_path):
 def test_lightbox_wide_diagram_fits_modal_envelope(_driver_path):
     result = _run_node(_driver_path, {
         "scenario": "wide-lightbox",
-        "width": 2400,
+        "width": 4000,
         "height": 320,
         "viewportWidth": 360,
         "viewportHeight": 640,
@@ -408,4 +408,4 @@ def test_lightbox_wide_diagram_fits_modal_envelope(_driver_path):
     assert _px(result["viewportWidth"]) <= 324
     assert _px(result["viewportWidth"]) > 0
     assert _px(result["viewportHeight"]) > 0
-    assert result["scale"] < 0.25
+    assert result["scale"] < 0.1

--- a/tests/test_issue4814_mermaid_toolbar.py
+++ b/tests/test_issue4814_mermaid_toolbar.py
@@ -239,10 +239,17 @@ function runScenario(payload) {
     lightboxState.viewport.clientWidth = payload.viewportWidth || 960;
     lightboxState.viewport.clientHeight = payload.viewportHeight || 540;
     lightboxState.viewport.getBoundingClientRect = () => ({left: 0, top: 0, width: lightboxState.viewport.clientWidth, height: lightboxState.viewport.clientHeight});
+    const initialScale = lightboxState.scale;
+    const initialViewportWidth = lightboxState.viewport.style.width;
+    const initialViewportHeight = lightboxState.viewport.style.height;
+    lightboxState.fit();
     return {
-      scale: lightboxState.scale,
-      viewportWidth: lightboxState.viewport.style.width,
-      viewportHeight: lightboxState.viewport.style.height,
+      initialScale,
+      fitScale: lightboxState.scale,
+      initialViewportWidth,
+      initialViewportHeight,
+      viewportWidthAfterFit: lightboxState.viewport.style.width,
+      viewportHeightAfterFit: lightboxState.viewport.style.height,
       lightboxLabels: labelsFromToolbar(lightbox),
       mode: lightboxState.mode,
     };
@@ -421,7 +428,11 @@ def test_lightbox_wide_diagram_fits_modal_envelope(_driver_path):
 
     assert result["mode"] == "lightbox"
     expected_max_width = int(360 * 0.9)
-    assert _px(result["viewportWidth"]) <= expected_max_width
-    assert _px(result["viewportWidth"]) > 0
-    assert _px(result["viewportHeight"]) > 0
-    assert result["scale"] < 0.1
+    expected_max_height = int(640 * 0.9)
+    assert _px(result["initialViewportWidth"]) == expected_max_width
+    assert _px(result["initialViewportHeight"]) == expected_max_height
+    assert result["initialScale"] > result["fitScale"]
+    assert result["initialScale"] > 0.25
+    assert result["fitScale"] < 0.1
+    assert _px(result["viewportWidthAfterFit"]) == expected_max_width
+    assert _px(result["viewportHeightAfterFit"]) == expected_max_height

--- a/tests/test_issue4814_mermaid_toolbar.py
+++ b/tests/test_issue4814_mermaid_toolbar.py
@@ -169,6 +169,13 @@ function labelsFromToolbar(viewer) {
 }
 
 function runScenario(payload) {
+  if (Number.isFinite(payload.viewportWidth)) {
+    window.innerWidth = payload.viewportWidth;
+  }
+  if (Number.isFinite(payload.viewportHeight)) {
+    window.innerHeight = payload.viewportHeight;
+  }
+
   const svg = makeSvg(payload.width || 480, payload.height || 320);
   const host = makeHost(svg);
   const viewer = _mountMermaidViewer(svg, payload.options || {});
@@ -215,6 +222,30 @@ function runScenario(payload) {
     state.viewport.onwheel({deltaY: -3, deltaMode: 1, clientX: 240, clientY: 160, preventDefault() {}});
     const afterLineWheel = {scale: state.scale, x: state.x, y: state.y};
     return {fitScale, zoomInScale, zoomOutScale, maxScale, reset, beforeWheel, afterWheel, beforeLineWheel, afterLineWheel};
+  }
+
+  if (payload.scenario === 'wide-inline') {
+    return {
+      scale: state.scale,
+      viewportWidth: state.viewport.style.width,
+      viewportHeight: state.viewport.style.height,
+    };
+  }
+
+  if (payload.scenario === 'wide-lightbox') {
+    const lightboxSvg = makeSvg(payload.width || 480, payload.height || 320);
+    const lightbox = _mountMermaidViewer(lightboxSvg, {mode:'lightbox'});
+    const lightboxState = lightbox._mermaidViewer;
+    lightboxState.viewport.clientWidth = payload.viewportWidth || 960;
+    lightboxState.viewport.clientHeight = payload.viewportHeight || 540;
+    lightboxState.viewport.getBoundingClientRect = () => ({left: 0, top: 0, width: lightboxState.viewport.clientWidth, height: lightboxState.viewport.clientHeight});
+    return {
+      scale: lightboxState.scale,
+      viewportWidth: lightboxState.viewport.style.width,
+      viewportHeight: lightboxState.viewport.style.height,
+      lightboxLabels: labelsFromToolbar(lightbox),
+      mode: lightboxState.mode,
+    };
   }
 
   if (payload.scenario === 'drag') {
@@ -288,6 +319,10 @@ def _run_node(driver_path: str, payload: dict) -> dict:
     return json.loads(result.stdout)
 
 
+def _px(value) -> int:
+    return int(float(str(value).rstrip("px")))
+
+
 @pytest.fixture(scope="module")
 def _driver_path(tmp_path_factory):
     path = tmp_path_factory.mktemp("mermaid_toolbar_driver") / "driver.js"
@@ -305,10 +340,25 @@ def test_inline_viewer_mounts_toolbar_and_shell(_driver_path):
     })
 
     assert result["className"] == "mermaid-viewer mermaid-viewer--inline"
-    assert result["labels"] == ["Zoom in", "Zoom out", "Reset view", "Fit to screen", "Fullscreen"]
+    assert result["labels"] == ["Zoom in", "Zoom out", "Reset view", "Fullscreen"]
     assert result["canvasWidth"] == "480px"
     assert result["viewportWidth"] == "100%"
     assert result["hasInlineFullscreen"] is True
+
+
+def test_inline_wide_diagram_reads_readable_height_on_mobile(_driver_path):
+    result = _run_node(_driver_path, {
+        "scenario": "wide-inline",
+        "width": 2400,
+        "height": 320,
+        "viewportWidth": 360,
+        "viewportHeight": 640,
+        "options": {"mode": "inline"},
+    })
+
+    assert _px(result["viewportHeight"]) >= 220
+    assert result["scale"] > 0.25
+    assert result["scale"] < 1.0
 
 
 def test_zoom_fit_reset_and_wheel_update_state(_driver_path):
@@ -338,7 +388,24 @@ def test_drag_suppresses_accidental_lightbox_open(_driver_path):
 def test_lightbox_mode_uses_same_viewer_helper_without_fullscreen(_driver_path):
     result = _run_node(_driver_path, {"scenario": "fullscreen", "options": {"mode": "inline"}})
 
-    assert result["inlineLabels"] == ["Zoom in", "Zoom out", "Reset view", "Fit to screen", "Fullscreen"]
+    assert result["inlineLabels"] == ["Zoom in", "Zoom out", "Reset view", "Fullscreen"]
     assert result["lightboxLabels"] == ["Zoom in", "Zoom out", "Reset view", "Fit to screen"]
     assert result["opens"] == ["inline-lightbox"]
     assert result["lightboxClassName"] == "mermaid-viewer mermaid-viewer--lightbox"
+
+
+def test_lightbox_wide_diagram_fits_modal_envelope(_driver_path):
+    result = _run_node(_driver_path, {
+        "scenario": "wide-lightbox",
+        "width": 2400,
+        "height": 320,
+        "viewportWidth": 360,
+        "viewportHeight": 640,
+        "options": {"mode": "inline"},
+    })
+
+    assert result["mode"] == "lightbox"
+    assert _px(result["viewportWidth"]) <= 324
+    assert _px(result["viewportWidth"]) > 0
+    assert _px(result["viewportHeight"]) > 0
+    assert result["scale"] < 0.25

--- a/tests/test_issue4814_mermaid_toolbar.py
+++ b/tests/test_issue4814_mermaid_toolbar.py
@@ -361,6 +361,21 @@ def test_inline_wide_diagram_reads_readable_height_on_mobile(_driver_path):
     assert result["scale"] < 1.0
 
 
+def test_inline_tall_diagram_respects_viewport_cap_without_overflow_mismatch(_driver_path):
+    result = _run_node(_driver_path, {
+        "scenario": "wide-inline",
+        "width": 400,
+        "height": 2400,
+        "viewportWidth": 360,
+        "viewportHeight": 640,
+        "options": {"mode": "inline"},
+    })
+
+    assert _px(result["viewportHeight"]) == 448
+    assert result["scale"] < 0.25
+    assert _px(result["viewportHeight"]) == round(2400 * result["scale"])
+
+
 def test_zoom_fit_reset_and_wheel_update_state(_driver_path):
     result = _run_node(_driver_path, {"scenario": "zoom", "options": {"mode": "inline"}})
 
@@ -405,7 +420,8 @@ def test_lightbox_wide_diagram_fits_modal_envelope(_driver_path):
     })
 
     assert result["mode"] == "lightbox"
-    assert _px(result["viewportWidth"]) <= 324
+    expected_max_width = int(360 * 0.9)
+    assert _px(result["viewportWidth"]) <= expected_max_width
     assert _px(result["viewportWidth"]) > 0
     assert _px(result["viewportHeight"]) > 0
     assert result["scale"] < 0.1


### PR DESCRIPTION
## Thinking Path

- Mermaid diagrams regressed when the interactive viewer started deriving inline viewport height from the same fit scale it uses to shrink wide diagrams to width.
- That collapse gets worse on mobile, and the lightbox inherits the same helper path, so the readable fix belongs inside the existing browser-side Mermaid viewer instead of in a new renderer or backend path.
- Inline mode only needs one clear modal-opening affordance, so the fix keeps fullscreen inline, keeps fit in the lightbox, and proves the geometry change with the existing Node harness.

## What Changed

- `static/ui.js`: splits Mermaid inline readable sizing from modal fit sizing, keeps the viewer interaction model intact, and removes the inline `Fit to screen` control while keeping fullscreen inline.
- `tests/test_issue4814_mermaid_toolbar.py`: adds wide-diagram mobile regressions for inline and lightbox geometry, and updates the toolbar expectations to match the simplified inline control set.

## Why It Matters

Wide Mermaid diagrams stay readable instead of collapsing into a tiny strip, and opening fullscreen produces a usable modal fit on mobile-sized viewports. The toolbar also stops presenting two adjacent controls that look like the same fullscreen action.

## Verification

```text
pytest tests/test_issue4814_mermaid_toolbar.py -v --timeout=60
pytest tests/test_issue4075_mermaid_lightbox.py -v --timeout=60
npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5413.
Follows the maintainer merge-bot diagnosis in https://github.com/nesquena/hermes-webui/issues/5413#issuecomment-4868484442.

## Model Used

GPT 5.5 via Codex CLI
