### PR TITLE
fix(#5413): fit fullscreen Mermaid diagrams to the lightbox

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -1592,6 +1592,7 @@ function _mountMermaidViewer(svgEl, options = {}) {
 
   function _fitViewer(){
     const nextScale = _fitScale();
+    state.fitScale = nextScale;
     state.scale = nextScale;
     _centerForScale(nextScale);
     _applyTransform();
@@ -1599,11 +1600,20 @@ function _mountMermaidViewer(svgEl, options = {}) {
 
   function _resizeToEnvelope(){
     if(mode !== 'lightbox') return;
+    const hadFitScale = Number.isFinite(state.fitScale);
+    const previousFitScale = hadFitScale ? state.fitScale : _fitScale();
+    const wasAtFit = !hadFitScale || Math.abs(state.scale - previousFitScale) < 1e-9;
     const envelope = _lightboxViewportEnvelope();
     viewport.style.width = Math.max(1, Math.round(envelope.width)) + 'px';
     viewport.style.height = Math.max(1, Math.round(envelope.height)) + 'px';
-    state.scale = _fitScale();
-    _centerForScale(state.scale);
+    const nextFitScale = _fitScale();
+    state.fitScale = nextFitScale;
+    if(wasAtFit){
+      state.scale = nextFitScale;
+      _centerForScale(state.scale);
+    } else {
+      state.scale = Math.max(_minScale(), Math.min(_MERMAID_VIEWER_MAX_SCALE, state.scale));
+    }
     _applyTransform();
   }
 
@@ -1764,7 +1774,13 @@ function _openMermaidLightbox(svgEl) {
   clone.removeAttribute('height');
   const viewer = _mountMermaidViewer(clone, {mode:'lightbox'});
   if(viewer && viewer._mermaidViewer && typeof viewer._mermaidViewer.resizeToEnvelope === 'function'){
-    lb._mermaidResizeHandler = () => viewer._mermaidViewer.resizeToEnvelope();
+    lb._mermaidResizeHandler = () => {
+      if(lb._mermaidResizeTimer && typeof clearTimeout === 'function') clearTimeout(lb._mermaidResizeTimer);
+      lb._mermaidResizeTimer = setTimeout(() => {
+        lb._mermaidResizeTimer = null;
+        viewer._mermaidViewer.resizeToEnvelope();
+      }, 120);
+    };
     if(window && typeof window.addEventListener === 'function'){
       window.addEventListener('resize', lb._mermaidResizeHandler);
     }
@@ -1855,6 +1871,10 @@ function _closeImgLightbox(lb) {
   document.removeEventListener('keydown', lb._keyHandler);
   if(lb._mermaidResizeHandler && window && typeof window.removeEventListener === 'function'){
     window.removeEventListener('resize', lb._mermaidResizeHandler);
+  }
+  if(lb._mermaidResizeTimer && typeof clearTimeout === 'function'){
+    clearTimeout(lb._mermaidResizeTimer);
+    lb._mermaidResizeTimer = null;
   }
   lb.style.animation = 'lb-in .12s ease reverse';
   setTimeout(() => lb.parentNode && lb.parentNode.removeChild(lb), 120);

--- a/static/ui.js
+++ b/static/ui.js
@@ -1504,9 +1504,19 @@ function _mountMermaidViewer(svgEl, options = {}) {
   };
   root._mermaidViewer = state;
 
+  function _lightboxViewportEnvelope() {
+    const width = Math.round((window.innerWidth || box.width) * 0.9);
+    const height = Math.round((window.innerHeight || box.height) * 0.9);
+    return {
+      width: Math.max(1, Number.isFinite(width) ? width : 1),
+      height: Math.max(1, Number.isFinite(height) ? height : 1),
+    };
+  }
+
   function _viewportFallbackSize(){
-    const width = mode === 'lightbox' ? Math.round((window.innerWidth || box.width) * 0.9) : Math.round(window.innerWidth || box.width);
-    const height = mode === 'lightbox' ? Math.round((window.innerHeight || box.height) * 0.9) : Math.round((window.innerHeight || box.height) * 0.7);
+    if(mode === 'lightbox') return _lightboxViewportEnvelope();
+    const width = Math.round(window.innerWidth || box.width);
+    const height = Math.round((window.innerHeight || box.height) * 0.7);
     return {
       width: Math.max(1, Number.isFinite(width) ? width : 1),
       height: Math.max(1, Number.isFinite(height) ? height : 1),
@@ -1516,8 +1526,12 @@ function _mountMermaidViewer(svgEl, options = {}) {
   function _viewportSize(){
     const rect = viewport.getBoundingClientRect ? viewport.getBoundingClientRect() : null;
     const fallback = _viewportFallbackSize();
-    const width = viewport.clientWidth || (rect && rect.width) || fallback.width;
-    const height = viewport.clientHeight || (rect && rect.height) || fallback.height;
+    const width = mode === 'lightbox'
+      ? fallback.width
+      : (viewport.clientWidth || (rect && rect.width) || fallback.width);
+    const height = mode === 'lightbox'
+      ? fallback.height
+      : (viewport.clientHeight || (rect && rect.height) || fallback.height);
     return {
       width: Math.max(1, Number(width) || box.width || 1),
       height: Math.max(1, Number(height) || box.height || 1),
@@ -1529,10 +1543,10 @@ function _mountMermaidViewer(svgEl, options = {}) {
   }
 
   function _minScale(){
-    // Lightbox keeps master's flat minimum (unchanged zoom-out floor / fit
-    // bounds). Only inline mode uses the readable-height-derived minimum so a
-    // short inline viewport can't shrink the diagram below usability (#5434).
-    if(mode === 'lightbox') return _MERMAID_VIEWER_MIN_SCALE;
+    // Inline stays bounded by readable-height minimum to preserve usability.
+    // Lightbox allows fit-to-screen to shrink below the old 0.25 floor when
+    // the diagram envelope is narrower than 25%.
+    if(mode === 'lightbox') return Math.min(_MERMAID_VIEWER_MIN_SCALE, _rawFitScale(_viewportSize()));
     return Math.min(_MERMAID_VIEWER_MIN_SCALE, _inlineViewportHeight() / Math.max(1, box.height));
   }
 
@@ -1580,6 +1594,16 @@ function _mountMermaidViewer(svgEl, options = {}) {
     const nextScale = _fitScale();
     state.scale = nextScale;
     _centerForScale(nextScale);
+    _applyTransform();
+  }
+
+  function _resizeToEnvelope(){
+    if(mode !== 'lightbox') return;
+    const envelope = _lightboxViewportEnvelope();
+    viewport.style.width = Math.max(1, Math.round(envelope.width)) + 'px';
+    viewport.style.height = Math.max(1, Math.round(envelope.height)) + 'px';
+    state.scale = _fitScale();
+    _centerForScale(state.scale);
     _applyTransform();
   }
 
@@ -1669,6 +1693,7 @@ function _mountMermaidViewer(svgEl, options = {}) {
   state.zoomOut = _zoomOut;
   state.zoomAt = _setScale;
   state.applyTransform = _applyTransform;
+  state.resizeToEnvelope = _resizeToEnvelope;
   state.openLightbox = openLightbox;
 
   toolbar.appendChild(_createMermaidViewerButton('Zoom in', 'zoomIn', _zoomIn));
@@ -1680,22 +1705,16 @@ function _mountMermaidViewer(svgEl, options = {}) {
   }
 
   if(mode === 'lightbox'){
-    // Preserve master's lightbox initialization exactly: fit-to-screen scale
-    // and a viewport envelope sized to the fitted diagram. The inline readable-
-    // height sizing below must NOT leak into lightbox mode (#5434 gate finding).
-    const initialFit = _fitScale();
-    state.scale = initialFit;
-    viewport.style.width = Math.max(1, Math.round(box.width * initialFit)) + 'px';
-    viewport.style.height = Math.max(1, Math.round(box.height * initialFit)) + 'px';
+    state.resizeToEnvelope();
   } else {
     const initialHeight = _inlineViewportHeight();
     const readableScale = initialHeight / Math.max(1, box.height);
     state.scale = Math.max(_minScale(), Math.min(_MERMAID_VIEWER_MAX_SCALE, readableScale));
     viewport.style.width = '100%';
     viewport.style.height = Math.max(1, Math.round(initialHeight)) + 'px';
+    _centerForScale(state.scale);
+    _applyTransform();
   }
-  _centerForScale(state.scale);
-  _applyTransform();
 
   return root;
 }
@@ -1744,6 +1763,12 @@ function _openMermaidLightbox(svgEl) {
   clone.removeAttribute('width');
   clone.removeAttribute('height');
   const viewer = _mountMermaidViewer(clone, {mode:'lightbox'});
+  if(viewer && viewer._mermaidViewer && typeof viewer._mermaidViewer.resizeToEnvelope === 'function'){
+    lb._mermaidResizeHandler = () => viewer._mermaidViewer.resizeToEnvelope();
+    if(window && typeof window.addEventListener === 'function'){
+      window.addEventListener('resize', lb._mermaidResizeHandler);
+    }
+  }
   const cls = document.createElement('button');
   cls.className = 'img-lightbox-close';
   cls.setAttribute('aria-label', 'Close');
@@ -1757,6 +1782,7 @@ function _openMermaidLightbox(svgEl) {
   };
   document.body.appendChild(lb);
   document.addEventListener('keydown', lb._keyHandler);
+  return lb;
 }
 function _openImgLightboxWithNav(src, alt, images, index) {
   const lb = document.createElement('div');
@@ -1827,6 +1853,9 @@ function _navigateLightbox(lb, direction) {
 function _closeImgLightbox(lb) {
   if(!lb || !lb.parentNode) return;
   document.removeEventListener('keydown', lb._keyHandler);
+  if(lb._mermaidResizeHandler && window && typeof window.removeEventListener === 'function'){
+    window.removeEventListener('resize', lb._mermaidResizeHandler);
+  }
   lb.style.animation = 'lb-in .12s ease reverse';
   setTimeout(() => lb.parentNode && lb.parentNode.removeChild(lb), 120);
 }

--- a/tests/test_issue4814_mermaid_toolbar.py
+++ b/tests/test_issue4814_mermaid_toolbar.py
@@ -27,6 +27,8 @@ if (helperStart < 0 || helperEnd < 0) {
 
 const documentListeners = {};
 const windowListeners = {};
+let nextTimerId = 1;
+const pendingTimers = new Map();
 function makeClassList(node) {
   const classes = new Set();
   return {
@@ -183,10 +185,26 @@ function triggerWindowResize(width, height) {
     window.dispatchEvent({type: 'resize'});
   }
 }
+
+function flushTimers() {
+  const timers = [...pendingTimers.entries()];
+  pendingTimers.clear();
+  for (const [, fn] of timers) fn();
+}
+
 global.document = document;
 global.window = window;
 global.requestAnimationFrame = (fn) => fn();
 global.cancelAnimationFrame = () => {};
+global.setTimeout = (fn) => {
+  const id = nextTimerId;
+  nextTimerId += 1;
+  pendingTimers.set(id, fn);
+  return id;
+};
+global.clearTimeout = (id) => {
+  pendingTimers.delete(id);
+};
 
 eval(ui.slice(helperStart, helperEnd));
 
@@ -312,23 +330,46 @@ function runScenario(payload) {
     const beforeViewportHeight = lightboxState.viewport.style.height;
     const beforeScale = lightboxState.scale;
     triggerWindowResize(payload.resizedViewportWidth, payload.resizedViewportHeight);
+    const queuedAfterFirstResize = pendingTimers.size;
+    const preFlushViewportWidth = lightboxState.viewport.style.width;
+    const preFlushViewportHeight = lightboxState.viewport.style.height;
+    triggerWindowResize(payload.resizedViewportWidth + 20, payload.resizedViewportHeight + 20);
+    const queuedAfterSecondResize = pendingTimers.size;
+    flushTimers();
     const afterViewportWidth = lightboxState.viewport.style.width;
     const afterViewportHeight = lightboxState.viewport.style.height;
     const afterScale = lightboxState.scale;
+    lightboxState.zoomIn();
+    const manualZoomScale = lightboxState.scale;
+    triggerWindowResize(payload.zoomedViewportWidth, payload.zoomedViewportHeight);
+    flushTimers();
+    const afterManualZoomResizeScale = lightboxState.scale;
+    const afterManualZoomResizeViewportWidth = lightboxState.viewport.style.width;
+    const afterManualZoomResizeViewportHeight = lightboxState.viewport.style.height;
     _closeImgLightbox(lightbox);
     const afterCloseListenerCount = (windowListeners.resize || []).length;
     return {
       beforeListenerCount,
       afterOpenListenerCount,
       afterCloseListenerCount,
+      queuedAfterFirstResize,
+      queuedAfterSecondResize,
       beforeViewportWidth,
       beforeViewportHeight,
       beforeScale,
+      preFlushViewportWidth,
+      preFlushViewportHeight,
       afterViewportWidth,
       afterViewportHeight,
       afterScale,
-      expectedViewportWidth: Math.round((payload.resizedViewportWidth || 0) * 0.9),
-      expectedViewportHeight: Math.round((payload.resizedViewportHeight || 0) * 0.9),
+      manualZoomScale,
+      afterManualZoomResizeScale,
+      afterManualZoomResizeViewportWidth,
+      afterManualZoomResizeViewportHeight,
+      expectedViewportWidth: Math.round(((payload.resizedViewportWidth || 0) + 20) * 0.9),
+      expectedViewportHeight: Math.round(((payload.resizedViewportHeight || 0) + 20) * 0.9),
+      expectedZoomedViewportWidth: Math.round((payload.zoomedViewportWidth || 0) * 0.9),
+      expectedZoomedViewportHeight: Math.round((payload.zoomedViewportHeight || 0) * 0.9),
     };
   }
 
@@ -525,16 +566,26 @@ def test_lightbox_resize_recomputes_viewport_and_scale(_driver_path):
         "viewportHeight": 640,
         "resizedViewportWidth": 800,
         "resizedViewportHeight": 400,
+        "zoomedViewportWidth": 640,
+        "zoomedViewportHeight": 500,
         "options": {"mode": "inline"},
     })
 
     assert _px(result["beforeViewportWidth"]) == round(360 * 0.9)
     assert _px(result["beforeViewportHeight"]) == round(640 * 0.9)
-    assert _px(result["afterViewportWidth"]) == round(800 * 0.9)
-    assert _px(result["afterViewportHeight"]) == round(400 * 0.9)
+    assert _px(result["preFlushViewportWidth"]) == _px(result["beforeViewportWidth"])
+    assert _px(result["preFlushViewportHeight"]) == _px(result["beforeViewportHeight"])
+    assert result["queuedAfterFirstResize"] == 1
+    assert result["queuedAfterSecondResize"] == 1
+    assert _px(result["afterViewportWidth"]) == round((800 + 20) * 0.9)
+    assert _px(result["afterViewportHeight"]) == round((400 + 20) * 0.9)
     expectedScale = min(result["expectedViewportWidth"] / 4000, result["expectedViewportHeight"] / 320)
     assert abs(result["afterScale"] - expectedScale) < 1e-9
     assert result["afterScale"] != result["beforeScale"]
+    assert result["manualZoomScale"] > result["afterScale"]
+    assert abs(result["afterManualZoomResizeScale"] - result["manualZoomScale"]) < 1e-9
+    assert _px(result["afterManualZoomResizeViewportWidth"]) == round(640 * 0.9)
+    assert _px(result["afterManualZoomResizeViewportHeight"]) == round(500 * 0.9)
     assert result["beforeListenerCount"] == 0
     assert result["afterOpenListenerCount"] == 1
     assert result["afterCloseListenerCount"] == 0

--- a/tests/test_issue4814_mermaid_toolbar.py
+++ b/tests/test_issue4814_mermaid_toolbar.py
@@ -20,12 +20,13 @@ const fs = require('fs');
 
 const ui = fs.readFileSync(process.argv[2], 'utf8');
 const helperStart = ui.indexOf('const _MERMAID_VIEWER_MIN_SCALE');
-const helperEnd = ui.indexOf('function _openMermaidLightbox');
+const helperEnd = ui.indexOf('function _openImgLightboxWithNav');
 if (helperStart < 0 || helperEnd < 0) {
   throw new Error('could not locate Mermaid viewer helpers');
 }
 
 const documentListeners = {};
+const windowListeners = {};
 function makeClassList(node) {
   const classes = new Set();
   return {
@@ -100,6 +101,9 @@ function makeElement(tagName) {
     getBoundingClientRect() {
       return {left: 0, top: 0, width: this.clientWidth, height: this.clientHeight};
     },
+    querySelectorAll() {
+      return [];
+    },
     setPointerCapture(pointerId) {
       this.capturedPointerId = pointerId;
     },
@@ -150,7 +154,33 @@ const document = {
   },
 };
 
-const window = {innerWidth: 1200, innerHeight: 800};
+const window = {
+  innerWidth: 1200,
+  innerHeight: 800,
+  addEventListener(type, handler) {
+    (windowListeners[type] ||= []).push(handler);
+  },
+  removeEventListener(type, handler) {
+    const list = windowListeners[type] || [];
+    const idx = list.indexOf(handler);
+    if (idx >= 0) list.splice(idx, 1);
+  },
+  dispatchEvent(event) {
+    const type = event && event.type;
+    if (!type) return false;
+    const list = windowListeners[type] || [];
+    for (const handler of list) handler(event);
+    return true;
+  },
+};
+
+function triggerWindowResize(width, height) {
+  if (Number.isFinite(width)) window.innerWidth = width;
+  if (Number.isFinite(height)) window.innerHeight = height;
+  if (typeof window.dispatchEvent === 'function') {
+    window.dispatchEvent({type: 'resize'});
+  }
+}
 global.document = document;
 global.window = window;
 global.requestAnimationFrame = (fn) => fn();
@@ -233,25 +263,63 @@ function runScenario(payload) {
   }
 
   if (payload.scenario === 'wide-lightbox') {
+    const expectedEnvelopeWidth = Math.round((payload.viewportWidth || 0) * 0.9);
+    const expectedEnvelopeHeight = Math.round((payload.viewportHeight || 0) * 0.9);
     const lightboxSvg = makeSvg(payload.width || 480, payload.height || 320);
     const lightbox = _mountMermaidViewer(lightboxSvg, {mode:'lightbox'});
     const lightboxState = lightbox._mermaidViewer;
-    lightboxState.viewport.clientWidth = payload.viewportWidth || 960;
-    lightboxState.viewport.clientHeight = payload.viewportHeight || 540;
+    lightboxState.viewport.clientWidth = expectedEnvelopeWidth || 960;
+    lightboxState.viewport.clientHeight = expectedEnvelopeHeight || 540;
     lightboxState.viewport.getBoundingClientRect = () => ({left: 0, top: 0, width: lightboxState.viewport.clientWidth, height: lightboxState.viewport.clientHeight});
     const initialScale = lightboxState.scale;
     const initialViewportWidth = lightboxState.viewport.style.width;
     const initialViewportHeight = lightboxState.viewport.style.height;
     lightboxState.fit();
+    const fitScale = lightboxState.scale;
+    lightboxState.zoomOut();
+    const zoomOutScale = lightboxState.scale;
     return {
       initialScale,
-      fitScale: lightboxState.scale,
+      fitScale,
+      zoomOutScale,
+      expectedViewportWidth: expectedEnvelopeWidth,
+      expectedViewportHeight: expectedEnvelopeHeight,
       initialViewportWidth,
       initialViewportHeight,
       viewportWidthAfterFit: lightboxState.viewport.style.width,
       viewportHeightAfterFit: lightboxState.viewport.style.height,
       lightboxLabels: labelsFromToolbar(lightbox),
       mode: lightboxState.mode,
+    };
+  }
+
+  if (payload.scenario === 'lightbox-resize') {
+    const expectedEnvelopeWidth = Math.round((payload.viewportWidth || 0) * 0.9);
+    const expectedEnvelopeHeight = Math.round((payload.viewportHeight || 0) * 0.9);
+    const lightboxSvg = makeSvg(payload.width || 480, payload.height || 320);
+    const lightbox = _mountMermaidViewer(lightboxSvg, {mode:'lightbox'});
+    const lightboxState = lightbox && lightbox._mermaidViewer;
+    if (!lightboxState) throw new Error('unable to access lightbox viewer state');
+    lightboxState.viewport.clientWidth = expectedEnvelopeWidth || 960;
+    lightboxState.viewport.clientHeight = expectedEnvelopeHeight || 540;
+    lightboxState.viewport.getBoundingClientRect = () => ({left: 0, top: 0, width: lightboxState.viewport.clientWidth, height: lightboxState.viewport.clientHeight});
+    const beforeViewportWidth = lightboxState.viewport.style.width;
+    const beforeViewportHeight = lightboxState.viewport.style.height;
+    const beforeScale = lightboxState.scale;
+    triggerWindowResize(payload.resizedViewportWidth, payload.resizedViewportHeight);
+    lightboxState.resizeToEnvelope();
+    const afterViewportWidth = lightboxState.viewport.style.width;
+    const afterViewportHeight = lightboxState.viewport.style.height;
+    const afterScale = lightboxState.scale;
+    return {
+      beforeViewportWidth,
+      beforeViewportHeight,
+      beforeScale,
+      afterViewportWidth,
+      afterViewportHeight,
+      afterScale,
+      expectedViewportWidth: Math.round((payload.resizedViewportWidth || 0) * 0.9),
+      expectedViewportHeight: Math.round((payload.resizedViewportHeight || 0) * 0.9),
     };
   }
 
@@ -426,14 +494,35 @@ def test_lightbox_wide_diagram_fits_modal_envelope(_driver_path):
         "options": {"mode": "inline"},
     })
 
-    # Lightbox keeps master's contract: the flat min-scale floor (0.25) governs
-    # both mount and fit (a very wide diagram bottoms out at the floor), and the
-    # viewport is sized to the fitted diagram (box * scale). The inline readable-
-    # height sizing must NOT leak into lightbox mode (#5434 gate finding).
+    # Wide lightbox now sizes the viewport to the modal envelope first,
+    # then fits the full diagram into that envelope.
     assert result["mode"] == "lightbox"
-    assert result["initialScale"] == 0.25
-    assert result["fitScale"] == 0.25
-    assert _px(result["initialViewportWidth"]) == round(4000 * result["initialScale"])
-    assert _px(result["initialViewportHeight"]) == round(320 * result["initialScale"])
-    assert _px(result["viewportWidthAfterFit"]) == round(4000 * result["fitScale"])
-    assert _px(result["viewportHeightAfterFit"]) == round(320 * result["fitScale"])
+    assert _px(result["initialViewportWidth"]) == round(360 * 0.9)
+    assert _px(result["initialViewportHeight"]) == round(640 * 0.9)
+    expectedScale = min(result["expectedViewportWidth"] / 4000, result["expectedViewportHeight"] / 320)
+    assert abs(result["initialScale"] - expectedScale) < 1e-9
+    assert abs(result["fitScale"] - expectedScale) < 1e-9
+    assert abs(result["zoomOutScale"] - expectedScale) < 1e-9
+    assert _px(result["initialViewportWidth"]) == _px(result["viewportWidthAfterFit"])
+    assert _px(result["initialViewportHeight"]) == _px(result["viewportHeightAfterFit"])
+
+
+def test_lightbox_resize_recomputes_viewport_and_scale(_driver_path):
+    result = _run_node(_driver_path, {
+        "scenario": "lightbox-resize",
+        "width": 4000,
+        "height": 320,
+        "viewportWidth": 360,
+        "viewportHeight": 640,
+        "resizedViewportWidth": 800,
+        "resizedViewportHeight": 400,
+        "options": {"mode": "inline"},
+    })
+
+    assert _px(result["beforeViewportWidth"]) == round(360 * 0.9)
+    assert _px(result["beforeViewportHeight"]) == round(640 * 0.9)
+    assert _px(result["afterViewportWidth"]) == round(800 * 0.9)
+    assert _px(result["afterViewportHeight"]) == round(400 * 0.9)
+    expectedScale = min(result["expectedViewportWidth"] / 4000, result["expectedViewportHeight"] / 320)
+    assert abs(result["afterScale"] - expectedScale) < 1e-9
+    assert result["afterScale"] != result["beforeScale"]

--- a/tests/test_issue4814_mermaid_toolbar.py
+++ b/tests/test_issue4814_mermaid_toolbar.py
@@ -20,7 +20,7 @@ const fs = require('fs');
 
 const ui = fs.readFileSync(process.argv[2], 'utf8');
 const helperStart = ui.indexOf('const _MERMAID_VIEWER_MIN_SCALE');
-const helperEnd = ui.indexOf('function _openImgLightboxWithNav');
+const helperEnd = ui.indexOf("document.addEventListener('click'");
 if (helperStart < 0 || helperEnd < 0) {
   throw new Error('could not locate Mermaid viewer helpers');
 }
@@ -121,6 +121,8 @@ function makeElement(tagName) {
       copy.innerHTML = this.innerHTML;
       copy.clientWidth = this.clientWidth;
       copy.clientHeight = this.clientHeight;
+      if (this.viewBox) copy.viewBox = {baseVal: {...this.viewBox.baseVal}};
+      if (this.getBBox) copy.getBBox = this.getBBox;
       copy.classList = makeClassList(copy);
       for (const cls of String(this.className || '').split(/\s+/).filter(Boolean)) copy.classList.add(cls);
       return copy;
@@ -296,10 +298,13 @@ function runScenario(payload) {
   if (payload.scenario === 'lightbox-resize') {
     const expectedEnvelopeWidth = Math.round((payload.viewportWidth || 0) * 0.9);
     const expectedEnvelopeHeight = Math.round((payload.viewportHeight || 0) * 0.9);
+    triggerWindowResize(payload.viewportWidth, payload.viewportHeight);
     const lightboxSvg = makeSvg(payload.width || 480, payload.height || 320);
-    const lightbox = _mountMermaidViewer(lightboxSvg, {mode:'lightbox'});
-    const lightboxState = lightbox && lightbox._mermaidViewer;
+    const beforeListenerCount = (windowListeners.resize || []).length;
+    const lightbox = _openMermaidLightbox(lightboxSvg);
+    const lightboxState = lightbox && lightbox.children[0] && lightbox.children[0]._mermaidViewer;
     if (!lightboxState) throw new Error('unable to access lightbox viewer state');
+    const afterOpenListenerCount = (windowListeners.resize || []).length;
     lightboxState.viewport.clientWidth = expectedEnvelopeWidth || 960;
     lightboxState.viewport.clientHeight = expectedEnvelopeHeight || 540;
     lightboxState.viewport.getBoundingClientRect = () => ({left: 0, top: 0, width: lightboxState.viewport.clientWidth, height: lightboxState.viewport.clientHeight});
@@ -307,11 +312,15 @@ function runScenario(payload) {
     const beforeViewportHeight = lightboxState.viewport.style.height;
     const beforeScale = lightboxState.scale;
     triggerWindowResize(payload.resizedViewportWidth, payload.resizedViewportHeight);
-    lightboxState.resizeToEnvelope();
     const afterViewportWidth = lightboxState.viewport.style.width;
     const afterViewportHeight = lightboxState.viewport.style.height;
     const afterScale = lightboxState.scale;
+    _closeImgLightbox(lightbox);
+    const afterCloseListenerCount = (windowListeners.resize || []).length;
     return {
+      beforeListenerCount,
+      afterOpenListenerCount,
+      afterCloseListenerCount,
       beforeViewportWidth,
       beforeViewportHeight,
       beforeScale,
@@ -526,3 +535,6 @@ def test_lightbox_resize_recomputes_viewport_and_scale(_driver_path):
     expectedScale = min(result["expectedViewportWidth"] / 4000, result["expectedViewportHeight"] / 320)
     assert abs(result["afterScale"] - expectedScale) < 1e-9
     assert result["afterScale"] != result["beforeScale"]
+    assert result["beforeListenerCount"] == 0
+    assert result["afterOpenListenerCount"] == 1
+    assert result["afterCloseListenerCount"] == 0

--- a/tests/test_reasoning_chip_btw_fixes.py
+++ b/tests/test_reasoning_chip_btw_fixes.py
@@ -344,12 +344,18 @@ class TestResizeHandlerSymmetry:
     def test_resize_repositions_reasoning_dropdown(self):
         # The global resize handler must handle both composerModelDropdown AND
         # composerReasoningDropdown to keep them aligned when the window resizes.
-        m = re.search(
+        handlers = re.findall(
             r"window\.addEventListener\(\s*['\"]resize['\"][\s\S]*?\}\s*\)\s*;",
             UI_JS,
         )
-        assert m, "window resize handler not found in ui.js"
-        handler = m.group(0)
+        handler = next(
+            (
+                block for block in handlers
+                if "composerModelDropdown" in block and "_positionModelDropdown" in block
+            ),
+            None,
+        )
+        assert handler, "composer model dropdown resize handler not found in ui.js"
         assert "composerReasoningDropdown" in handler, (
             "window resize handler must also re-position composerReasoningDropdown "
             "while it's open (symmetric with the existing model-dropdown branch)"


### PR DESCRIPTION
## Thinking Path

- The inline #5413 fix shipped, but the fullscreen lightbox still derives its viewport from fitted SVG dimensions, so wide diagrams can open as a clipped strip of empty SVG space.
- Fullscreen needs the opposite order: allocate the modal envelope first, then fit the diagram's aspect ratio inside that live envelope.
- The fix stays in the existing Mermaid viewer helper so mount, Fit to screen, resize, and cleanup all use the same geometry authority.

## What Changed

- `static/ui.js`: size Mermaid lightbox viewports to the modal envelope, compute Fit to screen against that envelope, and debounce open-lightbox browser resize handling with cleanup on close.
- `tests/test_issue4814_mermaid_toolbar.py`: replace the stale wide-lightbox fitted-dimension assertion with modal-envelope fit coverage, add resize debounce and manual-zoom preservation coverage, and keep the existing inline sizing and toolbar preservation tests.

## Why It Matters

Fullscreen Mermaid should reveal the diagram, not an empty clipped edge of an oversized SVG. This preserves the readable inline behavior while making the fullscreen button respond correctly to narrow and resized browser windows without snapping deliberate manual zoom back to fit.

## Verification

```text
python -m pytest tests/test_issue4814_mermaid_toolbar.py -v --timeout=60
python -m pytest tests/test_reasoning_chip_btw_fixes.py::TestResizeHandlerSymmetry::test_resize_repositions_reasoning_dropdown -v --timeout=60
npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"
```

Passed locally: `tests/test_issue4814_mermaid_toolbar.py` reported 8 passed, the resize-handler symmetry regression reported 1 passed, and runtime guard ESLint passed for `static/**/*.js`.

Full-suite CI context, not a required local check unless requested: `python -m pytest tests/ -v --timeout=60`.

## Upstream

Refs #5413.

Prior related work: #5434 and release #5448 shipped the inline readable-sizing fix; Cutter's #5448 preview exposed that fullscreen still needed modal-envelope fit.

## Model Used

GPT 5.5 via Codex CLI
