### PR TITLE
fix(#5367): suppress transparent stream live row animation

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3978,10 +3978,8 @@ body.resizing .sidebar{transition:none!important;}
   box-shadow:none;
   transition:background .18s ease,border-color .18s ease,opacity .22s ease;
 }
-/* Only animate entrance for rows in the LIVE turn — putting the animation on the
-   base row class replayed the whole transcript's shimmer on every renderMessages
-   rebuild. (Trifecta finding V9.) */
-#liveAssistantTurn .transparent-event-row{animation:transparent-event-enter .18s ease-out both;}
+/* Suppress live row entrance replay during streaming rebuilds. */
+#liveAssistantTurn .transparent-event-row{animation:none!important;}
 .transparent-event-row[data-event-type="thinking"]{
   background:transparent;
   border-color:transparent;
@@ -4268,11 +4266,6 @@ body.resizing .sidebar{transition:none!important;}
   .transparent-event-row .thinking-card-header{min-height:30px;padding:5px 8px;}
   .transparent-detail-mode{padding:4px 6px 5px;}
 }
-@keyframes transparent-event-enter{
-  from{opacity:0;transform:translateY(2px);}
-  to{opacity:1;transform:translateY(0);}
-}
-
 /* ── Old-event fading (transparent mode: medium → low) ─────────────── */
 /* ── Old-event fading (transparent mode, LIVE turn only — gated in JS) ───── */
 .transparent-event-row[data-transparent-fade="1"]{opacity:.86;}

--- a/static/style.css
+++ b/static/style.css
@@ -3978,8 +3978,6 @@ body.resizing .sidebar{transition:none!important;}
   box-shadow:none;
   transition:background .18s ease,border-color .18s ease,opacity .22s ease;
 }
-/* Suppress live row entrance replay during streaming rebuilds. */
-#liveAssistantTurn .transparent-event-row{animation:none!important;}
 .transparent-event-row[data-event-type="thinking"]{
   background:transparent;
   border-color:transparent;

--- a/tests/test_issue3820_chat_activity_display_mode.py
+++ b/tests/test_issue3820_chat_activity_display_mode.py
@@ -641,9 +641,9 @@ def test_transparent_tool_completion_preserves_expand_state():
 
 
 def test_transparent_entrance_animation_is_live_turn_only():
-    """The entrance animation must be scoped to the live turn so it doesn't
-    replay across the whole transcript on every renderMessages. (Trifecta V9.)"""
-    assert "#liveAssistantTurn .transparent-event-row{animation:transparent-event-enter" in STYLE_CSS
+    """The live turn must suppress entrance animation replay during streaming rebuilds."""
+    assert "#liveAssistantTurn .transparent-event-row{animation:none!important" in STYLE_CSS
+    assert "transparent-event-enter" not in STYLE_CSS
 
 
 def test_live_worklog_reason_mirror_is_gated_to_compact_mode():

--- a/tests/test_issue3820_chat_activity_display_mode.py
+++ b/tests/test_issue3820_chat_activity_display_mode.py
@@ -641,8 +641,7 @@ def test_transparent_tool_completion_preserves_expand_state():
 
 
 def test_transparent_entrance_animation_is_live_turn_only():
-    """The live turn must suppress entrance animation replay during streaming rebuilds."""
-    assert "#liveAssistantTurn .transparent-event-row{animation:none!important" in STYLE_CSS
+    """Transparent Stream must not keep the removed entrance animation rule."""
     assert "transparent-event-enter" not in STYLE_CSS
 
 


### PR DESCRIPTION
## Thinking Path

- Issue #5367 identified two viable fixes for Transparent Stream flicker: reconcile live rows by identity, or suppress the live-row entrance animation when rebuilds still happen.
- #5400 shipped the durable reconcile path in v0.51.827, but b3nw reported on Discord: `did this fix go out? not improved at all in WebUI: v0.51.833`.
- v0.51.833 contains the reconcile code, so the remaining visible flicker is plausibly from live rows that still rebuild outside the stable-key path and replay `transparent-event-enter`.
- This change applies the first #5367 direction directly: the live turn still renders Transparent Stream rows, but those rows no longer run an entrance animation during streaming updates.

## What Changed

- `static/style.css`: remove `#liveAssistantTurn .transparent-event-row`, which is scoped to the live turn only.
- `static/style.css`: remove the now-unused `@keyframes transparent-event-enter` block.
- `tests/test_issue3820_chat_activity_display_mode.py`: update the CSS invariant test so it pins that the rule was removed.

## Why It Matters

Users still seeing Transparent Stream flicker after #5400 get the animation-side guard from the original #5367 maintainer direction. Existing `data-transparent-fade` opacity rules stay intact because this avoids forcing `opacity:1`.

## Verification

- `pytest tests/test_issue3820_chat_activity_display_mode.py -v --timeout=60`
- `pytest tests/test_smooth_text_fade.py -v --timeout=60`
- `npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"`

## Upstream

Refs #5367.

Follow-up to #5400, which shipped the reconcile path but left the live-row entrance animation available for any remaining rebuild path.

## Model Used

GPT 5 via Codex CLI