### PR TITLE
fix(profiles): include extra_models in profile model validation

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -2261,7 +2261,8 @@ def _profile_model_selection_exists(
             continue
         if model_provider and provider_id == model_provider:
             provider_seen = True
-        for model in group.get("models", []) or []:
+        all_group_models = (group.get("models") or []) + (group.get("extra_models") or [])
+        for model in all_group_models:
             if not isinstance(model, dict):
                 continue
             model_id = str(model.get("id") or "").strip()


### PR DESCRIPTION
## Problem

\`_profile_model_selection_exists()\` only iterates \`group["models"]\` — the visible subset produced by \`_split_picker_overflow_models()\`, capped at \`_MODEL_PICKER_VISIBLE_TARGET\` (15 entries). Any model that lands in \`group["extra_models"]\` (the overflow tail) always fails profile validation with *"model not available"*, even though the model is present in the live catalog and appears correctly in the \`/api/models/live\` dropdown.

## Reproducer

1. Open the New Profile modal — the \`/api/models/live?provider=openrouter\` dropdown lists models beyond the top 15 (e.g. \`z-ai/glm-5.2\`).
2. Select one of those overflow models and submit.
3. \`POST /api/profile/create\` returns 400: \`"Selected model 'z-ai/glm-5.2' is not available for provider 'openrouter'"\` despite the model being shown in the dropdown.

## Fix

Search both \`models\` and \`extra_models\` per group, consistent with how \`/model\` slash-command autocomplete uses the full catalog.

## Change

\`api/profiles.py\` — \`_profile_model_selection_exists()\`:

\`\`\`python
# before
for model in group.get("models", []) or []:

# after
all_group_models = (group.get("models") or []) + (group.get("extra_models") or [])
for model in all_group_models:
\`\`\`