### PR TITLE
fix(api/config): surface plugin-only providers in static catalog

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -35,6 +35,7 @@ import api.paths as _paths
 from api.plugin_providers import (
     effective_provider_display_name as _effective_provider_display_name,
     is_plugin_model_provider as _is_plugin_model_provider,
+    plugin_model_provider_profiles as _plugin_model_provider_profiles,
 )
 
 HOME = _paths.HOME
@@ -4488,6 +4489,23 @@ def _static_models_catalog_without_live_probes() -> dict:
             if canonical and _provider_has_key(canonical):
                 detected_providers.add(canonical)
 
+        # Plugin-only providers (e.g. 9router) are not in the static
+        # _PROVIDER_MODELS / _PROVIDER_DISPLAY tables and are detected above
+        # only when the user puts them in `providers.<slug>`.  Plugins ship
+        # with their own env-var wiring, so an installed-and-keyed plugin
+        # provider should also enter the static catalog even without a
+        # `providers:` block — otherwise the picker silently drops the
+        # group when the live-rebuild cache is cold.
+        try:
+            for _plugin_pid in list(_plugin_model_provider_profiles().keys()):
+                if not _plugin_pid or not _provider_has_key(_plugin_pid):
+                    continue
+                _canonical = _canonicalise_provider_id(_plugin_pid) or _plugin_pid
+                if _canonical:
+                    detected_providers.add(_canonical)
+        except Exception:
+            logger.debug("Plugin provider detection failed in static catalog", exc_info=True)
+
         fallback_cfg = cfg.get("fallback_providers", []) if isinstance(cfg, dict) else []
         if isinstance(fallback_cfg, list):
             for entry in fallback_cfg:
@@ -4621,12 +4639,32 @@ def _static_models_catalog_without_live_probes() -> dict:
                             raw_models.append({"id": item, "label": item})
             if not raw_models:
                 raw_models = copy.deepcopy(_PROVIDER_MODELS.get(pid, []))
+            # Plugin-only providers (e.g. 9router) are not in _PROVIDER_MODELS
+            # and rarely ship a `models:` allowlist in providers.<slug>, so
+            # the static catalog above would render them as empty groups that
+            # the picker filters out. Fall back to the plugin's own
+            # ProviderProfile.fallback_models so the provider surfaces a
+            # curated, network-free subset on the cold path. The live
+            # rebuild (_build_available_models_uncached) does a full
+            # /v1/models fetch and supersedes this view on the next call.
+            if not raw_models and _is_plugin_model_provider(pid):
+                _plugin_profile = _plugin_model_provider_profiles().get(
+                    (pid or "").strip().lower()
+                )
+                if _plugin_profile is not None:
+                    _fallback = getattr(_plugin_profile, "fallback_models", ()) or ()
+                    raw_models = [{"id": str(mid), "label": str(mid)} for mid in _fallback]
             for model_id in configured_model_ids.get(pid, []):
                 if model_id and not any(m.get("id") == model_id for m in raw_models):
                     raw_models.append(
                         {"id": model_id, "label": _get_label_for_model(model_id, groups)}
                     )
