### PR TITLE
fix(state-sync): mirror WebUI usage counters

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -95,6 +95,8 @@ def _sync_session_title_to_insights(session) -> None:
             title=session.title,
             message_count=len(messages),
             profile=getattr(session, "profile", None),
+            cache_read_tokens=getattr(session, "cache_read_tokens", None) or 0,
+            cache_write_tokens=getattr(session, "cache_write_tokens", None) or 0,
         )
     except Exception:
         logger.debug("Failed to update session title in state.db", exc_info=True)
@@ -20237,6 +20239,8 @@ def _handle_chat_sync(handler, body):
                 model=s.model,
                 title=s.title,
                 message_count=len(s.messages),
+                cache_read_tokens=s.cache_read_tokens or 0,
+                cache_write_tokens=s.cache_write_tokens or 0,
                 # #2762 / #2827 parity with api/streaming.py:5078: pass the
                 # session's profile explicitly so a future refactor that
                 # backgrounds this handler doesn't silently leak writes to

--- a/api/state_sync.py
+++ b/api/state_sync.py
@@ -134,7 +134,8 @@ def sync_session_start(session_id: str, model=None, profile: Optional[str] = Non
 
 def sync_session_usage(session_id: str, input_tokens: int=0, output_tokens: int=0,
                        estimated_cost=None, model=None, title: Optional[str] = None,
-                       message_count: Optional[int] = None, profile: Optional[str] = None) -> None:
+                       message_count: Optional[int] = None, profile: Optional[str] = None,
+                       cache_read_tokens: int = 0, cache_write_tokens: int = 0) -> None:
     """Update token usage and title for a WebUI session in state.db.
     Called after each turn completes. Uses absolute=True to set totals
     (the WebUI Session already accumulates across turns).
@@ -153,11 +154,17 @@ def sync_session_usage(session_id: str, input_tokens: int=0, output_tokens: int=
     try:
         # Ensure session exists first (idempotent)
         db.ensure_session(session_id=session_id, source='webui', model=model)
-        # Set absolute token counts
+        # Set absolute token counts. WebUI's sidecar already accumulates
+        # input/output/cache totals across turns, so mirror the same absolute
+        # values into state.db. Omitting cache counters makes insights/reporting
+        # show false 0% hit rates even when the live stream and sidecar saw warm
+        # prefix reads.
         db.update_token_counts(
             session_id=session_id,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
             estimated_cost_usd=estimated_cost,
             model=model,
             absolute=True,

--- a/api/state_sync.py
+++ b/api/state_sync.py
@@ -135,7 +135,8 @@ def sync_session_start(session_id: str, model=None, profile: Optional[str] = Non
 def sync_session_usage(session_id: str, input_tokens: int=0, output_tokens: int=0,
                        estimated_cost=None, model=None, title: Optional[str] = None,
                        message_count: Optional[int] = None, profile: Optional[str] = None,
-                       cache_read_tokens: int = 0, cache_write_tokens: int = 0) -> None:
+                       cache_read_tokens: int = 0, cache_write_tokens: int = 0,
+                       api_call_count: Optional[int] = None) -> None:
     """Update token usage and title for a WebUI session in state.db.
     Called after each turn completes. Uses absolute=True to set totals
     (the WebUI Session already accumulates across turns).
