### PR TITLE
fix(#5430): harden ElevenLabs TTS transport guards

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -16670,13 +16670,18 @@ def _handle_tts(handler, parsed):
             "voice_settings": {"stability": 0.5, "similarity_boost": 0.75},
         }).encode("utf-8")
 
-        from urllib.request import Request, urlopen as _urlopen
-
+        from urllib.request import Request, build_opener
         req = Request(url, data=req_body, headers={
             "xi-api-key": api_key,
             "Content-Type": "application/json",
             "Accept": "audio/mpeg",
         })
+
+        class _NoRedirectElevenlabsHandler(HTTPRedirectHandler):
+            """Refuse to follow redirects on the ElevenLabs call."""
+
+            def redirect_request(self, req, fp, code, msg, headers, newurl):
+                raise ValueError("ElevenLabs TTS upstream attempted a redirect")
 
         # Buffer the full response before sending first byte.
         # The streaming endpoint is designed for chunked delivery, but urllib's
@@ -16684,7 +16689,7 @@ def _handle_tts(handler, parsed):
         # payloads. A hard cap keeps the buffered path bounded even if the
         # upstream misbehaves.
         try:
-            with _urlopen(req, timeout=30) as resp:
+            with _tts_open(req, timeout=30, opener_factory=lambda: build_opener(ProxyHandler({}), _NoRedirectElevenlabsHandler())) as resp:
                 audio_data = _buffer_tts_audio_response(resp)
         except ValueError:
             logger.warning("ElevenLabs TTS rejected an invalid upstream response", exc_info=True)

--- a/api/routes.py
+++ b/api/routes.py
@@ -16670,18 +16670,11 @@ def _handle_tts(handler, parsed):
             "voice_settings": {"stability": 0.5, "similarity_boost": 0.75},
         }).encode("utf-8")
 
-        from urllib.request import Request, build_opener
         req = Request(url, data=req_body, headers={
             "xi-api-key": api_key,
             "Content-Type": "application/json",
             "Accept": "audio/mpeg",
         })
-
-        class _NoRedirectElevenlabsHandler(HTTPRedirectHandler):
-            """Refuse to follow redirects on the ElevenLabs call."""
-
-            def redirect_request(self, req, fp, code, msg, headers, newurl):
-                raise ValueError("ElevenLabs TTS upstream attempted a redirect")
 
         # Buffer the full response before sending first byte.
         # The streaming endpoint is designed for chunked delivery, but urllib's
@@ -16689,7 +16682,7 @@ def _handle_tts(handler, parsed):
         # payloads. A hard cap keeps the buffered path bounded even if the
         # upstream misbehaves.
         try:
-            with _tts_open(req, timeout=30, opener_factory=lambda: build_opener(ProxyHandler({}), _NoRedirectElevenlabsHandler())) as resp:
+            with _tts_open(req, timeout=30, opener_factory=lambda: build_opener(ProxyHandler({}), _NoRedirectTtsHandler())) as resp:
                 audio_data = _buffer_tts_audio_response(resp)
         except ValueError:
             logger.warning("ElevenLabs TTS rejected an invalid upstream response", exc_info=True)
@@ -16759,7 +16752,6 @@ def _handle_tts(handler, parsed):
             "voice": oai_voice,
         }).encode("utf-8")
 