-            if raw_models:
+            # Plugin-only providers (e.g. 9router) must enter `groups` even
+            # when `raw_models` is empty so the post-loop filter sees them.
+            # Without this, the earlier plugin-fallback pass only seeds
+            # `raw_models` when `fallback_models` is non-empty; the cold-cache
+            # picker still silently drops a keyed plugin with no models yet.
+            if raw_models or _is_plugin_model_provider(pid):
                 groups.append(
                     {
                         "provider": provider_name,
@@ -4662,7 +4700,14 @@ def _static_models_catalog_without_live_probes() -> dict:
         groups = [
             group
             for group in groups
-            if group.get("models") or str(group.get("provider_id") or "").startswith("custom:")
+            if group.get("models")
+            or str(group.get("provider_id") or "").startswith("custom:")
+            # Keep plugin-only providers visible even when no models surfaced
+            # yet (e.g. plugin's fallback_models is empty and live rebuild
+            # hasn't completed). Otherwise they silently drop from the
+            # picker and look "not installed" — the same 9router-empty-group
+            # regression this branch was added to fix.
+            or _is_plugin_model_provider(str(group.get("provider_id") or ""))
         ]
 
         providers_with_keys: set[str] = set()

--- a/tests/test_plugin_model_providers.py
+++ b/tests/test_plugin_model_providers.py
@@ -223,3 +223,156 @@ class TestPluginModelProvidersPicker:
             config.cfg.update(old_cfg)
             config._cfg_mtime = old_mtime
             config.invalidate_models_cache()
+
+
+class TestPluginFallbackModelsInStaticCatalog:
+    """Regression tests for the network-free /api/models catalog path.
+
+    ``_static_models_catalog_without_live_probes()`` is used for ``prefer_cache``
+    lookups and as the warm-cache payload.  Plugin-only providers (e.g. 9router)
+    are not in ``_PROVIDER_MODELS`` and rarely ship a ``models:`` allowlist in
+    ``providers.<slug>``, so without a fallback the static catalog would render
+    them as empty groups that the picker filters out.  The fix is to surface
+    the ``ProviderProfile.fallback_models`` declared by the plugin itself on
+    this cold path.
+    """
+
+    def test_static_catalog_surfaces_plugin_fallback_models(
+        self, monkeypatch, tmp_path
+    ):
+        _install_fake_yandex_plugin(monkeypatch)
+        _install_fake_hermes_cli(monkeypatch, authenticated=True, model_ids=[])
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # _provider_has_key reads the env var directly, not the .env file.
+        # Set it so the static catalog's plugin-detection branch fires.
+        monkeypatch.setenv("YANDEX_API_KEY", "test-y...n")
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("YANDEX_API_KEY=test-y...n", encoding="utf-8")
+
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        # No `providers.yandex.models:` allowlist, no `models:` in cfg at all.
+        # Active provider set to something else so yandex only enters via the
+        # plugin discovery path.
+        config.cfg["model"] = {"provider": "gemini", "default": "gemini-2.5-flash"}
+        config.cfg["providers"] = {}
+        try:
+            config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+        except Exception:
+            config._cfg_mtime = 0.0
+
+        config.invalidate_models_cache()
+        try:
+            catalog = config._static_models_catalog_without_live_probes()
+            yandex_group = next(
+                (
+                    g
+                    for g in catalog.get("groups", [])
+                    if g.get("provider_id") == "yandex"
+                ),
+                None,
+            )
+            assert yandex_group is not None, (
+                "plugin provider must appear in network-free static catalog "
+                "even without providers.<slug>.models allowlist"
+            )
+            # yandex fake plugin declares no fallback_models in this test's
+            # profile, so the group is allowed to be empty — but the provider
+            # itself must be present (not filtered out as an empty group).
+            assert yandex_group.get("models") == [] or yandex_group.get("models")
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime
+            config.invalidate_models_cache()
+
+    def test_static_catalog_uses_provider_fallback_models_when_declared(
+        self, monkeypatch, tmp_path
+    ):
+        """When the plugin declares ``fallback_models``, the static catalog
+        surfaces them as the group's model list."""
+        fallback = (
+            "gh/claude-sonnet-4.5",
+            "ag/claude-sonnet-4-6",
+            "ds/deepseek-chat",
+        )
+        profile = SimpleNamespace(
+            name="myplugin",
+            display_name="My Plugin",
+            env_vars=("MYPLUGIN_API_KEY",),
+            auth_type="api_key",
+            aliases=(),
+            fallback_models=fallback,
+        )
+
+        def _fake_list_providers():
+            return [profile]
+
+        fake_providers = types.ModuleType("providers")
+        fake_providers.list_providers = _fake_list_providers
+        monkeypatch.setitem(sys.modules, "providers", fake_providers)
+
+        from api.plugin_providers import invalidate_plugin_model_provider_cache
+
+        invalidate_plugin_model_provider_cache()
+
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # _provider_has_key reads the env var directly.
+        monkeypatch.setenv("MYPLUGIN_API_KEY", "test-m...n")
+        (tmp_path / ".env").write_text(
+            "MYPLUGIN_API_KEY=test-m...n", encoding="utf-8"
+        )
+
+        # Mock the plugin provider's API key as authenticated via hermes_cli.auth
+        fake_pkg = types.ModuleType("hermes_cli")
+        fake_pkg.__path__ = []
+        fake_models = types.ModuleType("hermes_cli.models")
+        fake_models.list_available_providers = lambda: []
+        fake_models.provider_model_ids = lambda pid: []
+        fake_auth = types.ModuleType("hermes_cli.auth")
+        fake_auth.get_auth_status = lambda pid: (
+            {"logged_in": True, "configured": True, "key_source": "env_file"}
+            if pid == "myplugin"
+            else {}
+        )
+        monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+        monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+        monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        config.cfg["model"] = {"provider": "gemini", "default": "gemini-2.5-flash"}
+        config.cfg["providers"] = {}
+        try:
+            config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+        except Exception:
+            config._cfg_mtime = 0.0
+
+        config.invalidate_models_cache()
+        try:
+            catalog = config._static_models_catalog_without_live_probes()
+            myplugin_group = next(
+                (
+                    g
+                    for g in catalog.get("groups", [])
+                    if g.get("provider_id") == "myplugin"
+                ),
+                None,
+            )
+            assert myplugin_group is not None, (
+                "plugin provider with fallback_models must appear in static catalog"
+            )
+            model_ids = [m.get("id") for m in myplugin_group.get("models", [])]
+            assert model_ids == list(fallback), (
+                f"static catalog should use plugin's fallback_models, got {model_ids}"
+            )
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime
+            config.invalidate_models_cache()


### PR DESCRIPTION
## Problem

Plugin-only providers (e.g. `9router`) are not in `_PROVIDER_MODELS` and rarely ship a `providers.<slug>.models` allowlist. As a result, `_static_models_catalog_without_live_probes()` — the network-free path used for `prefer_cache` and warm-cache payloads — emitted empty groups that the picker filtered out, making keyed plugin providers look uninstalled until the live rebuild fired.

## Fix

Two complementary changes in `api/config.py`:

1. **Detect plugin providers into the catalog.** Enumerate `_plugin_model_provider_profiles()` into `detected_providers` so a keyed plugin enters the static catalog even when `providers.<slug>` is unset.

2. **Keep plugin-only groups visible** in the build loop and post-loop filter, even with no models yet — without this, the post-loop guard (`or _is_plugin_model_provider(...)`) never fires because the group was never appended in the first place when `raw_models` was empty.

3. **Fall back to the plugin's own `ProviderProfile.fallback_models`** when declared, so a plugin without a `models:` allowlist still surfaces a curated, network-free subset on the cold path. The live `_build_available_models_uncached` does a full `/v1/models` fetch and supersedes this view on the next call.

## Tests

Added `TestPluginFallbackModelsInStaticCatalog` with two regression tests:
- `test_static_catalog_surfaces_plugin_fallback_models` — empty fallback still surfaces as a group, not silently dropped
- `test_static_catalog_uses_provider_fallback_models_when_declared` — declared fallback models appear verbatim

Both are necessary: the first proves the empty-group guard works; the second proves the fallback_models wiring works. Dropping either re-introduces a slice of the regression.

`./scripts/test.sh tests/test_plugin_model_providers.py` passes 8/8. Broader sweep (provider/model/plugin/catalog/profile-resolution): 262 tests pass, 0 failures.

## Reproducer

```bash
# With a keyed plugin-only provider (env var set, no providers.<slug> block):
export YANDEX_API_KEY=...  # or 9ROUTER_API_KEY, etc.
curl -s http://localhost:8787/api/models | jq '.groups[].provider_id' | grep -i yandex
# Before: missing.  After: present.
```

## Notes

- Branch rebased onto current `master` (v0.51.834).
- AGENTS.md mandates `./scripts/test.sh` for pytest; honored.
- No new dependencies.