@@ -165,6 +166,7 @@ def sync_session_usage(session_id: str, input_tokens: int=0, output_tokens: int=
             output_tokens=output_tokens,
             cache_read_tokens=cache_read_tokens,
             cache_write_tokens=cache_write_tokens,
+            api_call_count=api_call_count,
             estimated_cost_usd=estimated_cost,
             model=model,
             absolute=True,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -9100,6 +9100,7 @@ def _run_agent_streaming(
                             message_count=len(s.messages),
                             cache_read_tokens=s.cache_read_tokens or 0,
                             cache_write_tokens=s.cache_write_tokens or 0,
+                            api_call_count=getattr(agent, 'session_api_calls', None),
                             # #2762: pass the session's profile explicitly so the
                             # background-thread state.db lookup doesn't fall
                             # through to the process-global active profile and

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -9098,6 +9098,8 @@ def _run_agent_streaming(
                             model=model,
                             title=s.title,
                             message_count=len(s.messages),
+                            cache_read_tokens=s.cache_read_tokens or 0,
+                            cache_write_tokens=s.cache_write_tokens or 0,
                             # #2762: pass the session's profile explicitly so the
                             # background-thread state.db lookup doesn't fall
                             # through to the process-global active profile and

--- a/tests/test_issue2762_state_sync_profile_kwarg.py
+++ b/tests/test_issue2762_state_sync_profile_kwarg.py
@@ -82,12 +82,14 @@ def _read_session(db_path: Path, session_id: str):
     if not db_path.exists():
         return None
     conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
     try:
         # Real state.db schema (see api/state_sync.py + hermes_cli StateDB):
         # `sessions` table has `id` as PRIMARY KEY (not session_id). Use real
         # column names so the test queries the actual schema.
         cur = conn.execute(
-            "SELECT id AS session_id, title, input_tokens, output_tokens "
+            "SELECT id AS session_id, title, input_tokens, output_tokens, "
+            "cache_read_tokens, cache_write_tokens "
             "FROM sessions WHERE id = ?",
             (session_id,),
         )
@@ -213,6 +215,8 @@ def test_sync_session_usage_writes_only_to_named_profile(two_profile_homes):
         title='2762 regression test',
         message_count=3,
         profile='maiko',
+        cache_read_tokens=1200,
+        cache_write_tokens=300,
     )
 
     maiko_row = _read_session(two_profile_homes['maiko'] / 'state.db', '2762-regression')
@@ -220,6 +224,8 @@ def test_sync_session_usage_writes_only_to_named_profile(two_profile_homes):
 
     assert maiko_row is not None, \
         "sync_session_usage(profile='maiko') did not write to maiko's state.db"
+    assert maiko_row["cache_read_tokens"] == 1200
+    assert maiko_row["cache_write_tokens"] == 300
     assert hiyuki_row is None, \
         "sync_session_usage(profile='maiko') leaked into hiyuki's state.db — #2762 regression"
 

--- a/tests/test_issue2762_state_sync_profile_kwarg.py
+++ b/tests/test_issue2762_state_sync_profile_kwarg.py
@@ -89,7 +89,7 @@ def _read_session(db_path: Path, session_id: str):
         # column names so the test queries the actual schema.
         cur = conn.execute(
             "SELECT id AS session_id, title, input_tokens, output_tokens, "
-            "cache_read_tokens, cache_write_tokens "
+            "cache_read_tokens, cache_write_tokens, api_call_count "
             "FROM sessions WHERE id = ?",
             (session_id,),
         )
@@ -217,6 +217,7 @@ def test_sync_session_usage_writes_only_to_named_profile(two_profile_homes):
         profile='maiko',
         cache_read_tokens=1200,
         cache_write_tokens=300,
+        api_call_count=7,
     )
 
     maiko_row = _read_session(two_profile_homes['maiko'] / 'state.db', '2762-regression')
@@ -226,6 +227,7 @@ def test_sync_session_usage_writes_only_to_named_profile(two_profile_homes):
         "sync_session_usage(profile='maiko') did not write to maiko's state.db"
     assert maiko_row["cache_read_tokens"] == 1200
     assert maiko_row["cache_write_tokens"] == 300
+    assert maiko_row["api_call_count"] == 7
     assert hiyuki_row is None, \
         "sync_session_usage(profile='maiko') leaked into hiyuki's state.db — #2762 regression"
 


### PR DESCRIPTION
## Thinking Path

- WebUI stores cumulative token usage in its session sidecar JSON.
- `sync_to_insights` mirrors that WebUI usage into Hermes Agent `state.db` so insights and session accounting can use one durable source.
- The bridge only mirrored prompt/completion/cost totals, so WebUI sessions with prompt-cache reads could show correct sidecar usage but `0` cache reads in `state.db`.
- The same bridge also did not pass the cumulative API-call count from streaming, leaving `api_call_count` stale in state-backed reports.
- This PR forwards the existing cumulative WebUI counters through the existing state-sync bridge and pins the profile-routed invariant in tests.

## What Changed

- Extended `api.state_sync.sync_session_usage()` to accept and forward:
  - `cache_read_tokens`
  - `cache_write_tokens`
  - optional `api_call_count`
- Updated WebUI streaming finalization to pass the session's existing cumulative cache counters and the agent's cumulative `session_api_calls`.
- Updated title/sync-chat state-sync call sites to pass cache counters when available.
- Extended the existing explicit-profile state-sync regression test to assert cache counters and API-call counts land in the named profile DB.

## Why It Matters

Without this, WebUI sessions can appear cache-cold in `state.db` even when the live agent and WebUI sidecar recorded warm prompt-cache reads. That makes insights, usage summaries, and debugging reports misleading for WebUI-originated sessions.

## Verification

Ran on a clean branch from current `origin/master`:

```bash
PIP_USER=false ./scripts/test.sh tests/test_issue2762_state_sync_profile_kwarg.py tests/test_webui_state_db_reconciliation.py
python3 -m py_compile api/state_sync.py api/routes.py api/streaming.py tests/test_issue2762_state_sync_profile_kwarg.py
PIP_USER=false python3 scripts/ruff_lint.py --diff origin/master
git diff --check origin/master..HEAD
```

Results:

- `55 passed`
- `py_compile` passed
- `ruff_lint`: no new violations on added/modified lines
- `git diff --check`: clean

Also verified locally with a temp `state.db` smoke that:

- cache counters sync into the row
- unknown `api_call_count` preserves an existing value when paired with the companion Agent-side hardening
- explicit streaming `api_call_count` updates the row

## Risks / Follow-ups

- This PR forwards `api_call_count=None` for callers that do not know the cumulative count. Preserving an existing value for that `None` case requires the companion Hermes Agent PR that makes `SessionDB.update_token_counts(... absolute=True, api_call_count=None)` preserve the current row value.
- Historical rows already clobbered to zero still need a separate reconciliation/backfill if exact old reporting is needed.

## Contract Routing

Task type: runtime/session metadata durability bug fix

Touched areas:

- WebUI state-sync bridge
- WebUI streaming writeback metadata
- explicit-profile state DB regression coverage

Relevant public docs:

- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`

State layer affected: WebUI session sidecar totals mirrored into Hermes Agent `state.db` session rows.

Evidence: targeted state-sync/reconciliation tests, syntax check, diff lint, and local temp-DB smoke.

## Model Used

AI-assisted: OpenAI GPT-5.5 via Hermes, with Codex read-only review.