-        from urllib.request import Request, build_opener, urlopen as _urlopen
         req = Request(url, data=req_body, headers={
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",

--- a/tests/test_issue3510_elevenlabs_tts.py
+++ b/tests/test_issue3510_elevenlabs_tts.py
@@ -1,7 +1,7 @@
 """Coverage for the ElevenLabs TTS engine on the /api/ttt endpoint (#3510).
 
 Exercises the engine routing + guard rails of _handle_tts's elevenlabs branch
-in-process via a fake handler. The happy path mocks urllib.urlopen so no real
+in-process via a fake handler. The happy path mocks routes._tts_open so no real
 ElevenLabs network call is made; the rejection paths (missing key, bad config
 voice_id) bail before any network call.
 """
@@ -105,16 +105,14 @@ def test_elevenlabs_happy_path_streams_mp3(monkeypatch):
         def __exit__(self, *a):
             return False
 
-    def _fake_urlopen(req, timeout=30):
+    def _fake_tts_open(req, timeout=30, opener_factory=None, **_kw):
         captured["url"] = req.full_url
         captured["xi_api_key"] = req.get_header("Xi-api-key")
         captured["body"] = json.loads(req.data.decode("utf-8"))
         return _Resp()
 
-    # The branch does `from urllib.request import ... urlopen as _urlopen` at
-    # call time, so patching the source module is what takes effect.
-    import urllib.request as _ur
-    monkeypatch.setattr(_ur, "urlopen", _fake_urlopen)
+    # The ElevenLabs branch now routes through `_tts_open`.
+    monkeypatch.setattr(routes, "_tts_open", _fake_tts_open)
 
     h = _post({"text": "hello world", "engine": "elevenlabs"}, client="9.9.9.3")
     routes._handle_tts(h, None)
@@ -131,6 +129,11 @@ def test_elevenlabs_happy_path_streams_mp3(monkeypatch):
 def test_elevenlabs_overlong_text_rejected_before_engine(monkeypatch):
     """The shared 5000-char cap applies to the elevenlabs engine too (no call)."""
     monkeypatch.setenv("ELEVENLABS_API_KEY", "sk-test")
+
+    def _fail_if_called(*_args, **_kwargs):
+        raise AssertionError("ElevenLabs upstream called")
+
+    monkeypatch.setattr(routes, "_tts_open", _fail_if_called)
     h = _post({"text": "x" * 5001, "engine": "elevenlabs"}, client="9.9.9.4")
     routes._handle_tts(h, None)
     assert h.status == 400
@@ -158,15 +161,117 @@ def test_elevenlabs_rejects_oversized_upstream_audio(monkeypatch):
         def __exit__(self, *a):
             return False
 
-    def _fake_urlopen(req, timeout=30):
+    def _fake_tts_open(req, timeout=30, opener_factory=None, **_kw):
         return _Resp()
 
-    import urllib.request as _ur
     monkeypatch.setattr(routes, "_TTS_PROXY_MAX_BYTES", 4)
-    monkeypatch.setattr(_ur, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(routes, "_tts_open", _fake_tts_open)
 
     h = _post({"text": "hello world", "engine": "elevenlabs"}, client="9.9.9.5")
     routes._handle_tts(h, None)
 
     assert h.status == 502
     assert "ElevenLabs TTS generation failed" in (h.payload() or {}).get("error", "")
+
+
+def test_elevenlabs_tts_does_not_follow_upstream_redirect(monkeypatch):
+    # Regression proof: a fake redirect response should fail at _tts_open, not be followed.
+    import urllib.request as _ur
+    from urllib.request import HTTPRedirectHandler
+
+    class _Resp:
+        def __init__(self):
+            self._chunks = [b"ID3fakeaudio", b""]
+            self._i = 0
+        def info(self):
+            return {}
+        def read(self, n=-1):
+            c = self._chunks[self._i] if self._i < len(self._chunks) else b""
+            self._i += 1
+            return c
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    def _fake_urlopen(req, timeout=30):
+        return _Resp()
+
+    def _fake_tts_open(req, timeout=30, opener_factory=None, **_kw):
+        assert opener_factory is not None
+        opener = opener_factory()
+        redirect_handler = next(
+            (handler for handler in opener.handlers if isinstance(handler, HTTPRedirectHandler)),
+            None,
+        )
+        assert redirect_handler is not None
+        with pytest.raises(ValueError):
+            redirect_handler.redirect_request(
+                req,
+                None,
+                302,
+                "Found",
+                {"Location": "http://169.254.169.254/latest/meta-data"},
+                "http://169.254.169.254/latest/meta-data",
+            )
+        raise ValueError("redirect blocked 302")
+
+    # Keep the legacy path patched as fake audio to keep base and head checks
+    # behaviorally distinct.
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "sk-test")
+    import api.config as _cfg
+    monkeypatch.setattr(_cfg, "get_config", lambda: {"tts": {"elevenlabs": {"voice_id": "pNInz6obpgDQGcFmaJgB", "model": "eleven_multilingual_v2"}}})
+    monkeypatch.setattr(_ur, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(routes, "_tts_open", _fake_tts_open)
+    h = _post({"text": "hello world", "engine": "elevenlabs"}, client="9.9.9.6")
+    routes._handle_tts(h, None)
+
+    assert h.status == 502
+    assert "ElevenLabs TTS generation failed" in (h.payload() or {}).get("error", "")
+
+
+def test_elevenlabs_tts_uses_no_proxy_opener(monkeypatch):
+    captured = {}
+
+    class _Resp:
+        def __init__(self):
+            self.headers = {"Content-Type": "audio/mpeg"}
+            self._chunks = [b"ID3fakeaudio", b""]
+            self._i = 0
+        def read(self, n=-1):
+            c = self._chunks[self._i] if self._i < len(self._chunks) else b""
+            self._i += 1
+            return c
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    def _fake_tts_open(req, timeout=30, opener_factory=None, **_kw):
+        captured["opener_factory"] = opener_factory
+        opener = opener_factory()
+        captured["opener_handlers"] = opener.handlers
+        return _Resp()
+
+    from urllib.request import HTTPRedirectHandler
+
+    original_proxy_handler = routes.ProxyHandler
+
+    def _spy_proxy_handler(proxies=None, **_kw):
+        captured["proxy_init_kwargs"] = {"proxies": proxies}
+        return original_proxy_handler(proxies)
+
+    monkeypatch.setattr(routes, "ProxyHandler", _spy_proxy_handler)
+
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "sk-test")
+    import api.config as _cfg
+    monkeypatch.setattr(_cfg, "get_config", lambda: {"tts": {"elevenlabs": {"voice_id": "pNInz6obpgDQGcFmaJgB", "model": "eleven_multilingual_v2"}}})
+    monkeypatch.setattr(routes, "_tts_open", _fake_tts_open)
+
+    h = _post({"text": "hello world", "engine": "elevenlabs"}, client="9.9.9.7")
+    routes._handle_tts(h, None)
+
+    assert h.status == 200
+    assert h.wfile.getvalue() == b"ID3fakeaudio"
+    assert captured["proxy_init_kwargs"] == {"proxies": {}}
+    assert any(isinstance(handler, HTTPRedirectHandler) for handler in captured["opener_handlers"])

--- a/tests/test_issue3510_elevenlabs_tts.py
+++ b/tests/test_issue3510_elevenlabs_tts.py
@@ -232,6 +232,7 @@ def test_elevenlabs_tts_does_not_follow_upstream_redirect(monkeypatch):
 
 def test_elevenlabs_tts_uses_no_proxy_opener(monkeypatch):
     captured = {}
+    import urllib.request as _ur
 
     class _Resp:
         def __init__(self):
@@ -246,6 +247,9 @@ def test_elevenlabs_tts_uses_no_proxy_opener(monkeypatch):
             return self
         def __exit__(self, *a):
             return False
+
+    def _fake_urlopen(req, timeout=30):
+        return _Resp()
 
     def _fake_tts_open(req, timeout=30, opener_factory=None, **_kw):
         captured["opener_factory"] = opener_factory
@@ -266,6 +270,7 @@ def test_elevenlabs_tts_uses_no_proxy_opener(monkeypatch):
     monkeypatch.setenv("ELEVENLABS_API_KEY", "sk-test")
     import api.config as _cfg
     monkeypatch.setattr(_cfg, "get_config", lambda: {"tts": {"elevenlabs": {"voice_id": "pNInz6obpgDQGcFmaJgB", "model": "eleven_multilingual_v2"}}})
+    monkeypatch.setattr(_ur, "urlopen", _fake_urlopen)
     monkeypatch.setattr(routes, "_tts_open", _fake_tts_open)
 
     h = _post({"text": "hello world", "engine": "elevenlabs"}, client="9.9.9.7")

--- a/tests/test_issue3510_elevenlabs_tts.py
+++ b/tests/test_issue3510_elevenlabs_tts.py
@@ -176,7 +176,6 @@ def test_elevenlabs_rejects_oversized_upstream_audio(monkeypatch):
 
 def test_elevenlabs_tts_does_not_follow_upstream_redirect(monkeypatch):
     # Regression proof: a fake redirect response should fail at _tts_open, not be followed.
-    import urllib.request as _ur
     from urllib.request import HTTPRedirectHandler
 
     class _Resp:
@@ -193,9 +192,6 @@ def test_elevenlabs_tts_does_not_follow_upstream_redirect(monkeypatch):
             return self
         def __exit__(self, *a):
             return False
-
-    def _fake_urlopen(req, timeout=30):
-        return _Resp()
 
     def _fake_tts_open(req, timeout=30, opener_factory=None, **_kw):
         assert opener_factory is not None
@@ -216,12 +212,9 @@ def test_elevenlabs_tts_does_not_follow_upstream_redirect(monkeypatch):
             )
         raise ValueError("redirect blocked 302")
 
-    # Keep the legacy path patched as fake audio to keep base and head checks
-    # behaviorally distinct.
     monkeypatch.setenv("ELEVENLABS_API_KEY", "sk-test")
     import api.config as _cfg
     monkeypatch.setattr(_cfg, "get_config", lambda: {"tts": {"elevenlabs": {"voice_id": "pNInz6obpgDQGcFmaJgB", "model": "eleven_multilingual_v2"}}})
-    monkeypatch.setattr(_ur, "urlopen", _fake_urlopen)
     monkeypatch.setattr(routes, "_tts_open", _fake_tts_open)
     h = _post({"text": "hello world", "engine": "elevenlabs"}, client="9.9.9.6")
     routes._handle_tts(h, None)
@@ -232,7 +225,6 @@ def test_elevenlabs_tts_does_not_follow_upstream_redirect(monkeypatch):
 
 def test_elevenlabs_tts_uses_no_proxy_opener(monkeypatch):
     captured = {}
-    import urllib.request as _ur
 
     class _Resp:
         def __init__(self):
@@ -247,9 +239,6 @@ def test_elevenlabs_tts_uses_no_proxy_opener(monkeypatch):
             return self
         def __exit__(self, *a):
             return False
-
-    def _fake_urlopen(req, timeout=30):
-        return _Resp()
 
     def _fake_tts_open(req, timeout=30, opener_factory=None, **_kw):
         captured["opener_factory"] = opener_factory
@@ -270,7 +259,6 @@ def test_elevenlabs_tts_uses_no_proxy_opener(monkeypatch):
     monkeypatch.setenv("ELEVENLABS_API_KEY", "sk-test")
     import api.config as _cfg
     monkeypatch.setattr(_cfg, "get_config", lambda: {"tts": {"elevenlabs": {"voice_id": "pNInz6obpgDQGcFmaJgB", "model": "eleven_multilingual_v2"}}})
-    monkeypatch.setattr(_ur, "urlopen", _fake_urlopen)
     monkeypatch.setattr(routes, "_tts_open", _fake_tts_open)
 
     h = _post({"text": "hello world", "engine": "elevenlabs"}, client="9.9.9.7")


### PR DESCRIPTION
## Thinking Path

- ElevenLabs TTS still builds a keyed upstream request with `xi-api-key`, then sends it through urllib's default opener.
- That default transport can follow redirects or honor ambient proxy settings, which can move a keyed request outside the intended ElevenLabs host path.
- The fix keeps the patch local to ElevenLabs, reuses the existing `_tts_open` seam, and adds focused regression coverage for redirect blocking, no-proxy opener construction, and the existing happy-path behavior.

## What Changed

- `api/routes.py`: routes ElevenLabs TTS through `_tts_open` with a no-redirect handler and `ProxyHandler({})` instead of inline `urlopen`, while preserving the existing request headers and response handling.
- `tests/test_issue3510_elevenlabs_tts.py`: updates ElevenLabs tests to patch the `_tts_open` seam and adds focused regression coverage for redirect blocking and no-proxy opener construction.

## Why It Matters

An upstream redirect or proxy configuration should not be able to carry `xi-api-key` outside the intended ElevenLabs endpoint. This change hardens the ElevenLabs transport path without changing ordinary audio generation behavior.

## Verification

- `pytest tests/test_issue3510_elevenlabs_tts.py -v --timeout=60`

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5430.

Follow-up to the security review on https://github.com/nesquena/hermes-webui/pull/5407, which flagged the ElevenLabs branch separately from the OpenAI-specific fix.

## Model Used

GPT 5.5 via Codex CLI
